### PR TITLE
fix(privacy): scrub leaked install IPs from tests + pre-push advisory + CI backstop + scorer fix

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -186,6 +186,16 @@
                 "hooks": [
                     {
                         "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/pre_push_privacy_review.py",
+                        "timeout": 30
+                    }
+                ]
+            },
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
                         "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/repo_routing_guard.py",
                         "timeout": 10
                     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,47 @@ jobs:
           bash scripts/check_portability.sh
           echo "Portability scan (address classes): CLEAN"
 
+      - name: Install-IP scan (tests included)
+        # The gitleaks + portability scans above allowlist/exclude tests/, so a
+        # real install IP in a TEST fixture (network-topology disclosure) ships
+        # green. This step closes that blind spot: it scans the WHOLE tree —
+        # tests included — for THIS install's real network identifiers, with a
+        # small STABLE exclude for files that legitimately embed these patterns
+        # as data (scanner definitions + the sanitizer's own test fixtures).
+        # Pattern set is deliberately the SAME install identifiers already
+        # public in this file's PR-description scan (below) — this step adds NO
+        # new real identifier to public content. The install's more-specific
+        # container / host / Tailscale-v4 prefixes are intentionally NOT scanned
+        # here: naming them would be a NEW public disclosure, they fall in the
+        # same class as the IPv6 prefix already covered, and the deferred
+        # sanitizer-genericization follow-up closes the whole class via generic
+        # patterns + a local overlay. The values this PR actually remediates are
+        # covered below.
+        run: |
+          set -euo pipefail
+          hits=$(
+            rg -n --hidden \
+              --glob '!**/.git/**' \
+              --glob '!**/src/genesis/contribution/sanitize.py' \
+              --glob '!**/tests/test_contribution/test_sanitize.py' \
+              --glob '!**/src/genesis/util/netclass.py' \
+              --glob '!**/scripts/check_portability.sh' \
+              --glob '!**/scripts/hooks/commit-msg' \
+              --glob '!**/.gitleaks.toml' \
+              --glob '!**/.github/workflows/ci.yml' \
+              -e '10\.176\.[0-9]' \
+              -e '192\.168\.50\.[0-9]' \
+              -e '\bfd7a:' \
+              -e '\b(zorror|assistant1)\b' \
+              . 2>/dev/null || true
+          )
+          if [[ -n "$hits" ]]; then
+            echo "::error::Install-specific network identifiers found (tests/ included):"
+            printf '%s\n' "$hits"
+            exit 1
+          fi
+          echo "Install-IP scan (tests included): CLEAN"
+
       - name: Email scan
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,9 @@ jobs:
         # real install IP in a TEST fixture (network-topology disclosure) ships
         # green. This step closes that blind spot: it scans the WHOLE tree —
         # tests included — for THIS install's real network identifiers, with a
-        # small STABLE exclude for files that legitimately embed these patterns
-        # as data (scanner definitions + the sanitizer's own test fixtures).
+        # small STABLE exclude for SCANNER-DEFINITION files that embed these
+        # patterns as data (sanitize.py, .gitleaks.toml, commit-msg,
+        # check_portability.sh, netclass.py, this file's PR-desc scan).
         # Pattern set is deliberately the SAME install identifiers already
         # public in this file's PR-description scan (below) — this step adds NO
         # new real identifier to public content. The install's more-specific
@@ -204,11 +205,10 @@ jobs:
         # covered below.
         run: |
           set -euo pipefail
-          hits=$(
+          raw=$(
             rg -n --hidden \
               --glob '!**/.git/**' \
               --glob '!**/src/genesis/contribution/sanitize.py' \
-              --glob '!**/tests/test_contribution/test_sanitize.py' \
               --glob '!**/src/genesis/util/netclass.py' \
               --glob '!**/scripts/check_portability.sh' \
               --glob '!**/scripts/hooks/commit-msg' \
@@ -216,10 +216,16 @@ jobs:
               --glob '!**/.github/workflows/ci.yml' \
               -e '10\.176\.[0-9]' \
               -e '192\.168\.50\.[0-9]' \
-              -e '\bfd7a:' \
+              -e '\bfd7a:[0-9a-f:]' \
               -e '\b(zorror|assistant1)\b' \
               . 2>/dev/null || true
           )
+          # The sanitizer's own test MUST embed install-shaped inputs to verify
+          # redaction, so it is NOT excluded wholesale (a real host reintroduced
+          # there would then be invisible — Codex P1 on #1267). Instead allowlist
+          # only its KNOWN generic placeholder VALUES; a newly-added real host is
+          # not in this list and is still flagged.
+          hits=$(printf '%s' "$raw" | grep -vE 'tests/test_contribution/test_sanitize\.py:[0-9]+:.*(10\.176\.0\.[01]|fd7a::1)' || true)
           if [[ -n "$hits" ]]; then
             echo "::error::Install-specific network identifiers found (tests/ included):"
             printf '%s\n' "$hits"

--- a/scripts/hooks/pre_push_privacy_review.py
+++ b/scripts/hooks/pre_push_privacy_review.py
@@ -143,6 +143,56 @@ def _push_remote(cmd: str) -> str | None:
     return None
 
 
+def _effective_cwd(cmd: str, payload_cwd: str | None) -> str | None:
+    """The directory the ``git push`` actually runs in.
+
+    Honors a preceding ``cd <dir>`` segment and a ``git -C <dir>`` on the push
+    itself (either overrides the payload cwd) — so a ``git -C <worktree> push``
+    or ``cd <worktree> && git push`` is scanned against the repo actually being
+    pushed, not the hook's payload cwd. Falls back to ``payload_cwd``.
+    """
+    cwd = payload_cwd
+
+    def _resolve(base: str | None, path: str) -> str:
+        return path if os.path.isabs(path) else (os.path.join(base, path) if base else path)
+
+    for seg in re.split(r"\|\||&&|[;|&]", cmd):
+        try:
+            toks = shlex.split(seg)
+        except ValueError:
+            continue
+        if not toks:
+            continue
+        # A bare `cd <dir>` changes cwd for the following segments.
+        if toks[0] == "cd" and len(toks) >= 2 and not toks[1].startswith("-"):
+            cwd = _resolve(cwd, toks[1])
+            continue
+        k = 0
+        while k < len(toks) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", toks[k]):
+            k += 1
+        if k >= len(toks) or toks[k] != "git":
+            continue
+        # Scan the git args for `-C <dir>` and whether the subcommand is push.
+        c_dir: str | None = None
+        m = k + 1
+        while m < len(toks):
+            tok = toks[m]
+            if tok == "-C" and m + 1 < len(toks):
+                c_dir = toks[m + 1]
+                m += 2
+                continue
+            if tok.startswith("-"):
+                if tok in _GIT_GLOBAL_VALUE_OPTS and m + 1 < len(toks):
+                    m += 2
+                    continue
+                m += 1
+                continue
+            if tok == "push":
+                return _resolve(cwd, c_dir) if c_dir else cwd
+            break
+    return cwd
+
+
 def _targets_public_repo(remote: str, cwd: str | None) -> bool:
     """True if the push destination is origin (public), or is unresolvable.
 
@@ -208,7 +258,11 @@ def main() -> None:
         # the chain can never approach the hook's CC timeout (a timeout = block).
         global _deadline
         _deadline = time.monotonic() + _GIT_BUDGET_S
-        cwd = payload.get("cwd") if isinstance(payload, dict) else None
+        payload_cwd = payload.get("cwd") if isinstance(payload, dict) else None
+        # Resolve the repo the push ACTUALLY runs in — honoring `git -C <dir>`
+        # and a preceding `cd <dir>` — so we scan the branch being pushed, not
+        # the payload cwd (Codex P2 on #1267).
+        cwd = _effective_cwd(cmd, payload_cwd)
         if not _targets_public_repo(remote, cwd):
             return  # private-fork / non-origin push — real IPs allowed there
         diff_text = _outgoing_diff(cwd)

--- a/scripts/hooks/pre_push_privacy_review.py
+++ b/scripts/hooks/pre_push_privacy_review.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""PreToolUse ADVISORY: surface private-data leaks in an outgoing PUBLIC push.
+
+NON-BLOCKING. When a ``git push`` targets the public repo (origin), this hook
+scans the diff being pushed for this install's private data — install IPs,
+personal emails, and local release-fingerprints — and, if it finds any, injects
+a review prompt into the model's context (PreToolUse ``additionalContext``). It
+NEVER blocks the push: the CI ``leak-detector`` job and the branch/force gates
+in ``git_push_guard.py`` own hard enforcement. Its job is to make the author
+LOOK at suspicious lines before code goes public — the exact step that, when
+skipped manually, put real install IPs into public test fixtures.
+
+Reuses the contribution sanitizer's cheap REGEX scanners (``parse_diff`` +
+``_check_portability`` / ``_check_emails`` / ``_check_fingerprints``) — NOT the
+full ``scan_diff``, whose detect-secrets floor is fail-CLOSED (a false "missing
+binary" finding on every push, since the venv bin isn't on the hook's PATH) and
+whose secret scanners spawn one subprocess per added line (latency / timeout
+kill on large diffs).
+
+Contract: emits ONLY ``hookSpecificOutput.additionalContext`` on stdout and
+ALWAYS exits 0. It carries no ``permissionDecision``, so it composes cleanly
+with git_push_guard's ask/allow/deny on the same Bash matcher (each hook runs as
+a separate process; additionalContext is concatenated, order-independent). Any
+error → silent exit 0. An advisory must NEVER block a push.
+
+Stdlib + the contribution sanitizer only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+# Self-locate so `from hook_input import …` resolves both when CC runs this as a
+# script and when it is imported for tests (mirrors git_push_guard.py:27).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from hook_input import field, read_payload  # noqa: E402
+
+# Make `genesis.contribution.sanitize` importable. The genesis-hook wrapper runs
+# the venv python where genesis is editable-installed, so the import normally
+# resolves without this; the sys.path insert is a belt-and-suspenders fallback
+# (mirrors credential_surface_hook.py). genesis/__init__ is empty and sanitize
+# is stdlib-only at import time, so this is cheap (~150ms).
+_SRC = Path(__file__).resolve().parents[2] / "src"
+if _SRC.is_dir():
+    sys.path.insert(0, str(_SRC))
+
+_GIT_GLOBAL_VALUE_OPTS = ("-C", "-c", "--git-dir", "--work-tree", "--namespace")
+_PUSH_VALUE_FLAGS = ("-o", "--push-option", "--repo", "--receive-pack", "--exec")
+_MAX_LINES = 20
+# Total wall-clock budget for ALL git calls in one invocation, and a per-call
+# cap. A PreToolUse hook that TIMES OUT is treated by Claude Code as a BLOCK
+# (an external process kill a Python try/except cannot catch), so the chain of
+# git calls must finish comfortably under the hook's settings.json timeout (30s)
+# even on a degraded-disk host. On budget exhaustion _git returns None → the
+# scan is silently skipped (advisory degrades to quiet, never blocks).
+_GIT_BUDGET_S = 12.0
+_PER_CALL_TIMEOUT_S = 5.0
+_deadline: float | None = None  # set per-invocation in main()
+
+
+def _git(args: list[str], cwd: str | None) -> str | None:
+    """Run a read-only git command; return stripped stdout, or None on failure.
+
+    Bounded by the shared per-invocation ``_deadline`` (see _GIT_BUDGET_S) so
+    the chained git calls can never approach the hook's CC-level timeout.
+    """
+    timeout = _PER_CALL_TIMEOUT_S
+    if _deadline is not None:
+        remaining = _deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        timeout = min(timeout, remaining)
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=cwd or None,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def _norm_url(url: str) -> str:
+    """Normalize a git remote URL for comparison — drop the ``.git`` suffix,
+    a trailing slash, and case, so textually-different spellings of the SAME
+    repo (e.g. with/without ``.git``) still compare equal."""
+    return re.sub(r"\.git$", "", url.strip().lower()).rstrip("/")
+
+
+def _push_remote(cmd: str) -> str | None:
+    """The remote/URL a ``git push`` targets, or None if cmd is not a git push.
+
+    Returns "" for a bare ``git push`` (the branch's default push remote).
+    Best-effort argv parse over shell segments; ambiguity resolves toward "" so
+    the caller still scans (an advisory over-informs rather than misses).
+    """
+    for seg in re.split(r"\|\||&&|[;|&]", cmd):
+        try:
+            toks = shlex.split(seg)
+        except ValueError:
+            continue
+        # Skip leading `VAR=val` env assignments, then require `git` as the
+        # command word (so `echo git push` is not mistaken for a push).
+        k = 0
+        while k < len(toks) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", toks[k]):
+            k += 1
+        if k >= len(toks) or toks[k] != "git":
+            continue
+        i = k + 1
+        # Advance past git global options (and their values) to the subcommand.
+        while i < len(toks) and toks[i].startswith("-"):
+            if toks[i] in _GIT_GLOBAL_VALUE_OPTS and i + 1 < len(toks):
+                i += 2
+            else:
+                i += 1
+        if i >= len(toks) or toks[i] != "push":
+            continue
+        # First non-flag positional after `push` is the remote (or a URL).
+        j = i + 1
+        while j < len(toks):
+            tok = toks[j]
+            if tok.startswith("-"):
+                if tok in _PUSH_VALUE_FLAGS and j + 1 < len(toks):
+                    j += 2
+                    continue
+                j += 1
+                continue
+            return tok
+        return ""  # bare push
+    return None
+
+
+def _targets_public_repo(remote: str, cwd: str | None) -> bool:
+    """True if the push destination is origin (public), or is unresolvable.
+
+    Advisory bias: scan on origin AND on anything we cannot confidently resolve
+    to a NON-origin remote; skip only when the target clearly resolves to a
+    different remote (e.g. a private fork), where real install IPs are allowed.
+    """
+    origin_url = _git(["remote", "get-url", "--push", "origin"], cwd)
+    if remote == "":
+        tracked = _git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{push}"], cwd)
+        name = tracked.split("/", 1)[0] if tracked else "origin"
+        target_url = _git(["remote", "get-url", "--push", name], cwd)
+    elif "://" in remote or re.match(r"^[^/\s]+@[^/\s]+:", remote):
+        target_url = remote  # literal URL / scp-like target
+    else:
+        target_url = _git(["remote", "get-url", "--push", remote], cwd)
+    if not target_url or not origin_url:
+        return True  # uncertain → inform (a public push is the risky case)
+    return _norm_url(target_url) == _norm_url(origin_url)
+
+
+def _outgoing_diff(cwd: str | None) -> str:
+    """The unified diff being pushed (local commits not yet on origin)."""
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd)
+    base = None
+    if (
+        branch
+        and branch != "HEAD"
+        and _git(["rev-parse", "--verify", "--quiet", f"origin/{branch}"], cwd)
+    ):
+        base = f"origin/{branch}"
+    else:
+        base = _git(["merge-base", "origin/main", "HEAD"], cwd)
+    if not base:
+        return ""
+    return _git(["diff", f"{base}..HEAD"], cwd) or ""
+
+
+def _scan(diff_text: str) -> list:
+    """Run only the cheap regex scanners from the contribution sanitizer."""
+    from genesis.contribution import sanitize
+
+    parsed = sanitize.parse_diff(diff_text)
+    findings = list(sanitize._check_portability(parsed))
+    findings += sanitize._check_emails(parsed)
+    fp_env = os.environ.get("GENESIS_RELEASE_FINGERPRINTS")
+    fp = Path(fp_env) if fp_env else Path.home() / ".genesis" / "release-fingerprints.txt"
+    if fp.is_file():
+        findings += sanitize._check_fingerprints(parsed, fp)
+    return findings
+
+
+def main() -> None:
+    try:
+        payload = read_payload()
+        cmd = field(payload, "command")
+        if not cmd:
+            return
+        remote = _push_remote(cmd)
+        if remote is None:
+            return  # not a git push
+        # All git calls below share ONE wall-clock budget (see _GIT_BUDGET_S) so
+        # the chain can never approach the hook's CC timeout (a timeout = block).
+        global _deadline
+        _deadline = time.monotonic() + _GIT_BUDGET_S
+        cwd = payload.get("cwd") if isinstance(payload, dict) else None
+        if not _targets_public_repo(remote, cwd):
+            return  # private-fork / non-origin push — real IPs allowed there
+        diff_text = _outgoing_diff(cwd)
+        if not diff_text:
+            return
+        findings = _scan(diff_text)
+        if not findings:
+            return
+        seen: set = set()
+        lines: list[str] = []
+        for finding in findings:
+            key = (finding.file, finding.line, finding.message)
+            if key in seen:
+                continue
+            seen.add(key)
+            lines.append(f"  {finding.file or '?'}:{finding.line or '?'}  {finding.message}")
+        context = (
+            "[Pre-push privacy review] ⚠️ This push to the PUBLIC repo "
+            "adds lines matching private-data patterns. Before it lands, confirm "
+            "each is a generic placeholder (safe) or scrub the real value:\n"
+            + "\n".join(lines[:_MAX_LINES])
+        )
+        json.dump(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "additionalContext": context,
+                }
+            },
+            sys.stdout,
+        )
+    except Exception:
+        # An advisory must NEVER block a push — swallow everything, exit 0.
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/skill_injection_hook.py
+++ b/scripts/hooks/skill_injection_hook.py
@@ -129,26 +129,36 @@ def _save_session_nudge(session_id: str, skill_name: str) -> None:
 def _score_skill(skill: dict, keywords: list[str]) -> float:
     """Score a skill against prompt keywords. Returns raw match points.
 
-    Name and explicit-keyword hits score 2 points each, description hits 1.
-    Deliberately NOT normalized by prompt keyword count — a long prompt
-    must not dilute a genuine hit below the firing threshold.
+    Scores the CURATED signals only: a whole-word skill-NAME token hit or an
+    explicit frontmatter-KEYWORD hit is worth 2 points each. DESCRIPTION prose
+    is deliberately NOT scored. Free-text descriptions name many tools in
+    passing (an AWS skill's prose mentions "SageMaker", "usage plan",
+    "timeout"), so the old substring match over descriptions surfaced skills
+    on generic words — "plan" inside "usage plan", "out" inside "timeout" —
+    summing two incidental hits to the firing threshold. A term distinctive
+    enough to nudge a skill belongs in that skill's `keywords:` frontmatter,
+    not mined from prose. Matching is whole-word (token membership), so "aws"
+    matches the name "aws-lambda" but not "awesome". Deliberately NOT
+    normalized by prompt length — a long prompt must not dilute a genuine hit
+    below the firing threshold.
     """
     if not keywords:
         return 0.0
 
-    name_lower = skill.get("name", "").lower().replace("-", " ").replace("_", " ")
-    desc_lower = skill.get("description", "").lower()
+    # Whole-word name tokens (hyphens/underscores → spaces, then split).
+    name_tokens = set(
+        skill.get("name", "").lower().replace("-", " ").replace("_", " ").split()
+    )
     skill_kws = {kw.lower() for kw in skill.get("keywords", [])}
 
     matches = 0
     for kw in keywords:
         kw_lower = kw.lower()
-        if kw_lower in name_lower:
-            matches += 2  # Name match weighted 2x
+        if kw_lower in name_tokens:
+            matches += 2  # Whole-word name-token match
         elif kw_lower in skill_kws:
-            matches += 2  # Explicit keyword match weighted 2x
-        elif kw_lower in desc_lower:
-            matches += 1
+            matches += 2  # Explicit frontmatter-keyword match
+        # Description prose intentionally not scored (see docstring).
 
     return float(matches)
 
@@ -160,8 +170,8 @@ def _extract_keywords(prompt: str) -> list[str]:
     stop = {
         "the", "is", "are", "was", "and", "or", "but", "for", "with",
         "this", "that", "can", "you", "how", "what", "when", "where",
-        "why", "not", "let", "use", "need", "want", "please", "just",
-        "some", "make", "get", "also", "then", "into",
+        "why", "not", "let", "lets", "use", "need", "want", "please", "just",
+        "some", "make", "get", "also", "then", "into", "them", "out",
     }
     return [w for w in words if len(w) >= 3 and w not in stop][:12]
 

--- a/tests/test_contribution/test_sanitize.py
+++ b/tests/test_contribution/test_sanitize.py
@@ -137,7 +137,7 @@ def test_portability_ip_blocks():
     diff = (
         "diff --git a/config.py b/config.py\n"
         "--- a/config.py\n+++ b/config.py\n@@ -1 +1 @@\n"
-        "+OLLAMA_URL = 'http://10.176.34.199:11434'\n"
+        "+OLLAMA_URL = 'http://10.176.0.0:11434'\n"
     )
     r = sanitize.scan_diff(diff)
     assert r.ok is False
@@ -240,7 +240,7 @@ def test_multi_file_diff_all_scanned():
     diff = (
         "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n+ok_line\n"
         "diff --git a/b.py b/b.py\n--- a/b.py\n+++ b/b.py\n@@ -1 +1 @@\n"
-        "+IP = '10.176.34.199'\n"
+        "+IP = '10.176.0.0'\n"
     )
     r = sanitize.scan_diff(diff)
     assert r.ok is False
@@ -300,7 +300,7 @@ def test_parse_diff_dev_null_target():
 def test_findings_include_severity():
     diff = (
         "diff --git a/x.py b/x.py\n"
-        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n+ip=10.176.34.199\n"
+        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n+ip=10.176.0.0\n"
     )
     r = sanitize.scan_diff(diff)
     assert all(f.severity == Severity.BLOCK for f in r.blocking())
@@ -529,7 +529,7 @@ def test_portability_tailscale_ipv6_blocks():
     """Tailscale IPv6 (fd7a: ULA prefix) must be blocked pre-push."""
     diff = (
         "diff --git a/x.py b/x.py\n"
-        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n+HOST6 = 'fd7a:115c:a1e0::1'\n"
+        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n+HOST6 = 'fd7a::1'\n"
     )
     r = sanitize.scan_diff(diff)
     assert r.ok is False
@@ -540,7 +540,7 @@ def test_portability_10_176_range_blocks():
     """Any 10.176.x.x address (not just the two legacy literals) must block."""
     diff = (
         "diff --git a/x.py b/x.py\n"
-        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n+HOST = '10.176.99.42'\n"
+        "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n+HOST = '10.176.0.1'\n"
     )
     r = sanitize.scan_diff(diff)
     assert r.ok is False

--- a/tests/test_hooks/test_pre_push_privacy_review.py
+++ b/tests/test_hooks/test_pre_push_privacy_review.py
@@ -1,0 +1,172 @@
+"""Tests for the pre-push privacy ADVISORY hook.
+
+The hook is non-blocking: it emits `hookSpecificOutput.additionalContext` on
+findings and ALWAYS exits 0. Fixtures use a generic CGNAT literal (100.64.0.1)
+that the contribution sanitizer's portability scanner flags but that is NOT
+this install's real address (so this test file leaks nothing and is not caught
+by the CI install-IP scan).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT / "scripts" / "hooks"))
+sys.path.insert(0, str(_ROOT / "src"))
+
+import pre_push_privacy_review as hook  # noqa: E402
+
+_LEAK_DIFF = (
+    "diff --git a/x.py b/x.py\n"
+    "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n"
+    "+HOST = '100.64.0.1'\n"  # generic CGNAT — flagged by the sanitizer, not real
+)
+_CLEAN_DIFF = (
+    "diff --git a/x.py b/x.py\n"
+    "--- a/x.py\n+++ b/x.py\n@@ -1 +1 @@\n"
+    "+HOST = '8.8.8.8'\n"  # public address — no portability hit
+)
+
+
+# ── _push_remote parsing (pure) ────────────────────────────────────────
+
+
+def test_push_remote_bare():
+    assert hook._push_remote("git push") == ""
+
+
+def test_push_remote_named():
+    assert hook._push_remote("git push origin feature") == "origin"
+    assert hook._push_remote("git push private myfix") == "private"
+
+
+def test_push_remote_flags_before_remote():
+    assert hook._push_remote("git push -u origin HEAD") == "origin"
+    assert hook._push_remote("git -C /repo push origin main") == "origin"
+    assert hook._push_remote("git push --force-with-lease origin br") == "origin"
+
+
+def test_push_remote_env_prefix():
+    assert hook._push_remote("GIT_SSH=x git push origin main") == "origin"
+
+
+def test_push_remote_not_a_push():
+    assert hook._push_remote("git commit -m x") is None
+    assert hook._push_remote("git log --oneline") is None
+    # 'git' and 'push' present but 'git' is not the command word:
+    assert hook._push_remote("echo git push") is None
+    assert hook._push_remote("grep -r push src/") is None
+
+
+def test_push_remote_compound_command():
+    # A push anywhere in a compound command is detected.
+    assert hook._push_remote("git add -A && git push origin main") == "origin"
+    assert hook._push_remote("git push | tee log.txt") == ""
+
+
+# ── _scan (reuses the sanitizer's cheap regex scanners) ────────────────
+
+
+def test_scan_flags_install_pattern():
+    findings = hook._scan(_LEAK_DIFF)
+    assert findings, "portability scanner should flag the CGNAT literal"
+    assert any(getattr(f, "file", None) == "x.py" for f in findings)
+
+
+def test_scan_clean_diff_no_findings():
+    assert hook._scan(_CLEAN_DIFF) == []
+
+
+# ── main() end-to-end (git helpers monkeypatched) ──────────────────────
+
+
+def _run_main(monkeypatch, capsys, *, command, public, diff):
+    payload = {"tool_name": "Bash", "tool_input": {"command": command}, "cwd": "/tmp"}
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(hook, "_targets_public_repo", lambda remote, cwd: public)
+    monkeypatch.setattr(hook, "_outgoing_diff", lambda cwd: diff)
+    hook.main()
+    return capsys.readouterr().out
+
+
+def test_main_emits_advisory_on_public_push_with_leak(monkeypatch, capsys):
+    out = _run_main(
+        monkeypatch, capsys, command="git push origin feat", public=True, diff=_LEAK_DIFF
+    )
+    payload = json.loads(out)
+    ctx = payload["hookSpecificOutput"]["additionalContext"]
+    assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert "permissionDecision" not in payload["hookSpecificOutput"]
+    assert "Pre-push privacy review" in ctx
+    assert "x.py" in ctx
+
+
+def test_main_quiet_on_clean_diff(monkeypatch, capsys):
+    out = _run_main(
+        monkeypatch, capsys, command="git push origin feat", public=True, diff=_CLEAN_DIFF
+    )
+    assert out == ""
+
+
+def test_main_noop_on_non_origin_push(monkeypatch, capsys):
+    out = _run_main(
+        monkeypatch, capsys, command="git push private feat", public=False, diff=_LEAK_DIFF
+    )
+    assert out == ""
+
+
+def test_main_noop_on_non_push(monkeypatch, capsys):
+    payload = {"tool_name": "Bash", "tool_input": {"command": "git commit -m x"}}
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    hook.main()
+    assert capsys.readouterr().out == ""
+
+
+def test_main_never_raises_and_stays_quiet_on_error(monkeypatch, capsys):
+    # A scanner blowup must NEVER escape (would non-zero-exit → block the push).
+    def _boom(_diff):
+        raise RuntimeError("scanner exploded")
+
+    monkeypatch.setattr(hook, "_scan", _boom)
+    out = _run_main(
+        monkeypatch, capsys, command="git push origin feat", public=True, diff=_LEAK_DIFF
+    )
+    assert out == ""  # swallowed, exit 0
+
+
+# ── shared git budget + URL normalization (review SHOULD-FIX + NOTE) ────
+
+
+def test_git_bails_when_budget_exhausted(monkeypatch):
+    """Once the shared wall-clock budget is blown, _git returns None WITHOUT
+    spawning another git process — so chained calls can't approach the hook's
+    CC timeout (a PreToolUse timeout is treated as a block)."""
+    import time as _t
+
+    def _boom_run(*a, **k):
+        raise AssertionError("git must not run once the budget is exhausted")
+
+    monkeypatch.setattr(hook, "_deadline", _t.monotonic() - 1.0)
+    monkeypatch.setattr(hook.subprocess, "run", _boom_run)
+    assert hook._git(["rev-parse", "HEAD"], None) is None
+
+
+def test_targets_public_repo_normalizes_url(monkeypatch):
+    """An explicit-URL push to the same repo as origin but spelled differently
+    (``.git`` suffix / trailing slash) still counts as the public repo."""
+    monkeypatch.setattr(
+        hook,
+        "_git",
+        lambda args, cwd: (
+            "https://github.com/Org/Repo.git"
+            if args[:3] == ["remote", "get-url", "--push"]
+            else None
+        ),
+    )
+    assert hook._targets_public_repo("https://github.com/Org/Repo", None) is True
+    assert hook._targets_public_repo("https://github.com/Org/Repo/", None) is True
+    assert hook._targets_public_repo("https://github.com/Org/Other", None) is False

--- a/tests/test_hooks/test_pre_push_privacy_review.py
+++ b/tests/test_hooks/test_pre_push_privacy_review.py
@@ -155,6 +155,29 @@ def test_git_bails_when_budget_exhausted(monkeypatch):
     assert hook._git(["rev-parse", "HEAD"], None) is None
 
 
+def test_effective_cwd_git_dash_c():
+    # `git -C <dir> push` runs in <dir>, overriding the payload cwd.
+    assert hook._effective_cwd("git -C /wt push -u origin br", "/main") == "/wt"
+
+
+def test_effective_cwd_leading_cd():
+    # `cd <dir> && git push` runs in <dir>.
+    assert hook._effective_cwd("cd /wt && git push origin br", "/main") == "/wt"
+
+
+def test_effective_cwd_git_c_overrides_cd():
+    # `-C` on the push wins over a preceding `cd`.
+    assert hook._effective_cwd("cd /a && git -C /b push", "/main") == "/b"
+
+
+def test_effective_cwd_relative_cd_resolves_against_payload():
+    assert hook._effective_cwd("cd sub && git push", "/base") == "/base/sub"
+
+
+def test_effective_cwd_bare_push_uses_payload():
+    assert hook._effective_cwd("git push origin br", "/main") == "/main"
+
+
 def test_targets_public_repo_normalizes_url(monkeypatch):
     """An explicit-URL push to the same repo as origin but spelled differently
     (``.git`` suffix / trailing slash) still counts as the public repo."""

--- a/tests/test_hooks/test_skill_injection.py
+++ b/tests/test_hooks/test_skill_injection.py
@@ -115,14 +115,38 @@ def test_score_skill_raw_points_keyword_hit():
     assert _score_skill(skill, ["selenium"]) >= _MIN_SCORE
 
 
-def test_score_skill_raw_points_desc_hit_below_threshold():
-    """A lone description hit (1 point) stays below the firing threshold."""
-    from skill_injection_hook import _MIN_SCORE, _score_skill
+def test_score_skill_description_not_scored():
+    """Description prose is not scored at all — only name/keyword hits count.
+
+    A term appearing ONLY in the description scores 0 (the old scorer gave it
+    1 point; two such incidental hits could reach the threshold and fire a
+    spurious nudge — e.g. 'plan'→'usage plan' + 'out'→'timeout')."""
+    from skill_injection_hook import _score_skill
 
     skill = {"name": "forecasting", "description": "predict future trends", "keywords": []}
-    score = _score_skill(skill, ["trends"])
-    assert score == 1.0
-    assert score < _MIN_SCORE
+    assert _score_skill(skill, ["trends"]) == 0.0
+    # Two description-only hits still score 0 (the api-gateway FP class).
+    ag = {
+        "name": "api-gateway",
+        "description": "REST API, usage plan, throttling, CORS, timeout errors",
+        "keywords": [],
+    }
+    assert _score_skill(ag, ["plan", "out"]) == 0.0
+
+
+def test_score_skill_name_match_is_whole_word():
+    """Name matching is whole-word (token), not substring.
+
+    'aws' matches the name token in 'aws-lambda'; 'awe' / 'awesome' do not
+    (the old substring match let 'aws' hit 'awesome')."""
+    from skill_injection_hook import _MIN_SCORE, _score_skill
+
+    skill = {"name": "aws-lambda", "description": "serverless functions", "keywords": []}
+    assert _score_skill(skill, ["aws"]) == 2.0
+    assert _score_skill(skill, ["aws"]) >= _MIN_SCORE
+    assert _score_skill(skill, ["lambda"]) == 2.0
+    assert _score_skill(skill, ["awesome"]) == 0.0
+    assert _score_skill(skill, ["awe"]) == 0.0
 
 
 def test_score_skill_not_diluted_by_long_prompt():
@@ -200,6 +224,28 @@ def test_main_desc_only_hit_does_not_fire(tmp_path, monkeypatch, capsys):
         monkeypatch, capsys, catalog_file, "market trends overnight tonight"
     )
     assert "[Skill]" not in out
+
+
+def test_main_generic_words_do_not_fire_description_match(tmp_path, monkeypatch, capsys):
+    """Regression: generic words matching only a skill's DESCRIPTION prose must
+    not fire a nudge. 'ok lets plan them out' previously surfaced 'api-gateway'
+    via 'plan'→'usage plan' (+1) and 'out'→'timeout' (+1) = threshold 2."""
+    catalog_file = tmp_path / "skill_catalog.json"
+    api_gateway = {
+        "name": "api-gateway",
+        "description": (
+            "Build and operate APIs with Amazon API Gateway. Triggers on: "
+            "REST API, usage plan, throttling, CORS, timeout errors (4xx, 5xx)."
+        ),
+        "keywords": [],
+        "tier": 2,
+        "path": "skill-library/aws/aws-serverless/skills/api-gateway",
+    }
+    _write_catalog(catalog_file, tier2=[api_gateway])
+
+    out = _run_main(monkeypatch, capsys, catalog_file, "ok lets plan them out")
+    assert "[Skill]" not in out
+    assert "api-gateway" not in out
 
 
 def test_main_catalog_nudges_not_crowded_out_by_process_nudges(

--- a/tests/test_learning/test_observation_writer.py
+++ b/tests/test_learning/test_observation_writer.py
@@ -234,8 +234,8 @@ class TestBroaderNormalization:
 
     def test_ip_addresses_preserved(self):
         from genesis.learning.observation_writer import _normalize_for_dedup
-        a = _normalize_for_dedup("host 10.176.34.199")
-        b = _normalize_for_dedup("host 10.176.34.200")
+        a = _normalize_for_dedup("host 10.0.0.1")
+        b = _normalize_for_dedup("host 10.0.0.2")
         assert a != b
 
     def test_iso_timestamps_preserved(self):

--- a/tests/test_scripts/test_check_portability.py
+++ b/tests/test_scripts/test_check_portability.py
@@ -41,8 +41,8 @@ def _run(repo: Path) -> subprocess.CompletedProcess:
         "172.31.255.1",  # RFC1918 class B upper bound
         "100.64.0.1",  # Tailscale CGNAT lower bound
         "100.127.9.9",  # Tailscale CGNAT upper bound
-        "fd42:abcd::1",  # IPv6 ULA (container prefix shape)
-        "fd7a:115c::1",  # IPv6 ULA (Tailscale prefix shape)
+        "fdcc:abcd::1",  # IPv6 ULA (generic fc00::/7 class)
+        "fddd:115c::1",  # IPv6 ULA (generic fc00::/7 class)
     ],
 )
 def test_flags_private_address_classes(tmp_path, leak):


### PR DESCRIPTION
## What & why

A red-team of the internet-outage-resilience session (user-requested) turned up a **live privacy exposure**: this install's real private LAN/Tailscale addresses have been sitting in **public** test fixtures since an early release. Root cause — the `tests/` tree is a blind spot across *every* CI leak check (gitleaks allowlists `tests/`; the portability and email scans exclude it; `check_portability.sh` targets only `src/config/scripts`). Non-routable (network-topology disclosure, not access), but a hard-rule violation — and a tests-only leak of real addresses would ship CI-green.

This bundled PR remediates the exposure and adds prevention. **Mixed concerns by design** (privacy scrub + a new hook + CI + a scorer fix) — each part stands alone.

## The four parts

1. **Scrub (remediation).** Replace this install's real values in three test fixtures with pattern-matching placeholders. The sanitizer tests assert on the finding *kind*, not the exact value, so they stay meaningful.
2. **Pre-push privacy advisory hook** (`scripts/hooks/pre_push_privacy_review.py`). A non-blocking CC PreToolUse hook: on a `git push` to the public repo it scans the outgoing diff with the contribution sanitizer's cheap regex scanners and injects a review prompt. It **never blocks** (always exits 0; a shared git wall-clock budget keeps it well under the hook timeout, since a PreToolUse timeout is treated as a block). This is the "make me actually look before code goes public" gate whose absence caused the leak.
3. **CI backstop.** A new `Install-IP scan (tests included)` step scans the whole tree — tests included — for install identifiers, closing the blind spot. It uses only the identifiers already public in this file's PR-description scan (**zero new disclosure**) with a small, stable exclude list.
4. **Skill-injection scorer fix** (unrelated bug found en route). `_score_skill` now scores whole-word name + explicit-keyword hits only and no longer mines skill descriptions, which produced generic-word false positives — a prompt like "ok lets plan them out" surfaced the AWS `api-gateway` skill via "plan"→"usage plan" (+1) and "out"→"timeout" (+1) = threshold.

## Deferred (tracked)

- **Sanitizer pattern-list genericization** (follow-up): the public sanitizer + this CI step still *name* install identifiers as detection patterns ("a redactor must name what it redacts"). Genericizing them (generic RFC classes in public src + install-specifics in a local overlay) is behavior-changing and needs its own redaction-coverage test pass. This PR deliberately does not touch it, and adds **no new** identifiers to public content.
- **Skill keyword backfill** (tabled): distinctive terms living only in a skill's description no longer nudge; backfill `keywords:` frontmatter.

## Verification

- Targeted suites green: skill-injection (21), sanitizer/observation/portability scrub (84), pre-push hook (15), hook-input contract (40). ruff clean.
- Scorer verified live against the real catalog: the false positive is gone; distinctive matches (`aws`/`selenium`/`browser`) still fire.
- CI rg step verified clean over the tree post-scrub and catches an injected real-subnet test-fixture leak.
- Pre-push grep on the final diff = zero new install identifiers.
- Reviewer verdict DONE_WITH_CONCERNS → the one SHOULD-FIX (git-call timeouts vs the hook's own CC timeout) fixed with a shared wall-clock budget + regression test.

Ledger: a9864e1415804985bc08b1d9a2abde2b

🤖 Generated with [Claude Code](https://claude.com/claude-code)
