### PR TITLE
fix(ego): calibrate proposal auto-table to a generous backstop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   and extraction quality are unchanged; triage-depth labeling may shift by about one
   level on some items. No action needed on your end.
 
+- **Stale ego proposals get tabled on a generous backstop.** Ego proposals you
+  haven't acted on move to the recoverable *tabled* lane on a per-urgency
+  schedule (roughly 10 days for critical up to 30 for low) — a backstop behind
+  the ego's ongoing reconcile review, tuned to sit well past normal decision
+  time so it only clears the genuinely-forgotten. Tabling is reversible, never
+  deletion.
+
 ### Added
 
 - **GitHub activity notifications.** Genesis now watches your active GitHub repos

--- a/src/genesis/db/crud/ego.py
+++ b/src/genesis/db/crud/ego.py
@@ -1038,19 +1038,21 @@ async def auto_table_stale_proposals(
     db: aiosqlite.Connection,
     ttl_hours: dict | None = None,
     *,
-    unranked_cap_hours: int = 120,
+    unranked_cap_hours: int = 336,
 ) -> int:
     """Auto-table pending proposals older than their per-urgency staleness
     window, moving them to the recoverable 'tabled' cold lane.
 
-    Urgency-based window (config ``auto_table_ttl_hours``), replacing the old
-    flat 14-day threshold: stale genesis investigations lingered 6-9 days below
-    14d and were approved on self-healed signals (2026-08-06 dispatch review).
+    Urgency-based window (config ``auto_table_ttl_hours``). A BACKSTOP behind the
+    reconcile cycle (which withdraws stale/invalid proposals each pass), NOT the
+    primary staleness mechanism — windows sit generously above observed user
+    decision-latency (median ~1-2d, tail to ~12d; 2026-08-06 review) so only
+    truly-abandoned proposals are swept, never the normal-cadence tail.
     'tabled' is NOT deletion — the ego can un-table, and a still-relevant
     proposal is re-derived fresh next cycle. Unranked proposals (never put on
     the board → lower priority) age out faster, capped at
-    ``unranked_cap_hours`` (default 5d, preserving the prior behaviour).
-    Keeps intervention_journal in sync (same pattern as
+    ``unranked_cap_hours`` (default 14d — a shorter floor than the ranked
+    windows). Keeps intervention_journal in sync (same pattern as
     :func:`expire_stale_proposals`).
 
     Returns count of auto-tabled proposals.
@@ -1061,7 +1063,7 @@ async def auto_table_stale_proposals(
 
             ttl_hours = load_ego_config().auto_table_ttl_hours
         except Exception:  # config unreadable — fall back to safe defaults
-            ttl_hours = {"critical": 48, "high": 72, "normal": 120, "low": 168}
+            ttl_hours = {"critical": 240, "high": 336, "normal": 504, "low": 720}
 
     now_dt = datetime.now(UTC)
     cursor = await db.execute(

--- a/src/genesis/ego/types.py
+++ b/src/genesis/ego/types.py
@@ -196,17 +196,20 @@ class EgoConfig:
     revalidation_interval_hours: dict = field(
         default_factory=lambda: {"critical": 6, "high": 48, "normal": 72, "low": 168}
     )
-    # Auto-table staleness window, per-urgency hours: how long a pending
-    # proposal may sit before auto_table_stale_proposals moves it to the
-    # recoverable 'tabled' cold lane (NOT deleted — the ego can un-table, and a
-    # still-relevant proposal is re-derived fresh next cycle). Urgency-based,
-    # replacing the old flat 14-day threshold: stale genesis investigations
-    # lingered 6-9 days below 14d and were approved on self-healed signals
-    # (2026-08-06 dispatch review). Values sit at/under the prior 14d backstop.
-    # Defaults-COMPLETE mapping (merged over defaults on load). Unranked
-    # proposals (never boarded) age out faster via a floor (see the sweep).
+    # Auto-table staleness window, per-urgency HOURS (critical 240=10d, high
+    # 336=14d, normal 504=21d, low 720=30d): how long a pending proposal may sit
+    # before auto_table_stale_proposals moves it to the recoverable 'tabled'
+    # cold lane (NOT deleted — the ego can un-table, and a still-relevant
+    # proposal is re-derived fresh next cycle). This is a BACKSTOP behind the
+    # reconcile cycle (which already withdraws stale/invalid proposals each
+    # pass), NOT the primary staleness mechanism — so windows sit generously
+    # ABOVE observed user decision-latency (median ~1-2d, tail to ~12d;
+    # 2026-08-06 review) to catch only the truly-abandoned, never to amputate the
+    # normal-cadence tail. Defaults-COMPLETE mapping (merged over defaults on
+    # load). Unranked proposals (never boarded) age out via a shorter floor (see
+    # the sweep's unranked_cap_hours).
     auto_table_ttl_hours: dict = field(
-        default_factory=lambda: {"critical": 48, "high": 72, "normal": 120, "low": 168}
+        default_factory=lambda: {"critical": 240, "high": 336, "normal": 504, "low": 720}
     )
     # Additive ego autonomy — cap on ACTIVE goals in the genesis ego's OWN
     # lane (origin='genesis_ego'). Pausing frees a slot; the paused tail is

--- a/src/genesis/identity/GENESIS_EGO_SESSION.md
+++ b/src/genesis/identity/GENESIS_EGO_SESSION.md
@@ -118,8 +118,9 @@ After 24 hours, table items you no longer recommend. Withdraw only
 genuinely invalid proposals (factually wrong, superseded by events).
 
 Proposals pending too long are auto-tabled by the system on a per-urgency
-staleness window (roughly 2 days for critical up to 7 for low; unranked
-proposals age out sooner). Tabling is recoverable, not deletion.
+staleness window (roughly 10 days for critical up to 30 for low; unranked
+proposals age out sooner) — a backstop behind the reconcile cycle, not the
+primary staleness path. Tabling is recoverable, not deletion.
 
 ## Execution
 

--- a/src/genesis/identity/USER_EGO_SESSION.md
+++ b/src/genesis/identity/USER_EGO_SESSION.md
@@ -244,8 +244,9 @@ reasoning rather than withdrawing and re-proposing.
 ### Queue Health
 
 Proposals pending too long are auto-tabled by the system on a per-urgency
-staleness window (roughly 2 days for critical up to 7 for low; unranked
-proposals age out sooner). Tabling is recoverable, not deletion.
+staleness window (roughly 10 days for critical up to 30 for low; unranked
+proposals age out sooner) — a backstop behind the reconcile cycle, not the
+primary staleness path. Tabling is recoverable, not deletion.
 If the queue exceeds 15 pending proposals, consider:
 - Tabling lower-priority items (they can be resurfaced later)
 - Combining related proposals into one

--- a/tests/ego/test_config.py
+++ b/tests/ego/test_config.py
@@ -82,10 +82,10 @@ class TestLoadEgoConfig:
         tmp_config.write_text(yaml.dump({"auto_table_ttl_hours": {"high": 24}}))
         config = load_ego_config(tmp_config)
         assert config.auto_table_ttl_hours == {
-            "critical": 48,
+            "critical": 240,
             "high": 24,
-            "normal": 120,
-            "low": 168,
+            "normal": 504,
+            "low": 720,
         }
 
 


### PR DESCRIPTION
## What
Amends #1331. Recalibrates the per-urgency ego-proposal auto-table windows from the aggressive as-merged profile to a generous **backstop** profile.

| urgency | #1331 (as-merged) | this PR |
|---|---|---|
| critical | 48h (2d) | 240h (10d) |
| high | 72h (3d) | 336h (14d) |
| normal | 120h (5d) | 504h (21d) |
| low | 168h (7d) | 720h (30d) |
| unranked floor | 120h (5d) | 336h (14d) |

## Why
The #1331 windows were set without calibration against real cadence. Measured decision-latency for user-actioned proposals is **median ~1-2 days, tail to ~12 days**, and the reconcile cycle already withdraws stale/invalid proposals each pass (89 withdrawn vs 44 ever tabled). So age-based auto-table is a **backstop behind reconcile**, not the primary staleness mechanism — the windows should sit *above* the ~12d tail so they only clear the genuinely-forgotten, never amputate the normal-cadence tail. Under the new windows, no currently-pending proposal is swept on deploy.

## Scope
Config defaults + safe-fallback dict + `unranked_cap_hours` default + docstring + both identity-doc copy + CHANGELOG. **Mechanism unchanged** (same TOCTOU guard, same journal-sync, same sweep).

## Test
- `tests/ego/test_config.py` merge assertion updated to new defaults; validators unchanged.
- `tests/ego/test_proposal_lifecycle.py::TestAutoTableStaleProposals` (explicit-window mechanism tests, decoupled by design) + `test_defaults_to_config` (30d normal > 21d → still tables) — 51 passed.
- Runtime config load verified: defaults resolve to 240/336/504/720, unranked 336.
- Reviewed clean (feature-dev:code-reviewer, DONE, no findings).

Post-merge: deploy (server restart) + live E2E confirming the sweep tables a seeded stale proposal and spares fresh ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)