### PR TITLE
fix(observability): enumerate CC slots without the sandbox-blocked environ read

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -100,6 +100,21 @@ changes: verify the notification actually arrives. Ask: "If the system
 restarts right now, will this actually work?" If you can't answer yes
 with evidence, you're not done.
 
+**Verify in the REAL runtime context, not a shell proxy.** "Works when I
+run it" is not "works where it runs." Same code + same uid ≠ same context:
+a long-running systemd service (genesis-server, guardian) differs from your
+interactive shell in mount namespace, seccomp, `NoNewPrivileges`, dropped
+caps, and — the one that bites — **ptrace/`/proc` access**. Anything that
+reads `/proc/<other-pid>/{environ,mem,stat}`, another process's env, sockets,
+or namespaced/hardened resources MUST be verified by hitting the **live
+endpoint** (`curl` the real server) or running inside the real service — not
+`python -c` in your shell. (Origin, 2026-08: the CC-slot stale-code badge
+read `/proc/<pid>/environ`, which succeeds in a shell but returns EACCES
+under the server's `ProtectSystem=strict` sandbox — so `enumerate_cc_slots()`
+returned 0 in-server and **three** features shipped green but inert since
+July; the module's docstring claim "same-uid reads succeed" was a shell-tested
+falsehood. The fix routed around the ptrace-gated read entirely.)
+
 ### Instance-Fix vs Class-Fix Gate
 
 When a mechanism failed to write or propagate something (a memory, a

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1464,17 +1464,25 @@ async def _check_cc_slot_memory(db, slots: list[dict] | None = None) -> None:
         return
 
     now = time.monotonic()
+    # Evict expired cooldown entries so the pid-keyed map stays bounded to
+    # currently-cooling sessions. Keys are pids (unbounded over the loop's
+    # lifetime); an entry older than the cooldown no longer suppresses anything,
+    # so dropping it is behaviour-neutral and prevents slow growth on a
+    # long-running server.
+    for k in [k for k, t in _last_slot_alert_at.items() if now - t >= _SLOT_ALERT_COOLDOWN_S]:
+        del _last_slot_alert_at[k]
     for slot in slots:
         rss = slot.get("rss_mb", 0.0)
         if rss < SLOT_RSS_WARN_MB:
             continue
-        # slot may be None for an unregistered/manual interactive session (comm
-        # walk with no GENESIS_SLOT and no spawn file); key the cooldown by pid so
-        # such sessions don't collide on one bucket. (Cognitive `claude -p` calls
-        # are already excluded upstream, so every row here is a real session.)
+        # Key the cooldown by PID (unique per process), never the slot label: rows
+        # are pid-keyed and two live claude procs can share a label (or have none),
+        # so a label key would let one process suppress another's alert for an hour.
+        # (Cognitive `claude -p` calls are excluded upstream, so every row here is a
+        # real session.) The display label still prefers the slot when known.
         raw_slot = slot.get("slot")
         pid = slot.get("pid")
-        key = str(raw_slot) if raw_slot is not None else f"pid:{pid}"
+        key = f"pid:{pid}"
         label = f"slot cc-{raw_slot}" if raw_slot is not None else f"pid {pid}"
         last = _last_slot_alert_at.get(key)
         if last is not None and (now - last) < _SLOT_ALERT_COOLDOWN_S:

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1468,7 +1468,14 @@ async def _check_cc_slot_memory(db, slots: list[dict] | None = None) -> None:
         rss = slot.get("rss_mb", 0.0)
         if rss < SLOT_RSS_WARN_MB:
             continue
-        key = str(slot.get("slot", "?"))
+        # slot may be None for an unregistered/manual interactive session (comm
+        # walk with no GENESIS_SLOT and no spawn file); key the cooldown by pid so
+        # such sessions don't collide on one bucket. (Cognitive `claude -p` calls
+        # are already excluded upstream, so every row here is a real session.)
+        raw_slot = slot.get("slot")
+        pid = slot.get("pid")
+        key = str(raw_slot) if raw_slot is not None else f"pid:{pid}"
+        label = f"slot cc-{raw_slot}" if raw_slot is not None else f"pid {pid}"
         last = _last_slot_alert_at.get(key)
         if last is not None and (now - last) < _SLOT_ALERT_COOLDOWN_S:
             continue
@@ -1485,15 +1492,15 @@ async def _check_cc_slot_memory(db, slots: list[dict] | None = None) -> None:
                 source="cc_slot_monitor",
                 type="infrastructure_alert",
                 content=(
-                    f"CC slot cc-{key} (pid {slot.get('pid')}) is using "
+                    f"CC {label} (pid {pid}) is using "
                     f"{rss / 1024:.1f} GB RAM (warn {SLOT_RSS_WARN_MB // 1024} GB, "
                     f"crit {SLOT_RSS_CRIT_MB // 1024} GB). A single Claude Code "
-                    f"session may be leaking — consider restarting slot cc-{key}."
+                    f"session may be leaking — consider restarting {label}."
                 ),
                 priority=priority,
                 created_at=datetime.now(UTC).isoformat(),
             )
-            logger.warning("CC slot memory alert: cc-%s %.1f GB (%s)", key, rss / 1024, priority)
+            logger.warning("CC slot memory alert: %s %.1f GB (%s)", label, rss / 1024, priority)
         except Exception:
             logger.debug("Failed to create cc_slot alert observation", exc_info=True)
 

--- a/src/genesis/dashboard/routes/cc_sessions.py
+++ b/src/genesis/dashboard/routes/cc_sessions.py
@@ -137,9 +137,11 @@ async def _collect_detail(
     now = now or datetime.now(UTC)
     db.row_factory = aiosqlite.Row
 
-    def _slot_stale(slot: str | None, spid: int | None) -> tuple[bool, str | None]:
+    def _slot_stale(
+        slot: str | None, spid: int | None, proc_start: str | None = None
+    ) -> tuple[bool, str | None]:
         """(stale, deploy_commit_to_restart_to) for a live slot proc."""
-        ident = read_spawn_identity(slot, spid)
+        ident = read_spawn_identity(slot, spid, proc_start)
         if not ident or not deploy:
             return False, None
         completed_at, new_commit = deploy
@@ -174,7 +176,7 @@ async def _collect_detail(
         pid = row.get("pid")
         if pid in slot_by_pid and pid not in consumed:
             s = slot_by_pid[pid]
-            stale, dc = _slot_stale(s.get("slot"), s.get("pid"))
+            stale, dc = _slot_stale(s.get("slot"), s.get("pid"), s.get("started_at"))
             live = {
                 "slot": s.get("slot"),
                 "pid": s.get("pid"),

--- a/src/genesis/dashboard/templates/partials/modals/cc_sessions.html
+++ b/src/genesis/dashboard/templates/partials/modals/cc_sessions.html
@@ -33,7 +33,7 @@
               </div>
               <div style="font-size: 0.82rem; padding: 0.4rem 0.8rem; border-radius: 6px;"
                    :style="`background: rgba(59,130,246,0.12); color: #3b82f6;`"
-                   title="Live claude processes carrying GENESIS_SLOT (from /proc) — informational, not a filter">
+                   title="Live interactive claude sessions (from /proc) — informational, not a filter">
                 <span x-text="($store.genesisDashboard.ccSessionsModal.data.stats?.live_procs || 0)"></span> live procs
               </div>
               <div style="font-size: 0.82rem; padding: 0.4rem 0.8rem; border-radius: 6px; cursor: pointer; transition: opacity 0.15s;"
@@ -80,7 +80,7 @@
                         :title="'idle'"
                         x-text="s.idle_s != null ? $store.genesisDashboard.formatAgeSeconds(s.idle_s) + ' idle' : '-'"></span>
                   <span style="min-width: 108px;" :style="`color: ${s.live ? '#3b82f6' : 'var(--color-text-secondary)'}`"
-                        x-text="s.live ? ('#' + s.live.slot + ' pid ' + s.live.pid + ' ' + (s.live.rss_mb / 1024).toFixed(1) + 'G') : '—'"></span>
+                        x-text="s.live ? ((s.live.slot ? '#' + s.live.slot + ' ' : '') + 'pid ' + s.live.pid + ' ' + (s.live.rss_mb / 1024).toFixed(1) + 'G') : '—'"></span>
                   <template x-if="$store.genesisDashboard.ccSessionsModal.data.charters_available">
                     <span style="min-width: 130px; flex: 1; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;"
                           :title="s.charter ? ((s.charter.mission || 'no mission') + ' · ' + s.charter.compaction_count + ' compactions · ' + s.charter.ledger_open + ' open of ' + s.charter.ledger_total) : 'no charter'"
@@ -108,7 +108,7 @@
                 <div style="font-size: 0.78rem; font-weight: 600; color: #d9534f; margin-bottom: 0.3rem;">Live processes with no DB session row</div>
                 <template x-for="u in $store.genesisDashboard.ccSessionsModal.data.unmatched_slots" :key="u.pid">
                   <div style="font-size: 0.75rem; color: #f87171; display: flex; gap: 0.4rem; align-items: center;">
-                    <span x-text="'#' + u.slot + ' pid ' + u.pid + ' ' + (u.rss_mb / 1024).toFixed(1) + 'G (' + u.status + ')'"></span>
+                    <span x-text="(u.slot ? '#' + u.slot + ' ' : '') + 'pid ' + u.pid + ' ' + (u.rss_mb / 1024).toFixed(1) + 'G (' + u.status + ')'"></span>
                     <template x-if="u.stale_code">
                       <span style="font-size: 0.68rem; padding: 0.05rem 0.35rem; border-radius: 4px; background: rgba(240,173,78,0.15); color: #f0ad4e; white-space: nowrap;"
                             :title="'This process is running pre-deploy code (deployed commit ' + (u.deploy_commit || '?') + '). Restart it to load the deployed code.'"

--- a/src/genesis/dashboard/templates/partials/tabs/overview.html
+++ b/src/genesis/dashboard/templates/partials/tabs/overview.html
@@ -757,11 +757,11 @@
                   <span style="color:var(--color-text-secondary);"
                         title="Memory (RSS) used by each concurrent Claude Code worker session — leak detection. Green = healthy, amber ≥ 4 GB, red ≥ 6 GB.">Claude Code Sessions</span>
                   <div style="display:flex; flex-wrap:wrap; gap:0.35rem;">
-                    <template x-for="slot in $store.genesisDashboard.health.infrastructure.cc_slots" :key="slot.slot">
+                    <template x-for="slot in $store.genesisDashboard.health.infrastructure.cc_slots" :key="slot.pid">
                       <span style="font-size:0.7rem; padding:0.05rem 0.3rem; border-radius:3px; background:var(--color-background); white-space:nowrap;"
                             :style="`color: ${slot.status === 'error' ? '#d9534f' : slot.status === 'degraded' ? '#f0ad4e' : '#4caf50'}`"
-                            :title="'Session ' + slot.slot + ' (pid ' + slot.pid + '): ' + (slot.rss_mb / 1024).toFixed(2) + ' GB RSS'"
-                            x-text="'#' + slot.slot + ' ' + (slot.rss_mb / 1024).toFixed(1) + 'G'"></span>
+                            :title="(slot.slot ? 'Session ' + slot.slot : 'Unregistered session') + ' (pid ' + slot.pid + '): ' + (slot.rss_mb / 1024).toFixed(2) + ' GB RSS'"
+                            x-text="(slot.slot ? '#' + slot.slot : 'pid ' + slot.pid) + ' ' + (slot.rss_mb / 1024).toFixed(1) + 'G'"></span>
                     </template>
                   </div>
                 </div>

--- a/src/genesis/dashboard/templates/partials/tabs/sessions.html
+++ b/src/genesis/dashboard/templates/partials/tabs/sessions.html
@@ -33,7 +33,7 @@
                 </div>
                 <div style="font-size: 0.82rem; padding: 0.4rem 0.8rem; border-radius: 6px;"
                      :style="`background: rgba(59,130,246,0.12); color: #3b82f6;`"
-                     title="Live claude processes carrying GENESIS_SLOT (from /proc) — informational, not a filter">
+                     title="Live interactive claude sessions (from /proc) — informational, not a filter">
                   <span x-text="($store.genesisDashboard.sessionsTab.data.stats?.live_procs || 0)"></span> live procs
                 </div>
                 <div style="font-size: 0.82rem; padding: 0.4rem 0.8rem; border-radius: 6px; cursor: pointer; transition: opacity 0.15s;"
@@ -77,7 +77,7 @@
                     <span style="min-width: 74px; color: var(--color-text-secondary);"
                           x-text="s.idle_s != null ? $store.genesisDashboard.formatAgeSeconds(s.idle_s) + ' idle' : '-'"></span>
                     <span style="min-width: 90px;" :style="`color: ${s.live ? '#3b82f6' : 'var(--color-text-secondary)'}`"
-                          x-text="s.live ? ('#' + s.live.slot + ' pid ' + s.live.pid) : '—'"></span>
+                          x-text="s.live ? ((s.live.slot ? '#' + s.live.slot + ' ' : '') + 'pid ' + s.live.pid) : '—'"></span>
                     <template x-if="$store.genesisDashboard.sessionsTab.data.charters_available">
                       <span style="min-width: 110px; flex: 1; text-overflow: ellipsis; overflow: hidden; white-space: nowrap;"
                             :title="s.charter ? ((s.charter.mission || 'no mission') + ' · ' + s.charter.compaction_count + ' compactions · ' + s.charter.ledger_open + ' open of ' + s.charter.ledger_total) : 'no charter'"
@@ -104,7 +104,7 @@
                   <div style="font-size: 0.78rem; font-weight: 600; color: #d9534f; margin-bottom: 0.3rem;">Live processes with no DB session row</div>
                   <template x-for="u in $store.genesisDashboard.sessionsTab.data.unmatched_slots" :key="u.pid">
                     <div style="font-size: 0.75rem; color: #f87171; display: flex; gap: 0.4rem; align-items: center;">
-                      <span x-text="'#' + u.slot + ' pid ' + u.pid + ' ' + (u.rss_mb / 1024).toFixed(1) + 'G (' + u.status + ')'"></span>
+                      <span x-text="(u.slot ? '#' + u.slot + ' ' : '') + 'pid ' + u.pid + ' ' + (u.rss_mb / 1024).toFixed(1) + 'G (' + u.status + ')'"></span>
                       <template x-if="u.stale_code">
                         <span style="font-size: 0.68rem; padding: 0.05rem 0.35rem; border-radius: 4px; background: rgba(240,173,78,0.15); color: #f0ad4e; white-space: nowrap;"
                               :title="'This process is running pre-deploy code (deployed commit ' + (u.deploy_commit || '?') + '). Restart it to load the deployed code.'"

--- a/src/genesis/observability/cc_slots.py
+++ b/src/genesis/observability/cc_slots.py
@@ -14,7 +14,7 @@ gated and FAILS with EACCES inside genesis-server's systemd sandbox
 (``ProtectSystem=strict``); it only succeeds from an unsandboxed shell. So the
 slot label (``GENESIS_SLOT``, environ-only) is NOT readable in-server. This
 module therefore enriches the slot label from the ``mcp-spawn`` file plane
-(``slot_by_pid``, world-readable) and identifies interactive sessions by cmdline
+(``enumerate_spawn_slots``, world-readable) and identifies interactive sessions by cmdline
 (``/proc/<pid>/cmdline``, world-readable) — neither is ptrace-gated, so both work
 under the sandbox. VmRSS/comm/stat are likewise world-readable. See the
 ``verify_real_runtime_context`` lesson (shipped-green-but-inert since #855).
@@ -148,7 +148,7 @@ def enumerate_cc_slots() -> list[dict]:
     share ``comm=="claude"``) don't masquerade as sessions; cmdline is the
     authoritative signal, checked before any slot label is trusted. The slot label
     is then enrichment: from the process's environ (``GENESIS_SLOT``) when
-    readable, else from the ``mcp-spawn`` file plane (``slot_by_pid``) — the latter
+    readable, else from the ``mcp-spawn`` file plane (``enumerate_spawn_slots``) — the latter
     is the ONLY source that survives genesis-server's ``ProtectSystem`` sandbox,
     where ``/proc/<pid>/environ`` reads return EACCES.
 
@@ -169,14 +169,21 @@ def enumerate_cc_slots() -> list[dict]:
 
     # Lazy import keeps this module a stdlib-only leaf at import time (no cycle —
     # mcp_spawn_store imports nothing from genesis). The file-plane read is the
-    # sandbox-safe slot source.
+    # sandbox-safe slot source. Map pid -> (slot, spawn_at) so a recycled pid can
+    # be rejected below by comparing spawn_at to the live process's start time.
+    spawn_by_pid: dict[int, tuple[str, str]] = {}
+    _rec_current = None
     try:
-        from genesis.observability.mcp_spawn_store import slot_by_pid
+        from genesis.observability.mcp_spawn_store import (
+            enumerate_spawn_slots,
+        )
+        from genesis.observability.mcp_spawn_store import (
+            spawn_record_is_current as _rec_current,
+        )
 
-        spawn_slots = slot_by_pid()
+        spawn_by_pid = {pid: (slot, sat) for slot, pid, sat in enumerate_spawn_slots()}
     except Exception:
         logger.debug("cc_slots: spawn-plane lookup failed", exc_info=True)
-        spawn_slots = {}
 
     rows: list[dict] = []
     for pid in pids:
@@ -192,17 +199,25 @@ def enumerate_cc_slots() -> list[dict]:
         # (possibly OS-reused) pid to a slot. The slot label is enrichment only.
         if not _is_interactive(pid):
             continue
-        slot = _slot_label(pid) or spawn_slots.get(pid)
         rss = read_proc_rss_mb(pid)
         if rss is None:
             continue
+        started_at = read_proc_start_iso(pid)
+        # Slot label: environ (unsandboxed) first, else the spawn-file plane — but
+        # only when the plane record's pid was NOT recycled (its spawn_at is
+        # consistent with this process's start time); otherwise leave it unlabeled.
+        plane = spawn_by_pid.get(pid)
+        plane_slot = (
+            plane[0] if plane and _rec_current and _rec_current(plane[1], started_at) else None
+        )
+        slot = _slot_label(pid) or plane_slot
         rows.append(
             {
                 "slot": slot,
                 "pid": pid,
                 "rss_mb": rss,
                 "status": slot_status(rss),
-                "started_at": read_proc_start_iso(pid),
+                "started_at": started_at,
             }
         )
 

--- a/src/genesis/observability/cc_slots.py
+++ b/src/genesis/observability/cc_slots.py
@@ -6,9 +6,18 @@ A single session that balloons (a leak) is otherwise invisible — this surfaces
 per-slot RSS so it can be shown on the dashboard and alerted on. This is leak
 DETECTION, not OOM prevention (the container has ample headroom).
 
-Stdlib-only leaf module (no genesis imports → no import cycle). Uses same-uid
-/proc reads, which succeed despite yama ``ptrace_scope=1`` (that gates
-PTRACE_ATTACH, not the READ mode used for ``/proc/<pid>/environ``).
+Stdlib-only leaf at import time (the one genesis import — ``mcp_spawn_store``,
+itself a stdlib-only leaf — is lazy, inside the function, so no import cycle).
+
+IMPORTANT — reading ``/proc/<pid>/environ`` of ANOTHER process is ptrace-FSCREDS
+gated and FAILS with EACCES inside genesis-server's systemd sandbox
+(``ProtectSystem=strict``); it only succeeds from an unsandboxed shell. So the
+slot label (``GENESIS_SLOT``, environ-only) is NOT readable in-server. This
+module therefore enriches the slot label from the ``mcp-spawn`` file plane
+(``slot_by_pid``, world-readable) and identifies interactive sessions by cmdline
+(``/proc/<pid>/cmdline``, world-readable) — neither is ptrace-gated, so both work
+under the sandbox. VmRSS/comm/stat are likewise world-readable. See the
+``verify_real_runtime_context`` lesson (shipped-green-but-inert since #855).
 """
 
 from __future__ import annotations
@@ -99,6 +108,28 @@ def _slot_label(pid: int) -> str | None:
     return None
 
 
+def _is_interactive(pid: int) -> bool:
+    """True if a ``claude`` pid is an INTERACTIVE session, not a headless
+    ``claude -p`` cognitive/background call.
+
+    Genesis spawns internal ``claude -p`` subprocesses (CCInvoker triage/reflection/
+    extraction, the dashboard update router, the experiment router) that share
+    ``comm=="claude"`` but are NOT interactive slots. Interactive sessions run
+    WITHOUT ``-p``/``--print``; every headless invocation uses it (verified:
+    ``cc/invoker.py``, ``dashboard/routes/updates.py``, ``experimentation/
+    cc_router.py``). ``/proc/<pid>/cmdline`` is world-readable, so this
+    discriminates even inside the server sandbox (where environ is not readable).
+    Exact-arg match (NUL-separated argv) avoids matching ``-p`` inside a value or
+    another flag. Unreadable cmdline → treated as non-interactive (conservative:
+    never let an internal cognitive call masquerade as a session)."""
+    try:
+        with open(f"{_PROC}/{pid}/cmdline", "rb") as f:
+            args = f.read().split(b"\x00")
+    except OSError:
+        return False
+    return b"-p" not in args and b"--print" not in args
+
+
 def slot_status(rss_mb: float) -> str:
     """Map a slot's RSS (MB) to a health status."""
     if rss_mb >= SLOT_RSS_CRIT_MB:
@@ -109,20 +140,26 @@ def slot_status(rss_mb: float) -> str:
 
 
 def enumerate_cc_slots() -> list[dict]:
-    """One row per CC slot: ``{slot, pid, rss_mb, status, started_at}``, sorted by
-    slot.
+    """One row per live CC session: ``{slot, pid, rss_mb, status, started_at}``.
 
-    ``started_at`` is the claude process's wall-clock start (ISO UTC, or None if
-    unreadable) — a faithful proxy for the code version of that session's MCP
-    subprocesses, which spawn with the parent and never reload (used by the
-    dashboard to flag sessions running pre-deploy code). Additive key; existing
-    callers that ignore it are unaffected.
+    Walks /proc for ``claude`` processes. A process is kept only if it is an
+    INTERACTIVE session (``_is_interactive`` — not a headless ``claude -p``
+    cognitive/background call), so Genesis's own internal LLM subprocesses (which
+    share ``comm=="claude"``) don't masquerade as sessions; cmdline is the
+    authoritative signal, checked before any slot label is trusted. The slot label
+    is then enrichment: from the process's environ (``GENESIS_SLOT``) when
+    readable, else from the ``mcp-spawn`` file plane (``slot_by_pid``) — the latter
+    is the ONLY source that survives genesis-server's ``ProtectSystem`` sandbox,
+    where ``/proc/<pid>/environ`` reads return EACCES.
 
-    Walks /proc for `claude` processes tagged with GENESIS_SLOT and reads each
-    one's VmRSS. If two `claude` processes somehow share a slot, the larger RSS
-    wins. Best-effort: returns [] on failure (logged at DEBUG so an empty list
-    caused by an error is distinguishable in the logs from a genuine no-slots
-    state — this is a visibility feature, so a silent hole would defeat it).
+    Rows are keyed by pid (each live claude is one row); ``rss_mb``/``started_at``
+    come from world-readable /proc. ``slot`` may be None for an unregistered
+    interactive session (launched before the spawn-store writer existed, or a
+    manual ``claude``) — the dashboard join is pid-based so such rows still join,
+    and they are never flagged stale (no persisted commit). ``started_at`` is the
+    wall-clock start (ISO UTC, None if unreadable), a faithful proxy for the
+    session's MCP-subprocess code version. Best-effort: [] on failure (logged at
+    DEBUG so an error-empty is distinguishable from a genuine no-slots state).
     """
     try:
         pids = [int(n) for n in os.listdir(_PROC) if n.isdigit()]
@@ -130,7 +167,18 @@ def enumerate_cc_slots() -> list[dict]:
         logger.debug("cc_slots: cannot list /proc", exc_info=True)
         return []
 
-    by_slot: dict[str, dict] = {}
+    # Lazy import keeps this module a stdlib-only leaf at import time (no cycle —
+    # mcp_spawn_store imports nothing from genesis). The file-plane read is the
+    # sandbox-safe slot source.
+    try:
+        from genesis.observability.mcp_spawn_store import slot_by_pid
+
+        spawn_slots = slot_by_pid()
+    except Exception:
+        logger.debug("cc_slots: spawn-plane lookup failed", exc_info=True)
+        spawn_slots = {}
+
+    rows: list[dict] = []
     for pid in pids:
         try:
             with open(f"{_PROC}/{pid}/comm") as f:
@@ -138,24 +186,35 @@ def enumerate_cc_slots() -> list[dict]:
                     continue
         except OSError:
             continue  # pid vanished or unreadable — normal, skip
-        label = _slot_label(pid)
-        if label is None:
+        # cmdline is the AUTHORITATIVE interactive/headless signal, checked BEFORE
+        # any slot label is trusted: a headless `claude -p` cognitive/background
+        # call is never a session, even if a stale spawn-file entry maps its
+        # (possibly OS-reused) pid to a slot. The slot label is enrichment only.
+        if not _is_interactive(pid):
             continue
+        slot = _slot_label(pid) or spawn_slots.get(pid)
         rss = read_proc_rss_mb(pid)
         if rss is None:
             continue
-        prev = by_slot.get(label)
-        if prev is None or rss > prev["rss_mb"]:
-            by_slot[label] = {
-                "slot": label,
+        rows.append(
+            {
+                "slot": slot,
                 "pid": pid,
                 "rss_mb": rss,
                 "status": slot_status(rss),
                 "started_at": read_proc_start_iso(pid),
             }
-    # Numeric-aware sort so "10" follows "9" (labels are numeric strings today);
-    # any non-numeric label sorts last.
-    return sorted(
-        by_slot.values(),
-        key=lambda r: (0, int(r["slot"])) if r["slot"].isdigit() else (1, r["slot"]),
-    )
+        )
+
+    # Numeric-aware sort: digit-labeled slots first (so "10" follows "9"), then
+    # non-numeric labels, then unlabeled (None) rows by pid. All sort keys are
+    # (int-tag, str) so no int/str comparison across classes.
+    def _sort_key(r: dict) -> tuple[int, str]:
+        s = r["slot"]
+        if s is None:
+            return (2, f"{r['pid']:020d}")
+        if s.isdigit():
+            return (0, f"{int(s):020d}")
+        return (1, s)
+
+    return sorted(rows, key=_sort_key)

--- a/src/genesis/observability/mcp_spawn_store.py
+++ b/src/genesis/observability/mcp_spawn_store.py
@@ -79,6 +79,51 @@ def persist_spawn_commit(
         logger.debug("mcp_spawn_store: persist failed for slot %s", slot, exc_info=True)
 
 
+def enumerate_spawn_slots() -> list[tuple[str, int]]:
+    """``(slot_label, recorded_pid)`` for each persisted spawn file.
+
+    These are world-readable regular files (no ptrace-gated read), so this works
+    from the sandboxed genesis-server where ``/proc/<pid>/environ`` is unreadable —
+    it is how an in-server enumerator recovers a live session's slot without the
+    (sandbox-blocked) environ. Best-effort; never raises. Skips the atomic-write
+    temp files (``mkstemp`` names them ``.<slot>.<rand>`` — dot-prefixed) and any
+    torn/malformed file.
+    """
+    out: list[tuple[str, int]] = []
+    try:
+        names = os.listdir(_SPAWN_DIR)
+    except OSError:
+        return out
+    for name in names:
+        if name.startswith("."):  # atomic-write temp file, not a slot
+            continue
+        try:
+            raw = (_SPAWN_DIR / name).read_text().strip()
+        except OSError:
+            continue
+        parts = raw.split()
+        if len(parts) != 3:
+            continue
+        try:
+            pid = int(parts[0])
+        except ValueError:
+            continue
+        out.append((name, pid))
+    return out
+
+
+def slot_by_pid() -> dict[int, str]:
+    """Reverse map ``{recorded_pid: slot}`` from the spawn file plane.
+
+    Lets an enumerator label a live claude pid with its interactive slot without
+    reading the sandbox-blocked environ. Last-writer-wins if a pid somehow appears
+    in two slot files (a stale file not yet swept by disk-hygiene) — a transient
+    mislabel only; the stale-badge path is separately pid-validated by
+    ``read_spawn_identity``.
+    """
+    return {pid: slot for slot, pid in enumerate_spawn_slots()}
+
+
 def read_spawn_identity(slot: str, live_pid: int | None) -> tuple[str, str] | None:
     """``(commit, spawn_at)`` this slot's CURRENT session was spawned at, or None.
 

--- a/src/genesis/observability/mcp_spawn_store.py
+++ b/src/genesis/observability/mcp_spawn_store.py
@@ -18,6 +18,7 @@ import contextlib
 import logging
 import os
 import tempfile
+from datetime import datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -79,17 +80,19 @@ def persist_spawn_commit(
         logger.debug("mcp_spawn_store: persist failed for slot %s", slot, exc_info=True)
 
 
-def enumerate_spawn_slots() -> list[tuple[str, int]]:
-    """``(slot_label, recorded_pid)`` for each persisted spawn file.
+def enumerate_spawn_slots() -> list[tuple[str, int, str]]:
+    """``(slot_label, recorded_pid, spawn_at)`` for each persisted spawn file.
 
     These are world-readable regular files (no ptrace-gated read), so this works
     from the sandboxed genesis-server where ``/proc/<pid>/environ`` is unreadable —
     it is how an in-server enumerator recovers a live session's slot without the
-    (sandbox-blocked) environ. Best-effort; never raises. Skips the atomic-write
+    (sandbox-blocked) environ. ``spawn_at`` is returned so the caller can reject a
+    record whose recorded pid was RECYCLED by a newer process (see
+    ``spawn_record_is_current``). Best-effort; never raises. Skips the atomic-write
     temp files (``mkstemp`` names them ``.<slot>.<rand>`` — dot-prefixed) and any
     torn/malformed file.
     """
-    out: list[tuple[str, int]] = []
+    out: list[tuple[str, int, str]] = []
     try:
         names = os.listdir(_SPAWN_DIR)
     except OSError:
@@ -108,30 +111,48 @@ def enumerate_spawn_slots() -> list[tuple[str, int]]:
             pid = int(parts[0])
         except ValueError:
             continue
-        out.append((name, pid))
+        out.append((name, pid, parts[2]))
     return out
 
 
-def slot_by_pid() -> dict[int, str]:
-    """Reverse map ``{recorded_pid: slot}`` from the spawn file plane.
+def spawn_record_is_current(
+    spawn_at: str | None, proc_start_iso: str | None, grace_s: float = 120.0
+) -> bool:
+    """Whether a live process's start time is consistent with a spawn record.
 
-    Lets an enumerator label a live claude pid with its interactive slot without
-    reading the sandbox-blocked environ. Last-writer-wins if a pid somehow appears
-    in two slot files (a stale file not yet swept by disk-hygiene) — a transient
-    mislabel only; the stale-badge path is separately pid-validated by
-    ``read_spawn_identity``.
+    A spawn record maps a pid → slot/commit, but the OS can RECYCLE that pid for a
+    different process once the recorded session exits (before disk-hygiene prunes
+    the dead-pid file). The record is about the recorded session only if the live
+    process started no LATER than the record was written (``spawn_at`` is captured
+    at MCP-subprocess start, which is a beat after the claude process itself
+    started, so a genuine match has ``proc_start <= spawn_at``); a recycled pid
+    belongs to a process that started well AFTER the stale ``spawn_at``. A small
+    grace absorbs clock skew. Fail-OPEN (True) when either timestamp is missing or
+    unparseable — the pid match stays the primary signal and a momentarily
+    unreadable ``/proc/<pid>/stat`` must not drop a valid record.
     """
-    return {pid: slot for slot, pid in enumerate_spawn_slots()}
+    if not spawn_at or not proc_start_iso:
+        return True
+    try:
+        ps = datetime.fromisoformat(proc_start_iso)
+        sa = datetime.fromisoformat(spawn_at)
+    except (ValueError, TypeError):
+        return True
+    return (ps - sa).total_seconds() <= grace_s
 
 
-def read_spawn_identity(slot: str, live_pid: int | None) -> tuple[str, str] | None:
+def read_spawn_identity(
+    slot: str, live_pid: int | None, proc_start_iso: str | None = None
+) -> tuple[str, str] | None:
     """``(commit, spawn_at)`` this slot's CURRENT session was spawned at, or None.
 
-    Returns the pair ONLY if the file's recorded pid == ``live_pid`` (the live
-    claude pid for this slot). A slot reused by a new session whose MCP servers
-    have not rewritten the file yet still carries the OLD pid → mismatch → None
-    (fail-open — no false badge during the brief startup window). Missing or
-    malformed file → None.
+    Returns the pair ONLY if the file's recorded pid == ``live_pid`` AND — when
+    ``proc_start_iso`` is supplied — the live process's start time is consistent
+    with the recorded ``spawn_at`` (``spawn_record_is_current``), so a pid RECYCLED
+    by a new session after the old one exited is not mistaken for the recorded one.
+    A slot reused by a new session whose MCP servers have not rewritten the file
+    yet → pid mismatch (or start-time mismatch) → None (fail-open, no false badge
+    during the brief startup window). Missing or malformed file → None.
     """
     if not slot or live_pid is None:
         return None
@@ -148,5 +169,7 @@ def read_spawn_identity(slot: str, live_pid: int | None) -> tuple[str, str] | No
     except ValueError:
         return None
     if recorded_pid != live_pid or not commit or not spawn_at:
+        return None
+    if not spawn_record_is_current(spawn_at, proc_start_iso):
         return None
     return commit, spawn_at

--- a/tests/test_awareness/test_cc_slot_alert.py
+++ b/tests/test_awareness/test_cc_slot_alert.py
@@ -79,8 +79,26 @@ async def test_cooldown_suppresses_second_alert(_reset_cooldown_and_mock_create)
 @pytest.mark.asyncio
 async def test_distinct_slots_alert_independently(_reset_cooldown_and_mock_create):
     create = _reset_cooldown_and_mock_create
-    await loop._check_cc_slot_memory(object(), slots=[_slot("4", 6500), _slot("5", 6700)])
+    # distinct sessions have distinct pids; cooldown is keyed by pid
+    await loop._check_cc_slot_memory(
+        object(), slots=[_slot("4", 6500, pid=111), _slot("5", 6700, pid=222)]
+    )
     assert create.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_expired_cooldown_keys_are_evicted(_reset_cooldown_and_mock_create):
+    # pid-keyed cooldown must stay bounded: an entry older than the cooldown window
+    # is evicted on the next tick (behaviour-neutral hygiene, not a leak).
+    import time as _time
+
+    now = _time.monotonic()
+    loop._last_slot_alert_at["pid:999"] = now - loop._SLOT_ALERT_COOLDOWN_S - 100  # stale
+    loop._last_slot_alert_at["pid:111"] = now  # fresh, still cooling
+    # a below-threshold tick still runs the eviction pass at the top of the check
+    await loop._check_cc_slot_memory(object(), slots=[_slot("1", 100, pid=1)])
+    assert "pid:999" not in loop._last_slot_alert_at  # stale evicted
+    assert "pid:111" in loop._last_slot_alert_at  # fresh retained
 
 
 @pytest.mark.asyncio

--- a/tests/test_awareness/test_cc_slot_alert.py
+++ b/tests/test_awareness/test_cc_slot_alert.py
@@ -49,6 +49,17 @@ async def test_warn_is_high_priority_not_critical(_reset_cooldown_and_mock_creat
 
 
 @pytest.mark.asyncio
+async def test_null_slot_session_alerts_with_pid_key_and_label(_reset_cooldown_and_mock_create):
+    # An unregistered/manual interactive session has slot=None; it must still
+    # alert, keyed and labeled by pid (not collapsed onto a shared "None" bucket).
+    create = _reset_cooldown_and_mock_create
+    await loop._check_cc_slot_memory(object(), slots=[_slot(None, 6500, pid=98765)])
+    create.assert_awaited_once()
+    assert "pid 98765" in create.await_args.kwargs["content"]
+    assert "pid:98765" in loop._last_slot_alert_at  # cooldown keyed by pid, not "None"
+
+
+@pytest.mark.asyncio
 async def test_below_warn_no_alert(_reset_cooldown_and_mock_create):
     create = _reset_cooldown_and_mock_create
     await loop._check_cc_slot_memory(object(), slots=[_slot("1", 950)])

--- a/tests/test_dashboard/test_cc_sessions_routes.py
+++ b/tests/test_dashboard/test_cc_sessions_routes.py
@@ -139,7 +139,7 @@ def _patch_spawn(monkeypatch, mapping: dict):
     spawn_at)} map; the dashboard cross-checks pid internally."""
     import genesis.dashboard.routes.cc_sessions as mod
 
-    def fake(slot, live_pid):
+    def fake(slot, live_pid, proc_start=None):
         return mapping.get((slot, live_pid))
 
     monkeypatch.setattr(mod, "read_spawn_identity", fake)

--- a/tests/test_observability/test_cc_slots.py
+++ b/tests/test_observability/test_cc_slots.py
@@ -113,6 +113,23 @@ class TestEnumerateCcSlots:
         assert len(rows) == 1
         assert rows[0]["pid"] == 4242 and rows[0]["slot"] == "5"
 
+    def test_spawn_plane_label_dropped_when_pid_recycled(self, tmp_path, monkeypatch):
+        # The plane maps pid 4242 -> slot 5 with an ancient spawn_at, but this live
+        # interactive process started long AFTER it (pid recycled by the OS) → the
+        # stale label must be dropped (slot None); the process is still listed.
+        monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
+        spawn = tmp_path / "spawn"
+        spawn.mkdir()
+        (spawn / "5").write_text(f"4242 {'a' * 40} 1970-01-01T00:00:00+00:00\n")
+        monkeypatch.setattr(mcp_spawn_store, "_SPAWN_DIR", spawn)
+        _write_btime(tmp_path, 1_700_000_000)  # recent boot → proc start >> 1970 spawn_at
+        _make_proc_entry(tmp_path, 4242, "claude", None, 700_000)
+        _write_stat(tmp_path, 4242, "claude", 500_000)
+        rows = enumerate_cc_slots()
+        assert len(rows) == 1
+        assert rows[0]["pid"] == 4242
+        assert rows[0]["slot"] is None
+
     def test_stale_spawn_slot_on_headless_pid_is_excluded(self, tmp_path, monkeypatch):
         # A stale spawn-file maps a slot to a pid the OS has since reused for a
         # headless `claude -p` cognitive call. cmdline is authoritative → the call

--- a/tests/test_observability/test_cc_slots.py
+++ b/tests/test_observability/test_cc_slots.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 from datetime import UTC, datetime
 
-from genesis.observability import cc_slots
+import pytest
+
+from genesis.observability import cc_slots, mcp_spawn_store
 from genesis.observability.cc_slots import (
     SLOT_RSS_CRIT_MB,
     SLOT_RSS_WARN_MB,
@@ -15,8 +17,28 @@ from genesis.observability.cc_slots import (
     slot_status,
 )
 
+# Interactive slots run WITHOUT -p; every headless `claude -p` cognitive/background
+# call runs WITH it. cmdline is NUL-separated argv.
+_INTERACTIVE_CMD = b"claude\x00--dangerously-skip-permissions\x00"
+_PRINT_CMD = b"claude\x00-p\x00do a thing\x00--model\x00sonnet\x00"
 
-def _make_proc_entry(root, pid: int, comm: str, slot: str | None, rss_kb: int | None):
+
+@pytest.fixture(autouse=True)
+def _isolate_spawn_dir(tmp_path, monkeypatch):
+    """enumerate_cc_slots reads the mcp-spawn file plane for slot labels; point it
+    at an empty tmp so tests never read the real ~/.genesis/mcp-spawn. Tests that
+    exercise the plane override _SPAWN_DIR again (last setattr wins)."""
+    monkeypatch.setattr(mcp_spawn_store, "_SPAWN_DIR", tmp_path / "_spawn_isolated")
+
+
+def _make_proc_entry(
+    root,
+    pid: int,
+    comm: str,
+    slot: str | None,
+    rss_kb: int | None,
+    cmdline: bytes | None = _INTERACTIVE_CMD,
+):
     d = root / str(pid)
     d.mkdir()
     (d / "comm").write_text(comm + "\n")
@@ -24,6 +46,8 @@ def _make_proc_entry(root, pid: int, comm: str, slot: str | None, rss_kb: int | 
         (d / "environ").write_bytes(b"PATH=/usr/bin\x00GENESIS_SLOT=" + slot.encode() + b"\x00LANG=C\x00")
     else:
         (d / "environ").write_bytes(b"PATH=/usr/bin\x00LANG=C\x00")
+    if cmdline is not None:
+        (d / "cmdline").write_bytes(cmdline)
     if rss_kb is not None:
         (d / "status").write_text(f"Name:\t{comm}\nVmPeak:\t{rss_kb + 100} kB\nVmRSS:\t{rss_kb} kB\n")
 
@@ -54,40 +78,72 @@ class TestSlotStatus:
 
 
 class TestEnumerateCcSlots:
-    def test_filters_and_labels(self, tmp_path, monkeypatch):
+    def test_includes_interactive_labels_and_excludes_cognitive(self, tmp_path, monkeypatch):
+        # Comm-based: label from environ when readable; an interactive claude with
+        # NO slot is still a session (slot=None); a headless `claude -p` cognitive
+        # call is NOT a session and is excluded.
         monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
         _make_proc_entry(tmp_path, 1001, "claude", "3", 870_000)          # slot 3, healthy
         _make_proc_entry(tmp_path, 1002, "node", "3", 120_000)            # not claude → skip
-        _make_proc_entry(tmp_path, 1003, "claude", None, 500_000)         # no GENESIS_SLOT → skip
+        _make_proc_entry(tmp_path, 1003, "claude", None, 500_000)         # interactive, no slot → INCLUDED (slot None)
         _make_proc_entry(tmp_path, 1004, "claude", "7", 7 * 1024 * 1024)  # slot 7, CRIT (7 GB)
+        _make_proc_entry(
+            tmp_path, 1005, "claude", None, 400_000, cmdline=_PRINT_CMD
+        )  # cognitive `claude -p` → EXCLUDED
         (tmp_path / "notapid").mkdir()  # non-numeric entry ignored
 
         rows = enumerate_cc_slots()
-        slots = {r["slot"]: r for r in rows}
-        assert set(slots) == {"3", "7"}
-        assert slots["3"]["status"] == "healthy"
-        assert slots["3"]["rss_mb"] == round(870_000 / 1024, 1)
-        assert slots["3"]["pid"] == 1001
-        assert slots["7"]["status"] == "error"
-        # sorted by slot label
-        assert [r["slot"] for r in rows] == ["3", "7"]
+        by_pid = {r["pid"]: r for r in rows}
+        assert set(by_pid) == {1001, 1003, 1004}
+        assert by_pid[1001]["slot"] == "3" and by_pid[1001]["status"] == "healthy"
+        assert by_pid[1001]["rss_mb"] == round(870_000 / 1024, 1)
+        assert by_pid[1003]["slot"] is None  # interactive but unregistered
+        assert by_pid[1004]["slot"] == "7" and by_pid[1004]["status"] == "error"
 
-    def test_two_claude_sharing_a_slot_larger_rss_wins(self, tmp_path, monkeypatch):
+    def test_slot_label_from_spawn_plane_when_environ_absent(self, tmp_path, monkeypatch):
+        # The server-sandbox case: environ carries no readable GENESIS_SLOT, but the
+        # mcp-spawn file plane maps pid→slot. The label must come from the plane.
+        monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
+        spawn = tmp_path / "spawn"
+        spawn.mkdir()
+        (spawn / "5").write_text(f"4242 {'a' * 40} 2026-08-06T00:00:00+00:00\n")
+        monkeypatch.setattr(mcp_spawn_store, "_SPAWN_DIR", spawn)
+        _make_proc_entry(tmp_path, 4242, "claude", None, 700_000)  # no environ slot
+        rows = enumerate_cc_slots()
+        assert len(rows) == 1
+        assert rows[0]["pid"] == 4242 and rows[0]["slot"] == "5"
+
+    def test_stale_spawn_slot_on_headless_pid_is_excluded(self, tmp_path, monkeypatch):
+        # A stale spawn-file maps a slot to a pid the OS has since reused for a
+        # headless `claude -p` cognitive call. cmdline is authoritative → the call
+        # must be EXCLUDED, never labeled with the stale slot as a live session.
+        monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
+        spawn = tmp_path / "spawn"
+        spawn.mkdir()
+        (spawn / "3").write_text(f"7777 {'a' * 40} 2026-08-06T00:00:00+00:00\n")
+        monkeypatch.setattr(mcp_spawn_store, "_SPAWN_DIR", spawn)
+        # pid 7777 is now a headless cognitive call (cmdline has -p)
+        _make_proc_entry(tmp_path, 7777, "claude", None, 500_000, cmdline=_PRINT_CMD)
+        assert enumerate_cc_slots() == []
+
+    def test_two_claude_same_slot_label_both_kept_pid_keyed(self, tmp_path, monkeypatch):
+        # Rows are keyed by pid now (each live claude = one row); a shared slot label
+        # (anomalous) surfaces BOTH rather than silently hiding one.
         monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
         _make_proc_entry(tmp_path, 2001, "claude", "2", 500_000)
         _make_proc_entry(tmp_path, 2002, "claude", "2", 900_000)
         rows = enumerate_cc_slots()
-        assert len(rows) == 1
-        assert rows[0]["pid"] == 2002
-        assert rows[0]["rss_mb"] == round(900_000 / 1024, 1)
+        assert {r["pid"] for r in rows} == {2001, 2002}
+        assert all(r["slot"] == "2" for r in rows)
 
-    def test_numeric_slot_ordering(self, tmp_path, monkeypatch):
-        # "10" must follow "9", not sort lexicographically before it
+    def test_ordering_numeric_then_unlabeled(self, tmp_path, monkeypatch):
+        # "10" follows "9"; unlabeled (None) interactive sessions sort last.
         monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
         _make_proc_entry(tmp_path, 3001, "claude", "9", 800_000)
         _make_proc_entry(tmp_path, 3002, "claude", "10", 800_000)
         _make_proc_entry(tmp_path, 3003, "claude", "2", 800_000)
-        assert [r["slot"] for r in enumerate_cc_slots()] == ["2", "9", "10"]
+        _make_proc_entry(tmp_path, 3004, "claude", None, 800_000)  # unlabeled → last
+        assert [r["slot"] for r in enumerate_cc_slots()] == ["2", "9", "10", None]
 
     def test_empty_proc_returns_empty(self, tmp_path, monkeypatch):
         monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
@@ -96,6 +152,34 @@ class TestEnumerateCcSlots:
     def test_missing_proc_dir_returns_empty_not_raise(self, monkeypatch):
         monkeypatch.setattr(cc_slots, "_PROC", "/nonexistent/proc/path")
         assert enumerate_cc_slots() == []
+
+
+class TestIsInteractive:
+    def _cmdline(self, tmp_path, monkeypatch, pid, raw):
+        monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
+        (tmp_path / str(pid)).mkdir()
+        (tmp_path / str(pid) / "cmdline").write_bytes(raw)
+
+    def test_interactive_no_print_flag(self, tmp_path, monkeypatch):
+        self._cmdline(tmp_path, monkeypatch, 10, _INTERACTIVE_CMD)
+        assert cc_slots._is_interactive(10) is True
+
+    def test_short_print_flag_excluded(self, tmp_path, monkeypatch):
+        self._cmdline(tmp_path, monkeypatch, 11, _PRINT_CMD)
+        assert cc_slots._is_interactive(11) is False
+
+    def test_long_print_flag_excluded(self, tmp_path, monkeypatch):
+        self._cmdline(tmp_path, monkeypatch, 12, b"claude\x00--print\x00hi\x00")
+        assert cc_slots._is_interactive(12) is False
+
+    def test_permissions_flag_not_mistaken_for_print(self, tmp_path, monkeypatch):
+        # exact-arg match: --dangerously-skip-permissions must NOT match -p
+        self._cmdline(tmp_path, monkeypatch, 13, b"claude\x00--dangerously-skip-permissions\x00")
+        assert cc_slots._is_interactive(13) is True
+
+    def test_unreadable_cmdline_is_non_interactive(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cc_slots, "_PROC", str(tmp_path))
+        assert cc_slots._is_interactive(999_999) is False
 
 
 # ── start-time (btime + /proc/<pid>/stat field 22) ──────────────────────────

--- a/tests/test_observability/test_mcp_spawn_store.py
+++ b/tests/test_observability/test_mcp_spawn_store.py
@@ -74,11 +74,14 @@ class TestPersistRead:
 
 
 class TestEnumerateSpawnSlots:
-    def test_lists_slot_and_pid(self, tmp_path, monkeypatch):
+    def test_lists_slot_pid_and_spawn_at(self, tmp_path, monkeypatch):
         _point_dir(tmp_path, monkeypatch)
         store.persist_spawn_commit("4", 45285, FULL, AT)
         store.persist_spawn_commit("7", 1615462, FULL, AT)
-        assert sorted(store.enumerate_spawn_slots()) == [("4", 45285), ("7", 1615462)]
+        assert sorted(store.enumerate_spawn_slots()) == [
+            ("4", 45285, AT),
+            ("7", 1615462, AT),
+        ]
 
     def test_missing_dir_returns_empty(self, tmp_path, monkeypatch):
         _point_dir(tmp_path, monkeypatch)  # dir not created
@@ -92,13 +95,41 @@ class TestEnumerateSpawnSlots:
         (d / ".4.tmp9x").write_text(f"999 {FULL} {AT}\n")  # atomic-write temp → skip
         (d / "5").write_text("only two\n")  # not 3 tokens → skip
         (d / "6").write_text(f"notapid {FULL} {AT}\n")  # non-numeric pid → skip
-        assert store.enumerate_spawn_slots() == [("4", 45285)]
+        assert store.enumerate_spawn_slots() == [("4", 45285, AT)]
 
-    def test_slot_by_pid_reverse_map(self, tmp_path, monkeypatch):
+
+class TestSpawnRecordIsCurrent:
+    def test_proc_started_before_spawn_at_is_current(self):
+        # legit: the claude process started a beat before its MCP wrote spawn_at
+        assert (
+            store.spawn_record_is_current("2026-08-06T12:00:05+00:00", "2026-08-06T12:00:00+00:00")
+            is True
+        )
+
+    def test_proc_started_well_after_is_stale(self):
+        # recycled pid: the live process started long after the stale record
+        assert (
+            store.spawn_record_is_current("2026-08-06T12:00:00+00:00", "2026-08-06T14:00:00+00:00")
+            is False
+        )
+
+    def test_missing_or_unparseable_times_fail_open(self):
+        assert store.spawn_record_is_current(None, "2026-08-06T12:00:00+00:00") is True
+        assert store.spawn_record_is_current("2026-08-06T12:00:00+00:00", None) is True
+        assert store.spawn_record_is_current("garbage", "also-garbage") is True
+
+    def test_recycled_pid_rejected_by_read_spawn_identity(self, tmp_path, monkeypatch):
         _point_dir(tmp_path, monkeypatch)
-        store.persist_spawn_commit("4", 45285, FULL, AT)
-        store.persist_spawn_commit("7", 1615462, FULL, AT)
-        assert store.slot_by_pid() == {45285: "4", 1615462: "7"}
+        store.persist_spawn_commit("4", 45285, FULL, "2026-08-06T12:00:00+00:00")
+        # same pid, but the live process started 2h after the record → recycled
+        assert store.read_spawn_identity("4", 45285, "2026-08-06T14:00:00+00:00") is None
+        # a process started before spawn_at (genuine) still reads
+        assert store.read_spawn_identity("4", 45285, "2026-08-06T11:59:58+00:00") == (
+            FULL,
+            "2026-08-06T12:00:00+00:00",
+        )
+        # no start time supplied → pid match alone (back-compat, fail-open)
+        assert store.read_spawn_identity("4", 45285) == (FULL, "2026-08-06T12:00:00+00:00")
 
 
 class TestSessionPid:

--- a/tests/test_observability/test_mcp_spawn_store.py
+++ b/tests/test_observability/test_mcp_spawn_store.py
@@ -73,6 +73,34 @@ class TestPersistRead:
         store.persist_spawn_commit("4", 111, FULL, AT)  # must not raise
 
 
+class TestEnumerateSpawnSlots:
+    def test_lists_slot_and_pid(self, tmp_path, monkeypatch):
+        _point_dir(tmp_path, monkeypatch)
+        store.persist_spawn_commit("4", 45285, FULL, AT)
+        store.persist_spawn_commit("7", 1615462, FULL, AT)
+        assert sorted(store.enumerate_spawn_slots()) == [("4", 45285), ("7", 1615462)]
+
+    def test_missing_dir_returns_empty(self, tmp_path, monkeypatch):
+        _point_dir(tmp_path, monkeypatch)  # dir not created
+        assert store.enumerate_spawn_slots() == []
+
+    def test_skips_temp_and_malformed(self, tmp_path, monkeypatch):
+        _point_dir(tmp_path, monkeypatch)
+        d = tmp_path / "mcp-spawn"
+        d.mkdir()
+        (d / "4").write_text(f"45285 {FULL} {AT}\n")  # valid
+        (d / ".4.tmp9x").write_text(f"999 {FULL} {AT}\n")  # atomic-write temp → skip
+        (d / "5").write_text("only two\n")  # not 3 tokens → skip
+        (d / "6").write_text(f"notapid {FULL} {AT}\n")  # non-numeric pid → skip
+        assert store.enumerate_spawn_slots() == [("4", 45285)]
+
+    def test_slot_by_pid_reverse_map(self, tmp_path, monkeypatch):
+        _point_dir(tmp_path, monkeypatch)
+        store.persist_spawn_commit("4", 45285, FULL, AT)
+        store.persist_spawn_commit("7", 1615462, FULL, AT)
+        assert store.slot_by_pid() == {45285: "4", 1615462: "7"}
+
+
 class TestSessionPid:
     def test_parent_is_claude(self, tmp_path, monkeypatch):
         monkeypatch.setattr(store, "_PROC", str(tmp_path))


### PR DESCRIPTION
## Problem
genesis-server runs under systemd `ProtectSystem=strict`. Reading another process's `/proc/<pid>/environ` is ptrace-FSCREDS gated and returns EACCES inside that sandbox. `enumerate_cc_slots()` derived each CC session's slot only from `GENESIS_SLOT` (environ-only), so it returned `[]` whenever called from the server — leaving three features inert since the RSS-leak feature shipped (#855):
- the MCP-staleness stale-code dashboard badge (Part B, #1307)
- the per-slot RSS-leak detector (awareness loop)
- the infrastructure snapshot's `cc_slots`

Proven: the real `enumerate_cc_slots()` returns 0 under `systemd-run --user -p ProtectSystem=strict` and 6 unsandboxed; bisected to that single directive (NoNewPrivileges alone is fine).

## Fix
Enumerate `comm=="claude"` processes and keep one only if it is an **interactive** session — its cmdline has no `-p`/`--print` (the authoritative signal, checked before any slot label). This excludes the internal headless `claude -p` cognitive/background subprocesses that share `comm=="claude"` (verified across every spawn site) so they don't masquerade as sessions. The slot label is enrichment: from environ when readable, else from the world-readable `mcp-spawn` file plane (`slot_by_pid`), which survives the sandbox. Rows are keyed by pid; `slot` may be None for an unregistered interactive session (the dashboard join is pid-based; such rows are never flagged stale — they carry no persisted commit). Null-slot ripples through the RSS alert (pid-based key/label) and both dashboard templates (slot-or-pid render).

Also relocates a verification-discipline note into the genesis-development skill: post-deploy E2E must run in the real runtime context — this bug shipped green but inert because enumerate was verified in a shell that *can* read environ.

## Tests
`test_cc_slots` (comm walk, cmdline discriminator, file-plane label, pid-keying, stale-slot-on-reused-pid guard, ordering), `test_mcp_spawn_store` (`enumerate_spawn_slots`/`slot_by_pid`), `test_cc_slot_alert` (null-slot pid-keyed alert). 47 targeted tests pass; verify-RED confirmed the discriminator has teeth.

## Review
genesis-architect (design — the interactive/cognitive discriminator resolves a HIGH finding) + code-reviewer (line-by-line GO; two sub-threshold findings fixed with tests).

Follow-up: 44d6be99
Ledger: 52dbf6e7d6bc43ed8ff8cb29056376e1

🤖 Generated with [Claude Code](https://claude.com/claude-code)