### PR TITLE
fix(db): renumber MW-1 migration 0079 -> 0081 (duplicate prefix on main)

### DIFF
--- a/src/genesis/db/migrations/0081_mw1_extraction_judgment.py
+++ b/src/genesis/db/migrations/0081_mw1_extraction_judgment.py
@@ -27,8 +27,9 @@ INSERT on an existing DB (e.g. scripts/migrate_faiss_to_qdrant.py) needs the
 columns present there too. Being unindexed only means the INDEXES-parity guard
 cannot catch the omission — NOT that the mirror is unnecessary. schema_both_build_paths.
 
-(Numbered 0079: 0078 is the highest present; the runner applies by per-id tracking
-and only duplicate prefixes are fatal.)
+(Renumbered 0079 -> 0081: #1341 landed 0079_pending_issue_posts and #1330 owns
+0080, so this migration takes the next free prefix. The runner applies by per-id
+tracking and only duplicate prefixes are fatal.)
 """
 
 from __future__ import annotations

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1180,7 +1180,7 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE memory_metadata ADD COLUMN room TEXT",
         "memory_metadata.room")
 
-    # MW-1 Tier-0 extraction judgment axes (0079_mw1_extraction_judgment).
+    # MW-1 Tier-0 extraction judgment axes (0081_mw1_extraction_judgment).
     # These MUST be mirrored here (the base create_all_tables path) and not only
     # in the numbered migration: create_all_tables runs _migrate_add_columns but
     # NOT the numbered runner, so on an existing DB the CREATE TABLE is a no-op

--- a/tests/test_db/test_migration_0081_extraction_judgment.py
+++ b/tests/test_db/test_migration_0081_extraction_judgment.py
@@ -1,4 +1,4 @@
-"""MW-1 — 0079 extraction-judgment columns: migration + persistence.
+"""MW-1 — 0081 extraction-judgment columns: migration + persistence.
 
 Covers the STORE side: the five judgment columns exist on both schema build
 paths (numbered migration for legacy DBs, canonical CREATE for fresh DBs), the
@@ -15,7 +15,7 @@ import aiosqlite
 from genesis.db.crud import memory
 from genesis.db.schema import TABLES
 
-_mig = importlib.import_module("genesis.db.migrations.0079_mw1_extraction_judgment")
+_mig = importlib.import_module("genesis.db.migrations.0081_mw1_extraction_judgment")
 
 _JUDGMENT_COLS = {
     "speech_act",


### PR DESCRIPTION
## Problem
`#1341` landed `0079_pending_issue_posts.py` on main; then `#1325` merged `0079_mw1_extraction_judgment.py`, creating a **duplicate 0079 prefix**. The migration runner's pre-flight raises `RuntimeError` on duplicate prefixes (they collide on `schema_migrations.id`), leaving **main un-deployable** and `#1330`'s migration-check failing. GitHub's mergeable check is textual-only, so the two differently-named 0079 files merged without conflict and migration-check never ran against the merged tree.

## Fix
`0080` is owned by the incoming `#1330`, so this migration takes the next free prefix, **0081**. Rename only — migration logic is byte-identical. Updates the test's `import_module` string and the `_migrations.py` comment. No install ever recorded `0079_mw1` as applied, so no stale `schema_migrations` id results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)