### PR TITLE
feat(surplus): split staged ideation — ideas → review lane, self-obs → observations (WS-M PR-2)

### DIFF
--- a/config/surplus_ideation_promotion.yaml
+++ b/config/surplus_ideation_promotion.yaml
@@ -1,0 +1,15 @@
+# Surplus ideation → follow_ups 'idea' review-lane promotion pass (WS-M PR-2).
+#
+# After PR-2's intake split, brainstorm ideas are staged in surplus_insights; a
+# capped, FIFO promotion pass in the surplus maintenance GC graduates the pending
+# ones into the follow_ups 'idea' review lane (browse/triage in the cockpit).
+#
+# enabled     — master switch. false (or env GENESIS_SURPLUS_IDEATION_PROMOTION_DISABLED=1)
+#               stops promotion; staged ideas then just TTL-decay (pre-PR-2 behaviour).
+# cap_per_run — max ideas promoted per GC pass (protects the lane; overflow waits
+#               for the next pass or decays).
+#
+# Read live each GC pass — takes effect without a restart. Overlay in
+# surplus_ideation_promotion.local.yaml to customize per install.
+enabled: true
+cap_per_run: 20

--- a/src/genesis/dashboard/routes/follow_ups.py
+++ b/src/genesis/dashboard/routes/follow_ups.py
@@ -42,7 +42,7 @@ _COCKPIT_STATUSES = (
 )
 # Terminal states hidden by the cockpit's default "hide done" view.
 _DONE_STATUSES = ["completed", "failed"]
-_BATCH_ACTIONS = ("done", "delete", "tabled", "follow_up")
+_BATCH_ACTIONS = ("done", "delete", "tabled", "follow_up", "idea")
 
 
 @blueprint.route("/api/genesis/follow-ups/cockpit")

--- a/src/genesis/dashboard/templates/partials/tabs/follow_ups.html
+++ b/src/genesis/dashboard/templates/partials/tabs/follow_ups.html
@@ -213,7 +213,7 @@
                     </select>
                     <button x-show="item.kind !== 'tabled'" @click.stop="$store.genesisDashboard.cockpitMoveKind(item.id, 'tabled')"
                             style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(149,117,205,0.1); color:#9575cd; border:1px solid rgba(149,117,205,0.25);">→ Tabled</button>
-                    <button x-show="item.kind === 'tabled'" @click.stop="$store.genesisDashboard.cockpitMoveKind(item.id, 'follow_up')"
+                    <button x-show="item.kind !== 'follow_up'" @click.stop="$store.genesisDashboard.cockpitMoveKind(item.id, 'follow_up')"
                             style="font-size:0.65rem; padding:0.15rem 0.5rem; border-radius:3px; cursor:pointer; background:rgba(33,150,243,0.1); color:#2196F3; border:1px solid rgba(33,150,243,0.2);">→ Follow-up</button>
                     <select @click.stop
                             @change.stop="$store.genesisDashboard.cockpitSetDomain(item.id, $event.target.value); $event.target.selectedIndex=0;"

--- a/src/genesis/dashboard/templates/partials/tabs/follow_ups.html
+++ b/src/genesis/dashboard/templates/partials/tabs/follow_ups.html
@@ -14,7 +14,7 @@
       <div class="panel-body">
         <!-- Tier toggle: follow_up | tabled | all -->
         <div style="display:flex; gap:0.25rem; margin-bottom:0.6rem; align-items:center; flex-wrap:wrap;">
-          <template x-for="tier in [{k:'follow_up',l:'Follow-ups'},{k:'tabled',l:'Tabled'},{k:'',l:'All'}]" :key="tier.l">
+          <template x-for="tier in [{k:'follow_up',l:'Follow-ups'},{k:'tabled',l:'Tabled'},{k:'idea',l:'Ideas'},{k:'',l:'All'}]" :key="tier.l">
             <button style="font-size:0.7rem; padding:0.2rem 0.7rem; border-radius:3px; cursor:pointer; border:1px solid #555;"
                     :style="$store.genesisDashboard.cockpitFilters.kind === tier.k ? 'background:rgba(33,150,243,0.18); color:#2196F3; border-color:rgba(33,150,243,0.4); font-weight:600;' : 'background:transparent; color:var(--color-text-secondary);'"
                     @click="$store.genesisDashboard.cockpitFilters.kind = tier.k; $store.genesisDashboard.cockpitApplyFilter()"

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -523,6 +523,45 @@ async def purge_completed(
     return cursor.rowcount
 
 
+async def _decay_stale(
+    db: aiosqlite.Connection,
+    *,
+    source: str,
+    kind: str,
+    older_than_days: int,
+) -> int:
+    """Soft-decay stale NON-TERMINAL follow_ups of a ``(source, kind)`` lane.
+
+    A status flip (not a DELETE): every non-terminal row (``pending`` and —
+    defensively — ``blocked``/``in_progress``/``scheduled``) older than
+    *older_than_days* is flipped to ``completed`` with a decay note, so the
+    retention sweep (``purge_completed``) can later hard-delete it. Terminal
+    ``completed``/``failed`` rows already carry a ``completed_at`` and are the
+    purge sweep's job — excluding them keeps the two sweeps' responsibilities
+    disjoint (without this breadth a ``blocked`` marker would be immortal, skipped
+    by both). Shared by the inbox-marker and idea-lane decays.
+    """
+    older_than_days = max(1, older_than_days)
+    cutoff = (datetime.now(UTC) - timedelta(days=older_than_days)).isoformat()
+    cursor = await db.execute(
+        "UPDATE follow_ups "
+        "SET status = 'completed', completed_at = ?, resolution_notes = ? "
+        "WHERE source = ? "
+        "AND kind = ? "
+        "AND status NOT IN ('completed', 'failed') "
+        "AND created_at < ?",
+        (
+            _now_iso(),
+            f"decayed: not promoted within {older_than_days}d",
+            source,
+            kind,
+            cutoff,
+        ),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
 async def decay_stale_inbox_markers(
     db: aiosqlite.Connection,
     *,
@@ -535,34 +574,30 @@ async def decay_stale_inbox_markers(
     ego judgment (the ego has no authority to discard a user-curated marker). A
     marker that is never promoted eventually goes stale; this sweep ages such
     markers out by marking them ``completed`` with a decay note after
-    *older_than_days*.
-
-    This is a SOFT transition (a status flip, not a DELETE): the row is retained
-    and could be reactivated before the retention sweep (``purge_completed``)
-    eventually hard-deletes it. It targets every NON-TERMINAL tabled inbox
-    marker (``pending`` and — defensively — ``blocked``/``in_progress``/
-    ``scheduled`` a marker could be moved into via the cockpit/ego): terminal
-    ``completed``/``failed`` rows already carry a ``completed_at`` and are reaped
-    by ``purge_completed``, so excluding them here keeps the two sweeps'
-    responsibilities disjoint. Without this breadth a ``blocked`` tabled marker
-    would be immortal — decay (pending-only) and purge (completed/failed-only)
-    would both skip it. Non-inbox / non-tabled follow-ups are left untouched.
+    *older_than_days*. Non-inbox / non-tabled follow-ups are left untouched.
 
     Returns the number of markers decayed.
     """
-    older_than_days = max(1, older_than_days)
-    cutoff = (datetime.now(UTC) - timedelta(days=older_than_days)).isoformat()
-    cursor = await db.execute(
-        "UPDATE follow_ups "
-        "SET status = 'completed', completed_at = ?, resolution_notes = ? "
-        "WHERE source = 'inbox_evaluation' "
-        "AND kind = 'tabled' "
-        "AND status NOT IN ('completed', 'failed') "
-        "AND created_at < ?",
-        (_now_iso(), f"decayed: not promoted within {older_than_days}d", cutoff),
+    return await _decay_stale(
+        db, source="inbox_evaluation", kind="tabled", older_than_days=older_than_days
     )
-    await db.commit()
-    return cursor.rowcount
+
+
+async def decay_stale_ideas(
+    db: aiosqlite.Connection,
+    *,
+    older_than_days: int = 45,
+) -> int:
+    """Soft-decay un-triaged staged-ideation ideas (``source='surplus_ideation'``,
+    ``kind='idea'``) never converted to an actionable follow-up or dismissed — so
+    the review lane doesn't grow unbounded. Same soft-flip → ``purge_completed``
+    reap lifecycle as the inbox marker decay.
+
+    Returns the number of ideas decayed.
+    """
+    return await _decay_stale(
+        db, source="surplus_ideation", kind="idea", older_than_days=older_than_days
+    )
 
 
 async def get_recently_completed(
@@ -602,7 +637,7 @@ async def get_recently_completed(
 # dashboard Follow-ups tab). Pure data layer; kept here alongside the table.
 # ---------------------------------------------------------------------------
 
-_VALID_KIND = {"follow_up", "tabled"}
+_VALID_KIND = {"follow_up", "tabled", "idea"}
 _VALID_DOMAIN = {"internal", "user_world"}
 _VALID_PRIORITY = {"low", "medium", "high", "critical"}
 _VALID_STATUS = {

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -372,14 +372,24 @@ async def get_summary_counts(
     db: aiosqlite.Connection,
     *,
     include_tabled: bool = True,
+    kind: str | None = None,
 ) -> dict[str, int]:
     """Get counts by status for dashboard badges.
 
     include_tabled defaults True (existing callers unchanged); pass False to
-    count only the actionable ``follow_up`` lane."""
-    kind_where = "" if include_tabled else "WHERE kind = 'follow_up' "
+    count only the actionable ``follow_up`` lane. When ``kind`` is set, count
+    ONLY that specific kind (overrides include_tabled) — so a lane like
+    ``'tabled'`` or ``'idea'`` is counted directly rather than by subtraction,
+    which would conflate the non-follow_up kinds once a third kind exists."""
+    if kind is not None:
+        kind_where = "WHERE kind = ? "
+        params: tuple = (kind,)
+    else:
+        kind_where = "" if include_tabled else "WHERE kind = 'follow_up' "
+        params = ()
     cursor = await db.execute(
-        f"SELECT status, COUNT(*) FROM follow_ups {kind_where}GROUP BY status"
+        f"SELECT status, COUNT(*) FROM follow_ups {kind_where}GROUP BY status",
+        params,
     )
     return {row[0]: row[1] for row in await cursor.fetchall()}
 

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -183,6 +183,18 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "quarantined_reflection": timedelta(days=14),
     "code_audit": timedelta(days=14),
     "cc_memory_staleness": timedelta(days=14),
+    # WS-M PR-2 self-observation ideation — self-directed audits / gap-cluster /
+    # unblock / prompt-review output routed here (instead of the immortal KB) by
+    # surplus/intake.py Step 3a. Meta-observations about Genesis's own state:
+    # NOT in INTERNAL_OBS_TYPES (they surface in the dashboard observations panel
+    # for review), written at priority="low" so they never crowd the capped
+    # morning-report digest. 14d matches the sibling audit/meta types above.
+    "gap_clustering": timedelta(days=14),
+    "wing_audit": timedelta(days=14),
+    "self_unblock": timedelta(days=14),
+    "memory_audit": timedelta(days=14),
+    "procedure_audit": timedelta(days=14),
+    "prompt_effectiveness_review": timedelta(days=14),
     # provider_failure resolves on breaker recovery (ProviderEscalation); the
     # explicit TTL is only a backstop for a provider that never comes back
     # (= the previous implicit default, made explicit to silence the warning).

--- a/src/genesis/db/crud/surplus.py
+++ b/src/genesis/db/crud/surplus.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import aiosqlite
 
 
@@ -87,6 +89,35 @@ async def count_pending(db: aiosqlite.Connection) -> int:
     )
     row = await cursor.fetchone()
     return row[0] if row else 0
+
+
+async def list_promotable_ideas(
+    db: aiosqlite.Connection,
+    *,
+    task_types: Sequence[str],
+    limit: int,
+) -> list[dict]:
+    """Pending, unexpired staged ideation rows eligible for promotion into the
+    follow_ups 'idea' review lane (WS-M PR-2).
+
+    Filtered to ``task_types`` (surplus_insights is a shared table — only genuine
+    IDEA task types graduate) and ttl-unexpired (matching purge_expired's parser).
+    Ordered oldest-first (FIFO): curated ideas all tie at ~0.6 confidence, so
+    created_at order is the fair graduation order and guarantees every item is
+    seen before it decays when capacity suffices.
+    """
+    if not task_types:
+        return []
+    placeholders = ", ".join("?" for _ in task_types)
+    cursor = await db.execute(
+        "SELECT * FROM surplus_insights "
+        "WHERE promotion_status = 'pending' "
+        f"AND source_task_type IN ({placeholders}) "  # noqa: S608 - bound params
+        "AND (ttl = '' OR datetime(REPLACE(ttl, 'T', ' ')) >= datetime('now')) "
+        "ORDER BY created_at ASC LIMIT ?",
+        (*task_types, limit),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
 
 
 async def promote(db: aiosqlite.Connection, id: str, *, promoted_to: str) -> bool:

--- a/src/genesis/db/migrations/0076_follow_ups_idea_kind.py
+++ b/src/genesis/db/migrations/0076_follow_ups_idea_kind.py
@@ -1,0 +1,121 @@
+"""Add ``follow_ups.kind = 'idea'`` — the WS-M PR-2 ideas review lane.
+
+SQLite cannot ALTER a CHECK constraint, so widening ``kind IN ('follow_up',
+'tabled')`` to also allow ``'idea'`` requires a full table rebuild: create a
+``follow_ups_new`` with the corrected CHECK, copy rows over the column
+intersection, drop the original, rename into place, and recreate every index.
+
+The ``'idea'`` lane holds autonomous brainstorm findings promoted from
+surplus_insights staging; like ``'tabled'`` it is auto-excluded from every
+dispatch reader (they positively filter ``kind = 'follow_up'``), so this is a
+browse/review lane, never auto-dispatched.
+
+Self-contained + idempotent (mirrors 0012's CHECK-rebuild): guards on the live
+DDL already containing ``'idea'`` (fresh DBs get it from the canonical CREATE in
+_tables.py; a re-run is a no-op). The row copy uses ``_intersection_copy`` so a
+future column added to _tables.py but not here can never silently drop data — it
+RAISES, and (per the runner's atomic BEGIN/COMMIT + rollback) the raise rolls the
+whole migration back rather than false-greening a partial COMMIT; we therefore do
+NOT wrap it in try/except. No ``db.commit()`` — the runner owns the transaction.
+
+(Numbered 0076: 0075 is the highest present; the runner applies by per-id
+tracking and only duplicate prefixes are fatal.)
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+from genesis.db.schema._migrations import _intersection_copy
+
+# Full canonical follow_ups column set (must match _tables.py's CREATE verbatim,
+# revisit_condition LAST for fresh/migrated column-order parity) — only the kind
+# CHECK differs between up() (3 values) and down() (2 values).
+_COLUMNS_TEMPLATE = """
+    id               TEXT PRIMARY KEY,
+    source           TEXT NOT NULL,
+    source_session   TEXT,
+    content          TEXT NOT NULL,
+    reason           TEXT,
+    strategy         TEXT NOT NULL CHECK (
+        strategy IN ('scheduled_task', 'surplus_task', 'ego_judgment', 'user_input_needed')
+    ),
+    scheduled_at     TEXT,
+    status           TEXT NOT NULL DEFAULT 'pending' CHECK (
+        status IN ('pending', 'scheduled', 'in_progress', 'completed', 'failed', 'blocked')
+    ),
+    linked_task_id   TEXT,
+    priority         TEXT NOT NULL DEFAULT 'medium' CHECK (
+        priority IN ('low', 'medium', 'high', 'critical')
+    ),
+    created_at       TEXT NOT NULL,
+    completed_at     TEXT,
+    resolution_notes TEXT,
+    blocked_reason   TEXT,
+    escalated_to     TEXT,
+    verified_at      TEXT,
+    verification_notes TEXT,
+    pinned           INTEGER NOT NULL DEFAULT 0,
+    kind             TEXT NOT NULL DEFAULT 'follow_up' CHECK (
+        kind IN ({kind_values})
+    ),
+    domain           TEXT CHECK (
+        domain IN ('internal', 'user_world')
+    ),
+    goal_id          TEXT,
+    dedup_key        TEXT,
+    revisit_condition TEXT
+"""
+
+_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_follow_ups_status ON follow_ups(status)",
+    "CREATE INDEX IF NOT EXISTS idx_follow_ups_scheduled ON follow_ups(scheduled_at)",
+    "CREATE INDEX IF NOT EXISTS idx_follow_ups_source ON follow_ups(source)",
+    "CREATE INDEX IF NOT EXISTS idx_follow_ups_linked_task ON follow_ups(linked_task_id)",
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_follow_ups_dedup "
+    "ON follow_ups(dedup_key) WHERE dedup_key IS NOT NULL",
+)
+
+
+async def _rebuild(db: aiosqlite.Connection, *, kind_values: str) -> None:
+    """Rebuild follow_ups with the given kind CHECK, preserving all rows/indexes."""
+    await db.execute("DROP TABLE IF EXISTS follow_ups_new")
+    await db.execute(
+        f"CREATE TABLE follow_ups_new ({_COLUMNS_TEMPLATE.format(kind_values=kind_values)})"
+    )
+    # Copy over the column intersection (raise-on-drift — do NOT swallow; the
+    # runner rolls the migration back on the raise, never a partial COMMIT).
+    await _intersection_copy(db, src="follow_ups", dst="follow_ups_new")
+    await db.execute("DROP TABLE follow_ups")
+    await db.execute("ALTER TABLE follow_ups_new RENAME TO follow_ups")
+    for stmt in _INDEXES:
+        await db.execute(stmt)
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='follow_ups'"
+    )
+    row = await cursor.fetchone()
+    if not row:
+        return  # fresh DB — the canonical CREATE already carries the 'idea' CHECK
+    ddl = row[0] or ""
+    if "'idea'" in ddl:
+        return  # already widened
+    await _rebuild(db, kind_values="'follow_up', 'tabled', 'idea'")
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='follow_ups'"
+    )
+    row = await cursor.fetchone()
+    if not row:
+        return
+    ddl = row[0] or ""
+    if "'idea'" not in ddl:
+        return  # already narrowed
+    # Preserve data: reclassify any 'idea' rows to 'tabled' so the narrowed CHECK
+    # is satisfiable, then rebuild without 'idea'.
+    await db.execute("UPDATE follow_ups SET kind = 'tabled' WHERE kind = 'idea'")
+    await _rebuild(db, kind_values="'follow_up', 'tabled'")

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1287,7 +1287,7 @@ TABLES = {
             verification_notes TEXT,
             pinned           INTEGER NOT NULL DEFAULT 0,
             kind             TEXT NOT NULL DEFAULT 'follow_up' CHECK (
-                kind IN ('follow_up', 'tabled')
+                kind IN ('follow_up', 'tabled', 'idea')
             ),
             domain           TEXT CHECK (
                 domain IN ('internal', 'user_world')

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -205,8 +205,12 @@ async def _impl_follow_up_list(
             "total": sum(counts.values()),
         }
         if not include_tabled:
-            all_counts = await follow_ups.get_summary_counts(db, include_tabled=True)
-            result["tabled_count"] = sum(all_counts.values()) - sum(counts.values())
+            # Count each non-follow_up lane DIRECTLY (not by subtraction, which
+            # would lump 'idea' into 'tabled' now that a third kind exists).
+            tabled_counts = await follow_ups.get_summary_counts(db, kind="tabled")
+            idea_counts = await follow_ups.get_summary_counts(db, kind="idea")
+            result["tabled_count"] = sum(tabled_counts.values())
+            result["idea_count"] = sum(idea_counts.values())
         return result
     except Exception as exc:
         logger.error("follow_up_list failed", exc_info=True)

--- a/src/genesis/mcp/health/inbox_digest.py
+++ b/src/genesis/mcp/health/inbox_digest.py
@@ -66,14 +66,22 @@ async def _impl_inbox_digest(
         # 3. Recent completed evaluations
         evals = await inbox_crud.get_recent_completed(db, days=days)
 
+        # 4. Pending ideas (surplus-ideation review lane, WS-M PR-2). The same
+        # review spine as inbox follow-ups, filtered to the 'idea' kind.
+        ideas = await fu_crud.query_page(
+            db, kind="idea", source="surplus_ideation", status="pending", limit=25,
+        )
+
         # Build formatted output
-        formatted = _format_digest(pending, resolved, evals, days)
+        formatted = _format_digest(pending, resolved, evals, days, ideas)
 
         # Summary line
         parts = [f"{len(pending)} pending"]
         if resolved:
             parts.append(f"{len(resolved)} resolved")
         parts.append(f"{len(evals)} evaluated")
+        if ideas:
+            parts.append(f"{len(ideas)} ideas")
         summary = f"Inbox digest ({days}d): {', '.join(parts)}"
 
         return {
@@ -81,6 +89,7 @@ async def _impl_inbox_digest(
             "pending_follow_ups": pending,
             "resolved_follow_ups": resolved,
             "recent_evaluations": evals,
+            "pending_ideas": ideas,
             "formatted": formatted,
         }
     except Exception as exc:
@@ -93,8 +102,10 @@ def _format_digest(
     resolved: list[dict],
     evals: list[dict],
     days: int,
+    ideas: list[dict] | None = None,
 ) -> str:
     """Format digest data into markdown tables."""
+    ideas = ideas or []
     lines = [f"## Inbox Digest — Last {days} Days", ""]
 
     # Pending action items
@@ -108,6 +119,18 @@ def _format_digest(
             content = fu.get("content", "")[:120]
             strategy = fu.get("strategy", "")
             lines.append(f"| {priority} | {content} | {strategy} |")
+        lines.append("")
+
+    # Pending ideas (surplus-ideation review lane)
+    if ideas:
+        lines.append(f"### Pending Ideas ({len(ideas)} items)")
+        lines.append("")
+        lines.append("| Idea | Source |")
+        lines.append("|------|--------|")
+        for fu in ideas:
+            content = fu.get("content", "")[:120]
+            src = fu.get("source", "")
+            lines.append(f"| {content} | {src} |")
         lines.append("")
 
     # Resolved items
@@ -142,7 +165,7 @@ def _format_digest(
             lines.append(f"| {date} | {source_file} | {response} |")
         lines.append("")
 
-    if not pending and not resolved and not evals:
+    if not pending and not resolved and not evals and not ideas:
         lines.append("No inbox activity in this period.")
         lines.append("")
 

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -241,6 +241,20 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # re-read every ego cycle
     ),
+    "surplus_ideation_promotion": SettingsDomain(
+        name="surplus_ideation_promotion",
+        description=(
+            "Surplus ideation → follow_ups 'idea' review lane promotion (WS-M PR-2). "
+            "master `enabled` + `cap_per_run`. When on, the surplus maintenance GC "
+            "graduates pending staged brainstorm ideas into the cockpit 'idea' lane, "
+            "capped per pass (FIFO). off (or env "
+            "GENESIS_SURPLUS_IDEATION_PROMOTION_DISABLED=1) stops promotion — staged "
+            "ideas just TTL-decay. Read live each GC pass — no restart."
+        ),
+        config_filename="surplus_ideation_promotion.yaml",
+        readonly=False,
+        needs_restart=False,  # re-read every GC pass
+    ),
     "voice_act": SettingsDomain(
         name="voice_act",
         description=(
@@ -1264,8 +1278,30 @@ def _validate_memory_integrity(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_surplus_ideation_promotion(changes: dict) -> list[str]:
+    """Validate surplus ideation-promotion lever changes (see
+    genesis.surplus.promotion_config). Runtime already fails safe (disabled on a
+    bad `enabled`, default cap on a bad knob); this rejects bad WRITES so
+    settings_update reports the error instead of silently persisting e.g.
+    `enabled: "false"` (truthy) or a zero cap."""
+    from genesis.surplus.promotion_config import INT_KNOBS
+
+    errors: list[str] = []
+    valid_keys = ("enabled", *INT_KNOBS)
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            errors.append(f"'{key}' must be a positive int")
+    return errors
+
+
 _DOMAIN_VALIDATORS: dict[str, Any] = {
     "ego_reconcile": _validate_ego_reconcile,
+    "surplus_ideation_promotion": _validate_surplus_ideation_promotion,
     "memory_integrity": _validate_memory_integrity,
     "entity_adjudication": _validate_entity_adjudication,
     "cc_rate_limit_resume": _validate_cc_rate_limit_resume,

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -674,6 +674,42 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=3600,
         )
 
+        async def _idea_lane_decay_sweep() -> None:
+            # Soft-age-out un-triaged ideas in the surplus-ideation review lane
+            # (source='surplus_ideation', kind='idea'): status→completed after
+            # 45d, then reaped by the retention sweep. Mechanical TTL, like the
+            # inbox marker decay above — the review lane must not grow unbounded.
+            try:
+                if rt.paused:
+                    return
+            except Exception:
+                logger.warning(
+                    "Pause check failed — skipping idea lane decay",
+                    exc_info=True,
+                )
+                return
+            try:
+                from genesis.db.crud import follow_ups
+
+                decayed = await follow_ups.decay_stale_ideas(rt._db)
+                rt.record_job_success("idea_lane_decay")
+                if decayed:
+                    logger.info(
+                        "Idea lane decay: aged out %d un-triaged idea(s)",
+                        decayed,
+                    )
+            except Exception as exc:
+                rt.record_job_failure("idea_lane_decay", exc=exc)
+                logger.exception("Idea lane decay sweep failed")
+
+        rt._learning_scheduler.add_job(
+            _idea_lane_decay_sweep,
+            CronTrigger(hour=4, minute=45, timezone=user_timezone()),
+            id="idea_lane_decay",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+
         async def _run_recovery() -> None:
             if rt._recovery_orchestrator is not None:
                 try:

--- a/src/genesis/surplus/intake.py
+++ b/src/genesis/surplus/intake.py
@@ -574,37 +574,55 @@ async def run_intake(
         ]
         stats.scoring_skipped = True
 
-    # Step 3a: Ephemeral first-party ideation (self-directed brainstorm /
-    # unblock / audit output) is NOT durable knowledge — stage it in
-    # surplus_insights for the ideas-review lifecycle (TTL decay) instead of
-    # immortalizing it as a knowledge_unit. Keyed on the TRUE task type
-    # (source_task_type), preserved distinct from the collapsed IntakeSource.
-    from genesis.surplus.types import is_ephemeral_ideation
+    # Step 3a: Ephemeral first-party ideation is kept OUT of the immortal
+    # knowledge_units KB (PR-1). WS-M PR-2 splits it by semantics, keyed on the
+    # TRUE task type (source_task_type), preserved distinct from the collapsed
+    # IntakeSource:
+    #   • IDEAS (brainstorm) → surplus_insights staging (later promoted into the
+    #     follow_ups 'idea' review lane).
+    #   • SELF-OBSERVATIONS (audits / gap-cluster / unblock / prompt-review) →
+    #     the observation lane (TTL + resolve + dashboard/morning-report
+    #     surfacing), at priority="low" so they never crowd the capped daily
+    #     digest while staying browsable in the observations panel.
+    from genesis.surplus.types import is_ephemeral_ideation, is_idea_ideation
 
     if is_ephemeral_ideation(source_task_type):
+        route_ideas = is_idea_ideation(source_task_type)
         drive = _valid_drive(drive_alignment)
+        routed = 0
         for scored in scored_findings:
             try:
-                sid = await _route_to_staging(scored, db=db, drive_alignment=drive)
-                stats.staged_ids.append(sid)
-                stats.routed_staging += 1
+                if route_ideas:
+                    sid = await _route_to_staging(
+                        scored, db=db, drive_alignment=drive
+                    )
+                    stats.staged_ids.append(sid)
+                    stats.routed_staging += 1
+                else:
+                    await _route_to_observation(
+                        scored, db=db, priority="low", skip_if_duplicate=True
+                    )
+                    stats.routed_observation += 1
+                routed += 1
             except Exception as exc:
                 logger.error(
-                    "Intake staging failed for finding '%s': %s",
+                    "Intake ideation routing failed for finding '%s': %s",
                     scored.finding.title[:50], exc, exc_info=True,
                 )
                 stats.errors.append(f"{scored.finding.title[:50]}: {exc}")
         logger.info(
-            "Intake(staging): source=%s task=%s findings=%d staged=%d errors=%d",
-            stats.source, source_task_type, stats.findings_count,
-            stats.routed_staging, len(stats.errors),
+            "Intake(ideation): source=%s task=%s dest=%s findings=%d "
+            "routed=%d errors=%d",
+            stats.source, source_task_type,
+            "staging" if route_ideas else "observation",
+            stats.findings_count, routed, len(stats.errors),
         )
-        # If EVERY staging write failed, raise so the caller falls back
-        # (dispatch re-stages into surplus_insights via its own path).
-        if stats.findings_count > 0 and stats.routed_staging == 0 and stats.errors:
+        # If EVERY write failed, raise so the caller falls back (dispatch
+        # re-stages into surplus_insights via its own path).
+        if stats.findings_count > 0 and routed == 0 and stats.errors:
             raise RuntimeError(
-                f"Intake staging failed for all {stats.findings_count} findings: "
-                f"{stats.errors[0]}"
+                f"Intake ideation routing failed for all "
+                f"{stats.findings_count} findings: {stats.errors[0]}"
             )
         return stats
 
@@ -720,16 +738,22 @@ async def _route_to_observation(
     scored: ScoredFinding,
     *,
     db: aiosqlite.Connection,
+    priority: str = "medium",
+    skip_if_duplicate: bool = False,
 ) -> None:
-    """Create an observation for pattern-level insights."""
+    """Create an observation for pattern-level insights.
+
+    ``skip_if_duplicate`` (used by the self-observation ideation path) keys on
+    source + content_hash so a re-emitted identical finding is idempotent —
+    matching the content-hash-id upsert idempotency of the staging path. The
+    legacy pattern-insight caller keeps the default (priority="medium", no
+    dedup) so its behaviour is unchanged.
+    """
     from genesis.db.crud import observations
 
     obs_id = str(uuid.uuid4())
     now = datetime.now(UTC).isoformat()
-    content = (
-        f"{scored.finding.title}\n\n"
-        f"{scored.finding.content}"
-    )
+    content = f"{scored.finding.title}\n\n{scored.finding.content}"
     if scored.finding.relevance:
         content += f"\n\nRelevance: {scored.finding.relevance}"
 
@@ -739,8 +763,9 @@ async def _route_to_observation(
         source=f"intake:{scored.source.value}",
         type=scored.source_task_type or "intelligence_finding",
         content=content[:2000],
-        priority="medium",
+        priority=priority,
         created_at=now,
+        skip_if_duplicate=skip_if_duplicate,
     )
 
 

--- a/src/genesis/surplus/jobs/gates.py
+++ b/src/genesis/surplus/jobs/gates.py
@@ -145,6 +145,62 @@ async def schedule_model_eval(sched: SchedulerContext) -> None:
         )
 
 
+async def _promote_staged_ideas(db: aiosqlite.Connection) -> int:
+    """Graduate pending staged ideation into the follow_ups 'idea' review lane.
+
+    WS-M PR-2. Capped + FIFO + idempotent (a stable dedup_key spans all statuses
+    so a completed/dismissed idea is never recreated, and promote() flips the
+    staged row out of 'pending' so the next pass skips it). Crash-consistent: the
+    follow_up create and the surplus promote are separate commits, so a crash
+    between them leaves the staged row pending with its follow_up already present
+    — the next pass's exists_by_dedup_key precheck reconciles it. Gated by the
+    surplus_ideation_promotion settings lever; returns the count promoted.
+    """
+    import hashlib
+
+    import aiosqlite as _aiosqlite
+
+    from genesis.db.crud import follow_ups as fu_crud
+    from genesis.surplus.promotion_config import cap_per_run, is_enabled
+    from genesis.surplus.types import IDEA_TASK_TYPES
+
+    if not is_enabled():
+        return 0
+
+    task_types = [str(t) for t in IDEA_TASK_TYPES]
+    rows = await surplus_crud.list_promotable_ideas(db, task_types=task_types, limit=cap_per_run())
+    promoted = 0
+    for row in rows:
+        sid = row["id"]
+        dedup_key = hashlib.sha256(f"surplus_ideation|{sid}".encode()).hexdigest()
+        try:
+            if await fu_crud.exists_by_dedup_key(db, dedup_key):
+                # Follow-up already exists (a prior crash-interrupted pass, or a
+                # user-completed idea) — flip the staged row out of pending.
+                await surplus_crud.promote(db, sid, promoted_to="follow_up:dedup")
+                continue
+            reason = f"{row['source_task_type']} · {row['drive_alignment']}"
+            fid = await fu_crud.create(
+                db,
+                content=row["content"],
+                source="surplus_ideation",
+                strategy="surplus_task",
+                reason=reason,
+                kind="idea",
+                domain="internal",
+                dedup_key=dedup_key,
+            )
+            await surplus_crud.promote(db, sid, promoted_to=f"follow_up:{fid}")
+            promoted += 1
+        except _aiosqlite.IntegrityError:
+            # Lost a dedup race (unique dedup index) — the follow_up exists;
+            # reconcile by flipping the staged row out of pending.
+            await surplus_crud.promote(db, sid, promoted_to="follow_up:dedup")
+        except Exception:
+            logger.warning("Idea promotion failed for surplus insight %s", sid, exc_info=True)
+    return promoted
+
+
 async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
     """GC operations — each wrapped individually so one failure doesn't skip the rest."""
     # Purge expired surplus insights (TTL enforcement)
@@ -162,6 +218,14 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
             logger.info("Deleted %d long-discarded surplus insights", deleted)
     except Exception:
         logger.warning("GC: surplus discarded purge failed", exc_info=True)
+
+    # Promote pending staged ideation into the follow_ups 'idea' review lane
+    try:
+        promoted = await _promote_staged_ideas(db)
+        if promoted:
+            logger.info("Promoted %d staged ideas to the 'idea' review lane", promoted)
+    except Exception:
+        logger.warning("GC: idea promotion failed", exc_info=True)
 
     # GC: remove completed/failed pending_embeddings older than 30 days
     try:

--- a/src/genesis/surplus/promotion_config.py
+++ b/src/genesis/surplus/promotion_config.py
@@ -83,9 +83,12 @@ def is_enabled() -> bool:
     """
     if os.environ.get(_ENV_KILL_SWITCH) == "1":
         return False
-    cfg = load_config()
-    # Hand-edited unquoted `enabled: off` parses as YAML-1.1 boolean False.
-    return bool(cfg.get("enabled", True))
+    value = load_config().get("enabled", True)
+    # Only a real bool enables. A non-bool (e.g. a hand-edited `enabled: "false"`
+    # string — which bool() would read as truthy) degrades toward LESS write
+    # authority: disabled. `enabled: off`/`no` parse as YAML-1.1 booleans and
+    # pass through unchanged.
+    return value if isinstance(value, bool) else False
 
 
 def cap_per_run() -> int:

--- a/src/genesis/surplus/promotion_config.py
+++ b/src/genesis/surplus/promotion_config.py
@@ -1,0 +1,97 @@
+"""Config lever for the surplus ideation → 'idea' review-lane promotion pass.
+
+WS-M PR-2. Cloned from ``ego.reconcile_config``'s shape: fresh-read-per-call,
+master ``enabled`` flag + an env kill switch, degrade-toward-less-authority on
+damage.
+
+The promotion pass (``surplus/jobs/gates.py::_run_maintenance_gc``) graduates
+pending, unexpired staged brainstorm ideas into the follow_ups ``'idea'`` review
+lane, capped per run. Disabling it stops promotion; staged ideas then simply
+TTL-decay in surplus_insights (the pre-PR-2 behaviour) — so ``disabled`` is the
+safe degrade direction, and both a bad read and the env kill switch resolve
+there.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports the public ``INT_KNOBS`` from here (never
+the reverse).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_NAME = "surplus_ideation_promotion.yaml"
+
+_ENV_KILL_SWITCH = "GENESIS_SURPLUS_IDEATION_PROMOTION_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "cap_per_run": 20,
+}
+
+# Public: the settings-domain validator imports these to check knobs.
+INT_KNOBS = ("cap_per_run",)
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or corrupt
+    files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("surplus_ideation_promotion base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("surplus_ideation_promotion overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def is_enabled() -> bool:
+    """Whether the promotion pass runs — read live.
+
+    Env kill switch or ``enabled: false`` → disabled (staged ideas just
+    TTL-decay). A corrupt/unreadable ``enabled`` is coerced by ``bool()``;
+    the safe direction is disabled, but a truthy default keeps the feature on
+    for a healthy install.
+    """
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return False
+    cfg = load_config()
+    # Hand-edited unquoted `enabled: off` parses as YAML-1.1 boolean False.
+    return bool(cfg.get("enabled", True))
+
+
+def cap_per_run() -> int:
+    """Max ideas promoted per GC pass — positive-int knob with DEFAULTS fallback
+    so config damage never zeroes a limit or crashes the pass."""
+    value = load_config().get("cap_per_run")
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS["cap_per_run"])
+    return value

--- a/src/genesis/surplus/types.py
+++ b/src/genesis/surplus/types.py
@@ -110,26 +110,43 @@ KB_ROUTING_TASK_TYPES: frozenset[TaskType] = INSIGHT_PRODUCING_TASK_TYPES | {
 }
 
 
-# Task types that produce EPHEMERAL first-party ideation — self-directed
-# brainstorm / unblock / audit output. These are Genesis-authored work-items and
-# system flags, NOT durable external knowledge, so the intake pipeline STAGES
-# them in surplus_insights (ideas-review lifecycle with TTL decay) instead of
-# immortalizing them as knowledge_units. They stay in KB_ROUTING_TASK_TYPES (so
-# dispatch still calls run_intake); run_intake reroutes them to staging by
-# checking is_ephemeral_ideation() on the TRUE task type. EXCLUDES
+# EPHEMERAL first-party ideation — self-directed brainstorm / unblock / audit
+# output. These are Genesis-authored work-items and system flags, NOT durable
+# external knowledge, so the intake pipeline keeps them OUT of the immortal
+# knowledge_units KB (PR-1's intent). They stay in KB_ROUTING_TASK_TYPES (so
+# dispatch still calls run_intake); run_intake's Step 3a reroutes them off the
+# KB path by checking is_ephemeral_ideation() on the TRUE task type. EXCLUDES
 # ANTICIPATORY_RESEARCH (genuine web-cited knowledge) and CODE_AUDIT (its own
 # curated FindingsBridge ingestion path — see dispatch.py::_route_insights).
-EPHEMERAL_IDEATION_TASK_TYPES: frozenset[TaskType] = frozenset({
-    TaskType.SELF_UNBLOCK,
+#
+# WS-M PR-2 splits ephemeral ideation into TWO populations with distinct honest
+# homes (content-verified: the two are genuinely different animals):
+#   • IDEA_TASK_TYPES — genuine feature ideas (brainstorm output) → staged in
+#     surplus_insights, then promoted into the follow_ups 'idea' review lane.
+#   • SELF_OBSERVATION_TASK_TYPES — meta-patterns / audits / blocker analyses
+#     about Genesis's own state → the observation lane (TTL + resolve +
+#     dashboard/morning-report surfacing), via _route_to_observation.
+# A type MUST be in exactly ONE subset; EPHEMERAL_IDEATION_TASK_TYPES is their
+# union (kept as the Step-3a intercept guard so neither subset falls through to
+# the KB route loop).
+IDEA_TASK_TYPES: frozenset[TaskType] = frozenset({
     TaskType.BRAINSTORM_SELF,
     TaskType.BRAINSTORM_USER,
     TaskType.META_BRAINSTORM,
-    TaskType.MEMORY_AUDIT,
-    TaskType.PROCEDURE_AUDIT,
+})
+
+SELF_OBSERVATION_TASK_TYPES: frozenset[TaskType] = frozenset({
+    TaskType.SELF_UNBLOCK,
     TaskType.GAP_CLUSTERING,
     TaskType.WING_AUDIT,
+    TaskType.MEMORY_AUDIT,
+    TaskType.PROCEDURE_AUDIT,
     TaskType.PROMPT_EFFECTIVENESS_REVIEW,
 })
+
+EPHEMERAL_IDEATION_TASK_TYPES: frozenset[TaskType] = (
+    IDEA_TASK_TYPES | SELF_OBSERVATION_TASK_TYPES
+)
 
 
 def is_ephemeral_ideation(task_type: str) -> bool:
@@ -141,6 +158,28 @@ def is_ephemeral_ideation(task_type: str) -> bool:
     """
     try:
         return TaskType(task_type) in EPHEMERAL_IDEATION_TASK_TYPES
+    except ValueError:
+        return False
+
+
+def is_idea_ideation(task_type: str) -> bool:
+    """True if the surplus task-type is a genuine feature IDEA (brainstorm).
+
+    Ideas are staged in surplus_insights and promoted into the follow_ups
+    'idea' review lane. Unknown/empty strings → False.
+    """
+    try:
+        return TaskType(task_type) in IDEA_TASK_TYPES
+    except ValueError:
+        return False
+
+
+def is_self_observation_ideation(task_type: str) -> bool:
+    """True if the surplus task-type is a self-observation (audit / gap-cluster /
+    unblock / prompt-review) routed to the observation lane. Unknown/empty → False.
+    """
+    try:
+        return TaskType(task_type) in SELF_OBSERVATION_TASK_TYPES
     except ValueError:
         return False
 

--- a/tests/test_db/test_migration_0076_follow_ups_idea_kind.py
+++ b/tests/test_db/test_migration_0076_follow_ups_idea_kind.py
@@ -1,0 +1,218 @@
+"""Migration 0076 — add ``follow_ups.kind = 'idea'`` (WS-M PR-2 ideas lane).
+
+Covers the legacy CHECK-rebuild (2-value → 3-value kind), row/index preservation,
+the new value being accepted + a bogus value still rejected, fresh/migrated
+column-order parity, idempotency, the double-application path (create_all_tables
+then the runner), no-table no-op, and down() (idea→tabled reclassify + narrow).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+M76 = importlib.import_module("genesis.db.migrations.0076_follow_ups_idea_kind")
+
+# follow_ups as it exists BEFORE this migration (kind CHECK = 2 values).
+_LEGACY_DDL = """
+    CREATE TABLE follow_ups (
+        id               TEXT PRIMARY KEY,
+        source           TEXT NOT NULL,
+        source_session   TEXT,
+        content          TEXT NOT NULL,
+        reason           TEXT,
+        strategy         TEXT NOT NULL CHECK (
+            strategy IN ('scheduled_task', 'surplus_task', 'ego_judgment', 'user_input_needed')
+        ),
+        scheduled_at     TEXT,
+        status           TEXT NOT NULL DEFAULT 'pending' CHECK (
+            status IN ('pending', 'scheduled', 'in_progress', 'completed', 'failed', 'blocked')
+        ),
+        linked_task_id   TEXT,
+        priority         TEXT NOT NULL DEFAULT 'medium' CHECK (
+            priority IN ('low', 'medium', 'high', 'critical')
+        ),
+        created_at       TEXT NOT NULL,
+        completed_at     TEXT,
+        resolution_notes TEXT,
+        blocked_reason   TEXT,
+        escalated_to     TEXT,
+        verified_at      TEXT,
+        verification_notes TEXT,
+        pinned           INTEGER NOT NULL DEFAULT 0,
+        kind             TEXT NOT NULL DEFAULT 'follow_up' CHECK (
+            kind IN ('follow_up', 'tabled')
+        ),
+        domain           TEXT CHECK (
+            domain IN ('internal', 'user_world')
+        ),
+        goal_id          TEXT,
+        dedup_key        TEXT,
+        revisit_condition TEXT
+    )
+"""
+_LEGACY_INDEXES = (
+    "CREATE INDEX idx_follow_ups_status ON follow_ups(status)",
+    "CREATE INDEX idx_follow_ups_scheduled ON follow_ups(scheduled_at)",
+    "CREATE INDEX idx_follow_ups_source ON follow_ups(source)",
+    "CREATE INDEX idx_follow_ups_linked_task ON follow_ups(linked_task_id)",
+    "CREATE UNIQUE INDEX idx_follow_ups_dedup ON follow_ups(dedup_key) WHERE dedup_key IS NOT NULL",
+)
+
+
+async def _make_legacy_db() -> aiosqlite.Connection:
+    db = await aiosqlite.connect(":memory:")
+    await db.execute(_LEGACY_DDL)
+    for stmt in _LEGACY_INDEXES:
+        await db.execute(stmt)
+    # A row per surviving kind + a dedup_key to prove the unique index carries over.
+    await db.execute(
+        "INSERT INTO follow_ups (id, source, content, strategy, created_at, kind, "
+        "dedup_key) VALUES "
+        "('a', 'inbox_evaluation', 'hot', 'surplus_task', 't0', 'follow_up', 'k1'),"
+        "('b', 'inbox_evaluation', 'cold', 'surplus_task', 't0', 'tabled', 'k2')"
+    )
+    await db.commit()
+    return db
+
+
+async def _indexes(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='follow_ups' "
+        "AND name NOT LIKE 'sqlite_%'"
+    )
+    return {r[0] for r in await cur.fetchall()}
+
+
+async def _columns(db: aiosqlite.Connection) -> list[str]:
+    cur = await db.execute("PRAGMA table_info(follow_ups)")
+    return [r[1] for r in await cur.fetchall()]
+
+
+@pytest.mark.asyncio
+async def test_up_preserves_rows_and_indexes_and_widens_check():
+    db = await _make_legacy_db()
+    cols_before = await _columns(db)
+    await M76.up(db)
+
+    # Rows preserved.
+    cur = await db.execute("SELECT id, kind FROM follow_ups ORDER BY id")
+    assert [tuple(r) for r in await cur.fetchall()] == [
+        ("a", "follow_up"),
+        ("b", "tabled"),
+    ]
+    # 'idea' now accepted.
+    await db.execute(
+        "INSERT INTO follow_ups (id, source, content, strategy, created_at, kind) "
+        "VALUES ('c', 'surplus_ideation', 'an idea', 'surplus_task', 't1', 'idea')"
+    )
+    # A bogus kind is still rejected.
+    with pytest.raises(aiosqlite.IntegrityError):
+        await db.execute(
+            "INSERT INTO follow_ups (id, source, content, strategy, created_at, kind) "
+            "VALUES ('d', 's', 'x', 'surplus_task', 't1', 'nope')"
+        )
+    # All 5 indexes recreated, incl. the partial-unique dedup index.
+    idx = await _indexes(db)
+    assert idx == {
+        "idx_follow_ups_status",
+        "idx_follow_ups_scheduled",
+        "idx_follow_ups_source",
+        "idx_follow_ups_linked_task",
+        "idx_follow_ups_dedup",
+    }
+    # dedup uniqueness still enforced.
+    with pytest.raises(aiosqlite.IntegrityError):
+        await db.execute(
+            "INSERT INTO follow_ups (id, source, content, strategy, created_at, "
+            "dedup_key) VALUES ('e', 's', 'x', 'surplus_task', 't1', 'k1')"
+        )
+    # Column order unchanged (revisit_condition stays last).
+    assert await _columns(db) == cols_before
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_up_idempotent():
+    db = await _make_legacy_db()
+    await M76.up(db)
+    cols = await _columns(db)
+    await M76.up(db)  # second run must be a guarded no-op
+    assert await _columns(db) == cols
+    cur = await db.execute("SELECT COUNT(*) FROM follow_ups")
+    assert (await cur.fetchone())[0] == 2
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_up_no_table_noop():
+    db = await aiosqlite.connect(":memory:")
+    await M76.up(db)  # must not raise
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='follow_ups'"
+    )
+    assert await cur.fetchone() is None
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_column_order_parity_with_fresh_create():
+    """A migrated legacy DB and a fresh create_all_tables build agree on the
+    follow_ups column set + order."""
+    from genesis.db.schema import create_all_tables
+
+    legacy = await _make_legacy_db()
+    await M76.up(legacy)
+    migrated_cols = await _columns(legacy)
+    await legacy.close()
+
+    fresh = await aiosqlite.connect(":memory:")
+    await create_all_tables(fresh)
+    fresh_cols = await _columns(fresh)
+    await fresh.close()
+
+    assert migrated_cols == fresh_cols
+
+
+@pytest.mark.asyncio
+async def test_double_application_fresh_then_runner_is_noop():
+    """Fresh create_all_tables already carries 'idea' → up() guards to a no-op."""
+    from genesis.db.schema import create_all_tables
+
+    db = await aiosqlite.connect(":memory:")
+    await create_all_tables(db)
+    cols = await _columns(db)
+    await M76.up(db)  # canonical CREATE already has 'idea' → guard returns
+    assert await _columns(db) == cols
+    # 'idea' works on the fresh schema too.
+    await db.execute(
+        "INSERT INTO follow_ups (id, source, content, strategy, created_at, kind) "
+        "VALUES ('c', 'surplus_ideation', 'idea', 'surplus_task', 't1', 'idea')"
+    )
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_down_reclassifies_idea_and_narrows():
+    db = await _make_legacy_db()
+    await M76.up(db)
+    await db.execute(
+        "INSERT INTO follow_ups (id, source, content, strategy, created_at, kind) "
+        "VALUES ('c', 'surplus_ideation', 'idea', 'surplus_task', 't1', 'idea')"
+    )
+    await db.commit()
+
+    await M76.down(db)
+
+    # idea row preserved, reclassified to tabled.
+    cur = await db.execute("SELECT kind FROM follow_ups WHERE id='c'")
+    assert (await cur.fetchone())[0] == "tabled"
+    # 'idea' no longer accepted after narrowing.
+    with pytest.raises(aiosqlite.IntegrityError):
+        await db.execute(
+            "INSERT INTO follow_ups (id, source, content, strategy, created_at, kind) "
+            "VALUES ('d', 's', 'x', 'surplus_task', 't1', 'idea')"
+        )
+    await db.close()

--- a/tests/test_surplus/test_idea_decay_digest.py
+++ b/tests/test_surplus/test_idea_decay_digest.py
@@ -1,0 +1,82 @@
+"""WS-M PR-2: idea-lane decay + inbox_digest Ideas section."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import genesis.db.crud.follow_ups as fu
+
+
+def _old(days: int) -> str:
+    return (datetime.now(UTC) - timedelta(days=days)).isoformat()
+
+
+async def _mk(db, id, created_at, *, source="surplus_ideation", kind="idea"):
+    await fu.create(
+        db,
+        content=f"c-{id}",
+        source=source,
+        strategy="surplus_task",
+        kind=kind,
+        domain="internal",
+        dedup_key=id,
+        id=id,
+    )
+    await db.execute("UPDATE follow_ups SET created_at = ? WHERE id = ?", (created_at, id))
+    await db.commit()
+
+
+async def _status(db, id: str) -> str:
+    cur = await db.execute("SELECT status FROM follow_ups WHERE id = ?", (id,))
+    return (await cur.fetchone())[0]
+
+
+@pytest.mark.asyncio
+async def test_decay_stale_ideas_only_old_idea_lane(db):
+    await _mk(db, "old", _old(60))
+    await _mk(db, "new", _old(5))
+    await _mk(db, "marker", _old(90), source="inbox_evaluation", kind="tabled")
+
+    n = await fu.decay_stale_ideas(db, older_than_days=45)
+
+    assert n == 1
+    assert await _status(db, "old") == "completed"  # aged out
+    assert await _status(db, "new") == "pending"  # too recent
+    assert await _status(db, "marker") == "pending"  # different lane, untouched
+
+
+@pytest.mark.asyncio
+async def test_decay_inbox_markers_still_targets_tabled(db):
+    """The refactor to a shared _decay_stale keeps the inbox delegate scoped to
+    source='inbox_evaluation' AND kind='tabled'."""
+    await _mk(db, "marker", _old(70), source="inbox_evaluation", kind="tabled")
+    await _mk(db, "idea", _old(70))
+
+    n = await fu.decay_stale_inbox_markers(db, older_than_days=60)
+
+    assert n == 1
+    assert await _status(db, "marker") == "completed"
+    assert await _status(db, "idea") == "pending"  # idea lane untouched by inbox decay
+
+
+def test_format_digest_renders_ideas_section():
+    from genesis.mcp.health.inbox_digest import _format_digest
+
+    out = _format_digest(
+        [],
+        [],
+        [],
+        7,
+        ideas=[{"content": "Dynamic Awareness Depth Tuning", "source": "surplus_ideation"}],
+    )
+    assert "Pending Ideas (1 items)" in out
+    assert "Awareness Depth" in out
+
+
+def test_format_digest_backcompat_without_ideas():
+    from genesis.mcp.health.inbox_digest import _format_digest
+
+    out = _format_digest([], [], [], 7)  # positional legacy call, no ideas arg
+    assert "No inbox activity" in out

--- a/tests/test_surplus/test_idea_promotion.py
+++ b/tests/test_surplus/test_idea_promotion.py
@@ -1,0 +1,205 @@
+"""WS-M PR-2: staged-idea → follow_ups 'idea' review-lane promotion pass.
+
+Covers list_promotable_ideas (FIFO / task-type filter / ttl-unexpired), the GC
+promotion pass (promote → kind='idea', mark surplus promoted, idempotency, the
+settings off-switch, IDEA-only), the config lever, dispatch-exclusion of the
+'idea' kind, and the settings validator.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+import genesis.db.crud.follow_ups as fu_crud
+import genesis.db.crud.surplus as surplus_crud
+from genesis.surplus.jobs.gates import _promote_staged_ideas
+
+
+async def _stage(db, *, id, task_type, created_at, ttl, content="an idea"):
+    await surplus_crud.create(
+        db,
+        id=id,
+        content=content,
+        source_task_type=task_type,
+        generating_model="m",
+        drive_alignment="competence",
+        created_at=created_at,
+        ttl=ttl,
+        confidence=0.6,
+    )
+
+
+def _t(days_from_now: int) -> str:
+    return (datetime.now(UTC) + timedelta(days=days_from_now)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# list_promotable_ideas
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_promotable_ideas_fifo_and_filters(db):
+    # Two idea rows (different ages) + one non-idea + one expired idea.
+    await _stage(db, id="i-new", task_type="brainstorm_self", created_at=_t(-1), ttl=_t(7))
+    await _stage(db, id="i-old", task_type="brainstorm_user", created_at=_t(-5), ttl=_t(7))
+    await _stage(db, id="not-idea", task_type="gap_clustering", created_at=_t(-3), ttl=_t(7))
+    await _stage(db, id="i-expired", task_type="meta_brainstorm", created_at=_t(-9), ttl=_t(-1))
+
+    rows = await surplus_crud.list_promotable_ideas(
+        db,
+        task_types=["brainstorm_self", "brainstorm_user", "meta_brainstorm"],
+        limit=10,
+    )
+    ids = [r["id"] for r in rows]
+    # FIFO (oldest created_at first); non-idea + expired excluded.
+    assert ids == ["i-old", "i-new"]
+
+
+@pytest.mark.asyncio
+async def test_list_promotable_ideas_respects_limit_and_empty_types(db):
+    for i in range(3):
+        await _stage(db, id=f"i{i}", task_type="brainstorm_self", created_at=_t(-i), ttl=_t(7))
+    assert (
+        len(await surplus_crud.list_promotable_ideas(db, task_types=["brainstorm_self"], limit=2))
+        == 2
+    )
+    assert await surplus_crud.list_promotable_ideas(db, task_types=[], limit=10) == []
+
+
+# ---------------------------------------------------------------------------
+# _promote_staged_ideas (the GC pass)
+# ---------------------------------------------------------------------------
+
+
+async def _ideas_in_lane(db) -> list[dict]:
+    cur = await db.execute("SELECT * FROM follow_ups WHERE kind = 'idea'")
+    cur.row_factory = None
+    rows = await cur.fetchall()
+    cols = [d[0] for d in cur.description]
+    return [dict(zip(cols, r, strict=False)) for r in rows]
+
+
+@pytest.mark.asyncio
+async def test_promote_creates_idea_follow_up_and_marks_promoted(db):
+    await _stage(
+        db,
+        id="sid1",
+        task_type="brainstorm_self",
+        created_at=_t(-1),
+        ttl=_t(7),
+        content="Dynamic Awareness Depth Tuning",
+    )
+
+    n = await _promote_staged_ideas(db)
+
+    assert n == 1
+    lane = await _ideas_in_lane(db)
+    assert len(lane) == 1
+    fu = lane[0]
+    assert fu["kind"] == "idea"
+    assert fu["source"] == "surplus_ideation"
+    assert fu["strategy"] == "surplus_task"
+    assert fu["domain"] == "internal"
+    assert "Awareness Depth" in fu["content"]
+    # surplus row flipped out of pending.
+    staged = await surplus_crud.get_by_id(db, "sid1")
+    assert staged["promotion_status"] == "promoted"
+    assert staged["promoted_to"] == f"follow_up:{fu['id']}"
+
+
+@pytest.mark.asyncio
+async def test_promote_is_idempotent(db):
+    await _stage(db, id="sid1", task_type="brainstorm_self", created_at=_t(-1), ttl=_t(7))
+    assert await _promote_staged_ideas(db) == 1
+    # Second pass: row no longer pending → 0 new, still exactly one lane row.
+    assert await _promote_staged_ideas(db) == 0
+    assert len(await _ideas_in_lane(db)) == 1
+
+
+@pytest.mark.asyncio
+async def test_promote_reconciles_orphaned_followup(db):
+    """A crash between create and promote leaves a pending row whose follow_up
+    already exists; the next pass reconciles (promotes) without a duplicate."""
+    import hashlib
+
+    await _stage(db, id="sid1", task_type="brainstorm_self", created_at=_t(-1), ttl=_t(7))
+    dedup_key = hashlib.sha256(b"surplus_ideation|sid1").hexdigest()
+    await fu_crud.create(
+        db,
+        content="pre-existing",
+        source="surplus_ideation",
+        strategy="surplus_task",
+        kind="idea",
+        domain="internal",
+        dedup_key=dedup_key,
+    )
+    # surplus row still pending (promote never ran).
+    n = await _promote_staged_ideas(db)
+    assert n == 0  # not counted as a new promotion
+    assert len(await _ideas_in_lane(db)) == 1  # no duplicate
+    staged = await surplus_crud.get_by_id(db, "sid1")
+    assert staged["promotion_status"] == "promoted"  # reconciled
+
+
+@pytest.mark.asyncio
+async def test_promote_only_idea_types_not_self_observations(db):
+    await _stage(db, id="obs1", task_type="gap_clustering", created_at=_t(-1), ttl=_t(7))
+    assert await _promote_staged_ideas(db) == 0
+    assert await _ideas_in_lane(db) == []
+    # self-obs staged row untouched (still pending).
+    assert (await surplus_crud.get_by_id(db, "obs1"))["promotion_status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_promote_disabled_by_env(db, monkeypatch):
+    monkeypatch.setenv("GENESIS_SURPLUS_IDEATION_PROMOTION_DISABLED", "1")
+    await _stage(db, id="sid1", task_type="brainstorm_self", created_at=_t(-1), ttl=_t(7))
+    assert await _promote_staged_ideas(db) == 0
+    assert await _ideas_in_lane(db) == []
+
+
+@pytest.mark.asyncio
+async def test_promote_respects_cap(db, monkeypatch):
+    monkeypatch.setattr("genesis.surplus.promotion_config.cap_per_run", lambda: 2)
+    for i in range(3):
+        await _stage(db, id=f"s{i}", task_type="brainstorm_self", created_at=_t(-i - 1), ttl=_t(7))
+    assert await _promote_staged_ideas(db) == 2
+    assert len(await _ideas_in_lane(db)) == 2
+
+
+@pytest.mark.asyncio
+async def test_promoted_idea_excluded_from_dispatch(db):
+    """The 'idea' kind must never be auto-dispatched (positive kind='follow_up'
+    allow-list in get_actionable / get_pending)."""
+    await _stage(db, id="sid1", task_type="brainstorm_self", created_at=_t(-1), ttl=_t(7))
+    await _promote_staged_ideas(db)
+    actionable = await fu_crud.get_actionable(db)
+    assert all(f["kind"] == "follow_up" for f in actionable)
+    assert not any(f["source"] == "surplus_ideation" for f in actionable)
+
+
+# ---------------------------------------------------------------------------
+# config lever + settings validator
+# ---------------------------------------------------------------------------
+
+
+def test_config_defaults_and_env_kill(monkeypatch):
+    from genesis.surplus import promotion_config as pc
+
+    assert pc.is_enabled() is True  # shipped default
+    assert pc.cap_per_run() == 20
+    monkeypatch.setenv("GENESIS_SURPLUS_IDEATION_PROMOTION_DISABLED", "1")
+    assert pc.is_enabled() is False
+
+
+def test_settings_validator():
+    from genesis.mcp.health.settings import _validate_surplus_ideation_promotion as v
+
+    assert v({"enabled": True, "cap_per_run": 5}) == []
+    assert v({"enabled": "false"})  # truthy string rejected
+    assert v({"cap_per_run": 0})  # non-positive rejected
+    assert v({"cap_per_run": -3})
+    assert v({"bogus": 1})  # unknown key rejected

--- a/tests/test_surplus/test_idea_promotion.py
+++ b/tests/test_surplus/test_idea_promotion.py
@@ -203,3 +203,41 @@ def test_settings_validator():
     assert v({"cap_per_run": 0})  # non-positive rejected
     assert v({"cap_per_run": -3})
     assert v({"bogus": 1})  # unknown key rejected
+
+
+def test_config_nonbool_enabled_degrades_to_disabled(monkeypatch):
+    """Codex P2: a hand-edited `enabled: "false"` overlay (bypasses the settings
+    validator) must NOT read as truthy — degrade toward disabled."""
+    from genesis.surplus import promotion_config as pc
+
+    monkeypatch.setattr(pc, "load_config", lambda: {"enabled": "false", "cap_per_run": 20})
+    assert pc.is_enabled() is False
+    monkeypatch.setattr(pc, "load_config", lambda: {"enabled": 1, "cap_per_run": 20})
+    assert pc.is_enabled() is False  # int is not a bool → disabled
+    monkeypatch.setattr(pc, "load_config", lambda: {"enabled": True, "cap_per_run": 20})
+    assert pc.is_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_summary_counts_by_kind_separates_idea_from_tabled(db):
+    """Codex P2: with a third 'idea' kind, tabled/idea counts must be computed
+    per-kind, not by subtraction (which lumped idea into tabled)."""
+    for k in ("follow_up", "tabled", "idea"):
+        await fu_crud.create(
+            db,
+            content=f"c-{k}",
+            source="s",
+            strategy="surplus_task",
+            kind=k,
+            domain="internal",
+            dedup_key=k,
+            id=k,
+        )
+    tabled = await fu_crud.get_summary_counts(db, kind="tabled")
+    idea = await fu_crud.get_summary_counts(db, kind="idea")
+    fu_only = await fu_crud.get_summary_counts(db, include_tabled=False)
+    all_kinds = await fu_crud.get_summary_counts(db, include_tabled=True)
+    assert sum(tabled.values()) == 1
+    assert sum(idea.values()) == 1  # NOT lumped into tabled
+    assert sum(fu_only.values()) == 1  # follow_up lane only
+    assert sum(all_kinds.values()) == 3

--- a/tests/test_surplus/test_intake_staging.py
+++ b/tests/test_surplus/test_intake_staging.py
@@ -1,8 +1,11 @@
-"""WS-M PR-1: ephemeral-ideation staging gate + purge_discarded GC.
+"""WS-M PR-1/PR-2: ephemeral-ideation routing split + purge_discarded GC.
 
-Ideation task output (self_unblock / brainstorm / audits) must be STAGED in
-surplus_insights (ideas-review lifecycle, TTL decay) instead of immortalized as
-knowledge_units. anticipatory_research / code_audit stay KB-bound.
+PR-1 kept ideation output (self_unblock / brainstorm / audits) OUT of the
+immortal knowledge_units KB. PR-2 splits it by semantics:
+  • IDEAS (brainstorm) → surplus_insights staging (ideas-review lifecycle).
+  • SELF-OBSERVATIONS (audits / gap-cluster / unblock / prompt-review) → the
+    observation lane (TTL + resolve + dashboard surfacing), priority="low".
+anticipatory_research / code_audit stay KB-bound.
 """
 
 from __future__ import annotations
@@ -12,12 +15,17 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import genesis.db.crud.observations as obs_crud
 import genesis.db.crud.surplus as surplus_crud
 from genesis.surplus.intake import IntakeSource, run_intake
 from genesis.surplus.types import (
     EPHEMERAL_IDEATION_TASK_TYPES,
+    IDEA_TASK_TYPES,
+    SELF_OBSERVATION_TASK_TYPES,
     TaskType,
     is_ephemeral_ideation,
+    is_idea_ideation,
+    is_self_observation_ideation,
 )
 
 
@@ -48,28 +56,109 @@ class TestIdeationSet:
         assert not is_ephemeral_ideation("not_a_real_task_type")
 
 
+class TestIdeationSplit:
+    """PR-2: the ephemeral set splits into two DISJOINT subsets whose union is
+    the whole set (so the Step-3a intercept guard still catches all 9)."""
+
+    def test_subsets_are_disjoint(self):
+        assert frozenset() == IDEA_TASK_TYPES & SELF_OBSERVATION_TASK_TYPES
+
+    def test_union_equals_ephemeral(self):
+        assert IDEA_TASK_TYPES | SELF_OBSERVATION_TASK_TYPES == (EPHEMERAL_IDEATION_TASK_TYPES)
+
+    def test_idea_classification(self):
+        for tt in (
+            TaskType.BRAINSTORM_SELF,
+            TaskType.BRAINSTORM_USER,
+            TaskType.META_BRAINSTORM,
+        ):
+            assert is_idea_ideation(str(tt))
+            assert not is_self_observation_ideation(str(tt))
+
+    def test_self_observation_classification(self):
+        for tt in (
+            TaskType.SELF_UNBLOCK,
+            TaskType.GAP_CLUSTERING,
+            TaskType.WING_AUDIT,
+            TaskType.MEMORY_AUDIT,
+            TaskType.PROCEDURE_AUDIT,
+            TaskType.PROMPT_EFFECTIVENESS_REVIEW,
+        ):
+            assert is_self_observation_ideation(str(tt))
+            assert not is_idea_ideation(str(tt))
+
+    def test_unknown_string_neither(self):
+        assert not is_idea_ideation("nope")
+        assert not is_self_observation_ideation("")
+
+
 @pytest.mark.asyncio
-async def test_self_unblock_routes_to_staging_not_kb(db):
-    """A self_unblock finding is staged; the knowledge-base ingest is not called."""
+async def test_brainstorm_routes_to_staging_not_kb(db):
+    """An idea (brainstorm) is staged; the KB ingest is not called."""
+    with patch(
+        "genesis.memory.knowledge_ingest.ingest_knowledge_unit",
+        new=AsyncMock(),
+    ) as ingest:
+        stats = await run_intake(
+            content="Dynamic Awareness Depth Tuning\n\nA feedback loop for tick depth.",
+            source=IntakeSource.ANTICIPATORY_RESEARCH,  # collapsed source (real flow)
+            source_task_type="brainstorm_self",  # TRUE task type — drives the gate
+            generating_model="test-model",
+            drive_alignment="competence",
+            db=db,
+        )
+    assert stats.routed_staging >= 1
+    assert stats.routed_observation == 0
+    assert stats.routed_knowledge == 0
+    ingest.assert_not_awaited()
+    rows = await surplus_crud.list_pending(db, limit=50)
+    staged = [r for r in rows if "Awareness Depth" in r["content"]]
+    assert staged, "brainstorm finding should be staged in surplus_insights"
+    assert all(r["promotion_status"] == "pending" for r in staged)
+
+
+@pytest.mark.asyncio
+async def test_self_observation_routes_to_observation_not_kb(db):
+    """A self-observation (self_unblock) is written to the observation lane —
+    NOT staged, NOT KB-ingested (PR-2 split)."""
     with patch(
         "genesis.memory.knowledge_ingest.ingest_knowledge_unit",
         new=AsyncMock(),
     ) as ingest:
         stats = await run_intake(
             content="Self Unblock\n\nThe system is stuck in a priority collision.",
-            source=IntakeSource.ANTICIPATORY_RESEARCH,  # collapsed source (real flow)
-            source_task_type="self_unblock",  # TRUE task type — drives the gate
+            source=IntakeSource.ANTICIPATORY_RESEARCH,
+            source_task_type="self_unblock",  # a self-observation type
             generating_model="test-model",
-            drive_alignment="competence",
             db=db,
         )
-    assert stats.routed_staging >= 1
+    assert stats.routed_observation >= 1
+    assert stats.routed_staging == 0
     assert stats.routed_knowledge == 0
     ingest.assert_not_awaited()
+    # Not staged...
     rows = await surplus_crud.list_pending(db, limit=50)
-    staged = [r for r in rows if "priority collision" in r["content"]]
-    assert staged, "self_unblock finding should be staged in surplus_insights"
-    assert all(r["promotion_status"] == "pending" for r in staged)
+    assert not any("priority collision" in r["content"] for r in rows)
+    # ...written as an observation at priority='low', surfacing type.
+    obs = await obs_crud.query(db, type="self_unblock", limit=50)
+    assert obs, "self_unblock should be written to the observation lane"
+    assert all(o["priority"] == "low" for o in obs)
+
+
+@pytest.mark.asyncio
+async def test_self_observation_dedup_idempotent(db):
+    """Re-emitting an identical self-observation does not create a duplicate row."""
+    kwargs = dict(
+        content="Rapid Genesis Version Volatility\n\nVersion churned 3x in an hour.",
+        source=IntakeSource.ANTICIPATORY_RESEARCH,
+        source_task_type="gap_clustering",
+        generating_model="test-model",
+        db=db,
+    )
+    await run_intake(**kwargs)
+    await run_intake(**kwargs)
+    obs = await obs_crud.query(db, type="gap_clustering", limit=50)
+    assert len(obs) == 1, "identical self-observation should dedup on content_hash"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

WS-M PR-2 "split by semantics". PR-1 (#1264) stopped immortalizing ephemeral surplus ideation as `knowledge_units` by staging it in `surplus_insights`. A content review of the live staged rows showed they are **two different populations**, so routing all of them to one review surface would relocate noise rather than resolve it. This splits them at the intake gate to their honest homes:

- **IDEA types** (`brainstorm_self`/`brainstorm_user`, `meta_brainstorm`) → `surplus_insights` staging → promoted (capped, FIFO) into a **new `follow_ups` `kind='idea'` review lane** (cockpit "Ideas" tab + an `inbox_digest` Ideas section). Auto-excluded from autonomous dispatch (dispatch readers positively filter `kind='follow_up'`).
- **SELF_OBSERVATION types** (`gap_clustering`, `wing_audit`, `self_unblock`, `prompt_effectiveness_review`, `memory_audit`, `procedure_audit`) → the **observation lane** via `_route_to_observation` at `priority='low'` (dashboard observations panel + morning-report surfacing, TTL + resolve lifecycle).

The Step-3a intercept still fires on the **union** of both subsets, so neither can leak back to the KB route loop.

## How

- `surplus/types.py`: split `EPHEMERAL_IDEATION_TASK_TYPES` into `IDEA_TASK_TYPES` (3) + `SELF_OBSERVATION_TASK_TYPES` (6); the ephemeral set is their computed union (kept so the intercept catches all 9).
- `surplus/intake.py`: Step-3a branches idea→staging, self-obs→observation (`priority='low'`, `skip_if_duplicate=True`); the legacy pattern-insight caller is unchanged.
- `follow_ups.kind` gains `'idea'` via a `0076` CHECK-rebuild migration (raise-on-drift `_intersection_copy`, all 5 indexes incl. the partial-unique dedup index recreated, idempotent, reversible `down()`).
- Promotion pass in the surplus maintenance GC (`list_promotable_ideas` → `follow_ups.create(kind='idea')` → `surplus.promote`), idempotent (dedup precheck + reconcile) + crash-consistent, gated by a new **`surplus_ideation_promotion`** settings domain (`enabled` + `cap_per_run` + `GENESIS_SURPLUS_IDEATION_PROMOTION_DISABLED` kill switch).
- Idea-lane decay (shared `_decay_stale` helper) wired into the learning scheduler; the 6 observation types get `_TTL_BY_TYPE` entries (14d) and are deliberately NOT in `INTERNAL_OBS_TYPES` (they must surface for review).

## Verification

- 35 new + 445 targeted regression tests pass; ruff clean on all 15 changed modules.
- Migration `0076` round-trip: preserves all rows + 5 indexes, accepts `'idea'` / rejects bogus, fresh-vs-migrated column-order parity, idempotent, `down()` reclassifies idea→tabled.
- Reviews: genesis-architect (design, DONE — B1/S1/S2/S3 applied) + adversarial implementation review (DONE — 0 blocking, 0 should-fix, 2 accepted notes).

## Deploy

Runtime code + prose → `git pull` + server restart. Schema → additive `0076` migration at restart. New settings domain works with zero overlay (default enabled). Live E2E (a real intake finding routing to each destination) verified post-merge on deploy.

Ledger: c3edfbe9023c457db7adecad286c3081

🤖 Generated with [Claude Code](https://claude.com/claude-code)
