### PR TITLE
feat(memory): attribute cancelled recalls to sub-stage + executor pressure (WS-1 PR-2c)

### DIFF
--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -176,6 +176,11 @@ class StandaloneAdapter:
         timestamp-correlatable with awareness-tick / dispatch / bundle log lines,
         naming what starves the recall coroutine behind the route 503s.
 
+        The WARN also carries ``executor=`` — the default-executor pending depth
+        (PR-2c). A lag episode with a deep executor queue means ``to_thread`` work
+        (Qdrant recall, awareness-tick git) is saturating the thread pool, which
+        loop drift alone cannot distinguish from pure loop starvation.
+
         Debounced per stall EPISODE: one WARNING when drift first crosses the
         threshold, one INFO with the peak drift when it clears. A sustained
         multi-minute stall (the worst case, and exactly when log noise competes
@@ -186,6 +191,8 @@ class StandaloneAdapter:
         ``GENESIS_LOOP_LAG_SAMPLER`` (0/false/off) — disables the sampler at
         startup. Best-effort: any error ends the sampler without touching serve.
         """
+        from genesis.util.loop_diag import default_executor_pending
+
         interval = 0.5
         try:
             threshold_ms = float(os.environ.get("GENESIS_LOOP_LAG_WARN_MS", "250"))
@@ -207,10 +214,11 @@ class StandaloneAdapter:
                         lagging = True
                         logger.warning(
                             "event-loop lag %.0fms (interval %.0fms) — background "
-                            "work is starving the loop; recall 503s correlate here "
-                            "(further lag suppressed until it clears)",
+                            "work is starving the loop; recall 503s correlate here; "
+                            "executor=%s (further lag suppressed until it clears)",
                             drift_ms,
                             interval * 1000,
+                            default_executor_pending(),
                         )
                 elif lagging:
                     # Episode cleared — report the peak so the stall's severity is

--- a/src/genesis/memory/proactive.py
+++ b/src/genesis/memory/proactive.py
@@ -35,8 +35,42 @@ from typing import Any
 
 from genesis.memory import graph_expansion
 from genesis.memory.intent import classify_intent, classify_stance
+from genesis.util.loop_diag import default_executor_pending
 
 logger = logging.getLogger(__name__)
+
+# Recall sub-stage timers written incrementally into the engine ``stats`` dict by
+# ``retrieval._proactive_impl`` as each stage completes (vector/FTS/expand/…). Folded
+# into ``timings_ms`` on BOTH the success path and the cancellation path, so a 503 that
+# dies mid-recall still names the last stage that finished (the stage AFTER the last
+# present key is where the coroutine was starved). ``rerank_ms`` is folded separately
+# because its ``timings`` key drops the ``_ms`` suffix like the rest but is set on its
+# own stage. Keep in sync with the writers in ``retrieval.py``.
+_RECALL_SUBSTAGE_KEYS: tuple[str, ...] = (
+    "vector_ms",
+    "event_ms",
+    "expand_ms",
+    "fts_ms",
+    "expired_ms",
+    "activation_ms",
+    "breadcrumbs_ms",
+    "assembly_ms",
+)
+
+
+def _fold_engine_substages(timings: dict[str, Any], engine_stats: dict[str, Any]) -> None:
+    """Copy whatever recall sub-stage timers have been populated into ``timings``.
+
+    ``engine_stats`` is mutated in place by the engine as each stage finishes, so on a
+    mid-recall cancellation the completed stages are already present — this surfaces
+    them (minus the ``_ms`` suffix) so the 503 log attributes the stall to a stage.
+    """
+    for key in _RECALL_SUBSTAGE_KEYS:
+        if key in engine_stats:
+            timings[key.removesuffix("_ms")] = engine_stats[key]
+    if "rerank_ms" in engine_stats:
+        timings["rerank"] = engine_stats["rerank_ms"]
+
 
 # ---------------------------------------------------------------------------
 # Config — intent-aware budget + rerank posture, live-read from
@@ -588,6 +622,11 @@ async def proactive_context(
     # best-effort `except Exception` blocks never swallow it.
     timings: dict[str, Any] = {}
     phase = "embed"
+    # Monotonic clock at the start of the in-flight `phase`, so on cancellation we can
+    # report how long the coroutine was stuck in the phase that got cancelled
+    # (`phase_wall_ms`) — the recall phase completes in ~0.5s but a 503 burns ~4s in it,
+    # and that gap is the whole question PR-2c answers. Updated at each phase transition.
+    phase_started_at = time.monotonic()
     vector: list[float] | None = None
     engine_stats: dict[str, Any] = {}
     try:
@@ -619,6 +658,7 @@ async def proactive_context(
         kb_slots = max(1, budget // 3)
         phase = "recall"
         t_recall = time.monotonic()
+        phase_started_at = t_recall
         dicts = await _core._proactive_impl(
             prompt,
             limit=budget,
@@ -637,6 +677,7 @@ async def proactive_context(
 
         phase = "enrich"
         t_enrich = time.monotonic()
+        phase_started_at = t_enrich
         # PR-4b (ac27b693): route these post-recall reads off the shared write
         # lock onto recall's read-only pool via the same _ro_read seam recall's
         # own reads use. Both are pure indexed SELECTs (memory_metadata PK /
@@ -661,6 +702,7 @@ async def proactive_context(
 
         phase = "procedure"
         t_proc = time.monotonic()
+        phase_started_at = t_proc
         procedure = None
         if vector:
             procedure = await _surface_procedure(db, vector)
@@ -707,10 +749,23 @@ async def proactive_context(
         # timings gathered so far — the signal the 503 previously discarded —
         # rather than assert a cause, then re-raise so the task completes as
         # cancelled.
+        #
+        # PR-2c: the ~4s that a cancelled recall burns is the open question, so pull in
+        # three signals the bare phase name lacked. (1) Fold the recall sub-stage timers
+        # the engine already wrote into `engine_stats` before the cancel — the stage
+        # after the last present key is where it starved (an EMPTY fold ⇒ died in the
+        # first stage, the Qdrant `to_thread` vector search). (2) `phase_wall_ms` — how
+        # long we sat in the cancelled phase, so recall's ~0.5s success cost vs the ~4s
+        # cancel is explicit. (3) The default-executor pending depth: a deep queue with
+        # low loop-lag means `to_thread` (Qdrant/git) saturation, NOT loop starvation —
+        # the alternative the lag sampler can't see. All best-effort, log-only.
+        _fold_engine_substages(timings, engine_stats)
+        timings["phase_wall_ms"] = round((time.monotonic() - phase_started_at) * 1000, 1)
         timings["cancelled_after_ms"] = round((time.monotonic() - t0) * 1000, 1)
         logger.warning(
-            "proactive recall CANCELLED at phase=%s; partial timings=%s",
+            "proactive recall CANCELLED at phase=%s; executor=%s; partial timings=%s",
             phase,
+            default_executor_pending(),
             timings,
         )
         raise
@@ -720,26 +775,14 @@ async def proactive_context(
 
     timings["total"] = round((time.monotonic() - t0) * 1000, 1)
     total_ms = timings["total"]
-    if "rerank_ms" in engine_stats:
-        timings["rerank"] = engine_stats["rerank_ms"]
     # Sub-stage breakdown of the `recall` bucket (ac27b693): surfaced so a slow
     # recall can be attributed to a specific stage from the journal alone,
     # instead of guessed. PR-4 added the read-stage timers (event/expired/
     # breadcrumbs) + assembly so the previously-unaccounted recall residual
     # (read-lock contention) is now attributable. Present only when recall
-    # populated them.
-    for _k in (
-        "vector_ms",
-        "event_ms",
-        "expand_ms",
-        "fts_ms",
-        "expired_ms",
-        "activation_ms",
-        "breadcrumbs_ms",
-        "assembly_ms",
-    ):
-        if _k in engine_stats:
-            timings[_k.removesuffix("_ms")] = engine_stats[_k]
+    # populated them. Same fold the cancellation path uses (PR-2c) so both the
+    # success and 503 logs carry an identical sub-stage vocabulary.
+    _fold_engine_substages(timings, engine_stats)
     if total_ms > _SLOW_RECALL_LOG_MS:
         # One INFO line per slow call so a latency regression is diagnosable
         # from the journal alone (the 503 path discards timings_ms entirely —

--- a/src/genesis/util/loop_diag.py
+++ b/src/genesis/util/loop_diag.py
@@ -1,0 +1,48 @@
+"""Best-effort event-loop default-executor diagnostics.
+
+``asyncio.to_thread()`` dispatches work onto the running loop's default
+``ThreadPoolExecutor``. When background ``to_thread`` work (awareness-tick git
+ops, Qdrant recall calls, embedding backfills) saturates that pool, a queued
+call stalls while looking like a "slow await" — and the loop itself is idle, so
+the loop-lag sampler sees nothing. That is the failure mode the loop-lag
+sampler cannot distinguish on its own: *executor* starvation vs *loop*
+starvation behind a recall 503.
+
+:func:`default_executor_pending` reads the executor's pending-work depth and
+worker counts so a 503 (or a lag episode) can be attributed to executor
+saturation. It touches private CPython attributes
+(``loop._default_executor`` and ``ThreadPoolExecutor._work_queue`` /
+``_threads`` / ``_max_workers``) — stable across CPython 3.12 but wrapped in a
+blanket guard so any shape change, or a not-yet-created executor (lazily built
+by the first ``to_thread``), returns ``None`` instead of raising into a caller.
+This is diagnostic-only: it must never affect control flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def default_executor_pending() -> dict[str, int] | None:
+    """Return the running loop's default-executor pressure, or ``None``.
+
+    ``{"pending": <queued calls>, "workers": <live threads>,
+    "max_workers": <cap>}``. ``pending`` is the count of submitted calls not yet
+    picked up by a worker — a sustained non-zero value means every worker is
+    busy and ``to_thread`` work is backing up (the saturation signal). Returns
+    ``None`` outside a running loop, before the executor exists, or on any
+    attribute-shape change (best-effort; never raises).
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        executor = loop._default_executor  # type: ignore[attr-defined]
+        if executor is None:
+            return None
+        work_queue = executor._work_queue  # type: ignore[attr-defined]
+        return {
+            "pending": work_queue.qsize(),
+            "workers": len(executor._threads),  # type: ignore[attr-defined]
+            "max_workers": executor._max_workers,  # type: ignore[attr-defined]
+        }
+    except Exception:
+        return None

--- a/tests/test_memory/test_proactive_engine.py
+++ b/tests/test_memory/test_proactive_engine.py
@@ -752,3 +752,41 @@ async def test_proactive_context_logs_partial_timings_on_cancellation(caplog):
     # partial timings carry the completed embed phase but NOT recall (never finished)
     assert "'embed'" in warns[0]
     assert "'recall'" not in warns[0]
+    # PR-2c: the WARN now also carries the executor gauge, the wall time spent in the
+    # cancelled phase, and the total-since-start — the signals for attributing the ~4s.
+    assert "executor=" in warns[0]
+    assert "phase_wall_ms" in warns[0]
+    assert "cancelled_after_ms" in warns[0]
+
+
+async def test_proactive_context_cancellation_folds_completed_substages(caplog):
+    """PR-2c: recall sub-stage timers the engine wrote into ``stats`` BEFORE the
+    cancel must appear in the 503 WARN, so the log names the stage the coroutine
+    starved in. Simulate a recall that finished the vector + FTS stages (writing
+    their timers into the passed ``stats`` sink) and is then cancelled mid-flight.
+    """
+
+    async def _partial_then_cancel(prompt, **kwargs):
+        stats = kwargs.get("stats")
+        if stats is not None:
+            # Engine writes these incrementally as each stage completes; a cancel
+            # after FTS leaves vector+fts present but not the later stages.
+            stats["vector_ms"] = 210.5
+            stats["fts_ms"] = 44.2
+        raise asyncio.CancelledError
+
+    with (
+        patch("genesis.mcp.memory.core._memory_mod", return_value=_FakeMod()),
+        patch("genesis.mcp.memory.core._proactive_impl", new=_partial_then_cancel),
+        caplog.at_level(logging.WARNING),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await P.proactive_context(prompt="what did we decide", session_id="s")
+
+    warns = [r.getMessage() for r in caplog.records if "CANCELLED at phase" in r.getMessage()]
+    assert warns, "cancellation must emit a WARNING"
+    # Completed stages fold in (suffix stripped); never-reached stages stay absent.
+    assert "'vector'" in warns[0]
+    assert "'fts'" in warns[0]
+    assert "'activation'" not in warns[0]
+    assert "'assembly'" not in warns[0]

--- a/tests/test_util/test_loop_diag.py
+++ b/tests/test_util/test_loop_diag.py
@@ -1,0 +1,77 @@
+"""Tests for the best-effort default-executor gauge (PR-2c).
+
+The gauge pokes private CPython executor internals, so these lock in the
+contract that matters to callers: a well-formed dict once the executor exists,
+and ``None`` (never an exception) for every "can't measure" path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from genesis.util.loop_diag import default_executor_pending
+
+# asyncio_mode=auto: async tests run automatically; the sync test below runs sync
+# (a module-level asyncio mark would wrongly wrap it and assert-fail on "no loop").
+
+
+async def test_returns_none_before_executor_created():
+    # No to_thread has run on this loop yet → loop._default_executor is None.
+    loop = asyncio.get_running_loop()
+    assert loop._default_executor is None
+    assert default_executor_pending() is None
+
+
+async def test_returns_dict_after_to_thread():
+    # First to_thread lazily creates the default ThreadPoolExecutor.
+    await asyncio.to_thread(lambda: None)
+    stats = default_executor_pending()
+    assert stats is not None
+    assert set(stats) == {"pending", "workers", "max_workers"}
+    assert isinstance(stats["pending"], int) and stats["pending"] >= 0
+    assert stats["workers"] >= 1
+    assert stats["max_workers"] >= 1
+
+
+def test_returns_none_outside_running_loop():
+    # get_running_loop() raises with no loop → blanket guard returns None.
+    assert default_executor_pending() is None
+
+
+async def test_reflects_queued_work(monkeypatch):
+    """A backed-up executor reports a non-zero pending depth. Pin the pool to a
+    single worker and block it so a second submission has to queue."""
+    loop = asyncio.get_running_loop()
+    import concurrent.futures
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    loop.set_default_executor(executor)
+    try:
+        release = asyncio.Event()
+        started = asyncio.Event()
+
+        def _block():
+            # Signal we occupy the sole worker, then spin until released.
+            loop.call_soon_threadsafe(started.set)
+            while not release.is_set():
+                pass
+
+        busy = asyncio.ensure_future(asyncio.to_thread(_block))
+        await started.wait()
+        # Sole worker is occupied; queue a second call so pending > 0.
+        queued = asyncio.ensure_future(asyncio.to_thread(lambda: None))
+        await asyncio.sleep(0)  # let the submission enqueue
+
+        stats = default_executor_pending()
+        # Release BEFORE asserting: a failed assertion must not leave the busy-spin
+        # thread running, or the finally's shutdown(wait=True) stalls the whole run
+        # until the global pytest timeout (reviewer catch).
+        release.set()
+        await busy
+        await queued
+
+        assert stats is not None
+        assert stats["max_workers"] == 1
+        assert stats["pending"] >= 1
+    finally:
+        executor.shutdown(wait=True)


### PR DESCRIPTION
## What

Instrumentation-only follow-up to #1290. The 503 cancellation WARN named only the coarse phase (`phase=recall`), leaving the ~4s a cancelled recall burns unexplained — and the loop-lag sampler cannot distinguish the two competing mechanisms behind it: event-loop starvation vs default-executor (`asyncio.to_thread`) saturation. Live soak data showed every organic 503 dying in the recall phase (~3.2-4.2s) while the success path completes it in ~0.5s, with logged loop stalls too small to account for the gap.

## How

- **New `util/loop_diag.default_executor_pending()`** — best-effort gauge of the running loop's default ThreadPoolExecutor (`pending`/`workers`/`max_workers`). Blanket-guarded: returns `None` before the executor exists, outside a loop, or on any CPython attr-shape change; never raises into a caller. The default executor is the pool Qdrant recall `to_thread` calls share with other background `to_thread` work (verified: no `set_default_executor` anywhere in `src/`), so a deep pending queue during a stall names thread-pool saturation.
- **Cancellation WARN upgraded** (`proactive.py`): folds the recall sub-stage timers the engine already wrote incrementally into the `stats` sink before the cancel (an empty fold ⇒ died in the first stage, the vector search), plus `phase_wall_ms` (wall time inside the cancelled phase) and `executor=` gauge. The success path now shares the same `_fold_engine_substages` helper (pure refactor of the previous inline fold — behavior preserved), so both success and 503 logs carry one sub-stage vocabulary.
- **Loop-lag sampler WARN** (`standalone.py`) carries the `executor=` gauge per lag episode, so an episode with low lag but deep queue is attributable to executor saturation.

No changes to the recall engine (`retrieval.py`), recall results, or the wire contract.

## Test plan

- New `tests/test_util/test_loop_diag.py`: gauge contract — None before executor creation / outside a loop, well-formed dict after `to_thread`, queued-work case pinned to a 1-worker pool (hang-safe ordering: worker released before assertions).
- Extended cancellation test asserts `executor=`, `phase_wall_ms`, `cancelled_after_ms` in the WARN; new test proves completed sub-stages (vector/fts) fold into the WARN while never-reached stages stay absent.
- 33 targeted tests + 39 `tests/test_hosting/` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)