### PR TITLE
fix(memory): OR-fallback for FTS5 recall to end implicit-AND starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **FTS5 recall no longer starves on multi-word queries.** `_prepare_fts5` builds a
+  bare space-separated FTS5 MATCH, which SQLite treats as an implicit AND — so a
+  verbose query (`reference_lookup` / `knowledge_recall` natural-language text, and
+  memory recall on its non-expanded fallback path) required *every* token to be
+  present and otherwise returned nothing. A shared `db/crud/_fts.py::fetch_fts` now
+  runs the precise AND query first and, only when it returns zero rows and the query
+  isn't an already-structured boolean expression, retries the terms OR-joined —
+  adding partial matches where there were none while leaving every already-matching
+  query unchanged. Applied to the recall surfaces `knowledge.search_fts` and
+  `memory.search_ranked` (the latter's `boolean=False` path, which the hot recall
+  path falls back to when `expand_query` can't expand, e.g. Qdrant unavailable).
+  `memory.search` is left strict-AND on purpose — its only caller resolves entity
+  names by `results[0]` and must not be widened to single-term matches.
+  Audited-clean: `extraction_job`'s dedup check already OR-joins; `voice/hygiene`'s
+  constant-match sweep is unaffected.
+
 ### Added
 
 - **Opt-in career-outreach monitor (off by default).** A new daily monitor that,

--- a/src/genesis/db/crud/_fts.py
+++ b/src/genesis/db/crud/_fts.py
@@ -14,6 +14,63 @@ from __future__ import annotations
 
 import aiosqlite
 
+# Ultra-common English stopwords dropped from the OR retry so a verbose query
+# like "where is the nonexistent service" falls back to "nonexistent OR service"
+# instead of "where OR is OR the OR ..." (which matches almost every row). Kept
+# deliberately small — only near-universal function words — so it never strips a
+# meaningful content term. The AND pass is unaffected (it keeps every token).
+_OR_STOPWORDS = frozenset(
+    [
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "been",
+        "being",
+        "but",
+        "by",
+        "for",
+        "from",
+        "he",
+        "how",
+        "i",
+        "in",
+        "into",
+        "is",
+        "it",
+        "its",
+        "me",
+        "my",
+        "of",
+        "on",
+        "or",
+        "our",
+        "she",
+        "that",
+        "the",
+        "these",
+        "they",
+        "this",
+        "those",
+        "to",
+        "was",
+        "we",
+        "were",
+        "what",
+        "when",
+        "where",
+        "which",
+        "who",
+        "why",
+        "with",
+        "you",
+        "your",
+    ]
+)
+
 
 def or_fallback(escaped: str) -> str | None:
     """The OR-joined form of a cleaned (implicit-AND) FTS5 query.
@@ -22,10 +79,15 @@ def or_fallback(escaped: str) -> str | None:
     A multi-term query becomes ``term1 OR term2 OR ...`` — the lowercase tokens
     are plain search terms and the uppercase ``OR`` is the FTS5 operator
     (``_prepare_fts5`` lowercases its input, so no accidental operators survive
-    the join).
+    the join). Ultra-common stopwords are dropped from the OR join to keep the
+    fallback precise; if EVERY token is a stopword they are all kept (an OR of
+    stopwords still beats returning nothing).
     """
     parts = escaped.split()
-    return " OR ".join(parts) if len(parts) > 1 else None
+    if len(parts) <= 1:
+        return None
+    meaningful = [p for p in parts if p not in _OR_STOPWORDS]
+    return " OR ".join(meaningful or parts)
 
 
 async def fetch_fts(

--- a/src/genesis/db/crud/_fts.py
+++ b/src/genesis/db/crud/_fts.py
@@ -1,0 +1,57 @@
+"""Shared FTS5 query helpers.
+
+FTS5's default MATCH syntax treats space-separated bare terms as an implicit
+AND — every term must appear in a row. ``_prepare_fts5`` produces exactly such a
+bare string, so a multi-word natural-language query requires ALL its tokens to
+be present verbatim, else it returns nothing (a bare IP matches only because all
+its tokens happen to be present). ``fetch_fts`` keeps the precise AND-first
+behavior but falls back to an OR-join when AND finds nothing, so a verbose query
+still recalls the best partial matches (BM25-ranked). It only ever ADDS results
+when the AND query returned zero — it never changes a query that already hit.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+def or_fallback(escaped: str) -> str | None:
+    """The OR-joined form of a cleaned (implicit-AND) FTS5 query.
+
+    Returns ``None`` for a single-term query (AND == OR, no fallback needed).
+    A multi-term query becomes ``term1 OR term2 OR ...`` — the lowercase tokens
+    are plain search terms and the uppercase ``OR`` is the FTS5 operator
+    (``_prepare_fts5`` lowercases its input, so no accidental operators survive
+    the join).
+    """
+    parts = escaped.split()
+    return " OR ".join(parts) if len(parts) > 1 else None
+
+
+async def fetch_fts(
+    db: aiosqlite.Connection,
+    sql: str,
+    params: list,
+    *,
+    boolean: bool = False,
+    match_index: int = 0,
+) -> list:
+    """Run an FTS5 MATCH query, retrying OR-joined when AND returns nothing.
+
+    Callers MUST pass a lowercased, operator-free MATCH expression (as
+    ``_prepare_fts5`` produces) so the OR-join can never turn a bare token into
+    an FTS5 operator. ``params[match_index]`` MUST be the MATCH expression.
+    The OR retry fires only when the first (AND) pass returned zero rows, the
+    expression was not already a structured boolean query (``boolean`` is
+    False), and it is multi-term. The retry runs on a COPY of ``params`` so the
+    caller's list is never mutated.
+    """
+    rows = await db.execute_fetchall(sql, params)
+    if rows or boolean:
+        return rows
+    alt = or_fallback(params[match_index])
+    if alt is None:
+        return rows
+    retry = list(params)
+    retry[match_index] = alt
+    return await db.execute_fetchall(sql, retry)

--- a/src/genesis/db/crud/knowledge.py
+++ b/src/genesis/db/crud/knowledge.py
@@ -8,6 +8,8 @@ from datetime import UTC, datetime
 
 import aiosqlite
 
+from genesis.db.crud._fts import fetch_fts
+
 
 def _prepare_fts5(query: str) -> str | None:
     """Prepare a query string for FTS5 MATCH.
@@ -302,7 +304,10 @@ async def search_fts(
         params.append(domain)
     sql += " ORDER BY f.rank LIMIT ?"
     params.append(limit)
-    rows = await db.execute_fetchall(sql, params)
+    # AND-first, OR-fallback on zero rows: FTS5's implicit-AND otherwise starves
+    # multi-word queries (every token must match). knowledge_fts has no boolean
+    # mode, so the fallback always applies here.
+    rows = await fetch_fts(db, sql, params)
     return [
         {
             "unit_id": r[0], "concept": r[1], "body": r[2],

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -10,6 +10,7 @@ import re
 
 import aiosqlite
 
+from genesis.db.crud._fts import fetch_fts
 from genesis.db.timeutil import canonical_iso
 
 
@@ -137,6 +138,11 @@ async def search(
         params.append(collection)
     sql += " LIMIT ?"
     params.append(limit)
+    # DELIBERATELY no OR-fallback here (unlike search_ranked / knowledge.search_fts).
+    # memory.search's only callers are the entity-name resolver
+    # (linker._find_entity_by_name), which picks results[0] and must NOT be
+    # widened to single-term OR matches — that would bypass its difflib quality
+    # gate and create spurious graph links. Keep this path strict AND.
     rows = await db.execute_fetchall(sql, params)
     return [
         {"memory_id": r[0], "content": r[1], "source_type": r[2], "collection": r[3]} for r in rows
@@ -214,7 +220,10 @@ async def search_ranked(
         params.extend(include_only_subsystems)
     sql += " ORDER BY rank LIMIT ?"
     params.append(limit)
-    rows = await db.execute_fetchall(sql, params)
+    # AND-first, OR-fallback on zero rows (see _fts.fetch_fts). Skipped when the
+    # query is already a structured boolean expression (expand_query output),
+    # since re-tokenising a parenthesised OR/AND query would corrupt it.
+    rows = await fetch_fts(db, sql, params, boolean=boolean)
     return [
         {
             "memory_id": r[0],

--- a/tests/test_db/test_fts_or_fallback.py
+++ b/tests/test_db/test_fts_or_fallback.py
@@ -35,6 +35,22 @@ def test_or_fallback_empty_is_none():
     assert or_fallback("   ") is None
 
 
+def test_or_fallback_drops_stopwords():
+    # A verbose query OR-joins only the MEANINGFUL terms, not the/is/where noise.
+    assert or_fallback("where is the nonexistent service") == "nonexistent OR service"
+
+
+def test_or_fallback_all_stopwords_kept():
+    # If every token is a stopword, keep them all — an OR still beats nothing.
+    assert or_fallback("the a of") == "the OR a OR of"
+
+
+def test_or_fallback_reduces_to_single_meaningful_term():
+    # Multi-term query reducing to ONE meaningful term -> that term alone
+    # (a valid single-term FTS query, strictly better than the zero-row AND).
+    assert or_fallback("where is the service") == "service"
+
+
 @pytest.mark.skipif(not _fts5_available, reason="FTS5 not available")
 class TestFetchFts:
     @pytest.fixture

--- a/tests/test_db/test_fts_or_fallback.py
+++ b/tests/test_db/test_fts_or_fallback.py
@@ -1,0 +1,71 @@
+"""Unit tests for the shared FTS5 OR-fallback helper (db/crud/_fts.py).
+
+FTS5's default MATCH is implicit-AND, so a multi-word query starves unless every
+token is present. ``fetch_fts`` keeps AND-first precision but retries OR-joined
+when AND finds nothing — only ADDING results, never changing a query that hit.
+"""
+
+import sqlite3
+
+import pytest
+
+from genesis.db.crud._fts import fetch_fts, or_fallback
+
+# FTS5 may be unavailable in the in-memory SQLite build.
+_fts5_available = True
+try:
+    _c = sqlite3.connect(":memory:")
+    _c.execute("CREATE VIRTUAL TABLE _probe USING fts5(x)")
+    _c.close()
+except Exception:
+    _fts5_available = False
+
+
+def test_or_fallback_multi_term_joins_with_or():
+    assert or_fallback("alpha beta gamma") == "alpha OR beta OR gamma"
+
+
+def test_or_fallback_single_term_is_none():
+    # single term: AND == OR, no fallback needed
+    assert or_fallback("solo") is None
+
+
+def test_or_fallback_empty_is_none():
+    assert or_fallback("") is None
+    assert or_fallback("   ") is None
+
+
+@pytest.mark.skipif(not _fts5_available, reason="FTS5 not available")
+class TestFetchFts:
+    @pytest.fixture
+    async def db(self):
+        import aiosqlite
+
+        conn = await aiosqlite.connect(":memory:")
+        await conn.execute("CREATE VIRTUAL TABLE t USING fts5(body, tokenize='porter ascii')")
+        await conn.execute("INSERT INTO t(body) VALUES ('alpha beta gamma')")
+        await conn.commit()
+        yield conn
+        await conn.close()
+
+    _SQL = "SELECT body FROM t WHERE t MATCH ?"
+
+    async def test_and_miss_falls_back_to_or(self, db):
+        # 'alpha zzz' as implicit-AND requires BOTH -> 0 rows; OR-fallback finds 'alpha'.
+        rows = await fetch_fts(db, self._SQL, ["alpha zzz"])
+        assert rows and rows[0][0] == "alpha beta gamma"
+
+    async def test_and_hit_needs_no_fallback(self, db):
+        # both terms present -> AND already returns; fallback irrelevant.
+        rows = await fetch_fts(db, self._SQL, ["alpha beta"])
+        assert rows and rows[0][0] == "alpha beta gamma"
+
+    async def test_boolean_true_skips_fallback(self, db):
+        # boolean=True (already-structured query): no re-tokenising, AND miss stays empty.
+        rows = await fetch_fts(db, self._SQL, ["alpha zzz"], boolean=True)
+        assert rows == []
+
+    async def test_single_absent_term_stays_empty(self, db):
+        # single term, genuinely absent: no fallback can help, stays empty.
+        rows = await fetch_fts(db, self._SQL, ["zzz"])
+        assert rows == []

--- a/tests/test_db/test_knowledge_crud.py
+++ b/tests/test_db/test_knowledge_crud.py
@@ -143,6 +143,28 @@ async def test_fts_search(db):
     assert results[0]["concept"] == "VPC"
 
 
+async def test_fts_search_or_fallback_on_partial_terms(db):
+    # A term absent from the doc makes FTS5's implicit-AND return nothing; the
+    # OR-fallback surfaces the row on the term(s) that DO match.
+    await knowledge.insert(
+        db, project_type="cloud", domain="aws", source_doc="m1",
+        concept="VPC", body="Virtual Private Cloud for network isolation",
+    )
+    results = await knowledge.search_fts(db, "network nonexistentword")
+    assert len(results) == 1
+    assert results[0]["concept"] == "VPC"
+
+
+async def test_fts_search_and_precise_when_all_present(db):
+    # All terms present: the AND path already hits; fallback never fires.
+    await knowledge.insert(
+        db, project_type="cloud", domain="aws", source_doc="m1",
+        concept="VPC", body="Virtual Private Cloud for network isolation",
+    )
+    results = await knowledge.search_fts(db, "network isolation")
+    assert results[0]["concept"] == "VPC"
+
+
 async def test_fts_search_with_project_filter(db):
     await knowledge.insert(
         db, project_type="cloud", domain="aws", source_doc="m1",
@@ -380,7 +402,10 @@ async def test_upsert_fts_shadow_row_updated(db):
         source_doc="m1", concept="test url",
         body="first body text for full-text search",
     )
-    results_before = await knowledge.search_fts(db, "first body")
+    # Probe a term UNIQUE to the old content ("first"; "body" survives into the
+    # new content). Single-term so the OR-fallback can't resurface it — this
+    # tests upsert-replacement precisely, not FTS AND/OR semantics.
+    results_before = await knowledge.search_fts(db, "first")
     assert any(r["unit_id"] == uid for r in results_before)
 
     await knowledge.upsert(
@@ -388,8 +413,8 @@ async def test_upsert_fts_shadow_row_updated(db):
         source_doc="m1", concept="test url",
         body="replacement body content indexed fresh",
     )
-    results_old = await knowledge.search_fts(db, "first body")
-    # Old content no longer indexed
+    results_old = await knowledge.search_fts(db, "first")
+    # Old content no longer indexed (the unique old term is gone)
     assert not any(r["unit_id"] == uid for r in results_old)
     results_new = await knowledge.search_fts(db, "replacement body")
     assert any(r["unit_id"] == uid for r in results_new)

--- a/tests/test_db/test_memory.py
+++ b/tests/test_db/test_memory.py
@@ -71,6 +71,31 @@ async def test_search_ranked_with_collection(db):
     assert all(r["collection"] == "special" for r in results)
 
 
+async def test_search_is_and_only_no_fallback(db):
+    # memory.search is DELIBERATELY AND-only (no OR-fallback): its only caller is
+    # the entity-name resolver, which must not be widened to single-term matches.
+    # A partial-term query returns NOTHING (contrast search_ranked below).
+    await memory.create(db, memory_id="p1", content="alpha beta gamma delta")
+    assert await memory.search(db, query="alpha nonexistentword") == []
+    # A fully-present query still hits (basic AND path intact).
+    assert [r["memory_id"] for r in await memory.search(db, query="alpha beta")] == ["p1"]
+
+
+async def test_search_ranked_or_fallback_on_partial_terms(db):
+    await memory.create(db, memory_id="p3", content="alpha beta gamma delta")
+    results = await memory.search_ranked(db, query="alpha nonexistentword")
+    assert [r["memory_id"] for r in results] == ["p3"]
+
+
+async def test_search_ranked_boolean_true_skips_fallback(db):
+    # Default (raw) query surfaces via OR-fallback; the SAME query with
+    # boolean=True is treated as a structured expression and must NOT fall back,
+    # so it stays empty — proving the guard.
+    await memory.create(db, memory_id="p4", content="alpha beta gamma")
+    assert [r["memory_id"] for r in await memory.search_ranked(db, query="alpha zzz")] == ["p4"]
+    assert await memory.search_ranked(db, query="alpha zzz", boolean=True) == []
+
+
 async def test_get_taxonomy(db):
     await memory.create_metadata(
         db, memory_id="tx1", created_at="2020-01-01T00:00:00+00:00",


### PR DESCRIPTION
FTS5 treats a bare space-separated `MATCH` string as an implicit **AND**, so
multi-word natural-language queries (`reference_lookup` / `knowledge_recall`, and
memory recall on its non-expanded fallback path) required **every** token to be
present or returned nothing. Root cause re-verified on the live `knowledge_fts`:
an 11-term AND query returned 0 rows while the same terms OR-joined returned the
target ranked #1.

## Fix
New shared `db/crud/_fts.py::fetch_fts` runs the precise AND query first and —
**only when it returns zero rows and the query is not an already-structured
boolean expression** — retries the terms OR-joined (on a copy of `params`). It
only ever *adds* results when AND found none; it never changes a query that
already hit.

Wired into the recall surfaces:
- `knowledge.search_fts` (`knowledge_fts`; always applies — no boolean mode)
- `memory.search_ranked` (`memory_fts`, `boolean=False` path — the fallback the
  hot recall path uses when `expand_query` cannot expand, e.g. Qdrant down)

`memory.search` is left **strict-AND on purpose**: its only callers are the
entity-name resolver (`linker._find_entity_by_name`), which picks `results[0]`
and must not be widened to single-term matches (it would bypass its difflib
quality gate → spurious graph links). Audited-clean and unchanged:
`extraction_job` dedup already OR-joins; `voice/hygiene` matches a fixed constant.

## Tests / verification
- `_fts` helper units + integration on both recall paths (partial-term → fallback
  surfaces; all-present → AND unchanged; `boolean=True` → no fallback); a lock
  test pinning `memory.search` AND-only; one existing test re-probed off an
  incidental AND-strictness assumption.
- **82 passed** (incl. `test_linker` suites); an earlier full sweep of
  **2789 passed** across `test_db` + `test_memory` + memory MCP.
- FTS5 operator/numeric edge cases probed live (OR-joined lowercased tokens never
  form an operator); `params` copy is non-destructive; `match_index=0` correct in
  both callers.

Adversarially reviewed (genesis-architect): the single SHOULD-FIX — a linker
resolution gate that `memory.search` feeds — is resolved by **not** widening
`memory.search`, verified firsthand and by the linker test suites.

No migration, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)