### PR TITLE
feat(memory): MW-1 Tier-0 extraction judgment axes (write-only)

### DIFF
--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -339,6 +339,11 @@ async def create_metadata(
     invalid_at: str | None = None,
     source_subsystem: str | None = None,
     origin_class: str | None = None,
+    speech_act: str | None = None,
+    speech_act_confidence: float | None = None,
+    assertion_provenance: str | None = None,
+    durability: str | None = None,
+    expires_at: str | None = None,
 ) -> str:
     """Insert a row into memory_metadata. Returns memory_id.
 
@@ -352,6 +357,12 @@ async def create_metadata(
     (owner/first_party/external_untrusted), derived in
     ``MemoryStore.store()``; NULL = legacy/unclassified (gates treat it
     fail-closed at gate time).
+    ``speech_act`` / ``speech_act_confidence`` / ``assertion_provenance`` /
+    ``durability`` / ``expires_at`` are the MW-1 Tier-0 extraction judgment
+    axes — WRITE-ONLY (no reader yet). NULL = unclassified; expiry is opt-in
+    (``durability='temporary'`` + an elapsed canonicalized ``expires_at``
+    only). Contract in ``memory/judgment.py``.
+    # GROUNDWORK(mw-4-provenance-weight / mw-4-durability-ttl / mw-5-speech-act-protection)
     """
     # Bitemporal columns are raw TEXT-compared everywhere — canonicalize
     # at the write gate. Unparseable valid_at (LLM temporal strings like
@@ -363,8 +374,9 @@ async def create_metadata(
         "INSERT OR IGNORE INTO memory_metadata "
         "(memory_id, created_at, collection, confidence, embedding_status, "
         "memory_class, wing, room, valid_at, invalid_at, source_subsystem, "
-        "origin_class) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "origin_class, speech_act, speech_act_confidence, assertion_provenance, "
+        "durability, expires_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             memory_id,
             created_at,
@@ -378,6 +390,11 @@ async def create_metadata(
             canonical_iso(invalid_at),
             source_subsystem,
             origin_class,
+            speech_act,
+            speech_act_confidence,
+            assertion_provenance,
+            durability,
+            canonical_iso(expires_at),
         ),
     )
     await db.commit()

--- a/src/genesis/db/migrations/0079_mw1_extraction_judgment.py
+++ b/src/genesis/db/migrations/0079_mw1_extraction_judgment.py
@@ -1,0 +1,70 @@
+"""Add MW-1 Tier-0 extraction judgment columns to ``memory_metadata``.
+
+Three SEPARATE judgment axes, captured WRITE-ONLY at extraction time to cure the
+"defaulting disease" (every memory landing as ``memory_class=fact`` with no
+trust/durability/protection signal):
+
+  - ``speech_act`` (+ ``speech_act_confidence``) — what KIND of utterance;
+    drives existence-PROTECTION eligibility. Consumer: MW-5 (dream_shield).
+  - ``assertion_provenance`` — WHO asserted it (user/external/self_inference);
+    drives recall ranking WEIGHT. Consumer: MW-4. (Distinct from ``origin_class``,
+    a pipeline-trust label that is ``first_party`` for all transcript extraction.)
+  - ``durability`` + ``expires_at`` — permanent vs transient context; drives
+    temporary-context TTL lifecycle. Consumer: MW-4.
+
+All five columns are NULLable with NO default and NO backfill: expiry is strictly
+OPT-IN (a memory expires only on an EXPLICIT ``durability='temporary'`` + a valid
+elapsed ``expires_at``), so NULL/unclassified rows never expire — a wrong
+"temporary" must never silently delete memories. NOTHING reads these columns yet;
+MW-1 only writes them (# GROUNDWORK(mw-4-*) / (mw-5-*)).
+
+Self-contained + idempotent: each ADD is PRAGMA-guarded (applies via the base
+path OR the numbered runner; whichever ran first, the guard skips). No commit —
+the runner owns the transaction. Unindexed columns, so they need no mirror in
+``_migrate_add_columns`` (the base-path-parity guard is scoped to indexed columns).
+
+(Numbered 0079: 0078 is the highest present; the runner applies by per-id tracking
+and only duplicate prefixes are fatal.)
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_MEMORY_METADATA_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("speech_act", "TEXT"),
+    ("speech_act_confidence", "REAL"),
+    ("assertion_provenance", "TEXT"),
+    ("durability", "TEXT"),
+    ("expires_at", "TEXT"),
+)
+
+
+async def _add_column(db: aiosqlite.Connection, table: str, col: str, decl: str) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    )
+    if not await cursor.fetchone():
+        return  # fresh DB — CREATE TABLE already carries the column
+    cursor = await db.execute(f"PRAGMA table_info({table})")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if col not in cols:
+        await db.execute(f"ALTER TABLE {table} ADD COLUMN {col} {decl}")
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    for col, decl in _MEMORY_METADATA_COLUMNS:
+        await _add_column(db, "memory_metadata", col, decl)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_metadata'"
+    )
+    if not await cursor.fetchone():
+        return
+    cursor = await db.execute("PRAGMA table_info(memory_metadata)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    for col, _decl in _MEMORY_METADATA_COLUMNS:
+        if col in cols:
+            await db.execute(f"ALTER TABLE memory_metadata DROP COLUMN {col}")

--- a/src/genesis/db/migrations/0079_mw1_extraction_judgment.py
+++ b/src/genesis/db/migrations/0079_mw1_extraction_judgment.py
@@ -20,8 +20,12 @@ MW-1 only writes them (# GROUNDWORK(mw-4-*) / (mw-5-*)).
 
 Self-contained + idempotent: each ADD is PRAGMA-guarded (applies via the base
 path OR the numbered runner; whichever ran first, the guard skips). No commit —
-the runner owns the transaction. Unindexed columns, so they need no mirror in
-``_migrate_add_columns`` (the base-path-parity guard is scoped to indexed columns).
+the runner owns the transaction. These columns are ALSO mirrored in
+``_migrate_add_columns`` (guarded ``_try_alter``): create_all_tables runs that
+function but NOT the numbered runner, so a create_all_tables→``MemoryStore.store``
+INSERT on an existing DB (e.g. scripts/migrate_faiss_to_qdrant.py) needs the
+columns present there too. Being unindexed only means the INDEXES-parity guard
+cannot catch the omission — NOT that the mirror is unnecessary. schema_both_build_paths.
 
 (Numbered 0079: 0078 is the highest present; the runner applies by per-id tracking
 and only duplicate prefixes are fatal.)

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1180,6 +1180,31 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE memory_metadata ADD COLUMN room TEXT",
         "memory_metadata.room")
 
+    # MW-1 Tier-0 extraction judgment axes (0079_mw1_extraction_judgment).
+    # These MUST be mirrored here (the base create_all_tables path) and not only
+    # in the numbered migration: create_all_tables runs _migrate_add_columns but
+    # NOT the numbered runner, so on an existing DB the CREATE TABLE is a no-op
+    # and a create_all_tables→MemoryStore.store→create_metadata INSERT (e.g.
+    # scripts/migrate_faiss_to_qdrant.py) would hit 'no such column: speech_act'
+    # AFTER the Qdrant+FTS writes commit — a cross-store partial record. The
+    # columns are unindexed, so the INDEXES-parity guard cannot catch this;
+    # test_memory_metadata_base_path_upgrade does. schema_both_build_paths.
+    await _try_alter(db,
+        "ALTER TABLE memory_metadata ADD COLUMN speech_act TEXT",
+        "memory_metadata.speech_act")
+    await _try_alter(db,
+        "ALTER TABLE memory_metadata ADD COLUMN speech_act_confidence REAL",
+        "memory_metadata.speech_act_confidence")
+    await _try_alter(db,
+        "ALTER TABLE memory_metadata ADD COLUMN assertion_provenance TEXT",
+        "memory_metadata.assertion_provenance")
+    await _try_alter(db,
+        "ALTER TABLE memory_metadata ADD COLUMN durability TEXT",
+        "memory_metadata.durability")
+    await _try_alter(db,
+        "ALTER TABLE memory_metadata ADD COLUMN expires_at TEXT",
+        "memory_metadata.expires_at")
+
     # Bi-temporal columns for temporal fact tracking (0010_bitemporal_memory)
     await _try_alter(db,
         "ALTER TABLE memory_metadata ADD COLUMN valid_at TEXT",

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1209,7 +1209,19 @@ TABLES = {
             trust_level      TEXT,
             attribution      TEXT,
             origin_ref       TEXT,
-            capture_clarity  REAL
+            capture_clarity  REAL,
+            -- GROUNDWORK(mw-4-provenance-weight / mw-4-durability-ttl /
+            -- mw-5-speech-act-protection): MW-1 Tier-0 extraction judgment axes,
+            -- written WRITE-ONLY at extraction time — NOTHING reads them yet.
+            -- All NULLable with NO default: expiry is strictly opt-in
+            -- (durability='temporary' + an elapsed expires_at only), so an
+            -- unclassified row NEVER expires. Contract in memory/judgment.py;
+            -- added to existing DBs by migration 0079.
+            speech_act            TEXT,
+            speech_act_confidence REAL,
+            assertion_provenance  TEXT,
+            durability            TEXT,
+            expires_at            TEXT
         )
     """,
     "graduation_events": """

--- a/src/genesis/memory/extraction.py
+++ b/src/genesis/memory/extraction.py
@@ -16,6 +16,8 @@ import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
+from genesis.memory import judgment
+
 logger = logging.getLogger(__name__)
 
 # Proven extraction pattern from SkillRefiner (src/genesis/learning/skills/refiner.py)
@@ -40,6 +42,25 @@ For each extraction, provide:
   - optionally add "confidence" (0.0-1.0) and "ambiguous": true when you
     are unsure the two names refer to distinct known things
 - temporal: Date or time reference if mentioned (ISO format preferred)
+- speech_act: What KIND of statement this is (its force):
+  - "rule" — a standing directive/policy ("always X", "never Y", "must Z")
+  - "decision" — a settled choice ("we'll use X", "going with Y")
+  - "correction" — fixing a prior mistaken belief ("actually it's X, not Y")
+  - "observation" — a neutral noted fact (DEFAULT when unsure)
+  - "claim" — an asserted belief that could be contested
+  - "preference" — a like/dislike/leaning ("I prefer X")
+  - "question" — an open question
+  (type=decision usually implies speech_act="decision"; a governing rule ⇒ "rule")
+- speech_act_confidence: 0.0-1.0 — how sure you are of the speech_act label
+- provenance: WHO asserted this — "user" (the user stated it), "external"
+  (quoted from a source/doc/third party), or "self_inference" (Genesis inferred
+  it rather than being directly told). Omit if unclear.
+- durability: "permanent" (a lasting truth/rule/decision — DEFAULT) or
+  "temporary" (transient context that will go stale, e.g. "waiting on CI",
+  "currently debugging X"). Only mark "temporary" when it will clearly stop
+  being relevant — a wrong "temporary" causes the memory to be forgotten.
+- expires_at: for "temporary" only — ISO date/time it stops being relevant, if
+  known (otherwise omit)
 
 For each extraction that has a temporal reference AND describes a concrete
 action (something that happened, was decided, or will happen), additionally
@@ -109,6 +130,10 @@ Respond with a JSON object inside backticks containing:
         {"from": "Agentmail", "to": "P-3", "type": "categorized_as"}
       ],
       "temporal": "2026-03-17",
+      "speech_act": "claim",
+      "speech_act_confidence": 0.8,
+      "provenance": "external",
+      "durability": "permanent",
       "event": {"subject": "Genesis", "verb": "evaluated", "object": "Agentmail"}
     },
     {
@@ -168,6 +193,15 @@ class Extraction:
     event_subject: str | None = None
     event_verb: str | None = None
     event_object: str | None = None
+    # MW-1 Tier-0 judgment axes — WRITE-ONLY (consumers = MW-4 ranking/TTL,
+    # MW-5 protection). See memory/judgment.py. speech_act/durability default
+    # to the neutral, unprotected/non-expiring values; assertion_provenance and
+    # expires_at default NULL = unclassified.
+    speech_act: str = "observation"
+    speech_act_confidence: float = 0.5
+    assertion_provenance: str | None = None
+    durability: str = "permanent"
+    expires_at: str | None = None
 
 
 @dataclass
@@ -320,6 +354,17 @@ def parse_extraction_response_full(text: str) -> ParsedResponse:
         if scenario is not None:
             scenario = str(scenario).strip() or None
 
+        # MW-1 Tier-0 judgment axes — normalized to known values, defaulting
+        # SAFE (unknown speech_act → observation/unprotected; unknown durability
+        # → permanent/non-expiring; unknown provenance → None). See judgment.py.
+        speech_act = judgment.normalize_speech_act(item.get("speech_act"))
+        speech_act_confidence = judgment.clamp_unit(item.get("speech_act_confidence"))
+        assertion_provenance = judgment.normalize_provenance(item.get("provenance"))
+        durability = judgment.normalize_durability(item.get("durability"))
+        expires_at = item.get("expires_at")
+        if expires_at is not None:
+            expires_at = str(expires_at).strip() or None
+
         extractions.append(Extraction(
             content=content,
             extraction_type=ext_type,
@@ -331,6 +376,11 @@ def parse_extraction_response_full(text: str) -> ParsedResponse:
             event_subject=event_subject,
             event_verb=event_verb,
             event_object=event_object,
+            speech_act=speech_act,
+            speech_act_confidence=speech_act_confidence,
+            assertion_provenance=assertion_provenance,
+            durability=durability,
+            expires_at=expires_at,
         ))
 
     return ParsedResponse(
@@ -371,4 +421,10 @@ def extractions_to_store_kwargs(
         "extraction_timestamp": now_iso,
         "source_pipeline": "harvest",
         "valid_at": extraction.temporal,
+        # MW-1 Tier-0 judgment axes — write-only (consumers MW-4/MW-5).
+        "speech_act": extraction.speech_act,
+        "speech_act_confidence": extraction.speech_act_confidence,
+        "assertion_provenance": extraction.assertion_provenance,
+        "durability": extraction.durability,
+        "expires_at": extraction.expires_at,
     }

--- a/src/genesis/memory/judgment.py
+++ b/src/genesis/memory/judgment.py
@@ -1,0 +1,83 @@
+"""MW-1 — Tier-0 extraction judgment axes (provenance / speech_act / durability).
+
+Three SEPARATE axes captured at extraction time to cure the "defaulting disease"
+— every memory silently landing as ``memory_class=fact`` with no trust /
+durability / protection signal. Persisted WRITE-ONLY on ``memory_metadata``;
+NOTHING reads them yet. Consumers are downstream, already-filed workstreams:
+
+  - ``assertion_provenance`` → recall ranking WEIGHT
+    (# GROUNDWORK(mw-4-provenance-weight))
+  - ``durability`` + ``expires_at`` → temporary-context TTL lifecycle
+    (# GROUNDWORK(mw-4-durability-ttl))
+  - ``speech_act`` (+ ``speech_act_confidence``) → existence-PROTECTION eligibility
+    (# GROUNDWORK(mw-5-speech-act-protection))
+
+Do NOT collapse the three axes into one enum — that conflation IS the defaulting
+disease. Provenance (WHO asserted it) is not durability (is it a PERMANENT truth)
+is not speech-act (what KIND of utterance). In particular ``assertion_provenance``
+is distinct from ``memory_metadata.origin_class``: origin_class is a pipeline-trust
+label that resolves to ``first_party`` for ALL transcript extraction and so has
+zero power to tell "the user said it" from "Genesis inferred it".
+"""
+
+from __future__ import annotations
+
+# ── speech_act — what KIND of utterance (drives PROTECTION eligibility) ──
+SPEECH_ACTS: frozenset[str] = frozenset(
+    {"rule", "decision", "correction", "observation", "claim", "preference", "question"}
+)
+DEFAULT_SPEECH_ACT = "observation"  # neutral, unprotected — parser fallback
+
+# Only STRUCTURALLY-identifiable kinds earn existence-protection: a classifier can
+# hit these with confidence, where "fact"/"observation" cannot. ``preference`` is
+# deliberately EXCLUDED — preferences are exactly what legitimately gets superseded
+# ("used to prefer X, now Y"), and the permanent-identity layer (reference_store +
+# entity cards + pinning) already owns standing preferences. Consumed by MW-5's
+# dream_shield protection gate. # GROUNDWORK(mw-5-speech-act-protection)
+PROTECTED_SPEECH_ACTS: frozenset[str] = frozenset({"rule", "decision", "correction"})
+
+# How sure the extractor must be that something IS a protected kind before it earns
+# existence-protection. Consumed by MW-5. # GROUNDWORK(mw-5-speech-act-protection)
+PROTECTION_CONFIDENCE_FLOOR = 0.7
+
+# ── assertion_provenance — WHO asserted it (drives ranking WEIGHT) ──
+ASSERTION_PROVENANCES: frozenset[str] = frozenset({"user", "external", "self_inference"})
+
+# ── durability — a permanent truth vs transient context (drives lifecycle) ──
+DURABILITIES: frozenset[str] = frozenset({"permanent", "temporary"})
+DEFAULT_DURABILITY = "permanent"
+
+# Expiry is strictly OPT-IN: a memory drops out of recall IFF
+# ``durability == "temporary"`` AND a valid ``expires_at`` has elapsed.
+# NULL / "permanent" / anything-else NEVER expires — a wrong "temporary" must not
+# silently delete memories. The "temporary-without-an-explicit-date → default TTL"
+# policy belongs to the CONSUMER (MW-4), not this write path.
+# # GROUNDWORK(mw-4-durability-ttl)
+
+
+def normalize_speech_act(value: object) -> str:
+    """Coerce an LLM ``speech_act`` to a known value; unknown/missing → observation."""
+    if isinstance(value, str) and value in SPEECH_ACTS:
+        return value
+    return DEFAULT_SPEECH_ACT
+
+
+def normalize_durability(value: object) -> str:
+    """Coerce an LLM ``durability`` to a known value; unknown/missing → permanent (safe)."""
+    if isinstance(value, str) and value in DURABILITIES:
+        return value
+    return DEFAULT_DURABILITY
+
+
+def normalize_provenance(value: object) -> str | None:
+    """Coerce an LLM ``assertion_provenance``; unknown/missing → None (unclassified)."""
+    if isinstance(value, str) and value in ASSERTION_PROVENANCES:
+        return value
+    return None
+
+
+def clamp_unit(value: object, default: float = 0.5) -> float:
+    """Coerce a confidence to [0.0, 1.0]; non-numeric → ``default``."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return default
+    return max(0.0, min(1.0, float(value)))

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -127,6 +127,11 @@ class MemoryStore:
         project_type: str | None = None,
         supersedes: str | None = None,
         origin_class: str | None = None,
+        speech_act: str | None = None,
+        speech_act_confidence: float | None = None,
+        assertion_provenance: str | None = None,
+        durability: str | None = None,
+        expires_at: str | None = None,
     ) -> str:
         """Full store pipeline: embed -> Qdrant -> FTS5 -> auto-link. Returns memory_id.
 
@@ -375,6 +380,18 @@ class MemoryStore:
             invalid_at=invalid_at,
             source_subsystem=source_subsystem,
             origin_class=resolved_origin,
+            # MW-1 Tier-0 judgment axes — write-only to memory_metadata
+            # (consumers MW-4/MW-5). NOT denormalized into the Qdrant payload:
+            # the field is reachable at recall via the search_ranked metadata
+            # join (as origin_class's FTS fallback is), and a consumer that
+            # needs vector-path parity owns adding it to the payload + the
+            # re-embed recovery path together.
+            # GROUNDWORK(mw-4-provenance-weight / mw-4-durability-ttl / mw-5-speech-act-protection)
+            speech_act=speech_act,
+            speech_act_confidence=speech_act_confidence,
+            assertion_provenance=assertion_provenance,
+            durability=durability,
+            expires_at=expires_at,
         )
 
         # Mechanical code anchors (entity layer) — regex-only, every write

--- a/tests/test_db/test_memory_metadata_base_path_upgrade.py
+++ b/tests/test_db/test_memory_metadata_base_path_upgrade.py
@@ -1,0 +1,88 @@
+"""Regression: ``create_all_tables`` upgrades a legacy ``memory_metadata``.
+
+Root cause (MW-1, PR #1325 — Codex P1): the five judgment columns
+(``speech_act``/``speech_act_confidence``/``assertion_provenance``/
+``durability``/``expires_at``) were added to the canonical CREATE TABLE *and*
+the numbered migration ``0079`` — but NOT to ``_migrate_add_columns``.
+``create_all_tables`` runs ``_migrate_add_columns`` and NOT the numbered
+runner, so on a DB whose ``memory_metadata`` predates the columns the
+``CREATE TABLE IF NOT EXISTS`` is a no-op and the columns never appear.
+
+Unlike the #1123 ``ego_directives`` case, these columns are UNINDEXED, so the
+static ``INDEXES``-parity guard (``test_schema_base_path_parity``) correctly
+stays green — this is a *different* failure mode: any ``create_all_tables``
+upgrade path that then stores memories (e.g. ``scripts/migrate_faiss_to_qdrant``
+→ ``create_all_tables`` → ``MemoryStore.store`` → ``create_metadata`` INSERT)
+raises ``table memory_metadata has no column named speech_act`` — AFTER the
+Qdrant + FTS writes already committed, leaving a cross-store partial record.
+
+This guards the class the static guard cannot: a migration-added column that
+create_all_tables callers INSERT into must be mirrored on the base path too.
+``schema_both_build_paths``.
+
+The legacy table is constructed by building the current schema and DROPping the
+five columns — a faithful, low-maintenance stand-in for a pre-MW-1 DB (the real
+table is too large to hand-freeze the way ``ego_directives`` was).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.db.schema._migrations import create_all_tables
+
+_JUDGMENT_COLS = {
+    "speech_act",
+    "speech_act_confidence",
+    "assertion_provenance",
+    "durability",
+    "expires_at",
+}
+
+
+async def _columns(db: aiosqlite.Connection) -> set[str]:
+    cur = await db.execute("PRAGMA table_info(memory_metadata)")
+    return {row[1] for row in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_create_all_tables_upgrades_legacy_memory_metadata(tmp_path):
+    async with aiosqlite.connect(str(tmp_path / "legacy.db")) as db:
+        # Build the current schema, then strip the MW-1 columns to simulate a
+        # pre-0079 existing DB whose table predates them.
+        await create_all_tables(db)
+        for col in _JUDGMENT_COLS:
+            await db.execute(f"ALTER TABLE memory_metadata DROP COLUMN {col}")
+        assert not (_JUDGMENT_COLS & await _columns(db)), "setup failed to strip"
+
+        # A pre-existing metadata row, to prove the upgrade preserves data.
+        await db.execute(
+            "INSERT INTO memory_metadata (memory_id, created_at) "
+            "VALUES ('m-old', '2026-01-01T00:00:00')"
+        )
+
+        # This is the exact call the FAISS→Qdrant migration makes before storing.
+        await create_all_tables(db)
+
+        assert await _columns(db) >= _JUDGMENT_COLS, "base path did not add MW-1 columns"
+
+        # Existing row survives; new judgment columns are NULL (opt-in, no backfill).
+        cur = await db.execute(
+            "SELECT durability, speech_act FROM memory_metadata WHERE memory_id='m-old'"
+        )
+        row = await cur.fetchone()
+        assert row == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_create_all_tables_is_idempotent_on_legacy(tmp_path):
+    """A second create_all_tables pass must not raise (duplicate column)."""
+    async with aiosqlite.connect(str(tmp_path / "legacy.db")) as db:
+        await create_all_tables(db)
+        for col in _JUDGMENT_COLS:
+            await db.execute(f"ALTER TABLE memory_metadata DROP COLUMN {col}")
+
+        await create_all_tables(db)
+        await create_all_tables(db)  # must be a no-op, not "duplicate column"
+        assert await _columns(db) >= _JUDGMENT_COLS

--- a/tests/test_db/test_migration_0079_extraction_judgment.py
+++ b/tests/test_db/test_migration_0079_extraction_judgment.py
@@ -1,0 +1,141 @@
+"""MW-1 — 0079 extraction-judgment columns: migration + persistence.
+
+Covers the STORE side: the five judgment columns exist on both schema build
+paths (numbered migration for legacy DBs, canonical CREATE for fresh DBs), the
+migration is idempotent, and ``create_metadata`` persists the axes to
+``memory_metadata``.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+
+from genesis.db.crud import memory
+from genesis.db.schema import TABLES
+
+_mig = importlib.import_module("genesis.db.migrations.0079_mw1_extraction_judgment")
+
+_JUDGMENT_COLS = {
+    "speech_act",
+    "speech_act_confidence",
+    "assertion_provenance",
+    "durability",
+    "expires_at",
+}
+
+# A memory_metadata shaped like a legacy DB that predates MW-1 (no judgment cols).
+_LEGACY_DDL = """
+    CREATE TABLE memory_metadata (
+        memory_id        TEXT PRIMARY KEY,
+        created_at       TEXT NOT NULL,
+        collection       TEXT NOT NULL DEFAULT 'episodic_memory',
+        confidence       REAL,
+        embedding_status TEXT NOT NULL DEFAULT 'embedded',
+        memory_class     TEXT DEFAULT 'fact',
+        valid_at         TEXT,
+        invalid_at       TEXT,
+        origin_class     TEXT
+    )
+"""
+
+
+async def _columns(conn: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await conn.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def test_migration_adds_all_five_columns_to_legacy_db():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(_LEGACY_DDL)
+        await conn.commit()
+        assert _JUDGMENT_COLS & await _columns(conn, "memory_metadata") == set()
+
+        await _mig.up(conn)
+        await conn.commit()
+
+        cols = await _columns(conn, "memory_metadata")
+        assert cols >= _JUDGMENT_COLS
+    finally:
+        await conn.close()
+
+
+async def test_migration_is_idempotent():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(_LEGACY_DDL)
+        await conn.commit()
+        await _mig.up(conn)
+        await _mig.up(conn)  # second run must not raise (duplicate-column guard)
+        await conn.commit()
+        assert await _columns(conn, "memory_metadata") >= _JUDGMENT_COLS
+    finally:
+        await conn.close()
+
+
+async def test_fresh_db_create_carries_columns():
+    """The canonical CREATE TABLE (fresh-DB path) must already carry the cols —
+    else a fresh install diverges from a migrated one (base-path parity)."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["memory_metadata"])
+        await conn.commit()
+        assert await _columns(conn, "memory_metadata") >= _JUDGMENT_COLS
+    finally:
+        await conn.close()
+
+
+async def test_create_metadata_persists_judgment_fields():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["memory_metadata"])
+        await conn.commit()
+
+        await memory.create_metadata(
+            conn,
+            memory_id="mw1-a",
+            created_at="2026-08-06T00:00:00+00:00",
+            speech_act="rule",
+            speech_act_confidence=0.95,
+            assertion_provenance="user",
+            durability="temporary",
+            expires_at="2026-08-07",
+        )
+
+        cur = await conn.execute(
+            "SELECT speech_act, speech_act_confidence, assertion_provenance, "
+            "durability, expires_at FROM memory_metadata WHERE memory_id='mw1-a'"
+        )
+        row = await cur.fetchone()
+        assert row[0] == "rule"
+        assert row[1] == 0.95
+        assert row[2] == "user"
+        assert row[3] == "temporary"
+        # expires_at is canonicalized to full ISO by create_metadata.
+        assert row[4] is not None and row[4].startswith("2026-08-07")
+    finally:
+        await conn.close()
+
+
+async def test_create_metadata_defaults_null_when_unclassified():
+    """Non-extraction / unclassified writes leave the axes NULL (never a false
+    'temporary' — expiry is opt-in)."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["memory_metadata"])
+        await conn.commit()
+
+        await memory.create_metadata(
+            conn, memory_id="mw1-b", created_at="2026-08-06T00:00:00+00:00"
+        )
+
+        cur = await conn.execute(
+            "SELECT speech_act, speech_act_confidence, assertion_provenance, "
+            "durability, expires_at FROM memory_metadata WHERE memory_id='mw1-b'"
+        )
+        row = await cur.fetchone()
+        assert row == (None, None, None, None, None)
+    finally:
+        await conn.close()

--- a/tests/test_memory/test_bitemporal.py
+++ b/tests/test_memory/test_bitemporal.py
@@ -53,26 +53,15 @@ class TestExtractionValidAt:
 
 @pytest.fixture
 async def meta_db():
-    """In-memory SQLite with memory_metadata table."""
+    """In-memory SQLite with memory_metadata table (canonical DDL — never
+    drifts when columns are added, e.g. the MW-1 judgment axes)."""
     import aiosqlite
+
+    from genesis.db.schema import TABLES
+
     db = await aiosqlite.connect(":memory:")
     db.row_factory = aiosqlite.Row
-    await db.execute("""
-        CREATE TABLE memory_metadata (
-            memory_id        TEXT PRIMARY KEY,
-            created_at       TEXT NOT NULL,
-            collection       TEXT NOT NULL DEFAULT 'episodic_memory',
-            confidence       REAL,
-            embedding_status TEXT NOT NULL DEFAULT 'embedded',
-            memory_class     TEXT DEFAULT 'fact',
-            wing             TEXT,
-            room             TEXT,
-            valid_at         TEXT,
-            invalid_at       TEXT,
-            source_subsystem TEXT,
-            origin_class     TEXT
-        )
-    """)
+    await db.execute(TABLES["memory_metadata"])
     await db.commit()
     yield db
     await db.close()

--- a/tests/test_memory/test_extraction_judgment.py
+++ b/tests/test_memory/test_extraction_judgment.py
@@ -1,0 +1,157 @@
+"""MW-1 — Tier-0 extraction judgment fields (parse + kwargs + constants).
+
+Covers the WRITE side of the three judgment axes (provenance / speech_act /
+durability) as they ride the extraction LLM call: the parser must extract them,
+default SAFE when absent/garbage, and thread them into store() kwargs.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from genesis.memory import judgment
+from genesis.memory.extraction import (
+    Extraction,
+    extractions_to_store_kwargs,
+    parse_extraction_response,
+)
+
+
+def _wrap(item: dict) -> str:
+    return "```json\n" + json.dumps({"extractions": [item]}) + "\n```"
+
+
+class TestJudgmentConstants:
+    def test_protected_is_subset_of_speech_acts(self):
+        assert judgment.PROTECTED_SPEECH_ACTS <= judgment.SPEECH_ACTS
+
+    def test_preference_is_not_protected(self):
+        # Preferences get superseded; the identity layer owns standing prefs.
+        assert "preference" not in judgment.PROTECTED_SPEECH_ACTS
+        assert {"rule", "decision", "correction"} == judgment.PROTECTED_SPEECH_ACTS
+
+    def test_protection_confidence_floor(self):
+        assert judgment.PROTECTION_CONFIDENCE_FLOOR == 0.7
+
+    def test_defaults(self):
+        assert judgment.DEFAULT_SPEECH_ACT == "observation"
+        assert judgment.DEFAULT_DURABILITY == "permanent"
+
+
+class TestJudgmentNormalizers:
+    @pytest.mark.parametrize("value", sorted(judgment.SPEECH_ACTS))
+    def test_normalize_speech_act_passthrough(self, value):
+        assert judgment.normalize_speech_act(value) == value
+
+    @pytest.mark.parametrize("value", ["", "blah", None, 3, "Rule"])
+    def test_normalize_speech_act_unknown_defaults_observation(self, value):
+        assert judgment.normalize_speech_act(value) == "observation"
+
+    @pytest.mark.parametrize("value", ["", "forever", None, "PERMANENT"])
+    def test_normalize_durability_unknown_defaults_permanent(self, value):
+        assert judgment.normalize_durability(value) == "permanent"
+
+    @pytest.mark.parametrize("value", ["user", "external", "self_inference"])
+    def test_normalize_provenance_passthrough(self, value):
+        assert judgment.normalize_provenance(value) == value
+
+    @pytest.mark.parametrize("value", ["", "robot", None, "User"])
+    def test_normalize_provenance_unknown_is_none(self, value):
+        assert judgment.normalize_provenance(value) is None
+
+    def test_clamp_unit(self):
+        assert judgment.clamp_unit(1.5) == 1.0
+        assert judgment.clamp_unit(-0.2) == 0.0
+        assert judgment.clamp_unit(0.42) == 0.42
+        assert judgment.clamp_unit("x") == 0.5
+        assert judgment.clamp_unit(True) == 0.5  # bool is not a confidence
+
+
+class TestParseJudgmentFields:
+    def test_extracts_all_five(self):
+        item = {
+            "content": "Never push private data to public repos",
+            "type": "decision",
+            "confidence": 0.9,
+            "speech_act": "rule",
+            "speech_act_confidence": 0.95,
+            "provenance": "user",
+            "durability": "permanent",
+            "expires_at": None,
+        }
+        result = parse_extraction_response(_wrap(item))
+        assert len(result) == 1
+        ext = result[0]
+        assert ext.speech_act == "rule"
+        assert ext.speech_act_confidence == 0.95
+        assert ext.assertion_provenance == "user"
+        assert ext.durability == "permanent"
+        assert ext.expires_at is None
+
+    def test_temporary_with_expiry(self):
+        item = {
+            "content": "Waiting on CI run for PR #1323 to go green",
+            "type": "action_item",
+            "confidence": 0.8,
+            "speech_act": "observation",
+            "durability": "temporary",
+            "expires_at": "2026-08-07",
+        }
+        ext = parse_extraction_response(_wrap(item))[0]
+        assert ext.durability == "temporary"
+        assert ext.expires_at == "2026-08-07"
+
+    def test_defaults_when_absent(self):
+        item = {"content": "Some fact", "type": "entity", "confidence": 0.7}
+        ext = parse_extraction_response(_wrap(item))[0]
+        assert ext.speech_act == "observation"
+        assert ext.assertion_provenance is None
+        assert ext.durability == "permanent"
+        assert ext.expires_at is None
+
+    def test_invalid_enums_default_safe(self):
+        item = {
+            "content": "x",
+            "type": "entity",
+            "confidence": 0.5,
+            "speech_act": "shouting",
+            "provenance": "robot",
+            "durability": "eternal",
+        }
+        ext = parse_extraction_response(_wrap(item))[0]
+        assert ext.speech_act == "observation"
+        assert ext.assertion_provenance is None
+        assert ext.durability == "permanent"
+
+    def test_clamps_speech_act_confidence(self):
+        item = {
+            "content": "x",
+            "type": "entity",
+            "confidence": 0.5,
+            "speech_act": "rule",
+            "speech_act_confidence": 1.7,
+        }
+        ext = parse_extraction_response(_wrap(item))[0]
+        assert ext.speech_act_confidence == 1.0
+
+
+class TestKwargsThreading:
+    def test_kwargs_include_judgment_fields(self):
+        ext = Extraction(
+            content="Never push private data to public repos",
+            extraction_type="decision",
+            confidence=0.9,
+            speech_act="rule",
+            speech_act_confidence=0.95,
+            assertion_provenance="user",
+            durability="permanent",
+            expires_at=None,
+        )
+        kwargs = extractions_to_store_kwargs(ext)
+        assert kwargs["speech_act"] == "rule"
+        assert kwargs["speech_act_confidence"] == 0.95
+        assert kwargs["assertion_provenance"] == "user"
+        assert kwargs["durability"] == "permanent"
+        assert kwargs["expires_at"] is None

--- a/tests/test_memory/test_subsystem_sqlite_only.py
+++ b/tests/test_memory/test_subsystem_sqlite_only.py
@@ -7,27 +7,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiosqlite
 import pytest
 
+from genesis.db.schema import TABLES
 from genesis.memory.store import MemoryStore
 
 
 async def _build_db(path: str) -> aiosqlite.Connection:
     conn = await aiosqlite.connect(path)
-    await conn.execute("""
-        CREATE TABLE memory_metadata (
-            memory_id TEXT PRIMARY KEY,
-            created_at TEXT NOT NULL,
-            collection TEXT NOT NULL DEFAULT 'episodic_memory',
-            confidence REAL,
-            embedding_status TEXT NOT NULL DEFAULT 'embedded',
-            memory_class TEXT DEFAULT 'fact',
-            wing TEXT,
-            room TEXT,
-            valid_at TEXT,
-            invalid_at TEXT,
-            source_subsystem TEXT,
-            origin_class TEXT
-        )
-    """)
+    # Canonical DDL — never drifts when memory_metadata columns are added
+    # (e.g. the MW-1 judgment axes).
+    await conn.execute(TABLES["memory_metadata"])
     await conn.execute("""
         CREATE VIRTUAL TABLE memory_fts USING fts5(
             memory_id, content, source_type, tags, collection


### PR DESCRIPTION
## What
Capture three separate judgment axes per memory at extraction time — riding the existing extraction LLM call (≈free) — and persist them **write-only** to `memory_metadata`. Cures the "defaulting disease" (every new memory landing as `memory_class=fact` with no trust/durability/protection signal) for all NEW data.

- **speech_act** (+ `speech_act_confidence`) → existence-protection eligibility (consumer: MW-5)
- **assertion_provenance** (user / external / self_inference) → recall ranking weight (consumer: MW-4)
- **durability** (permanent / temporary) + **expires_at** → temporary-context TTL lifecycle (consumer: MW-4)

Three genuinely separate axes, not one collapsed enum. `assertion_provenance` is distinct from `origin_class` (a pipeline-trust label that resolves to `first_party` for all transcript extraction and so can't tell "the user said it" from "Genesis inferred it").

## Scope: write-only
Nothing reads these columns yet — **zero recall-path behavior change**. Consumers are downstream workstreams (MW-4 ranking/TTL, MW-5 protection), each tagged `# GROUNDWORK`.

## Safety: expiry is strictly opt-in
All five columns are NULLable with no default and no backfill. A memory expires from recall only on an explicit `durability='temporary'` **plus** an elapsed canonicalized `expires_at`; NULL / permanent / anything-else never expires — a wrong "temporary" cannot silently delete memories.

## Changes
- `memory/judgment.py` (new): canonical enums + safe-default normalizers (protected subset = rule/decision/correction; `preference` excluded — it gets superseded).
- `memory/extraction.py`: prompt fields, `Extraction` dataclass, parser (safe-default normalization), store-kwargs threading.
- `memory/store.py`, `db/crud/memory.py`: thread the 5 fields into the `create_metadata` INSERT — load-bearing on the `force_fts5_only` extraction path (the Qdrant payload is skipped there; the field is reachable at recall via the `search_ranked` metadata join like `origin_class`'s FTS fallback).
- `db/schema/_tables.py` + `db/migrations/0079_mw1_extraction_judgment.py`: 5 columns on `memory_metadata`, both build paths. Unindexed → deliberately not mirrored in `_migrate_add_columns` (the base-path-parity guard is index-scoped).

## Verification
- RED→GREEN; targeted collateral suite green; ruff clean.
- Migration validated on a copy of the live `memory_metadata` table: all 5 columns add cleanly, every existing row NULL (opt-in-expiry holds), idempotent re-run.
- One code-reviewer round: CLEAN (no BLOCKER / SHOULD-FIX).

Ledger: 5e6e85eaa4b4479a8b8fe5d6f7cc6cb4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
