### PR TITLE
feat(ego): urgency-based proposal auto-table window (replaces flat 14d)

### DIFF
--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -1036,83 +1036,88 @@ async def get_pending_queue(
 
 async def auto_table_stale_proposals(
     db: aiosqlite.Connection,
-    max_age_days: int = 14,
+    ttl_hours: dict | None = None,
+    *,
+    unranked_cap_hours: int = 120,
 ) -> int:
-    """Auto-table pending proposals older than *max_age_days*.
+    """Auto-table pending proposals older than their per-urgency staleness
+    window, moving them to the recoverable 'tabled' cold lane.
 
-    Also updates corresponding intervention_journal entries to keep
-    them in sync (same pattern as :func:`expire_stale_proposals`).
+    Urgency-based window (config ``auto_table_ttl_hours``), replacing the old
+    flat 14-day threshold: stale genesis investigations lingered 6-9 days below
+    14d and were approved on self-healed signals (2026-08-06 dispatch review).
+    'tabled' is NOT deletion — the ego can un-table, and a still-relevant
+    proposal is re-derived fresh next cycle. Unranked proposals (never put on
+    the board → lower priority) age out faster, capped at
+    ``unranked_cap_hours`` (default 5d, preserving the prior behaviour).
+    Keeps intervention_journal in sync (same pattern as
+    :func:`expire_stale_proposals`).
 
     Returns count of auto-tabled proposals.
     """
-    now = datetime.now(UTC).isoformat()
-    threshold = f"-{max_age_days} days"
+    if ttl_hours is None:
+        try:
+            from genesis.ego.config import load_ego_config
 
-    # Get IDs first so we can update journal too
+            ttl_hours = load_ego_config().auto_table_ttl_hours
+        except Exception:  # config unreadable — fall back to safe defaults
+            ttl_hours = {"critical": 48, "high": 72, "normal": 120, "low": 168}
+
+    now_dt = datetime.now(UTC)
     cursor = await db.execute(
-        "SELECT id FROM ego_proposals WHERE status = 'pending' AND created_at < datetime('now', ?)",
-        (threshold,),
+        "SELECT id, urgency, rank, created_at FROM ego_proposals "
+        "WHERE status = 'pending'"
     )
     rows = await cursor.fetchall()
-    if not rows:
+
+    stale_ids: list[str] = []
+    for r in rows:
+        _id, _urgency, _rank, _created_at = r[0], r[1], r[2], r[3]
+        window_h = ttl_hours.get(_urgency or "normal", ttl_hours.get("normal", 120))
+        # Unranked (never boarded) proposals are lower-priority — cap their
+        # window so they clean up faster (only ever shortens, never extends).
+        if _rank is None:
+            window_h = min(window_h, unranked_cap_hours)
+        try:
+            created = datetime.fromisoformat(_created_at)
+            age_s = (now_dt - created).total_seconds()
+        except (TypeError, ValueError):
+            # Unparseable or tz-naive created_at → skip this row, never abort
+            # the whole sweep.
+            continue
+        if age_s >= window_h * 3600:
+            stale_ids.append(_id)
+
+    if not stale_ids:
         return 0
 
-    ids = [r[0] for r in rows]
-    # Table proposals
-    await db.execute(
-        "UPDATE ego_proposals SET status = 'tabled', rank = NULL, "
-        "resolved_at = ? "
-        "WHERE status = 'pending' AND created_at < datetime('now', ?)",
-        (now, threshold),
+    now = now_dt.isoformat()
+    placeholders = ",".join("?" * len(stale_ids))
+    # Re-check status = 'pending' at write time (TOCTOU guard): a proposal
+    # concurrently approved/executed/withdrawn between the SELECT above and this
+    # UPDATE must NOT be clobbered back to 'tabled'. Mirrors the guard in every
+    # sibling mutator (table_proposal, expire_stale_proposals, ...).
+    result = await db.execute(
+        f"UPDATE ego_proposals SET status = 'tabled', rank = NULL, "
+        f"resolved_at = ? WHERE status = 'pending' AND id IN ({placeholders})",
+        (now, *stale_ids),
     )
-    # Update matching journal entries
-    placeholders = ",".join("?" * len(ids))
+    tabled_count = result.rowcount
+    # Journal sync scoped to proposals ACTUALLY tabled by this call (status +
+    # exact resolved_at), NOT the pre-guard candidate list: a proposal
+    # concurrently resolved between the SELECT and the guarded UPDATE is
+    # excluded above, and must not get its journal flipped to 'tabled' — that
+    # would permanently diverge journal outcome from the true proposal status.
     await db.execute(
         f"UPDATE intervention_journal SET outcome_status = 'tabled', "
-        f"resolved_at = ? WHERE proposal_id IN ({placeholders}) "
-        f"AND outcome_status = 'pending'",
-        (now, *ids),
+        f"resolved_at = ? WHERE outcome_status = 'pending' AND proposal_id IN ("
+        f"SELECT id FROM ego_proposals WHERE status = 'tabled' "
+        f"AND resolved_at = ? AND id IN ({placeholders}))",
+        (now, now, *stale_ids),
     )
     await db.commit()
-    logger.info("Auto-tabled %d stale proposal(s) (>%dd)", len(ids), max_age_days)
-
-    # Shorter threshold for unranked proposals — proposals that were never
-    # put on the board are lower-priority and should be cleaned up faster.
-    unranked_days = min(max_age_days, 5)
-    unranked_threshold = f"-{unranked_days} days"
-    cursor2 = await db.execute(
-        "SELECT id FROM ego_proposals "
-        "WHERE status = 'pending' AND rank IS NULL "
-        "AND created_at < datetime('now', ?)",
-        (unranked_threshold,),
-    )
-    unranked_rows = await cursor2.fetchall()
-    unranked_count = 0
-    if unranked_rows:
-        unranked_ids = [r[0] for r in unranked_rows]
-        await db.execute(
-            "UPDATE ego_proposals SET status = 'tabled', rank = NULL, "
-            "resolved_at = ? "
-            "WHERE status = 'pending' AND rank IS NULL "
-            "AND created_at < datetime('now', ?)",
-            (now, unranked_threshold),
-        )
-        placeholders2 = ",".join("?" * len(unranked_ids))
-        await db.execute(
-            f"UPDATE intervention_journal SET outcome_status = 'tabled', "
-            f"resolved_at = ? WHERE proposal_id IN ({placeholders2}) "
-            f"AND outcome_status = 'pending'",
-            (now, *unranked_ids),
-        )
-        await db.commit()
-        unranked_count = len(unranked_ids)
-        logger.info(
-            "Auto-tabled %d unranked proposal(s) (>%dd)",
-            unranked_count,
-            unranked_days,
-        )
-
-    return len(ids) + unranked_count
+    logger.info("Auto-tabled %d urgency-stale proposal(s)", tabled_count)
+    return tabled_count
 
 
 async def get_board(
@@ -1198,24 +1203,29 @@ async def expire_stale_proposals(db: aiosqlite.Connection) -> int:
         return 0
 
     ids = [r[0] for r in rows]
-    # Expire proposals
-    await db.execute(
+    # Expire proposals (status guard re-checked at write time).
+    result = await db.execute(
         "UPDATE ego_proposals SET status = 'expired', resolved_at = ? "
         "WHERE status = 'pending' AND expires_at IS NOT NULL AND expires_at < ?",
         (now, now),
     )
-    # Expire matching journal entries
+    expired_count = result.rowcount
+    # Journal sync scoped to proposals ACTUALLY expired by this call (status +
+    # exact resolved_at), NOT the pre-UPDATE candidate list — so a proposal
+    # concurrently resolved between the SELECT and the UPDATE does not get its
+    # journal wrongly flipped to 'expired' (journal/proposal divergence).
     placeholders = ",".join("?" * len(ids))
     await db.execute(
         f"UPDATE intervention_journal SET outcome_status = 'expired', "
-        f"resolved_at = ? WHERE proposal_id IN ({placeholders}) "
-        f"AND outcome_status = 'pending'",
-        (now, *ids),
+        f"resolved_at = ? WHERE outcome_status = 'pending' AND proposal_id IN ("
+        f"SELECT id FROM ego_proposals WHERE status = 'expired' "
+        f"AND resolved_at = ? AND id IN ({placeholders}))",
+        (now, now, *ids),
     )
     await db.commit()
-    if ids:
-        logger.info("Expired %d stale proposal(s)", len(ids))
-    return len(ids)
+    if expired_count:
+        logger.info("Expired %d stale proposal(s)", expired_count)
+    return expired_count
 
 
 async def get_batch_for_delivery(

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -456,7 +456,7 @@ class EgoCadenceManager:
             )
             if auto_tabled:
                 logger.info(
-                    "Pre-sweep auto-table: %d proposal(s) tabled (>14d)",
+                    "Pre-sweep auto-table: %d proposal(s) tabled (urgency-stale)",
                     auto_tabled,
                 )
         except Exception:

--- a/src/genesis/ego/config.py
+++ b/src/genesis/ego/config.py
@@ -60,21 +60,19 @@ def load_ego_config(path: Path | None = None) -> EgoConfig:
             ):
                 continue
             kwargs[field_name] = value
-    # revalidation_interval_hours is a defaults-COMPLETE mapping: consumers
-    # .get(urgency) and fall back to normal/72 only for MISSING keys, so a
-    # partial YAML override like {"high": 12} must merge OVER the declared
-    # defaults — wholesale replacement silently collapses omitted urgencies
-    # to 72h (critical 6→72, low 168→72). Other dict fields (e.g.
+    # revalidation_interval_hours and auto_table_ttl_hours are defaults-COMPLETE
+    # mappings: consumers .get(urgency) and fall back to normal only for
+    # MISSING keys, so a partial YAML override like {"high": 12} must merge
+    # OVER the declared defaults — wholesale replacement silently collapses
+    # omitted urgencies (critical 6→72, low 168→72). Other dict fields (e.g.
     # dispatch_model_overrides) are empty-by-default override maps where
     # wholesale assignment IS the semantics — do not blanket-merge those.
-    if "revalidation_interval_hours" in kwargs:
-        _reval_defaults = EgoConfig.__dataclass_fields__[
-            "revalidation_interval_hours"
-        ].default_factory()
-        kwargs["revalidation_interval_hours"] = {
-            **_reval_defaults,
-            **kwargs["revalidation_interval_hours"],
-        }
+    for _complete_field in ("revalidation_interval_hours", "auto_table_ttl_hours"):
+        if _complete_field in kwargs:
+            _defaults = EgoConfig.__dataclass_fields__[
+                _complete_field
+            ].default_factory()
+            kwargs[_complete_field] = {**_defaults, **kwargs[_complete_field]}
     return EgoConfig(**kwargs)
 
 
@@ -184,6 +182,22 @@ def validate_ego_config(changes: dict) -> list[str]:
                 elif not isinstance(_hours, (int, float)) or isinstance(_hours, bool) or _hours <= 0:
                     errors.append(
                         f"revalidation_interval_hours[{_urg}] must be a positive number"
+                    )
+    if "auto_table_ttl_hours" in changes:
+        v = changes["auto_table_ttl_hours"]
+        if not isinstance(v, dict):
+            errors.append("auto_table_ttl_hours must be a dict")
+        else:
+            _valid_urg = {"critical", "high", "normal", "low"}
+            for _urg, _hours in v.items():
+                if _urg not in _valid_urg:
+                    errors.append(
+                        f"auto_table_ttl_hours: unknown urgency {_urg!r} "
+                        f"(must be one of {sorted(_valid_urg)})"
+                    )
+                elif not isinstance(_hours, (int, float)) or isinstance(_hours, bool) or _hours <= 0:
+                    errors.append(
+                        f"auto_table_ttl_hours[{_urg}] must be a positive number"
                     )
     if "calibration_injection_enabled" in changes and not isinstance(
         changes["calibration_injection_enabled"], bool

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -196,6 +196,18 @@ class EgoConfig:
     revalidation_interval_hours: dict = field(
         default_factory=lambda: {"critical": 6, "high": 48, "normal": 72, "low": 168}
     )
+    # Auto-table staleness window, per-urgency hours: how long a pending
+    # proposal may sit before auto_table_stale_proposals moves it to the
+    # recoverable 'tabled' cold lane (NOT deleted — the ego can un-table, and a
+    # still-relevant proposal is re-derived fresh next cycle). Urgency-based,
+    # replacing the old flat 14-day threshold: stale genesis investigations
+    # lingered 6-9 days below 14d and were approved on self-healed signals
+    # (2026-08-06 dispatch review). Values sit at/under the prior 14d backstop.
+    # Defaults-COMPLETE mapping (merged over defaults on load). Unranked
+    # proposals (never boarded) age out faster via a floor (see the sweep).
+    auto_table_ttl_hours: dict = field(
+        default_factory=lambda: {"critical": 48, "high": 72, "normal": 120, "low": 168}
+    )
     # Additive ego autonomy — cap on ACTIVE goals in the genesis ego's OWN
     # lane (origin='genesis_ego'). Pausing frees a slot; the paused tail is
     # deliberately unbounded (user decision 2026-07-16) and reported in the

--- a/src/genesis/eval/regression_common.py
+++ b/src/genesis/eval/regression_common.py
@@ -41,8 +41,8 @@ async def withdraw_recovered_proposals(
     drop exactly them). Best-effort: never raises into the caller.
 
     Legacy rows filed before this column was populated have an empty
-    ``action_category`` and are intentionally left for the 14-day auto-table —
-    never matched by free-text content here.
+    ``action_category`` and are intentionally left for the per-urgency
+    auto-table sweep — never matched by free-text content here.
 
     Returns the number of rows withdrawn.
     """

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -117,7 +117,9 @@ the queue.
 After 24 hours, table items you no longer recommend. Withdraw only
 genuinely invalid proposals (factually wrong, superseded by events).
 
-Proposals pending longer than 14 days are auto-tabled by the system.
+Proposals pending too long are auto-tabled by the system on a per-urgency
+staleness window (roughly 2 days for critical up to 7 for low; unranked
+proposals age out sooner). Tabling is recoverable, not deletion.
 
 ## Execution
 

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -243,7 +243,9 @@ reasoning rather than withdrawing and re-proposing.
 
 ### Queue Health
 
-Proposals pending longer than 14 days are auto-tabled by the system.
+Proposals pending too long are auto-tabled by the system on a per-urgency
+staleness window (roughly 2 days for critical up to 7 for low; unranked
+proposals age out sooner). Tabling is recoverable, not deletion.
 If the queue exceeds 15 pending proposals, consider:
 - Tabling lower-priority items (they can be resurfaced later)
 - Combining related proposals into one

--- a/tests/ego/test_config.py
+++ b/tests/ego/test_config.py
@@ -75,6 +75,19 @@ class TestLoadEgoConfig:
         config = load_ego_config(tmp_config)
         assert config.revalidation_interval_hours == full
 
+    def test_partial_auto_table_override_merges_over_defaults(self, tmp_config):
+        """A partial auto_table_ttl_hours override merges OVER the full defaults
+        — omitted urgencies keep their declared window (same defaults-complete
+        semantics as revalidation_interval_hours)."""
+        tmp_config.write_text(yaml.dump({"auto_table_ttl_hours": {"high": 24}}))
+        config = load_ego_config(tmp_config)
+        assert config.auto_table_ttl_hours == {
+            "critical": 48,
+            "high": 24,
+            "normal": 120,
+            "low": 168,
+        }
+
 
 class TestSaveEgoConfig:
     def test_roundtrip(self, tmp_config):
@@ -134,6 +147,19 @@ class TestValidateEgoConfig:
         """proposal_expiry_minutes was removed — should not validate."""
         errors = validate_ego_config({"proposal_expiry_minutes": 240})
         assert errors == []  # unknown key, ignored
+
+    def test_invalid_auto_table_ttl_unknown_urgency(self):
+        errors = validate_ego_config({"auto_table_ttl_hours": {"bogus": 12}})
+        assert len(errors) == 1
+        assert "auto_table_ttl_hours" in errors[0]
+
+    def test_invalid_auto_table_ttl_non_positive(self):
+        errors = validate_ego_config({"auto_table_ttl_hours": {"high": 0}})
+        assert len(errors) == 1
+        assert "auto_table_ttl_hours" in errors[0]
+
+    def test_valid_auto_table_ttl(self):
+        assert validate_ego_config({"auto_table_ttl_hours": {"high": 72}}) == []
 
     def test_outcome_bus_capability_feed_rejects_non_bool(self):
         for bad in ("yes", 1, 0, None):

--- a/tests/ego/test_proposal_lifecycle.py
+++ b/tests/ego/test_proposal_lifecycle.py
@@ -21,7 +21,9 @@ def _ts(days_ago: int = 0, hours_ago: int = 0) -> str:
     ).isoformat()
 
 
-async def _create(db, id: str, *, rank=None, created_at=None, status="pending"):
+async def _create(
+    db, id: str, *, rank=None, created_at=None, status="pending", urgency="normal"
+):
     """Shorthand to create a proposal with sensible defaults."""
     await ego_crud.create_proposal(
         db,
@@ -31,6 +33,7 @@ async def _create(db, id: str, *, rank=None, created_at=None, status="pending"):
         rank=rank,
         created_at=created_at or _ts(),
         status=status,
+        urgency=urgency,
     )
 
 
@@ -152,28 +155,43 @@ class TestGetPendingQueue:
 
 
 class TestAutoTableStaleProposals:
+    # Explicit windows keep these deterministic regardless of ambient config.
+    _TTL = {"critical": 48, "high": 72, "normal": 120, "low": 168}
+
     @pytest.mark.asyncio
-    async def test_tables_old_proposals(self, db):
-        """Proposals older than max_age_days are tabled."""
-        await _create(db, "old", created_at=_ts(days_ago=15))
-        await _create(db, "fresh", created_at=_ts(days_ago=1))
-        count = await ego_crud.auto_table_stale_proposals(db, max_age_days=14)
+    async def test_tables_by_urgency_window(self, db):
+        """Ranked proposals are tabled once older than their per-urgency window
+        (high 3d, low 7d); fresher / within-window ones stay pending."""
+        # ranked so the unranked floor does not mask the urgency window.
+        await _create(db, "high_stale", rank=1, urgency="high", created_at=_ts(days_ago=4))
+        await _create(db, "high_fresh", rank=2, urgency="high", created_at=_ts(days_ago=2))
+        await _create(db, "low_within", rank=3, urgency="low", created_at=_ts(days_ago=6))
+        count = await ego_crud.auto_table_stale_proposals(db, ttl_hours=self._TTL)
         assert count == 1
+        assert (await ego_crud.get_proposal(db, "high_stale"))["status"] == "tabled"
+        assert (await ego_crud.get_proposal(db, "high_stale"))["rank"] is None
+        assert (await ego_crud.get_proposal(db, "high_fresh"))["status"] == "pending"
+        assert (await ego_crud.get_proposal(db, "low_within"))["status"] == "pending"
 
-        old = await ego_crud.get_proposal(db, "old")
-        assert old["status"] == "tabled"
-        assert old["rank"] is None
-        assert old["resolved_at"] is not None
-
-        fresh = await ego_crud.get_proposal(db, "fresh")
-        assert fresh["status"] == "pending"
+    @pytest.mark.asyncio
+    async def test_unranked_floor_ages_out_faster(self, db):
+        """Unranked (never boarded) proposals table at the floor even when their
+        urgency window is longer (low window 7d, floor 5d)."""
+        await _create(db, "low_unranked", urgency="low", created_at=_ts(days_ago=6))
+        await _create(db, "low_ranked", rank=1, urgency="low", created_at=_ts(days_ago=6))
+        count = await ego_crud.auto_table_stale_proposals(
+            db, ttl_hours=self._TTL, unranked_cap_hours=120
+        )
+        assert count == 1
+        assert (await ego_crud.get_proposal(db, "low_unranked"))["status"] == "tabled"
+        assert (await ego_crud.get_proposal(db, "low_ranked"))["status"] == "pending"
 
     @pytest.mark.asyncio
     async def test_only_affects_pending(self, db):
         """Auto-table does not touch non-pending proposals."""
-        await _create(db, "old_approved", created_at=_ts(days_ago=15))
+        await _create(db, "old_approved", rank=1, created_at=_ts(days_ago=15))
         await ego_crud.resolve_proposal(db, "old_approved", status="approved")
-        count = await ego_crud.auto_table_stale_proposals(db, max_age_days=14)
+        count = await ego_crud.auto_table_stale_proposals(db, ttl_hours=self._TTL)
         assert count == 0
         prop = await ego_crud.get_proposal(db, "old_approved")
         assert prop["status"] == "approved"
@@ -181,7 +199,7 @@ class TestAutoTableStaleProposals:
     @pytest.mark.asyncio
     async def test_updates_intervention_journal(self, db):
         """Auto-tabling also updates matching journal entries."""
-        await _create(db, "old_j", created_at=_ts(days_ago=15))
+        await _create(db, "old_j", rank=1, created_at=_ts(days_ago=15))
         await journal_crud.create(
             db,
             ego_source="user_ego_cycle",
@@ -190,7 +208,7 @@ class TestAutoTableStaleProposals:
             action_type="investigate",
             action_summary="Journal test",
         )
-        count = await ego_crud.auto_table_stale_proposals(db, max_age_days=14)
+        count = await ego_crud.auto_table_stale_proposals(db, ttl_hours=self._TTL)
         assert count == 1
 
         journal = await journal_crud.get_by_proposal(db, "old_j")
@@ -198,22 +216,17 @@ class TestAutoTableStaleProposals:
         assert journal["outcome_status"] == "tabled"
 
     @pytest.mark.asyncio
-    async def test_custom_threshold(self, db):
-        """Custom max_age_days threshold works."""
-        await _create(db, "p1", created_at=_ts(days_ago=8))
-        await _create(db, "p2", created_at=_ts(days_ago=3))
-
-        count = await ego_crud.auto_table_stale_proposals(db, max_age_days=7)
-        assert count == 1
-
-        p1 = await ego_crud.get_proposal(db, "p1")
-        assert p1["status"] == "tabled"
-        p2 = await ego_crud.get_proposal(db, "p2")
-        assert p2["status"] == "pending"
+    async def test_nothing_stale(self, db):
+        """Returns 0 when no proposals exceed their window."""
+        await _create(db, "fresh", rank=1, created_at=_ts(days_ago=1))
+        count = await ego_crud.auto_table_stale_proposals(db, ttl_hours=self._TTL)
+        assert count == 0
 
     @pytest.mark.asyncio
-    async def test_nothing_stale(self, db):
-        """Returns 0 when no proposals exceed threshold."""
-        await _create(db, "fresh", created_at=_ts(days_ago=1))
-        count = await ego_crud.auto_table_stale_proposals(db, max_age_days=14)
-        assert count == 0
+    async def test_defaults_to_config_when_ttl_omitted(self, db):
+        """With no explicit ttl_hours the sweep loads config defaults (or the
+        safe fallback) and still tables a clearly-stale proposal."""
+        await _create(db, "ancient", rank=1, created_at=_ts(days_ago=30))
+        count = await ego_crud.auto_table_stale_proposals(db)
+        assert count == 1
+        assert (await ego_crud.get_proposal(db, "ancient"))["status"] == "tabled"


### PR DESCRIPTION
## Problem

Stale genesis-ego investigation proposals lingered 6–9 days below the flat 14-day `auto_table_stale_proposals` threshold, then were approved and dispatched onto **self-healed signals** (surfaced by the 2026-08-06 ego-dispatch review). The staleness backstop was too coarse: a flat 14 days regardless of urgency.

## Change

Make the auto-table staleness window **per-urgency** instead of a flat 14 days, sending stale proposals to the recoverable **`tabled`** cold lane sooner. `tabled` is not deletion — the ego can un-table, and a still-relevant proposal is re-derived fresh next cycle (dedup excludes non-pending statuses).

- **`EgoConfig.auto_table_ttl_hours`** — `{critical: 48, high: 72, normal: 120, low: 168}` (2–7d). Defaults-complete, merge-over-defaults on load + validator, mirroring the existing `revalidation_interval_hours` pattern.
- **`auto_table_stale_proposals`** rewritten to a single-pass per-urgency window with an unranked cap (5d, preserving the prior "unranked age out faster" behaviour). Applies to **both egos** (matching the prior flat-14d scope).
- Reuses the already-wired sweep (`_sweep_with_expiry` → `cadence.py`); no new scheduler wiring.
- Ego identity docs (`USER_EGO_SESSION.md`, `GENESIS_EGO_SESSION.md`) + an eval comment updated off the now-false "14 days" claim (these files are injected into the ego's own context).

## Correctness (3 review rounds, terminated clean)

- **TOCTOU guard**: the proposal UPDATE re-checks `status='pending'` at write time and counts via `rowcount`, so a proposal concurrently approved/executed between SELECT and UPDATE is never clobbered back to `tabled`.
- **Journal/proposal divergence fix** (both `auto_table_stale_proposals` **and** its sibling `expire_stale_proposals` — same class bug): the `intervention_journal` UPDATE is scoped via subquery to rows *actually* tabled/expired this call (`status` + exact `resolved_at`), so a concurrently-resolved proposal excluded by the guard can't have its journal wrongly flipped.

## Tests

Urgency window, unranked cap, config-default path, config merge + validator; existing `expire_stale`/lifecycle tests still green. Full ego suite: **1219 passed / 1 skipped**; ruff clean.

## Pre-existing note (not introduced here, unreachable today)

`expire_stale_proposals`'s proposal UPDATE re-runs its predicate rather than scoping to the pre-fetched ids; a proposal inserted with an already-past `expires_at` between SELECT and UPDATE could be expired but journal-missed. No current caller inserts a past `expires_at`.

Context: follow-up `7c2dee76` (ego investigation-waste). Part of the 2026-08-06 ego-reliability workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)