### PR TITLE
feat(reflex): ingest job.failed + manual resolve/dismiss with taste-corpus verdict (PR-2b/2c)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -673,8 +673,8 @@ verified: ca875c4b 2026-07-24
   their own domain `.failed` pass `emit_event=False` to avoid double-counting.
   Fire-and-forget (a broken emit never blocks the `job_health` write), and
   `job.failed` is in the ego's `_REFLEX_OWNED_EVENT_TYPES` so it never spins a
-  reactive ego cycle. Dark until reflex intake widens (`ingest.py` still drops
-  non-`task.failed`).
+  reactive ego cycle. Ingested by the reflex arc as of PR-2b (`ingest.py`
+  consumes `job.failed`, guarded on `error_type` presence).
 - **perception/**: the real-time reflection engine — MICRO (and LIGHT without
   a CC bridge) run in-process via the router; DEEP/STRATEGIC go to the CC
   reflection bridge. GROUNDWORK: user-model-synthesis, pre-execution-gate
@@ -1272,16 +1272,17 @@ verified: 9037d45b 2026-07-07
 
 ## 14. Reflex arc — self-bug detection & repair
 
-The afferent nerve for Genesis's own screaming bugs: detect `task.failed`
-exceptions, fingerprint/dedup them, and (later phases) diagnose → card →
-fix under a human-gated tier model. **PR1 (dark) + PR1.5 (observability)**
-— ingestion scaffolding and its watch surface; no cards/sessions/LLM yet.
-Spec: `docs/superpowers/specs/2026-07-21-reflex-arc-design.md`.
+The afferent nerve for Genesis's own screaming bugs: detect `task.failed` /
+`job.failed` exceptions, fingerprint/dedup them, and (later phases) diagnose →
+card → fix under a human-gated tier model. **PR1 (dark) + PR1.5 (observability)
++ PR-2b (job.failed intake) + PR-2c (manual resolve/dismiss with verdict)** —
+ingestion, its watch surface, and the human exit lane; no auto diagnose/fix
+sessions/LLM yet. Spec: `docs/superpowers/specs/2026-07-21-reflex-arc-design.md`.
 
 ```yaml subsystem-map
 entry: reflex-arc
 modules: [reflex]
-verified: 302066ad 2026-07-23
+verified: 4cc75d50 2026-08-05
 ```
 
 - **reflex/**: `fingerprint.py` (pure: normalize task name, line-number-free
@@ -1304,9 +1305,11 @@ verified: 302066ad 2026-07-23
   108d, verified two installs). The **funnel (2026-07-23)** adds the real
   stream: `runtime/_job_health.record_job_failure` emits a throttled
   `job.failed` for every exception-driven background-job failure (see the
-  scheduled-job telemetry entry). Emitted now but NOT yet ingested —
-  `ingest.py` still drops non-`task.failed`; widening intake to `job.failed` is
-  the gated PR-2b.
+  scheduled-job telemetry entry). **Ingested as of PR-2b**: `ingest.py`
+  consumes `task.failed` AND `job.failed`, guarded on `error_type` presence so
+  only real exceptions become signals (a reason-only failure has no
+  `error_type` and stays in the job-health/Sentinel lane — the
+  `failure_details` contract).
 - **Trap**: BOTH `task.failed` and `job.failed` are carved out of the ego
   reactive path (`runtime/init/ego._is_reflex_owned_event`) — reflex owns that
   class; the ego's message-keyed dedup can't absorb variable-payload failure
@@ -1325,9 +1328,18 @@ verified: 302066ad 2026-07-23
   sites (`knowledge/orchestrator` tree_task, `health_data` single-flight,
   `events._db_writer`) stay bare with in-code comments — wrapping would
   double-report exceptions their callers already handle.
-- GROUNDWORK: diagnose lane (PR2), fix lane (PR3) — `reflex_diagnoses` /
-  `reflex_verdicts` writers and the card/gate/dispatch flow are NOT yet
-  built; the tables are inert scaffolding in PR1.
+- **Human exit (PR-2c)**: `reflex_signal_resolve` MCP tool moves a signal to a
+  terminal status — `fixed`→`resolved` (real bug fixed out-of-band, e.g. a
+  normal PR; no verdict row, it isn't a card judgment), `not_a_bug`/`wont_fix`→
+  `dismissed_*` + a taste-corpus verdict (`db/crud/reflex_verdicts.record`, the
+  first writer of that table; `verdict_point='diagnose_card'`). Idempotent on
+  terminal signals; the status transition is guarded on the observed status so a
+  race is a conflict, never a clobber. Until the auto diagnose lane ships this is
+  the ONLY way a signal leaves `new`.
+- GROUNDWORK: auto diagnose lane (PR2), fix lane (PR3) — `reflex_diagnoses` has
+  no writer yet and the card/gate/dispatch flow is NOT built. `reflex_verdicts`
+  is now live (manual dismissals, PR-2c); its diagnose/fix/promotion verdict
+  points remain groundwork.
 
 ---
 

--- a/src/genesis/db/crud/reflex_signals.py
+++ b/src/genesis/db/crud/reflex_signals.py
@@ -61,6 +61,19 @@ _REOPENABLE = (
     "fix_failed",
 )
 
+# Clean terminal dispositions — a signal already here has been CONSCIOUSLY closed
+# (fixed / dismissed / arc-merged), so a manual re-resolution is a no-op. Kept
+# distinct from ``_REOPENABLE`` (the recurrence-reopen policy, a superset) on
+# purpose: the failure/expiry terminals (``diagnose_failed`` / ``fix_failed`` /
+# ``card_expired``) are STUCK signals a human should still be able to dispose,
+# so they are deliberately absent here.
+TERMINAL_DISPOSED = (
+    "resolved",
+    "dismissed_notbug",
+    "dismissed_wontfix",
+    "merged",
+)
+
 
 def _row_to_dict(row: tuple) -> dict:
     return dict(zip(_COLS, row, strict=True))
@@ -165,6 +178,12 @@ async def set_status(
 
 async def get_by_fingerprint(db: aiosqlite.Connection, fingerprint: str) -> dict | None:
     cursor = await db.execute(f"{_SELECT} WHERE fingerprint = ?", (fingerprint,))
+    row = await cursor.fetchone()
+    return _row_to_dict(tuple(row)) if row is not None else None
+
+
+async def get_by_id(db: aiosqlite.Connection, signal_id: str) -> dict | None:
+    cursor = await db.execute(f"{_SELECT} WHERE id = ?", (signal_id,))
     row = await cursor.fetchone()
     return _row_to_dict(tuple(row)) if row is not None else None
 

--- a/src/genesis/db/crud/reflex_verdicts.py
+++ b/src/genesis/db/crud/reflex_verdicts.py
@@ -1,0 +1,77 @@
+"""CRUD for reflex_verdicts — the taste corpus (every human verdict in the arc).
+
+One row per human judgment at a card (dismissal, execute tap, PR verdict,
+promotion decision). An append-only log: the future judgment layer reads it as
+``(context, judgment)`` training examples, so verdicts are never mutated or
+deleted. ``context_snapshot`` is a JSON blob of the signal state at judgment
+time. ``verdict_point`` / ``verdict`` are CHECK-constrained by the schema
+(see ``db/schema/_tables.py``); callers pass values from that vocabulary.
+
+Callers pass the shared SerializedConnection: commit on write, never rollback.
+Timestamps are injected ISO-UTC strings — no wall clock in this module.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import aiosqlite
+
+
+async def record(
+    db: aiosqlite.Connection,
+    *,
+    signal_id: str,
+    verdict_point: str,
+    verdict: str,
+    resolved_by: str,
+    context_snapshot: dict,
+    now: str,
+    diagnosis_id: str | None = None,
+    approval_request_id: str | None = None,
+) -> str:
+    """Append one verdict row (taste corpus). Returns the new row id."""
+    verdict_id = uuid.uuid4().hex[:16]
+    await db.execute(
+        """INSERT INTO reflex_verdicts
+           (id, signal_id, diagnosis_id, verdict_point, verdict, resolved_by,
+            approval_request_id, context_snapshot, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            verdict_id,
+            signal_id,
+            diagnosis_id,
+            verdict_point,
+            verdict,
+            resolved_by,
+            approval_request_id,
+            json.dumps(context_snapshot),
+            now,
+        ),
+    )
+    await db.commit()
+    return verdict_id
+
+
+async def list_for_signal(db: aiosqlite.Connection, signal_id: str) -> list[dict]:
+    """All verdicts recorded for one signal, oldest first."""
+    cursor = await db.execute(
+        """SELECT id, signal_id, diagnosis_id, verdict_point, verdict, resolved_by,
+                  approval_request_id, context_snapshot, created_at
+           FROM reflex_verdicts WHERE signal_id = ? ORDER BY created_at""",
+        (signal_id,),
+    )
+    rows = await cursor.fetchall()
+    cols = (
+        "id",
+        "signal_id",
+        "diagnosis_id",
+        "verdict_point",
+        "verdict",
+        "resolved_by",
+        "approval_request_id",
+        "context_snapshot",
+        "created_at",
+    )
+    return [dict(zip(cols, tuple(r), strict=True)) for r in rows]

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -84,6 +84,7 @@ from genesis.mcp.health import j9_eval as _j9_eval  # noqa: E402, F401
 from genesis.mcp.health import manifest as _manifest  # noqa: E402
 from genesis.mcp.health import module_ops as _module_ops  # noqa: E402
 from genesis.mcp.health import provider as _provider  # noqa: E402
+from genesis.mcp.health import reflex_resolve as _reflex_resolve  # noqa: E402, F401
 from genesis.mcp.health import reflex_status as _reflex_status  # noqa: E402, F401
 from genesis.mcp.health import session_charter_tools as _session_charter_tools  # noqa: E402
 from genesis.mcp.health import session_control as _session_control  # noqa: E402
@@ -144,6 +145,7 @@ _impl_follow_up_create = _follow_up_tools._impl_follow_up_create
 _impl_follow_up_list = _follow_up_tools._impl_follow_up_list
 _impl_inbox_digest = _inbox_digest._impl_inbox_digest
 _impl_ego_focus_reset = _ego_tools._impl_ego_focus_reset
+_impl_reflex_signal_resolve = _reflex_resolve._impl_reflex_signal_resolve
 
 # direct_session_tools wired here
 direct_session_tools = _direct_session_tools
@@ -214,6 +216,8 @@ __all__ = [
     "_impl_inbox_digest",
     "_ego_tools",
     "_impl_ego_focus_reset",
+    "_reflex_resolve",
+    "_impl_reflex_signal_resolve",
     "direct_session_tools",
     "_impl_direct_session_run",
     "_impl_direct_session_status",

--- a/src/genesis/mcp/health/reflex_resolve.py
+++ b/src/genesis/mcp/health/reflex_resolve.py
@@ -49,6 +49,62 @@ _SNAPSHOT_FIELDS = (
 )
 
 
+async def _record_verdict(
+    db, signal: dict, disposition: str, verdict: str, resolved_by: str, rationale: str, now: str
+) -> tuple[str | None, bool]:
+    """Write one taste-corpus verdict for a signal. Returns ``(verdict_id, failed)``.
+
+    Never raises: a verdict-store failure is logged and reported as ``failed=True``
+    (the caller surfaces ``partial``), so a signal's terminal transition is never
+    unwound and the tool never crashes on a corpus-write blip."""
+    from genesis.db.crud import reflex_verdicts as verdicts_crud
+
+    context = {k: signal.get(k) for k in _SNAPSHOT_FIELDS}
+    context["disposition"] = disposition
+    context["rationale"] = rationale
+    try:
+        verdict_id = await verdicts_crud.record(
+            db,
+            signal_id=signal["id"],
+            verdict_point="diagnose_card",
+            verdict=verdict,
+            resolved_by=resolved_by,
+            context_snapshot=context,
+            now=now,
+        )
+        return verdict_id, False
+    except Exception:
+        logger.error(
+            "reflex_signal_resolve: verdict write failed for %s (status transition stands)",
+            signal["id"],
+            exc_info=True,
+        )
+        return None, True
+
+
+def _result(
+    status: str,
+    signal_id: str,
+    new_status: str,
+    verdict: str | None,
+    verdict_id: str | None,
+    rationale: str,
+    failed: bool,
+) -> dict:
+    out = {
+        "status": status,
+        "signal_id": signal_id,
+        "new_status": new_status,
+        "verdict": verdict,
+        "verdict_id": verdict_id,
+        "rationale": rationale,
+    }
+    if failed:
+        out["verdict_write_failed"] = True
+        out["message"] = "signal resolved, but the taste-corpus verdict write failed (logged)"
+    return out
+
+
 async def _impl_reflex_signal_resolve(
     db,
     *,
@@ -76,11 +132,33 @@ async def _impl_reflex_signal_resolve(
     current = signal["status"]
     to_status, verdict = _DISPOSITIONS[disposition]
 
-    # Idempotent: a CONSCIOUSLY-closed signal (resolved/dismissed/merged) → no-op,
-    # and crucially no second verdict row. Uses TERMINAL_DISPOSED, NOT _REOPENABLE:
-    # a failure/expiry signal (diagnose_failed/fix_failed/card_expired) is exactly
-    # the kind of stuck signal this tool exists to close, so it stays resolvable.
+    # Already CONSCIOUSLY closed (resolved/dismissed/merged) → no-op — EXCEPT the
+    # partial-write recovery case: a prior call moved the status but its verdict
+    # write failed (returned 'partial'), so the corpus row is missing. If this
+    # retry matches that disposition and the expected verdict truly isn't recorded,
+    # REPAIR it here — a transient DB blip must not cause permanent taste-corpus
+    # loss with no way back through the API. TERMINAL_DISPOSED (not _REOPENABLE):
+    # failure/expiry signals stay resolvable.
     if current in signals_crud.TERMINAL_DISPOSED:
+        if verdict is not None and current == to_status:
+            existing = await verdicts_crud.list_for_signal(db, signal_id)
+            already_recorded = any(
+                v.get("verdict_point") == "diagnose_card" and v.get("verdict") == verdict
+                for v in existing
+            )
+            if not already_recorded:
+                verdict_id, failed = await _record_verdict(
+                    db, signal, disposition, verdict, resolved_by, rationale, now
+                )
+                return _result(
+                    "partial" if failed else "repaired",
+                    signal_id,
+                    current,
+                    verdict,
+                    verdict_id,
+                    rationale,
+                    failed,
+                )
         return {
             "status": "noop",
             "message": f"signal already disposed ({current})",
@@ -101,46 +179,14 @@ async def _impl_reflex_signal_resolve(
         }
 
     verdict_id: str | None = None
-    verdict_write_failed = False
+    failed = False
     if verdict is not None:
-        context = {k: signal.get(k) for k in _SNAPSHOT_FIELDS}
-        context["disposition"] = disposition
-        context["rationale"] = rationale
-        try:
-            verdict_id = await verdicts_crud.record(
-                db,
-                signal_id=signal_id,
-                verdict_point="diagnose_card",
-                verdict=verdict,
-                resolved_by=resolved_by,
-                context_snapshot=context,
-                now=now,
-            )
-        except Exception:
-            # Status already moved; a missing corpus row is recoverable, a raised
-            # tool is not. Log loudly and surface a PARTIAL result rather than
-            # unwind the transition — a caller checking status=="ok" must NOT be
-            # told the taste-corpus write (this tool's core deliverable) landed.
-            verdict_write_failed = True
-            logger.error(
-                "reflex_signal_resolve: status set to %s but verdict write failed for %s",
-                to_status,
-                signal_id,
-                exc_info=True,
-            )
-
-    result = {
-        "status": "partial" if verdict_write_failed else "ok",
-        "signal_id": signal_id,
-        "new_status": to_status,
-        "verdict": verdict,
-        "verdict_id": verdict_id,
-        "rationale": rationale,
-    }
-    if verdict_write_failed:
-        result["verdict_write_failed"] = True
-        result["message"] = "signal resolved, but the taste-corpus verdict write failed (logged)"
-    return result
+        verdict_id, failed = await _record_verdict(
+            db, signal, disposition, verdict, resolved_by, rationale, now
+        )
+    return _result(
+        "partial" if failed else "ok", signal_id, to_status, verdict, verdict_id, rationale, failed
+    )
 
 
 @mcp.tool()

--- a/src/genesis/mcp/health/reflex_resolve.py
+++ b/src/genesis/mcp/health/reflex_resolve.py
@@ -1,0 +1,171 @@
+"""reflex_signal_resolve MCP tool — manually resolve or dismiss a reflex signal.
+
+The afferent nerve ingests signals but, until the diagnose/fix lanes ship, a
+signal has no way to LEAVE the ``new`` lane — it sits on the dashboard forever.
+This tool is the human exit: it moves a signal to a terminal status and, for a
+dismissal, records the judgment as a taste-corpus verdict (the spec's "a signal
+Jay dismisses is a verdict, not just deleted").
+
+Three dispositions, mapped to the schema's constrained vocabularies:
+
+- ``fixed``      → status ``resolved``. The bug was real and is fixed — often
+  out-of-band (a normal PR), which the verdict vocabulary has no value for, so
+  NO verdict row is written (it isn't a card judgment, just a lifecycle close).
+- ``not_a_bug``  → status ``dismissed_notbug``  + verdict ``dismiss_notbug``.
+- ``wont_fix``   → status ``dismissed_wontfix`` + verdict ``dismiss_wontfix``.
+
+Idempotent: a signal already in a terminal status is a no-op (no double verdict).
+Guarded: the status transition keys on the observed current status, so a
+concurrent change makes this a conflict rather than a clobber.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+# disposition → (terminal status, verdict value | None). None = no verdict row
+# (a lifecycle resolution, not a card judgment).
+_DISPOSITIONS: dict[str, tuple[str, str | None]] = {
+    "fixed": ("resolved", None),
+    "not_a_bug": ("dismissed_notbug", "dismiss_notbug"),
+    "wont_fix": ("dismissed_wontfix", "dismiss_wontfix"),
+}
+
+# Fields snapshotted into the verdict's context (the taste-corpus example input).
+_SNAPSHOT_FIELDS = (
+    "fingerprint",
+    "class_key",
+    "task_name",
+    "subsystem",
+    "error_type",
+    "status",
+    "occurrence_count",
+    "last_error_message",
+)
+
+
+async def _impl_reflex_signal_resolve(
+    db,
+    *,
+    signal_id: str,
+    disposition: str,
+    rationale: str,
+    now: str,
+    resolved_by: str = "user",
+) -> dict:
+    from genesis.db.crud import reflex_signals as signals_crud
+    from genesis.db.crud import reflex_verdicts as verdicts_crud
+
+    if disposition not in _DISPOSITIONS:
+        return {
+            "status": "error",
+            "message": f"unknown disposition {disposition!r} (fixed | not_a_bug | wont_fix)",
+        }
+    if not rationale or not rationale.strip():
+        return {"status": "error", "message": "rationale is required"}
+
+    signal = await signals_crud.get_by_id(db, signal_id)
+    if signal is None:
+        return {"status": "error", "message": f"signal {signal_id!r} not found"}
+
+    current = signal["status"]
+    to_status, verdict = _DISPOSITIONS[disposition]
+
+    # Idempotent: a CONSCIOUSLY-closed signal (resolved/dismissed/merged) → no-op,
+    # and crucially no second verdict row. Uses TERMINAL_DISPOSED, NOT _REOPENABLE:
+    # a failure/expiry signal (diagnose_failed/fix_failed/card_expired) is exactly
+    # the kind of stuck signal this tool exists to close, so it stays resolvable.
+    if current in signals_crud.TERMINAL_DISPOSED:
+        return {
+            "status": "noop",
+            "message": f"signal already disposed ({current})",
+            "signal_id": signal_id,
+            "signal_status": current,
+        }
+
+    # Transition FIRST (guarded on the observed status) so a lost race can't
+    # leave an orphan verdict describing a dismissal that never took effect.
+    ok = await signals_crud.set_status(
+        db, signal_id=signal_id, expected_from=current, to=to_status, now=now
+    )
+    if not ok:
+        return {
+            "status": "conflict",
+            "message": f"signal status changed under us (was {current}); not resolved",
+            "signal_id": signal_id,
+        }
+
+    verdict_id: str | None = None
+    verdict_write_failed = False
+    if verdict is not None:
+        context = {k: signal.get(k) for k in _SNAPSHOT_FIELDS}
+        context["disposition"] = disposition
+        context["rationale"] = rationale
+        try:
+            verdict_id = await verdicts_crud.record(
+                db,
+                signal_id=signal_id,
+                verdict_point="diagnose_card",
+                verdict=verdict,
+                resolved_by=resolved_by,
+                context_snapshot=context,
+                now=now,
+            )
+        except Exception:
+            # Status already moved; a missing corpus row is recoverable, a raised
+            # tool is not. Log loudly and surface a PARTIAL result rather than
+            # unwind the transition — a caller checking status=="ok" must NOT be
+            # told the taste-corpus write (this tool's core deliverable) landed.
+            verdict_write_failed = True
+            logger.error(
+                "reflex_signal_resolve: status set to %s but verdict write failed for %s",
+                to_status,
+                signal_id,
+                exc_info=True,
+            )
+
+    result = {
+        "status": "partial" if verdict_write_failed else "ok",
+        "signal_id": signal_id,
+        "new_status": to_status,
+        "verdict": verdict,
+        "verdict_id": verdict_id,
+        "rationale": rationale,
+    }
+    if verdict_write_failed:
+        result["verdict_write_failed"] = True
+        result["message"] = "signal resolved, but the taste-corpus verdict write failed (logged)"
+    return result
+
+
+@mcp.tool()
+async def reflex_signal_resolve(signal_id: str, disposition: str, rationale: str) -> dict:
+    """Resolve or dismiss a reflex signal, recording a taste-corpus verdict.
+
+    disposition:
+      - ``fixed``     — real bug, now fixed (often by a normal PR) → status
+        ``resolved`` (no verdict row; not a card judgment).
+      - ``not_a_bug`` — not a genuine defect → dismissed, verdict ``dismiss_notbug``.
+      - ``wont_fix``  — real but won't fix now → dismissed, verdict ``dismiss_wontfix``.
+
+    ``rationale`` (required) is recorded and, for dismissals, stored in the
+    taste-corpus context. Idempotent on already-terminal signals.
+    """
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = health_mcp_mod._service
+    if _service is None or _service._db is None:
+        return {"status": "unavailable", "message": "DB not initialized"}
+
+    return await _impl_reflex_signal_resolve(
+        _service._db,
+        signal_id=signal_id,
+        disposition=disposition,
+        rationale=rationale,
+        now=datetime.now(UTC).isoformat(),
+    )

--- a/src/genesis/reflex/ingest.py
+++ b/src/genesis/reflex/ingest.py
@@ -1,4 +1,11 @@
-"""Reflex ingestion — task.failed events → fingerprinted signal rows.
+"""Reflex ingestion — task.failed / job.failed events → fingerprinted signal rows.
+
+Two afferent sources feed the same pipeline: ``task.failed`` (crashed
+``tracked_task`` coroutines) and ``job.failed`` (exception-driven background-job
+failures, funnelled onto the bus by the PR-2a job-health path). Only
+exception-driven failures are ingested — an event without an ``error_type``
+(a semantic/reason-only failure) belongs to the job-health/Sentinel lane, not
+the reflex arc.
 
 Two-stage by design (mirrors the event bus's own persistence path): the
 bus subscriber only ENQUEUES — the event bus dispatches listeners inline
@@ -74,13 +81,29 @@ class ReflexIngestor:
 
     async def handle_event(self, event: GenesisEvent) -> None:
         try:
-            if event.event_type != "task.failed" or not self._enabled:
+            if event.event_type not in ("task.failed", "job.failed") or not self._enabled:
                 return
             details = getattr(event, "details", None) or {}
+            # Reflex ingests SCREAMING bugs — real exceptions. failure_details()
+            # sets error_type IFF an exception caused the failure; a semantic,
+            # reason-only failure carries error_reason and NO error_type and
+            # belongs to a different lane (recorded by job_health / owned by the
+            # Sentinel), not the reflex arc. Both current emitters fire
+            # exception-only (task.failed always; job.failed's PR-2a funnel gates
+            # on `exc is not None`), so today this guard is defense-in-depth
+            # honoring the failure_details contract — without it, a future
+            # reason-only event would MANUFACTURE a bogus "UnknownError" signal,
+            # the opposite of surfacing a real problem.
+            error_type = details.get("error_type")
+            # behavioral-lint: ignore no-hide-problems — lane-routing, not hiding
+            # (see the contract note above; reason-only failures stay visible via
+            # job_health).
+            if not error_type:
+                return
             payload = {
                 "task_name": str(details.get("task_name") or "unnamed"),
                 "error": str(details.get("error") or ""),
-                "error_type": str(details.get("error_type") or "UnknownError"),
+                "error_type": str(error_type),
                 "error_frames": [str(f) for f in (details.get("error_frames") or [])],
                 "subsystem": str(getattr(event, "subsystem", "") or "health"),
             }
@@ -90,7 +113,7 @@ class ReflexIngestor:
                 self._dropped += 1
                 if self._dropped % _DROP_WARN_EVERY == 1:
                     logger.warning(
-                        "Reflex ingest queue full — dropped %d task.failed events so far",
+                        "Reflex ingest queue full — dropped %d failure events so far",
                         self._dropped,
                     )
         except Exception:  # never break the bus — reflex is an observer

--- a/tests/test_reflex/test_ingest.py
+++ b/tests/test_reflex/test_ingest.py
@@ -74,6 +74,28 @@ class TestHandler:
         await ing.handle_event(_event())
         assert ing.stats["queued"] == 1
 
+    async def test_enqueues_job_failed(self, db):
+        # PR-2b: the background-job funnel (job.failed) feeds the same pipeline.
+        ing = _ingestor(db)
+        await ing.handle_event(_event(event_type="job.failed"))
+        assert ing.stats["queued"] == 1
+
+    async def test_skips_reason_only_failure_no_error_type(self, db):
+        # A semantic/reason-only failure carries error_reason and NO error_type
+        # (job_health's non-exception path) — not a reflex-arc bug. Skipped for
+        # BOTH sources so widening intake to job.failed can't manufacture a
+        # bogus "UnknownError" signal.
+        ing = _ingestor(db)
+        for etype in ("job.failed", "task.failed"):
+            await ing.handle_event(
+                SimpleNamespace(
+                    event_type=etype,
+                    subsystem="health",
+                    details={"task_name": "weekly_assessment", "error_reason": "no data"},
+                )
+            )
+        assert ing.stats["queued"] == 0
+
     async def test_ignores_other_event_types(self, db):
         ing = _ingestor(db)
         await ing.handle_event(_event(event_type="breaker.tripped"))

--- a/tests/test_reflex/test_resolve.py
+++ b/tests/test_reflex/test_resolve.py
@@ -180,3 +180,38 @@ class TestResolveTool:
         # transition still committed
         assert (await signals_crud.get_by_id(db, sig["id"]))["status"] == "dismissed_notbug"
         assert await verdicts_crud.list_for_signal(db, sig["id"]) == []
+
+    async def test_partial_then_retry_repairs_the_missing_verdict(self, db, monkeypatch):
+        # A transient verdict-write failure must be recoverable via the same API:
+        # the retry sees a terminal status with NO matching verdict and REPAIRS it
+        # (writes the missing corpus row) instead of no-op'ing forever.
+        sig = await _seed_signal(db)
+        real_record = verdicts_crud.record
+        calls = {"n": 0}
+
+        async def _flaky(*a, **k):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("verdict store down")
+            return await real_record(*a, **k)
+
+        monkeypatch.setattr(verdicts_crud, "record", _flaky)
+
+        out1 = await _impl_reflex_signal_resolve(
+            db, signal_id=sig["id"], disposition="not_a_bug", rationale="x", now=NOW
+        )
+        assert out1["status"] == "partial"
+        assert await verdicts_crud.list_for_signal(db, sig["id"]) == []
+
+        out2 = await _impl_reflex_signal_resolve(
+            db, signal_id=sig["id"], disposition="not_a_bug", rationale="x", now=NOW
+        )
+        assert out2["status"] == "repaired"
+        verdicts = await verdicts_crud.list_for_signal(db, sig["id"])
+        assert len(verdicts) == 1 and verdicts[0]["verdict"] == "dismiss_notbug"
+
+        # once the verdict exists, a further retry is a genuine no-op
+        out3 = await _impl_reflex_signal_resolve(
+            db, signal_id=sig["id"], disposition="not_a_bug", rationale="x", now=NOW
+        )
+        assert out3["status"] == "noop"

--- a/tests/test_reflex/test_resolve.py
+++ b/tests/test_reflex/test_resolve.py
@@ -1,0 +1,182 @@
+"""Tests for reflex_verdicts CRUD + the reflex_signal_resolve tool impl.
+
+Covers the three dispositions (fixed / not_a_bug / wont_fix), taste-corpus
+verdict writes, idempotency on terminal signals, and input validation.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+from datetime import UTC, datetime
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import reflex_signals as signals_crud
+from genesis.db.crud import reflex_verdicts as verdicts_crud
+from genesis.mcp.health.reflex_resolve import _impl_reflex_signal_resolve
+
+M70 = importlib.import_module("genesis.db.migrations.0070_reflex_arc")
+
+NOW = datetime(2026, 8, 5, 12, 0, 0, tzinfo=UTC).isoformat()
+
+
+@pytest.fixture
+async def db(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "t.db")) as conn:
+        await M70.up(conn)
+        await conn.commit()
+        yield conn
+
+
+async def _seed_signal(db, *, fingerprint="fp1", error_type="CCProcessError") -> dict:
+    return await signals_crud.upsert_occurrence(
+        db,
+        fingerprint=fingerprint,
+        class_key=f"{error_type}xcc",
+        task_name="direct-session-x",
+        subsystem="cc",
+        error_type=error_type,
+        error_message="You've hit your session limit",
+        traceback_tail="cc/invoker.py:run",
+        now=NOW,
+    )
+
+
+class TestVerdictsCrud:
+    async def test_record_and_list(self, db):
+        sig = await _seed_signal(db)
+        vid = await verdicts_crud.record(
+            db,
+            signal_id=sig["id"],
+            verdict_point="diagnose_card",
+            verdict="dismiss_notbug",
+            resolved_by="user",
+            context_snapshot={"rationale": "noise"},
+            now=NOW,
+        )
+        rows = await verdicts_crud.list_for_signal(db, sig["id"])
+        assert len(rows) == 1
+        assert rows[0]["id"] == vid
+        assert rows[0]["verdict"] == "dismiss_notbug"
+        assert json.loads(rows[0]["context_snapshot"]) == {"rationale": "noise"}
+
+
+class TestResolveTool:
+    async def test_fixed_sets_resolved_no_verdict(self, db):
+        sig = await _seed_signal(db)
+        out = await _impl_reflex_signal_resolve(
+            db,
+            signal_id=sig["id"],
+            disposition="fixed",
+            rationale="root cause fixed in PR-A0",
+            now=NOW,
+        )
+        assert out["status"] == "ok"
+        assert out["new_status"] == "resolved"
+        assert out["verdict_id"] is None
+        row = await signals_crud.get_by_id(db, sig["id"])
+        assert row["status"] == "resolved"
+        # 'fixed' is a lifecycle close, not a card judgment → no taste-corpus row
+        assert await verdicts_crud.list_for_signal(db, sig["id"]) == []
+
+    async def test_not_a_bug_dismisses_with_verdict(self, db):
+        sig = await _seed_signal(db)
+        out = await _impl_reflex_signal_resolve(
+            db,
+            signal_id=sig["id"],
+            disposition="not_a_bug",
+            rationale="environmental noise",
+            now=NOW,
+        )
+        assert out["status"] == "ok"
+        assert out["new_status"] == "dismissed_notbug"
+        row = await signals_crud.get_by_id(db, sig["id"])
+        assert row["status"] == "dismissed_notbug"
+        verdicts = await verdicts_crud.list_for_signal(db, sig["id"])
+        assert len(verdicts) == 1
+        assert verdicts[0]["verdict"] == "dismiss_notbug"
+        ctx = json.loads(verdicts[0]["context_snapshot"])
+        assert ctx["rationale"] == "environmental noise"
+        assert ctx["disposition"] == "not_a_bug"
+        assert ctx["class_key"] == "CCProcessErrorxcc"
+
+    async def test_wont_fix_dismisses_with_verdict(self, db):
+        sig = await _seed_signal(db)
+        out = await _impl_reflex_signal_resolve(
+            db, signal_id=sig["id"], disposition="wont_fix", rationale="later", now=NOW
+        )
+        assert out["new_status"] == "dismissed_wontfix"
+        verdicts = await verdicts_crud.list_for_signal(db, sig["id"])
+        assert verdicts[0]["verdict"] == "dismiss_wontfix"
+
+    async def test_idempotent_on_terminal_no_double_verdict(self, db):
+        sig = await _seed_signal(db)
+        await _impl_reflex_signal_resolve(
+            db, signal_id=sig["id"], disposition="not_a_bug", rationale="x", now=NOW
+        )
+        # second call is a no-op — must NOT write a second verdict
+        out = await _impl_reflex_signal_resolve(
+            db, signal_id=sig["id"], disposition="not_a_bug", rationale="x", now=NOW
+        )
+        assert out["status"] == "noop"
+        assert len(await verdicts_crud.list_for_signal(db, sig["id"])) == 1
+
+    async def test_unknown_disposition_rejected(self, db):
+        sig = await _seed_signal(db)
+        out = await _impl_reflex_signal_resolve(
+            db, signal_id=sig["id"], disposition="bogus", rationale="x", now=NOW
+        )
+        assert out["status"] == "error"
+        assert (await signals_crud.get_by_id(db, sig["id"]))["status"] == "new"
+
+    async def test_blank_rationale_rejected(self, db):
+        sig = await _seed_signal(db)
+        out = await _impl_reflex_signal_resolve(
+            db, signal_id=sig["id"], disposition="fixed", rationale="   ", now=NOW
+        )
+        assert out["status"] == "error"
+        assert (await signals_crud.get_by_id(db, sig["id"]))["status"] == "new"
+
+    async def test_missing_signal_rejected(self, db):
+        out = await _impl_reflex_signal_resolve(
+            db, signal_id="nope", disposition="fixed", rationale="x", now=NOW
+        )
+        assert out["status"] == "error"
+        assert "not found" in out["message"]
+
+    async def test_failure_state_signal_stays_resolvable(self, db):
+        # A stuck FAILURE terminal (e.g. card_expired) is NOT "already disposed"
+        # — a human must still be able to close it (it's exactly what this tool
+        # is for). It must resolve, not no-op.
+        sig = await _seed_signal(db)
+        await signals_crud.set_status(
+            db, signal_id=sig["id"], expected_from="new", to="card_expired", now=NOW
+        )
+        out = await _impl_reflex_signal_resolve(
+            db, signal_id=sig["id"], disposition="wont_fix", rationale="stale card", now=NOW
+        )
+        assert out["status"] == "ok"
+        assert out["new_status"] == "dismissed_wontfix"
+        assert (await signals_crud.get_by_id(db, sig["id"]))["status"] == "dismissed_wontfix"
+
+    async def test_verdict_write_failure_returns_partial(self, db, monkeypatch):
+        # If the status transition commits but the taste-corpus write raises, the
+        # caller must NOT be told status=="ok" — it's "partial" + a flag, and the
+        # transition still stands (no unwind).
+        sig = await _seed_signal(db)
+
+        async def _boom(*a, **k):
+            raise RuntimeError("verdict store down")
+
+        monkeypatch.setattr(verdicts_crud, "record", _boom)
+        out = await _impl_reflex_signal_resolve(
+            db, signal_id=sig["id"], disposition="not_a_bug", rationale="x", now=NOW
+        )
+        assert out["status"] == "partial"
+        assert out["verdict_write_failed"] is True
+        assert out["verdict_id"] is None
+        # transition still committed
+        assert (await signals_crud.get_by_id(db, sig["id"]))["status"] == "dismissed_notbug"
+        assert await verdicts_crud.list_for_signal(db, sig["id"]) == []


### PR DESCRIPTION
## Summary

Two cohesive steps for the reflex arc ("nerve" — Genesis's self-bug detection):
lets it hear the largest class of its own failures, and gives an ingested signal
a way to *leave* the `new` lane before the auto diagnose/fix lanes exist.

## PR-2b — ingest `job.failed`

PR-2a (#1226) funnels background-job exceptions onto the bus as `job.failed`, but
reflex intake was left dark — the ingestor dropped everything that wasn't
`task.failed`, so the single largest class of internal defects never reached the
self-bug store. This widens intake to `job.failed`.

Only **exception-driven** failures are ingested: a guard skips any event without
an `error_type`. `failure_details()` sets `error_type` iff a real exception caused
the failure; a semantic/reason-only failure (`error_reason`, no `error_type`)
belongs to the `job_health`/Sentinel lane, and ingesting it here would manufacture
a bogus `UnknownError` signal. Both current emitters fire exception-only, so the
guard is defense-in-depth honoring that contract.

## PR-2c — manual resolve/dismiss with a taste-corpus verdict

Until the auto lanes ship, a signal sits on the dashboard forever. New MCP tool
`reflex_signal_resolve` is the human exit — and writes the **first taste-corpus
verdict** (`reflex_verdicts`). Three dispositions, mapped to the schema's
CHECK-constrained vocabularies:

- `fixed` → status `resolved`, **no verdict row** — a real bug fixed out-of-band
  (e.g. a normal PR) is a lifecycle close, not a card judgment, and the verdict
  vocabulary has no "fixed_external" value; forcing `dismiss_wontfix` would poison
  the corpus (training data for the future judgment layer).
- `not_a_bug` → `dismissed_notbug` + verdict `dismiss_notbug`.
- `wont_fix` → `dismissed_wontfix` + verdict `dismiss_wontfix`.

Safety: the status transition is guarded on the observed status (a lost race is a
`conflict`, never a clobber) and runs **before** the verdict write (no orphan
verdicts); a verdict-write failure after the transition returns `partial`, never a
masked `ok`. Idempotency keys on a new public `TERMINAL_DISPOSED` set (clean
terminals only) — deliberately **not** the recurrence-reopen set — so failure/
expiry signals a human still needs to close stay resolvable.

Adds `reflex_verdicts` CRUD (first writer) + `reflex_signals.get_by_id`.

## Verification

- New tests RED-on-unfixed / GREEN-on-fixed (proven via stash for the intake
  guard). `tests/test_reflex/` full suite **83 pass** (incl. 10 resolve-tool +
  the new ingest cases); `tests/test_mcp/` health **318 pass**; the tool
  live-registers on the FastMCP instance. `ruff` clean; `subsystem-map` check
  CLEAN (`CURRENT.md` updated + re-stamped).

## Deploy path

Runtime code — `git pull` + server restart; MCP tool lands at the next CC session
start. Reflex ships **dark by default** (`config/reflex.yaml ingest_enabled:
false`); no schema migration (tables predate this from #1177), no config default
change, no host action.

## Notes

Behavior is scoped to the reflex arc, which is off by default on a standard
install — no user-facing effect there, hence no CHANGELOG entry (consistent with
the earlier dark reflex PRs).
