### PR TITLE
feat(hooks): machine-enforce the review escalation cap at the commit gate

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -427,6 +427,13 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
      cost), name the cap explicitly ("we've hit the 3-round escalation cap"),
      and get a FRESH decision: keep hardening, switch to a robust-by-
      construction redesign, narrow scope, or shelve.
+  These three are backstopped by a **machine layer**, so the cap holds even if a
+  session's own discipline lapses: `review_state.py` keeps a per-branch review-round
+  counter (bumped on every `mark`, on a distinct staged diff), and the commit gate
+  (`review_enforcement_commit.py`) HARD-BLOCKS the commit at `ESCALATION_ROUND_CAP`
+  (3) rounds unless the command carries a deliberate trailing `# escalation-ack`.
+  The ack is a conscious, logged act (like `# review-override`); adding it WITHOUT a
+  fresh user decision is the same violation as ignoring the prose above.
   Caveats: **multiple findings in a single pass = one round** (not an
   escalation); the same defect reappearing (an incomplete prior fix) is a
   fix-it-properly issue, not an escalation trigger. This complements the

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -428,12 +428,30 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
      and get a FRESH decision: keep hardening, switch to a robust-by-
      construction redesign, narrow scope, or shelve.
   These three are backstopped by a **machine layer**, so the cap holds even if a
-  session's own discipline lapses: `review_state.py` keeps a per-branch review-round
-  counter (bumped on every `mark`, on a distinct staged diff), and the commit gate
+  session's own discipline lapses: `review_state.py` keeps a per-branch counter of
+  CONSECUTIVE defect-bearing review rounds, and the commit gate
   (`review_enforcement_commit.py`) HARD-BLOCKS the commit at `ESCALATION_ROUND_CAP`
-  (3) rounds unless the command carries a deliberate trailing `# escalation-ack`.
-  The ack is a conscious, logged act (like `# review-override`); adding it WITHOUT a
-  fresh user decision is the same violation as ignoring the prose above.
+  (3) unless the command carries a deliberate trailing `# escalation-ack`. The
+  counter implements the "each find NEW defects" clause literally — so when you
+  `mark` a review, record its OUTCOME:
+  - Review surfaced a NEW **BLOCKER / SHOULD-FIX / P1 / P2** finding → mark as usual
+    (`python3 scripts/review_state.py mark --agent-output <path>`) — the round counts.
+  - Review surfaced **no** new BLOCKER/SHOULD-FIX/P1/P2 finding → add `--clean`
+    (`… mark --agent-output <path> --clean`) — this RESETS the streak
+    (circuit-breaker reset-on-success), so honestly-clean multi-commit development
+    (independent clean reviews of distinct diffs) never trips the cap.
+
+  A round is CLEAN iff the review found no BLOCKER/SHOULD-FIX/P1/P2. NOTEs, nitpicks,
+  and dispositioned optional-hardening do NOT make a round defect-bearing — without
+  this line a nitpick-prone reviewer would make every round "defect-bearing" and the
+  cap collapses back into raw commit-counting. An unflagged mark counts as
+  defect-bearing by default: a forgotten `--clean` gives a slightly early conscious
+  checkpoint (the safe direction), never a silently-disabled cap. The ack is a
+  conscious, logged act (like `# review-override`); adding it — or falsely passing
+  `--clean` — WITHOUT the honest review result is the same violation as ignoring the
+  prose above (the `--clean` flag mirrors the review record you write to
+  `~/.genesis/last_code_review.txt` at the same moment: falsifying one falsifies the
+  other).
   Caveats: **multiple findings in a single pass = one round** (not an
   escalation); the same defect reappearing (an incomplete prior fix) is a
   fix-it-properly issue, not an escalation trigger. This complements the

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -27,6 +27,7 @@ from shell_parse import (  # noqa: E402
     analyze,
     commit_skips_hooks,
     git_subcommand,
+    has_trailing_override,
     split_segments,
 )
 
@@ -387,10 +388,13 @@ def main() -> None:
 
     try:
         from review_state import (
+            ESCALATION_ROUND_CAP,
             get_current_branch,
+            get_review_round,
             has_code_changes,
             has_valid_review_marker,
             is_review_current,
+            reset_review_round,
         )
     except ImportError:
         # If review_state.py is missing, fail open — don't block
@@ -422,6 +426,42 @@ def main() -> None:
         if staged and all(_is_docs_or_config(p) for p in staged):
             sys.exit(0)
 
+    # Rule 3: review escalation cap. After ESCALATION_ROUND_CAP review→fix→re-review
+    # rounds on this change, block the commit until an explicit '# escalation-ack'
+    # trailing comment — a machine-enforced STOP so a review loop can't silently run
+    # long on a standing "proceed" (see genesis-development SKILL.md). Checked BEFORE
+    # Rule 2 ON PURPOSE: a '# review-override' (which exits Rule 2 early) must NOT be
+    # able to sneak a past-cap commit through — the two acknowledgments are
+    # independent. Like review-override, the ack does NOT bypass Rule 0 (--no-verify)
+    # or Rule 1 (main-branch), checked above. Recognition mirrors _commit_override:
+    # a clean trailing comment on EVERY commit segment (all(), so one ack can't
+    # license a chained sibling commit). NOTE: on a nested `bash -c 'git commit …'`
+    # the ack must sit on the INNER command (the sigil isn't propagated to wrappers);
+    # the documented `git commit … # escalation-ack` form is a plain segment.
+    round_n = get_review_round(cwd=cwd)
+    if round_n >= ESCALATION_ROUND_CAP:
+        commit_segs = [s for s in segs if git_subcommand(s.argv) == "commit"]
+        acked = bool(commit_segs) and all(
+            has_trailing_override(s.raw, sigil="escalation-ack") for s in commit_segs
+        )
+        if not acked:
+            _deny(
+                f"BLOCKED: review escalation cap reached — this change has had {round_n} "
+                f"review rounds (cap {ESCALATION_ROUND_CAP}). The review→fix loop has run "
+                "long. STOP and get a FRESH user decision on how to proceed (keep "
+                "hardening / switch to a robust-by-construction redesign / narrow scope / "
+                "shelve), then acknowledge that decision with a trailing shell comment "
+                "(outside any quotes):\n"
+                '  git commit -m "your message"  # escalation-ack'
+            )
+            return
+        # Acked = a fresh decision to continue → reset the round budget so the next
+        # stop is a fresh cap away, not per-commit friction for the branch's whole
+        # life. Reset stands even if a later rule blocks THIS commit: the
+        # acknowledgment was made, and erring toward less friction only happens
+        # AFTER a conscious ack.
+        reset_review_round(cwd=cwd)
+
     # Rule 2: Block commits without review (on branches)
     # Race condition: when command is "git add X && git commit", nothing is
     # staged yet at hook time because git add hasn't run. Detect git add in
@@ -438,7 +478,8 @@ def main() -> None:
     if rule2_blocks:
         # A trailing '# review-override' comment (outside quotes) acknowledges
         # accepted findings and bypasses ONLY this review gate — never Rule 0
-        # (--no-verify) or Rule 1 (main-branch), which are checked above.
+        # (--no-verify), Rule 1 (main-branch), or Rule 3 (escalation cap), all
+        # checked above.
         override = _commit_override(command, segs)
         if override == "valid":
             print(

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -411,33 +411,20 @@ def main() -> None:
         )
         return
 
-    # Docs/config-only skip: a commit whose ENTIRE staged set is documentation
-    # or config carries no code to review (adaptive-review "review level: None"),
-    # so skip Rule 2 for it. Conservative fail-toward-review default: we skip ONLY
-    # when (a) the commit is PURE — it cannot add/select content beyond the
-    # current index (no pathspec, no -a/-i/-o/-p, and no git add/rm/mv/reset in
-    # the chain, P1-D) — AND (b) the staged set is non-empty and every path is on
-    # the docs/config allowlist. An impure commit, an empty staged set, a diff we
-    # cannot read, or an ambiguous cwd (already blocked by Rule 1) falls through
-    # to normal enforcement — never skipped. Placed AFTER Rule 0 (--no-verify) and
-    # Rule 1 (main-branch) so it can never weaken those hard blocks.
-    if not _commit_may_add_content(segs):
-        staged = _staged_files(cwd)
-        if staged and all(_is_docs_or_config(p) for p in staged):
-            sys.exit(0)
-
     # Rule 3: review escalation cap. After ESCALATION_ROUND_CAP review→fix→re-review
     # rounds on this change, block the commit until an explicit '# escalation-ack'
     # trailing comment — a machine-enforced STOP so a review loop can't silently run
     # long on a standing "proceed" (see genesis-development SKILL.md). Checked BEFORE
-    # Rule 2 ON PURPOSE: a '# review-override' (which exits Rule 2 early) must NOT be
-    # able to sneak a past-cap commit through — the two acknowledgments are
-    # independent. Like review-override, the ack does NOT bypass Rule 0 (--no-verify)
-    # or Rule 1 (main-branch), checked above. Recognition mirrors _commit_override:
-    # a clean trailing comment on EVERY commit segment (all(), so one ack can't
-    # license a chained sibling commit). NOTE: on a nested `bash -c 'git commit …'`
-    # the ack must sit on the INNER command (the sigil isn't propagated to wrappers);
-    # the documented `git commit … # escalation-ack` form is a plain segment.
+    # both the docs/config skip AND Rule 2 ON PURPOSE: the hard stop must not be
+    # bypassable by file extension (a reviewed prompt/skill/docs-only commit at the
+    # cap would otherwise sneak past via the docs skip), nor by '# review-override'
+    # (which exits Rule 2 early) — the two acknowledgments are independent. Like
+    # review-override, the ack does NOT bypass Rule 0 (--no-verify) or Rule 1
+    # (main-branch), checked above. Recognition mirrors _commit_override: a clean
+    # trailing comment on EVERY commit segment (all(), so one ack can't license a
+    # chained sibling commit). NOTE: on a nested `bash -c 'git commit …'` the ack
+    # must sit on the INNER command (the sigil isn't propagated to wrappers); the
+    # documented `git commit … # escalation-ack` form is a plain segment.
     round_n = get_review_round(cwd=cwd)
     if round_n >= ESCALATION_ROUND_CAP:
         commit_segs = [s for s in segs if git_subcommand(s.argv) == "commit"]
@@ -461,6 +448,22 @@ def main() -> None:
         # acknowledgment was made, and erring toward less friction only happens
         # AFTER a conscious ack.
         reset_review_round(cwd=cwd)
+
+    # Docs/config-only skip: a commit whose ENTIRE staged set is documentation
+    # or config carries no code to review (adaptive-review "review level: None"),
+    # so skip Rule 2 for it. Conservative fail-toward-review default: we skip ONLY
+    # when (a) the commit is PURE — it cannot add/select content beyond the
+    # current index (no pathspec, no -a/-i/-o/-p, and no git add/rm/mv/reset in
+    # the chain, P1-D) — AND (b) the staged set is non-empty and every path is on
+    # the docs/config allowlist. An impure commit, an empty staged set, a diff we
+    # cannot read, or an ambiguous cwd (already blocked by Rule 1) falls through
+    # to normal enforcement — never skipped. Placed AFTER Rule 0 (--no-verify),
+    # Rule 1 (main-branch), and Rule 3 (escalation cap) so it can never weaken
+    # those hard blocks.
+    if not _commit_may_add_content(segs):
+        staged = _staged_files(cwd)
+        if staged and all(_is_docs_or_config(p) for p in staged):
+            sys.exit(0)
 
     # Rule 2: Block commits without review (on branches)
     # Race condition: when command is "git add X && git commit", nothing is

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -411,10 +411,13 @@ def main() -> None:
         )
         return
 
-    # Rule 3: review escalation cap. After ESCALATION_ROUND_CAP review→fix→re-review
-    # rounds on this change, block the commit until an explicit '# escalation-ack'
-    # trailing comment — a machine-enforced STOP so a review loop can't silently run
-    # long on a standing "proceed" (see genesis-development SKILL.md). Checked BEFORE
+    # Rule 3: review escalation cap. After ESCALATION_ROUND_CAP CONSECUTIVE
+    # defect-bearing review→fix→re-review rounds on this change (a clean review
+    # resets the streak — see review_state.bump_review_round), block the commit
+    # until an explicit '# escalation-ack' trailing comment — a machine-enforced
+    # STOP so a genuine review→fix loop can't silently run long on a standing
+    # "proceed" (see genesis-development SKILL.md), while honestly-clean
+    # multi-commit development never trips. Checked BEFORE
     # both the docs/config skip AND Rule 2 ON PURPOSE: the hard stop must not be
     # bypassable by file extension (a reviewed prompt/skill/docs-only commit at the
     # cap would otherwise sneak past via the docs skip), nor by '# review-override'
@@ -433,9 +436,10 @@ def main() -> None:
         )
         if not acked:
             _deny(
-                f"BLOCKED: review escalation cap reached — this change has had {round_n} "
-                f"review rounds (cap {ESCALATION_ROUND_CAP}). The review→fix loop has run "
-                "long. STOP and get a FRESH user decision on how to proceed (keep "
+                f"BLOCKED: review escalation cap reached — {round_n} consecutive review "
+                f"rounds each surfaced NEW defects (cap {ESCALATION_ROUND_CAP}). The "
+                "review→fix loop has run long. STOP and get a FRESH user decision on how "
+                "to proceed (keep "
                 "hardening / switch to a robust-by-construction redesign / narrow scope / "
                 "shelve), then acknowledge that decision with a trailing shell comment "
                 "(outside any quotes):\n"

--- a/scripts/review_state.py
+++ b/scripts/review_state.py
@@ -34,6 +34,14 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 _MARKER_DIR = Path.home() / ".genesis" / "review_markers"
+# Per-worktree review-ROUND counter (escalation cap). Deliberately a SEPARATE store
+# from the marker above: review_invalidate_on_commit clears the marker after every
+# commit, but the round count must SURVIVE commits — a review→fix→re-review loop
+# commits between rounds, and the whole point is to notice when that loop runs long.
+_ROUND_DIR = Path.home() / ".genesis" / "review_rounds"
+# After this many review rounds on one change, the commit gate blocks pending an
+# explicit '# escalation-ack'. Mirrors the genesis-development SKILL.md prose cap.
+ESCALATION_ROUND_CAP = 3
 # Legacy single-file marker (pre per-worktree scoping). Only read as a fallback
 # so an in-flight review from before an upgrade isn't lost mid-session.
 _LEGACY_STATE_FILE = Path.home() / ".genesis" / "review_state.json"
@@ -218,7 +226,10 @@ def mark_reviewed(agent_output_path: str | None = None, cwd: str | None = None) 
         "agent_evidence": agent_msg,
     }
     state_file.write_text(json.dumps(state, indent=2))
-    print(f"Review marker written: {state['diff_hash']}")
+    # Count this review round (escalation cap). A distinct staged diff on the same
+    # branch advances the count; re-marking the same diff does not. Best-effort.
+    round_n = bump_review_round(cwd=cwd)
+    print(f"Review marker written: {state['diff_hash']} (round {round_n})")
     return True
 
 
@@ -235,6 +246,113 @@ def clear_marker(cwd: str | None = None) -> None:
     for path in (_state_file(cwd), _LEGACY_STATE_FILE):
         with contextlib.suppress(OSError):
             path.unlink(missing_ok=True)
+
+
+# ── Review-round counter (escalation cap) ─────────────────────────────────────
+# Counts review→fix→re-review rounds per change so the commit gate can force a
+# conscious stop after ESCALATION_ROUND_CAP rounds. Kept in a per-worktree file
+# SEPARATE from the marker (the marker is wiped on every commit; the round count
+# must persist across the commits a review loop makes between rounds). A "round"
+# = one review mark on a DISTINCT staged diff on the same branch; re-marking the
+# same diff is not a new round, and a branch change resets the count.
+
+
+def _round_file(cwd: str | None = None) -> Path:
+    """Per-worktree round-counter path (same worktree key as the marker)."""
+    return _ROUND_DIR / f"{_worktree_key(cwd)}.json"
+
+
+def _staged_content_hash(cwd: str | None = None) -> str:
+    """SHA-256 of the FULL staged diff (``git diff --cached``) — content, not stat.
+
+    Round detection must distinguish two genuinely different fixes to the same
+    file: ``get_current_diff_hash`` hashes ``--stat`` (file + line counts only), so
+    ``x = 2`` → ``x = 3`` collide under it. This hashes the actual staged content so
+    any real change since the last mark reads as a new round.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--cached"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            cwd=cwd,
+        )
+        content = result.stdout
+        if not content.strip():
+            return "clean"
+        return hashlib.sha256(content.encode()).hexdigest()[:16]
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return "unknown"
+
+
+def _load_round(cwd: str | None = None) -> dict:
+    try:
+        p = _round_file(cwd)
+        if p.exists():
+            return json.loads(p.read_text())
+    except (json.JSONDecodeError, OSError):
+        pass
+    return {}
+
+
+def get_review_round(cwd: str | None = None) -> int:
+    """Review rounds recorded for the CURRENT branch's change.
+
+    Returns 0 when the stored count is for a different branch (a new change starts
+    fresh) or when no count exists. Never raises.
+    """
+    state = _load_round(cwd)
+    if not state or state.get("branch") != get_current_branch(cwd=cwd):
+        return 0
+    try:
+        return int(state.get("round", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def bump_review_round(cwd: str | None = None) -> int:
+    """Record one more review round for the current branch; return the new count.
+
+    A genuine new round (the staged diff changed since the last mark on this
+    branch) increments; re-marking the SAME diff does not (idempotent); a branch
+    change resets to 1. Best-effort — never raises into the caller.
+    """
+    branch = get_current_branch(cwd=cwd)
+    content_hash = _staged_content_hash(cwd=cwd)
+    # Nothing meaningfully staged ("clean") or a git error ("unknown") is NOT a
+    # review round — counting it would inflate toward a false-positive cap block
+    # (e.g. a mark run before the next fix is staged, or a transient git timeout).
+    if content_hash in ("clean", "unknown"):
+        return get_review_round(cwd=cwd)
+    state = _load_round(cwd)
+    if not state or state.get("branch") != branch:
+        state = {"branch": branch, "round": 1, "last_hash": content_hash}
+    elif state.get("last_hash") != content_hash:
+        state = {
+            "branch": branch,
+            "round": int(state.get("round", 0)) + 1,
+            "last_hash": content_hash,
+        }
+    # else: same branch + same staged diff → same round (idempotent re-mark).
+    try:
+        rf = _round_file(cwd)
+        rf.parent.mkdir(parents=True, exist_ok=True)
+        rf.write_text(json.dumps(state, indent=2))
+    except OSError:
+        pass
+    try:
+        return int(state.get("round", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def reset_review_round(cwd: str | None = None) -> None:
+    """Delete the round counter (e.g. after the change lands). Never raises."""
+    import contextlib
+
+    with contextlib.suppress(OSError):
+        _round_file(cwd).unlink(missing_ok=True)
 
 
 def get_current_branch(cwd: str | None = None) -> str:

--- a/scripts/review_state.py
+++ b/scripts/review_state.py
@@ -292,10 +292,21 @@ def _staged_content_hash(cwd: str | None = None) -> str:
 
 
 def _load_round(cwd: str | None = None) -> dict:
+    """Read the round-counter file, normalizing ANY non-dict content to ``{}``.
+
+    Validating the shape once, here at the single load boundary, is the whole
+    class-fix for malformed counters: valid JSON that is not an object (``[1,2,3]``,
+    ``42``, ``"str"`` from a manual edit / schema skew) would otherwise reach a
+    caller's ``.get()`` and raise ``AttributeError``, defeating the fail-open
+    contract. Every caller now provably receives a dict → their ``.get`` can't
+    raise → any malformed shape collapses to "no counter → fail open". Never raises.
+    """
     try:
         p = _round_file(cwd)
         if p.exists():
-            return json.loads(p.read_text())
+            data = json.loads(p.read_text())
+            if isinstance(data, dict):
+                return data
     except (json.JSONDecodeError, OSError):
         pass
     return {}

--- a/scripts/review_state.py
+++ b/scripts/review_state.py
@@ -227,8 +227,13 @@ def mark_reviewed(agent_output_path: str | None = None, cwd: str | None = None) 
     }
     state_file.write_text(json.dumps(state, indent=2))
     # Count this review round (escalation cap). A distinct staged diff on the same
-    # branch advances the count; re-marking the same diff does not. Best-effort.
-    round_n = bump_review_round(cwd=cwd)
+    # branch advances the count; re-marking the same diff does not. Best-effort:
+    # marking the review must ALWAYS succeed even if the counter is unwritable, so a
+    # counter problem can never leave the user stuck behind the review gate.
+    try:
+        round_n = bump_review_round(cwd=cwd)
+    except Exception:  # noqa: BLE001 - the counter must never block marking a review
+        round_n = 0
     print(f"Review marker written: {state['diff_hash']} (round {round_n})")
     return True
 
@@ -329,11 +334,15 @@ def bump_review_round(cwd: str | None = None) -> int:
     if not state or state.get("branch") != branch:
         state = {"branch": branch, "round": 1, "last_hash": content_hash}
     elif state.get("last_hash") != content_hash:
-        state = {
-            "branch": branch,
-            "round": int(state.get("round", 0)) + 1,
-            "last_hash": content_hash,
-        }
+        # A distinct staged diff → new round. Coerce the stored round defensively:
+        # a corrupt / partial-write / version-skewed value must NOT raise here, or
+        # it would crash `mark` and leave the user stuck behind the gate (this
+        # counter is best-effort — see the never-raises contract).
+        try:
+            prev = int(state.get("round", 0))
+        except (TypeError, ValueError):
+            prev = 0
+        state = {"branch": branch, "round": prev + 1, "last_hash": content_hash}
     # else: same branch + same staged diff → same round (idempotent re-mark).
     try:
         rf = _round_file(cwd)

--- a/scripts/review_state.py
+++ b/scripts/review_state.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import subprocess
 import sys
 import time
@@ -314,21 +315,46 @@ def _staged_content_hash(cwd: str | None = None) -> str:
         return "unknown"
 
 
-def _load_round(cwd: str | None = None) -> dict:
-    """Read the round-counter file, normalizing ANY non-dict content to ``{}``.
+def _coerce_finite_int(value: object, default: int = 0) -> int:
+    """Best-effort finite int from a persisted JSON value; ``default`` otherwise.
 
-    Validating the shape once, here at the single load boundary, is the whole
-    class-fix for malformed counters: valid JSON that is not an object (``[1,2,3]``,
-    ``42``, ``"str"`` from a manual edit / schema skew) would otherwise reach a
-    caller's ``.get()`` and raise ``AttributeError``, defeating the fail-open
-    contract. Every caller now provably receives a dict → their ``.get`` can't
-    raise → any malformed shape collapses to "no counter → fail open". Never raises.
+    Closes the malformed-counter VALUE class at a single point: a valid JSON number
+    like ``1e999`` parses to ``float('inf')``, and ``int(inf)`` raises ``OverflowError``
+    (NOT a subclass of ``TypeError``/``ValueError``), so a plain ``int()`` guard would
+    let it escape and crash the gate — violating the never-raises/fail-open contract.
+    Rejecting non-finite floats and catching ``OverflowError`` here means no persisted
+    round value can ever raise, however corrupt. Never raises.
+    """
+    try:
+        if isinstance(value, float) and not math.isfinite(value):
+            return default
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        return default
+
+
+def _load_round(cwd: str | None = None) -> dict:
+    """Read the round-counter file, normalizing shape AND the round VALUE.
+
+    Validating once, here at the single load boundary, is the whole class-fix for
+    malformed counters. Two sub-classes are closed here:
+      - SHAPE: valid JSON that is not an object (``[1,2,3]``, ``42``, ``"str"`` from a
+        manual edit / schema skew) would reach a caller's ``.get()`` and raise
+        ``AttributeError`` — normalized to ``{}``.
+      - VALUE: a well-formed dict whose ``round`` is pathological (``1e999`` → inf →
+        ``int()`` ``OverflowError``; a non-numeric string; null) — coerced to a finite
+        int via ``_coerce_finite_int`` so every caller provably gets a clean ``int``.
+    Every caller therefore receives a dict with a finite-int ``round`` → nothing a
+    corrupt file contains can raise → it collapses to "no/zero counter → fail open".
+    Never raises.
     """
     try:
         p = _round_file(cwd)
         if p.exists():
             data = json.loads(p.read_text())
             if isinstance(data, dict):
+                if "round" in data:
+                    data["round"] = _coerce_finite_int(data.get("round"))
                 return data
     except (json.JSONDecodeError, OSError):
         pass
@@ -344,10 +370,7 @@ def get_review_round(cwd: str | None = None) -> int:
     state = _load_round(cwd)
     if not state or state.get("branch") != get_current_branch(cwd=cwd):
         return 0
-    try:
-        return int(state.get("round", 0))
-    except (TypeError, ValueError):
-        return 0
+    return _coerce_finite_int(state.get("round", 0))
 
 
 def _write_round(state: dict, cwd: str | None = None) -> None:
@@ -397,17 +420,12 @@ def bump_review_round(cwd: str | None = None, *, clean: bool = False) -> int:
         # round defensively: a corrupt / partial-write / version-skewed value must
         # NOT raise here, or it would crash `mark` and leave the user stuck behind
         # the gate (this counter is best-effort — see the never-raises contract).
-        try:
-            prev = int(state.get("round", 0))
-        except (TypeError, ValueError):
-            prev = 0
+        # _coerce_finite_int also absorbs the `1e999`→inf→OverflowError value class.
+        prev = _coerce_finite_int(state.get("round", 0))
         state = {"branch": branch, "round": prev + 1, "last_hash": content_hash}
     # else: same branch + same staged diff → same round (idempotent re-mark).
     _write_round(state, cwd)
-    try:
-        return int(state.get("round", 0))
-    except (TypeError, ValueError):
-        return 0
+    return _coerce_finite_int(state.get("round", 0))
 
 
 def reset_review_round(cwd: str | None = None) -> None:

--- a/scripts/review_state.py
+++ b/scripts/review_state.py
@@ -19,7 +19,8 @@ not installed on many hosts.
 
 CLI usage:
     python3 review_state.py status     # prints current review state
-    python3 review_state.py mark --agent-output <path>
+    python3 review_state.py mark --agent-output <path>          # defect-bearing round
+    python3 review_state.py mark --agent-output <path> --clean  # clean round → reset streak
     python3 review_state.py diff-hash  # prints current diff hash
 """
 
@@ -195,12 +196,23 @@ def _verify_agent_output(path: str) -> tuple[bool, str]:
     return True, f"Agent output valid ({int(age)}s old, {p.stat().st_size} bytes)"
 
 
-def mark_reviewed(agent_output_path: str | None = None, cwd: str | None = None) -> bool:
+def mark_reviewed(
+    agent_output_path: str | None = None,
+    cwd: str | None = None,
+    *,
+    clean: bool = False,
+) -> bool:
     """Write the per-worktree review marker after verifying evidence.
 
     The authoritative gate is Check 2 (code-reviewer agent output). Check 1
     (gstack telemetry) is advisory — it annotates the marker but never refuses,
     because gstack is not installed on many hosts (see ``_verify_review_log``).
+
+    ``clean`` records the OUTCOME of the review for the escalation counter: pass
+    ``clean=True`` when the review surfaced NO new BLOCKER/SHOULD-FIX/P1/P2
+    finding — it resets the defect-bearing-round streak (circuit-breaker
+    reset-on-success). The default (``clean=False``) counts the round as
+    defect-bearing. See ``bump_review_round``.
 
     Returns True if the marker was written, False if the authoritative evidence
     check failed.
@@ -226,15 +238,16 @@ def mark_reviewed(agent_output_path: str | None = None, cwd: str | None = None) 
         "agent_evidence": agent_msg,
     }
     state_file.write_text(json.dumps(state, indent=2))
-    # Count this review round (escalation cap). A distinct staged diff on the same
-    # branch advances the count; re-marking the same diff does not. Best-effort:
-    # marking the review must ALWAYS succeed even if the counter is unwritable, so a
-    # counter problem can never leave the user stuck behind the review gate.
+    # Update the escalation counter (see bump_review_round). A defect-bearing round
+    # on a distinct staged diff advances the streak; a clean round resets it.
+    # Best-effort: marking the review must ALWAYS succeed even if the counter is
+    # unwritable, so a counter problem can never leave the user stuck behind the gate.
     try:
-        round_n = bump_review_round(cwd=cwd)
+        round_n = bump_review_round(cwd=cwd, clean=clean)
     except Exception:  # noqa: BLE001 - the counter must never block marking a review
         round_n = 0
-    print(f"Review marker written: {state['diff_hash']} (round {round_n})")
+    label = "clean → streak reset" if clean else f"round {round_n}"
+    print(f"Review marker written: {state['diff_hash']} ({label})")
     return True
 
 
@@ -254,12 +267,22 @@ def clear_marker(cwd: str | None = None) -> None:
 
 
 # ── Review-round counter (escalation cap) ─────────────────────────────────────
-# Counts review→fix→re-review rounds per change so the commit gate can force a
-# conscious stop after ESCALATION_ROUND_CAP rounds. Kept in a per-worktree file
-# SEPARATE from the marker (the marker is wiped on every commit; the round count
-# must persist across the commits a review loop makes between rounds). A "round"
-# = one review mark on a DISTINCT staged diff on the same branch; re-marking the
-# same diff is not a new round, and a branch change resets the count.
+# Counts CONSECUTIVE defect-bearing review→fix→re-review rounds per change so the
+# commit gate can force a conscious stop after ESCALATION_ROUND_CAP rounds. Kept
+# in a per-worktree file SEPARATE from the marker (the marker is wiped on every
+# commit; the round count must persist across the commits a review loop makes
+# between rounds).
+#
+# A round counts (advances the streak) only when the review it records surfaced a
+# NEW defect — the caller passes clean=False (the default) — AND the staged diff
+# is distinct from the last-counted one on this branch. A CLEAN review round
+# (clean=True: the review found no BLOCKER/SHOULD-FIX/P1/P2 finding) RESETS the
+# streak to 0 — circuit-breaker reset-on-success. This makes the machine
+# implement the SKILL.md cap literally ("3 rounds that each find NEW defects"):
+# honestly-clean multi-commit development (three independent clean reviews) never
+# trips, while a genuine review→fix loop that keeps surfacing defects still stops
+# at round 3. A branch change resets the count; re-marking the same diff does not
+# advance it.
 
 
 def _round_file(cwd: str | None = None) -> Path:
@@ -327,40 +350,60 @@ def get_review_round(cwd: str | None = None) -> int:
         return 0
 
 
-def bump_review_round(cwd: str | None = None) -> int:
-    """Record one more review round for the current branch; return the new count.
-
-    A genuine new round (the staged diff changed since the last mark on this
-    branch) increments; re-marking the SAME diff does not (idempotent); a branch
-    change resets to 1. Best-effort — never raises into the caller.
-    """
-    branch = get_current_branch(cwd=cwd)
-    content_hash = _staged_content_hash(cwd=cwd)
-    # Nothing meaningfully staged ("clean") or a git error ("unknown") is NOT a
-    # review round — counting it would inflate toward a false-positive cap block
-    # (e.g. a mark run before the next fix is staged, or a transient git timeout).
-    if content_hash in ("clean", "unknown"):
-        return get_review_round(cwd=cwd)
-    state = _load_round(cwd)
-    if not state or state.get("branch") != branch:
-        state = {"branch": branch, "round": 1, "last_hash": content_hash}
-    elif state.get("last_hash") != content_hash:
-        # A distinct staged diff → new round. Coerce the stored round defensively:
-        # a corrupt / partial-write / version-skewed value must NOT raise here, or
-        # it would crash `mark` and leave the user stuck behind the gate (this
-        # counter is best-effort — see the never-raises contract).
-        try:
-            prev = int(state.get("round", 0))
-        except (TypeError, ValueError):
-            prev = 0
-        state = {"branch": branch, "round": prev + 1, "last_hash": content_hash}
-    # else: same branch + same staged diff → same round (idempotent re-mark).
+def _write_round(state: dict, cwd: str | None = None) -> None:
+    """Persist the round-counter state (best-effort — never raises)."""
     try:
         rf = _round_file(cwd)
         rf.parent.mkdir(parents=True, exist_ok=True)
         rf.write_text(json.dumps(state, indent=2))
     except OSError:
         pass
+
+
+def bump_review_round(cwd: str | None = None, *, clean: bool = False) -> int:
+    """Update the defect-bearing-round streak for the current branch; return it.
+
+    ``clean=True`` — the review found no new BLOCKER/SHOULD-FIX/P1/P2 finding —
+    RESETS the streak to 0 (circuit-breaker reset-on-success) and returns 0,
+    regardless of whether the staged diff changed (a clean re-probe of the same
+    diff still closes the breaker).
+
+    ``clean=False`` (default, a defect-bearing round) increments when the staged
+    diff changed since the last counted mark on this branch; re-marking the SAME
+    diff does not (idempotent); a branch change resets to 1.
+
+    Best-effort — never raises into the caller.
+    """
+    branch = get_current_branch(cwd=cwd)
+    content_hash = _staged_content_hash(cwd=cwd)
+    # A CLEAN round resets the streak unconditionally — the review declared the
+    # current state defect-free, so no review→fix loop is in progress. Record the
+    # current content hash so the NEXT defect-bearing mark on a distinct diff
+    # correctly reads as a new (round-1) streak.
+    if clean:
+        _write_round({"branch": branch, "round": 0, "last_hash": content_hash}, cwd)
+        return 0
+    # Defect-bearing round. Nothing meaningfully staged ("clean") or a git error
+    # ("unknown") is NOT a review round — counting it would inflate toward a
+    # false-positive cap block (e.g. a mark run before the next fix is staged, or
+    # a transient git timeout).
+    if content_hash in ("clean", "unknown"):
+        return get_review_round(cwd=cwd)
+    state = _load_round(cwd)
+    if not state or state.get("branch") != branch:
+        state = {"branch": branch, "round": 1, "last_hash": content_hash}
+    elif state.get("last_hash") != content_hash:
+        # A distinct staged diff → new defect-bearing round. Coerce the stored
+        # round defensively: a corrupt / partial-write / version-skewed value must
+        # NOT raise here, or it would crash `mark` and leave the user stuck behind
+        # the gate (this counter is best-effort — see the never-raises contract).
+        try:
+            prev = int(state.get("round", 0))
+        except (TypeError, ValueError):
+            prev = 0
+        state = {"branch": branch, "round": prev + 1, "last_hash": content_hash}
+    # else: same branch + same staged diff → same round (idempotent re-mark).
+    _write_round(state, cwd)
     try:
         return int(state.get("round", 0))
     except (TypeError, ValueError):
@@ -413,12 +456,15 @@ def main() -> None:
         print(get_current_diff_hash())
 
     elif cmd == "mark":
-        # Parse --agent-output argument
+        # Parse --agent-output <path> and the optional --clean flag.
         agent_path = None
+        clean = False
         for i, arg in enumerate(sys.argv[2:], 2):
             if arg == "--agent-output" and i + 1 < len(sys.argv):
                 agent_path = sys.argv[i + 1]
-        if not mark_reviewed(agent_path):
+            elif arg == "--clean":
+                clean = True
+        if not mark_reviewed(agent_path, clean=clean):
             sys.exit(1)
 
     else:

--- a/tests/test_hooks/test_escalation_cap.py
+++ b/tests/test_hooks/test_escalation_cap.py
@@ -1,0 +1,221 @@
+"""Tests for the review escalation cap — the machine-enforced round counter +
+commit-gate block (scripts/review_state.py + scripts/review_enforcement_commit.py).
+
+Hermetic: throwaway git repo under ``tmp_path`` with ``HOME`` pointed at another
+temp dir, so the real per-worktree markers/round counters under ``~/.genesis/``
+are never touched. No network, no live server. (Scratch git in a pytest
+subprocess is not blocked by the interactive CC guards — per the hook-testing
+convention.)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOK = _REPO_ROOT / "scripts" / "review_enforcement_commit.py"
+_REVIEW_STATE = _REPO_ROOT / "scripts" / "review_state.py"
+
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "hooks"))
+import review_state  # noqa: E402
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "-c", "init.defaultBranch=main", "init", "-q")
+    _git(r, "config", "user.email", "t@e.st")
+    _git(r, "config", "user.name", "tester")
+    (r / "f.py").write_text("base = 1\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "base")
+    _git(r, "checkout", "-q", "-b", "feature/x")
+    return r
+
+
+@pytest.fixture
+def home(tmp_path: Path) -> Path:
+    h = tmp_path / "home"
+    (h / ".genesis").mkdir(parents=True)
+    return h
+
+
+def _stage(repo: Path, content: str) -> None:
+    (repo / "f.py").write_text(content)
+    _git(repo, "add", "-A")
+
+
+# ── Counter unit tests (review_state) ─────────────────────────────────────
+
+
+@pytest.fixture
+def _isolate_rounds(tmp_path, monkeypatch):
+    monkeypatch.setattr(review_state, "_ROUND_DIR", tmp_path / "rounds")
+
+
+def test_bump_increments_on_distinct_content(repo, _isolate_rounds):
+    # Two one-line fixes to the SAME file (identical --stat, different content):
+    # the round counter must key on CONTENT, so both count as distinct rounds.
+    _stage(repo, "a = 2\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 1
+    assert review_state.get_review_round(cwd=str(repo)) == 1
+    _stage(repo, "a = 3\n")  # same stat, different content → new round
+    assert review_state.bump_review_round(cwd=str(repo)) == 2
+    assert review_state.get_review_round(cwd=str(repo)) == 2
+
+
+def test_remark_same_content_no_increment(repo, _isolate_rounds):
+    _stage(repo, "a = 2\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 1
+    # Re-mark the identical staged diff (re-ran /review, no fix) → NOT a new round.
+    assert review_state.bump_review_round(cwd=str(repo)) == 1
+
+
+def test_branch_change_resets(repo, _isolate_rounds):
+    _stage(repo, "a = 2\n")
+    review_state.bump_review_round(cwd=str(repo))
+    _stage(repo, "a = 3\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 2
+    _git(repo, "commit", "-qm", "wip")
+    _git(repo, "checkout", "-q", "-b", "feature/y")
+    _stage(repo, "b = 1\n")
+    assert review_state.get_review_round(cwd=str(repo)) == 0  # different branch → fresh
+    assert review_state.bump_review_round(cwd=str(repo)) == 1  # reset to 1
+
+
+def test_get_round_zero_for_other_branch(repo, _isolate_rounds):
+    _stage(repo, "a = 2\n")
+    review_state.bump_review_round(cwd=str(repo))
+    _git(repo, "commit", "-qm", "wip")
+    _git(repo, "checkout", "-q", "-b", "other")
+    assert review_state.get_review_round(cwd=str(repo)) == 0
+
+
+def test_reset_clears(repo, _isolate_rounds):
+    _stage(repo, "a = 2\n")
+    review_state.bump_review_round(cwd=str(repo))
+    review_state.reset_review_round(cwd=str(repo))
+    assert review_state.get_review_round(cwd=str(repo)) == 0
+
+
+# ── Gate integration tests (review_enforcement_commit, subprocess) ────────
+
+
+def _run_hook(command: str, repo: Path, home: Path) -> subprocess.CompletedProcess:
+    payload = json.dumps(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "session_id": "test",
+        }
+    )
+    env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input=payload,
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _mark(repo: Path, home: Path) -> subprocess.CompletedProcess:
+    (home / ".genesis" / "last_code_review.txt").write_text("adversarial review: OK\n")
+    env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_REVIEW_STATE),
+            "mark",
+            "--agent-output",
+            str(home / ".genesis" / "last_code_review.txt"),
+        ],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _reach_rounds(repo: Path, home: Path, n: int) -> None:
+    """Drive the round counter to ``n`` via distinct staged diffs + marks."""
+    for i in range(1, n + 1):
+        _stage(repo, f"a = {i}\n")
+        m = _mark(repo, home)
+        assert m.returncode == 0, m.stderr
+
+
+def test_commit_blocked_at_round_cap(repo, home):
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP)  # 3 rounds
+    # Review IS current for the latest staged diff (just marked), so Rule 2 passes —
+    # the escalation cap (Rule 3) is what must now block.
+    res = _run_hook('git commit -m "wip"', repo, home)
+    assert res.returncode == 2, res.stdout + res.stderr
+    assert "escalation cap" in res.stderr
+
+
+def test_escalation_ack_allows_past_cap(repo, home):
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP)
+    res = _run_hook('git commit -m "wip"  # escalation-ack', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+def test_ack_inside_message_does_not_bypass(repo, home):
+    # The token buried in the -m string (not a clean trailing comment) must NOT ack.
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP)
+    res = _run_hook('git commit -m "escalation-ack please"', repo, home)
+    assert res.returncode == 2, res.stdout + res.stderr
+    assert "escalation cap" in res.stderr
+
+
+def test_below_cap_not_blocked_by_escalation(repo, home):
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP - 1)  # 2 rounds
+    res = _run_hook('git commit -m "wip"', repo, home)
+    assert res.returncode == 0, res.stderr  # review current + under cap → allowed
+
+
+def test_review_override_does_not_bypass_cap(repo, home):
+    # The cap is checked BEFORE Rule 2, so a '# review-override' (which would exit
+    # the review rule early) can NOT sneak a past-cap commit through.
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP)
+    _stage(repo, "unreviewed = 1\n")  # make review stale so override would apply
+    res = _run_hook('git commit -m "wip"  # review-override', repo, home)
+    assert res.returncode == 2, res.stdout + res.stderr
+    assert "escalation cap" in res.stderr
+
+
+def test_ack_resets_budget_no_permanent_friction(repo, home):
+    # Acking is a fresh decision → resets the round budget, so subsequent commits
+    # (back under the cap) don't each need a fresh ack.
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP)
+    r1 = _run_hook('git commit -m "wip"  # escalation-ack', repo, home)
+    assert r1.returncode == 0, r1.stderr  # ack allows + resets the counter
+    _git(repo, "commit", "-qm", "wip")  # actually land it
+    _stage(repo, "more = 1\n")
+    assert _mark(repo, home).returncode == 0  # one fresh review → round 1
+    r2 = _run_hook('git commit -m "wip2"', repo, home)
+    assert r2.returncode == 0, r2.stderr  # under cap again, no ack needed
+
+
+def test_clean_staged_mark_does_not_inflate(repo, _isolate_rounds):
+    # A mark with nothing staged ("clean" content hash) is not a review round.
+    _stage(repo, "a = 2\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 1
+    _git(repo, "commit", "-qm", "wip")  # staged area now clean
+    assert review_state.bump_review_round(cwd=str(repo)) == 1  # no inflation

--- a/tests/test_hooks/test_escalation_cap.py
+++ b/tests/test_hooks/test_escalation_cap.py
@@ -110,6 +110,56 @@ def test_reset_clears(repo, _isolate_rounds):
     assert review_state.get_review_round(cwd=str(repo)) == 0
 
 
+# ── Defect-bearing streak + reset-on-clean (option (e), round-4 fix) ───────
+
+
+def test_clean_mark_resets_streak(repo, _isolate_rounds):
+    # The counter tracks CONSECUTIVE defect-bearing rounds. Two defect-bearing
+    # rounds, then a clean review, must reset the streak to 0 — and the NEXT
+    # defect-bearing round starts fresh at 1, not resume at 3.
+    _stage(repo, "a = 2\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 1
+    _stage(repo, "a = 3\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 2
+    assert review_state.bump_review_round(cwd=str(repo), clean=True) == 0
+    assert review_state.get_review_round(cwd=str(repo)) == 0
+    _stage(repo, "a = 4\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 1
+
+
+def test_clean_resets_even_on_same_diff(repo, _isolate_rounds):
+    # A clean re-probe of the SAME staged diff still closes the breaker (reset),
+    # even though a defect-bearing re-mark of the same diff would be idempotent.
+    _stage(repo, "a = 2\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 1
+    assert review_state.bump_review_round(cwd=str(repo)) == 1  # same diff, idempotent
+    assert review_state.bump_review_round(cwd=str(repo), clean=True) == 0
+
+
+def test_defect_mark_on_same_diff_after_clean_reset_stays_zero(repo, _isolate_rounds):
+    # A clean reset records last_hash=<current>; a defect-bearing re-mark of the
+    # IDENTICAL staged diff is idempotent (nothing changed) → streak stays 0. The
+    # moment a real fix is staged (hash changes) the streak resumes at 1.
+    _stage(repo, "a = 2\n")
+    review_state.bump_review_round(cwd=str(repo))  # round 1
+    review_state.bump_review_round(cwd=str(repo), clean=True)  # reset, last_hash=H(a=2)
+    assert review_state.bump_review_round(cwd=str(repo)) == 0  # same diff → no new round
+    _stage(repo, "a = 3\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 1  # real change resumes at 1
+
+
+def test_defect_bearing_streak_still_reaches_cap_after_clean(repo, _isolate_rounds):
+    # Reset-on-clean must NOT defang the cap: after a clean reset, three fresh
+    # defect-bearing rounds still reach the cap (a genuine loop is still caught).
+    _stage(repo, "a = 2\n")
+    review_state.bump_review_round(cwd=str(repo))
+    review_state.bump_review_round(cwd=str(repo), clean=True)  # reset
+    for i, val in enumerate(("b = 1\n", "b = 2\n", "b = 3\n"), 1):
+        _stage(repo, val)
+        assert review_state.bump_review_round(cwd=str(repo)) == i
+    assert review_state.get_review_round(cwd=str(repo)) == review_state.ESCALATION_ROUND_CAP
+
+
 # ── Gate integration tests (review_enforcement_commit, subprocess) ────────
 
 
@@ -134,17 +184,20 @@ def _run_hook(command: str, repo: Path, home: Path) -> subprocess.CompletedProce
     )
 
 
-def _mark(repo: Path, home: Path) -> subprocess.CompletedProcess:
+def _mark(repo: Path, home: Path, *, clean: bool = False) -> subprocess.CompletedProcess:
     (home / ".genesis" / "last_code_review.txt").write_text("adversarial review: OK\n")
     env = {**os.environ, "HOME": str(home)}
+    args = [
+        sys.executable,
+        str(_REVIEW_STATE),
+        "mark",
+        "--agent-output",
+        str(home / ".genesis" / "last_code_review.txt"),
+    ]
+    if clean:
+        args.append("--clean")
     return subprocess.run(
-        [
-            sys.executable,
-            str(_REVIEW_STATE),
-            "mark",
-            "--agent-output",
-            str(home / ".genesis" / "last_code_review.txt"),
-        ],
+        args,
         cwd=str(repo),
         env=env,
         capture_output=True,
@@ -211,6 +264,37 @@ def test_ack_resets_budget_no_permanent_friction(repo, home):
     assert _mark(repo, home).returncode == 0  # one fresh review → round 1
     r2 = _run_hook('git commit -m "wip2"', repo, home)
     assert r2.returncode == 0, r2.stderr  # under cap again, no ack needed
+
+
+def test_codex_scenario_independent_clean_reviews_never_block(repo, home):
+    # Codex round-4 finding, verbatim: "When a branch contains three independently
+    # reviewed commits, or simply three clean reviews of distinct staged diffs,
+    # [the old counter] increments every time ... The commit gate then hard-blocks
+    # routine multi-commit development at round 3 even though no escalating
+    # review→fix loop occurred." With reset-on-clean the streak stays 0 throughout,
+    # so four clean-reviewed commits all pass the gate.
+    for i in range(1, 5):
+        _stage(repo, f"clean_{i} = {i}\n")
+        m = _mark(repo, home, clean=True)
+        assert m.returncode == 0, m.stderr
+        res = _run_hook(f'git commit -m "commit {i}"', repo, home)
+        assert res.returncode == 0, res.stdout + res.stderr
+        _git(repo, "commit", "-qm", f"commit {i}")  # actually land it
+
+
+def test_clean_mark_via_cli_prevents_block_after_defect_rounds(repo, home):
+    # Full CLI plumbing: two defect-bearing rounds, then a clean review via the
+    # `--clean` flag resets the streak, so the next commit is not blocked.
+    _reach_rounds(repo, home, 2)  # 2 defect-bearing rounds
+    _stage(repo, "clean_pass = 1\n")
+    m = _mark(repo, home, clean=True)
+    assert m.returncode == 0, m.stderr
+    assert "streak reset" in m.stdout
+    key = review_state._worktree_key(cwd=str(repo))
+    rf = home / ".genesis" / "review_rounds" / f"{key}.json"
+    assert json.loads(rf.read_text())["round"] == 0
+    res = _run_hook('git commit -m "wip"', repo, home)
+    assert res.returncode == 0, res.stdout + res.stderr
 
 
 def test_clean_staged_mark_does_not_inflate(repo, _isolate_rounds):

--- a/tests/test_hooks/test_escalation_cap.py
+++ b/tests/test_hooks/test_escalation_cap.py
@@ -248,3 +248,45 @@ def test_corrupt_round_counter_does_not_crash(repo, _isolate_rounds):
     rf.write_text(json.dumps({"branch": branch, "round": "not-an-int", "last_hash": "old"}))
     result = review_state.bump_review_round(cwd=str(repo))  # must not raise
     assert result == 1  # coerced the bad value to 0, then +1
+
+
+# ── Malformed counter-file shape (round-3 class fix) ──────────────────────
+
+
+def _write_round_file(repo, content: str) -> None:
+    rf = review_state._round_file(cwd=str(repo))
+    rf.parent.mkdir(parents=True, exist_ok=True)
+    rf.write_text(content)
+
+
+@pytest.mark.parametrize("bad", ["[]", "42", '"str"', "null", "[1, 2, 3]"])
+def test_load_round_returns_empty_for_non_dict(repo, _isolate_rounds, bad):
+    # Valid JSON that is not an object (manual edit / schema skew) must normalize to
+    # {} at the load boundary, so no caller's .get() can ever raise.
+    _write_round_file(repo, bad)
+    assert review_state._load_round(cwd=str(repo)) == {}
+
+
+def test_get_review_round_no_crash_on_truthy_non_dict(repo, _isolate_rounds):
+    # A TRUTHY non-dict ([1,2,3], 42) is the real crasher (empty [] is falsy and was
+    # already short-circuited) — get_review_round must fail open to 0, not raise.
+    _write_round_file(repo, "[1, 2, 3]")
+    assert review_state.get_review_round(cwd=str(repo)) == 0
+
+
+def test_bump_no_crash_on_truthy_non_dict(repo, _isolate_rounds):
+    _write_round_file(repo, "42")
+    _stage(repo, "a = 2\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 1  # treats as fresh, no crash
+
+
+def test_gate_fails_open_on_non_dict_counter(repo, home):
+    # End-to-end: a truthy non-dict counter file must NOT crash the commit gate.
+    _stage(repo, "a = 2\n")
+    assert _mark(repo, home).returncode == 0
+    key = review_state._worktree_key(cwd=str(repo))
+    rf = home / ".genesis" / "review_rounds" / f"{key}.json"
+    rf.parent.mkdir(parents=True, exist_ok=True)
+    rf.write_text("[1, 2, 3]")  # non-dict → gate must fail open, not crash
+    res = _run_hook('git commit -m "wip"', repo, home)
+    assert res.returncode == 0, res.stdout + res.stderr

--- a/tests/test_hooks/test_escalation_cap.py
+++ b/tests/test_hooks/test_escalation_cap.py
@@ -219,3 +219,32 @@ def test_clean_staged_mark_does_not_inflate(repo, _isolate_rounds):
     assert review_state.bump_review_round(cwd=str(repo)) == 1
     _git(repo, "commit", "-qm", "wip")  # staged area now clean
     assert review_state.bump_review_round(cwd=str(repo)) == 1  # no inflation
+
+
+def test_docs_only_commit_still_blocked_at_cap(repo, home):
+    # The hard stop must NOT be bypassable by file extension: a docs/skill-only
+    # commit at the cap (which would otherwise hit the docs-skip) is still blocked.
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP)
+    _git(repo, "commit", "-qm", "land code")  # clear staging (direct git, no gate)
+    (repo / "README.md").write_text("# docs change\n")
+    _git(repo, "add", "-A")  # staged set is now docs-only
+    res = _run_hook('git commit -m "docs"', repo, home)
+    assert res.returncode == 2, res.stdout + res.stderr
+    assert "escalation cap" in res.stderr
+    # ...and an ack lets the docs commit through.
+    res2 = _run_hook('git commit -m "docs"  # escalation-ack', repo, home)
+    assert res2.returncode == 0, res2.stderr
+
+
+def test_corrupt_round_counter_does_not_crash(repo, _isolate_rounds):
+    # A non-integer 'round' (corrupt / partial write / version skew) must NOT raise
+    # from bump — marking a review must always succeed (best-effort counter).
+    import json
+
+    _stage(repo, "a = 2\n")
+    rf = review_state._round_file(cwd=str(repo))
+    rf.parent.mkdir(parents=True, exist_ok=True)
+    branch = review_state.get_current_branch(cwd=str(repo))
+    rf.write_text(json.dumps({"branch": branch, "round": "not-an-int", "last_hash": "old"}))
+    result = review_state.bump_review_round(cwd=str(repo))  # must not raise
+    assert result == 1  # coerced the bad value to 0, then +1

--- a/tests/test_hooks/test_escalation_cap.py
+++ b/tests/test_hooks/test_escalation_cap.py
@@ -374,3 +374,52 @@ def test_gate_fails_open_on_non_dict_counter(repo, home):
     rf.write_text("[1, 2, 3]")  # non-dict → gate must fail open, not crash
     res = _run_hook('git commit -m "wip"', repo, home)
     assert res.returncode == 0, res.stdout + res.stderr
+
+
+# ── Malformed counter-file VALUE (round-5 class fix: 1e999 → inf → OverflowError) ──
+
+
+def test_coerce_finite_int_rejects_non_finite():
+    # int(float('inf')) raises OverflowError (not caught by TypeError/ValueError);
+    # int(nan) raises ValueError. The helper must absorb ALL of them → default.
+    assert review_state._coerce_finite_int(float("inf")) == 0
+    assert review_state._coerce_finite_int(float("-inf")) == 0
+    assert review_state._coerce_finite_int(float("nan")) == 0
+    assert review_state._coerce_finite_int("not-a-number") == 0
+    assert review_state._coerce_finite_int(None) == 0
+    assert review_state._coerce_finite_int(5) == 5
+    assert review_state._coerce_finite_int(3.9) == 3  # finite float still truncates
+
+
+def test_load_round_coerces_non_finite_round_to_zero(repo, _isolate_rounds):
+    # A well-formed dict whose 'round' is a non-finite JSON number (1e999 → inf)
+    # must be coerced to 0 at the load boundary — int(inf) OverflowError escapes the
+    # plain int() guards and would crash the gate. Both the load boundary and
+    # get_review_round must fail open to 0.
+    branch = review_state.get_current_branch(cwd=str(repo))
+    _write_round_file(repo, '{"branch": "' + branch + '", "round": 1e999, "last_hash": "x"}')
+    assert review_state._load_round(cwd=str(repo))["round"] == 0
+    assert review_state.get_review_round(cwd=str(repo)) == 0
+
+
+def test_bump_no_crash_on_infinity_round(repo, _isolate_rounds):
+    # A defect-bearing bump over an infinity 'round' must not raise; it coerces the
+    # bad value to 0 and increments to 1.
+    branch = review_state.get_current_branch(cwd=str(repo))
+    _write_round_file(repo, '{"branch": "' + branch + '", "round": 1e999, "last_hash": "old"}')
+    _stage(repo, "a = 2\n")
+    assert review_state.bump_review_round(cwd=str(repo)) == 1
+
+
+def test_gate_fails_open_on_infinity_round(repo, home):
+    # End-to-end: the gate calls get_review_round() unguarded; an infinity 'round'
+    # in the counter file must fail open (round→0 < cap → allowed), not crash.
+    _stage(repo, "a = 2\n")
+    assert _mark(repo, home).returncode == 0
+    branch = review_state.get_current_branch(cwd=str(repo))
+    key = review_state._worktree_key(cwd=str(repo))
+    rf = home / ".genesis" / "review_rounds" / f"{key}.json"
+    rf.parent.mkdir(parents=True, exist_ok=True)
+    rf.write_text('{"branch": "' + branch + '", "round": 1e999, "last_hash": "x"}')
+    res = _run_hook('git commit -m "wip"', repo, home)
+    assert res.returncode == 0, res.stdout + res.stderr


### PR DESCRIPTION
## Machine-enforce the review escalation cap at the commit gate

### Problem
The "stop after 3 review→fix→re-review rounds" escalation cap lived only in the
genesis-development skill prose, so a standing "proceed / merge when clean" could
silently carry a review loop past it (a recent PR ran ~7 rounds this way). Make it
machine-enforced.

### Change
- **`scripts/review_state.py`** — a per-branch counter of **consecutive
  defect-bearing review rounds**, in a store SEPARATE from the review marker (the
  marker is cleared on every commit; the round count must survive the commits a
  review loop makes between rounds). `bump_review_round(clean=)` (called from
  `mark_reviewed`) counts a round only when the review recorded a **new defect**
  (`clean=False`, the default) **and** the staged content changed since the last
  counted mark — hashing `git diff --cached` **content**, not `--stat`. A **clean**
  review (`clean=True`: no BLOCKER/SHOULD-FIX/P1/P2) **resets the streak to 0**
  (circuit-breaker reset-on-success). A re-mark of the same diff, an empty index, or
  a git error does not count; a branch change resets. `ESCALATION_ROUND_CAP = 3`.
- **`scripts/review_enforcement_commit.py`** — a new Rule 3, checked **before** the
  review-required rule so a `# review-override` can't sneak a past-cap commit
  through. At `round >= cap` it hard-blocks unless **every** commit segment carries
  a clean trailing `# escalation-ack` (quote-safe via `shell_parse.has_trailing_override`,
  matching the `# review-override` machinery). The ack is a fresh decision to
  continue and **resets the round budget** (no per-commit friction for the rest of
  the branch's life). It does not bypass the `--no-verify` or main-branch guards.
- **`SKILL.md`** — documents the machine backstop under the existing prose cap.

Fail-open on a missing/corrupt counter or import skew (consistent with the existing
gate — this is a discipline backstop, not a security control).

### Counting semantics (round-4 resolution)
The cap's own definition in the skill prose is *"3 rounds that **each find NEW
defects**"* — so the counter must count **defect-bearing** rounds, not distinct
diffs. The earlier revision counted distinct staged diffs, which meant three
independent **clean** reviews of distinct commits would trip the cap and hard-block
routine multi-commit development (Codex round-4 P2). The counter now implements the
prose literally:
- **defect-bearing round** (`mark --agent-output <path>`) → counts;
- **clean round** (`mark --agent-output <path> --clean`, no BLOCKER/SHOULD-FIX/P1/P2)
  → resets the streak to 0.

`clean` is pinned in `SKILL.md` to BLOCKER/SHOULD-FIX/P1/P2 only — NOTEs and nitpicks
do **not** make a round defect-bearing (otherwise a nitpick-prone reviewer collapses
the semantics back into raw counting). An unflagged mark defaults to defect-bearing
(fail toward catching loops). The `--clean` flag mirrors the review record written to
`~/.genesis/last_code_review.txt` at the same moment — same trust model as
`# review-override`, a deliberate-friction layer, not a security control. A **blocking
raw activity ceiling was deliberately not added** — it would re-introduce exactly this
false-positive; a visibility-only ceiling is deferred to a follow-up.

### Tests
`tests/test_hooks/test_escalation_cap.py` (hermetic throwaway-repo): counter unit
tests (distinct-content increments, same-diff/clean-index no-ops, branch reset,
malformed-counter fail-open) + defect-bearing/reset-on-clean tests (**Codex's exact
scenario as `test_codex_scenario_independent_clean_reviews_never_block`**,
clean-mark-resets-streak, clean-resets-same-diff, defect-mark-same-diff-after-reset,
streak-still-reaches-cap-after-clean, clean-via-CLI) + malformed-counter
value-class tests (`_coerce_finite_int` rejects inf/-inf/nan/str/None; load
boundary coerces `1e999`→0; gate fails open end-to-end on an infinity round) + gate
integration (blocked at cap, `# escalation-ack` allows + resets, review-override
does NOT bypass, ack-in-message doesn't spoof, docs-only still blocked at cap).
32/32 escalation + 63/63 `test_review_enforcement_commit.py`. Plus a live E2E
dry-run (real scripts, throwaway repo): 4/4 — clean reviews never block,
defect-bearing rounds trip, ack clears+resets, mid-loop clean resets.

### Review
Self-review + adversarial passes across the review→fix loop (the cap dogfooded on
its own PR): r1 self+adversarial (3 SHOULD-FIX — review-override bypassed the cap →
Rule 3 moved before Rule 2; `any()`→`all()` for multi-commit ack; counter never
reset → reset-on-ack, wiring the previously-dead `reset_review_round`; + 1 NOTE
clean/unknown-hash inflation → guarded); r2 Codex (2 P2 — docs-skip bypass, int
crash); r3 Codex (1 P2 — non-dict counter JSON → normalized at the single load
boundary); **r4 Codex (count defect-bearing rounds not distinct diffs →
circuit-breaker reset-on-clean)**; r5 Codex (1 P2 — a well-formed counter with
`round: 1e999` parses to inf; `int(inf)` raises `OverflowError`, escaping the
guards → the malformed-counter VALUE class, closed at the same load boundary via
`_coerce_finite_int` + non-finite rejection). Rounds 3–5 each hit the escalation
cap's own prose threshold → each stopped for a fresh user decision (this PR
dogfooding the cap it builds): r3 → robust shape normalization; r4 → the
defect-bearing semantic redesign; r5 → close the value class by construction +
merge on standing authority without another review loop.

### Deploy
Hooks/scripts — take effect at the next Claude Code session start (no server restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)