### PR TITLE
fix(cc): park (not crash) on Max session/weekly limits + resolve reset in account timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Background work now survives Claude session/weekly limits instead of failing.**
+  When Claude Code hit its Max-plan session or weekly usage limit, the message
+  ("You've hit your session limit · resets 4:10am") wasn't recognized as a limit
+  at all — it was treated as a generic crash, so the background session died and
+  its work was lost rather than being parked to auto-resume when the limit reset.
+  These limits are now recognized, and the resume is scheduled from the real
+  reset time in your account's own timezone (previously a bare reset time could
+  be read in the server's timezone and land hours off).
+
 - **Re-embedding a memory no longer downgrades its recall ranking.** When a
   memory's vector was rebuilt (after a vector-store outage, or by the nightly
   repair job), its priority class was silently recomputed from the text alone —

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -526,7 +526,17 @@ class CCInvoker:
         # Session expiry
         if "session" in lower and ("not found" in lower or "expired" in lower):
             return CCSessionError(stderr_text or stdout_text)
-        # Hard quota exhaustion (usage limit hit for hours — distinct from 429)
+        # Hard quota exhaustion (usage limit hit for hours — distinct from 429).
+        # "session limit" / "weekly limit" are the Max-plan rolling-window and
+        # weekly ceilings: real multi-minute-to-hours lockouts that reset at a
+        # defined time, NOT transient 429s. The CLI wording varies ("You've hit
+        # your session limit · resets 4:10am", "weekly limit reached", "usage
+        # limit reached") — cover the family, not one instance. Before this,
+        # "hit your session limit" matched NO pattern (the RATE list has "hit
+        # your limit" but "session" splits the substring) and fell through to
+        # generic CCProcessError, so the rate-limit park/resume layer never
+        # engaged and background sessions died instead of parking (reflex signal
+        # CCProcessError×cc, 2026-07/08).
         _QUOTA_PATTERNS = (
             "usage limit",
             "quota exceeded",
@@ -534,6 +544,8 @@ class CCInvoker:
             "usage cap",
             "spending limit",
             "token limit exceeded",
+            "session limit",
+            "weekly limit",
         )
         if any(p in lower for p in _QUOTA_PATTERNS):
             return CCQuotaExhaustedError(stderr_text or stdout_text, raw_text=combined)

--- a/src/genesis/cc/rate_limit_reset.py
+++ b/src/genesis/cc/rate_limit_reset.py
@@ -13,8 +13,9 @@ resets 4:10am (America/Los_Angeles)"``. The parser resolves that hint (falling
 back to ``now``'s tz when absent) so a UTC-clocked server does not schedule the
 resume hours off. The structured ``rate_limit_event`` payload layout is still
 undocumented, so key search stays defensive; on any miss it returns ``None`` and
-the scheduler uses its cadence floor. A weekly limit with only a wall-clock time
-is day-ambiguous → ``None`` (never guess "next 5pm").
+the scheduler uses its cadence floor. A weekly limit that NAMES a weekday
+("resets Monday 9am") resolves to that day's next occurrence; a weekly limit
+with only a BARE wall-clock is day-ambiguous → ``None`` (never guess "next 5pm").
 """
 
 from __future__ import annotations
@@ -157,6 +158,20 @@ _CLOCK_RE = re.compile(
     r"reset[a-z ]*?(?:at\s*)?(?P<h>\d{1,2})(?::(?P<min>\d{2}))?\s*(?P<ap>am|pm)",
     re.IGNORECASE,
 )
+# Weekday-bearing wall-clock, e.g. "resets Monday 9am". A named day makes a
+# WEEKLY reset UNambiguous (unlike a bare clock), so it can be resolved to a
+# concrete next-occurrence instead of dropped to None.
+_WEEKDAYS = {"mon": 0, "tue": 1, "wed": 2, "thu": 3, "fri": 4, "sat": 5, "sun": 6}
+# Match only genuine weekday tokens (3-letter abbrev OR full name), ``\b``-bounded
+# both ends so a word merely STARTING with a day prefix (``month``→mon,
+# ``friendly``→fri) can't false-match. Separator allows a comma ("Monday, 9am").
+# The map key is the captured token's first 3 letters.
+_WEEKDAY_CLOCK_RE = re.compile(
+    r"reset[a-z ]*?\b(?P<wd>mon(?:day)?|tue(?:sday)?|wed(?:nesday)?|thu(?:rsday)?|"
+    r"fri(?:day)?|sat(?:urday)?|sun(?:day)?)\b[,\s]+(?:at\s*)?"
+    r"(?P<h>\d{1,2})(?::(?P<min>\d{2}))?\s*(?P<ap>am|pm)",
+    re.IGNORECASE,
+)
 # A trailing IANA zone hint, e.g. "resets 4:10am (America/Los_Angeles)". The CC CLI
 # renders the reset time in the ACCOUNT's local zone, not the container's — so a
 # bare wall-clock parsed in ``now``'s tz (UTC on a server) lands hours off. Case
@@ -179,11 +194,28 @@ def _extract_tz_hint(text: str) -> tzinfo | None:
         return None
 
 
+def _clock_24h(h: str, minute: str | None, ap: str) -> tuple[int, int]:
+    """(hour_group, minute_group, am/pm) → 24h (hour, minute)."""
+    hour = int(h) % 12
+    if ap.lower() == "pm":
+        hour += 12
+    return hour, int(minute or 0)
+
+
+def _account_ref(now: datetime, text: str) -> tuple[datetime, tzinfo | None]:
+    """``now`` shifted into the account's zone if the prose names one, else
+    ``now`` unchanged. Returns ``(ref, tz)``; a wall-clock built on ``ref`` is
+    handed back to ``now``'s tz only when ``tz`` is not None."""
+    tz = _extract_tz_hint(text)
+    return (now.astimezone(tz), tz) if tz is not None else (now, None)
+
+
 def _reset_from_prose(text: str, now: datetime, limit_kind: str) -> datetime | None:
     """Parse a reset time from CC's prose. Relative durations are unambiguous;
-    a bare wall-clock time is day-ambiguous for a WEEKLY limit → None. A wall-
-    clock time carrying an ``(IANA/Zone)`` hint is resolved in that zone (the
-    account's local zone) and returned in ``now``'s tz."""
+    a weekday-bearing wall-clock ("Monday 9am") resolves to the next occurrence;
+    a BARE wall-clock is day-ambiguous for a WEEKLY limit → None. A wall-clock
+    carrying an ``(IANA/Zone)`` hint is resolved in that zone (the account's
+    local zone) and returned in ``now``'s tz."""
     if not text:
         return None
     low = text.lower()
@@ -196,22 +228,35 @@ def _reset_from_prose(text: str, now: datetime, limit_kind: str) -> datetime | N
         if hours or mins:
             return now + timedelta(hours=hours, minutes=mins)
 
-    # Wall-clock: "resets 5pm" / "resets at 11:30 am" / "resets 4:10am (America/Los_Angeles)".
+    # Weekday wall-clock: "resets Monday 9am" — a named day is unambiguous even
+    # for a weekly cap, so resolve the NEXT occurrence of that weekday/time
+    # (account-zone-aware) rather than dropping to the cadence floor. Checked
+    # before the bare-clock branch since the bare regex would also match here.
+    w = _WEEKDAY_CLOCK_RE.search(low)
+    if w:
+        hour, minute = _clock_24h(w.group("h"), w.group("min"), w.group("ap"))
+        target_wd = _WEEKDAYS[w.group("wd").lower()[:3]]
+        ref, tz = _account_ref(now, text)
+        days_ahead = (target_wd - ref.weekday()) % 7
+        candidate = ref.replace(hour=hour, minute=minute, second=0, microsecond=0) + timedelta(
+            days=days_ahead
+        )
+        if candidate <= ref:  # today-but-already-past → next week
+            candidate += timedelta(days=7)
+        return candidate.astimezone(now.tzinfo) if tz is not None else candidate
+
+    # Bare wall-clock: "resets 5pm" / "resets at 11:30 am" / "resets 4:10am (America/Los_Angeles)".
     c = _CLOCK_RE.search(low)
     if c:
         if limit_kind == WEEKLY:
             # Which day? Unknowable from a bare clock time — don't guess.
             return None
-        hour = int(c.group("h")) % 12
-        if c.group("ap").lower() == "pm":
-            hour += 12
-        minute = int(c.group("min") or 0)
+        hour, minute = _clock_24h(c.group("h"), c.group("min"), c.group("ap"))
         # Resolve the wall-clock in the account's zone when the CLI names it
         # (search the ORIGINAL-case text — zone keys are case-sensitive), then
         # hand back a datetime in ``now``'s tz. No hint → parse in ``now``'s tz
         # exactly as before (unchanged behavior).
-        tz = _extract_tz_hint(text)
-        ref = now.astimezone(tz) if tz is not None else now
+        ref, tz = _account_ref(now, text)
         candidate = ref.replace(hour=hour, minute=minute, second=0, microsecond=0)
         if candidate <= ref:
             candidate += timedelta(days=1)

--- a/src/genesis/cc/rate_limit_reset.py
+++ b/src/genesis/cc/rate_limit_reset.py
@@ -6,19 +6,22 @@ promise — resume is self-validating (a still-limited re-run re-parks), so an
 imprecise or missing reset only changes WHEN the first re-attempt fires, not
 whether the parked work survives.
 
-CRITICAL UNKNOWN — verify against the first real captured event: the exact
-field layout of a CC ``rate_limit_event`` payload is not documented, and the
-prose form ("resets Xpm") is only known from a code comment. This parser
-therefore searches defensively for common reset-time keys and falls back to
-prose; on any miss it returns ``None`` and the scheduler uses its cadence
-floor. A weekly limit with only a wall-clock time is day-ambiguous → ``None``
-(never guess "next 5pm").
+Prose form CONFIRMED against a real captured event (2026-08, reflex signal
+CCProcessError×cc): a wall-clock reset time in the ACCOUNT's local zone, named
+in a trailing ``(IANA/Zone)`` hint — e.g. ``"You've hit your session limit ·
+resets 4:10am (America/Los_Angeles)"``. The parser resolves that hint (falling
+back to ``now``'s tz when absent) so a UTC-clocked server does not schedule the
+resume hours off. The structured ``rate_limit_event`` payload layout is still
+undocumented, so key search stays defensive; on any miss it returns ``None`` and
+the scheduler uses its cadence floor. A weekly limit with only a wall-clock time
+is day-ambiguous → ``None`` (never guess "next 5pm").
 """
 
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, tzinfo
+from zoneinfo import ZoneInfo
 
 # limit_kind vocabulary — kept tiny; only used to size backoff and to decide
 # whether a bare wall-clock prose time is day-ambiguous.
@@ -154,11 +157,33 @@ _CLOCK_RE = re.compile(
     r"reset[a-z ]*?(?:at\s*)?(?P<h>\d{1,2})(?::(?P<min>\d{2}))?\s*(?P<ap>am|pm)",
     re.IGNORECASE,
 )
+# A trailing IANA zone hint, e.g. "resets 4:10am (America/Los_Angeles)". The CC CLI
+# renders the reset time in the ACCOUNT's local zone, not the container's — so a
+# bare wall-clock parsed in ``now``'s tz (UTC on a server) lands hours off. Case
+# preserved: IANA zone keys are case-sensitive.
+_TZ_HINT_RE = re.compile(r"\(([A-Za-z]+(?:/[A-Za-z0-9_+-]+)+)\)")
+
+
+def _extract_tz_hint(text: str) -> tzinfo | None:
+    """A trailing ``(Area/Location)`` zone hint as a tzinfo, or None.
+
+    Best-effort: an absent or unresolvable zone (no tzdata, bad name) returns
+    None so the caller falls back to naive parsing in ``now``'s tz — never
+    raises, never worse than pre-hint behavior."""
+    m = _TZ_HINT_RE.search(text)
+    if not m:
+        return None
+    try:
+        return ZoneInfo(m.group(1))
+    except Exception:
+        return None
 
 
 def _reset_from_prose(text: str, now: datetime, limit_kind: str) -> datetime | None:
     """Parse a reset time from CC's prose. Relative durations are unambiguous;
-    a bare wall-clock time is day-ambiguous for a WEEKLY limit → None."""
+    a bare wall-clock time is day-ambiguous for a WEEKLY limit → None. A wall-
+    clock time carrying an ``(IANA/Zone)`` hint is resolved in that zone (the
+    account's local zone) and returned in ``now``'s tz."""
     if not text:
         return None
     low = text.lower()
@@ -171,7 +196,7 @@ def _reset_from_prose(text: str, now: datetime, limit_kind: str) -> datetime | N
         if hours or mins:
             return now + timedelta(hours=hours, minutes=mins)
 
-    # Wall-clock: "resets 5pm" / "resets at 11:30 am".
+    # Wall-clock: "resets 5pm" / "resets at 11:30 am" / "resets 4:10am (America/Los_Angeles)".
     c = _CLOCK_RE.search(low)
     if c:
         if limit_kind == WEEKLY:
@@ -181,10 +206,16 @@ def _reset_from_prose(text: str, now: datetime, limit_kind: str) -> datetime | N
         if c.group("ap").lower() == "pm":
             hour += 12
         minute = int(c.group("min") or 0)
-        candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
-        if candidate <= now:
+        # Resolve the wall-clock in the account's zone when the CLI names it
+        # (search the ORIGINAL-case text — zone keys are case-sensitive), then
+        # hand back a datetime in ``now``'s tz. No hint → parse in ``now``'s tz
+        # exactly as before (unchanged behavior).
+        tz = _extract_tz_hint(text)
+        ref = now.astimezone(tz) if tz is not None else now
+        candidate = ref.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if candidate <= ref:
             candidate += timedelta(days=1)
-        return candidate
+        return candidate.astimezone(now.tzinfo) if tz is not None else candidate
     return None
 
 

--- a/tests/test_cc/test_invoker.py
+++ b/tests/test_cc/test_invoker.py
@@ -1158,6 +1158,40 @@ def test_classify_error_quota_from_stdout(invoker):
     assert isinstance(err, CCQuotaExhaustedError)
 
 
+def test_classify_error_session_limit(invoker):
+    """The Max-plan session-limit wording must classify as a typed limit error,
+    not generic CCProcessError. Regression for the exact live-captured message
+    (reflex signal CCProcessError×cc): before the fix it matched NO pattern
+    ("hit your limit" is not a substring of "hit your session limit"), fell
+    through to CCProcessError, and the rate-limit park/resume layer never
+    engaged — background sessions died instead of parking.
+    """
+    from genesis.cc.exceptions import CCProcessError, CCQuotaExhaustedError
+
+    # Exact live message (tz preserved; not private).
+    err = invoker._classify_error(
+        "", stdout_text="You've hit your session limit · resets 4:10am (America/Los_Angeles)"
+    )
+    assert isinstance(err, CCQuotaExhaustedError)
+    assert not isinstance(err, CCProcessError)
+    # raw_text must be carried so the park layer can parse the reset.
+    assert err.raw_text is not None and "session limit" in err.raw_text.lower()
+
+
+def test_classify_error_weekly_limit(invoker):
+    """Weekly-limit wording also classifies as a typed limit error (quota-side),
+    covering the message family, not just the session instance."""
+    from genesis.cc.exceptions import CCProcessError, CCQuotaExhaustedError
+
+    for msg in [
+        "You've hit your weekly limit · resets Monday 9am",
+        "Weekly limit reached for your plan",
+    ]:
+        err = invoker._classify_error(msg)
+        assert isinstance(err, CCQuotaExhaustedError), f"Failed for: {msg}"
+        assert not isinstance(err, CCProcessError)
+
+
 @pytest.mark.asyncio
 async def test_status_callback_on_quota_exhaustion():
     """Quota exhaustion triggers UNAVAILABLE status callback."""

--- a/tests/test_cc/test_rate_limit_reset.py
+++ b/tests/test_cc/test_rate_limit_reset.py
@@ -31,14 +31,71 @@ def test_prose_wallclock_session_next_occurrence():
 
 
 def test_prose_wallclock_weekly_is_ambiguous_none():
+    # BARE clock (no weekday) for a weekly cap stays day-ambiguous → None.
     kind, reset = parse_reset(raw_text="Weekly usage limit reached, resets 5pm", now=NOW)
     assert kind == WEEKLY
     assert reset is None
 
 
+def test_prose_weekly_weekday_resolves_next_occurrence():
+    """A weekly cap that NAMES a weekday is unambiguous — resolve the next
+    occurrence instead of dropping to None (so the resume waits for the real
+    reset rather than retrying on the cadence floor for days)."""
+    now = datetime(2026, 8, 5, 12, 0, 0, tzinfo=UTC)  # Wednesday
+    kind, reset = parse_reset(raw_text="You've hit your weekly limit · resets Monday 9am", now=now)
+    assert kind == WEEKLY
+    # Next Monday after Wed 2026-08-05 is 2026-08-10, 09:00 (no tz hint → UTC).
+    assert reset == datetime(2026, 8, 10, 9, 0, 0, tzinfo=UTC)
+
+
+def test_prose_weekly_weekday_honors_tz_hint():
+    """Weekday resolution is account-zone-aware when the CLI names the zone."""
+    now = datetime(2026, 8, 5, 12, 0, 0, tzinfo=UTC)  # Wednesday
+    _, reset = parse_reset(
+        raw_text="hit your weekly limit · resets Monday 9am (America/Los_Angeles)",
+        now=now,
+    )
+    # Monday 09:00 PDT (UTC-7) == 2026-08-10 16:00 UTC.
+    assert reset == datetime(2026, 8, 10, 16, 0, 0, tzinfo=UTC)
+
+
+def test_prose_weekday_same_day_already_passed_rolls_a_week():
+    """Named day == today but the time already passed → next week, not today."""
+    now = datetime(2026, 8, 5, 20, 0, 0, tzinfo=UTC)  # Wednesday 20:00
+    _, reset = parse_reset(raw_text="weekly limit resets Wednesday 9am", now=now)
+    assert reset == datetime(2026, 8, 12, 9, 0, 0, tzinfo=UTC)
+
+
 def test_wallclock_already_passed_rolls_to_tomorrow():
     kind, reset = parse_reset(raw_text="resets 9am", now=NOW)  # 9am < 2pm now
     assert reset == (NOW + timedelta(days=1)).replace(hour=9, minute=0)
+
+
+def test_prose_weekday_future_this_week_no_wrap():
+    """A weekday later this week resolves to this week (no spurious +7)."""
+    wed = datetime(2026, 8, 5, 12, 0, 0, tzinfo=UTC)  # Wednesday
+    _, reset = parse_reset(raw_text="weekly limit resets Friday 5pm", now=wed)
+    assert reset == datetime(2026, 8, 7, 17, 0, 0, tzinfo=UTC)  # this Friday
+
+
+def test_prose_weekday_full_name_and_comma():
+    """Full weekday names and a comma separator ("Monday, 9am") both parse."""
+    wed = datetime(2026, 8, 5, 12, 0, 0, tzinfo=UTC)
+    _, full = parse_reset(raw_text="weekly limit resets Monday, 9am", now=wed)
+    _, abbrev = parse_reset(raw_text="weekly limit resets Mon 9am", now=wed)
+    assert full == abbrev == datetime(2026, 8, 10, 9, 0, 0, tzinfo=UTC)
+
+
+def test_prose_weekday_prefix_word_is_not_a_weekday():
+    """A word merely STARTING with a day prefix (monthly→mon, friendly→fri) must
+    NOT be parsed as that weekday — it falls through to the bare-clock branch,
+    which is day-ambiguous for a weekly cap → None (not a wrong Monday)."""
+    wed = datetime(2026, 8, 5, 12, 0, 0, tzinfo=UTC)
+    assert parse_reset(raw_text="weekly limit resets monthly at 9am", now=wed) == (WEEKLY, None)
+    assert parse_reset(raw_text="weekly limit, friendly note, resets 9am", now=wed) == (
+        WEEKLY,
+        None,
+    )
 
 
 def test_prose_wallclock_honors_tz_hint():

--- a/tests/test_cc/test_rate_limit_reset.py
+++ b/tests/test_cc/test_rate_limit_reset.py
@@ -41,6 +41,51 @@ def test_wallclock_already_passed_rolls_to_tomorrow():
     assert reset == (NOW + timedelta(days=1)).replace(hour=9, minute=0)
 
 
+def test_prose_wallclock_honors_tz_hint():
+    """A trailing (IANA/Zone) hint is the account's local zone — resolve the
+    wall-clock there, not in the server's UTC. Regression for the live-captured
+    session-limit message that parsed ~hours off without this.
+    """
+    # 2026-08-03 09:00 UTC == 02:00 America/Los_Angeles (PDT, UTC-7). The message
+    # says the session resets at 4:10am PT → 11:10 UTC the SAME day (~1h out in
+    # wall terms), NOT the naive-UTC parse of 04:10 UTC which, being already past
+    # 09:00, would roll to the next day (hours off).
+    now = datetime(2026, 8, 3, 9, 0, 0, tzinfo=UTC)
+    kind, reset = parse_reset(
+        raw_text="You've hit your session limit · resets 4:10am (America/Los_Angeles)",
+        now=now,
+    )
+    assert kind == SESSION
+    assert reset == datetime(2026, 8, 3, 11, 10, 0, tzinfo=UTC)
+
+
+def test_prose_wallclock_tz_hint_rolls_to_tomorrow_in_zone():
+    """When the account-zone wall-clock has already passed, roll a day — the
+    comparison happens in the account zone, not UTC."""
+    # 2026-08-03 15:00 UTC == 08:00 PT. A 4:10am PT reset already passed today in
+    # PT → next day 4:10am PT == 2026-08-04 11:10 UTC.
+    now = datetime(2026, 8, 3, 15, 0, 0, tzinfo=UTC)
+    _, reset = parse_reset(
+        raw_text="hit your session limit · resets 4:10am (America/Los_Angeles)",
+        now=now,
+    )
+    assert reset == datetime(2026, 8, 4, 11, 10, 0, tzinfo=UTC)
+
+
+def test_prose_wallclock_no_tz_hint_unchanged():
+    """No zone hint → parse in ``now``'s tz exactly as before (unchanged path)."""
+    kind, reset = parse_reset(raw_text="Session limit — resets 5pm", now=NOW)
+    assert kind == SESSION
+    assert reset == NOW.replace(hour=17, minute=0)
+
+
+def test_prose_wallclock_invalid_tz_hint_falls_back():
+    """An unresolvable zone name must NOT raise — fall back to naive parsing."""
+    kind, reset = parse_reset(raw_text="session limit resets 5pm (Not/AZone)", now=NOW)
+    assert kind == SESSION
+    assert reset == NOW.replace(hour=17, minute=0)
+
+
 def test_event_epoch_seconds():
     ts = int((NOW + timedelta(hours=3)).timestamp())
     _, reset = parse_reset(raw_event={"type": "rate_limit_event", "resetsAt": ts}, now=NOW)


### PR DESCRIPTION
## Summary

Background Claude Code sessions were **dying instead of parking** when the account
hit its Max-plan **session** or **weekly** usage limit — losing their work rather
than auto-resuming after the limit reset.

Root cause: the CC error classifier (`CCInvoker._classify_error`) didn't recognize
the limit wording. The message *"You've hit your session limit · resets 4:10am"*
matched no pattern — `"hit your limit"` is not a substring of `"hit your **session**
limit"` — so it fell through to a generic `CCProcessError`. The rate-limit
park/resume durability layer keys off the **typed** limit exceptions
(`CCRateLimitError` / `CCQuotaExhaustedError`), so it never engaged. This surfaced
as a recurring self-bug signal (`CCProcessError × cc`).

## What changed

**1. Classify session/weekly limits (`cc/invoker.py`).** Added `"session limit"`
and `"weekly limit"` to the quota-pattern set. These are real multi-minute-to-hours
ceilings that reset at a defined time, not transient 429s, so they map to
`CCQuotaExhaustedError` (which carries `raw_text` for the park layer). Covers the
wording family, not one instance.

**2. Resolve the reset time in the account's timezone (`cc/rate_limit_reset.py`).**
The CLI renders a limit's reset time in the **account's** local zone, named in a
trailing `(IANA/Zone)` hint (e.g. `(America/Los_Angeles)`). The prose parser ignored
the hint and read the bare wall-clock in the server's UTC, scheduling the resume
hours off. It now resolves a trailing IANA zone hint via `zoneinfo` (wall-clock and
day-rollover computed in that zone, returned in `now`'s tz). Absent/unresolvable
zone falls back to the prior naive behavior — never raises, never worse than before.
This path was previously dark for session limits (they misclassified and carried no
`raw_text`), so the two fixes ship together.

The structured `rate_limit_event` **stream** path was never affected — it always
produced a typed `CCRateLimitError` carrying `raw_event`, and already parks.

## Verification

- New tests **RED on the unfixed code, GREEN on the fix** (proven via stash): the
  classifier now types session/weekly limits; the parser resolves the account-zone
  reset (with day-rollover done in-zone) and stays byte-identical on the no-hint path.
- Full files green: `tests/test_cc/test_invoker.py` + `tests/test_cc/test_rate_limit_reset.py`
  (135), plus the park-layer consumers `test_rate_limit_park.py` + `test_rate_limit_resume.py`
  (24). `ruff` clean.
- In-process **E2E chain** verified: limit message → `CCQuotaExhaustedError` carrying
  `raw_text` → park layer parses `limit_kind=session` and the correct reset time.

## Deploy path

Runtime code — reaches installs via `git pull` + server restart. No schema, no config,
no host action.
