### PR TITLE
fix(routing): retire dead llama-3.3-70b fallbacks + fix groq key-spelling resolution

### DIFF
--- a/src/genesis/contribution/version_gate.py
+++ b/src/genesis/contribution/version_gate.py
@@ -32,9 +32,12 @@ import subprocess
 import tomllib
 from pathlib import Path
 
-from genesis.observability.snapshots.api_keys import resolve_api_key
-
 from .findings import VersionGateResult
+
+# NOTE: ``resolve_api_key`` is imported LAZILY inside the two functions that use
+# it (``_select_model`` / ``_call_llm``) — a top-level import would pull in
+# ``genesis.observability`` at module load, which fails on a source-path fallback
+# of the contribution sanitizer that lacks health-only deps (aiohttp). #1384.
 
 logger = logging.getLogger(__name__)
 
@@ -338,6 +341,8 @@ def _load_models_from_config() -> list[tuple[str, str]]:
 def _select_model(override: str | None) -> str | None:
     if override:
         return override
+    from genesis.observability.snapshots.api_keys import resolve_api_key  # lazy — see top
+
     # Try routing config first, fall back to hardcoded defaults
     models = _load_models_from_config() or _FALLBACK_MODELS
     for model, service, _params in models:
@@ -367,6 +372,9 @@ async def _call_llm(prompt: str, model: str) -> str:
     would have made.
     """
     import litellm  # lazy import; keeps findings/identity light
+
+    from genesis.observability.snapshots.api_keys import resolve_api_key  # lazy — see top
+
     prefix = model.split("/", 1)[0] if "/" in model else model
     api_key = resolve_api_key(_SERVICE_BY_PREFIX.get(prefix, prefix))
     # Provider params form the BASE; the gate's fixed arguments override them —

--- a/src/genesis/contribution/version_gate.py
+++ b/src/genesis/contribution/version_gate.py
@@ -54,7 +54,10 @@ CONFIDENCE_THRESHOLD = 75
 _FALLBACK_MODELS = [
     ("openrouter/anthropic/claude-haiku-4.5", "openrouter", None),
     ("groq/openai/gpt-oss-120b", "groq", {"extra_body": {"reasoning_effort": "low"}}),
-    ("gemini/gemini-3-flash-preview", "google", None),
+    # Mirrors the canonical gemini-free provider in model_routing.yaml: the GA
+    # gemini-3.5-flash (Google's replacement for the deprecated 3-flash-preview)
+    # with thinking suppressed — 3.5 reasons by default, bloating free-tier TPM.
+    ("gemini/gemini-3.5-flash", "google", {"reasoning_effort": "disable"}),
 ]
 
 # litellm model-string prefix → provider service name where they differ.
@@ -366,16 +369,20 @@ async def _call_llm(prompt: str, model: str) -> str:
     import litellm  # lazy import; keeps findings/identity light
     prefix = model.split("/", 1)[0] if "/" in model else model
     api_key = resolve_api_key(_SERVICE_BY_PREFIX.get(prefix, prefix))
-    kwargs: dict = dict(_params_for_model(model) or {})
+    # Provider params form the BASE; the gate's fixed arguments override them —
+    # a provider config carrying temperature/max_tokens must never TypeError
+    # on duplicate keywords (Codex round-2), and the gate's deterministic
+    # temperature=0.0 always wins.
+    call_kwargs: dict = dict(_params_for_model(model) or {})
     if api_key:
-        kwargs["api_key"] = api_key
-    response = await litellm.acompletion(
+        call_kwargs["api_key"] = api_key
+    call_kwargs.update(
         model=model,
         messages=[{"role": "user", "content": prompt}],
         temperature=0.0,
         max_tokens=500,
-        **kwargs,
     )
+    response = await litellm.acompletion(**call_kwargs)
     return response.choices[0].message.content or ""
 
 

--- a/src/genesis/contribution/version_gate.py
+++ b/src/genesis/contribution/version_gate.py
@@ -44,14 +44,17 @@ CONFIDENCE_THRESHOLD = 75
 
 # Fallback model chain when routing config is unavailable.
 # Production can override by passing `model=...` to `check_version_gate()`.
-# Second element = provider SERVICE name for key resolution via
-# `resolve_api_key` (accepts API_KEY_<SVC> and <SVC>_API_KEY spellings —
-# the old single-name GROQ_API_KEY check silently made groq unselectable
-# on installs using the Genesis convention API_KEY_GROQ).
+# Tuple = (litellm model string, provider SERVICE for key resolution via
+# `resolve_api_key`, provider params to mirror on direct calls). The params
+# mirror the model's canonical provider config in model_routing.yaml — e.g.
+# gpt-oss-120b REQUIRES extra_body.reasoning_effort=low to stay under the
+# groq free-tier TPM ceiling; a direct call without it is a different call
+# than the router would make. gemini pinned to the currently-recommended 3.x
+# (docs/reference/gemini-routing.md: 2.0 = "Do not use", being phased out).
 _FALLBACK_MODELS = [
-    ("openrouter/anthropic/claude-haiku-4.5", "openrouter"),
-    ("groq/openai/gpt-oss-120b", "groq"),
-    ("gemini/gemini-2.0-flash", "google"),
+    ("openrouter/anthropic/claude-haiku-4.5", "openrouter", None),
+    ("groq/openai/gpt-oss-120b", "groq", {"extra_body": {"reasoning_effort": "low"}}),
+    ("gemini/gemini-3-flash-preview", "google", None),
 ]
 
 # litellm model-string prefix → provider service name where they differ.
@@ -320,7 +323,9 @@ def _load_models_from_config() -> list[tuple[str, str]]:
             ptype = pcfg.provider_type
             prefix = _PREFIX.get(ptype, ptype)
             model_str = f"{prefix}/{pcfg.model_id}" if prefix else pcfg.model_id
-            result.append((model_str, ptype))
+            # Carry the provider's params (e.g. reasoning_effort caps) so the
+            # direct call mirrors what the router would send.
+            result.append((model_str, ptype, pcfg.params))
         return result
     except Exception:
         logger.debug("Could not load routing config for contribution_gate", exc_info=True)
@@ -332,9 +337,19 @@ def _select_model(override: str | None) -> str | None:
         return override
     # Try routing config first, fall back to hardcoded defaults
     models = _load_models_from_config() or _FALLBACK_MODELS
-    for model, service in models:
+    for model, service, _params in models:
         if resolve_api_key(service):
             return model
+    return None
+
+
+def _params_for_model(model: str) -> dict | None:
+    """Provider params for a model string, from the config-derived chain first,
+    else the fallback chain — so a direct call mirrors the router's call shape
+    (e.g. gpt-oss-120b's reasoning_effort cap). None for unknown/override models."""
+    for m, _service, params in _load_models_from_config() or _FALLBACK_MODELS:
+        if m == model:
+            return params
     return None
 
 
@@ -344,12 +359,16 @@ async def _call_llm(prompt: str, model: str) -> str:
     The API key is resolved (both env spellings) and passed EXPLICITLY —
     litellm's own env lookup knows only the native <SVC>_API_KEY name, so a
     model selected via the Genesis convention (API_KEY_GROQ) would otherwise
-    401 at call time.
+    401 at call time. Provider params (e.g. reasoning-effort caps) are
+    mirrored for the same reason: a direct call must be the call the router
+    would have made.
     """
     import litellm  # lazy import; keeps findings/identity light
     prefix = model.split("/", 1)[0] if "/" in model else model
     api_key = resolve_api_key(_SERVICE_BY_PREFIX.get(prefix, prefix))
-    kwargs = {"api_key": api_key} if api_key else {}
+    kwargs: dict = dict(_params_for_model(model) or {})
+    if api_key:
+        kwargs["api_key"] = api_key
     response = await litellm.acompletion(
         model=model,
         messages=[{"role": "user", "content": prompt}],

--- a/src/genesis/contribution/version_gate.py
+++ b/src/genesis/contribution/version_gate.py
@@ -17,19 +17,22 @@ threshold of 75 as a safety margin against future prompt-change
 hedging.
 
 Model: Reads from ``contribution_gate`` call site in model_routing.yaml.
-Falls back to hardcoded chain (Claude Haiku 4.5 → Groq Llama → Gemini
-Flash) if config is unavailable. Calls litellm directly (not through the
-router) but records results to the neural monitor for visibility.
+Falls back to hardcoded chain (Claude Haiku 4.5 → Groq gpt-oss-120b →
+Gemini Flash) if config is unavailable. Calls litellm directly (not through
+the router) but records results to the neural monitor for visibility — so
+the API key is resolved via ``resolve_api_key`` (both env spellings) and
+passed explicitly.
 """
 from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 import subprocess
 import tomllib
 from pathlib import Path
+
+from genesis.observability.snapshots.api_keys import resolve_api_key
 
 from .findings import VersionGateResult
 
@@ -41,11 +44,18 @@ CONFIDENCE_THRESHOLD = 75
 
 # Fallback model chain when routing config is unavailable.
 # Production can override by passing `model=...` to `check_version_gate()`.
+# Second element = provider SERVICE name for key resolution via
+# `resolve_api_key` (accepts API_KEY_<SVC> and <SVC>_API_KEY spellings —
+# the old single-name GROQ_API_KEY check silently made groq unselectable
+# on installs using the Genesis convention API_KEY_GROQ).
 _FALLBACK_MODELS = [
-    ("openrouter/anthropic/claude-haiku-4.5", "API_KEY_OPENROUTER"),
-    ("groq/llama-3.3-70b-versatile", "GROQ_API_KEY"),
-    ("gemini/gemini-2.0-flash", "GOOGLE_API_KEY"),
+    ("openrouter/anthropic/claude-haiku-4.5", "openrouter"),
+    ("groq/openai/gpt-oss-120b", "groq"),
+    ("gemini/gemini-2.0-flash", "google"),
 ]
+
+# litellm model-string prefix → provider service name where they differ.
+_SERVICE_BY_PREFIX = {"gemini": "google"}
 
 # contribution_gate — gates community contribution submissions (Phase 6 pipeline).
 # Non-numeric ID by intent (predates the numeric scheme).
@@ -302,12 +312,6 @@ def _load_models_from_config() -> list[tuple[str, str]]:
             return []
         # Map provider type to litellm prefix
         _PREFIX = {"openrouter": "openrouter", "groq": "groq", "google": "gemini"}
-        # Map provider type to conventional env var for API key
-        _ENV = {
-            "openrouter": "API_KEY_OPENROUTER",
-            "groq": "GROQ_API_KEY",
-            "google": "GOOGLE_API_KEY",
-        }
         result = []
         for pname in site.chain:
             pcfg = config.providers.get(pname)
@@ -316,8 +320,7 @@ def _load_models_from_config() -> list[tuple[str, str]]:
             ptype = pcfg.provider_type
             prefix = _PREFIX.get(ptype, ptype)
             model_str = f"{prefix}/{pcfg.model_id}" if prefix else pcfg.model_id
-            env_var = _ENV.get(ptype, f"{ptype.upper()}_API_KEY")
-            result.append((model_str, env_var))
+            result.append((model_str, ptype))
         return result
     except Exception:
         logger.debug("Could not load routing config for contribution_gate", exc_info=True)
@@ -329,20 +332,30 @@ def _select_model(override: str | None) -> str | None:
         return override
     # Try routing config first, fall back to hardcoded defaults
     models = _load_models_from_config() or _FALLBACK_MODELS
-    for model, env_var in models:
-        if os.environ.get(env_var):
+    for model, service in models:
+        if resolve_api_key(service):
             return model
     return None
 
 
 async def _call_llm(prompt: str, model: str) -> str:
-    """Call the LLM via litellm.acompletion. Surfaces litellm errors."""
+    """Call the LLM via litellm.acompletion. Surfaces litellm errors.
+
+    The API key is resolved (both env spellings) and passed EXPLICITLY —
+    litellm's own env lookup knows only the native <SVC>_API_KEY name, so a
+    model selected via the Genesis convention (API_KEY_GROQ) would otherwise
+    401 at call time.
+    """
     import litellm  # lazy import; keeps findings/identity light
+    prefix = model.split("/", 1)[0] if "/" in model else model
+    api_key = resolve_api_key(_SERVICE_BY_PREFIX.get(prefix, prefix))
+    kwargs = {"api_key": api_key} if api_key else {}
     response = await litellm.acompletion(
         model=model,
         messages=[{"role": "user", "content": prompt}],
         temperature=0.0,
         max_tokens=500,
+        **kwargs,
     )
     return response.choices[0].message.content or ""
 

--- a/src/genesis/eval/promptfoo.py
+++ b/src/genesis/eval/promptfoo.py
@@ -51,7 +51,7 @@ async def compare_models(
     """Run a promptfoo A/B comparison between two models.
 
     Args:
-        model_a: First model identifier (litellm format, e.g. "groq/llama-3.3-70b-versatile")
+        model_a: First model identifier (litellm format, e.g. "groq/openai/gpt-oss-120b")
         model_b: Second model identifier
         dataset_path: Path to the eval dataset YAML
         delay_ms: Delay between requests (for rate limiting, e.g. 31000 for 2 RPM)

--- a/src/genesis/eval/reflection_golden_set.py
+++ b/src/genesis/eval/reflection_golden_set.py
@@ -169,11 +169,15 @@ async def _grade_observation(
         session_context=session_context,
     )
 
-    # Try providers in order: OpenRouter (DeepSeek V4), Gemini Flash, Groq
+    # Try providers in order: OpenRouter (DeepSeek V4), Gemini 3 Flash, Groq.
+    # Per-model provider params mirror the canonical routing config (gpt-oss
+    # needs reasoning_effort=low to stay under the groq free-tier TPM cap);
+    # gemini pinned to the recommended 3.x (2.0 is "Do not use" per
+    # docs/reference/gemini-routing.md).
     models = [
-        "openrouter/deepseek/deepseek-chat-v3-0324",
-        "gemini/gemini-2.0-flash",
-        "groq/openai/gpt-oss-120b",
+        ("openrouter/deepseek/deepseek-chat-v3-0324", None),
+        ("gemini/gemini-3-flash-preview", None),
+        ("groq/openai/gpt-oss-120b", {"extra_body": {"reasoning_effort": "low"}}),
     ]
     # litellm's env lookup knows only the native <SVC>_API_KEY spelling;
     # secrets.env uses the Genesis convention (API_KEY_GROQ etc.), so resolve
@@ -184,16 +188,18 @@ async def _grade_observation(
     last_exc = None
     response = None
     used_model = None
-    for model in models:
+    for model, params in models:
         prefix = model.split("/", 1)[0]
         api_key = resolve_api_key(_service_by_prefix.get(prefix, prefix))
-        key_kwargs = {"api_key": api_key} if api_key else {}
+        call_kwargs = dict(params or {})
+        if api_key:
+            call_kwargs["api_key"] = api_key
         try:
             response = await litellm.acompletion(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.0,
-                **key_kwargs,
+                **call_kwargs,
             )
             used_model = model
             break

--- a/src/genesis/eval/reflection_golden_set.py
+++ b/src/genesis/eval/reflection_golden_set.py
@@ -173,17 +173,27 @@ async def _grade_observation(
     models = [
         "openrouter/deepseek/deepseek-chat-v3-0324",
         "gemini/gemini-2.0-flash",
-        "groq/llama-3.3-70b-versatile",
+        "groq/openai/gpt-oss-120b",
     ]
+    # litellm's env lookup knows only the native <SVC>_API_KEY spelling;
+    # secrets.env uses the Genesis convention (API_KEY_GROQ etc.), so resolve
+    # and pass the key explicitly or the groq fallback 401s on every install.
+    from genesis.observability.snapshots.api_keys import resolve_api_key
+
+    _service_by_prefix = {"gemini": "google"}
     last_exc = None
     response = None
     used_model = None
     for model in models:
+        prefix = model.split("/", 1)[0]
+        api_key = resolve_api_key(_service_by_prefix.get(prefix, prefix))
+        key_kwargs = {"api_key": api_key} if api_key else {}
         try:
             response = await litellm.acompletion(
                 model=model,
                 messages=[{"role": "user", "content": prompt}],
                 temperature=0.0,
+                **key_kwargs,
             )
             used_model = model
             break

--- a/src/genesis/eval/reflection_golden_set.py
+++ b/src/genesis/eval/reflection_golden_set.py
@@ -169,14 +169,14 @@ async def _grade_observation(
         session_context=session_context,
     )
 
-    # Try providers in order: OpenRouter (DeepSeek V4), Gemini 3 Flash, Groq.
-    # Per-model provider params mirror the canonical routing config (gpt-oss
-    # needs reasoning_effort=low to stay under the groq free-tier TPM cap);
-    # gemini pinned to the recommended 3.x (2.0 is "Do not use" per
-    # docs/reference/gemini-routing.md).
+    # Try providers in order: OpenRouter (DeepSeek V4), Gemini, Groq.
+    # Per-model provider params mirror the canonical routing config: gpt-oss
+    # needs reasoning_effort=low (groq free-tier TPM cap); gemini-3.5-flash is
+    # the config's GA choice (replacing the deprecated 3-flash-preview) with
+    # thinking suppressed — it reasons by default, bloating TPM.
     models = [
         ("openrouter/deepseek/deepseek-chat-v3-0324", None),
-        ("gemini/gemini-3-flash-preview", None),
+        ("gemini/gemini-3.5-flash", {"reasoning_effort": "disable"}),
         ("groq/openai/gpt-oss-120b", {"extra_body": {"reasoning_effort": "low"}}),
     ]
     # litellm's env lookup knows only the native <SVC>_API_KEY spelling;

--- a/src/genesis/observability/snapshots/api_keys.py
+++ b/src/genesis/observability/snapshots/api_keys.py
@@ -25,6 +25,24 @@ _CC_MANAGED_TYPES: frozenset[str] = frozenset()
 _api_validation_cache: dict[str, dict] = {}
 
 
+def resolve_api_key(service: str) -> str | None:
+    """First non-empty API key for a provider service, accepting every
+    spelling Genesis recognizes: the install convention ``API_KEY_<SERVICE>``
+    plus the litellm/native ``<SERVICE>_API_KEY`` / ``<SERVICE>_API_TOKEN``.
+
+    Single source of truth for the acceptance loop — callers that invoke
+    litellm directly (outside the router) MUST pass the returned value as an
+    explicit ``api_key``: litellm's own env lookup knows only the native
+    spelling, so a convention-following install (``API_KEY_GROQ``) would 401.
+    """
+    svc = service.upper()
+    for pattern in (f"API_KEY_{svc}", f"{svc}_API_KEY", f"{svc}_API_TOKEN"):
+        val = os.environ.get(pattern)
+        if val and val not in ("None", "NA", ""):
+            return val
+    return None
+
+
 def has_api_key(provider_cfg) -> bool:
     """Check if a provider has a non-empty API key in the environment.
 
@@ -37,12 +55,7 @@ def has_api_key(provider_cfg) -> bool:
         return True
     if ptype in _CC_MANAGED_TYPES:
         return True  # CC handles auth — no API key needed
-    service = ptype.upper()
-    for pattern in [f"API_KEY_{service}", f"{service}_API_KEY", f"{service}_API_TOKEN"]:
-        val = os.environ.get(pattern)
-        if val and val not in ("None", "NA", ""):
-            return True
-    return False
+    return resolve_api_key(ptype) is not None
 
 
 def api_key_health(
@@ -138,13 +151,7 @@ def api_key_health(
         if ptype in _CC_MANAGED_TYPES:
             results[name] = {"status": "cc_managed", "provider_type": ptype, "key_health": "green"}
             continue
-        service = ptype.upper()
-        key = None
-        for pattern in [f"API_KEY_{service}", f"{service}_API_KEY", f"{service}_API_TOKEN"]:
-            val = os.environ.get(pattern)
-            if val and val not in ("None", "NA", ""):
-                key = val
-                break
+        key = resolve_api_key(ptype)
         entry: dict = {"provider_type": ptype}
         if not key:
             entry["status"] = "missing"
@@ -412,13 +419,7 @@ async def validate_api_keys(routing_config: RoutingConfig | None) -> None:
         ptype = provider_cfg.provider_type
         if ptype in _LOCAL_TYPES or ptype in _CC_MANAGED_TYPES or ptype in validators:
             continue
-        service = ptype.upper()
-        key = None
-        for pattern in [f"API_KEY_{service}", f"{service}_API_KEY", f"{service}_API_TOKEN"]:
-            val = os.environ.get(pattern)
-            if val and val not in ("None", "NA", ""):
-                key = val
-                break
+        key = resolve_api_key(ptype)
         if not key:
             continue
 

--- a/tests/test_contribution/test_version_gate.py
+++ b/tests/test_contribution/test_version_gate.py
@@ -231,6 +231,47 @@ def test_litellm_spelling_still_selects_groq(monkeypatch):
     assert version_gate._select_model(None) == "groq/openai/gpt-oss-120b"
 
 
+def test_fallback_chain_has_no_retired_models(monkeypatch):
+    """Codex round-1: the fallback still listed gemini-2.0-flash, which
+    docs/reference/gemini-routing.md marks 'Do not use' (being phased out) —
+    the same dead-model class this PR retires. The chain must carry only
+    currently-recommended models."""
+    models = [m for m, *_ in version_gate._FALLBACK_MODELS]
+    assert not any("gemini-2.0" in m or "gemini-1.5" in m or "llama-3.3" in m for m in models)
+    assert any("gemini-3-flash-preview" in m for m in models)
+
+
+@pytest.mark.asyncio
+async def test_call_llm_passes_groq_reasoning_params(monkeypatch):
+    """Codex round-1: groq-free's canonical config requires
+    extra_body.reasoning_effort=low (free-tier TPM guard); direct litellm
+    calls must mirror the provider params, not just the key."""
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("API_KEY_GROQ", "gsk-fake-params")
+    monkeypatch.setattr(version_gate, "_load_models_from_config", lambda: [])
+    captured = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+
+        class _Msg:
+            content = "ok"
+
+        class _Choice:
+            message = _Msg()
+
+        class _Resp:
+            choices = [_Choice()]
+
+        return _Resp()
+
+    import litellm
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    await version_gate._call_llm("p", "groq/openai/gpt-oss-120b")
+    assert captured.get("extra_body") == {"reasoning_effort": "low"}
+
+
 @pytest.mark.asyncio
 async def test_call_llm_passes_explicit_api_key(monkeypatch):
     """litellm's own env lookup knows only GROQ_API_KEY, so _call_llm must pass

--- a/tests/test_contribution/test_version_gate.py
+++ b/tests/test_contribution/test_version_gate.py
@@ -232,13 +232,59 @@ def test_litellm_spelling_still_selects_groq(monkeypatch):
 
 
 def test_fallback_chain_has_no_retired_models(monkeypatch):
-    """Codex round-1: the fallback still listed gemini-2.0-flash, which
-    docs/reference/gemini-routing.md marks 'Do not use' (being phased out) —
-    the same dead-model class this PR retires. The chain must carry only
-    currently-recommended models."""
+    """Codex rounds 1+2: the fallback carried gemini-2.0-flash ('Do not use'),
+    then my round-1 fix picked gemini-3-flash-preview from the WRONG authority
+    (the video-analysis doc) — the canonical routing config already replaced
+    that preview with gemini-3.5-flash + reasoning_effort=disable. The chain
+    must mirror the ROUTING CONFIG's current choice, retired families and
+    deprecated previews both rejected."""
     models = [m for m, *_ in version_gate._FALLBACK_MODELS]
-    assert not any("gemini-2.0" in m or "gemini-1.5" in m or "llama-3.3" in m for m in models)
-    assert any("gemini-3-flash-preview" in m for m in models)
+    assert not any(
+        "gemini-2.0" in m or "gemini-1.5" in m or "llama-3.3" in m or "preview" in m
+        for m in models
+    )
+    assert any("gemini-3.5-flash" in m for m in models)
+    # And the gemini entry mirrors the config's thinking-suppression param.
+    gem = next(t for t in version_gate._FALLBACK_MODELS if "gemini" in t[0])
+    assert gem[2] == {"reasoning_effort": "disable"}
+
+
+@pytest.mark.asyncio
+async def test_call_llm_provider_params_never_collide_with_fixed_args(monkeypatch):
+    """Codex round-2: a provider whose config params carry temperature or
+    max_tokens would collide with _call_llm's explicit keywords → TypeError →
+    gate fails open before litellm is even called. Fixed args must WIN over
+    provider params, never collide."""
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("API_KEY_GROQ", "gsk-fake-collide")
+    monkeypatch.setattr(
+        version_gate,
+        "_load_models_from_config",
+        lambda: [("groq/openai/gpt-oss-120b", "groq", {"temperature": 0.9, "max_tokens": 9})],
+    )
+    captured = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+
+        class _Msg:
+            content = "ok"
+
+        class _Choice:
+            message = _Msg()
+
+        class _Resp:
+            choices = [_Choice()]
+
+        return _Resp()
+
+    import litellm
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    out = await version_gate._call_llm("p", "groq/openai/gpt-oss-120b")
+    assert out == "ok"  # no TypeError
+    assert captured["temperature"] == 0.0  # fixed args win
+    assert captured["max_tokens"] == 500
 
 
 @pytest.mark.asyncio

--- a/tests/test_contribution/test_version_gate.py
+++ b/tests/test_contribution/test_version_gate.py
@@ -9,6 +9,15 @@ import pytest
 from genesis.contribution import version_gate
 
 
+def test_resolve_api_key_not_imported_at_module_level():
+    """Import-coupling fix (#1384): version_gate must NOT import
+    genesis.observability at module load — the contribution sanitizer can be
+    loaded via a source-path fallback that lacks health-only deps (aiohttp).
+    resolve_api_key is imported INSIDE the functions that use it, so it must
+    not be a module-level attribute."""
+    assert not hasattr(version_gate, "resolve_api_key")
+
+
 def test_parse_clean_json():
     raw = json.dumps({
         "already_fixed": True,

--- a/tests/test_contribution/test_version_gate.py
+++ b/tests/test_contribution/test_version_gate.py
@@ -183,13 +183,26 @@ async def test_unparseable_response_fails_open(monkeypatch):
     assert r.llm_error == "parse_error"
 
 
+# Every env spelling the key resolver accepts, for all three fallback services —
+# tests that need "no key present" must clear ALL of them (a dev shell with
+# secrets.env sourced would otherwise leak API_KEY_GROQ into the test).
+_ALL_KEY_SPELLINGS = tuple(
+    pattern
+    for svc in ("OPENROUTER", "GROQ", "GOOGLE")
+    for pattern in (f"API_KEY_{svc}", f"{svc}_API_KEY", f"{svc}_API_TOKEN")
+)
+
+
+def _clear_all_keys(monkeypatch):
+    for var in _ALL_KEY_SPELLINGS:
+        monkeypatch.delenv(var, raising=False)
+
+
 @pytest.mark.asyncio
 async def test_no_api_key_fails_open(monkeypatch):
     fake_commits = [{"sha": "x", "subject": "unrelated", "body": ""}]
     monkeypatch.setattr(version_gate, "fetch_upstream_log", lambda *a, **k: fake_commits)
-    # Clear all known keys
-    for var in ("API_KEY_OPENROUTER", "GROQ_API_KEY", "GOOGLE_API_KEY"):
-        monkeypatch.delenv(var, raising=False)
+    _clear_all_keys(monkeypatch)
     r = await version_gate.check_version_gate(
         user_subject="s", user_body="b", user_diff="d",
         user_sha="a", upstream_sha="b",
@@ -197,6 +210,56 @@ async def test_no_api_key_fails_open(monkeypatch):
     assert r.already_fixed is False
     assert r.parse_ok is False
     assert r.llm_error == "no_api_key"
+
+
+def test_genesis_env_spelling_selects_groq(monkeypatch):
+    """Regression: the Genesis convention is API_KEY_GROQ (stt, providers init,
+    onboarding floor) — the old single-name GROQ_API_KEY check made every groq
+    entry silently unselectable on convention-following installs."""
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("API_KEY_GROQ", "gsk-fake-genesis-spelling")
+    # Force the fallback list (config availability varies by test env).
+    monkeypatch.setattr(version_gate, "_load_models_from_config", lambda: [])
+    assert version_gate._select_model(None) == "groq/openai/gpt-oss-120b"
+
+
+def test_litellm_spelling_still_selects_groq(monkeypatch):
+    """The litellm-native spelling must keep working (acceptance, not a swap)."""
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-fake-litellm-spelling")
+    monkeypatch.setattr(version_gate, "_load_models_from_config", lambda: [])
+    assert version_gate._select_model(None) == "groq/openai/gpt-oss-120b"
+
+
+@pytest.mark.asyncio
+async def test_call_llm_passes_explicit_api_key(monkeypatch):
+    """litellm's own env lookup knows only GROQ_API_KEY, so _call_llm must pass
+    the resolved key explicitly — otherwise a selected-via-API_KEY_GROQ model
+    401s at call time (the exact failure a live smoke hit on 2026-08-12)."""
+    _clear_all_keys(monkeypatch)
+    monkeypatch.setenv("API_KEY_GROQ", "gsk-fake-explicit")
+    captured = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+
+        class _Msg:
+            content = "ok"
+
+        class _Choice:
+            message = _Msg()
+
+        class _Resp:
+            choices = [_Choice()]
+
+        return _Resp()
+
+    import litellm
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    out = await version_gate._call_llm("p", "groq/openai/gpt-oss-120b")
+    assert out == "ok"
+    assert captured.get("api_key") == "gsk-fake-explicit"
 
 
 def test_format_version_string(tmp_path):

--- a/tests/test_observability/test_api_keys.py
+++ b/tests/test_observability/test_api_keys.py
@@ -10,6 +10,33 @@ from genesis.observability.snapshots.api_keys import (
 # --- _compute_alert_severity: critical ONLY when an essential is uncovered ---
 
 
+def test_resolve_api_key_accepts_genesis_spelling(monkeypatch):
+    from genesis.observability.snapshots.api_keys import resolve_api_key
+
+    for var in ("API_KEY_GROQ", "GROQ_API_KEY", "GROQ_API_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("API_KEY_GROQ", "gsk-genesis")
+    assert resolve_api_key("groq") == "gsk-genesis"
+
+
+def test_resolve_api_key_accepts_native_spelling(monkeypatch):
+    from genesis.observability.snapshots.api_keys import resolve_api_key
+
+    for var in ("API_KEY_GROQ", "GROQ_API_KEY", "GROQ_API_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("GROQ_API_KEY", "gsk-native")
+    assert resolve_api_key("groq") == "gsk-native"
+
+
+def test_resolve_api_key_rejects_placeholders(monkeypatch):
+    from genesis.observability.snapshots.api_keys import resolve_api_key
+
+    for var in ("API_KEY_GROQ", "GROQ_API_KEY", "GROQ_API_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("API_KEY_GROQ", "None")
+    assert resolve_api_key("groq") is None
+
+
 def test_quota_exhaustion_silent_when_essentials_covered():
     """OpenRouter-style outage: paid + systemic + out of credits, but the
     essentials are still covered by free providers → SILENT (info), no banner.


### PR DESCRIPTION
## What

Post-groq-migration residuals (#1329 repointed the main `groq-free` provider to `openai/gpt-oss-120b`; this PR fixes what enumeration found still referencing the dead model or unable to use groq at all):

1. **Dead model ids** in two direct-litellm fallback chains — `contribution/version_gate.py` `_FALLBACK_MODELS` and `eval/reflection_golden_set.py` judge chain — plus a docstring example in `eval/promptfoo.py`.
2. **Latent key-resolution class bug**: version_gate keyed groq selection on `GROQ_API_KEY`, but the install convention is `API_KEY_GROQ` (stt, providers init, onboarding floor). Groq entries were silently unselectable, and these direct litellm calls (which bypass the router) would 401 even if selected — litellm's env lookup only knows the native spelling.

## Fix

- New shared `resolve_api_key(service)` in `observability/snapshots/api_keys.py`, extracted from `has_api_key`'s existing 3-pattern acceptance loop (`API_KEY_<SVC>`, `<SVC>_API_KEY`, `<SVC>_API_TOKEN`); DRYs the three duplicate copies (`has_api_key` / `api_key_health` / `validate_api_keys`) — behavior-preserving.
- `version_gate`: fallback tuples carry the service name; selection resolves via the shared helper; `_call_llm` passes the resolved key **explicitly** to `litellm.acompletion`.
- `reflection_golden_set`: explicit `api_key` per judge model (same class).

## Verification

- RED-first: selection-via-install-spelling and explicit-key tests witnessed failing pre-fix.
- 43 targeted (`test_version_gate.py` + `test_api_keys.py`) + 373 collateral (`test_routing/`, `test_health_data.py`, `test_credit_exhaustion.py`) green; ruff clean.
- Live E2E against real Groq: the previously-401ing call succeeds with only the install-convention env var set.
- Reviewer round clean (no findings ≥80); no key value flows into any log or recorder.

Noted for later (out of scope): private key-resolver helpers in `routing/litellm_delegate.py` + `observability/provider_health.py` could adopt the shared resolver in a future consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)