### PR TITLE
fix(hooks): sync-hooks worktree-safety + hook-version ledger completeness

### DIFF
--- a/.genesis-hook-versions
+++ b/.genesis-hook-versions
@@ -35,3 +35,14 @@ post-commit:a4d13b7b0c7e1540e28c553e15e0b07476bc10f6cd60737e59e76964426f09f0
 post-commit:6860283dc98d1fe5afcc7e332f3ebae7b2ce7ea95996de6870c43b5cb155d974
 commit-msg:94eff83990218255032996070991936f134b0f929febeba5053b7715a3c9d39a
 prepare-commit-msg:51b8fc7537264d3b5eeb2f21c3e7fa75a4528d77976ac21e138f7f1642b9e7da
+
+# Backfill (2026-08-01): historical versions that shipped on main but were never
+# recorded — they predate the commit that added the hook to the tracked set, so
+# the per-commit gate never captured them. Without these entries sync-hooks.sh
+# mis-classifies an install still carrying one as "user-modified" and never
+# updates it (commit-msg:f239fd3e was found live-wedged on this install). Found
+# by scripts/check_hook_versions_complete.sh, now a CI backstop.
+commit-msg:f239fd3eac3a780fd4b68c39a1769f65548640afeeb7300ff3288c6b2a2cbcb9
+post-commit:a5ca9f5a58f95e3db43534b5e852603c4caa5d2d975411ccc45333e4f6d0ad45
+pre-commit:843e381812f98c37f94d3d7853e2b3518e8802840bb10527443faf586066a1a7
+pre-commit:a5d39a2359d4bb6f86911b53c3cbc429aca570770ce71274c14992332db65041

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,6 +355,21 @@ jobs:
       - name: Subsystem-map drift guard
         run: python scripts/check_subsystem_map.py
 
+  hook-versions-check:
+    # Completeness backstop for .genesis-hook-versions: every version of a
+    # tracked git hook that ever shipped on main must be recorded, or a
+    # community install still carrying it gets wedged (sync-hooks.sh treats an
+    # unrecorded hash as "user-modified" and never updates it). The checker
+    # walks FULL hook history, so this job checks out fetch-depth: 0; it skips
+    # gracefully on a shallow clone. See scripts/check_hook_versions_complete.sh.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Hook-version ledger completeness guard
+        run: bash scripts/check_hook_versions_complete.sh
+
   cc-node-lockstep:
     # Enforce the CC↔Node pin lockstep: NODE_MAJOR in scripts/lib/cc_version.sh
     # must satisfy the pinned Claude Code's engines.node floor. Prevents the

--- a/scripts/check_hook_versions.sh
+++ b/scripts/check_hook_versions.sh
@@ -20,7 +20,8 @@ set -o pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VERSIONS_FILE="$REPO_ROOT/.genesis-hook-versions"
 
-# Keep in lockstep with update_hook_versions.sh and sync-hooks.sh.
+# Keep in lockstep with update_hook_versions.sh, sync-hooks.sh, and
+# check_hook_versions_complete.sh.
 TRACKED_HOOKS=(commit-msg post-commit pre-commit prepare-commit-msg pre-push)
 
 # Get list of staged files (relative to repo root)

--- a/scripts/check_hook_versions_complete.sh
+++ b/scripts/check_hook_versions_complete.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Phase 6 — CI completeness backstop for .genesis-hook-versions.
+#
+# For every tracked hook, walk its FULL git history and assert that every
+# version ever shipped on this branch has its sha256 recorded in
+# .genesis-hook-versions. A version that shipped but is NOT recorded is a
+# latent wedge: on a community install still carrying that version,
+# scripts/hooks/sync-hooks.sh sees dst != src AND dst-hash not-in-ledger,
+# mis-classifies it as "user-modified", and SKIPS it forever — the install
+# never picks up the fixed hook.
+#
+# The per-commit pre-commit gate (scripts/check_hook_versions.sh) only records
+# the CURRENT tree, so an intermediate version committed without running
+# scripts/update_hook_versions.sh (or under `git commit --no-verify`) slips
+# through. This script is the backstop that catches such a gap in CI.
+#
+# REQUIRES FULL HISTORY: a shallow clone (GitHub Actions default) sees only the
+# tip commit, so the history walk would be empty and this check would falsely
+# pass. It therefore SKIPS (exit 0, with a clear notice) on a shallow clone —
+# the CI job that runs it MUST check out with fetch-depth: 0. This mirrors the
+# graceful-degradation pattern in scripts/check_subsystem_map.py.
+#
+# Exit codes:
+#     0 — every shipped hook version is recorded (or shallow clone → skipped)
+#     1 — one or more shipped versions are missing from .genesis-hook-versions
+
+set -u
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+VERSIONS_FILE="$REPO_ROOT/.genesis-hook-versions"
+
+# Keep in lockstep with sync-hooks.sh HOOKS_TO_SYNC, check_hook_versions.sh,
+# and update_hook_versions.sh.
+TRACKED_HOOKS=(commit-msg post-commit pre-commit prepare-commit-msg pre-push)
+
+cd "$REPO_ROOT" || { echo "ERROR: cannot cd to repo root $REPO_ROOT" >&2; exit 1; }
+
+if [[ ! -f "$VERSIONS_FILE" ]]; then
+    echo "ERROR: $VERSIONS_FILE not found — the hook version ledger is missing." >&2
+    exit 1
+fi
+
+# Shallow clone → the history walk is meaningless; skip rather than false-pass.
+if [[ "$(git rev-parse --is-shallow-repository 2>/dev/null)" == "true" ]]; then
+    echo "NOTICE: shallow clone detected — skipping hook-version completeness check."
+    echo "        (Run in a job that checks out with fetch-depth: 0 to enforce it.)"
+    exit 0
+fi
+
+# Map "<hook>:<sha256>" → first-seen short commit, so a version that recurs
+# across commits is reported ONCE (keyed on the hash, not per-commit).
+declare -A MISSING
+_EMPTY_SHA=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+for h in "${TRACKED_HOOKS[@]}"; do
+    path="scripts/hooks/$h"
+    # Every commit on this branch that touched the hook = every version shipped.
+    # git log is newest-first; the -z guard below keeps the newest occurrence.
+    for c in $(git log --format='%H' -- "$path" 2>/dev/null); do
+        hash=$(git show "$c:$path" 2>/dev/null | sha256sum | awk '{print $1}')
+        # git show prints nothing for a commit where the path was absent (e.g.
+        # the delete side of a rename); sha256sum of empty input is the fixed
+        # _EMPTY_SHA — skip it so it can't masquerade as a real missing version.
+        [[ -z "$hash" || "$hash" == "$_EMPTY_SHA" ]] && continue
+        key="$h:$hash"
+        if ! grep -qxF "$key" "$VERSIONS_FILE"; then
+            [[ -z "${MISSING[$key]:-}" ]] && MISSING[$key]="${c:0:12}"
+        fi
+    done
+done
+
+# NOTE: under `set -u`, an associative array with NO elements is treated as
+# unbound, so ${#MISSING[@]} would error rather than yield 0. The ${MISSING[*]+x}
+# guard expands to empty (→ -z true) only when the array has no elements.
+if [[ -z "${MISSING[*]+x}" ]]; then
+    echo "OK: all shipped versions of ${TRACKED_HOOKS[*]} are recorded in .genesis-hook-versions"
+    exit 0
+fi
+
+echo "" >&2
+echo "BLOCKED: shipped hook version(s) missing from .genesis-hook-versions:" >&2
+# Emit on stdout so `sort` orders them, then redirect the sorted result to stderr
+# (piping a loop whose body writes to >&2 would leave sort with empty input).
+for key in "${!MISSING[@]}"; do
+    echo "  - $key (first seen in ${MISSING[$key]})"
+done | sort >&2
+echo "" >&2
+echo "A community install still carrying one of these versions would be wedged:" >&2
+echo "sync-hooks.sh would treat the hook as user-modified and never update it." >&2
+echo "" >&2
+echo "Fix: append each missing '<hook>:<sha256>' line to .genesis-hook-versions" >&2
+echo "(scripts/update_hook_versions.sh records the CURRENT tree; historical" >&2
+echo "versions must be added by hand from the digests listed above)." >&2
+echo "" >&2
+
+exit 1

--- a/scripts/check_hook_versions_complete.sh
+++ b/scripts/check_hook_versions_complete.sh
@@ -52,16 +52,38 @@ fi
 # across commits is reported ONCE (keyed on the hash, not per-commit).
 declare -A MISSING
 _EMPTY_SHA=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+_fail_closed() {
+    # A read failure means we did NOT examine the full history — for a
+    # completeness guard, that must ERROR (fail closed), never pass silently.
+    echo "ERROR: $1" >&2
+    echo "Cannot verify ledger completeness — run in a FULL clone (fetch-depth: 0," >&2
+    echo "not a shallow or blobless/partial clone)." >&2
+    exit 1
+}
+
 for h in "${TRACKED_HOOKS[@]}"; do
     path="scripts/hooks/$h"
     # Every commit on this branch that touched the hook = every version shipped.
     # git log is newest-first; the -z guard below keeps the newest occurrence.
-    for c in $(git log --format='%H' -- "$path" 2>/dev/null); do
+    # Capture first so a `git log` failure fails closed instead of looking like
+    # "no history" (empty output) and passing.
+    commits=$(git log --format='%H' -- "$path" 2>/dev/null) \
+        || _fail_closed "git log failed for $path"
+    for c in $commits; do
+        # Distinguish a genuinely-absent path (e.g. a delete-side commit — a
+        # legitimate skip) from an UNREADABLE object (a partial/blobless clone or
+        # object corruption — a read failure we must not paper over). ls-tree
+        # reports the path only when it exists in that commit's tree.
+        if [[ -z "$(git ls-tree -r --name-only "$c" -- "$path" 2>/dev/null)" ]]; then
+            continue  # path did not exist at this commit → not a shipped version
+        fi
+        # Path exists here, so we MUST be able to hash it. Pipe git show straight
+        # into sha256sum (capturing to a var would strip trailing newlines and
+        # change the digest). Under pipefail a git-show failure yields empty input
+        # → _EMPTY_SHA; combined with "path exists in tree" that is a read failure.
         hash=$(git show "$c:$path" 2>/dev/null | sha256sum | awk '{print $1}')
-        # git show prints nothing for a commit where the path was absent (e.g.
-        # the delete side of a rename); sha256sum of empty input is the fixed
-        # _EMPTY_SHA — skip it so it can't masquerade as a real missing version.
-        [[ -z "$hash" || "$hash" == "$_EMPTY_SHA" ]] && continue
+        [[ -z "$hash" || "$hash" == "$_EMPTY_SHA" ]] \
+            && _fail_closed "could not read $path at ${c:0:12} (unreadable object?)"
         key="$h:$hash"
         if ! grep -qxF "$key" "$VERSIONS_FILE"; then
             [[ -z "${MISSING[$key]:-}" ]] && MISSING[$key]="${c:0:12}"

--- a/scripts/hooks/sync-hooks.sh
+++ b/scripts/hooks/sync-hooks.sh
@@ -53,6 +53,26 @@ fi
 if [[ "$GIT_COMMON_DIR" != /* ]]; then
     GIT_COMMON_DIR="$REPO_ROOT/$GIT_COMMON_DIR"
 fi
+
+# Skip in a LINKED worktree. In a worktree, --git-dir points at
+# $GIT_COMMON_DIR/worktrees/<name> while --git-common-dir is the shared main
+# .git; in the main worktree they resolve to the same dir. HOOKS_DST below is
+# ALWAYS the shared $GIT_COMMON_DIR/hooks, but HOOKS_SRC is this checkout's
+# scripts/hooks — so syncing from a linked worktree would overwrite the shared
+# hooks with the worktree branch's (possibly older or feature-modified) copies,
+# affecting EVERY session/tree. Only the main worktree owns the shared hooks.
+# Resolve both to absolute real paths before comparing (one may be relative).
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || echo "")
+if [[ -n "$GIT_DIR" ]]; then
+    [[ "$GIT_DIR" != /* ]] && GIT_DIR="$REPO_ROOT/$GIT_DIR"
+    _gd_abs=$(cd "$GIT_DIR" 2>/dev/null && pwd)
+    _gc_abs=$(cd "$GIT_COMMON_DIR" 2>/dev/null && pwd)
+    if [[ -n "$_gd_abs" && -n "$_gc_abs" && "$_gd_abs" != "$_gc_abs" ]]; then
+        _log "in a linked worktree — skipping hook sync (shared hooks are owned by the main worktree)"
+        exit 0
+    fi
+fi
+
 HOOKS_DST="$GIT_COMMON_DIR/hooks"
 
 if [[ ! -d "$HOOKS_DST" ]]; then
@@ -82,6 +102,21 @@ _sha256_of() {
     sha256sum "$1" 2>/dev/null | awk '{print $1}'
 }
 
+# Atomically install $src → $dst: copy to a temp file in the SAME dir (so the
+# final mv is a same-filesystem rename, which is atomic), chmod, then rename over
+# $dst. A concurrent session — or git firing the hook mid-copy — never observes a
+# half-written, partially-executable hook. Returns non-zero on any failure; the
+# temp file is cleaned up so a failed install leaves no stray *.tmp.* behind.
+_atomic_install() {
+    local src="$1" dst="$2"
+    local tmp="$dst.tmp.$$"
+    if cp "$src" "$tmp" && chmod +x "$tmp" && mv -f "$tmp" "$dst"; then
+        return 0
+    fi
+    rm -f "$tmp" 2>/dev/null
+    return 1
+}
+
 _sync_one() {
     local name="$1"
     local src="$HOOKS_SRC/$name"
@@ -98,7 +133,7 @@ _sync_one() {
 
     if [[ ! -f "$dst" ]]; then
         # Fresh install — just copy.
-        cp "$src" "$dst" && chmod +x "$dst" || { _warn "cp failed for $name"; return 1; }
+        _atomic_install "$src" "$dst" || { _warn "cp failed for $name"; return 1; }
         _log "installed: $name"
         SYNCED=$((SYNCED + 1))
         return 0
@@ -127,7 +162,7 @@ _sync_one() {
     fi
 
     if [[ $is_known_prior -eq 1 ]]; then
-        cp "$src" "$dst" && chmod +x "$dst" || { _warn "cp failed for $name"; return 1; }
+        _atomic_install "$src" "$dst" || { _warn "cp failed for $name"; return 1; }
         _log "updated: $name (was stale prior version)"
         SYNCED=$((SYNCED + 1))
     else
@@ -154,7 +189,7 @@ _sync_helper() {
     src_hash=$(_sha256_of "$src")
 
     if [[ ! -f "$dst" ]]; then
-        cp "$src" "$dst" && chmod +x "$dst" || { _warn "cp failed for helper $name"; return 1; }
+        _atomic_install "$src" "$dst" || { _warn "cp failed for helper $name"; return 1; }
         _log "installed helper: $name"
         SYNCED=$((SYNCED + 1))
         return 0
@@ -166,7 +201,7 @@ _sync_helper() {
     fi
 
     # Helper drift — always overwrite.
-    cp "$src" "$dst" && chmod +x "$dst" || { _warn "cp failed for helper $name"; return 1; }
+    _atomic_install "$src" "$dst" || { _warn "cp failed for helper $name"; return 1; }
     _log "updated helper: $name"
     SYNCED=$((SYNCED + 1))
 }

--- a/scripts/update_hook_versions.sh
+++ b/scripts/update_hook_versions.sh
@@ -21,8 +21,8 @@ set -o pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 VERSIONS_FILE="$REPO_ROOT/.genesis-hook-versions"
 
-# Hooks we track. Keep in lockstep with check_hook_versions.sh and
-# sync-hooks.sh HOOKS_TO_SYNC.
+# Hooks we track. Keep in lockstep with check_hook_versions.sh,
+# check_hook_versions_complete.sh, and sync-hooks.sh HOOKS_TO_SYNC.
 TRACKED_HOOKS=(commit-msg post-commit pre-commit prepare-commit-msg pre-push)
 
 if [[ ! -f "$VERSIONS_FILE" ]]; then

--- a/tests/test_hooks/test_hook_versions_complete.py
+++ b/tests/test_hooks/test_hook_versions_complete.py
@@ -1,0 +1,125 @@
+"""Regression tests for scripts/check_hook_versions_complete.sh (PR-4).
+
+The checker walks the FULL git history of every tracked hook and fails if any
+shipped version's sha256 is absent from .genesis-hook-versions — the gap that
+wedges a community install (sync-hooks.sh mis-labels an unrecorded hash as
+"user-modified" and never updates it). These tests build hermetic throwaway
+repos so they never depend on the real repo's history, plus one guard that the
+real tree stays complete.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_hook_versions_complete.sh"
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "t@t.t")
+    _git(path, "config", "user.name", "t")
+    _git(path, "config", "commit.gpgsign", "false")
+    (path / "scripts" / "hooks").mkdir(parents=True, exist_ok=True)
+    shutil.copy(_SCRIPT, path / "scripts" / "check_hook_versions_complete.sh")
+
+
+def _write_hook(path: Path, name: str, body: str) -> str:
+    """Write a hook version, commit it, return its sha256."""
+    f = path / "scripts" / "hooks" / name
+    f.write_text(body)
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", f"hook {name}: {body[:8]}", "--no-verify")
+    return hashlib.sha256(body.encode()).hexdigest()
+
+
+def _run(path: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "scripts/check_hook_versions_complete.sh"],
+        cwd=path,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_detects_unrecorded_version(tmp_path: Path) -> None:
+    """Two versions ship but only the latest is recorded → exit 1, names the gap."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    old_hash = _write_hook(repo, "pre-commit", "#v1\n")
+    new_hash = _write_hook(repo, "pre-commit", "#v2\n")
+    # Ledger records ONLY the current version — the intermediate one is the gap.
+    (repo / ".genesis-hook-versions").write_text(f"pre-commit:{new_hash}\n")
+
+    result = _run(repo)
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert old_hash in result.stderr  # the missing version is reported
+    assert new_hash not in result.stderr  # the recorded one is not flagged
+
+
+def test_passes_when_all_recorded(tmp_path: Path) -> None:
+    """Every shipped version recorded → exit 0."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    h1 = _write_hook(repo, "pre-commit", "#v1\n")
+    h2 = _write_hook(repo, "pre-commit", "#v2\n")
+    (repo / ".genesis-hook-versions").write_text(f"pre-commit:{h1}\npre-commit:{h2}\n")
+
+    result = _run(repo)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_skips_on_shallow_clone(tmp_path: Path) -> None:
+    """A shallow clone can't see history → skip (exit 0), never a false pass/fail."""
+    origin = tmp_path / "origin"
+    _init_repo(origin)
+    _write_hook(origin, "pre-commit", "#v1\n")
+    _write_hook(origin, "pre-commit", "#v2\n")
+    # Record NOTHING — on a full clone this would fail; a shallow clone must skip.
+    (origin / ".genesis-hook-versions").write_text("# empty\n")
+    _git(origin, "add", "-A")
+    _git(origin, "commit", "-q", "-m", "ledger", "--no-verify")
+
+    shallow = tmp_path / "shallow"
+    subprocess.run(
+        ["git", "clone", "--depth", "1", "-q", origin.as_uri(), str(shallow)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    # The clone's script came from origin's tip; ensure it's present.
+    assert (shallow / "scripts" / "check_hook_versions_complete.sh").is_file()
+
+    result = _run(shallow)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "shallow" in result.stdout.lower()
+
+
+def test_real_tree_is_complete() -> None:
+    """The actual repo's ledger records every shipped hook version (skip if shallow)."""
+    is_shallow = subprocess.run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if is_shallow == "true":
+        pytest.skip("shallow clone — completeness is enforced by the fetch-depth:0 CI job")
+    result = subprocess.run(
+        ["bash", str(_SCRIPT)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_hooks/test_hook_versions_complete.py
+++ b/tests/test_hooks/test_hook_versions_complete.py
@@ -39,7 +39,7 @@ def _write_hook(path: Path, name: str, body: str) -> str:
     """Write a hook version, commit it, return its sha256."""
     f = path / "scripts" / "hooks" / name
     f.write_text(body)
-    _git(path, "add", "-A")
+    _git(path, "add", f"scripts/hooks/{name}")
     _git(path, "commit", "-q", "-m", f"hook {name}: {body[:8]}", "--no-verify")
     return hashlib.sha256(body.encode()).hexdigest()
 
@@ -88,7 +88,9 @@ def test_skips_on_shallow_clone(tmp_path: Path) -> None:
     _write_hook(origin, "pre-commit", "#v2\n")
     # Record NOTHING — on a full clone this would fail; a shallow clone must skip.
     (origin / ".genesis-hook-versions").write_text("# empty\n")
-    _git(origin, "add", "-A")
+    # Stage the ledger and the (copied-but-uncommitted) checker script explicitly,
+    # so the depth-1 clone's tip carries both.
+    _git(origin, "add", ".genesis-hook-versions", "scripts/check_hook_versions_complete.sh")
     _git(origin, "commit", "-q", "-m", "ledger", "--no-verify")
 
     shallow = tmp_path / "shallow"
@@ -104,6 +106,50 @@ def test_skips_on_shallow_clone(tmp_path: Path) -> None:
     result = _run(shallow)
     assert result.returncode == 0, result.stdout + result.stderr
     assert "shallow" in result.stdout.lower()
+
+
+def test_fails_closed_on_unreadable_history(tmp_path: Path) -> None:
+    """A version whose blob object is UNREADABLE (partial clone / corruption) must
+    ERROR, not be silently skipped as 'path absent' → the backstop would false-pass.
+
+    Deterministic: commit two versions, record BOTH (so a healthy repo PASSES),
+    then delete the loose object for the historical v1 blob. The tree still names
+    the path (ls-tree succeeds) but `git show` on the blob fails → fail closed.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    h1 = _write_hook(repo, "pre-commit", "#v1\n")
+    h2 = _write_hook(repo, "pre-commit", "#v2\n")
+    # Record BOTH versions: on a healthy repo this PASSES. The only way it can exit
+    # non-zero is the fail-closed read-failure path (not a real ledger gap).
+    (repo / ".genesis-hook-versions").write_text(f"pre-commit:{h1}\npre-commit:{h2}\n")
+
+    # Locate v1's blob object and delete it (loose in a fresh repo — no repack yet).
+    blob = subprocess.run(
+        ["git", "rev-parse", "HEAD~1:scripts/hooks/pre-commit"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    obj = repo / ".git" / "objects" / blob[:2] / blob[2:]
+    if not obj.is_file():
+        pytest.skip("v1 blob is packed, not loose — cannot deterministically remove it")
+    obj.unlink()
+
+    # Sanity: the tree still names the path, but the blob is now unreadable.
+    assert (
+        subprocess.run(
+            ["git", "show", "HEAD~1:scripts/hooks/pre-commit"], cwd=repo, capture_output=True
+        ).returncode
+        != 0
+    )
+
+    result = _run(repo)
+    assert result.returncode == 1, (
+        f"expected fail-closed, got {result.returncode}: {result.stdout}{result.stderr}"
+    )
+    assert "verify" in result.stderr.lower() or "unreadable" in result.stderr.lower()
 
 
 def test_real_tree_is_complete() -> None:


### PR DESCRIPTION
## Summary

Hardens Genesis's Phase-6 git-hook self-heal (`scripts/hooks/sync-hooks.sh`), which
copies tracked git hooks into the shared `$GIT_COMMON_DIR/hooks` at every session
start so users who `git pull` pick up hook updates without re-running `bootstrap.sh`.

Two latent bugs and one robustness fix:

### 1. Worktree race
A session started inside a **linked git worktree** ran that worktree's copy of the
sync with `HOOKS_SRC=<worktree>/scripts/hooks` but `HOOKS_DST=<shared>/.git/hooks` —
so a worktree on an older or feature branch could overwrite the shared hooks for
**every** working tree. Now the sync **skips when it detects a linked worktree**
(`git rev-parse --git-dir` != `--git-common-dir`, resolved to absolute paths); only
the main worktree owns the shared hooks. The main-checkout case is unchanged, so a
normal clone still auto-updates.

### 2. Hook-version ledger completeness
`.genesis-hook-versions` records the sha256 of every hook version ever shipped;
`sync-hooks.sh` treats a destination hook whose hash is **not** in the ledger as
"user-modified" and leaves it alone. Four versions that shipped on `main` were never
recorded, so an install still carrying one of them is wedged — the sync keeps
skipping it and it never receives the fixed hook.

- **Backfill** the four missing hashes.
- **Class fix:** `scripts/check_hook_versions_complete.sh` walks the full git history
  of every tracked hook and fails if any shipped version is missing from the ledger.
  The per-commit gate (`check_hook_versions.sh`) only records the *current* tree, so
  an intermediate version committed without `update_hook_versions.sh` slips through;
  this backstop catches it. It **requires full history** (skips gracefully on a
  shallow clone) and runs as a dedicated `fetch-depth: 0` CI job, `hook-versions-check`.

### 3. Atomic hook install
The copy sites in `sync-hooks.sh` now write to a temp file in the destination
directory and `mv` it into place, so a concurrent reader — or git firing the hook
mid-copy — never observes a half-written, partially-executable hook.

## Tests
`tests/test_hooks/test_hook_versions_complete.py` builds hermetic throwaway repos:
a negative case (an unrecorded intermediate version → the checker fails and names
the gap), a shallow-clone case (→ graceful skip), and a guard that the real tree's
ledger stays complete.

## Verification
- Worktree-skip verified live in both directions (linked worktree skips and leaves
  shared hooks byte-identical; main checkout syncs normally).
- The atomic install / known-prior update / user-modified skip / fresh-install paths
  verified against a hermetic repo.
- `check_hook_versions_complete.sh` passes on the current tree; the four backfilled
  hashes each resolve to a real historical commit.
- `shellcheck`, `ruff`, and `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
