### PR TITLE
fix(db): stop d0011 embed migration screaming ERROR on cold boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **No more spurious embedding error on restart.** A one-time procedure-embedding
+  repair runs shortly after boot; on some installs it fired before the network was
+  warm and logged a scary "all embedding backends failed" error with a full
+  traceback on every restart, even though it harmlessly retried on the next boot.
+  The repair now waits for boot I/O to settle and retries a cold-start blip before
+  giving up, and a not-yet-ready dependency is logged as a quiet, tracebackless
+  "will retry next boot" notice rather than an error. Operators can tune or disable
+  the wait with `GENESIS_DATA_MIGRATION_BOOT_DELAY_S` (seconds; `0` to disable).
+
 - **Re-embedding a memory no longer downgrades its recall ranking.** When a
   memory's vector was rebuilt (after a vector-store outage, or by the nightly
   repair job), its priority class was silently recomputed from the text alone —

--- a/src/genesis/db/data_migrations/_util.py
+++ b/src/genesis/db/data_migrations/_util.py
@@ -33,6 +33,20 @@ from genesis.db.connection import MIGRATION_BUSY_TIMEOUT_MS
 
 logger = logging.getLogger(__name__)
 
+
+class MigrationDependencyUnavailable(RuntimeError):
+    """A data migration's external dependency (embedding provider, Qdrant, …) was
+    not reachable, so the migration could not complete — but this is EXPECTED and
+    transient, typically a cold boot before network egress / a local service is
+    warm. The runner records it as failed (so it replays on the next boot, exactly
+    like any other failure) but logs it at WARNING WITHOUT a traceback — a genuine
+    migration bug raises some OTHER exception and keeps the ERROR+traceback.
+
+    Subclasses ``RuntimeError`` so existing ``except RuntimeError`` dependency
+    guards (e.g. d0011 ``verify()``) keep catching it unchanged.
+    """
+
+
 # 100 keeps each committed batch comfortably under the server's 5s busy_timeout
 # even for a fan-out migration (e.g. d0006's ~7 DELETEs/item ⇒ ~700 statements
 # per batch, sub-second), while amortizing commit/fsync overhead across items.

--- a/src/genesis/db/data_migrations/d0011_reembed_stale_procedure_embeddings.py
+++ b/src/genesis/db/data_migrations/d0011_reembed_stale_procedure_embeddings.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 
+from genesis.db.data_migrations._util import MigrationDependencyUnavailable
 from genesis.db.data_migrations.stale_embedding_repair import (
     count_stale_procedure_embeddings,
     reembed_stale_procedure_embeddings,
@@ -49,13 +50,18 @@ def verify() -> bool:
     embed of its current principle.
 
     Reached only after a successful ``migrate()`` (same run), so the embedder is
-    normally still up. If it went away in between, treat as not-done (retry next
-    boot) rather than raising."""
+    normally still up. If it went cold in between, let the dependency sentinel
+    PROPAGATE so the runner's WARN-and-defer path handles it (marks failed →
+    idempotent replay next boot) — NOT the generic verify-failed ERROR path, which
+    would reintroduce the spurious cold-boot ERROR this migration's fix removes."""
     db = sqlite3.connect(f"file:{genesis_db_path()}?mode=ro", uri=True)
     try:
         return count_stale_procedure_embeddings(db) == 0
+    except MigrationDependencyUnavailable:
+        raise  # runner classifies this as "dependency not ready" → WARN, retry next boot
     except RuntimeError:
-        logger.warning("d0011 verify: embedder unavailable — deferring to next boot")
+        # Any OTHER RuntimeError: keep the conservative not-done behavior.
+        logger.warning("d0011 verify: unexpected embedder error — deferring to next boot")
         return False
     finally:
         db.close()

--- a/src/genesis/db/data_migrations/runner.py
+++ b/src/genesis/db/data_migrations/runner.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
+import math
+import os
 import re
 import sqlite3
 from collections.abc import Awaitable, Callable
@@ -21,6 +23,7 @@ import aiosqlite
 
 from genesis.db._migration_discovery import discover_numbered_modules
 from genesis.db.crud import data_migrations as crud
+from genesis.db.data_migrations._util import MigrationDependencyUnavailable
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +40,39 @@ _DATA_MIGRATION_PATTERN = re.compile(r"^(d\d{4})_\w+\.py$")
 # defense-in-depth for the bookkeeping itself.
 _LEDGER_LOCK_RETRIES = 5
 _LEDGER_RETRY_DELAY_S = 0.5
+
+# Boot-settle delay before running data migrations. They kick as a background
+# task very early in boot and some make live network calls (e.g. d0011's embedder,
+# d0008's Qdrant client) that fail if egress / a local service isn't warm yet —
+# an EXPECTED cold-boot transient that logged a scary ERROR+traceback every restart.
+# Waiting lets boot IO quiet down before the first call; mirrors the same pattern in
+# runtime/init/infra_profile (which sleeps before its first network refresh). These
+# migrations are non-urgent idempotent backfills, so a one-time delay costs nothing.
+# Env-tunable (0 disables — used by tests and available to operators).
+_DEFAULT_BOOT_SETTLE_DELAY_S = 120.0
+
+
+def _boot_settle_delay_s() -> float:
+    """Seconds to wait after boot before running data migrations (see above).
+
+    Reads ``GENESIS_DATA_MIGRATION_BOOT_DELAY_S``; falls back to the default on an
+    unset or unparseable value. Clamped to ``>= 0``.
+    """
+    raw = os.environ.get("GENESIS_DATA_MIGRATION_BOOT_DELAY_S")
+    if raw is None:
+        return _DEFAULT_BOOT_SETTLE_DELAY_S
+    try:
+        val = float(raw)
+        if not math.isfinite(val):  # reject inf/nan: sleep(inf) would hang migrations forever
+            raise ValueError("non-finite")
+        return max(0.0, val)
+    except ValueError:
+        logger.warning(
+            "Invalid GENESIS_DATA_MIGRATION_BOOT_DELAY_S=%r; using default %.0fs",
+            raw,
+            _DEFAULT_BOOT_SETTLE_DELAY_S,
+        )
+        return _DEFAULT_BOOT_SETTLE_DELAY_S
 
 
 async def _ledger_write(make_coro: Callable[[], Awaitable[None]], *, what: str) -> bool:
@@ -163,6 +199,24 @@ class DataMigrationRunner:
                 }
             logger.info("Data migration %s completed: %s", name, summary_str)
             return {"id": mid, "name": name, "success": True, "summary": summary}
+        except MigrationDependencyUnavailable as exc:
+            # EXPECTED transient (cold boot: a dependency — embedder egress, Qdrant —
+            # wasn't warm yet). Same retry-next-boot handling as any failure (mark
+            # failed so reset_running_to_pending replays it), but WARN without a
+            # traceback: this is not a bug, and screaming ERROR+traceback on every
+            # restart was the whole complaint. A genuine bug raises a DIFFERENT
+            # exception and still hits the ERROR+traceback branch below.
+            err = repr(exc)  # bind before the closure (exc is except-scoped, del'd on exit)
+            await _ledger_write(
+                lambda: crud.mark_failed(self._db, mid, error=err),
+                what="mark_failed",
+            )
+            logger.warning(
+                "Data migration %s deferred: dependency not ready (%s) — will retry next boot",
+                name,
+                exc,
+            )
+            return {"id": mid, "name": name, "success": False, "error": str(exc), "deferred": True}
         except Exception as exc:  # noqa: BLE001 — record + continue; never abort the batch
             err = repr(exc)  # bind before the closure (exc is except-scoped, del'd on exit)
             await _ledger_write(
@@ -187,7 +241,15 @@ def _module_requires_operator(path: Path) -> bool:
 
 
 async def run_data_migrations(db: aiosqlite.Connection) -> list[dict]:
-    """Module entry point for the post-boot kick. Never raises."""
+    """Module entry point for the post-boot kick. Never raises.
+
+    Waits a boot-settle delay first (see ``_boot_settle_delay_s``) so cold-boot
+    network/service dependencies are warm before any migration's first call.
+    """
+    delay = _boot_settle_delay_s()
+    if delay > 0:
+        logger.debug("Data migrations: waiting %.0fs for boot IO to settle", delay)
+        await asyncio.sleep(delay)
     try:
         return await DataMigrationRunner(db).run_pending()
     except Exception:

--- a/src/genesis/db/data_migrations/stale_embedding_repair.py
+++ b/src/genesis/db/data_migrations/stale_embedding_repair.py
@@ -35,8 +35,12 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
+import time
 
-from genesis.db.data_migrations._util import commit_in_batches
+from genesis.db.data_migrations._util import (
+    MigrationDependencyUnavailable,
+    commit_in_batches,
+)
 from genesis.env import genesis_db_path
 from genesis.learning.procedural.embedding import (
     cosine_similarity,
@@ -51,6 +55,16 @@ logger = logging.getLogger(__name__)
 # (older) principle => stale. Well clear of the ~0.85 same-procedure bar and of
 # genuine distinct-lesson cosines, so it cleanly separates fresh from stale.
 FRESH_MATCH_THRESHOLD = 0.99
+
+# Bounded retry for a COLD-BOOT embedder blip (DNS/egress/TLS not warm yet). This
+# complements the data-migration runner's boot-settle delay: the delay moves the
+# first attempt past warmup, and these retries absorb any residual jitter around
+# it. Sync (this runs in the runner's worker thread via asyncio.to_thread), so the
+# sleeps block only this migration's thread, never an event loop. Exhausting them
+# raises MigrationDependencyUnavailable so the runner defers quietly (retry next
+# boot) instead of logging a scary ERROR+traceback for an expected transient.
+_EMBED_ATTEMPTS = 3
+_EMBED_RETRY_BASE_DELAY_S = 2.0  # exponential backoff between attempts: 2s, 4s
 
 
 def _candidates(conn: sqlite3.Connection) -> list[tuple[str, str, bytes | None]]:
@@ -91,8 +105,16 @@ def _embed_texts(texts: list[str], provider) -> list[list[float]]:
     ``get_embedding_provider()`` singleton, whose httpx connection pools are bound
     to the server's main loop: driving it from this throwaway worker-thread loop
     (or leaving a pooled connection bound to it) would break the migration or a
-    later live embed (Codex P2 on #1286). Fail-CLOSED: an unavailable embedder
-    surfaces as ``RuntimeError``.
+    later live embed (Codex P2 on #1286). A fresh provider is built on EACH retry
+    attempt (a new loop per ``asyncio.run``), so a cold-boot connection failure
+    doesn't poison later attempts. Fail-CLOSED after the bounded retry: a
+    persistently unavailable embedder surfaces as ``MigrationDependencyUnavailable``
+    (a ``RuntimeError`` subclass).
+
+    ``provider`` is INJECTED only in tests (with loop-agnostic fakes): an injected
+    provider is reused as-is across every retry's ``asyncio.run`` loop, so a real
+    httpx-backed provider must NEVER be injected here — the production path passes
+    ``None`` so each attempt builds and closes its own loop-bound provider.
     """
     if not texts:
         return []
@@ -109,10 +131,26 @@ def _embed_texts(texts: list[str], provider) -> list[list[float]]:
             if owns:
                 await _aclose_provider(prov)
 
-    try:
-        return asyncio.run(_run())
-    except EmbeddingUnavailableError as e:
-        raise RuntimeError(f"embedder unavailable; cannot re-embed stale procedures: {e}") from e
+    last_exc: EmbeddingUnavailableError | None = None
+    for attempt in range(1, _EMBED_ATTEMPTS + 1):
+        try:
+            return asyncio.run(_run())
+        except EmbeddingUnavailableError as e:
+            last_exc = e
+            if attempt < _EMBED_ATTEMPTS:
+                backoff = _EMBED_RETRY_BASE_DELAY_S * (2 ** (attempt - 1))
+                logger.warning(
+                    "reembed_stale: embedder unavailable (attempt %d/%d), retrying in %.0fs (%s)",
+                    attempt,
+                    _EMBED_ATTEMPTS,
+                    backoff,
+                    e,
+                )
+                time.sleep(backoff)
+    raise MigrationDependencyUnavailable(
+        f"embedder unavailable after {_EMBED_ATTEMPTS} attempts; "
+        f"cannot re-embed stale procedures: {last_exc}"
+    ) from last_exc
 
 
 def _classify(candidates, provider) -> tuple[list[tuple[str, bytes, bytes | None]], list[str]]:
@@ -155,8 +193,9 @@ def count_stale_procedure_embeddings(conn: sqlite3.Connection, provider=None) ->
 
     Used by the migration's ``verify()``. Unresolvable (bad-dimension) rows are
     counted as stale so ``verify()`` does not pass while they remain unverified.
-    Raises ``RuntimeError`` if no embedder is configured — the caller cannot
-    confirm freshness and should treat the migration as not-yet-done.
+    Raises ``MigrationDependencyUnavailable`` (a ``RuntimeError`` subclass) if the
+    embedder stays unavailable across the bounded retry — the caller cannot confirm
+    freshness and should treat the migration as not-yet-done.
     """
     candidates = _candidates(conn)
     if not candidates:
@@ -172,8 +211,9 @@ def reembed_stale_procedure_embeddings(
 
     Sync; opens its own read + write sqlite connections. Clean no-op (no provider
     needed) when there are no ``version > 1`` rows. Otherwise fail-CLOSED: raises
-    ``RuntimeError`` if the embedder is unavailable, so a one-time heal is retried
-    next boot rather than recording success with rows left stale.
+    ``MigrationDependencyUnavailable`` (a ``RuntimeError`` subclass) if the embedder
+    stays unavailable across the bounded retry, so a one-time heal is retried next
+    boot rather than recording success with rows left stale.
 
     Concurrency-safe against a live refine: the write is a compare-and-swap on the
     T0 stored embedding, so if a genuine refine lands on a targeted row between the

--- a/tests/test_db/test_data_migrations.py
+++ b/tests/test_db/test_data_migrations.py
@@ -288,6 +288,28 @@ async def test_runner_dependency_unavailable_warns_not_errors(db, monkeypatch, c
     assert not any(r.exc_info for r in recs)  # no traceback attached
 
 
+async def test_runner_verify_dependency_unavailable_warns_not_errors(db, monkeypatch, caplog):
+    # End-to-end (Codex #1296 P2): migrate() succeeds but verify() raises the
+    # sentinel (embedder went cold in between) → runner WARN-and-defers rather than
+    # taking the verify-failed ERROR path, so no spurious boot ERROR.
+    import logging
+
+    from genesis.db.data_migrations._util import MigrationDependencyUnavailable
+
+    def verify():
+        raise MigrationDependencyUnavailable("cold during verify")
+
+    _patch_migrations(monkeypatch, {"d0001_x": _fake_module(lambda: {"ok": 1}, verify)})
+    with caplog.at_level(logging.DEBUG, logger="genesis.db.data_migrations.runner"):
+        outcomes = await DataMigrationRunner(db).run_pending()
+
+    assert outcomes[0].get("deferred") is True
+    recs = [r for r in caplog.records if r.name == "genesis.db.data_migrations.runner"]
+    assert any(r.levelno == logging.WARNING and "deferred" in r.getMessage() for r in recs)
+    assert not any(r.levelno >= logging.ERROR for r in recs)  # no verify-failed ERROR
+    assert await crud.get_status(db, "d0001") == "failed"  # idempotent replay next boot
+
+
 async def test_runner_genuine_exception_still_logs_error_with_traceback(db, monkeypatch, caplog):
     # A NON-sentinel exception (a real migration bug) must still hit ERROR+traceback —
     # the WARN demotion is scoped to the dependency-unavailable sentinel only.

--- a/tests/test_db/test_data_migrations.py
+++ b/tests/test_db/test_data_migrations.py
@@ -26,6 +26,14 @@ async def db():
     await conn.close()
 
 
+@pytest.fixture(autouse=True)
+def _no_boot_settle_delay(monkeypatch):
+    """Disable the data-migration boot-settle delay by default so tests that call
+    run_data_migrations() don't wait the real 120s. The delay's own tests override
+    this and patch asyncio.sleep."""
+    monkeypatch.setenv("GENESIS_DATA_MIGRATION_BOOT_DELAY_S", "0")
+
+
 async def test_migration_0060_idempotent_after_create_all_tables():
     """The REAL boot path: init_db runs create_all_tables (which creates
     data_migrations from _tables.py) BEFORE the migration runner. Migration
@@ -254,6 +262,85 @@ def test_no_duplicate_migration_prefixes_in_tree():
             f"duplicate {label} prefix(es) {dupes} in {directory} — "
             "rename the newer file to the next free prefix"
         )
+
+
+async def test_runner_dependency_unavailable_warns_not_errors(db, monkeypatch, caplog):
+    # A cold-boot transient (embedder/Qdrant not warm) raises the sentinel: the
+    # runner defers it (marked failed -> replays next boot) and logs at WARNING
+    # with NO traceback — not the scary ERROR+traceback reserved for real bugs.
+    import logging
+
+    from genesis.db.data_migrations._util import MigrationDependencyUnavailable
+
+    def cold():
+        raise MigrationDependencyUnavailable("embedder unavailable after 3 attempts")
+
+    _patch_migrations(monkeypatch, {"d0001_x": _fake_module(cold, lambda: True)})
+    with caplog.at_level(logging.DEBUG, logger="genesis.db.data_migrations.runner"):
+        outcomes = await DataMigrationRunner(db).run_pending()
+
+    assert outcomes[0]["success"] is False
+    assert outcomes[0].get("deferred") is True
+    assert await crud.get_status(db, "d0001") == "failed"  # retryable -> replays next boot
+    recs = [r for r in caplog.records if r.name == "genesis.db.data_migrations.runner"]
+    assert any(r.levelno == logging.WARNING and "deferred" in r.getMessage() for r in recs)
+    assert not any(r.levelno >= logging.ERROR for r in recs)  # no ERROR
+    assert not any(r.exc_info for r in recs)  # no traceback attached
+
+
+async def test_runner_genuine_exception_still_logs_error_with_traceback(db, monkeypatch, caplog):
+    # A NON-sentinel exception (a real migration bug) must still hit ERROR+traceback —
+    # the WARN demotion is scoped to the dependency-unavailable sentinel only.
+    import logging
+
+    def boom():
+        raise RuntimeError("a real migration bug")
+
+    _patch_migrations(monkeypatch, {"d0001_x": _fake_module(boom, lambda: True)})
+    with caplog.at_level(logging.WARNING, logger="genesis.db.data_migrations.runner"):
+        await DataMigrationRunner(db).run_pending()
+
+    recs = [r for r in caplog.records if r.name == "genesis.db.data_migrations.runner"]
+    assert any(r.levelno == logging.ERROR and r.exc_info for r in recs)
+    assert await crud.get_status(db, "d0001") == "failed"
+
+
+async def test_run_data_migrations_waits_boot_settle_delay(db, monkeypatch):
+    # The entry point sleeps the configured boot-settle delay before running.
+    slept = {"secs": None}
+
+    async def fake_sleep(secs):
+        slept["secs"] = secs
+
+    monkeypatch.setattr(runner_mod.asyncio, "sleep", fake_sleep)
+    monkeypatch.setenv("GENESIS_DATA_MIGRATION_BOOT_DELAY_S", "7")  # overrides autouse 0
+    monkeypatch.setattr(DataMigrationRunner, "_discover", lambda self: [])
+    await runner_mod.run_data_migrations(db)
+    assert slept["secs"] == 7.0
+
+
+def test_boot_delay_rejects_non_finite_and_garbage(monkeypatch):
+    # inf would make asyncio.sleep(inf) hang migrations forever; nan / garbage are
+    # also nonsense — all fall back to the default rather than a hang or crash.
+    for bad in ("inf", "-inf", "nan", "not-a-number", ""):
+        monkeypatch.setenv("GENESIS_DATA_MIGRATION_BOOT_DELAY_S", bad)
+        assert runner_mod._boot_settle_delay_s() == runner_mod._DEFAULT_BOOT_SETTLE_DELAY_S
+    # A negative finite value clamps to 0 (disabled), not the default.
+    monkeypatch.setenv("GENESIS_DATA_MIGRATION_BOOT_DELAY_S", "-5")
+    assert runner_mod._boot_settle_delay_s() == 0.0
+
+
+async def test_run_data_migrations_no_delay_when_zero(db, monkeypatch):
+    slept = {"called": False}
+
+    async def fake_sleep(secs):
+        slept["called"] = True
+
+    monkeypatch.setattr(runner_mod.asyncio, "sleep", fake_sleep)
+    # autouse fixture already set the env to "0"
+    monkeypatch.setattr(DataMigrationRunner, "_discover", lambda self: [])
+    await runner_mod.run_data_migrations(db)
+    assert slept["called"] is False
 
 
 async def test_runner_redispatches_orphaned_running(db, monkeypatch):

--- a/tests/test_db/test_stale_embedding_repair.py
+++ b/tests/test_db/test_stale_embedding_repair.py
@@ -238,6 +238,25 @@ def test_migration_migrate_then_verify(tmp_path, monkeypatch):
     assert _emb_of(path, "A") == pack_embedding(_fake_vec("A-current"))
 
 
+def test_verify_propagates_dependency_unavailable(tmp_path, monkeypatch):
+    # Regression (Codex #1296 P2): a cold embedder DURING verify() must let the
+    # sentinel PROPAGATE (so the runner defers with a WARN), NOT be swallowed into
+    # a False that triggers the generic verify-failed ERROR path.
+    from genesis.db.data_migrations import d0011_reembed_stale_procedure_embeddings as mig
+    from genesis.db.data_migrations._util import MigrationDependencyUnavailable
+
+    monkeypatch.setattr(sr, "_EMBED_RETRY_BASE_DELAY_S", 0.0)
+    monkeypatch.setattr(sr, "_EMBED_ATTEMPTS", 1)
+    path = _make_db(tmp_path)
+    _insert(path, "A", "A-current", version=2, emb_text="A-OLD")  # a candidate → embedder needed
+    monkeypatch.setattr(mig, "genesis_db_path", lambda: path)
+    monkeypatch.setattr(
+        "genesis.memory.embeddings.EmbeddingProvider", lambda *a, **k: _UnavailableProvider()
+    )
+    with pytest.raises(MigrationDependencyUnavailable):
+        mig.verify()
+
+
 class _ConcurrentRefineProvider:
     """Simulates a genuine refine landing on the row DURING the embed phase —
     between the migration's candidate read (T0) and its write."""

--- a/tests/test_db/test_stale_embedding_repair.py
+++ b/tests/test_db/test_stale_embedding_repair.py
@@ -159,6 +159,7 @@ class _UnavailableProvider:
 def test_fail_closed_when_embedder_unavailable(tmp_path, monkeypatch):
     path = _make_db(tmp_path)
     _insert(path, "A", "A-current", version=2, emb_text="A-OLD")  # a real candidate
+    monkeypatch.setattr(sr, "_EMBED_RETRY_BASE_DELAY_S", 0.0)  # don't sleep between retries
     # No injected provider -> the migration constructs a local EmbeddingProvider;
     # simulate the backend being down so embed() raises.
     monkeypatch.setattr(
@@ -168,6 +169,54 @@ def test_fail_closed_when_embedder_unavailable(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match="embedder unavailable"):
         sr.reembed_stale_procedure_embeddings(path, provider=None)
+    assert _emb_of(path, "A") == pack_embedding(_fake_vec("A-OLD"))  # no half-heal
+
+
+class _FlakyProvider:
+    """EmbeddingUnavailableError for the first ``fail_times`` embed calls, then
+    succeeds — a cold-boot network blip (DNS/egress not warm) that clears on retry."""
+
+    def __init__(self, fail_times: int):
+        self.fail_times = fail_times
+        self.attempts = 0
+
+    async def embed(self, text: str) -> list[float]:
+        from genesis.memory.embeddings import EmbeddingUnavailableError
+
+        self.attempts += 1
+        if self.attempts <= self.fail_times:
+            raise EmbeddingUnavailableError("cold boot: backends not warm yet")
+        return _fake_vec(text)
+
+
+def test_embed_retries_then_succeeds_on_transient(tmp_path, monkeypatch):
+    # A transient cold-boot embedder failure must NOT fail the one-time heal: the
+    # bounded retry recovers once the backend warms.
+    monkeypatch.setattr(sr, "_EMBED_RETRY_BASE_DELAY_S", 0.0)  # no real sleeps
+    path = _make_db(tmp_path)
+    _insert(path, "A", "A-current", version=2, emb_text="A-OLD")
+    provider = _FlakyProvider(fail_times=2)  # fails twice, third attempt succeeds
+
+    result = sr.reembed_stale_procedure_embeddings(path, provider=provider)
+
+    assert result == {"targeted": 1, "stale": 1, "unresolvable": 0, "reembedded": 1}
+    assert provider.attempts == 3  # two failures + one success
+    assert _emb_of(path, "A") == pack_embedding(_fake_vec("A-current"))  # healed
+
+
+def test_embed_raises_dependency_unavailable_after_exhausting_retries(tmp_path, monkeypatch):
+    from genesis.db.data_migrations._util import MigrationDependencyUnavailable
+
+    monkeypatch.setattr(sr, "_EMBED_RETRY_BASE_DELAY_S", 0.0)
+    monkeypatch.setattr(sr, "_EMBED_ATTEMPTS", 2)
+    path = _make_db(tmp_path)
+    _insert(path, "A", "A-current", version=2, emb_text="A-OLD")
+
+    # A persistently-down embedder raises the sentinel (which is a RuntimeError
+    # subclass, so existing `except RuntimeError` dependency-guards still catch it).
+    with pytest.raises(MigrationDependencyUnavailable):
+        sr.reembed_stale_procedure_embeddings(path, provider=_UnavailableProvider())
+    assert issubclass(MigrationDependencyUnavailable, RuntimeError)
     assert _emb_of(path, "A") == pack_embedding(_fake_vec("A-OLD"))  # no half-heal
 
 


### PR DESCRIPTION
## Stop the d0011 embedding migration from logging a boot-time ERROR every restart

### Problem
The `d0011_reembed_stale_procedure_embeddings` data migration runs post-boot as a
fire-and-forget `tracked_task`, but makes a live embedding HTTP call ~33s into boot
— before network egress is warm. It fails with `EmbeddingUnavailableError`, and the
data-migration runner logs an `ERROR` + full traceback on **every restart**, even
though the migration is idempotent and harmlessly replays on the next boot. Root
cause is a network cold-start race (the embedding key is present at rest, not
late-arriving), not a real fault.

### Fix (three parts)
1. **Bounded retry** (3 attempts, exponential backoff) around the embed call in
   `stale_embedding_repair._embed_texts`, so a cold-start blip self-heals. A fresh
   provider is built per attempt (new `asyncio.run` loop), so a failed attempt
   can't poison a later one.
2. **Boot-settle delay** before the data-migration runner runs
   (`GENESIS_DATA_MIGRATION_BOOT_DELAY_S`, default 120s), mirroring the existing
   `runtime/init/infra_profile` pattern — moves the first attempt past warmup. The
   delay lives inside the fire-and-forget task and never blocks startup;
   non-finite/garbage values fall back to the default.
3. **A `MigrationDependencyUnavailable(RuntimeError)` sentinel**: the runner logs a
   not-yet-ready dependency at `WARNING` **without a traceback** (expected,
   replays next boot), while a genuine migration bug still raises a different
   exception and keeps the `ERROR`+traceback. Subclassing `RuntimeError` keeps
   existing `except RuntimeError` dependency guards (d0011 `verify()`) working
   unchanged.

Fail-closed semantics are preserved throughout: an unavailable embedder still
marks the migration failed so it replays next boot — it just does so quietly.

### Tests
`test_stale_embedding_repair.py`: retry-recovers-on-transient, sentinel-after-
exhaustion (Verify-RED first). `test_data_migrations.py`: sentinel → WARN (no
traceback) vs genuine exception → ERROR+traceback; boot-delay awaited vs skipped;
non-finite/garbage env falls back safely. An autouse fixture zeroes the delay so
the suite never waits the real 120s.

### Deploy
Runtime code — `git pull` + server restart. The effect (no boot ERROR) is visible
on the next restart after deploy.

### Review
Self-review + one `genesis-architect` pass: no blocking or should-fix findings.
Confirmed the delay can't block boot (fire-and-forget, sole caller
`runtime/_core.py:554`), the sentinel exception ordering is correct, and the retry
has no resource-leak/cross-loop hazard. Four NOTE-level items were addressed
(inf/nan parse guard, docstring accuracy, injected-provider caveat) or consciously
accepted (bounded recurring cost on a permanently-misconfigured embedder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
