### PR TITLE
fix(onboarding): /setup routes to onboarding skill, not bootstrap

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -1,12 +1,60 @@
-Run the Genesis bootstrap script to set up or repair the Claude Code configuration
-on this machine:
+---
+name: setup
+description: >
+  First-run onboarding or config repair. Routes on install state: a fresh
+  install (no ~/.genesis/setup-complete marker) runs guided onboarding; an
+  already-configured install runs config / Claude Code-config repair.
+---
+
+# Genesis Setup
+
+`/setup` covers two distinct jobs — first-run **onboarding** and config
+**repair** — and routes between them based on install state. Detect first, then
+route; do not assume.
+
+## Step 1 — Detect install state
 
 ```bash
-./scripts/bootstrap.sh
+test -f ~/.genesis/setup-complete && echo COMPLETE || echo FRESH
 ```
 
-For just the CC config (without full bootstrap):
+## Step 2 — Route
+
+- **FRESH** (marker absent) → **Guided onboarding** (below), *always* — even if
+  the user said "repair". A never-onboarded install has no configured system to
+  repair yet; onboarding *is* the setup. (Running `bootstrap.sh` here would mark
+  setup complete without configuring anything, permanently suppressing the
+  first-run onboarding prompt.)
+- **COMPLETE** (marker present) → **Config repair** (below). Running `/setup` on
+  an already-configured install is almost always a fix/refresh request. To
+  deliberately re-onboard or reconfigure one section, see the last section.
+
+### Guided onboarding
+
+Read `src/genesis/skills/onboarding/SKILL.md` and follow its steps: it configures
+the user profile, essential API keys, Telegram, GitHub backup, and verifies
+endpoints, then writes the `~/.genesis/setup-complete` marker itself at the end.
+Do **not** run `bootstrap.sh` for onboarding — bootstrap is infrastructure setup,
+not the onboarding flow.
+
+### Config repair
+
+Most repairs (hooks or MCP servers not firing) only need the Claude Code config
+re-rendered, which is safe on a running system:
+
 ```bash
 python scripts/setup_claude_config.py          # .mcp.json only
-python scripts/setup_claude_config.py --global  # Also update ~/.claude/settings.json
+python scripts/setup_claude_config.py --global  # also update ~/.claude/settings.json
 ```
+
+For a full config + service re-render, run `./scripts/bootstrap.sh`. It refuses
+to run while genesis-server is live — a safety guard, because its crash-recovery
+path can `git reset --hard` the tree. Stop the server first, or pass `--force`
+to override the guard deliberately.
+
+## Re-running onboarding on a configured install
+
+If the marker exists but the user wants to re-onboard or reconfigure one section
+(e.g. "reconfigure telegram"), read `src/genesis/skills/onboarding/SKILL.md`
+anyway — it detects the existing marker, notes that setup was already completed,
+and runs only the requested section.

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -1,33 +1,52 @@
 ---
 name: setup
 description: >
-  First-run onboarding or config repair. Routes on install state: a fresh
-  install (no ~/.genesis/setup-complete marker) runs guided onboarding; an
-  already-configured install runs config / Claude Code-config repair.
+  First-run onboarding or config repair. Routes on two signals — whether the
+  Layer-1 install finished, and whether onboarding has completed
+  (~/.genesis/setup-complete). A broken/half-finished install is repaired; a
+  complete-but-unconfigured install is onboarded; a configured install is
+  refreshed.
 ---
 
 # Genesis Setup
 
-`/setup` covers two distinct jobs — first-run **onboarding** and config
-**repair** — and routes between them based on install state. Detect first, then
-route; do not assume.
+`/setup` covers two jobs — finishing/repairing the **install** and running
+first-run **onboarding** — and routes between them from the system's actual
+state. Detect first, then route; do not assume.
 
-## Step 1 — Detect install state
+## Step 1 — Detect state
 
-```bash
-test -f ~/.genesis/setup-complete && echo COMPLETE || echo FRESH
-```
+Two independent signals:
 
-## Step 2 — Route
+- **Infrastructure** — did the Layer-1 install (`bootstrap.sh` / `install.sh`)
+  actually finish? An interrupted install leaves the venv or dependencies
+  incomplete, and the `~/.genesis/setup-complete` marker absent (it is written
+  only at the very end). Check that the venv exists and the package imports:
 
-- **FRESH** (marker absent) → **Guided onboarding** (below), *always* — even if
-  the user said "repair". A never-onboarded install has no configured system to
-  repair yet; onboarding *is* the setup. (Running `bootstrap.sh` here would mark
-  setup complete without configuring anything, permanently suppressing the
-  first-run onboarding prompt.)
-- **COMPLETE** (marker present) → **Config repair** (below). Running `/setup` on
-  an already-configured install is almost always a fix/refresh request. To
-  deliberately re-onboard or reconfigure one section, see the last section.
+  ```bash
+  ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  "$ROOT/.venv/bin/python" -c "import genesis" 2>/dev/null && echo INFRA_OK || echo INFRA_INCOMPLETE
+  ```
+
+- **Onboarding** — has the system been configured? The marker is written at the
+  end of onboarding (or by a completed `bootstrap.sh`):
+
+  ```bash
+  test -f ~/.genesis/setup-complete && echo ONBOARDED || echo NOT_ONBOARDED
+  ```
+
+## Step 2 — Route (decide in this order)
+
+1. **INFRA_INCOMPLETE** — the install is broken or half-finished (e.g. an
+   interrupted `bootstrap.sh`). Onboarding cannot run on a broken install, so
+   **repair the infrastructure first** → **Config repair** below. After it
+   completes, if keys/identity still need configuring, ask Genesis to "run
+   onboarding" — the skill will run the sections you need.
+2. **INFRA_OK + NOT_ONBOARDED** — a complete install that has not been configured
+   → **Guided onboarding** below. (Even if the user said "repair" — there is no
+   configured system to repair yet; onboarding *is* the setup.)
+3. **INFRA_OK + ONBOARDED** — an already-configured install → **Config repair**
+   below (the usual reason to run `/setup` on a working system).
 
 ### Guided onboarding
 
@@ -47,10 +66,10 @@ python scripts/setup_claude_config.py          # .mcp.json only
 python scripts/setup_claude_config.py --global  # also update ~/.claude/settings.json
 ```
 
-For a full config + service re-render, run `./scripts/bootstrap.sh`. It refuses
-to run while genesis-server is live — a safety guard, because its crash-recovery
-path can `git reset --hard` the tree. Stop the server first, or pass `--force`
-to override the guard deliberately.
+For a full install/config + service re-render (this also finishes an interrupted
+install), run `./scripts/bootstrap.sh`. It refuses to run while genesis-server is
+live — a safety guard, because its crash-recovery path can `git reset --hard` the
+tree. Stop the server first, or pass `--force` to override the guard deliberately.
 
 ## Re-running onboarding on a configured install
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -23,6 +23,13 @@ After bootstrap:
 2. Start Claude Code: `claude` in the genesis directory
 3. All hooks and MCP servers activate automatically
 
+> **Two install paths.** This bare-metal `bootstrap.sh` quick-start targets
+> developers and restores: it configures infrastructure and expects you to add
+> keys manually (steps above). For a guided, container-based install that walks
+> you through API keys, profile, and channels interactively, use
+> `scripts/host-setup.sh` (see the README) — it runs first-run onboarding
+> automatically, and you can re-trigger it with `/setup` if it doesn't start.
+
 ## Minimum Viable Setup
 
 Genesis needs at least one LLM provider. The cheapest path:
@@ -85,7 +92,7 @@ Populates the voice exemplar library with samples of your writing style.
 3. Add to `secrets.env`:
    ```
    TELEGRAM_BOT_TOKEN=your_bot_token
-   TELEGRAM_USER_ID=your_user_id
+   TELEGRAM_ALLOWED_USERS=your_numeric_user_id   # comma-separated for multiple
    ```
 
 ## Configuration Files


### PR DESCRIPTION
## Problem

The `/setup` slash command ran `scripts/bootstrap.sh` unconditionally, which broke the documented recovery path two different ways:

- On a **running** system, `bootstrap.sh` refuses to run (it guards against operating on a live install), so `/setup` just errored out.
- On a **fresh bare-metal** install, `bootstrap.sh` writes the `~/.genesis/setup-complete` marker — the same marker that gates the first-run onboarding prompt — so guided onboarding was silently suppressed.

Either way, the hint the installer prints ("If onboarding doesn't start, run `/setup`") did the opposite of what it promised, and it contradicted the onboarding skill's own documentation that it is `/setup`-invoked.

## Change

`/setup` now routes on install state:

- **Fresh install** (no `~/.genesis/setup-complete`) → reads and runs the guided onboarding skill. Always — a never-configured box has nothing to "repair".
- **Configured install** → config repair, leading with the safe Claude Code-config refresh, and only then the full `bootstrap.sh` (noting that `--force` deliberately overrides a safety guard).

`bootstrap.sh`'s marker write is intentionally left unchanged.

## Docs

- `SETUP.md`: corrected a dead env var (`TELEGRAM_USER_ID` → `TELEGRAM_ALLOWED_USERS`, the name actually read at runtime in `runtime/init/outreach.py`).
- Documented the two install paths (bare-metal `bootstrap.sh` vs guided `host-setup.sh`) so it's clear which one runs interactive onboarding.

## Verification

- Routing logic verified unambiguous for every install state (fresh / configured, with and without a repair request).
- All factual claims in the command cross-checked against source (marker path, the onboarding skill writing the marker at its final step, bootstrap's live-guard + `--force`, the config flags, the Telegram var).
- Independent code review (2 rounds), clean.
