### PR TITLE
feat(ego): operate-vs-develop gate (flag-gated) + global proposal cap + revalidation backfill + deliverable floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **The operations ego stays out of development work.** Genesis's COO ego no
+  longer proposes Genesis-development tasks (reviewing pull requests, scoping
+  refactors, patch-planning) — those are deterministically moved to the tabled
+  lane instead of reaching your approval queue, while genuine operational
+  diagnosis (a failing backup, a stuck provider) still flows normally. When you
+  later choose to unlock self-development, one config flag
+  (`genesis_self_development_enabled`) turns the guardrail off.
+- **One proposal queue of 15, not 15 per ego.** The pending-proposal cap now
+  counts both egos together, so the approval board can no longer grow to ~30
+  items.
+- **Stale proposals get premise re-checks.** Older pending proposals were
+  invisible to the premise-revalidation cadence (the field was never
+  backfilled) and re-validated items stayed flagged as overdue forever; both
+  are fixed, so dead proposals stop lingering on the board.
+- **Every ego investigation names its deliverable.** Investigation dispatches
+  from the operations ego now always carry a concrete output file that
+  post-dispatch verification checks, and both dispatch paths tell the session
+  exactly where to write it.
+
 - **Real spreadsheets and polished decks from the deliverable builder.** When the
   optional OfficeCLI tool is present, Genesis now produces genuine `.xlsx` files
   (with working formulas and cell formatting) and higher-fidelity `.pptx` decks,

--- a/config/ego.yaml
+++ b/config/ego.yaml
@@ -23,8 +23,16 @@ morning_report_effort: low   # effort for morning reports
 
 # Proposals
 board_size: 3                # max active proposals on the bulletin board
-max_pending_proposals: 15    # auto-table oldest unranked when exceeded
+max_pending_proposals: 15    # TOTAL pending across both egos — auto-table oldest unranked when exceeded
 batch_digest: true           # send proposals as batch (vs individual)
+
+# Roadmap flag: Genesis developing itself (writing/refactoring its own code,
+# reviewing PRs, scoping refactors) stays OFF until explicitly unlocked. While
+# false, the genesis ego's develop-scope proposals are deterministically tabled
+# (recoverable, never deleted) by the domain-boundary gate. Flip to true to
+# unlock self-development; the gate then passes develop-class proposals through
+# to normal approval. Takes effect next ego cycle (live-read).
+genesis_self_development_enabled: false
 
 # Morning report
 morning_report_hour: 8       # 24h format, local time

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -473,7 +473,7 @@ them.
 ```yaml subsystem-map
 entry: ego-self-model
 modules: [ego, identity, deliberation]
-verified: 7968d85a 2026-07-16
+verified: f6cb6d83 2026-08-05
 ```
 
 - **Two egos, both LIVE**: user ego (CEO, Opus, MCP profile `user_reflection`)
@@ -490,6 +490,28 @@ verified: 7968d85a 2026-07-16
   `_NEVER_DISPATCH_ACTION_TYPES` blocklist lives in `session.py`. Dispatches
   record `follow_ups` rows for accountability. `integrity.py` chain-verify is
   GROUNDWORK, explicitly NOT wired.
+- **Operate-vs-develop gate (2026-08-05)**: while
+  `EgoConfig.genesis_self_development_enabled` is False (roadmap default), the
+  COO's dev-artifact proposals (PR review, refactor, patch, schema work — even
+  read-only) are deterministically create-then-TABLED
+  (`session._flag_develop_scope` + the tabling loop in `_process_proposals`;
+  journal-resolved; dedup vs tabled twins so no per-cycle churn). Symptom-driven
+  diagnosis stays operate (escalation-only deliverable) — the realist rubric
+  (rule 8 + Rule 1) judges the fuzzy cases; markers stay near-zero-FP by design
+  (replay-verified over the full historical board). Flip the flag to unlock
+  self-development; delete flag + gate to remove.
+- **Pending cap is TOTAL across both egos** (15): `_process_proposals` counts
+  the global pending pool (informational rows excluded; develop-flagged
+  incoming excluded) and evicts global-oldest-unranked (24h guard). Evo-origin
+  rows are now cap-countable (deliberate).
+- **Revalidation cadence is live end-to-end**: `create_batch` stamps
+  `revalidate_at` (shared helper `config.next_revalidate_at`), migration 0077
+  backfilled pre-PR-6a pending rows, and reconcile reaffirm/revise RE-STAMP the
+  clock (a re-validated item leaves ⚠due). Genesis-ego dispatch/investigate
+  proposals get a default `expected_outputs` deliverable
+  (`~/.genesis/output/ego-reports/<id>.md`) when the ego omits one; both
+  dispatch-prompt paths render the required-files block
+  (`_required_outputs_block`).
 - **Goal provenance + additive autonomy (2026-07-16)**: `user_goals.origin`
   ('user' | 'genesis_ego', immutable after create — excluded from `update()`'s
   allow-list; CHECK-constrained; migration 0063). A `genesis_ego`-origin goal

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -585,6 +585,12 @@ async def ego_directives():
 
     active = await ego_crud.list_directives(rt._db, statuses=("active",), limit=50)
     resolved = await ego_crud.list_directives(rt._db, statuses=("completed", "cancelled"), limit=5)
+    # Recency window: directives resolve rarely, so without a cutoff the same
+    # handful of resolved rows lingers in this history for months.
+    from datetime import UTC, datetime, timedelta
+
+    _cutoff = (datetime.now(UTC) - timedelta(days=14)).isoformat()
+    resolved = [d for d in resolved if (d.get("resolved_at") or "") >= _cutoff]
     return jsonify(
         {
             "active": [_directive_view(d) for d in active],

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -402,13 +402,22 @@ async def set_mode(db: aiosqlite.Connection, mode: str, ego_key: str = "ego_mode
 async def has_pending_proposal_with_hash(
     db: aiosqlite.Connection,
     content_hash: str,
+    *,
+    statuses: tuple[str, ...] = ("pending", "approved"),
 ) -> bool:
-    """Check if a pending or approved proposal with this content hash exists."""
+    """Check if a proposal with this content hash exists in *statuses*.
+
+    Default statuses preserve the original pending/approved dedup semantics.
+    The develop-gate passes ``("pending", "approved", "tabled")`` so a
+    persistent dev-artifact idea the gate already tabled is not re-created
+    (and re-tabled, and re-journaled) every ego cycle.
+    """
+    placeholders = ",".join("?" for _ in statuses)
     cursor = await db.execute(
         "SELECT 1 FROM ego_proposals "
-        "WHERE content_hash = ? AND status IN ('pending', 'approved') "
+        f"WHERE content_hash = ? AND status IN ({placeholders}) "
         "LIMIT 1",
-        (content_hash,),
+        (content_hash, *statuses),
     )
     return await cursor.fetchone() is not None
 
@@ -599,15 +608,24 @@ async def resolve_proposal(
     return cursor.rowcount > 0
 
 
-async def reaffirm_proposal(db: aiosqlite.Connection, id: str) -> bool:
+async def reaffirm_proposal(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    revalidate_at: str | None = None,
+) -> bool:
     """Mark a pending proposal validated-as-of-now (reconcile reaffirm verdict).
 
-    Touches only ``last_validated_at``; status/rank/content are unchanged.
-    Returns True if a pending row was updated.
+    Touches ``last_validated_at`` and — when the caller provides the next
+    cadence stamp — advances ``revalidate_at``, so a just-reaffirmed item does
+    not stay perpetually ⚠due. Status/rank/content are unchanged. Returns True
+    if a pending row was updated.
     """
     cursor = await db.execute(
-        "UPDATE ego_proposals SET last_validated_at = ? WHERE id = ? AND status = 'pending'",
-        (datetime.now(UTC).isoformat(), id),
+        "UPDATE ego_proposals SET last_validated_at = ?, "
+        "revalidate_at = COALESCE(?, revalidate_at) "
+        "WHERE id = ? AND status = 'pending'",
+        (datetime.now(UTC).isoformat(), revalidate_at, id),
     )
     await db.commit()
     return cursor.rowcount > 0
@@ -665,6 +683,7 @@ async def revise_proposal(
     expected_outputs: str | None = None,
     revised_by: str | None = None,
     reason: str | None = None,
+    revalidate_at: str | None = None,
 ) -> int | None:
     """Version-revise a PENDING proposal in place (reconcile revise verdict).
 
@@ -706,7 +725,8 @@ async def revise_proposal(
         "rationale = COALESCE(?, rationale), confidence = COALESCE(?, confidence), "
         "execution_plan = COALESCE(?, execution_plan), "
         "expected_outputs = COALESCE(?, expected_outputs), revision_num = ?, "
-        "content_hash = ?, content_size = ?, last_validated_at = ? "
+        "content_hash = ?, content_size = ?, last_validated_at = ?, "
+        "revalidate_at = COALESCE(?, revalidate_at) "
         "WHERE id = ? AND status = 'pending' AND revision_num = ?",
         (
             content,
@@ -718,6 +738,7 @@ async def revise_proposal(
             new_hash,
             new_size,
             datetime.now(UTC).isoformat(),
+            revalidate_at,
             id,
             expected_revision,
         ),

--- a/src/genesis/db/migrations/0077_backfill_revalidate_at.py
+++ b/src/genesis/db/migrations/0077_backfill_revalidate_at.py
@@ -1,0 +1,79 @@
+"""Backfill ``ego_proposals.revalidate_at`` on pre-PR-6a pending rows.
+
+Migration 0071 added the revalidation columns dark (no backfill) and the
+PR-6a stamp in ``create_batch`` covers only rows created after it shipped —
+so every pending proposal from before then has ``revalidate_at IS NULL`` and
+is invisible to the reconcile stage's ⚠due premise-recheck flag. That gap is
+how provably-dead proposals (a merged-PR review, a resolved backup incident)
+sat on the board for a week with nothing prompting a re-check.
+
+Data-only and idempotent: stamps ``revalidate_at = created_at + interval``
+(the frozen per-urgency defaults below) and ``last_validated_at = created_at``
+ONLY where NULL, on PENDING rows only. Informational eval rows (j9/gauntlet)
+are deliberately excluded — per PR-6a's design they are acknowledge-only and
+never revalidated.
+
+Stamps are computed in Python (not SQLite ``datetime()``) for exact format
+parity with the organic PR-6a stamps: the reconcile ⚠due check is a STRING
+comparison against ``datetime.now(UTC).isoformat()``, and SQLite's
+``YYYY-MM-DD HH:MM:SS`` output (space separator, no offset) would misorder
+against ISO-8601 ``T``-separated values on same-day boundaries.
+
+Frozen snapshots (self-contained by convention — migrations never import live
+config/code whose meaning can drift):
+- interval defaults mirror ``EgoConfig.revalidation_interval_hours``
+- the informational tuple mirrors ``genesis.ego.types.INFORMATIONAL_ACTION_TYPES``
+
+``down()`` is a no-op: reversing would require distinguishing backfilled
+stamps from organic PR-6a stamps, which this migration deliberately makes
+indistinguishable (both encode "created_at + interval").
+
+(Numbered 0077: 0076 is the highest present; the runner applies by per-id
+tracking and only duplicate prefixes are fatal.)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import aiosqlite
+
+# Frozen snapshot of EgoConfig.revalidation_interval_hours defaults (hours).
+_INTERVAL_HOURS = {"critical": 6, "high": 48, "normal": 72, "low": 168}
+
+# Frozen snapshot of genesis.ego.types.INFORMATIONAL_ACTION_TYPES.
+_INFORMATIONAL_ACTION_TYPES = ("j9_regression", "gauntlet_regression")
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT 1 FROM pragma_table_info('ego_proposals') WHERE name = 'revalidate_at'"
+    )
+    if await cursor.fetchone() is None:
+        return  # pre-0071 DB — the column migration will run first next boot
+
+    _info_placeholders = ",".join("?" for _ in _INFORMATIONAL_ACTION_TYPES)
+    cursor = await db.execute(
+        "SELECT id, created_at, urgency FROM ego_proposals "
+        "WHERE status = 'pending' AND revalidate_at IS NULL "
+        f"AND action_type NOT IN ({_info_placeholders})",
+        _INFORMATIONAL_ACTION_TYPES,
+    )
+    rows = await cursor.fetchall()
+    for row_id, created_at, urgency in rows:
+        try:
+            created_dt = datetime.fromisoformat(created_at)
+        except (ValueError, TypeError):
+            continue  # unparseable created_at — leave the row untouched
+        hours = _INTERVAL_HOURS.get(urgency, _INTERVAL_HOURS["normal"])
+        revalidate_at = (created_dt + timedelta(hours=hours)).isoformat()
+        await db.execute(
+            "UPDATE ego_proposals SET revalidate_at = ?, "
+            "last_validated_at = COALESCE(last_validated_at, created_at) "
+            "WHERE id = ? AND revalidate_at IS NULL",
+            (revalidate_at, row_id),
+        )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """No-op: backfilled stamps are indistinguishable from organic ones."""

--- a/src/genesis/ego/config.py
+++ b/src/genesis/ego/config.py
@@ -10,6 +10,7 @@ import dataclasses
 import logging
 import os
 import tempfile
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import yaml
@@ -188,6 +189,10 @@ def validate_ego_config(changes: dict) -> list[str]:
         changes["calibration_injection_enabled"], bool
     ):
         errors.append("calibration_injection_enabled must be a boolean")
+    if "genesis_self_development_enabled" in changes and not isinstance(
+        changes["genesis_self_development_enabled"], bool
+    ):
+        errors.append("genesis_self_development_enabled must be a boolean")
     if "outcome_bus_capability_feed" in changes and not isinstance(
         changes["outcome_bus_capability_feed"], bool
     ):
@@ -232,3 +237,17 @@ def validate_ego_config(changes: dict) -> list[str]:
         if not isinstance(v, int) or isinstance(v, bool) or v < 1:
             errors.append("capability_improvement_max_signals must be integer >= 1")
     return errors
+
+
+def next_revalidate_at(urgency: str, *, from_dt: datetime | None = None) -> str:
+    """Next premise-recheck timestamp for a proposal of *urgency*.
+
+    One home for the revalidation-cadence math: ``create_batch`` uses it for
+    the initial stamp and the reconcile live-apply uses it to advance the
+    clock on reaffirm/revise (a just-revalidated item must not stay ⚠due).
+    Config-derived; degrades to the EgoConfig defaults.
+    """
+    intervals = load_ego_config().revalidation_interval_hours
+    hours = intervals.get(urgency, intervals.get("normal", 72))
+    base = from_dt if from_dt is not None else datetime.now(UTC)
+    return (base + timedelta(hours=hours)).isoformat()

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -11,7 +11,7 @@ import json
 import logging
 import re
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from genesis.db.crud import ego as ego_crud
@@ -326,10 +326,8 @@ class ProposalWorkflow:
         # reconcile stage can flag proposals whose premises are due for a
         # re-check. NEVER a kill path — overdue only queues verification
         # (locked decision #2). Config-derived; degrades to EgoConfig defaults.
+        from genesis.ego.config import next_revalidate_at
 
-        from genesis.ego.config import load_ego_config
-
-        _reval_intervals = load_ego_config().revalidation_interval_hours
         _created_dt = datetime.fromisoformat(created_at)
 
         # Pre-fetch valid goal IDs for validation (cheap SELECT, prevents
@@ -389,11 +387,20 @@ class ProposalWorkflow:
             # Dedup: skip if identical content already pending/approved.
             # Skip check for empty content to avoid false collisions on
             # the fixed SHA-256 of the empty string.
+            # Develop-gate-flagged drafts also dedup against TABLED rows:
+            # the gate tables them on creation, and without this a persistent
+            # dev-artifact idea would be re-created + re-tabled every cycle.
             if hash_val:
+                _dedup_statuses = (
+                    ("pending", "approved", "tabled")
+                    if p.get("_develop_scope")
+                    else ("pending", "approved")
+                )
                 try:
                     if await ego_crud.has_pending_proposal_with_hash(
                         self._db,
                         hash_val,
+                        statuses=_dedup_statuses,
                     ):
                         logger.info(
                             "Proposal dedup: skipping exact duplicate (hash=%s)",
@@ -403,9 +410,39 @@ class ProposalWorkflow:
                 except Exception:
                     logger.warning("Proposal dedup check failed, proceeding", exc_info=True)
 
-            _urg = p.get("urgency", "normal")
-            _reval_hours = _reval_intervals.get(_urg, _reval_intervals.get("normal", 72))
-            _revalidate_at = (_created_dt + timedelta(hours=_reval_hours)).isoformat()
+            _revalidate_at = next_revalidate_at(
+                p.get("urgency", "normal"), from_dt=_created_dt,
+            )
+
+            # Deliverable floor (genesis/operations ego only): an
+            # investigation/dispatch proposal must carry a verifiable
+            # deliverable so post-dispatch verification always applies —
+            # bare "probe/diagnose/trace" dispatches with nothing to check
+            # were unverifiable by construction. The default lands in the
+            # user-facing output plane; ~ is expanded by the verifier
+            # (verification._resolve_path) and the dispatch prompt renders
+            # the exact path. Scoped to the genesis ego: user-ego dispatch
+            # flows (content publishing etc.) have their own deliverable
+            # semantics and are deliberately untouched.
+            _eo_serialized = _serialize_expected_outputs(
+                p.get("expected_outputs"),
+            )
+            if (
+                _eo_serialized is None
+                and ego_source == "genesis_ego_cycle"
+                and p.get("action_type") in ("dispatch", "investigate")
+            ):
+                _eo_serialized = json.dumps(
+                    {
+                        "files": [f"~/.genesis/output/ego-reports/{pid}.md"],
+                        "min_size_bytes": 500,
+                    }
+                )
+                logger.info(
+                    "Proposal %s: injected default expected_outputs "
+                    "(deliverable floor)",
+                    pid,
+                )
 
             await ego_crud.create_proposal(
                 self._db,
@@ -431,9 +468,7 @@ class ProposalWorkflow:
                 content_hash=hash_val,
                 content_size=_content_size(proposal_content),
                 original_content=p.get("_original_content"),
-                expected_outputs=_serialize_expected_outputs(
-                    p.get("expected_outputs"),
-                ),
+                expected_outputs=_eo_serialized,
                 revalidate_at=_revalidate_at,
                 last_validated_at=created_at,
             )
@@ -552,6 +587,17 @@ class ProposalWorkflow:
                     pass  # Malformed timestamp — proceed with delivery
 
         proposals = await ego_crud.list_proposals_by_batch(self._db, batch_id)
+        # Digest ships only still-pending rows: proposals tabled between
+        # creation and delivery (develop-scope gate, queue cap) are recoverable
+        # records on the tabled lane, not approval requests.
+        _non_pending = sum(1 for p in proposals if p.get("status") != "pending")
+        if _non_pending:
+            logger.info(
+                "Digest for batch %s excludes %d non-pending proposal(s)",
+                batch_id,
+                _non_pending,
+            )
+            proposals = [p for p in proposals if p.get("status") == "pending"]
         if not proposals:
             logger.warning("No proposals found for batch %s", batch_id)
             return None

--- a/src/genesis/ego/proposals.py
+++ b/src/genesis/ego/proposals.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 from genesis.db.crud import ego as ego_crud
 from genesis.ego.types import partition_informational
+from genesis.ego.verification import parse_expected_outputs
 from genesis.util.approval_words import (
     APPROVE_PHRASES as _SHARED_BARE_APPROVE,
 )
@@ -427,10 +428,16 @@ class ProposalWorkflow:
             _eo_serialized = _serialize_expected_outputs(
                 p.get("expected_outputs"),
             )
+            # Inject when there is no USABLE spec — not merely when the field
+            # is absent. An ego-supplied ``{}`` or a dict without a valid
+            # ``files`` list serializes to a non-None string yet
+            # ``parse_expected_outputs`` (what the verifier uses) reads it as
+            # absent, so keying on ``is None`` alone would leave the dispatch
+            # unverifiable despite the floor.
             if (
-                _eo_serialized is None
-                and ego_source == "genesis_ego_cycle"
+                ego_source == "genesis_ego_cycle"
                 and p.get("action_type") in ("dispatch", "investigate")
+                and parse_expected_outputs(_eo_serialized) is None
             ):
                 _eo_serialized = json.dumps(
                     {

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -2001,6 +2001,29 @@ class EgoSession:
             re.IGNORECASE,
         ),
         re.compile(r"\b(?:write|produce|apply|author)\s+(?:a\s+)?patch\b", re.IGNORECASE),
+        # Install-script edits (editing, NOT running — "run the install script"
+        # is operate; the update.sh dispatch is a legitimate ops lever).
+        re.compile(
+            r"\b(?:edit|modif(?:y|ies)|rewrite|patch|amend)\b[^.\n]{0,50}?"
+            r"\b(?:install script|host.?setup|bootstrap\.sh|scripts/[\w./-]+\.sh|\.sh\b)",
+            re.IGNORECASE,
+        ),
+        # Source-file / source-code edits (object must be code, so "fix the
+        # wedged service" and "update the dashboard status" do NOT match).
+        re.compile(
+            r"\b(?:edit|modif(?:y|ies)|rewrite|patch|fix)\b[^.\n]{0,50}?"
+            r"\b(?:src/genesis|source code|source file|\.py\b)",
+            re.IGNORECASE,
+        ),
+        # Config-VALUE changes (thresholds, intervals, weights, caps — "user
+        # decisions" per the identity doc). Value-change verb + config noun;
+        # a bare noun in a symptom ("the timeout keeps firing") does not match.
+        re.compile(
+            r"\b(?:raise|lower|increase|decrease|set|bump|adjust|tune|change)\b"
+            r"[^.\n]{0,40}?\b(?:threshold|interval|routing weight|budget cap|"
+            r"failure limit|retry count|backoff)\b",
+            re.IGNORECASE,
+        ),
     )
 
     def _flag_develop_scope(self, proposals: list[dict]) -> list[dict]:
@@ -3128,15 +3151,22 @@ def _required_outputs_block(eo_raw: str | dict | None) -> str:
     deliverable paths that post-dispatch verification will check (file
     existence is a hard verification signal; a session never told the path
     would fail verification through no fault of its own). Returns ``""`` when
-    there is nothing to render.
+    there is nothing valid to render.
+
+    Renders through ``parse_expected_outputs`` — the SAME validator the
+    post-dispatch verifier uses — so a structurally malformed spec
+    (``{"files": 123}``, non-string ``required_strings``) yields an empty
+    block rather than raising while iterating/joining, and the rendered block
+    can never disagree with what verification will actually check.
     """
-    if not eo_raw:
-        return ""
+    from genesis.ego.verification import parse_expected_outputs
+
+    raw = json.dumps(eo_raw) if isinstance(eo_raw, dict) else eo_raw
     try:
-        parsed_eo = json.loads(eo_raw) if isinstance(eo_raw, str) else eo_raw
+        parsed = parse_expected_outputs(raw)
     except (ValueError, TypeError):
         return ""
-    if not isinstance(parsed_eo, dict) or not parsed_eo.get("files"):
+    if parsed is None:
         return ""
     eo_lines = [
         "\n## CRITICAL — Required Output Files",
@@ -3146,13 +3176,12 @@ def _required_outputs_block(eo_raw: str | dict | None) -> str:
         "different filenames.",
         "",
     ]
-    for fpath in parsed_eo["files"]:
-        eo_lines.append(f"  - {fpath}")
-    if parsed_eo.get("min_size_bytes"):
-        eo_lines.append(f"\nMin size: {parsed_eo['min_size_bytes']} bytes")
-    if parsed_eo.get("required_strings"):
+    eo_lines.extend(f"  - {fpath}" for fpath in parsed.files)
+    if parsed.min_size_bytes:
+        eo_lines.append(f"\nMin size: {parsed.min_size_bytes} bytes")
+    if parsed.required_strings:
         eo_lines.append(
-            f"Required content: {', '.join(parsed_eo['required_strings'])}"
+            f"Required content: {', '.join(parsed.required_strings)}"
         )
     return "\n".join(eo_lines)
 

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1037,6 +1037,11 @@ class EgoSession:
                 # (content, career, etc.) are rejected and auto-escalated.
                 if proposals and self._source_tag == "genesis_ego_cycle":
                     proposals = self._enforce_domain_boundary(proposals)
+                    # Operate-vs-develop deterministic floor (roadmap gate):
+                    # marks dev-artifact proposals; they are created then
+                    # immediately tabled in _process_proposals (recoverable,
+                    # never digested). Runs post-realist unconditionally.
+                    proposals = self._flag_develop_scope(proposals)
                 elif proposals and self._source_tag == "user_ego_cycle":
                     proposals = await self._enforce_user_domain_boundary(proposals)
 
@@ -1595,7 +1600,15 @@ class EgoSession:
                 full_id, board_row = matches[0]
 
                 if verdict == "reaffirm":
-                    ok = await ego_crud.reaffirm_proposal(self._db, full_id)
+                    from genesis.ego.config import next_revalidate_at
+
+                    ok = await ego_crud.reaffirm_proposal(
+                        self._db,
+                        full_id,
+                        revalidate_at=next_revalidate_at(
+                            board_row.get("urgency", "normal"),
+                        ),
+                    )
                     logger.info(
                         "Reconcile[live] draft[%d] reaffirm %s (ok=%s)",
                         i,
@@ -1637,7 +1650,15 @@ class EgoSession:
                     if not await self._revision_snapshot_exists(
                         board_row.get("batch_id")
                     ):
-                        ok = await ego_crud.reaffirm_proposal(self._db, full_id)
+                        from genesis.ego.config import next_revalidate_at
+
+                        ok = await ego_crud.reaffirm_proposal(
+                            self._db,
+                            full_id,
+                            revalidate_at=next_revalidate_at(
+                                board_row.get("urgency", "normal"),
+                            ),
+                        )
                         logger.info(
                             "Reconcile[live] draft[%d] revise->reaffirm %s "
                             "(digest not snapshot-protected; TOCTOU-safe) ok=%s",
@@ -1746,6 +1767,9 @@ class EgoSession:
             expected = int(board_row.get("revision_num", 1) or 1)
         except (ValueError, TypeError):
             expected = 1
+        from genesis.ego.config import next_revalidate_at
+        from genesis.ego.proposals import _serialize_expected_outputs
+
         new_rev = await ego_crud.revise_proposal(
             self._db,
             proposal_id,
@@ -1754,9 +1778,18 @@ class EgoSession:
             rationale=draft.get("rationale"),
             confidence=draft.get("confidence"),
             execution_plan=draft.get("execution_plan"),
-            expected_outputs=draft.get("expected_outputs"),
+            # Serialize: the LLM draft carries a dict; the column is TEXT.
+            # An unserialized dict would fail parameter binding and lose the
+            # revise to the keep-as-new fallback.
+            expected_outputs=_serialize_expected_outputs(
+                draft.get("expected_outputs"),
+            ),
             revised_by=self._source_tag,
             reason=(reason or "reconcile: sharpened from a fresh blind draft"),
+            # A revise IS a premise re-validation — advance the cadence clock.
+            revalidate_at=next_revalidate_at(
+                board_row.get("urgency", "normal"),
+            ),
         )
         if new_rev is None:
             logger.info(
@@ -1942,6 +1975,103 @@ class EgoSession:
         "system_monitoring", "genesis_maintenance",
     })
 
+    # Develop-work markers — the deterministic floor of the operate-vs-develop
+    # boundary (identity doc "Operate, Don't Develop" + realist rule 8). NARROW
+    # by design: only unambiguous dev-artifact signatures belong here, because
+    # this layer must stay near-zero false-positive on operate work. Fuzzy
+    # phrasing (read-only code tracing vs live-symptom diagnosis) is judged by
+    # the realist rubric, never this list.
+    # Cause-mentions must NOT match: a symptom diagnosis that names a refactor
+    # or migration as the suspected CAUSE ("backups fail since the scheduler
+    # refactor", "migration 0071 failed — investigate") is operate. Markers
+    # therefore require ACTION phrasing (verb + object), not the bare noun.
+    _DEVELOP_MARKER_PATTERNS = (
+        re.compile(r"\breview\b[^.\n]{0,80}?\bpull.?requests?\b", re.IGNORECASE),
+        re.compile(r"\breview\b[^.\n]{0,80}?\bpr\s*#\d+", re.IGNORECASE),
+        re.compile(r"\bpull.?requests?\b[^.\n]{0,60}?\b(?:review|merge|approv)", re.IGNORECASE),
+        re.compile(r"\b(?:merge|approve)\b[^.\n]{0,40}?\bpr\s*#\d+", re.IGNORECASE),
+        re.compile(
+            r"\brefactor(?:ing)?\s+(?:the|a|an|this|that)\s+\w+|\brefactor\s+of\b",
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r"\b(?:run|write|create|apply|author|build|add)\b[^.\n]{0,40}?"
+            r"\bschema\s+migrations?\b"
+            r"|\bchange\b[^.\n]{0,30}?\b(?:database|db)\s+schema\b",
+            re.IGNORECASE,
+        ),
+        re.compile(r"\b(?:write|produce|apply|author)\s+(?:a\s+)?patch\b", re.IGNORECASE),
+    )
+
+    def _flag_develop_scope(self, proposals: list[dict]) -> list[dict]:
+        """Mark develop-scope proposals for tabling (genesis ego only).
+
+        Deterministic floor of the operate-vs-develop boundary. While
+        ``genesis_self_development_enabled`` is False (the roadmap default),
+        a proposal that is unambiguously dev-artifact work — a SELF_MODIFY /
+        AUTONOMOUS_BUILD action domain, or an explicit develop marker (PR
+        review/merge, refactor, schema change, patch) — is marked here and
+        TABLED right after creation in ``_process_proposals``: it lands as a
+        recoverable row on the tabled lane, never deleted, never digested.
+        Runs after the realist unconditionally (same guarantee as
+        ``_enforce_domain_boundary``), so a realist outage cannot leak
+        develop work. Flipping the config flag to True disables the gate
+        without code changes (the self-development unlock path).
+        """
+        try:
+            from genesis.ego.config import load_ego_config
+
+            if load_ego_config().genesis_self_development_enabled:
+                return proposals
+        except Exception:
+            # Config read failure → keep enforcing (fail toward LESS autonomy).
+            logger.warning(
+                "develop-gate config read failed — enforcing", exc_info=True,
+            )
+
+        try:
+            from genesis.autonomy.classification import classify_domain
+            from genesis.autonomy.types import ActionDomain
+        except Exception:
+            classify_domain = None
+            ActionDomain = None
+            logger.warning(
+                "develop-gate classifier import failed — marker scan only",
+                exc_info=True,
+            )
+
+        for p in proposals:
+            reason = None
+            if classify_domain is not None:
+                try:
+                    domain = classify_domain(
+                        p.get("action_type", ""), p.get("execution_plan") or "",
+                    )
+                    if domain in (
+                        ActionDomain.SELF_MODIFY, ActionDomain.AUTONOMOUS_BUILD,
+                    ):
+                        reason = f"action domain {domain.value}"
+                except Exception:
+                    logger.warning(
+                        "develop-gate classify_domain failed for proposal",
+                        exc_info=True,
+                    )
+            if reason is None:
+                text = f"{p.get('content', '')} {p.get('execution_plan') or ''}"
+                for pat in self._DEVELOP_MARKER_PATTERNS:
+                    match = pat.search(text)
+                    if match:
+                        reason = f"develop marker {match.group(0)!r}"
+                        break
+            if reason:
+                p["_develop_scope"] = reason
+                logger.warning(
+                    "Genesis ego develop-scope proposal will be tabled (%s): %s",
+                    reason,
+                    p.get("content", "")[:80],
+                )
+        return proposals
+
     def _enforce_domain_boundary(
         self,
         proposals: list[dict],
@@ -2052,20 +2182,28 @@ class EgoSession:
         try:
             # Auto-table oldest unranked proposals when queue exceeds cap.
             # Respects the 24h guard — proposals < 24h old are not tabled.
+            # The cap is TOTAL across both egos (one user-facing board of 15),
+            # so the count is global; eviction is global-oldest-unranked-first
+            # regardless of which ego authored the tabled item.
             try:
-                all_pending = await ego_crud.list_pending_proposals(
-                    self._db, ego_source=self._source_tag,
-                )
+                all_pending = await ego_crud.list_pending_proposals(self._db)
                 # Informational eval rows (j9/gauntlet) are acknowledge-only and
                 # must not consume the approval-queue cap — otherwise a burst of
                 # eval regressions could auto-table real, actionable proposals.
                 pending, _informational = partition_informational(all_pending)
                 max_pending = getattr(self._config, "max_pending_proposals", 15)
-                if len(pending) + len(proposals) > max_pending:
+                # Develop-gate-flagged drafts are created-then-tabled and
+                # never occupy the board — counting them would evict real
+                # pending proposals to make room for rows that instantly
+                # leave.
+                _incoming = sum(
+                    1 for p in proposals if not p.get("_develop_scope")
+                )
+                if len(pending) + _incoming > max_pending:
                     unranked = [
                         p for p in pending if p.get("rank") is None
                     ]
-                    excess = len(pending) + len(proposals) - max_pending
+                    excess = len(pending) + _incoming - max_pending
                     oldest = sorted(
                         unranked, key=lambda x: x.get("created_at", ""),
                     )
@@ -2116,6 +2254,41 @@ class EgoSession:
                     )
             except Exception:
                 logger.warning("Failed to create intervention journal entries", exc_info=True)
+
+            # Develop-scope tabling (roadmap gate): rows flagged by
+            # _flag_develop_scope were created above so they exist as
+            # recoverable tabled records — never deleted. Tabled BEFORE the
+            # digest send; send_digest ships only still-pending rows.
+            for pid, prop in zip(ids, created, strict=False):
+                if prop.get("_develop_scope"):
+                    try:
+                        await ego_crud.table_proposal(self._db, pid)
+                        logger.info(
+                            "Tabled develop-scope proposal %s (%s) — "
+                            "self-development disabled",
+                            pid[:12],
+                            prop["_develop_scope"],
+                        )
+                        # Mirror every other tabling path: resolve the journal
+                        # row so it doesn't sit open forever.
+                        try:
+                            from genesis.db.crud import (
+                                intervention_journal as journal_crud,
+                            )
+
+                            await journal_crud.resolve(
+                                self._db,
+                                pid,
+                                outcome_status="tabled",
+                            )
+                        except Exception:
+                            pass
+                    except Exception:
+                        logger.warning(
+                            "Failed to table develop-scope proposal %s",
+                            pid,
+                            exc_info=True,
+                        )
 
             # Structural validation — annotates digest, doesn't block
             validation_issues = await self._proposals.validate_batch(proposals)
@@ -2198,6 +2371,16 @@ class EgoSession:
                     proposal_id, _brief_prop.get("action_type"),
                 )
                 continue
+
+            # The ego-authored brief prompt does not necessarily mention the
+            # proposal's expected_outputs — append the same required-files
+            # block _build_dispatch_prompt renders, or the dispatched session
+            # is never told the deliverable path that verification will check.
+            _eo_block = _required_outputs_block(
+                _brief_prop.get("expected_outputs") if _brief_prop else None,
+            )
+            if _eo_block:
+                prompt = f"{prompt}\n{_eo_block}"
 
             # Append content firewall rules to ego-authored dispatch prompt.
             # The ego writes the brief prompt directly — this safety net
@@ -2834,35 +3017,11 @@ class EgoSession:
             f"\nRationale: {prop.get('rationale') or ''}",
         ]
 
-        # Post-dispatch verification context
-        eo_raw = prop.get("expected_outputs")
-        if eo_raw:
-            try:
-                import json as _json
-
-                parsed_eo = _json.loads(eo_raw) if isinstance(eo_raw, str) else eo_raw
-                if isinstance(parsed_eo, dict) and parsed_eo.get("files"):
-                    eo_lines = [
-                        "\n## CRITICAL — Required Output Files",
-                        "You MUST save output to these EXACT file paths.",
-                        "The system auto-verifies these paths after completion.",
-                        "Do NOT rename, add suffixes, version numbers, or use",
-                        "different filenames.",
-                        "",
-                    ]
-                    for fpath in parsed_eo["files"]:
-                        eo_lines.append(f"  - {fpath}")
-                    if parsed_eo.get("min_size_bytes"):
-                        eo_lines.append(
-                            f"\nMin size: {parsed_eo['min_size_bytes']} bytes"
-                        )
-                    if parsed_eo.get("required_strings"):
-                        eo_lines.append(
-                            f"Required content: {', '.join(parsed_eo['required_strings'])}"
-                        )
-                    parts.append("\n".join(eo_lines))
-            except (ValueError, TypeError):
-                pass
+        # Post-dispatch verification context (shared renderer — the
+        # execution-brief path appends the same block).
+        eo_block = _required_outputs_block(prop.get("expected_outputs"))
+        if eo_block:
+            parts.append(eo_block)
 
         # World model context — ONLY for non-content dispatches.
         # Content dispatches get minimal context to prevent information
@@ -2959,6 +3118,43 @@ _CONTENT_DISPATCH_KEYWORDS = frozenset({
 })
 # "content" omitted — too broad for substring matching (matches
 # "content_hash", "content error rate"). Caught by action_type check.
+
+
+def _required_outputs_block(eo_raw: str | dict | None) -> str:
+    """Render ``expected_outputs`` as the "Required Output Files" prompt block.
+
+    Shared by ``_build_dispatch_prompt`` and the execution-brief path so every
+    dispatched session — whichever path built its prompt — is told the exact
+    deliverable paths that post-dispatch verification will check (file
+    existence is a hard verification signal; a session never told the path
+    would fail verification through no fault of its own). Returns ``""`` when
+    there is nothing to render.
+    """
+    if not eo_raw:
+        return ""
+    try:
+        parsed_eo = json.loads(eo_raw) if isinstance(eo_raw, str) else eo_raw
+    except (ValueError, TypeError):
+        return ""
+    if not isinstance(parsed_eo, dict) or not parsed_eo.get("files"):
+        return ""
+    eo_lines = [
+        "\n## CRITICAL — Required Output Files",
+        "You MUST save output to these EXACT file paths.",
+        "The system auto-verifies these paths after completion.",
+        "Do NOT rename, add suffixes, version numbers, or use",
+        "different filenames.",
+        "",
+    ]
+    for fpath in parsed_eo["files"]:
+        eo_lines.append(f"  - {fpath}")
+    if parsed_eo.get("min_size_bytes"):
+        eo_lines.append(f"\nMin size: {parsed_eo['min_size_bytes']} bytes")
+    if parsed_eo.get("required_strings"):
+        eo_lines.append(
+            f"Required content: {', '.join(parsed_eo['required_strings'])}"
+        )
+    return "\n".join(eo_lines)
 
 
 def _is_content_dispatch(prop: dict) -> bool:
@@ -3252,12 +3448,19 @@ monitoring, or internal maintenance.
         operate_rule = """
 8. **Operate vs develop (operations ego only).** These proposals should
    OPERATE the running system (diagnose, pull reversible operational levers,
-   dispatch remediation for a specific defect), NOT DEVELOP it. If a proposal
-   would write or refactor code, change a database schema, edit an install
-   script, or alter a configuration *value* (threshold, interval, routing
-   weight, budget cap), REJECT it: "Develop, not operate — escalate the
-   change to the user." A remediation dispatch for a specific operational
-   defect is fine; building a feature or redesigning a subsystem is not.
+   dispatch remediation for a specific defect), NOT DEVELOP it. REJECT a
+   proposal ("Develop, not operate — escalate the change to the user") when
+   it would: write or refactor code, change a database schema, edit an
+   install script, alter a configuration *value* (threshold, interval,
+   routing weight, budget cap) — OR do dev-artifact work even read-only:
+   review/approve a pull request, trace source code to scope a fix or
+   refactor, audit code quality or design. The test is the deliverable: a
+   patch or patch-plan = develop. Symptom carve-out: diagnosing a LIVE
+   operational symptom (failing backup, stuck breaker, silent emitter) is
+   operate even when the trail leads into code — PASS it when the stated
+   deliverable is an escalation of findings, not a code change. A
+   remediation dispatch for a specific operational defect is fine; building
+   a feature or redesigning a subsystem is not.
 """
 
     # Build Rule #1 based on ego source — genesis ego is allowed to
@@ -3271,7 +3474,11 @@ monitoring, or internal maintenance.
    checks, observation queries) should still be done in-cycle, but
    proposing a background session to diagnose a complex issue is a
    legitimate maintenance action. PASS these unless they are clearly
-   something the ego could resolve with a single MCP tool call."""
+   something the ego could resolve with a single MCP tool call. Every
+   dispatch/investigate proposal must name a concrete deliverable in
+   expected_outputs (the findings file the dispatched session will write);
+   when one is missing, AMEND the proposal to add it rather than
+   rejecting."""
     else:
         rule_1 = """
 1. **Read operations are NOT proposals.** Investigating, researching, reading,

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -181,7 +181,14 @@ class EgoConfig:
     # Genesis ego (COO) independent scheduling — defaults match user ego
     genesis_cadence_minutes: int = 90  # base interval for genesis ego
     genesis_max_interval_minutes: int = 240  # backoff ceiling for genesis ego
-    max_pending_proposals: int = 15  # auto-table oldest unranked when exceeded
+    max_pending_proposals: int = 15  # TOTAL across both egos — auto-table oldest unranked when exceeded
+    # Roadmap flag: Genesis developing itself (writing/refactoring its own code,
+    # reviewing PRs, scoping refactors) is OFF until explicitly unlocked. While
+    # False, the genesis ego's develop-scope proposals are deterministically
+    # tabled (never deleted) by the domain-boundary gate. Flip to True to unlock
+    # self-development when that capability is earned; the gate then passes
+    # develop-class proposals through to normal approval.
+    genesis_self_development_enabled: bool = False
     # Revalidation cadence (PR-6a): per-urgency hours after which a pending
     # proposal's premises are flagged "due for re-check" by the reconcile
     # stage. NEVER a kill path — overdue only queues verification (locked

--- a/src/genesis/ego/verification.py
+++ b/src/genesis/ego/verification.py
@@ -76,10 +76,20 @@ def parse_expected_outputs(raw: str | None) -> ExpectedOutputs | None:
     files = data.get("files")
     if not files or not isinstance(files, list):
         return None
+    # Coerce defensively: a structurally malformed spec (non-numeric
+    # min_size_bytes, non-list required_strings) yields a safe object rather
+    # than raising — callers (verifier + the dispatch-prompt renderer) treat a
+    # bad spec as "no usable spec", never as a crash.
+    try:
+        min_size = int(data.get("min_size_bytes", 0) or 0)
+    except (ValueError, TypeError):
+        min_size = 0
+    raw_required = data.get("required_strings")
+    required = [str(s) for s in raw_required] if isinstance(raw_required, list) else []
     return ExpectedOutputs(
         files=[str(f) for f in files],
-        min_size_bytes=int(data.get("min_size_bytes", 0)),
-        required_strings=list(data.get("required_strings") or []),
+        min_size_bytes=min_size,
+        required_strings=required,
     )
 
 

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -271,9 +271,20 @@ it. Hold the line between the two:
   editing install scripts, or altering configuration *values* (thresholds,
   intervals, routing weights, budget caps — those are user decisions).
 - Building new capabilities or "improving" a subsystem's design. Anything
-  that produces a patch. Autonomous self-modification is a capability
-  Genesis will earn later; for now, diagnose the problem and escalate the
-  code/config change to the user.
+  that produces a patch.
+- **Dev-artifact work, even read-only:** reviewing or approving pull
+  requests, tracing source code to scope a fix or refactor, auditing code
+  quality or design. The test is the deliverable — if the natural output is
+  a patch or a patch-plan, it is develop, no matter how read-only the first
+  step looks.
+- Autonomous self-modification is a capability Genesis will earn later; for
+  now, diagnose the problem and escalate the code/config change to the user.
+
+**The symptom carve-out (stays OPERATE):** diagnosing a LIVE operational
+symptom — a failing backup, a stuck breaker, a silently-absent emission —
+remains your job even when the trail leads into code. The deliverable of such
+a diagnosis is always an escalation of findings to the user, never a patch or
+patch-plan.
 
 **Never duplicate owned work.** Do NOT propose anything already owned by an
 active foreground session or an existing scheduled job. If a job already runs

--- a/tests/ego/test_develop_gate.py
+++ b/tests/ego/test_develop_gate.py
@@ -109,6 +109,61 @@ class TestFlagDevelopScope:
         out = _gate_session()._flag_develop_scope(proposals)
         assert not any(p.get("_develop_scope") for p in out)
 
+    def test_prohibited_writes_marked(self, monkeypatch):
+        """P1: config/maintenance action types classify as INTERNAL_WRITE (not
+        SELF_MODIFY), so unambiguous prohibited writes must be caught by
+        markers — install-script edits, source edits, config-value tuning."""
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda: EgoConfig(genesis_self_development_enabled=False),
+        )
+        prohibited = [
+            {"action_type": "config", "content": "Edit the install script to add a swap step"},
+            {"action_type": "maintenance", "content": "Modify scripts/host-setup.sh for oom"},
+            {
+                "action_type": "config",
+                "content": "Raise the circuit breaker failure threshold from 3 to 5",
+            },
+            {
+                "action_type": "config",
+                "content": "Increase the backoff interval for the surplus job",
+            },
+            {
+                "action_type": "maintenance",
+                "content": "Rewrite the fallback in src/genesis/providers",
+            },
+        ]
+        out = _gate_session()._flag_develop_scope(prohibited)
+        assert all(p.get("_develop_scope") for p in out), [
+            p["content"] for p in out if not p.get("_develop_scope")
+        ]
+
+    def test_running_scripts_and_symptoms_not_marked(self, monkeypatch):
+        """The same nouns in operate phrasing stay operate: running (not
+        editing) a script, a symptom naming a threshold/interval."""
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda: EgoConfig(genesis_self_development_enabled=False),
+        )
+        operate = [
+            {
+                "action_type": "maintenance",
+                "content": "Run the install script (scripts/update.sh) to resync deploy",
+            },
+            {
+                "action_type": "investigate",
+                "content": "The circuit breaker threshold keeps tripping — diagnose why and escalate",
+            },
+            {
+                "action_type": "investigate",
+                "content": "The retry interval elapsed before the job finished — investigate the cause",
+            },
+        ]
+        out = _gate_session()._flag_develop_scope(operate)
+        assert not any(p.get("_develop_scope") for p in out), [
+            p["content"] for p in out if p.get("_develop_scope")
+        ]
+
     def test_action_type_self_modify_marked(self, monkeypatch):
         monkeypatch.setattr(
             "genesis.ego.config.load_ego_config",
@@ -261,6 +316,26 @@ class TestCreateBatchHygiene:
         assert row["expected_outputs"] is None
 
     @pytest.mark.asyncio
+    async def test_empty_dict_outputs_gets_floor(self, db):
+        """P2: an ego-supplied {} (or dict without usable files) serializes to
+        a non-None string but parses as absent — the floor must still inject."""
+        wf = ProposalWorkflow(db=db, topic_manager=None)
+        _, ids, _ = await wf.create_batch(
+            [
+                {
+                    "action_type": "investigate",
+                    "content": "probe",
+                    "expected_outputs": {},
+                }
+            ],
+            ego_source="genesis_ego_cycle",
+        )
+        row = await ego_crud.get_proposal(db, ids[0])
+        parsed = parse_expected_outputs(row["expected_outputs"])
+        assert parsed is not None
+        assert parsed.files == [f"~/.genesis/output/ego-reports/{ids[0]}.md"]
+
+    @pytest.mark.asyncio
     async def test_ego_supplied_outputs_untouched(self, db):
         wf = ProposalWorkflow(db=db, topic_manager=None)
         eo = {"files": ["~/x.md"], "min_size_bytes": 100}
@@ -318,3 +393,11 @@ class TestRequiredOutputsBlock:
         assert _required_outputs_block("") == ""
         assert _required_outputs_block("not json") == ""
         assert _required_outputs_block(json.dumps({"files": []})) == ""
+
+    def test_malformed_shapes_never_raise(self):
+        """P2: structurally-malformed specs render empty, never TypeError."""
+        assert _required_outputs_block(json.dumps({"files": 123})) == ""
+        assert _required_outputs_block({"files": 123}) == ""
+        # non-string required_strings must not blow up ', '.join(...)
+        block = _required_outputs_block(json.dumps({"files": ["a.md"], "required_strings": 123}))
+        assert "a.md" in block  # renders files, drops the bad required_strings

--- a/tests/ego/test_develop_gate.py
+++ b/tests/ego/test_develop_gate.py
@@ -1,0 +1,320 @@
+"""Develop-boundary gate + global cap + deliverable floor (proposal hygiene).
+
+Covers:
+- ``EgoSession._flag_develop_scope`` — the deterministic operate-vs-develop
+  floor behind ``genesis_self_development_enabled`` (roadmap flag)
+- ``_DEVELOP_MARKER_PATTERNS`` — action-phrasing precision incl. the
+  cause-mention false-positive class
+- ``EgoConfig.genesis_self_development_enabled`` default + validation
+- the global (cross-ego) pending cap in ``_process_proposals``
+- ``create_batch`` deliverable-floor injection (genesis ego only) + tabled-dedup
+- ``_required_outputs_block`` shared renderer
+
+Wall-clock-independent; no live services.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+from genesis.db.schema import TABLES
+from genesis.ego.config import validate_ego_config
+from genesis.ego.proposals import ProposalWorkflow
+from genesis.ego.session import EgoSession, _required_outputs_block
+from genesis.ego.types import EgoConfig
+from genesis.ego.verification import parse_expected_outputs
+
+
+@pytest.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute(TABLES["ego_proposals"])
+        yield conn
+
+
+def _gate_session():
+    """Minimal mock EgoSession with the real gate method bound."""
+    session = MagicMock()
+    session._source_tag = "genesis_ego_cycle"
+    session._flag_develop_scope = EgoSession._flag_develop_scope.__get__(session)
+    session._DEVELOP_MARKER_PATTERNS = EgoSession._DEVELOP_MARKER_PATTERNS
+    return session
+
+
+# ── flag + gate behavior ─────────────────────────────────────────────────
+
+
+class TestFlagDevelopScope:
+    def test_pr_review_marked(self, monkeypatch):
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda: EgoConfig(genesis_self_development_enabled=False),
+        )
+        proposals = [
+            {
+                "action_type": "investigate",
+                "content": "Dispatch a session to review GENesis-AGI PR #1278 "
+                "for remaining fail-open edges before merge.",
+            }
+        ]
+        out = _gate_session()._flag_develop_scope(proposals)
+        assert out[0].get("_develop_scope"), "PR-review proposal must be marked"
+
+    def test_symptom_diagnosis_not_marked(self, monkeypatch):
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda: EgoConfig(genesis_self_development_enabled=False),
+        )
+        proposals = [
+            {
+                "action_type": "investigate",
+                "content": "Read-only diagnosis of why user_model_delta "
+                "emissions have been silent 14+ days. Check the "
+                "MIN_DELTA_CONFIDENCE gate against actual output confidence.",
+            },
+            {
+                "action_type": "maintenance",
+                "content": "Restart the wedged genesis-server service and "
+                "clear the dead-letter queue.",
+            },
+        ]
+        out = _gate_session()._flag_develop_scope(proposals)
+        assert not any(p.get("_develop_scope") for p in out)
+
+    def test_cause_mention_not_marked(self, monkeypatch):
+        """Naming a refactor/migration as the suspected CAUSE stays operate."""
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda: EgoConfig(genesis_self_development_enabled=False),
+        )
+        proposals = [
+            {
+                "action_type": "investigate",
+                "content": "Diagnose why backups fail since the scheduler "
+                "refactor landed; escalate findings.",
+            },
+            {
+                "action_type": "investigate",
+                "content": "The schema migration failed on restart — "
+                "read-only diagnosis, escalate to user.",
+            },
+        ]
+        out = _gate_session()._flag_develop_scope(proposals)
+        assert not any(p.get("_develop_scope") for p in out)
+
+    def test_action_type_self_modify_marked(self, monkeypatch):
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda: EgoConfig(genesis_self_development_enabled=False),
+        )
+        proposals = [{"action_type": "code_change", "content": "Adjust the threshold."}]
+        out = _gate_session()._flag_develop_scope(proposals)
+        assert out[0].get("_develop_scope", "").startswith("action domain")
+
+    def test_flag_on_disables_gate(self, monkeypatch):
+        """The self-development unlock: flag True → nothing is marked."""
+        monkeypatch.setattr(
+            "genesis.ego.config.load_ego_config",
+            lambda: EgoConfig(genesis_self_development_enabled=True),
+        )
+        proposals = [
+            {
+                "action_type": "code_change",
+                "content": "Refactor the routing module.",
+            }
+        ]
+        out = _gate_session()._flag_develop_scope(proposals)
+        assert not any(p.get("_develop_scope") for p in out)
+
+    def test_config_failure_enforces(self, monkeypatch):
+        """Config read failure fails toward LESS autonomy (gate stays on)."""
+
+        def _boom():
+            raise RuntimeError("config unavailable")
+
+        monkeypatch.setattr("genesis.ego.config.load_ego_config", _boom)
+        proposals = [
+            {
+                "action_type": "investigate",
+                "content": "Review the open pull request on the public repo.",
+            }
+        ]
+        out = _gate_session()._flag_develop_scope(proposals)
+        assert out[0].get("_develop_scope")
+
+
+class TestConfigFlag:
+    def test_default_off(self):
+        assert EgoConfig().genesis_self_development_enabled is False
+
+    def test_validator(self):
+        assert validate_ego_config({"genesis_self_development_enabled": True}) == []
+        errs = validate_ego_config({"genesis_self_development_enabled": "yes"})
+        assert any("genesis_self_development_enabled" in e for e in errs)
+
+
+# ── global cap ───────────────────────────────────────────────────────────
+
+
+def _cap_session(db, max_pending=15):
+    session = MagicMock()
+    session._source_tag = "genesis_ego_cycle"
+    session._db = db
+    session._config = MagicMock()
+    session._config.max_pending_proposals = max_pending
+    session._proposals = MagicMock()
+    session._proposals.create_batch = AsyncMock(return_value=("batch", [], []))
+    session._proposals.validate_batch = AsyncMock(return_value=[])
+    session._proposals.send_digest = AsyncMock(return_value=None)
+    session._event_bus = None
+    session._process_proposals = EgoSession._process_proposals.__get__(session)
+    return session
+
+
+async def _seed_pending(db, *, id, ego_source, age_hours=48, rank=None):
+    created = (datetime.now(UTC) - timedelta(hours=age_hours)).isoformat()
+    await ego_crud.create_proposal(
+        db,
+        id=id,
+        action_type="investigate",
+        content=f"proposal {id}",
+        created_at=created,
+        rank=rank,
+        ego_source=ego_source,
+    )
+
+
+class TestGlobalCap:
+    @pytest.mark.asyncio
+    async def test_cap_counts_both_egos(self, db):
+        """16 pending across BOTH egos + 1 incoming → global-oldest tabled."""
+        for i in range(9):
+            await _seed_pending(db, id=f"u{i}", ego_source="user_ego_cycle", age_hours=200 - i)
+        for i in range(7):
+            await _seed_pending(db, id=f"g{i}", ego_source="genesis_ego_cycle", age_hours=100 - i)
+        session = _cap_session(db)
+        await session._process_proposals(
+            [{"action_type": "investigate", "content": "new one"}], "cycle-1"
+        )
+        cur = await db.execute("SELECT COUNT(*) FROM ego_proposals WHERE status = 'pending'")
+        remaining = (await cur.fetchone())[0]
+        # 16 pending + 1 incoming = 17 → excess 2 tabled (oldest, cross-ego)
+        assert remaining == 14
+        cur = await db.execute(
+            "SELECT id FROM ego_proposals WHERE status = 'tabled' ORDER BY created_at"
+        )
+        tabled = [r[0] for r in await cur.fetchall()]
+        assert tabled == ["u0", "u1"], "global-oldest evicted regardless of ego"
+
+    @pytest.mark.asyncio
+    async def test_develop_flagged_incoming_not_counted(self, db):
+        """A flagged draft is created-then-tabled — it must not evict others."""
+        for i in range(15):
+            await _seed_pending(db, id=f"p{i}", ego_source="user_ego_cycle", age_hours=200 - i)
+        session = _cap_session(db)
+        await session._process_proposals(
+            [
+                {
+                    "action_type": "investigate",
+                    "content": "review pull request",
+                    "_develop_scope": "develop marker",
+                }
+            ],
+            "cycle-1",
+        )
+        cur = await db.execute("SELECT COUNT(*) FROM ego_proposals WHERE status = 'pending'")
+        # _incoming == 0 → 15 + 0 is not > 15 → nothing evicted
+        assert (await cur.fetchone())[0] == 15
+
+
+# ── deliverable floor + tabled dedup (create_batch) ──────────────────────
+
+
+class TestCreateBatchHygiene:
+    @pytest.mark.asyncio
+    async def test_injects_default_expected_outputs_genesis_ego(self, db):
+        wf = ProposalWorkflow(db=db, topic_manager=None)
+        _, ids, _ = await wf.create_batch(
+            [{"action_type": "investigate", "content": "probe the breakers"}],
+            ego_source="genesis_ego_cycle",
+        )
+        row = await ego_crud.get_proposal(db, ids[0])
+        parsed = parse_expected_outputs(row["expected_outputs"])
+        assert parsed is not None, "default expected_outputs must round-trip"
+        assert parsed.files == [f"~/.genesis/output/ego-reports/{ids[0]}.md"]
+
+    @pytest.mark.asyncio
+    async def test_no_injection_for_user_ego(self, db):
+        wf = ProposalWorkflow(db=db, topic_manager=None)
+        _, ids, _ = await wf.create_batch(
+            [{"action_type": "dispatch", "content": "publish the article"}],
+            ego_source="user_ego_cycle",
+        )
+        row = await ego_crud.get_proposal(db, ids[0])
+        assert row["expected_outputs"] is None
+
+    @pytest.mark.asyncio
+    async def test_ego_supplied_outputs_untouched(self, db):
+        wf = ProposalWorkflow(db=db, topic_manager=None)
+        eo = {"files": ["~/x.md"], "min_size_bytes": 100}
+        _, ids, _ = await wf.create_batch(
+            [
+                {
+                    "action_type": "investigate",
+                    "content": "probe things",
+                    "expected_outputs": eo,
+                }
+            ],
+            ego_source="genesis_ego_cycle",
+        )
+        row = await ego_crud.get_proposal(db, ids[0])
+        assert json.loads(row["expected_outputs"]) == eo
+
+    @pytest.mark.asyncio
+    async def test_flagged_draft_dedups_against_tabled(self, db):
+        """A tabled develop twin blocks re-creation (no per-cycle churn)."""
+        wf = ProposalWorkflow(db=db, topic_manager=None)
+        draft = {
+            "action_type": "investigate",
+            "content": "review pull request #9",
+            "_develop_scope": "develop marker",
+        }
+        _, ids, _ = await wf.create_batch([dict(draft)], ego_source="genesis_ego_cycle")
+        assert len(ids) == 1
+        await ego_crud.table_proposal(db, ids[0])
+        _, ids2, _ = await wf.create_batch([dict(draft)], ego_source="genesis_ego_cycle")
+        assert ids2 == [], "tabled twin must block re-creation of flagged draft"
+
+    @pytest.mark.asyncio
+    async def test_unflagged_draft_ignores_tabled(self, db):
+        """Normal drafts keep the original pending/approved-only dedup."""
+        wf = ProposalWorkflow(db=db, topic_manager=None)
+        draft = {"action_type": "maintenance", "content": "clear the queue"}
+        _, ids, _ = await wf.create_batch([dict(draft)], ego_source="genesis_ego_cycle")
+        await ego_crud.table_proposal(db, ids[0])
+        _, ids2, _ = await wf.create_batch([dict(draft)], ego_source="genesis_ego_cycle")
+        assert len(ids2) == 1, "tabled rows never block ordinary re-proposal"
+
+
+# ── shared required-outputs renderer ─────────────────────────────────────
+
+
+class TestRequiredOutputsBlock:
+    def test_renders_files_and_size(self):
+        block = _required_outputs_block(json.dumps({"files": ["~/a.md"], "min_size_bytes": 500}))
+        assert "Required Output Files" in block
+        assert "~/a.md" in block
+        assert "500 bytes" in block
+
+    def test_empty_inputs(self):
+        assert _required_outputs_block(None) == ""
+        assert _required_outputs_block("") == ""
+        assert _required_outputs_block("not json") == ""
+        assert _required_outputs_block(json.dumps({"files": []})) == ""

--- a/tests/ego/test_reconcile_apply.py
+++ b/tests/ego/test_reconcile_apply.py
@@ -352,10 +352,10 @@ class TestFailSafe:
 
         real_reaffirm = ego_crud.reaffirm_proposal
 
-        async def flaky_reaffirm(dbc, pid):
+        async def flaky_reaffirm(dbc, pid, **kwargs):
             if pid == "boom1boom1boom00":
                 raise RuntimeError("boom")
-            return await real_reaffirm(dbc, pid)
+            return await real_reaffirm(dbc, pid, **kwargs)
 
         monkeypatch.setattr(ego_crud, "reaffirm_proposal", flaky_reaffirm)
 

--- a/tests/ego/test_revise_crud.py
+++ b/tests/ego/test_revise_crud.py
@@ -59,6 +59,24 @@ async def test_reaffirm_noop_on_non_pending(db):
     assert (await _row(db))["last_validated_at"] is None
 
 
+async def test_reaffirm_restamps_revalidate_at(db):
+    """A reaffirm IS a premise re-validation — the cadence clock advances,
+    so a just-reaffirmed item does not stay perpetually ⚠due."""
+    await _seed(db)
+    stamp = "2099-01-01T00:00:00+00:00"
+    assert await ego_crud.reaffirm_proposal(db, "p1", revalidate_at=stamp) is True
+    assert (await _row(db))["revalidate_at"] == stamp
+
+
+async def test_reaffirm_without_stamp_preserves_revalidate_at(db):
+    await _seed(db)
+    await db.execute(
+        "UPDATE ego_proposals SET revalidate_at = 'KEEP' WHERE id = 'p1'"
+    )
+    assert await ego_crud.reaffirm_proposal(db, "p1") is True
+    assert (await _row(db))["revalidate_at"] == "KEEP"
+
+
 # ── revise (happy path) ──────────────────────────────────────────────────
 
 
@@ -87,6 +105,21 @@ async def test_revise_bumps_version_and_recomputes_hash(db):
     assert row["last_validated_at"] is not None
     # action_type is immutable
     assert row["action_type"] == "investigate"
+
+
+async def test_revise_restamps_revalidate_at(db):
+    """A revise IS a premise re-validation — the cadence clock advances."""
+    await _seed(db)
+    stamp = "2099-06-01T00:00:00+00:00"
+    new_rev = await ego_crud.revise_proposal(
+        db,
+        "p1",
+        expected_revision=1,
+        content="sharpened content",
+        revalidate_at=stamp,
+    )
+    assert new_rev == 2
+    assert (await _row(db))["revalidate_at"] == stamp
 
 
 async def test_revise_writes_prior_values_to_audit(db):

--- a/tests/test_dashboard/test_directives_goals_routes.py
+++ b/tests/test_dashboard/test_directives_goals_routes.py
@@ -7,12 +7,18 @@ not-bootstrapped guards, and the retire (resolve) contract incl. 400/404/503.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from flask import Flask
 
 from genesis.dashboard.api import blueprint
+
+# Dates relative to now so the resolved-history recency window (14 days) is
+# pinned on BOTH sides without a fixed calendar date that rots after 14 days.
+_RECENT_RESOLVED = (datetime.now(UTC) - timedelta(days=3)).isoformat()
+_STALE_RESOLVED = (datetime.now(UTC) - timedelta(days=30)).isoformat()
 
 
 @pytest.fixture()
@@ -71,7 +77,12 @@ def _grow(id_, origin):
 def _list_directives_side_effect(db, *, statuses=("active",), limit=20, **_kw):
     if "active" in statuses:
         return [_drow("c60", "genesis_ego", "active"), _drow("u1", "user_ego", "active")]
-    return [_drow("old", "user_ego", "completed", resolved_at="2026-07-19T00:00:00+00:00")]
+    # Two resolved rows: one inside the 14-day recency window, one outside.
+    # The route surfaces only the recent one.
+    return [
+        _drow("recent", "user_ego", "completed", resolved_at=_RECENT_RESOLVED),
+        _drow("stale", "user_ego", "completed", resolved_at=_STALE_RESOLVED),
+    ]
 
 
 class TestEgoDirectives:
@@ -86,7 +97,8 @@ class TestEgoDirectives:
             MockRT.instance.return_value = _rt()
             data = client.get("/api/genesis/ego/directives").get_json()
             assert [d["id"] for d in data["active"]] == ["c60", "u1"]
-            assert [d["id"] for d in data["resolved"]] == ["old"]
+            # Recency window drops resolved rows older than 14 days.
+            assert [d["id"] for d in data["resolved"]] == ["recent"]
             # payload projection carries priority/target/reaffirm for the panel
             assert data["active"][0]["ego_target"] == "genesis_ego"
             assert data["active"][0]["reaffirm_count"] == 0

--- a/tests/test_db/test_backfill_revalidate_at.py
+++ b/tests/test_db/test_backfill_revalidate_at.py
@@ -1,0 +1,104 @@
+"""Migration 0077 — revalidate_at backfill: scoping + format parity + idempotence.
+
+The migration does NOT commit (the runner owns the transaction); these tests
+read back on the same aiosqlite connection. Wall-clock-independent: stamps are
+asserted relative to the seeded created_at values, never to now().
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import ego as ego_crud
+from genesis.db.schema import TABLES
+
+M77 = importlib.import_module("genesis.db.migrations.0077_backfill_revalidate_at")
+
+_CREATED = "2026-07-28T02:56:31.450323+00:00"
+
+
+@pytest.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute(TABLES["ego_proposals"])
+        yield conn
+
+
+async def _seed(db, *, id, status="pending", urgency="normal", action_type="investigate"):
+    await ego_crud.create_proposal(
+        db,
+        id=id,
+        action_type=action_type,
+        content=f"proposal {id}",
+        urgency=urgency,
+        created_at=_CREATED,
+    )
+    if status != "pending":
+        await db.execute("UPDATE ego_proposals SET status = ? WHERE id = ?", (status, id))
+
+
+async def _reval(db, id):
+    cur = await db.execute(
+        "SELECT revalidate_at, last_validated_at FROM ego_proposals WHERE id = ?",
+        (id,),
+    )
+    return await cur.fetchone()
+
+
+@pytest.mark.asyncio
+async def test_backfills_pending_per_urgency(db):
+    await _seed(db, id="p_norm", urgency="normal")
+    await _seed(db, id="p_crit", urgency="critical")
+    await M77.up(db)
+
+    created_dt = datetime.fromisoformat(_CREATED)
+    row = await _reval(db, "p_norm")
+    assert row["revalidate_at"] == (created_dt + timedelta(hours=72)).isoformat()
+    assert row["last_validated_at"] == _CREATED
+    row = await _reval(db, "p_crit")
+    assert row["revalidate_at"] == (created_dt + timedelta(hours=6)).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_iso_format_parity(db):
+    """Stamps must compare correctly against datetime.now(UTC).isoformat()."""
+    await _seed(db, id="p1")
+    await M77.up(db)
+    row = await _reval(db, "p1")
+    # ISO-8601 'T'-separated with offset — same shape as the organic stamps,
+    # so the reconcile string comparison is well-ordered.
+    assert "T" in row["revalidate_at"]
+    assert row["revalidate_at"].endswith("+00:00")
+    assert row["revalidate_at"] < datetime.now(UTC).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_informational_and_non_pending_untouched(db):
+    await _seed(db, id="p_j9", action_type="j9_regression")
+    await _seed(db, id="p_done", status="approved")
+    await M77.up(db)
+    assert (await _reval(db, "p_j9"))["revalidate_at"] is None
+    assert (await _reval(db, "p_done"))["revalidate_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_idempotent_and_preserves_organic_stamps(db):
+    await _seed(db, id="p1")
+    await db.execute("UPDATE ego_proposals SET revalidate_at = 'ORGANIC' WHERE id = 'p1'")
+    await _seed(db, id="p2")
+    await M77.up(db)
+    stamped = (await _reval(db, "p2"))["revalidate_at"]
+    await M77.up(db)  # second run: no-op
+    assert (await _reval(db, "p1"))["revalidate_at"] == "ORGANIC"
+    assert (await _reval(db, "p2"))["revalidate_at"] == stamped
+
+
+@pytest.mark.asyncio
+async def test_pre_0071_db_without_column_is_noop(db):
+    await db.execute("ALTER TABLE ego_proposals DROP COLUMN revalidate_at")
+    await M77.up(db)  # must not raise

--- a/tests/test_ego/test_verification.py
+++ b/tests/test_ego/test_verification.py
@@ -42,6 +42,24 @@ def test_parse_json_with_empty_files():
     assert parse_expected_outputs(json.dumps({"files": []})) is None
 
 
+def test_parse_non_list_files_returns_none():
+    """A non-list 'files' (e.g. int) is not a usable spec — None, not a crash."""
+    assert parse_expected_outputs(json.dumps({"files": 123})) is None
+    assert parse_expected_outputs(json.dumps({"files": "report.md"})) is None
+
+
+def test_parse_malformed_optional_fields_coerce_safely():
+    """Non-numeric min_size_bytes / non-list required_strings must not raise —
+    they coerce to safe defaults so the spec is still usable, never a crash."""
+    result = parse_expected_outputs(
+        json.dumps({"files": ["a.md"], "min_size_bytes": "big", "required_strings": 123})
+    )
+    assert result is not None
+    assert result.files == ["a.md"]
+    assert result.min_size_bytes == 0
+    assert result.required_strings == []
+
+
 def test_parse_valid_minimal():
     """Minimal valid expected_outputs with only files."""
     raw = json.dumps({"files": ["/tmp/test.md"]})


### PR DESCRIPTION
Ego proposal hygiene — the next slice of the proposal-lifecycle umbrella (PR-1 #1193 → PR-6b #1298): a flag-gated operate-vs-develop boundary with teeth, one global pending cap, the revalidation backfill that makes ⚠due real on pre-existing rows, and a deliverable floor for investigation dispatches.

## Why

The pending board accumulated proposals a healthy realist had *correctly* passed under the current rubric but that should never have reached the approval queue:

- **Develop-scope leaks.** The operate-vs-develop rubric (PR-3 #1214) defines develop as *patch-producing* work, so read-only dev-artifact proposals ("review PR #NNNN before merge", "trace the gating logic to pinpoint the threshold") classify as legitimate investigation and pass. Verified against the live board: all six problem proposals carried `realist_verdict='pass'` — this is a **definitional gap, not a realist failure** (fail-open was investigated and ruled out; the rubric predates all six rows).
- **Per-ego cap.** `max_pending_proposals=15` counted per `ego_source`, so the user-facing board could legally reach ~30.
- **Dark revalidation.** Migration 0071 added `revalidate_at` with no backfill and PR-6a stamps only new rows — every older pending row was invisible to the ⚠due premise-recheck. Separately, reaffirm/revise never re-stamped the clock, so a re-validated item stayed flagged overdue forever.
- **Unverifiable investigations.** `expected_outputs` is opt-in; bare "probe/diagnose" dispatches skipped post-dispatch verification entirely, and the execution-brief dispatch path never rendered the required-files block even when outputs existed.

## What

**1. Roadmap flag (the off-switch).** `EgoConfig.genesis_self_development_enabled` (default `False`) + validator + yaml doc. Genesis self-development is deliberately a *future* capability: flip the flag to unlock it — no code change; delete the flag + gate to remove the mechanism entirely.

**2. Operate-vs-develop gate (deterministic floor, genesis/COO ego only).**
- Boundary redefinition in the identity doc + realist rule 8: **dev-artifact work is develop even when read-only** (PR review/merge, code tracing to scope a fix, refactor scoping — the test is whether the natural deliverable is a patch or patch-plan); **live-symptom diagnosis stays operate** even when the trail leads into code, with an escalation-only deliverable.
- `_flag_develop_scope` (runs unconditionally post-realist, beside `_enforce_domain_boundary`, so a realist outage cannot leak develop work): flags drafts via the autonomy `SELF_MODIFY`/`AUTONOMOUS_BUILD` classifier + a NARROW action-phrasing marker set. Cause-mentions ("backups fail since the scheduler refactor") deliberately do NOT match — fuzzy phrasing is the realist's job; the deterministic layer stays near-zero-FP.
- Flagged drafts are **created then immediately TABLED** (recoverable, journal-resolved, excluded from the digest via a new pending-only filter in `send_digest`) — never silently dropped. Tabled twins dedup so a persistent dev idea doesn't churn a new tabled row every cycle.
- **Replay-verified:** the detector ran over all 293 historical `ego_proposals`; it flags exactly the known develop-scope row (+1 genuine user-ego `code_change`), with zero false positives on operate rows and on synthetic cause-mention probes.

**3. Global cap.** The cap site now counts the total pending pool (both egos; informational j9/gauntlet rows still excluded; gate-flagged incoming excluded — they never occupy the board). Eviction stays global-oldest-unranked with the 24h guard. Note: evo-origin proposals are now cap-countable — deliberate; they are real approval work.

**4. Revalidation live end-to-end.**
- Migration **0077** backfills `revalidate_at = created_at + interval(urgency)` on pending rows where NULL (informational rows excluded per PR-6a design; stamps computed in Python for ISO-format parity with organic stamps — the ⚠due check is a string comparison; idempotent; `down()` no-op).
- `reaffirm_proposal`/`revise_proposal` gain an optional `revalidate_at` (COALESCE-guarded); the reconcile live-apply call sites pass `config.next_revalidate_at(urgency)` — a re-validated item leaves ⚠due. Semantics note for review: PR-6a's docstring said reaffirm "touches only last_validated_at"; leaving the clock un-advanced makes a reaffirmed item perpetually due, which defeats the cadence's stated purpose — flagging explicitly rather than assuming.
- The shared helper `config.next_revalidate_at` replaces the inline interval math in `create_batch`.
- **Deliberately NOT here:** the `ego_reconcile` shadow→live mode flip — that stays with its owned shadow-soak go/no-go follow-up; this PR only feeds the soak with real due-flags.

**5. Deliverable floor.** Genesis-ego `dispatch`/`investigate` proposals lacking `expected_outputs` get a default (`~/.genesis/output/ego-reports/<id>.md`, min-size advisory) so post-dispatch verification always applies; genesis realist Rule 1 now AMENDs a missing deliverable. `_required_outputs_block` extracted and rendered on BOTH dispatch-prompt paths — the execution-brief path previously never told the session its required files (file existence is a hard verification signal since #1180, so an untold session would fail verification through no fault of its own). Scoped to the genesis ego; user-ego dispatch flows untouched.

**Riders (deliberate, small):** 14-day recency window on the dashboard resolved-directives history (stale rows lingered for months on a rarely-resolving surface); `_reconcile_revise` now serializes a dict `expected_outputs` before DB binding (would previously fail parameter binding on the live-revise path); one test fake updated to the real reaffirm contract.

## Verification

- Targeted suites green: 2609 passed (`tests/ego/`, `tests/test_ego/`, `tests/test_db/`), including new `test_develop_gate.py` (gate on/off/fail-toward-enforcement, marker precision incl. cause-mentions, global cap cross-ego eviction, injection round-trip through `parse_expected_outputs`, tabled-twin dedup) and `test_backfill_revalidate_at.py` (per-urgency stamps, format parity, informational/non-pending exclusion, idempotency, pre-0071 no-op).
- Verify-RED: both new test files fail-at-collection against pre-change code (feature absent), green in this branch.
- Marker replay over all 293 historical proposals: 0 false positives (see above).
- Post-merge deploy plan: migration 0077 applies at restart; identity/realist prompt changes take effect next ego cycle; a live genesis-ego + user-ego cycle will be watched for gate log markers before closing out.

**Deploy path:** runtime code + additive data-only migration → `git pull` + server restart (standard). No host-deployed paths touched. Config default ships in `config/ego.yaml` (works with zero overlay). Retention: the tabled lane and `ego-reports/` live under existing GC/output conventions; no new unbounded store.

Ledger: 9bb21d8020194f2aa83fd41cc9b87402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
