### PR TITLE
Fix chunk_messages docstring and add characterization tests

### DIFF
--- a/src/genesis/util/jsonl.py
+++ b/src/genesis/util/jsonl.py
@@ -122,10 +122,9 @@ def chunk_messages(
 ) -> list[list[ConversationMessage]]:
     """Split messages into chunks for extraction.
 
-    Each chunk contains up to ``chunk_size`` messages.  Messages are split
-    into consecutive chunks of ``chunk_size``, preserving their original
-    order.  There is no pairing logic: a user+assistant pair may be split
-    across chunk boundaries.
+    Each chunk contains up to ``chunk_size`` messages. Messages are split
+    into consecutive chunks of up to ``chunk_size`` while preserving their
+    original order.
     """
     if not messages:
         return []

--- a/src/genesis/util/jsonl.py
+++ b/src/genesis/util/jsonl.py
@@ -122,10 +122,10 @@ def chunk_messages(
 ) -> list[list[ConversationMessage]]:
     """Split messages into chunks for extraction.
 
-    Each chunk contains up to ``chunk_size`` messages.  Chunks preserve
-    message order and never split a user+assistant pair across chunks
-    (best effort — if the last message in a chunk is a user message,
-    the next assistant message starts the next chunk).
+    Each chunk contains up to ``chunk_size`` messages.  Messages are split
+    into consecutive chunks of ``chunk_size``, preserving their original
+    order.  There is no pairing logic: a user+assistant pair may be split
+    across chunk boundaries.
     """
     if not messages:
         return []

--- a/tests/test_util/test_jsonl.py
+++ b/tests/test_util/test_jsonl.py
@@ -1,0 +1,48 @@
+"""Tests for genesis.util.jsonl — how message chunking actually behaves.
+
+These tests pin the real behavior of ``chunk_messages``: it splits a list
+into consecutive fixed-size chunks preserving order, with no user+assistant
+pairing logic.
+"""
+
+from genesis.util.jsonl import ConversationMessage, chunk_messages
+
+
+def _msgs(n: int) -> list[ConversationMessage]:
+    return [
+        ConversationMessage(role="user" if i % 2 == 0 else "assistant",
+                            text=f"message {i}",
+                            line_number=i)
+        for i in range(n)
+    ]
+
+
+def test_chunks_are_capped_at_chunk_size():
+    chunks = chunk_messages(_msgs(120), chunk_size=50)
+    assert [len(c) for c in chunks] == [50, 50, 20]
+
+
+def test_empty_is_empty():
+    assert chunk_messages([], chunk_size=50) == []
+
+
+def test_size_less_than_chunk_returns_single_chunk():
+    chunks = chunk_messages(_msgs(5), chunk_size=50)
+    assert [len(c) for c in chunks] == [5]
+
+
+def test_exact_multiple_has_no_trailing_chunk():
+    chunks = chunk_messages(_msgs(100), chunk_size=50)
+    assert [len(c) for c in chunks] == [50, 50]
+
+
+def test_preserves_message_order():
+    msgs = _msgs(120)
+    chunks = chunk_messages(msgs, chunk_size=50)
+    flattened = [m for chunk in chunks for m in chunk]
+    assert [m.line_number for m in flattened] == [m.line_number for m in msgs]
+
+
+def test_default_chunk_size_is_50():
+    chunks = chunk_messages(_msgs(120))
+    assert [len(c) for c in chunks] == [50, 50, 20]

--- a/tests/test_util/test_jsonl.py
+++ b/tests/test_util/test_jsonl.py
@@ -10,9 +10,9 @@ from genesis.util.jsonl import ConversationMessage, chunk_messages
 
 def _msgs(n: int) -> list[ConversationMessage]:
     return [
-        ConversationMessage(role="user" if i % 2 == 0 else "assistant",
-                            text=f"message {i}",
-                            line_number=i)
+        ConversationMessage(
+            role="user" if i % 2 == 0 else "assistant", text=f"message {i}", line_number=i
+        )
         for i in range(n)
     ]
 


### PR DESCRIPTION
## Summary

Update the `chunk_messages` docstring so it accurately reflects the current implementation and add characterization tests documenting the existing behavior.

## Changes

- Remove the inaccurate claim that user/assistant pairs are preserved across chunk boundaries.
- Update the docstring to describe the current chunking behavior.
- Add characterization tests covering:
  - empty input
  - chunk size limits
  - exact multiples
  - message order preservation
  - default chunk size

## Testing

- [x] `pytest tests/test_util/test_jsonl.py` passes (6 tests)
- [ ] `ruff check .` passes *(not run for the entire repository)*
- [ ] `pytest -v` passes *(not run)*
- [ ] Tested end-to-end *(not applicable)*
- [ ] `docs/architecture/CURRENT.md` updated *(not applicable)*

This PR does not change runtime behavior.