### PR TITLE
feat(campaigns): github_activity_pending pre-check to cost-gate the GitHub activity digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,10 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   be delivered, it's retried until it lands rather than lost. Off by default on a
   fresh install (it baselines quietly first); enable pings by setting
   `mode: live` in a `config/github_steward.local.yaml` overlay once it has run.
-  Kill switch: `GENESIS_GITHUB_STEWARD_DISABLED=1`.
+  Kill switch: `GENESIS_GITHUB_STEWARD_DISABLED=1`. A companion campaign
+  pre-check (`github_activity_pending`) lets an opt-in digest campaign batch the
+  non-urgent activity into a periodic Telegram summary while only spending on
+  ticks that actually have new activity — quiet windows spawn nothing.
 
 ### Fixed
 

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -318,7 +318,10 @@ verified: 9037d45b 2026-07-07
   campaign names/prompts/targets are USER DATA (DB + private backups), never
   tracked source; zero shipped defaults. `CampaignRunner` cron-ticks
   programmatic prechecks then dispatches DirectSessions; a 120s reaper
-  reconciles finished sessions.
+  reconciles finished sessions. Prechecks receive a `db` handle in their ctx;
+  `github_activity_pending` uses it to gate a digest campaign to ticks with new
+  unresolved `github_account_activity` observations (fail-open on a first run or
+  missing handle) so a quiet window spends nothing.
 - GROUNDWORK across the entry: cross-vendor-review, per-step-verify,
   trace-verify, task-verify (built, dark), outreach-voice,
   autonomous-distribution.

--- a/src/genesis/campaigns/prechecks.py
+++ b/src/genesis/campaigns/prechecks.py
@@ -68,11 +68,56 @@ async def check_slots_available(
     return True, None
 
 
+async def check_github_activity_pending(
+    campaign: dict, *, ctx: dict[str, Any]
+) -> tuple[bool, str | None]:
+    """Gate the GitHub-activity digest to ticks with NEW monitor activity.
+
+    Passes (dispatch the LLM digest) only when the account-activity monitor
+    (``recon/account_activity.py``) has recorded at least one *unresolved*
+    ``github_account_activity`` observation since this campaign's last run.
+    A quiet 6h window therefore spawns no session and costs nothing; the
+    digest, once dispatched, marks the rows it consumes resolved so the next
+    empty tick gates again.
+
+    Fail-OPEN on missing plumbing: if ``db`` is absent from ctx (an older
+    runner) or ``last_run_at`` is unset (the campaign's first run), let the
+    tick through rather than silently gating on infrastructure. A spurious
+    pass is cheap — the digest session no-ops on an empty read — whereas a
+    wrong gate would silently swallow a real contributor signal.
+
+    Timestamp note: ``last_run_at`` is ``datetime.now(UTC).isoformat()``
+    (``+00:00`` suffix) while the monitor's ``created_at`` is a ``Z``-suffixed
+    ``_now_z()``. The count does a lexical ``created_at > since`` compare; both
+    share the ``YYYY-MM-DDTHH:MM:SS`` prefix, so lexical order matches
+    chronological order across the boundary (the differing sub-second suffix
+    only ever diverges *within* the same second, which the unresolved filter
+    plus resolve-on-digest makes idempotent — no genuinely-new row is missed).
+    """
+    from genesis.db.crud import observations
+
+    since = campaign.get("last_run_at")
+    db = ctx.get("db")
+    if db is None or since is None:
+        return True, None  # fail-open: never gate on missing plumbing / first run
+
+    n = await observations.count_recent_unresolved_by_type_and_source(
+        db,
+        type="github_account_activity",
+        source="recon",
+        since=since,
+    )
+    if n > 0:
+        return True, None
+    return False, "no new github activity since last run"
+
+
 # ── Registry ────────────────────────────────────────────────────────────
 PRECHECK_REGISTRY: dict[str, Any] = {
     "rate_limit": check_rate_limit,
     "budget": check_budget,
     "slots_available": check_slots_available,
+    "github_activity_pending": check_github_activity_pending,
 }
 
 

--- a/src/genesis/campaigns/runner.py
+++ b/src/genesis/campaigns/runner.py
@@ -211,6 +211,7 @@ class CampaignRunner:
         ctx = {
             "daily_cost": daily_cost,
             "session_runner": self._session_runner,
+            "db": self._db,
         }
 
         from genesis.campaigns.prechecks import run_prechecks

--- a/tests/test_campaigns/test_prechecks.py
+++ b/tests/test_campaigns/test_prechecks.py
@@ -121,3 +121,166 @@ class TestRunPrechecks:
         ctx = {"daily_cost": 0.0}
         ok, reason = await run_prechecks(campaign, ctx)
         assert ok is True  # Unknown checks are skipped, not failures
+
+
+class TestGithubActivityPending:
+    """C2b digest gate: dispatch the LLM digest only when the account-activity
+    monitor recorded NEW unresolved ``github_account_activity`` observations
+    since this campaign's last run — so a quiet 6h window costs nothing.
+
+    Uses the real observations store (mocking ``observations`` crud is guarded
+    against by conftest). Plain ``async def`` because the ``db`` fixture is an
+    asyncio-mode fixture (matches tests/test_db/test_observations.py).
+    """
+
+    # last_run_at is written as datetime.now(UTC).isoformat() → +00:00 suffix;
+    # the monitor's obs created_at is _now_z() → Z suffix. The count does a
+    # lexical created_at > since compare; these tests pin that the format
+    # mismatch does not break the window (both share the YYYY-MM-DDTHH:MM:SS
+    # prefix, so lexical order == chronological order across the boundary).
+    _SINCE = "2026-08-06T00:00:00.000000+00:00"
+
+    @staticmethod
+    async def _mk(
+        db,
+        *,
+        oid,
+        created_at,
+        resolved=False,
+        type="github_account_activity",
+        source="recon",
+    ):
+        from genesis.db.crud import observations
+
+        await observations.create(
+            db,
+            id=oid,
+            source=source,
+            type=type,
+            content="{}",
+            priority="medium",
+            created_at=created_at,
+        )
+        if resolved:
+            await observations.resolve(
+                db, oid, resolved_at="2026-08-06T13:00:00Z", resolution_notes="digested"
+            )
+
+    async def test_gates_when_no_activity(self, db):
+        from genesis.campaigns.prechecks import check_github_activity_pending
+
+        ok, reason = await check_github_activity_pending(
+            {"last_run_at": self._SINCE}, ctx={"db": db}
+        )
+        assert ok is False
+        assert "github" in (reason or "").lower()
+
+    async def test_passes_when_new_activity_since(self, db):
+        from genesis.campaigns.prechecks import check_github_activity_pending
+
+        await self._mk(db, oid="a1", created_at="2026-08-06T12:00:00Z")
+        ok, reason = await check_github_activity_pending(
+            {"last_run_at": self._SINCE}, ctx={"db": db}
+        )
+        assert ok is True
+        assert reason is None
+
+    async def test_gates_when_activity_predates_since(self, db):
+        from genesis.campaigns.prechecks import check_github_activity_pending
+
+        # created BEFORE last_run — already covered by a prior tick
+        await self._mk(db, oid="old", created_at="2026-08-05T12:00:00Z")
+        ok, reason = await check_github_activity_pending(
+            {"last_run_at": self._SINCE}, ctx={"db": db}
+        )
+        assert ok is False
+
+    async def test_boundary_same_second_counts_as_new(self, db):
+        # The format mismatch only ever diverges WITHIN one wall-clock second.
+        # Here last_run_at falls mid-second (…12:00:00.500000+00:00) and the obs
+        # created_at is the same second (…12:00:00Z). Lexically `Z`(0x5A) > `.`
+        # (0x2E), so the same-second obs is counted as new. This is the harmless
+        # false-POSITIVE direction (at worst one extra dispatch that the digest's
+        # resolve-on-consume makes idempotent) — pin it so the documented bias is
+        # real and can't silently flip.
+        from genesis.campaigns.prechecks import check_github_activity_pending
+
+        await self._mk(db, oid="tie", created_at="2026-08-06T12:00:00Z")
+        ok, reason = await check_github_activity_pending(
+            {"last_run_at": "2026-08-06T12:00:00.500000+00:00"}, ctx={"db": db}
+        )
+        assert ok is True
+
+    async def test_boundary_just_after_worstcase_since_not_missed(self, db):
+        # The guarantee that matters: NO false-negatives. Worst case for a
+        # missed signal is a `since` with maximal sub-second (…00.999999+00:00)
+        # and an obs one second later (…01Z). Even here the lexical compare keeps
+        # it (`…12:00:01Z` > `…12:00:00.999999+00:00`), so a genuinely-new obs is
+        # never dropped by the Z-vs-+00:00 format difference.
+        from genesis.campaigns.prechecks import check_github_activity_pending
+
+        await self._mk(db, oid="after", created_at="2026-08-06T12:00:01Z")
+        ok, reason = await check_github_activity_pending(
+            {"last_run_at": "2026-08-06T12:00:00.999999+00:00"}, ctx={"db": db}
+        )
+        assert ok is True
+        assert reason is None
+
+    async def test_ignores_resolved_activity(self, db):
+        from genesis.campaigns.prechecks import check_github_activity_pending
+
+        # a NEW but already-digested (resolved) row must NOT re-trigger a tick
+        await self._mk(db, oid="done", created_at="2026-08-06T12:00:00Z", resolved=True)
+        ok, reason = await check_github_activity_pending(
+            {"last_run_at": self._SINCE}, ctx={"db": db}
+        )
+        assert ok is False
+
+    async def test_ignores_other_types_and_sources(self, db):
+        from genesis.campaigns.prechecks import check_github_activity_pending
+
+        # unresolved + recent, but the actor-seen marker and foreign sources are
+        # NOT the digest signal — only github_account_activity@recon counts.
+        await self._mk(db, oid="seen", created_at="2026-08-06T12:00:00Z", type="github_actor_seen")
+        await self._mk(db, oid="other", created_at="2026-08-06T12:00:00Z", source="cc_cap_monitor")
+        ok, reason = await check_github_activity_pending(
+            {"last_run_at": self._SINCE}, ctx={"db": db}
+        )
+        assert ok is False
+
+    async def test_fails_open_when_db_missing(self, db):
+        from genesis.campaigns.prechecks import check_github_activity_pending
+
+        # older runner without db in ctx → never gate on missing plumbing
+        ok, reason = await check_github_activity_pending({"last_run_at": self._SINCE}, ctx={})
+        assert ok is True
+        assert reason is None
+
+    async def test_fails_open_when_no_last_run(self, db):
+        from genesis.campaigns.prechecks import check_github_activity_pending
+
+        # first run (no last_run_at) → let it through; the digest no-ops if empty
+        ok, reason = await check_github_activity_pending({"last_run_at": None}, ctx={"db": db})
+        assert ok is True
+        assert reason is None
+
+    async def test_registered_in_registry(self):
+        from genesis.campaigns.prechecks import (
+            PRECHECK_REGISTRY,
+            check_github_activity_pending,
+        )
+
+        assert PRECHECK_REGISTRY.get("github_activity_pending") is check_github_activity_pending
+
+    async def test_run_prechecks_gates_via_registry(self, db):
+        # end-to-end through run_prechecks: registry lookup resolves the name and
+        # the db-in-ctx plumbing reaches the check.
+        campaign = {
+            "id": "c1",
+            "last_run_at": self._SINCE,
+            "max_daily_cost_usd": 1.0,
+            "pre_checks": '["github_activity_pending"]',
+        }
+        ok, reason = await run_prechecks(campaign, {"daily_cost": 0.0, "db": db})
+        assert ok is False
+        assert "github" in (reason or "").lower()


### PR DESCRIPTION
## What

Adds a campaign pre-check, `github_activity_pending`, and plumbs the runner's
`db` handle into the pre-check `ctx`. The pre-check gates a 6h "GitHub activity
digest" campaign (the LLM tier that consumes the account-activity monitor's
observations): it passes — allowing an LLM session to dispatch — only when the
monitor has recorded at least one **unresolved** `github_account_activity`
observation (source `recon`) since the campaign's `last_run_at`. A quiet window
therefore spawns no session and costs nothing.

This resolves the standing gap where `github_account_activity` observations had
no consumer: the digest campaign (shipped separately as install-local user data,
per the campaigns public/private contract) is that consumer, and this pre-check
makes its dispatch cost-gated.

## How

- `check_github_activity_pending(campaign, *, ctx)` counts unresolved
  `github_account_activity`/`recon` observations created after `last_run_at` via
  the existing `count_recent_unresolved_by_type_and_source` CRUD. `>0` → pass;
  `0` → skip with a reason.
- **Fail-open** on a missing `db` handle or first run (no `last_run_at`): a
  spurious pass is cheap (the digest no-ops on an empty read), whereas a wrong
  gate would silently swallow a contributor signal.
- Runner `ctx` gains `"db": self._db` — inert for the three existing pre-checks,
  which read only their own keys.

### Timestamp-compare safety

`last_run_at` is `datetime.now(UTC).isoformat()` (`+00:00` suffix); the monitor's
obs `created_at` is `_now_z()` (`Z` suffix). The count is a lexical
`created_at > since` compare. Both share the fixed-width `YYYY-MM-DDTHH:MM:SS`
prefix, so lexical order equals chronological order except within a single
second — where the differing suffix biases toward counting a same-second obs as
new (harmless false-positive, made idempotent by the digest resolving rows it
consumes). It **never** produces a false-negative, so a genuinely-new obs is
never dropped. Boundary tests pin both the same-second bias and the tightest
worst-case sub-second case.

## Tests

RED-first (`tests/test_campaigns/test_prechecks.py::TestGithubActivityPending`):
gating on no / predating / resolved / foreign-type-or-source activity; passing
on new activity; same-second and worst-case sub-second boundaries; both
fail-open branches; and registry + `db`-in-ctx wiring end-to-end through
`run_prechecks`. Full `test_campaigns` suite: 69/69. Ruff clean.

## Review

Reviewed by a local code-reviewer agent (verdict: clean — no functional bug;
its one finding, a test-coverage gap on the same-second boundary claim, is fixed
in this PR by the two boundary tests). The external cloud reviewer was
unavailable at authoring time (usage quota resets Aug 8); this PR can either
merge on green CI or hold for that pass, at maintainer discretion.

## Notes

- No behavior change on any existing campaign — the new check only runs for a
  campaign that explicitly lists `github_activity_pending` in its `pre_checks`.
- No private data.