### PR TITLE
fix(routing): curated free-pool openrouter-free + cost-mislabel guard + dead-slug cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   and extraction quality are unchanged; triage-depth labeling may shift by about one
   level on some items. No action needed on your end.
 
+### Fixed
+
+- **A "free" fallback model that was quietly a paid one.** An OpenRouter fallback
+  used by several background steps was labeled free but pointed at a paid model, so
+  on the rare occasions it was reached it could incur spend that Genesis recorded as
+  $0. It now uses a curated pool of genuinely-free models with automatic failover,
+  and Genesis warns at startup if any provider marked "free" actually points at a
+  paid model — so cost tracking can't silently miss real spend. No action needed on
+  your end.
+
 ### Added
 
 - **GitHub activity notifications.** Genesis now watches your active GitHub repos

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -693,47 +693,25 @@ profiles:
     last_reviewed: "2026-06-22"
     review_source: manual
 
-  qwen-2.5-72b:
-    display_name: "Qwen 2.5 72B Instruct"
-    provider: alibaba
-    api_id: "qwen/qwen-2.5-72b-instruct"
-    intelligence_tier: B
-    reasoning: B
-    instruction_following: A
-    anti_sycophancy: B
-    context_window: 131072
-    cost_tier: free
-    cost_per_mtok_in: 0.0
-    cost_per_mtok_out: 0.0
-    latency: moderate
-    strengths:
-      - structured output (reliable JSON)
-      - multilingual capability
-      - free tier on OpenRouter
-    weaknesses:
-      - reasoning depth vs frontier models
-      - creative tasks
-    best_for: [memory_consolidation, fact_extraction, triage, surplus_brainstorm]
-    avoid_for: [deep_reflection, strategic_reflection, foreground_conversation]
-    free_tier:
-      available: true
-      provider: openrouter
-      limits: "free tier variant"
-    last_reviewed: "2026-03-26"
-    review_source: manual
+  # NOTE (2026-08-07): the qwen-2.5-72b profile was removed — openrouter-free no
+  # longer points at qwen/qwen-2.5-72b-instruct (repointed to a curated gemma /
+  # nemotron :free pool), leaving this profile orphaned. See gemma-4-26b below.
 
-  mimo-v2-pro:
-    display_name: "MiMo V2 Pro"
+  mimo-v2.5-pro:
+    display_name: "MiMo V2.5 Pro"
     provider: xiaomi
-    api_id: "xiaomi/mimo-v2-pro"
+    api_id: "xiaomi/mimo-v2.5-pro"
     intelligence_tier: A
     reasoning: A
     instruction_following: A
     anti_sycophancy: B
     context_window: 131072
     cost_tier: cheap
-    cost_per_mtok_in: 0.60
-    cost_per_mtok_out: 2.40
+    # OpenRouter endpoints range ~$0.35-$1.00 in / ~$0.70-$3.00 out per MTok
+    # (2026-08-07). litellm's own DB prices this model, so completion_cost handles
+    # it directly; these are the cost-fallback figures (conservative upper end).
+    cost_per_mtok_in: 1.0
+    cost_per_mtok_out: 3.0
     latency: moderate
     strengths:
       - mathematical reasoning (strong chain-of-thought)
@@ -747,7 +725,7 @@ profiles:
     avoid_for: [foreground_conversation, outreach_draft, creative_writing]
     free_tier:
       available: false
-    last_reviewed: "2026-03-26"
+    last_reviewed: "2026-08-07"
     review_source: manual
 
   deepseek-v3:
@@ -1045,34 +1023,36 @@ profiles:
     last_reviewed: "2026-04-14"
     review_source: manual
 
-  qwen3-coder:
-    display_name: "Qwen3-Coder 480B"
-    provider: alibaba
-    api_id: "qwen/qwen3-coder:free"
+  # gemma-4-26b — primary of the curated openrouter-free :free pool (2026-08-07).
+  # Replaced the orphaned qwen3-coder profile (its qwen/qwen3-coder:free slug was
+  # delisted; the provider was unwired and removed from model_routing.yaml).
+  gemma-4-26b:
+    display_name: "Gemma 4 26B A4B (MoE)"
+    provider: google
+    api_id: "google/gemma-4-26b-a4b-it:free"
     intelligence_tier: B
     reasoning: B
     instruction_following: B
-    anti_sycophancy: C
+    anti_sycophancy: B
     context_window: 262144
     cost_tier: free
     cost_per_mtok_in: 0.0
     cost_per_mtok_out: 0.0
     latency: moderate
     strengths:
-      - code-specialized (SWE-bench 69.6)
-      - large MoE architecture (480B params, 35B active)
-      - 256k context window
+      - reliable structured output / JSON (10/10 on the structured_output golden set, 2026-08-07)
+      - token-efficient (no reasoning-token bloat, clean JSON at tight max_tokens)
+      - genuinely free (:free OpenRouter endpoint)
     weaknesses:
-      - code-focused, weaker on general reasoning
-      - benchmark data sparse (no GPQA/MMLU-Pro scores)
-      - quality unverified for Genesis tasks
-    best_for: [code_work, code_audit]
-    avoid_for: [deep_reflection, strategic_reflection, triage]
+      - smaller MoE, less nuance than 70B+ dense models
+      - creative writing
+    best_for: [extraction, classification, tagging, fact_extraction, surplus_brainstorm]
+    avoid_for: [deep_reflection, strategic_reflection]
     free_tier:
       available: true
       provider: openrouter
-      limits: "OpenRouter free tier (20 RPM, 200-1000 RPD)"
-    last_reviewed: "2026-04-14"
+      limits: "OpenRouter :free endpoint (curated openrouter-free primary; nemotron-3-super-120b:free failover)"
+    last_reviewed: "2026-08-07"
     review_source: manual
 
   deepseek-r1:

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -52,20 +52,11 @@ providers:
     params:
       extra_body:
         reasoning_effort: low
-  # GROUNDWORK: gpt-oss-120b — a free reasoning option for reasoning/JSON-heavy
-  # chains. Defined + tested (per-provider param plumbing), not yet wired into
-  # any chain; wiring is a separate routing-rebalance change.
-  groq-oss-120b:
-    type: groq
-    model: openai/gpt-oss-120b
-    profile: gpt-oss-120b
-    free: true
-    rpm_limit: 30
-    open_duration_s: 120
-    params:
-      extra_body:
-        include_reasoning: false
-        reasoning_effort: low
+  # NOTE (2026-08-07): the standalone groq-oss-120b GROUNDWORK alias was removed
+  # here — its purpose (a free gpt-oss-120b reasoning hop) is now fulfilled by
+  # groq-free itself, which serves openai/gpt-oss-120b after the 2026-08-06 llama
+  # migration. Two aliases on one shared Groq free-tier bucket with independent
+  # circuit breakers was a redundant footgun; consolidated to groq-free.
   gemini-free:
     type: google
     # GA stable (was gemini-3-flash-preview; gemini-3.5-flash is Google's own
@@ -83,12 +74,28 @@ providers:
     params:
       reasoning_effort: disable
   openrouter-free:
+    # Curated free-pool hop (2026-08-07): repointed off qwen/qwen-2.5-72b-instruct
+    # — that BARE slug is PAID on OpenRouter (~$0.36/$0.40 per MTok, verified live)
+    # yet was flagged free:true since the public release, so a successful call
+    # billed while the router recorded $0 (is_free zeroes cost). Now a curated
+    # OpenRouter free pool: primary gemma-4-26b-a4b:free (10/10 on the
+    # structured_output golden set, token-efficient), server-side failover to
+    # nemotron-3-super-120b:free (10/10 with token headroom). Both :free ⇒
+    # genuinely $0. The extra_body.models array is OpenRouter's fallback across
+    # ONLY these vetted models — deliberately NOT the openrouter/free auto-router,
+    # which routes onto JSON-broken tiny/safety models (measured 6/10). If both
+    # die, Genesis's own chain fallback takes over.
     type: openrouter
-    model: qwen/qwen-2.5-72b-instruct
-    profile: qwen-2.5-72b
+    model: google/gemma-4-26b-a4b-it:free
+    profile: gemma-4-26b
     free: true
     rpm_limit: 20
     open_duration_s: 120
+    params:
+      extra_body:
+        models:
+          - google/gemma-4-26b-a4b-it:free
+          - nvidia/nemotron-3-super-120b-a12b:free
   openrouter-haiku:
     type: openrouter
     model: anthropic/claude-haiku-4.5
@@ -153,13 +160,9 @@ providers:
     free: true
     rpm_limit: 20
     open_duration_s: 120
-  openrouter-qwen3coder:
-    type: openrouter
-    model: qwen/qwen3-coder:free
-    profile: qwen3-coder
-    free: true
-    rpm_limit: 8  # Actual OpenRouter limit (high-demand Venice backend)
-    open_duration_s: 120
+  # NOTE (2026-08-07): openrouter-qwen3coder removed — its qwen/qwen3-coder:free
+  # slug is delisted (0 OpenRouter endpoints, verified live) and it was wired
+  # into no chain, so it was dead weight. Drop rather than repoint.
   openrouter-deepseek-v4:
     type: openrouter
     model: deepseek/deepseek-v4-pro
@@ -182,9 +185,12 @@ providers:
     rpm_limit: 20
     open_duration_s: 120
   openrouter-mimo:
+    # 2026-08-07: repointed xiaomi/mimo-v2-pro (delisted, 0 endpoints, verified
+    # live) → mimo-v2.5-pro (7 live endpoints). Last fallback rung of the
+    # currently-disabled 36_code_auditor, so correctness hygiene, not an active fix.
     type: openrouter
-    model: xiaomi/mimo-v2-pro
-    profile: mimo-v2-pro
+    model: xiaomi/mimo-v2.5-pro
+    profile: mimo-v2.5-pro
     free: false
     rpm_limit: 20
     open_duration_s: 120

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1040,7 +1040,7 @@ How every LLM call picks a provider, and the registry for non-LLM tools.
 ```yaml subsystem-map
 entry: routing-providers
 modules: [routing, providers]
-verified: 9037d45b 2026-07-07
+verified: 409338c9 2026-08-07
 ```
 
 - **routing/**: `config/model_routing.yaml` defines ~54 numbered call sites,
@@ -1057,7 +1057,9 @@ verified: 9037d45b 2026-07-07
   silent non-registration is by design (absence ≠ bug). LLM breaker/health
   logic lives in routing, not here. No embedding provider registered → memory
   silently degrades to FTS5-only.
-- GROUNDWORK: gpt-oss-120b provider defined but unwired into any chain.
+- A load-time guard warns if an `openrouter` provider flagged `free: true` points
+  at a non-`:free` (paid) slug — the openrouter-free billing blind spot
+  (`_detect_mislabeled_free_openrouter`, config-only, visibility not gating).
 
 ## 12. Platform & data
 

--- a/docs/eval/benchmark-results.md
+++ b/docs/eval/benchmark-results.md
@@ -1,6 +1,6 @@
 # Model Benchmark Results
 
-Last updated: 2026-08-06
+Last updated: 2026-08-07
 
 Benchmark methodology: 3 datasets (classification, extraction, structured_output)
 with 37 total cases. Scores are `passed/attempted` — skipped cases (rate limits,
@@ -29,7 +29,7 @@ Best run per provider. Providers marked (free) cost $0; others are paid.
 | Provider | Reason | Status |
 |---|---|---|
 | openrouter-deepseek-r1 | Free endpoint removed from OpenRouter (2026-04-15). Provider entry removed from routing config 2026-05-24. | Removed |
-| openrouter-qwen3coder | Returns HTTP 401 "No cookie auth credentials found" on all requests — the Qwen3-Coder free endpoint appears to require browser/cookie auth, not API key (retested 2026-04-16 off-peak) | Disable or investigate |
+| openrouter-qwen3coder | qwen/qwen3-coder:free delisted (0 OpenRouter endpoints, verified live 2026-08-07); provider was unwired. Entry removed from routing config 2026-08-07. | Removed |
 
 ## Key Findings
 

--- a/src/genesis/routing/config.py
+++ b/src/genesis/routing/config.py
@@ -181,6 +181,54 @@ def _expand_env_vars(text: str) -> str:
     return _ENV_PATTERN.sub(repl, text)
 
 
+# OpenRouter free-tier convention: a genuinely-free model carries a ":free"
+# slug suffix; a BARE slug routes to PAID endpoints. So an OpenRouter provider
+# flagged `free: true` whose slug is NOT ":free"-suffixed is a mislabel — a paid
+# model billed at OpenRouter while the router records $0 (`is_free` zeroes cost),
+# so real spend is invisible (the openrouter-free regression, 2026-08). This
+# allowlist holds genuine $0 OpenRouter endpoints that legitimately lack the
+# ":free" suffix (the free-pool meta-router).
+_FREE_OPENROUTER_ALLOWLIST = frozenset({"openrouter/free"})
+
+
+def _detect_mislabeled_free_openrouter(
+    providers: dict[str, ProviderConfig],
+) -> list[str]:
+    """Return warning strings for OpenRouter providers flagged ``free: true``
+    whose model slug — or any curated ``params.extra_body.models`` fallback
+    member — is not ``:free``-suffixed (and not an allowlisted $0 meta-router).
+
+    A config-only, load-time guard (no profile/network dependency). It does NOT
+    gate routing — visibility only, per "cost is observability, not control".
+
+    Scoped to OpenRouter deliberately: the ``:free`` slug convention is
+    OpenRouter-specific. Other providers are free-by-account-tier and
+    legitimately keep list prices in their model_profiles, so a
+    profile-rate-based check would false-positive on them.
+    """
+    findings: list[str] = []
+    for name, cfg in providers.items():
+        if not cfg.is_free or cfg.provider_type != "openrouter":
+            continue
+        slugs = [cfg.model_id]
+        params = cfg.params if isinstance(cfg.params, dict) else {}
+        extra = params.get("extra_body")
+        models = extra.get("models") if isinstance(extra, dict) else None
+        if isinstance(models, list):
+            slugs.extend(m for m in models if isinstance(m, str))
+        suspect = [
+            s
+            for s in slugs
+            if not s.endswith(":free") and s not in _FREE_OPENROUTER_ALLOWLIST
+        ]
+        if suspect:
+            findings.append(
+                f"{name}: free:true but OpenRouter slug(s) are not ':free' "
+                f"(paid endpoint — bills while tracked as $0): {suspect}"
+            )
+    return findings
+
+
 def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
     """Parse raw YAML dict into a validated RoutingConfig."""
     if not isinstance(raw, dict):
@@ -251,6 +299,12 @@ def _parse(raw: dict, *, check_api_keys: bool = True) -> RoutingConfig:
             )
 
         providers[name] = cfg
+
+    # Class-fix guard (2026-08): warn loudly if any OpenRouter provider is
+    # flagged free:true but points at a paid (non-":free") slug — the
+    # openrouter-free billing blind spot. Visibility only; never gates routing.
+    for _finding in _detect_mislabeled_free_openrouter(providers):
+        logger.warning("Mislabeled free provider — %s", _finding)
 
     # --- Call sites ---
     call_sites: dict[str, CallSiteConfig] = {}

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -128,10 +128,15 @@ def test_load_full_yaml(monkeypatch):
     # 2026-06-23: 28 → 29 after groq-oss-120b added (free reasoning option,
     # not yet wired into any chain).
     # 2026-06-23 (WS2b): 29 → 28 after removing expired openrouter-trinity-free.
-    assert len(cfg.providers) == 28
+    # 2026-08-07: 28 → 26 after removing the redundant groq-oss-120b GROUNDWORK
+    # alias (groq-free now serves gpt-oss-120b post-migration) + the dead,
+    # unwired openrouter-qwen3coder (delisted qwen/qwen3-coder:free slug).
+    assert len(cfg.providers) == 26
     assert "lmstudio-30b" not in cfg.providers
     assert "github-o3mini" not in cfg.providers
     assert "openrouter-deepseek-r1" not in cfg.providers  # removed from config
+    assert "groq-oss-120b" not in cfg.providers  # removed 2026-08-07 (redundant w/ groq-free)
+    assert "openrouter-qwen3coder" not in cfg.providers  # removed 2026-08-07 (dead slug, unwired)
     # Call sites evolve — assert actual count matches config, and lock in
     # a few load-bearing ids rather than chasing the total on every edit.
     # 2026-05-10: 44 → 43 after net change (judge added by #304, 2_triage +
@@ -237,6 +242,32 @@ def test_load_full_yaml(monkeypatch):
     assert gf.model_id == "openai/gpt-oss-120b"
     assert gf.profile == "gpt-oss-120b"
     assert gf.params == {"extra_body": {"reasoning_effort": "low"}}
+
+    # openrouter-free provider — REPOINTED 2026-08-07 off the bare (paid)
+    # qwen/qwen-2.5-72b-instruct slug (flagged free:true but bills at OpenRouter)
+    # to a curated OpenRouter :free pool: gemma-4-26b-a4b primary +
+    # nemotron-3-super-120b failover via extra_body.models. Both :free ⇒ $0.
+    orf = cfg.providers["openrouter-free"]
+    assert orf.is_free is True
+    assert orf.provider_type == "openrouter"
+    assert orf.model_id == "google/gemma-4-26b-a4b-it:free"
+    assert orf.model_id.endswith(":free")  # the mislabel guard must pass on it
+    assert orf.profile == "gemma-4-26b"
+    assert orf.params == {
+        "extra_body": {
+            "models": [
+                "google/gemma-4-26b-a4b-it:free",
+                "nvidia/nemotron-3-super-120b-a12b:free",
+            ]
+        }
+    }
+    # The shipped config must be clean per the mislabel guard — no OpenRouter
+    # free-flagged provider pointing at a paid (non-:free) slug. Regression lock:
+    # reintroducing the openrouter-free bug (or a paid slug in a curated pool)
+    # fails here.
+    from genesis.routing.config import _detect_mislabeled_free_openrouter
+
+    assert _detect_mislabeled_free_openrouter(cfg.providers) == []
 
 
 def test_retry_profiles_under_watchdog_threshold():
@@ -623,3 +654,58 @@ def test_sanitize_drops_local_call_site_absent_from_base():
     result = _sanitize_local_overlay(base, local)
     assert "7_ego_cycle" not in (result.get("call_sites") or {})
     assert "live_site" in result["call_sites"]
+
+
+def test_detect_mislabeled_free_openrouter_flags_paid_slug_marked_free():
+    """Class-fix guard: a `type:openrouter` provider flagged free:true whose slug
+    (or any curated `params.extra_body.models` member) is not `:free` is a
+    paid-slug-mislabeled-free billing leak (the openrouter-free bug). The guard
+    must flag it while NOT flagging genuine `:free` slugs, the `openrouter/free`
+    meta-router, or non-openrouter free providers (which are free-by-account-tier
+    and legitimately carry list prices in their profiles)."""
+    from genesis.routing.config import _detect_mislabeled_free_openrouter
+    from genesis.routing.types import ProviderConfig
+
+    def pc(name, ptype, model, free, params=None):
+        return ProviderConfig(
+            name=name,
+            provider_type=ptype,
+            model_id=model,
+            is_free=free,
+            rpm_limit=None,
+            open_duration_s=120,
+            params=params,
+        )
+
+    providers = {
+        # THE BUG: paid OpenRouter slug (no :free) flagged free -> silent billing
+        "or-paid-as-free": pc("or-paid-as-free", "openrouter", "qwen/qwen-2.5-72b-instruct", True),
+        # OK: genuine :free slug
+        "or-free-ok": pc("or-free-ok", "openrouter", "google/gemma-4-26b-a4b-it:free", True),
+        # OK: the free-pool meta-router (allowlisted — genuinely $0, no :free suffix)
+        "or-meta": pc("or-meta", "openrouter", "openrouter/free", True),
+        # OK: non-openrouter free provider (free-by-account-tier; :free convention N/A)
+        "groq-ok": pc("groq-ok", "groq", "openai/gpt-oss-120b", True),
+        # OK: not free -> paid providers legitimately bill
+        "or-paid": pc("or-paid", "openrouter", "anthropic/claude-opus-4.6", False),
+        # THE BUG hiding in a curated pool: a paid slug in extra_body.models
+        "or-curated-bad": pc(
+            "or-curated-bad",
+            "openrouter",
+            "google/gemma-4-26b-a4b-it:free",
+            True,
+            params={
+                "extra_body": {
+                    "models": [
+                        "google/gemma-4-26b-a4b-it:free",  # ok
+                        "qwen/qwen-2.5-72b-instruct",  # paid, no :free -> must be caught
+                    ]
+                }
+            },
+        ),
+    }
+    flagged = _detect_mislabeled_free_openrouter(providers)
+    # findings are "<name>: <reason>" — compare the leading names as a set
+    # (substring checks collide: "or-paid" is inside "or-paid-as-free").
+    flagged_names = {f.split(":", 1)[0] for f in flagged}
+    assert flagged_names == {"or-paid-as-free", "or-curated-bad"}, flagged


### PR DESCRIPTION
## Why

`openrouter-free` — the most heavily-wired free fallback in the routing config (14 call
sites) — was pointed at the **bare** OpenRouter slug `qwen/qwen-2.5-72b-instruct`, which
resolves to **paid** endpoints (~$0.36/$0.40 per MTok, verified live), yet the provider was
flagged `free: true`. Because the delegate zeroes cost for `is_free` providers, a successful
call bills at OpenRouter while Genesis records **$0** — a silent cost blind spot. (Actual
impact to date ≈ $0: the hop is deep fallback and had never completed a call.) The bare slug
has been mislabeled since the public-release commit.

## What

- **Repoint `openrouter-free` to a curated OpenRouter `:free` pool.** Primary
  `google/gemma-4-26b-a4b:free`, server-side failover to
  `nvidia/nemotron-3-super-120b-a12b:free`, via OpenRouter's `extra_body.models` array. Both
  are genuinely $0, so `free: true` is now honest. The alias name is unchanged, so all 14
  chains inherit the repoint with no chain edits.
- **Load-time mislabel guard** (`_detect_mislabeled_free_openrouter`, `routing/config.py`):
  warns when any `type: openrouter` provider flagged `free: true` points at a non-`:free`
  (paid) slug — including any curated `extra_body.models` member — with `openrouter/free`
  (the $0 meta-router) allowlisted. Visibility only; it never gates routing
  ("cost is observability, not control"). This makes the mislabel class impossible to
  reintroduce silently on any install.
- **Dead-slug + redundancy cleanup:** repoint `openrouter-mimo` `xiaomi/mimo-v2-pro`
  (delisted, 0 endpoints) → `xiaomi/mimo-v2.5-pro` (live); remove the dead, unwired
  `openrouter-qwen3coder` (`qwen/qwen3-coder:free` delisted); remove the now-redundant
  `groq-oss-120b` GROUNDWORK alias (its reserved purpose — a free `gpt-oss-120b` reasoning
  hop — is fulfilled by `groq-free`, which serves `gpt-oss-120b` after the recent
  migration). Profiles reconciled accordingly (drop orphaned `qwen-2.5-72b`/`qwen3-coder`;
  rename `mimo-v2-pro`→`mimo-v2.5-pro`; add `gemma-4-26b`).

## Model chosen empirically

`openrouter/free` (the free-pool auto-router) was evaluated and **rejected**: on the
`structured_output` golden set it scored **6/10**, because it routes across a heterogeneous
pool that includes non-JSON models (a content-safety classifier; an empty-returning tiny
model). Pinned candidates on the same set: `gemma-4-26b-a4b:free` **10/10** (token-efficient,
no reasoning bloat), `nemotron-3-super-120b:free` **10/10** (with token headroom),
`gemma-4-31b:free` rate-limited (already saturated via `openrouter-gemma4`). The curated
two-model pool gives the resilience of a pool with the quality control of a shortlist —
verified live: routing stays within the shortlist and fails over correctly when the primary
is unavailable.

## Guard scope (deliberate)

The guard is OpenRouter-specific. The "paid slug marked free" mislabel is an OpenRouter
`:free`-convention phenomenon; other providers are free-by-account-tier and legitimately
keep list prices in their `model_profiles` (e.g. `mistral-large-free`, `gemini-free`), so a
profile-rate-based check would false-positive on them — it was considered and dropped.

## Tests

- New guard unit test (verify-RED then GREEN): flags a paid slug in the `model` field or a
  curated `models` member; does not flag `:free` slugs, the `openrouter/free` meta-router, or
  non-openrouter free providers.
- Regression lock: the shipped config is asserted guard-clean (`_detect_...(cfg.providers) == []`).
- Provider count assertion updated 28 → 26; `openrouter-free` config pinned.
- `tests/test_routing/` — 327 passed. ruff clean. Live routed `openrouter-free` call returns
  clean JSON on `gemma-4-26b` with `cost_usd=0.0`.

Closes follow-ups: openrouter-free cost blind spot; dead `openrouter-qwen3coder`;
`groq-free`/`groq-oss-120b` consolidation; the dead-`mimo` part of the model-roster hygiene
sweep (stale-version *upgrades* remain tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
