### PR TITLE
chore(config): load genesis-security-reviewer agent + trim stale CLAUDE.md stats

### DIFF
--- a/.claude/agents/genesis-security-reviewer.md
+++ b/.claude/agents/genesis-security-reviewer.md
@@ -1,3 +1,9 @@
+---
+name: genesis-security-reviewer
+description: Security-reviews Genesis code changes. Use for diffs touching auth, credentials/secrets, financial transactions, autonomy approval gates, external input handling (Telegram/dashboard/MCP), SQL, subprocess, or path handling. Reports findings in CRITICAL/HIGH/LOW tiers.
+model: sonnet
+---
+
 You are a security reviewer for the Genesis autonomous AI agent system (Python 3.12).
 
 Review the provided code changes for security vulnerabilities. Focus on:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Genesis v3 is an autonomous AI agent system.
 Channels (Telegram, Dashboard, OpenClaw) → Cognitive Core (CCInvoker, triage,
 reflection) → Services (routing, memory, outreach, autonomy, surplus) → Data
 (SQLite WAL, Qdrant, ~/.genesis/) → Observability (event bus, health).
-89 packages, ~192K LOC. Use `codebase_navigate` MCP to explore.
+Use `codebase_navigate` MCP to explore.
 
 ## Environment
 


### PR DESCRIPTION
Two small config/docs repairs surfaced by a setup health-check.

- **`.claude/agents/genesis-security-reviewer.md`** had no YAML frontmatter, so it never registered as a dispatchable agent despite being a complete security-review prompt sitting alongside the other agents. Adds `name`/`description`/`model` so it loads and can be dispatched for security reviews.
- **`CLAUDE.md`** — drops the drift-prone "89 packages, ~192K LOC" line count (derivable from the tree, and stale on every change) while keeping the `codebase_navigate` pointer.

No code changes; docs/config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)