### PR TITLE
fix(hooks): per-worktree review evidence + never-shared worktree key (complete #1244)

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -519,7 +519,7 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   conscious, logged act (like `# review-override`); adding it — or falsely passing
   `--clean` — WITHOUT the honest review result is the same violation as ignoring the
   prose above (the `--clean` flag mirrors the review record you write to
-  `~/.genesis/last_code_review.txt` at the same moment: falsifying one falsifies the
+  the per-worktree evidence path (`review_state.py evidence-path`) at the same moment: falsifying one falsifies the
   other).
   Caveats: **multiple findings in a single pass = one round** (not an
   escalation); the same defect reappearing (an incomplete prior fix) is a

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -957,8 +957,9 @@ def main() -> None:
                 "inline pass is FALSE CONFIDENCE, not clearance. Dispatch a genesis-architect "
                 "adversarial audit (assume bugs, enumerate the edge/boundary/sentinel/"
                 "hierarchy class, READ authoritative semantics for any domain code), save it "
-                "to ~/.genesis/last_code_review.txt, then re-mark:\n"
-                "  python3 scripts/review_state.py mark --agent-output ~/.genesis/last_code_review.txt\n"
+                "to the per-worktree path from `python3 scripts/review_state.py evidence-path` "
+                "(concurrent sessions don't clobber it), then re-mark:\n"
+                "  python3 scripts/review_state.py mark\n"
                 "If the audit genuinely ran but its format isn't recognized, acknowledge with "
                 "a trailing shell comment (outside any quotes):  # depth-ack"
             )
@@ -998,7 +999,8 @@ def main() -> None:
         _deny(
             "BLOCKED: Code changes exist without review. "
             "Run /review and dispatch the genesis-architect agent (adversarial audit) first, "
-            "then run: python3 scripts/review_state.py mark --agent-output ~/.genesis/last_code_review.txt\n"
+            "save it to `python3 scripts/review_state.py evidence-path`, "
+            "then run: python3 scripts/review_state.py mark\n"
             "If findings are intentionally accepted, append a trailing shell "
             "comment (outside any quotes): '  # review-override'"
         )

--- a/scripts/review_state.py
+++ b/scripts/review_state.py
@@ -12,16 +12,19 @@ changes only) at the time review was done.  If staged content changes, the marke
 becomes stale and review is required again.  Unstaged working-tree edits
 (e.g. from Codex) do not trigger review enforcement.
 
-Review evidence: the authoritative signal is the code-reviewer agent output
-(``~/.genesis/last_code_review.txt``). gstack skill-usage telemetry, when
-present, is recorded as advisory corroboration but never gates marking — it is
-not installed on many hosts.
+Review evidence: the authoritative signal is the code-reviewer agent output. It
+defaults to a PER-WORKTREE path (``review_state.py evidence-path``) so concurrent
+sessions don't overwrite each other's audit; ``--agent-output`` overrides it. gstack
+skill-usage telemetry, when present, is recorded as advisory corroboration but never
+gates marking — it is not installed on many hosts.
 
 CLI usage:
-    python3 review_state.py status     # prints current review state
-    python3 review_state.py mark --agent-output <path>          # defect-bearing round
+    python3 review_state.py status         # prints current review state
+    python3 review_state.py evidence-path  # prints this worktree's evidence path
+    python3 review_state.py mark           # evidence read from the per-worktree path
+    python3 review_state.py mark --agent-output <path>          # explicit override
     python3 review_state.py mark --agent-output <path> --clean  # clean round → reset streak
-    python3 review_state.py diff-hash  # prints current diff hash
+    python3 review_state.py diff-hash      # prints current diff hash
 """
 
 from __future__ import annotations
@@ -49,17 +52,27 @@ ESCALATION_ROUND_CAP = 3
 # Legacy single-file marker (pre per-worktree scoping). Only read as a fallback
 # so an in-flight review from before an upgrade isn't lost mid-session.
 _LEGACY_STATE_FILE = Path.home() / ".genesis" / "review_state.json"
+# Per-worktree review-EVIDENCE (the code-reviewer/genesis-architect audit output the
+# depth gate validates). Per-worktree — like the marker/round — so concurrent
+# sessions don't overwrite each other's evidence (which would validate one session's
+# marker against ANOTHER session's audit). Keyed by the same _worktree_key.
+_EVIDENCE_DIR = Path.home() / ".genesis" / "review_evidence"
 _MAX_EVIDENCE_AGE_SECONDS = 1800  # 30 minutes
 _GSTACK_ANALYTICS = Path.home() / ".gstack" / "analytics" / "skill-usage.jsonl"
 
 
-def _worktree_key(cwd: str | None = None) -> str:
-    """Stable per-worktree key from the git worktree root.
+def _worktree_root(cwd: str | None = None) -> str:
+    """Absolute worktree root used to key per-worktree state.
 
-    Concurrent CC sessions each work in their own git worktree; a single global
-    marker file let them clobber each other's review state (session B's commit
-    reset session A's marker mid-workflow). Keying the marker by worktree root
-    isolates them. Falls back to "default" outside a git repo.
+    Primary: ``git rev-parse --show-toplevel``. Fallback — git missing or timed out,
+    LIKELIEST under the concurrent load this keying exists to survive: walk up from
+    ``cwd`` to the nearest ``.git`` (a directory in the main tree, a FILE in a linked
+    worktree) and use that directory; if none is found, use the resolved ``cwd``.
+
+    CRITICAL: the fallback stays PER-LOCATION — never a single shared constant. The
+    old ``"default"`` fallback meant a transient git hiccup collapsed every concurrent
+    session onto ONE key, reopening the cross-session clobber #1244 fixed (observed as
+    a marker vanishing / round counter resetting mid-workflow).
     """
     try:
         result = subprocess.run(
@@ -71,10 +84,37 @@ def _worktree_key(cwd: str | None = None) -> str:
         )
         root = result.stdout.strip()
         if root:
-            return hashlib.sha256(root.encode()).hexdigest()[:12]
+            # realpath so the git-success key matches the fallback (which resolves
+            # symlinks) for the SAME worktree — otherwise a git-success mark and a
+            # git-failed hook check could compute different keys and disagree.
+            return os.path.realpath(root)
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         pass
-    return "default"
+    base = Path(cwd).resolve() if cwd else Path.cwd()
+    for d in (base, *base.parents):
+        if (d / ".git").exists():
+            return str(d)
+    return str(base)
+
+
+def _worktree_key(cwd: str | None = None) -> str:
+    """Stable, per-location key from the worktree root (see ``_worktree_root``).
+
+    Concurrent CC sessions each work in their own git worktree; a single global
+    marker file let them clobber each other's review state (session B's commit reset
+    session A's marker mid-workflow). Keying by worktree root isolates them — and the
+    key stays isolated even when git is briefly unavailable (no shared fallback).
+    """
+    return hashlib.sha256(_worktree_root(cwd).encode()).hexdigest()[:12]
+
+
+def _evidence_file(cwd: str | None = None) -> Path:
+    """Per-worktree review-evidence path (``--agent-output`` default).
+
+    Same worktree key as the marker/round so a session's evidence can't be
+    overwritten by a concurrent session between writing it and marking the review.
+    """
+    return _EVIDENCE_DIR / f"{_worktree_key(cwd)}.txt"
 
 
 def _state_file(cwd: str | None = None) -> Path:
@@ -334,7 +374,7 @@ def mark_reviewed(
     _review_found, review_msg = _verify_review_log()
 
     # Check 2 (authoritative): code-reviewer agent output must exist and be recent.
-    agent_path = agent_output_path or str(Path.home() / ".genesis" / "last_code_review.txt")
+    agent_path = agent_output_path or str(_evidence_file(cwd))
     agent_ok, agent_msg = _verify_agent_output(agent_path)
     if not agent_ok:
         print(f"REFUSED: {agent_msg}", file=sys.stderr)
@@ -605,7 +645,7 @@ def get_current_branch(cwd: str | None = None) -> str:
 
 def main() -> None:
     if len(sys.argv) < 2:
-        print("Usage: review_state.py [status|mark|diff-hash]", file=sys.stderr)
+        print("Usage: review_state.py [status|mark|diff-hash|evidence-path]", file=sys.stderr)
         sys.exit(1)
 
     cmd = sys.argv[1]
@@ -624,6 +664,13 @@ def main() -> None:
 
     elif cmd == "diff-hash":
         print(get_current_diff_hash())
+
+    elif cmd == "evidence-path":
+        # Create the dir so a `save-to $(evidence-path)` shell redirect (the flow the
+        # hook/SKILL instructions describe) doesn't fail on a fresh host — otherwise
+        # the evidence write fails, `mark` finds no evidence, and the gate REFUSES.
+        _EVIDENCE_DIR.mkdir(parents=True, exist_ok=True)
+        print(_evidence_file())
 
     elif cmd == "mark":
         # Parse --agent-output <path> and the optional --clean flag.

--- a/tests/test_scripts/test_review_evidence_isolation.py
+++ b/tests/test_scripts/test_review_evidence_isolation.py
@@ -1,0 +1,141 @@
+"""Concurrent-session isolation for the review gate's per-worktree state.
+
+#1244 made the review MARKER and ROUND counter per-worktree, but two gaps remained
+and are closed here:
+
+1. ``_worktree_key`` fell back to the SHARED constant ``"default"`` whenever
+   ``git rev-parse --show-toplevel`` failed (timeout/error). Under concurrent load
+   — exactly when a 5s git call is most likely to hiccup — every session collapsed
+   onto the same key and clobbered each other's marker/round/evidence again. The
+   fallback must stay per-location (derive the worktree root without git), never a
+   single shared bucket.
+
+2. The review-EVIDENCE file (``--agent-output``) defaulted to a single global
+   ``~/.genesis/last_code_review.txt``; concurrent sessions overwrote each other's
+   evidence, and the depth gate validates the marker against whatever content is in
+   that file. The default is now per-worktree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("review_state", _SCRIPTS / "review_state.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["review_state"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_rs = _load()
+
+
+def _mk_worktree(tmp_path: Path, name: str) -> Path:
+    root = tmp_path / name
+    root.mkdir()
+    (root / ".git").write_text("gitdir: /nowhere\n")  # a linked-worktree .git FILE
+    return root
+
+
+def test_worktree_key_never_collapses_to_shared_default_on_git_failure(tmp_path, monkeypatch):
+    a = _mk_worktree(tmp_path, "wt_a")
+    b = _mk_worktree(tmp_path, "wt_b")
+
+    # Force the git path to fail so the FALLBACK is exercised.
+    def _boom(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+    monkeypatch.setattr(_rs.subprocess, "run", _boom)
+
+    ka = _rs._worktree_key(cwd=str(a))
+    kb = _rs._worktree_key(cwd=str(b))
+
+    # The whole point: two worktrees must NOT share a key even when git fails.
+    assert ka != "default", "fallback must not be the shared constant"
+    assert kb != "default"
+    assert ka != kb, "two worktrees collapsed onto the same fallback key"
+    # Stable: same cwd -> same key across calls.
+    assert ka == _rs._worktree_key(cwd=str(a))
+
+
+def test_evidence_file_is_per_worktree(tmp_path, monkeypatch):
+    a = _mk_worktree(tmp_path, "wt_a")
+    b = _mk_worktree(tmp_path, "wt_b")
+
+    def _boom(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+    monkeypatch.setattr(_rs.subprocess, "run", _boom)
+
+    ea = _rs._evidence_file(cwd=str(a))
+    eb = _rs._evidence_file(cwd=str(b))
+    assert ea != eb, "evidence files collide across worktrees"
+    # And distinct from the legacy global path.
+    assert ea != Path.home() / ".genesis" / "last_code_review.txt"
+
+
+def test_worktree_key_success_and_fallback_agree(tmp_path, monkeypatch):
+    # THE core correctness property: for the SAME worktree, the git-success key must
+    # equal the git-FAILURE fallback key — else a git-success `mark` and a git-failed
+    # commit-hook check compute different keys and the gate falsely says "no review".
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True, capture_output=True)
+    k_git = _rs._worktree_key(cwd=str(repo))  # git rev-parse succeeds
+
+    def _boom(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+    monkeypatch.setattr(_rs.subprocess, "run", _boom)
+    k_fallback = _rs._worktree_key(cwd=str(repo))  # forced onto the walk-up fallback
+    assert k_git == k_fallback, "git-success and fallback keys diverge for one worktree"
+
+
+def test_worktree_key_subdir_matches_root_on_git_failure(tmp_path, monkeypatch):
+    # A cwd deep inside the worktree must key to the SAME worktree root as the root
+    # itself (the walk-up climbs to .git), matching what git --show-toplevel returns.
+    repo = tmp_path / "repo"
+    (repo / "sub" / "deep").mkdir(parents=True)
+    (repo / ".git").mkdir()
+
+    def _boom(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="git", timeout=5)
+
+    monkeypatch.setattr(_rs.subprocess, "run", _boom)
+    assert _rs._worktree_key(cwd=str(repo / "sub" / "deep")) == _rs._worktree_key(cwd=str(repo))
+
+
+def test_mark_reviewed_default_wires_the_per_worktree_evidence_file(tmp_path, monkeypatch):
+    # Guards the actual wiring (mark_reviewed's default agent_path = _evidence_file(cwd)),
+    # not just the path shape — a regression hardcoding the global path would be caught.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    captured = {}
+
+    def _capture(path):
+        captured["path"] = path
+        return (False, "stub")  # short-circuit mark_reviewed right after capture
+
+    monkeypatch.setattr(_rs, "_verify_agent_output", _capture)
+    _rs.mark_reviewed(agent_output_path=None, cwd=str(repo))
+    assert captured["path"] == str(_rs._evidence_file(cwd=str(repo)))
+
+
+def test_evidence_path_cli_creates_the_dir(tmp_path, monkeypatch, capsys):
+    # The evidence-path handler must create _EVIDENCE_DIR so a `> $(evidence-path)`
+    # shell redirect doesn't fail on a fresh host (which would then wedge the gate).
+    ev_dir = tmp_path / "review_evidence"
+    monkeypatch.setattr(_rs, "_EVIDENCE_DIR", ev_dir)
+    monkeypatch.setattr(sys, "argv", ["review_state.py", "evidence-path"])
+    assert not ev_dir.exists()
+    _rs.main()
+    assert ev_dir.exists(), "evidence-path must create _EVIDENCE_DIR"
+    assert capsys.readouterr().out.strip().startswith(str(ev_dir))


### PR DESCRIPTION
## What & why

Completes #1244. That PR made the review **marker** and **round counter** per-worktree so concurrent CC sessions don't clobber each other's review state — but two residual races remained, and both bit live this session:

1. **`_worktree_key` collapsed to a shared `"default"`** whenever `git rev-parse --show-toplevel` failed (timeout/error) — *likeliest under the concurrent load this keying exists to survive*. On that fallback every session shared one key, reopening the exact cross-session clobber #1244 fixed. Observed live as a review marker vanishing and the escalation round counter resetting `4→1` mid-workflow.
2. **The review-evidence file was global** (`--agent-output` defaulted to `~/.genesis/last_code_review.txt`). Concurrent sessions overwrote each other's audit, and the depth gate's `_evidence_is_adversarial` check validated a marker against whatever content happened to be in that shared file — a correctness hole, not just noise.

## Changes (all in `scripts/review_state.py` + instruction text)

- **`_worktree_root(cwd)`**: git primary; on failure, walk up to the nearest `.git` (a FILE in a linked worktree, a dir in the main tree), else the resolved cwd — **never a shared constant**. `_worktree_key` re-based on it; the git-success path is `realpath`'d so it matches the fallback for the same worktree.
- **Per-worktree evidence**: `_evidence_file(cwd)` under a new `_EVIDENCE_DIR`, keyed like the marker. `mark`'s default `--agent-output` now points there. New **`evidence-path`** CLI prints it (and creates the dir, so a `> $(evidence-path)` redirect can't fail on a fresh host).
- The two commit-hook instruction messages (`review_enforcement_commit.py`) and `SKILL.md` repointed to the per-worktree path.

## Tests

`tests/test_scripts/test_review_evidence_isolation.py` (6, verify-RED against the old `"default"` fallback / missing `_evidence_file`), including the core **git-success ↔ fallback key-agreement** property (a wrong fix here would block *every* commit), a subdir-cwd test, a real `mark_reviewed`-wiring test, and the evidence-dir-creation test. 229 existing gate/review tests (`test_hooks` + `test_scripts`) green; ruff clean.

genesis-architect audited; its SHOULD-FIX (evidence dir never created → gate could wedge on a fresh host) and the realpath asymmetry were both fixed in-branch. Both changes are fail-closed (never false-allow).
