### PR TITLE
feat(recon): GitHub account-activity monitor — ping first-time external contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 - **GitHub activity notifications.** Genesis now watches your active GitHub repos
   every couple of hours and pings you on Telegram when an *external* contributor
-  opens their first PR/issue, comments, or starts a discussion — filtering out
-  your own activity, bots, and CI so you only hear about real people. Off by
-  default on a fresh install (it baselines quietly first); enable pings by
-  setting `mode: live` in a `config/github_steward.local.yaml` overlay once it
-  has run. Kill switch: `GENESIS_GITHUB_STEWARD_DISABLED=1`.
+  opens their first PR/issue, comments, starts a discussion, or replies on one —
+  filtering out your own activity, bots, and CI so you only hear about real
+  people. It keys on when things were actually *created*, so an old issue that's
+  merely edited or closed never masquerades as new activity; and if a ping can't
+  be delivered, it's retried until it lands rather than lost. Off by default on a
+  fresh install (it baselines quietly first); enable pings by setting
+  `mode: live` in a `config/github_steward.local.yaml` overlay once it has run.
+  Kill switch: `GENESIS_GITHUB_STEWARD_DISABLED=1`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **GitHub activity notifications.** Genesis now watches your active GitHub repos
+  every couple of hours and pings you on Telegram when an *external* contributor
+  opens their first PR/issue, comments, or starts a discussion — filtering out
+  your own activity, bots, and CI so you only hear about real people. Off by
+  default on a fresh install (it baselines quietly first); enable pings by
+  setting `mode: live` in a `config/github_steward.local.yaml` overlay once it
+  has run. Kill switch: `GENESIS_GITHUB_STEWARD_DISABLED=1`.
+
 ### Fixed
 
 - **Email replies now count as engagement.** When someone replies to an email

--- a/config/github_steward.yaml
+++ b/config/github_steward.yaml
@@ -1,0 +1,37 @@
+# GitHub account-activity monitor ("github steward").
+# See src/genesis/recon/github_steward_config.py for the full contract.
+#
+# Every ~2h a deterministic (no-LLM) poll checks the owner's repos for activity
+# by EXTERNAL humans (not the owner, not bots/orgs) — a new PR/issue, a comment,
+# a discussion. Genuine external activity is recorded for the digest campaign; a
+# FIRST-TIME external contributor additionally triggers an immediate Telegram
+# ping. Owner login and repos are resolved LIVE — no install-specific names here.
+
+enabled: true
+
+# off | observe | live
+#   off     — the monitor does not run.
+#   observe — poll + record + seed the seen-actor set, but NEVER ping.
+#             First-deploy default: prevents a cold-start ping-storm. Flip to
+#             'live' (in a github_steward.local.yaml overlay) once seeded.
+#   live    — observe + ping on genuine first-time external activity.
+mode: observe
+
+# Repos deep-polled for full, actor-bearing activity. EMPTY here (no install-
+# specific names ship in the public repo). When empty, the monitor resolves the
+# owner's public, non-fork repos most-recently pushed, capped at auto_select_cap.
+# Pin specific repos in a gitignored github_steward.local.yaml overlay, e.g.:
+#   flagship_repos: ["your-org/your-repo"]
+flagship_repos: []
+
+# Auto-selection bounds when flagship_repos is empty.
+auto_select_cap: 5
+auto_select_days: 60
+
+# Logins to always treat as automation even if they're plain User/Org accounts
+# (e.g. a review bot that posts under a user account). Not a hardcoded literal —
+# an operator lever. Example: ["some-review-bot"]
+automation_denylist: []
+
+# Loud-truncation cap: activity events processed per tick.
+max_events_per_tick: 100

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -409,10 +409,15 @@ verified: d37d2214 2026-08-06
   (`recon_findings`/`recon_triage`) — intelligence-only, never auto-acts.
   `account_activity.py` (`AccountActivityMonitor`, sibling to `ReconGatherer` —
   which is intentionally no-push) is the exception that DOES push: a 2h
-  deterministic (no-LLM) poll for EXTERNAL activity on owned repos that pings
-  first-time contributors via `submit_raw` (pipeline lazy-resolved at tick —
-  surplus inits before outreach). Uses `run_gh_checked` so a failed poll never
-  advances the cursor. `off`/`observe`/`live` lever in `github_steward_config`.
+  deterministic (no-LLM) poll for EXTERNAL activity on owned repos (issues, PRs,
+  comments, discussions + their replies) that pings first-time contributors via
+  `submit_raw` (pipeline lazy-resolved at tick — surplus inits before outreach).
+  Keys on immutable `created_at` (not `updated_at`, which GitHub's `?since=`
+  filters on) with a pre-poll watermark cursor, so an edited/closed old item
+  never masquerades as new. Uses `run_gh_checked` so a failed poll never advances
+  the cursor; an undelivered ping is held in a `github_ping_pending` marker and
+  retried each tick until it lands. `off`/`observe`/`live` lever in
+  `github_steward_config`.
 - **web/**: stateless search (SearXNG primary, Brave fallback) + httpx fetch
   (50k-char cap), sanitizer-wrapped; consumed via importers (MCP web tools,
   research, recon, pipeline), not runtime init.

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -389,7 +389,7 @@ drop folder, web search/fetch, recon jobs, and the research pipeline.
 ```yaml subsystem-map
 entry: intake-research
 modules: [knowledge, inbox, research, recon, web, pipeline]
-verified: 9037d45b 2026-07-07
+verified: d37d2214 2026-08-06
 ```
 
 - **knowledge/**: orchestrator + manifest + tree index. Content-hash gate
@@ -407,6 +407,12 @@ verified: 9037d45b 2026-07-07
   Sun 8am, models.md synthesis Sun 10am, GitHub discovery, skill-security scan
   via external NVIDIA SkillSpector). Emits findings for triage
   (`recon_findings`/`recon_triage`) — intelligence-only, never auto-acts.
+  `account_activity.py` (`AccountActivityMonitor`, sibling to `ReconGatherer` —
+  which is intentionally no-push) is the exception that DOES push: a 2h
+  deterministic (no-LLM) poll for EXTERNAL activity on owned repos that pings
+  first-time contributors via `submit_raw` (pipeline lazy-resolved at tick —
+  surplus inits before outreach). Uses `run_gh_checked` so a failed poll never
+  advances the cursor. `off`/`observe`/`live` lever in `github_steward_config`.
 - **web/**: stateless search (SearXNG primary, Brave fallback) + httpx fetch
   (50k-char cap), sanitizer-wrapped; consumed via importers (MCP web tools,
   research, recon, pipeline), not runtime init.

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -77,6 +77,9 @@ INTERNAL_OBS_TYPES: frozenset[str] = frozenset(
         # via the generic observation surfacers (would double-notify).
         "github_account_activity",
         "github_actor_seen",
+        # Owed first-time ping the monitor retries each tick until delivered —
+        # internal retry state, never a user-facing surface.
+        "github_ping_pending",
     }
 )
 
@@ -168,6 +171,10 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     # added, give this type a no-expiry TTL to preserve that invariant.
     "github_account_activity": timedelta(days=30),
     "github_actor_seen": timedelta(days=90),
+    # Owed first-time ping, retried each ~2h tick. 7d cap: if a ping cannot be
+    # delivered for a week something is badly wrong and the 30d activity row is
+    # the backstop; short so an abandoned marker cannot linger.
+    "github_ping_pending": timedelta(days=7),
     # cognitive self-mod rollback audit (operator-visible correction event)
     "self_mod_rollback": timedelta(days=30),
     # skill-edit Critic shadow verdicts (WS1) — kept 30d (vs 14d for the

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -72,6 +72,11 @@ INTERNAL_OBS_TYPES: frozenset[str] = frozenset(
         # aggregate infrastructure_alert (raised by the awareness cap detector when
         # a run of these accumulates) surfaces to the user.
         "cc_cap_empty_event",
+        # GitHub account-activity monitor — the Telegram ping (priority) and the
+        # 6h digest campaign are the delivery paths; these rows must NOT surface
+        # via the generic observation surfacers (would double-notify).
+        "github_account_activity",
+        "github_actor_seen",
     }
 )
 
@@ -154,6 +159,15 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "test_isolation_gap": timedelta(days=30),
     "operational_gap": timedelta(days=30),
     "interaction_theme": timedelta(days=30),
+    # ── GitHub steward (account-activity monitor) ──────────────────────
+    # Activity events kept 30d for the 6h digest campaign to consume. The
+    # per-actor "seen" marker is written once (first sighting) and never
+    # deleted — the expiry sweep only flips resolved=1, it does not purge rows,
+    # and exists_by_hash checks all rows regardless of resolved state, so a
+    # contributor never decays back to "first-time". If a real purge job is ever
+    # added, give this type a no-expiry TTL to preserve that invariant.
+    "github_account_activity": timedelta(days=30),
+    "github_actor_seen": timedelta(days=90),
     # cognitive self-mod rollback audit (operator-visible correction event)
     "self_mod_rollback": timedelta(days=30),
     # skill-edit Critic shadow verdicts (WS1) — kept 30d (vs 14d for the

--- a/src/genesis/recon/account_activity.py
+++ b/src/genesis/recon/account_activity.py
@@ -3,11 +3,10 @@ activity on the owner's repos.
 
 Runs every ~2h from the surplus scheduler. It answers one question with `gh`
 calls and no LLM: did a real, external human (not the owner, not a bot/org) act
-on one of the owner's flagship repos — open a PR/issue, comment, or post a
-discussion? Genuine external activity is recorded as a ``github_account_activity``
-observation (the 6h digest campaign consumes these); a FIRST-TIME external
-contributor (or, in C2a-2, a security advisory / account notice) additionally
-pushes an immediate Telegram ping.
+on one of the owner's flagship repos — open a PR/issue, comment, post a
+discussion, or reply on one? Genuine external activity is recorded as a
+``github_account_activity`` observation (the 6h digest campaign consumes these);
+a FIRST-TIME external contributor additionally pushes an immediate Telegram ping.
 
 Design notes:
 - **SIBLING to ``ReconGatherer``**, not a method on it — that class has a
@@ -18,9 +17,20 @@ Design notes:
 - **run_gh_checked** (not ``run_gh``) so a failed poll is distinguishable from an
   empty one — a rate-limited poll must NOT advance the cursor (or a contributor
   who acted during the failed window is lost forever).
+- **created_at, not updated_at.** GitHub's ``?since=`` filters on *updated_at*, so
+  an old issue that is merely edited/closed/labeled re-surfaces and would be
+  mis-recorded as new activity by its ORIGINAL author. We key everything on the
+  immutable ``created_at`` and filter ``cursor < created_at <= watermark`` — so
+  only genuine new contributions count, each with the correct actor.
+- **Watermark cursor.** ``wm`` is captured BEFORE polling; the cursor advances to
+  ``wm`` (not the newest event's ts), so an event created mid-poll — after one
+  feed's request but before another's — is never skipped (it re-fetches next
+  tick; ``since`` is exclusive and event-dedup makes the overlap a no-op).
 - **State:** per-repo cursor in a home-anchored JSON sidecar (mutable,
-  must-never-expire — the ``pr_watch`` precedent); event-dedup + first-time via
-  the observation-hash primitive (no new table).
+  must-never-expire — the ``pr_watch`` precedent); event-dedup + first-contact via
+  the observation-hash primitive (no new table). A non-delivered first-time ping
+  is held in a ``github_ping_pending`` marker and retried each tick until it
+  lands, so a failed delivery never silently burns the first-contact signal.
 - **Modes** (``github_steward_config``): ``off`` / ``observe`` (record, never
   ping — first-deploy default, seeds the seen-actor set) / ``live`` (ping).
 """
@@ -40,15 +50,32 @@ import aiosqlite
 from genesis.db.crud import observations
 from genesis.env import genesis_home
 from genesis.recon import github_steward_config as steward_cfg
-from genesis.recon.gh_cli import run_gh, run_gh_checked
+from genesis.recon.gh_cli import run_gh_checked
 
 logger = logging.getLogger(__name__)
 
 _SOURCE = "recon"
 _ACTIVITY_TYPE = "github_account_activity"
 _ACTOR_SEEN_TYPE = "github_actor_seen"
+_PENDING_TYPE = "github_ping_pending"
 _GH_TIMEOUT = 20
 _SIDECAR_VERSION = 1
+
+
+def _now_z() -> str:
+    """UTC now as a ``Z``-suffixed second-precision ISO timestamp — the same
+    shape GitHub returns, so cursor/created_at lexical compares are chronological.
+    """
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _norm_ts(v: str) -> str:
+    """Normalize a stored timestamp to ``Z`` form. Legacy cursors were written
+    via ``isoformat()`` (``+00:00`` suffix), which sorts WRONG against GitHub's
+    ``Z`` timestamps (``'Z' > '+'``); normalize so comparisons stay correct."""
+    if v.endswith("+00:00"):
+        return v[:-6] + "Z"
+    return v
 
 
 @dataclass(frozen=True)
@@ -67,13 +94,13 @@ class ActivityResult:
 @dataclass(frozen=True)
 class ActivityEvent:
     repo: str
-    kind: str  # "pr" | "issue" | "comment" | "discussion"
+    kind: str  # "pr" | "issue" | "comment" | "discussion" | "discussion_comment"
     node_id: str
     actor: str
     number: int | None
     title: str
     url: str
-    updated_at: str
+    created_at: str
 
 
 def _event_hash(repo: str, kind: str, node_id: str) -> str:
@@ -82,6 +109,13 @@ def _event_hash(repo: str, kind: str, node_id: str) -> str:
 
 def _actor_hash(login: str) -> str:
     return hashlib.sha256(f"actor:{login.lower()}".encode()).hexdigest()[:32]
+
+
+def _pending_hash(login: str) -> str:
+    """Hash namespace for the retry marker — DISTINCT from ``_actor_hash`` so a
+    still-pending actor is never mistaken for an already-seen one (a shared hash
+    would make the first-contact check treat "ping owed" as "already told")."""
+    return hashlib.sha256(f"pending:{login.lower()}".encode()).hexdigest()[:32]
 
 
 class AccountActivityMonitor:
@@ -114,7 +148,7 @@ class AccountActivityMonitor:
             data = json.loads(path.read_text())
             if isinstance(data, dict):
                 cur = data.get("cursors", {})
-                return {k: v for k, v in cur.items() if isinstance(v, str)}
+                return {k: _norm_ts(v) for k, v in cur.items() if isinstance(v, str)}
         except FileNotFoundError:
             return {}
         except Exception:
@@ -180,22 +214,28 @@ class AccountActivityMonitor:
                 break
         return selected
 
-    async def _is_automation(self, login: str, denylist: set[str]) -> bool:
-        """True for bots/orgs/denylisted logins (cached per login)."""
+    async def _is_automation(self, login: str, denylist: set[str]) -> bool | None:
+        """True for bots/orgs/denylisted logins, False for confirmed humans, or
+        None when the human/bot verdict can't be resolved (the ``users/{login}``
+        lookup failed). The caller must NOT drop a None-verdict event — it holds
+        the cursor so a transient API failure never loses a possible human. Only
+        confirmed verdicts are cached (per login); an unresolved lookup retries
+        next tick."""
         key = login.lower()
         if key in self._automation_cache:
             return self._automation_cache[key]
-        verdict = False
         if login.endswith("[bot]") or key in denylist:
-            verdict = True
-        else:
-            out = await run_gh("gh", "api", f"users/{login}", "--jq", ".type", timeout=_GH_TIMEOUT)
-            # Unresolved (empty on error) → treat as automation-unknown → NOT a
-            # confirmed human, so we don't ping; recorded as observation only.
-            verdict = out.strip() in ("Bot", "Organization")
-            if not out.strip():
-                # Don't cache an unresolved lookup — retry next sighting.
-                return True
+            self._automation_cache[key] = True
+            return True
+        # run_gh_checked (not run_gh) so a FAILED lookup is distinguishable from a
+        # resolved-but-non-bot type — a rate-limited/timed-out classification must
+        # not masquerade as "confirmed automation" and silently drop the event.
+        ok, out = await run_gh_checked(
+            "gh", "api", f"users/{login}", "--jq", ".type", timeout=_GH_TIMEOUT
+        )
+        if not ok or not out.strip():
+            return None  # unresolved — do NOT cache, do NOT drop; retry next tick
+        verdict = out.strip() in ("Bot", "Organization")
         self._automation_cache[key] = verdict
         return verdict
 
@@ -219,12 +259,25 @@ class AccountActivityMonitor:
         denylist = {d.lower() for d in steward_cfg.str_list(cfg, "automation_denylist")}
         max_events = steward_cfg.knob_int(cfg, "max_events_per_tick")
         cursors = self._load_cursors()
-        now_iso = datetime.now(UTC).isoformat()
+        # Watermark: captured BEFORE any poll. Every cursor advances to this, so
+        # an event created between two feeds' requests can't be skipped.
+        wm = _now_z()
         result_errors = 0
         new_events = 0
         pinged = 0
         baselined = 0
         details: list[str] = []
+
+        # Deliver any owed retry pings first (live only) — actor-global, so this
+        # runs independent of which repo produced them.
+        if mode == "live":
+            try:
+                redelivered = await self._drain_pending(mode)
+                if redelivered:
+                    pinged += redelivered
+                    details.append(f"retry: delivered {redelivered} owed ping(s)")
+            except Exception:
+                logger.warning("github steward: pending-drain failed", exc_info=True)
 
         for repo in repos:
             since = cursors.get(repo)
@@ -237,33 +290,45 @@ class AccountActivityMonitor:
                 continue
 
             # Per-repo first sight (no cursor yet) → baseline SILENTLY: seed
-            # seen-actors, no records/pings, cursor := now. Per-repo, NOT global:
+            # seen-actors, no records/pings, cursor := wm. Per-repo, NOT global:
             # a repo newly entering the auto-select set / newly pinned must
             # baseline too, else its whole history replays as "new" (ping storm).
             if since is None:
                 seeded = await self._seed_actors(events)
-                cursors[repo] = now_iso
+                cursors[repo] = wm
                 baselined += 1
                 details.append(f"{repo}: baselined ({seeded} actors seeded)")
                 continue
 
-            # Process oldest-first, capped.
-            events.sort(key=lambda e: e.updated_at)
-            truncated = len(events) > max_events
+            # created_at watermark window: strictly after the cursor (exclusive,
+            # like GitHub's `since`), up to and including the watermark. This is
+            # what turns an edited-old-item (old created_at) into a no-op and
+            # defers a mid-poll event (created_at > wm) to the next tick.
+            window = [e for e in events if e.created_at and since < e.created_at <= wm]
+            window.sort(key=lambda e: e.created_at)
+            truncated = len(window) > max_events
             if truncated:
                 logger.warning(
-                    "github steward: %s had %d events (cap %d) — processing oldest "
-                    "%d; the rest are deferred to the next tick",
+                    "github steward: %s had %d in-window events (cap %d) — processing "
+                    "oldest %d; the rest are deferred to the next tick",
                     repo,
-                    len(events),
+                    len(window),
                     max_events,
                     max_events,
                 )
-            processed = events[:max_events]
+            processed = window[:max_events]
+            classify_failed = False
             for ev in processed:
                 if ev.actor.lower() == owner.lower():
                     continue
-                if await self._is_automation(ev.actor, denylist):
+                auto = await self._is_automation(ev.actor, denylist)
+                if auto is None:
+                    # Human/bot verdict unresolved (lookup failed) — NEVER drop a
+                    # possible human. Flag the repo so its cursor holds and this
+                    # event re-fetches next tick (dedup absorbs any overlap).
+                    classify_failed = True
+                    continue
+                if auto:
                     continue
                 did_ping = await self._record_event(ev, mode)
                 new_events += 1
@@ -271,24 +336,31 @@ class AccountActivityMonitor:
                     pinged += 1
                     details.append(f"PING {repo}#{ev.number} by {ev.actor} ({ev.kind})")
 
-            # Advance the cursor. GitHub's `since` is EXCLUSIVE ("updated after"),
-            # so the cursor must never move past — nor, on a truncation that
-            # splits a same-second group, even TO — an unprocessed event's ts (its
-            # deferred twin would then never satisfy `after` and be lost). Deferred
-            # events re-fetch next tick; dedup makes any overlap a no-op.
-            if processed:
-                if not truncated:
-                    cursors[repo] = processed[-1].updated_at or since
-                else:
-                    boundary = events[max_events].updated_at  # first deferred event
-                    safe = [
-                        e.updated_at
-                        for e in processed
-                        if e.updated_at and boundary and e.updated_at < boundary
-                    ]
-                    # If every processed event ties the boundary second, hold the
-                    # old cursor (re-fetch the window next tick — loud, never drops).
-                    cursors[repo] = safe[-1] if safe else since
+            # A repo with an unresolved classification holds its cursor entirely
+            # (like a poll error): re-poll next tick when the lookup may succeed.
+            # Already-recorded events dedup, already-pinged actors stay seen, so
+            # re-processing is idempotent.
+            if classify_failed:
+                details.append(f"{repo}: classify unresolved — cursor held")
+                continue
+
+            # Advance the cursor. No truncation → advance to the watermark (the
+            # whole window is done). Truncation → advance only to the newest
+            # PROCESSED created_at that is STRICTLY BEFORE the first deferred
+            # event's ts — because `since` is exclusive, landing ON a split
+            # same-second group would strand the deferred twin. If every
+            # processed event ties that boundary, hold the old cursor (re-fetch
+            # the window next tick — loud, never drops).
+            if not truncated:
+                cursors[repo] = wm
+            elif processed:
+                boundary = window[max_events].created_at
+                safe = [
+                    e.created_at
+                    for e in processed
+                    if e.created_at and boundary and e.created_at < boundary
+                ]
+                cursors[repo] = safe[-1] if safe else since
 
         self._save_cursors(cursors)
         return ActivityResult(
@@ -307,9 +379,11 @@ class AccountActivityMonitor:
         """Poll one repo's issues/PRs, comments, and discussions since the cursor.
 
         Returns (ok, events). ok=False if ANY sub-poll errored (so the caller
-        holds the cursor). Events are unsorted; the caller time-sorts + caps and
-        derives the next cursor from the events it actually processes. No
-        ``--paginate``: the cursor + 2h window bound each poll under one page.
+        holds the cursor). Events are unsorted and carry ``created_at``; the
+        caller applies the ``cursor < created_at <= wm`` window, sorts + caps.
+        Always ``--paginate``: the ``since`` window is usually one page, but a
+        stale cursor (post-downtime) or a busy repo must never silently drop a
+        second page of contributors.
         """
         events: list[ActivityEvent] = []
         since_q = f"since={since}&" if since else ""
@@ -318,12 +392,14 @@ class AccountActivityMonitor:
         ok, out = await run_gh_checked(
             "gh",
             "api",
-            f"repos/{repo}/issues?{since_q}state=all&per_page=100&sort=updated&direction=asc",
+            f"repos/{repo}/issues?{since_q}state=all&per_page=100&sort=updated&direction=desc",
+            "--paginate",
+            "--slurp",
             timeout=_GH_TIMEOUT,
         )
         if not ok:
             return False, []
-        for row in _parse_json_list(out):
+        for row in _parse_paged(out):
             actor = (row.get("user") or {}).get("login", "")
             if not actor:
                 continue
@@ -337,7 +413,7 @@ class AccountActivityMonitor:
                     number=row.get("number"),
                     title=(row.get("title") or "")[:120],
                     url=row.get("html_url", ""),
-                    updated_at=row.get("updated_at", ""),
+                    created_at=row.get("created_at", ""),
                 )
             )
 
@@ -345,12 +421,14 @@ class AccountActivityMonitor:
         ok, out = await run_gh_checked(
             "gh",
             "api",
-            f"repos/{repo}/issues/comments?{since_q}per_page=100&sort=updated&direction=asc",
+            f"repos/{repo}/issues/comments?{since_q}per_page=100&sort=updated&direction=desc",
+            "--paginate",
+            "--slurp",
             timeout=_GH_TIMEOUT,
         )
         if not ok:
             return False, []
-        for row in _parse_json_list(out):
+        for row in _parse_paged(out):
             actor = (row.get("user") or {}).get("login", "")
             if not actor:
                 continue
@@ -363,12 +441,12 @@ class AccountActivityMonitor:
                     number=_issue_num(row.get("issue_url", "")),
                     title=(row.get("body") or "")[:120],
                     url=row.get("html_url", ""),
-                    updated_at=row.get("updated_at", ""),
+                    created_at=row.get("created_at", ""),
                 )
             )
 
-        # 3. Discussions (GraphQL — REST doesn't cover them)
-        disc_ok, disc_events = await self._poll_discussions(repo, since)
+        # 3. Discussions + their comments (GraphQL — REST doesn't cover them)
+        disc_ok, disc_events = await self._poll_discussions(repo, since is None)
         if not disc_ok:
             return False, []
         events.extend(disc_events)
@@ -376,13 +454,21 @@ class AccountActivityMonitor:
         return True, events
 
     async def _poll_discussions(
-        self, repo: str, since: str | None
+        self, repo: str, baseline: bool
     ) -> tuple[bool, list[ActivityEvent]]:
+        """Discussions AND their comments, each as its own event with its own
+        ``createdAt`` + author. The caller applies the created_at window, so a
+        new external REPLY on an old discussion surfaces while an old discussion
+        merely bumped by an owner reply does not.
+        """
         owner, _, name = repo.partition("/")
+        first = 100 if baseline else 25
+        # Concatenate `first` (avoid f-string brace-escaping against GraphQL {}).
         query = (
             "query($o:String!,$n:String!){repository(owner:$o,name:$n){"
-            "discussions(first:25,orderBy:{field:UPDATED_AT,direction:DESC}){"
-            "nodes{number title updatedAt id author{login}}}}}"
+            "discussions(first:" + str(first) + ",orderBy:{field:UPDATED_AT,direction:DESC}){"
+            "nodes{number title createdAt url id author{login} "
+            "comments(last:20){nodes{id createdAt url author{login}}}}}}}"
         )
         ok, out = await run_gh_checked(
             "gh",
@@ -406,28 +492,42 @@ class AccountActivityMonitor:
                 .get("repository", {})
                 .get("discussions", {})
                 .get("nodes", [])
-            )
+            ) or []
         except Exception:
             return True, []  # malformed graphql payload — treat as no discussions
         for node in nodes:
-            updated = node.get("updatedAt", "")
-            if since and updated and updated <= since:
-                continue
-            actor = (node.get("author") or {}).get("login", "")
-            if not actor:
-                continue
-            events.append(
-                ActivityEvent(
-                    repo=repo,
-                    kind="discussion",
-                    node_id=str(node.get("id")),
-                    actor=actor,
-                    number=node.get("number"),
-                    title=(node.get("title") or "")[:120],
-                    url="",
-                    updated_at=updated,
+            number = node.get("number")
+            title = (node.get("title") or "")[:120]
+            d_actor = (node.get("author") or {}).get("login", "")
+            if d_actor:
+                events.append(
+                    ActivityEvent(
+                        repo=repo,
+                        kind="discussion",
+                        node_id=str(node.get("id")),
+                        actor=d_actor,
+                        number=number,
+                        title=title,
+                        url=node.get("url", ""),
+                        created_at=node.get("createdAt", ""),
+                    )
                 )
-            )
+            for c in (node.get("comments") or {}).get("nodes", []) or []:
+                c_actor = (c.get("author") or {}).get("login", "")
+                if not c_actor:
+                    continue
+                events.append(
+                    ActivityEvent(
+                        repo=repo,
+                        kind="discussion_comment",
+                        node_id=str(c.get("id")),
+                        actor=c_actor,
+                        number=number,
+                        title=title,
+                        url=c.get("url", ""),
+                        created_at=c.get("createdAt", ""),
+                    )
+                )
         return True, events
 
     async def _seed_actors(self, events: list[ActivityEvent]) -> int:
@@ -443,7 +543,7 @@ class AccountActivityMonitor:
                     type=_ACTOR_SEEN_TYPE,
                     content=f"seen:{ev.actor}",
                     priority="low",
-                    created_at=datetime.now(UTC).isoformat(),
+                    created_at=_now_z(),
                     content_hash=h,
                     skip_if_duplicate=True,
                 )
@@ -451,9 +551,11 @@ class AccountActivityMonitor:
         return seeded
 
     async def _record_event(self, ev: ActivityEvent, mode: str) -> bool:
-        """Record an external-activity observation; ping iff first-time + live.
+        """Record an external-activity observation; ping iff first-contact + live.
 
-        Returns True iff a ping was sent.
+        First-contact is collapsed to the ACTOR across both the seen-marker and
+        the pending-marker: a returning contributor OR a still-pending one never
+        re-pings. Returns True iff a ping was DELIVERED this call.
         """
         ev_hash = _event_hash(ev.repo, ev.kind, ev.node_id)
         # Dedup: already processed this exact event → nothing to do.
@@ -461,11 +563,22 @@ class AccountActivityMonitor:
             return False
 
         actor_h = _actor_hash(ev.actor)
-        first_time = not await observations.exists_by_hash(
-            self._db, source=_SOURCE, content_hash=actor_h
+        pending_h = _pending_hash(ev.actor)
+        # Contact owed unless we have already told them (seen) or currently have a
+        # retry queued for them (pending). The seen-marker is checked across ALL
+        # rows (permanent — a contributor never decays back to first-time, even
+        # after its 90d row is TTL-resolved). The pending-marker is checked
+        # UNRESOLVED-ONLY: once the daily TTL sweep resolves an abandoned (never
+        # delivered) pending row, it must STOP suppressing — otherwise a resolved
+        # row would read as "already contacted" forever and the contributor could
+        # never be pinged again. An expired pending re-arms first-contact.
+        seen = await observations.exists_by_hash(self._db, source=_SOURCE, content_hash=actor_h)
+        pending = await observations.exists_by_hash(
+            self._db, source=_SOURCE, content_hash=pending_h, unresolved_only=True
         )
+        first_time = not (seen or pending)
 
-        now = datetime.now(UTC).isoformat()
+        now = _now_z()
         summary = json.dumps(
             {
                 "repo": ev.repo,
@@ -477,6 +590,8 @@ class AccountActivityMonitor:
                 "first_time": first_time,
             }
         )
+        # Always record the activity observation — the durable record the 6h
+        # digest consumes (dedup by event hash).
         await observations.create(
             self._db,
             id=uuid.uuid4().hex,
@@ -488,37 +603,131 @@ class AccountActivityMonitor:
             content_hash=ev_hash,
             skip_if_duplicate=True,
         )
-        # Mark actor seen (first write wins; 90d TTL).
-        if first_time:
-            await observations.create(
-                self._db,
-                id=uuid.uuid4().hex,
-                source=_SOURCE,
-                type=_ACTOR_SEEN_TYPE,
-                content=f"seen:{ev.actor}",
-                priority="low",
-                created_at=now,
-                content_hash=actor_h,
-                skip_if_duplicate=True,
-            )
 
-        # Priority ping: a first-time external contributor. Only in live mode.
-        if first_time and mode == "live":
-            return await self._ping(ev)
+        if not first_time:
+            return False
+
+        if mode != "live":
+            # Observe: seed the seen-marker (no ping expected), so the eventual
+            # live flip does not treat this actor as first-time.
+            await self._mark_seen(ev.actor, now)
+            return False
+
+        # Live first-contact: attempt the ping.
+        if await self._ping(ev):
+            await self._mark_seen(ev.actor, now)
+            return True
+
+        # Not delivered — queue a durable retry (do NOT mark seen; the actor
+        # stays owed a ping until one lands). Keyed by actor, so a second event
+        # by the same actor while pending neither re-pings nor duplicates this.
+        await observations.create(
+            self._db,
+            id=uuid.uuid4().hex,
+            source=_SOURCE,
+            type=_PENDING_TYPE,
+            content=json.dumps(self._ping_payload(ev)),
+            priority="medium",
+            created_at=now,
+            content_hash=pending_h,
+            skip_if_duplicate=True,
+        )
         return False
 
+    async def _mark_seen(self, actor: str, now: str) -> None:
+        await observations.create(
+            self._db,
+            id=uuid.uuid4().hex,
+            source=_SOURCE,
+            type=_ACTOR_SEEN_TYPE,
+            content=f"seen:{actor}",
+            priority="low",
+            created_at=now,
+            content_hash=_actor_hash(actor),
+            skip_if_duplicate=True,
+        )
+
+    @staticmethod
+    def _ping_payload(ev: ActivityEvent) -> dict:
+        return {
+            "repo": ev.repo,
+            "kind": ev.kind,
+            "node_id": ev.node_id,
+            "actor": ev.actor,
+            "number": ev.number,
+            "title": ev.title,
+            "url": ev.url,
+        }
+
+    async def _drain_pending(self, mode: str) -> int:
+        """Re-attempt owed first-time pings. On delivery, mark the actor seen and
+        resolve the pending marker; otherwise leave it for the next tick. Returns
+        the count delivered this call."""
+        rows = await observations.query(
+            self._db, source=_SOURCE, type=_PENDING_TYPE, resolved=False, limit=100
+        )
+        delivered = 0
+        for row in rows:
+            try:
+                payload = json.loads(row["content"])
+            except Exception:
+                continue
+            actor = payload.get("actor", "")
+            if not actor:
+                continue
+            pending_h = _pending_hash(actor)
+            # Defensive: an actor seen via another path → resolve the stale
+            # pending WITHOUT a duplicate ping.
+            if await observations.exists_by_hash(
+                self._db, source=_SOURCE, content_hash=_actor_hash(actor)
+            ):
+                await observations.resolve_by_content_hash(
+                    self._db,
+                    source=_SOURCE,
+                    content_hash=pending_h,
+                    resolved_at=_now_z(),
+                    resolution_notes="actor already seen",
+                )
+                continue
+            ev = ActivityEvent(
+                repo=payload.get("repo", ""),
+                kind=payload.get("kind", ""),
+                node_id=str(payload.get("node_id", "")),
+                actor=actor,
+                number=payload.get("number"),
+                title=payload.get("title", ""),
+                url=payload.get("url", ""),
+                created_at="",
+            )
+            if await self._ping(ev):
+                await self._mark_seen(actor, _now_z())
+                await observations.resolve_by_content_hash(
+                    self._db,
+                    source=_SOURCE,
+                    content_hash=pending_h,
+                    resolved_at=_now_z(),
+                    resolution_notes="retry delivered",
+                )
+                delivered += 1
+            # else: leave the pending row unresolved — retried next tick.
+        return delivered
+
     async def _ping(self, ev: ActivityEvent) -> bool:
+        """Send the first-time-contributor ping. Returns True ONLY on a confirmed
+        DELIVERED result — a FAILED/IGNORED/REJECTED verdict (submit_raw does not
+        raise on these) must not count as delivered."""
         pipeline = self._pipeline()
         if pipeline is None:
             logger.warning("github steward: pipeline unavailable — cannot ping %s", ev.actor)
             return False
-        from genesis.outreach.types import OutreachCategory, OutreachRequest
+        from genesis.outreach.types import OutreachCategory, OutreachRequest, OutreachStatus
 
         verb = {
             "pr": "opened PR",
             "issue": "opened issue",
             "comment": "commented on",
             "discussion": "started discussion",
+            "discussion_comment": "replied on discussion",
         }.get(ev.kind, "acted on")
         num = f"#{ev.number}" if ev.number else ""
         text = f"👋 First-time contributor: {ev.actor} {verb} {ev.repo}{num}\n{ev.title}".strip()
@@ -535,12 +744,19 @@ class AccountActivityMonitor:
             verbatim=True,
         )
         try:
-            await pipeline.submit_raw(text, request)
-            logger.info("github steward: pinged first-time contributor %s on %s", ev.actor, ev.repo)
-            return True
+            result = await pipeline.submit_raw(text, request)
         except Exception:
             logger.error("github steward: ping failed for %s", ev.actor, exc_info=True)
             return False
+        if result is not None and result.status == OutreachStatus.DELIVERED:
+            logger.info("github steward: pinged first-time contributor %s on %s", ev.actor, ev.repo)
+            return True
+        logger.warning(
+            "github steward: ping to %s not delivered (status=%s) — will retry",
+            ev.actor,
+            getattr(result, "status", None),
+        )
+        return False
 
 
 # ── module helpers ────────────────────────────────────────────────────────
@@ -552,6 +768,27 @@ def _parse_json_list(out: str) -> list[dict]:
         return data if isinstance(data, list) else []
     except Exception:
         return []
+
+
+def _parse_paged(out: str) -> list[dict]:
+    """Flatten a ``gh api --paginate --slurp`` payload — an outer array whose
+    elements are each page's array — into a flat list of rows. A plain (single,
+    non-slurped) array is returned as-is, so this is safe on both shapes."""
+    if not out:
+        return []
+    try:
+        data = json.loads(out)
+    except Exception:
+        return []
+    if not isinstance(data, list):
+        return []
+    flat: list[dict] = []
+    for item in data:
+        if isinstance(item, list):
+            flat.extend(x for x in item if isinstance(x, dict))
+        elif isinstance(item, dict):
+            flat.append(item)
+    return flat
 
 
 def _issue_num(issue_url: str) -> int | None:

--- a/src/genesis/recon/account_activity.py
+++ b/src/genesis/recon/account_activity.py
@@ -1,0 +1,559 @@
+"""AccountActivityMonitor — deterministic (no-LLM) watch for EXTERNAL GitHub
+activity on the owner's repos.
+
+Runs every ~2h from the surplus scheduler. It answers one question with `gh`
+calls and no LLM: did a real, external human (not the owner, not a bot/org) act
+on one of the owner's flagship repos — open a PR/issue, comment, or post a
+discussion? Genuine external activity is recorded as a ``github_account_activity``
+observation (the 6h digest campaign consumes these); a FIRST-TIME external
+contributor (or, in C2a-2, a security advisory / account notice) additionally
+pushes an immediate Telegram ping.
+
+Design notes:
+- **SIBLING to ``ReconGatherer``**, not a method on it — that class has a
+  load-bearing no-push contract. This class pushes (like ``cc_update_analyzer``).
+- **Pipeline is lazy-resolved at tick time** (``GenesisRuntime.instance()``):
+  surplus init runs BEFORE outreach init, so the pipeline does not exist when
+  this monitor is constructed. Its first tick is hours after boot.
+- **run_gh_checked** (not ``run_gh``) so a failed poll is distinguishable from an
+  empty one — a rate-limited poll must NOT advance the cursor (or a contributor
+  who acted during the failed window is lost forever).
+- **State:** per-repo cursor in a home-anchored JSON sidecar (mutable,
+  must-never-expire — the ``pr_watch`` precedent); event-dedup + first-time via
+  the observation-hash primitive (no new table).
+- **Modes** (``github_steward_config``): ``off`` / ``observe`` (record, never
+  ping — first-deploy default, seeds the seen-actor set) / ``live`` (ping).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+
+from genesis.db.crud import observations
+from genesis.env import genesis_home
+from genesis.recon import github_steward_config as steward_cfg
+from genesis.recon.gh_cli import run_gh, run_gh_checked
+
+logger = logging.getLogger(__name__)
+
+_SOURCE = "recon"
+_ACTIVITY_TYPE = "github_account_activity"
+_ACTOR_SEEN_TYPE = "github_actor_seen"
+_GH_TIMEOUT = 20
+_SIDECAR_VERSION = 1
+
+
+@dataclass(frozen=True)
+class ActivityResult:
+    """Summary of one monitor tick."""
+
+    mode: str = "off"
+    checked_repos: int = 0
+    new_events: int = 0
+    pinged: int = 0
+    errors: int = 0
+    seeded: bool = False
+    details: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ActivityEvent:
+    repo: str
+    kind: str  # "pr" | "issue" | "comment" | "discussion"
+    node_id: str
+    actor: str
+    number: int | None
+    title: str
+    url: str
+    updated_at: str
+
+
+def _event_hash(repo: str, kind: str, node_id: str) -> str:
+    return hashlib.sha256(f"{repo}:{kind}:{node_id}".encode()).hexdigest()[:32]
+
+
+def _actor_hash(login: str) -> str:
+    return hashlib.sha256(f"actor:{login.lower()}".encode()).hexdigest()[:32]
+
+
+class AccountActivityMonitor:
+    """Deterministic external-GitHub-activity watch. See module docstring."""
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+        self._owner: str | None = None
+        # login(lower) -> is_automation (Bot/Organization or denylisted). Cached
+        # for the process lifetime so we hit users/{login} once per login ever.
+        self._automation_cache: dict[str, bool] = {}
+
+    # ── pipeline (lazy — outreach inits after surplus) ────────────────────
+    def _pipeline(self):
+        try:
+            from genesis.runtime._core import GenesisRuntime
+
+            return GenesisRuntime.instance().outreach_pipeline
+        except Exception:
+            logger.debug("github steward: outreach pipeline not resolvable", exc_info=True)
+            return None
+
+    # ── cursor sidecar (home-anchored; mutable, never-expiring state) ─────
+    def _sidecar_path(self) -> Path:
+        return genesis_home() / "github_steward" / "cursors.json"
+
+    def _load_cursors(self) -> dict[str, str]:
+        path = self._sidecar_path()
+        try:
+            data = json.loads(path.read_text())
+            if isinstance(data, dict):
+                cur = data.get("cursors", {})
+                return {k: v for k, v in cur.items() if isinstance(v, str)}
+        except FileNotFoundError:
+            return {}
+        except Exception:
+            logger.warning("github steward: cursor sidecar unreadable — treating as empty")
+        return {}
+
+    def _save_cursors(self, cursors: dict[str, str]) -> None:
+        path = self._sidecar_path()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {"version": _SIDECAR_VERSION, "cursors": cursors}
+            # Atomic write (tmp + rename) — a torn cursor file would reprocess
+            # or skip activity.
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(payload, indent=2))
+            tmp.replace(path)
+        except Exception:
+            logger.warning("github steward: failed to persist cursors", exc_info=True)
+
+    # ── gh helpers ────────────────────────────────────────────────────────
+    async def _resolve_owner(self) -> str | None:
+        if self._owner:
+            return self._owner
+        ok, out = await run_gh_checked("gh", "api", "user", "--jq", ".login", timeout=_GH_TIMEOUT)
+        if ok and out:
+            self._owner = out.strip()
+        return self._owner
+
+    async def _resolve_flagship_repos(self, cfg: dict, owner: str) -> list[str]:
+        """Config list (full ``owner/name``), or auto-select the owner's active
+        public source repos, capped. No install-specific names ship in code."""
+        pinned = steward_cfg.str_list(cfg, "flagship_repos")
+        if pinned:
+            # Normalize bare names to owner/name.
+            return [r if "/" in r else f"{owner}/{r}" for r in pinned]
+        cap = steward_cfg.knob_int(cfg, "auto_select_cap")
+        days = steward_cfg.knob_int(cfg, "auto_select_days")
+        # Fetch more than cap so the recency filter can still yield up to cap.
+        ok, out = await run_gh_checked(
+            "gh",
+            "api",
+            f"users/{owner}/repos?type=owner&sort=pushed&per_page={cap * 2}",
+            "--jq",
+            '.[] | select(.fork==false and .private==false) | "\\(.full_name)\\t\\(.pushed_at)"',
+            timeout=_GH_TIMEOUT,
+        )
+        if not ok or not out:
+            return []
+        cutoff = datetime.now(UTC) - timedelta(days=days)
+        selected: list[str] = []
+        for line in out.splitlines():
+            name, _, pushed = line.partition("\t")
+            name, pushed = name.strip(), pushed.strip()
+            if not name or not pushed:
+                continue
+            try:
+                pushed_dt = datetime.fromisoformat(pushed.replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if pushed_dt >= cutoff:
+                selected.append(name)
+            if len(selected) >= cap:
+                break
+        return selected
+
+    async def _is_automation(self, login: str, denylist: set[str]) -> bool:
+        """True for bots/orgs/denylisted logins (cached per login)."""
+        key = login.lower()
+        if key in self._automation_cache:
+            return self._automation_cache[key]
+        verdict = False
+        if login.endswith("[bot]") or key in denylist:
+            verdict = True
+        else:
+            out = await run_gh("gh", "api", f"users/{login}", "--jq", ".type", timeout=_GH_TIMEOUT)
+            # Unresolved (empty on error) → treat as automation-unknown → NOT a
+            # confirmed human, so we don't ping; recorded as observation only.
+            verdict = out.strip() in ("Bot", "Organization")
+            if not out.strip():
+                # Don't cache an unresolved lookup — retry next sighting.
+                return True
+        self._automation_cache[key] = verdict
+        return verdict
+
+    # ── main tick ─────────────────────────────────────────────────────────
+    async def gather(self) -> ActivityResult:
+        mode = steward_cfg.effective_mode()
+        if mode == "off":
+            return ActivityResult(mode="off")
+
+        cfg = steward_cfg.load_config()
+        owner = await self._resolve_owner()
+        if not owner:
+            logger.warning("github steward: could not resolve owner login — skipping tick")
+            return ActivityResult(mode=mode, errors=1)
+
+        repos = await self._resolve_flagship_repos(cfg, owner)
+        if not repos:
+            logger.info("github steward: no flagship repos resolved — nothing to poll")
+            return ActivityResult(mode=mode)
+
+        denylist = {d.lower() for d in steward_cfg.str_list(cfg, "automation_denylist")}
+        max_events = steward_cfg.knob_int(cfg, "max_events_per_tick")
+        cursors = self._load_cursors()
+        now_iso = datetime.now(UTC).isoformat()
+        result_errors = 0
+        new_events = 0
+        pinged = 0
+        baselined = 0
+        details: list[str] = []
+
+        for repo in repos:
+            since = cursors.get(repo)
+            ok, events = await self._poll_repo(repo, since, owner)
+            if not ok:
+                # Failed poll — do NOT advance the cursor (never lose a
+                # contributor to a rate-limited/timed-out window).
+                result_errors += 1
+                details.append(f"{repo}: poll error (cursor held)")
+                continue
+
+            # Per-repo first sight (no cursor yet) → baseline SILENTLY: seed
+            # seen-actors, no records/pings, cursor := now. Per-repo, NOT global:
+            # a repo newly entering the auto-select set / newly pinned must
+            # baseline too, else its whole history replays as "new" (ping storm).
+            if since is None:
+                seeded = await self._seed_actors(events)
+                cursors[repo] = now_iso
+                baselined += 1
+                details.append(f"{repo}: baselined ({seeded} actors seeded)")
+                continue
+
+            # Process oldest-first, capped.
+            events.sort(key=lambda e: e.updated_at)
+            truncated = len(events) > max_events
+            if truncated:
+                logger.warning(
+                    "github steward: %s had %d events (cap %d) — processing oldest "
+                    "%d; the rest are deferred to the next tick",
+                    repo,
+                    len(events),
+                    max_events,
+                    max_events,
+                )
+            processed = events[:max_events]
+            for ev in processed:
+                if ev.actor.lower() == owner.lower():
+                    continue
+                if await self._is_automation(ev.actor, denylist):
+                    continue
+                did_ping = await self._record_event(ev, mode)
+                new_events += 1
+                if did_ping:
+                    pinged += 1
+                    details.append(f"PING {repo}#{ev.number} by {ev.actor} ({ev.kind})")
+
+            # Advance the cursor. GitHub's `since` is EXCLUSIVE ("updated after"),
+            # so the cursor must never move past — nor, on a truncation that
+            # splits a same-second group, even TO — an unprocessed event's ts (its
+            # deferred twin would then never satisfy `after` and be lost). Deferred
+            # events re-fetch next tick; dedup makes any overlap a no-op.
+            if processed:
+                if not truncated:
+                    cursors[repo] = processed[-1].updated_at or since
+                else:
+                    boundary = events[max_events].updated_at  # first deferred event
+                    safe = [
+                        e.updated_at
+                        for e in processed
+                        if e.updated_at and boundary and e.updated_at < boundary
+                    ]
+                    # If every processed event ties the boundary second, hold the
+                    # old cursor (re-fetch the window next tick — loud, never drops).
+                    cursors[repo] = safe[-1] if safe else since
+
+        self._save_cursors(cursors)
+        return ActivityResult(
+            mode=mode,
+            checked_repos=len(repos),
+            new_events=new_events,
+            pinged=pinged,
+            errors=result_errors,
+            seeded=baselined > 0,
+            details=details,
+        )
+
+    async def _poll_repo(
+        self, repo: str, since: str | None, owner: str
+    ) -> tuple[bool, list[ActivityEvent]]:
+        """Poll one repo's issues/PRs, comments, and discussions since the cursor.
+
+        Returns (ok, events). ok=False if ANY sub-poll errored (so the caller
+        holds the cursor). Events are unsorted; the caller time-sorts + caps and
+        derives the next cursor from the events it actually processes. No
+        ``--paginate``: the cursor + 2h window bound each poll under one page.
+        """
+        events: list[ActivityEvent] = []
+        since_q = f"since={since}&" if since else ""
+
+        # 1. Issues + PRs (the /issues endpoint returns both; .pull_request marks PRs)
+        ok, out = await run_gh_checked(
+            "gh",
+            "api",
+            f"repos/{repo}/issues?{since_q}state=all&per_page=100&sort=updated&direction=asc",
+            timeout=_GH_TIMEOUT,
+        )
+        if not ok:
+            return False, []
+        for row in _parse_json_list(out):
+            actor = (row.get("user") or {}).get("login", "")
+            if not actor:
+                continue
+            kind = "pr" if row.get("pull_request") else "issue"
+            events.append(
+                ActivityEvent(
+                    repo=repo,
+                    kind=kind,
+                    node_id=str(row.get("node_id") or row.get("id")),
+                    actor=actor,
+                    number=row.get("number"),
+                    title=(row.get("title") or "")[:120],
+                    url=row.get("html_url", ""),
+                    updated_at=row.get("updated_at", ""),
+                )
+            )
+
+        # 2. Issue + PR comments
+        ok, out = await run_gh_checked(
+            "gh",
+            "api",
+            f"repos/{repo}/issues/comments?{since_q}per_page=100&sort=updated&direction=asc",
+            timeout=_GH_TIMEOUT,
+        )
+        if not ok:
+            return False, []
+        for row in _parse_json_list(out):
+            actor = (row.get("user") or {}).get("login", "")
+            if not actor:
+                continue
+            events.append(
+                ActivityEvent(
+                    repo=repo,
+                    kind="comment",
+                    node_id=str(row.get("node_id") or row.get("id")),
+                    actor=actor,
+                    number=_issue_num(row.get("issue_url", "")),
+                    title=(row.get("body") or "")[:120],
+                    url=row.get("html_url", ""),
+                    updated_at=row.get("updated_at", ""),
+                )
+            )
+
+        # 3. Discussions (GraphQL — REST doesn't cover them)
+        disc_ok, disc_events = await self._poll_discussions(repo, since)
+        if not disc_ok:
+            return False, []
+        events.extend(disc_events)
+
+        return True, events
+
+    async def _poll_discussions(
+        self, repo: str, since: str | None
+    ) -> tuple[bool, list[ActivityEvent]]:
+        owner, _, name = repo.partition("/")
+        query = (
+            "query($o:String!,$n:String!){repository(owner:$o,name:$n){"
+            "discussions(first:25,orderBy:{field:UPDATED_AT,direction:DESC}){"
+            "nodes{number title updatedAt id author{login}}}}}"
+        )
+        ok, out = await run_gh_checked(
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"o={owner}",
+            "-F",
+            f"n={name}",
+            timeout=_GH_TIMEOUT,
+        )
+        if not ok:
+            return False, []
+        events: list[ActivityEvent] = []
+        try:
+            nodes = (
+                json.loads(out)
+                .get("data", {})
+                .get("repository", {})
+                .get("discussions", {})
+                .get("nodes", [])
+            )
+        except Exception:
+            return True, []  # malformed graphql payload — treat as no discussions
+        for node in nodes:
+            updated = node.get("updatedAt", "")
+            if since and updated and updated <= since:
+                continue
+            actor = (node.get("author") or {}).get("login", "")
+            if not actor:
+                continue
+            events.append(
+                ActivityEvent(
+                    repo=repo,
+                    kind="discussion",
+                    node_id=str(node.get("id")),
+                    actor=actor,
+                    number=node.get("number"),
+                    title=(node.get("title") or "")[:120],
+                    url="",
+                    updated_at=updated,
+                )
+            )
+        return True, events
+
+    async def _seed_actors(self, events: list[ActivityEvent]) -> int:
+        """First-run baseline: mark every actor seen (no pings, no records)."""
+        seeded = 0
+        for ev in events:
+            h = _actor_hash(ev.actor)
+            if not await observations.exists_by_hash(self._db, source=_SOURCE, content_hash=h):
+                await observations.create(
+                    self._db,
+                    id=uuid.uuid4().hex,
+                    source=_SOURCE,
+                    type=_ACTOR_SEEN_TYPE,
+                    content=f"seen:{ev.actor}",
+                    priority="low",
+                    created_at=datetime.now(UTC).isoformat(),
+                    content_hash=h,
+                    skip_if_duplicate=True,
+                )
+                seeded += 1
+        return seeded
+
+    async def _record_event(self, ev: ActivityEvent, mode: str) -> bool:
+        """Record an external-activity observation; ping iff first-time + live.
+
+        Returns True iff a ping was sent.
+        """
+        ev_hash = _event_hash(ev.repo, ev.kind, ev.node_id)
+        # Dedup: already processed this exact event → nothing to do.
+        if await observations.exists_by_hash(self._db, source=_SOURCE, content_hash=ev_hash):
+            return False
+
+        actor_h = _actor_hash(ev.actor)
+        first_time = not await observations.exists_by_hash(
+            self._db, source=_SOURCE, content_hash=actor_h
+        )
+
+        now = datetime.now(UTC).isoformat()
+        summary = json.dumps(
+            {
+                "repo": ev.repo,
+                "kind": ev.kind,
+                "actor": ev.actor,
+                "number": ev.number,
+                "title": ev.title,
+                "url": ev.url,
+                "first_time": first_time,
+            }
+        )
+        await observations.create(
+            self._db,
+            id=uuid.uuid4().hex,
+            source=_SOURCE,
+            type=_ACTIVITY_TYPE,
+            content=summary,
+            priority="medium" if first_time else "low",
+            created_at=now,
+            content_hash=ev_hash,
+            skip_if_duplicate=True,
+        )
+        # Mark actor seen (first write wins; 90d TTL).
+        if first_time:
+            await observations.create(
+                self._db,
+                id=uuid.uuid4().hex,
+                source=_SOURCE,
+                type=_ACTOR_SEEN_TYPE,
+                content=f"seen:{ev.actor}",
+                priority="low",
+                created_at=now,
+                content_hash=actor_h,
+                skip_if_duplicate=True,
+            )
+
+        # Priority ping: a first-time external contributor. Only in live mode.
+        if first_time and mode == "live":
+            return await self._ping(ev)
+        return False
+
+    async def _ping(self, ev: ActivityEvent) -> bool:
+        pipeline = self._pipeline()
+        if pipeline is None:
+            logger.warning("github steward: pipeline unavailable — cannot ping %s", ev.actor)
+            return False
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+
+        verb = {
+            "pr": "opened PR",
+            "issue": "opened issue",
+            "comment": "commented on",
+            "discussion": "started discussion",
+        }.get(ev.kind, "acted on")
+        num = f"#{ev.number}" if ev.number else ""
+        text = f"👋 First-time contributor: {ev.actor} {verb} {ev.repo}{num}\n{ev.title}".strip()
+        if ev.url:
+            text += f"\n{ev.url}"
+        request = OutreachRequest(
+            category=OutreachCategory.NOTIFICATION,
+            channel="telegram",
+            # Unique per event so two distinct contributors don't dedup to one ping.
+            topic=f"GitHub steward: {ev.actor} {ev.kind} {ev.repo}{num}",
+            context=text,
+            signal_type="github_account_activity",
+            salience_score=0.9,
+            verbatim=True,
+        )
+        try:
+            await pipeline.submit_raw(text, request)
+            logger.info("github steward: pinged first-time contributor %s on %s", ev.actor, ev.repo)
+            return True
+        except Exception:
+            logger.error("github steward: ping failed for %s", ev.actor, exc_info=True)
+            return False
+
+
+# ── module helpers ────────────────────────────────────────────────────────
+def _parse_json_list(out: str) -> list[dict]:
+    if not out:
+        return []
+    try:
+        data = json.loads(out)
+        return data if isinstance(data, list) else []
+    except Exception:
+        return []
+
+
+def _issue_num(issue_url: str) -> int | None:
+    tail = issue_url.rstrip("/").rsplit("/", 1)[-1] if issue_url else ""
+    return int(tail) if tail.isdigit() else None

--- a/src/genesis/recon/gh_cli.py
+++ b/src/genesis/recon/gh_cli.py
@@ -3,7 +3,9 @@
 Single source of truth for invoking the GitHub CLI via subprocess with a
 timeout and uniform failure handling (the process-kill sequence on timeout is
 easy to get subtly wrong, so it lives here rather than being copy-pasted).
-Both ``ReconGatherer`` and ``github_discovery`` use this.
+Both ``ReconGatherer`` and ``github_discovery`` use ``run_gh``; the account
+activity monitor uses ``run_gh_checked`` where it must tell a real error apart
+from an empty result.
 """
 
 from __future__ import annotations
@@ -18,12 +20,12 @@ logger = logging.getLogger(__name__)
 _DEFAULT_TIMEOUT = 15
 
 
-async def run_gh(*args: str, timeout: int | float = _DEFAULT_TIMEOUT) -> str:
-    """Run a ``gh`` command with a timeout. Returns stdout, or "" on any failure.
+async def _exec_gh(args: tuple[str, ...], timeout: int | float) -> tuple[bool, str]:
+    """Run a ``gh`` command. Returns ``(ok, stdout)``.
 
-    Failure (non-zero exit, timeout, or spawn error) is logged and collapsed to
-    an empty string so callers can treat "no data" uniformly. On timeout the
-    child process is killed and reaped to avoid leaks.
+    ``ok`` is False on non-zero exit, timeout, or spawn error (with ``stdout``
+    then ``""``). The timeout process-kill/reap sequence lives here so both
+    public wrappers share exactly one implementation.
     """
     proc: asyncio.subprocess.Process | None = None
     try:
@@ -40,8 +42,8 @@ async def run_gh(*args: str, timeout: int | float = _DEFAULT_TIMEOUT) -> str:
                 " ".join(args),
                 stderr.decode("utf-8", errors="replace")[:200],
             )
-            return ""
-        return stdout.decode("utf-8", errors="replace").strip()
+            return False, ""
+        return True, stdout.decode("utf-8", errors="replace").strip()
     except TimeoutError:
         logger.warning("gh command timed out: %s", " ".join(args))
         if proc is not None:
@@ -49,7 +51,29 @@ async def run_gh(*args: str, timeout: int | float = _DEFAULT_TIMEOUT) -> str:
                 proc.kill()
             with contextlib.suppress(ProcessLookupError):
                 await proc.wait()
-        return ""
+        return False, ""
     except OSError:
         logger.warning("gh command failed to start: %s", " ".join(args), exc_info=True)
-        return ""
+        return False, ""
+
+
+async def run_gh(*args: str, timeout: int | float = _DEFAULT_TIMEOUT) -> str:
+    """Run a ``gh`` command. Returns stdout, or "" on any failure.
+
+    Failure (non-zero exit, timeout, or spawn error) is logged and collapsed to
+    an empty string so callers can treat "no data" uniformly. Use
+    ``run_gh_checked`` when you must distinguish an error from a genuinely empty
+    result (e.g. a cursor you must NOT advance on a failed poll).
+    """
+    _ok, stdout = await _exec_gh(args, timeout)
+    return stdout
+
+
+async def run_gh_checked(*args: str, timeout: int | float = _DEFAULT_TIMEOUT) -> tuple[bool, str]:
+    """Like ``run_gh`` but returns ``(ok, stdout)``.
+
+    ``ok`` is False iff the command failed (non-zero exit / timeout / spawn
+    error) — letting the caller tell a real error apart from an empty-but-
+    successful result, which ``run_gh`` collapses into the same ``""``.
+    """
+    return await _exec_gh(args, timeout)

--- a/src/genesis/recon/github_steward_config.py
+++ b/src/genesis/recon/github_steward_config.py
@@ -1,0 +1,137 @@
+"""Config lever for the GitHub account-activity monitor (the "github steward").
+
+Cloned from ``cc.foreground_reaper_config``: fresh-read-per-call, ``MODES``
+tuple + env kill switch, degrade-toward-less-authority on damage.
+
+Modes (increasing authority):
+  - ``off``     — the monitor does not run.
+  - ``observe`` — poll + record observations + seed the seen-actor set, but
+    NEVER ping. First-deploy default: prevents a cold-start ping-storm (every
+    existing contributor would otherwise classify as first-time). The operator
+    flips to ``live`` once the seen-actor set is seeded.
+  - ``live``    — observe + push priority Telegram pings for genuine external
+    activity (first-time contributor, security advisory, account notice).
+
+A missing/corrupt config degrades to DEFAULTS; an invalid ``mode`` degrades to
+``observe`` (safe: record but never ping — never a silent ``off`` that hides the
+feature, never an unattended ``live``). Env kill switch
+``GENESIS_GITHUB_STEWARD_DISABLED=1`` forces ``off``.
+
+Generalizability: NO install-specific repo names ship here. ``flagship_repos``
+defaults to empty; each install pins its own via the gitignored
+``github_steward.local.yaml`` overlay, and an empty list makes the monitor
+resolve the owner's active public repos live (capped).
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+MODES = ("off", "observe", "live")
+
+_CONFIG_NAME = "github_steward.yaml"
+
+_ENV_KILL_SWITCH = "GENESIS_GITHUB_STEWARD_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    # First deploy: observe (seed seen-actors, no pings) until the operator
+    # flips to live. Never default to a ping-capable mode on a fresh install.
+    "mode": "observe",
+    # Repos deep-polled for full actor-bearing activity. EMPTY in the shipped
+    # default (no install-specific names). Empty → resolve live: the owner's
+    # public, non-fork repos pushed within `auto_select_days`, capped at
+    # `auto_select_cap`. Pin specific repos via the .local.yaml overlay.
+    "flagship_repos": [],
+    "auto_select_cap": 5,
+    "auto_select_days": 60,
+    # Logins to always treat as automation even though they're plain User/Org
+    # accounts (e.g. a review bot posting under a user account). Config lever,
+    # not a hardcoded literal.
+    "automation_denylist": [],
+    # Loud-truncation cap: activity events processed per tick.
+    "max_events_per_tick": 100,
+}
+
+# Public: the settings-domain validator imports these to check knobs.
+INT_KNOBS = ("auto_select_cap", "auto_select_days", "max_events_per_tick")
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or corrupt
+    files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("github_steward base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("github_steward overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def effective_mode() -> str:
+    """The mode the monitor runs under — read live.
+
+    Env kill switch → ``off``. Master ``enabled: false`` → ``off``. An invalid
+    value degrades to ``observe`` (record safely, never ping).
+    """
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return "off"
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("mode")
+    if mode is False:
+        # Hand-edited unquoted `mode: off` parses as YAML-1.1 boolean False.
+        return "off"
+    if mode not in MODES:
+        logger.warning("github_steward has invalid mode %r — degrading to observe", mode)
+        return "observe"
+    return mode
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never zeroes a
+    limit or crashes the monitor."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value
+
+
+def str_list(cfg: dict[str, Any], key: str) -> list[str]:
+    """A list-of-strings knob, damage-tolerant (non-list / non-str → ignored)."""
+    value = cfg.get(key)
+    if not isinstance(value, list):
+        return []
+    return [v for v in value if isinstance(v, str) and v.strip()]

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -129,6 +129,21 @@ async def init(rt: GenesisRuntime) -> None:
             await _degraded(rt, "ReconGatherer")
 
         try:
+            # GitHub account-activity monitor (2h external-activity watch). No
+            # pipeline injected here — surplus init runs BEFORE outreach init, so
+            # the monitor lazy-resolves the pipeline at tick time.
+            from genesis.recon.account_activity import AccountActivityMonitor
+            account_monitor = AccountActivityMonitor(db=rt._db)
+            rt._surplus_scheduler.set_account_activity_monitor(account_monitor)
+            logger.info("AccountActivityMonitor wired to surplus scheduler")
+        except (ImportError, AttributeError):
+            logger.error("Failed to wire AccountActivityMonitor", exc_info=True)
+            await _degraded(rt, "AccountActivityMonitor")
+        except Exception:
+            logger.error("Unexpected error wiring AccountActivityMonitor", exc_info=True)
+            await _degraded(rt, "AccountActivityMonitor")
+
+        try:
             from genesis.recon.model_intelligence import ModelIntelligenceJob
             mi_job = ModelIntelligenceJob(
                 db=rt._db,

--- a/src/genesis/surplus/jobs/context.py
+++ b/src/genesis/surplus/jobs/context.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
     from genesis.memory.store import MemoryStore
     from genesis.observability.events import GenesisEventBus
+    from genesis.recon.account_activity import AccountActivityMonitor
     from genesis.recon.gatherer import ReconGatherer
     from genesis.routing.router import Router
     from genesis.surplus.brainstorm import BrainstormRunner
@@ -39,6 +40,7 @@ class SchedulerContext(Protocol):
     _maintenance_hours: int
     _analytical_hours: int
     _recon_gatherer: ReconGatherer | None
+    _account_activity_monitor: AccountActivityMonitor | None
     _model_intelligence_job: Any
     _models_md_synthesis_job: Any
     _skill_security_scan_job: Any

--- a/src/genesis/surplus/jobs/runners.py
+++ b/src/genesis/surplus/jobs/runners.py
@@ -88,6 +88,37 @@ async def run_recon_gather(sched: SchedulerContext) -> None:
         record_failure("recon_gather", str(exc))
 
 
+async def run_account_activity_monitor(sched: SchedulerContext) -> None:
+    """Poll owner repos for EXTERNAL GitHub activity; ping first-time contributors."""
+    if sched._account_activity_monitor is None:
+        record_failure("account_activity_monitor", "monitor not wired")
+        return
+    try:
+        result = await sched._account_activity_monitor.gather()
+        if result.new_events or result.pinged or result.errors:
+            logger.info(
+                "GitHub steward: mode=%s repos=%d new=%d pinged=%d errors=%d",
+                result.mode, result.checked_repos, result.new_events,
+                result.pinged, result.errors,
+            )
+        if sched._event_bus:
+            await sched._event_bus.emit(
+                Subsystem.RECON, Severity.DEBUG,
+                "heartbeat", "account_activity_monitor completed",
+            )
+        record_success("account_activity_monitor")
+    except Exception as exc:
+        logger.exception("Account activity monitor failed")
+        if sched._event_bus:
+            await sched._event_bus.emit(
+                Subsystem.RECON, Severity.ERROR,
+                "account_activity_monitor.failed",
+                "Account activity monitor failed with exception",
+                **failure_details(exc=exc),
+            )
+        record_failure("account_activity_monitor", str(exc))
+
+
 async def run_model_intelligence(sched: SchedulerContext) -> None:
     """Run model intelligence scan (weekly)."""
     if sched._model_intelligence_job is None:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -35,6 +35,7 @@ from genesis.surplus.types import SurplusExecutor, TaskType
 
 if TYPE_CHECKING:
     from genesis.memory.store import MemoryStore
+    from genesis.recon.account_activity import AccountActivityMonitor
     from genesis.recon.gatherer import ReconGatherer
     from genesis.routing.router import Router
 
@@ -118,6 +119,7 @@ class SurplusScheduler:
         # self._executor for any type without a registered entry.
         self._executors: dict[TaskType, SurplusExecutor] = {}
         self._recon_gatherer: ReconGatherer | None = None
+        self._account_activity_monitor: AccountActivityMonitor | None = None
         self._model_intelligence_job = None  # Set via set_model_intelligence_job()
         self._models_md_synthesis_job = None  # Set via set_models_md_synthesis_job()
         self._skill_security_scan_job = None  # Set via set_skill_security_scan_job()
@@ -207,6 +209,10 @@ class SurplusScheduler:
     def set_recon_gatherer(self, gatherer: ReconGatherer) -> None:
         """Set the recon gatherer for scheduled release checking."""
         self._recon_gatherer = gatherer
+
+    def set_account_activity_monitor(self, monitor: AccountActivityMonitor) -> None:
+        """Set the GitHub account-activity monitor (2h external-activity poll)."""
+        self._account_activity_monitor = monitor
 
     def set_model_intelligence_job(self, job) -> None:
         """Set the ModelIntelligenceJob for scheduled model landscape scanning."""
@@ -301,6 +307,16 @@ class SurplusScheduler:
             self.run_recon_gather,
             CronTrigger(day_of_week="tue,fri", hour=1, minute=45, timezone=user_timezone()),
             id="recon_gather",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+        # GitHub account-activity monitor: every 2h local. Deterministic (no
+        # LLM) external-activity watch. CronTrigger, never IntervalTrigger
+        # (which resets on restart).
+        self._scheduler.add_job(
+            self.run_account_activity_monitor,
+            CronTrigger(hour="*/2", timezone=user_timezone()),
+            id="account_activity_monitor",
             max_instances=1,
             misfire_grace_time=3600,
         )
@@ -720,6 +736,10 @@ class SurplusScheduler:
     async def run_recon_gather(self) -> None:
         """Check watchlist projects for new GitHub releases and star counts."""
         await runner_jobs.run_recon_gather(self)
+
+    async def run_account_activity_monitor(self) -> None:
+        """Poll owner repos for external GitHub activity (every 2h)."""
+        await runner_jobs.run_account_activity_monitor(self)
 
     async def run_model_intelligence(self) -> None:
         """Run model intelligence scan (weekly)."""

--- a/tests/test_recon/test_account_activity.py
+++ b/tests/test_recon/test_account_activity.py
@@ -1,8 +1,9 @@
 """Core logic of the GitHub account-activity monitor — no live gh calls.
 
-Exercises classification, event dedup, first-time detection, observe-vs-live
-ping gating, the cursor sidecar, and first-run seeding against a real in-memory
-observations store (no mocking of the crud chain).
+Exercises classification, event dedup, first-contact detection, observe-vs-live
+ping gating, the durable retry state machine, the created_at watermark model,
+the cursor sidecar, and first-run seeding against a real in-memory observations
+store (no mocking of the crud chain).
 """
 
 from __future__ import annotations
@@ -12,11 +13,14 @@ import pytest
 import pytest_asyncio
 
 from genesis.db.crud import observations
+from genesis.outreach.types import OutreachResult, OutreachStatus
 from genesis.recon.account_activity import (
     AccountActivityMonitor,
     ActivityEvent,
     _actor_hash,
     _event_hash,
+    _parse_paged,
+    _pending_hash,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -36,12 +40,21 @@ async def db():
 
 
 class _FakePipeline:
-    def __init__(self) -> None:
+    """Fake outreach pipeline. ``status`` controls the delivery verdict of the
+    next submit_raw (mutable between calls, to simulate a recovery)."""
+
+    def __init__(self, status: OutreachStatus = OutreachStatus.DELIVERED) -> None:
         self.sent: list = []
+        self.status = status
 
     async def submit_raw(self, text, request):
         self.sent.append((text, request))
-        return None
+        return OutreachResult(
+            outreach_id="fake",
+            status=self.status,
+            channel="telegram",
+            message_content=text,
+        )
 
 
 def _ev(
@@ -51,7 +64,7 @@ def _ev(
     node="N1",
     num=1,
     repo="owner/repo",
-    updated_at="2026-08-06T04:00:00Z",
+    created_at="2026-08-06T04:00:00Z",
 ) -> ActivityEvent:
     return ActivityEvent(
         repo=repo,
@@ -61,13 +74,15 @@ def _ev(
         number=num,
         title="Fix chunk_messages docstring",
         url="https://github.com/owner/repo/pull/1",
-        updated_at=updated_at,
+        created_at=created_at,
     )
 
 
-def _stub_gather(mon, monkeypatch, tmp_path, *, mode, events_by_repo, max_events=100):
-    """Wire a monitor for a gather() test: stub owner/repos/poll/classifier + a
-    temp sidecar, so gather()'s orchestration is exercised without live gh."""
+def _stub_gather(
+    mon, monkeypatch, tmp_path, *, mode, events_by_repo, max_events=100, wm="2026-08-06T05:00:00Z"
+):
+    """Wire a monitor for a gather() test: stub owner/repos/poll/classifier/wm +
+    a temp sidecar, so gather()'s orchestration is exercised without live gh."""
     import genesis.recon.github_steward_config as gsc
 
     repos = list(events_by_repo.keys())
@@ -82,6 +97,7 @@ def _stub_gather(mon, monkeypatch, tmp_path, *, mode, events_by_repo, max_events
         },
     )
     monkeypatch.setattr("genesis.recon.account_activity.genesis_home", lambda: tmp_path)
+    monkeypatch.setattr("genesis.recon.account_activity._now_z", lambda: wm)
     mon._owner = "owner"  # skip the live gh api user lookup
 
     async def fake_poll(repo, since, owner):
@@ -94,9 +110,9 @@ def _stub_gather(mon, monkeypatch, tmp_path, *, mode, events_by_repo, max_events
     mon._is_automation = not_automation
 
 
-def _mon(db) -> tuple[AccountActivityMonitor, _FakePipeline]:
+def _mon(db, status: OutreachStatus = OutreachStatus.DELIVERED):
     mon = AccountActivityMonitor(db)
-    pipe = _FakePipeline()
+    pipe = _FakePipeline(status)
     mon._pipeline = lambda: pipe  # lazy resolver → fake
     return mon, pipe
 
@@ -123,9 +139,10 @@ async def test_first_time_external_pings_in_live(db):
     assert "First-time contributor" in text and "AyushkhatiDev" in text
     assert req.channel == "telegram"
     assert req.topic.startswith("GitHub steward:")
-    # event + actor both recorded
+    # event recorded + actor marked seen (delivered), NO pending owed.
     assert await _has(db, _event_hash("owner/repo", "pr", "N1"))
     assert await _has(db, _actor_hash("AyushkhatiDev"))
+    assert not await _has(db, _pending_hash("AyushkhatiDev"))
 
 
 async def test_observe_mode_records_but_never_pings(db):
@@ -135,6 +152,7 @@ async def test_observe_mode_records_but_never_pings(db):
     assert pinged is False
     assert pipe.sent == []
     assert await _has(db, _event_hash("owner/repo", "pr", "N1"))  # still recorded
+    assert await _has(db, _actor_hash("AyushkhatiDev"))  # seeded seen (no ping expected)
     assert await _count(db, "github_account_activity") == 1
 
 
@@ -160,6 +178,126 @@ async def test_returning_contributor_records_without_ping(db):
     assert await _count(db, "github_account_activity") == 2
 
 
+# ── P2#5 — durable retry state machine ───────────────────────────────────────
+
+
+async def test_failed_ping_queues_pending_and_does_not_mark_seen(db):
+    """A non-delivered first-time ping (FAILED/IGNORED) must NOT burn the
+    first-contact signal: the actor stays un-seen and a pending marker is owed."""
+    mon, pipe = _mon(db, status=OutreachStatus.FAILED)
+    pinged = await mon._record_event(_ev(), "live")
+
+    assert pinged is False  # not delivered → not counted as a ping
+    assert len(pipe.sent) == 1  # we DID attempt
+    # activity recorded (durable), but actor NOT marked seen, pending IS owed.
+    assert await _has(db, _event_hash("owner/repo", "pr", "N1"))
+    assert not await _has(db, _actor_hash("AyushkhatiDev"))
+    assert await _has(db, _pending_hash("AyushkhatiDev"))
+
+
+async def test_pending_actor_not_treated_as_seen_but_not_requeued(db):
+    """A second event by a still-pending actor records but neither re-pings nor
+    creates a duplicate pending row (first-contact collapsed to the actor)."""
+    mon, pipe = _mon(db, status=OutreachStatus.FAILED)
+    await mon._record_event(_ev(node="N1"), "live")  # fails → pending
+    assert len(pipe.sent) == 1
+    pipe.sent.clear()
+
+    await mon._record_event(_ev(node="N2"), "live")  # same actor, still pending
+    assert pipe.sent == []  # no second ping attempt
+    assert await _count(db, "github_ping_pending") == 1  # not duplicated
+    assert await _count(db, "github_account_activity") == 2  # both events recorded
+
+
+async def test_drain_pending_delivers_then_marks_seen_and_resolves(db):
+    """When the pipeline recovers, the drain re-pings the pending actor exactly
+    once, marks them seen, and resolves the pending row."""
+    mon, pipe = _mon(db, status=OutreachStatus.FAILED)
+    await mon._record_event(_ev(), "live")  # fails → pending owed
+    pipe.sent.clear()
+    pipe.status = OutreachStatus.DELIVERED  # pipeline recovers
+
+    drained = await mon._drain_pending("live")
+
+    assert drained == 1
+    assert len(pipe.sent) == 1  # exactly one retry ping
+    assert await _has(db, _actor_hash("AyushkhatiDev"))  # now seen
+    # pending row resolved (no longer unresolved).
+    remaining = await observations.query(
+        db, source="recon", type="github_ping_pending", resolved=False
+    )
+    assert remaining == []
+
+
+async def test_drain_still_failing_leaves_pending(db):
+    mon, pipe = _mon(db, status=OutreachStatus.FAILED)
+    await mon._record_event(_ev(), "live")  # fails → pending
+    pipe.sent.clear()
+
+    drained = await mon._drain_pending("live")  # still FAILED
+
+    assert drained == 0
+    remaining = await observations.query(
+        db, source="recon", type="github_ping_pending", resolved=False
+    )
+    assert len(remaining) == 1  # still owed, will retry next tick
+    assert not await _has(db, _actor_hash("AyushkhatiDev"))  # still un-seen
+
+
+async def test_expired_pending_re_arms_first_contact(db):
+    """BLOCKER-1 regression: after the TTL sweep RESOLVES an abandoned (never
+    delivered) pending row, the actor must NOT be permanently suppressed — a
+    later event re-arms the first-contact attempt (else exists_by_hash on the
+    resolved pending row would read as 'already contacted' forever)."""
+    mon, pipe = _mon(db, status=OutreachStatus.FAILED)
+    await mon._record_event(_ev(node="N1"), "live")  # fails → pending (unresolved)
+    # Simulate the daily TTL sweep resolving the abandoned pending marker.
+    await observations.resolve_by_content_hash(
+        db,
+        source="recon",
+        content_hash=_pending_hash("AyushkhatiDev"),
+        resolved_at="2026-08-13T00:00:00Z",
+        resolution_notes="auto-expired (TTL)",
+    )
+    pipe.sent.clear()
+    pipe.status = OutreachStatus.DELIVERED  # pipeline recovered
+
+    pinged = await mon._record_event(_ev(node="N2"), "live")  # new event, same actor
+
+    assert pinged is True  # re-armed, not permanently suppressed
+    assert await _has(db, _actor_hash("AyushkhatiDev"))  # now delivered → seen
+
+
+async def test_drain_resolves_pending_if_actor_already_seen(db):
+    """Defensive: if an actor became seen by another path, a stale pending row is
+    resolved WITHOUT a duplicate ping."""
+    mon, pipe = _mon(db, status=OutreachStatus.FAILED)
+    await mon._record_event(_ev(), "live")  # fails → pending
+    # mark actor seen out-of-band (simulates a concurrent delivery)
+    await observations.create(
+        db,
+        id="x",
+        source="recon",
+        type="github_actor_seen",
+        content="seen:AyushkhatiDev",
+        priority="low",
+        created_at="2026-08-06T04:00:00Z",
+        content_hash=_actor_hash("AyushkhatiDev"),
+        skip_if_duplicate=True,
+    )
+    pipe.sent.clear()
+    pipe.status = OutreachStatus.DELIVERED
+
+    drained = await mon._drain_pending("live")
+
+    assert pipe.sent == []  # no double-ping
+    assert drained == 0
+    remaining = await observations.query(
+        db, source="recon", type="github_ping_pending", resolved=False
+    )
+    assert remaining == []  # stale pending cleared
+
+
 # ── classifier ───────────────────────────────────────────────────────────────
 
 
@@ -172,20 +310,34 @@ async def test_is_automation_bot_and_denylist_need_no_gh_call(db):
 async def test_is_automation_resolves_type(db, monkeypatch):
     mon, _ = _mon(db)
 
-    async def fake_run_gh(*args, **kwargs):
-        return "Organization"  # e.g. dependabot
+    async def org(*args, **kwargs):
+        return True, "Organization"  # e.g. dependabot
 
-    monkeypatch.setattr("genesis.recon.account_activity.run_gh", fake_run_gh)
+    monkeypatch.setattr("genesis.recon.account_activity.run_gh_checked", org)
     assert await mon._is_automation("dependabot", set()) is True
 
     async def human(*args, **kwargs):
-        return "User"
+        return True, "User"
 
-    monkeypatch.setattr("genesis.recon.account_activity.run_gh", human)
+    monkeypatch.setattr("genesis.recon.account_activity.run_gh_checked", human)
     assert await mon._is_automation("AyushkhatiDev", set()) is False
 
 
-# ── cursor sidecar ───────────────────────────────────────────────────────────
+async def test_is_automation_unresolved_returns_none(db, monkeypatch):
+    """BLOCKER-2: a FAILED users/{login} lookup must return None (unknown), not
+    True — so the caller holds the cursor instead of silently dropping a possible
+    human. An unknown verdict must NOT be cached (retry next tick)."""
+    mon, _ = _mon(db)
+
+    async def failed(*args, **kwargs):
+        return False, ""  # run_gh_checked failure
+
+    monkeypatch.setattr("genesis.recon.account_activity.run_gh_checked", failed)
+    assert await mon._is_automation("someone", set()) is None
+    assert "someone" not in mon._automation_cache  # not cached — retry later
+
+
+# ── cursor sidecar + format normalization ────────────────────────────────────
 
 
 async def test_cursor_sidecar_roundtrip(db, monkeypatch, tmp_path):
@@ -195,6 +347,30 @@ async def test_cursor_sidecar_roundtrip(db, monkeypatch, tmp_path):
     assert mon._load_cursors() == {}  # no file yet
     mon._save_cursors({"owner/repo": "2026-08-06T00:00:00Z"})
     assert mon._load_cursors() == {"owner/repo": "2026-08-06T00:00:00Z"}
+
+
+async def test_load_cursors_normalizes_offset_format(db, monkeypatch, tmp_path):
+    """A legacy cursor written as `+00:00` (isoformat) is normalized to `Z` so
+    lexical comparison against Z-suffixed GitHub timestamps is correct."""
+    mon, _ = _mon(db)
+    monkeypatch.setattr("genesis.recon.account_activity.genesis_home", lambda: tmp_path)
+    (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "github_steward" / "cursors.json").write_text(
+        '{"version": 1, "cursors": {"owner/repo": "2026-08-06T00:00:00+00:00"}}'
+    )
+    assert mon._load_cursors() == {"owner/repo": "2026-08-06T00:00:00Z"}
+
+
+# ── paginated-baseline parsing (P2#3) ────────────────────────────────────────
+
+
+async def test_parse_paged_flattens_pages():
+    # --slurp wraps each page's array into an outer array.
+    payload = '[[{"a": 1}], [{"a": 2}, {"a": 3}]]'
+    assert _parse_paged(payload) == [{"a": 1}, {"a": 2}, {"a": 3}]
+    # A non-paginated flat array is returned as-is.
+    assert _parse_paged('[{"a": 1}]') == [{"a": 1}]
+    assert _parse_paged("") == []
 
 
 # ── first-run seeding ────────────────────────────────────────────────────────
@@ -210,12 +386,94 @@ async def test_seed_actors_marks_all_without_records(db):
     assert await _count(db, "github_account_activity") == 0  # seeding writes no activity
 
 
-# ── gather() orchestration (the layer both review blockers lived in) ─────────
+# ── gather() orchestration ───────────────────────────────────────────────────
+
+
+async def test_gather_advances_cursor_to_watermark(db, monkeypatch, tmp_path):
+    """P2#2: after a normal (non-truncated) tick, the cursor advances to the
+    watermark captured BEFORE polling — NOT to the newest event's timestamp."""
+    repo = "owner/repo"
+    mon, pipe = _mon(db)
+    _stub_gather(
+        mon,
+        monkeypatch,
+        tmp_path,
+        mode="live",
+        wm="2026-08-06T05:00:00Z",
+        events_by_repo={repo: [_ev(actor="alice", node="A", created_at="2026-08-06T04:00:00Z")]},
+    )
+    (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "github_steward" / "cursors.json").write_text(
+        '{"version": 1, "cursors": {"owner/repo": "2026-08-06T00:00:00Z"}}'
+    )
+
+    await mon.gather()
+
+    # Cursor == watermark, not the event's 04:00 created_at.
+    assert mon._load_cursors()[repo] == "2026-08-06T05:00:00Z"
+
+
+async def test_gather_filters_old_created_before_cursor(db, monkeypatch, tmp_path):
+    """P2#1: an old issue re-surfaced by an edit (created_at <= cursor, but
+    returned because updated_at moved) is NOT recorded or pinged."""
+    repo = "owner/repo"
+    mon, pipe = _mon(db)
+    _stub_gather(
+        mon,
+        monkeypatch,
+        tmp_path,
+        mode="live",
+        wm="2026-08-06T05:00:00Z",
+        events_by_repo={
+            repo: [
+                # created long before the cursor — an edited old item.
+                _ev(actor="olduser", node="OLD", created_at="2026-01-01T00:00:00Z"),
+                # a genuinely new one after the cursor.
+                _ev(actor="newuser", node="NEW", created_at="2026-08-06T04:00:00Z"),
+            ]
+        },
+    )
+    (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "github_steward" / "cursors.json").write_text(
+        '{"version": 1, "cursors": {"owner/repo": "2026-08-01T00:00:00Z"}}'
+    )
+
+    await mon.gather()
+
+    pinged = {req.topic.split()[2] for _t, req in pipe.sent}
+    assert "newuser" in pinged
+    assert "olduser" not in pinged  # filtered by created_at <= cursor
+    assert not await _has(db, _event_hash(repo, "pr", "OLD"))  # not even recorded
+    assert await _has(db, _event_hash(repo, "pr", "NEW"))
+
+
+async def test_gather_drops_events_after_watermark(db, monkeypatch, tmp_path):
+    """An event created mid-poll (created_at > wm) is deferred this tick — not
+    recorded — and will re-fetch next tick (exclusive `since`)."""
+    repo = "owner/repo"
+    mon, pipe = _mon(db)
+    _stub_gather(
+        mon,
+        monkeypatch,
+        tmp_path,
+        mode="live",
+        wm="2026-08-06T05:00:00Z",
+        events_by_repo={repo: [_ev(actor="future", node="F", created_at="2026-08-06T05:30:00Z")]},
+    )
+    (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "github_steward" / "cursors.json").write_text(
+        '{"version": 1, "cursors": {"owner/repo": "2026-08-06T00:00:00Z"}}'
+    )
+
+    await mon.gather()
+
+    assert pipe.sent == []  # nothing at/after wm processed
+    assert not await _has(db, _event_hash(repo, "pr", "F"))
 
 
 async def test_gather_baselines_cursorless_repo_per_repo(db, monkeypatch, tmp_path):
     """A repo with NO cursor is baselined (seed, no ping) even when a SIBLING
-    repo already has one — per-repo, not global first-run (review BLOCKER 2)."""
+    repo already has one — per-repo, not global first-run."""
     r1, r2 = "owner/has-cursor", "owner/new-repo"
     mon, pipe = _mon(db)
     _stub_gather(
@@ -223,9 +481,10 @@ async def test_gather_baselines_cursorless_repo_per_repo(db, monkeypatch, tmp_pa
         monkeypatch,
         tmp_path,
         mode="live",
+        wm="2026-08-06T05:00:00Z",
         events_by_repo={
-            r1: [_ev(actor="alice", node="A1", repo=r1)],
-            r2: [_ev(actor="bob", node="B1", repo=r2)],
+            r1: [_ev(actor="alice", node="A1", repo=r1, created_at="2026-08-06T04:00:00Z")],
+            r2: [_ev(actor="bob", node="B1", repo=r2, created_at="2026-08-06T04:00:00Z")],
         },
     )
     (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
@@ -239,18 +498,50 @@ async def test_gather_baselines_cursorless_repo_per_repo(db, monkeypatch, tmp_pa
     assert "alice" in pinged  # cursored repo → processed, first-time ping
     assert "bob" not in pinged  # cursorless repo → baselined, NO ping
     assert r.errors == 0
-    assert r2 in mon._load_cursors()  # new repo now baselined with a cursor
+    assert mon._load_cursors()[r2] == "2026-08-06T05:00:00Z"  # baselined to wm
+
+
+async def test_gather_unresolved_automation_holds_cursor_not_drops(db, monkeypatch, tmp_path):
+    """BLOCKER-2: if the human/bot verdict can't be resolved for an actor, the
+    repo cursor is HELD (not advanced to wm) so the event re-fetches next tick —
+    a transient classification failure must never silently drop a contributor."""
+    repo = "owner/repo"
+    mon, pipe = _mon(db)
+    _stub_gather(
+        mon,
+        monkeypatch,
+        tmp_path,
+        mode="live",
+        wm="2026-08-06T05:00:00Z",
+        events_by_repo={repo: [_ev(actor="maybe", node="M", created_at="2026-08-06T04:00:00Z")]},
+    )
+
+    async def unknown(login, denylist):
+        return None  # verdict can't be resolved
+
+    mon._is_automation = unknown
+    (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "github_steward" / "cursors.json").write_text(
+        '{"version": 1, "cursors": {"owner/repo": "2026-08-01T00:00:00Z"}}'
+    )
+
+    await mon.gather()
+
+    # Cursor HELD at the old value, not advanced to wm — event re-fetches next tick.
+    assert mon._load_cursors()[repo] == "2026-08-01T00:00:00Z"
+    assert pipe.sent == []  # not pinged (unknown), but not dropped either
+    assert not await _has(db, _event_hash(repo, "pr", "M"))  # not recorded yet
 
 
 async def test_gather_truncation_holds_cursor_at_last_processed(db, monkeypatch, tmp_path):
     """With more events than the cap, the cursor advances only to the last
-    PROCESSED event — the rest re-fetch next tick, never dropped (BLOCKER 1)."""
+    PROCESSED event's created_at — the rest re-fetch next tick, never dropped."""
     repo = "owner/busy"
     mon, pipe = _mon(db)
     evs = [
-        _ev(actor="a", node="A", repo=repo, updated_at="2026-08-06T01:00:00Z"),
-        _ev(actor="b", node="B", repo=repo, updated_at="2026-08-06T02:00:00Z"),
-        _ev(actor="c", node="C", repo=repo, updated_at="2026-08-06T03:00:00Z"),
+        _ev(actor="a", node="A", repo=repo, created_at="2026-08-06T01:00:00Z"),
+        _ev(actor="b", node="B", repo=repo, created_at="2026-08-06T02:00:00Z"),
+        _ev(actor="c", node="C", repo=repo, created_at="2026-08-06T03:00:00Z"),
     ]
     _stub_gather(mon, monkeypatch, tmp_path, mode="live", max_events=2, events_by_repo={repo: evs})
     (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
@@ -264,21 +555,21 @@ async def test_gather_truncation_holds_cursor_at_last_processed(db, monkeypatch,
     assert pinged == {"a", "b"}  # only the oldest 2 processed
     assert "c" not in pinged  # the 3rd is deferred, NOT dropped
     assert r.errors == 0
-    # Cursor stops at the last PROCESSED event (b @ 02:00), NOT the newest (c @ 03:00).
+    # Cursor stops at the last PROCESSED event (b @ 02:00), NOT the watermark.
     assert mon._load_cursors()[repo] == "2026-08-06T02:00:00Z"
 
 
 async def test_gather_truncation_boundary_tie_does_not_strand_twin(db, monkeypatch, tmp_path):
     """`since` is EXCLUSIVE: if the cap splits a same-second group, the cursor
-    must stop BEFORE that second (not on it), or the deferred twin's ts would
-    equal the cursor and never re-fetch."""
+    must stop BEFORE that second, or the deferred twin's ts would equal the
+    cursor and never re-fetch."""
     repo = "owner/tie"
     mon, pipe = _mon(db)
     evs = [
-        _ev(actor="a", node="A", repo=repo, updated_at="2026-08-06T01:00:00Z"),
-        _ev(actor="b", node="B", repo=repo, updated_at="2026-08-06T02:00:00Z"),  # tie
-        _ev(actor="c", node="C", repo=repo, updated_at="2026-08-06T02:00:00Z"),  # tie (deferred)
-        _ev(actor="d", node="D", repo=repo, updated_at="2026-08-06T03:00:00Z"),
+        _ev(actor="a", node="A", repo=repo, created_at="2026-08-06T01:00:00Z"),
+        _ev(actor="b", node="B", repo=repo, created_at="2026-08-06T02:00:00Z"),  # tie
+        _ev(actor="c", node="C", repo=repo, created_at="2026-08-06T02:00:00Z"),  # tie (deferred)
+        _ev(actor="d", node="D", repo=repo, created_at="2026-08-06T03:00:00Z"),
     ]
     _stub_gather(mon, monkeypatch, tmp_path, mode="live", max_events=2, events_by_repo={repo: evs})
     (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
@@ -288,7 +579,7 @@ async def test_gather_truncation_boundary_tie_does_not_strand_twin(db, monkeypat
 
     await mon.gather()
 
-    # b (02:00) was processed, but its twin c (02:00) was deferred — so the cursor
-    # must hold at a (01:00), strictly before the tie second, so the next
-    # exclusive `since` poll re-fetches the whole 02:00 group (b via dedup, c fresh).
+    # b (02:00) processed but its twin c (02:00) deferred → cursor holds at
+    # a (01:00), strictly before the tie second, so the next exclusive `since`
+    # poll re-fetches the whole 02:00 group (b via dedup, c fresh).
     assert mon._load_cursors()[repo] == "2026-08-06T01:00:00Z"

--- a/tests/test_recon/test_account_activity.py
+++ b/tests/test_recon/test_account_activity.py
@@ -1,0 +1,294 @@
+"""Core logic of the GitHub account-activity monitor — no live gh calls.
+
+Exercises classification, event dedup, first-time detection, observe-vs-live
+ping gating, the cursor sidecar, and first-run seeding against a real in-memory
+observations store (no mocking of the crud chain).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from genesis.db.crud import observations
+from genesis.recon.account_activity import (
+    AccountActivityMonitor,
+    ActivityEvent,
+    _actor_hash,
+    _event_hash,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def db():
+    from genesis.db.schema import create_all_tables
+
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    try:
+        yield conn
+    finally:
+        await conn.close()
+
+
+class _FakePipeline:
+    def __init__(self) -> None:
+        self.sent: list = []
+
+    async def submit_raw(self, text, request):
+        self.sent.append((text, request))
+        return None
+
+
+def _ev(
+    *,
+    actor="AyushkhatiDev",
+    kind="pr",
+    node="N1",
+    num=1,
+    repo="owner/repo",
+    updated_at="2026-08-06T04:00:00Z",
+) -> ActivityEvent:
+    return ActivityEvent(
+        repo=repo,
+        kind=kind,
+        node_id=node,
+        actor=actor,
+        number=num,
+        title="Fix chunk_messages docstring",
+        url="https://github.com/owner/repo/pull/1",
+        updated_at=updated_at,
+    )
+
+
+def _stub_gather(mon, monkeypatch, tmp_path, *, mode, events_by_repo, max_events=100):
+    """Wire a monitor for a gather() test: stub owner/repos/poll/classifier + a
+    temp sidecar, so gather()'s orchestration is exercised without live gh."""
+    import genesis.recon.github_steward_config as gsc
+
+    repos = list(events_by_repo.keys())
+    monkeypatch.setattr(gsc, "effective_mode", lambda: mode)
+    monkeypatch.setattr(
+        gsc,
+        "load_config",
+        lambda: {
+            "flagship_repos": repos,
+            "automation_denylist": [],
+            "max_events_per_tick": max_events,
+        },
+    )
+    monkeypatch.setattr("genesis.recon.account_activity.genesis_home", lambda: tmp_path)
+    mon._owner = "owner"  # skip the live gh api user lookup
+
+    async def fake_poll(repo, since, owner):
+        return True, list(events_by_repo.get(repo, []))
+
+    async def not_automation(login, denylist):
+        return False
+
+    mon._poll_repo = fake_poll
+    mon._is_automation = not_automation
+
+
+def _mon(db) -> tuple[AccountActivityMonitor, _FakePipeline]:
+    mon = AccountActivityMonitor(db)
+    pipe = _FakePipeline()
+    mon._pipeline = lambda: pipe  # lazy resolver → fake
+    return mon, pipe
+
+
+async def _has(db, content_hash) -> bool:
+    return await observations.exists_by_hash(db, source="recon", content_hash=content_hash)
+
+
+async def _count(db, obs_type) -> int:
+    cur = await db.execute("SELECT COUNT(*) FROM observations WHERE type = ?", (obs_type,))
+    return (await cur.fetchone())[0]
+
+
+# ── ping gating ────────────────────────────────────────────────────────────
+
+
+async def test_first_time_external_pings_in_live(db):
+    mon, pipe = _mon(db)
+    pinged = await mon._record_event(_ev(), "live")
+
+    assert pinged is True
+    assert len(pipe.sent) == 1
+    text, req = pipe.sent[0]
+    assert "First-time contributor" in text and "AyushkhatiDev" in text
+    assert req.channel == "telegram"
+    assert req.topic.startswith("GitHub steward:")
+    # event + actor both recorded
+    assert await _has(db, _event_hash("owner/repo", "pr", "N1"))
+    assert await _has(db, _actor_hash("AyushkhatiDev"))
+
+
+async def test_observe_mode_records_but_never_pings(db):
+    mon, pipe = _mon(db)
+    pinged = await mon._record_event(_ev(), "observe")
+
+    assert pinged is False
+    assert pipe.sent == []
+    assert await _has(db, _event_hash("owner/repo", "pr", "N1"))  # still recorded
+    assert await _count(db, "github_account_activity") == 1
+
+
+async def test_dedup_second_sighting_is_noop(db):
+    mon, pipe = _mon(db)
+    await mon._record_event(_ev(), "live")
+    pipe.sent.clear()
+
+    pinged = await mon._record_event(_ev(), "live")  # identical event
+    assert pinged is False
+    assert pipe.sent == []
+    assert await _count(db, "github_account_activity") == 1  # not double-recorded
+
+
+async def test_returning_contributor_records_without_ping(db):
+    mon, pipe = _mon(db)
+    await mon._record_event(_ev(node="N1"), "live")  # first-time → seen + ping
+    pipe.sent.clear()
+
+    pinged = await mon._record_event(_ev(node="N2"), "live")  # same actor, new event
+    assert pinged is False  # no longer first-time
+    assert pipe.sent == []
+    assert await _count(db, "github_account_activity") == 2
+
+
+# ── classifier ───────────────────────────────────────────────────────────────
+
+
+async def test_is_automation_bot_and_denylist_need_no_gh_call(db):
+    mon, _ = _mon(db)
+    assert await mon._is_automation("chatgpt-codex-connector[bot]", set()) is True
+    assert await mon._is_automation("SomeReviewBot", {"somereviewbot"}) is True
+
+
+async def test_is_automation_resolves_type(db, monkeypatch):
+    mon, _ = _mon(db)
+
+    async def fake_run_gh(*args, **kwargs):
+        return "Organization"  # e.g. dependabot
+
+    monkeypatch.setattr("genesis.recon.account_activity.run_gh", fake_run_gh)
+    assert await mon._is_automation("dependabot", set()) is True
+
+    async def human(*args, **kwargs):
+        return "User"
+
+    monkeypatch.setattr("genesis.recon.account_activity.run_gh", human)
+    assert await mon._is_automation("AyushkhatiDev", set()) is False
+
+
+# ── cursor sidecar ───────────────────────────────────────────────────────────
+
+
+async def test_cursor_sidecar_roundtrip(db, monkeypatch, tmp_path):
+    mon, _ = _mon(db)
+    monkeypatch.setattr("genesis.recon.account_activity.genesis_home", lambda: tmp_path)
+
+    assert mon._load_cursors() == {}  # no file yet
+    mon._save_cursors({"owner/repo": "2026-08-06T00:00:00Z"})
+    assert mon._load_cursors() == {"owner/repo": "2026-08-06T00:00:00Z"}
+
+
+# ── first-run seeding ────────────────────────────────────────────────────────
+
+
+async def test_seed_actors_marks_all_without_records(db):
+    mon, _ = _mon(db)
+    seeded = await mon._seed_actors([_ev(actor="alice"), _ev(actor="bob", node="N2")])
+
+    assert seeded == 2
+    assert await _has(db, _actor_hash("alice"))
+    assert await _has(db, _actor_hash("bob"))
+    assert await _count(db, "github_account_activity") == 0  # seeding writes no activity
+
+
+# ── gather() orchestration (the layer both review blockers lived in) ─────────
+
+
+async def test_gather_baselines_cursorless_repo_per_repo(db, monkeypatch, tmp_path):
+    """A repo with NO cursor is baselined (seed, no ping) even when a SIBLING
+    repo already has one — per-repo, not global first-run (review BLOCKER 2)."""
+    r1, r2 = "owner/has-cursor", "owner/new-repo"
+    mon, pipe = _mon(db)
+    _stub_gather(
+        mon,
+        monkeypatch,
+        tmp_path,
+        mode="live",
+        events_by_repo={
+            r1: [_ev(actor="alice", node="A1", repo=r1)],
+            r2: [_ev(actor="bob", node="B1", repo=r2)],
+        },
+    )
+    (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "github_steward" / "cursors.json").write_text(
+        '{"version": 1, "cursors": {"owner/has-cursor": "2026-08-01T00:00:00Z"}}'
+    )
+
+    r = await mon.gather()
+
+    pinged = {req.topic.split()[2] for _t, req in pipe.sent}
+    assert "alice" in pinged  # cursored repo → processed, first-time ping
+    assert "bob" not in pinged  # cursorless repo → baselined, NO ping
+    assert r.errors == 0
+    assert r2 in mon._load_cursors()  # new repo now baselined with a cursor
+
+
+async def test_gather_truncation_holds_cursor_at_last_processed(db, monkeypatch, tmp_path):
+    """With more events than the cap, the cursor advances only to the last
+    PROCESSED event — the rest re-fetch next tick, never dropped (BLOCKER 1)."""
+    repo = "owner/busy"
+    mon, pipe = _mon(db)
+    evs = [
+        _ev(actor="a", node="A", repo=repo, updated_at="2026-08-06T01:00:00Z"),
+        _ev(actor="b", node="B", repo=repo, updated_at="2026-08-06T02:00:00Z"),
+        _ev(actor="c", node="C", repo=repo, updated_at="2026-08-06T03:00:00Z"),
+    ]
+    _stub_gather(mon, monkeypatch, tmp_path, mode="live", max_events=2, events_by_repo={repo: evs})
+    (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "github_steward" / "cursors.json").write_text(
+        '{"version": 1, "cursors": {"owner/busy": "2026-08-05T00:00:00Z"}}'
+    )
+
+    r = await mon.gather()
+
+    pinged = {req.topic.split()[2] for _t, req in pipe.sent}
+    assert pinged == {"a", "b"}  # only the oldest 2 processed
+    assert "c" not in pinged  # the 3rd is deferred, NOT dropped
+    assert r.errors == 0
+    # Cursor stops at the last PROCESSED event (b @ 02:00), NOT the newest (c @ 03:00).
+    assert mon._load_cursors()[repo] == "2026-08-06T02:00:00Z"
+
+
+async def test_gather_truncation_boundary_tie_does_not_strand_twin(db, monkeypatch, tmp_path):
+    """`since` is EXCLUSIVE: if the cap splits a same-second group, the cursor
+    must stop BEFORE that second (not on it), or the deferred twin's ts would
+    equal the cursor and never re-fetch."""
+    repo = "owner/tie"
+    mon, pipe = _mon(db)
+    evs = [
+        _ev(actor="a", node="A", repo=repo, updated_at="2026-08-06T01:00:00Z"),
+        _ev(actor="b", node="B", repo=repo, updated_at="2026-08-06T02:00:00Z"),  # tie
+        _ev(actor="c", node="C", repo=repo, updated_at="2026-08-06T02:00:00Z"),  # tie (deferred)
+        _ev(actor="d", node="D", repo=repo, updated_at="2026-08-06T03:00:00Z"),
+    ]
+    _stub_gather(mon, monkeypatch, tmp_path, mode="live", max_events=2, events_by_repo={repo: evs})
+    (tmp_path / "github_steward").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "github_steward" / "cursors.json").write_text(
+        '{"version": 1, "cursors": {"owner/tie": "2026-08-05T00:00:00Z"}}'
+    )
+
+    await mon.gather()
+
+    # b (02:00) was processed, but its twin c (02:00) was deferred — so the cursor
+    # must hold at a (01:00), strictly before the tie second, so the next
+    # exclusive `since` poll re-fetches the whole 02:00 group (b via dedup, c fresh).
+    assert mon._load_cursors()[repo] == "2026-08-06T01:00:00Z"

--- a/tests/test_recon/test_gh_cli.py
+++ b/tests/test_recon/test_gh_cli.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from genesis.recon.gh_cli import run_gh
+from genesis.recon.gh_cli import run_gh, run_gh_checked
 
 
 def _mock_subprocess(stdout: str, returncode: int = 0):
@@ -65,3 +65,32 @@ async def test_os_error_returns_empty():
     with patch("asyncio.create_subprocess_exec", side_effect=OSError("gh not found")):
         result = await run_gh("gh", "api", "test")
     assert result == ""
+
+
+# ── run_gh_checked: the (ok, stdout) contract that lets callers tell an error
+#    apart from an empty-but-successful result (a cursor must NOT advance on a
+#    failed poll). ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_checked_success_is_ok_with_stdout():
+    with patch("asyncio.create_subprocess_exec", side_effect=_mock_subprocess("[]")):
+        ok, out = await run_gh_checked("gh", "api", "test")
+    assert ok is True
+    assert out == "[]"  # a genuinely-empty-but-successful poll is (True, "[]")
+
+
+@pytest.mark.asyncio
+async def test_checked_nonzero_exit_is_not_ok():
+    with patch("asyncio.create_subprocess_exec", side_effect=_mock_subprocess("boom", returncode=1)):
+        ok, out = await run_gh_checked("gh", "api", "test")
+    assert ok is False
+    assert out == ""
+
+
+@pytest.mark.asyncio
+async def test_checked_os_error_is_not_ok():
+    with patch("asyncio.create_subprocess_exec", side_effect=OSError("gh not found")):
+        ok, out = await run_gh_checked("gh", "api", "test")
+    assert ok is False
+    assert out == ""


### PR DESCRIPTION
## What

A deterministic (no-LLM) monitor that watches your active GitHub repos every ~2h
and pings you on Telegram when an **external** person opens their first
PR/issue, comments, or starts a discussion — so a new contributor's first move
doesn't sit unseen. Your own activity, bots, and CI are filtered out. **Off by
default** (observe mode); it records observations that a separate 6h digest
campaign will later consume.

Public reusable infra ("C2a-1"). The consuming campaign is separate, local user
data (a later slice).

## How

- **`recon/account_activity.py` — `AccountActivityMonitor`** (sibling to
  `ReconGatherer`, whose no-push contract is load-bearing). Deep-polls flagship
  repos (from config, or live auto-selects the owner's recently-pushed public
  repos, capped). Classifies external-human (`login != owner`, not `[bot]`,
  `users/{login}.type ∉ {Bot, Organization}`, config denylist — cached per
  login). Dedups + detects first-time via the observation-hash primitive (no new
  table). Pings via `submit_raw`. **Pipeline is lazy-resolved at tick time** —
  surplus inits before outreach, so it can't be injected at construction.
- **`recon/gh_cli.py`** — adds `run_gh_checked() -> (ok, stdout)` sharing a core
  with the byte-identical `run_gh`. A **failed** poll is now distinguishable from
  an empty one, so the cursor **never advances on an errored/rate-limited poll**
  (a contributor active in that window would otherwise be lost forever).
- **Cursor safety** (home-anchored JSON sidecar): events are time-sorted and
  capped at `max_events_per_tick`; the cursor advances only to the last
  *processed* event, and — because GitHub's `since` is exclusive — stops
  *before* a same-second tie that straddles the cap. No event is ever dropped;
  deferred ones re-fetch next tick (dedup makes overlap a no-op).
- **`recon/github_steward_config.py`** — `off`/`observe`/`live` lever +
  `GENESIS_GITHUB_STEWARD_DISABLED` kill switch. Owner/repos/logins all resolved
  live; nothing install-specific ships.
- Registered `github_account_activity` + `github_actor_seen` in
  `INTERNAL_OBS_TYPES` + `_TTL_BY_TYPE` (else they double-surface + warn).
- Wired into the surplus scheduler (2h `CronTrigger`) + `runtime/init/surplus.py`.

## Verification

- **Live E2E (real `gh`, run twice):** first-run silently baselined 10 real
  contributors, 0 errors; a `live` dry-run pinged **exactly** the real external
  first-time contributors (AyushkhatiDev + 3 discussion authors) and skipped
  every owner PR and the Codex bot; truncation logged; cursor advanced to the
  last processed event.
- **Tests:** 11 monitor tests (incl. `gather()`-level regression locks for the
  per-repo baseline, truncation-holds-cursor, and exclusive-`since` tie) + 3
  `run_gh_checked` + 245 broader recon/surplus — all green. Ruff clean; no
  import cycle.
- **Reviewed 2 rounds:** round 1 found 2 real blockers (truncation event-loss;
  global-not-per-repo baseline ping-storm) + 2 should-fixes — all fixed; round 2
  PASS, plus an exclusive-`since` tie fix (same failure class) with its own test.

## Deploy path

Runtime code — `git pull` + server restart (the 2h job registers at bring-up).
No schema change. Empty-state safe: with no config repos it auto-selects; `off`
by default until enabled. Retention: observations auto-expire (30d/90d); the
cursor sidecar is a single small bounded file.

## Rollout

Ships `off`... actually `observe` (records + baselines, never pings). Flip to
`mode: live` in a gitignored `config/github_steward.local.yaml` once it has
baselined, to start pings.

Ledger: 8afa7fc0ebf740cd93267de87d6ba27e

🤖 Generated with [Claude Code](https://claude.com/claude-code)
