### PR TITLE
feat(contribution): Contributor Work-Log — sanitized public-issue supply for contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Contributor Work-Log — a curated supply of newcomer-friendly public issues.**
+  Genesis can now turn items from its own backlog or a codebase scan into public
+  GitHub issues for contributors to pick up — but never on its own say-so. Each
+  draft is sanitized server-side (a fail-closed scan of the title, body, *and*
+  labels blocks anything that looks like a private address, path, or secret) and
+  then held for your per-item approval on the dashboard; batch "approve all"
+  deliberately skips these, so every public post is an individual decision. It
+  ships in `propose_only` mode: drafts are proposed and approved but never
+  actually posted (dry-run) until you flip `mode: live` in a
+  `config/contributor_worklog.local.yaml` overlay. Once live, an approved draft
+  posts via `gh issue create`, de-duplicated against already-open issues so a
+  retry can't double-post. Kill switch: `GENESIS_CONTRIBUTOR_WORKLOG_DISABLED=1`.
+
 - **GitHub activity notifications.** Genesis now watches your active GitHub repos
   every couple of hours and pings you on Telegram when an *external* contributor
   opens their first PR/issue, comments, starts a discussion, or replies on one —

--- a/config/contributor_worklog.yaml
+++ b/config/contributor_worklog.yaml
@@ -1,0 +1,35 @@
+# Contributor Work-Log poster — public-issue supply for contributors.
+#
+# The poster drain re-reads the merged config (this file +
+# ~/.genesis/config/contributor_worklog.local.yaml) on EVERY tick, so a
+# settings_update("contributor_worklog", {...}) or a hand edit takes effect at
+# the next drain (no restart). The `contributor_issue_propose` MCP tool reads
+# the same lever.
+#
+# Master switch: false forces `off` from both consumers.
+enabled: true
+
+# Mode: off | propose_only | live
+#   off          — the tool refuses to propose; the drain does nothing.
+#   propose_only — (default, shipped posture) the tool proposes issues + holds
+#                  each for owner approval; on approval the drain shadow-observes
+#                  the egress ONCE and marks the hold `dry_run` (TERMINAL — never
+#                  posted). Flipping to `live` does NOT retro-post dry_run rows;
+#                  re-run the curator under `live` to actually post.
+#   live         — on approval the drain calls `gh issue create` on the public
+#                  repo, captures the issue number, and marks `posted`.
+#
+# An INVALID mode degrades to propose_only — never a silent `live` to a public
+# repo. Kill switch (separate lever): GENESIS_CONTRIBUTOR_WORKLOG_DISABLED=1
+# forces `off` regardless of this file.
+mode: propose_only
+
+# Terminal rows (posted / rejected / expired / dry_run) older than this are
+# pruned by scripts/disk_hygiene.sh. Held rows are NEVER pruned (they await
+# owner action).
+retention_days: 30
+
+# Backpressure: the `contributor_issue_propose` tool refuses a new proposal once
+# this many rows are still `held` (awaiting owner review). Keeps the approval
+# queue bounded so drafts don't pile up faster than they're reviewed.
+max_held: 25

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -289,7 +289,7 @@ gated — that contract is one-directional.
 ```yaml subsystem-map
 entry: autonomy-egress
 modules: [autonomy, outreach, distribution, content, campaigns]
-verified: 9037d45b 2026-07-07
+verified: 2f0239cb 2026-08-07
 ```
 
 - **The chokepoint is `outreach/pipeline.py _deliver`** — ~12 send paths
@@ -306,6 +306,21 @@ verified: 9037d45b 2026-07-07
   (hold-for-approval) is the designed next stage. CI
   backstop: `scripts/check_external_io.py` fails on new ungated egress
   endpoints.
+- **The Contributor Work-Log posts public GitHub issues, gated like email.** A
+  server-side MCP tool (`contributor_issue_propose`, genesis-health) sanitizes a
+  curator-drafted issue via the fail-closed `contribution/sanitize.py scan_prose`
+  (title+body+labels — every string that egresses), then HOLDS it: the
+  `approval_requests` row FIRST, then `pending_issue_posts` (mirroring the email
+  gate). Each hold is per-item owner-approved on the dashboard (excluded from
+  `approve_all_pending`, like email). The `contributor_issue_watcher` drain
+  (every 5 min, learning scheduler) resolves approved holds under the
+  `contributor_worklog` mode lever (`autonomy/contributor_worklog_config.py`,
+  default `propose_only`): `live` → `gh issue create` (shadow-gated door
+  `observe_github_issue_create`, `mark_posted` BEFORE `mark_consumed` +
+  pre-post `gh issue list` dedup for idempotency); `propose_only` → dry-run
+  terminal (never posts). Terminal rows pruned >30d via
+  `scripts/prune_contributor_issue_posts.py`; held rows never pruned. The
+  curator campaigns are LOCAL user data (uncommitted).
 - **`content/egress.py gate()` is LIVE** in the pipeline: anti-slop scrub +
   PII scan for EXTERNAL channels and `content`-category drafts only. Never
   applied to owner channels — don't add them.

--- a/scripts/disk_hygiene.sh
+++ b/scripts/disk_hygiene.sh
@@ -21,6 +21,9 @@
 #      (WS2-0 retrieval-efficacy report; dated md per run — file-age prune)
 #  10. Retention prune of ego_proposal_revisions (ego_reconcile config window)
 #      → scripts/prune_proposal_revisions.py (PR-5 reconcile revision audit)
+#  11. Retention prune of pending_issue_posts terminal rows (>30d)
+#      → scripts/prune_contributor_issue_posts.py (Contributor Work-Log hold
+#      store; held rows never pruned)
 #
 # Note: run under a hardened systemd sandbox (NoNewPrivileges, ProtectSystem=
 # strict), so disk_reclaim's --system (/var, sudo) path is intentionally NOT
@@ -125,6 +128,10 @@ main() {
     echo "--- repo pulse retention prune (>45d) ---"
     "$VENV_PY" "$REPO_DIR/scripts/prune_repo_pulse.py" --days 45 \
         || echo "prune_repo_pulse exited $?"
+
+    echo "--- contributor work-log terminal-row prune (>30d) ---"
+    "$VENV_PY" "$REPO_DIR/scripts/prune_contributor_issue_posts.py" --days 30 \
+        || echo "prune_contributor_issue_posts exited $?"
 
     echo "--- ego proposal-revision audit retention prune (ego_reconcile config) ---"
     "$VENV_PY" "$REPO_DIR/scripts/prune_proposal_revisions.py" \

--- a/scripts/prune_contributor_issue_posts.py
+++ b/scripts/prune_contributor_issue_posts.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Retention prune for pending_issue_posts (Contributor Work-Log hold store).
+
+Deletes TERMINAL rows (posted / rejected / expired / dry_run) older than a
+retention window (default 30 days) so the hold store stays bounded. ``held``
+rows are NEVER pruned — they await owner action indefinitely. Invoked by
+``scripts/disk_hygiene.sh`` (the genesis-disk-hygiene.timer); also runnable by
+hand. Best-effort — a failure here must not skip other hygiene steps.
+
+Mirrors ``scripts/prune_capability_shadow.py`` — same retention shape.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO_DIR = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+
+async def _prune(days: int) -> int:
+    from genesis.db.connection import get_raw_db
+    from genesis.db.crud.pending_issue_posts import prune_terminal
+
+    now = datetime.now(UTC).isoformat()
+    async with get_raw_db() as conn:
+        return await prune_terminal(conn, older_than_days=days, now=now)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="retention window in days (terminal rows older than this are deleted)",
+    )
+    args = ap.parse_args()
+    try:
+        deleted = asyncio.run(_prune(args.days))
+        print(
+            f"contributor_issue_posts prune: deleted {deleted} terminal row(s) "
+            f"older than {args.days}d"
+        )
+    except Exception as exc:
+        print(f"contributor_issue_posts prune error: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -487,16 +487,24 @@ class AutonomousCliApprovalGate:
     async def approve_all_pending(self, *, resolved_by: str) -> int:
         """Approve every pending approval request.  Returns count approved.
 
-        WS-8 email capability-gate holds are EXCLUDED: each held email is an
-        independent send decision and must be approved individually, never
-        swept by a batch "approve all".
+        Per-item-only action types are EXCLUDED from the batch sweep — each is
+        an independent, irreversible external decision that must be approved
+        individually, never swept by a single "approve all" click (dashboard
+        button OR Telegram ``cli_approve_all``, which both funnel here):
+
+        - WS-8 email capability-gate holds (each held email is one send).
+        - Contributor Work-Log issue holds (each is one public-repo post).
         """
+        from genesis.autonomy.contributor_worklog_config import (
+            CONTRIBUTOR_ISSUE_ACTION_TYPE,
+        )
         from genesis.autonomy.email_gate import EMAIL_GATE_ACTION_TYPE
 
+        excluded = {EMAIL_GATE_ACTION_TYPE, CONTRIBUTOR_ISSUE_ACTION_TYPE}
         pending = await self._approval_manager.get_pending()
         count = 0
         for req in pending:
-            if req.get("action_type") == EMAIL_GATE_ACTION_TYPE:
+            if req.get("action_type") in excluded:
                 continue
             ok = await self._approval_manager.resolve(
                 req["id"], status="approved", resolved_by=resolved_by,

--- a/src/genesis/autonomy/contributor_issue_watcher.py
+++ b/src/genesis/autonomy/contributor_issue_watcher.py
@@ -1,0 +1,272 @@
+"""Contributor Work-Log resolution watcher — drains held issue posts.
+
+Mirrors the WS-8 email gate watcher (:mod:`genesis.autonomy.email_gate_watcher`).
+A periodic drain (``CronTrigger`` */5min, ``max_instances=1`` — no in-drain
+races) resolves each ``pending_issue_posts`` ``held`` row against its linked
+approval, honoring the ``contributor_worklog`` mode lever (read live each tick):
+
+- **approved + ``live``**       → post the issue to GitHub below the gate + mark posted.
+- **approved + ``propose_only``**→ shadow-observe once + mark ``dry_run`` (TERMINAL — never
+  posted; a later flip to ``live`` does NOT retro-post it, by design).
+- **approved + ``off``**         → leave held (poster paused).
+- **rejected / cancelled**       → mark rejected.
+- **expired**                    → mark expired (no-decision, not a rejection).
+- **orphaned** (approval gone)   → expire, never post.
+- **pending**                    → still awaiting the owner; leave held.
+
+Public-repo dup-safety (stronger than the email pattern, because a duplicate
+public issue is more visible than a duplicate email):
+
+1. ``mark_posted`` runs BEFORE ``mark_consumed`` — a crash after the GitHub post
+   can't re-post next cycle, because the row has already left ``held`` (and
+   ``list_held`` won't return it).
+2. A pre-post ``gh issue list`` open-issue dedup doubles as crash-idempotency:
+   a normalized title already open on the repo is ADOPTED (mark_posted with its
+   number) instead of re-created — so a crash in the narrow window between
+   ``gh issue create`` and ``mark_posted`` self-heals on the next cycle rather
+   than opening a second issue. If the dedup LIST call fails we do NOT post
+   (can't verify) — the row stays held and retries next cycle.
+
+The drain reads ONLY the sanitized ``pending_issue_posts`` row (never re-reads
+any source), so the read-private / write-public boundary is enforced at the
+table. ``gh`` uses ambient server-side auth (same idiom as
+``contribution/pr_opener``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from datetime import UTC, datetime
+
+from genesis.autonomy import shadow_gate
+from genesis.autonomy.contributor_worklog_config import (
+    effective_mode,
+    normalize_title,
+)
+from genesis.db.crud import approval_requests as approval_crud
+from genesis.db.crud import pending_issue_posts as pip
+
+logger = logging.getLogger(__name__)
+
+_ISSUE_NUM_RE = re.compile(r"/issues/(\d+)\b")
+# GROUNDWORK(autonomous-distribution): the GitHub issue-create egress door. Every
+# autonomous external post routes through the shadow-gate (observe) before the gh
+# call; the capability cell is observe-only today (enforce stage later).
+_GH_TIMEOUT = 60
+
+
+def _run_gh(args: list[str], *, timeout: int = _GH_TIMEOUT) -> tuple[int, str, str]:
+    """Run ``gh <args>`` server-side (list-args, no shell, ambient auth). Returns
+    ``(returncode, stdout, stderr)``. A timeout/missing-binary maps to a non-zero
+    rc with a message on stderr — never raises."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", f"gh timed out after {timeout}s"
+    except FileNotFoundError:
+        return 127, "", "gh binary not found"
+
+
+def _issue_number_from_url(url: str) -> int | None:
+    m = _ISSUE_NUM_RE.search(url or "")
+    return int(m.group(1)) if m else None
+
+
+def _find_open_issue_by_title(repo: str, title_norm: str) -> tuple[bool, dict | None]:
+    """Look for an OPEN issue on *repo* whose normalized title matches. Returns
+    ``(ok, issue|None)`` — ``ok=False`` means the lookup itself failed (caller
+    must NOT post, since dedup can't be verified).
+
+    Scope note: ``--limit 200`` covers the 200 most-recently-created open issues
+    (gh's default order). This fully covers the crash-idempotency case (a just-
+    created issue is necessarily recent). The only gap is a PRE-EXISTING open
+    issue (human- or long-ago-opened) with a matching title on a repo with >200
+    OPEN issues — well beyond current scale, and the DB-side dedup already stops
+    Genesis re-proposing its own. Tracked for a search-based upgrade before the
+    repo approaches that ceiling (follow-up)."""
+    rc, out, err = _run_gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            "number,title,url",
+            "--limit",
+            "200",
+        ]
+    )
+    if rc != 0:
+        logger.warning("gh issue list failed for %s rc=%s: %s", repo, rc, err.strip())
+        return False, None
+    try:
+        issues = json.loads(out or "[]")
+    except (ValueError, TypeError):
+        logger.warning("gh issue list returned unparseable JSON for %s", repo)
+        return False, None
+    for issue in issues:
+        if normalize_title(issue.get("title", "")) == title_norm:
+            return True, issue
+    return True, None
+
+
+def _create_issue(
+    repo: str, title: str, body: str, labels: list[str]
+) -> tuple[int | None, str | None, str | None]:
+    """Create the issue via ``gh issue create``. Returns ``(number, url, error)``;
+    ``error`` non-None means the create failed and nothing was posted."""
+    args = ["issue", "create", "--repo", repo, "--title", title, "--body", body]
+    for label in labels:
+        args += ["--label", label]
+    rc, out, err = _run_gh(args)
+    if rc != 0:
+        return None, None, (err or out or "unknown gh error").strip()
+    url = out.strip().splitlines()[-1] if out.strip() else None
+    if not url:
+        return None, None, "gh issue create returned no URL"
+    return _issue_number_from_url(url), url, None
+
+
+def _labels_of(row: dict) -> list[str]:
+    raw = row.get("labels")
+    if not raw:
+        return []
+    try:
+        val = json.loads(raw)
+        return [str(x) for x in val] if isinstance(val, list) else []
+    except (ValueError, TypeError):
+        return []
+
+
+async def _resolve_approved(rt_db, row: dict, mode: str, now: str) -> bool:
+    """Handle an approved hold under the current mode. Returns True iff the row
+    was resolved (posted / dry-run / adopted). Leaves the row held (returns
+    False) on a transient failure so it retries next cycle."""
+    repo = row["repo"]
+    title = row["title"]
+    body = row["body"]
+
+    if mode == "propose_only":
+        # Dry-run-terminal: shadow-observe the egress ONCE (observe-before-enforce)
+        # and mark the hold terminal. NEVER posts; a later flip to live won't
+        # retro-post it.
+        await shadow_gate.observe_github_issue_create(
+            rt_db,
+            path="autonomy.contributor_issue_watcher.dry_run",
+            verb=row["cell_verb"],
+            risk_class=row["cell_risk_class"],
+            target=repo,
+            content=f"{title}\n\n{body}",
+        )
+        if await pip.mark_dry_run(rt_db, row["id"], dry_run_at=now):
+            await approval_crud.mark_consumed(rt_db, row["request_id"], consumed_at=now)
+            logger.info("Contributor issue %s dry-run (propose_only) — not posted", row["id"])
+            return True
+        return False
+
+    # mode == "live": actually post.
+    title_norm = normalize_title(title)
+    ok, existing = _find_open_issue_by_title(repo, title_norm)
+    if not ok:
+        # Dedup couldn't be verified — do NOT post (would risk a duplicate). Retry.
+        return False
+    if existing is not None:
+        # Already open (a prior cycle posted then crashed before mark_posted, OR a
+        # human/other path opened it). Adopt it — idempotent, no second issue.
+        num = existing.get("number") or _issue_number_from_url(existing.get("url", ""))
+        if await pip.mark_posted(
+            rt_db, row["id"], issue_number=num, issue_url=existing.get("url"), posted_at=now
+        ):
+            await approval_crud.mark_consumed(rt_db, row["request_id"], consumed_at=now)
+            logger.info(
+                "Contributor issue %s adopted existing open issue #%s (dedup/idempotency)",
+                row["id"],
+                num,
+            )
+            return True
+        return False
+
+    # Observe the egress, THEN post. mark_posted BEFORE mark_consumed so a crash
+    # after the post can't re-post (the row leaves 'held').
+    await shadow_gate.observe_github_issue_create(
+        rt_db,
+        path="autonomy.contributor_issue_watcher.post",
+        verb=row["cell_verb"],
+        risk_class=row["cell_risk_class"],
+        target=repo,
+        content=f"{title}\n\n{body}",
+    )
+    number, url, error = _create_issue(repo, title, body, _labels_of(row))
+    if error is not None:
+        logger.warning("Contributor issue %s post failed — retry next cycle: %s", row["id"], error)
+        return False
+    if await pip.mark_posted(rt_db, row["id"], issue_number=number, issue_url=url, posted_at=now):
+        await approval_crud.mark_consumed(rt_db, row["request_id"], consumed_at=now)
+        logger.info("Contributor issue %s posted → %s (#%s)", row["id"], url, number)
+        return True
+    return False
+
+
+async def drain_pending_issue_posts(rt: object) -> int:
+    """Resolve all held contributor-issue posts. Returns the number resolved.
+
+    ``off`` mode short-circuits (poster paused — every hold left untouched).
+    """
+    db = getattr(rt, "_db", None)
+    if db is None:
+        return 0
+
+    mode = effective_mode()
+    if mode == "off":
+        return 0
+
+    resolved = 0
+    for row in await pip.list_held(db):
+        now = datetime.now(UTC).isoformat()
+        approval = await approval_crud.get_by_id(db, row["request_id"])
+
+        if approval is None:
+            # Orphaned hold — the approval row vanished. Never post.
+            if await pip.mark_rejected(db, row["id"], rejected_at=now, expired=True):
+                resolved += 1
+            logger.warning("Contributor issue %s orphaned (approval missing) — expired", row["id"])
+            continue
+
+        status = approval.get("status")
+        if status == "approved":
+            if approval.get("consumed_at") is not None:
+                # Approval already consumed but hold still held: a prior cycle
+                # posted+consumed but crashed before the terminal mark. Under the
+                # dup-safe ordering (mark_posted BEFORE mark_consumed) this is
+                # unreachable for a real post, but guard anyway — expire the hold
+                # without re-posting.
+                if await pip.mark_rejected(db, row["id"], rejected_at=now, expired=True):
+                    resolved += 1
+                logger.warning(
+                    "Contributor issue %s approval already consumed — expired without re-post",
+                    row["id"],
+                )
+                continue
+            if await _resolve_approved(db, row, mode, now):
+                resolved += 1
+        elif status in ("rejected", "cancelled"):
+            if await pip.mark_rejected(db, row["id"], rejected_at=now):
+                resolved += 1
+        elif status == "expired":
+            if await pip.mark_rejected(db, row["id"], rejected_at=now, expired=True):
+                resolved += 1
+        # status == 'pending' → still awaiting the owner; leave held.
+
+    return resolved

--- a/src/genesis/autonomy/contributor_worklog_config.py
+++ b/src/genesis/autonomy/contributor_worklog_config.py
@@ -1,0 +1,136 @@
+"""Contributor Work-Log control surface — live-read mode lever + constants.
+
+The ONE place the Work-Log poster consults for policy (repo_pulse_config
+lineage). The Work-Log turns curated backlog/codebase items into public
+GitHub issues, gated behind per-item owner approval:
+
+- :func:`effective_mode` — ``off | propose_only | live``, re-read from the
+  merged YAML (``config/contributor_worklog.yaml`` + the user overlay
+  ``~/.genesis/config/contributor_worklog.local.yaml``) on EVERY call. No
+  boot cache — the drain re-reads each tick, so a ``settings_update`` or a
+  hand edit takes effect immediately.
+
+Unlike repo_pulse, ``propose_only`` is the DEFAULT and the shipped posture:
+the tool proposes issues + holds each for owner approval, but the drain
+DRY-RUNS the post even after approval (shadow-observes the egress once and
+marks the hold ``dry_run`` — terminal). ``live`` is the escalation that
+actually calls ``gh issue create``. An INVALID mode degrades to
+``propose_only`` — toward LESS write authority, never a silent ``live``
+(a public-repo write must never happen by config accident).
+
+Kill switch: ``GENESIS_CONTRIBUTOR_WORKLOG_DISABLED=1`` forces ``off`` from
+BOTH consumers (the ``contributor_issue_propose`` MCP tool and the poster
+drain) — folded into :func:`effective_mode` here rather than a separate
+hook, because both consumers read config directly (repo_pulse's hook could
+not, hence its split lever).
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only.
+``approval_gate`` / the MCP tool / the drain import the constants + mode from
+here, never the reverse (one-way).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+MODES = ("off", "propose_only", "live")
+
+# The approval_requests.action_type stamped on a held issue draft. Free-text
+# (approval_requests has no enum) but subsystem-agnostic — the dashboard
+# approve-all exclusion and the drain both match on this exact value.
+CONTRIBUTOR_ISSUE_ACTION_TYPE = "contributor_issue_post"
+
+# Capability cell (shadow-gate) for the external GitHub-issue egress door.
+CELL_DOMAIN = "github"
+CELL_VERB = "issue_create"
+CELL_RISK_CLASS = "public_write"
+
+# Env kill switch — forces `off` from both consumers.
+_DISABLE_ENV = "GENESIS_CONTRIBUTOR_WORKLOG_DISABLED"
+
+_CONFIG_NAME = "contributor_worklog.yaml"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "mode": "propose_only",  # ship posture: propose + approve, but NEVER auto-post
+    "retention_days": 30,  # terminal rows (posted/rejected/expired/dry_run) pruned after this
+    "max_held": 25,  # backpressure: the tool refuses new proposals past this many holds
+}
+
+_INT_KNOBS = (
+    "retention_days",
+    "max_held",
+)
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def _kill_switch_on() -> bool:
+    return os.environ.get(_DISABLE_ENV, "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or
+    corrupt files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except Exception:
+        logger.warning("contributor_worklog base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("contributor_worklog overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def effective_mode() -> str:
+    """The mode both consumers must run under — read live.
+
+    Env kill switch OR master ``enabled: false`` → ``off``. An invalid value
+    degrades to ``propose_only`` (observable, no auto-post — never a silent
+    ``live`` to a public repo).
+    """
+    if _kill_switch_on():
+        return "off"
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("mode")
+    if mode is False:
+        # A hand-edited unquoted `mode: off` parses as YAML-1.1 boolean False.
+        return "off"
+    if mode not in MODES:
+        logger.warning("contributor_worklog has invalid mode %r — degrading to propose_only", mode)
+        return "propose_only"
+    return mode
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never crashes a
+    consumer or zeroes a limit."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value

--- a/src/genesis/autonomy/contributor_worklog_config.py
+++ b/src/genesis/autonomy/contributor_worklog_config.py
@@ -52,9 +52,16 @@ MODES = ("off", "propose_only", "live")
 CONTRIBUTOR_ISSUE_ACTION_TYPE = "contributor_issue_post"
 
 # Capability cell (shadow-gate) for the external GitHub-issue egress door.
+# The risk class MUST be a valid ``genesis.autonomy.types.RiskClass`` member —
+# it keys the shared capability-grants machinery (severity ordering, prior
+# weights, the CHECK constraint), so an off-enum value would hard-fail the
+# future enforce stage. The Work-Log posts a sustained stream of autonomous,
+# publicly-visible issues under the owner's account → BULK, the highest
+# non-financial caution tier, so standing auto-post autonomy must be earned
+# against strong evidence. (Guarded by test_cell_constants_are_valid.)
 CELL_DOMAIN = "github"
 CELL_VERB = "issue_create"
-CELL_RISK_CLASS = "public_write"
+CELL_RISK_CLASS = "bulk"
 
 # Env kill switch — forces `off` from both consumers.
 _DISABLE_ENV = "GENESIS_CONTRIBUTOR_WORKLOG_DISABLED"
@@ -72,6 +79,13 @@ _INT_KNOBS = (
     "retention_days",
     "max_held",
 )
+
+
+def normalize_title(title: str) -> str:
+    """Case- and whitespace-insensitive issue-title key for dedup. Shared by the
+    propose tool (DB-side dedup) and the poster drain (GitHub open-issue dedup) so
+    the two dedup scopes can never drift apart."""
+    return " ".join((title or "").lower().split())
 
 
 def _base_path() -> Path:

--- a/src/genesis/autonomy/shadow_gate.py
+++ b/src/genesis/autonomy/shadow_gate.py
@@ -1,4 +1,4 @@
-"""WS5 capability SHADOW-gate — observe-only (Discord doors today).
+"""WS5 capability SHADOW-gate — observe-only (Discord + GitHub-issue doors today).
 
 At each autonomous external egress door, record what a capability gate WOULD decide
 (hold vs allow) WITHOUT holding. The lookup is READ-ONLY (no ``apply_event`` /
@@ -13,8 +13,9 @@ EGRESS-GATING CONTRACT — read before wiring ANY new outbound channel:
   voice/TTS, email-to-owner — is not external-world posting (the owner IS the recipient);
   gating it only obstructs the user. There is no gate on these today; keep it that way.
 - **Every autonomous EXTERNAL/public egress MUST be gated** — shadow-observed here now,
-  enforced later. Live external egress today: email (ENFORCES via ``autonomy.email_gate``)
-  and Discord (SHADOW-observed at the 3 doors below). Any FUTURE public channel — Medium,
+  enforced later. Live external egress today: email (ENFORCES via ``autonomy.email_gate``),
+  Discord (SHADOW-observed at the 3 doors below), and GitHub issue-create (SHADOW-observed
+  at the Contributor Work-Log poster door). Any FUTURE public channel — Medium,
   Twitter/X, Slack, autonomous ``distribution.DistributionManager.distribute`` publishing —
   MUST route its send through this shadow-gate before the enforce stage. Do not ship an
   unobserved external door.
@@ -24,10 +25,11 @@ EGRESS-GATING CONTRACT — read before wiring ANY new outbound channel:
   literal endpoint token — those carry a ``# GROUNDWORK(autonomous-distribution)`` marker at
   the call sites (``distribution/manager.py``, ``modules/content_pipeline/module.py``) instead.
 
-Coverage (the three live Discord doors — enumerated, exhaustive):
-- ``deliver`` — ``outreach/pipeline._deliver`` (server process) -> discord webhook
-- ``poll``    — ``mcp/outreach_mcp.outreach_poll`` (outreach subprocess) -> webhook
-- ``reply``   — ``mcp/discord_bot_mcp.send_reply`` (discord-bot subprocess) -> API
+Coverage (the live external doors — enumerated, exhaustive):
+- ``deliver``      — ``outreach/pipeline._deliver`` (server process) -> discord webhook
+- ``poll``         — ``mcp/outreach_mcp.outreach_poll`` (outreach subprocess) -> webhook
+- ``reply``        — ``mcp/discord_bot_mcp.send_reply`` (discord-bot subprocess) -> API
+- ``issue_create`` — ``autonomy/contributor_issue_watcher`` (server process) -> gh issue create
 """
 
 from __future__ import annotations
@@ -88,4 +90,46 @@ async def observe_discord_send(
         )
     except Exception:  # noqa: BLE001 — shadow is best-effort; NEVER break the real send
         logger.debug("capability shadow observe failed (best-effort)", exc_info=True)
+        return False
+
+
+async def observe_github_issue_create(
+    db,
+    *,
+    path: str,
+    verb: str,
+    risk_class: str,
+    target: str | None,
+    content: str | None,
+) -> bool:
+    """Record a GitHub-issue-create capability-shadow observation — the Contributor
+    Work-Log poster's external egress door. Same observe-only contract as
+    :func:`observe_discord_send`: reads the (github, verb, risk_class) cell
+    READ-ONLY (a not-yet-created cell reads ``not_determined`` => ``would_hold``),
+    best-effort, NEVER raises/blocks/mutates. Returns True iff a row was written."""
+    if db is None:
+        return False
+    domain = "github"
+    try:
+        cell = await cg.get_cell(db, domain, verb, risk_class)
+        state = cell["state"] if cell else None
+        would_hold = state != CellState.GRANTED.value
+        text = content or ""
+        return await capability_shadow.record(
+            db,
+            id=str(uuid.uuid4()),
+            observed_at=datetime.now(UTC).isoformat(),
+            path=path,
+            channel=domain,
+            cell_domain=domain,
+            cell_verb=verb,
+            cell_risk_class=risk_class,
+            cell_state=state,
+            would_hold=would_hold,
+            target=target,
+            content_preview=text[:_PREVIEW_MAX],
+            content_hash=hashlib.sha256(text.encode()).hexdigest(),
+        )
+    except Exception:  # noqa: BLE001 — shadow is best-effort; NEVER break the real post
+        logger.debug("capability shadow observe (github) failed (best-effort)", exc_info=True)
         return False

--- a/src/genesis/contribution/__init__.py
+++ b/src/genesis/contribution/__init__.py
@@ -23,6 +23,7 @@ from .sanitize import (
     MAX_DIFF_BYTES,
     parse_diff,
     scan_diff,
+    scan_prose,
 )
 from .version_gate import (
     CONFIDENCE_THRESHOLD,
@@ -66,5 +67,6 @@ __all__ = [
     "read_install_version",
     "run_review_chain",
     "scan_diff",
+    "scan_prose",
     "write_review_log",
 ]

--- a/src/genesis/contribution/sanitize.py
+++ b/src/genesis/contribution/sanitize.py
@@ -16,7 +16,7 @@ Scanners (all run when inputs are available):
    per finding.
 5. Secrets via `gitleaks detect` if binary is on PATH → BLOCK
    (optional second-layer, MVP-advisory).
-6. Portability patterns — IPs, /home/ubuntu/ paths, hardcoded
+6. Portability patterns — IPs, /home/<user>/ paths, hardcoded
    usernames, known private hostnames → BLOCK.
 7. Fingerprint scan — user-defined strings from
    ~/.genesis/release-fingerprints.txt → BLOCK.
@@ -705,6 +705,103 @@ def scan_diff(
     if ran:
         scanners_run.append("gitleaks")
         findings.extend(gl_hits)
+
+    ok = not any(f.severity == Severity.BLOCK for f in findings)
+    return SanitizerResult(ok=ok, findings=findings, scanners_run=scanners_run)
+
+
+def _parse_prose(text: str) -> _ParsedDiff:
+    """Wrap plain prose as a ``_ParsedDiff`` whose ``added_lines`` are EVERY
+    line of the text.
+
+    ``parse_diff`` only keeps ``+``-prefixed lines under a ``+++ b/<path>``
+    header, so it sees NOTHING in plain prose (an issue body, a comment) and a
+    scan of it fails OPEN. This wrapper hands every line to the raw-string
+    detectors instead. ``file`` is a synthetic ``"<prose>"`` label; line
+    numbers are 1-based to match a human reading the text.
+    """
+    added: list[tuple[str, int, str]] = [
+        ("<prose>", i, line) for i, line in enumerate(text.splitlines(), start=1)
+    ]
+    return _ParsedDiff(
+        file_paths=[],
+        added_lines=added,
+        is_binary=False,
+        size_bytes=len(text.encode("utf-8")),
+    )
+
+
+def scan_prose(
+    text: str,
+    *,
+    fingerprint_file: Path | None = None,
+) -> SanitizerResult:
+    """Fail-closed sanitizer for free TEXT (a drafted issue body, a comment) —
+    the prose analog of :func:`scan_diff`.
+
+    Runs ONLY the raw-string detectors that are meaningful on prose, over
+    EVERY line of *text*: portability classes (IPs, ``/home/<user>`` paths, CC
+    slugs), personal emails outside the allowlist, user fingerprints, and the
+    required ``detect-secrets`` floor. The diff-STRUCTURAL scanners
+    (forbidden-path, gitignore, binary, size) are deliberately skipped — they
+    describe a unified diff's shape, not prose content.
+
+    Do NOT reach for :func:`scan_diff` on prose: it routes through
+    :func:`parse_diff`, which drops every non-``+`` line, so plain text yields
+    zero ``added_lines`` and the scan returns ``ok=True`` regardless of what it
+    contains — a fail-OPEN hole through a fail-CLOSED component. This function
+    closes it.
+
+    Same contract as :func:`scan_diff`: ``ok`` is True iff no BLOCK finding.
+    A missing ``detect-secrets`` binary BLOCKs (the required floor); a missing
+    fingerprint file surfaces a non-blocking WARN (provisioning gap), never a
+    silent skip.
+    """
+    if fingerprint_file is None:
+        env_path = os.environ.get("GENESIS_RELEASE_FINGERPRINTS")
+        if env_path:
+            fingerprint_file = Path(env_path)
+        else:
+            fingerprint_file = Path.home() / ".genesis" / "release-fingerprints.txt"
+
+    parsed = _parse_prose(text)
+    findings: list[Finding] = []
+    scanners_run: list[str] = []
+
+    # Portability (IPs, /home/<user> paths, CC slugs)
+    findings.extend(_check_portability(parsed))
+    scanners_run.append("portability")
+
+    # Personal emails outside the allowlist
+    findings.extend(_check_emails(parsed))
+    scanners_run.append("email_allowlist")
+
+    # Fingerprints (optional — only runs if the file exists). Missing file =
+    # non-blocking WARN, mirroring scan_diff's provision-or-surface handling.
+    if fingerprint_file and fingerprint_file.is_file():
+        findings.extend(_check_fingerprints(parsed, fingerprint_file))
+        scanners_run.append("fingerprint")
+    else:
+        findings.append(
+            Finding(
+                kind=FindingKind.FINGERPRINT,
+                severity=Severity.WARN,
+                message=(
+                    "Release fingerprint file not found — this install's exact "
+                    "private identifiers are not being scanned. Run bootstrap "
+                    "(or `python -m genesis.contribution.fingerprints --write`) "
+                    "to generate it."
+                ),
+                scanner="fingerprint",
+                detail=str(fingerprint_file),
+            )
+        )
+
+    # detect-secrets (required floor — a missing binary BLOCKs, fail-closed)
+    ran, secret_hits = _run_detect_secrets(parsed)
+    if ran:
+        scanners_run.append("detect-secrets")
+        findings.extend(secret_hits)
 
     ok = not any(f.severity == Severity.BLOCK for f in findings)
     return SanitizerResult(ok=ok, findings=findings, scanners_run=scanners_run)

--- a/src/genesis/db/crud/pending_issue_posts.py
+++ b/src/genesis/db/crud/pending_issue_posts.py
@@ -1,0 +1,112 @@
+"""CRUD for ``pending_issue_posts`` — the Contributor Work-Log hold store.
+
+A row is written when the ``contributor_issue_propose`` MCP tool holds a
+sanitized issue draft awaiting owner approval (paired with an
+``approval_requests`` row). The resolution watcher drains ``status='held'``
+rows: on approval it posts the issue to GitHub and marks 'posted'; on
+rejection/timeout it marks 'rejected'/'expired'. ``mark_posted``/
+``mark_rejected`` gate on ``WHERE status='held'`` so a row can leave 'held'
+exactly once (double-post guard, alongside the ``request_id`` UNIQUE
+constraint).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def create(
+    db: aiosqlite.Connection,
+    *,
+    id: str,
+    request_id: str,
+    repo: str,
+    title: str,
+    body: str,
+    source: str,
+    cell_domain: str,
+    cell_verb: str,
+    cell_risk_class: str,
+    held_at: str,
+    labels: str | None = None,
+    source_ref: str | None = None,
+) -> str:
+    await db.execute(
+        """INSERT INTO pending_issue_posts
+             (id, request_id, repo, title, body, labels, source, source_ref,
+              cell_domain, cell_verb, cell_risk_class, held_at, status)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'held')""",
+        (
+            id,
+            request_id,
+            repo,
+            title,
+            body,
+            labels,
+            source,
+            source_ref,
+            cell_domain,
+            cell_verb,
+            cell_risk_class,
+            held_at,
+        ),
+    )
+    await db.commit()
+    return id
+
+
+async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
+    cursor = await db.execute("SELECT * FROM pending_issue_posts WHERE id = ?", (id,))
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def get_by_request(db: aiosqlite.Connection, request_id: str) -> dict | None:
+    cursor = await db.execute(
+        "SELECT * FROM pending_issue_posts WHERE request_id = ?", (request_id,)
+    )
+    row = await cursor.fetchone()
+    return dict(row) if row else None
+
+
+async def list_held(db: aiosqlite.Connection) -> list[dict]:
+    """All rows still awaiting resolution — the watcher's work list."""
+    cursor = await db.execute(
+        "SELECT * FROM pending_issue_posts WHERE status = 'held' ORDER BY held_at"
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def mark_posted(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    issue_number: int,
+    issue_url: str,
+    posted_at: str,
+) -> bool:
+    """Transition held → posted, recording the created issue. Returns False if
+    the row already left 'held' (double-post guard: only one caller can flip a
+    given hold)."""
+    cursor = await db.execute(
+        "UPDATE pending_issue_posts "
+        "SET status = 'posted', issue_number = ?, issue_url = ?, posted_at = ? "
+        "WHERE id = ? AND status = 'held'",
+        (issue_number, issue_url, posted_at, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def mark_rejected(
+    db: aiosqlite.Connection, id: str, *, rejected_at: str, expired: bool = False
+) -> bool:
+    """Transition held → rejected (or expired). Returns False if not still held."""
+    status = "expired" if expired else "rejected"
+    cursor = await db.execute(
+        "UPDATE pending_issue_posts SET status = ?, rejected_at = ? "
+        "WHERE id = ? AND status = 'held'",
+        (status, rejected_at, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0

--- a/src/genesis/db/crud/pending_issue_posts.py
+++ b/src/genesis/db/crud/pending_issue_posts.py
@@ -4,10 +4,12 @@ A row is written when the ``contributor_issue_propose`` MCP tool holds a
 sanitized issue draft awaiting owner approval (paired with an
 ``approval_requests`` row). The resolution watcher drains ``status='held'``
 rows: on approval it posts the issue to GitHub and marks 'posted'; on
-rejection/timeout it marks 'rejected'/'expired'. ``mark_posted``/
-``mark_rejected`` gate on ``WHERE status='held'`` so a row can leave 'held'
-exactly once (double-post guard, alongside the ``request_id`` UNIQUE
-constraint).
+rejection/timeout it marks 'rejected'/'expired'; in the default ``propose_only``
+lever mode an approved hold is shadow-observed once and marked ``'dry_run'``
+(TERMINAL — never posted; flipping the lever to ``live`` must not retro-post it).
+``mark_posted``/``mark_rejected``/``mark_dry_run`` all gate on
+``WHERE status='held'`` so a row can leave 'held' exactly once (double-post
+guard, alongside the ``request_id`` UNIQUE constraint).
 """
 
 from __future__ import annotations
@@ -93,6 +95,34 @@ async def mark_posted(
         "SET status = 'posted', issue_number = ?, issue_url = ?, posted_at = ? "
         "WHERE id = ? AND status = 'held'",
         (issue_number, issue_url, posted_at, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
+async def list_dedup_active(db: aiosqlite.Connection, repo: str) -> list[dict]:
+    """Rows in *repo* that should block a duplicate proposal: still awaiting
+    owner review ('held') or already live ('posted'). ``dry_run`` deliberately
+    does NOT block — a dry-run hold is re-proposed under 'live' mode to actually
+    post it; ``rejected``/``expired`` also don't block (an item may be
+    re-drafted). Returns id/title/source_ref/status for the caller to normalize
+    and compare (bounded small by the ``max_held`` backpressure knob)."""
+    cursor = await db.execute(
+        "SELECT id, title, source_ref, status FROM pending_issue_posts "
+        "WHERE repo = ? AND status IN ('held', 'posted')",
+        (repo,),
+    )
+    return [dict(r) for r in await cursor.fetchall()]
+
+
+async def mark_dry_run(db: aiosqlite.Connection, id: str, *, dry_run_at: str) -> bool:
+    """Transition held → dry_run (propose_only: approved but not posted). TERMINAL
+    — a later post/reject must not override it, so a lever flip to 'live' never
+    retro-posts a dry-run hold. Returns False if the row already left 'held'."""
+    cursor = await db.execute(
+        "UPDATE pending_issue_posts SET status = 'dry_run', dry_run_at = ? "
+        "WHERE id = ? AND status = 'held'",
+        (dry_run_at, id),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/src/genesis/db/crud/pending_issue_posts.py
+++ b/src/genesis/db/crud/pending_issue_posts.py
@@ -140,3 +140,27 @@ async def mark_rejected(
     )
     await db.commit()
     return cursor.rowcount > 0
+
+
+def _iso_days_before(now_iso: str, days: int) -> str:
+    """Return the ISO8601 timestamp *days* before ``now_iso``."""
+    from datetime import datetime, timedelta
+
+    return (datetime.fromisoformat(now_iso) - timedelta(days=days)).isoformat()
+
+
+async def prune_terminal(db: aiosqlite.Connection, *, older_than_days: int = 30, now: str) -> int:
+    """Delete TERMINAL rows (posted / rejected / expired / dry_run) whose terminal
+    timestamp is older than *older_than_days*. ``held`` rows are NEVER pruned —
+    they await the owner indefinitely. ``now`` is injected (never wall-clock) so
+    the cutover is deterministic and testable. Wired into ``disk_hygiene.sh``.
+    Returns the number of rows deleted."""
+    cutoff = _iso_days_before(now, older_than_days)
+    cursor = await db.execute(
+        "DELETE FROM pending_issue_posts "
+        "WHERE status IN ('posted', 'rejected', 'expired', 'dry_run') "
+        "AND COALESCE(posted_at, rejected_at, dry_run_at, held_at) < ?",
+        (cutoff,),
+    )
+    await db.commit()
+    return cursor.rowcount if cursor.rowcount is not None else 0

--- a/src/genesis/db/migrations/0079_pending_issue_posts.py
+++ b/src/genesis/db/migrations/0079_pending_issue_posts.py
@@ -35,11 +35,12 @@ _TABLE_DDL = """
         cell_risk_class     TEXT NOT NULL,          -- 'public_write'
         held_at             TEXT NOT NULL,
         status              TEXT NOT NULL DEFAULT 'held'
-                                CHECK (status IN ('held', 'posted', 'rejected', 'expired')),
+                                CHECK (status IN ('held', 'posted', 'rejected', 'expired', 'dry_run')),
         issue_number        INTEGER,                -- captured after a successful post
         issue_url           TEXT,
         posted_at           TEXT,
-        rejected_at         TEXT
+        rejected_at         TEXT,
+        dry_run_at          TEXT                    -- propose_only: approved but not posted (terminal)
     )
 """
 

--- a/src/genesis/db/migrations/0079_pending_issue_posts.py
+++ b/src/genesis/db/migrations/0079_pending_issue_posts.py
@@ -1,0 +1,60 @@
+"""Create ``pending_issue_posts`` — the Contributor Work-Log hold store.
+
+A local curator campaign drafts a public GitHub issue (from the follow-up
+backlog or a codebase scan). The ``contributor_issue_propose`` MCP tool
+sanitizes it server-side (``contribution.sanitize.scan_prose``) and, if clean,
+records the fully-resolved draft here (status='held') plus a linked
+``approval_requests`` row. A periodic resolution watcher
+(``contributor_issue_watcher``) then posts the issue below the gate on owner
+approval, or expires the hold on rejection/timeout — the same shape as the WS-8
+email autonomy gate (``pending_email_sends`` + ``email_gate_watcher``).
+
+``request_id`` is UNIQUE — the schema-level double-post guard: even if the
+watcher fires twice, only one row per approval can transition out of 'held'.
+
+Idempotent (``IF NOT EXISTS``). Fresh installs get the same DDL via
+``db/schema/_tables.py``; this migration covers existing installs.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_TABLE_DDL = """
+    CREATE TABLE IF NOT EXISTS pending_issue_posts (
+        id                  TEXT PRIMARY KEY,
+        request_id          TEXT NOT NULL UNIQUE,   -- FK approval_requests.id; double-post guard
+        repo                TEXT NOT NULL,          -- target repo, e.g. owner/name
+        title               TEXT NOT NULL,          -- sanitized issue title
+        body                TEXT NOT NULL,          -- sanitized issue body
+        labels              TEXT,                   -- JSON array of label names
+        source              TEXT NOT NULL,          -- 'follow_up' | 'codebase'
+        source_ref          TEXT,                   -- follow_up id (close-loop link), nullable
+        cell_domain         TEXT NOT NULL,          -- capability cell (shadow-gate): 'github'
+        cell_verb           TEXT NOT NULL,          -- 'issue_create'
+        cell_risk_class     TEXT NOT NULL,          -- 'public_write'
+        held_at             TEXT NOT NULL,
+        status              TEXT NOT NULL DEFAULT 'held'
+                                CHECK (status IN ('held', 'posted', 'rejected', 'expired')),
+        issue_number        INTEGER,                -- captured after a successful post
+        issue_url           TEXT,
+        posted_at           TEXT,
+        rejected_at         TEXT
+    )
+"""
+
+_INDEX_DDL = (
+    "CREATE INDEX IF NOT EXISTS idx_pending_issue_posts_status ON pending_issue_posts(status)",
+)
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    # NOTE: must NOT call db.commit()/BEGIN — the runner owns the transaction.
+    await db.execute(_TABLE_DDL)
+    for stmt in _INDEX_DDL:
+        await db.execute(stmt)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """Drop the table (and its indexes) — development/testing only."""
+    await db.execute("DROP TABLE IF EXISTS pending_issue_posts")

--- a/src/genesis/db/migrations/0079_pending_issue_posts.py
+++ b/src/genesis/db/migrations/0079_pending_issue_posts.py
@@ -32,7 +32,7 @@ _TABLE_DDL = """
         source_ref          TEXT,                   -- follow_up id (close-loop link), nullable
         cell_domain         TEXT NOT NULL,          -- capability cell (shadow-gate): 'github'
         cell_verb           TEXT NOT NULL,          -- 'issue_create'
-        cell_risk_class     TEXT NOT NULL,          -- 'public_write'
+        cell_risk_class     TEXT NOT NULL,          -- RiskClass, e.g. 'bulk'
         held_at             TEXT NOT NULL,
         status              TEXT NOT NULL DEFAULT 'held'
                                 CHECK (status IN ('held', 'posted', 'rejected', 'expired', 'dry_run')),

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -754,6 +754,32 @@ TABLES = {
             rejected_at         TEXT
         )
     """,
+    # Contributor Work-Log hold store — a curator-drafted, sanitized public
+    # GitHub issue held for owner approval (paired with an approval_requests
+    # row); the resolution watcher posts it on approval. Mirrors
+    # pending_email_sends (WS-8). Migration 0079.
+    "pending_issue_posts": """
+        CREATE TABLE IF NOT EXISTS pending_issue_posts (
+            id                  TEXT PRIMARY KEY,
+            request_id          TEXT NOT NULL UNIQUE,
+            repo                TEXT NOT NULL,
+            title               TEXT NOT NULL,
+            body                TEXT NOT NULL,
+            labels              TEXT,
+            source              TEXT NOT NULL,
+            source_ref          TEXT,
+            cell_domain         TEXT NOT NULL,
+            cell_verb           TEXT NOT NULL,
+            cell_risk_class     TEXT NOT NULL,
+            held_at             TEXT NOT NULL,
+            status              TEXT NOT NULL DEFAULT 'held'
+                                    CHECK (status IN ('held', 'posted', 'rejected', 'expired')),
+            issue_number        INTEGER,
+            issue_url           TEXT,
+            posted_at           TEXT,
+            rejected_at         TEXT
+        )
+    """,
     # WS-8 PR-D autonomous-send ledger — one row per email sent autonomously
     # under a GRANTED capability cell (i.e. the gate allowed it without holding
     # for owner approval).  This is the keystone the owner-visibility "Activity"
@@ -2358,6 +2384,7 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_capability_grants_domain ON capability_grants(domain, state)",
     # WS-8 email gate hold store (drain queries WHERE status='held')
     "CREATE INDEX IF NOT EXISTS idx_pending_email_sends_status ON pending_email_sends(status)",
+    "CREATE INDEX IF NOT EXISTS idx_pending_issue_posts_status ON pending_issue_posts(status)",
     # WS-8 PR-D autonomous-send ledger — per-cell rate-limit window + ledger ordering
     "CREATE INDEX IF NOT EXISTS idx_autonomous_email_sends_cell "
     "ON autonomous_email_sends(cell_domain, cell_verb, cell_risk_class, sent_at)",

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -773,11 +773,12 @@ TABLES = {
             cell_risk_class     TEXT NOT NULL,
             held_at             TEXT NOT NULL,
             status              TEXT NOT NULL DEFAULT 'held'
-                                    CHECK (status IN ('held', 'posted', 'rejected', 'expired')),
+                                    CHECK (status IN ('held', 'posted', 'rejected', 'expired', 'dry_run')),
             issue_number        INTEGER,
             issue_url           TEXT,
             posted_at           TEXT,
-            rejected_at         TEXT
+            rejected_at         TEXT,
+            dry_run_at          TEXT
         )
     """,
     # WS-8 PR-D autonomous-send ledger — one row per email sent autonomously

--- a/src/genesis/mcp/health/__init__.py
+++ b/src/genesis/mcp/health/__init__.py
@@ -68,6 +68,7 @@ from genesis.mcp.health import calibration_status as _calibration_status  # noqa
 from genesis.mcp.health import campaign_tools as _campaign_tools  # noqa: E402, F401
 from genesis.mcp.health import codebase as _codebase  # noqa: E402
 from genesis.mcp.health import cognitive_ledger_tools as _cognitive_ledger_tools  # noqa: E402, F401
+from genesis.mcp.health import contributor_issue as _contributor_issue  # noqa: E402, F401
 from genesis.mcp.health import db_schema as _db_schema  # noqa: E402
 from genesis.mcp.health import deliberation_tools as _deliberation_tools  # noqa: E402
 from genesis.mcp.health import direct_session_tools as _direct_session_tools  # noqa: E402

--- a/src/genesis/mcp/health/contributor_issue.py
+++ b/src/genesis/mcp/health/contributor_issue.py
@@ -33,6 +33,7 @@ from genesis.autonomy.contributor_worklog_config import (
     effective_mode,
     knob_int,
     load_config,
+    normalize_title,
 )
 from genesis.contribution import scan_prose
 from genesis.contribution.findings import Severity
@@ -41,11 +42,6 @@ from genesis.env import github_public_repo, github_user
 from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
-
-
-def _normalize_title(title: str) -> str:
-    """Case- and whitespace-insensitive title key for dedup."""
-    return " ".join(title.lower().split())
 
 
 def _default_repo() -> str:
@@ -108,9 +104,9 @@ async def _impl_contributor_issue_propose(
             "status": "backpressure",
             "reason": f"{held_count} issue(s) already awaiting review (max_held reached)",
         }
-    title_norm = _normalize_title(title)
+    title_norm = normalize_title(title)
     for r in active:
-        if _normalize_title(r["title"]) == title_norm or (
+        if normalize_title(r["title"]) == title_norm or (
             source_ref is not None and r["source_ref"] == source_ref
         ):
             return {

--- a/src/genesis/mcp/health/contributor_issue.py
+++ b/src/genesis/mcp/health/contributor_issue.py
@@ -1,0 +1,227 @@
+"""``contributor_issue_propose`` MCP tool — the Contributor Work-Log's PROPOSE
+door (server-side, trusted boundary).
+
+A LOCAL curator campaign (follow-up-backlog or codebase scan) drafts a public
+GitHub issue and calls this tool. Here — NOT in the untrusted curator subprocess
+— the draft passes the fail-closed prose sanitizer
+(:func:`genesis.contribution.scan_prose`), and only if clean is it parked in
+``pending_issue_posts`` (status='held') with a linked ``approval_requests`` row.
+The owner reviews the FULL body + approves/rejects per item on the dashboard; a
+separate poster drain (``contributor_issue_watcher``) posts it below the gate on
+approval (in ``live`` mode) or dry-runs it (in ``propose_only``).
+
+Mirrors the WS-8 email autonomy gate exactly (two-row create, approval FIRST so
+a crash never orphans a hold). DB access mirrors ``evo_run`` — the long-lived
+health-service connection, so a row written here is visible to the dashboard and
+the drain. GitHub open-issue dedup happens at POST time in the drain (this tool
+does DB-side dedup only; the curator profile has no ``gh``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from genesis.autonomy.approval import ApprovalManager
+from genesis.autonomy.contributor_worklog_config import (
+    CELL_DOMAIN,
+    CELL_RISK_CLASS,
+    CELL_VERB,
+    CONTRIBUTOR_ISSUE_ACTION_TYPE,
+    effective_mode,
+    knob_int,
+    load_config,
+)
+from genesis.contribution import scan_prose
+from genesis.contribution.findings import Severity
+from genesis.db.crud import pending_issue_posts as pip
+from genesis.env import github_public_repo, github_user
+from genesis.mcp.health import mcp
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_title(title: str) -> str:
+    """Case- and whitespace-insensitive title key for dedup."""
+    return " ".join(title.lower().split())
+
+
+def _default_repo() -> str:
+    owner = github_user()
+    name = github_public_repo()
+    return f"{owner}/{name}" if owner else name
+
+
+async def _impl_contributor_issue_propose(
+    db,
+    *,
+    title: str,
+    body: str,
+    labels: list[str] | None = None,
+    repo: str = "",
+    source: str = "codebase",
+    source_follow_up_id: str = "",
+) -> dict:
+    """Testable core (takes an explicit db). See the tool docstring below."""
+    mode = effective_mode()
+    if mode == "off":
+        return {"status": "disabled", "reason": "contributor_worklog mode is off"}
+
+    title = (title or "").strip()
+    body = (body or "").strip()
+    if not title or not body:
+        return {"status": "error", "reason": "title and body are both required"}
+    if source not in ("follow_up", "codebase"):
+        return {"status": "error", "reason": f"source must be follow_up|codebase, got {source!r}"}
+
+    repo = (repo or "").strip() or _default_repo()
+    if "/" not in repo:
+        return {"status": "error", "reason": f"repo must be owner/name, got {repo!r}"}
+    source_ref = (source_follow_up_id or "").strip() or None
+    label_list = [str(x).strip() for x in (labels or []) if str(x).strip()]
+
+    # 1) Privacy sanitizer at the TRUSTED server boundary (fail-closed). A
+    #    misbehaving curator subprocess cannot bypass this — it runs HERE.
+    #    Labels reach the public repo too (drain: `gh issue create --label ...`),
+    #    so they are scanned alongside title+body — the sanitizer covers EVERY
+    #    curator-supplied string that egresses, not just the body.
+    scan_input = f"{title}\n\n{body}"
+    if label_list:
+        scan_input += "\n\n" + "\n".join(label_list)
+    scan = scan_prose(scan_input)
+    if not scan.ok:
+        reasons = [
+            f"{f.kind.value}: {f.message}" for f in scan.findings if f.severity == Severity.BLOCK
+        ]
+        logger.warning("contributor_issue_propose BLOCKED %d finding(s): %s", len(reasons), reasons)
+        return {"status": "blocked", "reasons": reasons, "scanners_run": scan.scanners_run}
+
+    # 2) Backpressure + DB-side dedup (GitHub open-issue dedup is done at post
+    #    time in the drain — the curator profile has no gh).
+    cfg = load_config()
+    active = await pip.list_dedup_active(db, repo)
+    held_count = sum(1 for r in active if r["status"] == "held")
+    if held_count >= knob_int(cfg, "max_held"):
+        return {
+            "status": "backpressure",
+            "reason": f"{held_count} issue(s) already awaiting review (max_held reached)",
+        }
+    title_norm = _normalize_title(title)
+    for r in active:
+        if _normalize_title(r["title"]) == title_norm or (
+            source_ref is not None and r["source_ref"] == source_ref
+        ):
+            return {
+                "status": "duplicate",
+                "reason": "an active proposal already covers this item",
+                "existing_id": r["id"],
+            }
+
+    # 3) Two-row create — approval FIRST so a crash never orphans a hold.
+    context = json.dumps(
+        {
+            "kind": CONTRIBUTOR_ISSUE_ACTION_TYPE,
+            "repo": repo,
+            "labels": label_list,
+            "source": source,
+            "source_follow_up_id": source_ref,
+            "cell": [CELL_DOMAIN, CELL_VERB, CELL_RISK_CLASS],
+        }
+    )
+    approval = ApprovalManager(db=db)
+    request_id = await approval.request_approval(
+        action_type=CONTRIBUTOR_ISSUE_ACTION_TYPE,
+        action_class="irreversible",  # a public-repo post is not cleanly undoable
+        description=f"Post GitHub issue to {repo}:\n\n# {title}\n\n{body}",
+        context=context,
+        timeout_seconds=None,  # wait for the owner; never auto-approve, never auto-drop
+    )
+    now = datetime.now(UTC).isoformat()
+    pending_id = str(uuid.uuid4())
+    await pip.create(
+        db,
+        id=pending_id,
+        request_id=request_id,
+        repo=repo,
+        title=title,
+        body=body,
+        labels=json.dumps(label_list) if label_list else None,
+        source=source,
+        source_ref=source_ref,
+        cell_domain=CELL_DOMAIN,
+        cell_verb=CELL_VERB,
+        cell_risk_class=CELL_RISK_CLASS,
+        held_at=now,
+    )
+    logger.info(
+        "contributor_issue_propose HELD %s → %s (request=%s, mode=%s, source=%s)",
+        pending_id,
+        repo,
+        request_id,
+        mode,
+        source,
+    )
+    return {
+        "status": "held",
+        "pending_id": pending_id,
+        "request_id": request_id,
+        "repo": repo,
+        "mode": mode,
+        "message": (
+            "Issue draft held for owner approval on the dashboard. "
+            + (
+                "It will post on approval (live mode)."
+                if mode == "live"
+                else "On approval it is dry-run only (propose_only) — flip to live to post."
+            )
+        ),
+    }
+
+
+@mcp.tool()
+async def contributor_issue_propose(
+    title: str,
+    body: str,
+    labels: list[str] | None = None,
+    repo: str = "",
+    source: str = "codebase",
+    source_follow_up_id: str = "",
+) -> dict:
+    """Propose a public GitHub issue for the Contributor Work-Log — sanitize it
+    server-side and, if clean, hold it for owner approval on the dashboard.
+
+    NOTHING is posted by this call. In the default ``propose_only`` mode an
+    approved hold is still dry-run (never posted); flip the ``contributor_worklog``
+    lever to ``live`` to actually post. Blocked drafts create NO row.
+
+    Args:
+        title: issue title (sanitized here; must be public-safe).
+        body: issue body / description (sanitized here).
+        labels: GitHub label names (e.g. ["good first issue"]). Optional.
+        repo: target ``owner/name``. Defaults to this install's public repo.
+        source: provenance — "follow_up" (backlog-derived) or "codebase".
+        source_follow_up_id: originating follow_up id, for the close-loop link
+            (stored on ``source_ref``). Optional.
+
+    Returns a status dict: ``held`` (parked + approval created), ``blocked``
+    (sanitizer findings, no row), ``duplicate`` / ``backpressure`` (no row),
+    ``disabled`` (mode off), or ``error``.
+    """
+    import genesis.mcp.health_mcp as health_mcp_mod
+
+    _service = getattr(health_mcp_mod, "_service", None)
+    db = getattr(_service, "_db", None) if _service is not None else None
+    if db is None:
+        return {"status": "error", "reason": "health service DB unavailable"}
+
+    return await _impl_contributor_issue_propose(
+        db,
+        title=title,
+        body=body,
+        labels=labels,
+        repo=repo,
+        source=source,
+        source_follow_up_id=source_follow_up_id,
+    )

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -132,6 +132,21 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # each worker run is a fresh process
     ),
+    "contributor_worklog": SettingsDomain(
+        name="contributor_worklog",
+        description=(
+            "Contributor Work-Log poster — master `enabled` + `mode` "
+            "off/propose_only/live plus `retention_days`/`max_held` knobs. "
+            "propose_only (default, shipped) proposes public GitHub issues + "
+            "holds each for owner approval but NEVER auto-posts (dry-run); "
+            "live posts approved issues via `gh issue create`. Invalid mode "
+            "degrades to propose_only. Read live by the drain each tick — "
+            "takes effect immediately, no restart."
+        ),
+        config_filename="contributor_worklog.yaml",
+        readonly=False,
+        needs_restart=False,  # drain re-reads each tick
+    ),
     "memory_integrity": SettingsDomain(
         name="memory_integrity",
         description=(
@@ -1171,6 +1186,27 @@ def _validate_repo_pulse(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_contributor_worklog(changes: dict) -> list[str]:
+    """Validate Contributor Work-Log lever changes (see
+    genesis.autonomy.contributor_worklog_config)."""
+    from genesis.autonomy.contributor_worklog_config import _INT_KNOBS, MODES
+
+    errors: list[str] = []
+    valid_keys = ("enabled", "mode", *_INT_KNOBS)
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif key == "mode":
+            if value not in MODES:
+                errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")
+        elif isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            errors.append(f"'{key}' must be a positive int")
+    return errors
+
+
 def _validate_pr_watch(changes: dict) -> list[str]:
     """Validate pr-watch lever changes (see
     genesis.session_awareness.pr_watch_config)."""
@@ -1450,6 +1486,7 @@ _DOMAIN_VALIDATORS: dict[str, Any] = {
     "session_ledger_shadow": _validate_session_ledger_shadow,
     "ws2_ledger": _validate_ws2_ledger,
     "repo_pulse": _validate_repo_pulse,
+    "contributor_worklog": _validate_contributor_worklog,
     "pr_watch": _validate_pr_watch,
     "skill_evolution_gate": _validate_skill_evolution_gate,
     "cc_roster": _validate_cc_roster,

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -486,6 +486,42 @@ async def init(rt: GenesisRuntime) -> None:
             misfire_grace_time=300,
         )
 
+        # Contributor Work-Log poster — the resolution watcher for held public
+        # GitHub-issue drafts. Drains pending_issue_posts: approved + live → post
+        # via `gh issue create`; approved + propose_only → dry-run terminal;
+        # rejected/expired/orphaned → close out. Mode read live each tick; `off`
+        # short-circuits. max_instances=1 ⇒ no in-drain races.
+        from genesis.autonomy.contributor_issue_watcher import (
+            drain_pending_issue_posts,
+        )
+
+        async def _contributor_issue_drain() -> None:
+            try:
+                if rt.paused:
+                    return
+            except Exception:
+                logger.warning(
+                    "Pause check failed — skipping contributor issue drain",
+                    exc_info=True,
+                )
+                return
+            try:
+                n = await drain_pending_issue_posts(rt)
+                rt.record_job_success("contributor_issue_drain")
+                if n:
+                    logger.info("Contributor issue drain resolved %d held draft(s)", n)
+            except Exception as exc:
+                rt.record_job_failure("contributor_issue_drain", exc=exc)
+                raise
+
+        rt._learning_scheduler.add_job(
+            _contributor_issue_drain,
+            CronTrigger(minute="*/5", timezone=user_timezone()),
+            id="contributor_issue_drain",
+            max_instances=1,
+            misfire_grace_time=300,
+        )
+
         # WS-8 PR-D capability staleness decay — a GRANTED email cell idle past
         # the half-life lapses back to NOT_DETERMINED (holds again on next use),
         # so standing autonomy can't entrench unused. Daily, INFO-level.

--- a/tests/test_autonomy/test_contributor_issue_watcher.py
+++ b/tests/test_autonomy/test_contributor_issue_watcher.py
@@ -1,0 +1,275 @@
+"""Contributor Work-Log poster drain — resolves held issue posts against their
+approval + the mode lever. `gh` is mocked at the `_run_gh` seam; the shadow
+observation and DB transitions run for real against an in-memory schema.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import aiosqlite
+import pytest
+
+from genesis.autonomy import contributor_issue_watcher as ciw
+from genesis.autonomy.approval import ApprovalManager
+from genesis.db.crud import approval_requests as ar
+from genesis.db.crud import pending_issue_posts as pip
+from genesis.db.schema import create_all_tables
+
+_REPO = "WingedGuardian/GENesis-AGI"
+
+
+class _RT:
+    def __init__(self, db):
+        self._db = db
+
+
+@pytest.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+async def _seed_held(db, *, title="Add a newcomer task", body="Details.", labels=None, repo=_REPO):
+    """Create a held pending_issue_posts row + its linked approval (pending)."""
+    mgr = ApprovalManager(db=db)
+    rid = await mgr.request_approval(
+        action_type="contributor_issue_post",
+        action_class="irreversible",
+        description="issue draft",
+        context="{}",
+    )
+    pid = str(uuid.uuid4())
+    await pip.create(
+        db,
+        id=pid,
+        request_id=rid,
+        repo=repo,
+        title=title,
+        body=body,
+        labels=json.dumps(labels) if labels else None,
+        source="codebase",
+        cell_domain="github",
+        cell_verb="issue_create",
+        cell_risk_class="bulk",
+        held_at="2026-08-07T00:00:00",
+    )
+    return pid, rid, mgr
+
+
+class _FakeGh:
+    """Stand-in for ciw._run_gh. Records calls; canned list/create responses."""
+
+    def __init__(
+        self,
+        *,
+        list_out="[]",
+        list_rc=0,
+        create_rc=0,
+        create_url=f"https://github.com/{_REPO}/issues/42",
+    ):
+        self.list_out = list_out
+        self.list_rc = list_rc
+        self.create_rc = create_rc
+        self.create_url = create_url
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args, *, timeout=60):
+        self.calls.append(args)
+        if args[:2] == ["issue", "list"]:
+            return (
+                self.list_rc,
+                self.list_out if self.list_rc == 0 else "",
+                "" if self.list_rc == 0 else "list boom",
+            )
+        if args[:2] == ["issue", "create"]:
+            if self.create_rc == 0:
+                return (0, self.create_url + "\n", "")
+            return (1, "", "create boom")
+        return (0, "", "")
+
+    def created(self) -> bool:
+        return any(c[:2] == ["issue", "create"] for c in self.calls)
+
+
+def _mode(monkeypatch, mode: str):
+    monkeypatch.setattr(ciw, "effective_mode", lambda: mode)
+
+
+# ── propose_only: dry-run terminal, never posts ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_propose_only_approved_dry_runs(db, monkeypatch):
+    _mode(monkeypatch, "propose_only")
+    gh = _FakeGh()
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid, rid, mgr = await _seed_held(db)
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 1
+    assert not gh.created()  # NEVER posts in propose_only
+    row = await pip.get_by_id(db, pid)
+    assert row["status"] == "dry_run"
+    assert row["dry_run_at"]
+    assert (await ar.get_by_id(db, rid))["consumed_at"] is not None
+    # a shadow observation was recorded (observe-before-enforce).
+    cur = await db.execute(
+        "SELECT COUNT(*) FROM capability_shadow_events WHERE cell_domain='github'"
+    )
+    assert (await cur.fetchone())[0] == 1
+
+
+# ── live: post ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_live_approved_posts_and_records_number(db, monkeypatch):
+    _mode(monkeypatch, "live")
+    gh = _FakeGh(list_out="[]")  # no existing issue
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid, rid, mgr = await _seed_held(db, labels=["good first issue"])
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 1
+    assert gh.created()
+    # labels were passed to gh
+    create_call = next(c for c in gh.calls if c[:2] == ["issue", "create"])
+    assert "--label" in create_call and "good first issue" in create_call
+    row = await pip.get_by_id(db, pid)
+    assert row["status"] == "posted"
+    assert row["issue_number"] == 42
+    assert row["issue_url"] == f"https://github.com/{_REPO}/issues/42"
+    assert (await ar.get_by_id(db, rid))["consumed_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_live_adopts_existing_open_issue_no_repost(db, monkeypatch):
+    """Crash-idempotency + dedup: a normalized-title match already open on the
+    repo is adopted (mark_posted with its number), NOT re-created."""
+    _mode(monkeypatch, "live")
+    existing = json.dumps(
+        [
+            {
+                "number": 7,
+                "title": "add a NEWCOMER task",
+                "url": f"https://github.com/{_REPO}/issues/7",
+            }
+        ]
+    )
+    gh = _FakeGh(list_out=existing)
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid, rid, mgr = await _seed_held(db, title="Add a newcomer task")
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 1
+    assert not gh.created()  # adopted, not re-created
+    row = await pip.get_by_id(db, pid)
+    assert row["status"] == "posted"
+    assert row["issue_number"] == 7
+
+
+@pytest.mark.asyncio
+async def test_live_dedup_list_failure_does_not_post(db, monkeypatch):
+    """If the open-issue dedup LIST fails, we must NOT post (can't verify dup) —
+    the row stays held and retries next cycle."""
+    _mode(monkeypatch, "live")
+    gh = _FakeGh(list_rc=1)
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid, rid, mgr = await _seed_held(db)
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 0
+    assert not gh.created()
+    assert (await pip.get_by_id(db, pid))["status"] == "held"  # still held → retry
+
+
+@pytest.mark.asyncio
+async def test_live_create_failure_leaves_held(db, monkeypatch):
+    _mode(monkeypatch, "live")
+    gh = _FakeGh(list_out="[]", create_rc=1)
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid, rid, mgr = await _seed_held(db)
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 0
+    assert gh.created()  # attempted
+    row = await pip.get_by_id(db, pid)
+    assert row["status"] == "held"  # retry next cycle
+    assert (await ar.get_by_id(db, rid))["consumed_at"] is None  # not consumed on failure
+
+
+# ── non-approved resolutions ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rejected_marks_rejected_no_post(db, monkeypatch):
+    _mode(monkeypatch, "live")
+    gh = _FakeGh()
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid, rid, mgr = await _seed_held(db)
+    await mgr.resolve(rid, status="rejected")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 1
+    assert not gh.created()
+    assert (await pip.get_by_id(db, pid))["status"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_orphaned_approval_expires(db, monkeypatch):
+    _mode(monkeypatch, "live")
+    monkeypatch.setattr(ciw, "_run_gh", _FakeGh())
+    pid, rid, _ = await _seed_held(db)
+    # delete the approval row → orphan.
+    await db.execute("DELETE FROM approval_requests WHERE id = ?", (rid,))
+    await db.commit()
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 1
+    assert (await pip.get_by_id(db, pid))["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_pending_left_held(db, monkeypatch):
+    _mode(monkeypatch, "live")
+    gh = _FakeGh()
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid, rid, _ = await _seed_held(db)  # approval left pending
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 0
+    assert not gh.created()
+    assert (await pip.get_by_id(db, pid))["status"] == "held"
+
+
+# ── mode / plumbing gates ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_off_mode_short_circuits(db, monkeypatch):
+    _mode(monkeypatch, "off")
+    gh = _FakeGh()
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid, rid, mgr = await _seed_held(db)
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 0
+    assert not gh.created()
+    assert (await pip.get_by_id(db, pid))["status"] == "held"  # untouched
+
+
+@pytest.mark.asyncio
+async def test_no_db_returns_zero(monkeypatch):
+    _mode(monkeypatch, "live")
+    assert await ciw.drain_pending_issue_posts(_RT(None)) == 0

--- a/tests/test_autonomy/test_contributor_worklog_config.py
+++ b/tests/test_autonomy/test_contributor_worklog_config.py
@@ -1,0 +1,170 @@
+"""Contributor Work-Log control surface: live-read mode lever + knobs + env
+kill switch + settings domain registration/validator (repo_pulse lineage)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from genesis.autonomy import contributor_worklog_config as cwc
+from genesis.mcp.health.settings import (
+    _DOMAIN_REGISTRY,
+    _DOMAIN_VALIDATORS,
+    _validate_contributor_worklog,
+)
+
+
+@pytest.fixture
+def config_dirs(tmp_path, monkeypatch) -> tuple[Path, Path]:
+    """Redirect base + overlay config resolution into tmp dirs, and clear the
+    kill-switch env so tests start from a clean lever."""
+    repo_dir = tmp_path / "repo"
+    user_dir = tmp_path / "user_config"
+    (repo_dir / "config").mkdir(parents=True)
+    user_dir.mkdir(parents=True)
+    monkeypatch.setattr(cwc, "repo_root", lambda: repo_dir)
+    monkeypatch.setattr("genesis._config_overlay._user_config_dir", lambda: user_dir)
+    monkeypatch.delenv(cwc._DISABLE_ENV, raising=False)
+    return (
+        repo_dir / "config" / "contributor_worklog.yaml",
+        user_dir / "contributor_worklog.local.yaml",
+    )
+
+
+# ── effective_mode ───────────────────────────────────────────────────────
+
+
+def test_defaults_propose_only_when_no_config(config_dirs):
+    """Shipped posture: propose + approve, but NEVER auto-post."""
+    assert cwc.effective_mode() == "propose_only"
+
+
+def test_off_via_mode(config_dirs):
+    base, _ = config_dirs
+    base.write_text("mode: 'off'\n")
+    assert cwc.effective_mode() == "off"
+
+
+def test_off_via_unquoted_yaml_bool(config_dirs):
+    base, _ = config_dirs
+    base.write_text("mode: off\n")
+    assert cwc.effective_mode() == "off"
+
+
+def test_master_enabled_false_wins(config_dirs):
+    base, _ = config_dirs
+    base.write_text("enabled: false\nmode: live\n")
+    assert cwc.effective_mode() == "off"
+
+
+def test_live_mode(config_dirs):
+    base, _ = config_dirs
+    base.write_text("mode: live\n")
+    assert cwc.effective_mode() == "live"
+
+
+def test_invalid_mode_degrades_to_propose_only(config_dirs, caplog):
+    """Invalid config never silently posts to a public repo — degrades to
+    propose_only, not live."""
+    base, _ = config_dirs
+    base.write_text("mode: bananas\n")
+    with caplog.at_level("WARNING"):
+        assert cwc.effective_mode() == "propose_only"
+    assert any("propose_only" in r.message for r in caplog.records)
+
+
+def test_env_kill_switch_forces_off(config_dirs, monkeypatch):
+    """The kill switch overrides even an explicit `mode: live`."""
+    base, _ = config_dirs
+    base.write_text("mode: live\n")
+    assert cwc.effective_mode() == "live"
+    monkeypatch.setenv(cwc._DISABLE_ENV, "1")
+    assert cwc.effective_mode() == "off"
+
+
+def test_overlay_wins_over_base(config_dirs):
+    base, overlay = config_dirs
+    base.write_text("mode: live\n")
+    overlay.write_text("mode: 'off'\n")
+    assert cwc.effective_mode() == "off"
+
+
+def test_corrupt_base_degrades_to_defaults(config_dirs):
+    base, _ = config_dirs
+    base.write_text("{{{{not yaml")
+    assert cwc.effective_mode() == "propose_only"
+
+
+def test_read_live_no_cache(config_dirs):
+    base, _ = config_dirs
+    base.write_text("mode: live\n")
+    assert cwc.effective_mode() == "live"
+    base.write_text("mode: 'off'\n")
+    assert cwc.effective_mode() == "off"  # next call
+
+
+# ── knob accessors ───────────────────────────────────────────────────────
+
+
+def test_knobs_from_config_and_defaults(config_dirs):
+    base, _ = config_dirs
+    base.write_text("retention_days: 7\n")
+    cfg = cwc.load_config()
+    assert cwc.knob_int(cfg, "retention_days") == 7
+    assert cwc.knob_int(cfg, "max_held") == cwc.DEFAULTS["max_held"]
+
+
+def test_knobs_reject_garbage_toward_defaults(config_dirs):
+    base, _ = config_dirs
+    base.write_text("retention_days: -3\nmax_held: 'many'\n")
+    cfg = cwc.load_config()
+    assert cwc.knob_int(cfg, "retention_days") == cwc.DEFAULTS["retention_days"]
+    assert cwc.knob_int(cfg, "max_held") == cwc.DEFAULTS["max_held"]
+
+
+# ── constants (imported by the MCP tool, drain, and approve-all exclusion) ─
+
+
+def test_shared_constants_stable():
+    assert cwc.CONTRIBUTOR_ISSUE_ACTION_TYPE == "contributor_issue_post"
+    assert cwc.CELL_DOMAIN == "github"
+    assert cwc.CELL_VERB == "issue_create"
+    assert cwc.CELL_RISK_CLASS == "public_write"
+
+
+# ── settings domain ──────────────────────────────────────────────────────
+
+
+def test_domain_registered():
+    assert "contributor_worklog" in _DOMAIN_REGISTRY
+    d = _DOMAIN_REGISTRY["contributor_worklog"]
+    assert d.readonly is False
+    assert d.needs_restart is False
+    assert d.config_filename == "contributor_worklog.yaml"
+    assert "contributor_worklog" in _DOMAIN_VALIDATORS
+
+
+def test_validator_accepts_valid_changes():
+    assert _validate_contributor_worklog({"enabled": False}) == []
+    assert _validate_contributor_worklog({"mode": "off"}) == []
+    assert _validate_contributor_worklog({"mode": "propose_only"}) == []
+    assert _validate_contributor_worklog({"mode": "live"}) == []
+    assert _validate_contributor_worklog({"retention_days": 60, "max_held": 5}) == []
+
+
+def test_validator_rejects_bad_values():
+    assert _validate_contributor_worklog({"mode": "shadow"})
+    assert _validate_contributor_worklog({"enabled": "false"})
+    assert _validate_contributor_worklog({"retention_days": 0})
+    assert _validate_contributor_worklog({"max_held": True})
+    assert _validate_contributor_worklog({"bogus": 1})
+
+
+def test_base_config_file_matches_defaults():
+    """The shipped config/contributor_worklog.yaml parses and matches DEFAULTS."""
+    import yaml
+
+    base = Path(__file__).parents[2] / "config" / "contributor_worklog.yaml"
+    cfg = yaml.safe_load(base.read_text())
+    assert cfg == cwc.DEFAULTS

--- a/tests/test_autonomy/test_contributor_worklog_config.py
+++ b/tests/test_autonomy/test_contributor_worklog_config.py
@@ -130,7 +130,17 @@ def test_shared_constants_stable():
     assert cwc.CONTRIBUTOR_ISSUE_ACTION_TYPE == "contributor_issue_post"
     assert cwc.CELL_DOMAIN == "github"
     assert cwc.CELL_VERB == "issue_create"
-    assert cwc.CELL_RISK_CLASS == "public_write"
+    assert cwc.CELL_RISK_CLASS == "bulk"
+
+
+def test_cell_constants_are_valid():
+    """The risk class MUST be a real RiskClass member — an off-enum value would
+    hard-fail the shared capability-grants machinery (CHECK constraint + severity
+    / prior-weight dicts) the moment the enforce stage touches this cell. This
+    guard would have caught the original 'public_write' (not a RiskClass) value."""
+    from genesis.autonomy.types import RiskClass
+
+    assert cwc.CELL_RISK_CLASS in {r.value for r in RiskClass}
 
 
 # ── settings domain ──────────────────────────────────────────────────────

--- a/tests/test_contribution/test_sanitize.py
+++ b/tests/test_contribution/test_sanitize.py
@@ -619,3 +619,123 @@ def test_fingerprint_missing_file_warns(tmp_path, clean_diff):
     )
     # The scan did NOT run, so it must not be reported as executed.
     assert "fingerprint" not in r.scanners_run
+
+
+# ── scan_prose: fail-closed sanitizer for free-text (issue bodies, etc.) ──────
+#
+# The Contributor Work-Log pipeline sanitizes PROSE (a drafted GitHub issue
+# title+body), not a unified diff. scan_diff() CANNOT be reused for that — it
+# routes everything through parse_diff(), which only keeps lines prefixed with
+# `+` under a `+++ b/<path>` header. Plain prose has neither, so parse_diff
+# yields ZERO added_lines → zero findings → ok=True: a FAIL-OPEN path through a
+# fail-CLOSED component. scan_prose() runs the raw-string detectors
+# (portability, emails, fingerprints, detect-secrets) directly on every line,
+# preserving the fail-closed `ok` contract.
+
+
+def test_scan_diff_fails_open_on_prose(tmp_path):
+    """Characterization: scan_diff() on plain prose sees no diff `+` lines, so
+    a private IP + home path sail through as ok=True. This is exactly the
+    fail-open hole scan_prose() exists to close — the paired proof below shows
+    scan_prose() BLOCKs the same text."""
+    prose = "Reach the box at 10.1.2.3 or look under /home/alice/genesis/data."
+    r = sanitize.scan_diff(prose, fingerprint_file=tmp_path / "no-fp.txt")
+    assert r.ok is True  # <-- the bug, pinned: prose is invisible to scan_diff
+
+
+def test_scan_prose_blocks_private_ip(tmp_path):
+    r = sanitize.scan_prose(
+        "Reach the box at 10.1.2.3 to reproduce.",
+        fingerprint_file=tmp_path / "no-fp.txt",
+    )
+    assert r.ok is False
+    assert any(f.kind == FindingKind.PORTABILITY for f in r.blocking())
+
+
+def test_scan_prose_blocks_home_path(tmp_path):
+    r = sanitize.scan_prose(
+        "The config lives at /home/alice/genesis/config.yaml on the box.",
+        fingerprint_file=tmp_path / "no-fp.txt",
+    )
+    assert r.ok is False
+    assert any(f.kind == FindingKind.PORTABILITY for f in r.blocking())
+
+
+def test_scan_prose_clean_ok(tmp_path):
+    """Genuinely portable technical prose — the kind a good-first-issue body
+    would contain — passes clean."""
+    r = sanitize.scan_prose(
+        "In `src/genesis/parser.py` the `chunk()` helper drops the last token "
+        "when the input has no trailing newline. Add a test and fix the "
+        "off-by-one. Good first issue.",
+        fingerprint_file=tmp_path / "no-fp.txt",
+    )
+    assert r.ok is True
+    assert r.blocking() == []
+
+
+def test_scan_prose_blocks_personal_email(tmp_path):
+    r = sanitize.scan_prose(
+        "Ping alice.jones@gmail.com for context.",
+        fingerprint_file=tmp_path / "no-fp.txt",
+    )
+    assert r.ok is False
+    assert any(f.kind == FindingKind.EMAIL for f in r.blocking())
+
+
+def test_scan_prose_blocks_fingerprint(tmp_path):
+    """Install-specific literals (host names, private repo) are caught only by
+    the fingerprint layer — scan_prose must run it when the file is present."""
+    fp = tmp_path / "fp.txt"
+    fp.write_text("SecretHostName\n")
+    r = sanitize.scan_prose(
+        "The failure only reproduces on SecretHostName after a reboot.",
+        fingerprint_file=fp,
+    )
+    assert r.ok is False
+    assert any(f.kind == FindingKind.FINGERPRINT for f in r.blocking())
+
+
+def test_scan_prose_scans_all_lines_not_just_first(tmp_path):
+    """A multi-paragraph body must be scanned in full — a leak on line 3 (not
+    the first line) is still caught. This is the precise property scan_diff
+    loses on prose."""
+    body = (
+        "## Summary\n"
+        "The digest table renders wrong when a cell has a pipe.\n"
+        "Seen live on 192.168.1.50 during testing.\n"
+        "## Steps\n"
+        "1. Add an inbox item with a `|`.\n"
+    )
+    r = sanitize.scan_prose(body, fingerprint_file=tmp_path / "no-fp.txt")
+    assert r.ok is False
+    assert any(
+        f.kind == FindingKind.PORTABILITY and f.line == 3 for f in r.blocking()
+    )
+
+
+def test_scan_prose_detect_secrets_missing_fails_closed(tmp_path):
+    """detect-secrets is the required floor — if the binary is absent, the
+    prose scan fails CLOSED (ok=False), never open."""
+    with patch.object(sanitize.shutil, "which", return_value=None):
+        r = sanitize.scan_prose(
+            "totally benign text", fingerprint_file=tmp_path / "no-fp.txt"
+        )
+    assert r.ok is False
+    assert any(f.kind == FindingKind.SECRET for f in r.blocking())
+
+
+def test_scan_prose_skips_diff_structural_scanners(tmp_path):
+    """scan_prose runs ONLY the raw-string detectors — the diff-structural
+    scanners (forbidden-path, gitignore, binary, size) are meaningless on prose
+    and must not run."""
+    r = sanitize.scan_prose(
+        "A clean sentence about `parser.py`.", fingerprint_file=tmp_path / "no-fp.txt"
+    )
+    assert r.ok is True
+    for structural in ("forbidden_paths", "gitignored_paths", "binary_check", "size_cap"):
+        assert structural not in r.scanners_run
+    # ...but the raw-string detectors DID run.
+    assert "portability" in r.scanners_run
+    assert "email_allowlist" in r.scanners_run
+    assert "detect-secrets" in r.scanners_run

--- a/tests/test_db/test_pending_issue_posts.py
+++ b/tests/test_db/test_pending_issue_posts.py
@@ -7,8 +7,8 @@ hold on rejection/timeout. Mirrors the WS-8 pending_email_sends shape.
 
 Covers the fresh-install path (create_all_tables), the versioned migration
 (up/down/idempotency), the request_id UNIQUE + status CHECK constraints, and the
-held→posted / held→rejected transitions including the double-post guard (a hold
-can leave 'held' exactly once).
+held→posted / held→rejected / held→dry_run transitions including the double-post
+guard (a hold can leave 'held' exactly once; dry_run is terminal).
 """
 
 from __future__ import annotations
@@ -221,3 +221,23 @@ class TestCrud:
         # already 'posted' — reject must not override.
         assert await pip.mark_rejected(db, "p1", rejected_at=_TS) is False
         assert (await pip.get_by_id(db, "p1"))["status"] == "posted"
+
+    @pytest.mark.asyncio
+    async def test_mark_dry_run_once(self, db):
+        # propose_only path: an approved hold is dry-run-terminal — shadow-observed
+        # once, marked 'dry_run', and NEVER posted (flipping the lever to 'live'
+        # must not retro-post it). Same single-flip guard as mark_posted.
+        await pip.create(db, **_ROW)
+        assert await pip.mark_dry_run(db, "p1", dry_run_at=_TS) is True
+        row = await pip.get_by_id(db, "p1")
+        assert row["status"] == "dry_run"
+        assert row["dry_run_at"] == _TS
+        # terminal: a second flip is a no-op, and it never reappears as work.
+        assert await pip.mark_dry_run(db, "p1", dry_run_at=_TS) is False
+        assert await pip.list_held(db) == []
+        # dry_run is terminal — a later post/reject must not override it.
+        assert (
+            await pip.mark_posted(db, "p1", issue_number=9, issue_url="u", posted_at=_TS) is False
+        )
+        assert await pip.mark_rejected(db, "p1", rejected_at=_TS) is False
+        assert (await pip.get_by_id(db, "p1"))["status"] == "dry_run"

--- a/tests/test_db/test_pending_issue_posts.py
+++ b/tests/test_db/test_pending_issue_posts.py
@@ -1,0 +1,223 @@
+"""Tests for pending_issue_posts — table, migration 0079, and CRUD.
+
+The Contributor Work-Log hold store: a curator drafts a public GitHub issue,
+which is sanitized + parked here (status='held') with a linked approval_requests
+row; a resolution watcher posts it below the gate on approval, or expires the
+hold on rejection/timeout. Mirrors the WS-8 pending_email_sends shape.
+
+Covers the fresh-install path (create_all_tables), the versioned migration
+(up/down/idempotency), the request_id UNIQUE + status CHECK constraints, and the
+held→posted / held→rejected transitions including the double-post guard (a hold
+can leave 'held' exactly once).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import pending_issue_posts as pip
+
+MIGRATION = importlib.import_module("genesis.db.migrations.0079_pending_issue_posts")
+
+_ROW = {
+    "id": "p1",
+    "request_id": "req-1",
+    "repo": "WingedGuardian/GENesis-AGI",
+    "title": "Fix off-by-one in chunk()",
+    "body": "The chunk() helper drops the last token when input lacks a newline.",
+    "source": "follow_up",
+    "source_ref": "fu-abc",
+    "labels": '["good first issue"]',
+    "cell_domain": "github",
+    "cell_verb": "issue_create",
+    "cell_risk_class": "public_write",
+    "held_at": "2026-08-07T00:00:00",
+}
+_TS = "2026-08-07T01:00:00"
+
+
+@pytest.fixture
+async def db(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    async with aiosqlite.connect(db_path) as conn:
+        conn.row_factory = aiosqlite.Row
+        await MIGRATION.up(conn)
+        await conn.commit()
+        yield conn
+
+
+# --------------------------------------------------------------------------- #
+# Schema / migration
+# --------------------------------------------------------------------------- #
+class TestSchema:
+    @pytest.mark.asyncio
+    async def test_table_and_index_exist(self, db):
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='pending_issue_posts'"
+        )
+        assert await cur.fetchone() is not None
+        cur = await db.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' "
+            "AND name='idx_pending_issue_posts_status'"
+        )
+        assert await cur.fetchone() is not None
+
+    @pytest.mark.asyncio
+    async def test_up_is_idempotent(self, tmp_path):
+        path = str(tmp_path / "idem.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await MIGRATION.up(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='pending_issue_posts'"
+            )
+            assert (await cur.fetchone())[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_down_drops_table(self, tmp_path):
+        path = str(tmp_path / "down.db")
+        async with aiosqlite.connect(path) as conn:
+            await MIGRATION.up(conn)
+            await MIGRATION.down(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='pending_issue_posts'"
+            )
+            assert (await cur.fetchone())[0] == 0
+
+    @pytest.mark.asyncio
+    async def test_fresh_install_creates_table(self, tmp_path):
+        from genesis.db.schema import create_all_tables
+
+        path = str(tmp_path / "fresh.db")
+        async with aiosqlite.connect(path) as conn:
+            await create_all_tables(conn)
+            await conn.commit()
+            cur = await conn.execute(
+                "SELECT COUNT(*) FROM sqlite_master "
+                "WHERE type='table' AND name='pending_issue_posts'"
+            )
+            assert (await cur.fetchone())[0] == 1
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_status(self, db):
+        with pytest.raises(aiosqlite.IntegrityError):
+            await db.execute(
+                "INSERT INTO pending_issue_posts "
+                "(id, request_id, repo, title, body, source, "
+                " cell_domain, cell_verb, cell_risk_class, held_at, status) "
+                "VALUES ('x','r','o/r','t','b','follow_up',"
+                "'github','issue_create','public_write','t','BOGUS')"
+            )
+
+    @pytest.mark.asyncio
+    async def test_request_id_unique(self, db):
+        await pip.create(db, **_ROW)
+        with pytest.raises(aiosqlite.IntegrityError):
+            await pip.create(db, **{**_ROW, "id": "p2"})  # same request_id
+
+
+# --------------------------------------------------------------------------- #
+# CRUD + transitions
+# --------------------------------------------------------------------------- #
+class TestCrud:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, db):
+        await pip.create(db, **_ROW)
+        row = await pip.get_by_id(db, "p1")
+        assert row["status"] == "held"
+        assert row["repo"] == "WingedGuardian/GENesis-AGI"
+        assert row["title"] == "Fix off-by-one in chunk()"
+        assert row["source"] == "follow_up"
+        assert row["source_ref"] == "fu-abc"
+        assert row["labels"] == '["good first issue"]'
+        assert (await pip.get_by_request(db, "req-1"))["id"] == "p1"
+
+    @pytest.mark.asyncio
+    async def test_create_defaults_nullable(self, db):
+        # labels + source_ref are optional; a codebase-sourced draft omits them.
+        await pip.create(
+            db,
+            id="c1",
+            request_id="req-c1",
+            repo="WingedGuardian/GENesis-AGI",
+            title="Add a test for parser.chunk",
+            body="No test covers the empty-input case.",
+            source="codebase",
+            cell_domain="github",
+            cell_verb="issue_create",
+            cell_risk_class="public_write",
+            held_at="2026-08-07T00:00:00",
+        )
+        row = await pip.get_by_id(db, "c1")
+        assert row["labels"] is None
+        assert row["source_ref"] is None
+        assert row["source"] == "codebase"
+
+    @pytest.mark.asyncio
+    async def test_list_held(self, db):
+        await pip.create(db, **_ROW)
+        await pip.create(db, **{**_ROW, "id": "p2", "request_id": "req-2"})
+        held = await pip.list_held(db)
+        assert {r["id"] for r in held} == {"p1", "p2"}
+
+    @pytest.mark.asyncio
+    async def test_mark_posted_once(self, db):
+        await pip.create(db, **_ROW)
+        assert (
+            await pip.mark_posted(
+                db,
+                "p1",
+                issue_number=42,
+                issue_url="https://github.com/o/r/issues/42",
+                posted_at=_TS,
+            )
+            is True
+        )
+        # double-post guard: second flip is a no-op.
+        assert (
+            await pip.mark_posted(
+                db,
+                "p1",
+                issue_number=42,
+                issue_url="https://github.com/o/r/issues/42",
+                posted_at=_TS,
+            )
+            is False
+        )
+        row = await pip.get_by_id(db, "p1")
+        assert row["status"] == "posted"
+        assert row["issue_number"] == 42
+        assert row["issue_url"] == "https://github.com/o/r/issues/42"
+        assert row["posted_at"] == _TS
+        assert await pip.list_held(db) == []
+
+    @pytest.mark.asyncio
+    async def test_mark_rejected_and_expired(self, db):
+        await pip.create(db, **_ROW)
+        assert await pip.mark_rejected(db, "p1", rejected_at=_TS) is True
+        assert (await pip.get_by_id(db, "p1"))["status"] == "rejected"
+
+        await pip.create(db, **{**_ROW, "id": "p2", "request_id": "req-2"})
+        assert await pip.mark_rejected(db, "p2", rejected_at=_TS, expired=True) is True
+        assert (await pip.get_by_id(db, "p2"))["status"] == "expired"
+
+    @pytest.mark.asyncio
+    async def test_posted_then_reject_is_noop(self, db):
+        await pip.create(db, **_ROW)
+        await pip.mark_posted(
+            db,
+            "p1",
+            issue_number=7,
+            issue_url="u",
+            posted_at=_TS,
+        )
+        # already 'posted' — reject must not override.
+        assert await pip.mark_rejected(db, "p1", rejected_at=_TS) is False
+        assert (await pip.get_by_id(db, "p1"))["status"] == "posted"

--- a/tests/test_db/test_pending_issue_posts.py
+++ b/tests/test_db/test_pending_issue_posts.py
@@ -33,7 +33,7 @@ _ROW = {
     "labels": '["good first issue"]',
     "cell_domain": "github",
     "cell_verb": "issue_create",
-    "cell_risk_class": "public_write",
+    "cell_risk_class": "bulk",
     "held_at": "2026-08-07T00:00:00",
 }
 _TS = "2026-08-07T01:00:00"
@@ -113,7 +113,7 @@ class TestSchema:
                 "(id, request_id, repo, title, body, source, "
                 " cell_domain, cell_verb, cell_risk_class, held_at, status) "
                 "VALUES ('x','r','o/r','t','b','follow_up',"
-                "'github','issue_create','public_write','t','BOGUS')"
+                "'github','issue_create','bulk','t','BOGUS')"
             )
 
     @pytest.mark.asyncio
@@ -152,7 +152,7 @@ class TestCrud:
             source="codebase",
             cell_domain="github",
             cell_verb="issue_create",
-            cell_risk_class="public_write",
+            cell_risk_class="bulk",
             held_at="2026-08-07T00:00:00",
         )
         row = await pip.get_by_id(db, "c1")
@@ -207,6 +207,32 @@ class TestCrud:
         await pip.create(db, **{**_ROW, "id": "p2", "request_id": "req-2"})
         assert await pip.mark_rejected(db, "p2", rejected_at=_TS, expired=True) is True
         assert (await pip.get_by_id(db, "p2"))["status"] == "expired"
+
+    @pytest.mark.asyncio
+    async def test_prune_terminal_keeps_held_and_recent(self, db):
+        # held row (never prunable), an OLD posted row, and a RECENT dry_run row.
+        await pip.create(db, **{**_ROW, "id": "held", "request_id": "r-held"})
+        await pip.create(db, **{**_ROW, "id": "old", "request_id": "r-old"})
+        await pip.mark_posted(
+            db, "old", issue_number=1, issue_url="u", posted_at="2026-01-01T00:00:00"
+        )
+        await pip.create(db, **{**_ROW, "id": "new", "request_id": "r-new"})
+        await pip.mark_dry_run(db, "new", dry_run_at="2026-08-06T00:00:00")
+
+        now = "2026-08-07T00:00:00"
+        deleted = await pip.prune_terminal(db, older_than_days=30, now=now)
+        assert deleted == 1  # only the old posted row
+        assert await pip.get_by_id(db, "old") is None
+        assert (await pip.get_by_id(db, "held"))["status"] == "held"  # held NEVER pruned
+        assert (await pip.get_by_id(db, "new"))["status"] == "dry_run"  # recent kept
+
+    @pytest.mark.asyncio
+    async def test_prune_terminal_never_prunes_held_even_when_ancient(self, db):
+        # a held row with an ancient held_at must survive — it awaits the owner.
+        await pip.create(db, **{**_ROW, "held_at": "2020-01-01T00:00:00"})
+        deleted = await pip.prune_terminal(db, older_than_days=1, now="2026-08-07T00:00:00")
+        assert deleted == 0
+        assert (await pip.get_by_id(db, "p1"))["status"] == "held"
 
     @pytest.mark.asyncio
     async def test_posted_then_reject_is_noop(self, db):

--- a/tests/test_db/test_schema.py
+++ b/tests/test_db/test_schema.py
@@ -61,6 +61,7 @@ EXPECTED_TABLES = [
     "campaign_runs",
     "capability_grants",  # WS-8 PR-B: per-(domain,verb,risk_class) cells
     "pending_email_sends",  # WS-8 PR-C: email autonomy gate hold store
+    "pending_issue_posts",  # Contributor Work-Log: sanitized issue-draft hold store
     "autonomous_email_sends",  # WS-8 PR-D: autonomous-send ledger (visibility + flag + rate-limit)
     "capability_shadow_events",  # WS5 Stage 2: Discord capability shadow-gate observations
     "immunity_shadow_events",  # WS-3 B1: provenance-gate (injection) shadow observations

--- a/tests/test_mcp/test_contributor_issue.py
+++ b/tests/test_mcp/test_contributor_issue.py
@@ -75,7 +75,7 @@ async def test_held_creates_row_and_approval(db, live):
     assert ctx["repo"] == _REPO
     assert ctx["labels"] == ["good first issue", "help wanted"]
     assert ctx["source_follow_up_id"] == "fu-123"
-    assert ctx["cell"] == ["github", "issue_create", "public_write"]
+    assert ctx["cell"] == ["github", "issue_create", "bulk"]
 
 
 @pytest.mark.asyncio
@@ -96,7 +96,7 @@ async def test_blocked_private_ip_creates_no_row(db, live):
     res = await _propose(
         db,
         title="Fix the timeout on the box",
-        body="On the host at 192.168.50.77 the poller hangs; raise the timeout.",
+        body="On the host at 192.168.1.42 the poller hangs; raise the timeout.",
     )
     assert res["status"] == "blocked"
     assert res["reasons"]  # non-empty findings

--- a/tests/test_mcp/test_contributor_issue.py
+++ b/tests/test_mcp/test_contributor_issue.py
@@ -1,0 +1,230 @@
+"""contributor_issue_propose MCP tool core (_impl) — the Contributor Work-Log
+PROPOSE door: server-side sanitize → hold + linked approval, with dedup /
+backpressure / mode gating. Mirrors the WS-8 email-gate two-row shape.
+"""
+
+from __future__ import annotations
+
+import json
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import approval_requests as ar
+from genesis.db.crud import pending_issue_posts as pip
+from genesis.db.schema import create_all_tables
+from genesis.mcp.health import contributor_issue as ci
+
+_REPO = "WingedGuardian/GENesis-AGI"
+
+
+@pytest.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await create_all_tables(conn)
+        await conn.commit()
+        yield conn
+
+
+@pytest.fixture
+def live(monkeypatch):
+    """Force mode=live with a small max_held so backpressure is testable."""
+    monkeypatch.setattr(ci, "effective_mode", lambda: "live")
+    monkeypatch.setattr(ci, "load_config", lambda: {"max_held": 3})
+
+
+async def _propose(db, **kw):
+    kw.setdefault("repo", _REPO)
+    return await ci._impl_contributor_issue_propose(db, **kw)
+
+
+# ── happy path ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_held_creates_row_and_approval(db, live):
+    res = await _propose(
+        db,
+        title="Add a test for parser.chunk empty input",
+        body="No test covers the empty-input branch of chunk(); add one.",
+        labels=["good first issue", "help wanted"],
+        source="follow_up",
+        source_follow_up_id="fu-123",
+    )
+    assert res["status"] == "held"
+    assert res["repo"] == _REPO
+    assert res["mode"] == "live"
+
+    row = await pip.get_by_id(db, res["pending_id"])
+    assert row["status"] == "held"
+    assert row["title"] == "Add a test for parser.chunk empty input"
+    assert row["source"] == "follow_up"
+    assert row["source_ref"] == "fu-123"
+    assert json.loads(row["labels"]) == ["good first issue", "help wanted"]
+    assert row["cell_domain"] == "github"
+    assert row["request_id"] == res["request_id"]
+
+    # linked approval row, correct type/class/context.
+    appr = await ar.get_by_id(db, res["request_id"])
+    assert appr is not None
+    assert appr["action_type"] == "contributor_issue_post"
+    assert appr["action_class"] == "irreversible"
+    assert appr["status"] == "pending"
+    ctx = json.loads(appr["context"])
+    assert ctx["repo"] == _REPO
+    assert ctx["labels"] == ["good first issue", "help wanted"]
+    assert ctx["source_follow_up_id"] == "fu-123"
+    assert ctx["cell"] == ["github", "issue_create", "public_write"]
+
+
+@pytest.mark.asyncio
+async def test_propose_only_message_hints_dry_run(db, monkeypatch):
+    monkeypatch.setattr(ci, "effective_mode", lambda: "propose_only")
+    monkeypatch.setattr(ci, "load_config", lambda: {"max_held": 25})
+    res = await _propose(db, title="Improve the README quickstart", body="Clarify setup steps.")
+    assert res["status"] == "held"
+    assert res["mode"] == "propose_only"
+    assert "dry-run" in res["message"].lower()
+
+
+# ── fail-closed sanitizer ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_blocked_private_ip_creates_no_row(db, live):
+    res = await _propose(
+        db,
+        title="Fix the timeout on the box",
+        body="On the host at 192.168.50.77 the poller hangs; raise the timeout.",
+    )
+    assert res["status"] == "blocked"
+    assert res["reasons"]  # non-empty findings
+    # NO row, NO approval created.
+    assert await pip.list_held(db) == []
+    cur = await db.execute("SELECT COUNT(*) FROM approval_requests")
+    assert (await cur.fetchone())[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_blocked_private_ip_in_label_creates_no_row(db, live):
+    """Labels egress to the public repo via `gh issue create --label`, so they
+    are sanitized too — a private identifier in a LABEL must block, not just in
+    the body."""
+    res = await _propose(
+        db,
+        title="A perfectly clean title",
+        body="A perfectly clean body with nothing sensitive.",
+        labels=["good first issue", "seen-on-10.0.0.5"],
+    )
+    assert res["status"] == "blocked"
+    assert res["reasons"]
+    assert await pip.list_held(db) == []
+    cur = await db.execute("SELECT COUNT(*) FROM approval_requests")
+    assert (await cur.fetchone())[0] == 0
+
+
+# ── dedup + backpressure ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_duplicate_title_blocked(db, live):
+    a = await _propose(db, title="Add retries to the fetch helper", body="It fails on flaky nets.")
+    assert a["status"] == "held"
+    # same title, different case/whitespace → duplicate.
+    b = await _propose(db, title="  add   RETRIES to the fetch helper ", body="Different body.")
+    assert b["status"] == "duplicate"
+    assert b["existing_id"] == a["pending_id"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_source_ref_blocked(db, live):
+    a = await _propose(db, title="First title", body="Body one.", source_follow_up_id="fu-9")
+    assert a["status"] == "held"
+    b = await _propose(
+        db, title="Completely different title", body="Body two.", source_follow_up_id="fu-9"
+    )
+    assert b["status"] == "duplicate"
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_block_reproposal(db, live):
+    """A dry-run hold is re-proposed under 'live' to actually post — so it must
+    NOT count as a dedup collision."""
+    a = await _propose(db, title="Port the config loader", body="Move it off the old path.")
+    await pip.mark_dry_run(db, a["pending_id"], dry_run_at="2026-08-07T00:00:00")
+    b = await _propose(db, title="Port the config loader", body="Move it off the old path.")
+    assert b["status"] == "held"
+    assert b["pending_id"] != a["pending_id"]
+
+
+@pytest.mark.asyncio
+async def test_backpressure_at_max_held(db, live):
+    # max_held=3 (from the `live` fixture).
+    for i in range(3):
+        r = await _propose(db, title=f"Task number {i}", body=f"Body {i}.")
+        assert r["status"] == "held"
+    over = await _propose(db, title="One too many", body="Should be refused.")
+    assert over["status"] == "backpressure"
+    assert len(await pip.list_held(db)) == 3
+
+
+# ── gating / validation ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mode_off_disabled(db, monkeypatch):
+    monkeypatch.setattr(ci, "effective_mode", lambda: "off")
+    res = await _propose(db, title="anything", body="anything")
+    assert res["status"] == "disabled"
+    assert await pip.list_held(db) == []
+
+
+@pytest.mark.asyncio
+async def test_missing_fields_error(db, live):
+    assert (await _propose(db, title="", body="b"))["status"] == "error"
+    assert (await _propose(db, title="t", body=""))["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_bad_source_error(db, live):
+    res = await _propose(db, title="t", body="b", source="bogus")
+    assert res["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_bad_repo_error(db, live):
+    res = await _propose(db, title="t", body="b", repo="not-a-repo")
+    assert res["status"] == "error"
+
+
+# ── batch approve-all must NEVER sweep a held issue (public-repo write) ─────
+
+
+@pytest.mark.asyncio
+async def test_approve_all_pending_excludes_contributor_issue(db, live):
+    """A single 'approve all' click (dashboard or Telegram cli_approve_all) must
+    NOT bulk-approve held contributor-issue drafts — each is one public-repo
+    post and must be approved individually. Mirrors the WS-8 email exclusion."""
+    from unittest.mock import MagicMock
+
+    from genesis.autonomy.approval import ApprovalManager
+    from genesis.autonomy.approval_gate import AutonomousCliApprovalGate
+    from genesis.db.crud import approval_requests as ar
+
+    # A held contributor-issue draft (creates its own approval row) ...
+    res = await _propose(db, title="Contributor task", body="A newcomer-friendly task.")
+    issue_rid = res["request_id"]
+    # ... alongside an ordinary CLI-fallback approval.
+    mgr = ApprovalManager(db=db)
+    cli_rid = await mgr.request_approval(
+        action_type="autonomous_cli_fallback",
+        action_class="reversible",
+        description="cli action",
+    )
+    gate = AutonomousCliApprovalGate(runtime=MagicMock(), approval_manager=mgr)
+
+    n = await gate.approve_all_pending(resolved_by="user")
+    assert n == 1  # only the CLI approval was swept
+    assert (await ar.get_by_id(db, issue_rid))["status"] == "pending"  # still held
+    assert (await ar.get_by_id(db, cli_rid))["status"] == "approved"


### PR DESCRIPTION
## Contributor Work-Log — public-issue supply for contributors

Turns curated backlog/codebase items into public GitHub issues for contributors, gated behind per-item owner approval. This PR is the committed **infrastructure** (propose + post path); the curator campaigns that feed it are local, uncommitted user data.

### Flow
1. A local curator drafts an issue and calls the `contributor_issue_propose` MCP tool (server-side, trusted boundary).
2. The tool sanitizes title + body + labels with the fail-closed `scan_prose` (blocks private IPs/paths/emails/secrets); if clean, it **holds** the draft in `pending_issue_posts` + a linked `approval_requests` row (approval row FIRST, crash-safe).
3. Owner approves **per item** on the dashboard — batch "approve all" excludes these, exactly like the WS-8 email gate.
4. The `contributor_issue_watcher` drain (every 5 min, `max_instances=1`) resolves approved holds under the `contributor_worklog` mode lever:
   - `propose_only` (default) → shadow-observe the egress once + mark `dry_run` (terminal; a later flip to `live` never retro-posts it).
   - `live` → `gh issue create`, deduped against open issues. `mark_posted` runs **before** `mark_consumed`, and a pre-post `gh issue list` dedup adopts an already-open same-title issue, so a crash can't double-post.
   - `off` → leave held. rejected/cancelled/expired/orphan → close out.

### Safety
- Fail-closed sanitizer at the **trusted server boundary** — a misbehaving curator subprocess can't bypass it; it covers every string that egresses (title, body, **and** labels).
- The new GitHub issue-create egress door is **shadow-gated** (`observe_github_issue_create`, observe-only, best-effort).
- Ships `propose_only` — **nothing posts** until `mode: live` is set in a `config/contributor_worklog.local.yaml` overlay. Env kill switch: `GENESIS_CONTRIBUTOR_WORKLOG_DISABLED=1`.
- Retention prune of terminal rows (>30d); **held rows are never pruned**.

### Tests / verification
- Unit + integration (~90 tests): sanitizer prose fail-closed, hold-store transitions (`dry_run` terminal + single-flip), propose tool (block / dedup / backpressure / mode / approve-all exclusion), drain state machine (live / propose_only / off / dedup-adopt / list+create failure / orphan / pending), retention (held never pruned), cell-risk-class validity.
- Full propose → approve → drain chain **E2E-verified locally** (both modes, no double-post); `gh` mocked only at the subprocess boundary.
- Two local Claude review rounds on each half (propose + post path). Codex adversarial review owed once quota resets.

### Deferred
- `a3d226da` — upgrade the pre-post GitHub dedup to a search-based lookup before the repo approaches ~200 open issues (dormant today: repo far below that, ships `propose_only`, DB-side dedup unbounded).

Ledger: e9bcfcc4543b4bb5b40a2367d950f339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
