### PR TITLE
feat(ego): surface completed dispatch findings in the dashboard

### DIFF
--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -338,6 +338,8 @@ async def ego_cadence():
 @_async_route
 async def ego_proposals_all():
     """Return all proposals with optional status filter and limit."""
+    import contextlib
+
     from genesis.db.crud import ego as ego_crud
     from genesis.runtime import GenesisRuntime
 
@@ -349,6 +351,18 @@ async def ego_proposals_all():
     limit = min(request.args.get("limit", 50, type=int), 200)
 
     proposals = await ego_crud.list_proposals(rt._db, status=status, limit=limit)
+    # Surface completed ego-dispatch findings: attach the dispatch session's
+    # output excerpt + transcript pointer so the debrief is discoverable in the
+    # dashboard, not just the 1000-char user_response summary.
+    from genesis.db.crud import cc_sessions as cc_sessions_crud
+
+    # Best-effort: a join failure (e.g. a legacy row with non-JSON metadata) must
+    # never 500 the core proposals list — degrade to no dispatch info.
+    dispatch_map: dict = {}
+    with contextlib.suppress(Exception):
+        dispatch_map = await cc_sessions_crud.dispatch_info_for_proposals(
+            rt._db, [p["id"] for p in proposals]
+        )
     return jsonify(
         [
             {
@@ -374,6 +388,7 @@ async def ego_proposals_all():
                 "revision_num": p.get("revision_num", 1),
                 "revalidate_at": p.get("revalidate_at"),
                 "last_validated_at": p.get("last_validated_at"),
+                "dispatch": dispatch_map.get(p["id"]),
             }
             for p in proposals
         ]

--- a/src/genesis/dashboard/templates/partials/modals/ego.html
+++ b/src/genesis/dashboard/templates/partials/modals/ego.html
@@ -340,6 +340,23 @@
                         <span style="font-weight: 600;">Response:</span> <span x-text="p.user_response"></span>
                       </div>
                     </template>
+                    <!-- Dispatch findings: the completed dispatch session's output, so the
+                         investigation is discoverable beyond the truncated response summary -->
+                    <template x-if="p.dispatch">
+                      <details style="margin-top: 0.3rem;">
+                        <summary style="font-size: 0.72rem; color: var(--color-text-secondary); cursor: pointer; font-weight: 600;">
+                          Dispatch output
+                        </summary>
+                        <pre style="font-size: 0.7rem; color: var(--color-text-secondary); white-space: pre-wrap; word-break: break-word; margin: 0.3rem 0; max-height: 22rem; overflow-y: auto; background: rgba(0,0,0,0.04); padding: 0.4rem; border-radius: 4px;"
+                             x-text="p.dispatch.output_excerpt"></pre>
+                        <div style="font-size: 0.66rem; color: var(--color-text-secondary); opacity: 0.8;">
+                          <span>session: </span><span x-text="p.dispatch.session_id"></span>
+                          <template x-if="p.dispatch.transcript_path">
+                            <span> · transcript: <span x-text="p.dispatch.transcript_path"></span></span>
+                          </template>
+                        </div>
+                      </details>
+                    </template>
                     <!-- Approve/Reject buttons (pending, non-informational only) -->
                     <template x-if="p.status === 'pending' && !$store.genesisDashboard.isInformationalProposal(p)">
                       <div style="margin-top: 0.5rem; display: flex; gap: 0.4rem; align-items: center;">

--- a/src/genesis/db/crud/cc_sessions.py
+++ b/src/genesis/db/crud/cc_sessions.py
@@ -343,6 +343,50 @@ async def query_by_skill_tag(
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def dispatch_info_for_proposals(
+    db: aiosqlite.Connection,
+    proposal_ids: list[str],
+) -> dict[str, dict]:
+    """Map ``proposal_id -> {session_id, transcript_path, output_excerpt}`` for
+    ego-dispatch sessions whose ``metadata.caller_context`` is
+    ``ego_proposal:<id>`` (set by ``direct_session._store_result``).
+
+    One bounded query over the passed id set (the caller caps it). Newest session
+    wins per proposal (retries re-dispatch under the same caller_context). The
+    excerpt is capped so the dashboard payload stays small — the full text lives
+    in ``metadata.output_text`` and the CC transcript at ``transcript_path``.
+    Filters on ``json_extract(metadata,'$.caller_context')`` — an unindexed scan
+    of cc_sessions, acceptable for an on-demand dashboard read.
+    """
+    if not proposal_ids:
+        return {}
+    keys = [f"ego_proposal:{pid}" for pid in proposal_ids]
+    placeholders = ",".join("?" * len(keys))
+    cursor = await db.execute(
+        f"""SELECT id AS session_id,
+                   json_extract(metadata, '$.caller_context') AS caller_context,
+                   json_extract(metadata, '$.transcript_path') AS transcript_path,
+                   json_extract(metadata, '$.output_text') AS output_text
+            FROM cc_sessions
+            WHERE json_valid(metadata)
+              AND json_extract(metadata, '$.caller_context') IN ({placeholders})
+            ORDER BY started_at DESC""",
+        tuple(keys),
+    )
+    out: dict[str, dict] = {}
+    for r in await cursor.fetchall():
+        cc = r["caller_context"] or ""
+        pid = cc.split(":", 1)[1] if ":" in cc else ""
+        if not pid or pid in out:  # newest wins (DESC order above)
+            continue
+        out[pid] = {
+            "session_id": r["session_id"],
+            "transcript_path": r["transcript_path"],
+            "output_excerpt": (r["output_text"] or "")[:4000],
+        }
+    return out
+
+
 async def get_by_session_types(
     db: aiosqlite.Connection,
     session_types: set[str],

--- a/tests/test_db/test_cc_sessions_dispatch.py
+++ b/tests/test_db/test_cc_sessions_dispatch.py
@@ -1,0 +1,113 @@
+"""Tests for cc_sessions.dispatch_info_for_proposals — the join that surfaces
+completed ego-dispatch findings in the dashboard proposal detail."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from genesis.db.crud import cc_sessions as cc_crud
+
+
+async def _mk_session(db, *, sid, proposal_id, output, transcript, started_at):
+    await cc_crud.create(
+        db,
+        id=sid,
+        session_type="background_task",
+        model="opus",
+        started_at=started_at,
+        last_activity_at=started_at,
+        source_tag="ego_dispatch",
+        metadata=json.dumps(
+            {
+                "caller_context": f"ego_proposal:{proposal_id}",
+                "output_text": output,
+                "transcript_path": transcript,
+            }
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_maps_proposal_to_dispatch_output(db):
+    await _mk_session(
+        db,
+        sid="s1",
+        proposal_id="pA",
+        output="finding A body",
+        transcript="/x/a.jsonl",
+        started_at="2026-08-01T00:00:00+00:00",
+    )
+    out = await cc_crud.dispatch_info_for_proposals(db, ["pA", "pMissing"])
+    assert set(out) == {"pA"}  # unmatched proposal id absent
+    assert out["pA"]["session_id"] == "s1"
+    assert out["pA"]["output_excerpt"] == "finding A body"
+    assert out["pA"]["transcript_path"] == "/x/a.jsonl"
+
+
+@pytest.mark.asyncio
+async def test_newest_session_wins(db):
+    await _mk_session(
+        db,
+        sid="old",
+        proposal_id="pB",
+        output="OLD",
+        transcript="/x/old.jsonl",
+        started_at="2026-08-01T00:00:00+00:00",
+    )
+    await _mk_session(
+        db,
+        sid="new",
+        proposal_id="pB",
+        output="NEW",
+        transcript="/x/new.jsonl",
+        started_at="2026-08-05T00:00:00+00:00",
+    )
+    out = await cc_crud.dispatch_info_for_proposals(db, ["pB"])
+    assert out["pB"]["session_id"] == "new"
+    assert out["pB"]["output_excerpt"] == "NEW"
+
+
+@pytest.mark.asyncio
+async def test_empty_ids_returns_empty(db):
+    assert await cc_crud.dispatch_info_for_proposals(db, []) == {}
+
+
+@pytest.mark.asyncio
+async def test_malformed_metadata_row_is_skipped_not_fatal(db):
+    # A legacy/corrupt row with non-JSON metadata must be filtered by json_valid,
+    # not raise a "malformed JSON" error that breaks the whole join.
+    await cc_crud.create(
+        db,
+        id="bad",
+        session_type="background_task",
+        model="opus",
+        started_at="2026-08-02T00:00:00+00:00",
+        last_activity_at="2026-08-02T00:00:00+00:00",
+        metadata="this is not json",
+    )
+    await _mk_session(
+        db,
+        sid="good",
+        proposal_id="pD",
+        output="D",
+        transcript="/x/d.jsonl",
+        started_at="2026-08-01T00:00:00+00:00",
+    )
+    out = await cc_crud.dispatch_info_for_proposals(db, ["pD"])
+    assert out["pD"]["session_id"] == "good"  # good row returned, bad row skipped
+
+
+@pytest.mark.asyncio
+async def test_excerpt_capped(db):
+    await _mk_session(
+        db,
+        sid="big",
+        proposal_id="pC",
+        output="x" * 9000,
+        transcript=None,
+        started_at="2026-08-01T00:00:00+00:00",
+    )
+    out = await cc_crud.dispatch_info_for_proposals(db, ["pC"])
+    assert len(out["pC"]["output_excerpt"]) == 4000


### PR DESCRIPTION
## What
Makes completed ego-dispatch findings **discoverable** in the dashboard. After a dispatch finishes, the proposal detail showed only the 1000-char `user_response` summary; the full investigation output lived unseen in `cc_sessions.metadata`. This joins them back.

- **CRUD** `cc_sessions.dispatch_info_for_proposals(ids)`: one bounded query (`json_extract(metadata,'$.caller_context') IN (...)`) mapping each proposal → its dispatch session's `output_excerpt` (capped 4000) + `transcript_path` + `session_id`. Newest session wins per proposal.
- **Route** `ego_proposals_all`: attaches a `dispatch` field per proposal.
- **Template**: a collapsible `<details>` "Dispatch output" block (Alpine `x-text`, XSS-safe), shown only when `p.dispatch` exists.

Discoverability-first: **read-only surfacing, no LLM extraction, no auto-filed follow-ups** (the prior `record_follow_ups` harvest ran 84% noise and stays disabled).

## Robustness (review SHOULD-FIX addressed)
The join is best-effort so it can never regress the core proposals view: `contextlib.suppress` at the call site **and** a `json_valid(metadata)` guard in the query (SQLite short-circuits `AND`) so a legacy non-JSON metadata row can neither 500 the endpoint nor wipe out discoverability for good rows. `json_extract` raises on malformed JSON (verified) — the guard is load-bearing.

## Test
`tests/test_db/test_cc_sessions_dispatch.py` (5): maps output, newest-wins, empty-ids, excerpt-capped, malformed-metadata-skipped (RED without the `json_valid` guard). Verified **live against prod data** — real dispatch output surfaces for historical proposals (e.g. the voice identity-slice dispatch). Reviewed (feature-dev:code-reviewer): 1 SHOULD-FIX, fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)