### PR TITLE
fix(routing): repoint dead NIM free models to glm-5.2/flash-0731/minimax-m3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Model routing repointed off discontinued free NVIDIA NIM models.** NVIDIA NIM
+  end-of-lifed the `deepseek-v4-pro` model (and stopped serving `kimi-k2.6` to some
+  accounts), so ~20 routing chains — including the ones behind evaluation, the dream
+  cycle, and entity reasoning — were silently failing their free primary over to a
+  paid fallback. Chains now use current, verified free NIM models (GLM-5.2 as the
+  best-quality free primary, DeepSeek V4 Flash, MiniMax-M3), every chain keeps a
+  non-NIM fallback so a single NVIDIA-side model pull can't silently degrade a
+  cognitive path, and the eval judge stays on its DeepSeek-V4 model so scoring stays
+  comparable over time. A config test now blocks re-introducing a known-dead model
+  slug. If you don't use NVIDIA NIM (no `API_KEY_NVIDIA_NIM`), nothing changes.
+
 - **No more false "critical failure" alarms when the system is briefly busy.** The
   health signal that watches your local infrastructure (database, vector store, and
   Ollama if enabled) probes those services with a short timeout. When background work

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -120,17 +120,24 @@ providers:
   # ── Phase 2 providers (gated on eval before chain promotion) ──
   nvidia-nim-deepseek:
     type: nvidia_nim
-    model: deepseek-ai/deepseek-v4-pro
-    profile: nvidia-nim-deepseek-v4-pro
+    model: deepseek-ai/deepseek-v4-flash-0731
+    profile: nvidia-nim-deepseek-v4-flash-0731
     free: true
-    rpm_limit: 20  # 40 RPM shared pool — 20 each to stay within aggregate limit
+    rpm_limit: 13  # ~40 RPM NVIDIA free-tier shared across 3 nvidia_nim providers — ~13 each
     open_duration_s: 120
-  nvidia-nim-kimi:
+  nvidia-nim-glm:
     type: nvidia_nim
-    model: moonshotai/kimi-k2.6
-    profile: nvidia-nim-kimi-k2.6
+    model: z-ai/glm-5.2
+    profile: nvidia-nim-glm-5.2
     free: true
-    rpm_limit: 20  # 40 RPM shared pool — 20 each to stay within aggregate limit
+    rpm_limit: 13  # ~40 RPM NVIDIA free-tier shared across 3 nvidia_nim providers — ~13 each
+    open_duration_s: 120
+  nvidia-nim-minimax:
+    type: nvidia_nim
+    model: minimaxai/minimax-m3
+    profile: nvidia-nim-minimax-m3
+    free: true
+    rpm_limit: 13  # ~40 RPM NVIDIA free-tier shared across 3 nvidia_nim providers — ~13 each
     open_duration_s: 120
   # cerebras DISABLED — all models removed from Cerebras as of 2026-05.
   # Only reasoning-only models remain (gpt-oss-120b, zai-glm-4.7) which
@@ -282,7 +289,7 @@ call_sites:
     # paid fallback. Healthy OpenRouter-free models first; NIM last (shared
     # 40 RPM pool, currently flaky).
     - openrouter-gemma4
-    - nvidia-nim-kimi
+    - nvidia-nim-minimax
     - nvidia-nim-deepseek
     retry_profile: background
   4_light_reflection:
@@ -340,7 +347,7 @@ call_sites:
     - groq-free
     - openrouter-free
     - nvidia-nim-deepseek
-    - nvidia-nim-kimi
+    - nvidia-nim-minimax
     never_pays: true
   13_morning_report:
     chain:
@@ -362,6 +369,7 @@ call_sites:
     cc_model: Sonnet
   17_executor_review:
     chain:
+    - nvidia-nim-glm
     - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
@@ -400,6 +408,7 @@ call_sites:
   # Free-tier only. Separate from 22_tagging (entity extraction).
   dream_cycle_synthesis:
     chain:
+    - nvidia-nim-glm
     - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
     - groq-free
@@ -407,8 +416,10 @@ call_sites:
   # Adversarial challenge of synthesis output. Different provider from
   # synthesis (Kimi challenges DeepSeek) ensures model independence.
   dream_cycle_synthesis_challenge:
+    # Adversarial check of dream_cycle_synthesis — MUST lead with a different
+    # model than that base site (glm) so the two-model gate stays independent.
     chain:
-    - nvidia-nim-kimi
+    - nvidia-nim-minimax
     - groq-free
     # Paid Kimi via OpenRouter as last-resort fallback — same model family as
     # the free NIM primary, so the Kimi-challenges-DeepSeek independence holds
@@ -417,7 +428,8 @@ call_sites:
     retry_profile: background
   dream_cycle_entity_check:
     chain:
-    - nvidia-nim-kimi
+    - nvidia-nim-glm
+    - nvidia-nim-minimax
     - groq-free
     - mistral-small-free
     - openrouter-free
@@ -434,7 +446,8 @@ call_sites:
   # the dial — start on the proven entity-check chain.
   dream_cycle_relationship_classify:
     chain:
-    - nvidia-nim-kimi
+    - nvidia-nim-glm
+    - nvidia-nim-minimax
     - groq-free
     - mistral-small-free
     - openrouter-free
@@ -445,6 +458,8 @@ call_sites:
   # Adversarial challenge of entity "duplicate" verdicts. Flipped pairing:
   # DeepSeek challenges Kimi's entity judgments.
   dream_cycle_entity_challenge:
+    # Adversarial check of dream_cycle_entity_check — MUST lead with a different
+    # model than that base site (glm) so the two-model gate stays independent.
     chain:
     - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
@@ -453,7 +468,8 @@ call_sites:
   # Same free-SLM shape as dream_cycle_entity_check; hourly, small backlog.
   entity_adjudication:
     chain:
-    - nvidia-nim-kimi
+    - nvidia-nim-glm
+    - nvidia-nim-minimax
     - groq-free
     - mistral-small-free
     - openrouter-free
@@ -465,6 +481,9 @@ call_sites:
   # (DeepSeek challenges Kimi) so a single model's mistake cannot merge two
   # distinct entities — both must agree before a merge.
   entity_adjudication_challenge:
+    # Adversarial check of entity_adjudication before a DESTRUCTIVE merge_entity —
+    # MUST lead with a different model than that base site (glm) so "both agree"
+    # is a genuine two-model gate, not glm agreeing with itself.
     chain:
     - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
@@ -474,7 +493,8 @@ call_sites:
   # Same free background family as the dream-cycle classification sites.
   wing_backfill:
     chain:
-    - nvidia-nim-kimi
+    - nvidia-nim-glm
+    - nvidia-nim-minimax
     - nvidia-nim-deepseek
     - groq-free
     - openrouter-deepseek-v4-flash
@@ -532,10 +552,11 @@ call_sites:
     - groq-free
     - mistral-large-free
     - nvidia-nim-deepseek
-    - nvidia-nim-kimi
+    - nvidia-nim-minimax
     description: Synthesize research results into concise summaries
   38_procedure_extraction:
     chain:
+    - nvidia-nim-glm
     - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
@@ -546,8 +567,10 @@ call_sites:
       pipeline candidates
   38a_procedure_novelty_llm:
     chain:
+    - nvidia-nim-glm
     - nvidia-nim-deepseek
     - openrouter-deepseek-v4
+    - groq-free
     default_paid: true
     description: Cross-task_type procedure dedup judgment (is a new procedure
       redundant with existing ones). S-tier only — precision is the safety
@@ -571,6 +594,7 @@ call_sites:
     description: "Unified cognitive loop focus selector — picks ego attention direction from pending signals"
   43_task_retrospective:
     chain:
+    - nvidia-nim-glm
     - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
@@ -580,6 +604,7 @@ call_sites:
     description: Post-execution retrospective learning extraction
   44_task_premortem:
     chain:
+    - nvidia-nim-glm
     - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
@@ -646,6 +671,7 @@ call_sites:
     description: "Proactive infrastructure monitoring \u2014 trend detection and forecasting"
   40_knowledge_distillation:
     chain:
+    - nvidia-nim-glm
     - nvidia-nim-deepseek
     - groq-free
     - gemini-free
@@ -746,8 +772,8 @@ call_sites:
       \ grader is slow/down) and sheds under REDUCED degradation."
   judge:
     chain:
-    - nvidia-nim-deepseek
     - openrouter-deepseek-v4
+    - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
     default_paid: true
     retry_profile: background

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -131,12 +131,18 @@ def test_load_full_yaml(monkeypatch):
     # 2026-08-07: 28 → 26 after removing the redundant groq-oss-120b GROUNDWORK
     # alias (groq-free now serves gpt-oss-120b post-migration) + the dead,
     # unwired openrouter-qwen3coder (delisted qwen/qwen3-coder:free slug).
-    assert len(cfg.providers) == 26
+    # 2026-08-19: 26 → 27 — NIM repoint after NVIDIA EOL'd deepseek-v4-pro (410)
+    # and stopped serving kimi-k2.6 (404): removed nvidia-nim-kimi, added
+    # nvidia-nim-glm (z-ai/glm-5.2) + nvidia-nim-minimax (minimaxai/minimax-m3).
+    assert len(cfg.providers) == 27
     assert "lmstudio-30b" not in cfg.providers
     assert "github-o3mini" not in cfg.providers
     assert "openrouter-deepseek-r1" not in cfg.providers  # removed from config
     assert "groq-oss-120b" not in cfg.providers  # removed 2026-08-07 (redundant w/ groq-free)
     assert "openrouter-qwen3coder" not in cfg.providers  # removed 2026-08-07 (dead slug, unwired)
+    assert "nvidia-nim-kimi" not in cfg.providers  # removed 2026-08-19 (kimi-k2.6 404-for-account)
+    assert "nvidia-nim-glm" in cfg.providers  # z-ai/glm-5.2 (best free NIM reasoning)
+    assert "nvidia-nim-minimax" in cfg.providers  # minimaxai/minimax-m3
     # Call sites evolve — assert actual count matches config, and lock in
     # a few load-bearing ids rather than chasing the total on every edit.
     # 2026-05-10: 44 → 43 after net change (judge added by #304, 2_triage +
@@ -204,11 +210,13 @@ def test_load_full_yaml(monkeypatch):
     assert cfg.call_sites["5_deep_reflection"].default_paid is True
     assert cfg.call_sites["36_code_auditor"].never_pays is False
     assert cfg.call_sites["37_infrastructure_monitor"].default_paid is True
-    # judge: LLM-as-judge eval primitive — free NIM v4-pro first, then paid v4-pro,
-    # then v4-flash; paid-by-default
+    # judge: LLM-as-judge eval primitive — deepseek-4 family ONLY (a model swap
+    # shifts the longitudinal eval baseline). NIM's free deepseek-v4-pro was EOL'd
+    # (410, 2026-08-07), so paid OpenRouter deepseek-v4-pro is first to keep the
+    # EXACT judge model, then free NIM deepseek-v4-flash-0731, then paid v4-flash.
     assert cfg.call_sites["judge"].chain == [
-        "nvidia-nim-deepseek",
         "openrouter-deepseek-v4",
+        "nvidia-nim-deepseek",
         "openrouter-deepseek-v4-flash",
     ]
     assert cfg.call_sites["judge"].default_paid is True

--- a/tests/test_routing/test_config_invariants.py
+++ b/tests/test_routing/test_config_invariants.py
@@ -1,0 +1,78 @@
+"""Invariants on the SHIPPED routing config (config/model_routing.yaml).
+
+Guards the 2026-08 NIM repoint (after NVIDIA NIM EOL'd deepseek-v4-pro and made
+kimi-k2.6 404-for-account): no re-introduction of the dead NIM model slugs, every
+call-site keeps a non-NIM fallback (NIM's free tier churns silently), and judge
+stays deepseek-family so the eval baseline doesn't shift under a model swap.
+"""
+
+from __future__ import annotations
+
+from genesis.env import repo_root
+from genesis.routing.config import load_config
+
+_NIM_PROVIDERS = {"nvidia-nim-glm", "nvidia-nim-deepseek", "nvidia-nim-minimax"}
+# NIM model slugs verified dead 2026-08 (410 EOL / 404-for-account) — never repoint here.
+_DEAD_NIM_SLUGS = {
+    "deepseek-ai/deepseek-v4-pro",
+    "moonshotai/kimi-k2.6",
+    "moonshotai/kimi-k2.5",
+    "deepseek-ai/deepseek-coder-6.7b-instruct",
+}
+
+
+def _cfg():
+    return load_config(str(repo_root() / "config" / "model_routing.yaml"))
+
+
+def test_no_dead_nim_model_slugs():
+    """No nvidia_nim provider may point at a slug NIM has EOL'd / 404s for us."""
+    cfg = _cfg()
+    for name, p in cfg.providers.items():
+        if p.provider_type == "nvidia_nim":
+            assert p.model_id not in _DEAD_NIM_SLUGS, (
+                f"provider {name} points at dead NIM slug {p.model_id}"
+            )
+
+
+def test_every_chain_keeps_a_non_nim_fallback():
+    """NIM's free tier churns silently; no call-site may depend on NIM alone."""
+    offenders = [
+        name
+        for name, cs in _cfg().call_sites.items()
+        if cs.chain and all(p in _NIM_PROVIDERS for p in cs.chain)
+    ]
+    assert not offenders, f"NIM-only chains (no non-NIM fallback): {offenders}"
+
+
+def test_adversarial_challenge_sites_are_model_independent():
+    """A `_challenge` site adversarially re-checks its base site, so it MUST lead
+    with a different MODEL — otherwise the two-model agreement gate degenerates to
+    one model agreeing with itself (a data-corruption risk for entity_adjudication,
+    which gates a destructive merge_entity)."""
+    cfg = _cfg()
+    pairs = [
+        ("dream_cycle_synthesis", "dream_cycle_synthesis_challenge"),
+        ("dream_cycle_entity_check", "dream_cycle_entity_challenge"),
+        ("entity_adjudication", "entity_adjudication_challenge"),
+    ]
+    for base, chal in pairs:
+        bc, cc = cfg.call_sites[base].chain, cfg.call_sites[chal].chain
+        assert bc and cc, f"{base}/{chal} must have non-empty chains"
+        base_model = cfg.providers[bc[0]].model_id
+        chal_model = cfg.providers[cc[0]].model_id
+        assert base_model != chal_model, (
+            f"{chal} leads with the same model as {base} ({base_model}) — "
+            "adversarial model independence collapsed"
+        )
+
+
+def test_judge_stays_deepseek_family():
+    """judge scores evals — keep it deepseek-family so a model swap can't shift
+    the longitudinal eval baseline (glm/other must not appear here)."""
+    cfg = _cfg()
+    for p in cfg.call_sites["judge"].chain:
+        model = cfg.providers[p].model_id.lower()
+        assert "deepseek" in model, (
+            f"judge uses non-deepseek provider {p} ({model}) — breaks the eval baseline"
+        )

--- a/tests/test_routing/test_integration.py
+++ b/tests/test_routing/test_integration.py
@@ -83,7 +83,7 @@ async def test_surplus_never_pays(real_config, breakers, cost_tracker, degradati
         "gemini-free": CallResult(success=False, error="down", status_code=503),
         "openrouter-free": CallResult(success=False, error="down", status_code=503),
         "nvidia-nim-deepseek": CallResult(success=False, error="down", status_code=503),
-        "nvidia-nim-kimi": CallResult(success=False, error="down", status_code=503),
+        "nvidia-nim-minimax": CallResult(success=False, error="down", status_code=503),
     })
     router = Router(
         config=real_config, breakers=breakers, cost_tracker=cost_tracker,


### PR DESCRIPTION
## What

NVIDIA NIM **EOL'd `deepseek-v4-pro`** (HTTP 410, 2026-08-07) and **stopped serving `kimi-k2.6`** to our account (404-for-account). Both were configured as **free primaries** on ~20 cognitive routing chains, so those chains were silently failing their free primary over to a **paid** OpenRouter fallback. (The original follow-up's "~2.6k wasted calls/wk" framing was wrong — the circuit breaker skips a dead provider once open; the real cost was the silent free→paid failover.)

## Verification (live, this session)

Probed the NVIDIA NIM catalog + inference with our key: `deepseek-v4-pro` → 410 (dated EOL), `kimi-k2.6` → 404-for-account (an NVIDIA **free-tier account entitlement** gap, not a pay-gate). All three replacements returned **200 OK**: `z-ai/glm-5.2`, `deepseek-v4-flash-0731`, `minimaxai/minimax-m3`. Model ranking (Artificial Analysis Intelligence Index) via a genesis-researcher pass.

## Change (`config/model_routing.yaml`)

- `nvidia-nim-deepseek`: `deepseek-v4-pro` → `deepseek-v4-flash-0731` (free, live).
- **add** `nvidia-nim-glm`: `z-ai/glm-5.2` (free; highest-scoring reachable free model, AA 53).
- `nvidia-nim-kimi` (dead) → renamed `nvidia-nim-minimax`: `minimaxai/minimax-m3` (free).
- `glm-5.2` leads the high-value non-judge chains; **every chain keeps a non-NIM fallback** (NIM's free tier churns silently — this is the 2nd model to vanish).
- **judge**: deepseek-v4-family **only**, paid OpenRouter `deepseek-v4-pro` **first**, so the LLM-as-judge eval baseline stays comparable across a model swap.
- The 3 adversarial `_challenge` sites deliberately do **not** lead with glm — they must use a different model than their glm-first base (a two-model independence gate before a destructive `merge_entity`).
- `rpm_limit` 13 each (3 `nvidia_nim` providers share NVIDIA's ~40 RPM free tier). Folds `2dc96b27` (non-deepseek escape on judge/38a).

## Tests

New `tests/test_routing/test_config_invariants.py` guards: no dead NIM slugs, a non-NIM fallback per chain, judge stays deepseek-family, and base≠challenge model independence (verify-RED confirmed against the old config's dead slugs). Fixture updates (provider count 26→27, judge chain). **333 routing tests pass.** `ruff` clean.

## Review

genesis-architect: found **2 SHOULD-FIX** (both fixed) — the mechanical "glm-first everywhere" rule had collapsed adversarial model-independence on the 3 `_challenge` sites, and the `rpm_limit` comment was arithmetically stale. Fixed + locked with the independence guard test.

## Deploy / E2E

Config change — `git pull` + server restart. Post-deploy E2E: a live `route_call` per repointed high-value call-site confirms the new free primary is used (no 410/404, no silent paid failover).

Follow-up: 42bdc04a8d0e4d4bbfd851814b8ef3c7

🤖 Generated with [Claude Code](https://claude.com/claude-code)