### PR TITLE
feat(hooks): review-depth front-stop — substantial changes need an adversarial audit (PR-R1)

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -420,7 +420,14 @@ under-depth inline pass was self-certified as sufficient). The commit gate now
 COMPUTES substantiality from the staged diff
 (`review_scope.classify_change_substantiality`) and BLOCKS a substantial change
 whose review marker is not an ADVERSARIAL audit (`review_enforcement_commit.py`
-Rule 2.5). A precision-filtered "no findings" inline pass is FALSE CONFIDENCE for a
+Rule 2.5). Substantiality is a surface-area × risk model — ≥50 reviewable lines OR
+>1 code file OR an auth/api/migrations file OR an **executable prompt/agent/skill
+surface** (`.claude/agents|commands|skills/*`, `src/genesis/skills/*`), so the
+"Prompt / LLM behavior → both + extra scrutiny" row above is machine-enforced (a
+trivial edit to one is depth-audited). User-sovereign top-level CAPS docs
+(`SOUL.md`/`USER.md`/`CLAUDE.md`) are exempt. Clearance binds the marker to the
+reviewed diff's FULL content, so re-staging different content after the audit
+re-blocks. A precision-filtered "no findings" inline pass is FALSE CONFIDENCE for a
 substantial change — not clearance. Depth is override-exempt: a findings
 `# review-override` does NOT waive it; only a loud, logged `# depth-ack` does (the
 audited escape for a genuine format mismatch). "Adversarial" is verified

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -412,6 +412,40 @@ The enforcement hooks (`review_enforcement_prompt.py`,
 safety nets, not the decision-maker. This protocol provides the
 judgment framework.
 
+### Review depth is machine-checked (the front-stop)
+
+The "substantial → adversarial /review-level audit" decision above is no longer
+left to judgment alone (that judgment is exactly what failed on PR #1353 — an
+under-depth inline pass was self-certified as sufficient). The commit gate now
+COMPUTES substantiality from the staged diff
+(`review_scope.classify_change_substantiality`) and BLOCKS a substantial change
+whose review marker is not an ADVERSARIAL audit (`review_enforcement_commit.py`
+Rule 2.5). A precision-filtered "no findings" inline pass is FALSE CONFIDENCE for a
+substantial change — not clearance. Depth is override-exempt: a findings
+`# review-override` does NOT waive it; only a loud, logged `# depth-ack` does (the
+audited escape for a genuine format mismatch). "Adversarial" is verified
+STRUCTURALLY — a severity ladder (BLOCKER/SHOULD-FIX/NOTE, CRITICAL/HIGH/LOW,
+P1/P2/P3, or the CODE_AUDITOR JSON contract) + `file:line` engagement + substance —
+so run the real recall-tuned audit (`genesis-architect` / `CODE_AUDITOR.md`); do not
+hand-write a soft prompt.
+
+**Honest enforcement model — where the teeth actually are.** The local hook is
+ADVISORY anti-autopilot friction, NOT tamper-proof: on a single-user-authored repo
+the same actor can edit the hook or hand-write the marker. The enforcing teeth live
+where the author has no control at commit time — the **independent cloud reviewer
+(Codex)** + a **required human approval**, gated by **branch protection**, plus the
+CI `review-depth-check` that recomputes substantiality and flags it loudly on the PR
+(advisory, exit-0-always). The local gate's job is to interrupt autopilot; the real
+gate is external. Do not mistake a green local hook for clearance.
+
+**Close every review with a verdict.** End each review with an explicit
+`Ready to merge: Yes | No | With fixes` + a one-line reason, alongside the
+DONE / DONE_WITH_CONCERNS completion status. And the DON'Ts that keep a review
+honest: never "looks good" without reading the code; never a finding on code you
+did not read; never vague ("improve error handling") — always `file:line` + why it
+matters. (Deliberately NOT a "praise-first / acknowledge strengths" balance: an
+adversarial audit's job is to assume bugs and enumerate the class, not to reassure.)
+
 Two protocol steps apply to every review at "Code-reviewer inline" level or
 above (full definitions in `.claude/agents/genesis-architect.md`):
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -395,6 +395,30 @@ jobs:
       - name: CC↔Node pin-lockstep guard
         run: python scripts/check_cc_node_lockstep.py
 
+  review-depth-check:
+    # Advisory review-DEPTH visibility: recompute substantiality on the PR range
+    # (base...HEAD, so it needs full history — fetch-depth: 0) and emit a LOUD
+    # ::warning:: annotation when the change is substantial, so the human reviewer
+    # + the independent cloud reviewer apply an adversarial /review-level audit
+    # rather than a lean pass. Advisory BY DESIGN (exit 0 always): a committed audit
+    # artifact is forgeable and the local hook is editable by the same author, so
+    # the enforcing teeth are the independent reviewer + a required human approval
+    # (branch protection), not this check. Stdlib-only. See scripts/check_review_depth.py.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Review-depth advisory
+        env:
+          # Event base SHA (trusted-format) — robust vs origin/* ref materialization,
+          # matching the leak-detector job. Passed via env (not interpolated into run).
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: python scripts/check_review_depth.py
+
   test:
     runs-on: ubuntu-latest
     # CI is blocking — local full-suite runs are banned. See procedure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,29 @@ Cross-tool agent entry point (Codex, Cursor, OpenCode, …). The canonical
 project instructions live in **CLAUDE.md** — read it first; everything below
 is supplementary.
 
+## Code Review Mandate (adversarial)
+
+When reviewing a diff or PR (including automated PR review), review ADVERSARIALLY,
+not to confirm:
+
+- **Assume there are latent bugs and enumerate the CLASS.** For each concern, find
+  EVERY instance, not one example — edge/boundary/sentinel/hierarchy/error cases,
+  empty/None/zero/single-element inputs, rename/binary/unicode paths. A single
+  spot-check is not a review. Do not confidence-filter to "no findings"; a
+  precision-filtered "looks good" on a substantial change is false confidence.
+- **READ the authoritative semantics before judging domain code** (cgroup/systemd,
+  SQLite/WAL, async/cancellation, timezones, git plumbing, cryptography). Reason from
+  the spec/source, not assumption — assumption is what produces serial defects.
+- **Quote `file:line` for every finding**, state why it matters in THIS codebase, and
+  rank by real severity: **P1** (bug/security/data-loss) · **P2** (wrong under edge
+  conditions, missing handling) · **P3** (quality/nit). Generic advice ("validate
+  input") without a specific code path is not P1.
+- **Check the fix does not REMOVE constraints** (validation, guards, type enforcement)
+  and does not break existing behavior; a finding whose "fix" regresses something is
+  itself a finding. Verify claims against the code — a stated mechanism can be wrong
+  even when the concern is real.
+- **End with a verdict:** `Ready to merge: Yes | No | With fixes` + a one-line reason.
+
 ## GitNexus — Code Intelligence (advisory)
 
 This repo is indexed by GitNexus. The MCP tools (`impact`, `query`,

--- a/scripts/check_review_depth.py
+++ b/scripts/check_review_depth.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""CI review-depth advisory: recompute substantiality on the PR range and LOUDLY
+flag a substantial change so the human reviewer + the independent cloud reviewer
+apply adversarial depth.
+
+Advisory BY DESIGN. On a single-user-authored repo a committed audit artifact is
+forgeable and a local hook is editable by the same actor, so this check does NOT
+verify audit content and does NOT fail the build on its own. The enforcing teeth
+live where the PR author has no control: the independent cloud reviewer (Codex) +
+a REQUIRED human approval, gated by branch protection. This check's job is
+VISIBILITY — make "this is substantial → it needs an adversarial /review-level
+audit, not a lean pass" impossible to miss on the PR.
+
+Exit 0 ALWAYS (a fail-open advisory — an unexpected error must never fail the
+build). Emits a GitHub Actions ``::warning::`` annotation when the PR range
+classifies substantial, AND — critically — a DISTINCT warning when the range can't
+be computed (``unknown``), so a git error never masquerades as clearance. Reuses
+``review_scope`` (the SAME predicate as the commit gate) over ``base...HEAD``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+if _SCRIPT_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPT_DIR)
+
+
+def _ref_exists(ref: str, cwd: str | None) -> bool:
+    r = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", ref],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    return r.returncode == 0 and bool(r.stdout.strip())
+
+
+def _resolve_base(cwd: str | None = None) -> str | None:
+    """The base for the PR range. Prefer the event base SHA (``PR_BASE_SHA``, set from
+    ``github.event.pull_request.base.sha`` — robust vs whether ``origin/*`` tracking refs
+    are materialized, matching the hardened ``leak-detector`` job; a SHA is trusted-format,
+    not injectable). Fall back to ``origin/$GITHUB_BASE_REF`` then origin/main|master.
+    Returns a ref/SHA or None (→ caller skips, advisory)."""
+    sha = os.environ.get("PR_BASE_SHA", "").strip()
+    if sha and _ref_exists(sha, cwd):
+        return sha
+    base_ref = os.environ.get("GITHUB_BASE_REF", "").strip()
+    candidates = ([f"origin/{base_ref}"] if base_ref else []) + ["origin/main", "origin/master"]
+    for cand in candidates:
+        if _ref_exists(cand, cwd):
+            return cand
+    return None
+
+
+def _run(cwd: str | None) -> int:
+    from review_scope import classify_range_substantiality
+
+    base = _resolve_base(cwd)
+    if not base:
+        print("review-depth-check: no resolvable base — skipping (advisory).")
+        return 0
+    level = classify_range_substantiality(base, cwd=cwd)
+    if level == "substantial":
+        msg = (
+            "SUBSTANTIAL change: this PR needs an ADVERSARIAL /review-level audit "
+            "(assume bugs, enumerate the edge/boundary/sentinel/hierarchy class, read "
+            "authoritative semantics) — NOT a precision-filtered lean pass. A 'no "
+            "findings' inline review is false confidence, not clearance. Confirm the "
+            "independent reviewer (Codex) engaged and a human approved with depth."
+        )
+        print(f"::warning title=Review depth required::{msg}")
+        print(f"review-depth-check: SUBSTANTIAL (base {base}) — advisory, see annotation.")
+    elif level == "unknown":
+        # A git error / unreachable merge-base must NEVER read as clearance (that is the
+        # exact silent-false-inline this check exists to prevent). Fail LOUD, distinctly.
+        print(
+            "::warning title=Review depth: range not computable::Could NOT compute the PR "
+            f"range ({base}...HEAD) — do NOT treat this as clearance; classify depth "
+            "manually. (Is fetch-depth:0 set and the base reachable?)"
+        )
+        print(f"review-depth-check: UNKNOWN (base {base}) — range not computable.")
+    else:
+        print(f"review-depth-check: {level} (base {base}) — no adversarial-depth requirement.")
+    return 0
+
+
+def main(cwd: str | None = None) -> int:
+    try:
+        return _run(cwd)
+    except Exception as e:  # noqa: BLE001 - fail-open advisory: never fail the build
+        print(f"review-depth-check: skipped (unexpected error: {e}).")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_review_depth.py
+++ b/scripts/check_review_depth.py
@@ -92,6 +92,14 @@ def main(cwd: str | None = None) -> int:
     try:
         return _run(cwd)
     except Exception as e:  # noqa: BLE001 - fail-open advisory: never fail the build
+        # An unexpected import/classifier error must NOT read as clearance: a green job
+        # with no annotation is INDISTINGUISHABLE from "not substantial", the exact
+        # silent-false-inline this check exists to surface. Emit the same DISTINCT
+        # ::warning:: as an uncomputable range before exiting 0.
+        print(
+            "::warning title=Review depth: check errored::review-depth-check could NOT "
+            f"run ({e}) — do NOT treat this as clearance; classify depth manually."
+        )
         print(f"review-depth-check: skipped (unexpected error: {e}).")
         return 0
 

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -188,6 +188,20 @@ def _strip_trailing_comment(seg: str) -> str:
     return "".join(out)
 
 
+# The recognized ack/override sigils. A trailing comment may carry several of these
+# together (`# audit-ack depth-ack`), so the leading run of the comment is allowed to
+# contain any of them; the FIRST prose token ends the run. Kept in sync with the
+# sigils actually passed to has_trailing_override across the guard hooks.
+_KNOWN_SIGILS = ("review-override", "depth-ack", "audit-ack", "escalation-ack", "ci-override")
+
+
+def _token_is_sigil(tok: str, sigil: str) -> bool:
+    """Whether ``tok`` IS the sigil token — the sigil optionally followed by
+    punctuation (``review-override:``), but NOT a prefix of a longer word-token
+    (``review-override-x``)."""
+    return bool(re.match(re.escape(sigil) + r"(?![-\w])", tok))
+
+
 def _has_trailing_override(seg: str, sigil: str = "review-override") -> bool:
     """Whether the segment carries a genuine ``# <sigil>`` comment.
 
@@ -195,8 +209,15 @@ def _has_trailing_override(seg: str, sigil: str = "review-override") -> bool:
     so a token buried in a quoted message word does not count. ``sigil`` selects
     which override token to detect (``review-override`` by default; the CI-status
     merge gate passes ``ci-override``).
+
+    The sigil must appear in the LEADING contiguous run of recognized ack/override
+    tokens: `# review-override: accepted P2s` (sigil first, prose follows) and
+    `# audit-ack depth-ack` (a run of two sigils — each satisfies its own check)
+    both count, but `# not a review-override` / `# see review-override docs` do NOT
+    — a prose token ahead of the sigil ends the run. This keeps independent acks
+    able to coexist without letting an incidental or negated prose mention waive
+    the gate.
     """
-    token = re.compile(re.escape(sigil) + r"(?![-\w])")
     quote: str | None = None
     prev_ws = True
     i, n = 0, len(seg)
@@ -217,11 +238,13 @@ def _has_trailing_override(seg: str, sigil: str = "review-override") -> bool:
             i += 1
             continue
         if c == "#" and prev_ws:
-            rest = seg[i + 1 :].strip()
-            # The sigil must be the token, optionally followed by punctuation /
-            # comment text (`# review-override: accepted P2s`), but NOT be a
-            # prefix of a longer token (`review-override-x`, `review-overridexyz`).
-            return bool(token.match(rest))
+            for tok in seg[i + 1 :].split():
+                if _token_is_sigil(tok, sigil):
+                    return True  # the queried sigil, reached within the leading run
+                if not any(_token_is_sigil(tok, s) for s in _KNOWN_SIGILS):
+                    return False  # a prose token ends the leading run of sigils
+                # else: a DIFFERENT recognized sigil — still in the run, keep scanning
+            return False
         prev_ws = c.isspace()
         i += 1
     return False

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -79,6 +79,25 @@ def _commit_override(command: str, segs: list) -> str:
 _DOCS_CONFIG_EXTS = {".md", ".rst", ".txt", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
 _DOCS_CONFIG_BASENAMES = {"CHANGELOG", "LICENSE", ".GITIGNORE"}  # compared upper-cased
 
+# Executable prompt/agent/skill SURFACES: files whose content shapes autonomous LLM
+# behavior (agent + slash-command + skill definitions, and the in-repo skill library).
+# These are NEVER docs/config even when ``.md`` — an autonomous system editing its own
+# prompts is high-consequence (genesis-development SKILL.md requires prompt/LLM-behavior
+# changes to get adversarial review + a CI warning). User-sovereign top-level CAPS behavior
+# docs (SOUL.md, USER.md, CLAUDE.md) are deliberately NOT here: the user editing their own
+# behavior files is not gated (user sovereignty). Directory prefixes, `/`-normalized.
+_PROMPT_SURFACE_PREFIXES = (
+    ".claude/agents/",
+    ".claude/commands/",
+    ".claude/skills/",
+    "src/genesis/skills/",
+)
+
+
+def _is_prompt_surface(path: str) -> bool:
+    """Whether a path is an executable prompt/agent/skill surface (behavior-shaping)."""
+    return path.replace("\\", "/").startswith(_PROMPT_SURFACE_PREFIXES)
+
 
 def _is_docs_or_config(path: str) -> bool:
     """Whether a staged path is a docs/config file (per the conservative allowlist).
@@ -86,9 +105,13 @@ def _is_docs_or_config(path: str) -> bool:
     Anything under a ``.github/`` directory is NEVER docs/config: GitHub Actions
     workflows are executable CI config (arbitrary ``run:`` with repo secrets), so
     a workflow-only commit MUST still be reviewed even though it is ``.yml``.
+    Likewise an executable prompt/agent/skill SURFACE is never docs/config even when
+    ``.md`` — it shapes autonomous behavior and must reach the review + depth gates.
     """
     norm = path.replace("\\", "/")
     if ".github" in norm.split("/"):  # leading `.github/` or any `/.github/` component
+        return False
+    if _is_prompt_surface(norm):  # behavior surface — reviewable, never docs-skipped
         return False
     base = os.path.basename(norm)
     if base.upper() in _DOCS_CONFIG_BASENAMES:
@@ -390,11 +413,11 @@ def main() -> None:
         from review_state import (
             ESCALATION_ROUND_CAP,
             get_current_branch,
-            get_current_diff_hash,
             get_review_round,
             has_code_changes,
             has_valid_review_marker,
             is_review_current,
+            marker_content_current,
             reset_review_round,
         )
     except ImportError:
@@ -547,20 +570,14 @@ def main() -> None:
     else:
         # Normal commit: the staged index IS the commit content, so classify it
         # directly. Crucially, the marker's adversarial clearance counts ONLY when the
-        # marker genuinely BINDS this diff — is_review_current (marker.diff_hash == the
-        # current staged hash) AND that hash is real, not "unknown"/"clean". Otherwise an
-        # adversarial audit of an EARLIER diff A would falsely clear a later substantial
-        # diff B that a '# review-override' then waives past Rule 2's staleness block,
-        # when B was never audited (the integrity hole this depth gate exists to close).
-        # Excluding "unknown" fails CLOSED on a transient stat-diff error (the depth gate
-        # is the stricter one and has the '# depth-ack' escape) rather than letting the
-        # is_review_current() clean/unknown short-circuit wrong-clear a substantial diff.
+        # marker genuinely BINDS this diff's CONTENT — marker_content_current compares the
+        # recorded FULL-content hash to the staged content (not the stat-only diff_hash,
+        # which a same-shape swap collides under) and fails CLOSED on mismatch/absence/
+        # error. Otherwise an adversarial audit of an EARLIER diff A would falsely clear a
+        # later substantial diff B that a '# review-override' then waives past Rule 2's
+        # staleness block, when B was never audited (the integrity hole this gate closes).
         depth_level = staged_level
-        depth_is_adversarial = (
-            marker_adversarial
-            and is_review_current(cwd=cwd)
-            and get_current_diff_hash(cwd=cwd) not in ("unknown", "clean")
-        )
+        depth_is_adversarial = marker_adversarial and marker_content_current(cwd=cwd)
 
     if depth_level == "substantial" and not depth_is_adversarial:
         depth_acked = bool(commit_segs) and all(
@@ -575,8 +592,9 @@ def main() -> None:
         else:
             _deny(
                 "BLOCKED (review depth): this is a SUBSTANTIAL change (≥50 reviewable "
-                "lines, or >1 code file, or an auth/api/migrations file) but the "
-                "review is not an ADVERSARIAL audit. A precision-filtered 'no findings' "
+                "lines, or >1 code file, or an auth/api/migrations file, or a prompt/agent/"
+                "skill surface) but the review is not an ADVERSARIAL audit. A "
+                "precision-filtered 'no findings' "
                 "inline pass is FALSE CONFIDENCE, not clearance. Dispatch a genesis-architect "
                 "adversarial audit (assume bugs, enumerate the edge/boundary/sentinel/"
                 "hierarchy class, READ authoritative semantics for any domain code), save it "

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -429,8 +429,8 @@ def main() -> None:
     # must sit on the INNER command (the sigil isn't propagated to wrappers); the
     # documented `git commit … # escalation-ack` form is a plain segment.
     round_n = get_review_round(cwd=cwd)
+    commit_segs = [s for s in segs if git_subcommand(s.argv) == "commit"]
     if round_n >= ESCALATION_ROUND_CAP:
-        commit_segs = [s for s in segs if git_subcommand(s.argv) == "commit"]
         acked = bool(commit_segs) and all(
             has_trailing_override(s.raw, sigil="escalation-ack") for s in commit_segs
         )
@@ -438,11 +438,12 @@ def main() -> None:
             _deny(
                 f"BLOCKED: review escalation cap reached — {round_n} consecutive review "
                 f"rounds each surfaced NEW defects (cap {ESCALATION_ROUND_CAP}). The "
-                "review→fix loop has run long. STOP and get a FRESH user decision on how "
-                "to proceed (keep "
-                "hardening / switch to a robust-by-construction redesign / narrow scope / "
-                "shelve), then acknowledge that decision with a trailing shell comment "
-                "(outside any quotes):\n"
+                "review→fix loop has run long — the round-2 mode-switch audit did NOT "
+                "converge, which means the DESIGN or the problem statement is likely "
+                "wrong, not just this fix. STOP and get a FRESH user decision on how to "
+                "proceed (robust-by-construction redesign / narrow scope / shelve), then "
+                "acknowledge that decision with a trailing shell comment (outside any "
+                "quotes):\n"
                 '  git commit -m "your message"  # escalation-ack'
             )
             return
@@ -452,6 +453,43 @@ def main() -> None:
         # acknowledgment was made, and erring toward less friction only happens
         # AFTER a conscious ack.
         reset_review_round(cwd=cwd)
+    elif round_n == ESCALATION_ROUND_CAP - 1:
+        # Tier 1 — MODE-SWITCH, one round BEFORE the hard stop. Two consecutive
+        # defect-bearing rounds is the signature of fixing the INSTANCE a reviewer
+        # named instead of the CLASS: round N's narrow patch leaves sibling
+        # edge/boundary/sentinel cases that round N+1 then surfaces. Stopping here
+        # only "fails louder"; the fix is to force a DIFFERENT approach so the loop
+        # CONVERGES in one more round instead of grinding to the round-3 stop. Block
+        # until a '# audit-ack' — NOT a hard stop (the session can proceed once it
+        # has done the audit), and deliberately one round earlier than the cap so
+        # the intervention lands while the loop is still short. Does NOT reset the
+        # counter: a still-narrow fix must still reach the round-3 stop, and a
+        # clean review afterwards resets the streak via bump_review_round(clean).
+        # Independent of '# review-override' (Rule 2) and '# escalation-ack' (above).
+        acked = bool(commit_segs) and all(
+            has_trailing_override(s.raw, sigil="audit-ack") for s in commit_segs
+        )
+        if not acked:
+            _deny(
+                f"BLOCKED (mode-switch): {round_n} consecutive review rounds each "
+                f"surfaced NEW defects (cap {ESCALATION_ROUND_CAP}). You are fixing the "
+                "INSTANCE the reviewer named, not the CLASS — a third round is how the "
+                "loop runs away. Do NOT commit another one-line patch. STOP and switch "
+                "approach:\n"
+                "  1. Dispatch a FRESH-CONTEXT adversarial reviewer (a subagent with "
+                "clean context) over the ENTIRE diff — tell it to exhaustively "
+                "enumerate every edge/boundary/sentinel/hierarchy/error case, "
+                "independent of what the bot flagged.\n"
+                "  2. For any domain semantics in play (cgroup, systemd, SQLite, async, "
+                "timezones, …), READ the authoritative docs/source — do not reason from "
+                "assumption; assumption is what produced the serial defects.\n"
+                "  3. Fix the WHOLE enumerated class in ONE commit — not just the named "
+                "case.\n"
+                "Then acknowledge you did the audit (not another blind patch) with a "
+                "trailing shell comment (outside any quotes):\n"
+                '  git commit -m "your message"  # audit-ack'
+            )
+            return
 
     # Docs/config-only skip: a commit whose ENTIRE staged set is documentation
     # or config carries no code to review (adaptive-review "review level: None"),
@@ -468,6 +506,53 @@ def main() -> None:
         staged = _staged_files(cwd)
         if staged and all(_is_docs_or_config(p) for p in staged):
             sys.exit(0)
+
+    # Rule 2.5: review DEPTH. A SUBSTANTIAL change needs an ADVERSARIAL audit, not a
+    # precision-filtered inline pass — a "no findings" from a confidence-≥80 reviewer
+    # is FALSE CONFIDENCE, not clearance. Checked BEFORE Rule 2 (and its override) so
+    # '# review-override' waives FINDINGS but NOT the depth requirement (D1). A loud,
+    # logged '# depth-ack' is the audited escape for a genuine format mismatch.
+    # Substantiality is taken from the current staged diff OR the marker's RECORDED
+    # level (so a `git add && commit` chain — empty index at hook time — still enforces
+    # via what was reviewed). Fail-OPEN on any classifier/marker error: this is advisory
+    # anti-autopilot friction; the CI review-depth check is the real backstop. Runs
+    # AFTER the docs skip, so a pure-docs commit never reaches it.
+    try:
+        from review_scope import classify_change_substantiality
+
+        staged_level = classify_change_substantiality(cwd=cwd)
+    except Exception:  # noqa: BLE001 - depth is advisory; never crash the gate
+        staged_level = "unknown"
+    try:
+        from review_state import get_marker_depth
+
+        marker_level, is_adversarial = get_marker_depth(cwd=cwd)
+    except Exception:  # noqa: BLE001 - a marker-read error must not block (fail open)
+        marker_level, is_adversarial = None, True
+    if (staged_level == "substantial" or marker_level == "substantial") and not is_adversarial:
+        depth_acked = bool(commit_segs) and all(
+            has_trailing_override(s.raw, sigil="depth-ack") for s in commit_segs
+        )
+        if depth_acked:
+            print(
+                "NOTE: depth-ack honored — substantial-change adversarial-audit "
+                "requirement waived by explicit acknowledgment.",
+                file=sys.stderr,
+            )
+        else:
+            _deny(
+                "BLOCKED (review depth): this is a SUBSTANTIAL change (≥50 reviewable "
+                "lines, or >1 code file, or a new code file, or auth/api/migrations) but the "
+                "review is not an ADVERSARIAL audit. A precision-filtered 'no findings' "
+                "inline pass is FALSE CONFIDENCE, not clearance. Dispatch a genesis-architect "
+                "adversarial audit (assume bugs, enumerate the edge/boundary/sentinel/"
+                "hierarchy class, READ authoritative semantics for any domain code), save it "
+                "to ~/.genesis/last_code_review.txt, then re-mark:\n"
+                "  python3 scripts/review_state.py mark --agent-output ~/.genesis/last_code_review.txt\n"
+                "If the audit genuinely ran but its format isn't recognized, acknowledge with "
+                "a trailing shell comment (outside any quotes):  # depth-ack"
+            )
+            return
 
     # Rule 2: Block commits without review (on branches)
     # Race condition: when command is "git add X && git commit", nothing is
@@ -507,7 +592,7 @@ def main() -> None:
             return
         _deny(
             "BLOCKED: Code changes exist without review. "
-            "Run /review and dispatch the superpowers:code-reviewer agent first, "
+            "Run /review and dispatch the genesis-architect agent (adversarial audit) first, "
             "then run: python3 scripts/review_state.py mark --agent-output ~/.genesis/last_code_review.txt\n"
             "If findings are intentionally accepted, append a trailing shell "
             "comment (outside any quotes): '  # review-override'"

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -390,6 +390,7 @@ def main() -> None:
         from review_state import (
             ESCALATION_ROUND_CAP,
             get_current_branch,
+            get_current_diff_hash,
             get_review_round,
             has_code_changes,
             has_valid_review_marker,
@@ -507,16 +508,19 @@ def main() -> None:
         if staged and all(_is_docs_or_config(p) for p in staged):
             sys.exit(0)
 
+    # `git add X && git commit` stages in the SAME command chain: nothing is staged yet
+    # at hook time (git add hasn't run), so we can neither classify the current diff nor
+    # bind the marker to it. Detected once here and reused by Rule 2.5 and Rule 2.
+    stages_in_same_command = any(git_subcommand(s.argv) == "add" for s in segs)
+
     # Rule 2.5: review DEPTH. A SUBSTANTIAL change needs an ADVERSARIAL audit, not a
     # precision-filtered inline pass — a "no findings" from a confidence-≥80 reviewer
     # is FALSE CONFIDENCE, not clearance. Checked BEFORE Rule 2 (and its override) so
     # '# review-override' waives FINDINGS but NOT the depth requirement (D1). A loud,
     # logged '# depth-ack' is the audited escape for a genuine format mismatch.
-    # Substantiality is taken from the current staged diff OR the marker's RECORDED
-    # level (so a `git add && commit` chain — empty index at hook time — still enforces
-    # via what was reviewed). Fail-OPEN on any classifier/marker error: this is advisory
-    # anti-autopilot friction; the CI review-depth check is the real backstop. Runs
-    # AFTER the docs skip, so a pure-docs commit never reaches it.
+    # Fail-OPEN on any classifier/marker error: this is advisory anti-autopilot
+    # friction; the CI review-depth check is the real backstop. Runs AFTER the docs
+    # skip, so a pure-docs commit never reaches it.
     try:
         from review_scope import classify_change_substantiality
 
@@ -526,10 +530,39 @@ def main() -> None:
     try:
         from review_state import get_marker_depth
 
-        marker_level, is_adversarial = get_marker_depth(cwd=cwd)
-    except Exception:  # noqa: BLE001 - a marker-read error must not block (fail open)
-        marker_level, is_adversarial = None, True
-    if (staged_level == "substantial" or marker_level == "substantial") and not is_adversarial:
+        marker_level, marker_adversarial = get_marker_depth(cwd=cwd)
+    except Exception:  # noqa: BLE001 - a marker-read error must not block on the add-chain
+        # path (fail OPEN there); on the normal path the is_review_current() guard below
+        # re-reads the marker and fails CLOSED, the safe direction for the stricter gate.
+        marker_level, marker_adversarial = None, True
+
+    if stages_in_same_command:
+        # Index empty at hook time — the staged classify reads "inline", so depth falls
+        # back to the marker's RECORDED level (else a substantial change staged in the
+        # same chain would slip the gate). We cannot diff-bind here (staging hasn't
+        # happened), so the marker's adversarial bit is trusted as recorded — a KNOWN
+        # add-chain hash-blindness limitation (tracked follow-up), symmetric with Rule 2.
+        depth_level = marker_level
+        depth_is_adversarial = marker_adversarial
+    else:
+        # Normal commit: the staged index IS the commit content, so classify it
+        # directly. Crucially, the marker's adversarial clearance counts ONLY when the
+        # marker genuinely BINDS this diff — is_review_current (marker.diff_hash == the
+        # current staged hash) AND that hash is real, not "unknown"/"clean". Otherwise an
+        # adversarial audit of an EARLIER diff A would falsely clear a later substantial
+        # diff B that a '# review-override' then waives past Rule 2's staleness block,
+        # when B was never audited (the integrity hole this depth gate exists to close).
+        # Excluding "unknown" fails CLOSED on a transient stat-diff error (the depth gate
+        # is the stricter one and has the '# depth-ack' escape) rather than letting the
+        # is_review_current() clean/unknown short-circuit wrong-clear a substantial diff.
+        depth_level = staged_level
+        depth_is_adversarial = (
+            marker_adversarial
+            and is_review_current(cwd=cwd)
+            and get_current_diff_hash(cwd=cwd) not in ("unknown", "clean")
+        )
+
+    if depth_level == "substantial" and not depth_is_adversarial:
         depth_acked = bool(commit_segs) and all(
             has_trailing_override(s.raw, sigil="depth-ack") for s in commit_segs
         )
@@ -542,7 +575,7 @@ def main() -> None:
         else:
             _deny(
                 "BLOCKED (review depth): this is a SUBSTANTIAL change (≥50 reviewable "
-                "lines, or >1 code file, or a new code file, or auth/api/migrations) but the "
+                "lines, or >1 code file, or an auth/api/migrations file) but the "
                 "review is not an ADVERSARIAL audit. A precision-filtered 'no findings' "
                 "inline pass is FALSE CONFIDENCE, not clearance. Dispatch a genesis-architect "
                 "adversarial audit (assume bugs, enumerate the edge/boundary/sentinel/"
@@ -554,12 +587,7 @@ def main() -> None:
             )
             return
 
-    # Rule 2: Block commits without review (on branches)
-    # Race condition: when command is "git add X && git commit", nothing is
-    # staged yet at hook time because git add hasn't run. Detect git add in
-    # the same command chain — if present, require the marker file to exist
-    # (the PostToolUse hook deletes it after every commit).
-    stages_in_same_command = any(git_subcommand(s.argv) == "add" for s in segs)
+    # Rule 2: Block commits without review (on branches).
     if stages_in_same_command:
         # Can't check diff hash (staging hasn't happened yet) — require the
         # marker file to exist and not be expired.

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -91,12 +91,22 @@ _PROMPT_SURFACE_PREFIXES = (
     ".claude/commands/",
     ".claude/skills/",
     "src/genesis/skills/",
+    "src/genesis/identity/",  # runtime prompt templates (CODE_AUDITOR, INBOX_EVALUATE, …)
 )
 
 
 def _is_prompt_surface(path: str) -> bool:
-    """Whether a path is an executable prompt/agent/skill surface (behavior-shaping)."""
-    return path.replace("\\", "/").startswith(_PROMPT_SURFACE_PREFIXES)
+    """Whether a path is an executable prompt/agent/skill surface (behavior-shaping).
+
+    Covers the fixed prompt roots above PLUS any ``prompts/`` package under the runtime
+    tree (``src/genesis/autonomy/executor/prompts/``, ``src/genesis/sentinel/prompts/``, …)
+    — the class, not just the named roots. Top-level user CAPS docs stay exempt (they do
+    not live under these paths).
+    """
+    norm = path.replace("\\", "/")
+    return norm.startswith(_PROMPT_SURFACE_PREFIXES) or (
+        norm.startswith("src/genesis/") and "/prompts/" in norm
+    )
 
 
 def _is_docs_or_config(path: str) -> bool:
@@ -526,15 +536,19 @@ def main() -> None:
     # to normal enforcement — never skipped. Placed AFTER Rule 0 (--no-verify),
     # Rule 1 (main-branch), and Rule 3 (escalation cap) so it can never weaken
     # those hard blocks.
-    if not _commit_may_add_content(segs):
+    # Whether the commit may stage content BEYOND the current index — a pathspec, -a/-i/-o/-p,
+    # or a git add/rm/mv/reset in the chain (P1-D). When true the hook-time index does NOT
+    # reflect what will be committed, so we can neither classify the staged diff nor bind the
+    # marker to it; depth (Rule 2.5) and Rule 2 fall back to the recorded/valid marker. This
+    # is the SAME predicate the docs-skip uses, so `git commit -am` / a pathspec commit is
+    # handled exactly like `git add && commit` — NOT just a bare `git add` (which the old
+    # add-only check missed, letting `commit -am` of unstaged substantial work slip the gate).
+    commit_may_add_content = _commit_may_add_content(segs)
+
+    if not commit_may_add_content:
         staged = _staged_files(cwd)
         if staged and all(_is_docs_or_config(p) for p in staged):
             sys.exit(0)
-
-    # `git add X && git commit` stages in the SAME command chain: nothing is staged yet
-    # at hook time (git add hasn't run), so we can neither classify the current diff nor
-    # bind the marker to it. Detected once here and reused by Rule 2.5 and Rule 2.
-    stages_in_same_command = any(git_subcommand(s.argv) == "add" for s in segs)
 
     # Rule 2.5: review DEPTH. A SUBSTANTIAL change needs an ADVERSARIAL audit, not a
     # precision-filtered inline pass — a "no findings" from a confidence-≥80 reviewer
@@ -559,12 +573,14 @@ def main() -> None:
         # re-reads the marker and fails CLOSED, the safe direction for the stricter gate.
         marker_level, marker_adversarial = None, True
 
-    if stages_in_same_command:
-        # Index empty at hook time — the staged classify reads "inline", so depth falls
-        # back to the marker's RECORDED level (else a substantial change staged in the
-        # same chain would slip the gate). We cannot diff-bind here (staging hasn't
-        # happened), so the marker's adversarial bit is trusted as recorded — a KNOWN
-        # add-chain hash-blindness limitation (tracked follow-up), symmetric with Rule 2.
+    if commit_may_add_content:
+        # The hook-time index does NOT reflect what will be committed (`git add && commit`,
+        # `git commit -am`, a pathspec/-i/-o/-p commit, …), so the staged classify reads
+        # "inline"; depth falls back to the marker's RECORDED level (else a substantial
+        # change committed this way would slip the gate). We cannot content-bind here
+        # (the real diff isn't staged yet), so the marker's adversarial bit is trusted as
+        # recorded — a KNOWN content-blindness limitation (tracked follow-up), symmetric
+        # with Rule 2 below.
         depth_level = marker_level
         depth_is_adversarial = marker_adversarial
     else:
@@ -606,9 +622,9 @@ def main() -> None:
             return
 
     # Rule 2: Block commits without review (on branches).
-    if stages_in_same_command:
-        # Can't check diff hash (staging hasn't happened yet) — require the
-        # marker file to exist and not be expired.
+    if commit_may_add_content:
+        # The staged diff at hook time isn't what will be committed (staging deferred, -a,
+        # a pathspec, …) — can't check the diff hash, so require a valid (unexpired) marker.
         rule2_blocks = not has_valid_review_marker(cwd=cwd)
     else:
         rule2_blocks = has_code_changes(cwd=cwd) and not is_review_current(cwd=cwd)

--- a/scripts/review_scope.py
+++ b/scripts/review_scope.py
@@ -517,6 +517,131 @@ def build_manifest(cwd: str | None = None, base: str | None = None) -> dict | No
     }
 
 
+# ── Substantiality classifier (commit-time review-DEPTH gate) ─────────────────
+# The depth gate distinguishes a SUBSTANTIAL change (needs an adversarial
+# /review-level audit) from a small inline one. It reads the STAGED index
+# (``--cached``), NOT build_manifest's merge-base..working-tree basis: the review
+# marker is keyed to the staged diff (review_state.get_current_diff_hash hashes
+# ``git diff --cached``), so the classifier MUST share that basis or the mark-time
+# level and the commit-time re-check could disagree on a byte-identical staged
+# diff (level thrashing / spurious blocks). Fail-opens to "unknown" so a git error
+# never fabricates a depth requirement — the CI review-depth check is the real
+# backstop; this local layer is advisory anti-autopilot friction.
+_SUBSTANTIAL_DIFF_LINES = 50
+_DOMAIN_SENSITIVE_TAGS = frozenset({"auth", "api", "migrations"})
+
+
+def _parse_numstat_perfile(text: str) -> tuple[dict[str, int], set[str]]:
+    """Parse ``git diff -z --numstat -M`` → ``(per_file_lines, binary_paths)``.
+
+    ``per_file_lines`` maps each path → added+deleted (unlike ``_parse_numstat_z``'s
+    total) so the caller can sum only the REVIEWABLE lines. ``binary_paths`` is the
+    set of files with ``-`` counts (a binary can't be line-counted OR code-reviewed,
+    so the caller excludes them from both line and file counts). For a rename the
+    stats attach to the DST only (one key per rename → no double-count). Mirrors
+    ``_parse_numstat_z``'s -z record shapes (normal: ``<a>\\t<d>\\t<path>\\0``;
+    rename: ``<a>\\t<d>\\t\\0<src>\\0<dst>\\0``).
+    """
+    tokens = text.split("\x00")
+    out: dict[str, int] = {}
+    binary: set[str] = set()
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        if not tok:
+            i += 1
+            continue
+        parts = tok.split("\t")
+        if len(parts) < 3:
+            i += 1
+            continue
+        added, deleted = parts[0], parts[1]
+        inline_path = "\t".join(parts[2:])
+        if inline_path == "":  # rename/copy: dst is the token after next (src)
+            path = tokens[i + 2] if i + 2 < n else ""
+            i += 3
+        else:
+            path = inline_path
+            i += 1
+        if not path:
+            continue
+        if added == "-" or deleted == "-":  # binary — not line-countable
+            out[path] = 0
+            binary.add(path)
+            continue
+        try:
+            out[path] = int(added) + int(deleted)
+        except ValueError:
+            out[path] = 0
+    return out, binary
+
+
+def _substantiality_level(records: list[dict], per_file: dict[str, int], binary: set[str]) -> str:
+    """Pure substantiality predicate over parsed diff records — the SHARED core of
+    the staged (--cached) and PR-range (base...HEAD) paths.
+
+    Substantial when ANY holds over the reviewable files (docs-config/binary/vendored
+    excluded): reviewable lines ≥ ``_SUBSTANTIAL_DIFF_LINES`` (50), OR >1 distinct code
+    file, OR a new code file, OR a domain-sensitive ``scope_tag`` (auth/api/migrations).
+    """
+
+    def _reviewable(p: str) -> bool:
+        return p not in binary and not _is_vendored(p) and _category(p) != "docs-config"
+
+    reviewable_lines = sum(n for p, n in per_file.items() if _reviewable(p))
+    # Distinct code files from the numstat MAP — ONE key per rename (dst), so a file
+    # move counts once, not twice (name-status emits both src+dst → the double-count
+    # bug this replaces). Binary excluded (a binary asset is not code to review).
+    code_paths = {p for p in per_file if _reviewable(p) and _category(p) == "code"}
+    scope_tags: set[str] = set()
+    new_code_file = False
+    for rec in records:  # both rename sides here → domain-sensitivity on either side
+        path = rec["path"]
+        if not _reviewable(path):
+            continue
+        tag = _scope_tag(path)
+        if tag:
+            scope_tags.add(tag)
+        if rec["change_type"][:1] == "A" and _category(path) == "code":
+            new_code_file = True  # a NEW code file (renames are R, not A)
+    substantial = (
+        reviewable_lines >= _SUBSTANTIAL_DIFF_LINES
+        or len(code_paths) > 1
+        or new_code_file
+        or bool(scope_tags & _DOMAIN_SENSITIVE_TAGS)
+    )
+    return "substantial" if substantial else "inline"
+
+
+def _classify_diff(diff_args: list[str], cwd: str | None) -> str:
+    """Run the two -z diffs, parse, and classify — or ``"unknown"`` on any git error
+    (fail OPEN: no fabricated depth requirement; the CI check is the backstop)."""
+    name_status = _git(["diff", *diff_args, "-z", "--name-status", "-M"], cwd)
+    numstat = _git(["diff", *diff_args, "-z", "--numstat", "-M"], cwd)
+    if name_status is None or numstat is None:
+        return "unknown"
+    per_file, binary = _parse_numstat_perfile(numstat)
+    return _substantiality_level(_parse_name_status_z(name_status), per_file, binary)
+
+
+def classify_change_substantiality(cwd: str | None = None) -> str:
+    """Substantiality of the STAGED change (--cached) — for the commit-time depth gate.
+
+    Uses the staged index so it shares the review marker's basis (which hashes
+    ``git diff --cached``); a different basis would let the mark-time level and the
+    commit-time re-check disagree on a byte-identical staged diff. Returns
+    ``"substantial"`` | ``"inline"`` | ``"unknown"``.
+    """
+    return _classify_diff(["--cached"], cwd)
+
+
+def classify_range_substantiality(base: str, cwd: str | None = None) -> str:
+    """Substantiality of ``base...HEAD`` — for the CI review-depth check (a PR range,
+    not a staged index). Same predicate, different basis. ``"unknown"`` on git error."""
+    return _classify_diff([f"{base}...HEAD"], cwd)
+
+
 def render_reminder_block(manifest: dict | None) -> str:
     """Human-readable manifest for the review reminder, or "" when nothing to add.
 

--- a/scripts/review_scope.py
+++ b/scripts/review_scope.py
@@ -54,9 +54,16 @@ except ImportError:  # pragma: no cover - sibling always present in scripts/
         return ext.lower() in {".md", ".rst", ".txt", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
 
     def _is_prompt_surface(path: str) -> bool:
-        return path.replace("\\", "/").startswith(
-            (".claude/agents/", ".claude/commands/", ".claude/skills/", "src/genesis/skills/")
-        )
+        norm = path.replace("\\", "/")
+        return norm.startswith(
+            (
+                ".claude/agents/",
+                ".claude/commands/",
+                ".claude/skills/",
+                "src/genesis/skills/",
+                "src/genesis/identity/",
+            )
+        ) or (norm.startswith("src/genesis/") and "/prompts/" in norm)
 
 
 _GIT_TIMEOUT = 10  # per-call ceiling when no deadline is in force

--- a/scripts/review_scope.py
+++ b/scripts/review_scope.py
@@ -46,12 +46,17 @@ _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 if _SCRIPT_DIR not in sys.path:
     sys.path.insert(0, _SCRIPT_DIR)
 try:
-    from review_enforcement_commit import _is_docs_or_config
+    from review_enforcement_commit import _is_docs_or_config, _is_prompt_surface
 except ImportError:  # pragma: no cover - sibling always present in scripts/
 
     def _is_docs_or_config(path: str) -> bool:
         _, ext = os.path.splitext(path)
         return ext.lower() in {".md", ".rst", ".txt", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
+
+    def _is_prompt_surface(path: str) -> bool:
+        return path.replace("\\", "/").startswith(
+            (".claude/agents/", ".claude/commands/", ".claude/skills/", "src/genesis/skills/")
+        )
 
 
 _GIT_TIMEOUT = 10  # per-call ceiling when no deadline is in force
@@ -584,10 +589,12 @@ def _substantiality_level(records: list[dict], per_file: dict[str, int], binary:
     A surface-area × risk model. Substantial when ANY holds over the reviewable files
     (docs-config/binary/vendored excluded): reviewable lines ≥ ``_SUBSTANTIAL_DIFF_LINES``
     (50) OR >1 distinct code file (surface area), OR a domain-sensitive ``scope_tag``
-    (auth/api/migrations — risk/importance). NOT triggered by mere newness: a trivial
-    single new file is INLINE (Rule 2 still requires *a* review, just not an adversarial
-    audit), but a small change to a critical auth/api/migration file IS substantial. An
-    adversarial audit tracks consequence, not line count alone.
+    (auth/api/migrations — risk/importance), OR an executable prompt/agent/skill SURFACE
+    (behavior risk — a change to what shapes autonomous LLM behavior). NOT triggered by
+    mere newness: a trivial single new file is INLINE (Rule 2 still requires *a* review,
+    just not an adversarial audit), but a small change to a critical file (auth/api/
+    migration or a prompt surface) IS substantial. An adversarial audit tracks
+    consequence, not line count alone.
     """
 
     def _reviewable(p: str) -> bool:
@@ -599,6 +606,7 @@ def _substantiality_level(records: list[dict], per_file: dict[str, int], binary:
     # bug this replaces). Binary excluded (a binary asset is not code to review).
     code_paths = {p for p in per_file if _reviewable(p) and _category(p) == "code"}
     scope_tags: set[str] = set()
+    prompt_surface = False
     for rec in records:  # both rename sides here → domain-sensitivity on either side
         path = rec["path"]
         if not _reviewable(path):
@@ -606,10 +614,13 @@ def _substantiality_level(records: list[dict], per_file: dict[str, int], binary:
         tag = _scope_tag(path)
         if tag:
             scope_tags.add(tag)
+        if _is_prompt_surface(path):  # behavior-shaping surface, even a small edit
+            prompt_surface = True
     substantial = (
         reviewable_lines >= _SUBSTANTIAL_DIFF_LINES
         or len(code_paths) > 1
         or bool(scope_tags & _DOMAIN_SENSITIVE_TAGS)
+        or prompt_surface
     )
     return "substantial" if substantial else "inline"
 

--- a/scripts/review_scope.py
+++ b/scripts/review_scope.py
@@ -581,9 +581,13 @@ def _substantiality_level(records: list[dict], per_file: dict[str, int], binary:
     """Pure substantiality predicate over parsed diff records — the SHARED core of
     the staged (--cached) and PR-range (base...HEAD) paths.
 
-    Substantial when ANY holds over the reviewable files (docs-config/binary/vendored
-    excluded): reviewable lines ≥ ``_SUBSTANTIAL_DIFF_LINES`` (50), OR >1 distinct code
-    file, OR a new code file, OR a domain-sensitive ``scope_tag`` (auth/api/migrations).
+    A surface-area × risk model. Substantial when ANY holds over the reviewable files
+    (docs-config/binary/vendored excluded): reviewable lines ≥ ``_SUBSTANTIAL_DIFF_LINES``
+    (50) OR >1 distinct code file (surface area), OR a domain-sensitive ``scope_tag``
+    (auth/api/migrations — risk/importance). NOT triggered by mere newness: a trivial
+    single new file is INLINE (Rule 2 still requires *a* review, just not an adversarial
+    audit), but a small change to a critical auth/api/migration file IS substantial. An
+    adversarial audit tracks consequence, not line count alone.
     """
 
     def _reviewable(p: str) -> bool:
@@ -595,7 +599,6 @@ def _substantiality_level(records: list[dict], per_file: dict[str, int], binary:
     # bug this replaces). Binary excluded (a binary asset is not code to review).
     code_paths = {p for p in per_file if _reviewable(p) and _category(p) == "code"}
     scope_tags: set[str] = set()
-    new_code_file = False
     for rec in records:  # both rename sides here → domain-sensitivity on either side
         path = rec["path"]
         if not _reviewable(path):
@@ -603,12 +606,9 @@ def _substantiality_level(records: list[dict], per_file: dict[str, int], binary:
         tag = _scope_tag(path)
         if tag:
             scope_tags.add(tag)
-        if rec["change_type"][:1] == "A" and _category(path) == "code":
-            new_code_file = True  # a NEW code file (renames are R, not A)
     substantial = (
         reviewable_lines >= _SUBSTANTIAL_DIFF_LINES
         or len(code_paths) > 1
-        or new_code_file
         or bool(scope_tags & _DOMAIN_SENSITIVE_TAGS)
     )
     return "substantial" if substantial else "inline"

--- a/scripts/review_state.py
+++ b/scripts/review_state.py
@@ -133,6 +133,22 @@ def is_review_current(cwd: str | None = None) -> bool:
     return bool(state) and state.get("diff_hash") == current
 
 
+def marker_content_current(cwd: str | None = None) -> bool:
+    """Whether the marker's recorded FULL-content hash binds the CURRENT staged diff.
+
+    Stricter than :func:`is_review_current` (which compares the stat-only ``diff_hash``,
+    so a same-shape content swap reads as current). Used by the commit depth gate to
+    grant adversarial clearance ONLY when the marked content IS the staged content —
+    an audit of diff A must not clear a different-content diff B of the same shape.
+    Fails CLOSED: a real staged hash that mismatches / is absent / errors → False.
+    """
+    current = _staged_content_hash(cwd=cwd)
+    if current in ("clean", "unknown"):
+        return False  # nothing concrete to bind (or a git error) — never clear on this
+    state = _load_marker(cwd)
+    return bool(state) and state.get("content_hash") == current
+
+
 def has_valid_review_marker(cwd: str | None = None) -> bool:
     """Check if a (per-worktree) review marker exists and is not expired.
 
@@ -321,6 +337,11 @@ def mark_reviewed(
     state_file.parent.mkdir(parents=True, exist_ok=True)
     state = {
         "diff_hash": get_current_diff_hash(cwd=cwd),
+        # FULL-content hash of the reviewed diff. diff_hash is stat-only (files + line
+        # counts), so a same-shape content swap collides under it; the depth gate binds
+        # adversarial clearance to THIS instead, so an audit of diff A cannot clear a
+        # different-content diff B that shares A's shape (see marker_content_current).
+        "content_hash": _staged_content_hash(cwd=cwd),
         "reviewed_at": datetime.now(UTC).isoformat(),
         "review_evidence": review_msg,  # advisory annotation (gstack corroboration)
         "agent_evidence": agent_msg,

--- a/scripts/review_state.py
+++ b/scripts/review_state.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import re
 import subprocess
 import sys
 import time
@@ -197,6 +198,73 @@ def _verify_agent_output(path: str) -> tuple[bool, str]:
     return True, f"Agent output valid ({int(age)}s old, {p.stat().st_size} bytes)"
 
 
+# ── Review DEPTH signals (for the substantial-change depth gate) ──────────────
+# A SUBSTANTIAL change needs an ADVERSARIAL audit, not a precision-filtered inline
+# pass. We can't semantically grade a review, so we verify STRUCTURAL engagement
+# markers a shallow "looks good, 88% confident" pass lacks. Deliberately LENIENT on
+# vocabulary (accepts every real reviewer's ladder — genesis-architect
+# BLOCKER/SHOULD-FIX/NOTE, genesis-security CRITICAL/HIGH/LOW, Codex P1/P2/P3, the
+# CODE_AUDITOR JSON contract) but STRICT on engagement (must reference specific
+# code), so it rejects a rubber stamp without false-blocking a differently-shaped
+# real audit. This is an advisory anti-autopilot floor, NOT tamper-proof: a
+# determined same-user agent can hand-write these markers — the real teeth are the
+# CI review-depth check + the independent cloud reviewer + the human merge.
+# Severity-ladder LABELS — matched CASE-SENSITIVELY (uppercase): every real
+# reviewer emits them in caps (genesis-architect BLOCKER/SHOULD-FIX, genesis-security
+# CRITICAL/HIGH/LOW, Codex P1/P2/P3, CODE_AUDITOR JSON "severity":"high" values). NOT
+# IGNORECASE, because lowercase "high confidence"/"low risk"/"medium-sized" is ordinary
+# prose a SHALLOW pass uses — matching it would gut the discriminator (audit finding).
+_LADDER_LABEL_RE = re.compile(r"\b(BLOCKER|SHOULD[- ]FIX|CRITICAL|HIGH|MEDIUM|LOW|P[123])\b")
+# Structural markers that are unambiguous even lowercased (a JSON key / a heading).
+_LADDER_PHRASE_RE = re.compile(r'"severity"\s*:|scope\s*check', re.IGNORECASE)
+# Engagement with SPECIFIC code (not prose) — accept either shape a real reviewer
+# uses: a contiguous ``foo.py:42`` pointer (architect/security/Codex prose), OR the
+# CODE_AUDITOR JSON contract's separate ``"file"``/``"line"`` fields (which never
+# render as ``file:line``). Requiring only the prose form would false-block a
+# legitimate JSON audit.
+_FILE_LINE_RE = re.compile(r"[\w./-]+\.\w+:\d+")
+_JSON_FILE_RE = re.compile(r'"file"\s*:')
+_JSON_LINE_RE = re.compile(r'"line"\s*:')
+_MIN_EVIDENCE_CHARS = 400  # a real audit is substantive, not a one-liner
+
+
+def _evidence_is_adversarial(text: str) -> tuple[bool, str]:
+    """Lenient STRUCTURAL check that review evidence is an adversarial audit.
+
+    NOT semantic grading — requires all three engagement markers a shallow pass
+    lacks: (1) a recognized severity ladder OR a scope-coverage statement, (2)
+    engagement with specific code (a ``file:line`` pointer OR the JSON
+    ``"file"``+``"line"`` finding contract), (3) a minimum length. The conjunction
+    is what makes a casual prose "high confidence" (no code reference) fail while a
+    genuinely clean audit ("Scope Check: … no BLOCKER at foo.py:42") passes.
+    """
+    stripped = text.strip()
+    if len(stripped) < _MIN_EVIDENCE_CHARS:
+        return False, f"evidence too short ({len(stripped)} < {_MIN_EVIDENCE_CHARS} chars)"
+    if not (_LADDER_LABEL_RE.search(text) or _LADDER_PHRASE_RE.search(text)):
+        return False, "no severity ladder / scope-check marker (reads like a shallow pass)"
+    has_engagement = bool(_FILE_LINE_RE.search(text)) or bool(
+        _JSON_FILE_RE.search(text) and _JSON_LINE_RE.search(text)
+    )
+    if not has_engagement:
+        return False, "no file:line engagement (no specific code referenced)"
+    return True, "adversarial-audit structure present"
+
+
+def get_marker_depth(cwd: str | None = None) -> tuple[str | None, bool]:
+    """``(level, adversarial)`` recorded in the current marker; ``(None, False)`` if absent.
+
+    Read by the commit gate's depth check. ``level`` is the computed
+    substantiality at mark time; ``adversarial`` is the derived content-verify
+    result — NEITHER is self-reported by the caller.
+    """
+    state = _load_marker(cwd)
+    if not state:
+        return None, False
+    level = state.get("level")
+    return (level if isinstance(level, str) else None), bool(state.get("adversarial"))
+
+
 def mark_reviewed(
     agent_output_path: str | None = None,
     cwd: str | None = None,
@@ -226,8 +294,27 @@ def mark_reviewed(
     agent_ok, agent_msg = _verify_agent_output(agent_path)
     if not agent_ok:
         print(f"REFUSED: {agent_msg}", file=sys.stderr)
-        print("Dispatch the superpowers:code-reviewer agent first.", file=sys.stderr)
+        print("Dispatch the genesis-architect agent (adversarial audit) first.", file=sys.stderr)
         return False
+
+    # Review-DEPTH signals — COMPUTED here, never self-reported by the caller.
+    # ``level`` is the staged-change substantiality; ``adversarial`` is the derived
+    # result of structurally verifying the evidence. Both fail-soft: a classifier or
+    # read error must never block writing the marker (depth is advisory).
+    try:
+        from review_scope import classify_change_substantiality
+
+        level = classify_change_substantiality(cwd=cwd)
+    except Exception:  # noqa: BLE001 - depth is advisory; never block marking a review
+        level = "unknown"
+    adversarial = False
+    depth_msg = "not checked"
+    try:
+        adversarial, depth_msg = _evidence_is_adversarial(
+            Path(agent_path).read_text(errors="replace")
+        )
+    except OSError as e:
+        depth_msg = f"evidence unreadable ({e})"
 
     # Authoritative evidence present — write the per-worktree marker.
     state_file = _state_file(cwd)
@@ -237,8 +324,21 @@ def mark_reviewed(
         "reviewed_at": datetime.now(UTC).isoformat(),
         "review_evidence": review_msg,  # advisory annotation (gstack corroboration)
         "agent_evidence": agent_msg,
+        "level": level,  # computed substantiality (substantial|inline|unknown)
+        "adversarial": adversarial,  # derived: evidence has adversarial-audit structure
+        "depth_evidence": depth_msg,
     }
     state_file.write_text(json.dumps(state, indent=2))
+    # Loud feedback when a substantial change was marked WITHOUT adversarial-audit
+    # structure: the commit-time depth gate will block it (this is the fast-feedback).
+    if level == "substantial" and not adversarial:
+        print(
+            f"WARNING: substantial change marked with a non-adversarial review ({depth_msg}). "
+            "The commit depth gate will BLOCK this — run a genesis-architect adversarial "
+            "audit (enumerate the edge/boundary/sentinel class; read authoritative "
+            "semantics) and re-mark.",
+            file=sys.stderr,
+        )
     # Update the escalation counter (see bump_review_round). A defect-bearing round
     # on a distinct staged diff advances the streak; a clean round resets it.
     # Best-effort: marking the review must ALWAYS succeed even if the counter is

--- a/tests/test_hooks/test_escalation_cap.py
+++ b/tests/test_hooks/test_escalation_cap.py
@@ -237,10 +237,79 @@ def test_ack_inside_message_does_not_bypass(repo, home):
     assert "escalation cap" in res.stderr
 
 
-def test_below_cap_not_blocked_by_escalation(repo, home):
+def test_first_defect_round_not_blocked(repo, home):
+    # One defect-bearing round (below the mode-switch tier) → allowed with no ack.
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP - 2)  # 1 round
+    res = _run_hook('git commit -m "wip"', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+# ── Tier 1: round CAP-1 mode-switch (audit-ack) ───────────────────────────
+
+
+def test_mode_switch_blocks_at_second_defect_round(repo, home):
+    # Two consecutive defect-bearing rounds → the mode-switch tier blocks (one round
+    # BEFORE the hard cap), demanding a fresh-eyes audit rather than another patch.
     _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP - 1)  # 2 rounds
     res = _run_hook('git commit -m "wip"', repo, home)
-    assert res.returncode == 0, res.stderr  # review current + under cap → allowed
+    assert res.returncode == 2, res.stdout + res.stderr
+    assert "mode-switch" in res.stderr
+    assert "audit-ack" in res.stderr
+
+
+def test_audit_ack_allows_past_mode_switch(repo, home):
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP - 1)
+    res = _run_hook('git commit -m "wip"  # audit-ack', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
+def test_audit_ack_inside_message_does_not_bypass(repo, home):
+    # The token buried in -m (not a clean trailing comment) must NOT ack.
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP - 1)
+    res = _run_hook('git commit -m "did the audit-ack thing"', repo, home)
+    assert res.returncode == 2, res.stdout + res.stderr
+    assert "mode-switch" in res.stderr
+
+
+def test_escalation_ack_does_not_satisfy_mode_switch(repo, home):
+    # The two acks are distinct: at the round-2 mode-switch the gate wants the
+    # AUDIT ack, not the round-3 user-decision ack. A wrong sigil stays blocked.
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP - 1)
+    res = _run_hook('git commit -m "wip"  # escalation-ack', repo, home)
+    assert res.returncode == 2, res.stdout + res.stderr
+    assert "mode-switch" in res.stderr
+
+
+def test_audit_ack_does_not_reset_counter_so_round3_still_hard_stops(repo, home):
+    # The mode-switch ack lets THIS commit through but must NOT reset the streak:
+    # if the "audit" didn't actually converge and a third defect round follows,
+    # the hard cap must still fire. (Only a CLEAN review resets the streak.)
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP - 1)  # round 2
+    r_mode = _run_hook('git commit -m "audited"  # audit-ack', repo, home)
+    assert r_mode.returncode == 0, r_mode.stderr
+    _git(repo, "commit", "-qm", "audited")  # land it
+    _stage(repo, "third = 1\n")  # a THIRD distinct defect round
+    assert _mark(repo, home).returncode == 0
+    # Assert via the gate (subprocess under the test HOME) — an in-process
+    # get_review_round() would read the REAL ~/.genesis, not the test home. The
+    # hard stop firing proves the counter reached the cap (audit-ack did NOT reset).
+    r_hard = _run_hook('git commit -m "wip3"', repo, home)
+    assert r_hard.returncode == 2, r_hard.stdout + r_hard.stderr
+    assert "escalation cap" in r_hard.stderr
+
+
+def test_audit_ack_then_clean_review_resets(repo, home):
+    # The intended happy path: mode-switch → do the audit → a CLEAN review resets
+    # the streak, so the branch is back to zero friction (no round-3 stop).
+    _reach_rounds(repo, home, review_state.ESCALATION_ROUND_CAP - 1)  # round 2
+    r_mode = _run_hook('git commit -m "audited"  # audit-ack', repo, home)
+    assert r_mode.returncode == 0, r_mode.stderr
+    _git(repo, "commit", "-qm", "audited")
+    _stage(repo, "post_audit = 1\n")
+    m = _mark(repo, home, clean=True)  # audit converged → clean review resets streak
+    assert m.returncode == 0 and "streak reset" in m.stdout
+    res = _run_hook('git commit -m "wip"', repo, home)
+    assert res.returncode == 0, res.stdout + res.stderr
 
 
 def test_review_override_does_not_bypass_cap(repo, home):

--- a/tests/test_hooks/test_review_depth_gate.py
+++ b/tests/test_hooks/test_review_depth_gate.py
@@ -170,6 +170,29 @@ def test_depth_ack_inside_quotes_does_not_waive(repo, home):
     assert "review depth" in r.stderr.lower()
 
 
+def test_stale_adversarial_marker_does_not_clear_new_diff(repo, home):
+    # D1-diffbind (Codex P2): an adversarial audit of diff A must NOT clear a DIFFERENT
+    # substantial diff B. The marker is adversarial + current for A; restaging B makes it
+    # stale. Rule 2's staleness block is waivable by '# review-override', so depth must
+    # catch B on its own — the marker's adversarial bit counts ONLY when it is CURRENT for
+    # the staged diff. (verify-RED: B committed cleanly before the diff-binding fix.)
+    #
+    # NOTE the marker's diff_hash is `git diff --cached --stat` (files + line counts, a
+    # pre-existing stat-only design), so B must differ in SHAPE, not just content, for
+    # is_review_current to see it as stale. This closes the realistic case and brings
+    # depth to PARITY with Rule 2's staleness check; a same-shape content swap is a
+    # system-wide stat-hash limitation (tracked follow-up), not specific to this gate.
+    _stage_substantial(repo)  # A: f.py, +60 lines
+    m = _mark(repo, home, _ADVERSARIAL)  # adversarial marker bound to diff A
+    assert m.returncode == 0
+    # restage a DIFFERENT-SHAPE substantial diff B (f.py at +80 lines → stat differs)
+    (repo / "f.py").write_text("base = 1\n" + "".join(f"z{i} = {i}\n" for i in range(80)))
+    _git(repo, "add", "-A")
+    r = _run_hook('git commit -m "x"  # review-override', repo, home)
+    assert r.returncode == 2, r.stdout + r.stderr
+    assert "review depth" in r.stderr.lower()
+
+
 def test_add_and_commit_chain_falls_back_to_marker_level(repo, home):
     # `git add && commit` in ONE command: the index is EMPTY at hook time, so the
     # current-staged classify reads "inline" — depth must fall back to the marker's

--- a/tests/test_hooks/test_review_depth_gate.py
+++ b/tests/test_hooks/test_review_depth_gate.py
@@ -1,0 +1,182 @@
+"""Integration tests for the commit-gate review-DEPTH rule (Rule 2.5).
+
+Hermetic: throwaway git repo under ``tmp_path`` with ``HOME`` redirected, so real
+~/.genesis markers are untouched. Drives scripts/review_enforcement_commit.py as a
+subprocess exactly as the CC PreToolUse hook does (JSON payload on stdin).
+
+The rule: a SUBSTANTIAL staged change requires an ADVERSARIAL review marker; a
+shallow/inline pass BLOCKS (exit 2). '# review-override' waives FINDINGS but NOT
+depth (D1); '# depth-ack' is the audited escape. Inline changes are unaffected.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HOOK = _REPO_ROOT / "scripts" / "review_enforcement_commit.py"
+_REVIEW_STATE = _REPO_ROOT / "scripts" / "review_state.py"
+
+# A review artifact with adversarial-audit structure: a severity ladder + a
+# file:line pointer + past the length floor.
+_ADVERSARIAL = (
+    "Scope Check: CLEAN\n"
+    "BLOCKER 1 — off-by-one at f.py:1 mishandles the empty case.\n"
+    "SHOULD-FIX 2 — missing boundary validation.\n"
+    "NOTE 3 — consider a test for the None input.\n"
+    "Completion status: DONE.\n" + "detail " * 80
+)
+_SHALLOW = "Reviewed the change. Looks good to me. 88% confident.\n"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    _git(r, "-c", "init.defaultBranch=main", "init", "-q")
+    _git(r, "config", "user.email", "t@e.st")
+    _git(r, "config", "user.name", "tester")
+    (r / "f.py").write_text("base = 1\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "base")
+    _git(r, "checkout", "-q", "-b", "feature/x")
+    return r
+
+
+@pytest.fixture
+def home(tmp_path: Path) -> Path:
+    h = tmp_path / "home"
+    (h / ".genesis").mkdir(parents=True)
+    return h
+
+
+def _stage_substantial(repo: Path) -> None:
+    (repo / "f.py").write_text("base = 1\n" + "".join(f"x{i} = {i}\n" for i in range(60)))
+    _git(repo, "add", "-A")
+
+
+def _stage_inline(repo: Path) -> None:
+    (repo / "f.py").write_text("base = 2\n")
+    _git(repo, "add", "-A")
+
+
+def _mark(repo: Path, home: Path, evidence: str) -> subprocess.CompletedProcess:
+    """Write review evidence then run `review_state.py mark` (computes level/adversarial)."""
+    (home / ".genesis" / "last_code_review.txt").write_text(evidence)
+    env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_REVIEW_STATE),
+            "mark",
+            "--agent-output",
+            str(home / ".genesis" / "last_code_review.txt"),
+        ],
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _run_hook(command: str, repo: Path, home: Path) -> subprocess.CompletedProcess:
+    payload = json.dumps(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "session_id": "test",
+        }
+    )
+    env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input=payload,
+        cwd=str(repo),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# --------------------------------------------------------------------------- #
+def test_substantial_without_marker_blocked_on_depth(repo, home):
+    _stage_substantial(repo)
+    r = _run_hook('git commit -m "x"', repo, home)
+    assert r.returncode == 2
+    assert "review depth" in r.stderr.lower()
+
+
+def test_substantial_with_shallow_marker_blocked(repo, home):
+    _stage_substantial(repo)
+    _mark(repo, home, _SHALLOW)  # marker: level=substantial, adversarial=False
+    r = _run_hook('git commit -m "x"', repo, home)
+    assert r.returncode == 2
+    assert "review depth" in r.stderr.lower()
+
+
+def test_substantial_with_adversarial_marker_allowed(repo, home):
+    _stage_substantial(repo)
+    m = _mark(repo, home, _ADVERSARIAL)
+    assert m.returncode == 0
+    r = _run_hook('git commit -m "x"', repo, home)
+    assert r.returncode == 0, r.stderr
+
+
+def test_inline_with_shallow_marker_allowed(repo, home):
+    # A small inline change never triggers the depth requirement.
+    _stage_inline(repo)
+    _mark(repo, home, _SHALLOW)
+    r = _run_hook('git commit -m "x"', repo, home)
+    assert r.returncode == 0, r.stderr
+
+
+def test_depth_ack_allows_substantial_shallow(repo, home):
+    _stage_substantial(repo)
+    _mark(repo, home, _SHALLOW)
+    r = _run_hook('git commit -m "x"  # depth-ack', repo, home)
+    assert r.returncode == 0, r.stderr
+    assert "depth-ack honored" in r.stderr.lower()
+
+
+def test_review_override_does_not_waive_depth(repo, home):
+    # D1: '# review-override' waives FINDINGS but must NOT waive the depth requirement.
+    _stage_substantial(repo)
+    _mark(repo, home, _SHALLOW)
+    r = _run_hook('git commit -m "x"  # review-override', repo, home)
+    assert r.returncode == 2
+    assert "review depth" in r.stderr.lower()
+
+
+def test_depth_ack_inside_quotes_does_not_waive(repo, home):
+    # '# depth-ack' inside the commit MESSAGE (quoted) is not a clean trailing shell
+    # comment, so it must NOT waive depth — mirrors the other sigils' in-quote handling.
+    _stage_substantial(repo)
+    _mark(repo, home, _SHALLOW)
+    r = _run_hook('git commit -m "fix bug  # depth-ack"', repo, home)
+    assert r.returncode == 2
+    assert "review depth" in r.stderr.lower()
+
+
+def test_add_and_commit_chain_falls_back_to_marker_level(repo, home):
+    # `git add && commit` in ONE command: the index is EMPTY at hook time, so the
+    # current-staged classify reads "inline" — depth must fall back to the marker's
+    # RECORDED substantial level, or a substantial change would slip the gate here.
+    _stage_substantial(repo)
+    _mark(repo, home, _SHALLOW)  # marker.level = substantial, adversarial = False
+    _git(repo, "reset", "-q")  # empty the index → classify(cwd) would see "inline"
+    r = _run_hook('git add -A && git commit -m "x"', repo, home)
+    assert r.returncode == 2
+    assert "review depth" in r.stderr.lower()

--- a/tests/test_hooks/test_review_depth_gate.py
+++ b/tests/test_hooks/test_review_depth_gate.py
@@ -177,16 +177,14 @@ def test_stale_adversarial_marker_does_not_clear_new_diff(repo, home):
     # catch B on its own — the marker's adversarial bit counts ONLY when it is CURRENT for
     # the staged diff. (verify-RED: B committed cleanly before the diff-binding fix.)
     #
-    # NOTE the marker's diff_hash is `git diff --cached --stat` (files + line counts, a
-    # pre-existing stat-only design), so B must differ in SHAPE, not just content, for
-    # is_review_current to see it as stale. This closes the realistic case and brings
-    # depth to PARITY with Rule 2's staleness check; a same-shape content swap is a
-    # system-wide stat-hash limitation (tracked follow-up), not specific to this gate.
-    _stage_substantial(repo)  # A: f.py, +60 lines
-    m = _mark(repo, home, _ADVERSARIAL)  # adversarial marker bound to diff A
+    # Depth clearance binds the marker's FULL-content hash (marker_content_current), so
+    # even a SAME-SHAPE swap — B shares A's files and ±line counts, differing only in
+    # content — is caught (the stat-only diff_hash would collide and wrongly read current).
+    _stage_substantial(repo)  # A: f.py, +60 lines of "x{i} = {i}"
+    m = _mark(repo, home, _ADVERSARIAL)  # adversarial marker bound to diff A's content
     assert m.returncode == 0
-    # restage a DIFFERENT-SHAPE substantial diff B (f.py at +80 lines → stat differs)
-    (repo / "f.py").write_text("base = 1\n" + "".join(f"z{i} = {i}\n" for i in range(80)))
+    # restage a SAME-SHAPE substantial diff B (f.py, +60 lines, different content)
+    (repo / "f.py").write_text("base = 1\n" + "".join(f"z{i} = {i}\n" for i in range(60)))
     _git(repo, "add", "-A")
     r = _run_hook('git commit -m "x"  # review-override', repo, home)
     assert r.returncode == 2, r.stdout + r.stderr

--- a/tests/test_hooks/test_review_enforcement_commit.py
+++ b/tests/test_hooks/test_review_enforcement_commit.py
@@ -645,6 +645,17 @@ def test_user_caps_behavior_doc_only_commit_skips(repo: Path, home: Path) -> Non
     assert res.returncode == 0, res.stderr
 
 
+def test_commit_dash_am_of_unstaged_edit_is_gated(repo: Path, home: Path) -> None:
+    """`git commit -am` stages tracked edits AT COMMIT TIME, so the hook-time index is
+    empty. It must be treated as content-adding (require a valid marker) — not slip through
+    as 'no staged changes'. Regression for the -a/-am (and pathspec/-i/-o/-p) bypass class
+    that the old bare-`git add` check missed (Codex round-2 P2-A)."""
+    _git(repo, "reset", "-q")  # unstage the fixture change → clean index, unstaged f.py edit
+    res = _run_hook('git commit -am "x"', repo, home)
+    assert res.returncode == 2
+    assert "without review" in res.stderr
+
+
 def test_mixed_docs_and_code_enforced(repo: Path, home: Path) -> None:
     """One code file among docs → the whole set is NOT docs-only → enforced."""
     _restage(repo, {"README.md": "# docs\n", "foo.py": "print(1)\n"})

--- a/tests/test_hooks/test_review_enforcement_commit.py
+++ b/tests/test_hooks/test_review_enforcement_commit.py
@@ -626,6 +626,25 @@ def test_code_file_still_enforced(repo: Path, home: Path) -> None:
     assert "without review" in res.stderr
 
 
+def test_prompt_surface_only_commit_not_skipped(repo: Path, home: Path) -> None:
+    """A prompt/agent surface (.claude/agents/*.md) is NOT docs-config, so a prompt-only
+    commit does NOT take the pure-docs skip — it is substantial (behavior risk) and hits
+    the depth gate."""
+    _restage(repo, {".claude/agents/reviewer.md": "You are a reviewer.\n"})
+    res = _run_hook('git commit -m "prompt"', repo, home)
+    assert res.returncode == 2
+    assert "review depth" in res.stderr.lower()
+
+
+def test_user_caps_behavior_doc_only_commit_skips(repo: Path, home: Path) -> None:
+    """User-sovereign CAPS docs (SOUL.md/USER.md) stay docs-config → a commit touching
+    only them still takes the docs skip (the user editing their own behavior files is not
+    gated)."""
+    _restage(repo, {"SOUL.md": "# Who you are\nBe helpful.\n", "USER.md": "# User\nBrief.\n"})
+    res = _run_hook('git commit -m "soul"', repo, home)
+    assert res.returncode == 0, res.stderr
+
+
 def test_mixed_docs_and_code_enforced(repo: Path, home: Path) -> None:
     """One code file among docs → the whole set is NOT docs-only → enforced."""
     _restage(repo, {"README.md": "# docs\n", "foo.py": "print(1)\n"})

--- a/tests/test_hooks/test_shell_parse.py
+++ b/tests/test_hooks/test_shell_parse.py
@@ -107,6 +107,41 @@ class TestOverride:
         assert sp.analyze("git push # review-override: accepted P2s")[0].override
         assert sp.analyze("git push # review-override — notes")[0].override
 
+    def test_independent_sigils_coexist(self):
+        # Codex P2: two INDEPENDENT acks must be able to share one trailing comment —
+        # at escalation round 2 a genuine-but-unrecognized audit needs BOTH audit-ack
+        # (Rule 3) and depth-ack (Rule 2.5). Every whitespace token is scanned, so order
+        # is irrelevant and each sigil matches its own token.
+        for cmd in (
+            "git commit -m x # audit-ack depth-ack",
+            "git commit -m x # depth-ack audit-ack",
+        ):
+            seg = sp.analyze(cmd)[0].raw
+            assert sp.has_trailing_override(seg, sigil="audit-ack"), cmd
+            assert sp.has_trailing_override(seg, sigil="depth-ack"), cmd
+
+    def test_multi_token_still_rejects_prefix_of_longer_token(self):
+        # The multi-token scan must NOT loosen the exact-token guard: a sigil that is a
+        # prefix of a longer token still does not match.
+        seg = sp.analyze("git commit -m x # depth-ack-nope")[0].raw
+        assert not sp.has_trailing_override(seg, sigil="depth-ack")
+
+    def test_prose_mention_does_not_authorize(self):
+        # Regression (self-audit): the multi-token scan must accept a sigil only in the
+        # LEADING run of recognized ack/override tokens — a sigil appearing after prose,
+        # negated or incidental, must NOT waive the gate.
+        for cmd in (
+            "git commit -m x # not a review-override, just cleanup",
+            "git commit -m x # see review-override docs before merging",
+        ):
+            assert not sp.analyze(cmd)[0].override, cmd
+        # depth-ack buried after prose is likewise not honored
+        seg = sp.analyze("git commit -m x # TODO consider depth-ack later")[0].raw
+        assert not sp.has_trailing_override(seg, sigil="depth-ack")
+        # a non-sigil token AHEAD of a real sigil ends the run (the sigil is unreachable)
+        seg2 = sp.analyze("git commit -m x # depth-ack-nope audit-ack")[0].raw
+        assert not sp.has_trailing_override(seg2, sigil="audit-ack")
+
 
 # ── commit hook-skip flag detection ─────────────────────────────────────
 

--- a/tests/test_scripts/test_check_review_depth.py
+++ b/tests/test_scripts/test_check_review_depth.py
@@ -137,7 +137,9 @@ def test_ci_warns_loudly_on_unknown(tmp_path, capsys, monkeypatch):
 
 
 def test_ci_fails_open_on_exception(tmp_path, capsys, monkeypatch):
-    # An unexpected exception must never fail the build (exit-0-always contract).
+    # An unexpected exception must never fail the build (exit-0-always contract) — but it
+    # must ALSO emit a distinct ::warning:: (Codex P2): a green job with no annotation is
+    # indistinguishable from "not substantial", so a crash must not read as clearance.
     monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
     repo = _mk(tmp_path, {"seed.py": "x = 2\n"})
     import review_scope
@@ -150,3 +152,4 @@ def test_ci_fails_open_on_exception(tmp_path, capsys, monkeypatch):
     out = capsys.readouterr().out
     assert rc == 0
     assert "skipped" in out.lower()
+    assert "::warning" in out and "clearance" in out.lower()

--- a/tests/test_scripts/test_check_review_depth.py
+++ b/tests/test_scripts/test_check_review_depth.py
@@ -1,0 +1,152 @@
+"""Tests for scripts/check_review_depth.py — the CI review-depth advisory.
+
+Advisory by design: exit 0 always; emits a ::warning:: annotation ONLY when the PR
+range (base...HEAD) classifies substantial. Hermetic tmp_path repos with a simulated
+``refs/remotes/origin/main`` base ref.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS))  # so check_review_depth's lazy `import review_scope` resolves
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_chk = _load("check_review_depth")
+
+
+def _git(repo: Path, *args: str) -> str:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, env=env, check=True
+    ).stdout
+
+
+def _mk(tmp_path: Path, second: dict[str, str]) -> Path:
+    """Seed commit becomes origin/main; a second commit adds `second` files."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "seed.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "seed")
+    base = _git(repo, "rev-parse", "HEAD").strip()
+    _git(repo, "update-ref", "refs/remotes/origin/main", base)  # simulate the remote base
+    for name, content in second.items():
+        (repo / name).write_text(content)
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "work")
+    return repo
+
+
+def test_ci_flags_substantial(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    repo = _mk(tmp_path, {"big.py": "def f():\n" + "".join(f"    y{i} = {i}\n" for i in range(60))})
+    rc = _chk.main(cwd=str(repo))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "::warning" in out
+    assert "SUBSTANTIAL" in out
+
+
+def test_ci_quiet_on_inline(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    repo = _mk(tmp_path, {"seed.py": "x = 2\n"})  # 1-line inline change
+    rc = _chk.main(cwd=str(repo))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "::warning" not in out
+    assert "inline" in out
+
+
+def test_ci_skips_without_base(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    monkeypatch.delenv("PR_BASE_SHA", raising=False)
+    repo = tmp_path / "plain"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")  # a git repo but NO origin/main ref
+    (repo / "seed.py").write_text("x = 1\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "seed")
+    rc = _chk.main(cwd=str(repo))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no resolvable base" in out
+
+
+_BIG = {"big.py": "def f():\n" + "".join(f"    y{i} = {i}\n" for i in range(60))}
+
+
+def test_ci_resolves_from_github_base_ref(tmp_path, capsys, monkeypatch):
+    # The PRIMARY real-CI path: base from origin/$GITHUB_BASE_REF (not the fallback).
+    monkeypatch.delenv("PR_BASE_SHA", raising=False)
+    repo = _mk(tmp_path, _BIG)
+    base = _git(repo, "rev-parse", "refs/remotes/origin/main").strip()
+    _git(repo, "update-ref", "refs/remotes/origin/dev", base)
+    monkeypatch.setenv("GITHUB_BASE_REF", "dev")
+    rc = _chk.main(cwd=str(repo))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "::warning" in out and "origin/dev" in out
+
+
+def test_ci_resolves_from_pr_base_sha(tmp_path, capsys, monkeypatch):
+    # Event base SHA takes precedence and works even with origin/* refs removed.
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    repo = _mk(tmp_path, _BIG)
+    base = _git(repo, "rev-parse", "refs/remotes/origin/main").strip()
+    _git(repo, "update-ref", "-d", "refs/remotes/origin/main")  # prove the SHA path resolves
+    monkeypatch.setenv("PR_BASE_SHA", base)
+    rc = _chk.main(cwd=str(repo))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "::warning" in out and "SUBSTANTIAL" in out
+
+
+def test_ci_warns_loudly_on_unknown(tmp_path, capsys, monkeypatch):
+    # A git error / unreachable range returns "unknown" — it must FAIL LOUD, never
+    # masquerade as "no depth requirement" clearance.
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    repo = _mk(tmp_path, {"seed.py": "x = 2\n"})
+    import review_scope
+
+    monkeypatch.setattr(review_scope, "classify_range_substantiality", lambda *a, **k: "unknown")
+    rc = _chk.main(cwd=str(repo))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "::warning" in out and "not computable" in out.lower()
+
+
+def test_ci_fails_open_on_exception(tmp_path, capsys, monkeypatch):
+    # An unexpected exception must never fail the build (exit-0-always contract).
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    repo = _mk(tmp_path, {"seed.py": "x = 2\n"})
+    import review_scope
+
+    def _boom(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(review_scope, "classify_range_substantiality", _boom)
+    rc = _chk.main(cwd=str(repo))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "skipped" in out.lower()

--- a/tests/test_scripts/test_review_depth.py
+++ b/tests/test_scripts/test_review_depth.py
@@ -163,6 +163,26 @@ def test_small_skill_surface_is_substantial(tmp_path):
     assert _classify(repo) == "substantial"
 
 
+def test_identity_prompt_template_is_substantial(tmp_path):
+    # Runtime prompt templates under src/genesis/identity/ (CODE_AUDITOR, INBOX_EVALUATE,
+    # …) are behavior surfaces — a small edit is substantial (Codex round-2 P2-D).
+    repo = _mk_repo(tmp_path)
+    (repo / "src" / "genesis" / "identity").mkdir(parents=True)
+    (repo / "src" / "genesis" / "identity" / "CODE_AUDITOR.md").write_text("audit hard\n")
+    _git(repo, "add", "-A")
+    assert _classify(repo) == "substantial"
+
+
+def test_runtime_prompts_dir_is_substantial(tmp_path):
+    # Any prompts/ package under the runtime tree (autonomy/executor/prompts,
+    # sentinel/prompts, …) is a behavior surface — enumerated, not just named roots.
+    repo = _mk_repo(tmp_path)
+    (repo / "src" / "genesis" / "sentinel" / "prompts").mkdir(parents=True)
+    (repo / "src" / "genesis" / "sentinel" / "prompts" / "SENTINEL.md").write_text("watch\n")
+    _git(repo, "add", "-A")
+    assert _classify(repo) == "substantial"
+
+
 def test_user_caps_behavior_doc_is_inline(tmp_path):
     # User-sovereign CAPS behavior docs (SOUL.md/USER.md/CLAUDE.md) are NOT prompt
     # surfaces: the user editing their own behavior files is not gated (docs-config).

--- a/tests/test_scripts/test_review_depth.py
+++ b/tests/test_scripts/test_review_depth.py
@@ -4,9 +4,10 @@ Two units under test (both fail-open / advisory — the CI review-depth check is
 real backstop):
   * review_scope.classify_change_substantiality — STAGED-diff (--cached) based
     substantiality, so it shares the review marker's basis (no mark-vs-commit
-    thrash). Substantial when reviewable lines ≥ 50 OR >1 code file OR a new code
-    file OR a domain-sensitive scope_tag (auth/api/migrations). Docs/binary/vendored
-    lines never inflate it.
+    thrash). A surface-area × risk model: substantial when reviewable lines ≥ 50 OR
+    >1 code file (surface area) OR a domain-sensitive scope_tag (auth/api/migrations —
+    risk). Mere newness of a file is NOT a trigger. Docs/binary/vendored lines never
+    inflate it.
   * review_state._evidence_is_adversarial — lenient STRUCTURAL check (ladder OR
     scope-check) AND file:line engagement AND a length floor, so a real audit in
     any reviewer's vocabulary passes but a shallow "looks good" one-liner fails.
@@ -103,18 +104,43 @@ def test_more_than_one_code_file_is_substantial(tmp_path):
     assert _classify(repo) == "substantial"
 
 
-def test_new_code_file_is_substantial(tmp_path):
+def test_small_new_code_file_is_inline(tmp_path):
+    # Surface-area × risk model: newness ALONE is not substantial. A trivial single new
+    # file of little consequence is INLINE — Rule 2 still requires *a* review, just not
+    # an adversarial audit. It escalates only via line count, >1 file, or a domain scope
+    # (the three tests around this one). (verify-RED: asserted substantial before this.)
     repo = _mk_repo(tmp_path)
-    (repo / "brandnew.py").write_text("def n():\n    return 0\n")  # small but NEW
+    (repo / "brandnew.py").write_text("def n():\n    return 0\n")  # small AND new
+    _git(repo, "add", "brandnew.py")
+    assert _classify(repo) == "inline"
+
+
+def test_large_new_code_file_is_substantial(tmp_path):
+    # A new file is NOT exempt when it carries real surface area (≥50 reviewable lines) —
+    # the line-count trigger fires regardless of add-vs-modify.
+    repo = _mk_repo(tmp_path)
+    (repo / "brandnew.py").write_text(
+        "def n():\n" + "".join(f"    y{i} = {i}\n" for i in range(60))
+    )
     _git(repo, "add", "brandnew.py")
     assert _classify(repo) == "substantial"
 
 
 def test_domain_sensitive_scope_tag_is_substantial(tmp_path):
     repo = _mk_repo(tmp_path)
-    # small, single, existing (not new) — the ONLY trigger is the auth scope_tag
+    # small, single, existing (not new) — the ONLY trigger is the auth scope_tag: a
+    # small change to a CRITICAL file still warrants an adversarial audit (risk axis).
     (repo / "auth_service.py").write_text("def login():\n    return False\n")
     _git(repo, "add", "auth_service.py")
+    assert _classify(repo) == "substantial"
+
+
+def test_small_new_domain_file_is_substantial(tmp_path):
+    # Risk axis for a NEW file: small + single + new, but auth-scoped → substantial.
+    # Newness is not the trigger; the critical scope is.
+    repo = _mk_repo(tmp_path)
+    (repo / "auth_helper.py").write_text("def check():\n    return False\n")  # small, new, auth
+    _git(repo, "add", "auth_helper.py")
     assert _classify(repo) == "substantial"
 
 
@@ -144,7 +170,7 @@ def test_rename_single_code_file_is_inline(tmp_path):
 
 def test_new_binary_asset_is_inline(tmp_path):
     # NOTE 3 (audit-found): a binary asset is not code to review — adding one must not
-    # trip new_code_file → substantial.
+    # inflate substantiality (it is excluded from the reviewable set entirely).
     repo = _mk_repo(tmp_path)
     (repo / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
     _git(repo, "add", "logo.png")

--- a/tests/test_scripts/test_review_depth.py
+++ b/tests/test_scripts/test_review_depth.py
@@ -144,6 +144,35 @@ def test_small_new_domain_file_is_substantial(tmp_path):
     assert _classify(repo) == "substantial"
 
 
+def test_small_prompt_surface_is_substantial(tmp_path):
+    # Behavior risk: a small change to an executable prompt/agent surface is substantial —
+    # an autonomous system editing its own prompts is high-consequence (SKILL.md policy).
+    repo = _mk_repo(tmp_path)
+    (repo / ".claude" / "agents").mkdir(parents=True)
+    (repo / ".claude" / "agents" / "reviewer.md").write_text("You are a reviewer.\n")  # tiny
+    _git(repo, "add", "-A")
+    assert _classify(repo) == "substantial"
+
+
+def test_small_skill_surface_is_substantial(tmp_path):
+    # A small edit to a skill package (behavior surface) is substantial.
+    repo = _mk_repo(tmp_path)
+    (repo / ".claude" / "skills" / "foo").mkdir(parents=True)
+    (repo / ".claude" / "skills" / "foo" / "SKILL.md").write_text("do the thing\n")
+    _git(repo, "add", "-A")
+    assert _classify(repo) == "substantial"
+
+
+def test_user_caps_behavior_doc_is_inline(tmp_path):
+    # User-sovereign CAPS behavior docs (SOUL.md/USER.md/CLAUDE.md) are NOT prompt
+    # surfaces: the user editing their own behavior files is not gated (docs-config).
+    repo = _mk_repo(tmp_path)
+    (repo / "SOUL.md").write_text("# Who you are\nBe helpful.\n")
+    (repo / "USER.md").write_text("# The user\nPrefers brevity.\n")
+    _git(repo, "add", "-A")
+    assert _classify(repo) == "inline"
+
+
 def test_large_docs_only_change_is_inline(tmp_path):
     repo = _mk_repo(tmp_path)
     (repo / "seed.md").write_text("seed\n" + "".join(f"line {i}\n" for i in range(80)))

--- a/tests/test_scripts/test_review_depth.py
+++ b/tests/test_scripts/test_review_depth.py
@@ -1,0 +1,260 @@
+"""Tests for the review-DEPTH gate primitives in scripts/.
+
+Two units under test (both fail-open / advisory — the CI review-depth check is the
+real backstop):
+  * review_scope.classify_change_substantiality — STAGED-diff (--cached) based
+    substantiality, so it shares the review marker's basis (no mark-vs-commit
+    thrash). Substantial when reviewable lines ≥ 50 OR >1 code file OR a new code
+    file OR a domain-sensitive scope_tag (auth/api/migrations). Docs/binary/vendored
+    lines never inflate it.
+  * review_state._evidence_is_adversarial — lenient STRUCTURAL check (ladder OR
+    scope-check) AND file:line engagement AND a length floor, so a real audit in
+    any reviewer's vocabulary passes but a shallow "looks good" one-liner fails.
+
+All git fixtures are synthetic tmp_path repos — install-agnostic.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_rs = _load("review_scope")
+_state = _load("review_state")
+
+
+# --------------------------------------------------------------------------- #
+# git fixtures
+# --------------------------------------------------------------------------- #
+def _git(repo: Path, *args: str) -> str:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    out = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return out.stdout
+
+
+def _mk_repo(tmp_path: Path) -> Path:
+    """Repo seeded with committed baseline files the tests then stage edits onto."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "seed.md").write_text("seed\n")
+    (repo / "helper.py").write_text("def helper():\n    return 1\n")
+    (repo / "helper2.py").write_text("def helper2():\n    return 2\n")
+    (repo / "auth_service.py").write_text("def login():\n    return True\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "seed")
+    return repo
+
+
+def _classify(repo: Path) -> str:
+    return _rs.classify_change_substantiality(cwd=str(repo))
+
+
+# --------------------------------------------------------------------------- #
+# classify_change_substantiality
+# --------------------------------------------------------------------------- #
+def test_small_single_code_edit_is_inline(tmp_path):
+    repo = _mk_repo(tmp_path)
+    (repo / "helper.py").write_text("def helper():\n    return 3\n")  # 1-line change
+    _git(repo, "add", "helper.py")
+    assert _classify(repo) == "inline"
+
+
+def test_fifty_plus_reviewable_lines_is_substantial(tmp_path):
+    repo = _mk_repo(tmp_path)
+    (repo / "helper.py").write_text(
+        "def helper():\n" + "".join(f"    x{i} = {i}\n" for i in range(60))
+    )
+    _git(repo, "add", "helper.py")
+    assert _classify(repo) == "substantial"
+
+
+def test_more_than_one_code_file_is_substantial(tmp_path):
+    repo = _mk_repo(tmp_path)
+    (repo / "helper.py").write_text("def helper():\n    return 3\n")
+    (repo / "helper2.py").write_text("def helper2():\n    return 4\n")
+    _git(repo, "add", "helper.py", "helper2.py")
+    assert _classify(repo) == "substantial"
+
+
+def test_new_code_file_is_substantial(tmp_path):
+    repo = _mk_repo(tmp_path)
+    (repo / "brandnew.py").write_text("def n():\n    return 0\n")  # small but NEW
+    _git(repo, "add", "brandnew.py")
+    assert _classify(repo) == "substantial"
+
+
+def test_domain_sensitive_scope_tag_is_substantial(tmp_path):
+    repo = _mk_repo(tmp_path)
+    # small, single, existing (not new) — the ONLY trigger is the auth scope_tag
+    (repo / "auth_service.py").write_text("def login():\n    return False\n")
+    _git(repo, "add", "auth_service.py")
+    assert _classify(repo) == "substantial"
+
+
+def test_large_docs_only_change_is_inline(tmp_path):
+    repo = _mk_repo(tmp_path)
+    (repo / "seed.md").write_text("seed\n" + "".join(f"line {i}\n" for i in range(80)))
+    _git(repo, "add", "seed.md")
+    assert _classify(repo) == "inline"  # docs lines must NOT inflate substantiality
+
+
+def test_docs_flood_plus_tiny_code_is_inline(tmp_path):
+    repo = _mk_repo(tmp_path)
+    (repo / "seed.md").write_text("seed\n" + "".join(f"line {i}\n" for i in range(80)))
+    (repo / "helper.py").write_text("def helper():\n    return 9\n")  # 1 reviewable line
+    _git(repo, "add", "seed.md", "helper.py")
+    assert _classify(repo) == "inline"  # only reviewable (non-docs) lines count
+
+
+def test_rename_single_code_file_is_inline(tmp_path):
+    # SHOULD-FIX 1 (audit-found): a pure rename of ONE code file is ONE logical file,
+    # not two. name-status emits both src+dst; counting records double-counted it as
+    # >1 code file → substantial. (verify-RED: this asserted substantial before the fix.)
+    repo = _mk_repo(tmp_path)
+    _git(repo, "mv", "helper.py", "renamed_helper.py")
+    assert _classify(repo) == "inline"
+
+
+def test_new_binary_asset_is_inline(tmp_path):
+    # NOTE 3 (audit-found): a binary asset is not code to review — adding one must not
+    # trip new_code_file → substantial.
+    repo = _mk_repo(tmp_path)
+    (repo / "logo.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 64)
+    _git(repo, "add", "logo.png")
+    assert _classify(repo) == "inline"
+
+
+def test_no_staged_changes_is_inline(tmp_path):
+    repo = _mk_repo(tmp_path)
+    assert _classify(repo) == "inline"
+
+
+def test_classify_range_substantial(tmp_path):
+    # classify_range_substantiality uses base...HEAD (the CI PR-range basis) with the
+    # SAME predicate as the staged path.
+    repo = _mk_repo(tmp_path)
+    (repo / "big.py").write_text("def f():\n" + "".join(f"    y{i} = {i}\n" for i in range(60)))
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "big")
+    base = _git(repo, "rev-parse", "HEAD~1").strip()
+    assert _rs.classify_range_substantiality(base, cwd=str(repo)) == "substantial"
+
+
+def test_outside_git_repo_is_unknown(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert _rs.classify_change_substantiality(cwd=str(plain)) == "unknown"
+
+
+# --------------------------------------------------------------------------- #
+# _evidence_is_adversarial
+# --------------------------------------------------------------------------- #
+_ARCHITECT = (
+    "Scope Check: CLEAN\n"
+    "BLOCKER 1 — the marker at review_state.py:241 is self-reported.\n"
+    "SHOULD-FIX 2 — classify at review_scope.py:433 reuses the wrong basis.\n"
+    "NOTE 3 — import topology risk at review_scope.py:49.\n"
+    "Completion status: DONE_WITH_CONCERNS.\n" + "x" * 300
+)
+_SECURITY = (
+    "CRITICAL: SQL injection in db.py:42 — unparameterized query.\n"
+    "HIGH: path traversal at io.py:88.\n"
+    "LOW: verbose error at api.py:12.\n" + "y" * 300
+)
+_CODEX = "P1: race at loop.py:1784.\nP2: cooldown at loop.py:1790.\n" + "z" * 350
+_JSON_AUDIT = '[{"file":"a.py","line":10,"severity":"high","category":"async_state"}]\n' + "q" * 350
+_CLEAN_AUDIT = (
+    "Scope Check: covered helper.py:2, auth_service.py:2, review_scope.py:433. "
+    "Enumerated the edge/boundary/sentinel class; no BLOCKER or SHOULD-FIX found. "
+    "NOTE: consider a test for the rename case at review_scope.py:472.\n" + "w" * 250
+)
+
+
+def test_accepts_architect_ladder():
+    ok, _ = _state._evidence_is_adversarial(_ARCHITECT)
+    assert ok
+
+
+def test_accepts_security_ladder():
+    assert _state._evidence_is_adversarial(_SECURITY)[0]
+
+
+def test_accepts_codex_ladder():
+    assert _state._evidence_is_adversarial(_CODEX)[0]
+
+
+def test_accepts_code_auditor_json():
+    assert _state._evidence_is_adversarial(_JSON_AUDIT)[0]
+
+
+def test_accepts_clean_but_engaged_audit():
+    assert _state._evidence_is_adversarial(_CLEAN_AUDIT)[0]
+
+
+def test_rejects_short_stub():
+    ok, msg = _state._evidence_is_adversarial("Looks good. 88% confident.")
+    assert not ok
+    assert "short" in msg
+
+
+def test_rejects_long_prose_without_ladder_or_fileline():
+    ok, msg = _state._evidence_is_adversarial("The change looks reasonable overall. " * 30)
+    assert not ok
+
+
+def test_rejects_uppercase_ladder_without_file_engagement():
+    # An uppercase ladder label is present, but there is NO file:line / JSON
+    # engagement → rejected on engagement (not on the ladder).
+    ok, msg = _state._evidence_is_adversarial(
+        "CRITICAL: there is a serious problem somewhere in this module. " * 12
+    )
+    assert not ok
+    assert "file:line" in msg
+
+
+def test_rejects_shallow_high_confidence_prose_even_with_fileline():
+    # SHOULD-FIX 2 (audit-found): lowercase "high confidence / low risk" is the exact
+    # phrasing a rubber stamp uses — it must NOT satisfy the ladder even WITH a
+    # file:line pointer. (This PASSED before the case-sensitivity fix — verify-RED.)
+    text = "Reviewed helper.py:2 — high confidence, low risk, medium effort overall. " * 12
+    ok, msg = _state._evidence_is_adversarial(text)
+    assert not ok
+    assert "ladder" in msg
+
+
+# --------------------------------------------------------------------------- #
+# get_marker_depth
+# --------------------------------------------------------------------------- #
+def test_get_marker_depth_absent_is_none_false(tmp_path, monkeypatch):
+    monkeypatch.setattr(_state, "_MARKER_DIR", tmp_path / "markers")
+    monkeypatch.setattr(_state, "_LEGACY_STATE_FILE", tmp_path / "legacy.json")
+    level, adversarial = _state.get_marker_depth(cwd=str(tmp_path))
+    assert level is None
+    assert adversarial is False


### PR DESCRIPTION
## Why

The commit review gate was **depth-blind**: the review marker recorded only file
existence + mtime, so a shallow precision-filtered "no findings" inline pass and a
deep adversarial audit were indistinguishable. A substantial change could be
self-certified. This adds a front-stop that distinguishes the two — and, just as
importantly, is **honest about where enforcement actually lives**.

## What

**Local commit hook (advisory anti-autopilot friction):**
- `review_scope.classify_change_substantiality` (staged `--cached`) + a shared
  `_substantiality_level` predicate + `classify_range_substantiality` (`base...HEAD`).
  Substantial (a **surface-area × risk** model) = ≥50 reviewable lines OR >1 distinct code
  file (surface area) OR an auth/api/migrations scope tag OR an **executable prompt/agent/
  skill surface** (`.claude/agents|commands|skills/*`, `src/genesis/skills/*` — behavior
  risk). Mere newness of a file is NOT a trigger: a trivial new file is `inline` (Rule 2
  still requires a review, just not an adversarial audit); a small change to a critical file
  stays substantial. User-sovereign top-level CAPS docs (`SOUL.md`/`USER.md`/`CLAUDE.md`)
  are exempt. Renames count once; binary/docs/vendored excluded.
- `review_state._evidence_is_adversarial` — a *lenient structural* check (a severity
  ladder OR scope-check, AND `file:line`/JSON engagement, AND a length floor). Accepts
  every real reviewer's vocabulary (genesis-architect, genesis-security, Codex,
  CODE_AUDITOR JSON); rejects a rubber stamp. `mark_reviewed` now **computes** the level
  and **derives** the adversarial bit — neither is self-reported.
- `review_enforcement_commit` **Rule 2.5**: blocks a substantial change whose marker is
  non-adversarial, placed *before* the review-exists rule so a findings `# review-override`
  cannot waive depth; `# depth-ack` is the logged escape. Fails **open** on any error.
- Fixes the phantom `superpowers:code-reviewer` reference → `genesis-architect`.

**CI (visibility) + independent reviewer:**
- `scripts/check_review_depth.py` + a `review-depth-check` job: recompute substantiality
  on the PR range and emit a loud `::warning::` when substantial. Advisory (exit-0-always);
  fails **loud** on an uncomputable range (an error must never read as clearance) and
  **open** on exception. Prefers the event base SHA like `leak-detector`.
- `AGENTS.md`: an adversarial-review mandate the cross-tool reviewers (incl. the Codex PR
  bot) read.

**Docs:** `genesis-development/SKILL.md` documents the machine-checked depth decision + the
honest enforcement model.

## The honest model (why the local hook is advisory)

On a single-user-authored repo the same actor can edit the hook or hand-write the marker,
so a local gate is **not tamper-proof**. This PR does not pretend otherwise. The enforcing
teeth live where the author has no commit-time control: the **independent cloud reviewer
(Codex)** + a **required human approval** + **branch protection** + the CI advisory. The
local hook's job is to interrupt autopilot.

## Dogfood

This PR's own review-depth commit was audited by a fresh-context `genesis-architect`
adversarial pass, which found **4 real defects in the gate's own construction** (a rename
double-count → mis-classified as substantial; a near-noop ladder regex that let "high
confidence" prose pass; binary-as-code; test gaps) — all fixed with verify-RED tests. The
theory demonstrating itself.

## Verification

131 tests (substantiality unit + gate integration + escalation regression + CI-script),
ruff clean, privacy scan clean.

## Review rounds (follow-up commits)

A fresh-context `genesis-architect` adversarial audit + two Codex bot rounds were addressed:

**Round 1**
- **Substantiality → surface-area × risk** (above): dropped the unconditional new-code-file
  trigger so trivial new files don't demand an adversarial audit.
- **Diff-binding (Codex P2):** Rule 2.5 trusts the marker's adversarial bit only when it is
  current for the staged diff, so an audit of an earlier diff can't clear a later one waived
  past Rule 2 by `# review-override`.
- **Coexisting acks (Codex P2):** `_has_trailing_override` accepts a sigil only in the
  *leading contiguous run* of recognized ack tokens — `# audit-ack depth-ack` waives both,
  but a prose/negated mention (`# not a review-override`) does not.
- **CI visibility (Codex P2):** `check_review_depth.py` emits a distinct `::warning::` on an
  unexpected error, so a crashed job can't read as clearance.

**Round 2**
- **Content-bound clearance (Codex P2):** the marker now records a full-content hash
  (`_staged_content_hash`) and `marker_content_current()` grants adversarial clearance only
  when the staged content matches what was audited. This closes the *same-shape* swap (diff B
  sharing A's files and ±line counts) the stat-only hash collided on — previously a residual,
  now fixed; fails closed on mismatch.
- **Prompt-surface risk (Codex P2):** executable prompt/agent/skill surfaces are depth-
  sensitive (see What), no longer swallowed by the pure-docs skip; user CAPS docs stay exempt.

**Round 3**
- **Content-selecting commits (Codex P2):** Rule 2.5 and Rule 2 now branch on the existing
  `_commit_may_add_content()` (the docs-skip's predicate) instead of a bare-`git add` check,
  so `git commit -am`, a pathspec commit, `-i/-o/-p`, and a preceding `git rm/mv/reset` are
  gated (fall back to a valid/recorded marker) rather than slipping as "no staged changes".
- **Full prompt-root class (Codex P2):** added `src/genesis/identity/*` (runtime prompt
  templates) and any `src/genesis/**/prompts/*` (executor, sentinel) to the behavior-risk
  surfaces — the class, not just the named roots.
- **Declined (tracked):** two contrived edge cases — a batch `.py→.md` rename to excluded
  destinations, and self-marking source as binary via `.gitattributes` — are outside the
  advisory gate's threat model (the single author can bypass the local hook anyway) and are
  tracked as follow-ups rather than chased.

## Follow-ups (not blocking)

- **Branch protection** must be enabled (currently off) for CI checks to actually gate
  merge — this is the lever that turns the whole thing from advisory into enforcing.
- Substantiality edge cases (declined above): reviewable rename-source counting when the
  rename destination is excluded; retaining source paths reported binary via `.gitattributes`
  as substantial. Contrived / outside the advisory gate's threat model.
- A hermetic merge-commit-HEAD (`refs/pull/N/merge`) range test for the CI check (range
  semantics verified by reasoning; real-CI shape untested).
- The `git add && commit` add-chain path uses an age-only marker check (pre-existing
  hash-blindness) — depth falls back to the recorded marker level, but worth hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)