### PR TITLE
fix(cc): secure-by-default MCP scoping for autonomous CC sessions

### DIFF
--- a/.claude/docs/background-sessions.md
+++ b/.claude/docs/background-sessions.md
@@ -71,6 +71,17 @@ it also reaches the `genesis-recon` discovery tools (GitHub/model-intel/skill
 scanning, findings storage) — the only profile that does.
 Use `observe` for read-only investigation.
 
+**MCP scoping is secure-by-default.** `CCInvocation.strict_mcp_config` defaults to
+True, so every background session gets `--strict-mcp-config`: it loads ONLY the
+servers in its generated `--mcp-config` (its `mcp_profile`) and never additively
+inherits the operator's user-scoped `~/.claude.json` MCP servers (Claude Code's
+`--mcp-config` is additive without strict — probe-verified). A profile that maps to
+no genesis servers therefore runs with zero MCP tools (fail-closed), not the
+operator's full set. Only human-driven foreground/interactive sessions
+(`cc/conversation.py`, `cc/checkpoint.py`) opt out (`strict_mcp_config=False`) to
+keep the full user-scoped toolset. As defense-in-depth, `_UNIVERSAL_DISALLOW` also
+denies the user-scoped servers by name (`_USER_SCOPED_MCP_WILDCARDS`).
+
 **`steward` is the one built-in Bash-enabled profile** — its Bash is restricted
 to the `gh` CLI only, enforced by `scripts/bash_safety_hook.sh` via the
 `GENESIS_BASH_ALLOWLIST` env var set from `CCInvocation.bash_allowlist`. It

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   reserved for your (foreground) work. A foreground session can promote a tabled
   item to the board.
 
+- **All autonomous background sessions are now MCP-scoped by default.** Genesis
+  runs many kinds of background Claude Code sessions (reflection, sentinel,
+  inbox/mail triage, autonomy executor, ego gates, research). These are now secure
+  by default: each session loads only the Genesis MCP tools it is explicitly given
+  and no longer additively inherits the operator's user-scoped MCP servers (e.g.
+  code-editing tools) that were never intended for autonomous use. A session that
+  forgets to scope itself now fails closed (no extra tools) rather than open. Your
+  own foreground conversations are unchanged — they keep the full toolset. This
+  closes a latent tool-scope gap; nothing you'd notice day to day, no action needed.
+
 - **Free-tier model refresh.** Groq is retiring Llama 3.3 70B (the model behind
   several of Genesis's free reasoning/extraction/tagging steps) on 2026-08-16, so
   those steps now use Groq's recommended replacement, gpt-oss-120b. Structured-output

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -215,6 +215,26 @@ verified: 5dcd9fd4 2026-08-07
   autonomous/dispatched session's `follow_up_create` (source=`ego_dispatch`) is routed to
   the cold `tabled` lane, never the hot board (`mcp/health/follow_up_tools.py`).
 
+- **Secure-by-default MCP scoping (ALL autonomous sessions)** — `CCInvocation.
+  strict_mcp_config` defaults to **True** (`cc/types.py`), so `--mcp-config` is
+  authoritative and the operator's user-scoped `~/.claude.json` servers (additive
+  without strict — probe-verified 2026-08-09) never leak into a background session.
+  `_build_args` suppresses the flag under `--bare` (bare+strict exits non-zero,
+  probe-verified). This is the class fix behind the reflection lockdown above:
+  ~15 autonomous `CCInvocation` sites (reflection, sentinel, inbox/mail, direct_session,
+  ego cycle, autonomy executor/research) were leaking user-scoped MCP write tools.
+  Foreground/interactive sites (`cc/conversation.py` ×3, `cc/checkpoint.py`) opt out
+  with `strict_mcp_config=False` to keep the full toolset; a forgotten site fails
+  closed (zero MCP), never open. The weekly reflection arms
+  (`run_weekly_assessment`/`run_quality_calibration`) now route through the shared
+  `_reflection_lockdown_kwargs` helper alongside `_reflect_inner` (they previously ran
+  unrestricted). `autonomy/executor/step_dispatcher` pins CODE/VERIFICATION steps to
+  the genesis-only `reflection` MCP profile (keeps memory/health, drops the
+  arbitrary-source-edit servers; code edits flow through the audited Write/Edit
+  built-ins). Defense-in-depth: `_USER_SCOPED_MCP_WILDCARDS` denied by name in
+  `_UNIVERSAL_DISALLOW` + the reflection denylist. Guards:
+  `tests/test_cc/test_mcp_strict_default.py`, `tests/test_cc/test_invoker.py`.
+
 - `cc/direct_session.py` + `cc/conversation.py` (both >1000 LOC; split
   candidates). Profile machinery: `PROFILES`, `_PROFILE_ADDENDA`,
   `_PROFILE_SKILLS`, `_PROFILE_TO_MCP` (direct_session.py) +

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -194,7 +194,7 @@ any task bigger than an LLM call.
 ```yaml subsystem-map
 entry: execution-cc
 modules: [cc]
-verified: 5dcd9fd4 2026-08-07
+verified: 437c56c0 2026-08-09
 ```
 
 - **Reflection tool lockdown — read-only + observations only**

--- a/src/genesis/autonomy/executor/step_dispatcher.py
+++ b/src/genesis/autonomy/executor/step_dispatcher.py
@@ -188,6 +188,38 @@ class StepDispatcher:
             else CCModel.SONNET
         )
 
+        # Secure-by-default MCP scoping. strict_mcp_config defaults to True, so
+        # --mcp-config is authoritative. CODE steps run in the worktree cwd (where
+        # project-scoped genesis + serena servers would otherwise load); VERIFICATION
+        # runs in background_session_dir. Pin both to the genesis-only "reflection"
+        # profile so strict drops the user-scoped serena/gitnexus/codebase-memory
+        # servers. build_mcp_config loads servers WHOLESALE, so also pass the MCP
+        # portion of the reflection denylist: this DENIES the write/admin genesis
+        # tools (settings_update — which could disable the autonomous approval gate —
+        # ego_directive, campaign_*, module_call, direct_session_run, task_submit,
+        # memory_store, knowledge_ingest, …) while KEEPING genesis READ tools and the
+        # built-ins (Bash/Write/Edit) that code steps need. Built-ins are unaffected by
+        # strict; code edits still flow through the audited Edit/Write PreToolUse hooks.
+        # Mirrors research.py/DirectSession (never mcp_config without a denylist).
+        # Non-code steps get no MCP: strict with no config → zero servers (probe-verified).
+        step_mcp_config: str | None = None
+        step_disallowed: list[str] | None = None
+        if is_code_or_verify:
+            try:
+                from genesis.cc.session_config import SessionConfigBuilder
+
+                _scb = SessionConfigBuilder()
+                step_mcp_config = _scb.build_mcp_config("reflection")
+                step_disallowed = [
+                    t for t in _scb.build_reflection_disallowed() if t.startswith("mcp__")
+                ]
+            except Exception:
+                logger.debug(
+                    "step MCP config build failed; running with no MCP", exc_info=True
+                )
+                step_mcp_config = None
+                step_disallowed = None
+
         invocation = CCInvocation(
             prompt=prompt,
             expect_output=True,  # silent-cap detection (step needs a result)
@@ -195,6 +227,8 @@ class StepDispatcher:
             effort=effort,
             timeout_s=step_type.default_timeout_s,
             skip_permissions=True,
+            mcp_config=step_mcp_config,
+            disallowed_tools=step_disallowed,
             working_dir=working_dir,
         )
 

--- a/src/genesis/cc/checkpoint.py
+++ b/src/genesis/cc/checkpoint.py
@@ -38,6 +38,11 @@ class CheckpointManager:
             prompt=response_text, resume_session_id=session_id,
             skip_permissions=True,
             working_dir=background_session_dir(),
+            # This resumes a checkpointed owner-attended conversation (QUESTION/
+            # DECISION/ERROR the user answered). Opt OUT of secure-by-default
+            # strict MCP scoping so the resumed session keeps the same full
+            # toolset it had originally — the flip must not silently strip it.
+            strict_mcp_config=False,
         )
         output = await self._invoker.run(invocation)
         if output.is_error:

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -276,6 +276,10 @@ class ConversationLoop:
                 # WS-3 B4: owner-attended interactive conversation — spare it
                 # from the gate-4 pushed-surfaces enforce drop.
                 supervised=True,
+                # Owner-attended interactive session: keep the full user-scoped
+                # MCP toolset. Opt OUT of secure-by-default strict scoping
+                # (see CCInvocation.strict_mcp_config).
+                strict_mcp_config=False,
                 **resume_overrides,
             )
 
@@ -580,6 +584,10 @@ class ConversationLoop:
                 # WS-3 B4: owner-attended interactive conversation — spare it
                 # from the gate-4 pushed-surfaces enforce drop.
                 supervised=True,
+                # Owner-attended interactive session: keep the full user-scoped
+                # MCP toolset. Opt OUT of secure-by-default strict scoping
+                # (see CCInvocation.strict_mcp_config).
+                strict_mcp_config=False,
                 **resume_overrides,
             )
 
@@ -857,6 +865,10 @@ class ConversationLoop:
             roster_eligible=True,  # fresh retry stays roster-routable (no resume)
             # WS-3 B4: owner-attended interactive conversation (fresh retry).
             supervised=True,
+            # Owner-attended interactive session: keep the full user-scoped MCP
+            # toolset. Opt OUT of secure-by-default strict scoping
+            # (see CCInvocation.strict_mcp_config).
+            strict_mcp_config=False,
         )
 
     @staticmethod

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -1332,6 +1332,14 @@ class DirectSessionRunner:
         # observe/research get health + memory only.
         mcp_profile = _PROFILE_TO_MCP.get(request.profile, "reflection")
         mcp_config = self._config_builder.build_mcp_config(profile=mcp_profile)
+        # Secure-by-default: strict_mcp_config (CCInvocation default True) makes the
+        # generated --mcp-config authoritative, dropping the user-scoped ~/.claude.json
+        # servers. Honor an EXPLICIT mcp_profile="full" (a deliberate, trusted
+        # install-local overlay choice — build_mcp_config returns None there so CC uses
+        # its full default config) by opting that dispatch OUT of strict: "full" must
+        # mean full. Every other profile stays strict, so a None returned for an
+        # unknown/failed profile fails CLOSED to zero servers (never a silent full-leak).
+        strict_mcp = mcp_profile != "full"
 
         # Prepend planning instruction if the caller opted in.
         prompt = request.prompt
@@ -1393,6 +1401,7 @@ class DirectSessionRunner:
             origin=_PROFILE_ORIGIN.get(request.profile),
             claude_code_tmpdir=_bg_session_sandbox(session_id),
             mcp_config=mcp_config,
+            strict_mcp_config=strict_mcp,
             bash_allowlist=_PROFILE_BASH_ALLOWLIST.get(request.profile, ()),
             roster_eligible=roster_eligible,
             **routing,

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING
 
 from genesis.cc import rate_limit_park, roster
 from genesis.cc.exceptions import CCQuotaExhaustedError, CCRateLimitError
+from genesis.cc.session_config import _USER_SCOPED_MCP_WILDCARDS
 from genesis.cc.types import (
     CCInvocation,
     CCModel,
@@ -151,6 +152,16 @@ _UNIVERSAL_DISALLOW = [
     "mcp__genesis-memory__knowledge_ingest",
     "mcp__genesis-memory__knowledge_ingest_batch",
     "mcp__genesis-memory__knowledge_ingest_source",
+    # ── User-scoped MCP servers (defense-in-depth) ────────────────
+    # strict_mcp_config (CCInvocation default True) already drops these by making
+    # --mcp-config authoritative; deny them by name too so a site that opts out of
+    # strict — or a future CC scoping change — still can't reach their
+    # arbitrary-source-edit / graph-mutation tools (serena replace_symbol_body,
+    # gitnexus rename, codebase-memory delete_project), which bypass the Edit/Write
+    # PreToolUse hooks entirely. NOT exhaustive (a NEW user-scoped server wouldn't be
+    # listed) — strict is the categorical guarantee; this is belt-and-suspenders.
+    # Shared with build_reflection_disallowed via _USER_SCOPED_MCP_WILDCARDS.
+    *_USER_SCOPED_MCP_WILDCARDS,
 ]
 
 _NO_OUTREACH_SEND = [

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -343,7 +343,12 @@ class CCInvoker:
             args += ["--resume", inv.resume_session_id]
         if inv.mcp_config:
             args += ["--mcp-config", inv.mcp_config]
-        if inv.strict_mcp_config:
+        # --bare already disables ALL MCP discovery; combining it with
+        # --strict-mcp-config makes CC exit non-zero (probe-verified, CC 2.1.x),
+        # so skip strict under bare. strict is safe with any other config state:
+        # with a --mcp-config it pins to those servers; with none it yields zero
+        # servers cleanly (probe-verified) — the secure-by-default posture.
+        if inv.strict_mcp_config and not inv.bare:
             args.append("--strict-mcp-config")
         # Register the span-capture PostToolUse hook for this dispatched session.
         # Dispatched sessions run with a cwd outside any git repo, so CC never

--- a/src/genesis/cc/reflection_bridge/_bridge.py
+++ b/src/genesis/cc/reflection_bridge/_bridge.py
@@ -66,6 +66,55 @@ _DOWNGRADE_RETRY_BACKOFF_S = 30
 
 _DEFAULT_PROMPT_DIR = Path(__file__).resolve().parent.parent.parent / "identity"
 
+
+def _reflection_lockdown_kwargs(mcp_profile: str) -> dict:
+    """Read-only reflection tool lockdown as CCInvocation kwargs.
+
+    Every reflection entry point (the depth-based ``_reflect_inner`` path, the weekly
+    self-assessment, and the quality-calibration arm) MUST route through this so no
+    arm silently runs unrestricted. Returns a genesis-only ``mcp_config`` (the given
+    profile), the derived read-only ``disallowed_tools`` denylist, and
+    ``strict_mcp_config=True`` so ``--mcp-config`` is authoritative (user-scoped
+    ``~/.claude.json`` servers never leak in — verified additive without strict).
+
+    Fail-closed: on any config-generation error, points ``mcp_config`` at the shipped
+    empty ``config/no_mcp.json`` (never None — avoids the untested bare-strict combo)
+    and denies the built-ins + both reflection MCP servers wholesale.
+    """
+    from genesis.cc.session_config import SessionConfigBuilder
+
+    try:
+        _mcp = SessionConfigBuilder()
+        mcp_path = _mcp.build_mcp_config(mcp_profile)
+        reflection_disallowed = _mcp.build_reflection_disallowed()
+        # Fail-closed: never leave mcp_config None under strict (see docstring).
+        if mcp_path is None:
+            mcp_path = _mcp.build_mcp_config("none")
+    except Exception:
+        logger.warning(
+            "Reflection MCP/tool config generation failed, using fail-closed defaults",
+            exc_info=True,
+        )
+        from genesis.cc.session_config import (
+            _REFLECTION_DENY_BUILTINS,
+            _REFLECTION_MCP_SERVERS,
+        )
+        from genesis.env import repo_root
+
+        try:
+            mcp_path = str(repo_root() / "config" / "no_mcp.json")
+        except Exception:
+            mcp_path = None  # last resort; strict_mcp_config still forces zero servers
+        reflection_disallowed = list(_REFLECTION_DENY_BUILTINS) + [
+            f"mcp__{server}__*" for server, _ in _REFLECTION_MCP_SERVERS
+        ]
+    return {
+        "mcp_config": mcp_path,
+        "disallowed_tools": reflection_disallowed,
+        "strict_mcp_config": True,
+    }
+
+
 _DEPTH_AUTONOMY_LEVEL = {
     Depth.LIGHT: 1,
     Depth.DEEP: 2,
@@ -256,55 +305,16 @@ class CCReflectionBridge:
             prompt_dir=self._prompt_dir,
         )
 
-        # 2. Prepare CLI invocation
-        try:
-            from genesis.cc.session_config import SessionConfigBuilder
-
-            _mcp = SessionConfigBuilder()
-            if depth == Depth.LIGHT:
-                mcp_path = _mcp.build_mcp_config("none")
-            elif depth in (Depth.DEEP, Depth.STRATEGIC):
-                mcp_path = _mcp.build_mcp_config("reflection")
-            else:
-                mcp_path = None
-            # Reflection sessions are READ-ONLY + observation-writing only. The
-            # denylist is the reliable scoping mechanism: --allowedTools is NOT a
-            # strict allowlist under --dangerously-skip-permissions (verified
-            # empirically 2026-08-07 — it left Bash available). Derived so future
-            # write tools are auto-denied; see build_reflection_disallowed.
-            reflection_disallowed = _mcp.build_reflection_disallowed()
-            # Fail-closed: if reflection MCP-config generation returned None, use the
-            # EMPTY config so strict_mcp_config (below) can't fall through to CC's
-            # default (user-scoped) MCP discovery — which would load servers (e.g.
-            # gitnexus, codebase-memory-mcp) whose write tools the genesis-only denylist
-            # does NOT cover.
-            if mcp_path is None:
-                mcp_path = _mcp.build_mcp_config("none")
-        except Exception:
-            logger.warning(
-                "MCP/tool config generation failed, using fail-closed defaults",
-                exc_info=True,
-            )
-            # Fail closed: point at the EMPTY MCP config (with strict_mcp_config no other
-            # server can load) AND reuse the full built-in denylist + wildcard MCP denies
-            # (single source of truth — no drift from a hand-maintained literal).
-            from genesis.cc.session_config import (
-                _REFLECTION_DENY_BUILTINS,
-                _REFLECTION_MCP_SERVERS,
-            )
-            from genesis.env import repo_root
-
-            # Resolve the shipped empty MCP config by PATH (no dependency on the
-            # config builder succeeding), so mcp_config is a real empty config rather
-            # than None — avoids relying on the untested "--strict-mcp-config with no
-            # --mcp-config" combination.
-            try:
-                mcp_path = str(repo_root() / "config" / "no_mcp.json")
-            except Exception:
-                mcp_path = None  # last resort; strict_mcp_config still forces zero servers
-            reflection_disallowed = list(_REFLECTION_DENY_BUILTINS) + [
-                f"mcp__{server}__*" for server, _ in _REFLECTION_MCP_SERVERS
-            ]
+        # 2. Prepare CLI invocation. Read-only tool lockdown via the shared helper
+        # (single source of truth for ALL reflection entry points — this path plus
+        # the weekly-assessment and quality-calibration arms). LIGHT loads no MCP;
+        # DEEP/STRATEGIC load the genesis-only "reflection" profile. The helper
+        # derives the read-only denylist and sets strict so user-scoped
+        # ~/.claude.json servers can't leak in (--mcp-config is additive without it).
+        _reflection_profile = (
+            "reflection" if depth in (Depth.DEEP, Depth.STRATEGIC) else "none"
+        )
+        _lockdown = _reflection_lockdown_kwargs(_reflection_profile)
         invocation = CCInvocation(
             prompt=prompt,
             expect_output=True,  # silent-cap detection (reflection always emits text)
@@ -313,12 +323,9 @@ class CCReflectionBridge:
             timeout_s=_DEPTH_TIMEOUT_S.get(depth, 300),
             system_prompt=self._system_prompt_for_depth(depth),
             skip_permissions=True,
-            disallowed_tools=reflection_disallowed,
-            mcp_config=mcp_path,
-            # ONLY the reflection MCP config's servers load — NOT the user-scoped
-            # servers in ~/.claude.json (--mcp-config is additive without this). Makes
-            # the genesis-only derived denylist authoritative. (Matches eval bench arms.)
-            strict_mcp_config=True,
+            disallowed_tools=_lockdown["disallowed_tools"],
+            mcp_config=_lockdown["mcp_config"],
+            strict_mcp_config=_lockdown["strict_mcp_config"],
             working_dir=background_session_dir(),
             stream_idle_timeout_ms=(
                 _DEPTH_TIMEOUT_S.get(depth, 300) * 1000
@@ -605,6 +612,9 @@ class CCReflectionBridge:
             "Evaluate each of the 6 dimensions using this data."
         )
 
+        # Read-only reflection lockdown (shared with _reflect_inner + calibration):
+        # genesis health+memory read tools only, strict scoping, no user-scoped leak.
+        _lockdown = _reflection_lockdown_kwargs("reflection")
         invocation = CCInvocation(
             prompt=prompt,
             expect_output=True,  # silent-cap detection (weekly assessment output)
@@ -612,6 +622,9 @@ class CCReflectionBridge:
             effort=EffortLevel.HIGH,
             system_prompt=load_prompt_file("SELF_ASSESSMENT.md", self._prompt_dir),
             skip_permissions=True,
+            disallowed_tools=_lockdown["disallowed_tools"],
+            mcp_config=_lockdown["mcp_config"],
+            strict_mcp_config=_lockdown["strict_mcp_config"],
             working_dir=background_session_dir(),
         )
         output = await self._invoker.run(invocation)
@@ -682,6 +695,9 @@ class CCReflectionBridge:
             "Evaluate quality drift and identify quarantine candidates."
         )
 
+        # Read-only reflection lockdown (shared with _reflect_inner + assessment):
+        # genesis health+memory read tools only, strict scoping, no user-scoped leak.
+        _lockdown = _reflection_lockdown_kwargs("reflection")
         invocation = CCInvocation(
             prompt=prompt,
             expect_output=True,  # silent-cap detection (quality calibration output)
@@ -689,6 +705,9 @@ class CCReflectionBridge:
             effort=EffortLevel.HIGH,
             system_prompt=load_prompt_file("QUALITY_CALIBRATION.md", self._prompt_dir),
             skip_permissions=True,
+            disallowed_tools=_lockdown["disallowed_tools"],
+            mcp_config=_lockdown["mcp_config"],
+            strict_mcp_config=_lockdown["strict_mcp_config"],
             working_dir=background_session_dir(),
         )
         output = await self._invoker.run(invocation)

--- a/src/genesis/cc/session_config.py
+++ b/src/genesis/cc/session_config.py
@@ -85,6 +85,19 @@ _REFLECTION_DENY_BUILTINS: tuple[str, ...] = (
     "EnterWorktree", "ExitWorktree",
 )
 
+# User/project-scoped MCP servers that CC discovers from ~/.claude.json (+ the
+# repo's .mcp.json at repo cwd): arbitrary-source-edit / graph-mutation tools that
+# bypass the Edit/Write PreToolUse hooks. strict_mcp_config (CCInvocation default
+# True) drops them categorically by making --mcp-config authoritative; these
+# by-name wildcard denies are defense-in-depth for any path that opts out of strict
+# or a future CC scoping change. Shared by build_reflection_disallowed and
+# direct_session._UNIVERSAL_DISALLOW so the two can't drift.
+_USER_SCOPED_MCP_WILDCARDS: tuple[str, ...] = (
+    "mcp__serena__*",
+    "mcp__gitnexus__*",
+    "mcp__codebase-memory-mcp__*",
+)
+
 
 def _registered_mcp_tool_names(modpath: str) -> list[str]:
     """Tool names registered on a FastMCP server module's ``mcp`` object.
@@ -155,7 +168,11 @@ class SessionConfigBuilder:
         (``mcp__<server>__*``) — fail-closed: observations still flow through the
         parsed ``observations`` output field, and no write tool can leak.
         """
-        disallowed: list[str] = list(_REFLECTION_DENY_BUILTINS)
+        # Base = write/action built-ins + user-scoped MCP wildcards (defense-in-depth;
+        # strict_mcp_config already drops the latter categorically).
+        disallowed: list[str] = list(_REFLECTION_DENY_BUILTINS) + list(
+            _USER_SCOPED_MCP_WILDCARDS
+        )
         try:
             for server, modpath in _REFLECTION_MCP_SERVERS:
                 for name in _registered_mcp_tool_names(modpath):
@@ -169,9 +186,11 @@ class SessionConfigBuilder:
                 "this is fixed, but no write tool can leak.",
                 exc_info=True,
             )
-            disallowed = list(_REFLECTION_DENY_BUILTINS) + [
-                f"mcp__{server}__*" for server, _ in _REFLECTION_MCP_SERVERS
-            ]
+            disallowed = (
+                list(_REFLECTION_DENY_BUILTINS)
+                + list(_USER_SCOPED_MCP_WILDCARDS)
+                + [f"mcp__{server}__*" for server, _ in _REFLECTION_MCP_SERVERS]
+            )
         return disallowed
 
     def build_reflection_config(self, depth: str = "deep") -> dict:

--- a/src/genesis/cc/types.py
+++ b/src/genesis/cc/types.py
@@ -253,8 +253,18 @@ class CCInvocation:
     # (probe-verified 2026-07-09). Built-in tools remain available.
     safe_mode: bool = False
     # --strict-mcp-config: CC honors ONLY the servers in --mcp-config, ignoring
-    # user/project-scope MCP configs. Without it, mcp_config is additive.
-    strict_mcp_config: bool = False
+    # user/project-scope MCP configs. Without it, mcp_config is additive — CC
+    # merges in the user-scoped ~/.claude.json servers (gitnexus, codebase-memory,
+    # the claude.ai connectors) and, at repo cwd, project-scoped serena, none of
+    # which any Genesis denylist names. So the default is SECURE-BY-DEFAULT (True):
+    # every session gets --strict-mcp-config unless it opts out. Human-driven
+    # foreground/interactive sessions that legitimately want the full user-scoped
+    # toolset set strict_mcp_config=False explicitly (see cc/conversation.py,
+    # cc/checkpoint.py). A site that forgets fails CLOSED (loses the additive
+    # servers), never open. Pair strict with a real --mcp-config path (a genesis
+    # profile, or config/no_mcp.json for zero servers) — bare strict with no
+    # --mcp-config is an undocumented CC combination; avoid it.
+    strict_mcp_config: bool = True
     append_system_prompt: bool = False
     stream_idle_timeout_ms: int | None = None
     # Headless CC (-p) waits for dispatched background Workflow/subagent tasks

--- a/tests/test_cc/test_invoker.py
+++ b/tests/test_cc/test_invoker.py
@@ -72,9 +72,29 @@ def test_build_args_strict_mcp_config(invoker):
     )
     args = invoker._build_args(inv)
     assert "--strict-mcp-config" in args
-    # Default stays additive: flag absent unless opted in.
-    default_args = invoker._build_args(CCInvocation(prompt="hello"))
-    assert "--strict-mcp-config" not in default_args
+
+
+def test_build_args_strict_is_default(invoker):
+    """Secure-by-default: a plain invocation emits --strict-mcp-config so
+    --mcp-config is authoritative and user-scoped ~/.claude.json servers can't
+    leak in. (Flipped from opt-in on 2026-08-09; see CCInvocation.strict_mcp_config.)"""
+    args = invoker._build_args(CCInvocation(prompt="hello"))
+    assert "--strict-mcp-config" in args
+
+
+def test_build_args_strict_opt_out(invoker):
+    """Foreground/interactive sites opt out to keep the full user-scoped toolset."""
+    args = invoker._build_args(CCInvocation(prompt="hello", strict_mcp_config=False))
+    assert "--strict-mcp-config" not in args
+
+
+def test_build_args_strict_suppressed_under_bare(invoker):
+    """--bare already disables all MCP; --bare + --strict-mcp-config makes CC exit
+    non-zero (probe-verified), so the invoker must NOT emit strict under bare even
+    when strict_mcp_config is True (which is the default)."""
+    args = invoker._build_args(CCInvocation(prompt="hello", bare=True, strict_mcp_config=True))
+    assert "--bare" in args
+    assert "--strict-mcp-config" not in args
 
 
 def test_build_args_safe_mode(invoker):

--- a/tests/test_cc/test_mcp_strict_default.py
+++ b/tests/test_cc/test_mcp_strict_default.py
@@ -1,0 +1,182 @@
+"""Secure-by-default MCP scoping for autonomous CC sessions (follow-up a8f15c94).
+
+Claude Code's ``--mcp-config`` is ADDITIVE: without ``--strict-mcp-config`` a session
+also loads the user-scoped ``~/.claude.json`` MCP servers (gitnexus, codebase-memory,
+serena at repo cwd) — arbitrary-source-edit / graph-mutation tools that bypass the
+Edit/Write PreToolUse hooks. The fix flips ``CCInvocation.strict_mcp_config`` to default
+True (secure-by-default); human-driven foreground/interactive sites opt out. These tests
+pin that contract and guard the regressions that keep reopening (a new autonomous site
+forgetting strict; a reflection arm bypassing the shared lockdown).
+
+Empirical basis (probe-verified 2026-08-09, CC 2.1.x): strict + genesis config → only
+those servers; strict + no config → zero servers, exit 0; ``--bare`` + strict → exit 1.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+from genesis.cc.direct_session import _UNIVERSAL_DISALLOW
+from genesis.cc.session_config import (
+    _USER_SCOPED_MCP_WILDCARDS,
+    SessionConfigBuilder,
+)
+from genesis.cc.types import CCInvocation
+
+_SRC = pathlib.Path(__file__).resolve().parents[2] / "src" / "genesis"
+
+
+def test_ccinvocation_strict_mcp_config_default_true():
+    """The flip: a plain invocation is strict by default (fail-closed to no leak)."""
+    assert CCInvocation(prompt="x").strict_mcp_config is True
+
+
+def test_user_scoped_wildcards_nonempty_and_shared_no_drift():
+    """The user-scoped denies are one shared constant, present in BOTH the DirectSession
+    universal denylist and the reflection denylist — so the two can't drift apart."""
+    assert _USER_SCOPED_MCP_WILDCARDS  # non-empty
+    assert set(_USER_SCOPED_MCP_WILDCARDS) <= set(_UNIVERSAL_DISALLOW)
+    refl = set(SessionConfigBuilder().build_reflection_disallowed())
+    assert set(_USER_SCOPED_MCP_WILDCARDS) <= refl
+    # Sanity: the three known user-scoped servers are covered by wildcard.
+    assert {"mcp__serena__*", "mcp__gitnexus__*", "mcp__codebase-memory-mcp__*"} <= set(
+        _USER_SCOPED_MCP_WILDCARDS
+    )
+
+
+def test_reflection_lockdown_kwargs_is_read_only():
+    """The shared reflection helper yields strict + a real config + a denylist that
+    denies writes/user-scoped servers but keeps observation_write."""
+    import genesis.cc.reflection_bridge._bridge as bridge
+
+    lk = bridge._reflection_lockdown_kwargs("reflection")
+    assert lk["strict_mcp_config"] is True
+    assert lk["mcp_config"]  # never None (avoids the bare-strict combo)
+    denied = set(lk["disallowed_tools"])
+    assert {"mcp__serena__*", "mcp__gitnexus__*", "mcp__codebase-memory-mcp__*"} <= denied
+    assert "mcp__genesis-health__follow_up_create" in denied
+    assert "Bash" in denied and "Write" in denied and "Task" in denied
+    assert "mcp__genesis-memory__observation_write" not in denied
+
+
+def test_reflection_lockdown_none_profile_points_at_no_mcp():
+    """LIGHT / fail-closed profile still supplies a real empty config (never None)."""
+    import genesis.cc.reflection_bridge._bridge as bridge
+
+    lk = bridge._reflection_lockdown_kwargs("none")
+    assert str(lk["mcp_config"]).endswith("no_mcp.json")
+    assert lk["strict_mcp_config"] is True
+
+
+def _functions_containing_ccinvocation(path: pathlib.Path) -> dict[str, str]:
+    """Map function name -> source, for every function whose body constructs a
+    CCInvocation."""
+    src = path.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    out: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            continue
+        for sub in ast.walk(node):
+            if (
+                isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Name)
+                and sub.func.id == "CCInvocation"
+            ):
+                out[node.name] = ast.get_source_segment(src, node) or ""
+                break
+    return out
+
+
+def test_all_reflection_arms_use_the_lockdown_helper():
+    """Every reflection entry point that builds a CCInvocation MUST route through
+    _reflection_lockdown_kwargs — this is the guard that keeps a NEW arm (like the
+    weekly-assessment / quality-calibration gap in PR #1343) from silently running
+    unrestricted."""
+    bridge = _SRC / "cc" / "reflection_bridge" / "_bridge.py"
+    funcs = _functions_containing_ccinvocation(bridge)
+    assert funcs, "expected reflection CCInvocation construction sites"
+    offenders = [name for name, body in funcs.items() if "_reflection_lockdown_kwargs" not in body]
+    assert not offenders, (
+        "reflection functions build a CCInvocation without the shared read-only "
+        f"lockdown helper (they would run unrestricted): {offenders}"
+    )
+
+
+def test_step_dispatcher_code_denylist_recipe_denies_admin_keeps_reads_and_builtins():
+    """The exact denylist recipe step_dispatcher applies to CODE/VERIFICATION steps —
+    the MCP portion of build_reflection_disallowed — must DENY the write/admin genesis
+    MCP tools (a code step must not be able to disable the autonomous approval gate via
+    settings_update, or call ego_directive/campaign_*/memory_store) and the user-scoped
+    servers, while KEEPING the genesis READ tools and the built-ins (Bash/Write/Edit)
+    that code steps need. This is the behavioral guard behind the source-wiring check."""
+    recipe = [
+        t for t in SessionConfigBuilder().build_reflection_disallowed() if t.startswith("mcp__")
+    ]
+    must_deny = {
+        "mcp__genesis-health__settings_update",
+        "mcp__genesis-health__ego_directive",
+        "mcp__genesis-health__campaign_create",
+        "mcp__genesis-health__module_call",
+        "mcp__genesis-health__direct_session_run",
+        "mcp__genesis-health__task_submit",
+        "mcp__genesis-memory__memory_store",
+        "mcp__genesis-memory__knowledge_ingest",
+        "mcp__serena__*",
+        "mcp__gitnexus__*",
+        "mcp__codebase-memory-mcp__*",
+    }
+    assert must_deny <= set(recipe), f"recipe fails to deny: {must_deny - set(recipe)}"
+    # Genesis reads stay available (a code step may recall context).
+    for read_tool in (
+        "mcp__genesis-health__health_status",
+        "mcp__genesis-memory__memory_recall",
+    ):
+        assert read_tool not in recipe
+    # Built-ins are NOT in the mcp-only recipe → code steps keep Bash/Write/Edit/Task.
+    for builtin in ("Bash", "Write", "Edit", "Task"):
+        assert builtin not in recipe
+
+
+def test_step_dispatcher_wires_mcp_config_and_denylist_together():
+    """Source guard: CODE/VERIFICATION steps must pass BOTH a genesis mcp_config AND a
+    disallowed_tools denylist (mcp_config without a denylist was the review BLOCKER —
+    it exposed the full genesis-health admin surface). Gated on is_code_or_verify."""
+    src = (_SRC / "autonomy" / "executor" / "step_dispatcher.py").read_text(encoding="utf-8")
+    assert "is_code_or_verify" in src
+    assert "step_mcp_config = " in src and "build_mcp_config" in src
+    assert "step_disallowed = " in src and "build_reflection_disallowed" in src
+    assert 'startswith("mcp__")' in src  # MCP-only filter (keeps built-ins)
+    assert "mcp_config=step_mcp_config" in src
+    assert "disallowed_tools=step_disallowed" in src
+
+
+def _count_ccinvocations_with_false_strict(path: pathlib.Path) -> int:
+    """Count CCInvocation(...) calls that pass strict_mcp_config=False (AST, so an
+    unrelated assignment elsewhere in the file can't satisfy it)."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    n = 0
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "CCInvocation"
+        ):
+            for kw in node.keywords:
+                if (
+                    kw.arg == "strict_mcp_config"
+                    and isinstance(kw.value, ast.Constant)
+                    and kw.value.value is False
+                ):
+                    n += 1
+    return n
+
+
+def test_foreground_interactive_sites_opt_out_of_strict():
+    """Owner-attended interactive paths keep the full user-scoped toolset — the three
+    conversation CCInvocation sites + the checkpoint resume MUST set
+    strict_mcp_config=False so the secure-by-default flip doesn't silently strip the
+    user's tools mid-conversation. AST-based so a stray literal can't satisfy it."""
+    assert _count_ccinvocations_with_false_strict(_SRC / "cc" / "conversation.py") >= 3
+    assert _count_ccinvocations_with_false_strict(_SRC / "cc" / "checkpoint.py") >= 1

--- a/tests/test_cc/test_mcp_strict_default.py
+++ b/tests/test_cc/test_mcp_strict_default.py
@@ -16,8 +16,15 @@ from __future__ import annotations
 
 import ast
 import pathlib
+from unittest.mock import MagicMock
 
-from genesis.cc.direct_session import _UNIVERSAL_DISALLOW
+import genesis.cc.direct_session as direct_session
+from genesis.cc.direct_session import (
+    _PROFILE_TO_MCP,
+    _UNIVERSAL_DISALLOW,
+    DirectSessionRequest,
+    DirectSessionRunner,
+)
 from genesis.cc.session_config import (
     _USER_SCOPED_MCP_WILDCARDS,
     SessionConfigBuilder,
@@ -180,3 +187,43 @@ def test_foreground_interactive_sites_opt_out_of_strict():
     user's tools mid-conversation. AST-based so a stray literal can't satisfy it."""
     assert _count_ccinvocations_with_false_strict(_SRC / "cc" / "conversation.py") >= 3
     assert _count_ccinvocations_with_false_strict(_SRC / "cc" / "checkpoint.py") >= 1
+
+
+def test_directsession_builtin_profiles_never_map_to_full():
+    """No BUILT-IN DirectSession profile maps to the "full" MCP profile — every built-in
+    stays strict-scoped. (A built-in silently going "full" would reopen the leak for that
+    profile; only deliberate, trusted install-local overlays may choose "full".)"""
+    assert "full" not in set(_PROFILE_TO_MCP.values())
+
+
+def test_directsession_explicit_full_profile_opts_out_of_strict():
+    """Codex P2 regression guard: build_mcp_config("full") returns None (CC uses its full
+    default), so under the strict-by-default flip a profile that INTENDS full MCP would
+    silently get ZERO servers. _build_invocation must honor an explicit mcp_profile="full"
+    by opting that dispatch out of strict (full means full), while a concrete profile stays
+    strict. Behavioral: exercises the real _build_invocation with a real config builder."""
+    runner = DirectSessionRunner(
+        invoker=MagicMock(),
+        session_manager=MagicMock(),
+        config_builder=SessionConfigBuilder(),
+        runtime=MagicMock(),
+    )
+    # Concrete profile (observe -> reflection) stays strict with a real config.
+    inv_norm = runner._build_invocation(
+        DirectSessionRequest(profile="observe", prompt="hi"), "s-norm"
+    )
+    assert inv_norm.strict_mcp_config is True
+    assert inv_norm.mcp_config  # a real genesis-only config path
+
+    # Remap a valid profile to the "full" MCP profile (simulating a trusted overlay);
+    # the dispatch must opt OUT of strict so CC's full default config is honored.
+    orig = _PROFILE_TO_MCP["observe"]
+    try:
+        direct_session._PROFILE_TO_MCP["observe"] = "full"
+        inv_full = runner._build_invocation(
+            DirectSessionRequest(profile="observe", prompt="hi"), "s-full"
+        )
+    finally:
+        direct_session._PROFILE_TO_MCP["observe"] = orig
+    assert inv_full.strict_mcp_config is False
+    assert inv_full.mcp_config is None


### PR DESCRIPTION
## Why

Claude Code's `--mcp-config` flag is **additive**: unless `--strict-mcp-config` is also
passed, a session loads the servers in the config file *plus* the user-scoped servers from
`~/.claude.json` (and, at repo cwd, project-scoped ones). Genesis dispatches many autonomous
background CC sessions with a Genesis-only `--mcp-config` but **without** `--strict-mcp-config`,
so those sessions additively inherited the operator's user-scoped MCP servers (code-editing and
graph tools) — whose write operations (`replace_symbol_body`, coordinated `rename`,
`delete_project`, …) **bypass the `Edit`/`Write` PreToolUse hooks** entirely, since those hooks
match only the built-in `Edit`/`Write`/`NotebookEdit` tools.

`CCInvocation.strict_mcp_config` defaulted to `False`, so every autonomous site had to remember
to opt in — and most didn't. This is the class fix behind the reflection tool lockdown (#1343),
which addressed one path; ~15 autonomous `CCInvocation` sites had the same leak.

Empirically verified on Claude Code 2.1.x via the live `init`-event tool list:
- genesis config, no strict → user-scoped servers **load** (the leak).
- genesis config, `--strict-mcp-config` → **only** the config's servers load (the fix), exit 0.
- `--bare` + `--strict-mcp-config` → CC exits non-zero (hence the invoker suppresses strict under bare).

## What

- **`CCInvocation.strict_mcp_config` now defaults to `True`** (secure-by-default). `--mcp-config`
  becomes authoritative for every dispatched session; a site that forgets to scope itself fails
  **closed** (zero MCP), never open.
- **Invoker** suppresses `--strict-mcp-config` under `--bare` (they're mutually incompatible).
- **Foreground/interactive opt-outs**: the owner-attended conversation paths (`conversation.py` ×3)
  and the checkpoint resume (`checkpoint.py`) set `strict_mcp_config=False` — a human is driving,
  so the full toolset is legitimate; the flip must not silently strip it.
- **Reflection**: extracted a shared `_reflection_lockdown_kwargs` helper and applied it to **all
  three** reflection entry points. The weekly self-assessment and quality-calibration arms
  previously ran fully unrestricted (a gap left by #1343).
- **Autonomy executor**: CODE/VERIFICATION steps are pinned to the Genesis-only reflection MCP
  profile **and** paired with a denylist that drops the write/admin Genesis MCP tools (since
  `build_mcp_config` loads servers wholesale) while keeping Genesis read tools and the built-ins
  (`Bash`/`Write`/`Edit`) that code steps need. Code edits still flow through the audited
  `Edit`/`Write` hooks.
- **Defense-in-depth**: the user-scoped servers are also denied by name (a shared
  `_USER_SCOPED_MCP_WILDCARDS` constant) in the DirectSession universal denylist and the reflection
  denylist — belt-and-suspenders behind the categorical strict guarantee.

## Verification

- **Live init-event probe** (CC 2.1.x): strict-scoped sessions load only `genesis-health` +
  `genesis-memory` (zero user-scoped) even at repo cwd; the foreground opt-out preserves the full
  toolset. Real code paths emit the correct flags per session type (reflection / DirectSession /
  foreground / code-step), including code steps keeping their built-ins.
- **Tests**: `2117 passed / 2 skipped` across `test_cc` + `test_autonomy` + `test_reflection`;
  `126` targeted (new `test_mcp_strict_default.py` guards: strict-default, bare-guard, reflection
  arms all use the helper (AST), step-CODE denylist recipe, foreground opt-out (AST); updated
  `test_invoker.py`). ruff clean. Verify-RED confirmed on the bare-guard.

## Review

One review round (security lens). Codex was unavailable (models-manager parse error), so a Claude
reviewer was used per the documented fallback. It caught one BLOCKER — the code-step MCP config was
initially granted without a denylist, exposing the full `genesis-health` admin surface (incl.
`settings_update`); fixed by scoping it to the reflection denylist's MCP portion. All findings
resolved; one pre-existing sentinel fail-silent path tracked as a separate follow-up.

Follow-up: a8f15c94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
