### PR TITLE
docs(review): calibrate the adversarial review mandate to the declared threat model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,20 @@ not to confirm:
   and does not break existing behavior; a finding whose "fix" regresses something is
   itself a finding. Verify claims against the code — a stated mechanism can be wrong
   even when the concern is real.
+- **Calibrate severity to the code's DECLARED threat model — do not harden low-stakes
+  code ad infinitum.** Adversarial rigor above stays FULL for high-consequence surfaces
+  (auth, credentials, financial, data-loss, external input, approval gates). But a
+  guard/module often states its own scope — e.g. "accident-prevention on a single-author
+  repo, not adversarial; a deliberate evader already has `python -c 'subprocess…'`,
+  invisible to any string guard." Weigh findings against THAT model: a bypass that
+  requires deliberate multi-step evasion of an *accident-prevention* layer is a **NOTE /
+  P3**, not a P1. **Do not re-flag documented accepted-residue** — a form the code
+  explicitly marks out-of-scope ("accepted residue", "outside the threat model") — as a
+  new blocking finding round after round. When, after ~3 review→fix rounds on one change,
+  the only new findings are adjacent evasion variants on such a surface, say so in the
+  verdict ("remaining items are out-of-threat-model residue, not blocking") instead of
+  continuing to enumerate: over-hardening code whose functionality doesn't warrant it is
+  itself a review failure.
 - **End with a verdict:** `Ready to merge: Yes | No | With fixes` + a one-line reason.
 
 ## GitNexus — Code Intelligence (advisory)


### PR DESCRIPTION
## What

Automated PR review reads AGENTS.md's **Code Review Mandate**, which instructs
maximal adversarial enumeration — *"assume latent bugs, find EVERY instance"* —
with **no calibration to a change's actual consequence.**

On a low-stakes, accident-prevention guard that states its own scope in-code
("not adversarial; a deliberate evader already has `python -c subprocess`, invisible
to any string guard"), that produces an **unbounded review→fix loop**: each round
surfaces another deliberate-evasion bypass the threat model explicitly excludes, and
nothing signals when to stop. Over-hardening code whose functionality doesn't warrant
it burns rounds and can regress the guard.

## The clause

Adds one bullet to the mandate. **Full adversarial rigor stays** for high-consequence
surfaces (auth, credentials, financial, data-loss, external input, approval gates).
For code that declares a lower threat model:

- a bypass requiring deliberate multi-step evasion of an *accident-prevention* layer is
  a **NOTE/P3**, not a P1;
- **documented accepted-residue** (a form the code marks out-of-scope) is not re-flagged
  as a new blocking finding round after round;
- after ~3 review→fix rounds where new findings are only adjacent evasion variants on
  such a surface, the verdict says so ("out-of-threat-model residue") rather than
  continuing to enumerate.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
