### PR TITLE
fix(alerts): GENESIS_HOME-aware container alert-queue root so tests can't write real alerts

### DIFF
--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -628,10 +628,11 @@ class WatchdogChecker:
         outreach pipeline; the dedupe_key collapses repeats to a single live
         entry per reason. Best-effort — never raises."""
         try:
+            from genesis.env import alert_queue_root
             from genesis.guardian.alert.queue import enqueue_alert
 
             enqueue_alert(
-                Path.home() / ".genesis" / "alerts" / "queue",
+                alert_queue_root(),
                 severity="warning",
                 source="watchdog",
                 title="Watchdog flap-damping repeated restarts",
@@ -721,10 +722,11 @@ class WatchdogChecker:
         (the oneshot watchdog has no outreach pipeline); the awareness tick drains
         it to the owner. Best-effort — never raises."""
         try:
+            from genesis.env import alert_queue_root
             from genesis.guardian.alert.queue import enqueue_alert
 
             enqueue_alert(
-                Path.home() / ".genesis" / "alerts" / "queue",
+                alert_queue_root(),
                 severity="warning",
                 source="watchdog",
                 title="Watchdog suppressed restart — server starved, not down",

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -102,6 +102,19 @@ def genesis_home() -> Path:
     return Path(value).expanduser() if value else Path.home() / ".genesis"
 
 
+def alert_queue_root() -> Path:
+    """Durable alert-queue root for the CONTAINER side (``~/.genesis/alerts/queue``).
+
+    Resolved via ``genesis_home()`` so it honors the ``GENESIS_HOME`` override.
+    That lets the test suite isolate it to a tmp dir (see the
+    ``_isolate_alert_queue`` conftest fixture) instead of writing real alerts the
+    live server would drain to the owner's Telegram. The HOST guardian uses
+    ``config.state_path/"alerts"/"queue"`` (a different, non-home path) and is
+    unaffected by this resolver.
+    """
+    return genesis_home() / "alerts" / "queue"
+
+
 def internal_api_token_path() -> Path:
     """Path to the persistent internal API token (generated once at server boot).
 

--- a/src/genesis/runtime/init/alert_drain.py
+++ b/src/genesis/runtime/init/alert_drain.py
@@ -16,11 +16,8 @@ meaningful tick outreach is up; until then entries are kept and retried.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
-
-_QUEUE_ROOT = Path.home() / ".genesis" / "alerts" / "queue"
 
 
 def wire(rt) -> None:
@@ -80,9 +77,15 @@ def _make_drainer(rt):
         return result.status in (OutreachStatus.DELIVERED, OutreachStatus.REJECTED)
 
     async def _drainer() -> None:
-        drained = await alert_queue.drain(_QUEUE_ROOT, _send)
+        # Resolve at drain time (call-time) via the GENESIS_HOME-aware resolver,
+        # so the queue root matches what watchdog writes and the test suite can
+        # isolate both through one seam (_isolate_alert_queue).
+        from genesis.env import alert_queue_root
+
+        root = alert_queue_root()
+        drained = await alert_queue.drain(root, _send)
         if drained:
             logger.info("Delivered %d queued alert(s) via outreach", drained)
-        alert_queue.prune(_QUEUE_ROOT)
+        alert_queue.prune(root)
 
     return _drainer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def _isolate_circuit_breaker_state(tmp_path, monkeypatch):
 
 # ── Safety: prevent tests from writing REAL durable alerts ──────────────────
 @pytest.fixture(autouse=True)
-def _isolate_alert_queue(tmp_path, monkeypatch):
+def _isolate_alert_queue(tmp_path):
     """Redirect the durable alert-queue root to tmp for ALL tests.
 
     ``_alert_flap`` / ``_alert_starved`` (watchdog) and the alert-drain init
@@ -82,11 +82,19 @@ def _isolate_alert_queue(tmp_path, monkeypatch):
     delivered as real incidents). Surgical: only the alert-queue root, NOT
     ``GENESIS_HOME`` globally, so config/state reads are untouched. The HOST
     guardian queue (``config.state_path``) is a separate path, unaffected.
+
+    Uses a fixture-OWNED ``MonkeyPatch`` (not the shared ``monkeypatch``
+    fixture) so a test that calls ``monkeypatch.undo()`` mid-body cannot revert
+    this suite-isolation patch and re-expose the real queue — mirrors
+    ``_isolate_user_config_dir``.
     """
-    monkeypatch.setattr(
+    mp = pytest.MonkeyPatch()
+    mp.setattr(
         "genesis.env.alert_queue_root",
         lambda: tmp_path / "alerts" / "queue",
     )
+    yield
+    mp.undo()
 
 
 # ── Safety: isolate tests from the install's config overlays ──

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,26 @@ def _isolate_circuit_breaker_state(tmp_path, monkeypatch):
     monkeypatch.setattr(cb_mod, "_STATE_FILE", tmp_path / "cb_state.json")
 
 
+# ── Safety: prevent tests from writing REAL durable alerts ──────────────────
+@pytest.fixture(autouse=True)
+def _isolate_alert_queue(tmp_path, monkeypatch):
+    """Redirect the durable alert-queue root to tmp for ALL tests.
+
+    ``_alert_flap`` / ``_alert_starved`` (watchdog) and the alert-drain init
+    resolve their queue root via ``env.alert_queue_root()``; patching that one
+    resolver keeps any test reaching an alert path from writing a REAL
+    ``~/.genesis/alerts/queue`` entry that the live server drains to the owner's
+    Telegram (this happened — test-sized 'flap-damping' backoff values were
+    delivered as real incidents). Surgical: only the alert-queue root, NOT
+    ``GENESIS_HOME`` globally, so config/state reads are untouched. The HOST
+    guardian queue (``config.state_path``) is a separate path, unaffected.
+    """
+    monkeypatch.setattr(
+        "genesis.env.alert_queue_root",
+        lambda: tmp_path / "alerts" / "queue",
+    )
+
+
 # ── Safety: isolate tests from the install's config overlays ──
 @pytest.fixture(autouse=True)
 def _isolate_user_config_dir(tmp_path):

--- a/tests/test_autonomy/test_alert_queue_isolation.py
+++ b/tests/test_autonomy/test_alert_queue_isolation.py
@@ -1,0 +1,71 @@
+"""91cdc681 — the durable alert-queue writers must resolve their root via
+``env.alert_queue_root()`` (GENESIS_HOME-aware) so no test writes a REAL
+``~/.genesis/alerts/queue`` entry the live server would drain to the owner.
+
+Repo-wide safety net: ``test_watchdog.py`` stubs ``enqueue_alert`` locally, but
+any OTHER test reaching an alert path was unprotected. These lock the central
+resolver + the global ``_isolate_alert_queue`` conftest fixture.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import genesis.env as env
+from genesis.autonomy.watchdog import WatchdogChecker
+
+
+def _build_checker(tmp_path: Path) -> WatchdogChecker:
+    """Minimal real WatchdogChecker (mirrors test_watchdog._make_checker)."""
+    return WatchdogChecker(
+        status_file=str(tmp_path / "status.json"),
+        staleness_threshold_s=300,
+        max_restart_attempts=5,
+        backoff_initial_s=1,
+        backoff_max_s=10,
+        config_validation=False,
+        secrets_path=str(tmp_path / "secrets.env"),
+        state_file=str(tmp_path / "watchdog_state.json"),
+        stabilization_s=600,
+        flap_window_s=21600,
+        flap_threshold=3,
+        flap_backoff_max_s=7200,
+    )
+
+
+def test_conftest_isolates_alert_queue_off_real_home():
+    """The global autouse fixture must redirect the resolver away from real home."""
+    real = Path.home() / ".genesis" / "alerts" / "queue"
+    assert env.alert_queue_root() != real
+
+
+def test_alert_flap_writes_through_resolver(tmp_path, monkeypatch):
+    """_alert_flap must enqueue under env.alert_queue_root(), not a hardcoded home."""
+    # Contain any Path.home() fallback so a RED run (buggy code) never pollutes
+    # the real ~/.genesis; assert on a distinct resolver path.
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    queue = tmp_path / "iso" / "alerts" / "queue"
+    monkeypatch.setattr(env, "alert_queue_root", lambda: queue)
+
+    checker = _build_checker(tmp_path)
+    checker._alert_flap("repro-reason", 3, 60.0)
+
+    assert list(queue.glob("*.json")), (
+        "alert must be written under env.alert_queue_root(), not a hardcoded "
+        "Path.home()/.genesis/alerts/queue"
+    )
+    # Real home must be untouched.
+    real = Path(tmp_path / "home") / ".genesis" / "alerts" / "queue"
+    assert not (real.exists() and list(real.glob("*.json")))
+
+
+def test_alert_starved_writes_through_resolver(tmp_path, monkeypatch):
+    """_alert_starved must also route through the resolver."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    queue = tmp_path / "iso" / "alerts" / "queue"
+    monkeypatch.setattr(env, "alert_queue_root", lambda: queue)
+
+    checker = _build_checker(tmp_path)
+    checker._alert_starved("repro-reason", {"lag_ms": 1200, "sample_age_s": 3}, 1)
+
+    assert list(queue.glob("*.json")), "starved alert must be written under env.alert_queue_root()"

--- a/tests/test_guardian/test_alert_drain.py
+++ b/tests/test_guardian/test_alert_drain.py
@@ -49,7 +49,7 @@ def _enqueue(root, **kw):
 @pytest.mark.asyncio
 async def test_delivered_unlinks_and_uses_identity_topic(tmp_path, monkeypatch):
     root = tmp_path / "queue"
-    monkeypatch.setattr(alert_drain, "_QUEUE_ROOT", root)
+    monkeypatch.setattr("genesis.env.alert_queue_root", lambda: root)
     _enqueue(root, dedupe_key="backup:k1")
     pipe = _FakePipeline(OutreachStatus.DELIVERED)
 
@@ -67,7 +67,7 @@ async def test_delivered_unlinks_and_uses_identity_topic(tmp_path, monkeypatch):
 async def test_rejected_is_terminal_unlinks(tmp_path, monkeypatch):
     # REJECTED (outreach dedup) must NOT wedge the entry forever.
     root = tmp_path / "queue"
-    monkeypatch.setattr(alert_drain, "_QUEUE_ROOT", root)
+    monkeypatch.setattr("genesis.env.alert_queue_root", lambda: root)
     _enqueue(root, dedupe_key="backup:k1")
     await alert_drain._make_drainer(_RT(pipeline=_FakePipeline(OutreachStatus.REJECTED)))()
     assert q.list_queued(root) == []
@@ -76,7 +76,7 @@ async def test_rejected_is_terminal_unlinks(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_failed_keeps_for_retry(tmp_path, monkeypatch):
     root = tmp_path / "queue"
-    monkeypatch.setattr(alert_drain, "_QUEUE_ROOT", root)
+    monkeypatch.setattr("genesis.env.alert_queue_root", lambda: root)
     _enqueue(root)
     await alert_drain._make_drainer(_RT(pipeline=_FakePipeline(OutreachStatus.FAILED)))()
     assert len(q.list_queued(root)) == 1  # transient → kept
@@ -85,7 +85,7 @@ async def test_failed_keeps_for_retry(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_unwired_pipeline_keeps_entry(tmp_path, monkeypatch):
     root = tmp_path / "queue"
-    monkeypatch.setattr(alert_drain, "_QUEUE_ROOT", root)
+    monkeypatch.setattr("genesis.env.alert_queue_root", lambda: root)
     _enqueue(root)
     await alert_drain._make_drainer(_RT(pipeline=None))()  # outreach not up yet
     assert len(q.list_queued(root)) == 1  # kept, never lost
@@ -94,7 +94,7 @@ async def test_unwired_pipeline_keeps_entry(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_empty_queue_is_noop(tmp_path, monkeypatch):
     root = tmp_path / "queue"
-    monkeypatch.setattr(alert_drain, "_QUEUE_ROOT", root)
+    monkeypatch.setattr("genesis.env.alert_queue_root", lambda: root)
     # No entries — drainer runs clean, no pipeline call.
     pipe = _FakePipeline(OutreachStatus.DELIVERED)
     await alert_drain._make_drainer(_RT(pipeline=pipe))()


### PR DESCRIPTION
## What

The container durable alert-queue root was hardcoded as `Path.home()/".genesis"/"alerts"/"queue"` at three write/drain sites. Any test reaching an alert path wrote a **real** durable alert that the live server drains to the owner — test-sized flap-damping backoffs were being delivered as real incidents.

## Change

- **`env.alert_queue_root()`** — one container-side resolver, `genesis_home()/"alerts"/"queue"` (honors `GENESIS_HOME`).
- **`watchdog.py`** (`_alert_flap`, `_alert_starved`) and **`runtime/init/alert_drain.py`** now resolve via it at **call time** (inline import → a patchable seam).
- **`conftest.py` `_isolate_alert_queue`** — global autouse fixture that redirects the resolver to a tmp dir. Surgical: patches only this one symbol, not `GENESIS_HOME` globally, so config/state reads are untouched. Repo-wide safety net — no test can write a real alert (previously only `test_watchdog.py` had a local stub).
- **New `test_alert_queue_isolation.py`** (verify-RED confirmed: the behavioral tests fail against the old hardcoded path). **`test_alert_drain.py`** lockstep-ported off the removed `_QUEUE_ROOT` seam.

## Scope / correctness

- The **HOST guardian** queue (`config.state_path/"alerts"/"queue"`) is a separate path — deliberately unchanged.
- Writer (watchdog, a separate oneshot process) and drainer (in-server) both resolve via the same resolver → identical path in prod (`GENESIS_HOME` is unset in prod).
- Class-complete: grep confirms zero hardcoded home alert-writers remain; the only other `enqueue_alert` caller is the HOST path.
- **Known scope boundary (prod-inert):** shell writers (`scripts/lib/alert_queue.sh`, tmp-watchgod) still key off `HOME`/`GENESIS_ALERT_QUEUE_ROOT`. With `GENESIS_HOME` unset (prod) all sides agree; converging shell+python on one home-path resolver is tracked as a broader follow-up.

## Testing

`ruff` clean; 1098 tests green (guardian + autonomy + isolation + a cross-subsystem smoke). Verify-RED→GREEN on the new behavioral tests.

Follow-up: 91cdc6811d9142b7bc6189250bcfd8cb

🤖 Generated with [Claude Code](https://claude.com/claude-code)