### PR TITLE
feat(resilience): cc-tmp auto-converge via cold-start + timer host apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **cc-tmp blast-radius isolation now converges on its own.** The dedicated,
+  size-capped volume that stops a runaway temp write from filling the container
+  root — and taking every Claude Code session down with it — used to attach only
+  during a guardian redeploy that happened to land while no CC session was live,
+  which on a busy install is almost never. A cold-start apply (before the server
+  starts) plus a periodic retry timer now keep trying until a quiet moment is
+  found, and the infrastructure-posture alert tells "converging" apart from
+  "needs attention" so it doesn't nag when it's simply waiting. No action needed;
+  a deliberate container restart closes it immediately.
+
 - **GitHub steward now surfaces responses to your upstream contributions.** Beyond
   the flagship-repo deep-poll, the account-activity monitor gained an account-level
   notifications lane: it pings you when someone @mentions you on any repo, or

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1053,6 +1053,16 @@ if [[ -d "$SYSTEMD_TEMPLATE_DIR" ]]; then
                 echo "  + $timer_name enabled + started" || true
         fi
     done
+
+    # Enable the cc-tmp cold-start apply SERVICE (WantedBy=default.target, not a
+    # timer — the loop above only enables timers). Enable-only (not --now): it is
+    # meant to fire in the CC-quiet cold-start window before genesis-server, so
+    # arming it for the next boot is correct; the paired timer handles periodic
+    # attempts. Without this an existing install would render but never activate it.
+    if [ -f "$SYSTEMD_USER_DIR/genesis-cc-tmp-align.service" ]; then
+        systemctl --user enable genesis-cc-tmp-align.service 2>/dev/null && \
+            echo "  + genesis-cc-tmp-align.service enabled (cold-start cc-tmp apply)" || true
+    fi
 else
     echo "  Template directory $SYSTEMD_TEMPLATE_DIR not found — skipping"
 fi

--- a/scripts/cc_tmp_align_host.sh
+++ b/scripts/cc_tmp_align_host.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# cc_tmp_align_host.sh — opportunistic cc-tmp blast-radius isolation via the host.
+#
+# WHY: ~/.genesis/cc-tmp is the TMPDIR for every CC session + genesis-server. The
+# remediation that moves it onto a dedicated, size-capped incus volume
+# (scripts/lib/cc_tmp_volume.sh::cc_tmp_volume_apply) MUST run host-side (needs
+# incus) and deliberately SKIPS while any CC session is live (attaching over
+# cc-tmp would shadow open temp files). Today it only fires from the guardian
+# `redeploy` verb — which lands whenever an update happens, almost never at a
+# CC-quiet moment — so on a busy install the apply skips forever and cc-tmp stays
+# on the rootfs. This entrypoint fires the host-side apply OPPORTUNISTICALLY from
+# the container: at container cold-start (before genesis-server + interactive
+# sessions attach — the one deterministically quiet window) and periodically via
+# a timer (applies only if the host observes CC quiet). It NEVER forces: the
+# host-side guard still skips if a session is live, and this simply records the
+# outcome so the awareness posture can distinguish "blocked on a live CC session"
+# (converging) from a terminal failure.
+#
+# HOST-ONLY reach by design: it only issues a single gateway SSH verb
+# (`cc-tmp-apply`), which runs the apply with the host's own incus + privilege —
+# so it needs no local sudo and is safe under NoNewPrivileges/ProtectSystem=strict.
+#
+# Non-fatal + idempotent: a guardian-less install is a clean no-op; an
+# unreachable host or an old gateway (no `cc-tmp-apply` verb) records an honest
+# marker and exits 0. The apply itself is idempotent (already-isolated → no-op).
+# Always exits 0 — the durable signal is the marker + the awareness posture nag,
+# not this unit's status; a persistent gap surfaces as an infra_profile fact.
+#
+# Invoked by scripts/systemd/genesis-cc-tmp-align.{service,timer}.template.
+
+set -u
+
+GENESIS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_PY="$GENESIS_ROOT/.venv/bin/python"
+GUARDIAN_CONFIG="$HOME/.genesis/guardian_remote.yaml"
+SSH_KEY="$HOME/.ssh/genesis_guardian_ed25519"
+MARKER="$HOME/.genesis/state/cc_tmp_apply.json"
+
+# ── Single-flight guard: never let two runs issue concurrent host applies. ──
+LOCKFILE="$HOME/.genesis/locks/cc_tmp_align_host.lock"
+mkdir -p "$(dirname "$LOCKFILE")" 2>/dev/null || true
+if ! exec {LOCK_FD}>"$LOCKFILE"; then
+    echo "cc_tmp_align_host: cannot open lockfile $LOCKFILE — skipping (non-fatal)"
+    exit 0
+fi
+if ! flock -n "$LOCK_FD"; then
+    echo "cc_tmp_align_host: another run is in progress — skipping"
+    exit 0
+fi
+
+# ── Guardian-less install → clean no-op (no host plane to reach). ──
+if [ ! -f "$GUARDIAN_CONFIG" ]; then
+    echo "cc_tmp_align_host: no guardian_remote.yaml — host apply not applicable (no-op)"
+    exit 0
+fi
+if [ ! -f "$SSH_KEY" ]; then
+    echo "cc_tmp_align_host: guardian SSH key $SSH_KEY missing — cannot reach host (skipping)"
+    exit 0
+fi
+if [ ! -x "$VENV_PY" ]; then
+    echo "cc_tmp_align_host: venv python ($VENV_PY) unavailable — cannot parse guardian config (skipping)"
+    exit 0
+fi
+
+# ── Parse host_ip / host_user (yaml.safe_load, mirroring cc_align_host.sh). ──
+HOST_IP="$("$VENV_PY" -c "import yaml, pathlib; print(yaml.safe_load(pathlib.Path('$GUARDIAN_CONFIG').read_text()).get('host_ip', ''))" 2>/dev/null || true)"
+HOST_USER="$("$VENV_PY" -c "import yaml, pathlib; print(yaml.safe_load(pathlib.Path('$GUARDIAN_CONFIG').read_text()).get('host_user', 'ubuntu'))" 2>/dev/null || echo "ubuntu")"
+if [ -z "$HOST_IP" ]; then
+    echo "cc_tmp_align_host: host_ip unparseable in $GUARDIAN_CONFIG — skipping (non-fatal)"
+    exit 0
+fi
+
+# ── Issue the host-side apply verb. `timeout` bounds a hung incus op on the
+# host (fast in practice; 90s is generous). Unreachable/old-gateway → empty or
+# a non-JSON `denied`, both handled by the marker writer below. ──
+RESP="$(timeout 90 ssh -i "$SSH_KEY" -o BatchMode=yes -o ConnectTimeout=10 \
+    "${HOST_USER}@${HOST_IP}" cc-tmp-apply 2>/dev/null || true)"
+
+# ── Record the outcome marker (robust to non-JSON / old gateway / unreachable).
+# Read by infra_profile's storage collector so the awareness posture nag can
+# distinguish blocked-on-live-CC (converging) from a terminal skip. ──
+mkdir -p "$(dirname "$MARKER")" 2>/dev/null || true
+"$VENV_PY" - "$MARKER" "$RESP" <<'PY'
+import datetime
+import json
+import os
+import sys
+import tempfile
+
+marker = sys.argv[1]
+resp = sys.argv[2] if len(sys.argv) > 2 else ""
+now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+try:
+    d = json.loads(resp)
+    if not isinstance(d, dict):
+        raise ValueError("not an object")
+    if d.get("ok") is False:
+        reason = "gateway-error"
+        applied = False
+        procs = None
+    else:
+        reason = d.get("result") or "unknown"
+        applied = bool(d.get("applied"))
+        procs = d.get("claude_procs")
+except Exception:
+    # empty stdout (host unreachable) or non-JSON "denied" (gateway predates the
+    # cc-tmp-apply verb) — an honest "could not reach the apply this run".
+    reason = "unreachable-or-old-gateway"
+    applied = False
+    procs = None
+
+out = {
+    "last_attempt_at": now,
+    "last_reason": reason,
+    "claude_procs": procs,
+    "applied": applied,
+}
+mdir = os.path.dirname(marker)
+fd, tmp = tempfile.mkstemp(dir=mdir, prefix=".cc_tmp_apply.", suffix=".json")
+try:
+    with os.fdopen(fd, "w") as f:
+        json.dump(out, f)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, marker)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise
+print(f"cc_tmp_align_host: result={reason} applied={applied} procs={procs}")
+PY
+
+exit 0

--- a/scripts/cc_tmp_align_host.sh
+++ b/scripts/cc_tmp_align_host.sh
@@ -37,6 +37,15 @@ GUARDIAN_CONFIG="$HOME/.genesis/guardian_remote.yaml"
 SSH_KEY="$HOME/.ssh/genesis_guardian_ed25519"
 MARKER="$HOME/.genesis/state/cc_tmp_apply.json"
 
+# Invalidate any prior outcome marker. Called on the preflight no-op paths where
+# the apply can't even be ATTEMPTED this run (no guardian, broken key/venv/config):
+# a stale "live-cc" marker there would keep the awareness posture falsely
+# "converging/patient" when nothing is actually converging. Clearing it makes the
+# collector emit no cc_tmp_apply_* facts, so posture falls back to the honest
+# actionable nag. Safe when absent (rm -f). NOT called on the lock/single-flight
+# skips — another run owns the marker there.
+_invalidate_marker() { rm -f "$MARKER" 2>/dev/null || true; }
+
 # ── Single-flight guard: never let two runs issue concurrent host applies. ──
 LOCKFILE="$HOME/.genesis/locks/cc_tmp_align_host.lock"
 mkdir -p "$(dirname "$LOCKFILE")" 2>/dev/null || true
@@ -52,14 +61,17 @@ fi
 # ── Guardian-less install → clean no-op (no host plane to reach). ──
 if [ ! -f "$GUARDIAN_CONFIG" ]; then
     echo "cc_tmp_align_host: no guardian_remote.yaml — host apply not applicable (no-op)"
+    _invalidate_marker
     exit 0
 fi
 if [ ! -f "$SSH_KEY" ]; then
     echo "cc_tmp_align_host: guardian SSH key $SSH_KEY missing — cannot reach host (skipping)"
+    _invalidate_marker
     exit 0
 fi
 if [ ! -x "$VENV_PY" ]; then
     echo "cc_tmp_align_host: venv python ($VENV_PY) unavailable — cannot parse guardian config (skipping)"
+    _invalidate_marker
     exit 0
 fi
 
@@ -68,6 +80,7 @@ HOST_IP="$("$VENV_PY" -c "import yaml, pathlib; print(yaml.safe_load(pathlib.Pat
 HOST_USER="$("$VENV_PY" -c "import yaml, pathlib; print(yaml.safe_load(pathlib.Path('$GUARDIAN_CONFIG').read_text()).get('host_user', 'ubuntu'))" 2>/dev/null || echo "ubuntu")"
 if [ -z "$HOST_IP" ]; then
     echo "cc_tmp_align_host: host_ip unparseable in $GUARDIAN_CONFIG — skipping (non-fatal)"
+    _invalidate_marker
     exit 0
 fi
 

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -21,6 +21,8 @@
 #   host-profile    — read-only host body-schema JSON (meminfo/nproc/kernel,
 #                     storage pool, incus version + container limits.*) for the
 #                     container's infra_profile host plane
+#   cc-tmp-apply    — attach ~/.genesis/cc-tmp to its dedicated incus volume IF
+#                     no CC session is live (idempotent; JSON result token)
 #   bundle-status   — read-only offline repo-bundle archive JSON (host-only
 #                     archived `git bundle` copies + newest stamp; F.4 lifeline)
 #   provision-status          — read-only Proxmox host capacity (audit token)
@@ -888,6 +890,35 @@ PYEOF
         PYTHONPATH="$INSTALL_DIR/src" \
         GUARDIAN_CONFIG="$INSTALL_DIR/config/guardian.yaml" \
             timeout 30 "$VENV_PY" -m genesis.guardian --ram-status
+        ;;
+    cc-tmp-apply)
+        # Host-side cc-tmp isolation apply — attaches ~/.genesis/cc-tmp to its
+        # dedicated incus volume IF no CC session is live (the lib's own guard).
+        # Fired opportunistically by the container's cc_tmp_align_host.sh (a
+        # cold-start oneshot + a periodic timer), so the apply converges during a
+        # quiet window instead of only when a redeploy happens to land quiet.
+        # Emits ONE JSON line on stdout carrying the lib's result token; the lib's
+        # human progress text goes to stderr to preserve the stdout=JSON contract.
+        INSTALL_DIR="${HOME}/.local/share/genesis-guardian"
+        _CCTMP_LIB="$INSTALL_DIR/scripts/lib/cc_tmp_volume.sh"
+        if [ ! -f "$_CCTMP_LIB" ]; then
+            echo '{"ok": false, "action": "cc-tmp-apply", "error": "cc_tmp_volume lib not found — run update to redeploy"}' >&2
+            exit 1
+        fi
+        # shellcheck source=/dev/null
+        . "$_CCTMP_LIB"
+        cc_tmp_volume_apply 1>&2
+        _cctmp_res="${_cctmpvol_result:-unknown}"
+        _cctmp_procs="${_cctmpvol_claude_procs:-}"
+        _cctmp_applied=false
+        if [ "$_cctmp_res" = "applied" ]; then _cctmp_applied=true; fi
+        if [[ "$_cctmp_procs" =~ ^[0-9]+$ ]]; then
+            _cctmp_procs_json="$_cctmp_procs"
+        else
+            _cctmp_procs_json="null"
+        fi
+        printf '{"ok": true, "action": "cc-tmp-apply", "result": "%s", "claude_procs": %s, "applied": %s}\n' \
+            "$_cctmp_res" "$_cctmp_procs_json" "$_cctmp_applied"
         ;;
     host-profile)
         # Read-only: print the host body-schema JSON (system identity, storage

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1173,6 +1173,16 @@ if [ -d "$SYSTEMD_TEMPLATE_DIR" ]; then
     done
 fi
 
+# Enable the cc-tmp cold-start apply SERVICE (WantedBy=default.target, not a
+# timer — the loop above only enables timers). Enable-only (not --now): it is
+# meant to fire in the CC-quiet cold-start window before genesis-server, so
+# arming it for the next boot is correct; the paired timer handles periodic
+# attempts. Without this the cold-start leg would render but never activate.
+if [ -f "$SYSTEMD_USER_DIR/genesis-cc-tmp-align.service" ]; then
+    systemctl --user enable genesis-cc-tmp-align.service 2>/dev/null && \
+        echo "    + genesis-cc-tmp-align.service enabled (cold-start cc-tmp apply)" || true
+fi
+
 # Enable AND start tmp watchgod (OS-level temp protection)
 WATCHGOD_SRC="$REPO_DIR/config/genesis-tmp-watchgod.service"
 if [ -f "$WATCHGOD_SRC" ]; then

--- a/scripts/lib/cc_tmp_volume.sh
+++ b/scripts/lib/cc_tmp_volume.sh
@@ -211,6 +211,23 @@ cc_tmp_volume_apply() {
         echo "  + created storage volume '$pool/$vol' (${size}GiB)."
     fi
 
+    # Re-check for a live CC session IMMEDIATELY before the attach. The guard at
+    # the top ran before the pool/driver/volume-create steps; a session could have
+    # launched in that window (a periodic apply competes with cc-slot / CCInvoker /
+    # interactive `claude` launches, none of which share this lock). This does NOT
+    # fully serialize against launches — an external/interactive `claude` cannot be
+    # made to take a Genesis lock — but it narrows the shadow-a-live-session window
+    # to a single incus call. The deterministic cold-start apply (ordered before
+    # genesis-server) stays the race-free convergence path. The volume just created
+    # is kept and reused by a later apply.
+    if incus exec "$c" -- pgrep -x claude >/dev/null 2>&1; then
+        _cctmpvol_result="live-cc"
+        _cctmpvol_claude_procs="$(incus exec "$c" -- pgrep -xc claude 2>/dev/null || echo '')"
+        echo "  Skipped: a Claude Code session became live before attach — deferring"
+        echo "           to a later apply during a quiet window (volume kept for retry)."
+        return 0
+    fi
+
     # Attach (hot-plug, no restart — spike-proven). Leave the volume on failure
     # so a later apply can retry without re-creating it.
     if ! incus config device add "$c" "$dev" disk \

--- a/scripts/lib/cc_tmp_volume.sh
+++ b/scripts/lib/cc_tmp_volume.sh
@@ -49,7 +49,12 @@ CCTMPVOL_DEVICE_NAME="${CCTMPVOL_DEVICE_NAME:-cc-tmp}"
 CCTMPVOL_VOLUME_NAME="${CCTMPVOL_VOLUME_NAME:-}" # "" → <container>-cc-tmp (collision-safe per host)
 CCTMPVOL_POOL="${CCTMPVOL_POOL:-}"               # "" → the root device's pool
 CCTMPVOL_MOUNT_PATH="${CCTMPVOL_MOUNT_PATH:-}"   # "" → <container home>/.genesis/cc-tmp
-CCTMPVOL_GUARDIAN_YAML="${CCTMPVOL_GUARDIAN_YAML:-$HOME/.local/state/genesis-guardian/guardian.yaml}"
+# Default matches the authoritative path install_guardian.sh writes + every other
+# gateway verb reads ($INSTALL_DIR/config/guardian.yaml, INSTALL_DIR=.local/share/
+# genesis-guardian). A wrong default here silently resolves the container to the
+# "genesis" literal (container_name never read) — breaking every non-default-name
+# install for BOTH this helper's callers (redeploy + cc-tmp-apply).
+CCTMPVOL_GUARDIAN_YAML="${CCTMPVOL_GUARDIAN_YAML:-$HOME/.local/share/genesis-guardian/config/guardian.yaml}"
 
 # Machine-readable outcome of the LAST cc_tmp_volume_apply, set at every return
 # site (and reset at entry). Lets a caller — the guardian `cc-tmp-apply` verb —

--- a/scripts/lib/cc_tmp_volume.sh
+++ b/scripts/lib/cc_tmp_volume.sh
@@ -51,6 +51,14 @@ CCTMPVOL_POOL="${CCTMPVOL_POOL:-}"               # "" → the root device's pool
 CCTMPVOL_MOUNT_PATH="${CCTMPVOL_MOUNT_PATH:-}"   # "" → <container home>/.genesis/cc-tmp
 CCTMPVOL_GUARDIAN_YAML="${CCTMPVOL_GUARDIAN_YAML:-$HOME/.local/state/genesis-guardian/guardian.yaml}"
 
+# Machine-readable outcome of the LAST cc_tmp_volume_apply, set at every return
+# site (and reset at entry). Lets a caller — the guardian `cc-tmp-apply` verb —
+# report WHY the apply skipped, distinguishing "blocked on a live CC session"
+# (converges later) from a terminal skip (unsupported pool, verify-failed) or
+# success. Sourced into the caller's shell, so it persists after the call.
+_cctmpvol_result=""
+_cctmpvol_claude_procs=""
+
 # _cctmpvol_container — resolve the target container: explicit seam, else the
 # container_name from guardian.yaml, else the universal "genesis" default
 # (matches install_guardian.sh / guardian config).
@@ -115,12 +123,16 @@ _cctmpvol_mount_path() {
 # cc_tmp_volume_apply — the entrypoint. Always returns 0.
 cc_tmp_volume_apply() {
     echo "--- cc-tmp dedicated volume (blast-radius isolation) ---"
+    _cctmpvol_result=""
+    _cctmpvol_claude_procs=""
 
     if [[ "$CCTMPVOL_DISABLE" == "1" ]]; then
+        _cctmpvol_result="disabled"
         echo "  Skipped: CCTMPVOL_DISABLE=1."
         return 0
     fi
     if ! command -v incus >/dev/null 2>&1; then
+        _cctmpvol_result="no-incus"
         echo "  Skipped: incus not available (not a guardian host vantage)."
         return 0
     fi
@@ -130,16 +142,19 @@ cc_tmp_volume_apply() {
     dev="$CCTMPVOL_DEVICE_NAME"
 
     if ! incus info "$c" >/dev/null 2>&1; then
+        _cctmpvol_result="not-found"
         echo "  Skipped: container '$c' not found."
         return 0
     fi
     if [[ "$(incus info "$c" 2>/dev/null | awk -F': *' '/^Status:/ {print tolower($2); exit}')" != "running" ]]; then
+        _cctmpvol_result="not-running"
         echo "  Skipped: container '$c' is not running."
         return 0
     fi
 
     # Idempotency: the device already exists → cc-tmp is already isolated.
     if incus config device get "$c" "$dev" source >/dev/null 2>&1; then
+        _cctmpvol_result="already-isolated"
         echo "  cc-tmp already on a dedicated volume (device '$dev' on '$c')."
         return 0
     fi
@@ -150,6 +165,8 @@ cc_tmp_volume_apply() {
     # apply permanently unreachable on a live install; its cc-tmp temp files
     # are short-lived and the pre-split contents are shadowed, not deleted.
     if incus exec "$c" -- pgrep -x claude >/dev/null 2>&1; then
+        _cctmpvol_result="live-cc"
+        _cctmpvol_claude_procs="$(incus exec "$c" -- pgrep -xc claude 2>/dev/null || echo '')"
         echo "  Skipped: a Claude Code session is live in '$c' — attach would shadow its"
         echo "           open temp files. Converges on a later apply during a quiet window."
         return 0
@@ -157,6 +174,7 @@ cc_tmp_volume_apply() {
 
     pool="$(_cctmpvol_pool "$c")"
     if [[ -z "$pool" ]]; then
+        _cctmpvol_result="no-pool"
         echo "  Skipped: could not resolve a storage pool for '$c'."
         return 0
     fi
@@ -172,6 +190,7 @@ cc_tmp_volume_apply() {
     case "$driver" in
         lvm | zfs | btrfs | ceph) : ;;
         *)
+            _cctmpvol_result="unsupported-pool"
             echo "  Skipped: pool '$pool' (driver='${driver:-unknown}') does not enforce a"
             echo "           per-volume size cap on its own device — cc-tmp isolation would be"
             echo "           cosmetic. A block/CoW-backed pool (lvm/zfs/btrfs/ceph) is required."
@@ -185,6 +204,7 @@ cc_tmp_volume_apply() {
     # Create the volume if absent (thin — an empty create costs ~zero pool).
     if ! incus storage volume show "$pool" "$vol" >/dev/null 2>&1; then
         if ! incus storage volume create "$pool" "$vol" "size=${size}GiB" >/dev/null 2>&1; then
+            _cctmpvol_result="volume-create-failed"
             echo "  WARNING: could not create storage volume '$pool/$vol' — cc-tmp NOT isolated."
             return 0
         fi
@@ -195,6 +215,7 @@ cc_tmp_volume_apply() {
     # so a later apply can retry without re-creating it.
     if ! incus config device add "$c" "$dev" disk \
         pool="$pool" source="$vol" path="$path" >/dev/null 2>&1; then
+        _cctmpvol_result="attach-failed"
         echo "  WARNING: could not attach volume at '$path' — cc-tmp NOT isolated (volume kept for retry)."
         return 0
     fi
@@ -221,8 +242,10 @@ cc_tmp_volume_apply() {
     if [[ -n "$uid" && -n "$gid" ]] \
         && incus exec "$c" --user "$uid" --group "$gid" -- \
             sh -c "touch '$path/.cctmpvol-verify' && rm -f '$path/.cctmpvol-verify'" 2>/dev/null; then
+        _cctmpvol_result="applied"
         echo "  + cc-tmp now on dedicated volume '$pool/$vol' (${size}GiB) at $path on '$c'."
     else
+        _cctmpvol_result="verify-failed-rolledback"
         incus config device remove "$c" "$dev" >/dev/null 2>&1 || true
         echo "  WARNING: volume attached but not writable by $CCTMPVOL_USER — rolled back the device."
         echo "           cc-tmp stays on the rootfs (un-isolated). Check container idmap:"

--- a/scripts/systemd/genesis-cc-tmp-align.service.template
+++ b/scripts/systemd/genesis-cc-tmp-align.service.template
@@ -1,0 +1,32 @@
+[Unit]
+Description=Genesis cc-tmp isolation — opportunistic dedicated-volume apply (cold-start + timer)
+# Run in the ONE deterministically CC-quiet window: after the container is up but
+# BEFORE genesis-server starts (it spawns ego/background CC sessions) and before
+# an interactive session attaches. The host-side apply skips while any CC session
+# is live, so this ordering is what lets it converge on an otherwise-busy install.
+# The script bounds its own SSH (ConnectTimeout=10 + timeout 90) and is a clean
+# no-op without a guardian, so an unreachable host adds only the connect timeout
+# to boot before genesis-server proceeds; a miss is non-fatal (marker + posture
+# nag carry the state) and the timer / next cold-start converge.
+Before=genesis-server.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=__REPO_DIR__
+ExecStart=/bin/bash __REPO_DIR__/scripts/cc_tmp_align_host.sh
+# Cap above the script's own 90s SSH bound so a slow host is SIGTERMed rather than
+# blocking boot indefinitely; the common (quiet/unreachable) paths return in seconds.
+TimeoutStartSec=120
+# Needs ssh + flock (/usr/bin) and the venv python (absolute path). No sudo/npm —
+# the host-side cc-tmp-apply verb owns its own incus privilege — so a hardened
+# NoNewPrivileges/ProtectSystem=strict sandbox is safe.
+Environment=PATH=__VENV__/bin:/usr/local/bin:/usr/bin:/bin
+StandardOutput=journal
+StandardError=journal
+# Home-scoped: writes only the single-flight lock + the apply marker under ~/.genesis.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=%h
+
+[Install]
+WantedBy=default.target

--- a/scripts/systemd/genesis-cc-tmp-align.timer.template
+++ b/scripts/systemd/genesis-cc-tmp-align.timer.template
@@ -1,0 +1,18 @@
+[Unit]
+Description=Genesis cc-tmp isolation — periodic opportunistic apply
+
+[Timer]
+# An early post-boot attempt (covers a cold-start run that found the host not yet
+# reachable), then ~every 2h. Each fire is a cheap probe: the host-side apply
+# no-ops unless CC is quiet, so a busy install just keeps trying cheaply until a
+# lull while a quiet install converges on the first fire. The 2h cadence honors
+# the project's 7200s timeout floor as a polling interval. Persistent catches a
+# missed run after downtime; RandomizedDelaySec de-correlates from other timers.
+OnBootSec=15min
+OnUnitInactiveSec=7200
+Persistent=true
+AccuracySec=1h
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -406,6 +406,7 @@ if [ "$MODE" != "guardian-only" ] && [ "$HAS_GENESIS" = true ]; then
         # Stop all Genesis services (timer first, then service, to prevent restart)
         for unit in genesis-watchdog.timer genesis-watchdog.service \
                     genesis-disk-hygiene.timer genesis-disk-hygiene.service \
+                    genesis-cc-tmp-align.timer genesis-cc-tmp-align.service \
                     genesis-server.service genesis-bridge.service \
                     qdrant.service; do
             safe_disable_service "$unit"
@@ -473,9 +474,11 @@ if [ "$MODE" != "guardian-only" ] && [ "$HAS_GENESIS" = true ]; then
             # Stop all services (timers first to prevent restart races)
             container_exec "
                 systemctl --user stop genesis-watchdog.timer genesis-watchdog.service 2>/dev/null || true;
+                systemctl --user stop genesis-cc-tmp-align.timer genesis-cc-tmp-align.service 2>/dev/null || true;
                 systemctl --user stop genesis-server.service genesis-bridge.service qdrant.service 2>/dev/null || true;
                 systemctl --user disable genesis-server.service genesis-bridge.service \
-                    genesis-watchdog.timer genesis-watchdog.service qdrant.service 2>/dev/null || true
+                    genesis-watchdog.timer genesis-watchdog.service \
+                    genesis-cc-tmp-align.timer genesis-cc-tmp-align.service qdrant.service 2>/dev/null || true
             "
             ok "Stopped Genesis services"
 

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -572,6 +572,15 @@ _INFRA_POSTURE_DETAIL = {
         "volume, size-capped so a runaway can never reach the rootfs; requires "
         "a block/CoW-backed storage pool — lvm/zfs/btrfs/ceph)"
     ),
+    "cc_tmp_apply_blocked_on_cc": (
+        "the Claude Code scratch dir (~/.genesis/cc-tmp) still shares a filesystem "
+        "with the container root, but the dedicated-volume apply is CONVERGING: its "
+        "last attempt skipped only because a CC session was live (attaching would "
+        "shadow open temp files). It re-attempts on the next CC-quiet cold-start and "
+        "on a periodic timer (genesis-cc-tmp-align) — no action needed unless this "
+        "persists across many quiet windows. To close it immediately, a deliberate "
+        "container restart runs the apply in the guaranteed-quiet boot window"
+    ),
 }
 
 
@@ -654,7 +663,16 @@ def _infra_missing_protections(profile: dict) -> list[str]:
         _facts("virt").get("container") == "lxc"
         and _facts("storage").get("cc_tmp_isolated") is False
     ):
-        missing.append("cc_tmp_shared_fs")
+        # cc-tmp is on the rootfs either way (fact stays False), but distinguish
+        # the CONVERGING state — the opportunistic apply skipped only because a CC
+        # session was live, and will attach on the next quiet cold-start/lull —
+        # from a state that needs a human (unsupported pool, verify-failed, or
+        # never-attempted). Only the surfaced detail differs; the alert still fires
+        # so the posture stays honest that isolation is not yet in place.
+        if _facts("storage").get("cc_tmp_apply_blocked_on_cc") is True:
+            missing.append("cc_tmp_apply_blocked_on_cc")
+        else:
+            missing.append("cc_tmp_shared_fs")
     return sorted(missing)
 
 

--- a/src/genesis/guardian/remote.py
+++ b/src/genesis/guardian/remote.py
@@ -10,7 +10,7 @@ enforces this restriction, not our code.
 
 Gateway allowlist: restart-timer, pause, resume, status, reset-state, version,
 update, sync-gateway, redeploy, update-cc, update-node, test-approval,
-disk-status, host-profile, reharden-key, ping, provision-status,
+disk-status, host-profile, cc-tmp-apply, reharden-key, ping, provision-status,
 provision-grow-disk, provision-grow-memory, provision-vzdump,
 provision-vzdump-status, storage-expand, grow-root,
 set-container-limits.

--- a/src/genesis/infra_profile/collectors/container.py
+++ b/src/genesis/infra_profile/collectors/container.py
@@ -25,6 +25,7 @@ import platform
 import shutil
 import socket
 import sqlite3
+from datetime import UTC, datetime
 from pathlib import Path
 
 from genesis.infra_profile.types import SectionResult
@@ -32,6 +33,28 @@ from genesis.infra_profile.types import SectionResult
 logger = logging.getLogger(__name__)
 
 _CMD_TIMEOUT = 15.0
+
+# A cc-tmp apply marker is trusted as "converging" only while its attempt
+# timestamp is within this bound — ~3x the genesis-cc-tmp-align timer's 2h
+# (OnUnitInactiveSec=7200) retry cadence. Beyond it the timer is plausibly
+# dead/disabled or a run couldn't update the marker, so a stale "live-cc" must
+# read as actionable rather than "converging forever". This one freshness rule
+# subsumes the dead-timer, lock-open-failure, and marker-write-failure paths.
+_CC_TMP_MARKER_FRESH_S = 6 * 3600
+
+
+def _cc_tmp_marker_fresh(at: object) -> bool:
+    """True if a cc-tmp apply marker's ``last_attempt_at`` is recent enough that
+    the retry timer is plausibly still running. Non-str / unparseable → not fresh."""
+    if not isinstance(at, str) or not at:
+        return False
+    try:
+        ts = datetime.fromisoformat(at)
+    except ValueError:
+        return False
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=UTC)
+    return (datetime.now(UTC) - ts).total_seconds() < _CC_TMP_MARKER_FRESH_S
 
 # Filesystem types worth recording as real mounts. Kernel plumbing
 # (proc/sysfs/cgroup2/…) is noise; tmpfs is deliberately IN — tmpfs sizes
@@ -475,21 +498,27 @@ async def collect_storage(
 
     # cc-tmp apply OUTCOME — the container-side opportunistic apply
     # (scripts/cc_tmp_align_host.sh) records its last result in
-    # ~/.genesis/state/cc_tmp_apply.json. Surfacing the reason lets the awareness
-    # posture rule tell "blocked on a live CC session" (converging, patient) apart
-    # from a terminal skip (still needs a human) or never-attempted. Best-effort;
-    # absent/unreadable → silent (a fresh install has no marker until the unit runs).
+    # ~/.genesis/state/cc_tmp_apply.json. The raw reason + timestamp are VOLATILE
+    # scheduling artifacts (they change as CC sessions come and go), so they go in
+    # METRICS — rendered but NEVER hashed, so they can't spam infrastructure_drift
+    # or churn the posture alert. Only the DERIVED cc_tmp_apply_blocked_on_cc is a
+    # FACT, and it is FRESHNESS-BOUNDED (see _cc_tmp_marker_fresh): a "live-cc"
+    # marker reads as "converging" ONLY while recent, so a stale marker (dead
+    # timer, lock-open failure, write failure) falls back to the actionable nag
+    # instead of "converging forever". Best-effort; absent/unreadable → silent.
     try:
         _marker = Path.home() / ".genesis" / "state" / "cc_tmp_apply.json"
         _m = json.loads(_marker.read_text())
         if isinstance(_m, dict):
             _reason = _m.get("last_reason")
-            if isinstance(_reason, str) and _reason:
-                facts["cc_tmp_apply_last_reason"] = _reason
-                facts["cc_tmp_apply_blocked_on_cc"] = _reason == "live-cc"
             _at = _m.get("last_attempt_at")
+            if isinstance(_reason, str) and _reason:
+                metrics["cc_tmp_apply_last_reason"] = _reason
             if isinstance(_at, str) and _at:
-                facts["cc_tmp_apply_last_attempt_at"] = _at
+                metrics["cc_tmp_apply_last_attempt_at"] = _at
+            facts["cc_tmp_apply_blocked_on_cc"] = (
+                _reason == "live-cc" and _cc_tmp_marker_fresh(_at)
+            )
     except (OSError, ValueError):
         pass
 

--- a/src/genesis/infra_profile/collectors/container.py
+++ b/src/genesis/infra_profile/collectors/container.py
@@ -473,6 +473,26 @@ async def collect_storage(
     except OSError:
         pass
 
+    # cc-tmp apply OUTCOME — the container-side opportunistic apply
+    # (scripts/cc_tmp_align_host.sh) records its last result in
+    # ~/.genesis/state/cc_tmp_apply.json. Surfacing the reason lets the awareness
+    # posture rule tell "blocked on a live CC session" (converging, patient) apart
+    # from a terminal skip (still needs a human) or never-attempted. Best-effort;
+    # absent/unreadable → silent (a fresh install has no marker until the unit runs).
+    try:
+        _marker = Path.home() / ".genesis" / "state" / "cc_tmp_apply.json"
+        _m = json.loads(_marker.read_text())
+        if isinstance(_m, dict):
+            _reason = _m.get("last_reason")
+            if isinstance(_reason, str) and _reason:
+                facts["cc_tmp_apply_last_reason"] = _reason
+                facts["cc_tmp_apply_blocked_on_cc"] = _reason == "live-cc"
+            _at = _m.get("last_attempt_at")
+            if isinstance(_at, str) and _at:
+                facts["cc_tmp_apply_last_attempt_at"] = _at
+    except (OSError, ValueError):
+        pass
+
     return SectionResult(name="storage", facts=facts, metrics=metrics)
 
 

--- a/tests/test_awareness/test_infra_protection_posture.py
+++ b/tests/test_awareness/test_infra_protection_posture.py
@@ -503,6 +503,13 @@ def test_every_rule_slug_has_detail_text():
     # without detail text would KeyError inside the (swallowed) check. Derive
     # the producible set from the rules themselves.
     producible = set(_infra_missing_protections(_profile(**_ALL_DEFECTS)))
+    # cc-tmp has a reason-branch: _ALL_DEFECTS yields the actionable slug, while
+    # the CONVERGING variant is produced only when the apply marker reports
+    # blocked-on-a-live-CC-session — cover that branch so both cc-tmp slugs are
+    # in the producible set (and neither is an orphan detail entry).
+    prof_blocked = _profile(**_ALL_DEFECTS)
+    prof_blocked["sections"]["storage"]["facts"]["cc_tmp_apply_blocked_on_cc"] = True
+    producible |= set(_infra_missing_protections(prof_blocked))
     assert producible == set(_loop._INFRA_POSTURE_DETAIL)
 
 
@@ -521,6 +528,7 @@ def test_resilience_facts_are_covered():
         "networkd_default_route_keepconfig",
         "network_watchdog_enabled",
         "cc_tmp_isolated",
+        "cc_tmp_apply_blocked_on_cc",
     ):
         assert fact in src, f"posture rules no longer read {fact!r}"
 
@@ -530,3 +538,48 @@ def test_check_is_wired_into_the_tick():
     # pipeline, not just exist as a function.
     src = inspect.getsource(_loop)
     assert "await _check_infra_protection_posture(self._db)" in src
+
+
+# ── cc-tmp apply reason-aware surfacing (converging vs actionable) ────────────
+
+
+def _lxc_unisolated(**storage_extra):
+    prof = _profile(cc_tmp_isolated=False, container="lxc")
+    prof["sections"]["storage"]["facts"].update(storage_extra)
+    return prof
+
+
+def test_blocked_on_cc_surfaces_converging_slug():
+    missing = _infra_missing_protections(_lxc_unisolated(cc_tmp_apply_blocked_on_cc=True))
+    assert "cc_tmp_apply_blocked_on_cc" in missing
+    assert "cc_tmp_shared_fs" not in missing  # not the actionable nag while converging
+
+
+def test_never_attempted_falls_back_to_actionable_slug():
+    # No marker yet (fact absent) → the actionable nag, not the converging one.
+    missing = _infra_missing_protections(_lxc_unisolated())
+    assert "cc_tmp_shared_fs" in missing
+    assert "cc_tmp_apply_blocked_on_cc" not in missing
+
+
+def test_terminal_skip_false_is_actionable():
+    # A terminal skip (unsupported pool / verify-failed) → blocked_on_cc False → actionable.
+    missing = _infra_missing_protections(_lxc_unisolated(cc_tmp_apply_blocked_on_cc=False))
+    assert "cc_tmp_shared_fs" in missing
+    assert "cc_tmp_apply_blocked_on_cc" not in missing
+
+
+def test_isolated_true_silent_regardless_of_reason():
+    prof = _profile(cc_tmp_isolated=True, container="lxc")
+    prof["sections"]["storage"]["facts"]["cc_tmp_apply_blocked_on_cc"] = True
+    missing = _infra_missing_protections(prof)
+    assert "cc_tmp_apply_blocked_on_cc" not in missing
+    assert "cc_tmp_shared_fs" not in missing
+
+
+def test_both_cc_tmp_slugs_have_detail_entries():
+    # Guards the KeyError trap: _check_infra_protection_posture looks up
+    # _INFRA_POSTURE_DETAIL[slug] for every missing slug, so an emittable slug
+    # WITHOUT a detail entry would crash the (best-effort) posture check.
+    assert "cc_tmp_apply_blocked_on_cc" in _loop._INFRA_POSTURE_DETAIL
+    assert "cc_tmp_shared_fs" in _loop._INFRA_POSTURE_DETAIL

--- a/tests/test_infra_profile/test_collectors_container.py
+++ b/tests/test_infra_profile/test_collectors_container.py
@@ -444,3 +444,65 @@ async def test_storage_cc_tmp_fact_absent_when_missing(proc_root, sys_root, tmp_
     monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
     result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
     assert "cc_tmp_isolated" not in result.facts
+
+
+def _write_marker(home, **fields):
+    (home / ".genesis" / "state").mkdir(parents=True, exist_ok=True)
+    (home / ".genesis" / "state" / "cc_tmp_apply.json").write_text(json.dumps(fields))
+
+
+async def test_storage_cc_tmp_apply_marker_surfaced(proc_root, sys_root, tmp_path, monkeypatch):
+    home = tmp_path / "h"
+    (home / ".genesis" / "cc-tmp").mkdir(parents=True)
+    _write_marker(
+        home,
+        last_attempt_at="2026-08-09T00:00:00+00:00",
+        last_reason="live-cc",
+        claude_procs=5,
+        applied=False,
+    )
+    monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
+    result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
+    assert result.facts["cc_tmp_apply_last_reason"] == "live-cc"
+    assert result.facts["cc_tmp_apply_blocked_on_cc"] is True
+    assert result.facts["cc_tmp_apply_last_attempt_at"] == "2026-08-09T00:00:00+00:00"
+
+
+async def test_storage_cc_tmp_apply_terminal_reason_not_blocked(
+    proc_root, sys_root, tmp_path, monkeypatch
+):
+    home = tmp_path / "h"
+    (home / ".genesis" / "cc-tmp").mkdir(parents=True)
+    _write_marker(
+        home,
+        last_attempt_at="2026-08-09T00:00:00+00:00",
+        last_reason="unsupported-pool",
+        applied=False,
+    )
+    monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
+    result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
+    assert result.facts["cc_tmp_apply_last_reason"] == "unsupported-pool"
+    assert result.facts["cc_tmp_apply_blocked_on_cc"] is False
+
+
+async def test_storage_cc_tmp_apply_marker_absent_silent(
+    proc_root, sys_root, tmp_path, monkeypatch
+):
+    home = tmp_path / "h"
+    (home / ".genesis" / "cc-tmp").mkdir(parents=True)  # no state/ marker
+    monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
+    result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
+    assert "cc_tmp_apply_last_reason" not in result.facts
+    assert "cc_tmp_apply_blocked_on_cc" not in result.facts
+
+
+async def test_storage_cc_tmp_apply_marker_corrupt_silent(
+    proc_root, sys_root, tmp_path, monkeypatch
+):
+    home = tmp_path / "h"
+    (home / ".genesis" / "cc-tmp").mkdir(parents=True)
+    (home / ".genesis" / "state").mkdir(parents=True)
+    (home / ".genesis" / "state" / "cc_tmp_apply.json").write_text("not valid json {{{")
+    monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
+    result = await collect_storage(proc_root=proc_root, sys_root=sys_root)  # must not raise
+    assert "cc_tmp_apply_last_reason" not in result.facts

--- a/tests/test_infra_profile/test_collectors_container.py
+++ b/tests/test_infra_profile/test_collectors_container.py
@@ -451,21 +451,42 @@ def _write_marker(home, **fields):
     (home / ".genesis" / "state" / "cc_tmp_apply.json").write_text(json.dumps(fields))
 
 
-async def test_storage_cc_tmp_apply_marker_surfaced(proc_root, sys_root, tmp_path, monkeypatch):
+def _fresh_now() -> str:
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat()
+
+
+async def test_storage_cc_tmp_apply_volatile_fields_are_metrics_not_facts(
+    proc_root, sys_root, tmp_path, monkeypatch
+):
+    # The raw reason/timestamp are volatile (change as CC sessions come/go) → they
+    # MUST live in metrics (never hashed), not facts, or they spam infra drift.
     home = tmp_path / "h"
     (home / ".genesis" / "cc-tmp").mkdir(parents=True)
-    _write_marker(
-        home,
-        last_attempt_at="2026-08-09T00:00:00+00:00",
-        last_reason="live-cc",
-        claude_procs=5,
-        applied=False,
-    )
+    _write_marker(home, last_attempt_at=_fresh_now(), last_reason="live-cc", claude_procs=5)
     monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
     result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
-    assert result.facts["cc_tmp_apply_last_reason"] == "live-cc"
+    # derived + freshness-bounded → FACT
     assert result.facts["cc_tmp_apply_blocked_on_cc"] is True
-    assert result.facts["cc_tmp_apply_last_attempt_at"] == "2026-08-09T00:00:00+00:00"
+    # raw volatile fields → METRICS, and NOT duplicated into facts
+    assert result.metrics["cc_tmp_apply_last_reason"] == "live-cc"
+    assert "cc_tmp_apply_last_attempt_at" in result.metrics
+    assert "cc_tmp_apply_last_reason" not in result.facts
+    assert "cc_tmp_apply_last_attempt_at" not in result.facts
+
+
+async def test_storage_cc_tmp_apply_stale_marker_not_converging(
+    proc_root, sys_root, tmp_path, monkeypatch
+):
+    # A live-cc marker whose attempt is OLD (dead/disabled timer, lock/write
+    # failure) must NOT read as converging — the freshness bound flips it.
+    home = tmp_path / "h"
+    (home / ".genesis" / "cc-tmp").mkdir(parents=True)
+    _write_marker(home, last_attempt_at="2020-01-01T00:00:00+00:00", last_reason="live-cc")
+    monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
+    result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
+    assert result.facts["cc_tmp_apply_blocked_on_cc"] is False
 
 
 async def test_storage_cc_tmp_apply_terminal_reason_not_blocked(
@@ -473,16 +494,11 @@ async def test_storage_cc_tmp_apply_terminal_reason_not_blocked(
 ):
     home = tmp_path / "h"
     (home / ".genesis" / "cc-tmp").mkdir(parents=True)
-    _write_marker(
-        home,
-        last_attempt_at="2026-08-09T00:00:00+00:00",
-        last_reason="unsupported-pool",
-        applied=False,
-    )
+    _write_marker(home, last_attempt_at=_fresh_now(), last_reason="unsupported-pool")
     monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
     result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
-    assert result.facts["cc_tmp_apply_last_reason"] == "unsupported-pool"
-    assert result.facts["cc_tmp_apply_blocked_on_cc"] is False
+    assert result.facts["cc_tmp_apply_blocked_on_cc"] is False  # not live-cc
+    assert result.metrics["cc_tmp_apply_last_reason"] == "unsupported-pool"
 
 
 async def test_storage_cc_tmp_apply_marker_absent_silent(
@@ -492,8 +508,8 @@ async def test_storage_cc_tmp_apply_marker_absent_silent(
     (home / ".genesis" / "cc-tmp").mkdir(parents=True)  # no state/ marker
     monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
     result = await collect_storage(proc_root=proc_root, sys_root=sys_root)
-    assert "cc_tmp_apply_last_reason" not in result.facts
     assert "cc_tmp_apply_blocked_on_cc" not in result.facts
+    assert "cc_tmp_apply_last_reason" not in result.metrics
 
 
 async def test_storage_cc_tmp_apply_marker_corrupt_silent(
@@ -505,4 +521,37 @@ async def test_storage_cc_tmp_apply_marker_corrupt_silent(
     (home / ".genesis" / "state" / "cc_tmp_apply.json").write_text("not valid json {{{")
     monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
     result = await collect_storage(proc_root=proc_root, sys_root=sys_root)  # must not raise
-    assert "cc_tmp_apply_last_reason" not in result.facts
+    assert "cc_tmp_apply_blocked_on_cc" not in result.facts
+
+
+async def test_storage_marker_does_not_churn_facts_hash(proc_root, sys_root, tmp_path, monkeypatch):
+    # Cluster-A regression guard: the SAME converging state sampled at two
+    # different times (different last_attempt_at) must produce IDENTICAL facts, so
+    # section_hash is stable and no spurious infrastructure_drift fires — only the
+    # metrics differ.
+    home = tmp_path / "h"
+    (home / ".genesis" / "cc-tmp").mkdir(parents=True)
+    monkeypatch.setattr(_container.Path, "home", staticmethod(lambda: home))
+    monkeypatch.setattr(_container, "_cc_tmp_marker_fresh", lambda _at: True)
+    _write_marker(home, last_attempt_at="2026-08-09T10:00:00+00:00", last_reason="live-cc")
+    first = await collect_storage(proc_root=proc_root, sys_root=sys_root)
+    _write_marker(home, last_attempt_at="2026-08-09T10:02:00+00:00", last_reason="live-cc")
+    second = await collect_storage(proc_root=proc_root, sys_root=sys_root)
+    assert first.facts == second.facts  # hashed surface stable across marker churn
+    assert (
+        first.metrics["cc_tmp_apply_last_attempt_at"]
+        != second.metrics["cc_tmp_apply_last_attempt_at"]
+    )
+
+
+def test_cc_tmp_marker_fresh_helper():
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime.now(UTC)
+    assert _container._cc_tmp_marker_fresh((now - timedelta(minutes=30)).isoformat()) is True
+    assert _container._cc_tmp_marker_fresh((now - timedelta(hours=12)).isoformat()) is False
+    assert _container._cc_tmp_marker_fresh("2020-01-01T00:00:00+00:00") is False
+    assert _container._cc_tmp_marker_fresh("not-a-timestamp") is False
+    assert _container._cc_tmp_marker_fresh(None) is False
+    # a naive (tz-less) timestamp is treated as UTC, not crashed
+    assert _container._cc_tmp_marker_fresh(now.replace(tzinfo=None).isoformat()) is True

--- a/tests/test_scripts/test_cc_tmp_align_host.py
+++ b/tests/test_scripts/test_cc_tmp_align_host.py
@@ -20,7 +20,15 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ALIGN = REPO_ROOT / "scripts" / "cc_tmp_align_host.sh"
 
 
-def _harness(tmp_path, *, ssh_response="", ssh_rc=0, with_guardian=True, with_key=True):
+def _harness(
+    tmp_path,
+    *,
+    ssh_response="",
+    ssh_rc=0,
+    with_guardian=True,
+    with_key=True,
+    preexisting_marker=None,
+):
     root = tmp_path  # doubles as GENESIS_ROOT (has .venv) and HOME (has .genesis/.ssh)
     (root / "scripts").mkdir(parents=True, exist_ok=True)
     script = root / "scripts" / "cc_tmp_align_host.sh"
@@ -33,6 +41,9 @@ def _harness(tmp_path, *, ssh_response="", ssh_rc=0, with_guardian=True, with_ke
 
     gdir = root / ".genesis"
     gdir.mkdir(exist_ok=True)
+    if preexisting_marker is not None:
+        (gdir / "state").mkdir(parents=True, exist_ok=True)
+        (gdir / "state" / "cc_tmp_apply.json").write_text(json.dumps(preexisting_marker))
     if with_guardian:
         (gdir / "guardian_remote.yaml").write_text("host_ip: 192.0.2.9\nhost_user: opuser\n")
     sshdir = root / ".ssh"
@@ -141,3 +152,44 @@ def test_self_guards_present():
     assert "flock -n" in txt, "must single-flight"
     assert "guardian_remote.yaml" in txt, "must no-op without a guardian"
     assert "cc-tmp-apply" in txt, "must call the gateway verb"
+
+
+# ── stale-marker invalidation on preflight no-op (Codex P2) ──────────────────
+
+
+def test_preflight_noop_clears_stale_marker(tmp_path):
+    # A prior run recorded live-cc; guardian later removed → the no-op path must
+    # invalidate the stale marker so the posture stops falsely reporting
+    # "converging" when nothing is actually being retried.
+    proc, marker = _harness(
+        tmp_path,
+        with_guardian=False,
+        preexisting_marker={
+            "last_attempt_at": "2026-08-09T00:00:00+00:00",
+            "last_reason": "live-cc",
+            "applied": False,
+        },
+    )
+    assert proc.returncode == 0
+    assert marker is None  # stale marker invalidated → collector falls back to actionable
+
+
+def test_missing_key_clears_stale_marker(tmp_path):
+    proc, marker = _harness(
+        tmp_path,
+        with_key=False,
+        preexisting_marker={"last_attempt_at": "x", "last_reason": "live-cc", "applied": False},
+    )
+    assert proc.returncode == 0
+    assert marker is None
+
+
+def test_successful_run_still_overwrites_marker(tmp_path):
+    # A preexisting marker must NOT block a real run from recording its outcome.
+    proc, marker = _harness(
+        tmp_path,
+        ssh_response=_applied_json(result="applied"),
+        preexisting_marker={"last_attempt_at": "old", "last_reason": "live-cc", "applied": False},
+    )
+    assert proc.returncode == 0
+    assert marker["last_reason"] == "applied"

--- a/tests/test_scripts/test_cc_tmp_align_host.py
+++ b/tests/test_scripts/test_cc_tmp_align_host.py
@@ -1,0 +1,143 @@
+"""Behavioral tests for the container-side entrypoint scripts/cc_tmp_align_host.sh.
+
+It SSHes the guardian `cc-tmp-apply` verb and records the outcome in
+~/.genesis/state/cc_tmp_apply.json (read by the infra_profile storage collector,
+which feeds the awareness posture nag). The script resolves its venv python from
+its own location, so the harness copies the REAL script into a tmp GENESIS_ROOT
+with a symlink to the running venv python (needs yaml) and stubs `ssh` on PATH —
+so the logic under test is the shipped code, end to end.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALIGN = REPO_ROOT / "scripts" / "cc_tmp_align_host.sh"
+
+
+def _harness(tmp_path, *, ssh_response="", ssh_rc=0, with_guardian=True, with_key=True):
+    root = tmp_path  # doubles as GENESIS_ROOT (has .venv) and HOME (has .genesis/.ssh)
+    (root / "scripts").mkdir(parents=True, exist_ok=True)
+    script = root / "scripts" / "cc_tmp_align_host.sh"
+    script.write_text(ALIGN.read_text())
+    script.chmod(0o755)
+    # Real venv python (has yaml + json) so the script's absolute VENV_PY resolves.
+    venvbin = root / ".venv" / "bin"
+    venvbin.mkdir(parents=True)
+    os.symlink(sys.executable, venvbin / "python")
+
+    gdir = root / ".genesis"
+    gdir.mkdir(exist_ok=True)
+    if with_guardian:
+        (gdir / "guardian_remote.yaml").write_text("host_ip: 192.0.2.9\nhost_user: opuser\n")
+    sshdir = root / ".ssh"
+    sshdir.mkdir(exist_ok=True)
+    if with_key:
+        (sshdir / "genesis_guardian_ed25519").write_text("KEY")
+
+    bind = root / "bin"
+    bind.mkdir(exist_ok=True)
+    respfile = root / "ssh_response.txt"
+    respfile.write_text(ssh_response)
+    ssh = bind / "ssh"
+    ssh.write_text(f"#!/usr/bin/env bash\ncat '{respfile}'\nexit {ssh_rc}\n")
+    ssh.chmod(0o755)
+
+    env = dict(os.environ)
+    env["HOME"] = str(root)
+    env["PATH"] = f"{bind}:/usr/bin:/bin"
+    proc = subprocess.run(
+        ["bash", str(script)], env=env, capture_output=True, text=True, timeout=60
+    )
+    marker = root / ".genesis" / "state" / "cc_tmp_apply.json"
+    data = json.loads(marker.read_text()) if marker.exists() else None
+    return proc, data
+
+
+def _applied_json(result="applied", applied=True, procs=None):
+    return json.dumps(
+        {
+            "ok": True,
+            "action": "cc-tmp-apply",
+            "result": result,
+            "claude_procs": procs,
+            "applied": applied,
+        }
+    )
+
+
+def test_parses_clean():
+    res = subprocess.run(["bash", "-n", str(ALIGN)], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr
+
+
+def test_guardian_less_is_clean_noop(tmp_path):
+    proc, marker = _harness(tmp_path, with_guardian=False)
+    assert proc.returncode == 0
+    assert marker is None  # no host plane → nothing attempted, no marker
+
+
+def test_missing_key_skips(tmp_path):
+    proc, marker = _harness(tmp_path, with_key=False)
+    assert proc.returncode == 0
+    assert marker is None
+
+
+def test_writes_applied_marker(tmp_path):
+    proc, marker = _harness(tmp_path, ssh_response=_applied_json())
+    assert proc.returncode == 0, proc.stderr
+    assert marker["last_reason"] == "applied"
+    assert marker["applied"] is True
+    assert "last_attempt_at" in marker and marker["last_attempt_at"]
+
+
+def test_writes_live_cc_marker_with_count(tmp_path):
+    proc, marker = _harness(
+        tmp_path, ssh_response=_applied_json(result="live-cc", applied=False, procs=6)
+    )
+    assert proc.returncode == 0
+    assert marker["last_reason"] == "live-cc"
+    assert marker["applied"] is False
+    assert marker["claude_procs"] == 6
+
+
+def test_gateway_error_json_marks_gateway_error(tmp_path):
+    resp = json.dumps({"ok": False, "action": "cc-tmp-apply", "error": "lib missing"})
+    proc, marker = _harness(tmp_path, ssh_response=resp)
+    assert proc.returncode == 0
+    assert marker["last_reason"] == "gateway-error"
+    assert marker["applied"] is False
+
+
+def test_old_gateway_denied_is_honest_marker(tmp_path):
+    # A gateway predating the verb answers a non-JSON "denied" line.
+    proc, marker = _harness(tmp_path, ssh_response='{"ok": false, "error": "denied"}\n')
+    assert proc.returncode == 0
+    # 'denied' arrives as a valid ok=false JSON here → gateway-error; a truly
+    # non-JSON line is covered below.
+    assert marker["last_reason"] in ("gateway-error", "unreachable-or-old-gateway")
+
+
+def test_non_json_response_is_unreachable_marker(tmp_path):
+    proc, marker = _harness(tmp_path, ssh_response="not json at all\n")
+    assert proc.returncode == 0
+    assert marker["last_reason"] == "unreachable-or-old-gateway"
+    assert marker["applied"] is False
+
+
+def test_unreachable_empty_response_is_marker(tmp_path):
+    proc, marker = _harness(tmp_path, ssh_response="", ssh_rc=255)
+    assert proc.returncode == 0
+    assert marker["last_reason"] == "unreachable-or-old-gateway"
+
+
+def test_self_guards_present():
+    txt = ALIGN.read_text()
+    assert "flock -n" in txt, "must single-flight"
+    assert "guardian_remote.yaml" in txt, "must no-op without a guardian"
+    assert "cc-tmp-apply" in txt, "must call the gateway verb"

--- a/tests/test_scripts/test_cc_tmp_align_template.py
+++ b/tests/test_scripts/test_cc_tmp_align_template.py
@@ -55,3 +55,12 @@ def test_only_supported_render_placeholders():
     for tmpl in (SVC, TIMER):
         for ph in re.findall(r"__[A-Z_]+__", tmpl.read_text()):
             assert ph in supported, f"unsupported render placeholder {ph} in {tmpl.name}"
+
+
+def test_uninstall_stops_and_disables_the_new_units():
+    # Both container-side uninstall paths (direct + remote) must stop/disable the
+    # new service AND timer, or an uninstall leaves dangling enabled links under
+    # default.target.wants / timers.target.wants (enable != file-glob removal).
+    txt = (REPO_ROOT / "scripts" / "uninstall.sh").read_text()
+    assert txt.count("genesis-cc-tmp-align.timer") >= 2
+    assert txt.count("genesis-cc-tmp-align.service") >= 2

--- a/tests/test_scripts/test_cc_tmp_align_template.py
+++ b/tests/test_scripts/test_cc_tmp_align_template.py
@@ -1,0 +1,57 @@
+"""Structural tests for the genesis-cc-tmp-align systemd units + their enablement.
+
+The cold-start leg is a SERVICE (WantedBy=default.target) ordered before
+genesis-server — the one deterministically CC-quiet window. Because the generic
+render/enable loops only *enable* ``*.timer.template``, this service needs an
+EXPLICIT enable in BOTH install.sh (fresh) and bootstrap.sh (existing installs),
+or it renders but never activates. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SVC = REPO_ROOT / "scripts" / "systemd" / "genesis-cc-tmp-align.service.template"
+TIMER = REPO_ROOT / "scripts" / "systemd" / "genesis-cc-tmp-align.timer.template"
+INSTALL = REPO_ROOT / "scripts" / "install.sh"
+BOOTSTRAP = REPO_ROOT / "scripts" / "bootstrap.sh"
+
+
+def test_service_runs_in_the_quiet_cold_start_window():
+    t = SVC.read_text()
+    assert "Before=genesis-server.service" in t  # quiet window: before ego/bg CC spawn
+    assert "Type=oneshot" in t
+    assert "cc_tmp_align_host.sh" in t
+    assert "WantedBy=default.target" in t  # cold-start leg pulled in at boot
+
+
+def test_service_is_hardened_and_bounded():
+    t = SVC.read_text()
+    assert "NoNewPrivileges=yes" in t
+    assert "ProtectSystem=strict" in t
+    assert "ReadWritePaths=%h" in t
+    assert "TimeoutStartSec=" in t  # bounds boot delay if the host is slow/unreachable
+
+
+def test_timer_is_periodic_and_persistent():
+    t = TIMER.read_text()
+    assert "OnUnitInactiveSec=" in t  # keep retrying on a busy install
+    assert "Persistent=true" in t
+    assert "WantedBy=timers.target" in t
+
+
+def test_service_explicitly_enabled_on_fresh_and_existing_installs():
+    for f in (INSTALL, BOOTSTRAP):
+        assert "enable genesis-cc-tmp-align.service" in f.read_text(), (
+            f"{f.name} must EXPLICITLY enable the cold-start service — the timer "
+            f"loop does not cover a WantedBy=default.target service"
+        )
+
+
+def test_only_supported_render_placeholders():
+    supported = {"__HOME__", "__VENV__", "__REPO_DIR__", "__CC_BIN_DIR__"}
+    for tmpl in (SVC, TIMER):
+        for ph in re.findall(r"__[A-Z_]+__", tmpl.read_text()):
+            assert ph in supported, f"unsupported render placeholder {ph} in {tmpl.name}"

--- a/tests/test_scripts/test_cc_tmp_volume_sh.py
+++ b/tests/test_scripts/test_cc_tmp_volume_sh.py
@@ -74,10 +74,18 @@ case "$1" in
       pgrep)
         # count form (-c / -xc) prints a number like real `pgrep -c`; the plain
         # existence form (-x) just sets exit status. The lib uses -x for the guard
-        # decision and -xc only to report the count when a session is live.
+        # decision (before create AND again before attach) and -xc to report the
+        # count when a session is live.
         for a in "$@"; do case "$a" in -*c*)
-          if [ "${INCUS_CLAUDE_RUNNING:-0}" = "1" ]; then echo "${INCUS_CLAUDE_COUNT:-3}"; exit 0; else echo 0; exit 1; fi ;;
+          if [ "${INCUS_CLAUDE_RUNNING:-0}" = "1" ] || [ -n "${INCUS_CLAUDE_LIVE_FROM_CALL:-}" ]; then echo "${INCUS_CLAUDE_COUNT:-3}"; exit 0; else echo 0; exit 1; fi ;;
         esac; done
+        # existence form. INCUS_CLAUDE_LIVE_FROM_CALL simulates TOCTOU: not live at
+        # the first guard, live by the Nth existence check (count kept in a file).
+        if [ -n "${INCUS_CLAUDE_LIVE_FROM_CALL:-}" ]; then
+          _pn=$(( $(cat "${INCUS_PGREP_CALLS:-/dev/null}" 2>/dev/null || echo 0) + 1 ))
+          echo "$_pn" > "${INCUS_PGREP_CALLS:-/dev/null}" 2>/dev/null || true
+          [ "$_pn" -ge "$INCUS_CLAUDE_LIVE_FROM_CALL" ] && exit 0 || exit 1
+        fi
         [ "${INCUS_CLAUDE_RUNNING:-0}" = "1" ] && exit 0 || exit 1 ;;
       getent) echo "ubuntu:x:1000:1000::/home/ubuntu:/bin/bash"; exit 0 ;;
       id)
@@ -104,6 +112,7 @@ def _sandbox(tmp_path, **incus_env):
     env = {
         "PATH": f"{bindir}:/usr/bin:/bin",
         "INCUS_LOG": str(tmp_path / "incus.log"),
+        "INCUS_PGREP_CALLS": str(tmp_path / "pgrep_calls"),  # TOCTOU sim counter
         "HOME": str(tmp_path),  # so a stray guardian.yaml lookup can't leak
     }
     env.update({k: str(v) for k, v in incus_env.items()})
@@ -386,3 +395,25 @@ def test_result_token_applied_on_happy_path(tmp_path):
 def test_result_token_verify_failed_rolledback(tmp_path):
     rc, res, _ = _result(_sandbox(tmp_path, INCUS_VERIFY_RC=1))
     assert rc == 0 and res == "verify-failed-rolledback"
+
+
+# ── TOCTOU narrowing: re-check for a live session right before the attach ─────
+
+
+def test_live_cc_between_create_and_attach_skips_attach(tmp_path):
+    # Quiet at the first guard (call 1) → past create; a session launches before
+    # the attach (live from call 2). The pre-attach re-check must abort the attach:
+    # the volume was created (kept for reuse) but is NOT attached over the newly
+    # live session's temp tree.
+    env = _sandbox(tmp_path, INCUS_CLAUDE_LIVE_FROM_CALL=2)
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    log = _log(tmp_path)
+    assert "storage volume create" in log  # got past the first guard
+    assert "config device add" not in log  # the re-check aborted the attach
+
+
+def test_result_token_live_cc_at_recheck(tmp_path):
+    rc, res, procs = _result(_sandbox(tmp_path, INCUS_CLAUDE_LIVE_FROM_CALL=2))
+    assert rc == 0 and res == "live-cc"
+    assert procs == "3"  # count reported at the re-check skip

--- a/tests/test_scripts/test_cc_tmp_volume_sh.py
+++ b/tests/test_scripts/test_cc_tmp_volume_sh.py
@@ -417,3 +417,22 @@ def test_result_token_live_cc_at_recheck(tmp_path):
     rc, res, procs = _result(_sandbox(tmp_path, INCUS_CLAUDE_LIVE_FROM_CALL=2))
     assert rc == 0 and res == "live-cc"
     assert procs == "3"  # count reported at the re-check skip
+
+
+# ── container resolution honors the authoritative guardian.yaml default ──────
+
+
+def test_guardian_yaml_default_resolves_container_name(tmp_path):
+    # The lib's CCTMPVOL_GUARDIAN_YAML default must point at the authoritative
+    # path install_guardian.sh writes ($HOME/.local/share/genesis-guardian/config/
+    # guardian.yaml). If it points elsewhere, container_name is never read and the
+    # apply silently targets the "genesis" literal — breaking non-default installs.
+    env = _sandbox(tmp_path)  # HOME=tmp_path; CCTMPVOL_GUARDIAN_YAML unset → default
+    cfgdir = tmp_path / ".local" / "share" / "genesis-guardian" / "config"
+    cfgdir.mkdir(parents=True)
+    (cfgdir / "guardian.yaml").write_text('container_name: "mybox"\n')
+    res = _run(env)
+    assert res.returncode == 0 and "__DONE__" in res.stdout
+    log = _log(tmp_path)
+    assert "info mybox" in log  # incus ops target the configured container
+    assert "genesis-cc-tmp" not in log  # NOT the default-name fallback volume

--- a/tests/test_scripts/test_cc_tmp_volume_sh.py
+++ b/tests/test_scripts/test_cc_tmp_volume_sh.py
@@ -71,7 +71,14 @@ case "$1" in
       [ "$a" = "--" ] && seen=1
     done
     case "$inner" in
-      pgrep) [ "${INCUS_CLAUDE_RUNNING:-0}" = "1" ] && exit 0 || exit 1 ;;
+      pgrep)
+        # count form (-c / -xc) prints a number like real `pgrep -c`; the plain
+        # existence form (-x) just sets exit status. The lib uses -x for the guard
+        # decision and -xc only to report the count when a session is live.
+        for a in "$@"; do case "$a" in -*c*)
+          if [ "${INCUS_CLAUDE_RUNNING:-0}" = "1" ]; then echo "${INCUS_CLAUDE_COUNT:-3}"; exit 0; else echo 0; exit 1; fi ;;
+        esac; done
+        [ "${INCUS_CLAUDE_RUNNING:-0}" = "1" ] && exit 0 || exit 1 ;;
       getent) echo "ubuntu:x:1000:1000::/home/ubuntu:/bin/bash"; exit 0 ;;
       id)
         for a in "$@"; do
@@ -308,3 +315,74 @@ def test_guardian_paths_include_the_lib_everywhere():
     assert "scripts/lib/cc_tmp_volume.sh" in UPDATE_SH.read_text()
     assert "scripts/lib/cc_tmp_volume.sh" in WATCHDOG.read_text()
     assert "scripts/lib/cc_tmp_volume.sh" in DEPLOY_HEALTH.read_text()
+
+
+# ── machine-readable result tokens (consumed by the gateway cc-tmp-apply verb) ──
+
+
+def _result(env, extra_env=None):
+    """Run cc_tmp_volume_apply and return (rc, result_token, claude_procs)."""
+    if extra_env:
+        env = {**env, **extra_env}
+    script = (
+        f'set -euo pipefail; source "{LIB}"; '
+        "cc_tmp_volume_apply >/dev/null 2>&1; "
+        r'printf "RESULT=%s\nPROCS=%s\n" "${_cctmpvol_result:-}" "${_cctmpvol_claude_procs:-}"'
+    )
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=env)
+    res = procs = ""
+    for line in r.stdout.splitlines():
+        if line.startswith("RESULT="):
+            res = line[len("RESULT=") :]
+        elif line.startswith("PROCS="):
+            procs = line[len("PROCS=") :]
+    return r.returncode, res, procs
+
+
+def test_result_token_disabled(tmp_path):
+    rc, res, _ = _result(_sandbox(tmp_path, CCTMPVOL_DISABLE=1))
+    assert rc == 0 and res == "disabled"
+
+
+def test_result_token_no_incus(tmp_path):
+    env = _sandbox(tmp_path)
+    onlybash = tmp_path / "onlybash2"
+    onlybash.mkdir()
+    os.symlink(shutil.which("bash"), onlybash / "bash")
+    env["PATH"] = str(onlybash)
+    rc, res, _ = _result(env)
+    assert rc == 0 and res == "no-incus"
+
+
+def test_result_token_not_running(tmp_path):
+    rc, res, _ = _result(_sandbox(tmp_path, INCUS_INFO_STATUS="Stopped"))
+    assert rc == 0 and res == "not-running"
+
+
+def test_result_token_already_isolated(tmp_path):
+    rc, res, _ = _result(_sandbox(tmp_path, INCUS_DEVICE_ATTACHED=1))
+    assert rc == 0 and res == "already-isolated"
+
+
+def test_result_token_live_cc_reports_reason_and_count(tmp_path):
+    # The whole point of the token: report WHY (blocked on a live session) AND how
+    # many, so the awareness posture can mark the gap "converging" not "broken".
+    rc, res, procs = _result(_sandbox(tmp_path, INCUS_CLAUDE_RUNNING=1, INCUS_CLAUDE_COUNT=5))
+    assert rc == 0 and res == "live-cc"
+    assert procs == "5"
+
+
+def test_result_token_unsupported_pool(tmp_path):
+    rc, res, _ = _result(_sandbox(tmp_path, INCUS_DRIVER="dir"))
+    assert rc == 0 and res == "unsupported-pool"
+
+
+def test_result_token_applied_on_happy_path(tmp_path):
+    rc, res, procs = _result(_sandbox(tmp_path))
+    assert rc == 0 and res == "applied"
+    assert procs == ""  # count only populated on a live-cc skip
+
+
+def test_result_token_verify_failed_rolledback(tmp_path):
+    rc, res, _ = _result(_sandbox(tmp_path, INCUS_VERIFY_RC=1))
+    assert rc == 0 and res == "verify-failed-rolledback"

--- a/tests/test_scripts/test_gateway_cc_tmp_apply.py
+++ b/tests/test_scripts/test_gateway_cc_tmp_apply.py
@@ -1,0 +1,99 @@
+"""Tests for the guardian-gateway.sh ``cc-tmp-apply`` verb.
+
+Runs the REAL gateway against a throwaway ``$HOME`` install dir. The verb sources
+``$INSTALL_DIR/scripts/lib/cc_tmp_volume.sh`` and calls ``cc_tmp_volume_apply``,
+then emits ONE JSON line on stdout carrying the lib's result token (the lib's
+own incus logic is covered by test_cc_tmp_volume_sh.py). Here we pin the verb's
+CONTRACT: lib-missing → clean JSON error; stdout is exactly the JSON line while
+the lib's human progress goes to stderr; result/claude_procs/applied reflect the
+lib's outcome; a non-numeric count serializes as JSON ``null``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+_GATEWAY = Path(__file__).resolve().parents[2] / "scripts" / "guardian-gateway.sh"
+
+
+def _run(home: Path):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["SSH_ORIGINAL_COMMAND"] = "cc-tmp-apply"
+    return subprocess.run(
+        ["bash", str(_GATEWAY)],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _install_stub_lib(home: Path, *, result: str, procs: str, human: str = "progress") -> None:
+    """Drop a stub cc_tmp_volume.sh in the install dir that just sets the result
+    seam vars and prints a human line (which the verb must route to stderr)."""
+    lib = home / ".local" / "share" / "genesis-guardian" / "scripts" / "lib" / "cc_tmp_volume.sh"
+    lib.parent.mkdir(parents=True, exist_ok=True)
+    lib.write_text(
+        "_cctmpvol_result=''\n"
+        "_cctmpvol_claude_procs=''\n"
+        "cc_tmp_volume_apply() {\n"
+        f"    echo '{human}'\n"
+        f"    _cctmpvol_result='{result}'\n"
+        f"    _cctmpvol_claude_procs='{procs}'\n"
+        "}\n"
+    )
+
+
+def test_lib_missing_returns_clean_json_error(tmp_path):
+    (tmp_path / ".local" / "share" / "genesis-guardian").mkdir(parents=True)
+    proc = _run(tmp_path)
+    assert proc.returncode == 1
+    payload = json.loads(proc.stderr.strip().splitlines()[-1])
+    assert payload["ok"] is False
+    assert payload["action"] == "cc-tmp-apply"
+    assert "not found" in payload["error"]
+
+
+def test_emits_single_json_line_human_to_stderr(tmp_path):
+    _install_stub_lib(tmp_path, result="live-cc", procs="4", human="SHOULD_BE_STDERR")
+    proc = _run(tmp_path)
+    assert proc.returncode == 0, proc.stderr
+    # stdout is EXACTLY the JSON line — nothing else.
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1, proc.stdout
+    payload = json.loads(lines[0])
+    assert payload == {
+        "ok": True,
+        "action": "cc-tmp-apply",
+        "result": "live-cc",
+        "claude_procs": 4,
+        "applied": False,
+    }
+    # the lib's human progress must NOT pollute stdout
+    assert "SHOULD_BE_STDERR" not in proc.stdout
+    assert "SHOULD_BE_STDERR" in proc.stderr
+
+
+def test_applied_flag_true_only_on_applied(tmp_path):
+    _install_stub_lib(tmp_path, result="applied", procs="")
+    payload = json.loads(_run(tmp_path).stdout.strip())
+    assert payload["result"] == "applied"
+    assert payload["applied"] is True
+    assert payload["claude_procs"] is None  # empty count → JSON null
+
+
+def test_non_applied_result_is_not_applied(tmp_path):
+    _install_stub_lib(tmp_path, result="unsupported-pool", procs="")
+    payload = json.loads(_run(tmp_path).stdout.strip())
+    assert payload["result"] == "unsupported-pool"
+    assert payload["applied"] is False
+
+
+def test_non_numeric_count_serializes_null(tmp_path):
+    _install_stub_lib(tmp_path, result="no-incus", procs="not-a-number")
+    payload = json.loads(_run(tmp_path).stdout.strip())
+    assert payload["claude_procs"] is None


### PR DESCRIPTION
## What

Makes the cc-tmp dedicated-volume blast-radius isolation **converge on its own**.

Today `cc_tmp_volume_apply` (which moves `~/.genesis/cc-tmp` onto a size-capped
incus volume so a runaway temp write can't fill the container root and kill every
CC session) skips whenever a CC session is live, and only ever runs from the
guardian `redeploy` verb — which on a busy install almost never lands during a
quiet window, so the protection often never activates.

## How

- **New gateway verb `cc-tmp-apply`** — runs the (unchanged) host-side apply and
  emits a JSON result token. The live-CC guard condition is byte-identical.
- **`scripts/cc_tmp_align_host.sh`** — container entrypoint (mirrors
  `cc_align_host.sh`) that SSHes the verb and records the outcome in
  `~/.genesis/state/cc_tmp_apply.json`.
- **Two systemd units** — a oneshot service ordered `Before=genesis-server.service`
  (the deterministically CC-quiet cold-start window) + a periodic retry timer.
  The service is explicitly enabled in `install.sh` **and** `bootstrap.sh` (the
  generic loop only enables timers).
- **Result tokens** at every `cc_tmp_volume.sh` return site (behavior otherwise
  unchanged).
- **Honest posture** — the infra-posture nag now distinguishes
  `cc_tmp_apply_blocked_on_cc` (converging, patient) from `cc_tmp_shared_fs`
  (actionable), so it doesn't nag while simply waiting for a quiet window.

No Leg 3 (active session-quiescing): the guard still unconditionally skips on any
live `claude`; convergence relies on a quiet cold-start / lull, and a deliberate
container restart closes it immediately.

## Deploy

Touches guardian paths → **host redeploy required after merge** (`update.sh`).
Container units + entrypoint deploy via the bootstrap render/enable loops.

## Verification

- 138 targeted tests across `test_cc_tmp_volume_sh`, `test_gateway_cc_tmp_apply`,
  `test_cc_tmp_align_host`, `test_cc_tmp_align_template`,
  `test_infra_protection_posture`, `test_collectors_container`.
- `ruff` + `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
