### PR TITLE
feat(hooks): Codex round-escalation gate — force the step-back before round N+1

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -528,6 +528,26 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   trigger when the class won't lock within ≤3 rounds. (Origin: PR #1281 ran ~7
   reviewer rounds because a standing "proceed once clean" silently carried
   through rounds 4–6.)
+
+  **The Codex-round twin of the cap** (`git_push_guard.py`
+  `_check_codex_round_escalation`): the local counter above is BLIND to a loop
+  that churns through CODEX rounds while every local review is clean — the
+  2026-08-12 MW-3 #1372 whack-a-mole shape (5 Codex rounds, local counter at 0,
+  and the round-4 "fix" of a non-bug introduced the only genuine liveness bug).
+  So `gh pr comment … "@codex review"` HARD-BLOCKS once the PR already carries
+  `ESCALATION_ROUND_CAP` Codex reviews (counted live from the GitHub API;
+  fail-open on any API error), until a trailing `# escalation-ack`. Before
+  acking, DO THE STEP-BACK the block prints: (1) triage every open finding —
+  {live bug | latent trap | hardening | observation}; only live bugs and
+  cheaper-now-than-later traps may change already-reviewed code, the rest get a
+  documented acceptance or route to the PR that owns the area; (2) fix
+  MECHANISMS, not instances; (3) for state-machine/queue code, enumerate EVERY
+  status value and trace the change under each (your tests encode your own
+  state model — they can't catch states you didn't consider); (4) consider
+  REVERTING a prior round's fix rather than patching it again; (5) escalate to
+  the user with a minimize-change recommendation. The ack asserts that
+  step-back happened — appending it without doing the work is the same
+  violation as falsifying `--clean`.
 - **External review feedback is a set of claims to VERIFY, not orders.** For
   every bot/external finding: check it against the actual code (its stated
   mechanism may be wrong even when the underlying concern is real — quote the

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1080,6 +1080,11 @@ def _check_codex_round_escalation(segs) -> tuple[bool, str]:
     try:
         if any(has_trailing_override(s.raw, "escalation-ack") for s in segs):
             return False, ""
+        # Earlier trigger segments in THIS command count toward the total: each
+        # segment sees the same pre-execution API count, so `request && request`
+        # at cap-1 would otherwise dispatch round N+1 unacknowledged (round-2
+        # finding). Keyed per (repo, pr) so distinct PRs don't cross-count.
+        in_cmd: dict[str, int] = {}
         for seg in segs:
             if gh_pr_subcommand(seg.argv) != "comment":
                 continue
@@ -1089,9 +1094,13 @@ def _check_codex_round_escalation(segs) -> tuple[bool, str]:
             if not pr_num:
                 continue
             ids = _codex_review_commit_ids(pr_num, repo=repo)
-            if ids is None or len(ids) < ESCALATION_ROUND_CAP:
+            if ids is None:
                 continue
-            return True, _escalation_advisory(pr_num, len(ids), repo)
+            key = f"{repo or ''}|{pr_num}"
+            effective = len(ids) + in_cmd.get(key, 0)
+            if effective >= ESCALATION_ROUND_CAP:
+                return True, _escalation_advisory(pr_num, effective, repo)
+            in_cmd[key] = in_cmd.get(key, 0) + 1
     except Exception:
         return False, ""
     return False, ""

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -948,24 +948,18 @@ def _pr_head_sha(pr_num: str, repo: str | None = None) -> str | None:
     return sha or None
 
 
-def _codex_review_commit_ids(pr_num: str, repo: str | None = None) -> list[str] | None:
-    """FULL commit oids (``.commit_id``) of EVERY Codex review on the PR,
-    oldest-first, or None on any API/parse error (distinct from ``[]`` = the
-    query succeeded and Codex has posted no review).
-
-    Uses GitHub's authoritative per-review ``commit_id`` (the exact 40-char oid
-    the review was submitted against) rather than parsing review bodies — a
-    full-oid identity, immune to short-prefix collisions/grinding. The
-    ``/pulls/N/reviews`` endpoint returns reviews oldest-first. A ``DISMISSED``
-    review is SKIPPED at the source — it neither vouches for a commit (the
-    #1366 freshness gate falls back to the last non-dismissed review, possibly
-    stale → block, or none → block) nor counts as an active round (the
-    escalation gate undercounts by exactly the consciously-dismissed reviews —
-    the safe direction). Tests inject via ``_TEST_GH_CODEX_REVIEWS`` (one JSON
-    object per line: ``{login, commit_id[, state]}``; a missing ``state``
-    counts as active). Fail-safe: None on any API/parse error.
-    Consumers: ``_latest_codex_reviewed_sha`` (reviewed-head gate, last entry)
-    and ``_check_codex_round_escalation`` (round count, len()).
+def _codex_reviews(pr_num: str, repo: str | None = None) -> list[dict] | None:
+    """EVERY Codex review record ``{commit_id, state}`` on the PR, oldest-first,
+    or None on any API/parse error (distinct from ``[]`` = query succeeded, no
+    Codex review). INCLUDES ``DISMISSED`` reviews — consumers filter per their
+    need: freshness (``_codex_review_commit_ids``) skips dismissed (a dismissed
+    review vouches for NO commit); the escalation counter COUNTS them (a
+    dismissed round already RAN and consumed the review budget — #1385 round-5:
+    3 dismissed rounds must still trip the 3-round cap). Uses GitHub's
+    authoritative per-review ``commit_id`` (immune to prefix grinding); the
+    ``/pulls/N/reviews`` endpoint returns reviews oldest-first. Tests inject via
+    ``_TEST_GH_CODEX_REVIEWS`` (one JSON object per line: ``{login,
+    commit_id[, state]}``; missing ``state`` = active). Fail-safe: None on error.
     """
     raw = os.environ.get("_TEST_GH_CODEX_REVIEWS")
     if raw is None:
@@ -991,7 +985,7 @@ def _codex_review_commit_ids(pr_num: str, repo: str | None = None) -> list[str] 
             raw = result.stdout
         except Exception:
             return None
-    ids: list[str] = []
+    reviews: list[dict] = []
     for line in (raw or "").splitlines():
         line = line.strip()
         if not line:
@@ -1000,19 +994,31 @@ def _codex_review_commit_ids(pr_num: str, repo: str | None = None) -> list[str] 
             obj = json.loads(line)
         except Exception:
             continue
-        # isinstance: a valid-JSON non-object line (`null`, a number) must be
-        # skipped, not raise AttributeError out of the docstring's "None on any
-        # parse error" contract (run_guard would turn that into a hook crash).
         if not isinstance(obj, dict):
             continue
         if (obj.get("login") or "") != _CODEX_REVIEW_BOT:
             continue
-        if (obj.get("state") or "").upper() == "DISMISSED":
-            continue  # a dismissed review does not vouch for any commit
-        cid = (obj.get("commit_id") or "").strip().lower()
-        if cid:
-            ids.append(cid)
-    return ids
+        reviews.append(
+            {
+                "commit_id": (obj.get("commit_id") or "").strip().lower(),
+                "state": (obj.get("state") or "").upper(),
+            }
+        )
+    return reviews
+
+
+def _codex_review_commit_ids(pr_num: str, repo: str | None = None) -> list[str] | None:
+    """NON-DISMISSED Codex review commit oids, oldest-first, or None on error.
+
+    Freshness identity — a dismissed review vouches for no commit, so the #1366
+    reviewed-head gate must not treat its sha as reviewed. For ROUND COUNTING
+    (dismissed rounds still ran) the escalation gate uses ``_codex_reviews``
+    directly. Consumer: ``_latest_codex_reviewed_sha`` (last entry).
+    """
+    reviews = _codex_reviews(pr_num, repo=repo)
+    if reviews is None:
+        return None
+    return [r["commit_id"] for r in reviews if r["state"] != "DISMISSED" and r["commit_id"]]
 
 
 def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | None:
@@ -1038,7 +1044,19 @@ def _comment_target(argv: list[str]) -> tuple[str | None, str | None]:
         idx = argv.index("comment")
     except ValueError:
         return None, None
+    # Value-taking flags whose SEPARATED value must not be read as the positional
+    # target — a PR URL inside a `--body` text would otherwise redirect the gate
+    # to an unrelated repo (#1385 round-5). Glued forms (`--body=…`, `-b…`,
+    # `-R…`, `--repo=…`) are single `-`-prefixed tokens already skipped below.
+    _VALUE_FLAGS = {"-b", "--body", "-F", "--body-file", "-R", "--repo"}
+    skip_next = False
     for tok in argv[idx + 1 :]:
+        if skip_next:
+            skip_next = False
+            continue
+        if tok in _VALUE_FLAGS:
+            skip_next = True
+            continue
         if tok.startswith("-"):
             continue
         if pr_num is None and tok.isdigit():
@@ -1153,11 +1171,14 @@ def _check_codex_round_escalation(segs) -> tuple[bool, str]:
             pr_num, repo = _comment_target(seg.argv)
             if not pr_num:
                 continue
-            ids = _codex_review_commit_ids(pr_num, repo=repo)
-            if ids is None:
+            # Count ALL Codex review rounds — including DISMISSED, which still
+            # ran and consumed the budget (#1385 round-5). Freshness uses the
+            # dismissed-filtered ``_codex_review_commit_ids``; the cap does not.
+            reviews = _codex_reviews(pr_num, repo=repo)
+            if reviews is None:
                 continue
             key = f"{repo or ''}|{pr_num}"
-            effective = len(ids) + in_cmd.get(key, 0)
+            effective = len(reviews) + in_cmd.get(key, 0)
             if effective >= ESCALATION_ROUND_CAP:
                 return True, _escalation_advisory(pr_num, effective, repo)
             in_cmd[key] = in_cmd.get(key, 0) + 1

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -70,7 +70,10 @@ from hook_input import field, read_payload, run_guard  # noqa: E402
 # gate in this file (force-push, merge, sqlite) would silently vanish.
 try:
     from review_state import ESCALATION_ROUND_CAP  # noqa: E402
-except ImportError:  # pragma: no cover — exercised via sys.modules stub in tests
+except Exception:  # noqa: BLE001 — ANY failure (absent OR broken: SyntaxError,
+    # read error, top-level runtime error in review_state) must degrade to the
+    # default cap, NEVER propagate: a module-load exception exits 1 (non-blocking)
+    # and silently disables every fail-closed gate in this file (round-6 P1).
     ESCALATION_ROUND_CAP = 3  # the genesis-development SKILL.md prose cap
 
 from shell_parse import (  # noqa: E402
@@ -1158,6 +1161,14 @@ def _check_codex_round_escalation(segs) -> tuple[bool, str]:
     try:
         if any(has_trailing_override(s.raw, "escalation-ack") for s in segs):
             return False, ""
+        # Bound this scan's gh (_codex_reviews) calls by the SHARED hook deadline,
+        # so a slow API + a compound command can't push the aggregate past the
+        # ~60s hook wall-clock and get the WHOLE hook SIGKILLed — which fails open
+        # on every gate (round-6 P1). Idempotent: a later merge gate reuses this
+        # same deadline (it arms only when None), never resets it.
+        global _merge_deadline
+        if _merge_deadline is None:
+            _merge_deadline = time.monotonic() + _MERGE_GATE_BUDGET_S
         # Earlier trigger segments in THIS command count toward the total: each
         # segment sees the same pre-execution API count, so `request && request`
         # at cap-1 would otherwise dispatch round N+1 unacknowledged (round-2
@@ -2494,8 +2505,12 @@ def main() -> int:
             # findings) reads it via _gh_timeout so the AGGREGATE finishes under the
             # hook's ~60s wall-clock, instead of summing per-call caps past it and
             # getting SIGKILLed mid-gate (Codex P1 #1373). Budget < 60s with headroom.
+            # Idempotent: the escalation gate may have already armed it for the same
+            # command (round-6 P1) — reuse that deadline so the two gates share ONE
+            # aggregate budget, never re-extend it here.
             global _merge_deadline
-            _merge_deadline = time.monotonic() + _MERGE_GATE_BUDGET_S
+            if _merge_deadline is None:
+                _merge_deadline = time.monotonic() + _MERGE_GATE_BUDGET_S
             merge_repo = _merge_target_repo(merge_seg.argv, merge_seg.raw)
             # For a DERIVED (no --repo) merge, the dir gh resolves the repo AND a
             # numberless branch-PR from — threaded to _resolve_pr_number so a

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -52,7 +52,22 @@ import sys
 # script (sys.path[0] is this dir) AND when it is imported as a module for tests
 # (importlib does not add the file's dir to sys.path).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# scripts/ (parent dir) for review_state — the shared escalation-cap constant, so
+# the Codex-round gate below and the commit gate's Rule 3 stop at the same N.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from hook_input import field, read_payload, run_guard  # noqa: E402
+
+# SOFT dependency (mirrors review_enforcement_commit.py's guard for the SAME
+# import): an unimportable review_state must degrade ONLY the round-escalation
+# advisory to its documented default — never crash this module at load time.
+# A module-load exception exits 1 BEFORE run_guard's fail-closed wrapper can
+# convert it to a block, and CC treats non-2 as non-blocking → EVERY fail-closed
+# gate in this file (force-push, merge, sqlite) would silently vanish.
+try:
+    from review_state import ESCALATION_ROUND_CAP  # noqa: E402
+except ImportError:  # pragma: no cover — exercised via sys.modules stub in tests
+    ESCALATION_ROUND_CAP = 3  # the genesis-development SKILL.md prose cap
+
 from shell_parse import (  # noqa: E402
     analyze,
     commit_skips_hooks,
@@ -889,16 +904,18 @@ def _pr_head_sha(pr_num: str, repo: str | None = None) -> str | None:
     return sha or None
 
 
-def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | None:
-    """The FULL commit oid (``.commit_id``) of Codex's MOST RECENT review, or None
-    if Codex has posted no review (or on any API/parse error).
+def _codex_review_commit_ids(pr_num: str, repo: str | None = None) -> list[str] | None:
+    """FULL commit oids (``.commit_id``) of EVERY Codex review on the PR,
+    oldest-first, or None on any API/parse error (distinct from ``[]`` = the
+    query succeeded and Codex has posted no review).
 
     Uses GitHub's authoritative per-review ``commit_id`` (the exact 40-char oid
-    the review was submitted against) rather than parsing the review body — so the
-    comparison is a full-oid identity, immune to short-prefix collisions/grinding.
-    The ``/pulls/N/reviews`` endpoint returns reviews oldest-first, so the last
-    Codex entry wins. Tests inject via ``_TEST_GH_CODEX_REVIEWS`` (one JSON object
-    per line: ``{login, commit_id}``). Fail-safe: None on any API/parse error.
+    the review was submitted against) rather than parsing review bodies — a
+    full-oid identity, immune to short-prefix collisions/grinding. The
+    ``/pulls/N/reviews`` endpoint returns reviews oldest-first. Tests inject via
+    ``_TEST_GH_CODEX_REVIEWS`` (one JSON object per line: ``{login, commit_id}``).
+    Consumers: ``_latest_codex_reviewed_sha`` (the #1366 reviewed-head gate,
+    last entry) and ``_check_codex_round_escalation`` (round count, len()).
     """
     raw = os.environ.get("_TEST_GH_CODEX_REVIEWS")
     if raw is None:
@@ -921,7 +938,7 @@ def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | No
             raw = result.stdout
         except Exception:
             return None
-    latest: str | None = None
+    ids: list[str] = []
     for line in (raw or "").splitlines():
         line = line.strip()
         if not line:
@@ -934,8 +951,121 @@ def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | No
             continue
         cid = (obj.get("commit_id") or "").strip().lower()
         if cid:
-            latest = cid
-    return latest
+            ids.append(cid)
+    return ids
+
+
+def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | None:
+    """The FULL commit oid of Codex's MOST RECENT review, or None if Codex has
+    posted no review (or on any API/parse error). See
+    ``_codex_review_commit_ids`` for the query/identity model."""
+    ids = _codex_review_commit_ids(pr_num, repo=repo)
+    return ids[-1] if ids else None
+
+
+def _comment_pr_number(argv: list[str]) -> str | None:
+    """PR number from a ``gh pr comment`` segment's argv (bare number, #N, or
+    PR URL), or None (numberless form — gh would infer the branch's PR, which
+    this advisory deliberately does NOT chase; see the fail-open table)."""
+    try:
+        idx = argv.index("comment")
+    except ValueError:
+        return None
+    for tok in argv[idx + 1 :]:
+        if tok.startswith("-"):
+            continue
+        if tok.isdigit():
+            return tok
+        if tok.startswith("#") and tok[1:].isdigit():
+            return tok[1:]
+        url = re.match(r"\S*/pull/(\d+)\b", tok)
+        if url:
+            return url.group(1)
+    return None
+
+
+def _comment_repo(argv: list[str]) -> str | None:
+    """Explicit ``--repo``/``-R`` value on a gh pr comment segment, if any."""
+    for i, tok in enumerate(argv):
+        if tok in ("--repo", "-R") and i + 1 < len(argv):
+            return argv[i + 1]
+        if tok.startswith("--repo="):
+            return tok.split("=", 1)[1]
+    return None
+
+
+def _escalation_advisory(pr_num: str, rounds: int) -> str:
+    return (
+        f"BLOCKED: this would be Codex round {rounds + 1} on PR #{pr_num} — "
+        f"{rounds} rounds already ran (cap {ESCALATION_ROUND_CAP}). Repeated "
+        "rounds each finding NEW defects is the whack-a-mole signature: the "
+        "fixes themselves are becoming the bug source. STEP BACK before "
+        "requesting another round:\n"
+        "  1. TRIAGE every open finding FIRST — classify each as {live bug | "
+        "latent trap | hardening | observation}. Only live bugs and "
+        "cheaper-now-than-later traps may change already-reviewed code; "
+        "everything else gets a documented acceptance or routes to the PR that "
+        "owns that area. Findings are inputs to judgment, not a to-do list.\n"
+        "  2. Fix MECHANISMS, not instances — ask 'what made this bug "
+        "possible?' and remove that; patching the named instance leaves the "
+        "class alive for the next round to find.\n"
+        "  3. State-machine/queue/lifecycle code: enumerate EVERY status value "
+        "and trace your change under each one. Your tests encode your own "
+        "model of the states — they cannot catch the states you didn't "
+        "consider.\n"
+        "  4. Consider REVERTING a prior round's fix instead of patching it "
+        "again — less code is often the real fix.\n"
+        "  5. ESCALATE to the user with a minimize-change recommendation — "
+        "past the cap, standing approval is consumed; each extra round needs "
+        "a fresh, conscious decision.\n"
+        "After doing the above (triage table produced, user consulted), "
+        "re-run with a trailing shell comment (outside any quotes):\n"
+        f'  gh pr comment {pr_num} --body "@codex review"  # escalation-ack'
+    )
+
+
+def _check_codex_round_escalation(segs) -> tuple[bool, str]:
+    """Block a ``gh pr comment … @codex review`` once the PR already carries
+    ``ESCALATION_ROUND_CAP`` Codex reviews, until a trailing ``# escalation-ack``.
+
+    Companion to the commit gate's Rule 3 (review_enforcement_commit.py): that
+    counter tracks LOCAL review→fix rounds and stays asleep when every local
+    review is clean while the loop churns through CODEX rounds on the PR — the
+    exact blind spot of the 2026-08-12 MW-3 #1372 whack-a-mole (5 Codex rounds,
+    local counter at 0). This gate counts the PR's actual Codex reviews from the
+    GitHub API (stateless, authoritative) at the one moment the groove happens:
+    requesting the next round.
+
+    FAIL-OPEN state table (advisory logic must never break workflow — the
+    opposite posture from the fail-closed merge gates, on purpose):
+      segment isn't `gh pr comment`            → untouched
+      comment without an '@codex review' body  → untouched
+      trailing '# escalation-ack' on the seg   → allow (the conscious continue)
+      numberless comment (branch-PR inference) → allow (no PR to count against)
+      gh/API/parse error (ids is None)         → allow
+      rounds < ESCALATION_ROUND_CAP            → allow, silently
+      rounds >= cap, no ack                    → BLOCK with the step-back order
+    Any unexpected exception → allow (caught here, NOT left to run_guard's
+    fail-closed exit-2, which would turn an advisory bug into a hard block).
+    """
+    try:
+        for seg in segs:
+            if gh_pr_subcommand(seg.argv) != "comment":
+                continue
+            if not any("@codex review" in tok.lower() for tok in seg.argv):
+                continue
+            if has_trailing_override(seg.raw, "escalation-ack"):
+                return False, ""
+            pr_num = _comment_pr_number(seg.argv)
+            if not pr_num:
+                return False, ""
+            ids = _codex_review_commit_ids(pr_num, repo=_comment_repo(seg.argv))
+            if ids is None or len(ids) < ESCALATION_ROUND_CAP:
+                return False, ""
+            return True, _escalation_advisory(pr_num, len(ids))
+    except Exception:
+        return False, ""
+    return False, ""
 
 
 def _check_codex_reviewed_head(
@@ -1919,6 +2049,17 @@ def main() -> int:
                 "its own command so each is gated separately.",
                 file=sys.stderr,
             )
+            return 2
+
+        # ── Codex round-escalation gate (`gh pr comment … @codex review`) ──
+        # Once a PR already carries ESCALATION_ROUND_CAP Codex reviews,
+        # requesting another round is the whack-a-mole moment — force the
+        # step-back (triage / mechanism / state-space) before round N+1.
+        # Fail-open inside the check; '# escalation-ack' is the conscious
+        # continue after a fresh user decision.
+        esc_block, esc_msg = _check_codex_round_escalation(segs)
+        if esc_block:
+            print(esc_msg, file=sys.stderr)
             return 2
 
         # An interactive push defers to a native approve/deny dialog at the END

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -963,38 +963,59 @@ def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | No
     return ids[-1] if ids else None
 
 
-def _comment_pr_number(argv: list[str]) -> str | None:
-    """PR number from a ``gh pr comment`` segment's argv (bare number, #N, or
-    PR URL), or None (numberless form — gh would infer the branch's PR, which
-    this advisory deliberately does NOT chase; see the fail-open table)."""
+def _comment_target(argv: list[str]) -> tuple[str | None, str | None]:
+    """(pr_number, repo) from a ``gh pr comment`` segment's argv.
+
+    Number from a bare number, #N, or PR URL; a URL target ALSO carries its
+    OWNER/REPO (counting against the hook cwd's repo for a cross-repo URL could
+    produce a wrong count and a FALSE block — Codex round-1 finding). An
+    explicit ``--repo``/``-R`` flag wins over the URL-derived repo. A branch
+    target (non-numeric, non-URL positional) yields (None, …) → fail-open.
+    """
+    pr_num: str | None = None
+    url_repo: str | None = None
     try:
         idx = argv.index("comment")
     except ValueError:
-        return None
+        return None, None
     for tok in argv[idx + 1 :]:
         if tok.startswith("-"):
             continue
-        if tok.isdigit():
-            return tok
-        if tok.startswith("#") and tok[1:].isdigit():
-            return tok[1:]
-        url = re.match(r"\S*/pull/(\d+)\b", tok)
-        if url:
-            return url.group(1)
-    return None
+        if pr_num is None and tok.isdigit():
+            pr_num = tok
+        elif pr_num is None and tok.startswith("#") and tok[1:].isdigit():
+            pr_num = tok[1:]
+        elif pr_num is None:
+            url = re.match(r"(?:[a-z]+://[^/\s]+/)?([^/\s]+/[^/\s]+)/pull/(\d+)\b", tok)
+            if url:
+                url_repo, pr_num = url.group(1), url.group(2)
+    return pr_num, _comment_repo(argv) or url_repo
 
 
 def _comment_repo(argv: list[str]) -> str | None:
-    """Explicit ``--repo``/``-R`` value on a gh pr comment segment, if any."""
+    """Explicit ``--repo``/``-R`` value on a gh pr comment segment, if any.
+
+    Handles separated (``--repo o/r`` / ``-R o/r``), ``--repo=o/r``, and glued
+    ``-Ro/r`` forms. A host-qualified ``HOST/OWNER/REPO`` is reduced to its
+    OWNER/REPO tail (the REST path shape this gate queries).
+    """
+    val: str | None = None
     for i, tok in enumerate(argv):
         if tok in ("--repo", "-R") and i + 1 < len(argv):
-            return argv[i + 1]
-        if tok.startswith("--repo="):
-            return tok.split("=", 1)[1]
-    return None
+            val = argv[i + 1]
+        elif tok.startswith("--repo="):
+            val = tok.split("=", 1)[1]
+        elif tok.startswith("-R") and len(tok) > 2 and not tok.startswith("-R="):
+            val = tok[2:]
+        elif tok.startswith("-R=") and len(tok) > 3:
+            val = tok[3:]
+    if val and val.count("/") >= 2:
+        val = "/".join(val.split("/")[-2:])
+    return val
 
 
-def _escalation_advisory(pr_num: str, rounds: int) -> str:
+def _escalation_advisory(pr_num: str, rounds: int, repo: str | None = None) -> str:
+    repo_arg = f" --repo {repo}" if repo else ""
     return (
         f"BLOCKED: this would be Codex round {rounds + 1} on PR #{pr_num} — "
         f"{rounds} rounds already ran (cap {ESCALATION_ROUND_CAP}). Repeated "
@@ -1020,7 +1041,7 @@ def _escalation_advisory(pr_num: str, rounds: int) -> str:
         "a fresh, conscious decision.\n"
         "After doing the above (triage table produced, user consulted), "
         "re-run with a trailing shell comment (outside any quotes):\n"
-        f'  gh pr comment {pr_num} --body "@codex review"  # escalation-ack'
+        f'  gh pr comment {pr_num}{repo_arg} --body "@codex review"  # escalation-ack'
     )
 
 
@@ -1038,31 +1059,39 @@ def _check_codex_round_escalation(segs) -> tuple[bool, str]:
 
     FAIL-OPEN state table (advisory logic must never break workflow — the
     opposite posture from the fail-closed merge gates, on purpose):
-      segment isn't `gh pr comment`            → untouched
-      comment without an '@codex review' body  → untouched
-      trailing '# escalation-ack' on the seg   → allow (the conscious continue)
-      numberless comment (branch-PR inference) → allow (no PR to count against)
-      gh/API/parse error (ids is None)         → allow
-      rounds < ESCALATION_ROUND_CAP            → allow, silently
-      rounds >= cap, no ack                    → BLOCK with the step-back order
+      segment isn't `gh pr comment`               → untouched
+      comment without an '@codex review' body     → untouched (body-file/stdin
+        bodies are unresolvable here — documented coverage limit, fail-open;
+        blocking unresolvable bodies would false-block non-trigger comments)
+      '# escalation-ack' trailing ANY segment     → allow the whole command (a
+        nested `bash -c '…' # escalation-ack` carries the ack on the OUTER
+        segment; the ack is a conscious human-directed act, so one ack licenses
+        the command it trails)
+      numberless/branch target (no PR number)     → that segment allows;
+        SCANNING CONTINUES (an allowed segment must not shield a later one)
+      gh/API/parse error (ids is None)            → that segment allows, scan on
+      rounds < ESCALATION_ROUND_CAP               → that segment allows, scan on
+      any segment at rounds >= cap, no ack        → BLOCK with the step-back
+        order (URL targets carry their OWN repo into the count — counting the
+        hook cwd's repo for a cross-repo URL could produce a FALSE block)
     Any unexpected exception → allow (caught here, NOT left to run_guard's
     fail-closed exit-2, which would turn an advisory bug into a hard block).
     """
     try:
+        if any(has_trailing_override(s.raw, "escalation-ack") for s in segs):
+            return False, ""
         for seg in segs:
             if gh_pr_subcommand(seg.argv) != "comment":
                 continue
             if not any("@codex review" in tok.lower() for tok in seg.argv):
                 continue
-            if has_trailing_override(seg.raw, "escalation-ack"):
-                return False, ""
-            pr_num = _comment_pr_number(seg.argv)
+            pr_num, repo = _comment_target(seg.argv)
             if not pr_num:
-                return False, ""
-            ids = _codex_review_commit_ids(pr_num, repo=_comment_repo(seg.argv))
+                continue
+            ids = _codex_review_commit_ids(pr_num, repo=repo)
             if ids is None or len(ids) < ESCALATION_ROUND_CAP:
-                return False, ""
-            return True, _escalation_advisory(pr_num, len(ids))
+                continue
+            return True, _escalation_advisory(pr_num, len(ids), repo)
     except Exception:
         return False, ""
     return False, ""

--- a/tests/test_hooks/test_git_push_guard_escalation.py
+++ b/tests/test_hooks/test_git_push_guard_escalation.py
@@ -1,0 +1,177 @@
+"""Codex round-escalation gate on `gh pr comment … @codex review`.
+
+Once a PR already carries ESCALATION_ROUND_CAP Codex reviews, requesting
+another round must BLOCK with the step-back advisory (triage / mechanism /
+state-space) until a trailing '# escalation-ack'. Companion to the commit
+gate's Rule 3: that counter tracks LOCAL review rounds and stays asleep when
+every local review is clean while the loop churns through CODEX rounds — the
+2026-08-12 MW-3 whack-a-mole blind spot this gate closes.
+
+Network-free via the existing _TEST_GH_CODEX_REVIEWS seam (JSONL, one
+{login, commit_id} per line — same seam the reviewed-head gate uses).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_HOOKS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts" / "hooks"
+_spec = importlib.util.spec_from_file_location(
+    "git_push_guard_escalation_under_test", _HOOKS_DIR / "git_push_guard.py"
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+CODEX = "chatgpt-codex-connector[bot]"
+CAP = _mod.ESCALATION_ROUND_CAP
+
+
+def _reviews_jsonl(*commit_ids: str, login: str = CODEX) -> str:
+    return "\n".join(json.dumps({"login": login, "commit_id": cid}) for cid in commit_ids)
+
+
+def _shas(n: int) -> list[str]:
+    return [f"{i:x}" * 40 for i in range(1, n + 1)]
+
+
+def _segs(cmd: str):
+    return _mod.analyze(cmd)
+
+
+def _check(cmd: str):
+    return _mod._check_codex_round_escalation(_segs(cmd))
+
+
+TRIGGER = 'gh pr comment 1372 --body "@codex review"'
+
+
+class TestCountHelper:
+    def test_counts_only_codex_reviews(self, monkeypatch):
+        mixed = _reviews_jsonl(*_shas(2)) + "\n" + _reviews_jsonl("f" * 40, login="some-human")
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", mixed)
+        ids = _mod._codex_review_commit_ids("1372")
+        assert ids is not None and len(ids) == 2
+
+    def test_empty_seam_is_zero_not_none(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
+        assert _mod._codex_review_commit_ids("1372") == []
+
+    def test_latest_sha_still_last_entry(self, monkeypatch):
+        # Refactor regression: the #1366 reviewed-head gate consumes the SAME
+        # fetch — the latest sha must remain the LAST codex entry.
+        shas = _shas(3)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*shas))
+        assert _mod._latest_codex_reviewed_sha("1372") == shas[-1]
+
+    def test_api_error_returns_none(self, monkeypatch):
+        monkeypatch.delenv("_TEST_GH_CODEX_REVIEWS", raising=False)
+
+        def boom(*a, **k):
+            raise OSError("no network in tests")
+
+        monkeypatch.setattr(_mod.subprocess, "run", boom)
+        assert _mod._codex_review_commit_ids("1372") is None
+
+
+class TestEscalationGate:
+    def test_at_cap_blocks_with_step_back_order(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        block, msg = _check(TRIGGER)
+        assert block is True
+        low = msg.lower()
+        # The advisory must carry all three disciplines + the continue path.
+        assert "triage" in low
+        assert "mechanism" in low
+        assert "state" in low and "enumerate" in low
+        assert "revert" in low
+        assert "escalation-ack" in msg
+
+    def test_above_cap_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP + 2)))
+        block, _ = _check(TRIGGER)
+        assert block is True
+
+    def test_below_cap_allows_silently(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP - 1)))
+        assert _check(TRIGGER) == (False, "")
+
+    def test_ack_sigil_allows(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP + 1)))
+        block, _ = _check(TRIGGER + "  # escalation-ack")
+        assert block is False
+
+    def test_non_codex_comment_untouched(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        assert _check('gh pr comment 1372 --body "great work"') == (False, "")
+
+    def test_non_comment_commands_untouched(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        for cmd in ("git status", "gh pr view 1372", "echo '@codex review'"):
+            assert _check(cmd) == (False, "")
+
+    def test_numberless_comment_fails_open(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        assert _check('gh pr comment --body "@codex review"') == (False, "")
+
+    def test_api_error_fails_open(self, monkeypatch):
+        monkeypatch.delenv("_TEST_GH_CODEX_REVIEWS", raising=False)
+
+        def boom(*a, **k):
+            raise OSError("no network in tests")
+
+        monkeypatch.setattr(_mod.subprocess, "run", boom)
+        assert _check(TRIGGER) == (False, "")
+
+    def test_url_and_hash_pr_forms_resolve(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        for form in (
+            'gh pr comment "#1372" --body "@codex review"',
+            'gh pr comment https://github.com/o/r/pull/1372 --body "@codex review"',
+        ):
+            block, _ = _check(form)
+            assert block is True, form
+
+    def test_explicit_repo_flag_parsed(self):
+        argv = ["gh", "pr", "comment", "7", "--repo", "o/r", "--body", "x"]
+        assert _mod._comment_repo(argv) == "o/r"
+        assert _mod._comment_pr_number(argv) == "7"
+
+
+class TestSoftDependency:
+    def test_module_loads_without_review_state(self, monkeypatch):
+        """CRITICAL (reviewer, round 1): an unguarded top-level import of
+        review_state would crash the WHOLE guard at module load (exit 1 → CC
+        treats as non-blocking → every fail-closed gate silently gone). The
+        import must be soft: review_state unimportable → module still loads,
+        cap falls back to its documented default."""
+        import sys as _sys
+
+        monkeypatch.setitem(_sys.modules, "review_state", None)  # forces ImportError
+        spec = importlib.util.spec_from_file_location(
+            "git_push_guard_no_review_state", _HOOKS_DIR / "git_push_guard.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # must NOT raise
+        assert mod.ESCALATION_ROUND_CAP == 3  # documented fallback = the prose cap
+
+
+class TestMainWiring:
+    def _run_main(self, monkeypatch, cmd: str) -> int:
+        monkeypatch.setattr(_mod, "read_payload", lambda: {"tool_input": {"command": cmd}})
+        return _mod.main()
+
+    def test_main_blocks_at_cap(self, monkeypatch, capsys):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        rc = self._run_main(monkeypatch, TRIGGER)
+        assert rc == 2
+        assert "escalation-ack" in capsys.readouterr().err
+
+    def test_main_allows_below_cap(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP - 1)))
+        assert self._run_main(monkeypatch, TRIGGER) == 0
+
+    def test_main_allows_with_ack(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        assert self._run_main(monkeypatch, TRIGGER + "  # escalation-ack") == 0

--- a/tests/test_hooks/test_git_push_guard_escalation.py
+++ b/tests/test_hooks/test_git_push_guard_escalation.py
@@ -32,6 +32,13 @@ def _reviews_jsonl(*commit_ids: str, login: str = CODEX) -> str:
     return "\n".join(json.dumps({"login": login, "commit_id": cid}) for cid in commit_ids)
 
 
+def _reviews_jsonl_stated(*pairs: tuple[str, str], login: str = CODEX) -> str:
+    """JSONL with explicit review state, e.g. ("aaa...", "DISMISSED")."""
+    return "\n".join(
+        json.dumps({"login": login, "commit_id": cid, "state": st}) for cid, st in pairs
+    )
+
+
 def _shas(n: int) -> list[str]:
     return [f"{i:x}" * 40 for i in range(1, n + 1)]
 
@@ -73,6 +80,59 @@ class TestCountHelper:
 
         monkeypatch.setattr(_mod.subprocess, "run", boom)
         assert _mod._codex_review_commit_ids("1372") is None
+
+    def test_dismissed_reviews_skipped_for_freshness(self, monkeypatch):
+        # A dismissed review vouches for no commit — freshness ignores it.
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_REVIEWS",
+            _reviews_jsonl_stated(("a" * 40, "DISMISSED"), ("b" * 40, "COMMENTED")),
+        )
+        assert _mod._codex_review_commit_ids("1372") == ["b" * 40]
+        assert _mod._latest_codex_reviewed_sha("1372") == "b" * 40
+
+    def test_freshness_falls_to_earlier_active_when_latest_dismissed(self, monkeypatch):
+        # Realistic shape: an active review, then a LATER dismissed one (re-review
+        # dismissed as stale). Freshness must fall back to the earlier active sha,
+        # NOT the dismissed latest — the merge gate then blocks unless HEAD==that.
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_REVIEWS",
+            _reviews_jsonl_stated(("a" * 40, "COMMENTED"), ("b" * 40, "DISMISSED")),
+        )
+        assert _mod._codex_review_commit_ids("1372") == ["a" * 40]
+        assert _mod._latest_codex_reviewed_sha("1372") == "a" * 40
+
+    def test_freshness_none_when_all_dismissed(self, monkeypatch):
+        # All-dismissed → no vouched commit → None → the #1366 merge gate
+        # fail-CLOSED blocks (a dismissed-only PR is never "reviewed at HEAD").
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_REVIEWS",
+            _reviews_jsonl_stated(("a" * 40, "DISMISSED"), ("b" * 40, "DISMISSED")),
+        )
+        assert _mod._codex_review_commit_ids("1372") == []
+        assert _mod._latest_codex_reviewed_sha("1372") is None
+
+
+class TestDismissedRoundCounting:
+    """Codex round 5 (#1385): dismissed reviews STILL RAN as rounds and consumed
+    the review budget, so the escalation counter must count them — even though
+    freshness skips them."""
+
+    def test_dismissed_reviews_count_toward_escalation_cap(self, monkeypatch):
+        # CAP dismissed Codex reviews = CAP rounds already ran → a new unacked
+        # trigger is round N+1 and must BLOCK (was: allowed, count skipped them).
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_REVIEWS",
+            _reviews_jsonl_stated(*[(f"{i:x}" * 40, "DISMISSED") for i in range(1, CAP + 1)]),
+        )
+        block, _ = _check(TRIGGER)
+        assert block is True
+
+    def test_dismissed_below_cap_still_allows(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_REVIEWS",
+            _reviews_jsonl_stated(*[(f"{i:x}" * 40, "DISMISSED") for i in range(1, CAP)]),
+        )
+        assert _check(TRIGGER) == (False, "")
 
 
 class TestEscalationGate:
@@ -170,6 +230,56 @@ class TestEscalationGate:
     def test_host_qualified_repo_reduced_to_owner_repo(self):
         argv = ["gh", "pr", "comment", "7", "--repo", "ghe.example.com/o/r", "--body", "x"]
         assert _mod._comment_repo(argv) == "o/r"
+
+    def test_url_inside_body_value_not_taken_as_pr_target(self):
+        # Round-5 (#1385): a legit branch-target comment whose --body TEXT
+        # contains a PR URL must NOT resolve to that URL's repo/number — the
+        # gate would otherwise count/block against an unrelated repo. The
+        # positional target is the branch ('feature') → non-numeric → fail-open.
+        argv = [
+            "gh",
+            "pr",
+            "comment",
+            "feature",
+            "--body",
+            "https://github.com/other/project/pull/7 @codex review",
+        ]
+        assert _mod._comment_target(argv) == (None, None)
+
+    def test_url_inside_short_body_flag_not_taken_as_target(self):
+        argv = [
+            "gh",
+            "pr",
+            "comment",
+            "feature",
+            "-b",
+            "https://github.com/o/r/pull/9 @codex review",
+        ]
+        assert _mod._comment_target(argv) == (None, None)
+
+    def test_glued_body_forms_not_taken_as_target(self):
+        # Glued value forms (`--body=…`, `-b…`) are single `-`-prefixed tokens
+        # already skipped by the generic dash-prefix branch — a URL inside them
+        # must not resolve as the target either.
+        assert _mod._comment_target(
+            ["gh", "pr", "comment", "feature", "--body=https://github.com/o/r/pull/9"]
+        ) == (None, None)
+        assert _mod._comment_target(
+            ["gh", "pr", "comment", "feature", "-bhttps://github.com/o/r/pull/9"]
+        ) == (None, None)
+
+    def test_real_url_target_still_resolves_with_body(self):
+        # Guard against over-skipping: a genuine URL TARGET still resolves even
+        # when a --body value is also present.
+        argv = [
+            "gh",
+            "pr",
+            "comment",
+            "https://github.com/o/r/pull/12",
+            "--body",
+            "@codex review",
+        ]
+        assert _mod._comment_target(argv) == ("12", "o/r")
 
 
 class TestCodexRound1Fixes:

--- a/tests/test_hooks/test_git_push_guard_escalation.py
+++ b/tests/test_hooks/test_git_push_guard_escalation.py
@@ -135,8 +135,79 @@ class TestEscalationGate:
 
     def test_explicit_repo_flag_parsed(self):
         argv = ["gh", "pr", "comment", "7", "--repo", "o/r", "--body", "x"]
+        assert _mod._comment_target(argv) == ("7", "o/r")
+
+    def test_host_qualified_repo_reduced_to_owner_repo(self):
+        argv = ["gh", "pr", "comment", "7", "--repo", "ghe.example.com/o/r", "--body", "x"]
         assert _mod._comment_repo(argv) == "o/r"
-        assert _mod._comment_pr_number(argv) == "7"
+
+
+class TestCodexRound1Fixes:
+    """Codex round-1 findings on the gate itself (compound-scan, URL repo,
+    outer ack, remediation repo) — each witnessed RED before its fix."""
+
+    def test_compound_scans_every_comment_segment(self, monkeypatch):
+        # Finding 2: an allowed FIRST segment must not return for the whole
+        # command — a later at-cap request in the same compound must still block.
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        cmd = (
+            'gh pr comment --body "@codex review" && '  # numberless → allowed
+            'gh pr comment 1372 --body "@codex review"'  # at cap → must block
+        )
+        block, _ = _check(cmd)
+        assert block is True
+
+    def test_url_target_carries_its_repo_into_the_count(self, monkeypatch):
+        # Finding 1: a PR-URL target names its repo — the count must query THAT
+        # repo, not the hook cwd's. Capture the api path via a fake subprocess.
+        monkeypatch.delenv("_TEST_GH_CODEX_REVIEWS", raising=False)
+        seen = {}
+
+        def fake_run(argv, **kwargs):
+            seen["path"] = next(a for a in argv if a.startswith("repos/"))
+
+            class R:
+                returncode = 0
+                stdout = _reviews_jsonl(*_shas(CAP))
+
+            return R()
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        block, _ = _check(
+            'gh pr comment https://github.com/other/project/pull/7 --body "@codex review"'
+        )
+        assert block is True
+        assert seen["path"] == "repos/other/project/pulls/7/reviews"
+
+    def test_glued_repo_flag_parsed(self):
+        argv = ["gh", "pr", "comment", "7", "-Rother/project", "--body", "x"]
+        assert _mod._comment_repo(argv) == "other/project"
+
+    def test_outer_ack_on_nested_command_honored(self, monkeypatch):
+        # Finding 4: `bash -c '…' # escalation-ack` — the inner gh segment's raw
+        # text lacks the outer trailing comment; a whole-command trailing ack
+        # must still count as the conscious continue (false-block prevention).
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
+        cmd = "bash -c 'gh pr comment 1372 --body \"@codex review\"'  # escalation-ack"
+        block, _ = _check(cmd)
+        assert block is False
+
+    def test_block_message_preserves_repo_flag(self, monkeypatch):
+        # Finding 5: the printed remediation must keep --repo, or copying it
+        # posts the trigger against the wrong repository.
+        monkeypatch.delenv("_TEST_GH_CODEX_REVIEWS", raising=False)
+
+        def fake_run(argv, **kwargs):
+            class R:
+                returncode = 0
+                stdout = _reviews_jsonl(*_shas(CAP))
+
+            return R()
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        block, msg = _check('gh pr comment 7 --repo other/project --body "@codex review"')
+        assert block is True
+        assert "--repo other/project" in msg
 
 
 class TestSoftDependency:

--- a/tests/test_hooks/test_git_push_guard_escalation.py
+++ b/tests/test_hooks/test_git_push_guard_escalation.py
@@ -135,6 +135,36 @@ class TestDismissedRoundCounting:
         assert _check(TRIGGER) == (False, "")
 
 
+class TestEscalationSharedDeadline:
+    """P1 (round 6): the escalation scan's gh (_codex_reviews) calls must be
+    bounded by the shared hook deadline — otherwise a slow API + a compound
+    command can exceed the ~60s hook wall-clock, CC SIGKILLs the hook, and EVERY
+    gate (force-push/merge/sqlite) fails open. The gate must arm _merge_deadline
+    before its first gh call."""
+
+    def test_escalation_scan_arms_shared_deadline_before_gh_calls(self, monkeypatch):
+        seen = {}
+
+        def fake_reviews(pr, repo=None):
+            seen["deadline_armed"] = _mod._merge_deadline is not None
+            return []
+
+        monkeypatch.setattr(_mod, "_codex_reviews", fake_reviews)
+        monkeypatch.setattr(_mod, "_merge_deadline", None)
+        _mod._check_codex_round_escalation(_segs(TRIGGER))
+        assert seen.get("deadline_armed") is True
+
+    def test_escalation_does_not_reset_an_already_armed_deadline(self, monkeypatch):
+        import time as _time
+
+        preset = _time.monotonic() + 5.0
+        monkeypatch.setattr(_mod, "_merge_deadline", preset)
+        monkeypatch.setattr(_mod, "_codex_reviews", lambda pr, repo=None: [])
+        _mod._check_codex_round_escalation(_segs(TRIGGER))
+        # Must not extend a deadline a prior gate already armed (aggregate budget).
+        assert _mod._merge_deadline == preset
+
+
 class TestEscalationGate:
     def test_at_cap_blocks_with_step_back_order(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP)))
@@ -382,6 +412,26 @@ class TestSoftDependency:
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)  # must NOT raise
         assert mod.ESCALATION_ROUND_CAP == 3  # documented fallback = the prose cap
+
+    def test_module_loads_when_review_state_import_raises_non_importerror(self, monkeypatch):
+        """P1 (round 6): a BROKEN review_state (SyntaxError / read error, not just
+        absent) raised a NON-ImportError past the `except ImportError`, propagating
+        out of module load → exit 1 (non-blocking) → EVERY fail-closed gate silently
+        gone. Any import failure must degrade to the default cap, not crash."""
+        import sys as _sys
+
+        class _BoomModule:
+            @property
+            def ESCALATION_ROUND_CAP(self):  # simulates a broken review_state
+                raise RuntimeError("broken review_state (SyntaxError/read error)")
+
+        monkeypatch.setitem(_sys.modules, "review_state", _BoomModule())
+        spec = importlib.util.spec_from_file_location(
+            "git_push_guard_boom_review_state", _HOOKS_DIR / "git_push_guard.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)  # must NOT raise
+        assert mod.ESCALATION_ROUND_CAP == 3
 
 
 class TestMainWiring:

--- a/tests/test_hooks/test_git_push_guard_escalation.py
+++ b/tests/test_hooks/test_git_push_guard_escalation.py
@@ -192,6 +192,22 @@ class TestCodexRound1Fixes:
         block, _ = _check(cmd)
         assert block is False
 
+    def test_double_trigger_in_one_command_counts_both(self, monkeypatch):
+        # Round-2 finding: at CAP-1 existing reviews, `request && request` for
+        # the SAME PR must block — each segment previously fetched the same
+        # pre-execution count, so both passed and the second dispatched round
+        # N+1 unacked. The scan must count earlier trigger segments in the
+        # same command toward the round total.
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(*_shas(CAP - 1)))
+        cmd = (
+            'gh pr comment 1372 --body "@codex review" && gh pr comment 1372 --body "@codex review"'
+        )
+        block, _ = _check(cmd)
+        assert block is True
+        # A single trigger at CAP-1 still passes (it IS round CAP, allowed).
+        block, _ = _check('gh pr comment 1372 --body "@codex review"')
+        assert block is False
+
     def test_block_message_preserves_repo_flag(self, monkeypatch):
         # Finding 5: the printed remediation must keep --repo, or copying it
         # posts the trigger against the wrong repository.


### PR DESCRIPTION
## Why

The review-escalation system (`review_state` round counter + the commit gate's Rule 3) tracks **local** review→fix rounds — and stays asleep when every local review is clean while the loop churns through **Codex** rounds on the PR. A 5-Codex-round loop ran with the local counter at 0; round-4's fix of a non-bug introduced the only genuine liveness bug of the PR. The groove needed a machine stop at the moment it actually happens: requesting the next round.

## What

- `gh pr comment … "@codex review"` now **hard-blocks** once the PR already carries `ESCALATION_ROUND_CAP` Codex reviews (counted live from the GitHub API), printing the step-back order: (1) triage findings {live bug | latent trap | hardening | observation} — only live bugs and cheaper-now traps may change reviewed code; (2) fix mechanisms, not instances; (3) enumerate the full state space for state-machine edits; (4) consider reverting a prior round's fix; (5) escalate with a minimize-change recommendation. Trailing `# escalation-ack` (the existing sigil — same semantics as the commit gate's: a fresh user decision) is the conscious continue.
- The #1366 reviewed-head gate's fetch refactored into a shared `_codex_review_commit_ids` (latest = last entry; behavior-identical for that fail-closed consumer).
- The new check is **fail-open by construction** (numberless comment / API error / any exception → allow; full state table in its docstring) — an advisory bug can never block unrelated commands.
- Reviewer round 1 found 1 CRITICAL, fixed + locked: the `review_state` import is now a guarded **soft dependency** — unimportable `review_state` degrades only the advisory's threshold to its documented default instead of crashing the module at load (which would have silently disarmed every fail-closed gate in the file, since a load-time exception exits before `run_guard`'s fail-closed wrapper exists).
- SKILL.md: the Codex-round twin of the cap documented next to the local-round cap.

## Verification

- RED-first throughout (incl. the module-load crash witnessed with `review_state` stubbed out).
- 18 new tests + 2,513 hook/scripts suite green; ruff clean.
- Live E2E against the real GitHub API: a PR with 4 Codex rounds → block exit 2 with the full advisory; with `# escalation-ack` → exit 0; a 0-round PR → untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)