### PR TITLE
feat(resilience): distinguish down vs event-loop-starved genesis-server

### DIFF
--- a/config/autonomy.yaml
+++ b/config/autonomy.yaml
@@ -65,6 +65,17 @@ watchdog:
   flap_window_seconds: 21600             # 6h rolling per-reason window
   flap_threshold: 3                      # same-reason restarts before damping kicks in
   flap_backoff_max_seconds: 7200         # cap escalating flap backoff at 2h
+  # Down-vs-starved distinguisher: before restarting genesis-server for a
+  # staleness/zombie reason, the watchdog queries the off-loop liveness probe
+  # (a SYNC Flask route that answers even when the event loop is starved). A
+  # fresh, high-lag reading = UP-but-starved, not dead — a restart there just
+  # re-triggers the boot backlog that caused the starvation. Suppress + alert,
+  # bounded by max_starved_skips so a genuinely-stuck loop still recovers. Port
+  # matches the shipped server default (5000); change both together if relocated.
+  liveness_url: "http://127.0.0.1:5000/api/genesis/liveness"
+  liveness_lag_suppress_ms: 1000         # suppress restart only above this loop lag (well over the 250ms warn floor)
+  liveness_sample_stale_s: 120           # sample older than this = loop fully wedged → restart, don't suppress
+  liveness_max_starved_skips: 6          # max consecutive suppressed restarts (~30 min at 300s cadence) before restarting anyway
 
 # CC rate limit detection patterns
 # These are parsed from CC CLI stderr/stdout when rate limits are hit.

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -1006,6 +1006,12 @@ def _liveness_detail() -> str:
         loop = resp.json().get("loop")
         if not isinstance(loop, dict):
             return ""
+        # A wedged loop (or a dead sampler) keeps returning the LAST sample with a
+        # growing sample_age_s — don't present stale drift/executor depth as current
+        # load. Past a freshness window, report the staleness instead of the number.
+        age = loop.get("sample_age_s")
+        if isinstance(age, (int, float)) and age > 30:
+            return f" (loop sample stale {age:.0f}s — possibly wedged)"
         parts: list[str] = []
         lag = loop.get("lag_ms")
         if isinstance(lag, (int, float)):

--- a/scripts/proactive_memory_hook.py
+++ b/scripts/proactive_memory_hook.py
@@ -984,6 +984,40 @@ def _ensure_knowledge_retrieved_count(db_path: Path) -> None:
         pass  # Never block
 
 
+def _liveness_detail() -> str:
+    """Best-effort loop-health suffix for the degraded banner.
+
+    One quick GET to the OFF-loop liveness probe (a sync route that answers even
+    when the event loop is starved), returning e.g. ``" (loop lag 4200ms,
+    executor backlog 37)"`` or ``""`` on any failure. Never raises. Only called on
+    the "reachable but under load" branches — the connect-refused branch means the
+    server is down and there is nothing to probe. The tight budget is safe: the
+    server already answered (503) or is reachable-but-slow only on the LOOP, and
+    this route bypasses the loop, so it returns in milliseconds.
+    """
+    import httpx
+
+    try:
+        url = f"{_SERVER_BASE}/api/genesis/liveness"
+        with httpx.Client(timeout=httpx.Timeout(0.6, connect=0.2), trust_env=False) as client:
+            resp = client.get(url)
+        if resp.status_code != 200:
+            return ""
+        loop = resp.json().get("loop")
+        if not isinstance(loop, dict):
+            return ""
+        parts: list[str] = []
+        lag = loop.get("lag_ms")
+        if isinstance(lag, (int, float)):
+            parts.append(f"loop lag {lag:.0f}ms")
+        execu = loop.get("executor")
+        if isinstance(execu, dict) and isinstance(execu.get("pending"), int):
+            parts.append(f"executor backlog {execu['pending']}")
+        return f" ({', '.join(parts)})" if parts else ""
+    except Exception:
+        return ""
+
+
 def _server_failure_reason(
     *, status: int | None = None, detail: str = "", exc: BaseException | None = None
 ) -> str:
@@ -993,7 +1027,9 @@ def _server_failure_reason(
     timeout — e.g. mid-restart) from a server that IS reachable but whose recall
     call failed or ran past its 4.5s budget (a 503 / read-timeout). Calling the
     latter "unreachable" both misleads and masks the real latency story, so the
-    banner names the actual cause instead.
+    banner names the actual cause instead — and on the reachable-but-loaded
+    branches appends the live loop-lag / executor backlog so "under load" is a
+    number, not a guess.
     """
     import httpx
 
@@ -1004,14 +1040,18 @@ def _server_failure_reason(
         if isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout)):
             return "genesis-server unreachable (connection refused — likely restarting or down)"
         if isinstance(exc, httpx.TimeoutException):
-            return f"recall timed out after {_SERVER_TIMEOUT_S:g}s (server reachable, under load)"
+            return (
+                f"recall timed out after {_SERVER_TIMEOUT_S:g}s "
+                f"(server reachable, under load){_liveness_detail()}"
+            )
         return "recall call failed (server reachable)"
     if status is not None and status != 200:
         base = f"server returned HTTP {status} (reachable"
         if status == 503:
             base += ", over budget or still booting"
         base += ")"
-        return f"{base}: {detail}" if detail else base
+        base = f"{base}: {detail}" if detail else base
+        return f"{base}{_liveness_detail()}"
     return "genesis-server unavailable"
 
 

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -67,6 +67,10 @@ class WatchdogChecker:
         flap_window_s: int = 21600,
         flap_threshold: int = 3,
         flap_backoff_max_s: int = 7200,
+        liveness_url: str = "http://127.0.0.1:5000/api/genesis/liveness",
+        liveness_lag_suppress_ms: float = 1000.0,
+        liveness_sample_stale_s: float = 120.0,
+        liveness_max_starved_skips: int = 6,
         remediation_registry: RemediationRegistry | None = None,
         outreach_fn: OutreachFn | None = None,
     ) -> None:
@@ -84,6 +88,10 @@ class WatchdogChecker:
         self._flap_window_s = flap_window_s
         self._flap_threshold = flap_threshold
         self._flap_backoff_max_s = flap_backoff_max_s
+        self._liveness_url = liveness_url
+        self._liveness_lag_suppress_ms = liveness_lag_suppress_ms
+        self._liveness_sample_stale_s = liveness_sample_stale_s
+        self._liveness_max_starved_skips = liveness_max_starved_skips
         self._remediation_registry = remediation_registry
         self._outreach_fn = outreach_fn
         self._target_service = self._detect_target_service()
@@ -126,6 +134,12 @@ class WatchdogChecker:
                 flap_window_s=wd.get("flap_window_seconds", 21600),
                 flap_threshold=wd.get("flap_threshold", 3),
                 flap_backoff_max_s=wd.get("flap_backoff_max_seconds", 7200),
+                liveness_url=wd.get(
+                    "liveness_url", "http://127.0.0.1:5000/api/genesis/liveness"
+                ),
+                liveness_lag_suppress_ms=wd.get("liveness_lag_suppress_ms", 1000.0),
+                liveness_sample_stale_s=wd.get("liveness_sample_stale_s", 120.0),
+                liveness_max_starved_skips=wd.get("liveness_max_starved_skips", 6),
             )
         except (yaml.YAMLError, OSError, AttributeError):
             logger.warning("Failed to load watchdog config — using defaults", exc_info=True)
@@ -275,6 +289,64 @@ class WatchdogChecker:
                 "Deploy in progress — deferring %s restart until it completes", reason,
             )
             return WatchdogAction.SKIP
+
+        # Down-vs-starved gate: for a genesis-server staleness/zombie restart,
+        # consult the OFF-loop liveness probe before restarting. A fresh, high-lag
+        # sample means the event loop is STARVED (background work saturating it),
+        # not dead — and a restart re-triggers the boot extraction backlog that
+        # caused the starvation (the mutual false-positive storm). Suppress the
+        # restart (BOUNDED, so a genuinely-stuck loop still recovers) and alert
+        # instead. Every ambiguous / dead / wedged verdict falls through to the
+        # normal restart path below: suppression requires a POSITIVE starved
+        # reading, so a truly-dead server is never left unrestarted. Runs BEFORE
+        # _record_failure so a suppressed cycle never trips backoff/flap counters.
+        if reason in ("stale_status_restart", "zombie_scheduler") and self._targets_server():
+            verdict, detail = self._probe_liveness()
+            d = detail or {}
+            if verdict == "starved":
+                skips = int(state.get("starved_skips", 0)) + 1
+                if skips <= self._liveness_max_starved_skips:
+                    state["starved_skips"] = skips
+                    self._save_state(state)
+                    self._alert_starved(reason, d, skips)
+                    logger.warning(
+                        "Liveness probe: server UP but event loop STARVED "
+                        "(lag %sms, sample %ss old, executor=%s) — suppressing "
+                        "'%s' restart (%d/%d); a restart would re-trigger the "
+                        "starvation. Alerting instead.",
+                        d.get("lag_ms", "?"), d.get("sample_age_s", "?"),
+                        d.get("executor"), reason, skips,
+                        self._liveness_max_starved_skips,
+                    )
+                    return WatchdogAction.SKIP
+                # Past the suppression bound: stop suppressing and proceed to the
+                # restart path. Deliberately do NOT reset starved_skips here (that
+                # would re-enable suppression next cycle) — it stays pinned so we
+                # keep pressing to restart. Flap-damping/backoff below may still
+                # defer the actual restart, so this is "proceed", not a guarantee.
+                logger.error(
+                    "Liveness probe: loop still STARVED past the suppression bound "
+                    "(%d skips, bound %d) — no longer suppressing; proceeding to the "
+                    "restart path (flap-damping/backoff may still defer it).",
+                    skips - 1, self._liveness_max_starved_skips,
+                )
+                # fall through to restart
+            else:
+                # Any NON-starved verdict breaks the consecutive-starved run, so
+                # reset the counter (it means CONSECUTIVE starved skips) — else a
+                # responsive/unknown cycle that lands in a backoff window (no
+                # _record_failure) would leave a stale count to accumulate against.
+                if verdict == "wedged":
+                    logger.error(
+                        "Liveness probe: server reachable but loop-health sample is "
+                        "STALE (%ss old) — loop fully wedged (awareness/status/"
+                        "telegram all dead); restarting.",
+                        d.get("sample_age_s", "?"),
+                    )
+                if state.get("starved_skips"):
+                    state["starved_skips"] = 0
+                    self._save_state(state)
+                # down / unknown / wedged / responsive → normal restart logic below
 
         # Flap damping: a SLOW recurring same-reason restart (spaced beyond the
         # 120s stabilization window, so consecutive_failures keeps resetting to
@@ -525,6 +597,10 @@ class WatchdogChecker:
         state["consecutive_failures"] += 1
         state["last_reason"] = reason
         state["last_restart_at"] = now
+        # An actual restart ends the current run of suppressed-starved cycles —
+        # the counter tracks CONSECUTIVE starved skips, so reset it here (a
+        # healthy reset via _reset_state also clears it by writing a fresh dict).
+        state["starved_skips"] = 0
         # Rolling per-reason restart history for flap damping. Recorded on
         # every actual restart decision (never on a backoff-skip), pruned to
         # the flap window. Deliberately survives _reset_state so SLOW
@@ -569,6 +645,93 @@ class WatchdogChecker:
             )
         except Exception:
             logger.debug("flap alert enqueue failed", exc_info=True)
+
+    def _targets_server(self) -> bool:
+        """True when this watchdog monitors genesis-server (not the legacy relay).
+
+        The liveness probe reflects the SERVER process's event loop; consulting it
+        for a relay-only legacy install would be meaningless, so the down-vs-starved
+        gate only engages when genesis-server is the target.
+        """
+        return "genesis-server" in self._target_service
+
+    def _probe_liveness(self) -> tuple[str, dict | None]:
+        """Classify the server's loop health via the OFF-loop sync probe.
+
+        Returns ``(verdict, loop_block)``. Verdicts:
+          - ``"down"``       — connection refused (nothing listening on the port)
+          - ``"unknown"``    — timeout / non-200 / unparseable / no loop sample
+          - ``"wedged"``     — 200 but the loop-health sample is STALE (sampler stopped)
+          - ``"starved"``    — 200, fresh sample, lag at/over the suppress threshold
+          - ``"responsive"`` — 200, fresh sample, low lag
+
+        Fail-closed: every ambiguous outcome is ``"unknown"``, which the caller
+        treats as "restart still allowed" — suppression requires a POSITIVE
+        ``"starved"`` reading. Never raises. Uses stdlib ``urllib`` (the watchdog
+        is a minimal oneshot; no httpx dependency). The 3s timeout bounds only a
+        hung TCP connect — the sync route reads memory and answers in milliseconds
+        even under full loop starvation, so this is not a speculative work-timeout.
+        """
+        import urllib.error
+        import urllib.request
+
+        try:
+            req = urllib.request.Request(self._liveness_url, method="GET")  # noqa: S310
+            with urllib.request.urlopen(req, timeout=3.0) as resp:  # noqa: S310
+                if resp.status != 200:
+                    return "unknown", None
+                body = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.URLError as exc:
+            # Connection refused (port not listening) is the unambiguous DOWN
+            # signal; everything else here (timeout, DNS, HTTP error) is unknown.
+            if isinstance(getattr(exc, "reason", None), ConnectionRefusedError):
+                return "down", None
+            return "unknown", None
+        except (TimeoutError, OSError, ValueError):
+            # ValueError = JSON parse failure; TimeoutError/OSError = socket-level
+            # failures not wrapped in URLError. All ambiguous → unknown.
+            return "unknown", None
+
+        loop_block = body.get("loop") if isinstance(body, dict) else None
+        if not isinstance(loop_block, dict):
+            return "unknown", None
+        age = loop_block.get("sample_age_s")
+        lag = loop_block.get("lag_ms")
+        if not isinstance(age, (int, float)) or not isinstance(lag, (int, float)):
+            return "unknown", loop_block
+        if age > self._liveness_sample_stale_s:
+            return "wedged", loop_block
+        if lag >= self._liveness_lag_suppress_ms or loop_block.get("lagging") is True:
+            return "starved", loop_block
+        return "responsive", loop_block
+
+    def _alert_starved(self, reason: str, detail: dict, count: int) -> None:
+        """Surface ONE durable alert that a restart was suppressed because the
+        server is up-but-starved. Same queue + dedupe mechanism as ``_alert_flap``
+        (the oneshot watchdog has no outreach pipeline); the awareness tick drains
+        it to the owner. Best-effort — never raises."""
+        try:
+            from genesis.guardian.alert.queue import enqueue_alert
+
+            enqueue_alert(
+                Path.home() / ".genesis" / "alerts" / "queue",
+                severity="warning",
+                source="watchdog",
+                title="Watchdog suppressed restart — server starved, not down",
+                body=(
+                    f"'{reason}' restart suppressed ({count}/"
+                    f"{self._liveness_max_starved_skips}): the liveness probe reports "
+                    f"the server UP but its event loop starved (lag "
+                    f"{detail.get('lag_ms', '?')}ms, sample "
+                    f"{detail.get('sample_age_s', '?')}s old, executor "
+                    f"{detail.get('executor')}). Restarting would re-trigger the boot "
+                    f"backlog that caused the starvation. Investigate loop/executor "
+                    f"load; the watchdog restarts anyway if it does not clear."
+                ),
+                dedupe_key="watchdog:starved",
+            )
+        except Exception:
+            logger.debug("starved alert enqueue failed", exc_info=True)
 
     def _reset_state(self) -> None:
         if not self._state_path.exists():

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -677,7 +677,13 @@ class WatchdogChecker:
 
         try:
             req = urllib.request.Request(self._liveness_url, method="GET")  # noqa: S310
-            with urllib.request.urlopen(req, timeout=3.0) as resp:  # noqa: S310
+            # Loopback probe must NEVER traverse a proxy: an inherited http_proxy
+            # without a 127.0.0.1 no_proxy entry would route this LOCAL health check
+            # to the proxy — a proxy error → 'unknown' (blind restart returns), or a
+            # proxy-forged 200 → a WRONG 'starved' suppression of a needed restart.
+            # Mirror the proactive hook's trust_env=False with a proxy-free opener.
+            opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+            with opener.open(req, timeout=3.0) as resp:
                 if resp.status != 200:
                     return "unknown", None
                 body = json.loads(resp.read().decode("utf-8"))
@@ -701,7 +707,11 @@ class WatchdogChecker:
             return "unknown", loop_block
         if age > self._liveness_sample_stale_s:
             return "wedged", loop_block
-        if lag >= self._liveness_lag_suppress_ms or loop_block.get("lagging") is True:
+        # Honor the CONFIGURED suppression floor only — do NOT also suppress on the
+        # sampler's independent warn-level `lagging` flag (default 250ms), which is
+        # below the 1000ms floor: suppressing there would contradict autonomy.yaml
+        # and hold back a restart on a merely-mildly-laggy server (bias to restart).
+        if lag >= self._liveness_lag_suppress_ms:
             return "starved", loop_block
         return "responsive", loop_block
 

--- a/src/genesis/dashboard/routes/health.py
+++ b/src/genesis/dashboard/routes/health.py
@@ -94,6 +94,61 @@ async def heartbeat_canary():
     }), 200
 
 
+@blueprint.route("/api/genesis/liveness")
+def liveness_probe():
+    """Off-loop liveness probe — answers even when the event loop is STARVED.
+
+    Deliberately a SYNC route (NO ``@_async_route``): Flask serves it on its own
+    worker thread (``threaded=True``), so it never bounces onto the runtime event
+    loop and therefore still responds when background work has starved that loop —
+    the exact case where ``/api/genesis/heartbeat`` (async) hangs indefinitely,
+    indistinguishable from a dead process. Reads only plain in-memory values (the
+    off-loop loop-health sample + the awareness loop's integer counters); never
+    touches a coroutine, the event bus, or any loop-bound async object.
+
+    Always HTTP 200 when the process + Flask thread are alive — classification
+    (down / starved / wedged / responsive) is the CALLER's job. Fail-closed: any
+    field it cannot read is ``null`` (UNKNOWN), never a healthy-looking default, so
+    a consumer must treat ``loop: null`` as unknown rather than clear.
+    """
+    from genesis.util import loop_health
+
+    loop_block = None
+    sample = loop_health.read()
+    if sample is not None:
+        loop_block = {
+            "lag_ms": round(sample.drift_ms, 1),
+            "peak_ms": round(sample.peak_ms, 1),
+            "lagging": sample.lagging,
+            "threshold_ms": sample.threshold_ms,
+            "executor": sample.executor,
+            # Computed at READ time (see loop_health.age_s) — a growing age under
+            # starvation is the WEDGED signal.
+            "sample_age_s": round(loop_health.age_s(sample), 3),
+        }
+
+    awareness_block = None
+    try:
+        from genesis.runtime import GenesisRuntime
+
+        # peek() — never lazily constructs a blank singleton (this is a read-only
+        # observability path); None before bootstrap → awareness stays null.
+        rt = GenesisRuntime.peek()
+        if rt is not None and rt.is_bootstrapped and rt.awareness_loop is not None:
+            awareness_block = {
+                "tick_count": rt.awareness_loop.tick_count,
+                "last_tick_at": rt.awareness_loop.last_tick_at,
+            }
+    except Exception:
+        awareness_block = None
+
+    return jsonify({
+        "alive": True,
+        "loop": loop_block,
+        "awareness": awareness_block,
+    }), 200
+
+
 @blueprint.route("/api/genesis/provider-activity")
 @_async_route
 async def provider_activity():

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -191,6 +191,7 @@ class StandaloneAdapter:
         ``GENESIS_LOOP_LAG_SAMPLER`` (0/false/off) — disables the sampler at
         startup. Best-effort: any error ends the sampler without touching serve.
         """
+        from genesis.util import loop_health
         from genesis.util.loop_diag import default_executor_pending
 
         interval = 0.5
@@ -206,6 +207,7 @@ class StandaloneAdapter:
                 t0 = loop.time()
                 await asyncio.sleep(interval)
                 drift_ms = (loop.time() - t0 - interval) * 1000
+                executor = default_executor_pending()
                 if drift_ms > threshold_ms:
                     peak_ms = max(peak_ms, drift_ms)
                     if not lagging:
@@ -218,7 +220,7 @@ class StandaloneAdapter:
                             "executor=%s (further lag suppressed until it clears)",
                             drift_ms,
                             interval * 1000,
-                            default_executor_pending(),
+                            executor,
                         )
                 elif lagging:
                     # Episode cleared — report the peak so the stall's severity is
@@ -230,6 +232,22 @@ class StandaloneAdapter:
                     )
                     lagging = False
                     peak_ms = 0.0
+                # Publish the reading OFF-loop every iteration so a sync Flask
+                # worker (and the watchdog via the HTTP probe) can read loop
+                # health during starvation — exactly when every @_async_route
+                # endpoint hangs on this same loop. If starvation is severe
+                # enough that asyncio.sleep stops returning, publishes cease and
+                # the sample's age grows: that growing age is the WEDGED signal.
+                loop_health.publish(
+                    loop_health.LoopHealthSample(
+                        drift_ms=drift_ms,
+                        peak_ms=peak_ms,
+                        lagging=lagging,
+                        threshold_ms=threshold_ms,
+                        executor=executor,
+                        sampled_monotonic=time.monotonic(),
+                    )
+                )
         except asyncio.CancelledError:
             pass
 

--- a/src/genesis/util/loop_health.py
+++ b/src/genesis/util/loop_health.py
@@ -1,0 +1,72 @@
+"""Off-loop-readable snapshot of event-loop scheduling health.
+
+The loop-lag sampler (``hosting/standalone.py::_loop_lag_sampler``) runs ON the
+event loop and, until now, only LOGGED its drift measurement. That left no way
+for an off-loop reader — a synchronous Flask worker thread, or the external
+watchdog process — to answer the one question that matters during an incident:
+*is the loop starved, or is the process dead?* Every ``@_async_route`` health
+endpoint bounces the request back onto the same starved loop and hangs, which is
+indistinguishable from a crash.
+
+This module is the publish/read seam. The sampler calls :func:`publish` each
+iteration with the latest sample; a synchronous consumer calls :func:`read` +
+:func:`age_s` to classify:
+
+  - :func:`read` is ``None``                 → UNKNOWN (sampler never ran / disabled)
+  - fresh sample (small ``age_s``) + high lag → loop is STARVED but still scheduling
+  - stale sample (large ``age_s``)           → loop is WEDGED (the sampler itself stalled)
+
+Concurrency: a single module-level reference to an immutable frozen dataclass,
+swapped atomically under the GIL. The writer is the loop thread; readers are
+Flask worker threads (and, across a process boundary, the watchdog via the HTTP
+probe). No lock is needed — the reference swap is atomic and the payload never
+mutates in place. This is diagnostic-only and must never affect control flow.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LoopHealthSample:
+    """One immutable reading from the loop-lag sampler.
+
+    ``sampled_monotonic`` is captured with :func:`time.monotonic` so
+    :func:`age_s` is immune to wall-clock jumps — a growing age while the loop is
+    starved is the WEDGED signal (the sampler stopped publishing because
+    ``asyncio.sleep`` never returned).
+    """
+
+    drift_ms: float
+    peak_ms: float
+    lagging: bool
+    threshold_ms: float
+    executor: dict | None
+    sampled_monotonic: float
+
+
+_latest: LoopHealthSample | None = None
+
+
+def publish(sample: LoopHealthSample) -> None:
+    """Store the latest sample (called from the loop thread, every interval)."""
+    global _latest
+    _latest = sample
+
+
+def read() -> LoopHealthSample | None:
+    """Return the latest published sample, or ``None`` if none was ever published."""
+    return _latest
+
+
+def age_s(sample: LoopHealthSample, *, now: float | None = None) -> float:
+    """Seconds since ``sample`` was taken, computed at READ time.
+
+    ``now`` is injectable for deterministic tests; defaults to
+    :func:`time.monotonic`. Clamped at 0 so a monotonic reference that predates
+    the sample (should not happen, but cheap to guard) never yields a negative age.
+    """
+    ref = time.monotonic() if now is None else now
+    return max(0.0, ref - sample.sampled_monotonic)

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -48,13 +48,15 @@ def _liveness_probe_refused():
     — the same insulation pattern as the autouse _is_bridge_active /
     update_in_progress mocks. 'down' falls through to the normal restart path, i.e.
     exactly the pre-feature behavior. The liveness-distinguisher tests below
-    override urlopen per-scenario to exercise the other verdicts.
+    override the opener per-scenario to exercise the other verdicts. (The probe
+    uses a proxy-free build_opener().open(), so the seam is OpenerDirector.open,
+    not urlopen.)
     """
 
     def _refused(*_a, **_k):
         raise urllib.error.URLError(ConnectionRefusedError("refused"))
 
-    with patch("urllib.request.urlopen", side_effect=_refused):
+    with patch("urllib.request.OpenerDirector.open", side_effect=_refused):
         yield
 
 
@@ -825,7 +827,7 @@ class TestNetworkSuppression:
 
 
 class _FakeResp:
-    """Minimal urlopen() context-manager stand-in."""
+    """Minimal opener.open() context-manager stand-in."""
 
     def __init__(self, status: int, payload: dict):
         self.status = status
@@ -841,7 +843,7 @@ class _FakeResp:
         return False
 
 
-def _urlopen_returning(status: int, payload: dict):
+def _opener_returning(status: int, payload: dict):
     def _f(*_a, **_k):
         return _FakeResp(status, payload)
 
@@ -873,45 +875,47 @@ class TestProbeLivenessClassification:
         assert block is None
 
     def test_timeout_is_unknown(self, tmp_path: Path):
-        with patch("urllib.request.urlopen", side_effect=TimeoutError("slow")):
+        with patch("urllib.request.OpenerDirector.open", side_effect=TimeoutError("slow")):
             verdict, _ = self._checker(tmp_path)._probe_liveness()
         assert verdict == "unknown"
 
     def test_non_200_is_unknown(self, tmp_path: Path):
-        with patch("urllib.request.urlopen", _urlopen_returning(503, {})):
+        with patch("urllib.request.OpenerDirector.open", _opener_returning(503, {})):
             verdict, _ = self._checker(tmp_path)._probe_liveness()
         assert verdict == "unknown"
 
     def test_null_loop_is_unknown(self, tmp_path: Path):
         # loop:null (sampler never published) must NOT read as healthy.
-        with patch("urllib.request.urlopen", _urlopen_returning(200, {"loop": None})):
+        with patch("urllib.request.OpenerDirector.open", _opener_returning(200, {"loop": None})):
             verdict, _ = self._checker(tmp_path)._probe_liveness()
         assert verdict == "unknown"
 
     def test_fresh_low_lag_is_responsive(self, tmp_path: Path):
         payload = {"loop": {"lag_ms": 12.0, "sample_age_s": 0.5, "lagging": False}}
-        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+        with patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)):
             verdict, _ = self._checker(tmp_path)._probe_liveness()
         assert verdict == "responsive"
 
     def test_fresh_high_lag_is_starved(self, tmp_path: Path):
         payload = {"loop": {"lag_ms": 4200.0, "sample_age_s": 1.0, "lagging": True}}
-        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+        with patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)):
             verdict, block = self._checker(tmp_path)._probe_liveness()
         assert verdict == "starved"
         assert block["lag_ms"] == 4200.0
 
-    def test_lagging_flag_alone_is_starved(self, tmp_path: Path):
-        # Below the 1000ms suppress floor but the sticky episode flag is set.
+    def test_lagging_flag_below_floor_is_responsive(self, tmp_path: Path):
+        # Warn-level lag (sampler's 250ms 'lagging' flag) is BELOW the 1000ms
+        # suppress floor → NOT starved. Suppression honors the configured floor
+        # only, never the sampler's independently-tunable warn flag.
         payload = {"loop": {"lag_ms": 300.0, "sample_age_s": 1.0, "lagging": True}}
-        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+        with patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)):
             verdict, _ = self._checker(tmp_path)._probe_liveness()
-        assert verdict == "starved"
+        assert verdict == "responsive"
 
     def test_stale_sample_is_wedged(self, tmp_path: Path):
         # High lag but the sample itself is old → the sampler stopped → wedged.
         payload = {"loop": {"lag_ms": 5000.0, "sample_age_s": 500.0, "lagging": True}}
-        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+        with patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)):
             verdict, _ = self._checker(tmp_path)._probe_liveness()
         assert verdict == "wedged"
 
@@ -928,7 +932,7 @@ class TestLivenessRestartGate:
         payload = {"loop": {"lag_ms": 4200.0, "sample_age_s": 1.0, "lagging": True,
                             "executor": {"pending": 30}}}
         with (
-            patch("urllib.request.urlopen", _urlopen_returning(200, payload)),
+            patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)),
             patch.object(c, "_alert_starved") as alert,
         ):
             action = c.check()
@@ -947,7 +951,7 @@ class TestLivenessRestartGate:
             "restart_history": [], "starved_skips": 6,
         }))
         payload = {"loop": {"lag_ms": 4200.0, "sample_age_s": 1.0, "lagging": True}}
-        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+        with patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)):
             action = c.check()
         # Past the bound → restart anyway; _record_failure resets the counter.
         assert action is WatchdogAction.RESTART
@@ -965,7 +969,7 @@ class TestLivenessRestartGate:
             "restart_history": [], "starved_skips": 3,
         }))
         payload = {"loop": {"lag_ms": 5.0, "sample_age_s": 0.5, "lagging": False}}
-        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+        with patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)):
             action = c.check()
         assert action is WatchdogAction.BACKOFF  # backoff active → no restart, no _record_failure
         state = json.loads((tmp_path / "watchdog_state.json").read_text())
@@ -974,19 +978,19 @@ class TestLivenessRestartGate:
     def test_wedged_restarts(self, tmp_path: Path):
         c = self._stale(tmp_path)
         payload = {"loop": {"lag_ms": 5000.0, "sample_age_s": 500.0, "lagging": True}}
-        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+        with patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)):
             assert c.check() is WatchdogAction.RESTART
 
     def test_responsive_restarts(self, tmp_path: Path):
         # status.json stale but loop fine = the status-writer task died; restart.
         c = self._stale(tmp_path)
         payload = {"loop": {"lag_ms": 10.0, "sample_age_s": 0.5, "lagging": False}}
-        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+        with patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)):
             assert c.check() is WatchdogAction.RESTART
 
     def test_unknown_restarts(self, tmp_path: Path):
         c = self._stale(tmp_path)
-        with patch("urllib.request.urlopen", side_effect=TimeoutError("slow")):
+        with patch("urllib.request.OpenerDirector.open", side_effect=TimeoutError("slow")):
             assert c.check() is WatchdogAction.RESTART
 
     def test_down_restarts(self, tmp_path: Path):
@@ -998,7 +1002,7 @@ class TestLivenessRestartGate:
         c = _liveness_checker(tmp_path, _zombie_file(tmp_path))
         payload = {"loop": {"lag_ms": 4200.0, "sample_age_s": 1.0, "lagging": True}}
         with (
-            patch("urllib.request.urlopen", _urlopen_returning(200, payload)),
+            patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)),
             patch.object(c, "_alert_starved"),
         ):
             assert c.check() is WatchdogAction.SKIP

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -60,6 +60,21 @@ def _liveness_probe_refused():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _no_real_alert_queue():
+    """Insulate the REAL alert queue: _alert_flap/_alert_starved enqueue to a
+    hardcoded ~/.genesis/alerts/queue, so any test reaching them unpatched
+    writes a production alert that the live server drains to the owner's
+    Telegram (this happened — test-generated 'flap-damping' alerts with
+    test-sized backoff values were delivered as if they were real incidents).
+    Both call sites import enqueue_alert at call time, so patching the source
+    module attribute intercepts them; per-test `patch(...)` layers on top for
+    call assertions.
+    """
+    with patch("genesis.guardian.alert.queue.enqueue_alert", return_value=True):
+        yield
+
+
 @pytest.fixture()
 def fresh_status(tmp_path: Path) -> Path:
     """Write a fresh status.json and return the path."""

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 import time
+import urllib.error  # noqa: F401 - used by the _liveness_probe_refused fixture
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -37,6 +38,23 @@ def _no_deploy_in_progress():
     The IR-2 deploy-guard tests override this to True.
     """
     with patch("genesis.autonomy.watchdog.update_in_progress", return_value=False):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _liveness_probe_refused():
+    """Default the off-loop liveness probe to 'connection refused' (verdict
+    'down') so every existing restart test is insulated from a live localhost:5000
+    — the same insulation pattern as the autouse _is_bridge_active /
+    update_in_progress mocks. 'down' falls through to the normal restart path, i.e.
+    exactly the pre-feature behavior. The liveness-distinguisher tests below
+    override urlopen per-scenario to exercise the other verdicts.
+    """
+
+    def _refused(*_a, **_k):
+        raise urllib.error.URLError(ConnectionRefusedError("refused"))
+
+    with patch("urllib.request.urlopen", side_effect=_refused):
         yield
 
 
@@ -801,3 +819,238 @@ class TestNetworkSuppression:
         assert c._network_suppresses_restart(
             {"network": {"state": "OFFLINE", "last_probe_at": future}}
         ) is False
+
+
+# --- Down-vs-starved liveness distinguisher --------------------------------------
+
+
+class _FakeResp:
+    """Minimal urlopen() context-manager stand-in."""
+
+    def __init__(self, status: int, payload: dict):
+        self.status = status
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+
+def _urlopen_returning(status: int, payload: dict):
+    def _f(*_a, **_k):
+        return _FakeResp(status, payload)
+
+    return _f
+
+
+def _liveness_checker(tmp_path: Path, status_file: Path, target: str = "genesis-server.service"):
+    """A checker with a DETERMINISTIC target (so _targets_server doesn't depend on
+    the host's real systemd) and config_validation off (so the restart path lands
+    on RESTART, not a validation SKIP)."""
+    c = _make_checker(tmp_path, status_file)
+    c._target_service = target
+    return c
+
+
+class TestProbeLivenessClassification:
+    """The verdict machine, exercised directly by faking urllib.request.urlopen.
+
+    (The autouse _liveness_probe_refused fixture defaults urlopen to refused; each
+    test overrides it for the verdict it exercises.)"""
+
+    def _checker(self, tmp_path: Path) -> WatchdogChecker:
+        return _make_checker(tmp_path, tmp_path / "status.json")
+
+    def test_connection_refused_is_down(self, tmp_path: Path):
+        # The autouse fixture already raises URLError(ConnectionRefusedError).
+        verdict, block = self._checker(tmp_path)._probe_liveness()
+        assert verdict == "down"
+        assert block is None
+
+    def test_timeout_is_unknown(self, tmp_path: Path):
+        with patch("urllib.request.urlopen", side_effect=TimeoutError("slow")):
+            verdict, _ = self._checker(tmp_path)._probe_liveness()
+        assert verdict == "unknown"
+
+    def test_non_200_is_unknown(self, tmp_path: Path):
+        with patch("urllib.request.urlopen", _urlopen_returning(503, {})):
+            verdict, _ = self._checker(tmp_path)._probe_liveness()
+        assert verdict == "unknown"
+
+    def test_null_loop_is_unknown(self, tmp_path: Path):
+        # loop:null (sampler never published) must NOT read as healthy.
+        with patch("urllib.request.urlopen", _urlopen_returning(200, {"loop": None})):
+            verdict, _ = self._checker(tmp_path)._probe_liveness()
+        assert verdict == "unknown"
+
+    def test_fresh_low_lag_is_responsive(self, tmp_path: Path):
+        payload = {"loop": {"lag_ms": 12.0, "sample_age_s": 0.5, "lagging": False}}
+        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+            verdict, _ = self._checker(tmp_path)._probe_liveness()
+        assert verdict == "responsive"
+
+    def test_fresh_high_lag_is_starved(self, tmp_path: Path):
+        payload = {"loop": {"lag_ms": 4200.0, "sample_age_s": 1.0, "lagging": True}}
+        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+            verdict, block = self._checker(tmp_path)._probe_liveness()
+        assert verdict == "starved"
+        assert block["lag_ms"] == 4200.0
+
+    def test_lagging_flag_alone_is_starved(self, tmp_path: Path):
+        # Below the 1000ms suppress floor but the sticky episode flag is set.
+        payload = {"loop": {"lag_ms": 300.0, "sample_age_s": 1.0, "lagging": True}}
+        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+            verdict, _ = self._checker(tmp_path)._probe_liveness()
+        assert verdict == "starved"
+
+    def test_stale_sample_is_wedged(self, tmp_path: Path):
+        # High lag but the sample itself is old → the sampler stopped → wedged.
+        payload = {"loop": {"lag_ms": 5000.0, "sample_age_s": 500.0, "lagging": True}}
+        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+            verdict, _ = self._checker(tmp_path)._probe_liveness()
+        assert verdict == "wedged"
+
+
+class TestLivenessRestartGate:
+    """check() → _restart_if_allowed consulting the probe. Every verdict except
+    'starved' must still reach the normal restart path (fail-open)."""
+
+    def _stale(self, tmp_path: Path):
+        return _liveness_checker(tmp_path, _stale_file(tmp_path))
+
+    def test_starved_suppresses_stale_restart(self, tmp_path: Path):
+        c = self._stale(tmp_path)
+        payload = {"loop": {"lag_ms": 4200.0, "sample_age_s": 1.0, "lagging": True,
+                            "executor": {"pending": 30}}}
+        with (
+            patch("urllib.request.urlopen", _urlopen_returning(200, payload)),
+            patch.object(c, "_alert_starved") as alert,
+        ):
+            action = c.check()
+        assert action is WatchdogAction.SKIP
+        alert.assert_called_once()
+        state = json.loads((tmp_path / "watchdog_state.json").read_text())
+        assert state["starved_skips"] == 1
+        # A suppressed cycle must NOT burn the restart/backoff counter.
+        assert state.get("consecutive_failures", 0) == 0
+
+    def test_starved_suppression_is_bounded(self, tmp_path: Path):
+        c = self._stale(tmp_path)
+        # Pre-seed the counter at the cap so the next starved cycle exceeds it.
+        (tmp_path / "watchdog_state.json").write_text(json.dumps({
+            "consecutive_failures": 0, "next_attempt_after": None,
+            "restart_history": [], "starved_skips": 6,
+        }))
+        payload = {"loop": {"lag_ms": 4200.0, "sample_age_s": 1.0, "lagging": True}}
+        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+            action = c.check()
+        # Past the bound → restart anyway; _record_failure resets the counter.
+        assert action is WatchdogAction.RESTART
+        state = json.loads((tmp_path / "watchdog_state.json").read_text())
+        assert state["starved_skips"] == 0
+
+    def test_non_starved_verdict_resets_skips_even_under_backoff(self, tmp_path: Path):
+        """A non-starved verdict must reset starved_skips (it means CONSECUTIVE
+        starved skips) even when the fall-through lands in a backoff window where
+        _record_failure never runs — otherwise a stale count would accumulate."""
+        c = self._stale(tmp_path)
+        future = time.time() + 9999
+        (tmp_path / "watchdog_state.json").write_text(json.dumps({
+            "consecutive_failures": 1, "next_attempt_after": future,
+            "restart_history": [], "starved_skips": 3,
+        }))
+        payload = {"loop": {"lag_ms": 5.0, "sample_age_s": 0.5, "lagging": False}}
+        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+            action = c.check()
+        assert action is WatchdogAction.BACKOFF  # backoff active → no restart, no _record_failure
+        state = json.loads((tmp_path / "watchdog_state.json").read_text())
+        assert state["starved_skips"] == 0  # reset by the gate, not by _record_failure
+
+    def test_wedged_restarts(self, tmp_path: Path):
+        c = self._stale(tmp_path)
+        payload = {"loop": {"lag_ms": 5000.0, "sample_age_s": 500.0, "lagging": True}}
+        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+            assert c.check() is WatchdogAction.RESTART
+
+    def test_responsive_restarts(self, tmp_path: Path):
+        # status.json stale but loop fine = the status-writer task died; restart.
+        c = self._stale(tmp_path)
+        payload = {"loop": {"lag_ms": 10.0, "sample_age_s": 0.5, "lagging": False}}
+        with patch("urllib.request.urlopen", _urlopen_returning(200, payload)):
+            assert c.check() is WatchdogAction.RESTART
+
+    def test_unknown_restarts(self, tmp_path: Path):
+        c = self._stale(tmp_path)
+        with patch("urllib.request.urlopen", side_effect=TimeoutError("slow")):
+            assert c.check() is WatchdogAction.RESTART
+
+    def test_down_restarts(self, tmp_path: Path):
+        # The autouse fixture already yields 'down' (connection refused).
+        c = self._stale(tmp_path)
+        assert c.check() is WatchdogAction.RESTART
+
+    def test_zombie_starved_suppresses(self, tmp_path: Path):
+        c = _liveness_checker(tmp_path, _zombie_file(tmp_path))
+        payload = {"loop": {"lag_ms": 4200.0, "sample_age_s": 1.0, "lagging": True}}
+        with (
+            patch("urllib.request.urlopen", _urlopen_returning(200, payload)),
+            patch.object(c, "_alert_starved"),
+        ):
+            assert c.check() is WatchdogAction.SKIP
+
+    def test_bridge_inactive_never_probes(self, tmp_path: Path):
+        # service down = definitionally dead; the probe is not consulted.
+        c = _liveness_checker(tmp_path, _stale_file(tmp_path))
+        with (
+            patch.object(c, "_is_bridge_active", return_value=False),
+            patch.object(c, "_bridge_exited_unconfigured", return_value=False),
+            patch.object(c, "_probe_liveness") as probe,
+        ):
+            action = c.check()
+        probe.assert_not_called()
+        assert action is WatchdogAction.RESTART
+
+    def test_relay_target_never_probes(self, tmp_path: Path):
+        # A legacy relay-only install: the server-loop probe is meaningless.
+        c = _liveness_checker(tmp_path, _stale_file(tmp_path), target="genesis-bridge.service")
+        with patch.object(c, "_probe_liveness") as probe:
+            action = c.check()
+        probe.assert_not_called()
+        assert action is WatchdogAction.RESTART
+
+
+class TestLivenessConfig:
+    def test_from_yaml_loads_liveness_keys(self):
+        # The shipped config/autonomy.yaml carries the liveness knobs.
+        c = WatchdogChecker.from_yaml()
+        assert c._liveness_lag_suppress_ms == 1000
+        assert c._liveness_sample_stale_s == 120
+        assert c._liveness_max_starved_skips == 6
+        assert c._liveness_url.endswith("/api/genesis/liveness")
+
+
+def _stale_file(tmp_path: Path) -> Path:
+    """A stale status.json (20 min old) at a fixed path per tmp_path."""
+    p = tmp_path / "status.json"
+    old = datetime.now(UTC) - timedelta(minutes=20)
+    p.write_text(json.dumps({"timestamp": old.isoformat()}))
+    return p
+
+
+def _zombie_file(tmp_path: Path) -> Path:
+    """Fresh status.json but with a stale scheduler heartbeat (zombie scheduler),
+    past stabilization, no heavy workload, no network suppression."""
+    p = tmp_path / "status.json"
+    now = datetime.now(UTC)
+    old = now - timedelta(minutes=30)
+    p.write_text(json.dumps({
+        "timestamp": now.isoformat(),
+        "uptime_s": 99999,
+        "scheduler_heartbeats": {"surplus": old.isoformat()},
+    }))
+    return p

--- a/tests/test_dashboard/test_liveness_route.py
+++ b/tests/test_dashboard/test_liveness_route.py
@@ -1,0 +1,93 @@
+"""GET /api/genesis/liveness — the off-loop, sync liveness probe.
+
+The probe exists to answer *is the loop starved, or is the process dead?* during
+an incident, when every ``@_async_route`` health endpoint hangs on the starved
+loop. Its load-bearing property is that it is a SYNC route: Flask serves it on
+its own worker thread, so it answers even when the runtime event loop is not
+running. The regression guard below (a configured-but-stopped loop still returns
+200) is the RED test — an ``@_async_route`` version 503s in that exact case.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from flask import Flask
+
+import genesis.dashboard.routes.health  # noqa: F401 - registers routes on the blueprint
+from genesis.dashboard._blueprint import blueprint
+from genesis.util import loop_health
+
+
+def _app() -> Flask:
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    return app
+
+
+def _sample(**over) -> loop_health.LoopHealthSample:
+    base = dict(
+        drift_ms=1234.5,
+        peak_ms=1500.0,
+        lagging=True,
+        threshold_ms=250.0,
+        executor={"pending": 7, "workers": 11, "max_workers": 11},
+        sampled_monotonic=100.0,
+    )
+    base.update(over)
+    return loop_health.LoopHealthSample(**base)
+
+
+def test_loop_null_when_no_sample(monkeypatch):
+    """No sample ever published → loop is null (UNKNOWN), never a healthy default."""
+    monkeypatch.setattr(loop_health, "_latest", None)
+    with _app().test_client() as c:
+        resp = c.get("/api/genesis/liveness")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["alive"] is True
+    assert body["loop"] is None
+
+
+def test_reports_sample_with_age_at_read_time(monkeypatch):
+    monkeypatch.setattr(loop_health, "_latest", _sample())
+    # age_s is computed at READ time from monotonic — pin it deterministically.
+    monkeypatch.setattr(loop_health.time, "monotonic", lambda: 103.0)  # 100.0 → 3.0s
+    with _app().test_client() as c:
+        body = c.get("/api/genesis/liveness").get_json()
+    loop = body["loop"]
+    assert loop["lag_ms"] == 1234.5
+    assert loop["lagging"] is True
+    assert loop["sample_age_s"] == 3.0
+    assert loop["executor"]["pending"] == 7
+
+
+def test_answers_200_with_configured_but_stopped_loop(monkeypatch):
+    """RED guard: a configured-but-NOT-running loop still gets 200 — proving the
+    route is SYNC and never bounces onto the loop. An @_async_route would 503
+    here (see test_async_route_configured_but_stopped_loop_returns_503)."""
+    monkeypatch.setattr(loop_health, "_latest", None)
+    app = _app()
+    loop = asyncio.new_event_loop()  # configured, NOT running (starvation proxy)
+    app.config["GENESIS_EVENT_LOOP"] = loop
+    try:
+        with app.test_client() as c:
+            resp = c.get("/api/genesis/liveness")
+        assert resp.status_code == 200
+        assert resp.get_json()["alive"] is True
+    finally:
+        loop.close()
+
+
+def test_awareness_null_when_runtime_unavailable(monkeypatch):
+    """A failure reading the awareness loop degrades to awareness:null, still 200."""
+    monkeypatch.setattr(loop_health, "_latest", None)
+
+    def _boom():
+        raise RuntimeError("no runtime")
+
+    monkeypatch.setattr("genesis.runtime.GenesisRuntime.peek", _boom)
+    with _app().test_client() as c:
+        resp = c.get("/api/genesis/liveness")
+    assert resp.status_code == 200
+    assert resp.get_json()["awareness"] is None

--- a/tests/test_hosting/test_loop_lag_sampler.py
+++ b/tests/test_hosting/test_loop_lag_sampler.py
@@ -89,6 +89,38 @@ async def test_bad_env_threshold_falls_back_to_default(monkeypatch, caplog):
     assert [r for r in caplog.records if "event-loop lag" in r.getMessage()]
 
 
+async def test_publishes_sample_off_loop(monkeypatch):
+    """Each iteration publishes an off-loop-readable LoopHealthSample so a sync
+    consumer (the /liveness route, the watchdog) can read loop health during
+    starvation. RED before the publish() wiring: loop_health.read() stays None."""
+    from genesis.util import loop_health
+
+    monkeypatch.setattr(loop_health, "_latest", None)
+    # drift 450ms > 250ms default → lagging sample.
+    adapter = _adapter_with_fake_clock(monkeypatch, times=[0.0, 0.95])
+    await adapter._loop_lag_sampler()
+
+    sample = loop_health.read()
+    assert sample is not None, "sampler must publish a sample each iteration"
+    assert round(sample.drift_ms) == 450
+    assert sample.lagging is True
+    assert sample.threshold_ms == 250.0
+
+
+async def test_published_sample_reflects_cleared_episode(monkeypatch):
+    """After a stall clears, the published sample reports lagging=False — a
+    consumer must see recovery, not a stuck 'lagging' flag."""
+    from genesis.util import loop_health
+
+    monkeypatch.setattr(loop_health, "_latest", None)
+    # iter1: drift 450 (lagging); iter2: drift 0 (clears).
+    adapter = _adapter_with_fake_clock(monkeypatch, times=[0.0, 0.95, 0.95, 1.45], stop_after=2)
+    await adapter._loop_lag_sampler()
+    sample = loop_health.read()
+    assert sample is not None
+    assert sample.lagging is False
+
+
 async def test_sustained_lag_warns_once_then_reports_clear(monkeypatch, caplog):
     """A multi-sample stall must WARN exactly once (episode debounce), then emit
     an INFO with the peak drift when it clears — not one line per sample."""

--- a/tests/test_learning/test_proactive_hook_degraded_banner.py
+++ b/tests/test_learning/test_proactive_hook_degraded_banner.py
@@ -42,13 +42,16 @@ def test_reason_connect_failures_are_unreachable(exc: Exception):
     assert "connection refused" in reason
 
 
-def test_reason_read_timeout_is_reachable_not_unreachable():
+def test_reason_read_timeout_is_reachable_not_unreachable(monkeypatch):
+    # Stub the live loop-lag probe so this unit stays hermetic (no network I/O).
+    monkeypatch.setattr(hook, "_liveness_detail", lambda: "")
     reason = hook._server_failure_reason(exc=httpx.ReadTimeout("read timed out"))
     assert "unreachable" not in reason
     assert "timed out" in reason and "reachable" in reason
 
 
-def test_reason_503_is_reachable_over_budget():
+def test_reason_503_is_reachable_over_budget(monkeypatch):
+    monkeypatch.setattr(hook, "_liveness_detail", lambda: "")
     reason = hook._server_failure_reason(status=503, detail="recall over budget")
     assert "unreachable" not in reason
     assert "503" in reason and "reachable" in reason
@@ -67,8 +70,9 @@ def test_reason_generic_exception_is_reachable():
     assert "reachable" in reason
 
 
-def test_banner_503_says_reachable_not_unreachable():
+def test_banner_503_says_reachable_not_unreachable(monkeypatch):
     """The core fix: a reachable-but-503 recall must NOT print 'unreachable'."""
+    monkeypatch.setattr(hook, "_liveness_detail", lambda: "")
     results = [{"memory_id": "abc12345", "content": "a recalled fact"}]
     reason = hook._server_failure_reason(status=503, detail="recall over budget")
     out = hook._format_degraded(results, reason=reason)
@@ -100,3 +104,43 @@ def test_banner_none_reason_falls_back_safely():
     banner = hook._format_degraded(results, reason=None).splitlines()[0]
     assert banner.startswith("[Memory recall degraded — ")
     assert "genesis-server unavailable" in banner
+
+
+# --- liveness-detail suffix on the reachable-but-loaded branches -----------------
+
+
+def test_liveness_detail_appended_on_read_timeout(monkeypatch):
+    """A reachable-but-slow recall (read timeout) appends the live loop-lag detail
+    so 'under load' becomes a number, not a guess."""
+    monkeypatch.setattr(hook, "_liveness_detail", lambda: " (loop lag 4200ms, executor backlog 30)")
+    reason = hook._server_failure_reason(exc=httpx.ReadTimeout("t"))
+    assert "under load" in reason
+    assert "loop lag 4200ms" in reason
+
+
+def test_liveness_detail_appended_on_503(monkeypatch):
+    monkeypatch.setattr(hook, "_liveness_detail", lambda: " (loop lag 900ms)")
+    reason = hook._server_failure_reason(status=503, detail="over budget")
+    assert "503" in reason and "over budget" in reason
+    assert "loop lag 900ms" in reason
+
+
+def test_liveness_detail_not_probed_on_connect_refused(monkeypatch):
+    """A down server (connection refused) must NOT be probed — nothing to read."""
+    calls = {"n": 0}
+
+    def _spy():
+        calls["n"] += 1
+        return " (should not appear)"
+
+    monkeypatch.setattr(hook, "_liveness_detail", _spy)
+    reason = hook._server_failure_reason(exc=httpx.ConnectError("refused"))
+    assert "should not appear" not in reason
+    assert calls["n"] == 0
+
+
+def test_liveness_detail_fails_closed_to_empty(monkeypatch):
+    """_liveness_detail never raises and returns '' when the probe is unreachable
+    (points at a dead port so the result is deterministic on any host)."""
+    monkeypatch.setattr(hook, "_SERVER_BASE", "http://127.0.0.1:9")
+    assert hook._liveness_detail() == ""

--- a/tests/test_learning/test_proactive_hook_degraded_banner.py
+++ b/tests/test_learning/test_proactive_hook_degraded_banner.py
@@ -144,3 +144,50 @@ def test_liveness_detail_fails_closed_to_empty(monkeypatch):
     (points at a dead port so the result is deterministic on any host)."""
     monkeypatch.setattr(hook, "_SERVER_BASE", "http://127.0.0.1:9")
     assert hook._liveness_detail() == ""
+
+
+def _stub_liveness_client(monkeypatch, loop: dict) -> None:
+    """Stub httpx.Client so _liveness_detail parses the given loop block."""
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"loop": loop}
+
+    class _Client:
+        def __init__(self, **_k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def get(self, _url):
+            return _Resp()
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+
+
+def test_liveness_detail_fresh_sample_shows_lag(monkeypatch):
+    _stub_liveness_client(
+        monkeypatch,
+        {"lag_ms": 4200, "sample_age_s": 1.0, "executor": {"pending": 30}},
+    )
+    detail = hook._liveness_detail()
+    assert "loop lag 4200ms" in detail
+    assert "executor backlog 30" in detail
+
+
+def test_liveness_detail_stale_sample_reports_staleness(monkeypatch):
+    """A wedged loop returns an old sample with a growing age — the banner must
+    report staleness, not present the historical drift as current load."""
+    _stub_liveness_client(
+        monkeypatch,
+        {"lag_ms": 4200, "sample_age_s": 240.0, "executor": {"pending": 30}},
+    )
+    detail = hook._liveness_detail()
+    assert "stale" in detail
+    assert "4200" not in detail  # the historical drift is NOT presented as current

--- a/tests/test_util/test_loop_health.py
+++ b/tests/test_util/test_loop_health.py
@@ -1,0 +1,89 @@
+"""Unit tests for the loop-health publish/read seam (``genesis.util.loop_health``).
+
+The module's integration behavior is covered via the sampler
+(``tests/test_hosting/test_loop_lag_sampler.py``) and the sync liveness route
+(``tests/test_dashboard/test_liveness_route.py``); these pin the module's own
+contract directly — above all the ``age_s`` clamp and ``now=`` override, which
+the integration tests never reach.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from genesis.util import loop_health
+from genesis.util.loop_health import LoopHealthSample
+
+
+def _sample(sampled_monotonic: float = 100.0) -> LoopHealthSample:
+    return LoopHealthSample(
+        drift_ms=12.5,
+        peak_ms=40.0,
+        lagging=False,
+        threshold_ms=250.0,
+        executor={"pending": 0},
+        sampled_monotonic=sampled_monotonic,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_state(monkeypatch):
+    """Reset the module-global latest-sample reference around every test, so
+    test order (and the sampler integration tests sharing the process) can
+    never leak a sample into these units."""
+    monkeypatch.setattr(loop_health, "_latest", None)
+
+
+def test_read_before_any_publish_is_none():
+    """None = UNKNOWN (sampler never ran) — the fail-closed default."""
+    assert loop_health.read() is None
+
+
+def test_publish_then_read_round_trips_same_object():
+    s = _sample()
+    loop_health.publish(s)
+    assert loop_health.read() is s
+
+
+def test_publish_replaces_prior_sample():
+    first = _sample(sampled_monotonic=100.0)
+    second = _sample(sampled_monotonic=200.0)
+    loop_health.publish(first)
+    loop_health.publish(second)
+    assert loop_health.read() is second
+
+
+def test_sample_is_immutable():
+    """The lock-free reader contract relies on the payload never mutating."""
+    s = _sample()
+    with pytest.raises(AttributeError):
+        s.drift_ms = 999.0  # type: ignore[misc]
+
+
+def test_age_s_with_injected_now():
+    s = _sample(sampled_monotonic=100.0)
+    assert loop_health.age_s(s, now=142.5) == 42.5
+
+
+def test_age_s_clamps_negative_to_zero():
+    """A monotonic reference that predates the sample must never yield a
+    negative age (a negative age would read as 'fresher than fresh' and could
+    mask a wedge)."""
+    s = _sample(sampled_monotonic=100.0)
+    assert loop_health.age_s(s, now=99.0) == 0.0
+
+
+def test_age_s_zero_elapsed_is_zero():
+    s = _sample(sampled_monotonic=100.0)
+    assert loop_health.age_s(s, now=100.0) == 0.0
+
+
+def test_age_s_defaults_to_monotonic_clock():
+    """Without ``now=``, age is computed from time.monotonic() at read time and
+    grows between reads (bounded sanity check, no sleeps)."""
+    s = _sample(sampled_monotonic=time.monotonic())
+    first = loop_health.age_s(s)
+    second = loop_health.age_s(s)
+    assert 0.0 <= first <= second < 60.0


### PR DESCRIPTION
## What

The in-container watchdog restarts genesis-server on 900s `status.json` staleness. But `status.json` is written **on the event loop**, so a *starved* (not dead) loop makes it go stale — and the watchdog would blind-restart a starved-but-alive server, re-triggering the boot-extraction backlog that caused the starvation (a mutual false-positive storm). This lets the watchdog tell the two apart.

## How

- **`util/loop_health.py`** (new) — off-loop publish/read seam for the loop-lag sampler's reading. A GIL-atomic frozen-dataclass reference swap (writer = loop thread, readers = Flask worker threads / the cross-process watchdog via HTTP); `age_s()` computed at read time from `time.monotonic()`.
- **`hosting/standalone.py`** — the loop-lag sampler now `publish()`es every iteration. If starvation is severe enough that `asyncio.sleep` stops returning, publishes cease and the sample's age grows — that growing age is the WEDGED signal.
- **`dashboard/routes/health.py`** — NEW **sync** `GET /api/genesis/liveness`. No `@_async_route`, so Flask's threaded server answers it **off the event loop** even during starvation (when `/api/genesis/heartbeat` and every other async route hangs). Returns `{alive, loop: {…sample_age_s} | null, awareness: {…} | null}`, fail-closed to null. Uses `peek()` (never lazily constructs a runtime).
- **`autonomy/watchdog.py`** — tri-state gate at the top of `_restart_if_allowed` (genesis-server, staleness/zombie reasons only): `down/unknown/wedged/responsive → restart` (unchanged path); `starved` (fresh, high-lag sample) → **bounded** suppress (`max_starved_skips=6`, ~30 min) + one deduped alert. A dead process can never produce a fresh 200 sample, so it always restarts. `starved_skips` resets on any non-starved verdict and on `_record_failure`.
- **`config/autonomy.yaml`** — `liveness_url` / `liveness_lag_suppress_ms=1000` / `liveness_sample_stale_s=120` / `liveness_max_starved_skips=6`.
- **`scripts/proactive_memory_hook.py`** — the degraded banner appends live loop-lag / executor-backlog on the reachable-but-loaded branches (never on connect-refused).

## Safety

The load-bearing property — **a genuinely dead server is never left unrestarted** — was adversarially audited (genesis-architect): every `_probe_liveness` failure mode (connection refused, timeout, HTTPError, JSON garbage, null/partial loop, non-numeric fields, stale sample) terminates in a restart-allowed path. Suppression is the only non-restart branch and requires a positive fresh sample. Ships **live** (observability; no lever) — it can only make restart behavior *less* aggressive, bounded at ~30 min, and every ambiguous verdict restarts.

Note: on this install the blind-restart has never actually fired (`restart_history: []`); this is preventive plus honest hook labeling and the first readable loop-lag metric. The **guardian-side** probe consult (its probes are also loop-bound) is a tracked **phase-2 follow-up** to keep this PR reviewable.

## Testing

- New: liveness-route (5, incl. a RED guard that a configured-but-stopped loop still 200s — proving the route is sync); sampler-publish (2); watchdog probe-classification (8) + restart-gate tri-state (9, full down/unknown/wedged/responsive/starved matrix incl. bound + bridge-inactive/relay never-probe); hook liveness-detail suffix (4). 111 tests green; `test_scripts` + hook subprocess green.
- Verify-RED confirmed on the suppression gate (disabled → starved cases wrongly RESTART) and the `starved_skips` reset.

Subsystem map reviewed: no entry's judgment-layer prose is made stale (the change is a watchdog-internal decision refinement, not a subsystem-capability change), so no map edit — noted here for transparency.

Addresses follow-up b4421dea (down-vs-starved distinguisher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)