### PR TITLE
fix(contribution): repair the two silently-dead secret scanners in the sanitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Contribution secret-scanning now actually blocks leaked secrets.** The sanitizer
+  that checks community-contribution diffs before opening a public PR ran two secret
+  scanners — detect-secrets (the required floor) and gitleaks — but both were silently
+  finding nothing: detect-secrets' output parser missed every hit because it didn't
+  account for the confidence/entropy suffix in the tool's output, and gitleaks was
+  invoked with a flag combination that made it scan nothing from its input. A diff
+  containing an API token or private key could pass the sanitizer clean. Both scanners
+  now work (gitleaks also loads the repo's custom PII rules), and new tests exercise the
+  real scanner binaries so this can't silently regress. The privacy scanners for IP
+  addresses, emails, and install fingerprints were unaffected.
+
 - **No more false "critical failure" alarms when the system is briefly busy.** The
   health signal that watches your local infrastructure (database, vector store, and
   Ollama if enabled) probes those services with a short timeout. When background work

--- a/src/genesis/contribution/sanitize.py
+++ b/src/genesis/contribution/sanitize.py
@@ -560,12 +560,17 @@ def _run_detect_secrets(parsed: _ParsedDiff) -> tuple[bool, list[Finding]]:
     return True, hits
 
 
-def _run_gitleaks(diff_text: str) -> tuple[bool, list[Finding]]:
-    """Optional second-layer scan with gitleaks if installed.
+def _run_gitleaks(
+    added_lines: list[tuple[str, int, str]],
+) -> tuple[bool, list[Finding]]:
+    """Optional second-layer secret scan with gitleaks if installed.
 
-    Runs `gitleaks detect --pipe` with the diff on stdin, loading the repo's
-    `.gitleaks.toml` via `-c` (it extends the default rules — useDefault=true —
-    with the genesis PII rules). Returns (scanner_ran, findings).
+    Scans ONLY the diff's ADDED lines (like _run_detect_secrets and the other
+    scanners), so a secret on a REMOVED or context line is never flagged — a
+    contribution that DELETES a secret isn't falsely blocked. Runs
+    `gitleaks detect --pipe` over the added-line content on stdin, loading the
+    repo's `.gitleaks.toml` via `-c` (extends the default rules — useDefault=true
+    — with the genesis PII rules). Returns (scanner_ran, findings).
 
     NOTE: `--no-git` must NOT be combined with `--pipe`. That combination makes
     gitleaks scan nothing from stdin — it silently returned zero findings (even
@@ -581,6 +586,15 @@ def _run_gitleaks(diff_text: str) -> tuple[bool, list[Finding]]:
     gitleaks = shutil.which("gitleaks") or shutil.which("betterleaks")
     if gitleaks is None:
         return False, []
+    if not added_lines:
+        return True, []
+
+    # Feed ONLY the added-line texts (one per line). Findings are attributed back
+    # to the source (file, line) by matching the reported secret text below — NOT
+    # by gitleaks' line number, which is unreliable over this header-less --pipe
+    # content (gitleaks emits 0-based line numbers with no diff hunk header, and
+    # the numbering is version-dependent).
+    content = "\n".join(text for _, _, text in added_lines) + "\n"
 
     # gitleaks --pipe reads stdin since 8.x (NOT with --no-git — see docstring).
     cmd = [gitleaks, "detect", "--pipe", "--report-format", "json",
@@ -600,7 +614,7 @@ def _run_gitleaks(diff_text: str) -> tuple[bool, list[Finding]]:
     try:
         proc = subprocess.run(
             cmd,
-            input=diff_text,
+            input=content,
             capture_output=True,
             text=True,
             timeout=30,
@@ -623,15 +637,24 @@ def _run_gitleaks(diff_text: str) -> tuple[bool, list[Finding]]:
             if not isinstance(f, dict):
                 continue
             rule = f.get("RuleID", "unknown")
-            file = f.get("File", "")
-            line = f.get("StartLine", 0)
+            # Attribute by matching the reported secret text back to the added line
+            # that contains it — robust to gitleaks' unreliable line numbers over
+            # header-less --pipe content. If it can't be located (unexpected), leave
+            # (file, line) unset; the finding is still BLOCK either way.
+            match_text = f.get("Secret") or f.get("Match", "")
+            src_file, src_line = None, None
+            if match_text:
+                for fpath, lno, text in added_lines:
+                    if match_text in text:
+                        src_file, src_line = fpath, lno
+                        break
             hits.append(
                 Finding(
                     kind=FindingKind.SECRET,
                     severity=Severity.BLOCK,
                     message=f"Potential secret ({rule})",
-                    file=file or None,
-                    line=int(line) if line else None,
+                    file=src_file,
+                    line=src_line,
                     scanner="gitleaks",
                     detail=f.get("Match", "")[:120],
                 )
@@ -755,7 +778,7 @@ def scan_diff(
         findings.extend(secret_hits)
 
     # 8. gitleaks (optional second layer)
-    ran, gl_hits = _run_gitleaks(diff_text)
+    ran, gl_hits = _run_gitleaks(parsed.added_lines)
     if ran:
         scanners_run.append("gitleaks")
         findings.extend(gl_hits)

--- a/src/genesis/contribution/sanitize.py
+++ b/src/genesis/contribution/sanitize.py
@@ -521,8 +521,10 @@ def _run_detect_secrets(parsed: _ParsedDiff) -> tuple[bool, list[Finding]]:
                 )
             )
             continue
-        # --string prints lines like "<plugin>: True" for positives and
-        # "<plugin>: False" for negatives. Parse for any True.
+        # --string prints lines like "<plugin> : True  (unverified)" /
+        # "<plugin> : True  (4.872)" for positives and "<plugin> : False" for
+        # negatives. The verdict carries a status/entropy SUFFIX, so match with
+        # startswith("true") — an exact `== "true"` silently missed EVERY finding.
         if proc.returncode != 0:
             # Same fail-closed rationale: a nonzero exit means the line was not
             # reliably scanned.
@@ -542,7 +544,7 @@ def _run_detect_secrets(parsed: _ParsedDiff) -> tuple[bool, list[Finding]]:
             if ":" not in out_line:
                 continue
             key, _, val = out_line.partition(":")
-            if val.strip().lower() == "true":
+            if val.strip().lower().startswith("true"):
                 hits.append(
                     Finding(
                         kind=FindingKind.SECRET,
@@ -561,19 +563,43 @@ def _run_detect_secrets(parsed: _ParsedDiff) -> tuple[bool, list[Finding]]:
 def _run_gitleaks(diff_text: str) -> tuple[bool, list[Finding]]:
     """Optional second-layer scan with gitleaks if installed.
 
-    Runs `gitleaks detect --no-git --pipe` with the diff on stdin
-    (via a temp path, since gitleaks needs a file). Returns
-    (scanner_ran, findings).
+    Runs `gitleaks detect --pipe` with the diff on stdin, loading the repo's
+    `.gitleaks.toml` via `-c` (it extends the default rules — useDefault=true —
+    with the genesis PII rules). Returns (scanner_ran, findings).
+
+    NOTE: `--no-git` must NOT be combined with `--pipe`. That combination makes
+    gitleaks scan nothing from stdin — it silently returned zero findings (even
+    the default rules never fired). `--no-git` only makes sense with `--source`
+    (a directory scan, as CI uses).
+
+    NOTE: the `.gitleaks.toml` `[allowlist] paths` (tests/, sanitize.py, …) does
+    NOT apply here — in `--pipe` mode gitleaks never populates a finding's `File`
+    field, so path-based allowlisting is structurally inert. A contributor cannot
+    hide a secret behind an allowlisted-looking diff path on this scan. (The
+    allowlist only affects CI's separate `--source .` directory scan.)
     """
     gitleaks = shutil.which("gitleaks") or shutil.which("betterleaks")
     if gitleaks is None:
         return False, []
 
-    # gitleaks --pipe reads stdin since 8.x. Use that when available.
+    # gitleaks --pipe reads stdin since 8.x (NOT with --no-git — see docstring).
+    cmd = [gitleaks, "detect", "--pipe", "--report-format", "json",
+           "--report-path", "/dev/stdout"]
+    # Load the repo's .gitleaks.toml so the genesis PII rules fire; skip
+    # gracefully if absent (default rules still apply; a fresh clone ships it).
+    # SECURITY: resolve via the trusted server-side genesis.env.repo_root()
+    # (GENESIS_REPO_ROOT-aware) — deliberately NOT scan_diff()'s caller-supplied
+    # repo_root, which for a contribution could be an untrusted checkout whose
+    # own .gitleaks.toml disables every rule. Do not "simplify" this to thread
+    # the caller's path through.
+    from genesis.env import repo_root
+
+    config = repo_root() / ".gitleaks.toml"
+    if config.is_file():
+        cmd += ["-c", str(config)]
     try:
         proc = subprocess.run(
-            [gitleaks, "detect", "--no-git", "--pipe", "--report-format", "json",
-             "--report-path", "/dev/stdout"],
+            cmd,
             input=diff_text,
             capture_output=True,
             text=True,

--- a/tests/test_contribution/test_sanitize_real_scanners.py
+++ b/tests/test_contribution/test_sanitize_real_scanners.py
@@ -60,7 +60,7 @@ def test_gitleaks_real_binary_scans_stdin():
 
     RED against ``--no-git --pipe`` (that combo scans nothing from stdin).
     """
-    ran, hits = sanitize._run_gitleaks(_SECRET_DIFF)
+    ran, hits = sanitize._run_gitleaks(sanitize.parse_diff(_SECRET_DIFF).added_lines)
     assert ran
     assert any(h.kind == FindingKind.SECRET and h.severity == Severity.BLOCK for h in hits), (
         "gitleaks must flag the github token via --pipe (default rule)"
@@ -73,7 +73,7 @@ def test_gitleaks_loads_repo_config_for_genesis_rules():
 
     Proves the config is actually loaded (extends defaults), not just default rules.
     """
-    ran, hits = sanitize._run_gitleaks(_SECRET_DIFF)
+    ran, hits = sanitize._run_gitleaks(sanitize.parse_diff(_SECRET_DIFF).added_lines)
     assert ran
     assert any(
         "account" in (h.detail or "").lower() or "123456789012" in (h.detail or "") for h in hits
@@ -86,6 +86,53 @@ def test_scan_diff_end_to_end_blocks_secret():
     result = sanitize.scan_diff(_SECRET_DIFF)
     assert result.ok is False
     assert any(f.kind == FindingKind.SECRET for f in result.blocking())
+
+
+@pytest.mark.skipif(shutil.which("gitleaks") is None, reason="gitleaks not installed")
+def test_gitleaks_ignores_secret_on_a_removed_line():
+    """gitleaks scans only ADDED lines — a secret on a REMOVED line must NOT be
+    flagged (a contribution that DELETES a secret is a good change, not a block).
+    RED against the old code, which fed the whole diff to gitleaks."""
+    removal_diff = (
+        "diff --git a/config.py b/config.py\n"
+        "--- a/config.py\n"
+        "+++ b/config.py\n"
+        "@@ -1 +1 @@\n"
+        '-github_token = "ghp_1a2B3c4D5e6F7g8H9i0J1k2L3m4N5o6P7q8R"\n'
+        "+cleaned = true\n"
+    )
+    ran, hits = sanitize._run_gitleaks(sanitize.parse_diff(removal_diff).added_lines)
+    assert ran
+    assert hits == [], "a secret on a removed line must not be flagged"
+
+
+@pytest.mark.skipif(shutil.which("gitleaks") is None, reason="gitleaks not installed")
+def test_gitleaks_attributes_finding_to_correct_file_and_line():
+    """The reported (file, line) must be the TRUE source location of the secret.
+    gitleaks' line numbers over header-less --pipe content are unreliable (0-based,
+    version-dependent), so attribution is by content-match. A multi-file diff with
+    the secret on the 2nd added line of the 2nd file catches off-by-one AND
+    file-boundary errors."""
+    diff = (
+        "diff --git a/a.py b/a.py\n"
+        "--- a/a.py\n"
+        "+++ b/a.py\n"
+        "@@ -0,0 +1 @@\n"
+        "+harmless = 1\n"
+        "diff --git a/b.py b/b.py\n"
+        "--- a/b.py\n"
+        "+++ b/b.py\n"
+        "@@ -0,0 +1,2 @@\n"
+        "+keep = 2\n"
+        '+token = "ghp_1a2B3c4D5e6F7g8H9i0J1k2L3m4N5o6P7q8R"\n'
+    )
+    ran, hits = sanitize._run_gitleaks(sanitize.parse_diff(diff).added_lines)
+    assert ran
+    secret_hits = [h for h in hits if h.kind == FindingKind.SECRET]
+    assert secret_hits, "the github token must be flagged"
+    h = secret_hits[0]
+    assert h.file == "b.py", f"wrong file attribution: {h.file}"
+    assert h.line == 2, f"wrong line attribution: {h.line} (token is on b.py line 2)"
 
 
 # ── Install-agnostic argv guards (run on CI without the gitleaks binary) ──
@@ -107,7 +154,7 @@ def _capture_gitleaks_argv(monkeypatch, repo_dir):
         return _sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(sanitize.subprocess, "run", _fake_run)
-    sanitize._run_gitleaks(_SECRET_DIFF)
+    sanitize._run_gitleaks(sanitize.parse_diff(_SECRET_DIFF).added_lines)
     return captured["cmd"]
 
 

--- a/tests/test_contribution/test_sanitize_real_scanners.py
+++ b/tests/test_contribution/test_sanitize_real_scanners.py
@@ -1,0 +1,88 @@
+"""REAL-binary integration tests for the contribution secret scanners.
+
+These deliberately do NOT mock detect-secrets / gitleaks (unlike test_sanitize.py's
+``no_external_scanners`` fixture). They guard against the 2026-08 regression where
+BOTH secret layers were silently dead while the mocked tests stayed green:
+
+- ``_run_detect_secrets`` matched ``val == "true"`` but real detect-secrets output
+  is ``True  (unverified)`` / ``True  (4.872)`` — the entropy/status suffix meant it
+  parsed ZERO findings (the "required floor" caught nothing).
+- ``_run_gitleaks`` passed ``--no-git`` alongside ``--pipe``; that combination makes
+  gitleaks scan nothing from stdin (verified: even the default ``github-pat`` rule
+  never fires). Removing ``--no-git`` restores the scan; ``-c .gitleaks.toml`` adds
+  the genesis rules (the config extends defaults via ``useDefault = true``).
+
+detect-secrets is a declared core dependency, so its test runs on CI. gitleaks is an
+optional external binary → skipif-guarded.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from genesis.contribution import sanitize
+from genesis.contribution.findings import FindingKind, Severity
+
+# A github PAT (default-rule secret for both scanners) + a 12-digit account id near
+# a keyword (the genesis-aws-account-id custom rule, gitleaks -c only). Synthetic.
+_SECRET_DIFF = (
+    "diff --git a/config.py b/config.py\n"
+    "--- a/config.py\n"
+    "+++ b/config.py\n"
+    "@@ -0,0 +1,2 @@\n"
+    '+github_token = "ghp_1a2B3c4D5e6F7g8H9i0J1k2L3m4N5o6P7q8R"\n'
+    '+account_id = "123456789012"\n'
+)
+
+
+@pytest.mark.skipif(shutil.which("detect-secrets") is None, reason="detect-secrets not installed")
+def test_detect_secrets_real_binary_flags_suffixed_true():
+    """The REAL detect-secrets '<plugin> : True  (suffix)' output must parse as a hit.
+
+    RED against the ``== "true"`` parser (the suffix makes it miss every finding).
+    """
+    parsed = sanitize.parse_diff(_SECRET_DIFF)
+    ran, hits = sanitize._run_detect_secrets(parsed)
+    assert ran
+    assert any(h.kind == FindingKind.SECRET and h.severity == Severity.BLOCK for h in hits), (
+        "detect-secrets must BLOCK on the github token (real output is 'True  (unverified)')"
+    )
+
+
+@pytest.mark.skipif(
+    shutil.which("gitleaks") is None and shutil.which("betterleaks") is None,
+    reason="gitleaks not installed",
+)
+def test_gitleaks_real_binary_scans_stdin():
+    """REAL gitleaks must actually scan the piped diff and flag the token.
+
+    RED against ``--no-git --pipe`` (that combo scans nothing from stdin).
+    """
+    ran, hits = sanitize._run_gitleaks(_SECRET_DIFF)
+    assert ran
+    assert any(h.kind == FindingKind.SECRET and h.severity == Severity.BLOCK for h in hits), (
+        "gitleaks must flag the github token via --pipe (default rule)"
+    )
+
+
+@pytest.mark.skipif(shutil.which("gitleaks") is None, reason="gitleaks not installed")
+def test_gitleaks_loads_repo_config_for_genesis_rules():
+    """With -c <repo>/.gitleaks.toml the custom genesis-aws-account-id rule fires.
+
+    Proves the config is actually loaded (extends defaults), not just default rules.
+    """
+    ran, hits = sanitize._run_gitleaks(_SECRET_DIFF)
+    assert ran
+    assert any(
+        "account" in (h.detail or "").lower() or "123456789012" in (h.detail or "") for h in hits
+    ), "the genesis-aws-account-id rule (only in .gitleaks.toml) must fire with -c"
+
+
+@pytest.mark.skipif(shutil.which("detect-secrets") is None, reason="detect-secrets not installed")
+def test_scan_diff_end_to_end_blocks_secret():
+    """Full scan_diff over a secret-bearing diff must NOT be ok (the floor blocks it)."""
+    result = sanitize.scan_diff(_SECRET_DIFF)
+    assert result.ok is False
+    assert any(f.kind == FindingKind.SECRET for f in result.blocking())

--- a/tests/test_contribution/test_sanitize_real_scanners.py
+++ b/tests/test_contribution/test_sanitize_real_scanners.py
@@ -86,3 +86,46 @@ def test_scan_diff_end_to_end_blocks_secret():
     result = sanitize.scan_diff(_SECRET_DIFF)
     assert result.ok is False
     assert any(f.kind == FindingKind.SECRET for f in result.blocking())
+
+
+# ── Install-agnostic argv guards (run on CI without the gitleaks binary) ──
+# These spy on subprocess.run so the gitleaks invocation itself is locked even
+# where the real binary is absent (the real-binary tests above skip on CI).
+def _capture_gitleaks_argv(monkeypatch, repo_dir):
+    import subprocess as _sp
+
+    captured: dict = {}
+    monkeypatch.setattr(
+        sanitize.shutil,
+        "which",
+        lambda name: "/fake/gitleaks" if name == "gitleaks" else None,
+    )
+    monkeypatch.setattr("genesis.env.repo_root", lambda: repo_dir)
+
+    def _fake_run(cmd, *a, **k):
+        captured["cmd"] = list(cmd)
+        return _sp.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(sanitize.subprocess, "run", _fake_run)
+    sanitize._run_gitleaks(_SECRET_DIFF)
+    return captured["cmd"]
+
+
+def test_gitleaks_argv_no_nogit_and_loads_config(monkeypatch, tmp_path):
+    """gitleaks must be invoked WITHOUT --no-git (it nullifies --pipe) and WITH
+    -c pointing at the repo .gitleaks.toml when the config exists."""
+    (tmp_path / ".gitleaks.toml").write_text("[extend]\nuseDefault = true\n")
+    cmd = _capture_gitleaks_argv(monkeypatch, tmp_path)
+    assert "--no-git" not in cmd, "--no-git must NOT be combined with --pipe"
+    assert "--pipe" in cmd
+    assert "-c" in cmd
+    assert cmd[cmd.index("-c") + 1] == str(tmp_path / ".gitleaks.toml")
+
+
+def test_gitleaks_argv_skips_config_when_absent(monkeypatch, tmp_path):
+    """No .gitleaks.toml → -c is omitted (graceful skip; default rules still apply),
+    and --no-git is still absent."""
+    cmd = _capture_gitleaks_argv(monkeypatch, tmp_path)  # empty dir, no config
+    assert "-c" not in cmd
+    assert "--no-git" not in cmd
+    assert "--pipe" in cmd


### PR DESCRIPTION
## What

The contribution sanitizer (`scan_diff` — the gate that scans a community-contribution diff before opening a public PR/issue) ran two secret scanners that **both caught nothing**. A diff containing a github PAT + AWS account id scanned `ok=True, findings=[]` — it would have passed real secrets clean. The existing tests stayed green because they **mocked** the scanner binaries with the wrong output format.

## Root causes (both empirically verified against the real binaries)

- **detect-secrets — the required, fail-closed floor (a core dependency, always runs):** `_run_detect_secrets` parsed each plugin verdict with `val.strip().lower() == "true"`, but real detect-secrets 1.5.0 emits `<plugin> : True  (unverified)` / `True  (4.872)` — the status/entropy suffix means **0** True lines matched. The floor parsed zero findings.
- **gitleaks — optional second layer:** invoked as `gitleaks detect --no-git --pipe …`. `--no-git` combined with `--pipe` makes gitleaks scan **nothing** from stdin (even the default rules never fire). `--no-git` only belongs with `--source` (a directory scan, which is what CI uses).

## Fix

- `_run_detect_secrets`: match `startswith("true")` (the verdict carries a suffix).
- `_run_gitleaks`: drop `--no-git`; add `-c <repo_root()>/.gitleaks.toml` (extends the default rules with the genesis PII rules via `useDefault=true`), graceful skip if the config is absent.
- **Security:** the config resolves via the trusted server-side `genesis.env.repo_root()`, deliberately **not** `scan_diff()`'s caller-supplied `repo_root` (an untrusted contributor checkout could ship a rule-disabling `.gitleaks.toml`). A comment pins this so no refactor reintroduces the vector.

## Tests

New `test_sanitize_real_scanners.py` exercises the **real** binaries (detect-secrets is a declared dep → runs on CI; gitleaks `skipif`), replacing the false-confidence mocks. **verify-RED → GREEN:** 4 failed pre-fix → 4 pass. Existing mocked suite unchanged (223/223 `test_contribution/` pass). `ruff` clean.

The pure-Python privacy scanners (private IPs, emails, install fingerprints) were unaffected — verified still firing.

## Review

genesis-security-reviewer: **no blocking findings.** Confirmed the fixes only strengthen detection (no weakening); tested and **disproved** an allowlist-bypass hypothesis (gitleaks `--pipe` never populates a finding's `File` field, so path-based `[allowlist] paths` is inert on this scan path); confirmed blocked-secret snippets never reach a public surface (`build_pr_body` emits only a count, and PR creation is refused when the sanitizer isn't ok).

## Deploy

Runtime library used by `python -m genesis contribute` / the PR opener — picked up on next invocation (no migration/host/hook changes).

Follow-up: a9420b6951d84bbeb32cd43a965dec68

🤖 Generated with [Claude Code](https://claude.com/claude-code)