### PR TITLE
test(config): suite-wide isolation from install-local config overlays

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,77 @@ def _isolate_circuit_breaker_state(tmp_path, monkeypatch):
     monkeypatch.setattr(cb_mod, "_STATE_FILE", tmp_path / "cb_state.json")
 
 
+# ── Safety: isolate tests from the install's config overlays ──
+@pytest.fixture(autouse=True)
+def _isolate_user_config_dir(tmp_path, monkeypatch):
+    """Neutralize BOTH overlay vectors so tests never read install-local state.
+
+    ``config/*.local.yaml`` overlays are install-local (e.g. a voice-live
+    install arms ``voice_act.local.yaml`` ``mode: live``). Every loader that
+    calls ``merge_local_overlay`` resolves them from two locations, and BOTH
+    leak into tests unpatched — green on CI (no overlays), red or falsely green
+    on a live install:
+
+    1. **User dir** (``~/.genesis/config/*.local.yaml``) — absolute, so it leaks
+       in the main tree AND in a sibling worktree. Patched by redirecting
+       ``_user_config_dir`` to an empty per-test dir.
+    2. **Repo-relative sibling** (``<repo>/config/*.local.yaml``) — gitignored,
+       present only in the main tree, so a worktree test run structurally can't
+       catch it. When a loader is called with a real repo config path (e.g.
+       ``load_ego_config()`` with no args → ``repo_root()/config/ego.yaml``),
+       ``_resolve_overlay_path`` falls back to the real sibling. We wrap the
+       resolver so any overlay that resolves INSIDE the real repo config dir is
+       redirected to the empty dir. tmp-rooted overlays (the overlay tests'
+       own fixtures, and ``test_config_save``-style tests) are never touched.
+
+    ``security/immunity.py`` binds ``_user_config_dir`` at module level (its own
+    reference), so it is patched separately. The guards in
+    tests/test_config_overlay.py keep this list complete and catch any NEW
+    hand-rolled ``.local.yaml`` resolver that bypasses ``merge_local_overlay``.
+    Independent resolvers (routing, recon, mcp settings) hold their own logic
+    and are tracked for consolidation (follow-up); the MCP ``_USER_CONFIG_DIR``
+    constants are excluded as too import-heavy for an every-test fixture — their
+    tests self-isolate.
+    """
+    from genesis import _config_overlay
+    from genesis.env import repo_root
+    from genesis.security import immunity
+
+    user_dir = tmp_path / "user-config-isolated"
+    monkeypatch.setattr(_config_overlay, "_user_config_dir", lambda: user_dir)
+    monkeypatch.setattr(immunity, "_user_config_dir", lambda: user_dir)
+
+    # Vector 2: neutralize the repo-relative sibling fallback.
+    _orig_resolve = _config_overlay._resolve_overlay_path
+
+    def _sandboxed_resolve(base_path):
+        result = _orig_resolve(base_path)
+        try:
+            resolved = result.resolve()
+        except OSError:  # pragma: no cover - defensive (symlink loops)
+            return result
+        # Resolve the real config dir LAZILY (repo_root() reads GENESIS_REPO_ROOT
+        # per call), so a test that re-points GENESIS_REPO_ROOT after fixture
+        # setup is still honored — and the deterministic regression test can aim
+        # a synthetic overlay at it.
+        real_config_dir = (repo_root() / "config").resolve()
+        if resolved.is_relative_to(real_config_dir):
+            # A real install-local overlay — redirect to the guaranteed-absent
+            # isolated dir so the loader falls through to shipped defaults.
+            return user_dir / result.name
+        return result
+
+    monkeypatch.setattr(_config_overlay, "_resolve_overlay_path", _sandboxed_resolve)
+    # immunity.py binds `_resolve_overlay_path` at MODULE level (a by-name
+    # import), so its own reference must be patched too — patching only
+    # _config_overlay's attribute does not reach it (record_demotion() would
+    # otherwise still fall back to the real config/ws3_immunity.local.yaml
+    # sibling). Lazy importers (memory/graph_expansion, ledger/learned_knobs)
+    # re-resolve against the patched _config_overlay each call, so they need no
+    # separate patch. The guard test tracks module-level importers of both names.
+    monkeypatch.setattr(immunity, "_resolve_overlay_path", _sandboxed_resolve)
+
+
 @pytest.fixture(autouse=True)
 def _isolate_ledger_write_failures():
     """Reset the ledger writer + grader failure counters around every test.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def _isolate_circuit_breaker_state(tmp_path, monkeypatch):
 
 # ── Safety: isolate tests from the install's config overlays ──
 @pytest.fixture(autouse=True)
-def _isolate_user_config_dir(tmp_path, monkeypatch):
+def _isolate_user_config_dir(tmp_path):
     """Neutralize BOTH overlay vectors so tests never read install-local state.
 
     ``config/*.local.yaml`` overlays are install-local (e.g. a voice-live
@@ -100,14 +100,21 @@ def _isolate_user_config_dir(tmp_path, monkeypatch):
     and are tracked for consolidation (follow-up); the MCP ``_USER_CONFIG_DIR``
     constants are excluded as too import-heavy for an every-test fixture — their
     tests self-isolate.
+
+    Uses a fixture-OWNED ``MonkeyPatch`` rather than the shared ``monkeypatch``
+    fixture: a test that calls ``monkeypatch.undo()`` mid-body (e.g.
+    ``test_learned_knobs``) would otherwise also revert THIS suite-isolation
+    patch — and a subsequent config read in that test would hit the real overlay.
+    An independent instance we undo in teardown is immune to that.
     """
     from genesis import _config_overlay
     from genesis.env import repo_root
     from genesis.security import immunity
 
+    mp = pytest.MonkeyPatch()
     user_dir = tmp_path / "user-config-isolated"
-    monkeypatch.setattr(_config_overlay, "_user_config_dir", lambda: user_dir)
-    monkeypatch.setattr(immunity, "_user_config_dir", lambda: user_dir)
+    mp.setattr(_config_overlay, "_user_config_dir", lambda: user_dir)
+    mp.setattr(immunity, "_user_config_dir", lambda: user_dir)
 
     # Vector 2: neutralize the repo-relative sibling fallback.
     _orig_resolve = _config_overlay._resolve_overlay_path
@@ -129,7 +136,7 @@ def _isolate_user_config_dir(tmp_path, monkeypatch):
             return user_dir / result.name
         return result
 
-    monkeypatch.setattr(_config_overlay, "_resolve_overlay_path", _sandboxed_resolve)
+    mp.setattr(_config_overlay, "_resolve_overlay_path", _sandboxed_resolve)
     # immunity.py binds `_resolve_overlay_path` at MODULE level (a by-name
     # import), so its own reference must be patched too — patching only
     # _config_overlay's attribute does not reach it (record_demotion() would
@@ -137,7 +144,11 @@ def _isolate_user_config_dir(tmp_path, monkeypatch):
     # sibling). Lazy importers (memory/graph_expansion, ledger/learned_knobs)
     # re-resolve against the patched _config_overlay each call, so they need no
     # separate patch. The guard test tracks module-level importers of both names.
-    monkeypatch.setattr(immunity, "_resolve_overlay_path", _sandboxed_resolve)
+    mp.setattr(immunity, "_resolve_overlay_path", _sandboxed_resolve)
+    try:
+        yield
+    finally:
+        mp.undo()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -110,6 +110,16 @@ def test_suite_isolates_user_config_dir_from_real_home():
     assert immunity._resolve_overlay_path is _config_overlay._resolve_overlay_path
 
 
+def test_isolation_survives_a_test_calling_monkeypatch_undo(monkeypatch):
+    """A test that calls ``monkeypatch.undo()`` mid-body (e.g. test_learned_knobs)
+    must NOT revert the suite-isolation patch — the fixture owns its own
+    MonkeyPatch instance, independent of the shared ``monkeypatch`` fixture."""
+    real = Path.home() / ".genesis" / "config"
+    monkeypatch.setattr("os.environ", dict(__import__("os").environ))  # any patch
+    monkeypatch.undo()  # reverts THIS test's patches — must not touch the fixture's
+    assert _config_overlay._user_config_dir() != real
+
+
 def test_module_level_user_config_bindings_are_patched_or_listed():
     """Enumerate every module-level binding of a config-overlay seam in src.
 
@@ -183,7 +193,12 @@ def test_no_unisolated_local_yaml_resolver():
     """
     # Hand-rolled resolvers that read a real overlay sibling WITHOUT the shared
     # seam. Independent of merge_local_overlay by design/history; tracked for
-    # consolidation (follow-up e2fd22c5).
+    # consolidation (follow-up e2fd22c5). NOT patched by the autouse fixture on
+    # purpose: routing.config alone costs ~4.3s to import (litellm etc.), so
+    # pulling these into an every-test fixture is prohibitive — consolidation
+    # onto the shared resolver is the correct fix, not a per-test patch. Until
+    # then, their OWN tests that load a real repo path may still merge host
+    # values (a falsely-green risk, not a hard failure).
     independent_resolvers = {
         "guardian/config.py",  # provisioning.local.yaml (guardian state dir)
         "mcp/health/settings.py",  # own _load_yaml_local + _USER_CONFIG_DIR

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -12,7 +12,16 @@ Every test monkeypatches ``_user_config_dir`` so it never touches the real
 
 from __future__ import annotations
 
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
 from genesis import _config_overlay
+
+_SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "genesis"
+_HOME_CONFIG_RE = re.compile(r'Path\.home\(\)\s*/\s*["\']\.genesis["\']\s*/\s*["\']config["\']')
 
 
 def test_merge_reads_user_dir_overlay_first(tmp_path, monkeypatch):
@@ -72,3 +81,205 @@ def test_mtime_zero_when_no_overlay(tmp_path, monkeypatch):
     monkeypatch.setattr(_config_overlay, "_user_config_dir", lambda: user_dir)
     base_path = tmp_path / "foo.yaml"
     assert _config_overlay.local_overlay_mtime(base_path) == 0.0
+
+
+# ── Suite-wide isolation guards ──────────────────────────────────────────────
+# config/*.local.yaml overlays are install-local state (e.g. a voice-live
+# install arms voice_act.local.yaml `mode: live`). Without suite-wide isolation,
+# any of the 30+ config loaders' tests silently read the REAL install's
+# overlays — green on CI, red (or falsely green) on a live install. The autouse
+# ``_isolate_user_config_dir`` fixture in tests/conftest.py neutralizes both the
+# user-dir and repo-sibling vectors of ``merge_local_overlay``. These guards
+# keep that isolation honest as the codebase grows:
+#   1. every module-level user-config-dir binding is patched or allow-listed,
+#   2. no NEW hand-rolled ``.local.yaml`` resolver slips in unrouted+unlisted,
+#   3. the repo-sibling neutralizer actually fires where a sibling exists.
+
+
+def test_suite_isolates_user_config_dir_from_real_home():
+    """The autouse conftest fixture must be active for every test."""
+    from genesis.security import immunity
+
+    real = Path.home() / ".genesis" / "config"
+    assert _config_overlay._user_config_dir() != real
+    assert immunity._user_config_dir() != real
+    # immunity holds its OWN module-level _resolve_overlay_path binding, so the
+    # fixture must patch that copy too (else record_demotion() falls back to the
+    # real config/ws3_immunity.local.yaml sibling). Both must point at the same
+    # sandboxed resolver.
+    assert immunity._resolve_overlay_path is _config_overlay._resolve_overlay_path
+
+
+def test_module_level_user_config_bindings_are_patched_or_listed():
+    """Enumerate every module-level binding of a config-overlay seam in src.
+
+    A module that binds ``_user_config_dir`` OR ``_resolve_overlay_path`` (an
+    alias import from ``genesis._config_overlay``) OR assigns a module-level
+    constant to ``Path.home()/".genesis"/"config"`` holds its OWN reference —
+    patching ``genesis._config_overlay`` does not reach it, so the autouse
+    fixture must patch that module's copy too. (Lazy, function-local imports
+    re-resolve against the patched ``_config_overlay`` on each call and are
+    fine — hence module-level only.) Each such module must be accounted for in
+    exactly one bucket below.
+    """
+    # Patched directly by the autouse _isolate_user_config_dir fixture
+    # (both _user_config_dir AND _resolve_overlay_path).
+    patched_in_conftest = {"security/immunity.py"}
+    # Own ``_USER_CONFIG_DIR`` + resolver; import-heavy (FastMCP registry at
+    # module level), so excluded from the every-test fixture — their own tests
+    # patch _USER_CONFIG_DIR (tests/test_mcp/test_settings.py, test_recon_*.py).
+    self_isolated = {"mcp/health/settings.py", "mcp/recon_mcp.py"}
+    # Whole-file config paths (``~/.genesis/config/<name>.yaml``), NOT
+    # ``.local.yaml`` overlays — a distinct mechanism. No test invokes these
+    # loaders with zero args today (verified), so they can't leak yet; listed
+    # so the net SEES them and a future zero-arg caller trips this guard.
+    whole_file_config = {
+        "distribution/config.py",
+        "ego/config.py",
+        "outreach/config.py",
+        "pipeline/profiles.py",
+        "mcp/health/module_ops.py",
+        "runtime/init/modules.py",
+    }
+    accounted = patched_in_conftest | self_isolated | whole_file_config
+
+    found: set[str] = set()
+    for path in _SRC_ROOT.rglob("*.py"):
+        rel = path.relative_to(_SRC_ROOT).as_posix()
+        if rel == "_config_overlay.py":
+            continue  # the canonical definition itself
+        text = path.read_text(encoding="utf-8")
+        tree = ast.parse(text)
+        for node in tree.body:  # module level only — lazy imports are fine
+            is_alias_import = (
+                isinstance(node, ast.ImportFrom)
+                and node.module == "genesis._config_overlay"
+                and any(a.name in ("_user_config_dir", "_resolve_overlay_path") for a in node.names)
+            )
+            is_home_config_const = isinstance(node, ast.Assign) and bool(
+                _HOME_CONFIG_RE.search(ast.get_source_segment(text, node) or "")
+            )
+            if is_alias_import or is_home_config_const:
+                found.add(rel)
+
+    unaccounted = found - accounted
+    assert not unaccounted, (
+        f"New module-level user-config-dir binding(s) in {sorted(unaccounted)}: "
+        "add to the _isolate_user_config_dir fixture (tests/conftest.py), or — "
+        "if import-heavy / a whole-file config — to the matching allow-list here."
+    )
+    stale = accounted - found
+    assert not stale, f"Stale allow-list entries (binding removed from src): {sorted(stale)}"
+
+
+def test_no_unisolated_local_yaml_resolver():
+    """Catch any NEW ``.local.yaml`` resolver that reads install-local overlays
+    without a test seam.
+
+    Scans EVERY file for a non-docstring ``.local.yaml`` string constant (no
+    per-file ``merge_local_overlay`` skip — that would hide a file that both
+    routes some configs AND hand-rolls a leaky resolver, per review). Every hit
+    must land in exactly one conscious bucket; anything else is a regression.
+    """
+    # Hand-rolled resolvers that read a real overlay sibling WITHOUT the shared
+    # seam. Independent of merge_local_overlay by design/history; tracked for
+    # consolidation (follow-up e2fd22c5).
+    independent_resolvers = {
+        "guardian/config.py",  # provisioning.local.yaml (guardian state dir)
+        "mcp/health/settings.py",  # own _load_yaml_local + _USER_CONFIG_DIR
+        "recon/github_discovery.py",  # discovery topics overlay
+        "recon/watchlist.py",  # recon_watchlist.local.yaml
+        "routing/config.py",  # model_routing.local.yaml (load-bearing)
+    }
+    # Build a ``.local.yaml`` filename but resolve it through the PATCHED seam
+    # (_user_config_dir / _resolve_overlay_path), so they ARE isolated by the
+    # fixture — the string constant is just a filename passed to the seam.
+    shared_seam_users = {
+        "security/immunity.py",  # _user_config_dir()/ws3_immunity.local.yaml + _resolve_overlay_path
+        "ledger/learned_knobs.py",  # _user_config_dir()/<stem>.local.yaml (user-dir-always)
+    }
+    # Files that merely MENTION ".local.yaml" in a message/help string.
+    prose_mentions = {"mcp/health/reflex_status.py"}
+    accounted = independent_resolvers | shared_seam_users | prose_mentions
+
+    found: set[str] = set()
+    for path in _SRC_ROOT.rglob("*.py"):
+        rel = path.relative_to(_SRC_ROOT).as_posix()
+        if rel == "_config_overlay.py":
+            continue
+        text = path.read_text(encoding="utf-8")
+        tree = ast.parse(text)
+        docstring_const_ids = {
+            id(n.body[0].value)
+            for n in ast.walk(tree)
+            if isinstance(getattr(n, "body", None), list)
+            and n.body
+            and isinstance(n.body[0], ast.Expr)
+            and isinstance(n.body[0].value, ast.Constant)
+            and isinstance(n.body[0].value.value, str)
+        }
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Constant)
+                and isinstance(node.value, str)
+                and ".local.yaml" in node.value
+                and id(node) not in docstring_const_ids
+            ):
+                found.add(rel)
+                break
+
+    unaccounted = found - accounted
+    assert not unaccounted, (
+        f"New unrouted .local.yaml resolver(s) in {sorted(unaccounted)}: route "
+        "through genesis._config_overlay.merge_local_overlay (preferred, gets "
+        "test isolation for free), or add to the allow-list here with rationale."
+    )
+    stale = accounted - found
+    assert not stale, f"Stale allow-list entries (resolver removed from src): {sorted(stale)}"
+
+
+def test_repo_sibling_overlay_is_neutralized(tmp_path, monkeypatch):
+    """Finding-1 regression (deterministic, CI-exercised): a loader given a repo
+    config path must NOT read the install-local ``<repo>/config/*.local.yaml``
+    sibling.
+
+    Points ``GENESIS_REPO_ROOT`` at a synthetic tree with a planted overlay, so
+    the check runs everywhere (no dependence on host state / pre-existing
+    overlays). The fixture's ``_sandboxed_resolve`` resolves ``repo_root()``
+    lazily, so this re-pointing is honored. Verified-RED by disabling the
+    wrapper: the planted overlay's keys then leak into ``merged``.
+    """
+    fake_repo = tmp_path / "fake_repo"
+    cfg_dir = fake_repo / "config"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "widget.yaml").write_text("base_key: 1\n")
+    (cfg_dir / "widget.local.yaml").write_text("leaked_overlay_key: 999\n")
+    monkeypatch.setenv("GENESIS_REPO_ROOT", str(fake_repo))
+
+    sentinel = {"base_key": 1}
+    merged = _config_overlay.merge_local_overlay(dict(sentinel), cfg_dir / "widget.yaml")
+    assert merged == sentinel, (
+        "repo-relative overlay leaked into a test merge — the _sandboxed_resolve "
+        "neutralizer in conftest is not covering it"
+    )
+
+
+def test_repo_sibling_overlay_is_neutralized_on_real_tree():
+    """Same regression against the REAL repo config dir when it has overlays
+    (main tree). Complements the synthetic test above with a real-file check;
+    skips on a fresh worktree / CI where the gitignored overlays are absent."""
+    from genesis.env import repo_root
+
+    cfg_dir = repo_root() / "config"
+    siblings = sorted(cfg_dir.glob("*.local.yaml"))
+    if not siblings:
+        pytest.skip("no repo-relative overlay present in this tree")
+    sib = siblings[0]
+    base_path = cfg_dir / sib.name.replace(".local.yaml", ".yaml")
+
+    sentinel = {"__sentinel_base_only__": True}
+    merged = _config_overlay.merge_local_overlay(dict(sentinel), base_path)
+    assert merged == sentinel, (
+        f"repo-relative overlay {sib.name} leaked into a test merge — the "
+        "_sandboxed_resolve neutralizer in conftest is not covering it"
+    )


### PR DESCRIPTION
## Problem

Config loaders resolve `.local.yaml` overlays from two in-process locations — the user dir (`~/.genesis/config/`) and a gitignored repo-relative sibling (`<repo>/config/`). **Both leaked into config-loader tests** via the shared `merge_local_overlay` path: green on CI (a fresh clone has no overlays), but red or falsely green on a live install. On a voice-live install, three `TestVoiceActConfig` tests failed for exactly this reason.

## What this PR covers (and what it doesn't)

**Fixes the in-process `merge_local_overlay` resolver** — the shared path used by all 34 routed loaders — plus two related in-process holes:

- redirect `_user_config_dir()` to an empty per-test dir (user-dir vector);
- wrap `_resolve_overlay_path` so a repo-relative sibling under the real config dir is redirected too (`repo_root()` read lazily);
- patch `security/immunity`'s own module-level `_resolve_overlay_path` binding;
- use a **fixture-owned `MonkeyPatch`** so a test calling `monkeypatch.undo()` can't collapse the isolation.

Three guards keep it honest (module-level seam importers patched/listed; no unrouted `.local.yaml` resolver slips in; a deterministic repo-sibling neutralizer test).

**Deferred to a tracked follow-up** (9b405708), all verified falsely-green on this install (not hard failures): the **independent** `.local.yaml` resolvers (routing/recon/guardian — routing.config costs ~4.3s to import, so it can't live in an every-test fixture), the **subprocess** boundary (child processes passing the real `HOME`), and **import-time cached config** (module globals read at collection, before any per-test fixture). Each is a distinct mechanism deserving its own scoped work rather than expanding this PR round-over-round.

## Verification

- The 3 originally-failing `TestVoiceActConfig` tests now pass.
- Repo-sibling leak and all guards **verify-RED'd**; the `monkeypatch.undo()` regression verify-RED'd.
- Blast radius: ~1400 targeted tests pass across security, routing, recon, inbox, ledger, mcp, graph_expansion, roster, reconcile, plus the overlay/voice suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)