### PR TITLE
Escape markdown table cells in inbox digest

### DIFF
--- a/src/genesis/mcp/health/inbox_digest.py
+++ b/src/genesis/mcp/health/inbox_digest.py
@@ -97,6 +97,11 @@ async def _impl_inbox_digest(
         return {"error": f"Failed to generate inbox digest: {exc}"}
 
 
+def _cell(value: str) -> str:
+    """Escape a value so it stays inside one Markdown table cell."""
+    return value.replace("\n", " ").replace("|", "\\|")
+
+
 def _format_digest(
     pending: list[dict],
     resolved: list[dict],
@@ -118,7 +123,7 @@ def _format_digest(
             priority = fu.get("priority", "medium")
             content = fu.get("content", "")[:120]
             strategy = fu.get("strategy", "")
-            lines.append(f"| {priority} | {content} | {strategy} |")
+            lines.append(f"| {priority} | {_cell(content)} | {_cell(strategy)} |")
         lines.append("")
 
     # Pending ideas (surplus-ideation review lane)
@@ -130,7 +135,7 @@ def _format_digest(
         for fu in ideas:
             content = fu.get("content", "")[:120]
             src = fu.get("source", "")
-            lines.append(f"| {content} | {src} |")
+            lines.append(f"| {_cell(content)} | {_cell(src)} |")
         lines.append("")
 
     # Resolved items
@@ -144,7 +149,7 @@ def _format_digest(
             notes = (fu.get("resolution_notes") or "—")[:80]
             completed_at = fu.get("completed_at", "")
             age = _relative_age(completed_at)
-            lines.append(f"| {content} | {notes} | {age} |")
+            lines.append(f"| {_cell(content)} | {_cell(notes)} | {age} |")
         lines.append("")
 
     # Recent evaluations
@@ -162,7 +167,7 @@ def _format_digest(
             date = (ev.get("processed_at") or ev.get("created_at") or "")[:10]
             source_file = Path(ev.get("file_path", "")).name
             response = Path(ev.get("response_path", "")).name if ev.get("response_path") else "—"
-            lines.append(f"| {date} | {source_file} | {response} |")
+            lines.append(f"| {date} | {_cell(source_file)} | {_cell(response)} |")
         lines.append("")
 
     if not pending and not resolved and not evals and not ideas:

--- a/tests/test_inbox/test_inbox_digest.py
+++ b/tests/test_inbox/test_inbox_digest.py
@@ -254,3 +254,22 @@ class TestFormatDigest:
 
         output = _format_digest([], [], [], 7)
         assert "No inbox activity" in output
+
+    def test_format_escapes_pipe_and_newline(self):
+        from genesis.mcp.health.inbox_digest import _format_digest
+
+        pending = [
+            {
+                "priority": "high",
+                "content": "Compare X | Y\nsecond line",
+                "strategy": "ego_judgment",
+            }
+        ]
+
+        output = _format_digest(pending, [], [], 7)
+
+        assert "Compare X \\| Y second line" in output
+
+        body = output.split("|----------|------|----------|")[1]
+
+        assert body.strip().count("\n| ") == 0


### PR DESCRIPTION
## Summary

Escape Markdown table cell values in `_format_digest()` to prevent table
corruption when free-text fields contain pipe characters (`|`) or newlines.

## Changes

- Add `_cell()` helper to sanitize Markdown table cell values.
- Escape `|` as `\|`.
- Replace embedded newlines with spaces.
- Apply sanitization to free-text fields used in digest tables.
- Add characterization test covering pipes and newlines.

## Testing

```bash
pytest tests/test_inbox/test_inbox_digest.py