### PR TITLE
feat(ci-diag): distinguish GitHub Actions outages from real CI failures

### DIFF
--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -67,8 +67,10 @@ _GH_STATUS_TIMEOUT_S = 5  # preflight only; a slow/unreachable status page fails
 # Statuspage's documented non-operational component states. An explicit
 # allowlist: any OTHER value (schema-invalid types, new/unknown states,
 # "operational") does NOT count as degraded — fail-open by construction.
+# under_maintenance included (Codex P2): scheduled Actions maintenance stalls
+# CI for infra reasons exactly like an outage does.
 _GH_DEGRADED_STATUSES = frozenset(
-    {"degraded_performance", "partial_outage", "major_outage"}
+    {"degraded_performance", "partial_outage", "major_outage", "under_maintenance"}
 )
 
 

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -62,25 +62,41 @@ _STALE_PRIORITY_DEMOTION = {"critical": "high", "high": "medium", "medium": "med
 _BUILD_PR_CI_TIMEOUT_S = 20  # per-PR gh call; PRs are checked concurrently
 _MAX_BUILD_PR_CHECKS = 10    # cap concurrent gh calls (rate-limit safety)
 
-_GITHUB_STATUS_URL = "https://www.githubstatus.com/api/v2/status.json"
+_GITHUB_STATUS_URL = "https://www.githubstatus.com/api/v2/components.json"
 _GH_STATUS_TIMEOUT_S = 5  # preflight only; a slow/unreachable status page fails open
+# Statuspage's documented non-operational component states. An explicit
+# allowlist: any OTHER value (schema-invalid types, new/unknown states,
+# "operational") does NOT count as degraded — fail-open by construction.
+_GH_DEGRADED_STATUSES = frozenset(
+    {"degraded_performance", "partial_outage", "major_outage"}
+)
 
 
 async def _github_actions_degraded() -> bool:
-    """True only when GitHub reports an ACTIVE incident (status indicator != none).
+    """True only when the GitHub *Actions* component reports a degraded state.
 
-    Fail-OPEN: any error, timeout, or malformed payload returns False, so a real
-    CI failure is never masked as an infra outage — this only ever ADDS a hedged
-    'incident' annotation when GitHub positively confirms one. Uses the summary
-    indicator (not per-component) intentionally; the annotation is hedged, so a
-    non-Actions incident at worst adds a soft, clearly-conditional note.
+    Component-scoped (``/api/v2/components.json``, the ``Actions`` entry) — the
+    aggregate status indicator also trips on unrelated components (Packages,
+    Codespaces), which would mislabel genuine CI failures as infra incidents.
+    Degraded ONLY when the component's status is a string in the documented
+    non-operational enum (explicit allowlist). Fail-OPEN: any error, timeout,
+    missing component, or malformed/unknown status returns False, so a real CI
+    failure is never masked — this only ever ADDS a hedged 'incident' annotation
+    when GitHub positively confirms an Actions problem.
     """
     try:
         async with httpx.AsyncClient(timeout=_GH_STATUS_TIMEOUT_S) as client:
             resp = await client.get(_GITHUB_STATUS_URL)
             resp.raise_for_status()
-            indicator = ((resp.json() or {}).get("status") or {}).get("indicator")
-        return str(indicator or "none").lower() != "none"
+            components = (resp.json() or {}).get("components") or []
+        for comp in components:
+            if not isinstance(comp, dict):
+                continue
+            if str(comp.get("name") or "").strip().lower() != "actions":
+                continue
+            status = comp.get("status")
+            return isinstance(status, str) and status.lower() in _GH_DEGRADED_STATUSES
+        return False  # Actions component not found → cannot confirm → fail open
     except Exception:
         logger.debug("githubstatus preflight failed; failing open", exc_info=True)
         return False

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import aiosqlite
+import httpx
 
 from genesis.content.drafter import ContentDrafter
 from genesis.content.types import DraftRequest, FormatTarget
@@ -61,8 +62,33 @@ _STALE_PRIORITY_DEMOTION = {"critical": "high", "high": "medium", "medium": "med
 _BUILD_PR_CI_TIMEOUT_S = 20  # per-PR gh call; PRs are checked concurrently
 _MAX_BUILD_PR_CHECKS = 10    # cap concurrent gh calls (rate-limit safety)
 
+_GITHUB_STATUS_URL = "https://www.githubstatus.com/api/v2/status.json"
+_GH_STATUS_TIMEOUT_S = 5  # preflight only; a slow/unreachable status page fails open
 
-async def _pr_ci_status(pr_url: str) -> str | None:
+
+async def _github_actions_degraded() -> bool:
+    """True only when GitHub reports an ACTIVE incident (status indicator != none).
+
+    Fail-OPEN: any error, timeout, or malformed payload returns False, so a real
+    CI failure is never masked as an infra outage — this only ever ADDS a hedged
+    'incident' annotation when GitHub positively confirms one. Uses the summary
+    indicator (not per-component) intentionally; the annotation is hedged, so a
+    non-Actions incident at worst adds a soft, clearly-conditional note.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=_GH_STATUS_TIMEOUT_S) as client:
+            resp = await client.get(_GITHUB_STATUS_URL)
+            resp.raise_for_status()
+            indicator = ((resp.json() or {}).get("status") or {}).get("indicator")
+        return str(indicator or "none").lower() != "none"
+    except Exception:
+        logger.debug("githubstatus preflight failed; failing open", exc_info=True)
+        return False
+
+
+async def _pr_ci_status(
+    pr_url: str, *, actions_degraded: bool | None = None
+) -> str | None:
     """One-shot CI rollup for a draft build PR via
     ``gh pr view <url> --json statusCheckRollup``. Returns a compact word
     ('passing'/'failing'/'pending'/'no checks'), or None on error/timeout.
@@ -70,6 +96,10 @@ async def _pr_ci_status(pr_url: str) -> str | None:
     Uses the shared ``run_gh`` helper, which kills+reaps the child process on
     timeout (the process-kill sequence is easy to get subtly wrong, so it is
     not re-implemented here).
+
+    ``actions_degraded`` is the GitHub-incident state, resolved ONCE per report
+    by the caller and passed in so an outage does not trigger one status GET per
+    failing PR. When ``None`` (default), it is resolved lazily per call.
     """
     import json
 
@@ -87,7 +117,18 @@ async def _pr_ci_status(pr_url: str) -> str | None:
         checks = json.loads(raw).get("statusCheckRollup") or []
     except (ValueError, TypeError):
         return None
-    return _summarize_ci_rollup(checks)
+    summary = _summarize_ci_rollup(checks)
+    # A GitHub Actions outage surfaces as 'failing' (runner startup/cancel) or a
+    # stuck 'pending' — annotate (never suppress) when GitHub confirms an incident.
+    if summary in ("failing", "pending"):
+        degraded = (
+            actions_degraded
+            if actions_degraded is not None
+            else await _github_actions_degraded()
+        )
+        if degraded:
+            return f"{summary} (GitHub Actions incident, may not be a code issue)"
+    return summary
 
 
 def _summarize_ci_rollup(checks: list) -> str:
@@ -652,8 +693,17 @@ class MorningReportGenerator:
 
         if open_prs:
             checked = open_prs[:_MAX_BUILD_PR_CHECKS]
+            # Resolve the GitHub-incident state ONCE per report — it is global to
+            # all PRs; resolving per-PR would fire N concurrent identical status
+            # GETs during an outage (exactly when this path is hot).
+            actions_degraded = await _github_actions_degraded()
             ci_states = await asyncio.gather(
-                *[_pr_ci_status(r.get("pr_url") or "") for r in checked]
+                *[
+                    _pr_ci_status(
+                        r.get("pr_url") or "", actions_degraded=actions_degraded
+                    )
+                    for r in checked
+                ]
             )
             lines.append("")
             lines.append("Open build PRs (draft, awaiting your review/merge):")

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -486,19 +486,42 @@ class _FakeStatusClient:
         return _FakeStatusResp(self._payload)
 
 
+def _components(*entries):
+    return {"components": [dict(e) for e in entries]}
+
+
 @pytest.mark.asyncio
-async def test_github_actions_degraded_reads_indicator(monkeypatch):
+async def test_github_actions_degraded_component_scoped(monkeypatch):
+    # Operational Actions → not degraded.
     monkeypatch.setattr(
         _mr_mod.httpx, "AsyncClient",
-        lambda **kw: _FakeStatusClient(payload={"status": {"indicator": "none"}}),
+        lambda **kw: _FakeStatusClient(
+            payload=_components({"name": "Actions", "status": "operational"}),
+        ),
     )
     assert await _mr_mod._github_actions_degraded() is False
 
+    # Degraded Actions → degraded.
     monkeypatch.setattr(
         _mr_mod.httpx, "AsyncClient",
-        lambda **kw: _FakeStatusClient(payload={"status": {"indicator": "major"}}),
+        lambda **kw: _FakeStatusClient(
+            payload=_components({"name": "Actions", "status": "major_outage"}),
+        ),
     )
     assert await _mr_mod._github_actions_degraded() is True
+
+    # An UNRELATED component's outage must NOT trip the Actions preflight
+    # (the aggregate-indicator approach did — Codex P2).
+    monkeypatch.setattr(
+        _mr_mod.httpx, "AsyncClient",
+        lambda **kw: _FakeStatusClient(
+            payload=_components(
+                {"name": "Packages", "status": "major_outage"},
+                {"name": "Actions", "status": "operational"},
+            ),
+        ),
+    )
+    assert await _mr_mod._github_actions_degraded() is False
 
 
 @pytest.mark.asyncio
@@ -513,7 +536,27 @@ async def test_github_actions_degraded_fails_open(monkeypatch):
 
     monkeypatch.setattr(
         _mr_mod.httpx, "AsyncClient",
-        lambda **kw: _FakeStatusClient(payload={}),  # no 'status' key
+        lambda **kw: _FakeStatusClient(payload={}),  # no 'components' key
+    )
+    assert await _mr_mod._github_actions_degraded() is False
+
+    # Schema-invalid statuses (bool/int/object/unknown string) are NOT outages —
+    # the allowlist rejects them (Codex P2: `true`/`1` must not read as degraded).
+    for bad in (True, 1, {"level": "major"}, "weird_new_state", None):
+        monkeypatch.setattr(
+            _mr_mod.httpx, "AsyncClient",
+            lambda _bad=bad, **kw: _FakeStatusClient(
+                payload=_components({"name": "Actions", "status": _bad}),
+            ),
+        )
+        assert await _mr_mod._github_actions_degraded() is False, bad
+
+    # Actions component absent entirely → cannot confirm → fail open.
+    monkeypatch.setattr(
+        _mr_mod.httpx, "AsyncClient",
+        lambda **kw: _FakeStatusClient(
+            payload=_components({"name": "Packages", "status": "operational"}),
+        ),
     )
     assert await _mr_mod._github_actions_degraded() is False
 

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -409,10 +409,17 @@ async def test_build_lane_section_renders(db, mock_health, mock_drafter, monkeyp
                     source_file="New Genesis Capabilities.md",
                     verdict="dont_build", verdict_reason="brain-not-body scope")
 
-    async def fake_ci(url):
+    async def fake_ci(url, *, actions_degraded=None):
         return "passing"
 
     monkeypatch.setattr(_mr_mod, "_pr_ci_status", fake_ci)
+
+    async def _not_degraded():
+        return False
+
+    # _get_build_lane_section resolves the incident state once before the gather;
+    # stub it so the test makes no real githubstatus network call.
+    monkeypatch.setattr(_mr_mod, "_github_actions_degraded", _not_degraded)
 
     gen = MorningReportGenerator(mock_health, db, mock_drafter)
     section = await gen._get_build_lane_section()
@@ -444,6 +451,144 @@ async def test_pr_ci_status_none_on_empty_or_no_url(monkeypatch):
     monkeypatch.setattr(gh_cli, "run_gh", fake_run_gh)
     assert await _mr_mod._pr_ci_status("https://x/pull/1") is None
     assert await _mr_mod._pr_ci_status("") is None
+
+
+# --- GitHub Actions outage pre-flight (distinguish infra outage from real failure) ---
+
+
+class _FakeStatusResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeStatusClient:
+    """Async-context-manager stand-in for httpx.AsyncClient."""
+
+    def __init__(self, *, payload=None, exc=None):
+        self._payload = payload
+        self._exc = exc
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url):
+        if self._exc is not None:
+            raise self._exc
+        return _FakeStatusResp(self._payload)
+
+
+@pytest.mark.asyncio
+async def test_github_actions_degraded_reads_indicator(monkeypatch):
+    monkeypatch.setattr(
+        _mr_mod.httpx, "AsyncClient",
+        lambda **kw: _FakeStatusClient(payload={"status": {"indicator": "none"}}),
+    )
+    assert await _mr_mod._github_actions_degraded() is False
+
+    monkeypatch.setattr(
+        _mr_mod.httpx, "AsyncClient",
+        lambda **kw: _FakeStatusClient(payload={"status": {"indicator": "major"}}),
+    )
+    assert await _mr_mod._github_actions_degraded() is True
+
+
+@pytest.mark.asyncio
+async def test_github_actions_degraded_fails_open(monkeypatch):
+    # Unreachable / malformed status page must NOT report degraded — never mask
+    # a real CI failure as an infra outage.
+    monkeypatch.setattr(
+        _mr_mod.httpx, "AsyncClient",
+        lambda **kw: _FakeStatusClient(exc=RuntimeError("boom")),
+    )
+    assert await _mr_mod._github_actions_degraded() is False
+
+    monkeypatch.setattr(
+        _mr_mod.httpx, "AsyncClient",
+        lambda **kw: _FakeStatusClient(payload={}),  # no 'status' key
+    )
+    assert await _mr_mod._github_actions_degraded() is False
+
+
+@pytest.mark.asyncio
+async def test_pr_ci_status_annotates_on_actions_incident(monkeypatch):
+    import genesis.recon.gh_cli as gh_cli
+
+    async def fake_run_gh(*args, timeout=None):
+        return '{"statusCheckRollup": [{"conclusion": "FAILURE"}]}'
+
+    monkeypatch.setattr(gh_cli, "run_gh", fake_run_gh)
+
+    async def _degraded():
+        return True
+
+    monkeypatch.setattr(_mr_mod, "_github_actions_degraded", _degraded)
+    out = await _mr_mod._pr_ci_status("https://x/pull/1")
+    assert out is not None and out.startswith("failing")
+    assert "GitHub Actions" in out  # incident annotation present
+
+
+@pytest.mark.asyncio
+async def test_pr_ci_status_no_annotation_when_not_degraded(monkeypatch):
+    import genesis.recon.gh_cli as gh_cli
+
+    async def fake_run_gh(*args, timeout=None):
+        return '{"statusCheckRollup": [{"conclusion": "FAILURE"}]}'
+
+    monkeypatch.setattr(gh_cli, "run_gh", fake_run_gh)
+
+    async def _not_degraded():
+        return False
+
+    monkeypatch.setattr(_mr_mod, "_github_actions_degraded", _not_degraded)
+    assert await _mr_mod._pr_ci_status("https://x/pull/1") == "failing"
+
+
+@pytest.mark.asyncio
+async def test_pr_ci_status_annotates_pending_branch(monkeypatch):
+    import genesis.recon.gh_cli as gh_cli
+
+    async def fake_run_gh(*args, timeout=None):
+        return '{"statusCheckRollup": [{"status": "IN_PROGRESS"}]}'
+
+    monkeypatch.setattr(gh_cli, "run_gh", fake_run_gh)
+
+    async def _degraded():
+        return True
+
+    monkeypatch.setattr(_mr_mod, "_github_actions_degraded", _degraded)
+    out = await _mr_mod._pr_ci_status("https://x/pull/1")
+    assert out is not None and out.startswith("pending")
+    assert "GitHub Actions" in out
+
+
+@pytest.mark.asyncio
+async def test_pr_ci_status_honors_precomputed_degraded(monkeypatch):
+    # When actions_degraded is supplied by the caller, the per-call status check
+    # must NOT run (resolved once per report, not per PR).
+    import genesis.recon.gh_cli as gh_cli
+
+    async def fake_run_gh(*args, timeout=None):
+        return '{"statusCheckRollup": [{"conclusion": "FAILURE"}]}'
+
+    monkeypatch.setattr(gh_cli, "run_gh", fake_run_gh)
+
+    async def _boom():
+        raise AssertionError("must not resolve per-call when precomputed")
+
+    monkeypatch.setattr(_mr_mod, "_github_actions_degraded", _boom)
+
+    out = await _mr_mod._pr_ci_status("https://x/pull/1", actions_degraded=True)
+    assert out is not None and out.startswith("failing") and "GitHub Actions" in out
+    assert await _mr_mod._pr_ci_status("https://x/pull/1", actions_degraded=False) == "failing"
 
 
 # --- message_queue finding closure (confirm_delivery) ---

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -510,6 +510,15 @@ async def test_github_actions_degraded_component_scoped(monkeypatch):
     )
     assert await _mr_mod._github_actions_degraded() is True
 
+    # Scheduled maintenance stalls CI for infra reasons too (Codex P2).
+    monkeypatch.setattr(
+        _mr_mod.httpx, "AsyncClient",
+        lambda **kw: _FakeStatusClient(
+            payload=_components({"name": "Actions", "status": "under_maintenance"}),
+        ),
+    )
+    assert await _mr_mod._github_actions_degraded() is True
+
     # An UNRELATED component's outage must NOT trip the Actions preflight
     # (the aggregate-indicator approach did — Codex P2).
     monkeypatch.setattr(


### PR DESCRIPTION
## What

The morning report's build-lane CI rollup collapses a GitHub Actions outage into
`failing` (runner startup/cancel) or an indefinite `pending` — indistinguishable
from a genuine code failure. This adds a **fail-open** githubstatus preflight
(`_github_actions_degraded`): GET `githubstatus.com/api/v2/status.json`, and
**only** when it positively confirms an active incident **and** the rollup is
`failing`/`pending`, append a hedged `(GitHub Actions incident, may not be a code
issue)` note.

## Safety

- **Fail-open:** any error / timeout / malformed payload returns `False`, so a
  real CI failure is never masked as an outage. The annotation is prefix-preserving
  (`failing (...)` still reads `failing`) — it only ever *adds* context.
- The incident state is resolved **once per report** (not per PR) and threaded
  into `_pr_ci_status`, so an outage doesn't fan out one status GET per failing PR.
- Leaf reporting helper — no change to the delivery pipeline or egress gate.

## Testing

- New unit tests: indicator parsing, fail-open (exception + malformed payload),
  `failing`/`pending` annotation branches, no-annotation-when-healthy, and that a
  precomputed incident boolean skips the per-call check. 44/44 in the suite pass.
- `ruff` clean; the real githubstatus API contract was verified end-to-end
  (`status.indicator` shape matches the parser).
