### PR TITLE
feat(repo-pulse): reconcile standalone follow_up rows against merged PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,11 @@ the working documents — ledger rows are the durable index, not a duplicate.
 `Ledger: <item-id>` (the 32-hex row id) on its own line in the PR body —
 the repo-pulse worker auto-absorbs the row with PR evidence at the next
 session boundary. A bare id without the marker reads as context, not
-completion (proposal only).
+completion (proposal only). The identical convention exists for a **hot
+follow-up** row: cite `Follow-up: <id>` (the 32-hex follow_up id) and the
+worker completes that row with PR evidence the same way (bare id → proposal;
+pinned rows surface as a proposal for human confirmation, never auto-completed;
+`tabled` rows are never touched).
 
 ## Knowledge Ingestion (Conversational Path)
 

--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -1001,10 +1001,19 @@ def _load_charter_db(session_id: str, db_path: Path | None) -> tuple[dict | None
                     # Repo-pulse proposals (PR-4a) — own guard: pre-0062
                     # installs have no pulse tables and the charter block
                     # must render byte-identically without them.
+                    # Ledger-only: the rendered confirm command is
+                    # session_ledger_update(...), which can only resolve a
+                    # ledger id. follow_up-target proposals (target_kind added by
+                    # migration 0084) are session-agnostic and get their own
+                    # global surface — never surface them here with a confirm
+                    # command that can't find them. Pre-0084 DBs lack the column;
+                    # the enclosing try/except then renders the block empty (same
+                    # graceful degradation as the pre-0062 no-tables case).
                     cur = await db.execute(
                         "SELECT item_id, item_text, pr_number, pr_title"
                         " FROM repo_pulse_annotations"
                         " WHERE item_session_id = ? AND status = 'proposed'"
+                        " AND target_kind = 'ledger'"
                         " AND (confidence IS NULL OR confidence >= ?)"
                         " ORDER BY observed_at DESC LIMIT 3",
                         (session_id, _pulse_floor()),

--- a/src/genesis/dashboard/routes/cc_sessions.py
+++ b/src/genesis/dashboard/routes/cc_sessions.py
@@ -424,6 +424,7 @@ async def cc_sessions_pulse_resolve(annotation_id: str):
 
 async def _resolve_pulse(db, annotation_id: str, status: str) -> tuple[dict, int]:
     """Resolve core (extracted so tests exercise it on the fixture loop)."""
+    from genesis.db.crud.follow_ups import absorb_followup
     from genesis.db.crud.repo_pulse import get_annotation, resolve_annotation
     from genesis.db.crud.session_charters import get_ledger_item, ledger_update
 
@@ -447,15 +448,21 @@ async def _resolve_pulse(db, annotation_id: str, status: str) -> tuple[dict, int
         )
         absorbed = False
         if ok and status == "confirmed":
-            item = await get_ledger_item(db, row["item_id"])
-            if item is not None and item.get("status") in ("open", "in_progress"):
-                absorbed = await ledger_update(
-                    db,
-                    row["item_id"],
-                    status="absorbed",
-                    evidence=f"PR #{row['pr_number']}: {row['pr_title'] or ''} "
-                    f"[pulse confirm via dashboard]",
-                )
+            # Dispatch by store: a follow_up-target annotation absorbs the
+            # follow_up (conditional open-only), NOT a ledger row that doesn't
+            # exist. Defensive default 'ledger' keeps pre-0084 rows correct.
+            target_kind = dict(row).get("target_kind") or "ledger"
+            evidence = (
+                f"PR #{row['pr_number']}: {row['pr_title'] or ''} [pulse confirm via dashboard]"
+            )
+            if target_kind == "follow_up":
+                absorbed = await absorb_followup(db, row["item_id"], evidence=evidence)
+            else:
+                item = await get_ledger_item(db, row["item_id"])
+                if item is not None and item.get("status") in ("open", "in_progress"):
+                    absorbed = await ledger_update(
+                        db, row["item_id"], status="absorbed", evidence=evidence
+                    )
     except (sqlite3.Error, aiosqlite.Error) as exc:
         logger.error("pulse resolve failed: %s", exc)
         return {"error": "pulse store unavailable"}, 503

--- a/src/genesis/dashboard/routes/cc_sessions.py
+++ b/src/genesis/dashboard/routes/cc_sessions.py
@@ -313,7 +313,14 @@ async def _pulse_lookup(db, cc_session_id: str) -> dict:
     try:
         from genesis.db.crud.repo_pulse import list_annotations, summary
 
-        annotations = await list_annotations(db, session_id=cc_session_id, limit=100)
+        # Ledger-only: this per-session panel keys on item_session_id, which is
+        # a ledger-shaped binding. follow_up-target proposals are session-agnostic
+        # (source_session is often NULL) and get their own global surface (a
+        # tracked follow-up); rendering them here would either hide the NULL ones
+        # or offer a ledger confirm command that can't resolve a follow_up id.
+        annotations = await list_annotations(
+            db, session_id=cc_session_id, target_kind="ledger", limit=100
+        )
         health = await summary(db)
     except Exception as exc:
         logger.debug("pulse tables unavailable (pre-0062 install?): %s", exc)

--- a/src/genesis/dashboard/routes/cc_sessions.py
+++ b/src/genesis/dashboard/routes/cc_sessions.py
@@ -440,12 +440,16 @@ async def _resolve_pulse(db, annotation_id: str, status: str) -> tuple[dict, int
         row = await get_annotation(db, annotation_id)
         if row is None or row["status"] != "proposed":
             return {"error": "unknown or already-resolved annotation"}, 404
-        # Resolve the annotation FIRST: its conditional proposed→terminal
-        # UPDATE is the race arbiter. Two concurrent resolutions can't both
-        # win it, so the ledger absorb below only ever runs for the winner —
-        # never an absorbed item under a rejected annotation. (The inverse
-        # residue — confirmed annotation, absorb missed — is visible and
-        # human-fixable via the injected hint.)
+        # Resolve the annotation FIRST — the conditional proposed→terminal UPDATE
+        # is the race arbiter: a concurrent confirm+reject can't both win it, so
+        # the absorb below only ever runs for the confirm winner, never under a
+        # rejected annotation. (Absorb-FIRST was tried and REVERTED: it reopened a
+        # WORSE residue — a follow_up completed under a human-REJECTED annotation,
+        # permanent + invisible since reconcile never revisits a terminal row.)
+        # The milder residue this order can leave — a confirmed annotation whose
+        # absorb missed because the row moved off-open — is accepted, consistent
+        # with the ledger path; the follow_up confirm surface is dormant anyway
+        # until the global proposal surface lands.
         ok = await resolve_annotation(
             db,
             annotation_id,

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -390,27 +390,36 @@ async def absorb_followup(
     id: str,
     *,
     evidence: str,
+    require_unpinned: bool = False,
 ) -> bool:
-    """Mark a still-open follow_up 'completed' with PR evidence (repo-pulse absorb).
+    """Mark a still-open HOT follow_up 'completed' with PR evidence (repo-pulse absorb).
 
     Conditional by design — only a row still in ``('pending','in_progress')``
     transitions. The detached repo-pulse worker races ego/foreground writers, so
     an unconditional ``update_status`` would clobber a concurrent transition (e.g.
     a user just set it 'blocked'); the WHERE guard makes the absorb
     lost-update-safe and replay-idempotent (a re-covered enumeration window
-    matches nothing on the second run). Mirrors the ledger absorb and the
-    dashboard's own open-only guard.
+    matches nothing on the second run).
 
-    The CALLER scopes to the HOT lane (``kind='follow_up'``) and excludes pinned
-    rows — this enforces only the open-status precondition. ``evidence`` is
-    APPENDED to any existing ``resolution_notes`` (prior context is never lost).
-    Returns True iff a row changed.
+    Lane invariants are enforced ATOMICALLY here, not from the caller's stale
+    load-time snapshot (a concurrent pin or ``kind``→``tabled`` between load and
+    this UPDATE could otherwise slip past them): ``kind='follow_up'`` is ALWAYS
+    required, so the cold ``tabled``/``idea`` lanes are never absorbed by either
+    caller. ``require_unpinned=True`` (the worker's auto-absorb) additionally
+    refuses pinned rows atomically — honouring "automation never auto-resolves a
+    pinned row"; the dashboard confirm passes ``False`` because a human
+    explicitly confirming a pinned proposal is an intended override. ``evidence``
+    is APPENDED to any existing ``resolution_notes`` (prior context is never
+    lost). Returns True iff a row changed.
     """
+    where = "id = ? AND kind = 'follow_up' AND status IN ('pending', 'in_progress')"
+    if require_unpinned:
+        where += " AND pinned = 0"
     cursor = await db.execute(
         "UPDATE follow_ups SET status = 'completed', completed_at = ?, "
         "resolution_notes = TRIM("
         "COALESCE(resolution_notes || char(10) || char(10), '') || ?"
-        ") WHERE id = ? AND status IN ('pending', 'in_progress')",
+        f") WHERE {where}",  # noqa: S608 — where is composed of string literals only
         (_now_iso(), evidence, id),
     )
     await db.commit()

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -385,6 +385,38 @@ async def update_notes(
     return cursor.rowcount > 0
 
 
+async def absorb_followup(
+    db: aiosqlite.Connection,
+    id: str,
+    *,
+    evidence: str,
+) -> bool:
+    """Mark a still-open follow_up 'completed' with PR evidence (repo-pulse absorb).
+
+    Conditional by design — only a row still in ``('pending','in_progress')``
+    transitions. The detached repo-pulse worker races ego/foreground writers, so
+    an unconditional ``update_status`` would clobber a concurrent transition (e.g.
+    a user just set it 'blocked'); the WHERE guard makes the absorb
+    lost-update-safe and replay-idempotent (a re-covered enumeration window
+    matches nothing on the second run). Mirrors the ledger absorb and the
+    dashboard's own open-only guard.
+
+    The CALLER scopes to the HOT lane (``kind='follow_up'``) and excludes pinned
+    rows — this enforces only the open-status precondition. ``evidence`` is
+    APPENDED to any existing ``resolution_notes`` (prior context is never lost).
+    Returns True iff a row changed.
+    """
+    cursor = await db.execute(
+        "UPDATE follow_ups SET status = 'completed', completed_at = ?, "
+        "resolution_notes = TRIM("
+        "COALESCE(resolution_notes || char(10) || char(10), '') || ?"
+        ") WHERE id = ? AND status IN ('pending', 'in_progress')",
+        (_now_iso(), evidence, id),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
+
+
 async def link_task(
     db: aiosqlite.Connection,
     id: str,

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -187,6 +187,21 @@ async def get_by_status(
     return [dict(row) for row in await cursor.fetchall()]
 
 
+async def get_open_followups(db: aiosqlite.Connection) -> list[dict]:
+    """Hot follow_up rows still open (pending or in_progress), oldest first.
+
+    ONE statement, so it is a single consistent snapshot: a concurrent writer
+    moving a row in_progress<->pending can never make it fall between two
+    queries (the repo-pulse reconciler's loader must not silently drop such a
+    row and then advance its PR cursor past it). Cold ``tabled``/``idea`` rows
+    are excluded (kind='follow_up')."""
+    cursor = await db.execute(
+        "SELECT * FROM follow_ups WHERE kind = 'follow_up' "
+        "AND status IN ('pending', 'in_progress') ORDER BY created_at ASC"
+    )
+    return [dict(row) for row in await cursor.fetchall()]
+
+
 async def get_actionable(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/db/crud/follow_ups.py
+++ b/src/genesis/db/crud/follow_ups.py
@@ -391,6 +391,7 @@ async def absorb_followup(
     *,
     evidence: str,
     require_unpinned: bool = False,
+    commit: bool = True,
 ) -> bool:
     """Mark a still-open HOT follow_up 'completed' with PR evidence (repo-pulse absorb).
 
@@ -422,7 +423,11 @@ async def absorb_followup(
         f") WHERE {where}",  # noqa: S608 — where is composed of string literals only
         (_now_iso(), evidence, id),
     )
-    await db.commit()
+    # commit=False lets a caller stage this completion and commit it in the SAME
+    # transaction as a related write (the worker commits the absorb + its audit
+    # annotation together via repo_pulse.insert_annotation).
+    if commit:
+        await db.commit()
     return cursor.rowcount > 0
 
 

--- a/src/genesis/db/crud/repo_pulse.py
+++ b/src/genesis/db/crud/repo_pulse.py
@@ -49,6 +49,37 @@ async def _tables_available(db: aiosqlite.Connection) -> bool:
     return exists
 
 
+_ANNOTATION_INSERT_SQL = (
+    "INSERT OR IGNORE INTO repo_pulse_annotations "
+    "(id, run_id, observed_at, tier, item_id, item_session_id, "
+    "item_text, pr_number, pr_title, pr_merged_at, confidence, "
+    "rationale, status, resolved_at, resolution_ref, target_kind) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+)
+
+
+def _annotation_params(ann: dict, run_id: str) -> tuple:
+    """Positional params for ``_ANNOTATION_INSERT_SQL`` from an annotation dict."""
+    return (
+        ann["id"],
+        run_id,
+        ann["observed_at"],
+        ann["tier"],
+        ann["item_id"],
+        ann.get("item_session_id"),
+        ann.get("item_text"),
+        ann["pr_number"],
+        ann.get("pr_title"),
+        ann.get("pr_merged_at"),
+        ann.get("confidence"),
+        ann.get("rationale"),
+        ann["status"],
+        ann.get("resolved_at"),
+        ann.get("resolution_ref"),
+        ann.get("target_kind", "ledger"),
+    )
+
+
 async def record_run(
     db: aiosqlite.Connection,
     *,
@@ -129,32 +160,33 @@ async def record_run(
         ),
     )
     for ann in annotations or []:
-        await db.execute(
-            "INSERT OR IGNORE INTO repo_pulse_annotations "
-            "(id, run_id, observed_at, tier, item_id, item_session_id, "
-            "item_text, pr_number, pr_title, pr_merged_at, confidence, "
-            "rationale, status, resolved_at, resolution_ref, target_kind) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (
-                ann["id"],
-                run_id,
-                ann["observed_at"],
-                ann["tier"],
-                ann["item_id"],
-                ann.get("item_session_id"),
-                ann.get("item_text"),
-                ann["pr_number"],
-                ann.get("pr_title"),
-                ann.get("pr_merged_at"),
-                ann.get("confidence"),
-                ann.get("rationale"),
-                ann["status"],
-                ann.get("resolved_at"),
-                ann.get("resolution_ref"),
-                ann.get("target_kind", "ledger"),
-            ),
-        )
+        await db.execute(_ANNOTATION_INSERT_SQL, _annotation_params(ann, run_id))
     await db.commit()
+    return True
+
+
+async def insert_annotation(
+    db: aiosqlite.Connection, ann: dict, *, run_id: str, commit: bool = True
+) -> bool:
+    """Persist ONE annotation (INSERT OR IGNORE), optionally committing.
+
+    Lets the worker record a follow-up ABSORB and its 'applied' audit annotation
+    in a SINGLE transaction: call ``absorb_followup(..., commit=False)`` then this
+    with ``commit=True`` on the same connection, so a crash — or a failed
+    end-of-run ``record_run`` — can't leave a completed follow_up with no
+    annotation. Validates tier/target_kind/status like ``record_run``; a no-op
+    returning False before migration 0062 (tables absent)."""
+    if ann.get("tier") not in TIERS:
+        raise ValueError(f"invalid annotation tier: {ann.get('tier')!r}")
+    if ann.get("target_kind", "ledger") not in TARGET_KINDS:
+        raise ValueError(f"invalid annotation target_kind: {ann.get('target_kind')!r}")
+    if ann.get("status") not in ANNOTATION_STATUSES:
+        raise ValueError(f"invalid annotation status: {ann.get('status')!r}")
+    if not await _tables_available(db):
+        return False
+    await db.execute(_ANNOTATION_INSERT_SQL, _annotation_params(ann, run_id))
+    if commit:
+        await db.commit()
     return True
 
 

--- a/src/genesis/db/crud/repo_pulse.py
+++ b/src/genesis/db/crud/repo_pulse.py
@@ -21,6 +21,9 @@ import aiosqlite
 
 RUN_STATUSES = ("ok", "failed", "timeout", "lock_busy", "no_new_prs")
 TIERS = ("exact", "fuzzy")
+# Which store an annotation's item_id addresses (a8a4f59e). Absent → 'ledger'
+# (the original lane), so pre-target_kind callers keep working unchanged.
+TARGET_KINDS = ("ledger", "follow_up")
 ANNOTATION_STATUSES = ("applied", "proposed", "confirmed", "rejected", "superseded")
 # Terminal states a 'proposed' annotation may resolve to (reconciliation / 4b buttons).
 RESOLUTION_STATUSES = ("confirmed", "rejected", "superseded")
@@ -89,6 +92,8 @@ async def record_run(
     for ann in annotations or []:
         if ann.get("tier") not in TIERS:
             raise ValueError(f"invalid annotation tier: {ann.get('tier')!r}")
+        if ann.get("target_kind", "ledger") not in TARGET_KINDS:
+            raise ValueError(f"invalid annotation target_kind: {ann.get('target_kind')!r}")
         if ann.get("status") not in ANNOTATION_STATUSES:
             raise ValueError(f"invalid annotation status: {ann.get('status')!r}")
         if not ann.get("item_id"):
@@ -128,8 +133,8 @@ async def record_run(
             "INSERT OR IGNORE INTO repo_pulse_annotations "
             "(id, run_id, observed_at, tier, item_id, item_session_id, "
             "item_text, pr_number, pr_title, pr_merged_at, confidence, "
-            "rationale, status, resolved_at, resolution_ref) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "rationale, status, resolved_at, resolution_ref, target_kind) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 ann["id"],
                 run_id,
@@ -146,6 +151,7 @@ async def record_run(
                 ann["status"],
                 ann.get("resolved_at"),
                 ann.get("resolution_ref"),
+                ann.get("target_kind", "ledger"),
             ),
         )
     await db.commit()
@@ -170,22 +176,32 @@ async def tables_available(db: aiosqlite.Connection) -> bool:
 
 
 async def annotation_exists(
-    db: aiosqlite.Connection, tier: str, item_id: str, pr_number: int
+    db: aiosqlite.Connection,
+    tier: str,
+    item_id: str,
+    pr_number: int,
+    *,
+    target_kind: str = "ledger",
 ) -> bool:
-    """True when this (tier, item_id, pr_number) match was already recorded.
+    """True when this (tier, target_kind, item_id, pr_number) match was recorded.
 
     The worker's re-absorb guard: a re-covered enumeration window (or a
     deliberately reopened item) must not be acted on twice for the same
     PR. Any status counts — a rejected proposal is still a decision made.
+    ``target_kind`` scopes by store (ledger vs follow_up ids share the
+    uuid4.hex shape); it defaults to 'ledger' so the original lane's
+    positional callers are unchanged.
     """
     if tier not in TIERS:
         raise ValueError(f"invalid annotation tier: {tier!r}")
+    if target_kind not in TARGET_KINDS:
+        raise ValueError(f"invalid target_kind: {target_kind!r}")
     if not await _tables_available(db):
         return False
     cursor = await db.execute(
         "SELECT 1 FROM repo_pulse_annotations "
-        "WHERE tier = ? AND item_id = ? AND pr_number = ? LIMIT 1",
-        (tier, item_id, pr_number),
+        "WHERE tier = ? AND target_kind = ? AND item_id = ? AND pr_number = ? LIMIT 1",
+        (tier, target_kind, item_id, pr_number),
     )
     return await cursor.fetchone() is not None
 
@@ -231,11 +247,16 @@ async def list_annotations(
     *,
     session_id: str | None = None,
     status: str | None = None,
+    target_kind: str | None = None,
     limit: int = 500,
 ) -> list[dict]:
-    """Annotations newest first, optionally filtered by session and/or status."""
+    """Annotations newest first, optionally filtered by session, status, and/or
+    target_kind. Each returned dict carries ``target_kind`` (SELECT *), so a
+    caller may also dispatch per-row without pre-filtering."""
     if status is not None and status not in ANNOTATION_STATUSES:
         raise ValueError(f"invalid annotation status: {status!r}")
+    if target_kind is not None and target_kind not in TARGET_KINDS:
+        raise ValueError(f"invalid target_kind: {target_kind!r}")
     lim = max(1, min(int(limit), 2000))
     clauses, params = [], []
     if session_id is not None:
@@ -244,6 +265,9 @@ async def list_annotations(
     if status is not None:
         clauses.append("status = ?")
         params.append(status)
+    if target_kind is not None:
+        clauses.append("target_kind = ?")
+        params.append(target_kind)
     where = f"WHERE {' AND '.join(clauses)} " if clauses else ""
     cursor = await db.execute(
         f"SELECT * FROM repo_pulse_annotations {where}"  # noqa: S608 — clauses are literals

--- a/src/genesis/db/migrations/0084_repo_pulse_target_kind.py
+++ b/src/genesis/db/migrations/0084_repo_pulse_target_kind.py
@@ -1,0 +1,64 @@
+"""Add ``target_kind`` to repo_pulse_annotations + widen the dedupe index.
+
+a8a4f59e — the repo-pulse annotator gains a second reconciliation lane for
+standalone ``follow_ups`` rows alongside the existing ``session_ledger`` lane.
+Every annotation now records WHICH store its ``item_id`` addresses:
+
+  - ``target_kind`` — 'ledger' (existing rows backfill here via the DEFAULT) or
+    'follow_up'. Ledger and follow_up ids are both uuid4.hex, so the re-absorb
+    dedupe guard must scope by store: the UNIQUE index widens from
+    ``(tier, item_id, pr_number)`` to ``(tier, target_kind, item_id, pr_number)``.
+    Widening a unique index can only add distinctness, so existing (all-'ledger')
+    rows can never violate the new constraint.
+
+Additive + idempotent. The column ALTER is PRAGMA/duplicate-guarded; the index
+is DROP-then-CREATE (SQLite can't ALTER an index). Mirrored in
+``db/schema/_tables.py`` (CREATE carries the column; INDEXES carries the 4-col
+unique index) and ``_migrate_add_columns`` (the create_all_tables base path),
+per schema_both_build_paths. The runner owns the transaction — no commit here.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='repo_pulse_annotations'"
+    )
+    if not await cursor.fetchone():
+        return  # fresh DB — create_all_tables already carries the column + 4-col index
+
+    cursor = await db.execute("PRAGMA table_info(repo_pulse_annotations)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "target_kind" not in cols:
+        await db.execute(
+            "ALTER TABLE repo_pulse_annotations "
+            "ADD COLUMN target_kind TEXT NOT NULL DEFAULT 'ledger'"
+        )
+
+    # Widen the re-absorb dedupe guard to scope by store (ledger vs follow_up
+    # ids share the uuid4.hex shape). Drop the 3-col index, create the 4-col one.
+    await db.execute("DROP INDEX IF EXISTS idx_rpa_dedupe")
+    await db.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_rpa_dedupe "
+        "ON repo_pulse_annotations(tier, target_kind, item_id, pr_number)"
+    )
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='repo_pulse_annotations'"
+    )
+    if not await cursor.fetchone():
+        return
+    await db.execute("DROP INDEX IF EXISTS idx_rpa_dedupe")
+    await db.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_rpa_dedupe "
+        "ON repo_pulse_annotations(tier, item_id, pr_number)"
+    )
+    cursor = await db.execute("PRAGMA table_info(repo_pulse_annotations)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "target_kind" in cols:
+        await db.execute("ALTER TABLE repo_pulse_annotations DROP COLUMN target_kind")

--- a/src/genesis/db/migrations/0084_repo_pulse_target_kind.py
+++ b/src/genesis/db/migrations/0084_repo_pulse_target_kind.py
@@ -54,6 +54,11 @@ async def down(db: aiosqlite.Connection) -> None:
     if not await cursor.fetchone():
         return
     await db.execute("DROP INDEX IF EXISTS idx_rpa_dedupe")
+    # The widened index admitted rows the narrow one can't: a ledger and a
+    # follow_up annotation sharing (tier, item_id, pr_number) would violate the
+    # recreated 3-col UNIQUE. The follow_up-target rows are THIS migration's own
+    # data, so purge them (while the column still exists) before narrowing.
+    await db.execute("DELETE FROM repo_pulse_annotations WHERE target_kind = 'follow_up'")
     await db.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_rpa_dedupe "
         "ON repo_pulse_annotations(tier, item_id, pr_number)"

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -195,6 +195,14 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "ALTER TABLE follow_ups ADD COLUMN dedup_key TEXT",
         "follow_ups.dedup_key")
 
+    # a8a4f59e: which store a repo-pulse annotation's item_id addresses
+    # ('ledger' | 'follow_up'). The index swap to the 4-col dedupe guard is
+    # owned by migration 0084 (SQLite can't ALTER an index); this base-path
+    # ALTER only guarantees the column lands for schema_both_build_paths.
+    await _try_alter(db,
+        "ALTER TABLE repo_pulse_annotations ADD COLUMN target_kind TEXT NOT NULL DEFAULT 'ledger'",
+        "repo_pulse_annotations.target_kind")
+
     # Phase 9: thread_id on cc_sessions (for forum topic multi-session)
     await _try_alter(db,
         "ALTER TABLE cc_sessions ADD COLUMN thread_id TEXT",

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -196,12 +196,24 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
         "follow_ups.dedup_key")
 
     # a8a4f59e: which store a repo-pulse annotation's item_id addresses
-    # ('ledger' | 'follow_up'). The index swap to the 4-col dedupe guard is
-    # owned by migration 0084 (SQLite can't ALTER an index); this base-path
-    # ALTER only guarantees the column lands for schema_both_build_paths.
+    # ('ledger' | 'follow_up').
     await _try_alter(db,
         "ALTER TABLE repo_pulse_annotations ADD COLUMN target_kind TEXT NOT NULL DEFAULT 'ledger'",
         "repo_pulse_annotations.target_kind")
+    # ...and widen its dedupe index HERE too, not only in migration 0084: the
+    # INDEXES pass below uses CREATE ... IF NOT EXISTS, which cannot replace an
+    # already-existing 3-col idx_rpa_dedupe. Without this, a legacy DB upgraded
+    # via create_all_tables (whichever runs first vs the numbered runner) keeps
+    # the 3-col UNIQUE and INSERT OR IGNORE silently drops one store's annotation
+    # for a shared (tier,item_id,pr). Safe: a pre-0084 DB has no follow_up-target
+    # rows yet, so the narrower->wider swap can't collide. Best-effort (0084 is
+    # the authoritative swap); runs after the column ALTER so the 4-col ref is valid.
+    with contextlib.suppress(Exception):
+        await db.execute("DROP INDEX IF EXISTS idx_rpa_dedupe")
+        await db.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_rpa_dedupe "
+            "ON repo_pulse_annotations(tier, target_kind, item_id, pr_number)"
+        )
 
     # Phase 9: thread_id on cc_sessions (for forum topic multi-session)
     await _try_alter(db,

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1983,7 +1983,10 @@ TABLES = {
                             CHECK(status IN ('applied','proposed','confirmed',
                                              'rejected','superseded')),
             resolved_at     TEXT,
-            resolution_ref  TEXT
+            resolution_ref  TEXT,
+            -- 'ledger' | 'follow_up' — which store item_id addresses (a8a4f59e).
+            -- LAST column: ALTER appends here, so fresh/migrated order stays in parity.
+            target_kind     TEXT NOT NULL DEFAULT 'ledger'
         )
     """,
     # ── WS-2 sensor fabric (M9/M10) ──────────────────────────────────────
@@ -2566,7 +2569,7 @@ INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_slse_session ON session_ledger_shadow_events(session_id, observed_at)",
     "CREATE INDEX IF NOT EXISTS idx_slse_observed ON session_ledger_shadow_events(observed_at)",
     "CREATE UNIQUE INDEX IF NOT EXISTS idx_rpa_dedupe "
-    "ON repo_pulse_annotations(tier, item_id, pr_number)",
+    "ON repo_pulse_annotations(tier, target_kind, item_id, pr_number)",
     "CREATE INDEX IF NOT EXISTS idx_rpa_status ON repo_pulse_annotations(status, observed_at)",
     "CREATE INDEX IF NOT EXISTS idx_rpa_session ON repo_pulse_annotations(item_session_id, status)",
     "CREATE INDEX IF NOT EXISTS idx_rpr_started ON repo_pulse_runs(started_at)",

--- a/src/genesis/session_awareness/repo_pulse.py
+++ b/src/genesis/session_awareness/repo_pulse.py
@@ -50,6 +50,12 @@ MARKER_RE = re.compile(r"[Ll]edger:\s*([0-9a-f]{32})(?![0-9a-fA-F])")
 # Bare 32-hex token — context citation, proposal-only. Lookarounds reject
 # tokens embedded in longer hex runs (40-hex SHAs).
 BARE_HEX_RE = re.compile(r"(?<![0-9a-fA-F])([0-9a-f]{32})(?![0-9a-fA-F])")
+# `Follow-up: <32-hex>` marker — the standalone-follow_up completion citation
+# (a8a4f59e), mirroring `Ledger:`. Two human-typed words, so the PREFIX is fully
+# case-insensitive (`(?i:...)`) and the hyphen optional (Follow-up/follow-up/
+# FOLLOW-UP/Followup); the hex stays lowercase-strict (uuid4.hex) and the
+# trailing lookahead keeps a 40-hex SHA from half-matching.
+FOLLOWUP_MARKER_RE = re.compile(r"(?i:follow-?up):\s*([0-9a-f]{32})(?![0-9a-fA-F])")
 
 _HEX32_RE = re.compile(r"[0-9a-f]{32}")
 _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$")
@@ -91,6 +97,11 @@ def extract_bare_ids(text: str) -> set[str]:
     return set(BARE_HEX_RE.findall(text or ""))
 
 
+def extract_followup_marker_ids(text: str) -> set[str]:
+    """32-hex ids cited with the explicit ``Follow-up:`` completion marker."""
+    return set(FOLLOWUP_MARKER_RE.findall(text or ""))
+
+
 def build_item_index(open_items: list[dict]) -> dict[str, dict]:
     """Map every addressable 32-hex token to its open ledger row.
 
@@ -123,7 +134,42 @@ def match_exact(prs: list[dict], open_items: list[dict]) -> list[dict]:
     for pr in prs:
         text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
         marker_ids = extract_marker_ids(text)
-        bare_ids = extract_bare_ids(text) - marker_ids
+        # A `Follow-up: <id>` citation is owned by the follow-up lane; its hex
+        # must not double as a ledger bare-hex proposal (de-collision, a8a4f59e).
+        bare_ids = extract_bare_ids(text) - marker_ids - extract_followup_marker_ids(text)
+        seen_items: set[str] = set()
+        for token in sorted(marker_ids):
+            item = index.get(token)
+            if item is not None and item["id"] not in seen_items:
+                seen_items.add(item["id"])
+                matches.append({"item": item, "pr": pr, "via": "marker"})
+        for token in sorted(bare_ids):
+            item = index.get(token)
+            if item is not None and item["id"] not in seen_items:
+                seen_items.add(item["id"])
+                matches.append({"item": item, "pr": pr, "via": "bare"})
+    return matches
+
+
+def match_followup(prs: list[dict], followups: list[dict]) -> list[dict]:
+    """Deterministic id-citation matches for standalone ``follow_ups`` rows.
+
+    The follow-up analogue of ``match_exact``: ``via='marker'`` (a
+    ``Follow-up: <id>`` citation) is absorb-eligible; ``via='bare'`` (a bare
+    32-hex token) is proposal-only. Follow_up rows have NO ``source_ref`` — they
+    are addressed by ``id`` alone (so no ``build_item_index`` source-token
+    layer). Bare tokens carried by EITHER convention's marker (``Follow-up:`` or
+    ``Ledger:``) are excluded, so a marker citation never doubles as a bare
+    proposal. One match per (follow_up, pr) pair; a marker hit swallows the same
+    pair's bare hit. Result dicts share ``match_exact``'s ``{item, pr, via}``
+    shape so the worker treats both lanes uniformly.
+    """
+    index = {str(f["id"]): f for f in followups if f.get("id")}
+    matches: list[dict] = []
+    for pr in prs:
+        text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
+        marker_ids = extract_followup_marker_ids(text)
+        bare_ids = extract_bare_ids(text) - marker_ids - extract_marker_ids(text)
         seen_items: set[str] = set()
         for token in sorted(marker_ids):
             item = index.get(token)

--- a/src/genesis/session_awareness/repo_pulse.py
+++ b/src/genesis/session_awareness/repo_pulse.py
@@ -51,11 +51,14 @@ MARKER_RE = re.compile(r"[Ll]edger:\s*([0-9a-f]{32})(?![0-9a-fA-F])")
 # tokens embedded in longer hex runs (40-hex SHAs).
 BARE_HEX_RE = re.compile(r"(?<![0-9a-fA-F])([0-9a-f]{32})(?![0-9a-fA-F])")
 # `Follow-up: <32-hex>` marker — the standalone-follow_up completion citation
-# (a8a4f59e), mirroring `Ledger:`. Two human-typed words, so the PREFIX is fully
-# case-insensitive (`(?i:...)`) and the hyphen optional (Follow-up/follow-up/
-# FOLLOW-UP/Followup); the hex stays lowercase-strict (uuid4.hex) and the
-# trailing lookahead keeps a 40-hex SHA from half-matching.
-FOLLOWUP_MARKER_RE = re.compile(r"(?i:follow-?up):\s*([0-9a-f]{32})(?![0-9a-fA-F])")
+# (a8a4f59e). ANCHORED to line-start (`^[ \t]*`, MULTILINE): "follow-up" is
+# ordinary English, so an inline/negated mention ("this is not a follow-up: …")
+# must NOT trip the destructive live auto-complete — the documented convention
+# is "on its own line", and an unanchored id still lands as a bare-hex PROPOSAL
+# (non-destructive). Prefix case-insensitive, hyphen optional (Follow-up/
+# follow-up/FOLLOW-UP/Followup); hex lowercase-strict (uuid4.hex); trailing
+# lookahead keeps a 40-hex SHA from half-matching.
+FOLLOWUP_MARKER_RE = re.compile(r"(?im:^[ \t]*follow-?up):\s*([0-9a-f]{32})(?![0-9a-fA-F])")
 
 _HEX32_RE = re.compile(r"[0-9a-f]{32}")
 _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$")

--- a/src/genesis/session_awareness/repo_pulse.py
+++ b/src/genesis/session_awareness/repo_pulse.py
@@ -51,14 +51,16 @@ MARKER_RE = re.compile(r"[Ll]edger:\s*([0-9a-f]{32})(?![0-9a-fA-F])")
 # tokens embedded in longer hex runs (40-hex SHAs).
 BARE_HEX_RE = re.compile(r"(?<![0-9a-fA-F])([0-9a-f]{32})(?![0-9a-fA-F])")
 # `Follow-up: <32-hex>` marker — the standalone-follow_up completion citation
-# (a8a4f59e). ANCHORED to line-start (`^[ \t]*`, MULTILINE): "follow-up" is
-# ordinary English, so an inline/negated mention ("this is not a follow-up: …")
-# must NOT trip the destructive live auto-complete — the documented convention
-# is "on its own line", and an unanchored id still lands as a bare-hex PROPOSAL
-# (non-destructive). Prefix case-insensitive, hyphen optional (Follow-up/
-# follow-up/FOLLOW-UP/Followup); hex lowercase-strict (uuid4.hex); trailing
-# lookahead keeps a 40-hex SHA from half-matching.
-FOLLOWUP_MARKER_RE = re.compile(r"(?im:^[ \t]*follow-?up):\s*([0-9a-f]{32})(?![0-9a-fA-F])")
+# (a8a4f59e). Anchored at BOTH ends (`^[ \t]*…[ \t]*$`, MULTILINE) to enforce the
+# documented "on its own line" convention: "follow-up" is ordinary English, so
+# neither an inline/negated mention ("this is not a follow-up: <id>") NOR a
+# trailing qualification ("Follow-up: <id> — context only") may trip the
+# destructive live auto-complete; both fall through to a non-destructive bare-hex
+# PROPOSAL. Prefix case-insensitive + hyphen-optional (Follow-up/follow-up/
+# FOLLOW-UP/Followup); the id is same-line only ([ \t]*, not \s*) and
+# lowercase-strict (uuid4.hex); the end anchor also rejects a 40-hex SHA (its
+# 32-prefix can't sit at line end).
+FOLLOWUP_MARKER_RE = re.compile(r"^[ \t]*(?i:follow-?up):[ \t]*([0-9a-f]{32})[ \t]*$", re.MULTILINE)
 
 _HEX32_RE = re.compile(r"[0-9a-f]{32}")
 _FENCE_RE = re.compile(r"^\s*```(?:json)?\s*|\s*```\s*$")
@@ -124,6 +126,16 @@ def build_item_index(open_items: list[dict]) -> dict[str, dict]:
     return index
 
 
+def _pr_text(pr: dict) -> str:
+    """PR title+body as one newline-normalized block. GitHub normalizes PR-body
+    textarea input to CRLF, so a real ``Follow-up: <id>\\r\\n`` line has a stray
+    ``\\r`` between the id and ``\\n`` that the line-anchored ``FOLLOWUP_MARKER_RE``
+    (``[ \\t]*$``) cannot match. Collapsing ``\\r\\n``/``\\r`` to ``\\n`` keeps the
+    marker working on real GitHub input (bare/ledger matching is unaffected)."""
+    text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def match_exact(prs: list[dict], open_items: list[dict]) -> list[dict]:
     """Deterministic id-citation matches: ``via='marker'`` or ``via='bare'``.
 
@@ -135,7 +147,7 @@ def match_exact(prs: list[dict], open_items: list[dict]) -> list[dict]:
     index = build_item_index(open_items)
     matches: list[dict] = []
     for pr in prs:
-        text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
+        text = _pr_text(pr)
         marker_ids = extract_marker_ids(text)
         # A `Follow-up: <id>` citation is owned by the follow-up lane; its hex
         # must not double as a ledger bare-hex proposal (de-collision, a8a4f59e).
@@ -170,7 +182,7 @@ def match_followup(prs: list[dict], followups: list[dict]) -> list[dict]:
     index = {str(f["id"]): f for f in followups if f.get("id")}
     matches: list[dict] = []
     for pr in prs:
-        text = f"{pr.get('title') or ''}\n{pr.get('body') or ''}"
+        text = _pr_text(pr)
         marker_ids = extract_followup_marker_ids(text)
         bare_ids = extract_bare_ids(text) - marker_ids - extract_marker_ids(text)
         seen_items: set[str] = set()

--- a/src/genesis/session_awareness/repo_pulse_worker.py
+++ b/src/genesis/session_awareness/repo_pulse_worker.py
@@ -235,8 +235,7 @@ async def _load_open_followups(db_path: Path | str) -> list[dict] | None:
             )
             if not await cur.fetchone():
                 return []  # pre-migration / bare DB — nothing to reconcile, skip
-            rows = await followups_crud.get_pending(db, include_tabled=False)
-            rows += await followups_crud.get_by_status(db, "in_progress", include_tabled=False)
+            rows = await followups_crud.get_open_followups(db)  # ONE consistent snapshot
     except Exception:
         return None
     rows.sort(key=lambda r: str(r.get("created_at") or ""), reverse=True)

--- a/src/genesis/session_awareness/repo_pulse_worker.py
+++ b/src/genesis/session_awareness/repo_pulse_worker.py
@@ -699,7 +699,9 @@ async def _run_locked(
                         f"PR #{pr['number']}: {str(pr.get('title') or '')[:120]} "
                         f"(merged {pr.get('mergedAt')}) [repo-pulse follow-up]"
                     )
-                    if await followups_crud.absorb_followup(db, item["id"], evidence=evidence):
+                    if await followups_crud.absorb_followup(
+                        db, item["id"], evidence=evidence, require_unpinned=True
+                    ):
                         annotations.append(
                             _followup_annotation("applied", item, pr, rationale="follow-up-marker")
                         )

--- a/src/genesis/session_awareness/repo_pulse_worker.py
+++ b/src/genesis/session_awareness/repo_pulse_worker.py
@@ -39,6 +39,7 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+from genesis.db.crud import follow_ups as followups_crud
 from genesis.db.crud import repo_pulse as pulse_crud
 from genesis.db.crud.session_charters import ledger_all, ledger_update
 from genesis.env import genesis_db_path
@@ -49,6 +50,7 @@ from genesis.session_awareness.repo_pulse import (
     PULSE_TIMEOUT_S,
     build_fuzzy_prompt,
     match_exact,
+    match_followup,
     parse_matches,
 )
 from genesis.session_awareness.repo_pulse_config import (
@@ -210,6 +212,37 @@ async def _load_open_items(db_path: Path | str) -> list[dict] | None:
     return open_rows
 
 
+async def _load_open_followups(db_path: Path | str) -> list[dict] | None:
+    """Open HOT follow_up rows (kind='follow_up', pending/in_progress), newest first.
+
+    The follow-up analogue of _load_open_items. Fail-closed on a genuine read
+    failure (None → keep the cursor, re-cover next run). But a MISSING follow_ups
+    table is a pre-migration/bootstrap state, NOT a read failure — there are no
+    follow-ups to reconcile, so it returns [] (skip the lane) rather than failing
+    an otherwise-good run (mirrors the pulse-store pre-migration guard). Excludes
+    the cold 'tabled' lane and terminal rows; pinned rows ARE loaded (a marker
+    hit on a pinned row is a proposal, never an auto-absorb — the caller
+    enforces that). Union of pending + in_progress matches ``absorb_followup``'s
+    WHERE clause.
+    """
+    import aiosqlite
+
+    try:
+        async with aiosqlite.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5) as db:
+            db.row_factory = aiosqlite.Row
+            cur = await db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='follow_ups'"
+            )
+            if not await cur.fetchone():
+                return []  # pre-migration / bare DB — nothing to reconcile, skip
+            rows = await followups_crud.get_pending(db, include_tabled=False)
+            rows += await followups_crud.get_by_status(db, "in_progress", include_tabled=False)
+    except Exception:
+        return None
+    rows.sort(key=lambda r: str(r.get("created_at") or ""), reverse=True)
+    return rows
+
+
 async def _reconcile(db_path: Path | str, now_iso: str) -> dict[str, int]:
     """Sweep 'proposed' annotations against the current ledger state.
 
@@ -231,7 +264,15 @@ async def _reconcile(db_path: Path | str, now_iso: str) -> dict[str, int]:
                 return counts
             ledger = {r["id"]: r for r in await ledger_all(db)}
             for ann in proposed:
-                resolution = _resolution_for(ann, ledger.get(ann["item_id"]), now_iso)
+                # Dispatch by store: a follow_up-target proposal must be
+                # resolved against follow_up state, NOT the ledger dict (else it
+                # is 'item_missing' → superseded every run — the architect
+                # BLOCKER). This IS the per-store filter for the ledger read too.
+                if (ann.get("target_kind") or "ledger") == "follow_up":
+                    fu = await followups_crud.get_by_id(db, ann["item_id"])
+                    resolution = _followup_resolution_for(ann, fu, now_iso)
+                else:
+                    resolution = _resolution_for(ann, ledger.get(ann["item_id"]), now_iso)
                 if resolution is None:
                     continue
                 status, ref = resolution
@@ -264,6 +305,33 @@ def _resolution_for(ann: dict, item: dict | None, now_iso: str) -> tuple[str, st
     return None
 
 
+def _followup_resolution_for(ann: dict, item: dict | None, now_iso: str) -> tuple[str, str] | None:
+    """Resolution mapping for a follow_up-target proposal — the follow-up
+    analogue of _resolution_for, reading follow_up state (NOT ledger). Without
+    this, the reconcile sweep looks a follow_up id up in the ledger dict, finds
+    nothing, and supersedes the proposal every run (the architect BLOCKER).
+
+    completed-with-this-PR-evidence → confirmed; completed otherwise →
+    superseded (shipped, not attributed); failed → rejected; deleted → superseded
+    (missing); still-open past STALE_PROPOSAL_DAYS → superseded (stale).
+    """
+    if item is None:
+        return "superseded", "followup_missing"
+    status = item.get("status")
+    if status == "completed":
+        if _evidence_names_pr(item.get("resolution_notes"), ann["pr_number"]):
+            return "confirmed", f"completed with PR #{ann['pr_number']} evidence"
+        return "superseded", "completed_via_other_evidence"
+    if status == "failed":
+        return "rejected", "followup_failed"
+    # pending / in_progress / blocked / scheduled — leave live proposals until stale
+    observed = _parse_iso(ann.get("observed_at") or "")
+    now_dt = _parse_iso(now_iso)
+    if observed and now_dt and (now_dt - observed) > timedelta(days=STALE_PROPOSAL_DAYS):
+        return "superseded", f"stale_{STALE_PROPOSAL_DAYS}d"
+    return None
+
+
 def _annotation(tier: str, status: str, item: dict, pr: dict, **over) -> dict:
     ann = {
         "id": uuid.uuid4().hex,
@@ -280,6 +348,18 @@ def _annotation(tier: str, status: str, item: dict, pr: dict, **over) -> dict:
         "status": status,
     }
     ann.update(over)
+    return ann
+
+
+def _followup_annotation(status: str, item: dict, pr: dict, **over) -> dict:
+    """Build a follow_up-target annotation. Reuses _annotation for the common
+    fields, then stamps target_kind and overrides the item-shape-divergent
+    columns: follow_ups carry ``content``/``source_session``, not
+    ``text``/``session_id``. Follow-up lane is exact-only, so tier is 'exact'."""
+    ann = _annotation("exact", status, item, pr, **over)
+    ann["target_kind"] = "follow_up"
+    ann["item_text"] = str(item.get("content") or "")[:300]
+    ann["item_session_id"] = item.get("source_session")
     return ann
 
 
@@ -569,6 +649,91 @@ async def _run_locked(
                     annotations.append(
                         _annotation("exact", "proposed", item, pr, rationale="bare-hex")
                     )
+
+    # ── follow-up lane (a8a4f59e) ────────────────────────────────────────
+    # Exact-marker reconciliation of standalone HOT follow_up rows, mirroring
+    # the ledger exact tier and riding the SAME already-fetched `prs`. Fuzzy is
+    # deferred (hundreds of open rows x MAX_ITEMS=40 would be a lottery;
+    # marker/bare-hex is self-scoping). A failed follow_up snapshot is
+    # fail-closed like the ledger one: keep the cursor, re-cover next run (the
+    # ledger exact writes already happened and are re-absorb-guarded).
+    followup_items = await _load_open_followups(db_path)
+    if followup_items is None:
+        detail_notes.append("followup_read_failed")
+        recorded = await _record_run(
+            db_path,
+            **_base_row(
+                status="failed",
+                repo=repo,
+                n_prs=len(prs),
+                n_open_items=len(open_items),
+                n_exact=n_exact,
+            ),
+            annotations=annotations,
+        )
+        if recorded:
+            _write_cursor(root, cursor, merged_at=None)
+        await _record_telemetry(db_path, "failed", "followup_read_failed")
+        return {"status": "failed", "detail": "followup_read_failed", "n_exact": n_exact}
+
+    n_followup = 0
+    followup_matches = match_followup(prs, followup_items)
+    if followup_matches:
+        import aiosqlite
+
+        async with aiosqlite.connect(str(db_path), timeout=10) as db:
+            await db.execute("PRAGMA busy_timeout=5000")
+            db.row_factory = aiosqlite.Row
+            if not await pulse_crud.tables_available(db):
+                followup_matches = []
+            for m in followup_matches:
+                item, pr, via = m["item"], m["pr"], m["via"]
+                if await pulse_crud.annotation_exists(
+                    db, "exact", item["id"], pr["number"], target_kind="follow_up"
+                ):
+                    continue  # per-store re-absorb guard
+                n_followup += 1
+                pinned = bool(item.get("pinned"))
+                if via == "marker" and mode == "live" and not pinned:
+                    evidence = (
+                        f"PR #{pr['number']}: {str(pr.get('title') or '')[:120]} "
+                        f"(merged {pr.get('mergedAt')}) [repo-pulse follow-up]"
+                    )
+                    if await followups_crud.absorb_followup(db, item["id"], evidence=evidence):
+                        annotations.append(
+                            _followup_annotation("applied", item, pr, rationale="follow-up-marker")
+                        )
+                        continue
+                    # Absorb no-op: the row moved off open between load and now
+                    # (concurrent writer) — record a proposal, not a false absorb.
+                    annotations.append(
+                        _followup_annotation(
+                            "proposed", item, pr, rationale="follow-up-marker (absorb missed)"
+                        )
+                    )
+                elif via == "marker" and pinned:
+                    # Pinned invariant: automation never auto-resolves a pinned
+                    # row — a marker hit is a proposal a human confirms.
+                    annotations.append(
+                        _followup_annotation(
+                            "proposed",
+                            item,
+                            pr,
+                            rationale="follow-up-marker (pinned, proposal-only)",
+                        )
+                    )
+                elif via == "marker":  # propose_only mode
+                    annotations.append(
+                        _followup_annotation(
+                            "proposed", item, pr, rationale="follow-up-marker (propose_only)"
+                        )
+                    )
+                else:  # bare hex — context citation, proposal-only
+                    annotations.append(
+                        _followup_annotation("proposed", item, pr, rationale="bare-hex")
+                    )
+    if followup_items:
+        detail_notes.append(f"followup exact={n_followup}/{len(followup_items)} open")
 
     remaining = [i for i in open_items if i["id"] not in absorbed]
     n_fuzzy = 0

--- a/src/genesis/session_awareness/repo_pulse_worker.py
+++ b/src/genesis/session_awareness/repo_pulse_worker.py
@@ -700,11 +700,18 @@ async def _run_locked(
                         f"(merged {pr.get('mergedAt')}) [repo-pulse follow-up]"
                     )
                     if await followups_crud.absorb_followup(
-                        db, item["id"], evidence=evidence, require_unpinned=True
+                        db, item["id"], evidence=evidence, require_unpinned=True, commit=False
                     ):
-                        annotations.append(
-                            _followup_annotation("applied", item, pr, rationale="follow-up-marker")
+                        applied = _followup_annotation(
+                            "applied", item, pr, rationale="follow-up-marker"
                         )
+                        # Commit the completion + its audit annotation ATOMICALLY
+                        # (one transaction): a crash before the end-of-run
+                        # _record_run can then never orphan either — no completed
+                        # follow_up without its annotation (Codex P1). The later
+                        # _record_run re-write is an INSERT OR IGNORE no-op.
+                        await pulse_crud.insert_annotation(db, applied, run_id=run_id, commit=True)
+                        annotations.append(applied)
                         continue
                     # Absorb no-op: the row moved off open between load and now
                     # (concurrent writer) — record a proposal, not a false absorb.

--- a/tests/test_dashboard/test_cc_sessions_routes.py
+++ b/tests/test_dashboard/test_cc_sessions_routes.py
@@ -550,6 +550,44 @@ async def test_pulse_confirm_absorbs_item_with_pr_evidence(db):
     assert "PR #1081" in row["evidence"]
 
 
+async def _seed_followup_proposal(db, *, ann_id="af1", fu_id="fu0", status="proposed"):
+    await db.execute(
+        "INSERT INTO follow_ups (id, source, content, reason, strategy, status, "
+        "priority, kind, created_at) VALUES (?, 'test', 'ship it', 'r', "
+        "'ego_judgment', 'pending', 'medium', 'follow_up', '2026-07-10T00:00:00+00:00')",
+        (fu_id,),
+    )
+    await db.execute(
+        "INSERT INTO repo_pulse_runs (run_id, started_at, trigger, status)"
+        " VALUES ('rf1', '2026-07-14T00:00:00+00:00', 'manual', 'ok')"
+    )
+    await db.execute(
+        "INSERT INTO repo_pulse_annotations (id, run_id, observed_at, tier, item_id,"
+        " item_session_id, item_text, pr_number, pr_title, status, target_kind)"
+        " VALUES (?, 'rf1', '2026-07-14T00:00:00+00:00', 'exact', ?,"
+        " 'cc-xyz', 'ship it', 1305, 'feat: officecli', ?, 'follow_up')",
+        (ann_id, fu_id, status),
+    )
+    await db.commit()
+
+
+async def test_pulse_confirm_absorbs_followup_target(db):
+    """A follow_up-target annotation confirmed via the dashboard absorbs the
+    FOLLOW_UP (conditional open-only), not a nonexistent ledger row — the
+    reader-dispatch obligation from the foundation audit."""
+    from genesis.dashboard.routes.cc_sessions import _resolve_pulse
+
+    await _seed_followup_proposal(db)
+    payload, code = await _resolve_pulse(db, "af1", "confirmed")
+    assert code == 200
+    assert payload["ok"] is True and payload["item_absorbed"] is True
+    assert await _ann_status(db, "af1") == "confirmed"
+    cur = await db.execute("SELECT status, resolution_notes FROM follow_ups WHERE id = 'fu0'")
+    row = await cur.fetchone()
+    assert row[0] == "completed"
+    assert "PR #1305" in row[1]
+
+
 async def test_pulse_reject_leaves_ledger_untouched(db):
     from genesis.dashboard.routes.cc_sessions import _resolve_pulse
 

--- a/tests/test_dashboard/test_cc_sessions_routes.py
+++ b/tests/test_dashboard/test_cc_sessions_routes.py
@@ -588,6 +588,19 @@ async def test_pulse_confirm_absorbs_followup_target(db):
     assert "PR #1305" in row[1]
 
 
+async def test_pulse_lookup_excludes_followup_proposals(db):
+    """The per-session pulse panel is ledger-only — a session-bound follow_up
+    annotation is NOT surfaced here (session-agnostic → separate global surface;
+    avoids the NULL-session gap + the ledger-only confirm command, Codex P2)."""
+    from genesis.dashboard.routes.cc_sessions import _pulse_lookup
+
+    await _seed_followup_proposal(db, ann_id="afx", fu_id="fux")  # item_session_id='cc-xyz'
+    out = await _pulse_lookup(db, "cc-xyz")
+    assert out["available"] is True
+    assert all(a["target_kind"] == "ledger" for a in out["annotations"])
+    assert not any(a["id"] == "afx" for a in out["annotations"])
+
+
 async def test_pulse_reject_leaves_ledger_untouched(db):
     from genesis.dashboard.routes.cc_sessions import _resolve_pulse
 

--- a/tests/test_dashboard/test_cc_sessions_routes.py
+++ b/tests/test_dashboard/test_cc_sessions_routes.py
@@ -601,6 +601,25 @@ async def test_pulse_lookup_excludes_followup_proposals(db):
     assert not any(a["id"] == "afx" for a in out["annotations"])
 
 
+async def test_pulse_confirm_followup_not_open_absorb_missed(db):
+    """Resolve-first: confirming a follow_up whose row moved off-open (blocked)
+    confirms the annotation (the race arbiter) but the absorb misses — 200,
+    item_absorbed False, follow_up NOT force-completed. The confirmed-but-absorb-
+    missed residue is accepted (ledger-consistent); absorb-first was reverted as
+    it reopened the worse absorbed-under-a-rejected-annotation residue."""
+    from genesis.dashboard.routes.cc_sessions import _resolve_pulse
+
+    await _seed_followup_proposal(db, ann_id="af2", fu_id="fu2")
+    await db.execute("UPDATE follow_ups SET status='blocked' WHERE id='fu2'")
+    await db.commit()
+    payload, code = await _resolve_pulse(db, "af2", "confirmed")
+    assert code == 200
+    assert payload["item_absorbed"] is False
+    assert await _ann_status(db, "af2") == "confirmed"  # resolve-first: annotation is the arbiter
+    cur = await db.execute("SELECT status FROM follow_ups WHERE id='fu2'")
+    assert (await cur.fetchone())[0] == "blocked"  # follow_up untouched (never force-completed)
+
+
 async def test_pulse_reject_leaves_ledger_untouched(db):
     from genesis.dashboard.routes.cc_sessions import _resolve_pulse
 

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -137,6 +137,20 @@ async def test_absorb_followup_require_unpinned_refuses_pinned(db):
     assert (await follow_ups.get_by_id(db, fid))["status"] == "completed"
 
 
+async def test_get_open_followups_single_snapshot(db):
+    """One consistent snapshot of the hot open lane: pending + in_progress,
+    kind='follow_up' only; tabled and terminal rows excluded."""
+    fp = await follow_ups.create(db, **_BASE)  # pending
+    fi = await follow_ups.create(db, **_BASE)
+    await follow_ups.update_status(db, fi, status="in_progress")
+    ft = await follow_ups.create(db, **_BASE)
+    await follow_ups.set_kind(db, ft, "tabled")  # cold lane — excluded
+    fc = await follow_ups.create(db, **_BASE)
+    await follow_ups.update_status(db, fc, status="completed")  # terminal — excluded
+    ids = {r["id"] for r in await follow_ups.get_open_followups(db)}
+    assert ids == {fp, fi}
+
+
 async def test_purge_failed_old(db):
     """Old failed follow-ups are also purged."""
     fid = await follow_ups.create(db, **_BASE)

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -114,6 +114,29 @@ async def test_absorb_followup_idempotent_replay(db):
     assert row["resolution_notes"].count("PR #7") == 1
 
 
+async def test_absorb_followup_refuses_tabled_kind(db):
+    """Atomic kind guard: the cold tabled/idea lane is never absorbed, even when
+    'pending' and even if a caller's snapshot was stale (Codex P2)."""
+    fid = await follow_ups.create(db, **_BASE)
+    await follow_ups.set_kind(db, fid, "tabled")
+    assert await follow_ups.absorb_followup(db, fid, evidence="PR #1") is False
+    assert (await follow_ups.get_by_id(db, fid))["status"] == "pending"
+
+
+async def test_absorb_followup_require_unpinned_refuses_pinned(db):
+    """require_unpinned=True (the worker's auto-absorb) refuses a pinned row
+    atomically — closing the load→UPDATE pin race. The dashboard path
+    (require_unpinned=False) can still complete a pinned row (human override)."""
+    fid = await follow_ups.create(db, **_BASE)
+    await follow_ups.set_pinned(db, fid, True)
+    assert (
+        await follow_ups.absorb_followup(db, fid, evidence="PR #1", require_unpinned=True)
+    ) is False
+    assert (await follow_ups.get_by_id(db, fid))["status"] == "pending"
+    assert await follow_ups.absorb_followup(db, fid, evidence="PR #1") is True
+    assert (await follow_ups.get_by_id(db, fid))["status"] == "completed"
+
+
 async def test_purge_failed_old(db):
     """Old failed follow-ups are also purged."""
     fid = await follow_ups.create(db, **_BASE)

--- a/tests/test_db/test_follow_ups.py
+++ b/tests/test_db/test_follow_ups.py
@@ -68,6 +68,52 @@ async def test_purge_completed_keeps_pending(db):
     assert row["status"] == "pending"
 
 
+# ── absorb_followup: repo-pulse conditional absorb (a8a4f59e) ─────────────
+
+
+async def test_absorb_followup_completes_open_row(db):
+    """A pending row is marked completed with PR evidence + completed_at."""
+    fid = await follow_ups.create(db, **_BASE)
+    changed = await follow_ups.absorb_followup(db, fid, evidence="PR #1305 [repo-pulse exact]")
+    assert changed is True
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "completed"
+    assert row["completed_at"]
+    assert "PR #1305" in row["resolution_notes"]
+
+
+async def test_absorb_followup_appends_not_overwrites_notes(db):
+    """Prior resolution_notes context is preserved (append, never clobber)."""
+    fid = await follow_ups.create(db, **_BASE)
+    await follow_ups.update_notes(db, fid, resolution_notes="earlier triage note")
+    await follow_ups.absorb_followup(db, fid, evidence="PR #42 evidence")
+    row = await follow_ups.get_by_id(db, fid)
+    assert "earlier triage note" in row["resolution_notes"]
+    assert "PR #42 evidence" in row["resolution_notes"]
+
+
+async def test_absorb_followup_skips_non_open_row(db):
+    """Lost-update safety: a row a concurrent writer moved off open (e.g.
+    'blocked') is NOT clobbered — the absorb no-ops and returns False."""
+    fid = await follow_ups.create(db, **_BASE)
+    await follow_ups.update_status(db, fid, status="blocked", blocked_reason="waiting")
+    changed = await follow_ups.absorb_followup(db, fid, evidence="PR #99")
+    assert changed is False
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["status"] == "blocked"
+    assert "PR #99" not in (row["resolution_notes"] or "")
+
+
+async def test_absorb_followup_idempotent_replay(db):
+    """A re-covered enumeration window absorbing the same row twice: the first
+    transitions it, the second matches nothing (already completed)."""
+    fid = await follow_ups.create(db, **_BASE)
+    assert await follow_ups.absorb_followup(db, fid, evidence="PR #7") is True
+    assert await follow_ups.absorb_followup(db, fid, evidence="PR #7 again") is False
+    row = await follow_ups.get_by_id(db, fid)
+    assert row["resolution_notes"].count("PR #7") == 1
+
+
 async def test_purge_failed_old(db):
     """Old failed follow-ups are also purged."""
     fid = await follow_ups.create(db, **_BASE)

--- a/tests/test_db/test_migration_0062_repo_pulse.py
+++ b/tests/test_db/test_migration_0062_repo_pulse.py
@@ -315,6 +315,27 @@ async def test_insert_annotation_single_row_and_dedup(db):
 
 
 @pytest.mark.asyncio
+async def test_base_path_migrate_add_columns_swaps_dedupe_index(db):
+    """The create_all_tables base path (_migrate_add_columns) also widens
+    idx_rpa_dedupe to the store-scoped 4-col index — not only migration 0084 — so
+    a legacy DB upgraded WITHOUT the numbered runner is store-correct (Codex P2)."""
+    from genesis.db.schema._migrations import _migrate_add_columns, create_all_tables
+
+    await create_all_tables(db)  # full base-path schema (so _migrate_add_columns has its tables)
+    # simulate a legacy install: force idx_rpa_dedupe back to the old 3-col shape
+    await db.execute("DROP INDEX IF EXISTS idx_rpa_dedupe")
+    await db.execute(
+        "CREATE UNIQUE INDEX idx_rpa_dedupe ON repo_pulse_annotations(tier, item_id, pr_number)"
+    )
+    cur = await db.execute("PRAGMA index_info(idx_rpa_dedupe)")
+    assert len(await cur.fetchall()) == 3
+    # re-running the base path must widen it (not only migration 0084)
+    await _migrate_add_columns(db)
+    cur = await db.execute("PRAGMA index_info(idx_rpa_dedupe)")
+    assert len(await cur.fetchall()) == 4  # widened on the base path
+
+
+@pytest.mark.asyncio
 async def test_pre_migration_guard_noops(db):
     """Subprocess writer against an un-migrated DB: no-op, no create, and
     the caller can see False (so it must NOT advance its cursor)."""

--- a/tests/test_db/test_migration_0062_repo_pulse.py
+++ b/tests/test_db/test_migration_0062_repo_pulse.py
@@ -276,6 +276,31 @@ async def test_target_kind_scopes_dedupe_and_existence(db):
 
 
 @pytest.mark.asyncio
+async def test_0084_down_purges_followup_rows_before_narrowing(db):
+    """down() must not fail when the widened index admitted a ledger+follow_up
+    pair sharing (tier, item_id, pr_number): the follow_up rows are purged before
+    the 3-col UNIQUE is recreated (Codex P2 — the narrower index would otherwise
+    raise UNIQUE constraint failed)."""
+    await M62.up(db)
+    await M84.up(db)
+    await crud.record_run(
+        db,
+        **_run_kwargs(run_id="r1"),
+        annotations=[
+            _annotation(id="a1", tier="exact", target_kind="ledger"),
+            _annotation(id="a2", tier="exact", target_kind="follow_up"),
+        ],
+    )
+    await M84.down(db)  # must NOT raise
+    anns = await crud.list_annotations(db)
+    assert {a["id"] for a in anns} == {"a1"}  # follow_up row purged, ledger kept
+    cur = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_rpa_dedupe'"
+    )
+    assert await cur.fetchone() is not None  # 3-col unique index recreated
+
+
+@pytest.mark.asyncio
 async def test_pre_migration_guard_noops(db):
     """Subprocess writer against an un-migrated DB: no-op, no create, and
     the caller can see False (so it must NOT advance its cursor)."""

--- a/tests/test_db/test_migration_0062_repo_pulse.py
+++ b/tests/test_db/test_migration_0062_repo_pulse.py
@@ -301,6 +301,20 @@ async def test_0084_down_purges_followup_rows_before_narrowing(db):
 
 
 @pytest.mark.asyncio
+async def test_insert_annotation_single_row_and_dedup(db):
+    """insert_annotation persists ONE annotation and is INSERT OR IGNORE — a
+    re-insert of the same row (as the end-of-run record_run does) is a no-op."""
+    await M62.up(db)
+    await M84.up(db)
+    await crud.record_run(db, **_run_kwargs(run_id="r1"))  # a run row to reference
+    ann = _annotation(id="s1", tier="exact", target_kind="follow_up", status="applied")
+    assert await crud.insert_annotation(db, ann, run_id="r1") is True
+    assert {a["id"] for a in await crud.list_annotations(db)} == {"s1"}
+    assert await crud.insert_annotation(db, ann, run_id="r1") is True  # OR IGNORE no-op
+    assert len(await crud.list_annotations(db)) == 1
+
+
+@pytest.mark.asyncio
 async def test_pre_migration_guard_noops(db):
     """Subprocess writer against an un-migrated DB: no-op, no create, and
     the caller can see False (so it must NOT advance its cursor)."""

--- a/tests/test_db/test_migration_0062_repo_pulse.py
+++ b/tests/test_db/test_migration_0062_repo_pulse.py
@@ -17,6 +17,10 @@ import pytest
 from genesis.db.crud import repo_pulse as crud
 
 M62 = importlib.import_module("genesis.db.migrations.0062_repo_pulse")
+# CRUD now writes target_kind (0084) — the CRUD-exercising tests below apply
+# both migrations; the 0062-isolation tests (columns/idempotent/down/guard)
+# deliberately apply M62 alone.
+M84 = importlib.import_module("genesis.db.migrations.0084_repo_pulse_target_kind")
 
 SID = "aaaabbbb-cccc-dddd-eeee-ffff00001111"
 ITEM = "0123456789abcdef0123456789abcdef"
@@ -172,6 +176,7 @@ async def test_status_and_tier_checks_enforced(db):
 @pytest.mark.asyncio
 async def test_record_run_with_annotations_roundtrip(db):
     await M62.up(db)
+    await M84.up(db)
     ok = await crud.record_run(db, **_run_kwargs(n_fuzzy=1), annotations=[_annotation()])
     assert ok is True
     runs = await crud.list_runs(db)
@@ -203,6 +208,7 @@ async def test_unique_index_dedupes_recovered_windows(db):
     """A re-covered enumeration window re-observing the same
     (tier, item_id, pr_number) match is absorbed, never duplicated."""
     await M62.up(db)
+    await M84.up(db)
     await crud.record_run(db, **_run_kwargs(run_id="r1"), annotations=[_annotation(id="a1")])
     await crud.record_run(
         db,
@@ -221,6 +227,7 @@ async def test_dedupe_does_not_resurrect_resolved_proposals(db):
     """Once a proposal is rejected, a later run re-observing the same match
     must NOT flip it back to proposed (INSERT OR IGNORE leaves it be)."""
     await M62.up(db)
+    await M84.up(db)
     await crud.record_run(db, **_run_kwargs(run_id="r1"), annotations=[_annotation(id="a1")])
     assert await crud.resolve_annotation(
         db, "a1", status="rejected", resolved_at="2026-07-16T13:00:00+00:00"
@@ -230,6 +237,42 @@ async def test_dedupe_does_not_resurrect_resolved_proposals(db):
     assert len(anns) == 1
     assert anns[0]["id"] == "a1"
     assert anns[0]["status"] == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_target_kind_scopes_dedupe_and_existence(db):
+    """The 4-col unique index (0084) scopes the re-absorb guard by store: a
+    ledger and a follow_up annotation sharing the same (tier, item_id,
+    pr_number) BOTH persist — ledger/follow_up ids are the same uuid4.hex shape
+    and must not collide — and annotation_exists isolates by target_kind."""
+    await M62.up(db)
+    await M84.up(db)
+    await crud.record_run(
+        db,
+        **_run_kwargs(run_id="r1"),
+        annotations=[
+            _annotation(id="a1", tier="exact", target_kind="ledger"),
+            _annotation(id="a2", tier="exact", target_kind="follow_up"),
+        ],
+    )
+    anns = await crud.list_annotations(db)
+    assert {a["id"] for a in anns} == {"a1", "a2"}  # NOT deduped across stores
+    assert {a["target_kind"] for a in anns} == {"ledger", "follow_up"}
+    # existence scopes by store: the same pair is present in BOTH lanes
+    assert await crud.annotation_exists(db, "exact", ITEM, 1080, target_kind="ledger")
+    assert await crud.annotation_exists(db, "exact", ITEM, 1080, target_kind="follow_up")
+    # a follow_up-only pair is invisible to the default (ledger) caller
+    other = "ffff0000ffff0000ffff0000ffff0000"
+    await crud.record_run(
+        db,
+        **_run_kwargs(run_id="r2"),
+        annotations=[_annotation(id="a3", tier="exact", item_id=other, target_kind="follow_up")],
+    )
+    assert not await crud.annotation_exists(db, "exact", other, 1080)  # default ledger
+    assert await crud.annotation_exists(db, "exact", other, 1080, target_kind="follow_up")
+    # target_kind filter on list
+    fu = await crud.list_annotations(db, target_kind="follow_up")
+    assert {a["id"] for a in fu} == {"a2", "a3"}
 
 
 @pytest.mark.asyncio
@@ -267,6 +310,7 @@ async def test_validation_rejects_bad_values_before_any_insert(db):
 @pytest.mark.asyncio
 async def test_resolve_annotation_lifecycle(db):
     await M62.up(db)
+    await M84.up(db)
     await crud.record_run(db, **_run_kwargs(), annotations=[_annotation(id="a1")])
     assert await crud.resolve_annotation(
         db,
@@ -288,6 +332,7 @@ async def test_resolve_annotation_lifecycle(db):
 @pytest.mark.asyncio
 async def test_resolve_rejects_applied_rows_and_bad_statuses(db):
     await M62.up(db)
+    await M84.up(db)
     await crud.record_run(
         db,
         **_run_kwargs(),
@@ -309,6 +354,7 @@ async def test_resolve_rejects_applied_rows_and_bad_statuses(db):
 @pytest.mark.asyncio
 async def test_summary_counts_and_precision(db):
     await M62.up(db)
+    await M84.up(db)
     await crud.record_run(
         db,
         **_run_kwargs(run_id="r1"),
@@ -340,6 +386,7 @@ async def test_summary_counts_and_precision(db):
 @pytest.mark.asyncio
 async def test_prune_deletes_old_runs_and_annotations(db):
     await M62.up(db)
+    await M84.up(db)
     await crud.record_run(
         db,
         **_run_kwargs(run_id="old", started_at="2026-05-01T00:00:00+00:00"),

--- a/tests/test_scripts/test_session_context_pulse.py
+++ b/tests/test_scripts/test_session_context_pulse.py
@@ -134,6 +134,24 @@ def test_only_this_sessions_proposals_and_only_proposed(tmp_path):
     assert "Pulse" not in _block(db_file)
 
 
+def test_followup_target_proposal_not_injected(tmp_path):
+    """A follow_up-target proposal is ledger-filtered out of the session pulse
+    injection — the rendered confirm command is session_ledger_update(...), which
+    can't resolve a follow_up id, so it must never surface here (Codex P2)."""
+    db_file = _make_db(tmp_path)
+    conn = sqlite3.connect(db_file)
+    conn.execute(
+        "INSERT INTO repo_pulse_annotations (id, run_id, observed_at, tier, item_id,"
+        " item_session_id, item_text, pr_number, pr_title, confidence, status, target_kind)"
+        " VALUES ('afu', 'r1', '2026-07-16T00:00:00+00:00', 'exact', 'fu-1', ?,"
+        " 'a follow up', 1305, 'feat: x', NULL, 'proposed', 'follow_up')",
+        (SID,),
+    )
+    conn.commit()
+    conn.close()
+    assert "Pulse" not in _block(db_file)  # the only proposal is follow_up → filtered
+
+
 def test_clear_emits_nothing(tmp_path):
     db_file = _make_db(tmp_path)
     _seed_proposal(db_file, "a1")

--- a/tests/test_session_awareness/test_repo_pulse.py
+++ b/tests/test_session_awareness/test_repo_pulse.py
@@ -241,3 +241,68 @@ def test_parse_injected_ids_in_reason_are_inert():
 def test_parse_int_confidence_accepted_and_rounded():
     out = rp.parse_matches(_envelope({"matches": [_good_match(confidence=1)]}), 3, 5)
     assert out[0]["confidence"] == 1.0
+
+
+# ── follow-up lane: exact-marker matching (a8a4f59e) ─────────────────────
+#
+# Standalone follow_up rows have NO source_ref — they match by id only. The
+# `Follow-up: <32-hex>` marker mirrors `Ledger:` for absorb-eligibility; bare
+# hex is proposal-only. Locks the marker contract + the bare-hex de-collision
+# with the ledger lane.
+
+
+def _fu(fu_id=FOLLOWUP, content="ship OfficeCLI deliverables", status="pending"):
+    """A standalone follow_up row as loaded by the worker (no source_ref)."""
+    return {"id": fu_id, "content": content, "status": status, "source_session": "sid-2"}
+
+
+def test_followup_marker_in_body_matches():
+    matches = rp.match_followup([_pr(body=f"Ships it.\n\nFollow-up: {FOLLOWUP}")], [_fu()])
+    assert len(matches) == 1
+    assert matches[0]["via"] == "marker"
+    assert matches[0]["item"]["id"] == FOLLOWUP
+    assert matches[0]["pr"]["number"] == 1080
+
+
+def test_followup_marker_hyphen_optional_and_case_insensitive():
+    for body in (f"Followup: {FOLLOWUP}", f"follow-up: {FOLLOWUP}", f"FOLLOW-UP: {FOLLOWUP}"):
+        matches = rp.match_followup([_pr(body=body)], [_fu()])
+        assert [m["via"] for m in matches] == ["marker"], body
+
+
+def test_followup_bare_hex_is_proposal_only():
+    matches = rp.match_followup([_pr(body=f"relates to {FOLLOWUP} from triage")], [_fu()])
+    assert [m["via"] for m in matches] == ["bare"]
+
+
+def test_followup_marker_swallows_bare_same_pair():
+    body = f"Follow-up: {FOLLOWUP}\n\nalso {FOLLOWUP} again in prose"
+    matches = rp.match_followup([_pr(body=body)], [_fu()])
+    assert [m["via"] for m in matches] == ["marker"]
+
+
+def test_followup_unknown_id_and_empty_no_match():
+    assert rp.match_followup([_pr(body=f"Follow-up: {ITEM_B}")], [_fu()]) == []
+    assert rp.match_followup([_pr(body=""), _pr(body=None)], [_fu()]) == []
+    assert rp.match_followup([_pr(body=f"Follow-up: {FOLLOWUP}")], []) == []
+
+
+def test_followup_40hex_sha_never_matches():
+    body = f"Follow-up: {SHA40}"
+    assert rp.match_followup([_pr(body=body)], [_fu(fu_id=SHA40[:32])]) == []
+
+
+def test_ledger_bare_excludes_followup_marked_id():
+    """De-collision: a `Follow-up: X` in a PR must NOT also raise a ledger
+    bare-hex proposal for a ledger row whose source_ref carries X — the
+    follow-up lane owns that citation."""
+    ledger_row = _item(source_ref=f"tracks follow-up {FOLLOWUP}")
+    matches = rp.match_exact([_pr(body=f"Follow-up: {FOLLOWUP}")], [ledger_row])
+    assert matches == []
+
+
+def test_followup_bare_excludes_ledger_marked_id():
+    """Symmetric: a `Ledger: X` citation is not a follow-up bare proposal even
+    if X coincidentally equals a follow_up id."""
+    matches = rp.match_followup([_pr(body=f"Ledger: {FOLLOWUP}")], [_fu()])
+    assert matches == []

--- a/tests/test_session_awareness/test_repo_pulse.py
+++ b/tests/test_session_awareness/test_repo_pulse.py
@@ -321,3 +321,15 @@ def test_followup_marker_must_be_line_anchored():
         f"shipped it\nFollow-up: {FOLLOWUP}",
     ):
         assert [m["via"] for m in rp.match_followup([_pr(body=body)], [_fu()])] == ["marker"], body
+    # trailing text after the id → NOT a marker (BOTH ends anchored) — lands as a
+    # non-destructive bare proposal, never a live auto-complete
+    for body in (
+        f"Follow-up: {FOLLOWUP} (already done separately)",
+        f"Follow-up: {FOLLOWUP} # context only",
+        f"Follow-up: {FOLLOWUP}.",
+    ):
+        assert [m["via"] for m in rp.match_followup([_pr(body=body)], [_fu()])] == ["bare"], body
+    # real GitHub PR bodies are CRLF — the line-anchored marker must still fire
+    # (the `\r` before `\n` is normalized away), else auto-absorb silently dies
+    for body in (f"Follow-up: {FOLLOWUP}\r\n", f"done\r\nFollow-up: {FOLLOWUP}\r\nmore\r\n"):
+        assert [m["via"] for m in rp.match_followup([_pr(body=body)], [_fu()])] == ["marker"], body

--- a/tests/test_session_awareness/test_repo_pulse.py
+++ b/tests/test_session_awareness/test_repo_pulse.py
@@ -306,3 +306,18 @@ def test_followup_bare_excludes_ledger_marked_id():
     if X coincidentally equals a follow_up id."""
     matches = rp.match_followup([_pr(body=f"Ledger: {FOLLOWUP}")], [_fu()])
     assert matches == []
+
+
+def test_followup_marker_must_be_line_anchored():
+    """`Follow-up:` is only a live marker on its own line — an inline/negated
+    mention falls through to a bare-hex PROPOSAL (non-destructive). 'follow-up'
+    is ordinary English, so an unanchored marker would auto-complete on prose."""
+    inline = f"This is not a follow-up: {FOLLOWUP} in the usual sense."
+    assert [m["via"] for m in rp.match_followup([_pr(body=inline)], [_fu()])] == ["bare"]
+    # own line, optionally indented or preceded by other lines → marker
+    for body in (
+        f"Follow-up: {FOLLOWUP}",
+        f"  Follow-up: {FOLLOWUP}",
+        f"shipped it\nFollow-up: {FOLLOWUP}",
+    ):
+        assert [m["via"] for m in rp.match_followup([_pr(body=body)], [_fu()])] == ["marker"], body

--- a/tests/test_session_awareness/test_repo_pulse_worker.py
+++ b/tests/test_session_awareness/test_repo_pulse_worker.py
@@ -21,11 +21,13 @@ import aiosqlite
 import pytest
 
 from genesis.db.crud import repo_pulse as pulse_crud
+from genesis.db.schema._tables import TABLES
 from genesis.session_awareness import repo_pulse_worker as rpw
 from genesis.session_awareness.repo_pulse_config import DEFAULTS
 
 M58 = importlib.import_module("genesis.db.migrations.0058_session_charters")
 M62 = importlib.import_module("genesis.db.migrations.0062_repo_pulse")
+M84 = importlib.import_module("genesis.db.migrations.0084_repo_pulse_target_kind")
 
 SID = "aaaabbbb-cccc-dddd-eeee-ffff00001111"
 ITEM = "0123456789abcdef0123456789abcdef"
@@ -56,6 +58,8 @@ async def db_path(tmp_path) -> Path:
     async with aiosqlite.connect(str(path)) as db:
         await M58.up(db)
         await M62.up(db)
+        await M84.up(db)  # target_kind column + widened index
+        await db.execute(TABLES["follow_ups"])  # the follow-up lane reads this
         await db.commit()
     yield path
     pulse_crud._tables_verified = False
@@ -438,9 +442,12 @@ async def test_pre_migration_never_absorbs_ledger(pulse_root, tmp_path, monkeypa
     assert out["status"] == "failed"
     assert out.get("absorbed", []) == []
     assert (await _item_row(bare))["status"] == "open"  # untouched
-    # once the migration lands, the replayed window absorbs normally
+    # once the migration lands, the replayed window absorbs normally.
+    # (follow_ups table intentionally still absent — exercises the follow-up
+    # lane's graceful pre-migration skip, so the ledger absorb still succeeds.)
     async with aiosqlite.connect(str(bare)) as db:
         await M62.up(db)
+        await M84.up(db)  # target_kind — record_run writes it
         await db.commit()
     pulse_crud._tables_verified = False
     out2 = await _run(bare, monkeypatch, gh=_gh([_pr(body=f"Ledger: {ITEM}")]))
@@ -650,3 +657,141 @@ async def test_no_open_items_skips_fuzzy_but_records(pulse_root, db_path, monkey
     runs = await _runs(db_path)
     assert runs[0]["model"] is None  # fuzzy never ran
     assert _cursor(rpw._pulse_root())["last_merged_at"] == MERGED_NEW
+
+
+# ── follow-up lane (a8a4f59e): standalone follow_up reconciliation ────────
+
+FU = "aaaa1111bbbb2222cccc3333dddd4444"
+MERGED_NEXT = "2026-07-17T10:00:00Z"
+
+
+async def _seed_followup(
+    db_path,
+    fu_id=FU,
+    *,
+    content="ship OfficeCLI deliverables",
+    status="pending",
+    pinned=0,
+    kind="follow_up",
+    resolution_notes=None,
+    created="2026-07-10T00:00:00+00:00",
+):
+    async with aiosqlite.connect(str(db_path)) as db:
+        await db.execute(
+            "INSERT INTO follow_ups "
+            "(id, source, content, reason, strategy, status, priority, pinned, "
+            "kind, resolution_notes, created_at) "
+            "VALUES (?, 'test', ?, 'r', 'ego_judgment', ?, 'medium', ?, ?, ?, ?)",
+            (fu_id, content, status, pinned, kind, resolution_notes, created),
+        )
+        await db.commit()
+
+
+async def _followup_row(db_path, fu_id=FU) -> dict | None:
+    async with aiosqlite.connect(str(db_path)) as db:
+        db.row_factory = aiosqlite.Row
+        cur = await db.execute("SELECT * FROM follow_ups WHERE id = ?", (fu_id,))
+        row = await cur.fetchone()
+        return dict(row) if row else None
+
+
+@pytest.mark.asyncio
+async def test_followup_marker_absorbs_in_live(pulse_root, db_path, monkeypatch, live_mode):
+    await _seed_followup(db_path)
+    out = await _run(db_path, monkeypatch, gh=_gh([_pr(body=f"Follow-up: {FU}")]))
+    assert out["status"] == "ok"
+    row = await _followup_row(db_path)
+    assert row["status"] == "completed"
+    assert "PR #1080" in row["resolution_notes"]
+    assert "[repo-pulse follow-up]" in row["resolution_notes"]
+    anns = await _anns(db_path, target_kind="follow_up")
+    assert len(anns) == 1
+    assert anns[0]["status"] == "applied"
+    assert anns[0]["target_kind"] == "follow_up"
+    assert anns[0]["item_text"] == "ship OfficeCLI deliverables"  # content, not text
+    assert anns[0]["rationale"] == "follow-up-marker"
+
+
+@pytest.mark.asyncio
+async def test_followup_pinned_marker_is_proposal(pulse_root, db_path, monkeypatch, live_mode):
+    await _seed_followup(db_path, pinned=1)
+    out = await _run(db_path, monkeypatch, gh=_gh([_pr(body=f"Follow-up: {FU}")]))
+    assert out["status"] == "ok"
+    assert (await _followup_row(db_path))["status"] == "pending"  # never auto-resolved
+    anns = await _anns(db_path, target_kind="follow_up")
+    assert anns[0]["status"] == "proposed"
+    assert "pinned" in anns[0]["rationale"]
+
+
+@pytest.mark.asyncio
+async def test_followup_bare_hex_is_proposal_in_live(pulse_root, db_path, monkeypatch, live_mode):
+    await _seed_followup(db_path)
+    out = await _run(db_path, monkeypatch, gh=_gh([_pr(body=f"see {FU} from triage")]))
+    assert out["status"] == "ok"
+    assert (await _followup_row(db_path))["status"] == "pending"
+    anns = await _anns(db_path, target_kind="follow_up")
+    assert anns[0]["status"] == "proposed"
+    assert anns[0]["rationale"] == "bare-hex"
+
+
+@pytest.mark.asyncio
+async def test_followup_tabled_lane_excluded(pulse_root, db_path, monkeypatch, live_mode):
+    await _seed_followup(db_path, kind="tabled")
+    out = await _run(db_path, monkeypatch, gh=_gh([_pr(body=f"Follow-up: {FU}")]))
+    assert out["status"] == "ok"
+    assert (await _followup_row(db_path))["status"] == "pending"  # tabled never touched
+    assert await _anns(db_path, target_kind="follow_up") == []
+
+
+@pytest.mark.asyncio
+async def test_followup_marker_proposed_in_propose_only(pulse_root, db_path, monkeypatch):
+    monkeypatch.setattr(rpw, "effective_mode", lambda: "propose_only")
+    await _seed_followup(db_path)
+    out = await _run(db_path, monkeypatch, gh=_gh([_pr(body=f"Follow-up: {FU}")]))
+    assert out["status"] == "ok"
+    assert (await _followup_row(db_path))["status"] == "pending"
+    anns = await _anns(db_path, target_kind="follow_up")
+    assert anns[0]["status"] == "proposed"
+    assert "propose_only" in anns[0]["rationale"]
+
+
+@pytest.mark.asyncio
+async def test_followup_proposal_survives_reconcile_while_open(
+    pulse_root, db_path, monkeypatch, live_mode
+):
+    """The architect BLOCKER: a follow_up-target proposal must NOT be superseded
+    by the reconcile sweep while its follow_up is still open. A ledger-only
+    reconcile would look the id up in the ledger dict, miss it, and kill the
+    proposal ('item_missing') every run."""
+    await _seed_followup(db_path)
+    await _run(db_path, monkeypatch, gh=_gh([_pr(number=1080, body=f"see {FU}")]))
+    assert (await _anns(db_path, target_kind="follow_up"))[0]["status"] == "proposed"
+    # a later run reconciles at its start; the follow_up is still pending
+    await _run(
+        db_path, monkeypatch, gh=_gh([_pr(number=1081, body="unrelated", merged=MERGED_NEXT)])
+    )
+    anns = await _anns(db_path, target_kind="follow_up")
+    assert len(anns) == 1
+    assert anns[0]["status"] == "proposed"  # SURVIVES — the BLOCKER fix
+
+
+@pytest.mark.asyncio
+async def test_followup_proposal_confirmed_when_completed_with_pr(
+    pulse_root, db_path, monkeypatch, live_mode
+):
+    """A follow_up-target proposal → confirmed once the follow_up completes with
+    evidence naming the same PR (the follow-up reconcile mapping)."""
+    await _seed_followup(db_path)
+    await _run(db_path, monkeypatch, gh=_gh([_pr(number=1080, body=f"see {FU}")]))
+    async with aiosqlite.connect(str(db_path)) as db:
+        await db.execute(
+            "UPDATE follow_ups SET status='completed', "
+            "resolution_notes='done via PR #1080' WHERE id=?",
+            (FU,),
+        )
+        await db.commit()
+    await _run(
+        db_path, monkeypatch, gh=_gh([_pr(number=1081, body="unrelated", merged=MERGED_NEXT)])
+    )
+    anns = await _anns(db_path, target_kind="follow_up")
+    assert anns[0]["status"] == "confirmed"

--- a/tests/test_session_awareness/test_repo_pulse_worker.py
+++ b/tests/test_session_awareness/test_repo_pulse_worker.py
@@ -795,3 +795,24 @@ async def test_followup_proposal_confirmed_when_completed_with_pr(
     )
     anns = await _anns(db_path, target_kind="follow_up")
     assert anns[0]["status"] == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_followup_absorb_and_annotation_are_atomic(
+    pulse_root, db_path, monkeypatch, live_mode
+):
+    """The absorb + its 'applied' annotation commit in ONE transaction, so even
+    if the end-of-run _record_run never lands, the completed follow_up still has
+    its audit annotation — no orphaned completion (Codex P1)."""
+
+    async def _never_lands(*a, **kw):
+        return False  # simulate record_run not committing (crash/failure window)
+
+    await _seed_followup(db_path)
+    monkeypatch.setattr(rpw, "_record_run", _never_lands)
+    await _run(db_path, monkeypatch, gh=_gh([_pr(body=f"Follow-up: {FU}")]))
+    # both persisted by the atomic absorb, independent of the failed _record_run
+    assert (await _followup_row(db_path))["status"] == "completed"
+    anns = await _anns(db_path, target_kind="follow_up")
+    assert len(anns) == 1
+    assert anns[0]["status"] == "applied"


### PR DESCRIPTION
## Problem
Standalone hot `follow_up` rows rot into false TODOs: when their work ships via a
merged PR, nothing reconciles them, so they sit `pending` forever. Verified
specimen: the OfficeCLI follow-up row, still `pending` though its PR (#1305) merged.
The repo-pulse worker already reconciles the session **ledger** this way — the gap
is that it only ever loads ledger rows.

## Approach — a second exact-marker lane on the existing worker
Mirror the ledger exact tier for standalone follow_ups, riding the same
already-fetched PRs (no extra `gh` round-trip, no sibling worker):

- **Marker:** `Follow-up: <32-hex>` in a PR body auto-completes the hot follow_up
  with PR evidence (live mode); a bare id is a proposal; pinned rows surface as a
  proposal for human confirmation; `tabled` rows are never touched.
- **Store:** reuses `repo_pulse_annotations` with an additive `target_kind`
  column (`ledger`|`follow_up`) and a widened unique index (migration 0084), so
  ledger and follow_up ids (same uuid4.hex shape) can't collide.
- **Absorb:** a conditional open-only `absorb_followup` UPDATE — lost-update-safe
  against the detached worker, replay-idempotent.
- **Reconcile:** the sweep dispatches by `target_kind` — a follow_up proposal
  resolves against follow_up state, never the ledger (else it would be superseded
  every run). The dashboard confirm path dispatches the same way.
- **Fuzzy deferred:** exact marker/bare-hex is self-scoping, so the hundreds of
  open idea-rows never enter an LLM prompt.

## Validation
- 208 tests green (matcher, migration/CRUD, worker lane incl. two reconcile
  regressions, dashboard confirm), ruff clean.
- Two genesis-architect adversarial audits (foundation + wiring): no BLOCKERs.
  Every proposed-annotation reader enumerated; full follow_up status vocabulary
  covered; fail-closed cursor semantics; no ledger-lane regression.

## Deploy path
Runtime worker + additive migration 0084 (applies at restart) + hooks/dashboard
change (next session / server restart). Forward-looking: already-rotted rows are
only retro-absorbed if a merged PR's body carries the raw id.

Follow-up: a8a4f59e2a3d46e69183cd8fd04d249d

🤖 Generated with [Claude Code](https://claude.com/claude-code)
