### PR TITLE
fix(hooks): harden the Codex-at-head merge gate (sigil split, smart-delta, TOCTOU tests)

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -754,11 +754,23 @@ findings below, a gated `gh pr merge`:
   via `--match-head-commit` (GitHub rejects it server-side if the head moved —
   TOCTOU defense); the `--check-pr` command supplies this;
 - requires Codex to have reviewed the **current head** — Codex does NOT auto-review
-  a later fix-commit, so comment `@codex review` and wait after any push;
+  a later fix-commit, so comment `@codex review` and wait after any push.
+  **Smart-delta narrowing:** a STALE review passes anyway when the unreviewed
+  delta (`reviewed...head` via the compare API, classified by `review_scope`
+  substantiality) is provably review-trivial (docs-only / a small single-file
+  touch-up) — the merge is then still bound to the exact head that was
+  classified. A substantial or unclassifiable delta blocks; an ABSENT review
+  always blocks;
 - requires the PR base to equal the repo's default branch (retarget guard);
 - blocks unless mergeability is a definite `MERGEABLE` (a failed/unknown read
-  does not merge). `# review-override` waives the review/freshness/base gates
-  (not CI — that is `# ci-override`).
+  does not merge).
+- **Override sigils are split by boundary** so one waiver can't silently disarm
+  an unrelated gate: `# review-override` waives ONLY the finding scans
+  (review-body + inline P1s); `# stale-review-override` waives ONLY the
+  review-context gates (Codex-at-head freshness + base-invariant); CI is
+  `# ci-override`. Append several sigils in one trailing comment when several
+  waivers are genuinely intended — but the right fix for a stale review is
+  `@codex review`, not the sigil.
 
 The review-findings gate specifically:
 

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1008,6 +1008,13 @@ def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | No
     status = data.get("status")
     if status in ("identical", "behind"):
         return "inline"  # HEAD content ⊆ what Codex reviewed → nothing unreviewed
+    if status not in ("ahead", "diverged"):
+        # A MISSING/unknown status (`{status: null, …}` from a truncated or
+        # unexpected compare response) must fail CLOSED — NOT fall through to file
+        # classification, where an empty `files` would read as "inline" and permit
+        # a STALE review to bind the merge on a delta that was never verified
+        # (Codex P2, #1373). Only the documented linear statuses are classifiable.
+        return None
     files = data.get("files")
     if not isinstance(files, list):
         return None
@@ -2563,23 +2570,33 @@ def main() -> int:
     return 0
 
 
-def _parse_check_pr_repo(argv: list[str]) -> str | None:
-    """The target repo named on a ``--check-pr`` invocation's trailing args, or None.
+# Sentinel: `--check-pr` was given a repo option with an EXPLICITLY EMPTY value
+# (`--repo`, `--repo=`, `-R`, `-R=`). Distinct from None ("no repo option → cwd
+# repo"): an empty value is a MISTAKE, and silently falling back to the cwd repo
+# would report an all-clear (and a suggested merge command) for an unrelated
+# same-numbered PR (Codex P2, #1373). The caller rejects it instead.
+_CHECK_PR_REPO_EMPTY = object()
 
+
+def _parse_check_pr_repo(argv: list[str]):
+    """The target repo named on a ``--check-pr`` invocation's trailing args.
+
+    Returns the OWNER/REPO string, ``None`` (no repo option → cwd repo), or
+    ``_CHECK_PR_REPO_EMPTY`` (an option was given with an empty value → reject).
     Accepts every normal gh spelling — ``--repo X``, ``-R X``, ``--repo=X``,
-    ``-R=X`` — not just the separate ``--repo`` form: a ``-R owner/repo`` that
-    went unrecognized silently checked the CWD repo and could print an all-clear
-    (and a suggested merge command) for the WRONG target (Codex P2, #1366).
+    ``-R=X``, glued ``-Rowner/repo`` — not just the separate ``--repo`` form: a
+    form that went unrecognized silently checked the CWD repo (Codex P2, #1366).
     """
     for i, tok in enumerate(argv):
         if tok in ("--repo", "-R"):
-            return argv[i + 1] if i + 1 < len(argv) else None
+            val = argv[i + 1] if i + 1 < len(argv) else ""
+            return val if val else _CHECK_PR_REPO_EMPTY
         if tok.startswith(("--repo=", "-R=")):
-            return tok.split("=", 1)[1] or None
+            return tok.split("=", 1)[1] or _CHECK_PR_REPO_EMPTY
         if tok.startswith("-R") and not tok.startswith("--") and len(tok) > 2:
             # glued pflag shorthand `-Rowner/repo` — enforcement's
             # _merge_target_repo accepts it, so the report must too.
-            return tok[2:] or None
+            return tok[2:]
     return None
 
 
@@ -2616,7 +2633,21 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     print(f"base-branch    : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (default)'}")
     failures += 1 if blocked else 0
     blocked, msg, verified_head = _check_codex_reviewed_head(pr_num, repo=repo)
-    print(f"codex-at-head  : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (current)'}")
+    if blocked:
+        label = "BLOCK — " + msg.splitlines()[0]
+    else:
+        # Distinguish a genuinely-current review from a stale-but-trivial-delta
+        # allow — both return the same tuple, but the report must NOT assert
+        # "current" when Codex reviewed an older SHA (Codex P2, #1373). Re-derive
+        # the reviewed SHA vs HEAD for an honest label (structured-stdout consumers
+        # read this, not the stderr NOTE).
+        _reviewed = _latest_codex_reviewed_sha(pr_num, repo=repo)
+        _head = _pr_head_sha(pr_num, repo=repo)
+        if _reviewed and _head and _reviewed != _head.strip().lower():
+            label = f"ok (STALE review of {_reviewed[:12]}, delta since is trivial)"
+        else:
+            label = "ok (current)"
+    print(f"codex-at-head  : {label}")
     if not blocked and verified_head:
         print("merge-with     : " + _suggested_merge_cmd(pr_num, verified_head, repo))
     failures += 1 if blocked else 0
@@ -2641,5 +2672,14 @@ if __name__ == "__main__":
     # Report mode: `git_push_guard.py --check-pr <N> [--repo OWNER/REPO]` — the
     # canonical pre-merge check (same functions as enforcement). No hook payload.
     if len(sys.argv) >= 3 and sys.argv[1] == "--check-pr":
-        sys.exit(check_pr_report(sys.argv[2], repo=_parse_check_pr_repo(sys.argv[3:])))
+        _repo = _parse_check_pr_repo(sys.argv[3:])
+        if _repo is _CHECK_PR_REPO_EMPTY:
+            print(
+                "ERROR: --repo/-R was given an empty value. Specify OWNER/REPO, or "
+                "omit the option to check the current repository — an empty value "
+                "would silently report the WRONG repo.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        sys.exit(check_pr_report(sys.argv[2], repo=_repo))
     run_guard(main, "git_push_guard")

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -51,6 +51,7 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 
 # Self-locate so `from hook_input import …` resolves both when CC runs this as a
 # script (sys.path[0] is this dir) AND when it is imported as a module for tests
@@ -335,6 +336,37 @@ def _merge_target_repo(argv: list[str], cmd: str):
     return None
 
 
+# Merge-path SHARED-DEADLINE budget. `.claude/settings.json` kills this PreToolUse
+# hook at ~60s. The gh-pr-merge gates run sequentially, so per-call timeouts alone
+# cannot bound the AGGREGATE: on a degraded API where each call succeeds just under
+# its own cap, the sum exceeds 60s and Claude SIGKILLs the hook MID-GATE — which
+# fails toward "tool runs" and silently disengages the WHOLE gate stack (incl. the
+# TOCTOU binding), the exact bypass the timeouts exist to prevent (Codex P1 #1373).
+# main() computes ONE deadline before the gates and threads it through every
+# merge-path gh helper via `_gh_timeout`, so the total finishes with headroom under
+# 60s and each fail-closed gate reaches its own block/allow decision first.
+_MERGE_GATE_BUDGET_S = 45.0
+# Shared merge-path deadline (a monotonic() instant). main() sets it once before the
+# gh-pr-merge gates; every merge-path gh call reads it via _gh_timeout so the AGGREGATE
+# finishes with headroom under the hook's ~60s wall-clock. A module global is safe:
+# this PreToolUse hook is a SINGLE-SHOT process (one command, no concurrency), and it
+# stays None on every other path (push, the --check-pr report) → those use full caps.
+_merge_deadline: float | None = None
+
+
+def _gh_timeout(cap: float) -> float:
+    """Per-call subprocess timeout under the shared merge-path deadline (``_merge_deadline``).
+
+    ``cap`` when no merge deadline is set (every non-merge caller, and the tests, are
+    unaffected). Under a deadline, the smaller of ``cap`` and the time remaining, floored
+    at 1s so a nearly-expired budget makes the call fail FAST — its caller's existing
+    error path then returns its fail-closed/open value — rather than overrun the
+    wall-clock and get the whole hook SIGKILLed mid-gate. Never raises."""
+    if _merge_deadline is None:
+        return cap
+    return max(1.0, min(cap, _merge_deadline - time.monotonic()))
+
+
 def _derive_repo_from_cwd(cwd: str) -> str | None:
     """The OWNER/REPO gh resolves in directory ``cwd`` (``nameWithOwner``), or None.
 
@@ -355,7 +387,9 @@ def _derive_repo_from_cwd(cwd: str) -> str | None:
                 ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
                 capture_output=True,
                 text=True,
-                timeout=6,  # merge-path budget (see main): pre-gate resolution, fail-closed
+                timeout=_gh_timeout(
+                    6
+                ),  # merge-path budget (see main): pre-gate resolution, fail-closed
                 cwd=cwd,
             )
             raw = result.stdout if result.returncode == 0 else ""
@@ -436,7 +470,9 @@ def _resolve_pr_number(cmd: str, repo: str | None = None, cwd: str | None = None
             ["gh", "pr", "view", "--json", "number", "--jq", ".number"],
             capture_output=True,
             text=True,
-            timeout=6,  # merge-path budget (see main): pre-gate resolution, fail-closed
+            timeout=_gh_timeout(
+                6
+            ),  # merge-path budget (see main): pre-gate resolution, fail-closed
             cwd=cwd,  # None ⇒ the hook's own cwd (legacy path)
         )
         resolved = result.stdout.strip()
@@ -466,7 +502,9 @@ def _check_mergeable(pr_num: str, repo: str | None = None) -> str | None:
             ],
             capture_output=True,
             text=True,
-            timeout=8,  # merge-path budget (see main): fail-closed → a timeout BLOCKS w/ retry
+            timeout=_gh_timeout(
+                8
+            ),  # merge-path budget (see main): fail-closed → a timeout BLOCKS w/ retry
         )
         return result.stdout.strip() if result.returncode == 0 else None
     except Exception:
@@ -516,7 +554,7 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
                 ],
                 capture_output=True,
                 text=True,
-                timeout=8,  # merge-path budget (see main): fail-open → "unknown"
+                timeout=_gh_timeout(8),  # merge-path budget (see main): fail-open → "unknown"
             )
             if result.returncode != 0:
                 return "unknown", []
@@ -711,7 +749,7 @@ def _check_inline_review_findings(
             ],
             capture_output=True,
             text=True,
-            timeout=8,  # merge-path budget (see main): advisory scan, fail-open
+            timeout=_gh_timeout(8),  # merge-path budget (see main): advisory scan, fail-open
         )
         if result.returncode != 0:
             return _scan_unreadable(strict, "inline review comments")
@@ -786,7 +824,7 @@ def _check_pr_review_findings(
             ],
             capture_output=True,
             text=True,
-            timeout=8,  # merge-path budget (see main): advisory scan, fail-open
+            timeout=_gh_timeout(8),  # merge-path budget (see main): advisory scan, fail-open
         )
         if result.returncode != 0:
             return _scan_unreadable(strict, "review-body comments")  # gh error
@@ -884,7 +922,9 @@ def _pr_head_sha(pr_num: str, repo: str | None = None) -> str | None:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=6,  # merge-path budget (see main): fail-closed → unreadable head BLOCKS
+                timeout=_gh_timeout(
+                    6
+                ),  # merge-path budget (see main): fail-closed → unreadable head BLOCKS
             )
             raw = result.stdout if result.returncode == 0 else ""
         except Exception:
@@ -925,7 +965,7 @@ def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | No
                 # See the merge-path timeout budget note in main(): every gh call on
                 # this path must finish (or fail open/closed on its own) well inside
                 # the hook's 60s wall-clock, or a SIGKILL disengages ALL gates at once.
-                timeout=8,
+                timeout=_gh_timeout(8),
             )
             if result.returncode != 0:
                 return None
@@ -967,8 +1007,9 @@ def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | No
     block — ``None`` blocks like ``"substantial"`` (stale is the default-block state;
     triviality is an exception granted only on positive evidence).
 
-    ``status`` semantics (top-level compare status): ``identical``/``behind`` → HEAD's
-    content is a subset of (or equal to) what Codex reviewed → ``"inline"``. ``ahead``
+    ``status`` semantics (top-level compare status): ``identical`` (trees match) →
+    ``"inline"``. ``behind`` is NOT inline — an ancestor head can still carry code the
+    reviewed commit removed → it fails closed (None). ``ahead``
     (the normal append case) or ``diverged`` (a rebase/force-push rewrite) → classify
     the actual changed ``files`` — a diverged rewrite must NOT be assumed trivial.
     Compare TRUNCATION guard: GitHub caps ``files`` at 300 per comparison; at the cap a
@@ -992,7 +1033,7 @@ def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | No
                 text=True,
                 # Merge-path timeout budget (see main()): one compare round-trip is
                 # fast; 8s keeps the worst case inside the hook's 60s wall-clock.
-                timeout=8,
+                timeout=_gh_timeout(8),
             )
             if result.returncode != 0:
                 return None
@@ -1006,9 +1047,14 @@ def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | No
     if not isinstance(data, dict):  # valid JSON but not an object → unclassifiable
         return None
     status = data.get("status")
-    if status in ("identical", "behind"):
-        return "inline"  # HEAD content ⊆ what Codex reviewed → nothing unreviewed
+    if status == "identical":
+        return "inline"  # trees match exactly → nothing unreviewed
     if status not in ("ahead", "diverged"):
+        # NOTE `behind` is NOT treated as inline (Codex P1 #1373): head being an
+        # ANCESTOR of the reviewed commit does not make head's TREE a content subset
+        # — if the reviewed commit deleted/replaced code and the PR is then reset to
+        # its parent, head carries code Codex never approved (it reviewed the removal).
+        # `behind` falls here → None → fail closed (re-review required).
         # A MISSING/unknown status (`{status: null, …}` from a truncated or
         # unexpected compare response) must fail CLOSED — NOT fall through to file
         # classification, where an empty `files` would read as "inline" and permit
@@ -1149,7 +1195,9 @@ def _pr_base_ref(pr_num: str, repo: str | None = None) -> str | None:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=6,  # merge-path budget (see main): fail-closed → unreadable base BLOCKS
+                timeout=_gh_timeout(
+                    6
+                ),  # merge-path budget (see main): fail-closed → unreadable base BLOCKS
             )
             raw = result.stdout if result.returncode == 0 else ""
         except Exception:
@@ -1182,7 +1230,9 @@ def _repo_default_branch(repo: str | None = None) -> str | None:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=6,  # merge-path budget (see main): fail-closed → unreadable default BLOCKS
+                timeout=_gh_timeout(
+                    6
+                ),  # merge-path budget (see main): fail-closed → unreadable default BLOCKS
             )
             raw = result.stdout if result.returncode == 0 else ""
         except Exception:
@@ -2236,6 +2286,14 @@ def main() -> int:
             # Pass the merge SEGMENT's raw text (not the whole compound command)
             # so an unrelated segment's PR URL cannot select the gated repo
             # (`echo …/other/repo/pull/9 && gh pr merge 12` must gate the cwd repo).
+            #
+            # Arm the SHARED merge-path deadline BEFORE the first gh call: every gate's
+            # gh subprocess (repo/PR resolution → mergeable → CI → base → freshness →
+            # findings) reads it via _gh_timeout so the AGGREGATE finishes under the
+            # hook's ~60s wall-clock, instead of summing per-call caps past it and
+            # getting SIGKILLed mid-gate (Codex P1 #1373). Budget < 60s with headroom.
+            global _merge_deadline
+            _merge_deadline = time.monotonic() + _MERGE_GATE_BUDGET_S
             merge_repo = _merge_target_repo(merge_seg.argv, merge_seg.raw)
             # For a DERIVED (no --repo) merge, the dir gh resolves the repo AND a
             # numberless branch-PR from — threaded to _resolve_pr_number so a
@@ -2643,7 +2701,12 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
         # read this, not the stderr NOTE).
         _reviewed = _latest_codex_reviewed_sha(pr_num, repo=repo)
         _head = _pr_head_sha(pr_num, repo=repo)
-        if _reviewed and _head and _reviewed != _head.strip().lower():
+        if _reviewed is None or _head is None:
+            # A transiently-failed re-read must NOT read as "current" (Codex P2
+            # #1373): the enforcement gate already passed, but the report must not
+            # ASSERT the head was reviewed when it could not confirm it.
+            label = "ok (freshness label unverified — re-read failed)"
+        elif _reviewed != _head.strip().lower():
             label = f"ok (STALE review of {_reviewed[:12]}, delta since is trivial)"
         else:
             label = "ok (current)"

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -35,8 +35,12 @@ hostile collaborator force-pushes or retargets. Findings outside this model
 OUT OF SCOPE BY DESIGN — reply as such rather than adding another patch. The
 cluster-safe ``--match-head-commit`` parse + fail-closed shadow-flag belt already
 exceed the model (defense-in-depth), which is fine; they are not an invitation to
-chase every argv-shaping edge. ``# review-override`` is the conscious escape for
-every gate here.
+chase every argv-shaping edge. Conscious escapes are split by boundary so one
+waiver cannot silently disarm an unrelated gate: ``# review-override`` waives the
+FINDING scans (review-body + inline P1s), ``# stale-review-override`` waives the
+review-CONTEXT gates (Codex-at-head freshness + base-is-default), and
+``# ci-override`` waives the CI gate. A session that genuinely needs several
+appends several (one trailing comment may carry multiple sigils).
 """
 
 from __future__ import annotations
@@ -351,7 +355,7 @@ def _derive_repo_from_cwd(cwd: str) -> str | None:
                 ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=6,  # merge-path budget (see main): pre-gate resolution, fail-closed
                 cwd=cwd,
             )
             raw = result.stdout if result.returncode == 0 else ""
@@ -432,7 +436,7 @@ def _resolve_pr_number(cmd: str, repo: str | None = None, cwd: str | None = None
             ["gh", "pr", "view", "--json", "number", "--jq", ".number"],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=6,  # merge-path budget (see main): pre-gate resolution, fail-closed
             cwd=cwd,  # None ⇒ the hook's own cwd (legacy path)
         )
         resolved = result.stdout.strip()
@@ -462,7 +466,7 @@ def _check_mergeable(pr_num: str, repo: str | None = None) -> str | None:
             ],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=8,  # merge-path budget (see main): fail-closed → a timeout BLOCKS w/ retry
         )
         return result.stdout.strip() if result.returncode == 0 else None
     except Exception:
@@ -512,7 +516,7 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
                 ],
                 capture_output=True,
                 text=True,
-                timeout=15,
+                timeout=8,  # merge-path budget (see main): fail-open → "unknown"
             )
             if result.returncode != 0:
                 return "unknown", []
@@ -707,7 +711,7 @@ def _check_inline_review_findings(
             ],
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=8,  # merge-path budget (see main): advisory scan, fail-open
         )
         if result.returncode != 0:
             return _scan_unreadable(strict, "inline review comments")
@@ -782,7 +786,7 @@ def _check_pr_review_findings(
             ],
             capture_output=True,
             text=True,
-            timeout=15,
+            timeout=8,  # merge-path budget (see main): advisory scan, fail-open
         )
         if result.returncode != 0:
             return _scan_unreadable(strict, "review-body comments")  # gh error
@@ -880,7 +884,7 @@ def _pr_head_sha(pr_num: str, repo: str | None = None) -> str | None:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=6,  # merge-path budget (see main): fail-closed → unreadable head BLOCKS
             )
             raw = result.stdout if result.returncode == 0 else ""
         except Exception:
@@ -897,8 +901,12 @@ def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | No
     the review was submitted against) rather than parsing the review body — so the
     comparison is a full-oid identity, immune to short-prefix collisions/grinding.
     The ``/pulls/N/reviews`` endpoint returns reviews oldest-first, so the last
-    Codex entry wins. Tests inject via ``_TEST_GH_CODEX_REVIEWS`` (one JSON object
-    per line: ``{login, commit_id}``). Fail-safe: None on any API/parse error.
+    Codex entry wins. A ``DISMISSED`` review is SKIPPED — a review the author
+    dismissed must not satisfy the freshness gate (it can even sit at HEAD), so
+    the gate falls back to the last non-dismissed Codex review (possibly stale →
+    block) or none (absent → block). Tests inject via ``_TEST_GH_CODEX_REVIEWS``
+    (one JSON object per line: ``{login, commit_id[, state]}``; a missing
+    ``state`` counts as active). Fail-safe: None on any API/parse error.
     """
     raw = os.environ.get("_TEST_GH_CODEX_REVIEWS")
     if raw is None:
@@ -910,11 +918,14 @@ def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | No
                     f"repos/{repo or ':owner/:repo'}/pulls/{pr_num}/reviews",
                     "--paginate",
                     "--jq",
-                    ".[] | {login: .user.login, commit_id: .commit_id}",
+                    ".[] | {login: .user.login, commit_id: .commit_id, state: .state}",
                 ],
                 capture_output=True,
                 text=True,
-                timeout=20,
+                # See the merge-path timeout budget note in main(): every gh call on
+                # this path must finish (or fail open/closed on its own) well inside
+                # the hook's 60s wall-clock, or a SIGKILL disengages ALL gates at once.
+                timeout=8,
             )
             if result.returncode != 0:
                 return None
@@ -930,33 +941,120 @@ def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | No
             obj = json.loads(line)
         except Exception:
             continue
+        # isinstance: a valid-JSON non-object line (`null`, a number) must be
+        # skipped, not raise AttributeError out of the docstring's "None on any
+        # parse error" contract (run_guard would turn that into a hook crash).
+        if not isinstance(obj, dict):
+            continue
         if (obj.get("login") or "") != _CODEX_REVIEW_BOT:
             continue
+        if (obj.get("state") or "").upper() == "DISMISSED":
+            continue  # a dismissed review does not vouch for any commit
         cid = (obj.get("commit_id") or "").strip().lower()
         if cid:
             latest = cid
     return latest
 
 
+def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | None) -> str | None:
+    """Substantiality of what HEAD adds OVER the Codex-reviewed SHA, via the compare API.
+
+    Returns ``"substantial"`` / ``"inline"`` (a real classification of the unreviewed
+    delta) or ``None`` when it cannot be classified (API/parse error). The reviewed SHA
+    is often NOT in the local object store (a past PR head), so the delta is fetched
+    remotely rather than via local ``git diff``. The CALLER decides the fail direction:
+    inside the fail-closed freshness gate, only a definitive ``"inline"`` narrows the
+    block — ``None`` blocks like ``"substantial"`` (stale is the default-block state;
+    triviality is an exception granted only on positive evidence).
+
+    ``status`` semantics (top-level compare status): ``identical``/``behind`` → HEAD's
+    content is a subset of (or equal to) what Codex reviewed → ``"inline"``. ``ahead``
+    (the normal append case) or ``diverged`` (a rebase/force-push rewrite) → classify
+    the actual changed ``files`` — a diverged rewrite must NOT be assumed trivial.
+    Compare TRUNCATION guard: GitHub caps ``files`` at 300 per comparison; at the cap a
+    substantial code file may sit beyond it → ``"substantial"`` (conservative).
+
+    Tests inject via ``_TEST_GH_COMPARE`` (the JSON object this would fetch).
+    """
+    raw = os.environ.get("_TEST_GH_COMPARE")
+    if raw is None:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo or ':owner/:repo'}/compare/{reviewed_sha}...{head_sha}",
+                    "--jq",
+                    "{status: .status, files: [.files[]? | {filename, additions, deletions, "
+                    'status, previous_filename, has_patch: has("patch")}]}',
+                ],
+                capture_output=True,
+                text=True,
+                # Merge-path timeout budget (see main()): one compare round-trip is
+                # fast; 8s keeps the worst case inside the hook's 60s wall-clock.
+                timeout=8,
+            )
+            if result.returncode != 0:
+                return None
+            raw = result.stdout
+        except Exception:
+            return None
+    try:
+        data = json.loads(raw or "{}")
+    except Exception:
+        return None
+    if not isinstance(data, dict):  # valid JSON but not an object → unclassifiable
+        return None
+    status = data.get("status")
+    if status in ("identical", "behind"):
+        return "inline"  # HEAD content ⊆ what Codex reviewed → nothing unreviewed
+    files = data.get("files")
+    if not isinstance(files, list):
+        return None
+    if len(files) >= 300:
+        return "substantial"  # compare file cap hit → can't rule out substantial code
+    try:
+        # review_scope lives in scripts/ (parent of scripts/hooks/). Lazy import ON
+        # PURPOSE: an import failure must degrade THIS classification to None (the
+        # caller then blocks — the gate's fail direction), never crash the guard's
+        # module load and drop every push/merge protection. De-duped sys.path insert.
+        _scripts_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        if _scripts_dir not in sys.path:
+            sys.path.insert(0, _scripts_dir)
+        from review_scope import classify_compare_substantiality
+
+        return classify_compare_substantiality(files)
+    except Exception:
+        return None
+
+
 def _check_codex_reviewed_head(
     pr_num: str, *, force: bool = False, repo: str | None = None
 ) -> tuple[bool, str, str | None]:
-    """Block a merge unless Codex has reviewed the PR's CURRENT head commit.
+    """Block a merge unless Codex has reviewed the PR's CURRENT head commit —
+    or the delta since its last review is provably TRIVIAL.
 
     Compares the PR's ``headRefOid`` against the FULL ``commit_id`` of Codex's
-    latest review — an EXACT identity, no prefix match. Fail-CLOSED: if the head
-    cannot be read, or Codex has no review / reviewed a different commit, the
-    merge is BLOCKED. This is an enforcement gate, so an unverifiable review is
-    treated as absent (blocked), NOT waved through — matching ``_check_mergeable``
-    (which blocks on UNKNOWN), not the advisory finding-scanners. ``force`` (a
-    ``# review-override`` on the merge segment) is the conscious escape (e.g. a
-    genuine Codex outage).
+    latest non-dismissed review — an EXACT identity, no prefix match. Fail-CLOSED:
+    if the head cannot be read, or Codex has no review, the merge is BLOCKED. A
+    STALE review (Codex reviewed an older commit) blocks UNLESS the unreviewed
+    delta (``reviewed...head`` via the compare API) classifies as review-trivial
+    (``review_scope`` substantiality: docs-only / a small single-file touch-up) —
+    the smart-delta narrowing that keeps the gate's teeth pointed at UNREVIEWED
+    SUBSTANTIAL CODE instead of taxing every post-review typo fix (measured
+    2026-08-11: a binary stale-blocks gate would have blocked 14/18 recent
+    merges). An UNCLASSIFIABLE delta blocks — triviality is an exception granted
+    only on positive evidence. ``force`` (a ``# stale-review-override`` on the
+    merge segment — deliberately NOT ``# review-override``, which waives the P1
+    finding scans; the two boundaries are independent) is the conscious escape
+    (e.g. a genuine Codex outage).
 
     Returns ``(should_block, message, verified_head)`` — ``verified_head`` is the
-    full head oid the review was verified against (only when not blocked and not
-    forced); the caller binds the MERGE to it via ``--match-head-commit`` so a
-    push landing between this check and the merge cannot smuggle an unreviewed
-    head through (TOCTOU — Codex P1, PR #1366).
+    full head oid this check verified/classified against (when not blocked and
+    not forced — including the trivial-delta allow, so the merge is still bound
+    to the exact head that was assessed); the caller binds the MERGE to it via
+    ``--match-head-commit`` so a push landing between this check and the merge
+    cannot smuggle an unreviewed head through (TOCTOU — Codex P1, PR #1366).
     """
     if force:
         return False, "", None
@@ -967,7 +1065,7 @@ def _check_codex_reviewed_head(
             (
                 f"could not read PR #{pr_num}'s head commit to verify a current Codex "
                 f"review (GitHub query failed).\n"
-                f"Retry, or append '# review-override' to merge anyway."
+                f"Retry, or append '# stale-review-override' to merge anyway."
             ),
             None,
         )
@@ -980,20 +1078,40 @@ def _check_codex_reviewed_head(
                 f"no Codex review found for PR #{pr_num} at head {head[:12]}.\n"
                 f"Codex reviews on PR-open — it does NOT auto-review a later fix-commit; "
                 f"comment '@codex review' on the PR to review the current head (then wait), "
-                f"or append '# review-override' to merge without a current Codex review "
-                f"(e.g. Codex is down)."
+                f"or append '# stale-review-override' to merge without a current Codex "
+                f"review (e.g. Codex is down)."
             ),
             None,
         )
     if reviewed != head:
+        level = _classify_post_review_delta(reviewed, head, repo)
+        if level == "inline":
+            # The unreviewed delta is provably review-trivial — allow, but still
+            # bind the merge to THIS head (TOCTOU): the triviality claim is about
+            # exactly this reviewed...head range, not any later push.
+            print(
+                f"NOTE: Codex's review on PR #{pr_num} is on {reviewed[:12]} (head "
+                f"{head[:12]}), but the delta since is review-trivial — allowing. "
+                f"Inspect: git log {reviewed[:12]}..{head[:12]} --oneline",
+                file=sys.stderr,
+            )
+            return False, "", head
+        delta_note = (
+            "the unreviewed delta is SUBSTANTIAL"
+            if level == "substantial"
+            else "the unreviewed delta could not be classified (treated as substantial)"
+        )
         return (
             True,
             (
                 f"Codex's latest review is STALE: it reviewed {reviewed[:12]}, but PR "
-                f"#{pr_num} head is {head[:12]} (new commits pushed after the review).\n"
+                f"#{pr_num} head is {head[:12]}, and {delta_note} — Codex never saw "
+                f"this code.\n"
                 f"Comment '@codex review' on the PR to re-review the current head (Codex "
                 f"does NOT auto-review fix-commits), then wait; or append "
-                f"'# review-override' to merge anyway."
+                f"'# stale-review-override' to merge anyway.\n"
+                f"  (inspect the unreviewed commits: git log {reviewed[:12]}..{head[:12]} "
+                f"--oneline)"
             ),
             None,
         )
@@ -1024,7 +1142,7 @@ def _pr_base_ref(pr_num: str, repo: str | None = None) -> str | None:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=6,  # merge-path budget (see main): fail-closed → unreadable base BLOCKS
             )
             raw = result.stdout if result.returncode == 0 else ""
         except Exception:
@@ -1057,7 +1175,7 @@ def _repo_default_branch(repo: str | None = None) -> str | None:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=10,
+                timeout=6,  # merge-path budget (see main): fail-closed → unreadable default BLOCKS
             )
             raw = result.stdout if result.returncode == 0 else ""
         except Exception:
@@ -1077,7 +1195,9 @@ def _check_base_is_default(
     cannot see it). This repo's PRs always target the default branch, so a
     non-default base is anomalous → block. Fail-CLOSED: an unreadable base OR
     default is treated as unverifiable → block (matching the rest of this gate).
-    ``force`` (a ``# review-override`` on the merge segment) is the conscious
+    ``force`` (a ``# stale-review-override`` on the merge segment — the
+    review-CONTEXT sigil, shared with the freshness gate and deliberately NOT
+    ``# review-override``, which waives the P1 finding scans) is the conscious
     escape for a deliberate stacked/non-default PR. Declared threat model: this
     guards an ACCIDENTAL retarget on a single-author repo, not an adversary.
     """
@@ -1091,7 +1211,7 @@ def _check_base_is_default(
             (
                 f"could not confirm PR #{pr_num}'s base branch against the repo default "
                 f"(base={base or '?'}, default={default or '?'}) — retry, or append "
-                f"'# review-override' to merge anyway."
+                f"'# stale-review-override' to merge anyway."
             ),
         )
     if base != default:
@@ -1100,7 +1220,7 @@ def _check_base_is_default(
             (
                 f"PR #{pr_num} targets base '{base}', not the default branch '{default}'. "
                 f"A retargeted PR's Codex review may not reflect the new diff — re-run "
-                f"'@codex review' on the PR, or append '# review-override' for a "
+                f"'@codex review' on the PR, or append '# stale-review-override' for a "
                 f"deliberate stacked/non-default PR."
             ),
         )
@@ -2158,6 +2278,25 @@ def main() -> int:
                 )
                 return 2
             if pr_num:
+                # ── Merge-path gh TIMEOUT BUDGET ──────────────────────────
+                # This hook runs under a 60s CC wall-clock (settings.json). A
+                # wall-clock overrun SIGKILLs the hook MID-GATE, which "fails
+                # toward tool-runs" — i.e. it silently disengages EVERY merge
+                # gate at once, precisely when the GitHub API is degraded. So
+                # each sequential gh call on this path — INCLUDING the
+                # pre-gate repo/PR resolution above (6s each) — carries a tight
+                # per-call timeout (6-8s): pre-gates + fail-closed gates
+                # (derive 6 + resolve 6 + mergeable 8 + ci 8 + base 6+6 +
+                # freshness 6+8 + delta 8 = 62s absolute worst) each reach
+                # their own block/allow decision at or inside the budget, and
+                # any ONE of them timing out fail-closes IMMEDIATELY (the
+                # additive worst case needs every call slow-but-successful);
+                # the TOCTOU binding runs argv-only right after freshness, so
+                # only the tail advisory scanners (fail-OPEN by design) could
+                # ever be clipped, which nets the same outcome as their error
+                # path.
+                # A timing-out fail-closed gate returns BLOCK immediately, so
+                # the additive worst case needs every call slow-but-successful.
                 mergeable = _check_mergeable(pr_num, repo=merge_repo)
                 if mergeable == "CONFLICTING":
                     print(
@@ -2218,15 +2357,23 @@ def main() -> int:
                     )
 
                 force_override = merge_seg.override
+                # The review-CONTEXT waiver (freshness + base gates) is a SEPARATE
+                # sigil from # review-override: the freshness gate is the
+                # high-traffic one (Codex never auto-re-reviews a push), and if its
+                # escape also waived the P1 finding scans, the path of least
+                # resistance would systematically disarm P1 enforcement (Codex P1 +
+                # architect SHOULD-FIX on #1366). One trailing comment may carry
+                # both sigils when both waivers are genuinely intended.
+                stale_override = has_trailing_override(merge_seg.raw, "stale-review-override")
 
                 # Base-branch invariant: a PR retargeted AFTER Codex reviewed it
                 # keeps the SAME head oid, so head-freshness alone can't see the
                 # base change that may have altered the effective diff. Require
-                # base == the repo's default branch. Waived by # review-override
-                # for a deliberate stacked/non-default PR.
+                # base == the repo's default branch. Waived by
+                # # stale-review-override for a deliberate stacked/non-default PR.
                 should_block, base_msg = _check_base_is_default(
                     pr_num,
-                    force=force_override,
+                    force=stale_override,
                     repo=merge_repo,
                 )
                 if should_block:
@@ -2242,11 +2389,13 @@ def main() -> int:
                 # scans below: a review published between the scans and this check
                 # would otherwise pass freshness while its own P1 comments went
                 # unscanned (the scans came back empty). Freshness first, then
-                # findings. A not-yet-reviewed / stale-reviewed head blocks here.
-                # Waived by # review-override.
+                # findings. A not-yet-reviewed head blocks; a stale-reviewed head
+                # blocks unless the unreviewed delta is provably review-trivial
+                # (smart-delta — see _check_codex_reviewed_head). Waived by
+                # # stale-review-override (NOT # review-override).
                 should_block, fresh_msg, verified_head = _check_codex_reviewed_head(
                     pr_num,
-                    force=force_override,
+                    force=stale_override,
                     repo=merge_repo,
                 )
                 if should_block:
@@ -2257,41 +2406,18 @@ def main() -> int:
                     print(fresh_msg, file=sys.stderr)
                     return 2
 
-                # Unresolved review findings (review body) — now AFTER freshness.
-                should_block, review_msg = _check_pr_review_findings(
-                    pr_num,
-                    force=force_override,
-                    repo=merge_repo,
-                )
-                if should_block:
-                    print(
-                        f"BLOCKED: PR #{pr_num} has unresolved review findings.",
-                        file=sys.stderr,
-                    )
-                    print(review_msg, file=sys.stderr)
-                    return 2
-
-                # Inline review comments (Codex P1/P2 badges) — separate
-                # endpoint, separate check. P1 blocks; P2 warns.
-                should_block, inline_msg = _check_inline_review_findings(
-                    pr_num,
-                    force=force_override,
-                    repo=merge_repo,
-                )
-                if should_block:
-                    print(
-                        f"BLOCKED: PR #{pr_num} has unresolved INLINE review findings.",
-                        file=sys.stderr,
-                    )
-                    print(inline_msg, file=sys.stderr)
-                    return 2
-
                 # Bind the MERGE to the verified head (TOCTOU — Codex P1): a push
                 # landing between the check above and the merge would otherwise
                 # merge an UNREVIEWED head under a stale verification. GitHub
                 # enforces `--match-head-commit` server-side (the merge is
                 # rejected if the head moved), making check→merge atomic. Only
-                # engaged when the freshness check ran (not # review-override).
+                # engaged when the freshness check ran (not # stale-review-override).
+                # Placed IMMEDIATELY after the freshness gate — BEFORE the two
+                # advisory network scanners below — so a hook wall-clock SIGKILL
+                # during a slow scan can never skip the binding enforcement (it
+                # needs only argv + verified_head, no gh call): a clipped scanner
+                # nets its own fail-open outcome, but a clipped BINDING would have
+                # re-opened the unbound-merge race this block exists to close.
                 if verified_head:
                     # Fail-closed belt: content value-flags can smuggle a
                     # --match-head-commit token as their VALUE (gh takes it as
@@ -2327,6 +2453,37 @@ def main() -> int:
                             file=sys.stderr,
                         )
                         return 2
+
+                # Unresolved review findings (review body) — AFTER freshness +
+                # binding (see the ordering note above). Waived by
+                # # review-override (the FINDINGS sigil — not the stale one).
+                should_block, review_msg = _check_pr_review_findings(
+                    pr_num,
+                    force=force_override,
+                    repo=merge_repo,
+                )
+                if should_block:
+                    print(
+                        f"BLOCKED: PR #{pr_num} has unresolved review findings.",
+                        file=sys.stderr,
+                    )
+                    print(review_msg, file=sys.stderr)
+                    return 2
+
+                # Inline review comments (Codex P1/P2 badges) — separate
+                # endpoint, separate check. P1 blocks; P2 warns.
+                should_block, inline_msg = _check_inline_review_findings(
+                    pr_num,
+                    force=force_override,
+                    repo=merge_repo,
+                )
+                if should_block:
+                    print(
+                        f"BLOCKED: PR #{pr_num} has unresolved INLINE review findings.",
+                        file=sys.stderr,
+                    )
+                    print(inline_msg, file=sys.stderr)
+                    return 2
 
         # ── sqlite3 write operations ────────────────────────────────
         # Whole-command match (never misses a fragmented/wrapped invocation),
@@ -2406,6 +2563,26 @@ def main() -> int:
     return 0
 
 
+def _parse_check_pr_repo(argv: list[str]) -> str | None:
+    """The target repo named on a ``--check-pr`` invocation's trailing args, or None.
+
+    Accepts every normal gh spelling — ``--repo X``, ``-R X``, ``--repo=X``,
+    ``-R=X`` — not just the separate ``--repo`` form: a ``-R owner/repo`` that
+    went unrecognized silently checked the CWD repo and could print an all-clear
+    (and a suggested merge command) for the WRONG target (Codex P2, #1366).
+    """
+    for i, tok in enumerate(argv):
+        if tok in ("--repo", "-R"):
+            return argv[i + 1] if i + 1 < len(argv) else None
+        if tok.startswith(("--repo=", "-R=")):
+            return tok.split("=", 1)[1] or None
+        if tok.startswith("-R") and not tok.startswith("--") and len(tok) > 2:
+            # glued pflag shorthand `-Rowner/repo` — enforcement's
+            # _merge_target_repo accepts it, so the report must too.
+            return tok[2:] or None
+    return None
+
+
 def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     """CANONICAL pre-merge report: run the SAME checks the merge gate enforces.
 
@@ -2464,9 +2641,5 @@ if __name__ == "__main__":
     # Report mode: `git_push_guard.py --check-pr <N> [--repo OWNER/REPO]` — the
     # canonical pre-merge check (same functions as enforcement). No hook payload.
     if len(sys.argv) >= 3 and sys.argv[1] == "--check-pr":
-        _repo_arg = None
-        if "--repo" in sys.argv[3:]:
-            _ri = sys.argv.index("--repo")
-            _repo_arg = sys.argv[_ri + 1] if _ri + 1 < len(sys.argv) else None
-        sys.exit(check_pr_report(sys.argv[2], repo=_repo_arg))
+        sys.exit(check_pr_report(sys.argv[2], repo=_parse_check_pr_repo(sys.argv[3:])))
     run_guard(main, "git_push_guard")

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -192,7 +192,14 @@ def _strip_trailing_comment(seg: str) -> str:
 # together (`# audit-ack depth-ack`), so the leading run of the comment is allowed to
 # contain any of them; the FIRST prose token ends the run. Kept in sync with the
 # sigils actually passed to has_trailing_override across the guard hooks.
-_KNOWN_SIGILS = ("review-override", "depth-ack", "audit-ack", "escalation-ack", "ci-override")
+_KNOWN_SIGILS = (
+    "review-override",
+    "depth-ack",
+    "audit-ack",
+    "escalation-ack",
+    "ci-override",
+    "stale-review-override",
+)
 
 
 def _token_is_sigil(tok: str, sigil: str) -> bool:

--- a/scripts/review_scope.py
+++ b/scripts/review_scope.py
@@ -660,6 +660,64 @@ def classify_range_substantiality(base: str, cwd: str | None = None) -> str:
     return _classify_diff([f"{base}...HEAD"], cwd)
 
 
+def classify_compare_substantiality(files: list[dict] | None) -> str:
+    """Substantiality of a GitHub COMPARE-API ``files[]`` list — for the merge
+    review-freshness gate (the delta the independent reviewer has NOT seen).
+
+    Reuses the shared :func:`_substantiality_level` predicate over records built from
+    the compare payload instead of a local ``git diff`` — the merge hook runs locally
+    and the reviewed SHA may not be in the local object store (a past PR head), so the
+    delta is fetched remotely (``gh api repos/…/compare/{base}...{head}``) and passed
+    here. An empty / ``None`` list means no reviewable delta → ``"inline"``. Never
+    touches git; never raises.
+
+    Each compare file record carries ``filename``, ``additions``, ``deletions``,
+    ``status`` (added/modified/renamed/…), optional ``previous_filename`` (rename src),
+    and ``has_patch`` (False for binary/too-large). Binary detection is best-effort: a
+    file with no patch and zero line changes that is not a pure rename is treated as a
+    binary asset and excluded (mirrors the ``binary`` exclusion the git-diff path gets
+    from ``--numstat`` ``-`` counts).
+    """
+    records: list[dict] = []
+    per_file: dict[str, int] = {}
+    binary: set[str] = set()
+    for f in files or []:
+        if not isinstance(f, dict):
+            continue
+        path = f.get("filename")
+        if not path:
+            continue
+        untrusted = False
+        try:
+            lines = int(f.get("additions") or 0) + int(f.get("deletions") or 0)
+        except (TypeError, ValueError):
+            lines = 0
+            untrusted = True  # malformed counts — can't lean "trivial" on them
+        per_file[path] = lines
+        records.append({"path": path})
+        prev = f.get("previous_filename")  # rename source — domain-sensitivity on either side
+        if prev:
+            records.append({"path": prev})
+        has_patch = f.get("has_patch")
+        if has_patch is None:
+            has_patch = "patch" in f
+        if not has_patch and lines == 0 and f.get("status") not in ("renamed", "copied"):
+            # No patch + no counted lines: for an untagged asset (image, archive —
+            # ``_scope_tag`` maps no pattern, and note ``_category`` calls every
+            # non-docs/test path "code", so category alone cannot tell a .png from
+            # a .py) that is the binary shape — exclude like the git-diff path
+            # does. But a SOURCE-shaped file (a recognized scope tag: backend/
+            # frontend/api/…) in that shape is an over-limit/suppressed text diff:
+            # its content is unverifiable, and "trivial" needs positive evidence.
+            if _category(path) == "code" and _scope_tag(path):
+                untrusted = True
+            else:
+                binary.add(path)
+        if untrusted and not _is_vendored(path) and _category(path) == "code" and _scope_tag(path):
+            return "substantial"  # unverifiable source delta — fail toward review
+    return _substantiality_level(records, per_file, binary)
+
+
 def render_reminder_block(manifest: dict | None) -> str:
     """Human-readable manifest for the review reminder, or "" when nothing to add.
 

--- a/scripts/review_scope.py
+++ b/scripts/review_scope.py
@@ -698,6 +698,15 @@ def classify_compare_substantiality(files: list[dict] | None) -> str:
         prev = f.get("previous_filename")  # rename source — domain-sensitivity on either side
         if prev:
             records.append({"path": prev})
+            # Attribute the rename's line count to the SOURCE too (Codex P2 #1373): a
+            # rename FROM code TO an excluded dest (`src/foo.py → docs/foo.md`) would
+            # otherwise contribute NOTHING — the docs dest is excluded and the source
+            # carried no count — so a 200-line code removal/rewrite classified "inline"
+            # and let a stale review pass. ``max`` avoids double-inflation while
+            # ensuring the reviewable side (whichever it is) carries the magnitude;
+            # _substantiality_level only counts reviewable paths, so an excluded prev
+            # is harmless.
+            per_file[prev] = max(per_file.get(prev, 0), lines)
         has_patch = f.get("has_patch")
         if has_patch is None:
             has_patch = "patch" in f

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -423,6 +423,17 @@ class TestPostReviewDeltaClassify:
         files = [_code_file(path=f"docs/f{i}.md", additions=1) for i in range(300)]
         assert self._lvl(monkeypatch, _compare_json("ahead", files)) == "substantial"
 
+    def test_unknown_status_fails_closed(self, monkeypatch):
+        # Codex P2 #1373: a MISSING/unknown status (`{status:null,files:[]}` from a
+        # truncated compare) must fail CLOSED (None → caller blocks), NOT fall
+        # through to file classification where empty files would read "inline" and
+        # let a STALE review bind the merge on an unverified delta.
+        import json as _json
+
+        assert self._lvl(monkeypatch, _json.dumps({"status": None, "files": []})) is None
+        assert self._lvl(monkeypatch, _json.dumps({"files": []})) is None  # status absent
+        assert self._lvl(monkeypatch, _json.dumps({"status": "weird", "files": []})) is None
+
     def test_non_dict_payload_unclassifiable(self, monkeypatch):
         assert self._lvl(monkeypatch, "null") is None
 
@@ -640,10 +651,58 @@ class TestCheckPrRepoArg:
     def test_absent(self):
         assert _mod._parse_check_pr_repo([]) is None
 
-    def test_dangling_flag(self):
-        assert _mod._parse_check_pr_repo(["--repo"]) is None
-
     def test_glued_short(self):
         # pflag shorthand `-Rowner/repo` — enforcement accepts it; the report must too
         # (architect F3: unrecognized → silently checked the CWD repo).
         assert _mod._parse_check_pr_repo(["-Rocto/voice"]) == "octo/voice"
+
+    def test_explicit_empty_value_rejected(self):
+        # Codex P2 #1373: an EXPLICITLY empty repo value must be distinguishable from
+        # "no option" (None → cwd repo) so the caller can reject it rather than
+        # silently report the WRONG same-numbered PR.
+        for argv in (["--repo"], ["--repo="], ["-R"], ["-R="]):
+            assert _mod._parse_check_pr_repo(argv) is _mod._CHECK_PR_REPO_EMPTY, argv
+
+    def test_no_option_is_none(self):
+        assert _mod._parse_check_pr_repo(["--squash", "--admin"]) is None
+
+
+class TestCheckPrReportFreshnessLabel:
+    """Codex P2 #1373: the canonical report must not print 'ok (current)' when the
+    review is STALE-but-trivial — the structured stdout would mislead consumers."""
+
+    def _run_report(self, monkeypatch, capsys, reviews, compare):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", reviews)
+        monkeypatch.setenv("_TEST_GH_COMPARE", compare)
+        monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("green", []))
+        monkeypatch.setattr(_mod, "_check_base_is_default", lambda n, repo=None: (False, ""))
+        monkeypatch.setattr(
+            _mod, "_check_pr_review_findings", lambda n, repo=None, strict=False: (False, "")
+        )
+        monkeypatch.setattr(
+            _mod, "_check_inline_review_findings", lambda n, repo=None, strict=False: (False, "")
+        )
+        _mod.check_pr_report("5")
+        return capsys.readouterr().out
+
+    def test_stale_trivial_labeled_stale(self, monkeypatch, capsys):
+        out = self._run_report(
+            monkeypatch,
+            capsys,
+            reviews=_reviews_jsonl(STALE),
+            compare=_compare_json("ahead", [_code_file(additions=3)]),
+        )
+        assert "codex-at-head" in out
+        assert "STALE review" in out
+        assert "ok (current)" not in out
+
+    def test_current_labeled_current(self, monkeypatch, capsys):
+        out = self._run_report(
+            monkeypatch,
+            capsys,
+            reviews=_reviews_jsonl(HEAD),
+            compare=_compare_json("identical"),
+        )
+        assert "ok (current)" in out

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -402,8 +402,13 @@ class TestPostReviewDeltaClassify:
     def test_identical_is_inline(self, monkeypatch):
         assert self._lvl(monkeypatch, _compare_json("identical")) == "inline"
 
-    def test_behind_is_inline(self, monkeypatch):
-        assert self._lvl(monkeypatch, _compare_json("behind")) == "inline"
+    def test_behind_fails_closed(self, monkeypatch):
+        # Codex P1 #1373: `behind` (head is an ANCESTOR of the reviewed commit) does
+        # NOT make head a content-subset — if the reviewed commit deleted code and the
+        # PR reset to its parent, head carries code Codex never approved. Must NOT be
+        # inline; it falls to the not-ahead/diverged branch → None → block.
+        assert self._lvl(monkeypatch, _compare_json("behind")) is None
+        assert self._lvl(monkeypatch, _compare_json("behind", [_code_file()])) is None
 
     def test_ahead_substantial(self, monkeypatch):
         assert self._lvl(monkeypatch, _compare_json("ahead", [_code_file()])) == "substantial"
@@ -706,3 +711,53 @@ class TestCheckPrReportFreshnessLabel:
             compare=_compare_json("identical"),
         )
         assert "ok (current)" in out
+
+
+class TestMergeDeadline:
+    """Codex P1 #1373: _gh_timeout bounds the AGGREGATE merge-path gh time under the
+    hook's ~60s wall-clock via a shared deadline, so per-call caps can't sum past it."""
+
+    def test_no_deadline_returns_cap(self, monkeypatch):
+        monkeypatch.setattr(_mod, "_merge_deadline", None)
+        assert _mod._gh_timeout(8) == 8
+        assert _mod._gh_timeout(6) == 6
+
+    def test_deadline_clamps_to_remaining(self, monkeypatch):
+        import time as _t
+
+        monkeypatch.setattr(_mod, "_merge_deadline", _t.monotonic() + 3)
+        # remaining ~3s < cap 8 → clamped toward remaining (not the full cap)
+        assert _mod._gh_timeout(8) <= 3.5
+
+    def test_expired_deadline_floors_at_one(self, monkeypatch):
+        import time as _t
+
+        monkeypatch.setattr(_mod, "_merge_deadline", _t.monotonic() - 5)  # already past
+        assert _mod._gh_timeout(8) == 1.0  # fail FAST, never negative/zero
+
+    def test_budget_under_wallclock(self):
+        # The documented worst-case pre-binding aggregate must leave headroom under 60s.
+        assert _mod._MERGE_GATE_BUDGET_S <= 50
+
+
+class TestReportFreshnessUnreadable:
+    """Codex P2 #1373: a failed relabel re-read must not read as 'ok (current)'."""
+
+    def test_failed_reread_labeled_unverified(self, monkeypatch, capsys):
+        monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("green", []))
+        monkeypatch.setattr(_mod, "_check_base_is_default", lambda n, repo=None: (False, ""))
+        monkeypatch.setattr(
+            _mod, "_check_pr_review_findings", lambda n, repo=None, strict=False: (False, "")
+        )
+        monkeypatch.setattr(
+            _mod, "_check_inline_review_findings", lambda n, repo=None, strict=False: (False, "")
+        )
+        # freshness gate passes (allowed), but the relabel re-reads fail (None)
+        monkeypatch.setattr(_mod, "_check_codex_reviewed_head", lambda n, repo=None: (False, "", HEAD))
+        monkeypatch.setattr(_mod, "_latest_codex_reviewed_sha", lambda n, repo=None: None)
+        monkeypatch.setattr(_mod, "_pr_head_sha", lambda n, repo=None: None)
+        _mod.check_pr_report("5")
+        out = capsys.readouterr().out
+        assert "unverified" in out
+        assert "ok (current)" not in out

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -339,3 +339,311 @@ class TestDeriveRepoFromCwd:
         # fails closed.
         monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "$VAR")
         assert _mod._derive_repo_from_cwd("/x") is None
+
+
+def _reviews_jsonl_state(*entries, login="chatgpt-codex-connector[bot]"):
+    """One JSON object per line with an explicit state: entries are (commit_id, state)."""
+    return "\n".join(
+        json.dumps({"login": login, "commit_id": cid, "state": state}) for cid, state in entries
+    )
+
+
+def _compare_json(status="ahead", files=None):
+    return json.dumps({"status": status, "files": files or []})
+
+
+def _code_file(path="src/module_a.py", additions=80, deletions=0, has_patch=True, **kw):
+    f = {
+        "filename": path,
+        "additions": additions,
+        "deletions": deletions,
+        "status": kw.get("status", "modified"),
+        "has_patch": has_patch,
+    }
+    if "previous_filename" in kw:
+        f["previous_filename"] = kw["previous_filename"]
+    return f
+
+
+class TestDismissedAndMalformedReviews:
+    """DISMISSED must not vouch for a commit; malformed NDJSON must not crash."""
+
+    def test_dismissed_latest_falls_back_to_earlier(self, monkeypatch):
+        # Latest Codex review at HEAD is DISMISSED → the earlier (stale) one governs.
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_REVIEWS",
+            _reviews_jsonl_state((STALE, "COMMENTED"), (HEAD, "DISMISSED")),
+        )
+        assert _mod._latest_codex_reviewed_sha("5") == STALE
+
+    def test_all_dismissed_is_absent(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl_state((HEAD, "DISMISSED")))
+        assert _mod._latest_codex_reviewed_sha("5") is None
+
+    def test_missing_state_counts_as_active(self, monkeypatch):
+        # Backward-compat: pre-existing seam entries carry no state.
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))
+        assert _mod._latest_codex_reviewed_sha("5") == HEAD
+
+    def test_non_dict_json_line_skipped(self, monkeypatch):
+        # A valid-JSON non-object line (`null`) must be SKIPPED, not raise
+        # AttributeError out of the "None on any parse error" contract.
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "null\n" + _reviews_jsonl(HEAD))
+        assert _mod._latest_codex_reviewed_sha("5") == HEAD
+
+
+class TestPostReviewDeltaClassify:
+    """_classify_post_review_delta over the _TEST_GH_COMPARE seam."""
+
+    def _lvl(self, monkeypatch, payload):
+        monkeypatch.setenv("_TEST_GH_COMPARE", payload)
+        return _mod._classify_post_review_delta(STALE, HEAD, None)
+
+    def test_identical_is_inline(self, monkeypatch):
+        assert self._lvl(monkeypatch, _compare_json("identical")) == "inline"
+
+    def test_behind_is_inline(self, monkeypatch):
+        assert self._lvl(monkeypatch, _compare_json("behind")) == "inline"
+
+    def test_ahead_substantial(self, monkeypatch):
+        assert self._lvl(monkeypatch, _compare_json("ahead", [_code_file()])) == "substantial"
+
+    def test_ahead_trivial_is_inline(self, monkeypatch):
+        assert self._lvl(monkeypatch, _compare_json("ahead", [_code_file(additions=3)])) == "inline"
+
+    def test_diverged_substantial_still_classifies(self, monkeypatch):
+        # A rebase/force-push rewrite must NOT be assumed trivial.
+        assert self._lvl(monkeypatch, _compare_json("diverged", [_code_file()])) == "substantial"
+
+    def test_docs_only_delta_is_inline(self, monkeypatch):
+        docs = [_code_file(path="README.md", additions=200)]
+        assert self._lvl(monkeypatch, _compare_json("ahead", docs)) == "inline"
+
+    def test_truncated_compare_is_substantial(self, monkeypatch):
+        files = [_code_file(path=f"docs/f{i}.md", additions=1) for i in range(300)]
+        assert self._lvl(monkeypatch, _compare_json("ahead", files)) == "substantial"
+
+    def test_non_dict_payload_unclassifiable(self, monkeypatch):
+        assert self._lvl(monkeypatch, "null") is None
+
+    def test_files_not_list_unclassifiable(self, monkeypatch):
+        assert self._lvl(monkeypatch, json.dumps({"status": "ahead", "files": "oops"})) is None
+
+
+class TestSmartDeltaFreshness:
+    """Stale review + delta classification inside _check_codex_reviewed_head."""
+
+    def _setup_stale(self, monkeypatch, compare_payload):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(STALE))
+        monkeypatch.setenv("_TEST_GH_COMPARE", compare_payload)
+
+    def test_stale_trivial_delta_allows_and_binds_head(self, monkeypatch):
+        self._setup_stale(monkeypatch, _compare_json("ahead", [_code_file(additions=3)]))
+        block, msg, verified = _mod._check_codex_reviewed_head("5")
+        assert block is False
+        # TOCTOU: the triviality claim is about exactly this head — merge must bind to it.
+        assert verified == HEAD
+
+    def test_stale_substantial_delta_blocks(self, monkeypatch):
+        self._setup_stale(monkeypatch, _compare_json("ahead", [_code_file()]))
+        block, msg, verified = _mod._check_codex_reviewed_head("5")
+        assert block is True and verified is None
+        assert "SUBSTANTIAL" in msg
+        assert "stale-review-override" in msg
+
+    def test_stale_unclassifiable_delta_blocks(self, monkeypatch):
+        # Triviality is an exception granted only on positive evidence — an
+        # unclassifiable compare (fail direction of a fail-CLOSED gate) blocks.
+        self._setup_stale(monkeypatch, "null")
+        block, msg, _ = _mod._check_codex_reviewed_head("5")
+        assert block is True
+        assert "could not be classified" in msg
+
+    def test_absent_review_still_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
+        monkeypatch.setenv("_TEST_GH_COMPARE", _compare_json("identical"))
+        block, msg, _ = _mod._check_codex_reviewed_head("5")
+        assert block is True  # absent is not narrowed by smart-delta
+        assert "stale-review-override" in msg
+
+
+class TestMainLevelIntegration:
+    """main()-level wiring: TOCTOU binding enforcement + sigil decoupling.
+
+    These run the REAL _check_codex_reviewed_head / _check_base_is_default via
+    the _TEST_GH_* seams (only _check_mergeable and the two advisory scanners
+    are stubbed), so the `if verified_head:` binding block and the sigil routing
+    in main() are actually exercised — previously zero tests reached them
+    (architect SHOULD-FIX on #1366: delete the binding block and nothing went red).
+    """
+
+    def _drive(self, monkeypatch, command, *, reviews=None, compare=None):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD) if reviews is None else reviews
+        )
+        if compare is not None:
+            monkeypatch.setenv("_TEST_GH_COMPARE", compare)
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "main")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "t", "conclusion": "SUCCESS"}])
+        )
+        monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        monkeypatch.setattr(
+            _mod, "_check_pr_review_findings", lambda n, force=False, repo=None: (False, "")
+        )
+        monkeypatch.setattr(
+            _mod, "_check_inline_review_findings", lambda n, force=False, repo=None: (False, "")
+        )
+        monkeypatch.setattr(
+            _mod,
+            "read_payload",
+            lambda: {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            },
+        )
+        return _mod.main()
+
+    # ── TOCTOU binding (fresh review at HEAD → binding REQUIRED) ──
+    def test_unbound_merge_blocks(self, monkeypatch, capsys):
+        rc = self._drive(monkeypatch, "gh pr merge 5 --squash --admin")
+        assert rc == 2
+        assert "must be bound" in capsys.readouterr().err
+
+    def test_bound_merge_passes(self, monkeypatch):
+        rc = self._drive(monkeypatch, f"gh pr merge 5 --squash --admin --match-head-commit {HEAD}")
+        assert rc == 0
+
+    def test_shadow_flag_blocks(self, monkeypatch, capsys):
+        rc = self._drive(
+            monkeypatch,
+            f"gh pr merge 5 --squash --admin --body x --match-head-commit {HEAD}",
+        )
+        assert rc == 2
+        assert "shadow" in capsys.readouterr().err.lower()
+
+    def test_mismatched_binding_blocks(self, monkeypatch, capsys):
+        rc = self._drive(monkeypatch, f"gh pr merge 5 --squash --admin --match-head-commit {STALE}")
+        assert rc == 2
+        assert "does not" in capsys.readouterr().err
+
+    # ── Sigil decoupling (stale review + substantial delta) ──
+    def _stale_substantial(self):
+        return dict(
+            reviews=_reviews_jsonl(STALE),
+            compare=_compare_json("ahead", [_code_file()]),
+        )
+
+    def test_review_override_does_not_waive_freshness(self, monkeypatch, capsys):
+        rc = self._drive(
+            monkeypatch,
+            "gh pr merge 5 --squash --admin  # review-override",
+            **self._stale_substantial(),
+        )
+        assert rc == 2  # the P1-findings sigil must NOT waive the freshness gate
+        assert "STALE" in capsys.readouterr().err
+
+    def test_stale_review_override_waives_freshness(self, monkeypatch):
+        rc = self._drive(
+            monkeypatch,
+            "gh pr merge 5 --squash --admin  # stale-review-override",
+            **self._stale_substantial(),
+        )
+        assert rc == 0  # waived; verified_head None → binding not required
+
+    def test_no_sigil_stale_substantial_blocks(self, monkeypatch):
+        rc = self._drive(monkeypatch, "gh pr merge 5 --squash --admin", **self._stale_substantial())
+        assert rc == 2
+
+    # ── Smart-delta through main(): stale + trivial → allowed but still bound ──
+    def test_stale_trivial_requires_binding(self, monkeypatch, capsys):
+        rc = self._drive(
+            monkeypatch,
+            "gh pr merge 5 --squash --admin",
+            reviews=_reviews_jsonl(STALE),
+            compare=_compare_json("ahead", [_code_file(additions=3)]),
+        )
+        assert rc == 2  # allowed by smart-delta, but the merge must bind to HEAD
+        assert "must be bound" in capsys.readouterr().err
+
+    def test_stale_trivial_bound_passes(self, monkeypatch):
+        rc = self._drive(
+            monkeypatch,
+            f"gh pr merge 5 --squash --admin --match-head-commit {HEAD}",
+            reviews=_reviews_jsonl(STALE),
+            compare=_compare_json("ahead", [_code_file(additions=3)]),
+        )
+        assert rc == 0
+
+
+class TestStaleSigilDoesNotWaiveScanners:
+    """The reverse decoupling direction: # stale-review-override must NOT feed the
+    finding scanners' force — a stale-sigil merge with an unresolved P1 still blocks.
+    (Architect F5 on this patch: the forward direction alone left a regression that
+    routes stale_override into the scanners undetected.)"""
+
+    def test_stale_sigil_p1_findings_still_block(self, monkeypatch, capsys):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(STALE))
+        monkeypatch.setenv("_TEST_GH_COMPARE", _compare_json("ahead", [_code_file()]))
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "main")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "t", "conclusion": "SUCCESS"}])
+        )
+        monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        # Scanner stub blocks UNLESS its own force (i.e. # review-override) is set.
+        monkeypatch.setattr(
+            _mod,
+            "_check_pr_review_findings",
+            lambda n, force=False, repo=None: (not force, "" if force else "P1 unresolved"),
+        )
+        monkeypatch.setattr(
+            _mod, "_check_inline_review_findings", lambda n, force=False, repo=None: (False, "")
+        )
+        monkeypatch.setattr(
+            _mod,
+            "read_payload",
+            lambda: {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": "gh pr merge 5 --squash --admin  # stale-review-override"
+                },
+            },
+        )
+        rc = _mod.main()
+        assert rc == 2  # freshness waived, but the P1 findings gate still blocks
+        assert "unresolved review findings" in capsys.readouterr().err
+
+
+class TestCheckPrRepoArg:
+    """--check-pr accepts every normal gh repo spelling (Codex P2 on #1366)."""
+
+    def test_separate_long(self):
+        assert _mod._parse_check_pr_repo(["--repo", "octo/voice"]) == "octo/voice"
+
+    def test_separate_short(self):
+        assert _mod._parse_check_pr_repo(["-R", "octo/voice"]) == "octo/voice"
+
+    def test_equals_long(self):
+        assert _mod._parse_check_pr_repo(["--repo=octo/voice"]) == "octo/voice"
+
+    def test_equals_short(self):
+        assert _mod._parse_check_pr_repo(["-R=octo/voice"]) == "octo/voice"
+
+    def test_absent(self):
+        assert _mod._parse_check_pr_repo([]) is None
+
+    def test_dangling_flag(self):
+        assert _mod._parse_check_pr_repo(["--repo"]) is None
+
+    def test_glued_short(self):
+        # pflag shorthand `-Rowner/repo` — enforcement accepts it; the report must too
+        # (architect F3: unrecognized → silently checked the CWD repo).
+        assert _mod._parse_check_pr_repo(["-Rocto/voice"]) == "octo/voice"

--- a/tests/test_scripts/test_review_scope.py
+++ b/tests/test_scripts/test_review_scope.py
@@ -532,3 +532,93 @@ def test_hook_silent_on_clean_tree(tmp_path):
     repo = _mk_repo(tmp_path)
     out = _run_prompt_hook(repo)
     assert out.strip() == ""
+
+
+# --------------------------------------------------------------------------- #
+# classify_compare_substantiality — GitHub compare-API files[] → substantiality
+# (the merge review-freshness gate's delta classifier). Pure; no git/network.
+# --------------------------------------------------------------------------- #
+def _cf(filename, additions=0, deletions=0, status="modified", has_patch=True, previous_filename=None):
+    f = {
+        "filename": filename,
+        "additions": additions,
+        "deletions": deletions,
+        "status": status,
+        "has_patch": has_patch,
+    }
+    if previous_filename:
+        f["previous_filename"] = previous_filename
+    return f
+
+
+def test_compare_empty_is_inline():
+    assert _rs.classify_compare_substantiality([]) == "inline"
+    assert _rs.classify_compare_substantiality(None) == "inline"
+
+
+def test_compare_large_single_code_file_is_substantial():
+    assert _rs.classify_compare_substantiality([_cf("src/app.py", additions=60, deletions=5)]) == "substantial"
+
+
+def test_compare_small_single_code_file_is_inline():
+    assert _rs.classify_compare_substantiality([_cf("src/app.py", additions=8, deletions=1)]) == "inline"
+
+
+def test_compare_two_code_files_is_substantial():
+    files = [_cf("a.py", additions=3), _cf("b.py", additions=4)]
+    assert _rs.classify_compare_substantiality(files) == "substantial"
+
+
+def test_compare_docs_only_is_inline():
+    assert _rs.classify_compare_substantiality([_cf("README.md", additions=200)]) == "inline"
+
+
+def test_compare_domain_sensitive_small_is_substantial():
+    assert _rs.classify_compare_substantiality([_cf("src/auth_session.py", additions=3)]) == "substantial"
+
+
+def test_compare_binary_asset_excluded():
+    # Binary asset (no patch, 0 lines, not a rename) must NOT count as a code file:
+    # binary + ONE small code file = 1 reviewable code file → inline. If the binary
+    # were wrongly counted it would be 2 code files → substantial (discriminating).
+    files = [
+        _cf("logo.png", additions=0, deletions=0, status="added", has_patch=False),
+        _cf("src/app.py", additions=4, deletions=1),
+    ]
+    assert _rs.classify_compare_substantiality(files) == "inline"
+
+
+def test_compare_rename_side_domain_sensitivity():
+    files = [_cf("src/x.py", additions=0, deletions=0, status="renamed", previous_filename="src/auth.py")]
+    assert _rs.classify_compare_substantiality(files) == "substantial"
+
+
+def test_compare_non_dict_entry_skipped():
+    files = [None, "junk", _cf("src/app.py", additions=4)]
+    assert _rs.classify_compare_substantiality(files) == "inline"
+
+
+def test_compare_suppressed_code_file_is_substantial():
+    # Architect F4: a CODE-category file with no patch and zero counted lines is
+    # UNVERIFIABLE (an over-limit/suppressed text diff, if the API emits one) —
+    # it must fail toward review, never silently exclude like a binary asset.
+    files = [_cf("src/generated_big.py", additions=0, deletions=0, status="added", has_patch=False)]
+    assert _rs.classify_compare_substantiality(files) == "substantial"
+
+
+def test_compare_malformed_counts_on_code_file_is_substantial():
+    # Architect F7: unparseable additions/deletions on a code file must not lean
+    # "trivial" (lines=0) — malformed data on reviewable code fails toward review.
+    files = [{"filename": "src/app.py", "additions": "lots", "deletions": 0,
+              "status": "modified", "has_patch": True}]
+    assert _rs.classify_compare_substantiality(files) == "substantial"
+
+
+def test_compare_binary_noncode_asset_still_excluded():
+    # The F4 fix must NOT flip genuine binary assets: a no-patch/0-lines PNG is
+    # still excluded (non-code category), so binary+small-code stays inline.
+    files = [
+        _cf("logo.png", additions=0, deletions=0, status="added", has_patch=False),
+        _cf("src/app.py", additions=4, deletions=1),
+    ]
+    assert _rs.classify_compare_substantiality(files) == "inline"

--- a/tests/test_scripts/test_review_scope.py
+++ b/tests/test_scripts/test_review_scope.py
@@ -622,3 +622,17 @@ def test_compare_binary_noncode_asset_still_excluded():
         _cf("src/app.py", additions=4, deletions=1),
     ]
     assert _rs.classify_compare_substantiality(files) == "inline"
+
+
+def test_compare_rename_code_to_docs_counts_source():
+    # Codex P2 #1373: a 200-line rename FROM code TO an excluded docs dest must still
+    # classify substantial — the source (code) carries the magnitude, not the dest.
+    files = [_cf("docs/foo.md", additions=150, deletions=50, status="renamed",
+                 previous_filename="src/foo.py")]
+    assert _rs.classify_compare_substantiality(files) == "substantial"
+
+
+def test_compare_rename_docs_to_docs_still_inline():
+    # A docs->docs rename (neither side reviewable code) stays inline.
+    files = [_cf("docs/b.md", additions=150, status="renamed", previous_filename="docs/a.md")]
+    assert _rs.classify_compare_substantiality(files) == "inline"


### PR DESCRIPTION
## What

Hardens the merge-time Codex-at-head freshness gate, driven by two adversarial
reviews of it as-merged plus an empirical block-rate measurement: a binary
stale-blocks gate would have blocked **14 of the 18 most recently merged PRs**
(10 stale + 4 absent), and its only escape also waived unresolved P1 findings.

## Changes

- **Override sigils split by boundary.** The freshness + base-invariant gates
  now waive on a dedicated `# stale-review-override`; `# review-override`
  keeps waiving only the finding scans. The freshness gate is the
  high-traffic one — if its escape also waived P1 findings, the path of least
  resistance would systematically disarm P1 enforcement. One trailing comment
  may carry several sigils when several waivers are genuinely intended.
- **Smart-delta narrowing.** A STALE review blocks only when the unreviewed
  delta (`reviewed...head` via the compare API) classifies substantial; a
  provably review-trivial delta (docs-only / small single-file touch-up)
  passes — still TOCTOU-bound via `--match-head-commit` to the exact head
  that was classified. Substantial, unclassifiable, diverged-substantial, or
  ≥300-file (compare truncation cap) deltas block; an absent review always
  blocks; `identical`/`behind` count as reviewed.
- **DISMISSED reviews no longer satisfy the gate** (state filter; falls back
  to the last non-dismissed review), and valid-JSON non-object NDJSON lines
  are skipped instead of raising out of the fail-safe contract.
- **TOCTOU binding moved ahead of the advisory scanners** — it is argv-only,
  so a hook wall-clock overrun during a slow network scan can never skip
  binding enforcement — and it now has main()-level integration tests
  (previously zero coverage; mutation-verified: neutering the block fails 4
  tests), plus both-direction sigil-decoupling tests.
- **Merge-path gh timeouts tightened to 6-8s** (including pre-gate repo/PR
  resolution) with a budget rationale in `main()`: each fail-closed gate
  reaches its own decision inside the hook's 60s wall-clock instead of being
  SIGKILLed mid-call (which fails toward tool-runs and would disengage every
  gate at once precisely when the API is degraded).
- The compare-delta classifier **fails toward review on unverifiable source
  files** (suppressed/over-limit diffs, malformed counts — scope-tag
  discriminated so genuine binary assets still exclude), and `--check-pr`
  accepts `-R` / `--repo=` / glued `-R` spellings like enforcement does.

## Consciously accepted (flagged for a follow-up decision)

Repo meta-surfaces (`CLAUDE.md`, hook scripts, settings) classify by the same
substantiality predicate as the commit-time depth gate, so a small edit to
them rides the trivial-delta allowance — kept for predicate parity.

## Verification

- **MEASURED:** full hook + review-scope suites green (1404); 20 new tests
  verified-RED against the pre-patch baseline; TOCTOU-binding and
  sigil-routing mutations each fail their tests; ruff clean.
- **Live E2E (read-only):** `--check-pr` runs every gate against real PRs and
  prints the bound merge command; the smart-delta verdict on a real
  stale-with-trivial-delta PR allows and binds to the classified head; a real
  12-commit delta classifies substantial (block path); a real
  stale-with-substantial-delta PR blocks.
- Reviewed by two independent adversarial passes of the merged baseline plus
  a fresh-context adversarial review of this patch (all SHOULD-FIX findings
  adopted; empirical probes on compare semantics, cap boundaries, and sigil
  cross-matching came back clean).

Hook change → effective at the next Claude Code session start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
