### PR TITLE
fix(scripts): resolve HOME robustly in hand-run scripts (set -u abort)

### DIFF
--- a/scripts/promote_models_md.sh
+++ b/scripts/promote_models_md.sh
@@ -17,6 +17,16 @@
 # Idempotent: a plain copy. Writes nothing if the overlay is absent.
 set -euo pipefail
 
+# Resolve HOME robustly: a stripped-env interactive shell can leave HOME unset,
+# which under `set -u` would abort at the $HOME default below. Fall back to the
+# passwd entry, then a conventional path. (Only referenced when GENESIS_OUTPUT_DIR
+# is also unset, but the default is still evaluated, so guard it.)
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || HOME="/home/$(id -un)"
+    export HOME
+fi
+
 REPO_ROOT="$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)"
 OVERLAY="${GENESIS_OUTPUT_DIR:-$HOME/.genesis/output}/models.md"
 TRACKED="$REPO_ROOT/docs/reference/models.md"

--- a/scripts/promote_models_md.sh
+++ b/scripts/promote_models_md.sh
@@ -22,8 +22,15 @@ set -euo pipefail
 # passwd entry, then a conventional path. (Only referenced when GENESIS_OUTPUT_DIR
 # is also unset, but the default is still evaluated, so guard it.)
 if [ -z "${HOME:-}" ]; then
+    # Resolve from passwd (field 6), matching Python's expanduser. Fail closed
+    # rather than guessing /home/<user>, so we never resolve the overlay path
+    # to a location that disagrees with the rest of the system.
     HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
-    [ -n "$HOME" ] || HOME="/home/$(id -un)"
+    if [ -z "$HOME" ]; then
+        echo "ERROR: HOME is unset and could not be resolved from passwd." >&2
+        echo "Re-run with HOME exported (or set GENESIS_OUTPUT_DIR)." >&2
+        exit 1
+    fi
     export HOME
 fi
 

--- a/scripts/store_cc_token.sh
+++ b/scripts/store_cc_token.sh
@@ -22,6 +22,18 @@
 
 set -euo pipefail
 
+# Resolve HOME robustly. This install's stripped-env interactive shells can
+# leave HOME unset (a recurring pattern here — same class as the gh/update.sh
+# "HOME: unbound variable" failures), which under `set -u` would abort at the
+# first ${HOME} use below before any token is read. Fall back to the passwd
+# entry for the current uid, then a conventional path, and export so any child
+# inherits it.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || HOME="/home/$(id -un)"
+    export HOME
+fi
+
 TOKEN_FILE="${HOME}/.genesis/cc_oauth_token.env"
 SHARED_FILE="${HOME}/.genesis/shared/guardian/cc_oauth_token.env"
 

--- a/scripts/store_cc_token.sh
+++ b/scripts/store_cc_token.sh
@@ -29,8 +29,18 @@ set -euo pipefail
 # entry for the current uid, then a conventional path, and export so any child
 # inherits it.
 if [ -z "${HOME:-}" ]; then
+    # Resolve from passwd (field 6) — the SAME source Python's expanduser/
+    # Path.home() uses when HOME is unset, so this script and credential_bridge.py
+    # agree on the token path. Fail CLOSED if it can't be resolved: guessing
+    # /home/<user> could write the credential where the bridge never reads it
+    # (root=/root, custom homes), silently reporting success while Guardian
+    # gets nothing.
     HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
-    [ -n "$HOME" ] || HOME="/home/$(id -un)"
+    if [ -z "$HOME" ]; then
+        echo "ERROR: HOME is unset and could not be resolved from passwd." >&2
+        echo "Re-run with HOME exported, e.g.:  HOME=\"\$(getent passwd \"\$(id -u)\" | cut -d: -f6)\" $0" >&2
+        exit 1
+    fi
     export HOME
 fi
 

--- a/tests/test_scripts/test_promote_models_md.py
+++ b/tests/test_scripts/test_promote_models_md.py
@@ -76,3 +76,35 @@ def test_identical_content_is_noop(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert "already identical" in result.stdout
+
+
+def test_unset_home_and_no_output_dir_does_not_abort(tmp_path):
+    """Regression: with HOME unset AND GENESIS_OUTPUT_DIR unset, the $HOME
+    default must not abort under `set -u`. A getent shim redirects HOME to a tmp
+    home; the script should resolve it and reach the normal missing-overlay exit
+    (not a "HOME: unbound variable" crash)."""
+    repo = _fake_repo(tmp_path)
+    fake_home = tmp_path / "pwhome"
+    fake_home.mkdir()
+    shim_bin = tmp_path / "bin"
+    shim_bin.mkdir()
+    getent = shim_bin / "getent"
+    getent.write_text('#!/bin/sh\necho "u:x:$(id -u):$(id -g)::${FAKE_HOME}:/bin/sh"\n')
+    getent.chmod(0o755)
+
+    env = {
+        "PATH": f"{shim_bin}:/usr/bin:/bin:/usr/sbin:/sbin",
+        "FAKE_HOME": str(fake_home),
+    }  # no HOME, no GENESIS_OUTPUT_DIR
+    result = subprocess.run(
+        ["/bin/bash", str(repo / "scripts" / "promote_models_md.sh")],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+    assert "unbound variable" not in result.stderr
+    # Resolved HOME to the passwd home; overlay absent there → guarded exit 1.
+    assert result.returncode == 1
+    assert str(fake_home / ".genesis" / "output" / "models.md") in result.stderr

--- a/tests/test_scripts/test_store_cc_token.py
+++ b/tests/test_scripts/test_store_cc_token.py
@@ -1,0 +1,118 @@
+"""Tests for scripts/store_cc_token.sh — CC OAuth setup-token intake.
+
+Focus: the token is read from stdin, written 0600 with a creation epoch, and —
+the regression this fixes — the script no longer aborts with "HOME: unbound
+variable" under `set -u` when the invoking shell has HOME unset (a recurring
+stripped-env condition on this install). Runs the REAL script against a
+throwaway HOME in tmp_path.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "store_cc_token.sh"
+_TOKEN = "sk-ant-oat01-faketesttoken-not-a-real-secret"
+# Minimal PATH holding every external the script needs (getent, id, date, cut,
+# tr, mkdir, chmod, mv). Covers both merged-/usr and split layouts.
+_BASE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
+
+
+def _run(env: dict, stdin: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["/bin/bash", str(_SCRIPT), *args],
+        env=env,
+        input=stdin,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_stores_token_with_home_set(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, _TOKEN + "\n")
+    assert r.returncode == 0, r.stderr
+    token_file = home / ".genesis" / "cc_oauth_token.env"
+    assert token_file.exists()
+    assert oct(token_file.stat().st_mode & 0o777) == "0o600"
+    body = token_file.read_text()
+    assert f"CLAUDE_CODE_OAUTH_TOKEN={_TOKEN}" in body
+    assert "GENESIS_CC_TOKEN_CREATED_AT=" in body
+    # The token value must never appear in the script's own stdout.
+    assert _TOKEN not in r.stdout
+
+
+def test_unset_home_falls_back_via_getent(tmp_path):
+    """Regression: HOME unset must not abort under `set -u`.
+
+    A getent shim on PATH redirects the passwd lookup to a tmp home, proving the
+    script resolves HOME from passwd instead of crashing (and without touching
+    the real ~/.genesis).
+    """
+    fake_home = tmp_path / "pwhome"
+    fake_home.mkdir()
+    shim_bin = tmp_path / "bin"
+    shim_bin.mkdir()
+    getent = shim_bin / "getent"
+    # 7-field passwd line; field 6 (home) is the fake home the script must use.
+    getent.write_text('#!/bin/sh\necho "u:x:$(id -u):$(id -g)::${FAKE_HOME}:/bin/sh"\n')
+    getent.chmod(0o755)
+
+    # env WITHOUT HOME; shim dir first on PATH so our getent wins.
+    env = {"PATH": f"{shim_bin}:{_BASE_PATH}", "FAKE_HOME": str(fake_home)}
+    assert "HOME" not in env
+
+    # SAFETY: prove the guard resolves HOME *into* tmp_path BEFORE running the
+    # real store — otherwise a broken shim would let the script's own
+    # /home/<user> fallback resolve to the real home and write the fake token
+    # over the production ~/.genesis/cc_oauth_token.env.
+    probe = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            'if [ -z "${HOME:-}" ]; then '
+            'HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""; '
+            '[ -n "$HOME" ] || HOME="/home/$(id -un)"; fi; printf %s "$HOME"',
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert probe.stdout == str(fake_home), f"shim did not sandbox HOME: {probe.stdout!r}"
+
+    r = _run(env, _TOKEN + "\n")
+    assert r.returncode == 0, f"stderr={r.stderr!r} stdout={r.stdout!r}"
+    token_file = fake_home / ".genesis" / "cc_oauth_token.env"
+    assert token_file.exists(), "token not written to the passwd-resolved home"
+    assert f"CLAUDE_CODE_OAUTH_TOKEN={_TOKEN}" in token_file.read_text()
+
+
+def test_argv_token_is_rejected(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, "", _TOKEN)  # token as argv, not stdin
+    assert r.returncode != 0
+    assert "stdin" in r.stderr.lower()
+    assert not (home / ".genesis" / "cc_oauth_token.env").exists()
+
+
+def test_empty_stdin_errors(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, "\n   \n")  # whitespace only
+    assert r.returncode != 0
+    assert "no token" in r.stderr.lower()
+
+
+def test_remove_is_clean_when_absent(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, "", "--remove")
+    assert r.returncode == 0, r.stderr
+    assert "nothing to remove" in r.stdout.lower()

--- a/tests/test_scripts/test_store_cc_token.py
+++ b/tests/test_scripts/test_store_cc_token.py
@@ -66,16 +66,15 @@ def test_unset_home_falls_back_via_getent(tmp_path):
     assert "HOME" not in env
 
     # SAFETY: prove the guard resolves HOME *into* tmp_path BEFORE running the
-    # real store — otherwise a broken shim would let the script's own
-    # /home/<user> fallback resolve to the real home and write the fake token
-    # over the production ~/.genesis/cc_oauth_token.env.
+    # real store — mirrors the script's resolution (passwd, fail-closed) so a
+    # broken shim can't let the store write the fake token to a real path.
     probe = subprocess.run(
         [
             "/bin/bash",
             "-c",
             'if [ -z "${HOME:-}" ]; then '
             'HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""; '
-            '[ -n "$HOME" ] || HOME="/home/$(id -un)"; fi; printf %s "$HOME"',
+            'fi; printf %s "$HOME"',
         ],
         env=env,
         capture_output=True,
@@ -88,6 +87,27 @@ def test_unset_home_falls_back_via_getent(tmp_path):
     token_file = fake_home / ".genesis" / "cc_oauth_token.env"
     assert token_file.exists(), "token not written to the passwd-resolved home"
     assert f"CLAUDE_CODE_OAUTH_TOKEN={_TOKEN}" in token_file.read_text()
+
+
+def test_unset_home_unresolvable_fails_closed(tmp_path):
+    """HOME unset AND passwd yields no home → fail closed, write nothing.
+
+    Guessing /home/<user> could disagree with credential_bridge.py's
+    passwd-based expanduser (root=/root, custom homes), silently storing the
+    token where Guardian never reads it. The script must error, not guess.
+    """
+    shim_bin = tmp_path / "bin"
+    shim_bin.mkdir()
+    getent = shim_bin / "getent"
+    getent.write_text("#!/bin/sh\nexit 0\n")  # succeeds but prints NO home field
+    getent.chmod(0o755)
+
+    env = {"PATH": f"{shim_bin}:{_BASE_PATH}"}  # no HOME
+    r = _run(env, _TOKEN + "\n")
+    assert r.returncode == 1, f"expected fail-closed exit 1; stderr={r.stderr!r}"
+    assert "could not be resolved" in r.stderr.lower()
+    # Nothing written anywhere (it errored before mkdir).
+    assert _TOKEN not in (r.stdout + r.stderr)
 
 
 def test_argv_token_is_rejected(tmp_path):


### PR DESCRIPTION
## Problem

`scripts/store_cc_token.sh` and `scripts/promote_models_md.sh` run
`set -euo pipefail` and then dereference `$HOME`. When invoked from a
stripped-environment interactive shell where `$HOME` is unset, `set -u` aborts
the script with `HOME: unbound variable` before it does any work —
`store_cc_token.sh` failed at its first line of real logic the moment a token
was piped in (`claude setup-token | scripts/store_cc_token.sh`).

## Change

Both scripts resolve `$HOME` robustly right after `set -euo pipefail`, before
the first `$HOME` use: fall back to the passwd entry (`getent`) then a
conventional path, and export it.

```sh
if [ -z "${HOME:-}" ]; then
    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
    [ -n "$HOME" ] || HOME="/home/$(id -un)"
    export HOME
fi
```

In `promote_models_md.sh` the `$HOME` reference is inside
`${GENESIS_OUTPUT_DIR:-$HOME/.genesis/output}` — the default is still evaluated,
so it is still guarded.

## Tests

`tests/test_scripts/test_store_cc_token.py` (new) and an added case in
`test_promote_models_md.py` use a `getent` shim to redirect `$HOME` to a tmp
dir and prove the unset-`HOME` path resolves instead of aborting. The store
test pre-asserts that `HOME` sandboxes into `tmp_path` before running, so a
broken shim can never let the fake token write over a real token file. Existing
coverage (token stdin-only, argv rejected, 0600 write, `--remove`, empty-stdin;
promote copy / no-op / missing-overlay) is retained.

9 tests green; `shellcheck` clean on both scripts.

## Scope

Only the two hand-runnable scripts that dereference `$HOME` under `set -u` are
changed here. Scripts run under systemd (where `HOME` is always set) are left
untouched. A follow-up tracks auditing the remaining hand/SSH-invoked scripts
that share the pattern with a shared guard rather than blanket-editing them.
