### PR TITLE
fix(security): deny Bash on mail judge + MCP writes on inbox judge (judge-lockdown partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   background sessions that legitimately orchestrate — e.g. the deep-research `Workflow`
   path — are intentionally out of scope and tracked separately.)
 
+- **Inbox/mail evaluation judges further hardened against adversarial external input.**
+  Both judges reason over untrusted content (emails / dropped inbox items) with
+  permissions skipped. The mail judge — whose prompt uses no tools at all — now denies
+  `Bash` entirely. The inbox judge now denies every memory/settings write tool (it only
+  ever needed reads plus a single observation write), closing a path where injected
+  content could mutate stored memory or settings; the denial is derived from the
+  reflection read-only denylist, so a future write tool is auto-covered. The inbox judge
+  still retains shell access for one narrow job — fetching YouTube inbox links — which is
+  tracked separately.
+
 - **The autonomous-CLI approval gate now ships ON by default.** Every background
   Claude Code session Genesis dispatches must be rooted in an explicit user
   approval — but the committed policy config shipped the gate *off*, so a fresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,13 +66,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 - **Inbox/mail evaluation judges further hardened against adversarial external input.**
   Both judges reason over untrusted content (emails / dropped inbox items) with
-  permissions skipped. The mail judge — whose prompt uses no tools at all — now denies
-  `Bash` entirely. The inbox judge now denies every memory/settings write tool (it only
-  ever needed reads plus a single observation write), closing a path where injected
-  content could mutate stored memory or settings; the denial is derived from the
-  reflection read-only denylist, so a future write tool is auto-covered. The inbox judge
-  still retains shell access for one narrow job — fetching YouTube inbox links — which is
-  tracked separately.
+  permissions skipped. The mail judge — whose prompt uses no tools at all — now runs a
+  full act-nothing denylist (shell, all file-edit, subagent-spawn, side-effecting actions,
+  and web tools), and a stale config-path bug that pointed its empty-MCP profile at a
+  nonexistent file was fixed. The inbox judge now denies every memory/settings write tool
+  (it only ever needed reads plus a single optional observation write), closing a path
+  where injected content could mutate stored memory or settings; the denial is derived from
+  the reflection read-only denylist, so a future write tool is auto-covered. Two narrower
+  residuals on the inbox judge remain tracked (not closed here): it keeps shell access for
+  one job — fetching YouTube links — and its retained observation writer is not yet
+  provenance-stamped or type-constrained; both are handled in follow-up work.
 
 - **The autonomous-CLI approval gate now ships ON by default.** Every background
   Claude Code session Genesis dispatches must be rooted in an explicit user

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -235,10 +235,14 @@ verified: 51253c67 2026-08-13
   value, not an orphaned constant). `sentinel/dispatcher._DEGRADED_DISALLOWED_TOOLS` keeps
   its own literal (deliberate import-cycle avoidance) but is held ⊇ by
   `tests/test_cc/test_spawn_lockdown.py`, which locks the class so a new denylist that
-  forgets spawn-blocking fails CI. NOTE: the inbox/mail judges are spawn-hardened here but
-  are NOT yet fully read-only — they still leave `Bash` (and, for inbox, memory/settings
-  MCP writes) available on external input; closing that broader boundary is a separate
-  tracked follow-up.
+  forgets spawn-blocking fails CI. The mail judge is now fully denied `Bash` (its prompt
+  uses no tools); the inbox judge additionally denies every genesis MCP *write*
+  (`memory_store`/`settings_update`/`follow_up_create`/…) while keeping the reads +
+  `observation_write` its prompt needs (derived from `build_reflection_disallowed` minus
+  `Bash`, so a future write tool is auto-denied). The inbox judge's ONE remaining residual
+  is `Bash` — retained for the `yt-dlp`/`curl` YouTube-fetch path; relocating that fetch
+  into Python so `Bash` can also be denied is tracked separately (follow-up 727a3724, the
+  inbox judge's injection→RCE surface).
   **Out of scope (tracked follow-up):** `cc/direct_session` (its `research` profile runs a
   DOCUMENTED deep-research `Workflow` — blocking the class there would break that path) and
   the autonomy-executor sessions; those legitimately spawn/orchestrate and need a

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -235,14 +235,19 @@ verified: 51253c67 2026-08-13
   value, not an orphaned constant). `sentinel/dispatcher._DEGRADED_DISALLOWED_TOOLS` keeps
   its own literal (deliberate import-cycle avoidance) but is held ⊇ by
   `tests/test_cc/test_spawn_lockdown.py`, which locks the class so a new denylist that
-  forgets spawn-blocking fails CI. The mail judge is now fully denied `Bash` (its prompt
-  uses no tools); the inbox judge additionally denies every genesis MCP *write*
-  (`memory_store`/`settings_update`/`follow_up_create`/…) while keeping the reads +
-  `observation_write` its prompt needs (derived from `build_reflection_disallowed` minus
-  `Bash`, so a future write tool is auto-denied). The inbox judge's ONE remaining residual
-  is `Bash` — retained for the `yt-dlp`/`curl` YouTube-fetch path; relocating that fetch
-  into Python so `Bash` can also be denied is tracked separately (follow-up 727a3724, the
-  inbox judge's injection→RCE surface).
+  forgets spawn-blocking fails CI. The mail judge — whose prompt uses NO tools — now runs
+  an ACT-NOTHING denylist (Bash + all file-edit + spawn + side-effecting actions + web
+  tools, closing the Read+WebFetch exfil path), and its empty-MCP config is resolved via
+  the canonical `build_mcp_config("none")` (the old hand-counted `parents[2]` path pointed
+  at a nonexistent `src/config/no_mcp.json`). The inbox judge denies every genesis MCP
+  *write* (`memory_store`/`settings_update`/`follow_up_create`/…) via
+  `build_reflection_disallowed` minus `Bash`, keeping the reads it needs plus the optional
+  `observation_write`. Two RESIDUALS on the inbox judge, both tracked (follow-up 727a3724),
+  NOT closed here: (1) `Bash` — retained for the `yt-dlp`/`curl` YouTube-fetch path
+  (injection→RCE surface); (2) the retained `observation_write` neither stamps external
+  provenance nor constrains observation `type`, so an injected item could in principle forge
+  a `user_model_delta` — a low-likelihood, curated-input vector whose real fix (a provisional
+  provenance tier + writer type-authorization) belongs in the memory-provenance work.
   **Out of scope (tracked follow-up):** `cc/direct_session` (its `research` profile runs a
   DOCUMENTED deep-research `Workflow` — blocking the class there would break that path) and
   the autonomy-executor sessions; those legitimately spawn/orchestrate and need a

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -16,7 +16,6 @@ from apscheduler.triggers.interval import IntervalTrigger
 
 from genesis.autonomy.autonomous_dispatch import AutonomousDispatchRequest
 from genesis.cc.session_config import SessionConfigBuilder
-from genesis.cc.types import SPAWN_TOOL_NAMES
 from genesis.inbox.scanner import (
     compute_hash,
     detect_changes,
@@ -36,12 +35,27 @@ logger = logging.getLogger(__name__)
 _PROMPT_DIR = Path(__file__).resolve().parent.parent / "identity"
 _SYSTEM_PROMPT_FILE = "INBOX_EVALUATE.md"
 
-# The inbox-eval judge denies file writes and the whole SPAWN class (SPAWN_TOOL_NAMES =
-# Agent/Task/Workflow/Skill) — no subagent spawn can inherit a fresh, unrestricted
-# toolset and escape. NOTE: this is spawn-hardening, NOT a full read-only boundary — the
-# judge still leaves Bash (and this profile's memory/settings MCP writes) available on
-# external input; closing that is a separate tracked follow-up.
-_EVAL_DISALLOWED_TOOLS: list[str] = ["Write", "Edit", "NotebookEdit", *SPAWN_TOOL_NAMES]
+
+def _eval_disallowed_tools() -> list[str]:
+    """Tools denied to the inbox-eval judge (runs skip_permissions on EXTERNAL input).
+
+    This is the reflection read-only denylist (``build_reflection_disallowed``)
+    MINUS ``Bash``. It denies file writes, the whole SPAWN class
+    (Agent/Task/Workflow/Skill — a spawned child would escape with a fresh,
+    unrestricted toolset), the user-scoped MCP servers, and every genesis MCP
+    *write* (``memory_store`` / ``settings_update`` / ``follow_up_create`` / …),
+    while KEEPING the reads the prompt needs (``memory_recall`` /
+    ``procedure_recall`` / genesis-health status reads) and its one sanctioned
+    write (``observation_write``).
+
+    ``Bash`` is deliberately RETAINED: the prompt shells out to ``yt-dlp`` /
+    ``curl`` to fetch YouTube (and SSL-failing) inbox URLs. Relocating that fetch
+    into Python so ``Bash`` can also be denied is the remaining residual of
+    follow-up 727a3724 (the inbox judge's injection→RCE surface). Deriving from
+    ``build_reflection_disallowed`` (live per call) means a genesis MCP write
+    added in a future PR is auto-denied here with no code change.
+    """
+    return [t for t in SessionConfigBuilder().build_reflection_disallowed() if t != "Bash"]
 
 
 _FALLBACK_SYSTEM_PROMPT = (
@@ -1338,12 +1352,13 @@ class InboxMonitor:
             system_prompt=system_prompt,
             timeout_s=self._config.timeout_s,
             skip_permissions=True,
-            disallowed_tools=list(_EVAL_DISALLOWED_TOOLS),
+            disallowed_tools=_eval_disallowed_tools(),
             working_dir=background_session_dir(),
             mcp_config=mcp_path,
-            # WS-3: inbox evaluations process EXTERNAL content by construction,
-            # and this session's MCP profile ("reflection") includes
-            # genesis-memory — its writes must carry external provenance.
+            # WS-3: inbox evaluations process EXTERNAL content by construction.
+            # The dangerous genesis MCP writes are now denied (see
+            # _eval_disallowed_tools); the ONE write left — observation_write —
+            # must carry external provenance, so stamp the whole session.
             origin=ORIGIN_EXTERNAL_UNTRUSTED,
         )
 

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -45,8 +45,8 @@ def _eval_disallowed_tools() -> list[str]:
     unrestricted toolset), the user-scoped MCP servers, and every genesis MCP
     *write* (``memory_store`` / ``settings_update`` / ``follow_up_create`` / …),
     while KEEPING the reads the prompt needs (``memory_recall`` /
-    ``procedure_recall`` / genesis-health status reads) and its one sanctioned
-    write (``observation_write``).
+    ``procedure_recall`` / genesis-health status reads) and the one write the
+    prompt still uses (``observation_write`` — the OPTIONAL ``user_signal`` digest).
 
     ``Bash`` is deliberately RETAINED: the prompt shells out to ``yt-dlp`` /
     ``curl`` to fetch YouTube (and SSL-failing) inbox URLs. Relocating that fetch
@@ -54,6 +54,15 @@ def _eval_disallowed_tools() -> list[str]:
     follow-up 727a3724 (the inbox judge's injection→RCE surface). Deriving from
     ``build_reflection_disallowed`` (live per call) means a genesis MCP write
     added in a future PR is auto-denied here with no code change.
+
+    NOTE: the retained ``observation_write`` is a RESIDUAL write surface, not a
+    proven-safe one. Today it neither stamps external provenance (the tool ignores
+    the session origin, unlike the procedural/knowledge writers) nor constrains the
+    observation ``type`` — so an injected item could in principle forge a
+    ``user_model_delta`` that the user-model pipeline auto-accepts. That is a
+    LOW-likelihood, curated-input vector; the real fix (a provisional provenance
+    tier + type-authorization on the writer) is tracked in the memory-provenance
+    work, deliberately NOT bolted onto this tool-denylist change.
     """
     return [t for t in SessionConfigBuilder().build_reflection_disallowed() if t != "Bash"]
 
@@ -1355,10 +1364,11 @@ class InboxMonitor:
             disallowed_tools=_eval_disallowed_tools(),
             working_dir=background_session_dir(),
             mcp_config=mcp_path,
-            # WS-3: inbox evaluations process EXTERNAL content by construction.
-            # The dangerous genesis MCP writes are now denied (see
-            # _eval_disallowed_tools); the ONE write left — observation_write —
-            # must carry external provenance, so stamp the whole session.
+            # WS-3: inbox evaluations process EXTERNAL content by construction, so
+            # stamp the session external — the Python-side eval-memory writes read
+            # this, and any future origin-aware MCP write will too. NOTE: the one
+            # retained MCP write here (observation_write) does NOT currently honor
+            # this stamp (see _eval_disallowed_tools) — tracked, not fixed here.
             origin=ORIGIN_EXTERNAL_UNTRUSTED,
         )
 

--- a/src/genesis/mail/monitor.py
+++ b/src/genesis/mail/monitor.py
@@ -37,12 +37,13 @@ logger = logging.getLogger(__name__)
 
 _IDENTITY_DIR = Path(__file__).resolve().parents[1] / "identity"
 
-# The mail judge denies file writes and the whole SPAWN class (SPAWN_TOOL_NAMES =
-# Agent/Task/Workflow/Skill) — no subagent spawn can escape with a fresh toolset. Its MCP
-# config is no_mcp (no memory server). NOTE: spawn-hardening, NOT a full read-only
-# boundary — Bash is still available on external input; closing that is a separate
-# tracked follow-up.
-_JUDGE_DISALLOWED_TOOLS: list[str] = ["Write", "Edit", "NotebookEdit", *SPAWN_TOOL_NAMES]
+# The mail judge reads pre-digested briefs and emits JSON keep/discard decisions —
+# its prompt (MAIL_EVALUATE.md) uses NO tools. So it denies Bash, file writes, and the
+# whole SPAWN class (SPAWN_TOOL_NAMES = Agent/Task/Workflow/Skill — a spawned child would
+# escape with a fresh toolset), and its MCP config is no_mcp (no memory server). This is a
+# full read-only boundary on an external-input, skip_permissions session — nothing the
+# judge legitimately does is lost (727a3724).
+_JUDGE_DISALLOWED_TOOLS: list[str] = ["Bash", "Write", "Edit", "NotebookEdit", *SPAWN_TOOL_NAMES]
 
 
 class MailMonitor:

--- a/src/genesis/mail/monitor.py
+++ b/src/genesis/mail/monitor.py
@@ -38,12 +38,39 @@ logger = logging.getLogger(__name__)
 _IDENTITY_DIR = Path(__file__).resolve().parents[1] / "identity"
 
 # The mail judge reads pre-digested briefs and emits JSON keep/discard decisions —
-# its prompt (MAIL_EVALUATE.md) uses NO tools. So it denies Bash, file writes, and the
-# whole SPAWN class (SPAWN_TOOL_NAMES = Agent/Task/Workflow/Skill — a spawned child would
-# escape with a fresh toolset), and its MCP config is no_mcp (no memory server). This is a
-# full read-only boundary on an external-input, skip_permissions session — nothing the
-# judge legitimately does is lost (727a3724).
-_JUDGE_DISALLOWED_TOOLS: list[str] = ["Bash", "Write", "Edit", "NotebookEdit", *SPAWN_TOOL_NAMES]
+# its prompt (MAIL_EVALUATE.md) uses NO tools. So it runs with an ACT-NOTHING denylist on
+# this external-input, skip_permissions session: deny every mutation, file-edit, the whole
+# SPAWN class (SPAWN_TOOL_NAMES = Agent/Task/Workflow/Skill — a spawned child would escape
+# with a fresh toolset), every side-effecting action, and the web tools (the last closes
+# the Read+WebFetch exfiltration path Codex flagged). Reads (Read/Grep/Glob/LS) are
+# harmless with no web/bash/MCP left to exfil through. Mirrors the sentinel-degraded
+# "propose-only" posture (sentinel/dispatcher._DEGRADED_DISALLOWED_TOOLS); kept as its own
+# list to avoid a mail->sentinel import — the guardrail test pins the members so the two
+# can't silently drift. Nothing the judge legitimately does is lost (727a3724).
+_JUDGE_DISALLOWED_TOOLS: list[str] = [
+    "Bash",
+    "Write",
+    "Edit",
+    "MultiEdit",
+    "NotebookEdit",
+    *SPAWN_TOOL_NAMES,
+    "SendMessage",
+    "ReportFindings",
+    "CronCreate",
+    "CronDelete",
+    "ScheduleWakeup",
+    "Monitor",
+    "TaskCreate",
+    "TaskUpdate",
+    "TaskStop",
+    "RemoteTrigger",
+    "PushNotification",
+    "DesignSync",
+    "EnterWorktree",
+    "ExitWorktree",
+    "WebFetch",
+    "WebSearch",
+]
 
 
 class MailMonitor:
@@ -509,9 +536,14 @@ class MailMonitor:
             )
 
         try:
-            # Judge outputs JSON decisions only — no tools needed.
-            _no_mcp = str(Path(__file__).resolve().parents[2] / "config" / "no_mcp.json")
+            # Judge outputs JSON decisions only — no tools needed. Resolve the empty
+            # MCP profile via the canonical builder rather than a hand-counted
+            # parents[...] path (the old parents[2] resolved to a NONEXISTENT
+            # src/config/no_mcp.json — repo-root is config/no_mcp.json).
+            from genesis.cc.session_config import SessionConfigBuilder
             from genesis.memory.provenance import ORIGIN_EXTERNAL_UNTRUSTED
+
+            _no_mcp = SessionConfigBuilder().build_mcp_config("none")
 
             invocation = CCInvocation(
                 prompt=prompt,

--- a/tests/test_cc/test_spawn_lockdown.py
+++ b/tests/test_cc/test_spawn_lockdown.py
@@ -13,10 +13,11 @@ ARE the value passed to their ``CCInvocation``), not an orphaned constant.
 
 Scope — this guard is about the SPAWN class ONLY, across: reflection (fully read-only),
 the inbox/mail judges, the experimentation single-turn completion, and sentinel-degraded.
-NOTE: the inbox/mail judges are spawn-hardened here but are NOT yet fully read-only —
-they still leave ``Bash`` (and, for inbox, memory/settings MCP writes) available on
-external input; that broader boundary is a separate, tracked follow-up, not this guard's
-concern. Deliberately NOT covered here at all:
+NOTE: the mail judge is now fully denied ``Bash`` (its prompt uses no tools). The inbox
+judge additionally denies every genesis MCP *write* (memory_store/settings_update/…)
+while KEEPING the reads + ``observation_write`` its prompt needs; its ONLY remaining
+residual is ``Bash`` (retained for the yt-dlp/curl YouTube-fetch path — relocating that
+into Python is follow-up 727a3724). Deliberately NOT covered here at all:
 - ``surplus`` — NOT a CC session: the live ``SurplusLLMExecutor`` runs via the tool-less
   Router (no ``claude -p``, no spawn tools to deny), so it is outside this scope.
 - ``cc/direct_session`` (its ``research`` profile runs a documented deep-research
@@ -56,9 +57,9 @@ def test_sentinel_degraded_denies_spawn():
 
 
 def test_inbox_eval_judge_denies_spawn():
-    from genesis.inbox.monitor import _EVAL_DISALLOWED_TOOLS
+    from genesis.inbox.monitor import _eval_disallowed_tools
 
-    assert set(_EVAL_DISALLOWED_TOOLS) >= _SPAWN
+    assert set(_eval_disallowed_tools()) >= _SPAWN
 
 
 def test_mail_judge_denies_spawn():
@@ -71,3 +72,46 @@ def test_experimentation_completion_denies_spawn():
     from genesis.experimentation.cc_router import _CLI_DISALLOWED_TOOLS
 
     assert set(_CLI_DISALLOWED_TOOLS) >= _SPAWN
+
+
+# ── 727a3724 (partial): judge Bash + inbox MCP-write hardening ────────────────
+# The inbox/mail judges run skip_permissions=True on EXTERNAL, adversarial input.
+# These lock the LOSSLESS half of that hardening: no Bash on the mail judge (its
+# prompt uses no tools) and no dangerous MCP writes on the inbox judge, without
+# removing any capability either prompt actually uses.
+
+
+def test_mail_judge_denies_bash():
+    from genesis.mail.monitor import _JUDGE_DISALLOWED_TOOLS
+
+    assert "Bash" in _JUDGE_DISALLOWED_TOOLS
+
+
+def test_inbox_judge_denies_mcp_writes():
+    from genesis.inbox.monitor import _eval_disallowed_tools
+
+    d = set(_eval_disallowed_tools())
+    assert "mcp__genesis-memory__memory_store" in d
+    assert "mcp__genesis-health__settings_update" in d
+    assert "mcp__genesis-health__follow_up_create" in d
+
+
+def test_inbox_judge_keeps_reads_and_observation_write():
+    # Guard against OVER-denial: the prompt needs these reads + its one sanctioned
+    # write (observation_write). Denying them would silently break inbox eval.
+    from genesis.inbox.monitor import _eval_disallowed_tools
+
+    d = set(_eval_disallowed_tools())
+    assert "mcp__genesis-memory__memory_recall" not in d
+    assert "mcp__genesis-memory__procedure_recall" not in d
+    assert "mcp__genesis-memory__observation_write" not in d
+
+
+def test_inbox_judge_retains_bash_residual():
+    # DELIBERATE residual (727a3724): Bash is kept so the prompt can shell out to
+    # yt-dlp/curl for YouTube inbox URLs. If a future change denies Bash WITHOUT
+    # relocating that fetch into Python, YouTube inbox items break — this pins the
+    # residual so the trade-off is made consciously, not by accident.
+    from genesis.inbox.monitor import _eval_disallowed_tools
+
+    assert "Bash" not in _eval_disallowed_tools()

--- a/tests/test_cc/test_spawn_lockdown.py
+++ b/tests/test_cc/test_spawn_lockdown.py
@@ -81,10 +81,40 @@ def test_experimentation_completion_denies_spawn():
 # removing any capability either prompt actually uses.
 
 
-def test_mail_judge_denies_bash():
+def test_mail_judge_denies_full_action_class():
+    # The mail prompt (MAIL_EVALUATE.md) uses NO tools, so it runs act-nothing:
+    # deny Bash + all file-edit + spawn + side-effecting actions + web (the last
+    # closes the Read+WebFetch exfiltration path).
     from genesis.mail.monitor import _JUDGE_DISALLOWED_TOOLS
 
-    assert "Bash" in _JUDGE_DISALLOWED_TOOLS
+    d = set(_JUDGE_DISALLOWED_TOOLS)
+    for t in (
+        "Bash",
+        "Write",
+        "Edit",
+        "MultiEdit",
+        "NotebookEdit",
+        "WebFetch",
+        "WebSearch",
+        "CronCreate",
+        "RemoteTrigger",
+        "PushNotification",
+        "SendMessage",
+        "Monitor",
+    ):
+        assert t in d, f"mail judge must deny {t}"
+
+
+def test_mail_judge_no_mcp_config_exists():
+    # Regression for the parents[2] path bug: the mail judge's empty-MCP config
+    # must resolve to a REAL file (strict_mcp_config requires a readable path;
+    # the old hand-counted path pointed at a nonexistent src/config/no_mcp.json).
+    from pathlib import Path
+
+    from genesis.cc.session_config import SessionConfigBuilder
+
+    p = SessionConfigBuilder().build_mcp_config("none")
+    assert p and Path(p).exists(), f"no_mcp config must exist, got {p!r}"
 
 
 def test_inbox_judge_denies_mcp_writes():


### PR DESCRIPTION
## What

Hardens the two Genesis CC "judge" sessions that reason over adversarial external input
(emails / dropped inbox items) under `skip_permissions`. This is the **lossless** half of
the judge-hardening work — no capability either prompt actually uses is removed.

- **Mail judge**: its prompt uses no tools, so it now denies `Bash` outright (Bash +
  Write/Edit/NotebookEdit + the subagent-spawn class). MCP config is `no_mcp`.
- **Inbox judge**: the denylist is now derived from the reflection read-only denylist
  **minus `Bash`** — denying every genesis MCP *write* (memory/settings/follow-up writes) +
  Write/Edit/spawn + user-scoped MCP servers, while keeping the reads the prompt needs
  (memory/procedure recall, health status) and its one sanctioned write (`observation_write`).
  Deriving from the reflection denylist means a future MCP write tool is auto-denied.

## Deliberately out of scope (tracked)

`Bash` is **retained** on the inbox judge for the one job its prompt needs it for — fetching
YouTube inbox URLs via `yt-dlp`/`curl`. Relocating that fetch into Python so `Bash` can also
be denied is the remaining residual (the inbox judge's injection→RCE surface), tracked as a
separate follow-up.

## Tests

New guardrail tests assert: `Bash` denied on mail, MCP writes denied on inbox, reads +
`observation_write` preserved (over-denial guard), and `Bash` retained on inbox (pins the
deliberate residual). `test_cc` (811), `test_inbox` + `test_mail` (411) suites pass.
Adversarial security review clean — no CRITICAL/HIGH, strict-superset + fail-closed confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
