### PR TITLE
fix(security): don't log a non-numeric TELEGRAM_ALLOWED_USERS entry verbatim (CodeQL #160)

### DIFF
--- a/src/genesis/channels/bridge_config.py
+++ b/src/genesis/channels/bridge_config.py
@@ -59,12 +59,19 @@ def build_bridge_config(
     allowed_users: set[int] = set()
     allowed_raw = secrets.get("TELEGRAM_ALLOWED_USERS", "")
     if allowed_raw:
-        for uid in allowed_raw.split(","):
+        for idx, uid in enumerate(allowed_raw.split(","), start=1):
             uid = uid.strip()
             if uid.isdigit():
                 allowed_users.add(int(uid))
             elif uid and log:
-                log.warning("Invalid UID in TELEGRAM_ALLOWED_USERS: %r", uid)
+                # Never echo the raw entry: a value mis-pasted into this field
+                # (e.g. a bot token, which has the shape "<id>:<secret>") would be
+                # logged in clear text. Report the POSITION only so the user can
+                # locate it in their config without leaking its content.
+                log.warning(
+                    "TELEGRAM_ALLOWED_USERS entry #%d is not a numeric user ID — skipping it",
+                    idx,
+                )
 
     if not allowed_users:
         if log:

--- a/tests/test_channels/test_bridge_wiring.py
+++ b/tests/test_channels/test_bridge_wiring.py
@@ -52,6 +52,30 @@ def test_load_bridge_config_invalid_uids_returns_none(secrets_file):
     assert _load_bridge_config() is None
 
 
+def test_invalid_uid_is_not_logged_verbatim(caplog):
+    """A non-numeric TELEGRAM_ALLOWED_USERS entry (e.g. a bot token mis-pasted
+    into the field) must NOT be echoed to logs — only its position (CodeQL
+    py/clear-text-logging-sensitive-data, alert #160)."""
+    import logging
+
+    from genesis.channels.bridge_config import build_bridge_config
+
+    sensitive = "123456:AA_secret_bot_token_value"
+    with caplog.at_level(logging.WARNING):
+        result = build_bridge_config(
+            {"TELEGRAM_BOT_TOKEN": "tok", "TELEGRAM_ALLOWED_USERS": sensitive},
+            log=logging.getLogger("test.bridge_config"),
+        )
+    assert result is None  # no valid numeric users
+    # The raw (possibly-secret) entry must never appear in log output.
+    assert sensitive not in caplog.text
+    assert "secret_bot_token" not in caplog.text
+    # A position-based diagnostic is still emitted.
+    assert any(
+        "not a numeric user ID" in r.getMessage() for r in caplog.records
+    )
+
+
 def test_load_bridge_config_missing_token_returns_none(secrets_file):
     """Missing token → None (headless mode), not SystemExit."""
     secrets_file.write_text('SOME_KEY=value\n')


### PR DESCRIPTION
Fixes CodeQL alert #160 — `py/clear-text-logging-sensitive-data` (HIGH).

## Problem

`build_bridge_config` logged a non-numeric `TELEGRAM_ALLOWED_USERS` entry
verbatim (`log.warning("Invalid UID …: %r", uid)`). That value is taint-tracked
from a secret, and the realistic failure is a **bot token mis-pasted into the
allowed-users field** — a bot token has the shape `<id>:<secret>`, exactly what
the existing test fixture (`123456:ABC-token`) mimics — which would then be
echoed in clear text to the logs (journald / dashboard).

## Fix

Log the offending entry's **1-based position**, not its content:

```
TELEGRAM_ALLOWED_USERS entry #<n> is not a numeric user ID — skipping it
```

The tainted value no longer reaches any log sink (breaking the CodeQL taint
path), while the diagnostic stays useful — the operator can locate the bad entry
by position. No other behaviour change: valid numeric UIDs still parse, empty
entries are still skipped, and the return-None contract is unchanged.

## Test

`test_invalid_uid_is_not_logged_verbatim` passes a bot-token-shaped value and
asserts it is absent from the captured logs while a position-based warning is
still emitted. Teeth-verified against the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
