### PR TITLE
fix(memory): incremental byte-offset transcript read + off-loop extraction (WS-1)

### DIFF
--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -507,7 +507,7 @@ async def get_extractable(
     status_ph = ",".join("?" for _ in statuses)
     cursor = await db.execute(
         f"SELECT id, cc_session_id, source_tag, last_extracted_at, "
-        f"       last_extracted_line, started_at "
+        f"       last_extracted_line, last_extracted_byte, started_at "
         f"FROM cc_sessions "
         f"WHERE source_tag IN ({tag_ph}) "
         f"  AND status IN ({status_ph}) "
@@ -524,12 +524,26 @@ async def update_extraction_watermark(
     *,
     last_extracted_line: int,
     last_extracted_at: str,
+    last_extracted_byte: int | None = None,
 ) -> bool:
-    """Update the extraction watermark for a session."""
-    cursor = await db.execute(
-        "UPDATE cc_sessions SET last_extracted_at = ?, last_extracted_line = ? WHERE id = ?",
-        (last_extracted_at, last_extracted_line, id),
-    )
+    """Update the extraction watermark for a session.
+
+    ``last_extracted_byte`` is the incremental-resume hint (byte offset of the
+    START of line ``last_extracted_line``). When None the column is left
+    untouched, preserving any prior value — callers that computed a byte offset
+    pass it; legacy/reference paths omit it.
+    """
+    if last_extracted_byte is None:
+        cursor = await db.execute(
+            "UPDATE cc_sessions SET last_extracted_at = ?, last_extracted_line = ? WHERE id = ?",
+            (last_extracted_at, last_extracted_line, id),
+        )
+    else:
+        cursor = await db.execute(
+            "UPDATE cc_sessions SET last_extracted_at = ?, last_extracted_line = ?, "
+            "last_extracted_byte = ? WHERE id = ?",
+            (last_extracted_at, last_extracted_line, last_extracted_byte, id),
+        )
     await db.commit()
     return cursor.rowcount > 0
 

--- a/src/genesis/db/migrations/0080_cc_sessions_extracted_byte.py
+++ b/src/genesis/db/migrations/0080_cc_sessions_extracted_byte.py
@@ -1,0 +1,56 @@
+"""Add ``cc_sessions.last_extracted_byte`` — incremental transcript-read resume.
+
+The memory-extraction cycle re-read every extractable transcript from byte 0
+each pass (only the PARSE was skipped below the line watermark), synchronously
+on the event loop — a periodic multi-second block that starved recall (503s).
+This column stores the byte offset of the START of line ``last_extracted_line``
+so the reader can ``seek()`` and read only the delta.
+
+Nullable, NO default: NULL = "never computed" → the reader falls back to a full
+scan from byte 0 once, then populates it. No backfill — existing rows self-heal
+on their next extraction cycle. Load-bearing INVARIANT (enforced by the reader +
+extraction tests): if ``last_extracted_byte IS NOT NULL`` it is the byte start of
+line ``last_extracted_line``; any inconsistency degrades to a one-cycle legacy
+scan, never a content error.
+
+Self-contained + idempotent: the ADD is PRAGMA-guarded (applies via the base
+path in ``_migrations.py::_migrate_add_columns`` OR this standalone numbered
+runner; whichever ran first, the guard skips). No commit — the runner owns the
+transaction.
+
+(Numbered 0080: 0078 is the highest present on disk; 0079 is claimed by the
+in-flight MW-1 PR. The runner applies by per-id tracking and only duplicate
+prefixes are fatal.)
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def _add_column(db: aiosqlite.Connection, table: str, col: str, decl: str) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    )
+    if not await cursor.fetchone():
+        return  # fresh DB — CREATE TABLE / base-path ALTER already carries the column
+    cursor = await db.execute(f"PRAGMA table_info({table})")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if col not in cols:
+        await db.execute(f"ALTER TABLE {table} ADD COLUMN {col} {decl}")
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await _add_column(db, "cc_sessions", "last_extracted_byte", "INTEGER")
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='cc_sessions'"
+    )
+    if not await cursor.fetchone():
+        return
+    cursor = await db.execute("PRAGMA table_info(cc_sessions)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "last_extracted_byte" in cols:
+        await db.execute("ALTER TABLE cc_sessions DROP COLUMN last_extracted_byte")

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -863,6 +863,12 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
     await _try_alter(db,
         "ALTER TABLE cc_sessions ADD COLUMN last_extracted_line INTEGER DEFAULT 0",
         "cc_sessions.last_extracted_line")
+    # Incremental transcript resume: byte offset of the START of line
+    # last_extracted_line. NULLable, NO default — NULL means "never computed"
+    # → the reader falls back to a full scan from byte 0 once, then populates.
+    await _try_alter(db,
+        "ALTER TABLE cc_sessions ADD COLUMN last_extracted_byte INTEGER",
+        "cc_sessions.last_extracted_byte")
 
     # Memory photographic: expand memory_links CHECK constraint to support
     # typed relationships from conversation extraction (discussed_in,

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -22,6 +22,7 @@ enforces this so a new session type can never silently fall out of extraction
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -45,7 +46,7 @@ from genesis.memory.source_verification import compute_jaccard, verify_source_ov
 from genesis.util.jsonl import (
     chunk_messages,
     format_chunk_for_extraction,
-    read_transcript_messages,
+    read_transcript_delta,
 )
 
 if TYPE_CHECKING:
@@ -239,26 +240,63 @@ async def run_extraction_cycle(
             last_line = start_line_override
         else:
             last_line = session.get("last_extracted_line") or 0
-        transcript_path = _find_transcript(transcript_dir, cc_session_id)
+        # Incremental resume: seek to the stored byte offset (= start of line
+        # last_line) and read only the delta. Disabled for reference-only
+        # mining and start_line_override re-reads, which deliberately re-scan.
+        use_incremental = not reference_only_mode and start_line_override is None
+        start_byte = session.get("last_extracted_byte") if use_incremental else None
+
+        # Filesystem discovery + transcript read run OFF the event loop
+        # (asyncio.to_thread): synchronous transcript I/O here was blocking the
+        # loop for 6-7s per cycle and starving memory-recall (503s). The
+        # incremental read above keeps the offloaded work tiny; the offload is
+        # defense-in-depth for a legitimately-large delta. See follow-up 470cec53.
+        transcript_path = await asyncio.to_thread(
+            _find_transcript, transcript_dir, cc_session_id
+        )
         if not transcript_path and session.get("source_tag") == "voice":
             # Voice sessions keep their transcripts outside the CC projects
             # dir (same CC-JSONL format, written by the voice transcript
             # writer) so the CC resume picker never lists them.
-            transcript_path = _find_transcript(voice_transcript_dir(), cc_session_id)
+            transcript_path = await asyncio.to_thread(
+                _find_transcript, voice_transcript_dir(), cc_session_id
+            )
 
         if not transcript_path:
             continue
 
-        # Read new messages since last extraction
-        messages = read_transcript_messages(
+        # Read new messages since last extraction (incremental + off-loop).
+        delta = await asyncio.to_thread(
+            read_transcript_delta,
             transcript_path,
             start_line=last_line,
+            start_byte=start_byte,
         )
+        messages = delta.messages
         if not messages:
+            # No new user/assistant messages. If the file changed (non-message
+            # lines appended), advance BOTH watermarks so the next cycle
+            # stat-gates instead of re-reading from byte 0. Skip in
+            # reference-only mode (leaves prod extraction state untouched) and
+            # when the stat-gate already confirmed nothing changed.
+            if use_incremental and not delta.unchanged:
+                await _update_watermark(
+                    db, session_id, delta.new_line_count,
+                    last_extracted_byte=delta.new_byte_offset,
+                )
             continue
 
         chunks = chunk_messages(messages, chunk_size=chunk_size)
-        max_line = last_line
+        # On a truncation/rotation reset the delta re-emits absolute line numbers
+        # from 0, so the line base must reset too — otherwise max() below pins
+        # max_line to the stale pre-truncation watermark while last_chunk_end_byte
+        # points into the shrunk file, breaking the byte==line invariant. The
+        # empty-branch above already resets by writing delta.new_line_count.
+        max_line = 0 if delta.truncated_reset else last_line
+        # Byte offset of the start of line `max_line` — the incremental resume
+        # point, kept in lock-step with the line watermark below. None until the
+        # chunk loop sets it (guaranteed: this path only runs with ≥1 message).
+        last_chunk_end_byte: int | None = None
         all_keywords: set[str] = set()
         latest_topic = ""
         session_extraction_count = 0
@@ -272,6 +310,10 @@ async def run_extraction_cycle(
             chunk_start = chunk[0].line_number
             chunk_end = chunk[-1].line_number
             max_line = max(max_line, chunk_end + 1)
+            # end_byte of the last message = byte start of line (chunk_end + 1)
+            # = byte start of line `max_line`. Kept in lock-step so the resume
+            # point survives a cap-break (the last processed chunk sets both).
+            last_chunk_end_byte = chunk[-1].end_byte
 
             result = await _extract_chunk(
                 chunk=chunk,
@@ -539,7 +581,10 @@ async def run_extraction_cycle(
         # production extraction state untouched — the next regular cycle
         # will still pick up the same transcripts for episodic storage.
         if not reference_only_mode:
-            await _update_watermark(db, session_id, max_line)
+            await _update_watermark(
+                db, session_id, max_line,
+                last_extracted_byte=last_chunk_end_byte,
+            )
             if all_keywords or latest_topic:
                 await _update_session_index(
                     db, session_id,
@@ -553,8 +598,6 @@ async def run_extraction_cycle(
             # threshold OR the chunk path flagged candidates. Returns 0..N
             # topic-segmented playbooks.
             try:
-                import asyncio
-
                 from genesis.learning.procedural.struggle_detector import (
                     STRUGGLE_THRESHOLD,
                     build_spine_and_haystack,
@@ -697,7 +740,6 @@ async def _drain_procedure_rebuilds(
     attempts exhausted → discard, surfacing an observation so the genuine loss is
     visible, never silent.
     """
-    import asyncio
 
     from genesis.db.crud import deferred_work as dw_crud
     from genesis.learning.procedural.judge import (
@@ -872,8 +914,14 @@ async def _update_watermark(
     db: aiosqlite.Connection,
     session_id: str,
     line_number: int,
+    *,
+    last_extracted_byte: int | None = None,
 ) -> None:
-    """Update the extraction watermark for a session."""
+    """Update the extraction watermark for a session.
+
+    ``last_extracted_byte`` is the incremental-resume hint (byte offset of the
+    start of line ``line_number``); None leaves the stored byte offset untouched.
+    """
     from genesis.db.crud import cc_sessions as sessions_crud
 
     now_iso = datetime.now(UTC).isoformat()
@@ -881,6 +929,7 @@ async def _update_watermark(
         db, session_id,
         last_extracted_line=line_number,
         last_extracted_at=now_iso,
+        last_extracted_byte=last_extracted_byte,
     )
 
 

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -272,16 +272,21 @@ async def run_extraction_cycle(
             start_line=last_line,
             start_byte=start_byte,
         )
+        if delta.failed:
+            # Transcript I/O error (stat/read). Discard any partial read and
+            # retry cleanly next cycle. NEVER advance or initialize a watermark
+            # on a failed read — empty OR partial: a partial message set committed
+            # here (readline() raising mid-stream after some lines parsed) would
+            # advance past still-unread content on a transient glitch and drop it.
+            continue
         messages = delta.messages
         if not messages:
             # No new user/assistant messages. If the file changed (non-message
             # lines appended), advance BOTH watermarks so the next cycle
             # stat-gates instead of re-reading from byte 0. Skip in
-            # reference-only mode (leaves prod extraction state untouched),
-            # when the stat-gate already confirmed nothing changed, and when
-            # transcript I/O failed (advancing on a failed read would persist
-            # byte=0 against a nonzero line watermark → whole-file re-read).
-            if use_incremental and not delta.unchanged and not delta.failed:
+            # reference-only mode (leaves prod extraction state untouched) and
+            # when the stat-gate already confirmed nothing changed.
+            if use_incremental and not delta.unchanged:
                 await _update_watermark(
                     db, session_id, delta.new_line_count,
                     last_extracted_byte=delta.new_byte_offset,

--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -277,9 +277,11 @@ async def run_extraction_cycle(
             # No new user/assistant messages. If the file changed (non-message
             # lines appended), advance BOTH watermarks so the next cycle
             # stat-gates instead of re-reading from byte 0. Skip in
-            # reference-only mode (leaves prod extraction state untouched) and
-            # when the stat-gate already confirmed nothing changed.
-            if use_incremental and not delta.unchanged:
+            # reference-only mode (leaves prod extraction state untouched),
+            # when the stat-gate already confirmed nothing changed, and when
+            # transcript I/O failed (advancing on a failed read would persist
+            # byte=0 against a nonzero line watermark → whole-file re-read).
+            if use_incremental and not delta.unchanged and not delta.failed:
                 await _update_watermark(
                     db, session_id, delta.new_line_count,
                     last_extracted_byte=delta.new_byte_offset,

--- a/src/genesis/util/jsonl.py
+++ b/src/genesis/util/jsonl.py
@@ -45,6 +45,7 @@ class TranscriptDelta:
     new_line_count: int
     unchanged: bool = False       # stat-gate hit: file size == start_byte, nothing read
     truncated_reset: bool = False  # stored offset was past EOF → re-read from 0
+    failed: bool = False          # stat()/read() raised — caller MUST NOT advance watermarks
 
 
 def _parse_transcript_line(
@@ -129,6 +130,10 @@ def read_transcript_delta(
       * a partial trailing line (no newline yet — active append) is NOT
         consumed; ``new_byte_offset`` stays at its start so it is read whole
         on a later call.
+      * a ``stat()``/read ``OSError`` → ``failed=True`` (empty result); the
+        caller MUST NOT advance either watermark — persisting the coerced
+        ``byte=0`` against a nonzero line watermark would force a whole-file
+        re-read next cycle.
 
     Opens in BINARY mode: ``stat().st_size`` is directly comparable to the byte
     offset, and splitting on ``b"\\n"`` (0x0A) never tears a multibyte UTF-8
@@ -138,10 +143,15 @@ def read_transcript_delta(
         size = path.stat().st_size
     except OSError:
         logger.warning("Could not stat transcript: %s", path, exc_info=True)
+        # I/O failure — signal it so the caller preserves BOTH watermarks. A
+        # non-failed empty result would let the empty branch persist byte=0
+        # against a nonzero line watermark (invariant violation → whole-file
+        # re-read next cycle).
         return TranscriptDelta(
             messages=[],
             new_byte_offset=start_byte or 0,
             new_line_count=start_line,
+            failed=True,
         )
 
     truncated_reset = False
@@ -169,6 +179,7 @@ def read_transcript_delta(
 
     messages: list[ConversationMessage] = []
     byte_pos = seek_pos
+    read_failed = False
     try:
         with open(path, "rb") as f:
             f.seek(seek_pos)
@@ -194,12 +205,14 @@ def read_transcript_delta(
                     messages.append(msg)
     except OSError:
         logger.warning("Could not read transcript: %s", path, exc_info=True)
+        read_failed = True
 
     return TranscriptDelta(
         messages=messages,
         new_byte_offset=byte_pos,
         new_line_count=line_no,
         truncated_reset=truncated_reset,
+        failed=read_failed,
     )
 
 

--- a/src/genesis/util/jsonl.py
+++ b/src/genesis/util/jsonl.py
@@ -216,7 +216,13 @@ def read_transcript_delta(
                     # Partial trailing line (write in progress) — do not
                     # consume; byte_pos stays at its start.
                     break
-                if max_lines is not None and (line_no - start_line) >= max_lines:
+                # Cap counts from the effective scan base, NOT the stored
+                # watermark: after a truncation/boundary reset `emit_from` is 0
+                # while `start_line` is stale, so `line_no - start_line` would let
+                # a bounded read of a rotated transcript run unbounded. In the
+                # normal seeking case emit_from == start_line, so this is
+                # unchanged there.
+                if max_lines is not None and (line_no - emit_from) >= max_lines:
                     break
                 current_line = line_no
                 byte_pos += len(raw)

--- a/src/genesis/util/jsonl.py
+++ b/src/genesis/util/jsonl.py
@@ -24,6 +24,183 @@ class ConversationMessage:
     line_number: int
     timestamp: str | None = None
     tool_names: list[str] = field(default_factory=list)
+    # Byte offset of the START of the NEXT line (i.e. one-past this message's
+    # line).  Populated only by ``read_transcript_delta`` (byte-aware); left
+    # None by the text-mode ``read_transcript_messages``.
+    end_byte: int | None = None
+
+
+@dataclass
+class TranscriptDelta:
+    """Result of an incremental (byte-offset-resumed) transcript read.
+
+    INVARIANT: ``new_byte_offset`` is the byte position of the START of line
+    ``new_line_count``.  Passing them back as ``(start_line, start_byte)`` on a
+    later call resumes exactly where this read stopped, with ABSOLUTE line
+    numbers preserved.
+    """
+
+    messages: list[ConversationMessage]
+    new_byte_offset: int
+    new_line_count: int
+    unchanged: bool = False       # stat-gate hit: file size == start_byte, nothing read
+    truncated_reset: bool = False  # stored offset was past EOF → re-read from 0
+
+
+def _parse_transcript_line(
+    raw_line: str, line_num: int
+) -> ConversationMessage | None:
+    """Parse one JSONL entry into a ConversationMessage, or None.
+
+    Returns None for tool_result/thinking/metadata entries and for
+    user/assistant entries with no textual content.  Extracted from
+    ``read_transcript_messages`` so both the text-mode and byte-mode readers
+    share one parse contract.
+    """
+    try:
+        obj = json.loads(raw_line)
+    except json.JSONDecodeError:
+        return None
+
+    entry_type = obj.get("type")
+    if entry_type not in ("user", "assistant"):
+        return None
+
+    msg = obj.get("message", {})
+    content = msg.get("content", "")
+    timestamp = obj.get("timestamp")
+
+    if isinstance(content, str) and content.strip():
+        # User text message
+        return ConversationMessage(
+            role="user",
+            text=content.strip(),
+            line_number=line_num,
+            timestamp=timestamp,
+        )
+
+    if isinstance(content, list):
+        # Assistant response with typed blocks
+        text_parts: list[str] = []
+        tool_names: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type == "text":
+                text = block.get("text", "").strip()
+                if text:
+                    text_parts.append(text)
+            elif block_type == "tool_use":
+                # Keep tool name, skip payload
+                tool_names.append(block.get("name", "unknown_tool"))
+            # Skip: tool_result, thinking, other block types
+        if text_parts:
+            return ConversationMessage(
+                role=entry_type,
+                text="\n\n".join(text_parts),
+                line_number=line_num,
+                timestamp=timestamp,
+                tool_names=tool_names,
+            )
+
+    return None
+
+
+def read_transcript_delta(
+    path: Path,
+    *,
+    start_line: int = 0,
+    start_byte: int | None = None,
+    max_lines: int | None = None,
+) -> TranscriptDelta:
+    """Incrementally read a CC JSONL transcript, resuming from a byte offset.
+
+    When ``start_byte`` is not None it is treated as the byte position of the
+    start of line ``start_line`` (the INVARIANT above): the reader ``seek()``s
+    there and reads only the delta.  When ``start_byte`` is None the reader
+    falls back to a full scan from byte 0 (legacy behaviour), emitting only
+    messages at ``line_number >= start_line`` but still tracking true byte
+    offsets so the caller can persist a resume point.
+
+    Safety:
+      * file size == ``start_byte``  → ``unchanged=True`` (stat-gate, no open).
+      * file size <  ``start_byte``  → ``truncated_reset=True``, re-read from 0.
+      * a partial trailing line (no newline yet — active append) is NOT
+        consumed; ``new_byte_offset`` stays at its start so it is read whole
+        on a later call.
+
+    Opens in BINARY mode: ``stat().st_size`` is directly comparable to the byte
+    offset, and splitting on ``b"\\n"`` (0x0A) never tears a multibyte UTF-8
+    sequence.
+    """
+    try:
+        size = path.stat().st_size
+    except OSError:
+        logger.warning("Could not stat transcript: %s", path, exc_info=True)
+        return TranscriptDelta(
+            messages=[],
+            new_byte_offset=start_byte or 0,
+            new_line_count=start_line,
+        )
+
+    truncated_reset = False
+    if start_byte is not None:
+        if size == start_byte:
+            # Nothing appended since last read — the cheap stat-gate.
+            return TranscriptDelta(
+                messages=[],
+                new_byte_offset=start_byte,
+                new_line_count=start_line,
+                unchanged=True,
+            )
+        if size < start_byte:
+            # Transcript truncated/rotated — the stored offset is invalid.
+            truncated_reset = True
+            start_byte = None
+
+    seeking = start_byte is not None
+    seek_pos = start_byte if seeking else 0
+    # When seeking, the line AT seek_pos IS line `start_line`.  When scanning
+    # from 0 (legacy / reset), line numbers count from 0 and we emit only
+    # those >= start_line (0 after a reset).
+    emit_from = 0 if truncated_reset else start_line
+    line_no = start_line if seeking else 0
+
+    messages: list[ConversationMessage] = []
+    byte_pos = seek_pos
+    try:
+        with open(path, "rb") as f:
+            f.seek(seek_pos)
+            while True:
+                raw = f.readline()
+                if not raw:
+                    break  # EOF
+                if not raw.endswith(b"\n"):
+                    # Partial trailing line (write in progress) — do not
+                    # consume; byte_pos stays at its start.
+                    break
+                if max_lines is not None and (line_no - start_line) >= max_lines:
+                    break
+                current_line = line_no
+                byte_pos += len(raw)
+                line_no += 1
+                if current_line < emit_from:
+                    continue
+                text_line = raw.decode("utf-8", errors="replace")
+                msg = _parse_transcript_line(text_line, current_line)
+                if msg is not None:
+                    msg.end_byte = byte_pos
+                    messages.append(msg)
+    except OSError:
+        logger.warning("Could not read transcript: %s", path, exc_info=True)
+
+    return TranscriptDelta(
+        messages=messages,
+        new_byte_offset=byte_pos,
+        new_line_count=line_no,
+        truncated_reset=truncated_reset,
+    )
 
 
 def read_transcript_messages(

--- a/src/genesis/util/jsonl.py
+++ b/src/genesis/util/jsonl.py
@@ -127,6 +127,9 @@ def read_transcript_delta(
     Safety:
       * file size == ``start_byte``  → ``unchanged=True`` (stat-gate, no open).
       * file size <  ``start_byte``  → ``truncated_reset=True``, re-read from 0.
+      * file size >  ``start_byte`` but ``byte[start_byte-1]`` is NOT a newline
+        (file rewritten/replaced at a same-or-larger size) → ``truncated_reset``,
+        full scan from 0 — never seek mid-line and silently skip content.
       * a partial trailing line (no newline yet — active append) is NOT
         consumed; ``new_byte_offset`` stays at its start so it is read whole
         on a later call.
@@ -157,7 +160,13 @@ def read_transcript_delta(
     truncated_reset = False
     if start_byte is not None:
         if size == start_byte:
-            # Nothing appended since last read — the cheap stat-gate.
+            # Nothing appended since last read — the cheap stat-gate. This
+            # assumes the file is APPEND-ONLY (CC session transcripts are
+            # UUID-named and only grow): a same-size in-place REPLACEMENT would
+            # be missed here, but that cannot occur for these files, and
+            # detecting it would require persisting file identity (inode/mtime).
+            # The size>offset path below still validates the stored offset is a
+            # real line boundary, so a reshaped larger file self-heals.
             return TranscriptDelta(
                 messages=[],
                 new_byte_offset=start_byte,
@@ -182,6 +191,22 @@ def read_transcript_delta(
     read_failed = False
     try:
         with open(path, "rb") as f:
+            if seeking and seek_pos > 0:
+                # Validate the stored offset is still a line boundary. CC session
+                # transcripts are append-only, so the byte immediately before
+                # seek_pos MUST be a newline. If it is not, the file was rewritten
+                # or replaced under a same-or-larger size (which the size check
+                # above cannot detect), and seeking would land mid-line and
+                # silently skip content. Degrade to a full scan from byte 0 (same
+                # as truncation) so the read self-heals instead of corrupting.
+                f.seek(seek_pos - 1)
+                if f.read(1) != b"\n":
+                    seeking = False
+                    seek_pos = 0
+                    emit_from = 0
+                    line_no = 0
+                    byte_pos = 0
+                    truncated_reset = True
             f.seek(seek_pos)
             while True:
                 raw = f.readline()

--- a/tests/test_db/test_migration_0080_cc_sessions_extracted_byte.py
+++ b/tests/test_db/test_migration_0080_cc_sessions_extracted_byte.py
@@ -1,0 +1,79 @@
+"""Migration 0080: last_extracted_byte on cc_sessions (incremental transcript resume)."""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+m0080 = importlib.import_module("genesis.db.migrations.0080_cc_sessions_extracted_byte")
+
+
+async def _legacy_db() -> aiosqlite.Connection:
+    """Pre-0080 cc_sessions shape (has last_extracted_line, no byte offset)."""
+    db = await aiosqlite.connect(":memory:")
+    await db.execute(
+        """CREATE TABLE cc_sessions (
+            id TEXT PRIMARY KEY, session_type TEXT NOT NULL, model TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'active', started_at TEXT NOT NULL,
+            last_activity_at TEXT NOT NULL, source_tag TEXT NOT NULL DEFAULT 'foreground',
+            last_extracted_at TEXT, last_extracted_line INTEGER DEFAULT 0
+        )"""
+    )
+    await db.commit()
+    return db
+
+
+async def _cols(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table})")  # noqa: S608
+    return {row[1] for row in await cur.fetchall()}
+
+
+@pytest.mark.asyncio
+async def test_up_adds_column():
+    db = await _legacy_db()
+    try:
+        await m0080.up(db)
+        assert "last_extracted_byte" in await _cols(db, "cc_sessions")
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_up_is_idempotent():
+    db = await _legacy_db()
+    try:
+        await m0080.up(db)
+        await m0080.up(db)  # duplicate ADD must not raise
+        assert "last_extracted_byte" in await _cols(db, "cc_sessions")
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_existing_rows_read_null():
+    db = await _legacy_db()
+    try:
+        await db.execute(
+            "INSERT INTO cc_sessions (id, session_type, model, started_at, "
+            "last_activity_at, last_extracted_line) "
+            "VALUES ('s1', 'foreground', 'sonnet', '2026-01-01', '2026-01-01', 500)"
+        )
+        await m0080.up(db)
+        cur = await db.execute("SELECT last_extracted_byte FROM cc_sessions WHERE id='s1'")
+        row = await cur.fetchone()
+        assert row[0] is None  # NULL = never computed → legacy scan + populate
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_down_drops_column():
+    db = await _legacy_db()
+    try:
+        await m0080.up(db)
+        await m0080.down(db)
+        assert "last_extracted_byte" not in await _cols(db, "cc_sessions")
+    finally:
+        await db.close()

--- a/tests/test_memory/test_extraction_offload.py
+++ b/tests/test_memory/test_extraction_offload.py
@@ -21,7 +21,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from genesis.db.crud import cc_sessions
-from genesis.util.jsonl import TranscriptDelta
+from genesis.util.jsonl import ConversationMessage, TranscriptDelta
 
 
 def _user(text: str) -> str:
@@ -346,3 +346,68 @@ async def test_io_failure_does_not_advance_watermark(db, tmp_path, monkeypatch):
     row = await cc_sessions.get_by_id(db, "sess-iofail")
     assert row["last_extracted_line"] == 5  # line watermark unchanged
     assert row["last_extracted_byte"] is None  # byte watermark NOT advanced to 0
+
+
+@pytest.mark.asyncio
+async def test_partial_read_failure_does_not_advance_or_extract(db, tmp_path, monkeypatch):
+    """A mid-stream read failure that already parsed SOME messages must NOT advance
+    the watermark OR extract the partial set (the has-messages path honors
+    ``delta.failed`` too).
+
+    ``read_transcript_delta`` returns the messages parsed before an ``OSError`` with
+    ``failed=True``. Committing that partial chunk would advance the watermark past
+    still-unread content on a transient glitch and drop it; the cycle must discard it
+    and retry cleanly next pass.
+    """
+    from genesis.memory import extraction_job
+    from genesis.memory.extraction import Extraction
+
+    await _mk_session(db, "sess-partial")
+    await cc_sessions.update_extraction_watermark(
+        db,
+        "sess-partial",
+        last_extracted_line=2,
+        last_extracted_at="2026-08-07T00:00:00",
+        last_extracted_byte=100,
+    )
+
+    def partial_failed(_path, *, start_line=0, start_byte=None, max_lines=None):
+        msg = ConversationMessage(
+            role="user", text="parsed before the error", line_number=start_line, timestamp=None
+        )
+        msg.end_byte = 150
+        return TranscriptDelta(
+            messages=[msg],
+            new_byte_offset=150,
+            new_line_count=start_line + 1,
+            failed=True,
+        )
+
+    extract_calls: list[dict] = []
+
+    async def spy_extract(**kwargs):
+        extract_calls.append(kwargs)
+        return SimpleNamespace(
+            extractions=[Extraction(content="x", extraction_type="entity", confidence=0.9)],
+            session_keywords=[],
+            session_topic="",
+            parse_error=None,
+        )
+
+    monkeypatch.setattr(
+        extraction_job, "_find_transcript", lambda *_a, **_k: tmp_path / "sess-partial.jsonl"
+    )
+    monkeypatch.setattr(extraction_job, "read_transcript_delta", partial_failed)
+    monkeypatch.setattr(extraction_job, "_extract_chunk", spy_extract)
+
+    await extraction_job.run_extraction_cycle(
+        db=db,
+        store=AsyncMock(),
+        router=AsyncMock(),
+        transcript_dir=tmp_path,
+    )
+
+    row = await cc_sessions.get_by_id(db, "sess-partial")
+    assert row["last_extracted_line"] == 2  # unchanged
+    assert row["last_extracted_byte"] == 100  # NOT advanced to 150
+    assert extract_calls == []  # partial set discarded, never extracted

--- a/tests/test_memory/test_extraction_offload.py
+++ b/tests/test_memory/test_extraction_offload.py
@@ -293,3 +293,56 @@ async def test_cap_break_writes_watermark_at_last_processed_chunk(
     # watermark reflects the LAST processed chunk (chunk 0 → line 1), byte in step
     assert row["last_extracted_line"] == 1
     assert row["last_extracted_byte"] == line0_end
+
+
+# --------------------------------------------------------------------------- #
+# transcript I/O failure — BOTH watermarks preserved (never advanced/initialized)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_io_failure_does_not_advance_watermark(db, tmp_path, monkeypatch):
+    """A failed transcript read leaves BOTH watermarks untouched.
+
+    Regression guard for the empty-branch write on a freshly-migrated session
+    (line watermark set, byte watermark NULL): a ``failed=True`` delta must NOT
+    persist ``byte=0`` against the nonzero line watermark — doing so violates the
+    invariant and makes the next cycle seek byte 0 while numbering from the old
+    line, re-reading the ENTIRE transcript (the multi-second loop-block this PR
+    exists to remove).
+    """
+    from genesis.memory import extraction_job
+
+    await _mk_session(db, "sess-iofail")
+    # Migrated state: line watermark advanced, byte watermark still NULL.
+    await cc_sessions.update_extraction_watermark(
+        db, "sess-iofail", last_extracted_line=5, last_extracted_at="2026-08-07T00:00:00"
+    )
+    pre = await cc_sessions.get_by_id(db, "sess-iofail")
+    assert pre["last_extracted_line"] == 5
+    assert pre["last_extracted_byte"] is None  # the state the bug corrupts
+
+    def failed_delta(_path, *, start_line=0, start_byte=None, max_lines=None):
+        # what read_transcript_delta returns on a stat()/read() OSError
+        return TranscriptDelta(
+            messages=[],
+            new_byte_offset=start_byte or 0,
+            new_line_count=start_line,
+            failed=True,
+        )
+
+    monkeypatch.setattr(
+        extraction_job, "_find_transcript", lambda *_a, **_k: tmp_path / "sess-iofail.jsonl"
+    )
+    monkeypatch.setattr(extraction_job, "read_transcript_delta", failed_delta)
+
+    await extraction_job.run_extraction_cycle(
+        db=db,
+        store=AsyncMock(),
+        router=AsyncMock(),
+        transcript_dir=tmp_path,
+    )
+
+    row = await cc_sessions.get_by_id(db, "sess-iofail")
+    assert row["last_extracted_line"] == 5  # line watermark unchanged
+    assert row["last_extracted_byte"] is None  # byte watermark NOT advanced to 0

--- a/tests/test_memory/test_extraction_offload.py
+++ b/tests/test_memory/test_extraction_offload.py
@@ -1,0 +1,295 @@
+"""Incremental + off-loop transcript reading in run_extraction_cycle.
+
+Covers the follow-up 470cec53 fix:
+  * the transcript filesystem reads run OFF the event-loop thread
+    (asyncio.to_thread), so a slow read never starves memory-recall;
+  * the byte-offset watermark is written in lock-step with the line watermark
+    (the INVARIANT: last_extracted_byte == byte start of line last_extracted_line)
+    on BOTH the has-messages path and the empty-but-changed path;
+  * a caught-up session stat-gates on the next cycle (no re-read, watermark stable).
+
+Real-DB tests avoid AsyncMock fragility with the pre-loop procedure-rebuild drain.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.db.crud import cc_sessions
+from genesis.util.jsonl import TranscriptDelta
+
+
+def _user(text: str) -> str:
+    return json.dumps({"type": "user", "message": {"content": text}}, ensure_ascii=False)
+
+
+def _asst(text: str) -> str:
+    return json.dumps(
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}},
+        ensure_ascii=False,
+    )
+
+
+def _summary() -> str:
+    return json.dumps({"type": "summary", "summary": "meta"})
+
+
+def _write_transcript(tmp_path, name: str, lines: list[str]):
+    p = tmp_path / f"{name}.jsonl"
+    p.write_bytes(("\n".join(lines) + "\n").encode("utf-8"))
+    return p
+
+
+async def _mk_session(db, sid: str) -> None:
+    await cc_sessions.create(
+        db,
+        id=sid,
+        session_type="foreground",
+        model="sonnet",
+        started_at="2026-08-07T00:00:00",
+        last_activity_at="2026-08-07T00:00:00",
+        source_tag="foreground",
+        status="active",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# off-loop: both _find_transcript and read_transcript_delta run in a worker
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_transcript_reads_run_off_the_event_loop(db, tmp_path, monkeypatch):
+    from genesis.memory import extraction_job
+
+    await _mk_session(db, "sess-off")
+    loop_thread = threading.get_ident()
+    seen: dict[str, int] = {}
+
+    def spy_find(_dir, _cc_id):
+        seen["find"] = threading.get_ident()
+        return tmp_path / "sess-off.jsonl"
+
+    def spy_delta(_path, *, start_line=0, start_byte=None, max_lines=None):
+        seen["delta"] = threading.get_ident()
+        # nothing new — empty + unchanged so the cycle short-circuits
+        return TranscriptDelta(
+            messages=[],
+            new_byte_offset=start_byte or 0,
+            new_line_count=start_line,
+            unchanged=True,
+        )
+
+    monkeypatch.setattr(extraction_job, "_find_transcript", spy_find)
+    monkeypatch.setattr(extraction_job, "read_transcript_delta", spy_delta)
+
+    await extraction_job.run_extraction_cycle(
+        db=db,
+        store=AsyncMock(),
+        router=AsyncMock(),
+        transcript_dir=tmp_path,
+    )
+
+    assert seen.get("find") is not None, "_find_transcript never ran"
+    assert seen.get("delta") is not None, "read_transcript_delta never ran"
+    assert seen["find"] != loop_thread, "_find_transcript ran on the event-loop thread"
+    assert seen["delta"] != loop_thread, "read_transcript_delta ran on the event-loop thread"
+
+
+# --------------------------------------------------------------------------- #
+# empty-but-changed path — dual-write invariant + next-cycle stat-gate
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_empty_change_advances_both_watermarks_then_stat_gates(db, tmp_path):
+    from genesis.memory import extraction_job
+
+    await _mk_session(db, "sess-empty")
+    # three NON-message lines — read, but yield zero ConversationMessages
+    p = _write_transcript(tmp_path, "sess-empty", [_summary(), _summary(), _summary()])
+    size = p.stat().st_size
+
+    await extraction_job.run_extraction_cycle(
+        db=db,
+        store=AsyncMock(),
+        router=AsyncMock(),
+        transcript_dir=tmp_path,
+    )
+
+    row = await cc_sessions.get_by_id(db, "sess-empty")
+    # INVARIANT: byte offset == start of line `new_line_count` (== EOF here)
+    assert row["last_extracted_line"] == 3
+    assert row["last_extracted_byte"] == size
+
+    # second cycle: size == stored byte → stat-gate → watermark unchanged
+    await extraction_job.run_extraction_cycle(
+        db=db,
+        store=AsyncMock(),
+        router=AsyncMock(),
+        transcript_dir=tmp_path,
+    )
+    row2 = await cc_sessions.get_by_id(db, "sess-empty")
+    assert row2["last_extracted_line"] == 3
+    assert row2["last_extracted_byte"] == size
+
+
+# --------------------------------------------------------------------------- #
+# has-messages path — byte watermark tracks the line watermark (max_line)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_messages_path_writes_byte_in_lockstep_with_line(db, tmp_path, monkeypatch):
+    from genesis.memory import extraction_job
+
+    await _mk_session(db, "sess-msg")
+    # 3 message lines → chunk_end line 2 → max_line 3; byte == EOF (start of line 3)
+    p = _write_transcript(tmp_path, "sess-msg", [_user("a"), _asst("b"), _user("c")])
+    size = p.stat().st_size
+
+    # bypass the LLM: process chunks (advancing max_line + last_chunk_end_byte)
+    # but store nothing, so no store/router/downstream complexity.
+    async def fake_extract(**_kwargs):
+        return SimpleNamespace(
+            extractions=[],
+            session_keywords=[],
+            session_topic="",
+            parse_error=None,
+        )
+
+    monkeypatch.setattr(extraction_job, "_extract_chunk", fake_extract)
+
+    await extraction_job.run_extraction_cycle(
+        db=db,
+        store=AsyncMock(),
+        router=AsyncMock(),
+        transcript_dir=tmp_path,
+    )
+
+    row = await cc_sessions.get_by_id(db, "sess-msg")
+    assert row["last_extracted_line"] == 3
+    assert row["last_extracted_byte"] == size  # start of line 3, in lock-step
+
+    # resume: no growth → stat-gate, watermark stable (proves the offset resumes)
+    await extraction_job.run_extraction_cycle(
+        db=db,
+        store=AsyncMock(),
+        router=AsyncMock(),
+        transcript_dir=tmp_path,
+    )
+    row2 = await cc_sessions.get_by_id(db, "sess-msg")
+    assert row2["last_extracted_byte"] == size
+
+
+# --------------------------------------------------------------------------- #
+# truncation/rotation WITH new content — line watermark must RESET in lock-step
+# (regression guard for the has-messages-path max() staleness bug)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_truncation_with_new_content_resets_line_watermark(
+    db,
+    tmp_path,
+    monkeypatch,
+):
+    from genesis.memory import extraction_job
+
+    await _mk_session(db, "sess-trunc")
+
+    async def fake_extract(**_kwargs):
+        return SimpleNamespace(
+            extractions=[],
+            session_keywords=[],
+            session_topic="",
+            parse_error=None,
+        )
+
+    monkeypatch.setattr(extraction_job, "_extract_chunk", fake_extract)
+
+    # cycle 1: a longer transcript (4 message lines) → watermark line=4, byte=size1
+    _write_transcript(
+        tmp_path,
+        "sess-trunc",
+        [_user("a"), _asst("b"), _user("c"), _asst("d")],
+    )
+    await extraction_job.run_extraction_cycle(
+        db=db,
+        store=AsyncMock(),
+        router=AsyncMock(),
+        transcript_dir=tmp_path,
+    )
+    assert (await cc_sessions.get_by_id(db, "sess-trunc"))["last_extracted_line"] == 4
+
+    # cycle 2: transcript ROTATED to a SHORTER file with NEW content (2 lines).
+    # size2 < stored byte → read_transcript_delta resets to a from-0 scan and
+    # re-emits absolute line numbers starting at 0.
+    p2 = _write_transcript(tmp_path, "sess-trunc", [_user("x"), _asst("y")])
+    size2 = p2.stat().st_size
+    await extraction_job.run_extraction_cycle(
+        db=db,
+        store=AsyncMock(),
+        router=AsyncMock(),
+        transcript_dir=tmp_path,
+    )
+
+    row = await cc_sessions.get_by_id(db, "sess-trunc")
+    # INVARIANT: the line watermark must RESET to the new (shrunk) file — not
+    # stay stale at 4 — and the byte must be the start of that line (== EOF).
+    assert row["last_extracted_line"] == 2, "stale line watermark survived truncation"
+    assert row["last_extracted_byte"] == size2
+
+
+# --------------------------------------------------------------------------- #
+# per-session cap break — watermarks stay in lock-step at the last processed
+# chunk (both are set at the top of every chunk iteration, before the break)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_cap_break_writes_watermark_at_last_processed_chunk(
+    db,
+    tmp_path,
+    monkeypatch,
+):
+    from genesis.memory import extraction_job
+    from genesis.memory.extraction import Extraction
+
+    await _mk_session(db, "sess-cap")
+    lines = [_user("m0"), _asst("m1"), _user("m2")]
+    _write_transcript(tmp_path, "sess-cap", lines)
+    # byte offset of the start of line 1 == byte length of line 0 (+ newline)
+    line0_end = len((lines[0] + "\n").encode("utf-8"))
+
+    async def one_extraction(**_kwargs):
+        return SimpleNamespace(
+            extractions=[
+                Extraction(content="fact zero", extraction_type="entity", confidence=0.9),
+            ],
+            session_keywords=[],
+            session_topic="",
+            parse_error=None,
+        )
+
+    monkeypatch.setattr(extraction_job, "_extract_chunk", one_extraction)
+
+    # chunk_size=1 → one chunk per message; cap=1 → break after chunk 0 stores.
+    await extraction_job.run_extraction_cycle(
+        db=db,
+        store=AsyncMock(),
+        router=AsyncMock(),
+        transcript_dir=tmp_path,
+        chunk_size=1,
+        max_extractions_per_session=1,
+    )
+
+    row = await cc_sessions.get_by_id(db, "sess-cap")
+    # watermark reflects the LAST processed chunk (chunk 0 → line 1), byte in step
+    assert row["last_extracted_line"] == 1
+    assert row["last_extracted_byte"] == line0_end

--- a/tests/test_util/test_jsonl_incremental.py
+++ b/tests/test_util/test_jsonl_incremental.py
@@ -285,3 +285,47 @@ def test_io_failure_sets_failed_flag_not_a_stat_gate(tmp_path):
     assert d.failed is True
     assert d.messages == []
     assert d.unchanged is False  # a genuine failure, NOT the stat-gate no-op
+
+
+def test_replaced_file_offset_not_a_line_boundary_resets_to_full_scan(tmp_path):
+    """A same-or-larger REPLACEMENT (not an append) whose stored offset no longer
+    lands on a line boundary must NOT be seeked blindly.
+
+    ``size > start_byte`` alone cannot distinguish an append from a rewrite. If the
+    byte before ``start_byte`` is not a newline, the file was reshaped under us and
+    seeking there would land mid-line and permanently skip content — the reader must
+    fall back to a full scan (``truncated_reset``) instead.
+    """
+    p = tmp_path / "t.jsonl"
+    v1 = [_user("a"), _asst("b")]
+    _write(p, v1)
+    boundary = _line_start_offsets(v1)[1]  # start of line 1 — valid boundary in v1
+
+    # Replace with a DIFFERENT, larger file whose line 0 is long enough that
+    # `boundary` now falls INSIDE its first line (byte[boundary-1] != b"\n").
+    v2 = [_user("x" * (boundary + 50)), _asst("y"), _user("z")]
+    _write(p, v2)
+    assert p.stat().st_size > boundary  # exercises the size>offset seek path
+
+    d = read_transcript_delta(p, start_line=1, start_byte=boundary)
+
+    assert d.truncated_reset is True, "reshaped file was seeked blindly"
+    assert d.failed is False
+    # full re-scan from 0: all three v2 messages, ABSOLUTE line numbers from 0
+    assert [m.line_number for m in d.messages] == [0, 1, 2]
+    assert d.new_line_count == 3
+    assert d.new_byte_offset == p.stat().st_size
+
+
+def test_valid_boundary_append_still_seeks_without_reset(tmp_path):
+    """Control: a genuine append (byte before start_byte IS a newline) still takes
+    the fast seek path — the boundary guard must not false-positive."""
+    p = tmp_path / "t.jsonl"
+    v1 = [_user("a"), _asst("b")]
+    _write(p, v1)
+    first = read_transcript_delta(p, start_line=0, start_byte=None)
+
+    _write(p, v1 + [_user("c")])
+    d = read_transcript_delta(p, start_line=first.new_line_count, start_byte=first.new_byte_offset)
+    assert d.truncated_reset is False
+    assert [m.line_number for m in d.messages] == [2]  # only the appended line

--- a/tests/test_util/test_jsonl_incremental.py
+++ b/tests/test_util/test_jsonl_incremental.py
@@ -1,0 +1,268 @@
+"""Tests for genesis.util.jsonl.read_transcript_delta — incremental byte-offset resume.
+
+The extraction cycle re-reads every extractable transcript from byte 0 each pass;
+``read_transcript_delta`` makes that incremental: seek to a stored byte offset and
+read only the delta.  The load-bearing INVARIANT these tests pin:
+
+    if a returned ``new_byte_offset`` is later passed back as ``start_byte`` with the
+    matching ``start_line``, it is the byte position of the START of line
+    ``new_line_count`` — so a resumed read continues exactly where the prior one
+    stopped, with ABSOLUTE line numbers preserved.
+
+Everything degrades safely: a NULL/absent ``start_byte`` falls back to a full scan
+from byte 0 (legacy behaviour), and a stored offset past EOF resets to 0.
+"""
+
+from __future__ import annotations
+
+import json
+
+from genesis.util.jsonl import (
+    read_transcript_delta,
+    read_transcript_messages,
+)
+
+# --------------------------------------------------------------------------- #
+# fixture helpers — write real CC-format JSONL and compute expected byte offsets
+# --------------------------------------------------------------------------- #
+
+
+def _user(text: str) -> str:
+    return json.dumps({"type": "user", "message": {"content": text}}, ensure_ascii=False)
+
+
+def _asst(text: str) -> str:
+    return json.dumps(
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}},
+        ensure_ascii=False,
+    )
+
+
+def _summary() -> str:
+    # A non-user/assistant entry — read but yields NO ConversationMessage.
+    return json.dumps({"type": "summary", "summary": "meta"})
+
+
+def _write(path, lines: list[str], *, trailing_newline: bool = True) -> None:
+    data = "\n".join(lines)
+    if lines and trailing_newline:
+        data += "\n"
+    path.write_bytes(data.encode("utf-8"))
+
+
+def _line_start_offsets(lines: list[str]) -> list[int]:
+    """offs[i] = byte offset of the start of line i; offs[len(lines)] = EOF."""
+    offs = [0]
+    for ln in lines:
+        offs.append(offs[-1] + len((ln + "\n").encode("utf-8")))
+    return offs
+
+
+# --------------------------------------------------------------------------- #
+# first read (start_byte=None) — full scan, reports offsets
+# --------------------------------------------------------------------------- #
+
+
+def test_first_read_scans_from_zero_and_reports_offsets(tmp_path):
+    lines = [_user("a"), _asst("b"), _user("c")]
+    p = tmp_path / "t.jsonl"
+    _write(p, lines)
+    offs = _line_start_offsets(lines)
+
+    d = read_transcript_delta(p, start_line=0, start_byte=None)
+
+    assert [m.line_number for m in d.messages] == [0, 1, 2]
+    assert [m.text for m in d.messages] == ["a", "b", "c"]
+    assert d.new_line_count == 3
+    assert d.new_byte_offset == offs[3]  # EOF
+    assert d.unchanged is False
+    assert d.truncated_reset is False
+    # each message's end_byte == start of the NEXT line
+    assert [m.end_byte for m in d.messages] == [offs[1], offs[2], offs[3]]
+
+
+# --------------------------------------------------------------------------- #
+# THE INVARIANT — new_byte_offset is the byte start of line new_line_count
+# --------------------------------------------------------------------------- #
+
+
+def test_invariant_byte_offset_is_line_start(tmp_path):
+    lines = [_user("x"), _summary(), _asst("y"), _summary(), _user("z")]
+    p = tmp_path / "t.jsonl"
+    _write(p, lines)
+    offs = _line_start_offsets(lines)
+
+    d = read_transcript_delta(p, start_line=0, start_byte=None)
+
+    # independent computation: offset of the start of line `new_line_count`
+    assert d.new_byte_offset == offs[d.new_line_count]
+
+
+# --------------------------------------------------------------------------- #
+# unchanged file — stat-gate returns immediately, no reparse
+# --------------------------------------------------------------------------- #
+
+
+def test_unchanged_file_returns_empty_no_work(tmp_path):
+    lines = [_user("a"), _asst("b"), _user("c")]
+    p = tmp_path / "t.jsonl"
+    _write(p, lines)
+    first = read_transcript_delta(p, start_line=0, start_byte=None)
+
+    second = read_transcript_delta(
+        p, start_line=first.new_line_count, start_byte=first.new_byte_offset
+    )
+
+    assert second.unchanged is True
+    assert second.messages == []
+    assert second.new_byte_offset == first.new_byte_offset
+    assert second.new_line_count == first.new_line_count
+
+
+# --------------------------------------------------------------------------- #
+# grown file — read ONLY the delta, absolute line numbers preserved
+# --------------------------------------------------------------------------- #
+
+
+def test_grown_file_returns_only_new_with_absolute_line_numbers(tmp_path):
+    lines = [_user("a"), _asst("b"), _user("c")]
+    p = tmp_path / "t.jsonl"
+    _write(p, lines)
+    first = read_transcript_delta(p, start_line=0, start_byte=None)
+
+    grown = lines + [_asst("d"), _user("e")]
+    _write(p, grown)
+    offs = _line_start_offsets(grown)
+
+    d = read_transcript_delta(p, start_line=first.new_line_count, start_byte=first.new_byte_offset)
+
+    assert [m.line_number for m in d.messages] == [3, 4]  # ABSOLUTE, not 0/1
+    assert [m.text for m in d.messages] == ["d", "e"]
+    assert d.new_line_count == 5
+    assert d.new_byte_offset == offs[5]
+    assert d.unchanged is False
+
+
+# --------------------------------------------------------------------------- #
+# non-message lines advance the offset but yield no messages
+# (the "empty but changed" case the extraction empty-branch dual-writes on)
+# --------------------------------------------------------------------------- #
+
+
+def test_non_message_lines_advance_offset_yield_no_messages(tmp_path):
+    lines = [_summary(), _summary(), _summary()]
+    p = tmp_path / "t.jsonl"
+    _write(p, lines)
+    offs = _line_start_offsets(lines)
+
+    d = read_transcript_delta(p, start_line=0, start_byte=None)
+
+    assert d.messages == []
+    assert d.unchanged is False  # file WAS read (not stat-gated)
+    assert d.new_line_count == 3
+    assert d.new_byte_offset == offs[3]
+
+
+# --------------------------------------------------------------------------- #
+# truncation / rotation — stored offset past EOF → reset to 0
+# --------------------------------------------------------------------------- #
+
+
+def test_truncation_resets_and_rereads_from_zero(tmp_path):
+    big = [_user("a"), _asst("b"), _user("c"), _asst("d")]
+    p = tmp_path / "t.jsonl"
+    _write(p, big)
+    first = read_transcript_delta(p, start_line=0, start_byte=None)
+
+    # transcript rotated/replaced with a SHORTER file
+    short = [_user("x"), _asst("y")]
+    _write(p, short)
+
+    d = read_transcript_delta(p, start_line=first.new_line_count, start_byte=first.new_byte_offset)
+
+    assert d.truncated_reset is True
+    assert [m.line_number for m in d.messages] == [0, 1]  # re-read from top
+    assert [m.text for m in d.messages] == ["x", "y"]
+
+
+# --------------------------------------------------------------------------- #
+# active append — a partial trailing line (no \n) is NOT consumed
+# --------------------------------------------------------------------------- #
+
+
+def test_partial_trailing_line_not_consumed(tmp_path):
+    complete = [_user("a"), _asst("b")]
+    p = tmp_path / "t.jsonl"
+    # two complete lines + a THIRD partial line mid-write (no trailing newline)
+    _write(p, complete)  # ends with \n
+    offs = _line_start_offsets(complete)
+    with open(p, "ab") as f:
+        f.write(_user("partial-not-terminated").encode("utf-8"))  # no \n
+
+    d = read_transcript_delta(p, start_line=0, start_byte=None)
+
+    assert [m.text for m in d.messages] == ["a", "b"]  # partial excluded
+    assert d.new_line_count == 2
+    assert d.new_byte_offset == offs[2]  # points at START of the partial line
+
+    # complete the partial line, resume from the stored offset → now it reads
+    with open(p, "ab") as f:
+        f.write(b"\n")
+    d2 = read_transcript_delta(p, start_line=d.new_line_count, start_byte=d.new_byte_offset)
+    assert [m.line_number for m in d2.messages] == [2]
+    assert [m.text for m in d2.messages] == ["partial-not-terminated"]
+
+
+# --------------------------------------------------------------------------- #
+# multibyte UTF-8 — byte offsets are byte-accurate, no torn characters
+# --------------------------------------------------------------------------- #
+
+
+def test_multibyte_line_offsets_are_byte_accurate(tmp_path):
+    lines = [_user("café ☕ 日本語"), _asst("plain")]
+    p = tmp_path / "t.jsonl"
+    _write(p, lines)
+    offs = _line_start_offsets(lines)
+
+    d = read_transcript_delta(p, start_line=0, start_byte=None)
+
+    assert d.messages[0].text == "café ☕ 日本語"
+    assert d.messages[0].end_byte == offs[1]  # byte length, not char count
+    assert d.new_byte_offset == offs[2]
+
+
+# --------------------------------------------------------------------------- #
+# legacy fallback — start_byte=None with start_line>0 skips-but-scans
+# (existing rows whose last_extracted_byte is still NULL)
+# --------------------------------------------------------------------------- #
+
+
+def test_legacy_scan_with_start_line_skips_but_tracks_bytes(tmp_path):
+    lines = [_user("a"), _asst("b"), _user("c"), _asst("d"), _user("e")]
+    p = tmp_path / "t.jsonl"
+    _write(p, lines)
+    offs = _line_start_offsets(lines)
+
+    d = read_transcript_delta(p, start_line=3, start_byte=None)
+
+    assert [m.line_number for m in d.messages] == [3, 4]  # only >= start_line
+    assert d.new_line_count == 5
+    assert d.new_byte_offset == offs[5]  # whole file scanned for the offset
+
+
+# --------------------------------------------------------------------------- #
+# parity — the untouched read_transcript_messages still behaves identically
+# --------------------------------------------------------------------------- #
+
+
+def test_read_transcript_messages_parity(tmp_path):
+    lines = [_user("a"), _summary(), _asst("b"), _user("c")]
+    p = tmp_path / "t.jsonl"
+    _write(p, lines)
+
+    old = read_transcript_messages(p, start_line=0)
+    new = read_transcript_delta(p, start_line=0, start_byte=None).messages
+
+    assert [(m.role, m.text, m.line_number) for m in old] == [
+        (m.role, m.text, m.line_number) for m in new
+    ]

--- a/tests/test_util/test_jsonl_incremental.py
+++ b/tests/test_util/test_jsonl_incremental.py
@@ -266,3 +266,22 @@ def test_read_transcript_messages_parity(tmp_path):
     assert [(m.role, m.text, m.line_number) for m in old] == [
         (m.role, m.text, m.line_number) for m in new
     ]
+
+
+def test_io_failure_sets_failed_flag_not_a_stat_gate(tmp_path):
+    """A stat()/read() error returns ``failed=True`` with an empty, NON-``unchanged``
+    delta.
+
+    The empty-result branch in ``run_extraction_cycle`` advances BOTH watermarks
+    whenever ``not unchanged``. Without a distinct failure flag, a transient stat()
+    failure on a freshly-migrated session (``last_extracted_byte`` NULL → ``start_byte``
+    None → ``new_byte_offset`` coerced to 0) paired with a nonzero ``start_line`` would
+    persist byte=0 against that line watermark — the invariant violation that makes the
+    next cycle re-read the ENTIRE transcript from byte 0.
+    """
+    missing = tmp_path / "never_created.jsonl"  # stat() raises FileNotFoundError (OSError)
+    d = read_transcript_delta(missing, start_line=40000, start_byte=None)
+
+    assert d.failed is True
+    assert d.messages == []
+    assert d.unchanged is False  # a genuine failure, NOT the stat-gate no-op

--- a/tests/test_util/test_jsonl_incremental.py
+++ b/tests/test_util/test_jsonl_incremental.py
@@ -329,3 +329,44 @@ def test_valid_boundary_append_still_seeks_without_reset(tmp_path):
     d = read_transcript_delta(p, start_line=first.new_line_count, start_byte=first.new_byte_offset)
     assert d.truncated_reset is False
     assert [m.line_number for m in d.messages] == [2]  # only the appended line
+
+
+def test_max_lines_capped_after_reset(tmp_path):
+    """``max_lines`` bounds lines processed even AFTER a reset.
+
+    After truncation (or a boundary reset) ``line_no`` restarts at 0 while the
+    stored ``start_line`` is stale. Counting from ``emit_from`` (the effective
+    scan base, 0 after a reset) keeps the cap honest; counting from ``start_line``
+    would let a bounded read of a rotated transcript run unbounded.
+    """
+    p = tmp_path / "t.jsonl"
+    v1 = [_user(f"m{i}") for i in range(8)]
+    _write(p, v1)
+    first = read_transcript_delta(p, start_line=0, start_byte=None)
+    assert first.new_line_count == 8  # watermark at line 8
+
+    # rotate to a SHORTER file (size < stored offset) → truncation reset from 0
+    v2 = [_user("x0"), _user("x1"), _user("x2"), _user("x3")]
+    _write(p, v2)
+    d = read_transcript_delta(
+        p, start_line=first.new_line_count, start_byte=first.new_byte_offset, max_lines=2
+    )
+
+    assert d.truncated_reset is True
+    assert len(d.messages) == 2, "max_lines ignored after reset (counted from stale start_line)"
+    assert [m.line_number for m in d.messages] == [0, 1]
+
+
+def test_max_lines_unchanged_on_normal_seek(tmp_path):
+    """Control: on a normal seek (emit_from == start_line) the cap is unchanged."""
+    p = tmp_path / "t.jsonl"
+    base = [_user("a"), _asst("b")]
+    _write(p, base)
+    first = read_transcript_delta(p, start_line=0, start_byte=None)
+
+    _write(p, base + [_user("c"), _asst("d"), _user("e")])
+    d = read_transcript_delta(
+        p, start_line=first.new_line_count, start_byte=first.new_byte_offset, max_lines=2
+    )
+    assert d.truncated_reset is False
+    assert [m.line_number for m in d.messages] == [2, 3]  # exactly 2, from the watermark


### PR DESCRIPTION
## Problem
The memory-extraction cycle re-read every extractable transcript from byte 0 **synchronously on the asyncio event loop** each pass, blocking it 6–7s and starving memory-recall (HTTP 503s). Confirmed by overnight py-spy: 6/6 mega-spike event-loop-lag WARNs caught MainThread on-CPU in `read_transcript_messages`, timestamp-matched to the WARNs.

## Fix
- **`read_transcript_delta`** (`util/jsonl.py`): binary-mode byte-offset resume — `seek()` to a stored offset and read only the delta; stat-gate (skip without opening) when file size == stored offset; reset to a full scan on truncation/rotation.
- **`run_extraction_cycle`**: offloads `_find_transcript` + the read via `asyncio.to_thread`, and persists a new `cc_sessions.last_extracted_byte` watermark **in lock-step** with `last_extracted_line`.
- **Invariant** (test-gated): `last_extracted_byte`, when set, is the byte start of line `last_extracted_line`. NULL → legacy full scan, then self-populates. A truncation reset also resets the line base so the invariant holds on the shrunk file.
- **Schema**: nullable `last_extracted_byte` via migration `0080` + base-path `_try_alter` (dual path); no backfill, idempotent, `down()` present.

`read_transcript_messages` left unchanged (parity-tested). Chronic sub-second lag from infra-snapshot/SSL work on the loop is tracked separately.

## Tests (RED-first)
- `test_jsonl_incremental.py` (10): byte-accurate delta, the invariant, stat-gate, truncation reset, partial-trailing-line, multibyte, legacy fallback, parity.
- `test_extraction_offload.py` (5): off-loop execution (`get_ident`), dual-write invariant on both the messages and empty paths (real-DB persistence), stat-gate on the second cycle, **truncation-with-new-content regression** (seen RED first), **cap-break** lock-step.
- `test_migration_0080_*.py` (4): apply/idempotent/NULL/down.

Local review: 2 rounds (1 blocker — truncation watermark staleness — found, fixed RED→GREEN, confirmed clean). Full collateral ring + ruff green.

Follow-up: 470cec53