### PR TITLE
fix(hooks): resolve gh pr merge PR from the positional, not a value-flag's value (E3)

### DIFF
--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -436,20 +436,50 @@ def _extract_pr_number(cmd: str) -> str | None:
         tokens = shlex.split(spaced)
     except ValueError:
         tokens = spaced.split()
-    for tok in tokens:
+    seps = {";", "&", "|", "&&", "||"}
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
         # Stop at the end of THIS command — tokens after a separator
         # belong to a chained command, and their digits must not be read
         # as this merge's target (`gh pr merge 123; echo 456` merges 123
         # but this loop would otherwise return 456). 2026-07-10 review.
-        if tok in {";", "&", "|", "&&", "||"}:
+        if tok in seps:
             break
-        if tok.isdigit():
-            return tok
-        if tok.startswith("#") and tok[1:].isdigit():
-            return tok[1:]
-        url = re.match(r"\S*/pull/(\d+)\b", tok)
-        if url:
-            return url.group(1)
+        # A value-taking flag consumes the NEXT token as its value, so an
+        # UNQUOTED numeric value is never misread as the PR: gh parses
+        # `gh pr merge --subject 123 5` as subject="123" + PR 5, and the old
+        # loop returned 123 (the flag value) → the gates checked the WRONG PR
+        # (E3, 2026-08-19). Covers long/short-single value flags
+        # (--subject/-t/--body/--match-head-commit/--repo…) and short clusters
+        # whose trailing value-letter has no glued remainder (`-db 123` → -b
+        # eats 123). Mirrors _merge_match_head / _comment_target, which already
+        # skip value flags — this was the one gh-arg parser here that didn't.
+        # NEVER swallow a separator as a value (a dangling `--subject ; gh pr
+        # merge 999` must not leak the chained command's 999): only consume the
+        # next token when it isn't a separator; the break above then ends it.
+        if tok in _GH_MERGE_VALUE_FLAGS or _short_cluster_consumes_next(tok):
+            nxt = tokens[i + 1] if i + 1 < len(tokens) else None
+            i += 2 if (nxt is not None and nxt not in seps) else 1
+            continue
+        # The PR is a POSITIONAL — a bare number / #N / /pull/N URL, which never
+        # starts with '-'. Guarding the matchers on that closes the GLUED
+        # value-flag sibling of E3 (adversarial review 2026-08-19): `--body=…`
+        # and `-b…` are single '-'-prefixed tokens that DON'T consume a next
+        # token, so they fall through here — and the URL matcher's `\S*` prefix
+        # would otherwise read a `/pull/N` smuggled inside the flag's VALUE as
+        # the PR while gh merges the trailing positional. (`--` end-of-options
+        # also starts with '-' → skipped; the following bare positional still
+        # resolves, matching gh.)
+        if not tok.startswith("-"):
+            if tok.isdigit():
+                return tok
+            if tok.startswith("#") and tok[1:].isdigit():
+                return tok[1:]
+            url = re.match(r"\S*/pull/(\d+)\b", tok)
+            if url:
+                return url.group(1)
+        i += 1
     return None
 
 

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -619,3 +619,41 @@ def test_merge_fetches_target_the_gated_pr_and_repo(monkeypatch):
         else:  # review-body
             ok = f"repos/{REPO}/issues/{pr}/comments" in parts
         assert ok, f"{label} fetch off-target: {parts}"
+
+
+def test_e3_stale_override_gates_positional_pr_not_flag_value(monkeypatch):
+    """E3 (2026-08-19) — wrong-PR resolution. gh parses ``gh pr merge --subject 123 5``
+    as subject="123" + PR **5** (the trailing positional), but the old
+    ``_extract_pr_number`` returned **123** (the ``--subject`` VALUE) → every gate
+    then checked the WRONG PR. It is contained on the normal path (the shadow-flag
+    belt refuses ``--subject`` once the head binding engages), so the reachable
+    main()-level observable is under ``# stale-review-override`` — which waives
+    freshness and with it SKIPS the shadow belt + binding, letting the command flow
+    into the finding scanners. An inline P1 seeded on PR 5 (the true gh target) must
+    BLOCK, and the scan must target PR 5, never 123. Old resolver → 123 → clean scan
+    → exit 0. Proven on the router's call log (assert in the TEST frame, Codex #1399)."""
+    calls: list = []
+
+    def router(argv, **kwargs):  # noqa: ANN001 - subprocess.run signature
+        parts = [str(a) for a in argv]
+        if "mergeable" in " ".join(parts):
+            return _proc(0, "MERGEABLE")
+        if any("/pulls/" in a and a.endswith("/comments") for a in parts):
+            calls.append(("inline", tuple(parts)))
+            # P1 lives only on the TRUE target (PR 5); the wrong PR (123) sees nothing.
+            hit = f"repos/{REPO}/pulls/5/comments" in parts
+            return _proc(0, _INLINE_P1_LINE if hit else "")
+        if any("/issues/" in a and a.endswith("/comments") for a in parts):
+            calls.append(("review-body", tuple(parts)))
+            return _proc(0, "[]")
+        return _proc(0, "")
+
+    cmd = "gh pr merge --subject 123 5 --repo owner/repo --squash --admin  # stale-review-override"
+    rc = _run(monkeypatch, cmd, reviews="", router=router)
+    assert rc == 2, f"expected a block on PR 5's inline P1, got exit {rc}"
+    inline = [parts for label, parts in calls if label == "inline"]
+    assert inline, "inline findings were never fetched"
+    assert all(f"repos/{REPO}/pulls/5/comments" in parts for parts in inline), inline
+    assert not any(f"repos/{REPO}/pulls/123/comments" in parts for parts in inline), (
+        f"findings scanned the WRONG PR (123, the --subject value): {inline}"
+    )

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1253,6 +1253,11 @@ class TestResolvePrNumber:
             ("gh pr merge 5 | tee 777", "5"),
             ("gh pr merge --admin xyz\necho 456", None),  # newline chain
             ("gh pr merge 123\necho 456", "123"),
+            # A dangling value flag must NOT swallow the separator as its value
+            # and then read a CHAINED command's digits (E3 guard: naive value-
+            # skipping would return 999 here). 2026-08-19.
+            ("gh pr merge --subject ; gh pr merge 999", None),
+            ("gh pr merge -db ; gh pr merge 999", None),
         ],
     )
     def test_stops_at_shell_separator(self, guard_module, cmd, expected):
@@ -1263,6 +1268,58 @@ class TestResolvePrNumber:
         # not resolve as the PR number.
         cmd = 'gh pr merge --subject "fix 123"'
         assert guard_module._extract_pr_number(cmd) is None
+
+    @pytest.mark.parametrize(
+        ("cmd", "expected"),
+        [
+            # E3 (2026-08-19): an UNQUOTED numeric value that gh consumes as a
+            # value-flag's argument must NOT be read as the PR number — gh takes
+            # the trailing bare positional as the PR. `gh pr merge --subject 123 5`
+            # merges PR 5 (subject "123"); the old loop returned 123 (the flag
+            # value) → the gates checked the WRONG PR. Long, short, cluster,
+            # and non-shadow (--match-head-commit / --repo) value flags all apply.
+            ("gh pr merge --subject 123 5", "5"),
+            ("gh pr merge -t 123 5", "5"),
+            ("gh pr merge --body 123 5", "5"),
+            ("gh pr merge --match-head-commit 123 5 --admin", "5"),
+            ("gh pr merge --repo 123 5", "5"),
+            ("gh pr merge -db 123 5", "5"),  # -d(bool)+-b(value): -b eats 123
+        ],
+    )
+    def test_unquoted_flag_value_not_pr_number(self, guard_module, cmd, expected):
+        assert guard_module._extract_pr_number(cmd) == expected
+
+    @pytest.mark.parametrize(
+        ("cmd", "expected"),
+        [
+            # GLUED value flags (sibling of E3, found in adversarial review): a
+            # `--flag=value` long or a `-fvalue` short does NOT consume a next
+            # token, so it falls through to the positional matchers — and the URL
+            # matcher's `\S*` prefix would read a `/pull/N` smuggled INSIDE the
+            # value as the PR while gh merges the trailing positional. A positional
+            # PR ref never starts with '-'; the matchers must skip '-'-prefixed
+            # tokens. gh merges 5 in every case here.
+            ("gh pr merge --body=https://github.com/o/r/pull/999 5", "5"),
+            ("gh pr merge -bhttps://github.com/o/r/pull/999 5", "5"),
+            ("gh pr merge --body-file=/tmp/x/pull/42 5", "5"),
+        ],
+    )
+    def test_glued_flag_value_url_not_pr_number(self, guard_module, cmd, expected):
+        assert guard_module._extract_pr_number(cmd) == expected
+
+    @pytest.mark.parametrize(
+        ("cmd", "expected"),
+        [
+            # Regression LOCKS (must stay green): a positional BEFORE any flag is
+            # still the PR; a GLUED long value flag never leaks its digits.
+            ("gh pr merge 123 --subject 456", "123"),
+            ("gh pr merge --subject=99 5", "5"),
+            ("gh pr merge -db123 5", "5"),  # glued short value: -b's value is 123
+            ("gh pr merge -- 5", "5"),  # -- end-of-options: the positional still resolves
+        ],
+    )
+    def test_positional_pr_still_resolved(self, guard_module, cmd, expected):
+        assert guard_module._extract_pr_number(cmd) == expected
 
     def test_resolves_current_branch_pr(self, guard_module):
         with patch.object(


### PR DESCRIPTION
## What

`_extract_pr_number` (the `gh pr merge` PR-number resolver behind every merge gate) read the **first bare-digit token** in the command and did **not** skip a value-flag's argument. So an unquoted numeric flag value was misread as the target PR:

- `gh pr merge --subject 123 5` → returned `123` (the `--subject` value), while gh actually merges the trailing positional **PR 5**. Every downstream gate then evaluated the wrong PR's facts.

gh's own semantics (docs): `--subject` / `--body` / `--body-file` / `--author-email` / `--repo` / `--match-head-commit` are value-taking flags; the lone positional is the PR (number / URL / branch).

## Fix

Walk the tokens with gh-equivalent consumption, reusing the value-flag specs the sibling parsers already use (`_GH_MERGE_VALUE_FLAGS`, `_short_cluster_consumes_next` — the same set `_merge_match_head` / `_comment_target` rely on):

1. A value flag (long, short-single, or a short cluster whose trailing value-letter has no glued remainder like `-db`) consumes its next token — skip both. Never swallow a shell separator as a value (a dangling `--subject ; gh pr merge 999` must not leak the chained command's `999`).
2. A positional PR ref never starts with `-`. Guarding the number/`#N`/URL matchers on that also closes a **glued-value sibling** of the same class found in review: `--body=…/pull/999` and `-b…/pull/999` are single `-`-prefixed tokens that don't consume a next token, and the URL matcher's `\S*` prefix would otherwise read `999` out of the flag's value.

The two sibling parsers in this file already skipped value flags; this resolver was the one that didn't.

## Reachability / severity

Contained on the normal merge path (the shadow-flag belt refuses `--subject`/`--body`/… once the head-binding engages; the only non-shadow value flags — `--repo`, `--match-head-commit` — hit repo-unresolvable / match-head-mismatch blocks, and GitHub enforces `--match-head-commit` server-side). The reachable observable is under `# stale-review-override` (freshness waived → shadow belt + binding skipped), where the finding scanners then run on the mis-resolved PR. Correctness / defense-in-depth fix; the resolver is the contract, not the belts. Sole caller is fail-closed (unresolved → block or numberless re-resolve); a wrong skip can only over-block.

## Tests (RED-first)

- Unit (`TestResolvePrNumber`): unquoted value flags (`--subject/-t/--body/--match-head-commit/--repo/-db 123 5` → `5`), glued-value URL siblings (`--body=…/pull/999 5` → `5`), chained-command guard (`--subject ; gh pr merge 999` → `None`), `--` end-of-options (`-- 5` → `5`), and positional/quoted/URL/separator regression locks. Each new case verify-RED'd (returned the wrong PR before the fix).
- End-to-end (`test_e3_stale_override_gates_positional_pr_not_flag_value`): drives `main()` with `--subject 123 5 # stale-review-override`, seeds an inline P1 on PR 5, and asserts the scan targets PR 5 not 123 (verify-RED at the main() level: reverted source → gate scanned PR 123 and allowed).

Full `tests/test_hooks/` + `tests/test_scripts/` green; ruff clean.

Ledger: de9f128c
