### PR TITLE
fix(telegram): label Genesis outbound messages as outbound

### DIFF
--- a/src/genesis/channels/telegram/adapter_v2.py
+++ b/src/genesis/channels/telegram/adapter_v2.py
@@ -296,6 +296,7 @@ class TelegramAdapterV2(ChannelAdapter):
                     sender="genesis",
                     content=text,
                     thread_id=message_thread_id,
+                    direction="outbound",
                 )
         except Exception:
             log.warning("Failed to persist outreach message %s", msg.message_id, exc_info=True)

--- a/tests/test_channels/test_telegram_outbound_direction.py
+++ b/tests/test_channels/test_telegram_outbound_direction.py
@@ -1,0 +1,38 @@
+"""Regression guard for follow-up 69f30078.
+
+TelegramAdapterV2.send_message persists Genesis's own outbound messages. It must
+store them with direction="outbound" — the CRUD default is "inbound", and the
+canonical handler path (_handler_messages.py / topics.py) already passes
+direction="outbound", so this adapter store must match. Nothing branches on the
+column today, but a truthful label matters for analytics and future consumers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.channels.telegram.adapter_v2 import TelegramAdapterV2
+
+
+@pytest.mark.asyncio
+async def test_send_message_persists_outbound_direction():
+    adapter = TelegramAdapterV2(token="123:abc", conversation_loop=MagicMock())
+    adapter._app = MagicMock()  # truthy so send_message proceeds
+    fake_msg = MagicMock(message_id=999)
+    store_mock = AsyncMock()
+
+    with (
+        patch(
+            "genesis.channels.telegram.adapter_v2.send_with_client_heal",
+            new=AsyncMock(return_value=fake_msg),
+        ),
+        patch("genesis.db.crud.telegram_messages.store", new=store_mock),
+    ):
+        await adapter.send_message("12345", "hello from genesis")
+
+    store_mock.assert_awaited_once()
+    _, kwargs = store_mock.call_args
+    assert kwargs["sender"] == "genesis"
+    assert kwargs["direction"] == "outbound"


### PR DESCRIPTION
## What

`TelegramAdapterV2.send_message` persists Genesis's own outbound messages via `telegram_messages.store(sender="genesis", ...)` but did not pass `direction=`, so they defaulted to `direction="inbound"` (CRUD default). The canonical handler path (`_handler_messages.py`, `topics.py:262`) already passes `direction="outbound"`; the enumeration confirms `adapter_v2.py` was the **only** telegram store site missing it (`_handler_messages.py:1210` is `rt._memory_store`, a different store). Fix: add `direction="outbound"`.

## Scope / honesty

No code currently branches on `telegram_messages.direction` — conversation context attributes speaker by `sender` (which was already stored correctly). So this is **analytics/label-truthfulness hygiene, not a live functional bug**: the outbound rows are now labelled correctly for the dashboard and any future consumer, and align with the `(chat_id, message_id, direction)` UNIQUE semantics.

## Testing

- New `tests/test_channels/test_telegram_outbound_direction.py` (verify-RED confirmed: `KeyError: 'direction'` on the old code): asserts the adapter's store call persists `sender="genesis"`, `direction="outbound"`.
- Existing `test_telegram_adapter_v2.py` green; ruff clean.
- Adversarial review: Scope CLEAN, no BLOCKER/SHOULD-FIX; class-completeness and RED/GREEN independently re-verified.
