### PR TITLE
feat(onboarding): tiered readiness model above the functional floor (PR-B1 backend)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1040,7 +1040,16 @@ verified: b662f3e3 2026-07-17
   from the `~/.genesis/setup-complete` marker (which means only "bootstrap
   finished"). Single source of truth shared by three surfaces: the dashboard
   `setup-status` route, the ego cadence gate (`_should_run` requires marker AND
-  `floor_met`), and the CC session-start onboarding prompt.
+  `floor_met`), and the CC session-start onboarding prompt. Above the floor,
+  `readiness.py` layers a cumulative 4-tier model on the same primitives —
+  **T0 Bootstrapped → T1 Functional (`floor_met`) → T2 Connected (proactive
+  Telegram reach: bot token + ≥1 valid `TELEGRAM_ALLOWED_USERS` id, parity-pinned
+  to the live adapter start-gate `channels.bridge._load_bridge_config`) → T3
+  Autonomous (`ego.enabled`)**. Pure over secrets + one injected `ego_enabled`
+  bool (no runtime import on the hot path); web-search/autonomy-posture/surplus are
+  enrichment, never tier gates (autonomy has no on/off switch — it's always
+  initialised and gated per-action by the mandatory approval gate). `setup-status`
+  emits `tier`/`tier_name`/`telegram_configured`/`ego_enabled` additively.
 - **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
   without it interleaved commits pin `in_transaction` until restart). Two
   schema paths coexist: base DDL (`schema/_tables.py`, ~113 CREATE TABLE; docs

--- a/src/genesis/channels/bridge.py
+++ b/src/genesis/channels/bridge.py
@@ -26,6 +26,7 @@ import time
 
 from genesis.cc.conversation import ConversationLoop
 from genesis.cc.system_prompt import SystemPromptAssembler
+from genesis.channels.bridge_config import build_bridge_config, parse_secrets_env_text
 from genesis.channels.config import load_channel_defaults as _load_channel_defaults  # noqa: F401
 from genesis.env import secrets_path
 from genesis.runtime import GenesisRuntime
@@ -49,50 +50,14 @@ def _load_bridge_config() -> dict | None:
         log.error("Secrets file not found: %s — cannot start (broken install?)", path)
         sys.exit(2)
 
-    secrets: dict[str, str] = {}
     with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" in line:
-                key, _, value = line.partition("=")
-                secrets[key.strip()] = value.strip().strip('"')
+        text = f.read()
 
-    token = secrets.get("TELEGRAM_BOT_TOKEN", "")
-    if not token or token == "PLACEHOLDER":  # noqa: S105 - sentinel placeholder, not a credential
-        log.info("TELEGRAM_BOT_TOKEN not set — Telegram adapter will not start")
-        return None
-
-    allowed_users: set[int] = set()
-    allowed_raw = secrets.get("TELEGRAM_ALLOWED_USERS", "")
-    if allowed_raw:
-        for uid in allowed_raw.split(","):
-            uid = uid.strip()
-            if uid.isdigit():
-                allowed_users.add(int(uid))
-            elif uid:
-                log.warning("Invalid UID in TELEGRAM_ALLOWED_USERS: %r", uid)
-
-    if not allowed_users:
-        log.error(
-            "TELEGRAM_ALLOWED_USERS is empty or has no valid user IDs — "
-            "Telegram will not start. Set numeric user IDs "
-            "(get yours from @userinfobot on Telegram)"
-        )
-        return None
-
-    # Optional forum chat ID for per-session topics
-    forum_raw = secrets.get("TELEGRAM_FORUM_CHAT_ID", "")
-    forum_chat_id = int(forum_raw) if forum_raw.strip().lstrip("-").isdigit() else None
-
-    return {
-        "token": token,
-        "allowed_users": allowed_users,
-        "whisper_model": secrets.get("WHISPER_MODEL", "whisper-large-v3"),
-        "day_boundary_hour": int(secrets.get("DAY_BOUNDARY_HOUR", "0")),
-        "forum_chat_id": forum_chat_id,
-    }
+    # Parse + validate via the shared, side-effect-free loader (the SAME code the
+    # onboarding readiness T2 signal uses, so the "would Telegram start?" answer can
+    # never drift between the two). ``log`` threads the adapter's diagnostics; a
+    # malformed value still raises here exactly as before (adapter stays stopped).
+    return build_bridge_config(parse_secrets_env_text(text), log=log)
 
 
 

--- a/src/genesis/channels/bridge_config.py
+++ b/src/genesis/channels/bridge_config.py
@@ -1,0 +1,88 @@
+"""Shared, side-effect-free Telegram bridge-config parser.
+
+The SINGLE source of truth for "given secrets.env content, what Telegram config would
+the adapter load (or None if it can't start)?" — used by BOTH the live adapter
+start-gate (``channels.bridge._load_bridge_config``) and the onboarding readiness T2
+signal (``genesis.onboarding.readiness``), so the two can NEVER diverge on parsing or
+validation. Stdlib-only (no ``GenesisRuntime``, no file IO, no ``sys.exit``) so it is
+safe to import and call on the dashboard hot path.
+
+Parsing mirrors the adapter's historical manual semantics (line-based,
+``key.strip() = value.strip().strip('"')``, ``#``-comment lines skipped) — deliberately
+NOT dotenv, which strips single quotes / inline comments / interpolates ``${VAR}``.
+Malformed values the adapter would choke on (a non-numeric ``DAY_BOUNDARY_HOUR``, or a
+``TELEGRAM_ALLOWED_USERS`` entry that ``str.isdigit()`` accepts but ``int()`` rejects —
+e.g. ``'²'``) RAISE here exactly as they do in the adapter; a caller that must not crash
+(readiness) wraps the call and treats a raise as "not loadable".
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+_TELEGRAM_TOKEN_PLACEHOLDER = "PLACEHOLDER"  # noqa: S105 - sentinel, not a credential
+
+
+def parse_secrets_env_text(text: str) -> dict[str, str]:
+    """Parse ``secrets.env`` TEXT with the adapter's manual semantics (NOT dotenv)."""
+    parsed: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, _, value = line.partition("=")
+            parsed[key.strip()] = value.strip().strip('"')
+    return parsed
+
+
+def build_bridge_config(
+    secrets: Mapping[str, str], *, log: logging.Logger | None = None
+) -> dict | None:
+    """Build the Telegram bridge config from a parsed secrets mapping.
+
+    Returns the config dict, or ``None`` if Telegram cannot start (missing/placeholder
+    token, or no valid numeric recipient). RAISES (``ValueError``) on a value the live
+    adapter would also choke on — a non-numeric ``DAY_BOUNDARY_HOUR``, or a
+    ``TELEGRAM_ALLOWED_USERS`` entry that ``str.isdigit()`` accepts but ``int()`` rejects
+    — so the adapter's fail-to-load behaviour is preserved for its caller. ``log``
+    (optional) receives the adapter's diagnostic messages; readiness passes none (silent
+    on the dashboard hot path).
+    """
+    token = secrets.get("TELEGRAM_BOT_TOKEN", "")
+    if not token or token == _TELEGRAM_TOKEN_PLACEHOLDER:
+        if log:
+            log.info("TELEGRAM_BOT_TOKEN not set — Telegram adapter will not start")
+        return None
+
+    allowed_users: set[int] = set()
+    allowed_raw = secrets.get("TELEGRAM_ALLOWED_USERS", "")
+    if allowed_raw:
+        for uid in allowed_raw.split(","):
+            uid = uid.strip()
+            if uid.isdigit():
+                allowed_users.add(int(uid))
+            elif uid and log:
+                log.warning("Invalid UID in TELEGRAM_ALLOWED_USERS: %r", uid)
+
+    if not allowed_users:
+        if log:
+            log.error(
+                "TELEGRAM_ALLOWED_USERS is empty or has no valid user IDs — "
+                "Telegram will not start. Set numeric user IDs "
+                "(get yours from @userinfobot on Telegram)"
+            )
+        return None
+
+    # Optional forum chat ID for per-session topics.
+    forum_raw = secrets.get("TELEGRAM_FORUM_CHAT_ID", "")
+    forum_chat_id = int(forum_raw) if forum_raw.strip().lstrip("-").isdigit() else None
+
+    return {
+        "token": token,
+        "allowed_users": allowed_users,
+        "whisper_model": secrets.get("WHISPER_MODEL", "whisper-large-v3"),
+        "day_boundary_hour": int(secrets.get("DAY_BOUNDARY_HOUR", "0")),
+        "forum_chat_id": forum_chat_id,
+    }

--- a/src/genesis/dashboard/routes/setup.py
+++ b/src/genesis/dashboard/routes/setup.py
@@ -22,6 +22,7 @@ from flask import jsonify, request
 
 from genesis.dashboard._blueprint import _async_route, blueprint
 from genesis.onboarding.floor import UNSET_SENTINELS, compute_floor, read_persisted_secrets
+from genesis.onboarding.readiness import compute_readiness
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +42,11 @@ def setup_status():
     ``floor_met`` (and its three legs ``cc_oauth`` / ``llm_key_present`` /
     ``embedding_key_present``) is the LIVE "is this Genesis functional" signal;
     ``onboarded`` is the separate "bootstrap finished" marker, kept for display.
+
+    Also emits the cumulative readiness tier ABOVE the floor
+    (``genesis.onboarding.readiness``): ``tier`` (0..3) + ``tier_name`` plus the
+    two gates the floor does not cover — ``telegram_configured`` (T2, proactive
+    reach) and ``ego_enabled`` (T3). All additive; existing fields unchanged.
     """
     # Read secrets.env once; reuse for both the floor and the password check.
     secrets = read_persisted_secrets()
@@ -60,17 +66,32 @@ def setup_status():
     except OSError:
         logger.warning("setup-status: could not read USER.md", exc_info=True)
 
-    return jsonify(
-        {
-            "onboarded": _SETUP_COMPLETE_MARKER.is_file(),
-            "password_set": secrets_have_password,
-            "cc_oauth": floor.cc_oauth,
-            "llm_key_present": floor.llm_key_present,
-            "embedding_key_present": floor.embedding_key_present,
-            "floor_met": floor.floor_met,
-            "identity_set": identity_set,
-        }
-    )
+    # Ego-loop enable state gates T3 (the user-controlled driver of autonomous
+    # behaviour). Resolved fail-safe: this route drives first-run and must NEVER
+    # 500 — an unreadable ego config degrades to "ego off" (worst case shows T2
+    # instead of T3), never a crash. Lazy import (mirrors routes/ego.py) so the
+    # ego module is not pulled at blueprint import time.
+    try:
+        from genesis.ego.config import load_ego_config
+
+        ego_enabled = bool(load_ego_config().enabled)
+    except Exception:  # noqa: BLE001 - setup-status must never raise into first-run
+        logger.warning("setup-status: ego config unreadable; ego_enabled=False", exc_info=True)
+        ego_enabled = False
+
+    readiness = compute_readiness(secrets=secrets, ego_enabled=ego_enabled)
+
+    payload = {
+        "onboarded": _SETUP_COMPLETE_MARKER.is_file(),
+        "password_set": secrets_have_password,
+        "cc_oauth": floor.cc_oauth,
+        "llm_key_present": floor.llm_key_present,
+        "embedding_key_present": floor.embedding_key_present,
+        "floor_met": floor.floor_met,
+        "identity_set": identity_set,
+    }
+    payload.update(readiness.as_dict())
+    return jsonify(payload)
 
 
 @blueprint.route("/api/genesis/keys/test", methods=["POST"])

--- a/src/genesis/dashboard/routes/setup.py
+++ b/src/genesis/dashboard/routes/setup.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from flask import jsonify, request
 
 from genesis.dashboard._blueprint import _async_route, blueprint
-from genesis.onboarding.floor import UNSET_SENTINELS, compute_floor, read_persisted_secrets
+from genesis.onboarding.floor import UNSET_SENTINELS, read_persisted_secrets
 from genesis.onboarding.readiness import compute_readiness
 
 logger = logging.getLogger(__name__)
@@ -48,9 +48,8 @@ def setup_status():
     two gates the floor does not cover — ``telegram_configured`` (T2, proactive
     reach) and ``ego_enabled`` (T3). All additive; existing fields unchanged.
     """
-    # Read secrets.env once; reuse for both the floor and the password check.
+    # Read secrets.env once; reuse for the floor legs and the password check.
     secrets = read_persisted_secrets()
-    floor = compute_floor(secrets=secrets)
     secrets_have_password = secrets.get("DASHBOARD_PASSWORD", "").strip() not in UNSET_SENTINELS
 
     # Identity considered "set" when USER.md exists and differs from its shipped
@@ -79,7 +78,12 @@ def setup_status():
         logger.warning("setup-status: ego config unreadable; ego_enabled=False", exc_info=True)
         ego_enabled = False
 
+    # Compute readiness ONCE and read the floor legs from its snapshot, so the
+    # payload's floor fields and the tier can never disagree (compute_floor reads the
+    # live CC-OAuth state, so a second independent computation could flip mid-request
+    # and report e.g. floor_met=false alongside tier 3 — a cumulative-contract break).
     readiness = compute_readiness(secrets=secrets, ego_enabled=ego_enabled)
+    floor = readiness.floor
 
     payload = {
         "onboarded": _SETUP_COMPLETE_MARKER.is_file(),

--- a/src/genesis/dashboard/routes/setup.py
+++ b/src/genesis/dashboard/routes/setup.py
@@ -78,15 +78,20 @@ def setup_status():
         logger.warning("setup-status: ego config unreadable; ego_enabled=False", exc_info=True)
         ego_enabled = False
 
+    # The setup-complete marker gates T3 (the ego cadence won't run without it), so it
+    # is read ONCE here and threaded into readiness AND the payload — one snapshot, so
+    # `onboarded` and the tier can never contradict each other.
+    onboarded = _SETUP_COMPLETE_MARKER.is_file()
+
     # Compute readiness ONCE and read the floor legs from its snapshot, so the
     # payload's floor fields and the tier can never disagree (compute_floor reads the
     # live CC-OAuth state, so a second independent computation could flip mid-request
     # and report e.g. floor_met=false alongside tier 3 — a cumulative-contract break).
-    readiness = compute_readiness(secrets=secrets, ego_enabled=ego_enabled)
+    readiness = compute_readiness(secrets=secrets, ego_enabled=ego_enabled, onboarded=onboarded)
     floor = readiness.floor
 
     payload = {
-        "onboarded": _SETUP_COMPLETE_MARKER.is_file(),
+        "onboarded": onboarded,
         "password_set": secrets_have_password,
         "cc_oauth": floor.cc_oauth,
         "llm_key_present": floor.llm_key_present,

--- a/src/genesis/onboarding/readiness.py
+++ b/src/genesis/onboarding/readiness.py
@@ -17,11 +17,14 @@ never drift:
   the whole ``GenesisRuntime`` onto the ``setup-status`` hot path and ``sys.exit``\\s on
   a missing file — so both it and readiness call the extracted stdlib-only loader.) A
   parity test still pins the two equal across quoted / commented / malformed shapes.
-* **T3 Autonomous** — the ego/awareness loop is enabled (``ego.enabled``), the
-  user-controlled driver of proactive behaviour. NOTE: the autonomy subsystem has
-  **no on/off switch** — its manager/dispatcher are always initialised on a running
-  install and gated per-action by the mandatory approval gate — so "autonomy" is not
-  a tier gate; the ego loop is the honest signal for "acts on its own".
+* **T3 Autonomous** — the ego/awareness loop is enabled (``ego.enabled``) AND
+  bootstrap is complete (the ``~/.genesis/setup-complete`` marker, surfaced as
+  ``onboarded``). Both are required because ``EgoCadenceManager._should_run()`` rejects
+  every cycle when the marker is absent (``ego/cadence.py``), so an enabled-but-not-yet-
+  onboarded ego cannot actually act. The ego loop is the honest signal for "acts on its
+  own"; the autonomy subsystem itself has **no on/off switch** (its manager/dispatcher
+  are always initialised and gated per-action by the mandatory approval gate), so
+  "autonomy" is not a tier gate.
 
 Tiers are cumulative: a tier is reached only when its own gate AND all lower gates
 are met, so de-configuring a lower capability visibly drops the level (matching the
@@ -29,9 +32,20 @@ floor's live-recompute philosophy). Everything else that makes an install *good*
 rather than *minimal* — web-search availability, autonomy posture, surplus, voice,
 the dashboard password — is enrichment surfaced by the panel, never a tier gate.
 
-Like the floor, readiness is **presence-based and pure over persisted state plus one
-injected bool** (``ego_enabled``, resolved by the route from the ego config so this
-module needs no runtime/ego import) — safe on the ``setup-status`` hot path.
+Like the floor, readiness is **presence-based and pure over persisted state plus two
+injected bools** (``ego_enabled`` from the ego config and ``onboarded`` from the marker,
+both resolved by the route so this module needs no runtime/ego import) — safe on the
+``setup-status`` hot path.
+
+**Presence-based limitation (deliberate):** readiness answers "is this *configured* to
+work", not "is it running right now", exactly as the floor reports "LLM key present"
+even if that provider is momentarily down. It therefore does NOT reflect *runtime*
+disables that leave persisted config intact — e.g. launching with
+``python -m genesis serve --no-telegram`` skips the Telegram adapter
+(``hosting/standalone.py``) while the credentials remain, so T2 still reports Connected.
+Capturing that would require live-runtime coupling on the hot path (and would never end
+— any number of runtime conditions can suppress a configured capability); it is out of
+scope for this signal by design.
 """
 
 from __future__ import annotations
@@ -93,6 +107,7 @@ class ReadinessStatus:
     floor: FloorStatus
     telegram_configured: bool  # T2 — proactive Telegram reach
     ego_enabled: bool  # T3 — ego/awareness loop enabled
+    onboarded: bool  # T3 — ~/.genesis/setup-complete marker (the ego gate needs it)
 
     @property
     def tier(self) -> int:
@@ -101,7 +116,12 @@ class ReadinessStatus:
             return 0
         if not self.telegram_configured:
             return 1
-        if not self.ego_enabled:
+        # T3 (Autonomous) requires BOTH the ego loop enabled AND bootstrap complete:
+        # EgoCadenceManager._should_run() rejects every cycle when the
+        # ~/.genesis/setup-complete marker is absent (ego/cadence.py), so an enabled
+        # ego that is not onboarded still cannot act — reporting Autonomous there
+        # would contradict `onboarded: false`.
+        if not (self.ego_enabled and self.onboarded):
             return 2
         return 3
 
@@ -126,16 +146,18 @@ def compute_readiness(
     secrets: Mapping[str, str] | None = None,
     *,
     ego_enabled: bool,
+    onboarded: bool,
     secrets_text: str | None = None,
 ) -> ReadinessStatus:
     """Compute the cumulative readiness tier.
 
     ``secrets`` (dotenv-parsed) drives the floor legs; ``secrets_text`` (raw
     ``secrets.env`` text) drives the T2 Telegram gate via the adapter's manual parse.
-    Both default to a live read. ``ego_enabled`` is **injected** (not read here) so
-    this module needs no runtime/ego import on the hot path — the route resolves it
-    from the ego config and passes it in. Never raises (delegates to never-raise
-    reads).
+    Both default to a live read. ``ego_enabled`` (ego config) and ``onboarded`` (the
+    ``~/.genesis/setup-complete`` marker) are **injected** — both gate T3, since the
+    ego cadence requires the marker AND ``ego.enabled`` to run — so this module needs
+    no runtime/ego import on the hot path (the route resolves both and passes them in).
+    Never raises (delegates to never-raise reads).
     """
     if secrets is None:
         secrets = read_persisted_secrets()
@@ -146,4 +168,5 @@ def compute_readiness(
         floor=floor,
         telegram_configured=_telegram_reach_configured(secrets_text),
         ego_enabled=bool(ego_enabled),
+        onboarded=bool(onboarded),
     )

--- a/src/genesis/onboarding/readiness.py
+++ b/src/genesis/onboarding/readiness.py
@@ -80,17 +80,37 @@ def _telegram_reach_configured(secrets_text: str) -> bool:
     """Whether Genesis can PROACTIVELY reach the owner via Telegram.
 
     Decided from the RAW ``secrets.env`` text exactly as the live adapter start-gate
-    decides it: a non-empty, non-placeholder ``TELEGRAM_BOT_TOKEN`` AND at least one
-    valid numeric id in ``TELEGRAM_ALLOWED_USERS`` (its first entry seeds the default
-    DM recipient, so without it there is no one to message unprompted). Pure — no
-    file IO, no runtime import.
+    decides it: True only when the live adapter would actually LOAD — a non-empty,
+    non-placeholder ``TELEGRAM_BOT_TOKEN`` AND at least one valid numeric id in
+    ``TELEGRAM_ALLOWED_USERS`` (its first entry seeds the default DM recipient) AND
+    every other setting ``_load_bridge_config`` parses is well-formed. A malformed
+    optional setting (e.g. a non-numeric ``DAY_BOUNDARY_HOUR``) makes the live loader
+    RAISE → ``hosting/standalone.py::_start_telegram`` catches it and leaves Telegram
+    stopped → not reachable, so this returns False too (mirrored so the T2 signal
+    can't claim Connected on a config the adapter refuses to load). Pure — no file
+    IO, no runtime import; never raises.
     """
-    secrets = _parse_secrets_env_text(secrets_text)
-    token = secrets.get("TELEGRAM_BOT_TOKEN", "")
-    if not token or token == _TELEGRAM_TOKEN_PLACEHOLDER:
+    try:
+        secrets = _parse_secrets_env_text(secrets_text)
+        token = secrets.get("TELEGRAM_BOT_TOKEN", "")
+        if not token or token == _TELEGRAM_TOKEN_PLACEHOLDER:
+            return False
+        allowed_raw = secrets.get("TELEGRAM_ALLOWED_USERS", "")
+        if not any(uid.strip().isdigit() for uid in allowed_raw.split(",")):
+            return False
+        # Mirror the remaining conversions ``_load_bridge_config`` performs, so a
+        # value that would make the live loader raise (→ adapter stays stopped) is
+        # reported as NOT reachable, not Connected. ``DAY_BOUNDARY_HOUR`` is the one
+        # unguarded ``int()`` in the loader; ``TELEGRAM_FORUM_CHAT_ID`` is guarded
+        # there and mirrored guarded here. The surrounding try/except is a safety net
+        # for any other conversion the loader may grow.
+        forum_raw = secrets.get("TELEGRAM_FORUM_CHAT_ID", "")
+        if forum_raw.strip().lstrip("-").isdigit():
+            int(forum_raw)
+        int(secrets.get("DAY_BOUNDARY_HOUR", "0"))
+    except (ValueError, TypeError):
         return False
-    allowed_raw = secrets.get("TELEGRAM_ALLOWED_USERS", "")
-    return any(uid.strip().isdigit() for uid in allowed_raw.split(","))
+    return True
 
 
 def _read_secrets_env_text() -> str:
@@ -104,7 +124,10 @@ def _read_secrets_env_text() -> str:
     try:
         path = secrets_path()
         return path.read_text() if path.is_file() else ""
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: missing / permission / disk. ValueError covers UnicodeDecodeError
+        # (its subclass) — a non-UTF-8 secrets.env must degrade to "not configured",
+        # NOT 500 the setup-status route. (``except OSError`` alone let it escape.)
         return ""
 
 

--- a/src/genesis/onboarding/readiness.py
+++ b/src/genesis/onboarding/readiness.py
@@ -1,0 +1,120 @@
+"""Tiered *readiness* — the capability spectrum ABOVE the functional floor.
+
+The floor (:mod:`genesis.onboarding.floor`) answers a single binary question:
+"can this install *think*?" Readiness answers "how far past the floor is it?" — a
+cumulative 4-tier model layered directly on the floor's primitives so the two can
+never drift:
+
+* **T0 Bootstrapped** — install ran but the floor is not yet met (can't think).
+* **T1 Functional** — the floor is met (thinks + remembers).
+* **T2 Connected** — Genesis can PROACTIVELY reach the owner outside the dashboard:
+  a real ``TELEGRAM_BOT_TOKEN`` AND at least one valid numeric user id in
+  ``TELEGRAM_ALLOWED_USERS`` (whose first entry seeds the default DM recipient).
+  This is the exact condition the live adapter's own start-gate enforces
+  (``channels.bridge._load_bridge_config``) — replicated here as a pure,
+  hot-path-safe secrets read (importing the bridge would drag the whole
+  ``GenesisRuntime`` onto the ``setup-status`` path) and pinned to the real gate by
+  a parity test.
+* **T3 Autonomous** — the ego/awareness loop is enabled (``ego.enabled``), the
+  user-controlled driver of proactive behaviour. NOTE: the autonomy subsystem has
+  **no on/off switch** — its manager/dispatcher are always initialised on a running
+  install and gated per-action by the mandatory approval gate — so "autonomy" is not
+  a tier gate; the ego loop is the honest signal for "acts on its own".
+
+Tiers are cumulative: a tier is reached only when its own gate AND all lower gates
+are met, so de-configuring a lower capability visibly drops the level (matching the
+floor's live-recompute philosophy). Everything else that makes an install *good*
+rather than *minimal* — web-search availability, autonomy posture, surplus, voice,
+the dashboard password — is enrichment surfaced by the panel, never a tier gate.
+
+Like the floor, readiness is **presence-based and pure over persisted secrets plus
+one injected bool** (``ego_enabled``, resolved by the route from the ego config so
+this module needs no runtime/ego import) — safe on the ``setup-status`` hot path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from genesis.onboarding.floor import FloorStatus, compute_floor, read_persisted_secrets
+
+# The token sentinel the live adapter treats as "unset"
+# (``channels.bridge._load_bridge_config``) — kept in exact sync by
+# ``tests/test_onboarding/test_readiness.py::test_telegram_reach_parity_with_bridge``.
+_TELEGRAM_TOKEN_PLACEHOLDER = "PLACEHOLDER"  # noqa: S105 - sentinel, not a credential
+
+_TIER_NAMES = {0: "Bootstrapped", 1: "Functional", 2: "Connected", 3: "Autonomous"}
+
+
+def _telegram_reach_configured(secrets: Mapping[str, str]) -> bool:
+    """Whether Genesis can PROACTIVELY reach the owner via Telegram.
+
+    Mirrors the live adapter start-gate (``channels.bridge._load_bridge_config``): a
+    non-empty, non-placeholder ``TELEGRAM_BOT_TOKEN`` AND at least one valid numeric
+    user id in ``TELEGRAM_ALLOWED_USERS`` (its first entry seeds the default DM
+    recipient, so without it there is no one to message unprompted). Pure secrets
+    read — no runtime import. Pinned to the real gate by a parity test.
+    """
+    token = str(secrets.get("TELEGRAM_BOT_TOKEN", "")).strip()
+    if not token or token == _TELEGRAM_TOKEN_PLACEHOLDER:
+        return False
+    allowed_raw = str(secrets.get("TELEGRAM_ALLOWED_USERS", ""))
+    return any(part.strip().isdigit() for part in allowed_raw.split(","))
+
+
+@dataclass(frozen=True)
+class ReadinessStatus:
+    """The readiness gates and the cumulative tier they imply."""
+
+    floor: FloorStatus
+    telegram_configured: bool  # T2 — proactive Telegram reach
+    ego_enabled: bool  # T3 — ego/awareness loop enabled
+
+    @property
+    def tier(self) -> int:
+        """0..3, cumulative — the highest tier whose gate AND all lower gates hold."""
+        if not self.floor.floor_met:
+            return 0
+        if not self.telegram_configured:
+            return 1
+        if not self.ego_enabled:
+            return 2
+        return 3
+
+    @property
+    def tier_name(self) -> str:
+        return _TIER_NAMES[self.tier]
+
+    def as_dict(self) -> dict[str, object]:
+        # Only the readiness-specific fields — the floor legs (``cc_oauth`` /
+        # ``llm_key_present`` / ``embedding_key_present`` / ``floor_met``) are already
+        # emitted by the ``setup-status`` route, so re-emitting them here would
+        # duplicate keys.
+        return {
+            "tier": self.tier,
+            "tier_name": self.tier_name,
+            "telegram_configured": self.telegram_configured,
+            "ego_enabled": self.ego_enabled,
+        }
+
+
+def compute_readiness(
+    secrets: Mapping[str, str] | None = None, *, ego_enabled: bool
+) -> ReadinessStatus:
+    """Compute the cumulative readiness tier from persisted secrets + ego state.
+
+    ``ego_enabled`` is **injected** (not read here) so this module stays pure over
+    ``secrets`` with no runtime/ego import on the hot path — the route resolves it
+    from the ego config and passes it in. ``secrets`` defaults to a live
+    ``read_persisted_secrets()`` read. Never raises (delegates to the floor's own
+    never-raise reads).
+    """
+    if secrets is None:
+        secrets = read_persisted_secrets()
+    floor = compute_floor(secrets=secrets)
+    return ReadinessStatus(
+        floor=floor,
+        telegram_configured=_telegram_reach_configured(secrets),
+        ego_enabled=bool(ego_enabled),
+    )

--- a/src/genesis/onboarding/readiness.py
+++ b/src/genesis/onboarding/readiness.py
@@ -10,11 +10,15 @@ never drift:
 * **T2 Connected** — Genesis can PROACTIVELY reach the owner outside the dashboard:
   a real ``TELEGRAM_BOT_TOKEN`` AND at least one valid numeric user id in
   ``TELEGRAM_ALLOWED_USERS`` (whose first entry seeds the default DM recipient).
-  This is the exact condition the live adapter's own start-gate enforces
-  (``channels.bridge._load_bridge_config``) — replicated here as a pure,
-  hot-path-safe secrets read (importing the bridge would drag the whole
-  ``GenesisRuntime`` onto the ``setup-status`` path) and pinned to the real gate by
-  a parity test.
+  This is the EXACT condition the live adapter's own start-gate enforces
+  (``channels.bridge._load_bridge_config``) — and it is computed the same way that
+  gate computes it: the **raw** ``secrets.env`` text parsed with the adapter's own
+  manual parser (see ``_parse_secrets_env_text``), NOT the floor's dotenv view.
+  (Importing the bridge to reuse the gate directly would drag the whole
+  ``GenesisRuntime`` onto the ``setup-status`` hot path, and ``_load_bridge_config``
+  additionally ``sys.exit``\\s on a missing file — neither is acceptable here.) The
+  two parsers are pinned equal by a parity test across quoted / commented /
+  interpolated shapes.
 * **T3 Autonomous** — the ego/awareness loop is enabled (``ego.enabled``), the
   user-controlled driver of proactive behaviour. NOTE: the autonomy subsystem has
   **no on/off switch** — its manager/dispatcher are always initialised on a running
@@ -27,9 +31,9 @@ floor's live-recompute philosophy). Everything else that makes an install *good*
 rather than *minimal* — web-search availability, autonomy posture, surplus, voice,
 the dashboard password — is enrichment surfaced by the panel, never a tier gate.
 
-Like the floor, readiness is **presence-based and pure over persisted secrets plus
-one injected bool** (``ego_enabled``, resolved by the route from the ego config so
-this module needs no runtime/ego import) — safe on the ``setup-status`` hot path.
+Like the floor, readiness is **presence-based and pure over persisted state plus one
+injected bool** (``ego_enabled``, resolved by the route from the ego config so this
+module needs no runtime/ego import) — safe on the ``setup-status`` hot path.
 """
 
 from __future__ import annotations
@@ -37,30 +41,71 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from genesis.env import secrets_path
 from genesis.onboarding.floor import FloorStatus, compute_floor, read_persisted_secrets
 
 # The token sentinel the live adapter treats as "unset"
-# (``channels.bridge._load_bridge_config``) — kept in exact sync by
-# ``tests/test_onboarding/test_readiness.py::test_telegram_reach_parity_with_bridge``.
+# (``channels.bridge._load_bridge_config``).
 _TELEGRAM_TOKEN_PLACEHOLDER = "PLACEHOLDER"  # noqa: S105 - sentinel, not a credential
 
 _TIER_NAMES = {0: "Bootstrapped", 1: "Functional", 2: "Connected", 3: "Autonomous"}
 
 
-def _telegram_reach_configured(secrets: Mapping[str, str]) -> bool:
+def _parse_secrets_env_text(text: str) -> dict[str, str]:
+    """Parse ``secrets.env`` TEXT with the SAME manual semantics the live Telegram
+    adapter uses (``channels.bridge._load_bridge_config``): line-based,
+    ``key.strip() = value.strip().strip('"')``, ``#``-prefixed and blank lines
+    skipped.
+
+    Deliberately NOT dotenv: dotenv additionally strips *single* quotes, strips
+    *inline* ``# comments``, and interpolates ``${VAR}`` — so a hand-edited
+    ``TELEGRAM_ALLOWED_USERS='12345'`` would parse to a valid id under dotenv but is
+    rejected by the adapter's manual parser. The adapter's parse is the ground truth
+    for whether Telegram can actually start, so the T2 signal mirrors it exactly
+    (pinned by ``tests/test_onboarding/test_readiness.py::
+    test_telegram_reach_parity_with_bridge``).
+    """
+    parsed: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, _, value = line.partition("=")
+            parsed[key.strip()] = value.strip().strip('"')
+    return parsed
+
+
+def _telegram_reach_configured(secrets_text: str) -> bool:
     """Whether Genesis can PROACTIVELY reach the owner via Telegram.
 
-    Mirrors the live adapter start-gate (``channels.bridge._load_bridge_config``): a
-    non-empty, non-placeholder ``TELEGRAM_BOT_TOKEN`` AND at least one valid numeric
-    user id in ``TELEGRAM_ALLOWED_USERS`` (its first entry seeds the default DM
-    recipient, so without it there is no one to message unprompted). Pure secrets
-    read — no runtime import. Pinned to the real gate by a parity test.
+    Decided from the RAW ``secrets.env`` text exactly as the live adapter start-gate
+    decides it: a non-empty, non-placeholder ``TELEGRAM_BOT_TOKEN`` AND at least one
+    valid numeric id in ``TELEGRAM_ALLOWED_USERS`` (its first entry seeds the default
+    DM recipient, so without it there is no one to message unprompted). Pure — no
+    file IO, no runtime import.
     """
-    token = str(secrets.get("TELEGRAM_BOT_TOKEN", "")).strip()
+    secrets = _parse_secrets_env_text(secrets_text)
+    token = secrets.get("TELEGRAM_BOT_TOKEN", "")
     if not token or token == _TELEGRAM_TOKEN_PLACEHOLDER:
         return False
-    allowed_raw = str(secrets.get("TELEGRAM_ALLOWED_USERS", ""))
-    return any(part.strip().isdigit() for part in allowed_raw.split(","))
+    allowed_raw = secrets.get("TELEGRAM_ALLOWED_USERS", "")
+    return any(uid.strip().isdigit() for uid in allowed_raw.split(","))
+
+
+def _read_secrets_env_text() -> str:
+    """Raw ``secrets.env`` text for the T2 manual parse; never raises.
+
+    A missing file (fresh install) or an unreadable one yields ``""`` → "telegram not
+    configured", never an exception onto the ``setup-status`` route. (Unlike the
+    adapter's ``_load_bridge_config``, which ``sys.exit``\\s on a missing file — wrong
+    behaviour for a dashboard hot path.)
+    """
+    try:
+        path = secrets_path()
+        return path.read_text() if path.is_file() else ""
+    except OSError:
+        return ""
 
 
 @dataclass(frozen=True)
@@ -100,21 +145,27 @@ class ReadinessStatus:
 
 
 def compute_readiness(
-    secrets: Mapping[str, str] | None = None, *, ego_enabled: bool
+    secrets: Mapping[str, str] | None = None,
+    *,
+    ego_enabled: bool,
+    secrets_text: str | None = None,
 ) -> ReadinessStatus:
-    """Compute the cumulative readiness tier from persisted secrets + ego state.
+    """Compute the cumulative readiness tier.
 
-    ``ego_enabled`` is **injected** (not read here) so this module stays pure over
-    ``secrets`` with no runtime/ego import on the hot path — the route resolves it
-    from the ego config and passes it in. ``secrets`` defaults to a live
-    ``read_persisted_secrets()`` read. Never raises (delegates to the floor's own
-    never-raise reads).
+    ``secrets`` (dotenv-parsed) drives the floor legs; ``secrets_text`` (raw
+    ``secrets.env`` text) drives the T2 Telegram gate via the adapter's manual parse.
+    Both default to a live read. ``ego_enabled`` is **injected** (not read here) so
+    this module needs no runtime/ego import on the hot path — the route resolves it
+    from the ego config and passes it in. Never raises (delegates to never-raise
+    reads).
     """
     if secrets is None:
         secrets = read_persisted_secrets()
+    if secrets_text is None:
+        secrets_text = _read_secrets_env_text()
     floor = compute_floor(secrets=secrets)
     return ReadinessStatus(
         floor=floor,
-        telegram_configured=_telegram_reach_configured(secrets),
+        telegram_configured=_telegram_reach_configured(secrets_text),
         ego_enabled=bool(ego_enabled),
     )

--- a/src/genesis/onboarding/readiness.py
+++ b/src/genesis/onboarding/readiness.py
@@ -10,15 +10,13 @@ never drift:
 * **T2 Connected** — Genesis can PROACTIVELY reach the owner outside the dashboard:
   a real ``TELEGRAM_BOT_TOKEN`` AND at least one valid numeric user id in
   ``TELEGRAM_ALLOWED_USERS`` (whose first entry seeds the default DM recipient).
-  This is the EXACT condition the live adapter's own start-gate enforces
-  (``channels.bridge._load_bridge_config``) — and it is computed the same way that
-  gate computes it: the **raw** ``secrets.env`` text parsed with the adapter's own
-  manual parser (see ``_parse_secrets_env_text``), NOT the floor's dotenv view.
-  (Importing the bridge to reuse the gate directly would drag the whole
-  ``GenesisRuntime`` onto the ``setup-status`` hot path, and ``_load_bridge_config``
-  additionally ``sys.exit``\\s on a missing file — neither is acceptable here.) The
-  two parsers are pinned equal by a parity test across quoted / commented /
-  interpolated shapes.
+  This is the EXACT condition the live adapter's own start-gate enforces — it runs the
+  SAME side-effect-free loader (``channels.bridge_config.build_bridge_config`` over the
+  raw ``secrets.env`` text, NOT the floor's dotenv view), so the two cannot drift.
+  (``channels.bridge._load_bridge_config`` itself can't be reused directly — it drags
+  the whole ``GenesisRuntime`` onto the ``setup-status`` hot path and ``sys.exit``\\s on
+  a missing file — so both it and readiness call the extracted stdlib-only loader.) A
+  parity test still pins the two equal across quoted / commented / malformed shapes.
 * **T3 Autonomous** — the ego/awareness loop is enabled (``ego.enabled``), the
   user-controlled driver of proactive behaviour. NOTE: the autonomy subsystem has
   **no on/off switch** — its manager/dispatcher are always initialised on a running
@@ -41,76 +39,33 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from genesis.channels.bridge_config import build_bridge_config, parse_secrets_env_text
 from genesis.env import secrets_path
 from genesis.onboarding.floor import FloorStatus, compute_floor, read_persisted_secrets
 
-# The token sentinel the live adapter treats as "unset"
-# (``channels.bridge._load_bridge_config``).
-_TELEGRAM_TOKEN_PLACEHOLDER = "PLACEHOLDER"  # noqa: S105 - sentinel, not a credential
-
 _TIER_NAMES = {0: "Bootstrapped", 1: "Functional", 2: "Connected", 3: "Autonomous"}
-
-
-def _parse_secrets_env_text(text: str) -> dict[str, str]:
-    """Parse ``secrets.env`` TEXT with the SAME manual semantics the live Telegram
-    adapter uses (``channels.bridge._load_bridge_config``): line-based,
-    ``key.strip() = value.strip().strip('"')``, ``#``-prefixed and blank lines
-    skipped.
-
-    Deliberately NOT dotenv: dotenv additionally strips *single* quotes, strips
-    *inline* ``# comments``, and interpolates ``${VAR}`` — so a hand-edited
-    ``TELEGRAM_ALLOWED_USERS='12345'`` would parse to a valid id under dotenv but is
-    rejected by the adapter's manual parser. The adapter's parse is the ground truth
-    for whether Telegram can actually start, so the T2 signal mirrors it exactly
-    (pinned by ``tests/test_onboarding/test_readiness.py::
-    test_telegram_reach_parity_with_bridge``).
-    """
-    parsed: dict[str, str] = {}
-    for line in text.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if "=" in line:
-            key, _, value = line.partition("=")
-            parsed[key.strip()] = value.strip().strip('"')
-    return parsed
 
 
 def _telegram_reach_configured(secrets_text: str) -> bool:
     """Whether Genesis can PROACTIVELY reach the owner via Telegram.
 
-    Decided from the RAW ``secrets.env`` text exactly as the live adapter start-gate
-    decides it: True only when the live adapter would actually LOAD — a non-empty,
-    non-placeholder ``TELEGRAM_BOT_TOKEN`` AND at least one valid numeric id in
-    ``TELEGRAM_ALLOWED_USERS`` (its first entry seeds the default DM recipient) AND
-    every other setting ``_load_bridge_config`` parses is well-formed. A malformed
-    optional setting (e.g. a non-numeric ``DAY_BOUNDARY_HOUR``) makes the live loader
-    RAISE → ``hosting/standalone.py::_start_telegram`` catches it and leaves Telegram
-    stopped → not reachable, so this returns False too (mirrored so the T2 signal
-    can't claim Connected on a config the adapter refuses to load). Pure — no file
-    IO, no runtime import; never raises.
+    Delegates to the **same** side-effect-free loader the live adapter start-gate uses
+    (``channels.bridge_config``): True iff ``build_bridge_config`` returns a config for
+    the raw ``secrets.env`` text — i.e. the adapter would actually load (non-empty,
+    non-placeholder token AND ≥1 valid numeric ``TELEGRAM_ALLOWED_USERS`` id AND every
+    other parsed setting well-formed). Because it runs the loader's OWN code rather than
+    a copy, the T2 signal cannot drift from what Telegram will actually do.
+
+    A value the loader chokes on (a non-numeric ``DAY_BOUNDARY_HOUR``; a
+    ``TELEGRAM_ALLOWED_USERS`` entry that ``str.isdigit()`` accepts but ``int()`` rejects,
+    e.g. ``'²'``) makes ``build_bridge_config`` RAISE → the adapter would stay stopped →
+    not reachable, so this catches it and returns False. Pure — no file IO, no runtime
+    import, never raises. ``log`` is omitted so the loader is silent on the hot path.
     """
     try:
-        secrets = _parse_secrets_env_text(secrets_text)
-        token = secrets.get("TELEGRAM_BOT_TOKEN", "")
-        if not token or token == _TELEGRAM_TOKEN_PLACEHOLDER:
-            return False
-        allowed_raw = secrets.get("TELEGRAM_ALLOWED_USERS", "")
-        if not any(uid.strip().isdigit() for uid in allowed_raw.split(",")):
-            return False
-        # Mirror the remaining conversions ``_load_bridge_config`` performs, so a
-        # value that would make the live loader raise (→ adapter stays stopped) is
-        # reported as NOT reachable, not Connected. ``DAY_BOUNDARY_HOUR`` is the one
-        # unguarded ``int()`` in the loader; ``TELEGRAM_FORUM_CHAT_ID`` is guarded
-        # there and mirrored guarded here. The surrounding try/except is a safety net
-        # for any other conversion the loader may grow.
-        forum_raw = secrets.get("TELEGRAM_FORUM_CHAT_ID", "")
-        if forum_raw.strip().lstrip("-").isdigit():
-            int(forum_raw)
-        int(secrets.get("DAY_BOUNDARY_HOUR", "0"))
+        return build_bridge_config(parse_secrets_env_text(secrets_text)) is not None
     except (ValueError, TypeError):
         return False
-    return True
 
 
 def _read_secrets_env_text() -> str:

--- a/tests/test_dashboard/test_setup_wizard_api.py
+++ b/tests/test_dashboard/test_setup_wizard_api.py
@@ -228,6 +228,27 @@ def test_setup_status_readiness_fields_backward_compatible(wiz):
         assert key in body
 
 
+def test_setup_status_floor_computed_once_snapshot_consistent(wiz):
+    # Regression (Codex #1318): the route must compute the floor ONCE. If
+    # cc_oauth_present flips between calls, a double-computation would let floor_met
+    # (payload) and the tier's floor basis disagree (e.g. floor_met=false + tier 3).
+    calls = {"n": 0}
+
+    def flaky_oauth():
+        calls["n"] += 1
+        return calls["n"] == 1  # True on the first read, False on any later read
+
+    wiz["monkeypatch"].setattr(floor_mod, "cc_oauth_present", flaky_oauth)
+    wiz["secrets"].write_text(
+        _functional_secrets() + "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n"
+    )
+    body = wiz["client"].get("/api/genesis/setup-status").get_json()
+    assert calls["n"] == 1, "floor must be computed exactly once per request"
+    # One snapshot → floor_met and the tier agree (tier>=1 iff floor met).
+    assert body["floor_met"] is True
+    assert body["tier"] >= 1
+
+
 def test_keys_test_missing_fields_returns_400(wiz):
     resp = wiz["client"].post("/api/genesis/keys/test", json={"provider_type": "groq"})
     assert resp.status_code == 400

--- a/tests/test_dashboard/test_setup_wizard_api.py
+++ b/tests/test_dashboard/test_setup_wizard_api.py
@@ -35,6 +35,11 @@ def wiz(tmp_path, monkeypatch):
     monkeypatch.setattr(setup_mod, "_SETUP_COMPLETE_MARKER", marker)
     # setup.py reads secrets via the floor module now — patch it there.
     monkeypatch.setattr(floor_mod, "secrets_path", lambda: secrets_file)
+    # readiness reads the RAW secrets.env text (T2 manual parse) via its OWN
+    # secrets_path import — patch it too so T2 sees the temp file, not the real box.
+    import genesis.onboarding.readiness as readiness_mod
+
+    monkeypatch.setattr(readiness_mod, "secrets_path", lambda: secrets_file)
     # Default: CC is logged in. Individual tests override for floor-leg coverage.
     monkeypatch.setattr(floor_mod, "cc_oauth_present", lambda: True)
 

--- a/tests/test_dashboard/test_setup_wizard_api.py
+++ b/tests/test_dashboard/test_setup_wizard_api.py
@@ -179,16 +179,25 @@ def test_setup_status_token_without_allowed_users_stays_tier1(wiz):
     assert body["tier"] == 1
 
 
-def test_setup_status_tier3_autonomous_when_ego_enabled(wiz):
-    # Floor + telegram + ego loop enabled → Autonomous (T3).
+def test_setup_status_tier3_autonomous_needs_ego_and_marker(wiz):
+    # Floor + telegram + ego loop enabled + bootstrap marker → Autonomous (T3).
     wiz["secrets"].write_text(
         _functional_secrets() + "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n"
     )
     wiz["monkeypatch"].setattr(
         wiz["ego_config"], "load_ego_config", lambda *a, **k: SimpleNamespace(enabled=True)
     )
+    # Without the setup-complete marker the ego cadence can't run → capped at T2,
+    # and `onboarded` must not be True alongside an Autonomous tier.
     body = wiz["client"].get("/api/genesis/setup-status").get_json()
     assert body["ego_enabled"] is True
+    assert body["onboarded"] is False
+    assert body["tier"] == 2
+
+    # With the marker present, the same config reaches Autonomous.
+    wiz["marker"].write_text("2026-08-06\n")
+    body = wiz["client"].get("/api/genesis/setup-status").get_json()
+    assert body["onboarded"] is True
     assert body["tier"] == 3
     assert body["tier_name"] == "Autonomous"
 

--- a/tests/test_dashboard/test_setup_wizard_api.py
+++ b/tests/test_dashboard/test_setup_wizard_api.py
@@ -10,6 +10,8 @@ caller-supplied base_url (SSRF guard).
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from flask import Flask
 
@@ -36,12 +38,21 @@ def wiz(tmp_path, monkeypatch):
     # Default: CC is logged in. Individual tests override for floor-leg coverage.
     monkeypatch.setattr(floor_mod, "cc_oauth_present", lambda: True)
 
+    # The route lazy-imports load_ego_config from its source module — patch it there.
+    # Default: ego loop OFF (so tier hinges on what each test configures).
+    import genesis.ego.config as ego_config_mod
+
+    monkeypatch.setattr(
+        ego_config_mod, "load_ego_config", lambda *a, **k: SimpleNamespace(enabled=False)
+    )
+
     return {
         "client": app.test_client(),
         "identity": identity,
         "secrets": secrets_file,
         "marker": marker,
         "monkeypatch": monkeypatch,
+        "ego_config": ego_config_mod,
     }
 
 
@@ -57,6 +68,11 @@ def test_setup_status_fresh_install(wiz):
         "embedding_key_present": False,
         "floor_met": False,
         "identity_set": False,
+        # readiness fields (additive) — fresh box is Bootstrapped/T0.
+        "tier": 0,
+        "tier_name": "Bootstrapped",
+        "telegram_configured": False,
+        "ego_enabled": False,
     }
 
 
@@ -129,6 +145,82 @@ def test_setup_status_identity_set_only_when_differs_from_example(wiz):
     # customized → set
     (wiz["identity"] / "USER.md").write_text("I am the real user.\n")
     assert wiz["client"].get("/api/genesis/setup-status").get_json()["identity_set"] is True
+
+
+def _functional_secrets() -> str:
+    # cc_oauth is True via the fixture; groq (LLM) + deepinfra (embedding) → floor met.
+    return "API_KEY_GROQ=g\nAPI_KEY_DEEPINFRA=d\n"
+
+
+def test_setup_status_tier2_connected_needs_token_and_allowed_users(wiz):
+    # Floor met + a valid Telegram proactive-reach config (token + numeric UID),
+    # ego OFF → Connected (T2).
+    wiz["secrets"].write_text(
+        _functional_secrets() + "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n"
+    )
+    body = wiz["client"].get("/api/genesis/setup-status").get_json()
+    assert body["floor_met"] is True
+    assert body["telegram_configured"] is True
+    assert body["ego_enabled"] is False
+    assert body["tier"] == 2
+    assert body["tier_name"] == "Connected"
+
+
+def test_setup_status_token_without_allowed_users_stays_tier1(wiz):
+    # A bot token but no valid recipient can't proactively reach → NOT Connected.
+    wiz["secrets"].write_text(_functional_secrets() + "TELEGRAM_BOT_TOKEN=abc\n")
+    body = wiz["client"].get("/api/genesis/setup-status").get_json()
+    assert body["telegram_configured"] is False
+    assert body["tier"] == 1
+
+
+def test_setup_status_tier3_autonomous_when_ego_enabled(wiz):
+    # Floor + telegram + ego loop enabled → Autonomous (T3).
+    wiz["secrets"].write_text(
+        _functional_secrets() + "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n"
+    )
+    wiz["monkeypatch"].setattr(
+        wiz["ego_config"], "load_ego_config", lambda *a, **k: SimpleNamespace(enabled=True)
+    )
+    body = wiz["client"].get("/api/genesis/setup-status").get_json()
+    assert body["ego_enabled"] is True
+    assert body["tier"] == 3
+    assert body["tier_name"] == "Autonomous"
+
+
+def test_setup_status_ego_config_unreadable_is_failsafe_not_500(wiz):
+    # An ego config that raises must degrade to ego_enabled=False, NEVER 500 the
+    # first-run route.
+    def _boom(*a, **k):
+        raise RuntimeError("ego.yaml corrupt")
+
+    wiz["monkeypatch"].setattr(wiz["ego_config"], "load_ego_config", _boom)
+    wiz["secrets"].write_text(
+        _functional_secrets() + "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n"
+    )
+    resp = wiz["client"].get("/api/genesis/setup-status")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ego_enabled"] is False
+    assert body["tier"] == 2  # capped at Connected without ego
+
+
+def test_setup_status_readiness_fields_backward_compatible(wiz):
+    # The original floor fields must be unchanged/still present alongside the new ones.
+    wiz["secrets"].write_text(_functional_secrets())
+    body = wiz["client"].get("/api/genesis/setup-status").get_json()
+    for key in (
+        "onboarded",
+        "password_set",
+        "cc_oauth",
+        "llm_key_present",
+        "embedding_key_present",
+        "floor_met",
+        "identity_set",
+    ):
+        assert key in body
+    for key in ("tier", "tier_name", "telegram_configured", "ego_enabled"):
+        assert key in body
 
 
 def test_keys_test_missing_fields_returns_400(wiz):

--- a/tests/test_onboarding/test_readiness.py
+++ b/tests/test_onboarding/test_readiness.py
@@ -32,8 +32,15 @@ def _floor(met: bool) -> FloorStatus:
     return FloorStatus(cc_oauth=met, llm_key_present=met, embedding_key_present=met)
 
 
-def _status(*, floor_met: bool, telegram: bool, ego: bool) -> ReadinessStatus:
-    return ReadinessStatus(floor=_floor(floor_met), telegram_configured=telegram, ego_enabled=ego)
+def _status(
+    *, floor_met: bool, telegram: bool, ego: bool, onboarded: bool = True
+) -> ReadinessStatus:
+    return ReadinessStatus(
+        floor=_floor(floor_met),
+        telegram_configured=telegram,
+        ego_enabled=ego,
+        onboarded=onboarded,
+    )
 
 
 # ── Tier truth table (the cumulative gate logic) ───────────────────────────────
@@ -68,6 +75,14 @@ def test_ego_without_telegram_does_not_reach_tier3():
     assert _status(floor_met=True, telegram=False, ego=True).tier == 1
 
 
+def test_not_onboarded_caps_at_tier2():
+    # Ego enabled but bootstrap marker absent → the ego cadence can't run, so T3 is
+    # NOT reached (avoids "onboarded: false" alongside Autonomous).
+    assert _status(floor_met=True, telegram=True, ego=True, onboarded=False).tier == 2
+    # With the marker present, the same config reaches T3.
+    assert _status(floor_met=True, telegram=True, ego=True, onboarded=True).tier == 3
+
+
 def test_tier_names_cover_every_tier():
     names = {
         _status(floor_met=fm, telegram=tg, ego=eg).tier_name
@@ -89,8 +104,8 @@ def test_as_dict_shape_excludes_floor_legs():
         "telegram_configured": True,
         "ego_enabled": True,
     }
-    # Floor legs are emitted by the route, NOT duplicated here.
-    assert "floor_met" not in d and "cc_oauth" not in d
+    # Floor legs AND `onboarded` are emitted by the route, NOT duplicated here.
+    assert "floor_met" not in d and "cc_oauth" not in d and "onboarded" not in d
 
 
 # ── T2 gate: _telegram_reach_configured (raw-text, adapter-manual semantics) ────
@@ -231,11 +246,17 @@ def floor_met(monkeypatch):
     # embedding leg is _has_any(secrets, EMBEDDING_KEY_NAMES) — supply a key below.
 
 
-def test_compute_readiness_threads_secrets_text_and_ego(floor_met):
+def test_compute_readiness_threads_secrets_text_ego_and_onboarded(floor_met):
     secrets = {"API_KEY_DEEPINFRA": "di-xxx"}  # satisfies the floor embedding leg
     tg = "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n"
-    assert compute_readiness(secrets=secrets, secrets_text=tg, ego_enabled=False).tier == 2
-    assert compute_readiness(secrets=secrets, secrets_text=tg, ego_enabled=True).tier == 3
+    base = dict(secrets=secrets, secrets_text=tg, onboarded=True)
+    assert compute_readiness(**base, ego_enabled=False).tier == 2
+    assert compute_readiness(**base, ego_enabled=True).tier == 3
+    # Ego enabled but NOT onboarded (marker absent) → capped at T2.
+    assert (
+        compute_readiness(secrets=secrets, secrets_text=tg, ego_enabled=True, onboarded=False).tier
+        == 2
+    )
 
 
 def test_compute_readiness_reads_file_when_text_omitted(floor_met, tmp_path, monkeypatch):
@@ -243,7 +264,7 @@ def test_compute_readiness_reads_file_when_text_omitted(floor_met, tmp_path, mon
     secrets_file = tmp_path / "secrets.env"
     secrets_file.write_text("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n")
     monkeypatch.setattr(readiness_mod, "secrets_path", lambda: secrets_file)
-    r = compute_readiness(secrets={"API_KEY_DEEPINFRA": "d"}, ego_enabled=False)
+    r = compute_readiness(secrets={"API_KEY_DEEPINFRA": "d"}, ego_enabled=False, onboarded=True)
     assert r.telegram_configured is True
     assert r.tier == 2
 
@@ -251,7 +272,7 @@ def test_compute_readiness_reads_file_when_text_omitted(floor_met, tmp_path, mon
 def test_compute_readiness_floor_reuse_parity(floor_met):
     # readiness.floor must BE the floor's own computation (no drift).
     secrets = {"API_KEY_DEEPINFRA": "di-xxx"}
-    r = compute_readiness(secrets=secrets, secrets_text="", ego_enabled=False)
+    r = compute_readiness(secrets=secrets, secrets_text="", ego_enabled=False, onboarded=True)
     assert r.floor.as_dict() == floor_mod.compute_floor(secrets=secrets).as_dict()
     assert r.floor.floor_met is True
 
@@ -261,10 +282,14 @@ def test_compute_readiness_floor_unmet_is_tier0(monkeypatch):
     # telegram + ego "configured".
     monkeypatch.setattr(floor_mod, "cc_oauth_present", lambda: False)
     tg = "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n"
-    assert compute_readiness(secrets={}, secrets_text=tg, ego_enabled=True).tier == 0
+    assert (
+        compute_readiness(secrets={}, secrets_text=tg, ego_enabled=True, onboarded=True).tier == 0
+    )
 
 
 def test_compute_readiness_ego_flag_is_coerced_bool(floor_met):
     tg = "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=1\n"
-    r = compute_readiness(secrets={"API_KEY_DEEPINFRA": "d"}, secrets_text=tg, ego_enabled=1)
+    r = compute_readiness(
+        secrets={"API_KEY_DEEPINFRA": "d"}, secrets_text=tg, ego_enabled=1, onboarded=True
+    )
     assert r.ego_enabled is True

--- a/tests/test_onboarding/test_readiness.py
+++ b/tests/test_onboarding/test_readiness.py
@@ -1,0 +1,191 @@
+"""Tests for the tiered readiness layer (``genesis.onboarding.readiness``).
+
+Readiness sits ABOVE the functional floor and must:
+* compute a cumulative tier (T0..T3) that a de-configured lower gate visibly drops;
+* gate T2 on Genesis being able to PROACTIVELY reach the owner via Telegram — the
+  EXACT condition the live adapter's start-gate enforces (parity-pinned to
+  ``channels.bridge._load_bridge_config``), incl. rejecting the real
+  "bot token pasted into TELEGRAM_ALLOWED_USERS" mistake;
+* gate T3 on the injected ``ego_enabled`` bool (the ego/awareness loop);
+* reuse the floor's own computation so the two can never drift.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.onboarding import floor as floor_mod
+from genesis.onboarding.floor import FloorStatus
+from genesis.onboarding.readiness import (
+    ReadinessStatus,
+    _telegram_reach_configured,
+    compute_readiness,
+)
+
+
+def _floor(met: bool) -> FloorStatus:
+    """A FloorStatus whose ``floor_met`` is exactly ``met`` (all three legs = met)."""
+    return FloorStatus(cc_oauth=met, llm_key_present=met, embedding_key_present=met)
+
+
+def _status(*, floor_met: bool, telegram: bool, ego: bool) -> ReadinessStatus:
+    return ReadinessStatus(floor=_floor(floor_met), telegram_configured=telegram, ego_enabled=ego)
+
+
+# ── Tier truth table (the cumulative gate logic) ───────────────────────────────
+
+
+def test_tier0_when_floor_unmet_regardless_of_higher_gates():
+    # Even with telegram + ego configured, an unmet floor pins the tier at 0 —
+    # tiers are cumulative, a higher gate never "leaks" past a lower one.
+    assert _status(floor_met=False, telegram=True, ego=True).tier == 0
+
+
+def test_tier1_floor_met_no_channel():
+    s = _status(floor_met=True, telegram=False, ego=False)
+    assert s.tier == 1
+    assert s.tier_name == "Functional"
+
+
+def test_tier2_floor_and_telegram_no_ego():
+    s = _status(floor_met=True, telegram=True, ego=False)
+    assert s.tier == 2
+    assert s.tier_name == "Connected"
+
+
+def test_tier3_floor_telegram_and_ego():
+    s = _status(floor_met=True, telegram=True, ego=True)
+    assert s.tier == 3
+    assert s.tier_name == "Autonomous"
+
+
+def test_ego_without_telegram_does_not_reach_tier3():
+    # Cumulative: ego on but no channel → capped at T1 (T2 gate unmet).
+    assert _status(floor_met=True, telegram=False, ego=True).tier == 1
+
+
+def test_tier_names_cover_every_tier():
+    names = {
+        _status(floor_met=fm, telegram=tg, ego=eg).tier_name
+        for fm, tg, eg in [
+            (False, False, False),
+            (True, False, False),
+            (True, True, False),
+            (True, True, True),
+        ]
+    }
+    assert names == {"Bootstrapped", "Functional", "Connected", "Autonomous"}
+
+
+def test_as_dict_shape_excludes_floor_legs():
+    d = _status(floor_met=True, telegram=True, ego=True).as_dict()
+    assert d == {
+        "tier": 3,
+        "tier_name": "Autonomous",
+        "telegram_configured": True,
+        "ego_enabled": True,
+    }
+    # Floor legs are emitted by the route, NOT duplicated here.
+    assert "floor_met" not in d and "cc_oauth" not in d
+
+
+# ── T2 gate: _telegram_reach_configured (proactive-reach semantics) ────────────
+
+
+@pytest.mark.parametrize(
+    "secrets, expected",
+    [
+        ({}, False),  # nothing configured
+        ({"TELEGRAM_BOT_TOKEN": "abc123"}, False),  # token but no recipient → can't reach
+        ({"TELEGRAM_BOT_TOKEN": "abc123", "TELEGRAM_ALLOWED_USERS": "12345"}, True),
+        # The real mistake (memory 47a55700): a bot token pasted into ALLOWED_USERS.
+        # Non-numeric → no valid recipient → NOT connected.
+        ({"TELEGRAM_BOT_TOKEN": "abc123", "TELEGRAM_ALLOWED_USERS": "abc:token"}, False),
+        # Placeholder token never counts even with a valid recipient.
+        ({"TELEGRAM_BOT_TOKEN": "PLACEHOLDER", "TELEGRAM_ALLOWED_USERS": "12345"}, False),
+        # Empty token never counts.
+        ({"TELEGRAM_BOT_TOKEN": "", "TELEGRAM_ALLOWED_USERS": "12345"}, False),
+        # One valid UID among invalid ones still counts.
+        ({"TELEGRAM_BOT_TOKEN": "abc", "TELEGRAM_ALLOWED_USERS": "nope,678"}, True),
+        # Whitespace-padded numeric still counts.
+        ({"TELEGRAM_BOT_TOKEN": "abc", "TELEGRAM_ALLOWED_USERS": " 789 "}, True),
+    ],
+)
+def test_telegram_reach_configured(secrets, expected):
+    assert _telegram_reach_configured(secrets) is expected
+
+
+def test_telegram_reach_parity_with_bridge(tmp_path, monkeypatch):
+    """The T2 signal must equal the LIVE adapter start-gate, case for case.
+
+    Importing the bridge is heavy (pulls GenesisRuntime), which is exactly why the
+    hot-path helper is a replica — this test is the pin that keeps the replica
+    honest: for every secrets shape, ``_telegram_reach_configured`` agrees with
+    ``_load_bridge_config() is not None``.
+    """
+    bridge = pytest.importorskip("genesis.channels.bridge")
+
+    secrets_file = tmp_path / "secrets.env"
+    monkeypatch.setattr(bridge, "secrets_path", lambda: secrets_file)
+    monkeypatch.setattr(floor_mod, "secrets_path", lambda: secrets_file)
+
+    cases = [
+        "",
+        "TELEGRAM_BOT_TOKEN=abc123\n",
+        "TELEGRAM_BOT_TOKEN=abc123\nTELEGRAM_ALLOWED_USERS=12345\n",
+        "TELEGRAM_BOT_TOKEN=abc123\nTELEGRAM_ALLOWED_USERS=notanumber\n",
+        "TELEGRAM_BOT_TOKEN=PLACEHOLDER\nTELEGRAM_ALLOWED_USERS=12345\n",
+        "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=notanum,678\n",
+    ]
+    for content in cases:
+        secrets_file.write_text(content)
+        live = bridge._load_bridge_config() is not None
+        replica = _telegram_reach_configured(floor_mod.read_persisted_secrets())
+        assert replica is live, f"parity mismatch for {content!r}: replica={replica} live={live}"
+
+
+# ── compute_readiness wiring (threads secrets + ego through the real floor) ─────
+
+
+@pytest.fixture()
+def floor_met(monkeypatch):
+    """Make the floor's non-telegram legs pass so tier hinges on telegram/ego."""
+    monkeypatch.setattr(floor_mod, "cc_oauth_present", lambda: True)
+    monkeypatch.setattr(floor_mod, "_llm_key_present", lambda secrets: True)
+    # embedding leg is _has_any(secrets, EMBEDDING_KEY_NAMES) — supply a key below.
+
+
+def test_compute_readiness_threads_secrets_and_ego(floor_met):
+    secrets = {
+        "API_KEY_DEEPINFRA": "di-xxx",  # satisfies the floor embedding leg
+        "TELEGRAM_BOT_TOKEN": "abc",
+        "TELEGRAM_ALLOWED_USERS": "12345",
+    }
+    assert compute_readiness(secrets=secrets, ego_enabled=False).tier == 2
+    assert compute_readiness(secrets=secrets, ego_enabled=True).tier == 3
+
+
+def test_compute_readiness_floor_reuse_parity(floor_met):
+    # readiness.floor must BE the floor's own computation (no drift).
+    secrets = {"API_KEY_DEEPINFRA": "di-xxx"}
+    r = compute_readiness(secrets=secrets, ego_enabled=False)
+    assert r.floor.as_dict() == floor_mod.compute_floor(secrets=secrets).as_dict()
+    assert r.floor.floor_met is True  # legs monkeypatched true + embedding key present
+
+
+def test_compute_readiness_floor_unmet_is_tier0(monkeypatch):
+    # No floor monkeypatch → real legs fail on empty secrets → tier 0 even with
+    # telegram + ego "configured".
+    monkeypatch.setattr(floor_mod, "cc_oauth_present", lambda: False)
+    secrets = {"TELEGRAM_BOT_TOKEN": "abc", "TELEGRAM_ALLOWED_USERS": "12345"}
+    assert compute_readiness(secrets=secrets, ego_enabled=True).tier == 0
+
+
+def test_compute_readiness_ego_flag_is_coerced_bool(floor_met):
+    secrets = {
+        "API_KEY_DEEPINFRA": "di-xxx",
+        "TELEGRAM_BOT_TOKEN": "abc",
+        "TELEGRAM_ALLOWED_USERS": "1",
+    }
+    r = compute_readiness(secrets=secrets, ego_enabled=1)  # truthy non-bool
+    assert r.ego_enabled is True

--- a/tests/test_onboarding/test_readiness.py
+++ b/tests/test_onboarding/test_readiness.py
@@ -122,6 +122,12 @@ def test_as_dict_shape_excludes_floor_legs():
         ("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345 # me\n", False),
         # Double quotes ARE stripped (adapter's .strip('"')) → valid.
         ('TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS="12345"\n', True),
+        # Valid token + recipient but a malformed setting the live loader parses
+        # (DAY_BOUNDARY_HOUR) → _load_bridge_config raises → adapter stays stopped →
+        # NOT reachable (the P2 the bot caught).
+        ("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=1\nDAY_BOUNDARY_HOUR=abc\n", False),
+        # A well-formed DAY_BOUNDARY_HOUR does not block reach.
+        ("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=1\nDAY_BOUNDARY_HOUR=6\n", True),
     ],
 )
 def test_telegram_reach_configured(text, expected):
@@ -159,16 +165,33 @@ def test_telegram_reach_parity_with_bridge(tmp_path, monkeypatch):
         "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345 # me\n",
         'TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS="12345"\n',
         "TELEGRAM_BOT_TOKEN='PLACEHOLDER'\nTELEGRAM_ALLOWED_USERS=12345\n",
+        # Malformed non-telegram setting: the live loader RAISES (adapter stays
+        # stopped). "Would the adapter load" is False → replica must also be False.
+        "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=1\nDAY_BOUNDARY_HOUR=abc\n",
     ]
     for content in cases:
         secrets_file.write_text(content)
-        live = bridge._load_bridge_config() is not None
+        # A raise from the live loader means "adapter would NOT load" — equivalent to
+        # None for the reach question, so treat it as False (not a test error).
+        try:
+            live = bridge._load_bridge_config() is not None
+        except Exception:  # noqa: BLE001 - a raising loader == not loadable == False
+            live = False
         replica = _telegram_reach_configured(secrets_file.read_text())
         assert replica is live, f"parity mismatch for {content!r}: replica={replica} live={live}"
 
 
 def test_read_secrets_env_text_missing_file_is_empty(tmp_path, monkeypatch):
     monkeypatch.setattr(readiness_mod, "secrets_path", lambda: tmp_path / "nope.env")
+    assert _read_secrets_env_text() == ""
+
+
+def test_read_secrets_env_text_non_utf8_is_empty(tmp_path, monkeypatch):
+    # A non-UTF-8 secrets.env must degrade to "" (not configured), never 500 the
+    # route: read_text() raises UnicodeDecodeError (a ValueError subclass, NOT OSError).
+    bad = tmp_path / "secrets.env"
+    bad.write_bytes(b"\xff\xfe\x00TELEGRAM_BOT_TOKEN=abc\n")
+    monkeypatch.setattr(readiness_mod, "secrets_path", lambda: bad)
     assert _read_secrets_env_text() == ""
 
 

--- a/tests/test_onboarding/test_readiness.py
+++ b/tests/test_onboarding/test_readiness.py
@@ -3,9 +3,11 @@
 Readiness sits ABOVE the functional floor and must:
 * compute a cumulative tier (T0..T3) that a de-configured lower gate visibly drops;
 * gate T2 on Genesis being able to PROACTIVELY reach the owner via Telegram — the
-  EXACT condition the live adapter's start-gate enforces (parity-pinned to
-  ``channels.bridge._load_bridge_config``), incl. rejecting the real
-  "bot token pasted into TELEGRAM_ALLOWED_USERS" mistake;
+  EXACT condition the live adapter's start-gate enforces, computed from the RAW
+  secrets.env text with the adapter's OWN manual parser (NOT dotenv), and
+  parity-pinned to ``channels.bridge._load_bridge_config`` across quoted / commented
+  / interpolated shapes (incl. rejecting the "bot token pasted into
+  TELEGRAM_ALLOWED_USERS" mistake);
 * gate T3 on the injected ``ego_enabled`` bool (the ego/awareness loop);
 * reuse the floor's own computation so the two can never drift.
 """
@@ -15,9 +17,11 @@ from __future__ import annotations
 import pytest
 
 from genesis.onboarding import floor as floor_mod
+from genesis.onboarding import readiness as readiness_mod
 from genesis.onboarding.floor import FloorStatus
 from genesis.onboarding.readiness import (
     ReadinessStatus,
+    _read_secrets_env_text,
     _telegram_reach_configured,
     compute_readiness,
 )
@@ -89,62 +93,86 @@ def test_as_dict_shape_excludes_floor_legs():
     assert "floor_met" not in d and "cc_oauth" not in d
 
 
-# ── T2 gate: _telegram_reach_configured (proactive-reach semantics) ────────────
+# ── T2 gate: _telegram_reach_configured (raw-text, adapter-manual semantics) ────
 
 
 @pytest.mark.parametrize(
-    "secrets, expected",
+    "text, expected",
     [
-        ({}, False),  # nothing configured
-        ({"TELEGRAM_BOT_TOKEN": "abc123"}, False),  # token but no recipient → can't reach
-        ({"TELEGRAM_BOT_TOKEN": "abc123", "TELEGRAM_ALLOWED_USERS": "12345"}, True),
+        ("", False),  # nothing configured
+        ("TELEGRAM_BOT_TOKEN=abc123\n", False),  # token but no recipient → can't reach
+        ("TELEGRAM_BOT_TOKEN=abc123\nTELEGRAM_ALLOWED_USERS=12345\n", True),
         # The real mistake (memory 47a55700): a bot token pasted into ALLOWED_USERS.
         # Non-numeric → no valid recipient → NOT connected.
-        ({"TELEGRAM_BOT_TOKEN": "abc123", "TELEGRAM_ALLOWED_USERS": "abc:token"}, False),
+        ("TELEGRAM_BOT_TOKEN=abc123\nTELEGRAM_ALLOWED_USERS=abc:token\n", False),
         # Placeholder token never counts even with a valid recipient.
-        ({"TELEGRAM_BOT_TOKEN": "PLACEHOLDER", "TELEGRAM_ALLOWED_USERS": "12345"}, False),
+        ("TELEGRAM_BOT_TOKEN=PLACEHOLDER\nTELEGRAM_ALLOWED_USERS=12345\n", False),
         # Empty token never counts.
-        ({"TELEGRAM_BOT_TOKEN": "", "TELEGRAM_ALLOWED_USERS": "12345"}, False),
+        ("TELEGRAM_BOT_TOKEN=\nTELEGRAM_ALLOWED_USERS=12345\n", False),
         # One valid UID among invalid ones still counts.
-        ({"TELEGRAM_BOT_TOKEN": "abc", "TELEGRAM_ALLOWED_USERS": "nope,678"}, True),
+        ("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=nope,678\n", True),
         # Whitespace-padded numeric still counts.
-        ({"TELEGRAM_BOT_TOKEN": "abc", "TELEGRAM_ALLOWED_USERS": " 789 "}, True),
+        ("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS= 789 \n", True),
+        # Comment lines are ignored; a real value below still parses.
+        ("# a comment\nTELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=1\n", True),
+        # Manual parse (like the adapter) does NOT strip single quotes → '12345' is
+        # not a valid numeric id → NOT connected (the divergence the review caught).
+        ("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS='12345'\n", False),
+        # Manual parse does NOT strip inline comments → "12345 # me" is not numeric.
+        ("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345 # me\n", False),
+        # Double quotes ARE stripped (adapter's .strip('"')) → valid.
+        ('TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS="12345"\n', True),
     ],
 )
-def test_telegram_reach_configured(secrets, expected):
-    assert _telegram_reach_configured(secrets) is expected
+def test_telegram_reach_configured(text, expected):
+    assert _telegram_reach_configured(text) is expected
 
 
 def test_telegram_reach_parity_with_bridge(tmp_path, monkeypatch):
     """The T2 signal must equal the LIVE adapter start-gate, case for case.
 
-    Importing the bridge is heavy (pulls GenesisRuntime), which is exactly why the
-    hot-path helper is a replica — this test is the pin that keeps the replica
-    honest: for every secrets shape, ``_telegram_reach_configured`` agrees with
-    ``_load_bridge_config() is not None``.
+    This is the load-bearing pin: ``_telegram_reach_configured`` must agree with
+    ``channels.bridge._load_bridge_config`` for EVERY secrets shape — including the
+    quoted / inline-comment / interpolation shapes where dotenv (the floor's parser)
+    and the adapter's manual parser diverge. Fails hard (not skip) if the bridge
+    can't import — a silent skip would let parity drift ship unnoticed.
     """
-    bridge = pytest.importorskip("genesis.channels.bridge")
+    try:
+        from genesis.channels import bridge
+    except Exception as exc:  # noqa: BLE001 - the pin must be loud, never skipped
+        pytest.fail(
+            f"bridge must import for the parity pin (got {exc!r}); this test is the "
+            "sole guard against T2 signal drift"
+        )
 
     secrets_file = tmp_path / "secrets.env"
     monkeypatch.setattr(bridge, "secrets_path", lambda: secrets_file)
-    monkeypatch.setattr(floor_mod, "secrets_path", lambda: secrets_file)
 
     cases = [
-        "",
         "TELEGRAM_BOT_TOKEN=abc123\n",
         "TELEGRAM_BOT_TOKEN=abc123\nTELEGRAM_ALLOWED_USERS=12345\n",
         "TELEGRAM_BOT_TOKEN=abc123\nTELEGRAM_ALLOWED_USERS=notanumber\n",
         "TELEGRAM_BOT_TOKEN=PLACEHOLDER\nTELEGRAM_ALLOWED_USERS=12345\n",
         "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=notanum,678\n",
+        # Divergent shapes (dotenv vs manual) — both must now AGREE via manual parse:
+        "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS='12345'\n",
+        "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345 # me\n",
+        'TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS="12345"\n',
+        "TELEGRAM_BOT_TOKEN='PLACEHOLDER'\nTELEGRAM_ALLOWED_USERS=12345\n",
     ]
     for content in cases:
         secrets_file.write_text(content)
         live = bridge._load_bridge_config() is not None
-        replica = _telegram_reach_configured(floor_mod.read_persisted_secrets())
+        replica = _telegram_reach_configured(secrets_file.read_text())
         assert replica is live, f"parity mismatch for {content!r}: replica={replica} live={live}"
 
 
-# ── compute_readiness wiring (threads secrets + ego through the real floor) ─────
+def test_read_secrets_env_text_missing_file_is_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(readiness_mod, "secrets_path", lambda: tmp_path / "nope.env")
+    assert _read_secrets_env_text() == ""
+
+
+# ── compute_readiness wiring (threads floor secrets + telegram text + ego) ─────
 
 
 @pytest.fixture()
@@ -155,37 +183,40 @@ def floor_met(monkeypatch):
     # embedding leg is _has_any(secrets, EMBEDDING_KEY_NAMES) — supply a key below.
 
 
-def test_compute_readiness_threads_secrets_and_ego(floor_met):
-    secrets = {
-        "API_KEY_DEEPINFRA": "di-xxx",  # satisfies the floor embedding leg
-        "TELEGRAM_BOT_TOKEN": "abc",
-        "TELEGRAM_ALLOWED_USERS": "12345",
-    }
-    assert compute_readiness(secrets=secrets, ego_enabled=False).tier == 2
-    assert compute_readiness(secrets=secrets, ego_enabled=True).tier == 3
+def test_compute_readiness_threads_secrets_text_and_ego(floor_met):
+    secrets = {"API_KEY_DEEPINFRA": "di-xxx"}  # satisfies the floor embedding leg
+    tg = "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n"
+    assert compute_readiness(secrets=secrets, secrets_text=tg, ego_enabled=False).tier == 2
+    assert compute_readiness(secrets=secrets, secrets_text=tg, ego_enabled=True).tier == 3
+
+
+def test_compute_readiness_reads_file_when_text_omitted(floor_met, tmp_path, monkeypatch):
+    # When secrets_text is not passed, T2 reads the raw file via secrets_path.
+    secrets_file = tmp_path / "secrets.env"
+    secrets_file.write_text("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n")
+    monkeypatch.setattr(readiness_mod, "secrets_path", lambda: secrets_file)
+    r = compute_readiness(secrets={"API_KEY_DEEPINFRA": "d"}, ego_enabled=False)
+    assert r.telegram_configured is True
+    assert r.tier == 2
 
 
 def test_compute_readiness_floor_reuse_parity(floor_met):
     # readiness.floor must BE the floor's own computation (no drift).
     secrets = {"API_KEY_DEEPINFRA": "di-xxx"}
-    r = compute_readiness(secrets=secrets, ego_enabled=False)
+    r = compute_readiness(secrets=secrets, secrets_text="", ego_enabled=False)
     assert r.floor.as_dict() == floor_mod.compute_floor(secrets=secrets).as_dict()
-    assert r.floor.floor_met is True  # legs monkeypatched true + embedding key present
+    assert r.floor.floor_met is True
 
 
 def test_compute_readiness_floor_unmet_is_tier0(monkeypatch):
     # No floor monkeypatch → real legs fail on empty secrets → tier 0 even with
     # telegram + ego "configured".
     monkeypatch.setattr(floor_mod, "cc_oauth_present", lambda: False)
-    secrets = {"TELEGRAM_BOT_TOKEN": "abc", "TELEGRAM_ALLOWED_USERS": "12345"}
-    assert compute_readiness(secrets=secrets, ego_enabled=True).tier == 0
+    tg = "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345\n"
+    assert compute_readiness(secrets={}, secrets_text=tg, ego_enabled=True).tier == 0
 
 
 def test_compute_readiness_ego_flag_is_coerced_bool(floor_met):
-    secrets = {
-        "API_KEY_DEEPINFRA": "di-xxx",
-        "TELEGRAM_BOT_TOKEN": "abc",
-        "TELEGRAM_ALLOWED_USERS": "1",
-    }
-    r = compute_readiness(secrets=secrets, ego_enabled=1)  # truthy non-bool
+    tg = "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=1\n"
+    r = compute_readiness(secrets={"API_KEY_DEEPINFRA": "d"}, secrets_text=tg, ego_enabled=1)
     assert r.ego_enabled is True

--- a/tests/test_onboarding/test_readiness.py
+++ b/tests/test_onboarding/test_readiness.py
@@ -123,11 +123,14 @@ def test_as_dict_shape_excludes_floor_legs():
         # Double quotes ARE stripped (adapter's .strip('"')) → valid.
         ('TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS="12345"\n', True),
         # Valid token + recipient but a malformed setting the live loader parses
-        # (DAY_BOUNDARY_HOUR) → _load_bridge_config raises → adapter stays stopped →
-        # NOT reachable (the P2 the bot caught).
+        # (DAY_BOUNDARY_HOUR) → the loader raises → adapter stays stopped → NOT
+        # reachable (Codex round-2 P2).
         ("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=1\nDAY_BOUNDARY_HOUR=abc\n", False),
         # A well-formed DAY_BOUNDARY_HOUR does not block reach.
         ("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=1\nDAY_BOUNDARY_HOUR=6\n", True),
+        # str.isdigit() accepts '²' but int() rejects it → the loader raises on the
+        # allowed-user conversion → adapter stopped → NOT reachable (Codex round-3 P2).
+        ("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=²\n", False),
     ],
 )
 def test_telegram_reach_configured(text, expected):
@@ -168,6 +171,8 @@ def test_telegram_reach_parity_with_bridge(tmp_path, monkeypatch):
         # Malformed non-telegram setting: the live loader RAISES (adapter stays
         # stopped). "Would the adapter load" is False → replica must also be False.
         "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=1\nDAY_BOUNDARY_HOUR=abc\n",
+        # str.isdigit()-true / int()-false unicode digit → loader raises → False.
+        "TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=²\n",
     ]
     for content in cases:
         secrets_file.write_text(content)
@@ -193,6 +198,26 @@ def test_read_secrets_env_text_non_utf8_is_empty(tmp_path, monkeypatch):
     bad.write_bytes(b"\xff\xfe\x00TELEGRAM_BOT_TOKEN=abc\n")
     monkeypatch.setattr(readiness_mod, "secrets_path", lambda: bad)
     assert _read_secrets_env_text() == ""
+
+
+# ── shared loader contract (channels.bridge_config — the single source of truth) ─
+
+
+def test_build_bridge_config_contract():
+    from genesis.channels.bridge_config import build_bridge_config
+    from genesis.channels.bridge_config import parse_secrets_env_text as p
+
+    assert build_bridge_config(p("")) is None  # missing token
+    assert build_bridge_config(p("TELEGRAM_BOT_TOKEN=abc")) is None  # no recipient
+    cfg = build_bridge_config(p("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=12345"))
+    assert cfg is not None and cfg["allowed_users"] == {12345}
+    # Values the live adapter chokes on RAISE here too (preserved fail-to-load):
+    with pytest.raises(ValueError):
+        build_bridge_config(
+            p("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=1\nDAY_BOUNDARY_HOUR=x")
+        )
+    with pytest.raises(ValueError):
+        build_bridge_config(p("TELEGRAM_BOT_TOKEN=abc\nTELEGRAM_ALLOWED_USERS=²"))
 
 
 # ── compute_readiness wiring (threads floor secrets + telegram text + ego) ─────


### PR DESCRIPTION
## Tiered readiness above the functional floor (PR-B1 backend)

### What
Adds `genesis.onboarding.readiness`, a cumulative 4-tier model layered on the existing
functional floor, emitted additively from the `setup-status` route:

  T0 Bootstrapped → T1 Functional (`floor_met`) → T2 Connected → T3 Autonomous

- **T2 Connected** — Genesis can *proactively* reach the owner via Telegram: a real
  `TELEGRAM_BOT_TOKEN` AND ≥1 valid numeric `TELEGRAM_ALLOWED_USERS` id (its first
  entry seeds the default DM recipient). Computed from the **raw `secrets.env` text
  using the live adapter's own manual parser** (`channels.bridge._load_bridge_config`),
  NOT dotenv — the two diverge on hand-quoted / inline-commented values, and the
  adapter's parse is the ground truth for whether Telegram can actually start. Pinned
  equal to the adapter by a parity test across those shapes.
- **T3 Autonomous** — the ego/awareness loop is enabled (`ego.enabled`). The autonomy
  subsystem has no on/off switch (always initialised; gated per-action by the mandatory
  approval gate), so it is enrichment, never a tier gate. Web-search (multi-provider,
  incl. keyless SearXNG) and surplus are likewise enrichment, not gates.

Pure over persisted secrets + one injected `ego_enabled` bool (no runtime import on the
hot path). The route resolves `ego_enabled` fail-safe — an unreadable ego config
degrades T3→T2, never 500s the first-run route.

### Fields (additive, backward-compatible)
`setup-status` gains `tier`, `tier_name`, `telegram_configured`, `ego_enabled`. Existing
floor fields unchanged.

### Tests
`tests/test_onboarding/test_readiness.py` — tier truth table; the T2 raw-text gate incl.
the "bot token pasted into `TELEGRAM_ALLOWED_USERS`" false-positive guard; a **bridge
parity test** across quoted / inline-comment / double-quoted shapes that fails hard
(never silently skips) since it is the sole guard against T2 drift. Plus
`test_setup_wizard_api.py` — new fields, tier wiring, ego fail-safe (200 not 500),
backward-compat. Floor tests unregressed; ruff clean.

### No UI
The persistent readiness panel is PR-B2 (separate). Deploy: dashboard runtime
(`pip install -e .` + restart genesis-server), no host paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
