### PR TITLE
feat(memory): dream-cycle importance shield + widened centrality (shadow)

### DIFF
--- a/config/dream_shield.yaml
+++ b/config/dream_shield.yaml
@@ -1,0 +1,32 @@
+# Dream-cycle importance-shield policy.
+#
+# Protects high-salience memories from being consolidated away by the dream
+# merge path. Enabled by default. Edit the user overlay
+# (~/.genesis/config/dream_shield.local.yaml) to change these per install;
+# this shipped file is the zero-overlay default and must work as-is.
+#
+# Off switches: set `enabled: false` here/overlay, or export
+# GENESIS_DREAM_SHIELD_DISABLED=1 (scheduler-level kill switch).
+
+enabled: true
+
+# Shield a member at/above this percentile of the collection's live activation
+# distribution (0.90 = protect the top ~10% most-salient memories from merge).
+activation_percentile: 0.90
+
+# Shield a member at/above this percentile of the NONZERO betweenness-centrality
+# distribution (bridge-node protection). Ignored when the centrality cache is
+# empty (fresh install) — the shield falls back to activation + confidence only.
+centrality_percentile: 0.90
+
+# Shield any member at/above this raw confidence regardless of activation.
+# Catches rare-but-critical, rarely-retrieved memories that activation alone
+# would miss. Set above the common 0.95 extraction-default (only the deliberately
+# high-confidence tail, ~6% of memories, clears 0.98) — a lower floor would make
+# a fifth of the store merge-immune.
+confidence_floor: 0.98
+
+# Weekly link-repair prunes the graph edges of nodes deprecated at least this
+# many days ago. MUST exceed the manual dream-rollback review window — rollback
+# restores deprecated memories but CANNOT restore their pruned edges.
+deprecated_edge_prune_days: 30

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -36,7 +36,7 @@ side.
 ```yaml subsystem-map
 entry: memory
 modules: [memory, qdrant]
-verified: 51bfbb35 2026-07-30
+verified: 7706dc2f 2026-08-05
 ```
 
 **Cross-store integrity is detect + repair.** SQLite (`memory_metadata`/
@@ -143,6 +143,20 @@ weekly clustering (Sun 4am) persists a value-ranked worklist to
 change (#892). `_CapacityBreaker` aborts on consecutive provider exhaustion.
 `_cross_wing_scan` writes `memory_links` even under dry_run — intentional
 additive layer, not a leak.
+
+**Importance shield (Phase 2c)** — `memory/dream_shield.py` +
+`memory/dream_shield_config.py` (config: `config/dream_shield.yaml` + local
+overlay; env kill-switch `GENESIS_DREAM_SHIELD_DISABLED`). Before enqueue, the
+weekly pass removes high-salience members from clusters (skip-member) so the
+merge path never consolidates them away: shielded if activation ≥ collection
+percentile (production `compute_activation`), OR raw confidence ≥ a floor
+(default 0.98, above the 0.95 extraction-default spike), OR betweenness
+centrality ≥ the nonzero percentile. Thresholds freeze into each slice; the
+drain re-checks live members via `shield_filter_live` (catches salience that
+rose mid-week) and counts `shield_missing_thresholds` — which must be 0 before
+any live flip. Centrality persistence widened from top-500 to all-nonzero
+(`dream_centrality.py`, `graph.centrality_scores(top_n=None)`) so the shield has
+a real bridge-node population; `centrality_cache` gains its first reader.
 
 **Do not touch:** the drain's shadow hardwiring; the dry_run-independent link
 write. **Trap:** with no embedding provider registered, memory silently

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -100,6 +100,29 @@ async def batch_link_counts(
     return {mid: (total_map.get(mid, 0), inbound_map.get(mid, 0)) for mid in memory_ids}
 
 
+async def all_link_counts(db: aiosqlite.Connection) -> dict[str, int]:
+    """Total (bidirectional) link count for EVERY id in ``memory_links``.
+
+    One aggregate query over the whole table — no IN-lists. Intended for
+    full-collection passes (the dream-cycle importance shield scores every
+    memory), where the per-id-set :func:`batch_link_counts` would issue ~N/400
+    chunked queries. Callers that only need a specific id-set should keep using
+    :func:`batch_link_counts`.
+
+    Returns ``{memory_id: total_links}`` for every id that appears as a source
+    or target; ids with no links are simply absent (treat as 0). ``total_links``
+    matches the ``total`` element of :func:`batch_link_counts`.
+    """
+    rows = await db.execute_fetchall(
+        "SELECT id, COUNT(*) FROM ("
+        "  SELECT source_id AS id FROM memory_links"
+        "  UNION ALL"
+        "  SELECT target_id AS id FROM memory_links"
+        ") GROUP BY id",
+    )
+    return {row[0]: row[1] for row in rows}
+
+
 async def inter_candidate_links(
     db: aiosqlite.Connection,
     memory_ids: list[str],

--- a/src/genesis/memory/dream_centrality.py
+++ b/src/genesis/memory/dream_centrality.py
@@ -22,8 +22,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-TOP_N: int = 500
-
 
 async def run_centrality_recompute(
     *,
@@ -45,6 +43,7 @@ async def run_centrality_recompute(
     """
     report: dict[str, Any] = {
         "nodes_scored": 0,
+        "nodes_persisted": 0,
         "top_score": 0.0,
         "computation_ms": 0.0,
     }
@@ -53,7 +52,11 @@ async def run_centrality_recompute(
 
     t0 = time.monotonic()
     try:
-        scores = await centrality_scores(db, top_n=TOP_N)
+        # top_n=None: persist the FULL scored ranking (not just the top-500).
+        # Betweenness already computes every node — the widening only changes
+        # how many rows land in the cache, which the importance shield reads
+        # as its bridge-node population.
+        scores = await centrality_scores(db, top_n=None)
     except Exception as exc:
         logger.warning("Centrality computation failed: %s", exc, exc_info=True)
         report["error"] = str(exc)
@@ -67,8 +70,22 @@ async def run_centrality_recompute(
         report["top_score"] = round(scores[0][1], 6)
         report["top_memory"] = scores[0][0]
 
-    if not scores:
-        logger.info("Centrality: no scores computed (empty graph?)")
+    # Persist only NONZERO scores. Betweenness is heavily zero-inflated (with
+    # k-pivot approximation most nodes score exactly 0); persisting zeros would
+    # make a percentile over the cache degenerate to ~0 and shield everything,
+    # and would bloat the table toward the full collection size.
+    nonzero = [(mid, score) for mid, score in scores if score > 0.0]
+    report["nodes_persisted"] = len(nonzero)
+
+    if not nonzero:
+        # Still clear the cache — a run that finds no bridges supersedes stale
+        # rows (atomic replace, same as the populated path).
+        await db.execute("DELETE FROM centrality_cache")
+        await db.commit()
+        logger.info(
+            "Centrality: %d nodes scored, 0 nonzero (empty/degenerate graph?)",
+            len(scores),
+        )
         return report
 
     # Atomic replacement: delete all + insert batch
@@ -77,12 +94,12 @@ async def run_centrality_recompute(
     await db.executemany(
         "INSERT INTO centrality_cache (memory_id, centrality_score, computed_at) "
         "VALUES (?, ?, ?)",
-        [(mid, round(score, 8), now_iso) for mid, score in scores],
+        [(mid, round(score, 8), now_iso) for mid, score in nonzero],
     )
     await db.commit()
 
     logger.info(
-        "Centrality: cached %d scores in %.1fms (top: %.6f)",
-        len(scores), elapsed_ms, scores[0][1],
+        "Centrality: cached %d/%d nonzero scores in %.1fms (top: %.6f)",
+        len(nonzero), len(scores), elapsed_ms, nonzero[0][1],
     )
     return report

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -274,6 +274,50 @@ async def run(
         logger.warning("Cross-wing scan failed", exc_info=True)
         report["cross_wing_findings"] = []
 
+    # Phase 2c — Importance shield. Remove high-salience members (percentile
+    # activation / centrality, or a confidence floor) from clusters BEFORE they
+    # are enqueued, so the merge path never consolidates them away. Thresholds
+    # are computed over the true (non-deprecated) population in `buckets` here
+    # and frozen into each slice for the drain's live re-check. A shield failure
+    # must degrade toward LESS write authority — but pre-live (drain is SHADOW)
+    # the safe degradation is to enqueue UNSHIELDED and flag loudly: the drain's
+    # `shield_missing_thresholds` counter then stays non-zero, which is the
+    # explicit precondition gate on the future live-merge flip.
+    shield_thresholds: dict[str, Any] | None = None
+    try:
+        from genesis.memory import dream_shield
+
+        flat_points = [p for pts in buckets.values() for p in pts]
+        shield_state = await dream_shield.compute_shield_state(db, flat_points)
+        all_clusters, shield_stats = dream_shield.apply_shield_to_clusters(
+            all_clusters, shield_state,
+        )
+        if shield_state is not None:
+            shield_thresholds = {
+                "activation_threshold": shield_state.activation_threshold,
+                "centrality_threshold": shield_state.centrality_threshold,
+            }
+        report["shield"] = {
+            "enabled": shield_state is not None,
+            "activation_threshold": (
+                shield_state.activation_threshold if shield_state else None
+            ),
+            "centrality_threshold": (
+                shield_state.centrality_threshold if shield_state else None
+            ),
+            "population": shield_state.population if shield_state else 0,
+            **shield_stats,
+        }
+    except Exception as exc:
+        report["errors"].append({"phase": "shield", "error": str(exc)})
+        report["shield"] = {"enabled": False, "error": str(exc)}
+        logger.warning(
+            "Dream cycle %s: importance shield failed — enqueuing UNSHIELDED "
+            "(shadow-safe; the drain's shield_missing_thresholds gate blocks the "
+            "live flip): %s",
+            run_id[:8], exc, exc_info=True,
+        )
+
     # Phase 3 — Persist the value-ranked synthesis worklist for the daily drain.
     # Destructive synthesis/deprecate moved OUT of this weekly pass into
     # run_synthesis_drain (bounded daily slices). This enqueue runs in ALL modes:
@@ -283,6 +327,7 @@ async def run(
     try:
         worklist = await _persist_worklist(
             db, all_clusters, weekly_run_id=run_id, cap=WORKLIST_CAP,
+            shield_thresholds=shield_thresholds,
         )
         report["worklist_enqueued"] = worklist["enqueued"]
         report["oversize_flagged"] = worklist["oversize_flagged"]
@@ -376,10 +421,17 @@ async def _persist_worklist(
     *,
     weekly_run_id: str,
     cap: int = WORKLIST_CAP,
+    shield_thresholds: dict[str, Any] | None = None,
 ) -> dict[str, int]:
     """Persist the top-value clusters as the daily-drain worklist.
 
     Returns ``{"enqueued": n, "oversize_flagged": n, "superseded": n}``.
+
+    ``shield_thresholds`` (when set) is frozen into each slice payload as a
+    ``shield`` block, so the daily drain re-checks live members against the same
+    activation/centrality bar the weekly pass used (catching salience that rose
+    during the drain week). Absent it, slices carry no block — backward
+    compatible with pre-shield rows.
 
     Supersedes any prior ``dream_synthesis_slice`` rows (a fresh full re-cluster
     is authoritative) via an explicit synchronous supersede — NOT a staleness
@@ -406,13 +458,16 @@ async def _persist_worklist(
 
     enqueued = 0
     for cluster in ranked:
-        payload = json.dumps({
+        payload_dict: dict[str, Any] = {
             "member_ids": [item["id"] for item in cluster],
             "wing": cluster[0].get("wing", "general"),
             "room": cluster[0].get("room", "uncategorized"),
             "weekly_run_id": weekly_run_id,
             "value_score": len(cluster),
-        })
+        }
+        if shield_thresholds is not None:
+            payload_dict["shield"] = shield_thresholds
+        payload = json.dumps(payload_dict)
         item_id = await queue.enqueue(
             WORKLIST_WORK_TYPE, None, MEMORY_OPS, payload,
             "dream_cycle weekly synthesis worklist",
@@ -505,6 +560,15 @@ async def run_synthesis_drain(
         "memories_deprecated": 0, "adversarial_blocked": 0,
         "shrink_gate_blocked": 0, "rollback_flagged": False,
         "aborted_capacity": False, "aborted_infra": False, "errors": [],
+        # Importance-shield drain re-check (see dream_shield.shield_filter_live):
+        #  - shield_members_skipped: individual members removed from clusters
+        #  - shield_skipped: clusters completed as no-op because shielding left
+        #    <2 mergeable members (distinct from stale_skipped)
+        #  - shield_missing_thresholds: slices with no frozen shield block while
+        #    the shield is enabled (pre-upgrade rows / enqueue-time shield
+        #    failure) — must reach 0 before the PR2 live-merge flip
+        "shield_members_skipped": 0, "shield_skipped": 0,
+        "shield_missing_thresholds": 0,
     }
 
     # Preflight: don't consume the worklist when Qdrant is unreachable — a dead
@@ -557,16 +621,46 @@ async def run_synthesis_drain(
             )
             break
         report["drained"] += 1
-        if len(cluster) < 2:
-            # Normal lifecycle outcome (members deprecated since Sunday), not a
-            # failure — completed, so it doesn't surface on the dashboard
-            # errors view via query_failed (FM-5).
-            await queue.mark_completed(item["id"])
-            report["stale_skipped"] += 1
-            logger.info(
-                "Dream drain %s: slice stale (<2 live members) — completed as "
-                "no-op", run_id[:8],
+
+        # Importance-shield re-check against the FROZEN thresholds in the slice.
+        # A member whose salience rose during the drain week (e.g. retrieved
+        # more) is removed here even though it passed at enqueue. Enable state
+        # is read LIVE inside shield_filter_live, so an operator can disable the
+        # shield mid-week. A slice with no shield block predates the shield (or
+        # its enqueue-time computation failed) — do NOT filter (no bar to filter
+        # against), but count it: this counter must be 0 before the live flip.
+        from genesis.memory import dream_shield, dream_shield_config
+
+        shield_block = payload.get("shield")
+        n_shielded = 0
+        if shield_block is not None:
+            cluster, n_shielded = await dream_shield.shield_filter_live(
+                db, cluster,
+                activation_threshold=shield_block.get("activation_threshold"),
+                centrality_threshold=shield_block.get("centrality_threshold"),
             )
+            report["shield_members_skipped"] += n_shielded
+        elif dream_shield_config.shield_enabled():
+            report["shield_missing_thresholds"] += 1
+
+        if len(cluster) < 2:
+            # <2 mergeable members: a normal lifecycle no-op — completed, so it
+            # doesn't surface on the dashboard errors view (FM-5). Attribute the
+            # skip to the shield when shielding caused the shrink, else to
+            # staleness (members deprecated since Sunday).
+            await queue.mark_completed(item["id"])
+            if n_shielded > 0:
+                report["shield_skipped"] += 1
+                logger.info(
+                    "Dream drain %s: slice shielded below 2 members — completed "
+                    "as no-op", run_id[:8],
+                )
+            else:
+                report["stale_skipped"] += 1
+                logger.info(
+                    "Dream drain %s: slice stale (<2 live members) — completed "
+                    "as no-op", run_id[:8],
+                )
             continue
         pending.append((item, cluster))
 

--- a/src/genesis/memory/dream_shield.py
+++ b/src/genesis/memory/dream_shield.py
@@ -1,0 +1,281 @@
+"""Dream-cycle importance shield.
+
+Protects high-salience memories from being consolidated away by the dream merge
+path. The weekly clusterer enqueues near-duplicate clusters for merge; without
+a shield, a heavily-retrieved, high-confidence, or bridge-of-the-graph memory
+is merged into a synthesis exactly like a throwaway one (its salience and access
+history uncompensated). The shield removes such members from clusters BEFORE
+they are enqueued (skip-member: the unshielded remainder still merges if ≥2
+survive), and re-checks live at drain time to catch members whose salience rose
+during the week.
+
+Salience signals (any one shields a member):
+
+- **activation** ≥ the collection's activation percentile — the production
+  ``compute_activation`` score (confidence × recency × access/connectivity).
+- **confidence** ≥ an absolute floor — catches rare-but-critical, rarely-
+  retrieved memories that activation (an access-pattern proxy) would miss.
+- **centrality** ≥ the nonzero betweenness percentile — bridge nodes that
+  link-degree (already inside activation) cannot detect.
+
+Thresholds are computed at enqueue over the true (non-deprecated) population and
+FROZEN into each slice payload, so the daily drain re-checks against a stable
+bar (a percentile edit takes effect next weekly run). The enable/kill-switch
+state is read LIVE at drain, so an operator can disable mid-week.
+
+Pure-compute (one ``all_link_counts`` aggregate + per-member ``compute_activation``);
+no LLM calls, no mutations.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.db.crud import memory_links
+from genesis.memory import dream_shield_config
+from genesis.memory.activation import compute_activation
+
+logger = logging.getLogger(__name__)
+
+
+def _percentile(values: list[float], p: float) -> float | None:
+    """Value at percentile ``p`` (0..1) via nearest-rank on ascending order.
+
+    Returns None for an empty input. ``p`` is the fraction BELOW the returned
+    value, so ``p=0.9`` yields a threshold roughly the top-decile floor:
+    members ``>=`` it are ~the top 10%. ``p=0.0`` returns the minimum (shields
+    everything ``>=`` min, i.e. all).
+    """
+    if not values:
+        return None
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, int(p * len(ordered)))
+    return ordered[idx]
+
+
+@dataclass(frozen=True)
+class ShieldState:
+    """Frozen snapshot of the shield's thresholds + per-member scores.
+
+    ``activation_threshold`` is None only when the population is empty;
+    ``centrality_threshold`` is None when the centrality cache holds no nonzero
+    rows (fresh install) — in both cases that signal simply doesn't fire.
+    """
+
+    activation_threshold: float | None
+    centrality_threshold: float | None
+    confidence_floor: float
+    activation_by_id: dict[str, float] = field(default_factory=dict)
+    centrality_by_id: dict[str, float] = field(default_factory=dict)
+    population: int = 0
+
+
+def _activation_for(point: dict, link_count: int, now: str) -> float:
+    """Production activation for one point, mirroring HybridRetriever's field
+    extraction (retrieval.py ``_compute_activations``). Missing ``created_at``
+    falls back to ``now`` (recency 1.0) — conservative (over-shields).
+
+    Returns 0.0 on any compute error (e.g. a malformed timestamp): one bad
+    payload among tens of thousands must NEVER crash the whole shield. A 0.0
+    activation simply means "not shielded by the activation signal" — the
+    confidence floor and centrality still apply to that member.
+    """
+    payload = point.get("payload", {})
+    try:
+        return compute_activation(
+            confidence=payload.get("confidence", 0.5),
+            created_at=payload.get("created_at") or now,
+            retrieved_count=payload.get("retrieved_count", 0),
+            link_count=link_count,
+            source=payload.get("source", ""),
+            tags=payload.get("tags") or [],
+            now=now,
+            memory_class=payload.get("memory_class", "fact"),
+            last_retrieved_at=payload.get("last_retrieved_at"),
+        ).final_score
+    except Exception:
+        logger.debug(
+            "Shield: activation compute failed for %s — treating as 0.0",
+            point.get("id"),
+            exc_info=True,
+        )
+        return 0.0
+
+
+async def _centrality_map(
+    db: aiosqlite.Connection, memory_ids: list[str] | None = None
+) -> dict[str, float]:
+    """Load betweenness scores from centrality_cache. Whole cache when
+    ``memory_ids`` is None (enqueue-time percentile population); a specific
+    id-set at drain time."""
+    if memory_ids is None:
+        rows = await db.execute_fetchall("SELECT memory_id, centrality_score FROM centrality_cache")
+        return {r[0]: r[1] for r in rows}
+    if not memory_ids:
+        return {}
+    _CHUNK = 800
+    out: dict[str, float] = {}
+    for off in range(0, len(memory_ids), _CHUNK):
+        chunk = memory_ids[off : off + _CHUNK]
+        ph = ",".join("?" * len(chunk))
+        rows = await db.execute_fetchall(
+            f"SELECT memory_id, centrality_score FROM centrality_cache "  # noqa: S608 - placeholders bound
+            f"WHERE memory_id IN ({ph})",
+            chunk,
+        )
+        for r in rows:
+            out[r[0]] = r[1]
+    return out
+
+
+async def compute_shield_state(
+    db: aiosqlite.Connection,
+    points: list[dict],
+    *,
+    now: str | None = None,
+) -> ShieldState | None:
+    """Compute enqueue-time thresholds + per-member scores over the full
+    (non-deprecated) collection. Returns None when the shield is disabled.
+
+    ``points`` are ``{"id", "payload": {...}}`` dicts (the flattened dream
+    buckets). Uses one ``all_link_counts`` aggregate for connectivity.
+    """
+    if not dream_shield_config.shield_enabled():
+        return None
+
+    cfg = dream_shield_config.load_config()
+    act_pct = dream_shield_config.knob_float01(cfg, "activation_percentile")
+    cent_pct = dream_shield_config.knob_float01(cfg, "centrality_percentile")
+    conf_floor = dream_shield_config.knob_float01(cfg, "confidence_floor")
+    now_str = now or datetime.now(UTC).isoformat()
+
+    link_counts = await memory_links.all_link_counts(db)
+    activation_by_id: dict[str, float] = {}
+    for pt in points:
+        mid = pt["id"]
+        activation_by_id[mid] = _activation_for(pt, link_counts.get(mid, 0), now_str)
+
+    activation_threshold = _percentile(list(activation_by_id.values()), act_pct)
+
+    centrality_by_id = await _centrality_map(db)
+    nonzero = [v for v in centrality_by_id.values() if v > 0.0]
+    centrality_threshold = _percentile(nonzero, cent_pct) if nonzero else None
+
+    return ShieldState(
+        activation_threshold=activation_threshold,
+        centrality_threshold=centrality_threshold,
+        confidence_floor=conf_floor,
+        activation_by_id=activation_by_id,
+        centrality_by_id=centrality_by_id,
+        population=len(points),
+    )
+
+
+def _shielded(
+    activation: float,
+    confidence: float,
+    centrality: float,
+    *,
+    act_thr: float | None,
+    cent_thr: float | None,
+    conf_floor: float,
+) -> bool:
+    """Shared predicate: any salience signal at/above its bar shields."""
+    if act_thr is not None and activation >= act_thr:
+        return True
+    if confidence >= conf_floor:
+        return True
+    return cent_thr is not None and centrality >= cent_thr
+
+
+def _member_is_shielded(member: dict, state: ShieldState) -> bool:
+    """Enqueue-time predicate — scores come from the precomputed state maps."""
+    mid = member["id"]
+    return _shielded(
+        state.activation_by_id.get(mid, 0.0),
+        member.get("payload", {}).get("confidence", 0.5),
+        state.centrality_by_id.get(mid, 0.0),
+        act_thr=state.activation_threshold,
+        cent_thr=state.centrality_threshold,
+        conf_floor=state.confidence_floor,
+    )
+
+
+def apply_shield_to_clusters(
+    clusters: list[list[dict]],
+    state: ShieldState | None,
+) -> tuple[list[list[dict]], dict[str, int]]:
+    """Remove shielded members from each cluster (skip-member).
+
+    A cluster keeps its unshielded members if ≥2 survive; otherwise it is
+    dropped entirely (a 1-member cluster is not mergeable). Returns the
+    surviving clusters and stats. ``state=None`` (shield disabled) is a no-op.
+    """
+    stats = {"members_shielded": 0, "clusters_trimmed": 0, "clusters_dropped": 0}
+    if state is None:
+        return clusters, stats
+
+    out: list[list[dict]] = []
+    for cluster in clusters:
+        survivors = [m for m in cluster if not _member_is_shielded(m, state)]
+        removed = len(cluster) - len(survivors)
+        stats["members_shielded"] += removed
+        if len(survivors) < 2:
+            if removed:
+                stats["clusters_dropped"] += 1
+            else:
+                out.append(cluster)  # untouched (already sub-2 upstream — keep as-is)
+            continue
+        if removed:
+            stats["clusters_trimmed"] += 1
+        out.append(survivors)
+    return out, stats
+
+
+async def shield_filter_live(
+    db: aiosqlite.Connection,
+    cluster: list[dict],
+    *,
+    activation_threshold: float | None,
+    centrality_threshold: float | None,
+    now: str | None = None,
+) -> tuple[list[dict], int]:
+    """Drain-time re-check on LIVE payloads against the FROZEN slice thresholds.
+
+    Catches members whose salience rose during the drain week (e.g.
+    retrieved_count climbed). Reads the confidence floor and enable state LIVE
+    from config. Returns (survivors, shielded_count). No-op when disabled.
+    """
+    if not dream_shield_config.shield_enabled():
+        return cluster, 0
+
+    conf_floor = dream_shield_config.knob_float01(
+        dream_shield_config.load_config(), "confidence_floor"
+    )
+    now_str = now or datetime.now(UTC).isoformat()
+
+    ids = [m["id"] for m in cluster]
+    link_counts = await memory_links.batch_link_counts(db, ids)
+    cent_map = await _centrality_map(db, ids) if centrality_threshold is not None else {}
+
+    survivors: list[dict] = []
+    shielded = 0
+    for m in cluster:
+        mid = m["id"]
+        act = _activation_for(m, link_counts.get(mid, (0, 0))[0], now_str)
+        if _shielded(
+            act,
+            m.get("payload", {}).get("confidence", 0.5),
+            cent_map.get(mid, 0.0),
+            act_thr=activation_threshold,
+            cent_thr=centrality_threshold,
+            conf_floor=conf_floor,
+        ):
+            shielded += 1
+        else:
+            survivors.append(m)
+    return survivors, shielded

--- a/src/genesis/memory/dream_shield.py
+++ b/src/genesis/memory/dream_shield.py
@@ -74,6 +74,21 @@ class ShieldState:
     population: int = 0
 
 
+def _safe_confidence(payload: dict) -> float:
+    """Payload confidence coerced to a float — None/non-numeric → 0.5.
+
+    A present-but-null ``confidence`` makes ``payload.get("confidence", 0.5)``
+    return ``None`` (the default applies only to ABSENT keys), and ``None >=
+    float`` raises ``TypeError``. One such payload must not crash the floor
+    comparison (weekly: disables the shield for the worklist; drain: propagates
+    after mark_processing and stalls the shadow drain).
+    """
+    v = payload.get("confidence", 0.5)
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
+        return 0.5
+    return float(v)
+
+
 def _activation_for(point: dict, link_count: int, now: str) -> float:
     """Production activation for one point, mirroring HybridRetriever's field
     extraction (retrieval.py ``_compute_activations``). Missing ``created_at``
@@ -87,7 +102,7 @@ def _activation_for(point: dict, link_count: int, now: str) -> float:
     payload = point.get("payload", {})
     try:
         return compute_activation(
-            confidence=payload.get("confidence", 0.5),
+            confidence=_safe_confidence(payload),
             created_at=payload.get("created_at") or now,
             retrieved_count=payload.get("retrieved_count", 0),
             link_count=link_count,
@@ -161,7 +176,16 @@ async def compute_shield_state(
 
     activation_threshold = _percentile(list(activation_by_id.values()), act_pct)
 
-    centrality_by_id = await _centrality_map(db)
+    # Centrality percentile over the LIVE population only. centrality_cache is
+    # built from the full memory_links graph (deprecated nodes included — dream
+    # soft-deletes keep metadata/links for rollback), so restrict to the current
+    # point ids before thresholding — otherwise stale high-centrality deprecated
+    # rows inflate the bar and a live bridge that should be protected stays
+    # mergeable (activation uses only these live points, so the populations must
+    # match).
+    point_ids = {pt["id"] for pt in points}
+    full_centrality = await _centrality_map(db)
+    centrality_by_id = {mid: v for mid, v in full_centrality.items() if mid in point_ids}
     nonzero = [v for v in centrality_by_id.values() if v > 0.0]
     centrality_threshold = _percentile(nonzero, cent_pct) if nonzero else None
 
@@ -197,7 +221,7 @@ def _member_is_shielded(member: dict, state: ShieldState) -> bool:
     mid = member["id"]
     return _shielded(
         state.activation_by_id.get(mid, 0.0),
-        member.get("payload", {}).get("confidence", 0.5),
+        _safe_confidence(member.get("payload", {})),
         state.centrality_by_id.get(mid, 0.0),
         act_thr=state.activation_threshold,
         cent_thr=state.centrality_threshold,
@@ -269,7 +293,7 @@ async def shield_filter_live(
         act = _activation_for(m, link_counts.get(mid, (0, 0))[0], now_str)
         if _shielded(
             act,
-            m.get("payload", {}).get("confidence", 0.5),
+            _safe_confidence(m.get("payload", {})),
             cent_map.get(mid, 0.0),
             act_thr=activation_threshold,
             cent_thr=centrality_threshold,

--- a/src/genesis/memory/dream_shield_config.py
+++ b/src/genesis/memory/dream_shield_config.py
@@ -1,0 +1,135 @@
+"""Dream-cycle importance-shield control surface — enable lever + threshold knobs.
+
+The ONE place the dream-cycle shield consults for policy (the
+``memory_integrity_config`` / ``entity_adjudication_config`` lineage). Re-reads
+the merged YAML (``config/dream_shield.yaml`` + user overlay
+``~/.genesis/config/dream_shield.local.yaml``) on EVERY call — no boot cache, so
+an operator edit takes effect on the next scheduled run.
+
+The shield protects high-salience memories from being consolidated away by the
+dream-cycle merge path. It is enabled by default: the failure posture is to
+shield MORE (an invalid percentile falls back to the shipped 0.90, never to
+"shield nothing"), because a silently-off shield is exactly the blind spot this
+lever exists to make operator-controllable, not accidental.
+
+Two independent off switches:
+
+- ``enabled: false`` in the overlay — operator intent, honored immediately.
+- ``GENESIS_DREAM_SHIELD_DISABLED=1`` — scheduler-level env kill switch.
+
+Note ``deprecated_edge_prune_days`` lives here (not a merge knob) because it is
+coupled to the shield/rewire lifecycle: it bounds how long a deprecated node's
+graph edges linger before the weekly link-repair prune reaps them, and MUST
+exceed the manual dream-rollback review window (rollback cannot restore pruned
+edges).
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_NAME = "dream_shield.yaml"
+_ENV_KILL_SWITCH = "GENESIS_DREAM_SHIELD_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    # Shield any member at/above this percentile of the collection's live
+    # activation distribution (confidence × recency × access/connectivity).
+    "activation_percentile": 0.90,
+    # Shield any member at/above this percentile of the NONZERO betweenness-
+    # centrality distribution (bridge-node protection). Degrades to
+    # activation-only when the centrality cache is empty.
+    "centrality_percentile": 0.90,
+    # Shield any member at/above this raw confidence regardless of activation —
+    # closes the rare-but-critical, low-recency gap (activation proxies
+    # importance via access patterns, which breaks for high-stakes memories
+    # that are rarely retrieved). Set to 0.98, deliberately ABOVE the common
+    # 0.95 extraction-default spike (measured 2026-08-05: ~21% of live memories
+    # sit at >=0.95 but only ~6% at >=0.98) — otherwise the floor would protect
+    # a default-valued fifth of the store from ever merging, not the genuinely
+    # high-confidence tail.
+    "confidence_floor": 0.98,
+    # Weekly link-repair prunes graph edges of nodes deprecated at least this
+    # long ago. MUST exceed the dream-rollback review window (rollback cannot
+    # restore pruned edges). Consumed by the link-repair phase (PR-B2).
+    "deprecated_edge_prune_days": 30,
+}
+
+_INT_KNOBS = ("deprecated_edge_prune_days",)
+_FLOAT01_KNOBS = ("activation_percentile", "centrality_percentile", "confidence_floor")
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or
+    corrupt files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("dream_shield base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("dream_shield overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def env_disabled() -> bool:
+    """True if the scheduler-level kill switch is set."""
+    return os.environ.get(_ENV_KILL_SWITCH, "").strip().lower() in ("1", "true", "yes")
+
+
+def shield_enabled() -> bool:
+    """Whether the shield must run — read live.
+
+    Env kill switch or master ``enabled: false`` → off. Any other state → on
+    (the shield's fail-posture is to protect MORE, never to silently skip).
+    """
+    if env_disabled():
+        return False
+    cfg = load_config()
+    return bool(cfg.get("enabled", True))
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never crashes a
+    job or zeroes a limit."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value
+
+
+def knob_float01(cfg: dict[str, Any], key: str) -> float:
+    """[0,1] float knob with DEFAULTS fallback (percentiles, confidence floor)."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or not 0 <= value <= 1:
+        return float(DEFAULTS[key])
+    return float(value)

--- a/src/genesis/memory/graph.py
+++ b/src/genesis/memory/graph.py
@@ -200,12 +200,17 @@ async def traverse(
 
 async def centrality_scores(
     db: aiosqlite.Connection,
-    top_n: int = 100,
+    top_n: int | None = 100,
 ) -> list[tuple[str, float]]:
-    """Return top-N memories by betweenness centrality.
+    """Return memories ranked by betweenness centrality.
 
     Identifies memories that are "bridges" between clusters of knowledge.
     Requires NetworkX; returns empty list if unavailable.
+
+    ``top_n`` caps the returned slice; ``top_n=None`` returns EVERY scored
+    node (the full ranking). Betweenness is computed over all nodes regardless
+    — ``top_n`` is only a post-sort slice — so ``None`` adds no compute cost,
+    just a longer list.
     """
     if not _NX_AVAILABLE:
         return []
@@ -219,7 +224,7 @@ async def centrality_scores(
     k = min(200, n_nodes) if n_nodes > 200 else None
     scores = nx.betweenness_centrality(G, k=k)
     ranked = sorted(scores.items(), key=lambda x: x[1], reverse=True)
-    return ranked[:top_n]
+    return ranked if top_n is None else ranked[:top_n]
 
 
 # ─── CTE fallbacks ───────────────────────────────────────────────────────────

--- a/src/genesis/surplus/jobs/dream.py
+++ b/src/genesis/surplus/jobs/dream.py
@@ -100,6 +100,8 @@ async def run_dream_cycle() -> None:
                     f"{report.get('worklist_enqueued', 0)} enqueued for "
                     f"daily drain, "
                     f"{report.get('oversize_flagged', 0)} oversize flagged, "
+                    f"{report.get('shield', {}).get('members_shielded', 0)} "
+                    f"members shielded, "
                     f"{len(report.get('errors', []))} errors"
                 ),
                 priority="low",
@@ -219,6 +221,9 @@ async def run_dream_synthesis_drain() -> None:
                     f"{report.get('drained', 0)} drained, "
                     f"{report.get('would_merge', 0)} would merge, "
                     f"{report.get('stale_skipped', 0)} stale, "
+                    f"{report.get('shield_members_skipped', 0)} members shielded, "
+                    f"{report.get('shield_skipped', 0)} shield-skipped, "
+                    f"{report.get('shield_missing_thresholds', 0)} missing-thresholds, "
                     f"{len(report.get('errors', []))} errors"
                 ),
                 priority="low",

--- a/tests/test_db/test_memory_links.py
+++ b/tests/test_db/test_memory_links.py
@@ -480,3 +480,30 @@ async def test_neighbors_of_exclude_link_types_empty_is_noop(db):
     )
     rows = await memory_links.neighbors_of(db, ["seed"], exclude_link_types=())
     assert [r["memory_id"] for r in rows] == ["n1"]
+
+
+async def test_all_link_counts_empty_table(db):
+    assert await memory_links.all_link_counts(db) == {}
+
+
+async def test_all_link_counts_counts_both_directions(db):
+    # a—b, a—c, d—a : a touches 3 edges; b,c,d touch 1 each.
+    for s, t in [("a", "b"), ("a", "c"), ("d", "a")]:
+        await memory_links.create(
+            db, source_id=s, target_id=t, link_type="supports", created_at="2026-01-01"
+        )
+    counts = await memory_links.all_link_counts(db)
+    assert counts == {"a": 3, "b": 1, "c": 1, "d": 1}
+
+
+async def test_all_link_counts_agrees_with_batch_link_counts(db):
+    edges = [("x", "y"), ("y", "z"), ("x", "z"), ("x", "w")]
+    for s, t in edges:
+        await memory_links.create(
+            db, source_id=s, target_id=t, link_type="supports", created_at="2026-01-01"
+        )
+    all_counts = await memory_links.all_link_counts(db)
+    ids = ["x", "y", "z", "w"]
+    batch = await memory_links.batch_link_counts(db, ids)
+    for mid in ids:
+        assert all_counts[mid] == batch[mid][0], f"total mismatch for {mid}"

--- a/tests/test_memory/test_dream_centrality.py
+++ b/tests/test_memory/test_dream_centrality.py
@@ -100,3 +100,38 @@ async def test_centrality_runs_in_dry_run(phase_kwargs):
     db = phase_kwargs["db"]
     cursor = await db.execute("SELECT COUNT(*) FROM centrality_cache")
     assert (await cursor.fetchone())[0] == 1  # written even in dry_run
+
+
+async def test_centrality_requests_all_nodes(phase_kwargs):
+    """Widened persistence: centrality_scores is called with top_n=None so the
+    full scored population (not just top-500) is available to the shield."""
+    with patch(
+        "genesis.memory.graph.centrality_scores",
+        new_callable=AsyncMock,
+        return_value=[("mem-1", 0.5)],
+    ) as mock_scores:
+        await run_centrality_recompute(**phase_kwargs)
+
+    _, kwargs = mock_scores.call_args
+    assert kwargs.get("top_n") is None
+
+
+async def test_centrality_skips_zero_scores(phase_kwargs):
+    """Zero-betweenness nodes (the vast majority) are NOT persisted — otherwise
+    a percentile over the cache degenerates to 0 and shields everything."""
+    mock_scores = [("bridge", 0.42), ("z1", 0.0), ("z2", 0.0)]
+
+    with patch(
+        "genesis.memory.graph.centrality_scores",
+        new_callable=AsyncMock,
+        return_value=mock_scores,
+    ):
+        report = await run_centrality_recompute(**phase_kwargs)
+
+    assert report["nodes_scored"] == 3  # all computed
+    assert report["nodes_persisted"] == 1  # only the nonzero one
+
+    db = phase_kwargs["db"]
+    cursor = await db.execute("SELECT memory_id FROM centrality_cache")
+    rows = [r[0] for r in await cursor.fetchall()]
+    assert rows == ["bridge"]

--- a/tests/test_memory/test_dream_cycle.py
+++ b/tests/test_memory/test_dream_cycle.py
@@ -897,3 +897,160 @@ class TestAsyncYielding:
         # First call should be _scroll_and_group_sync
         first_call_fn = mock_to_thread.call_args_list[0][0][0]
         assert first_call_fn.__name__ == "_scroll_and_group_sync"
+
+
+# ── Importance shield wiring (worklist embedding + drain re-check) ────────────
+
+
+def _conf_cluster(confs, wing="memory", room="store", tag=""):
+    """Cluster with explicit per-member confidence (for shield tests)."""
+    return [
+        {
+            "id": f"{tag}{wing}-{room}-{i}",
+            "wing": wing,
+            "room": room,
+            "payload": {"content": f"fact {i}", "confidence": c, "wing": wing, "room": room},
+        }
+        for i, c in enumerate(confs)
+    ]
+
+
+class TestShieldWorklistEmbedding:
+    @pytest.mark.asyncio
+    async def test_persist_embeds_shield_block(self, db):
+        """When shield_thresholds is passed, each slice payload carries them so
+        the drain can re-check against the frozen bar."""
+        clusters = _clusters_of_sizes(3)
+        await _persist_worklist(
+            db, clusters, weekly_run_id="w",
+            shield_thresholds={"activation_threshold": 0.42, "centrality_threshold": None},
+        )
+        cursor = await db.execute(
+            "SELECT payload_json FROM deferred_work_queue WHERE work_type = ?",
+            (WORKLIST_WORK_TYPE,),
+        )
+        payload = json.loads((await cursor.fetchone())[0])
+        assert payload["shield"] == {"activation_threshold": 0.42, "centrality_threshold": None}
+
+    @pytest.mark.asyncio
+    async def test_persist_without_thresholds_has_no_shield_block(self, db):
+        """Backward compatible: no shield_thresholds → no shield block."""
+        await _persist_worklist(db, _clusters_of_sizes(2), weekly_run_id="w")
+        cursor = await db.execute(
+            "SELECT payload_json FROM deferred_work_queue WHERE work_type = ?",
+            (WORKLIST_WORK_TYPE,),
+        )
+        payload = json.loads((await cursor.fetchone())[0])
+        assert "shield" not in payload
+
+
+class TestShieldRunWiring:
+    @pytest.mark.asyncio
+    async def test_run_computes_shield_and_passes_thresholds(self, db):
+        """End-to-end through run(): the shield computes real thresholds over the
+        scrolled population and threads them into _persist_worklist."""
+        mock_qdrant = MagicMock()
+        with patch(_SCROLL) as mock_scroll, patch(_SEARCH) as mock_search, \
+             patch(_BATCH_VEC) as mock_vec, patch(
+                 "genesis.memory.dream_cycle._persist_worklist",
+                 new_callable=AsyncMock,
+                 return_value={"enqueued": 0, "oversize_flagged": 0, "superseded": 0},
+             ) as mock_persist:
+            mock_scroll.return_value = (
+                [
+                    {"id": "p1", "payload": {"wing": "memory", "room": "store",
+                                             "content": "fact A", "confidence": 0.9}},
+                    {"id": "p2", "payload": {"wing": "memory", "room": "store",
+                                             "content": "fact A rephrased", "confidence": 0.8}},
+                ],
+                None,
+            )
+            mock_search.return_value = [{"id": "p2", "score": 0.92, "payload": {}}]
+            mock_vec.return_value = {"p1": [0.1] * 768, "p2": [0.1] * 768}
+
+            report = await run(
+                qdrant=mock_qdrant, db=db, router=AsyncMock(),
+                store=AsyncMock(), dry_run=True,
+            )
+
+        assert report["shield"]["enabled"] is True
+        # Real activation percentile computed over the 2 scrolled points.
+        assert report["shield"]["activation_threshold"] is not None
+        assert report["shield"]["population"] == 2
+        # Thresholds were threaded into the worklist persist call.
+        passed = mock_persist.call_args.kwargs["shield_thresholds"]
+        assert passed is not None
+        assert "activation_threshold" in passed
+
+
+class TestShieldDrainRecheck:
+    @pytest.mark.asyncio
+    async def test_drain_trims_high_confidence_member(self, db):
+        """A member crossing the confidence floor is filtered at drain; the
+        unshielded remainder (>=2) still merges."""
+        cluster = _conf_cluster([0.4, 0.4, 0.99])  # 3rd shielded by floor 0.95
+        await _persist_worklist(
+            db, [cluster], weekly_run_id="w",
+            shield_thresholds={"activation_threshold": 999.0, "centrality_threshold": None},
+        )
+        report = await run_synthesis_drain(
+            qdrant=_drain_qdrant(_live_points(cluster)), db=db,
+            router=AsyncMock(), store=AsyncMock(), budget=10, dry_run=True,
+        )
+        assert report["drained"] == 1
+        assert report["shield_members_skipped"] == 1
+        assert report["would_merge"] == 1  # 2 survivors still mergeable
+        assert report["shield_skipped"] == 0
+
+    @pytest.mark.asyncio
+    async def test_drain_shield_drops_cluster_below_two(self, db):
+        """Shield removing a member from a 2-cluster leaves <2 survivors → the
+        cluster is completed as a shield-skip, distinct from stale-skip."""
+        cluster = _conf_cluster([0.4, 0.99])
+        await _persist_worklist(
+            db, [cluster], weekly_run_id="w",
+            shield_thresholds={"activation_threshold": 999.0, "centrality_threshold": None},
+        )
+        report = await run_synthesis_drain(
+            qdrant=_drain_qdrant(_live_points(cluster)), db=db,
+            router=AsyncMock(), store=AsyncMock(), budget=10, dry_run=True,
+        )
+        assert report["shield_skipped"] == 1
+        assert report["stale_skipped"] == 0
+        assert report["would_merge"] == 0
+        cursor = await db.execute(
+            "SELECT status FROM deferred_work_queue WHERE work_type = ?",
+            (WORKLIST_WORK_TYPE,),
+        )
+        assert [r["status"] for r in await cursor.fetchall()] == ["completed"]
+
+    @pytest.mark.asyncio
+    async def test_drain_missing_shield_block_counted_not_filtered(self, db):
+        """A pre-upgrade slice (no shield block) is NOT filtered but is counted —
+        the counter is the PR2 live-flip precondition (must reach 0)."""
+        cluster = _conf_cluster([0.99, 0.99])  # would all be shielded IF filtered
+        await _persist_worklist(db, [cluster], weekly_run_id="w")  # no thresholds
+        report = await run_synthesis_drain(
+            qdrant=_drain_qdrant(_live_points(cluster)), db=db,
+            router=AsyncMock(), store=AsyncMock(), budget=10, dry_run=True,
+        )
+        assert report["shield_missing_thresholds"] == 1
+        assert report["shield_members_skipped"] == 0
+        assert report["would_merge"] == 1  # unfiltered — still merges
+
+    @pytest.mark.asyncio
+    async def test_drain_shield_kill_switch_disables_filtering(self, db, monkeypatch):
+        """With the shield disabled, a slice carrying thresholds is NOT filtered."""
+        from genesis.memory import dream_shield_config
+        monkeypatch.setattr(dream_shield_config, "shield_enabled", lambda: False)
+        cluster = _conf_cluster([0.99, 0.99])
+        await _persist_worklist(
+            db, [cluster], weekly_run_id="w",
+            shield_thresholds={"activation_threshold": 0.0, "centrality_threshold": None},
+        )
+        report = await run_synthesis_drain(
+            qdrant=_drain_qdrant(_live_points(cluster)), db=db,
+            router=AsyncMock(), store=AsyncMock(), budget=10, dry_run=True,
+        )
+        assert report["shield_members_skipped"] == 0
+        assert report["would_merge"] == 1

--- a/tests/test_memory/test_dream_shield.py
+++ b/tests/test_memory/test_dream_shield.py
@@ -1,0 +1,232 @@
+"""Importance shield — percentile helper, state computation, cluster filtering,
+drain-time re-check. All install-agnostic (real db fixture, no live services)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from genesis.memory import dream_shield, dream_shield_config
+
+NOW = "2026-08-05T00:00:00+00:00"
+
+
+def _iso_days_ago(n: int) -> str:
+    return (datetime.fromisoformat(NOW) - timedelta(days=n)).isoformat()
+
+
+def _point(mid, *, confidence=0.5, retrieved_count=0, days_old=10, **extra):
+    payload = {
+        "confidence": confidence,
+        "retrieved_count": retrieved_count,
+        "created_at": _iso_days_ago(days_old),
+        "source": "session_extraction",
+        **extra,
+    }
+    return {"id": mid, "payload": payload}
+
+
+# ── percentile helper ─────────────────────────────────────────────────────────
+
+
+def test_percentile_empty_is_none():
+    assert dream_shield._percentile([], 0.9) is None
+
+
+def test_percentile_single_value():
+    assert dream_shield._percentile([0.4], 0.9) == 0.4
+
+
+def test_percentile_p90_top_decile():
+    # 10 values → p0.9 threshold is the max (top 10% = 1 element).
+    vals = [float(i) for i in range(10)]  # 0..9
+    assert dream_shield._percentile(vals, 0.9) == 9.0
+
+
+def test_percentile_p80_top_quintile():
+    vals = [float(i) for i in range(10)]  # 0..9
+    # p0.8 → index int(0.8*10)=8 → value 8; members >= 8 are {8,9} = top 20%.
+    assert dream_shield._percentile(vals, 0.8) == 8.0
+
+
+def test_percentile_unsorted_input():
+    assert dream_shield._percentile([5.0, 1.0, 9.0, 3.0, 7.0], 0.0) == 1.0
+
+
+# ── compute_shield_state ──────────────────────────────────────────────────────
+
+
+def _enable(monkeypatch, **overrides):
+    cfg = {
+        "enabled": True,
+        "activation_percentile": 0.90,
+        "centrality_percentile": 0.90,
+        "confidence_floor": 0.98,
+        "deprecated_edge_prune_days": 30,
+        **overrides,
+    }
+    monkeypatch.setattr(dream_shield_config, "load_config", lambda: cfg)
+    monkeypatch.setattr(dream_shield_config, "shield_enabled", lambda: cfg["enabled"])
+
+
+async def test_compute_shield_state_none_when_disabled(monkeypatch, db):
+    monkeypatch.setattr(dream_shield_config, "shield_enabled", lambda: False)
+    state = await dream_shield.compute_shield_state(db, [_point("a")], now=NOW)
+    assert state is None
+
+
+async def test_compute_shield_state_empty_points(monkeypatch, db):
+    _enable(monkeypatch)
+    state = await dream_shield.compute_shield_state(db, [], now=NOW)
+    assert state is not None
+    assert state.population == 0
+    assert state.activation_threshold is None  # nothing to threshold
+
+
+async def test_compute_shield_state_empty_centrality_cache(monkeypatch, db):
+    _enable(monkeypatch)
+    points = [_point(f"m{i}", retrieved_count=i, days_old=1) for i in range(10)]
+    state = await dream_shield.compute_shield_state(db, points, now=NOW)
+    assert state.centrality_threshold is None  # cache empty → activation-only
+    assert state.activation_threshold is not None
+    assert state.population == 10
+
+
+async def test_compute_shield_state_reads_nonzero_centrality(monkeypatch, db):
+    _enable(monkeypatch)
+    now_iso = NOW
+    await db.executemany(
+        "INSERT INTO centrality_cache (memory_id, centrality_score, computed_at) VALUES (?,?,?)",
+        [("bridge", 0.5, now_iso), ("mid", 0.2, now_iso), ("low", 0.01, now_iso)],
+    )
+    await db.commit()
+    points = [_point("bridge"), _point("mid"), _point("low")]
+    state = await dream_shield.compute_shield_state(db, points, now=NOW)
+    assert state.centrality_threshold is not None
+    assert state.centrality_by_id["bridge"] == 0.5
+
+
+async def test_high_retrieved_high_confidence_lands_above_threshold(monkeypatch, db):
+    _enable(monkeypatch)
+    # One clearly-salient point (recent, high confidence, heavily retrieved)
+    # among many dull ones with a realistic spread (increasing age → decreasing
+    # activation) → the star is shielded by activation; the dullest is not.
+    dull = [_point(f"d{i}", confidence=0.4, retrieved_count=0, days_old=100 + i) for i in range(20)]
+    star = _point("star", confidence=0.95, retrieved_count=15, days_old=1)
+    state = await dream_shield.compute_shield_state(db, [*dull, star], now=NOW)
+    assert dream_shield._member_is_shielded(star, state) is True
+    # dull[-1] is the oldest → lowest activation → well below the p90 bar.
+    assert dream_shield._member_is_shielded(dull[-1], state) is False
+
+
+# ── apply_shield_to_clusters ──────────────────────────────────────────────────
+
+
+async def test_compute_shield_state_survives_malformed_created_at(monkeypatch, db):
+    """One point with a garbage created_at must not crash the whole shield —
+    it gets activation 0.0 (not shielded by activation) while the rest score."""
+    _enable(monkeypatch)
+    good = [_point(f"g{i}", retrieved_count=i, days_old=1) for i in range(5)]
+    bad = {
+        "id": "bad",
+        "payload": {
+            "confidence": 0.5,
+            "created_at": "not-a-date",
+            "retrieved_count": 0,
+            "source": "session_extraction",
+        },
+    }
+    state = await dream_shield.compute_shield_state(db, [*good, bad], now=NOW)
+    assert state is not None
+    assert state.population == 6
+    assert state.activation_by_id["bad"] == 0.0  # degraded, not crashed
+
+
+async def test_shield_filter_live_survives_malformed_created_at(monkeypatch, db):
+    """A malformed live payload at drain must not break the drain."""
+    _enable(monkeypatch)
+    bad = {"id": "bad", "payload": {"confidence": 0.4, "created_at": "xyz"}}
+    a, b = _point("a", confidence=0.4), _point("b", confidence=0.4)
+    survivors, n = await dream_shield.shield_filter_live(
+        db, [bad, a, b], activation_threshold=0.30, centrality_threshold=None, now=NOW
+    )
+    assert n == 0  # bad point degrades to activation 0.0, not shielded
+    assert {m["id"] for m in survivors} == {"bad", "a", "b"}
+
+
+async def test_apply_shield_none_state_is_noop():
+    clusters = [[_point("a"), _point("b")]]
+    out, stats = dream_shield.apply_shield_to_clusters(clusters, None)
+    assert out == clusters
+    assert stats == {"members_shielded": 0, "clusters_trimmed": 0, "clusters_dropped": 0}
+
+
+async def test_apply_shield_trims_shielded_member(monkeypatch, db):
+    _enable(monkeypatch)
+    star = _point("star", confidence=0.99)  # shielded by confidence floor
+    a, b = _point("a", confidence=0.4), _point("b", confidence=0.4)
+    state = await dream_shield.compute_shield_state(db, [star, a, b], now=NOW)
+    out, stats = dream_shield.apply_shield_to_clusters([[star, a, b]], state)
+    assert len(out) == 1
+    assert {m["id"] for m in out[0]} == {"a", "b"}  # star removed, ≥2 survive
+    assert stats["members_shielded"] == 1
+    assert stats["clusters_trimmed"] == 1
+    assert stats["clusters_dropped"] == 0
+
+
+async def test_apply_shield_drops_cluster_below_two(monkeypatch, db):
+    _enable(monkeypatch)
+    star = _point("star", confidence=0.99)
+    a = _point("a", confidence=0.4)
+    state = await dream_shield.compute_shield_state(db, [star, a], now=NOW)
+    out, stats = dream_shield.apply_shield_to_clusters([[star, a]], state)
+    assert out == []  # only 1 survivor → whole cluster dropped
+    assert stats["members_shielded"] == 1
+    assert stats["clusters_dropped"] == 1
+
+
+async def test_apply_shield_all_members_shielded(monkeypatch, db):
+    _enable(monkeypatch)
+    s1, s2 = _point("s1", confidence=0.99), _point("s2", confidence=0.99)
+    state = await dream_shield.compute_shield_state(db, [s1, s2], now=NOW)
+    out, stats = dream_shield.apply_shield_to_clusters([[s1, s2]], state)
+    assert out == []
+    assert stats["members_shielded"] == 2
+    assert stats["clusters_dropped"] == 1
+
+
+# ── shield_filter_live (drain-time) ───────────────────────────────────────────
+
+
+async def test_filter_live_confidence_floor(monkeypatch, db):
+    _enable(monkeypatch)
+    star = _point("star", confidence=0.99)
+    a, b = _point("a", confidence=0.4), _point("b", confidence=0.4)
+    survivors, n = await dream_shield.shield_filter_live(
+        db, [star, a, b], activation_threshold=999.0, centrality_threshold=None, now=NOW
+    )
+    assert {m["id"] for m in survivors} == {"a", "b"}
+    assert n == 1
+
+
+async def test_filter_live_rose_activation(monkeypatch, db):
+    _enable(monkeypatch)
+    # frozen threshold captured at enqueue; a member now exceeds it because
+    # retrieved_count rose during the week.
+    risen = _point("risen", confidence=0.5, retrieved_count=19, days_old=1)
+    a, b = _point("a", confidence=0.4, days_old=120), _point("b", confidence=0.4, days_old=120)
+    # threshold between the dull baseline and the risen member's live activation.
+    survivors, n = await dream_shield.shield_filter_live(
+        db, [risen, a, b], activation_threshold=0.30, centrality_threshold=None, now=NOW
+    )
+    assert "risen" not in {m["id"] for m in survivors}
+    assert n == 1
+
+
+async def test_filter_live_disabled_is_noop(monkeypatch, db):
+    monkeypatch.setattr(dream_shield_config, "shield_enabled", lambda: False)
+    cluster = [_point("a", confidence=0.99), _point("b")]
+    survivors, n = await dream_shield.shield_filter_live(
+        db, cluster, activation_threshold=0.0, centrality_threshold=None, now=NOW
+    )
+    assert survivors == cluster
+    assert n == 0

--- a/tests/test_memory/test_dream_shield.py
+++ b/tests/test_memory/test_dream_shield.py
@@ -153,6 +153,61 @@ async def test_shield_filter_live_survives_malformed_created_at(monkeypatch, db)
     assert {m["id"] for m in survivors} == {"bad", "a", "b"}
 
 
+async def test_compute_shield_state_survives_null_confidence(monkeypatch, db):
+    """A payload with explicit `confidence: null` must not crash the floor
+    comparison (`.get(k, default)` returns None when the key is present-but-null,
+    and None >= float raises TypeError)."""
+    _enable(monkeypatch)
+    # Recent, high-activation neighbours set the bar; the null-confidence member
+    # is old (low activation) so only the confidence floor could shield it.
+    good = [_point(f"g{i}", retrieved_count=10, days_old=1) for i in range(3)]
+    nullc = {
+        "id": "nc",
+        "payload": {
+            "confidence": None,
+            "created_at": _iso_days_ago(300),
+            "retrieved_count": 0,
+            "source": "session_extraction",
+        },
+    }
+    state = await dream_shield.compute_shield_state(db, [*good, nullc], now=NOW)
+    assert state is not None
+    # Must not raise; coerced to the 0.5 default → below the 0.98 floor, and old
+    # → below the activation bar → not shielded.
+    assert dream_shield._member_is_shielded(nullc, state) is False
+
+
+async def test_shield_filter_live_survives_null_confidence(monkeypatch, db):
+    """Drain-time floor comparison must not crash on null confidence — otherwise
+    it propagates AFTER the item is marked processing and stalls the drain."""
+    _enable(monkeypatch)
+    nullc = {"id": "nc", "payload": {"confidence": None, "created_at": _iso_days_ago(1)}}
+    a, b = _point("a", confidence=0.4), _point("b", confidence=0.4)
+    survivors, n = await dream_shield.shield_filter_live(
+        db, [nullc, a, b], activation_threshold=0.30, centrality_threshold=None, now=NOW
+    )
+    assert n == 0
+    assert {m["id"] for m in survivors} == {"nc", "a", "b"}
+
+
+async def test_centrality_percentile_excludes_out_of_population(monkeypatch, db):
+    """The centrality percentile must be computed over the LIVE population only.
+    A high-centrality deprecated node still in the cache (dream soft-deletes keep
+    metadata/links) must not inflate the threshold and under-shield live bridges."""
+    _enable(monkeypatch, centrality_percentile=0.5)
+    await db.executemany(
+        "INSERT INTO centrality_cache (memory_id, centrality_score, computed_at) VALUES (?,?,?)",
+        [("ghost", 0.99, NOW), ("m0", 0.01, NOW), ("m1", 0.02, NOW), ("m2", 0.03, NOW)],
+    )
+    await db.commit()
+    points = [_point("m0"), _point("m1"), _point("m2")]  # 'ghost' NOT in population
+    state = await dream_shield.compute_shield_state(db, points, now=NOW)
+    # p0.5 over the in-population {0.01,0.02,0.03} = 0.02; if 'ghost' 0.99 leaked
+    # in it would be 0.03. Also 'ghost' must not appear in the by_id map.
+    assert state.centrality_threshold == 0.02
+    assert "ghost" not in state.centrality_by_id
+
+
 async def test_apply_shield_none_state_is_noop():
     clusters = [[_point("a"), _point("b")]]
     out, stats = dream_shield.apply_shield_to_clusters(clusters, None)

--- a/tests/test_memory/test_dream_shield_config.py
+++ b/tests/test_memory/test_dream_shield_config.py
@@ -1,0 +1,78 @@
+"""dream_shield config lever — enable/kill-switch + knob degradation."""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.memory import dream_shield_config as cfg
+
+
+def test_defaults_shape_and_values():
+    assert cfg.DEFAULTS["enabled"] is True
+    assert cfg.DEFAULTS["activation_percentile"] == 0.90
+    assert cfg.DEFAULTS["centrality_percentile"] == 0.90
+    assert cfg.DEFAULTS["confidence_floor"] == 0.98
+    assert cfg.DEFAULTS["deprecated_edge_prune_days"] == 30
+
+
+def test_shield_enabled_default_true(monkeypatch):
+    monkeypatch.setattr(cfg, "load_config", lambda: dict(cfg.DEFAULTS))
+    assert cfg.shield_enabled() is True
+
+
+def test_shield_enabled_false_when_disabled(monkeypatch):
+    monkeypatch.setattr(cfg, "load_config", lambda: {"enabled": False})
+    assert cfg.shield_enabled() is False
+
+
+def test_shield_enabled_false_when_yaml_false(monkeypatch):
+    # YAML-1.1 unquoted `enabled: no` → boolean False; honor the intent.
+    monkeypatch.setattr(cfg, "load_config", lambda: {"enabled": False})
+    assert cfg.shield_enabled() is False
+
+
+def test_env_kill_switch_forces_disabled(monkeypatch):
+    monkeypatch.setenv(cfg._ENV_KILL_SWITCH, "1")
+    monkeypatch.setattr(cfg, "load_config", lambda: dict(cfg.DEFAULTS))
+    assert cfg.shield_enabled() is False
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0.75, 0.75),
+        (0.0, 0.0),
+        (1.0, 1.0),
+        (1.5, 0.90),  # out of [0,1] → default
+        (-0.1, 0.90),
+        (True, 0.90),  # bool is not a valid float knob
+        ("x", 0.90),
+        (None, 0.90),
+    ],
+)
+def test_knob_float01_falls_back_on_damage(value, expected):
+    assert cfg.knob_float01({"activation_percentile": value}, "activation_percentile") == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (14, 14),
+        (0, 30),
+        (-3, 30),
+        (True, 30),
+        ("x", 30),
+        (None, 30),
+    ],
+)
+def test_knob_int_falls_back_on_damage(value, expected):
+    assert (
+        cfg.knob_int({"deprecated_edge_prune_days": value}, "deprecated_edge_prune_days")
+        == expected
+    )
+
+
+def test_load_config_returns_defaults_shape():
+    merged = cfg.load_config()
+    for k in cfg.DEFAULTS:
+        assert k in merged

--- a/tests/test_memory/test_graph.py
+++ b/tests/test_memory/test_graph.py
@@ -174,3 +174,16 @@ class TestCentrality:
         score_by_id = dict(scores)
         # B connects to C and E — should have non-zero centrality
         assert score_by_id.get("B", 0.0) > 0.0
+
+    @pytest.mark.asyncio
+    async def test_centrality_top_n_none_returns_all_nodes(self, graph_db):
+        """top_n=None returns every graph node, not a truncated slice."""
+        invalidate_graph_cache()
+        capped = await centrality_scores(graph_db, top_n=1)
+        invalidate_graph_cache()
+        full = await centrality_scores(graph_db, top_n=None)
+        assert len(capped) == 1
+        # The fixture graph has more than one node → full is strictly larger.
+        assert len(full) > len(capped)
+        # And the capped top-1 id is present in the full set.
+        assert capped[0][0] in dict(full)


### PR DESCRIPTION
## Why

The dream cycle merges near-duplicate memory clusters. A shadow replay over the current live worklist (1,858 members) showed **~2.8% sit at/above the collection's p90 activation** — including load-bearing behavioral-rule memories — and would be consolidated into syntheses (retrieved_count reset, confidence capped) with **no salience compensation**. The merge path had no concept of memory importance. This closes that gap before any live-merge flip.

## What

**Phase 2c (weekly, pre-enqueue)** — remove high-salience members from clusters before they are enqueued (skip-member: the unshielded remainder still merges if ≥2 survive). A member is shielded if **any** of:
- activation ≥ collection percentile (production `compute_activation`)
- raw confidence ≥ floor (default **0.98** — deliberately above the measured 0.95 extraction-default spike; 0.95 matched 21% of the store, 0.98 matches ~6%)
- betweenness centrality ≥ the nonzero percentile

Thresholds **freeze into each slice payload**; the **daily drain re-checks** live members (`shield_filter_live`) to catch salience that rose mid-week, and counts `shield_missing_thresholds` — **which must reach 0 before the live-merge flip** (the explicit gate).

**Centrality widened** top-500 → all-nonzero (`graph.centrality_scores(top_n=None)`; `dream_centrality` persists `score>0` only, guarding the zero-inflated betweenness distribution from collapsing the percentile). `centrality_cache` gains its first reader. New one-pass `all_link_counts` CRUD for the full-collection activation pass.

## Safety / scope

- **Read-only, drain stays SHADOW** — no behavior change to the live store yet. This is groundwork before the (separate, user-gated) live flip.
- Config-tunable (`config/dream_shield.yaml` + local overlay) + env kill switch `GENESIS_DREAM_SHIELD_DISABLED`; invalid knobs degrade toward MORE shielding.
- Empty-state correct (fresh install: no centrality → activation-only; no config → defaults). Malformed-payload safe (one bad timestamp cannot crash the shield).
- Percentile-based, no install-specific constants.

## Verification

- 129 targeted tests green; ruff clean.
- **E2E read-only over 60,727 live memories**: activation_threshold 0.49 (≈ replay's 0.485); the replay-flagged behavioral-rule memory is shielded.
- Inline review found + fixed one HIGH (malformed-timestamp crash); cloud Codex review to follow on this PR.

Ledger: 4e0015918a0e46c596f25d65138e184f

🤖 Generated with [Claude Code](https://claude.com/claude-code)