### PR TITLE
fix(cc-tmp): keep pytest off cc-tmp, break the watchgod ORANGE loop, capture session deaths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,33 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   and campaign bookkeeping follows the park to the delivering session's real
   result instead of recording a false failed run (bounded at 7 days so a stuck
   resume can never stall a campaign forever).
+- **Test runs no longer trip the temp-protection watchdog.** pytest writes its
+  scratch tree under `$TMPDIR`, which on a Claude Code session is the
+  budget-policed `~/.genesis/cc-tmp`; a broad suite could fill it and drive the
+  `genesis-tmp-watchgod` service into a sustained high-pressure state. pytest is
+  now redirected to `~/tmp` (off the budget) for every run rooted in the repo,
+  the dev console, autonomy verification, and the eval gauntlet — CI is
+  unaffected.
+- **Temp watchdog no longer loops on non-reclaimable pressure.** When
+  `~/.genesis/cc-tmp` stays over budget after the watchdog's cache cleanup, it
+  now re-measures before considering any idle-session reap (so it never reaps a
+  session that cleanup already made unnecessary) and, if nothing is reclaimable
+  and nothing is safely reapable, raises a single alert instead of re-evaluating
+  every poll.
 
 ### Added
+
+- **Claude Code session exits are recorded.** When a CC session's process exits
+  — a clean quit, a crash, or an OS/kill signal — its exit status (with a
+  signal-decoded hint) and a tail of the terminal are written to
+  `~/.genesis/logs/cc_exit_<slot>.log`, so a session that vanishes is
+  diagnosable instead of leaving no trace. Self-rotating; no effect on the
+  session lifecycle.
+- **cgroup OOM kills are captured.** The temp watchdog now records any new
+  out-of-memory kill in the container cgroup (timestamp, memory state, top
+  processes) to `~/.genesis/logs/oom_events.log` and alerts once — turning a
+  previously invisible cause of vanished processes into a durable signal.
+  Degrades to a no-op on hosts without the cgroup-v2 interface.
 
 - **Telegram DM "scroll-up".** Sessions can now read the conversation archive
   on demand: `conversation_history` accepts `chat_id` (scoped to one chat) and

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -167,10 +167,23 @@ if [[ ${#CLAUDE_EXTRA_ARGS[@]} -gt 0 ]]; then
     CLAUDE_ARGS_Q=$(printf ' %q' "${CLAUDE_EXTRA_ARGS[@]}")
 fi
 
-# -u: force UTF-8 output even if a future client's locale detection fails
+# -u: force UTF-8 output even if a future client's locale detection fails.
+#
+# The inner command drops the old `exec claude` so that when claude EXITS we can
+# record why before the pane vanishes: cc_exit_capture.sh logs the exit status
+# (signal-decoded) + a pane-scrollback tail to ~/.genesis/logs/cc_exit_<slot>.log.
+# Without this a dying session (V8 abort, OOM kill, clean exit) leaves no trace —
+# the 2026-08-19 death was undiagnosable for exactly that reason. `exit $__ec`
+# reproduces claude's exit code as the pane's, so tmux sees the same dead-status
+# and the `-A` attach-or-create behaviour (this runs only on CREATE) is unchanged.
+# Captures when claude EXITS on its own (crash/OOM-of-claude/clean quit — the
+# cases we care about); a SIGHUP to the pane itself (tmux kill-session / unit
+# stop) may reap the wrapper before the trailer runs — the watchgod OOM sampler
+# covers that subset. Capture is best-effort and never alters the exit code.
+# `\$` defers expansion to the pane's shell; the `${...}` expand here in cc-slot.sh.
 exec tmux -u new-session -A -s "$SESSION_NAME" \
     -e "GENESIS_SLOT=${SLOT}" \
     -e "GENESIS_CC_PERMISSION_MODE=${GENESIS_CC_PERMISSION_MODE:-auto}" \
     -e "CLAUDE_CODE_TMPDIR=$CLAUDE_CODE_TMPDIR" \
     -e "LANG=$LANG" \
-    "cd ${GENESIS_ROOT} && exec claude ${CC_PERM_FLAG}${CLAUDE_ARGS_Q}"
+    "cd ${GENESIS_ROOT} && claude ${CC_PERM_FLAG}${CLAUDE_ARGS_Q}; __ec=\$?; ${GENESIS_ROOT}/scripts/cc_exit_capture.sh ${SLOT} \$__ec >/dev/null 2>&1; exit \$__ec"

--- a/scripts/cc_exit_capture.sh
+++ b/scripts/cc_exit_capture.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# cc_exit_capture.sh <slot> <exit_code>
+#
+# Records a Claude Code session's exit — the exit status (with a signal-decoded
+# hint) plus a tail of the pane scrollback — to ~/.genesis/logs/cc_exit_<slot>.log.
+#
+# Why: a CC session runs as tmux `... exec claude` (see cc-slot.sh). When claude
+# exits, the pane and its output vanish together, so a session that dies (a V8/
+# Node fatal abort, a cgroup OOM kill, or just a clean exit) leaves NO durable
+# trace — the 2026-08-19 session death was undiagnosable for exactly this reason
+# (the kernel dmesg ring had cycled and the pane's dying words were already gone).
+# cc-slot.sh drops the inner `exec` and calls this on claude's return so the exit
+# is recorded before the pane closes.
+#
+# Best-effort by construction: it must NEVER fail the caller or change the
+# session's exit code — the session is already on its way out.
+
+set -u
+
+slot="${1:-unknown}"
+ec="${2:-unknown}"
+
+# Resolve HOME under stripped env (same guard as cc-slot.sh); give up quietly if
+# unresolvable — there is nowhere to log and this must not disrupt the exit.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)" || HOME=""
+fi
+[ -n "${HOME:-}" ] || exit 0
+
+log_dir="${HOME}/.genesis/logs"
+log="${log_dir}/cc_exit_${slot}.log"
+mkdir -p "$log_dir" 2>/dev/null || exit 0
+
+{
+    echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) cc-${slot} claude exited status=${ec} ==="
+    # Decode the common fatal exits (128 + signo) into a first-look diagnosis.
+    case "$ec" in
+        0)   echo "  (clean exit)" ;;
+        130) echo "  (SIGINT — Ctrl-C)" ;;
+        134) echo "  (SIGABRT — likely a V8/Node fatal abort, e.g. JS-heap OOM)" ;;
+        137) echo "  (SIGKILL — likely a cgroup/OS OOM kill or forced termination)" ;;
+        139) echo "  (SIGSEGV — native crash)" ;;
+        143) echo "  (SIGTERM — terminated)" ;;
+    esac
+    # Pane scrollback tail — the dying words, if any reached the normal screen.
+    # Guarded on TMUX_PANE so the script is harmless when run outside tmux.
+    if [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
+        echo "  --- pane tail (last 200 lines) ---"
+        tmux capture-pane -p -t "$TMUX_PANE" -S -200 2>/dev/null | sed 's/^/  | /'
+    fi
+    echo
+} >> "$log" 2>/dev/null || exit 0
+
+# Self-rotation: keep the per-slot log bounded (last ~2000 lines ≈ several exits)
+# so it never becomes an unbounded disk leak on a smaller install.
+lines=$(wc -l < "$log" 2>/dev/null || echo 0)
+if [ "${lines:-0}" -gt 2000 ]; then
+    tail -n 2000 "$log" > "${log}.tmp" 2>/dev/null && mv "${log}.tmp" "$log" 2>/dev/null || true
+fi
+exit 0

--- a/scripts/cc_exit_capture.sh
+++ b/scripts/cc_exit_capture.sh
@@ -17,6 +17,11 @@
 
 set -u
 
+# The captured pane tail can contain prompts, command output, or credentials, so
+# keep the log owner-only. umask covers newly-created dir/file; the explicit
+# chmod below also tightens a log that predates this hardening.
+umask 077
+
 slot="${1:-unknown}"
 ec="${2:-unknown}"
 
@@ -30,6 +35,9 @@ fi
 log_dir="${HOME}/.genesis/logs"
 log="${log_dir}/cc_exit_${slot}.log"
 mkdir -p "$log_dir" 2>/dev/null || exit 0
+# Enforce owner-only on the log even if it predates this change (umask only
+# affects freshly-created files). Best-effort — never fail the caller.
+[ -e "$log" ] && chmod 600 "$log" 2>/dev/null || true
 
 {
     echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) cc-${slot} claude exited status=${ec} ==="

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -28,6 +28,13 @@ STATE_FILE="$HOME/.genesis/watchgod_state.json"
 LOG_FILE="$HOME/.genesis/logs/tmp_watchgod.log"
 ALERT_DIR="$HOME/.genesis/alerts"
 
+# OOM event capture: the container cgroup-v2 cumulative oom_kill counter, and a
+# durable log for the snapshots. OOM_EVENTS_FILE is overridable so tests can
+# point it at a fixture file. OOM_LOG lives beside the watchgod log (NOT in
+# cc-tmp) so it survives cleanup.
+OOM_EVENTS_FILE="${OOM_EVENTS_FILE:-/sys/fs/cgroup/memory.events}"
+OOM_LOG="$(dirname "$LOG_FILE")/oom_events.log"
+
 # Durable alert queue (F.3) — emergency-tier events page Telegram via the
 # container drainer. Guarded: if the lib is ever not co-located, degrade to a
 # no-op so `set -e` can never take the service down over an alert.
@@ -152,7 +159,7 @@ clean_cc_yellow() {
 
 clean_cc_orange() {
     clean_cc_yellow
-    log WARN "Zone A ORANGE — deleting caches, killing idle sessions"
+    log WARN "Zone A ORANGE — deleting caches, then re-measuring before any session kill"
 
     # Delete claude-skills cache (~35MB, CC re-clones on demand)
     find "$CC_TMP_DIR" -type d -name "claude-skills" -exec rm -rf {} + 2>/dev/null || true
@@ -160,7 +167,31 @@ clean_cc_orange() {
     # Delete tsx cache (~1.2MB, rebuilt automatically)
     find "$CC_TMP_DIR" -type d -name "tsx-*" -exec rm -rf {} + 2>/dev/null || true
 
+    mkdir -p "$ALERT_DIR"
+    touch "$ALERT_DIR/tmp_warning"
+
+    # LOOP-BREAK: re-measure AFTER the cleanup above and kill idle sessions ONLY
+    # if we're still over the ORANGE line. This closes the runaway that killed no
+    # session but churned for ~4.5h on 2026-08-19: the tier that dispatched us
+    # here was measured BEFORE cleanup, so without a re-measure the daemon would
+    # re-enter ORANGE every poll and re-run the kill loop forever while the real
+    # filler (a pytest tree the cache-evict never touches) sat untouched. Killing
+    # an idle session cannot reduce cc-tmp anyway (sessions aren't the filler), so
+    # a kill here is at best useless and at worst reaps an innocent bystander.
+    # Use dir_usage_mb (du) — it drops immediately after rm; df can lag on
+    # held-open deleted fds.
+    local used_after threshold_orange
+    used_after=$(dir_usage_mb "$CC_TMP_DIR")
+    threshold_orange=$(( CC_TMP_BUDGET_MB * 75 / 100 ))
+    if (( used_after <= threshold_orange )); then
+        log INFO "ORANGE resolved by cache cleanup (used=${used_after}MB <= ${threshold_orange}MB) — no session kills"
+        rm -f "$ALERT_DIR/tmp_orange_stuck" 2>/dev/null || true
+        return 0
+    fi
+
+    log WARN "ORANGE persists after cleanup (used=${used_after}MB > ${threshold_orange}MB) — evaluating idle sessions"
     # Kill idle CC tmux sessions (unattached, idle > 2h)
+    local killed_any=0
     while IFS= read -r session; do
         [[ -z "$session" ]] && continue
         local sname
@@ -174,13 +205,23 @@ clean_cc_orange() {
             if (( idle_s > 7200 )); then
                 log WARN "Killing idle CC session: $sname (idle ${idle_s}s)"
                 tmux kill-session -t "$sname" 2>/dev/null || true
+                killed_any=1
             fi
         fi
     done < <(tmux list-sessions -F '#{session_name}:#{session_attached}' 2>/dev/null | grep ':0$' || true)
 
-    # Alert
-    mkdir -p "$ALERT_DIR"
-    touch "$ALERT_DIR/tmp_warning"
+    # Stuck-ORANGE: cleanup didn't resolve it AND nothing was killable → the
+    # daemon has nothing safe left to do. Per design D2 (ORANGE is dashboard/log
+    # only — only RED pages) this does NOT page; it records the stuck state ONCE
+    # (dedupe flag) in the log instead of silently re-polling forever, so the
+    # condition is discoverable. If cc-tmp keeps filling it escalates to RED,
+    # which DOES page. The flag is cleared ONLY on the green transition (main
+    # loop), never on a kill: reaping an idle session does not reduce cc-tmp, so
+    # a kill that leaves us ORANGE must not re-arm and re-log the same episode.
+    if (( killed_any == 0 )) && [[ ! -f "$ALERT_DIR/tmp_orange_stuck" ]]; then
+        log WARN "cc-tmp STUCK ORANGE (used=${used_after}MB, budget=${CC_TMP_BUDGET_MB}MB): reclaim freed nothing and no idle (>2h) session is killable — non-reclaimable data is filling cc-tmp (see cc_tmp_top snapshots). Dashboard/log-only per D2; RED will page if it escalates."
+        touch "$ALERT_DIR/tmp_orange_stuck"
+    fi
 }
 
 clean_cc_red() {
@@ -357,10 +398,71 @@ check_sys_tmp() {
     echo "$tier:$pct"
 }
 
+# ── OOM event capture (best-effort, cgroup v2) ───────────────
+# A cgroup OOM kill silently collapses a CC session (tmux `exec claude` → claude
+# is reaped → the last pane dies → the session ends) and leaves no durable trace:
+# the kernel dmesg ring cycles and the kernel journal is usually unreadable from
+# inside the container. This samples the container cgroup's CUMULATIVE oom_kill
+# counter each poll and, on a NEW kill since the daemon started, records a
+# timestamped snapshot (memory + top-RSS processes) and pages once. Read-only —
+# it never kills or reclaims anything. Degrades to a no-op when the cgroup-v2
+# interface file is absent/unreadable (older layouts / non-cgroup2 hosts).
+
+_read_oom_kill() {
+    # Echo the current cumulative oom_kill count; non-zero return if unavailable.
+    [[ -r "$OOM_EVENTS_FILE" ]] || return 1
+    awk '/^oom_kill /{print $2; found=1} END{exit !found}' "$OOM_EVENTS_FILE" 2>/dev/null
+}
+
+check_oom_events() {
+    # $1 = previous baseline count. Echoes the (possibly-updated) baseline so the
+    # caller can carry it to the next tick. On an increment: durable snapshot +
+    # one dedup'd page. Never touches stdout except the final baseline echo.
+    local prev="$1" cur
+    cur=$(_read_oom_kill) || { printf '%s' "$prev"; return 0; }
+    [[ -z "$cur" ]] && { printf '%s' "$prev"; return 0; }
+    if [[ -n "$prev" ]] && (( cur > prev )); then
+        local n=$(( cur - prev )) stamp
+        stamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        {
+            echo "# OOM event ${stamp}: cgroup oom_kill ${prev} -> ${cur} (+${n})"
+            echo "## memory (MB):"; free -m 2>/dev/null | head -2
+            echo "## top RSS:"; ps -eo pid,rss,comm --sort=-rss 2>/dev/null | head -12
+            echo
+        } >> "$OOM_LOG" 2>/dev/null || true
+        log WARN "cgroup OOM kill detected (oom_kill ${prev} -> ${cur}); snapshot → ${OOM_LOG}"
+        # Emergency tier (pages): an OOM kill is a discrete serious event — the
+        # usual reason a CC session vanishes with no crash message — not routine
+        # tier pressure, so unlike ORANGE it warrants a proactive page (per the
+        # 2026-08-19 decision). Deduped per distinct oom_kill total.
+        queue_alert emergency "watchgod:oom" "cgroup OOM kill(s) detected" \
+            "${n} process(es) OOM-killed in the container cgroup (oom_kill ${prev}->${cur}). A CC session vanishing with no crash message is often this. Snapshot: ${OOM_LOG}" \
+            "watchgod:oom:${cur}"
+        # Bound the OOM log (retention discipline — matches cc_exit/log rotation);
+        # keep the most recent ~1000 lines so a thrashing container can't leak it.
+        local oom_lines
+        oom_lines=$(wc -l < "$OOM_LOG" 2>/dev/null || echo 0)
+        if (( ${oom_lines:-0} > 1000 )); then
+            tail -n 1000 "$OOM_LOG" > "${OOM_LOG}.tmp" 2>/dev/null && mv "${OOM_LOG}.tmp" "$OOM_LOG" 2>/dev/null || true
+        fi
+    fi
+    printf '%s' "$cur"
+}
+
 # ── Main loop ────────────────────────────────────────────────
 main() {
     mkdir -p "$(dirname "$LOG_FILE")" "$ALERT_DIR"
     log INFO "Watchgod starting (poll=${POLL_INTERVAL}s, budget=${CC_TMP_BUDGET_MB}MB, sacred=${SACRED_GROUND_MB}MB)"
+
+    # Baseline the OOM counter at startup so we only page on NEW kills (never the
+    # cumulative-since-boot history). Empty baseline = monitoring unavailable.
+    local oom_baseline
+    oom_baseline=$(_read_oom_kill) || oom_baseline=""
+    if [[ -z "$oom_baseline" ]]; then
+        log INFO "OOM event capture unavailable (no readable ${OOM_EVENTS_FILE}) — OOM monitoring off"
+    else
+        log INFO "OOM event capture armed (baseline oom_kill=${oom_baseline})"
+    fi
 
     while true; do
         load_config
@@ -376,9 +478,13 @@ main() {
 
         write_state "$cc_tier" "$cc_used" "$sys_tier" "$sys_pct"
 
+        # Durable OOM capture — snapshot + page on any NEW cgroup OOM kill.
+        oom_baseline=$(check_oom_events "$oom_baseline")
+
         # Clear stale alerts when back to green
         if [[ "$cc_tier" == "green" && "$sys_tier" == "green" ]]; then
-            rm -f "$ALERT_DIR/tmp_warning" "$ALERT_DIR/tmp_emergency" 2>/dev/null || true
+            rm -f "$ALERT_DIR/tmp_warning" "$ALERT_DIR/tmp_emergency" \
+                  "$ALERT_DIR/tmp_orange_stuck" 2>/dev/null || true
         fi
 
         # Log rotation — truncate when > 1MB

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -204,8 +204,13 @@ clean_cc_orange() {
             local idle_s=$(( now - last_activity ))
             if (( idle_s > 7200 )); then
                 log WARN "Killing idle CC session: $sname (idle ${idle_s}s)"
-                tmux kill-session -t "$sname" 2>/dev/null || true
-                killed_any=1
+                # Count a reap only when tmux actually killed it — if the session
+                # vanished between listing and killing (or the kill fails), we
+                # reclaimed nothing, so killed_any must stay 0 and the stuck
+                # marker must still be recorded rather than silently skipped.
+                if tmux kill-session -t "$sname" 2>/dev/null; then
+                    killed_any=1
+                fi
             fi
         fi
     done < <(tmux list-sessions -F '#{session_name}:#{session_attached}' 2>/dev/null | grep ':0$' || true)
@@ -215,9 +220,10 @@ clean_cc_orange() {
     # only — only RED pages) this does NOT page; it records the stuck state ONCE
     # (dedupe flag) in the log instead of silently re-polling forever, so the
     # condition is discoverable. If cc-tmp keeps filling it escalates to RED,
-    # which DOES page. The flag is cleared ONLY on the green transition (main
-    # loop), never on a kill: reaping an idle session does not reduce cc-tmp, so
-    # a kill that leaves us ORANGE must not re-arm and re-log the same episode.
+    # which DOES page. The flag is cleared (main loop) whenever cc-tmp LEAVES
+    # ORANGE (green/yellow/red) — never on a kill: reaping an idle session does
+    # not reduce cc-tmp, so a kill that leaves us ORANGE keeps cc_tier==orange and
+    # must not re-arm and re-log the same episode.
     if (( killed_any == 0 )) && [[ ! -f "$ALERT_DIR/tmp_orange_stuck" ]]; then
         log WARN "cc-tmp STUCK ORANGE (used=${used_after}MB, budget=${CC_TMP_BUDGET_MB}MB): reclaim freed nothing and no idle (>2h) session is killable — non-reclaimable data is filling cc-tmp (see cc_tmp_top snapshots). Dashboard/log-only per D2; RED will page if it escalates."
         touch "$ALERT_DIR/tmp_orange_stuck"
@@ -481,10 +487,20 @@ main() {
         # Durable OOM capture — snapshot + page on any NEW cgroup OOM kill.
         oom_baseline=$(check_oom_events "$oom_baseline")
 
-        # Clear stale alerts when back to green
+        # Clear the shared cc+sys alert flags only when BOTH zones are green:
+        # tmp_warning/tmp_emergency are touched by both the cc AND sys handlers
+        # (one dedupe key across zones), so a red episode in either zone must
+        # keep them set.
         if [[ "$cc_tier" == "green" && "$sys_tier" == "green" ]]; then
-            rm -f "$ALERT_DIR/tmp_warning" "$ALERT_DIR/tmp_emergency" \
-                  "$ALERT_DIR/tmp_orange_stuck" 2>/dev/null || true
+            rm -f "$ALERT_DIR/tmp_warning" "$ALERT_DIR/tmp_emergency" 2>/dev/null || true
+        fi
+        # tmp_orange_stuck is cc-tmp-SPECIFIC (only clean_cc_orange sets it), so
+        # clear it whenever cc-tmp is no longer ORANGE — independent of the sys
+        # tier. Otherwise a cc episode that falls to YELLOW while /tmp stays
+        # non-green leaves a stale flag that suppresses the once-per-episode STUCK
+        # record of a later, distinct cc-tmp ORANGE episode.
+        if [[ "$cc_tier" != "orange" ]]; then
+            rm -f "$ALERT_DIR/tmp_orange_stuck" 2>/dev/null || true
         fi
 
         # Log rotation — truncate when > 1MB

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -488,6 +488,11 @@ class CCInvoker:
         # cleanroom). Applied last by contract; see CCInvocation.env_overrides.
         if inv and inv.env_overrides:
             env.update(inv.env_overrides)
+            # Preserve the TMPDIR ≡ CLAUDE_CODE_TMPDIR invariant even if an
+            # override changed CLAUDE_CODE_TMPDIR but not TMPDIR (else the two
+            # silently desync). An explicit TMPDIR override still wins.
+            if "CLAUDE_CODE_TMPDIR" in inv.env_overrides and "TMPDIR" not in inv.env_overrides:
+                env["TMPDIR"] = env["CLAUDE_CODE_TMPDIR"]
         return env
 
     def _register_proc(self, key: str, proc: asyncio.subprocess.Process) -> None:

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -462,6 +462,15 @@ class CCInvoker:
             (inv.claude_code_tmpdir if inv and inv.claude_code_tmpdir else None)
             or self._CC_SANDBOX_TMPDIR
         )
+        # Keep TMPDIR consistent with CLAUDE_CODE_TMPDIR (never inconsistent — the
+        # invariant util/tmp.py protects). This also completes the per-invocation
+        # sandbox isolation above: without it a headless session's *subprocess*
+        # temp (e.g. the gauntlet agent running the fixture's pytest, whose
+        # tmp_path defaults under $TMPDIR) still lands in the inherited cc-tmp and
+        # can trip genesis-tmp-watchgod. For the default sandbox both resolve to
+        # cc-tmp (unchanged); for an override (gauntlet) TMPDIR follows it off
+        # cc-tmp.
+        env["TMPDIR"] = env["CLAUDE_CODE_TMPDIR"]
         # Prevent CC's alt-screen renderer from corrupting terminal scrollback
         # in Linux/tmux.  No-op on CC <2.1.132; required post-migration.
         env["CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN"] = "1"

--- a/src/genesis/eval/gauntlet.py
+++ b/src/genesis/eval/gauntlet.py
@@ -200,7 +200,7 @@ async def _run_pytest(workdir: Path) -> tuple[int, str]:
     # suite has its own rootdir, so the genesis ``tests/conftest.py`` redirect
     # never loads for it — without this its pytest tmp would default to
     # ``$TMPDIR`` (= watchgod-policed cc-tmp on a CC session). See
-    # ``genesis.util.tmp.pytest_basetemp_override``.
+    # ``genesis.util.tmp.should_redirect_pytest_basetemp``.
     proc = await asyncio.create_subprocess_exec(
         sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider",
         "--basetemp", str(workdir / "_pytest_tmp"),

--- a/src/genesis/eval/gauntlet.py
+++ b/src/genesis/eval/gauntlet.py
@@ -196,8 +196,14 @@ def _release_lock(fh) -> None:
 
 async def _run_pytest(workdir: Path) -> tuple[int, str]:
     """Run the fixture's pytest suite in ``workdir``. Returns (exit_code, output)."""
+    # Pin basetemp under the (already off-cc-tmp) workdir. This foreign fixture
+    # suite has its own rootdir, so the genesis ``tests/conftest.py`` redirect
+    # never loads for it — without this its pytest tmp would default to
+    # ``$TMPDIR`` (= watchgod-policed cc-tmp on a CC session). See
+    # ``genesis.util.tmp.pytest_basetemp_override``.
     proc = await asyncio.create_subprocess_exec(
         sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider",
+        "--basetemp", str(workdir / "_pytest_tmp"),
         cwd=str(workdir),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,

--- a/src/genesis/eval/gauntlet.py
+++ b/src/genesis/eval/gauntlet.py
@@ -194,16 +194,21 @@ def _release_lock(fh) -> None:
         fh.close()
 
 
-async def _run_pytest(workdir: Path) -> tuple[int, str]:
-    """Run the fixture's pytest suite in ``workdir``. Returns (exit_code, output)."""
-    # Pin basetemp under the (already off-cc-tmp) workdir. This foreign fixture
-    # suite has its own rootdir, so the genesis ``tests/conftest.py`` redirect
-    # never loads for it — without this its pytest tmp would default to
-    # ``$TMPDIR`` (= watchgod-policed cc-tmp on a CC session). See
-    # ``genesis.util.tmp.should_redirect_pytest_basetemp``.
+async def _run_pytest(workdir: Path, basetemp: Path) -> tuple[int, str]:
+    """Run the fixture's pytest suite in ``workdir``. Returns (exit_code, output).
+
+    ``basetemp`` MUST live OUTSIDE ``workdir`` (the copied project the model
+    edited): pytest wipes ``--basetemp`` before collection, so a basetemp nested
+    in the project would delete any top-level file/dir of the same name the
+    fixture or the model's solution legitimately created → a false failure. It is
+    also off cc-tmp — this foreign fixture has its own rootdir, so the genesis
+    ``tests/conftest.py`` redirect never loads for it (see
+    ``genesis.util.tmp.should_redirect_pytest_basetemp``); without an explicit
+    basetemp its tmp would default to ``$TMPDIR`` (watchgod-policed cc-tmp).
+    """
     proc = await asyncio.create_subprocess_exec(
         sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider",
-        "--basetemp", str(workdir / "_pytest_tmp"),
+        "--basetemp", str(basetemp),
         cwd=str(workdir),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
@@ -290,7 +295,9 @@ async def _run_one_fixture(
                 output_tokens=output.output_tokens,
             )
 
-        pyrc, pytest_out = await _run_pytest(workdir)
+        # basetemp under workroot (the temp PARENT of workdir), so it is outside
+        # the copied project and reaped with workroot at line ~319.
+        pyrc, pytest_out = await _run_pytest(workdir, workroot / "_pytest_tmp")
         if "No module named pytest" in pytest_out:
             return _skip(fx, "pytest unavailable in gauntlet environment")
         passed = pyrc == 0

--- a/src/genesis/util/tmp.py
+++ b/src/genesis/util/tmp.py
@@ -29,3 +29,42 @@ def big_tmp_dir() -> str:
     target = os.environ.get("GENESIS_BIG_TMP") or str(Path.home() / "tmp")
     Path(target).mkdir(parents=True, exist_ok=True)
     return target
+
+
+def pytest_basetemp_override(
+    current_basetemp: str | None,
+    tmpdir_env: str | None,
+    home: str,
+    big_tmp: str,
+) -> str | None:
+    """Decide where pytest should root its per-run temp tree. Pure — no I/O.
+
+    pytest's ``tmp_path``/``basetemp`` default to ``<TMPDIR>/pytest-of-<user>/``.
+    On a Genesis install ``TMPDIR`` is ``~/.genesis/cc-tmp`` (set for CC sessions
+    by ``scripts/cc-slot.sh``), the budget-policed dir the ``genesis-tmp-watchgod``
+    service reacts to — so an un-redirected suite dumps hundreds of MB there and
+    trips the watchgod. This returns a basetemp UNDER ``big_tmp`` (``~/tmp``, the
+    non-budgeted on-disk dir) so the caller can steer ``config.option.basetemp``.
+
+    Redirect ONLY when BOTH hold, else return ``None`` (leave pytest's default):
+      * the caller did not already pass ``--basetemp`` (``current_basetemp is None``);
+      * ``TMPDIR`` resolves to ``<home>/.genesis/cc-tmp`` or a path under it.
+
+    On CI ``TMPDIR`` is unset → returns ``None`` → no-op (CI keeps its own tmp).
+    This never rewrites the process ``TMPDIR`` (see the module docstring — that
+    would desync Claude Code's ``TMPDIR``/``CLAUDE_CODE_TMPDIR``); it only names a
+    basetemp for pytest's own option.
+
+    Returns the shared ``<big_tmp>/pytest`` base; the CALLER must scope a
+    per-process leaf under it (pytest clears an explicit basetemp at session
+    start, so concurrent runs sharing one path would delete each other's temp).
+    """
+    if current_basetemp is not None:
+        return None
+    if not tmpdir_env:
+        return None
+    cc_tmp = os.path.realpath(os.path.join(home, ".genesis", "cc-tmp"))
+    resolved = os.path.realpath(tmpdir_env)
+    if resolved == cc_tmp or resolved.startswith(cc_tmp + os.sep):
+        return os.path.join(big_tmp, "pytest")
+    return None

--- a/src/genesis/util/tmp.py
+++ b/src/genesis/util/tmp.py
@@ -31,40 +31,37 @@ def big_tmp_dir() -> str:
     return target
 
 
-def pytest_basetemp_override(
+def should_redirect_pytest_basetemp(
     current_basetemp: str | None,
     tmpdir_env: str | None,
     home: str,
-    big_tmp: str,
-) -> str | None:
-    """Decide where pytest should root its per-run temp tree. Pure — no I/O.
+) -> bool:
+    """Whether pytest's basetemp should be steered off cc-tmp. Pure — no I/O.
 
     pytest's ``tmp_path``/``basetemp`` default to ``<TMPDIR>/pytest-of-<user>/``.
     On a Genesis install ``TMPDIR`` is ``~/.genesis/cc-tmp`` (set for CC sessions
     by ``scripts/cc-slot.sh``), the budget-policed dir the ``genesis-tmp-watchgod``
     service reacts to — so an un-redirected suite dumps hundreds of MB there and
-    trips the watchgod. This returns a basetemp UNDER ``big_tmp`` (``~/tmp``, the
-    non-budgeted on-disk dir) so the caller can steer ``config.option.basetemp``.
+    trips the watchgod.
 
-    Redirect ONLY when BOTH hold, else return ``None`` (leave pytest's default):
+    Redirect ONLY when BOTH hold (else ``False`` — leave pytest's default AND do
+    no filesystem work):
       * the caller did not already pass ``--basetemp`` (``current_basetemp is None``);
       * ``TMPDIR`` resolves to ``<home>/.genesis/cc-tmp`` or a path under it.
 
-    On CI ``TMPDIR`` is unset → returns ``None`` → no-op (CI keeps its own tmp).
-    This never rewrites the process ``TMPDIR`` (see the module docstring — that
-    would desync Claude Code's ``TMPDIR``/``CLAUDE_CODE_TMPDIR``); it only names a
-    basetemp for pytest's own option.
-
-    Returns the shared ``<big_tmp>/pytest`` base; the CALLER must scope a
-    per-process leaf under it (pytest clears an explicit basetemp at session
-    start, so concurrent runs sharing one path would delete each other's temp).
+    On CI ``TMPDIR`` is unset → ``False`` → no-op (CI keeps its own tmp). Being a
+    pure predicate (no ``big_tmp_dir()`` call) is deliberate: the caller must not
+    create ``~/tmp`` on the no-op / explicit-``--basetemp`` path (that would break
+    a read-only-home or CI run during config). The caller redirects to a
+    per-process leaf under :func:`big_tmp_dir` (``~/tmp``) only when this is True;
+    per-process because pytest clears an explicit basetemp at session start, so
+    concurrent runs sharing one path would delete each other's temp. This never
+    rewrites the process ``TMPDIR`` (see the module docstring).
     """
     if current_basetemp is not None:
-        return None
+        return False
     if not tmpdir_env:
-        return None
+        return False
     cc_tmp = os.path.realpath(os.path.join(home, ".genesis", "cc-tmp"))
     resolved = os.path.realpath(tmpdir_env)
-    if resolved == cc_tmp or resolved.startswith(cc_tmp + os.sep):
-        return os.path.join(big_tmp, "pytest")
-    return None
+    return resolved == cc_tmp or resolved.startswith(cc_tmp + os.sep)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,37 @@ def _safe_killpg(pgid: int, sig: int) -> None:
 os.killpg = _safe_killpg  # type: ignore[assignment]
 
 
+# ── Redirect pytest's temp tree OFF the watchgod-policed cc-tmp ───────────
+# A CC session's TMPDIR is ``~/.genesis/cc-tmp`` (set by scripts/cc-slot.sh),
+# and pytest's ``tmp_path``/basetemp default under ``$TMPDIR``. Left alone, a
+# broad suite dumps hundreds of MB of ``pytest-of-<user>/`` into that
+# budget-policed dir and trips ``genesis-tmp-watchgod`` (stuck-ORANGE churn).
+# This steers pytest's own basetemp to ``~/tmp`` (``big_tmp_dir``) instead —
+# WITHOUT touching the process ``TMPDIR`` (which would desync CC's
+# TMPDIR/CLAUDE_CODE_TMPDIR). Runs at config time, before any ``tmp_path``
+# fixture resolves. No-op on CI (TMPDIR unset) and when ``--basetemp`` is
+# passed explicitly. See ``genesis.util.tmp.pytest_basetemp_override``.
+def pytest_configure(config):
+    from genesis.util.tmp import big_tmp_dir, pytest_basetemp_override
+
+    target = pytest_basetemp_override(
+        current_basetemp=config.option.basetemp,
+        tmpdir_env=os.environ.get("TMPDIR"),
+        home=os.path.expanduser("~"),
+        big_tmp=big_tmp_dir(),
+    )
+    if target is not None:
+        # Scope the leaf per-process. pytest CLEARS an explicit basetemp at
+        # session start and roots tmp_path directly under it (no pytest-of-<user>
+        # numbered rotation), so two concurrent runs sharing one path would
+        # rmtree each other's live temp. The CC concurrent-test guard only covers
+        # Bash-tool pytest — autonomy/gauntlet subprocesses bypass it — so the
+        # per-pid leaf is what actually keeps simultaneous runs isolated.
+        target = os.path.join(target, str(os.getpid()))
+        Path(target).mkdir(parents=True, exist_ok=True)
+        config.option.basetemp = target
+
+
 # ── Safety: prevent tests from polluting production circuit breaker state ──
 @pytest.fixture(autouse=True)
 def _isolate_circuit_breaker_state(tmp_path, monkeypatch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,39 @@ os.killpg = _safe_killpg  # type: ignore[assignment]
 # TMPDIR/CLAUDE_CODE_TMPDIR). Runs at config time, before any ``tmp_path``
 # fixture resolves. No-op on CI (TMPDIR unset) and when ``--basetemp`` is
 # passed explicitly. See ``genesis.util.tmp.should_redirect_pytest_basetemp``.
+def _reap_stale_pytest_basetemps(pytest_base: str) -> None:
+    """Remove per-PID basetemp dirs left by runs that exited abnormally (SIGKILL/
+    host crash — ``pytest_unconfigure`` never ran). A leaf is stale iff its name
+    is an integer PID that is no longer alive; LIVE PIDs (concurrent runs) are
+    spared, so this never touches another in-flight suite. Best-effort — this is
+    the safety net that makes cleanup survive abnormal exits (``pytest_unconfigure``
+    handles the normal path)."""
+    import shutil
+
+    try:
+        names = os.listdir(pytest_base)
+    except OSError:
+        return
+    for name in names:
+        # isdecimal (NOT isdigit): isdigit is True for superscripts like '²' whose
+        # int() raises ValueError — this loop must never raise out of
+        # pytest_configure (that would break collection for the WHOLE suite,
+        # strictly worse than the leak it prevents).
+        if not name.isdecimal():
+            continue
+        pid = int(name)
+        if pid <= 1:
+            continue  # our leaf is always our own PID (>1); never signal 0/1
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            shutil.rmtree(os.path.join(pytest_base, name), ignore_errors=True)  # dead → reap
+        except (OSError, OverflowError):
+            # alive-but-not-ours (PermissionError), transient, or an out-of-PID-range
+            # name (os.kill(10**30,0) → OverflowError, which is NOT an OSError) → spare.
+            pass
+
+
 def pytest_configure(config):
     from genesis.util.tmp import big_tmp_dir, should_redirect_pytest_basetemp
 
@@ -87,9 +120,13 @@ def pytest_configure(config):
     # rotation), so two concurrent runs sharing one path would rmtree each other's
     # live temp. The CC concurrent-test guard only covers Bash-tool pytest —
     # autonomy/gauntlet subprocesses bypass it — so the per-pid leaf is what keeps
-    # simultaneous runs isolated. pytest_unconfigure removes it so per-pid dirs
-    # can't accumulate under ~/tmp/pytest indefinitely.
-    target = os.path.join(big_tmp_dir(), "pytest", str(os.getpid()))
+    # simultaneous runs isolated.
+    pytest_base = os.path.join(big_tmp_dir(), "pytest")
+    # Reap dead-PID leaves from prior abnormal exits BEFORE creating ours, so the
+    # ~/tmp/pytest dir can't accumulate (the daily hygiene job only prunes direct
+    # children of ~/tmp, whose mtime every run refreshes — so it never ages out).
+    _reap_stale_pytest_basetemps(pytest_base)
+    target = os.path.join(pytest_base, str(os.getpid()))
     Path(target).mkdir(parents=True, exist_ok=True)
     config.option.basetemp = target
     config._genesis_basetemp_cleanup = target

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,26 +69,43 @@ os.killpg = _safe_killpg  # type: ignore[assignment]
 # WITHOUT touching the process ``TMPDIR`` (which would desync CC's
 # TMPDIR/CLAUDE_CODE_TMPDIR). Runs at config time, before any ``tmp_path``
 # fixture resolves. No-op on CI (TMPDIR unset) and when ``--basetemp`` is
-# passed explicitly. See ``genesis.util.tmp.pytest_basetemp_override``.
+# passed explicitly. See ``genesis.util.tmp.should_redirect_pytest_basetemp``.
 def pytest_configure(config):
-    from genesis.util.tmp import big_tmp_dir, pytest_basetemp_override
+    from genesis.util.tmp import big_tmp_dir, should_redirect_pytest_basetemp
 
-    target = pytest_basetemp_override(
+    # Decide FIRST (pure, no I/O) — only touch the filesystem when we actually
+    # redirect, so the no-op / CI / explicit-`--basetemp` path never creates
+    # `~/tmp` (which would break a read-only-home or CI run during config).
+    if not should_redirect_pytest_basetemp(
         current_basetemp=config.option.basetemp,
         tmpdir_env=os.environ.get("TMPDIR"),
         home=os.path.expanduser("~"),
-        big_tmp=big_tmp_dir(),
-    )
-    if target is not None:
-        # Scope the leaf per-process. pytest CLEARS an explicit basetemp at
-        # session start and roots tmp_path directly under it (no pytest-of-<user>
-        # numbered rotation), so two concurrent runs sharing one path would
-        # rmtree each other's live temp. The CC concurrent-test guard only covers
-        # Bash-tool pytest — autonomy/gauntlet subprocesses bypass it — so the
-        # per-pid leaf is what actually keeps simultaneous runs isolated.
-        target = os.path.join(target, str(os.getpid()))
-        Path(target).mkdir(parents=True, exist_ok=True)
-        config.option.basetemp = target
+    ):
+        return
+    # Scope the leaf per-process. pytest CLEARS an explicit basetemp at session
+    # start and roots tmp_path directly under it (no pytest-of-<user> numbered
+    # rotation), so two concurrent runs sharing one path would rmtree each other's
+    # live temp. The CC concurrent-test guard only covers Bash-tool pytest —
+    # autonomy/gauntlet subprocesses bypass it — so the per-pid leaf is what keeps
+    # simultaneous runs isolated. pytest_unconfigure removes it so per-pid dirs
+    # can't accumulate under ~/tmp/pytest indefinitely.
+    target = os.path.join(big_tmp_dir(), "pytest", str(os.getpid()))
+    Path(target).mkdir(parents=True, exist_ok=True)
+    config.option.basetemp = target
+    config._genesis_basetemp_cleanup = target
+
+
+def pytest_unconfigure(config):
+    """Remove the per-process basetemp tree this session created. pytest wipes an
+    explicit basetemp at session START but never at exit, and each run gets a new
+    PID, so without this the ``~/tmp/pytest/<pid>`` dirs would accumulate (the
+    daily hygiene job only prunes direct children of ``~/tmp``, whose mtime every
+    new run refreshes — so it never ages out). Best-effort."""
+    import shutil
+
+    target = getattr(config, "_genesis_basetemp_cleanup", None)
+    if target:
+        shutil.rmtree(target, ignore_errors=True)
 
 
 # ── Safety: prevent tests from polluting production circuit breaker state ──

--- a/tests/test_cc/test_invoker_roster_env.py
+++ b/tests/test_cc/test_invoker_roster_env.py
@@ -43,6 +43,23 @@ def test_build_args_omits_model_flag_when_override_set():
     assert "--model" not in args
 
 
+def test_build_env_tmpdir_tracks_claude_code_tmpdir(tmp_path):
+    """TMPDIR must stay CONSISTENT with CLAUDE_CODE_TMPDIR (the invariant
+    util/tmp.py protects) — and follow a per-invocation sandbox override, so a
+    headless session's subprocess temp (e.g. the gauntlet agent running the
+    fixture's pytest, whose tmp_path defaults under $TMPDIR) leaves cc-tmp instead
+    of tripping genesis-tmp-watchgod."""
+    invoker = CCInvoker()
+    # default: both resolve to the shared cc-tmp sandbox (consistent, unchanged).
+    env = invoker._build_env(_inv())
+    assert env["TMPDIR"] == env["CLAUDE_CODE_TMPDIR"]
+    # per-invocation override (gauntlet): TMPDIR follows the sandbox off cc-tmp.
+    sandbox = str(tmp_path / "cc-sandbox")
+    env2 = invoker._build_env(_inv(claude_code_tmpdir=sandbox))
+    assert env2["CLAUDE_CODE_TMPDIR"] == sandbox
+    assert env2["TMPDIR"] == sandbox
+
+
 def test_build_args_includes_model_flag_for_claude():
     args = CCInvoker()._build_args(_inv())
     assert "--model" in args

--- a/tests/test_cc/test_invoker_roster_env.py
+++ b/tests/test_cc/test_invoker_roster_env.py
@@ -58,6 +58,15 @@ def test_build_env_tmpdir_tracks_claude_code_tmpdir(tmp_path):
     env2 = invoker._build_env(_inv(claude_code_tmpdir=sandbox))
     assert env2["CLAUDE_CODE_TMPDIR"] == sandbox
     assert env2["TMPDIR"] == sandbox
+    # A future env_overrides that changes CLAUDE_CODE_TMPDIR must not desync
+    # TMPDIR — it follows unless TMPDIR is ALSO explicitly overridden.
+    ov = str(tmp_path / "ov")
+    env3 = invoker._build_env(_inv(env_overrides={"CLAUDE_CODE_TMPDIR": ov}))
+    assert env3["TMPDIR"] == ov, "TMPDIR must track an override of CLAUDE_CODE_TMPDIR"
+    env4 = invoker._build_env(
+        _inv(env_overrides={"CLAUDE_CODE_TMPDIR": ov, "TMPDIR": "/explicit"})
+    )
+    assert env4["TMPDIR"] == "/explicit", "an explicit TMPDIR override still wins"
 
 
 def test_build_args_includes_model_flag_for_claude():

--- a/tests/test_eval/test_gauntlet.py
+++ b/tests/test_eval/test_gauntlet.py
@@ -447,7 +447,7 @@ class TestRunPytestBounded:
             return proc
 
         monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec)
-        rc, out = await g._run_pytest(tmp_path)
+        rc, out = await g._run_pytest(tmp_path, tmp_path / "_pt_bt")
         assert rc == -1
         assert "timed out" in out
         assert len(killpg_calls) == 1
@@ -468,7 +468,7 @@ class TestRunPytestBounded:
             return proc
 
         monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec)
-        rc, out = await g._run_pytest(tmp_path)
+        rc, out = await g._run_pytest(tmp_path, tmp_path / "_pt_bt")
         assert rc == 0
         assert captured.get("start_new_session") is True
         assert "preexec_fn" not in captured
@@ -504,7 +504,7 @@ class TestRunPytestBounded:
             return proc
 
         monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec)
-        task = _asyncio.get_running_loop().create_task(g._run_pytest(tmp_path))
+        task = _asyncio.get_running_loop().create_task(g._run_pytest(tmp_path, tmp_path / "_pt_bt"))
         await started.wait()
         task.cancel()
         with pytest.raises(_asyncio.CancelledError):

--- a/tests/test_scripts/test_cc_exit_capture.py
+++ b/tests/test_scripts/test_cc_exit_capture.py
@@ -1,0 +1,148 @@
+"""cc_exit_capture.sh — durable record of why a CC session died.
+
+A CC session runs as tmux ``... exec claude`` (cc-slot.sh). When claude exits the
+pane vanishes with its output, so a dying session leaves no trace — the
+2026-08-19 death was undiagnosable for exactly this reason. cc-slot.sh now drops
+the inner ``exec`` and calls cc_exit_capture.sh on claude's return to log the
+exit status (signal-decoded) + a pane-scrollback tail.
+
+Two layers: (1) the script's status/hint/rotation logic, tested directly with
+TMUX_PANE unset (no tmux needed); (2) the FULL flow — the exact cc-slot inner
+command shape with a fake crashing ``claude`` — in a scratch tmux server on a
+private ``-L`` socket, so the real cc-* sessions are never touched.
+"""
+
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+_CAPTURE = Path(__file__).resolve().parents[2] / "scripts" / "cc_exit_capture.sh"
+
+
+def _run_capture(home: Path, slot: str, ec: str, tmux_pane: str | None = None):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env.pop("TMUX_PANE", None)
+    if tmux_pane is not None:
+        env["TMUX_PANE"] = tmux_pane
+    return subprocess.run(
+        [str(_CAPTURE), slot, ec],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _log_for(home: Path, slot: str) -> Path:
+    return home / ".genesis" / "logs" / f"cc_exit_{slot}.log"
+
+
+# ── Layer 1: script logic, no tmux ───────────────────────────────────────
+
+
+def test_records_exit_status_and_clean_hint(tmp_path):
+    home = tmp_path / "home"
+    r = _run_capture(home, "1", "0")
+    assert r.returncode == 0, r.stderr
+    body = _log_for(home, "1").read_text()
+    assert "cc-1 claude exited status=0" in body
+    assert "clean exit" in body
+
+
+def test_decodes_fatal_signals(tmp_path):
+    home = tmp_path / "home"
+    cases = {
+        "134": "SIGABRT",  # V8/Node fatal abort
+        "137": "SIGKILL",  # OOM kill
+        "139": "SIGSEGV",
+        "143": "SIGTERM",
+    }
+    for ec in cases:
+        _run_capture(home, "2", ec)
+    body = _log_for(home, "2").read_text()
+    for ec, marker in cases.items():
+        assert f"status={ec}" in body, body
+        assert marker in body, f"missing {marker} decode:\n{body}"
+
+
+def test_never_fails_when_home_unwritable(tmp_path):
+    """Best-effort: a capture problem must never surface a non-zero exit (it would
+    otherwise change the session's exit code). Point HOME at a non-dir."""
+    bad = tmp_path / "afile"
+    bad.write_text("not a dir")
+    env = dict(os.environ)
+    env["HOME"] = str(bad)
+    env.pop("TMUX_PANE", None)
+    r = subprocess.run(
+        [str(_CAPTURE), "1", "137"],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+    assert r.returncode == 0, f"capture must exit 0 even when it cannot log: {r.stderr}"
+
+
+def test_log_self_rotates(tmp_path):
+    home = tmp_path / "home"
+    log = _log_for(home, "3")
+    log.parent.mkdir(parents=True)
+    log.write_text("\n".join(f"old line {i}" for i in range(5000)) + "\n")
+    _run_capture(home, "3", "0")
+    lines = log.read_text().splitlines()
+    assert len(lines) <= 2000 + 5, f"log not rotated: {len(lines)} lines"
+    assert "cc-3 claude exited status=0" in log.read_text()
+
+
+# ── Layer 2: full flow in a scratch tmux (never the live sessions) ───────
+
+
+@pytest.mark.skipif(not shutil.which("tmux"), reason="tmux not available")
+def test_full_flow_captures_crash_in_scratch_tmux(tmp_path):
+    """Mimic cc-slot's exact inner command with a fake crashing claude, in a
+    private tmux server. Assert the exit status AND the pane's dying words are
+    captured, and the session actually ends (exit-code preservation)."""
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    marker = f"CRASH_MARKER_{uuid.uuid4().hex[:8]}"
+    fake_claude = tmp_path / "fakeclaude.sh"
+    fake_claude.write_text(f"#!/usr/bin/env bash\necho '{marker}'\nexit 134\n")
+    fake_claude.chmod(0o755)
+
+    sock = f"ccexit-test-{os.getpid()}-{uuid.uuid4().hex[:6]}"
+    # The exact shape cc-slot.sh builds: run claude (no exec), capture on return,
+    # preserve the exit code. HOME is set so capture logs into our sandbox.
+    inner = (
+        f"HOME={home} '{fake_claude}'; __ec=$?; "
+        f"HOME={home} '{_CAPTURE}' 7 $__ec >/dev/null 2>&1; exit $__ec"
+    )
+    try:
+        subprocess.run(
+            ["tmux", "-L", sock, "new-session", "-d", "-s", "t", inner],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        # Condition-based wait (bounded): the session ends when the inner cmd exits.
+        deadline = time.monotonic() + 15
+        gone = False
+        while time.monotonic() < deadline:
+            r = subprocess.run(["tmux", "-L", sock, "has-session", "-t", "t"], capture_output=True)
+            if r.returncode != 0:
+                gone = True
+                break
+            time.sleep(0.2)
+        assert gone, "session never ended — exit-code preservation broken"
+    finally:
+        subprocess.run(["tmux", "-L", sock, "kill-server"], capture_output=True)
+
+    body = _log_for(home, "7").read_text()
+    assert "cc-7 claude exited status=134" in body, body
+    assert "SIGABRT" in body, body
+    assert marker in body, f"pane dying words not captured:\n{body}"

--- a/tests/test_scripts/test_cc_exit_capture.py
+++ b/tests/test_scripts/test_cc_exit_capture.py
@@ -14,6 +14,7 @@ private ``-L`` socket, so the real cc-* sessions are never touched.
 
 import os
 import shutil
+import stat
 import subprocess
 import time
 import uuid
@@ -87,6 +88,28 @@ def test_never_fails_when_home_unwritable(tmp_path):
         stdin=subprocess.DEVNULL,
     )
     assert r.returncode == 0, f"capture must exit 0 even when it cannot log: {r.stderr}"
+
+
+def test_log_is_owner_only(tmp_path):
+    """The captured tail can contain credentials/prompts → the log must be 0600
+    so another local account can't read it."""
+    home = tmp_path / "home"
+    _run_capture(home, "1", "0")
+    mode = stat.S_IMODE(_log_for(home, "1").stat().st_mode)
+    assert mode == 0o600, f"log mode {oct(mode)} (must be 0600)"
+
+
+def test_pre_existing_log_is_tightened(tmp_path):
+    """A log that predates this hardening (mode 0644) is tightened to 0600 on the
+    next append — not left world-readable."""
+    home = tmp_path / "home"
+    log = _log_for(home, "2")
+    log.parent.mkdir(parents=True)
+    log.write_text("older entry\n")
+    os.chmod(log, 0o644)
+    _run_capture(home, "2", "137")
+    mode = stat.S_IMODE(log.stat().st_mode)
+    assert mode == 0o600, f"pre-existing log not tightened: {oct(mode)}"
 
 
 def test_log_self_rotates(tmp_path):

--- a/tests/test_scripts/test_session_doors.py
+++ b/tests/test_scripts/test_session_doors.py
@@ -176,16 +176,31 @@ class TestManualMode:
         result = run("manual", "--resume", "a b'c")
         assert result.returncode == 0, result.stderr
         # %q-quoted through the tmux command string: the shell inside the
-        # session must receive the original value as ONE argument.
+        # session must receive the original value as ONE argument. Parse only the
+        # claude-args segment — between 'claude ' and the '; __ec=' exit-capture
+        # trailer the inner command now appends.
         line = _new_session_line(log)
         cmd = line.split("LANG=", 1)[1].split(" ", 1)[1]
+        claude_args = cmd.split("claude", 1)[1].split("; __ec=", 1)[0]
         parsed = subprocess.run(
-            ["bash", "-c", f'set -- {cmd.split("claude", 1)[1]}; printf "%s\\n" "$@"'],
+            ["bash", "-c", f'set -- {claude_args}; printf "%s\\n" "$@"'],
             capture_output=True,
             text=True,
             timeout=10,
         )
         assert "a b'c" in parsed.stdout.splitlines()
+
+    def test_inner_command_wires_exit_capture(self, door):
+        """The inner tmux command drops `exec` and records claude's exit via
+        cc_exit_capture.sh before the pane vanishes, preserving claude's code as
+        the pane's exit. Locks the wiring the 2026-08-19 death observability adds."""
+        run, log, _sessions, _listing = door
+        result = run("manual")
+        assert result.returncode == 0, result.stderr
+        line = _new_session_line(log)
+        assert "cc_exit_capture.sh 1 $__ec" in line, line  # slot 1, deferred code
+        assert "exit $__ec" in line, line  # claude's code reproduced as the pane's
+        assert "exec claude" not in line, "inner exec must be dropped so the trailer runs"
 
 
 class TestHostnameMode:

--- a/tests/test_scripts/test_watchgod_loopbreak.py
+++ b/tests/test_scripts/test_watchgod_loopbreak.py
@@ -1,0 +1,222 @@
+"""tmp_watchgod ORANGE loop-break + durable OOM capture.
+
+Regression cover for the 2026-08-19 runaway: cc-tmp went ORANGE (a ~382MB pytest
+tree the cache-evict never touches), and because the tier that dispatched the
+handler was measured BEFORE cleanup, the daemon re-entered ORANGE every poll and
+re-ran the idle-session kill loop for ~4.5h. The loop-break re-measures AFTER
+cleanup and kills ONLY if still over the line; when nothing is reclaimable and
+nothing is killable it pages once instead of looping silently.
+
+Plus the OOM sampler: on a NEW cgroup oom_kill it writes a durable snapshot and
+pages once (the death that started all this left no diagnosable trace).
+
+tmux is a configurable STUB (never a real session): it reports whatever sessions
+the test injects and records every kill-session call to a file, so we can assert
+the loop-break did or did NOT kill. queue_alert is overridden to a call-log so we
+can assert page-once. The script's sourcing guard loads its functions without
+starting the daemon.
+"""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_WATCHGOD = Path(__file__).resolve().parents[2] / "scripts" / "tmp_watchgod.sh"
+
+# A configurable tmux stub. STUB_SESSIONS is echoed for list-sessions (one
+# "name:attached" line), STUB_ACTIVITY is the session_activity epoch, and every
+# kill-session target is appended to STUB_KILLLOG. Any other verb is a no-op.
+_TMUX_STUB = r"""#!/usr/bin/env bash
+case "$1" in
+  list-sessions)   [[ -n "${STUB_SESSIONS:-}" ]] && printf '%s\n' "$STUB_SESSIONS" ;;
+  display-message) echo "${STUB_ACTIVITY:-0}" ;;
+  kill-session)    echo "$3" >> "${STUB_KILLLOG:?}" ;;
+esac
+exit 0
+"""
+
+
+def _make_exec(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _sandbox(tmp_path):
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    (home / ".genesis" / "alerts").mkdir(parents=True)
+    cctmp = home / ".genesis" / "cc-tmp"
+    cctmp.mkdir(parents=True)
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    _make_exec(bind / "tmux", _TMUX_STUB)
+    return home, cctmp, bind
+
+
+def _run(home, bind, snippet, extra_env=None):
+    env = dict(os.environ)
+    env.update(HOME=str(home), PATH=f"{bind}:{os.environ['PATH']}")
+    if extra_env:
+        env.update({k: str(v) for k, v in extra_env.items()})
+    return subprocess.run(
+        ["bash", "-c", f"source '{_WATCHGOD}'\n{snippet}"],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+# The snippet prefix: shrink the budget so a few MB crosses ORANGE, and override
+# queue_alert to a call-log. threshold_orange = budget*75/100; budget=4 → 3MB.
+_PRELUDE = (
+    'CC_TMP_BUDGET_MB=4; queue_alert() { echo "ALERT $*" >> "$HOME/.genesis/alerts/calls.log"; }; '
+)
+
+
+def _mb(path: Path, mb: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * (mb * 1024 * 1024))
+
+
+# ── Fix 3: ORANGE loop-break ─────────────────────────────────────────────
+
+
+def test_orange_resolved_by_cleanup_does_not_kill(tmp_path):
+    """The core regression: when cache cleanup drops cc-tmp back under the ORANGE
+    line, NO session is killed — even though a killable (idle>2h, unattached)
+    session exists. Before the loop-break this killed a session every poll."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    _mb(cctmp / "claude-skills" / "blob", 6)  # >3MB ORANGE; evicted by cleanup
+    killlog = home / "killed.log"
+    env = {"STUB_SESSIONS": "cc-99:0", "STUB_ACTIVITY": "100", "STUB_KILLLOG": str(killlog)}
+    proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not killlog.exists(), (
+        "loop-break failed: a session was killed after cleanup resolved ORANGE"
+    )
+    log = (home / ".genesis" / "logs" / "tmp_watchgod.log").read_text()
+    assert "resolved by cache cleanup" in log, log
+
+
+def test_orange_persists_no_killable_logs_once_no_page(tmp_path):
+    """Non-reclaimable data keeps cc-tmp ORANGE and no idle session is killable →
+    per design D2 this does NOT page (only RED pages); it records the stuck state
+    once (dedupe flag + a single STUCK log line), not silently every poll."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    _mb(cctmp / "bigdata" / "blob", 6)  # NOT a cache/session dir → cleanup can't evict
+    killlog = home / "killed.log"
+    env = {"STUB_SESSIONS": "", "STUB_KILLLOG": str(killlog)}  # no sessions
+    # Call twice — the second must NOT re-log the stuck state (flag dedupe).
+    proc = _run(home, bind, _PRELUDE + "clean_cc_orange; clean_cc_orange", env)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not killlog.exists(), "nothing was killable; no kill should occur"
+    stuck = home / ".genesis" / "alerts" / "tmp_orange_stuck"
+    assert stuck.exists(), "stuck-ORANGE dedupe flag not set"
+    # D2: no page — the alert queue is never touched for a stuck ORANGE.
+    assert not (home / ".genesis" / "alerts" / "calls.log").exists(), (
+        "stuck ORANGE must NOT page (D2: only RED pages)"
+    )
+    logtext = (home / ".genesis" / "logs" / "tmp_watchgod.log").read_text()
+    assert logtext.count("STUCK ORANGE") == 1, (
+        f"expected exactly one STUCK log line, got {logtext.count('STUCK ORANGE')}"
+    )
+
+
+def test_orange_persists_with_killable_reaps_and_no_stuck_flag(tmp_path):
+    """When ORANGE persists AND an idle>2h unattached session exists, it IS
+    reaped (unchanged behavior) and the stuck flag is not raised."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    _mb(cctmp / "bigdata" / "blob", 6)
+    killlog = home / "killed.log"
+    env = {"STUB_SESSIONS": "cc-77:0", "STUB_ACTIVITY": "100", "STUB_KILLLOG": str(killlog)}
+    proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert killlog.exists() and "cc-77" in killlog.read_text(), "idle session should be reaped"
+    stuck = home / ".genesis" / "alerts" / "tmp_orange_stuck"
+    assert not stuck.exists(), "stuck flag must not be set when a session was killed"
+
+
+def test_kill_does_not_clear_stuck_flag_no_double_page(tmp_path):
+    """Regression for the double-page edge: once stuck-ORANGE has paged, a later
+    poll that happens to reap a newly-idle session must NOT clear the flag (a kill
+    doesn't reduce cc-tmp), else the next still-ORANGE poll re-arms and re-pages
+    the same episode. The flag clears only on the green transition."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    _mb(cctmp / "bigdata" / "blob", 6)  # persists ORANGE
+    stuck = home / ".genesis" / "alerts" / "tmp_orange_stuck"
+    stuck.touch()  # a prior poll already paged
+    killlog = home / "killed.log"
+    env = {"STUB_SESSIONS": "cc-88:0", "STUB_ACTIVITY": "100", "STUB_KILLLOG": str(killlog)}
+    proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert killlog.exists(), "idle session should still be reaped"
+    assert stuck.exists(), "a kill must NOT clear the stuck flag (would re-page next poll)"
+
+
+def test_attached_session_never_killed(tmp_path):
+    """An ATTACHED session (activity recent, or simply not matched by the ':0$'
+    unattached filter) is never a kill candidate — asserts the filter shape."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    _mb(cctmp / "bigdata" / "blob", 6)
+    killlog = home / "killed.log"
+    # attached=1 → the ':0$' grep drops it, so the stub still lists it but the
+    # loop never sees it. (list-sessions output is pre-filtered by the script.)
+    env = {"STUB_SESSIONS": "cc-5:1", "STUB_KILLLOG": str(killlog)}
+    proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not killlog.exists(), "attached session must never be killed"
+
+
+# ── Fix 4: durable OOM capture ───────────────────────────────────────────
+
+
+def _oom_file(tmp_path, kills: int) -> Path:
+    f = tmp_path / "memory.events"
+    f.write_text(f"low 0\nhigh 0\nmax 0\noom 3\noom_kill {kills}\noom_group_kill 0\n")
+    return f
+
+
+def test_oom_increment_logs_and_pages(tmp_path):
+    home, _cc, bind = _sandbox(tmp_path)
+    oom = _oom_file(tmp_path, 5)
+    out = _run(
+        home,
+        bind,
+        _PRELUDE + 'result=$(check_oom_events 3); echo "BASELINE=$result"',
+        {"OOM_EVENTS_FILE": str(oom)},
+    )
+    assert out.returncode == 0, f"{out.stdout}\n{out.stderr}"
+    assert "BASELINE=5" in out.stdout, out.stdout  # baseline advances to current
+    oom_log = (home / ".genesis" / "logs" / "oom_events.log").read_text()
+    assert "oom_kill 3 -> 5 (+2)" in oom_log, oom_log
+    calls = (home / ".genesis" / "alerts" / "calls.log").read_text()
+    # OOM pages at EMERGENCY tier (a discrete serious event), unlike stuck-ORANGE.
+    assert "emergency watchgod:oom" in calls, calls
+
+
+def test_oom_no_increment_is_silent(tmp_path):
+    home, _cc, bind = _sandbox(tmp_path)
+    oom = _oom_file(tmp_path, 5)
+    out = _run(
+        home,
+        bind,
+        _PRELUDE + 'result=$(check_oom_events 5); echo "BASELINE=$result"',
+        {"OOM_EVENTS_FILE": str(oom)},
+    )
+    assert "BASELINE=5" in out.stdout, out.stdout
+    assert not (home / ".genesis" / "logs" / "oom_events.log").exists()
+    assert not (home / ".genesis" / "alerts" / "calls.log").exists()
+
+
+def test_oom_unavailable_is_noop(tmp_path):
+    home, _cc, bind = _sandbox(tmp_path)
+    out = _run(
+        home,
+        bind,
+        _PRELUDE + 'result=$(check_oom_events 3); echo "BASELINE=$result"',
+        {"OOM_EVENTS_FILE": str(tmp_path / "does-not-exist")},
+    )
+    assert out.returncode == 0, f"{out.stdout}\n{out.stderr}"
+    assert "BASELINE=3" in out.stdout, out.stdout  # baseline preserved, no crash

--- a/tests/test_scripts/test_watchgod_loopbreak.py
+++ b/tests/test_scripts/test_watchgod_loopbreak.py
@@ -31,7 +31,7 @@ _TMUX_STUB = r"""#!/usr/bin/env bash
 case "$1" in
   list-sessions)   [[ -n "${STUB_SESSIONS:-}" ]] && printf '%s\n' "$STUB_SESSIONS" ;;
   display-message) echo "${STUB_ACTIVITY:-0}" ;;
-  kill-session)    echo "$3" >> "${STUB_KILLLOG:?}" ;;
+  kill-session)    echo "$3" >> "${STUB_KILLLOG:?}"; exit "${STUB_KILL_RC:-0}" ;;
 esac
 exit 0
 """
@@ -153,6 +153,26 @@ def test_kill_does_not_clear_stuck_flag_no_double_page(tmp_path):
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert killlog.exists(), "idle session should still be reaped"
     assert stuck.exists(), "a kill must NOT clear the stuck flag (would re-page next poll)"
+
+
+def test_failed_kill_does_not_count_as_reaped(tmp_path):
+    """If tmux kill-session FAILS (session vanished between listing and killing,
+    or any error), killed_any must stay 0 — nothing was reclaimed — so the stuck
+    marker is still recorded rather than silently skipped on a phantom reap."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    _mb(cctmp / "bigdata" / "blob", 6)  # persists ORANGE
+    killlog = home / "killed.log"
+    env = {
+        "STUB_SESSIONS": "cc-66:0",
+        "STUB_ACTIVITY": "100",
+        "STUB_KILLLOG": str(killlog),
+        "STUB_KILL_RC": "1",  # kill-session fails
+    }
+    proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert killlog.exists(), "kill was attempted"
+    stuck = home / ".genesis" / "alerts" / "tmp_orange_stuck"
+    assert stuck.exists(), "a FAILED kill must not suppress the stuck marker"
 
 
 def test_attached_session_never_killed(tmp_path):

--- a/tests/test_util/test_tmp.py
+++ b/tests/test_util/test_tmp.py
@@ -6,6 +6,7 @@ passing dir=big_tmp_dir(). These verify the helper resolves + creates the right 
 and that tempfile actually honors it.
 """
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -111,3 +112,48 @@ def test_pytest_unconfigure_removes_per_pid_basetemp(tmp_path):
     assert not leaf.exists(), "per-pid basetemp not cleaned at unconfigure"
     # No-op safe when nothing was recorded (e.g. the redirect never fired).
     mod.pytest_unconfigure(SimpleNamespace())
+
+
+def test_reap_stale_pytest_basetemps(tmp_path):
+    """The startup sweep reaps per-PID leaves from abnormal exits (dead PID),
+    spares live runs (this process), and ignores non-PID / pid<=1 names — so a
+    SIGKILL/crash can't leak the basetemp (pytest_unconfigure never runs then)."""
+    import importlib.util
+    import subprocess
+
+    conftest_path = Path(__file__).resolve().parents[1] / "conftest.py"
+    spec = importlib.util.spec_from_file_location("_genesis_conftest_probe2", conftest_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    base = tmp_path / "pytest"
+    base.mkdir()
+    # A genuinely-dead PID: spawn + reap a trivial process, then reuse its PID.
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    dead = base / str(proc.pid)
+    dead.mkdir()
+    (dead / "scratch").write_text("x")
+    live = base / str(os.getpid())
+    live.mkdir()
+    non_pid = base / "not-a-pid"
+    non_pid.mkdir()
+    init = base / "1"
+    init.mkdir()
+    # Unexpected on-disk state the reaper must survive without raising (it would
+    # otherwise break collection for the WHOLE suite):
+    superscript = base / "²"  # '²'.isdigit() True but int('²') → ValueError
+    superscript.mkdir()
+    huge = base / ("9" * 40)  # os.kill(10**40, 0) → OverflowError (not an OSError)
+    huge.mkdir()
+
+    mod._reap_stale_pytest_basetemps(str(base))  # must NOT raise
+
+    assert not dead.exists(), "dead-PID leaf must be reaped"
+    assert live.exists(), "live-PID (this process) must be spared"
+    assert non_pid.exists(), "non-PID name must be ignored"
+    assert init.exists(), "pid<=1 must be skipped (never signal 0/1)"
+    assert superscript.exists(), "unicode-digit name must be skipped, not crash"
+    assert huge.exists(), "out-of-range PID name must be spared, not crash"
+    # No crash on a missing base dir.
+    mod._reap_stale_pytest_basetemps(str(tmp_path / "does-not-exist"))

--- a/tests/test_util/test_tmp.py
+++ b/tests/test_util/test_tmp.py
@@ -9,7 +9,7 @@ and that tempfile actually honors it.
 import tempfile
 from pathlib import Path
 
-from genesis.util.tmp import big_tmp_dir, pytest_basetemp_override
+from genesis.util.tmp import big_tmp_dir, should_redirect_pytest_basetemp
 
 
 def test_default_is_home_tmp_and_is_created(tmp_path, monkeypatch):
@@ -37,52 +37,77 @@ def test_tempfile_lands_under_big_tmp_dir(tmp_path, monkeypatch):
         assert Path(f.name).parent == Path(d)
 
 
-# ── pytest_basetemp_override — the decision that keeps pytest tmp off cc-tmp ──
+# ── should_redirect_pytest_basetemp — the (pure, side-effect-free) decision ──
 
 _HOME = "/home/genesisuser"
-_BIG = "/home/genesisuser/tmp"
 _CCTMP = "/home/genesisuser/.genesis/cc-tmp"
 
 
-def test_override_redirects_when_tmpdir_is_cc_tmp():
-    """The core case: TMPDIR == cc-tmp and no --basetemp → redirect under big_tmp."""
-    got = pytest_basetemp_override(None, _CCTMP, _HOME, _BIG)
-    assert got == "/home/genesisuser/tmp/pytest"
+def test_redirect_when_tmpdir_is_cc_tmp():
+    """The core case: TMPDIR == cc-tmp and no --basetemp → redirect."""
+    assert should_redirect_pytest_basetemp(None, _CCTMP, _HOME) is True
 
 
-def test_override_redirects_when_tmpdir_under_cc_tmp():
+def test_redirect_when_tmpdir_under_cc_tmp():
     """A subdir of cc-tmp also redirects (prefix match, not just exact)."""
-    got = pytest_basetemp_override(None, _CCTMP + "/sub", _HOME, _BIG)
-    assert got == "/home/genesisuser/tmp/pytest"
+    assert should_redirect_pytest_basetemp(None, _CCTMP + "/sub", _HOME) is True
 
 
-def test_override_noop_when_explicit_basetemp_passed():
+def test_noredirect_when_explicit_basetemp_passed():
     """An explicit --basetemp always wins — never override the caller."""
-    assert pytest_basetemp_override("/some/where", _CCTMP, _HOME, _BIG) is None
+    assert should_redirect_pytest_basetemp("/some/where", _CCTMP, _HOME) is False
 
 
-def test_override_noop_on_ci_tmpdir_unset():
+def test_noredirect_on_ci_tmpdir_unset():
     """CI leaves TMPDIR unset → no-op (CI keeps its own default tmp)."""
-    assert pytest_basetemp_override(None, None, _HOME, _BIG) is None
-    assert pytest_basetemp_override(None, "", _HOME, _BIG) is None
+    assert should_redirect_pytest_basetemp(None, None, _HOME) is False
+    assert should_redirect_pytest_basetemp(None, "", _HOME) is False
 
 
-def test_override_noop_when_tmpdir_elsewhere():
+def test_noredirect_when_tmpdir_elsewhere():
     """A TMPDIR that isn't cc-tmp (e.g. /tmp) is left alone."""
-    assert pytest_basetemp_override(None, "/tmp", _HOME, _BIG) is None
+    assert should_redirect_pytest_basetemp(None, "/tmp", _HOME) is False
 
 
-def test_override_prefix_is_boundary_safe():
+def test_redirect_prefix_is_boundary_safe():
     """A sibling dir sharing the cc-tmp name PREFIX must NOT match (path-boundary)."""
-    assert pytest_basetemp_override(None, _CCTMP + "-evil", _HOME, _BIG) is None
+    assert should_redirect_pytest_basetemp(None, _CCTMP + "-evil", _HOME) is False
 
 
-def test_override_resolves_symlinked_tmpdir_into_cc_tmp(tmp_path):
+def test_redirect_resolves_symlinked_tmpdir_into_cc_tmp(tmp_path):
     """A TMPDIR symlink that resolves INTO cc-tmp still redirects (realpath)."""
     home = tmp_path
     cc = home / ".genesis" / "cc-tmp"
     cc.mkdir(parents=True)
     link = tmp_path / "tmpdir-link"
     link.symlink_to(cc)
-    got = pytest_basetemp_override(None, str(link), str(home), str(home / "tmp"))
-    assert got == str(home / "tmp" / "pytest")
+    assert should_redirect_pytest_basetemp(None, str(link), str(home)) is True
+
+
+def test_predicate_is_pure_no_filesystem_side_effect(tmp_path, monkeypatch):
+    """The predicate must NOT create ~/tmp (or anything) — that side-effect on the
+    no-op path was the regression this refactor fixes."""
+    monkeypatch.setenv("GENESIS_BIG_TMP", str(tmp_path / "should-not-exist"))
+    should_redirect_pytest_basetemp(None, None, str(tmp_path))  # CI no-op path
+    assert not (tmp_path / "should-not-exist").exists()
+
+
+def test_pytest_unconfigure_removes_per_pid_basetemp(tmp_path):
+    """The conftest's pytest_unconfigure deletes the per-pid basetemp it recorded,
+    so ~/tmp/pytest/<pid> dirs can't accumulate (the retention-leak fix). Tests the
+    real conftest functions loaded fresh."""
+    import importlib.util
+    from types import SimpleNamespace
+
+    conftest_path = Path(__file__).resolve().parents[1] / "conftest.py"
+    spec = importlib.util.spec_from_file_location("_genesis_conftest_probe", conftest_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    leaf = tmp_path / "pytest" / "12345"
+    leaf.mkdir(parents=True)
+    (leaf / "scratch.txt").write_text("x")
+    mod.pytest_unconfigure(SimpleNamespace(_genesis_basetemp_cleanup=str(leaf)))
+    assert not leaf.exists(), "per-pid basetemp not cleaned at unconfigure"
+    # No-op safe when nothing was recorded (e.g. the redirect never fired).
+    mod.pytest_unconfigure(SimpleNamespace())

--- a/tests/test_util/test_tmp.py
+++ b/tests/test_util/test_tmp.py
@@ -9,7 +9,7 @@ and that tempfile actually honors it.
 import tempfile
 from pathlib import Path
 
-from genesis.util.tmp import big_tmp_dir
+from genesis.util.tmp import big_tmp_dir, pytest_basetemp_override
 
 
 def test_default_is_home_tmp_and_is_created(tmp_path, monkeypatch):
@@ -35,3 +35,54 @@ def test_tempfile_lands_under_big_tmp_dir(tmp_path, monkeypatch):
     d = big_tmp_dir()
     with tempfile.NamedTemporaryFile(dir=d, suffix=".x") as f:
         assert Path(f.name).parent == Path(d)
+
+
+# ── pytest_basetemp_override — the decision that keeps pytest tmp off cc-tmp ──
+
+_HOME = "/home/genesisuser"
+_BIG = "/home/genesisuser/tmp"
+_CCTMP = "/home/genesisuser/.genesis/cc-tmp"
+
+
+def test_override_redirects_when_tmpdir_is_cc_tmp():
+    """The core case: TMPDIR == cc-tmp and no --basetemp → redirect under big_tmp."""
+    got = pytest_basetemp_override(None, _CCTMP, _HOME, _BIG)
+    assert got == "/home/genesisuser/tmp/pytest"
+
+
+def test_override_redirects_when_tmpdir_under_cc_tmp():
+    """A subdir of cc-tmp also redirects (prefix match, not just exact)."""
+    got = pytest_basetemp_override(None, _CCTMP + "/sub", _HOME, _BIG)
+    assert got == "/home/genesisuser/tmp/pytest"
+
+
+def test_override_noop_when_explicit_basetemp_passed():
+    """An explicit --basetemp always wins — never override the caller."""
+    assert pytest_basetemp_override("/some/where", _CCTMP, _HOME, _BIG) is None
+
+
+def test_override_noop_on_ci_tmpdir_unset():
+    """CI leaves TMPDIR unset → no-op (CI keeps its own default tmp)."""
+    assert pytest_basetemp_override(None, None, _HOME, _BIG) is None
+    assert pytest_basetemp_override(None, "", _HOME, _BIG) is None
+
+
+def test_override_noop_when_tmpdir_elsewhere():
+    """A TMPDIR that isn't cc-tmp (e.g. /tmp) is left alone."""
+    assert pytest_basetemp_override(None, "/tmp", _HOME, _BIG) is None
+
+
+def test_override_prefix_is_boundary_safe():
+    """A sibling dir sharing the cc-tmp name PREFIX must NOT match (path-boundary)."""
+    assert pytest_basetemp_override(None, _CCTMP + "-evil", _HOME, _BIG) is None
+
+
+def test_override_resolves_symlinked_tmpdir_into_cc_tmp(tmp_path):
+    """A TMPDIR symlink that resolves INTO cc-tmp still redirects (realpath)."""
+    home = tmp_path
+    cc = home / ".genesis" / "cc-tmp"
+    cc.mkdir(parents=True)
+    link = tmp_path / "tmpdir-link"
+    link.symlink_to(cc)
+    got = pytest_basetemp_override(None, str(link), str(home), str(home / "tmp"))
+    assert got == str(home / "tmp" / "pytest")


### PR DESCRIPTION
## Summary

Five coordinated fixes from an investigation into a Claude Code session that died silently on a live install, plus the temp-watchdog runaway that investigation surfaced.

**Honest framing:** none of these "fixes the death." The root cause was a `claude` process self-exit whose cause is unknowable post-hoc (the pane's dying output died with the pane); host `dmesg` ruled out an OOM and the log ruled out the watchdog. These fix the *real* defects the investigation found — and make the next such death diagnosable.

### What's in it

- **pytest no longer fills cc-tmp.** pytest's scratch tree defaults under `$TMPDIR`, which on a Claude Code session is the budget-policed `~/.genesis/cc-tmp`; a broad suite dumped hundreds of MB there and drove the temp-watchdog into a sustained high-pressure state. A pure `pytest_basetemp_override()` + a `pytest_configure` hook redirect every repo-rooted run to `~/tmp` (per-process leaf so concurrent runs stay isolated), no-op on CI, never rewriting the process `TMPDIR`. The eval gauntlet's foreign suite gets an explicit `--basetemp`.
- **The temp-watchdog no longer loops on non-reclaimable pressure.** `clean_cc_orange` re-measures after its cache cleanup and only reaps an idle session if still over budget; when nothing is reclaimable and nothing is safely reapable it raises a single alert instead of re-evaluating every poll.
- **cgroup OOM kills are captured.** The watchdog samples the container cgroup's `oom_kill` counter and, on a new kill, records memory + top processes to `oom_events.log` and pages once. No-op on non-cgroup2 layouts.
- **Claude Code session exits are recorded.** cc-slot drops the inner `exec` so a session's exit status (signal-decoded) + a terminal tail land in `cc_exit_<slot>.log` before the pane vanishes. Exit code, session lifecycle, and `-A` reattach are unchanged; capture is best-effort.

### Testing

- 28 targeted tests: pure-helper table (boundary/symlink/CI-no-op), watchdog loop-break + OOM sampler via source-and-call with a stub tmux, and a full scratch-tmux E2E that captures a fake crash (status + decode + dying words + session ends).
- Loop-break verify-RED confirmed (defeating it makes the regression test fail).
- Dogfooded live: this branch's redirect kept the author's cc-tmp flat through every test run.

### Review

Adversarial review (independent `genesis-architect`, 2 rounds): round 1 found 1 SHOULD-FIX (concurrent-run basetemp isolation) + 3 NOTEs (OOM-log retention, an ORANGE double-page edge, a comment precision) — all applied; round 2 (a design-tier decision: OOM pages at emergency, stuck-ORANGE stays dashboard/log-only per the watchdog's D2 invariant) came back clean.

**Codex: unavailable** this run — the local Codex CLI errored on model refresh and could not produce a review; the independent Claude reviewer stood in per the documented fallback. Re-run `@codex review` here if desired.

### Deploy

`systemctl --user restart genesis-tmp-watchgod` (scripts) + `pip install -e .` (util change); cc-slot and the pytest hook apply on the next CC session / pytest run. CI unaffected by the redirect (TMPDIR unset there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
