### PR TITLE
perf(health): serve top_tags stale-while-revalidate + offload /proc scans off the loop (MW-0)

### DIFF
--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1458,7 +1458,8 @@ async def _check_cc_slot_memory(db, slots: list[dict] | None = None) -> None:
             enumerate_cc_slots,
         )
         if slots is None:
-            slots = enumerate_cc_slots()
+            # /proc scan is ~1s of sync syscalls — keep it off the event loop.
+            slots = await asyncio.to_thread(enumerate_cc_slots)
     except Exception:
         logger.debug("cc_slot memory check: enumeration failed", exc_info=True)
         return

--- a/src/genesis/dashboard/routes/cc_sessions.py
+++ b/src/genesis/dashboard/routes/cc_sessions.py
@@ -16,6 +16,7 @@ waypoint spine (this is its first reader), and repo-pulse annotations.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import sqlite3
@@ -261,7 +262,8 @@ async def cc_sessions_detail():
     if not rt.is_bootstrapped or rt.db is None:
         return jsonify({"error": "not bootstrapped"}), 503
 
-    slots = enumerate_cc_slots()
+    # /proc scan is ~1s of sync syscalls — keep it off the event loop.
+    slots = await asyncio.to_thread(enumerate_cc_slots)
     deploy = await last_successful_update(rt.db)  # (completed_at, new_commit) | None
     return jsonify(await _collect_detail(rt.db, slots, deploy=deploy))
 

--- a/src/genesis/memory/health.py
+++ b/src/genesis/memory/health.py
@@ -5,11 +5,17 @@ Pure SQL aggregates and Qdrant vector queries — NO LLM judgment.
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 import random
+import sqlite3
+import time
 from datetime import UTC, datetime, timedelta
 
 import aiosqlite
+
+from genesis.util.tasks import tracked_task
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +51,6 @@ async def near_duplicate_stats(
     blocking the event loop. Default sample_size is 20 to keep cost bounded
     (~40 Qdrant calls: scroll + search per sample).
     """
-    import asyncio
 
     try:
         cursor = await db.execute("SELECT memory_id FROM memory_metadata")
@@ -131,8 +136,179 @@ async def orphan_stats(db: aiosqlite.Connection, *, min_age_days: int = 7) -> di
     }
 
 
+# ---------------------------------------------------------------------------
+# top_tags: serve stale-while-revalidate (SWR)
+#
+# The top-tags computation scans the ENTIRE memory_fts corpus (one row per
+# memory) and tag-counts it in pure Python. It is O(corpus) and was historically
+# run INLINE on the caller's event loop — a multi-hundred-ms Python loop that
+# grew with the corpus and chronically starved the genesis-server loop (recall
+# 503s, lag WARNs). `top_tags` has ZERO production consumers, so it never needs
+# to be fresh on the request path. It is now served stale-while-revalidate,
+# mirroring `memory.intent.TagCooccurrenceIndex` (follow-up ac27b693): the cheap
+# collection/total aggregates stay fresh on the caller connection; top_tags is
+# served from a module cache that a single-flight background task refreshes
+# off-loop (via a SEPARATE read-only sqlite connection) when stale.
+# ---------------------------------------------------------------------------
+
+_top_tags_cache: list[tuple[str, int]] = []
+_top_tags_built_at: float = 0.0  # monotonic ts; 0.0 => never built
+_top_tags_corpus_count: int = 0  # corpus size at last build (drives staleness)
+_top_tags_rebuild_in_flight: bool = False  # single-flight guard for the bg task
+_TAG_STATS_STALE_DELTA = 0.10  # rebuild when the corpus count changes by >10%
+_TAG_STATS_MAX_AGE_S = 3600.0  # ...or when the cache is older than this
+
+
+def _top_tags_disabled() -> bool:
+    """Env kill switch — disables the background top_tags rebuild entirely."""
+    return os.environ.get("GENESIS_TOP_TAGS_DISABLED", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _reset_top_tags_state() -> None:
+    """Test seam: reset the module-level SWR state to a cold start."""
+    global _top_tags_cache, _top_tags_built_at, _top_tags_corpus_count  # noqa: PLW0603
+    global _top_tags_rebuild_in_flight  # noqa: PLW0603
+    _top_tags_cache = []
+    _top_tags_built_at = 0.0
+    _top_tags_corpus_count = 0
+    _top_tags_rebuild_in_flight = False
+
+
+def _scan_top_tags(db_path: str, limit: int = 20) -> list[tuple[str, int]]:
+    """Count the top *limit* tags from memory_fts on a fresh READ-ONLY connection.
+
+    Runs OFF the event loop (inside ``asyncio.to_thread``), never on the caller
+    path. Opens its own ``mode=ro`` connection (WAL-visible — NOT ``immutable=1``,
+    which would miss un-checkpointed writes) so it never touches the shared
+    aiosqlite write connection. Iterates the cursor directly (no ``fetchall``) so
+    SQLite's C ``step`` releases the GIL between rows — the pure-Python counting
+    holds the GIL only in microsecond slices instead of one multi-hundred-ms block.
+    """
+    conn: sqlite3.Connection | None = None
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        conn.execute("PRAGMA busy_timeout=5000")
+        cursor = conn.execute("SELECT tags FROM memory_fts WHERE tags != ''")
+        tag_counts: dict[str, int] = {}
+        for (tags_str,) in cursor:  # iterate directly — GIL released between rows
+            if not tags_str:
+                continue
+            for tag in tags_str.split():
+                tag = tag.strip().strip(",")
+                if tag:
+                    tag_counts[tag] = tag_counts.get(tag, 0) + 1
+        return sorted(tag_counts.items(), key=lambda x: x[1], reverse=True)[:limit]
+    except sqlite3.Error:
+        logger.warning("memory_fts scan for top_tags failed", exc_info=True)
+        return []
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+async def _rebuild_top_tags(db_path: str, total: int) -> None:
+    """Background SWR rebuild: scan tags in a thread, update the cache, clear flag.
+
+    Single-flight — the scheduler sets ``_top_tags_rebuild_in_flight`` before
+    scheduling this, and this clears it in a ``finally`` so a scan failure can't
+    wedge the cache stale forever. The built-at / corpus markers are always set
+    (even on an empty/failed scan) so a persistent FTS error can't hot-loop the
+    scheduler; the cache simply refreshes on the next staleness window.
+    """
+    global _top_tags_cache, _top_tags_built_at, _top_tags_corpus_count  # noqa: PLW0603
+    global _top_tags_rebuild_in_flight  # noqa: PLW0603
+    try:
+        _top_tags_cache = await asyncio.to_thread(_scan_top_tags, db_path)
+        _top_tags_built_at = time.monotonic()
+        _top_tags_corpus_count = total
+        logger.info(
+            "top_tags cache rebuilt in background (%d tags, corpus=%d)",
+            len(_top_tags_cache),
+            total,
+        )
+    finally:
+        _top_tags_rebuild_in_flight = False
+
+
+def _top_tags_is_stale(total: int) -> bool:
+    """True when the cache needs a rebuild (never built, corpus drift, or age).
+
+    "Ever built" is tracked by ``_top_tags_built_at != 0.0`` ALONE — NOT by a
+    non-zero corpus count, so a genuinely empty corpus that has been built reads
+    as fresh (the delta check below handles a later 0 → N growth via max(…, 1)).
+    """
+    if _top_tags_built_at == 0.0:
+        return True
+    delta = abs(total - _top_tags_corpus_count) / max(_top_tags_corpus_count, 1)
+    if delta > _TAG_STATS_STALE_DELTA:
+        return True
+    return (time.monotonic() - _top_tags_built_at) > _TAG_STATS_MAX_AGE_S
+
+
+async def _main_db_path(db: aiosqlite.Connection) -> str | None:
+    """Resolve the main database file path for the out-of-band read-only scan.
+
+    Returns None for ``:memory:`` databases (tests) — a separate connection
+    cannot see an in-memory DB, so the rebuild is skipped gracefully.
+    """
+    try:
+        cursor = await db.execute("PRAGMA database_list")
+        for row in await cursor.fetchall():
+            # PRAGMA database_list columns: (seq, name, file)
+            if row[1] == "main":
+                return row[2] or None
+    except aiosqlite.Error:
+        logger.warning("Failed to resolve main db path for top_tags scan", exc_info=True)
+    return None
+
+
+async def _maybe_refresh_top_tags(db: aiosqlite.Connection, total: int) -> None:
+    """Schedule a single-flight background top_tags rebuild if the cache is stale."""
+    global _top_tags_rebuild_in_flight  # noqa: PLW0603
+    if _top_tags_disabled() or _top_tags_rebuild_in_flight:
+        return
+    if not _top_tags_is_stale(total):
+        return
+    # Claim single-flight BEFORE the first await (_main_db_path yields on the
+    # SerializedConnection lock). The in-flight guard above and this set have no
+    # await between them, so under cooperative scheduling a second concurrent
+    # caller sees the flag set and bails — no double-schedule. Once the rebuild is
+    # actually scheduled, ownership of clearing the flag transfers to
+    # _rebuild_top_tags's finally; until then, THIS finally clears it — including
+    # on CancelledError (BaseException, so `except Exception` would miss it),
+    # which the widened flag-held window across the await now makes reachable
+    # (wait_for timeouts, DB-lock retries, restart cancellation).
+    _top_tags_rebuild_in_flight = True
+    scheduled = False
+    try:
+        db_path = await _main_db_path(db)
+        if db_path is None:
+            return  # :memory: (tests) — no out-of-band scan possible
+        tracked_task(_rebuild_top_tags(db_path, total), name="top_tags_rebuild")
+        scheduled = True
+    except Exception:
+        # Resolution or scheduling failed — flag cleared in the finally below.
+        logger.warning("Failed to schedule top_tags rebuild", exc_info=True)
+    finally:
+        if not scheduled:
+            _top_tags_rebuild_in_flight = False
+
+
 async def distribution_stats(db: aiosqlite.Connection) -> dict:
-    """Counts by collection and top-20 tags from FTS5."""
+    """Counts by collection and total (fresh) + top-20 tags (served stale).
+
+    The collection/total aggregates are cheap and computed fresh on the caller
+    connection. ``top_tags`` is served from the SWR cache above; a stale cache
+    triggers a single-flight background refresh (off-loop) but this call always
+    returns immediately with whatever the cache currently holds. ``top_tags`` has
+    no production consumers, so staleness is invisible; freshness is never worth
+    an O(corpus) FTS scan on the event loop.
+    """
     try:
         cursor = await db.execute(
             "SELECT collection, COUNT(*) FROM memory_metadata GROUP BY collection"
@@ -145,23 +321,14 @@ async def distribution_stats(db: aiosqlite.Connection) -> dict:
         logger.error("Failed to compute distribution stats", exc_info=True)
         return {"error": "DB unavailable"}
 
-    # Tag distribution from FTS5 — may not be available in all environments
-    top_tags: list[tuple[str, int]] = []
-    try:
-        cursor = await db.execute("SELECT tags FROM memory_fts WHERE tags != ''")
-        tag_counts: dict[str, int] = {}
-        for (tags_str,) in await cursor.fetchall():
-            if not tags_str:
-                continue
-            for tag in tags_str.split():
-                tag = tag.strip().strip(",")
-                if tag:
-                    tag_counts[tag] = tag_counts.get(tag, 0) + 1
-        top_tags = sorted(tag_counts.items(), key=lambda x: x[1], reverse=True)[:20]
-    except aiosqlite.Error:
-        logger.warning("memory_fts not available for tag distribution", exc_info=True)
+    await _maybe_refresh_top_tags(db, total)
 
-    return {"by_collection": by_collection, "total": total, "top_tags": top_tags}
+    return {
+        "by_collection": by_collection,
+        "total": total,
+        "top_tags": list(_top_tags_cache),
+        "top_tags_warming": _top_tags_built_at == 0.0,
+    }
 
 
 async def growth_stats(db: aiosqlite.Connection) -> dict:

--- a/src/genesis/memory/session_observer.py
+++ b/src/genesis/memory/session_observer.py
@@ -17,6 +17,7 @@ This processor:
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -250,9 +251,10 @@ async def process_pending_observations(
     # Adopt crash-stranded .processing files before scanning: the finally-
     # restore below only covers files renamed by THIS run, so a mid-tick
     # crash would otherwise strand its renamed files forever.
-    _recover_stale_processing_files()
+    # Both are synchronous filesystem walks — keep them off the event loop.
+    await asyncio.to_thread(_recover_stale_processing_files)
 
-    obs_files = _find_observation_files()
+    obs_files = await asyncio.to_thread(_find_observation_files)
     if not obs_files:
         return result
 

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import shutil
@@ -352,7 +353,8 @@ async def infrastructure(
     try:
         from genesis.observability.cc_slots import enumerate_cc_slots
 
-        infra["cc_slots"] = enumerate_cc_slots()
+        # /proc scan is ~1s of sync syscalls — keep it off the event loop.
+        infra["cc_slots"] = await asyncio.to_thread(enumerate_cc_slots)
     except Exception:
         infra["cc_slots"] = []
 

--- a/tests/test_awareness/test_cc_slot_alert.py
+++ b/tests/test_awareness/test_cc_slot_alert.py
@@ -8,7 +8,8 @@ split, the per-slot cooldown, and the db-None / below-threshold no-ops.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -90,3 +91,43 @@ async def test_create_failure_never_raises(_reset_cooldown_and_mock_create):
     create.side_effect = RuntimeError("db locked")
     # must not propagate into the tick
     await loop._check_cc_slot_memory(object(), slots=[_slot("4", 6500)])
+
+
+# ── MW-0 A2: the /proc enumeration must run OFF the event loop ───────────────
+
+
+@pytest.mark.asyncio
+async def test_slots_none_offloads_enumeration(monkeypatch):
+    """When slots are not injected, enumerate_cc_slots (~1s of sync /proc
+    syscalls) must be dispatched through asyncio.to_thread, never on the loop."""
+    import genesis.observability.cc_slots as cc_slots_mod
+
+    sentinel = MagicMock(return_value=[])
+    monkeypatch.setattr(cc_slots_mod, "enumerate_cc_slots", sentinel)
+
+    dispatched = []
+    real_to_thread = asyncio.to_thread
+
+    async def spy(fn, *a, **k):
+        dispatched.append(fn)
+        return await real_to_thread(fn, *a, **k)
+
+    monkeypatch.setattr(loop.asyncio, "to_thread", spy)
+
+    await loop._check_cc_slot_memory(object(), slots=None)
+
+    assert sentinel in dispatched  # enumeration went through to_thread
+    sentinel.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_injected_slots_skip_enumeration(monkeypatch):
+    """The slots= injection path must NOT enumerate at all (tests / future
+    snapshot-sharing pass pre-collected slots)."""
+    import genesis.observability.cc_slots as cc_slots_mod
+
+    enum = MagicMock(side_effect=AssertionError("must not enumerate with injected slots"))
+    monkeypatch.setattr(cc_slots_mod, "enumerate_cc_slots", enum)
+
+    await loop._check_cc_slot_memory(object(), slots=[_slot("1", 100)])
+    enum.assert_not_called()

--- a/tests/test_dashboard/test_cc_sessions_routes.py
+++ b/tests/test_dashboard/test_cc_sessions_routes.py
@@ -12,7 +12,7 @@ The charter tables are created with inline DDL matching migration 0058
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from flask import Flask
@@ -162,6 +162,44 @@ def test_detail_503_when_not_bootstrapped(client):
 def test_route_registered_on_dashboard_blueprint(app):
     rules = {rule.rule for rule in app.url_map.iter_rules()}
     assert "/api/genesis/cc-sessions/detail" in rules
+
+
+async def test_detail_route_offloads_slot_enumeration(app, db, monkeypatch):
+    """MW-0 A2: the detail route's ~1s /proc enumeration runs OFF the event loop
+    (asyncio.to_thread), never inline on the request/server loop."""
+    import genesis.dashboard.routes.cc_sessions as mod
+    import genesis.observability.cc_slots as cc_slots_mod
+
+    await _seed_charter_tables(db)
+    _patch_spawn(monkeypatch, {})  # hermetic — never read the real ~/.genesis
+
+    monkeypatch.setattr("genesis.runtime.GenesisRuntime", MagicMock(instance=lambda: _mock_rt(db)))
+    # Deploy resolution is orthogonal to this offload — stub it out.
+    monkeypatch.setattr(
+        "genesis.db.crud.update_history.last_successful_update",
+        AsyncMock(return_value=None),
+    )
+    enum = MagicMock(return_value=[])
+    monkeypatch.setattr(cc_slots_mod, "enumerate_cc_slots", enum)
+
+    dispatched = []
+    real_to_thread = mod.asyncio.to_thread
+
+    async def spy(fn, *a, **k):
+        dispatched.append(fn)
+        return await real_to_thread(fn, *a, **k)
+
+    monkeypatch.setattr(mod.asyncio, "to_thread", spy)
+
+    # The blueprint decorator wraps async views in a run_until_complete sync
+    # shim; await the raw coroutine (__wrapped__) directly on the test's loop so
+    # the aiosqlite db stays on one loop.
+    raw_view = mod.cc_sessions_detail.__wrapped__
+    with app.test_request_context():
+        await raw_view()
+
+    assert enum in dispatched  # enumeration dispatched through to_thread
+    enum.assert_called_once()
 
 
 # ── Helper level (real db fixture, injected slots) ───────────────────────────

--- a/tests/test_memory/test_health.py
+++ b/tests/test_memory/test_health.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+import sqlite3
 from datetime import UTC, datetime, timedelta
 
+import aiosqlite
 import pytest
 
+from genesis.memory import health as health_mod
 from genesis.memory.health import (
+    _scan_top_tags,
     distribution_stats,
     full_health_report,
     growth_stats,
@@ -16,6 +21,282 @@ from genesis.memory.health import (
 
 def _ts(days_ago: int = 0) -> str:
     return (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
+
+
+@pytest.fixture(autouse=True)
+def _reset_top_tags_state():
+    """Isolate the module-level SWR cache between tests."""
+    health_mod._reset_top_tags_state()
+    yield
+    health_mod._reset_top_tags_state()
+
+
+class _RecordingConn:
+    """Proxy that records every SQL string executed on the wrapped connection."""
+
+    def __init__(self, real):
+        self._real = real
+        self.executed: list[str] = []
+
+    async def execute(self, sql, *args, **kwargs):
+        self.executed.append(sql)
+        return await self._real.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+async def _make_file_db(path):
+    """A file-backed SerializedConnection with the full schema (memory_fts incl.)."""
+    from genesis.db.connection import SerializedConnection
+    from genesis.db.schema import create_all_tables
+
+    conn = await aiosqlite.connect(str(path))
+    conn.row_factory = aiosqlite.Row
+    await conn.execute("PRAGMA foreign_keys=ON")
+    await create_all_tables(conn)
+    await conn.commit()
+    return SerializedConnection(conn)
+
+
+async def _seed_fts(db, rows: list[tuple[str, str]]) -> None:
+    """rows = [(memory_id, tags), ...] — also seed memory_metadata for `total`."""
+    for mem_id, tags in rows:
+        await db.execute("INSERT INTO memory_fts (memory_id, tags) VALUES (?, ?)", (mem_id, tags))
+        await db.execute(
+            "INSERT INTO memory_metadata (memory_id, created_at) VALUES (?, ?)",
+            (mem_id, _ts()),
+        )
+    await db.commit()
+
+
+# --- A1: top_tags served stale-while-revalidate, never on the caller loop -----
+
+
+@pytest.mark.asyncio()
+async def test_distribution_stats_never_scans_fts_on_caller_connection(tmp_path, monkeypatch):
+    """THE regression guard: the O(corpus) memory_fts scan must NEVER run on the
+    caller's connection (the event loop). It is served stale, refreshed off-loop
+    via a separate read-only connection."""
+    db = await _make_file_db(tmp_path / "g.db")
+    try:
+        await _seed_fts(db, [("m1", "alpha beta"), ("m2", "alpha gamma"), ("m3", "alpha beta")])
+
+        # Capture the scheduled rebuild coroutine instead of firing a real task.
+        captured = []
+        monkeypatch.setattr(health_mod, "tracked_task", lambda coro, **kw: captured.append(coro))
+
+        proxy = _RecordingConn(db)
+        first = await distribution_stats(proxy)
+
+        # Caller connection never touched memory_fts (only cheap aggregates + pragma).
+        assert not any("memory_fts" in s for s in proxy.executed), proxy.executed
+        # Cold start: cache empty, warming flag set, a rebuild was scheduled.
+        assert first["top_tags"] == []
+        assert first["top_tags_warming"] is True
+        assert first["total"] == 3
+        assert len(captured) == 1
+
+        # Run the background rebuild (off-loop path) and confirm it populates cache.
+        await captured[0]
+        assert dict(health_mod._top_tags_cache) == {"alpha": 3, "beta": 2, "gamma": 1}
+
+        # A subsequent call serves the materialized tags, still without scanning fts.
+        proxy2 = _RecordingConn(db)
+        second = await distribution_stats(proxy2)
+        assert not any("memory_fts" in s for s in proxy2.executed)
+        assert second["top_tags"][0] == ("alpha", 3)
+        assert second["top_tags_warming"] is False
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio()
+async def test_distribution_stats_cold_start_in_memory_skips_rebuild(empty_db, monkeypatch):
+    """On :memory: (tests) no out-of-band scan is possible — serve empty, schedule
+    nothing, never block. The public shape stays intact (top_tags is a list)."""
+    scheduled = []
+    monkeypatch.setattr(health_mod, "tracked_task", lambda coro, **kw: scheduled.append(coro))
+
+    result = await distribution_stats(empty_db)
+    assert result["top_tags"] == []
+    assert isinstance(result["top_tags"], list)
+    assert result["top_tags_warming"] is True
+    assert scheduled == []  # :memory: → _main_db_path None → no rebuild
+
+
+def test_scan_top_tags_counts_and_is_readonly(tmp_path):
+    """The sync scanner counts tags correctly, honors the limit, uses a RO
+    connection (writes rejected), and fails soft on a bad path."""
+    db_path = str(tmp_path / "s.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE VIRTUAL TABLE memory_fts USING fts5("
+        "memory_id UNINDEXED, content, source_type, tags, collection UNINDEXED, "
+        "tokenize='porter ascii')"
+    )
+    conn.executemany(
+        "INSERT INTO memory_fts (memory_id, tags) VALUES (?, ?)",
+        [("m1", "alpha beta"), ("m2", "alpha gamma"), ("m3", "alpha beta")],
+    )
+    conn.commit()
+    conn.close()
+
+    result = _scan_top_tags(db_path)
+    assert result[0] == ("alpha", 3)
+    assert dict(result) == {"alpha": 3, "beta": 2, "gamma": 1}
+    assert _scan_top_tags(db_path, limit=1) == [("alpha", 3)]
+
+    # mode=ro really is read-only.
+    ro = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            ro.execute("INSERT INTO memory_fts (memory_id, tags) VALUES ('x', 'y')")
+    finally:
+        ro.close()
+
+    # Missing DB → graceful empty, no raise.
+    assert _scan_top_tags(str(tmp_path / "nope.db")) == []
+
+
+@pytest.mark.asyncio()
+async def test_rebuild_top_tags_populates_cache_and_clears_flag(tmp_path):
+    """The async rebuild materializes the cache, stamps built_at/corpus, and
+    always releases the single-flight guard."""
+    db_path = str(tmp_path / "r.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE VIRTUAL TABLE memory_fts USING fts5("
+        "memory_id UNINDEXED, content, source_type, tags, collection UNINDEXED)"
+    )
+    conn.executemany(
+        "INSERT INTO memory_fts (memory_id, tags) VALUES (?, ?)",
+        [("m1", "x y"), ("m2", "x")],
+    )
+    conn.commit()
+    conn.close()
+
+    health_mod._top_tags_rebuild_in_flight = True
+    await health_mod._rebuild_top_tags(db_path, total=2)
+
+    assert dict(health_mod._top_tags_cache) == {"x": 2, "y": 1}
+    assert health_mod._top_tags_built_at > 0.0
+    assert health_mod._top_tags_corpus_count == 2
+    assert health_mod._top_tags_rebuild_in_flight is False
+
+
+@pytest.mark.asyncio()
+async def test_maybe_refresh_single_flight_and_staleness(empty_db, monkeypatch, tmp_path):
+    """Schedules once when stale; not while a rebuild is in flight; not when fresh;
+    reschedules when the corpus drifts >10%."""
+    db = await _make_file_db(tmp_path / "sf.db")
+    try:
+        await _seed_fts(db, [("m1", "a b"), ("m2", "a c")])
+
+        # This test asserts scheduling COUNT, not the rebuild — close each
+        # captured coro so it is not left unawaited (RuntimeWarning hygiene).
+        scheduled = []
+
+        def _capture_and_close(coro, **kw):
+            scheduled.append(coro)
+            coro.close()
+
+        monkeypatch.setattr(health_mod, "tracked_task", _capture_and_close)
+
+        # Cold + stale → schedules exactly one.
+        await health_mod._maybe_refresh_top_tags(db, total=100)
+        assert len(scheduled) == 1
+        assert health_mod._top_tags_rebuild_in_flight is True
+
+        # In-flight → no second schedule.
+        await health_mod._maybe_refresh_top_tags(db, total=100)
+        assert len(scheduled) == 1
+
+        # Simulate the rebuild completing at corpus=100.
+        health_mod._top_tags_rebuild_in_flight = False
+        health_mod._top_tags_built_at = health_mod.time.monotonic()
+        health_mod._top_tags_corpus_count = 100
+
+        # Fresh (5% drift, within age) → no schedule.
+        await health_mod._maybe_refresh_top_tags(db, total=105)
+        assert len(scheduled) == 1
+
+        # >10% drift → reschedule.
+        await health_mod._maybe_refresh_top_tags(db, total=120)
+        assert len(scheduled) == 2
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio()
+async def test_top_tags_kill_switch_disables_rebuild(monkeypatch, tmp_path):
+    """GENESIS_TOP_TAGS_DISABLED neutralizes the background rebuild entirely."""
+    db = await _make_file_db(tmp_path / "k.db")
+    try:
+        await _seed_fts(db, [("m1", "a b")])
+        monkeypatch.setenv("GENESIS_TOP_TAGS_DISABLED", "1")
+        scheduled = []
+        monkeypatch.setattr(health_mod, "tracked_task", lambda coro, **kw: scheduled.append(coro))
+
+        result = await distribution_stats(db)
+        assert scheduled == []
+        assert result["top_tags"] == []
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio()
+async def test_concurrent_refresh_schedules_single_rebuild(tmp_path, monkeypatch):
+    """Single-flight under concurrency: two stale callers racing through the
+    _main_db_path await must schedule EXACTLY ONE rebuild (not two)."""
+    db = await _make_file_db(tmp_path / "cc.db")
+    try:
+        await _seed_fts(db, [("m1", "a b"), ("m2", "a c")])
+
+        scheduled = []
+
+        def _capture_and_close(coro, **kw):
+            scheduled.append(coro)
+            coro.close()
+
+        monkeypatch.setattr(health_mod, "tracked_task", _capture_and_close)
+
+        # Both see the same cold (stale) cache and race through the await in
+        # _main_db_path; the flag must be claimed before that yield.
+        await asyncio.gather(
+            health_mod._maybe_refresh_top_tags(db, 100),
+            health_mod._maybe_refresh_top_tags(db, 100),
+        )
+        assert len(scheduled) == 1
+    finally:
+        await db.close()
+
+
+def test_stale_stabilizes_for_empty_corpus():
+    """A genuinely empty corpus that has been built must NOT read as perpetually
+    stale (else every health check reschedules a rebuild)."""
+    # Simulate a completed build over an empty corpus.
+    health_mod._top_tags_built_at = health_mod.time.monotonic()
+    health_mod._top_tags_corpus_count = 0
+    assert health_mod._top_tags_is_stale(0) is False  # built + still empty → fresh
+    assert health_mod._top_tags_is_stale(100) is True  # corpus grew → stale
+
+
+@pytest.mark.asyncio()
+async def test_cancelled_during_resolve_releases_flag(empty_db, monkeypatch):
+    """Cancellation while suspended in _main_db_path (the window the single-flight
+    claim now spans) must release the in-flight flag AND re-raise — never wedge
+    the flag True (which would silently disable all future refreshes)."""
+
+    async def _cancel(_db):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(health_mod, "_main_db_path", _cancel)
+
+    with pytest.raises(asyncio.CancelledError):
+        await health_mod._maybe_refresh_top_tags(empty_db, 100)  # cold → stale → claims flag
+
+    assert health_mod._top_tags_rebuild_in_flight is False  # not wedged
 
 
 @pytest.mark.asyncio()

--- a/tests/test_memory/test_session_observer.py
+++ b/tests/test_memory/test_session_observer.py
@@ -237,6 +237,35 @@ async def test_process_pending_observations_no_files(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_process_pending_offloads_walkers(tmp_path, monkeypatch):
+    """MW-0 A2: both synchronous filesystem walks (stale-recovery + file scan)
+    run OFF the event loop via asyncio.to_thread, in order."""
+    import genesis.memory.session_observer as so
+
+    monkeypatch.setattr(so, "_sessions_dir", lambda: tmp_path)
+    recover = MagicMock()
+    find = MagicMock(return_value=[])
+    monkeypatch.setattr(so, "_recover_stale_processing_files", recover)
+    monkeypatch.setattr(so, "_find_observation_files", find)
+
+    dispatched = []
+    real_to_thread = so.asyncio.to_thread
+
+    async def spy(fn, *a, **k):
+        dispatched.append(fn)
+        return await real_to_thread(fn, *a, **k)
+
+    monkeypatch.setattr(so.asyncio, "to_thread", spy)
+
+    result = await process_pending_observations(store=AsyncMock(), router=AsyncMock())
+    assert result.files_processed == 0  # no files → early return
+    # Both walks were dispatched through to_thread, recovery before the scan.
+    assert dispatched == [recover, find]
+    recover.assert_called_once()
+    find.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_process_pending_observations_stores_notes(tmp_path, monkeypatch):
     """Observations are read, LLM is called, notes are stored."""
     # Keep the stale-recovery scan off the real ~/.genesis/sessions

--- a/tests/test_observability/test_infrastructure_snapshot_offload.py
+++ b/tests/test_observability/test_infrastructure_snapshot_offload.py
@@ -1,0 +1,52 @@
+"""MW-0 A2: the infrastructure snapshot must enumerate CC slots OFF the event
+loop. `enumerate_cc_slots` is a ~1s synchronous /proc scan; running it inline on
+the snapshot collector (which fires on the shared server loop) starved recall.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import genesis.observability.service_status as service_status
+import genesis.observability.snapshots.infrastructure  # noqa: F401 — ensure loaded
+
+# The `snapshots` package re-exports the `infrastructure` FUNCTION, shadowing the
+# submodule attribute — fetch the real module object from sys.modules to patch it.
+infra_mod = sys.modules["genesis.observability.snapshots.infrastructure"]
+
+
+@pytest.mark.asyncio
+async def test_infrastructure_offloads_cc_slot_enumeration(monkeypatch):
+    # Neutralize the network probes so the collector is hermetic + fast.
+    monkeypatch.setattr(
+        infra_mod,
+        "probe_qdrant",
+        AsyncMock(return_value=SimpleNamespace(status="healthy", latency_ms=1.0)),
+    )
+    monkeypatch.setattr(service_status, "probe_qdrant_collections", AsyncMock(return_value={}))
+
+    import genesis.observability.cc_slots as cc_slots_mod
+
+    sentinel_slots = [{"slot": "1", "pid": 1, "rss_mb": 1.0, "status": "healthy"}]
+    enum = MagicMock(return_value=sentinel_slots)
+    monkeypatch.setattr(cc_slots_mod, "enumerate_cc_slots", enum)
+
+    dispatched = []
+    real_to_thread = infra_mod.asyncio.to_thread
+
+    async def spy(fn, *a, **k):
+        dispatched.append(fn)
+        return await real_to_thread(fn, *a, **k)
+
+    monkeypatch.setattr(infra_mod.asyncio, "to_thread", spy)
+
+    # db/scheduler/state_machine all None → axis updates no-op, no DB queries.
+    infra = await infra_mod.infrastructure(None, None, None, None)
+
+    assert enum in dispatched  # enumeration dispatched through to_thread
+    enum.assert_called_once()
+    assert infra["cc_slots"] == sentinel_slots


### PR DESCRIPTION
## What

Removes the dominant chronic event-loop blocker in genesis-server: `memory/health.py::distribution_stats` scanned the entire `memory_fts` corpus (~69k rows) and tag-counted it in pure Python **on the event loop**, fired on every health snapshot by internal consumers (ego context builders, sentinel, morning report). Measured on real data: ~596ms per call. Its only output, `top_tags`, has **zero production consumers**.

## The fix

**A1 — `top_tags` served stale-while-revalidate** (`memory/health.py`). The cheap `by_collection`/`total` aggregates stay fresh on the caller connection. `top_tags` is served from a module cache that a single-flight background `tracked_task` refreshes off-loop, via a **separate read-only** sqlite connection (`mode=ro`, WAL-visible) so it never touches the shared write connection. Staleness = never-built OR corpus-count drift >10% OR age >1h. Mirrors the existing `memory/intent.py::TagCooccurrenceIndex` SWR pattern. Env kill switch `GENESIS_TOP_TAGS_DISABLED` neutralizes the background rebuild.

**A2 — off-loop offloads.** The ~1s synchronous `/proc` scan `enumerate_cc_slots()` and the session-observer's two filesystem walks are wrapped in `asyncio.to_thread`, at every call site on the loop (awareness tick, infrastructure snapshot, CC-sessions detail route, pending-observations processing).

## Impact (measured, real corpus)

| | before | after |
|---|---|---|
| `distribution_stats` hot-path cost | ~620ms (on-loop) | **29ms** (cheap queries only) |
| top-tags scan | every snapshot, on-loop | hourly, off-loop, single-flight |

Return shape is backward-compatible (`by_collection`, `total`, `top_tags` unchanged; adds `top_tags_warming` bool — no consumer reads `top_tags`).

## Tests

- RED witnessed first: `distribution_stats` scanning `memory_fts` on the caller connection.
- `distribution_stats_never_scans_fts_on_caller_connection` regression guard (file-backed, proves the scan runs on a separate connection); `_scan_top_tags` correctness + RO-write-rejected; rebuild-populates-cache; single-flight + staleness-delta; kill switch.
- A2 offload guards (thread-dispatch spies) for all four sites.
- 86 affected-suite tests green + 176-test collateral ring (loop, health-snapshot consumers, ego context) green; ruff clean.

## Rollback

`GENESIS_TOP_TAGS_DISABLED=1` + restart neutralizes A1's background machinery (serves empty top_tags); A2 offloads are pure `to_thread` wrappers with no switch needed.

## Follow-up

If the post-deploy soak still shows lag-WARN episodes clustering with snapshot activity, add a ~20–30s serve-stale cache inside `HealthDataService.snapshot()` (internal-snapshot TTL — pre-scoped fast-follow).
