### PR TITLE
fix(recon): models.md synthesis writes a local overlay, not tracked source

### DIFF
--- a/scripts/promote_models_md.sh
+++ b/scripts/promote_models_md.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Genesis — promote the local models.md overlay onto the tracked reference.
+#
+# The weekly models_md_synthesis job refreshes a LOCAL overlay
+# (~/.genesis/output/models.md) instead of committing to tracked source, so a
+# clone's autonomous run never diverges docs/reference/models.md (which used to
+# make every `git pull` conflict). The tracked doc is a maintainer-curated
+# reference. Run this to copy a reviewed overlay back onto it, then review the
+# diff and open a PR for a deliberate public refresh.
+#
+# Usage:
+#   ./scripts/promote_models_md.sh
+#
+# Env:
+#   GENESIS_OUTPUT_DIR   overlay location (default ~/.genesis/output)
+#
+# Idempotent: a plain copy. Writes nothing if the overlay is absent.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)"
+OVERLAY="${GENESIS_OUTPUT_DIR:-$HOME/.genesis/output}/models.md"
+TRACKED="$REPO_ROOT/docs/reference/models.md"
+
+if [[ ! -f "$OVERLAY" ]]; then
+    echo "No overlay at $OVERLAY — the weekly synthesis job hasn't produced one yet." >&2
+    echo "(It seeds itself from the tracked doc on first run, then updates in place.)" >&2
+    exit 1
+fi
+
+# Compare before copying (git-independent, so the helper also works from a
+# tarball checkout). cmp -s is non-zero when TRACKED is absent → we still copy.
+if cmp -s "$OVERLAY" "$TRACKED"; then
+    echo "Overlay already identical to docs/reference/models.md — nothing to promote."
+    exit 0
+fi
+
+cp "$OVERLAY" "$TRACKED"
+
+echo "Copied overlay -> docs/reference/models.md."
+echo "Review with:  git -C \"$REPO_ROOT\" diff -- docs/reference/models.md"
+echo "Then commit on a branch and open a PR for the public refresh."

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -448,6 +448,29 @@ def build_lane_enabled() -> bool:
     return False
 
 
+def models_md_synthesis_enabled() -> bool:
+    """Whether the weekly models.md synthesis job may run. Default ON.
+
+    The job dispatches a CC session that refreshes the LOCAL models.md overlay
+    (``~/.genesis/output/models.md``) from recent model-intelligence findings —
+    it no longer commits to the tracked reference doc. This is the operator
+    off-switch for that autonomous behavior (a CC-cost or catalog-noise
+    concern), distinct from the global ``runtime.paused`` gate. Set
+    ``GENESIS_MODELS_MD_SYNTHESIS_OFF=1`` in secrets.env or
+    ``models_md_synthesis.enabled: false`` in ``~/.genesis/config/genesis.yaml``.
+    The check is per-run, so a flip takes effect on the next weekly tick with no
+    restart. Fails toward ON (env read can't raise, local config swallows).
+    """
+    env_val = os.environ.get("GENESIS_MODELS_MD_SYNTHESIS_OFF")
+    if env_val is not None:
+        # The env var names the OFF state: a truthy value DISABLES the job.
+        return env_val.strip().lower() not in {"1", "true", "yes", "on"}
+    local_val = _local_config().get("models_md_synthesis", {}).get("enabled")
+    if local_val is not None:
+        return bool(local_val)
+    return True
+
+
 def user_timezone() -> str:
     """User's local timezone (IANA format).
 

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -458,8 +458,12 @@ def models_md_synthesis_enabled() -> bool:
     concern), distinct from the global ``runtime.paused`` gate. Set
     ``GENESIS_MODELS_MD_SYNTHESIS_OFF=1`` in secrets.env or
     ``models_md_synthesis.enabled: false`` in ``~/.genesis/config/genesis.yaml``.
-    The check is per-run, so a flip takes effect on the next weekly tick with no
-    restart. Fails toward ON (env read can't raise, local config swallows).
+    The runner evaluates this per weekly tick, but a change takes effect only
+    after a genesis-server restart: a running process's env is static and
+    ``_local_config()`` caches the YAML parse for the process lifetime (same
+    restart requirement as ``build_lane_enabled``). The weekly cadence leaves
+    ample time to restart before the next run. Fails toward ON (env read can't
+    raise, local config swallows).
     """
     env_val = os.environ.get("GENESIS_MODELS_MD_SYNTHESIS_OFF")
     if env_val is not None:

--- a/src/genesis/recon/models_md_synthesis.py
+++ b/src/genesis/recon/models_md_synthesis.py
@@ -1,8 +1,17 @@
 """Weekly models.md synthesis — updates the model catalog from recon findings.
 
 Reads recent model intelligence findings from knowledge_units, builds a
-prompt, and dispatches a CC background session to update
-docs/reference/models.md with a git commit.
+prompt, and dispatches a CC background session to refresh the LOCAL models.md
+overlay (``~/.genesis/output/models.md``). The overlay is seeded once from the
+tracked reference doc (``docs/reference/models.md``) and thereafter updated in
+place with NO git commit — so every clone's weekly run stops diverging tracked
+source (which used to make every ``git pull`` conflict on models.md). The
+tracked doc stays a maintainer-curated reference; ``scripts/promote_models_md.sh``
+copies a reviewed overlay back onto it for a deliberate public refresh.
+
+The overlay is a per-install FORK, not a mirror: it seeds once and later
+upstream edits to the tracked doc do NOT re-seed it. Delete the overlay to
+re-seed from the current tracked doc.
 
 Scheduled via SurplusScheduler: Sunday 8am UTC, 2h after model intelligence.
 """
@@ -12,10 +21,11 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shutil
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-from genesis.env import repo_root
+from genesis.env import output_dir, repo_root
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -34,7 +44,8 @@ _ACTIONABLE_TYPES = frozenset({
     "stale_profile",
 })
 
-# Path to the models.md file (relative to repo root, for the CC session prompt).
+# Tracked reference doc (relative to repo root) — the one-time seed source for
+# the local overlay; not written by this job.
 _MODELS_MD_REL = "docs/reference/models.md"
 
 _SESSION_PROMPT_TEMPLATE = """\
@@ -43,7 +54,7 @@ You are updating the Genesis model catalog.
 ## Task
 
 Read the file `{models_md_path}`, apply the intelligence findings below,
-and write the updated file back. Then git commit the change.
+and write the updated file back.
 
 ## Rules
 
@@ -79,9 +90,8 @@ and write the updated file back. Then git commit the change.
 2. Apply the findings below to produce the updated content
 3. Verify your output meets the validation rules above
 4. Write the updated file with the Write tool
-5. Run: `cd {repo_root} && git add {models_md_rel} && git commit -m "docs(models): weekly synthesis update"`
 
-If the file is unchanged (no material findings to apply), skip steps 3-5
+If the file is unchanged (no material findings to apply), skip steps 3-4
 and report "no changes needed."
 
 ## Intelligence Findings (last 7 days)
@@ -91,12 +101,12 @@ and report "no changes needed."
 
 
 class ModelsMdSynthesisJob:
-    """Weekly job: synthesize recon findings into docs/reference/models.md.
+    """Weekly job: synthesize recon findings into the local models.md overlay.
 
     Dispatches a CC background session to perform the update, rather than
     calling the LLM router directly.  This gives natural resilience (no
-    single-provider dependency) and lets the session use tools for file
-    I/O and git operations.
+    single-provider dependency) and lets the session use the Write tool for
+    file I/O.  The session writes the local overlay only — no git commit.
     """
 
     def __init__(self, *, db: aiosqlite.Connection):
@@ -110,18 +120,24 @@ class ModelsMdSynthesisJob:
             logger.info("Models.md synthesis: no actionable findings in last 7 days")
             return {"skipped": True, "reason": "no_findings"}
 
-        # 2. Build session prompt
+        # 2. Resolve the LOCAL overlay target, seeding it once from the tracked
+        #    reference doc. The session edits the overlay in place (no git), so a
+        #    clone's weekly run never diverges tracked source. Seed idiom mirrors
+        #    scripts/setup-local-config.sh (copy shipped default if absent).
         serialized = self._serialize_findings(findings)
-        root = repo_root()
-        models_md_path = root / _MODELS_MD_REL
-        if not models_md_path.exists():
-            logger.error("Models.md not found at %s", models_md_path)
-            return {"skipped": True, "reason": "file_not_found"}
+        overlay = output_dir() / "models.md"
+        if not overlay.exists():
+            tracked_seed = repo_root() / _MODELS_MD_REL
+            if not tracked_seed.exists():
+                logger.error("Models.md seed not found at %s", tracked_seed)
+                return {"skipped": True, "reason": "no_seed"}
+            overlay.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(tracked_seed, overlay)
+            logger.info("Seeded models.md overlay from %s", tracked_seed)
+        models_md_path = overlay
 
         prompt = _SESSION_PROMPT_TEMPLATE.format(
             models_md_path=str(models_md_path),
-            models_md_rel=_MODELS_MD_REL,
-            repo_root=str(root),
             findings=serialized,
         )
 
@@ -148,7 +164,7 @@ class ModelsMdSynthesisJob:
             notify_on_failure_only=True,
             source_tag="models_md_synthesis",
             caller_context="schedule:models_md_synthesis",
-            tool_exceptions=("Write", "Bash"),
+            tool_exceptions=("Write",),
         )
 
         session_id = await runner.spawn(request)

--- a/src/genesis/surplus/jobs/runners.py
+++ b/src/genesis/surplus/jobs/runners.py
@@ -179,9 +179,11 @@ async def run_github_discovery(sched: SchedulerContext) -> None:
 async def run_models_md_synthesis(sched: SchedulerContext) -> None:
     """Run weekly models.md synthesis (Sunday 8am UTC).
 
-    Dispatches a CC background session to update docs/reference/models.md
-    from recent model intelligence findings.  Fire-and-forget: job health
-    records the dispatch outcome, not the session completion.
+    Dispatches a CC background session to refresh the LOCAL models.md overlay
+    (``~/.genesis/output/models.md``) from recent model intelligence findings —
+    no git commit, so a clone's weekly run never diverges tracked source.
+    Fire-and-forget: job health records the dispatch outcome, not the session
+    completion.
     """
     try:
         from genesis.runtime import GenesisRuntime
@@ -190,6 +192,10 @@ async def run_models_md_synthesis(sched: SchedulerContext) -> None:
             return
     except Exception:
         pass
+    from genesis.env import models_md_synthesis_enabled
+    if not models_md_synthesis_enabled():
+        logger.debug("Models.md synthesis skipped (disabled via lever)")
+        return
     if sched._models_md_synthesis_job is None:
         record_failure("models_md_synthesis", "job not wired")
         return

--- a/tests/test_recon/test_models_md_synthesis.py
+++ b/tests/test_recon/test_models_md_synthesis.py
@@ -1,8 +1,169 @@
 """Tests for ModelsMdSynthesisJob — weekly models.md synthesis."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from genesis.recon.models_md_synthesis import ModelsMdSynthesisJob
+
+_SEED_CONTENT = (
+    "<!-- header -->\n"
+    "## THE HEAVY LIFTERS\nseed\n"
+    "## THE ALL-ROUNDERS\nseed\n"
+    "## THE SPECIALISTS\nseed\n"
+)
+
+
+def _job_with_one_finding():
+    """A job whose DB returns exactly one actionable finding."""
+    findings_data = [
+        ("concept1", '{"type": "pricing_change", "model": "x"}', "2026-08-01"),
+    ]
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall = AsyncMock(return_value=findings_data)
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=mock_cursor)
+    return ModelsMdSynthesisJob(db=mock_db)
+
+
+class _FakeRunner:
+    """Captures the DirectSessionRequest instead of spawning a real session."""
+
+    def __init__(self):
+        self.request = None
+
+    async def spawn(self, request):
+        self.request = request
+        return "sess-test"
+
+
+def _patch_dispatch(monkeypatch, tmp_path, *, seed: bool = True):
+    """Point output_dir()/repo_root() at tmp dirs and stub the runtime.
+
+    Returns (overlay_dir, runner). When ``seed`` is True a tracked seed doc is
+    written under the fake repo root so the overlay can seed from it.
+    """
+    overlay_dir = tmp_path / "output"
+    repo = tmp_path / "repo"
+    if seed:
+        seed_doc = repo / "docs" / "reference" / "models.md"
+        seed_doc.parent.mkdir(parents=True, exist_ok=True)
+        seed_doc.write_text(_SEED_CONTENT)
+    monkeypatch.setattr(
+        "genesis.recon.models_md_synthesis.output_dir", lambda: overlay_dir
+    )
+    monkeypatch.setattr(
+        "genesis.recon.models_md_synthesis.repo_root", lambda: repo
+    )
+    runner = _FakeRunner()
+    fake_rt = MagicMock()
+    fake_rt._direct_session_runner = runner
+    monkeypatch.setattr("genesis.runtime.GenesisRuntime.instance", lambda: fake_rt)
+    return overlay_dir, runner
+
+
+class TestOverlayTarget:
+    """The job writes a local overlay, seeds it once, and never git-commits."""
+
+    @pytest.mark.asyncio
+    async def test_seeds_overlay_and_points_prompt_at_it(self, monkeypatch, tmp_path):
+        overlay_dir, runner = _patch_dispatch(monkeypatch, tmp_path)
+        overlay = overlay_dir / "models.md"
+        assert not overlay.exists()
+
+        result = await _job_with_one_finding().run()
+
+        assert result["dispatched"] is True
+        # Overlay was seeded from the tracked reference doc.
+        assert overlay.exists()
+        assert overlay.read_text() == _SEED_CONTENT
+        # Prompt targets the overlay, not the tracked doc.
+        assert str(overlay) in runner.request.prompt
+        assert "docs/reference/models.md" not in runner.request.prompt
+
+    @pytest.mark.asyncio
+    async def test_prompt_has_no_git_commit(self, monkeypatch, tmp_path):
+        _, runner = _patch_dispatch(monkeypatch, tmp_path)
+        await _job_with_one_finding().run()
+        prompt = runner.request.prompt
+        assert "git commit" not in prompt
+        assert "git add" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_tool_exceptions_write_only(self, monkeypatch, tmp_path):
+        _, runner = _patch_dispatch(monkeypatch, tmp_path)
+        await _job_with_one_finding().run()
+        # Bash dropped — with git gone the session only needs Write.
+        assert runner.request.tool_exceptions == ("Write",)
+
+    @pytest.mark.asyncio
+    async def test_existing_overlay_not_reseeded(self, monkeypatch, tmp_path):
+        overlay_dir, runner = _patch_dispatch(monkeypatch, tmp_path)
+        overlay = overlay_dir / "models.md"
+        overlay.parent.mkdir(parents=True, exist_ok=True)
+        overlay.write_text("PRIOR OVERLAY CONTENT\n")
+
+        await _job_with_one_finding().run()
+
+        # Seed-once: an existing overlay is left as-is (the session updates it).
+        assert overlay.read_text() == "PRIOR OVERLAY CONTENT\n"
+        assert str(overlay) in runner.request.prompt
+
+    @pytest.mark.asyncio
+    async def test_no_seed_skips(self, monkeypatch, tmp_path):
+        # No overlay and no tracked seed → cannot proceed.
+        _, runner = _patch_dispatch(monkeypatch, tmp_path, seed=False)
+        result = await _job_with_one_finding().run()
+        assert result == {"skipped": True, "reason": "no_seed"}
+        assert runner.request is None  # never dispatched
+
+
+class TestSynthesisLever:
+    """The GENESIS_MODELS_MD_SYNTHESIS_OFF operator lever."""
+
+    def test_default_on(self, monkeypatch):
+        from genesis import env
+
+        monkeypatch.delenv("GENESIS_MODELS_MD_SYNTHESIS_OFF", raising=False)
+        monkeypatch.setattr(env, "_local_config", lambda: {})
+        assert env.models_md_synthesis_enabled() is True
+
+    @pytest.mark.parametrize("val", ["1", "true", "yes", "on", "TRUE", " On "])
+    def test_env_off(self, monkeypatch, val):
+        from genesis import env
+
+        monkeypatch.setenv("GENESIS_MODELS_MD_SYNTHESIS_OFF", val)
+        assert env.models_md_synthesis_enabled() is False
+
+    @pytest.mark.parametrize("val", ["0", "false", "no", "off", ""])
+    def test_env_falsey_stays_on(self, monkeypatch, val):
+        from genesis import env
+
+        monkeypatch.setenv("GENESIS_MODELS_MD_SYNTHESIS_OFF", val)
+        assert env.models_md_synthesis_enabled() is True
+
+    def test_local_config_disable(self, monkeypatch):
+        from genesis import env
+
+        monkeypatch.delenv("GENESIS_MODELS_MD_SYNTHESIS_OFF", raising=False)
+        monkeypatch.setattr(
+            env, "_local_config", lambda: {"models_md_synthesis": {"enabled": False}}
+        )
+        assert env.models_md_synthesis_enabled() is False
+
+    @pytest.mark.asyncio
+    async def test_runner_short_circuits_when_disabled(self, monkeypatch):
+        from genesis.surplus.jobs import runners
+
+        monkeypatch.setenv("GENESIS_MODELS_MD_SYNTHESIS_OFF", "1")
+        sched = MagicMock()
+        sched._models_md_synthesis_job = MagicMock()
+        sched._models_md_synthesis_job.run = AsyncMock()
+
+        await runners.run_models_md_synthesis(sched)
+
+        # Disabled → the job is never invoked.
+        sched._models_md_synthesis_job.run.assert_not_called()
 
 
 class TestParseBody:

--- a/tests/test_scripts/test_promote_models_md.py
+++ b/tests/test_scripts/test_promote_models_md.py
@@ -1,0 +1,78 @@
+"""Tests for scripts/promote_models_md.sh — overlay → tracked-reference copy.
+
+Runs the REAL script against a throwaway repo + overlay in tmp_path, driving
+the tracked doc location via the script's own layout and the overlay location
+via GENESIS_OUTPUT_DIR. Covers: happy-path copy, the missing-overlay guard
+(non-zero exit + guidance), and the identical-content no-op branch.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "promote_models_md.sh"
+
+
+def _fake_repo(tmp_path: Path) -> Path:
+    """A tmp dir shaped like the repo, with the script reachable at scripts/."""
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "docs" / "reference").mkdir(parents=True)
+    # The script resolves REPO_ROOT from its own location, so copy it in.
+    dst = repo / "scripts" / "promote_models_md.sh"
+    dst.write_text(_SCRIPT.read_text())
+    dst.chmod(0o755)
+    return repo
+
+
+def _run(repo: Path, output_dir: Path):
+    env = dict(os.environ)
+    env["GENESIS_OUTPUT_DIR"] = str(output_dir)
+    return subprocess.run(
+        ["bash", str(repo / "scripts" / "promote_models_md.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def test_copies_overlay_onto_tracked(tmp_path):
+    repo = _fake_repo(tmp_path)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    (output_dir / "models.md").write_text("OVERLAY v2\n")
+    tracked = repo / "docs" / "reference" / "models.md"
+    tracked.write_text("OLD TRACKED\n")
+
+    result = _run(repo, output_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert tracked.read_text() == "OVERLAY v2\n"
+
+
+def test_missing_overlay_exits_nonzero(tmp_path):
+    repo = _fake_repo(tmp_path)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()  # no models.md inside
+
+    result = _run(repo, output_dir)
+
+    assert result.returncode != 0
+    assert "No overlay" in result.stderr
+
+
+def test_identical_content_is_noop(tmp_path):
+    repo = _fake_repo(tmp_path)
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    (output_dir / "models.md").write_text("SAME\n")
+    tracked = repo / "docs" / "reference" / "models.md"
+    tracked.write_text("SAME\n")
+
+    result = _run(repo, output_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert "already identical" in result.stdout


### PR DESCRIPTION
## Problem

The weekly `models_md_synthesis` job dispatched a background session that edited
the **tracked** file `docs/reference/models.md` and `git commit`ed it. That job
runs on every clone, so each install's `main` accumulated local synthesis
commits and diverged from upstream — making a routine `git pull` conflict on
`models.md`. Nothing in `src/` reads the file programmatically (it's a
human/LLM-facing reference), so the divergence was pure workflow cost.

## Change

The job now refreshes a **local overlay** instead of tracked source:

- `recon/models_md_synthesis.py` — `run()` targets `~/.genesis/output/models.md`
  (via `env.output_dir()`), seeded once from the tracked reference doc if absent
  (seed-if-absent, mirroring `setup-local-config.sh`) and updated in place with
  **no git commit**. The prompt drops the `git add`/`commit` step, and
  `tool_exceptions` tightens from `("Write", "Bash")` to `("Write",)` since the
  session no longer shells out. The overlay is a per-install fork, not a mirror
  (delete it to re-seed from the current tracked doc).
- `scripts/promote_models_md.sh` (new) — copies a reviewed overlay back onto the
  tracked reference for a deliberate, PR-reviewed public refresh.
- `env.models_md_synthesis_enabled()` (new) — operator lever
  (`GENESIS_MODELS_MD_SYNTHESIS_OFF` env / `models_md_synthesis.enabled` local
  config, default **on**), checked in the runner and mirroring
  `build_lane_enabled`. The job previously had no dedicated off-switch.

The tracked `docs/reference/models.md` stays a maintainer-curated reference, so
every existing pointer to it (config comments, docs index) remains valid.

## Tests

- `tests/test_recon/test_models_md_synthesis.py` — overlay seed-once, prompt
  targets the overlay, no git in the prompt, `Write`-only tools, no-seed skip;
  lever semantics (env / local config / default) and runner short-circuit.
- `tests/test_scripts/test_promote_models_md.py` — copy, missing-overlay guard,
  identical-content no-op.

35 tests green; `ruff` clean; `shellcheck` clean. Verified end-to-end against
real paths: the job seeds the overlay from the real tracked doc while leaving
the tracked doc untouched and git-clean; the lever short-circuits the runner
when off; the promote script copies, no-ops on identical content, and guards a
missing overlay.
