### PR TITLE
fix(follow-ups): id-prefix resolution + scheduled-orphan gate + hygiene watchdog

### DIFF
--- a/config/follow_up_watchdog.yaml
+++ b/config/follow_up_watchdog.yaml
@@ -1,0 +1,23 @@
+# Follow-up hygiene watchdog (awareness hourly band) — read-and-alert only.
+#
+# Flags hot-lane follow_ups rows that fell into an invisible/stuck state:
+#   - orphaned_scheduled: status='scheduled' with no linked_task_id (invisible to
+#     every surface — the black hole the follow_up_update H2 gate now prevents;
+#     this catches pre-gate / programmatic strays).
+#   - past_due_scheduled: a scheduled_task whose scheduled_at passed but the
+#     dispatcher never actuated it.
+# Emits one deduped, self-resolving infrastructure_alert (→ morning report).
+#
+# Env kill switch: GENESIS_FOLLOW_UP_WATCHDOG_DISABLED=1 forces it off.
+
+enabled: true
+
+# A row must be this old (created_at) / this far past scheduled_at before it's
+# flagged — avoids alerting on a row a concurrent writer is mid-transition on.
+grace_hours: 6
+
+# Max offender ids listed inside the single alert (for the morning session).
+max_listed: 10
+
+# Base alert severity; escalated to 'critical' if any flagged row is critical.
+alert_priority: high

--- a/src/genesis/awareness/follow_up_watchdog_config.py
+++ b/src/genesis/awareness/follow_up_watchdog_config.py
@@ -1,0 +1,102 @@
+"""Config lever for the follow-up hygiene watchdog (awareness hourly band).
+
+Cloned from ``cc.rate_limit_resume_config`` minus the mode ladder: this check is
+read-and-alert only (it mutates nothing), so there is no authority to grade —
+just an ``enabled`` master switch + int knobs + an env kill switch.
+
+Failure posture: a missing/corrupt config degrades to DEFAULTS; the env kill
+switch ``GENESIS_FOLLOW_UP_WATCHDOG_DISABLED=1`` forces the check off regardless
+of the file.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports the public ``DEFAULTS`` / ``INT_KNOBS``
+from here (never the reverse).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_NAME = "follow_up_watchdog.yaml"
+_ENV_KILL_SWITCH = "GENESIS_FOLLOW_UP_WATCHDOG_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    # A row must be at least this old (created_at) before an orphaned_scheduled
+    # finding fires, and scheduled_at must be this far past for past_due — avoids
+    # alerting on a row that a concurrent writer is mid-transition on.
+    "grace_hours": 6,
+    # Cap the offender ids listed inside a single alert (the alert is one deduped
+    # observation; the list is for the morning session to act on).
+    "max_listed": 10,
+    # Base severity of the alert. Escalated to 'critical' when any flagged row is
+    # itself priority='critical'.
+    "alert_priority": "high",
+}
+
+INT_KNOBS = ("grace_hours", "max_listed")
+_VALID_ALERT_PRIORITY = ("low", "medium", "high", "critical")
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or corrupt
+    files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("follow_up_watchdog base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("follow_up_watchdog overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def is_enabled() -> bool:
+    """True unless the env kill switch is set or the config disables it."""
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return False
+    return bool(load_config().get("enabled", True))
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never zeroes a
+    limit or crashes the check."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value
+
+
+def alert_priority(cfg: dict[str, Any]) -> str:
+    """The configured base alert priority, falling back to the default on damage."""
+    value = cfg.get("alert_priority")
+    if value in _VALID_ALERT_PRIORITY:
+        return str(value)
+    return str(DEFAULTS["alert_priority"])

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1138,6 +1138,156 @@ async def _resolve_deploy_staleness(db) -> None:
         logger.debug("Failed to resolve deploy staleness alerts", exc_info=True)
 
 
+# ── Follow-up hygiene watchdog ────────────────────────────────────────────────
+# Flags hot-lane follow_ups that fell into an invisible/stuck state (the failure
+# class behind the July-2026 graph-bake-off loss): status='scheduled' with no
+# linked_task_id (invisible to every surface — the follow_up_update H2 gate now
+# prevents new ones; this catches pre-gate/programmatic strays), and scheduled_task
+# rows the dispatcher never actuated. Read-and-alert only — one deduped,
+# self-resolving infrastructure_alert (→ morning report). Slow-moving → hourly.
+_FU_WATCHDOG_SOURCE = "follow_up_watchdog"
+_FU_WATCHDOG_COOLDOWN_S = 6 * 3600  # same-state re-alerts at most every 6h
+_last_fu_watchdog_alert_at: float = 0.0
+_last_fu_watchdog_alert_key: str = ""
+
+
+def _created_before(row: dict, cutoff: datetime) -> bool:
+    """True if the row's created_at is older than cutoff (grace boundary).
+
+    Un-parseable/missing created_at → treat as old (flag it) rather than hide it.
+    """
+    raw = row.get("created_at")
+    if not raw:
+        return True
+    try:
+        dt = datetime.fromisoformat(raw)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt <= cutoff
+    except (ValueError, TypeError):
+        return True
+
+
+async def _check_follow_up_watchdog(db) -> None:
+    """Alert when hot-lane follow-ups are stuck invisible/undispatched.
+
+    Best-effort — the whole body is guarded and never raises into the tick."""
+    global _last_fu_watchdog_alert_at, _last_fu_watchdog_alert_key
+    if db is None:
+        return
+    try:
+        from genesis.awareness import follow_up_watchdog_config as cfg_mod
+
+        if not cfg_mod.is_enabled():
+            # Turning the watchdog off must not strand an already-open alert as
+            # permanently unresolved (every other check reaches its _resolve_*).
+            # Clear its own alerts, then stay quiet.
+            await _resolve_follow_up_watchdog(db)
+            return
+        cfg = cfg_mod.load_config()
+        grace_hours = cfg_mod.knob_int(cfg, "grace_hours")
+        max_listed = cfg_mod.knob_int(cfg, "max_listed")
+        base_priority = cfg_mod.alert_priority(cfg)
+
+        from genesis.db.crud import follow_ups as fu_crud
+
+        cutoff = datetime.now(UTC) - timedelta(hours=grace_hours)
+        orphaned = [
+            r for r in await fu_crud.get_orphaned_scheduled(db) if _created_before(r, cutoff)
+        ]
+        past_due = await fu_crud.get_past_due_scheduled(db, grace_hours=grace_hours)
+
+        findings: list[tuple[str, dict]] = [("orphaned_scheduled", r) for r in orphaned]
+        findings += [("past_due_scheduled", r) for r in past_due]
+        if not findings:
+            await _resolve_follow_up_watchdog(db)
+            return
+
+        classes = sorted({c for c, _ in findings})
+        critical = any(r.get("priority") == "critical" for _, r in findings)
+        priority = "critical" if critical else base_priority
+        alert_key = ",".join(classes) + ":" + priority
+        now = time.monotonic()
+        if (
+            now - _last_fu_watchdog_alert_at < _FU_WATCHDOG_COOLDOWN_S
+            and alert_key == _last_fu_watchdog_alert_key
+        ):
+            return
+
+        content_hash = hashlib.sha256(f"follow_up_watchdog:{alert_key}".encode()).hexdigest()
+        # Keep exactly ONE active alert = the current state.
+        await observations.supersede_except_hash(
+            db,
+            source=_FU_WATCHDOG_SOURCE,
+            type="infrastructure_alert",
+            keep_content_hash=content_hash,
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes="superseded by a new follow-up watchdog alert state",
+        )
+
+        listed = findings[:max_listed]
+        rows = " | ".join(
+            f"{r['id'][:8]} · {(r.get('content') or '')[:80]} · {cls}" for cls, r in listed
+        )
+        more = len(findings) - len(listed)
+        content = (
+            f"{len(findings)} hot-lane follow-up(s) are stuck invisible/undispatched: "
+            f"{len(orphaned)} orphaned-scheduled (status='scheduled' with no linked task — "
+            f"in NO surface: not actionable, not dispatched, not linked-active), "
+            f"{len(past_due)} past-due scheduled (scheduled_at elapsed, dispatcher never "
+            f"actuated). Fix each via follow_up_update (the 8-char id prefix now resolves): "
+            f"give it a real trigger (work_state='blocked_on_trigger' + revisit_condition), "
+            f"complete it, or fail it. [{rows}"
+            + (f" | (+{more} more)]" if more else "]")
+        )
+        created = await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source=_FU_WATCHDOG_SOURCE,
+            type="infrastructure_alert",
+            content=content,
+            priority=priority,
+            created_at=datetime.now(UTC).isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
+        )
+        if created is None:
+            return  # An unresolved alert for this exact state already exists.
+        _last_fu_watchdog_alert_at = now
+        _last_fu_watchdog_alert_key = alert_key
+        logger.warning(
+            "Follow-up watchdog alert (%s): %d orphaned-scheduled, %d past-due",
+            priority,
+            len(orphaned),
+            len(past_due),
+        )
+    except Exception:
+        logger.debug("Failed follow-up watchdog check", exc_info=True)
+
+
+async def _resolve_follow_up_watchdog(db) -> None:
+    """Resolve outstanding follow-up watchdog alerts once no findings remain."""
+    global _last_fu_watchdog_alert_at, _last_fu_watchdog_alert_key
+    if db is None:
+        return
+    try:
+        resolved = await observations.resolve_by_source_and_type(
+            db,
+            source=_FU_WATCHDOG_SOURCE,
+            type="infrastructure_alert",
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes="auto-resolved: follow-up hygiene cleared",
+        )
+        if resolved:
+            _last_fu_watchdog_alert_at = 0.0
+            _last_fu_watchdog_alert_key = ""
+            logger.info(
+                "Auto-resolved %d follow-up watchdog alert observation(s)", resolved
+            )
+    except Exception:
+        logger.debug("Failed to resolve follow-up watchdog alerts", exc_info=True)
+
+
 # nodatacow (chattr +C) drift detection: on btrfs, a CoW SQLite DB suffers WAL
 # write-amplification + chronic fragmentation. The install sets +C on data/;
 # this catches regressions (a restore/recreate that dropped the flag). Static
@@ -2309,6 +2459,11 @@ class AwarenessLoop:
                     # consistency/recall-probe rows; slow-moving (daily jobs) →
                     # hourly is ample.
                     await _check_memory_integrity_posture(self._db)
+                    # Follow-up hygiene: hot-lane rows stuck invisible
+                    # (orphaned-scheduled) or undispatched (past-due scheduled).
+                    # Day-scale lifecycle signal → hourly; self-resolves when
+                    # rows gain a trigger or close.
+                    await _check_follow_up_watchdog(self._db)
                 await _check_wal_health(self._db)
                 # WS-2 M10: persist the alert/incident open-set to alert_events.
                 # Every tick (5 min), not hourly — a short-lived alert that fires

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1206,7 +1206,12 @@ async def _check_follow_up_watchdog(db) -> None:
         classes = sorted({c for c, _ in findings})
         critical = any(r.get("priority") == "critical" for _, r in findings)
         priority = "critical" if critical else base_priority
-        alert_key = ",".join(classes) + ":" + priority
+        # Key on the FULL offender id set (ALL findings, not the display slice) as well
+        # as class + priority. When the offender set changes but class + priority don't,
+        # a class-only key leaves the stale alert deduped forever with its original
+        # ids/count while the newly-stuck row stays hidden — defeating the watchdog (P1).
+        offender_key = ",".join(sorted(r["id"] for _, r in findings))
+        alert_key = ",".join(classes) + ":" + priority + "|" + offender_key
         now = time.monotonic()
         if (
             now - _last_fu_watchdog_alert_at < _FU_WATCHDOG_COOLDOWN_S
@@ -1236,8 +1241,9 @@ async def _check_follow_up_watchdog(db) -> None:
             f"in NO surface: not actionable, not dispatched, not linked-active), "
             f"{len(past_due)} past-due scheduled (scheduled_at elapsed, dispatcher never "
             f"actuated). Fix each via follow_up_update (the 8-char id prefix now resolves): "
-            f"give it a real trigger (work_state='blocked_on_trigger' + revisit_condition), "
-            f"complete it, or fail it. [{rows}"
+            f"set status='blocked' with a blocked_reason (+ a revisit_condition), or "
+            f"complete/fail it. NOTE: work_state alone changes the lane/kind, NOT status — "
+            f"an orphan left status='scheduled' stays invisible. [{rows}"
             + (f" | (+{more} more)]" if more else "]")
         )
         created = await observations.create(

--- a/src/genesis/db/crud/_id_resolve.py
+++ b/src/genesis/db/crud/_id_resolve.py
@@ -1,0 +1,83 @@
+"""Shared unique-prefix id resolver for MCP tools keyed on Genesis-generated ids.
+
+Most Genesis ids are ``uuid4().hex`` (32-char) or dashed UUIDs (36-char). The
+proactive hook, ``memory_expand``, and ``session_charter`` all accept short hex
+handles, so the ecosystem *teaches* prefix usage — but most id-taking tools do
+exact-match lookups and reject a prefix with a soft "not found" that a caller
+skims past. That mismatch silently lost a hard-dated commitment (the July 2026
+graph-bake-off row: an 8-char prefix passed to ``follow_up_update``).
+
+This mirrors ``genesis.mcp.memory.core._resolve_id_prefixes`` /
+``genesis.db.crud.memory.match_id_prefix``: a unique prefix resolves; an
+ambiguous prefix is never guessed; full-length and non-hex ids pass through
+untouched; DB errors fail open (identical behaviour to no resolver).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+# Outcome constants (callers switch on these).
+RESOLVED = "resolved"  # exactly one match — matches == [full_id]
+AMBIGUOUS = "ambiguous"  # >1 match — matches == candidate ids (never guessed)
+NOT_FOUND = "not_found"  # zero matches for a prefix-shaped id — matches == []
+PASSTHROUGH = "passthrough"  # not prefix-shaped (full/non-hex) — matches == [raw]
+
+# table/id_column are ALWAYS developer-supplied literals, never caller input.
+# Guarded so they can never reach f-string interpolation as anything but a plain
+# identifier (defence-in-depth against a future misuse).
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _prefix_re(min_len: int) -> re.Pattern[str]:
+    # Hex, optionally dashed, at least min_len chars — a partial id. Anything
+    # else (full ids, non-hex) bypasses resolution untouched.
+    return re.compile(rf"^[0-9a-f][0-9a-f-]{{{min_len - 1},}}$")
+
+
+async def resolve_unique_prefix(
+    db: aiosqlite.Connection,
+    *,
+    table: str,
+    id_column: str,
+    raw_id: str,
+    full_len: int = 32,
+    min_len: int = 4,
+) -> tuple[list[str], str]:
+    """Resolve ``raw_id`` against ``{table}.{id_column}`` by unique prefix.
+
+    Returns ``(matches, outcome)``:
+      * ``RESOLVED``    → ``matches == [full_id]``
+      * ``AMBIGUOUS``   → ``matches`` are the candidate ids (>=2, for the error)
+      * ``NOT_FOUND``   → ``matches == []`` (prefix-shaped but nothing matched)
+      * ``PASSTHROUGH`` → ``matches == [raw_id]`` (full-length / non-hex / too short)
+    """
+    if not _IDENT_RE.match(table) or not _IDENT_RE.match(id_column):
+        raise ValueError(f"unsafe identifier: table={table!r} id_column={id_column!r}")
+
+    mid = raw_id.strip().lower().removeprefix("id:")
+    if len(mid) >= full_len or not _prefix_re(min_len).match(mid):
+        return [raw_id], PASSTHROUGH
+
+    try:
+        # LIMIT 3 → distinguish unique (1) from ambiguous (>=2) AND let the caller
+        # name two candidates plus "possibly more" in an ambiguity error.
+        cursor = await db.execute(
+            f"SELECT {id_column} FROM {table} WHERE {id_column} LIKE ? || '%' LIMIT 3",
+            (mid,),
+        )
+        matches = [str(r[0]) for r in await cursor.fetchall()]
+    except Exception:
+        logger.debug("prefix resolution failed for %r on %s", raw_id, table, exc_info=True)
+        return [raw_id], PASSTHROUGH
+
+    if len(matches) == 1:
+        return matches, RESOLVED
+    if matches:
+        return matches, AMBIGUOUS
+    return [], NOT_FOUND

--- a/src/genesis/db/crud/_id_resolve.py
+++ b/src/genesis/db/crud/_id_resolve.py
@@ -10,7 +10,8 @@ graph-bake-off row: an 8-char prefix passed to ``follow_up_update``).
 This mirrors ``genesis.mcp.memory.core._resolve_id_prefixes`` /
 ``genesis.db.crud.memory.match_id_prefix``: a unique prefix resolves; an
 ambiguous prefix is never guessed; full-length and non-hex ids pass through
-untouched; DB errors fail open (identical behaviour to no resolver).
+as the NORMALIZED id (an ``id:`` tag / whitespace / case stripped, never
+prefix-matched); DB errors fail open to that same normalized id.
 """
 
 from __future__ import annotations
@@ -26,7 +27,7 @@ logger = logging.getLogger(__name__)
 RESOLVED = "resolved"  # exactly one match — matches == [full_id]
 AMBIGUOUS = "ambiguous"  # >1 match — matches == candidate ids (never guessed)
 NOT_FOUND = "not_found"  # zero matches for a prefix-shaped id — matches == []
-PASSTHROUGH = "passthrough"  # not prefix-shaped (full/non-hex) — matches == [raw]
+PASSTHROUGH = "passthrough"  # not prefix-shaped (full/non-hex) — matches == [mid] (normalized)
 
 # table/id_column are ALWAYS developer-supplied literals, never caller input.
 # Guarded so they can never reach f-string interpolation as anything but a plain
@@ -55,14 +56,16 @@ async def resolve_unique_prefix(
       * ``RESOLVED``    → ``matches == [full_id]``
       * ``AMBIGUOUS``   → ``matches`` are the candidate ids (>=2, for the error)
       * ``NOT_FOUND``   → ``matches == []`` (prefix-shaped but nothing matched)
-      * ``PASSTHROUGH`` → ``matches == [raw_id]`` (full-length / non-hex / too short)
+      * ``PASSTHROUGH`` → ``matches == [mid]`` — the NORMALIZED id (an ``id:`` tag,
+        whitespace, and case stripped); full-length / non-hex / too short, so never
+        prefix-matched, but returned normalized so an exact lookup still hits.
     """
     if not _IDENT_RE.match(table) or not _IDENT_RE.match(id_column):
         raise ValueError(f"unsafe identifier: table={table!r} id_column={id_column!r}")
 
     mid = raw_id.strip().lower().removeprefix("id:")
     if len(mid) >= full_len or not _prefix_re(min_len).match(mid):
-        return [raw_id], PASSTHROUGH
+        return [mid], PASSTHROUGH
 
     try:
         # LIMIT 3 → distinguish unique (1) from ambiguous (>=2) AND let the caller
@@ -74,7 +77,7 @@ async def resolve_unique_prefix(
         matches = [str(r[0]) for r in await cursor.fetchall()]
     except Exception:
         logger.debug("prefix resolution failed for %r on %s", raw_id, table, exc_info=True)
-        return [raw_id], PASSTHROUGH
+        return [mid], PASSTHROUGH
 
     if len(matches) == 1:
         return matches, RESOLVED

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -236,6 +236,50 @@ async def get_scheduled_due(
     return [dict(row) for row in await cursor.fetchall()]
 
 
+async def get_orphaned_scheduled(db: aiosqlite.Connection) -> list[dict]:
+    """Hot-lane rows stuck in status='scheduled' with NO linked_task_id.
+
+    status='scheduled' is only legitimate when set by ``link_task`` atomically
+    with a ``linked_task_id`` (so ``get_linked_active`` surfaces it). A scheduled
+    row missing the link is INVISIBLE to every surface — not in ``get_actionable``
+    (excludes 'scheduled'), not in ``get_scheduled_due`` (needs status='pending' +
+    scheduled_at), not in ``get_linked_active`` (needs linked_task_id). This is the
+    black hole the follow_up_update H2 gate now prevents; this reader catches any
+    that pre-date the gate or were written programmatically. Hot lane only.
+    """
+    cursor = await db.execute(
+        "SELECT * FROM follow_ups "
+        "WHERE status = 'scheduled' AND linked_task_id IS NULL AND kind = 'follow_up' "
+        "ORDER BY created_at ASC",
+    )
+    return [dict(row) for row in await cursor.fetchall()]
+
+
+async def get_past_due_scheduled(db: aiosqlite.Connection, *, grace_hours: int) -> list[dict]:
+    """Hot-lane scheduled_task rows the dispatcher never actuated, >grace_hours past due.
+
+    The dispatcher consumes EXACTLY ``get_scheduled_due``'s set — strategy=
+    'scheduled_task' AND status='pending' AND scheduled_at<=now — and on dispatch
+    the row moves to in_progress then to status='scheduled' with a linked_task_id
+    (tracked thereafter by ``get_linked_active``). So the ONLY state that means
+    "never actuated" is a row STILL in status='pending' with no linked_task_id whose
+    scheduled_at is now >grace_hours old. Narrowing to that avoids false-positiving on
+    healthy dispatched rows simply waiting on idle-gated surplus compute (they are
+    status='scheduled'+linked with a frozen scheduled_at) and avoids double-counting
+    genuine orphans (status='scheduled', caught by get_orphaned_scheduled). Reuses the
+    ``datetime(scheduled_at) <= datetime('now', '-N hours')`` shape. Hot lane only.
+    """
+    cursor = await db.execute(
+        "SELECT * FROM follow_ups "
+        "WHERE strategy = 'scheduled_task' AND status = 'pending' AND linked_task_id IS NULL "
+        "AND kind = 'follow_up' AND scheduled_at IS NOT NULL "
+        "AND datetime(scheduled_at) <= datetime('now', ?) "
+        "ORDER BY scheduled_at ASC",
+        (f"-{int(grace_hours)} hours",),
+    )
+    return [dict(row) for row in await cursor.fetchall()]
+
+
 async def get_linked_active(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -119,6 +119,21 @@ async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
     return dict(row) if row else None
 
 
+async def resolve_id(db: aiosqlite.Connection, id_or_prefix: str) -> tuple[list[str], str]:
+    """Resolve a full id OR a short hex prefix to the follow_up row(s).
+
+    Thin wrapper over the shared resolver so ``follow_up_update`` accepts the
+    same short handles the proactive hook / memory_expand hand out. Returns
+    ``(matches, outcome)`` — see ``crud/_id_resolve``. follow_up ids are
+    ``uuid4().hex`` (32-char, no dashes).
+    """
+    from genesis.db.crud._id_resolve import resolve_unique_prefix
+
+    return await resolve_unique_prefix(
+        db, table="follow_ups", id_column="id", raw_id=id_or_prefix, full_len=32
+    )
+
+
 async def get_pending(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -231,18 +231,20 @@ async def _impl_follow_up_update(
     """Update an existing follow-up item."""
     db = _get_db()
     if db is None:
-        return {"error": "Database not available"}
+        return {"error": "Database not available", "error_code": "db_unavailable"}
 
     valid_statuses = {"pending", "scheduled", "in_progress", "completed", "failed", "blocked"}
     if status and status not in valid_statuses:
         return {
-            "error": f"Invalid status '{status}'. Must be one of: {', '.join(sorted(valid_statuses))}"
+            "error": f"Invalid status '{status}'. Must be one of: {', '.join(sorted(valid_statuses))}",
+            "error_code": "invalid_status",
         }
 
     valid_priorities = {"low", "medium", "high", "critical"}
     if priority and priority not in valid_priorities:
         return {
-            "error": f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(valid_priorities))}"
+            "error": f"Invalid priority '{priority}'. Must be one of: {', '.join(sorted(valid_priorities))}",
+            "error_code": "invalid_priority",
         }
 
     from genesis.db.crud import follow_ups
@@ -253,13 +255,43 @@ async def _impl_follow_up_update(
                 f"Invalid work_state '{work_state}'. Must be one of: "
                 f"{', '.join(sorted(follow_ups.VALID_WORK_STATE))}. See follow_up_create "
                 "for the ready / blocked_on_trigger / deferred_cold meanings."
-            )
+            ),
+            "error_code": "invalid_work_state",
         }
 
     try:
+        # Resolve a full id OR a short hex prefix (the proactive hook / memory_expand
+        # hand out ``id:<8-char>`` handles, so callers pass them here too). An
+        # ambiguous prefix is NEVER guessed; a bare exact miss is loud.
+        from genesis.db.crud import _id_resolve
+
+        matches, outcome = await follow_ups.resolve_id(db, follow_up_id)
+        resolved_from: str | None = None
+        if outcome == _id_resolve.AMBIGUOUS:
+            shown = ", ".join(m[:12] for m in matches[:2])
+            more = " (and possibly more)" if len(matches) >= 3 else ""
+            return {
+                "error": (
+                    f"Follow-up id '{follow_up_id}' is AMBIGUOUS — it matches {shown}{more}. "
+                    "NOTHING was updated. Re-run with a longer id prefix or the full id."
+                ),
+                "error_code": "ambiguous_id",
+            }
+        if outcome == _id_resolve.RESOLVED and matches[0] != follow_up_id:
+            resolved_from = follow_up_id
+            follow_up_id = matches[0]
+
         existing = await follow_ups.get_by_id(db, follow_up_id)
         if not existing:
-            return {"error": f"Follow-up '{follow_up_id}' not found"}
+            return {
+                "error": (
+                    f"No follow-up matches id '{follow_up_id}'. NOTHING was updated — "
+                    "the change you intended did NOT happen. Run follow_up_list (or check "
+                    "the id against a recent follow_up_create response) and retry with a "
+                    "correct id."
+                ),
+                "error_code": "not_found",
+            }
 
         # Resolve any lane change UP-FRONT (before writes) so a gate failure never
         # leaves a partial update. Lane moves go through work_state (the item's
@@ -280,7 +312,8 @@ async def _impl_follow_up_update(
                         "work_state='blocked_on_trigger' requires revisit_condition — "
                         "name the time/event/precondition you're waiting on, or use "
                         "'deferred_cold' (tabled) / 'ready' instead."
-                    )
+                    ),
+                    "error_code": "blocked_on_trigger_needs_revisit",
                 }
             if work_state == "blocked_on_trigger" and existing.get("strategy") == "surplus_task":
                 return {
@@ -289,8 +322,38 @@ async def _impl_follow_up_update(
                         "follow-up — surplus tasks dispatch immediately on idle compute, "
                         "ignoring the trigger. Recreate it as scheduled_task (time trigger) "
                         "or user_input_needed / ego_judgment (event trigger)."
-                    )
+                    ),
+                    "error_code": "blocked_on_trigger_surplus_conflict",
                 }
+
+        # H2 — reject the orphan-making transition INTO status='scheduled'.
+        # status='scheduled' is set legitimately only by link_task(), atomically
+        # with a linked_task_id. This tool can set the status but not the link, so
+        # a manual follow_up_update(status='scheduled') on an UNLINKED row produces
+        # a row invisible to every surface (not in get_actionable — which excludes
+        # 'scheduled'; not in get_scheduled_due — needs status='pending'+scheduled_at;
+        # not in get_linked_active — needs linked_task_id). That is exactly the
+        # black hole the July-2026 bake-off row fell into. A row that already
+        # carries a linked_task_id stays visible via get_linked_active, so only the
+        # unlinked case is blocked. 'blocked' is intentionally NOT gated (it is
+        # visible in get_actionable).
+        if (
+            status == "scheduled"
+            and existing.get("status") != "scheduled"
+            and not existing.get("linked_task_id")
+        ):
+            return {
+                "error": (
+                    "Refusing status='scheduled' on a follow-up with no linked task — "
+                    "it would be INVISIBLE to every surface (not actionable, not "
+                    "dispatched, not linked-active). NOTHING was updated. To park this "
+                    "for later, use work_state='blocked_on_trigger' with a "
+                    "revisit_condition (event trigger) or recreate it with "
+                    "strategy='scheduled_task' + a scheduled_at (time trigger). "
+                    "'scheduled' status is set by the dispatcher, not by hand."
+                ),
+                "error_code": "scheduled_needs_link",
+            }
 
         if priority and priority != existing.get("priority"):
             await db.execute(
@@ -319,7 +382,7 @@ async def _impl_follow_up_update(
                 blocked_reason=blocked_reason,
             )
             if not updated:
-                return {"error": "Update failed — row not modified"}
+                return {"error": "Update failed — row not modified", "error_code": "not_modified"}
         elif blocked_reason is not None:
             # blocked_reason without an explicit status means "block this" — honor
             # the documented contract (it previously silently kept the existing
@@ -343,7 +406,7 @@ async def _impl_follow_up_update(
             )
 
         refreshed = await follow_ups.get_by_id(db, follow_up_id)
-        return {
+        result = {
             "id": follow_up_id,
             "status": refreshed["status"],
             "kind": refreshed.get("kind"),
@@ -352,9 +415,13 @@ async def _impl_follow_up_update(
             "pinned": bool(refreshed.get("pinned", 0)),
             "message": "Follow-up updated.",
         }
+        if resolved_from is not None:
+            # Echo the full id so the caller learns it for subsequent calls.
+            result["resolved_from"] = resolved_from
+        return result
     except Exception as exc:
         logger.error("follow_up_update failed", exc_info=True)
-        return {"error": f"Failed to update follow-up: {exc}"}
+        return {"error": f"Failed to update follow-up: {exc}", "error_code": "internal_error"}
 
 
 # ---------------------------------------------------------------------------
@@ -444,8 +511,16 @@ async def follow_up_update(
     or move it between the hot (follow_up) and cold (tabled) lanes.
 
     Args:
-        follow_up_id: The ID of the follow-up to update.
-        status: New status (pending, scheduled, in_progress, completed, failed, blocked). Empty to keep current.
+        follow_up_id: The follow-up id — a full id OR a short hex prefix (>=4 chars,
+            e.g. an 8-char ``id:`` handle from the proactive hook). A unique prefix
+            resolves; an ambiguous one is rejected (never guessed); an unknown id
+            fails LOUD with error_code='not_found' (the update did NOT happen).
+        status: New status (pending, in_progress, completed, failed, blocked). Empty
+            to keep current. NOTE: 'scheduled' is set by the dispatcher (link_task),
+            not by hand — passing status='scheduled' on an unlinked row is REJECTED
+            (error_code='scheduled_needs_link') because it would be invisible to
+            every surface. To park for later use work_state='blocked_on_trigger'
+            (event) or recreate with strategy='scheduled_task' (time).
         resolution_notes: Notes on resolution or progress. Appended context for future sessions.
         blocked_reason: Why this follow-up is blocked (sets status to blocked if status not provided).
         priority: New priority (low, medium, high, critical). Empty to keep current.

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -280,6 +280,14 @@ async def _impl_follow_up_update(
         if outcome == _id_resolve.RESOLVED and matches[0] != follow_up_id:
             resolved_from = follow_up_id
             follow_up_id = matches[0]
+        elif outcome == _id_resolve.PASSTHROUGH and matches and matches[0] != follow_up_id:
+            # A full-length / tagged / whitespace-padded handle (e.g. the
+            # ``id:<32hex>`` the proactive hook emits) is normalized by the resolver
+            # but not "resolved from a prefix". Adopt the normalized id for the exact
+            # lookup — WITHOUT a resolved_from note (it's transparent normalization,
+            # not prefix disambiguation). Skipping this leaves the exact lookup on the
+            # raw ``id:``-tagged string, which misses though the row exists.
+            follow_up_id = matches[0]
 
         existing = await follow_ups.get_by_id(db, follow_up_id)
         if not existing:

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -270,6 +270,21 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # re-read every GC pass
     ),
+    "follow_up_watchdog": SettingsDomain(
+        name="follow_up_watchdog",
+        description=(
+            "Follow-up hygiene watchdog (awareness hourly band) — master `enabled` "
+            "+ `grace_hours` / `max_listed` / `alert_priority`. Flags hot-lane rows "
+            "stuck invisible (status='scheduled' with no linked task) or undispatched "
+            "(past-due scheduled_task) as one deduped, self-resolving "
+            "infrastructure_alert → morning report. Read-and-alert only (mutates "
+            "nothing). off (or env GENESIS_FOLLOW_UP_WATCHDOG_DISABLED=1) silences it. "
+            "Read live each hourly tick — no restart."
+        ),
+        config_filename="follow_up_watchdog.yaml",
+        readonly=False,
+        needs_restart=False,  # re-read every hourly tick
+    ),
     "voice_act": SettingsDomain(
         name="voice_act",
         description=(
@@ -1331,8 +1346,36 @@ def _validate_surplus_ideation_promotion(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_follow_up_watchdog(changes: dict) -> list[str]:
+    """Validate follow-up watchdog lever changes (see
+    genesis.awareness.follow_up_watchdog_config)."""
+    from genesis.awareness.follow_up_watchdog_config import (
+        _VALID_ALERT_PRIORITY,
+        INT_KNOBS,
+    )
+
+    errors: list[str] = []
+    valid_keys = ("enabled", "alert_priority", *INT_KNOBS)
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif key == "alert_priority":
+            if value not in _VALID_ALERT_PRIORITY:
+                errors.append(
+                    f"'alert_priority' must be one of {', '.join(_VALID_ALERT_PRIORITY)}; "
+                    f"got {value!r}"
+                )
+        elif isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            errors.append(f"'{key}' must be a positive int")
+    return errors
+
+
 _DOMAIN_VALIDATORS: dict[str, Any] = {
     "ego_reconcile": _validate_ego_reconcile,
+    "follow_up_watchdog": _validate_follow_up_watchdog,
     "surplus_ideation_promotion": _validate_surplus_ideation_promotion,
     "memory_integrity": _validate_memory_integrity,
     "entity_adjudication": _validate_entity_adjudication,

--- a/tests/test_awareness/test_follow_up_watchdog.py
+++ b/tests/test_awareness/test_follow_up_watchdog.py
@@ -219,6 +219,43 @@ async def test_resolves_when_rows_fixed(db):
     assert await _alerts(db) == []
 
 
+async def test_offender_set_change_supersedes_stale_alert(db):
+    """P1: when the offender SET changes but class+priority don't, the stale alert
+    must be superseded and a NEW alert must name the currently-stuck row. The dedup
+    key includes the offender ids, not just class+priority — otherwise the morning
+    report keeps listing an already-fixed row and hides the newly-stuck one."""
+    a = await _mk_orphaned_scheduled(db)
+    await loop._check_follow_up_watchdog(db)
+    alerts = await _alerts(db)
+    assert len(alerts) == 1
+    assert a[:8] in alerts[0]["content"]
+
+    # Fix A, and strand a DIFFERENT row B of the SAME class + priority.
+    await fu_crud.update_status(db, a, "completed")
+    b = await _mk_orphaned_scheduled(db)
+    # Reset the in-process cooldown so only DB-level dedup is under test.
+    loop._last_fu_watchdog_alert_at = 0.0
+    loop._last_fu_watchdog_alert_key = ""
+    await loop._check_follow_up_watchdog(db)
+
+    alerts = await _alerts(db)
+    assert len(alerts) == 1
+    assert b[:8] in alerts[0]["content"]  # the newly-stuck row surfaces
+    assert a[:8] not in alerts[0]["content"]  # the fixed row no longer listed
+
+
+async def test_remediation_prescribes_visible_status_change(db):
+    """P2: the alert's remediation must prescribe a VISIBLE status change. A
+    work_state change alone sets kind/revisit_condition, NOT status, so it can't
+    un-strand an orphan — the advice must not tell the operator otherwise."""
+    await _mk_orphaned_scheduled(db)
+    await loop._check_follow_up_watchdog(db)
+    content = (await _alerts(db))[0]["content"]
+    assert "status='blocked'" in content
+    # must NOT prescribe a bare work_state change as the repair
+    assert "work_state='blocked_on_trigger'" not in content
+
+
 async def test_critical_row_escalates_priority(db):
     await _mk_orphaned_scheduled(db, priority="critical")
     await loop._check_follow_up_watchdog(db)

--- a/tests/test_awareness/test_follow_up_watchdog.py
+++ b/tests/test_awareness/test_follow_up_watchdog.py
@@ -1,0 +1,313 @@
+"""Tests for the follow-up hygiene watchdog (_check_follow_up_watchdog).
+
+Under test is the ALERTING state machine, not the CRUD queries: it fires ONE
+deduped, self-resolving infrastructure_alert when hot-lane follow_ups are stuck
+invisible (orphaned-scheduled: status='scheduled' with no linked_task_id) or
+undispatched (past-due scheduled_task), and resolves on recovery.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import aiosqlite
+import pytest
+
+from genesis.awareness import loop
+from genesis.db.crud import follow_ups as fu_crud
+from genesis.db.schema import create_all_tables
+
+pytestmark = pytest.mark.asyncio
+
+SOURCE = "follow_up_watchdog"
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_cooldowns(monkeypatch):
+    monkeypatch.setattr(loop, "_last_fu_watchdog_alert_at", 0.0)
+    monkeypatch.setattr(loop, "_last_fu_watchdog_alert_key", "")
+
+
+async def _alerts(db) -> list[dict]:
+    cur = await db.execute(
+        "SELECT * FROM observations WHERE source = ? AND type = 'infrastructure_alert' "
+        "AND resolved = 0",
+        (SOURCE,),
+    )
+    return [dict(r) for r in await cur.fetchall()]
+
+
+async def _mk_orphaned_scheduled(db, *, age_hours: float = 48, priority: str = "high") -> str:
+    """A row in status='scheduled' with NO linked_task_id (the black hole)."""
+    res = await fu_crud.create(
+        db,
+        content="stuck scheduled item",
+        reason="r",
+        source="test",
+        strategy="user_input_needed",
+        kind="follow_up",
+        priority=priority,
+    )
+    fid = res["id"] if isinstance(res, dict) else res
+    created = (datetime.now(UTC) - timedelta(hours=age_hours)).isoformat()
+    await db.execute(
+        "UPDATE follow_ups SET status='scheduled', linked_task_id=NULL, created_at=? WHERE id=?",
+        (created, fid),
+    )
+    await db.commit()
+    return fid
+
+
+async def _mk_past_due(db, *, due_hours_ago: float = 48) -> str:
+    res = await fu_crud.create(
+        db,
+        content="overdue scheduled task",
+        reason="r",
+        source="test",
+        strategy="scheduled_task",
+        kind="follow_up",
+        scheduled_at=(datetime.now(UTC) - timedelta(hours=due_hours_ago)).isoformat(),
+    )
+    fid = res["id"] if isinstance(res, dict) else res
+    await db.execute("UPDATE follow_ups SET status='pending' WHERE id=?", (fid,))
+    await db.commit()
+    return fid
+
+
+# ── the two finding classes fire ─────────────────────────────────────────────
+
+
+async def test_orphaned_scheduled_row_raises_alert(db):
+    await _mk_orphaned_scheduled(db)
+    await loop._check_follow_up_watchdog(db)
+    alerts = await _alerts(db)
+    assert len(alerts) == 1
+    assert "orphaned-scheduled" in alerts[0]["content"]
+
+
+async def test_past_due_scheduled_row_raises_alert(db):
+    await _mk_past_due(db)
+    await loop._check_follow_up_watchdog(db)
+    alerts = await _alerts(db)
+    assert len(alerts) == 1
+    assert "past-due" in alerts[0]["content"]
+
+
+async def test_dispatched_linked_scheduled_task_not_past_due(db):
+    """A healthy scheduled_task that WAS dispatched is status='scheduled'+linked with
+    a frozen past scheduled_at — it must NOT be reported as 'dispatcher never
+    actuated' (the BLOCKER the review caught). It's tracked via get_linked_active."""
+    res = await fu_crud.create(
+        db,
+        content="dispatched, waiting on idle surplus",
+        reason="r",
+        source="test",
+        strategy="scheduled_task",
+        kind="follow_up",
+        scheduled_at=(datetime.now(UTC) - timedelta(hours=48)).isoformat(),
+    )
+    fid = res["id"] if isinstance(res, dict) else res
+    await fu_crud.link_task(db, fid, "task-xyz")  # -> status='scheduled', linked_task_id set
+    past_due = await fu_crud.get_past_due_scheduled(db, grace_hours=6)
+    assert all(r["id"] != fid for r in past_due)
+    await loop._check_follow_up_watchdog(db)
+    assert await _alerts(db) == []
+
+
+async def test_orphaned_scheduled_task_not_double_counted(db):
+    """A genuine orphan that also happens to be a scheduled_task (status='scheduled',
+    no link, old scheduled_at) is caught by get_orphaned_scheduled ONLY — never also
+    by get_past_due_scheduled (which is now status='pending'-only), so it's listed
+    once, not twice."""
+    res = await fu_crud.create(
+        db,
+        content="orphaned scheduled_task",
+        reason="r",
+        source="test",
+        strategy="scheduled_task",
+        kind="follow_up",
+        scheduled_at=(datetime.now(UTC) - timedelta(hours=48)).isoformat(),
+    )
+    fid = res["id"] if isinstance(res, dict) else res
+    old = (datetime.now(UTC) - timedelta(hours=48)).isoformat()
+    await db.execute(
+        "UPDATE follow_ups SET status='scheduled', linked_task_id=NULL, created_at=? WHERE id=?",
+        (old, fid),
+    )
+    await db.commit()
+    orphaned = await fu_crud.get_orphaned_scheduled(db)
+    past_due = await fu_crud.get_past_due_scheduled(db, grace_hours=6)
+    assert any(r["id"] == fid for r in orphaned)
+    assert all(r["id"] != fid for r in past_due)  # not double-counted
+
+
+# ── grace + exemptions ───────────────────────────────────────────────────────
+
+
+async def test_row_within_grace_not_flagged(db):
+    # created 1h ago, grace default 6h → not yet flagged.
+    await _mk_orphaned_scheduled(db, age_hours=1)
+    await loop._check_follow_up_watchdog(db)
+    assert await _alerts(db) == []
+
+
+async def test_linked_scheduled_row_not_flagged(db):
+    """status='scheduled' WITH a linked_task_id is visible via get_linked_active —
+    not an orphan, must not alert."""
+    res = await fu_crud.create(
+        db, content="linked", reason="r", source="test", strategy="surplus_task", kind="follow_up"
+    )
+    fid = res["id"] if isinstance(res, dict) else res
+    await fu_crud.link_task(db, fid, "task-abc")  # sets linked_task_id + scheduled
+    await loop._check_follow_up_watchdog(db)
+    assert await _alerts(db) == []
+
+
+async def test_tabled_lane_ignored(db):
+    """A tabled (cold-lane) orphan is consciously off-surface — not flagged."""
+    res = await fu_crud.create(
+        db, content="cold", reason="r", source="test", strategy="ego_judgment", kind="tabled"
+    )
+    fid = res["id"] if isinstance(res, dict) else res
+    old = (datetime.now(UTC) - timedelta(hours=48)).isoformat()
+    await db.execute(
+        "UPDATE follow_ups SET status='scheduled', linked_task_id=NULL, created_at=? WHERE id=?",
+        (old, fid),
+    )
+    await db.commit()
+    await loop._check_follow_up_watchdog(db)
+    assert await _alerts(db) == []
+
+
+async def test_pinned_row_still_flagged(db):
+    fid = await _mk_orphaned_scheduled(db)
+    await db.execute("UPDATE follow_ups SET pinned=1 WHERE id=?", (fid,))
+    await db.commit()
+    await loop._check_follow_up_watchdog(db)
+    assert len(await _alerts(db)) == 1
+
+
+# ── dedup / supersede / resolve ──────────────────────────────────────────────
+
+
+async def test_same_state_dedup_no_second_observation(db):
+    await _mk_orphaned_scheduled(db)
+    await loop._check_follow_up_watchdog(db)
+    # Reset the in-process cooldown so only DB-level dedup can stop a duplicate.
+    loop._last_fu_watchdog_alert_at = 0.0
+    loop._last_fu_watchdog_alert_key = ""
+    await loop._check_follow_up_watchdog(db)
+    assert len(await _alerts(db)) == 1
+
+
+async def test_resolves_when_rows_fixed(db):
+    fid = await _mk_orphaned_scheduled(db)
+    await loop._check_follow_up_watchdog(db)
+    assert len(await _alerts(db)) == 1
+    # Fix the row (give it a real terminal state).
+    await fu_crud.update_status(db, fid, "completed")
+    await loop._check_follow_up_watchdog(db)
+    assert await _alerts(db) == []
+
+
+async def test_critical_row_escalates_priority(db):
+    await _mk_orphaned_scheduled(db, priority="critical")
+    await loop._check_follow_up_watchdog(db)
+    alerts = await _alerts(db)
+    assert alerts[0]["priority"] == "critical"
+
+
+# ── config gating ────────────────────────────────────────────────────────────
+
+
+async def test_disabled_config_no_alert(db, monkeypatch):
+    from genesis.awareness import follow_up_watchdog_config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "is_enabled", lambda: False)
+    await _mk_orphaned_scheduled(db)
+    await loop._check_follow_up_watchdog(db)
+    assert await _alerts(db) == []
+
+
+async def test_env_kill_switch_no_alert(db, monkeypatch):
+    monkeypatch.setenv("GENESIS_FOLLOW_UP_WATCHDOG_DISABLED", "1")
+    await _mk_orphaned_scheduled(db)
+    await loop._check_follow_up_watchdog(db)
+    assert await _alerts(db) == []
+
+
+async def test_disable_while_alert_open_resolves_it(db, monkeypatch):
+    """Disabling the watchdog while an alert is open must RESOLVE it, not strand it
+    unresolved forever (SHOULD-FIX from review)."""
+    await _mk_orphaned_scheduled(db)
+    await loop._check_follow_up_watchdog(db)
+    assert len(await _alerts(db)) == 1
+    from genesis.awareness import follow_up_watchdog_config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "is_enabled", lambda: False)
+    await loop._check_follow_up_watchdog(db)
+    assert await _alerts(db) == []  # cleared, not stranded
+
+
+async def test_check_never_raises_on_db_error(db):
+    # A closed connection must degrade to a debug log, never raise into the tick.
+    await db.close()
+    await loop._check_follow_up_watchdog(db)  # must not raise
+
+
+# ── config module degradation ────────────────────────────────────────────────
+
+
+async def test_config_defaults_when_missing(monkeypatch, tmp_path):
+    from genesis.awareness import follow_up_watchdog_config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "_base_path", lambda: tmp_path / "nope.yaml")
+    cfg = cfg_mod.load_config()
+    assert cfg["enabled"] is True
+    assert cfg_mod.knob_int(cfg, "grace_hours") == 6
+
+
+async def test_knob_int_clamps_bad_values():
+    from genesis.awareness import follow_up_watchdog_config as cfg_mod
+
+    assert cfg_mod.knob_int({"grace_hours": 0}, "grace_hours") == 6
+    assert cfg_mod.knob_int({"grace_hours": -3}, "grace_hours") == 6
+    assert cfg_mod.knob_int({"grace_hours": True}, "grace_hours") == 6
+    assert cfg_mod.knob_int({"grace_hours": 12}, "grace_hours") == 12
+
+
+async def test_alert_priority_falls_back_on_bad_value():
+    from genesis.awareness import follow_up_watchdog_config as cfg_mod
+
+    assert cfg_mod.alert_priority({"alert_priority": "bogus"}) == "high"
+    assert cfg_mod.alert_priority({"alert_priority": "critical"}) == "critical"
+
+
+# ── settings domain + validator ──────────────────────────────────────────────
+
+
+async def test_settings_domain_registered():
+    from genesis.mcp.health import settings
+
+    assert "follow_up_watchdog" in settings._DOMAIN_REGISTRY
+    assert "follow_up_watchdog" in settings._DOMAIN_VALIDATORS
+
+
+async def test_validator_accepts_valid_and_rejects_bad():
+    from genesis.mcp.health.settings import _validate_follow_up_watchdog as v
+
+    assert v({"enabled": True, "grace_hours": 6, "max_listed": 5, "alert_priority": "high"}) == []
+    assert v({"enabled": "yes"})  # non-bool
+    assert v({"grace_hours": 0})  # non-positive int
+    assert v({"grace_hours": -1})
+    assert v({"alert_priority": "urgent"})  # bad enum
+    assert v({"unknown_key": 1})  # unknown key

--- a/tests/test_db/test_id_resolve.py
+++ b/tests/test_db/test_id_resolve.py
@@ -1,0 +1,98 @@
+"""Tests for the shared unique-prefix id resolver (crud/_id_resolve.py).
+
+Mirrors the memory_expand / session_charter resolvers: a short hex prefix
+resolves to a unique full id; ambiguous prefixes are never guessed; full-length
+and non-hex ids pass through untouched; DB errors fail open.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import _id_resolve
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _mk(db: aiosqlite.Connection, *ids: str) -> None:
+    await db.execute("CREATE TABLE t (id TEXT PRIMARY KEY)")
+    for i in ids:
+        await db.execute("INSERT INTO t (id) VALUES (?)", (i,))
+    await db.commit()
+
+
+async def _resolve(db, raw):
+    return await _id_resolve.resolve_unique_prefix(db, table="t", id_column="id", raw_id=raw)
+
+
+async def test_unique_prefix_resolves():
+    async with aiosqlite.connect(":memory:") as db:
+        full = "abcd1234" + "0" * 24
+        await _mk(db, full, "9999" + "f" * 28)
+        matches, outcome = await _resolve(db, "abcd1234")
+    assert outcome == _id_resolve.RESOLVED
+    assert matches == [full]
+
+
+async def test_ambiguous_prefix_reports_candidates():
+    async with aiosqlite.connect(":memory:") as db:
+        a, b = "dead0001" + "a" * 24, "dead0001" + "b" * 24
+        await _mk(db, a, b)
+        matches, outcome = await _resolve(db, "dead0001")
+    assert outcome == _id_resolve.AMBIGUOUS
+    assert set(matches) >= {a, b}  # candidates surfaced for the error message
+
+
+async def test_no_match_reports_not_found():
+    async with aiosqlite.connect(":memory:") as db:
+        await _mk(db, "abcd1234" + "0" * 24)
+        matches, outcome = await _resolve(db, "beef")
+    assert outcome == _id_resolve.NOT_FOUND
+    assert matches == []
+
+
+async def test_full_length_id_passes_through():
+    async with aiosqlite.connect(":memory:") as db:
+        await _mk(db, "abcd1234" + "0" * 24)
+        # A 32-char string is treated as a full id — never LIKE-matched.
+        matches, outcome = await _resolve(db, "f" * 32)
+    assert outcome == _id_resolve.PASSTHROUGH
+    assert matches == ["f" * 32]
+
+
+async def test_non_hex_id_passes_through():
+    async with aiosqlite.connect(":memory:") as db:
+        await _mk(db, "abcd1234" + "0" * 24)
+        matches, outcome = await _resolve(db, "not-a-hex-id!")
+    assert outcome == _id_resolve.PASSTHROUGH
+    assert matches == ["not-a-hex-id!"]
+
+
+async def test_short_prefix_below_min_len_passes_through():
+    async with aiosqlite.connect(":memory:") as db:
+        await _mk(db, "abcd1234" + "0" * 24)
+        # < min_len (4) hex chars is too short to risk a LIKE — pass through.
+        matches, outcome = await _resolve(db, "ab")
+    assert outcome == _id_resolve.PASSTHROUGH
+    assert matches == ["ab"]
+
+
+async def test_db_error_fails_open():
+    async with aiosqlite.connect(":memory:") as db:
+        # No table `t` created → the LIKE query raises → fail open to passthrough.
+        matches, outcome = await _id_resolve.resolve_unique_prefix(
+            db, table="t", id_column="id", raw_id="abcd1234"
+        )
+    assert outcome == _id_resolve.PASSTHROUGH
+    assert matches == ["abcd1234"]
+
+
+async def test_bad_identifier_rejected():
+    """table/id_column are developer literals — a non-identifier must raise, not
+    reach string interpolation."""
+    async with aiosqlite.connect(":memory:") as db:
+        with pytest.raises((ValueError, AssertionError)):
+            await _id_resolve.resolve_unique_prefix(
+                db, table="t; DROP TABLE t", id_column="id", raw_id="abcd1234"
+            )

--- a/tests/test_db/test_id_resolve.py
+++ b/tests/test_db/test_id_resolve.py
@@ -88,6 +88,34 @@ async def test_db_error_fails_open():
     assert matches == ["abcd1234"]
 
 
+async def test_tagged_and_padded_full_ids_normalize_on_passthrough():
+    """A full-length id handed in with an ``id:`` tag, surrounding whitespace, or
+    uppercase must pass through as the NORMALIZED id — so the caller's exact lookup
+    still hits the row. Regression: passthrough previously echoed the raw string,
+    so ``id:<32hex>`` reached exact-match lookups un-normalized and missed."""
+    async with aiosqlite.connect(":memory:") as db:
+        await _mk(db, "abcd1234" + "0" * 24)
+        for raw in ("id:" + "f" * 32, "  " + "f" * 32 + "  ", "F" * 32):
+            matches, outcome = await _resolve(db, raw)
+            assert outcome == _id_resolve.PASSTHROUGH, raw
+            assert matches == ["f" * 32], raw
+
+
+async def test_db_error_fail_open_normalizes():
+    """The DB-error fail-open branch must ALSO return the normalized id (parity with
+    the prefix-shape passthrough and the memory resolver) — a short hex prefix with
+    an ``id:`` tag reaches the LIKE query, which raises with no table, then fails
+    open to the normalized ``mid``, not the raw."""
+    async with aiosqlite.connect(":memory:") as db:
+        # No table `t` → the LIKE query raises → fail open. ``id:ABCD`` is a valid
+        # short prefix shape, so it reaches the query rather than the length gate.
+        matches, outcome = await _id_resolve.resolve_unique_prefix(
+            db, table="t", id_column="id", raw_id="id:ABCD"
+        )
+    assert outcome == _id_resolve.PASSTHROUGH
+    assert matches == ["abcd"]
+
+
 async def test_bad_identifier_rejected():
     """table/id_column are developer literals — a non-identifier must raise, not
     reach string interpolation."""

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -561,6 +561,28 @@ async def test_update_full_length_unknown_id_not_prefix_guessed(db):
     assert res.get("error_code") == "not_found", res
 
 
+async def test_update_accepts_id_tagged_full_handle(db):
+    """A full-length id handed in as an ``id:<32hex>`` handle — the exact shape the
+    proactive hook / memory_expand emit — must resolve and update end-to-end. RED
+    before the passthrough-normalization fix: the ``id:``-tagged string reached
+    exact-match get_by_id un-normalized → not_found, silently dropping the update."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="tagged-handle row",
+            reason="r",
+            strategy="user_input_needed",
+            work_state="ready",
+        )
+        fid = created["id"]
+        res = await follow_up_tools._impl_follow_up_update(
+            "id:" + fid, status="completed", resolution_notes="closed via tagged id"
+        )
+    assert "error" not in res, res
+    assert res["id"] == fid
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "completed"
+
+
 # ─── H2: reject the orphan-making status='scheduled' transition ───────────────
 # status='scheduled' is set ONLY by link_task() atomically with linked_task_id.
 # follow_up_update can set the status but not the link, so a manual

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -485,3 +485,131 @@ async def test_notes_only_does_not_write_stale_status(db):
     row = await follow_ups.get_by_id(db, fid)
     assert row["status"] == "completed"  # stale in_progress NOT written back
     assert row["resolution_notes"] == "fg note"
+
+
+# ─── H4a/H4c: short-prefix id resolution + loud failed lookups ────────────────
+# Root cause of the July graph-bake-off loss: a session passed an 8-char id
+# prefix to follow_up_update; exact-match get_by_id returned a soft "not found"
+# dict the session skimmed past, so a hard-dated commitment silently died.
+
+
+async def test_update_accepts_unique_8char_prefix(db):
+    """THE incident repro: an 8-char hex prefix must resolve to the row and the
+    update must land. RED today (exact-match get_by_id → not-found dict)."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="commit the bake-off",
+            reason="r",
+            strategy="user_input_needed",
+            work_state="ready",
+        )
+        fid = created["id"]
+        res = await follow_up_tools._impl_follow_up_update(
+            fid[:8], priority="high", resolution_notes="revived"
+        )
+    assert "error" not in res, res
+    assert res["id"] == fid
+    assert res.get("resolved_from") == fid[:8]
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["priority"] == "high"
+    assert row["resolution_notes"] == "revived"
+
+
+async def test_update_not_found_is_loud(db):
+    """A truly-unknown id must return error_code='not_found' and a message that
+    states the NON-EFFECT explicitly. RED today (bare string, no error_code)."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_update(
+            "ffffffffffffffffffffffffffffffff", status="completed"
+        )
+    assert res.get("error_code") == "not_found", res
+    assert "did NOT" in res["error"] or "NOTHING" in res["error"]
+
+
+async def test_update_ambiguous_prefix_rejected_no_write(db):
+    """An ambiguous prefix must be rejected (error_code='ambiguous_id') and change
+    NOTHING — never guess a row."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        a = await follow_up_tools._impl_follow_up_create(
+            content="row A", reason="r", strategy="ego_judgment", work_state="ready"
+        )
+        b = await follow_up_tools._impl_follow_up_create(
+            content="row B", reason="r", strategy="ego_judgment", work_state="ready"
+        )
+        # Force a shared 8-char prefix.
+        await db.execute(
+            "UPDATE follow_ups SET id = ? WHERE id = ?", ("dead0001" + "a" * 24, a["id"])
+        )
+        await db.execute(
+            "UPDATE follow_ups SET id = ? WHERE id = ?", ("dead0001" + "b" * 24, b["id"])
+        )
+        await db.commit()
+        res = await follow_up_tools._impl_follow_up_update("dead0001", priority="critical")
+    assert res.get("error_code") == "ambiguous_id", res
+    row_a = await follow_ups.get_by_id(db, "dead0001" + "a" * 24)
+    assert row_a["priority"] != "critical"  # no write happened
+
+
+async def test_update_full_length_unknown_id_not_prefix_guessed(db):
+    """A full-length (32-char) unknown id must NOT be prefix-matched to a
+    coincidental longer/shorter row — it passes through to a clean not-found."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        await follow_up_tools._impl_follow_up_create(
+            content="real", reason="r", strategy="ego_judgment", work_state="ready"
+        )
+        res = await follow_up_tools._impl_follow_up_update("0" * 32, status="completed")
+    assert res.get("error_code") == "not_found", res
+
+
+# ─── H2: reject the orphan-making status='scheduled' transition ───────────────
+# status='scheduled' is set ONLY by link_task() atomically with linked_task_id.
+# follow_up_update can set the status but not the link, so a manual
+# follow_up_update(status='scheduled') orphans the row invisibly (not in
+# get_actionable / get_scheduled_due / get_linked_active). This is what July 10
+# attempted. blocked is visible and intentionally NOT gated.
+
+
+async def test_update_scheduled_without_link_rejected(db):
+    """follow_up_update(status='scheduled') on an unlinked row is rejected with
+    error_code='scheduled_needs_link' and changes nothing. RED today (succeeds,
+    orphans the row)."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="revisit later", reason="r", strategy="user_input_needed", work_state="ready"
+        )
+        fid = created["id"]
+        res = await follow_up_tools._impl_follow_up_update(fid, status="scheduled")
+    assert res.get("error_code") == "scheduled_needs_link", res
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "pending"  # unchanged — no orphan created
+
+
+async def test_update_scheduled_with_existing_link_allowed(db):
+    """A row that already carries a linked_task_id CAN be set scheduled (it stays
+    visible via get_linked_active) — the gate only blocks the orphan case."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="linked", reason="r", strategy="surplus_task", work_state="ready"
+        )
+        fid = created["id"]
+        await follow_ups.link_task(db, fid, "task-123")  # sets linked_task_id + scheduled
+        # Move it off scheduled, then re-affirm scheduled via the tool.
+        await follow_ups.update_status(db, fid, "in_progress")
+        res = await follow_up_tools._impl_follow_up_update(fid, status="scheduled")
+    assert "error" not in res, res
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "scheduled"
+
+
+async def test_update_blocked_still_works_untouched(db):
+    """Regression guard: 'blocked' is visible in get_actionable and is NOT gated —
+    the bare-blocked_reason contract stays intact after H2."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="thing", reason="r", strategy="ego_judgment", work_state="ready"
+        )
+        fid = created["id"]
+        res = await follow_up_tools._impl_follow_up_update(fid, blocked_reason="waiting on PR")
+    assert res["status"] == "blocked"
+    actionable = await follow_ups.get_actionable(db, limit=50)
+    assert any(r["id"] == fid for r in actionable)  # still visible


### PR DESCRIPTION
## Why

A hard-dated commitment (the July graph-bake-off row) silently died: a session passed an 8-char id prefix to `follow_up_update`, exact-match `get_by_id` returned a soft `{"error": ...}` dict the session skimmed past, and the update never landed. Root-cause red-team then found the deeper issue — the transition that *creates* invisible rows isn't `blocked` (which is visible in `get_actionable`) but `status='scheduled'` with no `linked_task_id`, which is exactly what that session attempted.

## What (two commits)

**H4a/H4c — id-prefix resolution + loud failures** (`67541e2d`)
- New `db/crud/_id_resolve.py`: shared unique-prefix resolver mirroring the `memory_expand` / `session_charter` resolvers (resolve-or-report-ambiguous, fail-open on DB error, identifier-guarded literals). `follow_ups.resolve_id()` wraps it.
- `follow_up_update` now resolves short hex prefixes, fails **loud** with an additive `error_code` + an explicit non-effect message, and echoes `resolved_from` on success.

**H2 — reject the orphan-making transition** (`67541e2d`)
- `follow_up_update(status='scheduled')` on a row with no `linked_task_id` is rejected (`error_code='scheduled_needs_link'`). That status is set only by `link_task()` atomically with the link; setting it by hand orphans the row invisibly (absent from `get_actionable` / `get_scheduled_due` / `get_linked_active`). `blocked` is intentionally left untouched (it is visible).

**H1 — hourly hygiene watchdog** (`8a17d6fe`)
- `_check_follow_up_watchdog` (awareness hourly band) fires one deduped, self-resolving `infrastructure_alert` (→ morning report) for hot-lane rows stuck as `orphaned_scheduled` (status='scheduled', no link) or `past_due_scheduled` (a `scheduled_task` the dispatcher never actuated — narrowed to still-`pending`+unlinked so healthy dispatched rows don't false-positive). Config lever `follow_up_watchdog` (enabled + grace/max-listed/priority + env kill switch).

## Verification

- New tests: incident repro, 7 resolver cases, H2 gate + guards, full watchdog state machine (20 tests incl. the two review-caught regressions), config degradation, settings validator.
- Broader regression ring: 335 passed. Lint clean.
- **E2E against a copy of the live production DB**: watchdog surfaces the real invisible orphan `b5590faf` (1 alert, idempotent); prefix resolution, scheduled-orphan rejection, and loud not-found all confirmed on real rows.

## Review

feature-dev:code-reviewer on each commit. PR-1: DONE, no findings. PR-2: one BLOCKER (past-due false-positive on dispatched rows) + one SHOULD-FIX (disable-while-open stranded the alert) — both fixed with tests, everything else verified correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)