### PR TITLE
docs(agents-md): refresh inventory to include taste skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ Body-scope inventory for cross-tool agents — Genesis's skills and action tools
 - **shelve** — Shelve the current session — create a bookmark so you can find and resume it later with /unshelve.
 - **stealth-browser** — Anti-detection behavioral rules for stealth browser automation
 - **subsystem-map** — This skill should be used before answering "does Genesis have X", "does Genesis lack X", auditing Genesis capabilities, comparing Genesis to an external system, or reviewing/summarizing the architecture. It routes to the canonical judgment-layer subsystem map so audits start from the map, not from a cold grep. Also fires after changing a subsystem's capabilities, to keep the map current.
+- **taste** — Use before generating, editing, or reviewing any user interface — a dashboard panel, a landing page, an email, a slide, an app screen. Sets three deliberate design dials (variance, motion, density) BEFORE generation so the output has a point of view instead of defaulting to the timid, uniform look that reads as "AI made this". Applies to Genesis's OWN dashboard UI, not only things built for others.
 - **triage-calibration** — Daily triage accuracy calibration — use during scheduled calibration runs to verify triage classification accuracy against few-shot examples and adjust confidence thresholds
 - **unshelve** — Search for shelved sessions — find past bookmarked sessions by keyword or browse recent ones.
 - **user_evaluate** — Evaluate content for personal relevance to the user using the user model


### PR DESCRIPTION
On-demand regeneration of the AGENTS.md managed block after #1289 landed the `taste` skill. The exporter from #1288 now lists it (41 skills, 80 body tools) with its full description — closes the one-skill staleness and demonstrates the exporter picks up new skills end-to-end.

Docs-only (AGENTS.md managed block). Part of the capability-build campaign (ledger `09ab9c12a8fd49c686cc644201b448c7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)