### PR TITLE
fix(routing): surface the legacy degradation fallback instead of silent

### DIFF
--- a/src/genesis/routing/circuit_breaker.py
+++ b/src/genesis/routing/circuit_breaker.py
@@ -358,7 +358,23 @@ class CircuitBreakerRegistry:
                 return DegradationLevel.ESSENTIAL
             return DegradationLevel.NORMAL
 
-        # Legacy provider-count fallback (no essential map injected).
+        # Legacy provider-count fallback (no essential map injected). In a
+        # correctly-configured install the essential map is always present
+        # (build_essential_provider_map), so reaching here in production means it
+        # came back empty (a misconfig that essential.py already logs at build
+        # time) and degradation is now the count-based heuristic that can
+        # false-alarm "all paid down => ESSENTIAL". Surface it ONCE per instance
+        # so the fallback is never silent; bare unit-test registries legitimately
+        # hit this and warn once, which is harmless.
+        if not getattr(self, "_legacy_degradation_warned", False):
+            logger.warning(
+                "Degradation is running the LEGACY provider-count fallback: no "
+                "essential-site map was injected. In production this means "
+                "build_essential_provider_map returned empty (a misconfiguration) "
+                "and coverage-based degradation is disabled — cloud degradation may "
+                "false-alarm. Verify the essential provider config."
+            )
+            self._legacy_degradation_warned = True
         cloud_providers = [
             name
             for name, cfg in self._providers.items()

--- a/tests/test_routing/test_circuit_breaker.py
+++ b/tests/test_routing/test_circuit_breaker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 from genesis.routing.circuit_breaker import (
     _MAX_OPEN_S,
@@ -395,6 +396,33 @@ def test_degradation_l5_all_ollama_down():
         for _ in range(3):
             reg.get(name).record_failure(ErrorCategory.TRANSIENT)
     assert reg.compute_degradation_level() == DegradationLevel.LOCAL_COMPUTE_DOWN
+
+
+def test_legacy_degradation_path_warns_once(caplog):
+    """Entering the count-based legacy fallback (no essential map injected)
+    surfaces a one-time warning so a misconfigured install is not silently
+    mis-degrading — but the warning does not repeat on the same instance."""
+    providers = {"a": _provider("a"), "b": _provider("b")}
+    reg = CircuitBreakerRegistry(providers, clock=lambda: 0)
+    with caplog.at_level(logging.WARNING, logger="genesis.routing.circuit_breaker"):
+        reg.compute_degradation_level()
+        reg.compute_degradation_level()  # second call must NOT re-warn
+    hits = [r for r in caplog.records if "LEGACY provider-count fallback" in r.message]
+    assert len(hits) == 1
+
+
+def test_coverage_degradation_path_does_not_warn(caplog):
+    """With an essential-site map injected, the coverage path is used and the
+    legacy-fallback warning never fires."""
+    providers = {
+        "p1": _provider("p1", "openrouter"),
+        "p2": _provider("p2", "google", is_free=True),
+    }
+    essential = {"9_fact_extraction": ["p1", "p2"]}
+    reg = CircuitBreakerRegistry(providers, clock=lambda: 0, essential_sites=essential)
+    with caplog.at_level(logging.WARNING, logger="genesis.routing.circuit_breaker"):
+        reg.compute_degradation_level()
+    assert not [r for r in caplog.records if "LEGACY provider-count fallback" in r.message]
 
 
 # --- Save/load round-trip tests ---


### PR DESCRIPTION
## What
`CircuitBreakerRegistry.compute_degradation_level()` has a legacy provider-count fallback that runs only when **no** essential-site map was injected. It's inert in a correctly-configured install (the map is always built via `build_essential_provider_map` at `runtime/init/router.py`), but if it's ever reached in production it means a misconfig/wiring bug — and degradation silently switches to a count-based heuristic that can false-alarm "all paid providers down ⇒ ESSENTIAL".

## Fix
Emit a **once-per-instance** `logger.warning` when the legacy fallback is entered, so the condition is surfaced instead of silent (provision-or-surface). No behavior change beyond the log line; bare unit-test registries legitimately hit this path and warn once (harmless).

## Why it's not redundant
`essential.py` only errors when `build_essential_provider_map` returns an *empty* dict (config-content bug). This warning also covers a **distinct** failure mode: a caller constructing the registry without going through that builder at all (a wiring bug).

## Test
Two caplog tests: warns-once on the legacy path (no re-warn on the same instance); no-warn when an essential map is present. Existing `test_degradation_l0/l1/l2/l3/l5` unaffected (13 degradation tests green). Reviewed clean (feature-dev:code-reviewer, DONE).

Honest note: low-value/low-risk defensive hardening of an inert path — shipped for completeness of the ego-reliability sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)