### PR TITLE
docs: core principle — evidence must match the scope of the claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,27 @@ Background session transcripts (reflections, inbox, surplus) are stored
 under `~/.genesis/background-sessions/` (outside the repo, so CC's resume
 picker doesn't include them).
 
+## Core Principle: Evidence Must Match the Scope of the Claim
+
+Applies to every assertion — in conversation, and doubly in anything written to disk.
+
+- **Scope matching.** One file supports "this file says X," never "the system does X."
+  One observation supports a question, not a conclusion. A derived list (digest, backlog,
+  index, prior summary, plan doc) supports claims about the LIST — never about the corpus
+  it was derived from. When the user names a corpus, read the corpus, not a proxy.
+- **Evidence tiers.** Every stated fact is one of: **MEASURED** (number + denominator),
+  **READ** (artifact + location, e.g. file:line / PR / live query), **INFERRED** (must be
+  hedged out loud — "I think", "unverified, but"), or **ASSUMED** (say so). An unmarked
+  claim wears verified grammar and WILL be read as MEASURED/READ.
+- **Permanent-record discipline.** Never write an INFERRED claim into permanent record
+  (memory stores, follow-ups, specs, ledgers, evaluations, comments) in the grammar of a
+  fact — permanent record has no tone of voice; the next session builds on confident
+  sentences. Status claims written to disk carry provenance + date ("per <artifact>, <date>").
+- **A surprising observation is a question, not an answer.** The pull to explain an anomaly
+  with a tidy story is precisely the moment to measure instead.
+- **Status of work** (built/unbuilt/pending/shipped/active) comes from artifact enumeration
+  (merged PRs, live DB, running processes) — never from plans, row lists, or prior docs.
+
 ## Confidence Framework
 
 > Expanded reference with examples, failure modes, and due diligence companion: `.claude/docs/confidence-framework.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,8 +184,12 @@ Applies to every assertion — in conversation, and doubly in anything written t
   sentences. Status claims written to disk carry provenance + date ("per <artifact>, <date>").
 - **A surprising observation is a question, not an answer.** The pull to explain an anomaly
   with a tidy story is precisely the moment to measure instead.
-- **Status of work** (built/unbuilt/pending/shipped/active) comes from artifact enumeration
-  (merged PRs, live DB, running processes) — never from plans, row lists, or prior docs.
+- **Status of work: the evidence must match the SPECIFIC status claimed.** A merged PR
+  proves **merged/built** — never shipped/active (merged ≠ deployed; activation requires
+  the deploy path to have run plus a running-version or log marker). **Live/active** claims
+  need live state (running process, logs, live DB). **Unbuilt/absent** claims need
+  enumeration, not a failed spot-check. Never derive any status from plans, row lists, or
+  prior docs.
 
 ## Confidence Framework
 


### PR DESCRIPTION
## What

Adds a top-level CLAUDE.md section (ahead of the Confidence Framework) establishing evidence discipline for every assertion:

- **Scope matching** — evidence must match the claim's quantifier; derived lists (digests, backlogs, plan docs) support claims about the list, never the corpus they derive from.
- **Evidence tiers** — MEASURED / READ / INFERRED / ASSUMED; unmarked claims read as verified, so INFERRED must be hedged out loud.
- **Permanent-record discipline** — never write an INFERRED claim to durable stores (memory, follow-ups, specs, ledgers) in fact-grammar; status claims on disk carry provenance + date.
- **Surprising observation = a question, not an answer.**
- **Work status comes from artifact enumeration** (merged PRs, live DB), never plans or row lists.

## Why

A review session repeatedly asserted stale intermediate-artifact claims in fact-grammar (a shipped feature presented as a pending candidate; a merged instrumentation PR described as unbuilt; a refuted metric premise repeated). The failure class is structural, so the fix is a structural language rule loaded into every session on every install.

## Verification

Docs-only; no code paths touched. Section renders in loaded context at next CC session start via git pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)