### PR TITLE
chore(privacy): genericize example strings in docstrings and fixtures

### DIFF
--- a/docs/architecture/genesis-v3-build-phases.md
+++ b/docs/architecture/genesis-v3-build-phases.md
@@ -378,7 +378,7 @@ perception pipeline actually perceive.
     Draft after Phase 4 implementation. Pull from v2 USER.md: timezone (EST),
     communication preferences ("brief first, detailed as context deepens", "don't offer
     next steps by default"), philosophical/first-principles thinking style, "critic when
-    Jay locks onto one track" instruction. Omit: v2-specific tool references, v2 action
+    the user locks onto one track" instruction. Omit: v2-specific tool references, v2 action
     policy (superseded by L1-L4 autonomy), relationship section (superseded by SOUL.md).
   - Context assembly must position identity docs early (high attention region)
 - **Context assembly principles** (learned from v2 + design discussion):
@@ -502,7 +502,7 @@ LLM, you're testing the wrong thing.
 - **User model evolution**: v2 had a static USER.md (~300 tokens) injected every prompt.
   v3's user model is richer — it lives in the user model cache (Phase 0 schema) and gets
   synthesized by Light reflection (#11). Phase 5 builds the retrieval side: when Genesis
-  needs user preferences (e.g., "does Jay prefer brief or detailed here?"), it pulls from
+  needs user preferences (e.g., "does the user prefer brief or detailed here?"), it pulls from
   the user model store, not a static file. user.md is the seed; the user model is the
   living version. v2 items to seed: timezone, communication style, autonomy preferences,
   thinking style, relationship expectations.

--- a/scripts/retrieval_efficacy_report.py
+++ b/scripts/retrieval_efficacy_report.py
@@ -32,7 +32,7 @@ from pathlib import Path
 _DATASET = "longmemeval_oracle"
 
 # A lever does not flip live on this report alone — but the report renders the
-# gate so the numbers are read against the agreed bar (Jay pulls each flip).
+# gate so the numbers are read against the agreed bar (the operator pulls each flip).
 _GATE_CHECKLIST = (
     (
         "scope (PR-A)",

--- a/src/genesis/channels/voice/genesis_bridge.py
+++ b/src/genesis/channels/voice/genesis_bridge.py
@@ -127,7 +127,7 @@ _ACT_TOOL_DECLARATIONS = [
             "Store a durable fact the user tells you to remember about "
             "themselves, their preferences, people in their life, or their "
             "world — e.g. 'remember I prefer morning meetings', 'remember my "
-            "wife's name is Sarah'. Call this ONLY when the user explicitly asks "
+            "manager's name is Alex'. Call this ONLY when the user explicitly asks "
             "you to remember or note something for later. Do NOT call it for "
             "questions (use ask_genesis) or ordinary chatter."
         ),

--- a/src/genesis/contribution/pr_opener.py
+++ b/src/genesis/contribution/pr_opener.py
@@ -81,7 +81,7 @@ def build_pr_body(
 
     All of these fields are MANDATORY per the Phase 6 plan. If a
     section is empty or unavailable, we say so explicitly — never
-    silently omit. Jay uses these to triage.
+    silently omit. The operator uses these to triage.
     """
     install_hash = install.install_id[:8]
     short_sha = source_sha[:12] if source_sha else "unknown"

--- a/src/genesis/mcp/health/reflex_resolve.py
+++ b/src/genesis/mcp/health/reflex_resolve.py
@@ -4,7 +4,7 @@ The afferent nerve ingests signals but, until the diagnose/fix lanes ship, a
 signal has no way to LEAVE the ``new`` lane — it sits on the dashboard forever.
 This tool is the human exit: it moves a signal to a terminal status and, for a
 dismissal, records the judgment as a taste-corpus verdict (the spec's "a signal
-Jay dismisses is a verdict, not just deleted").
+the user dismisses is a verdict, not just deleted").
 
 Three dispositions, mapped to the schema's constrained vocabularies:
 

--- a/src/genesis/mcp/memory/knowledge.py
+++ b/src/genesis/mcp/memory/knowledge.py
@@ -365,7 +365,7 @@ async def knowledge_ingest(
 
     ``concept`` (optional): override the derived ``concept`` field. Defaults to
     ``content[:200]``. The reference store passes a structured identifier here
-    (e.g. ``"ScarletAndRage forum login"``) so that the unique key
+    (e.g. ``"ExampleForum login"``) so that the unique key
     ``(project_type, domain, concept)`` behaves like a dedup key on logical
     identity rather than raw content prefix.
 
@@ -492,7 +492,7 @@ async def reference_store(
     ``kind`` must be one of: credentials, url, network, persona_pointer,
     account, fact.
 
-    ``identifier`` is the human-readable name (e.g. "ScarletAndRage forum
+    ``identifier`` is the human-readable name (e.g. "ExampleForum
     login"). It becomes the unique key ``concept`` field — use the same
     identifier across re-stores to get upsert semantics.
 
@@ -504,7 +504,7 @@ async def reference_store(
     context, purpose, or relationship — not just the value itself.
 
     ``tags`` are optional extra tags for retrieval (e.g. ``["forum",
-    "persona:614buckeye"]``). The ``reference`` tag and the ``kind`` tag are
+    "persona:example"]``). The ``reference`` tag and the ``kind`` tag are
     added automatically.
 
     ``source`` is optional provenance (``session_id``, ``captured_via``,
@@ -622,7 +622,7 @@ async def reference_lookup(
     Combines two paths, same pattern as ``knowledge_recall``:
     1. Vector search via ``HybridRetriever.recall(source="episodic")`` over
        the ``episodic_memory`` Qdrant collection — catches semantic matches
-       ("that forum for Ohio State fans" → "ScarletAndRage forum login")
+       ("that community hobby forum" → "ExampleForum login")
        that keyword search misses. References live in episodic_memory
        alongside other personal data.
     2. FTS5 keyword search over ``knowledge_fts`` — catches exact token

--- a/src/genesis/memory/entity_seed.py
+++ b/src/genesis/memory/entity_seed.py
@@ -22,7 +22,7 @@ SEED_CONFIDENCE = 0.95
 # (name, entity_type, summary)
 SEED_ENTITIES: list[tuple[str, str, str]] = [
     ("OMI", "device", "Wearable always-on AI mic (omi.me); evaluated, not adopted"),
-    ("HAOS Voice PE", "device", "Home Assistant Voice Preview Edition — the invested edge device"),
+    ("HAOS Voice PE", "device", "Home Assistant Voice Preview Edition — the target edge device"),
     ("voice-edge-device", "concept", "Category: voice/edge hardware endpoints (wearables, smart speakers)"),
     ("GENesis-Voice", "repo", "Public repo for voice/edge-device software (firmware, esphome, bridges)"),
     ("GENesis-AGI", "repo", "Public primary repo — the Genesis cognitive core"),

--- a/src/genesis/memory/knowledge_ingest.py
+++ b/src/genesis/memory/knowledge_ingest.py
@@ -68,7 +68,7 @@ async def ingest_knowledge_unit(
 
     ``concept`` overrides the default ``content[:200]`` derivation. The
     reference store uses a structured identifier like
-    ``"ScarletAndRage forum login"``.
+    ``"ExampleForum login"``.
 
     ``tags_json`` overrides the default tags array. Pass a pre-built JSON
     string when the caller needs reference-specific tag layout.

--- a/src/genesis/memory/retrieval.py
+++ b/src/genesis/memory/retrieval.py
@@ -1288,7 +1288,7 @@ class HybridRetriever:
             # Genesis), so offload each blocking search to a worker thread — it
             # must never block the shared event loop while other coroutines (other
             # recalls, the rest of the server) are waiting, which matters under
-            # Jay's 5-7 concurrent-session norm (ac27b693, PR-2). track_operation
+            # the user's 5-7 concurrent-session norm (ac27b693, PR-2). track_operation
             # stays ON the event loop wrapping the await, so per-collection
             # "qdrant.search" telemetry (the provider:qdrant_unreachable signal in
             # mcp/health/errors.py) is byte-identical to the inline version, and

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -103,7 +103,7 @@ def _build_operational_brief() -> str:
 _BACKOFF_SCHEDULE_S: tuple[float, ...] = (0.0, 15 * 60, 45 * 60, 2 * 60 * 60)
 _ESCALATE_AT_ATTEMPT = len(_BACKOFF_SCHEDULE_S) + 1  # 5
 
-# Ring buffer size for 2-of-N debouncing. Jay was explicit: "It doesn't need
+# Ring buffer size for 2-of-N debouncing. The user was explicit: "It doesn't need
 # to be two consecutive ticks — it's just two out of three. Consecutive or not."
 _ALARM_RING_SIZE = 3
 _ALARM_CONFIRMATION_COUNT = 2

--- a/tests/test_contribution/test_sanitize.py
+++ b/tests/test_contribution/test_sanitize.py
@@ -103,9 +103,9 @@ def test_forbidden_secrets_env_blocks():
 
 def test_forbidden_research_profiles_blocks():
     diff = (
-        "diff --git a/config/research-profiles/jay.yaml b/config/research-profiles/jay.yaml\n"
-        "--- a/config/research-profiles/jay.yaml\n"
-        "+++ b/config/research-profiles/jay.yaml\n"
+        "diff --git a/config/research-profiles/example.yaml b/config/research-profiles/example.yaml\n"
+        "--- a/config/research-profiles/example.yaml\n"
+        "+++ b/config/research-profiles/example.yaml\n"
         "@@ -1 +1 @@\n+topic: foo\n"
     )
     r = sanitize.scan_diff(diff)
@@ -184,7 +184,7 @@ def test_email_blocks_personal():
     diff = (
         "diff --git a/README.md b/README.md\n"
         "--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n"
-        "+Contact: jay@somedomain.org\n"
+        "+Contact: someone@somedomain.org\n"
     )
     r = sanitize.scan_diff(diff)
     assert r.ok is False

--- a/tests/test_db/test_knowledge_crud.py
+++ b/tests/test_db/test_knowledge_crud.py
@@ -295,12 +295,12 @@ async def test_delete_nonexistent(db):
 async def test_find_by_unique_key_hit(db):
     uid = await knowledge.insert(
         db, project_type="reference", domain="reference.credentials",
-        source_doc="manual", concept="ScarletAndRage login",
+        source_doc="manual", concept="HobbyForum login",
         body="forum creds",
     )
     row = await knowledge.find_by_unique_key(
         db, project_type="reference", domain="reference.credentials",
-        concept="ScarletAndRage login",
+        concept="HobbyForum login",
     )
     assert row is not None
     assert row["id"] == uid
@@ -321,14 +321,14 @@ async def test_find_by_unique_key_miss(db):
 async def test_upsert_insert_path(db):
     uid, inserted = await knowledge.upsert(
         db, project_type="reference", domain="reference.urls",
-        source_doc="session-a", concept="ScarletAndRage forum",
-        body="https://forum.thescarletandrage.com — Ohio State fan forum",
+        source_doc="session-a", concept="HobbyForum forum",
+        body="https://forum.example-community.org — hobby community forum",
     )
     assert inserted is True
     assert uid
     row = await knowledge.get(db, uid)
     assert row is not None
-    assert row["body"] == "https://forum.thescarletandrage.com — Ohio State fan forum"
+    assert row["body"] == "https://forum.example-community.org — hobby community forum"
 
 
 async def test_upsert_update_path_preserves_id(db):

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -386,13 +386,13 @@ async def test_reference_store_full_roundtrip():
             tools = await _get_tools()
             unit_id = await tools["reference_store"].fn(
                 kind="credentials",
-                identifier="ScarletAndRage forum login",
-                value="614Buckeye / hunter2",
+                identifier="HobbyForum forum login",
+                value="ForumUser42 / hunter2",
                 description=(
-                    "Login for forum.thescarletandrage.com, used by the "
-                    "614Buckeye persona. Ohio State fan forum."
+                    "Login for forum.example-community.org, used by the "
+                    "ForumUser42 persona. hobby community forum."
                 ),
-                tags=["forum", "persona:614buckeye"],
+                tags=["forum", "persona:example"],
                 source={
                     "session_id": "sess-abc",
                     "captured_via": "user_paste",
@@ -405,11 +405,11 @@ async def test_reference_store_full_roundtrip():
             row = await mod.knowledge.get(real_db, unit_id)
             assert row["project_type"] == "reference"
             assert row["domain"] == "reference.credentials"
-            assert row["concept"] == "ScarletAndRage forum login"
-            assert "614Buckeye / hunter2" in row["body"]
-            assert "Ohio State fan forum" in row["body"]
+            assert row["concept"] == "HobbyForum forum login"
+            assert "ForumUser42 / hunter2" in row["body"]
+            assert "hobby community forum" in row["body"]
             assert "forum" in row["tags"]
-            assert "persona:614buckeye" in row["tags"]
+            assert "persona:example" in row["tags"]
             assert "reference" in row["tags"]
             assert "credentials" in row["tags"]
             assert row["qdrant_id"] == "qdrant-cred-1"
@@ -680,10 +680,10 @@ async def test_reference_lookup_hybrid_vector_path():
             tools = await _get_tools()
             unit_id = await tools["reference_store"].fn(
                 kind="persona_pointer",
-                identifier="614Buckeye persona",
-                value="~/.claude/personas/614buckeye/persona.md",
+                identifier="ForumUser42 persona",
+                value="~/.claude/personas/example/persona.md",
                 description=(
-                    "Ohio State fan persona for low-key forum engagement"
+                    "hobby community persona for low-key forum engagement"
                 ),
             )
 

--- a/tests/test_memory/test_extraction_job.py
+++ b/tests/test_memory/test_extraction_job.py
@@ -328,7 +328,7 @@ class TestRunExtractionCycle:
                 "uuid": "u1",
                 "timestamp": "2026-04-11T12:00:00Z",
                 "message": {"role": "user", "content": [
-                    {"type": "text", "text": "login is 614Buckeye password is OhioState614!Bucks"},
+                    {"type": "text", "text": "login is ForumUser42 password is Passw0rd!x9z"},
                 ]},
             },
         ]
@@ -353,10 +353,10 @@ class TestRunExtractionCycle:
             router.route_call = AsyncMock(return_value=AsyncMock(
                 success=True,
                 content=(
-                    '```json\n{"extractions": [{"content": "ScarletAndRage '
-                    'login: username: 614Buckeye password: OhioState614!Bucks", '
+                    '```json\n{"extractions": [{"content": "HobbyForum '
+                    'login: username: ForumUser42 password: Passw0rd!x9z", '
                     '"type": "entity", "confidence": 0.9, '
-                    '"entities": ["ScarletAndRage"]}]}\n```'
+                    '"entities": ["HobbyForum"]}]}\n```'
                 ),
                 call_site_id="9_fact_extraction",
                 error=None,

--- a/tests/test_memory/test_reference_extraction.py
+++ b/tests/test_memory/test_reference_extraction.py
@@ -21,21 +21,21 @@ from genesis.memory.reference_extraction import (
 class TestClassifyCredentialPair:
     def test_colon_separated(self):
         ext = Extraction(
-            content="Jay's ScarletAndRage login: username: 614Buckeye password: OhioState614!Bucks",
+            content="The user's HobbyForum login: username: ForumUser42 password: Passw0rd!x9z",
             extraction_type="entity",
             confidence=0.9,
-            entities=["ScarletAndRage", "614Buckeye"],
+            entities=["HobbyForum", "ForumUser42"],
         )
         ref = classify_as_reference(ext)
         assert ref is not None
         assert ref["kind"] == "credentials"
-        assert "614Buckeye" in ref["value"]
-        assert "OhioState614!Bucks" in ref["value"]
-        assert ref["identifier"] == "ScarletAndRage"
+        assert "ForumUser42" in ref["value"]
+        assert "Passw0rd!x9z" in ref["value"]
+        assert ref["identifier"] == "HobbyForum"
 
     def test_natural_language(self):
         ext = Extraction(
-            content="The user's login is 614Buckeye and the password is OhioState614!Bucks",
+            content="The user's login is ForumUser42 and the password is Passw0rd!x9z",
             extraction_type="entity",
             confidence=0.85,
             entities=[],
@@ -101,17 +101,17 @@ class TestClassifyUrl:
     def test_url_with_description(self):
         ext = Extraction(
             content=(
-                "The Ohio State fan forum at https://forum.thescarletandrage.com/ "
-                "is where the 614Buckeye persona posts"
+                "The hobby community forum at https://forum.example-community.org/ "
+                "is where the ForumUser42 persona posts"
             ),
             extraction_type="entity",
             confidence=0.85,
-            entities=["ScarletAndRage"],
+            entities=["HobbyForum"],
         )
         ref = classify_as_reference(ext)
         assert ref is not None
         assert ref["kind"] == "url"
-        assert ref["value"] == "https://forum.thescarletandrage.com/"
+        assert ref["value"] == "https://forum.example-community.org/"
 
     def test_bare_url_rejected(self):
         ext = Extraction(
@@ -166,7 +166,7 @@ class TestClassifyNetwork:
 class TestClassifyNonReference:
     def test_plain_statement(self):
         ext = Extraction(
-            content="Jay decided to move forward with the memory rebalance plan",
+            content="The user decided to move forward with the memory rebalance plan",
             extraction_type="decision",
             confidence=0.9,
         )
@@ -214,12 +214,12 @@ async def test_ingest_classified_extraction(db_with_schema, mock_store):
     """A credential-shaped extraction gets ingested as a reference."""
     ext = Extraction(
         content=(
-            "ScarletAndRage forum login for the 614Buckeye persona: "
-            "username: 614Buckeye password: OhioState614!Bucks"
+            "HobbyForum forum login for the ForumUser42 persona: "
+            "username: ForumUser42 password: Passw0rd!x9z"
         ),
         extraction_type="entity",
         confidence=0.95,
-        entities=["ScarletAndRage"],
+        entities=["HobbyForum"],
     )
     unit_id = await ingest_reference_from_extraction(
         ext,
@@ -239,9 +239,9 @@ async def test_ingest_classified_extraction(db_with_schema, mock_store):
     assert row is not None
     assert row[0] == "reference"
     assert row[1] == "reference.credentials"
-    assert row[2] == "ScarletAndRage"
-    assert "614Buckeye" in row[3]
-    assert "OhioState614!Bucks" in row[3]
+    assert row[2] == "HobbyForum"
+    assert "ForumUser42" in row[3]
+    assert "Passw0rd!x9z" in row[3]
     assert "reference.credentials" in row[3]  # header salt
     assert "credentials" in row[4]
     assert "reference" in row[4]

--- a/tests/test_memory/test_reference_extraction_precision.py
+++ b/tests/test_memory/test_reference_extraction_precision.py
@@ -57,7 +57,7 @@ class TestRejectsProseFalsePositives:
         # "content pass committed" → was captured as credentials value "committed"
         ext = _ext(
             "The portfolio website is complete, with all four threads and the "
-            "content pass committed to main, authored by Jay Wingard.",
+            "content pass committed to main, authored by Test User.",
             entities=["portfolio website"],
         )
         assert classify_as_reference(ext) is None
@@ -122,8 +122,8 @@ class TestStillClassifiesGenuine:
     def test_lowercase_password_pair_still_captured(self):
         # all-lowercase passwords are legitimate (no entropy gate that rejects them)
         ext = _ext(
-            "ScarletAndRage login: username: buckeye614 password: verysecretword",
-            entities=["ScarletAndRage"],
+            "HobbyForum login: username: forumuser42 password: verysecretword",
+            entities=["HobbyForum"],
         )
         ref = classify_as_reference(ext)
         assert ref is not None
@@ -172,7 +172,7 @@ async def test_mixed_chunk_ingests_only_genuine_references(_db, _store):
         ),
         _ext(
             "The portfolio website is complete; the content pass committed to "
-            "main, authored by Jay Wingard.",
+            "main, authored by Test User.",
             ["portfolio website"],
         ),
         _ext(
@@ -187,8 +187,8 @@ async def test_mixed_chunk_ingests_only_genuine_references(_db, _store):
         ),
         # genuine references that MUST still be captured:
         _ext(
-            "ScarletAndRage login: username: buckeye614 password: Sup3r!secret",
-            ["ScarletAndRage"],
+            "HobbyForum login: username: forumuser42 password: Sup3r!secret",
+            ["HobbyForum"],
         ),
         _ext(
             "The Genesis API server runs on host 203.0.113.50 for embeddings",

--- a/tests/test_memory/test_reference_ops.py
+++ b/tests/test_memory/test_reference_ops.py
@@ -33,7 +33,7 @@ from genesis.memory.reference_ops import (
 
 _CASES = [
     # (description, value)
-    ("ScarletAndRage forum login for the 614buckeye persona", "admin / Hunter2!xyz"),
+    ("HobbyForum forum login for the example persona", "admin / Hunter2!xyz"),
     ("Edge router admin panel", "https://203.0.113.10/admin"),
     ("Container host on the lab subnet", "203.0.113.42"),
     # value containing the separator + special chars
@@ -52,7 +52,7 @@ def test_parse_roundtrip_mcp_formatter(description, value):
         identifier="Test Entry",
         description=description,
         value=value,
-        tags=["forum", "persona:614buckeye"],
+        tags=["forum", "persona:example"],
         source={"captured_via": "manual", "session_id": "sess123"},
     )
     parsed = parse_reference_body(body)

--- a/tests/test_surplus/test_executor.py
+++ b/tests/test_surplus/test_executor.py
@@ -65,7 +65,7 @@ async def test_post_to_telegram_keeps_quotes_raw():
     renders &quot;/&#x27; literally), while &/</> stay escaped for HTML safety."""
     ex = object.__new__(SurplusLLMExecutor)
     ex._topic_manager = AsyncMock()
-    content = "{\"title\": \"Jay's plan & <next> steps\"}"
+    content = "{\"title\": \"the user's plan & <next> steps\"}"
     await ex._post_to_telegram(_make_task(), content)
 
     ex._topic_manager.send_to_category.assert_called_once()
@@ -119,7 +119,7 @@ def test_humanize_multiple_findings():
 def test_humanize_non_findings_json_unchanged():
     # A JSON object without a findings list is returned verbatim — protects the
     # keeps-quotes-raw regression and avoids mangling other structured output.
-    raw = '{"title": "Jay\'s plan & <next> steps"}'
+    raw = '{"title": "the user\'s plan & <next> steps"}'
     assert _humanize_surplus_content(raw) == raw
 
 


### PR DESCRIPTION
## What

Genericize install-specific illustrative strings in docstrings, seed data, and
test fixtures with neutral placeholders (example forum/user/domain names, generic
operator references). Pure genericization — no logic change.

## Why

Example strings in shipped source and test fixtures should be install-agnostic
placeholders, not values tied to any particular install. This aligns the example
data with the project's generalizability convention.

## Scope

- Docstrings / seed data: `knowledge.py`, `knowledge_ingest.py`, `entity_seed.py`,
  `genesis_bridge.py`, plus generic operator references in a few code comments.
- Test fixtures: reference-extraction, knowledge-CRUD, memory-MCP, extraction-job,
  reference-ops, sanitize, and surplus suites — fixture values and their assertions
  updated in lockstep.

## Verification

- Reference-extraction classifier and sanitizer behavior preserved (placeholders
  chosen to keep the same classification paths — credential/URL/forbidden-path/email).
- **246 tests pass** across all 8 affected files.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
