### PR TITLE
feat(recon): career-outreach monitor — drive career-agent, nudge owner (ships off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Opt-in career-outreach monitor (off by default).** A new daily monitor that,
+  once enabled, drives a configured external career-agent module to stage
+  first-touch outreach drafts into your mail Drafts, then sends you a single
+  Telegram nudge to review and send them — it never sends mail itself (you click
+  Send). Ships `off`; flip `off → observe → live` in `career_outreach.yaml`
+  (env kill switch: `GENESIS_CAREER_OUTREACH_DISABLED=1`). No-ops cleanly on
+  installs that don't have a career-agent module configured.
+
 - **cc-tmp blast-radius isolation now converges on its own.** The dedicated,
   size-capped volume that stops a runaway temp write from filling the container
   root — and taking every Claude Code session down with it — used to attach only

--- a/config/career_outreach.yaml
+++ b/config/career_outreach.yaml
@@ -19,6 +19,6 @@
 # career_outreach.local.yaml overlay, never here.
 enabled: true
 mode: off
-reasoning_module: "Career Ops"
+reasoning_module: ""   # set your career-agent module's name in career_outreach.local.yaml
 max_auto_runs_per_tick: 3
 dispatch_timeout_s: 240

--- a/config/career_outreach.yaml
+++ b/config/career_outreach.yaml
@@ -1,0 +1,24 @@
+# Career-outreach monitor — operator lever.
+# Semantics: src/genesis/recon/career_outreach_config.py
+#
+# This monitor drives a configured external career-agent module to run
+# job-outreach discovery and stage first-touch DRAFTS, then nudges the owner to
+# review + send. It NEVER sends mail itself — the external module stages drafts
+# into the owner's mail Drafts and the owner clicks Send (draft-and-hold).
+#
+# mode: off | observe | live
+#   off     — monitor does not run. SHIPPED DEFAULT (an actuator stays inert
+#             until the owner opts in).
+#   observe — resolve + seed state, NEVER dispatch a draft-staging run or nudge
+#             (flip off -> observe to seed silently, then observe -> live).
+#   live    — drive due discovery + up to max_auto_runs_per_tick draft-staging
+#             runs, then nudge the owner when NEW drafts were staged.
+#
+# Env kill switch: GENESIS_CAREER_OUTREACH_DISABLED=1 forces off.
+# Install-specific knobs (module names, targeting) belong in the gitignored
+# career_outreach.local.yaml overlay, never here.
+enabled: true
+mode: off
+reasoning_module: "Career Ops"
+max_auto_runs_per_tick: 3
+dispatch_timeout_s: 240

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -493,8 +493,8 @@ verified: 557d3587 2026-08-09
   `off`/`observe`/`live` + `GENESIS_CAREER_OUTREACH_DISABLED` kill). Bridge
   lazy-resolved at tick; `execute_operation` returns an error DICT (never raises)
   so a dispatch error surfaces → job-health failure; `check_health_cached` gates;
-  absent-module → clean no-op (generic installs). The remote `radar_status` is
-  the draft source-of-truth; a `career_outreach_nudged` observation is the
+  absent-module → clean no-op (generic installs). The external engine's own
+  staged-draft state is the source of truth; a `career_outreach_nudged` observation is the
   per-company nudge-dedup ledger so a re-tick / undelivered nudge never
   double-nudges. ONE daily job (`max_instances=1` is per-job; a second would race
   the single remote). Discovery-sweep driving is GROUNDWORK-deferred.

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -484,6 +484,20 @@ verified: 557d3587 2026-08-09
   notification's `latest_comment_url` and pinging immediately in `live`.
   `off`/`observe`/`live` lever + `notifications` reason-allowlist in
   `github_steward_config`.
+- **recon/career_outreach.py** (`CareerOutreachMonitor`) — the recon entry that
+  not only pushes but ACTS: a daily surplus-cron ACTUATOR driving a configured
+  external career-agent module (SSH CC dispatch, declared in the install's
+  `~/.genesis` module overlay) to stage first-touch outreach drafts into the
+  owner's mail Drafts (the module never sends — owner clicks Send), then pushing
+  ONE Telegram nudge for newly-staged drafts. Ships `off` (`career_outreach_config`
+  `off`/`observe`/`live` + `GENESIS_CAREER_OUTREACH_DISABLED` kill). Bridge
+  lazy-resolved at tick; `execute_operation` returns an error DICT (never raises)
+  so a dispatch error surfaces → job-health failure; `check_health_cached` gates;
+  absent-module → clean no-op (generic installs). The remote `radar_status` is
+  the draft source-of-truth; a `career_outreach_nudged` observation is the
+  per-company nudge-dedup ledger so a re-tick / undelivered nudge never
+  double-nudges. ONE daily job (`max_instances=1` is per-job; a second would race
+  the single remote). Discovery-sweep driving is GROUNDWORK-deferred.
 - **web/**: stateless search (SearXNG primary, Brave fallback) + httpx fetch
   (50k-char cap), sanitizer-wrapped; consumed via importers (MCP web tools,
   research, recon, pipeline), not runtime init.

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -80,6 +80,10 @@ INTERNAL_OBS_TYPES: frozenset[str] = frozenset(
         # Owed first-time ping the monitor retries each tick until delivered —
         # internal retry state, never a user-facing surface.
         "github_ping_pending",
+        # Career-outreach monitor — per-draft "already nudged the owner" dedup
+        # marker. The owner nudge (Telegram) is the delivery path; these rows must
+        # NOT surface via the generic observation surfacers (would double-notify).
+        "career_outreach_nudged",
     }
 )
 
@@ -175,6 +179,11 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     # delivered for a week something is badly wrong and the 30d activity row is
     # the backstop; short so an abandoned marker cannot linger.
     "github_ping_pending": timedelta(days=7),
+    # Career-outreach monitor — per-draft "already nudged" dedup marker. 30d:
+    # long enough that a still-open staged draft is not re-nudged, bounded so an
+    # abandoned marker cannot linger. The remote radar_status is the source of
+    # truth for draft counts; this row only records "owner already nudged".
+    "career_outreach_nudged": timedelta(days=30),
     # cognitive self-mod rollback audit (operator-visible correction event)
     "self_mod_rollback": timedelta(days=30),
     # skill-edit Critic shadow verdicts (WS1) — kept 30d (vs 14d for the

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -181,8 +181,8 @@ _TTL_BY_TYPE: dict[str, timedelta] = {
     "github_ping_pending": timedelta(days=7),
     # Career-outreach monitor — per-draft "already nudged" dedup marker. 30d:
     # long enough that a still-open staged draft is not re-nudged, bounded so an
-    # abandoned marker cannot linger. The remote radar_status is the source of
-    # truth for draft counts; this row only records "owner already nudged".
+    # abandoned marker cannot linger. The external engine's own staged-draft state is
+    # the source of truth for draft counts; this row only records "owner already nudged".
     "career_outreach_nudged": timedelta(days=30),
     # cognitive self-mod rollback audit (operator-visible correction event)
     "self_mod_rollback": timedelta(days=30),

--- a/src/genesis/recon/career_outreach.py
+++ b/src/genesis/recon/career_outreach.py
@@ -283,7 +283,8 @@ class CareerOutreachMonitor:
                 break
             payload = _parse_json(_reply_text(result))
             if not isinstance(payload, dict):
-                details.append("auto-run: unparseable reply — stopping")
+                errors += 1
+                details.append("auto-run: unparseable reply (protocol failure) — stopping")
                 break
             if payload.get("none_left"):
                 details.append("auto-run: no target accounts left")
@@ -297,7 +298,8 @@ class CareerOutreachMonitor:
                 break
             company = (payload.get("company") or "").strip()
             if not company:
-                details.append("auto-run: reply missing 'company' — stopping")
+                errors += 1
+                details.append("auto-run: reply missing 'company' (protocol failure) — stopping")
                 break
             auto_runs += 1
             details.append(f"staged: {company}")
@@ -311,7 +313,9 @@ class CareerOutreachMonitor:
         # against the engine's existing target backlog.
         nudged = 0
         drafts_working = 0
-        if not adapter_error:
+        if not adapter_error and self._is_paused():
+            details.append("paused mid-tick — skipping staged-draft read + nudge")
+        elif not adapter_error:
             working, err = await self._list_working(mod, timeout)
             if err:
                 errors += 1
@@ -360,16 +364,19 @@ class CareerOutreachMonitor:
                             )
                         nudged = len(fresh)
                         details.append(f"nudged {nudged} new staged draft(s)")
-                    elif status == OutreachStatus.IGNORED:
-                        # Quiet-hours defer — an EXPECTED outcome, not a failure. Not
-                        # marked, so it retries next tick.
-                        details.append(
-                            f"nudge deferred (quiet hours) — {len(fresh)} draft(s) retry next tick"
-                        )
+                    elif status == OutreachStatus.REJECTED:
+                        # Pipeline dedup — an identical nudge went out recently, so the
+                        # owner already has it. NOT a failure; not re-marked (a harmless
+                        # re-derive next tick, dampened by the set-hash topic dedup).
+                        details.append(f"nudge deduped (already sent) — {len(fresh)} draft(s)")
                     else:
-                        # FAILED / REJECTED / no-pipeline / exception — unsuccessful.
-                        # COUNT it so a persistent delivery failure surfaces as a
-                        # job-health failure; not marked, so it retries.
+                        # FAILED / None (no pipeline / exception) — a real delivery
+                        # failure. COUNT it so a persistent failure surfaces as a
+                        # job-health failure; not marked, so it retries. (submit_raw skips
+                        # quiet-hours governance, so IGNORED never occurs here — owner
+                        # nudges deliver immediately, which is correct: owner-facing
+                        # delivery is never gated by contract, and the tick runs at 08:00,
+                        # post-quiet.)
                         errors += 1
                         details.append(
                             f"nudge not delivered (status={status}) — "
@@ -407,26 +414,34 @@ class CareerOutreachMonitor:
         text = _reply_text(result)
         data = _parse_json(text)
         if isinstance(data, list):
-            return [d for d in data if isinstance(d, dict)], False
-        # A NON-EMPTY reply that is not a JSON array is a protocol violation — surface
-        # it as an error (err=True → job-health failure) so a persistently-malformed
-        # module reply is diagnosable, NOT silently indistinguishable from "none"
-        # (which would make observe seed nothing, then live blast the whole backlog).
-        if text.strip():
-            logger.warning(
-                "career outreach: list-staged reply was not a JSON array "
-                "(malformed module reply?): %s",
-                text.strip()[:160],
-            )
-            return [], True
-        return [], False
+            valid = [d for d in data if isinstance(d, dict) and (d.get("company") or "").strip()]
+            if data and not valid:
+                # A non-empty list with no schema-valid (company-bearing) entries is a
+                # protocol violation — surface it, don't silently under-seed.
+                logger.warning(
+                    "career outreach: list-staged reply was a list with no company-bearing "
+                    "entries: %r",
+                    str(data)[:160],
+                )
+                return [], True
+            return valid, False
+        # Empty text or a non-array reply is a protocol violation — the module is
+        # contracted to return a JSON array ("[]" for none). Surface it as an error
+        # (err=True → job-health failure) so it is diagnosable and observe NEVER
+        # under-seeds (which would make a later live tick over-nudge the backlog).
+        logger.warning(
+            "career outreach: list-staged reply was not a JSON array (malformed/empty): %r",
+            (text or "")[:160],
+        )
+        return [], True
 
     async def _nudge(self, fresh: list[dict]):
         """Push ONE owner-facing Telegram nudge for the freshly-staged drafts.
         Returns the delivery ``OutreachStatus`` (``None`` if there is no pipeline or
-        the send raised) so the caller can distinguish DELIVERED (mark), IGNORED
-        (quiet-hours defer — retry, not a failure), and FAILED/REJECTED (a
-        job-health failure)."""
+        the send raised) so the caller can distinguish DELIVERED (mark), REJECTED
+        (pipeline dedup — already sent, not a failure), and FAILED/None (a job-health
+        failure). ``submit_raw`` skips quiet-hours governance, so IGNORED never occurs
+        — owner-facing delivery is intentionally never gated."""
         from genesis.outreach.types import OutreachCategory, OutreachRequest, OutreachStatus
 
         pipeline = self._pipeline()

--- a/src/genesis/recon/career_outreach.py
+++ b/src/genesis/recon/career_outreach.py
@@ -4,8 +4,8 @@ career-agent engine to stage first-touch outreach drafts, then nudges the owner.
 Unlike its sibling ``AccountActivityMonitor`` (a sense-and-report monitor), this
 one *acts on the owner's behalf*: on a daily tick it dispatches to a configured
 external "reasoning" module (the install's own career-agent, declared in the
-``~/.genesis`` module overlay) to run that engine's auto-run-to-staged-draft for
-up to ``max_auto_runs_per_tick`` page-worthy accounts, then pushes ONE Telegram
+``~/.genesis`` module overlay) to run that engine's first-touch draft-staging flow
+for up to ``max_auto_runs_per_tick`` target accounts, then pushes ONE Telegram
 nudge listing the newly-staged drafts. It NEVER sends mail — the external engine
 stages drafts into the owner's mail Drafts and the owner clicks Send
 (draft-and-hold). The autonomous act is bounded to discover+draft (reversible);
@@ -26,14 +26,16 @@ Design notes:
   lie on every failed dispatch).
 - **Health gate.** ``check_health_cached()`` (60s TTL) each tick; an unhealthy
   module (remote box down) is a CLEAN skip, not a failure — an expected transient.
+- **Pause-aware.** The pause state is re-checked between external actions, so an
+  owner ``/pause`` mid-tick halts the remaining (each up-to-timeout-long) dispatches.
 - **Absent user-module → clean no-op.** On an install without the career-agent
   overlay module, ``module_registry.get()`` returns ``None`` and the tick returns
   silently (never a job-health failure on a generic install).
-- **State: nudge-dedup only.** The remote engine's ``radar_status`` is the source
-  of truth for which accounts have staged drafts; a ``career_outreach_nudged``
+- **State: nudge-dedup only.** The external engine's own staged-draft state is the
+  source of truth for which accounts have staged drafts; a ``career_outreach_nudged``
   observation (content-hashed per company) records only "the owner has already
   been nudged for this draft", so a re-tick does not re-nudge. Because the nudge
-  list is RE-DERIVED from the working set each tick minus this ledger, a
+  list is RE-DERIVED from the staged-draft set each tick minus this ledger, a
   non-delivered nudge simply retries next tick.
 - **Modes** (``career_outreach_config``): ``off`` (default — inert) / ``observe``
   (seed the nudged-set from the existing backlog, never dispatch a staging run or
@@ -62,27 +64,28 @@ _NUDGE_TYPE = "career_outreach_nudged"
 # The external reasoning module owns account selection, the per-day cap, drafting,
 # and staging; Genesis only drives the cadence + the owner nudge. Each dispatch
 # instructs the module to do exactly ONE account and reply with ONLY compact JSON
-# (its entire reply is the bridge return value — no prose reaches this side).
+# (its entire reply is the bridge return value — no prose reaches this side). The
+# phrasing is generic (outcome, not the module's internal schema) so it works with
+# any career-agent module, not one specific implementation.
 _AUTORUN_PROMPT = (
     "This is Genesis driving your outreach engine (a timed dispatch under the "
-    "bridge's hard cap). Pick your SINGLE top page-worthy account that is NOT yet "
-    "worked (radar_status watch/radar, not already 'working'), and run your "
-    "auto-run-to-staged-draft for it: eval-lite -> find-contact -> draft -> stage "
-    "the first-touch draft into the owner's mail Drafts, then promote it to "
-    "radar_status='working'. NEVER send. Do EXACTLY ONE account. Your ENTIRE reply "
-    "is the return value: reply with ONLY compact JSON, no prose — "
+    "bridge's hard cap). Pick your SINGLE highest-priority target account that you "
+    "have NOT yet drafted a first-touch outreach for, and run your full first-touch "
+    "outreach flow for it (evaluate fit, find the right contact, draft, and stage "
+    "the first-touch draft into the owner's mail Drafts), then mark it as worked in "
+    "your own tracking. NEVER send. Do EXACTLY ONE account. Your ENTIRE reply is "
+    "the return value: reply with ONLY compact JSON, no prose — "
     '{"company":"<name>","contact":"<email-or-name>","draft_summary":"<one line>"} '
-    'if you staged one, or {"none_left":true} if no page-worthy account remains, '
+    'if you staged one, or {"none_left":true} if no target account remains, '
     'or {"error":"<reason>"} if you could not.'
 )
 
 _LIST_WORKING_PROMPT = (
-    "This is Genesis. READ-ONLY: list the accounts currently at "
-    "radar_status='working' (a first-touch draft is already staged in the owner's "
-    "mail Drafts, awaiting the owner's send). Stage nothing, change nothing. Your "
-    "ENTIRE reply is the return value: reply with ONLY a compact JSON array, no "
-    'prose — [{"company":"<name>","contact":"<email-or-name>"}, ...] (empty array '
-    "[] if none)."
+    "This is Genesis. READ-ONLY: list the accounts for which you have already "
+    "staged a first-touch draft (awaiting the owner's send). Stage nothing, change "
+    "nothing. Your ENTIRE reply is the return value: reply with ONLY a compact JSON "
+    'array, no prose — [{"company":"<name>","contact":"<email-or-name>"}, ...] '
+    "(empty array [] if none)."
 )
 
 
@@ -135,10 +138,10 @@ class CareerOutreachResult:
     mode: str = "off"
     health_ok: bool = True
     auto_runs: int = 0  # dispatches that staged a fresh draft
-    drafts_working: int = 0  # accounts seen at radar_status='working'
+    drafts_working: int = 0  # accounts with a staged first-touch draft
     nudged: int = 0  # newly-staged drafts included in a delivered nudge
-    seeded: int = 0  # observe: existing working accounts seeded into the ledger
-    errors: int = 0  # adapter-level dispatch failures (→ job-health FAILURE)
+    seeded: int = 0  # observe: existing staged-draft accounts seeded into the ledger
+    errors: int = 0  # unsuccessful operations (→ job-health FAILURE)
     details: list[str] = field(default_factory=list)
 
 
@@ -169,6 +172,17 @@ class CareerOutreachMonitor:
             logger.debug("career outreach: outreach pipeline not resolvable", exc_info=True)
             return None
 
+    def _is_paused(self) -> bool:
+        """True if the owner has /paused Genesis. Re-checked BETWEEN external actions
+        so a mid-tick pause halts the remaining dispatches (each up to the dispatch
+        timeout long) — /pause promises all background activity stops."""
+        try:
+            from genesis.runtime._core import GenesisRuntime
+
+            return bool(GenesisRuntime.instance().paused)
+        except Exception:
+            return False
+
     # ── main tick ─────────────────────────────────────────────────────────
     async def gather(self) -> CareerOutreachResult:
         mode = cfg.effective_mode()
@@ -182,9 +196,9 @@ class CareerOutreachMonitor:
             return CareerOutreachResult(mode=mode)
 
         reasoning_name = cfg.module_name(conf, "reasoning_module")
-        mod = reg.get(reasoning_name)
+        mod = reg.get(reasoning_name) if reasoning_name else None
         if mod is None:
-            # Absent user-module → clean no-op (a generic install lacks the
+            # Absent/unnamed user-module → clean no-op (a generic install lacks the
             # overlay). NOT a job-health failure — this is expected off-install.
             logger.debug("career outreach: module %r not loaded — no-op", reasoning_name)
             return CareerOutreachResult(mode=mode)
@@ -210,13 +224,13 @@ class CareerOutreachMonitor:
         return await self._live(mod, conf, timeout)
 
     async def _observe_seed(self, mod, timeout: int) -> CareerOutreachResult:
-        """Seed the nudged-ledger from the pre-existing working backlog so a later
-        flip to ``live`` does NOT nudge drafts that were staged before the monitor
-        existed. Never dispatches a staging run, never nudges."""
+        """Seed the nudged-ledger from the pre-existing staged-draft backlog so a
+        later flip to ``live`` does NOT nudge drafts that were staged before the
+        monitor existed. Never dispatches a staging run, never nudges."""
         working, err = await self._list_working(mod, timeout)
         if err:
             return CareerOutreachResult(
-                mode="observe", errors=1, details=["observe: list-working dispatch error"]
+                mode="observe", errors=1, details=["observe: list-staged dispatch error"]
             )
         seeded = 0
         for acct in working:
@@ -240,7 +254,7 @@ class CareerOutreachMonitor:
             mode="observe",
             drafts_working=len(working),
             seeded=seeded,
-            details=[f"observe: seeded {seeded} existing working account(s), no nudge"],
+            details=[f"observe: seeded {seeded} existing staged-draft account(s), no nudge"],
         )
 
     async def _live(self, mod, conf: dict, timeout: int) -> CareerOutreachResult:
@@ -250,9 +264,12 @@ class CareerOutreachMonitor:
         details: list[str] = []
         adapter_error = False
 
-        # 1. Drive up to `cap` auto-run-to-staged-draft dispatches — the module
-        #    self-selects + self-caps (won't re-pick a 'working' one).
+        # 1. Drive up to `cap` first-touch draft-staging dispatches — the module
+        #    self-selects + self-caps (won't re-pick an already-drafted account).
         for _ in range(cap):
+            if self._is_paused():
+                details.append("paused mid-tick — stopping auto-run loop")
+                break
             result = await mod.execute_operation(
                 "dispatch", {"prompt": _AUTORUN_PROMPT, "timeout_s": timeout}
             )
@@ -269,11 +286,13 @@ class CareerOutreachMonitor:
                 details.append("auto-run: unparseable reply — stopping")
                 break
             if payload.get("none_left"):
-                details.append("auto-run: no page-worthy accounts left")
+                details.append("auto-run: no target accounts left")
                 break
             if payload.get("error"):
-                # Module-reported (not adapter) failure for this account — soft
-                # stop, not a job-health failure.
+                # Module-reported failure (e.g. auth/drafting) — COUNT it so a
+                # persistent module error surfaces as a job-health failure, not a
+                # silent green tick; still stop the loop.
+                errors += 1
                 details.append(f"auto-run: module error: {str(payload.get('error'))[:120]}")
                 break
             company = (payload.get("company") or "").strip()
@@ -283,20 +302,20 @@ class CareerOutreachMonitor:
             auto_runs += 1
             details.append(f"staged: {company}")
 
-        # 2. Nudge — RE-DERIVE the nudge list from the current working set minus the
-        #    already-nudged ledger (so an undelivered nudge simply retries next
+        # 2. Nudge — RE-DERIVE the nudge list from the current staged-draft set minus
+        #    the already-nudged ledger (so an undelivered nudge simply retries next
         #    tick). Skip if the box just errored (avoid a second doomed dispatch).
         # GROUNDWORK(career-outreach-discovery): before the auto-run loop, drive any
-        # due discovery sweep here (scoped small, < the 300s cap) to widen the
-        # radar with net-new agentic-AI companies; deferred for the MVP, which
-        # runs against the existing radar backlog.
+        # due discovery step here (scoped small, < the 300s cap) to widen the target
+        # set with net-new candidate companies; deferred for the MVP, which runs
+        # against the engine's existing target backlog.
         nudged = 0
         drafts_working = 0
         if not adapter_error:
             working, err = await self._list_working(mod, timeout)
             if err:
                 errors += 1
-                details.append("nudge: list-working dispatch error")
+                details.append("nudge: list-staged dispatch error")
             else:
                 drafts_working = len(working)
                 fresh = []
@@ -320,8 +339,13 @@ class CareerOutreachMonitor:
                         {"company": company, "contact": (acct.get("contact") or "").strip()}
                     )
                 # N=0 → NO nudge (never a "0 drafts staged" spam message).
-                if fresh:
-                    if await self._nudge(fresh):
+                if fresh and self._is_paused():
+                    details.append(f"paused — skipping nudge for {len(fresh)} draft(s)")
+                elif fresh:
+                    from genesis.outreach.types import OutreachStatus
+
+                    status = await self._nudge(fresh)
+                    if status == OutreachStatus.DELIVERED:
                         for acct in fresh:
                             await observations.create(
                                 self._db,
@@ -336,9 +360,20 @@ class CareerOutreachMonitor:
                             )
                         nudged = len(fresh)
                         details.append(f"nudged {nudged} new staged draft(s)")
-                    else:
+                    elif status == OutreachStatus.IGNORED:
+                        # Quiet-hours defer — an EXPECTED outcome, not a failure. Not
+                        # marked, so it retries next tick.
                         details.append(
-                            f"nudge not delivered — {len(fresh)} draft(s) retry next tick"
+                            f"nudge deferred (quiet hours) — {len(fresh)} draft(s) retry next tick"
+                        )
+                    else:
+                        # FAILED / REJECTED / no-pipeline / exception — unsuccessful.
+                        # COUNT it so a persistent delivery failure surfaces as a
+                        # job-health failure; not marked, so it retries.
+                        errors += 1
+                        details.append(
+                            f"nudge not delivered (status={status}) — "
+                            f"{len(fresh)} draft(s) retry next tick"
                         )
 
         return CareerOutreachResult(
@@ -351,22 +386,21 @@ class CareerOutreachMonitor:
         )
 
     async def _list_working(self, mod, timeout: int) -> tuple[list[dict], bool]:
-        """Ask the reasoning module for the current ``radar_status='working'``
-        accounts (the source of truth for staged drafts). Returns ``(accounts,
-        err)`` where ``err`` is True on an adapter-level dispatch failure (the
-        caller surfaces it). A successful dispatch whose reply is not a JSON array
-        yields ``([], False)`` but is logged at WARNING — a persistently-malformed
-        reply must be diagnosable, not silently indistinguishable from "none"."""
-        # GROUNDWORK(career-outreach-http-read): this reads the working set via an SSH
-        # CC dispatch to the reasoning module (~100s, costs a turn). A future Career
-        # Agent HTTP op returning the radar working-set would be a cheaper/faster read
-        # path — reintroduce a `data_module` config knob pointing at it when it exists.
+        """Ask the reasoning module for the accounts with an already-staged
+        first-touch draft (the source of truth for staged drafts). Returns
+        ``(accounts, err)`` where ``err`` is True on a dispatch failure OR a
+        NON-EMPTY reply that is not a JSON array (a protocol violation the caller
+        surfaces as a job-health failure); a genuinely empty reply is ``([], False)``."""
+        # GROUNDWORK(career-outreach-http-read): this reads the staged-draft set via an
+        # SSH CC dispatch to the reasoning module (~100s, costs a turn). A future HTTP
+        # op returning that set would be a cheaper/faster read path — reintroduce a
+        # `data_module` config knob pointing at it when it exists.
         result = await mod.execute_operation(
             "dispatch", {"prompt": _LIST_WORKING_PROMPT, "timeout_s": timeout}
         )
         if isinstance(result, dict) and result.get("error"):
             logger.info(
-                "career outreach: list-working dispatch error: %s",
+                "career outreach: list-staged dispatch error: %s",
                 str(result.get("error"))[:120],
             )
             return [], True
@@ -374,25 +408,31 @@ class CareerOutreachMonitor:
         data = _parse_json(text)
         if isinstance(data, list):
             return [d for d in data if isinstance(d, dict)], False
-        # Not an adapter failure, but do not swallow a malformed reply silently —
-        # it would otherwise look identical to "no working accounts".
+        # A NON-EMPTY reply that is not a JSON array is a protocol violation — surface
+        # it as an error (err=True → job-health failure) so a persistently-malformed
+        # module reply is diagnosable, NOT silently indistinguishable from "none"
+        # (which would make observe seed nothing, then live blast the whole backlog).
         if text.strip():
             logger.warning(
-                "career outreach: list-working reply was not a JSON array "
+                "career outreach: list-staged reply was not a JSON array "
                 "(malformed module reply?): %s",
                 text.strip()[:160],
             )
+            return [], True
         return [], False
 
-    async def _nudge(self, fresh: list[dict]) -> bool:
+    async def _nudge(self, fresh: list[dict]):
         """Push ONE owner-facing Telegram nudge for the freshly-staged drafts.
-        Returns True ONLY on a confirmed DELIVERED result (submit_raw returns
-        FAILED/IGNORED/REJECTED without raising — those must not count)."""
+        Returns the delivery ``OutreachStatus`` (``None`` if there is no pipeline or
+        the send raised) so the caller can distinguish DELIVERED (mark), IGNORED
+        (quiet-hours defer — retry, not a failure), and FAILED/REJECTED (a
+        job-health failure)."""
+        from genesis.outreach.types import OutreachCategory, OutreachRequest, OutreachStatus
+
         pipeline = self._pipeline()
         if pipeline is None:
             logger.warning("career outreach: pipeline unavailable — cannot nudge")
-            return False
-        from genesis.outreach.types import OutreachCategory, OutreachRequest, OutreachStatus
+            return None
 
         n = len(fresh)
         lines = "\n".join(
@@ -405,13 +445,20 @@ class CareerOutreachMonitor:
             f"📇 Career outreach: {n} draft{plural} staged in your Drafts — "
             f"review + send:\n{lines}{more}"
         )
+        # A stable hash of the fresh company set in the topic — submit_raw dedups on
+        # (signal_type, topic, category) for 24h, so date+count alone would collapse
+        # two DISTINCT same-size batches on one day into one; the set-hash keeps them
+        # distinct while an identical same-day retry still dedups (idempotent resend).
+        set_hash = hashlib.sha256(
+            ",".join(sorted(a["company"].strip().lower() for a in fresh)).encode()
+        ).hexdigest()[:8]
         request = OutreachRequest(
             category=OutreachCategory.NOTIFICATION,
             channel="telegram",
-            # Date-stamped so distinct ticks are not deduped into one, while an
-            # identical same-day fresh-set (an undelivered retry within the day)
-            # dedups rather than double-sends.
-            topic=f"Career outreach: {n} staged draft(s) {datetime.now(UTC).strftime('%Y-%m-%d')}",
+            topic=(
+                f"Career outreach: {n} staged draft(s) "
+                f"{datetime.now(UTC).strftime('%Y-%m-%d')} {set_hash}"
+            ),
             context=text,
             signal_type="career_outreach_nudged",
             salience_score=0.85,
@@ -421,12 +468,10 @@ class CareerOutreachMonitor:
             result = await pipeline.submit_raw(text, request)
         except Exception:
             logger.error("career outreach: nudge failed", exc_info=True)
-            return False
-        if result is not None and result.status == OutreachStatus.DELIVERED:
+            return None
+        status = getattr(result, "status", None)
+        if status == OutreachStatus.DELIVERED:
             logger.info("career outreach: nudged %d staged draft(s)", n)
-            return True
-        logger.warning(
-            "career outreach: nudge not delivered (status=%s) — will retry",
-            getattr(result, "status", None),
-        )
-        return False
+        else:
+            logger.warning("career outreach: nudge not delivered (status=%s) — will retry", status)
+        return status

--- a/src/genesis/recon/career_outreach.py
+++ b/src/genesis/recon/career_outreach.py
@@ -1,0 +1,432 @@
+"""CareerOutreachMonitor — an ACTUATOR-in-recon that drives a dormant external
+career-agent engine to stage first-touch outreach drafts, then nudges the owner.
+
+Unlike its sibling ``AccountActivityMonitor`` (a sense-and-report monitor), this
+one *acts on the owner's behalf*: on a daily tick it dispatches to a configured
+external "reasoning" module (the install's own career-agent, declared in the
+``~/.genesis`` module overlay) to run that engine's auto-run-to-staged-draft for
+up to ``max_auto_runs_per_tick`` page-worthy accounts, then pushes ONE Telegram
+nudge listing the newly-staged drafts. It NEVER sends mail — the external engine
+stages drafts into the owner's mail Drafts and the owner clicks Send
+(draft-and-hold). The autonomous act is bounded to discover+draft (reversible);
+the standing ``live`` lever is the owner's authorization for that bounded loop.
+
+Design notes:
+- **SIBLING to ``AccountActivityMonitor``** — reuses the surplus-cron + lazy
+  ``GenesisRuntime`` resolution + ``observations`` content-hash dedup + Telegram
+  ``submit_raw`` push. But it PUSHES and ACTS, so it is doc'd as an actuator, not
+  the no-side-effect recon contract.
+- **Bridge is lazy-resolved at tick time** — surplus init runs before some deps;
+  the module registry + outreach pipeline are resolved via ``GenesisRuntime.
+  instance()`` when the first tick fires (a daily cron, hours after boot).
+- **``execute_operation`` returns an ERROR DICT — it does not raise.** A
+  disabled/unhealthy module, an IPC exception, or a dispatch timeout all come
+  back as ``{"error": ...}``. The tick inspects the return and surfaces
+  ``errors`` so the runner records a job-health FAILURE (a naive success would
+  lie on every failed dispatch).
+- **Health gate.** ``check_health_cached()`` (60s TTL) each tick; an unhealthy
+  module (remote box down) is a CLEAN skip, not a failure — an expected transient.
+- **Absent user-module → clean no-op.** On an install without the career-agent
+  overlay module, ``module_registry.get()`` returns ``None`` and the tick returns
+  silently (never a job-health failure on a generic install).
+- **State: nudge-dedup only.** The remote engine's ``radar_status`` is the source
+  of truth for which accounts have staged drafts; a ``career_outreach_nudged``
+  observation (content-hashed per company) records only "the owner has already
+  been nudged for this draft", so a re-tick does not re-nudge. Because the nudge
+  list is RE-DERIVED from the working set each tick minus this ledger, a
+  non-delivered nudge simply retries next tick.
+- **Modes** (``career_outreach_config``): ``off`` (default — inert) / ``observe``
+  (seed the nudged-set from the existing backlog, never dispatch a staging run or
+  nudge) / ``live`` (drive staging runs + nudge new drafts).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+import aiosqlite
+
+from genesis.db.crud import observations
+from genesis.recon import career_outreach_config as cfg
+
+logger = logging.getLogger(__name__)
+
+_SOURCE = "recon"
+_NUDGE_TYPE = "career_outreach_nudged"
+
+# The external reasoning module owns account selection, the per-day cap, drafting,
+# and staging; Genesis only drives the cadence + the owner nudge. Each dispatch
+# instructs the module to do exactly ONE account and reply with ONLY compact JSON
+# (its entire reply is the bridge return value — no prose reaches this side).
+_AUTORUN_PROMPT = (
+    "This is Genesis driving your outreach engine (a timed dispatch under the "
+    "bridge's hard cap). Pick your SINGLE top page-worthy account that is NOT yet "
+    "worked (radar_status watch/radar, not already 'working'), and run your "
+    "auto-run-to-staged-draft for it: eval-lite -> find-contact -> draft -> stage "
+    "the first-touch draft into the owner's mail Drafts, then promote it to "
+    "radar_status='working'. NEVER send. Do EXACTLY ONE account. Your ENTIRE reply "
+    "is the return value: reply with ONLY compact JSON, no prose — "
+    '{"company":"<name>","contact":"<email-or-name>","draft_summary":"<one line>"} '
+    'if you staged one, or {"none_left":true} if no page-worthy account remains, '
+    'or {"error":"<reason>"} if you could not.'
+)
+
+_LIST_WORKING_PROMPT = (
+    "This is Genesis. READ-ONLY: list the accounts currently at "
+    "radar_status='working' (a first-touch draft is already staged in the owner's "
+    "mail Drafts, awaiting the owner's send). Stage nothing, change nothing. Your "
+    "ENTIRE reply is the return value: reply with ONLY a compact JSON array, no "
+    'prose — [{"company":"<name>","contact":"<email-or-name>"}, ...] (empty array '
+    "[] if none)."
+)
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _nudge_hash(company: str) -> str:
+    """Content-hash namespace for the per-company 'owner already nudged' marker."""
+    return hashlib.sha256(f"career_nudged:{company.strip().lower()}".encode()).hexdigest()[:32]
+
+
+def _reply_text(result: object) -> str:
+    """The model's final message out of a dispatch return (the bridge payload)."""
+    if isinstance(result, dict):
+        return str(result.get("text") or result.get("output") or "")
+    return str(result or "")
+
+
+def _parse_json(text: str) -> object | None:
+    """Best-effort parse of a dispatch reply that should be compact JSON. Tolerates
+    a stray markdown fence or leading prose by falling back to the outermost
+    ``{...}`` / ``[...]`` span."""
+    text = (text or "").strip()
+    if not text:
+        return None
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text.lstrip().lower().startswith("json"):
+            text = text.lstrip()[4:]
+        text = text.strip()
+    try:
+        return json.loads(text)
+    except Exception:
+        pass
+    for open_c, close_c in (("{", "}"), ("[", "]")):
+        i, j = text.find(open_c), text.rfind(close_c)
+        if 0 <= i < j:
+            try:
+                return json.loads(text[i : j + 1])
+            except Exception:
+                continue
+    return None
+
+
+@dataclass(frozen=True)
+class CareerOutreachResult:
+    """Summary of one monitor tick."""
+
+    mode: str = "off"
+    health_ok: bool = True
+    auto_runs: int = 0  # dispatches that staged a fresh draft
+    drafts_working: int = 0  # accounts seen at radar_status='working'
+    nudged: int = 0  # newly-staged drafts included in a delivered nudge
+    seeded: int = 0  # observe: existing working accounts seeded into the ledger
+    errors: int = 0  # adapter-level dispatch failures (→ job-health FAILURE)
+    details: list[str] = field(default_factory=list)
+
+
+class CareerOutreachMonitor:
+    """Drives the external career-agent engine to stage drafts + nudges the owner.
+    See the module docstring."""
+
+    def __init__(self, db: aiosqlite.Connection) -> None:
+        self._db = db
+
+    # ── lazy runtime deps (module registry + outreach pipeline) ───────────
+    def _module_registry(self):
+        try:
+            from genesis.runtime._core import GenesisRuntime
+
+            rt = GenesisRuntime.instance()
+            return getattr(rt, "module_registry", None) or getattr(rt, "_module_registry", None)
+        except Exception:
+            logger.debug("career outreach: module registry not resolvable", exc_info=True)
+            return None
+
+    def _pipeline(self):
+        try:
+            from genesis.runtime._core import GenesisRuntime
+
+            return GenesisRuntime.instance().outreach_pipeline
+        except Exception:
+            logger.debug("career outreach: outreach pipeline not resolvable", exc_info=True)
+            return None
+
+    # ── main tick ─────────────────────────────────────────────────────────
+    async def gather(self) -> CareerOutreachResult:
+        mode = cfg.effective_mode()
+        if mode == "off":
+            return CareerOutreachResult(mode="off")
+
+        conf = cfg.load_config()
+        reg = self._module_registry()
+        if reg is None:
+            logger.debug("career outreach: module registry unavailable — skip")
+            return CareerOutreachResult(mode=mode)
+
+        reasoning_name = cfg.module_name(conf, "reasoning_module")
+        mod = reg.get(reasoning_name)
+        if mod is None:
+            # Absent user-module → clean no-op (a generic install lacks the
+            # overlay). NOT a job-health failure — this is expected off-install.
+            logger.debug("career outreach: module %r not loaded — no-op", reasoning_name)
+            return CareerOutreachResult(mode=mode)
+
+        try:
+            healthy = await mod.check_health_cached()
+        except Exception:
+            # A RAISE (vs a clean False) is unexpected — surface it as an error so a
+            # persistently-throwing health check records a job-health FAILURE rather
+            # than a silent clean skip.
+            logger.warning("career outreach: health check raised — skipping tick", exc_info=True)
+            return CareerOutreachResult(
+                mode=mode, health_ok=False, errors=1, details=["health check raised"]
+            )
+        if not healthy:
+            logger.info("career outreach: reasoning module unhealthy (remote down?) — clean skip")
+            return CareerOutreachResult(mode=mode, health_ok=False)
+
+        timeout = cfg.knob_int(conf, "dispatch_timeout_s")
+
+        if mode == "observe":
+            return await self._observe_seed(mod, timeout)
+        return await self._live(mod, conf, timeout)
+
+    async def _observe_seed(self, mod, timeout: int) -> CareerOutreachResult:
+        """Seed the nudged-ledger from the pre-existing working backlog so a later
+        flip to ``live`` does NOT nudge drafts that were staged before the monitor
+        existed. Never dispatches a staging run, never nudges."""
+        working, err = await self._list_working(mod, timeout)
+        if err:
+            return CareerOutreachResult(
+                mode="observe", errors=1, details=["observe: list-working dispatch error"]
+            )
+        seeded = 0
+        for acct in working:
+            company = (acct.get("company") or "").strip()
+            if not company:
+                continue
+            wrote = await observations.create(
+                self._db,
+                id=uuid.uuid4().hex,
+                source=_SOURCE,
+                type=_NUDGE_TYPE,
+                content=f"seed:{company}",
+                priority="low",
+                created_at=_now_z(),
+                content_hash=_nudge_hash(company),
+                skip_if_duplicate=True,
+            )
+            if wrote:
+                seeded += 1
+        return CareerOutreachResult(
+            mode="observe",
+            drafts_working=len(working),
+            seeded=seeded,
+            details=[f"observe: seeded {seeded} existing working account(s), no nudge"],
+        )
+
+    async def _live(self, mod, conf: dict, timeout: int) -> CareerOutreachResult:
+        cap = cfg.knob_int(conf, "max_auto_runs_per_tick")
+        auto_runs = 0
+        errors = 0
+        details: list[str] = []
+        adapter_error = False
+
+        # 1. Drive up to `cap` auto-run-to-staged-draft dispatches — the module
+        #    self-selects + self-caps (won't re-pick a 'working' one).
+        for _ in range(cap):
+            result = await mod.execute_operation(
+                "dispatch", {"prompt": _AUTORUN_PROMPT, "timeout_s": timeout}
+            )
+            # Adapter-level failure (disabled / unhealthy / IPC error / timeout)
+            # comes back as an error DICT — it does NOT raise. Surface it so the
+            # runner records a job-health FAILURE, and stop the loop.
+            if isinstance(result, dict) and result.get("error"):
+                errors += 1
+                adapter_error = True
+                details.append(f"auto-run dispatch error: {str(result.get('error'))[:120]}")
+                break
+            payload = _parse_json(_reply_text(result))
+            if not isinstance(payload, dict):
+                details.append("auto-run: unparseable reply — stopping")
+                break
+            if payload.get("none_left"):
+                details.append("auto-run: no page-worthy accounts left")
+                break
+            if payload.get("error"):
+                # Module-reported (not adapter) failure for this account — soft
+                # stop, not a job-health failure.
+                details.append(f"auto-run: module error: {str(payload.get('error'))[:120]}")
+                break
+            company = (payload.get("company") or "").strip()
+            if not company:
+                details.append("auto-run: reply missing 'company' — stopping")
+                break
+            auto_runs += 1
+            details.append(f"staged: {company}")
+
+        # 2. Nudge — RE-DERIVE the nudge list from the current working set minus the
+        #    already-nudged ledger (so an undelivered nudge simply retries next
+        #    tick). Skip if the box just errored (avoid a second doomed dispatch).
+        # GROUNDWORK(career-outreach-discovery): before the auto-run loop, drive any
+        # due discovery sweep here (scoped small, < the 300s cap) to widen the
+        # radar with net-new agentic-AI companies; deferred for the MVP, which
+        # runs against the existing radar backlog.
+        nudged = 0
+        drafts_working = 0
+        if not adapter_error:
+            working, err = await self._list_working(mod, timeout)
+            if err:
+                errors += 1
+                details.append("nudge: list-working dispatch error")
+            else:
+                drafts_working = len(working)
+                fresh = []
+                seen: set[str] = set()
+                for acct in working:
+                    company = (acct.get("company") or "").strip()
+                    if not company or company.lower() in seen:
+                        continue
+                    seen.add(company.lower())
+                    # unresolved_only=True honors the 30d TTL: resolve_expired sweeps the
+                    # marker at TTL, re-opening the gate so a still-unsent draft is gently
+                    # re-nudged (bounded dedup, matching the shipped 30d comment).
+                    if await observations.exists_by_hash(
+                        self._db,
+                        source=_SOURCE,
+                        content_hash=_nudge_hash(company),
+                        unresolved_only=True,
+                    ):
+                        continue
+                    fresh.append(
+                        {"company": company, "contact": (acct.get("contact") or "").strip()}
+                    )
+                # N=0 → NO nudge (never a "0 drafts staged" spam message).
+                if fresh:
+                    if await self._nudge(fresh):
+                        for acct in fresh:
+                            await observations.create(
+                                self._db,
+                                id=uuid.uuid4().hex,
+                                source=_SOURCE,
+                                type=_NUDGE_TYPE,
+                                content=f"nudged:{acct['company']}",
+                                priority="low",
+                                created_at=_now_z(),
+                                content_hash=_nudge_hash(acct["company"]),
+                                skip_if_duplicate=True,
+                            )
+                        nudged = len(fresh)
+                        details.append(f"nudged {nudged} new staged draft(s)")
+                    else:
+                        details.append(
+                            f"nudge not delivered — {len(fresh)} draft(s) retry next tick"
+                        )
+
+        return CareerOutreachResult(
+            mode="live",
+            auto_runs=auto_runs,
+            drafts_working=drafts_working,
+            nudged=nudged,
+            errors=errors,
+            details=details,
+        )
+
+    async def _list_working(self, mod, timeout: int) -> tuple[list[dict], bool]:
+        """Ask the reasoning module for the current ``radar_status='working'``
+        accounts (the source of truth for staged drafts). Returns ``(accounts,
+        err)`` where ``err`` is True on an adapter-level dispatch failure (the
+        caller surfaces it). A successful dispatch whose reply is not a JSON array
+        yields ``([], False)`` but is logged at WARNING — a persistently-malformed
+        reply must be diagnosable, not silently indistinguishable from "none"."""
+        # GROUNDWORK(career-outreach-http-read): this reads the working set via an SSH
+        # CC dispatch to the reasoning module (~100s, costs a turn). A future Career
+        # Agent HTTP op returning the radar working-set would be a cheaper/faster read
+        # path — reintroduce a `data_module` config knob pointing at it when it exists.
+        result = await mod.execute_operation(
+            "dispatch", {"prompt": _LIST_WORKING_PROMPT, "timeout_s": timeout}
+        )
+        if isinstance(result, dict) and result.get("error"):
+            logger.info(
+                "career outreach: list-working dispatch error: %s",
+                str(result.get("error"))[:120],
+            )
+            return [], True
+        text = _reply_text(result)
+        data = _parse_json(text)
+        if isinstance(data, list):
+            return [d for d in data if isinstance(d, dict)], False
+        # Not an adapter failure, but do not swallow a malformed reply silently —
+        # it would otherwise look identical to "no working accounts".
+        if text.strip():
+            logger.warning(
+                "career outreach: list-working reply was not a JSON array "
+                "(malformed module reply?): %s",
+                text.strip()[:160],
+            )
+        return [], False
+
+    async def _nudge(self, fresh: list[dict]) -> bool:
+        """Push ONE owner-facing Telegram nudge for the freshly-staged drafts.
+        Returns True ONLY on a confirmed DELIVERED result (submit_raw returns
+        FAILED/IGNORED/REJECTED without raising — those must not count)."""
+        pipeline = self._pipeline()
+        if pipeline is None:
+            logger.warning("career outreach: pipeline unavailable — cannot nudge")
+            return False
+        from genesis.outreach.types import OutreachCategory, OutreachRequest, OutreachStatus
+
+        n = len(fresh)
+        lines = "\n".join(
+            f"• {a['company']}" + (f" — {a['contact']}" if a.get("contact") else "")
+            for a in fresh[:20]
+        )
+        more = f"\n(+{n - 20} more)" if n > 20 else ""
+        plural = "s" if n != 1 else ""
+        text = (
+            f"📇 Career outreach: {n} draft{plural} staged in your Drafts — "
+            f"review + send:\n{lines}{more}"
+        )
+        request = OutreachRequest(
+            category=OutreachCategory.NOTIFICATION,
+            channel="telegram",
+            # Date-stamped so distinct ticks are not deduped into one, while an
+            # identical same-day fresh-set (an undelivered retry within the day)
+            # dedups rather than double-sends.
+            topic=f"Career outreach: {n} staged draft(s) {datetime.now(UTC).strftime('%Y-%m-%d')}",
+            context=text,
+            signal_type="career_outreach_nudged",
+            salience_score=0.85,
+            verbatim=True,
+        )
+        try:
+            result = await pipeline.submit_raw(text, request)
+        except Exception:
+            logger.error("career outreach: nudge failed", exc_info=True)
+            return False
+        if result is not None and result.status == OutreachStatus.DELIVERED:
+            logger.info("career outreach: nudged %d staged draft(s)", n)
+            return True
+        logger.warning(
+            "career outreach: nudge not delivered (status=%s) — will retry",
+            getattr(result, "status", None),
+        )
+        return False

--- a/src/genesis/recon/career_outreach_config.py
+++ b/src/genesis/recon/career_outreach_config.py
@@ -61,11 +61,12 @@ DEFAULTS: dict[str, Any] = {
     # owner's behalf — it stays inert until the owner deliberately opts in.
     "mode": "off",
     # Name of the external reasoning module (as declared in the install's ~/.genesis
-    # module overlay). An absent module → the monitor no-ops cleanly. Config knob,
-    # never a hardcoded literal elsewhere.
-    "reasoning_module": "Career Ops",  # SSH CC dispatch — runs the outreach modes
+    # module overlay). SHIPPED EMPTY so no install-specific module name lands in the
+    # public repo — set it in the gitignored career_outreach.local.yaml overlay.
+    # Empty (or an absent module) → the monitor no-ops cleanly.
+    "reasoning_module": "",
     # Per-tick cap on draft-staging auto-runs (bounds cost + mirrors the remote
-    # engine's own daily cap). Loud-truncation: excess page-worthy accounts wait
+    # engine's own daily cap). Loud-truncation: excess target accounts wait
     # for the next tick, never silently dropped.
     "max_auto_runs_per_tick": 3,
     # Per-dispatch bridge timeout, in seconds. MUST stay under the module's own
@@ -76,6 +77,11 @@ DEFAULTS: dict[str, Any] = {
 
 # Public: the settings-domain validator imports these to check knobs.
 INT_KNOBS = ("max_auto_runs_per_tick", "dispatch_timeout_s")
+
+# Key-specific upper bounds — a typo (e.g. max_auto_runs_per_tick: 3000) must not
+# authorize thousands of sequential draft-staging sessions, and dispatch_timeout_s
+# MUST stay under the module's 300s SSH CC hard cap so OUR timeout fires cleanly.
+_MAX_BY_KNOB: dict[str, int] = {"max_auto_runs_per_tick": 10, "dispatch_timeout_s": 290}
 
 
 def _base_path() -> Path:
@@ -130,11 +136,18 @@ def effective_mode() -> str:
 
 
 def knob_int(cfg: dict[str, Any], key: str) -> int:
-    """Positive-int knob with DEFAULTS fallback — config damage never zeroes a
-    limit or crashes the monitor."""
+    """Positive-int knob with DEFAULTS fallback + a key-specific upper bound —
+    config damage never zeroes a limit, crashes the monitor, or authorizes an
+    unbounded run."""
     value = cfg.get(key)
     if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
         return int(DEFAULTS[key])
+    cap = _MAX_BY_KNOB.get(key)
+    if cap is not None and value > cap:
+        logger.warning(
+            "career_outreach %s=%d exceeds the max (%d) — clamping down", key, value, cap
+        )
+        return cap
     return value
 
 

--- a/src/genesis/recon/career_outreach_config.py
+++ b/src/genesis/recon/career_outreach_config.py
@@ -123,7 +123,10 @@ def effective_mode() -> str:
     if os.environ.get(_ENV_KILL_SWITCH) == "1":
         return "off"
     cfg = load_config()
-    if not cfg.get("enabled", True):
+    # Master switch: require a LITERAL boolean True to stay enabled. A non-bool
+    # (e.g. the string "false" from env-templated YAML, or any corruption) degrades
+    # to off — the master actuator switch fails toward LESS authority.
+    if cfg.get("enabled", True) is not True:
         return "off"
     mode = cfg.get("mode")
     if mode is False:

--- a/src/genesis/recon/career_outreach_config.py
+++ b/src/genesis/recon/career_outreach_config.py
@@ -1,0 +1,146 @@
+"""Config lever for the career-outreach monitor (the "career outreach driver").
+
+Cloned from ``recon.github_steward_config``: fresh-read-per-call, ``MODES``
+tuple + env kill switch, degrade-toward-less-authority on damage.
+
+This monitor is an ACTUATOR-in-recon (not the no-side-effect sense-and-report
+recon contract): on a daily cadence it drives a configured external career-agent
+module (the install's own "hands", declared in ``~/.genesis/config/modules/``) to
+run job-outreach discovery and stage first-touch DRAFTS, then nudges the owner to
+review + send. It NEVER sends mail itself — the external module stages drafts into
+the owner's mail Drafts and the owner clicks Send (draft-and-hold). The autonomous
+act is bounded to discover+draft (reversible: a bad draft is deleted, not
+un-sent); the standing ``live`` lever IS the owner's authorization for that
+bounded loop.
+
+Modes (increasing authority):
+  - ``off``     — the monitor does not run. SHIPPED DEFAULT: an actuator does
+    nothing on a fresh install until the owner opts in.
+  - ``observe`` — resolve state + seed the already-nudged set, but NEVER dispatch
+    a draft-staging run and NEVER nudge. The seed step prevents a cold-start nudge
+    over a pre-existing draft backlog; the operator flips ``off → observe → live``.
+  - ``live``    — drive due discovery + up to ``max_auto_runs_per_tick``
+    draft-staging runs, then push ONE owner nudge when NEW drafts were staged.
+
+A missing/corrupt config degrades to DEFAULTS (mode ``off``); an invalid ``mode``
+value degrades to ``observe`` (record/seed safely, never a silent authority
+grant, never hide the feature entirely). Env kill switch
+``GENESIS_CAREER_OUTREACH_DISABLED=1`` forces ``off``.
+
+Generalizability: the career-agent modules are the install's own overlay
+modules — NO install-specific targeting data ships here. On an install without
+those modules the monitor no-ops cleanly (the module registry returns ``None``).
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+MODES = ("off", "observe", "live")
+
+_CONFIG_NAME = "career_outreach.yaml"
+
+_ENV_KILL_SWITCH = "GENESIS_CAREER_OUTREACH_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    # Shipped default: OFF. This monitor drives an external engine to act on the
+    # owner's behalf — it stays inert until the owner deliberately opts in.
+    "mode": "off",
+    # Name of the external reasoning module (as declared in the install's ~/.genesis
+    # module overlay). An absent module → the monitor no-ops cleanly. Config knob,
+    # never a hardcoded literal elsewhere.
+    "reasoning_module": "Career Ops",  # SSH CC dispatch — runs the outreach modes
+    # Per-tick cap on draft-staging auto-runs (bounds cost + mirrors the remote
+    # engine's own daily cap). Loud-truncation: excess page-worthy accounts wait
+    # for the next tick, never silently dropped.
+    "max_auto_runs_per_tick": 3,
+    # Per-dispatch bridge timeout, in seconds. MUST stay under the module's own
+    # SSH CC hard cap (300s) so a slow run is our timeout, cleanly, not the SSH
+    # adapter's opaque one.
+    "dispatch_timeout_s": 240,
+}
+
+# Public: the settings-domain validator imports these to check knobs.
+INT_KNOBS = ("max_auto_runs_per_tick", "dispatch_timeout_s")
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or corrupt
+    files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("career_outreach base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("career_outreach overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def effective_mode() -> str:
+    """The mode the monitor runs under — read live.
+
+    Env kill switch → ``off``. Master ``enabled: false`` → ``off``. An invalid
+    value degrades to ``observe`` (record/seed safely, never act, never a silent
+    ``off`` that hides the feature).
+    """
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return "off"
+    cfg = load_config()
+    if not cfg.get("enabled", True):
+        return "off"
+    mode = cfg.get("mode")
+    if mode is False:
+        # Hand-edited unquoted `mode: off` parses as YAML-1.1 boolean False.
+        return "off"
+    if mode not in MODES:
+        logger.warning("career_outreach has invalid mode %r — degrading to observe", mode)
+        return "observe"
+    return mode
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never zeroes a
+    limit or crashes the monitor."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value
+
+
+def module_name(cfg: dict[str, Any], key: str) -> str:
+    """A module-name knob, damage-tolerant (non-str / blank → DEFAULTS)."""
+    value = cfg.get(key)
+    if isinstance(value, str) and value.strip():
+        return value
+    return str(DEFAULTS[key])

--- a/src/genesis/runtime/init/surplus.py
+++ b/src/genesis/runtime/init/surplus.py
@@ -144,6 +144,22 @@ async def init(rt: GenesisRuntime) -> None:
             await _degraded(rt, "AccountActivityMonitor")
 
         try:
+            # Career-outreach monitor (daily actuator — drives the external
+            # career-agent engine to stage drafts + nudge the owner). No pipeline
+            # or module registry injected here — both are lazy-resolved at tick
+            # time. No-ops cleanly on installs without the career-agent module.
+            from genesis.recon.career_outreach import CareerOutreachMonitor
+            career_monitor = CareerOutreachMonitor(db=rt._db)
+            rt._surplus_scheduler.set_career_outreach_monitor(career_monitor)
+            logger.info("CareerOutreachMonitor wired to surplus scheduler")
+        except (ImportError, AttributeError):
+            logger.error("Failed to wire CareerOutreachMonitor", exc_info=True)
+            await _degraded(rt, "CareerOutreachMonitor")
+        except Exception:
+            logger.error("Unexpected error wiring CareerOutreachMonitor", exc_info=True)
+            await _degraded(rt, "CareerOutreachMonitor")
+
+        try:
             from genesis.recon.model_intelligence import ModelIntelligenceJob
             mi_job = ModelIntelligenceJob(
                 db=rt._db,

--- a/src/genesis/surplus/jobs/runners.py
+++ b/src/genesis/surplus/jobs/runners.py
@@ -119,6 +119,58 @@ async def run_account_activity_monitor(sched: SchedulerContext) -> None:
         record_failure("account_activity_monitor", str(exc))
 
 
+async def run_career_outreach_monitor(sched: SchedulerContext) -> None:
+    """Drive the external career-agent engine to stage outreach drafts; nudge owner."""
+    if sched._career_outreach_monitor is None:
+        record_failure("career_outreach_monitor", "monitor not wired")
+        return
+    try:
+        from genesis.runtime import GenesisRuntime
+
+        if GenesisRuntime.instance().paused:
+            logger.debug("Career outreach monitor skipped (Genesis paused)")
+            return
+    except Exception:
+        pass
+    try:
+        result = await sched._career_outreach_monitor.gather()
+        if result.mode != "off" and (
+            result.auto_runs or result.nudged or result.seeded or result.errors
+        ):
+            logger.info(
+                "Career outreach: mode=%s auto_runs=%d working=%d nudged=%d "
+                "seeded=%d errors=%d",
+                result.mode, result.auto_runs, result.drafts_working,
+                result.nudged, result.seeded, result.errors,
+            )
+        if sched._event_bus:
+            await sched._event_bus.emit(
+                Subsystem.RECON, Severity.DEBUG,
+                "heartbeat", "career_outreach_monitor completed",
+            )
+        # An adapter-level dispatch failure is surfaced as result.errors (NOT an
+        # exception — execute_operation returns an error dict), so a bare
+        # record_success would lie on every failed dispatch. Record failure when
+        # a dispatch errored; an unhealthy remote (health_ok=False, errors=0) is a
+        # clean skip and records success.
+        if result.errors:
+            record_failure(
+                "career_outreach_monitor", "; ".join(result.details) or "dispatch error"
+            )
+        else:
+            record_success("career_outreach_monitor")
+    except Exception as exc:
+        logger.exception("Career outreach monitor failed")
+        if sched._event_bus:
+            await sched._event_bus.emit(
+                Subsystem.RECON, Severity.ERROR,
+                "career_outreach_monitor.failed",
+                "Career outreach monitor failed with exception",
+                **failure_details(exc=exc),
+            )
+        record_failure("career_outreach_monitor", str(exc))
+
+
 async def run_model_intelligence(sched: SchedulerContext) -> None:
     """Run model intelligence scan (weekly)."""
     if sched._model_intelligence_job is None:

--- a/src/genesis/surplus/jobs/runners.py
+++ b/src/genesis/surplus/jobs/runners.py
@@ -134,9 +134,12 @@ async def run_career_outreach_monitor(sched: SchedulerContext) -> None:
         pass
     try:
         result = await sched._career_outreach_monitor.gather()
-        if result.mode != "off" and (
-            result.auto_runs or result.nudged or result.seeded or result.errors
-        ):
+        if result.mode == "off":
+            # Disabled-by-config: record NOTHING (neither success nor failure) so the
+            # actuator stays invisible in job-health on installs that never enabled it
+            # (surplus convention — cf. _guard.SKIP).
+            return
+        if result.auto_runs or result.nudged or result.seeded or result.errors:
             logger.info(
                 "Career outreach: mode=%s auto_runs=%d working=%d nudged=%d "
                 "seeded=%d errors=%d",

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -120,6 +120,7 @@ class SurplusScheduler:
         self._executors: dict[TaskType, SurplusExecutor] = {}
         self._recon_gatherer: ReconGatherer | None = None
         self._account_activity_monitor: AccountActivityMonitor | None = None
+        self._career_outreach_monitor = None  # Set via set_career_outreach_monitor()
         self._model_intelligence_job = None  # Set via set_model_intelligence_job()
         self._models_md_synthesis_job = None  # Set via set_models_md_synthesis_job()
         self._skill_security_scan_job = None  # Set via set_skill_security_scan_job()
@@ -213,6 +214,10 @@ class SurplusScheduler:
     def set_account_activity_monitor(self, monitor: AccountActivityMonitor) -> None:
         """Set the GitHub account-activity monitor (2h external-activity poll)."""
         self._account_activity_monitor = monitor
+
+    def set_career_outreach_monitor(self, monitor) -> None:
+        """Set the career-outreach monitor (daily draft-staging driver + nudge)."""
+        self._career_outreach_monitor = monitor
 
     def set_model_intelligence_job(self, job) -> None:
         """Set the ModelIntelligenceJob for scheduled model landscape scanning."""
@@ -317,6 +322,18 @@ class SurplusScheduler:
             self.run_account_activity_monitor,
             CronTrigger(hour="*/2", timezone=user_timezone()),
             id="account_activity_monitor",
+            max_instances=1,
+            misfire_grace_time=3600,
+        )
+        # Career-outreach monitor: daily at 08:00 local. ACTUATOR — drives the
+        # external career-agent engine to stage first-touch outreach drafts, then
+        # nudges the owner. ONE job (max_instances=1 is per-job; a second job would
+        # race on the single remote engine). Ships OFF (career_outreach_config).
+        # CronTrigger, never IntervalTrigger (which resets on restart).
+        self._scheduler.add_job(
+            self.run_career_outreach_monitor,
+            CronTrigger(hour=8, timezone=user_timezone()),
+            id="career_outreach_monitor",
             max_instances=1,
             misfire_grace_time=3600,
         )
@@ -740,6 +757,10 @@ class SurplusScheduler:
     async def run_account_activity_monitor(self) -> None:
         """Poll owner repos for external GitHub activity (every 2h)."""
         await runner_jobs.run_account_activity_monitor(self)
+
+    async def run_career_outreach_monitor(self) -> None:
+        """Drive the career-agent engine to stage outreach drafts (daily)."""
+        await runner_jobs.run_career_outreach_monitor(self)
 
     async def run_model_intelligence(self) -> None:
         """Run model intelligence scan (weekly)."""

--- a/tests/test_recon/test_career_outreach.py
+++ b/tests/test_recon/test_career_outreach.py
@@ -1,0 +1,435 @@
+"""Tests for the career-outreach monitor: config lever + obs-type governance.
+
+The lever is an actuator gate (off/observe/live) that ships OFF; these tests lock
+the degrade-toward-less-authority behavior and the architect's obs-governance
+requirement (a new obs-type must be registered in BOTH governance sets).
+"""
+
+from __future__ import annotations
+
+import json
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from genesis.db.crud import observations
+from genesis.outreach.types import OutreachResult, OutreachStatus
+from genesis.recon import career_outreach_config as cfg
+from genesis.recon.career_outreach import (
+    CareerOutreachMonitor,
+    CareerOutreachResult,
+    _nudge_hash,
+)
+
+
+def _write(tmp_path, text):
+    p = tmp_path / "cfg.yaml"  # non-canonical stem → no real .local.yaml overlay
+    p.write_text(text)
+    return p
+
+
+def test_ships_off_by_default(monkeypatch, tmp_path):
+    # No config file at all → DEFAULTS → off (actuator inert on a fresh install).
+    monkeypatch.delenv(cfg._ENV_KILL_SWITCH, raising=False)
+    monkeypatch.setattr(cfg, "_base_path", lambda: tmp_path / "absent.yaml")
+    assert cfg.effective_mode() == "off"
+
+
+def test_default_config_ships_off():
+    # The DEFAULTS themselves ship off (belt-and-suspenders on the shipped value).
+    assert cfg.DEFAULTS["mode"] == "off"
+
+
+def test_env_kill_switch_forces_off(monkeypatch, tmp_path):
+    p = _write(tmp_path, "enabled: true\nmode: live\n")
+    monkeypatch.setattr(cfg, "_base_path", lambda: p)
+    monkeypatch.setenv(cfg._ENV_KILL_SWITCH, "1")
+    assert cfg.effective_mode() == "off"
+
+
+def test_enabled_false_forces_off(monkeypatch, tmp_path):
+    p = _write(tmp_path, "enabled: false\nmode: live\n")
+    monkeypatch.setattr(cfg, "_base_path", lambda: p)
+    monkeypatch.delenv(cfg._ENV_KILL_SWITCH, raising=False)
+    assert cfg.effective_mode() == "off"
+
+
+def test_observe_and_live_pass_through(monkeypatch, tmp_path):
+    monkeypatch.delenv(cfg._ENV_KILL_SWITCH, raising=False)
+    for mode in ("observe", "live"):
+        p = _write(tmp_path, f"enabled: true\nmode: {mode}\n")
+        monkeypatch.setattr(cfg, "_base_path", lambda p=p: p)
+        assert cfg.effective_mode() == mode
+
+
+def test_invalid_mode_degrades_to_observe(monkeypatch, tmp_path):
+    # Invalid → observe (seed/record safely; never a silent off that hides the
+    # feature, never an unattended live).
+    p = _write(tmp_path, "enabled: true\nmode: bogus\n")
+    monkeypatch.setattr(cfg, "_base_path", lambda: p)
+    monkeypatch.delenv(cfg._ENV_KILL_SWITCH, raising=False)
+    assert cfg.effective_mode() == "observe"
+
+
+def test_yaml_off_boolean_parses_as_off(monkeypatch, tmp_path):
+    # Hand-edited unquoted `mode: off` → YAML-1.1 boolean False → off, not observe.
+    p = _write(tmp_path, "enabled: true\nmode: off\n")
+    monkeypatch.setattr(cfg, "_base_path", lambda: p)
+    monkeypatch.delenv(cfg._ENV_KILL_SWITCH, raising=False)
+    assert cfg.effective_mode() == "off"
+
+
+def test_knob_int_damage_tolerant():
+    d = cfg.DEFAULTS
+    assert cfg.knob_int({"max_auto_runs_per_tick": 5}, "max_auto_runs_per_tick") == 5
+    for bad in (0, -3, True, "x", None):
+        assert (
+            cfg.knob_int({"max_auto_runs_per_tick": bad}, "max_auto_runs_per_tick")
+            == d["max_auto_runs_per_tick"]
+        )
+    assert cfg.knob_int({}, "dispatch_timeout_s") == d["dispatch_timeout_s"]
+
+
+def test_module_name_damage_tolerant():
+    d = cfg.DEFAULTS
+    assert cfg.module_name({"reasoning_module": "My Ops"}, "reasoning_module") == "My Ops"
+    assert cfg.module_name({"reasoning_module": "  "}, "reasoning_module") == d["reasoning_module"]
+    assert cfg.module_name({"reasoning_module": 42}, "reasoning_module") == d["reasoning_module"]
+    assert cfg.module_name({}, "reasoning_module") == d["reasoning_module"]
+
+
+def test_dispatch_timeout_under_ssh_cap():
+    # Must stay under the module's SSH CC hard cap (300s) so OUR timeout fires
+    # cleanly rather than the adapter's opaque one.
+    assert cfg.DEFAULTS["dispatch_timeout_s"] < 300
+
+
+def test_nudge_obs_type_registered_in_both_governance_sets():
+    # Architect concern #3: unregistered in INTERNAL_OBS_TYPES → leaks to user
+    # surfacers; unregistered in _TTL_BY_TYPE → unknown-type warning every write.
+    from genesis.db.crud.observations import _TTL_BY_TYPE, INTERNAL_OBS_TYPES
+
+    assert "career_outreach_nudged" in INTERNAL_OBS_TYPES
+    assert "career_outreach_nudged" in _TTL_BY_TYPE
+
+
+# ── monitor tick tests (against a real in-memory observations store) ────────
+
+
+@pytest_asyncio.fixture
+async def db():
+    from genesis.db.schema import create_all_tables
+
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    try:
+        yield conn
+    finally:
+        await conn.close()
+
+
+class _FakePipeline:
+    def __init__(self, status: OutreachStatus = OutreachStatus.DELIVERED) -> None:
+        self.sent: list = []
+        self.status = status
+
+    async def submit_raw(self, text, request):
+        self.sent.append((text, request))
+        return OutreachResult(
+            outreach_id="fake", status=self.status, channel="telegram", message_content=text
+        )
+
+
+class _FakeModule:
+    """Implements the real module contract the monitor drives: check_health_cached
+    + execute_operation returning DICTS (the bridge never raises). Distinguishes
+    the read-only list-working dispatch from an auto-run by the prompt text."""
+
+    def __init__(
+        self, *, healthy=True, autoruns=None, working=None, autorun_error=None, working_error=False
+    ) -> None:
+        self._healthy = healthy
+        self._autoruns = list(autoruns or [])
+        self._working = list(working or [])
+        self._autorun_error = autorun_error
+        self._working_error = working_error
+        self.calls: list[str] = []
+
+    async def check_health_cached(self) -> bool:
+        return self._healthy
+
+    async def execute_operation(self, op, params):
+        prompt = (params or {}).get("prompt", "")
+        self.calls.append(prompt)
+        if "READ-ONLY: list" in prompt:
+            if self._working_error:
+                return {"error": "ssh down"}
+            return {"text": json.dumps(self._working)}
+        # auto-run dispatch
+        if self._autorun_error is not None:
+            return {"error": self._autorun_error}
+        if self._autoruns:
+            return {"text": json.dumps(self._autoruns.pop(0))}
+        return {"text": json.dumps({"none_left": True})}
+
+
+class _FakeRegistry:
+    def __init__(self, module):
+        self._module = module
+
+    def get(self, name):
+        return self._module
+
+
+def _autorun_calls(mod: _FakeModule) -> int:
+    return sum(1 for c in mod.calls if "READ-ONLY: list" not in c)
+
+
+def _cfg(monkeypatch, *, mode, cap=3):
+    monkeypatch.setattr(cfg, "effective_mode", lambda: mode)
+    monkeypatch.setattr(
+        cfg,
+        "load_config",
+        lambda: {
+            "reasoning_module": "Career Ops",
+            "data_module": "Career Agent",
+            "max_auto_runs_per_tick": cap,
+            "dispatch_timeout_s": 240,
+        },
+    )
+
+
+def _mon(db, module=None, *, pipe_status=OutreachStatus.DELIVERED, registry_none=False):
+    mon = CareerOutreachMonitor(db)
+    pipe = _FakePipeline(pipe_status)
+    mon._pipeline = lambda: pipe
+    mon._module_registry = (lambda: None) if registry_none else (lambda: _FakeRegistry(module))
+    return mon, pipe
+
+
+@pytest.mark.asyncio
+async def test_off_mode_returns_immediately(db, monkeypatch):
+    _cfg(monkeypatch, mode="off")
+    mod = _FakeModule()
+    mon, pipe = _mon(db, mod)
+    result = await mon.gather()
+    assert result.mode == "off"
+    assert mod.calls == [] and pipe.sent == []
+
+
+@pytest.mark.asyncio
+async def test_absent_module_is_clean_noop_no_error(db, monkeypatch):
+    # Architect concern #5: a generic install lacking the overlay module must
+    # no-op cleanly — NOT a job-health failure (errors stays 0).
+    _cfg(monkeypatch, mode="live")
+    mon, pipe = _mon(db, None)  # registry.get() → None
+    result = await mon.gather()
+    assert result.mode == "live"
+    assert result.errors == 0 and result.auto_runs == 0 and pipe.sent == []
+
+
+@pytest.mark.asyncio
+async def test_registry_unavailable_is_clean_noop(db, monkeypatch):
+    _cfg(monkeypatch, mode="live")
+    mon, pipe = _mon(db, _FakeModule(), registry_none=True)
+    result = await mon.gather()
+    assert result.mode == "live" and result.errors == 0 and pipe.sent == []
+
+
+@pytest.mark.asyncio
+async def test_unhealthy_module_clean_skip_no_dispatch(db, monkeypatch):
+    # Architect concern #2: remote down → clean skip (health_ok False, errors 0),
+    # and NO dispatch is attempted.
+    _cfg(monkeypatch, mode="live")
+    mod = _FakeModule(healthy=False)
+    mon, pipe = _mon(db, mod)
+    result = await mon.gather()
+    assert result.health_ok is False and result.errors == 0
+    assert mod.calls == [] and pipe.sent == []
+
+
+@pytest.mark.asyncio
+async def test_execute_operation_error_dict_surfaces_error(db, monkeypatch):
+    # Architect concern #1: execute_operation returns an ERROR DICT (no raise) —
+    # the tick must surface it as errors>0 (→ runner records job-health failure),
+    # not silently succeed, and must not proceed to a second doomed dispatch.
+    _cfg(monkeypatch, mode="live")
+    mod = _FakeModule(autorun_error="SSH CC dispatch timed out after 240s")
+    mon, pipe = _mon(db, mod)
+    result = await mon.gather()
+    assert result.errors >= 1 and result.auto_runs == 0
+    assert _autorun_calls(mod) == 1  # broke the loop; did not keep dispatching
+    assert pipe.sent == []  # adapter error → skip the nudge derivation
+
+
+@pytest.mark.asyncio
+async def test_n_zero_no_nudge(db, monkeypatch):
+    # No page-worthy accounts and no working drafts → NO "0 drafts" spam nudge.
+    _cfg(monkeypatch, mode="live")
+    mod = _FakeModule(autoruns=[], working=[])
+    mon, pipe = _mon(db, mod)
+    result = await mon.gather()
+    assert result.nudged == 0 and pipe.sent == []
+
+
+@pytest.mark.asyncio
+async def test_observe_seeds_but_does_not_nudge(db, monkeypatch):
+    _cfg(monkeypatch, mode="observe")
+    mod = _FakeModule(working=[{"company": "Acme"}, {"company": "Globex"}])
+    mon, pipe = _mon(db, mod)
+    result = await mon.gather()
+    assert result.mode == "observe" and result.seeded == 2
+    assert pipe.sent == []  # observe never nudges
+    # Both seeded into the dedup ledger.
+    for co in ("Acme", "Globex"):
+        assert await observations.exists_by_hash(db, source="recon", content_hash=_nudge_hash(co))
+
+
+@pytest.mark.asyncio
+async def test_live_nudges_only_new_drafts(db, monkeypatch):
+    # Pre-seed one already-nudged account; live must nudge ONLY the new one.
+    await observations.create(
+        db,
+        id="seed1",
+        source="recon",
+        type="career_outreach_nudged",
+        content="seed:Acme",
+        priority="low",
+        created_at="2026-08-10T00:00:00Z",
+        content_hash=_nudge_hash("Acme"),
+        skip_if_duplicate=True,
+    )
+    _cfg(monkeypatch, mode="live")
+    mod = _FakeModule(
+        autoruns=[{"company": "Globex", "contact": "eng@globex.dev", "draft_summary": "x"}],
+        working=[
+            {"company": "Acme", "contact": "a@acme.dev"},
+            {"company": "Globex", "contact": "eng@globex.dev"},
+        ],
+    )
+    mon, pipe = _mon(db, mod)
+    result = await mon.gather()
+    assert result.auto_runs == 1 and result.nudged == 1
+    assert len(pipe.sent) == 1
+    body = pipe.sent[0][0]
+    assert "Globex" in body and "Acme" not in body
+    # Globex now marked; Acme still marked (unchanged).
+    assert await observations.exists_by_hash(db, source="recon", content_hash=_nudge_hash("Globex"))
+
+
+@pytest.mark.asyncio
+async def test_cap_respected(db, monkeypatch):
+    _cfg(monkeypatch, mode="live", cap=2)
+    mod = _FakeModule(
+        autoruns=[
+            {"company": "A", "contact": "a", "draft_summary": "s"},
+            {"company": "B", "contact": "b", "draft_summary": "s"},
+            {"company": "C", "contact": "c", "draft_summary": "s"},  # would be a 3rd
+        ],
+        working=[],
+    )
+    mon, _ = _mon(db, mod)
+    result = await mon.gather()
+    assert result.auto_runs == 2
+    assert _autorun_calls(mod) == 2  # stopped at the cap, never dispatched the 3rd
+
+
+@pytest.mark.asyncio
+async def test_undelivered_nudge_not_marked_retries(db, monkeypatch):
+    # Undelivered nudge → account NOT marked, so it re-derives + retries next tick.
+    _cfg(monkeypatch, mode="live")
+    mod = _FakeModule(autoruns=[], working=[{"company": "Zeta", "contact": "z@zeta.dev"}])
+    mon, pipe = _mon(db, mod, pipe_status=OutreachStatus.FAILED)
+    result = await mon.gather()
+    assert result.nudged == 0 and len(pipe.sent) == 1  # attempted, not delivered
+    assert not await observations.exists_by_hash(
+        db, source="recon", content_hash=_nudge_hash("Zeta")
+    )
+
+
+@pytest.mark.asyncio
+async def test_nudge_gate_reopens_after_marker_resolved(db, monkeypatch):
+    # unresolved_only=True: a nudged marker blocks re-nudge while unresolved; after
+    # resolve_expired resolves it at TTL, the gate re-opens so a still-working draft
+    # is gently re-nudged (bounded dedup, not permanent).
+    _cfg(monkeypatch, mode="live")
+    mod = _FakeModule(autoruns=[], working=[{"company": "Zeta", "contact": "z@zeta.dev"}])
+    mon, pipe = _mon(db, mod)
+    await observations.create(
+        db,
+        id="z1",
+        source="recon",
+        type="career_outreach_nudged",
+        content="nudged:Zeta",
+        priority="low",
+        created_at="2026-08-10T00:00:00Z",
+        content_hash=_nudge_hash("Zeta"),
+        skip_if_duplicate=True,
+    )
+    r1 = await mon.gather()
+    assert r1.nudged == 0 and pipe.sent == []  # blocked while unresolved
+    await db.execute(
+        "UPDATE observations SET resolved = 1 WHERE content_hash = ?", (_nudge_hash("Zeta"),)
+    )
+    await db.commit()
+    r2 = await mon.gather()
+    assert r2.nudged == 1 and len(pipe.sent) == 1  # gate re-opened → re-nudged
+
+
+@pytest.mark.asyncio
+async def test_health_check_raise_records_error(db, monkeypatch):
+    # NOTE #5: a RAISED health check (vs clean False) surfaces errors>0 so a
+    # persistently-throwing probe records a job-health FAILURE, not a silent skip.
+    _cfg(monkeypatch, mode="live")
+
+    class _RaisingModule(_FakeModule):
+        async def check_health_cached(self):
+            raise RuntimeError("probe boom")
+
+    mon, pipe = _mon(db, _RaisingModule())
+    result = await mon.gather()
+    assert result.health_ok is False and result.errors == 1 and pipe.sent == []
+
+
+@pytest.mark.asyncio
+async def test_runner_records_failure_on_dispatch_errors(monkeypatch):
+    # Architect concern #1 end-to-end: result.errors → runner records FAILURE.
+    from genesis.surplus.jobs import runners
+
+    calls = {"fail": [], "success": []}
+    monkeypatch.setattr(runners, "record_failure", lambda k, m=None: calls["fail"].append((k, m)))
+    monkeypatch.setattr(runners, "record_success", lambda k: calls["success"].append(k))
+
+    class _StubMon:
+        async def gather(self):
+            return CareerOutreachResult(mode="live", errors=1, details=["adapter boom"])
+
+    class _Sched:
+        _career_outreach_monitor = _StubMon()
+        _event_bus = None
+
+    await runners.run_career_outreach_monitor(_Sched())
+    assert calls["fail"] and calls["fail"][0][0] == "career_outreach_monitor"
+    assert not calls["success"]
+
+
+@pytest.mark.asyncio
+async def test_runner_records_success_on_clean_tick(monkeypatch):
+    from genesis.surplus.jobs import runners
+
+    calls = {"fail": [], "success": []}
+    monkeypatch.setattr(runners, "record_failure", lambda k, m=None: calls["fail"].append((k, m)))
+    monkeypatch.setattr(runners, "record_success", lambda k: calls["success"].append(k))
+
+    class _StubMon:
+        async def gather(self):
+            return CareerOutreachResult(mode="live", auto_runs=1, nudged=1)
+
+    class _Sched:
+        _career_outreach_monitor = _StubMon()
+        _event_bus = None
+
+    await runners.run_career_outreach_monitor(_Sched())
+    assert calls["success"] == ["career_outreach_monitor"] and not calls["fail"]

--- a/tests/test_recon/test_career_outreach.py
+++ b/tests/test_recon/test_career_outreach.py
@@ -91,6 +91,14 @@ def test_knob_int_damage_tolerant():
     assert cfg.knob_int({}, "dispatch_timeout_s") == d["dispatch_timeout_s"]
 
 
+def test_knob_int_enforces_upper_bounds():
+    # A typo must not authorize an unbounded run; dispatch_timeout_s must stay under
+    # the 300s SSH cap.
+    assert cfg.knob_int({"dispatch_timeout_s": 2400}, "dispatch_timeout_s") == 290
+    assert cfg.knob_int({"max_auto_runs_per_tick": 3000}, "max_auto_runs_per_tick") == 10
+    assert cfg.knob_int({"dispatch_timeout_s": 120}, "dispatch_timeout_s") == 120  # under cap
+
+
 def test_module_name_damage_tolerant():
     d = cfg.DEFAULTS
     assert cfg.module_name({"reasoning_module": "My Ops"}, "reasoning_module") == "My Ops"
@@ -148,13 +156,23 @@ class _FakeModule:
     the read-only list-working dispatch from an auto-run by the prompt text."""
 
     def __init__(
-        self, *, healthy=True, autoruns=None, working=None, autorun_error=None, working_error=False
+        self,
+        *,
+        healthy=True,
+        autoruns=None,
+        working=None,
+        autorun_error=None,
+        working_error=False,
+        working_malformed=False,
+        autorun_payload_error=None,
     ) -> None:
         self._healthy = healthy
         self._autoruns = list(autoruns or [])
         self._working = list(working or [])
-        self._autorun_error = autorun_error
-        self._working_error = working_error
+        self._autorun_error = autorun_error  # adapter-level {"error"} for auto-run
+        self._working_error = working_error  # adapter-level {"error"} for list
+        self._working_malformed = working_malformed  # non-JSON-array list reply
+        self._autorun_payload_error = autorun_payload_error  # module-reported {"error"}
         self.calls: list[str] = []
 
     async def check_health_cached(self) -> bool:
@@ -166,10 +184,14 @@ class _FakeModule:
         if "READ-ONLY: list" in prompt:
             if self._working_error:
                 return {"error": "ssh down"}
+            if self._working_malformed:
+                return {"text": "sorry, I could not list them"}
             return {"text": json.dumps(self._working)}
         # auto-run dispatch
         if self._autorun_error is not None:
             return {"error": self._autorun_error}
+        if self._autorun_payload_error is not None:
+            return {"text": json.dumps({"error": self._autorun_payload_error})}
         if self._autoruns:
             return {"text": json.dumps(self._autoruns.pop(0))}
         return {"text": json.dumps({"none_left": True})}
@@ -193,8 +215,7 @@ def _cfg(monkeypatch, *, mode, cap=3):
         cfg,
         "load_config",
         lambda: {
-            "reasoning_module": "Career Ops",
-            "data_module": "Career Agent",
+            "reasoning_module": "test-module",
             "max_auto_runs_per_tick": cap,
             "dispatch_timeout_s": 240,
         },
@@ -266,7 +287,7 @@ async def test_execute_operation_error_dict_surfaces_error(db, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_n_zero_no_nudge(db, monkeypatch):
-    # No page-worthy accounts and no working drafts → NO "0 drafts" spam nudge.
+    # No target accounts and no staged drafts → NO "0 drafts" spam nudge.
     _cfg(monkeypatch, mode="live")
     mod = _FakeModule(autoruns=[], working=[])
     mon, pipe = _mon(db, mod)
@@ -344,6 +365,7 @@ async def test_undelivered_nudge_not_marked_retries(db, monkeypatch):
     mon, pipe = _mon(db, mod, pipe_status=OutreachStatus.FAILED)
     result = await mon.gather()
     assert result.nudged == 0 and len(pipe.sent) == 1  # attempted, not delivered
+    assert result.errors >= 1  # FAILED delivery counts as a job-health failure (B5)
     assert not await observations.exists_by_hash(
         db, source="recon", content_hash=_nudge_hash("Zeta")
     )
@@ -413,6 +435,127 @@ async def test_runner_records_failure_on_dispatch_errors(monkeypatch):
     await runners.run_career_outreach_monitor(_Sched())
     assert calls["fail"] and calls["fail"][0][0] == "career_outreach_monitor"
     assert not calls["success"]
+
+
+@pytest.mark.asyncio
+async def test_runner_skips_health_record_when_off(monkeypatch):
+    # Codex P2: mode="off" records NEITHER success nor failure — a disabled install
+    # stays invisible in job-health (surplus convention).
+    from genesis.surplus.jobs import runners
+
+    calls = {"fail": [], "success": []}
+    monkeypatch.setattr(runners, "record_failure", lambda k, m=None: calls["fail"].append(k))
+    monkeypatch.setattr(runners, "record_success", lambda k: calls["success"].append(k))
+
+    class _StubMon:
+        async def gather(self):
+            return CareerOutreachResult(mode="off")
+
+    class _Sched:
+        _career_outreach_monitor = _StubMon()
+        _event_bus = None
+
+    await runners.run_career_outreach_monitor(_Sched())
+    assert not calls["fail"] and not calls["success"]
+
+
+@pytest.mark.asyncio
+async def test_pause_midtick_halts_dispatches_and_nudge(db, monkeypatch):
+    # Codex P1: an owner /pause mid-tick stops the remaining dispatches AND the nudge.
+    _cfg(monkeypatch, mode="live", cap=3)
+    mod = _FakeModule(
+        autoruns=[
+            {"company": "A", "contact": "a", "draft_summary": "s"},
+            {"company": "B", "contact": "b", "draft_summary": "s"},
+        ],
+        working=[{"company": "A", "contact": "a"}],
+    )
+    mon, pipe = _mon(db, mod)
+    state = {"n": 0}
+
+    def paused():
+        state["n"] += 1
+        return state["n"] > 1  # first check False (1 dispatch), then True
+
+    mon._is_paused = paused
+    result = await mon.gather()
+    assert result.auto_runs == 1 and _autorun_calls(mod) == 1  # 2nd auto-run blocked
+    assert result.nudged == 0 and pipe.sent == []  # nudge skipped while paused
+
+
+@pytest.mark.asyncio
+async def test_malformed_list_reply_is_error_observe_and_live(db, monkeypatch):
+    # Codex P2: a NON-EMPTY, non-JSON-array list reply is a protocol violation →
+    # errors≥1 (not a silent empty set that would make observe seed nothing, then
+    # live blast the whole backlog).
+    _cfg(monkeypatch, mode="observe")
+    mon, _ = _mon(db, _FakeModule(working_malformed=True))
+    r_obs = await mon.gather()
+    assert r_obs.errors == 1 and r_obs.seeded == 0
+
+    _cfg(monkeypatch, mode="live")
+    mon2, pipe2 = _mon(db, _FakeModule(autoruns=[], working_malformed=True))
+    r_live = await mon2.gather()
+    assert r_live.errors >= 1 and pipe2.sent == []
+
+
+@pytest.mark.asyncio
+async def test_module_reported_error_counts_as_failure(db, monkeypatch):
+    # Codex P2: a module-reported {"error"} in the auto-run payload increments errors
+    # so a persistent module error surfaces as a job-health failure.
+    _cfg(monkeypatch, mode="live")
+    mon, _ = _mon(db, _FakeModule(autorun_payload_error="auth failed", working=[]))
+    result = await mon.gather()
+    assert result.errors >= 1
+
+
+@pytest.mark.asyncio
+async def test_ignored_nudge_is_not_an_error(db, monkeypatch):
+    # Codex P2: a quiet-hours IGNORED nudge is an EXPECTED defer — NOT a failure —
+    # and is not marked (retries next tick).
+    _cfg(monkeypatch, mode="live")
+    mod = _FakeModule(autoruns=[], working=[{"company": "Zeta", "contact": "z@zeta.dev"}])
+    mon, pipe = _mon(db, mod, pipe_status=OutreachStatus.IGNORED)
+    result = await mon.gather()
+    assert result.errors == 0 and result.nudged == 0 and len(pipe.sent) == 1
+    assert not await observations.exists_by_hash(
+        db, source="recon", content_hash=_nudge_hash("Zeta")
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_pipeline_nudge_counts_as_failure(db, monkeypatch):
+    # Codex P2: no pipeline → the nudge cannot be delivered → a job-health failure.
+    _cfg(monkeypatch, mode="live")
+    mod = _FakeModule(autoruns=[], working=[{"company": "Zeta", "contact": "z@zeta.dev"}])
+    mon, _ = _mon(db, mod)
+    mon._pipeline = lambda: None
+    result = await mon.gather()
+    assert result.errors >= 1 and result.nudged == 0
+
+
+@pytest.mark.asyncio
+async def test_nudge_topic_distinguishes_distinct_sets(db):
+    # Codex P2: distinct same-size same-day fresh sets get distinct topics (a stable
+    # set-hash), so submit_raw's 24h (signal_type, topic, category) dedup does not
+    # collapse two genuinely different batches into one.
+    mon = CareerOutreachMonitor(db)
+    sent = []
+
+    class _CapturePipe:
+        async def submit_raw(self, text, request):
+            sent.append(request)
+            return OutreachResult(
+                outreach_id="x",
+                status=OutreachStatus.DELIVERED,
+                channel="telegram",
+                message_content=text,
+            )
+
+    mon._pipeline = lambda: _CapturePipe()
+    await mon._nudge([{"company": "Acme", "contact": ""}])
+    await mon._nudge([{"company": "Globex", "contact": ""}])
+    assert sent[0].topic != sent[1].topic
 
 
 @pytest.mark.asyncio

--- a/tests/test_recon/test_career_outreach.py
+++ b/tests/test_recon/test_career_outreach.py
@@ -164,7 +164,9 @@ class _FakeModule:
         autorun_error=None,
         working_error=False,
         working_malformed=False,
+        working_empty_text=False,
         autorun_payload_error=None,
+        autorun_malformed=False,
     ) -> None:
         self._healthy = healthy
         self._autoruns = list(autoruns or [])
@@ -172,7 +174,9 @@ class _FakeModule:
         self._autorun_error = autorun_error  # adapter-level {"error"} for auto-run
         self._working_error = working_error  # adapter-level {"error"} for list
         self._working_malformed = working_malformed  # non-JSON-array list reply
+        self._working_empty_text = working_empty_text  # empty-text list reply
         self._autorun_payload_error = autorun_payload_error  # module-reported {"error"}
+        self._autorun_malformed = autorun_malformed  # unparseable auto-run reply
         self.calls: list[str] = []
 
     async def check_health_cached(self) -> bool:
@@ -186,12 +190,16 @@ class _FakeModule:
                 return {"error": "ssh down"}
             if self._working_malformed:
                 return {"text": "sorry, I could not list them"}
+            if self._working_empty_text:
+                return {"text": ""}
             return {"text": json.dumps(self._working)}
         # auto-run dispatch
         if self._autorun_error is not None:
             return {"error": self._autorun_error}
         if self._autorun_payload_error is not None:
             return {"text": json.dumps({"error": self._autorun_payload_error})}
+        if self._autorun_malformed:
+            return {"text": "sorry, I could not do that"}
         if self._autoruns:
             return {"text": json.dumps(self._autoruns.pop(0))}
         return {"text": json.dumps({"none_left": True})}
@@ -481,6 +489,8 @@ async def test_pause_midtick_halts_dispatches_and_nudge(db, monkeypatch):
     result = await mon.gather()
     assert result.auto_runs == 1 and _autorun_calls(mod) == 1  # 2nd auto-run blocked
     assert result.nudged == 0 and pipe.sent == []  # nudge skipped while paused
+    # Codex r3 P1: the intervening list-staged read (another dispatch) is ALSO skipped.
+    assert not any("READ-ONLY: list" in c for c in mod.calls)
 
 
 @pytest.mark.asyncio
@@ -510,12 +520,13 @@ async def test_module_reported_error_counts_as_failure(db, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_ignored_nudge_is_not_an_error(db, monkeypatch):
-    # Codex P2: a quiet-hours IGNORED nudge is an EXPECTED defer — NOT a failure —
-    # and is not marked (retries next tick).
+async def test_rejected_nudge_is_not_an_error(db, monkeypatch):
+    # Codex r3 P2: submit_raw skips quiet-hours governance so IGNORED never occurs; a
+    # REJECTED nudge is pipeline dedup (the owner already got an identical one) — NOT a
+    # failure, and not re-marked (a harmless re-derive next tick).
     _cfg(monkeypatch, mode="live")
     mod = _FakeModule(autoruns=[], working=[{"company": "Zeta", "contact": "z@zeta.dev"}])
-    mon, pipe = _mon(db, mod, pipe_status=OutreachStatus.IGNORED)
+    mon, pipe = _mon(db, mod, pipe_status=OutreachStatus.REJECTED)
     result = await mon.gather()
     assert result.errors == 0 and result.nudged == 0 and len(pipe.sent) == 1
     assert not await observations.exists_by_hash(
@@ -556,6 +567,69 @@ async def test_nudge_topic_distinguishes_distinct_sets(db):
     await mon._nudge([{"company": "Acme", "contact": ""}])
     await mon._nudge([{"company": "Globex", "contact": ""}])
     assert sent[0].topic != sent[1].topic
+
+
+@pytest.mark.asyncio
+async def test_unparseable_autorun_reply_counts_as_failure(db, monkeypatch):
+    # Codex r3 P2: an unparseable auto-run reply is a protocol failure → errors≥1
+    # (this also surfaces an injection-refusal reply as a job-health failure).
+    _cfg(monkeypatch, mode="live")
+    mon, _ = _mon(db, _FakeModule(autorun_malformed=True, working=[]))
+    result = await mon.gather()
+    assert result.errors >= 1 and result.auto_runs == 0
+
+
+@pytest.mark.asyncio
+async def test_autorun_missing_company_counts_as_failure(db, monkeypatch):
+    # Codex r3 P2: an auto-run reply missing 'company' is a protocol failure → errors≥1.
+    _cfg(monkeypatch, mode="live")
+    mon, _ = _mon(db, _FakeModule(autoruns=[{"draft_summary": "x"}], working=[]))
+    result = await mon.gather()
+    assert result.errors >= 1 and result.auto_runs == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_text_list_reply_is_error(db, monkeypatch):
+    # Codex r3 P2: an empty-TEXT list reply (not "[]") is a protocol violation → error,
+    # so observe never silently under-seeds (which would make live over-nudge).
+    _cfg(monkeypatch, mode="observe")
+    mon, _ = _mon(db, _FakeModule(working_empty_text=True))
+    result = await mon.gather()
+    assert result.errors == 1 and result.seeded == 0
+
+
+@pytest.mark.asyncio
+async def test_list_with_no_company_entries_is_error(db, monkeypatch):
+    # Codex r3 P2: a non-empty list whose entries lack 'company' is malformed → error.
+    _cfg(monkeypatch, mode="observe")
+    mon, _ = _mon(db, _FakeModule(working=[{"draft_summary": "x"}]))
+    result = await mon.gather()
+    assert result.errors == 1 and result.seeded == 0
+
+
+@pytest.mark.asyncio
+async def test_valid_empty_array_list_is_not_error(db, monkeypatch):
+    # A valid empty array "[]" = genuinely no staged drafts, NOT an error.
+    _cfg(monkeypatch, mode="observe")
+    mon, _ = _mon(db, _FakeModule(working=[]))
+    result = await mon.gather()
+    assert result.errors == 0 and result.seeded == 0
+
+
+def test_enabled_string_false_degrades_to_off(monkeypatch, tmp_path):
+    # Codex r3 P2: a string "false" (env-templated YAML) is truthy in Python — the
+    # master switch requires a literal bool and degrades a non-bool to off.
+    p = _write(tmp_path, 'enabled: "false"\nmode: live\n')
+    monkeypatch.setattr(cfg, "_base_path", lambda: p)
+    monkeypatch.delenv(cfg._ENV_KILL_SWITCH, raising=False)
+    assert cfg.effective_mode() == "off"
+
+
+def test_enabled_nonbool_int_degrades_to_off(monkeypatch, tmp_path):
+    p = _write(tmp_path, "enabled: 1\nmode: live\n")  # truthy int, not literal True
+    monkeypatch.setattr(cfg, "_base_path", lambda: p)
+    monkeypatch.delenv(cfg._ENV_KILL_SWITCH, raising=False)
+    assert cfg.effective_mode() == "off"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

A daily surplus-cron **actuator** (`CareerOutreachMonitor`) that, once enabled, drives a configured external career-agent module (SSH bridge) to stage first-touch outreach drafts into the owner's mail Drafts, then pushes **one** Telegram nudge to review + send. It **never sends mail itself** — the module stages drafts, the owner clicks Send (draft-and-hold). Ships **off**.

Part of the C3 "career cold-outreach engine": this is the Genesis-side heartbeat that drives an already-built, dormant remote engine (wire-and-drive, not build).

## Design

- **Lever:** `career_outreach_config` `off`/`observe`/`live` + `GENESIS_CAREER_OUTREACH_DISABLED`. `observe` seeds the nudge-dedup ledger silently before the first `live` nudge (so flipping on doesn't blast the pre-existing backlog).
- **Bridge:** lazy-resolved at tick; `execute_operation` returns an error **dict** (never raises) → surfaced as a job-health failure (a naive `record_success` would lie); `check_health_cached` gates; **absent-module → clean no-op** (generic installs never alarm).
- **One daily cron** (`max_instances=1` is per-job; a second would race the single remote engine).
- **Nudge-dedup:** a registered `career_outreach_nudged` observation (in **both** governance sets); `unresolved_only` gate honors the 30d TTL re-open; N=0 → no nudge; undelivered → retries next tick.
- Discovery-sweep driving is `GROUNDWORK`-deferred (existing radar backlog is the seed).

## Review

genesis-architect design review + adversarial implementation audit — **every runtime-resolve verified against the real definitions** (`submit_raw`, all `OutreachRequest` fields, `observations.create`/`exists_by_hash`, the runtime properties, both governance sets), so no ship-green-explode-live bug. 2 SHOULD-FIX fixed (TTL/dedup asymmetry; dead `data_module` knob), NOTEs dispositioned. Read path live-probed against the real module (clean JSON). **25** targeted tests; **373** across recon/db/learning/outreach; ruff clean.

## Deploy

Runtime code — `git pull` + server restart. Ships **off**; no behavior until the owner opts in. Retention = the obs 30d TTL via the existing expiry sweep.

Advances C3 (ledger `74f38fb556864acf8947e0ca2e083255`) — monitor built; live E2E + activation still pending, so this PR does not close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)