### PR TITLE
feat(ego): PR-6b reconcile live-apply core (default-shadow)

### DIFF
--- a/src/genesis/ego/reconcile_config.py
+++ b/src/genesis/ego/reconcile_config.py
@@ -25,10 +25,14 @@ degrades to DEFAULTS; an invalid ``mode`` degrades to ``shadow`` (never a silent
 hides the feature). The env kill switch ``GENESIS_EGO_RECONCILE_DISABLED=1``
 forces ``off`` (no reconcile CC call runs).
 
-NOTE (PR-5 → PR-6 dependency): flipping ``mode: live`` is only safe once PR-6's
-resolve-side ``expected_revision`` guards are wired into the Telegram/MCP/
-dashboard resolve paths — otherwise a live revise reintroduces the approve-time
-TOCTOU that versioned revision exists to close. Until then, keep ``shadow``.
+NOTE (live-apply safety): a live ``revise`` mutates a pending item's content and
+bumps its ``revision_num``, which would reintroduce the approve-time TOCTOU
+(a user approving content they never saw) unless every resolve path pins the
+revision the user was shown. Those resolve-side ``expected_revision`` guards
+shipped in #1257 (Telegram/MCP/dashboard/comms all pass the rendered revision).
+PR-6b's live-apply is built on top of them, so the TOCTOU is closed. The flip to
+``mode: live`` remains a deliberate user action gated on shadow-soak + replay
+evidence — never flipped automatically.
 
 Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
 ``genesis.mcp.health.settings`` imports the public ``MODES`` / ``INT_KNOBS``

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1430,15 +1430,23 @@ class EgoSession:
         return snapshot
 
     async def _reconcile_drafts(self, proposals: list[dict]) -> list[dict]:
-        """PR-5 reconcile stage — OBSERVE-ONLY. Match this cycle's drafts against
-        the ego-scoped pending board + a deterministic covered-work snapshot and
-        LOG the per-draft verdicts (new/reaffirm/revise/withdraw). Applies
-        NOTHING — verdict application lands in PR-6. Returns drafts unchanged and
-        is fully fail-open: any error passes the drafts through untouched.
+        """Reconcile stage. Match this cycle's drafts against the ego-scoped
+        pending board + a deterministic covered-work snapshot, get a per-draft
+        verdict (new/reaffirm/revise/withdraw), and — in ``live`` mode — apply
+        the board verdicts, returning only the surviving drafts (those still to
+        be created). Fully fail-open: any error passes the drafts through
+        untouched.
 
-        Gated by the ego_reconcile settings lever: off = the stage does not run
-        (no extra CC call); shadow/live both observe-only in PR-5 (live's apply
-        is PR-6).
+        Gated by the ego_reconcile settings lever:
+          - ``off``    — the stage does not run (no extra CC call).
+          - ``shadow`` — run + LOG the verdicts, apply NOTHING; drafts returned
+            unchanged (the default; the observation signal for the replay gate).
+          - ``live``   — apply verdicts via ``_apply_reconcile_verdicts``:
+            reaffirm/revise the matched board item, withdraw covered work, and
+            drop the reconciled drafts; only ``new``/unresolved drafts survive to
+            the realist → create. Live-``revise`` depends on the resolve-side
+            ``expected_revision`` guards (PR-6a) being deployed — the flip is
+            gated on that (see reconcile_config).
         """
         self._last_reconcile_cost_usd = 0.0
         if not proposals:
@@ -1462,6 +1470,13 @@ class EgoSession:
             self._last_reconcile_cost_usd = output.cost_usd
             verdicts = _parse_reconcile_response(output.text, len(proposals))
             self._log_reconcile_verdicts(mode, verdicts, proposals, board, covered)
+            if mode == "live":
+                # PR-6b: apply board verdicts and return ONLY the surviving
+                # drafts (those still to create). Everything before the apply
+                # loop is read-only, so an error here still fails open safely.
+                return await self._apply_reconcile_verdicts(
+                    proposals, verdicts, board
+                )
         except Exception:
             logger.warning(
                 "Reconcile stage failed, passing drafts through", exc_info=True
@@ -1507,6 +1522,215 @@ class EgoSession:
                 str(prop.get("content", ""))[:80].replace("\n", " "),
                 str(v.get("reason", ""))[:120],
             )
+
+    async def _apply_reconcile_verdicts(
+        self,
+        proposals: list[dict],
+        verdicts: dict[int, dict],
+        board: list[dict],
+    ) -> list[dict]:
+        """PR-6b LIVE apply of reconcile verdicts. Returns the SURVIVING drafts
+        (those still to be created), which flow to the realist -> create_batch
+        exactly as today. Board verdicts (reaffirm/withdraw/revise) are applied
+        here and their drafts dropped from the returned list.
+
+        Per-draft fail-open: each draft is KEPT-as-new unless a mutation SUCCEEDS
+        and warrants dropping it. One draft's failure fails open THAT draft only
+        and never abandons an already-committed board decision — so a mid-loop
+        error cannot bubble to the caller's outer except and return the full
+        input list (which would double-create a draft whose board twin was
+        already mutated). All DB writes happen inside the per-draft try; the only
+        code before the loop (prefix_map build) is read-only.
+
+        target_id resolution: the reconcile prompt renders board ids truncated to
+        12 chars, so the model can only ever emit a 12-char prefix. We map that
+        prefix back to the FULL id from the exact board snapshot reconcile was
+        shown; an unmatched or ambiguous prefix downgrades the verdict to "new"
+        (fail-safe), so a hallucinated/mistranscribed id never mutates the wrong
+        proposal.
+        """
+        prefix_map: dict[str, list[tuple[str, dict]]] = {}
+        for b in board:
+            bid = str(b.get("id", "") or "")
+            if bid:
+                prefix_map.setdefault(bid[:12], []).append((bid, b))
+
+        survivors: list[dict] = []
+        for i, draft in enumerate(proposals):
+            try:
+                v = verdicts.get(i) or {}
+                verdict = v.get("verdict", "new")
+                raw_target = v.get("target_id")
+
+                if verdict == "new":
+                    survivors.append(draft)
+                    continue
+
+                # withdraw with NO board target = covered-work invalidated a
+                # FRESH draft that has no board twin -> DROP the draft (do not
+                # create it). This is NOT a board withdrawal, and is decoupled
+                # from the 24h guard: the draft is covered regardless of any
+                # board item's age.
+                if verdict == "withdraw" and not raw_target:
+                    logger.info(
+                        "Reconcile[live] draft[%d] dropped — covered-work, no board twin :: %s",
+                        i,
+                        str(draft.get("content", ""))[:80].replace("\n", " "),
+                    )
+                    continue
+
+                matches = (
+                    prefix_map.get(str(raw_target)[:12]) if raw_target else None
+                )
+                if not matches or len(matches) != 1:
+                    logger.info(
+                        "Reconcile[live] draft[%d] verdict=%s target=%r unresolved "
+                        "-> keep as new",
+                        i,
+                        verdict,
+                        raw_target,
+                    )
+                    survivors.append(draft)
+                    continue
+                full_id, board_row = matches[0]
+
+                if verdict == "reaffirm":
+                    ok = await ego_crud.reaffirm_proposal(self._db, full_id)
+                    logger.info(
+                        "Reconcile[live] draft[%d] reaffirm %s (ok=%s)",
+                        i,
+                        full_id[:12],
+                        ok,
+                    )
+                    # Board item covers it -> drop the fresh re-derivation. A
+                    # False ok means the board item is no longer pending
+                    # (approved/withdrawn/tabled) — re-creating it would either
+                    # duplicate approved work or resurrect a rejected one, so
+                    # dropping is correct in every case.
+                    continue
+
+                if verdict == "withdraw":
+                    retired = await self._reconcile_withdraw(
+                        full_id, board_row, v.get("reason")
+                    )
+                    logger.info(
+                        "Reconcile[live] draft[%d] withdraw %s (board_retired=%s)",
+                        i,
+                        full_id[:12],
+                        retired,
+                    )
+                    # Duplicate of an invalidated/covered item -> drop the draft
+                    # whether or not the board retire fired (24h guard may defer).
+                    continue
+
+                if verdict == "revise":
+                    applied = await self._reconcile_revise(
+                        full_id, board_row, draft, v.get("reason")
+                    )
+                    if applied:
+                        continue  # board item sharpened in place -> drop draft
+                    survivors.append(draft)  # race/dedup/non-pending -> keep new
+                    continue
+
+                survivors.append(draft)  # unknown verdict -> keep
+            except Exception:
+                logger.warning(
+                    "Reconcile[live] draft[%d] apply failed — keeping as new",
+                    i,
+                    exc_info=True,
+                )
+                survivors.append(draft)
+        return survivors
+
+    async def _reconcile_withdraw(
+        self, proposal_id: str, board_row: dict, reason: str | None
+    ) -> bool:
+        """Withdraw a board item invalidated by covered-work, honoring the 24h
+        user-protection guard (mirrors the ego-directed withdraw path,
+        session.py withdrawn-ids loop): no withdraw of an item delivered < 24h
+        ago. Returns True iff the board item was retired. The caller drops the
+        draft regardless (reconcile judged it a duplicate/covered)."""
+        created = str(board_row.get("created_at", "") or "")
+        if created:
+            try:
+                age = datetime.now(UTC) - datetime.fromisoformat(created)
+                if age.total_seconds() < 86400:
+                    logger.info(
+                        "Reconcile[live] withdraw of %s deferred (%.1fh old, <24h guard)",
+                        proposal_id[:12],
+                        age.total_seconds() / 3600,
+                    )
+                    return False
+            except (ValueError, TypeError):
+                pass  # unparseable timestamp — allow withdrawal
+        ok = await ego_crud.withdraw_proposal(
+            self._db,
+            proposal_id,
+            user_response=(reason or "reconcile: covered by shipped/active work"),
+        )
+        if ok:
+            with contextlib.suppress(Exception):
+                from genesis.db.crud import intervention_journal as journal_crud
+
+                await journal_crud.resolve(
+                    self._db, proposal_id, outcome_status="withdrawn"
+                )
+        return ok
+
+    async def _reconcile_revise(
+        self, proposal_id: str, board_row: dict, draft: dict, reason: str | None
+    ) -> bool:
+        """Apply a reconcile 'revise' verdict: sharpen a pending board item in
+        place with the draft's content. Architect ruling A — apply directly; the
+        USER APPROVAL on the pending board is the safety gate, the realist is a
+        quality pre-filter only, and action_type is immutable in revise_proposal.
+
+        Guard-first via revise_proposal (pending + revision-num atomic guard, no
+        revert path). Hash-dedup pre-check (revise_proposal does NOT dedup): if
+        the sharpened content already exists on another pending/approved
+        proposal, skip the revise and keep the draft as new — create_batch's own
+        hash-dedup then collapses it. Returns True only if the revise applied."""
+        from genesis.ego.integrity import content_hash as _content_hash
+
+        new_content = str(draft.get("content", "") or "")
+        if not new_content:
+            return False
+        if await ego_crud.has_pending_proposal_with_hash(
+            self._db, _content_hash(new_content)
+        ):
+            logger.info(
+                "Reconcile[live] revise of %s skipped — content duplicates an "
+                "existing pending item",
+                proposal_id[:12],
+            )
+            return False
+        try:
+            expected = int(board_row.get("revision_num", 1) or 1)
+        except (ValueError, TypeError):
+            expected = 1
+        new_rev = await ego_crud.revise_proposal(
+            self._db,
+            proposal_id,
+            expected_revision=expected,
+            content=new_content,
+            rationale=draft.get("rationale"),
+            confidence=draft.get("confidence"),
+            execution_plan=draft.get("execution_plan"),
+            expected_outputs=draft.get("expected_outputs"),
+            revised_by=self._source_tag,
+            reason=(reason or "reconcile: sharpened from a fresh blind draft"),
+        )
+        if new_rev is None:
+            logger.info(
+                "Reconcile[live] revise of %s not applied "
+                "(race/non-pending/rev-mismatch) -> keep draft",
+                proposal_id[:12],
+            )
+            return False
+        logger.info(
+            "Reconcile[live] revised %s -> rev %d", proposal_id[:12], new_rev
+        )
+        return True
 
     async def _filter_proposals(
         self,
@@ -2814,7 +3038,8 @@ For EACH draft (by index) output exactly one verdict:
 
 Judge the SEMANTIC match yourself; do not require identical wording. When unsure, prefer "new".
 
-Output STRICT JSON only — an array with one object per draft:
+Output ONLY the JSON array — no preamble, no explanation, no code fence, no text
+before or after it. One object per draft, index-aligned:
 [{{"index": 0, "verdict": "new|reaffirm|revise|withdraw", "target_id": "<board id or null>", "reason": "<one line>"}}]
 """
 
@@ -2840,6 +3065,17 @@ def _parse_reconcile_response(
         if match:
             with contextlib.suppress(json.JSONDecodeError):
                 parsed = json.loads(match.group(1).strip())
+    if parsed is None:
+        # Robust extraction: anchor on the real array-of-objects start "[{"
+        # (optional whitespace between), greedy to the last "}]". Immune to
+        # preamble prose containing stray brackets like "The draft [0] ...",
+        # which the naive find("[")/rfind("]") slice below mis-grabs → JSON
+        # error → every draft silently defaults to "new" (PR-6b replay gate
+        # measured this firing ~13% of the time, whenever the model preambles).
+        match = re.search(r"\[\s*\{.*\}\s*\]", text, re.DOTALL)
+        if match:
+            with contextlib.suppress(json.JSONDecodeError):
+                parsed = json.loads(match.group(0))
     if parsed is None:
         first = text.find("[")
         last = text.rfind("]")

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1624,6 +1624,28 @@ class EgoSession:
                     continue
 
                 if verdict == "revise":
+                    # A revise mutates the board item's content + bumps
+                    # revision_num, which only stays TOCTOU-safe if every pending
+                    # digest for that item is revision-snapshot-protected (so a
+                    # stale reply refuses). A digest sent before #1257 shipped
+                    # snapshotting has none — resolve_proposals then falls back to
+                    # expected_revision=None (unguarded). For such an item, revise
+                    # would reopen the approve-time race; reaffirm instead (keep
+                    # the board item as-is, drop the duplicate draft) — no TOCTOU
+                    # and no duplicate. Only the sharpening is deferred until the
+                    # item is next re-digested (with a snapshot) or resolved.
+                    if not await self._revision_snapshot_exists(
+                        board_row.get("batch_id")
+                    ):
+                        ok = await ego_crud.reaffirm_proposal(self._db, full_id)
+                        logger.info(
+                            "Reconcile[live] draft[%d] revise->reaffirm %s "
+                            "(digest not snapshot-protected; TOCTOU-safe) ok=%s",
+                            i,
+                            full_id[:12],
+                            ok,
+                        )
+                        continue  # drop the duplicate draft
                     applied = await self._reconcile_revise(
                         full_id, board_row, draft, v.get("reason")
                     )
@@ -1676,6 +1698,22 @@ class EgoSession:
                     self._db, proposal_id, outcome_status="withdrawn"
                 )
         return ok
+
+    async def _revision_snapshot_exists(self, batch_id: object) -> bool:
+        """True iff the proposal's delivery batch has a revision snapshot — i.e.
+        its digest was sent after #1257 shipped snapshotting, so a resolve of it
+        is revision-guarded. A missing snapshot (pre-#1257 digest, or never
+        digested) means a resolve would be unguarded, so a live revise of that
+        item is unsafe. Fail-closed (return False) on any error."""
+        if not batch_id:
+            return False
+        try:
+            snap = await ego_crud.get_state(
+                self._db, f"revision_snapshot:{batch_id}"
+            )
+            return bool(snap)
+        except Exception:
+            return False
 
     async def _reconcile_revise(
         self, proposal_id: str, board_row: dict, draft: dict, reason: str | None
@@ -3046,8 +3084,12 @@ For EACH draft (by index) output exactly one verdict:
 - "new": nothing above covers it — genuinely novel work.
 - "reaffirm": a pending board item ALREADY covers it — put the board id in target_id.
 - "revise": a board item covers it but this draft sharpens/updates it — target_id = board id.
-- "withdraw": a board item is INVALIDATED by covered-work (an active job already does it,
-  or a merged PR closed it) — target_id = the board id to retire, reason = the evidence.
+- "withdraw": the work is ALREADY COVERED by covered-work (an active job already does it,
+  or a merged PR closed it). If a pending board item covers the same work, set target_id =
+  that board id to retire it. If NO board item matches but the draft itself is already
+  covered by an active job or merged PR, still use "withdraw" with target_id = null — this
+  drops the redundant draft (there is nothing on the board to retire, but the work is
+  handled). Put the covering evidence in reason.
 
 Judge the SEMANTIC match yourself; do not require identical wording. When unsure, prefer "new".
 

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -77,7 +77,14 @@ decision. Includes board items (ranked) plus unranked items.
 > **Note (reconcile stage):** When the operational reconcile stage is active
 > (the default), your pending board is NOT shown while you draft — you propose
 > freely and a separate reconcile pass matches your drafts against the board
-> afterward. Do not try to re-rank or unboard a board you cannot see; the
+> afterward. Each draft is judged: **new** (kept and created), **reaffirm** (a
+> board item already covers it — the board item is re-validated and your
+> duplicate is dropped), **revise** (a board item covers it but your draft
+> sharpens it — the board item is updated in place, keeping its lineage), or
+> **withdraw** (covered by an active job or shipped work — retired, not
+> re-proposed). When reconcile runs in *live* mode it applies these outcomes for
+> you, so re-deriving the same work is safe: it will be reconciled, never
+> duplicated. Do not try to re-rank or unboard a board you cannot see; the
 > board-review and unboard steps below apply only when the reconcile stage is
 > off (board in context).
 

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -190,7 +190,12 @@ user's domain — they approve or reject at their own pace.
 
 > **Note (reconcile stage):** When the reconcile stage is active (the default),
 > your pending board is NOT shown while you draft — you propose freely and a
-> separate reconcile pass reviews your drafts against the board afterward. Do
+> separate reconcile pass reviews your drafts against the board afterward. Each
+> draft is judged **new** (kept), **reaffirm** (a board item already covers it —
+> re-validated, your duplicate dropped), **revise** (your draft sharpens a board
+> item — updated in place, lineage kept), or **withdraw** (already covered by
+> shipped/active work — retired). In *live* mode these are applied for you, so
+> re-deriving the same idea is safe — it is reconciled, never duplicated. Do
 > not try to re-rank a board you cannot see; the board-review step below applies
 > only when the reconcile stage is off (board in context).
 

--- a/tests/ego/test_reconcile_apply.py
+++ b/tests/ego/test_reconcile_apply.py
@@ -10,6 +10,7 @@ a lightweight EgoSession via ``__new__`` rather than the full constructor.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 
@@ -43,8 +44,20 @@ def sess(db):
     return s
 
 
-async def _board_item(db, *, id: str, content: str = "board work", age_hours: float = 48.0) -> dict:
-    """Insert a pending board proposal aged `age_hours` and return its row dict."""
+async def _board_item(
+    db,
+    *,
+    id: str,
+    content: str = "board work",
+    age_hours: float = 48.0,
+    batch: str = "batch_default",
+    snapshotted: bool = True,
+) -> dict:
+    """Insert a pending board proposal aged `age_hours` and return its row dict.
+
+    By default writes a revision_snapshot for its batch (so a live revise of it
+    is TOCTOU-safe). Pass ``snapshotted=False`` to simulate a pre-#1257 digest
+    with no snapshot (revise must then reaffirm-fallback)."""
     created = (datetime.now(UTC) - timedelta(hours=age_hours)).isoformat()
     await ego_crud.create_proposal(
         db,
@@ -52,11 +65,14 @@ async def _board_item(db, *, id: str, content: str = "board work", age_hours: fl
         action_type="investigate",
         content=content,
         status="pending",
+        batch_id=batch,
         created_at=created,
         content_hash=content_hash(content),
         content_size=len(content.encode()),
         ego_source="genesis_ego_cycle",
     )
+    if snapshotted:
+        await ego_crud.set_state(db, key=f"revision_snapshot:{batch}", value=json.dumps({id: 1}))
     row = await ego_crud.get_proposal(db, id)
     return dict(row)
 
@@ -182,6 +198,32 @@ class TestApplyVerdicts:
             ("rv11rv11rv110000",),
         )
         assert (await cur.fetchone())["content"] == "stale text"
+
+    async def test_revise_unsnapshotted_reaffirms_instead(self, sess, db):
+        """Codex P2: a revise verdict on a board item whose digest has NO revision
+        snapshot (e.g. a pre-#1257 digest) must NOT revise — that would reopen the
+        approve-time TOCTOU on a late reply (resolve falls back to unguarded). It
+        reaffirms instead: board item kept as-is, duplicate draft dropped, content
+        unchanged. No duplicate is created."""
+        board_row = await _board_item(
+            db,
+            id="nosnap1nosnap100",
+            content="original",
+            batch="pre1257batch",
+            snapshotted=False,
+        )
+        assert board_row["last_validated_at"] is None
+        drafts = [_draft("sharper content the model wanted to apply")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts,
+            {0: {"verdict": "revise", "target_id": "nosnap1nosna"}},
+            [board_row],
+        )
+        assert survivors == []  # duplicate draft dropped, NOT kept-as-new
+        row = await ego_crud.get_proposal(db, "nosnap1nosnap100")
+        assert row["content"] == "original"  # NOT revised (no snapshot)
+        assert row["revision_num"] == 1
+        assert row["last_validated_at"] is not None  # reaffirmed instead
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ego/test_reconcile_apply.py
+++ b/tests/ego/test_reconcile_apply.py
@@ -1,0 +1,396 @@
+"""PR-6b — reconcile live-apply tests.
+
+Covers the parser robustness fix and the live-apply branch of the reconcile
+stage: verdict application, per-draft fail-open, 12-char target-prefix
+resolution, the 24h withdraw guard, and revise hash-dedup / race handling.
+
+The apply methods only touch ``self._db`` and ``self._source_tag``, so we build
+a lightweight EgoSession via ``__new__`` rather than the full constructor.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import aiosqlite
+import pytest
+
+from genesis.cc.types import CCOutput
+from genesis.db.crud import ego as ego_crud
+from genesis.db.schema import TABLES
+from genesis.ego.integrity import content_hash
+from genesis.ego.session import EgoSession, _parse_reconcile_response
+
+
+@pytest.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        for table in ("ego_proposals", "ego_proposal_revisions", "ego_state"):
+            await conn.execute(TABLES[table])
+        yield conn
+
+
+@pytest.fixture
+def sess(db):
+    """Lightweight EgoSession — only _db/_source_tag are needed by the apply
+    methods; skip the heavy constructor."""
+    s = EgoSession.__new__(EgoSession)
+    s._db = db
+    s._source_tag = "genesis_ego_cycle"
+    s._last_reconcile_cost_usd = 0.0
+    return s
+
+
+async def _board_item(db, *, id: str, content: str = "board work", age_hours: float = 48.0) -> dict:
+    """Insert a pending board proposal aged `age_hours` and return its row dict."""
+    created = (datetime.now(UTC) - timedelta(hours=age_hours)).isoformat()
+    await ego_crud.create_proposal(
+        db,
+        id=id,
+        action_type="investigate",
+        content=content,
+        status="pending",
+        created_at=created,
+        content_hash=content_hash(content),
+        content_size=len(content.encode()),
+        ego_source="genesis_ego_cycle",
+    )
+    row = await ego_crud.get_proposal(db, id)
+    return dict(row)
+
+
+def _draft(content: str = "fresh draft") -> dict:
+    return {"action_type": "investigate", "content": content, "confidence": 0.8}
+
+
+# ---------------------------------------------------------------------------
+# Parser robustness (the ~13% preamble bug)
+# ---------------------------------------------------------------------------
+
+
+class TestParserRobustness:
+    def test_preamble_prose_with_brackets_parsed(self):
+        """Model preambles with 'The draft [0] ...' then emits the array. The
+        naive find('[') slice grabbed the prose bracket → {} → all 'new'. The
+        regex tier must recover the real verdicts."""
+        raw = (
+            "I'll analyze the single draft against the board.\n\n"
+            "The draft [0] proposes dispatching a weekly install test.\n\n"
+            '[{"index": 0, "verdict": "reaffirm", "target_id": "a80588ac034e", '
+            '"reason": "board already covers it"}]'
+        )
+        verdicts = _parse_reconcile_response(raw, 1)
+        assert verdicts[0]["verdict"] == "reaffirm"
+        assert verdicts[0]["target_id"] == "a80588ac034e"
+
+    def test_clean_array_still_parses(self):
+        raw = '[{"index": 0, "verdict": "new", "target_id": null, "reason": "x"}]'
+        assert _parse_reconcile_response(raw, 1)[0]["verdict"] == "new"
+
+    def test_fenced_json_still_parses(self):
+        raw = '```json\n[{"index": 0, "verdict": "withdraw", "target_id": "abc"}]\n```'
+        assert _parse_reconcile_response(raw, 1)[0]["verdict"] == "withdraw"
+
+    def test_garbage_returns_empty(self):
+        assert _parse_reconcile_response("no json here at all", 1) == {}
+
+
+# ---------------------------------------------------------------------------
+# Live apply — verdict handling
+# ---------------------------------------------------------------------------
+
+
+class TestApplyVerdicts:
+    async def test_new_kept(self, sess, db):
+        drafts = [_draft("novel work")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts, {0: {"verdict": "new", "target_id": None}}, []
+        )
+        assert survivors == drafts
+
+    async def test_reaffirm_drops_draft_and_stamps_validated(self, sess, db):
+        board_row = await _board_item(db, id="b1aaaaaaaaaa1111")
+        assert board_row["last_validated_at"] is None
+        drafts = [_draft("re-derived board work")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts,
+            {0: {"verdict": "reaffirm", "target_id": "b1aaaaaaaaaa"}},
+            [board_row],
+        )
+        assert survivors == []  # dropped
+        row = await ego_crud.get_proposal(db, "b1aaaaaaaaaa1111")
+        assert row["last_validated_at"] is not None
+        assert row["status"] == "pending"
+
+    async def test_withdraw_null_target_drops_draft(self, sess, db):
+        """Covered-work invalidated a FRESH draft with no board twin → drop it,
+        no board mutation."""
+        board_row = await _board_item(db, id="keepkeepkeep0001")
+        drafts = [_draft("covered by a cron job")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts, {0: {"verdict": "withdraw", "target_id": None}}, [board_row]
+        )
+        assert survivors == []  # dropped
+        # Unrelated board item untouched.
+        assert (await ego_crud.get_proposal(db, "keepkeepkeep0001"))["status"] == "pending"
+
+    async def test_withdraw_valid_target_retires_and_drops(self, sess, db):
+        board_row = await _board_item(db, id="wd11wd11wd110000", age_hours=48)
+        drafts = [_draft("dup of an invalidated item")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts,
+            {0: {"verdict": "withdraw", "target_id": "wd11wd11wd11", "reason": "job does it"}},
+            [board_row],
+        )
+        assert survivors == []
+        row = await ego_crud.get_proposal(db, "wd11wd11wd110000")
+        assert row["status"] == "withdrawn"
+        assert "job does it" in (row["user_response"] or "")
+
+    async def test_withdraw_24h_guard_defers_board_but_drops_draft(self, sess, db):
+        """A <24h board item is NOT withdrawn (user-protection guard), but the
+        duplicate draft is still dropped."""
+        board_row = await _board_item(db, id="young1young10000", age_hours=2)
+        drafts = [_draft("dup of a fresh board item")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts,
+            {0: {"verdict": "withdraw", "target_id": "young1young1"}},
+            [board_row],
+        )
+        assert survivors == []  # draft still dropped
+        row = await ego_crud.get_proposal(db, "young1young10000")
+        assert row["status"] == "pending"  # board NOT withdrawn (<24h)
+
+    async def test_revise_applies_and_drops(self, sess, db):
+        board_row = await _board_item(db, id="rv11rv11rv110000", content="stale text")
+        drafts = [_draft("sharper, better text")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts,
+            {0: {"verdict": "revise", "target_id": "rv11rv11rv11", "reason": "sharper"}},
+            [board_row],
+        )
+        assert survivors == []  # dropped
+        row = await ego_crud.get_proposal(db, "rv11rv11rv110000")
+        assert row["content"] == "sharper, better text"
+        assert row["revision_num"] == 2
+        assert row["status"] == "pending"
+        # Prior values archived.
+        cur = await db.execute(
+            "SELECT content FROM ego_proposal_revisions WHERE proposal_id = ?",
+            ("rv11rv11rv110000",),
+        )
+        assert (await cur.fetchone())["content"] == "stale text"
+
+
+# ---------------------------------------------------------------------------
+# Fail-safe: hallucinated / ambiguous targets, races, dedup
+# ---------------------------------------------------------------------------
+
+
+class TestFailSafe:
+    async def test_hallucinated_target_keeps_as_new(self, sess, db):
+        """A target prefix that matches no board id → downgrade to new (create),
+        never mutate a wrong proposal."""
+        board_row = await _board_item(db, id="real1real1real00")
+        drafts = [_draft("some work")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts,
+            {0: {"verdict": "reaffirm", "target_id": "ffffffffffff"}},  # no match
+            [board_row],
+        )
+        assert survivors == drafts  # kept as new
+        # Board item NOT reaffirmed.
+        assert (await ego_crud.get_proposal(db, "real1real1real00"))["last_validated_at"] is None
+
+    async def test_prefix_resolves_to_full_id(self, sess, db):
+        """The model sees only id[:12]; the full id must be resolved from it."""
+        board_row = await _board_item(db, id="abcdefabcdefXXXX")
+        drafts = [_draft()]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts,
+            {0: {"verdict": "reaffirm", "target_id": "abcdefabcdef"}},  # 12-char prefix
+            [board_row],
+        )
+        assert survivors == []
+        assert (await ego_crud.get_proposal(db, "abcdefabcdefXXXX"))[
+            "last_validated_at"
+        ] is not None
+
+    async def test_ambiguous_prefix_keeps_as_new(self, sess, db):
+        """Two board ids sharing a 12-char prefix → ambiguous → fail-safe new."""
+        r1 = await _board_item(db, id="dupdupdupdup0001")
+        r2 = await _board_item(db, id="dupdupdupdup0002", content="other")
+        drafts = [_draft()]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts, {0: {"verdict": "reaffirm", "target_id": "dupdupdupdup"}}, [r1, r2]
+        )
+        assert survivors == drafts  # kept
+        assert (await ego_crud.get_proposal(db, "dupdupdupdup0001"))["last_validated_at"] is None
+
+    async def test_revise_hash_dup_keeps_as_new(self, sess, db):
+        """Revising to content that already exists on another pending item is
+        skipped (revise_proposal does not dedup) → keep the draft as new."""
+        board_row = await _board_item(db, id="tgt1tgt1tgt10000", content="original")
+        # Another pending item already holds the target content.
+        await _board_item(db, id="other1other10000", content="already pending text")
+        drafts = [_draft("already pending text")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts, {0: {"verdict": "revise", "target_id": "tgt1tgt1tgt1"}}, [board_row]
+        )
+        assert survivors == drafts  # kept as new; revise skipped
+        row = await ego_crud.get_proposal(db, "tgt1tgt1tgt10000")
+        assert row["content"] == "original"  # unchanged
+        assert row["revision_num"] == 1
+
+    async def test_revise_nonpending_keeps_as_new(self, sess, db):
+        """A board item concurrently approved → revise guard rowcount 0 → keep."""
+        board_row = await _board_item(db, id="appr1appr1appr00", content="orig")
+        await db.execute(
+            "UPDATE ego_proposals SET status = 'approved' WHERE id = ?",
+            ("appr1appr1appr00",),
+        )
+        await db.commit()
+        drafts = [_draft("new content")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts, {0: {"verdict": "revise", "target_id": "appr1appr1appr"}}, [board_row]
+        )
+        assert survivors == drafts  # kept
+        row = await ego_crud.get_proposal(db, "appr1appr1appr00")
+        assert row["content"] == "orig"  # unchanged
+
+    async def test_withdraw_unresolvable_target_keeps_as_new(self, sess, db):
+        """A withdraw verdict with a NON-null but unresolvable target must be
+        kept-as-new (created), NOT silently dropped — dropping would lose real
+        work whose board twin couldn't be resolved. (The unresolved-target check
+        precedes verdict dispatch, so this holds for every verdict, but withdraw
+        is the dangerous one: its resolved path DROPS the draft.)"""
+        board_row = await _board_item(db, id="exists1exists100")
+        drafts = [_draft("work that must not vanish")]
+        survivors = await sess._apply_reconcile_verdicts(
+            drafts,
+            {0: {"verdict": "withdraw", "target_id": "nomatch0nomat"}},  # non-null, no match
+            [board_row],
+        )
+        assert survivors == drafts  # kept as new, NOT dropped
+        # The real board item is untouched (no wrong withdrawal).
+        assert (await ego_crud.get_proposal(db, "exists1exists100"))["status"] == "pending"
+
+    async def test_per_draft_withdraw_failure_isolated(self, sess, db, monkeypatch):
+        """A raising withdraw path fails open THAT draft (kept as new) without
+        abandoning other drafts — symmetry with the reaffirm fail-open."""
+        b1 = await _board_item(db, id="wok1wok1wok10000")
+        b2 = await _board_item(db, id="wbad1wbad1wbad00")
+
+        async def flaky_withdraw(dbc, pid, **kw):
+            if pid == "wbad1wbad1wbad00":
+                raise RuntimeError("boom")
+            return True
+
+        monkeypatch.setattr(ego_crud, "withdraw_proposal", flaky_withdraw)
+        drafts = [_draft("d0"), _draft("d1")]
+        verdicts = {
+            0: {"verdict": "withdraw", "target_id": "wok1wok1wok1"},
+            1: {"verdict": "withdraw", "target_id": "wbad1wbad1wba"},
+        }
+        survivors = await sess._apply_reconcile_verdicts(drafts, verdicts, [b1, b2])
+        assert survivors == [drafts[1]]  # d1 failed → kept; d0 dropped
+
+    async def test_missing_verdict_defaults_new(self, sess, db):
+        drafts = [_draft("a"), _draft("b")]
+        survivors = await sess._apply_reconcile_verdicts(drafts, {}, [])
+        assert survivors == drafts  # both kept
+
+    async def test_per_draft_failure_isolated(self, sess, db, monkeypatch):
+        """One draft's apply raising must not abandon others or already-applied
+        board decisions — the failing draft is kept as new, the rest proceed."""
+        b1 = await _board_item(db, id="ok11ok11ok110000")
+        b2 = await _board_item(db, id="boom1boom1boom00")
+
+        real_reaffirm = ego_crud.reaffirm_proposal
+
+        async def flaky_reaffirm(dbc, pid):
+            if pid == "boom1boom1boom00":
+                raise RuntimeError("boom")
+            return await real_reaffirm(dbc, pid)
+
+        monkeypatch.setattr(ego_crud, "reaffirm_proposal", flaky_reaffirm)
+
+        drafts = [_draft("d0"), _draft("d1")]
+        verdicts = {
+            0: {"verdict": "reaffirm", "target_id": "ok11ok11ok11"},
+            1: {"verdict": "reaffirm", "target_id": "boom1boom1boom"},
+        }
+        survivors = await sess._apply_reconcile_verdicts(drafts, verdicts, [b1, b2])
+        # d0 applied (dropped); d1 failed → kept as new.
+        assert survivors == [drafts[1]]
+        assert (await ego_crud.get_proposal(db, "ok11ok11ok110000"))[
+            "last_validated_at"
+        ] is not None
+
+
+# ---------------------------------------------------------------------------
+# Mode gating via _reconcile_drafts
+# ---------------------------------------------------------------------------
+
+
+class TestModeGating:
+    def _gate(self, sess, raw_text: str):
+        out = CCOutput(
+            session_id="s",
+            text=raw_text,
+            model_used="opus",
+            cost_usd=0.01,
+            input_tokens=100,
+            output_tokens=50,
+            duration_ms=100,
+            exit_code=0,
+            is_error=False,
+            error_message=None,
+        )
+        sess._run_gate_cc = AsyncMock(return_value=out)
+        sess._gather_covered_work = AsyncMock(
+            return_value={"jobs": [], "stale_jobs": [], "merged_prs": []}
+        )
+
+    async def test_shadow_applies_nothing(self, sess, db, monkeypatch):
+        import genesis.ego.reconcile_config as rc
+
+        monkeypatch.setattr(rc, "effective_mode", lambda: "shadow")
+        await _board_item(db, id="shadow1shadow100")
+        self._gate(
+            sess,
+            '[{"index": 0, "verdict": "reaffirm", "target_id": "shadow1shadow"}]',
+        )
+        drafts = [_draft("re-derived")]
+        out = await sess._reconcile_drafts(drafts)
+        assert out == drafts  # unchanged — shadow observes only
+        assert (await ego_crud.get_proposal(db, "shadow1shadow100"))["last_validated_at"] is None
+
+    async def test_live_applies(self, sess, db, monkeypatch):
+        import genesis.ego.reconcile_config as rc
+
+        monkeypatch.setattr(rc, "effective_mode", lambda: "live")
+        # board must be discoverable via list_pending_proposals(ego_source=tag)
+        await _board_item(db, id="live1live1live000")
+        self._gate(
+            sess,
+            '[{"index": 0, "verdict": "reaffirm", "target_id": "live1live1liv"}]',
+        )
+        drafts = [_draft("re-derived")]
+        out = await sess._reconcile_drafts(drafts)
+        assert out == []  # draft dropped (reaffirmed)
+        assert (await ego_crud.get_proposal(db, "live1live1live000"))[
+            "last_validated_at"
+        ] is not None
+
+    async def test_off_skips_entirely(self, sess, db, monkeypatch):
+        import genesis.ego.reconcile_config as rc
+
+        monkeypatch.setattr(rc, "effective_mode", lambda: "off")
+        sess._run_gate_cc = AsyncMock()
+        drafts = [_draft()]
+        out = await sess._reconcile_drafts(drafts)
+        assert out == drafts
+        sess._run_gate_cc.assert_not_called()


### PR DESCRIPTION
Completes the ego reconcile chain: adds the `mode=="live"` apply branch to the reconcile stage. In `shadow` (the default) the stage still only logs verdicts; in `live` it applies board verdicts and returns only the surviving drafts, which flow to the realist → create exactly as today. **Ships default-shadow: zero behavior change at merge.** The flip to `live` stays a deliberate user action.

## What's in it
- **Robust parser** — anchor JSON-array extraction on `[{ … }]` before the naive bracket slice, so model preamble prose ("The draft [0] …") no longer drops every verdict to "new" (measured ~13% of calls previously).
- **`_apply_reconcile_verdicts`** — per-draft fail-open (each draft kept-as-new unless a mutation succeeds; a mid-loop error never bulk-returns the input and double-creates against an already-mutated board item); 12-char target-prefix resolution to the full board id (unmatched/ambiguous → downgrade to new, fail-safe against mistranscribed ids); null-target withdraw drops the covered draft.
- **`_reconcile_withdraw`** — 24h user-protection guard on the board withdrawal only; the duplicate draft is dropped regardless.
- **`_reconcile_revise`** — applied directly (guard-first via `revise_proposal`) with a load-bearing hash-dedup pre-check.
- Identity prose (both ego docs): reaffirm/revise/withdraw vocabulary.

## Safety / dependency
A live `revise` bumps a pending item's `revision_num`, so it depends on the resolve-side `expected_revision` guards (from #1257, merged and included here) to close the approve-time TOCTOU. The `reconcile_config` flip-note documents that the guards are wired.

## Verification
- 22 targeted live-apply tests + full ego suite green; 150 tests across the merged 2A+2B surface pass.
- E2E on a copy of the live DB: revise bumps the revision and rewrites content → a stale-digest resolve is **refused** → the current-revision resolve **succeeds** (TOCTOU closed, 9/9 checks).
- Live parser E2E: real reconcile CC calls parse cleanly, verdicts and target ids correct.
- Reviews: genesis-architect (design) + adversarial impl review — both "mechanics solid"; findings folded in.

Ledger: 930209cb83b545b0aad147b27d005d4b

🤖 Generated with [Claude Code](https://claude.com/claude-code)