### PR TITLE
fix(hygiene): reap detached-HEAD worktrees + recover them

### DIFF
--- a/scripts/worktree_lifecycle.py
+++ b/scripts/worktree_lifecycle.py
@@ -4,7 +4,10 @@
 Identifies and trashes worktrees that are:
 1. Not in use by any process (no /proc/*/cwd inside them)
 2. Inactive for 14+ days (no file modifications)
-3. Branch is merged (PR merged on GitHub) OR has zero unique commits
+3. Merged into main — branch merged (PR on GitHub) OR zero unique commits.
+   A detached-HEAD worktree (no branch) is judged by whether its HEAD commit
+   is already in main; without this it would default to branch "unknown" and
+   never be reaped.
 
 Trashed worktrees are recoverable for 7 days. After that, permanently
 deleted along with their branches.
@@ -83,7 +86,9 @@ def _find_processes_in_dir(dir_path: str) -> list[int]:
 def _list_worktrees(repo_root: Path) -> list[dict]:
     """Parse git worktree list --porcelain into structured data.
 
-    Returns list of dicts with keys: path, branch, head.
+    Returns list of dicts with keys: path, head, branch, detached. ``branch`` is
+    absent for a detached HEAD (porcelain emits a bare ``detached`` line instead),
+    in which case ``detached`` is True.
     Excludes the main worktree (bare=True or first entry).
     """
     try:
@@ -111,6 +116,10 @@ def _list_worktrees(repo_root: Path) -> list[dict]:
             # refs/heads/branch-name → branch-name
             ref = line[len("branch "):]
             current["branch"] = ref.removeprefix("refs/heads/")
+        elif line == "detached":
+            # Detached HEAD: porcelain emits a bare "detached" line and NO
+            # "branch " line. Mark it so the merge check keys off the HEAD sha.
+            current["detached"] = True
         elif line == "":
             if current and "path" in current and not is_first:
                 worktrees.append(current)
@@ -155,20 +164,25 @@ def _last_activity_time(worktree_path: str) -> float:
     return latest
 
 
-def _branch_is_merged(branch: str, repo_root: Path) -> bool:
-    """Check if a branch's PR is merged on GitHub.
+def _is_merged(ref: str, repo_root: Path, *, is_branch: bool = True) -> bool:
+    """Check whether a worktree's work is already in ``main``.
 
-    Three methods tried in order:
-    1. git merge-base --is-ancestor (fast, works for non-squash merges)
-    2. gh pr list --head <branch> --state merged (handles squash merges)
-    3. Zero unique commits vs main (git cherry)
+    ``ref`` is a branch name (``is_branch=True``) or, for a detached-HEAD
+    worktree, its HEAD commit SHA (``is_branch=False``). Three methods in order:
+    1. git merge-base --is-ancestor (fast; works for a branch ref OR a raw SHA)
+    2. gh pr list --head <branch> --state merged (branch only — handles squash
+       merges; a bare SHA is never a PR head, so this is skipped when detached)
+    3. Zero unique commits vs main (git cherry; patch-id, works for either ref)
 
-    Returns False on any error (fail-safe: keep the worktree).
+    Returns False on any error (fail-safe: keep the worktree). Consequence for a
+    detached HEAD: if its commits were squash-merged (so it is neither an ancestor
+    of main nor patch-equivalent) it is kept, never reaped — fail-safe, since the
+    gh-PR method that would catch a squash can't key off a bare SHA.
     """
-    # Method 1: git merge-base
+    # Method 1: git merge-base (branch ref or raw SHA)
     try:
         result = subprocess.run(
-            ["git", "merge-base", "--is-ancestor", branch, "main"],
+            ["git", "merge-base", "--is-ancestor", ref, "main"],
             capture_output=True, cwd=str(repo_root), timeout=10,
         )
         if result.returncode == 0:
@@ -176,24 +190,26 @@ def _branch_is_merged(branch: str, repo_root: Path) -> bool:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
 
-    # Method 2: gh pr list (handles squash merges)
-    try:
-        result = subprocess.run(
-            ["gh", "pr", "list", "--head", branch, "--state", "merged",
-             "--limit", "1", "--json", "number"],
-            capture_output=True, text=True, cwd=str(repo_root), timeout=30,
-        )
-        if result.returncode == 0:
-            prs = json.loads(result.stdout)
-            if prs:
-                return True
-    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
-        pass
+    # Method 2: gh pr list (handles squash merges) — branch heads only; a bare
+    # commit SHA is never a PR head, so skip it for a detached HEAD.
+    if is_branch:
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "list", "--head", ref, "--state", "merged",
+                 "--limit", "1", "--json", "number"],
+                capture_output=True, text=True, cwd=str(repo_root), timeout=30,
+            )
+            if result.returncode == 0:
+                prs = json.loads(result.stdout)
+                if prs:
+                    return True
+        except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
+            pass
 
-    # Method 3: zero unique commits
+    # Method 3: zero unique commits (patch-id equivalence)
     try:
         result = subprocess.run(
-            ["git", "cherry", "main", branch],
+            ["git", "cherry", "main", ref],
             capture_output=True, text=True, cwd=str(repo_root), timeout=10,
         )
         if result.returncode == 0:
@@ -221,7 +237,8 @@ def _trash_worktree(
     Returns True if trashed (or would be trashed in dry-run).
     """
     wt_path = Path(wt["path"])
-    branch = wt.get("branch", "unknown")
+    branch = wt.get("branch", "")
+    detached = wt.get("detached", False)
     name = wt_path.name
     date_str = datetime.now(UTC).strftime("%Y%m%d")
     trash_name = f"{name}-{date_str}"
@@ -248,6 +265,7 @@ def _trash_worktree(
             "original_path": str(wt_path),
             "branch": branch,
             "commit": wt.get("head", ""),
+            "detached": detached,
             "trashed_at": datetime.now(UTC).isoformat(),
         }
         staging_meta = TRASH_DIR / f".{trash_path.name}.meta.staging"
@@ -266,7 +284,8 @@ def _trash_worktree(
             capture_output=True, cwd=str(repo_root), timeout=10,
         )
 
-        _log(f"TRASH {wt_path}: branch={branch}, recoverable for {TRASH_RETENTION_DAYS}d at {trash_path}")
+        ref_label = f"branch={branch}" if branch else f"detached {wt.get('head', '')[:8]}"
+        _log(f"TRASH {wt_path}: {ref_label}, recoverable for {TRASH_RETENTION_DAYS}d at {trash_path}")
         return True
     except (OSError, shutil.Error) as e:
         _log(f"ERROR trashing {wt_path}: {e}")
@@ -371,8 +390,12 @@ def _recover(name: str, repo_root: Path) -> bool:
     meta = json.loads(meta_path.read_text())
     original_path = meta.get("original_path", "")
     branch = meta.get("branch", "")
+    commit = meta.get("commit", "")
+    detached = meta.get("detached", False)
 
-    if not original_path or not branch:
+    # Recoverable if we have a place to put it AND a ref to recreate it from
+    # (a branch, or — for a detached HEAD — its commit).
+    if not original_path or (not branch and not commit):
         print(f"Incomplete metadata in {meta_path}", file=sys.stderr)
         return False
 
@@ -381,9 +404,13 @@ def _recover(name: str, repo_root: Path) -> bool:
         print(f"Original path already exists: {original_path}", file=sys.stderr)
         return False
 
-    # Try to recreate worktree from the branch
+    # Recreate the worktree: detached at its commit, or checked out on its branch.
+    if detached or not branch:
+        add_cmd = ["git", "worktree", "add", "--detach", original_path, commit]
+    else:
+        add_cmd = ["git", "worktree", "add", original_path, branch]
     result = subprocess.run(
-        ["git", "worktree", "add", original_path, branch],
+        add_cmd,
         capture_output=True, text=True, cwd=str(repo_root), timeout=30,
     )
 
@@ -416,7 +443,8 @@ def _recover(name: str, repo_root: Path) -> bool:
     # Clean up trash entry
     shutil.rmtree(str(trash_path))
 
-    print(f"Recovered to {original_path} (branch: {branch})")
+    ref_label = f"branch: {branch}" if branch else f"detached at {commit[:8]}"
+    print(f"Recovered to {original_path} ({ref_label})")
     if trash_files:
         print(f"Restored {len(trash_files)} uncommitted file(s) from trash")
     return True
@@ -506,7 +534,8 @@ def main() -> int:
 
     for wt in worktrees:
         wt_path = wt.get("path", "")
-        branch = wt.get("branch", "unknown")
+        branch = wt.get("branch")  # None for a detached HEAD
+        head = wt.get("head", "")
 
         if not wt_path or not Path(wt_path).exists():
             _log(f"SKIP {wt_path}: directory does not exist (ghost entry)")
@@ -526,9 +555,12 @@ def main() -> int:
             _log(f"SKIP {wt_path}: activity {age_days:.0f}d ago (< {STALE_DAYS}d)")
             continue
 
-        # Check 3: branch merged
-        if not _branch_is_merged(branch, repo_root):
-            _log(f"SKIP {wt_path}: branch '{branch}' not merged")
+        # Check 3: work already merged into main. A detached HEAD (no branch)
+        # is judged by its HEAD commit, not the missing branch name.
+        ref, is_branch = (branch, True) if branch else (head, False)
+        if not ref or not _is_merged(ref, repo_root, is_branch=is_branch):
+            label = f"branch '{branch}'" if branch else f"detached HEAD {head[:8]}"
+            _log(f"SKIP {wt_path}: {label} not merged")
             continue
 
         # All checks passed — trash it

--- a/scripts/worktree_lifecycle.py
+++ b/scripts/worktree_lifecycle.py
@@ -168,18 +168,28 @@ def _is_merged(ref: str, repo_root: Path, *, is_branch: bool = True) -> bool:
     """Check whether a worktree's work is already in ``main``.
 
     ``ref`` is a branch name (``is_branch=True``) or, for a detached-HEAD
-    worktree, its HEAD commit SHA (``is_branch=False``). Three methods in order:
-    1. git merge-base --is-ancestor (fast; works for a branch ref OR a raw SHA)
-    2. gh pr list --head <branch> --state merged (branch only — handles squash
-       merges; a bare SHA is never a PR head, so this is skipped when detached)
-    3. Zero unique commits vs main (git cherry; patch-id, works for either ref)
+    worktree, its HEAD commit SHA (``is_branch=False``).
 
-    Returns False on any error (fail-safe: keep the worktree). Consequence for a
-    detached HEAD: if its commits were squash-merged (so it is neither an ancestor
-    of main nor patch-equivalent) it is kept, never reaped — fail-safe, since the
-    gh-PR method that would catch a squash can't key off a bare SHA.
+    For a BRANCH, three methods in order:
+    1. git merge-base --is-ancestor (fast; branch tip is an ancestor of main)
+    2. gh pr list --head <branch> --state merged (handles squash merges)
+    3. Zero unique commits vs main (git cherry; patch-id equivalence)
+
+    For a DETACHED HEAD, ONLY Method 1 (true ancestor of main) is trusted; the
+    patch-id method (3) and the PR method (2) are skipped. This is deliberate: a
+    bare commit referenced only by the worktree HEAD has no branch protecting it,
+    so reaping a merely patch-equivalent (non-ancestor) commit would let a GC
+    collect it inside the recovery window; and ``git cherry`` omits merge commits
+    entirely (no patch id), so a unique merge commit would be mis-read as "no
+    unique work" and wrongly reaped. A true ancestor is both genuinely in main's
+    history AND reachable (GC-safe). The cost is fail-safe: a detached HEAD whose
+    work reached main only by squash/rebase (patch-equal but not an ancestor) is
+    kept, never reaped.
+
+    Returns False on any error (fail-safe: keep the worktree).
     """
-    # Method 1: git merge-base (branch ref or raw SHA)
+    # Method 1: git merge-base (branch ref or raw SHA) — the ONLY method for a
+    # detached HEAD (see docstring: patch-id/PR methods are unsafe for a bare SHA).
     try:
         result = subprocess.run(
             ["git", "merge-base", "--is-ancestor", ref, "main"],
@@ -190,23 +200,24 @@ def _is_merged(ref: str, repo_root: Path, *, is_branch: bool = True) -> bool:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
 
-    # Method 2: gh pr list (handles squash merges) — branch heads only; a bare
-    # commit SHA is never a PR head, so skip it for a detached HEAD.
-    if is_branch:
-        try:
-            result = subprocess.run(
-                ["gh", "pr", "list", "--head", ref, "--state", "merged",
-                 "--limit", "1", "--json", "number"],
-                capture_output=True, text=True, cwd=str(repo_root), timeout=30,
-            )
-            if result.returncode == 0:
-                prs = json.loads(result.stdout)
-                if prs:
-                    return True
-        except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
-            pass
+    if not is_branch:
+        return False  # detached HEAD: ancestor-only, no patch-id/PR fallbacks
 
-    # Method 3: zero unique commits (patch-id equivalence)
+    # Method 2: gh pr list (handles squash merges) — branch heads only.
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--head", ref, "--state", "merged",
+             "--limit", "1", "--json", "number"],
+            capture_output=True, text=True, cwd=str(repo_root), timeout=30,
+        )
+        if result.returncode == 0:
+            prs = json.loads(result.stdout)
+            if prs:
+                return True
+    except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
+        pass
+
+    # Method 3: zero unique commits (patch-id equivalence) — branch heads only.
     try:
         result = subprocess.run(
             ["git", "cherry", "main", ref],
@@ -426,8 +437,13 @@ def _recover(name: str, repo_root: Path) -> bool:
             print(f"Failed to move: {e}", file=sys.stderr)
             return False
 
-    # Worktree recreated from branch — now copy any uncommitted files
-    # that were in the trash but not in the branch
+    # Overlay the trashed WORKING state back onto the fresh checkout. The
+    # checkout only carries committed content, so restore every trashed file
+    # that is missing OR differs — this preserves uncommitted tracked edits and
+    # untracked files (mode via copy2). Note: a file the user had *deleted* in
+    # the dirty worktree, and the staged-vs-unstaged split, are not reconstructed.
+    import filecmp
+
     trash_files = set()
     for item in trash_path.rglob("*"):
         if item.is_file() and ".git" not in item.parts:
@@ -435,7 +451,7 @@ def _recover(name: str, repo_root: Path) -> bool:
             if rel.name == ".trash_meta.json":
                 continue
             target = Path(original_path) / rel
-            if not target.exists():
+            if not target.exists() or not filecmp.cmp(str(item), str(target), shallow=False):
                 target.parent.mkdir(parents=True, exist_ok=True)
                 shutil.copy2(str(item), str(target))
                 trash_files.add(str(rel))

--- a/scripts/worktree_lifecycle.py
+++ b/scripts/worktree_lifecycle.py
@@ -3,8 +3,9 @@
 
 Identifies and trashes worktrees that are:
 1. Not in use by any process (no /proc/*/cwd inside them)
-2. Not locked (`git worktree lock`) and with no in-progress Git operation
-   (rebase/merge/cherry-pick/revert/bisect) — both signal deliberate work
+2. Not locked (`git worktree lock`), with no in-progress Git operation
+   (rebase/merge/cherry-pick/revert/bisect), and not containing a nested
+   worktree — each signals deliberate/in-progress work to preserve
 3. Inactive for 14+ days (no file modifications)
 4. Merged into main — branch merged (PR on GitHub) OR zero unique commits.
    A detached-HEAD worktree (no branch) is judged by whether its HEAD commit
@@ -260,8 +261,10 @@ def _has_in_progress_op(worktree_path: str) -> bool:
     per-worktree admin dir, discarded by ``git worktree prune``), making
     ``git rebase --continue`` etc. impossible. Resolves each marker via
     ``git rev-parse --git-path`` so it hits the worktree's OWN admin dir, not the
-    shared one. Fail-safe: on any error returns False (treat as not-in-progress,
-    letting the other skip-checks decide) — this never *causes* a reap on its own.
+    shared one. Fail-CLOSED: if the marker paths can't be resolved (git missing,
+    timeout, or the worktree's .git is transiently unreadable/malformed), returns
+    True (unknown → assume in-progress and KEEP the worktree) rather than letting a
+    possibly-mid-operation worktree be reaped.
     """
     for marker in _IN_PROGRESS_MARKERS:
         try:
@@ -270,12 +273,12 @@ def _has_in_progress_op(worktree_path: str) -> bool:
                 capture_output=True, text=True, cwd=worktree_path, timeout=10,
             )
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-            return False
+            return True  # fail-closed: can't verify state → protect the worktree
         if result.returncode != 0:
-            continue
+            return True  # can't resolve marker path (broken/unreadable .git) → protect
         rel = result.stdout.strip()
         if not rel:
-            continue
+            return True  # unexpected empty path → protect rather than assume clean
         p = rel if os.path.isabs(rel) else os.path.join(worktree_path, rel)
         if os.path.exists(p):
             return True
@@ -495,27 +498,41 @@ def _recover(name: str, repo_root: Path) -> bool:
             print(f"Failed to move: {e}", file=sys.stderr)
             return False
 
-    # Restore UNTRACKED files that were in the trash but not recreated by the
-    # fresh checkout (copy-only-missing). We deliberately do NOT overlay files
-    # that already exist in the checkout: overwriting through a checked-out
-    # tracked symlink could write OUTSIDE the worktree, and reconstructing the
-    # full dirty state (uncommitted tracked edits, deletions, mode-only changes,
-    # the staged/unstaged split) is not attempted — see the recovery contract in
-    # the function docstring. Committed content is always safe in main.
+    # Restore UNTRACKED files/symlinks that were in the trash but not recreated by
+    # the fresh checkout (copy-only-missing). Reconstructing the full dirty state
+    # (uncommitted tracked edits, deletions, mode-only changes, the staged/unstaged
+    # split) is not attempted — see the recovery contract in the function docstring;
+    # committed content is always safe in main.
+    #
+    # Two hard safety invariants (a recovery must NEVER write outside the worktree):
+    #  1. copy-only-missing keyed on os.path.lexists (does NOT dereference), so an
+    #     existing OR dangling destination symlink is left untouched — never written
+    #     through to whatever it points at.
+    #  2. the resolved parent of every destination must stay INSIDE the worktree
+    #     root; a symlinked path component that would redirect the write outside is
+    #     refused. Symlinks are recreated AS symlinks (os.symlink), never dereferenced.
+    worktree_root = os.path.realpath(original_path)
     trash_files = set()
     for item in trash_path.rglob("*"):
-        if item.is_file() and ".git" not in item.parts:
-            rel = item.relative_to(trash_path)
-            if rel.name == ".trash_meta.json":
-                continue
-            target = Path(original_path) / rel
-            if not target.exists():
-                target.parent.mkdir(parents=True, exist_ok=True)
-                # follow_symlinks=False: restore an untracked symlink AS a symlink
-                # (don't dereference — avoids materializing its target and avoids a
-                # crash if that target is unreadable).
-                shutil.copy2(str(item), str(target), follow_symlinks=False)
-                trash_files.add(str(rel))
+        if ".git" in item.parts:
+            continue
+        if not (item.is_symlink() or item.is_file()):
+            continue  # dirs are created implicitly; skip FIFOs/sockets/etc.
+        rel = item.relative_to(trash_path)
+        if rel.name == ".trash_meta.json":
+            continue
+        target = Path(original_path) / rel
+        if os.path.lexists(str(target)):
+            continue  # invariant 1: never overwrite / never write through a dest symlink
+        parent_real = os.path.realpath(str(target.parent))
+        if parent_real != worktree_root and not parent_real.startswith(worktree_root + os.sep):
+            continue  # invariant 2: a symlinked path component would escape the worktree
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if item.is_symlink():
+            os.symlink(os.readlink(str(item)), str(target))  # restore the link itself
+        else:
+            shutil.copy2(str(item), str(target))
+        trash_files.add(str(rel))
 
     # Clean up trash entry
     shutil.rmtree(str(trash_path))
@@ -631,7 +648,18 @@ def main() -> int:
             _log(f"SKIP {wt_path}: locked (git worktree lock)")
             continue
         if _has_in_progress_op(wt_path):
-            _log(f"SKIP {wt_path}: in-progress git operation (rebase/merge/cherry-pick)")
+            _log(f"SKIP {wt_path}: in-progress or unresolvable git state (rebase/merge/broken .git)")
+            continue
+
+        # Never reap a worktree that CONTAINS another linked worktree: trashing
+        # moves the whole directory, dragging the nested worktree (and bypassing
+        # ITS locked/in-progress protections, which are checked on its own row).
+        wt_prefix = wt_path.rstrip("/") + os.sep
+        nested = [o["path"] for o in worktrees
+                  if o.get("path") and o["path"] != wt_path
+                  and o["path"].rstrip("/").startswith(wt_prefix)]
+        if nested:
+            _log(f"SKIP {wt_path}: contains nested worktree(s): {', '.join(nested[:3])}")
             continue
 
         # Check 1: active processes

--- a/scripts/worktree_lifecycle.py
+++ b/scripts/worktree_lifecycle.py
@@ -3,14 +3,16 @@
 
 Identifies and trashes worktrees that are:
 1. Not in use by any process (no /proc/*/cwd inside them)
-2. Inactive for 14+ days (no file modifications)
-3. Merged into main — branch merged (PR on GitHub) OR zero unique commits.
+2. Not locked (`git worktree lock`) and with no in-progress Git operation
+   (rebase/merge/cherry-pick/revert/bisect) — both signal deliberate work
+3. Inactive for 14+ days (no file modifications)
+4. Merged into main — branch merged (PR on GitHub) OR zero unique commits.
    A detached-HEAD worktree (no branch) is judged by whether its HEAD commit
    is already in main; without this it would default to branch "unknown" and
    never be reaped.
 
-Trashed worktrees are recoverable for 7 days. After that, permanently
-deleted along with their branches.
+Trashed worktrees are recoverable for 7 days (see _recover for the recovery
+contract). After that, permanently deleted along with their branches.
 
 Usage:
     worktree_lifecycle.py                    # Run: trash stale, purge old trash
@@ -86,9 +88,10 @@ def _find_processes_in_dir(dir_path: str) -> list[int]:
 def _list_worktrees(repo_root: Path) -> list[dict]:
     """Parse git worktree list --porcelain into structured data.
 
-    Returns list of dicts with keys: path, head, branch, detached. ``branch`` is
-    absent for a detached HEAD (porcelain emits a bare ``detached`` line instead),
-    in which case ``detached`` is True.
+    Returns list of dicts with keys: path, head, branch, detached, locked.
+    ``branch`` is absent for a detached HEAD (porcelain emits a bare ``detached``
+    line instead), in which case ``detached`` is True. ``locked`` is True when the
+    worktree is under ``git worktree lock``.
     Excludes the main worktree (bare=True or first entry).
     """
     try:
@@ -120,6 +123,12 @@ def _list_worktrees(repo_root: Path) -> list[dict]:
             # Detached HEAD: porcelain emits a bare "detached" line and NO
             # "branch " line. Mark it so the merge check keys off the HEAD sha.
             current["detached"] = True
+        elif line == "locked" or line.startswith("locked "):
+            # Explicit `git worktree lock` — an operator "do not touch" signal.
+            # (Porcelain emits `locked` since git 2.36; on older git the flag is
+            # simply never set and such a worktree falls through to the normal
+            # merged/inactive checks — degrades safe, never a hard error.)
+            current["locked"] = True
         elif line == "":
             if current and "path" in current and not is_first:
                 worktrees.append(current)
@@ -232,6 +241,44 @@ def _is_merged(ref: str, repo_root: Path, *, is_branch: bool = True) -> bool:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
 
+    return False
+
+
+# Per-worktree admin-dir markers for an in-progress Git operation. Each lives
+# under the worktree's OWN git dir (git resolves them per-worktree), so a paused
+# rebase/merge/cherry-pick/revert/bisect in one worktree is detectable there.
+_IN_PROGRESS_MARKERS = (
+    "rebase-merge", "rebase-apply", "MERGE_HEAD", "CHERRY_PICK_HEAD",
+    "REVERT_HEAD", "BISECT_LOG", "sequencer",
+)
+
+
+def _has_in_progress_op(worktree_path: str) -> bool:
+    """True if the worktree has a paused Git operation (rebase/merge/…).
+
+    Reaping such a worktree would destroy its sequencer state (it lives in the
+    per-worktree admin dir, discarded by ``git worktree prune``), making
+    ``git rebase --continue`` etc. impossible. Resolves each marker via
+    ``git rev-parse --git-path`` so it hits the worktree's OWN admin dir, not the
+    shared one. Fail-safe: on any error returns False (treat as not-in-progress,
+    letting the other skip-checks decide) — this never *causes* a reap on its own.
+    """
+    for marker in _IN_PROGRESS_MARKERS:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--git-path", marker],
+                capture_output=True, text=True, cwd=worktree_path, timeout=10,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            return False
+        if result.returncode != 0:
+            continue
+        rel = result.stdout.strip()
+        if not rel:
+            continue
+        p = rel if os.path.isabs(rel) else os.path.join(worktree_path, rel)
+        if os.path.exists(p):
+            return True
     return False
 
 
@@ -373,7 +420,18 @@ def _purge_old_trash(repo_root: Path, *, dry_run: bool = False) -> None:
 
 
 def _recover(name: str, repo_root: Path) -> bool:
-    """Recover a worktree from the trash."""
+    """Recover a worktree from the trash.
+
+    Recovery contract: recreates the worktree at its recorded ref (the branch, or
+    for a detached HEAD its commit) and restores untracked files that were in the
+    trash. It does NOT reconstruct the full dirty working state — uncommitted
+    tracked modifications, deletions, mode-only changes, and the staged/unstaged
+    split are not reapplied. This is intentional: the reaper only trashes worktrees
+    already merged into main, so committed content is always recoverable from main,
+    and overlaying arbitrary dirty state risks writing through checked-out symlinks.
+    (Full working-state recovery would require preserving the git admin dir at trash
+    time via ``git worktree move`` instead of ``shutil.move`` + ``git worktree prune``.)
+    """
     if not TRASH_DIR.exists():
         print(f"No trash directory found at {TRASH_DIR}", file=sys.stderr)
         return False
@@ -437,13 +495,13 @@ def _recover(name: str, repo_root: Path) -> bool:
             print(f"Failed to move: {e}", file=sys.stderr)
             return False
 
-    # Overlay the trashed WORKING state back onto the fresh checkout. The
-    # checkout only carries committed content, so restore every trashed file
-    # that is missing OR differs — this preserves uncommitted tracked edits and
-    # untracked files (mode via copy2). Note: a file the user had *deleted* in
-    # the dirty worktree, and the staged-vs-unstaged split, are not reconstructed.
-    import filecmp
-
+    # Restore UNTRACKED files that were in the trash but not recreated by the
+    # fresh checkout (copy-only-missing). We deliberately do NOT overlay files
+    # that already exist in the checkout: overwriting through a checked-out
+    # tracked symlink could write OUTSIDE the worktree, and reconstructing the
+    # full dirty state (uncommitted tracked edits, deletions, mode-only changes,
+    # the staged/unstaged split) is not attempted — see the recovery contract in
+    # the function docstring. Committed content is always safe in main.
     trash_files = set()
     for item in trash_path.rglob("*"):
         if item.is_file() and ".git" not in item.parts:
@@ -451,9 +509,12 @@ def _recover(name: str, repo_root: Path) -> bool:
             if rel.name == ".trash_meta.json":
                 continue
             target = Path(original_path) / rel
-            if not target.exists() or not filecmp.cmp(str(item), str(target), shallow=False):
+            if not target.exists():
                 target.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(str(item), str(target))
+                # follow_symlinks=False: restore an untracked symlink AS a symlink
+                # (don't dereference — avoids materializing its target and avoids a
+                # crash if that target is unreadable).
+                shutil.copy2(str(item), str(target), follow_symlinks=False)
                 trash_files.add(str(rel))
 
     # Clean up trash entry
@@ -462,7 +523,13 @@ def _recover(name: str, repo_root: Path) -> bool:
     ref_label = f"branch: {branch}" if branch else f"detached at {commit[:8]}"
     print(f"Recovered to {original_path} ({ref_label})")
     if trash_files:
-        print(f"Restored {len(trash_files)} uncommitted file(s) from trash")
+        print(f"Restored {len(trash_files)} untracked file(s) from trash")
+    print(
+        "Note: committed state restored at the ref plus untracked files; uncommitted "
+        "tracked edits, deletions, mode changes, and staged state are NOT reapplied "
+        "(committed content is always recoverable from main).",
+        file=sys.stderr,
+    )
     return True
 
 
@@ -555,6 +622,16 @@ def main() -> int:
 
         if not wt_path or not Path(wt_path).exists():
             _log(f"SKIP {wt_path}: directory does not exist (ghost entry)")
+            continue
+
+        # Operator protection: never reap a locked worktree or one with a paused
+        # Git operation (rebase/merge/…). Both signal deliberate/in-progress work;
+        # reaping would discard a `git worktree lock` or destroy sequencer state.
+        if wt.get("locked"):
+            _log(f"SKIP {wt_path}: locked (git worktree lock)")
+            continue
+        if _has_in_progress_op(wt_path):
+            _log(f"SKIP {wt_path}: in-progress git operation (rebase/merge/cherry-pick)")
             continue
 
         # Check 1: active processes

--- a/tests/test_scripts/test_worktree_lifecycle.py
+++ b/tests/test_scripts/test_worktree_lifecycle.py
@@ -257,3 +257,80 @@ def test_recover_legacy_branch_entry(reaper_repo, tmp_path, monkeypatch):
     # Restored ON the branch (not detached) — the legacy path is unchanged.
     branch = _git(src, "symbolic-ref", "--short", "HEAD").strip()
     assert branch == "merged-br"
+
+
+# ─── detached reap predicate is ancestor-ONLY (Codex P1 findings B & C) ───────
+
+
+def test_is_merged_detached_merge_commit_kept(reaper_repo):
+    """A detached MERGE commit (both parents in main, unique tree, NOT an
+    ancestor) must be KEPT. `git cherry` omits merges, so the old patch-id path
+    read empty output as "merged" and would wrongly reap unique merge work.
+    Ancestor-only detached detection keeps it. (Codex finding C.)
+    """
+    repo = reaper_repo.repo
+    side_tree = _git(repo, "rev-parse", f"{reaper_repo.c_side}^{{tree}}").strip()
+    merge = _git(
+        repo,
+        "commit-tree",
+        side_tree,
+        "-p",
+        reaper_repo.c1,
+        "-p",
+        reaper_repo.c0,
+        "-m",
+        "unique-merge",
+    ).strip()
+    # Sanity: not an ancestor, and git cherry emits nothing (merge omitted).
+    not_anc = subprocess.run(
+        ["git", "-C", str(repo), "merge-base", "--is-ancestor", merge, "main"],
+        capture_output=True,
+    ).returncode
+    assert not_anc != 0, "merge commit should not be an ancestor of main"
+    assert _git(repo, "cherry", "main", merge).strip() == ""
+    assert wl._is_merged(merge, repo, is_branch=False) is False
+
+
+def test_is_merged_detached_patch_equal_kept(reaper_repo):
+    """A detached commit patch-EQUAL to main but NOT an ancestor must be KEPT.
+    The old patch-id path counted it merged and reaped it, but it is referenced
+    only by the worktree HEAD → GC-fragile in the recovery window. Ancestor-only
+    detached detection keeps it. (Codex finding B.)
+    """
+    repo = reaper_repo.repo
+    c1_tree = _git(repo, "rev-parse", f"{reaper_repo.c1}^{{tree}}").strip()
+    # Same tree as c1, parent c0, distinct message → distinct sha, patch-equal, not an ancestor.
+    patch_equal = _git(
+        repo, "commit-tree", c1_tree, "-p", reaper_repo.c0, "-m", "cherrypicked"
+    ).strip()
+    assert patch_equal != reaper_repo.c1
+    # git cherry marks it patch-equal ('-'), i.e. zero unique '+' → old logic said merged.
+    assert _git(repo, "cherry", "main", patch_equal).strip().startswith("-")
+    assert wl._is_merged(patch_equal, repo, is_branch=False) is False
+
+
+# ─── recovery preserves uncommitted tracked edits (Codex P1 finding A) ────────
+
+
+def test_recover_preserves_uncommitted_modification(reaper_repo, tmp_path, monkeypatch):
+    """Recovery must not silently drop an uncommitted edit to a TRACKED file.
+
+    The old copy loop only restored files MISSING from the fresh checkout, so a
+    modified tracked file was reverted to its committed content while recovery
+    reported success. The overlay restores files that differ. (Codex finding A.)
+    """
+    trash = tmp_path / "trash"
+    trash.mkdir()
+    monkeypatch.setattr(wl, "TRASH_DIR", trash)
+    monkeypatch.setattr(wl, "LOG_DIR", trash / "logs")
+
+    wt = reaper_repo.wt_branch_merged
+    (wt / "a.txt").write_text("LOCALLY MODIFIED\n")  # a.txt is tracked (committed at c0)
+
+    wl._trash_worktree(_wt_by_path(reaper_repo.repo, wt), reaper_repo.repo)
+    assert not wt.exists()
+
+    assert wl._recover("wt_branch_merged", reaper_repo.repo) is True
+    assert (wt / "a.txt").read_text() == "LOCALLY MODIFIED\n", (
+        "recovery reverted an uncommitted tracked modification"
+    )

--- a/tests/test_scripts/test_worktree_lifecycle.py
+++ b/tests/test_scripts/test_worktree_lifecycle.py
@@ -1,0 +1,259 @@
+"""Tests for scripts/worktree_lifecycle.py — the daily worktree reaper.
+
+Regression coverage for the detached-HEAD blind spot: ``git worktree list
+--porcelain`` emits a bare ``detached`` line (no ``branch``) for a detached
+worktree, so the reaper used to default ``branch="unknown"`` and skip such
+worktrees forever even when their HEAD commit is fully merged into ``main``.
+
+These use REAL git repos in ``tmp_path`` (the house pattern from
+``test_git_repair.py``); the reaper shells out to git directly, so there is no
+mock seam. The load-bearing invariants under test:
+  * ``_list_worktrees`` marks a detached worktree (``detached=True``, no ``branch``);
+  * a detached HEAD at a MERGED commit is classified reapable, at an UNMERGED
+    commit is kept (fail-safe);
+  * the branch path is unchanged (merged branch still reaped);
+  * ``main()`` reaps ONLY the merged worktrees and trashes recoverably;
+  * a trashed detached worktree round-trips through ``_recover`` (re-added detached
+    at its commit), not just a plain-directory move.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "worktree_lifecycle.py"
+_spec = importlib.util.spec_from_file_location("worktree_lifecycle", _SCRIPT)
+wl = importlib.util.module_from_spec(_spec)
+sys.modules["worktree_lifecycle"] = wl
+_spec.loader.exec_module(wl)
+
+
+# ─── fixtures / helpers ──────────────────────────────────────────────────────
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _age_path(path: Path, days: float) -> None:
+    """Backdate mtimes of a worktree (dir + top-2 levels) past the stale gate.
+
+    Mirrors what ``_last_activity_time`` walks (dir + children, one level deep,
+    skipping ``.git``), so the worktree reads as inactive.
+    """
+    old = time.time() - days * 86400
+    os.utime(path, (old, old))
+    for item in path.rglob("*"):
+        if ".git" in item.parts:
+            continue
+        with contextlib.suppress(OSError):
+            os.utime(item, (old, old))
+
+
+@pytest.fixture
+def reaper_repo(tmp_path: Path):
+    """A real repo with detached + branch worktrees in known merge states.
+
+    Returns an object with: ``repo`` (main tree), the commit shas ``c0``/``c1``
+    (both on main) and ``c_side`` (NOT on main), and the worktree paths.
+    """
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    _git(repo, "config", "user.email", "s@s")
+    _git(repo, "config", "user.name", "s")
+
+    (repo / "a.txt").write_text("a\n")
+    _git(repo, "add", "a.txt")
+    _git(repo, "commit", "-q", "-m", "c0")
+    c0 = _git(repo, "rev-parse", "HEAD").strip()
+
+    (repo / "b.txt").write_text("b\n")
+    _git(repo, "add", "b.txt")
+    _git(repo, "commit", "-q", "-m", "c1")
+    c1 = _git(repo, "rev-parse", "HEAD").strip()  # main tip; c0 is an ancestor
+
+    # A commit that will NOT be in main's history (reachable only via a worktree).
+    _git(repo, "branch", "sidebr", c1)
+    _git(repo, "worktree", "add", "-q", str(tmp_path / "_sidewt"), "sidebr")
+    (tmp_path / "_sidewt" / "s.txt").write_text("s\n")
+    _git(tmp_path / "_sidewt", "add", "s.txt")
+    _git(tmp_path / "_sidewt", "commit", "-q", "-m", "c-side")
+    c_side = _git(tmp_path / "_sidewt", "rev-parse", "HEAD").strip()
+    _git(repo, "worktree", "remove", "--force", str(tmp_path / "_sidewt"))
+    _git(repo, "branch", "-D", "sidebr")  # c_side now only reachable via a detached HEAD
+
+    # A real branch that is merged into main (points at the ancestor c0).
+    _git(repo, "branch", "merged-br", c0)
+
+    wt_det_merged = tmp_path / "wt_det_merged"
+    wt_det_unmerged = tmp_path / "wt_det_unmerged"
+    wt_branch_merged = tmp_path / "wt_branch_merged"
+    _git(repo, "worktree", "add", "-q", "--detach", str(wt_det_merged), c0)
+    _git(repo, "worktree", "add", "-q", "--detach", str(wt_det_unmerged), c_side)
+    _git(repo, "worktree", "add", "-q", str(wt_branch_merged), "merged-br")
+
+    # Push all three past the 14-day inactivity gate.
+    for p in (wt_det_merged, wt_det_unmerged, wt_branch_merged):
+        _age_path(p, 20)
+
+    return type(
+        "ReaperRepo",
+        (),
+        {
+            "repo": repo,
+            "c0": c0,
+            "c1": c1,
+            "c_side": c_side,
+            "wt_det_merged": wt_det_merged,
+            "wt_det_unmerged": wt_det_unmerged,
+            "wt_branch_merged": wt_branch_merged,
+        },
+    )()
+
+
+def _wt_by_path(repo: Path, target: Path) -> dict:
+    for wt in wl._list_worktrees(repo):
+        if Path(wt["path"]) == target:
+            return wt
+    raise AssertionError(f"worktree not found: {target}")
+
+
+# ─── _list_worktrees: detached marking ───────────────────────────────────────
+
+
+def test_list_worktrees_marks_detached(reaper_repo):
+    wt = _wt_by_path(reaper_repo.repo, reaper_repo.wt_det_merged)
+    assert wt.get("detached") is True
+    assert "branch" not in wt
+    assert wt["head"] == reaper_repo.c0
+
+
+def test_list_worktrees_branch_worktree_unmarked(reaper_repo):
+    wt = _wt_by_path(reaper_repo.repo, reaper_repo.wt_branch_merged)
+    assert wt.get("detached") is not True
+    assert wt["branch"] == "merged-br"
+
+
+# ─── _is_merged: detached evaluated by HEAD commit ───────────────────────────
+
+
+def test_is_merged_detached_at_merged_commit(reaper_repo):
+    wt = _wt_by_path(reaper_repo.repo, reaper_repo.wt_det_merged)
+    assert wl._is_merged(wt["head"], reaper_repo.repo, is_branch=False) is True
+
+
+def test_is_merged_detached_at_unmerged_commit(reaper_repo):
+    wt = _wt_by_path(reaper_repo.repo, reaper_repo.wt_det_unmerged)
+    assert wl._is_merged(wt["head"], reaper_repo.repo, is_branch=False) is False
+
+
+def test_is_merged_branch_still_works(reaper_repo):
+    # Regression guard: the branch path (Method 1 short-circuits, no gh) is unchanged.
+    assert wl._is_merged("merged-br", reaper_repo.repo, is_branch=True) is True
+
+
+# ─── main(): end-to-end wiring — reap only the merged, trash recoverably ──────
+
+
+def _run_main(monkeypatch, repo: Path, trash: Path, *, argv=("worktree_lifecycle.py",)):
+    monkeypatch.setattr(wl, "_repo_root", lambda: repo)
+    monkeypatch.setattr(wl, "TRASH_DIR", trash)
+    monkeypatch.setattr(wl, "LOG_DIR", trash / "logs")
+    monkeypatch.setattr(sys, "argv", list(argv))
+    return wl.main()
+
+
+def test_main_reaps_detached_merged_only(reaper_repo, tmp_path, monkeypatch):
+    trash = tmp_path / "trash"
+    rc = _run_main(monkeypatch, reaper_repo.repo, trash)
+    assert rc == 0
+
+    # Detached-at-merged and branch-merged: reaped (moved out of place).
+    assert not reaper_repo.wt_det_merged.exists()
+    assert not reaper_repo.wt_branch_merged.exists()
+    # Detached-at-unmerged: kept (fail-safe).
+    assert reaper_repo.wt_det_unmerged.exists()
+
+    # The detached entry landed in trash with detached metadata + real commit sha.
+    import json
+
+    metas = list(trash.glob("wt_det_merged-*/.trash_meta.json"))
+    assert len(metas) == 1, f"expected one trashed detached worktree, got {metas}"
+    meta = json.loads(metas[0].read_text())
+    assert meta["detached"] is True
+    assert meta["commit"] == reaper_repo.c0
+
+
+# ─── _recover: detached round-trip (Part 3) ──────────────────────────────────
+
+
+def test_recover_detached_roundtrip(reaper_repo, tmp_path, monkeypatch):
+    trash = tmp_path / "trash"
+    _run_main(monkeypatch, reaper_repo.repo, trash)
+    assert not reaper_repo.wt_det_merged.exists()
+
+    # Recover it — must come back as a DETACHED worktree at the original commit,
+    # not a plain-directory move.
+    ok = wl._recover("wt_det_merged", reaper_repo.repo)
+    assert ok is True
+    assert reaper_repo.wt_det_merged.exists()
+
+    head = _git(reaper_repo.wt_det_merged, "rev-parse", "HEAD").strip()
+    assert head == reaper_repo.c0
+    # Detached HEAD: symbolic-ref for HEAD fails (not on a branch).
+    detached = subprocess.run(
+        ["git", "-C", str(reaper_repo.wt_det_merged), "symbolic-ref", "-q", "HEAD"],
+        capture_output=True,
+    )
+    assert detached.returncode != 0, "recovered worktree should be detached, not on a branch"
+
+
+def test_recover_legacy_branch_entry(reaper_repo, tmp_path, monkeypatch):
+    """A PRE-FIX trash entry (no ``detached`` key, ``branch`` set) still round-trips.
+
+    Locks the backward-compat guarantee for the ~dozens of legacy branch entries
+    already on disk: ``_recover`` must default ``detached`` to False and take the
+    ``git worktree add <path> <branch>`` path unchanged.
+    """
+    import json
+
+    trash = tmp_path / "trash"
+    trash.mkdir()
+    monkeypatch.setattr(wl, "TRASH_DIR", trash)
+
+    # Simulate the OLD reaper having trashed the branch worktree: move the dir out,
+    # prune the registration, and write a LEGACY meta with no ``detached`` key.
+    src = reaper_repo.wt_branch_merged
+    entry = trash / "wt_branch_merged-20260101"
+    subprocess.run(["mv", str(src), str(entry)], check=True)
+    _git(reaper_repo.repo, "worktree", "prune")
+    (entry / ".trash_meta.json").write_text(
+        json.dumps(
+            {
+                "original_path": str(src),
+                "branch": "merged-br",
+                "commit": reaper_repo.c0,
+                "trashed_at": "2026-01-01T00:00:00+00:00",
+            }
+        )
+    )
+
+    ok = wl._recover("wt_branch_merged", reaper_repo.repo)
+    assert ok is True
+    assert src.exists()
+    # Restored ON the branch (not detached) — the legacy path is unchanged.
+    branch = _git(src, "symbolic-ref", "--short", "HEAD").strip()
+    assert branch == "merged-br"

--- a/tests/test_scripts/test_worktree_lifecycle.py
+++ b/tests/test_scripts/test_worktree_lifecycle.py
@@ -402,3 +402,94 @@ def test_skip_in_progress_worktree(reaper_repo, tmp_path, monkeypatch):
 
     assert wl.main() == 0
     assert wt.exists(), "worktree with an in-progress git op must not be reaped"
+
+
+# ─── final class-closing round: symlink-safe recovery + fail-closed + nested ──
+
+
+def test_recover_restores_untracked_symlink_as_symlink(reaper_repo, tmp_path, monkeypatch):
+    """An untracked symlink is restored AS a symlink, not materialized/dropped."""
+    trash = tmp_path / "trash"
+    trash.mkdir()
+    monkeypatch.setattr(wl, "TRASH_DIR", trash)
+    monkeypatch.setattr(wl, "LOG_DIR", trash / "logs")
+
+    wt = reaper_repo.wt_branch_merged
+    (wt / "lnk").symlink_to("some/relative/target")  # untracked (dangling) symlink
+
+    wl._trash_worktree(_wt_by_path(reaper_repo.repo, wt), reaper_repo.repo)
+    assert wl._recover("wt_branch_merged", reaper_repo.repo) is True
+    restored = wt / "lnk"
+    assert restored.is_symlink(), "untracked symlink was not restored as a symlink"
+    assert os.readlink(str(restored)) == "some/relative/target"
+
+
+def test_recover_does_not_write_through_dangling_dest_symlink(tmp_path, monkeypatch):
+    """Recovery must NEVER write outside the worktree via a checked-out dest symlink.
+
+    Committed tree has a dangling symlink `esc` -> OUTSIDE; the dirty worktree
+    replaced it with a regular file (so the trash holds a regular `esc`). On
+    recovery, `git worktree add` restores the committed dangling symlink; the copy
+    loop must NOT write the trashed regular file through it to OUTSIDE. (Codex 512.)
+    """
+    repo = tmp_path / "repo"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    _git(repo, "config", "user.email", "s@s")
+    _git(repo, "config", "user.name", "s")
+    outside = tmp_path / "OUTSIDE.txt"  # must never be created
+    os.symlink(str(outside), str(repo / "esc"))  # committed symlink -> outside
+    _git(repo, "add", "esc")
+    _git(repo, "commit", "-qm", "add symlink")
+    _git(repo, "branch", "wbr", "HEAD")
+
+    wt = tmp_path / "wt"
+    _git(repo, "worktree", "add", "-q", str(wt), "wbr")
+    (wt / "esc").unlink()
+    (wt / "esc").write_text("dirty payload")  # dirty regular file replacing the symlink
+
+    trash = tmp_path / "trash"
+    trash.mkdir()
+    monkeypatch.setattr(wl, "TRASH_DIR", trash)
+    monkeypatch.setattr(wl, "LOG_DIR", trash / "logs")
+    wtdict = next(w for w in wl._list_worktrees(repo) if Path(w["path"]) == wt)
+    wl._trash_worktree(wtdict, repo)
+
+    assert wl._recover("wt", repo) is True
+    assert not outside.exists(), (
+        "recovery wrote through a dangling dest symlink OUTSIDE the worktree"
+    )
+
+
+def test_has_in_progress_op_fails_closed(tmp_path):
+    """When git state can't be resolved (non-repo / broken .git), fail CLOSED (True)."""
+    d = tmp_path / "notgit"
+    d.mkdir()
+    assert wl._has_in_progress_op(str(d)) is True
+
+
+def test_skip_worktree_containing_nested(reaper_repo, tmp_path, monkeypatch):
+    """A worktree that CONTAINS another linked worktree is never reaped."""
+    trash = tmp_path / "trash"
+    monkeypatch.setattr(wl, "_repo_root", lambda: reaper_repo.repo)
+    monkeypatch.setattr(wl, "TRASH_DIR", trash)
+    monkeypatch.setattr(wl, "LOG_DIR", trash / "logs")
+    monkeypatch.setattr(sys, "argv", ["worktree_lifecycle.py"])
+
+    parent = reaper_repo.wt_branch_merged  # merged → would be reaped
+    nested = parent / "nested_wt"
+    # nested at an UNMERGED commit so it is never independently reaped (deterministic)
+    _git(reaper_repo.repo, "worktree", "add", "-q", "--detach", str(nested), reaper_repo.c_side)
+    _age_path(parent, 20)
+    # _age_path skips '.git', but the nested worktree's gitdir pointer file
+    # (nested_wt/.git) stays fresh and keeps the PARENT reading as active — which
+    # would mask the guard (the activity check, not the nested guard, would protect
+    # the parent). Backdate the nested worktree fully so ONLY the nested guard can
+    # keep the parent alive → the test REDs if the guard is removed.
+    old = time.time() - 20 * 86400
+    for p in nested.rglob("*"):
+        with contextlib.suppress(OSError):
+            os.utime(p, (old, old), follow_symlinks=False)
+    os.utime(nested / ".git", (old, old))
+
+    assert wl.main() == 0
+    assert parent.exists(), "worktree containing a nested worktree must not be reaped"

--- a/tests/test_scripts/test_worktree_lifecycle.py
+++ b/tests/test_scripts/test_worktree_lifecycle.py
@@ -312,12 +312,13 @@ def test_is_merged_detached_patch_equal_kept(reaper_repo):
 # ─── recovery preserves uncommitted tracked edits (Codex P1 finding A) ────────
 
 
-def test_recover_preserves_uncommitted_modification(reaper_repo, tmp_path, monkeypatch):
-    """Recovery must not silently drop an uncommitted edit to a TRACKED file.
+def test_recover_restores_untracked_file(reaper_repo, tmp_path, monkeypatch):
+    """Recovery restores UNTRACKED files that the fresh checkout would not recreate.
 
-    The old copy loop only restored files MISSING from the fresh checkout, so a
-    modified tracked file was reverted to its committed content while recovery
-    reported success. The overlay restores files that differ. (Codex finding A.)
+    This is the recovery contract's positive guarantee (copy-only-missing). Full
+    dirty-state reconstruction — uncommitted tracked edits, deletions, mode-only
+    changes, the staged split — is an intentional non-goal (see _recover docstring),
+    since the reaper only trashes worktrees already merged into main.
     """
     trash = tmp_path / "trash"
     trash.mkdir()
@@ -325,12 +326,79 @@ def test_recover_preserves_uncommitted_modification(reaper_repo, tmp_path, monke
     monkeypatch.setattr(wl, "LOG_DIR", trash / "logs")
 
     wt = reaper_repo.wt_branch_merged
-    (wt / "a.txt").write_text("LOCALLY MODIFIED\n")  # a.txt is tracked (committed at c0)
+    (wt / "scratch.txt").write_text("untracked scratch\n")  # untracked, absent from the commit
 
     wl._trash_worktree(_wt_by_path(reaper_repo.repo, wt), reaper_repo.repo)
     assert not wt.exists()
 
     assert wl._recover("wt_branch_merged", reaper_repo.repo) is True
-    assert (wt / "a.txt").read_text() == "LOCALLY MODIFIED\n", (
-        "recovery reverted an uncommitted tracked modification"
+    assert (wt / "scratch.txt").read_text() == "untracked scratch\n", (
+        "recovery dropped an untracked file that was in the trash"
     )
+
+
+def test_recover_does_not_reapply_tracked_modification(reaper_repo, tmp_path, monkeypatch):
+    """A trashed uncommitted edit to a TRACKED file is NOT reapplied on recovery.
+
+    copy-only-missing leaves the checked-out (committed) content intact. This LOCKS
+    the overlay->copy-only-missing revert: the old filecmp overlay would have
+    overwritten the tracked file with the trashed modification, so this test fails
+    on the pre-revert code and passes now. (Codex 444/456 non-goal, by design.)
+    """
+    trash = tmp_path / "trash"
+    trash.mkdir()
+    monkeypatch.setattr(wl, "TRASH_DIR", trash)
+    monkeypatch.setattr(wl, "LOG_DIR", trash / "logs")
+
+    wt = reaper_repo.wt_branch_merged
+    committed = (wt / "a.txt").read_text()  # tracked, committed at c0
+    (wt / "a.txt").write_text("DIRTY EDIT\n")  # uncommitted tracked modification
+
+    wl._trash_worktree(_wt_by_path(reaper_repo.repo, wt), reaper_repo.repo)
+    assert wl._recover("wt_branch_merged", reaper_repo.repo) is True
+    assert (wt / "a.txt").read_text() == committed, (
+        "recovery reapplied a trashed tracked modification (overlay behavior)"
+    )
+
+
+def test_skip_locked_worktree(reaper_repo, tmp_path, monkeypatch):
+    """A locked (git worktree lock) worktree is never reaped, even when merged."""
+    trash = tmp_path / "trash"
+    monkeypatch.setattr(wl, "_repo_root", lambda: reaper_repo.repo)
+    monkeypatch.setattr(wl, "TRASH_DIR", trash)
+    monkeypatch.setattr(wl, "LOG_DIR", trash / "logs")
+    monkeypatch.setattr(sys, "argv", ["worktree_lifecycle.py"])
+
+    # merged branch worktree that would otherwise be reaped → lock it
+    _git(
+        reaper_repo.repo,
+        "worktree",
+        "lock",
+        str(reaper_repo.wt_branch_merged),
+        "--reason",
+        "protected",
+    )
+
+    # sanity: the parser flags it locked
+    assert _wt_by_path(reaper_repo.repo, reaper_repo.wt_branch_merged).get("locked") is True
+
+    assert wl.main() == 0
+    assert reaper_repo.wt_branch_merged.exists(), "locked worktree must not be reaped"
+
+
+def test_skip_in_progress_worktree(reaper_repo, tmp_path, monkeypatch):
+    """A worktree with a paused Git operation (MERGE_HEAD) is never reaped."""
+    trash = tmp_path / "trash"
+    monkeypatch.setattr(wl, "_repo_root", lambda: reaper_repo.repo)
+    monkeypatch.setattr(wl, "TRASH_DIR", trash)
+    monkeypatch.setattr(wl, "LOG_DIR", trash / "logs")
+    monkeypatch.setattr(sys, "argv", ["worktree_lifecycle.py"])
+
+    wt = reaper_repo.wt_det_merged  # detached at a merged commit → would be reaped
+    # Simulate an in-progress merge: write MERGE_HEAD into the worktree's admin dir.
+    admin = _git(wt, "rev-parse", "--absolute-git-dir").strip()
+    (Path(admin) / "MERGE_HEAD").write_text(_git(wt, "rev-parse", "HEAD"))
+    assert wl._has_in_progress_op(str(wt)) is True
+
+    assert wl.main() == 0
+    assert wt.exists(), "worktree with an in-progress git op must not be reaped"


### PR DESCRIPTION
## What

The daily worktree reaper (`scripts/worktree_lifecycle.py`, run by
`genesis-disk-hygiene.timer`) never reaped **detached-HEAD** worktrees — they
accumulated forever even when fully merged into `main`.

## Root cause (measured)

`git worktree list --porcelain` emits `HEAD <sha>` + a bare `detached` line (and
**no** `branch` line) for a detached worktree. The parser stored `head` but no
`branch`, so `main()` defaulted `branch="unknown"` and the merged-check ran all
three methods against the literal ref `unknown` — all fail → the worktree was
skipped every day. Fingerprint in the live journal: `SKIP …/e2e-phase1: branch
'unknown' not merged` (recurring). The other ~90 branch worktrees were reaped
correctly; detached HEAD was the sole blind spot.

## The fix (3 parts)

1. **Parse the `detached` marker** — `_list_worktrees` sets `detached=True` (no
   `branch` key), making detachment explicit.
2. **Judge detached worktrees by their HEAD commit** — renamed
   `_branch_is_merged(branch, …)` → `_is_merged(ref, …, *, is_branch=True)`. For a
   detached HEAD the caller passes the HEAD **sha** with `is_branch=False`;
   `git merge-base --is-ancestor <ref> main` and `git cherry main <ref>` work for a
   branch name or a raw sha, and the `gh pr list --head` method is gated behind
   `is_branch` (a bare sha is never a PR head). The branch path is byte-identical.
3. **Round-trip detached worktrees through recovery** — `_trash_worktree` persists
   `detached` + `commit` in `.trash_meta.json`; `_recover` recreates a detached
   worktree via `git worktree add --detach <commit>` (the old branch-only recovery
   could not restore a detached worktree). Backward-compatible with existing
   branch trash entries (they take the unchanged branch path).

Fail-safe on every git error path (a bad/unknown ref → keep the worktree).

## Tests (new — `tests/test_scripts/test_worktree_lifecycle.py`)

Real-git repos in `tmp_path` (house pattern from `test_git_repair.py`). 8 tests:
detached marking, `_is_merged` for detached-at-merged / detached-at-unmerged /
merged-branch, full `main()` wiring (reaps merged detached + merged branch, keeps
unmerged detached), detached recovery round-trip (asserts the recovered worktree
is actually detached), and legacy-branch-entry recovery (back-compat lock).
**Verify-RED demonstrated:** on unfixed code 6 failed with the exact production
message `branch 'unknown' not merged`; all 8 pass after the fix.

## Verification (E2E on real data)

- 8/8 tests green; `ruff` clean.
- Adversarial `genesis-architect` review: no BLOCKER / SHOULD-FIX; two advisory
  NOTES applied (docstring note on the fail-safe squash-merge gap; a legacy-branch
  recovery test).
- **Live run on the real 96-worktree set:** dry-run confirmed the fixed reaper
  selects exactly the two stuck detached worktrees that the old code skipped; the
  real run trashed them with the new `detached <sha>` log path; metadata verified
  (`detached:true` + commit); a live `--recover` round-trip restored one as a
  detached worktree at its commit, then it was re-trashed. Recoverable-trash
  semantics intact.

## Deploy path

Test-only + a single stdlib script; no runtime code, no migrations. Reaches other
installs via `git pull` (the `genesis-disk-hygiene.timer` picks up the new code on
its next daily run). Note: detached worktrees trashed by the fixed reaper require
the fixed `_recover` to restore them (they carry `branch:""`); this ships together.

Follow-up: 34534d7c

🤖 Generated with [Claude Code](https://claude.com/claude-code)
