### PR TITLE
fix(inbox): hold approvals until resolved; orphan-only recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   `notifications` reason-allowlist in `github_steward.yaml`; respects the same
   `off`/`observe`/`live` lever and pings immediately in `live`.
 
+### Fixed
+
+- **Inbox approvals no longer nag.** A pending "inbox evaluation" approval now
+  holds until you respond — it is asked once and blocks until approved, like
+  every other approval, instead of re-sending a fresh request every few hours
+  for content that hasn't changed. A stuck (orphaned) approval that can never be
+  dispatched is still auto-recovered, so the monitor never wedges.
+
 ### Changed
 
 - **Reflection sessions are now strictly read-only.** Genesis's autonomous

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -425,7 +425,7 @@ drop folder, web search/fetch, recon jobs, and the research pipeline.
 ```yaml subsystem-map
 entry: intake-research
 modules: [knowledge, inbox, research, recon, web, pipeline]
-verified: d37d2214 2026-08-06
+verified: 557d3587 2026-08-09
 ```
 
 - **knowledge/**: orchestrator + manifest + tree index. Content-hash gate
@@ -437,8 +437,12 @@ verified: d37d2214 2026-08-06
 - **inbox/**: file-drop monitor with approval-gated dispatch; phase order
   resume → detect → create → dispatch; `approval_key_stable=True` (ONE
   site-level approval key). The refresh path folds parked files into the
-  batch so approvals fire once (#914). Coherence + URL-failure heuristics gate
-  dispatch.
+  batch so approvals fire once (#914). A pending approval is HELD until the
+  user resolves it (no re-ask, no age-based cancel) and is auto-cancelled only
+  when *orphaned* — no live inbox row (`awaiting_approval:`/`dispatching:`)
+  still references it (`count_live_rows_for_approval`); this replaced the old
+  4h staleness cancel that re-detected unchanged files and nagged. Coherence +
+  URL-failure heuristics gate dispatch.
 - **recon/**: scheduled intelligence jobs (release watch, model intelligence
   Sun 8am, models.md synthesis Sun 10am, GitHub discovery, skill-security scan
   via external NVIDIA SkillSpector). Emits findings for triage

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -121,6 +121,37 @@ async def get_awaiting_approval(db: aiosqlite.Connection) -> list[dict]:
     return [dict(row) for row in rows]
 
 
+async def count_live_rows_for_approval(
+    db: aiosqlite.Connection, request_id: str,
+) -> int:
+    """Count inbox rows still actively bound to an approval request.
+
+    A row is 'live' iff it is in ``processing`` state carrying an
+    ``awaiting_approval:<request_id>`` or ``dispatching:<request_id>`` marker —
+    i.e. a batch that is parked on, or mid-dispatch against, exactly this
+    approval. Invalidated (``approval_invalidated:``), failed, and completed
+    rows do NOT count.
+
+    A return of ``0`` means the approval is **orphaned**: no inbox row will
+    ever be dispatched against it (its rows were invalidated or superseded
+    while the approval was left pending). The monitor uses this to cancel an
+    orphaned approval for recovery — replacing the old blunt age-based
+    staleness cancel — WITHOUT dropping a healthy pending approval that a
+    user simply hasn't answered yet.
+    """
+    cursor = await db.execute(
+        """SELECT COUNT(*) FROM inbox_items
+           WHERE status = 'processing'
+             AND error_message IN (?, ?)""",
+        (
+            f"{AWAITING_APPROVAL_PREFIX}{request_id}",
+            f"{DISPATCHING_PREFIX}{request_id}",
+        ),
+    )
+    row = await cursor.fetchone()
+    return int(row[0]) if row else 0
+
+
 async def claim_for_dispatch(
     db: aiosqlite.Connection, id: str, *, reqid: str,
 ) -> bool:

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -35,10 +35,6 @@ logger = logging.getLogger(__name__)
 _PROMPT_DIR = Path(__file__).resolve().parent.parent / "identity"
 _SYSTEM_PROMPT_FILE = "INBOX_EVALUATE.md"
 
-# Max age before a pending inbox approval is considered abandoned.
-# Approvals with timeout_at=None wait indefinitely by design, but the
-# inbox monitor shouldn't block forever if the user never responds.
-_MAX_APPROVAL_STALENESS = timedelta(hours=4)
 
 _FALLBACK_SYSTEM_PROMPT = (
     "You are Genesis performing an inbox evaluation. "
@@ -685,38 +681,39 @@ class InboxMonitor:
                 )
 
         if pending is not None:
-            # Staleness guard: auto-cancel approvals pending longer than
-            # _MAX_APPROVAL_STALENESS.  Without this, an approval with
-            # timeout_at=None blocks the inbox monitor indefinitely when
-            # the user never responds and no new files arrive.
-            created_str = pending.get("created_at", "")
-            created_dt = parse_utc_iso(created_str)
-            if created_str and created_dt is None:
-                logger.warning(
-                    "Staleness guard: unparseable approval created_at %r; "
-                    "skipping age-check this cycle (guard left intact)",
-                    created_str,
+            # Orphan-recovery guard (replaces the old age-based staleness
+            # cancel). A healthy pending approval is HELD indefinitely — the
+            # user blocks-until-approved with no re-ask, exactly like every
+            # other autonomous-CLI approval. But an approval that NO live inbox
+            # row references can never be dispatched (its rows were invalidated
+            # or superseded while it was left pending); holding it would block
+            # the monitor forever (the indefinite-block failure #329 originally
+            # guarded against). So cancel ONLY when it is genuinely orphaned,
+            # never merely because it is old.
+            pending_id = pending.get("id")
+            live_rows = (
+                await inbox_items.count_live_rows_for_approval(
+                    self._db,
+                    str(pending_id),
                 )
-            if created_dt is not None:
-                age = self._clock() - created_dt
-                if age > _MAX_APPROVAL_STALENESS:
-                    pending_id = pending.get("id")
-                    logger.info(
-                        "Cancelling stale inbox approval %s (%.1fh old, threshold %.1fh)",
+                if pending_id
+                else None  # no id → cannot classify → hold (never cancel a None)
+            )
+            if pending_id and live_rows == 0:
+                logger.info(
+                    "Cancelling orphaned inbox approval %s (no live inbox rows reference it)",
+                    pending_id,
+                )
+                try:
+                    gate = self._autonomous_dispatcher.approval_gate
+                    await gate.approval_manager.cancel(pending_id)
+                except Exception:
+                    logger.warning(
+                        "Failed to cancel orphaned approval %s",
                         pending_id,
-                        age.total_seconds() / 3600,
-                        _MAX_APPROVAL_STALENESS.total_seconds() / 3600,
+                        exc_info=True,
                     )
-                    try:
-                        gate = self._autonomous_dispatcher.approval_gate
-                        await gate.approval_manager.cancel(pending_id)
-                    except Exception:
-                        logger.warning(
-                            "Failed to cancel stale approval %s",
-                            pending_id,
-                            exc_info=True,
-                        )
-                    pending = None  # Cleared — proceed normally
+                pending = None  # Recovered — proceed with normal detection
 
         if pending is not None:
             # Approval pending — scan anyway to detect new content.

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -704,16 +704,35 @@ class InboxMonitor:
                     "Cancelling orphaned inbox approval %s (no live inbox rows reference it)",
                     pending_id,
                 )
+                cancelled = False
                 try:
                     gate = self._autonomous_dispatcher.approval_gate
-                    await gate.approval_manager.cancel(pending_id)
+                    cancelled = bool(await gate.approval_manager.cancel(pending_id))
                 except Exception:
                     logger.warning(
                         "Failed to cancel orphaned approval %s",
                         pending_id,
                         exc_info=True,
                     )
-                pending = None  # Recovered — proceed with normal detection
+                if cancelled:
+                    pending = None  # Recovered — proceed with normal detection
+                else:
+                    # cancel() returns False (it does not raise) when the row is
+                    # no longer 'pending' — the user APPROVED it between
+                    # find_site_pending() and cancel() (a TOCTOU), or a transient
+                    # DB failure. Do NOT clear the hold and rush into detection:
+                    # a just-approved, content-agnostic stable-key approval would
+                    # otherwise be reused+consumed by unrelated new content in
+                    # this same cycle. Hold now; the next scan re-reads a fresh
+                    # state (an approved request is no longer returned by
+                    # find_site_pending and is consumed via the normal
+                    # resume/dispatch path).
+                    logger.info(
+                        "Orphaned inbox approval %s was not cancellable (raced to "
+                        "resolved, or transient failure) — holding this cycle",
+                        pending_id,
+                    )
+                    return [], []
 
         if pending is not None:
             # Approval pending — scan anyway to detect new content.

--- a/tests/test_inbox/test_crud.py
+++ b/tests/test_inbox/test_crud.py
@@ -229,3 +229,56 @@ async def test_query_by_batch(db):
     )
     batch1 = await inbox_items.query_by_batch(db, "batch-1")
     assert len(batch1) == 2
+
+
+async def _set_marker(db, item_id: str, marker: str) -> None:
+    await db.execute(
+        "UPDATE inbox_items SET error_message = ? WHERE id = ?",
+        (marker, item_id),
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_count_live_rows_for_approval(db):
+    """Only processing rows carrying awaiting_approval:<id> or
+    dispatching:<id> for the SAME request count as live."""
+    req = "req-abc"
+    # 1) awaiting_approval on the target req -> live
+    await inbox_items.create(
+        db, id="await-hit", file_path="/inbox/a.md",
+        content_hash="h", status="processing", created_at="2026-03-10T00:00:00",
+    )
+    await _set_marker(db, "await-hit", f"{inbox_items.AWAITING_APPROVAL_PREFIX}{req}")
+    # 2) dispatching on the target req -> live
+    await inbox_items.create(
+        db, id="disp-hit", file_path="/inbox/b.md",
+        content_hash="h", status="processing", created_at="2026-03-10T00:00:00",
+    )
+    await _set_marker(db, "disp-hit", f"{inbox_items.DISPATCHING_PREFIX}{req}")
+    # 3) invalidated (failed) on the target req -> NOT live
+    await inbox_items.create(
+        db, id="inval", file_path="/inbox/c.md",
+        content_hash="h", status="failed", created_at="2026-03-10T00:00:00",
+    )
+    await _set_marker(
+        db, "inval",
+        f"{inbox_items.APPROVAL_INVALIDATED_PREFIX}approval terminal:cancelled",
+    )
+    # 4) awaiting on a DIFFERENT req -> NOT counted for `req`
+    await inbox_items.create(
+        db, id="await-other", file_path="/inbox/d.md",
+        content_hash="h", status="processing", created_at="2026-03-10T00:00:00",
+    )
+    await _set_marker(
+        db, "await-other", f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-other",
+    )
+    # 5) completed row (no marker) -> NOT counted
+    await inbox_items.create(
+        db, id="done", file_path="/inbox/e.md",
+        content_hash="h", status="completed", created_at="2026-03-10T00:00:00",
+    )
+
+    assert await inbox_items.count_live_rows_for_approval(db, req) == 2
+    assert await inbox_items.count_live_rows_for_approval(db, "req-other") == 1
+    assert await inbox_items.count_live_rows_for_approval(db, "no-such-req") == 0

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -1446,6 +1446,51 @@ async def test_precheck_cancels_orphaned_approval(
 
 
 @pytest.mark.asyncio
+async def test_orphan_cancel_lost_race_holds_without_routing(
+    monitor, inbox_dir, mock_invoker, db, clock,
+):
+    """TOCTOU guard (Codex P1): if an orphaned approval is APPROVED by the user
+    between find_site_pending() and cancel(), cancel() returns False (the row is
+    no longer pending). The monitor must then HOLD this cycle — it must NOT clear
+    the hold and route new content onto the just-approved, content-agnostic
+    stable-key approval. Hold now; the next scan re-reads a fresh state."""
+    pending_site_row = {
+        "id": "req-race",
+        "status": "pending",
+        "action_type": "autonomous_cli_fallback",
+        "created_at": (clock.now - timedelta(minutes=5)).isoformat(),
+        "_context": {"subsystem": "inbox", "policy_id": "inbox_evaluation"},
+    }
+    decision = AutonomousDispatchDecision(
+        mode="blocked", reason="approval requested", approval_request_id="req-race",
+    )
+    monitor._autonomous_dispatcher = _make_wired_dispatcher(
+        decision=decision, pending_sites=[pending_site_row],
+    )
+    # Simulate the race: by the time cancel() runs, the row is already resolved
+    # (user approved it) -> resolve() matches 0 pending rows -> returns False.
+    monitor._autonomous_dispatcher.approval_gate.approval_manager.cancel = AsyncMock(
+        return_value=False,
+    )
+    # New content arrives — it must NOT be routed onto the raced approval.
+    (inbox_dir / "raced.md").write_text("new content during the race")
+
+    result = await monitor.check_once()
+
+    disp = monitor._autonomous_dispatcher
+    disp.approval_gate.approval_manager.cancel.assert_called_once_with("req-race")
+    disp.route.assert_not_called()
+    assert result.batches_dispatched == 0
+    # The new file was NOT recorded/dispatched this cycle (the monitor held).
+    row = await (
+        await db.execute(
+            "SELECT COUNT(*) FROM inbox_items WHERE file_path LIKE '%raced.md'",
+        )
+    ).fetchone()
+    assert row[0] == 0
+
+
+@pytest.mark.asyncio
 async def test_precheck_holds_approval_with_live_rows(
     monitor, inbox_dir, mock_invoker, db, clock,
 ):

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -1326,12 +1326,50 @@ def _make_wired_dispatcher(
     return dispatcher
 
 
+async def _seed_parked_row(
+    db,
+    inbox_dir,
+    *,
+    request_id: str,
+    filename: str = "parked.md",
+    content: str = "parked content",
+):
+    """Create a real inbox file + a LIVE awaiting_approval row referencing
+    ``request_id``, so the monitor's orphan-guard sees the approval as still
+    bound to live work (and the resume pass leaves the row parked).
+
+    Returns ``(path, content_hash)``.
+    """
+    from genesis.db.crud import inbox_items
+    from genesis.inbox.scanner import compute_hash
+
+    f = inbox_dir / filename
+    f.write_text(content)
+    h = compute_hash(f)
+    row_id = f"row-{request_id}"
+    await inbox_items.create(
+        db,
+        id=row_id,
+        file_path=str(f),
+        content_hash=h,
+        status="processing",
+        created_at="2026-03-10T11:00:00+00:00",
+    )
+    await db.execute(
+        "UPDATE inbox_items SET error_message = ? WHERE id = ?",
+        (f"{inbox_items.AWAITING_APPROVAL_PREFIX}{request_id}", row_id),
+    )
+    await db.commit()
+    return f, h
+
+
 @pytest.mark.asyncio
 async def test_precheck_skips_detection_when_site_blocked_no_new_files(
     monitor, inbox_dir, mock_invoker, db,
 ):
-    """When an inbox_evaluation approval is already pending and no new
-    files were added, detection still short-circuits — no dispatch."""
+    """When an inbox_evaluation approval is already pending (with a live
+    parked row) and no new files were added, detection short-circuits —
+    the approval HOLDS, no dispatch and no cancel."""
     pending_site_row = {
         "id": "req-already-pending",
         "status": "pending",
@@ -1348,70 +1386,36 @@ async def test_precheck_skips_detection_when_site_blocked_no_new_files(
     monitor._autonomous_dispatcher = _make_wired_dispatcher(
         decision=decision,
         pending_sites=[pending_site_row],
+        approval_by_id={"req-already-pending": {
+            "id": "req-already-pending", "status": "pending",
+        }},
     )
+    # A live parked row keeps the approval bound to real work (not orphaned).
+    await _seed_parked_row(db, inbox_dir, request_id="req-already-pending")
 
-    # No new files — just run check
+    # No NEW files — just run check
     result = await monitor.check_once()
 
-    # No dispatch happened
+    # No dispatch happened, and the held approval was NOT cancelled.
     monitor._autonomous_dispatcher.route.assert_not_called()
+    monitor._autonomous_dispatcher.approval_gate.approval_manager.cancel.assert_not_called()
     assert result.batches_dispatched == 0
     mock_invoker.run.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_precheck_cancels_stale_approval_and_proceeds(
+async def test_precheck_cancels_orphaned_approval(
     monitor, inbox_dir, mock_invoker, db, clock,
 ):
-    """When a pending inbox approval exceeds _MAX_APPROVAL_STALENESS,
-    the monitor auto-cancels it and proceeds with normal detection
-    instead of blocking indefinitely."""
-    from genesis.inbox.monitor import _MAX_APPROVAL_STALENESS
-
-    # Create an approval that's older than the staleness threshold
-    stale_created = (clock.now - _MAX_APPROVAL_STALENESS - timedelta(hours=1)).isoformat()
+    """A pending inbox approval that NO live inbox row references is
+    orphaned — it can never be dispatched, so the monitor cancels it for
+    recovery and proceeds with normal detection. This holds regardless of
+    the approval's age (no age threshold)."""
+    # A *young* approval, deliberately, to prove the trigger is orphaning and
+    # NOT age. No _seed_parked_row call => zero live rows => orphaned.
+    fresh_created = (clock.now - timedelta(minutes=5)).isoformat()
     pending_site_row = {
-        "id": "req-stale",
-        "status": "pending",
-        "action_type": "autonomous_cli_fallback",
-        "created_at": stale_created,
-        "_context": {
-            "subsystem": "inbox",
-            "policy_id": "inbox_evaluation",
-        },
-    }
-    decision = AutonomousDispatchDecision(
-        mode="allowed", reason="auto-approved",
-    )
-    monitor._autonomous_dispatcher = _make_wired_dispatcher(
-        decision=decision,
-        pending_sites=[pending_site_row],
-    )
-
-    # Drop a file — should be detected because the stale approval is cancelled
-    (inbox_dir / "notes.md").write_text("content after stale approval")
-    result = await monitor.check_once()
-
-    # The stale approval was cancelled and dispatch proceeded
-    monitor._autonomous_dispatcher.approval_gate.approval_manager.cancel.assert_called_once_with(
-        "req-stale",
-    )
-    assert result.items_new == 1
-    assert result.batches_dispatched == 1
-
-
-@pytest.mark.asyncio
-async def test_precheck_does_not_cancel_fresh_approval(
-    monitor, inbox_dir, mock_invoker, db, clock,
-):
-    """A pending approval younger than _MAX_APPROVAL_STALENESS is NOT
-    cancelled — the monitor correctly blocks."""
-    from genesis.inbox.monitor import _MAX_APPROVAL_STALENESS
-
-    # Create an approval that's younger than the staleness threshold
-    fresh_created = (clock.now - _MAX_APPROVAL_STALENESS + timedelta(hours=1)).isoformat()
-    pending_site_row = {
-        "id": "req-fresh",
+        "id": "req-orphan",
         "status": "pending",
         "action_type": "autonomous_cli_fallback",
         "created_at": fresh_created,
@@ -1422,18 +1426,105 @@ async def test_precheck_does_not_cancel_fresh_approval(
     }
     decision = AutonomousDispatchDecision(
         mode="blocked", reason="approval requested",
-        approval_request_id="req-fresh",
+        approval_request_id="req-orphan",
     )
     monitor._autonomous_dispatcher = _make_wired_dispatcher(
         decision=decision,
         pending_sites=[pending_site_row],
     )
 
-    # No new files — should block normally
+    # NO new file: the ONLY reason a cancel can happen is the orphan-guard
+    # (a young approval is not stale, and with no new content the legacy
+    # refresh path never fires) — so this cleanly isolates orphan recovery.
     result = await monitor.check_once()
 
+    # The orphaned approval was cancelled for recovery.
+    monitor._autonomous_dispatcher.approval_gate.approval_manager.cancel.assert_called_once_with(
+        "req-orphan",
+    )
+    assert result.batches_dispatched == 0
+
+
+@pytest.mark.asyncio
+async def test_precheck_holds_approval_with_live_rows(
+    monitor, inbox_dir, mock_invoker, db, clock,
+):
+    """A pending approval that a live inbox row still references is HELD —
+    never cancelled — no matter how old it is. This is 'block until
+    approved, no re-ask' for healthy approvals."""
+    # Make the approval ancient to prove age does NOT trigger a cancel.
+    ancient_created = (clock.now - timedelta(days=30)).isoformat()
+    pending_site_row = {
+        "id": "req-held",
+        "status": "pending",
+        "action_type": "autonomous_cli_fallback",
+        "created_at": ancient_created,
+        "_context": {
+            "subsystem": "inbox",
+            "policy_id": "inbox_evaluation",
+        },
+    }
+    decision = AutonomousDispatchDecision(
+        mode="blocked", reason="approval requested",
+        approval_request_id="req-held",
+    )
+    monitor._autonomous_dispatcher = _make_wired_dispatcher(
+        decision=decision,
+        pending_sites=[pending_site_row],
+        approval_by_id={"req-held": {"id": "req-held", "status": "pending"}},
+    )
+    # A live parked row referencing the approval => not orphaned => hold.
+    await _seed_parked_row(db, inbox_dir, request_id="req-held")
+
+    # No new files — should hold, not cancel, not dispatch
+    result = await monitor.check_once()
+
+    monitor._autonomous_dispatcher.approval_gate.approval_manager.cancel.assert_not_called()
+    monitor._autonomous_dispatcher.route.assert_not_called()
     assert result.batches_dispatched == 0
     mock_invoker.run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pending_inbox_approval_blocks_without_reask(
+    monitor, inbox_dir, mock_invoker, db, clock,
+):
+    """The user's guarantee: a held inbox approval is re-asked ZERO times.
+    Across many scans, with the clock advanced well past any historical
+    re-ask window, the monitor never cancels and never re-routes (which
+    would mint a fresh approval), and the parked row stays live."""
+    pending_site_row = {
+        "id": "req-quiet",
+        "status": "pending",
+        "action_type": "autonomous_cli_fallback",
+        "created_at": (clock.now - timedelta(hours=1)).isoformat(),
+        "_context": {
+            "subsystem": "inbox",
+            "policy_id": "inbox_evaluation",
+        },
+    }
+    decision = AutonomousDispatchDecision(
+        mode="blocked", reason="approval requested",
+        approval_request_id="req-quiet",
+    )
+    monitor._autonomous_dispatcher = _make_wired_dispatcher(
+        decision=decision,
+        pending_sites=[pending_site_row],
+        approval_by_id={"req-quiet": {"id": "req-quiet", "status": "pending"}},
+    )
+    _, _ = await _seed_parked_row(db, inbox_dir, request_id="req-quiet")
+
+    for _ in range(4):
+        clock.now = clock.now + timedelta(hours=12)  # sail past 24h re-ask window
+        await monitor.check_once()
+
+    disp = monitor._autonomous_dispatcher
+    disp.approval_gate.approval_manager.cancel.assert_not_called()
+    disp.route.assert_not_called()
+    from genesis.db.crud import inbox_items
+    row = await inbox_items.get_by_id(db, "row-req-quiet")
+    assert row["status"] == "processing"
+    assert row["error_message"] == f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-quiet"
 
 
 @pytest.mark.asyncio
@@ -1441,8 +1532,15 @@ async def test_precheck_refreshes_when_new_files_added_while_blocked(
     monitor, inbox_dir, mock_invoker, db,
 ):
     """When an inbox_evaluation approval is pending but new files arrive,
-    the stale approval is cancelled and files are detected so a fresh
-    approval reflecting the current inbox state can be created."""
+    the approval is cancelled and files are detected so a fresh approval
+    reflecting the current inbox state can be created.
+
+    Note: this case seeds no live parked row, so under the orphan-guard the
+    approval is cancelled via the orphan path before the refresh path; the
+    end state (file detected, one route()) is equivalent. The genuine
+    refresh-with-live-rows / fold path is pinned separately by
+    ``test_refresh_path_with_live_rows_folds_unchanged_sibling``.
+    """
     pending_site_row = {
         "id": "req-already-pending",
         "status": "pending",
@@ -1477,6 +1575,66 @@ async def test_precheck_refreshes_when_new_files_added_while_blocked(
     )
     # Dispatch was attempted (creating a fresh approval)
     monitor._autonomous_dispatcher.route.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_path_with_live_rows_folds_unchanged_sibling(
+    monitor, inbox_dir, mock_invoker, db,
+):
+    """The genuine refresh path (driver B): when an approval with LIVE parked
+    rows is pending and genuinely-new content arrives, the orphan-guard HOLDS
+    (live rows exist) and falls through to the refresh path — which cancels the
+    held approval, folds the unchanged parked sibling into the batch, and
+    re-parks BOTH files under the fresh approval. This proves the orphan-guard
+    does not short-circuit the fold, and that an unchanged sibling is not
+    stranded (the leapfrog the nag was made of)."""
+    pending_site_row = {
+        "id": "req-a",
+        "status": "pending",
+        "action_type": "autonomous_cli_fallback",
+        "_context": {"subsystem": "inbox", "policy_id": "inbox_evaluation"},
+    }
+    # A fresh approval id is minted after the refresh-cancel.
+    decision = AutonomousDispatchDecision(
+        mode="blocked", reason="approval requested", approval_request_id="req-b",
+    )
+    monitor._autonomous_dispatcher = _make_wired_dispatcher(
+        decision=decision,
+        pending_sites=[pending_site_row],
+        approval_by_id={"req-a": {"id": "req-a", "status": "pending"}},
+    )
+    # Live parked row for the UNCHANGED sibling, bound to req-a.
+    await _seed_parked_row(db, inbox_dir, request_id="req-a", filename="held.md")
+
+    # Genuinely-new content arrives while the approval is pending.
+    (inbox_dir / "arrived.md").write_text("brand new content")
+    await monitor.check_once()
+
+    disp = monitor._autonomous_dispatcher
+    # The held approval was cancelled by the REFRESH path (not left uncancelled),
+    # exactly once, for req-a.
+    disp.approval_gate.approval_manager.cancel.assert_called_once_with("req-a")
+
+    # Both the new file AND the folded unchanged sibling are re-parked under the
+    # fresh approval (req-b) — nothing stranded.
+    from genesis.db.crud import inbox_items
+
+    rows = [
+        dict(r)
+        for r in await (
+            await db.execute(
+                "SELECT file_path, status, error_message FROM inbox_items "
+                "WHERE status='processing' AND error_message = ?",
+                (f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-b",),
+            )
+        ).fetchall()
+    ]
+    reparked = {Path(r["file_path"]).name for r in rows}
+    assert reparked == {"held.md", "arrived.md"}, reparked
+
+    # The original parked row for the sibling was superseded (failed), not left live.
+    old = await inbox_items.get_by_id(db, "row-req-a")
+    assert old["status"] == "failed"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The inbox monitor re-sent a fresh approval request every few hours for **unchanged** content instead of asking once and holding on the most recent unapproved request. Observed live: repeated `parked awaiting approval` / `cancelling stale inbox approval` cycles for an inbox file whose content had not changed.

## Root cause

`_phase_detect_changes` auto-cancelled any pending inbox approval older than `_MAX_APPROVAL_STALENESS` (4h). The next scan's resume pass saw the approval `cancelled` and flipped its parked `inbox_items` rows to `status='failed'`. Retriable-`failed` rows are excluded from the `get_all_known` hash baseline, so the baseline fell back to the older completed hash — the unchanged file then re-read as "modified", re-queued, and re-parked under a **brand-new** approval. That loop is the nag.

The 4h guard was originally added (#329) because a pending approval with `timeout_at=None` could block the monitor indefinitely. Since then the approval-resolution paths (buttons, bare-text) were fixed, so approvals are resolvable — but the blunt age-cancel turned every healthy hold into churn.

## Fix

Replace the age-based cancel with an **orphan-only recovery guard**:

- New read-only CRUD `inbox_items.count_live_rows_for_approval(db, request_id)` — counts `processing` rows whose marker is exactly `awaiting_approval:<id>` or `dispatching:<id>`.
- In `_phase_detect_changes`, a pending approval is now **held indefinitely** until the user resolves it (block-until-approved, no re-ask), and is auto-cancelled **only when orphaned** — no live inbox row references it (its rows were invalidated/superseded while it was left pending). This keeps the #329 indefinite-block recovery without the nag.
- The genuine-new-content refresh/fold path (#914) is unchanged and still fires on real changes.

Does **not** weaken the mandatory approval gate — a lifecycle fix *around* the gate.

## Testing

- New: orphan-cancel (young approval, no live rows → cancel), hold-with-live-rows (ancient approval, live row → never cancel), no-reask-across-scans (4 cycles / 48h → zero cancels/re-routes), refresh-with-live-rows fold (unchanged sibling folded + re-parked, not stranded), plus a CRUD unit test. New monitor tests were verified RED against the old age-based code before implementing.
- Full `tests/test_inbox/` suite: 344 passed (incl. the stateful drop-dispatch/oscillator regressions).

## Deploy path

Runtime code only — `git pull` + server restart. No schema/migration, no config, no new store, no host paths. Empty-state safe (fresh install: no rows → no orphan cancel fires).

## Review

Inline code review (Claude, `feature-dev:code-reviewer`): DONE, no BLOCKER/SHOULD-FIX. Traced that a healthy pending approval cannot be misclassified as orphaned (invalidation is atomic per-drop within the same resume pass that precedes detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)