### PR TITLE
feat(hooks): deterministic review-coverage manifest in the review reminder

### DIFF
--- a/scripts/review_enforcement_prompt.py
+++ b/scripts/review_enforcement_prompt.py
@@ -58,11 +58,15 @@ def main() -> None:
         "result (e.g., if you wired a notification, confirm it actually sends; "
         "if you fixed a data path, confirm the data actually flows). "
         "Ask: 'If the system restarts now, will this actually work?' "
-        "If you cannot answer yes WITH EVIDENCE, you are not done."
+        "If you cannot answer yes WITH EVIDENCE, you are not done.",
+        flush=True,  # flush BEFORE the manifest's git calls: hook stdout is
+        # block-buffered (piped), so if the manifest git work overruns the 10s
+        # hook timeout and Python is killed, the base reminder must already be out.
     )
 
     # Additive: deterministic per-file review-scope manifest. Fully fail-open —
     # any import/build error is swallowed so the base reminder above stands alone.
+    # build_manifest self-bounds its total git time under the hook timeout.
     try:
         from review_scope import build_manifest, render_reminder_block
 

--- a/scripts/review_enforcement_prompt.py
+++ b/scripts/review_enforcement_prompt.py
@@ -37,7 +37,10 @@ def main() -> None:
     if is_review_current():
         sys.exit(0)
 
-    # Unreviewed changes exist — inject warning
+    # Unreviewed changes exist — inject the base reminder UNCONDITIONALLY first.
+    # The deterministic review-scope manifest below is strictly ADDITIVE: it is
+    # built and appended behind its own guards so a manifest error can never
+    # truncate or suppress this core reminder.
     print(
         "MANDATORY: Unreviewed code changes detected. "
         "You MUST run /review and dispatch the superpowers:code-reviewer agent "
@@ -57,6 +60,17 @@ def main() -> None:
         "Ask: 'If the system restarts now, will this actually work?' "
         "If you cannot answer yes WITH EVIDENCE, you are not done."
     )
+
+    # Additive: deterministic per-file review-scope manifest. Fully fail-open —
+    # any import/build error is swallowed so the base reminder above stands alone.
+    try:
+        from review_scope import build_manifest, render_reminder_block
+
+        block = render_reminder_block(build_manifest())
+        if block:
+            print("\n" + block)
+    except Exception:  # noqa: BLE001 - manifest is best-effort, never load-bearing
+        pass
 
 
 if __name__ == "__main__":

--- a/scripts/review_scope.py
+++ b/scripts/review_scope.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Deterministic per-file review-coverage manifest.
+
+Genesis's ``/review`` dispatches specialist reviewers by aggregate scope
+signals, but each specialist independently runs ``git diff`` and self-selects
+hunks — nothing enumerates the changed files or guarantees each is covered, so
+on a large changeset a file can go unreviewed by all of them. This module emits
+a deterministic manifest of the branch changeset (merge-base..working-tree) that
+``review_enforcement_prompt.py`` injects into the review reminder, naming every
+code file that MUST be covered. It is model-independent and strictly additive:
+never blocks, never gates — an annotation on top of the existing reminder.
+
+Design (self-contained ON PURPOSE):
+  * NO ``import genesis`` — the enforcement hooks run on the MAIN repo's venv
+    even from a worktree (editable install → main's ``src``), and the gstack
+    skill lives in ``~/.claude`` (absent on most installs). The only repo reuse
+    is the sibling ``_is_docs_or_config`` (github-aware), imported the same way
+    the other enforcement hooks import their siblings.
+  * ``scope_tag`` is ONE category per file, FIRST-MATCH-WINS, in the exact case
+    order of ``~/.claude/skills/gstack/bin/gstack-diff-scope`` (the source of
+    truth — kept in sync by ``test_review_scope.py``'s conformance test). A
+    multi-tag port would over-set the aggregate specialist gating (e.g.
+    ``auth_controller.py`` must resolve to API only, never AUTH).
+  * ``category`` (code/test/fixture/docs-config) is a SEPARATE axis from
+    ``scope_tag``; the MUST-cover list is the ``code`` files, decided by the
+    github-aware ``_is_docs_or_config`` so ``.github/`` workflows stay in-scope.
+  * ``diff_lines`` is the UNFILTERED whole-diff line sum (matches the skill's
+    ``<50`` specialist-skip gate).
+  * Everything fail-opens to ``None`` — ``timeout=10`` on every git call (it
+    runs on every user prompt), and any git error yields ``None`` so the hook
+    prints its base reminder unchanged.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+
+# Reuse ONLY the sibling github-aware docs/config classifier (scripts/ is not a
+# package — same sys.path trick the other enforcement hooks use).
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+try:
+    from review_enforcement_commit import _is_docs_or_config
+except ImportError:  # pragma: no cover - sibling always present in scripts/
+
+    def _is_docs_or_config(path: str) -> bool:
+        _, ext = os.path.splitext(path)
+        return ext.lower() in {".md", ".rst", ".txt", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
+
+
+_GIT_TIMEOUT = 10
+_MAX_LISTED_FILES = 50  # LOUD-truncate beyond this; the true total is always printed
+
+# ── scope taxonomy — MIRRORS gstack-diff-scope, first-match-wins ──────────────
+# Order is load-bearing: it is the exact `case` order in
+# ~/.claude/skills/gstack/bin/gstack-diff-scope. fnmatch's `*` spans `/` just
+# like a bash `case` glob, so these patterns match the same paths. If gstack's
+# patterns change (e.g. it grew .mjs/.cjs in #1810), update this list AND the
+# conformance test that pins the two together.
+_SCOPE_PATTERNS: list[tuple[str, tuple[str, ...]]] = [
+    (
+        "frontend",
+        (
+            "*.css",
+            "*.scss",
+            "*.less",
+            "*.sass",
+            "*.pcss",
+            "*.module.css",
+            "*.module.scss",
+            "*.tsx",
+            "*.jsx",
+            "*.vue",
+            "*.svelte",
+            "*.astro",
+            "*.erb",
+            "*.haml",
+            "*.slim",
+            "*.hbs",
+            "*.ejs",
+            "*.html",
+            "tailwind.config.*",
+            "postcss.config.*",
+            "app/views/*",
+            "*/components/*",
+            "styles/*",
+            "css/*",
+            "app/assets/stylesheets/*",
+        ),
+    ),
+    (
+        "prompts",
+        (
+            "*prompt_builder*",
+            "*generation_service*",
+            "*writer_service*",
+            "*designer_service*",
+            "*evaluator*",
+            "*scorer*",
+            "*classifier_service*",
+            "*analyzer*",
+            "*voice*.rb",
+            "*writing*.rb",
+            "*prompt*.rb",
+            "*token*.rb",
+            "app/services/chat_tools/*",
+            "app/services/x_thread_tools/*",
+            "config/system_prompts/*",
+        ),
+    ),
+    (
+        "tests",
+        (
+            "*.test.*",
+            "*.spec.*",
+            "*_test.*",
+            "*_spec.*",
+            "test/*",
+            "tests/*",
+            "spec/*",
+            "__tests__/*",
+            "cypress/*",
+            "e2e/*",
+        ),
+    ),
+    ("docs", ("*.md",)),
+    (
+        "config",
+        (
+            "package.json",
+            "package-lock.json",
+            "yarn.lock",
+            "bun.lock",
+            "bun.lockb",
+            "Gemfile",
+            "Gemfile.lock",
+            "*.yml",
+            "*.yaml",
+            ".github/*",
+            "requirements.txt",
+            "pyproject.toml",
+            "go.mod",
+            "Cargo.toml",
+            "composer.json",
+        ),
+    ),
+    ("migrations", ("db/migrate/*", "*/migrations/*", "alembic/*", "prisma/migrations/*")),
+    (
+        "api",
+        (
+            "*controller*",
+            "*route*",
+            "*endpoint*",
+            "*/api/*",
+            "*.graphql",
+            "*.gql",
+            "openapi.*",
+            "swagger.*",
+        ),
+    ),
+    ("auth", ("*auth*", "*session*", "*jwt*", "*oauth*", "*permission*", "*role*")),
+    (
+        "backend",
+        (
+            "*.rb",
+            "*.py",
+            "*.go",
+            "*.rs",
+            "*.java",
+            "*.php",
+            "*.ex",
+            "*.exs",
+            "*.ts",
+            "*.js",
+            "*.mjs",
+            "*.cjs",
+            "*.mts",
+            "*.cts",
+        ),
+    ),
+]
+
+_TEST_GLOBS = ("*.test.*", "*.spec.*", "*_test.*", "*_spec.*")
+_TEST_DIRS = {"test", "tests", "spec", "__tests__", "cypress", "e2e"}
+
+# Vendored / generated / minified / lockfiles — not our code to review. Mirrors
+# ocr's `default_path` exclusion class (validated by the 2026-08-05 A-B against
+# `ocr review --preview`), plus common generated-artifact shapes. fnmatch `*`
+# spans `/`, so the `*/x/*` forms catch nested occurrences.
+_VENDOR_GLOBS = (
+    "node_modules/*",
+    "*/node_modules/*",
+    "vendor/*",
+    "*/vendor/*",
+    "dist/*",
+    "*/dist/*",
+    "build/*",
+    "*/build/*",
+    ".venv/*",
+    "*/.venv/*",
+    "*/site-packages/*",
+    "*.min.js",
+    "*.min.css",
+    "*.map",
+    "*.lock",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "bun.lockb",
+    "*_pb2.py",
+    "*_pb2_grpc.py",
+    "*.generated.*",
+    "generated/*",
+    "*/generated/*",
+)
+
+
+def _is_vendored(path: str) -> bool:
+    p = path.replace("\\", "/")
+    return any(fnmatch.fnmatchcase(p, g) for g in _VENDOR_GLOBS)
+
+
+def _scope_tag(path: str) -> str:
+    """Single gstack scope category for a path (first-match-wins), or "" if none."""
+    p = path.replace("\\", "/")
+    for tag, patterns in _SCOPE_PATTERNS:
+        if any(fnmatch.fnmatchcase(p, pat) for pat in patterns):
+            return tag
+    return ""
+
+
+def _category(path: str) -> str:
+    """Coverage axis: fixture | test | docs-config | code (independent of scope_tag).
+
+    Test/fixture path membership is checked BEFORE docs/config so a data asset
+    UNDER a test tree (``tests/fixtures/case.yaml``, ``tests/config.yml``,
+    ``tests/snapshots/out.md``) is classified as a reviewable test/fixture — not
+    silently dropped as ``docs-config``. Genuine docs/config (README.md,
+    config/app.yaml, pyproject.toml) still excludes via the github-aware sibling
+    ``_is_docs_or_config`` (so a ``.github/`` workflow stays code, never docs).
+    """
+    p = path.replace("\\", "/")
+    parts = p.split("/")
+    base = parts[-1]
+    if "fixtures" in parts:
+        return "fixture"
+    if any(fnmatch.fnmatchcase(base, g) for g in _TEST_GLOBS):
+        return "test"
+    if any(d in _TEST_DIRS for d in parts[:-1]):
+        return "test"
+    if _is_docs_or_config(p):
+        return "docs-config"
+    return "code"
+
+
+def _specialists(scope_tags: set[str], diff_lines: int) -> list[str]:
+    """Scope-indicated specialist set, BEFORE the skill's adaptive/hit-rate gating.
+
+    Mirrors the gstack skill's gating (SKILL.md Step 4.5): under 50 changed
+    lines the skill skips all specialists; otherwise Testing+Maintainability are
+    always-on and the rest are conditional on aggregate scope flags.
+    """
+    if diff_lines < 50:
+        return []
+    picked = {"testing", "maintainability"}
+    if "auth" in scope_tags or ("backend" in scope_tags and diff_lines > 100):
+        picked.add("security")
+    if "backend" in scope_tags or "frontend" in scope_tags:
+        picked.add("performance")
+    if "migrations" in scope_tags:
+        picked.add("data-migration")
+    if "api" in scope_tags:
+        picked.add("api-contract")
+    if "frontend" in scope_tags:
+        picked.add("design")
+    return sorted(picked)
+
+
+# ── git plumbing — fail-open, always timed ────────────────────────────────────
+def _git(args: list[str], cwd: str | None) -> str | None:
+    """Run a git command; return stdout, or None on ANY error (fail-open)."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+            cwd=cwd,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError, UnicodeDecodeError):
+        # UnicodeDecodeError: text=True strict-decodes stdout; a filename with
+        # invalid UTF-8 bytes would otherwise raise it (not an OSError subclass)
+        # and crash a standalone `main()` call, violating the fail-open contract.
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _base_ref(cwd: str | None) -> str | None:
+    """Resolve the base ref to diff against.
+
+    Primary: ``origin/HEAD`` symbolic ref. But that is UNSET on most fresh
+    clones / CI checkouts, so the fallback chain (origin/main → origin/master →
+    main → master) is the common path, not a rare one.
+    """
+    out = _git(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], cwd)
+    if out and out.strip().startswith("refs/remotes/"):
+        return out.strip()[len("refs/remotes/") :]  # e.g. "origin/main"
+    for cand in ("origin/main", "origin/master", "main", "master"):
+        if _git(["rev-parse", "--verify", "--quiet", cand], cwd) not in (None, ""):
+            return cand
+    return None
+
+
+def _merge_base(base: str, cwd: str | None) -> str | None:
+    out = _git(["merge-base", base, "HEAD"], cwd)
+    if not out or not out.strip():
+        return None
+    return out.strip()
+
+
+def _parse_name_status_z(text: str) -> list[dict]:
+    """Parse ``git diff -z --name-status -M`` (NUL-delimited) into per-file records.
+
+    -z emits paths VERBATIM (no quoting/escaping), so paths containing tabs or
+    newlines parse correctly — unlike the default tab-and-newline format. Tokens:
+    ``<status>\\0<path>\\0`` for A/M/D; ``<status>\\0<src>\\0<dst>\\0`` for R/C,
+    where the DEST is the current reviewable file.
+    """
+    tokens = text.split("\x00")
+    files: list[dict] = []
+    i = 0
+    n = len(tokens)
+    while i < n:
+        status = tokens[i]
+        if not status:  # trailing empty token after the final NUL
+            i += 1
+            continue
+        ct = status[:1]
+        if ct in ("R", "C"):
+            if i + 2 >= n:
+                break  # malformed tail — stop rather than misparse
+            path = tokens[i + 2]  # dst
+            i += 3
+        else:
+            if i + 1 >= n:
+                break
+            path = tokens[i + 1]
+            i += 2
+        if path:
+            files.append({"path": path, "change_type": ct})
+    return files
+
+
+def _parse_numstat_z(text: str) -> tuple[int, set[str]]:
+    """Return (total added+deleted across ALL files, set of binary file paths).
+
+    Parses ``git diff -z --numstat -M`` (NUL-delimited, verbatim paths). Record
+    shapes: ``<added>\\t<deleted>\\t<path>\\0`` for a normal file, and
+    ``<added>\\t<deleted>\\t\\0<src>\\0<dst>\\0`` for a rename/copy (the stats
+    token ends with a trailing tab and the two paths follow as separate NUL
+    tokens). diff_lines is UNFILTERED (matches the skill's <50 gate); binary rows
+    carry ``-`` counts and contribute no lines but ARE collected so the caller can
+    exclude them (a binary can't be code-reviewed).
+    """
+    tokens = text.split("\x00")
+    total = 0
+    binary: set[str] = set()
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if not tok:
+            i += 1
+            continue
+        parts = tok.split("\t")
+        if len(parts) < 3:
+            i += 1
+            continue
+        # A path may itself contain literal tabs (verbatim under -z); rejoin
+        # everything past the two count fields so it isn't truncated (else the
+        # binary path wouldn't match the -z name-status path and the file would
+        # wrongly stay reviewable).
+        added, deleted = parts[0], parts[1]
+        inline_path = "\t".join(parts[2:])
+        if inline_path == "":  # rename/copy: dst is the token after next (src)
+            path = tokens[i + 2] if i + 2 < n else ""
+            i += 3
+        else:
+            path = inline_path
+            i += 1
+        if added == "-" or deleted == "-":  # binary
+            if path:
+                binary.add(path)
+            continue
+        try:
+            total += int(added) + int(deleted)
+        except ValueError:
+            continue
+    return total, binary
+
+
+def build_manifest(cwd: str | None = None, base: str | None = None) -> dict | None:
+    """Build the review-coverage manifest for the branch changeset, or None.
+
+    Returns ``{base, diff_lines, counts, files:[{path,change_type,category,
+    scope_tag}], specialists}``. None on any git failure / no resolvable base /
+    no merge-base — the caller then prints its base reminder unchanged.
+    """
+    base_ref = base or _base_ref(cwd)
+    if not base_ref:
+        return None
+    mb = _merge_base(base_ref, cwd)
+    if not mb:
+        return None
+    name_status = _git(["diff", "-z", "--name-status", "-M", mb], cwd)
+    if name_status is None:
+        return None
+
+    # Fail-open must be all-or-nothing: if numstat fails after name-status
+    # succeeded, a partial manifest would carry a WRONG diff_lines (→ wrong
+    # specialist gating) and skip binary exclusion. Return None instead.
+    numstat = _git(["diff", "-z", "--numstat", "-M", mb], cwd)
+    if numstat is None:
+        return None
+    diff_lines, binary_paths = _parse_numstat_z(numstat)
+
+    records = _parse_name_status_z(name_status)
+    counts = {
+        "code": 0,
+        "test": 0,
+        "fixture": 0,
+        "docs-config": 0,
+        "review_required": 0,
+        "excluded": 0,
+    }
+    scope_tags: set[str] = set()
+    files: list[dict] = []
+    for rec in records:
+        path = rec["path"]
+        category = _category(path)
+        tag = _scope_tag(path)
+        counts[category] = counts.get(category, 0) + 1
+
+        # Reviewability is a SEPARATE decision from category. Exclude what can't
+        # or shouldn't be code-reviewed, in precedence order: binary (can't) →
+        # vendored/generated (not ours) → docs-config (Genesis policy: docs-only
+        # commits are review-exempt, matching the commit gate's _is_docs_or_config).
+        # Everything else — code, tests, fixtures — MUST be covered.
+        if path in binary_paths:
+            reason: str | None = "binary"
+        elif _is_vendored(path):
+            reason = "vendored"
+        elif category == "docs-config":
+            reason = "docs"
+        else:
+            reason = None
+        review_required = reason is None
+
+        if review_required:
+            counts["review_required"] += 1
+            if tag:
+                scope_tags.add(tag)  # excluded files don't drive specialist gating
+        else:
+            counts["excluded"] += 1
+
+        files.append(
+            {
+                "path": path,
+                "change_type": rec["change_type"],
+                "category": category,
+                "scope_tag": tag,
+                "review_required": review_required,
+                "exclude_reason": reason,
+            }
+        )
+
+    return {
+        "base": base_ref,
+        "diff_lines": diff_lines,
+        "counts": counts,
+        "files": files,
+        "specialists": _specialists(scope_tags, diff_lines),
+    }
+
+
+def render_reminder_block(manifest: dict | None) -> str:
+    """Human-readable manifest for the review reminder, or "" when nothing to add.
+
+    Returns "" for a missing manifest or a changeset with no reviewable files
+    (docs/binary/vendored-only) — the hook then prints only its base reminder.
+    Lists the reviewable set (code + tests + fixtures), and accounts for excluded
+    files with a count so nothing is silently dropped.
+    """
+    if not manifest:
+        return ""
+    reviewable = [f for f in manifest.get("files", []) if f.get("review_required")]
+    if not reviewable:
+        return ""
+
+    total = len(reviewable)
+    lines = [
+        f"DETERMINISTIC REVIEW SCOPE — these {total} file(s) MUST each be covered "
+        f"by the review (branch changeset vs {manifest.get('base', '?')}):"
+    ]
+    for f in reviewable[:_MAX_LISTED_FILES]:
+        tag = f.get("scope_tag") or f.get("category") or f.get("change_type", "?")
+        lines.append(f"  - {f['path']} [{tag}]")
+    if total > _MAX_LISTED_FILES:
+        lines.append(f"  … and {total - _MAX_LISTED_FILES} more ({total} files total)")
+
+    excluded = manifest.get("counts", {}).get("excluded", 0)
+    if excluded:
+        lines.append(
+            f"  ({excluded} other changed file(s) excluded — docs/binary/vendored, "
+            "not reviewable code)"
+        )
+
+    specialists = manifest.get("specialists") or []
+    if specialists:
+        lines.append(
+            "Scope-indicated specialists (BEFORE the skill's adaptive/hit-rate "
+            "gating; treat as input, not a verdict): " + ", ".join(specialists) + "."
+        )
+    else:
+        lines.append(
+            f"Changeset is {manifest.get('diff_lines', 0)} lines (<50) — /review "
+            "skips specialists; still cover every file above."
+        )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    as_json = "--json" in sys.argv
+    base = None
+    if "--base" in sys.argv:
+        i = sys.argv.index("--base")
+        if i + 1 < len(sys.argv):
+            base = sys.argv[i + 1]
+    manifest = build_manifest(base=base)
+    if as_json:
+        print(json.dumps(manifest, indent=2))
+        return
+    if manifest is None:
+        print("No review manifest (no resolvable base / merge-base / not a git repo).")
+        return
+    block = render_reminder_block(manifest)
+    print(block or f"No reviewable files in changeset ({manifest['counts']}).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/review_scope.py
+++ b/scripts/review_scope.py
@@ -38,6 +38,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 
 # Reuse ONLY the sibling github-aware docs/config classifier (scripts/ is not a
 # package — same sys.path trick the other enforcement hooks use).
@@ -53,7 +54,13 @@ except ImportError:  # pragma: no cover - sibling always present in scripts/
         return ext.lower() in {".md", ".rst", ".txt", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
 
 
-_GIT_TIMEOUT = 10
+_GIT_TIMEOUT = 10  # per-call ceiling when no deadline is in force
+# The UserPromptSubmit hook runs with a 10s timeout. build_manifest bounds its
+# TOTAL serial git time under that so it never overruns the hook (which, on a
+# block-buffered pipe, could otherwise get killed before the base reminder flushes
+# — but the hook flushes first, so the worst case is a missing manifest, never a
+# missing reminder). Headroom left for the reminder print + Python startup.
+_MANIFEST_GIT_BUDGET = 6.0
 _MAX_LISTED_FILES = 50  # LOUD-truncate beyond this; the true total is always printed
 
 # ── scope taxonomy — MIRRORS gstack-diff-scope, first-match-wins ──────────────
@@ -282,14 +289,25 @@ def _specialists(scope_tags: set[str], diff_lines: int) -> list[str]:
 
 
 # ── git plumbing — fail-open, always timed ────────────────────────────────────
-def _git(args: list[str], cwd: str | None) -> str | None:
-    """Run a git command; return stdout, or None on ANY error (fail-open)."""
+def _git(args: list[str], cwd: str | None, deadline: float | None = None) -> str | None:
+    """Run a git command; return stdout, or None on ANY error (fail-open).
+
+    ``deadline`` (a ``time.monotonic()`` value) caps the per-call timeout by the
+    time remaining in the manifest's total git budget — so several serial calls
+    can't collectively overrun the hook timeout. Past the deadline → None.
+    """
+    timeout = _GIT_TIMEOUT
+    if deadline is not None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        timeout = min(_GIT_TIMEOUT, remaining)
     try:
         result = subprocess.run(
             ["git", *args],
             capture_output=True,
             text=True,
-            timeout=_GIT_TIMEOUT,
+            timeout=timeout,
             cwd=cwd,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError, UnicodeDecodeError):
@@ -302,24 +320,24 @@ def _git(args: list[str], cwd: str | None) -> str | None:
     return result.stdout
 
 
-def _base_ref(cwd: str | None) -> str | None:
+def _base_ref(cwd: str | None, deadline: float | None = None) -> str | None:
     """Resolve the base ref to diff against.
 
     Primary: ``origin/HEAD`` symbolic ref. But that is UNSET on most fresh
     clones / CI checkouts, so the fallback chain (origin/main → origin/master →
     main → master) is the common path, not a rare one.
     """
-    out = _git(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], cwd)
+    out = _git(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], cwd, deadline)
     if out and out.strip().startswith("refs/remotes/"):
         return out.strip()[len("refs/remotes/") :]  # e.g. "origin/main"
     for cand in ("origin/main", "origin/master", "main", "master"):
-        if _git(["rev-parse", "--verify", "--quiet", cand], cwd) not in (None, ""):
+        if _git(["rev-parse", "--verify", "--quiet", cand], cwd, deadline) not in (None, ""):
             return cand
     return None
 
 
-def _merge_base(base: str, cwd: str | None) -> str | None:
-    out = _git(["merge-base", base, "HEAD"], cwd)
+def _merge_base(base: str, cwd: str | None, deadline: float | None = None) -> str | None:
+    out = _git(["merge-base", base, "HEAD"], cwd, deadline)
     if not out or not out.strip():
         return None
     return out.strip()
@@ -330,8 +348,11 @@ def _parse_name_status_z(text: str) -> list[dict]:
 
     -z emits paths VERBATIM (no quoting/escaping), so paths containing tabs or
     newlines parse correctly — unlike the default tab-and-newline format. Tokens:
-    ``<status>\\0<path>\\0`` for A/M/D; ``<status>\\0<src>\\0<dst>\\0`` for R/C,
-    where the DEST is the current reviewable file.
+    ``<status>\\0<path>\\0`` for A/M/D; ``<status>\\0<src>\\0<dst>\\0`` for R/C.
+    For a rename/copy BOTH sides are emitted as records (mirroring the commit
+    gate's ``_staged_files``): a rename FROM reviewable code TO an excluded dest
+    (``src/auth.py -> README.md``) would otherwise drop the removed code from
+    coverage entirely.
     """
     tokens = text.split("\x00")
     files: list[dict] = []
@@ -346,15 +367,18 @@ def _parse_name_status_z(text: str) -> list[dict]:
         if ct in ("R", "C"):
             if i + 2 >= n:
                 break  # malformed tail — stop rather than misparse
-            path = tokens[i + 2]  # dst
+            src, dst = tokens[i + 1], tokens[i + 2]
             i += 3
+            for p in (src, dst):  # both sides — either may be the reviewable one
+                if p:
+                    files.append({"path": p, "change_type": ct})
         else:
             if i + 1 >= n:
                 break
             path = tokens[i + 1]
             i += 2
-        if path:
-            files.append({"path": path, "change_type": ct})
+            if path:
+                files.append({"path": path, "change_type": ct})
     return files
 
 
@@ -413,20 +437,23 @@ def build_manifest(cwd: str | None = None, base: str | None = None) -> dict | No
     scope_tag}], specialists}``. None on any git failure / no resolvable base /
     no merge-base — the caller then prints its base reminder unchanged.
     """
-    base_ref = base or _base_ref(cwd)
+    # Bound TOTAL serial git time under the 10s hook timeout (the base reminder is
+    # already flushed, so an overrun only costs the manifest, never the reminder).
+    deadline = time.monotonic() + _MANIFEST_GIT_BUDGET
+    base_ref = base or _base_ref(cwd, deadline)
     if not base_ref:
         return None
-    mb = _merge_base(base_ref, cwd)
+    mb = _merge_base(base_ref, cwd, deadline)
     if not mb:
         return None
-    name_status = _git(["diff", "-z", "--name-status", "-M", mb], cwd)
+    name_status = _git(["diff", "-z", "--name-status", "-M", mb], cwd, deadline)
     if name_status is None:
         return None
 
     # Fail-open must be all-or-nothing: if numstat fails after name-status
     # succeeded, a partial manifest would carry a WRONG diff_lines (→ wrong
     # specialist gating) and skip binary exclusion. Return None instead.
-    numstat = _git(["diff", "-z", "--numstat", "-M", mb], cwd)
+    numstat = _git(["diff", "-z", "--numstat", "-M", mb], cwd, deadline)
     if numstat is None:
         return None
     diff_lines, binary_paths = _parse_numstat_z(numstat)

--- a/tests/test_scripts/test_review_scope.py
+++ b/tests/test_scripts/test_review_scope.py
@@ -406,10 +406,10 @@ def test_build_manifest_fail_open_when_numstat_fails(tmp_path, monkeypatch):
     _git(repo, "commit", "-qm", "work")
     real_git = _rs._git
 
-    def fake_git(args, cwd):
+    def fake_git(args, cwd, deadline=None):
         if "--numstat" in args:
             return None
-        return real_git(args, cwd)
+        return real_git(args, cwd, deadline)
 
     monkeypatch.setattr(_rs, "_git", fake_git)
     assert _rs.build_manifest(cwd=str(repo)) is None
@@ -420,7 +420,8 @@ def test_parse_name_status_z_handles_rename_and_tab_paths():
     text = "M\x00src/a.py\x00A\x00weird\tname.py\x00R100\x00old.py\x00new.py\x00"
     recs = _rs._parse_name_status_z(text)
     got = {r["path"]: r["change_type"] for r in recs}
-    assert got == {"src/a.py": "M", "weird\tname.py": "A", "new.py": "R"}
+    # Rename emits BOTH sides now (src+dst) so a code source isn't dropped.
+    assert got == {"src/a.py": "M", "weird\tname.py": "A", "old.py": "R", "new.py": "R"}
 
 
 def test_parse_numstat_z_normal_binary_and_rename():
@@ -446,6 +447,47 @@ def test_git_fail_open_on_unicode_decode_error(monkeypatch):
 
     monkeypatch.setattr(_rs.subprocess, "run", boom)
     assert _rs._git(["diff"], None) is None
+
+
+def test_git_returns_none_past_deadline(monkeypatch):
+    # Codex P2: a deadline in the past must short-circuit to None (bounds the
+    # manifest's total git time under the hook timeout) without even calling git.
+    called = {"n": 0}
+
+    def spy(*a, **k):
+        called["n"] += 1
+        raise AssertionError("should not run past deadline")
+
+    monkeypatch.setattr(_rs.subprocess, "run", spy)
+    assert _rs._git(["diff"], None, deadline=_rs.time.monotonic() - 1) is None
+    assert called["n"] == 0
+
+
+def test_parse_name_status_z_rename_emits_both_sides():
+    # Codex P2: rename FROM reviewable code TO an excluded dest must still surface
+    # the source, else removed code is dropped from coverage.
+    text = "R100\x00src/auth.py\x00README.md\x00"
+    recs = _rs._parse_name_status_z(text)
+    paths = {r["path"] for r in recs}
+    assert paths == {"src/auth.py", "README.md"}
+    assert all(r["change_type"] == "R" for r in recs)
+
+
+def test_build_manifest_rename_to_docs_keeps_code_source(tmp_path):
+    repo = _mk_repo(tmp_path)
+    (repo / "auth.py").write_text("def login():\n    return 1\n" * 20)
+    _git(repo, "add", "auth.py")
+    _git(repo, "commit", "-qm", "add code")
+    base_tip = _git(repo, "rev-parse", "HEAD").strip()
+    _git(repo, "checkout", "-q", "-b", "feat/rename-to-docs")
+    _git(repo, "mv", "auth.py", "NOTES.md")  # code -> docs rename
+    _git(repo, "commit", "-qm", "rename to docs")
+    m = _rs.build_manifest(cwd=str(repo), base=base_tip)
+    assert m is not None
+    reviewable = {f["path"] for f in m["files"] if f["review_required"]}
+    assert "auth.py" in reviewable  # removed code still named
+    excluded = {f["path"] for f in m["files"] if not f["review_required"]}
+    assert "NOTES.md" in excluded  # docs dest excluded
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_scripts/test_review_scope.py
+++ b/tests/test_scripts/test_review_scope.py
@@ -1,0 +1,492 @@
+"""Tests for scripts/review_scope.py — the deterministic review-coverage manifest.
+
+The manifest enumerates the branch changeset (merge-base..working-tree) so the
+review reminder can name every code file that MUST be covered — closing the gap
+where /review specialists each self-select hunks and a file can go unreviewed.
+
+Invariants under test (architect-reviewed 2026-08-05):
+  * scope_tag is ONE category per file, FIRST-MATCH-WINS in gstack's case order
+    (a multi-tag port would over-set aggregate specialist gating);
+  * category (code/test/fixture/docs-config) is a SEPARATE axis via the
+    github-aware `_is_docs_or_config`, so `.github/` workflows stay in-scope;
+  * diff_lines is the UNFILTERED whole-diff sum (matches the skill's <50 gate);
+  * everything fail-opens to None (never crashes/blocks the enforcement hook);
+  * the hook prints its base reminder UNCONDITIONALLY, manifest strictly additive.
+
+All git fixtures are synthetic tmp_path repos — no dependence on the live repo,
+network, or gh auth (install-agnostic).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+_SCRIPT_PATH = _SCRIPTS / "review_scope.py"
+_spec = importlib.util.spec_from_file_location("review_scope", _SCRIPT_PATH)
+_rs = importlib.util.module_from_spec(_spec)
+sys.modules["review_scope"] = _rs
+_spec.loader.exec_module(_rs)
+
+
+# --------------------------------------------------------------------------- #
+# git fixture helper
+# --------------------------------------------------------------------------- #
+def _git(repo: Path, *args: str) -> str:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    out = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return out.stdout
+
+
+def _mk_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "seed.md").write_text("seed\n")
+    _git(repo, "add", "seed.md")
+    _git(repo, "commit", "-qm", "seed")
+    return repo
+
+
+# --------------------------------------------------------------------------- #
+# _scope_tag — ONE tag per file, first-match-wins (gstack case order)
+# --------------------------------------------------------------------------- #
+def test_scope_tag_auth_controller_is_api_not_auth():
+    # THE critical regression: gstack matches *controller* (API) before *auth*.
+    assert _rs._scope_tag("app/auth_controller.py") == "api"
+
+
+def test_scope_tag_evaluator_is_prompts_not_backend():
+    assert _rs._scope_tag("services/foo_evaluator.py") == "prompts"
+
+
+def test_scope_tag_tests_path_is_tests_not_migrations():
+    assert _rs._scope_tag("tests/db/migrations/test_x.py") == "tests"
+
+
+def test_scope_tag_github_workflow_is_config():
+    assert _rs._scope_tag(".github/workflows/ci.yml") == "config"
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("src/App.tsx", "frontend"),
+        ("web/styles.css", "frontend"),
+        ("src/core/engine.py", "backend"),
+        ("cmd/main.go", "backend"),
+        ("lib/util.mjs", "backend"),
+        ("alembic/versions/0001_x.py", "migrations"),
+        ("src/api/routes.py", "api"),
+        ("auth/session_store.py", "auth"),
+        ("docs/guide.md", "docs"),
+        ("notes.txt", ""),  # unmatched by any gstack case
+    ],
+)
+def test_scope_tag_table(path, expected):
+    assert _rs._scope_tag(path) == expected
+
+
+# --------------------------------------------------------------------------- #
+# _category — code/test/fixture/docs-config (github-aware, separate axis)
+# --------------------------------------------------------------------------- #
+def test_category_github_workflow_is_code():
+    # _is_docs_or_config returns False for .github/ → must be reviewed as code.
+    assert _rs._category(".github/workflows/ci.yml") == "code"
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("README.md", "docs-config"),
+        ("config/app.yaml", "docs-config"),
+        ("src/core/engine.py", "code"),
+        ("tests/test_engine.py", "test"),
+        ("tests/fixtures/sample.json", "fixture"),
+    ],
+)
+def test_category_table(path, expected):
+    assert _rs._category(path) == expected
+
+
+# --------------------------------------------------------------------------- #
+# _specialists — aggregate scope OR → skill gating thresholds
+# --------------------------------------------------------------------------- #
+def test_specialists_small_diff_none():
+    assert _rs._specialists({"backend"}, 40) == []
+
+
+def test_specialists_backend_under_100_no_security():
+    got = set(_rs._specialists({"backend"}, 60))
+    assert got == {"testing", "maintainability", "performance"}
+
+
+def test_specialists_backend_over_100_adds_security():
+    got = set(_rs._specialists({"backend"}, 150))
+    assert got == {"testing", "maintainability", "performance", "security"}
+
+
+def test_specialists_auth_triggers_security_not_performance():
+    got = set(_rs._specialists({"auth"}, 60))
+    assert got == {"testing", "maintainability", "security"}
+
+
+def test_specialists_frontend_adds_design_and_performance():
+    got = set(_rs._specialists({"frontend"}, 60))
+    assert got == {"testing", "maintainability", "performance", "design"}
+
+
+def test_specialists_migrations_and_api():
+    got = set(_rs._specialists({"migrations", "api"}, 60))
+    assert got == {"testing", "maintainability", "data-migration", "api-contract"}
+
+
+# --------------------------------------------------------------------------- #
+# build_manifest — integration against real tmp git repos
+# --------------------------------------------------------------------------- #
+def test_build_manifest_enumerates_branch_changeset(tmp_path):
+    repo = _mk_repo(tmp_path)
+    _git(repo, "checkout", "-q", "-b", "feat/x")
+    (repo / "src").mkdir()
+    (repo / "src" / "engine.py").write_text("def f():\n    return 1\n" * 30)
+    (repo / "README.md").write_text("seed\nmore docs\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "work")
+
+    m = _rs.build_manifest(cwd=str(repo))
+    assert m is not None
+    paths = {f["path"] for f in m["files"]}
+    assert "src/engine.py" in paths
+    assert "README.md" in paths
+    eng = next(f for f in m["files"] if f["path"] == "src/engine.py")
+    assert eng["category"] == "code"
+    assert eng["scope_tag"] == "backend"
+    assert m["counts"]["code"] >= 1
+    assert m["diff_lines"] >= 30  # unfiltered: counts docs too
+
+
+def test_build_manifest_includes_uncommitted_worktree(tmp_path):
+    # Two-dot `git diff <merge-base>` must include NOT-yet-committed changes
+    # (staged + tracked working-tree edits) — matching the specialists' exact
+    # `git diff $DIFF_BASE`. Note: truly UNTRACKED (never `git add`ed) files are
+    # invisible to `git diff` and thus to the specialists too, so they are
+    # correctly absent from the manifest — they aren't part of the changeset.
+    repo = _mk_repo(tmp_path)
+    _git(repo, "checkout", "-q", "-b", "feat/y")
+    (repo / "live.py").write_text("x = 1\n")
+    _git(repo, "add", "live.py")  # staged, uncommitted → in the changeset
+    (repo / "seed.md").write_text("seed\nedited unstaged\n")  # tracked, unstaged
+    m = _rs.build_manifest(cwd=str(repo))
+    assert m is not None
+    paths = {f["path"] for f in m["files"]}
+    assert "live.py" in paths  # staged new file appears
+    assert "seed.md" in paths  # unstaged tracked edit appears
+
+
+def test_build_manifest_rename_captured(tmp_path):
+    repo = _mk_repo(tmp_path)
+    (repo / "old.py").write_text("y = 2\n" * 20)
+    _git(repo, "add", "old.py")
+    _git(repo, "commit", "-qm", "add old")
+    base_tip = _git(repo, "rev-parse", "HEAD").strip()
+    _git(repo, "checkout", "-q", "-b", "feat/rename")
+    _git(repo, "mv", "old.py", "new.py")
+    _git(repo, "commit", "-qm", "rename")
+    m = _rs.build_manifest(cwd=str(repo), base=base_tip)
+    assert m is not None
+    paths = {f["path"] for f in m["files"]}
+    assert "new.py" in paths  # dest side captured, no crash
+
+
+def test_build_manifest_includes_test_files_as_reviewable(tmp_path):
+    # A-B finding (vs ocr): test files ARE reviewable and must appear in the
+    # coverage set (Testing specialist owns them) — not dropped like docs.
+    repo = _mk_repo(tmp_path)
+    _git(repo, "checkout", "-q", "-b", "feat/tests")
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_new.py").write_text("def test_a():\n    assert True\n" * 10)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "tests")
+    m = _rs.build_manifest(cwd=str(repo))
+    assert m is not None
+    rec = next(f for f in m["files"] if f["path"] == "tests/test_new.py")
+    assert rec["category"] == "test"
+    assert rec["review_required"] is True
+    assert rec["exclude_reason"] is None
+
+
+def test_build_manifest_excludes_binary(tmp_path):
+    repo = _mk_repo(tmp_path)
+    _git(repo, "checkout", "-q", "-b", "feat/bin")
+    (repo / "logo.png").write_bytes(b"\x89PNG\r\n\x00\x00binary\x00data\xff\xfe")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "bin")
+    m = _rs.build_manifest(cwd=str(repo))
+    assert m is not None
+    rec = next(f for f in m["files"] if f["path"] == "logo.png")
+    assert rec["review_required"] is False
+    assert rec["exclude_reason"] == "binary"
+
+
+def test_build_manifest_excludes_vendored(tmp_path):
+    repo = _mk_repo(tmp_path)
+    _git(repo, "checkout", "-q", "-b", "feat/vendor")
+    (repo / "node_modules").mkdir()
+    (repo / "node_modules" / "lib.js").write_text("module.exports = 1\n" * 10)
+    (repo / "app.min.js").write_text("var a=1;\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "vendor")
+    m = _rs.build_manifest(cwd=str(repo))
+    assert m is not None
+    vend = next(f for f in m["files"] if f["path"] == "node_modules/lib.js")
+    assert vend["review_required"] is False
+    assert vend["exclude_reason"] == "vendored"
+    minified = next(f for f in m["files"] if f["path"] == "app.min.js")
+    assert minified["review_required"] is False
+    assert minified["exclude_reason"] == "vendored"
+
+
+def test_build_manifest_fail_open_outside_git(tmp_path):
+    non_repo = tmp_path / "plain"
+    non_repo.mkdir()
+    assert _rs.build_manifest(cwd=str(non_repo)) is None
+
+
+def test_build_manifest_empty_diff_on_base(tmp_path):
+    # On the base branch with nothing new → no files, but not a crash.
+    repo = _mk_repo(tmp_path)
+    m = _rs.build_manifest(cwd=str(repo))
+    # Either None (no merge-base delta) or an empty file list — never raises.
+    assert m is None or m["files"] == []
+
+
+# --------------------------------------------------------------------------- #
+# render_reminder_block — additive, LOUD truncation, docs-only omission
+# --------------------------------------------------------------------------- #
+def _f(path, category, scope_tag, review_required=True, exclude_reason=None):
+    return {
+        "path": path,
+        "change_type": "M",
+        "category": category,
+        "scope_tag": scope_tag,
+        "review_required": review_required,
+        "exclude_reason": exclude_reason,
+    }
+
+
+def test_render_lists_reviewable_files_and_specialists():
+    manifest = {
+        "base": "abc",
+        "diff_lines": 120,
+        "counts": {"review_required": 1, "excluded": 0},
+        "files": [_f("src/a.py", "code", "backend")],
+        "specialists": ["maintainability", "performance", "testing"],
+    }
+    block = _rs.render_reminder_block(manifest)
+    assert "src/a.py" in block
+    assert "MUST" in block
+    assert "performance" in block
+    assert "before" in block.lower()  # "before adaptive gating" framing
+
+
+def test_render_includes_tests_in_coverage():
+    # A-B finding: ocr reviews test files; the manifest must NOT drop them, else
+    # a test-only PR yields an empty coverage list.
+    manifest = {
+        "base": "abc",
+        "diff_lines": 60,
+        "counts": {"review_required": 1, "excluded": 0},
+        "files": [_f("tests/test_x.py", "test", "tests")],
+        "specialists": ["maintainability", "testing"],
+    }
+    assert "tests/test_x.py" in _rs.render_reminder_block(manifest)
+
+
+def test_render_docs_only_returns_empty():
+    manifest = {
+        "base": "abc",
+        "diff_lines": 10,
+        "counts": {"review_required": 0, "excluded": 1},
+        "files": [
+            _f("README.md", "docs-config", "docs", review_required=False, exclude_reason="docs")
+        ],
+        "specialists": [],
+    }
+    assert _rs.render_reminder_block(manifest) == ""
+
+
+def test_render_accounts_for_excluded_files_loudly():
+    # Excluded files (docs/binary/vendored) are counted, never silently dropped.
+    manifest = {
+        "base": "abc",
+        "diff_lines": 60,
+        "counts": {"review_required": 1, "excluded": 3},
+        "files": [
+            _f("src/a.py", "code", "backend"),
+            _f("logo.png", "code", "", review_required=False, exclude_reason="binary"),
+            _f(
+                "node_modules/x.js",
+                "code",
+                "backend",
+                review_required=False,
+                exclude_reason="vendored",
+            ),
+            _f("README.md", "docs-config", "docs", review_required=False, exclude_reason="docs"),
+        ],
+        "specialists": ["testing", "maintainability"],
+    }
+    block = _rs.render_reminder_block(manifest)
+    assert "src/a.py" in block
+    assert "logo.png" not in block  # excluded files not in the MUST-cover list
+    assert "3" in block  # excluded count surfaced
+
+
+def test_render_truncates_loudly():
+    files = [_f(f"src/f{i}.py", "code", "backend") for i in range(80)]
+    manifest = {
+        "base": "abc",
+        "diff_lines": 800,
+        "counts": {"review_required": 80, "excluded": 0},
+        "files": files,
+        "specialists": ["testing"],
+    }
+    block = _rs.render_reminder_block(manifest)
+    assert "80" in block  # true total surfaced
+    assert "more" in block.lower()  # explicit truncation marker
+
+
+def test_render_none_manifest_is_empty():
+    assert _rs.render_reminder_block(None) == ""
+
+
+# --------------------------------------------------------------------------- #
+# Codex-review fixes: category precedence, numstat fail-open, -z parsing
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("tests/fixtures/case.yaml", "fixture"),  # under tests, .yaml → fixture, NOT docs
+        ("tests/config.yml", "test"),  # under tests, .yml → test, NOT docs
+        ("tests/snapshots/out.md", "test"),  # under tests, .md → test, NOT docs
+        ("config/app.yaml", "docs-config"),  # genuine config → excluded
+        ("docs/guide.md", "docs-config"),  # genuine docs → excluded
+    ],
+)
+def test_category_test_tree_beats_docs(path, expected):
+    # Codex P1: test/fixture path membership must win over docs/config so a data
+    # asset under a test tree is not silently dropped from coverage.
+    assert _rs._category(path) == expected
+
+
+def test_build_manifest_fail_open_when_numstat_fails(tmp_path, monkeypatch):
+    # Codex P1: partial git failure (name-status ok, numstat fails) must return
+    # None — never a manifest with wrong diff_lines / no binary exclusion.
+    repo = _mk_repo(tmp_path)
+    _git(repo, "checkout", "-q", "-b", "feat/partial")
+    (repo / "m.py").write_text("x = 1\n" * 30)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "work")
+    real_git = _rs._git
+
+    def fake_git(args, cwd):
+        if "--numstat" in args:
+            return None
+        return real_git(args, cwd)
+
+    monkeypatch.setattr(_rs, "_git", fake_git)
+    assert _rs.build_manifest(cwd=str(repo)) is None
+
+
+def test_parse_name_status_z_handles_rename_and_tab_paths():
+    # Codex P2: -z emits paths verbatim; a literal tab in a path must survive.
+    text = "M\x00src/a.py\x00A\x00weird\tname.py\x00R100\x00old.py\x00new.py\x00"
+    recs = _rs._parse_name_status_z(text)
+    got = {r["path"]: r["change_type"] for r in recs}
+    assert got == {"src/a.py": "M", "weird\tname.py": "A", "new.py": "R"}
+
+
+def test_parse_numstat_z_normal_binary_and_rename():
+    # normal (5+3), binary (-,- skipped but collected), rename (2+1, dst path).
+    text = "5\t3\tsrc/a.py\x00-\t-\timg.bin\x002\t1\t\x00old.py\x00new.py\x00"
+    total, binary = _rs._parse_numstat_z(text)
+    assert total == 11  # 5+3 + 2+1 ; binary contributes 0
+    assert binary == {"img.bin"}
+
+
+def test_parse_numstat_z_preserves_tab_in_path():
+    # A binary file whose name contains a literal tab: the full path must be
+    # reconstructed (parts[2:] joined) so it matches the -z name-status path.
+    text = "-\t-\tweird\tname.bin\x005\t3\tok\tpath.py\x00"
+    total, binary = _rs._parse_numstat_z(text)
+    assert binary == {"weird\tname.bin"}  # not truncated to "weird"
+    assert total == 8  # the tab-named text file still counts
+
+
+def test_git_fail_open_on_unicode_decode_error(monkeypatch):
+    def boom(*a, **k):
+        raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+    monkeypatch.setattr(_rs.subprocess, "run", boom)
+    assert _rs._git(["diff"], None) is None
+
+
+# --------------------------------------------------------------------------- #
+# hook wiring — base reminder ALWAYS prints; manifest strictly additive
+# --------------------------------------------------------------------------- #
+def _run_prompt_hook(repo: Path) -> str:
+    env = {k: v for k, v in os.environ.items() if k != "GENESIS_CC_SESSION"}
+    out = subprocess.run(
+        [sys.executable, str(_SCRIPTS / "review_enforcement_prompt.py")],
+        capture_output=True,
+        text=True,
+        cwd=str(repo),
+        env=env,
+    )
+    return out.stdout
+
+
+def test_hook_emits_base_reminder_and_manifest_on_unreviewed_code(tmp_path):
+    repo = _mk_repo(tmp_path)
+    _git(repo, "checkout", "-q", "-b", "feat/z")
+    (repo / "mod.py").write_text("def g():\n    return 2\n" * 30)
+    _git(repo, "add", "mod.py")  # staged → triggers the hook
+    out = _run_prompt_hook(repo)
+    assert "Unreviewed code changes detected" in out  # base reminder present
+    assert "mod.py" in out  # manifest appended
+
+
+def test_hook_base_reminder_survives_when_manifest_unavailable(tmp_path):
+    # Orphan branch → no merge-base with the base ref → build_manifest returns
+    # None, but staged code still triggers the hook. The base reminder MUST
+    # still print (manifest is strictly additive, never load-bearing).
+    repo = _mk_repo(tmp_path)
+    _git(repo, "checkout", "-q", "--orphan", "feat/orphan")
+    _git(repo, "reset", "-q")  # drop the index carried over from main
+    (repo / "mod.py").write_text("def g():\n    return 2\n" * 30)
+    _git(repo, "add", "mod.py")
+    out = _run_prompt_hook(repo)
+    assert "Unreviewed code changes detected" in out  # base reminder survives
+
+
+def test_hook_silent_on_clean_tree(tmp_path):
+    repo = _mk_repo(tmp_path)
+    out = _run_prompt_hook(repo)
+    assert out.strip() == ""


### PR DESCRIPTION
## What

Adds `scripts/review_scope.py`, a deterministic per-file **review-coverage manifest**, and injects it into the review-enforcement reminder (`scripts/review_enforcement_prompt.py`).

## Why

Today `/review` picks specialists by aggregate scope signals, but each specialist independently re-runs `git diff` and self-selects hunks. Nothing enumerates the changed files or guarantees each one is covered, so on a large changeset a changed file can go unreviewed by every specialist. This names every file that MUST be covered, model-independently.

## How

- **Self-contained**: no `genesis`-package import (hooks run on the main venv even from a worktree, and can't assume the package imports cleanly). The only reuse is the sibling github-aware `_is_docs_or_config`.
- **Strictly additive + fail-open**: the base "unreviewed changes" reminder always prints first; the manifest is appended behind its own guards. Any git error/timeout returns `None` and the reminder stands alone. Runs on every prompt, so every git call is timed.
- **Reviewable set** = code + tests + fixtures, minus binary/vendored. Docs/config are excluded to stay consistent with the commit gate's own `_is_docs_or_config` policy (`.github/` workflows remain in-scope as code).
- **scope_tag** is one tag per file, first-match-wins, mirroring `gstack-diff-scope`; scope-indicated specialists are surfaced as input (labelled "before the skill's adaptive gating"), never as a competing verdict.
- **git plumbing** uses `git diff -z` NUL parsing (verbatim paths, correct under tabs/renames/binary); `diff_lines` is the unfiltered whole-diff sum to match the skill's <50 specialist gate.

## Evidence

A-B validation vs `ocr review --preview` (a deterministic no-LLM file selector) over 8 real merged PRs: mean Jaccard 0.976. The only systematic divergence was config `.yaml`/`.toml`, which this manifest excludes to match the existing commit-gate policy. No external binary dependency ships.

Reviewed by Codex and a Claude reviewer (two sequential rounds, all findings fixed): numstat all-or-nothing fail-open, test/fixture classification precedence, `-z` NUL parsing, `UnicodeDecodeError` fail-open, and tab-in-path reconstruction. 53 targeted tests; `ruff` clean.

## Verification

- `pytest tests/test_scripts/test_review_scope.py` (53 passing)
- E2E: the real `UserPromptSubmit` hook emits the base reminder plus the manifest on a live diff, and fail-opens (base reminder survives) when the manifest can't be built.

Context: capability-build campaign ledger `09ab9c12a8fd49c686cc644201b448c7` (item #12). The campaign row stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
