### PR TITLE
fix(voice): strip inline markdown from voice context before S2S

### DIFF
--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -24,6 +24,8 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from genesis.channels.tts_config import SanitizationSettings, sanitize_for_speech
+
 if TYPE_CHECKING:
     from genesis.channels.voice.handler import VoiceConversationHandler
 
@@ -666,4 +668,10 @@ def _extract_voice_context(ek_text: str, max_chars: int = 500) -> str:
                 context_lines.append(clean)
 
     result = ". ".join(context_lines)
+    if result:
+        # Strip inline markdown (bold/links/inline-code) so the S2S model never
+        # vocalizes "star star" or a raw URL. Reuse the voice-channel sanitizer;
+        # disable its own truncation (max_chars=0) so the caller's max_chars
+        # stays authoritative.
+        result = sanitize_for_speech(result, SanitizationSettings(max_chars=0))
     return result[:max_chars] if result else ""

--- a/tests/test_channels/test_voice_s2s.py
+++ b/tests/test_channels/test_voice_s2s.py
@@ -1476,3 +1476,41 @@ class TestVoiceActValidator:
         assert _validate_voice_act({"mode": "bananas"})
         assert _validate_voice_act({"enabled": "false"})
         assert _validate_voice_act({"bogus": 1})
+
+
+class TestExtractVoiceContext:
+    """_extract_voice_context strips markdown so the S2S model never vocalizes
+    'star star' or a raw URL (regression for the identity-slice bold/link bug)."""
+
+    def test_strips_bold_inline_code_and_links(self):
+        from genesis.channels.voice.genesis_bridge import _extract_voice_context
+
+        ek = (
+            "### Active Context\n"
+            "- Shipping **the voice pipeline** and [the dashboard](https://example.test/x)\n"
+            "- Reviewing `the config` module\n"
+            "### Next Section\n"
+            "- Should be ignored\n"
+        )
+        out = _extract_voice_context(ek)
+        # No raw markdown reaches the S2S model.
+        assert "*" not in out
+        assert "](" not in out
+        assert "`" not in out
+        assert "https://" not in out
+        # Content words survive the strip.
+        assert "the voice pipeline" in out
+        assert "the dashboard" in out
+        # The following section is excluded.
+        assert "ignored" not in out
+
+    def test_plain_bullets_unchanged(self):
+        from genesis.channels.voice.genesis_bridge import _extract_voice_context
+
+        out = _extract_voice_context("### Active Context\n- First item\n- Second item\n")
+        assert out == "First item. Second item"
+
+    def test_empty_when_no_active_context(self):
+        from genesis.channels.voice.genesis_bridge import _extract_voice_context
+
+        assert _extract_voice_context("### Other\n- x\n") == ""


### PR DESCRIPTION
## What
`_extract_voice_context()` (`src/genesis/channels/voice/genesis_bridge.py`) builds the spoken "what you've been working on" context from the essential-knowledge Active Context section, but only did `lstrip('- ')` — leaving inline `**bold**` and `[text](url)` markdown that the S2S model vocalizes as "star star" / raw URLs.

## Fix
Reuse the existing voice-channel sanitizer `sanitize_for_speech` (`channels/tts_config.py`) on the joined result, with `SanitizationSettings(max_chars=0)` so the sanitizer's own truncation is disabled and the caller's `[:max_chars]` slice stays the sole truncation point. Mirrors the identity-slice fix (B2 / #1236) for the sibling extractor, and stays consistent with `handler.py`/`_delivery.py`/`tts.py` which already use this sanitizer.

## Test
New `TestExtractVoiceContext` (markdown-strip + content-preservation + section-boundary + empty-state). Verified E2E by direct execution: OLD output keeps `**bold**`/`[link](url)`; NEW = `Shipping the voice pipeline and the dashboard. Reviewing the config module`. Reviewed clean (feature-dev:code-reviewer, DONE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)