### PR TITLE
fix(security): gate user-model + autonomy-dispatch against untrusted-origin observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   `notifications` reason-allowlist in `github_steward.yaml`; respects the same
   `off`/`observe`/`live` lever and pings immediately in `live`.
 
+### Security
+
+- **Untrusted content can no longer poison your user model or trigger autonomy.**
+  Background sessions that process external material (e.g. the inbox evaluator over
+  the links you drop in) now write observations stamped with their true origin, and
+  the pipelines that would auto-apply an observation into privileged state — your
+  learned user model, and autonomous task dispatch — refuse any update whose origin
+  isn't first-party. A crafted item can no longer smuggle a high-confidence "fact
+  about you" into Genesis's self-model or spawn a task. Refused updates are held
+  (not discarded) and logged, and normal reflection-authored updates are unaffected.
+
 ### Fixed
 
 - **No more false "critical failure" alarms when the system is briefly busy.** The

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -220,7 +220,7 @@ any task bigger than an LLM call.
 ```yaml subsystem-map
 entry: execution-cc
 modules: [cc]
-verified: 51253c67 2026-08-13
+verified: d71d1d39 2026-08-18
 ```
 
 - **Subagent-spawn lockdown — one source of truth across the restricted sessions**
@@ -242,12 +242,23 @@ verified: 51253c67 2026-08-13
   at a nonexistent `src/config/no_mcp.json`). The inbox judge denies every genesis MCP
   *write* (`memory_store`/`settings_update`/`follow_up_create`/…) via
   `build_reflection_disallowed` minus `Bash`, keeping the reads it needs plus the optional
-  `observation_write`. Two RESIDUALS on the inbox judge, both tracked (follow-up 727a3724),
-  NOT closed here: (1) `Bash` — retained for the `yt-dlp`/`curl` YouTube-fetch path
-  (injection→RCE surface); (2) the retained `observation_write` neither stamps external
-  provenance nor constrains observation `type`, so an injected item could in principle forge
-  a `user_model_delta` — a low-likelihood, curated-input vector whose real fix (a provisional
-  provenance tier + writer type-authorization) belongs in the memory-provenance work.
+  `observation_write`. RESIDUALS on the inbox judge: (1) `Bash` — STILL retained for the
+  `yt-dlp`/`curl` YouTube-fetch path (injection→RCE surface, open — follow-up 727a3724);
+  (2) the two PRIVILEGED-WRITE consumers of forged observations are now gated (the
+  memory-provenance work): `observation_write` stamps the session origin
+  (`session_origin_from_env`) so an eval-session write lands `external_untrusted`, and the
+  user-model consumer gate (`UserModelEvolver.process_pending_deltas` via
+  `immunity.is_trusted_for_privileged_write`) plus the autonomy-dispatcher `task_detected`
+  gate bar any untrusted-origin (fail-closed on NULL) delta/task from auto-accept (barred
+  deltas left unresolved for TTL, never discarded). **PARTIAL — the broader
+  observation-content-INJECTION surface is still OPEN** (tracked follow-up): the digest types
+  the judge writes (`user_signal`/`architecture_insight`) are surfaced UNFILTERED into LLM
+  context by consumers this change did NOT touch — `essential_knowledge._recent_decisions`
+  (raw SQL → the always-loaded L1 file), `reflection.gather_evaluation_context` (14-day
+  lookback → deep-reflection prompt → can launder into a `first_party`-stamped delta), and
+  several ego/sentinel raw-`FROM observations` reads. The robust fix is to exclude/wrap
+  external-origin content (`is_blockable`, keeping NULL) at the surfacing points, with a
+  coverage guardrail that also catches raw-SQL consumers.
   **Out of scope (tracked follow-up):** `cc/direct_session` (its `research` profile runs a
   DOCUMENTED deep-research `Workflow` — blocking the class there would break that path) and
   the autonomy-executor sessions; those legitimately spawn/orchestrate and need a

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -244,13 +244,18 @@ verified: d71d1d39 2026-08-18
   `build_reflection_disallowed` minus `Bash`, keeping the reads it needs plus the optional
   `observation_write`. RESIDUALS on the inbox judge: (1) `Bash` — STILL retained for the
   `yt-dlp`/`curl` YouTube-fetch path (injection→RCE surface, open — follow-up 727a3724);
-  (2) the two PRIVILEGED-WRITE consumers of forged observations are now gated (the
+  (2) the PRIVILEGED-WRITE consumers of forged observations are now gated (the
   memory-provenance work): `observation_write` stamps the session origin
-  (`session_origin_from_env`) so an eval-session write lands `external_untrusted`, and the
-  user-model consumer gate (`UserModelEvolver.process_pending_deltas` via
-  `immunity.is_trusted_for_privileged_write`) plus the autonomy-dispatcher `task_detected`
-  gate bar any untrusted-origin (fail-closed on NULL) delta/task from auto-accept (barred
-  deltas left unresolved for TTL, never discarded). **PARTIAL — the broader
+  (`session_origin_from_env`) so an eval-session write lands `external_untrusted`, and BOTH
+  user-model consumers — `process_pending_deltas` (accept) and `synthesize_narrative`
+  (evidence → USER_KNOWLEDGE.md) — read only trusted-origin deltas via the SQL
+  `origin_class_in=TRUSTED_PRIVILEGED_WRITE_ORIGINS` filter (filtering in-query, not
+  post-LIMIT, so a forged-delta flood can't starve trusted deltas out of the window, and a
+  TTL-resolved barred delta can't launder into the narrative). Fail-closed on NULL; barred
+  rows are left for the 14-day TTL, never discarded. The autonomy-dispatcher `task_detected`
+  pickup applies the same trust check (`immunity.is_trusted_for_privileged_write`) SKIP-ONLY
+  — it refuses dispatch without resolving/hiding the row (the path is inert today; producer
+  stamping is in the follow-up). **PARTIAL — the broader
   observation-content-INJECTION surface is still OPEN** (tracked follow-up): the digest types
   the judge writes (`user_signal`/`architecture_insight`) are surfaced UNFILTERED into LLM
   context by consumers this change did NOT touch — `essential_knowledge._recent_decisions`

--- a/src/genesis/autonomy/dispatcher.py
+++ b/src/genesis/autonomy/dispatcher.py
@@ -356,11 +356,35 @@ class TaskDispatcher:
             logger.error("Failed to query task observations", exc_info=True)
             return dispatched
 
+        from genesis.security.immunity import is_trusted_for_privileged_write
+
         active_descriptions = {t.get("description", "") for t in active}
 
         for obs in pending_obs:
             obs_id = obs["id"]
             content = obs.get("content", "")
+
+            # WS-3 poisoning gate: never dispatch an autonomy task from an
+            # observation whose origin isn't trusted-for-privileged-write. A
+            # task_detected forged via observation_write from an external-origin
+            # session must not spawn a background CC session. Currently inert —
+            # observations carries no `metadata` column, so plan_path below is
+            # always None and every row skips there anyway — so this gate has NO
+            # live effect today; it is defensive against a future `metadata`
+            # addition re-arming an ungated auto-dispatch surface.
+            # DEPENDENCY (tracked follow-up): the legit owner-initiated producers
+            # (cc/conversation.py `task_detected` writes) do NOT yet stamp
+            # origin_class, so they would ALSO be barred here (fail-closed on
+            # NULL). Producer-side stamping MUST land before this pickup path is
+            # wired (metadata), or legitimate user-requested tasks are dropped.
+            if not is_trusted_for_privileged_write(obs.get("origin_class")):
+                logger.warning(
+                    "task_detected %s BARRED from dispatch (origin_class=%r)",
+                    obs_id,
+                    obs.get("origin_class"),
+                )
+                await self._resolve_observation(obs_id, "barred:untrusted_origin")
+                continue
 
             # Dedup: check if already dispatched or task exists
             if obs_id in self._dispatched:

--- a/src/genesis/autonomy/dispatcher.py
+++ b/src/genesis/autonomy/dispatcher.py
@@ -364,26 +364,28 @@ class TaskDispatcher:
             obs_id = obs["id"]
             content = obs.get("content", "")
 
-            # WS-3 poisoning gate: never dispatch an autonomy task from an
+            # WS-3 poisoning gate: never DISPATCH an autonomy task from an
             # observation whose origin isn't trusted-for-privileged-write. A
             # task_detected forged via observation_write from an external-origin
-            # session must not spawn a background CC session. Currently inert —
-            # observations carries no `metadata` column, so plan_path below is
-            # always None and every row skips there anyway — so this gate has NO
-            # live effect today; it is defensive against a future `metadata`
-            # addition re-arming an ungated auto-dispatch surface.
-            # DEPENDENCY (tracked follow-up): the legit owner-initiated producers
+            # session must not spawn a background CC session. SKIP-ONLY (do NOT
+            # resolve): the pickup path is currently inert (no `metadata` column,
+            # so plan_path below is always None and every row skips there anyway),
+            # and — critically — the legit owner-initiated producers
             # (cc/conversation.py `task_detected` writes) do NOT yet stamp
-            # origin_class, so they would ALSO be barred here (fail-closed on
-            # NULL). Producer-side stamping MUST land before this pickup path is
-            # wired (metadata), or legitimate user-requested tasks are dropped.
+            # origin_class, so they arrive NULL and would be barred here too.
+            # Resolving a barred row would HIDE those legitimate rows from the
+            # dashboard/morning-report/L1 context within one cycle; skipping
+            # leaves every row's visibility untouched while still refusing
+            # dispatch. Producer-side stamping (so legit rows dispatch once the
+            # metadata path is wired) is tracked in the memory-provenance
+            # follow-up. Logged at debug — the dispatcher runs frequently.
             if not is_trusted_for_privileged_write(obs.get("origin_class")):
-                logger.warning(
-                    "task_detected %s BARRED from dispatch (origin_class=%r)",
+                logger.debug(
+                    "task_detected %s not dispatched (origin_class=%r not "
+                    "trusted-for-privileged-write)",
                     obs_id,
                     obs.get("origin_class"),
                 )
-                await self._resolve_observation(obs_id, "barred:untrusted_origin")
                 continue
 
             # Dedup: check if already dispatched or task exists

--- a/src/genesis/db/crud/observations.py
+++ b/src/genesis/db/crud/observations.py
@@ -433,6 +433,7 @@ async def query(
     category: str | None = None,
     resolved: bool | None = None,
     exclude_types: tuple[str, ...] | frozenset[str] | None = None,
+    origin_class_in: list[str] | None = None,
     limit: int = 50,
 ) -> list[dict]:
     if sum(map(bool, (source, source_in, source_prefix))) > 1:
@@ -470,6 +471,15 @@ async def query(
         type_placeholders = ",".join("?" for _ in exclude_types)
         sql += f" AND type NOT IN ({type_placeholders})"
         params.extend(exclude_types)
+    if origin_class_in:
+        # SQL-level origin filter — applied BEFORE the LIMIT so barred rows can
+        # never crowd trusted rows out of the result window (the user-model
+        # poisoning-gate consumers pass the trusted set here). NULL origin_class
+        # is excluded by SQL IN-semantics (fail-closed), which is the intended
+        # behaviour for the privileged-read consumers.
+        oc_placeholders = ",".join("?" for _ in origin_class_in)
+        sql += f" AND origin_class IN ({oc_placeholders})"
+        params.extend(origin_class_in)
     sql += " ORDER BY created_at DESC LIMIT ?"
     params.append(limit)
     rows = await db.execute_fetchall(sql, params)

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -55,14 +55,21 @@ def _eval_disallowed_tools() -> list[str]:
     ``build_reflection_disallowed`` (live per call) means a genesis MCP write
     added in a future PR is auto-denied here with no code change.
 
-    NOTE: the retained ``observation_write`` is a RESIDUAL write surface, not a
-    proven-safe one. Today it neither stamps external provenance (the tool ignores
-    the session origin, unlike the procedural/knowledge writers) nor constrains the
-    observation ``type`` — so an injected item could in principle forge a
-    ``user_model_delta`` that the user-model pipeline auto-accepts. That is a
-    LOW-likelihood, curated-input vector; the real fix (a provisional provenance
-    tier + type-authorization on the writer) is tracked in the memory-provenance
-    work, deliberately NOT bolted onto this tool-denylist change.
+    NOTE: the retained ``observation_write`` now STAMPS the session origin (WS-3):
+    an eval-session write lands ``origin_class='external_untrusted'`` (like the
+    procedural/knowledge writers). Two PRIVILEGED-WRITE consumers are now gated on
+    that origin — ``UserModelEvolver.process_pending_deltas`` (user model) and the
+    autonomy dispatcher's ``task_detected`` pickup — via
+    ``immunity.is_trusted_for_privileged_write``, so a forged
+    ``user_model_delta`` / ``task_detected`` is rejected at the point of privileged
+    consumption. PARTIAL, NOT the whole vector: the digest types this tool writes
+    (``user_signal`` / ``architecture_insight``) are still surfaced UNFILTERED into
+    LLM context by other consumers (``essential_knowledge._recent_decisions`` → the
+    always-loaded L1 file; ``reflection`` context; several ego/sentinel raw-SQL
+    reads). Closing that broader observation-content-surfacing surface (exclude/wrap
+    external-origin content at the surfacing points) is tracked — see the
+    "external-origin observation content" follow-up. (The ``Bash``/fetch relocation
+    remains the open part of 727a3724, above.)
     """
     return [t for t in SessionConfigBuilder().build_reflection_disallowed() if t != "Bash"]
 
@@ -1366,9 +1373,9 @@ class InboxMonitor:
             mcp_config=mcp_path,
             # WS-3: inbox evaluations process EXTERNAL content by construction, so
             # stamp the session external — the Python-side eval-memory writes read
-            # this, and any future origin-aware MCP write will too. NOTE: the one
-            # retained MCP write here (observation_write) does NOT currently honor
-            # this stamp (see _eval_disallowed_tools) — tracked, not fixed here.
+            # this, and the retained MCP write (observation_write) NOW honors it too
+            # (it forwards session_origin_from_env), so a delta forged here is
+            # stamped external and barred by the user-model consumer gate.
             origin=ORIGIN_EXTERNAL_UNTRUSTED,
         )
 

--- a/src/genesis/mcp/memory/observations.py
+++ b/src/genesis/mcp/memory/observations.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import UTC, datetime
 
 from genesis.db.crud import observations
+from genesis.memory.provenance import ORIGIN_FIRST_PARTY, session_origin_from_env
 
 from ..memory import mcp
 
@@ -43,6 +44,14 @@ async def observation_write(
         created_at=datetime.now(UTC).isoformat(),
         category=category,
         speculative=int(speculative),
+        # WS-3: stamp the dispatching session's origin (mirrors memory_store /
+        # procedure_store / knowledge writers), so an external-origin session
+        # (e.g. the inbox judge over untrusted content) can no longer forge a
+        # privileged-looking observation — a NULL origin used to read as
+        # first-party "by omission" and slip past the user-model consumer gate.
+        # Coalesce None → first_party (server/foreground writers); the gate
+        # normalizes adversarially, so a raw None must never be forwarded.
+        origin_class=session_origin_from_env() or ORIGIN_FIRST_PARTY,
         skip_if_duplicate=True,
     )
     return result or "duplicate_skipped"

--- a/src/genesis/memory/user_model.py
+++ b/src/genesis/memory/user_model.py
@@ -75,34 +75,47 @@ class UserModelEvolver:
         gate-2 — lets the USER_KNOWLEDGE writer aggregate their stored
         origin_class without changing this method's return contract).
         """
-        from genesis.security.immunity import is_trusted_for_privileged_write
+        from genesis.security.immunity import TRUSTED_PRIVILEGED_WRITE_ORIGINS
 
-        raw_pending = await observations.query(
-            self._db, type="user_model_delta", resolved=False
+        # WS-3 poisoning gate: fetch ONLY trusted-origin (owner/first_party)
+        # unresolved deltas, filtered in SQL. Filtering in the query (not in
+        # Python after a LIMITed fetch) is load-bearing: it stops a flood of
+        # forged/NULL-origin deltas from crowding trusted deltas out of the
+        # newest-N window (a persistent user-model-learning DoS). Fail-closed —
+        # NULL origin is excluded by IN-semantics. Legit reflection deltas carry
+        # first_party in quiet windows (reflection_window_origin never returns
+        # None), so the normal pipeline is unaffected. Barred rows are left
+        # unresolved for the 14-day TTL to reap and are ALSO excluded from
+        # synthesize_narrative's evidence query below, so they can never launder
+        # into USER_KNOWLEDGE.md after TTL-resolution. This is an unconditional
+        # invariant (like never-block-owner), NOT wired through the
+        # shadow-clamped gate_mode("identity") — that would be a silent no-op.
+        pending = await observations.query(
+            self._db,
+            type="user_model_delta",
+            resolved=False,
+            origin_class_in=list(TRUSTED_PRIVILEGED_WRITE_ORIGINS),
         )
-        # WS-3 poisoning gate: only auto-accept deltas whose STORED origin is
-        # trusted-for-privileged-write (owner/first_party). Fail-closed — a
-        # NULL/external origin (a delta forged via observation_write from an
-        # external-origin session, or a reflection delta written while an
-        # external session overlapped the 60-min window) is skipped, left
-        # UNRESOLVED for the 14-day TTL to reap, and logged. Conservative-safe:
-        # it delays/skips a user-model update, never corrupts it. The gate is an
-        # unconditional invariant (like never-block-owner), NOT wired through the
-        # shadow-clamped gate_mode("identity") — routing it there would make it a
-        # silent no-op. Legit reflection deltas carry first_party in quiet
-        # windows (reflection_window_origin never returns None), so this does not
-        # starve the normal pipeline.
-        pending = []
-        for _delta in raw_pending:
-            if is_trusted_for_privileged_write(_delta.get("origin_class")):
-                pending.append(_delta)
-            else:
+        # Observability: surface a poisoning-attempt signal (COUNT only — never
+        # re-fetch untrusted content into the accept path). process_pending_deltas
+        # runs on a multi-hour cadence, so a warning here is a signal, not spam.
+        try:
+            _ph = ",".join("?" for _ in TRUSTED_PRIVILEGED_WRITE_ORIGINS)
+            cur = await self._db.execute(
+                "SELECT COUNT(*) FROM observations "  # noqa: S608 - _ph is only "?" placeholders; values bound as params
+                "WHERE type = 'user_model_delta' AND resolved = 0 "
+                f"AND (origin_class IS NULL OR origin_class NOT IN ({_ph}))",
+                TRUSTED_PRIVILEGED_WRITE_ORIGINS,
+            )
+            row = await cur.fetchone()
+            if row and row[0]:
                 logger.warning(
-                    "user_model_delta %s BARRED from auto-accept (origin_class="
-                    "%r not trusted-for-privileged-write) — left unresolved for TTL",
-                    _delta.get("id"),
-                    _delta.get("origin_class"),
+                    "%d untrusted user_model_delta(s) present, BARRED from "
+                    "auto-accept (origin not owner/first_party) — left for TTL",
+                    row[0],
                 )
+        except Exception:
+            logger.debug("barred user_model_delta count failed", exc_info=True)
         if not pending:
             # Touch synthesized_at to confirm model is current even when there
             # is no TRUSTED pending work — an empty query OR every pending delta
@@ -236,12 +249,19 @@ class UserModelEvolver:
         if snapshot is None or not snapshot.model:
             return None
 
-        # Pull recent evidence (most recent resolved deltas) for context
+        # Pull recent evidence (most recent resolved deltas) for context.
+        # WS-3: restrict to trusted-origin deltas — a barred external/NULL delta
+        # becomes resolved=True once its 14-day TTL fires (resolve_expired), so
+        # WITHOUT this filter it would launder into the narrative that overwrites
+        # USER_KNOWLEDGE.md. Same trusted set as the accept path above.
+        from genesis.security.immunity import TRUSTED_PRIVILEGED_WRITE_ORIGINS
+
         try:
             recent = await observations.query(
                 self._db,
                 type="user_model_delta",
                 resolved=True,
+                origin_class_in=list(TRUSTED_PRIVILEGED_WRITE_ORIGINS),
                 limit=_NARRATIVE_EVIDENCE_LIMIT,
             )
         except Exception:

--- a/src/genesis/memory/user_model.py
+++ b/src/genesis/memory/user_model.py
@@ -75,14 +75,40 @@ class UserModelEvolver:
         gate-2 — lets the USER_KNOWLEDGE writer aggregate their stored
         origin_class without changing this method's return contract).
         """
-        pending = await observations.query(
+        from genesis.security.immunity import is_trusted_for_privileged_write
+
+        raw_pending = await observations.query(
             self._db, type="user_model_delta", resolved=False
         )
+        # WS-3 poisoning gate: only auto-accept deltas whose STORED origin is
+        # trusted-for-privileged-write (owner/first_party). Fail-closed — a
+        # NULL/external origin (a delta forged via observation_write from an
+        # external-origin session, or a reflection delta written while an
+        # external session overlapped the 60-min window) is skipped, left
+        # UNRESOLVED for the 14-day TTL to reap, and logged. Conservative-safe:
+        # it delays/skips a user-model update, never corrupts it. The gate is an
+        # unconditional invariant (like never-block-owner), NOT wired through the
+        # shadow-clamped gate_mode("identity") — routing it there would make it a
+        # silent no-op. Legit reflection deltas carry first_party in quiet
+        # windows (reflection_window_origin never returns None), so this does not
+        # starve the normal pipeline.
+        pending = []
+        for _delta in raw_pending:
+            if is_trusted_for_privileged_write(_delta.get("origin_class")):
+                pending.append(_delta)
+            else:
+                logger.warning(
+                    "user_model_delta %s BARRED from auto-accept (origin_class="
+                    "%r not trusted-for-privileged-write) — left unresolved for TTL",
+                    _delta.get("id"),
+                    _delta.get("origin_class"),
+                )
         if not pending:
-            # Touch synthesized_at to confirm model is current even when
-            # no new deltas exist.  Without this, the user_goal_staleness
-            # signal's project-staleness path decays to 1.0 whenever the
-            # delta pipeline is idle (no new observations to process).
+            # Touch synthesized_at to confirm model is current even when there
+            # is no TRUSTED pending work — an empty query OR every pending delta
+            # quarantined above. Without this, the user_goal_staleness signal's
+            # project-staleness path decays to 1.0 whenever the delta pipeline is
+            # idle (no new observations to process).
             try:
                 await self._db.execute(
                     "UPDATE user_model_cache SET synthesized_at = ? "

--- a/src/genesis/security/immunity.py
+++ b/src/genesis/security/immunity.py
@@ -177,6 +177,15 @@ def is_blockable(origin_class: str | None) -> bool:
     return effective_origin_class(origin_class) == ORIGIN_EXTERNAL_UNTRUSTED
 
 
+#: The origins trusted to be AUTO-CONSUMED into privileged state (user model,
+#: autonomy dispatch). Single source of truth — used both by
+#: :func:`is_trusted_for_privileged_write` (per-row checks, e.g. the dispatcher)
+#: and as the ``origin_class_in`` SQL filter for privileged READ consumers (the
+#: user-model accept + narrative queries), so a barred row can never crowd a
+#: trusted row out of a LIMITed query window.
+TRUSTED_PRIVILEGED_WRITE_ORIGINS: tuple[str, ...] = (ORIGIN_OWNER, ORIGIN_FIRST_PARTY)
+
+
 def is_trusted_for_privileged_write(origin_class: str | None) -> bool:
     """True ONLY for owner/first_party origins — the gate for AUTO-CONSUMING an
     observation into PRIVILEGED state (the user model, an autonomy dispatch).
@@ -193,7 +202,7 @@ def is_trusted_for_privileged_write(origin_class: str | None) -> bool:
     inside the generic ``observations.query`` (which has many non-privileged
     readers that must stay origin-agnostic).
     """
-    return effective_origin_class(origin_class) in (ORIGIN_OWNER, ORIGIN_FIRST_PARTY)
+    return effective_origin_class(origin_class) in TRUSTED_PRIVILEGED_WRITE_ORIGINS
 
 
 def _overlay_path() -> Path:

--- a/src/genesis/security/immunity.py
+++ b/src/genesis/security/immunity.py
@@ -52,6 +52,8 @@ from genesis.env import repo_root
 from genesis.memory.provenance import (
     ORIGIN_CLASSES,
     ORIGIN_EXTERNAL_UNTRUSTED,
+    ORIGIN_FIRST_PARTY,
+    ORIGIN_OWNER,
 )
 
 logger = logging.getLogger(__name__)
@@ -173,6 +175,25 @@ def is_blockable(origin_class: str | None) -> bool:
     block decision through this helper.
     """
     return effective_origin_class(origin_class) == ORIGIN_EXTERNAL_UNTRUSTED
+
+
+def is_trusted_for_privileged_write(origin_class: str | None) -> bool:
+    """True ONLY for owner/first_party origins — the gate for AUTO-CONSUMING an
+    observation into PRIVILEGED state (the user model, an autonomy dispatch).
+
+    Distinct from :func:`is_blockable`, which governs recall drop/wrap and is
+    permissive by design (only ``external_untrusted`` is blocked). This is the
+    STRICTER write-side predicate: fail-closed via
+    :func:`effective_origin_class`, so a NULL/unknown/``external_untrusted``
+    origin returns False and is NEVER auto-accepted into a privileged surface —
+    an unstamped or externally-sourced observation cannot poison the user model
+    or trigger an autonomy dispatch. A future non-owner "derived/provisional"
+    origin would also be untrusted here by construction (it is not
+    owner/first_party). Consult this at the point of the privileged ACTION, not
+    inside the generic ``observations.query`` (which has many non-privileged
+    readers that must stay origin-agnostic).
+    """
+    return effective_origin_class(origin_class) in (ORIGIN_OWNER, ORIGIN_FIRST_PARTY)
 
 
 def _overlay_path() -> Path:

--- a/tests/test_autonomy/test_dispatcher_origin_gate.py
+++ b/tests/test_autonomy/test_dispatcher_origin_gate.py
@@ -5,8 +5,11 @@ external-origin session must never spawn a background CC session. The pickup
 path is currently INERT (the observations table has no ``metadata`` column, so
 ``plan_path`` is always None and every row skips there) — this gate is
 forward-safe: it ensures that a future ``metadata`` addition cannot silently
-re-arm an ungated auto-dispatch surface. A barred row is resolved
-(``barred:untrusted_origin``) rather than left to re-log every cycle.
+re-arm an ungated auto-dispatch surface. A barred row is SKIP-ONLY: it is not
+dispatched but is left PENDING (not resolved), so legitimate NULL-origin owner
+rows stay visible in the dashboard/L1 exactly as before — only dispatch is
+refused. (Resolving barred rows would hide those legitimate rows; producer-side
+origin stamping is tracked in the memory-provenance follow-up.)
 """
 
 from __future__ import annotations

--- a/tests/test_autonomy/test_dispatcher_origin_gate.py
+++ b/tests/test_autonomy/test_dispatcher_origin_gate.py
@@ -46,44 +46,47 @@ async def _dispatcher_with_db():
 
 
 @pytest.mark.asyncio
-async def test_untrusted_task_detected_barred_and_resolved():
+async def test_untrusted_task_detected_not_dispatched_and_left_pending():
+    """SKIP-ONLY: an untrusted-origin task_detected is not dispatched, and — the
+    anti-regression property — is NOT resolved, so it stays visible in the
+    dashboard/L1 exactly as before this gate; only dispatch is refused. The gate
+    is a no-op today (inert pickup path), so the observable guarantee is
+    'nothing dispatched, nothing hidden'."""
     db, disp = await _dispatcher_with_db()
     try:
         await _seed(db, id="ext", origin_class="external_untrusted")
         await _seed(db, id="nul", origin_class=None)  # fail-closed
 
         n = await disp.dispatch_cycle()
-        assert n == 0  # nothing dispatched (inert)
+        assert n == 0  # nothing dispatched
 
         pending = {
             r["id"] for r in await observations.query(db, type="task_detected", resolved=False)
         }
-        assert "ext" not in pending  # barred → resolved
-        assert "nul" not in pending  # NULL fail-closed → barred → resolved
-
-        resolved = {
-            r["id"]: r for r in await observations.query(db, type="task_detected", resolved=True)
-        }
-        assert "barred:untrusted_origin" in (resolved["ext"].get("resolution_notes") or "")
-        assert "barred:untrusted_origin" in (resolved["nul"].get("resolution_notes") or "")
+        assert "ext" in pending  # skip-only: NOT resolved/hidden
+        assert "nul" in pending
+        # Nothing was resolved by the dispatcher — no visibility regression.
+        resolved = await observations.query(db, type="task_detected", resolved=True)
+        assert resolved == []
     finally:
         await db.close()
 
 
 @pytest.mark.asyncio
-async def test_trusted_task_detected_not_barred():
-    """A first_party task_detected is NOT barred by the gate — it proceeds to
-    the (inert) plan_path check and is skipped there, left pending. Proves the
-    gate discriminates on origin, not on everything."""
+async def test_trusted_task_detected_also_left_pending():
+    """A first_party task_detected is likewise not dispatched today (inert
+    plan_path) and stays pending — same observable outcome as the untrusted case
+    while the path is inert. Producer-side stamping + live dispatch behaviour are
+    tracked in the memory-provenance follow-up."""
     db, disp = await _dispatcher_with_db()
     try:
         await _seed(db, id="tru", origin_class="first_party")
         n = await disp.dispatch_cycle()
-        assert n == 0  # still inert (no plan_path)
+        assert n == 0
 
         pending = {
             r["id"] for r in await observations.query(db, type="task_detected", resolved=False)
         }
-        assert "tru" in pending  # skipped at plan_path, NOT barred → still pending
+        assert "tru" in pending
     finally:
         await db.close()

--- a/tests/test_autonomy/test_dispatcher_origin_gate.py
+++ b/tests/test_autonomy/test_dispatcher_origin_gate.py
@@ -1,0 +1,89 @@
+"""WS-3 poisoning gate on the autonomy dispatcher's observation pickup.
+
+A ``task_detected`` observation forged via observation_write from an
+external-origin session must never spawn a background CC session. The pickup
+path is currently INERT (the observations table has no ``metadata`` column, so
+``plan_path`` is always None and every row skips there) — this gate is
+forward-safe: it ensures that a future ``metadata`` addition cannot silently
+re-arm an ungated auto-dispatch surface. A barred row is resolved
+(``barred:untrusted_origin``) rather than left to re-log every cycle.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.autonomy.dispatcher import TaskDispatcher
+from genesis.db.crud import observations
+
+
+async def _seed(db, *, id: str, origin_class: str | None) -> None:
+    await observations.create(
+        db,
+        id=id,
+        source="inbox_evaluation" if origin_class == "external_untrusted" else "conversation",
+        type="task_detected",
+        content=f"task-{id}",
+        priority="medium",
+        created_at="2026-03-08T00:00:00",
+        origin_class=origin_class,
+    )
+
+
+async def _dispatcher_with_db():
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    from genesis.db.schema import create_all_tables
+
+    await create_all_tables(db)
+    await db.commit()
+    # executor is never invoked: Path 1 is a no-op (no active tasks) and the
+    # gate/plan_path checks short-circuit before self.submit for every row here.
+    return db, TaskDispatcher(db=db, executor=MagicMock())
+
+
+@pytest.mark.asyncio
+async def test_untrusted_task_detected_barred_and_resolved():
+    db, disp = await _dispatcher_with_db()
+    try:
+        await _seed(db, id="ext", origin_class="external_untrusted")
+        await _seed(db, id="nul", origin_class=None)  # fail-closed
+
+        n = await disp.dispatch_cycle()
+        assert n == 0  # nothing dispatched (inert)
+
+        pending = {
+            r["id"] for r in await observations.query(db, type="task_detected", resolved=False)
+        }
+        assert "ext" not in pending  # barred → resolved
+        assert "nul" not in pending  # NULL fail-closed → barred → resolved
+
+        resolved = {
+            r["id"]: r for r in await observations.query(db, type="task_detected", resolved=True)
+        }
+        assert "barred:untrusted_origin" in (resolved["ext"].get("resolution_notes") or "")
+        assert "barred:untrusted_origin" in (resolved["nul"].get("resolution_notes") or "")
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_trusted_task_detected_not_barred():
+    """A first_party task_detected is NOT barred by the gate — it proceeds to
+    the (inert) plan_path check and is skipped there, left pending. Proves the
+    gate discriminates on origin, not on everything."""
+    db, disp = await _dispatcher_with_db()
+    try:
+        await _seed(db, id="tru", origin_class="first_party")
+        n = await disp.dispatch_cycle()
+        assert n == 0  # still inert (no plan_path)
+
+        pending = {
+            r["id"] for r in await observations.query(db, type="task_detected", resolved=False)
+        }
+        assert "tru" in pending  # skipped at plan_path, NOT barred → still pending
+    finally:
+        await db.close()

--- a/tests/test_autonomy/test_executor/test_dispatcher.py
+++ b/tests/test_autonomy/test_executor/test_dispatcher.py
@@ -226,6 +226,9 @@ class TestDispatchCycle:
             "id": "obs-1",
             "content": "Build feature Y",
             "metadata": {"plan_path": str(plan)},
+            # Trusted origin: this fixture exercises the DISPATCH path, which the
+            # WS-3 poisoning gate now allows only for owner/first_party rows.
+            "origin_class": "first_party",
         }
 
         with (
@@ -250,6 +253,8 @@ class TestDispatchCycle:
             "id": "obs-2",
             "content": "Already running",
             "metadata": {"plan_path": "/some/path"},
+            # Trusted origin: exercises the dedup path past the WS-3 origin gate.
+            "origin_class": "first_party",
         }
 
         with (

--- a/tests/test_mcp/test_observation_write_origin.py
+++ b/tests/test_mcp/test_observation_write_origin.py
@@ -1,0 +1,81 @@
+"""observation_write stamps the dispatching session's origin_class (WS-3).
+
+Before this fix, observation_write was the one memory writer that dropped the
+session origin — an external-origin session (e.g. the inbox judge running over
+untrusted content) wrote a NULL origin that every origin-aware reader treated as
+first-party "by omission", letting a forged user_model_delta slip past the
+user-model consumer gate. This proves the tool now forwards the session origin
+like its sibling writers (memory_store / procedure_store / knowledge).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import aiosqlite
+import pytest
+
+from genesis.mcp.memory_mcp import mcp
+
+
+async def _get_tools():
+    return await mcp.get_tools()
+
+
+async def _write_and_read_origin(monkeypatch, origin_env: str | None) -> str:
+    import genesis.mcp.memory_mcp as mod
+
+    async with aiosqlite.connect(":memory:") as real_db:
+        real_db.row_factory = aiosqlite.Row
+        from genesis.db.schema import create_all_tables
+
+        await create_all_tables(real_db)
+        await real_db.commit()
+
+        old_store, old_db, old_retriever = mod._store, mod._db, mod._retriever
+        try:
+            mod._store = MagicMock()
+            mod._db = real_db
+            mod._retriever = MagicMock()
+
+            if origin_env is None:
+                monkeypatch.delenv("GENESIS_SESSION_ORIGIN", raising=False)
+            else:
+                monkeypatch.setenv("GENESIS_SESSION_ORIGIN", origin_env)
+
+            tools = await _get_tools()
+            obs_id = await tools["observation_write"].fn(
+                content="the user prefers Rust",
+                source="inbox_evaluation",
+                type="user_model_delta",
+            )
+            assert obs_id and obs_id != "duplicate_skipped"
+            cursor = await real_db.execute(
+                "SELECT origin_class FROM observations WHERE id = ?", (obs_id,)
+            )
+            row = await cursor.fetchone()
+            assert row is not None
+            return row["origin_class"]
+        finally:
+            mod._store, mod._db, mod._retriever = old_store, old_db, old_retriever
+
+
+@pytest.mark.asyncio
+async def test_external_session_stamps_external_origin(monkeypatch):
+    """The inbox-judge case: origin env → stored external_untrusted, so the
+    consumer gate can bar a forged user_model_delta."""
+    assert await _write_and_read_origin(monkeypatch, "external_untrusted") == "external_untrusted"
+
+
+@pytest.mark.asyncio
+async def test_unset_session_defaults_first_party(monkeypatch):
+    """Server/foreground writers (no env stamp) coalesce to first_party — NOT
+    a raw NULL (which the gate would treat adversarially as untrusted)."""
+    assert await _write_and_read_origin(monkeypatch, None) == "first_party"
+
+
+@pytest.mark.asyncio
+async def test_invalid_session_origin_defaults_first_party(monkeypatch):
+    """session_origin_from_env returns None on a garbage value → coalesced to
+    first_party (the producer side validates loudly; this side is fail-safe)."""
+    assert await _write_and_read_origin(monkeypatch, "not_a_real_origin") == "first_party"

--- a/tests/test_memory/test_user_model.py
+++ b/tests/test_memory/test_user_model.py
@@ -16,6 +16,8 @@ async def _create_delta(
     value: str,
     confidence: float,
     origin_class: str | None = "first_party",
+    created_at: str = "2026-03-08T00:00:00",
+    resolved: bool = False,
 ) -> None:
     # Default origin_class="first_party" mirrors the REAL writers
     # (reflection_bridge/_output + perception/writer), which stamp
@@ -35,9 +37,13 @@ async def _create_delta(
             "confidence": confidence,
         }),
         priority="medium",
-        created_at="2026-03-08T00:00:00",
+        created_at=created_at,
         origin_class=origin_class,
     )
+    if resolved:
+        await observations.resolve(
+            db, id, resolved_at=created_at, resolution_notes="test-resolved"
+        )
 
 
 @pytest.mark.asyncio
@@ -390,3 +396,68 @@ async def test_owner_origin_accepted(db):
     result = await UserModelEvolver(db=db).process_pending_deltas()
     assert result is not None
     assert result.model["preferred_language"] == "Rust"
+
+
+@pytest.mark.asyncio
+async def test_barred_flood_does_not_starve_trusted_delta(db):
+    """P1 regression: a flood of NEWER barred deltas must NOT crowd an older
+    trusted delta out of the newest-N query window. Filtering origin in SQL (not
+    in Python after a LIMITed fetch) is what makes this hold — with a Python
+    post-filter and the default limit=50, the 60 barred rows below would fill the
+    window and the trusted delta would never be seen."""
+    await _create_delta(
+        db, id="trusted-old", field="preferred_language", value="Python",
+        confidence=0.95, origin_class="first_party",
+        created_at="2026-03-01T00:00:00",  # OLDER than the flood
+    )
+    for i in range(60):  # > default limit of 50, all NEWER, all barred
+        await _create_delta(
+            db, id=f"ext-{i}", field=f"forged_{i}", value="x",
+            confidence=0.99, origin_class="external_untrusted",
+            created_at=f"2026-03-09T00:{i // 60:02d}:{i % 60:02d}",
+        )
+    result = await UserModelEvolver(db=db).process_pending_deltas()
+    assert result is not None
+    assert result.model["preferred_language"] == "Python"  # trusted still accepted
+    assert all(not k.startswith("forged_") for k in result.model)  # no barred value
+
+
+@pytest.mark.asyncio
+async def test_narrative_excludes_barred_resolved_deltas(db):
+    """P1 regression: synthesize_narrative pulls RESOLVED deltas as evidence. A
+    barred delta becomes resolved once its TTL fires, so without an origin filter
+    it would launder into the USER_KNOWLEDGE.md narrative prompt. Assert the
+    barred delta's content never reaches the prompt."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from genesis.db.crud import user_model as user_model_crud
+
+    # Seed a non-empty model so synthesize_narrative proceeds past its early return.
+    await user_model_crud.upsert(
+        db, model_json={"preferred_language": "Python"}, synthesized_at="2026-03-08T00:00:00",
+        synthesized_by="test", evidence_count=1, last_change_type="test",
+    )
+    await _create_delta(
+        db, id="tru", field="preferred_language", value="Python", confidence=0.9,
+        origin_class="first_party", resolved=True,
+    )
+    await _create_delta(
+        db, id="ext", field="INJECTED_SECRET", value="attacker_payload", confidence=0.99,
+        origin_class="external_untrusted", resolved=True,
+    )
+
+    captured = {}
+    result_obj = MagicMock(success=True, content="narrative", provider_used="x",
+                           input_tokens=1, output_tokens=1, cost_usd=0.0)
+
+    async def _route_call(call_site_id, messages, **kw):
+        captured["prompt"] = messages[0]["content"]
+        return result_obj
+
+    router = MagicMock()
+    router.route_call = AsyncMock(side_effect=_route_call)
+
+    out = await UserModelEvolver(db=db).synthesize_narrative(router)
+    assert out == "narrative"
+    assert "attacker_payload" not in captured["prompt"]  # barred delta excluded
+    assert "INJECTED_SECRET" not in captured["prompt"]

--- a/tests/test_memory/test_user_model.py
+++ b/tests/test_memory/test_user_model.py
@@ -9,8 +9,20 @@ from genesis.memory.user_model import UserModelEvolver
 
 
 async def _create_delta(
-    db, *, id: str, field: str, value: str, confidence: float
+    db,
+    *,
+    id: str,
+    field: str,
+    value: str,
+    confidence: float,
+    origin_class: str | None = "first_party",
 ) -> None:
+    # Default origin_class="first_party" mirrors the REAL writers
+    # (reflection_bridge/_output + perception/writer), which stamp
+    # reflection_window_origin — first_party in a quiet window. The pre-WS-3
+    # NULL default was unrealistic: no live writer produces NULL deltas, and the
+    # poisoning gate fail-closes NULL, so seeding NULL would misrepresent the
+    # legit pipeline. Gate tests pass origin_class explicitly.
     await observations.create(
         db,
         id=id,
@@ -24,6 +36,7 @@ async def _create_delta(
         }),
         priority="medium",
         created_at="2026-03-08T00:00:00",
+        origin_class=origin_class,
     )
 
 
@@ -303,3 +316,77 @@ async def test_accepted_ids_out_untouched_when_nothing_accepted(db):
     out: list[str] = []
     assert await evolver.process_pending_deltas(accepted_ids_out=out) is None
     assert out == []
+
+
+# ── WS-3 poisoning gate: only owner/first_party origins auto-accept ──────────
+
+
+@pytest.mark.asyncio
+async def test_external_origin_delta_barred_from_auto_accept(db):
+    """A high-confidence delta with an external origin (e.g. forged via
+    observation_write from the inbox judge) must NOT reach the user model."""
+    await _create_delta(
+        db, id="ext", field="risk_tolerance", value="maximal",
+        confidence=0.95, origin_class="external_untrusted",
+    )
+    result = await UserModelEvolver(db=db).process_pending_deltas()
+    assert result is None  # nothing accepted
+
+
+@pytest.mark.asyncio
+async def test_null_origin_delta_barred_fail_closed(db):
+    """Fail-closed: a NULL origin (legacy/unstamped) is untrusted, not
+    first-party 'by omission'."""
+    await _create_delta(
+        db, id="nul", field="risk_tolerance", value="maximal",
+        confidence=0.95, origin_class=None,
+    )
+    result = await UserModelEvolver(db=db).process_pending_deltas()
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_barred_delta_left_unresolved_for_ttl(db):
+    """Barred deltas are NOT resolved — they stay pending for the 14-day TTL to
+    reap (never silently discarded, in case of a labeling error)."""
+    await _create_delta(
+        db, id="ext", field="editor", value="emacs",
+        confidence=0.95, origin_class="external_untrusted",
+    )
+    await UserModelEvolver(db=db).process_pending_deltas()
+    still_pending = await observations.query(
+        db, type="user_model_delta", resolved=False
+    )
+    assert any(r["id"] == "ext" for r in still_pending)
+
+
+@pytest.mark.asyncio
+async def test_first_party_accepted_external_barred_in_mixed_batch(db):
+    """Positive control + gate together: in a mixed batch only the trusted
+    (first_party) delta lands; the external one is barred. Proves the barred
+    tests above are not vacuously green (the accept path works)."""
+    await _create_delta(
+        db, id="fp", field="editor", value="vim",
+        confidence=0.9, origin_class="first_party",
+    )
+    await _create_delta(
+        db, id="ext", field="editor", value="emacs",
+        confidence=0.95, origin_class="external_untrusted",
+    )
+    out: list[str] = []
+    result = await UserModelEvolver(db=db).process_pending_deltas(accepted_ids_out=out)
+    assert result is not None
+    assert result.model["editor"] == "vim"  # only the trusted origin
+    assert out == ["fp"]
+
+
+@pytest.mark.asyncio
+async def test_owner_origin_accepted(db):
+    """owner is trusted-for-privileged-write (belt with first_party)."""
+    await _create_delta(
+        db, id="own", field="preferred_language", value="Rust",
+        confidence=0.9, origin_class="owner",
+    )
+    result = await UserModelEvolver(db=db).process_pending_deltas()
+    assert result is not None
+    assert result.model["preferred_language"] == "Rust"

--- a/tests/test_security/test_immunity.py
+++ b/tests/test_security/test_immunity.py
@@ -222,3 +222,39 @@ def test_record_demotion_carries_repo_sibling_overlay_keys(config_dirs):
     assert written["autonomy"]["mode"] == "enforce"  # carried over
     assert written["injection"]["mode"] == "shadow"
     assert immunity.gate_mode("autonomy") == "enforce"  # still applies
+
+
+# ─── is_trusted_for_privileged_write (write-side trust predicate) ─────────────
+
+
+@pytest.mark.parametrize(
+    "origin,expected",
+    [
+        ("owner", True),
+        ("first_party", True),
+        ("external_untrusted", False),
+        (None, False),  # fail-closed: unstamped is NOT trusted "by omission"
+        ("garbage", False),  # unknown → external → not trusted
+        ("", False),
+    ],
+)
+def test_is_trusted_for_privileged_write(origin, expected):
+    """The write-side gate: only owner/first_party may auto-consume into
+    privileged state (user model, autonomy dispatch). Fail-closed on
+    NULL/unknown (NOT first-party 'by omission'). No config read, so no
+    config_dirs fixture needed."""
+    assert immunity.is_trusted_for_privileged_write(origin) is expected
+
+
+def test_trusted_write_is_a_distinct_predicate_from_blockable():
+    """For the current 3-class taxonomy the write-side gate is the logical
+    complement of is_blockable — but it is defined INDEPENDENTLY (owner/
+    first_party allow-list, not `not is_blockable`) so that a future
+    non-owner 'derived/provisional' origin would be kept-in-recall
+    (not blockable) yet barred-from-privileged-write. Today they agree on
+    every value; this pins that agreement so a taxonomy change is a conscious
+    diff."""
+    for origin in ("owner", "first_party", "external_untrusted", None, "garbage"):
+        assert immunity.is_trusted_for_privileged_write(origin) is (
+            not immunity.is_blockable(origin)
+        )

--- a/tests/test_security/test_privileged_write_coverage.py
+++ b/tests/test_security/test_privileged_write_coverage.py
@@ -1,51 +1,83 @@
-"""Guardrail: every privileged observation-consumer consults the WS-3 write gate.
+"""Guardrail: every privileged observation-consumer gates on origin.
 
-``is_trusted_for_privileged_write`` (security/immunity.py) is a LIBRARY choke-point
-— nothing structurally forces a consumer to call it, so a refactor that drops the
-call, or a NEW privileged consumer that forgets it, would silently re-open the
-user-model / autonomy-dispatch poisoning surface. This test pins the enumerated
-consumer set.
+The origin gate is a LIBRARY choke-point — nothing structurally forces a consumer
+to apply it, so a refactor that drops the gate, or a NEW privileged consumer that
+forgets it, would silently re-open the poisoning surface. This test pins the
+enumerated consumer set AND — via AST — checks the gate appears inside the NAMED
+function's own body (not merely somewhere in the module), so moving the call out
+of the consumer fails CI.
 
 The class was enumerated via a Serena ``find_referencing_symbols`` sweep of
-``db/crud/observations.py::query`` (2026-08-18): exactly TWO privileged-write
-consumers are reachable via ``observation_write`` — the user model
-(``process_pending_deltas`` → USER_KNOWLEDGE.md) and the autonomy dispatcher
-(``dispatch_cycle`` task_detected pickup). Every other caller is a read-for-context
-path (perception/reflection/surplus), an observability read (dashboard/health/
-version signals), or a test. If a THIRD privileged consumer is added, add it here
-AND gate it.
+``db/crud/observations.py::query`` PLUS a raw-SQL grep of ``FROM observations``
+(2026-08-18 — the raw-SQL grep was added after review found ``observations.query``
+alone missed raw ``db.execute`` consumers). Consumers that AUTO-CONSUME a
+``user_model_delta`` / ``task_detected`` into privileged state:
+- ``user_model.process_pending_deltas`` — accept into the user model.
+- ``user_model.synthesize_narrative`` — resolved deltas → USER_KNOWLEDGE.md narrative.
+- ``autonomy.dispatcher.dispatch_cycle`` — task_detected → autonomy dispatch.
+Other ``observations`` readers surface content into LLM context WITHOUT the strict
+write-gate (essential_knowledge / reflection / ego) — that broader injection surface
+is a separate tracked follow-up, gated on the recall-side ``is_blockable`` predicate,
+not this write-side one.
 """
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import genesis
 
 _SRC = Path(genesis.__file__).parent
-_GATE = "is_trusted_for_privileged_write"
+
+# Any of these tokens, appearing INSIDE the named function, counts as gating on
+# origin: the per-row helper, the shared trusted-origin set, or the SQL filter arg.
+_GATE_TOKENS = (
+    "is_trusted_for_privileged_write",
+    "TRUSTED_PRIVILEGED_WRITE_ORIGINS",
+    "origin_class_in",
+)
 
 # (module relative path, the privileged-consumer function that MUST gate on origin)
 _PRIVILEGED_CONSUMERS = [
     ("memory/user_model.py", "process_pending_deltas"),
+    ("memory/user_model.py", "synthesize_narrative"),
     ("autonomy/dispatcher.py", "dispatch_cycle"),
 ]
 
 
-def test_privileged_consumers_reference_the_write_gate():
+def _function_ast_dump(module_src: str, func_name: str) -> str:
+    """AST dump of the named function's own node.
+
+    Using ``ast.dump`` (not the raw source segment) means COMMENTS are excluded —
+    a comment mentioning a gate token can't fool the guardrail; only a real
+    identifier / keyword-arg / string in the function's AST matches.
+    """
+    tree = ast.parse(module_src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef) and node.name == func_name:
+            return ast.dump(node)
+    raise AssertionError(f"function {func_name!r} not found in module")
+
+
+def test_privileged_consumers_gate_on_origin_in_their_own_body():
     for rel, func in _PRIVILEGED_CONSUMERS:
-        src = (_SRC / rel).read_text()
-        assert _GATE in src, (
-            f"{rel} must consult {_GATE}: its privileged consumer {func}() "
-            f"auto-writes state from observation content and must bar untrusted "
-            f"origins (WS-3 poisoning gate)."
+        dump = _function_ast_dump((_SRC / rel).read_text(), func)
+        assert any(tok in dump for tok in _GATE_TOKENS), (
+            f"{rel}::{func} must gate on origin (one of {_GATE_TOKENS}) INSIDE its "
+            f"own body — it auto-consumes observation content into privileged state."
         )
 
 
-def test_gate_helper_exists_and_is_importable():
-    from genesis.security.immunity import is_trusted_for_privileged_write
+def test_gate_helper_and_trusted_set_are_importable_and_consistent():
+    from genesis.security.immunity import (
+        TRUSTED_PRIVILEGED_WRITE_ORIGINS,
+        is_trusted_for_privileged_write,
+    )
 
-    # The invariant the consumers rely on: owner/first_party trusted, all else not.
-    assert is_trusted_for_privileged_write("first_party") is True
+    # The trusted set is exactly owner/first_party; the helper agrees with it.
+    assert set(TRUSTED_PRIVILEGED_WRITE_ORIGINS) == {"owner", "first_party"}
+    for origin in TRUSTED_PRIVILEGED_WRITE_ORIGINS:
+        assert is_trusted_for_privileged_write(origin) is True
     assert is_trusted_for_privileged_write("external_untrusted") is False
     assert is_trusted_for_privileged_write(None) is False

--- a/tests/test_security/test_privileged_write_coverage.py
+++ b/tests/test_security/test_privileged_write_coverage.py
@@ -1,0 +1,51 @@
+"""Guardrail: every privileged observation-consumer consults the WS-3 write gate.
+
+``is_trusted_for_privileged_write`` (security/immunity.py) is a LIBRARY choke-point
+— nothing structurally forces a consumer to call it, so a refactor that drops the
+call, or a NEW privileged consumer that forgets it, would silently re-open the
+user-model / autonomy-dispatch poisoning surface. This test pins the enumerated
+consumer set.
+
+The class was enumerated via a Serena ``find_referencing_symbols`` sweep of
+``db/crud/observations.py::query`` (2026-08-18): exactly TWO privileged-write
+consumers are reachable via ``observation_write`` — the user model
+(``process_pending_deltas`` → USER_KNOWLEDGE.md) and the autonomy dispatcher
+(``dispatch_cycle`` task_detected pickup). Every other caller is a read-for-context
+path (perception/reflection/surplus), an observability read (dashboard/health/
+version signals), or a test. If a THIRD privileged consumer is added, add it here
+AND gate it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import genesis
+
+_SRC = Path(genesis.__file__).parent
+_GATE = "is_trusted_for_privileged_write"
+
+# (module relative path, the privileged-consumer function that MUST gate on origin)
+_PRIVILEGED_CONSUMERS = [
+    ("memory/user_model.py", "process_pending_deltas"),
+    ("autonomy/dispatcher.py", "dispatch_cycle"),
+]
+
+
+def test_privileged_consumers_reference_the_write_gate():
+    for rel, func in _PRIVILEGED_CONSUMERS:
+        src = (_SRC / rel).read_text()
+        assert _GATE in src, (
+            f"{rel} must consult {_GATE}: its privileged consumer {func}() "
+            f"auto-writes state from observation content and must bar untrusted "
+            f"origins (WS-3 poisoning gate)."
+        )
+
+
+def test_gate_helper_exists_and_is_importable():
+    from genesis.security.immunity import is_trusted_for_privileged_write
+
+    # The invariant the consumers rely on: owner/first_party trusted, all else not.
+    assert is_trusted_for_privileged_write("first_party") is True
+    assert is_trusted_for_privileged_write("external_untrusted") is False
+    assert is_trusted_for_privileged_write(None) is False


### PR DESCRIPTION
## What & why

`observation_write` was the one memory writer that dropped the dispatching session's origin. An external-origin session — the inbox eval judge, which runs `skip_permissions` over untrusted curated content and retains `observation_write` — could forge a `user_model_delta` observation that stored a NULL origin (read as first-party "by omission") and was auto-accepted by `UserModelEvolver.process_pending_deltas` into `USER_KNOWLEDGE.md`, which is injected into every session. This closes the two **privileged-write auto-accept** paths.

## Changes

- **`observation_write` stamps origin** — `origin_class=session_origin_from_env() or ORIGIN_FIRST_PARTY`, mirroring the `memory_store` / `procedure_store` / `knowledge` writers. No schema change (the column has existed since the gate-2 substrate).
- **`immunity.is_trusted_for_privileged_write(origin)`** — owner/first_party only, fail-closed on NULL/unknown/external via `effective_origin_class`. The strict write-side companion to `is_blockable` (which stays permissive for the recall path).
- **Consumer gates** — `user_model.process_pending_deltas` and the autonomy dispatcher's `task_detected` pickup now skip any untrusted-origin row (don't auto-accept / don't dispatch), leave it unresolved for the TTL to reap, and log it. Legit reflection deltas carry `first_party` in quiet windows (`reflection_window_origin` never returns None), so the normal pipeline is unaffected.
- **Coverage guardrail** pins the enumerated privileged-consumer set so a future consumer can't silently skip the gate.

## Scope — PARTIAL by design

This closes the two privileged-**write** auto-accept paths only. Adversarial review found the broader observation-content-**injection** surface is still open: external-origin `user_signal` / `architecture_insight` digests (which the inbox judge legitimately writes) are surfaced **unfiltered** into `essential_knowledge.md` (via a raw-SQL `_recent_decisions` read), deep-reflection context, and several ego/sentinel raw-SQL reads. Closing that needs an architectural exclude/wrap choke-point (using `is_blockable`, keeping NULL — most internal writers are unstamped) plus a raw-SQL-inclusive coverage guardrail — tracked as a separate HIGH follow-up. Docs/comments in this PR say PARTIAL and point there.

## Testing

- `is_trusted_for_privileged_write` truth table; `observation_write` origin-stamp (external / unset→first_party / garbage→first_party); consumer-gate integration (external & NULL barred + left unresolved, first_party & owner accepted, mixed batch takes only the trusted value); dispatcher barred-and-resolved vs trusted-still-pending; coverage guardrail. All new tests verify-RED confirmed against the un-gated code.
- Lint clean; targeted suites green; no regression in the gate-2-substrate / perception-writer / delta-confidence tests.

Ledger: 6ff6ec278829451182851e1dc302d4cc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
