### PR TITLE
fix(ego): thread cycle exception into cadence failure recorder

### DIFF
--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -1086,7 +1086,7 @@ class EgoCadenceManager:
                 return "ran"
             except Exception as exc:
                 logger.error("Unified cycle failed", exc_info=True)
-                self._record_failure(str(exc))
+                self._record_failure(str(exc), exc=exc)
                 return "ran"
 
             if cycle is None:
@@ -1291,8 +1291,15 @@ class EgoCadenceManager:
         except Exception:
             logger.debug("Failed to record ego job success", exc_info=True)
 
-    def _record_failure(self, error: str) -> None:
-        """Increment circuit breaker, record job failure."""
+    def _record_failure(self, error: str, *, exc: BaseException | None = None) -> None:
+        """Increment circuit breaker, record job failure.
+
+        When an exception caused the failure, pass it as *exc*: ``record_job_failure``
+        then derives ``error_type``/``error_frames`` and emits the throttled
+        ``job.failed`` reflex event (ingested since #1304). Semantic failures with no
+        exception behind them (e.g. "cycle produced no usable output") pass ``exc=None``
+        and stay off the reflex bus — they are not Genesis bugs the reflex arc can act on.
+        """
         self._consecutive_failures += 1
 
         if self._consecutive_failures >= self._config.consecutive_failure_limit:
@@ -1312,6 +1319,7 @@ class EgoCadenceManager:
             GenesisRuntime.instance().record_job_failure(
                 self._session._source_tag,
                 error,
+                exc=exc,
             )
         except ImportError:
             pass

--- a/tests/ego/test_cadence.py
+++ b/tests/ego/test_cadence.py
@@ -1625,7 +1625,7 @@ class TestJobHealthKeyPerEgo:
             classmethod(lambda cls: mock_rt),
         )
         cadence._record_failure("boom")
-        mock_rt.record_job_failure.assert_called_once_with(source_tag, "boom")
+        mock_rt.record_job_failure.assert_called_once_with(source_tag, "boom", exc=None)
 
     async def test_two_egos_write_distinct_keys(
         self,

--- a/tests/test_ego/test_cadence_failure_recording.py
+++ b/tests/test_ego/test_cadence_failure_recording.py
@@ -1,0 +1,69 @@
+"""Tests for EgoCadenceManager._record_failure exception threading.
+
+Regression guard for follow-up ff762018: the ego cadence failure recorder must
+forward the caught exception to ``record_job_failure`` so exception-driven
+ego-cycle failures carry ``error_type``/``error_frames`` and fire the throttled
+``job.failed`` reflex event (the reflex arc ingests job.failed since #1304).
+Semantic (no-exception) failures must forward ``exc=None`` so they correctly
+stay off the reflex bus.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from genesis.ego.cadence import EgoCadenceManager
+
+
+def _make_manager() -> EgoCadenceManager:
+    """Minimal manager instance for exercising _record_failure in isolation.
+
+    Avoids the heavyweight __init__ (session/db/scheduler) — _record_failure
+    only touches the circuit-breaker fields, _config, and _session._source_tag.
+    """
+    mgr = object.__new__(EgoCadenceManager)
+    mgr._consecutive_failures = 0
+    mgr._circuit_open_until = None
+    mgr._config = SimpleNamespace(consecutive_failure_limit=3, failure_backoff_minutes=30)
+    mgr._session = SimpleNamespace(_source_tag="genesis_ego_cycle")
+    return mgr
+
+
+def test_record_failure_forwards_exception():
+    """Exception path forwards exc -> error_type derived + job.failed emitted."""
+    mgr = _make_manager()
+    boom = ValueError("boom")
+    rt = MagicMock()
+    with patch("genesis.runtime.GenesisRuntime") as GR:
+        GR.instance.return_value = rt
+        mgr._record_failure(str(boom), exc=boom)
+
+    rt.record_job_failure.assert_called_once()
+    args, kwargs = rt.record_job_failure.call_args
+    assert args[0] == "genesis_ego_cycle"
+    assert args[1] == "boom"
+    assert kwargs.get("exc") is boom
+
+
+def test_record_failure_semantic_path_forwards_no_exception():
+    """Semantic (no-exc) failure forwards exc=None -> stays off the reflex bus."""
+    mgr = _make_manager()
+    rt = MagicMock()
+    with patch("genesis.runtime.GenesisRuntime") as GR:
+        GR.instance.return_value = rt
+        mgr._record_failure("unified cycle returned None")
+
+    rt.record_job_failure.assert_called_once()
+    _, kwargs = rt.record_job_failure.call_args
+    assert kwargs.get("exc") is None
+
+
+def test_record_failure_still_increments_circuit_breaker():
+    """The circuit-breaker accounting is unchanged by the exc threading."""
+    mgr = _make_manager()
+    rt = MagicMock()
+    with patch("genesis.runtime.GenesisRuntime") as GR:
+        GR.instance.return_value = rt
+        mgr._record_failure("boom", exc=RuntimeError("x"))
+    assert mgr._consecutive_failures == 1


### PR DESCRIPTION
## What

`EgoCadenceManager._record_failure` stringified the caught exception and dropped it, calling `record_job_failure(source_tag, error)` with no `exc`. So exception-driven ego-cycle failures recorded only a bare string in `job_health` and never fired the `job.failed` reflex event that the reflex arc has ingested since #1304.

This threads the exception through: `_record_failure(error, *, exc=None)` forwards `exc` to `record_job_failure`, which derives `error_type`/`error_frames` and emits the throttled `job.failed` event. Semantic (no-exception) failures — `"unified cycle returned None"`, `"cycle produced no usable output"` — pass `exc=None` and correctly stay off the bus (they are not defects the reflex arc can act on).

It's the last emitter left from the #1225/#1226 exception-threading sweep; cadence was missed because it calls `record_job_failure` through its own `_record_failure` wrapper rather than directly.

## Why it's safe

- `exc` is keyword-only, default `None` — backward compatible; the two semantic call sites are unchanged.
- No feedback loop: `job.failed` is in `_REFLEX_OWNED_EVENT_TYPES`, and the reactive-cycle subscriber returns early for it, so an ego-cycle failure does not spawn another cycle.
- Single, throttled emit (streak-onset + hourly heartbeat, ~24/day/job); no double-emit.
- The recorder stays fully try/except-wrapped, and the circuit-breaker increment precedes it.

## Testing

- New `tests/test_ego/test_cadence_failure_recording.py` (3 tests, verify-RED confirmed against the old signature): exception path forwards `exc`; semantic path forwards `exc=None`; circuit-breaker accounting unchanged.
- Existing ego suite (`test_unified_cycle`, `test_signals`) green; ruff clean.
- Adversarial architect audit: Scope CLEAN, no BLOCKER/SHOULD-FIX.
