### PR TITLE
fix(hooks): accept a clean Codex issue-comment at head as merge freshness

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -755,6 +755,14 @@ findings below, a gated `gh pr merge`:
   TOCTOU defense); the `--check-pr` command supplies this;
 - requires Codex to have reviewed the **current head** — Codex does NOT auto-review
   a later fix-commit, so comment `@codex review` and wait after any push.
+  **Clean-comment freshness:** a *clean* Codex re-review is posted as an ISSUE
+  COMMENT ("Codex Review: Didn't find any major issues. … **Reviewed commit:**
+  `<sha>`"), not a review object, so the reviews API never sees it. The gate now
+  ALSO accepts that clean comment when its `Reviewed commit` sha names the current
+  head — so a genuinely-clean re-review no longer false-blocks (it used to force a
+  `# stale-review-override`). Fail-closed: the clean marker alone never vouches; a
+  parseable `Reviewed commit` sha at head is required, and the comment must be
+  authored by the Codex bot.
   **Smart-delta narrowing:** a STALE review passes anyway when the unreviewed
   delta (`reviewed...head` via the compare API, classified by `review_scope`
   substantiality) is provably review-trivial (docs-only / a small single-file

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -996,6 +996,88 @@ def _latest_codex_reviewed_sha(pr_num: str, repo: str | None = None) -> str | No
     return latest
 
 
+# A CLEAN Codex re-review is posted as an ISSUE COMMENT (not a review object): the body
+# opens "Codex Review: Didn't find any major issues." (the flavour sentence after —
+# "Swish!", "You're on a roll.", "Keep them coming!", … — VARIES, so anchor ONLY on the
+# stable prefix) and carries a "**Reviewed commit:** `<sha>`" line with a 10-char
+# ABBREVIATED sha. Both must be present for the comment to vouch for a commit.
+_CODEX_CLEAN_COMMENT_RE = re.compile(
+    r"Codex Review:\s*Didn'?t find any major issues", re.IGNORECASE
+)
+_CODEX_REVIEWED_COMMIT_RE = re.compile(
+    r"Reviewed commit:\**\s*`?([0-9a-fA-F]{7,40})`?", re.IGNORECASE
+)
+
+
+def _latest_codex_clean_comment_sha(pr_num: str, repo: str | None = None) -> str | None:
+    """The ABBREVIATED commit sha from Codex's most recent CLEAN issue-comment, or None.
+
+    Codex posts a clean RE-review as an ISSUE COMMENT, not a review object, so
+    ``_latest_codex_reviewed_sha`` (which reads the reviews API) never sees it — a clean
+    re-review would then false-block the merge (bit PR #1386 twice). This is the fallback
+    the freshness gate consults when the review-object path would otherwise block: it
+    reads ``issues/N/comments``, and for a comment authored by the Codex bot (login AND
+    ``user.type == "Bot"``) requires BOTH the clean marker AND a parseable
+    ``Reviewed commit: <sha>`` line — a marker alone never vouches (fail-closed to None).
+
+    Returns a PREFIX (>=7 hex, lowercased). The caller confirms it against the
+    AUTHORITATIVE head via ``head.startswith(...)``: there is NO prefix-grinding surface
+    because the head is a fixed value read from GitHub and the comment author is verified
+    as the Codex bot (a human cannot post as ``chatgpt-codex-connector[bot]``). The
+    reviews-API path keeps its full-oid identity; only this comment fallback is a prefix,
+    and only against a known head. Comments come oldest-first, so the last match (most
+    recent clean comment) wins. Tests inject via ``_TEST_GH_CODEX_COMMENTS`` (one JSON
+    object per line: ``{login, type, body}``). Fail-safe: None on any API/parse error.
+    """
+    raw = os.environ.get("_TEST_GH_CODEX_COMMENTS")
+    if raw is None:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo or ':owner/:repo'}/issues/{pr_num}/comments",
+                    "--paginate",
+                    "--jq",
+                    ".[] | {login: .user.login, type: .user.type, body: .body}",
+                ],
+                capture_output=True,
+                text=True,
+                # See the merge-path timeout budget note in main(): fail-safe → None.
+                timeout=_gh_timeout(8),
+            )
+            if result.returncode != 0:
+                return None
+            raw = result.stdout
+        except Exception:
+            return None
+    latest: str | None = None
+    for line in (raw or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if (obj.get("login") or "") != _CODEX_REVIEW_BOT:
+            continue
+        # Require the GitHub-enforced Bot author type too — belt-and-suspenders against
+        # a spoofed login string in an injected/malformed payload.
+        if (obj.get("type") or "") != "Bot":
+            continue
+        body = obj.get("body") or ""
+        if not _CODEX_CLEAN_COMMENT_RE.search(body):
+            continue
+        m = _CODEX_REVIEWED_COMMIT_RE.search(body)
+        if not m:
+            continue  # clean marker but no parseable sha → does not vouch (fail-closed)
+        latest = m.group(1).strip().lower()
+    return latest
+
+
 def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | None) -> str | None:
     """Substantiality of what HEAD adds OVER the Codex-reviewed SHA, via the compare API.
 
@@ -1124,6 +1206,18 @@ def _check_codex_reviewed_head(
         )
     head = head.strip().lower()
     reviewed = _latest_codex_reviewed_sha(pr_num, repo=repo)
+    if reviewed == head:
+        return False, "", head
+    # The review-object path can't vouch for the current head (Codex has no review, or
+    # only a STALE one). A clean Codex RE-review is an ISSUE COMMENT (not a review object)
+    # carrying a "Reviewed commit: <sha>" marker — accept it as freshness when it names
+    # THIS head (follow-up 7ff0fdc6). Consulted ONLY on the would-block path, so the common
+    # green case (a review object already at head, above) adds no extra API call. The
+    # comment sha is an abbreviated PREFIX, matched against the AUTHORITATIVE head — no
+    # grinding surface (fixed head, bot-verified author); see the helper's docstring.
+    clean_short = _latest_codex_clean_comment_sha(pr_num, repo=repo)
+    if clean_short and head.startswith(clean_short):
+        return False, "", head
     if not reviewed:
         return (
             True,
@@ -2701,12 +2795,23 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
         # read this, not the stderr NOTE).
         _reviewed = _latest_codex_reviewed_sha(pr_num, repo=repo)
         _head = _pr_head_sha(pr_num, repo=repo)
-        if _reviewed is None or _head is None:
+        _head_l = _head.strip().lower() if _head else None
+        if _head_l is not None and _reviewed == _head_l:
+            label = "ok (current)"
+        elif (
+            _head_l is not None
+            and (_clean := _latest_codex_clean_comment_sha(pr_num, repo=repo))
+            and _head_l.startswith(_clean)
+        ):
+            # Freshness satisfied by a clean Codex ISSUE-COMMENT at head (the review
+            # object is absent or stale) — the allow path added in follow-up 7ff0fdc6.
+            label = "ok (clean comment at head)"
+        elif _reviewed is None or _head is None:
             # A transiently-failed re-read must NOT read as "current" (Codex P2
             # #1373): the enforcement gate already passed, but the report must not
             # ASSERT the head was reviewed when it could not confirm it.
             label = "ok (freshness label unverified — re-read failed)"
-        elif _reviewed != _head.strip().lower():
+        elif _reviewed != _head_l:
             label = f"ok (STALE review of {_reviewed[:12]}, delta since is trivial)"
         else:
             label = "ok (current)"

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -16,6 +16,8 @@ import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+
 _WORKTREE = Path(__file__).resolve().parent.parent.parent
 _HOOKS_DIR = _WORKTREE / "scripts" / "hooks"
 _spec = importlib.util.spec_from_file_location("git_push_guard", _HOOKS_DIR / "git_push_guard.py")
@@ -26,9 +28,29 @@ HEAD = "0cd13afeb51025af5dc7bd24df1ffa57cd2babab"
 STALE = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_codex_comments(monkeypatch):
+    """Default: NO Codex issue-comments, so the clean-comment freshness fallback in
+    ``_check_codex_reviewed_head`` is network-free unless a test opts in. Tests override
+    with their own ``monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", …)`` (later wins)."""
+    monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")
+
+
 def _reviews_jsonl(*commit_ids, login="chatgpt-codex-connector[bot]"):
     """One JSON object per line, matching gh api .../reviews --jq '{login, commit_id}'."""
     return "\n".join(json.dumps({"login": login, "commit_id": cid}) for cid in commit_ids)
+
+
+def _clean_comment_jsonl(
+    short_sha, *, login="chatgpt-codex-connector[bot]", user_type="Bot", flavour="Swish!"
+):
+    """One Codex CLEAN issue-comment, matching the real body shape (variable flavour
+    sentence + a backtick-wrapped abbreviated ``Reviewed commit`` sha)."""
+    body = (
+        f"Codex Review: Didn't find any major issues. {flavour}\n\n"
+        f"**Reviewed commit:** `{short_sha}`\n\n<details>info</details>"
+    )
+    return json.dumps({"login": login, "type": user_type, "body": body})
 
 
 class TestReviewedCommitParsing:
@@ -761,3 +783,141 @@ class TestReportFreshnessUnreadable:
         out = capsys.readouterr().out
         assert "unverified" in out
         assert "ok (current)" not in out
+
+
+class TestCleanCommentParsing:
+    """_latest_codex_clean_comment_sha — parse the real Codex clean-comment shape."""
+
+    @pytest.mark.parametrize(
+        "flavour",
+        ["Swish!", "You're on a roll.", "Keep them coming!", ":rocket:", "What shall we delve into next?"],
+    )
+    def test_parses_all_flavour_variants(self, monkeypatch, flavour):
+        # Anchor is the STABLE prefix "Didn't find any major issues", not the flavour.
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl("0cd13afeb5", flavour=flavour))
+        assert _mod._latest_codex_clean_comment_sha("1") == "0cd13afeb5"
+
+    def test_latest_clean_comment_wins(self, monkeypatch):
+        # Comments come oldest-first; the most recent clean comment wins.
+        lines = "\n".join([_clean_comment_jsonl("aaaaaaa"), _clean_comment_jsonl("bbbbbbb")])
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", lines)
+        assert _mod._latest_codex_clean_comment_sha("1") == "bbbbbbb"
+
+    def test_sha_lowercased(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl("0CD13AFEB5"))
+        assert _mod._latest_codex_clean_comment_sha("1") == "0cd13afeb5"
+
+    def test_clean_marker_without_sha_is_none(self, monkeypatch):
+        body = json.dumps(
+            {"login": "chatgpt-codex-connector[bot]", "type": "Bot",
+             "body": "Codex Review: Didn't find any major issues. Swish!"}
+        )
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", body)
+        assert _mod._latest_codex_clean_comment_sha("1") is None  # fail-closed
+
+    def test_sha_without_clean_marker_is_none(self, monkeypatch):
+        # A FINDINGS comment carries a Reviewed-commit line but no clean marker.
+        body = json.dumps(
+            {"login": "chatgpt-codex-connector[bot]", "type": "Bot",
+             "body": "### Codex Review\n[P1] a real bug\n\n**Reviewed commit:** `0cd13afeb5`"}
+        )
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", body)
+        assert _mod._latest_codex_clean_comment_sha("1") is None
+
+    def test_non_codex_author_ignored(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl("0cd13afeb5", login="attacker", user_type="User")
+        )
+        assert _mod._latest_codex_clean_comment_sha("1") is None
+
+    def test_codex_login_but_not_bot_type_ignored(self, monkeypatch):
+        # Belt-and-suspenders: correct login string but user.type != Bot → ignored.
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl("0cd13afeb5", user_type="User")
+        )
+        assert _mod._latest_codex_clean_comment_sha("1") is None
+
+    def test_short_sha_below_min_length_rejected(self, monkeypatch):
+        # <7 hex is not a usable prefix (the regex floors at 7).
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl("0cd13"))
+        assert _mod._latest_codex_clean_comment_sha("1") is None
+
+
+class TestCleanCommentFreshness:
+    """_check_codex_reviewed_head — a clean Codex ISSUE-COMMENT at head satisfies
+    freshness even when the review-object path can't (absent / stale review)."""
+
+    def test_no_review_object_but_clean_comment_at_head_allows(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")  # no review object → would block
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl(HEAD[:10]))
+        block, msg, head = _mod._check_codex_reviewed_head("1")
+        assert block is False and msg == "" and head == HEAD  # bound for --match-head-commit
+
+    def test_stale_review_object_but_clean_comment_at_head_allows(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(STALE))  # stale → would block
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl(HEAD[:10]))
+        block, _, head = _mod._check_codex_reviewed_head("1")
+        assert block is False and head == HEAD
+
+    def test_clean_comment_for_different_sha_still_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl(STALE[:10]))  # not head
+        block, msg, _ = _mod._check_codex_reviewed_head("1")
+        assert block is True and "no codex review" in msg.lower()
+
+    def test_clean_marker_without_sha_still_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_COMMENTS",
+            json.dumps({"login": "chatgpt-codex-connector[bot]", "type": "Bot",
+                        "body": "Codex Review: Didn't find any major issues. Swish!"}),
+        )
+        block, _, _ = _mod._check_codex_reviewed_head("1")
+        assert block is True  # fail-closed: marker alone never vouches
+
+    def test_findings_comment_with_sha_still_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_COMMENTS",
+            json.dumps({"login": "chatgpt-codex-connector[bot]", "type": "Bot",
+                        "body": f"### Codex Review\n[P1] bug\n\n**Reviewed commit:** `{HEAD[:10]}`"}),
+        )
+        block, _, _ = _mod._check_codex_reviewed_head("1")
+        assert block is True
+
+    def test_spoofed_author_clean_comment_still_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_COMMENTS",
+            _clean_comment_jsonl(HEAD[:10], login="attacker", user_type="User"),
+        )
+        block, _, _ = _mod._check_codex_reviewed_head("1")
+        assert block is True
+
+    def test_current_review_object_does_not_need_comment(self, monkeypatch):
+        # Fast path: a review object at head allows without any comment.
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")  # none needed
+        block, _, head = _mod._check_codex_reviewed_head("1")
+        assert block is False and head == HEAD
+
+    def test_report_labels_clean_comment_at_head(self, monkeypatch, capsys):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl(HEAD[:10]))
+        # Stub the other gates so the report runs; we only assert the codex-at-head label.
+        monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("green", []))
+        monkeypatch.setattr(_mod, "_check_base_is_default", lambda n, repo=None: (False, ""))
+        monkeypatch.setattr(_mod, "_check_pr_review_findings", lambda n, repo=None, strict=False: (False, ""))
+        monkeypatch.setattr(_mod, "_check_inline_review_findings", lambda n, repo=None, strict=False: (False, ""))
+        _mod.check_pr_report("1")
+        out = capsys.readouterr().out
+        assert "clean comment at head" in out


### PR DESCRIPTION
## Problem

The pre-merge gate's `_check_codex_reviewed_head` enforces "Codex reviewed the current
head" by reading Codex **review objects** (the reviews API) and requiring the latest
review's full commit_id to equal the PR head. But a **clean** Codex re-review is not a
review object — it's an **issue comment**:

```
Codex Review: Didn't find any major issues. <varying flavour>

**Reviewed commit:** `2f5091d5b3`
```

The reviews API never returns it, so a genuinely-clean re-review **false-blocks** the
merge — forcing a `# stale-review-override`. This bit our own #1386 twice (it had zero
review objects, only the clean comment), and #1376 (a stale review object at an
intermediate commit + the clean comment at head).

## Fix

- New `_latest_codex_clean_comment_sha()`: reads `issues/N/comments`, and for a comment
  authored by the Codex bot (`login == chatgpt-codex-connector[bot]` **and**
  `user.type == "Bot"`) requires **both** the stable clean marker *and* a parseable
  `Reviewed commit: <sha>`.
- `_check_codex_reviewed_head` consults it **only on the would-block path** — a review
  object already at head still fast-paths with no extra API call. A comment naming the
  current head allows the merge and returns `verified_head = head`, so the
  `--match-head-commit` TOCTOU binding still applies.
- The report labels this case `ok (clean comment at head)`.

### Fail-closed (the invariant — it's the merge gate)

Marker alone, a sha for a *different* commit, a findings comment (sha but no clean
marker), a non-bot author, a `<7`-hex sha, or any API/parse error → still **BLOCK**. The
review-object path keeps its full-oid identity; only this comment fallback is an
abbreviated prefix, matched against the **authoritative** head (read from GitHub) — no
grinding surface. Freshness only: the P1/P2 finding scanners are untouched and still run.

## Verification

- verify-RED against `origin/main` (which blocks the exact case this allows).
- Unit + integration tests incl. all fail-closed cases; an autouse fixture keeps existing
  block-path tests network-free. 293 hook tests pass.
- **Live E2E** on the real PRs that broke: #1386 (no review object) and #1376 (stale
  review object) — both now pass freshness via the clean comment, each bound to its head.
- Adversarial security review across 7 attack surfaces: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
