### PR TITLE
feat(review): /deep-review adversarial-logic pre-push command + no-hand-rolled-parsing rule

### DIFF
--- a/.claude/commands/deep-review.md
+++ b/.claude/commands/deep-review.md
@@ -10,13 +10,18 @@ right-shape pass the easy default. (It reliably kills the first round; it is NOT
 whole loop — fix-churn and hand-rolled parsing drive the tail. See the Common Traps entry on
 CLI parsing.)
 
-## 1. Scope the FULL branch diff (not just the last commit)
+## 1. Stage everything, then scope the FULL branch diff
 
+- `ROOT="$(git rev-parse --show-toplevel)"` — the repo root. Use `$ROOT/scripts/…` for every
+  `scripts/…` path below: this repo's Bash cwd drifts, so a bare relative `scripts/…` can
+  resolve against the wrong directory and fail. (`git` commands find the root on their own.)
+- **Stage all intended changes first** (`git add …`) and skim `git status`: `git diff` never
+  shows UNTRACKED (never-added) files, so a brand-new source/test/hook/config file is invisible
+  to the review until it is staged. Nothing untracked = the diff is complete.
 - `git diff "$(git merge-base HEAD origin/main)"` — everything the branch changes vs the
-  merge-base, INCLUDING staged AND unstaged work (`git diff <commit>` compares the working
-  tree, so staged content is included). Add `--stat` for the file list. Do NOT use `..HEAD`
-  alone (misses uncommitted work) or plain `git diff` alone (misses STAGED work) — the state
-  you run this in is usually staged-but-uncommitted.
+  merge-base, INCLUDING staged and unstaged tracked work (`git diff <commit>` compares the
+  working tree). Add `--stat` for the file list. Do NOT use `..HEAD` alone (misses uncommitted
+  work) or plain `git diff` alone (misses STAGED work).
 
 ## 2. Dispatch the reviewer(s) — FRESH CONTEXT, sequential, un-anchored
 
@@ -51,16 +56,21 @@ If you're on your 3rd defect-bearing round, STOP at the escalation cap (see SKIL
 
 ## 4. Record evidence, mark, THEN commit (satisfies the commit review-depth gate)
 
-- `EVID="$(python3 scripts/review_state.py evidence-path)"` — the per-worktree evidence file.
-- Write the reviewer's structured findings to `$EVID` — must carry a severity-ladder label
-  (BLOCKER / SHOULD-FIX or CRITICAL/HIGH/MEDIUM/LOW/P1-P3), at least one `file:line`, and ≥400
-  chars, or the gate will not accept it as adversarial.
-- `python3 scripts/review_state.py mark --agent-output "$EVID"` — add `--clean` IFF the pass
-  found NO new BLOCKER/SHOULD-FIX/P1/P2 (resets the escalation streak; a forgotten `--clean` is
-  the safe direction).
-- Run `mark` AFTER the final `git add` and BEFORE `git commit`: the marker binds the *staged*
-  content, so don't restage after marking, and mark + commit within 30 min of writing the
-  evidence (it expires).
+- The marker binds the **final staged content**, not the text the reviewer saw. So after
+  applying §3's fixes: re-inspect the fixes (re-run the reviewer if they are non-trivial) and
+  write the evidence to describe the FINAL staged state — the findings AND that the fixes were
+  applied and verified. Do not let a marker attach a pre-fix review to post-fix code no one
+  re-read.
+- `EVID="$(python3 "$ROOT/scripts/review_state.py" evidence-path)"` — the per-worktree evidence
+  file. Write the findings to `$EVID`: must carry a severity-ladder label (BLOCKER / SHOULD-FIX,
+  or CRITICAL / WARNING from the security reviewer, or CRITICAL/HIGH/MEDIUM/LOW/P1-P3), at least
+  one `file:line`, and ≥400 chars, or the gate rejects it as non-adversarial.
+- `python3 "$ROOT/scripts/review_state.py" mark --agent-output "$EVID"` — add `--clean` IFF the
+  pass found nothing at **should-fix-or-worse**: genesis-architect → no BLOCKER/SHOULD-FIX;
+  genesis-security-reviewer → no CRITICAL/WARNING (WARNING is its "should address" tier); or no
+  P1/P2. A forgotten `--clean` is the safe direction (it counts the round).
+- Run `mark` AFTER the final `git add` and BEFORE `git commit`; don't restage after marking, and
+  mark + commit within 30 min of writing the evidence (it expires).
 
 For a quick self-check of a small change, use `/audit-changes` instead — this command is the
 heavyweight adversarial pass.

--- a/.claude/commands/deep-review.md
+++ b/.claude/commands/deep-review.md
@@ -1,0 +1,66 @@
+Run a fresh-context, un-anchored ADVERSARIAL-LOGIC review of the current diff before
+pushing — the review that catches real bugs, not a lint/secrets/"structural CLEAN" scan.
+Use it on any substantial change, and ALWAYS before pushing a hook, gate, parser, or
+security-surface change.
+
+Why this exists: an internal review-loop analysis of recent PRs found that first-round Codex
+findings were real, pre-existing bugs — the initial pushes had been self-reviewed with the
+WRONG SHAPE (a pattern/secrets scan), not an adversarial logic audit. This command makes the
+right-shape pass the easy default. (It reliably kills the first round; it is NOT a cure for the
+whole loop — fix-churn and hand-rolled parsing drive the tail. See the Common Traps entry on
+CLI parsing.)
+
+## 1. Scope the FULL branch diff (not just the last commit)
+
+- `git diff "$(git merge-base HEAD origin/main)"` — everything the branch changes vs the
+  merge-base, INCLUDING staged AND unstaged work (`git diff <commit>` compares the working
+  tree, so staged content is included). Add `--stat` for the file list. Do NOT use `..HEAD`
+  alone (misses uncommitted work) or plain `git diff` alone (misses STAGED work) — the state
+  you run this in is usually staged-but-uncommitted.
+
+## 2. Dispatch the reviewer(s) — FRESH CONTEXT, sequential, un-anchored
+
+Use the Agent tool. Do NOT self-review — a self-review is anchored to your own blind spots,
+which is exactly what lets Round-1 bugs through.
+
+- **`genesis-architect`** over the full diff — follow its protocol
+  (`.claude/agents/genesis-architect.md`): scope-drift check first, BLOCKER / SHOULD-FIX / NOTE
+  ladder with per-finding `file:line` + confidence, completion status last.
+- **ALSO `genesis-security-reviewer`** when the diff touches auth, credentials/secrets,
+  subprocess, SQL, path handling, external input (Telegram/dashboard/MCP), or hooks/gates.
+- Run them SEQUENTIALLY, never in parallel (standing rule — the second reviewer must see the
+  fixed code, and parallel doubles spend).
+
+Prime each reviewer with the RIGHT SHAPE (what a lint scan misses). Paste this into the prompt:
+
+> Assume there are bugs; enumerate the whole CLASS, not just the named cases. Read the
+> authoritative source (the library/loader/protocol you mirror) END-TO-END before deriving.
+> Apply the AI-code failure taxonomy in `.claude/skills/genesis-development/references/ai-code-audit.md`.
+> Hunt specifically for: fail-OPEN where fail-closed was intended; unhandled states in a state
+> machine; TOCTOU / non-atomic check-then-act; silently-swallowed errors that read as "all
+> clear"; and **hand-rolled CLI / `gh` / bash / argv parsing** — flag that as an ARCHITECTURAL
+> defect and recommend atomic binding + fail-closed-on-unparseable, NOT case-by-case patches
+> (it is the root of the Codex review loop).
+
+## 3. Triage → stage the class-level fix (don't commit yet)
+
+3-bucket disposition: FIX real+material now / evidence-tiered documented-accept / escalate.
+When you fix, fix the mechanism/class — a per-instance patch is what spawns the next review
+round. `git add` the fix, but do NOT commit yet — the commit is the last step, after the marker.
+If you're on your 3rd defect-bearing round, STOP at the escalation cap (see SKILL.md).
+
+## 4. Record evidence, mark, THEN commit (satisfies the commit review-depth gate)
+
+- `EVID="$(python3 scripts/review_state.py evidence-path)"` — the per-worktree evidence file.
+- Write the reviewer's structured findings to `$EVID` — must carry a severity-ladder label
+  (BLOCKER / SHOULD-FIX or CRITICAL/HIGH/MEDIUM/LOW/P1-P3), at least one `file:line`, and ≥400
+  chars, or the gate will not accept it as adversarial.
+- `python3 scripts/review_state.py mark --agent-output "$EVID"` — add `--clean` IFF the pass
+  found NO new BLOCKER/SHOULD-FIX/P1/P2 (resets the escalation streak; a forgotten `--clean` is
+  the safe direction).
+- Run `mark` AFTER the final `git add` and BEFORE `git commit`: the marker binds the *staged*
+  content, so don't restage after marking, and mark + commit within 30 min of writing the
+  evidence (it expires).
+
+For a quick self-check of a small change, use `/audit-changes` instead — this command is the
+heavyweight adversarial pass.

--- a/.claude/commands/deep-review.md
+++ b/.claude/commands/deep-review.md
@@ -10,6 +10,11 @@ right-shape pass the easy default. (It reliably kills the first round; it is NOT
 whole loop — fix-churn and hand-rolled parsing drive the tail. See the Common Traps entry on
 CLI parsing.)
 
+Note: `/deep-review` is the LOCAL pre-push adversarial pass (Claude-model reviewers). It does
+NOT replace the independent-model Codex review, which still runs on the PR and is required by the
+merge gate — the two are complementary (Codex catches cross-model blind spots). This command
+clears the local commit review-depth gate; it does not certify the PR by itself.
+
 ## 1. Stage everything, then scope the FULL branch diff
 
 - `ROOT="$(git rev-parse --show-toplevel)"` — the repo root. Use `$ROOT/scripts/…` for every
@@ -62,15 +67,17 @@ If you're on your 3rd defect-bearing round, STOP at the escalation cap (see SKIL
   applied and verified. Do not let a marker attach a pre-fix review to post-fix code no one
   re-read.
 - `EVID="$(python3 "$ROOT/scripts/review_state.py" evidence-path)"` — the per-worktree evidence
-  file. Write the findings to `$EVID`: must carry a severity-ladder label (BLOCKER / SHOULD-FIX,
-  or CRITICAL / WARNING from the security reviewer, or CRITICAL/HIGH/MEDIUM/LOW/P1-P3), at least
-  one `file:line`, and ≥400 chars, or the gate rejects it as non-adversarial.
+  file. Write the findings to `$EVID`: must carry a validator-recognized severity label
+  (BLOCKER / SHOULD-FIX / CRITICAL / HIGH / MEDIUM / LOW / P1-P3 — a security-reviewer WARNING is
+  NOT recognized by the validator, so render it as SHOULD-FIX in the text), at least one
+  `file:line`, and ≥400 chars, or the gate rejects the evidence as non-adversarial.
 - `python3 "$ROOT/scripts/review_state.py" mark --agent-output "$EVID"` — add `--clean` IFF the
   pass found nothing at **should-fix-or-worse**: genesis-architect → no BLOCKER/SHOULD-FIX;
   genesis-security-reviewer → no CRITICAL/WARNING (WARNING is its "should address" tier); or no
   P1/P2. A forgotten `--clean` is the safe direction (it counts the round).
-- Run `mark` AFTER the final `git add` and BEFORE `git commit`; don't restage after marking, and
-  mark + commit within 30 min of writing the evidence (it expires).
+- Run `mark` AFTER the final `git add` and BEFORE `git commit`. The evidence must be recent when
+  you `mark` (its age is checked at mark time), so write-then-mark promptly. Once marked, an
+  unchanged staged diff stays cleared by its diff-hash — if you restage or amend, re-mark.
 
 For a quick self-check of a small change, use `/audit-changes` instead — this command is the
 heavyweight adversarial pass.

--- a/.claude/docs/builder-workflow-integrations.md
+++ b/.claude/docs/builder-workflow-integrations.md
@@ -39,6 +39,16 @@ Output a structured report. If any issues found, fix them before proceeding.
 If no issues found, state "AUDIT CLEAN" explicitly.
 ```
 
+**Scope:** `/audit-changes` is the LIGHTWEIGHT self-check — a fast, same-session pass over
+your own diff, used by the deliverable-builder before a commit. It is deliberately NOT an
+adversarial audit. For a substantial change, a hook/gate/parser, or any security surface, run
+**`/deep-review`** (`.claude/commands/deep-review.md`) instead: it dispatches a fresh-context
+`genesis-architect` (+ `genesis-security-reviewer`) over the full branch diff with the
+right SHAPE (fail-open/state/TOCTOU/hand-rolled-parsing hunting) and writes the review-depth
+marker. An internal review-loop analysis found self-shaped reviews miss first-round bugs that
+an adversarial pass catches — `/deep-review` is the pass that catches them before the cloud
+reviewer does.
+
 ### 2. `/drift` Custom Command — Plan vs Reality Tracker
 
 **Source:** Vin's `/drift` command (Obsidian + Claude Code suite)

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -323,9 +323,14 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   fix-churn on the hand-rolled parser itself — no finite pre-push audit bounds that
   tail). The cure is architectural,
   not "review harder": bind atomically to the real tool (e.g. `gh pr merge
-  --match-head-commit`), fail CLOSED on any form you cannot parse, and use a
-  canonical parser (`shlex`/`bashlex`) — never bespoke semantics. Same family as
-  the canonical-parser lesson (regex→yaml, #1393). Loci today:
+  --match-head-commit`) and use a canonical parser (`shlex`/`bashlex`) — never
+  bespoke semantics. Choose the fail direction PER BOUNDARY by consequence: the
+  shared parser must DEGRADE gracefully (fail-open, never crash — that is
+  `shell_parse.py`'s stated contract), while each security-critical caller
+  (merge/push authorization) treats an unparseable command as a block (fail-closed
+  THERE). A parser-wide absolute fail-closed is wrong — it would deny legitimate
+  uncommon commands without closing evasion paths. Same family as the
+  canonical-parser lesson (regex→yaml, #1393). Loci today:
   `scripts/hooks/shell_parse.py` + `scripts/hooks/git_push_guard.py`.
 
 ### Iterative-Refinement Discipline

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -311,6 +311,22 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   through the server/CRUD path; reserve `immutable=1` for historical
   read-only sampling where a little staleness is fine. (A reconcile UPDATE
   read clean under `mode=ro` but appeared unchanged under `immutable=1`.)
+- **Never hand-roll `gh`/bash/CLI argv parsing inside a hook or security gate.**
+  Re-implementing shell/`gh` command-line semantics by hand (regex, manual token
+  walking) creates an effectively UNBOUNDED adversarial-divergence tail: a good
+  reviewer (Codex especially) will keep surfacing real gaps from true semantics —
+  `--repo`/`-R`/`-Rvalue`, `GH_REPO`, `cd`, `&&`, `||`, `--body-file -`, duplicate
+  flags, URL-vs-branch targets, enterprise hosts, `--help`, nested `bash -c` — and
+  each named fix ships the next round's bug. This is the mechanism behind the
+  measured Codex review-loop (an internal analysis of recent review-looping PRs:
+  first-round findings were real catchable bugs, but later rounds were dominated by
+  fix-churn on the hand-rolled parser itself — no finite pre-push audit bounds that
+  tail). The cure is architectural,
+  not "review harder": bind atomically to the real tool (e.g. `gh pr merge
+  --match-head-commit`), fail CLOSED on any form you cannot parse, and use a
+  canonical parser (`shlex`/`bashlex`) — never bespoke semantics. Same family as
+  the canonical-parser lesson (regex→yaml, #1393). Loci today:
+  `scripts/hooks/shell_parse.py` + `scripts/hooks/git_push_guard.py`.
 
 ### Iterative-Refinement Discipline
 
@@ -471,6 +487,12 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
 
 ### Review-loop discipline
 
+- **Run the pre-push adversarial pass with `/deep-review`** (`.claude/commands/deep-review.md`):
+  one command that dispatches a fresh-context `genesis-architect` (+ `genesis-security-reviewer`
+  on security surfaces) over the FULL branch diff with the right SHAPE — fail-open/state/TOCTOU/
+  hand-rolled-parsing hunting, not a lint/secrets scan — and writes the evidence marker. This is
+  the review that catches Round-1 bugs before Codex does; `/audit-changes` is only a light
+  self-check.
 - **One reviewer at a time — NEVER run two review agents simultaneously.** Run
   one reviewer (e.g. Codex), apply/verify its findings, then run the next
   reviewer (e.g. Claude) on the *fixed* code — sequential, never in parallel.


### PR DESCRIPTION
## Why

The commit review-depth front-stop (#1357) requires an adversarial marker for substantial
changes, but the *shape* of the pre-push review was left to discipline — and in practice the
habitual pass is a lint/secrets "structural CLEAN" scan, not an adversarial logic audit. An
internal review-loop analysis found that first-round Codex findings were real, pre-existing bugs
a right-shape pass would catch, while the multi-round tail is driven by fix-churn and,
architecturally, by hand-rolled `gh`/bash argv parsing inside the security hooks (an unbounded
adversarial-divergence tail).

## What

- **`/deep-review` command** — one command that dispatches a fresh-context `genesis-architect`
  (+ `genesis-security-reviewer` on security surfaces) over the full branch diff with the right
  SHAPE (fail-open/state/TOCTOU/hand-rolled-parsing hunting), then writes the review-depth marker
  via the per-worktree `evidence-path` → `mark` flow. Distinct from the lightweight
  `/audit-changes` (kept as-is for the deliverable-builder).
- **SKILL.md Common Traps** — "never hand-roll `gh`/bash/CLI argv parsing inside a hook or
  security gate": it creates an unbounded adversarial-divergence tail; bind atomically, fail
  CLOSED on any unparseable form, use a canonical parser. Loci noted for a future refactor.
- **Doc pointers** — SKILL.md review-loop discipline + `builder-workflow-integrations.md`
  distinguish `/deep-review` (heavy) from `/audit-changes` (light).

## Scope

Additive, docs/command only — no runtime code, no gate-logic changes. `/deep-review` reliably
kills the *first* review round; it is explicitly **not** a cure for the whole loop (the
architectural refactor of the hooks' argv parsing is tracked separately).

## Dogfood

A fresh-context `genesis-architect` adversarially reviewed this very diff and found a **BLOCKER**
(the command's own §1 diff-scoping returned an empty diff for staged-but-uncommitted work — the
exact false-clean it exists to prevent), a **SHOULD-FIX** (mark/commit ordering that the gate
would block), and 3 NOTEs — all fixed in the same commit and re-verified (the corrected
`git diff "$(git merge-base HEAD origin/main)"` shows the staged work; the old `..HEAD` form
returned empty). The command caught a real bug in itself.

## Verification

55 targeted tests pass (`test_generate_skill_catalog` #1393 parser + `test_skill_injection`);
SKILL.md frontmatter unchanged. The review-depth gate was satisfied by the real adversarial
marker, not a self-certification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
