### PR TITLE
feat(onboarding): readiness enrichment fields on setup-status (PR-B2a)

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1133,7 +1133,14 @@ verified: b662f3e3 2026-07-17
   bool (no runtime import on the hot path); web-search/autonomy-posture/surplus are
   enrichment, never tier gates (autonomy has no on/off switch — it's always
   initialised and gated per-action by the mandatory approval gate). `setup-status`
-  emits `tier`/`tier_name`/`telegram_configured`/`ego_enabled` additively.
+  emits `tier`/`tier_name`/`telegram_configured`/`ego_enabled` additively, plus
+  non-gating **enrichment** from `readiness.compute_enrichment` +
+  `autonomy.config_read.read_autonomy_default_level` (fail-safe, presence-based):
+  `web_search_keyed_providers` (premium providers augmenting the keyless SearXNG
+  baseline), `voice_configured` (explicit `VOICE_S2S_PROVIDER` opt-in — a bare
+  OpenAI LLM key does NOT count), `ego_cadence_minutes`, and `autonomy_level`
+  (shipped config default, not the live earned level). The persistent panel that
+  renders the tier + these chips is PR-B2b (frontend, not yet built).
 - **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
   without it interleaved commits pin `in_transaction` until restart). Two
   schema paths coexist: base DDL (`schema/_tables.py`, ~113 CREATE TABLE; docs

--- a/src/genesis/autonomy/config_read.py
+++ b/src/genesis/autonomy/config_read.py
@@ -39,11 +39,11 @@ def read_autonomy_default_level(
     """The shipped *default* autonomy level for ``category`` (fail-safe → 1).
 
     Reads ``config/autonomy.yaml``'s ``defaults`` block with ``yaml.safe_load`` and
-    returns ``int(defaults[category])``. Returns ``1`` on ANY failure — missing file,
-    unreadable/non-UTF-8 file, malformed YAML, absent ``defaults``/``category`` key, or
-    a non-int value — mirroring ``AutonomyStateMachine._load_config``'s graceful
-    fallback, so a surface that reads this (the readiness enrichment) can never be
-    500'd or misled by a bad config.
+    returns ``int(defaults[category])`` floored at ``1``. Returns ``1`` on ANY failure —
+    missing file, unreadable/non-UTF-8 file, malformed YAML, absent ``defaults``/
+    ``category`` key, a non-int value, or a sub-``1`` (0/negative) value — mirroring
+    ``AutonomyStateMachine._load_config``'s graceful fallback, so a surface that reads
+    this (the readiness enrichment) can never be 500'd or misled by a bad config.
 
     ``category`` defaults to ``direct_session`` — the autonomy category governing
     autonomous CC sessions, the posture most relevant to the "Autonomous" readiness
@@ -58,7 +58,12 @@ def read_autonomy_default_level(
         defaults = data.get("defaults") if isinstance(data, dict) else None
         if not isinstance(defaults, dict):
             return _DEFAULT_LEVEL
-        return int(defaults[category])
+        # Floor at L1: a value < 1 (a 0/negative typo) is a nonsensical autonomy level, so
+        # clamp up to the conservative default. NOT capped above: levels are per-category
+        # (autonomy.yaml `ceilings` run to 7 for direct_session), so a legitimately-high
+        # default must pass through — the category ceiling is enforced by the state
+        # machine, not this generic display read.
+        return max(_DEFAULT_LEVEL, int(defaults[category]))
     except (
         OSError,
         ValueError,

--- a/src/genesis/autonomy/config_read.py
+++ b/src/genesis/autonomy/config_read.py
@@ -59,7 +59,17 @@ def read_autonomy_default_level(
         if not isinstance(defaults, dict):
             return _DEFAULT_LEVEL
         return int(defaults[category])
-    except (OSError, ValueError, TypeError, KeyError, AttributeError, yaml.YAMLError):
+    except (
+        OSError,
+        ValueError,
+        TypeError,
+        KeyError,
+        AttributeError,
+        OverflowError,
+        yaml.YAMLError,
+    ):
+        # OverflowError: `int(float('inf'))` from a YAML `.inf` level. KeyError: absent
+        # category. AttributeError: non-dict slipping past the guard. All → conservative L1.
         logger.debug(
             "autonomy default-level read failed for %s (%s); using L%d",
             category,

--- a/src/genesis/autonomy/config_read.py
+++ b/src/genesis/autonomy/config_read.py
@@ -1,0 +1,70 @@
+"""Cheap, fail-safe reads of the autonomy *config* — the shipped default posture only.
+
+The authoritative, per-install autonomy state lives in the ``autonomy_states`` DB
+table and is served by :class:`genesis.autonomy.state_machine.AutonomyStateMachine`,
+whose ``_load_config`` is coupled to an ``aiosqlite`` connection. Surfaces that only
+need "what default level does this install ship / start at" — e.g. the dashboard
+``setup-status`` readiness enrichment — cannot afford a DB hit or an async context on
+the request path, so this module offers a pure, synchronous, never-raising read of
+``config/autonomy.yaml``'s ``defaults`` block.
+
+This is the CONFIG default, NOT the live earned level. Do not use it where the actual
+current per-install level matters (that requires the state machine + DB).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+# The shipped autonomy config. Module-level so tests can point the reader at a temp
+# file via the ``path`` arg without touching the YAML parsing itself.
+_AUTONOMY_CONFIG_PATH = repo_root() / "config" / "autonomy.yaml"
+
+# Conservative fallback for ANY read failure: L1 is the shipped default for every
+# category ("conservative start"), so a bad/missing config degrades to that floor
+# rather than inventing a higher, more-permissive level.
+_DEFAULT_LEVEL = 1
+
+
+def read_autonomy_default_level(
+    category: str = "direct_session", *, path: Path | None = None
+) -> int:
+    """The shipped *default* autonomy level for ``category`` (fail-safe → 1).
+
+    Reads ``config/autonomy.yaml``'s ``defaults`` block with ``yaml.safe_load`` and
+    returns ``int(defaults[category])``. Returns ``1`` on ANY failure — missing file,
+    unreadable/non-UTF-8 file, malformed YAML, absent ``defaults``/``category`` key, or
+    a non-int value — mirroring ``AutonomyStateMachine._load_config``'s graceful
+    fallback, so a surface that reads this (the readiness enrichment) can never be
+    500'd or misled by a bad config.
+
+    ``category`` defaults to ``direct_session`` — the autonomy category governing
+    autonomous CC sessions, the posture most relevant to the "Autonomous" readiness
+    tier. This is the CONFIG default, not the live earned level (per-install DB state).
+    """
+    cfg_path = path if path is not None else _AUTONOMY_CONFIG_PATH
+    try:
+        data = yaml.safe_load(cfg_path.read_text())
+        # A top-level scalar/list (e.g. a truncated or hand-mangled file) parses to a
+        # non-dict; guard so `.get` can't AttributeError and break the never-raise
+        # contract. Same for a non-mapping `defaults:` value.
+        defaults = data.get("defaults") if isinstance(data, dict) else None
+        if not isinstance(defaults, dict):
+            return _DEFAULT_LEVEL
+        return int(defaults[category])
+    except (OSError, ValueError, TypeError, KeyError, AttributeError, yaml.YAMLError):
+        logger.debug(
+            "autonomy default-level read failed for %s (%s); using L%d",
+            category,
+            cfg_path,
+            _DEFAULT_LEVEL,
+            exc_info=True,
+        )
+        return _DEFAULT_LEVEL

--- a/src/genesis/autonomy/config_read.py
+++ b/src/genesis/autonomy/config_read.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import yaml
 
+from genesis.autonomy.types import AutonomyLevel
 from genesis.env import repo_root
 
 logger = logging.getLogger(__name__)
@@ -39,11 +40,13 @@ def read_autonomy_default_level(
     """The shipped *default* autonomy level for ``category`` (fail-safe → 1).
 
     Reads ``config/autonomy.yaml``'s ``defaults`` block with ``yaml.safe_load`` and
-    returns ``int(defaults[category])`` floored at ``1``. Returns ``1`` on ANY failure —
-    missing file, unreadable/non-UTF-8 file, malformed YAML, absent ``defaults``/
-    ``category`` key, a non-int value, or a sub-``1`` (0/negative) value — mirroring
-    ``AutonomyStateMachine._load_config``'s graceful fallback, so a surface that reads
-    this (the readiness enrichment) can never be 500'd or misled by a bad config.
+    returns the level validated against the constructible :class:`AutonomyLevel` enum.
+    Returns ``1`` on ANY failure — missing file, unreadable/non-UTF-8 file, malformed
+    YAML, absent ``defaults``/``category`` key, a non-int value, or a value outside the
+    constructible level range (0/negative, or 5–7 which are not yet enum members) —
+    mirroring ``AutonomyStateMachine._load_config``'s graceful fallback, so a surface
+    that reads this (the readiness enrichment) can never be 500'd or advertise a level
+    the runtime couldn't actually construct.
 
     ``category`` defaults to ``direct_session`` — the autonomy category governing
     autonomous CC sessions, the posture most relevant to the "Autonomous" readiness
@@ -58,12 +61,14 @@ def read_autonomy_default_level(
         defaults = data.get("defaults") if isinstance(data, dict) else None
         if not isinstance(defaults, dict):
             return _DEFAULT_LEVEL
-        # Floor at L1: a value < 1 (a 0/negative typo) is a nonsensical autonomy level, so
-        # clamp up to the conservative default. NOT capped above: levels are per-category
-        # (autonomy.yaml `ceilings` run to 7 for direct_session), so a legitimately-high
-        # default must pass through — the category ceiling is enforced by the state
-        # machine, not this generic display read.
-        return max(_DEFAULT_LEVEL, int(defaults[category]))
+        # Validate against the CONSTRUCTIBLE AutonomyLevel enum (currently L1–L4; the
+        # yaml `ceilings` cap ACTIONS, not the level enum — L5–L7 are deferred to V5 and
+        # AutonomyStateMachine.load_or_create_defaults does `AutonomyLevel(level)`, which
+        # ValueErrors on an out-of-range default). `AutonomyLevel(int(...))` raises for
+        # any non-constructible value (0, negatives, 5–7), which the except below maps to
+        # the L1 fail-safe — so this display read can only ever advertise a real level,
+        # and auto-tracks the enum if V5 widens it.
+        return int(AutonomyLevel(int(defaults[category])))
     except (
         OSError,
         ValueError,

--- a/src/genesis/dashboard/routes/setup.py
+++ b/src/genesis/dashboard/routes/setup.py
@@ -22,7 +22,7 @@ from flask import jsonify, request
 
 from genesis.dashboard._blueprint import _async_route, blueprint
 from genesis.onboarding.floor import UNSET_SENTINELS, read_persisted_secrets
-from genesis.onboarding.readiness import compute_readiness
+from genesis.onboarding.readiness import compute_enrichment, compute_readiness
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,13 @@ def setup_status():
     Also emits the cumulative readiness tier ABOVE the floor
     (``genesis.onboarding.readiness``): ``tier`` (0..3) + ``tier_name`` plus the
     two gates the floor does not cover — ``telegram_configured`` (T2, proactive
-    reach) and ``ego_enabled`` (T3). All additive; existing fields unchanged.
+    reach) and ``ego_enabled`` (T3).
+
+    Finally emits NON-gating enrichment (never affects the floor or the tier):
+    ``web_search_keyed_providers`` (premium providers augmenting the keyless SearXNG
+    baseline), ``voice_configured`` (deliberate S2S opt-in), ``ego_cadence_minutes``
+    (think cadence), and ``autonomy_level`` (shipped autonomy default). All additive;
+    existing fields unchanged.
     """
     # Read secrets.env once; reuse for the floor legs and the password check.
     secrets = read_persisted_secrets()
@@ -73,10 +79,29 @@ def setup_status():
     try:
         from genesis.ego.config import load_ego_config
 
-        ego_enabled = bool(load_ego_config().enabled)
+        _ego_cfg = load_ego_config()
+        ego_enabled = bool(_ego_cfg.enabled)
     except Exception:  # noqa: BLE001 - setup-status must never raise into first-run
         logger.warning("setup-status: ego config unreadable; ego_enabled=False", exc_info=True)
         ego_enabled = False
+        _ego_cfg = None
+
+    # Enrichment: the ego think-cadence (base tick minutes). Read AFTER the ego gate and
+    # kept off its critical path — a bad/absent value must never disturb ego_enabled or
+    # the tier (getattr default when the config is missing/predates the field; a
+    # non-numeric value is coerced safely inside compute_enrichment).
+    ego_cadence_minutes = getattr(_ego_cfg, "cadence_minutes", 60)
+
+    # Enrichment: the shipped autonomy default level (config posture, NOT the live
+    # earned per-install level, which is DB state). The reader is itself fail-safe to L1;
+    # the wrap guards the (unlikely) import failure so first-run can never 500.
+    try:
+        from genesis.autonomy.config_read import read_autonomy_default_level
+
+        autonomy_level = read_autonomy_default_level()
+    except Exception:  # noqa: BLE001 - setup-status must never raise into first-run
+        logger.warning("setup-status: autonomy level unreadable; defaulting to L1", exc_info=True)
+        autonomy_level = 1
 
     # The setup-complete marker gates T3 (the ego cadence won't run without it), so it
     # is read ONCE here and threaded into readiness AND the payload — one snapshot, so
@@ -100,6 +125,15 @@ def setup_status():
         "identity_set": identity_set,
     }
     payload.update(readiness.as_dict())
+
+    # Non-gating enrichment (web-search premium providers, deliberate voice, ego cadence,
+    # autonomy default level). Additive; never affects the floor or the tier.
+    enrichment = compute_enrichment(
+        secrets=secrets,
+        ego_cadence_minutes=ego_cadence_minutes,
+        autonomy_level=autonomy_level,
+    )
+    payload.update(enrichment.as_dict())
     return jsonify(payload)
 
 

--- a/src/genesis/onboarding/readiness.py
+++ b/src/genesis/onboarding/readiness.py
@@ -241,9 +241,15 @@ def _voice_configured(secrets: Mapping[str, str]) -> bool:
     Requires an explicit ``VOICE_S2S_PROVIDER`` (``openai``/``gemini``) in ``secrets``
     AND that provider's API key present — NOT ``channels.voice.config.s2s_enabled``,
     whose "openai" default would report voice for any box that merely has an
-    ``OPENAI_API_KEY``. Pure dict read; never raises.
+    ``OPENAI_API_KEY``.
+
+    The provider value is matched **exactly, without stripping**, to mirror the runtime:
+    ``s2s_provider()`` reads the raw env value and ``s2s_enabled()`` compares it with a
+    bare ``== "openai"``/``"gemini"`` — so a hand-quoted ``" openai "`` (dotenv keeps the
+    inner spaces) would NOT enable voice at runtime, and must not read as configured here
+    either (the same parser-parity trap as the PR-B1 Telegram gate). Pure; never raises.
     """
-    provider = str(secrets.get("VOICE_S2S_PROVIDER", "")).strip()
+    provider = str(secrets.get("VOICE_S2S_PROVIDER", ""))
     key_name = _VOICE_PROVIDER_KEYS.get(provider)
     if key_name is None:
         return False

--- a/src/genesis/onboarding/readiness.py
+++ b/src/genesis/onboarding/readiness.py
@@ -32,6 +32,13 @@ floor's live-recompute philosophy). Everything else that makes an install *good*
 rather than *minimal* — web-search availability, autonomy posture, surplus, voice,
 the dashboard password — is enrichment surfaced by the panel, never a tier gate.
 
+:class:`EnrichmentStatus` / :func:`compute_enrichment` carry those non-gating signals
+alongside the tier: which premium web-search providers are keyed, whether S2S voice is
+deliberately configured, the ego think-cadence, and the shipped autonomy default level.
+Like the tier, they are presence-based and pure over persisted state plus two injected
+config ints (``ego_cadence_minutes``, ``autonomy_level``), so the module stays free of
+runtime/ego/autonomy imports on the ``setup-status`` hot path.
+
 Like the floor, readiness is **presence-based and pure over persisted state plus two
 injected bools** (``ego_enabled`` from the ego config and ``onboarded`` from the marker,
 both resolved by the route so this module needs no runtime/ego import) — safe on the
@@ -55,9 +62,27 @@ from dataclasses import dataclass
 
 from genesis.channels.bridge_config import build_bridge_config, parse_secrets_env_text
 from genesis.env import secrets_path
-from genesis.onboarding.floor import FloorStatus, compute_floor, read_persisted_secrets
+from genesis.onboarding.floor import (
+    UNSET_SENTINELS,
+    FloorStatus,
+    compute_floor,
+    provider_key_present,
+    read_persisted_secrets,
+)
 
 _TIER_NAMES = {0: "Bootstrapped", 1: "Functional", 2: "Connected", 3: "Autonomous"}
+
+# Premium (keyed) web-search providers, kept pre-sorted so the enrichment field has a
+# stable order without re-sorting per request. Web search is available regardless of
+# these — the keyless SearXNG primary is the bootstrap default — so this is pure
+# enrichment: "which PAID providers augment the keyless baseline", never a tier gate.
+_WEB_SEARCH_PREMIUM_PROVIDERS = ("brave", "exa", "tavily", "tinyfish")
+
+# Voice S2S provider -> the secrets key that enables it. Mirrors
+# ``channels.voice.config.s2s_enabled`` BUT requires an explicit provider: that module
+# defaults ``VOICE_S2S_PROVIDER`` to "openai", which would count any OpenAI LLM key as
+# "voice configured" — the panel wants deliberate opt-in, not an incidental LLM key.
+_VOICE_PROVIDER_KEYS = {"openai": "OPENAI_API_KEY", "gemini": "GOOGLE_API_KEY"}
 
 
 def _telegram_reach_configured(secrets_text: str) -> bool:
@@ -169,4 +194,95 @@ def compute_readiness(
         telegram_configured=_telegram_reach_configured(secrets_text),
         ego_enabled=bool(ego_enabled),
         onboarded=bool(onboarded),
+    )
+
+
+# ── Enrichment (non-gating capability signals surfaced by the panel) ───────────────
+
+
+def _as_int(value: object, default: int) -> int:
+    """Coerce an injected config value to ``int``, falling back on any bad value.
+
+    Keeps :func:`compute_enrichment` truly never-raising even if the route hands it a
+    non-numeric ego cadence / autonomy level (e.g. a ``null`` in a user-overridden
+    config, or a missing attribute resolved to a non-int default).
+    """
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _web_search_keyed_providers(secrets: Mapping[str, str]) -> tuple[str, ...]:
+    """Premium web-search providers whose key is configured, sorted.
+
+    Enrichment only: web search is available regardless (the keyless SearXNG primary is
+    the bootstrap default), so this reports which PAID providers augment it — never a
+    floor/tier gate. Uses the floor's own key-pattern check so "configured" means the
+    same thing here and to routing. Pure; never raises.
+    """
+    return tuple(p for p in _WEB_SEARCH_PREMIUM_PROVIDERS if provider_key_present(p, secrets))
+
+
+def _voice_configured(secrets: Mapping[str, str]) -> bool:
+    """Whether S2S voice is DELIBERATELY configured (explicit provider + its key).
+
+    Requires an explicit ``VOICE_S2S_PROVIDER`` (``openai``/``gemini``) in ``secrets``
+    AND that provider's API key present — NOT ``channels.voice.config.s2s_enabled``,
+    whose "openai" default would report voice for any box that merely has an
+    ``OPENAI_API_KEY``. Pure dict read; never raises.
+    """
+    provider = str(secrets.get("VOICE_S2S_PROVIDER", "")).strip()
+    key_name = _VOICE_PROVIDER_KEYS.get(provider)
+    if key_name is None:
+        return False
+    return str(secrets.get(key_name, "")).strip() not in UNSET_SENTINELS
+
+
+@dataclass(frozen=True)
+class EnrichmentStatus:
+    """Non-gating capability signals surfaced by the readiness panel.
+
+    NONE of these affect the tier (see the module docstring) — they describe how far an
+    install is *enriched* beyond the minimal functional path. Presence-based and pure
+    over persisted state plus two injected config ints, like :class:`ReadinessStatus`.
+    """
+
+    web_search_keyed_providers: tuple[str, ...]
+    voice_configured: bool
+    ego_cadence_minutes: int
+    autonomy_level: int
+
+    def as_dict(self) -> dict[str, object]:
+        # Distinct key namespace from the tier/floor fields — the route merges all three
+        # dicts into one flat payload, so these must not collide with existing keys.
+        return {
+            "web_search_keyed_providers": list(self.web_search_keyed_providers),
+            "voice_configured": self.voice_configured,
+            "ego_cadence_minutes": self.ego_cadence_minutes,
+            "autonomy_level": self.autonomy_level,
+        }
+
+
+def compute_enrichment(
+    secrets: Mapping[str, str] | None = None,
+    *,
+    ego_cadence_minutes: int,
+    autonomy_level: int,
+) -> EnrichmentStatus:
+    """Package the panel's non-gating enrichment signals.
+
+    The two pure signals (web-search keyed providers, voice) are read from ``secrets``
+    (defaulting to a live persisted read); the two config ints — ``ego_cadence_minutes``
+    (ego config) and ``autonomy_level`` (``config/autonomy.yaml`` default) — are
+    INJECTED by the route, exactly as :func:`compute_readiness` injects ``ego_enabled``,
+    so this module needs no ego/autonomy import on the hot path. Never raises.
+    """
+    if secrets is None:
+        secrets = read_persisted_secrets()
+    return EnrichmentStatus(
+        web_search_keyed_providers=_web_search_keyed_providers(secrets),
+        voice_configured=_voice_configured(secrets),
+        ego_cadence_minutes=_as_int(ego_cadence_minutes, 60),
+        autonomy_level=_as_int(autonomy_level, 1),
     )

--- a/src/genesis/onboarding/readiness.py
+++ b/src/genesis/onboarding/readiness.py
@@ -57,6 +57,7 @@ scope for this signal by design.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -68,6 +69,8 @@ from genesis.onboarding.floor import (
     compute_floor,
     read_persisted_secrets,
 )
+
+logger = logging.getLogger(__name__)
 
 _TIER_NAMES = {0: "Bootstrapped", 1: "Functional", 2: "Connected", 3: "Autonomous"}
 
@@ -203,12 +206,14 @@ def _as_int(value: object, default: int) -> int:
     """Coerce an injected config value to ``int``, falling back on any bad value.
 
     Keeps :func:`compute_enrichment` truly never-raising even if the route hands it a
-    non-numeric ego cadence / autonomy level (e.g. a ``null`` in a user-overridden
-    config, or a missing attribute resolved to a non-int default).
+    non-numeric ego cadence / autonomy level. ``int()`` raises across a WIDER set than
+    is obvious: ``TypeError`` (``None``/list), ``ValueError`` (non-numeric str), AND
+    ``OverflowError`` (``int(float('inf'))`` — a YAML ``.inf`` in a user-overridden ego/
+    autonomy config resolves to a float infinity). All three fall back to ``default``.
     """
     try:
         return int(value)  # type: ignore[arg-type]
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return default
 
 
@@ -282,13 +287,29 @@ def compute_enrichment(
     (defaulting to a live persisted read); the two config ints — ``ego_cadence_minutes``
     (ego config) and ``autonomy_level`` (``config/autonomy.yaml`` default) — are
     INJECTED by the route, exactly as :func:`compute_readiness` injects ``ego_enabled``,
-    so this module needs no ego/autonomy import on the hot path. Never raises.
+    so this module needs no ego/autonomy import on the hot path.
+
+    **Never raises — by construction.** The whole body is wrapped so that ANY
+    exception (a raising ``read_persisted_secrets``, an unforeseen coercion edge, a
+    future signal reader) degrades to an empty enrichment rather than propagating a 500
+    into the first-run ``setup-status`` route. Enrichment is non-gating, so an "unknown"
+    baseline is the correct fail-safe; the per-value guards (``_as_int``) keep the good
+    fields even when one is bad, and this wrap is the backstop for everything else.
     """
-    if secrets is None:
-        secrets = read_persisted_secrets()
-    return EnrichmentStatus(
-        web_search_keyed_providers=_web_search_keyed_providers(secrets),
-        voice_configured=_voice_configured(secrets),
-        ego_cadence_minutes=_as_int(ego_cadence_minutes, 60),
-        autonomy_level=_as_int(autonomy_level, 1),
-    )
+    try:
+        if secrets is None:
+            secrets = read_persisted_secrets()
+        return EnrichmentStatus(
+            web_search_keyed_providers=_web_search_keyed_providers(secrets),
+            voice_configured=_voice_configured(secrets),
+            ego_cadence_minutes=_as_int(ego_cadence_minutes, 60),
+            autonomy_level=_as_int(autonomy_level, 1),
+        )
+    except Exception:  # noqa: BLE001 - enrichment must never raise into setup-status
+        logger.warning("compute_enrichment failed; returning empty enrichment", exc_info=True)
+        return EnrichmentStatus(
+            web_search_keyed_providers=(),
+            voice_configured=False,
+            ego_cadence_minutes=60,
+            autonomy_level=1,
+        )

--- a/src/genesis/onboarding/readiness.py
+++ b/src/genesis/onboarding/readiness.py
@@ -66,7 +66,6 @@ from genesis.onboarding.floor import (
     UNSET_SENTINELS,
     FloorStatus,
     compute_floor,
-    provider_key_present,
     read_persisted_secrets,
 )
 
@@ -214,14 +213,21 @@ def _as_int(value: object, default: int) -> int:
 
 
 def _web_search_keyed_providers(secrets: Mapping[str, str]) -> tuple[str, ...]:
-    """Premium web-search providers whose key is configured, sorted.
+    """Premium web-search providers whose canonical key is configured, in stable order.
 
     Enrichment only: web search is available regardless (the keyless SearXNG primary is
     the bootstrap default), so this reports which PAID providers augment it — never a
-    floor/tier gate. Uses the floor's own key-pattern check so "configured" means the
-    same thing here and to routing. Pure; never raises.
+    floor/tier gate. Each web-search tool provider reads ONLY its canonical
+    ``API_KEY_<TYPE>`` env var (``web/search.py`` for Brave; ``runtime/init/providers.py``
+    for Tavily/Exa/TinyFish) — NOT routing's 3-pattern resolver — so we check that exact
+    key, not ``provider_key_present`` (whose ``<TYPE>_API_KEY`` / ``_API_TOKEN`` aliases
+    would advertise a provider that its adapter can't actually load). Pure; never raises.
     """
-    return tuple(p for p in _WEB_SEARCH_PREMIUM_PROVIDERS if provider_key_present(p, secrets))
+    return tuple(
+        p
+        for p in _WEB_SEARCH_PREMIUM_PROVIDERS
+        if str(secrets.get(f"API_KEY_{p.upper()}", "")).strip() not in UNSET_SENTINELS
+    )
 
 
 def _voice_configured(secrets: Mapping[str, str]) -> bool:

--- a/src/genesis/onboarding/readiness.py
+++ b/src/genesis/onboarding/readiness.py
@@ -36,7 +36,8 @@ the dashboard password — is enrichment surfaced by the panel, never a tier gat
 alongside the tier: which premium web-search providers are keyed, whether S2S voice is
 deliberately configured, the ego think-cadence, and the shipped autonomy default level.
 Like the tier, they are presence-based and pure over persisted state plus two injected
-config ints (``ego_cadence_minutes``, ``autonomy_level``), so the module stays free of
+config values (``ego_cadence_minutes`` — which may be fractional — and the ``autonomy_level``
+int), so the module stays free of
 runtime/ego/autonomy imports on the ``setup-status`` hot path.
 
 Like the floor, readiness is **presence-based and pure over persisted state plus two
@@ -58,6 +59,7 @@ scope for this signal by design.
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -217,6 +219,27 @@ def _as_int(value: object, default: int) -> int:
         return default
 
 
+def _as_finite_number(value: object, default: int) -> int | float:
+    """Coerce to a FINITE number, preserving fractional values; fall back on bad input.
+
+    Unlike :func:`_as_int`, this keeps a supported fractional cadence: the ego config
+    validator accepts ``int | float`` (``ego/config.py`` ``validate_ego_config``),
+    ``load_ego_config`` does not int-coerce the scalar, and ``EgoCadenceManager`` passes
+    it straight to APScheduler's ``IntervalTrigger(minutes=…)`` (which runs on floats) —
+    so the display field must report the real interval (``45.5`` stays ``45.5``), not a
+    truncated ``45``. Rejects non-numeric AND non-finite (``inf``/``nan``) → ``default``,
+    keeping the never-raise contract. Whole numbers normalise to ``int`` for clean JSON
+    (``60.0`` → ``60``).
+    """
+    try:
+        n = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    if not math.isfinite(n):
+        return default
+    return int(n) if n.is_integer() else n
+
+
 def _web_search_keyed_providers(secrets: Mapping[str, str]) -> tuple[str, ...]:
     """Premium web-search providers whose canonical key is configured, in stable order.
 
@@ -262,12 +285,12 @@ class EnrichmentStatus:
 
     NONE of these affect the tier (see the module docstring) — they describe how far an
     install is *enriched* beyond the minimal functional path. Presence-based and pure
-    over persisted state plus two injected config ints, like :class:`ReadinessStatus`.
+    over persisted state plus two injected config values, like :class:`ReadinessStatus`.
     """
 
     web_search_keyed_providers: tuple[str, ...]
     voice_configured: bool
-    ego_cadence_minutes: int
+    ego_cadence_minutes: int | float  # fractional cadence (e.g. 45.5) preserved
     autonomy_level: int
 
     def as_dict(self) -> dict[str, object]:
@@ -284,13 +307,13 @@ class EnrichmentStatus:
 def compute_enrichment(
     secrets: Mapping[str, str] | None = None,
     *,
-    ego_cadence_minutes: int,
+    ego_cadence_minutes: int | float,
     autonomy_level: int,
 ) -> EnrichmentStatus:
     """Package the panel's non-gating enrichment signals.
 
     The two pure signals (web-search keyed providers, voice) are read from ``secrets``
-    (defaulting to a live persisted read); the two config ints — ``ego_cadence_minutes``
+    (defaulting to a live persisted read); the two injected config values — ``ego_cadence_minutes``
     (ego config) and ``autonomy_level`` (``config/autonomy.yaml`` default) — are
     INJECTED by the route, exactly as :func:`compute_readiness` injects ``ego_enabled``,
     so this module needs no ego/autonomy import on the hot path.
@@ -308,7 +331,7 @@ def compute_enrichment(
         return EnrichmentStatus(
             web_search_keyed_providers=_web_search_keyed_providers(secrets),
             voice_configured=_voice_configured(secrets),
-            ego_cadence_minutes=_as_int(ego_cadence_minutes, 60),
+            ego_cadence_minutes=_as_finite_number(ego_cadence_minutes, 60),
             autonomy_level=_as_int(autonomy_level, 1),
         )
     except Exception:  # noqa: BLE001 - enrichment must never raise into setup-status

--- a/tests/test_autonomy/test_config_read.py
+++ b/tests/test_autonomy/test_config_read.py
@@ -51,6 +51,14 @@ def test_non_int_value_is_level_1(tmp_path):
     assert read_autonomy_default_level("direct_session", path=cfg) == 1
 
 
+def test_infinity_value_is_level_1(tmp_path):
+    # YAML `.inf` parses to float('inf'); int(inf) raises OverflowError (NOT ValueError/
+    # TypeError) — must still fail-safe to L1, honoring the never-raise contract.
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("defaults:\n  direct_session: .inf\n")
+    assert read_autonomy_default_level("direct_session", path=cfg) == 1
+
+
 def test_empty_file_is_level_1(tmp_path):
     cfg = tmp_path / "autonomy.yaml"
     cfg.write_text("")  # yaml.safe_load -> None

--- a/tests/test_autonomy/test_config_read.py
+++ b/tests/test_autonomy/test_config_read.py
@@ -59,6 +59,23 @@ def test_infinity_value_is_level_1(tmp_path):
     assert read_autonomy_default_level("direct_session", path=cfg) == 1
 
 
+def test_sub_one_level_floors_to_1(tmp_path):
+    # A 0/negative default is a nonsensical autonomy level → clamp UP to the L1 floor
+    # (Codex P2, corrected: only < 1 is invalid).
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("defaults:\n  direct_session: 0\n  outreach: -3\n")
+    assert read_autonomy_default_level("direct_session", path=cfg) == 1
+    assert read_autonomy_default_level("outreach", path=cfg) == 1
+
+
+def test_high_but_valid_level_passes_through(tmp_path):
+    # direct_session's ceiling is 7 ("effectively uncapped"), so a legitimately-high
+    # default must NOT be clamped down — the generic reader floors, never caps.
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("defaults:\n  direct_session: 6\n")
+    assert read_autonomy_default_level("direct_session", path=cfg) == 6
+
+
 def test_empty_file_is_level_1(tmp_path):
     cfg = tmp_path / "autonomy.yaml"
     cfg.write_text("")  # yaml.safe_load -> None

--- a/tests/test_autonomy/test_config_read.py
+++ b/tests/test_autonomy/test_config_read.py
@@ -59,21 +59,23 @@ def test_infinity_value_is_level_1(tmp_path):
     assert read_autonomy_default_level("direct_session", path=cfg) == 1
 
 
-def test_sub_one_level_floors_to_1(tmp_path):
-    # A 0/negative default is a nonsensical autonomy level → clamp UP to the L1 floor
-    # (Codex P2, corrected: only < 1 is invalid).
-    cfg = tmp_path / "autonomy.yaml"
-    cfg.write_text("defaults:\n  direct_session: 0\n  outreach: -3\n")
-    assert read_autonomy_default_level("direct_session", path=cfg) == 1
-    assert read_autonomy_default_level("outreach", path=cfg) == 1
+def test_non_constructible_level_is_1(tmp_path):
+    # Only L1–L4 are constructible AutonomyLevel members (L5–L7 deferred to V5); the
+    # yaml `ceilings` cap ACTIONS, not the enum. A default outside the enum (0, negative,
+    # or 5–7) would ValueError at AutonomyStateMachine.load_or_create_defaults, so the
+    # display read must fall back to L1 rather than advertise a non-constructible level.
+    for bad in ("0", "-3", "5", "6", "7", "99"):
+        cfg = tmp_path / f"autonomy_{bad}.yaml"
+        cfg.write_text(f"defaults:\n  direct_session: {bad}\n")
+        assert read_autonomy_default_level("direct_session", path=cfg) == 1, bad
 
 
-def test_high_but_valid_level_passes_through(tmp_path):
-    # direct_session's ceiling is 7 ("effectively uncapped"), so a legitimately-high
-    # default must NOT be clamped down — the generic reader floors, never caps.
-    cfg = tmp_path / "autonomy.yaml"
-    cfg.write_text("defaults:\n  direct_session: 6\n")
-    assert read_autonomy_default_level("direct_session", path=cfg) == 6
+def test_all_constructible_levels_pass_through(tmp_path):
+    # Every valid enum level (L1–L4) is returned as-is.
+    for good in (1, 2, 3, 4):
+        cfg = tmp_path / f"autonomy_{good}.yaml"
+        cfg.write_text(f"defaults:\n  direct_session: {good}\n")
+        assert read_autonomy_default_level("direct_session", path=cfg) == good
 
 
 def test_empty_file_is_level_1(tmp_path):

--- a/tests/test_autonomy/test_config_read.py
+++ b/tests/test_autonomy/test_config_read.py
@@ -1,0 +1,81 @@
+"""Tests for the fail-safe autonomy default-level reader (``config_read``).
+
+The reader feeds the dashboard ``setup-status`` readiness enrichment, which must never
+500 first-run — so EVERY failure mode degrades to the conservative L1 floor rather than
+raising.
+"""
+
+from __future__ import annotations
+
+from genesis.autonomy.config_read import read_autonomy_default_level
+
+
+def test_reads_shipped_default_per_category(tmp_path):
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("defaults:\n  direct_session: 2\n  outreach: 1\n")
+    assert read_autonomy_default_level("direct_session", path=cfg) == 2
+    assert read_autonomy_default_level("outreach", path=cfg) == 1
+
+
+def test_default_category_is_direct_session(tmp_path):
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("defaults:\n  direct_session: 4\n  outreach: 1\n")
+    assert read_autonomy_default_level(path=cfg) == 4
+
+
+def test_missing_file_is_level_1(tmp_path):
+    assert read_autonomy_default_level(path=tmp_path / "nope.yaml") == 1
+
+
+def test_malformed_yaml_is_level_1(tmp_path):
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("defaults: [unbalanced, flow, seq\n")  # unclosed -> YAMLError
+    assert read_autonomy_default_level(path=cfg) == 1
+
+
+def test_absent_defaults_block_is_level_1(tmp_path):
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("ceilings:\n  direct_session: 7\n")  # no `defaults:`
+    assert read_autonomy_default_level("direct_session", path=cfg) == 1
+
+
+def test_absent_category_is_level_1(tmp_path):
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("defaults:\n  direct_session: 3\n")
+    assert read_autonomy_default_level("sub_agent", path=cfg) == 1
+
+
+def test_non_int_value_is_level_1(tmp_path):
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("defaults:\n  direct_session: high\n")
+    assert read_autonomy_default_level("direct_session", path=cfg) == 1
+
+
+def test_empty_file_is_level_1(tmp_path):
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("")  # yaml.safe_load -> None
+    assert read_autonomy_default_level(path=cfg) == 1
+
+
+def test_non_mapping_root_is_level_1(tmp_path):
+    # A top-level scalar or list parses to a truthy non-dict; `.get` would
+    # AttributeError without the isinstance guard. Must still fail-safe, not raise.
+    scalar = tmp_path / "scalar.yaml"
+    scalar.write_text("just a bare string\n")
+    assert read_autonomy_default_level(path=scalar) == 1
+    seq = tmp_path / "seq.yaml"
+    seq.write_text("- a\n- b\n")
+    assert read_autonomy_default_level(path=seq) == 1
+
+
+def test_non_mapping_defaults_is_level_1(tmp_path):
+    # `defaults:` present but not a mapping (a list) → fail-safe, not raise.
+    cfg = tmp_path / "autonomy.yaml"
+    cfg.write_text("defaults:\n  - direct_session\n  - outreach\n")
+    assert read_autonomy_default_level(path=cfg) == 1
+
+
+def test_real_shipped_config_is_conservative_l1():
+    # The actual config/autonomy.yaml ships every category at L1 ("conservative start").
+    # Pins the reader against the real file, not just synthetic fixtures.
+    assert read_autonomy_default_level("direct_session") == 1

--- a/tests/test_dashboard/test_setup_wizard_api.py
+++ b/tests/test_dashboard/test_setup_wizard_api.py
@@ -258,6 +258,23 @@ def test_setup_status_enrichment_fields_reflect_config(wiz):
     assert body["floor_met"] is True
 
 
+def test_setup_status_overflow_cadence_is_failsafe_not_500(wiz):
+    # A user-overridden ego.yaml with `cadence_minutes: .inf` yields a float infinity;
+    # int(inf) raises OverflowError. compute_enrichment runs OUTSIDE the route's ego
+    # try/except, so this must be caught there (never 500 first-run) and fall back to 60.
+    wiz["monkeypatch"].setattr(
+        wiz["ego_config"],
+        "load_ego_config",
+        lambda *a, **k: SimpleNamespace(enabled=True, cadence_minutes=float("inf")),
+    )
+    wiz["secrets"].write_text(_functional_secrets())
+    resp = wiz["client"].get("/api/genesis/setup-status")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ego_cadence_minutes"] == 60
+    assert body["ego_enabled"] is True  # the bad cadence must not disturb ego/tier
+
+
 def test_setup_status_openai_llm_key_alone_is_not_voice(wiz):
     # Regression guard: s2s_provider() defaults to "openai", so a bare OPENAI_API_KEY
     # (an LLM key) must NOT read as deliberate voice setup.

--- a/tests/test_dashboard/test_setup_wizard_api.py
+++ b/tests/test_dashboard/test_setup_wizard_api.py
@@ -44,12 +44,21 @@ def wiz(tmp_path, monkeypatch):
     monkeypatch.setattr(floor_mod, "cc_oauth_present", lambda: True)
 
     # The route lazy-imports load_ego_config from its source module — patch it there.
-    # Default: ego loop OFF (so tier hinges on what each test configures).
+    # Default: ego loop OFF (so tier hinges on what each test configures); cadence at the
+    # shipped 60 so the enrichment field is deterministic.
     import genesis.ego.config as ego_config_mod
 
     monkeypatch.setattr(
-        ego_config_mod, "load_ego_config", lambda *a, **k: SimpleNamespace(enabled=False)
+        ego_config_mod,
+        "load_ego_config",
+        lambda *a, **k: SimpleNamespace(enabled=False, cadence_minutes=60),
     )
+
+    # The route also lazy-imports the autonomy default-level reader — patch it at the
+    # source so the enrichment field is hermetic (not coupled to config/autonomy.yaml).
+    import genesis.autonomy.config_read as autonomy_cfg_mod
+
+    monkeypatch.setattr(autonomy_cfg_mod, "read_autonomy_default_level", lambda *a, **k: 1)
 
     return {
         "client": app.test_client(),
@@ -58,6 +67,7 @@ def wiz(tmp_path, monkeypatch):
         "marker": marker,
         "monkeypatch": monkeypatch,
         "ego_config": ego_config_mod,
+        "autonomy_cfg": autonomy_cfg_mod,
     }
 
 
@@ -78,6 +88,11 @@ def test_setup_status_fresh_install(wiz):
         "tier_name": "Bootstrapped",
         "telegram_configured": False,
         "ego_enabled": False,
+        # enrichment fields (additive, non-gating) — nothing configured on a fresh box.
+        "web_search_keyed_providers": [],
+        "voice_configured": False,
+        "ego_cadence_minutes": 60,
+        "autonomy_level": 1,
     }
 
 
@@ -217,6 +232,38 @@ def test_setup_status_ego_config_unreadable_is_failsafe_not_500(wiz):
     body = resp.get_json()
     assert body["ego_enabled"] is False
     assert body["tier"] == 2  # capped at Connected without ego
+    assert body["ego_cadence_minutes"] == 60  # cadence also fails safe to the default
+
+
+def test_setup_status_enrichment_fields_reflect_config(wiz):
+    # A premium web-search key + deliberate voice opt-in + custom ego cadence + a
+    # non-default autonomy level must all surface through the route (non-gating).
+    wiz["secrets"].write_text(
+        _functional_secrets() + "API_KEY_BRAVE=bk\nVOICE_S2S_PROVIDER=openai\nOPENAI_API_KEY=sk\n"
+    )
+    wiz["monkeypatch"].setattr(
+        wiz["ego_config"],
+        "load_ego_config",
+        lambda *a, **k: SimpleNamespace(enabled=False, cadence_minutes=45),
+    )
+    wiz["monkeypatch"].setattr(
+        wiz["autonomy_cfg"], "read_autonomy_default_level", lambda *a, **k: 2
+    )
+    body = wiz["client"].get("/api/genesis/setup-status").get_json()
+    assert body["web_search_keyed_providers"] == ["brave"]
+    assert body["voice_configured"] is True
+    assert body["ego_cadence_minutes"] == 45
+    assert body["autonomy_level"] == 2
+    # Enrichment is non-gating: these do not change the floor/tier.
+    assert body["floor_met"] is True
+
+
+def test_setup_status_openai_llm_key_alone_is_not_voice(wiz):
+    # Regression guard: s2s_provider() defaults to "openai", so a bare OPENAI_API_KEY
+    # (an LLM key) must NOT read as deliberate voice setup.
+    wiz["secrets"].write_text(_functional_secrets() + "OPENAI_API_KEY=sk\n")
+    body = wiz["client"].get("/api/genesis/setup-status").get_json()
+    assert body["voice_configured"] is False
 
 
 def test_setup_status_readiness_fields_backward_compatible(wiz):
@@ -234,6 +281,13 @@ def test_setup_status_readiness_fields_backward_compatible(wiz):
     ):
         assert key in body
     for key in ("tier", "tier_name", "telegram_configured", "ego_enabled"):
+        assert key in body
+    for key in (
+        "web_search_keyed_providers",
+        "voice_configured",
+        "ego_cadence_minutes",
+        "autonomy_level",
+    ):
         assert key in body
 
 

--- a/tests/test_dashboard/test_setup_wizard_api.py
+++ b/tests/test_dashboard/test_setup_wizard_api.py
@@ -244,7 +244,8 @@ def test_setup_status_enrichment_fields_reflect_config(wiz):
     wiz["monkeypatch"].setattr(
         wiz["ego_config"],
         "load_ego_config",
-        lambda *a, **k: SimpleNamespace(enabled=False, cadence_minutes=45),
+        # A fractional cadence must survive the route + jsonify unchanged (not truncated).
+        lambda *a, **k: SimpleNamespace(enabled=False, cadence_minutes=45.5),
     )
     wiz["monkeypatch"].setattr(
         wiz["autonomy_cfg"], "read_autonomy_default_level", lambda *a, **k: 2
@@ -252,7 +253,7 @@ def test_setup_status_enrichment_fields_reflect_config(wiz):
     body = wiz["client"].get("/api/genesis/setup-status").get_json()
     assert body["web_search_keyed_providers"] == ["brave"]
     assert body["voice_configured"] is True
-    assert body["ego_cadence_minutes"] == 45
+    assert body["ego_cadence_minutes"] == 45.5
     assert body["autonomy_level"] == 2
     # Enrichment is non-gating: these do not change the floor/tier.
     assert body["floor_met"] is True

--- a/tests/test_onboarding/test_readiness.py
+++ b/tests/test_onboarding/test_readiness.py
@@ -23,6 +23,7 @@ from genesis.onboarding.readiness import (
     ReadinessStatus,
     _read_secrets_env_text,
     _telegram_reach_configured,
+    compute_enrichment,
     compute_readiness,
 )
 
@@ -293,3 +294,85 @@ def test_compute_readiness_ego_flag_is_coerced_bool(floor_met):
         secrets={"API_KEY_DEEPINFRA": "d"}, secrets_text=tg, ego_enabled=1, onboarded=True
     )
     assert r.ego_enabled is True
+
+
+# ── Enrichment signals (non-gating; surfaced by the panel) ─────────────────────
+
+
+@pytest.mark.parametrize(
+    "secrets, expected",
+    [
+        ({}, ()),  # nothing keyed → keyless SearXNG baseline only
+        ({"API_KEY_BRAVE": "b"}, ("brave",)),
+        ({"BRAVE_API_KEY": "b", "TAVILY_API_KEY": "t"}, ("brave", "tavily")),  # alt patterns
+        (
+            {"API_KEY_EXA": "e", "API_KEY_TINYFISH": "tf", "API_KEY_BRAVE": "b"},
+            ("brave", "exa", "tinyfish"),
+        ),  # sorted, not insertion order
+        ({"API_KEY_TAVILY": ""}, ()),  # unset sentinel doesn't count
+        ({"API_KEY_TAVILY": "None"}, ()),
+        ({"API_KEY_OPENROUTER": "x"}, ()),  # a non-web-search key is ignored
+    ],
+)
+def test_web_search_keyed_providers(secrets, expected):
+    assert readiness_mod._web_search_keyed_providers(secrets) == expected
+
+
+@pytest.mark.parametrize(
+    "secrets, expected",
+    [
+        ({}, False),
+        # An OpenAI LLM key WITHOUT an explicit provider must NOT read as voice (the
+        # false-positive s2s_enabled's "openai" default would cause).
+        ({"OPENAI_API_KEY": "sk"}, False),
+        ({"VOICE_S2S_PROVIDER": "openai"}, False),  # provider but no key
+        ({"VOICE_S2S_PROVIDER": "openai", "OPENAI_API_KEY": "sk"}, True),
+        ({"VOICE_S2S_PROVIDER": "gemini", "GOOGLE_API_KEY": "g"}, True),
+        ({"VOICE_S2S_PROVIDER": "gemini", "OPENAI_API_KEY": "sk"}, False),  # wrong key
+        ({"VOICE_S2S_PROVIDER": "none", "OPENAI_API_KEY": "sk"}, False),  # explicit off
+        ({"VOICE_S2S_PROVIDER": "openai", "OPENAI_API_KEY": ""}, False),  # unset sentinel
+        ({"VOICE_S2S_PROVIDER": " openai ", "OPENAI_API_KEY": "sk"}, True),  # trimmed
+    ],
+)
+def test_voice_configured(secrets, expected):
+    assert readiness_mod._voice_configured(secrets) is expected
+
+
+def test_compute_enrichment_packages_all_signals():
+    secrets = {"API_KEY_BRAVE": "b", "VOICE_S2S_PROVIDER": "openai", "OPENAI_API_KEY": "sk"}
+    e = compute_enrichment(secrets=secrets, ego_cadence_minutes=90, autonomy_level=2)
+    assert e.web_search_keyed_providers == ("brave",)
+    assert e.voice_configured is True
+    assert e.ego_cadence_minutes == 90
+    assert e.autonomy_level == 2
+
+
+def test_compute_enrichment_as_dict_shape_and_types():
+    e = compute_enrichment(secrets={}, ego_cadence_minutes=60, autonomy_level=1)
+    d = e.as_dict()
+    assert d == {
+        "web_search_keyed_providers": [],
+        "voice_configured": False,
+        "ego_cadence_minutes": 60,
+        "autonomy_level": 1,
+    }
+    # Providers must serialize as a JSON list (jsonify can't emit a tuple cleanly here).
+    assert isinstance(d["web_search_keyed_providers"], list)
+
+
+def test_compute_enrichment_coerces_injected_ints():
+    e = compute_enrichment(secrets={}, ego_cadence_minutes="45", autonomy_level="3")
+    assert e.ego_cadence_minutes == 45 and e.autonomy_level == 3
+
+
+def test_compute_enrichment_non_coercible_ints_fall_back_never_raises():
+    # A null/garbage cadence (e.g. a user-overridden ego.yaml) or level must NOT raise
+    # into the setup-status route — compute_enrichment coerces to the safe defaults.
+    e = compute_enrichment(secrets={}, ego_cadence_minutes=None, autonomy_level="oops")
+    assert e.ego_cadence_minutes == 60 and e.autonomy_level == 1
+
+
+def test_compute_enrichment_reads_persisted_secrets_when_omitted(monkeypatch):
+    monkeypatch.setattr(readiness_mod, "read_persisted_secrets", lambda: {"API_KEY_TAVILY": "t"})
+    e = compute_enrichment(ego_cadence_minutes=60, autonomy_level=1)
+    assert e.web_search_keyed_providers == ("tavily",)

--- a/tests/test_onboarding/test_readiness.py
+++ b/tests/test_onboarding/test_readiness.py
@@ -335,7 +335,10 @@ def test_web_search_keyed_providers(secrets, expected):
         ({"VOICE_S2S_PROVIDER": "gemini", "OPENAI_API_KEY": "sk"}, False),  # wrong key
         ({"VOICE_S2S_PROVIDER": "none", "OPENAI_API_KEY": "sk"}, False),  # explicit off
         ({"VOICE_S2S_PROVIDER": "openai", "OPENAI_API_KEY": ""}, False),  # unset sentinel
-        ({"VOICE_S2S_PROVIDER": " openai ", "OPENAI_API_KEY": "sk"}, True),  # trimmed
+        # Codex P2 parity: the runtime s2s_provider() does NOT strip and compares with a
+        # bare == "openai", so a hand-quoted " openai " (dotenv keeps inner spaces) would
+        # NOT enable voice at runtime — it must NOT read as configured here either.
+        ({"VOICE_S2S_PROVIDER": " openai ", "OPENAI_API_KEY": "sk"}, False),
     ],
 )
 def test_voice_configured(secrets, expected):

--- a/tests/test_onboarding/test_readiness.py
+++ b/tests/test_onboarding/test_readiness.py
@@ -369,11 +369,48 @@ def test_compute_enrichment_coerces_injected_ints():
     assert e.ego_cadence_minutes == 45 and e.autonomy_level == 3
 
 
-def test_compute_enrichment_non_coercible_ints_fall_back_never_raises():
-    # A null/garbage cadence (e.g. a user-overridden ego.yaml) or level must NOT raise
-    # into the setup-status route — compute_enrichment coerces to the safe defaults.
-    e = compute_enrichment(secrets={}, ego_cadence_minutes=None, autonomy_level="oops")
-    assert e.ego_cadence_minutes == 60 and e.autonomy_level == 1
+@pytest.mark.parametrize(
+    "cadence, level, exp_cadence, exp_level",
+    [
+        (None, "oops", 60, 1),  # TypeError / ValueError
+        (float("inf"), float("inf"), 60, 1),  # OverflowError: int(inf) (Codex P2)
+        (float("nan"), 3, 60, 3),  # ValueError: int(nan)
+        (["x"], {"y": 1}, 60, 1),  # TypeError on non-scalars
+    ],
+)
+def test_compute_enrichment_non_coercible_ints_fall_back_never_raises(
+    cadence, level, exp_cadence, exp_level
+):
+    # A null/garbage/inf/nan cadence (e.g. a user-overridden ego/autonomy config) must
+    # NOT raise into the setup-status route — _as_int coerces to the safe defaults.
+    e = compute_enrichment(secrets={}, ego_cadence_minutes=cadence, autonomy_level=level)
+    assert e.ego_cadence_minutes == exp_cadence and e.autonomy_level == exp_level
+
+
+def test_compute_enrichment_backstops_any_internal_raise(monkeypatch):
+    # Robust-by-construction: if ANY internal step raises (here a signal reader), the
+    # whole computation degrades to empty enrichment rather than 500ing setup-status.
+    def _boom(_secrets):
+        raise RuntimeError("unexpected reader failure")
+
+    monkeypatch.setattr(readiness_mod, "_web_search_keyed_providers", _boom)
+    e = compute_enrichment(secrets={}, ego_cadence_minutes=90, autonomy_level=2)
+    assert e.as_dict() == {
+        "web_search_keyed_providers": [],
+        "voice_configured": False,
+        "ego_cadence_minutes": 60,
+        "autonomy_level": 1,
+    }
+
+
+def test_compute_enrichment_backstops_raising_secrets_read(monkeypatch):
+    # The never-raise contract also covers a raising read_persisted_secrets (secrets=None).
+    def _boom():
+        raise OSError("secrets.env unreadable mid-read")
+
+    monkeypatch.setattr(readiness_mod, "read_persisted_secrets", _boom)
+    e = compute_enrichment(ego_cadence_minutes=60, autonomy_level=1)
+    assert e.web_search_keyed_providers == () and e.voice_configured is False
 
 
 def test_compute_enrichment_reads_persisted_secrets_when_omitted(monkeypatch):

--- a/tests/test_onboarding/test_readiness.py
+++ b/tests/test_onboarding/test_readiness.py
@@ -304,7 +304,7 @@ def test_compute_readiness_ego_flag_is_coerced_bool(floor_met):
     [
         ({}, ()),  # nothing keyed → keyless SearXNG baseline only
         ({"API_KEY_BRAVE": "b"}, ("brave",)),
-        ({"BRAVE_API_KEY": "b", "TAVILY_API_KEY": "t"}, ("brave", "tavily")),  # alt patterns
+        ({"API_KEY_BRAVE": "b", "API_KEY_TAVILY": "t"}, ("brave", "tavily")),
         (
             {"API_KEY_EXA": "e", "API_KEY_TINYFISH": "tf", "API_KEY_BRAVE": "b"},
             ("brave", "exa", "tinyfish"),
@@ -312,6 +312,10 @@ def test_compute_readiness_ego_flag_is_coerced_bool(floor_met):
         ({"API_KEY_TAVILY": ""}, ()),  # unset sentinel doesn't count
         ({"API_KEY_TAVILY": "None"}, ()),
         ({"API_KEY_OPENROUTER": "x"}, ()),  # a non-web-search key is ignored
+        # Codex P2 regression: the web adapters read ONLY the canonical API_KEY_<TYPE>,
+        # so routing's alias patterns (<TYPE>_API_KEY / _API_TOKEN) must NOT count — they
+        # would advertise a provider its adapter can't actually load.
+        ({"BRAVE_API_KEY": "b", "TAVILY_API_TOKEN": "t", "EXA_API_KEY": "e"}, ()),
     ],
 )
 def test_web_search_keyed_providers(secrets, expected):

--- a/tests/test_onboarding/test_readiness.py
+++ b/tests/test_onboarding/test_readiness.py
@@ -390,6 +390,19 @@ def test_compute_enrichment_non_coercible_ints_fall_back_never_raises(
     assert e.ego_cadence_minutes == exp_cadence and e.autonomy_level == exp_level
 
 
+def test_compute_enrichment_preserves_fractional_cadence():
+    # A SUPPORTED fractional cadence (validate_ego_config accepts int|float; the scheduler
+    # runs IntervalTrigger on floats) must be reported faithfully, not truncated to int.
+    e = compute_enrichment(secrets={}, ego_cadence_minutes=45.5, autonomy_level=2)
+    assert e.ego_cadence_minutes == 45.5
+    # Whole-number floats normalise to int for clean JSON (60.0 -> 60, not 60.0).
+    e2 = compute_enrichment(secrets={}, ego_cadence_minutes=60.0, autonomy_level=1)
+    assert e2.ego_cadence_minutes == 60 and isinstance(e2.ego_cadence_minutes, int)
+    # A numeric string is still coerced (parity with the old int path).
+    e3 = compute_enrichment(secrets={}, ego_cadence_minutes="90", autonomy_level=1)
+    assert e3.ego_cadence_minutes == 90 and isinstance(e3.ego_cadence_minutes, int)
+
+
 def test_compute_enrichment_backstops_any_internal_raise(monkeypatch):
     # Robust-by-construction: if ANY internal step raises (here a signal reader), the
     # whole computation degrades to empty enrichment rather than 500ing setup-status.


### PR DESCRIPTION
Adds four **non-gating enrichment** fields to the dashboard `GET /api/genesis/setup-status`
payload, above the existing cumulative tier model. All additive and backward-compatible —
no existing field renamed or removed. Backend only; the persistent readiness panel that
renders the tier + these chips is a follow-up (PR-B2b).

## New fields
- `web_search_keyed_providers` (list) — which premium web-search providers
  (brave/tavily/exa/tinyfish) have a key configured. Web search is available regardless
  (the keyless SearXNG primary is the bootstrap default), so this reports *which paid
  providers augment* the baseline — never a floor/tier gate.
- `voice_configured` (bool) — S2S voice **deliberately** set up: an explicit
  `VOICE_S2S_PROVIDER` (openai/gemini) plus that provider's key. `s2s_provider()` defaults
  to "openai", so a bare `OPENAI_API_KEY` (an LLM key) must NOT read as voice — this
  requires the explicit opt-in.
- `ego_cadence_minutes` (int) — the ego think-cadence.
- `autonomy_level` (int) — the shipped autonomy default level (config posture, NOT the
  live earned per-install level, which is DB state).

## Design
- `readiness.EnrichmentStatus` + `compute_enrichment` mirror `compute_readiness`: pure over
  persisted secrets plus two **injected** config ints, so the module stays free of
  ego/autonomy imports on the `setup-status` hot path. Injected ints are coerced via a
  defensive `_as_int`, so a malformed cadence/level can never raise.
- `autonomy.config_read.read_autonomy_default_level`: fail-safe `yaml` read of the shipped
  default; returns L1 on **any** failure (missing/malformed/non-mapping root/absent key/
  non-int), `isinstance`-guarded so a non-dict YAML root can't `AttributeError`.
- The route reads the ego cadence **off** the `ego_enabled` critical path, so a bad cadence
  value can never disturb the tier.

## Invariants preserved
- `setup_status` never 500s into first-run (every new read is fail-safe).
- The floor is computed exactly once per request.
- Enrichment is non-gating: nothing here changes the floor or the tier.

## Tests
- `tests/test_autonomy/test_config_read.py` (new): every fail-safe path → L1.
- `tests/test_onboarding/test_readiness.py`: web-search keyed-provider table, voice
  truth-table (incl. the bare-OpenAI-key false-positive guard), `compute_enrichment`
  packaging + non-coercible-int fallback.
- `tests/test_dashboard/test_setup_wizard_api.py`: exact-dict fresh-install extended,
  populated enrichment case, cadence fail-safe, backward-compat.

Self-reviewed + independent reviewer pass (two findings fixed: cadence/tier coupling;
non-dict YAML root). Verified E2E through the real route handler (HTTP 200; output equals
independent recomputation for every field; tier stays consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)