### PR TITLE
fix(telegram): nudge instead of confusing on topic-root approval replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Replying "yes" to an approval topic no longer starts a confused new chat.**
+  If you replied "yes"/"approve" to the *topic itself* (the forum topic header)
+  instead of the specific approval/proposal/content message, Genesis got no
+  context and spun up a fresh conversation that answered "I don't have anything
+  to confirm — what are you saying yes to?". It now recognizes that case and
+  asks you to reply to the specific message (or tap its ✅ button) rather than
+  guessing — it deliberately won't act on an ambiguous topic-level reply.
+
 - **Email replies now count as engagement.** When someone replies to an email
   Genesis sent (outreach pitch, follow-up), the reply was recorded for thread
   tracking but never registered as an engagement outcome — so reply rates read

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -1229,6 +1229,63 @@ async def _try_ego_correction_store(ctx: HandlerContext, msg) -> bool:
     return False
 
 
+def _is_topic_root_reply(msg) -> bool:
+    """True if ``msg`` is a reply to a forum topic's ROOT service message rather
+    than to a specific message. Telegram sets ``reply_to_message.message_id`` to
+    the topic id (== ``message_thread_id``) for such replies; the root
+    ``forum_topic_created`` service message carries no ``.text``, so it gives the
+    conversation handler no context to act on."""
+    reply_to = getattr(msg, "reply_to_message", None)
+    thread_id = getattr(msg, "message_thread_id", None)
+    if reply_to is None or thread_id is None:
+        return False
+    return getattr(reply_to, "message_id", None) == thread_id
+
+
+async def _try_topic_root_decision_nudge(ctx: HandlerContext, msg) -> bool:
+    """Catch a bare decision ("yes"/"approve"/…) that quote-replies the ROOT of a
+    decision topic (Approvals / Content Review / Ego Proposals) but matched no
+    pending item. Such a reply carries no item context, so letting it fall through
+    would spawn a confused, context-free conversation session ("no charter — what
+    are you confirming?"). Nudge the user to reply to the specific message instead.
+
+    Deliberately does NOT auto-resolve anything (resolving most-recent-pending
+    from an ambiguous topic-root reply risks acting on the WRONG item). Returns
+    True if the message was consumed (caller should return early)."""
+    if not _is_topic_root_reply(msg) or not msg.text:
+        return False
+    if _bare_decision(msg.text) is None:
+        return False
+    thread_id = getattr(msg, "message_thread_id", None)
+    try:
+        from genesis.runtime import GenesisRuntime
+
+        rt = GenesisRuntime.instance()
+        pipeline = rt.outreach_pipeline
+        if pipeline is None or pipeline.topic_manager is None:
+            return False
+        tm = pipeline.topic_manager
+        decision_threads = {
+            tm.get_thread_id("approvals"),
+            tm.get_thread_id("content_review"),
+            tm.get_thread_id("ego_proposals"),
+        }
+    except Exception:
+        return False
+    if thread_id not in decision_threads:
+        return False
+    try:
+        await msg.reply_text(
+            "You replied to the topic itself, so I can't tell which item you mean. "
+            "Reply directly to the specific message (or tap its ✅ button) to "
+            "act on it."
+        )
+    except Exception:
+        log.debug("Failed to send topic-root decision nudge", exc_info=True)
+    log.info("Topic-root bare decision nudged (thread %s)", thread_id)
+    return True
+
+
 async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes.DEFAULT_TYPE):
     user = update.effective_user
     if not user or not ctx.authorized(user.id):
@@ -1356,6 +1413,12 @@ async def handle_text(ctx: HandlerContext, update: Update, context: ContextTypes
                         exc_info=True,
                     )
             return
+
+    # A bare decision quote-replying a decision topic's ROOT (not a specific
+    # item) matched nothing above — nudge instead of spawning a context-free
+    # conversation session. No-op for anything else.
+    if await _try_topic_root_decision_nudge(ctx, msg):
+        return
 
     # Record implicit engagement: user is active after receiving outreach
     if ctx.engagement_tracker and ctx.db:

--- a/src/genesis/channels/telegram/_handler_messages.py
+++ b/src/genesis/channels/telegram/_handler_messages.py
@@ -22,7 +22,7 @@ from genesis.channels.telegram._handler_helpers import (
 )
 from genesis.channels.telegram.transport.streaming import DraftStreamer, generate_draft_id
 from genesis.channels.telegram.transport.update_dedupe import message_key
-from genesis.util.approval_words import scoped_decision
+from genesis.util.approval_words import phrase_decision, scoped_decision
 
 if TYPE_CHECKING:
     from genesis.channels.telegram._handler_context import HandlerContext
@@ -1254,7 +1254,11 @@ async def _try_topic_root_decision_nudge(ctx: HandlerContext, msg) -> bool:
     True if the message was consumed (caller should return early)."""
     if not _is_topic_root_reply(msg) or not msg.text:
         return False
-    if _bare_decision(msg.text) is None:
+    # Whole-message matcher (NOT the leading-token _bare_decision): a topic-root
+    # reply is not scoped to any item, so "yes, but shorten the title" / "no, what
+    # else?" carry a real instruction that must fall through to conversation — only
+    # a standalone bare decision ("yes"/"approve"/👍) should trigger the nudge.
+    if phrase_decision(msg.text) is None:
         return False
     thread_id = getattr(msg, "message_thread_id", None)
     try:

--- a/tests/test_channels/test_topic_root_nudge.py
+++ b/tests/test_channels/test_topic_root_nudge.py
@@ -90,3 +90,23 @@ async def test_nudge_skips_non_decision_topic():
     with _patch_topics(THREADS):
         assert await _try_topic_root_decision_nudge(MagicMock(), msg) is False
     msg.reply_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "yes, but shorten the title",
+        "no, what alternatives do we have?",
+        "ok change the wording though",
+    ],
+)
+async def test_nudge_skips_decision_prefixed_substantive_reply(text):
+    """A decision-token PREFIX followed by a real instruction must fall through
+    to conversation, NOT be swallowed by the nudge. The nudge uses the
+    whole-message matcher, so only a standalone bare decision triggers it —
+    the leading-token matcher would wrongly consume the instruction here."""
+    msg = _msg(text, 100, 100)  # topic-root reply in the Approvals topic
+    with _patch_topics(THREADS):
+        assert await _try_topic_root_decision_nudge(MagicMock(), msg) is False
+    msg.reply_text.assert_not_called()

--- a/tests/test_channels/test_topic_root_nudge.py
+++ b/tests/test_channels/test_topic_root_nudge.py
@@ -1,0 +1,92 @@
+"""Tests for the topic-root bare-decision nudge.
+
+A bare "yes"/"approve" that quote-replies a decision topic's ROOT (not a
+specific item) matches no pending item and, without this guard, would spawn a
+context-free conversation session ("no charter — what are you confirming?").
+The nudge intercepts it and asks the user to reply to the specific message —
+without auto-resolving anything (which would risk acting on the wrong item).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.channels.telegram._handler_messages import (
+    _is_topic_root_reply,
+    _try_topic_root_decision_nudge,
+)
+
+THREADS = {"approvals": 100, "content_review": 200, "ego_proposals": 300}
+
+
+def _msg(text, thread_id, reply_to_id):
+    m = MagicMock()
+    m.text = text
+    m.message_thread_id = thread_id
+    if reply_to_id is None:
+        m.reply_to_message = None
+    else:
+        reply = MagicMock()
+        reply.message_id = reply_to_id
+        m.reply_to_message = reply
+    m.reply_text = AsyncMock()
+    return m
+
+
+def _patch_topics(threads):
+    tm = MagicMock()
+    tm.get_thread_id.side_effect = lambda k: threads.get(k)
+    rt = MagicMock()
+    rt.outreach_pipeline = MagicMock()
+    rt.outreach_pipeline.topic_manager = tm
+    return patch("genesis.runtime.GenesisRuntime.instance", return_value=rt)
+
+
+def test_is_topic_root_reply():
+    assert _is_topic_root_reply(_msg("yes", 100, 100)) is True  # reply_to == thread
+    assert _is_topic_root_reply(_msg("yes", 100, 101)) is False  # specific message
+    assert _is_topic_root_reply(_msg("yes", None, 100)) is False  # not a topic
+    assert _is_topic_root_reply(_msg("yes", 100, None)) is False  # not a reply
+
+
+@pytest.mark.asyncio
+async def test_nudge_fires_on_topic_root_bare_decision():
+    msg = _msg("approve", 100, 100)  # topic-root reply in the Approvals topic
+    with _patch_topics(THREADS):
+        assert await _try_topic_root_decision_nudge(MagicMock(), msg) is True
+    msg.reply_text.assert_awaited_once()
+    assert "specific message" in msg.reply_text.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_nudge_fires_in_content_review_and_ego_topics():
+    for thread in (THREADS["content_review"], THREADS["ego_proposals"]):
+        msg = _msg("yes", thread, thread)
+        with _patch_topics(THREADS):
+            assert await _try_topic_root_decision_nudge(MagicMock(), msg) is True
+
+
+@pytest.mark.asyncio
+async def test_nudge_skips_non_decision_text():
+    """A substantive topic-root message still falls through to conversation."""
+    msg = _msg("what is the status of the pending items here?", 100, 100)
+    with _patch_topics(THREADS):
+        assert await _try_topic_root_decision_nudge(MagicMock(), msg) is False
+    msg.reply_text.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_nudge_skips_specific_message_reply():
+    """A quote-reply to a SPECIFIC message is left to the real resolvers."""
+    msg = _msg("approve", 100, 555)
+    with _patch_topics(THREADS):
+        assert await _try_topic_root_decision_nudge(MagicMock(), msg) is False
+
+
+@pytest.mark.asyncio
+async def test_nudge_skips_non_decision_topic():
+    """Topic-root bare decision in a non-decision topic → not our concern."""
+    msg = _msg("approve", 999, 999)
+    with _patch_topics(THREADS):
+        assert await _try_topic_root_decision_nudge(MagicMock(), msg) is False
+    msg.reply_text.assert_not_called()


### PR DESCRIPTION
## Problem
Replying a bare "yes"/"approve" to a forum **topic root** (the topic header) instead of the specific approval/proposal/content message matched no resolver in `handle_text` and fell through to a fresh, context-free CC conversation session. The topic-root service message has no `.text`, so the session saw only a naked "yes" and replied "I don't have anything to confirm — what are you saying yes to?".

## Fix (scope: minimal-safe — nudge only)
Detect the topic-root reply (`reply_to_message.message_id == message_thread_id`) in a decision topic (`approvals`/`content_review`/`ego_proposals`) that parses as a bare decision but matched nothing, and reply with a nudge to reply to the specific message (or tap ✅). It **deliberately does not auto-resolve** — resolving most-recent-pending from an ambiguous topic-root reply risks acting on the *wrong* item.

The fuller fix (a structured content-approval resolution with a terminal-state column + publish-idempotency, so a topic reply can safely resolve a specific content item) is deferred to its own design follow-up — content approvals currently have no resolver at all and rely on emergent CC re-derivation.

## Review & verification
1 review round, **clean**. Verified: correct topic-root signal; no false-positive interception (specific-message replies and substantive messages fall through); ordering masks no real resolver; nudge-only / no writes; fail-closed on runtime unavailability. Ruff clean; 6 nudge tests + 74 telegram-handler regression tests pass.

Partially addresses follow-up 8785140f (the confusing-fresh-session half). Bug A (CLI-approval topic-root fallback) and the structured content-approval resolution remain in that follow-up.

Follow-up: 8785140f

🤖 Generated with [Claude Code](https://claude.com/claude-code)