### PR TITLE
fix(db): rename colliding d0009 migration to d0010 + CI guard for prefix dupes

### DIFF
--- a/src/genesis/db/data_migrations/d0010_backfill_skill_proposal_dampening.py
+++ b/src/genesis/db/data_migrations/d0010_backfill_skill_proposal_dampening.py
@@ -1,4 +1,4 @@
-"""d0009 — align pre-existing skill_proposal observations to propose-only.
+"""d0010 — align pre-existing skill_proposal observations to propose-only.
 
 Two upgrade-path gaps for ``skill_proposal`` observations created by the OLD
 skill-evolution applicator (before propose-only shipped), both flagged in review:
@@ -70,7 +70,7 @@ def migrate() -> dict:
     finally:
         db.close()
     logger.info(
-        "d0009: skill_proposal category_filled=%d, expires_at_bumped=%d",
+        "d0010: skill_proposal category_filled=%d, expires_at_bumped=%d",
         category_filled,
         expires_bumped,
     )

--- a/tests/test_db/test_d0010_backfill_skill_proposal_dampening.py
+++ b/tests/test_db/test_d0010_backfill_skill_proposal_dampening.py
@@ -1,4 +1,4 @@
-"""d0009 — align pre-existing skill_proposal observations to propose-only.
+"""d0010 — align pre-existing skill_proposal observations to propose-only.
 
 Pre-propose-only proposal rows carry category=NULL (the exact-match dampening
 misses them) and a 14d expiry (they'd auto-resolve before review). This migration
@@ -12,7 +12,7 @@ import json
 import sqlite3
 from datetime import datetime, timedelta
 
-import genesis.db.data_migrations.d0009_backfill_skill_proposal_dampening as d0009
+import genesis.db.data_migrations.d0010_backfill_skill_proposal_dampening as d0010
 
 
 def _seed(path, rows) -> None:
@@ -72,13 +72,13 @@ def test_backfills_category_and_extends_expiry(tmp_path, monkeypatch):
             ("o-other", "bug_identified", 0, None, "not json", created, old_expiry),
         ],
     )
-    monkeypatch.setattr(d0009, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+    monkeypatch.setattr(d0010, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
 
-    assert d0009.verify() is False
-    result = d0009.migrate()
+    assert d0010.verify() is False
+    result = d0010.migrate()
     assert result["category_filled"] == 1
     assert result["expires_at_bumped"] == 1
-    assert d0009.verify() is True
+    assert d0010.verify() is True
 
     db = sqlite3.connect(tmp_path / "genesis.db")
     rows = {
@@ -97,12 +97,12 @@ def test_backfills_category_and_extends_expiry(tmp_path, monkeypatch):
     assert rows["o-other"][2] == old_expiry
 
     # Idempotent: a second run heals nothing.
-    assert d0009.migrate() == {"category_filled": 0, "expires_at_bumped": 0}
+    assert d0010.migrate() == {"category_filled": 0, "expires_at_bumped": 0}
 
 
 def test_noop_on_fresh_install(tmp_path, monkeypatch):
     _seed(tmp_path / "genesis.db", [])
-    monkeypatch.setattr(d0009, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
-    assert d0009.verify() is True
-    assert d0009.migrate() == {"category_filled": 0, "expires_at_bumped": 0}
-    assert d0009.verify() is True
+    monkeypatch.setattr(d0010, "genesis_db_path", lambda: str(tmp_path / "genesis.db"))
+    assert d0010.verify() is True
+    assert d0010.migrate() == {"category_filled": 0, "expires_at_bumped": 0}
+    assert d0010.verify() is True

--- a/tests/test_db/test_data_migrations.py
+++ b/tests/test_db/test_data_migrations.py
@@ -220,6 +220,42 @@ async def test_runner_rejects_duplicate_prefix(db, monkeypatch):
     assert await runner_mod.run_data_migrations(db) == []
 
 
+def test_no_duplicate_migration_prefixes_in_tree():
+    """Static guard: the REAL migration directories carry no duplicate prefixes.
+
+    Two concurrently-merged PRs each took `d0009` (2026-08-01: #1274 + #1276) —
+    the runner's runtime guard then made run_data_migrations a boot-time no-op
+    on EVERY install (error swallowed, all data migrations skipped) until one
+    was renamed. The runtime guard fires at deploy time on every install; this
+    test fires at CI time on the offending PR's merge ref, where the collision
+    is cheap to fix.
+    """
+    import re
+    from collections import Counter
+
+    from genesis.db._migration_discovery import discover_numbered_modules
+
+    surfaces = [
+        (
+            runner_mod._DATA_MIGRATIONS_DIR,
+            runner_mod._DATA_MIGRATION_PATTERN,
+            "data migration",
+        ),
+        (
+            runner_mod._DATA_MIGRATIONS_DIR.parent / "migrations",
+            re.compile(r"^(\d{4})_\w+\.py$"),
+            "schema migration",
+        ),
+    ]
+    for directory, pattern, label in surfaces:
+        ids = [mid for mid, _, _ in discover_numbered_modules(directory, pattern)]
+        dupes = {mid: n for mid, n in Counter(ids).items() if n > 1}
+        assert not dupes, (
+            f"duplicate {label} prefix(es) {dupes} in {directory} — "
+            "rename the newer file to the next free prefix"
+        )
+
+
 async def test_runner_redispatches_orphaned_running(db, monkeypatch):
     # A row left 'running' by a crashed prior boot must re-run.
     await crud.ensure_row(db, id="d0001", name="d0001_x", requires_operator=False)


### PR DESCRIPTION
Two concurrently-merged PRs (#1274, #1276) each took the `d0009` data-migration prefix. The runner's duplicate guard raises and `run_data_migrations` swallows the error to protect boot — net effect: **all data migrations silently skip on every install, every boot** until resolved.

**Fix:** rename the later one (`backfill_skill_proposal_dampening` → `d0010`; #1274's `resync_memory_class` keeps `d0009`). Safe in every ordering — the guard prevented either from running while both existed, so no ledger row exists under a wrong name.

**Class-fix:** `test_no_duplicate_migration_prefixes_in_tree` — a static scan of both real migration directories (schema + data), so a prefix collision fails CI on the offending PR's merge ref instead of no-op-ing deploys fleet-wide. (Verified: the guard detects the live `{'d0009': 2}` collision on the pre-fix tree.)

16 tests pass; ruff clean.