### PR TITLE
fix(dashboard): CSRF-harden cookie-authed /api mutations (same-origin check)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   breaks, set `GENESIS_DASHBOARD_API_AUTH=off` to disable just this gate without
   removing the password.
 
+### Security
+
+- **The dashboard API is now hardened against cross-site request forgery (CSRF).**
+  With a password set, a state-changing API call authenticated by your login
+  cookie must now originate from the dashboard itself (verified via the browser's
+  `Sec-Fetch-Site`/`Origin` headers). Previously another page — including a
+  separate service sharing your dashboard's host — could ride your logged-in
+  session to trigger dashboard actions; that path is now refused. Genesis's own
+  components (which use an internal token) and read-only calls are unaffected, and
+  the same `GENESIS_DASHBOARD_API_AUTH=off` switch disables this along with the
+  rest of the gate.
+
 ### Fixed
 
 - **Re-embedding a memory no longer downgrades its recall ranking.** When a

--- a/src/genesis/dashboard/auth.py
+++ b/src/genesis/dashboard/auth.py
@@ -15,6 +15,7 @@ import os
 import secrets
 from collections import defaultdict
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from flask import jsonify, redirect, request, session
 
@@ -191,6 +192,54 @@ _API_AUTH_OFF = ("off", "0", "false", "no")
 _GENESIS_API_PREFIXES = ("/api/genesis/", "/api/t/")
 
 
+# CSRF: Sec-Fetch-Site values that indicate a request is NOT a cross-origin ride.
+# ``same-origin`` = our own page's fetch; ``none`` = a direct user action (typed
+# URL / bookmark). ``same-site`` and ``cross-site`` are the CSRF-risky values.
+_SAFE_FETCH_SITES = frozenset({"same-origin", "none"})
+
+
+def _origin_matches_host(url: str) -> bool:
+    """True when ``url``'s host[:port] equals the request's ``Host`` header.
+
+    Host comparison is case-insensitive (hostnames are per RFC; browsers already
+    lowercase, this covers hand-crafted same-origin tooling) — a case mismatch can
+    only make the check stricter (fail-closed), never open a bypass.
+    """
+    try:
+        netloc = urlsplit(url).netloc
+    except ValueError:
+        return False
+    return bool(netloc) and netloc.lower() == (request.host or "").lower()
+
+
+def _is_same_origin_request() -> bool:
+    """Whether a state-changing request is same-origin — the CSRF check for the
+    cookie auth path.
+
+    ``SameSite=Lax`` attaches the session cookie on same-*site* requests too (a
+    sibling origin on another port/subdomain of the dashboard host), so a valid
+    cookie is not proof of same-origin intent. Primary signal is ``Sec-Fetch-Site``
+    (browser-set, unforgeable by page JS, present on every current browser): safe
+    iff ``same-origin`` or ``none``. When it is absent (older browser / non-browser
+    client) fall back to matching the ``Origin`` (then ``Referer``) host against the
+    request ``Host``. When NO same-origin signal is present at all, **fail closed** —
+    a legitimate machine caller authenticates with the internal bearer, not the
+    cookie, so a cookie-only request with no origin signal is refused (per the OWASP
+    CSRF Fetch-Metadata guidance: treat absent Sec-Fetch-* as unknown, do not fail
+    open).
+    """
+    sec_fetch_site = request.headers.get("Sec-Fetch-Site", "").strip().lower()
+    if sec_fetch_site:
+        return sec_fetch_site in _SAFE_FETCH_SITES
+    origin = request.headers.get("Origin", "").strip()
+    if origin:
+        return _origin_matches_host(origin)
+    referer = request.headers.get("Referer", "").strip()
+    if referer:
+        return _origin_matches_host(referer)
+    return False
+
+
 def check_api_mutation_auth():
     """App-level gate: require auth for ``/api/**`` STATE-CHANGING requests when a
     dashboard password is set.
@@ -206,8 +255,10 @@ def check_api_mutation_auth():
     ``/v1/*`` enforces its own bearer; a co-hosting framework's own ``/api/*`` routes
     are left alone); GET/HEAD/OPTIONS (non-mutating — guardian/health probes and
     dashboard polling stay open); and the ``/api/genesis/auth/*`` login/logout
-    endpoints. A mutation passes with a valid session cookie OR a valid internal
-    bearer token; otherwise the request is rejected with 401.
+    endpoints. A mutation passes with a valid internal bearer token, OR a valid
+    session cookie on a same-origin request (Sec-Fetch-Site / Origin — CSRF guard).
+    A cookie-authed cross-origin/originless mutation is rejected 403; a request with
+    no credential at all is rejected 401.
     """
     if not get_dashboard_password():
         return None
@@ -222,15 +273,23 @@ def check_api_mutation_auth():
     if request.method in ("GET", "HEAD", "OPTIONS"):
         return None
 
-    # Trusted browser session (same-origin cookie)?
-    if is_authenticated():
-        return None
-    # Trusted machine caller (internal bearer token)?
+    # Trusted machine caller (internal bearer token) — CSRF-immune (an attacker
+    # cannot read the 0600 token file), so it is checked FIRST and is
+    # origin-independent.
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
         expected = get_or_create_internal_api_token()
         if expected and hmac.compare_digest(auth_header[7:], expected):
             return None
+
+    # Trusted browser session (session cookie). A cookie is NOT proof of
+    # same-origin intent (``SameSite=Lax`` still attaches it on a same-site sibling
+    # origin), so a cookie-authed mutation must ALSO be same-origin — CSRF
+    # defense-in-depth. Fail-closed on a cross-origin/originless cookie request.
+    if is_authenticated():
+        if _is_same_origin_request():
+            return None
+        return jsonify({"error": "cross-origin request refused"}), 403
 
     return jsonify({"error": "authentication required"}), 401
 

--- a/src/genesis/dashboard/webui/js/api.js
+++ b/src/genesis/dashboard/webui/js/api.js
@@ -4,9 +4,13 @@
  * Simplified version of Agent Zero's api.js. Requests are same-origin, so the
  * Flask session cookie rides along automatically; when a dashboard password is
  * set, that cookie authenticates /api mutations (the server gates POST/PUT/
- * DELETE/PATCH). CSRF is covered by the SameSite=Lax session cookie (a cross-site
- * mutation carries no cookie), so no CSRF token exchange is needed here. On a 401
- * (expired/missing session) fetchApi redirects to the login page.
+ * DELETE/PATCH). CSRF: these same-origin fetches carry the browser's
+ * Sec-Fetch-Site: same-origin header, which the server's mutation gate requires
+ * for cookie-authed mutations (SameSite=Lax alone does NOT stop a same-site
+ * sibling origin from riding the cookie), so no CSRF token exchange is needed
+ * here. On a 401 (expired/missing session) fetchApi redirects to the login page;
+ * a 403 (cross-origin cookie mutation refused) is not something these same-origin
+ * requests produce.
  */
 
 // Exponential backoff state for server error recovery.

--- a/tests/test_dashboard/test_api_mutation_gate.py
+++ b/tests/test_dashboard/test_api_mutation_gate.py
@@ -73,7 +73,9 @@ def test_valid_session_cookie_passes(client, monkeypatch):
     _pw(monkeypatch)
     with client.session_transaction() as sess:
         sess["authenticated"] = True
-    assert client.post("/api/genesis/thing").status_code == 200
+    # A real same-origin browser fetch always carries Sec-Fetch-Site: same-origin.
+    resp = client.post("/api/genesis/thing", headers={"Sec-Fetch-Site": "same-origin"})
+    assert resp.status_code == 200
 
 
 def test_valid_internal_bearer_passes(client, monkeypatch):
@@ -140,6 +142,92 @@ def test_apply_gate_idempotent_and_wires(tmp_path, monkeypatch):
     assert hooks.count(auth_mod.check_api_mutation_auth) == 1
     assert app.test_client().post("/api/genesis/thing").status_code == 401  # actually gates
     auth_mod._internal_token_cache = None
+
+
+# ── CSRF: cookie-authed mutations must be same-origin (bearer path is immune) ──
+#
+# SameSite=Lax attaches the session cookie on same-SITE requests (a sibling origin
+# on another port/subdomain of the dashboard host), so a cookie alone is not proof
+# of same-origin intent. These assert the Sec-Fetch-Site (primary) + Origin
+# (fallback) same-origin check, fail-closed when neither signal is present.
+
+
+def _authed(client):
+    with client.session_transaction() as sess:
+        sess["authenticated"] = True
+
+
+def test_cookie_same_origin_sec_fetch_passes(client, monkeypatch):
+    _pw(monkeypatch)
+    _authed(client)
+    resp = client.post("/api/genesis/thing", headers={"Sec-Fetch-Site": "same-origin"})
+    assert resp.status_code == 200
+
+
+def test_cookie_sec_fetch_none_passes(client, monkeypatch):
+    # Sec-Fetch-Site: none = a direct user action (typed URL / bookmark), not a
+    # cross-origin ride — treated as safe per the OWASP fetch-metadata policy.
+    _pw(monkeypatch)
+    _authed(client)
+    resp = client.post("/api/genesis/thing", headers={"Sec-Fetch-Site": "none"})
+    assert resp.status_code == 200
+
+
+def test_cookie_same_site_sec_fetch_blocked(client, monkeypatch):
+    # The core threat: a same-site sibling origin riding the SameSite=Lax cookie.
+    _pw(monkeypatch)
+    _authed(client)
+    resp = client.post("/api/genesis/thing", headers={"Sec-Fetch-Site": "same-site"})
+    assert resp.status_code == 403
+
+
+def test_cookie_cross_site_sec_fetch_blocked(client, monkeypatch):
+    _pw(monkeypatch)
+    _authed(client)
+    resp = client.post("/api/genesis/thing", headers={"Sec-Fetch-Site": "cross-site"})
+    assert resp.status_code == 403
+
+
+def test_cookie_no_headers_fail_closed(client, monkeypatch):
+    # Neither Sec-Fetch-Site nor Origin — a cookie-authed mutation with no
+    # same-origin signal is refused (a real machine caller uses the bearer).
+    _pw(monkeypatch)
+    _authed(client)
+    assert client.post("/api/genesis/thing").status_code == 403
+
+
+def test_cookie_origin_fallback_matches_host(client, monkeypatch):
+    # No Sec-Fetch-Site (old browser) → Origin host must match the request Host.
+    _pw(monkeypatch)
+    _authed(client)
+    resp = client.post("/api/genesis/thing", headers={"Origin": "http://localhost"})
+    assert resp.status_code == 200
+
+
+def test_cookie_origin_fallback_mismatch_blocked(client, monkeypatch):
+    _pw(monkeypatch)
+    _authed(client)
+    resp = client.post("/api/genesis/thing", headers={"Origin": "http://evil.example"})
+    assert resp.status_code == 403
+
+
+def test_bearer_immune_to_cross_origin(client, monkeypatch):
+    # A valid internal bearer is CSRF-immune — origin headers must not block it.
+    _pw(monkeypatch)
+    token = auth_mod.get_or_create_internal_api_token()
+    resp = client.post(
+        "/api/genesis/thing",
+        headers={"Authorization": f"Bearer {token}", "Sec-Fetch-Site": "cross-site"},
+    )
+    assert resp.status_code == 200
+
+
+def test_csrf_not_enforced_when_kill_switch_off(client, monkeypatch):
+    _pw(monkeypatch)
+    monkeypatch.setenv("GENESIS_DASHBOARD_API_AUTH", "off")
+    _authed(client)
+    resp = client.post("/api/genesis/thing", headers={"Sec-Fetch-Site": "cross-site"})
+    assert resp.status_code == 200
 
 
 def test_agent_zero_adapter_applies_mutation_gate(monkeypatch):


### PR DESCRIPTION
## CSRF-harden cookie-authenticated `/api` mutations

### Problem
The app-level `/api` mutation gate (`check_api_mutation_auth`) accepted a session
cookie as proof of authorization when `DASHBOARD_PASSWORD` is set. The session
cookie is `SameSite=Lax`, which still attaches on **same-site** requests — so a
sibling origin (another port/subdomain on the dashboard host) could ride a
logged-in session into any of ~81 state-changing routes, including
`approvals/approve-all`, the `secrets` writer (PUT), `config-files` (PUT/DELETE),
`restart/*`, and `provision/*`. `SameSite=Lax` does not distinguish same-site
siblings, so it is not a CSRF defense here.

### Fix
- The **internal bearer token is now checked first** — it is CSRF-immune (an
  attacker cannot read the `0600` token file), so it stays origin-independent.
- The **cookie path now additionally requires the request to be same-origin**:
  primary signal `Sec-Fetch-Site` (browser-set, unforgeable by page JS; safe iff
  `same-origin`/`none`), falling back to matching the `Origin` (then `Referer`)
  host against the request `Host`. When no same-origin signal is present at all,
  it **fails closed** (403) — a legitimate machine caller uses the bearer, not the
  cookie. This follows the OWASP CSRF Fetch-Metadata guidance (treat absent
  `Sec-Fetch-*` as unknown; do not fail open).
- The `GENESIS_DASHBOARD_API_AUTH=off` kill switch still disables the whole gate.
- Fixes the stale `api.js` comment that asserted `SameSite=Lax` alone covered CSRF.

Same-origin dashboard fetches already send `Sec-Fetch-Site: same-origin`, so the
web UI needs no changes. Read-only calls, the `/v1` voice API, and a co-hosting
framework's own `/api/*` routes are untouched.

### Tests
Extends `tests/test_dashboard/test_api_mutation_gate.py` with the CSRF matrix
(same-origin/`none` pass; same-site/cross-site/no-header fail-closed; Origin
fallback match vs mismatch; bearer immune to cross-origin; kill-switch off).
Written test-first (the blocked cases fail against the pre-change code, then pass).

### Deploy
Runtime dashboard code only — `git pull` + server restart. No host/guardian paths.

### Review
Self-review + one `genesis-security-reviewer` pass: no blocking or should-fix
findings. Confirmed `Sec-Fetch-Site` is a Forbidden header (unforgeable by page
JS), the fail-closed branches have no fail-open hole, the bearer-first reorder is
behavior-preserving, and the host TCP passthrough does not strip/rewrite the
headers the check relies on. One optional case-insensitivity hardening was applied;
one scheme-comparison suggestion was consciously declined (would risk false-closed
403s on TLS-terminating installs without forwarded-proto trust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
