### PR TITLE
fix(reflection): salvage deep-reflection output that ends in prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Deep reflections no longer silently lose their output.** When a deep
+  reflection ended its session with a plain-prose wrap-up instead of the
+  required structured JSON (~40% of runs), both parsers failed: the Telegram
+  topic showed a "not parseable" stub and — worse — that cycle's cognitive
+  output (updated context summary, observations, memory consolidations, and
+  follow-up research it wanted to queue) was discarded. Genesis now re-derives
+  the structured result from the prose in one follow-up model call, so the
+  reflection's findings are kept and the topic shows a real summary. If the
+  salvage can't recover valid output, behavior is unchanged from before.
+
 - **Email replies now count as engagement.** When someone replies to an email
   Genesis sent (outreach pitch, follow-up), the reply was recorded for thread
   tracking but never registered as an engagement outcome — so reply rates read

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -532,6 +532,16 @@ call_sites:
       redundant with existing ones). S-tier only — precision is the safety
       property (validated 0 false-merges on deepseek-v4); fires per novel
       procedure, low volume.
+  41_reflection_json_salvage:
+    chain:
+    - mistral-large-free
+    - gemini-free
+    - openrouter-deepseek-v4
+    default_paid: true
+    description: Salvage a deep-reflection CC session that ended in prose (no
+      fenced JSON) into the required structured JSON, so the cycle's cognitive
+      output (cognitive_state_update, observations, memory_operations, surplus
+      requests) isn't discarded. Quality matters — recovers otherwise-lost work.
   40_ego_focus_selection:
     chain:
     - groq-free

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -23,6 +23,7 @@ from genesis.cc.constants import RATE_LIMIT_DEFERRAL_TTL_S
 from genesis.cc.reflection_bridge._output import (
     format_topic_summary,
     route_deep_output,
+    salvage_deep_reflection_json,
     send_to_topic,
     store_reflection_output,
 )
@@ -100,6 +101,8 @@ class CCReflectionBridge:
         self._context_assembler: ContextAssembler | None = None
         self._topic_manager = None
         self._autonomous_dispatcher = None
+        # Model router (route_call) for the deep-reflection JSON salvage retry.
+        self._router = None
 
     # ── Injection setters (for late binding) ──────────────────────────
 
@@ -126,6 +129,11 @@ class CCReflectionBridge:
     def set_autonomous_dispatcher(self, dispatcher: object) -> None:
         """Set the API-first autonomous dispatch router."""
         self._autonomous_dispatcher = dispatcher
+
+    def set_router(self, router: object) -> None:
+        """Set the model router (route_call) used for the deep-reflection JSON
+        salvage retry. Optional — salvage no-ops when unset."""
+        self._router = router
 
     # ── Main reflection entry point ───────────────────────────────────
 
@@ -440,12 +448,36 @@ class CCReflectionBridge:
         except Exception:
             logger.debug("Corpus recording failed (table may not exist yet)", exc_info=True)
 
+        # 4c. Salvage: a DEEP session that ended in PROSE (no fenced JSON) fails
+        # both parse sites and silently discards its cognitive output (~40% of
+        # runs). Re-derive the structured JSON via one routed LLM call and use it
+        # for BOTH routing and the topic summary. The RAW output.text is kept in
+        # the corpus above for audit. Strictly additive: when no salvage is needed
+        # (already parseable) or salvage fails, deep_text stays output.text and
+        # behavior is unchanged.
+        deep_text = output.text
+        if depth == Depth.DEEP:
+            salvaged = await salvage_deep_reflection_json(output.text, self._router)
+            if salvaged is not None:
+                deep_text = salvaged
+                logger.info(
+                    "Deep reflection ended in prose — structured JSON re-derived via salvage"
+                )
+                if self._event_bus:
+                    from genesis.observability.types import Severity, Subsystem
+                    await self._event_bus.emit(
+                        Subsystem.REFLECTION, Severity.WARNING,
+                        "deep_reflection.salvaged",
+                        "Deep reflection ended in prose; structured JSON re-derived via salvage",
+                        depth=depth.value,
+                    )
+
         # 5. Route output
         routing_failed = False
         if self._output_router and depth == Depth.DEEP:
             try:
                 routing_summary = await route_deep_output(
-                    output.text, db=db, output_router=self._output_router,
+                    deep_text, db=db, output_router=self._output_router,
                     gathered_obs_ids=gathered_obs_ids,
                     gathered_surplus_ids=gathered_surplus_ids,
                     tick_signal_names=(
@@ -471,9 +503,11 @@ class CCReflectionBridge:
                 except Exception:
                     logger.warning("Failed to mark influenced observations", exc_info=True)
 
-        # 6. Send to topic — parsed-fields summary only, never raw output.text
+        # 6. Send to topic — parsed-fields summary only, never raw output.text.
+        # Use the salvaged JSON (deep_text) so a prose-ended deep reflection shows
+        # a real summary instead of the "not parseable" stub.
         await send_to_topic(
-            session_id, depth, format_topic_summary(depth, output),
+            session_id, depth, format_topic_summary(depth, output, text=deep_text),
             topic_manager=self._topic_manager,
         )
 

--- a/src/genesis/cc/reflection_bridge/_output.py
+++ b/src/genesis/cc/reflection_bridge/_output.py
@@ -43,10 +43,13 @@ _SALVAGE_MAX_PROSE_CHARS = 12000
 _SALVAGE_PROMPT = """A deep-reflection session produced the analysis below as \
 free-form PROSE instead of the required JSON. Convert it FAITHFULLY into a single \
 JSON object. Do NOT invent content that is not in the prose; omit any field the \
-prose does not address — EXCEPT "cognitive_state_update" and "confidence", which \
-are required (synthesize them from the prose's overall assessment).
+prose does not address — EXCEPT "observations", "cognitive_state_update", and \
+"confidence", which are required (synthesize them from the prose's overall \
+assessment).
 
 Required:
+- "observations": [string, ...]        (max 5 — the key discrete findings in \
+the prose; the reflection's concrete conclusions).
 - "cognitive_state_update": string — a tight, factual summary of the current \
 cognitive state / situation described in the prose.
 - "confidence": float 0.0–1.0 — a calibrated confidence in this reflection's \
@@ -54,7 +57,6 @@ conclusions, inferred from the prose's own certainty. Do NOT default to 0.7; \
 below 0.5 signals genuine low confidence.
 
 Optional (include only when the prose supports it):
-- "observations": [string, ...]        (max 5 — the key findings)
 - "learnings": [string, ...]
 - "memory_operations": [{"operation": "dedup|merge|prune|flag_contradiction", \
 "target_ids": ["..."], "reason": "...", "merged_content": "..."}]

--- a/src/genesis/cc/reflection_bridge/_output.py
+++ b/src/genesis/cc/reflection_bridge/_output.py
@@ -57,9 +57,14 @@ Optional (include only when the prose supports it):
 "target_ids": ["..."], "reason": "...", "merged_content": "..."}]
 - "surplus_task_requests": [{"task_type": "...", "reason": "...", \
 "priority": 0.0, "drive_alignment": "..."}]
+- "skill_triggers": [string, ...]
+- "procedure_quarantines": [{"procedure_id": "...", "reason": "..."}]
+- "user_question": {"text": "...", "context": "...", "options": ["...", "..."]}
 - "contradictions": [ ... ]
 - "confidence": 0.0
 - "focus_next": string
+- "alternative_assessment": string
+- "separability": 0.0
 
 Output ONLY the JSON object — no markdown fence, no commentary.
 

--- a/src/genesis/cc/reflection_bridge/_output.py
+++ b/src/genesis/cc/reflection_bridge/_output.py
@@ -34,6 +34,93 @@ def _extract_fenced_json(text: str) -> str:
     return json_match.group(1) if json_match else text
 
 
+# Call site for the prose→JSON salvage retry (chain in config/model_routing.yaml).
+_SALVAGE_CALL_SITE = "41_reflection_json_salvage"
+# Cap the prose fed to the salvage model. Real failing rows are ~1.6k–2.9k chars;
+# this is generous headroom without paying for a runaway payload.
+_SALVAGE_MAX_PROSE_CHARS = 12000
+
+_SALVAGE_PROMPT = """A deep-reflection session produced the analysis below as \
+free-form PROSE instead of the required JSON. Convert it FAITHFULLY into a single \
+JSON object. Do NOT invent content that is not in the prose; omit any field the \
+prose does not address — EXCEPT "cognitive_state_update", which is required \
+(synthesize it from the prose's overall assessment).
+
+Required:
+- "cognitive_state_update": string — a tight, factual summary of the current \
+cognitive state / situation described in the prose.
+
+Optional (include only when the prose supports it):
+- "observations": [string, ...]        (max 5 — the key findings)
+- "learnings": [string, ...]
+- "memory_operations": [{"operation": "dedup|merge|prune|flag_contradiction", \
+"target_ids": ["..."], "reason": "...", "merged_content": "..."}]
+- "surplus_task_requests": [{"task_type": "...", "reason": "...", \
+"priority": 0.0, "drive_alignment": "..."}]
+- "contradictions": [ ... ]
+- "confidence": 0.0
+- "focus_next": string
+
+Output ONLY the JSON object — no markdown fence, no commentary.
+
+PROSE:
+{prose}
+"""
+
+
+def _extract_json_obj(text: str) -> dict | None:
+    """Whether ``text`` yields a reflection JSON dict — the salvage-skip gate.
+
+    Delegates to the CANONICAL extractor used by ``parse_deep_reflection_output``
+    (the production routing parser), so the gate and the parser are provably the
+    same algorithm: salvage fires exactly when routing would fail, never skips
+    when routing would fail, and never wastes a call when routing would succeed.
+    """
+    from genesis.reflection.output_router import extract_reflection_json
+
+    return extract_reflection_json(text)
+
+
+async def salvage_deep_reflection_json(raw_text: str, router) -> str | None:
+    """Salvage a deep-reflection CC session that ended in PROSE (no JSON) by
+    re-deriving the structured payload via one routed LLM call, so the cycle's
+    cognitive output (cognitive_state_update, observations, memory ops, surplus
+    requests) is not silently discarded.
+
+    Returns a strict ```json-fenced string to use in place of ``raw_text`` (parsed
+    identically by the router AND the Telegram topic summary), or None when no
+    salvage is needed (``raw_text`` already parses) or salvage fails (caller then
+    keeps the existing parse-failed behavior — this is strictly additive).
+    """
+    if router is None or not raw_text or not raw_text.strip():
+        return None
+    if _extract_json_obj(raw_text) is not None:
+        return None  # already parseable — nothing to salvage
+    # .replace (not .format) — the prompt embeds literal JSON braces.
+    prompt = _SALVAGE_PROMPT.replace("{prose}", raw_text[:_SALVAGE_MAX_PROSE_CHARS])
+    try:
+        result = await router.route_call(
+            call_site_id=_SALVAGE_CALL_SITE,
+            messages=[{"role": "user", "content": prompt}],
+            suppress_dead_letter=True,
+        )
+    except Exception:
+        logger.warning("Deep-reflection JSON salvage call raised", exc_info=True)
+        return None
+    if not getattr(result, "success", False) or not getattr(result, "content", None):
+        logger.warning(
+            "Deep-reflection JSON salvage produced no usable content (error=%s)",
+            getattr(result, "error", None),
+        )
+        return None
+    obj = _extract_json_obj(result.content)
+    if obj is None:
+        logger.warning("Deep-reflection JSON salvage output was still unparseable")
+        return None
+    # Normalize to a strict ```json fence so both consumers parse it identically.
+    return "```json\n" + json.dumps(obj) + "\n```"
+
+
 async def route_deep_output(
     raw_text: str,
     *,
@@ -414,7 +501,7 @@ async def _store_reflection_summary(
             )
 
 
-def format_topic_summary(depth, output) -> str:
+def format_topic_summary(depth, output, *, text: str | None = None) -> str:
     """Build the Telegram topic message from PARSED reflection fields only.
 
     Raw ``output.text`` must never reach the topic: when the model output is
@@ -422,17 +509,23 @@ def format_topic_summary(depth, output) -> str:
     internal noise, not a summary — it has leaked mid-session artifacts to
     the user verbatim. The topic stays a liveness surface: parse failure
     still produces a one-liner, never silence and never raw text.
+
+    ``text`` overrides ``output.text`` as the parse source — used to pass the
+    salvaged JSON for a deep reflection that ended in prose, so the topic shows
+    a real summary instead of the fallback stub.
     """
+    source_text = text if text is not None else output.text
     header = f"<b>{depth.value} Reflection</b>"
     fallback = (
         f"{header}\n\nReflection completed — output was not parseable; "
         "stored for review."
     )
-    try:
-        data = json.loads(_extract_fenced_json(output.text))
-    except (json.JSONDecodeError, TypeError):
-        return fallback
-    if not isinstance(data, dict):
+    # Use the SAME canonical extractor as the routing parser and the salvage
+    # gate, so the topic never shows the "not parseable" stub for output that
+    # actually routed (e.g. a bare-untagged ``` fence). One algorithm, three
+    # consumers — no divergent parser left.
+    data = _extract_json_obj(source_text)
+    if data is None:
         return fallback
 
     parts = [header]

--- a/src/genesis/cc/reflection_bridge/_output.py
+++ b/src/genesis/cc/reflection_bridge/_output.py
@@ -43,12 +43,15 @@ _SALVAGE_MAX_PROSE_CHARS = 12000
 _SALVAGE_PROMPT = """A deep-reflection session produced the analysis below as \
 free-form PROSE instead of the required JSON. Convert it FAITHFULLY into a single \
 JSON object. Do NOT invent content that is not in the prose; omit any field the \
-prose does not address — EXCEPT "cognitive_state_update", which is required \
-(synthesize it from the prose's overall assessment).
+prose does not address — EXCEPT "cognitive_state_update" and "confidence", which \
+are required (synthesize them from the prose's overall assessment).
 
 Required:
 - "cognitive_state_update": string — a tight, factual summary of the current \
 cognitive state / situation described in the prose.
+- "confidence": float 0.0–1.0 — a calibrated confidence in this reflection's \
+conclusions, inferred from the prose's own certainty. Do NOT default to 0.7; \
+below 0.5 signals genuine low confidence.
 
 Optional (include only when the prose supports it):
 - "observations": [string, ...]        (max 5 — the key findings)
@@ -61,7 +64,6 @@ Optional (include only when the prose supports it):
 - "procedure_quarantines": [{"procedure_id": "...", "reason": "..."}]
 - "user_question": {"text": "...", "context": "...", "options": ["...", "..."]}
 - "contradictions": [ ... ]
-- "confidence": 0.0
 - "focus_next": string
 - "alternative_assessment": string
 - "separability": 0.0

--- a/src/genesis/reflection/output_router.py
+++ b/src/genesis/reflection/output_router.py
@@ -49,31 +49,51 @@ def _safe_float(value: object, default: float) -> float:
         return default
 
 
+def extract_reflection_json(raw: str) -> dict | None:
+    """Recover the reflection JSON dict from raw CC output, returning None for
+    genuine prose. THE canonical extractor — the salvage-skip gate in
+    cc/reflection_bridge/_output.py delegates here so the gate and this parser
+    are provably the same algorithm (a divergence would let a deep reflection
+    silently lose its output when the gate believes routing will succeed).
+
+    Order matters: try the whole string as JSON, then a ```json-TAGGED block
+    (wherever it appears — a deep reflection often quotes a ```diff/```config
+    block BEFORE its real ```json block, so anchoring on the tag is required),
+    then any first fenced block as a lenient last resort.
+    """
+    if not raw:
+        return None
+    import re
+
+    def _as_dict(s: str) -> dict | None:
+        try:
+            obj = json.loads(s)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        return obj if isinstance(obj, dict) else None
+
+    # 1. Whole string is JSON.
+    if (obj := _as_dict(raw)) is not None:
+        return obj
+    # 2. An explicitly ```json-tagged block, anywhere in the text.
+    m = re.search(r"```json\s*(.*?)\s*```", raw, re.DOTALL)
+    if m and (obj := _as_dict(m.group(1))) is not None:
+        return obj
+    # 3. Any first fenced block (lenient back-compat).
+    m = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", raw, re.DOTALL)
+    if m and (obj := _as_dict(m.group(1))) is not None:
+        return obj
+    return None
+
+
 def parse_deep_reflection_output(raw_json: str) -> DeepReflectionOutput:
     """Parse raw CC output JSON into a DeepReflectionOutput.
 
     Tolerant of missing fields — returns defaults for anything absent.
     """
-    try:
-        data = json.loads(raw_json)
-    except (json.JSONDecodeError, TypeError):
-        # Try to extract JSON from markdown code block
-        if "```" in str(raw_json):
-            import re
-            match = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", str(raw_json), re.DOTALL)
-            if match:
-                try:
-                    data = json.loads(match.group(1))
-                except (json.JSONDecodeError, TypeError):
-                    logger.warning("Failed to parse extracted JSON from CC output")
-                    return DeepReflectionOutput(parse_failed=True)
-            else:
-                return DeepReflectionOutput(parse_failed=True)
-        else:
-            logger.warning("Failed to parse CC reflection output as JSON")
-            return DeepReflectionOutput(parse_failed=True)
-
-    if not isinstance(data, dict):
+    data = extract_reflection_json(raw_json)
+    if data is None:
+        logger.warning("Failed to parse CC reflection output as JSON")
         return DeepReflectionOutput(parse_failed=True)
 
     # Parse memory operations

--- a/src/genesis/runtime/init/reflection.py
+++ b/src/genesis/runtime/init/reflection.py
@@ -46,6 +46,10 @@ async def init(rt: GenesisRuntime) -> None:
         rt._cc_reflection_bridge.set_output_router(output_router)
         if hasattr(rt, "_context_assembler") and rt._context_assembler is not None:
             rt._cc_reflection_bridge.set_context_assembler(rt._context_assembler)
+        # Router for the deep-reflection JSON salvage retry (optional — salvage
+        # no-ops if unset). rt._router is initialized before reflection.
+        if getattr(rt, "_router", None) is not None:
+            rt._cc_reflection_bridge.set_router(rt._router)
         rt._output_router = output_router
 
         rt._reflection_scheduler = ReflectionScheduler(

--- a/tests/test_cc/test_reflection_salvage.py
+++ b/tests/test_cc/test_reflection_salvage.py
@@ -1,0 +1,166 @@
+"""Tests for the deep-reflection JSON salvage retry.
+
+A deep-reflection CC session sometimes ends its final message as free-form
+PROSE with no fenced JSON. Both parse sites then fail and the cycle's cognitive
+output (cognitive_state_update, observations, memory ops, surplus) is silently
+discarded. The salvage re-derives the structured JSON via one routed LLM call.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from genesis.awareness.types import Depth
+from genesis.cc.reflection_bridge._output import (
+    _extract_json_obj,
+    format_topic_summary,
+    salvage_deep_reflection_json,
+)
+from genesis.reflection.output_router import parse_deep_reflection_output
+
+# A real-shaped failing sample: coherent prose, zero JSON (mirrors the live
+# reflection_corpus failures — the model wrote a human wrap-up, not the schema).
+PROSE = (
+    "Deep reflection complete. Summary of what I found and did:\n\n"
+    "Headline finding: the groq-EOL question is resolved — both models were "
+    "deprecated 2026-06-17. I verified against the deprecation docs and closed "
+    "the escalation. Everything else is healthy or already has a next step."
+)
+
+VALID_JSON = {
+    "cognitive_state_update": "Groq EOL resolved; systems healthy.",
+    "observations": ["groq-EOL resolved", "all jobs green"],
+    "confidence": 0.8,
+    "focus_next": "pick a replacement model",
+}
+
+
+class _FakeRouter:
+    def __init__(self, content, *, success=True, raises=False):
+        self._content = content
+        self._success = success
+        self._raises = raises
+        self.calls: list = []
+
+    async def route_call(self, call_site_id, messages, **kwargs):
+        self.calls.append((call_site_id, messages, kwargs))
+        if self._raises:
+            raise RuntimeError("provider chain exhausted")
+        return SimpleNamespace(success=self._success, content=self._content, error=None)
+
+
+# ── _extract_json_obj ──────────────────────────────────────────────────
+
+
+def test_extract_json_obj_variants():
+    obj = {"a": 1}
+    assert _extract_json_obj(json.dumps(obj)) == obj  # bare
+    assert _extract_json_obj(f"```json\n{json.dumps(obj)}\n```") == obj  # ```json fence
+    assert _extract_json_obj(f"```\n{json.dumps(obj)}\n```") == obj  # bare fence
+    assert _extract_json_obj(PROSE) is None  # genuine prose
+    assert _extract_json_obj("") is None
+    assert _extract_json_obj("[1, 2, 3]") is None  # a list is not a reflection dict
+
+
+def test_multi_fence_json_block_found_by_gate_and_parser():
+    """A deep reflection that quotes a ```diff block BEFORE its real ```json
+    block must be parsed via the JSON-tagged block — by BOTH the salvage gate
+    and the production parser. (Regression: the parser used to grab the FIRST
+    fence, fail on the diff, and discard the whole reflection while the gate
+    thought it was fine — so salvage was skipped AND routing failed.)"""
+    payload = {"cognitive_state_update": "state", "observations": ["o1"]}
+    multi_fence = (
+        "Here is the diff I reviewed:\n"
+        "```diff\n-old\n+new\n```\n\n"
+        "Summary:\n"
+        f"```json\n{json.dumps(payload)}\n```"
+    )
+    # Gate finds the json block (so salvage correctly skips)...
+    assert _extract_json_obj(multi_fence) == payload
+    # ...AND the production parser now recovers it instead of parse_failed.
+    parsed = parse_deep_reflection_output(multi_fence)
+    assert not parsed.parse_failed
+    assert parsed.cognitive_state_update == "state"
+
+
+# ── salvage_deep_reflection_json ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_salvage_noop_when_already_parseable():
+    """Already-JSON output must NOT trigger a salvage call (happy path untouched)."""
+    router = _FakeRouter(json.dumps(VALID_JSON))
+    fenced = f"```json\n{json.dumps(VALID_JSON)}\n```"
+    assert await salvage_deep_reflection_json(fenced, router) is None
+    assert await salvage_deep_reflection_json(json.dumps(VALID_JSON), router) is None
+    assert router.calls == []  # no LLM call made
+
+
+@pytest.mark.asyncio
+async def test_salvage_prose_produces_parseable_json():
+    """Prose in + a router that returns valid JSON → a fenced string that BOTH
+    the router parser and the topic-summary parser accept."""
+    router = _FakeRouter(json.dumps(VALID_JSON))
+    salvaged = await salvage_deep_reflection_json(PROSE, router)
+    assert salvaged is not None
+    assert len(router.calls) == 1
+    assert router.calls[0][0] == "41_reflection_json_salvage"
+    # Router parser accepts it and recovers the real content.
+    parsed = parse_deep_reflection_output(salvaged)
+    assert not parsed.parse_failed
+    assert parsed.cognitive_state_update == VALID_JSON["cognitive_state_update"]
+    assert parsed.observations == VALID_JSON["observations"]
+    # Topic-summary parser (strict ```json) also accepts it.
+    assert _extract_json_obj(salvaged) == VALID_JSON
+
+
+@pytest.mark.asyncio
+async def test_salvage_returns_none_when_router_unset():
+    assert await salvage_deep_reflection_json(PROSE, None) is None
+
+
+@pytest.mark.asyncio
+async def test_salvage_returns_none_on_router_failure():
+    assert await salvage_deep_reflection_json(PROSE, _FakeRouter(None, success=False)) is None
+
+
+@pytest.mark.asyncio
+async def test_salvage_returns_none_when_router_raises():
+    assert await salvage_deep_reflection_json(PROSE, _FakeRouter(None, raises=True)) is None
+
+
+@pytest.mark.asyncio
+async def test_salvage_returns_none_when_output_still_prose():
+    """If the salvage model ALSO returns prose, salvage fails closed → None
+    (caller keeps the existing parse-failed behavior; strictly additive)."""
+    assert await salvage_deep_reflection_json(PROSE, _FakeRouter("still just prose, sorry")) is None
+
+
+# ── format_topic_summary text override ─────────────────────────────────
+
+
+def test_topic_summary_falls_back_on_prose():
+    out = SimpleNamespace(text=PROSE)
+    summary = format_topic_summary(Depth.DEEP, out)
+    assert "was not parseable" in summary  # the stub (pre-salvage behavior)
+
+
+def test_topic_summary_uses_salvaged_text_override():
+    """With the salvaged JSON passed as `text`, the topic shows a REAL summary
+    instead of the not-parseable stub — even though output.text is still prose."""
+    out = SimpleNamespace(text=PROSE)
+    salvaged = f"```json\n{json.dumps(VALID_JSON)}\n```"
+    summary = format_topic_summary(Depth.DEEP, out, text=salvaged)
+    assert "was not parseable" not in summary
+    assert "Groq EOL resolved" in summary
+
+
+def test_topic_summary_handles_bare_untagged_fence():
+    """A bare (untagged) ``` fence routes fine via the canonical extractor, so
+    the topic must NOT fall back to the stub for it (it used to, because
+    format_topic_summary had its own strict ```json-only parser)."""
+    out = SimpleNamespace(text=f"```\n{json.dumps(VALID_JSON)}\n```")
+    summary = format_topic_summary(Depth.DEEP, out)
+    assert "was not parseable" not in summary
+    assert "Groq EOL resolved" in summary

--- a/tests/test_cc/test_reflection_salvage.py
+++ b/tests/test_cc/test_reflection_salvage.py
@@ -185,8 +185,18 @@ def test_salvage_prompt_exposes_route_consumed_action_fields():
         "procedure_quarantines",
         "skill_triggers",
         "contradictions",
+        "confidence",
     ):
         assert field in _SALVAGE_PROMPT, f"salvage prompt omits route-consumed field {field!r}"
+
+
+def test_salvage_prompt_requires_confidence():
+    """confidence is canonical-required (REFLECTION_DEEP.md) and gates output —
+    a salvage that leaves it optional lets the model omit it, the parser then
+    substitutes the 0.5 sentinel, and the confidence gate passes it uncalibrated.
+    It must sit in the Required block, not Optional."""
+    required_block = _SALVAGE_PROMPT.split("Optional")[0]
+    assert "confidence" in required_block
 
 
 @pytest.mark.asyncio

--- a/tests/test_cc/test_reflection_salvage.py
+++ b/tests/test_cc/test_reflection_salvage.py
@@ -190,13 +190,17 @@ def test_salvage_prompt_exposes_route_consumed_action_fields():
         assert field in _SALVAGE_PROMPT, f"salvage prompt omits route-consumed field {field!r}"
 
 
-def test_salvage_prompt_requires_confidence():
-    """confidence is canonical-required (REFLECTION_DEEP.md) and gates output —
-    a salvage that leaves it optional lets the model omit it, the parser then
-    substitutes the 0.5 sentinel, and the confidence gate passes it uncalibrated.
-    It must sit in the Required block, not Optional."""
+def test_salvage_prompt_requires_full_canonical_set():
+    """The salvage prompt's Required block must be EXACTLY the canonical-required
+    set from REFLECTION_DEEP.md:215 — observations, confidence, and
+    cognitive_state_update. Leaving any of them optional lets the model omit it;
+    the parser then defaults it (empty list / 0.5 sentinel) while the rest of the
+    output makes routing report success, silently losing that field. Locking all
+    three closes the axis (regression: they were moved to Required one-at-a-time
+    across three review rounds)."""
     required_block = _SALVAGE_PROMPT.split("Optional")[0]
-    assert "confidence" in required_block
+    for field in ("observations", "confidence", "cognitive_state_update"):
+        assert field in required_block, f"canonical-required field {field!r} not in Required block"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cc/test_reflection_salvage.py
+++ b/tests/test_cc/test_reflection_salvage.py
@@ -198,7 +198,12 @@ def test_salvage_prompt_requires_full_canonical_set():
     output makes routing report success, silently losing that field. Locking all
     three closes the axis (regression: they were moved to Required one-at-a-time
     across three review rounds)."""
-    required_block = _SALVAGE_PROMPT.split("Optional")[0]
+    # Slice the ACTUAL Required section (between the "Required:" header and the
+    # "Optional" header) — NOT split("Optional")[0], which also captures the
+    # intro sentence that names the fields, so a bullet moved to Optional would
+    # still pass. This asserts each field is a Required BULLET.
+    assert "Required:" in _SALVAGE_PROMPT and "Optional" in _SALVAGE_PROMPT
+    required_block = _SALVAGE_PROMPT.split("Required:")[1].split("Optional")[0]
     for field in ("observations", "confidence", "cognitive_state_update"):
         assert field in required_block, f"canonical-required field {field!r} not in Required block"
 

--- a/tests/test_cc/test_reflection_salvage.py
+++ b/tests/test_cc/test_reflection_salvage.py
@@ -13,6 +13,7 @@ import pytest
 
 from genesis.awareness.types import Depth
 from genesis.cc.reflection_bridge._output import (
+    _SALVAGE_PROMPT,
     _extract_json_obj,
     format_topic_summary,
     salvage_deep_reflection_json,
@@ -164,3 +165,52 @@ def test_topic_summary_handles_bare_untagged_fence():
     summary = format_topic_summary(Depth.DEEP, out)
     assert "was not parseable" not in summary
     assert "Groq EOL resolved" in summary
+
+
+# ── salvage schema parity (Codex #1333 finding B) ──────────────────────
+
+
+def test_salvage_prompt_exposes_route_consumed_action_fields():
+    """The salvage prompt MUST expose every canonical field that route()
+    actually acts on — else a prose-ending reflection that raised a user
+    question or a procedure quarantine would have those actions silently
+    dropped while salvage still reports success. user_question →
+    Telegram notification; procedure_quarantines → a real DB quarantine."""
+    for field in (
+        "cognitive_state_update",
+        "observations",
+        "memory_operations",
+        "surplus_task_requests",
+        "user_question",
+        "procedure_quarantines",
+        "skill_triggers",
+        "contradictions",
+    ):
+        assert field in _SALVAGE_PROMPT, f"salvage prompt omits route-consumed field {field!r}"
+
+
+@pytest.mark.asyncio
+async def test_salvage_roundtrips_user_question_and_quarantines():
+    """A salvaged object carrying a user_question and a procedure_quarantine
+    must survive the router parser intact (the fields route() acts on)."""
+    payload = {
+        "cognitive_state_update": "A decision needs the owner; a procedure is failing.",
+        "observations": ["proc X success rate collapsed"],
+        "confidence": 0.7,
+        "user_question": {
+            "text": "Retire procedure X?",
+            "context": "success rate dropped to 20%",
+            "options": ["retire", "keep"],
+        },
+        "procedure_quarantines": [{"procedure_id": "proc-x", "reason": "declining effectiveness"}],
+    }
+    router = _FakeRouter(json.dumps(payload))
+    salvaged = await salvage_deep_reflection_json(PROSE, router)
+    assert salvaged is not None
+    parsed = parse_deep_reflection_output(salvaged)
+    assert not parsed.parse_failed
+    assert parsed.user_question is not None
+    assert parsed.user_question.text == "Retire procedure X?"
+    assert parsed.procedure_quarantines == [
+        {"procedure_id": "proc-x", "reason": "declining effectiveness"}
+    ]

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -160,7 +160,10 @@ def test_load_full_yaml(monkeypatch):
     # matcher neural-monitor registration).
     # 2026-07-17: 57 → 59 after entity_adjudication + entity_adjudication_challenge
     # added (entity-node merge-vs-distinct drainer).
-    assert len(cfg.call_sites) == 59
+    # 2026-08-07: 59 → 60 after 41_reflection_json_salvage added (deep-reflection
+    # prose-output salvage retry).
+    assert len(cfg.call_sites) == 60
+    assert "41_reflection_json_salvage" in cfg.call_sites  # deep-reflection salvage (2026-08-07)
     assert cfg.call_sites["repo_pulse"].dispatch == "cli"
     assert cfg.call_sites["repo_pulse"].chain == []
     assert cfg.call_sites["repo_pulse"].never_pays is True


### PR DESCRIPTION
## Problem
~40% of deep reflections ended their CC session with a free-form prose wrap-up instead of the required fenced JSON. Both parse sites then failed: the Telegram topic showed a "not parseable" stub, and — worse — the routing path discarded that cycle's cognitive output (`cognitive_state_update`, `observations`, `memory_operations`, `surplus_task_requests`) and marked the run `success=False`. Silent cognitive data loss. All failures were on `claude-sonnet-5` (a prompt-adherence issue, not a model outage).

## Fix
Deterministic post-hoc **salvage**: when a DEEP session's output isn't parseable, re-derive the structured JSON from the prose via one routed LLM call (new call site `41_reflection_json_salvage`), and use it for **both** routing and the topic summary. Raw output is still recorded to `reflection_corpus` for audit. Strictly additive — on already-parseable output, router-unset, call failure, or still-unparseable salvage, behavior is unchanged.

**Unified JSON extraction** (from review): one canonical `extract_reflection_json` (whole-JSON → ` ```json `-tagged-block-anywhere → any-first-fence) now backs the routing parser, the salvage-skip gate, AND the topic summary — eliminating three divergent parsers that could otherwise skip salvage while routing failed, or stub the topic for output that routed fine (e.g. a reflection that quotes a ` ```diff ` block before its ` ```json `).

## Review & verification
2 review rounds (both the parser-divergence class; 2nd was an incomplete-fix completion, now locked — all 3 consumers use one extractor).
- **Live E2E (real providers):** a real failing `reflection_corpus` prose row salvages to valid schema JSON — `cognitive_state_update` and observations recovered, routes cleanly.
- Ruff clean; salvage unit tests + multi-fence + bare-fence regression tests; 279 reflection-suite tests pass.
- Fail-closed paths tested (router None / raises / unsuccessful / still-prose → no-op). Invented `memory_operations` are inert (existing `target_id` validation). Router wiring is live (`set_router` in runtime init; router init precedes reflection init).

**Side-finding filed (`42bdc04a`):** `deepseek-v4-pro` (`nvidia-nim-deepseek`) reached EOL 2026-08-07T09:00Z (HTTP 410) — it leads several live chains (`judge`, `38_procedure_extraction`, `38a`); dropped from this PR's salvage chain, system-wide migration tracked separately.

Follow-up: 15e2f5a8

🤖 Generated with [Claude Code](https://claude.com/claude-code)