### PR TITLE
fix(routing): migrate groq-free off deprecated llama-3.3-70b → gpt-oss-120b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Changed
+
+- **Free-tier model refresh.** Groq is retiring Llama 3.3 70B (the model behind
+  several of Genesis's free reasoning/extraction/tagging steps) on 2026-08-16, so
+  those steps now use Groq's recommended replacement, gpt-oss-120b. Structured-output
+  and extraction quality are unchanged; triage-depth labeling may shift by about one
+  level on some items. No action needed on your end.
+
 ### Added
 
 - **GitHub activity notifications.** Genesis now watches your active GitHub repos

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -31,12 +31,27 @@ providers:
     rpm_limit: 30
     open_duration_s: 120
   groq-free:
+    # Migrated 2026-08-06: Groq deprecated llama-3.3-70b-versatile (shutdown
+    # 2026-08-16) → openai/gpt-oss-120b, Groq's recommended replacement on the
+    # same free-tier bucket (30 RPM / 1K RPD). Alias name kept deliberately: 32
+    # call-site chains + 8 code refs resolve `groq-free`, so an in-place repoint
+    # migrates all of them with zero churn. Benchmarked vs the llama baseline
+    # (config/eval_datasets): structured_output + extraction parity (100% / 67%),
+    # a mild triage-depth under-bias on classification (exact-match-exaggerated;
+    # reasoning_effort=medium gave no gain, so kept low). gpt-oss-120b is a
+    # reasoning model, but Groq returns reasoning in a separate field — content
+    # stays clean JSON with no suppression param (verified 10/10 structured_output
+    # across param variants). reasoning_effort:low just caps reasoning-token volume
+    # to stay under the free-tier TPM ceiling.
     type: groq
-    model: llama-3.3-70b-versatile
-    profile: llama-3.3-70b
+    model: openai/gpt-oss-120b
+    profile: gpt-oss-120b
     free: true
     rpm_limit: 30
     open_duration_s: 120
+    params:
+      extra_body:
+        reasoning_effort: low
   # GROUNDWORK: gpt-oss-120b — a free reasoning option for reasoning/JSON-heavy
   # chains. Defined + tested (per-provider param plumbing), not yet wired into
   # any chain; wiring is a separate routing-rebalance change.

--- a/docs/eval/benchmark-results.md
+++ b/docs/eval/benchmark-results.md
@@ -1,6 +1,6 @@
 # Model Benchmark Results
 
-Last updated: 2026-04-16
+Last updated: 2026-08-06
 
 Benchmark methodology: 3 datasets (classification, extraction, structured_output)
 with 37 total cases. Scores are `passed/attempted` — skipped cases (rate limits,
@@ -13,7 +13,7 @@ Best run per provider. Providers marked (free) cost $0; others are paid.
 
 | Provider | Classification | Extraction | Structured Output | AVG | Notes |
 |---|---|---|---|---|---|
-| groq-free | 12/15 (80%) | 8/12 (67%) | 10/10 (100%) | **82%** | Llama 4 Scout |
+| groq-free | 8/15 (53%) | 8/12 (67%) | 10/10 (100%) | **73%** | gpt-oss-120b — migrated 2026-08-06 from llama-3.3-70b-versatile (Groq EOL 2026-08-16). JSON/extraction parity; mild triage-depth under-bias on classification (exact-match-exaggerated; reasoning_effort tuning gave no gain). Prior llama baseline: 82% |
 | cerebras-qwen | 9/13 (69%) +2sk | 8/11 (73%) +1sk | 9/9 (100%) +1sk | **81%** | Qwen3 235B, 10 RPM |
 | gemini-free | 6/7 (86%) +8sk | 4/7 (57%) +5sk | 3/3 (100%) +7sk | **81%** | Daily quota (20 req/day) |
 | kimi-k2.5 | 10/15 (67%) | 9/12 (75%) | 10/10 (100%) | **81%** | Paid, $0.60/$2/MTok |

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -224,6 +224,20 @@ def test_load_full_yaml(monkeypatch):
     assert ml.is_free is True
     assert ml.model_id == "mistral-large-latest"
 
+    # groq-free provider — MIGRATED 2026-08-06: Groq deprecated
+    # llama-3.3-70b-versatile (shutdown 2026-08-16) → openai/gpt-oss-120b, its
+    # recommended free-tier replacement. The alias name is kept deliberately so
+    # all 32 call-site chains + 8 code refs resolve the repoint in place.
+    # reasoning_effort=low caps reasoning-token volume under the free-tier TPM
+    # ceiling; no reasoning-suppression param is needed (Groq returns reasoning
+    # in a separate field, so content stays clean JSON — benchmarked 10/10).
+    gf = cfg.providers["groq-free"]
+    assert gf.is_free is True
+    assert gf.provider_type == "groq"
+    assert gf.model_id == "openai/gpt-oss-120b"
+    assert gf.profile == "gpt-oss-120b"
+    assert gf.params == {"extra_body": {"reasoning_effort": "low"}}
+
 
 def test_retry_profiles_under_watchdog_threshold():
     """Every shipped retry profile must set max_total_s BELOW the watchdog's 900s


### PR DESCRIPTION
## Why

Groq is retiring `llama-3.3-70b-versatile` on **2026-08-16**. It backs the `groq-free`
provider, which is the primary/fallback hop in **32 routing chains** (reflection,
morning report, fact extraction, tagging, procedure extraction, CRAG grading, …) and is
referenced by name in 8 code defaults. Without migration those hops start failing on the
shutdown date.

## What

Repoint the `groq-free` provider **in place** to `openai/gpt-oss-120b` — Groq's recommended
replacement on the same free-tier bucket (30 RPM / 1K RPD). The alias name is kept
deliberately: every chain and code reference resolves `groq-free`, so an in-place repoint
migrates all consumers with **zero churn** (versus 32+ edits to rename).

`gpt-oss-120b` is a reasoning model; `params.extra_body.reasoning_effort: low` caps
reasoning-token volume under the free-tier TPM ceiling. No reasoning-suppression param is
needed — Groq returns reasoning in a separate field, so `content` stays clean JSON (verified
10/10 on structured output).

## Model chosen empirically, not from the vendor table

Ran the eval harness (`genesis eval benchmark`) against the golden datasets, current
baseline vs candidates:

| dataset | llama-3.3-70b (current) | gpt-oss-120b | gemini-3.5-flash |
|---|---|---|---|
| classification | 12/15 (80%) | 8/15 (53%) | rate-limited (saturated) |
| extraction | 8/12 (67%) | 8/12 (67%) | rate-limited |
| structured_output | 10/10 (100%) | 10/10 (100%) | rate-limited |

gpt-oss-120b ties on extraction and structured output. The classification gap is a
systematic ~1-level under-rating on an ordinal 0–4 triage-depth scale, exaggerated by the
exact-match scorer; `reasoning_effort=medium` did not improve it. `gemini-3.5-flash` was
ruled out — its free tier is already saturated. gpt-oss-120b is the best available free
option.

## Tests

- Regression test pins `groq-free` → `openai/gpt-oss-120b` with `reasoning_effort: low`
  (verified failing against the pre-migration config).
- `tests/test_routing/` suite: 62 passed. Chain-membership and provider-count assertions
  unchanged (alias name preserved; no provider added or removed).

## Follow-ups (tracked separately)

- Consolidate the now-redundant `groq-free` / `groq-oss-120b` aliases (both serve the same
  model; the latter is unwired).
- The classification-heavy chains where `groq-free` is the primary hop are candidates for a
  later throughput/quality rebalance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
