### PR TITLE
fix(reflection): read-only tool lockdown + reserve follow-up board for foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Changed
 
+- **Reflection sessions are now strictly read-only.** Genesis's autonomous
+  background reflections (deep/strategic) can read freely to investigate, but can
+  no longer call any write or action tool — their only output is observations (and
+  the structured reflection result the system parses). Previously reflections ran
+  with unrestricted tool access and could, in rare cases, mint a follow-up or other
+  write from ungrounded reasoning. Relatedly, any follow-up created by an
+  autonomous/dispatched session now lands in the recoverable *tabled* lane for
+  review rather than directly on the actionable follow-up board — the board stays
+  reserved for your (foreground) work. A foreground session can promote a tabled
+  item to the board.
+
 - **Free-tier model refresh.** Groq is retiring Llama 3.3 70B (the model behind
   several of Genesis's free reasoning/extraction/tagging steps) on 2026-08-16, so
   those steps now use Groq's recommended replacement, gpt-oss-120b. Structured-output

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -194,8 +194,26 @@ any task bigger than an LLM call.
 ```yaml subsystem-map
 entry: execution-cc
 modules: [cc]
-verified: 0a3fc19d 2026-07-23
+verified: 5dcd9fd4 2026-08-07
 ```
+
+- **Reflection tool lockdown — read-only + observations only**
+  (`session_config.build_reflection_disallowed`, wired at `reflection_bridge/_bridge.py`
+  into the reflection `CCInvocation.disallowed_tools`). Deep/strategic reflections run
+  with a DERIVED denylist = (live `genesis-health` + `genesis-memory` registry − a read
+  allowlist − `observation_write`) + the write/action built-ins (Bash/Write/Edit/Task/
+  Workflow/Skill/…), so a future write tool is auto-denied. `--allowedTools` is NOT a
+  strict allowlist under `--dangerously-skip-permissions` (verified empirically 2026-08-07
+  via the init-event tool list — it left Bash available); only `--disallowedTools` removes
+  a tool, so the scoping is a denylist. Guards (`tests/test_cc/test_reflection_tool_scope.py`):
+  a sentinel asserts known write tools stay denied, a static AST scan rejects any
+  write-shaped tool in the read-allowlist, and a fail-closed check confirms every
+  registered tool is read-allowed or denied (a new upstream tool is auto-denied by the
+  derivation). Reflection previously bypassed
+  all tool scoping (the orphaned `build_reflection_config`/`_READONLY_DISALLOWED` was never
+  wired) — root cause of a 2026-07-03 fabricated follow-up. Sacred-board companion: an
+  autonomous/dispatched session's `follow_up_create` (source=`ego_dispatch`) is routed to
+  the cold `tabled` lane, never the hot board (`mcp/health/follow_up_tools.py`).
 
 - `cc/direct_session.py` + `cc/conversation.py` (both >1000 LOC; split
   candidates). Profile machinery: `PROFILES`, `_PROFILE_ADDENDA`,

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -259,9 +259,44 @@ class CCReflectionBridge:
                 mcp_path = _mcp.build_mcp_config("reflection")
             else:
                 mcp_path = None
+            # Reflection sessions are READ-ONLY + observation-writing only. The
+            # denylist is the reliable scoping mechanism: --allowedTools is NOT a
+            # strict allowlist under --dangerously-skip-permissions (verified
+            # empirically 2026-08-07 — it left Bash available). Derived so future
+            # write tools are auto-denied; see build_reflection_disallowed.
+            reflection_disallowed = _mcp.build_reflection_disallowed()
+            # Fail-closed: if reflection MCP-config generation returned None, use the
+            # EMPTY config so strict_mcp_config (below) can't fall through to CC's
+            # default (user-scoped) MCP discovery — which would load servers (e.g.
+            # gitnexus, codebase-memory-mcp) whose write tools the genesis-only denylist
+            # does NOT cover.
+            if mcp_path is None:
+                mcp_path = _mcp.build_mcp_config("none")
         except Exception:
-            logger.warning("MCP config generation failed, using defaults", exc_info=True)
-            mcp_path = None
+            logger.warning(
+                "MCP/tool config generation failed, using fail-closed defaults",
+                exc_info=True,
+            )
+            # Fail closed: point at the EMPTY MCP config (with strict_mcp_config no other
+            # server can load) AND reuse the full built-in denylist + wildcard MCP denies
+            # (single source of truth — no drift from a hand-maintained literal).
+            from genesis.cc.session_config import (
+                _REFLECTION_DENY_BUILTINS,
+                _REFLECTION_MCP_SERVERS,
+            )
+            from genesis.env import repo_root
+
+            # Resolve the shipped empty MCP config by PATH (no dependency on the
+            # config builder succeeding), so mcp_config is a real empty config rather
+            # than None — avoids relying on the untested "--strict-mcp-config with no
+            # --mcp-config" combination.
+            try:
+                mcp_path = str(repo_root() / "config" / "no_mcp.json")
+            except Exception:
+                mcp_path = None  # last resort; strict_mcp_config still forces zero servers
+            reflection_disallowed = list(_REFLECTION_DENY_BUILTINS) + [
+                f"mcp__{server}__*" for server, _ in _REFLECTION_MCP_SERVERS
+            ]
         invocation = CCInvocation(
             prompt=prompt,
             expect_output=True,  # silent-cap detection (reflection always emits text)
@@ -270,7 +305,12 @@ class CCReflectionBridge:
             timeout_s=_DEPTH_TIMEOUT_S.get(depth, 300),
             system_prompt=self._system_prompt_for_depth(depth),
             skip_permissions=True,
+            disallowed_tools=reflection_disallowed,
             mcp_config=mcp_path,
+            # ONLY the reflection MCP config's servers load — NOT the user-scoped
+            # servers in ~/.claude.json (--mcp-config is additive without this). Makes
+            # the genesis-only derived denylist authoritative. (Matches eval bench arms.)
+            strict_mcp_config=True,
             working_dir=background_session_dir(),
             stream_idle_timeout_ms=(
                 _DEPTH_TIMEOUT_S.get(depth, 300) * 1000

--- a/src/genesis/cc/session_config.py
+++ b/src/genesis/cc/session_config.py
@@ -28,6 +28,80 @@ _READONLY_DISALLOWED = [
 # disallowed_tools matches tool NAMES (e.g. "Bash"), not command substrings.
 # Hooks fire for ALL sessions including claude -p, so protection is global.
 
+# ── Reflection tool lockdown ──────────────────────────────────────────────
+# Autonomous reflection sessions (DEEP/STRATEGIC) are READ-ONLY: they read
+# freely to investigate, and their ONLY write is an observation (the
+# observation_write tool for interaction_theme observations, plus the structured
+# `observations` output field that the reflection output router parses and writes
+# server-side). Every OTHER registered MCP tool is DENIED — the denylist is
+# DERIVED as (live registry − read-allowlist − observation_write), so a write
+# tool a future PR adds to either server is auto-denied here without a code
+# change. This gives a denylist the safety of an allowlist, which matters because
+# `--allowedTools` is NOT a strict allowlist under `--dangerously-skip-permissions`
+# (verified empirically 2026-08-07 via the init-event tool list: --allowedTools
+# left Bash available; only --disallowedTools removes a tool). The read-allowlist
+# below is the maintained artifact; tests/test_cc/test_reflection_tool_scope.py
+# enforces it stays complete against the live registry.
+_REFLECTION_READ_MCP: frozenset[str] = frozenset({
+    # genesis-health — status / list / get / query (no mutation)
+    "bench_status", "bootstrap_manifest", "build_lane_status", "calibration_status",
+    "campaign_list", "campaign_status", "codebase_navigate", "cognitive_modification_status",
+    "db_schema", "direct_session_list", "direct_session_status", "ego_calibration_status",
+    "ego_goal_list", "experiment_status", "health_alerts", "health_errors", "health_status",
+    "immunity_status", "inbox_digest", "infrastructure_profile", "j9_eval_status", "job_health",
+    "loop_closure_status", "module_list", "provider_activity", "reflex_status",
+    "session_charter", "settings_get", "settings_list",
+    "subsystem_heartbeats", "task_detail", "task_list", "update_history_recent",
+    "follow_up_list", "web_fetch", "web_search",
+    # genesis-memory — recall / query / lookup (no mutation)
+    "conversation_history", "document_query", "knowledge_recall", "knowledge_status",
+    "locate", "memory_expand", "memory_proactive", "memory_recall",
+    "memory_stats", "observation_query", "procedure_recall", "reference_lookup",
+    "reference_export",
+})
+# The single sanctioned reflection write. The rest of reflection's observations
+# flow through the parsed `observations` output field (written server-side), not a tool.
+_REFLECTION_WRITE_MCP: frozenset[str] = frozenset({"observation_write"})
+
+# The MCP servers a reflection session loads (mirrors _MCP_PROFILES["reflection"]).
+_REFLECTION_MCP_SERVERS: tuple[tuple[str, str], ...] = (
+    ("genesis-health", "genesis.mcp.health"),
+    ("genesis-memory", "genesis.mcp.memory"),
+)
+
+# Built-in (non-MCP) write/action tools reflection must NOT have. Read built-ins
+# (Read/Grep/Glob/WebFetch/WebSearch/ToolSearch/CronList/Task{Get,List,Output}/
+# ListMcpResourcesTool/ReadMcpResource*Tool) are left available. CC internals
+# aren't introspectable, so this is an explicit list; the scope test re-checks it.
+# Task/Workflow/Skill are denied because they SPAWN — a subagent would escape the
+# lockdown.
+_REFLECTION_DENY_BUILTINS: tuple[str, ...] = (
+    "Bash", "Write", "Edit", "NotebookEdit",
+    "Task", "Workflow", "Skill",
+    "SendMessage", "ReportFindings",
+    "CronCreate", "CronDelete", "ScheduleWakeup", "Monitor",
+    "TaskCreate", "TaskUpdate", "TaskStop",
+    "RemoteTrigger", "PushNotification", "DesignSync",
+    "EnterWorktree", "ExitWorktree",
+)
+
+
+def _registered_mcp_tool_names(modpath: str) -> list[str]:
+    """Tool names registered on a FastMCP server module's ``mcp`` object.
+
+    Late import (avoids a circular import at module load); tool registration
+    happens at import time via the ``@mcp.tool()`` decorators, and importing the
+    module does NOT start the server (that is ``mcp.run()``).
+    """
+    mod = __import__(modpath, fromlist=["mcp"])
+    server = mod.mcp
+    manager = getattr(server, "_tool_manager", None)
+    tools = getattr(manager, "_tools", None)
+    if isinstance(tools, dict):
+        return list(tools.keys())
+    raise RuntimeError(f"cannot enumerate MCP tools for {modpath!r}")
+
+
 def render_mcp_servers(
     template_path: Path, genesis_root: str, servers: set[str] | None = None,
 ) -> dict:
@@ -71,8 +145,37 @@ _MCP_PROFILES: dict[str, list[str]] = {
 class SessionConfigBuilder:
     """Builds CC session configurations per type."""
 
+    def build_reflection_disallowed(self) -> list[str]:
+        """Denylist that makes a reflection session read-only + observation-writing.
+
+        MCP tools: DERIVED as (live registry − read-allowlist − observation_write),
+        so a future write tool on either reflection server is auto-denied. Built-ins:
+        the explicit write/action set (_REFLECTION_DENY_BUILTINS). If registry
+        enumeration fails, fall back to denying both MCP servers wholesale
+        (``mcp__<server>__*``) — fail-closed: observations still flow through the
+        parsed ``observations`` output field, and no write tool can leak.
+        """
+        disallowed: list[str] = list(_REFLECTION_DENY_BUILTINS)
+        try:
+            for server, modpath in _REFLECTION_MCP_SERVERS:
+                for name in _registered_mcp_tool_names(modpath):
+                    if name in _REFLECTION_READ_MCP or name in _REFLECTION_WRITE_MCP:
+                        continue
+                    disallowed.append(f"mcp__{server}__{name}")
+        except Exception:
+            logger.error(
+                "Reflection MCP tool enumeration failed — denying both MCP servers "
+                "wholesale (fail-closed). DEEP investigation tools are lost until "
+                "this is fixed, but no write tool can leak.",
+                exc_info=True,
+            )
+            disallowed = list(_REFLECTION_DENY_BUILTINS) + [
+                f"mcp__{server}__*" for server, _ in _REFLECTION_MCP_SERVERS
+            ]
+        return disallowed
+
     def build_reflection_config(self, depth: str = "deep") -> dict:
-        """Config for reflection sessions: read-only tools, high effort."""
+        """Config for reflection sessions: read-only tools + observation_write."""
         if depth == "strategic":
             model = CCModel.OPUS
             effort = EffortLevel.MAX
@@ -85,7 +188,7 @@ class SessionConfigBuilder:
             "model": str(model),
             "effort": str(effort),
             "system_prompt": system_prompt,
-            "disallowed_tools": _READONLY_DISALLOWED,
+            "disallowed_tools": self.build_reflection_disallowed(),
             "skip_permissions": True,
         }
 

--- a/src/genesis/identity/REFLECTION_DEEP.md
+++ b/src/genesis/identity/REFLECTION_DEEP.md
@@ -135,8 +135,10 @@ Review unresolved observations from the past 30 days that are:
 - Still potentially relevant to the user's life dimensions
 
 For each, evaluate:
-- **Still actionable?** If yes, create a follow-up via `follow_up_create` or
-  connect to an existing goal. This anchors the insight so it won't age out.
+- **Still actionable?** If yes, record it as an actionable-insight `observation`
+  (via `observation_write`) so the ego picks it up and can act on it. Reflection
+  does NOT create follow-ups — the follow-up board is reserved for foreground
+  (sanctioned) paths; an observation is reflection's channel for surfacing work.
 - **Stale or irrelevant?** Let it expire naturally. No action needed.
 - **Pattern emerging?** If multiple unanchored insights cluster around the
   same theme, create an `interaction_theme` observation to surface the pattern.
@@ -164,15 +166,18 @@ DROP IT. Stale claims that persist across cycles erode trust. Silence > noise.
 
 **Investigation protocol (MANDATORY before cognitive state regeneration):**
 
-You have full tool access. USE IT. Before accepting any claim, investigate:
+You have full READ tool access (query/status MCP tools, Read/Grep/WebSearch). USE
+IT. (Reflection is read-only — no Bash, no writes except observations.) Before
+accepting any claim, investigate:
 
 1. **Verify escalations**: If light reflection escalated an issue, do not take
    it at face value. Check `health_status`, `job_health`, or `subsystem_heartbeats`
    MCP tools to see the current state. If signals are normal, note "escalation
    not confirmed by current state" and do not propagate.
 2. **Verify carried-forward claims**: If the previous cognitive state asserts
-   "X is broken" or "Y is stale," check it yourself. Query the relevant MCP
-   tool or run a diagnostic command. If the condition has resolved, DROP IT.
+   "X is broken" or "Y is stale," check it yourself. Query the relevant
+   read-only MCP tool (e.g. `health_status`, `job_health`, `db_schema`). If the
+   condition has resolved, DROP IT.
 3. **Prune stale observations**: When reviewing observations for memory
    consolidation, actively PRUNE any whose claims are contradicted by what
    you find during investigation. Use "prune" memory operation with reason

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -120,6 +120,19 @@ async def _impl_follow_up_create(
         else:
             source = "foreground_session"
 
+        # Sacred-board authorization: the hot `follow_up` board is reserved for
+        # sanctioned (≈ foreground) paths. An autonomous/dispatched CC session's
+        # LLM-authored follow-up is routed to the COLD `tabled` lane — tracked and
+        # surfaceable for review, never auto-dispatched; a human/foreground session
+        # promotes it to the board if warranted. Root cause of the 2026-07-03
+        # fabricated-follow-up incident: an autonomous session minted a board item.
+        # (Templated pipelines that call crud.follow_ups.create() directly bypass
+        # this tool and are governed at their own call sites.)
+        autonomous_routed = False
+        if source == "ego_dispatch" and kind != "tabled":
+            kind = "tabled"
+            autonomous_routed = True
+
         # The session declares domain when it knows; otherwise fall back to the
         # internal-only classifier (returns 'internal' on a keyword hit, else
         # None → stored NULL, never a user_world guess).
@@ -141,12 +154,20 @@ async def _impl_follow_up_create(
             revisit_condition=revisit_condition or None,
         )
         cond = revisit_condition.strip() or None
-        lane_msg = (
-            "Tabled (cold list — consciously not pursuing near-term; tracked, not "
-            "surfaced as actionable work)."
-            if kind == "tabled"
-            else f"Follow-up created (hot list). Strategy: {strategy}."
-        )
+        if autonomous_routed:
+            lane_msg = (
+                "Routed to the tabled (cold) lane: this is an autonomous/dispatched "
+                "session, and the hot follow-up board is reserved for sanctioned "
+                "(foreground) paths. Tracked and surfaceable for review; a foreground "
+                "session can promote it to the board."
+            )
+        elif kind == "tabled":
+            lane_msg = (
+                "Tabled (cold list — consciously not pursuing near-term; tracked, not "
+                "surfaced as actionable work)."
+            )
+        else:
+            lane_msg = f"Follow-up created (hot list). Strategy: {strategy}."
         return {
             "id": fid,
             "status": "pending",
@@ -307,8 +328,23 @@ async def _impl_follow_up_update(
         # pick the lane on update any more than on create. blocked_on_trigger
         # requires a revisit_condition (newly supplied, or already on the row).
         resolved_kind: str | None = None
+        autonomous_promotion_blocked = False
         if work_state is not None:
             resolved_kind = follow_ups.WORK_STATE_TO_KIND[work_state]
+            # Sacred-board authorization (mirror of _impl_follow_up_create): an
+            # autonomous/dispatched session may NOT PROMOTE a follow-up onto the hot
+            # board — only sanctioned (foreground) sessions may. Without this gate an
+            # autonomous session could follow_up_create (→ forced tabled) and then
+            # follow_up_update(work_state='ready') to flip it straight back onto the
+            # board, defeating Part B. Gate ONLY a genuine promotion (off-board → board):
+            # a re-affirm of an already-on-board item (existing kind == 'follow_up') is a
+            # no-op that must NOT demote it, and moving TO tabled stays allowed.
+            if resolved_kind == "follow_up" and existing.get("kind") != "follow_up":
+                import os
+
+                if os.environ.get("GENESIS_CC_SESSION") == "1":
+                    resolved_kind = "tabled"
+                    autonomous_promotion_blocked = True
             effective_cond = (
                 revisit_condition
                 if revisit_condition is not None
@@ -421,7 +457,13 @@ async def _impl_follow_up_update(
             "revisit_condition": refreshed.get("revisit_condition"),
             "priority": refreshed["priority"],
             "pinned": bool(refreshed.get("pinned", 0)),
-            "message": "Follow-up updated.",
+            "message": (
+                "Kept on the tabled (cold) lane: an autonomous/dispatched session "
+                "cannot promote a follow-up onto the hot board — a foreground session "
+                "must do that."
+                if autonomous_promotion_blocked
+                else "Follow-up updated."
+            ),
         }
         if resolved_from is not None:
             # Echo the full id so the caller learns it for subsequent calls.

--- a/tests/test_cc/test_reflection_tool_scope.py
+++ b/tests/test_cc/test_reflection_tool_scope.py
@@ -1,0 +1,215 @@
+"""Reflection tool-scope lockdown + coverage guardrail.
+
+Reflection sessions (deep/strategic) must be READ-ONLY + observation-writing only.
+The denylist is DERIVED as (live MCP registry − read-allowlist − observation_write),
+so a future write tool is auto-denied. These tests are the guardrail that keeps the
+read-allowlist honest against the live registry, and they pin the composition
+(known writes denied, reads + observation_write available).
+
+Why a denylist and not --allowedTools: verified empirically 2026-08-07 that
+`--allowedTools` is NOT a strict allowlist under `--dangerously-skip-permissions`
+(it left Bash available); only `--disallowedTools` removes a tool.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from genesis.cc.session_config import (
+    _REFLECTION_DENY_BUILTINS,
+    _REFLECTION_MCP_SERVERS,
+    _REFLECTION_READ_MCP,
+    _REFLECTION_WRITE_MCP,
+    SessionConfigBuilder,
+    _registered_mcp_tool_names,
+)
+
+# Sentinel writes that MUST always be denied to reflection (fabrication / mutation
+# / spawn / cost surface). Not exhaustive — the coverage test enforces the rest.
+_MUST_DENY_MCP = [
+    "mcp__genesis-health__follow_up_create",
+    "mcp__genesis-health__follow_up_update",
+    "mcp__genesis-health__settings_update",
+    "mcp__genesis-health__session_config",  # setter despite getter-shaped name
+    "mcp__genesis-health__task_submit",
+    "mcp__genesis-health__task_control",
+    "mcp__genesis-health__ego_directive",
+    "mcp__genesis-health__ego_goal_create",
+    "mcp__genesis-health__module_call",
+    "mcp__genesis-health__direct_session_run",
+    "mcp__genesis-health__deliberate",  # PAID model-panel call
+    "mcp__genesis-health__campaign_create",
+    "mcp__genesis-health__browser_run_js",
+    "mcp__genesis-memory__memory_store",
+    "mcp__genesis-memory__memory_synthesize",
+    "mcp__genesis-memory__knowledge_ingest",
+    "mcp__genesis-memory__observation_resolve",
+    "mcp__genesis-memory__reference_store",
+]
+_MUST_DENY_BUILTINS = ["Bash", "Write", "Edit", "NotebookEdit", "Task", "Workflow", "Skill"]
+
+# Read tools that MUST stay available (absent from the denylist).
+_MUST_ALLOW = [
+    "mcp__genesis-memory__observation_write",  # the ONE sanctioned write
+    "mcp__genesis-memory__memory_recall",
+    "mcp__genesis-memory__observation_query",
+    "mcp__genesis-health__health_status",
+    "mcp__genesis-health__follow_up_list",
+    "mcp__genesis-memory__reference_export",
+]
+
+
+@pytest.fixture
+def disallowed():
+    return set(SessionConfigBuilder().build_reflection_disallowed())
+
+
+@pytest.mark.parametrize("tool", _MUST_DENY_MCP + _MUST_DENY_BUILTINS)
+def test_write_tools_are_denied(disallowed, tool):
+    assert tool in disallowed, f"{tool} must be denied to reflection sessions"
+
+
+@pytest.mark.parametrize("tool", _MUST_ALLOW)
+def test_read_and_observation_write_are_allowed(disallowed, tool):
+    assert tool not in disallowed, f"{tool} must remain available to reflection"
+
+
+def test_default_deny_every_registered_tool_is_read_or_denied(disallowed):
+    """Fail-closed property: every live-registered MCP tool of the reflection servers is
+    EITHER explicitly read-allowed (or observation_write) OR in the derived denylist.
+    Because the denylist is derived as (registry − read − observation_write), a tool not
+    in the read set is ALWAYS denied — so a NEW upstream tool is auto-denied, safe by
+    construction. This asserts that property holds (nothing is neither allowed nor denied).
+
+    It does NOT, by itself, force a human classification decision (default-deny handles a
+    new tool safely). The genuine regression guards are: test_write_tools_are_denied
+    (sentinel writes stay denied), test_read_allowlist_tools_do_not_write_state (no
+    write-shaped tool in the read set), and test_read_allowlist_has_no_stale_entries
+    (a read tool removed/renamed upstream).
+
+    Scope note: two genesis reflection servers only — authoritative because the reflection
+    CCInvocation sets strict_mcp_config=True (_bridge.py), so ONLY those servers load;
+    test_reflection_mcp_servers_match_profile guards the server list."""
+    unclassified = []
+    for server, modpath in _REFLECTION_MCP_SERVERS:
+        for name in _registered_mcp_tool_names(modpath):
+            allowed = name in _REFLECTION_READ_MCP or name in _REFLECTION_WRITE_MCP
+            denied = f"mcp__{server}__{name}" in disallowed
+            if not (allowed or denied):
+                unclassified.append(f"{server}:{name}")
+    assert not unclassified, f"unclassified reflection tools (classify read/deny): {unclassified}"
+
+
+def test_read_allowlist_has_no_stale_entries():
+    """Every name in the read-allowlist must exist in the live registry (catch
+    typos / tools renamed or removed upstream)."""
+    live = set()
+    for _server, modpath in _REFLECTION_MCP_SERVERS:
+        live.update(_registered_mcp_tool_names(modpath))
+    stale = sorted(n for n in (_REFLECTION_READ_MCP | _REFLECTION_WRITE_MCP) if n not in live)
+    assert not stale, f"read/write allowlist names not in live registry: {stale}"
+
+
+def test_read_allowlist_contains_no_known_write():
+    """Guard against a write tool sneaking into the read-allowlist."""
+    known_write_names = {t.split("__")[-1] for t in _MUST_DENY_MCP}
+    leaked = _REFLECTION_READ_MCP & known_write_names
+    assert not leaked, f"write tools present in the read-allowlist: {leaked}"
+
+
+# Read tools whose @mcp.tool() body contains a write-shaped token but is verified
+# read-only (benign side effect, e.g. audit logging). Keep SHORT + justified.
+_READ_DESPITE_WRITE_TOKEN: dict[str, str] = {}
+_WRITE_TOKENS = (
+    "INSERT INTO",
+    "UPDATE ",
+    "DELETE FROM",
+    "_persist",
+    ".create(",
+    ".update_",
+    ".set_",
+    ".store(",
+    ".delete(",
+    ".upsert(",
+    ".ingest",
+    ".mark_",
+)
+
+
+def _dec_name(node):
+    if isinstance(node, ast.Attribute):
+        base = node.value.id if isinstance(node.value, ast.Name) else ""
+        return f"{base}.{node.attr}" if base else node.attr
+    if isinstance(node, ast.Name):
+        return node.id
+    return ""
+
+
+def _mcp_tool_sources() -> dict[str, str]:
+    """Map @mcp.tool()-decorated tool name -> its function source segment."""
+    out: dict[str, str] = {}
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    for d in ("src/genesis/mcp/health", "src/genesis/mcp/memory"):
+        for f in (repo / d).glob("*.py"):
+            src = f.read_text(encoding="utf-8")
+            tree = ast.parse(src)
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.AsyncFunctionDef):
+                    continue
+                is_tool = any(
+                    _dec_name(dec.func if isinstance(dec, ast.Call) else dec) == "mcp.tool"
+                    for dec in node.decorator_list
+                )
+                if is_tool:
+                    out[node.name] = ast.get_source_segment(src, node) or ""
+    return out
+
+
+def test_read_allowlist_tools_do_not_write_state():
+    """Static guardrail: no read-allowlisted MCP tool's own @mcp.tool() body performs
+    a state write. Catches a 'getter-shaped setter' (like session_config) being
+    misclassified into the read set — the exact BLOCKER a hand-curated sentinel missed.
+    (Limitation: sees the decorated body, not writes delegated to a helper in another
+    module — those still rely on the sentinel + coverage tests.)"""
+    sources = _mcp_tool_sources()
+    offenders = []
+    for name in sorted(_REFLECTION_READ_MCP):
+        body = sources.get(name)
+        if body is None or name in _READ_DESPITE_WRITE_TOKEN:
+            continue
+        hits = [tok for tok in _WRITE_TOKENS if tok in body]
+        if hits:
+            offenders.append(f"{name}: {hits}")
+    assert not offenders, (
+        "read-allowlisted tools contain write-shaped calls (misclassified into the "
+        f"read set, or add to _READ_DESPITE_WRITE_TOKEN with a reason): {offenders}"
+    )
+
+
+def test_reflection_mcp_servers_match_profile():
+    """The denylist derivation iterates _REFLECTION_MCP_SERVERS; the servers actually
+    loaded (under strict_mcp_config) come from _MCP_PROFILES['reflection']. If a future
+    PR adds a server to the profile without adding it here, that server's tools would load
+    with NONE denied. Keep them in lockstep."""
+    from genesis.cc.session_config import _MCP_PROFILES, _REFLECTION_MCP_SERVERS
+
+    assert {s for s, _ in _REFLECTION_MCP_SERVERS} == set(_MCP_PROFILES["reflection"])
+
+
+def test_fail_closed_when_registry_enumeration_breaks(monkeypatch):
+    """If registry enumeration fails, fall back to denying both servers wholesale
+    (fail-closed) — no write tool can leak."""
+    import genesis.cc.session_config as sc
+
+    def _boom(_modpath):
+        raise RuntimeError("registry unavailable")
+
+    monkeypatch.setattr(sc, "_registered_mcp_tool_names", _boom)
+    d = set(sc.SessionConfigBuilder().build_reflection_disallowed())
+    assert "mcp__genesis-health__*" in d
+    assert "mcp__genesis-memory__*" in d
+    for b in _REFLECTION_DENY_BUILTINS:
+        assert b in d

--- a/tests/test_cc/test_session_config.py
+++ b/tests/test_cc/test_session_config.py
@@ -11,6 +11,8 @@ from genesis.cc.session_config import (
     SessionConfigBuilder,
 )
 
+# Full read/deny composition + coverage guardrail live in test_reflection_tool_scope.py.
+
 
 @pytest.fixture
 def builder():
@@ -22,9 +24,15 @@ class TestBuildReflectionConfig:
         cfg = builder.build_reflection_config()
         assert cfg["model"] == "opus"
         assert cfg["effort"] == "high"
-        assert cfg["disallowed_tools"] == _READONLY_DISALLOWED
         assert cfg["skip_permissions"] is True
         assert "system_prompt" in cfg
+        # Reflection is read-only + observation-writing only: the derived denylist
+        # blocks write tools (incl. the built-in write set) while leaving reads and
+        # observation_write available. (Full composition: test_reflection_tool_scope.)
+        denied = set(cfg["disallowed_tools"])
+        assert {"Bash", "Write", "Edit"}.issubset(denied)
+        assert "mcp__genesis-health__follow_up_create" in denied
+        assert "mcp__genesis-memory__observation_write" not in denied
 
     def test_strategic_uses_opus(self, builder):
         cfg = builder.build_reflection_config("strategic")

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -14,6 +14,108 @@ from genesis.mcp.health import follow_up_tools
 pytestmark = pytest.mark.asyncio
 
 
+@pytest.fixture(autouse=True)
+def _foreground_by_default(monkeypatch):
+    """Pin source='foreground_session' by default so tests are deterministic
+    regardless of the runner's env (a CC session sets GENESIS_CC_SESSION=1 on
+    children, which would otherwise flip source→ego_dispatch and route to tabled).
+    Tests that want the autonomous path set the env explicitly."""
+    monkeypatch.delenv("GENESIS_CC_SESSION", raising=False)
+
+
+# ─── sacred-board source authorization (autonomous → tabled) ─────────────────
+
+
+async def test_autonomous_dispatch_routed_to_cold_lane(db, monkeypatch):
+    """An autonomous/dispatched CC session's LLM-authored follow-up is forced to
+    the COLD tabled lane even when its work_state would be 'ready' — the hot board
+    is reserved for sanctioned (foreground) paths. Root-cause fix for 030e6ddc."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="an autonomously-suggested task the dispatched session invented",
+            reason="autonomous session proposed it",
+            strategy="ego_judgment",
+            work_state="ready",  # would be hot 'follow_up' from a foreground session
+        )
+    assert res["kind"] == "tabled", res
+    row = await follow_ups.get_by_id(db, res["id"])
+    assert row["kind"] == "tabled"
+    assert row["source"] == "ego_dispatch"
+    # not on the actionable board
+    actionable = await follow_ups.get_actionable(db, limit=50)
+    assert all(r["id"] != res["id"] for r in actionable)
+    assert "cold" in res["message"].lower() or "tabled" in res["message"].lower()
+
+
+async def test_autonomous_cannot_promote_off_tabled_via_update(db, monkeypatch):
+    """The sacred-board guarantee must hold at UPDATE time too: an autonomous
+    session cannot flip a tabled item back onto the hot board via follow_up_update
+    (the create→tabled→update(ready) bypass). Foreground promotion still works."""
+    # Foreground creates a tabled item.
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="cold item",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="deferred_cold",
+        )
+    fid = created["id"]
+    assert created["kind"] == "tabled"
+
+    # Autonomous session tries to promote it to the board → blocked, stays tabled.
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_update(
+            follow_up_id=fid,
+            work_state="ready",
+        )
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["kind"] == "tabled", (res, row["kind"])
+
+    # A foreground session CAN promote it.
+    monkeypatch.delenv("GENESIS_CC_SESSION", raising=False)
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        await follow_up_tools._impl_follow_up_update(follow_up_id=fid, work_state="ready")
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["kind"] == "follow_up"
+
+
+async def test_autonomous_reaffirm_of_board_item_does_not_demote(db, monkeypatch):
+    """The update gate fires only on a genuine off-board→board PROMOTION. An autonomous
+    session re-affirming an already-on-board item (work_state='ready' on an existing
+    kind='follow_up', e.g. bumping priority) must NOT silently demote it to tabled."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        created = await follow_up_tools._impl_follow_up_create(
+            content="board item",
+            reason="r",
+            strategy="ego_judgment",
+            work_state="ready",
+        )
+    fid = created["id"]
+    assert created["kind"] == "follow_up"
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        await follow_up_tools._impl_follow_up_update(follow_up_id=fid, work_state="ready")
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["kind"] == "follow_up", "autonomous re-affirm must not demote a board item"
+
+
+async def test_foreground_ready_stays_on_the_board(db):
+    """A foreground session's 'ready' follow-up lands on the hot board (unchanged)."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        res = await follow_up_tools._impl_follow_up_create(
+            content="fix the thing the user asked for",
+            reason="user asked",
+            strategy="ego_judgment",
+            work_state="ready",
+        )
+    assert res["kind"] == "follow_up", res
+    row = await follow_ups.get_by_id(db, res["id"])
+    assert row["kind"] == "follow_up"
+    assert row["source"] == "foreground_session"
+
+
 # ─── work_state → kind derivation (create) ───────────────────────────────────
 
 


### PR DESCRIPTION
## Why

Autonomous background **reflection** sessions (deep/strategic) ran with
`--dangerously-skip-permissions` and **no tool restriction** — full built-ins
(`Bash`/`Write`/`Edit`/`Task`) plus the entire `genesis-health` + `genesis-memory` MCP
surface, and (because `--mcp-config` is additive) any user/project-scoped MCP servers too.
A reflection used this to write an **ungrounded follow-up straight onto the accountability
board**. Reflection's contract is read-only investigation whose only output is observations
(parsed from its structured result), so unrestricted tool access was an unintended leak — a
read-only config existed but was never wired into the reflection dispatch path.

## What

- **Reflection is locked to read-only + `observation_write`.** A derived `disallowed_tools`
  denylist is wired into the reflection `CCInvocation`, with `strict_mcp_config=True` so only
  reflection's own MCP servers load (never user/project-scoped ones). The denylist is derived
  as `(live registry − read-allowlist − observation_write)` + the write/action built-ins, so a
  future write tool is auto-denied. `--allowedTools` is **not** a strict allowlist under
  `--dangerously-skip-permissions` (verified via the CC init-event tool list), so the scope is a
  denylist; `Task`/`Workflow`/`Skill` are denied so a subagent can't escape the lockdown.
- **The hot follow-up board is foreground-only.** Any autonomous/dispatched session's
  `follow_up_create` is routed to the cold `tabled` lane, and `follow_up_update` cannot promote
  an item onto the board (a foreground session can). Re-affirming an existing board item stays a
  no-op (never a demotion).
- **`REFLECTION_DEEP.md`:** read-only framing; the "missed insights" anchor becomes an
  observation rather than a follow-up; `observation_write` retained.
- **Guardrails:** a sentinel test (known write tools stay denied), a static AST scan (rejects any
  write-shaped tool in the read-allowlist — it caught a recall tool doing a vector-store write), a
  server-list drift test, and a fail-closed default-deny check.

## Verification

- **Live (CC init-event tool list):** with strict config, user-scoped MCP servers are absent;
  built-in and MCP write tools are stripped; `--disallowedTools` honors the `mcp__server__*`
  wildcard; the read set + `observation_write` remain.
- **1703 tests pass**; ruff clean.

## Reviews

Three review rounds (security → architecture → final security); all findings resolved. Codex was
unavailable (a model-manager parse error), so Claude reviewers were used per the documented fallback.

Ledger: 3358cf1b6fa347569776f8548127efa4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
