### PR TITLE
fix(autonomy): bound codex-exec adversarial verify with hard timeout + tree-kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Autonomy no longer wedges when its cross-vendor reviewer hangs.** A task's
+  quality gate runs an adversarial verification through a `codex exec` subprocess.
+  That call had no timeout, so a hung codex (a known upstream model-catalog-refresh
+  hang) would hold the autonomy executor's shared execution slot indefinitely —
+  stalling every queued task until a restart. The call is now bounded by a hard
+  timeout (default 2h, override with `GENESIS_CODEX_REVIEW_TIMEOUT_S`); on timeout
+  the codex process tree is killed and verification degrades to the next reviewer in
+  the chain, freeing the executor. Mirrors the existing hard-timeout on deterministic
+  executor subprocesses.
+
 - **No more false "critical failure" alarms when the system is briefly busy.** The
   health signal that watches your local infrastructure (database, vector store, and
   Ollama if enabled) probes those services with a short timeout. When background work

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -16,6 +16,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import math
 import os
 import re
 import shutil
@@ -75,9 +76,12 @@ def _read_codex_timeout_s() -> float:
             raw, _DEFAULT_CODEX_EXEC_TIMEOUT_S,
         )
         return _DEFAULT_CODEX_EXEC_TIMEOUT_S
-    if value <= 0:
+    # Reject inf/nan too: inf would silently remove the hard bound (back to an
+    # unbounded hang), and nan corrupts asyncio's wait_for timer scheduling.
+    if not math.isfinite(value) or value <= 0:
         logger.warning(
-            "review: non-positive GENESIS_CODEX_REVIEW_TIMEOUT_S=%r -- using %ss",
+            "review: non-finite/non-positive GENESIS_CODEX_REVIEW_TIMEOUT_S=%r "
+            "-- using %ss",
             raw, _DEFAULT_CODEX_EXEC_TIMEOUT_S,
         )
         return _DEFAULT_CODEX_EXEC_TIMEOUT_S
@@ -92,8 +96,9 @@ def _kill_codex_process_tree(proc: asyncio.subprocess.Process) -> None:
 
     codex is a Node launcher that spawns child processes; killing only the
     direct PID can orphan them. The process is spawned with
-    ``preexec_fn=os.setpgrp`` so it leads its own group, letting us kill the
-    tree via ``killpg`` without touching the Genesis server's own group. The
+    ``start_new_session=True`` so it leads its own session/group, letting us
+    kill the tree via ``killpg`` without touching the Genesis server's own
+    group. The
     ``pgid <= 1`` guard refuses a group-wide kill that would signal every
     process in the container. Falls back to killing just the direct child if
     the group id is unavailable. Mirrors cc/invoker.py's timeout-kill pattern.
@@ -474,9 +479,14 @@ class TaskReviewer:
             # failed: Permission denied).  --full-auto also fails.
             # Verification is read-only in intent; the bypass only
             # affects the sandbox layer, not the prompt instructions.
-            # preexec_fn=os.setpgrp puts codex in its own process group so a
-            # timeout can kill the whole tree via killpg (see
-            # _kill_codex_process_tree) without touching the server's group.
+            # start_new_session=True puts codex in its own session/process group
+            # so a timeout can kill the whole tree via killpg (see
+            # _kill_codex_process_tree) without touching the server's group. We
+            # use start_new_session rather than preexec_fn=os.setpgrp because the
+            # C subprocess helper performs the setsid() async-signal-safely inside
+            # the child, avoiding the post-fork preexec_fn deadlock risk in this
+            # multi-threaded server (a deadlock there would hang before our
+            # wait_for timeout is even armed).
             proc = await asyncio.create_subprocess_exec(
                 "codex", "exec", "-",
                 "-c", 'model_reasoning_effort="medium"',
@@ -486,7 +496,7 @@ class TaskReviewer:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
-                preexec_fn=os.setpgrp,
+                start_new_session=True,
             )
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
                 proc.communicate(input=prompt.encode("utf-8")),

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -16,8 +16,10 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 import re
 import shutil
+import signal
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
@@ -37,6 +39,73 @@ _CALL_SITE_PLAN = "27_pre_execution_assessment"
 _CALL_SITE_EXECUTOR_REVIEW = "17_executor_review"
 _CALL_SITE_ADVERSARIAL = "20_adversarial_counterargument"
 _MAX_RETRIES = 2
+
+# Hard timeout (seconds) for the ``codex exec`` adversarial-verify subprocess.
+# _verify_via_codex runs under the autonomy executor semaphore (engine.py calls
+# verify_deliverable while dispatcher.py holds _exec_semaphore — a Semaphore(1)),
+# so a hung codex — e.g. the known upstream model-catalog refresh hang — would
+# block ALL autonomy task execution indefinitely, with no external watchdog to
+# recover it. This bounds that: on timeout the codex process *tree* is killed and
+# this link degrades to None (same as codex-not-installed), so verification falls
+# through to the CC-invoker / API links. The 2h default matches deterministic.py's
+# _HARD_TIMEOUT_S (the justified-exception case in the timeout policy — a raw
+# subprocess holding the executor semaphore). NOTE the *kill* deliberately differs
+# from deterministic.py's direct ``proc.kill()``: codex is a Node launcher that
+# spawns children, so we tree-kill via killpg (see _kill_codex_process_tree).
+# Override via GENESIS_CODEX_REVIEW_TIMEOUT_S for quicker recovery once codex
+# reviews are observed to complete well under it.
+_DEFAULT_CODEX_EXEC_TIMEOUT_S = 7200.0
+
+
+def _read_codex_timeout_s() -> float:
+    """Resolve the codex-exec timeout from env, failing safe to the 2h default.
+
+    Parsed at import time, so a malformed or non-positive override must NOT
+    raise (that would crash the import of the autonomy executor that imports
+    this module) — fall back to the default with a warning instead.
+    """
+    raw = os.environ.get("GENESIS_CODEX_REVIEW_TIMEOUT_S")
+    if raw is None:
+        return _DEFAULT_CODEX_EXEC_TIMEOUT_S
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "review: bad GENESIS_CODEX_REVIEW_TIMEOUT_S=%r -- using %ss",
+            raw, _DEFAULT_CODEX_EXEC_TIMEOUT_S,
+        )
+        return _DEFAULT_CODEX_EXEC_TIMEOUT_S
+    if value <= 0:
+        logger.warning(
+            "review: non-positive GENESIS_CODEX_REVIEW_TIMEOUT_S=%r -- using %ss",
+            raw, _DEFAULT_CODEX_EXEC_TIMEOUT_S,
+        )
+        return _DEFAULT_CODEX_EXEC_TIMEOUT_S
+    return value
+
+
+_CODEX_EXEC_TIMEOUT_S = _read_codex_timeout_s()
+
+
+def _kill_codex_process_tree(proc: asyncio.subprocess.Process) -> None:
+    """SIGKILL the whole process group led by *proc*.
+
+    codex is a Node launcher that spawns child processes; killing only the
+    direct PID can orphan them. The process is spawned with
+    ``preexec_fn=os.setpgrp`` so it leads its own group, letting us kill the
+    tree via ``killpg`` without touching the Genesis server's own group. The
+    ``pgid <= 1`` guard refuses a group-wide kill that would signal every
+    process in the container. Falls back to killing just the direct child if
+    the group id is unavailable. Mirrors cc/invoker.py's timeout-kill pattern.
+    """
+    try:
+        pgid = os.getpgid(proc.pid)
+        if pgid <= 1:
+            raise ValueError(f"Refusing killpg with pgid={pgid}")
+        os.killpg(pgid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, ValueError, TypeError):
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
 
 
 # ---------------------------------------------------------------------------
@@ -405,6 +474,9 @@ class TaskReviewer:
             # failed: Permission denied).  --full-auto also fails.
             # Verification is read-only in intent; the bypass only
             # affects the sandbox layer, not the prompt instructions.
+            # preexec_fn=os.setpgrp puts codex in its own process group so a
+            # timeout can kill the whole tree via killpg (see
+            # _kill_codex_process_tree) without touching the server's group.
             proc = await asyncio.create_subprocess_exec(
                 "codex", "exec", "-",
                 "-c", 'model_reasoning_effort="medium"',
@@ -414,11 +486,25 @@ class TaskReviewer:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 cwd=cwd,
+                preexec_fn=os.setpgrp,
             )
-            stdout_bytes, stderr_bytes = await proc.communicate(
-                input=prompt.encode("utf-8"),
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(input=prompt.encode("utf-8")),
+                timeout=_CODEX_EXEC_TIMEOUT_S,
             )
         except FileNotFoundError:
+            return None
+        except TimeoutError:
+            # Known upstream codex hang (model-catalog refresh). Kill the tree
+            # and degrade — leaving it would wedge the executor semaphore.
+            logger.warning(
+                "review: codex exec exceeded %ss -- killing process tree and "
+                "skipping codex link",
+                _CODEX_EXEC_TIMEOUT_S,
+            )
+            _kill_codex_process_tree(proc)
+            with contextlib.suppress(ProcessLookupError, OSError):
+                await proc.wait()
             return None
         except OSError:
             logger.warning("review: codex exec OS error", exc_info=True)

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -90,25 +90,40 @@ def _read_codex_timeout_s() -> float:
 
 _CODEX_EXEC_TIMEOUT_S = _read_codex_timeout_s()
 
+# Bound on the post-kill reap. After SIGKILL the process exits ~immediately, so
+# ``proc.wait()`` returns promptly — but the recovery path must not itself be
+# unbounded (a paused pipe transport with buffered data at cancel time is the
+# theoretical edge), or the timeout could re-create the executor wedge it exists
+# to prevent. 30s is far beyond any real SIGKILL-to-exit latency.
+_CODEX_KILL_REAP_TIMEOUT_S = 30.0
+
 
 def _kill_codex_process_tree(proc: asyncio.subprocess.Process) -> None:
     """SIGKILL the whole process group led by *proc*.
 
     codex is a Node launcher that spawns child processes; killing only the
-    direct PID can orphan them. The process is spawned with
-    ``start_new_session=True`` so it leads its own session/group, letting us
-    kill the tree via ``killpg`` without touching the Genesis server's own
-    group. The
-    ``pgid <= 1`` guard refuses a group-wide kill that would signal every
-    process in the container. Falls back to killing just the direct child if
-    the group id is unavailable. Mirrors cc/invoker.py's timeout-kill pattern.
+    direct PID can orphan them. The subprocess is spawned with
+    ``start_new_session=True``, so its process-group id *equals* ``proc.pid``
+    and — crucially — the kernel keeps that pgid reserved while ANY group member
+    is alive. We therefore signal ``proc.pid`` as the pgid **directly** rather
+    than via ``os.getpgid(proc.pid)``: once asyncio reaps the group *leader*
+    (which can happen while a descendant still holds a pipe, keeping
+    ``communicate()`` pending), ``getpgid`` would raise ``ProcessLookupError``
+    and a bare ``proc.kill()`` would no-op — leaking the very descendant this
+    guard exists to reap. The ``pgid <= 1`` guard refuses a container-wide kill.
     """
+    pgid = proc.pid
+    if not pgid or pgid <= 1:
+        # No usable own-group id (should not happen with start_new_session);
+        # fall back to signalling just the direct child.
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        return
     try:
-        pgid = os.getpgid(proc.pid)
-        if pgid <= 1:
-            raise ValueError(f"Refusing killpg with pgid={pgid}")
         os.killpg(pgid, signal.SIGKILL)
-    except (ProcessLookupError, PermissionError, ValueError, TypeError):
+    except ProcessLookupError:
+        pass  # whole group already gone — nothing to reap
+    except (PermissionError, OSError):
         with contextlib.suppress(ProcessLookupError):
             proc.kill()
 
@@ -498,12 +513,23 @@ class TaskReviewer:
                 cwd=cwd,
                 start_new_session=True,
             )
+        except FileNotFoundError:
+            return None
+        except OSError:
+            # Spawn failure (incl. ETIMEDOUT, which Python raises as TimeoutError
+            # -- an OSError subclass -- from a failing execve/chdir). proc is
+            # unbound here, so this must NOT reach the timeout-kill path below;
+            # degrade to the next reviewer just like the pre-timeout code did.
+            logger.warning("review: codex exec spawn error", exc_info=True)
+            return None
+
+        # Separate try so the timeout-kill path only runs for a communicate()
+        # timeout (proc is guaranteed bound), never a spawn-time TimeoutError.
+        try:
             stdout_bytes, stderr_bytes = await asyncio.wait_for(
                 proc.communicate(input=prompt.encode("utf-8")),
                 timeout=_CODEX_EXEC_TIMEOUT_S,
             )
-        except FileNotFoundError:
-            return None
         except TimeoutError:
             # Known upstream codex hang (model-catalog refresh). Kill the tree
             # and degrade — leaving it would wedge the executor semaphore.
@@ -513,11 +539,16 @@ class TaskReviewer:
                 _CODEX_EXEC_TIMEOUT_S,
             )
             _kill_codex_process_tree(proc)
-            with contextlib.suppress(ProcessLookupError, OSError):
-                await proc.wait()
+            # Bounded reap: the process is SIGKILLed so this returns promptly;
+            # the bound guarantees the recovery path can't itself re-wedge on a
+            # paused pipe transport.
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(
+                    proc.wait(), timeout=_CODEX_KILL_REAP_TIMEOUT_S,
+                )
             return None
         except OSError:
-            logger.warning("review: codex exec OS error", exc_info=True)
+            logger.warning("review: codex exec communicate error", exc_info=True)
             return None
 
         if proc.returncode != 0:

--- a/tests/test_autonomy/test_executor/test_review.py
+++ b/tests/test_autonomy/test_executor/test_review.py
@@ -592,6 +592,60 @@ class TestCodexTimeoutEnvParse:
         monkeypatch.setenv("GENESIS_CODEX_REVIEW_TIMEOUT_S", "0")
         assert _read_codex_timeout_s() == _DEFAULT_CODEX_EXEC_TIMEOUT_S
 
+    def test_infinity_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """inf parses via float() but would silently remove the hard bound."""
+        from genesis.autonomy.executor.review import (
+            _DEFAULT_CODEX_EXEC_TIMEOUT_S,
+            _read_codex_timeout_s,
+        )
+        monkeypatch.setenv("GENESIS_CODEX_REVIEW_TIMEOUT_S", "inf")
+        assert _read_codex_timeout_s() == _DEFAULT_CODEX_EXEC_TIMEOUT_S
+
+    def test_nan_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """nan parses via float() but corrupts asyncio's wait_for timer."""
+        from genesis.autonomy.executor.review import (
+            _DEFAULT_CODEX_EXEC_TIMEOUT_S,
+            _read_codex_timeout_s,
+        )
+        monkeypatch.setenv("GENESIS_CODEX_REVIEW_TIMEOUT_S", "nan")
+        assert _read_codex_timeout_s() == _DEFAULT_CODEX_EXEC_TIMEOUT_S
+
+
+@pytest.mark.asyncio
+class TestCodexSpawnOptions:
+    async def test_codex_spawned_in_new_session(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """codex must be spawned with start_new_session=True (its own
+        session/group) so the timeout tree-kill can killpg it safely — and
+        NOT via preexec_fn (post-fork deadlock risk in the threaded server)."""
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.shutil.which",
+            lambda name: "/usr/bin/codex",
+        )
+
+        captured: dict[str, object] = {}
+
+        async def _fake_exec(*_args, **kwargs):
+            captured.update(kwargs)
+            fake = MagicMock()
+            fake.returncode = 0
+            fake.communicate = AsyncMock(
+                return_value=(_codex_jsonl_output(json.dumps({"verdict": "pass"})), b""),
+            )
+            return fake
+
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.asyncio.create_subprocess_exec",
+            _fake_exec,
+        )
+        reviewer = TaskReviewer(router=AsyncMock())
+        result = await reviewer._verify_via_codex("deliverable", "reqs")
+
+        assert result is not None
+        assert captured.get("start_new_session") is True
+        assert "preexec_fn" not in captured
+
 
 @pytest.mark.asyncio
 class TestVerifyViaInvoker:

--- a/tests/test_autonomy/test_executor/test_review.py
+++ b/tests/test_autonomy/test_executor/test_review.py
@@ -441,11 +441,16 @@ class TestVerifyViaCodex:
         async def _never_returns(*_args, **_kwargs):
             await asyncio.sleep(3600)  # hang well past the timeout
 
+        killpg_calls: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.os.killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+
         # MagicMock base so .kill() is synchronous (like real Popen.kill);
-        # .communicate/.wait are async. Nonexistent pid -> os.getpgid raises
-        # ProcessLookupError, exercising the proc.kill() fallback branch.
+        # .communicate/.wait are async. pid == its own pgid (start_new_session).
         fake_proc = MagicMock()
-        fake_proc.pid = 2147483646
+        fake_proc.pid = 424242
         fake_proc.returncode = None
         fake_proc.communicate = _never_returns
         fake_proc.wait = AsyncMock()
@@ -464,16 +469,17 @@ class TestVerifyViaCodex:
             )
 
         assert result is None
-        # The hung subprocess must have been killed and reaped.
-        fake_proc.kill.assert_called_once()
+        # The hung tree must have been group-killed and then reaped.
+        assert killpg_calls == [(424242, signal.SIGKILL)]
         fake_proc.wait.assert_awaited()
 
-    async def test_codex_hang_kills_process_group(
+    async def test_codex_hang_kills_group_by_pid_not_getpgid(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """On timeout with a valid pgid, the whole process GROUP is SIGKILLed
-        (the production path — codex is a Node launcher that spawns children),
-        not just the direct pid."""
+        """The group is signalled by proc.pid DIRECTLY (== pgid under
+        start_new_session), NOT via os.getpgid — so that a reaped group leader
+        (whose descendant still holds the pipe) can't defeat the tree-kill.
+        getpgid must not even be consulted."""
         monkeypatch.setattr(
             "genesis.autonomy.executor.review.shutil.which",
             lambda name: "/usr/bin/codex",
@@ -487,11 +493,14 @@ class TestVerifyViaCodex:
 
         killpg_calls: list[tuple[int, int]] = []
         monkeypatch.setattr(
-            "genesis.autonomy.executor.review.os.getpgid", lambda pid: 4242,
-        )
-        monkeypatch.setattr(
             "genesis.autonomy.executor.review.os.killpg",
             lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+
+        def _fail_getpgid(_pid):
+            raise AssertionError("getpgid must not be called (leader may be reaped)")
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.os.getpgid", _fail_getpgid,
         )
 
         fake_proc = MagicMock()
@@ -517,8 +526,8 @@ class TestVerifyViaCodex:
     async def test_codex_hang_pgid_guard_refuses_group_kill(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """If getpgid returns <=1, killpg MUST NOT fire (killpg(1|0, sig) would
-        signal every process in the container); fall back to the direct pid."""
+        """If proc.pid (== pgid) is <=1, killpg MUST NOT fire (killpg(1|0, sig)
+        would signal every process in the container); fall back to proc.kill()."""
         monkeypatch.setattr(
             "genesis.autonomy.executor.review.shutil.which",
             lambda name: "/usr/bin/codex",
@@ -532,15 +541,12 @@ class TestVerifyViaCodex:
 
         killpg_calls: list[tuple[int, int]] = []
         monkeypatch.setattr(
-            "genesis.autonomy.executor.review.os.getpgid", lambda pid: 1,
-        )
-        monkeypatch.setattr(
             "genesis.autonomy.executor.review.os.killpg",
             lambda pgid, sig: killpg_calls.append((pgid, sig)),
         )
 
         fake_proc = MagicMock()
-        fake_proc.pid = 777
+        fake_proc.pid = 1  # degenerate pgid -> guard must refuse killpg
         fake_proc.returncode = None
         fake_proc.communicate = _never_returns
         fake_proc.wait = AsyncMock()
@@ -557,6 +563,70 @@ class TestVerifyViaCodex:
         assert result is None
         assert killpg_calls == []            # guard refused the group kill
         fake_proc.kill.assert_called_once()  # fell back to the direct kill
+
+    async def test_codex_spawn_timeout_degrades_not_crash(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A spawn-time TimeoutError (e.g. ETIMEDOUT from execve/chdir, which is
+        an OSError subclass) must degrade to None via the spawn handler — NOT
+        reach the timeout-kill path with an unbound proc (UnboundLocalError)."""
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.shutil.which",
+            lambda name: "/usr/bin/codex",
+        )
+
+        async def _spawn_times_out(*_args, **_kwargs):
+            raise TimeoutError("ETIMEDOUT on spawn")
+
+        with patch(
+            "genesis.autonomy.executor.review.asyncio.create_subprocess_exec",
+            _spawn_times_out,
+        ):
+            reviewer = TaskReviewer(router=AsyncMock())
+            result = await reviewer._verify_via_codex("deliverable", "reqs")
+
+        assert result is None
+
+    async def test_codex_kill_reap_is_bounded(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the post-kill reap (proc.wait) itself hangs (paused pipe transport
+        edge), the bounded wait_for must still let _verify_via_codex return None
+        rather than re-wedging the executor."""
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.shutil.which",
+            lambda name: "/usr/bin/codex",
+        )
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review._CODEX_EXEC_TIMEOUT_S", 0.05,
+        )
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review._CODEX_KILL_REAP_TIMEOUT_S", 0.05,
+        )
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.os.killpg", lambda pgid, sig: None,
+        )
+
+        async def _never_returns(*_args, **_kwargs):
+            await asyncio.sleep(3600)
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 555
+        fake_proc.returncode = None
+        fake_proc.communicate = _never_returns
+        fake_proc.wait = _never_returns  # reap hangs too
+
+        with patch(
+            "genesis.autonomy.executor.review.asyncio.create_subprocess_exec",
+            return_value=fake_proc,
+        ):
+            reviewer = TaskReviewer(router=AsyncMock())
+            # Outer guard well above both inner bounds (0.05 + 0.05).
+            result = await asyncio.wait_for(
+                reviewer._verify_via_codex("deliverable", "reqs"), timeout=5,
+            )
+
+        assert result is None
 
 
 class TestCodexTimeoutEnvParse:

--- a/tests/test_autonomy/test_executor/test_review.py
+++ b/tests/test_autonomy/test_executor/test_review.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import signal
 from dataclasses import dataclass
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -415,6 +417,180 @@ class TestVerifyViaCodex:
             result = await reviewer._verify_via_codex("deliverable", "reqs")
 
         assert result is None
+
+    async def test_codex_hang_times_out_and_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A hung ``codex exec`` must be killed at the timeout and return
+        None (the existing degradation path), not block forever.
+
+        Regression guard: without a timeout, a hung codex (known upstream
+        model-catalog refresh hang) wedges the autonomy executor semaphore
+        indefinitely, since verify_deliverable runs under it.
+        """
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.shutil.which",
+            lambda name: "/usr/bin/codex",
+        )
+        # Tiny timeout so the test does not actually wait.
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review._CODEX_EXEC_TIMEOUT_S",
+            0.05,
+        )
+
+        async def _never_returns(*_args, **_kwargs):
+            await asyncio.sleep(3600)  # hang well past the timeout
+
+        # MagicMock base so .kill() is synchronous (like real Popen.kill);
+        # .communicate/.wait are async. Nonexistent pid -> os.getpgid raises
+        # ProcessLookupError, exercising the proc.kill() fallback branch.
+        fake_proc = MagicMock()
+        fake_proc.pid = 2147483646
+        fake_proc.returncode = None
+        fake_proc.communicate = _never_returns
+        fake_proc.wait = AsyncMock()
+
+        with patch(
+            "genesis.autonomy.executor.review.asyncio.create_subprocess_exec",
+            return_value=fake_proc,
+        ):
+            reviewer = TaskReviewer(router=AsyncMock())
+            # Outer guard: if the fix is absent the inner call hangs, and
+            # this raises TimeoutError -> the test fails (RED), rather than
+            # hanging the suite.
+            result = await asyncio.wait_for(
+                reviewer._verify_via_codex("deliverable", "reqs"),
+                timeout=5,
+            )
+
+        assert result is None
+        # The hung subprocess must have been killed and reaped.
+        fake_proc.kill.assert_called_once()
+        fake_proc.wait.assert_awaited()
+
+    async def test_codex_hang_kills_process_group(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """On timeout with a valid pgid, the whole process GROUP is SIGKILLed
+        (the production path — codex is a Node launcher that spawns children),
+        not just the direct pid."""
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.shutil.which",
+            lambda name: "/usr/bin/codex",
+        )
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review._CODEX_EXEC_TIMEOUT_S", 0.05,
+        )
+
+        async def _never_returns(*_args, **_kwargs):
+            await asyncio.sleep(3600)
+
+        killpg_calls: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.os.getpgid", lambda pid: 4242,
+        )
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.os.killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 4242
+        fake_proc.returncode = None
+        fake_proc.communicate = _never_returns
+        fake_proc.wait = AsyncMock()
+
+        with patch(
+            "genesis.autonomy.executor.review.asyncio.create_subprocess_exec",
+            return_value=fake_proc,
+        ):
+            reviewer = TaskReviewer(router=AsyncMock())
+            result = await asyncio.wait_for(
+                reviewer._verify_via_codex("deliverable", "reqs"), timeout=5,
+            )
+
+        assert result is None
+        assert killpg_calls == [(4242, signal.SIGKILL)]
+        # Group kill taken -> the direct proc.kill() fallback is NOT used.
+        fake_proc.kill.assert_not_called()
+
+    async def test_codex_hang_pgid_guard_refuses_group_kill(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If getpgid returns <=1, killpg MUST NOT fire (killpg(1|0, sig) would
+        signal every process in the container); fall back to the direct pid."""
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.shutil.which",
+            lambda name: "/usr/bin/codex",
+        )
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review._CODEX_EXEC_TIMEOUT_S", 0.05,
+        )
+
+        async def _never_returns(*_args, **_kwargs):
+            await asyncio.sleep(3600)
+
+        killpg_calls: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.os.getpgid", lambda pid: 1,
+        )
+        monkeypatch.setattr(
+            "genesis.autonomy.executor.review.os.killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 777
+        fake_proc.returncode = None
+        fake_proc.communicate = _never_returns
+        fake_proc.wait = AsyncMock()
+
+        with patch(
+            "genesis.autonomy.executor.review.asyncio.create_subprocess_exec",
+            return_value=fake_proc,
+        ):
+            reviewer = TaskReviewer(router=AsyncMock())
+            result = await asyncio.wait_for(
+                reviewer._verify_via_codex("deliverable", "reqs"), timeout=5,
+            )
+
+        assert result is None
+        assert killpg_calls == []            # guard refused the group kill
+        fake_proc.kill.assert_called_once()  # fell back to the direct kill
+
+
+class TestCodexTimeoutEnvParse:
+    """_read_codex_timeout_s must fail safe: a malformed/non-positive override
+    parsed at import must not crash the autonomy executor's import."""
+
+    def test_default_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from genesis.autonomy.executor.review import (
+            _DEFAULT_CODEX_EXEC_TIMEOUT_S,
+            _read_codex_timeout_s,
+        )
+        monkeypatch.delenv("GENESIS_CODEX_REVIEW_TIMEOUT_S", raising=False)
+        assert _read_codex_timeout_s() == _DEFAULT_CODEX_EXEC_TIMEOUT_S
+
+    def test_valid_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from genesis.autonomy.executor.review import _read_codex_timeout_s
+        monkeypatch.setenv("GENESIS_CODEX_REVIEW_TIMEOUT_S", "600")
+        assert _read_codex_timeout_s() == 600.0
+
+    def test_malformed_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from genesis.autonomy.executor.review import (
+            _DEFAULT_CODEX_EXEC_TIMEOUT_S,
+            _read_codex_timeout_s,
+        )
+        monkeypatch.setenv("GENESIS_CODEX_REVIEW_TIMEOUT_S", "2h")
+        assert _read_codex_timeout_s() == _DEFAULT_CODEX_EXEC_TIMEOUT_S
+
+    def test_nonpositive_falls_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from genesis.autonomy.executor.review import (
+            _DEFAULT_CODEX_EXEC_TIMEOUT_S,
+            _read_codex_timeout_s,
+        )
+        monkeypatch.setenv("GENESIS_CODEX_REVIEW_TIMEOUT_S", "0")
+        assert _read_codex_timeout_s() == _DEFAULT_CODEX_EXEC_TIMEOUT_S
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`autonomy/executor/review.py::_verify_via_codex` runs `codex exec` and `await`s
`communicate()` with **no timeout**. `verify_deliverable` is invoked at the
VERIFYING phase under the autonomy executor's `_exec_semaphore` — a
`Semaphore(1)` acquired in `dispatcher._guarded_execute` around
`engine.execute`. So a hung `codex` (the known upstream model-catalog-refresh
hang is one of several causes) wedges **all** autonomy task execution
indefinitely, with no watchdog to recover short of a restart.

## Fix

- Wrap `communicate()` in `asyncio.wait_for(_CODEX_EXEC_TIMEOUT_S)`.
- On timeout, kill the codex process **tree** and return `None` — the existing
  "codex unavailable" degradation, so verification falls through to the
  CC-invoker / API links. `codex` is a Node launcher that spawns children, so
  the subprocess is spawned with `preexec_fn=os.setpgrp` (its own process
  group) and killed via a guarded `killpg` (a `pgid<=1` guard prevents a
  container-wide kill) — the exact pattern already proven in `cc/invoker.py`.
- Timeout default 2h (matches `deterministic.py`'s `_HARD_TIMEOUT_S`, the
  justified-exception case in the timeout policy — a raw subprocess holding the
  executor semaphore), override via `GENESIS_CODEX_REVIEW_TIMEOUT_S`. The
  override is parsed fail-safe so a malformed value can't crash the executor
  import.

## Tests / verification

- Unit: hang→timeout→None, the primary `killpg` branch, the `pgid<=1` guard
  refusal, and env-parse fallbacks. verify-RED confirmed by mutation (stripping
  the `wait_for` fails the test).
- Live E2E: a real hung codex process tree (parent + child) is fully reaped with
  zero orphans; a real `setpgrp` group is killed; the `pgid>1` guard holds.
- `test_executor` suite green (424); ruff clean.

## Review

genesis-architect adversarial review: SHIP-WITH-FIXES. Its MEDIUM-1 (env-parse
hardening) and NOTE-1 (killpg-branch + guard tests) landed in this PR. The
sibling `contribution/review.py` has the same orphan-on-timeout class in a
different subsystem (bounded 300s timeout, not an executor wedge) — tracked as a
follow-up, not inlined.

Ledger: 2a7374a115344b29883fe722fd2c8743

🤖 Generated with [Claude Code](https://claude.com/claude-code)
