### PR TITLE
fix(cc): steer dispatch durable-learning to Genesis memory, not MEMORY.md

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -286,7 +286,7 @@ _PROFILE_ADDENDA: dict[str, str] = {
 
 You have: Write, browser MCP tools, memory MCP tools, outreach send.
 You do NOT have: Edit, Bash, NotebookEdit.
-Your final message IS your deliverable. Write files to `~/.genesis/output/`.
+Your final message IS your deliverable. Write files to `~/.genesis/output/`. Persist durable learnings to Genesis memory (`procedure_store` / `observation_write`) — NEVER by writing or editing a `MEMORY.md` index (a dedicated consolidation job owns that file; a hand-edit truncates it and loses the other sessions' context).
 
 {_MISSION_INJECTION}
 """,
@@ -296,7 +296,7 @@ Your final message IS your deliverable. Write files to `~/.genesis/output/`.
 
 You have: Write, memory MCP tools, web tools (web_search, web_fetch).
 You do NOT have: Edit, Bash, NotebookEdit, browser tools.
-Your final message IS your deliverable. Write files to `~/.genesis/output/`.
+Your final message IS your deliverable. Write files to `~/.genesis/output/`. Persist durable learnings to Genesis memory (`procedure_store` / `observation_write`) — NEVER by writing or editing a `MEMORY.md` index (a dedicated consolidation job owns that file; a hand-edit truncates it and loses the other sessions' context).
 
 {_MISSION_INJECTION}
 """,
@@ -316,7 +316,7 @@ Your final message IS your deliverable.
 
 You have: Write, memory MCP tools, web tools, outreach_send.
 You do NOT have: Edit, Bash, NotebookEdit, browser tools.
-Your final message IS your deliverable. Write files to `~/.genesis/output/`.
+Your final message IS your deliverable. Write files to `~/.genesis/output/`. Persist durable learnings to Genesis memory (`procedure_store` / `observation_write`) — NEVER by writing or editing a `MEMORY.md` index (a dedicated consolidation job owns that file; a hand-edit truncates it and loses the other sessions' context).
 
 {_MISSION_INJECTION}
 """,

--- a/tests/test_cc/test_direct_session_profiles.py
+++ b/tests/test_cc/test_direct_session_profiles.py
@@ -237,6 +237,22 @@ def test_addenda_do_not_mention_reference_store_for_persistence():
         )
 
 
+def test_write_profiles_steer_persistence_to_genesis_memory():
+    """Write+memory investigation profiles must steer durable learnings to
+    Genesis memory (procedure_store/observation_write) and away from hand-editing
+    the CC MEMORY.md index. Background dispatches share one cwd-isolated memory
+    index (separate from the foreground index) that a full-file Write truncates,
+    losing other sessions' consolidated context (2026-08-06 review)."""
+    for profile in ("interact", "research", "campaign"):
+        addendum = _PROFILE_ADDENDA[profile]
+        assert "procedure_store" in addendum, (
+            f"{profile} addendum should point durable learnings at Genesis memory"
+        )
+        assert "MEMORY.md" in addendum, (
+            f"{profile} addendum should warn against editing the MEMORY.md index"
+        )
+
+
 def test_all_addenda_include_mission_injection():
     """All non-perimeter profiles must include the adapt-and-overcome mission text."""
     _PERIMETER_PROFILES = {"mail"}


### PR DESCRIPTION
## What
Adds one guidance sentence to the `interact`, `research`, and `campaign` dispatch-session profile addenda (`_PROFILE_ADDENDA` in `src/genesis/cc/direct_session.py`): persist durable learnings to Genesis memory (`procedure_store`/`observation_write`), never by hand-editing a `MEMORY.md` index. Plus a regression test pinning the guidance in all three.

## Why (root cause — corrected)
Ego-dispatch sessions run with cwd `~/.genesis/background-sessions`, so CC scopes their file-memory to a **separate** project dir from the user's foreground index. Three 2026-08-06 dispatches truncated *that shared-among-dispatches* index via full-file Write (dispatch profiles grant Write but not Edit), losing consolidated context until the next (irregular) consolidation.

A prior follow-up (`0361719f`) framed this as corrupting the user's *shared/live* memory index — that was a **mislabel** (the dirs are cwd-isolated, inode-distinct; no dispatch code references the shared path). No data-integrity risk to user memory, no data repair needed; the follow-up was corrected HIGH→medium.

## Why guidance-only (not a hook)
A PreToolUse block on Write→MEMORY.md would also block the **legitimate** consolidation job that regenerates the index. Steering the three investigation profiles (the only ones with Write + memory tools) is the clean fix; the tools named are reachable for exactly those profiles (they lack `_NO_MEMORY_WRITES`).

## Test
`test_write_profiles_steer_persistence_to_genesis_memory` — RED on main (base addenda contain neither `procedure_store` nor `MEMORY.md`), green here. Full profiles suite: 88 passed. Reviewed clean (feature-dev:code-reviewer, DONE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)