### PR TITLE
fix(sentinel): degraded-safe dispatch when MCP config is unavailable

### DIFF
--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -208,6 +208,10 @@ def _serialize_result(result: SentinelResult) -> str:
         "observation_id": result.observation_id,
         "reason": result.reason,
         "duration_s": result.duration_s,
+        # Persist the degraded marker so a parked-then-resumed run keeps its
+        # propose-only provenance (else resume deserializes degraded=False and
+        # the safety marker is lost). _deserialize_result reads it generically.
+        "degraded": result.degraded,
     })
 
 

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -115,6 +115,48 @@ _ALARM_CONFIRMATION_COUNT = 2
 # attempts → alarm recurs → dispatch again (every tick).
 _RESOLVED_COOLDOWN_S = 15 * 60  # 15 minutes
 
+# Tools disallowed when a Sentinel session runs DEGRADED (MCP config
+# unavailable). Without the genesis MCP servers the session cannot call
+# outreach_send_and_wait to self-gate its actions, so under skip_permissions it
+# must not act directly — block every mutation/action tool while keeping read
+# tools (Read/Grep/Glob) for diagnosis. proposed_actions still flow (they are
+# parsed from the session OUTPUT, not an MCP tool) and the parent approval gate
+# executes them. See _dispatch_cc_session / _escalate_mcp_config_unavailable.
+#
+# This is a SUPERSET of the established read-only reflection lockdown
+# (genesis.cc.session_config._REFLECTION_DENY_BUILTINS) plus MultiEdit and the web
+# tools: Read is KEPT for diagnosis, and Read + WebFetch is an exfiltration channel
+# (read a secret, embed it in a fetched URL), so the web tools must be blocked too.
+# Kept as a literal (not an import) to avoid an import cycle;
+# test_dispatcher.TestDegradedMcpConfig enforces the ⊇ _REFLECTION_DENY_BUILTINS
+# invariant so this never silently falls behind the reflection lockdown.
+_DEGRADED_DISALLOWED_TOOLS: tuple[str, ...] = (
+    "Bash",
+    "Write",
+    "Edit",
+    "MultiEdit",
+    "NotebookEdit",
+    "Task",
+    "Workflow",
+    "Skill",
+    "SendMessage",
+    "ReportFindings",
+    "CronCreate",
+    "CronDelete",
+    "ScheduleWakeup",
+    "Monitor",
+    "TaskCreate",
+    "TaskUpdate",
+    "TaskStop",
+    "RemoteTrigger",
+    "PushNotification",
+    "DesignSync",
+    "EnterWorktree",
+    "ExitWorktree",
+    "WebFetch",
+    "WebSearch",
+)
+
 
 def _serialize_request(request: SentinelRequest) -> str:
     """Serialize a SentinelRequest to JSON for state persistence."""
@@ -405,6 +447,49 @@ class SentinelDispatcher:
             )
         except Exception:
             logger.error("Failed to emit sentinel event %s", event_type, exc_info=True)
+
+    async def _escalate_mcp_config_unavailable(self, request: SentinelRequest) -> None:
+        """Surface a Sentinel MCP-config build failure loudly (event + outreach).
+
+        Called when ``build_mcp_config`` yields no config path — whether it
+        raised (import/other error) or returned ``None`` internally (render
+        failure, ``session_config.py``). The session then runs degraded
+        (propose-only), so this makes the config regression VISIBLE instead of
+        silently degrading the remediator to a no-op-ish diagnoser.
+        """
+        await self._emit_event(
+            "ERROR",
+            "sentinel.mcp_config_unavailable",
+            "Sentinel MCP config unavailable — running degraded (propose-only, "
+            "no direct action). Likely a SessionConfigBuilder regression.",
+        )
+        if self._outreach_pipeline is None:
+            return
+        try:
+            from genesis.outreach.pipeline import OutreachCategory, OutreachRequest
+
+            msg = (
+                "⚠️ Sentinel MCP config unavailable — the remediation session is "
+                "running in degraded propose-only mode (it can diagnose and "
+                "propose actions for approval, but cannot act directly). Trigger: "
+                f"{request.trigger_source} — {request.trigger_reason}. Likely a "
+                "SessionConfigBuilder regression; check the logs."
+            )
+            await self._outreach_pipeline.submit_raw(
+                msg,
+                OutreachRequest(
+                    category=OutreachCategory.BLOCKER,
+                    topic="Sentinel MCP config unavailable",
+                    context=msg,
+                    salience_score=1.0,
+                    signal_type="sentinel_mcp_config_unavailable",
+                    source_id=f"sentinel-mcp-unavailable:{int(time.time())}",
+                ),
+            )
+        except Exception:
+            logger.error(
+                "Sentinel MCP-unavailable escalation failed to send", exc_info=True
+            )
 
     async def _gated_dispatch(self, request: SentinelRequest) -> SentinelResult:
         """Gate checks and dispatch, protected by asyncio.Lock."""
@@ -1297,13 +1382,27 @@ class SentinelDispatcher:
         self._active_session_id = session_id
 
         try:
-            # Build MCP config so the CC session has health + outreach tools
+            # Build MCP config so the CC session has health + outreach tools.
+            # build_mcp_config can FAIL (import/other error → except below) OR
+            # return None (internal render failure — session_config.py swallows
+            # its own error and returns None). Guard the RESULT, not just the
+            # except, so both funnel to the same degraded-safe path.
             mcp_path = None
             try:
                 from genesis.cc.session_config import SessionConfigBuilder
                 mcp_path = SessionConfigBuilder().build_mcp_config("sentinel")
             except Exception:
                 logger.warning("Failed to build MCP config for Sentinel", exc_info=True)
+
+            degraded = mcp_path is None
+            if degraded:
+                # No genesis MCP servers → the session cannot call
+                # outreach_send_and_wait to self-gate. Under skip_permissions it
+                # could still mutate via Bash WITHOUT the approval gate, so drop
+                # to a propose-only posture (disallow mutation/action tools) and
+                # surface the failure loudly. Diagnose+propose still works and the
+                # parent-side approval gate governs execution.
+                await self._escalate_mcp_config_unavailable(request)
 
             invocation = CCInvocation(
                 prompt=full_prompt,
@@ -1312,6 +1411,9 @@ class SentinelDispatcher:
                 effort=EffortLevel.HIGH,
                 timeout_s=3600,
                 skip_permissions=True,
+                disallowed_tools=(
+                    list(_DEGRADED_DISALLOWED_TOOLS) if degraded else None
+                ),
                 system_prompt=system_prompt,
                 append_system_prompt=True,
                 output_format="text",
@@ -1321,8 +1423,8 @@ class SentinelDispatcher:
 
             output = await self._invoker.run(invocation)
 
-            # Parse output
-            result = self._parse_output(output, session_id)
+            # Parse output (degraded → don't trust self-reported resolution)
+            result = self._parse_output(output, session_id, degraded=degraded)
             return result
         finally:
             self._active_session_id = None
@@ -1332,8 +1434,17 @@ class SentinelDispatcher:
             except Exception:
                 logger.debug("Failed to end sentinel session", exc_info=True)
 
-    def _parse_output(self, output, session_id: str) -> SentinelResult:
-        """Parse the CC session output into a SentinelResult."""
+    def _parse_output(
+        self, output, session_id: str, degraded: bool = False
+    ) -> SentinelResult:
+        """Parse the CC session output into a SentinelResult.
+
+        ``degraded`` marks a session that ran without action tools (MCP config
+        unavailable → propose-only). Such a session structurally CANNOT have taken
+        action, so its self-reported ``resolved``/``actions_taken`` must not be
+        trusted (that would falsely mark the alarm HEALTHY and suppress
+        re-dispatch); only its ``proposed_actions`` are honoured (parent-gated).
+        """
         import json
         import re
 
@@ -1378,9 +1489,24 @@ class SentinelDispatcher:
         actions_taken = parsed.get("actions_taken", [])
         resolved = parsed.get("resolved", False)
 
+        # A degraded (tool-less) session could not have acted — never trust its
+        # self-reported resolution/actions_taken (fabricated in this mode). Keep
+        # only proposed_actions, which go through the parent approval gate.
+        if degraded:
+            resolved = False
+            actions_taken = []
+
         # Fallback: use the full text as diagnosis
         if not diagnosis and text:
             diagnosis = text[:500]
+
+        reason = (
+            "actions proposed"
+            if proposed_actions
+            else ("resolved" if resolved else "no actions proposed — escalating")
+        )
+        if degraded:
+            reason = f"degraded (propose-only): {reason}"
 
         return SentinelResult(
             dispatched=True,
@@ -1389,7 +1515,7 @@ class SentinelDispatcher:
             actions_taken=actions_taken,
             proposed_actions=proposed_actions,
             resolved=resolved,
-            reason="actions proposed" if proposed_actions else ("resolved" if resolved else "no actions proposed — escalating"),
+            reason=reason,
         )
 
     async def _approve_and_execute_actions(self, result: SentinelResult) -> list[dict]:

--- a/src/genesis/sentinel/dispatcher.py
+++ b/src/genesis/sentinel/dispatcher.py
@@ -136,6 +136,11 @@ _DEGRADED_DISALLOWED_TOOLS: tuple[str, ...] = (
     "Edit",
     "MultiEdit",
     "NotebookEdit",
+    # Subagent spawn: "Agent" is the CURRENT CC CLI name (tool_bootstrap.py /
+    # .claude/settings.json); "Task" is the obsolete name kept for parity with
+    # _REFLECTION_DENY_BUILTINS. Block BOTH — a spawned subagent escapes the
+    # propose-only lockdown and could mutate directly.
+    "Agent",
     "Task",
     "Workflow",
     "Skill",
@@ -246,6 +251,11 @@ class SentinelResult:
     observation_id: str = ""
     reason: str = ""  # Why dispatched or skipped
     duration_s: float = 0.0
+    # True when the session ran without action tools (MCP config unavailable →
+    # propose-only). A degraded session cannot have acted, so downstream MUST NOT
+    # trust its self-reported resolution — including the no-action-phrase
+    # heuristic in _finalize_dispatch.
+    degraded: bool = False
 
 
 def _extract_pattern(request: SentinelRequest) -> str:
@@ -895,6 +905,7 @@ class SentinelDispatcher:
         if (
             not resolved
             and result.dispatched
+            and not result.degraded  # a tool-less session's "resolved" is untrusted
             and not result.proposed_actions
             and result.diagnosis
         ):
@@ -1516,6 +1527,7 @@ class SentinelDispatcher:
             proposed_actions=proposed_actions,
             resolved=resolved,
             reason=reason,
+            degraded=degraded,
         )
 
     async def _approve_and_execute_actions(self, result: SentinelResult) -> list[dict]:

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -1342,6 +1342,50 @@ class TestDegradedMcpConfig:
         assert set(_REFLECTION_DENY_BUILTINS) <= set(_DEGRADED_DISALLOWED_TOOLS)
         # Web tools blocked: Read (kept for diagnosis) + WebFetch is exfiltration.
         assert {"WebFetch", "WebSearch"}.issubset(_DEGRADED_DISALLOWED_TOOLS)
+        # Subagent spawn blocked under BOTH names (current "Agent", obsolete "Task")
+        # so a degraded session cannot delegate mutation to a spawned agent.
+        assert {"Agent", "Task"}.issubset(_DEGRADED_DISALLOWED_TOOLS)
         # Direct-mutation built-ins.
-        for tool in ("Bash", "Write", "Edit", "MultiEdit", "NotebookEdit", "Task"):
+        for tool in ("Bash", "Write", "Edit", "MultiEdit", "NotebookEdit"):
             assert tool in _DEGRADED_DISALLOWED_TOOLS
+
+    @pytest.mark.asyncio
+    async def test_degraded_no_action_phrase_not_auto_resolved(self):
+        # _finalize_dispatch's no-action-phrase heuristic ("false positive" etc.)
+        # must NOT re-resolve a degraded session (the prompt encourages exactly
+        # those phrases; a tool-less session's resolution is untrusted).
+        d, _outreach = self._make_with_outreach()
+        mock_output = MagicMock()
+        mock_output.text = (
+            '{"diagnosis": "This looks like a false positive; no longer active.", '
+            '"actions_taken": [], "resolved": false, "proposed_actions": []}'
+        )
+        d._invoker.run = AsyncMock(return_value=mock_output)
+        with patch(
+            "genesis.cc.session_config.SessionConfigBuilder.build_mcp_config",
+            return_value=None,
+        ):
+            result = await self._run_dispatch(d)
+
+        assert result.degraded is True
+        assert result.resolved is False  # phrase heuristic skipped when degraded
+        assert d._state.state != SentinelState.HEALTHY
+
+    @pytest.mark.asyncio
+    async def test_healthy_no_action_phrase_still_auto_resolves(self):
+        # Control: the phrase heuristic still works on a NON-degraded session.
+        d, _outreach = self._make_with_outreach()
+        mock_output = MagicMock()
+        mock_output.text = (
+            '{"diagnosis": "Confirmed false positive — no longer active.", '
+            '"actions_taken": [], "resolved": false, "proposed_actions": []}'
+        )
+        d._invoker.run = AsyncMock(return_value=mock_output)
+        with patch(
+            "genesis.cc.session_config.SessionConfigBuilder.build_mcp_config",
+            return_value="/tmp/sentinel-mcp.json",
+        ):
+            result = await self._run_dispatch(d)
+
+        assert result.degraded is False
+        assert result.resolved is True  # heuristic unchanged for healthy sessions

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -11,6 +11,7 @@ import pytest
 from genesis.sentinel.classifier import FireAlarm
 from genesis.sentinel.dispatcher import (
     _BACKOFF_SCHEDULE_S,
+    _DEGRADED_DISALLOWED_TOOLS,
     _ESCALATE_AT_ATTEMPT,
     _RESOLVED_COOLDOWN_S,
     SentinelDispatcher,
@@ -1223,3 +1224,124 @@ class TestShadowClassification:
 
         assert result.dispatched
         assert _shadow_events(mock_log) == []
+
+
+class TestDegradedMcpConfig:
+    """When build_mcp_config yields no path (raises OR returns None), the session
+    runs degraded-safe: propose-only (mutation tools disallowed) + a loud ERROR
+    event + a BLOCKER outreach. proposed_actions still flow (parsed from output)
+    and the parent approval gate governs execution.
+    """
+
+    def _make_with_outreach(self):
+        outreach = AsyncMock()
+        # The dispatch approval gate runs before _dispatch_cc_session: grant it
+        # so the flow reaches the MCP-config build we're testing.
+        outreach.submit_raw_and_wait = AsyncMock(return_value=(MagicMock(), "approve"))
+        outreach.submit_raw = AsyncMock()
+        d = _make_dispatcher(outreach_pipeline=outreach)
+        d._state.started_at = "2020-01-01T00:00:00+00:00"
+        return d, outreach
+
+    async def _run_dispatch(self, d):
+        with patch("genesis.sentinel.dispatcher.write_last_run"), patch(
+            "genesis.sentinel.dispatcher.write_state_for_guardian"
+        ), patch("genesis.sentinel.dispatcher.append_log"):
+            return await d.dispatch(
+                SentinelRequest(
+                    trigger_source="test",
+                    trigger_reason="mcp degraded unit",
+                    tier=2,
+                )
+            )
+
+    def _last_invocation(self, d):
+        assert d._invoker.run.await_count >= 1
+        return d._invoker.run.call_args.args[0]
+
+    def _emitted_event_types(self, d):
+        return [c.args[2] for c in d._event_bus.emit.call_args_list if len(c.args) >= 3]
+
+    @pytest.mark.asyncio
+    async def test_none_config_dispatches_degraded_and_escalates(self):
+        d, outreach = self._make_with_outreach()
+        with patch(
+            "genesis.cc.session_config.SessionConfigBuilder.build_mcp_config",
+            return_value=None,
+        ):
+            await self._run_dispatch(d)
+
+        inv = self._last_invocation(d)
+        # Propose-only posture: mutation tools disallowed, no MCP config, but
+        # read tools remain (skip_permissions stays True) for diagnosis.
+        assert inv.disallowed_tools == list(_DEGRADED_DISALLOWED_TOOLS)
+        assert inv.mcp_config is None
+        assert inv.skip_permissions is True
+        # Loud ERROR event + BLOCKER outreach.
+        assert "sentinel.mcp_config_unavailable" in self._emitted_event_types(d)
+        from genesis.outreach.pipeline import OutreachCategory
+
+        assert outreach.submit_raw.await_count >= 1
+        assert outreach.submit_raw.call_args.args[1].category == OutreachCategory.BLOCKER
+
+    @pytest.mark.asyncio
+    async def test_build_raises_is_also_degraded(self):
+        d, _outreach = self._make_with_outreach()
+        with patch(
+            "genesis.cc.session_config.SessionConfigBuilder.build_mcp_config",
+            side_effect=RuntimeError("boom"),
+        ):
+            await self._run_dispatch(d)
+
+        inv = self._last_invocation(d)
+        assert inv.disallowed_tools == list(_DEGRADED_DISALLOWED_TOOLS)
+        assert "sentinel.mcp_config_unavailable" in self._emitted_event_types(d)
+
+    @pytest.mark.asyncio
+    async def test_healthy_config_is_not_degraded(self):
+        d, outreach = self._make_with_outreach()
+        with patch(
+            "genesis.cc.session_config.SessionConfigBuilder.build_mcp_config",
+            return_value="/tmp/sentinel-mcp.json",
+        ):
+            await self._run_dispatch(d)
+
+        inv = self._last_invocation(d)
+        assert inv.mcp_config == "/tmp/sentinel-mcp.json"
+        assert inv.disallowed_tools is None  # full posture — no degrade
+        assert "sentinel.mcp_config_unavailable" not in self._emitted_event_types(d)
+        assert outreach.submit_raw.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_degraded_session_resolution_not_trusted(self):
+        # A tool-less session cannot have acted; its self-reported resolution /
+        # actions_taken must NOT be trusted (else a real alarm is silently marked
+        # HEALTHY and re-dispatch suppressed). proposed_actions still flow.
+        d, _outreach = self._make_with_outreach()
+        mock_output = MagicMock()
+        mock_output.text = (
+            '{"diagnosis": "looked around", '
+            '"actions_taken": ["restarted svc X"], "resolved": true}'
+        )
+        d._invoker.run = AsyncMock(return_value=mock_output)
+        with patch(
+            "genesis.cc.session_config.SessionConfigBuilder.build_mcp_config",
+            return_value=None,
+        ):
+            result = await self._run_dispatch(d)
+
+        assert result.resolved is False
+        assert result.actions_taken == []
+        assert d._state.state != SentinelState.HEALTHY  # not silently resolved
+
+    def test_degraded_set_is_superset_of_reflection_lockdown(self):
+        # Reuse the codebase's established read-only lockdown rather than a
+        # hand-rolled list — and never silently fall behind it.
+        from genesis.cc.session_config import _REFLECTION_DENY_BUILTINS
+
+        assert set(_REFLECTION_DENY_BUILTINS) <= set(_DEGRADED_DISALLOWED_TOOLS)
+        # Web tools blocked: Read (kept for diagnosis) + WebFetch is exfiltration.
+        assert {"WebFetch", "WebSearch"}.issubset(_DEGRADED_DISALLOWED_TOOLS)
+        # Direct-mutation built-ins.
+        for tool in ("Bash", "Write", "Edit", "MultiEdit", "NotebookEdit", "Task"):
+            assert tool in _DEGRADED_DISALLOWED_TOOLS

--- a/tests/test_sentinel/test_dispatcher.py
+++ b/tests/test_sentinel/test_dispatcher.py
@@ -1389,3 +1389,18 @@ class TestDegradedMcpConfig:
 
         assert result.degraded is False
         assert result.resolved is True  # heuristic unchanged for healthy sessions
+
+    def test_degraded_flag_survives_serialize_roundtrip(self):
+        # A parked-then-resumed degraded run must keep its propose-only marker,
+        # else resume_from_approval deserializes degraded=False (safety lost).
+        from genesis.sentinel.dispatcher import _deserialize_result, _serialize_result
+
+        r = SentinelResult(
+            dispatched=True, diagnosis="x", proposed_actions=[{"a": 1}], degraded=True
+        )
+        back = _deserialize_result(_serialize_result(r))
+        assert back is not None
+        assert back.degraded is True
+        # Control: non-degraded round-trips as False.
+        r2 = SentinelResult(dispatched=True, degraded=False)
+        assert _deserialize_result(_serialize_result(r2)).degraded is False


### PR DESCRIPTION
## Problem

When the Sentinel's MCP config build yields no path — whether it raises, or
returns `None` internally — the remediation CC session ran with
`skip_permissions` and full tools but **no** Genesis MCP servers. Such a session
can act directly (e.g. via shell) yet cannot call the approval tool to self-gate
its actions. (No evidence this has fired — this is defensive hardening.)

## Fix

Guard the **return value** (not just the `except`, which the internal-`None`
path never reaches) and drop to a **propose-only** posture when degraded:

- disallow the mutation/action tools **and** the web tools — a read tool plus a
  fetch tool is a data-exfiltration channel — as a **superset** of the existing
  read-only lockdown set (a test enforces the superset invariant so it can't
  fall behind);
- emit a loud ERROR event and escalate via a blocker outreach, so a config
  regression is visible rather than silently degrading the remediator;
- keep the diagnose-and-propose channel (proposed actions are parsed from the
  session output, not an MCP tool) — the parent-side approval gate still governs
  execution.

Also: a degraded (tool-less) session cannot have acted, so its self-reported
`resolved`/`actions_taken` is no longer trusted (forced false/empty) — otherwise
a real alarm could be silently marked healthy and re-dispatch suppressed.

## Tests

`tests/test_sentinel/test_dispatcher.py::TestDegradedMcpConfig` — degraded via
`None` and via a raise, a healthy-path control, the superset-of-lockdown
invariant, and the resolution-not-trusted property. 73 dispatcher tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
