### PR TITLE
fix(inbox): end the approval-request storm — idempotent approvals, real DM scroll-up, faithful park resume

### DIFF
--- a/.claude/agents/genesis-researcher.md
+++ b/.claude/agents/genesis-researcher.md
@@ -8,8 +8,9 @@ You are a research agent for Genesis with access to powerful web and code intell
 
 ## Web Tools (MCP — use these, NOT CC WebFetch/WebSearch)
 
-- **`web_fetch(url)`** — Fetch any URL with smart anti-bot bypass. Scrapling TLS impersonation → Crawl4AI JS rendering → httpx. Returns structured content.
+- **`web_fetch(url)`** — Fetch any URL with smart anti-bot bypass. Auto chain: TinyFish (anti-bot, JS) → Scrapling TLS impersonation → Ladder → Crawl4AI JS rendering → httpx. Returns structured content.
 - **`web_search(query)`** — Search the web via TinyFish (primary) → SearXNG (self-hosted fallback) → Brave. For specialized search: `backend="tavily"` (AI-optimized), `backend="exa"` (semantic), `backend="perplexity"` (synthesized answer).
+- **Escalation when the free chain dead-ends** (hard anti-bot, paywalled, heavy JS): `web_fetch(url, backend="firecrawl")` / `web_search(query, backend="firecrawl")` — a PAID cloud scraping API (burns credits; never used automatically). Reach for it only after the auto chain has actually failed, and say so in your findings.
 - **CC WebFetch** — ONLY if you specifically need an AI-processed summary of content. Otherwise use `web_fetch`.
 - **CC WebSearch** — ONLY for trivial general lookups. Otherwise use `web_search`.
 
@@ -40,6 +41,7 @@ When searching for repos, libraries, or implementation patterns on GitHub:
 | Need | Tool |
 |------|------|
 | Fetch a webpage | `web_fetch(url)` |
+| Fetch failed on anti-bot/paywall/JS | `web_fetch(url, backend="firecrawl")` (paid, last resort) |
 | Search the internet | `web_search(query)` |
 | Search GitHub repos | `gh search repos "query"` via Bash |
 | Search GitHub code | `gh search code "query"` or grep.app via `web_fetch` |

--- a/.claude/skills/cc-update/SKILL.md
+++ b/.claude/skills/cc-update/SKILL.md
@@ -69,3 +69,24 @@ the delta touches:
 
 Capture any such change as a follow-up + a doc entry — that is how the next update stays
 execute-not-rediscover.
+
+## Detection → behavior (new-capability adoption path)
+
+The impact eval treats a new feature as *informational* by design ("available"
+is not "required") — correct for alerting, but it left no path from "detected"
+to "Genesis actually starts using it". So, when the changelog review flags a
+NEW skill/command/flag that Genesis would plausibly WANT (it overlaps an
+existing Genesis workflow, replaces a hand-rolled mechanism, or covers a known
+gap), do BOTH:
+
+1. File the informational KB entry as usual (no alert — calibration unchanged).
+2. Create a `follow_up_create` row (`work_state="ready"`, low priority) naming
+   the SPECIFIC instruction change, e.g. "once CC >= vX.Y.Z is pinned: prefer
+   native `/design` over the gstack `design-*` skills for UI drafting; decide
+   precedence and update the relevant skill/CLAUDE.md instruction". A
+   capability nobody wires into an instruction is a capability Genesis never
+   reaches for.
+
+Origin (2026-08-18): the `/design` research-preview announcement had no route
+from detection to adoption; the user asked "how do we make sure you
+automatically leverage this when you should?" — this step is the answer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,53 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **Inbox approval-request storm ended.** A stale-hash defect made the inbox
+  monitor see phantom "modified" files every 30-minute scan, each time
+  cancelling the pending approval and sending a fresh Telegram request — up to
+  48 messages a day. The known-hash map is now a single recency scan (newest
+  decisive row wins), and new/changed inbox content while a request is pending
+  parks onto the SAME request instead of cancelling it: one approval message,
+  ever, per outstanding batch — and approving once evaluates everything
+  outstanding at that moment.
+- **Inbox approvals never re-ask.** Delivered inbox approval requests send no
+  reminders (per-policy `reask_overrides` in `autonomous_cli_policy.yaml`,
+  `0` = never; other approval types keep their 24h re-ask). A request whose
+  Telegram delivery FAILED still retries each scan until one send succeeds —
+  that's recovery, not a reminder.
+- **Rate-limit-parked background sessions resume faithfully.** A parked
+  session's re-dispatch now carries its full execution shape (system prompt /
+  strategy doc, attribution tag, skills) instead of resuming with defaults,
+  and campaign bookkeeping follows the park to the delivering session's real
+  result instead of recording a false failed run (bounded at 7 days so a stuck
+  resume can never stall a campaign forever).
+
 ### Added
+
+- **Telegram DM "scroll-up".** Sessions can now read the conversation archive
+  on demand: `conversation_history` accepts `chat_id` (scoped to one chat) and
+  `before` (page arbitrarily far back, full-length messages), every fresh
+  telegram session is told its own chat id, and the session-recovery recap is
+  byte-budgeted and tail-biased so the END of long replies (option lists,
+  conclusions) survives instead of being cut at 300 characters.
+- **Firecrawl as an explicit paid escalation backend.**
+  `web_fetch(url, backend="firecrawl")` / `web_search(query,
+  backend="firecrawl")` reach the Firecrawl cloud API (needs
+  `FIRECRAWL_API_KEY`) — including from Bash-less background sessions. Never
+  part of the automatic chains: it burns credits only when you ask for it.
+- **Claude Code login-expiry warning + background fallback.** The interactive
+  claude.ai login's refresh token has a fixed lifetime that routine use does
+  not extend; Genesis now warns via Telegram days ahead
+  (`GENESIS_CC_LOGIN_EXPIRY_WARN_DAYS`, default 5), and — if the operator has
+  stored a 1-year `claude setup-token` via `scripts/store_cc_token.sh` —
+  background sessions fall back to it when the login is confirmed dead (never
+  over a working login).
+- **Settings writes are provenance-stamped, and disabling the approval gate
+  requires confirmation.** Every settings write records `# set-by: <actor> @
+  <time>` in the overlay file so a deliberate operator choice is never
+  mistaken for drift, and setting `manual_approval_required: false` now needs
+  an explicit confirmation flag and announces itself via Telegram.
 
 - **Opt-in career-outreach monitor (off by default).** A new daily monitor that,
   once enabled, drives a configured external career-agent module to stage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   on demand: `conversation_history` accepts `chat_id` (scoped to one chat) and
   `before` (page arbitrarily far back, full-length messages), every fresh
   telegram session is told its own chat id, and the session-recovery recap is
-  byte-budgeted and tail-biased so the END of long replies (option lists,
+  character-budgeted and tail-biased so the END of long replies (option lists,
   conclusions) survives instead of being cut at 300 characters.
 - **Firecrawl as an explicit paid escalation backend.**
   `web_fetch(url, backend="firecrawl")` / `web_search(query,

--- a/config/autonomous_cli_policy.yaml
+++ b/config/autonomous_cli_policy.yaml
@@ -1,5 +1,17 @@
 autonomous_cli_fallback_enabled: true
 manual_approval_required: true
+# Reminder cadence for a DELIVERED pending approval (hours). 0 = never re-ask.
+# Delivery-failure recovery is separate and always on: a request whose Telegram
+# send never succeeded retries each tick regardless of these values.
 reask_interval_hours: 24
+# Per-policy overrides (policy_id -> hours, 0 = never). Inbox evaluation is
+# idempotent (approve-once clears everything outstanding; new content parks
+# onto the same pending request), so repeated reminders carry no information —
+# pending requests stay visible via the dashboard and morning report.
+# Overlay note: nested maps DEEP-MERGE — deleting a key in your .local.yaml
+# does not remove this default. To restore inbox reminders, explicitly set
+# `reask_overrides: {inbox_evaluation: 24}` in your .local.yaml.
+reask_overrides:
+  inbox_evaluation: 0
 approval_channel: telegram
 shared_export_enabled: true

--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -207,6 +207,14 @@ When a new CC version is released, run through this:
    `src/genesis/recon/cc_update_analyzer.py` for the full lens definitions.)
 3. **Flag/API changes:** Are any CLI flags we use modified or deprecated?
 4. **New capabilities:** Does this unlock something we're working around?
+   **Detection → behavior:** for each new skill/command/flag Genesis would
+   plausibly WANT (overlaps an existing workflow, replaces a hand-rolled
+   mechanism, covers a known gap), do not stop at the informational KB note —
+   create a `follow_up_create` row (`work_state="ready"`, low priority) naming
+   the SPECIFIC instruction change that would make Genesis actually reach for
+   it (which skill/CLAUDE.md line to edit, and any precedence decision vs
+   existing skills). A detected-but-unwired capability is never used.
+   (Origin: the 2026-08 `/design` research-preview announcement.)
 5. **Obsolescence check:** Does this make something we built unnecessary?
 6. **Interactive UX check:** Does this change the foreground session experience?
    Rendering, scrollback, terminal behavior, keyboard shortcuts?

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -294,3 +294,62 @@ GENESIS_BACKUP_NAS=
 GENESIS_BACKUP_NAS_USER=
 # Used by: smb backend — share password
 GENESIS_BACKUP_NAS_PASS=
+
+# ─── Email (Gmail IMAP) ──────────────────────────────────────────────────
+# Used by: Mail monitor (genesis/mail/) — polls inbox for AI newsletters,
+#   announcements, and research; feeds the recon pipeline.
+# Setup: enable 2FA on the Gmail account, then generate an App Password at
+#   myaccount.google.com/apppasswords (this is NOT the account login password).
+GENESIS_GMAIL_ADDRESS=
+GENESIS_GMAIL_APP_PASSWORD=
+
+# ─── Browser / Web Automation ────────────────────────────────────────────
+# --- TinyFish ---
+# Used by: web_fetch anti-bot cloud backend, web_agent, and browser tinyfish=True.
+# Signup: tinyfish.ai
+API_KEY_TINYFISH=
+# GENESIS_CDP_URL: remote CDP browser endpoint (browser_navigate remote=True) —
+#   e.g. the user's real Chrome over Tailscale at http://<tailscale-ip>:9222. Optional.
+GENESIS_CDP_URL=
+
+# ─── LLM Providers (extra) ───────────────────────────────────────────────
+# --- Zhipu / Z.ai (GLM) ---
+# Used by: CC roster peer glm model (failover). Signup: bigmodel.cn / z.ai
+ZHIPU_API_KEY=
+
+# ─── AWS (EC2 install-test runner) ───────────────────────────────────────
+# Used by: scheduler/install_test.py — provisions ephemeral VMs for weekly
+#   install validation. Use an IAM user with EC2-only permissions.
+# (AWS Bedrock model routing uses API_KEY_BEDROCK above, not these.)
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION=us-east-1
+
+# ─── Proxmox provisioning (optional) ─────────────────────────────────────
+# Used by: provision_grow / provision_vzdump — privsep API tokens for a VM.
+# Format: user@realm!tokenid=<uuid>. Non-secret config (host/node/vmid/storage)
+#   lives in the host guardian.yaml, not here.
+PROXMOX_AUDIT_TOKEN=
+PROXMOX_PROVISION_TOKEN=
+
+# ─── TestSprite (AI testing / in-loop verifier) ──────────────────────────
+# Used by: TestSprite CLI (@testsprite/testsprite-cli) + MCP server for
+#   in-loop test verification of generated code.
+# Signup: testsprite.com (free tier available). Key: dashboard → Settings → API Keys.
+TESTSPRITE_API_KEY=
+
+# ─── Home Assistant media player (Voice PE) ──────────────────────────────
+# HA_MEDIA_PLAYER_ENTITY: Voice PE media_player entity for proactive chimes.
+#   Install-specific entity id (firmware adds a _media_player suffix); kept out
+#   of committed source (same invariant as HA_VOICE_PE_PREFIX above).
+HA_MEDIA_PLAYER_ENTITY=
+
+# ─── Misc runtime config ─────────────────────────────────────────────────
+# GENESIS_TIMEZONE: IANA tz used by some schedulers (parallels USER_TIMEZONE).
+GENESIS_TIMEZONE=UTC
+# GENESIS_CC_PERMISSION_MODE: Claude Code permission mode for autonomous sessions
+#   (e.g. 'bypass' to skip prompts). Leave unset for the default prompted mode.
+GENESIS_CC_PERMISSION_MODE=
+# CONTAINER: set to 1 on containerized installs (LXC/Docker) to enable
+#   --no-sandbox for Playwright/Chromium. Leave unset on bare metal / VM.
+CONTAINER=

--- a/src/genesis/autonomy/approval_gate.py
+++ b/src/genesis/autonomy/approval_gate.py
@@ -694,6 +694,31 @@ class AutonomousCliApprovalGate:
         invocation: CCInvocation | None,
         api_error: str | None,
     ) -> bool:
+        # Delivery-failure recovery comes FIRST and applies to every policy
+        # regardless of re-ask settings: while no successful delivery is on
+        # record, retry the send each tick — the user never received the one
+        # message they are entitled to. Once delivered, the re-ask policy
+        # below governs.
+        if context.get("delivery_id") is None:
+            await self._send_request(
+                request_id=request_id,
+                context=context,
+                action_label=action_label,
+                invocation=invocation,
+                api_error=api_error,
+            )
+            logger.info(
+                "Retried undelivered approval request %s for %s/%s",
+                request_id, subsystem, policy_id,
+            )
+            return True
+
+        # Re-ask 0 = NEVER remind about a delivered pending request. Checked
+        # BEFORE the stored next_reask_at so legacy rows written pre-deploy
+        # (with an already-elapsed window) cannot resend once.
+        if self._policy().reask_hours_for(policy_id) <= 0:
+            return False
+
         next_reask_at = context.get("next_reask_at")
         if next_reask_at:
             try:
@@ -835,9 +860,17 @@ class AutonomousCliApprovalGate:
         if delivery_id is not None:
             now = datetime.now(UTC)
             context["last_sent_at"] = now.isoformat()
+            # Per-policy re-ask interval; 0 = never remind → no next_reask_at
+            # (and _maybe_resend independently short-circuits on reask 0, so a
+            # legacy value here is harmless).
+            reask_hours = self._policy().reask_hours_for(
+                str(context.get("policy_id") or ""),
+            )
             context["next_reask_at"] = (
-                now + timedelta(hours=max(1, self._policy().reask_interval_hours))
-            ).isoformat()
+                (now + timedelta(hours=reask_hours)).isoformat()
+                if reask_hours > 0
+                else None
+            )
         await self._approval_manager.update_context(
             request_id, context=_context_dump(context),
         )

--- a/src/genesis/autonomy/cli_policy.py
+++ b/src/genesis/autonomy/cli_policy.py
@@ -7,7 +7,7 @@ import logging
 import os
 import stat
 import tempfile
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -67,9 +67,26 @@ class AutonomousCliPolicy:
     autonomous_cli_fallback_enabled: bool = True
     manual_approval_required: bool = True  # MANDATORY — must stay True (see above)
     reask_interval_hours: int = 24
+    # Per-policy re-ask overrides: policy_id -> hours. 0 = NEVER re-send a
+    # delivered pending request (the reminder cadence only — delivery-failure
+    # recovery in the gate is unaffected and applies to every policy). Policies
+    # not listed use the global reask_interval_hours. Shipped default silences
+    # inbox_evaluation only: its requests are idempotent commands over current
+    # inbox state (approve-once clears everything outstanding), and pending
+    # requests stay visible via the dashboard, morning report, and the
+    # "Approve all N pending" rows of other approval sends.
+    reask_overrides: dict[str, int] = field(default_factory=dict)
     approval_channel: str = "telegram"
     shared_export_enabled: bool = True
     source: str = "defaults"
+
+    def reask_hours_for(self, policy_id: str) -> int:
+        """Effective re-ask interval for a policy (0 = never re-ask)."""
+        try:
+            hours = int(self.reask_overrides.get(policy_id, self.reask_interval_hours))
+        except (TypeError, ValueError):
+            hours = self.reask_interval_hours
+        return max(0, hours)
 
     def as_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -85,8 +102,9 @@ def load_autonomous_cli_policy(path: Path | None = None) -> AutonomousCliPolicy:
         manual_approval_required=_env_bool(
             "GENESIS_AUTONOMOUS_CLI_APPROVAL_ENABLED", True,
         ),
+        # 0 is a legal value (= never re-ask); clamp only negatives.
         reask_interval_hours=max(
-            1, _env_int("GENESIS_AUTONOMOUS_CLI_REASK_INTERVAL_HOURS", 24),
+            0, _env_int("GENESIS_AUTONOMOUS_CLI_REASK_INTERVAL_HOURS", 24),
         ),
         approval_channel=(
             os.environ.get("GENESIS_AUTONOMOUS_APPROVAL_CHANNEL", "telegram")
@@ -121,6 +139,29 @@ def load_autonomous_cli_policy(path: Path | None = None) -> AutonomousCliPolicy:
         )
         return defaults
 
+    # 0 = never re-ask is a LEGAL value: a plain `or 24` would swallow it and
+    # max(1, …) would clamp it away, so parse None-aware and clamp only
+    # negatives. (2026-08 storm follow-up: "no reminders" must be expressible.)
+    _reask_raw = raw.get("reask_interval_hours", defaults.reask_interval_hours)
+    try:
+        _reask = max(0, int(_reask_raw)) if _reask_raw is not None else (
+            defaults.reask_interval_hours
+        )
+    except (TypeError, ValueError):
+        _reask = defaults.reask_interval_hours
+
+    _overrides_raw = raw.get("reask_overrides")
+    _overrides: dict[str, int] = {}
+    if isinstance(_overrides_raw, dict):
+        for _pid, _hours in _overrides_raw.items():
+            try:
+                _overrides[str(_pid)] = max(0, int(_hours))
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Ignoring non-integer reask_overrides entry %r: %r",
+                    _pid, _hours,
+                )
+
     return AutonomousCliPolicy(
         autonomous_cli_fallback_enabled=bool(
             raw.get(
@@ -131,10 +172,8 @@ def load_autonomous_cli_policy(path: Path | None = None) -> AutonomousCliPolicy:
         manual_approval_required=bool(
             raw.get("manual_approval_required", defaults.manual_approval_required),
         ),
-        reask_interval_hours=max(
-            1,
-            int(raw.get("reask_interval_hours", defaults.reask_interval_hours) or 24),
-        ),
+        reask_interval_hours=_reask,
+        reask_overrides=_overrides,
         approval_channel=str(
             raw.get("approval_channel", defaults.approval_channel) or "telegram",
         ).strip().lower() or "telegram",
@@ -170,6 +209,7 @@ class AutonomousCliPolicyExporter:
             "autonomous_cli_fallback_enabled": policy.autonomous_cli_fallback_enabled,
             "manual_approval_required": policy.manual_approval_required,
             "reask_interval_hours": policy.reask_interval_hours,
+            "reask_overrides": dict(policy.reask_overrides),
             "approval_channel": policy.approval_channel,
             "exported_at": datetime.now(UTC).isoformat(),
             "source": policy.source,

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -14,6 +14,7 @@ import contextlib
 import hashlib
 import json
 import logging
+import os
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -1881,6 +1882,72 @@ _CAP_ALERT_COOLDOWN_S = 3600  # one alert per hour max
 _last_cap_alert_at: float | None = None
 
 
+async def _check_cc_login_expiry(db) -> None:
+    """Warn ahead of the interactive CC login's refresh-token expiry.
+
+    The claude.ai OAuth refresh token has a FIXED lifetime (routine access-
+    token refresh does not extend it); when it lapses, every CC request —
+    including all background autonomy — fails until an interactive /login.
+    CC's own terminal warning is invisible on a headless box, so this raises
+    ONE critical observation (rides the critical-observations job to
+    Telegram) when expiry is inside the warning window, and auto-resolves
+    after the user re-logs in. Missing/unreadable credentials (fresh or
+    API-key-only installs, mid-rewrite reads) are silent — no signal is
+    never treated as expired. Best-effort; never raises into the tick.
+    """
+    if db is None:
+        return
+    try:
+        from genesis.cc.login_health import refresh_token_expiry
+
+        try:
+            warn_days = max(
+                1,
+                int(os.environ.get("GENESIS_CC_LOGIN_EXPIRY_WARN_DAYS", "5")),
+            )
+        except ValueError:
+            warn_days = 5
+
+        expiry = refresh_token_expiry()
+        now = datetime.now(UTC)
+        if expiry is None or (expiry - now) > timedelta(days=warn_days):
+            await observations.resolve_by_source_and_type(
+                db,
+                source="cc_login_monitor",
+                type="infrastructure_alert",
+                resolved_at=now.isoformat(),
+                resolution_notes=(
+                    "auto-resolved: CC login expiry no longer inside the "
+                    f"{warn_days}-day warning window"
+                ),
+            )
+            return
+
+        days_left = max(0.0, (expiry - now).total_seconds() / 86400)
+        content_hash = hashlib.sha256(b"cc_login_expiry_alert").hexdigest()
+        await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="cc_login_monitor",
+            type="infrastructure_alert",
+            content=(
+                f"CC interactive login expires {expiry.isoformat()} "
+                f"(~{days_left:.1f} days). Routine refresh does NOT extend it — "
+                "run /login in a foreground session before then, or ALL Claude "
+                "Code work (foreground + background autonomy) stops. Durable "
+                "backstop: `claude setup-token` once + scripts/store_cc_token.sh "
+                "stores a 1-year fallback token background sessions can use "
+                "when the login is confirmed dead."
+            ),
+            priority="critical",
+            created_at=now.isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
+        )
+    except Exception:
+        logger.debug("cc login expiry check failed", exc_info=True)
+
+
 async def _check_cc_cap_detection(db) -> None:
     """Alert when output-expecting cognitive CC invocations return empty in a run.
 
@@ -2753,6 +2820,10 @@ class AwarenessLoop:
                     # 'high' infrastructure_alert; self-resolves on recovery.
                     # Facts change at most ~daily (profile refresh) → hourly.
                     await _check_infra_protection_posture(self._db)
+                    # CC login refresh-token expiry: fixed lifetime, invisible
+                    # on a headless box until everything stops. Day-scale
+                    # signal → hourly; self-resolves after /login.
+                    await _check_cc_login_expiry(self._db)
                     # Memory integrity posture: reads the latest persisted
                     # consistency/recall-probe rows; slow-moving (daily jobs) →
                     # hourly is ample.

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1910,7 +1910,12 @@ async def _check_cc_login_expiry(db) -> None:
 
         expiry = refresh_token_expiry()
         now = datetime.now(UTC)
-        if expiry is None or (expiry - now) > timedelta(days=warn_days):
+        if expiry is None:
+            # No signal (missing/unreadable/mid-rewrite credentials) is NOT a
+            # verdict: neither alert nor resolve — a transient read failure
+            # must not clear a real standing warning.
+            return
+        if (expiry - now) > timedelta(days=warn_days):
             await observations.resolve_by_source_and_type(
                 db,
                 source="cc_login_monitor",

--- a/src/genesis/campaigns/runner.py
+++ b/src/genesis/campaigns/runner.py
@@ -367,6 +367,111 @@ def _read_strategy_doc(path: str) -> str:
         return ""
 
 
+# Sentinel: _follow_park could not produce a verdict (no park row / lookup
+# error) — the caller falls through to the session's own failed result.
+_NO_PARK_VERDICT = object()
+
+# How long a campaign will wait on an open (parked/resuming) rate-limit park
+# before treating the work as failed. Generous — real capacity droughts span
+# days — but bounded, so a resume loop stuck on a deterministic non-rate-limit
+# failure (which never increments attempts → never reaches needs_user) cannot
+# stall a campaign forever.
+_PARK_WAIT_BOUND = timedelta(days=7)
+
+
+def _parse_iso(raw: str) -> datetime | None:
+    """Parse an ISO timestamp defensively; naive values are assumed UTC."""
+    if not raw:
+        return None
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+async def _follow_park(db: Any, park_id: str) -> dict | None | object:
+    """Resolve a rate-limit park into a campaign-visible session verdict.
+
+    Returns:
+        None — park open (parked/resuming) or resumed-but-not-yet-delivered:
+            the work is still in flight, keep waiting.
+        dict — a terminal verdict: the delivering session's real result
+            (park resumed + a finished re-dispatched session found), or a
+            failure when the park itself went terminal (needs_user /
+            cancelled / expired).
+        _NO_PARK_VERDICT — park row missing/unreadable: no opinion.
+    """
+    try:
+        cursor = await db.execute(
+            "SELECT status, created_at FROM cc_rate_limit_parks WHERE id = ?",
+            (park_id,),
+        )
+        park_row = await cursor.fetchone()
+        if not park_row:
+            return _NO_PARK_VERDICT
+        park_status = str(park_row["status"])
+
+        if park_status in ("parked", "resuming"):
+            # Bounded wait (audit F1): a resume loop stuck on a genuine
+            # (non-rate-limit) failure can cycle parked→resuming forever
+            # without ever reaching needs_user. A campaign must not skip its
+            # ticks indefinitely on that — past the bound, surface a real
+            # failure so the next tick dispatches fresh work.
+            created = _parse_iso(str(park_row["created_at"] or ""))
+            if created and (datetime.now(UTC) - created) > _PARK_WAIT_BOUND:
+                return {
+                    "success": False,
+                    "output_text": (
+                        f"rate-limit park {park_id} still {park_status} after "
+                        f"{_PARK_WAIT_BOUND.days} days — wait bound exceeded; "
+                        "treating the parked campaign work as failed"
+                    ),
+                    "cost_usd": 0.0,
+                }
+            return None  # still in flight — the resume engine owns it
+
+        if park_status == "resumed":
+            # Find the re-dispatched session that delivered (its metadata
+            # carries caller_context "rate_limit_resume:<park_id>"; the
+            # closing quote pins the id boundary inside the JSON string).
+            cursor = await db.execute(
+                """SELECT status, cost_usd, metadata FROM cc_sessions
+                   WHERE metadata LIKE ?
+                   ORDER BY started_at DESC LIMIT 1""",
+                (f'%rate_limit_resume:{park_id}"%',),
+            )
+            deliv_row = await cursor.fetchone()
+            if not deliv_row:
+                return None  # resumed but the new session hasn't landed yet
+            deliv = dict(deliv_row)
+            dstatus = str(deliv.get("status", ""))
+            if dstatus not in ("completed", "failed"):
+                return None  # delivering session still running
+            dmeta = {}
+            with contextlib.suppress(json.JSONDecodeError, TypeError):
+                dmeta = json.loads(deliv.get("metadata") or "{}")
+            return {
+                "success": dstatus == "completed",
+                "output_text": dmeta.get("output_text", ""),
+                "cost_usd": deliv.get("cost_usd", 0.0) or 0.0,
+            }
+
+        # needs_user / cancelled / expired — genuinely terminal without
+        # delivery: surface as a real failure naming the park state.
+        return {
+            "success": False,
+            "output_text": (
+                f"rate-limit park {park_id} ended {park_status} without "
+                "delivering — the parked campaign work was not completed"
+            ),
+            "cost_usd": 0.0,
+        }
+    except Exception:
+        logger.warning("Failed to follow park %s", park_id, exc_info=True)
+        return _NO_PARK_VERDICT
+
+
 async def _check_session_status(db: Any, session_id: str) -> dict | None:
     """Check if a DirectSession has completed.
 
@@ -402,6 +507,17 @@ async def _check_session_status(db: Any, session_id: str) -> dict | None:
             if raw_meta:
                 with contextlib.suppress(json.JSONDecodeError, TypeError):
                     metadata = json.loads(raw_meta)
+
+            # Rate-limit-park awareness (2026-08-17 incident: a parked
+            # campaign session was captured as outcome=error while its resume
+            # later delivered — the campaign's bookkeeping never learned).
+            # A failed session stamped with a park_id is NOT a real failure:
+            # follow the park.
+            park_id = metadata.get("park_id")
+            if status == "failed" and park_id:
+                park_result = await _follow_park(db, str(park_id))
+                if park_result is not _NO_PARK_VERDICT:
+                    return park_result
 
             return {
                 "success": status == "completed",

--- a/src/genesis/campaigns/runner.py
+++ b/src/genesis/campaigns/runner.py
@@ -422,6 +422,18 @@ async def _follow_park(db: Any, park_id: str) -> dict | None | object:
             # Unparseable/missing created_at counts as OVER the bound — a
             # corrupt row must not reopen the unbounded-wait trajectory.
             if created is None or (datetime.now(UTC) - created) > _PARK_WAIT_BOUND:
+                # Close the park when abandoning it: leaving it open would let
+                # the resume engine execute the SAME campaign action later,
+                # after the campaign has already moved on (double-run).
+                try:
+                    from genesis.db.crud import cc_rate_limit_parks as _parks
+
+                    await _parks.mark_terminal(db, park_id, "cancelled")
+                except Exception:
+                    logger.warning(
+                        "Failed to cancel over-bound park %s", park_id,
+                        exc_info=True,
+                    )
                 return {
                     "success": False,
                     "output_text": (

--- a/src/genesis/campaigns/runner.py
+++ b/src/genesis/campaigns/runner.py
@@ -419,7 +419,9 @@ async def _follow_park(db: Any, park_id: str) -> dict | None | object:
             # ticks indefinitely on that — past the bound, surface a real
             # failure so the next tick dispatches fresh work.
             created = _parse_iso(str(park_row["created_at"] or ""))
-            if created and (datetime.now(UTC) - created) > _PARK_WAIT_BOUND:
+            # Unparseable/missing created_at counts as OVER the bound — a
+            # corrupt row must not reopen the unbounded-wait trajectory.
+            if created is None or (datetime.now(UTC) - created) > _PARK_WAIT_BOUND:
                 return {
                     "success": False,
                     "output_text": (

--- a/src/genesis/campaigns/runner.py
+++ b/src/genesis/campaigns/runner.py
@@ -377,6 +377,11 @@ _NO_PARK_VERDICT = object()
 # failure (which never increments attempts → never reaches needs_user) cannot
 # stall a campaign forever.
 _PARK_WAIT_BOUND = timedelta(days=7)
+# A resuming park whose claim is younger than this may have a LIVE queued/
+# running delivery attempt — cancelling the row would not stop it, so
+# abandonment holds until the attempt terminates on its own. Matches the
+# resume engine's stale-claim reclaim bound (_STALE_RESUMING_S = 2h).
+_ACTIVE_CLAIM_BOUND = timedelta(hours=2)
 
 
 def _parse_iso(raw: str) -> datetime | None:
@@ -404,7 +409,8 @@ async def _follow_park(db: Any, park_id: str) -> dict | None | object:
     """
     try:
         cursor = await db.execute(
-            "SELECT status, created_at FROM cc_rate_limit_parks WHERE id = ?",
+            "SELECT status, created_at, claimed_at FROM cc_rate_limit_parks "
+            "WHERE id = ?",
             (park_id,),
         )
         park_row = await cursor.fetchone()
@@ -422,6 +428,19 @@ async def _follow_park(db: Any, park_id: str) -> dict | None | object:
             # Unparseable/missing created_at counts as OVER the bound — a
             # corrupt row must not reopen the unbounded-wait trajectory.
             if created is None or (datetime.now(UTC) - created) > _PARK_WAIT_BOUND:
+                # An ACTIVELY-claimed resuming attempt may already have a
+                # queued/live delivery session; cancelling the ROW would not
+                # cancel that session → the exact double-run this bound
+                # prevents. Hold until the attempt terminates on its own
+                # (<= the resume engine's 2h reclaim bound), then abandon on
+                # a later tick.
+                claimed = _parse_iso(str(park_row["claimed_at"] or ""))
+                if (
+                    park_status == "resuming"
+                    and claimed is not None
+                    and (datetime.now(UTC) - claimed) <= _ACTIVE_CLAIM_BOUND
+                ):
+                    return None
                 # Close the park when abandoning it: leaving it open would let
                 # the resume engine execute the SAME campaign action later,
                 # after the campaign has already moved on (double-run). The

--- a/src/genesis/campaigns/runner.py
+++ b/src/genesis/campaigns/runner.py
@@ -424,16 +424,23 @@ async def _follow_park(db: Any, park_id: str) -> dict | None | object:
             if created is None or (datetime.now(UTC) - created) > _PARK_WAIT_BOUND:
                 # Close the park when abandoning it: leaving it open would let
                 # the resume engine execute the SAME campaign action later,
-                # after the campaign has already moved on (double-run).
+                # after the campaign has already moved on (double-run). The
+                # abandonment verdict is returned ONLY when the cancel is
+                # CONFIRMED — on a transient failure the campaign stays
+                # attached and retries next tick (never fail open into a
+                # detached-but-runnable park).
                 try:
                     from genesis.db.crud import cc_rate_limit_parks as _parks
 
                     await _parks.mark_terminal(db, park_id, "cancelled")
                 except Exception:
                     logger.warning(
-                        "Failed to cancel over-bound park %s", park_id,
+                        "Failed to cancel over-bound park %s — staying "
+                        "attached; will retry next tick",
+                        park_id,
                         exc_info=True,
                     )
+                    return None
                 return {
                     "success": False,
                     "output_text": (
@@ -457,7 +464,20 @@ async def _follow_park(db: Any, park_id: str) -> dict | None | object:
             )
             deliv_row = await cursor.fetchone()
             if not deliv_row:
-                return None  # resumed but the new session hasn't landed yet
+                # A park is marked resumed only AFTER its delivering session
+                # is persisted (mark_resumed_if_lineage runs post-_store_result)
+                # — a missing row means deleted/corrupted, never in-flight.
+                # Returning None here would skip campaign ticks FOREVER.
+                return {
+                    "success": False,
+                    "output_text": (
+                        f"rate-limit park {park_id} is resumed but its "
+                        "delivering session row is missing (deleted or "
+                        "corrupted) — treating the parked campaign work as "
+                        "failed"
+                    ),
+                    "cost_usd": 0.0,
+                }
             deliv = dict(deliv_row)
             dstatus = str(deliv.get("status", ""))
             if dstatus not in ("completed", "failed"):

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -464,11 +464,9 @@ class ConversationLoop:
             self._db, user_id=user_id, channel=str(channel),
             thread_id=thread_id,
         )
-        session_was_reset = False
         if session and self._should_reset(session):
             self._session_locks.pop(session["id"], None)
             await self._session_mgr.complete(session["id"])
-            session_was_reset = True
             session = None
 
         model = intent.model_override or (
@@ -522,9 +520,15 @@ class ConversationLoop:
             # notify the user and inject conversation context.
             cc_sid = session.get("cc_session_id")
             recovery_context = ""
-            if not cc_sid and (session_was_reset or not session.get("message_count")):
+            # Every fresh (non-resumed) CC session gets the recovery recap —
+            # the old `or not session.get("message_count")` clause read a
+            # column that does not exist (always falsy), so this HAS always
+            # fired on fresh sessions; the condition now says so honestly.
+            if not cc_sid:
                 recovery_context = await self._build_recovery_context(
-                    user_id, channel, thread_id,
+                    str(chat_id) if chat_id else user_id.replace("tg-", ""),
+                    channel,
+                    thread_id,
                 )
                 if recovery_context and on_event:
                     await on_event(StreamEvent(
@@ -545,6 +549,15 @@ class ConversationLoop:
                 )
                 system_prompt = await self._enrich_with_context(
                     system_prompt, prompt_text,
+                )
+                # Always tell a fresh telegram session which chat it is in
+                # (enables the scoped conversation_history scroll-up). Use the
+                # REAL chat id (correct in groups); fall back to the DM
+                # convention (user id == chat id in private chats).
+                system_prompt += self._conversation_identity_block(
+                    str(chat_id) if chat_id else user_id.replace("tg-", ""),
+                    channel,
+                    thread_id,
                 )
                 if recovery_context:
                     system_prompt += (
@@ -1301,50 +1314,135 @@ class ConversationLoop:
             logger.warning("Context injection skipped", exc_info=True)
         return system_prompt
 
+    # Total byte budget for the recovery recap (env-overridable settings
+    # lever: GENESIS_RECOVERY_CONTEXT_BUDGET). Sized so several full-length
+    # analytical replies survive — the old per-message 300-char HEAD chop
+    # dropped exactly the part that matters (numbered options/conclusions sit
+    # at the END of long replies; measured miss 2026-08-18: "option 3" at char
+    # ~3,850 of a 4,463-char reply).
+    RECOVERY_CONTEXT_BUDGET = 6000
+    RECOVERY_CONTEXT_MESSAGES = 20
+
+    @staticmethod
+    def _conversation_identity_block(
+        chat_ref: str,
+        channel: ChannelType,
+        thread_id: str | None,
+    ) -> str:
+        """One prompt block telling the session WHICH chat it is in, so it can
+        scroll up on demand. Without an explicit chat_id the model cannot make
+        a scoped ``conversation_history`` call — the 2026-08-18 failure mode
+        was a session truthfully claiming earlier context "isn't retrievable"
+        while the full thread sat one tool call away.
+
+        ``chat_ref`` is the REAL chat id (the handler's ``msg.chat.id`` —
+        negative for groups), optionally ``tg-``-prefixed. Never pass a
+        sender/user id here: in group/topic sessions the sender's personal id
+        is a valid-looking number that would misdirect scoped scroll-up at
+        the sender's private DM.
+        """
+        if str(channel) != "telegram":
+            return ""
+        chat_id_str = chat_ref.replace("tg-", "")
+        try:
+            int(chat_id_str)  # negative group ids are valid
+        except ValueError:
+            return ""
+        thread_note = f", thread_id={thread_id}" if thread_id else ""
+        return (
+            "\n\n## Conversation identity\n"
+            f"This is the Telegram chat with chat_id={chat_id_str}{thread_note}. "
+            "When the user references earlier conversation that is not in your "
+            "context, SCROLL UP before claiming it is unavailable: call "
+            f"`conversation_history(channel='telegram', chat_id={chat_id_str}, "
+            "limit=50)` (add `before=<oldest timestamp seen>` to page further "
+            "back). Messages return full-length."
+        )
+
     async def _build_recovery_context(
         self,
-        user_id: str,
+        chat_ref: str,
         channel: ChannelType,
         thread_id: str | None,
     ) -> str:
         """Load recent messages for session recovery context injection.
 
+        ``chat_ref``: the real chat id (optionally ``tg-``-prefixed; negative
+        for groups) — same contract as ``_conversation_identity_block``.
+
+        Byte-budgeted and TAIL-biased: messages are kept whole newest-first
+        until the budget runs low; a message too large for the remaining
+        budget keeps its END (marked with a leading ellipsis), because that is
+        where long analytical replies put their conclusions and option lists.
         Returns a formatted string of recent conversation, or "" if none.
         """
         if str(channel) != "telegram":
             return ""
         try:
+            import os
+
             from genesis.db.crud.telegram_messages import query_recent
 
-            # Extract numeric chat_id from user_id (tg-<id>)
-            chat_id_str = user_id.replace("tg-", "")
-            if not chat_id_str.isdigit():
+            try:
+                chat_id = int(chat_ref.replace("tg-", ""))
+            except ValueError:
                 return ""
-            chat_id = int(chat_id_str)
+
+            try:
+                budget = int(
+                    os.environ.get("GENESIS_RECOVERY_CONTEXT_BUDGET", "")
+                    or self.RECOVERY_CONTEXT_BUDGET,
+                )
+            except ValueError:
+                budget = self.RECOVERY_CONTEXT_BUDGET
+            budget = max(500, budget)
 
             messages = await query_recent(
                 self._db,
                 chat_id,
                 thread_id=int(thread_id) if thread_id else None,
-                limit=10,
+                limit=self.RECOVERY_CONTEXT_MESSAGES,
             )
             if not messages:
                 return ""
 
-            lines = []
-            for m in messages:
-                sender = m.get("sender", "?")
-                content = m.get("content", "")
-                if content:
-                    prefix = "User" if sender == "user" else "Genesis"
-                    # Truncate long messages
-                    if len(content) > 300:
-                        content = content[:300] + "..."
-                    lines.append(f"{prefix}: {content}")
-
-            if not lines:
+            # Walk newest → oldest, spending the budget where recency is;
+            # then restore chronological order for readability.
+            kept: list[str] = []
+            remaining = budget
+            for m in reversed(messages):
+                content = str(m.get("content") or "")
+                if not content:
+                    continue
+                prefix = "User" if m.get("sender") == "user" else "Genesis"
+                line = f"{prefix}: {content}"
+                if len(line) <= remaining:
+                    kept.append(line)
+                    remaining -= len(line)
+                elif remaining > 200:
+                    # Tail-keep: the end of a long reply carries its
+                    # conclusions/option lists — never the head alone.
+                    kept.append(f"{prefix}: …{line[-(remaining - 20):]}")
+                    remaining = 0
+                else:
+                    # Doesn't fit and no room for a meaningful tail — STOP
+                    # rather than skip: appending a smaller OLDER message here
+                    # would leave an unmarked hole mid-recap.
+                    break
+                if remaining <= 0:
+                    break
+            if not kept:
                 return ""
-            return "\n".join(lines)
+            kept.reverse()
+            recap = "\n".join(kept)
+            logger.info(
+                "Recovery context built for chat %s: %d msgs, %d/%d chars",
+                chat_id,
+                len(kept),
+                len(recap),
+                budget,
+            )
+            return recap
         except Exception:
             logger.warning("Failed to load recovery context", exc_info=True)
             return ""

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -1314,7 +1314,7 @@ class ConversationLoop:
             logger.warning("Context injection skipped", exc_info=True)
         return system_prompt
 
-    # Total byte budget for the recovery recap (env-overridable settings
+    # Total character budget for the recovery recap (env-overridable settings
     # lever: GENESIS_RECOVERY_CONTEXT_BUDGET). Sized so several full-length
     # analytical replies survive — the old per-message 300-char HEAD chop
     # dropped exactly the part that matters (numbered options/conclusions sit
@@ -1349,14 +1349,17 @@ class ConversationLoop:
         except ValueError:
             return ""
         thread_note = f", thread_id={thread_id}" if thread_id else ""
+        # Scope the suggested call to the ACTIVE topic when in a forum thread —
+        # an unscoped group call would pull unrelated topics' messages.
+        thread_arg = f", thread_id={thread_id}" if thread_id else ""
         return (
             "\n\n## Conversation identity\n"
             f"This is the Telegram chat with chat_id={chat_id_str}{thread_note}. "
             "When the user references earlier conversation that is not in your "
             "context, SCROLL UP before claiming it is unavailable: call "
-            f"`conversation_history(channel='telegram', chat_id={chat_id_str}, "
-            "limit=50)` (add `before=<oldest timestamp seen>` to page further "
-            "back). Messages return full-length."
+            f"`conversation_history(channel='telegram', chat_id={chat_id_str}"
+            f"{thread_arg}, limit=50)` (add `before=<oldest timestamp seen>` to "
+            "page further back). Messages return full-length."
         )
 
     async def _build_recovery_context(
@@ -1370,7 +1373,7 @@ class ConversationLoop:
         ``chat_ref``: the real chat id (optionally ``tg-``-prefixed; negative
         for groups) — same contract as ``_conversation_identity_block``.
 
-        Byte-budgeted and TAIL-biased: messages are kept whole newest-first
+        Character-budgeted and TAIL-biased: messages are kept whole newest-first
         until the budget runs low; a message too large for the remaining
         budget keeps its END (marked with a leading ellipsis), because that is
         where long analytical replies put their conclusions and option lists.

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -1009,7 +1009,15 @@ class DirectSessionRunner:
                     tools_called=telemetry,
                 )
                 try:
-                    await self._store_result(session_id, request, parked_result)
+                    # Stamp the park id STRUCTURED into the session metadata so
+                    # downstream bookkeeping (campaign reaper) can follow the
+                    # park instead of string-parsing the error message.
+                    await self._store_result(
+                        session_id,
+                        request,
+                        parked_result,
+                        extra_metadata={"park_id": park_id},
+                    )
                     await self._session_manager.fail(
                         session_id,
                         reason="rate_limited_parked",
@@ -1412,8 +1420,15 @@ class DirectSessionRunner:
         session_id: str,
         request: DirectSessionRequest,
         result: DirectSessionResult,
+        *,
+        extra_metadata: dict | None = None,
     ) -> None:
-        """Merge result data into cc_sessions.metadata (read-merge-write)."""
+        """Merge result data into cc_sessions.metadata (read-merge-write).
+
+        ``extra_metadata`` keys merge LAST (e.g. the rate-limit park stamp
+        ``{"park_id": ...}`` that lets campaign bookkeeping follow a parked
+        session to its resumed delivery instead of recording a false error).
+        """
         from genesis.db.crud import cc_sessions
 
         db = getattr(self._rt, "_db", None)
@@ -1467,6 +1482,9 @@ class DirectSessionRunner:
             payload = roster.endpoint_payload(result.roster_model)
             if payload:
                 existing["roster_endpoint"] = payload
+
+        if extra_metadata:
+            existing.update(extra_metadata)
 
         await db.execute(
             "UPDATE cc_sessions SET metadata = ? WHERE id = ?",

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -738,6 +738,7 @@ class CCInvoker:
             and (
                 "CLAUDE_CODE_OAUTH_TOKEN" in inv.env_overrides
                 or "CLAUDE_CONFIG_DIR" in inv.env_overrides
+                or "ANTHROPIC_API_KEY" in inv.env_overrides
             )
         ):
             return env

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -745,7 +745,7 @@ class CCInvoker:
         try:
             from genesis.cc.login_health import fallback_env_if_login_dead
 
-            fb = await fallback_env_if_login_dead()
+            fb = await fallback_env_if_login_dead(cc_path=self._claude_path)
             if fb:
                 return {**env, **fb}
         except Exception:

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -710,9 +710,51 @@ class CCInvoker:
                     span.set_status_error(output.error_message or "CC session error")
             return output
 
+    async def _apply_login_fallback(
+        self,
+        env: dict[str, str],
+        inv: CCInvocation | None,
+    ) -> dict[str, str]:
+        """Inject the stored 1-year setup-token ONLY when the interactive
+        login is hard-expired AND a live probe confirms logged-out
+        (login_health gates — never over a working login, never on
+        ambiguity). Skipped entirely for cleanroom/bare invocations whose
+        env_overrides manage their own auth (overrides win by contract).
+        """
+        if inv is not None and getattr(inv, "bare", False):
+            return env
+        # Peer-routed invocations (third-party ANTHROPIC_BASE_URL/AUTH_TOKEN)
+        # never use the claude.ai login — injecting the Anthropic OAuth
+        # setup-token there is useless at best and violates the roster's
+        # credential-isolation contract (the Anthropic credential must never
+        # travel toward a third-party endpoint).
+        if inv and (
+            getattr(inv, "anthropic_base_url", None) or getattr(inv, "anthropic_auth_token", None)
+        ):
+            return env
+        if (
+            inv
+            and inv.env_overrides
+            and (
+                "CLAUDE_CODE_OAUTH_TOKEN" in inv.env_overrides
+                or "CLAUDE_CONFIG_DIR" in inv.env_overrides
+            )
+        ):
+            return env
+        try:
+            from genesis.cc.login_health import fallback_env_if_login_dead
+
+            fb = await fallback_env_if_login_dead()
+            if fb:
+                return {**env, **fb}
+        except Exception:
+            logger.debug("login fallback check failed", exc_info=True)
+        return env
+
     async def _run_inner(self, invocation: CCInvocation) -> CCOutput:
         args = self._build_args(invocation)
         env = self._build_env(invocation)
+        env = await self._apply_login_fallback(env, invocation)
         start = time.monotonic()
 
         # Extract dispatched effort from args — may differ from invocation.effort
@@ -901,6 +943,7 @@ class CCInvoker:
         args.insert(1, "--verbose")
 
         env = self._build_env(invocation)
+        env = await self._apply_login_fallback(env, invocation)
         start = time.monotonic()
 
         # Extract dispatched effort from args — may differ from invocation.effort

--- a/src/genesis/cc/login_health.py
+++ b/src/genesis/cc/login_health.py
@@ -144,8 +144,9 @@ async def probe_logged_out(cc_path: str = "claude", timeout_s: float = 15.0) -> 
 
 async def fallback_env_if_login_dead(
     *,
-    probe=probe_logged_out,
+    probe=None,
     token_reader=read_fallback_token,
+    cc_path: str = "claude",
 ) -> dict[str, str] | None:
     """Env additions for a background CC invocation, or None (the common case).
 
@@ -155,6 +156,13 @@ async def fallback_env_if_login_dead(
     2. live probe CONFIRMS logged-out (cached _PROBE_CACHE_TTL_S seconds);
     3. a stored setup-token exists.
     """
+    if probe is None:
+        # Bind the probe to the CALLER'S configured executable — probing a
+        # literal PATH `claude` on installs with a non-PATH binary would read
+        # permanently ambiguous and the fallback would never activate.
+        async def probe() -> bool:
+            return await probe_logged_out(cc_path)
+
     global _probe_cache
     expiry = refresh_token_expiry()
     if expiry is None or expiry > datetime.now(UTC):

--- a/src/genesis/cc/login_health.py
+++ b/src/genesis/cc/login_health.py
@@ -1,0 +1,187 @@
+"""Container CC login health — refresh-token expiry + fallback-token gating.
+
+The claude.ai OAuth login stored in ``~/.claude/.credentials.json`` has a
+FIXED-lifetime refresh token: routine access-token refresh does NOT extend it,
+and when it lapses every CC request fails until an interactive ``/login``.
+Background sessions ride the same credentials, so a lapsed login silently
+kills autonomy. (Discovered 2026-08-18: nothing anywhere read
+``refreshTokenExpiresAt``.)
+
+Two consumers:
+
+- the awareness check ``_check_cc_login_expiry`` (warns days ahead via the
+  standard critical-observation → Telegram path);
+- the invoker's fallback injection: when the login is HARD-expired and a live
+  ``claude auth status`` probe CONFIRMS logged-out, CC invocations (foreground turns and
+background dispatches alike) get ``CLAUDE_CODE_OAUTH_TOKEN`` from the operator's stored 1-year setup-token
+  (``~/.genesis/cc_oauth_token.env``, written by ``scripts/store_cc_token.sh``).
+
+The injection mirrors the host guardian's honest boundary
+(``guardian/diagnosis.py``): the env token OVERRIDES a stored login, so it is
+injected ONLY on confirmed-dead login — never on ambiguity, never over a
+working login. The setup-token deliberately stays out of secrets.env
+(``credential_bridge.py`` — load_dotenv would hijack every container CC
+subprocess).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_FILE = Path("~/.genesis/cc_oauth_token.env").expanduser()
+
+# Confirmed-logged-out probe results are cached briefly so a burst of
+# background dispatches during an outage doesn't spawn a probe subprocess
+# each. A successful /login rewrites credentials.json with a future expiry,
+# which flips the CHEAP timestamp gate below immediately — so a stale cached
+# "logged out" can never override a restored login.
+_PROBE_CACHE_TTL_S = 60.0
+_probe_cache: tuple[float, bool] | None = None
+_probe_lock: asyncio.Lock | None = None
+
+
+def _get_probe_lock() -> asyncio.Lock:
+    """Single-flight guard: N concurrent dispatches during an outage share
+    one probe subprocess per cache window instead of spawning N."""
+    global _probe_lock
+    if _probe_lock is None:
+        _probe_lock = asyncio.Lock()
+    return _probe_lock
+
+
+def reset_probe_cache() -> None:
+    """Test hook: clear the cached probe verdict."""
+    global _probe_cache
+    _probe_cache = None
+
+
+def credentials_path() -> Path:
+    """CLAUDE_CONFIG_DIR-aware path to CC's credentials file."""
+    base = os.environ.get("CLAUDE_CONFIG_DIR", "")
+    root = Path(base).expanduser() if base else Path.home() / ".claude"
+    return root / ".credentials.json"
+
+
+def refresh_token_expiry() -> datetime | None:
+    """The interactive login's refresh-token expiry, or None when unknown.
+
+    None covers: missing file (fresh/API-key-only installs), unreadable or
+    mid-rewrite JSON, and absent field — a parse hiccup must read as "no
+    signal", never as "expired".
+    """
+    path = credentials_path()
+    try:
+        raw = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    oauth = raw.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return None
+    expires_ms = oauth.get("refreshTokenExpiresAt")
+    if not isinstance(expires_ms, (int, float)) or isinstance(expires_ms, bool):
+        return None
+    try:
+        return datetime.fromtimestamp(expires_ms / 1000, tz=UTC)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def read_fallback_token() -> str | None:
+    """The stored 1-year setup-token, or None when not provisioned."""
+    try:
+        for line in _TOKEN_FILE.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("CLAUDE_CODE_OAUTH_TOKEN="):
+                value = line.split("=", 1)[1].strip().strip('"').strip("'")
+                return value or None
+    except OSError:
+        return None
+    return None
+
+
+async def probe_logged_out(cc_path: str = "claude", timeout_s: float = 15.0) -> bool:
+    """Return True ONLY when ``claude auth status --json`` CONFIRMS
+    ``loggedIn: false``. Timeouts, unparseable output, and any other state
+    return False (ambiguity → never inject), mirroring guardian/diagnosis.py.
+    """
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            cc_path,
+            "auth",
+            "status",
+            "--json",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+        except TimeoutError:
+            if proc.returncode is None:
+                proc.kill()
+                await proc.wait()
+            return False
+        try:
+            logged_in = json.loads(stdout.decode("utf-8", errors="replace")).get(
+                "loggedIn",
+            )
+        except (json.JSONDecodeError, ValueError, AttributeError, TypeError):
+            return False
+        return logged_in is False
+    except Exception:
+        logger.debug("CC auth probe failed", exc_info=True)
+        return False
+
+
+async def fallback_env_if_login_dead(
+    *,
+    probe=probe_logged_out,
+    token_reader=read_fallback_token,
+) -> dict[str, str] | None:
+    """Env additions for a background CC invocation, or None (the common case).
+
+    Order of gates (each cheap-to-expensive, all must pass):
+    1. refresh token HARD-expired per credentials.json (cheap file read; a
+       working or merely-near-expiry login never proceeds);
+    2. live probe CONFIRMS logged-out (cached _PROBE_CACHE_TTL_S seconds);
+    3. a stored setup-token exists.
+    """
+    global _probe_cache
+    expiry = refresh_token_expiry()
+    if expiry is None or expiry > datetime.now(UTC):
+        return None
+
+    async with _get_probe_lock():
+        now = time.monotonic()
+        if _probe_cache is not None and now - _probe_cache[0] < _PROBE_CACHE_TTL_S:
+            confirmed_out = _probe_cache[1]
+        else:
+            confirmed_out = await probe()
+            _probe_cache = (now, confirmed_out)
+    if not confirmed_out:
+        return None
+
+    token = token_reader()
+    if not token:
+        logger.warning(
+            "CC login is expired and confirmed logged-out, but no fallback "
+            "setup-token is stored (~/.genesis/cc_oauth_token.env) — background "
+            "sessions will fail until /login or `claude setup-token` + "
+            "scripts/store_cc_token.sh",
+        )
+        return None
+
+    logger.warning(
+        "CC login expired + confirmed logged-out — injecting the stored "
+        "setup-token for this CC invocation (token value not logged).",
+    )
+    return {"CLAUDE_CODE_OAUTH_TOKEN": token}

--- a/src/genesis/cc/rate_limit_park.py
+++ b/src/genesis/cc/rate_limit_park.py
@@ -236,9 +236,15 @@ async def park_direct_session(
                 lineage_id,
             )
 
-        # Fresh background park — serialize enough to re-dispatch verbatim.
+        # Fresh background park — serialize the FULL execution shape so the
+        # resume re-dispatches an EQUIVALENT session. Dropping any of these
+        # silently changes the resumed session's behavior (measured 2026-08-17:
+        # a campaign resume ran WITHOUT its strategy doc because system_prompt
+        # was not serialized; source_tag loss also broke attribution).
         prompt = getattr(request, "prompt", "")
         origin = getattr(request, "origin_session_id", None)
+        skills = getattr(request, "skills", None)
+        tool_exceptions = getattr(request, "tool_exceptions", ()) or ()
         payload = {
             "prompt": prompt,
             "profile": getattr(request, "profile", "observe"),
@@ -246,6 +252,11 @@ async def park_direct_session(
             "effort": _enum_str(getattr(request, "effort", None), "high"),
             "timeout_s": int(getattr(request, "timeout_s", 3600)),
             "roster_model": getattr(request, "roster_model", None),
+            "system_prompt": getattr(request, "system_prompt", None),
+            "source_tag": getattr(request, "source_tag", "direct_session"),
+            "skills": list(skills) if skills is not None else None,
+            "tool_exceptions": list(tool_exceptions),
+            "planning_instruction": getattr(request, "planning_instruction", None),
         }
         return await parks.upsert_open_park(
             db,

--- a/src/genesis/cc/rate_limit_resume.py
+++ b/src/genesis/cc/rate_limit_resume.py
@@ -56,6 +56,15 @@ async def _redispatch(db, park: dict) -> None:
         effort=payload.get("effort", "high"),
         timeout_s=int(payload.get("timeout_s", 3600)),
         roster_model=payload.get("roster_model"),
+        # Preserve the parked request's full execution shape (system prompt,
+        # attribution, skills) — legacy parks without these keys resume with
+        # the old defaults. Delivery is deliberately overridden to
+        # RESULT-to-origin regardless of the original notify flags.
+        system_prompt=payload.get("system_prompt"),
+        source_tag=payload.get("source_tag", "direct_session"),
+        skills=payload.get("skills"),
+        tool_exceptions=payload.get("tool_exceptions"),
+        planning_instruction=payload.get("planning_instruction"),
         notify=False,
         notify_on_failure_only=False,
         delivery_mode="result",

--- a/src/genesis/dashboard/routes/settings.py
+++ b/src/genesis/dashboard/routes/settings.py
@@ -16,9 +16,56 @@ from genesis.mcp.health.settings import (
     _load_yaml_local,
     _load_yaml_merged,
     _local_filename,
+    gate_disable_error,
 )
 
 logger = logging.getLogger(__name__)
+
+
+async def _notify_gate_disabled() -> None:
+    """Owner Telegram notice for a confirmed approval-gate disable.
+
+    Best-effort — a notification failure never fails the settings write
+    (the provenance stamp + warning log remain the durable record). Owner-
+    facing delivery is never egress-gated.
+    """
+    try:
+        from genesis.outreach.types import OutreachCategory, OutreachRequest
+        from genesis.runtime import GenesisRuntime
+
+        rt = GenesisRuntime.instance()
+        pipeline = getattr(rt, "outreach_pipeline", None)
+        if not rt.is_bootstrapped or pipeline is None:
+            logger.warning(
+                "Approval gate disabled but outreach pipeline unavailable — "
+                "no Telegram notice sent",
+            )
+            return
+        result = await pipeline.submit(
+            OutreachRequest(
+                category=OutreachCategory.ALERT,
+                topic="Approval gate disabled",
+                context=(
+                    "manual_approval_required was set to FALSE via the "
+                    "dashboard (confirmed). Autonomous Claude Code sessions "
+                    "now dispatch WITHOUT per-run approval until it is set "
+                    "back to true (Settings → autonomous_cli_policy)."
+                ),
+                salience_score=1.0,
+                signal_type="approval_gate_disabled",
+                channel="telegram",
+                verbatim=True,
+            ),
+        )
+        status = getattr(result, "status", None)
+        delivered = getattr(status, "value", status)
+        if str(delivered).lower() not in ("delivered", "sent", "queued"):
+            logger.warning(
+                "Gate-disable Telegram notice not delivered (status=%s)",
+                delivered,
+            )
+    except Exception:
+        logger.warning("Gate-disable Telegram notice failed", exc_info=True)
 
 
 def _strip_hidden(domain, data: dict) -> dict:
@@ -83,6 +130,9 @@ async def settings_update(domain_name: str):
     if not changes or not isinstance(changes, dict):
         return jsonify({"error": "Request body must be a JSON object"}), 400
 
+    # Out-of-band confirmation flag — never merged into the config itself.
+    confirm_gate = bool(changes.pop("confirm_disable_approval_gate", False))
+
     # Validate
     validator = _DOMAIN_VALIDATORS.get(domain_name)
     if validator:
@@ -90,13 +140,30 @@ async def settings_update(domain_name: str):
         if errors:
             return jsonify({"error": "Validation failed", "details": errors}), 422
 
+    # Protected key: disabling the mandatory approval gate requires explicit
+    # confirmation (2026-08-18: a single unconfirmed PUT used to flip it
+    # silently), and a confirmed disable is announced via Telegram below.
+    gate_err = gate_disable_error(domain_name, changes, confirmed=confirm_gate)
+    if gate_err:
+        return jsonify({
+            "error": "confirmation required",
+            "details": gate_err,
+        }), 409
+
     # Write changes to the local overlay (not the base file)
     try:
         local = _load_yaml_local(domain.config_filename)
         new_local = _deep_merge(local, changes)
         local_file = _local_filename(domain.config_filename)
-        _atomic_yaml_write(local_file, new_local)
+        _atomic_yaml_write(
+            local_file, new_local, provenance="user via dashboard PUT",
+        )
         logger.info("Settings domain '%s' updated via dashboard (local overlay)", domain_name)
+        if (
+            domain_name == "autonomous_cli_policy"
+            and changes.get("manual_approval_required") is False
+        ):
+            await _notify_gate_disabled()
         # Return the full merged view
         base = _load_yaml(domain.config_filename)
         merged = _deep_merge(base, new_local)

--- a/src/genesis/dashboard/routes/settings.py
+++ b/src/genesis/dashboard/routes/settings.py
@@ -59,7 +59,9 @@ async def _notify_gate_disabled() -> None:
         )
         status = getattr(result, "status", None)
         delivered = getattr(status, "value", status)
-        if str(delivered).lower() not in ("delivered", "sent", "queued"):
+        # Real OutreachStatus values: delivered/engaged are success; pending/
+        # drafted are in-flight (not failures); rejected/failed/unknown warn.
+        if str(delivered).lower() in ("rejected", "failed") or delivered is None:
             logger.warning(
                 "Gate-disable Telegram notice not delivered (status=%s)",
                 delivered,
@@ -131,7 +133,9 @@ async def settings_update(domain_name: str):
         return jsonify({"error": "Request body must be a JSON object"}), 400
 
     # Out-of-band confirmation flag — never merged into the config itself.
-    confirm_gate = bool(changes.pop("confirm_disable_approval_gate", False))
+    # Strict identity check: bool("false") is True — a client serializing
+    # booleans as strings must NEVER accidentally satisfy the confirmation.
+    confirm_gate = changes.pop("confirm_disable_approval_gate", None) is True
 
     # Validate
     validator = _DOMAIN_VALIDATORS.get(domain_name)

--- a/src/genesis/dashboard/routes/settings.py
+++ b/src/genesis/dashboard/routes/settings.py
@@ -168,6 +168,13 @@ async def settings_update(domain_name: str):
             and changes.get("manual_approval_required") is False
         ):
             await _notify_gate_disabled()
+        elif (
+            domain_name == "autonomous_cli_policy"
+            and changes.get("manual_approval_required") is True
+        ):
+            from genesis.mcp.health.settings import resolve_gate_disable_alert
+
+            await resolve_gate_disable_alert("user via dashboard PUT")
         # Return the full merged view
         base = _load_yaml(domain.config_filename)
         merged = _deep_merge(base, new_local)

--- a/src/genesis/dashboard/routes/surplus.py
+++ b/src/genesis/dashboard/routes/surplus.py
@@ -240,8 +240,13 @@ async def update_surplus_config():
 
     # Merge into local overlay — NEVER write to the base config
     local = _load_yaml_local("surplus.yaml")
-    _deep_merge(local, data)
-    _atomic_yaml_write(_local_filename("surplus.yaml"), local)
+    # _deep_merge is PURE — discarding its return wrote the UNMERGED overlay
+    # back for months (pre-existing bug surfaced by the 2026-08-18 review).
+    local = _deep_merge(local, data)
+    _atomic_yaml_write(
+        _local_filename("surplus.yaml"), local,
+        provenance="user via dashboard surplus PUT",
+    )
 
     merged = _load_yaml_merged("surplus.yaml")
     return jsonify({"ok": True, "config": merged})

--- a/src/genesis/dashboard/templates/partials/tabs/config.html
+++ b/src/genesis/dashboard/templates/partials/tabs/config.html
@@ -207,7 +207,7 @@
                 <div style="display:flex; justify-content:space-between;"><span>CLI fallback</span><span x-text="$store.genesisDashboard.autonomousCliPolicy.effective_policy?.autonomous_cli_fallback_enabled ? 'enabled' : 'disabled'"></span></div>
                 <div style="display:flex; justify-content:space-between;"><span>Manual approval</span><span x-text="$store.genesisDashboard.autonomousCliPolicy.effective_policy?.manual_approval_required ? 'required' : 'not required'"></span></div>
                 <div style="display:flex; justify-content:space-between;"><span>Channel</span><span x-text="$store.genesisDashboard.autonomousCliPolicy.effective_policy?.approval_channel || 'telegram'"></span></div>
-                <div style="display:flex; justify-content:space-between;"><span>Re-ask</span><span x-text="(($store.genesisDashboard.autonomousCliPolicy.effective_policy?.reask_interval_hours || 24) + 'h')"></span></div>
+                <div style="display:flex; justify-content:space-between;"><span>Re-ask</span><span x-text="((($store.genesisDashboard.autonomousCliPolicy.effective_policy?.reask_interval_hours ?? 24) === 0 ? 'never' : ($store.genesisDashboard.autonomousCliPolicy.effective_policy?.reask_interval_hours ?? 24) + 'h'))"></span></div>
                 <div style="display:flex; justify-content:space-between;"><span>Source</span><span x-text="$store.genesisDashboard.autonomousCliPolicy.effective_policy?.source || 'unknown'"></span></div>
               </div>
             </div>

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -2214,14 +2214,27 @@
             }
           } catch (e) { console.warn(`Settings fetch ${domain} failed:`, e); }
         },
-        async saveSettings(domain) {
+        async saveSettings(domain, confirmGateDisable = false) {
           this.settingsSaving = true;
           try {
+            const payload = { ...this.settingsData[domain] };
+            if (confirmGateDisable) { payload.confirm_disable_approval_gate = true; }
             const resp = await fetchApi(`/api/genesis/settings/${domain}`, {
               method: "PUT",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify(this.settingsData[domain]),
+              body: JSON.stringify(payload),
             });
+            if (resp && resp.status === 409 && !confirmGateDisable) {
+              // Protected key: disabling the mandatory approval gate needs an
+              // explicit human confirmation, then a single retry with the flag.
+              const err = await resp.json().catch(() => ({}));
+              this.settingsSaving = false;
+              const detail = typeof err.details === "string" ? err.details : "This disables the mandatory approval gate for ALL autonomous sessions.";
+              if (window.confirm(detail + "\n\nProceed?")) {
+                return this.saveSettings(domain, true);
+              }
+              return;
+            }
             if (resp && resp.ok) {
               const d = await resp.json();
               this.settingsData[domain] = d.config;
@@ -2232,7 +2245,8 @@
               if (d.needs_restart) { this.settingsRestartMessage = "Settings saved. Restart Genesis server to apply."; }
             } else {
               const err = await resp.json().catch(() => ({}));
-              alert("Save failed: " + (err.details ? err.details.join(", ") : err.error || "Unknown error"));
+              const detail = Array.isArray(err.details) ? err.details.join(", ") : (err.details || err.error || "Unknown error");
+              alert("Save failed: " + detail);
             }
           } catch (e) { alert("Save failed: " + e.message); }
           this.settingsSaving = false;

--- a/src/genesis/db/crud/direct_session_queue.py
+++ b/src/genesis/db/crud/direct_session_queue.py
@@ -27,8 +27,20 @@ async def enqueue(
     roster_model: str | None = None,
     origin_session_id: str | None = None,
     delivery_mode: str | None = None,
+    system_prompt: str | None = None,
+    source_tag: str | None = None,
+    skills: list[str] | None = None,
+    tool_exceptions: list[str] | tuple[str, ...] | None = None,
+    planning_instruction: str | None = None,
 ) -> str:
-    """Insert a new queue item. Returns the queue_id."""
+    """Insert a new queue item. Returns the queue_id.
+
+    The optional execution-shape fields (system_prompt, source_tag, skills,
+    tool_exceptions, planning_instruction) exist so a rate-limit-parked
+    request round-trips VERBATIM — omitting them re-dispatches with defaults,
+    which silently changes behavior (a parked campaign once resumed without
+    its strategy doc).
+    """
     queue_id = f"dsq-{uuid.uuid4().hex[:12]}"
     payload = {
         "prompt": prompt,
@@ -42,6 +54,11 @@ async def enqueue(
         "roster_model": roster_model,
         "origin_session_id": origin_session_id,
         "delivery_mode": delivery_mode,
+        "system_prompt": system_prompt,
+        "source_tag": source_tag,
+        "skills": list(skills) if skills is not None else None,
+        "tool_exceptions": (list(tool_exceptions) if tool_exceptions is not None else None),
+        "planning_instruction": planning_instruction,
     }
     await db.execute(
         """INSERT INTO direct_session_queue

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -224,38 +224,39 @@ async def get_all_known(
     """
     from pathlib import Path
 
+    # ONE recency-ordered scan over ALL rows — never two passes. The 2026-08
+    # approval storm came from a second (permanently-failed) pass clobbering
+    # the first pass's newest completed hash with an OLDER exhausted row's
+    # hash, unconditionally: known != disk forever → phantom "modified" every
+    # scan → the monitor cancelled + re-sent the pending approval every tick.
+    #
     # ORDER BY created_at ASC, rowid ASC so the per-file dict-overwrite loop
-    # below deterministically keeps the NEWEST row's hash. A file has many rows
-    # (one per batch, plus reused rows), and `reuse_as_pending` resets created_at
-    # to now while KEEPING the old (low) rowid — so insertion/rowid order is NOT
-    # recency. Without this ORDER BY an arbitrary (stale) row's hash could win,
-    # so the file's current hash never matches "known" → phantom "modified"
-    # every scan (the detection storm).
+    # deterministically keeps the NEWEST decisive row's hash. A file has many
+    # rows (one per batch, plus reused rows), and `reuse_as_pending` resets
+    # created_at to now while KEEPING the old (low) rowid — so insertion/rowid
+    # order is NOT recency.
+    #
+    # Rows INVISIBLE to the scan (siblings decide; they never supply a hash):
+    # - retriable failed rows (retry_count < max): the retry lane owns their
+    #   re-queueing; letting one erase the file from "known" would re-classify
+    #   the file as NEW and re-evaluate FULL content.
+    # - completed rows whose response file was deleted: user-initiated re-eval.
     cursor = await db.execute(
         "SELECT file_path, content_hash, status, response_path, retry_count "
-        "FROM inbox_items WHERE status != 'failed' "
+        "FROM inbox_items "
         "ORDER BY created_at ASC, rowid ASC",
     )
     rows = await cursor.fetchall()
     result: dict[str, str] = {}
     for row in rows:
-        file_path, content_hash, status, response_path = (
-            row[0], row[1], row[2], row[3],
+        file_path, content_hash, status, response_path, retry_count = (
+            row[0], row[1], row[2], row[3], row[4],
         )
-        # If completed but response file was deleted, allow reprocessing
+        if status == "failed" and (retry_count or 0) < max_retries:
+            continue
         if status == "completed" and response_path and not Path(response_path).exists():
             continue
         result[file_path] = content_hash
-
-    # Permanently failed items (exhausted retries) should also block reprocessing
-    cursor2 = await db.execute(
-        "SELECT file_path, content_hash FROM inbox_items "
-        "WHERE status = 'failed' AND retry_count >= ? "
-        "ORDER BY created_at ASC, rowid ASC",
-        (max_retries,),
-    )
-    for row in await cursor2.fetchall():
-        result[row[0]] = row[1]
 
     return result
 

--- a/src/genesis/db/crud/inbox_items.py
+++ b/src/genesis/db/crud/inbox_items.py
@@ -152,6 +152,42 @@ async def count_live_rows_for_approval(
     return int(row[0]) if row else 0
 
 
+async def supersede_parked_rows(
+    db: aiosqlite.Connection,
+    file_path: str,
+    *,
+    processed_at: str,
+) -> int:
+    """Supersede a file's parked (awaiting-approval) rows in place.
+
+    Used when a file changes while its drop is parked on a pending approval:
+    the freshly-computed delta is a SUPERSET of the parked one (the baseline
+    only advances on completed rows), so the new drop replaces the parked rows
+    ON THE SAME approval request — dispatching both would evaluate the old
+    delta twice. Rows mid-dispatch (``dispatching:``) are deliberately NOT
+    touched: their CC call is in flight and completion advances the baseline.
+
+    This never cancels the approval request itself — under idempotent-approval
+    semantics the pending request absorbs new content; if superseding leaves
+    the request with zero live rows (content removed entirely), the monitor's
+    orphan-recovery guard cancels it on a later scan with no replacement.
+
+    Returns the number of rows superseded.
+    """
+    cursor = await db.execute(
+        """UPDATE inbox_items
+           SET status = 'failed',
+               error_message = ? || 'superseded by newer modification',
+               processed_at = ?
+           WHERE file_path = ? AND status = 'processing'
+             AND error_message LIKE ? || '%'""",
+        (APPROVAL_INVALIDATED_PREFIX, processed_at, file_path,
+         AWAITING_APPROVAL_PREFIX),
+    )
+    await db.commit()
+    return cursor.rowcount
+
+
 async def claim_for_dispatch(
     db: aiosqlite.Connection, id: str, *, reqid: str,
 ) -> bool:

--- a/src/genesis/db/crud/telegram_messages.py
+++ b/src/genesis/db/crud/telegram_messages.py
@@ -107,14 +107,29 @@ async def search(
     query: str,
     *,
     limit: int = 10,
+    thread_id: int | None = None,
+    before: str | None = None,
 ) -> list[dict]:
-    """Search messages by keyword (LIKE match, wildcards escaped)."""
+    """Search messages by keyword (LIKE match, wildcards escaped).
+
+    ``thread_id`` scopes to one forum topic; ``before`` (ISO, exclusive)
+    pages older matches — the same scroll-up contract as query_recent.
+    """
     escaped = _escape_like(query)
+    clauses = ["chat_id = ?", "content LIKE ? ESCAPE '\\'"]
+    params: list[object] = [chat_id, f"%{escaped}%"]
+    if thread_id is not None:
+        clauses.append("thread_id = ?")
+        params.append(thread_id)
+    if before:
+        clauses.append("timestamp < ?")
+        params.append(before)
+    params.append(limit)
     cursor = await db.execute(
-        """SELECT * FROM telegram_messages
-           WHERE chat_id = ? AND content LIKE ? ESCAPE '\\'
-           ORDER BY timestamp DESC, id DESC LIMIT ?""",
-        (chat_id, f"%{escaped}%", limit),
+        f"""SELECT * FROM telegram_messages
+           WHERE {" AND ".join(clauses)}
+           ORDER BY timestamp DESC, id DESC LIMIT ?""",  # noqa: S608 — literal clauses
+        params,
     )
     rows = await cursor.fetchall()
     return [dict(r) for r in reversed(rows)]
@@ -125,14 +140,23 @@ async def search_all(
     query: str,
     *,
     limit: int = 10,
+    before: str | None = None,
 ) -> list[dict]:
     """Search messages across all chats by keyword (LIKE match, wildcards escaped)."""
     escaped = _escape_like(query)
-    cursor = await db.execute(
-        """SELECT * FROM telegram_messages
-           WHERE content LIKE ? ESCAPE '\\'
-           ORDER BY timestamp DESC, id DESC LIMIT ?""",
-        (f"%{escaped}%", limit),
-    )
+    if before:
+        cursor = await db.execute(
+            """SELECT * FROM telegram_messages
+               WHERE content LIKE ? ESCAPE '\\' AND timestamp < ?
+               ORDER BY timestamp DESC, id DESC LIMIT ?""",
+            (f"%{escaped}%", before, limit),
+        )
+    else:
+        cursor = await db.execute(
+            """SELECT * FROM telegram_messages
+               WHERE content LIKE ? ESCAPE '\\'
+               ORDER BY timestamp DESC, id DESC LIMIT ?""",
+            (f"%{escaped}%", limit),
+        )
     rows = await cursor.fetchall()
     return [dict(r) for r in reversed(rows)]

--- a/src/genesis/db/crud/telegram_messages.py
+++ b/src/genesis/db/crud/telegram_messages.py
@@ -49,22 +49,29 @@ async def query_recent(
     *,
     thread_id: int | None = None,
     limit: int = 20,
+    before: str | None = None,
 ) -> list[dict]:
-    """Return recent messages for a chat, newest first then reversed for readability."""
+    """Return recent messages for a chat, newest first then reversed for readability.
+
+    ``before`` (ISO timestamp, exclusive) pages further back — the scroll-up
+    cursor: pass the oldest timestamp from the previous page to get the next
+    older window.
+    """
+    clauses = ["chat_id = ?"]
+    params: list[object] = [chat_id]
     if thread_id is not None:
-        cursor = await db.execute(
-            """SELECT * FROM telegram_messages
-               WHERE chat_id = ? AND thread_id = ?
-               ORDER BY timestamp DESC LIMIT ?""",
-            (chat_id, thread_id, limit),
-        )
-    else:
-        cursor = await db.execute(
-            """SELECT * FROM telegram_messages
-               WHERE chat_id = ?
-               ORDER BY timestamp DESC LIMIT ?""",
-            (chat_id, limit),
-        )
+        clauses.append("thread_id = ?")
+        params.append(thread_id)
+    if before:
+        clauses.append("timestamp < ?")
+        params.append(before)
+    params.append(limit)
+    cursor = await db.execute(
+        f"""SELECT * FROM telegram_messages
+           WHERE {" AND ".join(clauses)}
+           ORDER BY timestamp DESC LIMIT ?""",  # noqa: S608 — clauses are literals
+        params,
+    )
     rows = await cursor.fetchall()
     # Return in chronological order (oldest first) for readability
     return [dict(r) for r in reversed(rows)]
@@ -74,13 +81,22 @@ async def query_all_recent(
     db: aiosqlite.Connection,
     *,
     limit: int = 20,
+    before: str | None = None,
 ) -> list[dict]:
     """Return recent messages across all chats, newest first then reversed."""
-    cursor = await db.execute(
-        """SELECT * FROM telegram_messages
-           ORDER BY timestamp DESC LIMIT ?""",
-        (limit,),
-    )
+    if before:
+        cursor = await db.execute(
+            """SELECT * FROM telegram_messages
+               WHERE timestamp < ?
+               ORDER BY timestamp DESC LIMIT ?""",
+            (before, limit),
+        )
+    else:
+        cursor = await db.execute(
+            """SELECT * FROM telegram_messages
+               ORDER BY timestamp DESC LIMIT ?""",
+            (limit,),
+        )
     rows = await cursor.fetchall()
     return [dict(r) for r in reversed(rows)]
 

--- a/src/genesis/db/crud/telegram_messages.py
+++ b/src/genesis/db/crud/telegram_messages.py
@@ -69,7 +69,7 @@ async def query_recent(
     cursor = await db.execute(
         f"""SELECT * FROM telegram_messages
            WHERE {" AND ".join(clauses)}
-           ORDER BY timestamp DESC LIMIT ?""",  # noqa: S608 — clauses are literals
+           ORDER BY timestamp DESC, id DESC LIMIT ?""",  # noqa: S608 — clauses are literals
         params,
     )
     rows = await cursor.fetchall()
@@ -88,13 +88,13 @@ async def query_all_recent(
         cursor = await db.execute(
             """SELECT * FROM telegram_messages
                WHERE timestamp < ?
-               ORDER BY timestamp DESC LIMIT ?""",
+               ORDER BY timestamp DESC, id DESC LIMIT ?""",
             (before, limit),
         )
     else:
         cursor = await db.execute(
             """SELECT * FROM telegram_messages
-               ORDER BY timestamp DESC LIMIT ?""",
+               ORDER BY timestamp DESC, id DESC LIMIT ?""",
             (limit,),
         )
     rows = await cursor.fetchall()
@@ -113,7 +113,7 @@ async def search(
     cursor = await db.execute(
         """SELECT * FROM telegram_messages
            WHERE chat_id = ? AND content LIKE ? ESCAPE '\\'
-           ORDER BY timestamp DESC LIMIT ?""",
+           ORDER BY timestamp DESC, id DESC LIMIT ?""",
         (chat_id, f"%{escaped}%", limit),
     )
     rows = await cursor.fetchall()
@@ -131,7 +131,7 @@ async def search_all(
     cursor = await db.execute(
         """SELECT * FROM telegram_messages
            WHERE content LIKE ? ESCAPE '\\'
-           ORDER BY timestamp DESC LIMIT ?""",
+           ORDER BY timestamp DESC, id DESC LIMIT ?""",
         (f"%{escaped}%", limit),
     )
     rows = await cursor.fetchall()

--- a/src/genesis/identity/CONVERSATION.md
+++ b/src/genesis/identity/CONVERSATION.md
@@ -55,6 +55,16 @@ WebSearch) plus Genesis MCP tools across four servers: genesis-health,
 genesis-memory, genesis-outreach, and genesis-recon. The SessionStart hook
 injects the full tool list — refer to it for specifics.
 
+### Scroll-up (conversation history on demand)
+When the user references earlier conversation that is not in your context —
+"as we discussed", "option 3", "that thing from last week" — SCROLL UP before
+claiming the context is unavailable: call `conversation_history` (genesis-
+memory) with `channel='telegram'` and the `chat_id` from your "Conversation
+identity" prompt block; page further back with `before=<oldest timestamp
+seen>`. Messages return full-length, arbitrarily far back. A session-recovery
+recap in your prompt is a truncated preview, not the archive — the archive is
+one tool call away.
+
 ## External Module Dispatch
 
 Genesis has external modules — programs running on other machines that you

--- a/src/genesis/inbox/monitor.py
+++ b/src/genesis/inbox/monitor.py
@@ -464,8 +464,11 @@ class InboxMonitor:
         Rows stay in 'processing' state with an
         ``awaiting_approval:<request_id>`` marker in error_message.
         The resume pass ONLY dispatches on the pending→approved state
-        transition.  Hash validation happens FIRST so a file that
-        vanished or was edited while pending is invalidated immediately.
+        transition.  A VANISHED file is invalidated immediately regardless of
+        approval state; a file EDITED while the approval is still pending is
+        HELD (the detection phase supersedes it onto the same request this
+        tick) — the edit check applies only at dispatch time (approved), where
+        a stale delta is invalidated and the approval consumed.
 
         Invariant: resume items are ALWAYS dispatched as singleton
         batches to preserve the original content-stable approval key.
@@ -512,8 +515,16 @@ class InboxMonitor:
 
             p = Path(file_path)
 
-            # Hash check FIRST — vanished/changed files invalidate
-            # regardless of approval state.
+            # Vanish check FIRST — a deleted file invalidates regardless of
+            # approval state (nothing left to evaluate; the orphan guard
+            # cancels the request if no other rows remain).
+            #
+            # A CHANGED file is handled per approval state below: while the
+            # approval is still PENDING the row is HELD — the detection phase
+            # supersedes it with the recomputed delta on the SAME request in
+            # this very tick (invalidating here instead would zero the
+            # request's live rows and make the orphan guard cancel + re-request
+            # → a new Telegram message per edit, the residual storm seed).
             try:
                 current_hash = compute_hash(p)
             except (FileNotFoundError, PermissionError):
@@ -524,15 +535,6 @@ class InboxMonitor:
                     error_message=(
                         f"{inbox_items.APPROVAL_INVALIDATED_PREFIX}source file vanished"
                     ),
-                    processed_at=now_iso,
-                )
-                continue
-            if current_hash != stored_hash:
-                await inbox_items.update_status(
-                    self._db,
-                    row_id,
-                    status="failed",
-                    error_message=(f"{inbox_items.APPROVAL_INVALIDATED_PREFIX}content changed"),
                     processed_at=now_iso,
                 )
                 continue
@@ -600,7 +602,27 @@ class InboxMonitor:
                 )
                 continue
 
-            # approved or legacy fall-through: load content for dispatch
+            # approved or legacy fall-through: about to dispatch — a file
+            # changed since parking must NOT dispatch its stale delta (the
+            # user may have removed that content). Invalidate AND consume the
+            # approval: an approved-UNconsumed request stays reusable via the
+            # gate's `_find_existing` for its staleness window, so without the
+            # consume the re-detected post-approval content would ride the old
+            # grant this same tick instead of getting a fresh approval.
+            # Tri-state consume keeps sibling drops safe (their consume
+            # returns "already_consumed" and they proceed on their row
+            # claims). A vanished file needs no consume — nothing re-detects.
+            if current_hash != stored_hash:
+                await inbox_items.update_status(
+                    self._db,
+                    row_id,
+                    status="failed",
+                    error_message=(f"{inbox_items.APPROVAL_INVALIDATED_PREFIX}content changed"),
+                    processed_at=now_iso,
+                )
+                if request_id:
+                    await self._consume_approval(request_id)
+                continue
             try:
                 content = read_content(p)
             except (FileNotFoundError, PermissionError):
@@ -778,72 +800,23 @@ class InboxMonitor:
                 )
                 return [], []
 
-            # New content while approval pending — cancel the stale
-            # approval so a fresh one with updated content is created.
-            pending_id = pending.get("id")
+            # New content while approval pending: PARK IT ON THE SAME REQUEST.
+            # Inbox approval requests are idempotent commands over current
+            # inbox state (approve-once clears everything outstanding), so a
+            # new/modified file never cancels the pending request and never
+            # produces a new Telegram message: the new drop flows through the
+            # normal record path below, the gate's stable site key re-attaches
+            # it to the existing pending request, and _phase_create_records
+            # supersedes any now-stale parked rows for the same file (their
+            # delta is a subset of the fresh one). This replaces the old
+            # cancel-and-recreate refresh, which sent a fresh approval message
+            # per edit — and, when the known-hash map went stale, one every
+            # scan (the 2026-08 approval storm).
             logger.info(
-                "New inbox files detected while approval %s pending — "
-                "cancelling stale approval to refresh",
-                pending_id,
+                "New inbox content while approval %s pending — parking onto "
+                "the existing request (no new approval message)",
+                pending.get("id"),
             )
-            try:
-                gate = self._autonomous_dispatcher.approval_gate
-                await gate.approval_manager.cancel(pending_id)
-            except Exception:
-                logger.warning(
-                    "Failed to cancel stale inbox approval %s; "
-                    "proceeding with new detection anyway",
-                    pending_id,
-                    exc_info=True,
-                )
-
-            # Invalidate inbox_items parked on the cancelled approval and
-            # fold their files into THIS refresh. Invalidated rows are
-            # excluded from get_all_known and from retry by design ("fresh
-            # rows with fresh approvals"), so a parked file that is not
-            # re-dispatched here re-surfaces as phantom-new next scan and
-            # cancels the fresh approval in turn — two parked files then
-            # leapfrog forever: a cancel + a new request (a Telegram
-            # message) every scan with no disk change.
-            parked_paths: list[str] = []
-            try:
-                awaiting = await inbox_items.get_awaiting_approval(self._db)
-                for row in awaiting:
-                    marker = str(row.get("error_message") or "")
-                    if marker == (f"{inbox_items.AWAITING_APPROVAL_PREFIX}{pending_id}"):
-                        await inbox_items.update_status(
-                            self._db,
-                            str(row["id"]),
-                            status="failed",
-                            error_message=(
-                                f"{inbox_items.APPROVAL_INVALIDATED_PREFIX}"
-                                "superseded by new inbox scan"
-                            ),
-                            processed_at=self._clock().isoformat(),
-                        )
-                        parked_paths.append(str(row["file_path"]))
-            except Exception:
-                logger.warning(
-                    "Failed to invalidate parked inbox items for %s",
-                    pending_id,
-                    exc_info=True,
-                )
-
-            detected = {str(p) for p in new_files}
-            detected |= {str(p) for p in modified_files}
-            folded = [
-                Path(fp)
-                for fp in dict.fromkeys(parked_paths)
-                if fp not in detected and Path(fp).exists()
-            ]
-            if folded:
-                modified_files = [*modified_files, *folded]
-                logger.info(
-                    "Folded %d parked file(s) into the refresh batch: %s",
-                    len(folded),
-                    ", ".join(p.name for p in folded),
-                )
-
             return new_files, modified_files
 
         # Normal path: no approval pending.
@@ -934,6 +907,14 @@ class InboxMonitor:
                 continue
             if not content.strip():
                 logger.debug("Skipping empty modified file: %s", f)
+                # The user emptied the file: any parked rows reference content
+                # that no longer exists — supersede them (the orphan guard
+                # cancels the request later if nothing else is parked on it).
+                await inbox_items.supersede_parked_rows(
+                    self._db,
+                    str(f),
+                    processed_at=now_iso,
+                )
                 await inbox_items.create(
                     self._db,
                     id=item_id,
@@ -999,11 +980,36 @@ class InboxMonitor:
                     status="failed",
                     error_message="superseded_by_modification",
                 )
+            # Likewise supersede rows PARKED on a pending approval for this
+            # file: the fresh delta below is a superset of the parked one (the
+            # baseline advances only on completed rows), and the new drop
+            # re-parks on the SAME request — dispatching both on approval
+            # would evaluate the old delta twice. Never cancels the request.
+            superseded = await inbox_items.supersede_parked_rows(
+                self._db,
+                str(f),
+                processed_at=now_iso,
+            )
+            if superseded:
+                logger.info(
+                    "Superseded %d parked row(s) for %s with the fresh delta "
+                    "(same approval request)",
+                    superseded,
+                    f.name,
+                )
             if is_empty_delta:
                 # No new content vs the baseline: write a completing row to
                 # ADVANCE the known hash (no evaluation). This runs regardless
-                # of cooldown — it is the storm fix.
-                logger.debug("No new content in modified file: %s", f)
+                # of cooldown — it is the storm fix. INFO with the hash delta:
+                # silent baselining is how a mis-computed delta would eat items
+                # unobserved (the disproven-but-costly BUG-3 suspicion).
+                logger.info(
+                    "Empty delta for %s — advancing baseline hash to %s with "
+                    "no evaluation (byte-level change only: tracking params, "
+                    "whitespace, or already-evaluated lines)",
+                    f.name,
+                    h[:8],
+                )
                 await inbox_items.create(
                     self._db,
                     id=item_id,
@@ -1019,6 +1025,11 @@ class InboxMonitor:
             # site missing it. Instead of dropping, write a completing row to
             # ADVANCE the known hash (stopping re-detection), exactly like the
             # empty-delta branch above.
+            # NOTE (deliberate): any rows already PARKED for this file were
+            # superseded above and get NO replacement here — the parked delta
+            # is exactly the repeatedly-failing content the guard exists to
+            # stop re-chewing. The now-orphaned request is cancelled quietly
+            # by the orphan guard; the WARNING below is the operator trace.
             url_fail_count = await inbox_items.count_url_failures(
                 self._db,
                 str(f),
@@ -1264,10 +1275,12 @@ class InboxMonitor:
             ]
             if not claimed:
                 continue
-            # Consume the drop's approval (best-effort). The row-state claim above
-            # is the real gate, so a consume failure neither strands the drop nor
-            # bypasses at-most-once; it only leaves the content-agnostic approval
-            # rideable until the gate's 24h staleness window (WARNING-logged).
+            # Consume the drop's approval. Tri-state (see _consume_approval):
+            # consumed / already_consumed both proceed — the row-state claim
+            # above is the at-most-once dispatch gate, and already-consumed is
+            # NORMAL for sibling drops of an approve-once fanout and for
+            # cross-tick crash recovery. A persistent failure is ERROR-logged
+            # there (stale rideable approval) and still proceeds on the claim.
             reqid = claimed[0].approval_reqid
             if reqid:
                 await self._consume_approval(reqid)
@@ -1519,41 +1532,59 @@ class InboxMonitor:
             )
         return "approved"
 
-    async def _consume_approval(self, request_id: str) -> bool:
-        """Consume a resume drop's approval so the next drop cannot ride the
+    async def _consume_approval(self, request_id: str) -> str:
+        """Consume a resume drop's approval so a LATER NEW drop cannot ride the
         same (content-agnostic, stable-key) approval.
 
-        Returns True if the approval was consumed (or there is no gate to
-        consume against), False if the consume failed or the approval was
-        already consumed. A failure is logged at WARNING (it was previously
-        swallowed at debug) because a non-consumed approval can be ridden by a
-        later inbox drop until the gate's 24h staleness window expires.
+        Returns one of:
 
-        NOTE: the resume caller currently dispatches regardless of this result.
-        Acting on a False — skip-and-retry on transient failure, or fail-and-
-        re-detect when the approval is already consumed — requires the
-        at-most-once dispatch state machine tracked in follow-up 0b68d341.
+        - ``"consumed"`` — this call closed the approval (first drop this pass;
+          includes one transparent retry after a transient failure).
+        - ``"already_consumed"`` — a sibling drop consumed it earlier this pass,
+          or a prior tick consumed it before a crash left rows claimed
+          (``dispatching:``). NORMAL under approve-once/multi-drop fanout — the
+          per-row ``claim_for_dispatch`` is the at-most-once dispatch gate, so
+          callers proceed.
+        - ``"failed"`` — consume failed twice (e.g. DB lock). ERROR-logged: the
+          approval stays approved-unconsumed and IS rideable by a later new
+          drop via the gate's reuse path until its staleness window lapses.
+          Callers still proceed (the row claim gates dispatch); the loud log is
+          the containment.
+        - ``"no_gate"`` — no dispatcher/gate wired (gate-off/test path).
         """
         gate = getattr(self._autonomous_dispatcher, "approval_gate", None)
         consume = getattr(gate, "mark_consumed", None)
         if consume is None:
-            return True
-        try:
-            ok = bool(await consume(request_id))
-        except Exception:
-            logger.warning(
-                "Inbox resume: failed to consume approval %s — it may remain "
-                "rideable by a later drop until the 24h staleness window",
+            return "no_gate"
+        last_exc: Exception | None = None
+        for attempt in (1, 2):
+            try:
+                ok = bool(await consume(request_id))
+            except Exception as exc:
+                last_exc = exc
+                logger.debug(
+                    "Inbox resume: consume attempt %d for approval %s failed",
+                    attempt,
+                    request_id,
+                    exc_info=True,
+                )
+                continue
+            if ok:
+                return "consumed"
+            logger.debug(
+                "Inbox resume: approval %s already consumed (sibling drop or "
+                "crash recovery) — proceeding on the row claim",
                 request_id,
-                exc_info=True,
             )
-            return False
-        if not ok:
-            logger.warning(
-                "Inbox resume: approval %s was already consumed",
-                request_id,
-            )
-        return ok
+            return "already_consumed"
+        logger.error(
+            "Inbox resume: failed to consume approval %s after retry (%s) — it "
+            "remains rideable by a later inbox drop until the gate's staleness "
+            "window expires",
+            request_id,
+            last_exc,
+        )
+        return "failed"
 
     async def _dispatch_one_batch(
         self,

--- a/src/genesis/learning/fallback_chains.py
+++ b/src/genesis/learning/fallback_chains.py
@@ -8,10 +8,12 @@ and which fail, building procedural memory over time (Phase 6+).
 from __future__ import annotations
 
 CHAINS: dict[str, list[str]] = {
+    # NOTE: aspirational/static — the LIVE web_fetch chain is
+    # TinyFish → Scrapling → Ladder → Crawl4AI → httpx (mcp/health/web_tools.py),
+    # with Firecrawl as an EXPLICIT paid escalation backend, never first.
     "web_fetch": [
-        "firecrawl",
-        "playwright",
-        "requests_fallback",
+        "live_auto_chain",
+        "firecrawl_backend",
         "cache_lookup",
     ],
     "api_rate_limit": [

--- a/src/genesis/learning/tool_discovery.py
+++ b/src/genesis/learning/tool_discovery.py
@@ -31,10 +31,14 @@ KNOWN_TOOLS: list[dict[str, str | None]] = [
     {
         "name": "firecrawl",
         "category": "web",
-        "description": "Web scraping and content extraction",
-        "tool_type": "mcp",
+        "description": (
+            "Web scraping and content extraction (paid cloud API; reachable "
+            "as web_fetch backend='firecrawl' or the foreground Bash CLI — "
+            "there is NO Firecrawl MCP server)"
+        ),
+        "tool_type": "provider",
         "provider": "firecrawl",
-        "cost_tier": "cheap",
+        "cost_tier": "paid",
     },
     {
         "name": "playwright",

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -584,28 +584,32 @@ def _atomic_yaml_write(
     _USER_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     path = _USER_CONFIG_DIR / filename
 
-    header_lines: list[str] = []
+    # Preservation is UNCONDITIONAL — a caller that forgets `provenance` must
+    # never become a delete path for the hand-written operator rationale or
+    # prior stamps this feature exists to protect. Only the machine-stamped
+    # '# set-by:' history is capped; only the NEW stamp is conditional.
+    set_by: list[str] = []
+    other_comments: list[str] = []
+    try:
+        for line in path.read_text().splitlines():
+            if line.startswith("# set-by: "):
+                set_by.append(line)
+            elif line.startswith("#"):
+                other_comments.append(line)
+            elif line.strip():
+                break
+    except OSError:
+        pass
     if provenance:
-        # Preserve the ENTIRE leading comment block — hand-written operator
-        # rationale ('# provenance: …' etc.) is exactly the record this
-        # feature exists to protect; only the machine-stamped '# set-by:'
-        # history is capped.
-        set_by: list[str] = []
-        other_comments: list[str] = []
-        try:
-            for line in path.read_text().splitlines():
-                if line.startswith("# set-by: "):
-                    set_by.append(line)
-                elif line.startswith("#"):
-                    other_comments.append(line)
-                elif line.strip():
-                    break
-        except OSError:
-            pass
+        # Defense-in-depth: a newline in the actor string would write raw
+        # lines BELOW the comment prefix — top-level YAML injected above the
+        # real mapping in the same document. All current callers pass fixed
+        # strings; sanitize anyway so a future caller can't become a vector.
+        clean = provenance.replace("\r", " ").replace("\n", " ")
         set_by.append(
-            f"# set-by: {provenance} @ {datetime.now(UTC).isoformat()}",
+            f"# set-by: {clean} @ {datetime.now(UTC).isoformat()}",
         )
-        header_lines = other_comments + set_by[-_PROVENANCE_HISTORY_MAX:]
+    header_lines: list[str] = other_comments + set_by[-_PROVENANCE_HISTORY_MAX:]
 
     tmp_fd, tmp_path = tempfile.mkstemp(
         dir=str(path.parent),

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -1842,43 +1842,74 @@ async def _impl_settings_update(
         # pipeline here): a critical observation — the server's
         # critical-observations job pages it to Telegram. Best-effort; the
         # provenance stamp + warning above remain the durable record.
-        try:
-            import hashlib as _hashlib
-            import uuid as _uuid
-            from datetime import UTC as _UTC
-            from datetime import datetime as _datetime
-
-            from genesis.db.connection import get_raw_db
-            from genesis.db.crud import observations as _observations
-            from genesis.env import genesis_db_path
-
-            async with get_raw_db(genesis_db_path()) as db:
-                await _observations.create(
-                    db,
-                    id=str(_uuid.uuid4()),
-                    source="settings_guard",
-                    type="infrastructure_alert",
-                    content=(
-                        f"Approval gate DISABLED via {actor} (confirmed): "
-                        "manual_approval_required is now false — autonomous "
-                        "Claude Code sessions dispatch WITHOUT per-run "
-                        "approval until it is set back to true "
-                        "(Settings → autonomous_cli_policy)."
-                    ),
-                    priority="critical",
-                    created_at=_datetime.now(_UTC).isoformat(),
-                    content_hash=_hashlib.sha256(
-                        b"approval_gate_disabled_alert",
-                    ).hexdigest(),
-                    skip_if_duplicate=True,
-                )
-        except Exception:
-            logger.warning(
-                "Gate-disable critical observation write failed",
-                exc_info=True,
-            )
+        await write_gate_disable_alert(actor)
+    elif domain == "autonomous_cli_policy" and changes.get("manual_approval_required") is True:
+        # Gate restored: resolve the standing alert immediately so a stale
+        # "running without approval" critical cannot page after re-enable.
+        await resolve_gate_disable_alert(actor)
 
     return result
+
+
+async def write_gate_disable_alert(actor: str) -> None:
+    """Best-effort critical observation for a confirmed gate disable."""
+    try:
+        import hashlib as _hashlib
+        import uuid as _uuid
+        from datetime import UTC as _UTC
+        from datetime import datetime as _datetime
+
+        from genesis.db.connection import get_raw_db
+        from genesis.db.crud import observations as _observations
+        from genesis.env import genesis_db_path
+
+        async with get_raw_db(genesis_db_path()) as db:
+            await _observations.create(
+                db,
+                id=str(_uuid.uuid4()),
+                source="settings_guard",
+                type="infrastructure_alert",
+                content=(
+                    f"Approval gate DISABLED via {actor} (confirmed): "
+                    "manual_approval_required is now false — autonomous "
+                    "Claude Code sessions dispatch WITHOUT per-run "
+                    "approval until it is set back to true "
+                    "(Settings → autonomous_cli_policy)."
+                ),
+                priority="critical",
+                created_at=_datetime.now(_UTC).isoformat(),
+                content_hash=_hashlib.sha256(
+                    b"approval_gate_disabled_alert",
+                ).hexdigest(),
+                skip_if_duplicate=True,
+            )
+    except Exception:
+        logger.warning(
+            "Gate-disable critical observation write failed",
+            exc_info=True,
+        )
+
+
+async def resolve_gate_disable_alert(actor: str) -> None:
+    """Best-effort resolve of the gate-disabled alert when the gate returns."""
+    try:
+        from datetime import UTC as _UTC
+        from datetime import datetime as _datetime
+
+        from genesis.db.connection import get_raw_db
+        from genesis.db.crud import observations as _observations
+        from genesis.env import genesis_db_path
+
+        async with get_raw_db(genesis_db_path()) as db:
+            await _observations.resolve_by_source_and_type(
+                db,
+                source="settings_guard",
+                type="infrastructure_alert",
+                resolved_at=_datetime.now(_UTC).isoformat(),
+                resolution_notes=f"gate re-enabled via {actor}",
+            )
+    except Exception:
+        logger.warning("Gate-disable alert resolve failed", exc_info=True)
 
 
 # ── MCP tool wrappers ──────────────────────────────────────────────────

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -555,26 +555,101 @@ def _load_yaml_merged(filename: str) -> dict:
 _USER_CONFIG_DIR = Path.home() / ".genesis" / "config"
 
 
-def _atomic_yaml_write(filename: str, data: dict) -> Path:
+# Provenance header lines preserved across rewrites (newest last, capped so
+# the header can't grow unboundedly on a frequently-edited domain).
+_PROVENANCE_HISTORY_MAX = 5
+
+
+def _atomic_yaml_write(
+    filename: str,
+    data: dict,
+    *,
+    provenance: str | None = None,
+) -> Path:
     """Write YAML atomically to user config dir (~/.genesis/config/).
 
     Runtime config writes go to the user directory, not the repo tree,
     so git status stays clean and user settings don't leak into PRs.
+
+    ``provenance`` stamps a ``# set-by: <actor> @ <utc>`` header comment and
+    PRESERVES prior stamps (last ``_PROVENANCE_HISTORY_MAX``). This is the
+    durable answer to "is this user-set config an anomaly?": any future
+    session reading the overlay sees who set it and when, so a deliberate
+    user choice (e.g. disabling the approval gate from the dashboard) is
+    never mistaken for drift and "fixed" back. yaml.safe_load ignores the
+    comments, so readers are unaffected.
     """
+    from datetime import UTC, datetime
+
     _USER_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     path = _USER_CONFIG_DIR / filename
+
+    header_lines: list[str] = []
+    if provenance:
+        # Preserve the ENTIRE leading comment block — hand-written operator
+        # rationale ('# provenance: …' etc.) is exactly the record this
+        # feature exists to protect; only the machine-stamped '# set-by:'
+        # history is capped.
+        set_by: list[str] = []
+        other_comments: list[str] = []
+        try:
+            for line in path.read_text().splitlines():
+                if line.startswith("# set-by: "):
+                    set_by.append(line)
+                elif line.startswith("#"):
+                    other_comments.append(line)
+                elif line.strip():
+                    break
+        except OSError:
+            pass
+        set_by.append(
+            f"# set-by: {provenance} @ {datetime.now(UTC).isoformat()}",
+        )
+        header_lines = other_comments + set_by[-_PROVENANCE_HISTORY_MAX:]
+
     tmp_fd, tmp_path = tempfile.mkstemp(
         dir=str(path.parent),
         suffix=".yaml.tmp",
     )
     try:
         with open(tmp_fd, "w") as f:
+            if header_lines:
+                f.write("\n".join(header_lines) + "\n")
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
         Path(tmp_path).replace(path)
     except Exception:
         Path(tmp_path).unlink(missing_ok=True)
         raise
     return path
+
+
+def gate_disable_error(
+    domain: str,
+    changes: dict,
+    *,
+    confirmed: bool,
+) -> str | None:
+    """Error message when disabling the mandatory approval gate unconfirmed.
+
+    ``manual_approval_required: false`` turns off the approval gate for ALL
+    autonomous CC sessions — a single unconfirmed API call must not do that
+    silently (2026-08-18: a dashboard PUT flipped it with zero friction and
+    zero notification). The user remains sovereign: with explicit
+    confirmation the write proceeds (and the caller sends a Telegram notice).
+    """
+    if domain != "autonomous_cli_policy":
+        return None
+    if changes.get("manual_approval_required") is not False:
+        return None
+    if confirmed:
+        return None
+    return (
+        "Disabling manual_approval_required turns OFF the mandatory approval "
+        "gate for ALL autonomous Claude Code sessions. If this is deliberate, "
+        "repeat the request with confirm_disable_approval_gate=true — the "
+        "change is then applied, provenance-stamped, and announced via "
+        "Telegram."
+    )
 
 
 def _deep_merge(base: dict, overlay: dict) -> dict:
@@ -1666,6 +1741,8 @@ async def _impl_settings_update(
     domain: str,
     changes: dict,
     dry_run: bool = False,
+    confirm_disable_approval_gate: bool = False,
+    actor: str = "user via mcp settings_update",
 ) -> dict:
     entry = _DOMAIN_REGISTRY.get(domain)
     if entry is None:
@@ -1699,6 +1776,16 @@ async def _impl_settings_update(
                 "validation_errors": errors,
             }
 
+    # Protected key: disabling the mandatory approval gate needs explicit
+    # confirmation (see gate_disable_error).
+    gate_err = gate_disable_error(
+        domain,
+        changes,
+        confirmed=confirm_disable_approval_gate,
+    )
+    if gate_err:
+        return {"domain": domain, "error": gate_err}
+
     # Merge changes into the local overlay (NOT the base file).
     # The base file stays git-tracked and clean for upstream updates.
     local = _load_yaml_local(entry.config_filename)
@@ -1715,10 +1802,11 @@ async def _impl_settings_update(
             "needs_restart": entry.needs_restart,
         }
 
-    # Atomic write to .local.yaml
+    # Atomic write to .local.yaml (provenance-stamped: user-set config must
+    # never read as an anomaly to a future session).
     local_file = _local_filename(entry.config_filename)
     try:
-        _atomic_yaml_write(local_file, new_local)
+        _atomic_yaml_write(local_file, new_local, provenance=actor)
     except Exception:
         logger.error(
             "Failed to write local settings for %s",
@@ -1736,6 +1824,55 @@ async def _impl_settings_update(
     }
     if entry.needs_restart:
         result["note"] = "Changes saved. Restart genesis-server for them to take effect."
+    if domain == "autonomous_cli_policy" and changes.get("manual_approval_required") is False:
+        result["warning"] = (
+            "The mandatory approval gate is now DISABLED: autonomous Claude "
+            "Code sessions dispatch without per-run approval until "
+            "manual_approval_required is set back to true."
+        )
+        logger.warning(
+            "manual_approval_required disabled via %s (confirmed)",
+            actor,
+        )
+        # Owner-facing loudness from the MCP process (no live outreach
+        # pipeline here): a critical observation — the server's
+        # critical-observations job pages it to Telegram. Best-effort; the
+        # provenance stamp + warning above remain the durable record.
+        try:
+            import hashlib as _hashlib
+            import uuid as _uuid
+            from datetime import UTC as _UTC
+            from datetime import datetime as _datetime
+
+            from genesis.db.connection import get_raw_db
+            from genesis.db.crud import observations as _observations
+            from genesis.env import genesis_db_path
+
+            async with get_raw_db(genesis_db_path()) as db:
+                await _observations.create(
+                    db,
+                    id=str(_uuid.uuid4()),
+                    source="settings_guard",
+                    type="infrastructure_alert",
+                    content=(
+                        f"Approval gate DISABLED via {actor} (confirmed): "
+                        "manual_approval_required is now false — autonomous "
+                        "Claude Code sessions dispatch WITHOUT per-run "
+                        "approval until it is set back to true "
+                        "(Settings → autonomous_cli_policy)."
+                    ),
+                    priority="critical",
+                    created_at=_datetime.now(_UTC).isoformat(),
+                    content_hash=_hashlib.sha256(
+                        b"approval_gate_disabled_alert",
+                    ).hexdigest(),
+                    skip_if_duplicate=True,
+                )
+        except Exception:
+            logger.warning(
+                "Gate-disable critical observation write failed",
+                exc_info=True,
+            )
 
     return result
 
@@ -1770,6 +1907,7 @@ async def settings_update(
     domain: str,
     changes: dict,
     dry_run: bool = False,
+    confirm_disable_approval_gate: bool = False,
 ) -> dict:
     """Update configuration for a settings domain.
 
@@ -1777,6 +1915,15 @@ async def settings_update(
     keys change, existing keys are preserved). Set dry_run=True to
     validate without saving. Read-only domains are rejected.
 
+    Disabling autonomous_cli_policy.manual_approval_required (the mandatory
+    approval gate) additionally requires confirm_disable_approval_gate=True —
+    the change is then provenance-stamped and loudly warned in the result.
+
     Example: settings_update("tts", {"elevenlabs": {"stability": 0.9}})
     """
-    return await _impl_settings_update(domain, changes, dry_run=dry_run)
+    return await _impl_settings_update(
+        domain,
+        changes,
+        dry_run=dry_run,
+        confirm_disable_approval_gate=confirm_disable_approval_gate,
+    )

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -733,6 +733,7 @@ def _validate_autonomous_cli_policy(changes: dict) -> list[str]:
         "autonomous_cli_fallback_enabled",
         "manual_approval_required",
         "reask_interval_hours",
+        "reask_overrides",
         "approval_channel",
         "shared_export_enabled",
     }
@@ -750,13 +751,40 @@ def _validate_autonomous_cli_policy(changes: dict) -> list[str]:
         if key in changes and not isinstance(changes[key], bool):
             errors.append(f"{key} must be a boolean")
 
+    def _whole_hours(value: object) -> int | None:
+        """Strict whole-hours parse: bools and fractional values are invalid.
+
+        int(0.9) would silently truncate to the 0 = never-re-ask sentinel on
+        an approval-adjacent surface — reject instead of rounding.
+        """
+        if isinstance(value, bool) or not isinstance(value, int):
+            return None
+        return value
+
     if "reask_interval_hours" in changes:
-        try:
-            value = int(changes["reask_interval_hours"])
-            if value < 1 or value > 168:
-                errors.append("reask_interval_hours must be between 1 and 168")
-        except (TypeError, ValueError):
-            errors.append("reask_interval_hours must be an integer")
+        value = _whole_hours(changes["reask_interval_hours"])
+        if value is None:
+            errors.append("reask_interval_hours must be a whole number of hours")
+        elif value < 0 or value > 168:
+            errors.append(
+                "reask_interval_hours must be between 0 (never re-ask) and 168",
+            )
+
+    if "reask_overrides" in changes:
+        overrides = changes["reask_overrides"]
+        if not isinstance(overrides, dict):
+            errors.append("reask_overrides must be a mapping of policy_id -> hours")
+        else:
+            for pid, hours in overrides.items():
+                v = _whole_hours(hours)
+                if v is None:
+                    errors.append(
+                        f"reask_overrides.{pid} must be a whole number of hours",
+                    )
+                elif v < 0 or v > 168:
+                    errors.append(
+                        f"reask_overrides.{pid} must be between 0 (never) and 168",
+                    )
 
     if "approval_channel" in changes:
         channel = str(changes["approval_channel"] or "").strip().lower()

--- a/src/genesis/mcp/health/web_tools.py
+++ b/src/genesis/mcp/health/web_tools.py
@@ -600,7 +600,10 @@ async def web_fetch(
         urls: Multiple URLs (1-10) for parallel fetch via TinyFish.
         backend: "auto" (smart fallback), "tinyfish" (cloud anti-bot),
                  "ladder" (Googlebot proxy, paywalls), "scrapling" (fast, TLS),
-                 "crawl4ai" (JS-rendered), "httpx".
+                 "crawl4ai" (JS-rendered), "httpx", or "firecrawl" (PAID cloud
+                 scraping — explicit escalation only, never in the auto chain;
+                 use when the free chain dead-ends on hard anti-bot/paywalled/
+                 JS pages; burns Firecrawl credits).
         max_chars: Maximum characters per URL (default 50000 ≈ 12k tokens).
 
     Returns dict with: url, title, content, backend_used, status_code,

--- a/src/genesis/mcp/health/web_tools.py
+++ b/src/genesis/mcp/health/web_tools.py
@@ -91,6 +91,90 @@ async def _try_tinyfish_fetch(url: str, max_chars: int) -> dict | None:
     return None
 
 
+async def _try_firecrawl_fetch(url: str, max_chars: int) -> dict | None:
+    """Attempt a Firecrawl scrape (PAID). Returns result dict or None."""
+    import os
+    import time as _time
+
+    if not os.environ.get("FIRECRAWL_API_KEY"):
+        return None
+    start = _time.monotonic()
+    try:
+        from genesis.providers import firecrawl_client
+
+        data = await firecrawl_client.scrape(url)
+        markdown = str(data.get("markdown") or "")
+        if not markdown:
+            logger.debug("Firecrawl returned no markdown for %s", url)
+            return None
+        meta = data.get("metadata") or {}
+        return {
+            "url": str(meta.get("sourceURL") or url),
+            "title": str(meta.get("title") or ""),
+            "content": markdown[:max_chars],
+            "backend_used": "firecrawl",
+            "status_code": int(meta.get("statusCode") or 200),
+            "truncated": len(markdown) > max_chars,
+            "error": None,
+            "latency_ms": round((_time.monotonic() - start) * 1000, 1),
+        }
+    except Exception as exc:
+        import httpx as _httpx
+
+        if isinstance(exc, _httpx.HTTPStatusError):
+            # Paid backend: differentiate the operationally-important codes
+            # (401 bad key, 402/429 credits/limits) from transient errors.
+            logger.warning(
+                "Firecrawl fetch HTTP %s for %s",
+                exc.response.status_code,
+                url,
+            )
+        else:
+            logger.debug("Firecrawl fetch failed for %s: %s", url, exc)
+    return None
+
+
+async def _try_firecrawl_search(query: str, max_results: int) -> dict | None:
+    """Attempt a Firecrawl search (PAID). Returns result dict or None."""
+    import os
+
+    if not os.environ.get("FIRECRAWL_API_KEY"):
+        return None
+    try:
+        from genesis.providers import firecrawl_client
+
+        raw = await firecrawl_client.search(query, limit=max_results)
+        results = [
+            {
+                "title": str(r.get("title") or ""),
+                "url": str(r.get("url") or ""),
+                "snippet": str(r.get("description") or r.get("snippet") or ""),
+                "score": max(0.0, 1.0 - idx * 0.1),
+            }
+            for idx, r in enumerate(raw[:max_results])
+        ]
+        return {
+            "query": query,
+            "results": results,
+            "backend_used": "firecrawl",
+            "fallback_used": False,
+            "answer": None,
+            "error": None,
+        }
+    except Exception as exc:
+        import httpx as _httpx
+
+        if isinstance(exc, _httpx.HTTPStatusError):
+            logger.warning(
+                "Firecrawl search HTTP %s for %r",
+                exc.response.status_code,
+                query,
+            )
+        else:
+            logger.debug("Firecrawl search failed for %r: %s", query, exc)
+    return None
+
+
 async def _try_tinyfish_search(query: str, max_results: int) -> dict | None:
     """Attempt TinyFish search. Returns result dict or None on failure."""
     import os
@@ -267,8 +351,21 @@ async def _impl_web_fetch(
             "latency_ms": round(latency, 1),
         }
 
+    elif backend == "firecrawl":
+        # PAID escalation (burns account credits) — deliberately NOT in the
+        # auto chain. Use when the free chain dead-ends on hard anti-bot /
+        # JS / paywalled pages. Explicit-only, like tavily/exa on web_search.
+        fc_result = await _try_firecrawl_fetch(url, max_chars)
+        if fc_result:
+            return fc_result
+        return {
+            "url": url,
+            "error": "Firecrawl fetch failed or unavailable (FIRECRAWL_API_KEY set?)",
+            "backend_used": "firecrawl",
+        }
+
     else:
-        return {"error": f"Unknown backend '{backend}'. Use: auto, tinyfish, ladder, scrapling, crawl4ai, httpx"}
+        return {"error": f"Unknown backend '{backend}'. Use: auto, tinyfish, ladder, scrapling, crawl4ai, httpx, firecrawl (paid escalation)"}
 
 
 async def _impl_web_fetch_multi(
@@ -381,6 +478,20 @@ async def _impl_web_search(
             return tf_result
         return {"query": query, "error": "TinyFish search failed or unavailable", "backend_used": "tinyfish"}
 
+    elif backend == "firecrawl":
+        # PAID escalation (burns account credits) — explicit-only, like
+        # tavily/exa; full-page-quality results for hard-to-search targets.
+        fc_result = await _try_firecrawl_search(query, max_results)
+        if fc_result:
+            latency = (time.monotonic() - start) * 1000
+            fc_result["latency_ms"] = round(latency, 1)
+            return fc_result
+        return {
+            "query": query,
+            "error": "Firecrawl search failed or unavailable (FIRECRAWL_API_KEY set?)",
+            "backend_used": "firecrawl",
+        }
+
     elif backend == "tavily":
         try:
             from genesis.providers.tavily_adapter import TavilyAdapter
@@ -468,7 +579,7 @@ async def _impl_web_search(
             return {"query": query, "error": f"Perplexity unavailable: {exc}", "backend_used": "perplexity"}
 
     else:
-        return {"error": f"Unknown backend '{backend}'. Use: auto, tinyfish, searxng, brave, tavily, exa, perplexity"}
+        return {"error": f"Unknown backend '{backend}'. Use: auto, tinyfish, searxng, brave, tavily, exa, perplexity, firecrawl (paid escalation)"}
 
 
 @mcp.tool()
@@ -518,12 +629,13 @@ async def web_search(
     """Search the web and return structured results.
 
     Smart fallback chain: TinyFish (fast, free) → SearXNG (self-hosted) → Brave.
-    Paid backends (tavily, exa, perplexity) available via explicit backend param.
+    Paid backends (tavily, exa, perplexity, firecrawl) via explicit backend param.
 
     Args:
         query: Search query string. Supports site: filters with SearXNG.
         backend: "auto" (TinyFish→SearXNG→Brave), "tinyfish", "searxng",
-                 "brave", "tavily", "exa", or "perplexity".
+                 "brave", "tavily", "exa", "perplexity", or "firecrawl"
+                 (paid escalation — burns Firecrawl credits).
         max_results: Maximum results (default 10, max 20).
 
     Returns dict with: query, results (list of title/url/snippet/score),

--- a/src/genesis/mcp/memory/conversation.py
+++ b/src/genesis/mcp/memory/conversation.py
@@ -48,9 +48,12 @@ async def conversation_history(
         if search:
             if chat_id is not None:
                 return await telegram_messages.search(
-                    memory_mod._db, chat_id, search, limit=limit,
+                    memory_mod._db, chat_id, search,
+                    limit=limit, thread_id=thread_id, before=before,
                 )
-            return await telegram_messages.search_all(memory_mod._db, search, limit=limit)
+            return await telegram_messages.search_all(
+                memory_mod._db, search, limit=limit, before=before,
+            )
         if chat_id is not None:
             return await telegram_messages.query_recent(
                 memory_mod._db, chat_id,

--- a/src/genesis/mcp/memory/conversation.py
+++ b/src/genesis/mcp/memory/conversation.py
@@ -27,8 +27,17 @@ async def conversation_history(
     limit: int = 20,
     search: str | None = None,
     thread_id: int | None = None,
+    chat_id: int | None = None,
+    before: str | None = None,
 ) -> list[dict]:
-    """Retrieve recent conversation messages ("scroll up"). Supports Telegram and CC CLI."""
+    """Retrieve recent conversation messages ("scroll up"). Supports Telegram and CC CLI.
+
+    ``chat_id`` scopes the telegram view to ONE chat — pass your own chat id
+    for a real DM scroll-up (without it, results span ALL chats; that unscoped
+    default is intentional for reflection/cross-chat use). ``before`` (ISO
+    timestamp, exclusive) pages further back: pass the oldest timestamp from
+    the previous page to walk arbitrarily far up the conversation.
+    """
     memory_mod = _memory_mod()
     memory_mod._require_init()
     assert memory_mod._db is not None
@@ -37,16 +46,35 @@ async def conversation_history(
     if channel == "telegram":
         from genesis.db.crud import telegram_messages
         if search:
+            if chat_id is not None:
+                return await telegram_messages.search(
+                    memory_mod._db, chat_id, search, limit=limit,
+                )
             return await telegram_messages.search_all(memory_mod._db, search, limit=limit)
-        if thread_id is not None:
-            rows = await memory_mod._db.execute_fetchall(
-                """SELECT * FROM telegram_messages
-                   WHERE thread_id = ?
-                   ORDER BY timestamp DESC LIMIT ?""",
-                (thread_id, limit),
+        if chat_id is not None:
+            return await telegram_messages.query_recent(
+                memory_mod._db, chat_id,
+                thread_id=thread_id, limit=limit, before=before,
             )
+        if thread_id is not None:
+            if before:
+                rows = await memory_mod._db.execute_fetchall(
+                    """SELECT * FROM telegram_messages
+                       WHERE thread_id = ? AND timestamp < ?
+                       ORDER BY timestamp DESC LIMIT ?""",
+                    (thread_id, before, limit),
+                )
+            else:
+                rows = await memory_mod._db.execute_fetchall(
+                    """SELECT * FROM telegram_messages
+                       WHERE thread_id = ?
+                       ORDER BY timestamp DESC LIMIT ?""",
+                    (thread_id, limit),
+                )
             return [dict(r) for r in reversed(rows)]
-        return await telegram_messages.query_all_recent(memory_mod._db, limit=limit)
+        return await telegram_messages.query_all_recent(
+            memory_mod._db, limit=limit, before=before,
+        )
 
     if channel == "cc":
         jsonl_dir = str(Path.home() / ".claude" / "projects" / cc_project_dir())

--- a/src/genesis/providers/firecrawl_client.py
+++ b/src/genesis/providers/firecrawl_client.py
@@ -1,0 +1,101 @@
+"""Async HTTP client for the Firecrawl API (scrape + search).
+
+PAID escalation backend — never part of the web_fetch/web_search auto chains
+(every call burns account credits). Reachable as ``backend="firecrawl"`` on
+the web tools, which makes it available to Bash-less background sessions
+(the Firecrawl CLI plugin is foreground-Bash-only and there is NO Firecrawl
+MCP server).
+
+Auth: ``Authorization: Bearer $FIRECRAWL_API_KEY``. Lazy singleton httpx
+client for connection pooling (mirrors tinyfish_client).
+
+API endpoints (v2):
+  Scrape: POST https://api.firecrawl.dev/v2/scrape  {url, formats}
+  Search: POST https://api.firecrawl.dev/v2/search  {query, limit}
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_SCRAPE_URL = "https://api.firecrawl.dev/v2/scrape"
+_SEARCH_URL = "https://api.firecrawl.dev/v2/search"
+
+_client: httpx.AsyncClient | None = None
+
+
+def _get_key() -> str:
+    key = os.environ.get("FIRECRAWL_API_KEY", "")
+    if not key:
+        raise ValueError("FIRECRAWL_API_KEY required")
+    return key
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {_get_key()}",
+        "Content-Type": "application/json",
+    }
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        # Scrapes render JS server-side; generous but bounded.
+        _client = httpx.AsyncClient(timeout=60.0)
+    return _client
+
+
+async def scrape(url: str) -> dict[str, Any]:
+    """Scrape one URL to markdown. Returns the API's ``data`` object.
+
+    Raises on HTTP/transport errors; returns ``{}`` when the API reports
+    a non-success payload (caller degrades to its own fallback).
+    """
+    client = _get_client()
+    resp = await client.post(
+        _SCRAPE_URL,
+        headers=_headers(),
+        json={"url": url, "formats": ["markdown"]},
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    if not isinstance(body, dict) or not body.get("success"):
+        logger.debug("Firecrawl scrape non-success for %s: %s", url, body)
+        return {}
+    data = body.get("data")
+    return data if isinstance(data, dict) else {}
+
+
+async def search(query: str, *, limit: int = 10) -> list[dict[str, Any]]:
+    """Search the web. Returns a list of {title, url, description} dicts.
+
+    Raises on HTTP/transport errors; returns ``[]`` on non-success payloads.
+    """
+    client = _get_client()
+    resp = await client.post(
+        _SEARCH_URL,
+        headers=_headers(),
+        json={"query": query, "limit": max(1, min(limit, 20))},
+    )
+    resp.raise_for_status()
+    body = resp.json()
+    if not isinstance(body, dict) or not body.get("success"):
+        logger.debug("Firecrawl search non-success for %r: %s", query, body)
+        return []
+    data = body.get("data")
+    # v2 returns {"web": [...]} (plus optional news/images); older shapes
+    # returned a bare list — accept both defensively.
+    if isinstance(data, dict):
+        results = data.get("web", [])
+    elif isinstance(data, list):
+        results = data
+    else:
+        results = []
+    return [r for r in results if isinstance(r, dict)]

--- a/src/genesis/runtime/init/direct_session.py
+++ b/src/genesis/runtime/init/direct_session.py
@@ -49,10 +49,44 @@ async def _recover_stale_claims(db) -> None:
         logger.error("Direct session stale claim recovery failed", exc_info=True)
 
 
-async def _direct_session_poll(runner: DirectSessionRunner, db) -> None:
-    """Poll direct_session_queue for pending items, dispatch to runner."""
+def request_from_payload(payload: dict):
+    """Build a DirectSessionRequest from a queue payload — the single mapping
+    between the serialized queue/park shape and the live request.
+
+    Every execution-affecting field must round-trip here: an unmapped field
+    silently reverts to its default on resume (a parked campaign once resumed
+    without its strategy doc because system_prompt was dropped). Legacy
+    payloads without the newer keys keep the old defaults.
+    """
     from genesis.cc.direct_session import DirectSessionRequest
     from genesis.cc.types import CCModel, DeliveryMode, EffortLevel
+
+    delivery_mode_raw = payload.get("delivery_mode")
+    tool_exceptions = payload.get("tool_exceptions")
+    return DirectSessionRequest(
+        prompt=payload["prompt"],
+        profile=payload.get("profile", "observe"),
+        model=CCModel(payload.get("model", "sonnet")),
+        effort=EffortLevel(payload.get("effort", "high")),
+        timeout_s=payload.get("timeout_s", 3600),
+        notify=payload.get("notify", True),
+        notify_on_failure_only=payload.get("notify_on_failure_only", False),
+        caller_context=payload.get("caller_context"),
+        roster_model=payload.get("roster_model"),
+        system_prompt=payload.get("system_prompt"),
+        source_tag=payload.get("source_tag") or "direct_session",
+        skills=payload.get("skills"),
+        tool_exceptions=(tuple(tool_exceptions) if tool_exceptions is not None else ()),
+        planning_instruction=payload.get("planning_instruction"),
+        # Origin-delivery (added by the deliver_to_origin dispatch path);
+        # absent on legacy rows → None → derived legacy behavior.
+        origin_session_id=payload.get("origin_session_id"),
+        delivery_mode=(DeliveryMode(delivery_mode_raw) if delivery_mode_raw else None),
+    )
+
+
+async def _direct_session_poll(runner: DirectSessionRunner, db) -> None:
+    """Poll direct_session_queue for pending items, dispatch to runner."""
     from genesis.db.crud import direct_session_queue as dsq
 
     # Crash recovery on boot: reset claims orphaned before a crash/restart.
@@ -83,22 +117,7 @@ async def _direct_session_poll(runner: DirectSessionRunner, db) -> None:
             queue_id = row["id"]
             try:
                 payload = json.loads(row["payload_json"])
-                delivery_mode_raw = payload.get("delivery_mode")
-                request = DirectSessionRequest(
-                    prompt=payload["prompt"],
-                    profile=payload.get("profile", "observe"),
-                    model=CCModel(payload.get("model", "sonnet")),
-                    effort=EffortLevel(payload.get("effort", "high")),
-                    timeout_s=payload.get("timeout_s", 3600),
-                    notify=payload.get("notify", True),
-                    notify_on_failure_only=payload.get("notify_on_failure_only", False),
-                    caller_context=payload.get("caller_context"),
-                    roster_model=payload.get("roster_model"),
-                    # Origin-delivery (added by the deliver_to_origin dispatch path);
-                    # absent on legacy rows → None → derived legacy behavior.
-                    origin_session_id=payload.get("origin_session_id"),
-                    delivery_mode=(DeliveryMode(delivery_mode_raw) if delivery_mode_raw else None),
-                )
+                request = request_from_payload(payload)
                 session_id = await runner.spawn(request)
                 await dsq.mark_dispatched(db, queue_id, session_id)
                 logger.info(

--- a/src/genesis/skills/RESEARCH_EVALUATION.md
+++ b/src/genesis/skills/RESEARCH_EVALUATION.md
@@ -31,11 +31,15 @@ Fetch all sources simultaneously. Never serialize independent lookups.
 When a source is inaccessible, exhaust all autonomous options before involving
 the user:
 
-1. Try the primary tool (WebFetch, scrape, direct access)
-2. Try alternative tools in the toolkit (Firecrawl, other MCP tools)
+1. Try the primary tool (`web_fetch` MCP — its auto chain already escalates
+   TinyFish → Scrapling → Ladder → Crawl4AI → httpx)
+2. Try alternative backends: `web_fetch(url, backend="firecrawl")` (paid
+   escalation — cloud scraping API, reachable from Bash-less background
+   sessions; NOT in the auto chain because it burns credits), or in
+   foreground sessions the `firecrawl` CLI (a Bash plugin, not an MCP server)
 3. Route to a different model/service that CAN access the content type:
    - YouTube video → Gemini API (**MUST use file_data approach** — see below)
-   - Paywalled article → Firecrawl (JS rendering, paywall bypass)
+   - Paywalled article → Firecrawl backend (JS rendering, paywall bypass)
    - Authenticated service → check for specialized MCP tools
 4. Try creative workarounds (transcript APIs, metadata services, cached versions)
 5. Only then ask the user — with specific options, not "what was it about?"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,28 @@ def _isolate_alert_queue(tmp_path):
     mp.undo()
 
 
+# ── Safety: prevent tests from writing to the REAL genesis.db ────────────────
+@pytest.fixture(autouse=True)
+def _isolate_genesis_db_path(tmp_path):
+    """Redirect ``env.genesis_db_path()`` to tmp for ALL tests.
+
+    Same class as ``_isolate_alert_queue``: code paths that resolve the DB
+    lazily (e.g. the settings gate-disable critical-observation write via
+    ``get_raw_db(genesis_db_path())``) would otherwise write REAL rows the
+    live server pages to the owner's Telegram when tests run from the main
+    tree (from a worktree they silently mint a stray ``data/genesis.db``
+    instead — measured 2026-08-19). Tests that need a DB construct their own
+    in-memory connection; none legitimately resolve the install DB.
+    """
+    mp = pytest.MonkeyPatch()
+    mp.setattr(
+        "genesis.env.genesis_db_path",
+        lambda: tmp_path / "isolated-genesis.db",
+    )
+    yield
+    mp.undo()
+
+
 # ── Safety: isolate tests from the install's config overlays ──
 @pytest.fixture(autouse=True)
 def _isolate_user_config_dir(tmp_path):

--- a/tests/test_autonomy/test_autonomous_dispatch.py
+++ b/tests/test_autonomy/test_autonomous_dispatch.py
@@ -799,6 +799,224 @@ async def test_failed_delivery_does_not_advance_reask_window(
     assert context["next_reask_at"] is None
 
 
+def test_load_policy_reask_zero_and_overrides(tmp_path: Path, monkeypatch):
+    """reask_interval_hours: 0 (= never re-ask) must survive loading — the old
+    parser swallowed 0 via `or 24` then clamped via max(1, …). Per-policy
+    overrides map policy_id -> hours, 0 allowed; unlisted policies use the
+    global value. (2026-08-18 user directive: inbox never re-asks; ego /
+    reflection behavior unchanged.)"""
+    monkeypatch.setattr("genesis._config_overlay._user_config_dir", lambda: tmp_path)
+    path = tmp_path / "autonomous_cli_policy.yaml"
+    path.write_text(
+        "reask_interval_hours: 0\n"
+        "reask_overrides:\n"
+        "  inbox_evaluation: 0\n"
+        "  ego_cycle: 12\n",
+    )
+    policy = load_autonomous_cli_policy(path)
+    assert policy.reask_interval_hours == 0
+    assert policy.reask_hours_for("inbox_evaluation") == 0
+    assert policy.reask_hours_for("ego_cycle") == 12
+    # Unlisted policy falls back to the global value.
+    assert policy.reask_hours_for("reflection_deep") == 0
+
+    # Global default without the key stays 24; negative values clamp to 0.
+    path2 = tmp_path / "p2" / "autonomous_cli_policy.yaml"
+    path2.parent.mkdir()
+    path2.write_text("reask_overrides:\n  inbox_evaluation: -5\n")
+    policy2 = load_autonomous_cli_policy(path2)
+    assert policy2.reask_interval_hours == 24
+    assert policy2.reask_hours_for("inbox_evaluation") == 0
+
+
+def test_shipped_config_silences_inbox_reask(tmp_path: Path, monkeypatch):
+    """Lock the SHIPPED config artifact, not just the code paths: a yaml typo
+    in config/autonomous_cli_policy.yaml would silently revert inbox to 24h
+    reminders with every synthetic-yaml test still green."""
+    import genesis.autonomy.cli_policy as cli_policy_mod
+
+    # Keep a developer's real ~/.genesis overlay from masking the shipped file.
+    monkeypatch.setattr("genesis._config_overlay._user_config_dir", lambda: tmp_path)
+    shipped = (
+        Path(cli_policy_mod.__file__).resolve().parents[3]
+        / "config"
+        / "autonomous_cli_policy.yaml"
+    )
+    policy = load_autonomous_cli_policy(shipped)
+    assert policy.reask_hours_for("inbox_evaluation") == 0
+    assert policy.reask_hours_for("sentinel_dispatch") == 24
+    assert policy.manual_approval_required is True
+
+
+@pytest.mark.asyncio
+async def test_positive_override_sets_next_reask_window(runtime, approval_manager):
+    """A nonzero per-policy override must flow through _send_request into the
+    stored next_reask_at window (not just the loader)."""
+    import json as _json
+    from datetime import UTC, datetime
+
+    gate = AutonomousCliApprovalGate(
+        runtime=runtime,
+        approval_manager=approval_manager,
+        policy_loader=lambda: AutonomousCliPolicy(
+            manual_approval_required=True,
+            reask_overrides={"ego_cycle": 12},
+        ),
+    )
+    _, request_id, _ = await gate.ensure_approval(
+        subsystem="ego", policy_id="ego_cycle",
+        action_label="ego cycle",
+        invocation=_invocation(),
+        api_call_site_id="7_ego_cycle", api_error="api down",
+    )
+    row = await approval_manager.get_by_id(request_id)
+    context = _json.loads(row["context"])
+    next_dt = datetime.fromisoformat(context["next_reask_at"])
+    delta_hours = (next_dt - datetime.now(UTC)).total_seconds() / 3600
+    assert 11.5 < delta_hours <= 12.5
+
+
+def _gate_with_inbox_never_reask(runtime, approval_manager):
+    return AutonomousCliApprovalGate(
+        runtime=runtime,
+        approval_manager=approval_manager,
+        policy_loader=lambda: AutonomousCliPolicy(
+            manual_approval_required=True,
+            reask_overrides={"inbox_evaluation": 0},
+        ),
+    )
+
+
+async def _backdate_reask(approval_manager, request_id: str) -> None:
+    """Simulate a legacy pre-deploy row whose next_reask_at already passed."""
+    import json as _json
+
+    row = await approval_manager.get_by_id(request_id)
+    context = _json.loads(row["context"])
+    context["next_reask_at"] = "2020-01-01T00:00:00+00:00"
+    await approval_manager._db.execute(
+        "UPDATE approval_requests SET context = ? WHERE id = ?",
+        (_json.dumps(context), request_id),
+    )
+    await approval_manager._db.commit()
+
+
+@pytest.mark.asyncio
+async def test_reask_zero_no_resend_even_past_legacy_window(
+    runtime, approval_manager,
+):
+    """With reask 0 for a policy, a DELIVERED pending approval is never
+    re-sent — including legacy rows whose stored next_reask_at (written
+    before the reask-0 deploy) is already in the past."""
+    gate = _gate_with_inbox_never_reask(runtime, approval_manager)
+    status, request_id, _ = await gate.ensure_approval(
+        subsystem="inbox", policy_id="inbox_evaluation",
+        action_label="inbox evaluation",
+        invocation=_invocation(),
+        api_call_site_id=None, api_error=None,
+    )
+    assert status == "pending"
+    assert len(runtime.pipeline.sent) == 1
+
+    await _backdate_reask(approval_manager, request_id)
+
+    status2, request_id2, reason2 = await gate.ensure_approval(
+        subsystem="inbox", policy_id="inbox_evaluation",
+        action_label="inbox evaluation",
+        invocation=_invocation(),
+        api_call_site_id=None, api_error=None,
+    )
+    assert status2 == "pending"
+    assert request_id2 == request_id
+    assert len(runtime.pipeline.sent) == 1, (
+        "reask=0 must never send a reminder for a delivered request"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reask_zero_still_retries_failed_delivery(
+    runtime, approval_manager,
+):
+    """reask=0 removes REMINDERS, not delivery-failure recovery: while no
+    successful delivery is on record (delivery_id None), the next tick
+    retries the send for any approval type."""
+    gate = _gate_with_inbox_never_reask(runtime, approval_manager)
+
+    real_submit = runtime.pipeline.submit_raw
+
+    async def _fail_submit(text, request, *, reply_markup=None):
+        runtime.pipeline.sent.append((text, request, reply_markup))
+        return OutreachResult(
+            outreach_id="outreach-failed",
+            status=OutreachStatus.FAILED,
+            channel="telegram",
+            message_content=text,
+            error="simulated delivery failure",
+        )
+
+    runtime.pipeline.submit_raw = _fail_submit
+    status, request_id, _ = await gate.ensure_approval(
+        subsystem="inbox", policy_id="inbox_evaluation",
+        action_label="inbox evaluation",
+        invocation=_invocation(),
+        api_call_site_id=None, api_error=None,
+    )
+    assert status == "pending"
+    assert len(runtime.pipeline.sent) == 1
+
+    # Delivery works again — the retry must fire despite reask=0 …
+    runtime.pipeline.submit_raw = real_submit
+    status2, request_id2, _ = await gate.ensure_approval(
+        subsystem="inbox", policy_id="inbox_evaluation",
+        action_label="inbox evaluation",
+        invocation=_invocation(),
+        api_call_site_id=None, api_error=None,
+    )
+    assert request_id2 == request_id
+    assert len(runtime.pipeline.sent) == 2, (
+        "a never-delivered approval must retry its send even with reask=0"
+    )
+
+    # … and once delivered, it goes silent for good.
+    status3, _, _ = await gate.ensure_approval(
+        subsystem="inbox", policy_id="inbox_evaluation",
+        action_label="inbox evaluation",
+        invocation=_invocation(),
+        api_call_site_id=None, api_error=None,
+    )
+    assert len(runtime.pipeline.sent) == 2
+
+
+@pytest.mark.asyncio
+async def test_reask_override_scoped_per_policy(runtime, approval_manager):
+    """The inbox override must not change other policies: with the global
+    24h interval, an ego approval whose reask window has elapsed still
+    re-sends (current, user-liked behavior preserved)."""
+    gate = _gate_with_inbox_never_reask(runtime, approval_manager)
+    status, request_id, _ = await gate.ensure_approval(
+        subsystem="ego", policy_id="ego_cycle",
+        action_label="ego cycle",
+        invocation=_invocation(),
+        api_call_site_id="7_ego_cycle", api_error="api down",
+    )
+    assert status == "pending"
+    assert len(runtime.pipeline.sent) == 1
+
+    await _backdate_reask(approval_manager, request_id)
+
+    status2, request_id2, reason2 = await gate.ensure_approval(
+        subsystem="ego", policy_id="ego_cycle",
+        action_label="ego cycle",
+        invocation=_invocation(),
+        api_call_site_id="7_ego_cycle", api_error="api down",
+    )
+    assert request_id2 == request_id
+    assert len(runtime.pipeline.sent) == 2, (
+        "non-overridden policies keep the 24h re-ask behavior"
+    )
+    assert "reminder" in reason2
+
+
 @pytest.mark.asyncio
 async def test_successful_delivery_advances_reask_window(
     runtime, approval_gate, approval_manager,

--- a/tests/test_campaigns/test_runner.py
+++ b/tests/test_campaigns/test_runner.py
@@ -423,13 +423,17 @@ class TestParkAwareSessionStatus:
         assert "digest delivered after resume" in result["output_text"]
 
     @pytest.mark.asyncio
-    async def test_resumed_park_without_delivering_session_still_waits(self, db):
+    async def test_resumed_park_without_delivering_row_fails_closed(self, db):
         from genesis.campaigns.runner import _check_session_status
 
-        # Park marked resumed but the re-dispatched session hasn't been
-        # created/finished yet (queued or mid-run) → keep waiting.
+        # A park is marked resumed only AFTER its delivering session is
+        # persisted — a missing row means deleted/corrupted, never in-flight.
+        # Returning None here would skip campaign ticks forever (Codex P2).
         await self._seed_failed_parked_session(db, "resumed")
-        assert await _check_session_status(db, "camp-sess-1") is None
+        result = await _check_session_status(db, "camp-sess-1")
+        assert result is not None
+        assert result["success"] is False
+        assert "delivering session row is missing" in result["output_text"]
 
     @pytest.mark.asyncio
     async def test_terminal_park_reads_as_failure(self, db):
@@ -526,3 +530,31 @@ async def test_missing_park_row_falls_through_to_session_failure(db):
     result = await _check_session_status(db, "camp-sess-2")
     assert result is not None
     assert result["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_failed_park_cancel_keeps_campaign_attached(db, monkeypatch):
+    """Codex P2 lock: when the over-bound park's cancel FAILS transiently,
+    the campaign must stay attached (None = retry next tick) — returning the
+    failure verdict would detach it while the park stays runnable."""
+    from genesis.campaigns.runner import _check_session_status
+
+    helper = TestParkAwareSessionStatus()
+    await helper._seed_failed_parked_session(db, "parked")
+    await db.execute(
+        "UPDATE cc_rate_limit_parks SET created_at='2026-08-01T00:00:00+00:00' "
+        "WHERE id='rlp-test0001'",
+    )
+    await db.commit()
+
+    async def boom(_db, _pid, _status):
+        raise RuntimeError("db lock")
+
+    monkeypatch.setattr(
+        "genesis.db.crud.cc_rate_limit_parks.mark_terminal", boom,
+    )
+    assert await _check_session_status(db, "camp-sess-1") is None
+    row = await (await db.execute(
+        "SELECT status FROM cc_rate_limit_parks WHERE id='rlp-test0001'",
+    )).fetchone()
+    assert str(row["status"]) == "parked", "park must remain owned/attached"

--- a/tests/test_campaigns/test_runner.py
+++ b/tests/test_campaigns/test_runner.py
@@ -496,6 +496,12 @@ async def test_open_park_past_wait_bound_reads_as_failure(db):
     assert result is not None
     assert result["success"] is False
     assert "wait bound exceeded" in result["output_text"]
+    # Codex P2 lock: the abandoned park must be CLOSED — an open park would
+    # let the resume engine run the same campaign action again later.
+    row = await (await db.execute(
+        "SELECT status FROM cc_rate_limit_parks WHERE id='rlp-test0001'",
+    )).fetchone()
+    assert str(row["status"]) == "cancelled"
 
 
 @pytest.mark.asyncio

--- a/tests/test_campaigns/test_runner.py
+++ b/tests/test_campaigns/test_runner.py
@@ -351,3 +351,172 @@ class TestTickWrapperJobHealth:
             rt_cls.instance.return_value = inst
             # tick raised AND record_job_failure raised — still must not propagate.
             await runner._tick_wrapper("camp-1", "campaign_test")
+
+
+class TestParkAwareSessionStatus:
+    """_check_session_status must understand rate-limit parks (2026-08-17
+    incident: a campaign session that got parked was captured as
+    outcome=error while its resume later delivered successfully — the
+    campaign's bookkeeping never learned)."""
+
+    async def _seed_failed_parked_session(self, db, park_status: str):
+        from genesis.db.crud import cc_sessions
+
+        await cc_sessions.create(
+            db, id="camp-sess-1", session_type="background_task",
+            model="sonnet", effort="medium", source_tag="campaign",
+            started_at="2026-08-17T10:00:00+00:00",
+            last_activity_at="2026-08-17T10:00:00+00:00",
+        )
+        await db.execute(
+            "UPDATE cc_sessions SET status='failed', metadata=? WHERE id=?",
+            (json.dumps({"park_id": "rlp-test0001"}), "camp-sess-1"),
+        )
+        await db.execute(
+            """INSERT INTO cc_rate_limit_parks
+               (id, kind, dedup_key, payload_json, status, created_at, updated_at)
+               VALUES (?, 'direct_session', 'dk1', '{}', ?, ?, ?)""",
+            ("rlp-test0001", park_status,
+             "2026-08-17T10:00:00+00:00", "2026-08-17T10:00:00+00:00"),
+        )
+        await db.commit()
+
+    @pytest.mark.asyncio
+    async def test_parked_session_reads_as_still_running(self, db):
+        from genesis.campaigns.runner import _check_session_status
+
+        await self._seed_failed_parked_session(db, "parked")
+        assert await _check_session_status(db, "camp-sess-1") is None
+
+    @pytest.mark.asyncio
+    async def test_resuming_session_reads_as_still_running(self, db):
+        from genesis.campaigns.runner import _check_session_status
+
+        await self._seed_failed_parked_session(db, "resuming")
+        assert await _check_session_status(db, "camp-sess-1") is None
+
+    @pytest.mark.asyncio
+    async def test_resumed_park_captures_delivering_session_result(self, db):
+        from genesis.campaigns.runner import _check_session_status
+        from genesis.db.crud import cc_sessions
+
+        await self._seed_failed_parked_session(db, "resumed")
+        # The re-dispatched session that actually delivered:
+        await cc_sessions.create(
+            db, id="resumed-sess-9", session_type="background_task",
+            model="sonnet", effort="medium", source_tag="campaign",
+            started_at="2026-08-17T22:20:00+00:00",
+            last_activity_at="2026-08-17T22:20:00+00:00",
+        )
+        await db.execute(
+            "UPDATE cc_sessions SET status='completed', cost_usd=0.42, metadata=? "
+            "WHERE id=?",
+            (json.dumps({
+                "caller_context": "rate_limit_resume:rlp-test0001",
+                "output_text": "digest delivered after resume",
+            }), "resumed-sess-9"),
+        )
+        await db.commit()
+        result = await _check_session_status(db, "camp-sess-1")
+        assert result is not None
+        assert result["success"] is True
+        assert "digest delivered after resume" in result["output_text"]
+
+    @pytest.mark.asyncio
+    async def test_resumed_park_without_delivering_session_still_waits(self, db):
+        from genesis.campaigns.runner import _check_session_status
+
+        # Park marked resumed but the re-dispatched session hasn't been
+        # created/finished yet (queued or mid-run) → keep waiting.
+        await self._seed_failed_parked_session(db, "resumed")
+        assert await _check_session_status(db, "camp-sess-1") is None
+
+    @pytest.mark.asyncio
+    async def test_terminal_park_reads_as_failure(self, db):
+        from genesis.campaigns.runner import _check_session_status
+
+        await self._seed_failed_parked_session(db, "needs_user")
+        result = await _check_session_status(db, "camp-sess-1")
+        assert result is not None
+        assert result["success"] is False
+        assert "needs_user" in result["output_text"] or "needs_user" in str(result)
+
+
+@pytest.mark.asyncio
+async def test_store_result_stamps_extra_metadata(db):
+    """The production writer for the park stamp: _store_result(extra_metadata=
+    {"park_id": ...}) must land the key in cc_sessions.metadata — without it
+    the park-aware reaper above has nothing to follow."""
+    from types import SimpleNamespace
+
+    from genesis.cc.direct_session import (
+        DirectSessionRequest,
+        DirectSessionResult,
+        DirectSessionRunner,
+    )
+    from genesis.db.crud import cc_sessions
+
+    await cc_sessions.create(
+        db, id="stamp-sess", session_type="background_task",
+        model="sonnet", effort="medium",
+        started_at="2026-08-17T10:00:00+00:00",
+        last_activity_at="2026-08-17T10:00:00+00:00",
+    )
+    runner = DirectSessionRunner.__new__(DirectSessionRunner)
+    runner._rt = SimpleNamespace(_db=db)
+    await runner._store_result(
+        "stamp-sess",
+        DirectSessionRequest(prompt="p"),
+        DirectSessionResult(
+            session_id="stamp-sess", success=False,
+            error="rate_limited: parked for resume (rlp-x1)", duration_s=1.0,
+        ),
+        extra_metadata={"park_id": "rlp-x1"},
+    )
+    row = await cc_sessions.get_by_id(db, "stamp-sess")
+    assert json.loads(row["metadata"])["park_id"] == "rlp-x1"
+
+
+@pytest.mark.asyncio
+async def test_open_park_past_wait_bound_reads_as_failure(db):
+    """Audit F1: a park stuck open (parked/resuming) past the wait bound must
+    surface as a failure — a stuck resume loop never reaches needs_user, and
+    without the bound the campaign would skip its ticks forever."""
+    from genesis.campaigns.runner import _check_session_status
+
+    helper = TestParkAwareSessionStatus()
+    await helper._seed_failed_parked_session(db, "parked")
+    # Backdate the park's created_at beyond the 7-day bound.
+    await db.execute(
+        "UPDATE cc_rate_limit_parks SET created_at='2026-08-01T00:00:00+00:00' "
+        "WHERE id='rlp-test0001'",
+    )
+    await db.commit()
+    result = await _check_session_status(db, "camp-sess-1")
+    assert result is not None
+    assert result["success"] is False
+    assert "wait bound exceeded" in result["output_text"]
+
+
+@pytest.mark.asyncio
+async def test_missing_park_row_falls_through_to_session_failure(db):
+    """Audit F3a: session failed with a park_id whose park row is GONE —
+    the sentinel fallback must return the session's own failure, never a
+    permanent still-running None (that would be an invisible stall)."""
+    from genesis.campaigns.runner import _check_session_status
+    from genesis.db.crud import cc_sessions
+
+    await cc_sessions.create(
+        db, id="camp-sess-2", session_type="background_task",
+        model="sonnet", effort="medium", source_tag="campaign",
+        started_at="2026-08-17T10:00:00+00:00",
+        last_activity_at="2026-08-17T10:00:00+00:00",
+    )
+    await db.execute(
+        "UPDATE cc_sessions SET status='failed', metadata=? WHERE id=?",
+        (json.dumps({"park_id": "rlp-gone", "output_text": "boom"}), "camp-sess-2"),
+    )
+    await db.commit()
+    result = await _check_session_status(db, "camp-sess-2")
+    assert result is not None
+    assert result["success"] is False

--- a/tests/test_campaigns/test_runner.py
+++ b/tests/test_campaigns/test_runner.py
@@ -558,3 +558,48 @@ async def test_failed_park_cancel_keeps_campaign_attached(db, monkeypatch):
         "SELECT status FROM cc_rate_limit_parks WHERE id='rlp-test0001'",
     )).fetchone()
     assert str(row["status"]) == "parked", "park must remain owned/attached"
+
+
+@pytest.mark.asyncio
+async def test_over_bound_park_with_active_claim_holds(db):
+    """Codex round-3 lock: an over-bound RESUMING park with a FRESH claim may
+    have a live queued delivery — cancelling the row wouldn't stop it, so the
+    campaign must HOLD until the attempt terminates on its own."""
+    from datetime import UTC, datetime
+
+    from genesis.campaigns.runner import _check_session_status
+
+    helper = TestParkAwareSessionStatus()
+    await helper._seed_failed_parked_session(db, "resuming")
+    await db.execute(
+        "UPDATE cc_rate_limit_parks SET created_at='2026-08-01T00:00:00+00:00', "
+        "claimed_at=? WHERE id='rlp-test0001'",
+        (datetime.now(UTC).isoformat(),),
+    )
+    await db.commit()
+    assert await _check_session_status(db, "camp-sess-1") is None
+    row = await (await db.execute(
+        "SELECT status FROM cc_rate_limit_parks WHERE id='rlp-test0001'",
+    )).fetchone()
+    assert str(row["status"]) == "resuming", "actively-claimed park must survive"
+
+
+@pytest.mark.asyncio
+async def test_over_bound_park_with_stale_claim_abandons(db):
+    """A stale claim (crashed attempt, past the 2h reclaim bound) is safe to
+    abandon — nothing live can execute it."""
+    from genesis.campaigns.runner import _check_session_status
+
+    helper = TestParkAwareSessionStatus()
+    await helper._seed_failed_parked_session(db, "resuming")
+    await db.execute(
+        "UPDATE cc_rate_limit_parks SET created_at='2026-08-01T00:00:00+00:00', "
+        "claimed_at='2026-08-01T01:00:00+00:00' WHERE id='rlp-test0001'",
+    )
+    await db.commit()
+    result = await _check_session_status(db, "camp-sess-1")
+    assert result is not None and result["success"] is False
+    row = await (await db.execute(
+        "SELECT status FROM cc_rate_limit_parks WHERE id='rlp-test0001'",
+    )).fetchone()
+    assert str(row["status"]) == "cancelled"

--- a/tests/test_cc/test_login_health.py
+++ b/tests/test_cc/test_login_health.py
@@ -200,3 +200,25 @@ async def test_awareness_check_preserves_alert_on_unreadable_credentials(
         "AND resolved_at IS NULL",
     )
     assert len(rows) == 1, "no-signal must not resolve a standing alert"
+
+
+@pytest.mark.asyncio
+async def test_probe_uses_configured_cc_path(tmp_path, monkeypatch):
+    """Codex P2 lock: the login probe must run the CALLER'S configured
+    executable — a literal PATH `claude` reads permanently ambiguous on
+    installs with a non-PATH binary, so the fallback would never activate."""
+    _write_creds(
+        tmp_path, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)),
+    )
+    seen = []
+
+    async def fake_probe(cc_path="claude", timeout_s=15.0):
+        seen.append(cc_path)
+        return True
+
+    monkeypatch.setattr(login_health, "probe_logged_out", fake_probe)
+    env = await login_health.fallback_env_if_login_dead(
+        token_reader=lambda: "tok-x", cc_path="/opt/custom/claude",
+    )
+    assert env == {"CLAUDE_CODE_OAUTH_TOKEN": "tok-x"}
+    assert seen == ["/opt/custom/claude"]

--- a/tests/test_cc/test_login_health.py
+++ b/tests/test_cc/test_login_health.py
@@ -1,0 +1,175 @@
+"""Tests for container CC login-expiry health + fallback-token injection.
+
+Origin 2026-08-18: the interactive claude.ai OAuth refresh token hard-expires
+(routine access-token refresh does NOT extend it) and NOTHING monitored it —
+zero readers of refreshTokenExpiresAt anywhere. Background sessions ride the
+same credentials, so a lapsed login silently kills autonomy.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from genesis.cc import login_health
+
+
+def _write_creds(tmp_path, *, refresh_expires_ms: int | None) -> None:
+    oauth: dict = {"accessToken": "at", "refreshToken": "rt"}
+    if refresh_expires_ms is not None:
+        oauth["refreshTokenExpiresAt"] = refresh_expires_ms
+    (tmp_path / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": oauth}),
+    )
+
+
+def _ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    login_health.reset_probe_cache()
+    return tmp_path
+
+
+def test_refresh_token_expiry_reads_timestamp(tmp_path):
+    exp = datetime.now(UTC) + timedelta(days=3)
+    _write_creds(tmp_path, refresh_expires_ms=_ms(exp))
+    got = login_health.refresh_token_expiry()
+    assert got is not None
+    assert abs((got - exp).total_seconds()) < 2
+
+
+def test_refresh_token_expiry_no_signal_cases(tmp_path):
+    # Missing file → None (fresh/API-key-only installs stay silent).
+    assert login_health.refresh_token_expiry() is None
+    # Mid-rewrite garbage → None, never "expired".
+    (tmp_path / ".credentials.json").write_text("{not json")
+    assert login_health.refresh_token_expiry() is None
+    # Present but no expiry field → None.
+    _write_creds(tmp_path, refresh_expires_ms=None)
+    assert login_health.refresh_token_expiry() is None
+
+
+@pytest.mark.asyncio
+async def test_no_injection_while_login_alive(tmp_path):
+    """A future refresh expiry must NEVER probe nor inject — a working login
+    is never overridden (credential_bridge honest boundary)."""
+    _write_creds(
+        tmp_path,
+        refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=30)),
+    )
+    probes = []
+
+    async def probe():
+        probes.append(1)
+        return True
+
+    env = await login_health.fallback_env_if_login_dead(
+        probe=probe,
+        token_reader=lambda: "tok-x",
+    )
+    assert env is None
+    assert probes == [], "must not probe while the timestamp says alive"
+
+
+@pytest.mark.asyncio
+async def test_injects_only_on_expired_plus_confirmed_logged_out(tmp_path):
+    _write_creds(
+        tmp_path,
+        refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)),
+    )
+
+    async def confirmed_out():
+        return True
+
+    env = await login_health.fallback_env_if_login_dead(
+        probe=confirmed_out,
+        token_reader=lambda: "tok-fallback",
+    )
+    assert env == {"CLAUDE_CODE_OAUTH_TOKEN": "tok-fallback"}
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_probe_never_injects(tmp_path):
+    """Mirror the guardian rule: never inject on ambiguity."""
+    _write_creds(
+        tmp_path,
+        refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)),
+    )
+
+    async def ambiguous():
+        return False  # not CONFIRMED logged-out
+
+    env = await login_health.fallback_env_if_login_dead(
+        probe=ambiguous,
+        token_reader=lambda: "tok-x",
+    )
+    assert env is None
+
+
+@pytest.mark.asyncio
+async def test_no_token_file_no_injection(tmp_path):
+    _write_creds(
+        tmp_path,
+        refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)),
+    )
+
+    async def confirmed_out():
+        return True
+
+    env = await login_health.fallback_env_if_login_dead(
+        probe=confirmed_out,
+        token_reader=lambda: None,
+    )
+    assert env is None
+
+
+@pytest.mark.asyncio
+async def test_awareness_check_alerts_near_expiry_and_resolves(tmp_path, db):
+    from genesis.awareness.loop import _check_cc_login_expiry
+
+    # Near expiry (2 days) → one critical observation.
+    _write_creds(
+        tmp_path,
+        refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=2)),
+    )
+    await _check_cc_login_expiry(db)
+    rows = await db.execute_fetchall(
+        "SELECT * FROM observations WHERE source='cc_login_monitor' AND resolved_at IS NULL",
+    )
+    assert len(rows) == 1
+    assert "expires" in dict(rows[0])["content"]
+
+    # Duplicate-safe on the next tick.
+    await _check_cc_login_expiry(db)
+    rows = await db.execute_fetchall(
+        "SELECT * FROM observations WHERE source='cc_login_monitor' AND resolved_at IS NULL",
+    )
+    assert len(rows) == 1
+
+    # User re-logs in (expiry far again) → auto-resolves.
+    _write_creds(
+        tmp_path,
+        refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=300)),
+    )
+    await _check_cc_login_expiry(db)
+    rows = await db.execute_fetchall(
+        "SELECT * FROM observations WHERE source='cc_login_monitor' AND resolved_at IS NULL",
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_awareness_check_silent_without_credentials(tmp_path, db):
+    from genesis.awareness.loop import _check_cc_login_expiry
+
+    await _check_cc_login_expiry(db)
+    rows = await db.execute_fetchall(
+        "SELECT * FROM observations WHERE source='cc_login_monitor'",
+    )
+    assert rows == []

--- a/tests/test_cc/test_login_health.py
+++ b/tests/test_cc/test_login_health.py
@@ -173,3 +173,30 @@ async def test_awareness_check_silent_without_credentials(tmp_path, db):
         "SELECT * FROM observations WHERE source='cc_login_monitor'",
     )
     assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_awareness_check_preserves_alert_on_unreadable_credentials(
+    tmp_path, db,
+):
+    """Codex P2 lock: a transient unreadable/mid-rewrite credentials file is
+    NO SIGNAL — it must neither create nor RESOLVE a standing alert."""
+    from genesis.awareness.loop import _check_cc_login_expiry
+
+    _write_creds(
+        tmp_path, refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=2)),
+    )
+    await _check_cc_login_expiry(db)
+    rows = await db.execute_fetchall(
+        "SELECT id FROM observations WHERE source='cc_login_monitor' "
+        "AND resolved_at IS NULL",
+    )
+    assert len(rows) == 1
+
+    (tmp_path / ".credentials.json").write_text("{mid-rewrite garbage")
+    await _check_cc_login_expiry(db)
+    rows = await db.execute_fetchall(
+        "SELECT id FROM observations WHERE source='cc_login_monitor' "
+        "AND resolved_at IS NULL",
+    )
+    assert len(rows) == 1, "no-signal must not resolve a standing alert"

--- a/tests/test_cc/test_rate_limit_park.py
+++ b/tests/test_cc/test_rate_limit_park.py
@@ -246,3 +246,80 @@ class TestRunSessionParkWiring:
             await runner._run_session(req, "sess-fail")
         runner._deliver_result_to_origin.assert_awaited_once()
         assert await parks.count_open(db) == 0
+
+
+# ── Park→resume round-trip preserves the FULL execution shape (2026-08-18) ──
+# The canonical set of DirectSessionRequest fields that must survive a park:
+# missing any one silently changes the resumed session's behavior (measured:
+# a campaign resume ran WITHOUT its strategy doc because system_prompt was
+# dropped at park time).
+_ROUNDTRIP_FIELDS = {
+    "prompt", "profile", "model", "effort", "timeout_s", "roster_model",
+    "system_prompt", "source_tag", "skills", "tool_exceptions",
+    "planning_instruction",
+}
+
+
+async def test_park_payload_preserves_full_request_shape(db):
+    import json as _json
+
+    req = DirectSessionRequest(
+        prompt="campaign tick prompt",
+        profile="campaign",
+        system_prompt="STRATEGY DOC TEXT",
+        source_tag="campaign",
+        skills=["genesis-voice"],
+        tool_exceptions=("WebFetch",),
+        planning_instruction="think first",
+        caller_context="campaign:c1",
+        notify=False,
+    )
+    exc = CCRateLimitError("limit", raw_text="resets in 30m")
+    pid = await rlp.park_direct_session(db, request=req, exc=exc, now=NOW, mode="live")
+    assert pid is not None
+    payload = _json.loads((await parks.get_by_id(db, pid))["payload_json"])
+    missing = _ROUNDTRIP_FIELDS - set(payload)
+    assert not missing, f"park payload dropped execution fields: {missing}"
+    assert payload["system_prompt"] == "STRATEGY DOC TEXT"
+    assert payload["source_tag"] == "campaign"
+    assert payload["skills"] == ["genesis-voice"]
+    assert list(payload["tool_exceptions"]) == ["WebFetch"]
+    assert payload["planning_instruction"] == "think first"
+
+
+async def test_resume_redispatch_and_consumer_preserve_execution_fields(db):
+    import json as _json
+
+    from genesis.cc import rate_limit_resume as rlr
+    from genesis.runtime.init.direct_session import request_from_payload
+
+    req = DirectSessionRequest(
+        prompt="campaign tick prompt",
+        profile="campaign",
+        system_prompt="STRATEGY DOC TEXT",
+        source_tag="campaign",
+        skills=["genesis-voice"],
+        tool_exceptions=("WebFetch",),
+        planning_instruction="think first",
+    )
+    exc = CCRateLimitError("limit", raw_text="resets in 30m")
+    pid = await rlp.park_direct_session(db, request=req, exc=exc, now=NOW, mode="live")
+    park = await parks.get_by_id(db, pid)
+
+    await rlr._redispatch(db, park)
+    row = await db.execute_fetchall(
+        "SELECT payload_json FROM direct_session_queue ORDER BY rowid DESC LIMIT 1",
+    )
+    qpayload = _json.loads(row[0][0])
+    missing = (_ROUNDTRIP_FIELDS - {"roster_model"}) - {
+        k for k, v in qpayload.items() if v is not None
+    }
+    assert not missing, f"queue payload dropped execution fields: {missing}"
+
+    rebuilt = request_from_payload(qpayload)
+    assert rebuilt.system_prompt == "STRATEGY DOC TEXT"
+    assert rebuilt.source_tag == "campaign"
+    assert rebuilt.skills == ["genesis-voice"]
+    assert tuple(rebuilt.tool_exceptions) == ("WebFetch",)
+    assert rebuilt.planning_instruction == "think first"
+    assert rebuilt.profile == "campaign"

--- a/tests/test_cc/test_recovery_context.py
+++ b/tests/test_cc/test_recovery_context.py
@@ -1,0 +1,140 @@
+"""Tests for the DM session-recovery context builder (real scroll-up recap).
+
+Origin: 2026-08-18 — the user returned to a 5-day-old TARS thread and Genesis
+couldn't see "option 3" because the recap truncated each message to its FIRST
+300 chars while the numbered options sat at char ~3,850 of a 4,463-char reply.
+The recap is now byte-budgeted and TAIL-biased (conclusions/option lists live
+at the end of long analytical replies).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.cc.conversation import ConversationLoop
+from genesis.db.crud.telegram_messages import store
+from genesis.db.schema import create_all_tables
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+def _loop(db) -> ConversationLoop:
+    handler = ConversationLoop.__new__(ConversationLoop)
+    handler._db = db
+    return handler
+
+
+LONG_REPLY = (
+    "Here is the full TARS breakdown with a lot of detail. "
+    + ("Analysis paragraph. " * 180)  # ~3,600 chars of body
+    + "\nThree real options:\n"
+    "1. Free prompt pack\n"
+    "2. Paid community\n"
+    "3. Reverse-build it OPTION-THREE-MARKER"
+)
+
+
+@pytest.mark.asyncio
+async def test_recovery_context_keeps_tail_of_long_reply(db):
+    """The END of a long prior reply (where option lists / conclusions live)
+    must survive into the recap."""
+    await store(
+        db,
+        chat_id=555000111,
+        message_id=1,
+        sender="user",
+        content="Fetch this video about TARS",
+        timestamp="2026-08-13T04:03:00",
+    )
+    await store(
+        db,
+        chat_id=555000111,
+        message_id=2,
+        sender="genesis",
+        content=LONG_REPLY,
+        timestamp="2026-08-13T04:15:00",
+        direction="outbound",
+    )
+    ctx = await _loop(db)._build_recovery_context("tg-555000111", "telegram", None)
+    assert "OPTION-THREE-MARKER" in ctx, "tail of a long reply must survive the recap truncation"
+
+
+@pytest.mark.asyncio
+async def test_recovery_context_respects_total_budget(db):
+    """Total recap size stays within the byte budget while the NEWEST
+    messages are always represented."""
+    for i in range(30):
+        await store(
+            db,
+            chat_id=100,
+            message_id=i,
+            sender="user",
+            content=f"msg-{i:02d} " + ("filler " * 300),  # ~2,100 chars each
+            timestamp=f"2026-08-13T04:{i:02d}:00",
+        )
+    loop = _loop(db)
+    ctx = await loop._build_recovery_context("tg-100", "telegram", None)
+    budget = ConversationLoop.RECOVERY_CONTEXT_BUDGET
+    assert len(ctx) <= budget + 500, f"recap blew the budget: {len(ctx)}"
+    assert "msg-29" in ctx, "the newest message must always be present"
+
+
+@pytest.mark.asyncio
+async def test_recovery_context_empty_cases(db):
+    """No messages → empty string; non-telegram user ids → empty string."""
+    loop = _loop(db)
+    assert await loop._build_recovery_context("tg-999", "telegram", None) == ""
+    assert await loop._build_recovery_context("dashboard-1", "dashboard", None) == ""
+
+
+def test_conversation_identity_block():
+    """Fresh telegram sessions get an identity block naming their own chat_id
+    and the scoped scroll-up call — without it, "scoped to this chat" is
+    unimplementable (the model has no way to know its chat id)."""
+    block = ConversationLoop._conversation_identity_block(
+        "tg-555000111", "telegram", None,
+    )
+    assert "555000111" in block
+    assert "conversation_history" in block
+    assert "chat_id=555000111" in block
+    # Non-telegram and malformed ids produce no block.
+    assert ConversationLoop._conversation_identity_block(
+        "dashboard-1", "dashboard", None,
+    ) == ""
+    assert ConversationLoop._conversation_identity_block(
+        "tg-notanumber", "telegram", None,
+    ) == ""
+
+
+@pytest.mark.asyncio
+async def test_recovery_context_tail_keeps_oversized_newest_message(db):
+    """A single newest message LARGER than the whole budget must still be
+    represented — by its TAIL (audit F2: the truncation branch itself must be
+    exercised; a head-keep regression must fail here)."""
+    await store(
+        db, chat_id=100, message_id=1, sender="genesis",
+        content=("HEAD-MARKER " + "x" * 8000 + " END-MARKER"),
+        timestamp="2026-08-13T04:00:00", direction="outbound",
+    )
+    ctx = await _loop(db)._build_recovery_context("tg-100", "telegram", None)
+    assert "END-MARKER" in ctx, "oversized newest message must keep its tail"
+    assert "HEAD-MARKER" not in ctx, "head-biased truncation regression"
+    assert "…" in ctx, "truncation must be marked"
+
+
+def test_conversation_identity_block_group_chat_id():
+    """Group/topic chats have NEGATIVE chat ids and must produce a correct
+    block (audit finding: sender-id conflation would name the wrong chat)."""
+    block = ConversationLoop._conversation_identity_block(
+        "-100999888777", "telegram", "109",
+    )
+    assert "chat_id=-100999888777" in block
+    assert "thread_id=109" in block

--- a/tests/test_cc/test_recovery_context.py
+++ b/tests/test_cc/test_recovery_context.py
@@ -138,3 +138,16 @@ def test_conversation_identity_block_group_chat_id():
     )
     assert "chat_id=-100999888777" in block
     assert "thread_id=109" in block
+
+
+def test_conversation_identity_block_thread_scoped_suggestion():
+    """Codex P2 lock: in a forum-topic session the SUGGESTED scroll-up call
+    must be thread-scoped, or following it pulls unrelated topics."""
+    block = ConversationLoop._conversation_identity_block(
+        "-100999888777", "telegram", "109",
+    )
+    assert "chat_id=-100999888777, thread_id=109, limit=50" in block
+    dm_block = ConversationLoop._conversation_identity_block(
+        "555000111", "telegram", None,
+    )
+    assert "chat_id=555000111, limit=50" in dm_block

--- a/tests/test_dashboard/test_api.py
+++ b/tests/test_dashboard/test_api.py
@@ -551,3 +551,38 @@ def test_routing_config_reload_endpoint(client):
     load_config.assert_called_once()
     mock_router.reload_config.assert_called_once_with(fake_config)
     mock_router.scan_dlq_orphans_after_reload.assert_awaited_once()
+
+
+def test_settings_put_gate_disable_requires_confirmation(client, tmp_path):
+    """Dashboard PUT disabling the mandatory approval gate without the
+    confirm flag must 409 and write NOTHING; with the flag it applies
+    (2026-08-18: an unconfirmed PUT used to flip it silently)."""
+    with (
+        patch("genesis.mcp.health.settings._CONFIG_DIR", tmp_path),
+        patch("genesis.mcp.health.settings._USER_CONFIG_DIR", tmp_path),
+        patch(
+            "genesis.dashboard.routes.settings._notify_gate_disabled",
+            new=AsyncMock(),
+        ) as notify,
+    ):
+        resp = client.put(
+            "/api/genesis/settings/autonomous_cli_policy",
+            json={"manual_approval_required": False},
+        )
+        assert resp.status_code == 409
+        assert "confirm_disable_approval_gate" in resp.get_json()["details"]
+        assert not (tmp_path / "autonomous_cli_policy.local.yaml").exists()
+        notify.assert_not_awaited()
+
+        resp2 = client.put(
+            "/api/genesis/settings/autonomous_cli_policy",
+            json={
+                "manual_approval_required": False,
+                "confirm_disable_approval_gate": True,
+            },
+        )
+        assert resp2.status_code == 200
+        written = (tmp_path / "autonomous_cli_policy.local.yaml").read_text()
+        assert "manual_approval_required: false" in written
+        assert written.startswith("# set-by: user via dashboard PUT")
+        notify.assert_awaited_once()

--- a/tests/test_dashboard/test_api.py
+++ b/tests/test_dashboard/test_api.py
@@ -586,3 +586,44 @@ def test_settings_put_gate_disable_requires_confirmation(client, tmp_path):
         assert "manual_approval_required: false" in written
         assert written.startswith("# set-by: user via dashboard PUT")
         notify.assert_awaited_once()
+
+
+def test_surplus_put_actually_persists_merge(client, tmp_path):
+    """Deep-review SHOULD-FIX lock (pre-existing bug): the surplus PUT
+    discarded _deep_merge's return (it is PURE) and wrote the UNMERGED
+    overlay back while returning ok=True — user changes silently vanished."""
+    with (
+        patch("genesis.mcp.health.settings._CONFIG_DIR", tmp_path),
+        patch("genesis.mcp.health.settings._USER_CONFIG_DIR", tmp_path),
+    ):
+        resp = client.put(
+            "/api/genesis/surplus/config",
+            json={"enabled": True},
+        )
+        if resp.status_code == 404:
+            import pytest as _pytest
+
+            _pytest.skip("surplus config route not registered in this blueprint")
+        assert resp.status_code == 200
+        import yaml as _yaml
+
+        written = _yaml.safe_load((tmp_path / "surplus.local.yaml").read_text())
+        assert written.get("enabled") is True
+
+
+def test_settings_put_string_false_does_not_confirm_gate_disable(client, tmp_path):
+    """Security lock: bool('false') is True — a stringly-typed confirm flag
+    must NOT satisfy the gate-disable confirmation."""
+    with (
+        patch("genesis.mcp.health.settings._CONFIG_DIR", tmp_path),
+        patch("genesis.mcp.health.settings._USER_CONFIG_DIR", tmp_path),
+    ):
+        resp = client.put(
+            "/api/genesis/settings/autonomous_cli_policy",
+            json={
+                "manual_approval_required": False,
+                "confirm_disable_approval_gate": "false",
+            },
+        )
+        assert resp.status_code == 409
+        assert not (tmp_path / "autonomous_cli_policy.local.yaml").exists()

--- a/tests/test_inbox/test_crud.py
+++ b/tests/test_inbox/test_crud.py
@@ -155,6 +155,92 @@ async def test_get_all_known_reused_row_wins_over_older_completed(db):
 
 
 @pytest.mark.asyncio
+async def test_get_all_known_exhausted_failed_does_not_clobber_newer_completed(db):
+    """THE 2026-08 approval-storm seed (measured live): a permanently-failed row
+    (retry_count >= max) must NOT overwrite the hash of a NEWER completed row
+    for the same file.
+
+    Live specimen: Genesis.md had one exhausted row (hash 1e29dba0, created
+    08-14) and five newer completed rows (hash e77f117f == on-disk). The old
+    two-pass implementation let the exhausted row clobber the completed hash
+    unconditionally -> known != disk -> phantom "modified" every 30-min scan ->
+    the monitor cancelled + re-sent the pending approval every tick for days.
+    """
+    await inbox_items.create(
+        db, id="exhausted", file_path="/inbox/a.md", content_hash="POISON",
+        created_at="2026-08-14T04:00:00+00:00",
+    )
+    await inbox_items.update_status(
+        db, "exhausted", status="failed",
+        error_message="partial_url_failure", retry_count=3,
+    )
+    await inbox_items.create(
+        db, id="done", file_path="/inbox/a.md", content_hash="DISK",
+        status="completed", created_at="2026-08-18T17:00:00+00:00",
+    )
+    known = await inbox_items.get_all_known(db)
+    assert known["/inbox/a.md"] == "DISK"
+
+
+@pytest.mark.asyncio
+async def test_get_all_known_exhausted_failed_newest_still_blocks(db):
+    """When the exhausted-failed row IS the newest row for the file, it still
+    blocks reprocessing with its hash (existing contract, must survive the
+    newest-row-wins rewrite)."""
+    await inbox_items.create(
+        db, id="done", file_path="/inbox/a.md", content_hash="OLDDONE",
+        status="completed", created_at="2026-08-10T00:00:00+00:00",
+    )
+    await inbox_items.create(
+        db, id="exhausted", file_path="/inbox/a.md", content_hash="LASTFAIL",
+        created_at="2026-08-14T00:00:00+00:00",
+    )
+    await inbox_items.update_status(
+        db, "exhausted", status="failed", error_message="boom", retry_count=3,
+    )
+    known = await inbox_items.get_all_known(db)
+    assert known["/inbox/a.md"] == "LASTFAIL"
+
+
+@pytest.mark.asyncio
+async def test_get_all_known_completed_null_response_path_blocks(db):
+    """Completed rows with NULL response_path (empty-delta completing rows —
+    the exact shape the storm minted every tick) block with their hash; only
+    completed rows whose response file EXISTED and was DELETED re-open the
+    file for evaluation (user-initiated re-eval contract)."""
+    await inbox_items.create(
+        db, id="nullresp", file_path="/inbox/a.md", content_hash="H",
+        status="completed", created_at="2026-08-18T00:00:00+00:00",
+    )
+    known = await inbox_items.get_all_known(db)
+    assert known["/inbox/a.md"] == "H"
+
+
+@pytest.mark.asyncio
+async def test_get_all_known_retriable_failed_invisible_even_when_newest(db):
+    """A retriable-failed row (retry_count < max) is INVISIBLE to the
+    newest-row scan even when it is the newest row: terminal/active siblings
+    decide the known hash (per-file), and the retry lane owns re-queueing.
+    Without this, a newest retriable-failed row would erase the file from
+    'known', re-classify it as NEW, and re-evaluate FULL content (regression
+    the 2026-08-18 red-team flagged as F1)."""
+    await inbox_items.create(
+        db, id="done", file_path="/inbox/a.md", content_hash="DONE",
+        status="completed", created_at="2026-08-10T00:00:00+00:00",
+    )
+    await inbox_items.create(
+        db, id="retriable", file_path="/inbox/a.md", content_hash="FAILH",
+        created_at="2026-08-14T00:00:00+00:00",
+    )
+    await inbox_items.update_status(
+        db, "retriable", status="failed", error_message="rate limit",
+        retry_count=1,
+    )
+    known = await inbox_items.get_all_known(db)
+    assert known["/inbox/a.md"] == "DONE"
+
+
+@pytest.mark.asyncio
 async def test_update_status(db):
     await inbox_items.create(
         db, id="i1", file_path="/inbox/a.md",

--- a/tests/test_inbox/test_drop_dispatch.py
+++ b/tests/test_inbox/test_drop_dispatch.py
@@ -806,22 +806,46 @@ async def test_watch_bookmark_route_to_tabled_lane(
 
 
 @pytest.mark.asyncio
-async def test_consume_approval_returns_bool(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path):
+async def test_consume_approval_tri_state(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path, caplog,
+):
+    """_consume_approval distinguishes the three outcomes (F5, red-team
+    2026-08-18): consumed-now, already-consumed (sibling drop this pass OR
+    cross-tick crash recovery — both proceed; the row claim is the at-most-once
+    gate), and transient FAILURE (retried once, then ERROR — a stale
+    approved-unconsumed request is rideable by a later NEW drop)."""
+    import logging
+
     mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
-    # No dispatcher wired → nothing to consume → True (proceed).
-    assert await mon._consume_approval("req") is True
-    # mark_consumed returns False (already consumed) → False.
+    # No dispatcher wired → nothing to consume → "no_gate" (proceed).
+    assert await mon._consume_approval("req") == "no_gate"
+    # First consume wins → "consumed".
+    mon._autonomous_dispatcher = SimpleNamespace(
+        approval_gate=SimpleNamespace(mark_consumed=AsyncMock(return_value=True)),
+    )
+    assert await mon._consume_approval("req") == "consumed"
+    # mark_consumed returns False → "already_consumed" (normal multi-drop
+    # fanout / crash recovery — NOT an error).
     mon._autonomous_dispatcher = SimpleNamespace(
         approval_gate=SimpleNamespace(mark_consumed=AsyncMock(return_value=False)),
     )
-    assert await mon._consume_approval("req") is False
-    # mark_consumed raises (transient) → False (not swallowed silently).
+    assert await mon._consume_approval("req") == "already_consumed"
+    # Transient raise then success → retried once → "consumed".
+    flaky = AsyncMock(side_effect=[RuntimeError("db lock"), True])
     mon._autonomous_dispatcher = SimpleNamespace(
-        approval_gate=SimpleNamespace(
-            mark_consumed=AsyncMock(side_effect=RuntimeError("db lock")),
-        ),
+        approval_gate=SimpleNamespace(mark_consumed=flaky),
     )
-    assert await mon._consume_approval("req") is False
+    assert await mon._consume_approval("req") == "consumed"
+    assert flaky.await_count == 2
+    # Persistent failure → "failed" + ERROR (loud: rideable-approval risk).
+    with caplog.at_level(logging.ERROR):
+        mon._autonomous_dispatcher = SimpleNamespace(
+            approval_gate=SimpleNamespace(
+                mark_consumed=AsyncMock(side_effect=RuntimeError("db lock")),
+            ),
+        )
+        assert await mon._consume_approval("req") == "failed"
+    assert any("rideable" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -905,17 +929,17 @@ def _stateful_dispatcher(clock):
 
 
 @pytest.mark.asyncio
-async def test_refresh_folds_parked_files_no_oscillation(
+async def test_edit_while_pending_parks_on_same_request_no_churn(
     db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
 ):
-    """Two files parked on one approval + one file edited → the refresh must
-    cancel ONCE and re-park BOTH files on the fresh request.
+    """Idempotent-approval semantics (2026-08-18 user directive): an inbox
+    approval covers everything outstanding at approval time, so new/changed
+    content while the request is pending PARKS ONTO THE SAME REQUEST — no
+    cancel, no fresh request, no new Telegram message, ever.
 
-    Without folding the parked files into the refresh batch, the
-    not-refreshed file's rows are invalidated but never re-dispatched, so it
-    re-surfaces as phantom-"new" next scan and the two files leapfrog:
-    cancel + recreate every scan (a Telegram message each time) with NO disk
-    change — the 30-minute approval nag.
+    (Replaces the old cancel-once-and-refold behavior, which still sent one
+    new message per genuine edit and — via the phantom-modified storm seed —
+    one every 30 minutes when the known-hash map went stale.)
     """
     mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
     disp, gate = _stateful_dispatcher(mon._clock)
@@ -934,22 +958,75 @@ async def test_refresh_folds_parked_files_no_oscillation(
     # The user edits B while the approval is pending.
     file_b.write_text("https://example.com/b9")
 
-    # Scan 2: ONE cancel, and the refreshed request covers BOTH files.
+    # Scan 2: NO cancel, NO new request — B's old parked rows are superseded
+    # and its fresh delta parks on the SAME request; A stays parked untouched.
     await mon.check_once()
-    assert gate.cancel_calls == ["req-1"]
+    assert gate.cancel_calls == [], "edit-while-pending must not cancel"
+    assert gate.request_count == 1, "edit-while-pending must not re-request"
     parked = await inbox_items.get_awaiting_approval(db)
-    assert {p["file_path"] for p in parked} == {str(file_a), str(file_b)}, (
-        "parked files must fold into the refresh batch"
+    assert {p["file_path"] for p in parked} == {str(file_a), str(file_b)}
+    b_parked = [p for p in parked if p["file_path"] == str(file_b)]
+    # Supersession lock (F2, mutation-proven gap): exactly ONE live parked row
+    # for the edited file — a surviving pre-edit row would double-evaluate on
+    # approve.
+    assert len(b_parked) == 1, (
+        f"edited file must have exactly one parked row, got {len(b_parked)}"
     )
-    assert gate.request_count == 2
+    assert all("req-1" in (p["error_message"] or "") for p in parked)
+    assert "b9" in (b_parked[0]["batch_items"] or ""), (
+        "the re-parked drop must carry the recomputed delta"
+    )
 
-    # Scans 3-4, disk unchanged: detection stays quiet — no cancel, no new
-    # request, no dispatch. (Unfixed: A and B alternate forever.)
+    # Scans 3-4, disk unchanged: fully quiet.
     await mon.check_once()
     await mon.check_once()
-    assert gate.cancel_calls == ["req-1"], "approval churned on unchanged disk"
-    assert gate.request_count == 2
+    assert gate.cancel_calls == []
+    assert gate.request_count == 1
     assert mock_invoker.run.call_count == 0
+
+    # Approve once → everything outstanding dispatches — the fresh delta only,
+    # never the superseded pre-edit one.
+    gate.approve()
+    await mon.check_once()
+    assert mock_invoker.run.call_count >= 1
+    prompts = " ".join(c.args[0].prompt for c in mock_invoker.run.call_args_list)
+    assert "https://example.com/b9" in prompts
+    assert "https://example.com/b0" not in prompts, (
+        "superseded pre-edit delta must not dispatch"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sole_file_edit_while_pending_no_cancel_no_new_request(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """F3 lock: the SINGLE-file edit-while-pending case. If the resume pass
+    ever goes back to invalidating a still-pending changed row, this file's
+    live-row count hits 0 → the orphan guard cancels → a fresh request (one
+    Telegram message per edit — the residual storm seed). With hold+supersede
+    the request survives and the fresh delta re-parks on it."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    disp, gate = _stateful_dispatcher(mon._clock)
+    mon._autonomous_dispatcher = disp
+    file_a = inbox_dir / "Genesis.md"
+    file_a.write_text(_urls(1))  # a0
+
+    await mon.check_once()  # parks on req-1
+    assert gate.request_count == 1
+
+    file_a.write_text(_urls(2))  # edit while pending: a0 + a1
+
+    await mon.check_once()
+    assert gate.cancel_calls == [], "sole-file edit must not cancel the request"
+    assert gate.request_count == 1, "sole-file edit must not mint a new request"
+    parked = await inbox_items.get_awaiting_approval(db)
+    assert len(parked) == 1
+    assert "req-1" in (parked[0]["error_message"] or "")
+    assert "a1" in (parked[0]["batch_items"] or ""), "fresh delta must be parked"
+
+    await mon.check_once()  # unchanged disk: quiet
+    assert gate.request_count == 1
+    assert gate.cancel_calls == []
 
 
 @pytest.mark.asyncio
@@ -975,24 +1052,25 @@ async def test_refresh_does_not_resurrect_deleted_parked_file(
     file_a.unlink()
     file_b.write_text("https://example.com/b9")
 
-    await mon.check_once()  # refresh: only B re-parks
+    await mon.check_once()  # A's rows invalidated (vanished); B re-parks on req-1
     parked = await inbox_items.get_awaiting_approval(db)
     assert {p["file_path"] for p in parked} == {str(file_b)}
 
-    await mon.check_once()  # deleted file stays gone; no churn
+    await mon.check_once()  # deleted file stays gone; no churn, no new request
     parked = await inbox_items.get_awaiting_approval(db)
     assert {p["file_path"] for p in parked} == {str(file_b)}
-    assert gate.request_count == 2
+    assert gate.request_count == 1, "no fresh request may be minted"
+    assert gate.cancel_calls == [], "B still live — the request must survive"
 
 
 @pytest.mark.asyncio
-async def test_fold_skips_parked_path_missing_from_disk(
+async def test_detect_leaves_parked_rows_alone_no_cancel(
     db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
 ):
-    """Isolates the fold's exists() guard in _phase_detect_changes: a parked
-    row whose file is gone by the time the refresh folds (deleted mid-cycle,
-    after the resume phase's own vanished-file check already ran) must be
-    invalidated but NOT folded into the refresh batch."""
+    """_phase_detect_changes with a pending approval + new content must NOT
+    cancel the request nor touch parked rows — it returns the new files for
+    normal record creation, and the resume phase alone owns vanished-file
+    invalidation. (The old cancel+invalidate+fold block is gone.)"""
     mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
     disp, gate = _stateful_dispatcher(mon._clock)
     mon._autonomous_dispatcher = disp
@@ -1010,7 +1088,7 @@ async def test_fold_skips_parked_path_missing_from_disk(
         error_message=f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-1",
     )
     live = inbox_dir / "Live.md"
-    live.write_text("https://example.com/n0")  # triggers the refresh
+    live.write_text("https://example.com/n0")
 
     new_files, modified_files = await mon._phase_detect_changes(
         inbox_dir, resumed_paths=set(),
@@ -1018,19 +1096,22 @@ async def test_fold_skips_parked_path_missing_from_disk(
 
     returned = {str(p) for p in [*new_files, *modified_files]}
     assert str(live) in returned
-    assert str(ghost) not in returned, "vanished parked file was folded"
+    assert str(ghost) not in returned
     row = await inbox_items.get_by_id(db, "row-g")
-    assert row["status"] == "failed"  # still invalidated, just not re-dispatched
-    assert gate.cancel_calls == ["req-1"]
+    assert row["status"] == "processing", (
+        "detect must not invalidate parked rows (resume owns vanish checks)"
+    )
+    assert (row["error_message"] or "").startswith("awaiting_approval:")
+    assert gate.cancel_calls == [], "detect must never cancel a live request"
 
 
 @pytest.mark.asyncio
-async def test_folded_file_reevaluates_only_unprocessed_delta(
+async def test_new_file_while_pending_joins_request_delta_only(
     db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
 ):
-    """A folded parked file must go through the same delta batching as any
-    modified file: URLs already evaluated in a prior approved run are NOT
-    re-evaluated when the file is folded into a refresh batch."""
+    """A new file arriving while a request is pending parks on the SAME
+    request (no cancel, no new message), and delta batching still applies:
+    URLs already evaluated in a prior approved run are NOT re-evaluated."""
     mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
     disp, gate = _stateful_dispatcher(mon._clock)
     mon._autonomous_dispatcher = disp
@@ -1047,15 +1128,17 @@ async def test_folded_file_reevaluates_only_unprocessed_delta(
     await mon.check_once()
     assert gate.request_count == 2
 
-    # A second file arrives while req-2 is pending -> refresh folds A.
+    # A second file arrives while req-2 is pending -> joins req-2. No cancel.
     file_b = inbox_dir / "Capabilities.md"
     file_b.write_text("https://example.com/b0")
     await mon.check_once()
-    assert gate.cancel_calls == ["req-2"]
+    assert gate.cancel_calls == []
+    assert gate.request_count == 2, "new file must join the pending request"
     parked = await inbox_items.get_awaiting_approval(db)
     assert {p["file_path"] for p in parked} == {str(file_a), str(file_b)}
+    assert all("req-2" in (p["error_message"] or "") for p in parked)
 
-    # Approve the merged request: only the delta + the new file are evaluated.
+    # Approve once: only the delta + the new file are evaluated.
     gate.approve()
     await mon.check_once()
     prompts = " ".join(
@@ -1065,6 +1148,38 @@ async def test_folded_file_reevaluates_only_unprocessed_delta(
     assert "https://example.com/a3" in prompts
     assert "https://example.com/b0" in prompts
     assert "https://example.com/a0" not in prompts, "re-evaluated processed URL"
+
+
+@pytest.mark.asyncio
+async def test_content_removed_while_pending_orphans_quietly(
+    db, inbox_dir, mock_invoker, mock_session_manager, tmp_path,
+):
+    """If the user empties a parked file while its approval is pending, the
+    parked rows are superseded, the baseline advances, and the now-orphaned
+    request is cancelled by the orphan guard — with NO replacement request
+    and NO dispatch (nothing left to evaluate)."""
+    mon = _monitor(db, inbox_dir, mock_invoker, mock_session_manager, tmp_path)
+    disp, gate = _stateful_dispatcher(mon._clock)
+    mon._autonomous_dispatcher = disp
+    file_a = inbox_dir / "Genesis.md"
+    file_a.write_text(_urls(1))
+
+    await mon.check_once()  # parks on req-1
+    assert gate.request_count == 1
+
+    file_a.write_text("")   # user removes everything
+
+    await mon.check_once()  # superseded + hash advanced (+ orphan may cancel)
+    await mon.check_once()  # orphan guard has certainly run by now
+    assert gate.pending_id is None, "orphaned request must be cancelled"
+    assert gate.cancel_calls == ["req-1"]
+    assert gate.request_count == 1, "no replacement request may be minted"
+    parked = await inbox_items.get_awaiting_approval(db)
+    assert parked == []
+    assert mock_invoker.run.call_count == 0
+
+    await mon.check_once()  # and it stays quiet
+    assert gate.request_count == 1
 
 
 # ── Build-lane hook end-to-end (real monitor -> handle_eval -> greenlight) ──

--- a/tests/test_inbox/test_monitor.py
+++ b/tests/test_inbox/test_monitor.py
@@ -1626,22 +1626,22 @@ async def test_precheck_refreshes_when_new_files_added_while_blocked(
 async def test_refresh_path_with_live_rows_folds_unchanged_sibling(
     monitor, inbox_dir, mock_invoker, db,
 ):
-    """The genuine refresh path (driver B): when an approval with LIVE parked
-    rows is pending and genuinely-new content arrives, the orphan-guard HOLDS
-    (live rows exist) and falls through to the refresh path — which cancels the
-    held approval, folds the unchanged parked sibling into the batch, and
-    re-parks BOTH files under the fresh approval. This proves the orphan-guard
-    does not short-circuit the fold, and that an unchanged sibling is not
-    stranded (the leapfrog the nag was made of)."""
+    """Park-onto-pending (2026-08-18 idempotent-approval semantics): when an
+    approval with LIVE parked rows is pending and genuinely-new content
+    arrives, the orphan-guard HOLDS (live rows exist), the request is NEVER
+    cancelled, the unchanged parked sibling stays parked untouched on the
+    SAME request, and the new file's drop parks alongside it (the gate's
+    stable site key re-attaches it — mocked here as the same decision id).
+    No new approval message is ever produced for content changes."""
     pending_site_row = {
         "id": "req-a",
         "status": "pending",
         "action_type": "autonomous_cli_fallback",
         "_context": {"subsystem": "inbox", "policy_id": "inbox_evaluation"},
     }
-    # A fresh approval id is minted after the refresh-cancel.
+    # The gate's stable key re-attaches new drops to the SAME pending request.
     decision = AutonomousDispatchDecision(
-        mode="blocked", reason="approval requested", approval_request_id="req-b",
+        mode="blocked", reason="approval pending", approval_request_id="req-a",
     )
     monitor._autonomous_dispatcher = _make_wired_dispatcher(
         decision=decision,
@@ -1656,12 +1656,11 @@ async def test_refresh_path_with_live_rows_folds_unchanged_sibling(
     await monitor.check_once()
 
     disp = monitor._autonomous_dispatcher
-    # The held approval was cancelled by the REFRESH path (not left uncancelled),
-    # exactly once, for req-a.
-    disp.approval_gate.approval_manager.cancel.assert_called_once_with("req-a")
+    # The held approval is NEVER cancelled by new content.
+    disp.approval_gate.approval_manager.cancel.assert_not_called()
 
-    # Both the new file AND the folded unchanged sibling are re-parked under the
-    # fresh approval (req-b) — nothing stranded.
+    # Both files are parked on the SAME request — the sibling's original row
+    # untouched, the new file's drop alongside it.
     from genesis.db.crud import inbox_items
 
     rows = [
@@ -1670,16 +1669,18 @@ async def test_refresh_path_with_live_rows_folds_unchanged_sibling(
             await db.execute(
                 "SELECT file_path, status, error_message FROM inbox_items "
                 "WHERE status='processing' AND error_message = ?",
-                (f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-b",),
+                (f"{inbox_items.AWAITING_APPROVAL_PREFIX}req-a",),
             )
         ).fetchall()
     ]
-    reparked = {Path(r["file_path"]).name for r in rows}
-    assert reparked == {"held.md", "arrived.md"}, reparked
+    parked = {Path(r["file_path"]).name for r in rows}
+    assert parked == {"held.md", "arrived.md"}, parked
 
-    # The original parked row for the sibling was superseded (failed), not left live.
+    # The sibling's original parked row is STILL the live one (not superseded —
+    # its file never changed).
     old = await inbox_items.get_by_id(db, "row-req-a")
-    assert old["status"] == "failed"
+    assert old["status"] == "processing"
+    assert (old["error_message"] or "").startswith("awaiting_approval:req-a")
 
 
 @pytest.mark.asyncio

--- a/tests/test_learning/test_fallback_chains.py
+++ b/tests/test_learning/test_fallback_chains.py
@@ -13,7 +13,7 @@ def test_all_chains_are_non_empty():
 def test_get_chain_known():
     chain = get_chain("web_fetch")
     assert chain is not None
-    assert chain[0] == "firecrawl"
+    assert chain[0] == "live_auto_chain"
 
 
 def test_get_chain_unknown():
@@ -22,17 +22,17 @@ def test_get_chain_unknown():
 
 def test_get_next_method_first():
     method = get_next_method("web_fetch", [])
-    assert method == "firecrawl"
+    assert method == "live_auto_chain"
 
 
 def test_get_next_method_skips_failed():
-    method = get_next_method("web_fetch", ["firecrawl"])
-    assert method == "playwright"
+    method = get_next_method("web_fetch", ["live_auto_chain"])
+    assert method == "firecrawl_backend"
 
 
 def test_get_next_method_skips_multiple_failed():
-    method = get_next_method("web_fetch", ["firecrawl", "playwright"])
-    assert method == "requests_fallback"
+    method = get_next_method("web_fetch", ["live_auto_chain", "firecrawl_backend"])
+    assert method == "cache_lookup"
 
 
 def test_get_next_method_exhausted():

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -1865,3 +1865,60 @@ async def test_memory_core_facts_wraps_external_and_emits(monkeypatch):
     assert kwargs["gate"] == "injection"
     assert kwargs["source_ref"] == "mcp/memory/core.py::memory_core_facts"
     assert kwargs["blockable_count"] == 1
+
+
+async def test_conversation_history_chat_scoped_and_paginated():
+    """chat_id scopes the telegram branch to ONE chat (a DM scroll-up must not
+    leak other chats); `before` pages further back; the unscoped default is
+    unchanged (reflection sessions rely on the cross-chat view)."""
+    import aiosqlite
+
+    import genesis.mcp.memory_mcp as mod
+
+    async with aiosqlite.connect(":memory:") as real_db:
+        real_db.row_factory = aiosqlite.Row
+        from genesis.db.schema import create_all_tables
+        await create_all_tables(real_db)
+        await real_db.commit()
+
+        from genesis.db.crud.telegram_messages import store
+        for i in range(4):
+            await store(
+                real_db, chat_id=100, message_id=i, sender="user",
+                content=f"dm-{i}", timestamp=f"2026-08-13T04:0{i}:00",
+            )
+        await store(
+            real_db, chat_id=200, message_id=90, sender="genesis",
+            content="group-noise", timestamp="2026-08-13T04:02:30",
+        )
+
+        old_store, old_db, old_retriever = mod._store, mod._db, mod._retriever
+        try:
+            mod._store, mod._retriever = MagicMock(), MagicMock()
+            mod._db = real_db
+
+            tools = await _get_tools()
+            fn = tools["conversation_history"].fn
+
+            scoped = await fn(channel="telegram", chat_id=100, limit=10)
+            assert [m["content"] for m in scoped] == [
+                "dm-0", "dm-1", "dm-2", "dm-3",
+            ]
+
+            paged = await fn(
+                channel="telegram", chat_id=100,
+                before="2026-08-13T04:02:00", limit=10,
+            )
+            assert [m["content"] for m in paged] == ["dm-0", "dm-1"]
+
+            unscoped = await fn(channel="telegram", limit=10)
+            assert any(m["content"] == "group-noise" for m in unscoped), (
+                "default must stay unscoped (cross-chat)"
+            )
+
+            sscoped = await fn(channel="telegram", chat_id=100, search="dm-2")
+            assert [m["content"] for m in sscoped] == ["dm-2"]
+            snoise = await fn(channel="telegram", chat_id=100, search="group-noise")
+            assert snoise == []
+        finally:
+            mod._store, mod._db, mod._retriever = old_store, old_db, old_retriever

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -1922,3 +1922,55 @@ async def test_conversation_history_chat_scoped_and_paginated():
             assert snoise == []
         finally:
             mod._store, mod._db, mod._retriever = old_store, old_db, old_retriever
+
+
+async def test_conversation_history_search_honors_scoping_and_cursor():
+    """Codex round-3 lock: the search branch must honor thread_id and before —
+    otherwise paged search repeats the newest matches forever and a topic
+    search leaks other topics."""
+    import aiosqlite
+
+    import genesis.mcp.memory_mcp as mod
+
+    async with aiosqlite.connect(":memory:") as real_db:
+        real_db.row_factory = aiosqlite.Row
+        from genesis.db.schema import create_all_tables
+        await create_all_tables(real_db)
+        await real_db.commit()
+
+        from genesis.db.crud.telegram_messages import store
+        for i in range(3):
+            await store(
+                real_db, chat_id=100, message_id=i, sender="user",
+                content=f"needle-{i}", thread_id=7,
+                timestamp=f"2026-08-13T04:0{i}:00",
+            )
+        await store(
+            real_db, chat_id=100, message_id=50, sender="user",
+            content="needle-other-topic", thread_id=8,
+            timestamp="2026-08-13T04:01:30",
+        )
+
+        old_store, old_db, old_retriever = mod._store, mod._db, mod._retriever
+        try:
+            mod._store, mod._retriever = MagicMock(), MagicMock()
+            mod._db = real_db
+            tools = await _get_tools()
+            fn = tools["conversation_history"].fn
+
+            scoped = await fn(
+                channel="telegram", chat_id=100, thread_id=7, search="needle",
+            )
+            assert [m["content"] for m in scoped] == [
+                "needle-0", "needle-1", "needle-2",
+            ], "topic search must not leak other topics"
+
+            paged = await fn(
+                channel="telegram", chat_id=100, thread_id=7, search="needle",
+                before="2026-08-13T04:01:00",
+            )
+            assert [m["content"] for m in paged] == ["needle-0"], (
+                "search must honor the before cursor"
+            )
+        finally:
+            mod._store, mod._db, mod._retriever = old_store, old_db, old_retriever

--- a/tests/test_mcp/test_settings.py
+++ b/tests/test_mcp/test_settings.py
@@ -696,3 +696,50 @@ class TestSettingsProvenanceAndGateFlip:
         assert "manual_approval_required" not in loaded
         for line in text.splitlines():
             assert not line.strip() or line.startswith("#") or line.startswith("a:")
+
+    @pytest.mark.asyncio
+    async def test_gate_disable_alert_writes_and_reenable_resolves(
+        self, tmp_path, monkeypatch,
+    ):
+        """The observation write must actually LAND (the original test never
+        asserted it — the write silently failed into a stray db), and
+        re-enabling the gate must resolve the standing alert (Codex P2)."""
+        import aiosqlite
+
+        import genesis.mcp.health.settings as settings_mod
+        from genesis.db.schema import create_all_tables
+        from genesis.mcp.health.settings import _impl_settings_update
+
+        monkeypatch.setattr(settings_mod, "_USER_CONFIG_DIR", tmp_path)
+        dbp = tmp_path / "obs.db"
+        async with aiosqlite.connect(dbp) as db:
+            db.row_factory = aiosqlite.Row
+            await create_all_tables(db)
+            await db.commit()
+        monkeypatch.setattr("genesis.env.genesis_db_path", lambda: dbp)
+
+        result = await _impl_settings_update(
+            "autonomous_cli_policy", {"manual_approval_required": False},
+            confirm_disable_approval_gate=True,
+        )
+        assert result.get("status") == "applied"
+        async with aiosqlite.connect(dbp) as db:
+            db.row_factory = aiosqlite.Row
+            rows = await db.execute_fetchall(
+                "SELECT resolved_at FROM observations WHERE source='settings_guard'",
+            )
+        assert len(rows) == 1 and rows[0]["resolved_at"] is None, (
+            "the gate-disable critical observation must actually land"
+        )
+
+        result2 = await _impl_settings_update(
+            "autonomous_cli_policy", {"manual_approval_required": True},
+        )
+        assert result2.get("status") == "applied"
+        async with aiosqlite.connect(dbp) as db:
+            db.row_factory = aiosqlite.Row
+            rows = await db.execute_fetchall(
+                "SELECT resolved_at FROM observations WHERE source='settings_guard' "
+                "AND resolved_at IS NULL",
+            )
+        assert rows == [], "re-enable must resolve the standing alert"

--- a/tests/test_mcp/test_settings.py
+++ b/tests/test_mcp/test_settings.py
@@ -507,3 +507,46 @@ class TestValidateCcForegroundReaper:
 
         assert "cc_foreground_reaper" in _DOMAIN_REGISTRY
         assert "cc_foreground_reaper" in _DOMAIN_VALIDATORS
+
+
+class TestAutonomousCliPolicyValidator:
+    """reask 0 (= never re-ask) is legal; overrides map is validated."""
+
+    def test_reask_zero_accepted(self):
+        from genesis.mcp.health.settings import _validate_autonomous_cli_policy
+
+        assert _validate_autonomous_cli_policy({"reask_interval_hours": 0}) == []
+
+    def test_reask_negative_rejected(self):
+        from genesis.mcp.health.settings import _validate_autonomous_cli_policy
+
+        errs = _validate_autonomous_cli_policy({"reask_interval_hours": -1})
+        assert errs and "between 0" in errs[0]
+
+    def test_reask_overrides_valid_and_invalid(self):
+        from genesis.mcp.health.settings import _validate_autonomous_cli_policy
+
+        assert (
+            _validate_autonomous_cli_policy(
+                {"reask_overrides": {"inbox_evaluation": 0, "ego_cycle": 12}},
+            )
+            == []
+        )
+        errs = _validate_autonomous_cli_policy(
+            {"reask_overrides": {"inbox_evaluation": 999}},
+        )
+        assert errs and "inbox_evaluation" in errs[0]
+        errs2 = _validate_autonomous_cli_policy({"reask_overrides": "not-a-map"})
+        assert errs2 and "mapping" in errs2[0]
+
+    def test_fractional_and_bool_hours_rejected(self):
+        """int(0.9) would silently truncate to the 0 = never sentinel —
+        fractional and bool values must be rejected outright."""
+        from genesis.mcp.health.settings import _validate_autonomous_cli_policy
+
+        assert _validate_autonomous_cli_policy({"reask_interval_hours": 0.9})
+        assert _validate_autonomous_cli_policy({"reask_interval_hours": True})
+        assert _validate_autonomous_cli_policy(
+            {"reask_overrides": {"inbox_evaluation": 0.5}},
+        )
+        assert _validate_autonomous_cli_policy({"reask_overrides": {"x": False}})

--- a/tests/test_mcp/test_settings.py
+++ b/tests/test_mcp/test_settings.py
@@ -638,3 +638,61 @@ class TestSettingsProvenanceAndGateFlip:
             "manual_approval_required": False,
             "reask_interval_hours": 24,
         }
+
+    @pytest.mark.asyncio
+    async def test_gate_disable_falsy_nonbool_rejected_before_gate_check(
+        self, tmp_path, monkeypatch,
+    ):
+        """Deep-review NOTE lock: manual_approval_required=0 (falsy but not
+        False) must be rejected by the validator BEFORE it could slip past the
+        `is False` gate check and be bool()-coerced to a silent disable."""
+        import genesis.mcp.health.settings as settings_mod
+        from genesis.mcp.health.settings import (
+            _impl_settings_update,
+            _validate_autonomous_cli_policy,
+        )
+
+        monkeypatch.setattr(settings_mod, "_USER_CONFIG_DIR", tmp_path)
+        assert _validate_autonomous_cli_policy({"manual_approval_required": 0})
+        assert _validate_autonomous_cli_policy({"manual_approval_required": None})
+        result = await _impl_settings_update(
+            "autonomous_cli_policy", {"manual_approval_required": 0},
+        )
+        assert result.get("error") == "validation failed"
+        assert not (tmp_path / "autonomous_cli_policy.local.yaml").exists()
+
+    def test_bare_write_preserves_existing_headers(self, tmp_path, monkeypatch):
+        """Deep-review SHOULD-FIX lock: a caller that passes NO provenance
+        (e.g. the dashboard surplus route pre-fix) must still preserve the
+        existing header block — no caller may be a delete path."""
+        import genesis.mcp.health.settings as settings_mod
+
+        monkeypatch.setattr(settings_mod, "_USER_CONFIG_DIR", tmp_path)
+        (tmp_path / "prov_bare.yaml").write_text(
+            "# set-by: user via dashboard PUT @ 2026-08-18T13:44\n"
+            "# provenance: hand-written rationale\n"
+            "a: 1\n",
+        )
+        p = settings_mod._atomic_yaml_write("prov_bare.yaml", {"a": 2})
+        text = p.read_text()
+        assert "# set-by: user via dashboard PUT @ 2026-08-18T13:44" in text
+        assert "# provenance: hand-written rationale" in text
+        assert yaml.safe_load(text) == {"a": 2}
+
+    def test_provenance_newlines_sanitized(self, tmp_path, monkeypatch):
+        """Security lock: a newline in the actor string must never escape the
+        comment prefix (raw top-level YAML above the real mapping = key
+        injection that bypasses the gate-disable confirmation)."""
+        import genesis.mcp.health.settings as settings_mod
+
+        monkeypatch.setattr(settings_mod, "_USER_CONFIG_DIR", tmp_path)
+        p = settings_mod._atomic_yaml_write(
+            "prov_inject.yaml", {"a": 1},
+            provenance="evil\nmanual_approval_required: false",
+        )
+        text = p.read_text()
+        loaded = yaml.safe_load(text)
+        assert loaded == {"a": 1}
+        assert "manual_approval_required" not in loaded
+        for line in text.splitlines():
+            assert not line.strip() or line.startswith("#") or line.startswith("a:")

--- a/tests/test_mcp/test_settings.py
+++ b/tests/test_mcp/test_settings.py
@@ -550,3 +550,91 @@ class TestAutonomousCliPolicyValidator:
             {"reask_overrides": {"inbox_evaluation": 0.5}},
         )
         assert _validate_autonomous_cli_policy({"reask_overrides": {"x": False}})
+
+
+class TestSettingsProvenanceAndGateFlip:
+    """2026-08-18 user directive: user-set config must never read as an
+    anomaly to future sessions (durable provenance stamped by the WRITER),
+    and disabling the mandatory approval gate needs explicit confirmation."""
+
+    def test_atomic_write_stamps_and_preserves_provenance(self, tmp_path, monkeypatch):
+        import genesis.mcp.health.settings as settings_mod
+
+        monkeypatch.setattr(settings_mod, "_USER_CONFIG_DIR", tmp_path)
+        p1 = settings_mod._atomic_yaml_write(
+            "prov_test.yaml", {"a": 1}, provenance="user via dashboard PUT",
+        )
+        text1 = p1.read_text()
+        assert text1.startswith("# set-by: user via dashboard PUT @ ")
+        assert yaml.safe_load(text1) == {"a": 1}
+
+        # A second write by a different actor PRESERVES the first stamp.
+        p2 = settings_mod._atomic_yaml_write(
+            "prov_test.yaml", {"a": 2}, provenance="user via mcp settings_update",
+        )
+        text2 = p2.read_text()
+        assert "user via dashboard PUT" in text2
+        assert "user via mcp settings_update" in text2
+        assert yaml.safe_load(text2) == {"a": 2}
+
+    @pytest.mark.asyncio
+    async def test_gate_disable_requires_confirmation(self, tmp_path, monkeypatch):
+        import genesis.mcp.health.settings as settings_mod
+        from genesis.mcp.health.settings import _impl_settings_update
+
+        monkeypatch.setattr(settings_mod, "_USER_CONFIG_DIR", tmp_path)
+        result = await _impl_settings_update(
+            "autonomous_cli_policy", {"manual_approval_required": False},
+        )
+        assert "error" in result
+        assert "confirm_disable_approval_gate" in result["error"]
+        assert not (tmp_path / "autonomous_cli_policy.local.yaml").exists()
+
+        confirmed = await _impl_settings_update(
+            "autonomous_cli_policy", {"manual_approval_required": False},
+            confirm_disable_approval_gate=True,
+        )
+        assert confirmed.get("status") == "applied"
+        assert "warning" in confirmed
+        written = (tmp_path / "autonomous_cli_policy.local.yaml").read_text()
+        assert "manual_approval_required: false" in written
+        assert written.startswith("# set-by:")
+
+    @pytest.mark.asyncio
+    async def test_gate_enable_needs_no_confirmation(self, tmp_path, monkeypatch):
+        import genesis.mcp.health.settings as settings_mod
+        from genesis.mcp.health.settings import _impl_settings_update
+
+        monkeypatch.setattr(settings_mod, "_USER_CONFIG_DIR", tmp_path)
+        result = await _impl_settings_update(
+            "autonomous_cli_policy", {"manual_approval_required": True},
+        )
+        assert result.get("status") == "applied"
+
+    def test_hand_written_comments_survive_restamp(self, tmp_path, monkeypatch):
+        """Audit lock: the WHOLE leading comment block survives a rewrite —
+        hand-written operator rationale is exactly the record provenance
+        stamping exists to protect; only machine set-by lines are capped."""
+        import genesis.mcp.health.settings as settings_mod
+
+        monkeypatch.setattr(settings_mod, "_USER_CONFIG_DIR", tmp_path)
+        (tmp_path / "prov_mixed.yaml").write_text(
+            "# set-by: user (dashboard PUT) @ 2026-08-18T13:44\n"
+            "# provenance: deliberate sovereign choice — do NOT revert\n"
+            "#   future sessions: this is user-intentional\n"
+            "manual_approval_required: false\n",
+        )
+        p = settings_mod._atomic_yaml_write(
+            "prov_mixed.yaml",
+            {"manual_approval_required": False, "reask_interval_hours": 24},
+            provenance="user via mcp settings_update",
+        )
+        text = p.read_text()
+        assert "# provenance: deliberate sovereign choice" in text
+        assert "future sessions: this is user-intentional" in text
+        assert "# set-by: user (dashboard PUT) @ 2026-08-18T13:44" in text
+        assert "user via mcp settings_update" in text
+        assert yaml.safe_load(text) == {
+            "manual_approval_required": False,
+            "reask_interval_hours": 24,
+        }

--- a/tests/test_mcp/test_web_tools.py
+++ b/tests/test_mcp/test_web_tools.py
@@ -220,3 +220,143 @@ class TestWebSearch:
         result = await _impl_web_search("query", "nosuchbackend", 10)
         assert "error" in result
         assert "Unknown backend" in result["error"]
+
+
+class TestFirecrawlBackend:
+    """Firecrawl = PAID explicit-only escalation backend (never in auto)."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_firecrawl_fetch(self, monkeypatch):
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+
+        async def fake_scrape(url):
+            return {
+                "markdown": "Rendered paywalled content",
+                "metadata": {"title": "Hard Page", "sourceURL": url, "statusCode": 200},
+            }
+
+        import genesis.providers.firecrawl_client as fc
+
+        monkeypatch.setattr(fc, "scrape", fake_scrape)
+        result = await _impl_web_fetch("https://hard.example", "firecrawl", 50000)
+        assert result["backend_used"] == "firecrawl"
+        assert result["content"] == "Rendered paywalled content"
+        assert result["title"] == "Hard Page"
+        assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_firecrawl_fetch_without_key_errors(self, monkeypatch):
+        monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+        result = await _impl_web_fetch("https://hard.example", "firecrawl", 50000)
+        assert result["backend_used"] == "firecrawl"
+        assert "unavailable" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_firecrawl_never_in_auto_chain(self, monkeypatch):
+        """Auto must NEVER touch the paid backend, even with the key set."""
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+        called = []
+
+        async def fake_scrape(url):
+            called.append(url)
+            return {"markdown": "x", "metadata": {}}
+
+        import genesis.providers.firecrawl_client as fc
+
+        monkeypatch.setattr(fc, "scrape", fake_scrape)
+        with patch("genesis.mcp.health.web_tools._try_tinyfish_fetch") as tf:
+            tf.return_value = {
+                "url": "https://a.com", "title": "t", "content": "c",
+                "backend_used": "tinyfish", "status_code": 200,
+                "truncated": False, "error": None, "latency_ms": 1.0,
+            }
+            await _impl_web_fetch("https://a.com", "auto", 50000)
+        assert called == [], "auto chain must never burn Firecrawl credits"
+
+    @pytest.mark.asyncio
+    async def test_explicit_firecrawl_search(self, monkeypatch):
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+
+        async def fake_search(query, *, limit=10):
+            return [
+                {"title": "R1", "url": "https://r1.example", "description": "first"},
+                {"title": "R2", "url": "https://r2.example", "description": "second"},
+            ]
+
+        import genesis.providers.firecrawl_client as fc
+
+        monkeypatch.setattr(fc, "search", fake_search)
+        result = await _impl_web_search("hard query", "firecrawl", 10)
+        assert result["backend_used"] == "firecrawl"
+        assert [r["title"] for r in result["results"]] == ["R1", "R2"]
+        assert result["results"][0]["snippet"] == "first"
+
+    @pytest.mark.asyncio
+    async def test_auto_full_escalation_never_reaches_firecrawl(self, monkeypatch):
+        """Audit lock: even when EVERY free fetch rung fails/challenges, auto
+        must end at the free chain's last rung — never the paid backend."""
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+        called = []
+
+        async def fake_scrape(url):
+            called.append(url)
+            return {"markdown": "x", "metadata": {}}
+
+        import genesis.providers.firecrawl_client as fc
+
+        monkeypatch.setattr(fc, "scrape", fake_scrape)
+
+        class _ChallengedFetcher:
+            async def fetch(self, url, max_chars=50000):
+                from types import SimpleNamespace
+
+                return SimpleNamespace(
+                    url=url, title="", text="captcha challenge",
+                    status_code=403, truncated=False, error=None,
+                )
+
+        with (
+            patch("genesis.mcp.health.web_tools._try_tinyfish_fetch") as tf,
+            patch("genesis.mcp.health.web_tools._try_ladder_fetch") as lf,
+            patch("genesis.mcp.health.web_tools._try_crawl4ai") as cf,
+            patch("genesis.mcp.health.web_tools._get_fetcher") as gf,
+        ):
+            tf.return_value = None
+            lf.return_value = None
+            cf.return_value = None
+            gf.return_value = _ChallengedFetcher()
+            result = await _impl_web_fetch("https://hard.example", "auto", 50000)
+        assert called == [], "exhausted auto chain must not burn paid credits"
+        assert result["backend_used"] != "firecrawl"
+
+    @pytest.mark.asyncio
+    async def test_search_auto_never_reaches_firecrawl(self, monkeypatch):
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+        called = []
+
+        async def fake_search(query, *, limit=10):
+            called.append(query)
+            return []
+
+        import genesis.providers.firecrawl_client as fc
+
+        monkeypatch.setattr(fc, "search", fake_search)
+
+        class _EmptySearcher:
+            async def search(self, query, max_results=10):
+                from types import SimpleNamespace
+
+                return SimpleNamespace(
+                    query=query, results=[], backend_used=None,
+                    fallback_used=True, error="all free backends failed",
+                )
+
+        with (
+            patch("genesis.mcp.health.web_tools._try_tinyfish_search") as ts,
+            patch("genesis.mcp.health.web_tools._get_searcher") as gs,
+        ):
+            ts.return_value = None
+            gs.return_value = _EmptySearcher()
+            result = await _impl_web_search("hard query", "auto", 10)
+        assert called == [], "search auto chain must not burn paid credits"
+        assert result.get("backend_used") != "firecrawl"


### PR DESCRIPTION
## What

Seven commits fixing five measured defects plus four hardening features, all root-caused from a live incident (48 phantom approval requests/day for four days) and adversarially reviewed per-commit + branch-wide.

### Approval storm (the headline fix)
- `get_all_known()` rebuilt as ONE recency-ordered scan — a permanently-failed row can no longer clobber a newer completed row's hash (the storm seed: phantom "modified" every 30-min tick).
- New/modified inbox content while an approval is pending now **parks onto the same request** (per-file supersession, delta recomputed) — the cancel-and-recreate refresh that sent a fresh Telegram message per tick is gone. The orphan guard is the only remaining cancel path.
- Per-policy re-ask control: `reask_overrides: {inbox_evaluation: 0}` ships (never re-ask a delivered inbox request); all other policies keep the 24h re-ask. Delivery-failure recovery (no successful send on record) always retries, for every policy — recovery, not a reminder.
- Tri-state approval consume (consumed / already-consumed / failed-with-retry+ERROR); approved-then-edited content is invalidated AND its approval consumed at dispatch time, so post-approval edits require a fresh approval.

### DM continuity ("real scroll-up")
- `conversation_history` gains optional `chat_id` (scoped) + `before` (cursor pagination, full-length messages); unscoped cross-chat default preserved.
- Session-recovery recap is byte-budgeted and tail-biased (the END of long replies survives; the old per-message 300-char head chop dropped exactly the conclusions).
- Every fresh telegram session gets a conversation-identity block naming its real chat id (correct for negative group ids).

### Rate-limit park integrity
- Park payload/queue/consumer now round-trip the full execution shape (`system_prompt`, `source_tag`, `skills`, `tool_exceptions`, `planning_instruction`) — locked by a required-set test; a parked campaign no longer resumes without its strategy doc.
- Campaign bookkeeping follows parks (structured `park_id` metadata stamp): open park = still running (bounded 7 days, fail-closed on corrupt rows), resumed = capture the delivering session's real result, terminal = real failure.

### Hardening / features
- Firecrawl as an explicit **paid** escalation backend on `web_fetch`/`web_search` (never in the auto chains — locked by exhausted-chain purity tests); stale Firecrawl-is-MCP labels fixed.
- CC login health: hourly expiry warning for the fixed-lifetime OAuth refresh token (`GENESIS_CC_LOGIN_EXPIRY_WARN_DAYS`), plus fallback to a stored 1-year setup-token ONLY on hard-expired + probe-confirmed-dead login (never on ambiguity; never for peer-routed/bare/cleanroom invocations).
- Settings writes provenance-stamped (`# set-by:` headers, whole hand-written comment block preserved unconditionally); disabling `manual_approval_required` requires a strict-typed confirmation flag on both surfaces and is loud on both (Telegram alert / critical observation). Fixed a pre-existing silent data-loss bug in the surplus PUT (merge result discarded).
- cc-update process: new-capability detection now produces a ready follow-up naming the exact instruction change (adoption path, not just an informational note).

## Review
Six per-commit adversarial audits + a branch-wide fresh-context deep review + a sequential security review (no CRITICAL; both SHOULD-FIXes applied in the final commit). Every fix landed test-first; every new test was verified RED via the bug or deliberate sabotage.

## Deploy notes
- Config default change: `config/autonomous_cli_policy.yaml` gains `reask_overrides` (deep-merge means existing overlays inherit it; restoring inbox reminders requires an explicit `inbox_evaluation: 24`).
- Runtime code + MCP-server changes: server restart + next CC session start respectively; no schema migrations.
- First post-deploy inbox tick is a quiet no-op on this install (verified against live rows).

Ledger: ebf7fd58951f4750a5d0a9e99eb23e11
Ledger: 26f151bec33a46d69561e21fcb37e241
Follow-up: af265c4c1ce845248893ed1e61c498c3
Follow-up: 7f18b3ab8d0a43cb89639bb9de250635
Follow-up: 6fd24166616f48deaa8e5e34592ab45b
Follow-up: ebf2acaa586f4088a9a5e0d3391471fe

🤖 Generated with [Claude Code](https://claude.com/claude-code)