### PR TITLE
feat(memory): instrument the proactive-recall 503 path (WS-1 PR-2)

### DIFF
--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -89,6 +89,26 @@ class StandaloneAdapter:
         # dashboard route still needs the loop reference.
         self._app.config["GENESIS_EVENT_LOOP"] = self._loop
 
+        # Event-loop lag sampler — names the hog behind recall 503s. Dashboard
+        # routes bridge sync→async onto THIS loop and enforce their budget
+        # thread-side (dashboard/_blueprint.py), so when background cognition
+        # (awareness tick, reflection/session-observer dispatch, repo-bundle
+        # publish) blocks the loop, the recall coroutine can't progress and the
+        # route 503s even though recall itself is fast. This samples scheduling
+        # drift so a lag spike is timestamp-correlatable with those log lines.
+        # Cheap (wakes 2×/s, one subtraction); threshold + on/off are env levers.
+        from genesis.util.tasks import tracked_task
+
+        lag_sampler_task = None
+        if os.environ.get("GENESIS_LOOP_LAG_SAMPLER", "1").lower() not in (
+            "0",
+            "false",
+            "off",
+        ):
+            lag_sampler_task = tracked_task(
+                self._loop_lag_sampler(), name="loop-lag-sampler",
+            )
+
         # Create shared ConversationLoop for the OpenClaw endpoint.
         # Same pattern as _start_telegram() but without channel-specific
         # wiring (TTS, reply waiter, etc.).
@@ -138,13 +158,72 @@ class StandaloneAdapter:
                     uptime_h = (time.monotonic() - start_time) / 3600
                     logger.info("Standalone heartbeat: uptime=%.1fh", uptime_h)
 
-        from genesis.util.tasks import tracked_task
-
         heartbeat_task = tracked_task(_heartbeat(), name="standalone-heartbeat")
 
         # Block until shutdown
         await self._shutdown_event.wait()
         heartbeat_task.cancel()
+        if lag_sampler_task is not None:
+            lag_sampler_task.cancel()
+
+    async def _loop_lag_sampler(self) -> None:
+        """Sample event-loop scheduling drift; WARN when the loop stalls.
+
+        Sleeps a fixed interval and measures how much longer than the interval
+        the wake-up actually took — that excess is time the loop spent unable to
+        schedule ready callbacks (blocked in synchronous work on some task).
+        When drift exceeds the threshold we log at WARNING so the stall is
+        timestamp-correlatable with awareness-tick / dispatch / bundle log lines,
+        naming what starves the recall coroutine behind the route 503s.
+
+        Debounced per stall EPISODE: one WARNING when drift first crosses the
+        threshold, one INFO with the peak drift when it clears. A sustained
+        multi-minute stall (the worst case, and exactly when log noise competes
+        with other diagnostics) would otherwise emit a line every interval.
+
+        Env levers (no restart of the feature's *logic* required to retune):
+        ``GENESIS_LOOP_LAG_WARN_MS`` (default 250) — drift threshold to warn at;
+        ``GENESIS_LOOP_LAG_SAMPLER`` (0/false/off) — disables the sampler at
+        startup. Best-effort: any error ends the sampler without touching serve.
+        """
+        interval = 0.5
+        try:
+            threshold_ms = float(os.environ.get("GENESIS_LOOP_LAG_WARN_MS", "250"))
+        except ValueError:
+            threshold_ms = 250.0
+        loop = asyncio.get_running_loop()
+        lagging = False
+        peak_ms = 0.0
+        try:
+            while not self._shutdown_event.is_set():
+                t0 = loop.time()
+                await asyncio.sleep(interval)
+                drift_ms = (loop.time() - t0 - interval) * 1000
+                if drift_ms > threshold_ms:
+                    peak_ms = max(peak_ms, drift_ms)
+                    if not lagging:
+                        # Entering a stall episode — warn once, then suppress
+                        # per-sample noise until it clears.
+                        lagging = True
+                        logger.warning(
+                            "event-loop lag %.0fms (interval %.0fms) — background "
+                            "work is starving the loop; recall 503s correlate here "
+                            "(further lag suppressed until it clears)",
+                            drift_ms,
+                            interval * 1000,
+                        )
+                elif lagging:
+                    # Episode cleared — report the peak so the stall's severity is
+                    # in the journal without the per-sample flood.
+                    logger.info(
+                        "event-loop lag cleared (peak %.0fms, drift back under %.0fms)",
+                        peak_ms,
+                        threshold_ms,
+                    )
+                    lagging = False
+                    peak_ms = 0.0
+        except asyncio.CancelledError:
+            pass
 
     async def _voice_last_breath(self) -> None:
         """Best-effort spoken shutdown notice via the held VoiceChannelAdapter.

--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -25,6 +25,7 @@ fallback for when the server is unreachable.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from collections.abc import Callable
@@ -573,124 +574,152 @@ async def proactive_context(
     retriever = memory_mod._retriever
     db = memory_mod._db
 
-    # Embed once (cache-shared with recall's internal embed of the same text →
-    # a warm hit) — reused for procedure cosine + returned for the ambient fold.
-    t_embed = time.monotonic()
+    # The whole awaited phase sequence runs inside a try/except CancelledError.
+    # When the dashboard route's budget expires it cancels this coroutine
+    # (dashboard/_blueprint.py `_async_route` calls future.cancel(), which
+    # schedules a thread-safe task-cancel on the loop) and CancelledError is
+    # raised HERE at whatever await is in flight. Without this catch the
+    # accumulated phase timings die with the frame and the 503 logs nothing —
+    # the exact observability gap behind the #1169 timeout hunt (the completion
+    # path below only logs when the coroutine finishes). We record each phase
+    # into `timings` as it completes and track the in-flight `phase`, then on
+    # cancellation WARN with the phase + partials and RE-RAISE so the task still
+    # completes as cancelled. CancelledError is a BaseException, so the inner
+    # best-effort `except Exception` blocks never swallow it.
+    timings: dict[str, Any] = {}
+    phase = "embed"
     vector: list[float] | None = None
-    try:
-        vector, _available = await retriever._embed_query(prompt)
-    except Exception:
-        logger.debug("proactive embed failed — degrading", exc_info=True)
-    embed_ms = (time.monotonic() - t_embed) * 1000
-
-    # Rerank posture is read LIVE from config (proactive.profiles.<p>.rerank) so
-    # the documented ``rerank: off`` latency/cost kill switch takes effect
-    # without a restart — _PROFILES only supplies the default when config is
-    # silent, and reranking still no-ops downstream without API_KEY_VOYAGE.
-    rerank_live = _rerank_for(profile)
-
-    # The shared security pipeline (recall + filters + wrap + enforce + graph
-    # expansion + immunity emit + retrieved_count write-back).
-    # filter_noise + kb_slots restore the pre-flip hook's content guards (garbage
-    # rows + non-intentional knowledge_base + the KB slot budget) INSIDE the
-    # engine's backfill loop and BEFORE external-content wrapping — so a dropped
-    # noisy/over-cap hit is backfilled from the deeper safe pool (not left as a
-    # hole), the garbage check sees raw content, and dropped items skip
-    # retrieved_count write-backs (Codex on #1169). memory_proactive (the MCP
-    # tool) passes neither, so it is byte-for-byte unchanged.
-    kb_slots = max(1, budget // 3)
     engine_stats: dict[str, Any] = {}
-    t_recall = time.monotonic()
-    dicts = await _core._proactive_impl(
-        prompt,
-        limit=budget,
-        rerank=rerank_live,
-        extra_fts_terms=[k for k in (file_keywords or []) if k] or None,
-        filter_noise=True,
-        kb_slots=kb_slots,
-        rerank_timeout_s=_RERANK_TIMEOUT_S,
-        stats=engine_stats,
-        # This is THE latency-budgeted per-prompt path: push recall's
-        # write-backs/emits + the immunity emit off the request path so the
-        # 4.5s route budget isn't spent on post-result DB writes (ac27b693).
-        defer_side_effects=True,
-    )
-    recall_ms = (time.monotonic() - t_recall) * 1000
-
-    t_enrich = time.monotonic()
-    # PR-4b (ac27b693): route these post-recall reads off the shared write lock
-    # onto recall's read-only pool via the same _ro_read seam recall's own reads
-    # use. Both are pure indexed SELECTs (memory_metadata PK / memory_links
-    # source_id), so under concurrency they were queuing behind server writes,
-    # not query cost. _ro_read runs fn(pooled_conn, *args) and, on any pool
-    # miss/error, retries on the shared connection — so the helpers deliberately
-    # do NOT swallow their own DB errors (that would hide a transient pooled-read
-    # failure from the fallback; Codex #1197 P2). The best-effort catch lives HERE
-    # so that if BOTH the pooled and shared reads fail, enrichment degrades to
-    # nothing rather than failing recall (the pre-pool best-effort contract).
-    # retriever is genesis.mcp.memory._retriever (see CC memory two_retriever_wiring)
-    # — the same instance the pool was wired into in PR-4.
     try:
-        await retriever._ro_read(_enrich, dicts)
-        await retriever._ro_read(_breadcrumbs, dicts)
-    except Exception:
-        logger.debug("post-recall enrichment/breadcrumbs failed", exc_info=True)
-    enrich_ms = (time.monotonic() - t_enrich) * 1000
+        # Embed once (cache-shared with recall's internal embed of the same text
+        # → a warm hit) — reused for procedure cosine + returned for the ambient
+        # fold.
+        t_embed = time.monotonic()
+        try:
+            vector, _available = await retriever._embed_query(prompt)
+        except Exception:
+            logger.debug("proactive embed failed — degrading", exc_info=True)
+        timings["embed"] = round((time.monotonic() - t_embed) * 1000, 1)
 
-    lines = prof.renderer(dicts)
+        # Rerank posture is read LIVE from config (proactive.profiles.<p>.rerank)
+        # so the documented ``rerank: off`` latency/cost kill switch takes effect
+        # without a restart — _PROFILES only supplies the default when config is
+        # silent, and reranking still no-ops downstream without API_KEY_VOYAGE.
+        rerank_live = _rerank_for(profile)
 
-    t_proc = time.monotonic()
-    procedure = None
-    if vector:
-        procedure = await _surface_procedure(db, vector)
-        if procedure:
-            lines.append(_render_procedure_line(procedure))
-            # HONEST funnel signal: bump surfaced_count (NOT invocation_count —
-            # passive surfacing must never feed the promoter, which reads
-            # invocation_count). This lives server-side so EVERY profile records
-            # it in one place; the pre-flip fork bumped it in the hook
-            # (_record_procedure_surfaced), which the thin-client flip removes.
-            # SEMANTIC: counts "the engine included this procedure in a RETURNED
-            # recall response." Under the split client/server model this can
-            # marginally over-count vs "the user saw it": if this response is slow
-            # enough that the client times out (past its budget, see the hook's
-            # _SERVER_TIMEOUT_S) and
-            # falls back to the degraded path, the bump already committed but the
-            # line was never injected. Accepted — surfaced_count is advisory (never
-            # feeds promotion) and the window is a narrow race; a perfect fix would
-            # need the client to report surfaced-shown back (tracked follow-up).
-            # Best-effort: a bump failure must never fail recall. Deferred off
-            # the latency path (ac27b693) — this is an advisory funnel counter,
-            # never read synchronously, so a background write is strictly safe.
-            _proc_id = procedure["id"]
+        # The shared security pipeline (recall + filters + wrap + enforce + graph
+        # expansion + immunity emit + retrieved_count write-back).
+        # filter_noise + kb_slots restore the pre-flip hook's content guards
+        # (garbage rows + non-intentional knowledge_base + the KB slot budget)
+        # INSIDE the engine's backfill loop and BEFORE external-content wrapping —
+        # so a dropped noisy/over-cap hit is backfilled from the deeper safe pool
+        # (not left as a hole), the garbage check sees raw content, and dropped
+        # items skip retrieved_count write-backs (Codex on #1169). memory_proactive
+        # (the MCP tool) passes neither, so it is byte-for-byte unchanged.
+        kb_slots = max(1, budget // 3)
+        phase = "recall"
+        t_recall = time.monotonic()
+        dicts = await _core._proactive_impl(
+            prompt,
+            limit=budget,
+            rerank=rerank_live,
+            extra_fts_terms=[k for k in (file_keywords or []) if k] or None,
+            filter_noise=True,
+            kb_slots=kb_slots,
+            rerank_timeout_s=_RERANK_TIMEOUT_S,
+            stats=engine_stats,
+            # This is THE latency-budgeted per-prompt path: push recall's
+            # write-backs/emits + the immunity emit off the request path so the
+            # 4.5s route budget isn't spent on post-result DB writes (ac27b693).
+            defer_side_effects=True,
+        )
+        timings["recall"] = round((time.monotonic() - t_recall) * 1000, 1)
 
-            async def _bump_surfaced(proc_id: str = _proc_id) -> None:
-                try:
-                    await db.execute(
-                        "UPDATE procedural_memory SET surfaced_count = surfaced_count + 1 WHERE id = ?",
-                        (proc_id,),
-                    )
-                    await db.commit()
-                except Exception:
-                    logger.debug("surfaced_count bump failed", exc_info=True)
+        phase = "enrich"
+        t_enrich = time.monotonic()
+        # PR-4b (ac27b693): route these post-recall reads off the shared write
+        # lock onto recall's read-only pool via the same _ro_read seam recall's
+        # own reads use. Both are pure indexed SELECTs (memory_metadata PK /
+        # memory_links source_id), so under concurrency they were queuing behind
+        # server writes, not query cost. _ro_read runs fn(pooled_conn, *args) and,
+        # on any pool miss/error, retries on the shared connection — so the
+        # helpers deliberately do NOT swallow their own DB errors (that would hide
+        # a transient pooled-read failure from the fallback; Codex #1197 P2). The
+        # best-effort catch lives HERE so that if BOTH the pooled and shared reads
+        # fail, enrichment degrades to nothing rather than failing recall (the
+        # pre-pool best-effort contract). retriever is genesis.mcp.memory._retriever
+        # (see CC memory two_retriever_wiring) — the same instance the pool was
+        # wired into in PR-4.
+        try:
+            await retriever._ro_read(_enrich, dicts)
+            await retriever._ro_read(_breadcrumbs, dicts)
+        except Exception:
+            logger.debug("post-recall enrichment/breadcrumbs failed", exc_info=True)
+        timings["enrich"] = round((time.monotonic() - t_enrich) * 1000, 1)
 
-            from genesis.util.tasks import tracked_task
+        lines = prof.renderer(dicts)
 
-            tracked_task(_bump_surfaced(), name="proactive_surfaced_count")
+        phase = "procedure"
+        t_proc = time.monotonic()
+        procedure = None
+        if vector:
+            procedure = await _surface_procedure(db, vector)
+            if procedure:
+                lines.append(_render_procedure_line(procedure))
+                # HONEST funnel signal: bump surfaced_count (NOT invocation_count
+                # — passive surfacing must never feed the promoter, which reads
+                # invocation_count). This lives server-side so EVERY profile
+                # records it in one place; the pre-flip fork bumped it in the hook
+                # (_record_procedure_surfaced), which the thin-client flip removes.
+                # SEMANTIC: counts "the engine included this procedure in a
+                # RETURNED recall response." Under the split client/server model
+                # this can marginally over-count vs "the user saw it": if this
+                # response is slow enough that the client times out (past its
+                # budget, see the hook's _SERVER_TIMEOUT_S) and falls back to the
+                # degraded path, the bump already committed but the line was never
+                # injected. Accepted — surfaced_count is advisory (never feeds
+                # promotion) and the window is a narrow race; a perfect fix would
+                # need the client to report surfaced-shown back (tracked follow-up).
+                # Best-effort: a bump failure must never fail recall. Deferred off
+                # the latency path (ac27b693) — this is an advisory funnel counter,
+                # never read synchronously, so a background write is strictly safe.
+                _proc_id = procedure["id"]
 
-    procedure_ms = (time.monotonic() - t_proc) * 1000
+                async def _bump_surfaced(proc_id: str = _proc_id) -> None:
+                    try:
+                        await db.execute(
+                            "UPDATE procedural_memory SET surfaced_count = surfaced_count + 1 WHERE id = ?",
+                            (proc_id,),
+                        )
+                        await db.commit()
+                    except Exception:
+                        logger.debug("surfaced_count bump failed", exc_info=True)
+
+                from genesis.util.tasks import tracked_task
+
+                tracked_task(_bump_surfaced(), name="proactive_surfaced_count")
+
+        timings["procedure"] = round((time.monotonic() - t_proc) * 1000, 1)
+    except asyncio.CancelledError:
+        # Dominant cause is the route's 4.5s budget expiring mid-flight (the 503
+        # path); the route logs its own "exceeded timeout" line at the same
+        # timestamp to correlate against. Surface which phase was in flight + the
+        # timings gathered so far — the signal the 503 previously discarded —
+        # rather than assert a cause, then re-raise so the task completes as
+        # cancelled.
+        timings["cancelled_after_ms"] = round((time.monotonic() - t0) * 1000, 1)
+        logger.warning(
+            "proactive recall CANCELLED at phase=%s; partial timings=%s",
+            phase,
+            timings,
+        )
+        raise
 
     shadow = _shadow_projection(dicts, suppress)
     results = [_result_row(d) for d in dicts]
 
-    total_ms = (time.monotonic() - t0) * 1000
-    timings = {
-        "embed": round(embed_ms, 1),
-        "recall": round(recall_ms, 1),
-        "enrich": round(enrich_ms, 1),
-        "procedure": round(procedure_ms, 1),
-        "total": round(total_ms, 1),
-    }
+    timings["total"] = round((time.monotonic() - t0) * 1000, 1)
+    total_ms = timings["total"]
     if "rerank_ms" in engine_stats:
         timings["rerank"] = engine_stats["rerank_ms"]
     # Sub-stage breakdown of the `recall` bucket (ac27b693): surfaced so a slow

--- a/tests/test_hosting/test_loop_lag_sampler.py
+++ b/tests/test_hosting/test_loop_lag_sampler.py
@@ -1,0 +1,109 @@
+"""StandaloneAdapter._loop_lag_sampler — event-loop stall detector.
+
+The sampler sleeps a fixed interval and measures how much LONGER than the
+interval the wake-up actually took; that excess is time the loop could not
+schedule ready callbacks (blocked in synchronous work on some task) — the
+condition behind proactive-recall 503s. It WARNs when drift exceeds a
+threshold (``GENESIS_LOOP_LAG_WARN_MS``, default 250).
+
+Deterministic + install-agnostic: loop.time() and asyncio.sleep are faked so
+no real wall-clock time passes and the test is not timing-dependent.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from genesis.hosting import standalone
+from genesis.hosting.standalone import StandaloneAdapter
+
+pytestmark = pytest.mark.asyncio
+
+
+def _adapter_with_fake_clock(monkeypatch, *, times, stop_after=1):
+    """Wire an adapter whose sampler runs ``stop_after`` iterations then stops.
+
+    ``times`` supplies the loop.time() readings — two per iteration (t0 before
+    sleep, then the post-sleep read). asyncio.sleep is faked to set the shutdown
+    event after ``stop_after`` calls so the while-loop exits, and to advance
+    nothing real.
+    """
+    import asyncio as _asyncio
+
+    adapter = StandaloneAdapter()
+    adapter._shutdown_event = _asyncio.Event()
+
+    clock = iter(times)
+    fake_loop = MagicMock()
+    fake_loop.time = MagicMock(side_effect=lambda: next(clock))
+    monkeypatch.setattr(standalone.asyncio, "get_running_loop", lambda: fake_loop)
+
+    sleeps = {"n": 0}
+
+    async def _fake_sleep(_interval):
+        sleeps["n"] += 1
+        if sleeps["n"] >= stop_after:
+            adapter._shutdown_event.set()
+
+    monkeypatch.setattr(standalone.asyncio, "sleep", _fake_sleep)
+    return adapter
+
+
+async def test_warns_when_drift_exceeds_threshold(monkeypatch, caplog):
+    # interval 0.5s, post-sleep clock 0.95s → drift 450ms > 250ms default.
+    adapter = _adapter_with_fake_clock(monkeypatch, times=[0.0, 0.95])
+    with caplog.at_level(logging.WARNING):
+        await adapter._loop_lag_sampler()
+    lag_warns = [r.getMessage() for r in caplog.records if "event-loop lag" in r.getMessage()]
+    assert lag_warns, "a >threshold stall must WARN"
+    assert "450ms" in lag_warns[0]
+
+
+async def test_silent_when_drift_below_threshold(monkeypatch, caplog):
+    # drift 50ms < 250ms → no warning.
+    adapter = _adapter_with_fake_clock(monkeypatch, times=[0.0, 0.55])
+    with caplog.at_level(logging.WARNING):
+        await adapter._loop_lag_sampler()
+    assert not [r for r in caplog.records if "event-loop lag" in r.getMessage()]
+
+
+async def test_env_threshold_raises_the_bar(monkeypatch, caplog):
+    # A 450ms drift that WOULD warn at the default stays silent when the env
+    # lever raises the threshold above it (no restart of the logic required).
+    monkeypatch.setenv("GENESIS_LOOP_LAG_WARN_MS", "1000")
+    adapter = _adapter_with_fake_clock(monkeypatch, times=[0.0, 0.95])
+    with caplog.at_level(logging.WARNING):
+        await adapter._loop_lag_sampler()
+    assert not [r for r in caplog.records if "event-loop lag" in r.getMessage()]
+
+
+async def test_bad_env_threshold_falls_back_to_default(monkeypatch, caplog):
+    # A non-numeric override must not crash the sampler; it falls back to 250ms.
+    monkeypatch.setenv("GENESIS_LOOP_LAG_WARN_MS", "not-a-number")
+    adapter = _adapter_with_fake_clock(monkeypatch, times=[0.0, 0.95])
+    with caplog.at_level(logging.WARNING):
+        await adapter._loop_lag_sampler()
+    assert [r for r in caplog.records if "event-loop lag" in r.getMessage()]
+
+
+async def test_sustained_lag_warns_once_then_reports_clear(monkeypatch, caplog):
+    """A multi-sample stall must WARN exactly once (episode debounce), then emit
+    an INFO with the peak drift when it clears — not one line per sample."""
+    # iter1: 0.0→0.95 drift 450 (enter, WARN); iter2: 0.95→2.05 drift 600 (peak,
+    # suppressed); iter3: 2.05→2.55 drift 0 (clear, INFO with peak 600).
+    adapter = _adapter_with_fake_clock(
+        monkeypatch,
+        times=[0.0, 0.95, 0.95, 2.05, 2.05, 2.55],
+        stop_after=3,
+    )
+    with caplog.at_level(logging.INFO):
+        await adapter._loop_lag_sampler()
+    warns = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    clears = [r.getMessage() for r in caplog.records if "event-loop lag cleared" in r.getMessage()]
+    assert len(warns) == 1, f"sustained stall must warn once, got {warns}"
+    assert "suppressed until it clears" in warns[0]
+    assert len(clears) == 1
+    assert "peak 600ms" in clears[0]

--- a/tests/test_memory/test_proactive_engine.py
+++ b/tests/test_memory/test_proactive_engine.py
@@ -9,8 +9,12 @@ Install-agnostic: no live retriever, Qdrant, network, or DB.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from genesis.memory import proactive as P
 from genesis.memory.intent import classify_stance
@@ -718,3 +722,33 @@ def test_is_garbage_predicate():
     assert is_garbage("---\ntype: observation\n") is True
     assert is_garbage("{just braces, no json keys}") is False
     assert is_garbage("--- not frontmatter, just dashes") is False
+
+
+# --- cancellation observability (the 503 path) ------------------------------
+
+
+async def test_proactive_context_logs_partial_timings_on_cancellation(caplog):
+    """When the route budget expires mid-flight the coroutine is cancelled;
+    proactive_context must log WHICH phase was in flight + the partial timings
+    (the signal the 503 path previously discarded) and RE-RAISE CancelledError.
+
+    Embed completes on the fast fake retriever, so cancellation lands in the
+    recall phase — the log names phase=recall with embed already timed.
+    """
+    with (
+        patch("genesis.mcp.memory.core._memory_mod", return_value=_FakeMod()),
+        patch(
+            "genesis.mcp.memory.core._proactive_impl",
+            new=AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        caplog.at_level(logging.WARNING),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await P.proactive_context(prompt="what did we decide", session_id="s")
+
+    warns = [r.getMessage() for r in caplog.records if "CANCELLED at phase" in r.getMessage()]
+    assert warns, "cancellation must emit a WARNING naming the in-flight phase"
+    assert "phase=recall" in warns[0]
+    # partial timings carry the completed embed phase but NOT recall (never finished)
+    assert "'embed'" in warns[0]
+    assert "'recall'" not in warns[0]


### PR DESCRIPTION
## What

Makes the proactive-recall 503 path observable. Instrument-first — **no structural change to recall behavior.**

The dashboard route enforces its 4.5s budget thread-side (`run_coroutine_threadsafe` + `future.result(timeout=4.5)`) and, on expiry, `future.cancel()`s the recall coroutine (which schedules a thread-safe task-cancel on the loop → raises `CancelledError` at the current await) and returns 503. Previously `proactive_context` only logged timings when the coroutine **completed** slow, so the ~39%/24h of calls that time out logged nothing — no phase timings, no attribution. That was the observability hole behind the recall-timeout hunt.

## Changes

1. **`memory/proactive.py`** — `proactive_context` runs its awaited phase sequence (embed → recall → enrich → procedure) inside a `try/except asyncio.CancelledError`, accumulating per-phase timings incrementally and tracking the in-flight `phase`. On cancellation it WARNs the phase + partial timings (the data the 503 discarded) and **re-raises**. `CancelledError` is a `BaseException`, so the inner best-effort `except Exception` blocks never swallow it.
2. **`hosting/standalone.py`** — a `_loop_lag_sampler` measures event-loop scheduling drift every 500ms and WARNs once per stall **episode** (peak drift reported when it clears — debounced so a sustained stall does not flood the journal), making a loop stall timestamp-correlatable with the awareness-tick / dispatch / bundle lines that starve recall. Started in `serve()` after loop capture, cancelled at shutdown.

## Levers (generalizable, zero-config defaults)

- `GENESIS_LOOP_LAG_WARN_MS` (default 250) — drift threshold to warn at.
- `GENESIS_LOOP_LAG_SAMPLER` (`0`/`false`/`off`) — disables the sampler at startup.

## Tests

- `test_proactive_context_logs_partial_timings_on_cancellation` — cancellation logs phase + partials and re-raises.
- `test_loop_lag_sampler.py` — warn-above-threshold, silent-below, env-raises-bar, bad-env-fallback, sustained-lag-warns-once-then-clears.
- **28 targeted tests green, ruff clean.**

## Verification

Instrument-first, so behavior is unchanged; the payoff is measured post-deploy: real 503s now carry a paired `CANCELLED at phase=` WARN, and loop stalls emit a lag line. A 48h soak of this data drives the follow-up targeted-offload PR (PR-2b) — no speculative offloads here (diagnose-before-fix).

Part of WS-1 (memory/recall reliability). Instrumentation step for follow-up `ac03bfe3` — closed with data after the soak, not by this PR.