### PR TITLE
fix(awareness): suppress false critical_failure under event-loop starvation + stall sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **No more false "critical failure" alarms when the system is briefly busy.** The
+  health signal that watches your local infrastructure (database, vector store, and
+  Ollama if enabled) probes those services with a short timeout. When background work
+  momentarily stalls Genesis's event loop, those probes could time out even though the
+  services were perfectly healthy — firing a spurious "critical failure" that triggered
+  a reflection and a Telegram alert. Genesis now recognizes when a probe timed out
+  because the loop was starved (rather than because a service is actually down) and
+  suppresses the false alarm, while still firing on a genuine outage. A new diagnostic
+  also captures what code was blocking the loop during such a stall, to help track down
+  the underlying cause.
+
 - **Restricted reasoning sessions can no longer escape their tool restrictions by
   spawning.** Several of Genesis's restricted Claude Code sessions (deep/strategic
   reflection, the inbox/mail judges, and the experimentation completion) could spawn a

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -120,41 +120,62 @@ class StandaloneAdapter:
             "false",
             "off",
         ):
-            if lag_sampler_task is None:
-                logger.warning(
-                    "loop-stall sampler enabled but its heartbeat publisher "
-                    "(the loop-lag sampler, GENESIS_LOOP_LAG_SAMPLER) is disabled "
-                    "— the stall sampler will no-op until the publisher runs",
-                )
-            from genesis.util.loop_stall import run_loop_stall_sampler
-
+            # The sampler is diagnostic-only: any failure to start it (import
+            # error, thread-limit RuntimeError from Thread.start under resource
+            # pressure) must disable only the sampler, never abort serve() before
+            # Flask/Telegram come up.
             try:
-                stall_ms = float(os.environ.get("GENESIS_LOOP_STALL_MS", "1000"))
-            except ValueError:
-                stall_ms = 1000.0
-            # float() accepts nan/inf/negatives — reject them here so a misconfig
-            # is surfaced (the sampler's __init__ also clamps as a backstop).
-            # `not (x > 0)` catches NaN (NaN>0 is False), 0, and negatives.
-            if not (stall_ms > 0) or stall_ms == float("inf"):
-                logger.warning(
-                    "GENESIS_LOOP_STALL_MS=%r invalid (need a finite positive "
-                    "number); using 1000ms",
-                    stall_ms,
+                if lag_sampler_task is None:
+                    logger.warning(
+                        "loop-stall sampler enabled but its heartbeat publisher "
+                        "(the loop-lag sampler, GENESIS_LOOP_LAG_SAMPLER) is "
+                        "disabled — the stall sampler will no-op until it runs",
+                    )
+                from genesis.util.loop_stall import (
+                    _MIN_STALL_MS,
+                    run_loop_stall_sampler,
                 )
-                stall_ms = 1000.0
-            stall_stop_event = threading.Event()
-            # serve() runs on the event-loop thread, so this ident IS the loop's.
-            loop_thread_id = threading.get_ident()
-            threading.Thread(
-                target=run_loop_stall_sampler,
-                kwargs={
-                    "loop_thread_id": loop_thread_id,
-                    "stop_event": stall_stop_event,
-                    "stall_ms": stall_ms,
-                },
-                daemon=True,
-                name="loop-stall-sampler",
-            ).start()
+
+                try:
+                    stall_ms = float(os.environ.get("GENESIS_LOOP_STALL_MS", "1000"))
+                except ValueError:
+                    stall_ms = _MIN_STALL_MS
+                # float() accepts nan/inf/negatives, and a value below the ~500ms
+                # heartbeat cadence flags normal gaps as wedged — surface a
+                # misconfig (the sampler's __init__ also clamps as a backstop).
+                # `not (x > 0)` catches NaN (NaN>0 is False), 0, and negatives.
+                if (
+                    not (stall_ms > 0)
+                    or stall_ms == float("inf")
+                    or stall_ms < _MIN_STALL_MS
+                ):
+                    logger.warning(
+                        "GENESIS_LOOP_STALL_MS=%r invalid or below the %.0fms "
+                        "floor (heartbeat cadence); using %.0fms",
+                        stall_ms,
+                        _MIN_STALL_MS,
+                        _MIN_STALL_MS,
+                    )
+                    stall_ms = _MIN_STALL_MS
+                stall_stop_event = threading.Event()
+                # serve() runs on the event-loop thread, so this ident IS the loop's.
+                loop_thread_id = threading.get_ident()
+                threading.Thread(
+                    target=run_loop_stall_sampler,
+                    kwargs={
+                        "loop_thread_id": loop_thread_id,
+                        "stop_event": stall_stop_event,
+                        "stall_ms": stall_ms,
+                    },
+                    daemon=True,
+                    name="loop-stall-sampler",
+                ).start()
+            except Exception:
+                logger.warning(
+                    "loop-stall sampler failed to start; continuing without it",
+                    exc_info=True,
+                )
+                stall_stop_event = None
 
         # Create shared ConversationLoop for the OpenClaw endpoint.
         # Same pattern as _start_telegram() but without channel-specific

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -109,6 +109,43 @@ class StandaloneAdapter:
                 self._loop_lag_sampler(), name="loop-lag-sampler",
             )
 
+        # Off-loop stall-stack sampler: the on-loop lag sampler above can only
+        # MEASURE a stall after it clears, so it never captures the synchronous
+        # frame that blocked the loop. This daemon thread reads the loop-health
+        # heartbeat and, when it goes stale (loop wedged NOW), snapshots the loop
+        # thread's stack — catching the offending frame mid-stall. Diagnostic-only.
+        stall_stop_event = None
+        if os.environ.get("GENESIS_LOOP_STALL_SAMPLER", "1").lower() not in (
+            "0",
+            "false",
+            "off",
+        ):
+            if lag_sampler_task is None:
+                logger.warning(
+                    "loop-stall sampler enabled but its heartbeat publisher "
+                    "(the loop-lag sampler, GENESIS_LOOP_LAG_SAMPLER) is disabled "
+                    "— the stall sampler will no-op until the publisher runs",
+                )
+            from genesis.util.loop_stall import run_loop_stall_sampler
+
+            try:
+                stall_ms = float(os.environ.get("GENESIS_LOOP_STALL_MS", "1000"))
+            except ValueError:
+                stall_ms = 1000.0
+            stall_stop_event = threading.Event()
+            # serve() runs on the event-loop thread, so this ident IS the loop's.
+            loop_thread_id = threading.get_ident()
+            threading.Thread(
+                target=run_loop_stall_sampler,
+                kwargs={
+                    "loop_thread_id": loop_thread_id,
+                    "stop_event": stall_stop_event,
+                    "stall_ms": stall_ms,
+                },
+                daemon=True,
+                name="loop-stall-sampler",
+            ).start()
+
         # Create shared ConversationLoop for the OpenClaw endpoint.
         # Same pattern as _start_telegram() but without channel-specific
         # wiring (TTS, reply waiter, etc.).
@@ -165,6 +202,8 @@ class StandaloneAdapter:
         heartbeat_task.cancel()
         if lag_sampler_task is not None:
             lag_sampler_task.cancel()
+        if stall_stop_event is not None:
+            stall_stop_event.set()  # daemon thread exits its next wait()
 
     async def _loop_lag_sampler(self) -> None:
         """Sample event-loop scheduling drift; WARN when the loop stalls.

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -132,6 +132,16 @@ class StandaloneAdapter:
                 stall_ms = float(os.environ.get("GENESIS_LOOP_STALL_MS", "1000"))
             except ValueError:
                 stall_ms = 1000.0
+            # float() accepts nan/inf/negatives — reject them here so a misconfig
+            # is surfaced (the sampler's __init__ also clamps as a backstop).
+            # `not (x > 0)` catches NaN (NaN>0 is False), 0, and negatives.
+            if not (stall_ms > 0) or stall_ms == float("inf"):
+                logger.warning(
+                    "GENESIS_LOOP_STALL_MS=%r invalid (need a finite positive "
+                    "number); using 1000ms",
+                    stall_ms,
+                )
+                stall_ms = 1000.0
             stall_stop_event = threading.Event()
             # serve() runs on the event-loop thread, so this ident IS the loop's.
             loop_thread_id = threading.get_ident()

--- a/src/genesis/learning/signals/critical_failure.py
+++ b/src/genesis/learning/signals/critical_failure.py
@@ -3,21 +3,62 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime
 from typing import Any
 
 from genesis.awareness.types import SignalReading
 from genesis.observability.types import ProbeResult, ProbeStatus
+from genesis.util import loop_health
+
+logger = logging.getLogger(__name__)
+
+# A DOWN whose probes ALL merely timed out is a loop-starvation artifact — not a
+# real outage — only when the event loop is provably not scheduling normally. The
+# primary evidence is a WEDGED loop-health sample: the on-loop lag sampler
+# (hosting/standalone.py::_loop_lag_sampler) publishes every ~0.5s, so a sample
+# whose age exceeds this threshold means the sampler itself couldn't run — the
+# loop is stuck right now. Chosen > the 0.5s publish interval (so a normal gap
+# doesn't read as wedged) and <= the 3s probe timeout (so any stall long enough
+# to trip a probe also trips wedged). The fresh+lagging window is only ~0.5s, so
+# WEDGED is the primary discriminator; fresh+lagging is the secondary one.
+_WEDGED_AGE_S = 1.0
+
+# Above this age, a stale sample means the publisher (the on-loop lag sampler)
+# itself DIED — its docstring is explicit that "any error ends the sampler". That
+# is absent LIVE evidence, not proof the loop is wedged now, so we fail-closed
+# (keep 1.0) rather than suppress every subsequent DOWN forever. A real >30s loop
+# wedge is itself a genuine critical failure and is caught by the external
+# watchdog + the stall-stack sampler.
+_STALE_CEILING_S = 30.0
 
 
 class CriticalFailureCollector:
-    """Runs health probes: 1.0 if any DOWN, 0.5 if any DEGRADED, 0.0 if all HEALTHY."""
+    """Runs health probes: 1.0 if any DOWN, 0.5 if any DEGRADED, 0.0 if all HEALTHY.
+
+    Loop-starvation guard: a DOWN whose probes *all* timed out, while the event
+    loop is demonstrably starved (a WEDGED or fresh+lagging loop-health sample),
+    is reclassified to 0.0 — a probe timing out because the loop couldn't
+    schedule it is not an infrastructure outage. Fail-closed: a hard-error DOWN,
+    a mixed batch with any non-timeout DOWN, a healthy loop, or absent
+    loop-health evidence all keep 1.0; and any error in the suppression check
+    keeps the un-suppressed value (the ``_safe_collect`` wrapper would otherwise
+    turn an escaping exception into 0.0 and silently mask a real outage).
+    """
 
     signal_name = "critical_failure"
 
-    def __init__(self, probes: list[Callable[[], Coroutine[Any, Any, ProbeResult]]]) -> None:
+    def __init__(
+        self,
+        probes: list[Callable[[], Coroutine[Any, Any, ProbeResult]]],
+        *,
+        wedged_age_s: float = _WEDGED_AGE_S,
+        stale_ceiling_s: float = _STALE_CEILING_S,
+    ) -> None:
         self._probes = probes
+        self._wedged_age_s = wedged_age_s
+        self._stale_ceiling_s = stale_ceiling_s
 
     async def collect(self) -> SignalReading:
         if not self._probes:
@@ -34,9 +75,74 @@ class CriticalFailureCollector:
         else:
             value = 0.0
 
+        if value == 1.0:
+            suppressed = self._starvation_suppressed(results)
+            if suppressed is not None:
+                return suppressed
+
         return self._reading(value)
 
-    def _reading(self, value: float) -> SignalReading:
+    def _starvation_suppressed(
+        self, results: list[ProbeResult]
+    ) -> SignalReading | None:
+        """0.0 reading if this DOWN is a loop-starvation artifact, else ``None``.
+
+        Fully guarded: ANY failure returns ``None`` so the caller keeps
+        value=1.0. Never let an exception escape to ``_safe_collect`` (which
+        returns 0.0 — the suppression outcome — and would mask a real outage).
+        """
+        try:
+            down = [r for r in results if r.status == ProbeStatus.DOWN]
+            if not down or not all(r.timed_out for r in down):
+                # A hard-error (non-timeout) DOWN is present -> real outage.
+                return None
+            sample = loop_health.read()
+            if sample is None:
+                # No evidence the loop is starved -> fail-closed, keep 1.0.
+                return None
+            age = loop_health.age_s(sample)
+            # Suppress only on LIVE evidence the loop isn't scheduling right now:
+            # a FRESH sample still flagged lagging, OR a sample gone stale within
+            # the wedged window (the publisher missed recent beats -> loop stuck
+            # now). Both are freshness-gated: a sample staler than the ceiling
+            # means the publisher (the on-loop lag sampler) DIED, so its last
+            # reading -- whatever its `lagging` flag says -- is absent LIVE
+            # evidence, not proof the loop is wedged now. Fail-closed (keep 1.0)
+            # in that case, symmetrically for lagging True and False.
+            fresh_lagging = age <= self._wedged_age_s and sample.lagging
+            loop_wedged = self._wedged_age_s < age <= self._stale_ceiling_s
+            if not fresh_lagging and not loop_wedged:
+                return None
+            probes_named = ",".join(r.name for r in down)
+            logger.warning(
+                "critical_failure suppressed: all DOWN probes (%s) timed out under "
+                "event-loop starvation (drift=%.0fms, sample_age=%.2fs) — infra "
+                "not down, loop starved",
+                probes_named,
+                sample.drift_ms,
+                age,
+            )
+            return self._reading(
+                0.0,
+                metadata={
+                    "starvation_suppressed": True,
+                    "suppressed_probes": probes_named,
+                    "loop_drift_ms": round(sample.drift_ms, 1),
+                    "loop_sample_age_s": round(age, 2),
+                    "loop_executor": sample.executor,
+                },
+            )
+        except Exception:
+            logger.warning(
+                "critical_failure starvation-suppression check failed; keeping "
+                "value=1.0",
+                exc_info=True,
+            )
+            return None
+
+    def _reading(
+        self, value: float, *, metadata: dict | None = None
+    ) -> SignalReading:
         return SignalReading(
             name=self.signal_name,
             value=value,
@@ -46,6 +152,10 @@ class CriticalFailureCollector:
                 "0.0=DB/Qdrant (+Ollama if enabled) health probes all healthy. "
                 "0.5=a probe DEGRADED, 1.0=a probe DOWN. This tracks LOCAL "
                 "infrastructure/service health (including the local Ollama if "
-                "enabled), NOT cloud LLM-provider availability."
+                "enabled), NOT cloud LLM-provider availability. A DOWN caused "
+                "purely by probe timeouts while the event loop is starved is "
+                "suppressed to 0.0 (see metadata.starvation_suppressed) — the "
+                "infra is reachable, the loop just couldn't schedule the probe."
             ),
+            metadata=metadata,
         )

--- a/src/genesis/learning/signals/critical_failure.py
+++ b/src/genesis/learning/signals/critical_failure.py
@@ -114,19 +114,56 @@ class CriticalFailureCollector:
             if not fresh_lagging and not loop_wedged:
                 return None
             probes_named = ",".join(r.name for r in down)
+            # Preserve a genuine DEGRADED (e.g. a 503 — the service RESPONDED, not
+            # a timeout artifact): recompute the worst status over the results that
+            # are NOT timeout-suppressed. Every DOWN here is timeout-suppressed, so
+            # only HEALTHY/DEGRADED remain -> residual is 0.5 or 0.0. Hard-coding
+            # 0.0 would mask a real degradation coincident with the stall.
+            non_suppressed = [
+                r
+                for r in results
+                if not (r.status == ProbeStatus.DOWN and r.timed_out)
+            ]
+            residual = (
+                0.5
+                if any(r.status == ProbeStatus.DEGRADED for r in non_suppressed)
+                else 0.0
+            )
+            # Accepted residual: if a dependency is GENUINELY timing out
+            # (blackholed/overloaded) at the same instant the loop is wedged, this
+            # suppresses it for this tick. Unresolvable from a single reading
+            # (loop_health proves the loop is starved, never that the dependency is
+            # reachable) and self-healing — the next tick with a healthy loop fires
+            # 1.0. critical_failure is a reflection signal; hard failures are the
+            # status.json watchdog's domain.
             logger.warning(
-                "critical_failure suppressed: all DOWN probes (%s) timed out under "
-                "event-loop starvation (drift=%.0fms, sample_age=%.2fs) — infra "
-                "not down, loop starved",
+                "critical_failure suppressed to %.1f: all DOWN probes (%s) timed "
+                "out under event-loop starvation (drift=%.0fms, sample_age=%.2fs) "
+                "— infra not down, loop starved",
+                residual,
                 probes_named,
                 sample.drift_ms,
                 age,
             )
+            # The suppression explanation goes in baseline_note — the field the
+            # tick serializer + reflection prompt formatter actually retain
+            # (metadata is dropped by both) — so a suppressed reading is never
+            # mistaken for a genuinely-healthy 0.0.
+            remainder = (
+                "a genuinely-degraded probe remains" if residual else "no other fault"
+            )
             return self._reading(
-                0.0,
+                residual,
+                baseline_note=(
+                    f"SUPPRESSED under event-loop starvation: probe(s) "
+                    f"{probes_named} timed out because the loop couldn't schedule "
+                    f"them (drift {sample.drift_ms:.0f}ms), NOT a real outage. "
+                    f"Value {residual} ({remainder})."
+                ),
                 metadata={
                     "starvation_suppressed": True,
                     "suppressed_probes": probes_named,
+                    "residual_value": residual,
                     "loop_drift_ms": round(sample.drift_ms, 1),
                     "loop_sample_age_s": round(age, 2),
                     "loop_executor": sample.executor,
@@ -141,21 +178,25 @@ class CriticalFailureCollector:
             return None
 
     def _reading(
-        self, value: float, *, metadata: dict | None = None
+        self,
+        value: float,
+        *,
+        metadata: dict | None = None,
+        baseline_note: str | None = None,
     ) -> SignalReading:
         return SignalReading(
             name=self.signal_name,
             value=value,
             source="health_probes",
             collected_at=datetime.now(UTC).isoformat(),
-            baseline_note=(
+            baseline_note=baseline_note
+            or (
                 "0.0=DB/Qdrant (+Ollama if enabled) health probes all healthy. "
                 "0.5=a probe DEGRADED, 1.0=a probe DOWN. This tracks LOCAL "
                 "infrastructure/service health (including the local Ollama if "
                 "enabled), NOT cloud LLM-provider availability. A DOWN caused "
                 "purely by probe timeouts while the event loop is starved is "
-                "suppressed to 0.0 (see metadata.starvation_suppressed) — the "
-                "infra is reachable, the loop just couldn't schedule the probe."
+                "suppressed (the reading then carries a SUPPRESSED baseline_note)."
             ),
             metadata=metadata,
         )

--- a/src/genesis/learning/signals/critical_failure.py
+++ b/src/genesis/learning/signals/critical_failure.py
@@ -139,7 +139,8 @@ class CriticalFailureCollector:
             logger.warning(
                 "critical_failure suppressed to %.1f: all DOWN probes (%s) timed "
                 "out under event-loop starvation (drift=%.0fms, sample_age=%.2fs) "
-                "— infra not down, loop starved",
+                "— infra health indeterminate (loop couldn't schedule the probe), "
+                "re-checked next tick",
                 residual,
                 probes_named,
                 sample.drift_ms,
@@ -157,8 +158,9 @@ class CriticalFailureCollector:
                 baseline_note=(
                     f"SUPPRESSED under event-loop starvation: probe(s) "
                     f"{probes_named} timed out because the loop couldn't schedule "
-                    f"them (drift {sample.drift_ms:.0f}ms), NOT a real outage. "
-                    f"Value {residual} ({remainder})."
+                    f"them (drift {sample.drift_ms:.0f}ms), so their health is "
+                    f"INDETERMINATE this tick and is not counted as a critical "
+                    f"failure (re-checked next tick). Value {residual} ({remainder})."
                 ),
                 metadata={
                     "starvation_suppressed": True,

--- a/src/genesis/observability/health.py
+++ b/src/genesis/observability/health.py
@@ -150,6 +150,7 @@ async def probe_qdrant(
             latency_ms=round(latency, 2),
             message=str(exc),
             checked_at=_clock().isoformat(),
+            timed_out=isinstance(exc, TimeoutError),
         )
 
 
@@ -206,6 +207,7 @@ async def probe_ollama(
             latency_ms=round(latency, 2),
             message=str(exc),
             checked_at=_clock().isoformat(),
+            timed_out=isinstance(exc, TimeoutError),
         )
 
 

--- a/src/genesis/observability/types.py
+++ b/src/genesis/observability/types.py
@@ -91,6 +91,10 @@ class ProbeResult:
     message: str = ""
     checked_at: str = ""  # ISO datetime
     details: dict | None = None
+    # True when the DOWN was a timeout (vs a hard error like connection-refused).
+    # A timeout under a starved event loop is a scheduling artifact, not a real
+    # outage — critical_failure uses this to avoid firing on loop starvation.
+    timed_out: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/genesis/util/loop_stall.py
+++ b/src/genesis/util/loop_stall.py
@@ -83,11 +83,17 @@ class LoopStallSampler:
         if self._dumped_this_episode:
             # Already dumped for this stall episode — stay quiet until it clears.
             return False
-        self._dumped_this_episode = True
-        self._dump(sample, age_ms)
-        return True
+        # Consume the episode only on a SUCCESSFUL dump: a transient snapshot
+        # failure (a racing frame while format_stack runs) must be retried on the
+        # next poll, not swallow the whole episode with no capture.
+        if self._dump(sample, age_ms):
+            self._dumped_this_episode = True
+            return True
+        return False
 
-    def _dump(self, sample: object, age_ms: float) -> None:
+    def _dump(self, sample: object, age_ms: float) -> bool:
+        """Log the loop thread's stack. Returns True on success, False on a
+        transient snapshot failure (so the caller can retry the episode)."""
         try:
             frame = self._frames_source().get(self._loop_thread_id)
             if frame is None:
@@ -101,10 +107,12 @@ class LoopStallSampler:
                 getattr(sample, "executor", None),
                 stack,
             )
+            return True
         except Exception:
             # Diagnostic-only: a partial/racing frame snapshot must never raise
-            # into the sampler thread.
+            # into the sampler thread; report failure so the episode is retried.
             self._log.warning("loop-stall stack dump failed", exc_info=True)
+            return False
 
 
 def run_loop_stall_sampler(

--- a/src/genesis/util/loop_stall.py
+++ b/src/genesis/util/loop_stall.py
@@ -24,6 +24,7 @@ Depends on the loop-lag sampler (the heartbeat publisher); it no-ops while
 from __future__ import annotations
 
 import logging
+import math
 import sys
 import threading
 import traceback
@@ -55,6 +56,12 @@ class LoopStallSampler:
         log: logging.Logger = logger,
     ) -> None:
         self._loop_thread_id = loop_thread_id
+        # Reject NaN/inf/zero/negative: inf never dumps, and NaN/non-positive read
+        # a healthy heartbeat as wedged and never reset the episode flag. These
+        # parse as valid floats, so a ValueError guard at the env parser misses
+        # them — clamp at the boundary instead.
+        if not (math.isfinite(stall_ms) and stall_ms > 0):
+            stall_ms = _DEFAULT_STALL_MS
         self._stall_ms = stall_ms
         self._frames_source = frames_source
         self._health_read = health_read

--- a/src/genesis/util/loop_stall.py
+++ b/src/genesis/util/loop_stall.py
@@ -1,0 +1,121 @@
+"""Off-loop event-loop stall diagnostics — capture the loop thread's stack while wedged.
+
+The on-loop lag sampler (``hosting/standalone.py::_loop_lag_sampler``) can only
+MEASURE a stall after it clears — it reads drift once its own ``asyncio.sleep``
+returns, so by the time it logs, the synchronous frame that blocked the loop is
+already gone. This sampler runs OFF the loop, in a daemon thread, and reads the
+loop-health heartbeat the lag sampler publishes each ~0.5s: when that heartbeat
+goes stale (the on-loop sampler stopped publishing = the loop is stuck right
+now), it snapshots the loop thread's stack via :func:`sys._current_frames` and
+logs it — catching the offending synchronous frame mid-stall. Diagnostic-only;
+it never affects control flow.
+
+Why a custom thread instead of ``faulthandler.dump_traceback_later``: this
+targets the loop thread specifically (not every thread dumped to stderr), routes
+to the logger, reuses the already-published ``loop_health`` sample (no second
+timer to re-arm), and attaches executor pressure — at the cost of ~40 lines. One
+dump per stall EPISODE (reset when the loop recovers) keeps a multi-second stall
+from flooding the journal.
+
+Depends on the loop-lag sampler (the heartbeat publisher); it no-ops while
+``loop_health.read()`` is ``None``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import traceback
+from collections.abc import Callable
+
+from genesis.util import loop_health
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_STALL_MS = 1000.0
+_POLL_INTERVAL_S = 0.25
+
+
+class LoopStallSampler:
+    """Detects a wedged event loop (stale loop-health heartbeat) and dumps its stack.
+
+    The injectable seams (``frames_source`` / ``health_read`` / ``age_fn`` /
+    ``log``) make :meth:`poll_once` unit-testable without real threads or sleeps.
+    """
+
+    def __init__(
+        self,
+        *,
+        loop_thread_id: int,
+        stall_ms: float = _DEFAULT_STALL_MS,
+        frames_source: Callable[[], dict] = sys._current_frames,
+        health_read: Callable[[], object | None] = loop_health.read,
+        age_fn: Callable[..., float] = loop_health.age_s,
+        log: logging.Logger = logger,
+    ) -> None:
+        self._loop_thread_id = loop_thread_id
+        self._stall_ms = stall_ms
+        self._frames_source = frames_source
+        self._health_read = health_read
+        self._age_fn = age_fn
+        self._log = log
+        self._dumped_this_episode = False
+
+    def poll_once(self) -> bool:
+        """One poll step. Returns ``True`` iff it dumped a stack this call."""
+        sample = self._health_read()
+        if sample is None:
+            # Publisher hasn't run yet / disabled — nothing to judge.
+            return False
+        age_ms = self._age_fn(sample) * 1000.0
+        if age_ms < self._stall_ms:
+            # Loop is scheduling normally — reset so the next episode dumps once.
+            self._dumped_this_episode = False
+            return False
+        if self._dumped_this_episode:
+            # Already dumped for this stall episode — stay quiet until it clears.
+            return False
+        self._dumped_this_episode = True
+        self._dump(sample, age_ms)
+        return True
+
+    def _dump(self, sample: object, age_ms: float) -> None:
+        try:
+            frame = self._frames_source().get(self._loop_thread_id)
+            if frame is None:
+                stack = "<loop thread frame unavailable (loop moved on)>"
+            else:
+                stack = "".join(traceback.format_stack(frame))
+            self._log.warning(
+                "event-loop WEDGED %.0fms (no loop-health publish) — executor=%s\n"
+                "loop-thread stack (the synchronous frame starving the loop):\n%s",
+                age_ms,
+                getattr(sample, "executor", None),
+                stack,
+            )
+        except Exception:
+            # Diagnostic-only: a partial/racing frame snapshot must never raise
+            # into the sampler thread.
+            self._log.warning("loop-stall stack dump failed", exc_info=True)
+
+
+def run_loop_stall_sampler(
+    *,
+    loop_thread_id: int,
+    stop_event: threading.Event,
+    stall_ms: float = _DEFAULT_STALL_MS,
+    poll_interval_s: float = _POLL_INTERVAL_S,
+) -> None:
+    """Poll for a wedged loop until ``stop_event`` is set (runs in a daemon thread).
+
+    ``stop_event.wait`` doubles as the inter-poll sleep and the shutdown signal,
+    so the thread exits promptly on shutdown instead of only at interpreter
+    teardown.
+    """
+    sampler = LoopStallSampler(loop_thread_id=loop_thread_id, stall_ms=stall_ms)
+    while not stop_event.wait(poll_interval_s):
+        try:
+            sampler.poll_once()
+        except Exception:
+            logger.debug("loop-stall sampler poll failed", exc_info=True)

--- a/src/genesis/util/loop_stall.py
+++ b/src/genesis/util/loop_stall.py
@@ -36,6 +36,10 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_STALL_MS = 1000.0
 _POLL_INTERVAL_S = 0.25
+# The loop-health publisher (hosting/standalone.py::_loop_lag_sampler) beats every
+# ~500ms, so a stall threshold below that + jitter tolerance would flag a normal
+# heartbeat gap as WEDGED. Floor the threshold at 2x the cadence.
+_MIN_STALL_MS = 1000.0
 
 
 class LoopStallSampler:
@@ -62,6 +66,10 @@ class LoopStallSampler:
         # them — clamp at the boundary instead.
         if not (math.isfinite(stall_ms) and stall_ms > 0):
             stall_ms = _DEFAULT_STALL_MS
+        elif stall_ms < _MIN_STALL_MS:
+            # A finite positive value below the heartbeat cadence would flag normal
+            # publish gaps as wedged — floor it.
+            stall_ms = _MIN_STALL_MS
         self._stall_ms = stall_ms
         self._frames_source = frames_source
         self._health_read = health_read

--- a/tests/test_learning/test_critical_failure_starvation.py
+++ b/tests/test_learning/test_critical_failure_starvation.py
@@ -1,0 +1,158 @@
+"""critical_failure must not fire 1.0 when a probe DOWN is loop-starvation-caused.
+
+A health probe (Qdrant/Ollama) uses a 3s aiohttp timeout. When the event loop is
+starved (background work blocking it), the probe coroutine can't complete inside
+that budget and raises a timeout -> ProbeStatus.DOWN -> critical_failure=1.0, even
+though the infra is fine. These tests pin the suppression: a *timeout*-caused DOWN
+under a demonstrably unhealthy loop is reclassified to 0.0 (+ metadata), while a
+real outage (hard-error DOWN, or a healthy loop, or absent loop-health evidence)
+still fires 1.0.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from genesis.learning.signals.critical_failure import CriticalFailureCollector
+from genesis.observability.types import ProbeResult, ProbeStatus
+from genesis.util import loop_health
+
+
+def _probe(name: str, status: ProbeStatus, *, timed_out: bool = False):
+    """A zero-arg callable returning a coroutine yielding a crafted ProbeResult."""
+
+    async def _run() -> ProbeResult:
+        return ProbeResult(name=name, status=status, latency_ms=1.0, timed_out=timed_out)
+
+    return _run
+
+
+def _sample(*, age_s: float, lagging: bool, drift_ms: float = 2600.0):
+    """A LoopHealthSample whose age is `age_s` seconds (via sampled_monotonic)."""
+    return loop_health.LoopHealthSample(
+        drift_ms=drift_ms,
+        peak_ms=drift_ms,
+        lagging=lagging,
+        threshold_ms=250.0,
+        executor={"pending": 0, "workers": 11, "max_workers": 11},
+        sampled_monotonic=time.monotonic() - age_s,
+    )
+
+
+@pytest.mark.asyncio
+async def test_all_timeout_down_under_wedged_loop_suppressed(monkeypatch):
+    # Wedged: the on-loop sampler stopped publishing (stale sample, age > threshold).
+    monkeypatch.setattr(loop_health, "read", lambda: _sample(age_s=2.0, lagging=False))
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.DOWN, timed_out=True)])
+    r = await c.collect()
+    assert r.value == 0.0
+    assert r.metadata and r.metadata.get("starvation_suppressed") is True
+    assert "qdrant" in r.metadata.get("suppressed_probes", "")
+
+
+@pytest.mark.asyncio
+async def test_fresh_lagging_sample_also_suppresses(monkeypatch):
+    # WEDGED (stale age) is the primary discriminator, but a fresh sample still
+    # flagged lagging within the ~0.5s window also counts as loop-unhealthy.
+    monkeypatch.setattr(loop_health, "read", lambda: _sample(age_s=0.1, lagging=True))
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.DOWN, timed_out=True)])
+    r = await c.collect()
+    assert r.value == 0.0
+
+
+@pytest.mark.asyncio
+async def test_timeout_down_healthy_loop_not_suppressed(monkeypatch):
+    # Fresh sample, not lagging -> loop is healthy -> a real timeout still fires.
+    monkeypatch.setattr(loop_health, "read", lambda: _sample(age_s=0.1, lagging=False))
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.DOWN, timed_out=True)])
+    r = await c.collect()
+    assert r.value == 1.0
+
+
+@pytest.mark.asyncio
+async def test_mixed_hard_and_timeout_down_not_suppressed(monkeypatch):
+    # DB genuinely down (hard error) + Qdrant timing out from starvation: the real
+    # DB outage must NOT be masked. Suppress only when ALL DOWN probes timed out.
+    monkeypatch.setattr(loop_health, "read", lambda: _sample(age_s=2.0, lagging=True))
+    c = CriticalFailureCollector(
+        [
+            _probe("db", ProbeStatus.DOWN, timed_out=False),
+            _probe("qdrant", ProbeStatus.DOWN, timed_out=True),
+        ]
+    )
+    r = await c.collect()
+    assert r.value == 1.0
+
+
+@pytest.mark.asyncio
+async def test_dead_publisher_stale_sample_not_suppressed(monkeypatch):
+    # The lag sampler (the heartbeat publisher) died: loop_health.read() keeps
+    # returning a once-healthy sample whose age climbs unbounded. That is absent
+    # LIVE evidence, NOT proof the loop is wedged now -> a real timeout DOWN must
+    # not be masked (fail-closed past the stale ceiling).
+    monkeypatch.setattr(loop_health, "read", lambda: _sample(age_s=120.0, lagging=False))
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.DOWN, timed_out=True)])
+    r = await c.collect()
+    assert r.value == 1.0
+
+
+@pytest.mark.asyncio
+async def test_dead_publisher_stale_lagging_sample_not_suppressed(monkeypatch):
+    # Symmetric to the lagging=False case: if the publisher died MID-episode, its
+    # last sample carries lagging=True and its age climbs unbounded. A stale
+    # lagging=True sample past the ceiling is still absent LIVE evidence -> a real
+    # timeout DOWN must not be masked. (Both branches of the dead-publisher class.)
+    monkeypatch.setattr(loop_health, "read", lambda: _sample(age_s=120.0, lagging=True))
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.DOWN, timed_out=True)])
+    r = await c.collect()
+    assert r.value == 1.0
+
+
+@pytest.mark.asyncio
+async def test_wedged_window_lagging_suppresses(monkeypatch):
+    # Within the wedged window (fresh enough that the publisher is alive), a
+    # lagging sample is live evidence of a current stall -> suppress.
+    monkeypatch.setattr(loop_health, "read", lambda: _sample(age_s=2.0, lagging=True))
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.DOWN, timed_out=True)])
+    r = await c.collect()
+    assert r.value == 0.0
+
+
+@pytest.mark.asyncio
+async def test_no_loop_sample_not_suppressed(monkeypatch):
+    # Absent loop-health evidence -> fail-closed, never suppress.
+    monkeypatch.setattr(loop_health, "read", lambda: None)
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.DOWN, timed_out=True)])
+    r = await c.collect()
+    assert r.value == 1.0
+
+
+@pytest.mark.asyncio
+async def test_suppression_check_exception_keeps_value(monkeypatch):
+    # B1: a bug anywhere in the suppression path must default to the un-suppressed
+    # value (1.0) -- never let it escape to _safe_collect, which would return 0.0
+    # and silently zero a real outage.
+    def _boom():
+        raise RuntimeError("loop_health blew up")
+
+    monkeypatch.setattr(loop_health, "read", _boom)
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.DOWN, timed_out=True)])
+    r = await c.collect()
+    assert r.value == 1.0
+
+
+@pytest.mark.asyncio
+async def test_degraded_unchanged(monkeypatch):
+    monkeypatch.setattr(loop_health, "read", lambda: _sample(age_s=2.0, lagging=True))
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.DEGRADED)])
+    r = await c.collect()
+    assert r.value == 0.5
+
+
+@pytest.mark.asyncio
+async def test_all_healthy():
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.HEALTHY)])
+    r = await c.collect()
+    assert r.value == 0.0

--- a/tests/test_learning/test_critical_failure_starvation.py
+++ b/tests/test_learning/test_critical_failure_starvation.py
@@ -121,6 +121,39 @@ async def test_wedged_window_lagging_suppresses(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_degraded_preserved_when_timeout_down_suppressed(monkeypatch):
+    # Qdrant times out (a starvation artifact) but Ollama is genuinely DEGRADED
+    # (e.g. HTTP 503 — the service responded, not a timeout). Suppressing the
+    # timeout artifact must NOT flatten the real degradation to 0.0; the residual
+    # worst-status (0.5) must survive. (Codex P2-3.)
+    monkeypatch.setattr(loop_health, "read", lambda: _sample(age_s=2.0, lagging=False))
+    c = CriticalFailureCollector(
+        [
+            _probe("qdrant", ProbeStatus.DOWN, timed_out=True),
+            _probe("ollama", ProbeStatus.DEGRADED),
+        ]
+    )
+    r = await c.collect()
+    assert r.value == 0.5
+
+
+@pytest.mark.asyncio
+async def test_suppressed_reading_note_states_suppression(monkeypatch):
+    # The suppression must be visible in baseline_note (which IS persisted to the
+    # tick and formatted into reflection prompts), not only in metadata (which the
+    # tick serializer drops) — otherwise a suppressed reading is indistinguishable
+    # from a genuinely-healthy 0.0. (Codex P2-2.)
+    monkeypatch.setattr(loop_health, "read", lambda: _sample(age_s=2.0, lagging=False))
+    c = CriticalFailureCollector([_probe("qdrant", ProbeStatus.DOWN, timed_out=True)])
+    r = await c.collect()
+    assert r.value == 0.0
+    assert "suppress" in r.baseline_note.lower() or "starv" in r.baseline_note.lower()
+    healthy = CriticalFailureCollector([_probe("qdrant", ProbeStatus.HEALTHY)])
+    hr = await healthy.collect()
+    assert r.baseline_note != hr.baseline_note
+
+
+@pytest.mark.asyncio
 async def test_no_loop_sample_not_suppressed(monkeypatch):
     # Absent loop-health evidence -> fail-closed, never suppress.
     monkeypatch.setattr(loop_health, "read", lambda: None)

--- a/tests/test_observability/test_health.py
+++ b/tests/test_observability/test_health.py
@@ -81,6 +81,46 @@ class TestProbeOllama:
         assert result.status == ProbeStatus.DOWN
 
 
+class TestProbeTimeoutFlag:
+    """A timeout-caused DOWN is tagged timed_out=True; a hard error is not.
+
+    critical_failure uses this to distinguish a loop-starvation artifact (probe
+    timed out because the event loop couldn't schedule it) from a real outage.
+    """
+
+    @pytest.mark.asyncio
+    async def test_qdrant_timeout_sets_flag(self, aiohttp_mock):
+        # aiohttp's total ClientTimeout raises asyncio.TimeoutError (== builtin
+        # TimeoutError on 3.11+).
+        aiohttp_mock.get("http://localhost:6333/healthz", exception=TimeoutError())
+        result = await probe_qdrant(clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.DOWN
+        assert result.timed_out is True
+
+    @pytest.mark.asyncio
+    async def test_qdrant_hard_error_not_flagged(self, aiohttp_mock):
+        # Connection refused / unreachable surfaces as OSError (not a TimeoutError).
+        aiohttp_mock.get("http://localhost:6333/healthz", exception=OSError("refused"))
+        result = await probe_qdrant(clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.DOWN
+        assert result.timed_out is False
+
+    @pytest.mark.asyncio
+    async def test_ollama_timeout_sets_flag(self, aiohttp_mock):
+        url = "http://localhost:11434/api/tags"
+        aiohttp_mock.get(url, exception=TimeoutError())
+        result = await probe_ollama(url=url, clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.DOWN
+        assert result.timed_out is True
+
+    @pytest.mark.asyncio
+    async def test_probe_result_defaults_not_timed_out(self):
+        # Default is False so probe_db (no timeout) and healthy probes never
+        # accidentally read as timeout-caused.
+        r = ProbeResult(name="x", status=ProbeStatus.HEALTHY, latency_ms=0.0)
+        assert r.timed_out is False
+
+
 class TestProbeScheduler:
     @pytest.mark.asyncio
     async def test_running(self):

--- a/tests/test_util/test_loop_stall.py
+++ b/tests/test_util/test_loop_stall.py
@@ -82,6 +82,29 @@ def test_invalid_stall_ms_falls_back_to_default():
     assert LoopStallSampler(loop_thread_id=7, stall_ms=500.0)._stall_ms == 500.0
 
 
+def test_transient_dump_failure_retries_next_poll():
+    # A dump that raises (a racing frame while format_stack runs) must NOT consume
+    # the episode — the next poll retries and succeeds. (Codex round-2 finding.)
+    s = _Sample()
+    calls = {"n": 0}
+
+    def flaky_frames():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("racing frame")
+        return {7: None}
+
+    sampler = LoopStallSampler(
+        loop_thread_id=7,
+        stall_ms=1000.0,
+        frames_source=flaky_frames,
+        health_read=lambda: s,
+        age_fn=lambda sample, **kw: 2.0,
+    )
+    assert sampler.poll_once() is False  # dump raised -> episode NOT consumed
+    assert sampler.poll_once() is True  # retried -> captured
+
+
 def test_runner_exits_when_stop_set():
     stop = threading.Event()
     stop.set()  # already stopped -> the runner returns without polling

--- a/tests/test_util/test_loop_stall.py
+++ b/tests/test_util/test_loop_stall.py
@@ -69,6 +69,19 @@ def test_missing_loop_frame_is_safe():
     assert sampler.poll_once() is True  # dumps a placeholder, never raises
 
 
+def test_invalid_stall_ms_falls_back_to_default():
+    # NaN/inf/zero/negative all parse as valid floats but break the sampler
+    # (inf never dumps; NaN/non-positive report a healthy heartbeat as wedged and
+    # never reset). __init__ clamps them to the default. (Codex P2-4.)
+    from genesis.util.loop_stall import _DEFAULT_STALL_MS
+
+    for bad in (float("inf"), float("nan"), 0.0, -5.0):
+        s = LoopStallSampler(loop_thread_id=7, stall_ms=bad)
+        assert s._stall_ms == _DEFAULT_STALL_MS
+    # A valid positive value is kept.
+    assert LoopStallSampler(loop_thread_id=7, stall_ms=500.0)._stall_ms == 500.0
+
+
 def test_runner_exits_when_stop_set():
     stop = threading.Event()
     stop.set()  # already stopped -> the runner returns without polling

--- a/tests/test_util/test_loop_stall.py
+++ b/tests/test_util/test_loop_stall.py
@@ -1,0 +1,75 @@
+"""Tests for the off-loop loop-stall stack sampler (Part C, diagnostic-only).
+
+poll_once() is driven deterministically via injected seams — a fake frames
+source, a fake loop-health reader, and a fake age function — so no real threads,
+sleeps, or event loop are needed.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from genesis.util.loop_stall import LoopStallSampler, run_loop_stall_sampler
+
+
+class _Sample:
+    """Minimal stand-in for loop_health.LoopHealthSample."""
+
+    def __init__(self):
+        self.executor = {"pending": 0, "workers": 11, "max_workers": 11}
+        self.drift_ms = 2600.0
+
+
+def _make(*, age_holder, sample, frames, tid=7, stall_ms=1000.0):
+    return LoopStallSampler(
+        loop_thread_id=tid,
+        stall_ms=stall_ms,
+        frames_source=lambda: frames,
+        health_read=lambda: sample,
+        age_fn=lambda s, **kw: age_holder["v"],
+    )
+
+
+def test_wedged_dumps_once_then_resets_for_next_episode():
+    s = _Sample()
+    age = {"v": 2.0}  # 2000ms >= 1000ms stall -> wedged
+    sampler = _make(age_holder=age, sample=s, frames={7: None})
+
+    assert sampler.poll_once() is True  # first observation of the stall -> dump
+    assert sampler.poll_once() is False  # still wedged, already dumped this episode
+    age["v"] = 0.1  # loop recovered
+    assert sampler.poll_once() is False  # healthy -> no dump, episode resets
+    age["v"] = 2.0  # a new stall
+    assert sampler.poll_once() is True  # new episode -> dump again
+
+
+def test_none_sample_never_dumps():
+    sampler = LoopStallSampler(
+        loop_thread_id=7,
+        stall_ms=1000.0,
+        frames_source=lambda: {},
+        health_read=lambda: None,  # publisher never ran / disabled
+        age_fn=lambda s, **kw: 5.0,
+    )
+    assert sampler.poll_once() is False
+
+
+def test_below_threshold_never_dumps():
+    s = _Sample()
+    age = {"v": 0.2}  # 200ms < 1000ms
+    sampler = _make(age_holder=age, sample=s, frames={7: None})
+    assert sampler.poll_once() is False
+
+
+def test_missing_loop_frame_is_safe():
+    s = _Sample()
+    age = {"v": 2.0}
+    # The loop thread id is absent from the frames snapshot (race: loop moved on).
+    sampler = _make(age_holder=age, sample=s, frames={})
+    assert sampler.poll_once() is True  # dumps a placeholder, never raises
+
+
+def test_runner_exits_when_stop_set():
+    stop = threading.Event()
+    stop.set()  # already stopped -> the runner returns without polling
+    run_loop_stall_sampler(loop_thread_id=7, stop_event=stop, poll_interval_s=0.01)

--- a/tests/test_util/test_loop_stall.py
+++ b/tests/test_util/test_loop_stall.py
@@ -78,8 +78,16 @@ def test_invalid_stall_ms_falls_back_to_default():
     for bad in (float("inf"), float("nan"), 0.0, -5.0):
         s = LoopStallSampler(loop_thread_id=7, stall_ms=bad)
         assert s._stall_ms == _DEFAULT_STALL_MS
-    # A valid positive value is kept.
-    assert LoopStallSampler(loop_thread_id=7, stall_ms=500.0)._stall_ms == 500.0
+    # A valid value at/above the heartbeat-cadence floor is kept.
+    assert LoopStallSampler(loop_thread_id=7, stall_ms=1500.0)._stall_ms == 1500.0
+
+
+def test_stall_ms_below_heartbeat_cadence_is_floored():
+    # A finite positive value below the floor (~2x the 500ms publish cadence)
+    # would flag normal heartbeat gaps as wedged — it's raised to the floor.
+    from genesis.util.loop_stall import _MIN_STALL_MS, LoopStallSampler
+
+    assert LoopStallSampler(loop_thread_id=7, stall_ms=300.0)._stall_ms == _MIN_STALL_MS
 
 
 def test_transient_dump_failure_retries_next_poll():


### PR DESCRIPTION
## What

Two changes: stop a false `critical_failure` alarm, and instrument its root cause.

**B — `critical_failure` no longer fires on loop-starvation-induced probe timeouts.**
The `critical_failure` signal probes local infra (DB, Qdrant, + Ollama if enabled) with a
3s aiohttp timeout. When background work stalls the event loop, those probes time out and
report DOWN → `critical_failure=1.0` even though the infra is healthy. Because
`critical_failure` is a `_MICRO_CRITICAL_SIGNALS` member, each false spike woke a Micro
reflection + Telegram alert.

The collector now reclassifies a DOWN to `0.0` **only** when every DOWN probe timed out
**and** the `loop_health` sample (the off-loop seam from #1375) shows the loop is not
scheduling normally — a fresh + lagging sample, or a stale sample inside a wedged window
(1s–30s). Fail-closed: a hard-error (connection-refused) DOWN, a mixed batch, a healthy
loop, a stale sample past the 30s ceiling (i.e. the sampler itself died), or absent
evidence all keep `1.0`; and the suppression is wrapped so any internal exception keeps the
un-suppressed value (the `_safe_collect` wrapper would otherwise turn an escaping exception
into `0.0`). Probes now carry `ProbeResult.timed_out` to distinguish a timeout from a hard
error.

**Instrumentation — off-loop stall-stack sampler (`util/loop_stall.py`).**
The on-loop lag sampler can only measure a stall *after* it clears, so it never captures the
synchronous frame that blocked the loop. A new off-loop daemon thread reads the `loop_health`
heartbeat and, when it goes stale (loop wedged now), snapshots the loop thread's stack via
`sys._current_frames()` and logs it — one dump per episode. Diagnostic-only; env-gated
(`GENESIS_LOOP_STALL_SAMPLER` / `GENESIS_LOOP_STALL_MS`), no-op if the heartbeat publisher is
disabled.

## Why

The false alarm was firing repeatedly under normal background load. The underlying
loop-starvation source is not yet identified (a trace disproved the obvious hypothesis), so
the stall sampler is the instrument to catch it live; B stops the false alarm at the signal
boundary regardless of the source.

## Testing

Test-first (verify-RED → GREEN): probe timeout-flag (timeout vs hard error); suppression for
all-timeout + wedged / fresh-lagging; fail-closed for hard-error / mixed batch / healthy-loop
/ dead-publisher-stale / absent-evidence / suppression-exception; stall sampler
dedup/reset/none-sample/missing-frame/shutdown. New tests + health-probe and
standalone-shutdown-ordering regressions green; `ruff` clean. Pre-implementation review +
two adversarial diff reviews (genesis-architect); a SHOULD-FIX on dead-publisher staleness
was closed with a regression test.

## Deploy

Runtime code — `git pull` + server restart. No migration. The stall sampler starts with the
server; the suppression takes effect on the next steady-state awareness tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
