### PR TITLE
fix(skills): parse SKILL.md frontmatter with YAML, not a truncating regex

### DIFF
--- a/scripts/generate_skill_catalog.py
+++ b/scripts/generate_skill_catalog.py
@@ -21,6 +21,27 @@ try:
 except ImportError:  # pragma: no cover - pyyaml is a declared dependency
     yaml = None  # type: ignore[assignment]
 
+if yaml is not None:
+
+    class _FrontmatterLoader(yaml.SafeLoader):
+        """SafeLoader that keeps YAML 1.1 boolean-like scalars as their authored
+        string. Skill name/description/keywords are TEXT, so ``keywords: [off]``
+        must stay ``"off"`` — plain ``yaml.safe_load`` would coerce off/on/yes/
+        no/true/false to Python bools and catalog ``"False"``/``"True"``."""
+
+    # The subclass inherits SafeLoader's SHARED resolver map; give it its own
+    # copy (never mutate the base) with the bool implicit resolver dropped.
+    _FrontmatterLoader.yaml_implicit_resolvers = {
+        _ch: [
+            (_tag, _rx)
+            for (_tag, _rx) in _resolvers
+            if _tag != "tag:yaml.org,2002:bool"
+        ]
+        for _ch, _resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+    }
+else:  # pragma: no cover - pyyaml is a declared dependency
+    _FrontmatterLoader = None
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TIER1_DIR = REPO_ROOT / ".claude" / "skills"
 TIER2_DIRS = [
@@ -71,7 +92,9 @@ def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
             end = content.find("---", 3)
         if end > 0:
             try:
-                loaded = yaml.safe_load(content[3:end])
+                # _FrontmatterLoader is a SafeLoader subclass (no arbitrary
+                # object construction) that preserves boolean-like spellings.
+                loaded = yaml.load(content[3:end], Loader=_FrontmatterLoader)  # noqa: S506
             except Exception:
                 # Any parse failure (YAMLError, RecursionError on nested
                 # aliases, …) routes to the legacy fallback below rather than
@@ -85,7 +108,13 @@ def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
                 )
                 kw = loaded.get("keywords")
                 if isinstance(kw, (list, tuple)):
-                    keywords = [str(k).strip() for k in kw if str(k).strip()]
+                    # Drop null/empty flow elements (`[a, , b]` → a None) rather
+                    # than stringifying them into a bogus "None" keyword.
+                    keywords = [
+                        str(k).strip()
+                        for k in kw
+                        if k is not None and str(k).strip()
+                    ]
                 elif isinstance(kw, str):
                     keywords = [k.strip() for k in kw.split(",") if k.strip()]
                 else:

--- a/scripts/generate_skill_catalog.py
+++ b/scripts/generate_skill_catalog.py
@@ -24,21 +24,30 @@ except ImportError:  # pragma: no cover - pyyaml is a declared dependency
 if yaml is not None:
 
     class _FrontmatterLoader(yaml.SafeLoader):
-        """SafeLoader that keeps YAML 1.1 boolean-like scalars as their authored
-        string. Skill name/description/keywords are TEXT, so ``keywords: [off]``
-        must stay ``"off"`` — plain ``yaml.safe_load`` would coerce off/on/yes/
-        no/true/false to Python bools and catalog ``"False"``/``"True"``."""
+        """SafeLoader that loads every plain scalar as a STRING and FORBIDS YAML
+        aliases (a lone anchor with no alias is harmless). Skill frontmatter is flat text (name/description/
+        keywords), so it never legitimately uses anchors — refusing aliases at
+        the composer closes the alias-multiplication DoS class at the source
+        (billion-laughs expansion, and ``*a``-multiplied large scalars in keyword
+        lists — a crafted skill-library/plugin ``SKILL.md`` could otherwise
+        exhaust memory during the hourly catalog refresh). Clearing the implicit
+        resolvers keeps authored spellings verbatim (off/007/0x10/12:30 stay
+        strings); explicit ``!!python/*`` tags are still refused (SafeLoader).
+        Any alias raises → the caller falls back to the bounded legacy parse."""
 
-    # The subclass inherits SafeLoader's SHARED resolver map; give it its own
-    # copy (never mutate the base) with the bool implicit resolver dropped.
-    _FrontmatterLoader.yaml_implicit_resolvers = {
-        _ch: [
-            (_tag, _rx)
-            for (_tag, _rx) in _resolvers
-            if _tag != "tag:yaml.org,2002:bool"
-        ]
-        for _ch, _resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
-    }
+        def compose_node(self, parent, index):
+            if self.check_event(yaml.events.AliasEvent):
+                event = self.peek_event()
+                raise yaml.composer.ComposerError(
+                    None,
+                    None,
+                    "aliases are not allowed in skill frontmatter",
+                    event.start_mark,
+                )
+            return super().compose_node(parent, index)
+
+    # Own (empty) resolver map — never mutate SafeLoader's shared class attr.
+    _FrontmatterLoader.yaml_implicit_resolvers = {}
 else:  # pragma: no cover - pyyaml is a declared dependency
     _FrontmatterLoader = None
 
@@ -101,19 +110,24 @@ def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
                 # silently dropping the skill's description.
                 loaded = None
             if isinstance(loaded, dict):
+                # Metadata fields are TEXT. Accept only scalar (str) values and
+                # scalar keyword elements; REJECT non-scalar structures (lists,
+                # maps, alias trees) BEFORE any str() — recursively stringifying
+                # a YAML alias bomb can exhaust CPU/memory in the catalog refresh.
+                raw_name = loaded.get("name")
                 name = (
-                    str(loaded["name"]).strip()
-                    if loaded.get("name")
+                    raw_name.strip()
+                    if isinstance(raw_name, str) and raw_name.strip()
                     else fallback_name
+                )
+                raw_desc = loaded.get("description")
+                description = (
+                    _normalize_desc(raw_desc) if isinstance(raw_desc, str) else ""
                 )
                 kw = loaded.get("keywords")
                 if isinstance(kw, (list, tuple)):
-                    # Drop null/empty flow elements (`[a, , b]` → a None) rather
-                    # than stringifying them into a bogus "None" keyword.
                     keywords = [
-                        str(k).strip()
-                        for k in kw
-                        if k is not None and str(k).strip()
+                        s for k in kw if isinstance(k, str) and (s := k.strip())
                     ]
                 elif isinstance(kw, str):
                     keywords = [k.strip() for k in kw.split(",") if k.strip()]
@@ -121,7 +135,7 @@ def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
                     keywords = []
                 return {
                     "name": name,
-                    "description": _normalize_desc(loaded.get("description")),
+                    "description": description,
                     "keywords": keywords,
                 }
     # PyYAML unavailable, no frontmatter, or block not a mapping — legacy parse.

--- a/scripts/generate_skill_catalog.py
+++ b/scripts/generate_skill_catalog.py
@@ -16,6 +16,11 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 
+try:
+    import yaml
+except ImportError:  # pragma: no cover - pyyaml is a declared dependency
+    yaml = None  # type: ignore[assignment]
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TIER1_DIR = REPO_ROOT / ".claude" / "skills"
 TIER2_DIRS = [
@@ -44,8 +49,61 @@ def _extract_skill_info(skill_dir: Path) -> dict | None:
     return {"name": skill_dir.name, "description": "", "keywords": []}
 
 
+def _normalize_desc(value: object) -> str:
+    """Collapse a scalar (folded/literal/plain/quoted) to one scannable line."""
+    if value is None:
+        return ""
+    return " ".join(str(value).split())
+
+
 def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
-    """Parse YAML-like frontmatter from a markdown file."""
+    """Parse YAML frontmatter into name/description/keywords.
+
+    Uses a real YAML parser so descriptions with apostrophes, escaped quotes,
+    or multi-line/folded scalars survive in full (the previous regex truncated
+    them at the first ``'``/``"``/newline, dropping searchable text). Falls back
+    to a best-effort regex parse only when PyYAML is unavailable or the block is
+    not a valid YAML mapping.
+    """
+    if content.startswith("---") and yaml is not None:
+        end = content.find("\n---", 3)
+        if end < 0:
+            end = content.find("---", 3)
+        if end > 0:
+            try:
+                loaded = yaml.safe_load(content[3:end])
+            except Exception:
+                # Any parse failure (YAMLError, RecursionError on nested
+                # aliases, …) routes to the legacy fallback below rather than
+                # silently dropping the skill's description.
+                loaded = None
+            if isinstance(loaded, dict):
+                name = (
+                    str(loaded["name"]).strip()
+                    if loaded.get("name")
+                    else fallback_name
+                )
+                kw = loaded.get("keywords")
+                if isinstance(kw, (list, tuple)):
+                    keywords = [str(k).strip() for k in kw if str(k).strip()]
+                elif isinstance(kw, str):
+                    keywords = [k.strip() for k in kw.split(",") if k.strip()]
+                else:
+                    keywords = []
+                return {
+                    "name": name,
+                    "description": _normalize_desc(loaded.get("description")),
+                    "keywords": keywords,
+                }
+    # PyYAML unavailable, no frontmatter, or block not a mapping — legacy parse.
+    return _parse_frontmatter_legacy(content, fallback_name)
+
+
+def _parse_frontmatter_legacy(content: str, fallback_name: str = "") -> dict:
+    """Best-effort regex frontmatter parse — the no-PyYAML degraded fallback.
+
+    NOTE: truncates descriptions at apostrophes / escaped quotes / newlines;
+    ``_parse_frontmatter`` is the real parser and should be preferred."""
     name = fallback_name
     description = ""
 

--- a/tests/test_scripts/test_generate_skill_catalog.py
+++ b/tests/test_scripts/test_generate_skill_catalog.py
@@ -155,3 +155,85 @@ def test_scan_tier_relative_paths_under_repo_root(tmp_path):
     assert results[0]["path"] == str(
         Path(".claude") / "skills" / "gitnexus" / "gitnexus-cli"
     )
+
+
+def _fm(name: str, body: str) -> str:
+    """A SKILL.md string with the given frontmatter body."""
+    return f"---\nname: {name}\n{body}\n---\n# {name}\n"
+
+
+class TestParseFrontmatter:
+    """Descriptions must be parsed COMPLETELY — the regex parser truncated at
+    apostrophes (unquoted), escaped quotes (double-quoted), and newlines
+    (plain multi-line scalars), losing searchable text (regression: the live
+    catalog cut `genesis-voice` at "user's", `gitnexus-*` at `Examples: \\`,
+    and `code-intelligence`'s continuation line)."""
+
+    def test_unquoted_apostrophe_not_truncated(self):
+        # The genesis-voice failure: an apostrophe in an unquoted scalar.
+        content = _fm(
+            "genesis-voice",
+            "description: Apply when Genesis writes as itself. Not for writing "
+            "in the user's voice (that's voice-master).",
+        )
+        desc = _gen._parse_frontmatter(content)["description"]
+        assert "user's voice" in desc
+        assert "voice-master" in desc
+
+    def test_double_quoted_escaped_quote_not_truncated(self):
+        # The gitnexus-* failure: an escaped quote inside a double-quoted scalar.
+        content = _fm(
+            "gitnexus-cli",
+            'description: "Run CLI commands. Examples: \\"analyze a repo\\", '
+            '\\"check status\\"."',
+        )
+        desc = _gen._parse_frontmatter(content)["description"]
+        assert "analyze a repo" in desc
+        assert "check status" in desc
+
+    def test_plain_multiline_continuation_kept(self):
+        # The code-intelligence failure: a plain scalar wrapped across lines.
+        content = _fm(
+            "code-intelligence",
+            "description: Code understanding tool selection. Use when exploring "
+            "architecture,\n  finding definitions, or tracing execution.",
+        )
+        desc = _gen._parse_frontmatter(content)["description"]
+        assert "finding definitions" in desc
+        assert "tracing execution" in desc
+
+    def test_folded_scalar_joined_single_line(self):
+        content = _fm("x", "description: >\n  Line one\n  line two.")
+        assert _gen._parse_frontmatter(content)["description"] == "Line one line two."
+
+    def test_literal_scalar_normalized_single_line(self):
+        # Literal `|` keeps newlines in YAML; the catalog wants one scannable line.
+        content = _fm("x", "description: |\n  Multi\n  line desc.")
+        assert _gen._parse_frontmatter(content)["description"] == "Multi line desc."
+
+    def test_keywords_list_parsed(self):
+        content = _fm("x", "description: y\nkeywords: [alpha, beta, gamma]")
+        assert _gen._parse_frontmatter(content)["keywords"] == [
+            "alpha",
+            "beta",
+            "gamma",
+        ]
+
+    def test_simple_fields_still_work(self):
+        content = _fm("plain", "description: does a thing")
+        result = _gen._parse_frontmatter(content)
+        assert result["name"] == "plain"
+        assert result["description"] == "does a thing"
+
+    def test_no_frontmatter_uses_fallback_name(self):
+        result = _gen._parse_frontmatter("# just a heading\n", fallback_name="fb")
+        assert result["name"] == "fb"
+        assert result["description"] == ""
+        assert result["keywords"] == []
+
+    def test_falls_back_when_pyyaml_missing(self, monkeypatch):
+        # No-PyYAML degraded path: routes through _parse_frontmatter_legacy and
+        # still returns the correct shape for a simple (untruncatable) scalar.
+        monkeypatch.setattr(_gen, "yaml", None)
+        result = _gen._parse_frontmatter(_fm("x", "description: plain desc"))
+        assert result == {"name": "x", "description": "plain desc", "keywords": []}

--- a/tests/test_scripts/test_generate_skill_catalog.py
+++ b/tests/test_scripts/test_generate_skill_catalog.py
@@ -271,6 +271,44 @@ class TestParseFrontmatter:
         content = _fm("x", "description: y\nkeywords: [python, , web]")
         assert _gen._parse_frontmatter(content)["keywords"] == ["python", "web"]
 
+    def test_numeric_like_scalars_kept_verbatim(self):
+        # Leading-zero / hex / sexagesimal scalars must not be re-typed (YAML 1.1
+        # would give "7"/"16"/"750"); the authored spelling must survive.
+        content = _fm("x", "description: y\nkeywords: [007, 0x10]")
+        assert _gen._parse_frontmatter(content)["keywords"] == ["007", "0x10"]
+
+    def test_non_scalar_description_rejected(self):
+        # A description authored as a LIST is not text — reject it (empty),
+        # never str()/repr it into the catalog.
+        content = "---\nname: x\ndescription:\n  - a\n  - b\n---\n# x\n"
+        assert _gen._parse_frontmatter(content)["description"] == ""
+
+    def test_loader_refuses_yaml_aliases(self):
+        # Skill frontmatter never uses anchors/aliases; the loader refuses them,
+        # closing the alias-multiplication DoS class at the source.
+        import pytest
+        import yaml
+
+        with pytest.raises(yaml.YAMLError):
+            yaml.load("a: &x 1\nb: *x\n", Loader=_gen._FrontmatterLoader)  # noqa: S506
+
+    def test_alias_amplification_falls_back_without_blowup(self):
+        # A crafted alias-amplification frontmatter (many *a pointing at a large
+        # anchored scalar) must NOT materialize quadratically — aliases are
+        # refused, so the parser falls back to the bounded legacy regex.
+        import time
+
+        big = "x" * 2000
+        content = (
+            f"---\nname: y\nanchor: &a {big}\n"
+            "keywords: [*a, *a, *a, *a, *a, *a, *a, *a]\n---\n"
+        )
+        start = time.time()
+        result = _gen._parse_frontmatter(content)
+        assert time.time() - start < 1.0
+        # Legacy keeps only the literal "*a" tokens — never 8x the big scalar.
+        assert sum(len(k) for k in result["keywords"]) < len(big)
+
     def test_base_safeloader_bool_resolver_not_mutated(self):
         # Customizing _FrontmatterLoader must NOT mutate SafeLoader's shared
         # resolver map (a class-attribute footgun).

--- a/tests/test_scripts/test_generate_skill_catalog.py
+++ b/tests/test_scripts/test_generate_skill_catalog.py
@@ -237,3 +237,43 @@ class TestParseFrontmatter:
         monkeypatch.setattr(_gen, "yaml", None)
         result = _gen._parse_frontmatter(_fm("x", "description: plain desc"))
         assert result == {"name": "x", "description": "plain desc", "keywords": []}
+
+    def test_boolean_like_scalars_kept_as_strings(self):
+        # yaml.safe_load coerces YAML 1.1 booleans; the catalog needs the
+        # authored spelling (e.g. an "off" keyword) for matching.
+        content = _fm(
+            "x", "description: y\nkeywords: [off, on, no, yes, true, false]"
+        )
+        assert _gen._parse_frontmatter(content)["keywords"] == [
+            "off",
+            "on",
+            "no",
+            "yes",
+            "true",
+            "false",
+        ]
+
+    def test_boolean_like_description_kept_as_string(self):
+        assert _gen._parse_frontmatter(_fm("x", "description: yes"))["description"] == "yes"
+
+    def test_frontmatter_loader_refuses_python_object_tags(self):
+        # The custom loader is a SafeLoader subclass — arbitrary object
+        # construction (code execution) must still be refused.
+        import pytest
+        import yaml
+
+        payload = "!!python/object/apply:os.system ['echo pwned']"
+        with pytest.raises(yaml.YAMLError):
+            yaml.load(payload, Loader=_gen._FrontmatterLoader)  # noqa: S506
+
+    def test_keywords_drops_null_and_empty_elements(self):
+        # A null/empty flow element must not become a bogus "None" keyword.
+        content = _fm("x", "description: y\nkeywords: [python, , web]")
+        assert _gen._parse_frontmatter(content)["keywords"] == ["python", "web"]
+
+    def test_base_safeloader_bool_resolver_not_mutated(self):
+        # Customizing _FrontmatterLoader must NOT mutate SafeLoader's shared
+        # resolver map (a class-attribute footgun).
+        import yaml
+
+        assert yaml.safe_load("off") is False


### PR DESCRIPTION
## What

`_parse_frontmatter()` in `scripts/generate_skill_catalog.py` parsed skill frontmatter with a regex `["']?([^"'\n]+)` that stops at the first `'`, `"`, or newline. It therefore **truncated skill descriptions** whenever they contained an apostrophe (unquoted scalar), an escaped quote (double-quoted scalar), or a line wrap (plain multi-line scalar) — silently dropping searchable text from `~/.genesis/skill_catalog.json`.

Real cases in the live catalog:
- `genesis-voice` → cut at `user's` (lost "voice-master", "ghostwriter")
- `code-intelligence` → lost its whole continuation line
- all `gitnexus-*` → cut at `Examples: \`

## Why it matters

The catalog feeds **skill matching** for the skill-injection hook and the filter in the new `/list-skills` command. Truncated descriptions mean skills silently fail to match text that is present in their `SKILL.md`. (Surfaced by the `/list-skills` review, PR #1379.)

## Fix

- Parse the frontmatter block with `yaml.safe_load` (PyYAML is already a declared dependency, `pyproject.toml`), normalizing folded/literal/plain scalars to one scannable line.
- Keep the **old regex verbatim** as `_parse_frontmatter_legacy`, used only if PyYAML is unavailable or the block isn't a valid YAML mapping. Any parse failure routes to that fallback (broadened `except`), so a skill never silently loses its description.

## Verification

- **TDD, RED-verified**: the three truncation modes fail under the old regex, pass under the fix. Added folded/literal/keywords + fallback-path (`yaml=None`) tests. **17 passed**, ruff clean.
- **E2E on real data**: ran the fixed parser against the actual truncated `SKILL.md` files — `genesis-voice`/`code-intelligence`/`gitnexus-cli` now parse in full (the previously-dropped terms return).
- **No consumer regression** (23 hook + taste tests pass): the injection hook doesn't score on descriptions and all consumers re-truncate at display, so longer descriptions are safe.

## Deploy path

Runtime script — takes effect on the next catalog regeneration (the injection hook regenerates hourly / on missing). No schema, no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)