### PR TITLE
fix(perception): correct 5 stale/misleading signal baseline_notes fed to reflection

### DIFF
--- a/src/genesis/awareness/signals.py
+++ b/src/genesis/awareness/signals.py
@@ -499,8 +499,8 @@ class SchedulerLivenessCollector:
             collected_at=now.isoformat(),
             baseline_note=(
                 "0.5=the surplus scheduler has not run ANY of its jobs "
-                "(surplus_dispatch/surplus_brainstorm/schedule_code_index) in 15+ min "
-                "— it may be wedged"
+                "(surplus_dispatch/surplus_brainstorm/schedule_code_index) in "
+                f"{self._stale_threshold_s // 60}+ min — it may be wedged"
             ),
             metadata={"stale": stale_schedulers},
         )

--- a/src/genesis/awareness/signals.py
+++ b/src/genesis/awareness/signals.py
@@ -308,9 +308,10 @@ class ContainerMemoryCollector:
             warning_threshold=0.85,
             critical_threshold=0.90,
             baseline_note=(
-                "Excludes reclaimable page cache (anon+kernel only) — real memory pressure, "
-                "not cache noise. 70-80% is normal headroom; sustained above ~85% indicates "
-                "genuine OOM risk"
+                "Anon+kernel memory / cgroup limit (excludes the reclaimable page cache "
+                "that inflates memory.current). A pressure INDICATOR, not a definitive "
+                "OOM/PSI verdict — kernel slab can still include some reclaimable memory. "
+                "70-80% is normal headroom; sustained higher warrants attention."
             ),
         )
 
@@ -497,8 +498,9 @@ class SchedulerLivenessCollector:
             source="runtime",
             collected_at=now.isoformat(),
             baseline_note=(
-                "0.5+=one or more surplus scheduler jobs are stale past the 15-min "
-                "threshold (see metadata.stale for which) — the surplus scheduler may be wedged"
+                "0.5=the surplus scheduler has not run ANY of its jobs "
+                "(surplus_dispatch/surplus_brainstorm/schedule_code_index) in 15+ min "
+                "— it may be wedged"
             ),
             metadata={"stale": stale_schedulers},
         )

--- a/src/genesis/awareness/signals.py
+++ b/src/genesis/awareness/signals.py
@@ -307,7 +307,11 @@ class ContainerMemoryCollector:
             normal_max=0.80,
             warning_threshold=0.85,
             critical_threshold=0.90,
-            baseline_note="Includes page cache; 70-80% is normal for containerized workloads",
+            baseline_note=(
+                "Excludes reclaimable page cache (anon+kernel only) — real memory pressure, "
+                "not cache noise. 70-80% is normal headroom; sustained above ~85% indicates "
+                "genuine OOM risk"
+            ),
         )
 
 
@@ -480,7 +484,11 @@ class SchedulerLivenessCollector:
             return SignalReading(
                 name=self.signal_name, value=0.0, source="runtime",
                 collected_at=now.isoformat(),
-                baseline_note="0.0=scheduler active. Rises if surplus jobs stop running",
+                baseline_note=(
+                    "0.0=surplus scheduler active (checks ONLY the surplus jobs "
+                    "surplus_dispatch/surplus_brainstorm/schedule_code_index, not the "
+                    "awareness loop's own scheduler). Rises if those jobs stop running"
+                ),
             )
 
         return SignalReading(
@@ -488,6 +496,10 @@ class SchedulerLivenessCollector:
             value=min(1.0, len(stale_schedulers) * 0.5),
             source="runtime",
             collected_at=now.isoformat(),
+            baseline_note=(
+                "0.5+=one or more surplus scheduler jobs are stale past the 15-min "
+                "threshold (see metadata.stale for which) — the surplus scheduler may be wedged"
+            ),
             metadata={"stale": stale_schedulers},
         )
 

--- a/src/genesis/learning/signals/critical_failure.py
+++ b/src/genesis/learning/signals/critical_failure.py
@@ -44,7 +44,8 @@ class CriticalFailureCollector:
             collected_at=datetime.now(UTC).isoformat(),
             baseline_note=(
                 "0.0=DB/Qdrant (+Ollama if enabled) health probes all healthy. "
-                "0.5=a probe DEGRADED, 1.0=a probe DOWN (infrastructure health, "
-                "NOT an LLM-provider outage)"
+                "0.5=a probe DEGRADED, 1.0=a probe DOWN. This tracks LOCAL "
+                "infrastructure/service health (including the local Ollama if "
+                "enabled), NOT cloud LLM-provider availability."
             ),
         )

--- a/src/genesis/learning/signals/critical_failure.py
+++ b/src/genesis/learning/signals/critical_failure.py
@@ -42,5 +42,9 @@ class CriticalFailureCollector:
             value=value,
             source="health_probes",
             collected_at=datetime.now(UTC).isoformat(),
-            baseline_note="0.0=all providers reachable (healthy). 0.5=degraded, 1.0=provider down",
+            baseline_note=(
+                "0.0=DB/Qdrant (+Ollama if enabled) health probes all healthy. "
+                "0.5=a probe DEGRADED, 1.0=a probe DOWN (infrastructure health, "
+                "NOT an LLM-provider outage)"
+            ),
         )

--- a/src/genesis/learning/signals/pending_items.py
+++ b/src/genesis/learning/signals/pending_items.py
@@ -82,5 +82,9 @@ class PendingItemCollector:
             value=value,
             source=source,
             collected_at=datetime.now(UTC).isoformat(),
-            baseline_note="0.0=no stale pending items. Rises when follow-ups/tasks age past 3 days without resolution",
+            baseline_note=(
+                "0.0=no stale pending items; rises 3d->7d+ as follow-ups/tasks age unresolved. "
+                "NOTE: 1.0 can also mean the cognitive_state row is missing or unreadable, "
+                "not genuine staleness"
+            ),
         )

--- a/src/genesis/learning/signals/sentinel_activity.py
+++ b/src/genesis/learning/signals/sentinel_activity.py
@@ -54,5 +54,8 @@ class SentinelActivityCollector:
             value=value,
             source="sentinel_state",
             collected_at=datetime.now(UTC).isoformat(),
-            baseline_note="0.0=healthy (normal). 0.3=investigating, 0.7=remediating, 1.0=escalated",
+            baseline_note=(
+                "0.0=healthy (normal). 0.3=investigating, 0.5=awaiting user approval "
+                "(dispatch or action), 0.7=remediating, 1.0=escalated"
+            ),
         )

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -138,9 +138,9 @@ from __future__ import annotations
 _CALL_SITE_META: dict[str, dict] = {
     # ── WIRED: actively executing, have last_run records ──────────────
     "3_micro_reflection": {
-        "description": "Fast pattern check on the latest signals. Runs every awareness tick using free models.",
+        "description": "Fast LLM pattern check on the latest signals, fired only when a critical operational signal is active (~90% of micro ticks are silent by design; see PR #404). Free models.",
         "category": "reflection",
-        "frequency": "Every 5 min",
+        "frequency": "On critical signals (micro ticks otherwise silent)",
         "cost_policy": "Free primary",
         "model_tier": "slm",
     },

--- a/tests/test_awareness/test_signal_baseline_notes.py
+++ b/tests/test_awareness/test_signal_baseline_notes.py
@@ -1,0 +1,112 @@
+"""Regression: signal ``baseline_note`` strings must accurately describe what the
+collector measures.
+
+``baseline_note`` is fed VERBATIM into the reflection LLM prompt
+(``awareness/signal_format.py`` appends ``" -- baseline: {note}"``), so a stale or
+misleading note directly causes wrong reflections. A stale ``critical_failure`` note
+("provider is down") — describing an old circuit-breaker placeholder rather than the
+DB/Qdrant/Ollama health probes the collector actually runs — made a live Micro
+reflection falsely alert "a provider is down." These tests pin the accuracy of every
+note this audit corrected, each written to FAIL against the pre-fix strings.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from genesis.awareness.signals import ContainerMemoryCollector, SchedulerLivenessCollector
+from genesis.awareness.types import SignalReading
+from genesis.learning.signals.critical_failure import CriticalFailureCollector
+from genesis.learning.signals.pending_items import PendingItemCollector
+from genesis.learning.signals.sentinel_activity import SentinelActivityCollector
+
+
+async def test_critical_failure_note_describes_health_probes_not_providers():
+    # The collector runs DB/Qdrant/Ollama health probes, NOT LLM-provider circuit
+    # breakers. The note must not say "provider" (which primed a false "provider down"
+    # reflection). Empty probes → collect() still returns the note at value 0.0.
+    reading = await CriticalFailureCollector([]).collect()
+    note = reading.baseline_note or ""
+    # The old (stale) note framed this as LLM-provider reachability. Ban those
+    # misleading affirmatives; a clarifying "not an LLM-provider outage" is fine.
+    assert "providers reachable" not in note.lower(), note
+    assert "provider down" not in note.lower(), note
+    assert any(k in note.lower() for k in ("probe", "qdrant", "ollama")), note
+
+
+async def test_container_memory_note_says_excludes_cache_not_includes():
+    # The collector reads anon+kernel only and its own docstring says it EXCLUDES
+    # reclaimable page cache (which inflates memory.current and causes false pressure).
+    # The note must not claim the opposite ("Includes page cache").
+    import genesis.autonomy.watchdog as watchdog_mod
+
+    # patched at call time (collect imports it lazily) → hermetic vs host cgroup layout
+    orig = watchdog_mod.get_container_anon_memory
+    watchdog_mod.get_container_anon_memory = lambda: (1024, 4096)
+    try:
+        reading = await ContainerMemoryCollector().collect()
+    finally:
+        watchdog_mod.get_container_anon_memory = orig
+    note = reading.baseline_note or ""
+    assert "includes page cache" not in note.lower(), note
+    assert "exclud" in note.lower(), f"note should say it excludes cache: {note!r}"
+
+
+async def test_sentinel_note_documents_awaiting_approval_state(tmp_path):
+    # _STATE_VALUES maps awaiting_dispatch/action_approval -> 0.5; the note omitted 0.5
+    # entirely, leaving the LLM no grounding for "blocked on the user."
+    state = tmp_path / "sentinel_state.json"
+    state.write_text(json.dumps({"current_state": "awaiting_dispatch_approval"}))
+    reading = await SentinelActivityCollector(state_path=state).collect()
+    assert reading.value == 0.5  # sanity: the state maps to 0.5
+    note = reading.baseline_note or ""
+    assert "0.5" in note, note
+    assert "approval" in note.lower(), note
+
+
+async def test_pending_items_note_covers_missing_or_corrupt_state(db):
+    # value==1.0 also fires on a missing/corrupt cognitive_state row
+    # (no_cognitive_state / db_error / bad_timestamp), NOT only 7+ day staleness.
+    reading = await PendingItemCollector(db).collect()
+    # empty (or absent) cognitive_state -> 1.0 via no_cognitive_state/db_error
+    assert reading.value == 1.0
+    note = reading.baseline_note or ""
+    assert "cognitive_state" in note.lower() or "missing" in note.lower(), note
+
+
+def _fake_runtime(job_health: dict):
+    class _RT:
+        _bootstrap_completed_at = None  # skip the bootstrap grace branch
+        _surplus_scheduler = object()  # non-None → run the surplus liveness check
+
+        def __init__(self, jh):
+            self.job_health = jh
+
+    return _RT(job_health)
+
+
+async def test_scheduler_liveness_firing_branch_has_baseline_note():
+    # The FIRING branch (stale surplus jobs) previously attached NO baseline_note —
+    # exactly when the signal matters, the LLM got zero grounding. It must have one.
+    stale = (datetime.now(UTC) - timedelta(seconds=2000)).isoformat()  # > 900s threshold
+    collector = SchedulerLivenessCollector(
+        runtime=_fake_runtime({"surplus_dispatch": {"last_run": stale}})
+    )
+    reading = await collector.collect()
+    assert reading.value > 0.0, "expected the firing (stale) branch"
+    assert reading.baseline_note, "firing branch must carry a baseline_note"
+    assert "surplus" in (reading.baseline_note or "").lower()
+
+
+async def test_scheduler_liveness_healthy_note_scopes_to_surplus_only():
+    # The healthy-branch note must make clear it checks ONLY the surplus scheduler,
+    # not the awareness loop's own scheduling.
+    fresh = datetime.now(UTC).isoformat()
+    collector = SchedulerLivenessCollector(
+        runtime=_fake_runtime({"surplus_dispatch": {"last_run": fresh}})
+    )
+    reading = await collector.collect()
+    assert reading.value == 0.0
+    assert isinstance(reading, SignalReading)
+    assert "only" in (reading.baseline_note or "").lower(), reading.baseline_note

--- a/tests/test_awareness/test_signal_baseline_notes.py
+++ b/tests/test_awareness/test_signal_baseline_notes.py
@@ -103,6 +103,22 @@ async def test_scheduler_liveness_firing_branch_has_baseline_note():
     assert "surplus" in note
     # The note must not point the LLM at metadata — signal_format.py never renders it.
     assert "metadata" not in note, note
+    # Default threshold (900s) -> "15+ min".
+    assert "15+ min" in note, note
+
+
+async def test_scheduler_liveness_firing_note_derives_threshold_from_config():
+    # The duration in the note must derive from the configured stale_threshold_s, not
+    # a hardcoded "15 min" — else a reconfigured collector feeds the LLM a wrong duration.
+    stale = (datetime.now(UTC) - timedelta(seconds=2000)).isoformat()
+    collector = SchedulerLivenessCollector(
+        runtime=_fake_runtime({"surplus_dispatch": {"last_run": stale}}),
+        stale_threshold_s=120,  # 2 min
+    )
+    reading = await collector.collect()
+    note = (reading.baseline_note or "").lower()
+    assert "2+ min" in note, note
+    assert "15+ min" not in note, note
 
 
 async def test_scheduler_liveness_healthy_note_scopes_to_surplus_only():

--- a/tests/test_awareness/test_signal_baseline_notes.py
+++ b/tests/test_awareness/test_signal_baseline_notes.py
@@ -33,6 +33,9 @@ async def test_critical_failure_note_describes_health_probes_not_providers():
     assert "providers reachable" not in note.lower(), note
     assert "provider down" not in note.lower(), note
     assert any(k in note.lower() for k in ("probe", "qdrant", "ollama")), note
+    # Must distinguish local infra/service health from CLOUD LLM-provider status
+    # (Ollama, when enabled, IS a local LLM provider whose DOWN fires this signal).
+    assert "cloud" in note.lower(), note
 
 
 async def test_container_memory_note_says_excludes_cache_not_includes():
@@ -96,7 +99,10 @@ async def test_scheduler_liveness_firing_branch_has_baseline_note():
     reading = await collector.collect()
     assert reading.value > 0.0, "expected the firing (stale) branch"
     assert reading.baseline_note, "firing branch must carry a baseline_note"
-    assert "surplus" in (reading.baseline_note or "").lower()
+    note = (reading.baseline_note or "").lower()
+    assert "surplus" in note
+    # The note must not point the LLM at metadata — signal_format.py never renders it.
+    assert "metadata" not in note, note
 
 
 async def test_scheduler_liveness_healthy_note_scopes_to_surplus_only():


### PR DESCRIPTION
## What & why

Signal `baseline_note` strings are appended verbatim into the reflection LLM prompt
(`awareness/signal_format.py`), so an inaccurate one directly mis-grounds reflections.
A stale `critical_failure` note described LLM-provider reachability, but that signal
measures DB/Qdrant/Ollama health probes — priming a false "a provider is down"
micro-reflection on what was most likely a transient probe timeout (no provider outage
occurred). An audit of all 25 signal notes found 5 inaccurate; this corrects them.

## Changes

- **critical_failure**: describe the actual health probes (DB/Qdrant, +Ollama if
  enabled), not "providers"; clarify it is infrastructure health, not an LLM outage.
- **container_memory_pct**: note said *"Includes page cache"* but the collector reads
  anon+kernel only and its own docstring says it **excludes** reclaimable cache — the
  meaning was inverted (it was teaching the LLM to dismiss real pressure as cache).
- **stale_pending_items**: `1.0` also fires on a missing/unreadable cognitive-state row,
  not only 7+ day staleness. Kept concise — this note also renders into the user pulse.
- **sentinel_activity**: document the `0.5 = awaiting user approval` state (was omitted).
- **scheduler_liveness**: scope the healthy-branch note to the surplus jobs it actually
  checks; add a `baseline_note` to the firing branch (previously had none — no grounding
  exactly when the signal fires).
- **_call_site_meta**: correct the `micro_reflection` cadence doc (fires only on critical
  signals; ~90% of micro ticks are silent by design), not "every 5 min".

## Notes were verified accurate

Each corrected note was re-checked against its collector's `collect()` value semantics
and docstring (probe set, thresholds, state map, source fields). `SignalReading` carries
`baseline_note`/`metadata` independently, so the added firing-branch note is additive;
persistence (`awareness/loop.py`) writes it additively and no consumer parses/width-checks
the strings.

## Tests

`tests/test_awareness/test_signal_baseline_notes.py` — verify-RED: every assertion fails
against the pre-fix strings (bans the old misleading tokens, requires the corrected
grounding, and pins that the scheduler firing branch now carries a note). 6/6 green; no
regressions across `test_learning` + `test_observability` (162) and `test_signals` +
`test_integration` (10). Adversarially audited (genesis-architect); two findings fixed in
the same commit (unconditional-Ollama wording; trimmed internal tokens from the
user-facing pending-items note).

No data migration: notes are regenerated fresh per tick; historical ticks keep their text.
