### PR TITLE
feat(memory): delete-intent tombstones — cross-process repair safety, active by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Memory self-healing is now on by default, and deletes survive outages.**
+  Two upgrades complete the memory-repair story: (1) when a memory delete
+  can't finish because the vector store is unreachable, the intent is now
+  recorded as a durable "tombstone" — the nightly repair job re-attempts the
+  delete until it completes, and nothing will rebuild that memory's vector in
+  the meantime; (2) repair is now safe against deletes from every Genesis
+  process (not just the main server), so the nightly reconcile job runs by
+  default (`memory_integrity` mode `active`). Set `mode: passive` in your
+  local overlay for detection-only. Recall also stops surfacing "ghost"
+  leftovers: results whose backing record was deleted are filtered out of
+  vector search and ambient core-facts instead of reappearing until the
+  nightly sweep. (This treats any vector without a metadata record as a
+  ghost — including pre-metadata-era legacy vectors on long-lived installs;
+  those become invisible to semantic recall and are removed by the nightly
+  repair with their contents exported first.)
+
 - **Genesis can now repair memory drift automatically (opt-in).** Building on
   the Memory Integrity checks (which detect drift between the memory database
   and the vector store) and the one-time startup cleanup, a nightly repair job

--- a/config/memory_integrity.yaml
+++ b/config/memory_integrity.yaml
@@ -17,16 +17,16 @@ enabled: true
 
 # Mode: off | passive | active
 #   off     — jobs do not run.
-#   passive — (default) read-only checks + surfacing only (persist + posture
-#             alert + dashboard tile). NEVER repairs.
-#   active  — passive + the nightly reconcile repair job. Opt-in until the
-#             cross-process delete-intent tombstones land (PR-2): the
-#             per-memory-id lock (memory/_locks.py) serializes
-#             delete-vs-requeue only within one process, and deletes also run
-#             in the genesis-memory MCP process. Opt in with `mode: active`.
+#   passive — read-only checks + surfacing only (persist + posture alert +
+#             dashboard tile). NEVER repairs.
+#   active  — (default) passive + the nightly reconcile repair job (tombstone
+#             drain, ghost delete with payload export, mirror re-queue).
+#             Repair is serialized against deletes from every process: the
+#             per-memory-id lock in-process, delete-intent tombstones + the
+#             atomic requeue guard cross-process. Opt out with `mode: passive`.
 # An invalid value degrades to passive (still observing, never repairing) —
 # never a silent off.
-mode: passive
+mode: active
 
 # ── reconcile repair lane (mode=active only) ─────────────────────────────
 repair_min_age_seconds: 3600  # never touch an offender younger than this (in-flight writes)

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -44,21 +44,30 @@ verified: 51bfbb35 2026-07-30
 points; "lying mirror" rows claiming a vector that's gone) is structurally
 possible. `memory/integrity.py` (Phase 0) detects nightly via set algebra and
 persists reports; `memory/integrity_repair.py` (Phase 1, `memory_reconcile`
-job 04:40, `integrity_config` mode `active` — opt-in now, default once the
-cross-process delete-intent tombstones land: the per-memory-id lock
-serializes delete-vs-requeue only within one process, and
-`MemoryStore.delete()` also runs in the genesis-memory MCP process) repairs aged
-offenders nightly: ghosts deleted (payload exported to a date-stamped JSONL
-under `~/.genesis/output/` first), mirrors re-queued through
-`pending_embeddings.requeue_for_reembed` so `EmbeddingRecoveryWorker` rebuilds
-the real vector. Truncation asymmetry is load-bearing: a truncated point
-scroll keeps ghost classification sound (metadata read is complete) but makes
-mirror classification unsound (can't prove absence) — mirrors are skipped
-under truncation. Repair never consumes Phase 0's (possibly sampled) report —
-it re-enumerates exactly. Audit rows: `memory_reconcile_runs` (migration
-0074). One-time historical cleanup was d0008; `MemoryStore.delete()` is
-point-first + fail-closed (defers, returning `{"deferred": True}`, when Qdrant
-is unavailable — callers must honor it).
+job 04:40, `integrity_config` mode `active` — the default) repairs aged
+offenders nightly: open delete-intent tombstones drained first (deferred
+deletes re-attempted through the full store cascade; attempted ids excluded
+from that run's ghost/mirror sets), ghosts deleted (payload exported to a
+date-stamped JSONL under `~/.genesis/output/` first), mirrors re-queued
+through `pending_embeddings.requeue_for_reembed` so `EmbeddingRecoveryWorker`
+rebuilds the real vector. Repair is serialized against deletes from EVERY
+process: in-process via the per-memory-id lock (`memory/_locks.py`);
+cross-process via DB-backed tombstones (`memory/delete_tombstones.py`, rows on
+`deferred_work_queue`, written by `MemoryStore.delete()` when Qdrant is down)
+plus an atomic metadata/tombstone guard inside `requeue_for_reembed` (single
+SQL statement — SQLite's cross-process write lock makes it atomic vs a delete
+in any process, e.g. the genesis-memory MCP server's `reference_delete`). The
+irreducible floor (documented, self-healing): the recovery worker's
+SQLite-check→Qdrant-upsert micro-window vs a concurrent full delete can still
+strand a ghost until the next nightly sweep. Truncation asymmetry is
+load-bearing: a truncated point scroll keeps ghost classification sound
+(metadata read is complete) but makes mirror classification unsound (can't
+prove absence) — mirrors are skipped under truncation. Repair never consumes
+Phase 0's (possibly sampled) report — it re-enumerates exactly. Audit rows:
+`memory_reconcile_runs` (migration 0074). One-time historical cleanup was
+d0008; `MemoryStore.delete()` is point-first + fail-closed (defers, returning
+`{"deferred": True}` and recording a tombstone, when Qdrant is unavailable —
+callers must honor it).
 
 **Retrieval is TIERED — the hottest auto-fired paths carry the thinnest
 stack.** Deep path: `memory/retrieval.py` `HybridRetriever.recall` (bitemporal

--- a/src/genesis/db/crud/deferred_work.py
+++ b/src/genesis/db/crud/deferred_work.py
@@ -188,9 +188,13 @@ async def count_open_by_identity(
     ``has_open`` into ``_defer``'s broad handler and silently drop EVERY new
     delivery until the bad row is cleared. ``COALESCE(..., '')`` makes a
     missing/NULL signal_type or category match cleanly (SQL ``NULL = ?`` is never
-    true). Single-writer queue → the read-then-insert is race-free enough; the
-    ``idx_rlp_open_dedup`` partial-unique-index pattern (``cc_rate_limit_parks``)
-    is the upgrade path if a concurrent producer ever appears.
+    true). The read-then-insert dedup was designed single-writer; one
+    work_type is now multi-process (``memory_deferred_delete`` — both
+    genesis-server and the genesis-memory MCP process enqueue) but explicitly
+    DUP-TOLERANT: duplicate open tombstones are all closed together and a
+    double-drained delete is idempotent (memory/delete_tombstones.py). For any
+    future work_type that is NOT dup-tolerant, the ``idx_rlp_open_dedup``
+    partial-unique-index pattern (``cc_rate_limit_parks``) is the upgrade path.
     """
     cursor = await db.execute(
         """SELECT COUNT(*) FROM deferred_work_queue
@@ -207,6 +211,41 @@ async def count_open_by_identity(
     )
     row = await cursor.fetchone()
     return int(row[0])
+
+
+async def complete_open_by_identity(
+    db: aiosqlite.Connection,
+    *,
+    work_type: str,
+    topic: str,
+    category: str,
+    signal_type: str | None,
+    completed_at: str,
+) -> int:
+    """Mark every OPEN (pending/processing) row matching the payload dedup
+    identity ``(topic, category, signal_type)`` as completed. Returns the count.
+
+    The inverse of :func:`count_open_by_identity` — used when the deferred
+    work's outcome was achieved out-of-band (e.g. a memory delete succeeded on
+    retry through the normal path, so its delete-intent tombstone is obsolete).
+    Same ``json_valid`` guards: a corrupt row is skipped, never raises.
+    """
+    cursor = await db.execute(
+        """UPDATE deferred_work_queue
+           SET status = 'completed', completed_at = ?
+           WHERE work_type = ?
+             AND status IN ('pending', 'processing')
+             AND (CASE WHEN json_valid(payload_json)
+                       THEN json_extract(payload_json, '$.topic') END) = ?
+             AND COALESCE(CASE WHEN json_valid(payload_json)
+                       THEN json_extract(payload_json, '$.category') END, '') = ?
+             AND COALESCE(CASE WHEN json_valid(payload_json)
+                       THEN json_extract(payload_json, '$.signal_type') END, '')
+                 = COALESCE(?, '')""",
+        (completed_at, work_type, topic, category, signal_type),
+    )
+    await db.commit()
+    return cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0
 
 
 async def count_recovery_pending(

--- a/src/genesis/db/crud/pending_embeddings.py
+++ b/src/genesis/db/crud/pending_embeddings.py
@@ -104,6 +104,17 @@ async def mark_failed(
     return cursor.rowcount > 0
 
 
+_REQUEUE_GUARD = """
+       EXISTS (SELECT 1 FROM memory_metadata mm WHERE mm.memory_id = ?)
+       AND NOT EXISTS (
+           SELECT 1 FROM deferred_work_queue dw
+           WHERE dw.work_type = 'memory_deferred_delete'
+             AND dw.status IN ('pending', 'processing')
+             AND (CASE WHEN json_valid(dw.payload_json)
+                       THEN json_extract(dw.payload_json, '$.memory_id') END) = ?
+       )"""
+
+
 async def requeue_for_reembed(
     db: aiosqlite.Connection,
     *,
@@ -115,7 +126,7 @@ async def requeue_for_reembed(
     created_at: str,
     confidence: float | None,
     source: str = "memory_reconcile",
-) -> None:
+) -> bool:
     """Re-queue one memory for re-embedding, regardless of prior queue state.
 
     The lying-mirror repair primitive (d0008 semantics, shared by the periodic
@@ -133,6 +144,19 @@ async def requeue_for_reembed(
     - the ``memory_metadata.embedding_status`` mirror flips to ``'pending'`` so
       the row stops lying 'embedded' and the pair reads consistent while queued.
 
+    **Atomic against cross-process deletes**: both write branches carry, in the
+    SAME SQL statement, a guard that the metadata row still exists AND no open
+    delete-intent tombstone (``memory/delete_tombstones.py``) targets this id.
+    SQLite's cross-process write lock makes each statement atomic vs a
+    ``MemoryStore.delete()`` running in ANY process (e.g. the genesis-memory
+    MCP server) — a caller's earlier re-read can go stale, the statement
+    cannot. A requeue racing the window between a delete's point-removal and
+    its metadata cascade may still insert, but the cascade's
+    ``delete_by_memory`` (which runs after the metadata delete) removes that
+    row in the same delete. Returns True iff the queue row was actually
+    written/reset (False = lost the race or tombstoned; the memory is being
+    deleted, nothing to rebuild).
+
     Callers must pre-check content exists — a mirror with no recoverable FTS
     content cannot be re-embedded (mark it 'failed' instead; see the reconcile
     lane).
@@ -145,19 +169,20 @@ async def requeue_for_reembed(
     )
     exists = await cursor.fetchone()
     if exists:
-        await db.execute(
-            """UPDATE pending_embeddings
+        cursor = await db.execute(
+            f"""UPDATE pending_embeddings
                SET status = 'pending', error_message = NULL, content = ?,
                    tags = ?, memory_type = ?, collection = ?, confidence = ?
-               WHERE memory_id = ?""",
-            (content, tags, memory_type, collection, confidence, memory_id),
+               WHERE memory_id = ? AND {_REQUEUE_GUARD}""",  # noqa: S608
+            (content, tags, memory_type, collection, confidence, memory_id, memory_id, memory_id),
         )
     else:
-        await db.execute(
-            """INSERT INTO pending_embeddings
+        cursor = await db.execute(
+            f"""INSERT INTO pending_embeddings
                (id, memory_id, content, memory_type, tags, collection,
                 created_at, status, source, confidence)
-               VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)""",
+               SELECT ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?
+               WHERE {_REQUEUE_GUARD}""",  # noqa: S608
             (
                 _uuid.uuid4().hex,
                 memory_id,
@@ -168,13 +193,21 @@ async def requeue_for_reembed(
                 created_at,
                 source,
                 confidence,
+                memory_id,
+                memory_id,
             ),
         )
-    await db.execute(
-        "UPDATE memory_metadata SET embedding_status = 'pending' WHERE memory_id = ?",
-        (memory_id,),
-    )
+    requeued = bool(cursor.rowcount and cursor.rowcount > 0)
+    if requeued:
+        # Mirror flip only when the queue row actually landed — flipping the
+        # mirror for a refused requeue would un-lie nothing and could revive a
+        # row the delete cascade is about to remove.
+        await db.execute(
+            "UPDATE memory_metadata SET embedding_status = 'pending' WHERE memory_id = ?",
+            (memory_id,),
+        )
     await db.commit()
+    return requeued
 
 
 async def reset_failed_to_pending(

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -140,14 +140,14 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
             "a cross-backend consistency check (memory_metadata <-> Qdrant <-> "
             "memory_fts) and a recall-health probe over an install-local golden "
             "set, surfacing findings via a posture alert + dashboard tile. "
-            "Active adds the Phase-1 nightly reconcile job that repairs aged "
-            "drift (ghost vectors deleted with payload export; lying mirrors "
-            "re-queued for re-embed) — knobs repair_min_age_seconds / "
-            "max_repairs_per_run; opt-in until cross-process delete-intent "
-            "tombstones land (the per-memory-id lock serializes "
-            "delete-vs-requeue only within one process). Read live per run — "
-            "takes effect next scheduled run. Kill switch: "
-            "GENESIS_MEMORY_INTEGRITY_DISABLED=1."
+            "Active (default) adds the Phase-1 nightly reconcile job that "
+            "drains delete-intent tombstones and repairs aged drift (ghost "
+            "vectors deleted with payload export; lying mirrors re-queued for "
+            "re-embed) — knobs repair_min_age_seconds / max_repairs_per_run. "
+            "Repair is serialized against deletes from every process (per-id "
+            "lock in-process; tombstones + atomic requeue guard "
+            "cross-process). Read live per run — takes effect next scheduled "
+            "run. Kill switch: GENESIS_MEMORY_INTEGRITY_DISABLED=1."
         ),
         config_filename="memory_integrity.yaml",
         readonly=False,

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -1090,11 +1090,36 @@ async def memory_core_facts(
         logger.warning("Qdrant scroll for core_facts failed", exc_info=True)
         return []
 
+    # Ghost filter: core_facts scrolls Qdrant payloads directly (bypasses
+    # HybridRetriever and its stage-4b filter), so a deleted memory's leftover
+    # point would inject deleted content into this ambient surface until the
+    # nightly reconcile sweep. Metadata is the authority: a scrolled point with
+    # no memory_metadata row is a ghost — drop it. Fail-open on DB error (same
+    # posture as the origin enrichment below).
+    _ghost_ids: set[str] = set()
+    try:
+        _pids = {str(p.id) for p in points}
+        if _pids:
+            from genesis.memory.retrieval import metadata_missing_ids
+
+            _ghost_ids = await metadata_missing_ids(memory_mod._db, _pids)
+            if _ghost_ids:
+                logger.info(
+                    "core_facts: dropped %d ghost point(s) (vector without metadata row)",
+                    len(_ghost_ids),
+                )
+    except Exception:
+        # Fail-open is right; INVISIBLE fail-open is not — this is the ambient
+        # always-injected surface, so a persistently broken filter must be loud.
+        logger.warning("core_facts ghost filter failed — returning unfiltered", exc_info=True)
+
     now_str = datetime.now(UTC).isoformat()
     scored: list[tuple[dict, float]] = []
     for point in points:
         payload = point.payload or {}
         mid = str(point.id)
+        if mid in _ghost_ids:
+            continue
         link_count = await memory_mod.memory_links.count_links(memory_mod._db, mid)
         act = compute_activation(
             confidence=payload.get("confidence", 0.7),

--- a/src/genesis/memory/delete_tombstones.py
+++ b/src/genesis/memory/delete_tombstones.py
@@ -1,0 +1,129 @@
+"""Delete-intent tombstones — cross-process memory-delete durability.
+
+A memory delete that cannot complete (Qdrant unreachable → ``MemoryStore.delete``
+defers, touching nothing) must not be forgotten: the intent is recorded as a
+``deferred_work_queue`` row (``work_type='memory_deferred_delete'``) written
+through SQLite — which, unlike the process-local ``memory/_locks.py`` registry,
+is visible to EVERY Genesis process (genesis-server, the genesis-memory MCP
+server, one-off scripts). Consumers:
+
+- the nightly reconcile lane (``memory/integrity_repair.py``) drains open
+  tombstones FIRST, re-attempting the full delete before classifying offenders,
+  and excludes attempted ids from its ghost/mirror sets for that run;
+- ``EmbeddingRecoveryWorker`` skips re-embedding any memory with an open
+  tombstone (a deferred delete leaves metadata + queue row intact, so without
+  this check the worker would rebuild a vector that is about to be deleted);
+- ``pending_embeddings.requeue_for_reembed`` refuses (in the same SQL
+  statement, atomically vs writers in any process) to requeue a tombstoned id.
+
+No dedicated store: this reuses ``deferred_work_queue`` per its existing
+conventions — delete-intent IS deferred work; retention rides the queue's
+``prune_terminal``; the reconcile lane is the work_type's consumer (there is no
+central dispatcher). Dedup keys on the queue's ``(topic, category,
+signal_type)`` payload identity with ``topic = memory_id``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.db.crud import deferred_work as deferred_crud
+
+logger = logging.getLogger(__name__)
+
+WORK_TYPE = "memory_deferred_delete"
+_CATEGORY = "memory_delete"
+_PRIORITY = 50  # mid-band: behind resilience retries, ahead of batch worklists
+
+
+async def enqueue_tombstone(db: aiosqlite.Connection, *, memory_id: str, reason: str) -> bool:
+    """Record a delete intent for *memory_id*.
+
+    Returns True iff the intent is DURABLY RECORDED — either a new row was
+    written or an open tombstone already exists (dedup: repeated deferred
+    deletes of the same memory collapse to one row; the existing row IS the
+    recorded intent). False only when the write genuinely failed (logged; the
+    caller's delete result already says ``deferred`` either way).
+
+    The check-then-insert dedup is not atomic across processes — both
+    genesis-server and the genesis-memory MCP process can enqueue — but a
+    duplicate open tombstone is harmless: ``complete_open_tombstones`` closes
+    every open row for the id and a double-drained delete is idempotent.
+    """
+    try:
+        open_count = await deferred_crud.count_open_by_identity(
+            db,
+            work_type=WORK_TYPE,
+            topic=memory_id,
+            category=_CATEGORY,
+            signal_type=None,
+        )
+        if open_count:
+            return True  # intent already durably recorded
+        now = datetime.now(UTC).isoformat()
+        await deferred_crud.create(
+            db,
+            id=uuid.uuid4().hex,
+            work_type=WORK_TYPE,
+            priority=_PRIORITY,
+            payload_json=json.dumps(
+                {
+                    "topic": memory_id,
+                    "category": _CATEGORY,
+                    "signal_type": None,
+                    "memory_id": memory_id,
+                }
+            ),
+            deferred_at=now,
+            deferred_reason=reason,
+            created_at=now,
+            staleness_policy="drain",
+        )
+        return True
+    except Exception:
+        # Best-effort: the delete already reported deferred=True; a failed
+        # tombstone write must not mask that result. The consistency check
+        # still surfaces the resulting drift if this intent is lost.
+        logger.error("tombstone enqueue failed for %s", memory_id, exc_info=True)
+        return False
+
+
+async def has_open_tombstone(db: aiosqlite.Connection, *, memory_id: str) -> bool:
+    """True if a pending/processing delete intent exists for *memory_id*."""
+    return (
+        await deferred_crud.count_open_by_identity(
+            db,
+            work_type=WORK_TYPE,
+            topic=memory_id,
+            category=_CATEGORY,
+            signal_type=None,
+        )
+        > 0
+    )
+
+
+async def complete_open_tombstones(db: aiosqlite.Connection, *, memory_id: str) -> int:
+    """Close every open tombstone for *memory_id* after a successful delete."""
+    return await deferred_crud.complete_open_by_identity(
+        db,
+        work_type=WORK_TYPE,
+        topic=memory_id,
+        category=_CATEGORY,
+        signal_type=None,
+        completed_at=datetime.now(UTC).isoformat(),
+    )
+
+
+def memory_id_from_row(row: dict) -> str | None:
+    """Extract the target memory_id from a tombstone queue row (None if corrupt)."""
+    try:
+        payload = json.loads(row.get("payload_json") or "{}")
+    except (TypeError, ValueError):
+        return None
+    mid = payload.get("memory_id") or payload.get("topic")
+    return str(mid) if mid else None

--- a/src/genesis/memory/integrity_config.py
+++ b/src/genesis/memory/integrity_config.py
@@ -8,17 +8,16 @@ cache, so an operator edit takes effect on the next scheduled run.
 
 Modes (``off | passive | active``):
 
-- ``passive`` (DEFAULT) — run the read-only checks and surface findings
-  (persist + posture alert + dashboard). Never repairs. This was the whole of
-  Phase 0.
-- ``active`` — everything ``passive`` does, PLUS the Phase-1 periodic
-  reconcile job (``memory/integrity_repair.py``) that repairs aged ghost points
-  and lying mirrors nightly. Opt in with ``mode: active`` in the local overlay.
-  Not the default yet: the per-memory-id lock (``memory/_locks.py``) closes the
-  mirror-requeue-vs-delete race only WITHIN a process, and
-  ``MemoryStore.delete()`` also runs in the separate genesis-memory MCP
-  process — active becomes the default once the cross-process delete-intent
-  tombstones land (PR-2).
+- ``active`` (DEFAULT) — everything ``passive`` does, PLUS the Phase-1 periodic
+  reconcile job (``memory/integrity_repair.py``) that drains delete-intent
+  tombstones and repairs aged ghost points and lying mirrors nightly. Safe as
+  the default because repair is serialized against deletes from EVERY process:
+  in-process via the per-memory-id lock (``memory/_locks.py``), cross-process
+  via DB-backed tombstones (``memory/delete_tombstones.py``) plus the atomic
+  metadata/tombstone guard inside ``requeue_for_reembed``. Opt out with
+  ``mode: passive`` in the local overlay.
+- ``passive`` — run the read-only checks and surface findings (persist +
+  posture alert + dashboard). Never repairs. This was the whole of Phase 0.
 - ``off`` — do not run at all.
 
 Failure posture: an INVALID mode degrades to ``passive`` (still observing, no
@@ -54,11 +53,11 @@ _ENV_KILL_SWITCH = "GENESIS_MEMORY_INTEGRITY_DISABLED"
 
 DEFAULTS: dict[str, Any] = {
     "enabled": True,
-    # Repair stays opt-in until the cross-process delete-intent tombstones land
-    # (PR-2): the per-memory-id lock (memory/_locks.py) serializes
-    # delete-vs-requeue only within one process, and MemoryStore.delete() also
-    # runs in the genesis-memory MCP process. Opt in with mode: active.
-    "mode": "passive",
+    # Repair on by default: delete-vs-repair is serialized in-process by the
+    # per-memory-id lock (memory/_locks.py) and cross-process by delete-intent
+    # tombstones (memory/delete_tombstones.py) + the atomic requeue guard
+    # (crud/pending_embeddings.py). Opt out with mode: passive in the overlay.
+    "mode": "active",
     # ── consistency checker ──
     "sample_fraction": 1.0,  # 1.0 = exact full scan (cheap at single-user scale)
     "max_points": 500_000,  # Qdrant scroll budget; exceeding it sets truncated

--- a/src/genesis/memory/integrity_repair.py
+++ b/src/genesis/memory/integrity_repair.py
@@ -61,7 +61,9 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from genesis.db.connection import open_ro_connection
+from genesis.db.crud import deferred_work as deferred_crud
 from genesis.db.crud import pending_embeddings as pending_crud
+from genesis.memory import delete_tombstones
 from genesis.memory._locks import memory_id_lock
 from genesis.memory.integrity import _scroll_all_points
 from genesis.qdrant import collections as qdrant_ops
@@ -153,17 +155,104 @@ async def run_reconcile(
     max_points: int = 500_000,
     export_dir: Path | None = None,
     now: datetime | None = None,
+    delete_memory=None,
 ) -> ReconcileResult:
     """Enumerate and repair aged cross-store offenders. Returns the run outcome.
 
     ``db`` is the runtime's shared serialized aiosqlite connection (all writes);
     enumeration reads go through a WAL-aware read-only connection so the write
     lock is never held across the scan. ``now`` is injectable for tests.
+
+    ``delete_memory`` is an async callable ``(memory_id) -> dict`` — in
+    production ``rt.memory_store.delete`` — used to DRAIN open delete-intent
+    tombstones (``memory/delete_tombstones.py``) before classification: each
+    open tombstone's delete is re-attempted through the full store cascade
+    (which takes the per-id lock itself). Ids attempted this run are EXCLUDED
+    from the ghost/mirror sets — a memory whose delete is in flight must never
+    be re-embedded, and its just-deleted point must not be double-processed.
+    None (store unavailable on a degraded boot) skips the drain loudly.
     """
     start = time.monotonic()
     now_dt = now or datetime.now(UTC)
     cutoff = (now_dt - timedelta(seconds=min_age_seconds)).isoformat()
     export_dir = export_dir or (Path.home() / ".genesis" / "output")
+
+    # ── Drain delete-intent tombstones FIRST (before any classification) ──
+    tombstones_drained = 0
+    tombstones_failed = 0
+    tombstones_skipped_no_deleter = 0
+    tombstone_attempted: set[str] = set()
+    try:
+        tombstone_rows = await deferred_crud.query_pending(
+            db, work_type=delete_tombstones.WORK_TYPE, limit=max(1, int(max_repairs_per_run))
+        )
+    except Exception:
+        logger.warning("reconcile: tombstone query failed — skipping drain", exc_info=True)
+        tombstone_rows = []
+    now_iso_drain = now_dt.isoformat()
+    for row in tombstone_rows:
+        mid = delete_tombstones.memory_id_from_row(row)
+        if not mid:
+            # completed_at makes the terminal row prunable (prune_terminal
+            # skips NULL-completed_at rows — they'd accumulate forever).
+            await deferred_crud.update_status(
+                db,
+                row["id"],
+                status="discarded",
+                error_message="corrupt payload_json",
+                completed_at=now_iso_drain,
+            )
+            continue
+        if mid in tombstone_attempted:
+            # Duplicate open row for an id already handled THIS run (the
+            # multi-process enqueue dedup is best-effort, so dups can exist).
+            # If the attempt succeeded, complete_open_tombstones below already
+            # closed this row — re-processing would re-open a completed row
+            # and double-count the drain; if it failed, retrying now would
+            # fail identically. Skip either way.
+            continue
+        if delete_memory is None:
+            tombstones_skipped_no_deleter += 1
+            tombstone_attempted.add(mid)  # still never classify an intent-marked id
+            continue
+        tombstone_attempted.add(mid)
+        await deferred_crud.update_status(
+            db, row["id"], status="processing", last_attempt_at=now_iso_drain
+        )
+        outcome: dict | None = None
+        try:
+            outcome = await delete_memory(mid)
+        except Exception:
+            logger.warning("reconcile: tombstone delete raised for %s", mid, exc_info=True)
+        if outcome is not None and not outcome.get("deferred"):
+            # Full cascade completed — close EVERY open row for this id (this
+            # one is 'processing', duplicates are 'pending'; both close here).
+            # In production store.delete's own close-out (step 7) already did
+            # this; repeating it covers test doubles and mid-loop races, and
+            # is idempotent.
+            await delete_tombstones.complete_open_tombstones(db, memory_id=mid)
+            tombstones_drained += 1
+        else:
+            # Qdrant still unreachable (deferred again) or the delete raised —
+            # back to pending so the next run retries; attempts was already
+            # bumped by the processing transition. DELIBERATELY no attempts
+            # cap: a delete intent must never be silently dropped (the memory
+            # would survive its own deletion). A poisoned intent stays visible
+            # as status=partial + tombstones_failed with a growing attempts
+            # count — that is the operator signal to intervene.
+            await deferred_crud.update_status(
+                db,
+                row["id"],
+                status="pending",
+                error_message="drain re-attempt did not complete",
+            )
+            tombstones_failed += 1
+    if tombstones_skipped_no_deleter:
+        logger.warning(
+            "reconcile: %d open tombstone(s) but no delete callable (degraded boot?) — "
+            "drain deferred to next run",
+            tombstones_skipped_no_deleter,
+        )
 
     # ── Enumerate: Qdrant point set (with ages) across both collections ──
     points: dict[str, tuple[str, str]] = {}  # pid -> (created_at, collection)
@@ -198,10 +287,13 @@ async def run_reconcile(
         await ro.close()
     meta_ids = {str(r[0]) for r in meta_rows}
 
+    # tombstone_attempted ids are excluded from BOTH sets: their delete was
+    # (re-)attempted this run, so a lingering point is mid-cascade (not a
+    # ghost verdict) and a lingering metadata row must never be re-embedded.
     ghosts = [
         (pid, coll)
         for pid, (created, coll) in points.items()
-        if pid not in meta_ids and created and created < cutoff
+        if pid not in meta_ids and pid not in tombstone_attempted and created and created < cutoff
     ]
     if truncated:
         # Vector ABSENCE cannot be proven from a partial point set — a mirror
@@ -211,7 +303,11 @@ async def run_reconcile(
         mirrors = [
             (str(mid), str(coll) if coll else "episodic_memory")
             for mid, created, status, coll in meta_rows
-            if status == "embedded" and str(mid) not in points and created and str(created) < cutoff
+            if status == "embedded"
+            and str(mid) not in points
+            and str(mid) not in tombstone_attempted
+            and created
+            and str(created) < cutoff
         ]
 
     # ── Per-run cap (ghosts first — pure cleanup; mirrors restore recall) ──
@@ -324,7 +420,7 @@ async def run_reconcile(
             # memory_fts stores tags space-separated; the queue stores them
             # comma-separated (the worker rebuilds facet payload keys from that).
             tags = ",".join((frow[1] or "").split()) or None
-            await pending_crud.requeue_for_reembed(
+            requeued = await pending_crud.requeue_for_reembed(
                 db,
                 memory_id=mid,
                 content=content,
@@ -334,14 +430,31 @@ async def run_reconcile(
                 created_at=str(meta_created_at) if meta_created_at else now_dt.isoformat(),
                 confidence=confidence,
             )
-            mirrors_requeued += 1
+            # False = the statement's own metadata/tombstone guard refused (a
+            # cross-process delete won the race after our re-read) — correctly
+            # not requeued, don't count it as repaired.
+            if requeued:
+                mirrors_requeued += 1
 
     if ghost_export_skipped:
         # Ghosts whose export failed were left undeleted (retried next run) —
         # surface it so a persistent export failure is visible, not silent.
         details["ghost_export_skipped"] = ghost_export_skipped
+    if tombstones_failed:
+        details["tombstones_failed"] = tombstones_failed
+    if tombstones_skipped_no_deleter:
+        details["tombstones_skipped_no_deleter"] = tombstones_skipped_no_deleter
     status = (
-        "partial" if (ghost_delete_failed or ghost_export_skipped or capped or truncated) else "ok"
+        "partial"
+        if (
+            ghost_delete_failed
+            or ghost_export_skipped
+            or capped
+            or truncated
+            or tombstones_failed
+            or tombstones_skipped_no_deleter
+        )
+        else "ok"
     )
     result = ReconcileResult(
         status=status,
@@ -349,6 +462,7 @@ async def run_reconcile(
         ghost_delete_failed=ghost_delete_failed,
         mirrors_requeued=mirrors_requeued,
         mirrors_skipped_no_content=mirrors_skipped_no_content,
+        tombstones_drained=tombstones_drained,
         truncated=truncated,
         capped=capped,
         duration_ms=int((time.monotonic() - start) * 1000),

--- a/src/genesis/memory/integrity_repair.py
+++ b/src/genesis/memory/integrity_repair.py
@@ -182,12 +182,18 @@ async def run_reconcile(
     tombstones_failed = 0
     tombstones_skipped_no_deleter = 0
     tombstone_attempted: set[str] = set()
+    tombstone_query_failed = False
     try:
         tombstone_rows = await deferred_crud.query_pending(
             db, work_type=delete_tombstones.WORK_TYPE, limit=max(1, int(max_repairs_per_run))
         )
     except Exception:
+        # Must NOT read as a healthy run (Codex #1270 P2): with an empty
+        # worklist substituted silently, a persistent queue/schema problem
+        # would leave requested deletions pending forever while every audit
+        # row says ok. Flag it → status becomes partial.
         logger.warning("reconcile: tombstone query failed — skipping drain", exc_info=True)
+        tombstone_query_failed = True
         tombstone_rows = []
     now_iso_drain = now_dt.isoformat()
     for row in tombstone_rows:
@@ -444,6 +450,8 @@ async def run_reconcile(
         details["tombstones_failed"] = tombstones_failed
     if tombstones_skipped_no_deleter:
         details["tombstones_skipped_no_deleter"] = tombstones_skipped_no_deleter
+    if tombstone_query_failed:
+        details["tombstone_query_failed"] = True
     status = (
         "partial"
         if (
@@ -453,6 +461,7 @@ async def run_reconcile(
             or truncated
             or tombstones_failed
             or tombstones_skipped_no_deleter
+            or tombstone_query_failed
         )
         else "ok"
     )

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -619,6 +619,32 @@ async def _expired_candidate_ids(
     return {row[0] for row in rows}
 
 
+async def metadata_missing_ids(
+    db: aiosqlite.Connection,
+    candidate_ids: set[str],
+) -> set[str]:
+    """Return the subset of ``candidate_ids`` with NO ``memory_metadata`` row.
+
+    Ghost detector for the recall path: a Qdrant point whose metadata row is
+    gone is a deleted memory's leftover vector ("ghost" — e.g. the recovery
+    worker's upsert racing a cross-process delete). Its payload carries the
+    deleted content, so without a filter it flows straight back into recall
+    until the nightly reconcile sweep removes it. Callers must apply this ONLY
+    to vector-only candidates — legacy FTS rows without metadata are
+    deliberately kept (the long-standing fail-open for pre-metadata content).
+    """
+    if not candidate_ids:
+        return set()
+    placeholders = ",".join("?" * len(candidate_ids))
+    sql = (
+        f"SELECT memory_id FROM memory_metadata "  # noqa: S608 - literal SQL fragments; values bound as parameters
+        f"WHERE memory_id IN ({placeholders})"
+    )
+    cursor = await db.execute(sql, tuple(candidate_ids))
+    rows = await cursor.fetchall()
+    return candidate_ids - {str(row[0]) for row in rows}
+
+
 class HybridRetriever:
     """Hybrid retrieval: Qdrant vectors + FTS5 text + activation scoring, fused via RRF."""
 
@@ -1437,6 +1463,33 @@ class HybridRetriever:
                 qdrant_by_id.pop(mid, None)
                 fts_by_id.pop(mid, None)
             event_memory_ids = [m for m in event_memory_ids if m not in expired]
+
+        # Ghost filter: a VECTOR-ONLY candidate (Qdrant hit, no FTS hit) with
+        # no memory_metadata row is a deleted memory's leftover point — its
+        # payload would resurface deleted content until the nightly reconcile
+        # sweep. Scoped to vector-only ids ON PURPOSE: an FTS row without
+        # metadata is legacy pre-metadata content and stays recallable (the
+        # long-standing fail-open). Same degrade-open posture as the expiry
+        # filter: a DB failure keeps candidates rather than crashing recall.
+        vector_only = {mid for mid in all_ids if mid in qdrant_by_id and mid not in fts_by_id}
+        if vector_only:
+            try:
+                ghost_ids = await self._ro_read(metadata_missing_ids, vector_only)
+            except Exception:
+                logger.warning(
+                    "ghost filter failed, returning unfiltered candidates",
+                    exc_info=True,
+                )
+                ghost_ids = set()
+            if ghost_ids:
+                logger.info(
+                    "recall: dropped %d ghost candidate(s) (vector without metadata row)",
+                    len(ghost_ids),
+                )
+                all_ids -= ghost_ids
+                for mid in ghost_ids:
+                    qdrant_by_id.pop(mid, None)
+                event_memory_ids = [m for m in event_memory_ids if m not in ghost_ids]
         return all_ids, event_memory_ids
 
     async def _compute_activations(

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -521,6 +521,25 @@ class MemoryStore:
     async def _delete_locked(self, memory_id: str) -> dict:
         results: dict[str, bool | int] = {}
 
+        # 0. WRITE-AHEAD delete intent (Codex #1270 P1): record the tombstone
+        # BEFORE touching Qdrant, not just on the defer path. The intent stays
+        # open across the whole point-delete→cascade span, so the recovery
+        # worker's tombstone check (SQLite, cross-process) blocks a concurrent
+        # re-embed from resurrecting the vector even when THIS delete succeeds
+        # — the process-local id-lock cannot serialize the MCP process. Also
+        # crash-safe: a process dying mid-cascade leaves the intent for the
+        # nightly drain to complete. Best-effort — a failed write never blocks
+        # the delete itself. Step 7 closes it on success; a defer leaves it
+        # open as the durable retry record.
+        from genesis.memory.delete_tombstones import (
+            complete_open_tombstones,
+            enqueue_tombstone,
+        )
+
+        tombstoned = await enqueue_tombstone(
+            self._db, memory_id=memory_id, reason="delete_in_progress"
+        )
+
         # 1. Locate the point (unreliable collection column → check both) and
         # delete only where it lives. retrieve/delete raise on a real Qdrant error
         # → defer; an empty locate means the point is absent (nothing to delete).
@@ -545,18 +564,12 @@ class MemoryStore:
                 "Qdrant unavailable during delete of %s — deferring to keep stores "
                 "consistent (no orphan)", memory_id, exc_info=True,
             )
-            # Record the delete INTENT as a DB-backed tombstone so it survives
-            # the defer: visible to every process (unlike the in-process id
-            # lock), it blocks requeue/re-embed of this memory and is drained
-            # (delete re-attempted) by the nightly reconcile lane. Best-effort —
-            # enqueue_tombstone never raises.
-            from genesis.memory.delete_tombstones import enqueue_tombstone
-
+            # The write-ahead tombstone (step 0) stays OPEN — it is the durable
+            # retry record: visible to every process, it blocks requeue/re-embed
+            # of this memory and is drained (delete re-attempted) by the nightly
+            # reconcile lane.
             results["deferred"] = True
-            # True = intent durably recorded (new row OR an existing open one).
-            results["tombstoned"] = await enqueue_tombstone(
-                self._db, memory_id=memory_id, reason="qdrant_unreachable_on_delete"
-            )
+            results["tombstoned"] = tombstoned
             results["metadata"] = False
             results["fts5"] = False
             return results
@@ -598,13 +611,12 @@ class MemoryStore:
             )
             results["mentions_deleted"] = False
 
-        # 7. Close any open delete-intent tombstone: the delete just succeeded
-        # (possibly a retry of an earlier deferred attempt), so the recorded
-        # intent is satisfied — leaving it open would only make the reconcile
-        # lane re-attempt a no-op delete. Best-effort.
+        # 7. Close every open delete-intent tombstone: the cascade completed
+        # (this covers step 0's write-ahead intent, any earlier deferred
+        # attempt's row, and multi-process duplicates), so the recorded intent
+        # is satisfied — leaving it open would only make the reconcile lane
+        # re-attempt a no-op delete. Best-effort.
         try:
-            from genesis.memory.delete_tombstones import complete_open_tombstones
-
             await complete_open_tombstones(self._db, memory_id=memory_id)
         except Exception:
             logger.warning(

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -545,7 +545,18 @@ class MemoryStore:
                 "Qdrant unavailable during delete of %s — deferring to keep stores "
                 "consistent (no orphan)", memory_id, exc_info=True,
             )
+            # Record the delete INTENT as a DB-backed tombstone so it survives
+            # the defer: visible to every process (unlike the in-process id
+            # lock), it blocks requeue/re-embed of this memory and is drained
+            # (delete re-attempted) by the nightly reconcile lane. Best-effort —
+            # enqueue_tombstone never raises.
+            from genesis.memory.delete_tombstones import enqueue_tombstone
+
             results["deferred"] = True
+            # True = intent durably recorded (new row OR an existing open one).
+            results["tombstoned"] = await enqueue_tombstone(
+                self._db, memory_id=memory_id, reason="qdrant_unreachable_on_delete"
+            )
             results["metadata"] = False
             results["fts5"] = False
             return results
@@ -586,5 +597,18 @@ class MemoryStore:
                 "entity_mentions delete failed for %s", memory_id, exc_info=True,
             )
             results["mentions_deleted"] = False
+
+        # 7. Close any open delete-intent tombstone: the delete just succeeded
+        # (possibly a retry of an earlier deferred attempt), so the recorded
+        # intent is satisfied — leaving it open would only make the reconcile
+        # lane re-attempt a no-op delete. Best-effort.
+        try:
+            from genesis.memory.delete_tombstones import complete_open_tombstones
+
+            await complete_open_tombstones(self._db, memory_id=memory_id)
+        except Exception:
+            logger.warning(
+                "tombstone close-out failed for %s", memory_id, exc_info=True,
+            )
 
         return results

--- a/src/genesis/resilience/embedding_recovery.py
+++ b/src/genesis/resilience/embedding_recovery.py
@@ -154,6 +154,24 @@ class EmbeddingRecoveryWorker:
                     ):
                         continue
 
+                    # A DEFERRED delete (Qdrant was down) leaves metadata + this
+                    # queue row intact but records a delete-intent tombstone —
+                    # visible cross-process, unlike the id lock. Re-embedding a
+                    # memory that is awaiting deletion would rebuild a vector
+                    # the reconcile drain is about to remove; skip until the
+                    # tombstone resolves (drain deletes it, or a successful
+                    # retry closes the tombstone and the row drains normally).
+                    from genesis.memory.delete_tombstones import has_open_tombstone
+
+                    if await has_open_tombstone(
+                        self._db, memory_id=item["memory_id"]
+                    ):
+                        logger.info(
+                            "skipping re-embed of %s — open delete tombstone",
+                            item["memory_id"],
+                        )
+                        continue
+
                     # Deprecation is re-read HERE, after the embed and under the
                     # lock — NOT from the pre-embed `taxo` snapshot. A
                     # _mark_superseded landing during the embed sets deprecated=1

--- a/src/genesis/runtime/init/memory_integrity.py
+++ b/src/genesis/runtime/init/memory_integrity.py
@@ -154,12 +154,17 @@ def _wire_memory_integrity_jobs(scheduler, rt) -> None:
             from genesis.qdrant.collections import get_client
 
             cfg = integrity_config.load_config()
+            store = getattr(rt, "memory_store", None)
             result = await run_reconcile(
                 db=rt._db,
                 qdrant_client=get_client(),
                 min_age_seconds=integrity_config.knob_int(cfg, "repair_min_age_seconds"),
                 max_repairs_per_run=integrity_config.knob_int(cfg, "max_repairs_per_run"),
                 max_points=integrity_config.knob_int(cfg, "max_points"),
+                # Tombstone drain re-attempts deferred deletes through the full
+                # store cascade; on a degraded boot (no store) the drain is
+                # skipped loudly and the run reports partial.
+                delete_memory=store.delete if store is not None else None,
             )
             await mi_crud.insert_reconcile_run(
                 rt._db,

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -1699,6 +1699,13 @@ async def test_memory_core_facts_wraps_external_and_emits(monkeypatch):
         real_db.row_factory = aiosqlite.Row
         from genesis.db.schema import create_all_tables
         await create_all_tables(real_db)
+        # Scrolled points must have metadata rows — a point without one is a
+        # deleted memory's ghost and the core_facts ghost filter drops it.
+        for _mid in ("ext-1", "fp-1", "old-1"):
+            await real_db.execute(
+                "INSERT INTO memory_metadata (memory_id, created_at) VALUES (?, ?)",
+                (_mid, "2026-01-01T00:00:00+00:00"),
+            )
         await real_db.commit()
 
         qdrant = MagicMock()

--- a/tests/test_memory/test_delete_tombstones.py
+++ b/tests/test_memory/test_delete_tombstones.py
@@ -1,0 +1,184 @@
+"""Delete-intent tombstones: module lifecycle, store wiring, atomic requeue guard.
+
+The cross-process half of the delete-vs-repair story (PR-2): a deferred delete
+records a DB-backed tombstone; requeue/re-embed refuse tombstoned ids; a later
+successful delete closes the intent. Uses the real in-memory ``db`` fixture
+(full schema, SerializedConnection + Row factory — same as production).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.db.crud import deferred_work as deferred_crud
+from genesis.db.crud import memory as memory_crud
+from genesis.db.crud import pending_embeddings as pending_crud
+from genesis.memory import delete_tombstones as dt
+from genesis.memory.store import MemoryStore
+
+
+def _store(db):
+    ep = MagicMock()
+    ep.embed = AsyncMock(return_value=[0.1] * 1024)
+    ep.enrich = MagicMock(return_value="episodic: x")
+    return MemoryStore(
+        embedding_provider=ep,
+        qdrant_client=MagicMock(),
+        db=db,
+        linker=None,
+    )
+
+
+class TestTombstoneModule:
+    @pytest.mark.asyncio
+    async def test_enqueue_dedup_and_close_lifecycle(self, db):
+        assert await dt.enqueue_tombstone(db, memory_id="mem-t1", reason="test") is True
+        assert await dt.has_open_tombstone(db, memory_id="mem-t1") is True
+
+        # Second enqueue for the same id dedups to the open row — still True:
+        # the intent IS durably recorded, just not by a new row.
+        assert await dt.enqueue_tombstone(db, memory_id="mem-t1", reason="test") is True
+        rows = await deferred_crud.query_pending(db, work_type=dt.WORK_TYPE)
+        assert len(rows) == 1
+
+        # Different id is independent.
+        assert await dt.enqueue_tombstone(db, memory_id="mem-t2", reason="test") is True
+
+        closed = await dt.complete_open_tombstones(db, memory_id="mem-t1")
+        assert closed == 1
+        assert await dt.has_open_tombstone(db, memory_id="mem-t1") is False
+        assert await dt.has_open_tombstone(db, memory_id="mem-t2") is True
+
+    @pytest.mark.asyncio
+    async def test_enqueue_never_raises(self, db, monkeypatch):
+        async def _boom(*a, **k):
+            raise RuntimeError("db exploded")
+
+        monkeypatch.setattr(deferred_crud, "count_open_by_identity", _boom)
+        assert await dt.enqueue_tombstone(db, memory_id="mem-x", reason="test") is False
+
+    def test_memory_id_from_row(self):
+        assert dt.memory_id_from_row({"payload_json": '{"memory_id": "m1"}'}) == "m1"
+        assert dt.memory_id_from_row({"payload_json": '{"topic": "m2"}'}) == "m2"
+        assert dt.memory_id_from_row({"payload_json": "not json"}) is None
+        assert dt.memory_id_from_row({"payload_json": None}) is None
+
+
+class TestStoreDeleteTombstones:
+    @pytest.mark.asyncio
+    async def test_deferred_delete_records_tombstone(self, db):
+        store = _store(db)
+        store._qdrant.retrieve = MagicMock(side_effect=RuntimeError("qdrant down"))
+        result = await store.delete("mem-def")
+        assert result["deferred"] is True
+        assert result["tombstoned"] is True
+        assert await dt.has_open_tombstone(db, memory_id="mem-def") is True
+
+    @pytest.mark.asyncio
+    async def test_successful_delete_closes_open_tombstone(self, db):
+        await dt.enqueue_tombstone(db, memory_id="mem-ok", reason="earlier defer")
+        store = _store(db)
+        store._qdrant.retrieve = MagicMock(return_value=[])  # point already absent
+        result = await store.delete("mem-ok")
+        assert not result.get("deferred")
+        assert await dt.has_open_tombstone(db, memory_id="mem-ok") is False
+
+
+class TestAtomicRequeueGuard:
+    """requeue_for_reembed carries the metadata-exists + no-open-tombstone guard
+    INSIDE each write statement — the cross-process close of the Codex R4 race."""
+
+    async def _seed(self, db, mid: str):
+        await memory_crud.create(db, memory_id=mid, content=f"content {mid}")
+        await memory_crud.create_metadata(db, memory_id=mid, created_at="2026-03-11T12:00:00")
+        await db.execute(
+            "UPDATE memory_metadata SET embedding_status = 'embedded' WHERE memory_id = ?",
+            (mid,),
+        )
+        await db.commit()
+
+    async def _requeue(self, db, mid: str) -> bool:
+        return await pending_crud.requeue_for_reembed(
+            db,
+            memory_id=mid,
+            content="c",
+            tags=None,
+            memory_type="episodic",
+            collection="episodic_memory",
+            created_at="2026-03-11T12:00:00",
+            confidence=0.5,
+        )
+
+    @pytest.mark.asyncio
+    async def test_requeue_normal_path_true(self, db):
+        await self._seed(db, "mem-rq1")
+        assert await self._requeue(db, "mem-rq1") is True
+        rows = await db.execute_fetchall(
+            "SELECT status FROM pending_embeddings WHERE memory_id = 'mem-rq1'"
+        )
+        assert [r[0] for r in rows] == ["pending"]
+        meta = await db.execute_fetchall(
+            "SELECT embedding_status FROM memory_metadata WHERE memory_id = 'mem-rq1'"
+        )
+        assert meta[0][0] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_requeue_refused_when_metadata_gone(self, db):
+        # Simulates the cross-process delete winning after the caller's re-read.
+        assert await self._requeue(db, "mem-gone") is False
+        rows = await db.execute_fetchall(
+            "SELECT 1 FROM pending_embeddings WHERE memory_id = 'mem-gone'"
+        )
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_requeue_refused_when_tombstoned(self, db):
+        await self._seed(db, "mem-ts")
+        await dt.enqueue_tombstone(db, memory_id="mem-ts", reason="deferred delete")
+        assert await self._requeue(db, "mem-ts") is False
+        rows = await db.execute_fetchall(
+            "SELECT 1 FROM pending_embeddings WHERE memory_id = 'mem-ts'"
+        )
+        assert rows == []
+        # Mirror must NOT have been flipped for a refused requeue.
+        meta = await db.execute_fetchall(
+            "SELECT embedding_status FROM memory_metadata WHERE memory_id = 'mem-ts'"
+        )
+        assert meta[0][0] == "embedded"
+
+    @pytest.mark.asyncio
+    async def test_requeue_existing_row_not_reset_when_tombstoned(self, db):
+        await self._seed(db, "mem-row")
+        await pending_crud.create(
+            db,
+            id="pe-row",
+            memory_id="mem-row",
+            content="old",
+            memory_type="episodic",
+            collection="episodic_memory",
+            created_at="2026-03-11T12:00:00",
+            status="failed",
+        )
+        await dt.enqueue_tombstone(db, memory_id="mem-row", reason="deferred delete")
+        assert await self._requeue(db, "mem-row") is False
+        rows = await db.execute_fetchall(
+            "SELECT status, content FROM pending_embeddings WHERE memory_id = 'mem-row'"
+        )
+        assert [(r[0], r[1]) for r in rows] == [("failed", "old")]
+
+
+class TestMetadataMissingIds:
+    """metadata_missing_ids is the recall ghost detector — real-DB unit test."""
+
+    @pytest.mark.asyncio
+    async def test_partitions_present_and_missing(self, db):
+        from genesis.memory.retrieval import metadata_missing_ids
+
+        await memory_crud.create_metadata(
+            db, memory_id="mm-present", created_at="2026-03-11T12:00:00"
+        )
+        missing = await metadata_missing_ids(db, {"mm-present", "mm-ghost-a", "mm-ghost-b"})
+        assert missing == {"mm-ghost-a", "mm-ghost-b"}
+        assert await metadata_missing_ids(db, set()) == set()

--- a/tests/test_memory/test_delete_tombstones.py
+++ b/tests/test_memory/test_delete_tombstones.py
@@ -182,3 +182,51 @@ class TestMetadataMissingIds:
         missing = await metadata_missing_ids(db, {"mm-present", "mm-ghost-a", "mm-ghost-b"})
         assert missing == {"mm-ghost-a", "mm-ghost-b"}
         assert await metadata_missing_ids(db, set()) == set()
+
+
+class TestWriteAheadIntent:
+    """Codex #1270 P1: the tombstone is written BEFORE the cascade on EVERY
+    delete (not just the defer path), and closed after success — so the intent
+    is open, cross-process-visible, for the whole point-delete→cascade span."""
+
+    @pytest.mark.asyncio
+    async def test_successful_delete_writes_then_closes_intent(self, db):
+        store = _store(db)
+        store._qdrant.retrieve = MagicMock(return_value=[])
+        result = await store.delete("mem-wa")
+        assert not result.get("deferred")
+        # Intent was recorded and closed: a terminal completed row remains.
+        rows = await db.execute_fetchall(
+            "SELECT status, completed_at FROM deferred_work_queue "
+            "WHERE work_type = ? AND json_extract(payload_json, '$.memory_id') = 'mem-wa'",
+            (dt.WORK_TYPE,),
+        )
+        assert [r[0] for r in rows] == ["completed"]
+        assert rows[0][1] is not None  # prunable
+        assert await dt.has_open_tombstone(db, memory_id="mem-wa") is False
+
+    @pytest.mark.asyncio
+    async def test_intent_open_during_cascade(self, db):
+        """The tombstone must be OPEN at the moment the point delete runs —
+        that is the cross-process protection window."""
+        store = _store(db)
+        store._qdrant.retrieve = MagicMock(return_value=[])
+        open_during: dict[str, bool] = {}
+
+        # Sample tombstone state from inside the cascade via the metadata hook.
+        import genesis.memory.store as store_mod
+
+        real_delete_meta = store_mod.memory_crud.delete_metadata
+
+        async def _meta_spy(*args, **kwargs):
+            open_during["at_cascade"] = await dt.has_open_tombstone(db, memory_id="mem-wa2")
+            return await real_delete_meta(*args, **kwargs)
+
+        store_mod.memory_crud.delete_metadata = _meta_spy
+        try:
+            await store.delete("mem-wa2")
+        finally:
+            store_mod.memory_crud.delete_metadata = real_delete_meta
+
+        assert open_during.get("at_cascade") is True
+        assert await dt.has_open_tombstone(db, memory_id="mem-wa2") is False

--- a/tests/test_memory/test_recall_deferral.py
+++ b/tests/test_memory/test_recall_deferral.py
@@ -17,6 +17,20 @@ import pytest
 from genesis.memory.retrieval import HybridRetriever
 
 
+@pytest.fixture(autouse=True)
+def _no_ghost_filter(monkeypatch):
+    """These tests fabricate Qdrant hits over a MagicMock db whose empty query
+    answers make every candidate look like a metadata-less ghost — the recall
+    ghost filter would (correctly, per its contract) drop them all. Neutralize
+    it here; its behavior is pinned in test_retrieval.py and
+    test_delete_tombstones.py."""
+
+    async def _none(db, ids):
+        return set()
+
+    monkeypatch.setattr("genesis.memory.retrieval.metadata_missing_ids", _none)
+
+
 def _qdrant_hit(mid: str, score: float) -> dict:
     now = datetime.now(UTC).isoformat()
     return {

--- a/tests/test_memory/test_retrieval.py
+++ b/tests/test_memory/test_retrieval.py
@@ -1245,3 +1245,57 @@ async def test_recall_fires_entity_lane_shadow_on_zero_hits(mock_qdrant, mock_cr
     kw = spy.await_args.kwargs
     assert kw["ranked_lists"] == []
     assert kw["all_ids"] == set()
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_drops_vector_only_ghosts(mock_qdrant, mock_crud, mock_links, _mock_expand):
+    """A vector-only candidate with no memory_metadata row is a deleted
+    memory's leftover point — dropped before assembly. A candidate that also
+    has an FTS hit is never even checked (legacy fail-open preserved)."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = [
+        _make_qdrant_hit("mem-live", 0.95),
+        _make_qdrant_hit("mem-ghost", 0.90),
+    ]
+    mock_crud.search_ranked = AsyncMock(return_value=[_make_fts_row("mem-live", -5.0)])
+    _setup_link_mocks(mock_links)
+
+    with patch(
+        "genesis.memory.retrieval.metadata_missing_ids",
+        new_callable=AsyncMock,
+        return_value={"mem-ghost"},
+    ) as mock_missing:
+        results = await retriever.recall("test query", limit=5)
+
+    # Only the vector-only candidate was checked (mem-live has an FTS hit).
+    checked = mock_missing.call_args.args[-1]
+    assert checked == {"mem-ghost"}
+    assert [r.memory_id for r in results] == ["mem-live"]
+
+
+@pytest.mark.asyncio
+@patch("genesis.memory.retrieval.expand_query", new_callable=AsyncMock, return_value="test query")
+@patch("genesis.memory.retrieval.memory_links")
+@patch("genesis.memory.retrieval.memory_crud")
+@patch("genesis.memory.retrieval.qdrant_ops")
+async def test_recall_ghost_filter_failure_degrades_open(
+    mock_qdrant, mock_crud, mock_links, _mock_expand,
+):
+    """A raising ghost lookup degrades to 'no ghost filter applied'."""
+    retriever, _, _, _ = _build_retriever()
+    mock_qdrant.search.return_value = [_make_qdrant_hit("mem-1", 0.95)]
+    mock_crud.search_ranked = AsyncMock(return_value=[])
+    _setup_link_mocks(mock_links)
+
+    with patch(
+        "genesis.memory.retrieval.metadata_missing_ids",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("db locked"),
+    ):
+        results = await retriever.recall("test query", limit=5)
+
+    assert [r.memory_id for r in results] == ["mem-1"]

--- a/tests/test_memory_integrity/test_integrity_config.py
+++ b/tests/test_memory_integrity/test_integrity_config.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 from genesis.memory import integrity_config as ic
 
 
-def test_default_mode_is_passive(monkeypatch):
-    # PR-1 ships the repair lane + per-id lock but keeps the DEFAULT passive:
-    # the lock serializes delete-vs-requeue only within one process, and
-    # MemoryStore.delete() also runs in the genesis-memory MCP process. Active
-    # becomes the default with the cross-process tombstones (PR-2). Both
-    # DEFAULTS and the repo yaml agree.
+def test_default_mode_is_active(monkeypatch):
+    # Repair on by default: delete-vs-repair is serialized in-process by the
+    # per-memory-id lock AND cross-process by delete-intent tombstones + the
+    # atomic requeue guard (PR-2). Both DEFAULTS and the repo yaml agree.
     monkeypatch.delenv(ic._ENV_KILL_SWITCH, raising=False)
-    assert ic.DEFAULTS["mode"] == "passive"
-    assert ic.effective_mode() == "passive"
+    assert ic.DEFAULTS["mode"] == "active"
+    assert ic.effective_mode() == "active"
 
 
 def test_active_mode_honored_not_coerced(monkeypatch):
@@ -86,11 +84,11 @@ def test_settings_validator_rejects_invalid():
 
 
 def test_defaults_are_fresh_install_safe():
-    # A fresh clone with no overlay resolves to passive (repair opt-in until
-    # the cross-process tombstones land) + sane knobs. Repo yaml + DEFAULTS agree.
+    # A fresh clone with no overlay resolves to active (repair on by default;
+    # cross-process safety via tombstones) + sane knobs. Repo yaml + DEFAULTS agree.
     cfg = ic.load_config()
     assert cfg["enabled"] is True
-    assert cfg["mode"] == "passive"
+    assert cfg["mode"] == "active"
     assert cfg["sample_fraction"] == 1.0
     assert cfg["repair_min_age_seconds"] == 3600
     assert cfg["max_repairs_per_run"] == 500

--- a/tests/test_memory_integrity/test_integrity_repair.py
+++ b/tests/test_memory_integrity/test_integrity_repair.py
@@ -486,3 +486,187 @@ async def test_knowledge_collection_mirror_requeues_as_knowledge(tmp_path, monke
         "SELECT memory_type, collection FROM pending_embeddings WHERE memory_id = 'kb_mir'",
     )
     assert rows == [("knowledge", "knowledge_base")]
+
+
+# ── Tombstone drain (PR-2: cross-process deferred deletes) ──────────────────
+
+
+async def _run_rowfactory(path, client, monkeypatch, tmp_path, **kw):
+    """Like _run, but with the production Row factory — the tombstone drain
+    reads deferred_work_queue rows as dicts (crud.query_pending), which needs
+    aiosqlite.Row exactly as the runtime's shared connection provides."""
+    monkeypatch.setattr(
+        qdrant_ops,
+        "delete_point",
+        _fake_delete(client, **{k: kw.pop(k) for k in ("fail_ids",) if k in kw}),
+    )
+    conn = await aiosqlite.connect(path)
+    conn.row_factory = aiosqlite.Row
+    try:
+        return await integrity_repair.run_reconcile(
+            db=conn,
+            qdrant_client=client,
+            db_path=path,
+            export_dir=tmp_path / "export",
+            now=_NOW,
+            **kw,
+        )
+    finally:
+        await conn.close()
+
+
+async def _seed_tombstone(path: str, memory_id: str) -> None:
+    conn = await aiosqlite.connect(path)
+    await conn.execute(
+        "INSERT INTO deferred_work_queue (id, work_type, priority, payload_json, "
+        "deferred_at, deferred_reason, staleness_policy, status, created_at) "
+        "VALUES (?, 'memory_deferred_delete', 50, ?, ?, 'test', 'drain', 'pending', ?)",
+        (
+            f"tomb-{memory_id}",
+            json.dumps({"topic": memory_id, "category": "memory_delete",
+                        "signal_type": None, "memory_id": memory_id}),
+            _OLD,
+            _OLD,
+        ),
+    )
+    await conn.commit()
+    await conn.close()
+
+
+async def test_tombstone_drain_deletes_and_completes(tmp_path, monkeypatch):
+    """An open tombstone's delete is re-attempted via delete_memory; success
+    marks the row completed and counts tombstones_drained — and the id is
+    EXCLUDED from ghost classification even though its point is still
+    enumerable this run."""
+    path = await _db(tmp_path)
+    await _seed_tombstone(path, "m_tomb")
+    client = _points({"episodic_memory": {"m_tomb": {"created_at": _OLD, "content": "x"}}})
+
+    deleted_ids: list[str] = []
+
+    async def fake_delete_memory(mid: str) -> dict:
+        deleted_ids.append(mid)
+        client.points["episodic_memory"].pop(mid, None)
+        return {"qdrant_deleted": 1, "metadata": True}
+
+    result = await _run_rowfactory(
+        path, client, monkeypatch, tmp_path, delete_memory=fake_delete_memory
+    )
+    assert deleted_ids == ["m_tomb"]
+    assert result.tombstones_drained == 1
+    assert result.status == "ok"
+    assert result.ghosts_deleted == 0  # excluded from ghost set, not double-processed
+    rows = await _fetch(
+        path, "SELECT status FROM deferred_work_queue WHERE id = 'tomb-m_tomb'"
+    )
+    assert rows == [("completed",)]
+
+
+async def test_tombstone_drain_failure_stays_pending(tmp_path, monkeypatch):
+    """A drain attempt that defers again (Qdrant still down) goes back to
+    pending for the next run; the run reports partial with the count."""
+    path = await _db(tmp_path)
+    await _seed_tombstone(path, "m_still")
+
+    async def fake_delete_memory(mid: str) -> dict:
+        return {"deferred": True}
+
+    result = await _run_rowfactory(
+        path, _points({}), monkeypatch, tmp_path, delete_memory=fake_delete_memory
+    )
+    assert result.tombstones_drained == 0
+    assert result.status == "partial"
+    assert result.details.get("tombstones_failed") == 1
+    rows = await _fetch(
+        path, "SELECT status, attempts FROM deferred_work_queue WHERE id = 'tomb-m_still'"
+    )
+    assert rows == [("pending", 1)]
+
+
+async def test_tombstone_without_deleter_skipped_and_excluded(tmp_path, monkeypatch):
+    """No delete callable (degraded boot): the drain is skipped loudly, the run
+    is partial, and the tombstoned id is still excluded from mirror requeue —
+    an intent-marked memory must never be re-embedded."""
+    path = await _db(tmp_path)
+    await _seed(path, "m_nodel", created_at=_OLD)  # would otherwise be a mirror
+    await _seed_tombstone(path, "m_nodel")
+
+    result = await _run_rowfactory(path, _points({}), monkeypatch, tmp_path)
+    assert result.status == "partial"
+    assert result.details.get("tombstones_skipped_no_deleter") == 1
+    assert result.mirrors_requeued == 0
+    rows = await _fetch(
+        path, "SELECT COUNT(*) FROM pending_embeddings WHERE memory_id = 'm_nodel'"
+    )
+    assert rows[0][0] == 0
+
+
+async def test_corrupt_tombstone_discarded(tmp_path, monkeypatch):
+    path = await _db(tmp_path)
+    conn = await aiosqlite.connect(path)
+    await conn.execute(
+        "INSERT INTO deferred_work_queue (id, work_type, priority, payload_json, "
+        "deferred_at, deferred_reason, staleness_policy, status, created_at) "
+        "VALUES ('tomb-bad', 'memory_deferred_delete', 50, 'not json', ?, 'test', "
+        "'drain', 'pending', ?)",
+        (_OLD, _OLD),
+    )
+    await conn.commit()
+    await conn.close()
+
+    async def fake_delete_memory(mid: str) -> dict:  # pragma: no cover - not reached
+        raise AssertionError("must not be called for a corrupt row")
+
+    result = await _run_rowfactory(
+        path, _points({}), monkeypatch, tmp_path, delete_memory=fake_delete_memory
+    )
+    assert result.tombstones_drained == 0
+    rows = await _fetch(
+        path, "SELECT status FROM deferred_work_queue WHERE id = 'tomb-bad'"
+    )
+    assert rows == [("discarded",)]
+
+
+async def test_duplicate_tombstones_for_one_id_drain_once(tmp_path, monkeypatch):
+    """Two open tombstone rows for the SAME memory_id (best-effort multi-process
+    dedup can produce dups): the drain attempts the delete exactly once, closes
+    BOTH rows, counts one drain — and never re-opens a completed row."""
+    path = await _db(tmp_path)
+    await _seed_tombstone(path, "m_dup")
+    conn = await aiosqlite.connect(path)
+    await conn.execute(
+        "INSERT INTO deferred_work_queue (id, work_type, priority, payload_json, "
+        "deferred_at, deferred_reason, staleness_policy, status, created_at) "
+        "VALUES ('tomb-m_dup-2', 'memory_deferred_delete', 50, ?, ?, 'test', "
+        "'drain', 'pending', ?)",
+        (
+            json.dumps({"topic": "m_dup", "category": "memory_delete",
+                        "signal_type": None, "memory_id": "m_dup"}),
+            _OLD,
+            _OLD,
+        ),
+    )
+    await conn.commit()
+    await conn.close()
+
+    calls: list[str] = []
+
+    async def fake_delete_memory(mid: str) -> dict:
+        calls.append(mid)
+        return {"qdrant_deleted": 1, "metadata": True}
+
+    result = await _run_rowfactory(
+        path, _points({}), monkeypatch, tmp_path, delete_memory=fake_delete_memory
+    )
+    assert calls == ["m_dup"]  # exactly one attempt
+    assert result.tombstones_drained == 1
+    assert result.details.get("tombstones_failed") is None
+    rows = await _fetch(
+        path,
+        "SELECT id, status FROM deferred_work_queue WHERE work_type = 'memory_deferred_delete' "
+        "ORDER BY id",
+    )
+    assert [(r[0], r[1]) for r in rows] == [
+        ("tomb-m_dup", "completed"),
+        ("tomb-m_dup-2", "completed"),
+    ]

--- a/tests/test_memory_integrity/test_integrity_repair.py
+++ b/tests/test_memory_integrity/test_integrity_repair.py
@@ -670,3 +670,67 @@ async def test_duplicate_tombstones_for_one_id_drain_once(tmp_path, monkeypatch)
         ("tomb-m_dup", "completed"),
         ("tomb-m_dup-2", "completed"),
     ]
+
+
+async def test_tombstone_query_failure_reports_partial(tmp_path, monkeypatch):
+    """A failed tombstone-queue query must NOT read as a healthy run: the drain
+    was skipped, so requested deletions may still be pending (Codex #1270 P2)."""
+    path = await _db(tmp_path)
+
+    async def _boom(*a, **k):
+        raise RuntimeError("queue table unavailable")
+
+    monkeypatch.setattr(integrity_repair.deferred_crud, "query_pending", _boom)
+    result = await _run_rowfactory(path, _points({}), monkeypatch, tmp_path)
+    assert result.status == "partial"
+    assert result.details.get("tombstone_query_failed") is True
+    assert result.tombstones_drained == 0
+
+
+async def test_drain_with_real_store_delete_end_to_end(tmp_path, monkeypatch):
+    """Integration: the drain's pending→processing transition + the REAL
+    MemoryStore.delete (write-ahead dedup against the processing row, full
+    cascade, step-7 close-out) — the combined path the unit tests fake."""
+    from unittest.mock import MagicMock
+
+    import genesis.memory.store as store_mod
+    from genesis.memory.store import MemoryStore
+
+    path = await _db(tmp_path)
+    await _seed(path, "m_real", created_at=_OLD)  # metadata + fts row
+    await _seed_tombstone(path, "m_real")
+    client = _points({"episodic_memory": {"m_real": {"created_at": _OLD, "content": "x"}}})
+    monkeypatch.setattr(store_mod, "delete_point", _fake_delete(client))
+
+    conn = await aiosqlite.connect(path)
+    conn.row_factory = aiosqlite.Row
+    try:
+        store = MemoryStore(
+            embedding_provider=MagicMock(),
+            qdrant_client=client,
+            db=conn,
+            linker=None,
+        )
+        result = await integrity_repair.run_reconcile(
+            db=conn,
+            qdrant_client=client,
+            db_path=path,
+            export_dir=tmp_path / "export",
+            now=_NOW,
+            delete_memory=store.delete,
+        )
+    finally:
+        await conn.close()
+
+    assert result.tombstones_drained == 1
+    assert result.status == "ok"
+    # Memory fully gone across all stores; no duplicate tombstone row created
+    # by the write-ahead enqueue (it deduped against the drain's processing row).
+    assert await _fetch(path, "SELECT COUNT(*) FROM memory_metadata WHERE memory_id='m_real'") == [(0,)]
+    assert await _fetch(path, "SELECT COUNT(*) FROM memory_fts WHERE memory_id='m_real'") == [(0,)]
+    assert "m_real" not in client.points["episodic_memory"]
+    rows = await _fetch(
+        path,
+        "SELECT status FROM deferred_work_queue WHERE work_type='memory_deferred_delete'",
+    )
+    assert [r[0] for r in rows] == ["completed"]

--- a/tests/test_resilience/test_embedding_recovery.py
+++ b/tests/test_resilience/test_embedding_recovery.py
@@ -394,3 +394,28 @@ class TestDrainPending:
         assert await w.drain_pending() == 1
         payload = qdrant.upsert.call_args.kwargs["points"][0].payload
         assert payload["confidence"] == 0.0
+
+
+class TestTombstoneSkip:
+    """A memory with an open delete-intent tombstone (deferred delete: metadata
+    and queue row still intact) must NOT be re-embedded — the reconcile drain
+    is about to delete it. The queue row stays pending until the tombstone
+    resolves."""
+
+    @pytest.mark.asyncio
+    async def test_open_tombstone_skips_upsert(self, db, worker):
+        from genesis.memory.delete_tombstones import enqueue_tombstone
+
+        w, embedder, qdrant = worker
+        await crud.create(
+            db, id="pe-ts", memory_id="mem-ts", content="awaiting delete",
+            memory_type="episodic", collection="episodic_memory",
+            created_at="2026-03-11T12:00:00",
+        )
+        await enqueue_tombstone(db, memory_id="mem-ts", reason="deferred delete")
+
+        processed = await w.drain_pending()
+        assert processed == 0
+        assert qdrant.upsert.call_count == 0
+        # Still pending — drains normally once the tombstone resolves.
+        assert await crud.count_pending(db) == 1

--- a/tests/test_security/test_redteam_enforce.py
+++ b/tests/test_security/test_redteam_enforce.py
@@ -286,6 +286,15 @@ async def test_memory_core_facts_drops_external_dispatched_enforce(
             payload["origin_class"] = origin
         return SimpleNamespace(id=mid, payload=payload)
 
+    # Scrolled points need metadata rows — metadata-less points are ghosts and
+    # the core_facts ghost filter drops them before the gate under test runs.
+    for _mid in ("ext-1", "fp-1"):
+        await db.execute(
+            "INSERT INTO memory_metadata (memory_id, created_at) VALUES (?, ?)",
+            (_mid, "2026-01-01T00:00:00+00:00"),
+        )
+    await db.commit()
+
     qdrant = MagicMock()
     qdrant.scroll.return_value = (
         [
@@ -332,6 +341,11 @@ async def test_memory_core_facts_enriches_legacy_payload_from_sqlite(
     await db.execute(
         "INSERT INTO memory_metadata (memory_id, created_at, origin_class) VALUES (?, ?, ?)",
         ("legacy-ext", "2026-01-01T00:00:00+00:00", "external_untrusted"),
+    )
+    # fp-1 needs a metadata row too — the ghost filter drops metadata-less points.
+    await db.execute(
+        "INSERT INTO memory_metadata (memory_id, created_at) VALUES (?, ?)",
+        ("fp-1", "2026-01-01T00:00:00+00:00"),
     )
     await db.commit()
 
@@ -952,6 +966,14 @@ async def test_memory_core_facts_refills_after_enforced_drops(config_dirs, monke
         if origin is not None:
             payload["origin_class"] = origin
         return SimpleNamespace(id=mid, payload=payload)
+
+    # Metadata rows for the scrolled points (ghost filter drops metadata-less ids).
+    for _mid in ("ext-hi", "fp-lo"):
+        await db.execute(
+            "INSERT INTO memory_metadata (memory_id, created_at) VALUES (?, ?)",
+            (_mid, "2026-01-01T00:00:00+00:00"),
+        )
+    await db.commit()
 
     qdrant = MagicMock()
     qdrant.scroll.return_value = (


### PR DESCRIPTION
## Delete-intent tombstones — cross-process repair safety (memory-integrity PR-2 of 2)

PR #1260 shipped the nightly reconcile lane + a per-memory-id lock, with the default
held at `passive` because of a verified cross-process gap (round-4 P1): the lock is
process-local, but `MemoryStore.delete()` also runs in the separate `genesis-memory`
MCP process (`reference_delete` unconditionally; ingest stale-point cleanup
conditionally) against the same SQLite + Qdrant stores. This PR closes that gap with
DB-backed mechanisms that every process sees, and flips the default to `active`.

### The mechanism (three layers)
1. **Delete-intent tombstones** (`memory/delete_tombstones.py`) — a deferred delete
   (Qdrant unreachable → `delete()` touches nothing) now records its intent as a
   `deferred_work_queue` row (`work_type=memory_deferred_delete`; no new store —
   queue conventions, `prune_terminal` retention, dup-tolerant dedup). A later
   successful delete closes every open tombstone for the id.
2. **Reconcile drain** — the nightly lane drains open tombstones FIRST (re-attempting
   the full store cascade via a new `delete_memory` param), excludes attempted ids
   from that run's ghost/mirror classification, and reports `tombstones_drained` on
   the audit row. Failures return to pending — deliberately no attempts cap: a delete
   intent must never be silently dropped; a poisoned intent stays visible as
   `status=partial` with a growing attempts count. Corrupt rows are discarded
   prunable. Per-run id dedup collapses duplicate rows (one attempt, all closed).
3. **Atomic requeue guard** — `requeue_for_reembed`'s UPDATE and INSERT each carry
   `EXISTS(metadata) AND NOT EXISTS(open tombstone)` **inside the SQL statement**;
   SQLite's cross-process write lock makes each statement atomic vs a delete in any
   process. Returns bool; the `embedding_status` mirror only flips when the row
   actually landed. The recovery worker additionally skips open-tombstoned ids
   (a deferred delete leaves metadata + queue row intact — without this it would
   rebuild a vector that is about to be deleted).

### Recall-side ghost filter
Red-teaming PR-1 falsified the old "ghosts are invisible to recall" assumption: the
retriever assembles raw Qdrant payloads without a metadata join, and
`memory_core_facts` scrolls payloads directly. Both now drop metadata-less points —
scoped to VECTOR-ONLY candidates in the retriever so legacy FTS-only content keeps
its long-standing fail-open; degrade-open with warning logs on DB error. A raced
ghost is now recall-invisible even before the nightly sweep. (Ghost-population audit
on this install: 0 metadata-less points; the one live ghost found was fresh drift,
export-captured then deleted in a supervised run.)

### Default flip: `mode: active`
With in-process locks (PR-1) + cross-process tombstones + the atomic requeue guard,
active-by-default is now honestly claimable. Documented irreducible floor: the
worker's SQLite-check→Qdrant-upsert micro-window vs a concurrent full delete —
self-healed by the next nightly run and recall-invisible via the filter.

### Reviews & testing
- genesis-architect: DONE_WITH_CONCERNS — verified the guard SQL atomicity, drain
  ordering, lock discipline (no deadlock; the drain holds no lock), New-Store-Gate
  reuse justification, and staleness/retention semantics. 8 findings, all fixed
  in-PR (prunable discarded rows, truthful `tombstoned` flag incl. dedup, public
  `metadata_missing_ids`, warning-level fail-open on the ambient surface, documented
  no-cap decision, docstring/comment corrections, CHANGELOG legacy-vector clause).
- code-reviewer: DONE_WITH_CONCERNS — 1 finding (duplicate tombstone rows for one id
  double-processed by the drain), fixed with per-run id dedup +
  close-all-open-on-success + a regression test.
- 287 targeted tests pass (tombstone lifecycle, atomic-guard refusal paths, drain
  success/failure/corrupt/no-deleter/duplicate, worker skip, recall + core_facts
  ghost filters, config default agreement). Existing core_facts fixtures updated to
  seed metadata rows — a point without one is a ghost by definition under the new
  invariant.

Ledger: bd1cc9d5512f447e87ed0a3f00967e1d

🤖 Generated with [Claude Code](https://claude.com/claude-code)
