### PR TITLE
feat(memory): MW-2 lean keystone — coarse relationship classifier + edge-metadata stamping columns

### DIFF
--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -427,6 +427,21 @@ call_sites:
     - mistral-large-free
     - openrouter-gemma4
     retry_profile: background
+  # MW-2 relationship classifier — coarse relationship judgment
+  # (duplicate/contradicts/succeeded_by/distinct) between candidate memory pairs.
+  # Same free-SLM shape / task class as dream_cycle_entity_check; batched, on demand
+  # (MW-2 measurement probe now; MW-5 merge-gate nominees later). §6.2 model tier is
+  # the dial — start on the proven entity-check chain.
+  dream_cycle_relationship_classify:
+    chain:
+    - nvidia-nim-kimi
+    - groq-free
+    - mistral-small-free
+    - openrouter-free
+    - gemini-free
+    - mistral-large-free
+    - openrouter-gemma4
+    retry_profile: background
   # Adversarial challenge of entity "duplicate" verdicts. Flipped pairing:
   # DeepSeek challenges Kimi's entity judgments.
   dream_cycle_entity_challenge:

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -36,7 +36,7 @@ side.
 ```yaml subsystem-map
 entry: memory
 modules: [memory, qdrant]
-verified: 7706dc2f 2026-08-05
+verified: ef6eb541 2026-08-10
 ```
 
 **Cross-store integrity is detect + repair.** SQLite (`memory_metadata`/
@@ -170,6 +170,28 @@ synthesis→original provenance `extends` edge (ordinary `extends` from
 column stamped at merge (the synthesis's `created_at` is unreliable —
 `store()`'s exact-dedup can return an old pre-existing memory); non-dream
 deprecations leave `deprecated_at` NULL and are never pruned.
+
+**Relationship classifier (MW-2 lean keystone)** —
+`memory/relationship_classifier.py`: coarse relationship judgment
+(`duplicate`/`contradicts`/`succeeded_by`/`distinct` + confidence) between two
+candidate memories, generalizing `entity_resolution.check_semantic_overlap`
+(call site `dream_cycle_relationship_classify`, free-SLM chain, fail-safe
+`distinct@0.0`). This is the function MW-5's merge gate consumes on ≥0.95
+nominees; NOTHING calls it in the runtime yet (probe:
+`scripts/dev/mw2_classifier_probe.py`, read-only vs a DB copy). Migration 0082
+added five NULLable stamping columns to `memory_links` (`proposed_type`,
+`confidence`, `classifier`, `review_state`, `safe_for_boost`) — NULL
+`safe_for_boost` = boost-eligible (legacy default), no backfill, CHECK/PK
+unchanged. Measured 2026-08-10 (n=300 real ≥0.75 edges): 76.7% distinct /
+16.7% duplicate / 5.3% succeeded_by / 1.3% contradicts; `duplicate` ~80%
+hand-scored accurate, `contradicts` OVER-CALLED (bug↔fix pairs) — so MW-5 must
+challenge contradicts verdicts adversarially before acting, and the deferred
+MW-2b machinery (candidate_similar type + CHECK rebuild + write-path change +
+boost gating) is evidence-parked, not planned. The similarity linkers
+(`linker.py` auto_link 0.90/0.75, `connection_pass.py` 0.80) still write
+`extends`/`supports`/`related_to` — types recall ranking never reads
+(`neighbors_of` is strength-only; type matters only via the `contradicts`
+deny-list).
 
 **Do not touch:** the drain's shadow hardwiring; the dry_run-independent link
 write. **Trap:** with no embedding provider registered, memory silently

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -182,9 +182,10 @@ nominees; NOTHING calls it in the runtime yet (probe:
 added five NULLable stamping columns to `memory_links` (`proposed_type`,
 `confidence`, `classifier`, `review_state`, `safe_for_boost`) — NULL
 `safe_for_boost` = boost-eligible (legacy default), no backfill, CHECK/PK
-unchanged. Measured 2026-08-10 (n=300 real ≥0.75 edges): 76.7% distinct /
-16.7% duplicate / 5.3% succeeded_by / 1.3% contradicts; `duplicate` ~80%
-hand-scored accurate, `contradicts` OVER-CALLED (bug↔fix pairs) — so MW-5 must
+unchanged. Measured 2026-08-11 (n=300 real similarity edges, strength window
+[0.75, 1.0), 0 fail-safes): 73.0% distinct / 16.7% duplicate / 8.7%
+succeeded_by / 1.7% contradicts; `duplicate` ~80% hand-scored accurate,
+`contradicts` OVER-CALLED (bug↔fix pairs) — so MW-5 must
 challenge contradicts verdicts adversarially before acting, and the deferred
 MW-2b machinery (candidate_similar type + CHECK rebuild + write-path change +
 boost gating) is evidence-parked, not planned. The similarity linkers

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -182,10 +182,13 @@ nominees; NOTHING calls it in the runtime yet (probe:
 added five NULLable stamping columns to `memory_links` (`proposed_type`,
 `confidence`, `classifier`, `review_state`, `safe_for_boost`) — NULL
 `safe_for_boost` = boost-eligible (legacy default), no backfill, CHECK/PK
-unchanged. Measured 2026-08-11 (n=300 real similarity edges, strength window
-[0.75, 1.0), 0 fail-safes): 73.0% distinct / 16.7% duplicate / 8.7%
-succeeded_by / 1.7% contradicts; `duplicate` ~80% hand-scored accurate,
-`contradicts` OVER-CALLED (bug↔fix pairs) — so MW-5 must
+unchanged. Measured 2026-08-11 (n=300 sampled from the FULL ~197k-pair
+similarity population — strength ≥0.75, synthesis-provenance excluded by
+source marker, unordered-pair-deduped, boost-visibility-filtered, 0
+fail-safes): 73.2% distinct / 16.4% duplicate / 10.0% succeeded_by / 0.4%
+contradicts; ~17% of sampled edges had recall-hidden endpoints. `duplicate`
+~80% hand-scored accurate, `contradicts` OVER-CALLED (bug↔fix pairs) — so
+MW-5 must
 challenge contradicts verdicts adversarially before acting, and the deferred
 MW-2b machinery (candidate_similar type + CHECK rebuild + write-path change +
 boost gating) is evidence-parked, not planned. The similarity linkers

--- a/scripts/dev/mw2_classifier_probe.py
+++ b/scripts/dev/mw2_classifier_probe.py
@@ -38,9 +38,10 @@ SNAP = Path.home() / "tmp" / "mw2_probe_snapshot.db"
 OUT_DIR = Path.home() / ".genesis" / "output"
 
 # auto_link writes extends/supports; connection_pass writes related_to. These are
-# the similarity-derived (>=0.75) population MW-2 is about. (Not perfectly isolable
-# from extraction's strength=0.7 or synthesis's strength=1.0 edges — we report the
-# strength spread so the mix is visible.)
+# the similarity-derived (>=0.75) population MW-2 is about. The SELECT's strength
+# window [0.75, 1.0) excludes extraction-emitted typed links (exactly 0.7) and
+# synthesis provenance edges (exactly 1.0); the report's strength spread makes
+# the sampled window visible.
 _SIMILARITY_TYPES = ("extends", "supports", "related_to")
 
 
@@ -82,9 +83,14 @@ async def run(n: int, batch: int, seed: int) -> int:
     db.row_factory = aiosqlite.Row
     try:
         # Deterministic sample: seed sqlite's RANDOM via a stable ORDER key.
+        # Strength window isolates the SIMILARITY population (Codex P1):
+        # extraction-emitted typed links are strength=0.7 exactly and synthesis
+        # provenance edges are 1.0 exactly; auto_link writes cosine >=0.75 and
+        # connection_pass >=0.80, both strictly <1.0 in practice.
         rows = await db.execute_fetchall(
             "SELECT source_id, target_id, link_type, strength FROM memory_links "  # noqa: S608 - placeholders bound
             f"WHERE link_type IN ({','.join('?' * len(_SIMILARITY_TYPES))}) "
+            "AND strength >= 0.75 AND strength < 1.0 "
             "ORDER BY substr(source_id || target_id, 1, 12), source_id "
             "LIMIT ?",
             (*_SIMILARITY_TYPES, max(n * 3, n)),
@@ -107,7 +113,11 @@ async def run(n: int, batch: int, seed: int) -> int:
             return 2
 
         ids = sorted({r[0] for r in rows} | {r[1] for r in rows})
-        hydrated = await memory_crud.hydrate_for_expansion(db, ids)
+        # Chunk to stay under SQLite's 999-bind ceiling at large --n (Codex P2);
+        # hydrate_for_expansion itself builds ONE IN-clause.
+        hydrated: dict[str, dict] = {}
+        for off in range(0, len(ids), 400):
+            hydrated.update(await memory_crud.hydrate_for_expansion(db, ids[off : off + 400]))
 
         pairs: list[tuple[str, str]] = []
         meta: list[dict] = []
@@ -149,11 +159,18 @@ async def run(n: int, batch: int, seed: int) -> int:
             )
 
         # ── tally ──────────────────────────────────────────────────────────
-        dist = Counter(v["relationship"] for v in verdicts)
-        total = len(verdicts)
+        # Fail-safes (LLM/parse failure, out-of-vocab) are NOT verdicts — counting
+        # them as "distinct" would silently deflate the unsafe fraction (Codex P1).
+        classified = [v for v in verdicts if not v.get("failed")]
+        failsafe_count = len(verdicts) - len(classified)
+        dist = Counter(v["relationship"] for v in classified)
+        total = len(classified)
+        if not total:
+            print("Every classification failed — no distribution to report.", file=sys.stderr)
+            return 2
         unsafe = dist["contradicts"] + dist["succeeded_by"] + dist["duplicate"]
         conf_by_rel: dict[str, list[float]] = {r: [] for r in COARSE_RELATIONSHIPS}
-        for v in verdicts:
+        for v in classified:
             conf_by_rel[v["relationship"]].append(v["confidence"])
         strengths = [m["strength"] for m in meta]
 
@@ -165,6 +182,7 @@ async def run(n: int, batch: int, seed: int) -> int:
             "snapshot": str(SNAP),
             "sampled_edges": len(rows),
             "classified_pairs": total,
+            "failsafe_unclassified": failsafe_count,
             "stored_type_mix": dict(Counter(m["stored_link_type"] for m in meta)),
             "strength_spread": {
                 "min": round(min(strengths), 3),
@@ -210,10 +228,17 @@ async def run(n: int, batch: int, seed: int) -> int:
         await db.close()
 
 
+def _positive_int(value: str) -> int:
+    n = int(value)
+    if n <= 0:
+        raise argparse.ArgumentTypeError(f"must be a positive integer, got {n}")
+    return n
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--n", type=int, default=300, help="edges to sample")
-    ap.add_argument("--batch", type=int, default=15, help="pairs per LLM call")
+    ap.add_argument("--n", type=_positive_int, default=300, help="edges to sample")
+    ap.add_argument("--batch", type=_positive_int, default=15, help="pairs per LLM call")
     ap.add_argument("--seed", type=int, default=7)
     args = ap.parse_args()
     return asyncio.run(run(args.n, args.batch, args.seed))

--- a/scripts/dev/mw2_classifier_probe.py
+++ b/scripts/dev/mw2_classifier_probe.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""MW-2 Checkpoint A — relationship-classifier quality measurement probe.
+
+Samples real stored ``memory_links`` edges (auto_link / connection_pass's
+similarity-derived >=0.75 population), runs the COARSE relationship classifier
+via the REAL ``slm`` provider, and reports:
+
+  1. **Classifier quality** — a hand-scorable sample dump (content_a, content_b,
+     verdict, confidence) so a human can eyeball accuracy on real pairs. This is
+     the DISPROVEN-IF gate: coarse accuracy <~70% → stop / escalate model tier.
+  2. **Unsafe-edge fraction** — the verdict distribution over the stored
+     similarity graph: what share is genuinely unsafe (contradicts / succeeded_by
+     / duplicate) vs benign (distinct). This is the evidence that decides whether
+     MW-2b (stored-graph reclassification + boost-gating) is worth building at all.
+
+READ-ONLY: snapshots the live DB to ~/tmp via the sqlite online-backup API and
+runs entirely against the copy. Nothing in production is mutated. The router's
+cost tracker writes to the copy.
+
+Usage:
+  python scripts/dev/mw2_classifier_probe.py [--n 300] [--batch 15] [--seed 7]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sqlite3
+import sys
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+
+LIVE_DB = Path.home() / "genesis" / "data" / "genesis.db"
+SNAP = Path.home() / "tmp" / "mw2_probe_snapshot.db"
+OUT_DIR = Path.home() / ".genesis" / "output"
+
+# auto_link writes extends/supports; connection_pass writes related_to. These are
+# the similarity-derived (>=0.75) population MW-2 is about. (Not perfectly isolable
+# from extraction's strength=0.7 or synthesis's strength=1.0 edges — we report the
+# strength spread so the mix is visible.)
+_SIMILARITY_TYPES = ("extends", "supports", "related_to")
+
+
+def snapshot_live_db() -> None:
+    """WAL-safe online backup of the live DB → ~/tmp copy (read source, never write it)."""
+    SNAP.parent.mkdir(parents=True, exist_ok=True)
+    if SNAP.exists():
+        SNAP.unlink()
+    src = sqlite3.connect(f"file:{LIVE_DB}?mode=ro", uri=True)
+    dst = sqlite3.connect(str(SNAP))
+    try:
+        with dst:
+            src.backup(dst)
+    finally:
+        src.close()
+        dst.close()
+
+
+async def run(n: int, batch: int, seed: int) -> int:
+    snapshot_live_db()
+
+    import aiosqlite
+
+    from genesis.db.crud import memory as memory_crud
+    from genesis.memory.relationship_classifier import (
+        COARSE_RELATIONSHIPS,
+        classify_relationships,
+    )
+    from genesis.routing.circuit_breaker import CircuitBreakerRegistry
+    from genesis.routing.config import load_config
+    from genesis.routing.cost_tracker import CostTracker
+    from genesis.routing.degradation import DegradationTracker
+    from genesis.routing.litellm_delegate import LiteLLMDelegate
+    from genesis.routing.router import Router
+
+    db = await aiosqlite.connect(str(SNAP))
+    # The runtime sets this; the router's cost-tracker (budgets.list_active does
+    # dict(row)) requires it, and hydrate_for_expansion's index access still works.
+    db.row_factory = aiosqlite.Row
+    try:
+        # Deterministic sample: seed sqlite's RANDOM via a stable ORDER key.
+        rows = await db.execute_fetchall(
+            "SELECT source_id, target_id, link_type, strength FROM memory_links "  # noqa: S608 - placeholders bound
+            f"WHERE link_type IN ({','.join('?' * len(_SIMILARITY_TYPES))}) "
+            "ORDER BY substr(source_id || target_id, 1, 12), source_id "
+            "LIMIT ?",
+            (*_SIMILARITY_TYPES, max(n * 3, n)),
+        )
+        rows = list(rows)
+        # Stable pseudo-shuffle by seed, then take n (avoids RANDOM() nondeterminism).
+        rows.sort(key=lambda r: hash((seed, r[0], r[1])) & 0xFFFFFFFF)
+        rows = rows[:n]
+        if not rows:
+            print("No similarity edges found — nothing to probe.", file=sys.stderr)
+            return 2
+
+        ids = sorted({r[0] for r in rows} | {r[1] for r in rows})
+        hydrated = await memory_crud.hydrate_for_expansion(db, ids)
+
+        pairs: list[tuple[str, str]] = []
+        meta: list[dict] = []
+        for src_id, tgt_id, ltype, strength in rows:
+            ca = (hydrated.get(src_id) or {}).get("content")
+            cb = (hydrated.get(tgt_id) or {}).get("content")
+            if ca and cb:
+                pairs.append((ca, cb))
+                meta.append(
+                    {
+                        "source_id": src_id,
+                        "target_id": tgt_id,
+                        "stored_link_type": ltype,
+                        "strength": strength,
+                    }
+                )
+
+        if not pairs:
+            print("Edges sampled but no content hydrated — aborting.", file=sys.stderr)
+            return 2
+
+        # Real router (wing_backfill pattern) — keys from inherited env.
+        config_path = Path(__file__).resolve().parents[2] / "config" / "model_routing.yaml"
+        config = load_config(config_path)
+        router = Router(
+            config=config,
+            breakers=CircuitBreakerRegistry(config.providers),
+            cost_tracker=CostTracker(db=db),
+            degradation=DegradationTracker(),
+            delegate=LiteLLMDelegate(config),
+        )
+
+        verdicts: list[dict] = []
+        for i in range(0, len(pairs), batch):
+            chunk = pairs[i : i + batch]
+            verdicts.extend(await classify_relationships(router, chunk))
+            print(
+                f"  classified {min(i + batch, len(pairs))}/{len(pairs)} pairs...", file=sys.stderr
+            )
+
+        # ── tally ──────────────────────────────────────────────────────────
+        dist = Counter(v["relationship"] for v in verdicts)
+        total = len(verdicts)
+        unsafe = dist["contradicts"] + dist["succeeded_by"] + dist["duplicate"]
+        conf_by_rel: dict[str, list[float]] = {r: [] for r in COARSE_RELATIONSHIPS}
+        for v in verdicts:
+            conf_by_rel[v["relationship"]].append(v["confidence"])
+        strengths = [m["strength"] for m in meta]
+
+        def _mean(xs):
+            return round(sum(xs) / len(xs), 3) if xs else 0.0
+
+        report = {
+            "generated_at": datetime.now(UTC).isoformat(),
+            "snapshot": str(SNAP),
+            "sampled_edges": len(rows),
+            "classified_pairs": total,
+            "stored_type_mix": dict(Counter(m["stored_link_type"] for m in meta)),
+            "strength_spread": {
+                "min": round(min(strengths), 3),
+                "max": round(max(strengths), 3),
+                "mean": _mean(strengths),
+            },
+            "verdict_distribution": {r: dist[r] for r in sorted(dist)},
+            "verdict_pct": {r: round(100 * dist[r] / total, 1) for r in sorted(dist)},
+            "unsafe_fraction_pct": round(100 * unsafe / total, 1),
+            "mean_confidence_by_verdict": {r: _mean(conf_by_rel[r]) for r in COARSE_RELATIONSHIPS},
+        }
+
+        # ── hand-scorable sample (all unsafe verdicts + a slice of distinct) ──
+        sample = []
+        distinct_shown = 0
+        for (ca, cb), v, m in zip(pairs, verdicts, meta, strict=True):
+            is_unsafe = v["relationship"] != "distinct"
+            if is_unsafe or distinct_shown < 8:
+                if not is_unsafe:
+                    distinct_shown += 1
+                sample.append(
+                    {
+                        "verdict": v["relationship"],
+                        "confidence": v["confidence"],
+                        "reasoning": v.get("reasoning", ""),
+                        "stored_link_type": m["stored_link_type"],
+                        "strength": m["strength"],
+                        "content_a": ca[:400],
+                        "content_b": cb[:400],
+                    }
+                )
+
+        OUT_DIR.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+        report_path = OUT_DIR / f"mw2_classifier_probe_{stamp}.json"
+        report_path.write_text(json.dumps({"report": report, "sample": sample}, indent=2))
+
+        print("\n===== MW-2 CHECKPOINT A — classifier probe =====")
+        print(json.dumps(report, indent=2))
+        print(f"\nHand-scorable sample ({len(sample)} pairs) + full report → {report_path}")
+        return 0
+    finally:
+        await db.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=300, help="edges to sample")
+    ap.add_argument("--batch", type=int, default=15, help="pairs per LLM call")
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args()
+    return asyncio.run(run(args.n, args.batch, args.seed))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/mw2_classifier_probe.py
+++ b/scripts/dev/mw2_classifier_probe.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import sqlite3
 import sys
@@ -89,8 +90,17 @@ async def run(n: int, batch: int, seed: int) -> int:
             (*_SIMILARITY_TYPES, max(n * 3, n)),
         )
         rows = list(rows)
-        # Stable pseudo-shuffle by seed, then take n (avoids RANDOM() nondeterminism).
-        rows.sort(key=lambda r: hash((seed, r[0], r[1])) & 0xFFFFFFFF)
+
+        # Stable pseudo-shuffle by seed, then take n. Uses md5 (not builtin
+        # hash(): PEP-456 salts str hashing per process, which would make the
+        # same --seed draw a DIFFERENT sample every run — review finding).
+        def _stable_key(r) -> int:
+            digest = hashlib.md5(  # not crypto — a stable shuffle key
+                f"{seed}:{r[0]}:{r[1]}".encode(), usedforsecurity=False
+            ).hexdigest()
+            return int(digest[:8], 16)
+
+        rows.sort(key=_stable_key)
         rows = rows[:n]
         if not rows:
             print("No similarity edges found — nothing to probe.", file=sys.stderr)

--- a/scripts/dev/mw2_classifier_probe.py
+++ b/scripts/dev/mw2_classifier_probe.py
@@ -38,10 +38,11 @@ SNAP = Path.home() / "tmp" / "mw2_probe_snapshot.db"
 OUT_DIR = Path.home() / ".genesis" / "output"
 
 # auto_link writes extends/supports; connection_pass writes related_to. These are
-# the similarity-derived (>=0.75) population MW-2 is about. The SELECT's strength
-# window [0.75, 1.0) excludes extraction-emitted typed links (exactly 0.7) and
-# synthesis provenance edges (exactly 1.0); the report's strength spread makes
-# the sampled window visible.
+# the similarity-derived (>=0.75) population MW-2 is about. strength >= 0.75
+# excludes extraction-emitted typed links (exactly 0.7); synthesis provenance
+# edges (extends@1.0) are excluded by SOURCE (dream_cycle_run_id LIKE
+# 'synthesis:%' — the dream_link_repair marker) rather than by strength, so
+# exact-cosine auto_link edges (prime duplicate suspects) STAY in (Codex r2).
 _SIMILARITY_TYPES = ("extends", "supports", "related_to")
 
 
@@ -82,24 +83,36 @@ async def run(n: int, batch: int, seed: int) -> int:
     # dict(row)) requires it, and hydrate_for_expansion's index access still works.
     db.row_factory = aiosqlite.Row
     try:
-        # Deterministic sample: seed sqlite's RANDOM via a stable ORDER key.
-        # Strength window isolates the SIMILARITY population (Codex P1):
-        # extraction-emitted typed links are strength=0.7 exactly and synthesis
-        # provenance edges are 1.0 exactly; auto_link writes cosine >=0.75 and
-        # connection_pass >=0.80, both strictly <1.0 in practice.
+        # FULL eligible population (Codex r2: a pre-LIMIT on a lexicographic
+        # ORDER sampled only the earliest id-prefix cluster and no seed could
+        # ever reach later edges). Similarity population = the 3 types at
+        # strength >= 0.75, minus synthesis-provenance edges (identified by
+        # SOURCE marker, not by strength — exact-cosine auto_link edges stay).
         rows = await db.execute_fetchall(
             "SELECT source_id, target_id, link_type, strength FROM memory_links "  # noqa: S608 - placeholders bound
             f"WHERE link_type IN ({','.join('?' * len(_SIMILARITY_TYPES))}) "
-            "AND strength >= 0.75 AND strength < 1.0 "
-            "ORDER BY substr(source_id || target_id, 1, 12), source_id "
-            "LIMIT ?",
-            (*_SIMILARITY_TYPES, max(n * 3, n)),
+            "AND strength >= 0.75 "
+            "AND NOT (link_type = 'extends' AND source_id IN ("
+            "    SELECT memory_id FROM memory_metadata "
+            "    WHERE dream_cycle_run_id LIKE 'synthesis:%'))",
+            _SIMILARITY_TYPES,
         )
-        rows = list(rows)
+        eligible_edges = len(rows)
 
-        # Stable pseudo-shuffle by seed, then take n. Uses md5 (not builtin
-        # hash(): PEP-456 salts str hashing per process, which would make the
-        # same --seed draw a DIFFERENT sample every run — review finding).
+        # Dedup to UNORDERED pairs (A->B and B->A, or multi-type rows, are the
+        # same content pair — classifying both would double-count it); keep the
+        # strongest row per pair.
+        by_pair: dict[tuple[str, str], tuple] = {}
+        for r in rows:
+            key = (min(r[0], r[1]), max(r[0], r[1]))
+            if key not in by_pair or r[3] > by_pair[key][3]:
+                by_pair[key] = tuple(r)
+        rows = list(by_pair.values())
+        eligible_pairs = len(rows)
+
+        # Stable pseudo-shuffle by seed over the FULL population, then take n.
+        # md5, not builtin hash(): PEP-456 salts str hashing per process, which
+        # would make the same --seed draw a DIFFERENT sample every run.
         def _stable_key(r) -> int:
             digest = hashlib.md5(  # not crypto — a stable shuffle key
                 f"{seed}:{r[0]}:{r[1]}".encode(), usedforsecurity=False
@@ -119,21 +132,56 @@ async def run(n: int, batch: int, seed: int) -> int:
         for off in range(0, len(ids), 400):
             hydrated.update(await memory_crud.hydrate_for_expansion(db, ids[off : off + 400]))
 
+        # created_at per endpoint → per-pair chronology hint (Codex r2: the
+        # batch API accepts newers; the probe must actually supply them).
+        created_at: dict[str, str] = {}
+        for off in range(0, len(ids), 400):
+            chunk = ids[off : off + 400]
+            ph = ",".join("?" * len(chunk))
+            for mid, ca_ts in await db.execute_fetchall(
+                f"SELECT memory_id, created_at FROM memory_metadata "  # noqa: S608 - placeholders bound
+                f"WHERE memory_id IN ({ph})",
+                chunk,
+            ):
+                if ca_ts:
+                    created_at[mid] = ca_ts
+
+        now_iso = datetime.now(UTC).isoformat()
         pairs: list[tuple[str, str]] = []
+        newers: list[str | None] = []
         meta: list[dict] = []
+        skipped_invisible = 0
         for src_id, tgt_id, ltype, strength in rows:
-            ca = (hydrated.get(src_id) or {}).get("content")
-            cb = (hydrated.get(tgt_id) or {}).get("content")
-            if ca and cb:
-                pairs.append((ca, cb))
-                meta.append(
-                    {
-                        "source_id": src_id,
-                        "target_id": tgt_id,
-                        "stored_link_type": ltype,
-                        "strength": strength,
-                    }
-                )
+            row_a = hydrated.get(src_id) or {}
+            row_b = hydrated.get(tgt_id) or {}
+            ca = row_a.get("content")
+            cb = row_b.get("content")
+            if not (ca and cb):
+                continue
+            # Visibility parity with the boost path (graph_expansion skips
+            # bitemporally-expired / deprecated rows): an edge whose endpoint
+            # recall would hide cannot affect boosting — measuring it would
+            # inflate the boost-risk population (Codex r2).
+            visible = True
+            for row in (row_a, row_b):
+                inv = row.get("invalid_at")
+                if (inv is not None and inv <= now_iso) or row.get("deprecated"):
+                    visible = False
+            if not visible:
+                skipped_invisible += 1
+                continue
+            ts_a, ts_b = created_at.get(src_id), created_at.get(tgt_id)
+            newer = ("a" if ts_a > ts_b else "b") if ts_a and ts_b and ts_a != ts_b else None
+            pairs.append((ca, cb))
+            newers.append(newer)
+            meta.append(
+                {
+                    "source_id": src_id,
+                    "target_id": tgt_id,
+                    "stored_link_type": ltype,
+                    "strength": strength,
+                }
+            )
 
         if not pairs:
             print("Edges sampled but no content hydrated — aborting.", file=sys.stderr)
@@ -153,7 +201,9 @@ async def run(n: int, batch: int, seed: int) -> int:
         verdicts: list[dict] = []
         for i in range(0, len(pairs), batch):
             chunk = pairs[i : i + batch]
-            verdicts.extend(await classify_relationships(router, chunk))
+            verdicts.extend(
+                await classify_relationships(router, chunk, newers=newers[i : i + batch])
+            )
             print(
                 f"  classified {min(i + batch, len(pairs))}/{len(pairs)} pairs...", file=sys.stderr
             )
@@ -180,7 +230,10 @@ async def run(n: int, batch: int, seed: int) -> int:
         report = {
             "generated_at": datetime.now(UTC).isoformat(),
             "snapshot": str(SNAP),
-            "sampled_edges": len(rows),
+            "eligible_edges": eligible_edges,
+            "eligible_pairs_deduped": eligible_pairs,
+            "sampled_pairs": len(rows),
+            "skipped_invisible_endpoints": skipped_invisible,
             "classified_pairs": total,
             "failsafe_unclassified": failsafe_count,
             "stored_type_mix": dict(Counter(m["stored_link_type"] for m in meta)),

--- a/scripts/dev/mw2_classifier_probe.py
+++ b/scripts/dev/mw2_classifier_probe.py
@@ -45,6 +45,10 @@ OUT_DIR = Path.home() / ".genesis" / "output"
 # exact-cosine auto_link edges (prime duplicate suspects) STAY in (Codex r2).
 _SIMILARITY_TYPES = ("extends", "supports", "related_to")
 
+#: Size of the seeded REPRESENTATIVE hand-scoring subset (proportional across
+#: verdicts by construction — stable-key order over all classified pairs).
+_HAND_SCORE_N = 40
+
 
 def snapshot_live_db() -> None:
     """WAL-safe online backup of the live DB → ~/tmp copy (read source, never write it)."""
@@ -86,13 +90,16 @@ async def run(n: int, batch: int, seed: int) -> int:
         # FULL eligible population (Codex r2: a pre-LIMIT on a lexicographic
         # ORDER sampled only the earliest id-prefix cluster and no seed could
         # ever reach later edges). Similarity population = the 3 types at
-        # strength >= 0.75, minus synthesis-provenance edges (identified by
-        # SOURCE marker, not by strength — exact-cosine auto_link edges stay).
+        # strength >= 0.75, minus TRUE synthesis-provenance edges only:
+        # source has the synthesis marker AND strength is exactly 1.0 (the
+        # provenance-edge constant). A live dream-merge also REWIRES originals'
+        # similarity edges onto the synthesis preserving their cosine (<1.0) —
+        # those remain boost-live and stay in the population (Codex r3).
         rows = await db.execute_fetchall(
             "SELECT source_id, target_id, link_type, strength FROM memory_links "  # noqa: S608 - placeholders bound
             f"WHERE link_type IN ({','.join('?' * len(_SIMILARITY_TYPES))}) "
             "AND strength >= 0.75 "
-            "AND NOT (link_type = 'extends' AND source_id IN ("
+            "AND NOT (link_type = 'extends' AND strength = 1.0 AND source_id IN ("
             "    SELECT memory_id FROM memory_metadata "
             "    WHERE dream_cycle_run_id LIKE 'synthesis:%'))",
             _SIMILARITY_TYPES,
@@ -248,34 +255,61 @@ async def run(n: int, batch: int, seed: int) -> int:
             "mean_confidence_by_verdict": {r: _mean(conf_by_rel[r]) for r in COARSE_RELATIONSHIPS},
         }
 
-        # ── hand-scorable sample (all unsafe verdicts + a slice of distinct) ──
-        sample = []
-        distinct_shown = 0
-        for (ca, cb), v, m in zip(pairs, verdicts, meta, strict=True):
-            is_unsafe = v["relationship"] != "distinct"
-            if is_unsafe or distinct_shown < 8:
-                if not is_unsafe:
-                    distinct_shown += 1
-                sample.append(
-                    {
-                        "verdict": v["relationship"],
-                        "confidence": v["confidence"],
-                        "reasoning": v.get("reasoning", ""),
-                        "stored_link_type": m["stored_link_type"],
-                        "strength": m["strength"],
-                        "content_a": ca[:400],
-                        "content_b": cb[:400],
-                    }
-                )
+        # ── hand-scoring artifacts (Codex r3) ─────────────────────────────
+        # (a) hand_score_sample: a SEEDED REPRESENTATIVE subset across ALL
+        #     verdicts (stable-key order, so distinct — 73% of the population —
+        #     is proportionally present and overall accuracy / unsafe
+        #     false-negatives are measurable from the artifact);
+        # (b) unsafe_dump: every predicted-unsafe pair, as a diagnostic section.
+        # Entries carry endpoint ids + the SAME 1500-char span the classifier
+        # saw, so a reviewer can reproduce and score each verdict faithfully.
+        # (Local artifact — ~/.genesis/output is never a public surface.)
+        def _entry(ca: str, cb: str, v: dict, m: dict) -> dict:
+            return {
+                "source_id": m["source_id"],
+                "target_id": m["target_id"],
+                "verdict": v["relationship"],
+                "confidence": v["confidence"],
+                "reasoning": v.get("reasoning", ""),
+                "stored_link_type": m["stored_link_type"],
+                "strength": m["strength"],
+                "content_a": ca[:1500],
+                "content_b": cb[:1500],
+            }
+
+        joined = [
+            (ca, cb, v, m)
+            for (ca, cb), v, m in zip(pairs, verdicts, meta, strict=True)
+            if not v.get("failed")
+        ]
+        rep_order = sorted(
+            joined, key=lambda t: _stable_key((t[3]["source_id"], t[3]["target_id"]))
+        )
+        hand_score_sample = [_entry(ca, cb, v, m) for ca, cb, v, m in rep_order[:_HAND_SCORE_N]]
+        unsafe_dump = [
+            _entry(ca, cb, v, m) for ca, cb, v, m in joined if v["relationship"] != "distinct"
+        ]
 
         OUT_DIR.mkdir(parents=True, exist_ok=True)
         stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
         report_path = OUT_DIR / f"mw2_classifier_probe_{stamp}.json"
-        report_path.write_text(json.dumps({"report": report, "sample": sample}, indent=2))
+        report_path.write_text(
+            json.dumps(
+                {
+                    "report": report,
+                    "hand_score_sample": hand_score_sample,
+                    "unsafe_dump": unsafe_dump,
+                },
+                indent=2,
+            )
+        )
 
         print("\n===== MW-2 CHECKPOINT A — classifier probe =====")
         print(json.dumps(report, indent=2))
-        print(f"\nHand-scorable sample ({len(sample)} pairs) + full report → {report_path}")
+        print(
+            f"\nRepresentative hand-score sample ({len(hand_score_sample)}) + "
+            f"unsafe dump ({len(unsafe_dump)}) + full report → {report_path}"
+        )
         return 0
     finally:
         await db.close()

--- a/src/genesis/db/crud/memory_links.py
+++ b/src/genesis/db/crud/memory_links.py
@@ -18,12 +18,36 @@ async def create(
     link_type: str,
     strength: float = 0.5,
     created_at: str,
+    proposed_type: str | None = None,
+    confidence: float | None = None,
+    classifier: str | None = None,
+    review_state: str | None = None,
+    safe_for_boost: int | None = None,
 ) -> tuple[str, str]:
-    """Insert a memory link. Returns (source_id, target_id)."""
+    """Insert a memory link. Returns (source_id, target_id).
+
+    The five trailing kwargs are the MW-2 (0082) edge-metadata columns — the
+    classifier-verdict stamping location (GROUNDWORK(mw-5-merge-gate)). All
+    default ``None``, which preserves legacy semantics exactly: NULL
+    ``safe_for_boost`` = boost-eligible, NULL ``review_state`` = the
+    ``link_type`` stands as written. No production caller passes them yet.
+    """
     await db.execute(
-        "INSERT INTO memory_links (source_id, target_id, link_type, strength, created_at) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (source_id, target_id, link_type, strength, created_at),
+        "INSERT INTO memory_links (source_id, target_id, link_type, strength, created_at, "
+        "proposed_type, confidence, classifier, review_state, safe_for_boost) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            source_id,
+            target_id,
+            link_type,
+            strength,
+            created_at,
+            proposed_type,
+            confidence,
+            classifier,
+            review_state,
+            safe_for_boost,
+        ),
     )
     await db.commit()
     return (source_id, target_id)

--- a/src/genesis/db/migrations/0082_mw2_link_metadata.py
+++ b/src/genesis/db/migrations/0082_mw2_link_metadata.py
@@ -1,0 +1,74 @@
+"""Add MW-2 edge-metadata columns to ``memory_links``.
+
+Five NULLable columns — the stamping location for relationship-classifier
+verdicts (the coarse judgment function shipped by the MW-2 lean keystone):
+
+  - ``proposed_type`` — the classifier's verdict label (its vocabulary, e.g.
+    ``duplicate``/``succeeded_by`` — NOT constrained to the link_type CHECK).
+  - ``confidence`` — classifier confidence 0..1 (NULL = never classified).
+  - ``classifier`` — provenance of the judgment: ``'llm:<call_site>'`` /
+    ``'entity_scan'`` / NULL (legacy, never judged).
+  - ``review_state`` — ``'classified'`` / ``'confirmed'`` / NULL (legacy edge,
+    its ``link_type`` stands as written).
+  - ``safe_for_boost`` — INTEGER bool; **NULL means boost-eligible** (legacy
+    default — the 212k existing edges keep today's behavior; only a future
+    explicit ``0`` would gate an edge out of content expansion).
+
+All five are NULLable with NO default and NO backfill. NOTHING reads or writes
+them in production yet (# GROUNDWORK(mw-5-merge-gate)): MW-5's merge gate stamps
+verdicts here; the deferred MW-2b (stored-graph reclassification + boost gating)
+was measured 2026-08-10 as not-currently-justified (probe: 76.7% of similarity
+edges benign; unsafe slice mostly harmless duplicates — see
+``~/.genesis/output/mw2_classifier_probe_20260811_013928.json``).
+
+Deliberately NO CHECK change and NO table rebuild: the link_type allowlist stays
+the 12 types (locked by test_migration_0082's CHECK-unchanged test).
+
+Self-contained + idempotent: each ADD is PRAGMA-guarded (applies via the base
+path OR the numbered runner; whichever ran first, the guard skips). No commit —
+the runner owns the transaction. These columns are ALSO mirrored in
+``_migrate_add_columns`` (guarded ``_try_alter``): create_all_tables runs that
+function but NOT the numbered runner (schema_both_build_paths).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+_MEMORY_LINKS_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("proposed_type", "TEXT"),
+    ("confidence", "REAL"),
+    ("classifier", "TEXT"),
+    ("review_state", "TEXT"),
+    ("safe_for_boost", "INTEGER"),
+)
+
+
+async def _add_column(db: aiosqlite.Connection, table: str, col: str, decl: str) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    )
+    if not await cursor.fetchone():
+        return  # fresh DB — CREATE TABLE already carries the column
+    cursor = await db.execute(f"PRAGMA table_info({table})")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if col not in cols:
+        await db.execute(f"ALTER TABLE {table} ADD COLUMN {col} {decl}")
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    for col, decl in _MEMORY_LINKS_COLUMNS:
+        await _add_column(db, "memory_links", col, decl)
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='memory_links'"
+    )
+    if not await cursor.fetchone():
+        return
+    cursor = await db.execute("PRAGMA table_info(memory_links)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    for col, _decl in _MEMORY_LINKS_COLUMNS:
+        if col in cols:
+            await db.execute(f"ALTER TABLE memory_links DROP COLUMN {col}")

--- a/src/genesis/db/migrations/0082_mw2_link_metadata.py
+++ b/src/genesis/db/migrations/0082_mw2_link_metadata.py
@@ -17,9 +17,9 @@ verdicts (the coarse judgment function shipped by the MW-2 lean keystone):
 All five are NULLable with NO default and NO backfill. NOTHING reads or writes
 them in production yet (# GROUNDWORK(mw-5-merge-gate)): MW-5's merge gate stamps
 verdicts here; the deferred MW-2b (stored-graph reclassification + boost gating)
-was measured 2026-08-10 as not-currently-justified (probe: 76.7% of similarity
-edges benign; unsafe slice mostly harmless duplicates — see
-``~/.genesis/output/mw2_classifier_probe_20260811_013928.json``).
+was measured 2026-08-10/11 as not-currently-justified (probe, corrected
+population: 73.0% of similarity edges benign; unsafe slice mostly harmless
+duplicates — see ``~/.genesis/output/mw2_classifier_probe_20260811_042515.json``).
 
 Deliberately NO CHECK change and NO table rebuild: the link_type allowlist stays
 the 12 types (locked by test_migration_0082's CHECK-unchanged test).

--- a/src/genesis/db/migrations/0082_mw2_link_metadata.py
+++ b/src/genesis/db/migrations/0082_mw2_link_metadata.py
@@ -17,9 +17,10 @@ verdicts (the coarse judgment function shipped by the MW-2 lean keystone):
 All five are NULLable with NO default and NO backfill. NOTHING reads or writes
 them in production yet (# GROUNDWORK(mw-5-merge-gate)): MW-5's merge gate stamps
 verdicts here; the deferred MW-2b (stored-graph reclassification + boost gating)
-was measured 2026-08-10/11 as not-currently-justified (probe, corrected
-population: 73.0% of similarity edges benign; unsafe slice mostly harmless
-duplicates — see ``~/.genesis/output/mw2_classifier_probe_20260811_042515.json``).
+was measured 2026-08-11 as not-currently-justified (probe over the full
+~197k-pair similarity population, visibility-filtered: 73.2% benign-distinct;
+unsafe slice mostly harmless duplicates — see
+``~/.genesis/output/mw2_classifier_probe_20260811_045500.json``).
 
 Deliberately NO CHECK change and NO table rebuild: the link_type allowlist stays
 the 12 types (locked by test_migration_0082's CHECK-unchanged test).

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -925,6 +925,28 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
             "memory_links CHECK constraint migration failed", exc_info=True
         )
 
+    # MW-2 (0082) edge-metadata on memory_links — classifier-verdict stamping
+    # location (GROUNDWORK(mw-5-merge-gate)). Mirrored here because
+    # create_all_tables runs _migrate_add_columns but NOT the numbered runner,
+    # so an existing DB upgraded via the base path needs the columns too
+    # (schema_both_build_paths). All NULLable, no backfill; NULL safe_for_boost
+    # = boost-eligible (legacy default).
+    await _try_alter(db,
+        "ALTER TABLE memory_links ADD COLUMN proposed_type TEXT",
+        "memory_links.proposed_type")
+    await _try_alter(db,
+        "ALTER TABLE memory_links ADD COLUMN confidence REAL",
+        "memory_links.confidence")
+    await _try_alter(db,
+        "ALTER TABLE memory_links ADD COLUMN classifier TEXT",
+        "memory_links.classifier")
+    await _try_alter(db,
+        "ALTER TABLE memory_links ADD COLUMN review_state TEXT",
+        "memory_links.review_state")
+    await _try_alter(db,
+        "ALTER TABLE memory_links ADD COLUMN safe_for_boost INTEGER",
+        "memory_links.safe_for_boost")
+
     # Bookmark fix: add source column to session_bookmarks
     await _try_alter(db,
         "ALTER TABLE session_bookmarks ADD COLUMN source TEXT NOT NULL DEFAULT 'auto'",

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -558,6 +558,16 @@ TABLES = {
             ),
             strength    REAL NOT NULL DEFAULT 0.5,
             created_at  TEXT NOT NULL,
+            -- MW-2 (0082) edge-metadata: classifier-verdict stamping location.
+            -- All NULLable, no backfill. NULL safe_for_boost = boost-eligible
+            -- (legacy default). proposed_type carries the classifier's verdict
+            -- label and is deliberately NOT constrained by the link_type CHECK.
+            -- GROUNDWORK(mw-5-merge-gate): MW-5 stamps verdicts here.
+            proposed_type   TEXT,
+            confidence      REAL,
+            classifier      TEXT,
+            review_state    TEXT,
+            safe_for_boost  INTEGER,
             -- link_type is part of the PK (audit DLI-04 / D15): distinct
             -- relationship types between the same pair (e.g. supports AND
             -- contradicts) must coexist, not silently overwrite. Migration

--- a/src/genesis/memory/relationship_classifier.py
+++ b/src/genesis/memory/relationship_classifier.py
@@ -140,9 +140,22 @@ def _normalize_verdict(raw: dict[str, Any]) -> dict[str, Any]:
     becomes ``0.0`` (never silently high). A valid label keeps its clamped
     confidence.
     """
+    # Totality guard (Codex r3): a malformed ITEM must fail alone, never poison
+    # sibling verdicts in a batch. Non-str relationship ([]/{}/None) would raise
+    # TypeError on the frozenset test; an astronomical JSON int raises
+    # OverflowError in float(). Both are handled here; the except is the
+    # belt-and-suspenders for anything else malformed.
+    try:
+        return _normalize_verdict_inner(raw)
+    except Exception:  # noqa: BLE001 — normalization must be total
+        logger.debug("malformed verdict object", exc_info=True)
+        return _failsafe("malformed verdict → fail-safe")
+
+
+def _normalize_verdict_inner(raw: dict[str, Any]) -> dict[str, Any]:
     rel = raw.get("relationship")
     reasoning = str(raw.get("reasoning", "") or "")
-    if rel not in COARSE_RELATIONSHIPS:
+    if not isinstance(rel, str) or rel not in COARSE_RELATIONSHIPS:
         # The model responded, but outside the contract — a fail-safe, not a verdict.
         return {"relationship": "distinct", "confidence": 0.0, "reasoning": reasoning, "failed": True}
     conf = raw.get("confidence")

--- a/src/genesis/memory/relationship_classifier.py
+++ b/src/genesis/memory/relationship_classifier.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -109,7 +110,12 @@ def _newer_hint(newer: str | None) -> str:
 
 
 def _failsafe(reasoning: str = "classifier fail-safe → distinct") -> dict[str, Any]:
-    return {"relationship": "distinct", "confidence": 0.0, "reasoning": reasoning}
+    """A verdict that means "classification FAILED", not "genuinely distinct".
+
+    ``failed: True`` lets consumers (the measurement probe's tally, MW-5's
+    gate) exclude fail-safes instead of silently counting them as benign.
+    """
+    return {"relationship": "distinct", "confidence": 0.0, "reasoning": reasoning, "failed": True}
 
 
 def _parse_json(text: str | None) -> Any:
@@ -137,12 +143,18 @@ def _normalize_verdict(raw: dict[str, Any]) -> dict[str, Any]:
     rel = raw.get("relationship")
     reasoning = str(raw.get("reasoning", "") or "")
     if rel not in COARSE_RELATIONSHIPS:
-        return {"relationship": "distinct", "confidence": 0.0, "reasoning": reasoning}
+        # The model responded, but outside the contract — a fail-safe, not a verdict.
+        return {"relationship": "distinct", "confidence": 0.0, "reasoning": reasoning, "failed": True}
     conf = raw.get("confidence")
     # bool is a subclass of int — reject it explicitly so True→1.0 can't sneak in.
     if isinstance(conf, bool) or not isinstance(conf, (int, float)):
         conf = 0.0
-    conf = max(0.0, min(1.0, float(conf)))
+    conf = float(conf)
+    # json.loads accepts bare NaN/Infinity; min(1.0, nan) returns 1.0 in Python,
+    # so an unguarded clamp would make a NaN verdict MAXIMALLY trusted.
+    if not math.isfinite(conf):
+        conf = 0.0
+    conf = max(0.0, min(1.0, conf))
     return {"relationship": rel, "confidence": conf, "reasoning": reasoning}
 
 
@@ -189,16 +201,28 @@ async def classify_relationship(
         return _failsafe("exception → distinct")
 
 
-def _render_pairs(pairs: Sequence[tuple[str, str]]) -> str:
+def _render_pairs(
+    pairs: Sequence[tuple[str, str]],
+    newers: Sequence[str | None] | None = None,
+) -> str:
+    """Render numbered pairs; ``newers[i]`` ("a"/"b"/None) tags which memory is
+    NEWER so chronology survives batching (succeeded_by direction depends on it)."""
     blocks = []
     for i, (a, b) in enumerate(pairs):
-        blocks.append(f"[{i}]\nMemory A: {a[:_CONTENT_CAP]}\nMemory B: {b[:_CONTENT_CAP]}")
+        newer = newers[i] if newers and i < len(newers) else None
+        tag_a = " (NEWER)" if newer == "a" else ""
+        tag_b = " (NEWER)" if newer == "b" else ""
+        blocks.append(
+            f"[{i}]\nMemory A{tag_a}: {a[:_CONTENT_CAP]}\nMemory B{tag_b}: {b[:_CONTENT_CAP]}"
+        )
     return "\n\n".join(blocks)
 
 
 async def classify_relationships(
     router: Router,
     pairs: Sequence[tuple[str, str]],
+    *,
+    newers: Sequence[str | None] | None = None,
 ) -> list[dict[str, Any]]:
     """Batched :func:`classify_relationship` — one LLM call for many pairs.
 
@@ -211,7 +235,7 @@ async def classify_relationships(
     prompt = _BATCH_PROMPT.format(
         definitions=_DEFINITIONS,
         examples=_EXAMPLES,
-        pairs=_render_pairs(pairs),
+        pairs=_render_pairs(pairs, newers),
     )
     try:
         result = await router.route_call(

--- a/src/genesis/memory/relationship_classifier.py
+++ b/src/genesis/memory/relationship_classifier.py
@@ -146,15 +146,19 @@ def _normalize_verdict(raw: dict[str, Any]) -> dict[str, Any]:
         # The model responded, but outside the contract — a fail-safe, not a verdict.
         return {"relationship": "distinct", "confidence": 0.0, "reasoning": reasoning, "failed": True}
     conf = raw.get("confidence")
-    # bool is a subclass of int — reject it explicitly so True→1.0 can't sneak in.
-    if isinstance(conf, bool) or not isinstance(conf, (int, float)):
-        conf = 0.0
-    conf = float(conf)
-    # json.loads accepts bare NaN/Infinity; min(1.0, nan) returns 1.0 in Python,
-    # so an unguarded clamp would make a NaN verdict MAXIMALLY trusted.
-    if not math.isfinite(conf):
-        conf = 0.0
-    conf = max(0.0, min(1.0, conf))
+    # A valid label WITHOUT a trustworthy confidence is not a verdict: absent,
+    # non-numeric, bool (a subclass of int — True→1.0 must not sneak in), or
+    # non-finite (json.loads accepts bare NaN/Infinity, and min(1.0, nan)
+    # returns 1.0 in Python — an unguarded clamp would make a NaN verdict
+    # MAXIMALLY trusted). All fail safe, so tallies and confidence gates never
+    # count a malformed response as a real classification.
+    if (
+        isinstance(conf, bool)
+        or not isinstance(conf, (int, float))
+        or not math.isfinite(float(conf))
+    ):
+        return _failsafe(f"invalid confidence for label {rel!r} → fail-safe")
+    conf = max(0.0, min(1.0, float(conf)))
     return {"relationship": rel, "confidence": conf, "reasoning": reasoning}
 
 

--- a/src/genesis/memory/relationship_classifier.py
+++ b/src/genesis/memory/relationship_classifier.py
@@ -1,0 +1,244 @@
+"""MW-2 lean keystone — the reusable relationship-classifier function.
+
+Given two memory contents, classify their relationship into a COARSE, tractable
+vocabulary and attach a confidence. This is the judgment MW-5's merge gate
+consumes (``≥0.95`` cosine only NOMINATES; this function confirms same-assertion
+and rules out old-vs-new-truth / contradiction before any merge).
+
+Design decisions (see plan ``yes-go-ahead-as-humming-gosling.md`` MW-2 LEAN):
+
+- **Coarse vocabulary only** — ``{duplicate, contradicts, succeeded_by,
+  distinct}``. Generalizes ``entity_resolution.check_semantic_overlap``
+  (duplicate/contradicts/distinct) by adding ``succeeded_by`` (old→new truth).
+  Fine-grained typing (extends/supports/elaborates) is DELIBERATELY not
+  attempted: it is literature-unreliable on already-similar pairs, and NO
+  consumer reads a fabricated fine type (recall boost is type-agnostic —
+  ``neighbors_of`` ranks by ``MAX(strength)``, only the ``contradicts`` deny-list
+  uses type). Attempting it would replace a harmless heuristic with an
+  expensive, unreliable one.
+- **Direction-agnostic verdict** — ``succeeded_by`` means "one supersedes the
+  other"; the CALLER orders older→newer from ``created_at`` (as
+  ``dream_entity_scan`` already does). An optional ``newer`` hint is passed to
+  the prompt to help the model separate a temporal UPDATE (succeeded_by) from a
+  genuine CONFLICT (contradicts).
+- **Fail-safe** — any LLM/parse failure, an out-of-vocab verdict, or an
+  absent/low confidence resolves to ``distinct`` at confidence ``0.0``. Never
+  fabricate a merge-eligible verdict on uncertainty (mirrors the precedent's
+  ``distinct`` default; a wrong ``duplicate`` would drive a wrong merge).
+
+NOTHING mutates the graph here — this is a pure judgment function. The MW-2 lean
+keystone ships it + a shadow measurement probe; the stored-graph reclassification
+/ boost-gating machinery (MW-2b) is deferred behind that measurement.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from genesis.routing.router import Router
+
+logger = logging.getLogger(__name__)
+
+#: Observability call site — registered in ``observability/_call_site_meta.py``
+#: with ``model_tier="slm"`` (same tier as ``dream_cycle_entity_check``).
+CALL_SITE_ID: str = "dream_cycle_relationship_classify"
+
+#: The ONLY relationship labels this classifier may emit. Anything else the LLM
+#: returns is coerced to ``distinct`` (fail-safe). Deliberately excludes the
+#: fine-grained types (extends/supports/elaborates/related_to) — see module doc.
+COARSE_RELATIONSHIPS: frozenset[str] = frozenset(
+    {"duplicate", "contradicts", "succeeded_by", "distinct"}
+)
+
+#: Truncation applied to each memory's content before prompting (mirrors
+#: ``check_semantic_overlap``'s 1500-char cap — keeps token cost bounded).
+_CONTENT_CAP = 1500
+
+_DEFINITIONS = """\
+- "duplicate": the SAME assertion/information, possibly reworded.
+- "contradicts": the same topic, but CONFLICTING claims (different numbers, opposite conclusions).
+- "succeeded_by": the same topic, where one memory UPDATES/supersedes the other (newer truth replaces older).
+- "distinct": a related topic but genuinely DIFFERENT, non-conflicting information.
+
+confidence = how sure you are, 0.0-1.0. Use LOW confidence when the pair is only loosely related or the distinction is genuinely ambiguous. Do NOT guess "duplicate" or "contradicts" when unsure — prefer "distinct" with low confidence."""
+
+_EXAMPLES = """\
+Examples:
+A: "The deploy host runs the server" / B: "The deploy host runs the server (reworded)" -> {"relationship":"duplicate","confidence":0.95,"reasoning":"same fact reworded"}
+A: "Budget is 100/day" / B: "Budget is 250/day" -> {"relationship":"contradicts","confidence":0.9,"reasoning":"conflicting numbers, same subject"}
+A: "We chose engine X" / B: "We switched from X to engine Y" -> {"relationship":"succeeded_by","confidence":0.85,"reasoning":"B updates the decision in A"}
+A: "Notes about the voice pipeline" / B: "Notes about the billing flow" -> {"relationship":"distinct","confidence":0.8,"reasoning":"different subjects"}"""
+
+_SINGLE_PROMPT = """\
+Compare Memory A and Memory B and decide their relationship. Respond with JSON only, no other text:
+{{"relationship": "duplicate|contradicts|succeeded_by|distinct", "confidence": 0.0-1.0, "reasoning": "one sentence"}}
+
+{definitions}
+
+{examples}
+{newer_hint}
+Memory A:
+{content_a}
+
+Memory B:
+{content_b}"""
+
+_BATCH_PROMPT = """\
+Compare each numbered pair of memories and decide the relationship for EACH. Respond with a JSON ARRAY only, one object per pair, in order:
+[{{"pair_id": 0, "relationship": "duplicate|contradicts|succeeded_by|distinct", "confidence": 0.0-1.0, "reasoning": "one sentence"}}, ...]
+
+{definitions}
+
+{examples}
+
+Pairs:
+{pairs}"""
+
+
+def _newer_hint(newer: str | None) -> str:
+    if newer == "a":
+        return "\nNOTE: Memory A is the NEWER memory (if one updates the other, A is the update).\n"
+    if newer == "b":
+        return "\nNOTE: Memory B is the NEWER memory (if one updates the other, B is the update).\n"
+    return "\n"
+
+
+def _failsafe(reasoning: str = "classifier fail-safe → distinct") -> dict[str, Any]:
+    return {"relationship": "distinct", "confidence": 0.0, "reasoning": reasoning}
+
+
+def _parse_json(text: str | None) -> Any:
+    """Strip an optional markdown fence and ``json.loads``; ``None`` on failure."""
+    if not text:
+        return None
+    t = text.strip()
+    if t.startswith("```"):
+        # ```json\n...\n``` → drop the opening fence line and the closing fence.
+        t = t.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+    try:
+        return json.loads(t)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _normalize_verdict(raw: dict[str, Any]) -> dict[str, Any]:
+    """Coerce a raw parsed object into a trusted verdict.
+
+    Out-of-vocab relationship OR non-numeric/absent confidence ⇒ the value is not
+    trusted: an out-of-vocab type becomes ``distinct``; an absent confidence
+    becomes ``0.0`` (never silently high). A valid label keeps its clamped
+    confidence.
+    """
+    rel = raw.get("relationship")
+    reasoning = str(raw.get("reasoning", "") or "")
+    if rel not in COARSE_RELATIONSHIPS:
+        return {"relationship": "distinct", "confidence": 0.0, "reasoning": reasoning}
+    conf = raw.get("confidence")
+    # bool is a subclass of int — reject it explicitly so True→1.0 can't sneak in.
+    if isinstance(conf, bool) or not isinstance(conf, (int, float)):
+        conf = 0.0
+    conf = max(0.0, min(1.0, float(conf)))
+    return {"relationship": rel, "confidence": conf, "reasoning": reasoning}
+
+
+async def classify_relationship(
+    router: Router,
+    content_a: str,
+    content_b: str,
+    *,
+    newer: str | None = None,
+) -> dict[str, Any]:
+    """Classify the relationship between two memory contents.
+
+    Returns ``{"relationship", "confidence", "reasoning"}`` where ``relationship``
+    is one of :data:`COARSE_RELATIONSHIPS`. Fail-safe = ``distinct`` @ ``0.0``.
+
+    ``newer`` (``"a"``/``"b"``/``None``) tells the model which memory is newer, to
+    separate a temporal update (``succeeded_by``) from a conflict
+    (``contradicts``). Direction of ``succeeded_by`` is the caller's to apply.
+    """
+    prompt = _SINGLE_PROMPT.format(
+        definitions=_DEFINITIONS,
+        examples=_EXAMPLES,
+        newer_hint=_newer_hint(newer),
+        content_a=content_a[:_CONTENT_CAP],
+        content_b=content_b[:_CONTENT_CAP],
+    )
+    try:
+        result = await router.route_call(
+            CALL_SITE_ID,
+            [{"role": "user", "content": prompt}],
+            suppress_dead_letter=True,
+        )
+        if not result.success:
+            logger.warning(
+                "relationship classify LLM call failed: %s", getattr(result, "error", None)
+            )
+            return _failsafe(f"LLM error: {getattr(result, 'error', None)}")
+        data = _parse_json(result.content)
+        if not isinstance(data, dict):
+            return _failsafe("unparseable verdict → distinct")
+        return _normalize_verdict(data)
+    except Exception:  # noqa: BLE001 — a classifier failure must never propagate
+        logger.debug("relationship classify parse/call error", exc_info=True)
+        return _failsafe("exception → distinct")
+
+
+def _render_pairs(pairs: Sequence[tuple[str, str]]) -> str:
+    blocks = []
+    for i, (a, b) in enumerate(pairs):
+        blocks.append(f"[{i}]\nMemory A: {a[:_CONTENT_CAP]}\nMemory B: {b[:_CONTENT_CAP]}")
+    return "\n\n".join(blocks)
+
+
+async def classify_relationships(
+    router: Router,
+    pairs: Sequence[tuple[str, str]],
+) -> list[dict[str, Any]]:
+    """Batched :func:`classify_relationship` — one LLM call for many pairs.
+
+    Returns a verdict list aligned to ``pairs`` by index. Any pair the model omits
+    or malforms fails safe to ``distinct`` @ ``0.0``; a whole-call failure fails
+    every pair safe. Empty ``pairs`` returns ``[]`` with NO LLM call.
+    """
+    if not pairs:
+        return []
+    prompt = _BATCH_PROMPT.format(
+        definitions=_DEFINITIONS,
+        examples=_EXAMPLES,
+        pairs=_render_pairs(pairs),
+    )
+    try:
+        result = await router.route_call(
+            CALL_SITE_ID,
+            [{"role": "user", "content": prompt}],
+            suppress_dead_letter=True,
+        )
+        if not result.success:
+            logger.warning(
+                "relationship classify (batch) failed: %s", getattr(result, "error", None)
+            )
+            return [_failsafe(f"LLM error: {getattr(result, 'error', None)}") for _ in pairs]
+        data = _parse_json(result.content)
+        if not isinstance(data, list):
+            return [_failsafe("unparseable batch → distinct") for _ in pairs]
+        by_id: dict[int, dict[str, Any]] = {}
+        for item in data:
+            if (
+                isinstance(item, dict)
+                and isinstance(item.get("pair_id"), int)
+                and not isinstance(item.get("pair_id"), bool)
+            ):
+                by_id[item["pair_id"]] = item
+        return [
+            _normalize_verdict(by_id[i]) if i in by_id else _failsafe("missing in batch → distinct")
+            for i in range(len(pairs))
+        ]
+    except Exception:  # noqa: BLE001 — a classifier failure must never propagate
+        logger.debug("relationship classify (batch) error", exc_info=True)
+        return [_failsafe("exception → distinct") for _ in pairs]

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -523,6 +523,14 @@ _CALL_SITE_META: dict[str, dict] = {
         "wired": True,
         "see_also": ["dream_cycle_synthesis"],
     },
+    "dream_cycle_relationship_classify": {
+        "description": "MW-2 relationship classifier — coarse relationship judgment (duplicate/contradicts/succeeded_by/distinct) between two candidate memories, with confidence. The reusable function MW-5's merge gate will consume; currently driven only by the MW-2 shadow measurement probe. Fine-grained typing (extends/supports/elaborates) deliberately excluded — unreliable on already-similar pairs.",
+        "category": "consolidation",
+        "frequency": "On demand (MW-2 measurement probe now; MW-5 merge-gate nominees later); batched",
+        "model_tier": "slm",
+        "wired": False,
+        "see_also": ["dream_cycle_entity_check"],
+    },
     "dream_cycle_synthesis_challenge": {
         "description": "Adversarial challenge of dream cycle synthesis output. Different provider from synthesis (Kimi challenges DeepSeek) to ensure model independence. Blocks deprecation when information loss detected.",
         "category": "consolidation",

--- a/tests/test_db/test_migration_0082_link_metadata.py
+++ b/tests/test_db/test_migration_0082_link_metadata.py
@@ -1,0 +1,213 @@
+"""MW-2 — 0082 edge-metadata columns on ``memory_links``: migration + persistence.
+
+Lean-keystone STORE side: five judgment-metadata columns (`proposed_type`,
+`confidence`, `classifier`, `review_state`, `safe_for_boost`) exist on both
+schema build paths (numbered migration for legacy DBs, canonical CREATE for
+fresh DBs), the migration is idempotent, and ``memory_links.create`` can stamp
+them. NOTHING writes them in production yet — they are the stamping location
+MW-5's merge gate (and the MW-2 measurement probe) will use.
+
+Deliberately ABSENT (deferred MW-2b, per the 2026-08-10 measurement): no
+``candidate_similar`` link type, no CHECK change, no table rebuild — the CHECK
+must stay byte-identical, locked by a test here.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+
+from genesis.db.crud import memory_links
+from genesis.db.schema import TABLES
+
+_mig = importlib.import_module("genesis.db.migrations.0082_mw2_link_metadata")
+
+_METADATA_COLS = {
+    "proposed_type",
+    "confidence",
+    "classifier",
+    "review_state",
+    "safe_for_boost",
+}
+
+# A memory_links shaped like a legacy DB that predates MW-2 (no metadata cols).
+_LEGACY_DDL = """
+    CREATE TABLE memory_links (
+        source_id   TEXT NOT NULL,
+        target_id   TEXT NOT NULL,
+        link_type   TEXT NOT NULL CHECK (
+            link_type IN (
+                'supports','contradicts','extends','elaborates',
+                'discussed_in','evaluated_for','decided',
+                'action_item_for','categorized_as','related_to',
+                'succeeded_by','preceded_by'
+            )
+        ),
+        strength    REAL NOT NULL DEFAULT 0.5,
+        created_at  TEXT NOT NULL,
+        PRIMARY KEY (source_id, target_id, link_type)
+    )
+"""
+
+
+async def _columns(conn: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await conn.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def test_migration_adds_all_five_columns_to_legacy_db():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(_LEGACY_DDL)
+        await conn.commit()
+        assert _METADATA_COLS & await _columns(conn, "memory_links") == set()
+
+        await _mig.up(conn)
+        await conn.commit()
+
+        assert await _columns(conn, "memory_links") >= _METADATA_COLS
+    finally:
+        await conn.close()
+
+
+async def test_migration_is_idempotent_and_preserves_rows():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(_LEGACY_DDL)
+        await conn.execute(
+            "INSERT INTO memory_links VALUES ('a', 'b', 'supports', 0.8, '2026-08-10')"
+        )
+        await conn.commit()
+
+        await _mig.up(conn)
+        await _mig.up(conn)  # second run must not raise (duplicate-column guard)
+        await conn.commit()
+
+        assert await _columns(conn, "memory_links") >= _METADATA_COLS
+        cur = await conn.execute(
+            "SELECT strength, proposed_type FROM memory_links WHERE source_id='a' AND target_id='b'"
+        )
+        row = await cur.fetchone()
+        assert row[0] == 0.8  # data preserved
+        assert row[1] is None  # new cols NULL (no backfill)
+    finally:
+        await conn.close()
+
+
+async def test_fresh_db_create_carries_columns():
+    """The canonical CREATE TABLE (fresh-DB path) must already carry the cols —
+    else a fresh install diverges from a migrated one (base-path parity)."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["memory_links"])
+        await conn.commit()
+        assert await _columns(conn, "memory_links") >= _METADATA_COLS
+    finally:
+        await conn.close()
+
+
+async def test_check_constraint_unchanged_no_candidate_similar():
+    """MW-2b is DEFERRED: the CHECK allowlist must stay the 12 types — a
+    ``candidate_similar`` INSERT must still be rejected on both build paths,
+    and a legacy ``extends`` INSERT must still work."""
+    for ddl in (TABLES["memory_links"], _LEGACY_DDL):
+        conn = await aiosqlite.connect(":memory:")
+        try:
+            await conn.execute(ddl)
+            if ddl is _LEGACY_DDL:
+                await _mig.up(conn)
+            await conn.commit()
+
+            # Legacy type still accepted.
+            await conn.execute(
+                "INSERT INTO memory_links (source_id, target_id, link_type, "
+                "strength, created_at) VALUES ('a', 'b', 'extends', 0.9, 't')"
+            )
+            # 13th type still rejected (CHECK unchanged).
+            try:
+                await conn.execute(
+                    "INSERT INTO memory_links (source_id, target_id, link_type, "
+                    "strength, created_at) VALUES ('a', 'c', 'candidate_similar', 0.9, 't')"
+                )
+                raise AssertionError("candidate_similar INSERT should have violated CHECK")
+            except aiosqlite.IntegrityError:
+                pass
+        finally:
+            await conn.close()
+
+
+async def test_pk_still_three_column():
+    """PK must remain (source_id, target_id, link_type) — supports AND
+    contradicts for the same pair coexist (DLI-04)."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["memory_links"])
+        await conn.commit()
+        for ltype in ("supports", "contradicts"):
+            await conn.execute(
+                "INSERT INTO memory_links (source_id, target_id, link_type, "
+                f"strength, created_at) VALUES ('a', 'b', '{ltype}', 0.5, 't')"
+            )
+        cur = await conn.execute(
+            "SELECT COUNT(*) FROM memory_links WHERE source_id='a' AND target_id='b'"
+        )
+        assert (await cur.fetchone())[0] == 2
+    finally:
+        await conn.close()
+
+
+async def test_create_stamps_metadata_kwargs():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["memory_links"])
+        await conn.commit()
+
+        await memory_links.create(
+            conn,
+            source_id="m1",
+            target_id="m2",
+            # link_type stays an allowlist value; the VERDICT rides proposed_type.
+            link_type="supports",
+            strength=0.9,
+            created_at="2026-08-10T00:00:00+00:00",
+            proposed_type="duplicate",
+            confidence=0.93,
+            classifier="llm:dream_cycle_relationship_classify",
+            review_state="classified",
+            safe_for_boost=1,
+        )
+        cur = await conn.execute(
+            "SELECT proposed_type, confidence, classifier, review_state, "
+            "safe_for_boost FROM memory_links WHERE source_id='m1'"
+        )
+        row = await cur.fetchone()
+        assert row == ("duplicate", 0.93, "llm:dream_cycle_relationship_classify", "classified", 1)
+    finally:
+        await conn.close()
+
+
+async def test_create_defaults_null_when_unstamped():
+    """Every existing caller passes no metadata — the columns stay NULL (legacy
+    semantics: NULL safe_for_boost = boost-eligible, NULL review_state = typed
+    truth). This is the zero-regression contract."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["memory_links"])
+        await conn.commit()
+
+        await memory_links.create(
+            conn,
+            source_id="m1",
+            target_id="m2",
+            link_type="extends",
+            strength=0.91,
+            created_at="2026-08-10T00:00:00+00:00",
+        )
+        cur = await conn.execute(
+            "SELECT proposed_type, confidence, classifier, review_state, "
+            "safe_for_boost FROM memory_links WHERE source_id='m1'"
+        )
+        assert await cur.fetchone() == (None, None, None, None, None)
+    finally:
+        await conn.close()

--- a/tests/test_memory/test_relationship_classifier.py
+++ b/tests/test_memory/test_relationship_classifier.py
@@ -221,3 +221,39 @@ async def test_batch_renders_per_pair_newer_hint():
     await classify_relationships(router, [("old fact", "new fact")], newers=["b"])
     prompt = router.route_call.await_args.args[1][0]["content"]
     assert "NEWER" in prompt
+
+
+# ── Codex round-3: normalization must be total (per-item failure isolation) ──
+
+
+@pytest.mark.asyncio
+async def test_unhashable_relationship_fails_only_that_item():
+    # relationship=[] is unhashable — `[] in frozenset` raises TypeError. That
+    # must fail-safe THIS item only, never discard valid sibling verdicts.
+    router = _router(
+        json.dumps(
+            [
+                {"pair_id": 0, "relationship": "duplicate", "confidence": 0.9},
+                {"pair_id": 1, "relationship": [], "confidence": 0.8},
+            ]
+        )
+    )
+    verdicts = await classify_relationships(router, [("a0", "b0"), ("a1", "b1")])
+    assert verdicts[0]["relationship"] == "duplicate"
+    assert verdicts[0]["confidence"] == 0.9
+    assert verdicts[1]["relationship"] == "distinct"
+    assert verdicts[1]["failed"] is True
+
+
+@pytest.mark.asyncio
+async def test_astronomical_int_confidence_fails_only_that_item():
+    # A huge JSON integer parses to an arbitrary-precision int; float() of it
+    # raises OverflowError — must fail-safe the item, not the batch.
+    router = _router(
+        '[{"pair_id": 0, "relationship": "distinct", "confidence": 0.7},'
+        ' {"pair_id": 1, "relationship": "duplicate", "confidence": ' + "9" * 400 + "}]"
+    )
+    verdicts = await classify_relationships(router, [("a0", "b0"), ("a1", "b1")])
+    assert verdicts[0]["relationship"] == "distinct"
+    assert verdicts[0]["confidence"] == 0.7
+    assert verdicts[1]["failed"] is True

--- a/tests/test_memory/test_relationship_classifier.py
+++ b/tests/test_memory/test_relationship_classifier.py
@@ -110,12 +110,15 @@ async def test_confidence_clamped_to_unit_interval():
 
 
 @pytest.mark.asyncio
-async def test_missing_confidence_defaults_low_not_high():
-    # A verdict with no confidence must not be trusted as high-confidence.
+async def test_missing_confidence_is_a_failed_classification():
+    # A valid label WITHOUT a trustworthy confidence is not a verdict — it must
+    # be a fail-safe (failed=True) so tallies/gates never count it as classified
+    # (Codex r2: duplicate@NaN was counted as a real unsafe classification).
     router = _router(json.dumps({"relationship": "duplicate"}))
     v = await classify_relationship(router, "a", "b")
-    assert v["relationship"] == "duplicate"
+    assert v["relationship"] == "distinct"
     assert v["confidence"] == 0.0
+    assert v["failed"] is True
 
 
 @pytest.mark.asyncio
@@ -179,20 +182,23 @@ async def test_batch_empty_pairs_returns_empty():
 
 
 @pytest.mark.asyncio
-async def test_nan_confidence_rejected_to_zero_not_one():
+async def test_nan_confidence_rejected_as_failed():
     # json.loads accepts bare NaN; min(1.0, nan) returns 1.0 in Python, so an
     # unguarded clamp would make a NaN verdict MAXIMALLY trusted (Codex P2).
+    # r2: and it must be FAILED, not a kept label at 0.0 — else tallies count it.
     router = _router('{"relationship": "duplicate", "confidence": NaN}')
     v = await classify_relationship(router, "a", "b")
-    assert v["relationship"] == "duplicate"
+    assert v["relationship"] == "distinct"
     assert v["confidence"] == 0.0
+    assert v["failed"] is True
 
 
 @pytest.mark.asyncio
-async def test_infinite_confidence_rejected_to_zero():
+async def test_infinite_confidence_rejected_as_failed():
     router = _router('{"relationship": "contradicts", "confidence": Infinity}')
     v = await classify_relationship(router, "a", "b")
     assert v["confidence"] == 0.0
+    assert v["failed"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_memory/test_relationship_classifier.py
+++ b/tests/test_memory/test_relationship_classifier.py
@@ -1,0 +1,175 @@
+"""MW-2 lean keystone — the reusable relationship-classifier FUNCTION.
+
+Given two memory contents, classify their relationship into a COARSE, tractable
+vocabulary (``duplicate`` / ``contradicts`` / ``succeeded_by`` / ``distinct``)
+with a confidence. This is the judgment MW-5's merge gate consumes. Generalizes
+``entity_resolution.check_semantic_overlap`` (which does duplicate/contradicts/
+distinct) by adding ``succeeded_by`` (old→new truth) + a confidence field +
+few-shot prompting. Fine-grained typing (extends/supports/elaborates) is
+DELIBERATELY not attempted — it is literature-unreliable on already-similar pairs,
+and no consumer reads it (recall boost is type-agnostic).
+
+Fail-safe posture (mirrors the precedent): any LLM/parse failure, an out-of-vocab
+verdict, or a low/absent confidence resolves to ``distinct`` at confidence 0.0 —
+never fabricate a merge-eligible verdict on uncertainty.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from genesis.memory.relationship_classifier import (
+    COARSE_RELATIONSHIPS,
+    classify_relationship,
+    classify_relationships,
+)
+
+
+def _router(*contents, success=True, error=None):
+    """AsyncMock router whose route_call returns queued MagicMock results."""
+    router = AsyncMock()
+    results = [MagicMock(success=success, content=c, error=error) for c in contents]
+    router.route_call.side_effect = results if len(results) > 1 else None
+    if len(results) == 1:
+        router.route_call.return_value = results[0]
+    return router
+
+
+# ── vocabulary contract ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_coarse_vocab_is_the_four_tractable_types():
+    assert frozenset(
+        {"duplicate", "contradicts", "succeeded_by", "distinct"}
+    ) == COARSE_RELATIONSHIPS
+    # The fine-grained types the OLD linker fabricated must NOT be emittable.
+    for fine in ("extends", "supports", "elaborates", "related_to"):
+        assert fine not in COARSE_RELATIONSHIPS
+
+
+# ── single-pair classification ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_parses_valid_contradicts_verdict():
+    router = _router(
+        json.dumps(
+            {"relationship": "contradicts", "confidence": 0.9, "reasoning": "opposite numbers"}
+        )
+    )
+    v = await classify_relationship(router, "revenue up 10%", "revenue down 10%")
+    assert v["relationship"] == "contradicts"
+    assert v["confidence"] == 0.9
+    assert v["reasoning"]
+
+
+@pytest.mark.asyncio
+async def test_parses_succeeded_by_with_fence_stripped():
+    router = _router('```json\n{"relationship":"succeeded_by","confidence":0.7}\n```')
+    v = await classify_relationship(router, "old truth", "new truth", newer="b")
+    assert v["relationship"] == "succeeded_by"
+    assert v["confidence"] == 0.7
+
+
+@pytest.mark.asyncio
+async def test_llm_failure_defaults_distinct_zero_conf():
+    router = _router(None, success=False, error="timeout")
+    v = await classify_relationship(router, "a", "b")
+    assert v["relationship"] == "distinct"
+    assert v["confidence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_bad_json_defaults_distinct_zero_conf():
+    router = _router("not json at all")
+    v = await classify_relationship(router, "a", "b")
+    assert v["relationship"] == "distinct"
+    assert v["confidence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_out_of_vocab_verdict_coerced_to_distinct():
+    # 'extends' is deliberately excluded — an LLM that emits it must NOT leak a
+    # fine-grained (unreliable) type through as truth.
+    router = _router(json.dumps({"relationship": "extends", "confidence": 0.85}))
+    v = await classify_relationship(router, "a", "b")
+    assert v["relationship"] == "distinct"
+    assert v["confidence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_confidence_clamped_to_unit_interval():
+    router = _router(json.dumps({"relationship": "duplicate", "confidence": 1.7}))
+    v = await classify_relationship(router, "a", "b")
+    assert v["relationship"] == "duplicate"
+    assert v["confidence"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_missing_confidence_defaults_low_not_high():
+    # A verdict with no confidence must not be trusted as high-confidence.
+    router = _router(json.dumps({"relationship": "duplicate"}))
+    v = await classify_relationship(router, "a", "b")
+    assert v["relationship"] == "duplicate"
+    assert v["confidence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_uses_the_dedicated_call_site_id():
+    router = _router(json.dumps({"relationship": "distinct", "confidence": 0.5}))
+    await classify_relationship(router, "a", "b")
+    call_site = router.route_call.await_args.args[0]
+    assert call_site == "dream_cycle_relationship_classify"
+
+
+# ── batched classification ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_batch_returns_verdict_per_pair_aligned_by_index():
+    router = _router(
+        json.dumps(
+            [
+                {"pair_id": 0, "relationship": "duplicate", "confidence": 0.9},
+                {"pair_id": 1, "relationship": "distinct", "confidence": 0.6},
+            ]
+        )
+    )
+    pairs = [("a0", "b0"), ("a1", "b1")]
+    verdicts = await classify_relationships(router, pairs)
+    assert len(verdicts) == 2
+    assert verdicts[0]["relationship"] == "duplicate"
+    assert verdicts[1]["relationship"] == "distinct"
+
+
+@pytest.mark.asyncio
+async def test_batch_bad_json_all_default_distinct():
+    router = _router("garbage not json")
+    pairs = [("a0", "b0"), ("a1", "b1")]
+    verdicts = await classify_relationships(router, pairs)
+    assert len(verdicts) == 2
+    assert all(v["relationship"] == "distinct" and v["confidence"] == 0.0 for v in verdicts)
+
+
+@pytest.mark.asyncio
+async def test_batch_missing_pair_defaults_distinct():
+    # LLM only returned a verdict for pair 0 — pair 1 must fail safe.
+    router = _router(json.dumps([{"pair_id": 0, "relationship": "contradicts", "confidence": 0.8}]))
+    pairs = [("a0", "b0"), ("a1", "b1")]
+    verdicts = await classify_relationships(router, pairs)
+    assert verdicts[0]["relationship"] == "contradicts"
+    assert verdicts[1]["relationship"] == "distinct"
+    assert verdicts[1]["confidence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_batch_empty_pairs_returns_empty():
+    router = _router(json.dumps([]))
+    verdicts = await classify_relationships(router, [])
+    assert verdicts == []
+    # No LLM call for an empty batch.
+    router.route_call.assert_not_called()

--- a/tests/test_memory/test_relationship_classifier.py
+++ b/tests/test_memory/test_relationship_classifier.py
@@ -173,3 +173,45 @@ async def test_batch_empty_pairs_returns_empty():
     assert verdicts == []
     # No LLM call for an empty batch.
     router.route_call.assert_not_called()
+
+
+# ── Codex round-1 findings (2026-08-11) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_nan_confidence_rejected_to_zero_not_one():
+    # json.loads accepts bare NaN; min(1.0, nan) returns 1.0 in Python, so an
+    # unguarded clamp would make a NaN verdict MAXIMALLY trusted (Codex P2).
+    router = _router('{"relationship": "duplicate", "confidence": NaN}')
+    v = await classify_relationship(router, "a", "b")
+    assert v["relationship"] == "duplicate"
+    assert v["confidence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_infinite_confidence_rejected_to_zero():
+    router = _router('{"relationship": "contradicts", "confidence": Infinity}')
+    v = await classify_relationship(router, "a", "b")
+    assert v["confidence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_failsafe_verdicts_carry_failed_marker():
+    # Consumers (the probe's tally, MW-5) must be able to tell "genuinely
+    # distinct" from "classification failed" (Codex P1 on the probe tally).
+    router = _router("not json at all")
+    v = await classify_relationship(router, "a", "b")
+    assert v["failed"] is True
+    ok = _router(json.dumps({"relationship": "distinct", "confidence": 0.8}))
+    v2 = await classify_relationship(ok, "a", "b")
+    assert v2.get("failed") is not True
+
+
+@pytest.mark.asyncio
+async def test_batch_renders_per_pair_newer_hint():
+    # Chronology must survive batching (Codex P2): succeeded_by direction
+    # depends on which memory is newer.
+    router = _router(json.dumps([{"pair_id": 0, "relationship": "succeeded_by", "confidence": 0.9}]))
+    await classify_relationships(router, [("old fact", "new fact")], newers=["b"])
+    prompt = router.route_call.await_args.args[1][0]["content"]
+    assert "NEWER" in prompt

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -167,7 +167,8 @@ def test_load_full_yaml(monkeypatch):
     # added (entity-node merge-vs-distinct drainer).
     # 2026-08-07: 59 → 60 after 41_reflection_json_salvage added (deep-reflection
     # prose-output salvage retry).
-    assert len(cfg.call_sites) == 60
+    assert len(cfg.call_sites) == 61
+    assert "dream_cycle_relationship_classify" in cfg.call_sites  # MW-2 classifier (2026-08-10)
     assert "41_reflection_json_salvage" in cfg.call_sites  # deep-reflection salvage (2026-08-07)
     assert cfg.call_sites["repo_pulse"].dispatch == "cli"
     assert cfg.call_sites["repo_pulse"].chain == []


### PR DESCRIPTION
## What

The MW-2 **lean keystone** of the memory-judgment architecture — measurement-first scope:

1. **`memory/relationship_classifier.py`** (new): reusable coarse relationship-judgment function — `{duplicate, contradicts, succeeded_by, distinct}` + confidence, batched variant, fail-safe `distinct@0.0` on any LLM/parse failure, out-of-vocab coercion, bool-confidence rejection. Generalizes `entity_resolution.check_semantic_overlap`; call site `dream_cycle_relationship_classify` (free-SLM chain, `wired: False` — the dream-cycle merge gate is the intended consumer).
2. **Migration 0082**: five NULLable verdict-stamping columns on `memory_links` (`proposed_type`/`confidence`/`classifier`/`review_state`/`safe_for_boost`) via plain guarded ALTERs, mirrored on **both** schema build paths. NULL `safe_for_boost` = boost-eligible (legacy default); **no backfill, CHECK and 3-col PK unchanged — test-locked**. `crud.create()` gains five optional kwargs defaulting `None`; all 6 production call sites enumerated — zero behavior change.
3. **`scripts/dev/mw2_classifier_probe.py`** (new, dev-only): read-only measurement — snapshots the DB (online-backup API from a `mode=ro` source), samples real similarity edges, classifies via the real provider chain, reports verdict distribution + confidence + a hand-scorable sample. Cross-process-deterministic sampling (md5 stable key; builtin `hash()` is PEP-456 salted — review finding, fixed).

## Why lean (what was deliberately NOT built)

Verification showed recall ranking never reads stored link types (`neighbors_of` ranks by strength; type matters only via the `contradicts` deny-list), and the merge gate needs the classifier *function*, not a reclassified stored graph. Measurement on a live-install DB copy (n=300 similarity edges, real provider): **76.7% distinct / 16.7% duplicate / 5.3% succeeded_by / 1.3% contradicts**; hand-scoring found `duplicate` ~80% accurate but `contradicts` **over-called** (bug↔fix pairs misread) — so consumers must adversarially challenge contradicts verdicts before acting (spec updated). The heavy machinery (new candidate link type, CHECK table rebuild, hot-path write change, boost gating, full reclassification) is evidence-parked behind a tracked follow-up until a real consumer emerges.

## Verification

- RED-first: 13 classifier + 7 migration tests (each seen failing first).
- Collateral: 1553-test sweep (full `test_db/` + memory link/graph/store guards) green; ruff clean.
- E2E: 0082 applied to a live-install DB copy — all rows preserved, 673ms, idempotent re-run 9ms, PK/CHECK byte-identical, stamped insert + legacy-NULL semantics verified.
- Classifier live E2E: the n=300 probe run itself (real provider chain, real stored pairs).
- Review: 1 round, 1 finding (probe sample determinism), fixed + cross-process-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)