### PR TITLE
fix(memory): reference_lookup hydrates vector hits by qdrant_id, not primary key

### DIFF
--- a/scripts/migrate_reference_data.py
+++ b/scripts/migrate_reference_data.py
@@ -395,6 +395,12 @@ async def _ingest_entry(
         memory_class="fact",  # bypass 0.7x auto-reference penalty
         concept=entry.identifier,
         tags_json=tags_json,
+        # References live in episodic_memory alongside other personal data —
+        # match reference_store's invariant (mcp/memory/knowledge.py). Without
+        # this, ingest defaults to collection="knowledge_base", stranding
+        # migrated refs' vectors outside reference_lookup's episodic search.
+        collection="episodic_memory",
+        memory_type="episodic",
     )
     # ingest_knowledge_unit doesn't return the inserted flag directly;
     # we just return the ID here and count totals at the call site.

--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -94,16 +94,23 @@ async def get(db: aiosqlite.Connection, unit_id: str) -> dict | None:
 
 async def get_by_qdrant_ids(
     db: aiosqlite.Connection, qdrant_ids: list[str]
-) -> dict[str, dict]:
-    """Map Qdrant point IDs → knowledge_units rows (missing IDs omitted).
+) -> dict[str, list[dict]]:
+    """Map Qdrant point IDs → the knowledge_units rows sharing each ID.
 
     Qdrant point IDs map to ``knowledge_units.qdrant_id`` (NOT ``.id``) — the
     same contract as ``increment_retrieved_batch``. A retriever result's
     ``memory_id`` is the Qdrant point ID, so hydrating a vector hit back to its
     knowledge_units row must key on ``qdrant_id``, not the primary key (keying
     on ``.id`` silently matches nothing — the two are independent UUIDs). Uses
-    the ``idx_knowledge_units_qdrant_id`` index. Returned dict is keyed by
-    ``qdrant_id``.
+    the ``idx_knowledge_units_qdrant_id`` index.
+
+    Returns a LIST of rows per ``qdrant_id`` because a single Qdrant point can
+    back multiple units: ``MemoryStore.store`` dedups identical content to one
+    point, so two units with the same body but different
+    ``(project_type, domain, concept)`` keys share a ``qdrant_id`` (the column
+    is not UNIQUE). Collapsing to one row would silently drop the others and
+    could resolve a vector hit to the wrong unit; callers decide how to handle
+    a shared point (e.g. keep only rows matching a project/domain filter).
     """
     if not qdrant_ids:
         return {}
@@ -114,10 +121,10 @@ async def get_by_qdrant_ids(
     ) as cursor:
         rows = await cursor.fetchall()
         columns = [desc[0] for desc in cursor.description]
-    result: dict[str, dict] = {}
+    result: dict[str, list[dict]] = {}
     for row in rows:
         record = dict(zip(columns, row, strict=False))
-        result[record["qdrant_id"]] = record
+        result.setdefault(record["qdrant_id"], []).append(record)
     return result
 
 

--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -92,6 +92,35 @@ async def get(db: aiosqlite.Connection, unit_id: str) -> dict | None:
         return dict(zip(columns, row, strict=False))
 
 
+async def get_by_qdrant_ids(
+    db: aiosqlite.Connection, qdrant_ids: list[str]
+) -> dict[str, dict]:
+    """Map Qdrant point IDs → knowledge_units rows (missing IDs omitted).
+
+    Qdrant point IDs map to ``knowledge_units.qdrant_id`` (NOT ``.id``) — the
+    same contract as ``increment_retrieved_batch``. A retriever result's
+    ``memory_id`` is the Qdrant point ID, so hydrating a vector hit back to its
+    knowledge_units row must key on ``qdrant_id``, not the primary key (keying
+    on ``.id`` silently matches nothing — the two are independent UUIDs). Uses
+    the ``idx_knowledge_units_qdrant_id`` index. Returned dict is keyed by
+    ``qdrant_id``.
+    """
+    if not qdrant_ids:
+        return {}
+    placeholders = ",".join("?" for _ in qdrant_ids)
+    async with db.execute(
+        f"SELECT * FROM knowledge_units WHERE qdrant_id IN ({placeholders})",
+        qdrant_ids,
+    ) as cursor:
+        rows = await cursor.fetchall()
+        columns = [desc[0] for desc in cursor.description]
+    result: dict[str, dict] = {}
+    for row in rows:
+        record = dict(zip(columns, row, strict=False))
+        result[record["qdrant_id"]] = record
+    return result
+
+
 async def find_by_unique_key(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -116,14 +116,39 @@ async def knowledge_recall(
     except Exception:
         logger.warning("knowledge_fts search failed", exc_info=True)
 
+    # A retriever ``memory_id`` is the Qdrant point ID (== knowledge_units
+    # .qdrant_id), NOT the primary key. Map each vector hit back to its
+    # knowledge_units.id so (a) dedup against the FTS path — whose unit_id IS
+    # the primary key — actually matches, and (b) the returned unit_id is the
+    # usable primary key. Fall back to the raw Qdrant ID when no row exists so
+    # a hit is never dropped (unlike a stored reference, a generic knowledge
+    # vector may legitimately lack a knowledge_units row). Fail-open on a DB
+    # error to the raw ID — same best-effort stance as the FTS path above; a
+    # remap failure must not break recall.
+    try:
+        by_qdrant = await memory_mod.knowledge.get_by_qdrant_ids(
+            memory_mod._db, [r.memory_id for r in vector_results]
+        )
+    except Exception:
+        logger.warning("knowledge_recall: qdrant_id remap failed", exc_info=True)
+        by_qdrant = {}
+
     seen_ids: set[str] = set()
     merged: list[dict] = []
 
     for r in vector_results:
-        seen_ids.add(r.memory_id)
+        unit_id = (by_qdrant.get(r.memory_id) or {}).get("id") or r.memory_id
+        # Self-dedup on the resolved id (symmetric with the FTS loop below):
+        # two Qdrant points resolving to the same knowledge_units row must not
+        # produce two rows. (A stale orphaned point with no row still resolves
+        # to its own raw id and can't be deduped here — that is a separate
+        # stale-point cleanup concern, out of scope for this id-space fix.)
+        if unit_id in seen_ids:
+            continue
+        seen_ids.add(unit_id)
         merged.append(
             {
-                "unit_id": r.memory_id,
+                "unit_id": unit_id,
                 "content": r.content,
                 "source": r.source,
                 "source_doc": r.source,
@@ -634,7 +659,7 @@ async def reference_lookup(
     # Pull extra candidates so the post-filter to project_type=reference
     # doesn't leave us short of the requested limit.
     vector_limit = max(limit * 3, 10)
-    vector_hits: list[dict] = []
+    vector_qids: list[str] = []
     try:
         vector_results = await memory_mod._retriever.recall(
             query,
@@ -643,14 +668,9 @@ async def reference_lookup(
             # Gate rerank at the tool boundary (see knowledge_recall above).
             rerank=graph_expansion.reranker_enabled(),
         )
-        for r in vector_results:
-            vector_hits.append(
-                {
-                    "unit_id": r.memory_id,
-                    "score": getattr(r, "score", 0.0),
-                    "origin": "vector",
-                }
-            )
+        # A retriever ``memory_id`` is the Qdrant point ID (== knowledge_units
+        # .qdrant_id), NOT the primary key — keep them in rank order.
+        vector_qids = [r.memory_id for r in vector_results]
     except Exception:
         logger.warning(
             "reference_lookup: vector path failed, falling back to FTS only",
@@ -673,19 +693,44 @@ async def reference_lookup(
             exc_info=True,
         )
 
-    # Merge + dedup by unit_id, tracking origin.
-    seen: dict[str, str] = {}  # unit_id -> origin
-    for v in vector_hits:
-        seen[v["unit_id"]] = "vector"
+    # Resolve vector hits to their knowledge_units rows by Qdrant point ID.
+    # This MUST key on qdrant_id: the retriever's memory_id is the Qdrant point
+    # ID, so hydrating via knowledge.get (which looks up the primary key) would
+    # match nothing and silently drop every vector hit — the bug this fixes.
+    # Fail-open to FTS-only on a DB error, matching the vector-retriever and FTS
+    # paths above (both wrapped): a hydration fault must not turn an otherwise
+    # successful lookup into a total failure.
+    try:
+        by_qdrant = await memory_mod.knowledge.get_by_qdrant_ids(memory_mod._db, vector_qids)
+    except Exception:
+        logger.warning("reference_lookup: qdrant_id hydration failed, FTS-only", exc_info=True)
+        by_qdrant = {}
+
+    # Merge + dedup by knowledge_units.id, tracking origin. Vector hits keep
+    # their rank order (strongest first); FTS-only hits follow. Dedup now works
+    # because both paths are keyed in the same (primary-key) id space.
+    candidates: dict[str, dict] = {}  # unit_id -> {"row": row|None, "origin": str}
+    for qid in vector_qids:
+        row = by_qdrant.get(qid)
+        if row is None:
+            # Vector hit with no knowledge_units row — a plain episodic memory,
+            # not a stored reference. It cannot be a reference entry, so it is
+            # correctly excluded here (the project_type filter would drop it
+            # anyway); nothing broken is being suppressed.
+            continue
+        candidates.setdefault(row["id"], {"row": row, "origin": "vector"})
     for f in fts_results:
         uid = f["unit_id"]
-        seen[uid] = "both" if uid in seen else "fts"
+        if uid in candidates:
+            candidates[uid]["origin"] = "both"
+        else:
+            candidates[uid] = {"row": None, "origin": "fts"}
 
-    # Hydrate each candidate from knowledge_units, filtering post-hoc by
-    # project_type / domain (vector hits weren't filtered at retrieval time).
+    # Hydrate remaining (FTS-only) candidates and apply the post-hoc
+    # project_type / domain filter (vector hits weren't filtered at retrieval).
     full_rows: list[dict] = []
-    for uid, origin in seen.items():
-        row = await memory_mod.knowledge.get(memory_mod._db, uid)
+    for uid, info in candidates.items():
+        row = info["row"] or await memory_mod.knowledge.get(memory_mod._db, uid)
         if row is None:
             continue
         if row.get("project_type") != _REFERENCE_PROJECT:
@@ -702,11 +747,19 @@ async def reference_lookup(
                 "confidence": row["confidence"],
                 "source_doc": row["source_doc"],
                 "ingested_at": row["ingested_at"],
-                "origin": origin,
+                "origin": info["origin"],
             }
         )
         if len(full_rows) >= limit:
             break
+
+    logger.debug(
+        "reference_lookup: vector=%d fts=%d candidates=%d returned=%d",
+        len(vector_qids),
+        len(fts_results),
+        len(candidates),
+        len(full_rows),
+    )
 
     # Audit trail: log access for any credentials-kind entry that surfaces,
     # regardless of whether it came from the vector or FTS path.

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -137,12 +137,15 @@ async def knowledge_recall(
     merged: list[dict] = []
 
     for r in vector_results:
-        unit_id = (by_qdrant.get(r.memory_id) or {}).get("id") or r.memory_id
-        # Self-dedup on the resolved id (symmetric with the FTS loop below):
-        # two Qdrant points resolving to the same knowledge_units row must not
-        # produce two rows. (A stale orphaned point with no row still resolves
-        # to its own raw id and can't be deduped here — that is a separate
-        # stale-point cleanup concern, out of scope for this id-space fix.)
+        # A Qdrant point can back multiple units (shared-content dedup), so
+        # resolve to a primary key only when it's unambiguous. On 0 rows (no
+        # knowledge_units row) or >1 (an ambiguous shared point) fall back to
+        # the raw Qdrant id — never mislabel with an arbitrary unit's pk, which
+        # could wrongly suppress that unit's FTS result.
+        hit_rows = by_qdrant.get(r.memory_id, [])
+        unit_id = hit_rows[0]["id"] if len(hit_rows) == 1 else r.memory_id
+        # Self-dedup on the resolved id (symmetric with the FTS loop below): two
+        # vector hits resolving to the same row must not produce two results.
         if unit_id in seen_ids:
             continue
         seen_ids.add(unit_id)
@@ -711,14 +714,14 @@ async def reference_lookup(
     # because both paths are keyed in the same (primary-key) id space.
     candidates: dict[str, dict] = {}  # unit_id -> {"row": row|None, "origin": str}
     for qid in vector_qids:
-        row = by_qdrant.get(qid)
-        if row is None:
-            # Vector hit with no knowledge_units row — a plain episodic memory,
-            # not a stored reference. It cannot be a reference entry, so it is
-            # correctly excluded here (the project_type filter would drop it
-            # anyway); nothing broken is being suppressed.
-            continue
-        candidates.setdefault(row["id"], {"row": row, "origin": "vector"})
+        # A Qdrant point can back multiple units (shared-content dedup), and a
+        # point with no knowledge_units row (a plain episodic memory) yields an
+        # empty list. Add every backing row as a candidate; the project_type /
+        # domain filter below keeps only the reference rows — so a point shared
+        # by a reference and a non-reference resolves to the reference without
+        # dropping it, and a non-reference point is correctly excluded.
+        for row in by_qdrant.get(qid, []):
+            candidates.setdefault(row["id"], {"row": row, "origin": "vector"})
     for f in fts_results:
         uid = f["unit_id"]
         if uid in candidates:

--- a/tests/test_db/test_knowledge_crud.py
+++ b/tests/test_db/test_knowledge_crud.py
@@ -42,6 +42,39 @@ async def test_get_nonexistent(db):
     assert await knowledge.get(db, "nonexistent") is None
 
 
+async def test_get_by_qdrant_ids_maps_on_qdrant_id_not_pk(db):
+    """The helper keys on qdrant_id, not the primary key — the whole point.
+
+    A retriever result's memory_id is the Qdrant point ID, which equals
+    knowledge_units.qdrant_id and is a DIFFERENT UUID from the primary key.
+    Looking a vector hit up by primary key (knowledge.get) matches nothing;
+    this helper must match on qdrant_id.
+    """
+    uid = await knowledge.insert(
+        db,
+        project_type="reference",
+        domain="reference.network",
+        source_doc="t",
+        concept="host login",
+        body="ssh host",
+        qdrant_id="qd-point-1",
+    )
+    assert uid != "qd-point-1"  # the two id spaces are distinct
+
+    # Maps by qdrant_id → row, keyed by qdrant_id.
+    by_qdrant = await knowledge.get_by_qdrant_ids(db, ["qd-point-1"])
+    assert set(by_qdrant) == {"qd-point-1"}
+    assert by_qdrant["qd-point-1"]["id"] == uid
+
+    # The primary key is NOT a qdrant_id → no match (the exact prod failure).
+    assert await knowledge.get_by_qdrant_ids(db, [uid]) == {}
+
+
+async def test_get_by_qdrant_ids_empty_and_missing(db):
+    assert await knowledge.get_by_qdrant_ids(db, []) == {}
+    assert await knowledge.get_by_qdrant_ids(db, ["nope1", "nope2"]) == {}
+
+
 async def test_insert_with_all_fields(db):
     uid = await knowledge.insert(
         db,

--- a/tests/test_db/test_knowledge_crud.py
+++ b/tests/test_db/test_knowledge_crud.py
@@ -61,13 +61,34 @@ async def test_get_by_qdrant_ids_maps_on_qdrant_id_not_pk(db):
     )
     assert uid != "qd-point-1"  # the two id spaces are distinct
 
-    # Maps by qdrant_id → row, keyed by qdrant_id.
+    # Maps by qdrant_id → list of rows, keyed by qdrant_id.
     by_qdrant = await knowledge.get_by_qdrant_ids(db, ["qd-point-1"])
     assert set(by_qdrant) == {"qd-point-1"}
-    assert by_qdrant["qd-point-1"]["id"] == uid
+    assert [r["id"] for r in by_qdrant["qd-point-1"]] == [uid]
 
     # The primary key is NOT a qdrant_id → no match (the exact prod failure).
     assert await knowledge.get_by_qdrant_ids(db, [uid]) == {}
+
+
+async def test_get_by_qdrant_ids_preserves_shared_point(db):
+    """Two units sharing one Qdrant point are BOTH returned, never collapsed.
+
+    MemoryStore.store dedups identical content to a single Qdrant point, so two
+    units with the same body but different (project_type, domain, concept) keys
+    share a qdrant_id (the column is not UNIQUE). Collapsing to one row would
+    silently drop the other and could resolve a vector hit to the wrong unit.
+    """
+    uid_a = await knowledge.insert(
+        db, project_type="reference", domain="reference.url", source_doc="t",
+        concept="entry A", body="same body", qdrant_id="shared-point",
+    )
+    uid_b = await knowledge.insert(
+        db, project_type="genesis-infra", domain="claude-code", source_doc="t",
+        concept="entry B", body="same body", qdrant_id="shared-point",
+    )
+    by_qdrant = await knowledge.get_by_qdrant_ids(db, ["shared-point"])
+    assert set(by_qdrant) == {"shared-point"}
+    assert {r["id"] for r in by_qdrant["shared-point"]} == {uid_a, uid_b}
 
 
 async def test_get_by_qdrant_ids_empty_and_missing(db):

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -638,11 +638,15 @@ async def test_reference_lookup_non_credentials_no_audit():
 
 
 async def test_reference_lookup_hybrid_vector_path():
-    """I1 regression: reference_lookup must also consult the vector retriever.
+    """Regression: a vector hit must hydrate by Qdrant point ID, not primary key.
 
-    Builds a reference entry via reference_store, then simulates a vector
-    hit that returns it (no FTS match for the semantic query), and verifies
-    the result surfaces.
+    Builds a reference entry via reference_store, then simulates a vector hit
+    that returns it (no FTS match for the semantic query), and verifies the
+    result surfaces. The retriever returns ``memory_id`` = the Qdrant point ID
+    (what ``store.store`` returns, stored as ``knowledge_units.qdrant_id``) —
+    NOT the primary key. Hydrating that via ``knowledge.get`` (primary-key
+    lookup) matched nothing and dropped every reference; this asserts the
+    qdrant_id-keyed hydration path returns the entry.
     """
     from types import SimpleNamespace
 
@@ -683,13 +687,15 @@ async def test_reference_lookup_hybrid_vector_path():
                 ),
             )
 
-            # Semantic query that does NOT match any FTS5 token in the body.
-            # "ohio buckeyes fan" vs body containing "Ohio State fan persona" —
-            # FTS5 matches "ohio" and "fan" so FTS would still return this;
-            # test that the vector path ALSO returns it when FTS misses by
-            # querying with tokens that aren't in the body.
+            # Anti-remasking guard: the Qdrant point ID and the primary key are
+            # different UUIDs. The prior test mocked memory_id=unit_id, which
+            # masked the bug. Production returns the Qdrant point ID.
+            assert unit_id != "q-vector-1"
+
+            # Retriever returns the Qdrant point ID (== store.store's return,
+            # stored as qdrant_id), NOT the primary key.
             mock_retriever.recall = AsyncMock(return_value=[
-                SimpleNamespace(memory_id=unit_id, score=0.87),
+                SimpleNamespace(memory_id="q-vector-1", score=0.87),
             ])
 
             results = await tools["reference_lookup"].fn(
@@ -705,7 +711,12 @@ async def test_reference_lookup_hybrid_vector_path():
 
 
 async def test_reference_lookup_hybrid_merges_both_paths():
-    """Vector and FTS hits for the same entry merge to origin='both'."""
+    """Vector and FTS hits for the same entry merge to origin='both'.
+
+    Genuinely exercises cross-id-space dedup: the vector hit carries the Qdrant
+    point ID while FTS carries the primary key, so the merge must resolve the
+    vector hit to its primary key to recognise them as the same entry.
+    """
     from types import SimpleNamespace
 
     import aiosqlite
@@ -740,8 +751,11 @@ async def test_reference_lookup_hybrid_merges_both_paths():
                 description="Public example forum for testing",
             )
 
+            # Vector hit carries the Qdrant point ID (store.store's return),
+            # FTS carries the primary key — dedup must still merge them.
+            assert uid != "q-both"
             mock_retriever.recall = AsyncMock(return_value=[
-                SimpleNamespace(memory_id=uid, score=0.9),
+                SimpleNamespace(memory_id="q-both", score=0.9),
             ])
 
             results = await tools["reference_lookup"].fn(
@@ -750,6 +764,112 @@ async def test_reference_lookup_hybrid_merges_both_paths():
             assert len(results) == 1
             assert results[0]["unit_id"] == uid
             assert results[0]["origin"] == "both"
+        finally:
+            mod._store, mod._db, mod._retriever, mod._qdrant = old
+
+
+async def test_reference_lookup_vector_hit_without_knowledge_unit_skipped():
+    """A vector hit with no knowledge_units row is excluded, not an error.
+
+    The episodic collection holds plain memories alongside stored references;
+    a vector hit whose Qdrant point ID has no knowledge_units row is not a
+    reference and must be dropped cleanly (no exception, no bogus row).
+    """
+    from types import SimpleNamespace
+
+    import aiosqlite
+
+    import genesis.mcp.memory_mcp as mod
+    from genesis.db.schema import create_all_tables
+
+    async with aiosqlite.connect(":memory:") as real_db:
+        await create_all_tables(real_db)
+
+        mock_store = AsyncMock()
+        mock_store.store = AsyncMock(return_value="q-orphan")
+        mock_store.delete = AsyncMock(return_value={"metadata": 1, "fts5": 1})
+        mock_store._embeddings = MagicMock()
+        mock_store._embeddings.model_name = "m"
+
+        mock_retriever = AsyncMock()
+        # Qdrant point ID with no matching knowledge_units.qdrant_id row.
+        mock_retriever.recall = AsyncMock(return_value=[
+            SimpleNamespace(memory_id="not-a-knowledge-unit", score=0.95),
+        ])
+
+        old = (mod._store, mod._db, mod._retriever, mod._qdrant)
+        try:
+            mod._store = mock_store
+            mod._db = real_db
+            mod._retriever = mock_retriever
+            mod._qdrant = MagicMock()
+
+            tools = await _get_tools()
+            results = await tools["reference_lookup"].fn(
+                query="xyzzy-no-match-in-body",  # FTS returns nothing either
+            )
+            assert results == []
+        finally:
+            mod._store, mod._db, mod._retriever, mod._qdrant = old
+
+
+async def test_reference_lookup_hydration_error_degrades_to_fts():
+    """A vector-hydration DB error degrades to FTS-only, never a total failure.
+
+    reference_lookup's vector-retriever and FTS paths are both fail-open; the
+    qdrant_id hydration step must be too, so a transient DB fault on that one
+    query can't sink an otherwise-successful lookup.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    import aiosqlite
+
+    import genesis.mcp.memory_mcp as mod
+    from genesis.db.schema import create_all_tables
+
+    async with aiosqlite.connect(":memory:") as real_db:
+        await create_all_tables(real_db)
+
+        mock_store = AsyncMock()
+        mock_store.store = AsyncMock(return_value="q-degrade")
+        mock_store.delete = AsyncMock(return_value={"metadata": 1, "fts5": 1})
+        mock_store._embeddings = MagicMock()
+        mock_store._embeddings.model_name = "m"
+
+        mock_retriever = AsyncMock()
+        mock_retriever.recall = AsyncMock(return_value=[])
+
+        old = (mod._store, mod._db, mod._retriever, mod._qdrant)
+        try:
+            mod._store = mock_store
+            mod._db = real_db
+            mod._retriever = mock_retriever
+            mod._qdrant = MagicMock()
+
+            tools = await _get_tools()
+            uid = await tools["reference_store"].fn(
+                kind="url",
+                identifier="degrade forum",
+                value="https://example.com/degrade",
+                description="Public example forum for degrade testing",
+            )
+
+            # Vector hydration raises; FTS still matches "degrade forum".
+            mock_retriever.recall = AsyncMock(return_value=[
+                SimpleNamespace(memory_id="q-degrade", score=0.9),
+            ])
+            with patch.object(
+                mod.knowledge, "get_by_qdrant_ids",
+                new_callable=AsyncMock, side_effect=RuntimeError("db locked"),
+            ):
+                results = await tools["reference_lookup"].fn(
+                    query="degrade forum", kind="url",
+                )
+            # FTS path still surfaces the entry — degraded, not empty, no raise.
+            assert len(results) == 1
+            assert results[0]["unit_id"] == uid
+            assert results[0]["origin"] == "fts"
         finally:
             mod._store, mod._db, mod._retriever, mod._qdrant = old
 


### PR DESCRIPTION
## Problem

`reference_lookup`'s vector-search path built candidates from the retriever's
`memory_id` — which is the Qdrant point id (equal to `knowledge_units.qdrant_id`)
— but hydrated them via `knowledge.get`, a primary-key (`knowledge_units.id`)
lookup. Those are two independently generated UUIDs, so every vector hit matched
no row and was silently dropped. Semantic/partial reference queries returned `[]`
even when the entry existed (`memory_recall` found the same entry fine). Measured
against a live store, every reference row failed to hydrate under the old
primary-key lookup — the vector path returned nothing for references.

## Fix

- New `knowledge.get_by_qdrant_ids(db, qdrant_ids)` batch helper keyed on
  `qdrant_id` (mirrors the existing `increment_retrieved_batch` contract, uses
  the existing `idx_knowledge_units_qdrant_id` index).
- `reference_lookup` resolves vector hits through it and merges/dedups in
  primary-key space (dedup against the FTS path now actually matches). Hydration
  is fail-open to FTS-only on a DB error, matching the vector and FTS paths.
- `knowledge_recall` had the same root cause in a milder form (duplicate results
  + a wrong-id-space `unit_id` for vector hits): same remap, fail-open to the raw
  id, with self-dedup on the resolved id.
- The reference-migration script now ingests into the `episodic_memory`
  collection (matching `reference_store`'s invariant) so future migrated
  references are reachable by the vector path.

## Tests

- Two hybrid tests previously mocked `memory_id` == primary key, which masked the
  bug; corrected to the Qdrant point id with anti-remasking guards.
- Added: vector-hit-without-row skip, hydration-error-degrades-to-FTS, and
  `get_by_qdrant_ids` unit tests.
- Fail-before verified: the corrected tests fail on the unfixed code, pass after.

## Known residual (out of scope)

A stale orphaned Qdrant point (a live + stale point for the same content — the
deferred-delete scenario) can still yield a duplicate row in `knowledge_recall`
under a rare precondition. It is pre-existing, not introduced here, and not
cleanly closable without risking dropping legitimate no-row vectors — tracked
separately as a stale-point cleanup concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
