### PR TITLE
feat(follow-ups): work_state derives lane + revisit_condition (fix kind mis-classification)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,13 +370,20 @@ When a user shares a file path or URL in conversation:
   derail this session — or the user directs it as separate. Otherwise do it
   now, even if unrelated/unasked; "already noted in a PR/comment" is not a
   reason to also create a row. Valid ones: create via `follow_up_create` MCP,
-  never leave as just text. **Two lanes** (`kind` on a follow-up): `follow_up`
-  = committed work, actionable, dispatched/surfaced (the FIX-NOW-or-valid-defer
-  cases above); `tabled` = an awareness record — "tracked, keep a record, not
-  acting near-term" — bug-tracker semantics, never dispatched or surfaced as
-  action. Genuine someday/maybe and deferred known bugs go to `tabled`, not a
-  `follow_up` row. (Inbox WATCH/BOOKMARK markers auto-route to `tabled` and
-  soft-decay after 60d.)
+  never leave as just text. **`follow_up_create` takes a `work_state`, not a raw
+  lane** — declare the item's state and the tool DERIVES the lane, so priority
+  never decides it. It is an INTENT/tractability axis, NOT priority (a low-priority
+  item you still intend to do is `ready`, never `deferred_cold`):
+  `ready` (actionable now, just needs doing) and `blocked_on_trigger` (intended,
+  waiting on a specific time/event — REQUIRES a `revisit_condition`) → the HOT
+  `follow_up` lane (committed, actionable, dispatched/surfaced — the
+  FIX-NOW-or-valid-defer cases above); `deferred_cold` (consciously NOT pursuing
+  near-term — vague/hard/someday) → the COLD `tabled` lane (an awareness record,
+  bug-tracker semantics, never dispatched or surfaced). Genuine someday/maybe and
+  deferred known bugs are `deferred_cold`, not the hot lane. (`follow_up_update`
+  moves lanes via the same `work_state` — there is no raw-`kind` lane override on
+  either surface, so priority can't pick the lane on update either. Inbox
+  WATCH/BOOKMARK markers auto-route to `tabled` and soft-decay after 60d.)
 - **No laziness.** Find root causes. No temporary fixes. No shortcuts.
   Don't EVER mute the symptom — fix the problem.
 - **Read before writing.** Never modify code you haven't fully read.
@@ -386,8 +393,8 @@ When a user shares a file path or URL in conversation:
 - **NEVER hide broken things — FIX THEM.** Fix the root cause, not the
   symptom. This is a thinking rule, not just a code rule.
 - **Bugs you see get fixed or tracked — never ignored.** Fix now by default; a
-  bug you consciously defer becomes a `tabled` record (bug-tracker lane above),
-  never a silent drop.
+  bug you consciously defer becomes a `tabled` record (`work_state="deferred_cold"`,
+  bug-tracker lane above), never a silent drop.
 - **Data repair is not a fix.** If a mechanism failed to write or propagate
   something, hand-writing the missing artifact (memory, directive, row, flag)
   repairs ONE instance on ONE install. Label it "data repair", and fix the

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -317,7 +317,11 @@ verified: 0e65071c 2026-07-21
   cron jobs (via MCP) that dispatch background DirectSessions. Distinct from
   `surplus/scheduler.py`.
 - `follow_ups/` = accountability ledger + dispatcher (every 5 min) that turns
-  follow-ups into surplus tasks; retention sweep on the learning scheduler.
+  follow-ups into surplus tasks; retention sweep on the learning scheduler. The
+  `follow_up_create`/`update` MCP tools take a `work_state`
+  (ready/blocked_on_trigger/deferred_cold) and DERIVE the hot(`follow_up`)/
+  cold(`tabled`) lane, so priority never picks the lane; `blocked_on_trigger`
+  requires a `revisit_condition` (nullable column on `follow_ups`).
 - GROUNDWORK: v4-parallel-dispatch, v4-surplus-tasks, v4-rate-tracking.
 
 ## 5. Information intake & research

--- a/src/genesis/dashboard/templates/partials/tabs/follow_ups.html
+++ b/src/genesis/dashboard/templates/partials/tabs/follow_ups.html
@@ -173,6 +173,11 @@
                       <strong>Reason:</strong> <span x-text="item.reason"></span>
                     </div>
                   </template>
+                  <template x-if="item.revisit_condition">
+                    <div style="margin-bottom:0.3rem; color:var(--color-text-secondary); font-size:0.68rem;">
+                      <strong>Revisit when:</strong> <span x-text="item.revisit_condition"></span>
+                    </div>
+                  </template>
                   <div style="display:flex; gap:0.5rem; font-size:0.62rem; color:var(--color-text-secondary); flex-wrap:wrap; margin-bottom:0.4rem;">
                     <span x-text="'Strategy: ' + (item.strategy || 'unknown')"></span>
                     <span x-text="'Source: ' + (item.source || 'unknown')"></span>

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -51,6 +51,7 @@ async def create(
     priority: str = "medium",
     pinned: bool = False,
     kind: str = "follow_up",
+    revisit_condition: str | None = None,
     domain: str | None = None,
     goal_id: str | None = None,
     dedup_key: str | None = None,
@@ -69,9 +70,9 @@ async def create(
     await db.execute(
         """INSERT INTO follow_ups
            (id, source, source_session, content, reason, strategy,
-            scheduled_at, status, priority, pinned, kind, domain, goal_id,
-            dedup_key, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?)""",
+            scheduled_at, status, priority, pinned, kind, revisit_condition,
+            domain, goal_id, dedup_key, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             fid,
             source,
@@ -83,6 +84,7 @@ async def create(
             priority,
             int(pinned),
             kind,
+            revisit_condition.strip() if revisit_condition and revisit_condition.strip() else None,
             domain,
             goal_id,
             dedup_key,
@@ -612,6 +614,19 @@ _VALID_STATUS = {
     "blocked",
 }
 
+# Work-state → lane derivation. The MCP follow_up_create/update handlers take a
+# `work_state` (the item's actual state) and DERIVE `kind`, so priority can't leak
+# into the hot(follow_up)/cold(tabled) lane choice. `blocked_on_trigger` additionally
+# requires a `revisit_condition` (the trigger being waited on). See CC memory
+# followup_kind_conflation. Enforced at the MCP handler (judgment callers); rule-based
+# programmatic callers (e.g. inbox WATCH/BOOKMARK markers) set `kind` directly.
+WORK_STATE_TO_KIND = {
+    "ready": "follow_up",
+    "blocked_on_trigger": "follow_up",
+    "deferred_cold": "tabled",
+}
+VALID_WORK_STATE = frozenset(WORK_STATE_TO_KIND)
+
 # Allowlisted sort keys → ORDER BY fragment (never interpolate caller input).
 # Every fragment floats pinned rows to the top (pinned is a "keep visible"
 # flag, honored regardless of the chosen sort). The status sort ranks by
@@ -650,6 +665,24 @@ async def set_kind(db: aiosqlite.Connection, id: str, kind: str) -> bool:
     cursor = await db.execute(
         "UPDATE follow_ups SET kind = ? WHERE id = ?",
         (kind, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def set_revisit_condition(
+    db: aiosqlite.Connection, id: str, revisit_condition: str | None
+) -> bool:
+    """Set/clear a follow-up's revisit_condition — the trigger that resurfaces a
+    tabled item or the event a blocked follow_up waits on. None/whitespace clears it.
+
+    Targeted single-column write (mirrors set_kind/set_pinned): never a
+    read-modify-write of the row, so it can't reopen the #1198 lost-update race.
+    """
+    value = revisit_condition.strip() if revisit_condition and revisit_condition.strip() else None
+    cursor = await db.execute(
+        "UPDATE follow_ups SET revisit_condition = ? WHERE id = ?",
+        (value, id),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/src/genesis/db/migrations/0075_follow_up_revisit_condition.py
+++ b/src/genesis/db/migrations/0075_follow_up_revisit_condition.py
@@ -1,0 +1,50 @@
+"""Add ``follow_ups.revisit_condition`` — the trigger that resurfaces an item.
+
+Part of the follow-up lane-discipline fix (CC memory ``followup_kind_conflation``).
+The MCP ``follow_up_create``/``follow_up_update`` handlers now take a ``work_state``
+(``ready`` / ``blocked_on_trigger`` / ``deferred_cold``) and DERIVE ``kind``, so
+priority can no longer leak into the hot(follow_up)/cold(tabled) lane choice.
+``blocked_on_trigger`` requires a ``revisit_condition`` naming the time/event it
+waits on; ``deferred_cold`` may optionally carry the condition that would revive it.
+
+``revisit_condition`` is NULL for ``ready`` follow-ups and for rule-based
+programmatic rows (e.g. inbox WATCH/BOOKMARK markers) that set ``kind`` directly.
+
+Self-contained upgrade path: the column ADD is PRAGMA-guarded so this migration
+applies whether it runs via ``create_all_tables`` (which builds the canonical
+CREATE TABLE — already carrying the column — before the runner) OR via the
+standalone numbered-migration runner (``python -m genesis.db.migrations --apply``,
+used by update.sh) on a legacy DB. No commit — the runner owns the transaction.
+(Numbered 0075: 0074 is claimed by the in-flight memory-reconcile PR; the runner
+applies by per-id tracking and tolerates gaps — only duplicate prefixes are fatal.)
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='follow_ups'"
+    )
+    if not await cursor.fetchone():
+        return  # fresh DB — the CREATE TABLE already carries the column
+
+    cursor = await db.execute("PRAGMA table_info(follow_ups)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "revisit_condition" not in cols:
+        await db.execute("ALTER TABLE follow_ups ADD COLUMN revisit_condition TEXT")
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='follow_ups'"
+    )
+    if not await cursor.fetchone():
+        return
+
+    cursor = await db.execute("PRAGMA table_info(follow_ups)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "revisit_condition" in cols:
+        await db.execute("ALTER TABLE follow_ups DROP COLUMN revisit_condition")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1293,7 +1293,10 @@ TABLES = {
                 domain IN ('internal', 'user_world')
             ),
             goal_id          TEXT,
-            dedup_key        TEXT
+            dedup_key        TEXT,
+            -- Declared LAST so a fresh CREATE matches the migration 0075
+            -- ALTER ... ADD COLUMN (which appends) — fresh/migrated column-order parity.
+            revisit_condition TEXT
         )
     """,
     "file_modifications": """

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -33,11 +33,12 @@ async def _impl_follow_up_create(
     reason: str,
     strategy: str,
     *,
+    work_state: str,
     scheduled_at: str | None = None,
     priority: str = "medium",
     pinned: bool = False,
     domain: str | None = None,
-    kind: str = "follow_up",
+    revisit_condition: str = "",
     source_session: str | None = None,
 ) -> dict:
     """Create a follow-up item in the accountability ledger."""
@@ -63,9 +64,32 @@ async def _impl_follow_up_create(
             "error": f"Invalid domain '{domain}'. Must be one of: {', '.join(sorted(valid_domains))}"
         }
 
-    valid_kinds = {"follow_up", "tabled"}
-    if kind not in valid_kinds:
-        return {"error": f"Invalid kind '{kind}'. Must be one of: {', '.join(sorted(valid_kinds))}"}
+    from genesis.db.crud import follow_ups
+
+    if work_state not in follow_ups.VALID_WORK_STATE:
+        return {
+            "error": (
+                f"Invalid work_state '{work_state}'. Must be one of: "
+                f"{', '.join(sorted(follow_ups.VALID_WORK_STATE))}. "
+                "ready = actionable now, just needs doing (manpower) → follow_up (hot list). "
+                "blocked_on_trigger = intended but waiting on a specific time/event/"
+                "precondition → follow_up (hot list); requires revisit_condition. "
+                "deferred_cold = consciously NOT pursuing near-term (vague/hard/someday) "
+                "→ tabled (cold list). This is an intent axis, NOT priority — a "
+                "low-priority item you still intend to do is 'ready', not 'deferred_cold'."
+            )
+        }
+    kind = follow_ups.WORK_STATE_TO_KIND[work_state]
+    if work_state == "blocked_on_trigger" and not revisit_condition.strip():
+        return {
+            "error": (
+                "work_state='blocked_on_trigger' requires revisit_condition — name the "
+                "specific time/event/precondition you're waiting on. If there is no "
+                "concrete trigger and you're just not pursuing this near-term, use "
+                "work_state='deferred_cold' (tabled). If it needs doing now, use "
+                "work_state='ready'."
+            )
+        }
 
     if strategy == "scheduled_task" and not scheduled_at:
         return {"error": "scheduled_at is required when strategy is 'scheduled_task'"}
@@ -73,7 +97,6 @@ async def _impl_follow_up_create(
     try:
         import os
 
-        from genesis.db.crud import follow_ups
         from genesis.ego.domain_classifier import classify_domain
 
         # Detect dispatched session context for proper source attribution
@@ -100,20 +123,26 @@ async def _impl_follow_up_create(
             pinned=pinned,
             domain=domain,
             kind=kind,
+            revisit_condition=revisit_condition or None,
         )
+        cond = revisit_condition.strip() or None
         lane_msg = (
-            "Tabled (someday/maybe — tracked, not surfaced as actionable work)."
+            "Tabled (cold list — consciously not pursuing near-term; tracked, not "
+            "surfaced as actionable work)."
             if kind == "tabled"
-            else f"Follow-up created. Strategy: {strategy}."
+            else f"Follow-up created (hot list). Strategy: {strategy}."
         )
         return {
             "id": fid,
             "status": "pending",
             "kind": kind,
+            "work_state": work_state,
+            "revisit_condition": cond,
             "strategy": strategy,
             "domain": domain,
             "pinned": pinned,
             "message": lane_msg
+            + (f" Revisit when: {cond}." if cond else "")
             + (f" Domain: {domain}." if domain else "")
             + (" (pinned — ego cannot auto-resolve)" if pinned else ""),
         }
@@ -177,7 +206,8 @@ async def _impl_follow_up_update(
     blocked_reason: str | None = None,
     priority: str | None = None,
     pinned: bool | None = None,
-    kind: str | None = None,
+    work_state: str | None = None,
+    revisit_condition: str | None = None,
 ) -> dict:
     """Update an existing follow-up item."""
     db = _get_db()
@@ -196,16 +226,43 @@ async def _impl_follow_up_update(
             "error": f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(valid_priorities))}"
         }
 
-    valid_kinds = {"follow_up", "tabled"}
-    if kind and kind not in valid_kinds:
-        return {"error": f"Invalid kind '{kind}'. Must be one of: {', '.join(sorted(valid_kinds))}"}
+    from genesis.db.crud import follow_ups
+
+    if work_state is not None and work_state not in follow_ups.VALID_WORK_STATE:
+        return {
+            "error": (
+                f"Invalid work_state '{work_state}'. Must be one of: "
+                f"{', '.join(sorted(follow_ups.VALID_WORK_STATE))}. See follow_up_create "
+                "for the ready / blocked_on_trigger / deferred_cold meanings."
+            )
+        }
 
     try:
-        from genesis.db.crud import follow_ups
-
         existing = await follow_ups.get_by_id(db, follow_up_id)
         if not existing:
             return {"error": f"Follow-up '{follow_up_id}' not found"}
+
+        # Resolve any lane change UP-FRONT (before writes) so a gate failure never
+        # leaves a partial update. Lane moves go through work_state (the item's
+        # declared state) — there is no raw-`kind` lane override, so priority can't
+        # pick the lane on update any more than on create. blocked_on_trigger
+        # requires a revisit_condition (newly supplied, or already on the row).
+        resolved_kind: str | None = None
+        if work_state is not None:
+            resolved_kind = follow_ups.WORK_STATE_TO_KIND[work_state]
+            effective_cond = (
+                revisit_condition
+                if revisit_condition is not None
+                else existing.get("revisit_condition")
+            ) or ""
+            if work_state == "blocked_on_trigger" and not effective_cond.strip():
+                return {
+                    "error": (
+                        "work_state='blocked_on_trigger' requires revisit_condition — "
+                        "name the time/event/precondition you're waiting on, or use "
+                        "'deferred_cold' (tabled) / 'ready' instead."
+                    )
+                }
 
         if priority and priority != existing.get("priority"):
             await db.execute(
@@ -217,8 +274,10 @@ async def _impl_follow_up_update(
         if pinned is not None:
             await follow_ups.set_pinned(db, follow_up_id, pinned)
 
-        if kind:
-            await follow_ups.set_kind(db, follow_up_id, kind)
+        if resolved_kind:
+            await follow_ups.set_kind(db, follow_up_id, resolved_kind)
+        if revisit_condition is not None:
+            await follow_ups.set_revisit_condition(db, follow_up_id, revisit_condition)
 
         if status:
             updated = await follow_ups.update_status(
@@ -257,6 +316,7 @@ async def _impl_follow_up_update(
             "id": follow_up_id,
             "status": refreshed["status"],
             "kind": refreshed.get("kind"),
+            "revisit_condition": refreshed.get("revisit_condition"),
             "priority": refreshed["priority"],
             "pinned": bool(refreshed.get("pinned", 0)),
             "message": "Follow-up updated.",
@@ -276,62 +336,61 @@ async def follow_up_create(
     content: str,
     reason: str,
     strategy: str,
+    work_state: str,
     scheduled_at: str = "",
     priority: str = "medium",
     pinned: bool = False,
     domain: str = "",
-    kind: str = "follow_up",
+    revisit_condition: str = "",
 ) -> dict:
-    """Create a follow-up (or a tabled someday/maybe) in the accountability ledger.
+    """Create a follow-up in the accountability ledger.
 
-    Two lanes, chosen by `kind` — pick deliberately:
-    - kind="follow_up" (default): ACTIONABLE deferred work Genesis should own and
-      eventually DO. Enters the ledger, surfaces in the morning report, and the
-      ego/sessions act on it. Use ONLY when there is a real, intended next step.
-    - kind="tabled": a SOMEDAY/MAYBE — worth remembering but NOT committing to.
-      Tracked, but never surfaced as work or auto-actioned. Use for ideas,
-      interests, or possibilities to revisit later so they don't clog the
-      actionable queue. When torn between a low-priority follow_up and a maybe
-      with no concrete next step, prefer tabled.
+    Declare the item's WORK_STATE — the tool DERIVES the lane from it, so priority
+    never decides the lane. Two lists:
+    - HOT (follow_up): work you INTEND to do near-term. May be blocked on time, an
+      event, or just manpower — but NEVER hard-blocked / not-an-easy-fix / vague.
+    - COLD (tabled): things you are CONSCIOUSLY NOT doing near-term (further off,
+      harder, vaguer — maybe someday). Kept off the actionable queue.
 
     Args:
-        content: What needs to happen (actionable description)
-        reason: Why this follow-up exists (context for future sessions/ego)
-        kind: "follow_up" (actionable, default) or "tabled" (someday/maybe, never
-            auto-actioned). See the two-lane note above — don't file a real
-            commitment as tabled, and don't clog the actionable queue with maybes.
-        strategy: How to handle it — choose based on what kind of work this requires:
-            - user_input_needed: Park this for a future interactive session. No
-              automation touches it. Use for anything requiring real CC sessions:
-              coding, plan execution, Genesis development, file edits. Surfaces in
-              morning report so the user can trigger a session when ready.
-            - surplus_task: Enqueue to the free-model surplus system. Runs on idle
-              compute using lightweight free-tier models. ONLY for pure analysis,
-              summarization, or data processing. NOT for code changes, file edits,
-              or anything requiring an interactive CC session.
-            - scheduled_task: Same as surplus_task but triggered at a specific time.
-              Same constraints — free model only, no interactive work.
-            - ego_judgment: Hand to ego for evaluation in its next cycle. Ego decides
-              whether to act, defer, or escalate. Not auto-executed.
-        scheduled_at: ISO datetime for scheduled_task strategy (required if strategy is scheduled_task)
-        priority: low | medium | high | critical
-        pinned: If true, ego can see this follow-up but cannot auto-resolve it.
-            Only the user can close a pinned follow-up. Use for items you want
-            to track personally.
-        domain: Whose world this belongs to — "internal" (Genesis's own system
-            work: runtime, routing, memory, health, dev) or "user_world" (the
-            user's life, career, content, interests). Leave empty to let Genesis
-            classify (it only auto-detects internal; otherwise leaves it unset).
+        content: What needs to happen (actionable description).
+        reason: Why this follow-up exists (context for future sessions/ego).
+        work_state: The item's actual state — this DERIVES the lane. Pick honestly;
+            it is an intent/tractability axis, NOT priority (a low-priority item you
+            still intend to do is 'ready', not 'deferred_cold'):
+            - "ready": actionable now, just needs doing → HOT (follow_up).
+            - "blocked_on_trigger": intended, waiting on a specific time/event/
+              precondition → HOT (follow_up). REQUIRES revisit_condition.
+            - "deferred_cold": consciously not pursuing near-term (vague/hard/
+              someday) → COLD (tabled).
+        strategy: How to EXECUTE it if/when acted on (orthogonal to work_state):
+            - user_input_needed: park for a future interactive CC session (coding,
+              plan execution, Genesis dev, file edits). Surfaces in morning report.
+            - surplus_task: enqueue to the free-model surplus system — pure analysis/
+              summarization only, never code/file edits or interactive work.
+            - scheduled_task: like surplus_task but time-triggered (the time-based
+              form of blocked_on_trigger); requires scheduled_at. Free model only.
+            - ego_judgment: hand to ego to evaluate next cycle (a good default for
+              deferred_cold items, which have no near-term execution route).
+        revisit_condition: The trigger to revisit — REQUIRED when
+            work_state="blocked_on_trigger" (name the time/event/precondition).
+            Optional but encouraged for deferred_cold (what would revive it).
+        scheduled_at: ISO datetime (required when strategy is scheduled_task).
+        priority: low | medium | high | critical. Does NOT affect the lane.
+        pinned: If true, ego can see but cannot auto-resolve; only the user closes it.
+        domain: "internal" (Genesis's own system work) or "user_world" (the user's
+            life/career/content). Leave empty to let Genesis classify (internal-only).
     """
     return await _impl_follow_up_create(
         content,
         reason,
         strategy,
+        work_state=work_state,
         scheduled_at=scheduled_at or None,
         priority=priority,
         pinned=pinned,
         domain=domain or None,
-        kind=kind,
+        revisit_condition=revisit_condition,
     )
 
 
@@ -343,23 +402,27 @@ async def follow_up_update(
     blocked_reason: str = "",
     priority: str = "",
     pinned: str = "",
-    kind: str = "",
+    work_state: str = "",
+    revisit_condition: str = "",
 ) -> dict:
     """Update an existing follow-up item.
 
-    Use this to change status, add resolution notes, mark as blocked,
-    adjust priority, pin/unpin, or move it between the follow_up/tabled lanes.
+    Change status, add resolution notes, mark blocked, adjust priority, pin/unpin,
+    or move it between the hot (follow_up) and cold (tabled) lanes.
 
     Args:
-        follow_up_id: The ID of the follow-up to update
+        follow_up_id: The ID of the follow-up to update.
         status: New status (pending, scheduled, in_progress, completed, failed, blocked). Empty to keep current.
         resolution_notes: Notes on resolution or progress. Appended context for future sessions.
         blocked_reason: Why this follow-up is blocked (sets status to blocked if status not provided).
         priority: New priority (low, medium, high, critical). Empty to keep current.
-        pinned: Set to "true" to pin (ego cannot auto-resolve) or "false" to unpin. Empty to keep current.
-        kind: Move between lanes — "follow_up" (actionable) or "tabled" (someday/maybe).
-            Empty to keep current. Use to demote a follow-up you're no longer
-            committing to into tabled, or promote a tabled idea back to actionable work.
+        pinned: "true" to pin (ego cannot auto-resolve) or "false" to unpin. Empty to keep current.
+        work_state: Re-declare the item's state to move lanes:
+            "ready"/"blocked_on_trigger" → hot (follow_up); "deferred_cold" → cold
+            (tabled). blocked_on_trigger requires revisit_condition (new or already
+            set). Empty to keep the current lane.
+        revisit_condition: Set/replace the revisit trigger (the event that would
+            resurface the item). Empty to leave unchanged.
     """
     pinned_bool: bool | None = None
     if pinned.lower() in ("true", "1", "yes"):
@@ -374,7 +437,8 @@ async def follow_up_update(
         blocked_reason=blocked_reason or None,
         priority=priority or None,
         pinned=pinned_bool,
-        kind=kind or None,
+        work_state=work_state or None,
+        revisit_condition=revisit_condition or None,
     )
 
 

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -90,6 +90,21 @@ async def _impl_follow_up_create(
                 "work_state='ready'."
             )
         }
+    if work_state == "blocked_on_trigger" and strategy == "surplus_task":
+        # surplus_task dispatches immediately on idle compute (dispatcher.py:63-70),
+        # which would run the work BEFORE the trigger fires. A prose trigger can't
+        # gate an immediate dispatch — steer to a strategy that honors waiting.
+        return {
+            "error": (
+                "work_state='blocked_on_trigger' cannot use strategy='surplus_task' — "
+                "surplus tasks dispatch immediately on idle compute and would run before "
+                "the trigger fires. Use strategy='scheduled_task' (with scheduled_at) for "
+                "a time trigger, or 'user_input_needed' / 'ego_judgment' for an event "
+                "trigger so it isn't auto-dispatched before the event."
+            )
+        }
+    if work_state == "ready":
+        revisit_condition = ""  # a 'ready' item has no trigger — never store one
 
     if strategy == "scheduled_task" and not scheduled_at:
         return {"error": "scheduled_at is required when strategy is 'scheduled_task'"}
@@ -263,6 +278,15 @@ async def _impl_follow_up_update(
                         "'deferred_cold' (tabled) / 'ready' instead."
                     )
                 }
+            if work_state == "blocked_on_trigger" and existing.get("strategy") == "surplus_task":
+                return {
+                    "error": (
+                        "work_state='blocked_on_trigger' can't apply to a surplus_task "
+                        "follow-up — surplus tasks dispatch immediately on idle compute, "
+                        "ignoring the trigger. Recreate it as scheduled_task (time trigger) "
+                        "or user_input_needed / ego_judgment (event trigger)."
+                    )
+                }
 
         if priority and priority != existing.get("priority"):
             await db.execute(
@@ -276,7 +300,10 @@ async def _impl_follow_up_update(
 
         if resolved_kind:
             await follow_ups.set_kind(db, follow_up_id, resolved_kind)
-        if revisit_condition is not None:
+        if work_state == "ready":
+            # a 'ready' item has no trigger — clear any stale revisit_condition
+            await follow_ups.set_revisit_condition(db, follow_up_id, None)
+        elif revisit_condition is not None:
             await follow_ups.set_revisit_condition(db, follow_up_id, revisit_condition)
 
         if status:
@@ -360,7 +387,9 @@ async def follow_up_create(
             still intend to do is 'ready', not 'deferred_cold'):
             - "ready": actionable now, just needs doing → HOT (follow_up).
             - "blocked_on_trigger": intended, waiting on a specific time/event/
-              precondition → HOT (follow_up). REQUIRES revisit_condition.
+              precondition → HOT (follow_up). REQUIRES revisit_condition. Not valid
+              with strategy="surplus_task" (that dispatches immediately, ignoring the
+              trigger) — use scheduled_task (time) or user_input_needed/ego_judgment (event).
             - "deferred_cold": consciously not pursuing near-term (vague/hard/
               someday) → COLD (tabled).
         strategy: How to EXECUTE it if/when acted on (orthogonal to work_state):

--- a/tests/test_db/test_migration_0075_follow_up_revisit_condition.py
+++ b/tests/test_db/test_migration_0075_follow_up_revisit_condition.py
@@ -1,0 +1,128 @@
+"""Migration 0075 — add ``follow_ups.revisit_condition``.
+
+Covers the legacy upgrade, idempotency, the double-application path
+(``create_all_tables`` then the numbered runner — the fresh-DB boot case that a
+naive ALTER would crash on), the no-table no-op, ``down``, and — the reason the
+column is declared last in the canonical DDL — fresh/migrated column-ORDER parity.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M75 = importlib.import_module("genesis.db.migrations.0075_follow_up_revisit_condition")
+
+# follow_ups as it existed BEFORE this column (pre-0075 installs).
+_LEGACY_DDL = """
+    CREATE TABLE follow_ups (
+        id               TEXT PRIMARY KEY,
+        source           TEXT NOT NULL,
+        source_session   TEXT,
+        content          TEXT NOT NULL,
+        reason           TEXT,
+        strategy         TEXT NOT NULL CHECK (
+            strategy IN ('scheduled_task', 'surplus_task', 'ego_judgment', 'user_input_needed')
+        ),
+        scheduled_at     TEXT,
+        status           TEXT NOT NULL DEFAULT 'pending' CHECK (
+            status IN ('pending', 'scheduled', 'in_progress', 'completed', 'failed', 'blocked')
+        ),
+        linked_task_id   TEXT,
+        priority         TEXT NOT NULL DEFAULT 'medium' CHECK (
+            priority IN ('low', 'medium', 'high', 'critical')
+        ),
+        created_at       TEXT NOT NULL,
+        completed_at     TEXT,
+        resolution_notes TEXT,
+        blocked_reason   TEXT,
+        escalated_to     TEXT,
+        verified_at      TEXT,
+        verification_notes TEXT,
+        pinned           INTEGER NOT NULL DEFAULT 0,
+        kind             TEXT NOT NULL DEFAULT 'follow_up' CHECK (
+            kind IN ('follow_up', 'tabled')
+        ),
+        domain           TEXT CHECK (
+            domain IN ('internal', 'user_world')
+        ),
+        goal_id          TEXT,
+        dedup_key        TEXT
+    )
+"""
+
+
+async def _cols(db: aiosqlite.Connection) -> list[str]:
+    cur = await db.execute("PRAGMA table_info(follow_ups)")
+    return [row[1] for row in await cur.fetchall()]
+
+
+@pytest.mark.asyncio
+async def test_up_adds_column_to_legacy_db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_LEGACY_DDL)
+        assert "revisit_condition" not in await _cols(db)
+        await M75.up(db)
+        assert "revisit_condition" in await _cols(db)
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_LEGACY_DDL)
+        await M75.up(db)
+        await M75.up(db)  # second run must not raise
+        assert (await _cols(db)).count("revisit_condition") == 1
+
+
+@pytest.mark.asyncio
+async def test_double_path_after_create_all_tables(tmp_path):
+    """create_all_tables already carries the column; the runner must then no-op
+    (BLOCKER: a naive ALTER would raise 'duplicate column' on every fresh boot)."""
+    from genesis.db.schema import create_all_tables
+
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await create_all_tables(db)
+        assert "revisit_condition" in await _cols(db)
+        await M75.up(db)  # must not raise "duplicate column"
+        assert (await _cols(db)).count("revisit_condition") == 1
+
+
+@pytest.mark.asyncio
+async def test_up_no_ops_when_table_absent(tmp_path):
+    """A DB with no follow_ups table yet must not raise (fresh-install ordering)."""
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await M75.up(db)  # no-op, no raise
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='follow_ups'"
+        )
+        assert await cur.fetchone() is None
+
+
+@pytest.mark.asyncio
+async def test_fresh_and_migrated_column_order_identical(tmp_path):
+    """revisit_condition is declared LAST precisely so both paths agree byte-for-byte
+    — ALTER appends, so a mid-table CREATE would diverge from an upgraded DB."""
+    from genesis.db.schema import create_all_tables
+
+    async with aiosqlite.connect(str(tmp_path / "fresh.db")) as db:
+        await create_all_tables(db)
+        fresh = await _cols(db)
+    async with aiosqlite.connect(str(tmp_path / "migrated.db")) as db:
+        await db.execute(_LEGACY_DDL)
+        await M75.up(db)
+        migrated = await _cols(db)
+
+    assert fresh == migrated
+    assert fresh[-1] == "revisit_condition"
+
+
+@pytest.mark.asyncio
+async def test_down_removes_column(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as db:
+        await db.execute(_LEGACY_DDL)
+        await M75.up(db)
+        await M75.down(db)
+        assert "revisit_condition" not in await _cols(db)

--- a/tests/test_inbox/test_inbox_digest.py
+++ b/tests/test_inbox/test_inbox_digest.py
@@ -39,7 +39,8 @@ async def db():
         kind TEXT NOT NULL DEFAULT 'follow_up',
         domain TEXT,
         goal_id TEXT,
-        dedup_key TEXT
+        dedup_key TEXT,
+        revisit_condition TEXT
     )""")
     await conn.execute("""CREATE TABLE inbox_items (
         id TEXT PRIMARY KEY,

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -1,4 +1,6 @@
-"""Tests for the follow_up MCP tools — create/update, incl. the tabled lane."""
+"""Tests for the follow_up MCP tools — work_state → lane derivation, revisit
+condition gate, the hot(follow_up)/cold(tabled) lanes, and the update path.
+"""
 
 from __future__ import annotations
 
@@ -12,76 +14,227 @@ from genesis.mcp.health import follow_up_tools
 pytestmark = pytest.mark.asyncio
 
 
-async def test_create_default_kind_is_follow_up(db):
-    """Without an explicit kind, a create lands in the actionable follow_up lane."""
+# ─── work_state → kind derivation (create) ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("work_state", "expected_kind"),
+    [
+        ("ready", "follow_up"),
+        ("blocked_on_trigger", "follow_up"),
+        ("deferred_cold", "tabled"),
+    ],
+)
+async def test_create_work_state_derives_kind(db, work_state, expected_kind):
+    """The caller declares work_state; the tool DERIVES the lane (kind)."""
+    kwargs = {"revisit_condition": "when X lands"} if work_state == "blocked_on_trigger" else {}
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         res = await follow_up_tools._impl_follow_up_create(
             content="do the thing",
             reason="because",
             strategy="ego_judgment",
+            work_state=work_state,
+            **kwargs,
         )
     assert "id" in res, res
-    assert res["kind"] == "follow_up"
+    assert res["kind"] == expected_kind
+    assert res["work_state"] == work_state
     row = await follow_ups.get_by_id(db, res["id"])
-    assert row["kind"] == "follow_up"
+    assert row["kind"] == expected_kind
 
 
-async def test_create_kind_tabled(db):
-    """kind='tabled' routes a someday/maybe into the tabled lane, off the actionable queue."""
+async def test_create_ready_has_no_revisit_condition(db):
+    """A 'ready' item needs no trigger; revisit_condition stays NULL."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="just do it",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="ready",
+        )
+    assert res["revisit_condition"] is None
+    row = await follow_ups.get_by_id(db, res["id"])
+    assert row["revisit_condition"] is None
+
+
+async def test_create_deferred_cold_is_off_actionable_surface(db):
+    """deferred_cold → tabled: tracked but never on the actionable surface."""
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         res = await follow_up_tools._impl_follow_up_create(
             content="maybe explore idea Y someday",
-            reason="interesting",
+            reason="interesting, not now",
             strategy="ego_judgment",
-            kind="tabled",
+            work_state="deferred_cold",
         )
-    assert "id" in res, res
     assert res["kind"] == "tabled"
-    row = await follow_ups.get_by_id(db, res["id"])
-    assert row["kind"] == "tabled"
-    # A tabled item is kept OFF the actionable surface (never auto-actioned),
-    # even though its status is the default 'pending'.
     actionable = await follow_ups.get_actionable(db, limit=50)
     assert all(r["id"] != res["id"] for r in actionable)
 
 
-async def test_create_invalid_kind_errors(db):
+# ─── the blocked_on_trigger revisit_condition gate ───────────────────────────
+
+
+async def test_blocked_on_trigger_requires_revisit_condition(db):
+    """blocked_on_trigger with no trigger → teaching error, NO row created."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="waiting on something",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="blocked_on_trigger",
+        )
+        recent = await follow_ups.get_recent(db, limit=50, include_tabled=True)
+    assert "error" in res
+    assert "revisit_condition" in res["error"]
+    assert not any(r["content"] == "waiting on something" for r in recent)
+
+
+async def test_blocked_on_trigger_whitespace_condition_errors(db):
+    """A whitespace-only trigger is treated as empty → gate fires."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="x",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="blocked_on_trigger",
+            revisit_condition="   ",
+        )
+    assert "error" in res
+    assert "revisit_condition" in res["error"]
+
+
+async def test_blocked_on_trigger_with_condition_round_trips(db):
+    """A named trigger is stored (stripped) and round-trips through the row + response."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="ship after review",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="blocked_on_trigger",
+            revisit_condition="  when PR #123 merges  ",
+        )
+    assert res["kind"] == "follow_up"
+    assert res["revisit_condition"] == "when PR #123 merges"
+    row = await follow_ups.get_by_id(db, res["id"])
+    assert row["revisit_condition"] == "when PR #123 merges"
+
+
+async def test_deferred_cold_may_carry_optional_condition(db):
+    """deferred_cold does NOT require a trigger but may store one."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="someday, maybe",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="deferred_cold",
+            revisit_condition="if a user ever asks for it",
+        )
+    assert res["kind"] == "tabled"
+    row = await follow_ups.get_by_id(db, res["id"])
+    assert row["revisit_condition"] == "if a user ever asks for it"
+
+
+# ─── work_state validation / requiredness ────────────────────────────────────
+
+
+async def test_create_invalid_work_state_errors(db):
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         res = await follow_up_tools._impl_follow_up_create(
             content="x",
             reason="y",
             strategy="ego_judgment",
-            kind="bogus",
+            work_state="bogus",
         )
     assert "error" in res
-    assert "kind" in res["error"].lower()
+    assert "work_state" in res["error"]
 
 
-async def test_update_relanes_follow_up_to_tabled(db):
-    """follow_up_update kind='tabled' demotes an actionable item into the tabled lane."""
+async def test_create_work_state_is_required(db):
+    """work_state has no default — omitting it is a hard TypeError, not a silent lane."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db), pytest.raises(TypeError):
+        await follow_up_tools._impl_follow_up_create(
+            content="x",
+            reason="y",
+            strategy="ego_judgment",
+        )
+
+
+# ─── update path: lane moves via work_state (kind deprecated) ─────────────────
+
+
+async def test_update_relanes_via_work_state(db):
+    """follow_up_update work_state='deferred_cold' demotes an item to the cold lane."""
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         created = await follow_up_tools._impl_follow_up_create(
             content="reconsider later",
-            reason="low priority",
+            reason="not now",
             strategy="ego_judgment",
+            work_state="ready",
         )
         fid = created["id"]
-        res = await follow_up_tools._impl_follow_up_update(fid, kind="tabled")
+        res = await follow_up_tools._impl_follow_up_update(fid, work_state="deferred_cold")
     assert res.get("kind") == "tabled", res
     row = await follow_ups.get_by_id(db, fid)
     assert row["kind"] == "tabled"
 
 
-async def test_update_invalid_kind_errors(db):
+async def test_update_no_longer_accepts_raw_kind(db):
+    """The deprecated raw `kind` lane override was removed from follow_up_update —
+    lane moves go through work_state on BOTH surfaces (create + update), closing the
+    free-string / priority-reasoning door on the update path too."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="x",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="ready",
+        )
+        fid = created["id"]
+        with pytest.raises(TypeError):
+            await follow_up_tools._impl_follow_up_update(fid, kind="tabled")
+
+
+async def test_update_to_blocked_on_trigger_requires_condition(db):
+    """Moving to blocked_on_trigger needs a trigger (new or already on the row)."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="x",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="ready",
+        )
+        fid = created["id"]
+        # No condition supplied and none on the row → error.
+        res_err = await follow_up_tools._impl_follow_up_update(fid, work_state="blocked_on_trigger")
+        # Supplying one satisfies the gate.
+        res_ok = await follow_up_tools._impl_follow_up_update(
+            fid,
+            work_state="blocked_on_trigger",
+            revisit_condition="when Y happens",
+        )
+    assert "error" in res_err
+    assert "revisit_condition" in res_err["error"]
+    assert res_ok["kind"] == "follow_up"
+    assert res_ok["revisit_condition"] == "when Y happens"
+    # The gate failure left NO partial change: row is still the original follow_up.
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["kind"] == "follow_up"
+
+
+async def test_update_invalid_work_state_errors(db):
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         created = await follow_up_tools._impl_follow_up_create(
             content="z",
             reason="z",
             strategy="ego_judgment",
+            work_state="ready",
         )
-        res = await follow_up_tools._impl_follow_up_update(created["id"], kind="nope")
+        res = await follow_up_tools._impl_follow_up_update(created["id"], work_state="nope")
     assert "error" in res
-    assert "kind" in res["error"].lower()
+    assert "work_state" in res["error"]
+
+
+# ─── list: tabled excluded by default ────────────────────────────────────────
 
 
 async def test_list_excludes_tabled_by_default(db):
@@ -91,19 +244,19 @@ async def test_list_excludes_tabled_by_default(db):
             content="actionable thing",
             reason="r",
             strategy="ego_judgment",
+            work_state="ready",
         )
         await follow_up_tools._impl_follow_up_create(
             content="someday idea",
             reason="r",
             strategy="ego_judgment",
-            kind="tabled",
+            work_state="deferred_cold",
         )
         res = await follow_up_tools._impl_follow_up_list()
 
     kinds = [f["kind"] for f in res["follow_ups"]]
     assert "tabled" not in kinds
     assert res.get("tabled_count") == 1
-    # status counts + total reflect actionable items only (the tabled item is pending)
     assert res["total"] == 1
 
 
@@ -114,17 +267,33 @@ async def test_list_include_tabled_shows_them(db):
             content="actionable thing",
             reason="r",
             strategy="ego_judgment",
+            work_state="ready",
         )
         await follow_up_tools._impl_follow_up_create(
             content="someday idea",
             reason="r",
             strategy="ego_judgment",
-            kind="tabled",
+            work_state="deferred_cold",
         )
         res = await follow_up_tools._impl_follow_up_list(include_tabled=True)
 
     kinds = sorted(f["kind"] for f in res["follow_ups"])
     assert kinds == ["follow_up", "tabled"]
+
+
+async def test_list_returns_revisit_condition(db):
+    """The list surfaces revisit_condition so a future session sees the trigger."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        await follow_up_tools._impl_follow_up_create(
+            content="blocked item",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="blocked_on_trigger",
+            revisit_condition="after the migration lands",
+        )
+        res = await follow_up_tools._impl_follow_up_list()
+    item = next(f for f in res["follow_ups"] if f["content"] == "blocked item")
+    assert item["revisit_condition"] == "after the migration lands"
 
 
 async def test_list_status_filter_excludes_tabled(db):
@@ -134,20 +303,18 @@ async def test_list_status_filter_excludes_tabled(db):
             content="actionable pending",
             reason="r",
             strategy="ego_judgment",
+            work_state="ready",
         )
-        # tabled items keep their status ('pending' by default), so a naive
-        # status filter would surface them without the kind exclusion.
         await follow_up_tools._impl_follow_up_create(
             content="tabled pending",
             reason="r",
             strategy="ego_judgment",
-            kind="tabled",
+            work_state="deferred_cold",
         )
         res = await follow_up_tools._impl_follow_up_list(status_filter="pending")
     kinds = [f["kind"] for f in res["follow_ups"]]
     assert kinds == ["follow_up"]
 
-    # ...unless the caller opts in.
     with patch.object(follow_up_tools, "_get_db", return_value=db):
         res_incl = await follow_up_tools._impl_follow_up_list(
             status_filter="pending",
@@ -156,7 +323,9 @@ async def test_list_status_filter_excludes_tabled(db):
     assert sorted(f["kind"] for f in res_incl["follow_ups"]) == ["follow_up", "tabled"]
 
 
-# ─── d67c83c7: notes-only preserves status; blocked_reason blocks; no revert ──
+# ─── d67c83c7 / #1198: notes-only preserves status; blocked_reason blocks ─────
+# These guard the lost-update contract and MUST stay untouched by the work_state
+# work — the update path still routes notes-only writes through update_notes.
 
 
 async def test_update_notes_only_preserves_status(db):
@@ -166,6 +335,7 @@ async def test_update_notes_only_preserves_status(db):
             content="active work",
             reason="r",
             strategy="ego_judgment",
+            work_state="ready",
         )
         fid = created["id"]
         await follow_up_tools._impl_follow_up_update(fid, status="in_progress")
@@ -186,6 +356,7 @@ async def test_update_blocked_reason_sets_blocked(db):
             content="thing",
             reason="r",
             strategy="ego_judgment",
+            work_state="ready",
         )
         fid = created["id"]
         res = await follow_up_tools._impl_follow_up_update(
@@ -208,6 +379,7 @@ async def test_notes_only_does_not_write_stale_status(db):
             content="racy",
             reason="r",
             strategy="ego_judgment",
+            work_state="ready",
         )
         fid = created["id"]
         # Concurrent writer (e.g. ego resolve_follow_ups) completes it.

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -323,6 +323,96 @@ async def test_list_status_filter_excludes_tabled(db):
     assert sorted(f["kind"] for f in res_incl["follow_ups"]) == ["follow_up", "tabled"]
 
 
+# ─── Codex P1/P2: blocked_on_trigger dispatch semantics + ready clears trigger ─
+
+
+async def test_create_blocked_on_trigger_rejects_surplus_task(db):
+    """surplus_task dispatches immediately (dispatcher.py:63-70); pairing it with
+    blocked_on_trigger (wait for an event) would run before the trigger → rejected."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="analyze after X",
+            reason="r",
+            strategy="surplus_task",
+            work_state="blocked_on_trigger",
+            revisit_condition="after event X",
+        )
+        recent = await follow_ups.get_recent(db, limit=50, include_tabled=True)
+    assert "error" in res
+    assert "surplus_task" in res["error"]
+    assert not any(r["content"] == "analyze after X" for r in recent)
+
+
+async def test_create_blocked_on_trigger_allows_scheduled_task(db):
+    """scheduled_task IS a valid trigger — the scheduler fires it at scheduled_at."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="run at time T",
+            reason="r",
+            strategy="scheduled_task",
+            work_state="blocked_on_trigger",
+            revisit_condition="at 2026-08-01T00:00:00",
+            scheduled_at="2026-08-01T00:00:00",
+        )
+    assert res.get("kind") == "follow_up", res
+    assert res["revisit_condition"] == "at 2026-08-01T00:00:00"
+
+
+async def test_create_ready_ignores_supplied_revisit_condition(db):
+    """A 'ready' item has no trigger — any supplied revisit_condition is dropped."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="just do it",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="ready",
+            revisit_condition="spurious",
+        )
+    assert res["revisit_condition"] is None
+    row = await follow_ups.get_by_id(db, res["id"])
+    assert row["revisit_condition"] is None
+
+
+async def test_update_to_ready_clears_revisit_condition(db):
+    """Moving a blocked_on_trigger item to ready clears the now-obsolete trigger."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="was blocked",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="blocked_on_trigger",
+            revisit_condition="when Y",
+        )
+        fid = created["id"]
+        res = await follow_up_tools._impl_follow_up_update(fid, work_state="ready")
+    assert res["revisit_condition"] is None, res
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["revisit_condition"] is None
+
+
+async def test_update_to_blocked_on_trigger_rejects_surplus_task_row(db):
+    """A surplus_task row can't move to blocked_on_trigger (same dispatch conflict);
+    the gate fires before any write, so the row is unchanged."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="surplus item",
+            reason="r",
+            strategy="surplus_task",
+            work_state="ready",
+        )
+        fid = created["id"]
+        res = await follow_up_tools._impl_follow_up_update(
+            fid,
+            work_state="blocked_on_trigger",
+            revisit_condition="after Z",
+        )
+    assert "error" in res
+    assert "surplus_task" in res["error"]
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["kind"] == "follow_up"
+    assert row["revisit_condition"] is None
+
+
 # ─── d67c83c7 / #1198: notes-only preserves status; blocked_reason blocks ─────
 # These guard the lost-update contract and MUST stay untouched by the work_state
 # work — the update path still routes notes-only writes through update_notes.


### PR DESCRIPTION
## What
Follow-up lane mis-classification fix. `follow_up_create`/`follow_up_update` now take a **`work_state`** (`ready` / `blocked_on_trigger` / `deferred_cold`) and **derive** the hot(`follow_up`)/cold(`tabled`) lane, so priority can no longer decide the lane. Symmetric on both surfaces — the raw `kind` param is removed from both MCP tools (crud keeps `kind` for rule-based programmatic callers + the human dashboard batch action). `blocked_on_trigger` requires a `revisit_condition` (new nullable column, migration `0075`); `deferred_cold` may carry one optionally. Maps to GTD Next-Action / Waiting-For / Someday-Maybe.

## Why
A session mis-filed a real, actionable, near-term task as `tabled` using "low priority" reasoning. `kind` (lane) and `priority` are orthogonal, and a prose rule in context didn't prevent it. This makes the mechanism enforce the distinction: the caller declares the item's *state*, the lane falls out — priority never enters the choice. It's an intent/tractability axis: a low-priority item you still intend to do is `ready`, not `deferred_cold`.

## Changes
- **crud** (`db/crud/follow_ups.py`): `WORK_STATE_TO_KIND` mapping + `set_revisit_condition` targeted writer; `create()` gains `revisit_condition`.
- **MCP handlers** (`mcp/health/follow_up_tools.py`): required `work_state` on create; work_state-only lane moves on update; `blocked_on_trigger` gate (requires `revisit_condition`, whitespace-safe) resolved **before any write** (no partial updates); the #1198 lost-update contract is preserved.
- **schema**: `revisit_condition` column declared last (fresh/migrated column-order parity); PRAGMA-guarded migration `0075` (`0074` reserved for an in-flight PR — runner tolerates the gap, fatal only on duplicate prefix).
- **surface**: `revisit_condition` in `follow_up_list` output + dashboard render block.
- **docs**: `CLAUDE.md` lane guidance + `CURRENT.md` subsystem note.

## Enforcement targeting
The gate lives at the **MCP handler** (where a session's priority-reasoning failure happens), not at the crud INSERT — so the rule-based inbox WATCH/BOOKMARK markers (which legitimately create `tabled` rows) are unaffected.

## Tests
`work_state` derivation, the gate (incl. whitespace-only), revisit_condition round-trip, update-requires-work_state, kind-door-closed (TypeError), `0075` migration round-trip + column-order parity, inbox fixture DDL. All targeted suites green; ruff clean.

## Reviews
`genesis-architect` pre-build (1 BLOCKER — migration ADD-COLUMN idempotency on fresh DB — fixed) + `feature-dev:code-reviewer` (DONE; its update-surface observation was resolved by removing the raw `kind` door on update).

Ledger: 96622cb72abc4e7db9ea34e204c6a78d

🤖 Generated with [Claude Code](https://claude.com/claude-code)
