### PR TITLE
ci: cancel superseded runs + advanced CodeQL to end runner starvation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,14 @@ on:
   schedule:
     - cron: "0 6 * * 1"  # weekly Mon 06:00 UTC — surface new CVEs even without repo activity
 
+# One in-flight CI run per branch: a new push cancels the superseded run so it
+# stops holding runner slots. Many active branches fanning out full CI with no
+# cancellation was saturating the shared runner budget (queue starvation). Never
+# cancel main's post-merge run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1"  # weekly Mon 06:00 UTC — surface new CVEs even without repo activity
+
+# Cancel a branch's superseded CodeQL run the instant a new commit is pushed, so
+# stale in-flight analyses stop holding runner slots. Uncancelled fan-out across
+# many active branches was starving the shared runner budget and leaving CodeQL
+# queued for 50-75 min before it got cancelled. Never cancel main's post-merge run.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    # A CodeQL analysis of interpreted languages normally finishes in a few
+    # minutes; cap a genuinely hung run so it frees the runner instead of holding
+    # it for the 6h default (the only specific failure mode a timeout addresses here).
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Python is the core codebase; javascript-typescript covers the dashboard
+        # JS/TS. Dropped the redundant 'javascript'/'typescript' slices and the
+        # low-value 'actions' analysis the default setup also ran — together they
+        # tripled the per-push job count and were the slices starving in the queue.
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # No `queries:` → the default code-scanning suite (same coverage the
+          # prior default setup ran). The only built-in suites are
+          # security-extended / security-and-quality; "default" is not a valid
+          # value and is obtained by omission.
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

CodeQL and CI jobs were starving in the shared runner queue — sitting queued 50–75 min, then getting cancelled. Two causes:

- **No `concurrency` groups** on any workflow, so every push to any active branch left its superseded run holding runner slots (superseded runs were never cancelled).
- **CodeQL default setup** fanned out five language slices (`actions, javascript, javascript-typescript, python, typescript`) on every push + PR.

Together, across many concurrently-active branches, this saturated the runner budget.

## Fix

- **Concurrency groups** on both `ci.yml` and the new `codeql.yml`, keyed on workflow + branch, `cancel-in-progress` on everything except `main`. A new push cancels the branch's prior run instead of queuing a second; `main`'s post-merge run is never cancelled.
- **Advanced-setup CodeQL** (`codeql.yml`) replacing default setup: matrix reduced to `python` + `javascript-typescript` (drops the redundant `javascript`/`typescript` slices — `javascript-typescript` already covers both — and the low-value `actions` analysis), `build-mode: none`, 30-min timeout, `codeql-action@v4`. Same default query suite; no JS/TS coverage lost.

## Deploy note

CodeQL default setup is **mutually exclusive** with an advanced workflow, so it has been **disabled** in repo settings as part of this change. Fresh clones have default setup off, so `codeql.yml` works for them with no action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)