### PR TITLE
perf(observability): offload infra-snapshot /proc & cgroup reads off the loop

### DIFF
--- a/src/genesis/awareness/signals.py
+++ b/src/genesis/awareness/signals.py
@@ -290,7 +290,10 @@ class ContainerMemoryCollector:
     async def collect(self) -> SignalReading:
         from genesis.autonomy.watchdog import get_container_anon_memory
 
-        mem = get_container_anon_memory()
+        # Offload the synchronous cgroup reads off the event loop — this runs on
+        # every 5-min awareness tick and the /sys/fs/cgroup reads can stall under
+        # memory pressure (same chronic loop-lag class as the snapshot path).
+        mem = await asyncio.to_thread(get_container_anon_memory)
         if mem is None or mem[1] == 0:
             return _bootstrap_placeholder_reading(self.signal_name, "cgroup")
 

--- a/src/genesis/observability/snapshots/infrastructure.py
+++ b/src/genesis/observability/snapshots/infrastructure.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import shutil
+import threading
 import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -161,6 +162,11 @@ def _cpu_status(used_pct: float | None) -> str:
 
 # Module-level state for delta-based CPU reading (no blocking sleep)
 _last_cpu_reading: tuple[int, int, float] | None = None  # (idle, total, monotonic_time)
+# Guards the read-modify-write of _last_cpu_reading. _collect_cpu_usage now runs on
+# a worker thread (offloaded off the event loop via _collect_host_metrics), so the
+# delta baseline's compare-and-swap must be atomic even though snapshot computes are
+# single-flighted in practice (health_data.py coalesces concurrent callers).
+_cpu_lock = threading.Lock()
 
 
 def _collect_cpu_usage() -> dict:
@@ -183,13 +189,20 @@ def _collect_cpu_usage() -> dict:
         total = sum(int(p) for p in parts[1:])
         now = time.monotonic()
 
-        if _last_cpu_reading is None:
-            _last_cpu_reading = (idle, total, now)
+        # Atomic compare-and-swap of the delta baseline (tight lock scope — the
+        # /proc read above touches no shared state, so it stays outside the lock).
+        with _cpu_lock:
+            if _last_cpu_reading is None:
+                _last_cpu_reading = (idle, total, now)
+                prev = None
+            else:
+                prev = _last_cpu_reading
+                _last_cpu_reading = (idle, total, now)
+
+        if prev is None:
             return {"status": "healthy", "used_pct": None, "count": count, "pressure": pressure}
 
-        prev_idle, prev_total, _prev_time = _last_cpu_reading
-        _last_cpu_reading = (idle, total, now)
-
+        prev_idle, prev_total, _prev_time = prev
         delta_idle = idle - prev_idle
         delta_total = total - prev_total
         if delta_total == 0:
@@ -255,6 +268,85 @@ def _internet_probe_entry() -> dict | None:
         msg = f"{label} {dur}" if dur else label
         return {"status": "down" if state == "OFFLINE" else "degraded", "message": msg}
     return {"status": "unknown", "message": f"state {state}"}
+
+
+def _collect_host_metrics() -> dict:
+    """CPU + disk + cc_tmp — the synchronous /proc & /sys reads, collected in one
+    call so ``infrastructure()`` can offload the whole group with a single
+    ``asyncio.to_thread`` hop instead of blocking the event loop on each read.
+
+    These reads are usually sub-millisecond but stall exactly when the box is
+    under CPU/memory pressure (kernel-side contention on PSI / /proc), which is
+    when keeping the loop free matters most. Each section keeps its own
+    try/except so one failing read never blanks the others (identical isolation
+    to the previous inline form).
+    """
+    metrics: dict = {}
+    metrics["cpu"] = _collect_cpu_usage()
+
+    try:
+        usage = shutil.disk_usage("/")
+        free_pct = round(usage.free / usage.total * 100, 1)
+        metrics["disk"] = {
+            "total_gb": round(usage.total / (1024**3), 1),
+            "free_gb": round(usage.free / (1024**3), 1),
+            "free_pct": free_pct,
+        }
+    except OSError as exc:
+        metrics["disk"] = {"status": "error", "error": str(exc)}
+
+    try:
+        from genesis.observability.service_status import collect_cc_tmp_usage
+
+        metrics["cc_tmp"] = collect_cc_tmp_usage()
+    except (ImportError, OSError) as exc:
+        metrics["cc_tmp"] = {"status": "error", "error": str(exc)}
+
+    return metrics
+
+
+def _collect_container_memory() -> dict:
+    """Container cgroup memory (anon/kernel + PSI + MemAvailable) — the other
+    synchronous /sys/proc block, offloaded off the loop. Returns
+    ``{"container_memory": {...}}`` so the caller merges it in place, preserving
+    the original key ordering in the snapshot.
+    """
+    try:
+        from genesis.autonomy.watchdog import get_container_anon_memory, get_container_memory
+
+        anon_mem = get_container_anon_memory()
+        total_mem = get_container_memory()
+        if anon_mem and anon_mem[1] > 0:
+            anon_kernel, limit = anon_mem
+            anon_pct = anon_kernel / limit
+            mem_pressure = _read_psi(_PSI_MEMORY_PATH)
+            # Status = worse of anon% (OOM guard, non-reclaimable) and sustained
+            # memory PSI. Total cgroup usage (memory.current) is shown for
+            # reference but NOT used for health — it includes reclaimable page
+            # cache that inflates the metric, and whose reclaim is benign.
+            mem_info: dict = {
+                "status": memory_status(anon_pct, mem_pressure),
+                "current_gb": round((total_mem[0] if total_mem else anon_kernel) / (1024**3), 1),
+                "limit_gb": round(limit / (1024**3), 1),
+                "used_pct": round((total_mem[0] / limit * 100) if total_mem and total_mem[1] > 0 else anon_pct * 100, 1),
+                "anon_pct": round(anon_pct * 100, 1),
+                "pressure": mem_pressure,
+            }
+            # MemAvailable from /proc/meminfo — the kernel's estimate of
+            # memory available for new allocations without swapping. This is
+            # the metric that matters for OOM risk, not used_pct (which
+            # includes reclaimable file cache and inflates the number).
+            available_bytes = _read_mem_available()
+            if available_bytes is not None:
+                mem_info["available_gb"] = round(available_bytes / (1024**3), 1)
+                # Cap at 100% — on non-namespaced hosts, MemAvailable may
+                # exceed the cgroup limit, producing a nonsensical ratio.
+                mem_info["available_pct"] = round(min(available_bytes / limit * 100, 100.0), 1)
+            mem_info.update(_read_memory_stat())
+            return {"container_memory": mem_info}
+        return {"container_memory": {"status": "unavailable"}}
+    except Exception as exc:
+        return {"container_memory": {"status": "error", "error": str(exc)}}
 
 
 async def infrastructure(
@@ -330,25 +422,10 @@ async def infrastructure(
     else:
         infra["scheduler"] = {"status": "unknown", "error": "no scheduler or DB available"}
 
-    infra["cpu"] = _collect_cpu_usage()
-
-    try:
-        usage = shutil.disk_usage("/")
-        free_pct = round(usage.free / usage.total * 100, 1)
-        infra["disk"] = {
-            "total_gb": round(usage.total / (1024**3), 1),
-            "free_gb": round(usage.free / (1024**3), 1),
-            "free_pct": free_pct,
-        }
-    except OSError as exc:
-        infra["disk"] = {"status": "error", "error": str(exc)}
-
-    try:
-        from genesis.observability.service_status import collect_cc_tmp_usage
-
-        infra["cc_tmp"] = collect_cc_tmp_usage()
-    except (ImportError, OSError) as exc:
-        infra["cc_tmp"] = {"status": "error", "error": str(exc)}
+    # CPU + disk + cc_tmp are synchronous /proc & /sys reads — collect them off
+    # the event loop in one thread hop (they otherwise contribute a chronic class
+    # of sub-second loop-lag WARNs under memory/CPU pressure).
+    infra.update(await asyncio.to_thread(_collect_host_metrics))
 
     try:
         from genesis.observability.cc_slots import enumerate_cc_slots
@@ -365,43 +442,9 @@ async def infrastructure(
     except Exception as exc:
         infra["qdrant_collections"] = {"status": "error", "error": str(exc)}
 
-    try:
-        from genesis.autonomy.watchdog import get_container_anon_memory, get_container_memory
-
-        anon_mem = get_container_anon_memory()
-        total_mem = get_container_memory()
-        if anon_mem and anon_mem[1] > 0:
-            anon_kernel, limit = anon_mem
-            anon_pct = anon_kernel / limit
-            mem_pressure = _read_psi(_PSI_MEMORY_PATH)
-            # Status = worse of anon% (OOM guard, non-reclaimable) and sustained
-            # memory PSI. Total cgroup usage (memory.current) is shown for
-            # reference but NOT used for health — it includes reclaimable page
-            # cache that inflates the metric, and whose reclaim is benign.
-            mem_info: dict = {
-                "status": memory_status(anon_pct, mem_pressure),
-                "current_gb": round((total_mem[0] if total_mem else anon_kernel) / (1024**3), 1),
-                "limit_gb": round(limit / (1024**3), 1),
-                "used_pct": round((total_mem[0] / limit * 100) if total_mem and total_mem[1] > 0 else anon_pct * 100, 1),
-                "anon_pct": round(anon_pct * 100, 1),
-                "pressure": mem_pressure,
-            }
-            # MemAvailable from /proc/meminfo — the kernel's estimate of
-            # memory available for new allocations without swapping. This is
-            # the metric that matters for OOM risk, not used_pct (which
-            # includes reclaimable file cache and inflates the number).
-            available_bytes = _read_mem_available()
-            if available_bytes is not None:
-                mem_info["available_gb"] = round(available_bytes / (1024**3), 1)
-                # Cap at 100% — on non-namespaced hosts, MemAvailable may
-                # exceed the cgroup limit, producing a nonsensical ratio.
-                mem_info["available_pct"] = round(min(available_bytes / limit * 100, 100.0), 1)
-            mem_info.update(_read_memory_stat())
-            infra["container_memory"] = mem_info
-        else:
-            infra["container_memory"] = {"status": "unavailable"}
-    except Exception as exc:
-        infra["container_memory"] = {"status": "error", "error": str(exc)}
+    # Container cgroup memory reads (/sys/fs/cgroup + /proc/meminfo) — likewise
+    # offloaded off the loop; kept in its original snapshot position.
+    infra.update(await asyncio.to_thread(_collect_container_memory))
 
     try:
         result = await probe_guardian()

--- a/tests/test_awareness/test_signals.py
+++ b/tests/test_awareness/test_signals.py
@@ -1,7 +1,10 @@
 """Tests for signal collectors."""
 
+import threading
+
 from genesis.awareness.signals import (
     BudgetCollector,
+    ContainerMemoryCollector,
     ConversationCollector,
     CriticalFailureCollector,
     ErrorSpikeCollector,
@@ -81,3 +84,29 @@ async def test_collect_all_tolerates_failure():
     values = {r.name: r.value for r in readings}
     assert values["broken"] == 0.0
     assert values["conversations_since_reflection"] == 0.0
+
+
+async def test_container_memory_reads_run_off_the_main_thread(monkeypatch):
+    """RED guard: ContainerMemoryCollector.collect must offload the synchronous
+    cgroup reads via asyncio.to_thread. Reverting the offload to a direct
+    ``get_container_anon_memory()`` call runs it on the main (loop) thread → this
+    fails. Mirrors test_host_metrics_run_off_the_main_thread for the snapshot path.
+
+    The collector imports get_container_anon_memory from genesis.autonomy.watchdog
+    at call time, so patching it there intercepts the real cgroup read (this test
+    stays hermetic regardless of the host's /sys/fs/cgroup layout)."""
+    import genesis.autonomy.watchdog as watchdog_mod
+
+    main = threading.main_thread()
+    seen: dict = {}
+
+    def _record_thread():
+        seen["thread"] = threading.current_thread()
+        return (1024, 4096)  # (anon_kernel bytes, limit bytes) — non-zero, non-None
+
+    monkeypatch.setattr(watchdog_mod, "get_container_anon_memory", _record_thread)
+    reading = await ContainerMemoryCollector().collect()
+
+    assert isinstance(reading, SignalReading)
+    assert seen.get("thread") is not None, "get_container_anon_memory was never called"
+    assert seen["thread"] is not main, "cgroup reads must run off the loop thread"

--- a/tests/test_observability/test_infrastructure_snapshot_offload.py
+++ b/tests/test_observability/test_infrastructure_snapshot_offload.py
@@ -50,3 +50,70 @@ async def test_infrastructure_offloads_cc_slot_enumeration(monkeypatch):
     assert enum in dispatched  # enumeration dispatched through to_thread
     enum.assert_called_once()
     assert infra["cc_slots"] == sentinel_slots
+
+
+def _neutralize_network(monkeypatch):
+    monkeypatch.setattr(
+        infra_mod,
+        "probe_qdrant",
+        AsyncMock(return_value=SimpleNamespace(status="healthy", latency_ms=1.0)),
+    )
+    monkeypatch.setattr(service_status, "probe_qdrant_collections", AsyncMock(return_value={}))
+
+
+@pytest.mark.asyncio
+async def test_infrastructure_offloads_host_metrics_and_container_memory(monkeypatch):
+    """CPU/disk/cc_tmp and container-memory /proc reads must be dispatched through
+    asyncio.to_thread — not run inline on the event loop."""
+    _neutralize_network(monkeypatch)
+
+    dispatched = []
+    real_to_thread = infra_mod.asyncio.to_thread
+
+    async def spy(fn, *a, **k):
+        dispatched.append(fn)
+        return await real_to_thread(fn, *a, **k)
+
+    monkeypatch.setattr(infra_mod.asyncio, "to_thread", spy)
+    infra = await infra_mod.infrastructure(None, None, None, None)
+
+    assert infra_mod._collect_host_metrics in dispatched
+    assert infra_mod._collect_container_memory in dispatched
+    # The offloaded results still land under their original keys.
+    assert "cpu" in infra and "disk" in infra and "cc_tmp" in infra
+    assert "container_memory" in infra
+
+
+@pytest.mark.asyncio
+async def test_host_metrics_run_off_the_main_thread(monkeypatch):
+    """RED guard: reverting the offload runs _collect_host_metrics inline on the
+    main (loop) thread → this fails. With the offload it runs on a worker thread."""
+    import threading
+
+    _neutralize_network(monkeypatch)
+    main = threading.main_thread()
+    seen: dict = {}
+    real = infra_mod._collect_host_metrics
+
+    def _record_thread():
+        seen["thread"] = threading.current_thread()
+        return real()
+
+    monkeypatch.setattr(infra_mod, "_collect_host_metrics", _record_thread)
+    await infra_mod.infrastructure(None, None, None, None)
+
+    assert seen.get("thread") is not None, "_collect_host_metrics was never called"
+    assert seen["thread"] is not main, "host-metrics collection must run off the loop thread"
+
+
+def test_cpu_delta_baseline_persists_across_calls(monkeypatch):
+    """The module-global delta baseline (_last_cpu_reading) must persist across
+    calls so the offloaded collector still computes a real delta: first call
+    establishes the baseline (used_pct None), second computes a numeric delta
+    against it. (Baseline persistence is thread-agnostic — the lock-guarded global
+    is what makes it safe once the collector runs on worker threads.)"""
+    monkeypatch.setattr(infra_mod, "_last_cpu_reading", None)
+    first = infra_mod._collect_host_metrics()
+    assert first["cpu"]["used_pct"] is None  # baseline call
+    second = infra_mod._collect_host_metrics()
+    assert isinstance(second["cpu"]["used_pct"], float)  # delta computed, not re-baselined


### PR DESCRIPTION
## What

The infrastructure health snapshot did synchronous `/proc` & `/sys/fs/cgroup` reads **inline on the event loop** — CPU (`/proc/stat` + PSI), disk, `cc_tmp`, and container cgroup memory. Usually sub-millisecond, but they stall exactly under memory/CPU pressure (kernel-side contention on PSI / meminfo / memory.stat), producing a chronic class of sub-second event-loop lag WARNs — distinct from the extraction spikes fixed in #1330.

## How

- **`_collect_host_metrics()`** (cpu + disk + cc_tmp) and **`_collect_container_memory()`** — the sync reads, each keeping its original per-section `try/except` and error shapes.
- **`infrastructure()`** offloads both via `asyncio.to_thread` — two hops placed at the original call-site positions so the snapshot's key ordering is unchanged. Mirrors the existing `enumerate_cc_slots` offload (#1323).
- **`_collect_cpu_usage()`** guards its module-global delta baseline (`_last_cpu_reading`) with a `threading.Lock` now that it runs on worker threads. Defensive: `infrastructure()` snapshots are single-flighted (`health_data.py` coalesces), so the lock never actually contends.
- **`awareness/signals.py`** `ContainerMemoryCollector.collect` offloads the same cgroup read (runs on every 5-min awareness tick).

## Safety

Snapshot output is **byte-identical** to before — the adversarial review (genesis-architect) diffed every moved field (disk/cc_tmp character-identical; container_memory branching, ternaries, guards, caps, and unavailable/error fallbacks all preserved) and confirmed the CPU-baseline lock produces identical `used_pct` on every path with no deadlock/race. Empty-state (fresh install, cgroup paths absent) degrades to the same `unavailable`/`error` shapes.

## Testing

- New offload tests: both collectors dispatched through `to_thread`; a **thread-identity RED guard** (reverting to inline runs on the main thread → fails); CPU delta-baseline persistence across calls. 23 offload/health tests + 27 awareness signal tests green; existing `test_health_psi_cpu.py` / `test_health_data.py` shape tests unchanged.

Follow-on: the SSL-context sharing half of follow-up 6bbd2aa7 (httpx per-client context construction on the loop) is evidence-gated and ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)