### PR TITLE
fix(autonomy): ship the autonomous-CLI approval gate ON by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The autonomous-CLI approval gate now ships ON by default.** Every background
+  Claude Code session Genesis dispatches must be rooted in an explicit user
+  approval — but the committed policy config shipped the gate *off*, so a fresh
+  clone with no local overlay would auto-approve autonomous sessions without
+  asking. The shipped default is now `manual_approval_required: true`; a machine
+  that deliberately runs unattended still opts out through its own gitignored
+  overlay. A guardrail test pins the committed config, so the loader's
+  file-wins-over-code-default behavior can never silently ship the gate off again.
+
 - **Inbox approvals no longer nag.** A pending "inbox evaluation" approval now
   holds until you respond — it is asked once and blocks until approved, like
   every other approval, instead of re-sending a fresh request every few hours

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,10 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 - **The autonomous-CLI approval gate now ships ON by default.** Every background
   Claude Code session Genesis dispatches must be rooted in an explicit user
   approval — but the committed policy config shipped the gate *off*, so a fresh
-  clone with no local overlay would auto-approve autonomous sessions without
-  asking. The shipped default is now `manual_approval_required: true`; a machine
-  that deliberately runs unattended still opts out through its own gitignored
-  overlay. A guardrail test pins the committed config, so the loader's
-  file-wins-over-code-default behavior can never silently ship the gate off again.
+  clone would auto-approve autonomous sessions without asking. The shipped default
+  is now `manual_approval_required: true`, and a guardrail test pins the committed
+  config so the loader's file-wins-over-code-default behavior can never silently
+  ship the gate off again.
 
 - **Inbox approvals no longer nag.** A pending "inbox evaluation" approval now
   holds until you respond — it is asked once and blocks until approved, like

--- a/config/autonomous_cli_policy.yaml
+++ b/config/autonomous_cli_policy.yaml
@@ -1,5 +1,5 @@
 autonomous_cli_fallback_enabled: true
-manual_approval_required: false
+manual_approval_required: true
 reask_interval_hours: 24
 approval_channel: telegram
 shared_export_enabled: true

--- a/docs/reference/autonomous-cli-approval-gate.md
+++ b/docs/reference/autonomous-cli-approval-gate.md
@@ -7,6 +7,22 @@ Approvals are delivered to Telegram with inline buttons and gated
 per-call-site so the system **pauses** a call site while an approval
 is in flight instead of queuing duplicate prompts.
 
+## Shipped default & override
+
+The gate ships **ON by default**: `config/autonomous_cli_policy.yaml` commits
+`manual_approval_required: true`, so a fresh clone is safe-by-default — no
+autonomous background Claude Code session runs without an explicit user approval.
+
+Note *which* layer provides that guarantee: the `AutonomousCliPolicy` dataclass
+default is also `True`, but that is **not** what protects a fresh install.
+`load_autonomous_cli_policy` honors the committed YAML value whenever the key is
+present (it is), so the **shipped file — not the code default — is the effective
+default**. A machine that deliberately runs unattended overrides the posture via
+a gitignored `config/autonomous_cli_policy.local.yaml` overlay (user-dir-first,
+deep-merged over the committed file). A guardrail test
+(`test_committed_policy_ships_manual_approval_required_true`) pins the committed
+value so the safe default cannot silently regress.
+
 ## Delivery destination
 
 Approvals are posted to the `"Approvals"` topic in the supergroup

--- a/docs/reference/autonomous-cli-approval-gate.md
+++ b/docs/reference/autonomous-cli-approval-gate.md
@@ -7,21 +7,25 @@ Approvals are delivered to Telegram with inline buttons and gated
 per-call-site so the system **pauses** a call site while an approval
 is in flight instead of queuing duplicate prompts.
 
-## Shipped default & override
+## Shipped default
 
 The gate ships **ON by default**: `config/autonomous_cli_policy.yaml` commits
 `manual_approval_required: true`, so a fresh clone is safe-by-default — no
 autonomous background Claude Code session runs without an explicit user approval.
 
-Note *which* layer provides that guarantee: the `AutonomousCliPolicy` dataclass
-default is also `True`, but that is **not** what protects a fresh install.
+Note *which* layer provides that guarantee. The `AutonomousCliPolicy` dataclass
+default is also `True`, but that is **not** what protects a fresh install:
 `load_autonomous_cli_policy` honors the committed YAML value whenever the key is
-present (it is), so the **shipped file — not the code default — is the effective
-default**. A machine that deliberately runs unattended overrides the posture via
-a gitignored `config/autonomous_cli_policy.local.yaml` overlay (user-dir-first,
-deep-merged over the committed file). A guardrail test
-(`test_committed_policy_ships_manual_approval_required_true`) pins the committed
-value so the safe default cannot silently regress.
+present (it is), so the **committed file — not the code default — is the effective
+default**. A guardrail test
+(`test_committed_policy_ships_manual_approval_required_true`) reads the committed
+YAML directly and pins it to `true`, so the safe default cannot silently regress.
+
+The gate is mandatory and non-negotiable in Genesis's own behavior: it ships on,
+and no code path bypasses, auto-approves, or default-offs it — every autonomous
+background session Genesis dispatches is rooted in an explicit user approval. (An
+operator ultimately controls their own install's config, but that is a deliberate
+act on their own machine, not a Genesis-provided way to run unattended.)
 
 ## Delivery destination
 

--- a/tests/test_autonomy/test_autonomous_dispatch.py
+++ b/tests/test_autonomy/test_autonomous_dispatch.py
@@ -1035,3 +1035,34 @@ def test_local_overlay_overrides_yaml(tmp_path: Path):
     policy = load_autonomous_cli_policy(base)
     assert policy.manual_approval_required is True
     assert policy.source == f"config:{base.name}"
+
+
+def test_committed_policy_ships_manual_approval_required_true():
+    """GUARDRAIL: the COMMITTED config/autonomous_cli_policy.yaml must ship
+    ``manual_approval_required: true`` so a fresh clone with no local overlay is
+    safe-by-default — the autonomous-CLI approval gate ON.
+
+    This reads the committed file DIRECTLY (raw YAML, bypassing
+    ``merge_local_overlay``) so it pins the *shipped artifact* regardless of any
+    machine-local ``*.local.yaml`` override. It is the class-fix that would have
+    caught the 2026-04 drift (commit ``f1ed1949``) which silently shipped the
+    gate OFF for every fresh clone while this host stayed safe only via an
+    untracked overlay.
+
+    The gate is MANDATORY & non-negotiable — see the banner on
+    ``AutonomousCliPolicy`` (cli_policy.py), CLAUDE.md "## Traps", and CC memory
+    ``cli_gate_not_negotiable``. Never ship it default-off.
+    """
+    import yaml
+
+    from genesis.autonomy.cli_policy import _CONFIG_PATH
+
+    assert _CONFIG_PATH.exists(), f"committed policy file missing: {_CONFIG_PATH}"
+    raw = yaml.safe_load(_CONFIG_PATH.read_text())
+    assert isinstance(raw, dict), f"policy file is not a mapping: {_CONFIG_PATH}"
+    assert raw.get("manual_approval_required") is True, (
+        "SECURITY: config/autonomous_cli_policy.yaml must ship "
+        "manual_approval_required: true (safe-by-default). "
+        f"Found {raw.get('manual_approval_required')!r}. The autonomous-CLI "
+        "approval gate is mandatory & non-negotiable; never ship it default-off."
+    )


### PR DESCRIPTION
## What

Ship the autonomous-CLI approval gate **ON by default**: flip the committed
`config/autonomous_cli_policy.yaml` from `manual_approval_required: false` to
`true`, and add a guardrail test that pins the committed value.

## Why

The gate is the hard trust boundary behind earned autonomy — every autonomous
background Claude Code session must be rooted in an explicit user approval. It is
marked mandatory & non-negotiable in `cli_policy.py`'s banner and in the project
guidelines, and the `AutonomousCliPolicy` dataclass default is already `True`.

But the **committed config shipped it off**, and the loader honors the YAML value
whenever the key is present (`raw.get(...)`), so the code default never engages
for a fresh clone. Net effect: **a fresh clone with no local overlay
auto-approves autonomous sessions without asking** — unsafe-by-default. The
committed `false` traces to a deliberate "friction-free installs" choice premised
on "the code default is the safe fallback" — which the loader does not actually
provide — and is superseded by the current non-negotiable standing directive.

## Change

- `config/autonomous_cli_policy.yaml`: `manual_approval_required: false → true`.
  A machine that deliberately runs unattended still opts out via its own
  gitignored `*.local.yaml` overlay (user sovereignty preserved — no validator
  added blocking that override).
- **Guardrail test** (`test_committed_policy_ships_manual_approval_required_true`):
  reads the committed YAML **raw** (bypassing the overlay merge), asserts `is True`.
  This is the class-fix that catches any future silent re-flip. Verified RED→GREEN.
- Docs: CHANGELOG entry + a "Shipped default & override" section clarifying that
  the committed file — not the code default — is the effective default.

## Onboarding implication (follow-up)

Shipping the gate on-by-default means new users **will** see approval prompts
before autonomous sessions run. Without onboarding context, that reads as either
"something is broken" (sessions silently waiting on approval) or goes unnoticed.
This needs to be surfaced in the new-user onboarding / dashboard config-tab
enablement experience — tracked as a separate design effort (the config tab has
several other first-run setup steps that warrant the same treatment).

## Verification

- `pytest tests/test_autonomy/test_autonomous_dispatch.py` → 31 passed (incl. the
  new guardrail).
- Fresh-clone read-back (committed base only, no overlay) → `manual_approval_required = True`.
- Strengthening-only: reviewed adversarially (security pass) — no findings; no path
  is made less safe; `_config_overlay` untouched so overlays still win.
- No-op on any install that already forces `true` via an overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
