### PR TITLE
perf(memory): offload entity-registry difflib fuzzy-match off the event loop

### DIFF
--- a/src/genesis/memory/entity_registry.py
+++ b/src/genesis/memory/entity_registry.py
@@ -21,6 +21,7 @@ rewriting here.
 
 from __future__ import annotations
 
+import asyncio
 import difflib
 
 import aiosqlite
@@ -103,7 +104,13 @@ async def resolve_entity(
         else [entity_type]
     )
     candidates = await entities_crud.list_norm_names(db, entity_types=cluster)
-    near = _closest(norm_name, candidates)
+    # _closest runs synchronous O(n*m) difflib fuzzy-matching over every
+    # same-cluster candidate. As the entity registry grew past the "small enough
+    # to scan in-process" assumption this blocked the event loop ~1s+ (measured
+    # via the loop-stall sampler, PR #1398). Offload to a thread so the loop keeps
+    # scheduling — _closest is a pure function over an already-materialized list,
+    # so it is safe to run off-loop.
+    near = await asyncio.to_thread(_closest, norm_name, candidates)
     entity_id = await entities_crud.create_entity(
         db, name=name, norm_name=norm_name, entity_type=entity_type,
         source=source, _commit=False,


### PR DESCRIPTION
## What

Offload the entity-registry fuzzy-match (`_closest`) off the event loop.

## Why

The loop-stall sampler added in #1398 captured the live event-loop starvation source on
its first wedge: `entity_registry._closest` runs synchronous O(n·m) `difflib` fuzzy-matching
over every same-cluster candidate **on the event loop** during the memory-extraction cycle.
As the entity registry grew past the module's "small enough to scan in-process" assumption,
this blocked the loop ~1s+ per resolution (measured: WEDGED stack dumps at ~1050ms each,
`resolve_entity → _closest → difflib.ratio`). That loop starvation is what times out the
health probes into false `critical_failure` alarms and drives the recall 503s.

## Change

`resolve_entity` now runs `_closest` via `asyncio.to_thread`, so the loop keeps scheduling
while the match runs on a worker thread. `_closest` is a pure function over an
already-materialized candidate list (no DB, no shared state, no `self`), so it is safe
off-loop; behavior is unchanged.

## Testing

The 33 existing entity-layer + write-wiring tests pass unchanged (behavior-equivalence lock —
the offload does not alter `resolve_entity`'s output or the fuzzy AMBIGUOUS tier). `ruff` clean.
Concurrency safety (purity, await-ordering, executor/GIL) adversarially reviewed.

## Deploy

Runtime code — `git pull` + server restart. E2E: after restart, the `difflib` frames should no
longer appear in the loop-stall sampler's WEDGED dumps.

Addresses the difflib starvation source tracked under follow-up fb3cf7be (other candidate
sources — inbox scanner sync-I/O, the ~30-min timer thundering-herd — remain to confirm once
the sampler runs at steady state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
