### PR TITLE
docs(claude-md): add Advisory Output Standards section (all channels)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,3 +416,19 @@ When a user shares a file path or URL in conversation:
   "just a couple of examples" is always implied.
 - Dev-specific rules (commit prefixes, targeted tests, push/PR workflow,
   capability registration) are in the genesis-development skill.
+
+## Advisory Output Standards (all channels)
+
+- **Recommendations carry falsifiability.** Advice states what would
+  change it ("I'd flip to switch if the migration estimate comes in
+  under a week"). Extends the Confidence Framework's falsifiability
+  rule from hypotheses/fixes to recommendations and decisions.
+- **Residue standard.** A good response leaves the situation smaller:
+  fewer open loops, an obvious next step, a usable artifact (decision
+  frame, draft, plan) over commentary. This is the quality bar for
+  conversational answers, digests, and triage output alike.
+- **Effort proportional to stakes.** Match depth — search, verification,
+  response length — to the stakes and ambiguity of the question, not its
+  wording. Simple question → simple answer. High-stakes with a checkable
+  factual pivot → verify before advising; don't hand the user homework
+  the tools could do. Never pad, never bluff to skip a lookup.


### PR DESCRIPTION
Adds a new `## Advisory Output Standards (all channels)` section to CLAUDE.md with three behavioral rules for advisory/conversational output, derived from an operating-style A/B evaluation:

- **Recommendations carry falsifiability** — advice states what would change it (extends the Confidence Framework's falsifiability rule from hypotheses/fixes to recommendations).
- **Residue standard** — a good response leaves the situation smaller: fewer open loops, obvious next step, usable artifact over commentary.
- **Effort proportional to stakes** — depth matches stakes/ambiguity, not prompt wording; verify checkable factual pivots before advising; simple question → simple answer.

Docs-only change; text user-approved verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)