### PR TITLE
feat(deliverable-builder): OfficeCLI high-fidelity Office render backend

### DIFF
--- a/.claude/skills/deliverable-builder/SKILL.md
+++ b/.claude/skills/deliverable-builder/SKILL.md
@@ -34,7 +34,7 @@ you're publishing as Genesis (use content-publish / genesis-voice).
 | 3 | **Structure & altitude** — lead with the answer, action titles, methodology→appendix | `references/structure-altitude.md` | |
 | 4 | **Voice** — make it sound like the user | invoke the **voice-master** skill | |
 | 5 | **Anti-slop** — strip document/sentence AI tells | invoke the **humanizer** skill (voice-calibration off — voice-master already voiced it) | |
-| 6 | **Render** — produce the real file (PDF/DOCX/PPTX); set `status: rendered_unverified` | `references/render-guide.md` (pandoc / `/make-pdf` / `/drawio-skill`) | |
+| 6 | **Render** — produce the real file (PDF/DOCX/PPTX/XLSX); set `status: rendered_unverified` | `references/render-guide.md` (pandoc / `/make-pdf` / `/drawio-skill` / **OfficeCLI** when `office_deliverables` active) | |
 | 7 | **Verify** — fresh-context adversarial PASS/FAIL vs. the frozen criteria | `references/qa-protocol.md` | **Gate 2** (policeman) |
 | 8 | **Sign-off** — user approves the verified artifact | `references/approval-gates.md` | **Gate 3** (interactive) |
 
@@ -70,9 +70,11 @@ after Gate 3. If the user abandons it, set `cancelled`.
   `references/approval-gates.md`.
 
 ## What this does NOT do (yet)
-XLSX (needs `xlsxwriter`; offer CSV), polished decks beyond pandoc-basic, real Telegram file
-*attachment* for autonomous Gate 3 (sends path + summary for now — fast-follow), and the
-`enterprise-ai-skills` / `hallmark` extras. One deliverable at a time.
+Real Telegram file *attachment* for autonomous Gate 3 (sends path + summary for now —
+fast-follow), and the `enterprise-ai-skills` / `hallmark` extras. One deliverable at a time.
+(Real `.xlsx` with formulas and polished `.pptx` decks now work **when the optional OfficeCLI
+backend is present** — see `references/render-guide.md`; without it the builder falls back to
+CSV / pandoc-basic.)
 
 ## Example
 **User:** "Turn my take-home analysis into the submission packet it should have been."

--- a/.claude/skills/deliverable-builder/references/intake.md
+++ b/.claude/skills/deliverable-builder/references/intake.md
@@ -87,7 +87,7 @@ Establish, and write into the spec:
 - **audience** — who receives this, and what they already know.
 - **purpose** — the job it does for them.
 - **win_condition** — one sentence: what makes this a success in *their* eyes.
-- **format** — a deliberate decision, **not a default**. Use `references/format-guide.md` to form
+- **format** — a deliberate decision, **not a default**. Use `references/render-guide.md` to form
   a recommendation from audience+purpose, then **put it to the user with the alternatives.** The
   most common fork is **PDF (final, fixed) vs DOCX (they'll edit or comment on it)**; decks, XLSX,
   etc. live in the matrix. Confirm before drafting. **Never markdown for an external /

--- a/.claude/skills/deliverable-builder/references/qa-protocol.md
+++ b/.claude/skills/deliverable-builder/references/qa-protocol.md
@@ -28,7 +28,20 @@ Do these IN ORDER:
    Portable checks: PDF starts with `%PDF` (`head -c4`), or `pdfinfo <path>` / Python
    `import fitz; fitz.open(path).page_count`; DOCX/PPTX/XLSX are ZIP (`PK` magic). If the
    bytes don't match the claimed format, that alone is a FAIL:render.
-4. Open and read {spec.rendered_path} in full.
+3b. For an OFFICE file (.xlsx/.pptx/.docx) — LibreOffice is NOT installed, so verify
+   two ways (both LibreOffice-free): (i) STRUCTURAL validity with the stdlib —
+   `python3 -c "import zipfile,sys,os; z=zipfile.ZipFile(sys.argv[1]); req={'.xlsx':'xl/workbook.xml','.pptx':'ppt/presentation.xml','.docx':'word/document.xml'}; part=req[os.path.splitext(sys.argv[1])[1]]; assert '[Content_Types].xml' in z.namelist() and part in z.namelist()" {spec.rendered_path}`
+   (a missing required part = FAIL:render); (ii) if OfficeCLI produced it (audit_trail.render.tool
+   == "officecli"), SEMANTIC validity. OfficeCLI is NOT on PATH — resolve the pinned binary first:
+   `OCLI="$HOME/.genesis/deps/officecli/officecli-linux-$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')"`.
+   If `test -x "$OCLI"`, run `"$OCLI" view {spec.rendered_path} issues --json` — it must report
+   `count: 0`; a nonzero count (broken/stale formula, missing-sheet ref, low-contrast slide) is a
+   FAIL:render even though `"$OCLI" validate` (schema-only) may pass. If `$OCLI` is absent (the
+   file was rendered elsewhere), skip (ii) and rely on (i). The file must have been `save`/`close`d
+   before any non-OfficeCLI read.
+4. Open and read {spec.rendered_path} in full. For .xlsx, if `test -x "$OCLI"`, use
+   `"$OCLI" view {spec.rendered_path} text` (shows evaluated cell values); else unzip and read the
+   XML parts.
 
 Then judge, with EVIDENCE (a quote/line ref from the artifact) for every verdict:
 

--- a/.claude/skills/deliverable-builder/references/render-guide.md
+++ b/.claude/skills/deliverable-builder/references/render-guide.md
@@ -11,8 +11,8 @@ Intake from audience + purpose, using the matrix below.
 | Job take-home / technical submission | Hiring team (email) | **PDF** | `pandoc --pdf-engine=xelatex` + a `visual_style` font (below), or `/make-pdf` for branded polish |
 | Client report | External stakeholder | **PDF**, or **DOCX** if they'll edit | `pandoc` / `pandoc --reference-doc=template.docx` |
 | Executive one-pager | C-suite / board | **PDF** (1 page) | `/make-pdf` (preferred for design), else `pandoc` |
-| Slide deck | Present vs. edit | **PDF** (beamer) / **PPTX** (editable) | `pandoc -t beamer` / `pandoc -t pptx` |
-| Data hand-off (tabular) | Analyst / client | **XLSX** | *deferred v1* — `xlsxwriter` not installed; flag and offer CSV (`pandoc -t csv` / write `.csv`) |
+| Slide deck | Present vs. edit | **PDF** (beamer) / **PPTX** (editable) | **OfficeCLI** for a polished editable deck *if `office_deliverables` is active*; else `pandoc -t beamer` (PDF) / `pandoc -t pptx` (basic editable) |
+| Data hand-off (tabular) | Analyst / client | **XLSX** | **OfficeCLI** for a real `.xlsx` (formulas + formatting) *if `office_deliverables` is active*; else flag + offer **CSV** (`pandoc -t csv` / write `.csv`). `xlsxwriter`/`openpyxl` are NOT installed — OfficeCLI or CSV, never a python xlsx lib |
 | Diagram | Reviewer | SVG/PNG embedded in the primary format | `/drawio-skill` |
 | Internal spec / wiki / blog draft | Eng team / CMS | Markdown | (repo / CMS) — the only cases raw `.md` is allowed |
 
@@ -20,7 +20,14 @@ Intake from audience + purpose, using the matrix below.
 **Lato, Georgia, Liberation Sans/Serif, Arial, Noto Sans/Serif** (via `fc-list`); the `make-pdf`
 skill (`~/.claude/skills/gstack/make-pdf/`, needs the browse daemon), `drawio-skill`,
 `fpdf`/`fitz` in the venv. **NOT installed** (do not assume): marp, typst, weasyprint,
-wkhtmltopdf, docxtpl, python-docx, python-pptx, xlsxwriter, openpyxl.
+wkhtmltopdf, docxtpl, python-docx, python-pptx, xlsxwriter, openpyxl, LibreOffice/soffice.
+
+**Conditionally available — OfficeCLI** (`~/.genesis/deps/officecli/officecli-linux-<arch>`,
+bootstrap-provisioned): real `.xlsx`/`.pptx`/`.docx` with a render→inspect→fix loop. It is
+OPTIONAL — check before use. It is active when the SessionStart `capabilities.json` shows
+`office_deliverables: active`, or belt-and-suspenders inline:
+`OCLI="$HOME/.genesis/deps/officecli/officecli-linux-$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')"; test -x "$OCLI"`.
+If absent, fall back to the pandoc/CSV rows above — never call a missing binary.
 
 ## The font IS a tell — pick it from `visual_style`
 
@@ -76,6 +83,47 @@ templated, escalate the `visual_style`: *designed* → `/make-pdf` or `/design-h
 separate Gate-1 calls. See `structure-altitude.md` for the effort-artifact tells (elaborate
 tables, dense formatting) that read as AI *only* when the target is human-made. Match what the
 user asked for; do not impose a one-size "looks human" default.
+
+## OfficeCLI — high-fidelity Office with a render→inspect→fix loop (when active)
+
+Use for real `.xlsx` (formulas + cell formatting) and polished `.pptx` when
+`office_deliverables` is active. All commands are headless (no display needed).
+`OCLI` resolves as in the note above. OfficeCLI keeps the file "open" in a resident
+process — **`save` (flush, keep warm) or `close` (flush + release) before any
+non-OfficeCLI reader** (a screenshot of external state, a `zipfile` check, delivery).
+
+```bash
+# XLSX — create, author cells/formulas/formatting, add a second sheet
+"$OCLI" create "$OUT.xlsx" --force
+"$OCLI" add "$OUT.xlsx" / --type sheet --prop name=Summary
+"$OCLI" set "$OUT.xlsx" /Sheet1/A1 --prop value="Item" --prop bold=true
+"$OCLI" set "$OUT.xlsx" /Sheet1/B2 --prop value=10
+"$OCLI" set "$OUT.xlsx" /Sheet1/B4 --prop formula="SUM(B2:B3)" --prop numberformat="#,##0"
+"$OCLI" save "$OUT.xlsx"
+# formula prop OMITS the leading '='; OfficeCLI has a built-in evaluator (view text shows B4=35).
+
+# PPTX — title slide + content slide (bullets = literal \n between items)
+"$OCLI" create "$OUT.pptx" --force
+"$OCLI" add "$OUT.pptx" / --type slide --prop layout="Title Slide" --prop title="Quarterly Review" --prop text="Analytics Team"
+"$OCLI" add "$OUT.pptx" / --type slide --prop layout="Title and Content" --prop title="Highlights" --prop text="Revenue up 12 percent\nTwo new markets\nHeadcount 45"
+"$OCLI" save "$OUT.pptx"
+```
+
+**The render→inspect→fix loop (the reason to use OfficeCLI over pandoc):**
+
+```bash
+# 1. RENDER a screenshot to LOOK at layout (PNG; write to ~/tmp, never cc-tmp)
+"$OCLI" view "$OUT.xlsx" screenshot -o ~/tmp/ocli_shot.png    # xlsx 1600x1200; pptx --grid N for all slides
+# 2. INSPECT for semantic defects — `view issues` is the DETECTOR (not `validate`,
+#    which only checks OOXML schema and passes even on a broken formula ref).
+"$OCLI" view "$OUT.xlsx" issues --json    # {"data":{"count":N,"issues":[{subtype,path,message}]}}
+# 3. FIX any issue (broken/stale formula, missing-sheet ref, low-contrast slide), save, re-inspect to count:0.
+```
+
+Relevant `view issues` subtypes: xlsx `formula_not_evaluated`, `formula_cache_stale`,
+`formula_ref_missing_sheet`, `formula_eval_error`, `definedname_broken`; pptx
+`slide_field_not_evaluated`, `notes_unresolved_rid`, `low_contrast`, `broken_part_ref`.
+Clean up the screenshot PNG(s) after inspecting.
 
 ## After rendering — update the spec
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Real spreadsheets and polished decks from the deliverable builder.** When the
+  optional OfficeCLI tool is present, Genesis now produces genuine `.xlsx` files
+  (with working formulas and cell formatting) and higher-fidelity `.pptx` decks,
+  instead of falling back to CSV or a basic pandoc slide export. It renders,
+  screenshots the result to check the layout, and catches broken or stale formulas
+  before the file reaches you. The tool is installed automatically during setup;
+  if it is unavailable, the builder degrades cleanly to the previous CSV/pandoc path.
+
 - **First-run setup wizard on the dashboard.** A new install can go from a fresh
   dashboard to a working, connected Genesis without touching a terminal. A
   dismissible Setup card on the Overview tab walks you through setting a dashboard

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -423,6 +423,66 @@ fi
 if [[ -x "$SKILLSPECTOR_DIR/.venv/bin/skillspector" ]]; then
     echo "  SkillSpector: installed at $SKILLSPECTOR_DIR/.venv/bin/skillspector"
 fi
+
+# OfficeCLI (iOfficeAI — high-fidelity .xlsx/.pptx/.docx renderer for the
+# deliverable-builder skill; optional external binary, not vendored). The runtime
+# capability probe (_init_office_deliverables) resolves this pinned path; absent
+# → the skill falls back to pandoc/CSV and `office_deliverables` shows degraded.
+OCLI_VERSION="1.0.143"
+OCLI_DIR="$HOME/.genesis/deps/officecli"
+# Arch → release asset. OfficeCLI ships linux x64 + arm64; any other arch skips
+# (skill falls back to pandoc/CSV) — never fatal.
+case "$(uname -m)" in
+    x86_64)        OCLI_ARCH="x64" ;;
+    aarch64|arm64) OCLI_ARCH="arm64" ;;
+    *)             OCLI_ARCH="" ;;
+esac
+# Literal SHA256 pins — committed + review-gated. NOT fetched from the release's
+# SHA256SUMS: that is trust-on-first-use (a compromised release swaps binary AND
+# checksum in lockstep). Bump these deliberately whenever OCLI_VERSION changes.
+OCLI_SHA256_x64="6a29c598a789b57c92c03e560907d3f131a4bd0a068785b1d338a86fc31a58a7"
+OCLI_SHA256_arm64="c50298e4698fcd1b15fe1a0f096405ad260b5c84d4440882582d0bba1e57bd49"
+if [[ -z "$OCLI_ARCH" ]]; then
+    echo "  OfficeCLI: unsupported arch $(uname -m) — skipping (deliverable-builder uses pandoc/CSV)"
+else
+    OCLI_BIN="$OCLI_DIR/officecli-linux-$OCLI_ARCH"
+    _ocli_sha_var="OCLI_SHA256_$OCLI_ARCH"; OCLI_SHA256="${!_ocli_sha_var}"
+    # Trust the on-disk binary ONLY if it matches the committed literal hash.
+    # This is the idempotency guard AND the anti-tamper check in one: a matching
+    # hash means it's exactly the pinned version (skip), while a stale binary from
+    # an older pin, or a tampered one that merely reports the right --version,
+    # fails the hash and gets re-fetched. (Version-awareness falls out for free —
+    # a version bump changes the pinned hash, so the old binary no longer matches.)
+    _ocli_verify() { [[ -f "$OCLI_BIN" ]] && echo "${OCLI_SHA256}  ${OCLI_BIN}" | sha256sum -c - >/dev/null 2>&1; }
+    if _ocli_verify; then
+        chmod +x "$OCLI_BIN"  # ensure executable even on the already-verified path
+    else
+        echo "  OfficeCLI $OCLI_VERSION ($OCLI_ARCH) not present/verified — installing..."
+        mkdir -p "$OCLI_DIR"
+        OCLI_URL="https://github.com/iOfficeAI/OfficeCLI/releases/download/v${OCLI_VERSION}/officecli-linux-${OCLI_ARCH}"
+        # curl is PRIMARY: a public release asset needs no auth, so it works on a
+        # fresh install with no gh login. gh is the fallback. timeout guards a hung
+        # connection (~35MB binary; 300s is generous); one retry rides out a blip.
+        _ocli_fetch() {
+            rm -f "$OCLI_BIN"
+            timeout 300 curl -fSL "$OCLI_URL" -o "$OCLI_BIN" 2>/dev/null \
+                || ( cd "$OCLI_DIR" && timeout 300 gh release download "v${OCLI_VERSION}" \
+                        --repo iOfficeAI/OfficeCLI --pattern "officecli-linux-${OCLI_ARCH}" --clobber 2>/dev/null )
+        }
+        _ocli_fetch || { sleep 2; _ocli_fetch; } \
+            || echo "  WARNING: OfficeCLI download failed (deliverable-builder uses pandoc/CSV until installed)"
+        # Verify the freshly-downloaded binary against the committed pin; refuse on mismatch.
+        if _ocli_verify; then
+            chmod +x "$OCLI_BIN"
+        elif [[ -f "$OCLI_BIN" ]]; then
+            rm -f "$OCLI_BIN"
+            echo "  WARNING: OfficeCLI checksum mismatch — refusing binary (deliverable-builder uses pandoc/CSV)"
+        fi
+    fi
+    if [[ -x "$OCLI_BIN" ]]; then
+        echo "  OfficeCLI: installed at $OCLI_BIN ($OCLI_VERSION)"
+    fi
+fi
 echo
 
 # --- Python venv ---

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -440,8 +440,8 @@ esac
 # Literal SHA256 pins — committed + review-gated. NOT fetched from the release's
 # SHA256SUMS: that is trust-on-first-use (a compromised release swaps binary AND
 # checksum in lockstep). Bump these deliberately whenever OCLI_VERSION changes.
-OCLI_SHA256_x64="6a29c598a789b57c92c03e560907d3f131a4bd0a068785b1d338a86fc31a58a7"
-OCLI_SHA256_arm64="c50298e4698fcd1b15fe1a0f096405ad260b5c84d4440882582d0bba1e57bd49"
+OCLI_SHA256_x64="6a29c598a789b57c92c03e560907d3f131a4bd0a068785b1d338a86fc31a58a7"  # pragma: allowlist secret  (public release checksum, not a secret)
+OCLI_SHA256_arm64="c50298e4698fcd1b15fe1a0f096405ad260b5c84d4440882582d0bba1e57bd49"  # pragma: allowlist secret  (public release checksum, not a secret)
 if [[ -z "$OCLI_ARCH" ]]; then
     echo "  OfficeCLI: unsupported arch $(uname -m) — skipping (deliverable-builder uses pandoc/CSV)"
 else

--- a/src/genesis/runtime/_capabilities.py
+++ b/src/genesis/runtime/_capabilities.py
@@ -64,6 +64,7 @@ _CAPABILITY_DESCRIPTIONS: dict[str, str] = {
     "voice_wyoming": "Wyoming STT+TTS servers — audio transport for HA voice pipeline (:10300/:10301)",
     "voice_s2s": "Speech-to-speech session manager — GPT-Realtime/Gemini Live voice front-end with Genesis tool calling",
     "campaigns": "Campaign subsystem — persistent, scheduled, LLM-driven operations with strategy docs, pre-checks, and autonomous session dispatch",
+    "office_deliverables": "OfficeCLI (iOfficeAI) — high-fidelity .xlsx/.pptx/.docx renderer for the deliverable-builder skill; degrades to pandoc/CSV when the binary is absent. Optional external tool, provisioned by bootstrap.sh into ~/.genesis/deps/officecli/.",
 }
 
 

--- a/src/genesis/runtime/_core.py
+++ b/src/genesis/runtime/_core.py
@@ -208,6 +208,9 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         self._deferred_work_queue: DeferredWorkQueue | None = None
         self._cc_budget_tracker: CCBudgetTracker | None = None
         self._health_data: HealthDataService | None = None
+        # Optional external OfficeCLI binary (deliverable-builder render backend);
+        # resolved by _init_office_deliverables, None when not provisioned.
+        self._officecli_path: str | None = None
         self._activity_tracker: ProviderActivityTracker | None = None
         self._span_writer: SpanWriter | None = None
         self._outreach_pipeline: OutreachPipeline | None = None
@@ -483,6 +486,10 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
             await self._run_init_step_async("reflex", self._init_reflex)
         self._run_init_step("guardian", self._probe_guardian_status)
 
+        # Unconditional (also in readonly probes): optional OfficeCLI render
+        # backend. Present → active; absent → degraded (never fatal).
+        self._run_init_step("office_deliverables", self._init_office_deliverables)
+
         if _full:
             await self._run_init_step_async(
                 "guardian_monitoring",
@@ -744,6 +751,7 @@ class GenesisRuntime(_RuntimeProperties, _PauseStateMixin, _InitDelegatesMixin):
         "modules": "_module_registry",
         "pipeline": "_pipeline_orchestrator",
         "campaigns": "_campaign_runner",
+        "office_deliverables": "_officecli_path",
     }
 
     def _run_init_step(self, name: str, func) -> None:

--- a/src/genesis/runtime/_init_delegates.py
+++ b/src/genesis/runtime/_init_delegates.py
@@ -195,3 +195,31 @@ class _InitDelegatesMixin:
             logger.info("Guardian heartbeat not found (Guardian may not be installed)")
         except (json.JSONDecodeError, ValueError, OSError) as exc:
             logger.info("Guardian heartbeat unreadable: %s", exc)
+
+    def _init_office_deliverables(self) -> None:
+        """Resolve the optional OfficeCLI render backend; never raises.
+
+        Sets ``self._officecli_path`` to the PINNED bootstrap-provisioned binary
+        (``~/.genesis/deps/officecli/officecli-linux-<arch>``) if present and
+        executable, else None. It deliberately does NOT fall back to a
+        ``PATH``-resolved ``officecli``: that binary is unpinned (never
+        checksum-verified against the committed hash) AND would not match the
+        exact path the deliverable-builder skill invokes (``$OCLI`` = the pinned
+        path), so a PATH hit would report ``active`` while the skill's command
+        fails. None → capability ``degraded`` (skill falls back to pandoc/CSV).
+        MUST NOT raise, or _run_init_step records ``failed`` instead of ``degraded``.
+        """
+        import os
+        import platform
+
+        self._officecli_path = None
+        try:
+            arch = "arm64" if platform.machine() in ("aarch64", "arm64") else "x64"
+            pinned = Path.home() / ".genesis" / "deps" / "officecli" / f"officecli-linux-{arch}"
+            if pinned.is_file() and os.access(pinned, os.X_OK):
+                self._officecli_path = str(pinned)
+        except Exception as exc:  # noqa: BLE001 - probe is best-effort, never fatal
+            # Path.home() can raise RuntimeError (unresolvable HOME); any failure
+            # must degrade, never propagate (→ _run_init_step would mark "failed").
+            logger.info("OfficeCLI probe failed (treating as absent): %s", exc)
+            self._officecli_path = None

--- a/src/genesis/runtime/_init_delegates.py
+++ b/src/genesis/runtime/_init_delegates.py
@@ -55,6 +55,16 @@ from genesis.runtime.init import (
 
 logger = logging.getLogger("genesis.runtime")
 
+# OfficeCLI pinned SHA256 per arch. MUST stay in sync with the literal pins in
+# scripts/bootstrap.sh (OCLI_SHA256_x64 / OCLI_SHA256_arm64) — bump both together
+# on a version change (a drift-guard test asserts they match). The runtime probe
+# re-verifies the on-disk binary against this so a corrupted/replaced binary is
+# NOT used to render a deliverable (it degrades to pandoc/CSV instead).
+_OFFICECLI_SHA256 = {
+    "x64": "6a29c598a789b57c92c03e560907d3f131a4bd0a068785b1d338a86fc31a58a7",  # pragma: allowlist secret
+    "arm64": "c50298e4698fcd1b15fe1a0f096405ad260b5c84d4440882582d0bba1e57bd49",  # pragma: allowlist secret
+}
+
 
 class _InitDelegatesMixin:
     """Mixin: per-subsystem bootstrap step delegates."""
@@ -200,15 +210,18 @@ class _InitDelegatesMixin:
         """Resolve the optional OfficeCLI render backend; never raises.
 
         Sets ``self._officecli_path`` to the PINNED bootstrap-provisioned binary
-        (``~/.genesis/deps/officecli/officecli-linux-<arch>``) if present and
-        executable, else None. It deliberately does NOT fall back to a
-        ``PATH``-resolved ``officecli``: that binary is unpinned (never
-        checksum-verified against the committed hash) AND would not match the
-        exact path the deliverable-builder skill invokes (``$OCLI`` = the pinned
-        path), so a PATH hit would report ``active`` while the skill's command
-        fails. None → capability ``degraded`` (skill falls back to pandoc/CSV).
-        MUST NOT raise, or _run_init_step records ``failed`` instead of ``degraded``.
+        (``~/.genesis/deps/officecli/officecli-linux-<arch>``) only if it is
+        present, executable, AND its SHA256 matches the committed pin — else None.
+
+        It re-verifies the checksum (not just the executable bit) so a corrupted,
+        partially-written, or replaced binary is never used to render a user
+        deliverable — the capability degrades to pandoc/CSV instead. It also does
+        NOT fall back to a ``PATH``-resolved ``officecli``: that binary is unpinned
+        AND would not match the exact path the deliverable-builder skill invokes
+        (``$OCLI`` = the pinned path). None → capability ``degraded``. MUST NOT
+        raise, or _run_init_step records ``failed`` instead of ``degraded``.
         """
+        import hashlib
         import os
         import platform
 
@@ -216,8 +229,20 @@ class _InitDelegatesMixin:
         try:
             arch = "arm64" if platform.machine() in ("aarch64", "arm64") else "x64"
             pinned = Path.home() / ".genesis" / "deps" / "officecli" / f"officecli-linux-{arch}"
-            if pinned.is_file() and os.access(pinned, os.X_OK):
-                self._officecli_path = str(pinned)
+            expected = _OFFICECLI_SHA256.get(arch)
+            if expected and pinned.is_file() and os.access(pinned, os.X_OK):
+                h = hashlib.sha256()
+                with open(pinned, "rb") as fh:
+                    for chunk in iter(lambda: fh.read(1 << 20), b""):
+                        h.update(chunk)
+                if h.hexdigest() == expected:
+                    self._officecli_path = str(pinned)
+                else:
+                    logger.warning(
+                        "OfficeCLI binary at %s failed checksum verification — "
+                        "treating as absent (deliverable-builder uses pandoc/CSV)",
+                        pinned,
+                    )
         except Exception as exc:  # noqa: BLE001 - probe is best-effort, never fatal
             # Path.home() can raise RuntimeError (unresolvable HOME); any failure
             # must degrade, never propagate (→ _run_init_step would mark "failed").

--- a/tests/test_runtime/test_office_capability.py
+++ b/tests/test_runtime/test_office_capability.py
@@ -9,7 +9,9 @@ _run_init_step, misrepresenting a normal optional-absent state as an error).
 
 from __future__ import annotations
 
-from genesis.runtime import GenesisRuntime
+import hashlib
+
+from genesis.runtime import GenesisRuntime, _init_delegates
 
 
 def _bare_runtime():
@@ -23,8 +25,16 @@ def _fake_binary(home, arch="x64"):
     d = home / ".genesis" / "deps" / "officecli"
     d.mkdir(parents=True, exist_ok=True)
     b = d / f"officecli-linux-{arch}"
-    b.write_text("#!/bin/sh\necho 1.0.143\n")
+    b.write_bytes(b"#!/bin/sh\necho 1.0.143\n")
     b.chmod(0o755)
+    return b
+
+
+def _fake_binary_and_pin(home, arch, monkeypatch):
+    """Write a fake binary AND pin its real hash so the checksum re-verify passes."""
+    b = _fake_binary(home, arch)
+    digest = hashlib.sha256(b.read_bytes()).hexdigest()
+    monkeypatch.setitem(_init_delegates._OFFICECLI_SHA256, arch, digest)
     return b
 
 
@@ -37,7 +47,7 @@ def test_office_in_init_checks_maps_to_path_attr():
 def test_office_active_when_binary_present(tmp_path, monkeypatch):
     monkeypatch.setattr("platform.machine", lambda: "x86_64")
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
-    _fake_binary(tmp_path, "x64")
+    _fake_binary_and_pin(tmp_path, "x64", monkeypatch)
     rt = _bare_runtime()
     rt._run_init_step("office_deliverables", rt._init_office_deliverables)
     assert rt._officecli_path is not None
@@ -82,7 +92,7 @@ def test_office_probe_never_raises_on_unresolvable_home(monkeypatch):
 def test_office_arm64_binary_name(tmp_path, monkeypatch):
     monkeypatch.setattr("platform.machine", lambda: "aarch64")
     monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
-    _fake_binary(tmp_path, "arm64")
+    _fake_binary_and_pin(tmp_path, "arm64", monkeypatch)
     rt = _bare_runtime()
     rt._init_office_deliverables()
     assert rt._officecli_path is not None
@@ -94,3 +104,32 @@ def test_office_description_registered():
 
     assert "office_deliverables" in _CAPABILITY_DESCRIPTIONS
     assert _CAPABILITY_DESCRIPTIONS["office_deliverables"].strip()
+
+
+def test_office_degraded_on_checksum_mismatch(tmp_path, monkeypatch):
+    # Present + executable but hash != committed pin (corrupted/replaced binary) →
+    # degraded, NOT active. The renderer must not run a tampered/corrupt binary.
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    _fake_binary(tmp_path, "x64")  # NOT pinned → fake's hash != real pin
+    rt = _bare_runtime()
+    rt._run_init_step("office_deliverables", rt._init_office_deliverables)
+    assert rt._officecli_path is None
+    assert rt._bootstrap_manifest["office_deliverables"] == "degraded"
+
+
+def test_officecli_pins_match_bootstrap_sh():
+    # Drift guard: the Python pins MUST equal the bootstrap.sh literals, else a
+    # version bump in one place silently degrades the capability on every install.
+    import re
+    from pathlib import Path
+
+    bootstrap = (
+        Path(__file__).resolve().parents[2] / "scripts" / "bootstrap.sh"
+    ).read_text()
+    for arch in ("x64", "arm64"):
+        m = re.search(rf'OCLI_SHA256_{arch}="([0-9a-f]{{64}})"', bootstrap)
+        assert m, f"bootstrap.sh missing OCLI_SHA256_{arch} pin"
+        assert m.group(1) == _init_delegates._OFFICECLI_SHA256[arch], (
+            f"{arch} pin drift between bootstrap.sh and _init_delegates.py"
+        )

--- a/tests/test_runtime/test_office_capability.py
+++ b/tests/test_runtime/test_office_capability.py
@@ -1,0 +1,96 @@
+"""OfficeCLI capability wiring — external-binary presence → capabilities.json.
+
+OfficeCLI is an optional external renderer for the deliverable-builder skill. Its
+presence must surface as `office_deliverables: active` in capabilities.json and its
+absence as `degraded` (NOT `failed`, NOT missing) — the "provision-or-surface"
+contract. The probe must NEVER raise (a raise would record `failed`, per
+_run_init_step, misrepresenting a normal optional-absent state as an error).
+"""
+
+from __future__ import annotations
+
+from genesis.runtime import GenesisRuntime
+
+
+def _bare_runtime():
+    rt = GenesisRuntime.__new__(GenesisRuntime)
+    rt._bootstrap_manifest = {}
+    rt._officecli_path = None
+    return rt
+
+
+def _fake_binary(home, arch="x64"):
+    d = home / ".genesis" / "deps" / "officecli"
+    d.mkdir(parents=True, exist_ok=True)
+    b = d / f"officecli-linux-{arch}"
+    b.write_text("#!/bin/sh\necho 1.0.143\n")
+    b.chmod(0o755)
+    return b
+
+
+def test_office_in_init_checks_maps_to_path_attr():
+    # Guards the silent-always-"ok" trap: absent from _INIT_CHECKS → attr is None →
+    # _run_init_step can never record "degraded".
+    assert GenesisRuntime._INIT_CHECKS.get("office_deliverables") == "_officecli_path"
+
+
+def test_office_active_when_binary_present(tmp_path, monkeypatch):
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    _fake_binary(tmp_path, "x64")
+    rt = _bare_runtime()
+    rt._run_init_step("office_deliverables", rt._init_office_deliverables)
+    assert rt._officecli_path is not None
+    assert rt._officecli_path.endswith("officecli-linux-x64")
+    assert rt._bootstrap_manifest["office_deliverables"] == "ok"
+
+
+def test_office_degraded_when_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)  # empty — no pinned binary
+    rt = _bare_runtime()
+    rt._run_init_step("office_deliverables", rt._init_office_deliverables)
+    assert rt._officecli_path is None
+    assert rt._bootstrap_manifest["office_deliverables"] == "degraded"
+
+
+def test_office_ignores_unpinned_path_binary(tmp_path, monkeypatch):
+    # Pinned-path ONLY: an `officecli` on PATH must NOT make the capability active
+    # (it's unpinned/unverified AND wouldn't match the skill's $OCLI path).
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)  # no pinned binary
+    monkeypatch.setattr("shutil.which", lambda _name: "/usr/local/bin/officecli")
+    rt = _bare_runtime()
+    rt._init_office_deliverables()
+    assert rt._officecli_path is None  # PATH hit ignored
+
+
+def test_office_probe_never_raises_on_unresolvable_home(monkeypatch):
+    # Path.home() raises RuntimeError when HOME can't be resolved — the probe must
+    # degrade (None), never propagate (else _run_init_step records "failed").
+    def _boom():
+        raise RuntimeError("home not resolvable")
+
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    monkeypatch.setattr("pathlib.Path.home", _boom)
+    rt = _bare_runtime()
+    rt._run_init_step("office_deliverables", rt._init_office_deliverables)  # must not raise
+    assert rt._officecli_path is None
+    assert rt._bootstrap_manifest["office_deliverables"] == "degraded"
+
+
+def test_office_arm64_binary_name(tmp_path, monkeypatch):
+    monkeypatch.setattr("platform.machine", lambda: "aarch64")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    _fake_binary(tmp_path, "arm64")
+    rt = _bare_runtime()
+    rt._init_office_deliverables()
+    assert rt._officecli_path is not None
+    assert rt._officecli_path.endswith("officecli-linux-arm64")
+
+
+def test_office_description_registered():
+    from genesis.runtime._capabilities import _CAPABILITY_DESCRIPTIONS
+
+    assert "office_deliverables" in _CAPABILITY_DESCRIPTIONS
+    assert _CAPABILITY_DESCRIPTIONS["office_deliverables"].strip()

--- a/tests/test_scripts/test_bootstrap_guards.py
+++ b/tests/test_scripts/test_bootstrap_guards.py
@@ -151,3 +151,85 @@ def test_s3_dead_repo_example_removed():
     assert "REPO_EXAMPLE" not in cfg
     assert "genesis.yaml.example" not in cfg
     assert "Migrate from repo YAML" not in cfg  # the misleading comment is corrected
+
+
+# ── OfficeCLI: provisioned binary for deliverable-builder (external, optional) ──
+# The render backend for high-fidelity .xlsx/.pptx. Security-critical: a pinned
+# version + a COMMITTED literal SHA256 (not a fetched SHA256SUMS, which is TOFU).
+import re  # noqa: E402
+
+
+def test_officecli_pins_committed_literal_sha256_both_arches():
+    """BLOCKER guard: literal 64-hex SHA256 pins for x64 AND arm64 live in the
+    script (repo-reviewed), so verification can't be defeated by a swapped
+    release. A fetched SHA256SUMS would be trust-on-first-use."""
+    code = _code(BOOTSTRAP)
+    assert re.search(r'OCLI_SHA256_x64="[0-9a-f]{64}"', code)
+    assert re.search(r'OCLI_SHA256_arm64="[0-9a-f]{64}"', code)
+    # ...and it must actually be checked, refusing (deleting) on mismatch.
+    assert "sha256sum -c -" in code
+    assert 'rm -f "$OCLI_BIN"' in code
+    assert "checksum mismatch" in code.lower()
+
+
+def test_officecli_arch_detection_x64_arm64_and_skip():
+    code = _code(BOOTSTRAP)
+    assert 'x86_64)        OCLI_ARCH="x64"' in code or 'x86_64) OCLI_ARCH="x64"' in code
+    assert 'aarch64|arm64) OCLI_ARCH="arm64"' in code
+    # unsupported arch → empty → skip branch (never fatal)
+    assert 'OCLI_ARCH=""' in code
+    assert "unsupported arch" in code
+
+
+def test_officecli_guard_is_checksum_based_not_presence_or_version_only():
+    """The idempotency guard trusts the on-disk binary ONLY if its hash matches
+    the committed pin — which re-verifies an existing binary (anti-tamper) AND
+    re-downloads on a pin bump (the new hash won't match the old binary). NOT a
+    presence-only `-x` skip and NOT a spoofable `--version` check."""
+    code = _code(BOOTSTRAP)
+    assert "_ocli_verify()" in code
+    assert "if _ocli_verify; then" in code  # skip only when the hash matches
+    # anti-tamper: the guard re-hashes; it does NOT trust a bare --version string.
+    assert '"$OCLI_BIN" --version' not in code
+    # verify runs both on the existing binary AND the freshly-downloaded one.
+    assert code.count("_ocli_verify") >= 3
+
+
+def test_officecli_curl_primary_gh_fallback():
+    """curl (no auth needed for a public asset) must be tried BEFORE gh, so a
+    fresh install with no gh login still provisions."""
+    code = _code(BOOTSTRAP)
+    curl_i = code.find('curl -fSL "$OCLI_URL"')
+    gh_i = code.find("gh release download")
+    assert curl_i != -1 and gh_i != -1
+    assert curl_i < gh_i  # curl primary, gh fallback
+
+
+def test_officecli_nonfatal_and_bounded():
+    code = _code(BOOTSTRAP)
+    assert "WARNING: OfficeCLI download failed" in code  # non-fatal echo, never exit 1
+    assert "timeout 300 curl" in code  # bounded fetch
+    assert "sleep 2" in code  # one retry
+
+
+def test_officecli_arch_and_checksum_logic_functional(tmp_path):
+    """Functional: arch mapping + checksum accept/refuse behave correctly."""
+    script = r"""
+    for m in x86_64 aarch64 arm64 riscv64; do
+      case "$m" in x86_64) A="x64";; aarch64|arm64) A="arm64";; *) A="";; esac
+      echo "$m=$A"
+    done
+    f="$1"; good=$(sha256sum "$f" | awk '{print $1}')
+    echo "good  $f" | sed "s/^good/$good/" | sha256sum -c - >/dev/null 2>&1 && echo "good=accept" || echo "good=reject"
+    echo "0000000000000000000000000000000000000000000000000000000000000000  $f" | sha256sum -c - >/dev/null 2>&1 && echo "bad=accept" || echo "bad=reject"
+    """
+    f = tmp_path / "bin"
+    f.write_text("payload")
+    out = subprocess.run(
+        ["bash", "-c", script, "bash", str(f)], capture_output=True, text=True, check=True
+    ).stdout
+    assert "x86_64=x64" in out
+    assert "aarch64=arm64" in out and "arm64=arm64" in out
+    assert "riscv64=" in out  # unsupported → empty
+    assert "good=accept" in out
+    assert "bad=reject" in out  # checksum mismatch refused


### PR DESCRIPTION
## What

Adds **OfficeCLI** (iOfficeAI, Apache-2.0) as an **optional** high-fidelity Office render backend for the `deliverable-builder` skill: real `.xlsx` (working formulas + cell formatting) and polished `.pptx`, with a render → inspect → fix loop. Closes the skill's two known render gaps (XLSX was deferred to CSV; decks were pandoc-basic). Degrades cleanly to pandoc/CSV when the binary is absent.

## How

- **Provisioned in `bootstrap.sh`** (mirrors the SkillSpector pattern) into `~/.genesis/deps/officecli/`:
  - arch-detected (`x64` / `arm64` / skip-with-warning on others),
  - verified against a **committed literal SHA256 pin** (both arches) rather than a fetched `SHA256SUMS` (which would be trust-on-first-use: a compromised release swaps binary and checksum together),
  - **curl-primary, gh-fallback** (a public release asset needs no auth, so a fresh install with no `gh` login still provisions),
  - **checksum-gated idempotency**: the on-disk binary is trusted only if its hash matches the pin, so a tampered or stale (old-pin) binary is re-fetched; a version bump changes the pin and re-fetches automatically,
  - **non-fatal** throughout (never breaks bootstrap).
- **Capability surface**: `office_deliverables` appears in `~/.genesis/capabilities.json` as `active` when the pinned binary is present, `degraded` when absent. The runtime probe resolves the pinned path only (an unpinned `PATH` binary is never trusted) and never raises. Provision-or-surface, not a silent skip.
- **Skill prose** (`render-guide.md` / `qa-protocol.md` / `SKILL.md` / `intake.md`): capability-gated backend selection (falls back to pandoc/CSV when absent, never calls a missing binary), the author + render → `view issues` → fix commands, and **LibreOffice-free verification** — stdlib `zipfile` required-parts check plus OfficeCLI `view issues` for semantic defects (broken/stale formulas), since `validate` only checks OOXML schema.

## Evidence

- Reviewed by genesis-architect (design), then Codex and a Claude reviewer (two sequential rounds). All findings fixed: checksum-based guard (was spoofable `--version`), pinned-path-only probe (was an unpinned `PATH` fallback), full `$OCLI` path in qa-protocol (was bare `officecli`, not on `PATH`), broad-`Exception` probe, and a stale `SKILL.md` capability caveat that contradicted the feature.
- **22 targeted tests** (capability wiring: present→active / absent→degraded / unpinned-PATH-ignored / unresolvable-HOME→degraded; bootstrap guards: literal-pin present, arch detection, checksum-based guard, curl-primary, non-fatal, functional arch+checksum logic).
- **Level-4 E2E on real files** (headless, no LibreOffice): authored a RevOps `.xlsx` (formulas + formatting, two sheets) and a client `.pptx`, verified via `zipfile` required-parts and `view issues` (count 0), and proved the inspect loop catches a seeded broken-formula reference (count 1 → fixed → 0). Deliverables written to `~/.genesis/output/`, never the repo.

## Verification

- `pytest tests/test_runtime/test_office_capability.py tests/test_scripts/test_bootstrap_guards.py` (22 passing)
- `ruff check` clean; `bash -n scripts/bootstrap.sh` clean
- Runtime probe resolves the real provisioned binary → `office_deliverables: active`

Context: capability-build campaign ledger `09ab9c12a8fd49c686cc644201b448c7` (item #7). The campaign row stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
