### PR TITLE
fix(learning): skill-evolution is propose-only — stop autonomous auto-apply

### DIFF
--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -130,7 +130,6 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "learning": timedelta(days=14),
     "learning_regression": timedelta(days=14),
     "skill_evolution": timedelta(days=14),
-    "skill_proposal": timedelta(days=14),
     "scope_clarification": timedelta(days=14),
     "interpretation_correction": timedelta(days=14),
     "merged_observation": timedelta(days=14),
@@ -167,6 +166,11 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     # stays visible for adjudication.
     "skill_replay_verdict": timedelta(days=30),
     # ── 60-day (action-required, real issues) ──────────────────────────
+    # skill_proposal: the propose-only human-review queue — an autonomous skill
+    # edit staged for a human/CC to review + apply. Must NOT self-erase quickly
+    # (resolve_expired auto-resolves on TTL), which would silently empty the
+    # only safety queue; 60d gives real review headroom.
+    "skill_proposal": timedelta(days=60),
     "bug_identified": timedelta(days=60),
     "tech_debt": timedelta(days=60),
     "architecture_risk": timedelta(days=60),
@@ -586,6 +590,7 @@ async def exists_recent_by_type(
     source: str,
     type: str,
     window_minutes: int = 30,
+    category: str | None = None,
     category_like: str | None = None,
     category_not_like: str | None = None,
 ) -> bool:
@@ -593,6 +598,8 @@ async def exists_recent_by_type(
 
     Used as a cooldown gate to prevent near-duplicate observations from
     LLM reflections that produce different wording for the same system state.
+    ``category`` scopes the check to an EXACT category (use this when the value
+    may contain SQL ``LIKE`` metacharacters, e.g. a skill name with ``_``).
     ``category_like`` / ``category_not_like`` scope the check to categories
     matching (or not matching) a SQL LIKE pattern (e.g. ``"%:user"``) so
     cooldowns can mirror an ego-visibility partition — a reflection visible to
@@ -608,6 +615,9 @@ async def exists_recent_by_type(
         "AND created_at > ? "
     )
     params: list = [source, type, cutoff]
+    if category is not None:
+        query += "AND category = ? "
+        params.append(category)
     if category_like is not None:
         query += "AND category LIKE ? "
         params.append(category_like)

--- a/src/genesis/db/data_migrations/d0009_backfill_skill_proposal_dampening.py
+++ b/src/genesis/db/data_migrations/d0009_backfill_skill_proposal_dampening.py
@@ -1,0 +1,94 @@
+"""d0009 — align pre-existing skill_proposal observations to propose-only.
+
+Two upgrade-path gaps for ``skill_proposal`` observations created by the OLD
+skill-evolution applicator (before propose-only shipped), both flagged in review:
+
+1. ``category`` was never stamped (NULL). The new dampening gate matches an
+   EXACT ``category = skill_name`` (see ``pipeline._has_pending_proposal``), so a
+   NULL-category proposal is missed → a one-off duplicate re-proposal on upgrade.
+2. ``expires_at`` was persisted at the old 14-day TTL. Changing ``_TTL_BY_TYPE``
+   only affects NEW ``observations.create()`` calls, so an existing unresolved
+   proposal keeps its early expiry instead of the new 60-day review window and
+   would auto-resolve (``resolve_expired``) before a human reviews it.
+
+Heals both on every install (idempotent, post-boot), tightly scoped to
+UNRESOLVED ``skill_proposal`` rows. A fresh install (no such rows) is a clean
+no-op. Sync ``migrate()``/``verify()`` on their own connections (framework
+contract, cf. d0007) — never the runtime's async ``rt._db``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timedelta
+
+from genesis.env import genesis_db_path
+
+logger = logging.getLogger(__name__)
+
+requires_operator = False
+
+_NEW_TTL_DAYS = 60
+
+
+def migrate() -> dict:
+    """Backfill ``category`` (from ``content.skill_name``) and extend
+    ``expires_at`` to ``created_at`` + 60d for unresolved skill_proposal rows."""
+    db = sqlite3.connect(genesis_db_path(), timeout=30.0)
+    try:
+        # 1. category = skill_name where missing (parsed from the content JSON).
+        cur = db.execute(
+            "UPDATE observations "
+            "SET category = json_extract(content, '$.skill_name') "
+            "WHERE type = 'skill_proposal' AND resolved = 0 AND category IS NULL "
+            "AND json_valid(content) "
+            "AND json_extract(content, '$.skill_name') IS NOT NULL"
+        )
+        category_filled = cur.rowcount
+
+        # 2. Extend expires_at to created_at + 60d where the persisted expiry is
+        #    sooner. Computed in Python — matches observations.create()'s
+        #    (fromisoformat(created_at) + ttl).isoformat() — to avoid SQLite
+        #    datetime() ISO/timezone edge cases.
+        rows = db.execute(
+            "SELECT id, created_at, expires_at FROM observations "
+            "WHERE type = 'skill_proposal' AND resolved = 0"
+        ).fetchall()
+        expires_bumped = 0
+        for oid, created_at, expires_at in rows:
+            try:
+                target = (
+                    datetime.fromisoformat(created_at) + timedelta(days=_NEW_TTL_DAYS)
+                ).isoformat()
+            except (TypeError, ValueError):
+                continue
+            if expires_at is None or expires_at < target:
+                db.execute("UPDATE observations SET expires_at = ? WHERE id = ?", (target, oid))
+                expires_bumped += 1
+        db.commit()
+    finally:
+        db.close()
+    logger.info(
+        "d0009: skill_proposal category_filled=%d, expires_at_bumped=%d",
+        category_filled,
+        expires_bumped,
+    )
+    return {"category_filled": category_filled, "expires_at_bumped": expires_bumped}
+
+
+def verify() -> bool:
+    """Complete when no unresolved skill_proposal that has a ``content.skill_name``
+    still lacks a ``category`` (the dampening-correctness invariant). Read via
+    ``mode=ro`` (WAL-aware) so it sees migrate()'s just-committed write."""
+    db = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
+    try:
+        (null_cat,) = db.execute(
+            "SELECT COUNT(*) FROM observations "
+            "WHERE type = 'skill_proposal' AND resolved = 0 AND category IS NULL "
+            "AND json_valid(content) "
+            "AND json_extract(content, '$.skill_name') IS NOT NULL"
+        ).fetchone()
+        return null_cat == 0
+    finally:
+        db.close()

--- a/src/genesis/learning/skills/applicator.py
+++ b/src/genesis/learning/skills/applicator.py
@@ -1,4 +1,16 @@
-"""Skill applicator — applies or stages skill improvement proposals."""
+"""Skill applicator — stages skill improvement proposals for human review.
+
+**Propose-only.** Autonomous skill-evolution NEVER writes a skill file. Every
+proposal — MINOR or larger — is *staged* for a human / CC session to review and
+apply through the normal worktree/PR flow. The structural validator result, the
+MODERATE+ apply-recommendation, and the shadow Critic verdict all ride the staged
+proposal (with the full proposed content) so a reviewer can decide.
+
+Gated auto-apply is deferred to the future WS1 ``enforce`` mode; the autonomy
+level, validator wiring, and provenance capture below are retained for that path.
+(Origin: 2026-08-01 — the auto-apply seam repeatedly landed principle-violating
+edits that the shadow Critic flagged but could not block.)
+"""
 
 from __future__ import annotations
 
@@ -8,7 +20,6 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from genesis.learning.cognitive_ledger import record_file_modification
 from genesis.learning.skills.types import ChangeSize, SkillProposal
 from genesis.learning.skills.validator import SkillValidator
 
@@ -17,12 +28,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# GROUNDWORK(skill-autonomy-graduation): autonomy_state category skill_evolution, starts L2
+# GROUNDWORK(skill-autonomy-graduation): autonomy_state category skill_evolution,
+# starts L2. Retained for the future WS1 `enforce` mode that re-enables gated
+# auto-apply; under propose-only every change size is staged for human review.
 _DEFAULT_AUTONOMY_LEVEL = 2
 
 
 class SkillApplicator:
-    """Applies or stages skill proposals based on change size and autonomy level."""
+    """Stages skill proposals for human review (propose-only)."""
 
     def __init__(self, *, autonomy_level: int = _DEFAULT_AUTONOMY_LEVEL):
         self._autonomy_level = autonomy_level
@@ -30,12 +43,9 @@ class SkillApplicator:
 
     @staticmethod
     def _build_modification_metadata(proposal: SkillProposal) -> dict:
-        """Metadata recorded with a skill mutation in the cognitive-mod ledger.
-
-        Captures *why* the skill changed — the triggering signals
-        (failure_patterns_addressed + the SkillReport-derived provenance trace) —
-        not just the diff, so a degrading edit can be understood and rolled back.
-        """
+        """Provenance recorded with a staged proposal — the triggering signals
+        (failure_patterns_addressed + the SkillReport-derived trace), so an
+        eventually-applied edit can be understood and rolled back."""
         return {
             "skill_name": proposal.skill_name,
             "change_size": proposal.change_size.value,
@@ -52,116 +62,99 @@ class SkillApplicator:
         router: object | None = None,
         current_content: str | None = None,
     ) -> dict:
-        """Apply or stage a skill proposal.
+        """Stage a skill proposal for human review — never writes a skill file.
 
-        At L2: MINOR auto-applies (if validation passes), MODERATE+ staged for review.
+        Propose-only: MINOR and larger alike are staged. Autonomous auto-apply is
+        retired here; it returns via the future WS1 ``enforce`` mode.
 
         Args:
-            proposal: The skill proposal to apply or stage.
+            proposal: The skill proposal to stage.
             db: Database connection.
-            router: LLM router for MODERATE+ validation (optional).
-            current_content: Current SKILL.md content for consistency checking.
+            router: LLM router for the MODERATE+ apply-recommendation + the Critic.
+            current_content: Current SKILL.md content (Critic baseline + validation).
         """
         now = datetime.now(UTC).isoformat()
 
-        if proposal.change_size == ChangeSize.MINOR and self._autonomy_level >= 2:  # noqa: PLR2004
-            # Validate before auto-applying
-            validation = self._validator.validate(proposal, current_content)
+        # Structural validation — informs the reviewer (and the future enforce gate).
+        validation = self._validator.validate(proposal, current_content)
+        # `validated` = passed the applicable gate: the structural validator for
+        # MINOR, the LLM apply-recommendation for MODERATE+ (False when there is no
+        # router to run it). Same semantics as before, now on the staging path.
+        if proposal.change_size == ChangeSize.MINOR:
+            validated = validation.passed
+        elif router is not None:
+            validated = await self._llm_validate(proposal, router=router)
+        else:
+            validated = False
 
-            if not validation.passed:
-                logger.info(
-                    "MINOR proposal for %s failed validation (%s), staging for review",
-                    proposal.skill_name,
-                    validation.blocking_failures,
-                )
-                # Fall through to staging path
-                return await self._stage(
-                    proposal,
-                    db,
-                    validated=False,
-                    now=now,
-                    validation_detail=validation.test_results,
-                )
+        # Shadow Critic (WS1): screens for self-modification pathologies. Under
+        # propose-only this is pure ENRICHMENT — it logs the WS1 shadow observation
+        # AND its verdict rides the staged proposal for the reviewer. It never
+        # gates anything (nothing auto-applies).
+        critic = await self._run_critic(
+            proposal, db, router=router, current_content=current_content, now=now
+        )
 
-            # Auto-apply MINOR changes that pass validation
-            from genesis.learning.skills.wiring import get_skill_path
+        return await self._stage(
+            proposal,
+            db,
+            validated=validated,
+            now=now,
+            validation_detail=None if validation.passed else validation.test_results,
+            validation_warnings=(validation.warnings or None),
+            critic=critic,
+        )
 
-            path = get_skill_path(proposal.skill_name)
-            if path is None:
-                return {"action": "failed", "reason": "skill not found"}
+    async def _run_critic(
+        self,
+        proposal: SkillProposal,
+        db: aiosqlite.Connection,
+        *,
+        router: object | None,
+        current_content: str | None,
+        now: str,
+    ) -> dict | None:
+        """Run the shadow Critic, log the WS1 observation, return the verdict.
 
-            # Route the overwrite through the cognitive self-mod ledger so the
-            # pre-image is captured and a degrading skill edit can be rolled back.
-            await record_file_modification(
-                db,
-                actor="skill_evolution",
-                path=path,
-                new_content=proposal.proposed_content,
-                summary=f"MINOR auto-apply: {proposal.rationale[:200]}",
-                metadata=self._build_modification_metadata(proposal),
+        Best-effort — a judge problem must never disturb staging. Returns the
+        verdict dict (to ride the proposal) or ``None`` (gate off / no router /
+        no baseline / judge unavailable).
+        """
+        from genesis.db.crud import observations
+
+        try:
+            from genesis.learning.skills.skill_edit_critic import run_critic
+
+            critic = await run_critic(
+                current_content=current_content, proposal=proposal, router=router
             )
-
-            # Log observation (include validation warnings if any)
-            from genesis.db.crud import observations
-
-            obs_content = {
-                "skill_name": proposal.skill_name,
-                "change_size": proposal.change_size.value,
-                "rationale": proposal.rationale,
-                "confidence": proposal.confidence,
-            }
-            if validation.warnings:
-                obs_content["validation_warnings"] = validation.warnings
-
+        except Exception:
+            logger.warning(
+                "skill-edit Critic failed for %s (staging unaffected)",
+                proposal.skill_name,
+                exc_info=True,
+            )
+            return None
+        if critic is None:
+            return None
+        try:
             await observations.create(
                 db,
                 id=str(uuid.uuid4()),
-                source="skill_evolution",
-                type="skill_evolution",
-                content=json.dumps(obs_content),
-                priority="medium",
+                source="skill_evolution_gate",
+                type="skill_edit_critic",
+                category=proposal.skill_name,  # indexed dampening/dedup key
+                content=json.dumps(critic),
+                priority=("high" if critic.get("verdict") == "flagged" else "low"),
                 created_at=now,
             )
-
-            # Shadow skill-edit Critic (WS1): screen the edit for self-modification
-            # pathologies AFTER it has been applied. Pure telemetry — a judge
-            # problem must never disturb the auto-apply, so the whole block is
-            # best-effort and the verdict NEVER gates the edit (shadow invariant).
-            try:
-                from genesis.learning.skills.skill_edit_critic import run_critic
-
-                critic = await run_critic(
-                    current_content=current_content,
-                    proposal=proposal,
-                    router=router,
-                )
-                if critic is not None:
-                    await observations.create(
-                        db,
-                        id=str(uuid.uuid4()),
-                        source="skill_evolution_gate",
-                        type="skill_edit_critic",
-                        content=json.dumps(critic),
-                        priority=("high" if critic.get("verdict") == "flagged" else "low"),
-                        created_at=now,
-                    )
-            except Exception:
-                logger.warning(
-                    "skill-edit Critic (shadow) failed for %s; edit already applied",
-                    proposal.skill_name,
-                    exc_info=True,
-                )
-
-            logger.info("Auto-applied MINOR skill change to %s", proposal.skill_name)
-            return {"action": "applied", "skill_name": proposal.skill_name}
-
-        else:
-            # Stage MODERATE+ for review (or any change if autonomy < 2)
-            validated = False
-            if proposal.change_size != ChangeSize.MINOR and router:
-                validated = await self._llm_validate(proposal, router=router)
-
-            return await self._stage(proposal, db, validated=validated, now=now)
+        except Exception:
+            logger.warning(
+                "failed to log skill_edit_critic observation for %s",
+                proposal.skill_name,
+                exc_info=True,
+            )
+        return critic
 
     async def _stage(
         self,
@@ -171,8 +164,15 @@ class SkillApplicator:
         validated: bool,
         now: str,
         validation_detail: dict[str, str] | None = None,
+        validation_warnings: list[str] | None = None,
+        critic: dict | None = None,
     ) -> dict:
-        """Stage a proposal for user review."""
+        """Stage a proposal for human review — persists the FULL proposed content.
+
+        The full ``proposed_content`` is stored so the proposal is applicable by a
+        reviewer / CC session; a short preview + the Critic verdict are what a
+        surfacing view should show.
+        """
         from genesis.db.crud import observations
 
         content = {
@@ -181,35 +181,54 @@ class SkillApplicator:
             "rationale": proposal.rationale,
             "confidence": proposal.confidence,
             "validated": validated,
+            # Full body — required so the staged proposal can actually be applied.
+            "proposed_content": proposal.proposed_content,
             "proposed_content_preview": proposal.proposed_content[:500],
+            "provenance": self._build_modification_metadata(proposal),
         }
         if validation_detail:
             content["validation_detail"] = validation_detail
+        if validation_warnings:
+            content["validation_warnings"] = validation_warnings
+        if critic is not None:
+            # The reviewer's key signal — the pathology screen verdict.
+            content["critic"] = {
+                "verdict": critic.get("verdict"),
+                "score": critic.get("score"),
+                "rationale": critic.get("rationale"),
+                "pathologies": critic.get("pathologies"),
+            }
+
+        flagged = bool(critic and critic.get("verdict") == "flagged")
+        priority = "high" if (proposal.change_size == ChangeSize.MAJOR or flagged) else "medium"
 
         await observations.create(
             db,
             id=str(uuid.uuid4()),
             source="skill_evolution",
             type="skill_proposal",
+            category=proposal.skill_name,  # indexed dampening/dedup key
             content=json.dumps(content),
-            priority="high" if proposal.change_size == ChangeSize.MAJOR else "medium",
+            priority=priority,
             created_at=now,
         )
 
         logger.info(
-            "Staged %s skill proposal for %s (validated=%s)",
+            "Staged %s skill proposal for %s (validated=%s, critic=%s)",
             proposal.change_size.value,
             proposal.skill_name,
             validated,
+            (critic or {}).get("verdict"),
         )
         return {
             "action": "staged",
             "skill_name": proposal.skill_name,
             "validated": validated,
+            "critic_verdict": (critic or {}).get("verdict"),
         }
 
     async def _llm_validate(self, proposal: SkillProposal, *, router: object) -> bool:
-        """Validate a MODERATE+ proposal with a second LLM call."""
+        """Validate a MODERATE+ proposal with a second LLM call (apply-recommendation)."""
         prompt = (
             f"Review this skill change proposal and determine if it should be applied.\n\n"
             f"Skill: {proposal.skill_name}\n"

--- a/src/genesis/learning/skills/pipeline.py
+++ b/src/genesis/learning/skills/pipeline.py
@@ -55,11 +55,22 @@ class SkillEvolutionPipeline:
         proposed = 0
         applied = 0
         staged = 0
+        suppressed = 0
 
         for report in needs_review:
             content = load_skill(report.skill_name)
             if content is None:
                 logger.warning("Skill %s has no SKILL.md, skipping", report.skill_name)
+                continue
+
+            # Dampening: skip (and save the refiner LLM call) if an unresolved
+            # proposal for this skill is already awaiting human review.
+            if await self._has_pending_proposal(report.skill_name):
+                logger.info(
+                    "Skipping %s — an unresolved skill proposal is already pending review",
+                    report.skill_name,
+                )
+                suppressed += 1
                 continue
 
             proposal = await self._refiner.propose(
@@ -88,6 +99,7 @@ class SkillEvolutionPipeline:
             "proposed": proposed,
             "applied": applied,
             "staged": staged,
+            "suppressed": suppressed,
         }
         logger.info("Skill evolution pipeline: %s", summary)
         return summary
@@ -107,6 +119,13 @@ class SkillEvolutionPipeline:
         if content is None:
             return None
 
+        # Dampening: skip if an unresolved proposal for this skill already awaits review.
+        if await self._has_pending_proposal(skill_name):
+            logger.info(
+                "Skipping proposal for %s — one is already pending review", skill_name
+            )
+            return {"action": "suppressed", "skill_name": skill_name, "reason": "pending_proposal"}
+
         proposal = await self._refiner.propose(
             report, content, router=self._router,
         )
@@ -122,6 +141,36 @@ class SkillEvolutionPipeline:
             await self._notify_proposal(proposal)
 
         return result
+
+    async def _has_pending_proposal(self, skill_name: str) -> bool:
+        """True if an UNRESOLVED skill proposal already awaits review for this skill.
+
+        Propose-only dampening: don't re-propose (or spend the refiner LLM call)
+        while a prior proposal for the same skill is still pending review. The
+        window matches the ``skill_proposal`` 60d TTL so a pending proposal
+        suppresses for its full review life. Indexed on ``observations.category``
+        (stamped = ``skill_name``). Fails open (proceeds) on a query error — a
+        staged proposal is low-harm under propose-only.
+        """
+        from genesis.db.crud import observations
+
+        try:
+            return await observations.exists_recent_by_type(
+                self._db,
+                source="skill_evolution",
+                type="skill_proposal",
+                window_minutes=60 * 24 * 60,  # 60 days — matches the proposal TTL
+                # EXACT match — skill names can contain SQL LIKE metacharacters
+                # (e.g. `user_evaluate`), so a LIKE would over-suppress siblings.
+                category=skill_name,
+            )
+        except Exception:
+            logger.warning(
+                "dampening check failed for %s; proceeding with proposal",
+                skill_name,
+                exc_info=True,
+            )
+            return False
 
     async def _notify_proposal(self, proposal: SkillProposal) -> None:
         """Send outreach notification for a staged proposal."""

--- a/src/genesis/mcp/health/skill_replay_run.py
+++ b/src/genesis/mcp/health/skill_replay_run.py
@@ -31,7 +31,14 @@ def _default_suite_path(skill_name: str) -> Path:
 
 async def _resolve_ledger_old_content(db, target_path: str) -> str | None:
     """OLD content = ``prior_content`` of the most-recent ``skill_evolution`` edit
-    to ``target_path`` (the pre-image the applicator captured before overwriting)."""
+    to ``target_path`` (the pre-image the applicator captured before overwriting).
+
+    DORMANT UNDER PROPOSE-ONLY (2026-08-01): the skill-evolution pipeline no longer
+    auto-writes skill files, so no ``skill_evolution`` ledger pre-image is created —
+    this returns None for auto-fired edits and the replay gate then has no OLD
+    baseline. Re-source OLD = current-on-disk / NEW = the staged proposal's
+    ``proposed_content`` when wiring the future WS1 ``enforce`` mode (tracked as a
+    follow-up). Callers may still pass OLD content explicitly in the meantime."""
     if db is None:
         return None
     try:

--- a/tests/test_db/test_d0009_backfill_skill_proposal_dampening.py
+++ b/tests/test_db/test_d0009_backfill_skill_proposal_dampening.py
@@ -1,0 +1,108 @@
+"""d0009 — align pre-existing skill_proposal observations to propose-only.
+
+Pre-propose-only proposal rows carry category=NULL (the exact-match dampening
+misses them) and a 14d expiry (they'd auto-resolve before review). This migration
+backfills category from content.skill_name and extends expires_at to
+created_at + 60d, scoped to UNRESOLVED skill_proposal rows only.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta
+
+import genesis.db.data_migrations.d0009_backfill_skill_proposal_dampening as d0009
+
+
+def _seed(path, rows) -> None:
+    db = sqlite3.connect(path)
+    db.execute(
+        "CREATE TABLE observations (id TEXT PRIMARY KEY, type TEXT, resolved INTEGER, "
+        "category TEXT, content TEXT, created_at TEXT, expires_at TEXT)"
+    )
+    db.executemany(
+        "INSERT INTO observations "
+        "(id, type, resolved, category, content, created_at, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    db.commit()
+    db.close()
+
+
+def test_backfills_category_and_extends_expiry(tmp_path, monkeypatch):
+    created = "2026-07-25T00:00:00+00:00"
+    old_expiry = "2026-08-08T00:00:00+00:00"  # created + 14d
+    new_expiry = (datetime.fromisoformat(created) + timedelta(days=60)).isoformat()
+    _seed(
+        tmp_path / "genesis.db",
+        [
+            # old-style unresolved proposal: NULL category, 14d expiry
+            (
+                "p-old",
+                "skill_proposal",
+                0,
+                None,
+                json.dumps({"skill_name": "voice-master", "proposed_content": "x"}),
+                created,
+                old_expiry,
+            ),
+            # already-stamped proposal — category + expiry untouched
+            (
+                "p-new",
+                "skill_proposal",
+                0,
+                "aws-fde",
+                json.dumps({"skill_name": "aws-fde"}),
+                created,
+                new_expiry,
+            ),
+            # resolved proposal — untouched (only unresolved rows are healed)
+            (
+                "p-done",
+                "skill_proposal",
+                1,
+                None,
+                json.dumps({"skill_name": "gone"}),
+                created,
+                old_expiry,
+            ),
+            # unrelated observation type — untouched
+            ("o-other", "bug_identified", 0, None, "not json", created, old_expiry),
+        ],
+    )
+    monkeypatch.setattr(d0009, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+
+    assert d0009.verify() is False
+    result = d0009.migrate()
+    assert result["category_filled"] == 1
+    assert result["expires_at_bumped"] == 1
+    assert d0009.verify() is True
+
+    db = sqlite3.connect(tmp_path / "genesis.db")
+    rows = {
+        r[0]: r for r in db.execute("SELECT id, category, expires_at FROM observations").fetchall()
+    }
+    db.close()
+    # backfilled: category from content, expiry extended to +60d
+    assert rows["p-old"][1] == "voice-master"
+    assert rows["p-old"][2] == new_expiry
+    # already-stamped: untouched
+    assert rows["p-new"][1] == "aws-fde"
+    assert rows["p-new"][2] == new_expiry
+    # resolved + unrelated type: untouched
+    assert rows["p-done"][1] is None
+    assert rows["o-other"][1] is None
+    assert rows["o-other"][2] == old_expiry
+
+    # Idempotent: a second run heals nothing.
+    assert d0009.migrate() == {"category_filled": 0, "expires_at_bumped": 0}
+
+
+def test_noop_on_fresh_install(tmp_path, monkeypatch):
+    _seed(tmp_path / "genesis.db", [])
+    monkeypatch.setattr(d0009, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+    assert d0009.verify() is True
+    assert d0009.migrate() == {"category_filled": 0, "expires_at_bumped": 0}
+    assert d0009.verify() is True

--- a/tests/test_db/test_observations.py
+++ b/tests/test_db/test_observations.py
@@ -335,6 +335,16 @@ def test_process_reaper_would_kill_ttl_registered(caplog):
     )
 
 
+def test_skill_proposal_ttl_is_60d_not_the_14d_default():
+    """The propose-only human-review queue (`skill_proposal`) must NOT sit at the
+    14-day default: `resolve_expired` runs live and would auto-resolve unreviewed
+    proposals, silently emptying the only human-safety queue. 60d gives real
+    review headroom."""
+    from datetime import timedelta
+
+    assert observations._compute_ttl("skill_proposal") == timedelta(days=60)
+
+
 _GIT_ALERT = dict(
     source="git_health_monitor",
     type="infrastructure_alert",

--- a/tests/test_learning/test_cognitive_ledger_wiring.py
+++ b/tests/test_learning/test_cognitive_ledger_wiring.py
@@ -40,7 +40,7 @@ async def db(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_skill_applicator_records_ledger_row(db, tmp_path, monkeypatch):
+async def test_skill_applicator_stages_without_ledger_or_file_write(db, tmp_path, monkeypatch):
     from genesis.learning.skills.applicator import SkillApplicator
     from genesis.learning.skills.types import (
         ChangeSize,
@@ -68,15 +68,15 @@ async def test_skill_applicator_records_ledger_row(db, tmp_path, monkeypatch):
         wiring_mod, "get_skill_path", lambda name: skill_dir / "SKILL.md",
     )
 
-    result = await applicator.apply(proposal, db)
-    assert result["action"] == "applied"
-    assert (skill_dir / "SKILL.md").read_text() == "new content"
+    result = await applicator.apply(proposal, db, current_content="old content")
+    # Propose-only: the applicator STAGES the proposal — it must not write the
+    # skill file, nor a cognitive_file_modifications ledger row. Applying (and its
+    # ledger capture) moves to the future human-initiated apply/resolve path.
+    assert result["action"] == "staged"
+    assert (skill_dir / "SKILL.md").read_text() == "old content"
 
     rows = await cfm.recent(db, limit=10, actor="skill_evolution")
-    assert len(rows) == 1
-    assert rows[0]["prior_content"] == "old content"
-    assert rows[0]["applied_content"] == "new content"
-    assert rows[0]["metadata"]["skill_name"] == "test-skill"
+    assert len(rows) == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_learning/test_skill_edit_critic.py
+++ b/tests/test_learning/test_skill_edit_critic.py
@@ -262,7 +262,7 @@ async def _fetch_gate_obs(db):
     return await cur.fetchall()
 
 
-async def test_wiring_flagged_verdict_logs_and_still_applies(db, tmp_path, monkeypatch):
+async def test_wiring_flagged_verdict_logs_and_still_stages(db, tmp_path, monkeypatch):
     applicator, skill_md, proposal, restore = _minor_applicator_setup(tmp_path)
 
     async def fake_run_critic(**kwargs):
@@ -282,14 +282,17 @@ async def test_wiring_flagged_verdict_logs_and_still_applies(db, tmp_path, monke
     finally:
         restore()
 
-    # Shadow invariant: the edit applied unchanged.
-    assert result["action"] == "applied"
-    assert skill_md.read_text() == "new content"
-    # And a flagged verdict was logged at high priority (visible during bake).
+    # Propose-only invariant: the outcome is always STAGE — the Critic never
+    # changes it, and the applicator never writes a file.
+    assert result["action"] == "staged"
+    assert skill_md.read_text() == "old content\nguard: do NOT use when X"
+    # A flagged verdict is logged at high priority (visible during bake) and
+    # rides the staged proposal.
     rows = await _fetch_gate_obs(db)
     assert len(rows) == 1
     assert rows[0]["priority"] == "high"
     assert "constraint_stripping" in rows[0]["content"]
+    assert result["critic_verdict"] == "flagged"
 
 
 async def test_wiring_clean_verdict_logged_low_priority(db, tmp_path, monkeypatch):
@@ -306,15 +309,15 @@ async def test_wiring_clean_verdict_logged_low_priority(db, tmp_path, monkeypatc
     finally:
         restore()
 
-    assert result["action"] == "applied"
+    assert result["action"] == "staged"
     rows = await _fetch_gate_obs(db)
     assert len(rows) == 1
     assert rows[0]["priority"] == "low"
 
 
-async def test_wiring_critic_raise_does_not_block_edit(db, tmp_path, monkeypatch):
-    """B1 regression: a raise from the Critic block must NOT prevent the edit
-    (it runs after the file write) and must NOT propagate to abort the batch."""
+async def test_wiring_critic_raise_does_not_block_staging(db, tmp_path, monkeypatch):
+    """A raise from the Critic must NOT prevent staging or abort the batch — the
+    Critic is best-effort enrichment on the staging path (it never writes)."""
     applicator, skill_md, proposal, restore = _minor_applicator_setup(tmp_path)
 
     async def boom(**kwargs):
@@ -328,9 +331,9 @@ async def test_wiring_critic_raise_does_not_block_edit(db, tmp_path, monkeypatch
     finally:
         restore()
 
-    assert result["action"] == "applied"
-    assert skill_md.read_text() == "new content"
-    # Critic raised → no gate observation, but the edit still landed.
+    assert result["action"] == "staged"
+    assert skill_md.read_text() == "old content\nguard: do NOT use when X"
+    # Critic raised → no gate observation, but the proposal still staged.
     assert await _fetch_gate_obs(db) == []
 
 
@@ -349,5 +352,5 @@ async def test_wiring_none_verdict_logs_nothing(db, tmp_path, monkeypatch):
     finally:
         restore()
 
-    assert result["action"] == "applied"
+    assert result["action"] == "staged"
     assert await _fetch_gate_obs(db) == []

--- a/tests/test_learning/test_skill_evolution.py
+++ b/tests/test_learning/test_skill_evolution.py
@@ -448,6 +448,52 @@ class TestWS10ContentLoss:
         assert kwargs.get("current_content") == "the full current SKILL.md content", \
             f"pipeline must pass current_content so the consistency check can run; kwargs={kwargs}"
 
+    @pytest.mark.asyncio
+    async def test_run_suppresses_when_unresolved_proposal_pending(self, db):
+        """Dampening: a skill with an unresolved proposal is not re-proposed."""
+        from datetime import UTC, datetime
+
+        from genesis.db.crud import observations
+
+        await observations.create(
+            db, id="pend1", source="skill_evolution", type="skill_proposal",
+            category="s", content=json.dumps({"skill_name": "s"}),
+            priority="medium", created_at=datetime.now(UTC).isoformat(),
+        )
+        pipeline = SkillEvolutionPipeline(db=db, router=MagicMock())
+        report = SkillReport(skill_name="s", usage_count=5, success_count=2,
+                             failure_count=3, success_rate=0.4)
+        pipeline._analyzer.analyze_all = AsyncMock(return_value=[report])
+        pipeline._analyzer.needs_review = lambda r: True
+        pipeline._refiner.propose = AsyncMock(
+            side_effect=AssertionError("refiner must not run while a proposal is pending"))
+        import genesis.learning.skills.pipeline as pipeline_mod
+        original_load = pipeline_mod.load_skill
+        pipeline_mod.load_skill = lambda name: "content"
+        try:
+            summary = await pipeline.run()
+        finally:
+            pipeline_mod.load_skill = original_load
+        assert summary["suppressed"] == 1
+        assert summary["proposed"] == 0
+
+    @pytest.mark.asyncio
+    async def test_dampening_uses_exact_category_not_like_wildcard(self, db):
+        """A pending proposal for `user_evaluate` must NOT suppress `user-evaluate`
+        (the `_` is a SQL LIKE wildcard — dampening must use exact match)."""
+        from datetime import UTC, datetime
+
+        from genesis.db.crud import observations
+
+        await observations.create(
+            db, id="uw1", source="skill_evolution", type="skill_proposal",
+            category="user_evaluate", content=json.dumps({"skill_name": "user_evaluate"}),
+            priority="medium", created_at=datetime.now(UTC).isoformat(),
+        )
+        pipeline = SkillEvolutionPipeline(db=db, router=MagicMock())
+        assert await pipeline._has_pending_proposal("user_evaluate") is True
+        assert await pipeline._has_pending_proposal("user-evaluate") is False
+
 
 # ---------------------------------------------------------------------------
 # Applicator tests
@@ -455,11 +501,12 @@ class TestWS10ContentLoss:
 
 class TestApplicator:
     @pytest.mark.asyncio
-    async def test_apply_minor_auto_applies(self, db, tmp_path):
-        # Create a skill directory
+    async def test_apply_minor_stages(self, db, tmp_path):
+        """Propose-only: a MINOR proposal is STAGED, never written to the file."""
         skill_dir = tmp_path / "test-skill"
         skill_dir.mkdir()
-        (skill_dir / "SKILL.md").write_text("old content")
+        skill_file = skill_dir / "SKILL.md"
+        skill_file.write_text("old content")
 
         proposal = SkillProposal(
             skill_name="test-skill",
@@ -469,56 +516,112 @@ class TestApplicator:
         )
 
         applicator = SkillApplicator(autonomy_level=2)
-
-        # Mock validator to pass (this test is about applicator logic, not validation)
         from genesis.learning.skills.types import ValidationResult
         applicator._validator.validate = lambda *a, **kw: ValidationResult(
             passed=True, test_results={}, blocking_failures=[], warnings=[],
         )
 
-        # Patch get_skill_path to use tmp_path
-        import genesis.learning.skills.wiring as wiring_mod
-        original = wiring_mod.get_skill_path
+        result = await applicator.apply(proposal, db, current_content="old content")
 
-        def mock_get_path(name):
-            p = skill_dir / "SKILL.md"
-            return p if p.exists() else None
-
-        wiring_mod.get_skill_path = mock_get_path
-        try:
-            result = await applicator.apply(proposal, db)
-        finally:
-            wiring_mod.get_skill_path = original
-
-        assert result["action"] == "applied"
-        assert (skill_dir / "SKILL.md").read_text() == "new content"
+        assert result["action"] == "staged"
+        # The applicator NEVER writes a skill file.
+        assert skill_file.read_text() == "old content"
 
     @pytest.mark.asyncio
-    async def test_apply_minor_skill_not_found(self, db):
+    async def test_staged_proposal_persists_full_content_and_category(self, db):
+        """A staged proposal carries the FULL proposed content + category=skill_name."""
+        big = "x" * 4000  # larger than the old 500-char preview
+        proposal = SkillProposal(
+            skill_name="test-skill",
+            proposed_content=big,
+            rationale="r",
+            change_size=ChangeSize.MINOR,
+        )
+        applicator = SkillApplicator(autonomy_level=2)
+        from genesis.learning.skills.types import ValidationResult
+        applicator._validator.validate = lambda *a, **kw: ValidationResult(
+            passed=True, test_results={}, blocking_failures=[], warnings=[],
+        )
+        await applicator.apply(proposal, db)
+
+        cursor = await db.execute(
+            "SELECT content, category FROM observations WHERE type='skill_proposal' "
+            "ORDER BY created_at DESC LIMIT 1"
+        )
+        row = dict(await cursor.fetchone())
+        data = json.loads(row["content"])
+        assert data["proposed_content"] == big  # full body, not truncated
+        assert row["category"] == "test-skill"
+
+    @pytest.mark.asyncio
+    async def test_apply_stages_without_path_lookup(self, db):
+        """Regression: the old 'skill not found -> failed' branch is gone.
+
+        apply() never resolves the on-disk skill path or writes a file, so a
+        missing on-disk skill can no longer fail it — it just stages.
+        """
         proposal = SkillProposal(
             skill_name="nonexistent",
             proposed_content="x",
             rationale="r",
             change_size=ChangeSize.MINOR,
         )
-
         applicator = SkillApplicator(autonomy_level=2)
+        from genesis.learning.skills.types import ValidationResult
+        applicator._validator.validate = lambda *a, **kw: ValidationResult(
+            passed=True, test_results={}, blocking_failures=[], warnings=[],
+        )
+        result = await applicator.apply(proposal, db)
+        assert result["action"] == "staged"
 
-        # Mock validator to pass so we test the path-not-found logic
+    @pytest.mark.asyncio
+    async def test_critic_verdict_rides_staged_proposal(self, db, monkeypatch):
+        """A flagged Critic verdict is attached to the proposal + logged (WS1)."""
+        proposal = SkillProposal(
+            skill_name="test-skill",
+            proposed_content="new",
+            rationale="r",
+            change_size=ChangeSize.MINOR,
+        )
+        applicator = SkillApplicator(autonomy_level=2)
         from genesis.learning.skills.types import ValidationResult
         applicator._validator.validate = lambda *a, **kw: ValidationResult(
             passed=True, test_results={}, blocking_failures=[], warnings=[],
         )
 
-        import genesis.learning.skills.wiring as wiring_mod
-        original = wiring_mod.get_skill_path
-        wiring_mod.get_skill_path = lambda _: None
-        try:
-            result = await applicator.apply(proposal, db)
-        finally:
-            wiring_mod.get_skill_path = original
+        async def fake_critic(**kw):
+            return {
+                "verdict": "flagged",
+                "score": 0.15,
+                "rationale": "constraint-strip",
+                "pathologies": ["constraint_stripping"],
+                "change_size": "minor",
+            }
 
-        assert result["action"] == "failed"
+        monkeypatch.setattr(
+            "genesis.learning.skills.skill_edit_critic.run_critic", fake_critic
+        )
+
+        result = await applicator.apply(
+            proposal, db, router=MagicMock(), current_content="old"
+        )
+        assert result["critic_verdict"] == "flagged"
+
+        # verdict rides the proposal, and a flagged proposal is high priority
+        cursor = await db.execute(
+            "SELECT content, priority FROM observations WHERE type='skill_proposal' "
+            "ORDER BY created_at DESC LIMIT 1"
+        )
+        row = dict(await cursor.fetchone())
+        assert json.loads(row["content"])["critic"]["verdict"] == "flagged"
+        assert row["priority"] == "high"
+
+        # WS1 shadow observation also logged, stamped with the skill category
+        cursor = await db.execute(
+            "SELECT category FROM observations WHERE type='skill_edit_critic' "
+            "ORDER BY created_at DESC LIMIT 1"
+        )
+        assert dict(await cursor.fetchone())["category"] == "test-skill"
 
     @pytest.mark.asyncio
     async def test_apply_moderate_staged(self, db):


### PR DESCRIPTION
## Problem

The weekly autonomous **skill-evolution** pipeline (`CronTrigger` Sat 04:00) auto-applied MINOR skill edits directly to the tracked in-repo `SKILL.md` templates. It repeatedly landed **principle-violating edits** — e.g. a *"Fallback & Silent Recoveries"* section instructing a skill to swallow errors and hide failures from the user — that the shadow semantic **Critic flagged in real time but could not block** (it is shadow-by-construction, and no `enforce` mode was ever built). Because the applicator wrote the tracked template with **no commit**, each edit also left a dangling working-tree change that blocked `scripts/update.sh`.

Verified via the cognitive-modification ledger: 5 consecutive weekly `skill_evolution` auto-applies to one skill, two of them Critic-flagged, none blocked.

## Change — propose-only

Autonomous skill-evolution now **proposes, never applies**:

- **`applicator.apply()` never writes a skill file** (or a ledger row) — every change size is *staged* for human/CC review and application via the normal worktree/PR flow.
- The **Critic verdict and the full proposed content ride the staged proposal** (previously only a 500-char preview was kept, making a proposal un-applyable).
- **Dampening:** a skill with an unresolved proposal is not re-proposed (exact category match — skill names can contain SQL `LIKE` metacharacters), which also breaks the self-reinforcing "each bad edit tanks the success rate that triggers the next" spiral and saves the refiner LLM call.
- **TTL:** the `skill_proposal` review-queue observation moves 14d → 60d so the live `resolve_expired` sweep can't silently empty the safety queue.
- The WS1 shadow gates (Critic + replay) and the skill-autonomy-graduation GROUNDWORK are **preserved** as the future `enforce` re-enablement path — this deliberately does *not* build enforce, only stops auto-apply now.

## Deferred (follow-ups)

A dedicated `skill_proposal_resolve` apply/reject tool (DB-only state transition — never git from the server runtime), a per-run proposal digest, and re-sourcing the replay gate's OLD baseline (OLD=on-disk / NEW=proposal) since it previously read the now-absent ledger pre-image (documented with a loud comment, not silently inert).

## Verification

- 755 passed across the full `test_learning/` subsystem + observations; ruff clean.
- The no-write invariant is asserted directly (file unchanged + zero ledger rows) across MINOR/MODERATE/MAJOR × validation pass/fail × router present/absent × Critic clean/flagged/raise/None.
- Independent adversarial review caught and fixed a LIKE-wildcard over-suppression in the dampening query (now exact-match).
