### PR TITLE
docs(architecture): CURRENT.md — skill-evolution is propose-only, not auto-apply

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1005,11 +1005,13 @@ verified: fbcf8ee4 2026-07-21
   file — no proposal is ever blocked or auto-applied. Under propose-only NO
   cognitive-file-modification ledger pre-image is created (the apply/resolve
   path that would record one is a deferred follow-up). Two ADVISORY signals ride
-  the staged proposal for the reviewer, and neither gates staging: a STRUCTURAL
-  check (`skills/validator.py`) whose outcome is recorded as a `validated` flag
-  (for MINOR it reflects the structural result; for MODERATE+ an LLM
-  apply-recommendation) plus `validation_detail` when the structural check
-  fails; and, WHEN ENABLED (gate on, router + baseline available), a shadow
+  the staged proposal for the reviewer, and neither gates staging: a deterministic
+  validator suite (`skills/validator.py` — structure, trigger coverage,
+  testability/vague-language, size, examples, and MINOR-content consistency; any
+  hard failure un-passes it) whose outcome is recorded as a `validated` flag
+  (for MINOR it reflects that suite; for MODERATE+ an LLM apply-recommendation)
+  plus `validation_detail` on failure; and, WHEN ENABLED (gate on, router +
+  baseline available), a shadow
   **skill-edit Critic** (`skills/skill_edit_critic.py` +
   `eval/rubrics/skill_edit_regression.py`) that screens for self-modification
   pathologies via the `judge` call site and logs a `skill_evolution_gate`

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1001,18 +1001,21 @@ verified: fbcf8ee4 2026-07-21
   contradiction gates), weekly skill evolution, daily triage calibration.
   Weekly skill evolution is **propose-only** (autonomous auto-apply retired
   2026-08-01, #1276): it STAGES every SKILL.md edit (MINOR and larger) as a
-  `skill_proposal` observation for human/CC review — nothing is written to a
-  skill file, and under propose-only NO cognitive-file-modification ledger
-  pre-image is created (the apply/resolve path that would record one is a
-  deferred follow-up). A STRUCTURAL check (`skills/validator.py`) and a shadow
+  `skill_proposal` observation for human/CC review and never writes a skill
+  file — no proposal is ever blocked or auto-applied. Under propose-only NO
+  cognitive-file-modification ledger pre-image is created (the apply/resolve
+  path that would record one is a deferred follow-up). Two ADVISORY signals ride
+  the staged proposal for the reviewer, and neither gates staging: a STRUCTURAL
+  check (`skills/validator.py`) whose outcome is recorded as a `validated` flag
+  (for MINOR it reflects the structural result; for MODERATE+ an LLM
+  apply-recommendation) plus `validation_detail` when the structural check
+  fails; and, WHEN ENABLED (gate on, router + baseline available), a shadow
   **skill-edit Critic** (`skills/skill_edit_critic.py` +
-  `eval/rubrics/skill_edit_regression.py`) are ADVISORY — they ride every staged
-  proposal (a proposal that fails validation is still staged, flagged
-  `validated=false`); the Critic screens for self-modification pathologies via
-  the `judge` call site and LOGS a verdict (`skill_evolution_gate` observations).
-  Neither gates staging (WS1 shadow); the `autonomy_level` param + validator
-  wiring are retained as (currently unwired) groundwork for the future WS1
-  `enforce` mode. A complementary **held-out replay
+  `eval/rubrics/skill_edit_regression.py`) that screens for self-modification
+  pathologies via the `judge` call site and logs a `skill_evolution_gate`
+  verdict (WS1 shadow). The `autonomy_level` param + validator wiring are
+  retained as (currently unwired) groundwork for the future WS1 `enforce`
+  mode. A complementary **held-out replay
   gate** (`eval/skill_replay/`, tool `skill_replay_run`) goes further — it
   REPLAYS a frozen per-skill golden suite (`~/.genesis/eval/skill_golden/`,
   authored via `eval/skill_golden_set.py`) against OLD vs NEW content in

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1000,14 +1000,19 @@ verified: fbcf8ee4 2026-07-21
   procedural extraction (extract → judge → promote hourly, novelty +
   contradiction gates), weekly skill evolution, daily triage calibration.
   Weekly skill evolution is **propose-only** (autonomous auto-apply retired
-  2026-08-01, #1276): it STAGES MINOR (and larger) SKILL.md edits as proposals
-  for human/CC review past a STRUCTURAL check (`skills/validator.py`) — the
-  autonomy>=2 wiring is retained for the future WS1 `enforce` mode. A shadow
+  2026-08-01, #1276): it STAGES every SKILL.md edit (MINOR and larger) as a
+  `skill_proposal` observation for human/CC review — nothing is written to a
+  skill file, and under propose-only NO cognitive-file-modification ledger
+  pre-image is created (the apply/resolve path that would record one is a
+  deferred follow-up). A STRUCTURAL check (`skills/validator.py`) and a shadow
   **skill-edit Critic** (`skills/skill_edit_critic.py` +
-  `eval/rubrics/skill_edit_regression.py`) now screens each staged proposal for
-  self-modification pathologies via the `judge` call site and LOGS a verdict
-  (`skill_evolution_gate` observations) — it never blocks staging (WS1 shadow).
-  A complementary **held-out replay
+  `eval/rubrics/skill_edit_regression.py`) are ADVISORY — they ride every staged
+  proposal (a proposal that fails validation is still staged, flagged
+  `validated=false`); the Critic screens for self-modification pathologies via
+  the `judge` call site and LOGS a verdict (`skill_evolution_gate` observations).
+  Neither gates staging (WS1 shadow); the `autonomy_level` param + validator
+  wiring are retained as (currently unwired) groundwork for the future WS1
+  `enforce` mode. A complementary **held-out replay
   gate** (`eval/skill_replay/`, tool `skill_replay_run`) goes further — it
   REPLAYS a frozen per-skill golden suite (`~/.genesis/eval/skill_golden/`,
   authored via `eval/skill_golden_set.py`) against OLD vs NEW content in
@@ -1455,8 +1460,10 @@ verified: 9037d45b 2026-07-07
   `~/.genesis/skill_catalog.json`, self-heals hourly), consumed by the
   injection hook and by autonomous-session resources. Skill refinement is
   propose-only: `learning/skills/applicator.py` STAGES a proposal for human/CC
-  review — the tracked cognitive-file modification is recorded when a reviewer
-  APPLIES a staged proposal, not by the applicator.
+  review and never writes a skill file. Recording it as a tracked
+  cognitive-file modification is DEFERRED — no ledger pre-image is captured
+  under propose-only; the apply/resolve path that would create one is a
+  follow-up (future WS1 `enforce`).
   Voice-master exemplars are on the contribution FORBIDDEN list.
   Cross-tool export: `scripts/export_agents_md.py` writes a body-scope
   inventory (skills + action tools, never memory/brain) into a managed

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -999,12 +999,15 @@ verified: fbcf8ee4 2026-07-21
   discipline is load-bearing here. Loops that actually run: triage pipeline,
   procedural extraction (extract → judge → promote hourly, novelty +
   contradiction gates), weekly skill evolution, daily triage calibration.
-  Weekly skill evolution auto-applies MINOR SKILL.md edits at autonomy>=2 past
-  a STRUCTURAL check (`skills/validator.py`); a shadow **skill-edit Critic**
-  (`skills/skill_edit_critic.py` + `eval/rubrics/skill_edit_regression.py`)
-  now screens each auto-applied edit for self-modification pathologies via the
-  `judge` call site and LOGS a verdict (`skill_evolution_gate` observations) —
-  it never blocks the edit (WS1 shadow). A complementary **held-out replay
+  Weekly skill evolution is **propose-only** (autonomous auto-apply retired
+  2026-08-01, #1276): it STAGES MINOR (and larger) SKILL.md edits as proposals
+  for human/CC review past a STRUCTURAL check (`skills/validator.py`) — the
+  autonomy>=2 wiring is retained for the future WS1 `enforce` mode. A shadow
+  **skill-edit Critic** (`skills/skill_edit_critic.py` +
+  `eval/rubrics/skill_edit_regression.py`) now screens each staged proposal for
+  self-modification pathologies via the `judge` call site and LOGS a verdict
+  (`skill_evolution_gate` observations) — it never blocks staging (WS1 shadow).
+  A complementary **held-out replay
   gate** (`eval/skill_replay/`, tool `skill_replay_run`) goes further — it
   REPLAYS a frozen per-skill golden suite (`~/.genesis/eval/skill_golden/`,
   authored via `eval/skill_golden_set.py`) against OLD vs NEW content in
@@ -1450,8 +1453,10 @@ verified: 9037d45b 2026-07-07
   generation (`scripts/generate_skill_catalog.py` scans `.claude/skills/`,
   `src/genesis/skills/`, `~/.genesis/skill-library/` →
   `~/.genesis/skill_catalog.json`, self-heals hourly), consumed by the
-  injection hook and by autonomous-session resources. Skill refinement is a
-  tracked cognitive-file modification (`learning/skills/applicator.py`).
+  injection hook and by autonomous-session resources. Skill refinement is
+  propose-only: `learning/skills/applicator.py` STAGES a proposal for human/CC
+  review — the tracked cognitive-file modification is recorded when a reviewer
+  APPLIES a staged proposal, not by the applicator.
   Voice-master exemplars are on the contribution FORBIDDEN list.
   Cross-tool export: `scripts/export_agents_md.py` writes a body-scope
   inventory (skills + action tools, never memory/brain) into a managed

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1015,9 +1015,9 @@ verified: fbcf8ee4 2026-07-21
   **skill-edit Critic** (`skills/skill_edit_critic.py` +
   `eval/rubrics/skill_edit_regression.py`) that screens for self-modification
   pathologies via the `judge` call site and logs a `skill_evolution_gate`
-  verdict (WS1 shadow). The `autonomy_level` param + validator wiring are
-  retained as (currently unwired) groundwork for the future WS1 `enforce`
-  mode. A complementary **held-out replay
+  verdict (WS1 shadow). The validator suite above is live (advisory); only the
+  `autonomy_level` param is retained as (currently unread) groundwork for the
+  future WS1 `enforce` mode. A complementary **held-out replay
   gate** (`eval/skill_replay/`, tool `skill_replay_run`) goes further — it
   REPLAYS a frozen per-skill golden suite (`~/.genesis/eval/skill_golden/`,
   authored via `eval/skill_golden_set.py`) against OLD vs NEW content in


### PR DESCRIPTION
_(Fresh PR — supersedes #1378, whose PR number exhausted its Codex review budget after several rounds; same branch + commits.)_

## What

`docs/architecture/CURRENT.md` §10 and §13 described the weekly skill-evolution loop as **auto-applying** MINOR SKILL.md edits. Autonomous auto-apply was retired **2026-08-01 (#1276)** — the applicator is now **propose-only**: it STAGES every change (MINOR and larger) as a `skill_proposal` observation for human/CC review; nothing is written to a skill file and no cognitive-file-modification ledger pre-image is created (that apply/resolve path is deferred).

## Verified against source

- `learning/skills/applicator.py` (propose-only; `_stage` writes only the observation; `_autonomy_level` stored-not-read; validator + Critic are advisory and never gate).
- `learning/skills/validator.py:56-82` (6-test deterministic suite; `passed = no hard failures`).
- Loop is **live**: `runtime/init/learning.py` CronTrigger `skill_evolution`; `job_health` last-run 2026-08-08, 20/20 successes.
- Class-swept the file for stale auto-apply language.

## Prior Codex review (on #1378, same content)

Codex reviewed this content across three rounds; all findings were addressed or dispositioned:
- Size-dependent `validated` + conditional Critic → **fixed** (accurate wording).
- 'STRUCTURAL check' undersold the validator → **fixed** ('deterministic validator suite').
- **[P2] Refresh verification stamps → consciously DECLINED (owner-confirmed):** this change re-verified only the *skill-evolution slice* of §10/§13, not the whole entries (eval/J9, gauntlet, snapshot dims). Bumping the `verified:` stamp would over-claim freshness on the un-re-verified parts (the 'evidence must match the scope of the claim' principle). The subsystem-map staleness check is advisory (warns, doesn't fail); a full re-verify + bump can be a follow-up.

Docs-only; review-level none per the adaptive review protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)