### PR TITLE
fix(scripts): guard $HOME against unset under set -u across the script suite

### DIFF
--- a/scripts/apply_gstack_patches.sh
+++ b/scripts/apply_gstack_patches.sh
@@ -10,6 +10,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PATCHES_DIR="$PROJECT_DIR/config/gstack-patches"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -28,6 +28,16 @@
 #                                restore.sh to locate the source snapshot dir.
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 # Pluggable Tier-2 (off-site) backend interface — selects none/local/smb at runtime
 # (backward-compat: a configured GENESIS_BACKUP_NAS with no selector → smb).
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/backup_cc_memory.sh
+++ b/scripts/backup_cc_memory.sh
@@ -6,6 +6,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GENESIS_ROOT="${1:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,9 +12,12 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GENESIS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# HOME may be unset in some container environments; derive from passwd
+# HOME may be unset in some container environments; derive from passwd (uid,
+# not whoami — robust when the name lookup is missing) and fail closed rather
+# than proceed with HOME="" (which `set -u` would not catch).
 if [[ -z "${HOME:-}" ]]; then
-    HOME="$(getent passwd "$(whoami)" | cut -d: -f6)"
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
     export HOME
 fi
 

--- a/scripts/capture_recovery_state.sh
+++ b/scripts/capture_recovery_state.sh
@@ -3,6 +3,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 GENESIS_REPO="${GENESIS_REPO:-$HOME/genesis}"
 OUT_DIR="${1:-$HOME/tmp/genesis-recovery-$(date -u +%Y%m%dT%H%M%SZ)}"
 

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -16,6 +16,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 # SSH RemoteCommand doesn't source .bashrc (interactive guard) — set PATH explicitly
 export PATH="$HOME/.n/bin:$HOME/.bun/bin:$HOME/.npm-global/bin:$HOME/.local/bin:$PATH"
 

--- a/scripts/cc_align_host.sh
+++ b/scripts/cc_align_host.sh
@@ -25,6 +25,16 @@
 
 set -u
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 GENESIS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CC_ENV="$GENESIS_ROOT/scripts/lib/cc_version.sh"
 VENV_PY="$GENESIS_ROOT/.venv/bin/python"

--- a/scripts/cc_tmp_align_host.sh
+++ b/scripts/cc_tmp_align_host.sh
@@ -31,6 +31,16 @@
 
 set -u
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 GENESIS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENV_PY="$GENESIS_ROOT/.venv/bin/python"
 GUARDIAN_CONFIG="$HOME/.genesis/guardian_remote.yaml"

--- a/scripts/check_portability.sh
+++ b/scripts/check_portability.sh
@@ -17,6 +17,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 # --warn: NON-gating advisory sweep for the contributor-facing CI. It also
 # covers tests/ and ALWAYS exits 0 (fixtures may carry in-class placeholder
 # addresses — surfaced as warnings, never a hard block). Default (no flag)

--- a/scripts/code_intel_freeze.sh
+++ b/scripts/code_intel_freeze.sh
@@ -36,6 +36,16 @@
 
 set -u
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 REPO_PATH="${1:-}"
 if [ -z "$REPO_PATH" ]; then
     # Default to the repo this script ships in (scripts/ -> repo root).

--- a/scripts/code_intel_runner.sh
+++ b/scripts/code_intel_runner.sh
@@ -26,6 +26,16 @@
 
 set -u
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # CODE_INTEL_ENTRYPOINT is a test seam (inject a fake that returns a chosen rc);
 # it defaults to the real locked+capped entrypoint.

--- a/scripts/convert_db_nodatacow.sh
+++ b/scripts/convert_db_nodatacow.sh
@@ -35,6 +35,16 @@
 #
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 GENESIS_ROOT="${GENESIS_ROOT:-$HOME/genesis}"
 DB="${GENESIS_DB:-$GENESIS_ROOT/data/genesis.db}"
 DATA_DIR="$(dirname "$DB")"

--- a/scripts/disk_hygiene.sh
+++ b/scripts/disk_hygiene.sh
@@ -33,6 +33,16 @@
 # exercise a single step (e.g. prune_tmp) without running the whole groom.
 set -uo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -61,6 +61,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 STATE_DIR="${HOME}/.local/state/genesis-guardian"
 
 case "${SSH_ORIGINAL_COMMAND:-}" in

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -71,9 +71,12 @@ set_secret() {
 
 # ── HOME guard ───────────────────────────────────────────────
 # Ensure HOME is set (may be empty in container sessions without login shell)
-# and persisted in /etc/environment so all future sessions inherit it.
+# and persisted in /etc/environment so all future sessions inherit it. Resolve
+# from passwd by uid (robust when the name lookup is missing) and fail closed
+# rather than proceed with HOME="" (which `set -u` would not catch).
 if [ -z "${HOME:-}" ]; then
-    HOME="$(getent passwd "$(whoami)" | cut -d: -f6)"
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
     export HOME
 fi
 if ! grep -q "^HOME=" /etc/environment 2>/dev/null; then

--- a/scripts/install_guardian.sh
+++ b/scripts/install_guardian.sh
@@ -31,6 +31,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 # ── Defaults & arg parsing ────────────────────────────────────────────
 
 CONTAINER_NAME=""

--- a/scripts/lib/code_intel_index.sh
+++ b/scripts/lib/code_intel_index.sh
@@ -52,6 +52,16 @@
 
 set -u
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 REPO_PATH="${1:-}"
 TOOLS="${2:-both}"
 MODE="${3:-${CODE_INTEL_INDEX_MODE:-fast}}"

--- a/scripts/migrate-backup-history.sh
+++ b/scripts/migrate-backup-history.sh
@@ -30,6 +30,16 @@
 #   scripts/migrate-backup-history.sh [--backup-dir <path>] [--dry-run] [--yes]
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 # ── Args ─────────────────────────────────────────────────────────────
 BACKUP_DIR="${HOME:-}/backups/genesis-backups"
 DRY_RUN=false

--- a/scripts/opencode-wrapper.sh
+++ b/scripts/opencode-wrapper.sh
@@ -7,6 +7,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 OPENCODE_BIN="${HOME}/.npm-global/bin/opencode"
 
 kill_opencode() {

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -34,6 +34,16 @@
 #   - Writes ~/.genesis/restore_status.json on every run (success or failure).
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 # Pluggable Tier-2 (off-site) backend interface — selects none/local/smb at runtime
 # (backward-compat: a configured GENESIS_BACKUP_NAS with no selector → smb).
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/restore_cc_memory.sh
+++ b/scripts/restore_cc_memory.sh
@@ -6,6 +6,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GENESIS_ROOT="${1:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 

--- a/scripts/setup-local-config.sh
+++ b/scripts/setup-local-config.sh
@@ -12,6 +12,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 GENESIS_HOME="${HOME}/.genesis"
 CONFIG_DIR="${GENESIS_HOME}/config"
 LOCAL_CONFIG="${CONFIG_DIR}/genesis.yaml"

--- a/scripts/setup-vnc.sh
+++ b/scripts/setup-vnc.sh
@@ -8,6 +8,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GENESIS_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SYSTEMD_DIR="$HOME/.config/systemd/user"

--- a/scripts/spike_caveat_fixes_test.sh
+++ b/scripts/spike_caveat_fixes_test.sh
@@ -15,6 +15,16 @@
 # All state isolated to ~/tmp throwaway dirs.
 
 set -u
+
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
 set -o pipefail
 
 PASS=0

--- a/scripts/spike_cc_ensure_local_test.sh
+++ b/scripts/spike_cc_ensure_local_test.sh
@@ -14,6 +14,16 @@
 #
 # All state isolated to ~/tmp throwaway dirs.
 set -u
+
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
 set -o pipefail
 
 PASS=0

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -12,6 +12,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 POLL_INTERVAL=30
 CONF_FILE="$HOME/.genesis/config/watchgod.conf"
 STATE_FILE="$HOME/.genesis/watchgod_state.json"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -23,6 +23,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 # ── Globals ──────────────────────────────────────────────────
 MODE="default"          # default | genesis-only | guardian-only | full
 DRY_RUN=false

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -19,6 +19,17 @@
 set -Eeuo pipefail  # -E: the ERR trap is inherited by functions AND subshells
                     # (see _on_err's BASH_SUBSHELL guard for the subshell case)
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use (here: the
+# copy-to-temp guard below, before any backup/update work). Fall back to the
+# passwd entry for the current uid (same source Path.home() uses); fail closed
+# if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 # ── Copy-to-temp guard ──────────────────────────────────
 # The update script may update itself during git merge, which would corrupt
 # the running process. Industry standard (Chrome, Homebrew, Windows Update):

--- a/scripts/vendor_assets.sh
+++ b/scripts/vendor_assets.sh
@@ -8,6 +8,16 @@
 
 set -euo pipefail
 
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use. Fall back
+# to the passwd entry for the current uid (same source Path.home() uses); fail
+# closed if unresolvable. See CC memory sandbox_shell_no_home.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+    [ -n "$HOME" ] || { echo "ERROR: HOME is unset and could not be resolved from passwd." >&2; exit 1; }
+    export HOME
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 WEBUI_DIR="$REPO_DIR/src/genesis/dashboard/webui"

--- a/tests/test_scripts/test_home_guard_coverage.py
+++ b/tests/test_scripts/test_home_guard_coverage.py
@@ -1,0 +1,78 @@
+"""Guardrail: scripts using ``set -u`` + ``$HOME`` must resolve HOME before use.
+
+A stripped-env invocation (HOME unset) aborts a ``set -u`` script at its first
+``${HOME}`` expansion with "HOME: unbound variable". Scripts that both enable
+``set -u`` and dereference ``$HOME`` must carry a fallback that resolves HOME
+(passwd entry for the current uid, or the operator's home under sudo).
+
+See follow-up 731f3a11 and CC memory ``sandbox_shell_no_home``.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+
+# Scripts whose $HOME usage is NOT vulnerable to a host-side HOME-unset, with the
+# reason. Verified by reading the surrounding context on 2026-08-10.
+_ALLOWLIST = {
+    # $HOME is dereferenced inside `incus exec ... --env "HOME=/home/ubuntu"
+    # -- bash -c '...'` (container side, explicitly injected), and the one
+    # host-side home path resolves via ~${SUDO_USER} (operator home). Neither is
+    # affected by the host script's own HOME being unset.
+    "host-setup.sh",
+    # Never dereferences $HOME at runtime (uses ~${REMOTE_USER}); listed
+    # defensively so a future edit that adds a bare $HOME is a conscious choice.
+    "generate-ssh-config.sh",
+}
+
+_SET_U = re.compile(r"^\s*set\s+-[a-z]*u", re.M)
+_HOME_USE = re.compile(r"\$\{?HOME\b")
+# A guard that resolves HOME when unset: the passwd-fallback form used by
+# store_cc_token.sh / install.sh / bootstrap.sh, or the ~${SUDO_USER} operator
+# form, or a ${HOME:-...} default.
+_GUARD = re.compile(
+    r"getent passwd.*cut -d: -f6"  # passwd-uid fallback
+    r"|~\$\{SUDO_USER"  # operator-home form
+    r"|HOME=\"\$\{HOME:-",  # inline default form
+    re.S,
+)
+
+
+def _candidate_scripts():
+    for p in sorted(SCRIPTS_DIR.glob("*.sh")):
+        text = p.read_text()
+        if _SET_U.search(text) and _HOME_USE.search(text):
+            yield p, text
+
+
+def test_home_guarded_scripts_have_fallback():
+    """Every set -u script that uses $HOME resolves HOME-unset (or is allowlisted)."""
+    missing = [
+        p.name
+        for p, text in _candidate_scripts()
+        if p.name not in _ALLOWLIST and not _GUARD.search(text)
+    ]
+    assert not missing, (
+        "scripts enable `set -u` and dereference $HOME but lack a HOME-unset "
+        f"guard: {sorted(missing)}"
+    )
+
+
+def test_guard_snippet_resolves_home_when_unset():
+    """The passwd-fallback guard resolves HOME under `env -i` + `set -u`."""
+    guard = (
+        'if [ -z "${HOME:-}" ]; then '
+        'HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""; '
+        '[ -n "$HOME" ] || { echo unresolved >&2; exit 1; }; '
+        "export HOME; fi; "
+        'printf %s "$HOME"'
+    )
+    out = subprocess.run(
+        ["env", "-i", "bash", "-uc", guard],
+        capture_output=True,
+        text=True,
+    )
+    assert out.returncode == 0, f"guard aborted: {out.stderr!r}"
+    assert out.stdout.strip(), "guard did not resolve a HOME value"

--- a/tests/test_scripts/test_home_guard_coverage.py
+++ b/tests/test_scripts/test_home_guard_coverage.py
@@ -27,7 +27,12 @@ _ALLOWLIST = {
     "generate-ssh-config.sh",
 }
 
-_SET_U = re.compile(r"^\s*set\s+-[a-z]*u", re.M)
+# Any nounset spelling: `u` anywhere in any short-option cluster, any case-mix
+# and order (`set -u`, `set -euo pipefail`, `set -Eeuo pipefail`, `set -e -u`) —
+# Codex P2 2026-08-10: a lowercase-only class missed `-Eeuo` and silently passed
+# scripts/update.sh. No trailing \b after the `u`: in `-euo`/`-Eeuo` the u is
+# mid-cluster. Also covers the long form `set -o nounset` (unused today).
+_SET_U = re.compile(r"^\s*set\s+(?:-[A-Za-z]+\s+)*-[A-Za-z]*u|^\s*set\s+.*-o\s+nounset\b", re.M)
 _HOME_USE = re.compile(r"\$\{?HOME\b")
 # A guard that resolves HOME when unset: the passwd-fallback form used by
 # store_cc_token.sh / install.sh / bootstrap.sh, or the ~${SUDO_USER} operator
@@ -41,7 +46,9 @@ _GUARD = re.compile(
 
 
 def _candidate_scripts():
-    for p in sorted(SCRIPTS_DIR.glob("*.sh")):
+    # rglob, not glob: nested entry points (scripts/lib/*.sh) are runnable too —
+    # Codex P2 2026-08-10: the non-recursive scan missed lib/code_intel_index.sh.
+    for p in sorted(SCRIPTS_DIR.rglob("*.sh")):
         text = p.read_text()
         if _SET_U.search(text) and _HOME_USE.search(text):
             yield p, text


### PR DESCRIPTION
## What

Scripts that enable `set -u` and dereference `$HOME` abort at the first `${HOME}`
expansion when HOME is unset — which happens under stripped-env / systemd /
sandboxed invocations. This inserts a passwd-fallback guard (resolve HOME from
the current uid's passwd entry, fail **closed** if unresolvable) right after the
`set -*u*` line in 25 scripts, and unifies two pre-existing weaker guards
(`bootstrap.sh`, `install.sh`) onto the same fail-closed form (uid lookup instead
of name lookup, plus an explicit empty check).

## Why

A `HOME: unbound variable` abort is a silent, environment-dependent failure mode.
The guard makes these scripts robust to a missing HOME regardless of how they are
invoked, and fails closed rather than proceeding with `HOME=""`.

## Testing

- New coverage guardrail `tests/test_scripts/test_home_guard_coverage.py`:
  enumerates every `set -u` + `$HOME` script under `scripts/` and asserts each is
  guarded or allowlisted-with-reason, so a newly-added unguarded script fails the
  check. Includes a functional check that the guard resolves HOME under `env -i`.
- `bash -n` on all 27 edited scripts; `ruff` clean.
- Two scripts allowlisted with rationale: `host-setup.sh` (whole-body `sudo` /
  operator-home + container `--env HOME=` injection) and `generate-ssh-config.sh`
  (no runtime `$HOME` dereference).
