### PR TITLE
feat(hook): require a current Codex review at HEAD before merge

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -738,7 +738,29 @@ outlives its incident is a bug.
 
 ## Pre-Merge Gate
 
-`git_push_guard.py` enforces a **hard gate** on review findings:
+**Canonical pre-merge check:** run
+`python3 scripts/hooks/git_push_guard.py --check-pr <N> [--repo OWNER/REPO]`
+BEFORE proposing a merge. It runs the SAME functions the enforcement gate uses
+(mergeable → CI → base-invariant → Codex-freshness → review-body → inline
+findings), so the report and the gate can never disagree — never hand-roll a
+gh/jq review check (a hand-rolled query once used the GraphQL bot login on the
+REST endpoint, matched nothing, and reported "Codex clean" while P2s sat unread).
+When all gates pass it prints the exact atomic merge command to copy
+(`... --match-head-commit <verified-head>`); use that command verbatim.
+
+`git_push_guard.py` enforces a **hard gate** at merge time. Beyond the review
+findings below, a gated `gh pr merge`:
+- must carry `--admin` (explicit approval flag) and be bound to the reviewed head
+  via `--match-head-commit` (GitHub rejects it server-side if the head moved —
+  TOCTOU defense); the `--check-pr` command supplies this;
+- requires Codex to have reviewed the **current head** — Codex does NOT auto-review
+  a later fix-commit, so comment `@codex review` and wait after any push;
+- requires the PR base to equal the repo's default branch (retarget guard);
+- blocks unless mergeability is a definite `MERGEABLE` (a failed/unknown read
+  does not merge). `# review-override` waives the review/freshness/base gates
+  (not CI — that is `# ci-override`).
+
+The review-findings gate specifically:
 
 1. After CI passes, the merge hook automatically checks PR comments
    for automated review findings (ERROR, [P1], HARD BLOCK).

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -851,7 +851,7 @@ def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | No
 
 def _check_codex_reviewed_head(
     pr_num: str, *, force: bool = False, repo: str | None = None
-) -> tuple[bool, str]:
+) -> tuple[bool, str, str | None]:
     """Block a merge unless Codex has reviewed the PR's CURRENT head commit.
 
     Compares the PR's ``headRefOid`` against the FULL ``commit_id`` of Codex's
@@ -862,35 +862,67 @@ def _check_codex_reviewed_head(
     (which blocks on UNKNOWN), not the advisory finding-scanners. ``force`` (a
     ``# review-override`` on the merge segment) is the conscious escape (e.g. a
     genuine Codex outage).
+
+    Returns ``(should_block, message, verified_head)`` — ``verified_head`` is the
+    full head oid the review was verified against (only when not blocked and not
+    forced); the caller binds the MERGE to it via ``--match-head-commit`` so a
+    push landing between this check and the merge cannot smuggle an unreviewed
+    head through (TOCTOU — Codex P1, PR #1366).
     """
     if force:
-        return False, ""
+        return False, "", None
     head = _pr_head_sha(pr_num, repo=repo)
     if not head:
-        return True, (
-            f"could not read PR #{pr_num}'s head commit to verify a current Codex "
-            f"review (GitHub query failed).\n"
-            f"Retry, or append '# review-override' to merge anyway."
+        return (
+            True,
+            (
+                f"could not read PR #{pr_num}'s head commit to verify a current Codex "
+                f"review (GitHub query failed).\n"
+                f"Retry, or append '# review-override' to merge anyway."
+            ),
+            None,
         )
     head = head.strip().lower()
     reviewed = _latest_codex_reviewed_sha(pr_num, repo=repo)
     if not reviewed:
-        return True, (
-            f"no Codex review found for PR #{pr_num} at head {head[:12]}.\n"
-            f"Codex reviews on PR-open — it does NOT auto-review a later fix-commit; "
-            f"comment '@codex review' on the PR to review the current head (then wait), "
-            f"or append '# review-override' to merge without a current Codex review "
-            f"(e.g. Codex is down)."
+        return (
+            True,
+            (
+                f"no Codex review found for PR #{pr_num} at head {head[:12]}.\n"
+                f"Codex reviews on PR-open — it does NOT auto-review a later fix-commit; "
+                f"comment '@codex review' on the PR to review the current head (then wait), "
+                f"or append '# review-override' to merge without a current Codex review "
+                f"(e.g. Codex is down)."
+            ),
+            None,
         )
     if reviewed != head:
-        return True, (
-            f"Codex's latest review is STALE: it reviewed {reviewed[:12]}, but PR "
-            f"#{pr_num} head is {head[:12]} (new commits pushed after the review).\n"
-            f"Comment '@codex review' on the PR to re-review the current head (Codex "
-            f"does NOT auto-review fix-commits), then wait; or append "
-            f"'# review-override' to merge anyway."
+        return (
+            True,
+            (
+                f"Codex's latest review is STALE: it reviewed {reviewed[:12]}, but PR "
+                f"#{pr_num} head is {head[:12]} (new commits pushed after the review).\n"
+                f"Comment '@codex review' on the PR to re-review the current head (Codex "
+                f"does NOT auto-review fix-commits), then wait; or append "
+                f"'# review-override' to merge anyway."
+            ),
+            None,
         )
-    return False, ""
+    return False, "", head
+
+
+def _merge_match_head(argv: list[str]) -> str | None:
+    """The value of ``--match-head-commit`` on a gh pr merge argv, or None."""
+    argv = argv or []
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--match-head-commit" and i + 1 < len(argv):
+            return argv[i + 1]
+        if tok.startswith("--match-head-commit="):
+            return tok.split("=", 1)[1]
+        i += 1
+    return None
 
 
 def _is_dispatched() -> bool:
@@ -1885,7 +1917,7 @@ def main() -> int:
                 # — not merely have no open findings. A not-yet-reviewed or
                 # stale-reviewed head would otherwise merge unseen (the finding
                 # scans come back empty). Waived by # review-override.
-                should_block, fresh_msg = _check_codex_reviewed_head(
+                should_block, fresh_msg, verified_head = _check_codex_reviewed_head(
                     pr_num,
                     force=force_override,
                     repo=merge_repo,
@@ -1897,6 +1929,37 @@ def main() -> int:
                     )
                     print(fresh_msg, file=sys.stderr)
                     return 2
+
+                # Bind the MERGE to the verified head (TOCTOU — Codex P1): a push
+                # landing between the check above and the merge would otherwise
+                # merge an UNREVIEWED head under a stale verification. GitHub
+                # enforces `--match-head-commit` server-side (the merge is
+                # rejected if the head moved), making check→merge atomic. Only
+                # engaged when the freshness check ran (not # review-override).
+                if verified_head:
+                    match_head = _merge_match_head(merge_seg.argv)
+                    if match_head is None:
+                        print(
+                            "BLOCKED: merge must be bound to the Codex-verified head "
+                            "commit so a race with a new push cannot merge an "
+                            "unreviewed head. Re-run with:",
+                            file=sys.stderr,
+                        )
+                        print(
+                            f"  gh pr merge {pr_num} --squash --admin "
+                            f"--match-head-commit {verified_head}",
+                            file=sys.stderr,
+                        )
+                        return 2
+                    if match_head.strip().lower() != verified_head:
+                        print(
+                            f"BLOCKED: --match-head-commit {match_head[:12]} does not "
+                            f"equal the Codex-verified head {verified_head[:12]} — the "
+                            f"branch moved (or the sha is stale). Re-verify and use "
+                            f"the current verified head.",
+                            file=sys.stderr,
+                        )
+                        return 2
 
         # ── sqlite3 write operations ────────────────────────────────
         # Whole-command match (never misses a fragmented/wrapped invocation),
@@ -1976,5 +2039,56 @@ def main() -> int:
     return 0
 
 
+def check_pr_report(pr_num: str, repo: str | None = None) -> int:
+    """CANONICAL pre-merge report: run the SAME checks the merge gate enforces.
+
+    This exists so sessions never hand-roll the review check with ad-hoc
+    gh/jq (2026-08-10: a hand-rolled query used the GraphQL bot login on the
+    REST endpoint — `chatgpt-codex-connector` vs `…[bot]` — matched nothing,
+    and the empty result was reported as "Codex clean" while 5 P2 findings sat
+    unread). Report and enforcement share these functions, so they cannot
+    disagree: if this report has a bug, the gate blocks with the same bug.
+
+    Prints one line per gate; returns 0 when every gate would pass, 1 otherwise.
+    """
+    failures = 0
+    mergeable = _check_mergeable(pr_num, repo=repo)
+    print(f"mergeable      : {mergeable or 'unknown'}")
+    if mergeable in ("UNKNOWN", "CONFLICTING"):
+        failures += 1
+    ci_state, ci_bad = _pr_ci_status(pr_num, repo=repo)
+    print(f"ci             : {ci_state}{' (' + ', '.join(ci_bad[:6]) + ')' if ci_bad else ''}")
+    if ci_state in ("red", "pending"):
+        failures += 1
+    blocked, msg = _check_pr_review_findings(pr_num, repo=repo)
+    print(f"review-body    : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok'}")
+    failures += 1 if blocked else 0
+    blocked, msg = _check_inline_review_findings(pr_num, repo=repo)
+    print(
+        f"inline-findings: {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (P2s, if any, printed above)'}"
+    )
+    failures += 1 if blocked else 0
+    blocked, msg, verified_head = _check_codex_reviewed_head(pr_num, repo=repo)
+    print(f"codex-at-head  : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (current)'}")
+    if not blocked and verified_head:
+        print(
+            f"merge-with     : gh pr merge {pr_num} --squash --admin --match-head-commit {verified_head}"
+        )
+    failures += 1 if blocked else 0
+    print(
+        "verdict        :",
+        "MERGEABLE (all gates pass)" if failures == 0 else f"{failures} gate(s) would block",
+    )
+    return 0 if failures == 0 else 1
+
+
 if __name__ == "__main__":
+    # Report mode: `git_push_guard.py --check-pr <N> [--repo OWNER/REPO]` — the
+    # canonical pre-merge check (same functions as enforcement). No hook payload.
+    if len(sys.argv) >= 3 and sys.argv[1] == "--check-pr":
+        _repo_arg = None
+        if "--repo" in sys.argv[3:]:
+            _ri = sys.argv.index("--repo")
+            _repo_arg = sys.argv[_ri + 1] if _ri + 1 < len(sys.argv) else None
+        sys.exit(check_pr_report(sys.argv[2], repo=_repo_arg))
     run_guard(main, "git_push_guard")

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -657,11 +657,28 @@ def _inline_title(body: str) -> str:
     return (first[0].strip() if first else "")[:120]
 
 
+def _scan_unreadable(strict: bool, what: str) -> tuple[bool, str]:
+    """Return value for a finding scan that could NOT be read — a gh error,
+    timeout, or malformed JSON — as distinct from a scan that ran and found
+    nothing (an empty result / Codex quota, which stays clean either way).
+
+    Enforcement (``strict=False``, the default) fails OPEN: a transient gh error
+    must not wedge merges, and the freshness gate already requires a review to
+    EXIST at the head. Report mode (``strict=True``) fails CLOSED so the canonical
+    ``--check-pr`` report never presents an UNREADABLE scan as "ok" / emits a
+    false "all gates pass" (Codex P2, PR #1366).
+    """
+    if strict:
+        return True, f"could not read {what} — review status UNREADABLE (retry), not clean."
+    return False, ""
+
+
 def _check_inline_review_findings(
     pr_num: str,
     *,
     force: bool = False,
     repo: str | None = None,
+    strict: bool = False,
 ) -> tuple[bool, str]:
     """Scan INLINE review comments for P1/P2 badge findings.
 
@@ -669,7 +686,8 @@ def _check_inline_review_findings(
     thread has a reply (engagement = read) or the merge carries
     '# review-override'. P2 findings never block but are printed to
     stderr one per line — the session must consciously accept them.
-    Fail-open on any error, like _check_pr_review_findings.
+    On an UNREADABLE scan (gh error/timeout/malformed): enforcement fails OPEN;
+    ``strict`` (report mode) fails CLOSED — see ``_scan_unreadable``.
     """
     if force:
         return False, ""  # override NOTE already printed by the body gate
@@ -692,10 +710,10 @@ def _check_inline_review_findings(
             timeout=30,
         )
         if result.returncode != 0:
-            return False, ""
+            return _scan_unreadable(strict, "inline review comments")
         raw = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
     except Exception:
-        return False, ""
+        return _scan_unreadable(strict, "inline review comments")
 
     replied_to = {c.get("reply_to") for c in raw if c.get("reply_to")}
     p1: list[str] = []
@@ -733,14 +751,17 @@ def _check_inline_review_findings(
 
 
 def _check_pr_review_findings(
-    pr_num: str, *, force: bool = False, repo: str | None = None
+    pr_num: str, *, force: bool = False, repo: str | None = None, strict: bool = False
 ) -> tuple[bool, str]:
     """Check PR comments for unresolved automated review findings.
 
     Returns (should_block, message).
 
-    Fail-open: returns (False, "") on any error — the hook must never
-    become a single point of failure for merges.
+    On an UNREADABLE scan (gh error/timeout/malformed JSON), enforcement fails
+    OPEN — the hook must never become a single point of failure for merges — while
+    ``strict`` (report mode) fails CLOSED so ``--check-pr`` never reports a failed
+    scan as clean (see ``_scan_unreadable``). An empty result (no comments / Codex
+    quota) is clean either way.
     """
     if force:
         print(
@@ -764,9 +785,9 @@ def _check_pr_review_findings(
             timeout=15,
         )
         if result.returncode != 0:
-            return False, ""  # Fail-open on API error
+            return _scan_unreadable(strict, "review-body comments")  # gh error
     except Exception:
-        return False, ""  # Fail-open
+        return _scan_unreadable(strict, "review-body comments")
 
     output = result.stdout.strip()
     if not output or output == "[]":
@@ -776,7 +797,7 @@ def _check_pr_review_findings(
     try:
         raw_comments = json.loads(output)
     except json.JSONDecodeError:
-        return False, ""  # Fail-open on parse error
+        return _scan_unreadable(strict, "review-body comments")  # malformed JSON
 
     # GitHub API can return "body": null for deleted comments —
     # use `or ""` to coerce None to empty string (get's default only
@@ -2392,8 +2413,11 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     gh/jq (2026-08-10: a hand-rolled query used the GraphQL bot login on the
     REST endpoint — `chatgpt-codex-connector` vs `…[bot]` — matched nothing,
     and the empty result was reported as "Codex clean" while 5 P2 findings sat
-    unread). Report and enforcement share these functions, so they cannot
-    disagree: if this report has a bug, the gate blocks with the same bug.
+    unread). Report and enforcement share these functions, so a bug in one is a
+    bug in both. The ONE deliberate divergence: the report runs the finding scans
+    in ``strict`` mode, so an UNREADABLE scan (gh error) shows as a failure here
+    rather than fail-open as enforcement does — the report must never issue a
+    false all-clear.
 
     Prints one line per gate; returns 0 when every gate would pass, 1 otherwise.
     """
@@ -2419,10 +2443,12 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     if not blocked and verified_head:
         print("merge-with     : " + _suggested_merge_cmd(pr_num, verified_head, repo))
     failures += 1 if blocked else 0
-    blocked, msg = _check_pr_review_findings(pr_num, repo=repo)
+    # strict=True: a scan that could not be READ (gh error/malformed) must show as
+    # a failure here, never as "ok" — the report must not issue a false all-clear.
+    blocked, msg = _check_pr_review_findings(pr_num, repo=repo, strict=True)
     print(f"review-body    : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok'}")
     failures += 1 if blocked else 0
-    blocked, msg = _check_inline_review_findings(pr_num, repo=repo)
+    blocked, msg = _check_inline_review_findings(pr_num, repo=repo, strict=True)
     print(
         f"inline-findings: {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (P2s, if any, printed above)'}"
     )

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -911,6 +911,18 @@ def _check_codex_reviewed_head(
     return False, "", head
 
 
+def _suggested_merge_cmd(pr_num: str, verified_head: str, repo: str | None) -> str:
+    """The exact atomic merge command to copy — PRESERVING an explicit --repo.
+
+    Dropping the target repo from a generated command retargets the merge to the
+    cwd repo, which can merge an unrelated same-numbered PR (Codex P1, round 3).
+    ``repo`` is the already-normalized OWNER/REPO the gates ran against, or None
+    (cwd repo → no --repo).
+    """
+    repo_part = f"--repo {repo} " if repo else ""
+    return f"gh pr merge {pr_num} {repo_part}--squash --admin --match-head-commit {verified_head}"
+
+
 def _merge_match_head(argv: list[str]) -> str | None:
     """The value of ``--match-head-commit`` on a gh pr merge argv, or None.
 
@@ -1954,8 +1966,7 @@ def main() -> int:
                             file=sys.stderr,
                         )
                         print(
-                            f"  gh pr merge {pr_num} --squash --admin "
-                            f"--match-head-commit {verified_head}",
+                            "  " + _suggested_merge_cmd(pr_num, verified_head, merge_repo),
                             file=sys.stderr,
                         )
                         return 2
@@ -2079,9 +2090,7 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     blocked, msg, verified_head = _check_codex_reviewed_head(pr_num, repo=repo)
     print(f"codex-at-head  : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (current)'}")
     if not blocked and verified_head:
-        print(
-            f"merge-with     : gh pr merge {pr_num} --squash --admin --match-head-commit {verified_head}"
-        )
+        print("merge-with     : " + _suggested_merge_cmd(pr_num, verified_head, repo))
     failures += 1 if blocked else 0
     print(
         "verdict        :",

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -10,6 +10,33 @@ Catches all variations of pushing to or merging into the main branch:
 - gh pr merge with unresolved review findings (ERROR/[P1]/HARD BLOCK)
 
 Stdlib-only. Fail-open on parse errors (don't block legitimate work).
+
+Threat model (declared — the standing triage rule for the merge gate)
+---------------------------------------------------------------------
+This is a PROCESS gate for a SINGLE-AUTHOR, single-remote, github.com repo whose
+PRs target the default branch. It defends the SESSION'S OWN process failures, not
+an adversary:
+
+  * merging a head Codex never reviewed, or reviewed at an earlier commit
+    (``_check_codex_reviewed_head`` + the ``--match-head-commit`` binding);
+  * a race with the session's OWN later push between check and merge (same
+    binding — GitHub enforces it server-side);
+  * an ACCIDENTAL wrong-repo merge — a bare merge run from another checkout or
+    after a ``cd`` (``_derive_repo_from_cwd``); or an unresolvable ``--repo``;
+  * an ACCIDENTAL base retarget that silently invalidates the review, since the
+    head never moves (``_check_base_is_default``);
+  * an unreadable mergeability / review status read as "clean" (allowlist
+    posture: block unless a DEFINITE good value — MERGEABLE, a current review).
+
+It does NOT model a malicious operator crafting argv to defeat the gate (they own
+``--admin`` and ``# review-override`` already), NOR a multi-actor repo where a
+hostile collaborator force-pushes or retargets. Findings outside this model
+(adversarial argv shaping, hostile-collaborator timelines, non-github hosts) are
+OUT OF SCOPE BY DESIGN — reply as such rather than adding another patch. The
+cluster-safe ``--match-head-commit`` parse + fail-closed shadow-flag belt already
+exceed the model (defense-in-depth), which is fine; they are not an invitation to
+chase every argv-shaping edge. ``# review-override`` is the conscious escape for
+every gate here.
 """
 
 from __future__ import annotations
@@ -304,6 +331,36 @@ def _merge_target_repo(argv: list[str], cmd: str):
     return None
 
 
+def _derive_repo_from_cwd(cwd: str) -> str | None:
+    """The OWNER/REPO gh resolves in directory ``cwd`` (``nameWithOwner``), or None.
+
+    ``gh pr merge`` and ``gh repo view`` share gh's base-repo resolution (git
+    remotes in the working dir + the ``gh-resolved`` config key), so this is the
+    repo a bare (no ``--repo``) merge run FROM ``cwd`` will actually target.
+
+    Root cause this addresses: the hook's gh queries run in the HOOK process's
+    cwd, while gh executes the merge in the Bash tool's effective cwd. When those
+    differ (a ``cd`` before the merge, or the session sitting in another checkout)
+    a bare merge gated the wrong repo. Deriving the repo from the merge's own
+    effective cwd re-aligns them. Tests inject via ``_TEST_GH_DERIVED_REPO``.
+    """
+    raw = os.environ.get("_TEST_GH_DERIVED_REPO")
+    if raw is None:
+        try:
+            result = subprocess.run(
+                ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=cwd,
+            )
+            raw = result.stdout if result.returncode == 0 else ""
+        except Exception:
+            return None
+    got = (raw or "").strip()
+    return _normalize_repo(got) if got else None
+
+
 def _extract_pr_number(cmd: str) -> str | None:
     """PR number from a gh pr merge command (bare number, #N, or URL)."""
     match = re.search(r"\bgh pr merge\b(.*)$", cmd, re.DOTALL)
@@ -345,7 +402,7 @@ def _repo_args(repo: str | None) -> list[str]:
     return ["--repo", repo] if repo else []
 
 
-def _resolve_pr_number(cmd: str, repo: str | None = None) -> str | None:
+def _resolve_pr_number(cmd: str, repo: str | None = None, cwd: str | None = None) -> str | None:
     """Command PR number, else the current branch's open PR.
 
     No-arg `gh pr merge` from a PR branch is valid gh usage, but it
@@ -354,20 +411,29 @@ def _resolve_pr_number(cmd: str, repo: str | None = None) -> str | None:
     behind findings-ignored merges. Resolution failure is the caller's
     signal to fail CLOSED for merge commands.
 
-    With an explicit ``repo`` and no number in the command, `gh pr view
-    --repo` errors (a selector is required) → None → the caller fails CLOSED.
-    That is deliberate: resolving the CWD branch's PR *number* and gating it
-    against a DIFFERENT repo would re-create the wrong-PR bug this fix kills.
+    Numberless resolution of the branch's PR:
+      * ``cwd`` given (the merge's repo was DERIVED from that cwd, F3): run
+        ``gh pr view`` IN that dir with NO ``--repo`` — gh resolves the repo and
+        the branch's PR together, exactly as the bare merge will, so the number
+        matches the derived repo (both come from the same dir). Passing ``--repo``
+        here would instead error ("argument required when using the --repo flag").
+      * explicit user ``repo`` and NO ``cwd`` → fail CLOSED (None). Resolving a
+        cwd-branch PR *number* and gating it against a DIFFERENT user-named repo
+        would re-create the wrong-PR bug this gate kills.
+      * neither → gh's own cwd (the hook process's), the legacy behavior.
     """
     pr_num = _extract_pr_number(cmd)
     if pr_num:
         return pr_num
+    if repo is not None and cwd is None:
+        return None  # explicit --repo + numberless → fail CLOSED (see above)
     try:
         result = subprocess.run(
-            ["gh", "pr", "view", *_repo_args(repo), "--json", "number", "--jq", ".number"],
+            ["gh", "pr", "view", "--json", "number", "--jq", ".number"],
             capture_output=True,
             text=True,
             timeout=10,
+            cwd=cwd,  # None ⇒ the hook's own cwd (legacy path)
         )
         resolved = result.stdout.strip()
         if result.returncode == 0 and resolved.isdigit():
@@ -378,7 +444,9 @@ def _resolve_pr_number(cmd: str, repo: str | None = None) -> str | None:
 
 
 def _check_mergeable(pr_num: str, repo: str | None = None) -> str | None:
-    """Query GitHub for PR mergeable status. Returns MERGEABLE/UNKNOWN/CONFLICTING or None."""
+    """Query GitHub for PR mergeable status. Returns MERGEABLE/UNKNOWN/CONFLICTING,
+    or None on a failed query. Callers fail CLOSED: the merge gate blocks unless
+    the value is a definite MERGEABLE (None/"" — a failed read — no longer merges)."""
     try:
         result = subprocess.run(
             [
@@ -398,7 +466,7 @@ def _check_mergeable(pr_num: str, repo: str | None = None) -> str | None:
         )
         return result.stdout.strip() if result.returncode == 0 else None
     except Exception:
-        return None  # Fail-open
+        return None  # unreadable → caller treats as non-MERGEABLE → blocks
 
 
 # Check-run conclusions / statuses that mean the CI is NOT green.
@@ -909,6 +977,113 @@ def _check_codex_reviewed_head(
             None,
         )
     return False, "", head
+
+
+def _pr_base_ref(pr_num: str, repo: str | None = None) -> str | None:
+    """The branch this PR MERGES INTO (``baseRefName``), or None on any error.
+
+    Tests inject via ``_TEST_GH_BASE_REF`` (its own seam, mirroring
+    ``_pr_head_sha``'s ``_TEST_GH_HEAD_SHA`` — one gh interaction per seam keeps
+    each independently fakeable; the extra ``gh pr view`` is cheap on a rare merge).
+    """
+    raw = os.environ.get("_TEST_GH_BASE_REF")
+    if raw is None:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    pr_num,
+                    *_repo_args(repo),
+                    "--json",
+                    "baseRefName",
+                    "--jq",
+                    ".baseRefName",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            raw = result.stdout if result.returncode == 0 else ""
+        except Exception:
+            return None
+    ref = (raw or "").strip()
+    return ref or None
+
+
+def _repo_default_branch(repo: str | None = None) -> str | None:
+    """The repo's default branch name (``defaultBranchRef.name``), or None on error.
+
+    ``gh repo view`` takes the repo as a POSITIONAL (``gh repo view OWNER/REPO``),
+    not ``--repo`` — verified: ``gh pr view`` has no ``defaultBranchRef`` field, so
+    this cannot be folded into the base query. No positional ⇒ gh's cwd repo.
+    Tests inject via ``_TEST_GH_DEFAULT_BRANCH``.
+    """
+    raw = os.environ.get("_TEST_GH_DEFAULT_BRANCH")
+    if raw is None:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "repo",
+                    "view",
+                    *([repo] if repo else []),
+                    "--json",
+                    "defaultBranchRef",
+                    "--jq",
+                    ".defaultBranchRef.name",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            raw = result.stdout if result.returncode == 0 else ""
+        except Exception:
+            return None
+    name = (raw or "").strip()
+    return name or None
+
+
+def _check_base_is_default(
+    pr_num: str, *, force: bool = False, repo: str | None = None
+) -> tuple[bool, str]:
+    """Block unless the PR's base branch == the repo's default branch.
+
+    A PR retargeted AFTER Codex reviewed it still passes the head-freshness gate —
+    the head oid never moved — even though the base change can substantially alter
+    the effective diff (GitHub's review object records no base, so freshness alone
+    cannot see it). This repo's PRs always target the default branch, so a
+    non-default base is anomalous → block. Fail-CLOSED: an unreadable base OR
+    default is treated as unverifiable → block (matching the rest of this gate).
+    ``force`` (a ``# review-override`` on the merge segment) is the conscious
+    escape for a deliberate stacked/non-default PR. Declared threat model: this
+    guards an ACCIDENTAL retarget on a single-author repo, not an adversary.
+    """
+    if force:
+        return False, ""
+    base = _pr_base_ref(pr_num, repo=repo)
+    default = _repo_default_branch(repo=repo)
+    if not base or not default:
+        return (
+            True,
+            (
+                f"could not confirm PR #{pr_num}'s base branch against the repo default "
+                f"(base={base or '?'}, default={default or '?'}) — retry, or append "
+                f"'# review-override' to merge anyway."
+            ),
+        )
+    if base != default:
+        return (
+            True,
+            (
+                f"PR #{pr_num} targets base '{base}', not the default branch '{default}'. "
+                f"A retargeted PR's Codex review may not reflect the new diff — re-run "
+                f"'@codex review' on the PR, or append '# review-override' for a "
+                f"deliberate stacked/non-default PR."
+            ),
+        )
+    return False, ""
 
 
 def _suggested_merge_cmd(pr_num: str, verified_head: str, repo: str | None) -> str:
@@ -1914,19 +2089,41 @@ def main() -> int:
             # so an unrelated segment's PR URL cannot select the gated repo
             # (`echo …/other/repo/pull/9 && gh pr merge 12` must gate the cwd repo).
             merge_repo = _merge_target_repo(merge_seg.argv, merge_seg.raw)
+            # For a DERIVED (no --repo) merge, the dir gh resolves the repo AND a
+            # numberless branch-PR from — threaded to _resolve_pr_number so a
+            # numberless `gh pr merge` still resolves (an explicit --repo would
+            # error there). None ⇒ an explicit --repo or the legacy no-cwd path.
+            merge_cwd: str | None = None
+            if merge_repo is None:
+                # No explicit --repo/-R: gh resolves the repo from the merge's
+                # EFFECTIVE cwd (payload cwd + any preceding `cd`), which can
+                # differ from the HOOK process's cwd — so the gates' gh queries
+                # (run in the hook's cwd) could check a DIFFERENT repo than the
+                # one gh merges in (a bare merge from another checkout, or after
+                # a `cd`). Derive the repo gh will actually target and gate THAT.
+                # Fail CLOSED only when the cwd is ambiguous (_CWD_UNKNOWN) or gh
+                # can't resolve a repo there; no cwd info at all (None) keeps
+                # today's cwd-based behavior — there is nothing to derive from.
+                eff_cwd = _effective_cwd(cmd, payload, seg=merge_seg)
+                if eff_cwd is _CWD_UNKNOWN:
+                    merge_repo = _REPO_UNRESOLVED
+                elif eff_cwd is not None:
+                    merge_repo = _derive_repo_from_cwd(eff_cwd) or _REPO_UNRESOLVED
+                    merge_cwd = eff_cwd  # resolve a numberless PR in the same dir
             if merge_repo is _REPO_UNRESOLVED:
                 print(
-                    "BLOCKED: cannot resolve the target repo of this --repo/-R "
-                    "merge (a variable, an enterprise host, or an odd URL).",
+                    "BLOCKED: cannot determine which repository this merge targets "
+                    "(an unresolvable --repo/-R value, an enterprise host, an odd "
+                    "URL, or an ambiguous working directory).",
                     file=sys.stderr,
                 )
                 print(
-                    "Specify it as OWNER/REPO so the CI/review gates check the "
+                    "Append --repo OWNER/REPO so the CI/review gates check the "
                     "right repository, not the current directory's.",
                     file=sys.stderr,
                 )
                 return 2
-            pr_num = _resolve_pr_number(cmd, repo=merge_repo)
+            pr_num = _resolve_pr_number(cmd, repo=merge_repo, cwd=merge_cwd)
             if pr_num is None:
                 print(
                     "BLOCKED: cannot resolve which PR this merges "
@@ -1941,19 +2138,26 @@ def main() -> int:
                 return 2
             if pr_num:
                 mergeable = _check_mergeable(pr_num, repo=merge_repo)
-                if mergeable == "UNKNOWN":
-                    print(
-                        f"BLOCKED: PR #{pr_num} mergeable status is UNKNOWN.",
-                        file=sys.stderr,
-                    )
-                    print(
-                        "GitHub hasn't finished conflict analysis. Wait and retry.",
-                        file=sys.stderr,
-                    )
-                    return 2
                 if mergeable == "CONFLICTING":
                     print(
                         f"BLOCKED: PR #{pr_num} has merge conflicts. Resolve before merging.",
+                        file=sys.stderr,
+                    )
+                    return 2
+                if mergeable != "MERGEABLE":
+                    # Allowlist (fail-CLOSED): anything that is not a definite
+                    # MERGEABLE is unverifiable — UNKNOWN (GitHub still computing
+                    # conflicts), None/"" (the query FAILED; _check_mergeable
+                    # fails OPEN to None), or an unrecognized future state. The
+                    # old `== "UNKNOWN"` check let None/"" sail through and merge.
+                    # Retry is the remedy (a transient gh hiccup resolves).
+                    print(
+                        f"BLOCKED: PR #{pr_num} mergeable status is "
+                        f"'{mergeable or 'unreadable'}', not MERGEABLE.",
+                        file=sys.stderr,
+                    )
+                    print(
+                        "GitHub may still be computing it, or the query failed. Wait and retry.",
                         file=sys.stderr,
                     )
                     return 2
@@ -1992,8 +2196,47 @@ def main() -> int:
                         file=sys.stderr,
                     )
 
-                # Check for unresolved review findings
                 force_override = merge_seg.override
+
+                # Base-branch invariant: a PR retargeted AFTER Codex reviewed it
+                # keeps the SAME head oid, so head-freshness alone can't see the
+                # base change that may have altered the effective diff. Require
+                # base == the repo's default branch. Waived by # review-override
+                # for a deliberate stacked/non-default PR.
+                should_block, base_msg = _check_base_is_default(
+                    pr_num,
+                    force=force_override,
+                    repo=merge_repo,
+                )
+                if should_block:
+                    print(
+                        f"BLOCKED: PR #{pr_num} — base branch is not the repo default.",
+                        file=sys.stderr,
+                    )
+                    print(base_msg, file=sys.stderr)
+                    return 2
+
+                # Codex must have reviewed the CURRENT head (existence + freshness)
+                # — not merely have no open findings. This runs BEFORE the finding
+                # scans below: a review published between the scans and this check
+                # would otherwise pass freshness while its own P1 comments went
+                # unscanned (the scans came back empty). Freshness first, then
+                # findings. A not-yet-reviewed / stale-reviewed head blocks here.
+                # Waived by # review-override.
+                should_block, fresh_msg, verified_head = _check_codex_reviewed_head(
+                    pr_num,
+                    force=force_override,
+                    repo=merge_repo,
+                )
+                if should_block:
+                    print(
+                        f"BLOCKED: PR #{pr_num} — Codex has not reviewed the current head.",
+                        file=sys.stderr,
+                    )
+                    print(fresh_msg, file=sys.stderr)
+                    return 2
+
+                # Unresolved review findings (review body) — now AFTER freshness.
                 should_block, review_msg = _check_pr_review_findings(
                     pr_num,
                     force=force_override,
@@ -2020,23 +2263,6 @@ def main() -> int:
                         file=sys.stderr,
                     )
                     print(inline_msg, file=sys.stderr)
-                    return 2
-
-                # Codex must have reviewed the CURRENT head (existence + freshness)
-                # — not merely have no open findings. A not-yet-reviewed or
-                # stale-reviewed head would otherwise merge unseen (the finding
-                # scans come back empty). Waived by # review-override.
-                should_block, fresh_msg, verified_head = _check_codex_reviewed_head(
-                    pr_num,
-                    force=force_override,
-                    repo=merge_repo,
-                )
-                if should_block:
-                    print(
-                        f"BLOCKED: PR #{pr_num} — Codex has not reviewed the current head.",
-                        file=sys.stderr,
-                    )
-                    print(fresh_msg, file=sys.stderr)
                     return 2
 
                 # Bind the MERGE to the verified head (TOCTOU — Codex P1): a push
@@ -2173,13 +2399,26 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     """
     failures = 0
     mergeable = _check_mergeable(pr_num, repo=repo)
-    print(f"mergeable      : {mergeable or 'unknown'}")
-    if mergeable in ("UNKNOWN", "CONFLICTING"):
+    print(f"mergeable      : {mergeable or 'unreadable'}")
+    # Allowlist, matching the enforcement arm: anything that is not a definite
+    # MERGEABLE (UNKNOWN, None/"" query failure, or a new state) counts as a
+    # failure — the old `in (UNKNOWN, CONFLICTING)` set let None/"" pass.
+    if mergeable != "MERGEABLE":
         failures += 1
     ci_state, ci_bad = _pr_ci_status(pr_num, repo=repo)
     print(f"ci             : {ci_state}{' (' + ', '.join(ci_bad[:6]) + ')' if ci_bad else ''}")
     if ci_state in ("red", "pending"):
         failures += 1
+    # Order mirrors the gate: base-invariant → freshness → finding scans, so a
+    # review published mid-run can't pass freshness with its P1s unscanned.
+    blocked, msg = _check_base_is_default(pr_num, repo=repo)
+    print(f"base-branch    : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (default)'}")
+    failures += 1 if blocked else 0
+    blocked, msg, verified_head = _check_codex_reviewed_head(pr_num, repo=repo)
+    print(f"codex-at-head  : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (current)'}")
+    if not blocked and verified_head:
+        print("merge-with     : " + _suggested_merge_cmd(pr_num, verified_head, repo))
+    failures += 1 if blocked else 0
     blocked, msg = _check_pr_review_findings(pr_num, repo=repo)
     print(f"review-body    : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok'}")
     failures += 1 if blocked else 0
@@ -2187,11 +2426,6 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     print(
         f"inline-findings: {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (P2s, if any, printed above)'}"
     )
-    failures += 1 if blocked else 0
-    blocked, msg, verified_head = _check_codex_reviewed_head(pr_num, repo=repo)
-    print(f"codex-at-head  : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (current)'}")
-    if not blocked and verified_head:
-        print("merge-with     : " + _suggested_merge_cmd(pr_num, verified_head, repo))
     failures += 1 if blocked else 0
     print(
         "verdict        :",

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -912,17 +912,25 @@ def _check_codex_reviewed_head(
 
 
 def _merge_match_head(argv: list[str]) -> str | None:
-    """The value of ``--match-head-commit`` on a gh pr merge argv, or None."""
+    """The value of ``--match-head-commit`` on a gh pr merge argv, or None.
+
+    Returns the LAST occurrence, mirroring gh's pflag last-value-wins semantics
+    for a repeated string flag (same rule as ``_pr_create_head_raw``). Validating
+    the FIRST value would let ``--match-head-commit <verified> --match-head-commit
+    <other>`` pass the hook on <verified> while gh enforces <other> — re-opening
+    the TOCTOU through the fix itself (Codex P1, round 2).
+    """
     argv = argv or []
+    result: str | None = None
     i = 0
     while i < len(argv):
         tok = argv[i]
         if tok == "--match-head-commit" and i + 1 < len(argv):
-            return argv[i + 1]
-        if tok.startswith("--match-head-commit="):
-            return tok.split("=", 1)[1]
+            result = argv[i + 1]
+        elif tok.startswith("--match-head-commit="):
+            result = tok.split("=", 1)[1]
         i += 1
-    return None
+    return result
 
 
 def _is_dispatched() -> bool:

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -923,26 +923,115 @@ def _suggested_merge_cmd(pr_num: str, verified_head: str, repo: str | None) -> s
     return f"gh pr merge {pr_num} {repo_part}--squash --admin --match-head-commit {verified_head}"
 
 
-def _merge_match_head(argv: list[str]) -> str | None:
-    """The value of ``--match-head-commit`` on a gh pr merge argv, or None.
+# gh pr merge flags that CONSUME the FOLLOWING token as their value (separate
+# form). When scanning for --match-head-commit these values MUST be skipped, else
+# a `--body --match-head-commit=<sha>` — where the sha is --body's VALUE, taken as
+# body TEXT by gh with NO head binding — is misread as an active binding while gh
+# merges unbound (Codex P1, round 3). --repo is gate-relevant (handled elsewhere)
+# but still value-consuming here; --match-head-commit itself consumes its own SHA.
+# NOTE: the risk is the PARSE MODEL (pflag argument consumption + short-flag
+# clustering), not the flag names — the long value-flag set is identical across
+# gh 2.45–2.96 `gh pr merge --help`.
+_GH_MERGE_VALUE_FLAGS = frozenset(
+    {
+        "--body",
+        "-b",
+        "--body-file",
+        "-F",
+        "--subject",
+        "-t",
+        "--author-email",
+        "-A",
+        "--repo",
+        "-R",
+        "--match-head-commit",
+    }
+)
+# Content value-flags (LONG forms) that can SHADOW --match-head-commit as their
+# value and have NO legitimate use on a gated --admin squash-merge. Their mere
+# presence is refused (fail-closed belt over the value-skipping parse). Short
+# forms are handled letter-wise in the cluster helpers below.
+_GH_MERGE_SHADOW_FLAGS = frozenset({"--body", "--body-file", "--subject", "--author-email"})
+# Short flags on gh pr merge. VALUE letters consume a value (glued remainder, else
+# the NEXT token); the rest are booleans (-d/-m/-r/-s). A cluster like `-db` is
+# -d(bool) + -b(value), so gh's -b swallows the FOLLOWING token — a scan treating
+# `-db` as opaque misses that consumption (audit round 4: `-db --match-head-commit=X`
+# merges UNBOUND). SHADOW shorts are the content ones (not -R).
+_GH_MERGE_VALUE_SHORTS = "bFtAR"
+_GH_MERGE_SHADOW_SHORTS = "bFtA"
 
-    Returns the LAST occurrence, mirroring gh's pflag last-value-wins semantics
-    for a repeated string flag (same rule as ``_pr_create_head_raw``). Validating
-    the FIRST value would let ``--match-head-commit <verified> --match-head-commit
-    <other>`` pass the hook on <verified> while gh enforces <other> — re-opening
-    the TOCTOU through the fix itself (Codex P1, round 2).
+
+def _is_short_cluster(tok: str) -> bool:
+    return tok.startswith("-") and not tok.startswith("--") and len(tok) > 1
+
+
+def _short_cluster_consumes_next(tok: str) -> bool:
+    """Whether a ``-<letters>`` short cluster makes gh consume the NEXT argv token
+    as a value — a value-short letter with NO glued remainder after it. Boolean
+    letters before it are consumed in place. Mirrors pflag."""
+    if not _is_short_cluster(tok):
+        return False
+    letters = tok[1:]
+    for j, ch in enumerate(letters):
+        if ch in _GH_MERGE_VALUE_SHORTS:
+            return letters[j + 1 :] == ""  # glued remainder ⇒ value in-token, not next
+    return False
+
+
+def _merge_match_head(argv: list[str]) -> str | None:
+    """The value gh will use for ``--match-head-commit`` on a merge argv, or None.
+
+    Parses with gh-equivalent argument consumption: value-taking flags
+    (``_GH_MERGE_VALUE_FLAGS``) consume the next token, so a --match-head-commit
+    token that is actually ANOTHER flag's value is not misread as a binding. A
+    bare ``--`` ends option parsing (everything after is positional; gh rejects
+    extra positionals). Returns the LAST occurrence — gh pflag last-value-wins
+    (same rule as ``_pr_create_head_raw``); first-wins would let a trailing
+    ``--match-head-commit <other>`` be enforced by gh while the hook validated an
+    earlier value.
     """
     argv = argv or []
     result: str | None = None
     i = 0
     while i < len(argv):
         tok = argv[i]
-        if tok == "--match-head-commit" and i + 1 < len(argv):
-            result = argv[i + 1]
-        elif tok.startswith("--match-head-commit="):
+        if tok == "--":
+            break  # end of options — the rest are positionals gh would reject
+        if tok in _GH_MERGE_VALUE_FLAGS:
+            # Separate-form value flag consumes the NEXT token. When the flag is
+            # --match-head-commit itself, that next token is the value we want.
+            if tok == "--match-head-commit" and i + 1 < len(argv):
+                result = argv[i + 1]
+            i += 2
+            continue
+        if tok.startswith("--match-head-commit="):
             result = tok.split("=", 1)[1]
+            i += 1
+            continue
+        if _short_cluster_consumes_next(tok):
+            i += 2  # cluster's trailing value-short swallows the next token
+            continue
         i += 1
     return result
+
+
+def _merge_has_shadow_flag(argv: list[str]) -> bool:
+    """Whether the merge carries a content flag that could shadow the head-match
+    binding — long form, ``=`` form, bare short, or inside a short cluster
+    (``-db`` etc.). Refused outright as a fail-closed belt."""
+    for tok in argv or []:
+        if tok == "--":
+            break
+        base = tok.split("=", 1)[0]
+        if base in _GH_MERGE_SHADOW_FLAGS:
+            return True
+        if _is_short_cluster(base):
+            for ch in base[1:]:
+                if ch in _GH_MERGE_SHADOW_SHORTS:
+                    return True
+                if ch in _GH_MERGE_VALUE_SHORTS:
+                    break  # a value-short (e.g. -R): the rest is its glued value
+    return False
 
 
 def _is_dispatched() -> bool:
@@ -1957,6 +2046,18 @@ def main() -> int:
                 # rejected if the head moved), making check→merge atomic. Only
                 # engaged when the freshness check ran (not # review-override).
                 if verified_head:
+                    # Fail-closed belt: content value-flags can smuggle a
+                    # --match-head-commit token as their VALUE (gh takes it as
+                    # text → no binding) and have no use on a gated squash-merge.
+                    if _merge_has_shadow_flag(merge_seg.argv):
+                        print(
+                            "BLOCKED: --body/--subject/--body-file/--author-email are "
+                            "not allowed on a gated merge — they can shadow the "
+                            "--match-head-commit binding. Remove them (set a squash "
+                            "message via the GitHub UI if needed).",
+                            file=sys.stderr,
+                        )
+                        return 2
                     match_head = _merge_match_head(merge_seg.argv)
                     if match_head is None:
                         print(

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -757,6 +757,142 @@ def _check_pr_review_findings(
     return False, ""
 
 
+# ── Codex review FRESHNESS (a CURRENT review must exist, not just no findings) ──
+# The finding scanners above block on UNRESOLVED findings, but a merge can still
+# proceed with NO review at all, or a review of a STALE commit (Codex reviewed A,
+# code B pushed after) — the scans come back empty and the merge sails through
+# unseen. This gate requires Codex's most recent review to cover the PR's current
+# head, compared on the FULL 40-char oid GitHub records for the review
+# (the review object's ``commit_id``) — NOT a short prefix from the body, which a
+# stale prefix (or a ground SHA sharing it) could satisfy. Waived by
+# '# review-override' (the conscious "merge without a current Codex review" case).
+_CODEX_REVIEW_BOT = "chatgpt-codex-connector[bot]"
+
+
+def _pr_head_sha(pr_num: str, repo: str | None = None) -> str | None:
+    """The PR's current head commit oid (headRefOid), or None on any error.
+
+    Tests inject via the ``_TEST_GH_HEAD_SHA`` env var so no network is needed.
+    """
+    raw = os.environ.get("_TEST_GH_HEAD_SHA")
+    if raw is None:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    pr_num,
+                    *_repo_args(repo),
+                    "--json",
+                    "headRefOid",
+                    "--jq",
+                    ".headRefOid",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            raw = result.stdout if result.returncode == 0 else ""
+        except Exception:
+            return None
+    sha = (raw or "").strip()
+    return sha or None
+
+
+def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | None:
+    """The FULL commit oid (``.commit_id``) of Codex's MOST RECENT review, or None
+    if Codex has posted no review (or on any API/parse error).
+
+    Uses GitHub's authoritative per-review ``commit_id`` (the exact 40-char oid
+    the review was submitted against) rather than parsing the review body — so the
+    comparison is a full-oid identity, immune to short-prefix collisions/grinding.
+    The ``/pulls/N/reviews`` endpoint returns reviews oldest-first, so the last
+    Codex entry wins. Tests inject via ``_TEST_GH_CODEX_REVIEWS`` (one JSON object
+    per line: ``{login, commit_id}``). Fail-safe: None on any API/parse error.
+    """
+    raw = os.environ.get("_TEST_GH_CODEX_REVIEWS")
+    if raw is None:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo or ':owner/:repo'}/pulls/{pr_num}/reviews",
+                    "--paginate",
+                    "--jq",
+                    ".[] | {login: .user.login, commit_id: .commit_id}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+            if result.returncode != 0:
+                return None
+            raw = result.stdout
+        except Exception:
+            return None
+    latest: str | None = None
+    for line in (raw or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if (obj.get("login") or "") != _CODEX_REVIEW_BOT:
+            continue
+        cid = (obj.get("commit_id") or "").strip().lower()
+        if cid:
+            latest = cid
+    return latest
+
+
+def _check_codex_reviewed_head(
+    pr_num: str, *, force: bool = False, repo: str | None = None
+) -> tuple[bool, str]:
+    """Block a merge unless Codex has reviewed the PR's CURRENT head commit.
+
+    Compares the PR's ``headRefOid`` against the FULL ``commit_id`` of Codex's
+    latest review — an EXACT identity, no prefix match. Fail-CLOSED: if the head
+    cannot be read, or Codex has no review / reviewed a different commit, the
+    merge is BLOCKED. This is an enforcement gate, so an unverifiable review is
+    treated as absent (blocked), NOT waved through — matching ``_check_mergeable``
+    (which blocks on UNKNOWN), not the advisory finding-scanners. ``force`` (a
+    ``# review-override`` on the merge segment) is the conscious escape (e.g. a
+    genuine Codex outage).
+    """
+    if force:
+        return False, ""
+    head = _pr_head_sha(pr_num, repo=repo)
+    if not head:
+        return True, (
+            f"could not read PR #{pr_num}'s head commit to verify a current Codex "
+            f"review (GitHub query failed).\n"
+            f"Retry, or append '# review-override' to merge anyway."
+        )
+    head = head.strip().lower()
+    reviewed = _latest_codex_reviewed_sha(pr_num, repo=repo)
+    if not reviewed:
+        return True, (
+            f"no Codex review found for PR #{pr_num} at head {head[:12]}.\n"
+            f"Codex reviews on PR-open — it does NOT auto-review a later fix-commit; "
+            f"comment '@codex review' on the PR to review the current head (then wait), "
+            f"or append '# review-override' to merge without a current Codex review "
+            f"(e.g. Codex is down)."
+        )
+    if reviewed != head:
+        return True, (
+            f"Codex's latest review is STALE: it reviewed {reviewed[:12]}, but PR "
+            f"#{pr_num} head is {head[:12]} (new commits pushed after the review).\n"
+            f"Comment '@codex review' on the PR to re-review the current head (Codex "
+            f"does NOT auto-review fix-commits), then wait; or append "
+            f"'# review-override' to merge anyway."
+        )
+    return False, ""
+
+
 def _is_dispatched() -> bool:
     """True in a Genesis-dispatched (autonomous/headless) CC session.
 
@@ -1743,6 +1879,23 @@ def main() -> int:
                         file=sys.stderr,
                     )
                     print(inline_msg, file=sys.stderr)
+                    return 2
+
+                # Codex must have reviewed the CURRENT head (existence + freshness)
+                # — not merely have no open findings. A not-yet-reviewed or
+                # stale-reviewed head would otherwise merge unseen (the finding
+                # scans come back empty). Waived by # review-override.
+                should_block, fresh_msg = _check_codex_reviewed_head(
+                    pr_num,
+                    force=force_override,
+                    repo=merge_repo,
+                )
+                if should_block:
+                    print(
+                        f"BLOCKED: PR #{pr_num} — Codex has not reviewed the current head.",
+                        file=sys.stderr,
+                    )
+                    print(fresh_msg, file=sys.stderr)
                     return 2
 
         # ── sqlite3 write operations ────────────────────────────────

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -254,3 +254,88 @@ class TestMergeMatchHeadRepeat:
             f"--match-head-commit={HEAD}",
         ]
         assert _mod._merge_match_head(argv) == HEAD
+
+
+class TestPrBaseRef:
+    """_pr_base_ref reads the PR's baseRefName (seam _TEST_GH_BASE_REF)."""
+
+    def test_reads_seam(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "main")
+        assert _mod._pr_base_ref("1") == "main"
+
+    def test_strips_whitespace(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "  release-1.2\n")
+        assert _mod._pr_base_ref("1") == "release-1.2"
+
+    def test_empty_is_none(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "")
+        assert _mod._pr_base_ref("1") is None
+
+
+class TestRepoDefaultBranch:
+    """_repo_default_branch reads defaultBranchRef.name (seam _TEST_GH_DEFAULT_BRANCH)."""
+
+    def test_reads_seam(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
+        assert _mod._repo_default_branch() == "main"
+
+    def test_empty_is_none(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "")
+        assert _mod._repo_default_branch() is None
+
+
+class TestCheckBaseIsDefault:
+    """Base-retarget guard: block unless base == default; fail-CLOSED on unreadable;
+    force waives. Head-pinning can't catch a base change (the head never moves)."""
+
+    def _set(self, monkeypatch, base, default):
+        monkeypatch.setenv("_TEST_GH_BASE_REF", base)
+        monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", default)
+
+    def test_base_equals_default_passes(self, monkeypatch):
+        self._set(monkeypatch, "main", "main")
+        block, msg = _mod._check_base_is_default("1")
+        assert block is False and msg == ""
+
+    def test_base_differs_blocks(self, monkeypatch):
+        self._set(monkeypatch, "release-1.2", "main")
+        block, msg = _mod._check_base_is_default("1")
+        assert block is True and "not the default branch" in msg
+
+    def test_base_unreadable_fails_closed(self, monkeypatch):
+        self._set(monkeypatch, "", "main")
+        block, msg = _mod._check_base_is_default("1")
+        assert block is True and "could not confirm" in msg.lower()
+
+    def test_default_unreadable_fails_closed(self, monkeypatch):
+        self._set(monkeypatch, "main", "")
+        block, _ = _mod._check_base_is_default("1")
+        assert block is True
+
+    def test_force_waives(self, monkeypatch):
+        self._set(monkeypatch, "release-1.2", "main")  # would otherwise block
+        block, _ = _mod._check_base_is_default("1", force=True)
+        assert block is False
+
+
+class TestDeriveRepoFromCwd:
+    """_derive_repo_from_cwd resolves the OWNER/REPO gh targets in a dir
+    (seam _TEST_GH_DERIVED_REPO), normalized; None when unresolvable."""
+
+    def test_reads_seam(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "owner/repo")
+        assert _mod._derive_repo_from_cwd("/x") == "owner/repo"
+
+    def test_normalizes_url_form(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "github.com/owner/repo")
+        assert _mod._derive_repo_from_cwd("/x") == "owner/repo"
+
+    def test_empty_is_none(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "")
+        assert _mod._derive_repo_from_cwd("/x") is None
+
+    def test_unnormalizable_is_none(self, monkeypatch):
+        # A shell-variable / enterprise-host value can't be gated → None → caller
+        # fails closed.
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "$VAR")
+        assert _mod._derive_repo_from_cwd("/x") is None

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -123,6 +123,18 @@ class TestMergeMatchHead:
     def test_absent(self):
         assert _mod._merge_match_head(["gh", "pr", "merge", "5", "--admin"]) is None
 
+    def test_suggested_cmd_preserves_repo(self):
+        # Dropping --repo retargets a copied merge to the cwd repo (Codex P1 r3).
+        cmd = _mod._suggested_merge_cmd("5", HEAD, "octo/voice")
+        assert "--repo octo/voice" in cmd
+        assert cmd.endswith(f"--match-head-commit {HEAD}")
+        assert "gh pr merge 5 " in cmd
+
+    def test_suggested_cmd_no_repo_when_cwd(self):
+        cmd = _mod._suggested_merge_cmd("5", HEAD, None)
+        assert "--repo" not in cmd
+        assert cmd == f"gh pr merge 5 --squash --admin --match-head-commit {HEAD}"
+
     def test_repeated_flag_last_wins(self):
         # gh pflag semantics: the LAST repeated string-flag value is the one gh
         # enforces — the hook must validate that same value, else

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -57,19 +57,19 @@ class TestFreshnessGate:
     def test_current_review_passes(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))
-        block, msg = _mod._check_codex_reviewed_head("1")
+        block, msg, _head = _mod._check_codex_reviewed_head("1")
         assert block is False and msg == ""
 
     def test_no_review_blocks(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
-        block, msg = _mod._check_codex_reviewed_head("1")
+        block, msg, _head = _mod._check_codex_reviewed_head("1")
         assert block is True and "no codex review" in msg.lower()
 
     def test_stale_review_blocks(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(STALE))
-        block, msg = _mod._check_codex_reviewed_head("1")
+        block, msg, _head = _mod._check_codex_reviewed_head("1")
         assert block is True and "stale" in msg.lower()
 
     def test_prefix_no_longer_passes(self, monkeypatch):
@@ -78,13 +78,13 @@ class TestFreshnessGate:
         near = HEAD[:12] + "0" * 28  # same 12-char prefix, different full oid
         monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(near))
-        block, _ = _mod._check_codex_reviewed_head("1")
+        block, _, _head = _mod._check_codex_reviewed_head("1")
         assert block is True
 
     def test_force_override_bypasses(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")  # would otherwise block
-        block, _ = _mod._check_codex_reviewed_head("1", force=True)
+        block, _, _head = _mod._check_codex_reviewed_head("1", force=True)
         assert block is False
 
     def test_head_unresolvable_fails_closed(self, monkeypatch):
@@ -92,5 +92,33 @@ class TestFreshnessGate:
         # (fail-closed, like _check_mergeable's UNKNOWN), not waved through.
         monkeypatch.setenv("_TEST_GH_HEAD_SHA", "")  # empty → None
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))
-        block, msg = _mod._check_codex_reviewed_head("1")
+        block, msg, _head = _mod._check_codex_reviewed_head("1")
         assert block is True and "head" in msg.lower()
+
+    def test_pass_returns_verified_head(self, monkeypatch):
+        # The caller binds the merge to this oid via --match-head-commit (TOCTOU).
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))
+        block, _, head = _mod._check_codex_reviewed_head("1")
+        assert block is False and head == HEAD
+
+    def test_force_returns_no_verified_head(self, monkeypatch):
+        # Forced (# review-override) skips verification → no head to bind →
+        # the match-head requirement disengages too.
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))
+        block, _, head = _mod._check_codex_reviewed_head("1", force=True)
+        assert block is False and head is None
+
+
+class TestMergeMatchHead:
+    def test_separate_value(self):
+        argv = ["gh", "pr", "merge", "5", "--squash", "--admin", "--match-head-commit", HEAD]
+        assert _mod._merge_match_head(argv) == HEAD
+
+    def test_equals_form(self):
+        argv = ["gh", "pr", "merge", "5", f"--match-head-commit={HEAD}"]
+        assert _mod._merge_match_head(argv) == HEAD
+
+    def test_absent(self):
+        assert _mod._merge_match_head(["gh", "pr", "merge", "5", "--admin"]) is None

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1,0 +1,96 @@
+"""Tests for the Codex review-freshness merge gate in git_push_guard.
+
+The finding scanners (_check_pr_review_findings / _check_inline_review_findings)
+catch UNRESOLVED findings but not a merge whose head was never reviewed, or was
+reviewed at an EARLIER commit (Codex reviewed A, code B pushed after). This gate
+requires Codex's latest review ``commit_id`` (the full 40-char oid GitHub records
+the review against) to EXACTLY equal the PR's current ``headRefOid``.
+
+Network-free via the _TEST_GH_* env-injection seams (mirrors _pr_ci_status'
+_TEST_GH_CI_ROLLUP).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_WORKTREE = Path(__file__).resolve().parent.parent.parent
+_HOOKS_DIR = _WORKTREE / "scripts" / "hooks"
+_spec = importlib.util.spec_from_file_location("git_push_guard", _HOOKS_DIR / "git_push_guard.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+HEAD = "0cd13afeb51025af5dc7bd24df1ffa57cd2babab"
+STALE = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+
+def _reviews_jsonl(*commit_ids, login="chatgpt-codex-connector[bot]"):
+    """One JSON object per line, matching gh api .../reviews --jq '{login, commit_id}'."""
+    return "\n".join(json.dumps({"login": login, "commit_id": cid}) for cid in commit_ids)
+
+
+class TestReviewedCommitParsing:
+    def test_parses_commit_id(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))
+        assert _mod._latest_codex_reviewed_sha("1") == HEAD
+
+    def test_latest_review_wins(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl("a" * 40, "b" * 40))
+        assert _mod._latest_codex_reviewed_sha("1") == "b" * 40
+
+    def test_uppercase_normalized(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD.upper()))
+        assert _mod._latest_codex_reviewed_sha("1") == HEAD  # lowercased
+
+    def test_none_when_not_codex(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD, login="human"))
+        assert _mod._latest_codex_reviewed_sha("1") is None
+
+    def test_none_when_empty(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
+        assert _mod._latest_codex_reviewed_sha("1") is None
+
+
+class TestFreshnessGate:
+    def test_current_review_passes(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))
+        block, msg = _mod._check_codex_reviewed_head("1")
+        assert block is False and msg == ""
+
+    def test_no_review_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
+        block, msg = _mod._check_codex_reviewed_head("1")
+        assert block is True and "no codex review" in msg.lower()
+
+    def test_stale_review_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(STALE))
+        block, msg = _mod._check_codex_reviewed_head("1")
+        assert block is True and "stale" in msg.lower()
+
+    def test_prefix_no_longer_passes(self, monkeypatch):
+        # A stale review whose oid merely shares a PREFIX with head must NOT pass
+        # (the security fix: exact identity, not startswith).
+        near = HEAD[:12] + "0" * 28  # same 12-char prefix, different full oid
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(near))
+        block, _ = _mod._check_codex_reviewed_head("1")
+        assert block is True
+
+    def test_force_override_bypasses(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")  # would otherwise block
+        block, _ = _mod._check_codex_reviewed_head("1", force=True)
+        assert block is False
+
+    def test_head_unresolvable_fails_closed(self, monkeypatch):
+        # Enforcement gate: an unreadable head is treated as unverifiable → BLOCK
+        # (fail-closed, like _check_mergeable's UNKNOWN), not waved through.
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", "")  # empty → None
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))
+        block, msg = _mod._check_codex_reviewed_head("1")
+        assert block is True and "head" in msg.lower()

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -135,6 +135,108 @@ class TestMergeMatchHead:
         assert "--repo" not in cmd
         assert cmd == f"gh pr merge 5 --squash --admin --match-head-commit {HEAD}"
 
+    def test_shadowed_as_body_value_is_ignored(self):
+        # `--body --match-head-commit=<sha>` — gh takes the sha as BODY TEXT (no
+        # binding); the scan must NOT read it as an active binding (Codex P1 r3).
+        argv = [
+            "gh",
+            "pr",
+            "merge",
+            "5",
+            "--body",
+            f"--match-head-commit={HEAD}",
+            "--squash",
+            "--admin",
+        ]
+        assert _mod._merge_match_head(argv) is None
+
+    def test_shadowed_as_short_flag_value_is_ignored(self):
+        for vflag in ("-b", "-F", "-t", "-A", "--body-file", "--subject", "--author-email"):
+            argv = ["gh", "pr", "merge", "5", vflag, f"--match-head-commit={HEAD}", "--admin"]
+            assert _mod._merge_match_head(argv) is None, vflag
+
+    def test_real_binding_after_a_body_value(self):
+        # --body consumes 'msg'; the real --match-head-commit still parses.
+        argv = ["gh", "pr", "merge", "5", "--body", "msg", "--match-head-commit", HEAD, "--admin"]
+        assert _mod._merge_match_head(argv) == HEAD
+
+    def test_double_dash_ends_options(self):
+        argv = ["gh", "pr", "merge", "5", "--", f"--match-head-commit={HEAD}"]
+        assert _mod._merge_match_head(argv) is None
+
+    def test_glued_body_containing_flag_is_ignored(self):
+        argv = ["gh", "pr", "merge", "5", f"--body=--match-head-commit={HEAD}", "--admin"]
+        assert _mod._merge_match_head(argv) is None
+
+    def test_short_cluster_swallows_next_token(self):
+        # -db = -d(bool) + -b(value); gh's -b swallows the following
+        # --match-head-commit as BODY text (merges UNBOUND) — must NOT be read as
+        # a binding (audit round 4).
+        for cluster in ("-db", "-dt", "-dA", "-sb", "-mb"):
+            argv = [
+                "gh",
+                "pr",
+                "merge",
+                "5",
+                "--repo",
+                "o/r",
+                cluster,
+                f"--match-head-commit={HEAD}",
+                "--admin",
+            ]
+            assert _mod._merge_match_head(argv) is None, cluster
+
+    def test_bool_cluster_then_real_binding(self):
+        # -ds = two booleans; the real --match-head-commit still binds.
+        argv = ["gh", "pr", "merge", "5", "-ds", "--match-head-commit", HEAD]
+        assert _mod._merge_match_head(argv) == HEAD
+
+    def test_glued_short_body_is_ignored(self):
+        argv = ["gh", "pr", "merge", "5", f"-b--match-head-commit={HEAD}", "--admin"]
+        assert _mod._merge_match_head(argv) is None
+
+
+class TestMergeShadowFlag:
+    def test_detects_content_flags(self):
+        for vflag in (
+            "--body",
+            "-b",
+            "--body-file",
+            "-F",
+            "--subject",
+            "-t",
+            "--author-email",
+            "-A",
+        ):
+            assert _mod._merge_has_shadow_flag(["gh", "pr", "merge", "5", vflag, "x"]), vflag
+        assert _mod._merge_has_shadow_flag(["gh", "pr", "merge", "5", "--body=x"])
+
+    def test_clean_merge_has_no_shadow(self):
+        argv = [
+            "gh",
+            "pr",
+            "merge",
+            "5",
+            "--repo",
+            "o/r",
+            "--squash",
+            "--admin",
+            "--match-head-commit",
+            HEAD,
+        ]
+        assert _mod._merge_has_shadow_flag(argv) is False
+
+    def test_detects_shadow_inside_cluster(self):
+        for cluster in ("-db", "-dt", "-dA", "-sb", "-b"):
+            assert _mod._merge_has_shadow_flag(["gh", "pr", "merge", "5", cluster, "x"]), cluster
+
+    def test_repo_cluster_not_shadow(self):
+        # -R / -dR are --repo (allowed); the value-short stops cluster scanning.
+        assert _mod._merge_has_shadow_flag(["gh", "pr", "merge", "5", "-dR", "o/r"]) is False
+        assert _mod._merge_has_shadow_flag(["gh", "pr", "merge", "5", "-R", "o/r"]) is False
+
+
+class TestMergeMatchHeadRepeat:
     def test_repeated_flag_last_wins(self):
         # gh pflag semantics: the LAST repeated string-flag value is the one gh
         # enforces — the hook must validate that same value, else

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -122,3 +122,21 @@ class TestMergeMatchHead:
 
     def test_absent(self):
         assert _mod._merge_match_head(["gh", "pr", "merge", "5", "--admin"]) is None
+
+    def test_repeated_flag_last_wins(self):
+        # gh pflag semantics: the LAST repeated string-flag value is the one gh
+        # enforces — the hook must validate that same value, else
+        # `--match-head-commit <verified> --match-head-commit <other>` passes the
+        # hook at <verified> while gh merges at <other> (Codex P1, round 2).
+        argv = ["gh", "pr", "merge", "5", "--match-head-commit", HEAD, "--match-head-commit", STALE]
+        assert _mod._merge_match_head(argv) == STALE
+        argv = [
+            "gh",
+            "pr",
+            "merge",
+            "5",
+            "--match-head-commit",
+            STALE,
+            f"--match-head-commit={HEAD}",
+        ]
+        assert _mod._merge_match_head(argv) == HEAD

--- a/tests/test_hooks/test_git_push_guard_repo.py
+++ b/tests/test_hooks/test_git_push_guard_repo.py
@@ -199,23 +199,21 @@ class TestGateThreading:
 
 
 class TestResolvePrNumberFallback:
-    """The no-arg fallback must honor --repo (red-team finding 5): resolving
-    the CWD branch's PR number and gating it against ANOTHER repo would
-    re-create the wrong-PR bug through the fix itself."""
+    """The no-arg fallback must NOT resolve a CWD-branch PR and gate it against a
+    user-named --repo (red-team finding 5): that re-creates the wrong-PR bug. With
+    an explicit --repo and no number it fails CLOSED (None). Round 5 makes this a
+    short-circuit — no pointless gh call that would only error anyway (gh: "argument
+    required when using the --repo flag"). A DERIVED cwd (F3) instead resolves the
+    branch PR in that same dir with no --repo (see TestGetPushRemoteAndBranch's
+    sibling coverage in test_merge_review_gate.py)."""
 
-    def test_fallback_carries_repo_flag(self):
-        calls: list[list[str]] = []
-
-        def fake_run(args, **kwargs):
-            calls.append(list(args))
-            # gh errors when --repo is given without a PR selector — the
-            # coherent outcome is None → the caller fails CLOSED.
-            return _FakeResult(returncode=1, stderr="argument required when using --repo")
+    def test_explicit_repo_numberless_fails_closed_no_gh_call(self):
+        def fake_run(args, **kwargs):  # pragma: no cover — must not be reached
+            raise AssertionError("gh must not be called for explicit --repo + numberless")
 
         with patch.object(_mod.subprocess, "run", fake_run):
             result = _mod._resolve_pr_number("gh pr merge --repo octo/voice", repo="octo/voice")
         assert result is None
-        assert calls and "--repo" in calls[0]
 
     def test_explicit_number_needs_no_gh_call(self):
         calls: list[list[str]] = []
@@ -259,6 +257,6 @@ class TestMainFailsClosedOnUnresolvableRepo:
             env=env,
         )
         assert r.returncode == 2, f"variable --repo merge must block: {r.stdout}{r.stderr}"
-        assert "cannot resolve the target repo" in r.stderr
+        assert "cannot determine which repository" in r.stderr
         # And it must NOT have gated the cwd repo (no gh mergeable/review calls).
         assert not called.exists(), "no gh gate call should run for an unresolvable repo"

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1618,7 +1618,7 @@ class TestMergeableAllowlist:
             lambda n, force=False, repo=None: (False, "", None),
         )
         for name in ("_check_pr_review_findings", "_check_inline_review_findings"):
-            monkeypatch.setattr(guard_module, name, lambda n, repo=None: (False, ""))
+            monkeypatch.setattr(guard_module, name, lambda n, repo=None, strict=False: (False, ""))
         assert guard_module.check_pr_report("5") == 1
         assert "would block" in capsys.readouterr().out
 
@@ -1755,6 +1755,89 @@ class TestRepoDerivationGate:
         assert seen["repo"] is None  # not derived → cwd repo (unchanged behavior)
 
 
+class TestStrictScanMode:
+    """F-report (Codex P2, round 6): a finding scan that could not be READ (gh
+    error/timeout/malformed) must not be reported as clean. Report mode passes
+    strict=True → an unreadable scan blocks/fails; enforcement (default) stays
+    fail-open for Codex-quota/outage tolerance. An EMPTY result (quota) is clean
+    in both modes."""
+
+    def test_body_error_fails_closed_when_strict(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="x"),
+        ):
+            block, msg = guard_module._check_pr_review_findings("1", strict=True)
+        assert block is True and "unreadable" in msg.lower()
+
+    def test_body_error_fails_open_by_default(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="x"),
+        ):
+            block, _ = guard_module._check_pr_review_findings("1")
+        assert block is False
+
+    def test_body_empty_is_clean_even_when_strict(self, guard_module):
+        # Empty (quota / no comments) is NOT an error — clean in both modes.
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="[]"),
+        ):
+            block, _ = guard_module._check_pr_review_findings("1", strict=True)
+        assert block is False
+
+    def test_inline_error_fails_closed_when_strict(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="x"),
+        ):
+            block, msg = guard_module._check_inline_review_findings("1", strict=True)
+        assert block is True and "unreadable" in msg.lower()
+
+    def test_inline_error_fails_open_by_default(self, guard_module):
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="x"),
+        ):
+            block, _ = guard_module._check_inline_review_findings("1")
+        assert block is False
+
+    def test_report_counts_unreadable_scan_as_failure(self, guard_module, monkeypatch, capsys):
+        # The canonical report must not print "all gates pass" when a scan errored.
+        monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        monkeypatch.setattr(guard_module, "_pr_ci_status", lambda n, repo=None: ("green", []))
+        monkeypatch.setattr(
+            guard_module, "_check_base_is_default", lambda n, force=False, repo=None: (False, "")
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_codex_reviewed_head",
+            lambda n, force=False, repo=None: (False, "", "h"),
+        )
+        # Body scan errors (strict → block); inline clean.
+        monkeypatch.setattr(
+            guard_module,
+            "_check_pr_review_findings",
+            lambda n, repo=None, strict=False: (True, "could not read review-body comments")
+            if strict
+            else (False, ""),
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_inline_review_findings",
+            lambda n, repo=None, strict=False: (False, ""),
+        )
+        assert guard_module.check_pr_report("5") == 1
+        out = capsys.readouterr().out
+        assert "would block" in out and "all gates pass" not in out
+
+
 class TestGateOrdering:
     """F1: Codex freshness must be established BEFORE the finding scans.
 
@@ -1824,12 +1907,12 @@ class TestGateOrdering:
         monkeypatch.setattr(
             guard_module,
             "_check_pr_review_findings",
-            lambda n, force=False, repo=None: (calls.append("body"), (False, ""))[1],
+            lambda n, repo=None, strict=False: (calls.append("body"), (False, ""))[1],
         )
         monkeypatch.setattr(
             guard_module,
             "_check_inline_review_findings",
-            lambda n, force=False, repo=None: (calls.append("inline"), (False, ""))[1],
+            lambda n, repo=None, strict=False: (calls.append("inline"), (False, ""))[1],
         )
         guard_module.check_pr_report("5")
         assert calls.index("freshness") < calls.index("body")

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1290,6 +1290,28 @@ class TestResolvePrNumber:
         ):
             assert guard_module._resolve_pr_number("gh pr merge --squash") is None
 
+    def test_explicit_repo_numberless_fails_closed_without_gh(self, guard_module):
+        # explicit user --repo + no number + no cwd → None WITHOUT touching gh
+        # (gh pr view --repo errors without a selector; resolving a cwd-branch PR
+        # and gating it against a DIFFERENT repo is the wrong-PR bug).
+        with patch.object(guard_module.subprocess, "run", side_effect=AssertionError):
+            assert guard_module._resolve_pr_number("gh pr merge --squash", repo="o/r") is None
+
+    def test_derived_cwd_numberless_resolves_without_repo_flag(self, guard_module):
+        # A merge whose repo was DERIVED from cwd (F3): the numberless branch PR
+        # resolves by running gh IN that cwd with NO --repo — so it doesn't hit
+        # the `--repo needs a selector` error the previous line guards against.
+        with patch.object(
+            guard_module.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="88\n"),
+        ) as run:
+            got = guard_module._resolve_pr_number("gh pr merge --squash", repo="o/r", cwd="/wt")
+        assert got == "88"
+        argv = run.call_args_list[0].args[0]
+        assert "--repo" not in argv
+        assert run.call_args_list[0].kwargs.get("cwd") == "/wt"
+
 
 # ── CI-status merge gate (_pr_ci_status / _has_ci_override) ───────────────
 
@@ -1441,6 +1463,13 @@ class TestCiGateEndToEnd:
             "_check_codex_reviewed_head",
             lambda n, force=False, repo=None: (False, "", None),
         )
+        # Base-branch invariant (PR #1366) also makes real gh calls — mock it
+        # pass-through so this suite stays offline-hermetic.
+        monkeypatch.setattr(
+            guard_module,
+            "_check_base_is_default",
+            lambda n, force=False, repo=None: (False, ""),
+        )
 
     def test_red_ci_blocks_exit_2(self, guard_module, monkeypatch, capsys):
         monkeypatch.setenv(
@@ -1520,6 +1549,291 @@ class TestCiStatusUnfinishedStates:
             {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
         ])
         assert guard_module._pr_ci_status("1") == ("green", [])
+
+
+class TestMergeableAllowlist:
+    """F2: the mergeability gate is an ALLOWLIST — block unless status is a
+    definite MERGEABLE. The old `== UNKNOWN` check let None/'' (a FAILED query;
+    _check_mergeable fails OPEN to None) sail through and merge. Both the
+    enforcement arm and the report close this."""
+
+    def _payload(self, cmd):
+        return {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": cmd},
+        }
+
+    def _patch_downstream(self, guard_module, monkeypatch):
+        # Everything AFTER mergeability passes, so only mergeability decides.
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "SUCCESS"}])
+        )
+        for name in ("_check_pr_review_findings", "_check_inline_review_findings"):
+            monkeypatch.setattr(guard_module, name, lambda n, force=False, repo=None: (False, ""))
+        monkeypatch.setattr(
+            guard_module, "_check_base_is_default", lambda n, force=False, repo=None: (False, "")
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_codex_reviewed_head",
+            lambda n, force=False, repo=None: (False, "", None),
+        )
+
+    @pytest.mark.parametrize("bad", [None, "", "UNKNOWN", "SOMETHING_NEW"])
+    def test_non_mergeable_blocks(self, guard_module, monkeypatch, bad):
+        monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: bad)
+        self._patch_downstream(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module, "read_payload", lambda: self._payload("gh pr merge 5 --squash --admin")
+        )
+        assert guard_module.main() == 2
+
+    def test_conflicting_blocks_with_specific_message(self, guard_module, monkeypatch, capsys):
+        monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: "CONFLICTING")
+        self._patch_downstream(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module, "read_payload", lambda: self._payload("gh pr merge 5 --squash --admin")
+        )
+        assert guard_module.main() == 2
+        assert "merge conflicts" in capsys.readouterr().err
+
+    def test_mergeable_passes(self, guard_module, monkeypatch):
+        monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        self._patch_downstream(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module, "read_payload", lambda: self._payload("gh pr merge 5 --squash --admin")
+        )
+        assert guard_module.main() == 0
+
+    def test_report_counts_none_as_failure(self, guard_module, monkeypatch, capsys):
+        monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: None)
+        monkeypatch.setattr(guard_module, "_pr_ci_status", lambda n, repo=None: ("green", []))
+        monkeypatch.setattr(
+            guard_module, "_check_base_is_default", lambda n, force=False, repo=None: (False, "")
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_codex_reviewed_head",
+            lambda n, force=False, repo=None: (False, "", None),
+        )
+        for name in ("_check_pr_review_findings", "_check_inline_review_findings"):
+            monkeypatch.setattr(guard_module, name, lambda n, repo=None: (False, ""))
+        assert guard_module.check_pr_report("5") == 1
+        assert "would block" in capsys.readouterr().out
+
+
+class TestRepoDerivationGate:
+    """F3: a bare (no --repo) merge is gated against the repo gh will ACTUALLY
+    target — derived from the merge's effective cwd — not the hook process's cwd.
+    Fail-closed when that cwd is ambiguous or gh can't resolve a repo there."""
+
+    def _payload(self, cmd, cwd=None):
+        p = {"hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {"command": cmd}}
+        if cwd is not None:
+            p["cwd"] = cwd
+        return p
+
+    def _patch_ok(self, guard_module, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "SUCCESS"}])
+        )
+        monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        for name in ("_check_pr_review_findings", "_check_inline_review_findings"):
+            monkeypatch.setattr(guard_module, name, lambda n, force=False, repo=None: (False, ""))
+        monkeypatch.setattr(
+            guard_module, "_check_base_is_default", lambda n, force=False, repo=None: (False, "")
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_codex_reviewed_head",
+            lambda n, force=False, repo=None: (False, "", None),
+        )
+
+    def test_derived_repo_threads_into_gates(self, guard_module, monkeypatch):
+        seen = {}
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "octo/other")
+        self._patch_ok(guard_module, monkeypatch)
+
+        def rec_mergeable(n, repo=None):
+            seen["repo"] = repo
+            return "MERGEABLE"
+
+        monkeypatch.setattr(guard_module, "_check_mergeable", rec_mergeable)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("gh pr merge 5 --squash --admin", cwd="/some/other/checkout"),
+        )
+        assert guard_module.main() == 0
+        assert seen["repo"] == "octo/other"
+
+    def test_explicit_repo_skips_derivation(self, guard_module, monkeypatch):
+        seen = {}
+        # Seam would derive octo/other, but --repo must win (no derivation).
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "octo/other")
+        self._patch_ok(guard_module, monkeypatch)
+
+        def rec_mergeable(n, repo=None):
+            seen["repo"] = repo
+            return "MERGEABLE"
+
+        monkeypatch.setattr(guard_module, "_check_mergeable", rec_mergeable)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload(
+                "gh pr merge 5 --repo real/repo --squash --admin", cwd="/some/other/checkout"
+            ),
+        )
+        assert guard_module.main() == 0
+        assert seen["repo"] == "real/repo"
+
+    def test_unresolvable_cwd_repo_blocks(self, guard_module, monkeypatch):
+        # cwd resolves but gh can't name a repo there (seam empty) → fail-closed.
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "")
+        self._patch_ok(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("gh pr merge 5 --squash --admin", cwd="/not/a/repo"),
+        )
+        assert guard_module.main() == 2
+
+    def test_ambiguous_cd_blocks(self, guard_module, monkeypatch):
+        # A `cd` to an unresolvable target (shell var) → _CWD_UNKNOWN → fail-closed,
+        # even though a derivation seam is set.
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "octo/other")
+        self._patch_ok(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("cd $HOME && gh pr merge 5 --squash --admin", cwd="/repo"),
+        )
+        assert guard_module.main() == 2
+
+    def test_numberless_merge_threads_derived_cwd_to_resolver(self, guard_module, monkeypatch):
+        # Regression (architect audit, round 5): F3 derives an explicit repo for a
+        # numberless merge; _resolve_pr_number must get the DERIVED cwd so the
+        # branch PR still resolves (an explicit --repo would error). Without the
+        # cwd thread, a numberless `gh pr merge` that worked pre-F3 would block.
+        seen = {}
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "octo/other")
+        self._patch_ok(guard_module, monkeypatch)
+
+        def rec_resolve(cmd, repo=None, cwd=None):
+            seen["repo"] = repo
+            seen["cwd"] = cwd
+            return "5"
+
+        monkeypatch.setattr(guard_module, "_resolve_pr_number", rec_resolve)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("gh pr merge --squash --admin", cwd="/some/other/checkout"),
+        )
+        assert guard_module.main() == 0
+        assert seen["repo"] == "octo/other"
+        assert seen["cwd"] == "/some/other/checkout"
+
+    def test_no_cwd_info_keeps_cwd_behavior(self, guard_module, monkeypatch):
+        # Payload without cwd (older CC / test harness): nothing to derive from →
+        # merge_repo stays None (today's cwd-based behavior), NOT a block.
+        seen = {}
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "octo/other")
+        self._patch_ok(guard_module, monkeypatch)
+
+        def rec_mergeable(n, repo=None):
+            seen["repo"] = repo
+            return "MERGEABLE"
+
+        monkeypatch.setattr(guard_module, "_check_mergeable", rec_mergeable)
+        monkeypatch.setattr(
+            guard_module, "read_payload", lambda: self._payload("gh pr merge 5 --squash --admin")
+        )
+        assert guard_module.main() == 0
+        assert seen["repo"] is None  # not derived → cwd repo (unchanged behavior)
+
+
+class TestGateOrdering:
+    """F1: Codex freshness must be established BEFORE the finding scans.
+
+    If a review is published between the finding scans and the freshness check,
+    its matching commit_id passes freshness while any P1 comments published with
+    it were never scanned — the merge proceeds with unread findings. Ordering:
+    mergeable → CI → base-invariant → freshness → body findings → inline findings.
+    """
+
+    def _payload(self, cmd):
+        return {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": cmd},
+        }
+
+    def test_freshness_precedes_finding_scans(self, guard_module, monkeypatch):
+        calls: list[str] = []
+        monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "SUCCESS"}])
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_base_is_default",
+            lambda n, force=False, repo=None: (calls.append("base"), (False, ""))[1],
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_codex_reviewed_head",
+            lambda n, force=False, repo=None: (calls.append("freshness"), (False, "", None))[1],
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_pr_review_findings",
+            lambda n, force=False, repo=None: (calls.append("body"), (False, ""))[1],
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_inline_review_findings",
+            lambda n, force=False, repo=None: (calls.append("inline"), (False, ""))[1],
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("gh pr merge 5 --squash --admin"),
+        )
+        assert guard_module.main() == 0
+        assert "freshness" in calls and "body" in calls and "inline" in calls
+        assert calls.index("freshness") < calls.index("body")
+        assert calls.index("freshness") < calls.index("inline")
+
+    def test_report_freshness_precedes_finding_scans(self, guard_module, monkeypatch, capsys):
+        calls: list[str] = []
+        monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        monkeypatch.setattr(guard_module, "_pr_ci_status", lambda n, repo=None: ("green", []))
+        monkeypatch.setattr(
+            guard_module,
+            "_check_base_is_default",
+            lambda n, force=False, repo=None: (calls.append("base"), (False, ""))[1],
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_codex_reviewed_head",
+            lambda n, force=False, repo=None: (calls.append("freshness"), (False, "", "h"))[1],
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_pr_review_findings",
+            lambda n, force=False, repo=None: (calls.append("body"), (False, ""))[1],
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_inline_review_findings",
+            lambda n, force=False, repo=None: (calls.append("inline"), (False, ""))[1],
+        )
+        guard_module.check_pr_report("5")
+        assert calls.index("freshness") < calls.index("body")
+        assert calls.index("freshness") < calls.index("inline")
 
 
 class TestMultiMergeBlocked:

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1433,6 +1433,14 @@ class TestCiGateEndToEnd:
             "_check_inline_review_findings",
             lambda n, force=False, repo=None: (False, ""),
         )
+        # The Codex review-freshness gate (PR #1366) is a real network check —
+        # mock it pass-through (None verified_head also disengages the
+        # --match-head-commit binding) so this suite stays offline-hermetic.
+        monkeypatch.setattr(
+            guard_module,
+            "_check_codex_reviewed_head",
+            lambda n, force=False, repo=None: (False, "", None),
+        )
 
     def test_red_ci_blocks_exit_2(self, guard_module, monkeypatch, capsys):
         monkeypatch.setenv(


### PR DESCRIPTION
## What

Hardens `scripts/hooks/git_push_guard.py`'s `gh pr merge` gate so a merge cannot
proceed unless the current head has a **live, valid** Codex review — and binds the
merge atomically to the reviewed head. Closes the gap where a not-yet-reviewed,
stale-reviewed, or wrong-repo/wrong-base merge could slip through because the
finding scanners come back empty.

## Declared threat model (the standing triage rule)

This is a **process gate** for a **single-author, single-remote, github.com** repo
whose PRs target the default branch. It defends the session's **own process
failures** — not an adversary crafting argv (they own `--admin` and
`# review-override`), nor a hostile multi-actor repo. The model is written into the
module docstring; findings outside it are *out of scope by design*. This scoping is
what lets the gate stop growing new surfaces every review round.

## The gates (in order)

`mergeable → CI → base-invariant → freshness → review-body findings → inline findings`,
then an atomic head binding. Each is fail-closed within the declared model:

- **Freshness** (`_check_codex_reviewed_head`): the PR's `headRefOid` must exactly
  equal the **full `commit_id`** of Codex's latest review (no prefix match —
  grind-proof). Runs **before** the finding scans so a review published mid-run
  can't pass freshness with its own P1s unscanned.
- **Atomic head binding** (`--match-head-commit`): the merge is bound to the
  verified head; GitHub rejects it server-side if the head moved between check and
  merge (TOCTOU). The binding parse models gh/pflag **short-flag clustering** and a
  fail-closed shadow-flag belt so a content flag can't smuggle the token as its
  value.
- **Base-invariant** (`_check_base_is_default`): base must equal the repo's live
  default branch — catches a retarget that leaves the head oid unchanged.
- **Mergeability allowlist**: block unless a definite `MERGEABLE`; a failed/empty
  read (`None`/`""`) or `UNKNOWN` no longer merges.
- **Repo derivation** (`_derive_repo_from_cwd`): with no explicit `--repo`, the
  gate derives the repo gh will actually target from the merge's **effective cwd**
  (not the hook process's cwd) and gates that repo — fail-closed on an ambiguous
  cwd.
- **Canonical `--check-pr` report** shares these exact functions, so the pre-merge
  report and the enforcement gate can never drift (the origin of the false "Codex
  clean" report this PR's tooling prevents).

## Round-5 changes (resolving 4 outstanding Codex findings)

- **F1** ordering — freshness before finding scans (both enforcement + report).
- **F2** mergeability allowlist — closes a `None`/`""` fail-open in both sites.
- **F3** repo derivation — root cause was hook-cwd vs gh-effective-cwd (Codex's
  preceding-`cd` case was a sub-case); numberless-merge PR resolution threads the
  same cwd so it still resolves (regression caught by a fresh-context architect
  audit and fixed).
- **F4** base-retarget guard.

## Testing

- Network-free via `_TEST_GH_*` injection seams. New coverage: gate ordering
  (both sites), mergeability allowlist, base-invariant (match/mismatch/unreadable/
  force), repo derivation (derived/explicit/ambiguous/no-cwd) and the numberless-
  merge cwd threading.
- `tests/test_hooks/` **1296 passed**, targeted merge/freshness/repo suites 256
  passed; `ruff` clean. Verify-RED captured on the ordering test.
- Fresh-context adversarial review (genesis-security-reviewer + genesis-architect):
  security clean; one regression found and fixed with tests.

This is a **hook change** — it takes effect at the next CC session start.
