### PR TITLE
fix(contribution): gh secret set reads value from stdin (no --body-file)

### DIFF
--- a/src/genesis/contribution/fingerprints.py
+++ b/src/genesis/contribution/fingerprints.py
@@ -459,7 +459,9 @@ def sync_secret(
     print(f"  fingerprints: syncing {len(patterns)} pattern(s) to the CI secret on {slug}")
     try:
         proc = subprocess.run(
-            ["gh", "secret", "set", SECRET_NAME, "--repo", slug, "--body-file", "-"],
+            # gh reads the secret VALUE from stdin when --body is omitted (there
+            # is no --body-file flag); pass it via input= so it never hits argv.
+            ["gh", "secret", "set", SECRET_NAME, "--repo", slug],
             input=body,
             capture_output=True,
             text=True,

--- a/tests/test_contribution/test_fingerprints.py
+++ b/tests/test_contribution/test_fingerprints.py
@@ -390,8 +390,14 @@ def test_sync_secret_success(tmp_path, monkeypatch):
     ok = fp.sync_secret(path=fpfile, repo_root=Path("/srv/genesis"), home=home)
     assert ok is True
     secret_call = next(c for c in calls if c[0][1] == "secret")
-    assert "Owner/PubRepo" in secret_call[0]  # --repo carries the resolved slug
-    assert "zorrik" in secret_call[1]  # body passed via stdin
+    cmd = secret_call[0]
+    assert "Owner/PubRepo" in cmd  # --repo carries the resolved slug
+    assert "zorrik" in secret_call[1]  # body passed via stdin (input=)
+    # Contract lock (real gh has no --body-file; value must go via stdin, never
+    # argv). Guards the mock-hid-the-flag bug that shipped in the first cut.
+    assert "--body-file" not in cmd
+    assert not any(str(a).startswith("--body") for a in cmd)
+    assert "zorrik" not in " ".join(cmd)  # value never on the command line
 
 
 def test_sync_secret_repo_mismatch_skips(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

The secret-sync added in #1272 invoked `gh secret set … --body-file -`. That flag does not exist in the shipped `gh` — the secret value is read from **stdin** when `--body` is omitted. The call therefore failed at runtime (non-fatal: it logged and skipped), so the `GENESIS_PRIVATE_PATTERNS` Actions secret was never populated.

## Why the tests missed it

The unit tests mock `subprocess.run`, so they verified the code's control flow but not the real `gh` CLI contract — the value already flowed via `input=` (stdin), which is correct; only the extra bogus flag was wrong. Caught by an end-to-end run against real `gh` during post-merge verification.

## Fix

- Drop `--body-file -`; the value flows via `input=` (stdin), never argv.
- Add a contract-lock assertion to `test_sync_secret_success`: the command must not contain `--body-file` or any `--body*`, and the secret value must never appear on the command line.

Verified against real `gh`: the secret now sets (`GENESIS_PRIVATE_PATTERNS` present on the repo). Follow-on to #1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)