### PR TITLE
fix(skills): full SKILL.md descriptions via a bounded YAML parser

### DIFF
--- a/scripts/export_agents_md.py
+++ b/scripts/export_agents_md.py
@@ -140,11 +140,13 @@ def parse_mcp_tools(mcp_root: Path) -> list[dict]:
 def _frontmatter_description(skill_dir: Path) -> str | None:
     """Full, whitespace-normalized description from a skill's frontmatter.
 
-    The shared catalog scanner uses a line-based regex that truncates on
-    apostrophes/quotes and unfolded multi-line values; a proper YAML load of
-    the frontmatter block recovers the complete description. Returns None (so
-    the caller keeps the scanner's value) if yaml is unavailable or the block
-    doesn't parse to a usable string.
+    The shared catalog scanner now returns full descriptions via its own
+    string parser, but a YAML load here stays authoritative for AGENTS.md: it
+    resolves any scalar form (exotic escapes, multi-line quoted) exactly, so a
+    shipped artifact never depends on the scanner's documented edge-case limits.
+    Runs at build time over repo-tracked tiers only. Returns None (so the caller
+    keeps the scanner's value) if yaml is unavailable or the block doesn't parse
+    to a usable string.
     """
     if _yaml is None:
         return None
@@ -176,7 +178,7 @@ def collect_skills(repo_root: Path) -> list[dict]:
     install-specific ``~/.genesis/skill-library`` is intentionally NOT
     scanned (a shipped AGENTS.md must stay generalizable and must not leak
     a user's private skill names). Tier-1 wins on a name collision.
-    Descriptions are re-parsed with YAML so they aren't truncated.
+    Descriptions are re-parsed with YAML for authoritative full-fidelity values.
     """
     tier1 = _gsc._scan_tier(repo_root / ".claude" / "skills", 1, repo_root)
     seen = {s["name"].lower() for s in tier1}

--- a/scripts/export_agents_md.py
+++ b/scripts/export_agents_md.py
@@ -140,13 +140,11 @@ def parse_mcp_tools(mcp_root: Path) -> list[dict]:
 def _frontmatter_description(skill_dir: Path) -> str | None:
     """Full, whitespace-normalized description from a skill's frontmatter.
 
-    The shared catalog scanner now returns full descriptions via its own
-    string parser, but a YAML load here stays authoritative for AGENTS.md: it
-    resolves any scalar form (exotic escapes, multi-line quoted) exactly, so a
-    shipped artifact never depends on the scanner's documented edge-case limits.
-    Runs at build time over repo-tracked tiers only. Returns None (so the caller
-    keeps the scanner's value) if yaml is unavailable or the block doesn't parse
-    to a usable string.
+    The shared catalog scanner now parses frontmatter with a bounded YAML loader
+    too, so this build-time re-parse is belt-and-suspenders — both paths resolve
+    any scalar form (escapes, comments, multi-line/folded) exactly. Runs over
+    repo-tracked tiers only. Returns None (so the caller keeps the scanner's
+    value) if yaml is unavailable or the block doesn't parse to a usable string.
     """
     if _yaml is None:
         return None
@@ -178,7 +176,8 @@ def collect_skills(repo_root: Path) -> list[dict]:
     install-specific ``~/.genesis/skill-library`` is intentionally NOT
     scanned (a shipped AGENTS.md must stay generalizable and must not leak
     a user's private skill names). Tier-1 wins on a name collision.
-    Descriptions are re-parsed with YAML for authoritative full-fidelity values.
+    Descriptions are re-parsed with YAML as a build-time safety net (the scanner
+    also YAML-parses now, so this is redundant defense, not the sole source).
     """
     tier1 = _gsc._scan_tier(repo_root / ".claude" / "skills", 1, repo_root)
     seen = {s["name"].lower() for s in tier1}

--- a/scripts/generate_skill_catalog.py
+++ b/scripts/generate_skill_catalog.py
@@ -16,6 +16,42 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 
+try:
+    import yaml
+except ImportError:  # pragma: no cover - pyyaml is a declared dependency
+    yaml = None  # type: ignore[assignment]
+
+if yaml is not None:
+
+    class _FrontmatterLoader(yaml.SafeLoader):
+        """SafeLoader that loads every plain scalar as a STRING and FORBIDS YAML
+        aliases (a lone anchor with no alias is harmless). Skill frontmatter is
+        flat text (name/description/keywords) and never legitimately uses
+        anchors — refusing aliases at the composer closes the alias-multiplication
+        DoS class at the source (billion-laughs expansion, and ``*a``-multiplied
+        large scalars — a crafted skill-library/plugin ``SKILL.md`` could
+        otherwise exhaust memory during the hourly catalog refresh). Clearing the
+        implicit resolvers keeps authored spellings verbatim (off/007/0x10/12:30
+        stay strings); explicit ``!!python/*`` tags are still refused
+        (SafeLoader). Any alias raises → the caller falls back to the bounded
+        legacy parse."""
+
+        def compose_node(self, parent, index):
+            if self.check_event(yaml.events.AliasEvent):
+                event = self.peek_event()
+                raise yaml.composer.ComposerError(
+                    None,
+                    None,
+                    "aliases are not allowed in skill frontmatter",
+                    event.start_mark,
+                )
+            return super().compose_node(parent, index)
+
+    # Own (empty) resolver map — never mutate SafeLoader's shared class attr.
+    _FrontmatterLoader.yaml_implicit_resolvers = {}
+else:  # pragma: no cover - pyyaml is a declared dependency
+    _FrontmatterLoader = None
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TIER1_DIR = REPO_ROOT / ".claude" / "skills"
 TIER2_DIRS = [
@@ -23,6 +59,14 @@ TIER2_DIRS = [
     Path.home() / ".genesis" / "skill-library",
 ]
 CATALOG_PATH = Path.home() / ".genesis" / "skill_catalog.json"
+
+# Real skill frontmatters are <5 KB. Above this, skip the YAML parse and use the
+# linear legacy regex: a crafted mapping-heavy frontmatter (e.g. 100k `x: y`
+# entries) makes yaml.load materialize a huge object graph (~275x RSS
+# amplification measured), which could OOM the detached hourly catalog refresh.
+# The bound is on `len(block)` — CHARACTERS, a sufficient proxy for graph size
+# (exact byte count is irrelevant to the amplification risk).
+_MAX_FRONTMATTER_CHARS = 65_536
 
 
 def _extract_skill_info(skill_dir: Path) -> dict | None:
@@ -44,122 +88,88 @@ def _extract_skill_info(skill_dir: Path) -> dict | None:
     return {"name": skill_dir.name, "description": "", "keywords": []}
 
 
-# --- Description scalar extraction ------------------------------------------
-# Replaces a regex that truncated the value at the first apostrophe/quote/
-# newline (dropping searchable text from the catalog). Pure string slicing —
-# builds NO YAML object graph, so there is no alias/mapping-amplification DoS
-# surface; every matcher is linear (disjoint alternatives, single quantifier).
-# Handles the scalar forms real skill frontmatter uses: plain (incl. wrapped
-# multi-line), single/double-quoted (with '' and \\" escapes), and folded/
-# literal blocks (>, |, and their chomping variants). A build-time twin lives
-# in export_agents_md.py (_frontmatter_description, yaml-based) for AGENTS.md.
-_DQ_RE = re.compile(r'"((?:\\.|[^"\\])*)"', re.DOTALL)  # up to the closing "
-_SQ_RE = re.compile(r"'((?:''|[^'])*)'", re.DOTALL)  # up to the closing '
-_DQ_ESCAPES = {'"': '"', "\\": "\\", "n": " ", "t": " "}
-
-
-def _norm_ws(value: str) -> str:
-    """Collapse any run of whitespace to single spaces (one scannable line)."""
-    return " ".join(value.split())
-
-
-def _unescape_double(value: str) -> str:
-    """Resolve the double-quoted escapes that appear in skill frontmatter.
-
-    Handles ``\\"``, ``\\\\``, ``\\n``, ``\\t``; an unknown escape drops the
-    backslash (descriptions are display text, so exotic escapes need not be
-    byte-exact). Linear scan, output bounded by input.
-    """
-    out: list[str] = []
-    i, n = 0, len(value)
-    while i < n:
-        ch = value[i]
-        if ch == "\\" and i + 1 < n:
-            out.append(_DQ_ESCAPES.get(value[i + 1], value[i + 1]))
-            i += 2
-            continue
-        out.append(ch)
-        i += 1
-    return "".join(out)
-
-
-def _line_indent(line: str) -> int:
-    """Number of leading space/tab characters (indentation width)."""
-    return len(line) - len(line.lstrip(" \t"))
-
-
-def _collect_indented(
-    lines: list[str],
-    seed: str | None = None,
-    *,
-    key_indent: int = 0,
-    block: bool = False,
-) -> str:
-    """Fold a seed line plus continuation lines indented MORE than the key.
-
-    A continuation must be indented strictly deeper than ``key_indent`` (the
-    ``description:`` key's own indentation) — a line at the key's indent or
-    shallower is a SIBLING key / dedent and terminates the value. This is the
-    YAML block/plain continuation rule; without it a uniformly-indented mapping
-    (``  description: x`` / ``  keywords: [y]``) would fold the sibling key.
-
-    ``block=True`` (folded/literal ``>``/``|`` scalars): a blank line is a
-    paragraph break (not the end), and ``#`` is literal content. ``block=False``
-    (plain scalars): a blank line ends the value (we do not fold plain scalars
-    across blanks — conservative vs YAML, corpus-irrelevant), and a comment line
-    (``#`` first) ends the scalar, matching yaml.safe_load.
-    """
-    parts: list[str] = [] if seed is None else [seed]
-    for line in lines:
-        stripped = line.strip()
-        if not stripped:
-            if block:
-                continue  # blank = paragraph break inside a block scalar
-            if parts:
-                break
-            continue
-        if _line_indent(line) <= key_indent:
-            break  # sibling key or dedent — ends the value
-        if not block and stripped[0] == "#":
-            break  # a comment line ends a plain scalar (yaml ignores it)
-        parts.append(stripped)
-    return " ".join(parts)
-
-
-def _extract_description(frontmatter: str) -> str:
-    """Full description value from a frontmatter block, any YAML scalar form."""
-    m = re.search(r"^(?P<indent>[ \t]*)description:[ \t]*", frontmatter, re.MULTILINE)
-    if not m:
+def _normalize_desc(value: object) -> str:
+    """Collapse a scalar (folded/literal/plain/quoted) to one scannable line."""
+    if value is None:
         return ""
-    key_indent = len(m.group("indent"))
-    region = frontmatter[m.end() :]
-    stripped = region.split("\n", 1)[0].strip()
-    lead = stripped[:1]
-    if lead == '"':
-        q = _DQ_RE.match(region)
-        if q:
-            return _norm_ws(_unescape_double(q.group(1)))
-        return _norm_ws(stripped.strip('"'))
-    if lead == "'":
-        q = _SQ_RE.match(region)
-        if q:
-            return _norm_ws(q.group(1).replace("''", "'"))
-        return _norm_ws(stripped.strip("'"))
-    rest = region.split("\n")[1:]
-    if lead in (">", "|") or stripped == "":
-        # Folded/literal block scalar (>, >-, |, |-, …): fold lines indented
-        # deeper than the key, treating blanks as paragraph breaks.
-        return _norm_ws(_collect_indented(rest, key_indent=key_indent, block=True))
-    # Plain scalar: first line + continuation lines indented deeper than the key.
-    return _norm_ws(_collect_indented(rest, seed=stripped, key_indent=key_indent))
+    return " ".join(str(value).split())
 
 
 def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
-    """Parse YAML-like frontmatter from a markdown file."""
+    """Parse YAML frontmatter into name/description/keywords.
+
+    Uses a real YAML parser (the bounded, alias-forbidding ``_FrontmatterLoader``)
+    so descriptions with apostrophes, escaped quotes, inline comments, or
+    multi-line/folded scalars are extracted EXACTLY as YAML defines them. The
+    previous regex truncated at the first ``'``/``"``/newline; a hand-rolled
+    string parser cannot match YAML's scalar semantics (blank-line folding,
+    comment stripping, the full escape set), so we defer to yaml itself — the
+    same choice ``export_agents_md.py`` already makes for AGENTS.md.
+
+    A real parser builds an object graph, so the DoS surface is closed two ways
+    instead of "no graph": aliases are refused at the composer
+    (``_FrontmatterLoader``), and an oversized block skips YAML for the linear
+    legacy regex. Falls back to ``_parse_frontmatter_legacy`` when PyYAML is
+    unavailable, the block exceeds the size cap, or it is not a valid YAML
+    mapping.
+    """
+    if content.startswith("---") and yaml is not None:
+        end = content.find("\n---", 3)
+        if end < 0:
+            end = content.find("---", 3)
+        if end > 0:
+            block = content[3:end]
+            if len(block) > _MAX_FRONTMATTER_CHARS:
+                # Pathologically large frontmatter — the linear legacy regex
+                # extracts the fields without building a YAML object graph.
+                return _parse_frontmatter_legacy(content, fallback_name)
+            try:
+                loaded = yaml.load(block, Loader=_FrontmatterLoader)  # noqa: S506
+            except Exception:
+                # Any parse failure (YAMLError, RecursionError, …) routes to the
+                # legacy fallback rather than silently dropping the description.
+                loaded = None
+            if isinstance(loaded, dict):
+                # Metadata fields are TEXT. Accept only scalar (str) values and
+                # scalar keyword elements; REJECT non-scalar structures BEFORE any
+                # str() — recursively stringifying an alias tree can exhaust memory.
+                raw_name = loaded.get("name")
+                name = (
+                    raw_name.strip()
+                    if isinstance(raw_name, str) and raw_name.strip()
+                    else fallback_name
+                )
+                raw_desc = loaded.get("description")
+                description = (
+                    _normalize_desc(raw_desc) if isinstance(raw_desc, str) else ""
+                )
+                kw = loaded.get("keywords")
+                if isinstance(kw, (list, tuple)):
+                    keywords = [
+                        s for k in kw if isinstance(k, str) and (s := k.strip())
+                    ]
+                elif isinstance(kw, str):
+                    keywords = [k.strip() for k in kw.split(",") if k.strip()]
+                else:
+                    keywords = []
+                return {
+                    "name": name,
+                    "description": description,
+                    "keywords": keywords,
+                }
+    # PyYAML unavailable, no frontmatter, oversized, or block not a mapping.
+    return _parse_frontmatter_legacy(content, fallback_name)
+
+
+def _parse_frontmatter_legacy(content: str, fallback_name: str = "") -> dict:
+    """Degraded regex parse — the no-PyYAML / oversized-block / malformed-YAML
+    fallback ONLY. Truncates descriptions at apostrophes/escaped quotes/newlines;
+    ``_parse_frontmatter`` (YAML) is the real parser. Builds no object graph, so
+    a pathologically large frontmatter cannot amplify memory here.
+    """
     name = fallback_name
     description = ""
-
-    # Check for YAML frontmatter (--- delimited)
+    keywords: list[str] = []
     if content.startswith("---"):
         end = content.find("---", 3)
         if end > 0:
@@ -167,25 +177,33 @@ def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
             name_match = re.search(r'name:\s*["\']?([^"\'\n]+)', frontmatter)
             if name_match:
                 name = name_match.group(1).strip()
-            # Full description across any YAML scalar form (see _extract_description).
-            description = _extract_description(frontmatter)
-
-    keywords = []
-    if content.startswith("---"):
-        end = content.find("---", 3)
-        if end > 0:
-            frontmatter = content[3:end]
-            kw_match = re.search(
-                r"keywords:\s*\[([^\]]*)\]", frontmatter
-            )
+            desc_match = re.search(r'description:\s*["\']?([^"\'\n]+)', frontmatter)
+            if desc_match:
+                val = desc_match.group(1).strip()
+                if val in (">", "|", ">-", "|-"):
+                    # Folded/literal scalar: collect indented continuation lines.
+                    lines = frontmatter[desc_match.end() :].split("\n")
+                    parts: list[str] = []
+                    for line in lines:
+                        stripped = line.strip()
+                        if not stripped:
+                            if parts:
+                                break
+                            continue
+                        if line.startswith("  ") or line.startswith("\t"):
+                            parts.append(stripped)
+                        elif parts:
+                            break
+                    description = " ".join(parts)
+                else:
+                    description = val
+            kw_match = re.search(r"keywords:\s*\[([^\]]*)\]", frontmatter)
             if kw_match:
-                raw = kw_match.group(1)
                 keywords = [
                     k.strip().strip("'\"")
-                    for k in raw.split(",")
+                    for k in kw_match.group(1).split(",")
                     if k.strip()
                 ]
-
     return {"name": name, "description": description, "keywords": keywords}
 
 

--- a/scripts/generate_skill_catalog.py
+++ b/scripts/generate_skill_catalog.py
@@ -44,6 +44,103 @@ def _extract_skill_info(skill_dir: Path) -> dict | None:
     return {"name": skill_dir.name, "description": "", "keywords": []}
 
 
+# --- Description scalar extraction ------------------------------------------
+# Replaces a regex that truncated the value at the first apostrophe/quote/
+# newline (dropping searchable text from the catalog). Pure string slicing —
+# builds NO YAML object graph, so there is no alias/mapping-amplification DoS
+# surface; every matcher is linear (disjoint alternatives, single quantifier).
+# Handles the scalar forms real skill frontmatter uses: plain (incl. wrapped
+# multi-line), single/double-quoted (with '' and \\" escapes), and folded/
+# literal blocks (>, |, and their chomping variants). A build-time twin lives
+# in export_agents_md.py (_frontmatter_description, yaml-based) for AGENTS.md.
+_DQ_RE = re.compile(r'"((?:\\.|[^"\\])*)"', re.DOTALL)  # up to the closing "
+_SQ_RE = re.compile(r"'((?:''|[^'])*)'", re.DOTALL)  # up to the closing '
+_DQ_ESCAPES = {'"': '"', "\\": "\\", "n": " ", "t": " "}
+
+
+def _norm_ws(value: str) -> str:
+    """Collapse any run of whitespace to single spaces (one scannable line)."""
+    return " ".join(value.split())
+
+
+def _unescape_double(value: str) -> str:
+    """Resolve the double-quoted escapes that appear in skill frontmatter.
+
+    Handles ``\\"``, ``\\\\``, ``\\n``, ``\\t``; an unknown escape drops the
+    backslash (descriptions are display text, so exotic escapes need not be
+    byte-exact). Linear scan, output bounded by input.
+    """
+    out: list[str] = []
+    i, n = 0, len(value)
+    while i < n:
+        ch = value[i]
+        if ch == "\\" and i + 1 < n:
+            out.append(_DQ_ESCAPES.get(value[i + 1], value[i + 1]))
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def _collect_indented(
+    lines: list[str], seed: str | None = None, *, block: bool = False
+) -> str:
+    """Fold a seed line plus following more-indented continuation lines.
+
+    ``block=True`` (folded/literal ``>``/``|`` scalars): a blank line is a
+    paragraph break, not the end — only a column-0 line (the next key / dedent)
+    terminates. ``block=False`` (plain scalars): a blank line ends the value —
+    conservatively, we do NOT fold a plain scalar across a blank line (YAML
+    would join the paragraphs), which no corpus skill relies on and which avoids
+    over-capturing following structure. Any leading whitespace counts as
+    indented — YAML only requires MORE indent than the column-0 key, not a fixed
+    width. Column-0 keys (the corpus invariant) always stop the fold, so
+    keywords/name are never absorbed.
+    """
+    parts: list[str] = [] if seed is None else [seed]
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            if block:
+                continue  # blank = paragraph break inside a block scalar
+            if parts:
+                break
+            continue
+        if line[:1] in (" ", "\t"):
+            parts.append(stripped)
+        else:
+            break
+    return " ".join(parts)
+
+
+def _extract_description(frontmatter: str) -> str:
+    """Full description value from a frontmatter block, any YAML scalar form."""
+    m = re.search(r"^[ \t]*description:[ \t]*", frontmatter, re.MULTILINE)
+    if not m:
+        return ""
+    region = frontmatter[m.end() :]
+    stripped = region.split("\n", 1)[0].strip()
+    lead = stripped[:1]
+    if lead == '"':
+        q = _DQ_RE.match(region)
+        if q:
+            return _norm_ws(_unescape_double(q.group(1)))
+        return _norm_ws(stripped.strip('"'))
+    if lead == "'":
+        q = _SQ_RE.match(region)
+        if q:
+            return _norm_ws(q.group(1).replace("''", "'"))
+        return _norm_ws(stripped.strip("'"))
+    rest = region.split("\n")[1:]
+    if lead in (">", "|") or stripped == "":
+        # Folded/literal block scalar (>, >-, |, |-, …): fold indented lines,
+        # treating blank lines as paragraph breaks (not terminators).
+        return _norm_ws(_collect_indented(rest, block=True))
+    # Plain scalar: first line + any indented continuation lines.
+    return _norm_ws(_collect_indented(rest, seed=stripped))
+
+
 def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
     """Parse YAML-like frontmatter from a markdown file."""
     name = fallback_name
@@ -57,31 +154,8 @@ def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:
             name_match = re.search(r'name:\s*["\']?([^"\'\n]+)', frontmatter)
             if name_match:
                 name = name_match.group(1).strip()
-            # Handle YAML folded/literal scalars (> or |) and inline values
-            desc_match = re.search(
-                r'description:\s*["\']?([^"\'\n]+)', frontmatter
-            )
-            if desc_match:
-                val = desc_match.group(1).strip()
-                if val in (">", "|", ">-", "|-"):
-                    # Folded/literal scalar: collect indented continuation lines
-                    desc_start = desc_match.end()
-                    lines = frontmatter[desc_start:].split("\n")
-                    parts = []
-                    for line in lines:
-                        stripped = line.strip()
-                        if not stripped:
-                            if parts:
-                                break  # blank line ends the block
-                            continue
-                        # Continuation lines are indented
-                        if line.startswith("  ") or line.startswith("\t"):
-                            parts.append(stripped)
-                        elif parts:
-                            break
-                    description = " ".join(parts)
-                else:
-                    description = val
+            # Full description across any YAML scalar form (see _extract_description).
+            description = _extract_description(frontmatter)
 
     keywords = []
     if content.startswith("---"):

--- a/scripts/generate_skill_catalog.py
+++ b/scripts/generate_skill_catalog.py
@@ -83,20 +83,31 @@ def _unescape_double(value: str) -> str:
     return "".join(out)
 
 
+def _line_indent(line: str) -> int:
+    """Number of leading space/tab characters (indentation width)."""
+    return len(line) - len(line.lstrip(" \t"))
+
+
 def _collect_indented(
-    lines: list[str], seed: str | None = None, *, block: bool = False
+    lines: list[str],
+    seed: str | None = None,
+    *,
+    key_indent: int = 0,
+    block: bool = False,
 ) -> str:
-    """Fold a seed line plus following more-indented continuation lines.
+    """Fold a seed line plus continuation lines indented MORE than the key.
+
+    A continuation must be indented strictly deeper than ``key_indent`` (the
+    ``description:`` key's own indentation) — a line at the key's indent or
+    shallower is a SIBLING key / dedent and terminates the value. This is the
+    YAML block/plain continuation rule; without it a uniformly-indented mapping
+    (``  description: x`` / ``  keywords: [y]``) would fold the sibling key.
 
     ``block=True`` (folded/literal ``>``/``|`` scalars): a blank line is a
-    paragraph break, not the end — only a column-0 line (the next key / dedent)
-    terminates. ``block=False`` (plain scalars): a blank line ends the value —
-    conservatively, we do NOT fold a plain scalar across a blank line (YAML
-    would join the paragraphs), which no corpus skill relies on and which avoids
-    over-capturing following structure. Any leading whitespace counts as
-    indented — YAML only requires MORE indent than the column-0 key, not a fixed
-    width. Column-0 keys (the corpus invariant) always stop the fold, so
-    keywords/name are never absorbed.
+    paragraph break (not the end), and ``#`` is literal content. ``block=False``
+    (plain scalars): a blank line ends the value (we do not fold plain scalars
+    across blanks — conservative vs YAML, corpus-irrelevant), and a comment line
+    (``#`` first) ends the scalar, matching yaml.safe_load.
     """
     parts: list[str] = [] if seed is None else [seed]
     for line in lines:
@@ -107,18 +118,20 @@ def _collect_indented(
             if parts:
                 break
             continue
-        if line[:1] in (" ", "\t"):
-            parts.append(stripped)
-        else:
-            break
+        if _line_indent(line) <= key_indent:
+            break  # sibling key or dedent — ends the value
+        if not block and stripped[0] == "#":
+            break  # a comment line ends a plain scalar (yaml ignores it)
+        parts.append(stripped)
     return " ".join(parts)
 
 
 def _extract_description(frontmatter: str) -> str:
     """Full description value from a frontmatter block, any YAML scalar form."""
-    m = re.search(r"^[ \t]*description:[ \t]*", frontmatter, re.MULTILINE)
+    m = re.search(r"^(?P<indent>[ \t]*)description:[ \t]*", frontmatter, re.MULTILINE)
     if not m:
         return ""
+    key_indent = len(m.group("indent"))
     region = frontmatter[m.end() :]
     stripped = region.split("\n", 1)[0].strip()
     lead = stripped[:1]
@@ -134,11 +147,11 @@ def _extract_description(frontmatter: str) -> str:
         return _norm_ws(stripped.strip("'"))
     rest = region.split("\n")[1:]
     if lead in (">", "|") or stripped == "":
-        # Folded/literal block scalar (>, >-, |, |-, …): fold indented lines,
-        # treating blank lines as paragraph breaks (not terminators).
-        return _norm_ws(_collect_indented(rest, block=True))
-    # Plain scalar: first line + any indented continuation lines.
-    return _norm_ws(_collect_indented(rest, seed=stripped))
+        # Folded/literal block scalar (>, >-, |, |-, …): fold lines indented
+        # deeper than the key, treating blanks as paragraph breaks.
+        return _norm_ws(_collect_indented(rest, key_indent=key_indent, block=True))
+    # Plain scalar: first line + continuation lines indented deeper than the key.
+    return _norm_ws(_collect_indented(rest, seed=stripped, key_indent=key_indent))
 
 
 def _parse_frontmatter(content: str, fallback_name: str = "") -> dict:

--- a/tests/test_scripts/test_generate_skill_catalog.py
+++ b/tests/test_scripts/test_generate_skill_catalog.py
@@ -305,6 +305,42 @@ def test_parse_frontmatter_block_scalar_stops_at_col0_key():
     assert r["keywords"] == ["x", "y"]
 
 
+def test_parse_frontmatter_indented_mapping_stops_at_sibling_key():
+    """When the whole frontmatter mapping is indented, a plain description must
+    stop at the SIBLING key (same indent as the description key), not fold it.
+    Matches yaml.safe_load -> 'useful'."""
+    content = "---\n  name: im\n  description: useful\n  keywords: [x]\n---\n"
+    r = _gen._parse_frontmatter(content, "im")
+    assert r["description"] == "useful"
+    assert r["keywords"] == ["x"]
+
+
+def test_parse_frontmatter_plain_scalar_skips_comment_line():
+    """An indented comment line ends a plain scalar (yaml ignores it) -> 'foo'."""
+    content = "---\nname: c\ndescription: foo\n  # a trailing comment\nkeywords: [a]\n---\n"
+    r = _gen._parse_frontmatter(content, "c")
+    assert r["description"] == "foo"
+
+
+def test_parse_frontmatter_block_scalar_keeps_hash_as_content():
+    """Inside a block scalar, '#' is literal content, not a comment
+    (yaml.safe_load folds it in)."""
+    content = (
+        "---\nname: h\ndescription: >\n  line one\n  # still content here\n"
+        "keywords: [a]\n---\n"
+    )
+    r = _gen._parse_frontmatter(content, "h")
+    assert r["description"] == "line one # still content here"
+
+
+def test_parse_frontmatter_deeper_indent_child_then_col0_key():
+    """A more-indented continuation folds; a col-0 sibling key stops it."""
+    content = "---\nname: d\ndescription: foo\n    deeper\nkeywords: [a]\n---\n"
+    r = _gen._parse_frontmatter(content, "d")
+    assert r["description"] == "foo deeper"
+    assert r["keywords"] == ["a"]
+
+
 def test_parse_frontmatter_missing_description_is_empty():
     content = "---\nname: n\nkeywords: [a]\n---\n"
     r = _gen._parse_frontmatter(content, "n")

--- a/tests/test_scripts/test_generate_skill_catalog.py
+++ b/tests/test_scripts/test_generate_skill_catalog.py
@@ -155,3 +155,181 @@ def test_scan_tier_relative_paths_under_repo_root(tmp_path):
     assert results[0]["path"] == str(
         Path(".claude") / "skills" / "gitnexus" / "gitnexus-cli"
     )
+
+
+# ---------------------------------------------------------------------------
+# _parse_frontmatter — description extraction across YAML scalar forms.
+#
+# The legacy regex (`description:\s*["\']?([^"\'\n]+)`) truncated the value at
+# the first apostrophe/quote/newline, dropping searchable text from the
+# catalog. These tests pin the full-value behavior for every scalar form the
+# real skill corpus uses. Name + keywords extraction is unchanged and its
+# happy path is guarded too. All fixtures synthetic — no live-repo dependence.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_frontmatter_plain_apostrophe_not_truncated():
+    """A plain scalar with apostrophes survives in full (was cut at the ')."""
+    content = (
+        "---\n"
+        "name: voice\n"
+        "description: Apply when Genesis writes as itself. "
+        "Not for the user's voice (that's other). Activate here.\n"
+        "keywords: [voice]\n"
+        "---\n# body\n"
+    )
+    r = _gen._parse_frontmatter(content, fallback_name="voice")
+    assert r["name"] == "voice"
+    assert r["description"] == (
+        "Apply when Genesis writes as itself. Not for the user's voice "
+        "(that's other). Activate here."
+    )
+    assert r["keywords"] == ["voice"]
+
+
+def test_parse_frontmatter_double_quoted_unescapes_and_keeps_full():
+    """A double-quoted scalar with escaped quotes is captured whole + unescaped."""
+    content = (
+        "---\n"
+        "name: gx\n"
+        'description: "Use when X. Examples: \\"Index this repo\\", \\"Reanalyze\\""\n'
+        "keywords: [a]\n"
+        "---\n"
+    )
+    r = _gen._parse_frontmatter(content, "gx")
+    assert r["description"] == 'Use when X. Examples: "Index this repo", "Reanalyze"'
+
+
+def test_parse_frontmatter_single_quoted_doubled_apostrophe():
+    """A single-quoted scalar with a doubled '' escape survives (was cut at ')."""
+    content = "---\nname: s\ndescription: 'It''s a thing'\nkeywords: [a]\n---\n"
+    r = _gen._parse_frontmatter(content, "s")
+    assert r["description"] == "It's a thing"
+
+
+def test_parse_frontmatter_plain_multiline_folds_indented_continuations():
+    """A plain scalar wrapped across indented lines folds into one line."""
+    content = (
+        "---\n"
+        "name: ci\n"
+        "description: Line one,\n"
+        "  line two,\n"
+        "  line three\n"
+        "keywords: [a]\n"
+        "---\n"
+    )
+    r = _gen._parse_frontmatter(content, "ci")
+    assert r["description"] == "Line one, line two, line three"
+
+
+def test_parse_frontmatter_plain_multiline_stops_at_next_key():
+    """Plain-scalar folding must not swallow the following (non-indented) key."""
+    content = (
+        "---\n"
+        "name: ci\n"
+        "description: Only this line.\n"
+        "keywords: [alpha, beta]\n"
+        "---\n"
+    )
+    r = _gen._parse_frontmatter(content, "ci")
+    assert r["description"] == "Only this line."
+    assert r["keywords"] == ["alpha", "beta"]  # not eaten by the description
+
+
+def test_parse_frontmatter_folded_block_scalar_joined():
+    """`>` folded block: indented continuation lines are collected (guard)."""
+    content = (
+        "---\nname: f\ndescription: >\n  Folded one\n  folded two\n"
+        "keywords: [a]\n---\n"
+    )
+    r = _gen._parse_frontmatter(content, "f")
+    assert r["description"] == "Folded one folded two"
+
+
+def test_parse_frontmatter_literal_block_scalar_joined():
+    """`|` literal block: collected the same way as folded (guard)."""
+    content = (
+        "---\nname: l\ndescription: |\n  Literal one\n  literal two\n"
+        "keywords: [a]\n---\n"
+    )
+    r = _gen._parse_frontmatter(content, "l")
+    assert r["description"] == "Literal one literal two"
+
+
+def test_parse_frontmatter_chomped_folded_indicator():
+    """`>-` chomping indicator is treated as a block scalar, not literal text."""
+    content = (
+        "---\nname: c\ndescription: >-\n  Chomped one\n  chomped two\n"
+        "keywords: [a]\n---\n"
+    )
+    r = _gen._parse_frontmatter(content, "c")
+    assert r["description"] == "Chomped one chomped two"
+
+
+def test_parse_frontmatter_folded_block_multi_paragraph():
+    """A blank line inside a block scalar is a paragraph break, not the end —
+    content after it must not be dropped (matches yaml.safe_load)."""
+    content = (
+        "---\nname: mp\ndescription: >\n"
+        "  Paragraph one line.\n"
+        "\n"
+        "  Paragraph two line.\n"
+        "keywords: [a]\n---\n"
+    )
+    r = _gen._parse_frontmatter(content, "mp")
+    assert r["description"] == "Paragraph one line. Paragraph two line."
+
+
+def test_parse_frontmatter_block_scalar_single_space_indent():
+    """Block content only needs to be MORE indented than the col-0 key; a
+    single leading space must not yield an empty description."""
+    content = (
+        "---\nname: sp\ndescription: |\n"
+        " One line.\n"
+        " Two line.\n"
+        "keywords: [a]\n---\n"
+    )
+    r = _gen._parse_frontmatter(content, "sp")
+    assert r["description"] == "One line. Two line."
+
+
+def test_parse_frontmatter_block_scalar_stops_at_col0_key():
+    """A block scalar still terminates at the next column-0 key (no absorb)."""
+    content = (
+        "---\nname: b\ndescription: >\n"
+        "  Folded body.\n"
+        "keywords: [x, y]\n---\n"
+    )
+    r = _gen._parse_frontmatter(content, "b")
+    assert r["description"] == "Folded body."
+    assert r["keywords"] == ["x", "y"]
+
+
+def test_parse_frontmatter_missing_description_is_empty():
+    content = "---\nname: n\nkeywords: [a]\n---\n"
+    r = _gen._parse_frontmatter(content, "n")
+    assert r["name"] == "n"
+    assert r["description"] == ""
+
+
+def test_parse_frontmatter_no_frontmatter_uses_fallback_name():
+    r = _gen._parse_frontmatter("# just a heading\nsome text\n", "fallback")
+    assert r["name"] == "fallback"
+    assert r["description"] == ""
+    assert r["keywords"] == []
+
+
+def test_parse_frontmatter_keywords_flow_list_unchanged():
+    content = "---\nname: k\ndescription: d\nkeywords: [alpha, beta, gamma]\n---\n"
+    r = _gen._parse_frontmatter(content, "k")
+    assert r["keywords"] == ["alpha", "beta", "gamma"]
+
+
+def test_parse_frontmatter_pathological_input_is_bounded():
+    """Unterminated double-quote + many escapes must complete (no ReDoS/hang)
+    and never amplify beyond the input (no object graph)."""
+    big = '"' + ("\\a" * 200_000)  # unterminated quote, no closing "
+    content = f"---\nname: p\ndescription: {big}\nkeywords: [a]\n---\n"
+    r = _gen._parse_frontmatter(content, "p")
+    assert isinstance(r["description"], str)
+    assert len(r["description"]) <= len(content)

--- a/tests/test_scripts/test_generate_skill_catalog.py
+++ b/tests/test_scripts/test_generate_skill_catalog.py
@@ -361,6 +361,74 @@ def test_parse_frontmatter_keywords_flow_list_unchanged():
     assert r["keywords"] == ["alpha", "beta", "gamma"]
 
 
+def test_parse_frontmatter_plain_scalar_folds_across_blank_line():
+    """A plain scalar spans a blank line (yaml folds the paragraphs) -> both."""
+    content = "---\nname: a\ndescription: first\n\n  second\nkeywords: [x]\n---\n"
+    r = _gen._parse_frontmatter(content, "a")
+    assert r["description"] == "first second"
+
+
+def test_parse_frontmatter_inline_comment_stripped():
+    """An inline ' # comment' suffix on a plain scalar is removed (yaml)."""
+    content = "---\nname: a\ndescription: real text # author note\nkeywords: [x]\n---\n"
+    r = _gen._parse_frontmatter(content, "a")
+    assert r["description"] == "real text"
+
+
+def test_parse_frontmatter_double_quoted_unicode_escape_decoded():
+    r'''A double-quoted \u / \x escape decodes to the real character (yaml).'''
+    content = '---\nname: a\ndescription: "em\\u2014dash \\x20 gap"\nkeywords: [x]\n---\n'
+    r = _gen._parse_frontmatter(content, "a")
+    # — -> em dash, \x20 -> space; whitespace collapsed to single spaces.
+    assert r["description"] == "em—dash gap"
+    assert "—" in r["description"] and "u2014" not in r["description"]
+
+
+def test_parse_frontmatter_alias_bomb_is_refused_and_bounded():
+    """A YAML alias-multiplication payload is refused at the composer and the
+    parse falls back to the linear legacy regex — no object-graph expansion.
+    (Fails without _FrontmatterLoader's alias refusal.)"""
+    payload = ",".join(['"x"'] * 50)
+    refs = ",".join(["*a"] * 50)
+    content = f"---\nname: b\ndescription: &a [{payload}]\nkeywords: [{refs}]\n---\n"
+    r = _gen._parse_frontmatter(content, "b")
+    assert isinstance(r, dict)
+    # No alias expansion: keywords are the literal unexpanded tokens, not a
+    # multiplied structure, and the description stayed a short scalar.
+    assert len(r["keywords"]) <= 60
+    assert len(r["description"]) < 200
+
+
+def test_parse_frontmatter_merge_key_alias_is_refused():
+    """A YAML merge-key alias (`<<: *a`) is refused at the composer and routed to
+    the bounded legacy path — not expanded. (Pins compose_node coverage.)"""
+    content = (
+        "---\nname: m\ndescription: base &a real text\n"
+        "extra:\n  <<: *a\nkeywords: [x]\n---\n"
+    )
+    r = _gen._parse_frontmatter(content, "m")
+    assert isinstance(r, dict)
+    assert len(r["description"]) < 200  # no alias-driven growth
+
+
+def test_parse_frontmatter_alias_as_mapping_key_is_refused():
+    """An alias used as a mapping key (`*a : v`) is refused → bounded legacy."""
+    content = "---\nname: k\ndescription: &a hello\n*a : world\nkeywords: [x]\n---\n"
+    r = _gen._parse_frontmatter(content, "k")
+    assert isinstance(r, dict)
+    assert len(r["description"]) < 200
+
+
+def test_parse_frontmatter_oversized_block_falls_back_bounded():
+    """A frontmatter block over the size cap skips YAML for the linear legacy
+    regex (no object-graph amplification). (Fails without the size cap.)"""
+    huge = "y" * (_gen._MAX_FRONTMATTER_CHARS + 5000)
+    content = f"---\nname: o\ndescription: {huge}\nkeywords: [a]\n---\n"
+    r = _gen._parse_frontmatter(content, "o")
+    assert r["name"] == "o"
+    assert len(r["description"]) <= len(content)
+
+
 def test_parse_frontmatter_pathological_input_is_bounded():
     """Unterminated double-quote + many escapes must complete (no ReDoS/hang)
     and never amplify beyond the input (no object graph)."""


### PR DESCRIPTION
# PR: fix(skills): full SKILL.md descriptions via a bounded YAML parser

## Problem
`generate_skill_catalog.py::_parse_frontmatter` extracted descriptions with a
regex that stopped at the first apostrophe/quote/newline, dropping searchable
text (genesis-voice cut at "user's" ≈121 vs 210 chars; gitnexus/aws cut at the
first `\"`; multi-line plain scalars cut to the first line). Descriptions feed
the injection-hook nudge (`desc[:80]`), the autonomy executor's skill-awareness
list (`resources.py`, `desc[:120]`), and `/list-skills`.

## Approach — bounded, alias-forbidding `yaml.safe_load`
Parse frontmatter with `_FrontmatterLoader` (a `SafeLoader` subclass that
**refuses YAML aliases at the composer** and loads scalars as strings), behind a
64 KB size cap that routes pathologically large blocks to a linear legacy regex.
This is the same loader genesis-architect approved on a prior PR, and the same
choice `export_agents_md.py` already makes for AGENTS.md.

**Why yaml, not a hand parser:** a regex/string parser cannot match YAML's scalar
semantics (blank-line folding, inline-comment stripping, the full escape set) —
chasing that is unwinnable. Using yaml makes the parser correct *by construction*
and consolidates on one frontmatter parser. The DoS surface that motivated
avoiding yaml is closed two ways: **aliases refused** (billion-laughs / `*a`
multiplication) + **size cap** (mapping amplification) → legacy fallback.

## Validation
- 32 tests (truncation, every scalar form, blank-line fold, inline comment,
  `\u`/`\x` escape decode, **alias-bomb refused+bounded**, **oversized→legacy**).
- E2E over the real 65-skill catalog via `generate_catalog()`: 0 keyword diffs,
  0 description regressions, 15 improved. (One pre-existing malformed-YAML skill
  degrades gracefully to a non-empty description via the legacy fallback.)
- Measured DoS: alias-bomb → legacy ~3 ms; oversized(70 KB) → legacy ~0.7 ms.
- Consumer smoke: injection-hook `_score_skill` + `resources.py` consume the new
  catalog cleanly.

## Accepted residual (documented)
The only residual is **aggregate CPU** if an attacker plants ~100 crafted ≤64 KB
files in a scan root — but the scan roots are repo-versioned (PR-reviewed) or the
**user-curated** `~/.genesis/skill-library` (no autonomous ingestion; verified),
so exploiting it needs local FS write to the user's own dirs, and the impact is a
slow *background* refresh. The real amplifier — the hook re-spawning generators
with no concurrency guard — is a pre-existing hook bug filed separately
(follow-up `7ea8e6314c014b04ae421fc6c447732e`), not this parser's concern.

## Deploy path
Runtime script consumed by a hook + the autonomy executor: lands on `git pull`;
the catalog self-heals within 1 h — no migration, no restart-critical path.

Supersedes the closed hand-parser approach (which spiraled on YAML fidelity).
