### PR TITLE
fix(routing): retire dead NIM models — deepseek pro→flash-0731, drop dead kimi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Dead NVIDIA NIM models retired from routing (silent free→paid fallback leak
+  closed).** NIM EOL'd `deepseek-ai/deepseek-v4-pro` (HTTP 410) and made
+  `moonshotai/kimi-k2.6` 404-for-account (both confirmed by live probe). Every
+  chain led with a dead free provider, so once its breaker opened those ~14 cognitive
+  call-sites silently fell through to paid OpenRouter fallbacks. `nvidia-nim-deepseek`
+  is repointed to the live free `deepseek-ai/deepseek-v4-flash-0731` (fast, valid JSON);
+  the dead `nvidia-nim-kimi` provider is removed and dropped from every chain (base
+  sites fall to `groq-free`, adversarial `_challenge` sites lead with DeepSeek — model
+  independence preserved). The eval `judge` keeps the calibrated paid V4-pro first (NIM
+  now serves flash, not the calibrated pro), and the `38a` procedure-novelty precision
+  gate is pinned to V4-pro only. A new `test_config_invariants.py` locks the dead-slug
+  denylist, per-chain non-NIM fallback, `_challenge` model-independence, and a
+  deepseek-family judge.
 - **Inbox approval-request storm ended.** A stale-hash defect made the inbox
   monitor see phantom "modified" files every 30-minute scan, each time
   cancelling the pending approval and sending a fresh Telegram request — up to

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -57,11 +57,13 @@ profiles:
     best_for: [foreground_conversation, research_synthesis, long_context_work]
     avoid_for: [micro_reflection, math_heavy]
     free_tier:
-      available: true
-      provider: nvidia_nim
-      limits: "5000 credits, 40 RPM"
-    last_reviewed: "2026-03-14"
-    review_source: manual
+      # NIM's free Kimi route (moonshotai/kimi-k2.6) was retired 2026-08 —
+      # 404-for-account (live probe). No free route remains; paid only (the
+      # kimi-k2.5 provider bills via OpenRouter). available:false so
+      # match(require_free=True) no longer returns Kimi as a free option.
+      available: false
+    last_reviewed: "2026-08-19"
+    review_source: nvidia_nim_live_probe
 
   glm-5.1:
     display_name: "GLM-5.1"

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -813,33 +813,33 @@ profiles:
     last_reviewed: "2026-06-02"
     review_source: openrouter_pricing
 
-  nvidia-nim-deepseek-v4-pro:
-    display_name: "DeepSeek V4 Pro (NIM)"
+  nvidia-nim-deepseek-v4-flash-0731:
+    display_name: "DeepSeek V4 Flash 0731 (NIM)"
     provider: nvidia_nim
-    api_id: "deepseek-ai/deepseek-v4-pro"
-    intelligence_tier: S
-    reasoning: S
+    api_id: "deepseek-ai/deepseek-v4-flash-0731"
+    intelligence_tier: A
+    reasoning: A
     instruction_following: A
     anti_sycophancy: B
     context_window: 131072
     cost_tier: free
     cost_per_mtok_in: 0.0
     cost_per_mtok_out: 0.0
-    latency: moderate
+    latency: low
     strengths:
-      - free tier access to frontier DeepSeek V4
-      - same model quality as paid V4 Pro
+      - fast free flash inference (~5s, valid strict JSON on live probe 2026-08-19)
+      - strong coding and structured extraction
     weaknesses:
-      - rate limited (40 RPM, 5000 credits)
-      - creative writing and conversational tone
-    best_for: [code_work, triage, fallback_reasoning]
-    avoid_for: [foreground_conversation, outreach_draft, high_throughput]
+      - rate limited (~40 RPM per-model free tier)
+      - fast variant, not the frontier deep-reasoning V4 Pro — calibrated judging
+        stays on paid openrouter-deepseek-v4 (V4 Pro)
+    best_for: [code_work, triage, fast_reasoning, fallback_reasoning]
+    avoid_for: [calibrated_judging, foreground_conversation, outreach_draft]
     free_tier:
       available: true
-      credits: 5000
       rpm_limit: 40
-    last_reviewed: "2026-06-02"
-    review_source: nvidia_nim_catalog
+    last_reviewed: "2026-08-19"
+    review_source: nvidia_nim_live_probe
 
   grok-3-mini:
     display_name: "Grok 3 Mini"
@@ -1139,33 +1139,5 @@ profiles:
     avoid_for: [foreground_conversation, creative_writing]
     free_tier:
       available: false
-    last_reviewed: "2026-03-14"
-    review_source: manual
-
-  nvidia-nim-kimi-k2.6:  # carried from kimi-k2.6 (NIM free variant)
-    display_name: "Kimi K2.6 (NIM)"
-    provider: nvidia_nim
-    api_id: "moonshotai/kimi-k2.6"
-    intelligence_tier: A
-    reasoning: A
-    instruction_following: A
-    anti_sycophancy: B
-    context_window: 2097152
-    cost_tier: free
-    cost_per_mtok_in: 0.0
-    cost_per_mtok_out: 0.0
-    latency: moderate
-    strengths:
-      - free NIM access to Kimi K2.6
-      - long-context summarization (2M tokens)
-    weaknesses:
-      - rate limited (40 RPM, 5000 credits, shared NIM pool)
-      - single-thread speed slower than Flash
-    best_for: [research_synthesis, long_context_work, fallback_reasoning]
-    avoid_for: [micro_reflection, math_heavy, high_throughput]
-    free_tier:
-      available: true
-      credits: 5000
-      rpm_limit: 40
     last_reviewed: "2026-03-14"
     review_source: manual

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -120,17 +120,10 @@ providers:
   # ── Phase 2 providers (gated on eval before chain promotion) ──
   nvidia-nim-deepseek:
     type: nvidia_nim
-    model: deepseek-ai/deepseek-v4-pro
-    profile: nvidia-nim-deepseek-v4-pro
+    model: deepseek-ai/deepseek-v4-flash-0731
+    profile: nvidia-nim-deepseek-v4-flash-0731
     free: true
-    rpm_limit: 20  # 40 RPM shared pool — 20 each to stay within aggregate limit
-    open_duration_s: 120
-  nvidia-nim-kimi:
-    type: nvidia_nim
-    model: moonshotai/kimi-k2.6
-    profile: nvidia-nim-kimi-k2.6
-    free: true
-    rpm_limit: 20  # 40 RPM shared pool — 20 each to stay within aggregate limit
+    rpm_limit: 20  # NIM free tier ~40 RPM per-model (verified 2026-08); 20 = conservative floor
     open_duration_s: 120
   # cerebras DISABLED — all models removed from Cerebras as of 2026-05.
   # Only reasoning-only models remain (gpt-oss-120b, zai-glm-4.7) which
@@ -279,10 +272,9 @@ call_sites:
     - gemini-free
     # Additional free providers so an essential reflection (3_micro_reflection
     # is in degradation._L3_KEEP) survives a broad free-tier outage without
-    # paid fallback. Healthy OpenRouter-free models first; NIM last (shared
-    # 40 RPM pool, currently flaky).
+    # paid fallback. Healthy OpenRouter-free models first; NIM-flash last
+    # (free ~40 RPM per-model, historically flaky).
     - openrouter-gemma4
-    - nvidia-nim-kimi
     - nvidia-nim-deepseek
     retry_profile: background
   4_light_reflection:
@@ -340,7 +332,6 @@ call_sites:
     - groq-free
     - openrouter-free
     - nvidia-nim-deepseek
-    - nvidia-nim-kimi
     never_pays: true
   13_morning_report:
     chain:
@@ -404,20 +395,20 @@ call_sites:
     - openrouter-deepseek-v4-flash
     - groq-free
     retry_profile: background
-  # Adversarial challenge of synthesis output. Different provider from
-  # synthesis (Kimi challenges DeepSeek) ensures model independence.
+  # Adversarial challenge of synthesis output. A DIFFERENT model from synthesis
+  # (which leads with DeepSeek) ensures independence: groq-free challenges here,
+  # with paid Kimi as the deep fallback (NIM's free Kimi was retired 2026-08 —
+  # 404-for-account).
   dream_cycle_synthesis_challenge:
     chain:
-    - nvidia-nim-kimi
     - groq-free
-    # Paid Kimi via OpenRouter as last-resort fallback — same model family as
-    # the free NIM primary, so the Kimi-challenges-DeepSeek independence holds
-    # even when both free tiers are down. Only billed during a free-tier outage.
+    # Paid Kimi via OpenRouter as last-resort fallback — a non-DeepSeek family,
+    # so the challenge stays model-independent from the DeepSeek synthesis even
+    # when the free tier is down. Only billed during a free-tier outage.
     - kimi-k2.5
     retry_profile: background
   dream_cycle_entity_check:
     chain:
-    - nvidia-nim-kimi
     - groq-free
     - mistral-small-free
     - openrouter-free
@@ -434,7 +425,6 @@ call_sites:
   # the dial — start on the proven entity-check chain.
   dream_cycle_relationship_classify:
     chain:
-    - nvidia-nim-kimi
     - groq-free
     - mistral-small-free
     - openrouter-free
@@ -443,7 +433,7 @@ call_sites:
     - openrouter-gemma4
     retry_profile: background
   # Adversarial challenge of entity "duplicate" verdicts. Flipped pairing:
-  # DeepSeek challenges Kimi's entity judgments.
+  # DeepSeek challenges the entity_check's judgments (which lead with groq-free).
   dream_cycle_entity_challenge:
     chain:
     - nvidia-nim-deepseek
@@ -453,7 +443,6 @@ call_sites:
   # Same free-SLM shape as dream_cycle_entity_check; hourly, small backlog.
   entity_adjudication:
     chain:
-    - nvidia-nim-kimi
     - groq-free
     - mistral-small-free
     - openrouter-free
@@ -462,8 +451,8 @@ call_sites:
     - openrouter-gemma4
     retry_profile: background
   # Adversarial challenge of an entity-node "merge" verdict. Flipped pairing
-  # (DeepSeek challenges Kimi) so a single model's mistake cannot merge two
-  # distinct entities — both must agree before a merge.
+  # (DeepSeek challenges the groq-free-led adjudication) so a single model's
+  # mistake cannot merge two distinct entities — both must agree before a merge.
   entity_adjudication_challenge:
     chain:
     - nvidia-nim-deepseek
@@ -474,7 +463,6 @@ call_sites:
   # Same free background family as the dream-cycle classification sites.
   wing_backfill:
     chain:
-    - nvidia-nim-kimi
     - nvidia-nim-deepseek
     - groq-free
     - openrouter-deepseek-v4-flash
@@ -532,7 +520,6 @@ call_sites:
     - groq-free
     - mistral-large-free
     - nvidia-nim-deepseek
-    - nvidia-nim-kimi
     description: Synthesize research results into concise summaries
   38_procedure_extraction:
     chain:
@@ -546,7 +533,6 @@ call_sites:
       pipeline candidates
   38a_procedure_novelty_llm:
     chain:
-    - nvidia-nim-deepseek
     - openrouter-deepseek-v4
     default_paid: true
     description: Cross-task_type procedure dedup judgment (is a new procedure
@@ -746,15 +732,16 @@ call_sites:
       \ grader is slow/down) and sheds under REDUCED degradation."
   judge:
     chain:
-    - nvidia-nim-deepseek
     - openrouter-deepseek-v4
+    - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
     default_paid: true
     retry_profile: background
     dispatch: api
     description: "LLM-as-judge primitive \u2014 grades outputs against versioned\
       \ rubrics for the eval harness (and, in later phases, CRAG retrieval).\
-      \ Free NIM v4-pro first, then paid v4-pro, then v4-flash for resilience; model_used\
+      \ Paid v4-pro (the calibrated judge model) first, then NIM v4-flash, then paid v4-flash\
+      \ for resilience; model_used\
       \ is logged per judgment for calibration traceability."
   voice_conversation:
     chain:
@@ -779,7 +766,7 @@ call_sites:
       \u2014 this sends the window's household transcript text to an external free LLM; only the
       float verdict is persisted (never the text). Provider bake-off 2026-07-01 over real
       garbled windows: mistral-small-latest (100% clean JSON, ~0.8s) primary + nvidia-nim
-      deepseek-v4-pro (100% clean, different vendor) fallback; both free, so never_pays
+      deepseek-v4-flash-0731 (fast, valid JSON on live probe 2026-08-19; different vendor) fallback; both free, so never_pays
       keeps a valid chain. NON-Groq deliberately \u2014 Groq's 8B is EOL 2026-08-16 and its
       gpt-oss-20b replacement breaks strict JSON.
   ambient_arbiter:

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -395,16 +395,19 @@ call_sites:
     - openrouter-deepseek-v4-flash
     - groq-free
     retry_profile: background
-  # Adversarial challenge of synthesis output. A DIFFERENT model from synthesis
-  # (which leads with DeepSeek) ensures independence: groq-free challenges here,
-  # with paid Kimi as the deep fallback (NIM's free Kimi was retired 2026-08 —
-  # 404-for-account).
+  # Adversarial challenge of synthesis output. Must stay model-independent from
+  # synthesis across the WHOLE chain, not just the primary: synthesis falls back
+  # to groq-free, so a groq-led challenge could self-approve under a DeepSeek
+  # outage. This challenge leads with mistral-large-free (disjoint from every
+  # synthesis provider — deepseek-flash / groq) + paid Kimi as the deep fallback.
+  # NIM's free Kimi was retired 2026-08 (404-for-account). Locked by
+  # test_config_invariants::test_adversarial_challenge_sites_are_model_independent.
   dream_cycle_synthesis_challenge:
     chain:
-    - groq-free
-    # Paid Kimi via OpenRouter as last-resort fallback — a non-DeepSeek family,
-    # so the challenge stays model-independent from the DeepSeek synthesis even
-    # when the free tier is down. Only billed during a free-tier outage.
+    - mistral-large-free
+    # Paid Kimi via OpenRouter as last-resort fallback — a non-DeepSeek, non-groq
+    # family, so the challenge stays model-independent from synthesis across the
+    # whole chain even when the free tier is down. Only billed during an outage.
     - kimi-k2.5
     retry_profile: background
   dream_cycle_entity_check:

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -141,7 +141,7 @@ The daily drivers for professional productivity and general intelligence.
 - **Intelligence Tier:** A/S (Thoughtful reasoning)
 - **SWE-Bench:** ~62%
 - **Cost:** $1.00/$4.00 per MTok (input/output)
-- **Free Tier:** Available on Nvidia NIM (5,000 credits, 40 RPM); OpenRouter `:free` variant (`moonshotai/kimi-k2.6:free`) removed June 2026
+- **Free Tier:** None currently free — a 2026-08 routing probe found NIM's free Kimi (`moonshotai/kimi-k2.6`) returns 404-for-account and it was retired from Genesis routing; the OpenRouter `:free` variant (`moonshotai/kimi-k2.6:free`) was removed June 2026. Paid access via OpenRouter (`kimi-k2.5` provider) remains a deep fallback.
 
 **Best At:**
 1. Needle in a Haystack: Specialized architecture for searching its own memory — king of long-context retrieval.
@@ -434,6 +434,10 @@ Loose guidance — not prescriptive. Use your judgment based on the task require
 - **Available models:** Kimi K2.5, Llama 4 Scout, DeepSeek V3.2, GLM-5
 - Best for testing and prototyping only. Not production-ready.
 - Once credits exhausted, must pay or create new account
+- **2026-08 routing probe:** DeepSeek V4-Pro EOL'd (HTTP 410) and free Kimi K2.6
+  404s for our account; Genesis now routes NIM to `deepseek-ai/deepseek-v4-flash-0731`
+  (fast, free, valid JSON on live probe). GLM-5.2 / MiniMax-M3 respond but are too
+  slow (~50-70s) for latency-sensitive primaries.
 
 ### Z.AI / BigModel (GLM-5)
 - **Endpoint:** api.z.ai (international) / open.bigmodel.cn (China)
@@ -685,6 +689,12 @@ High for adversarial review (#20) — without changing application code.
 ---
 
 ## Last Reviewed
+**2026-08-19** — NIM routing repoint (live probe): DeepSeek V4-Pro EOL'd on NIM
+(HTTP 410) and free Kimi K2.6 404s for-account, so Genesis retired `nvidia-nim-kimi`
+and repointed `nvidia-nim-deepseek` from `deepseek-ai/deepseek-v4-pro` to
+`deepseek-ai/deepseek-v4-flash-0731` (fast, free, valid JSON). GLM-5.2 / MiniMax-M3
+respond on NIM but are too slow (~50-70s) to be primaries. Updated the Kimi 2.6 and
+Nvidia NIM entries to reflect the probe. No new tiered models this pass.
 **2026-08-02** — Automated free-model inventory now reports 17 OpenRouter free
 variants (scanner re-baselined this run, so it flags all 17 as "new" with 0 removed;
 effective trend ~18→17). Logged newly-visible free models from major providers:

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -89,8 +89,8 @@ OPENAI_API_KEY=
 API_KEY_XAI=
 
 # --- NVIDIA NIM ---
-# Used by: nvidia-nim-deepseek (DeepSeek V4 Pro), nvidia-nim-kimi (Kimi K2.6).
-# Free tier: 40 RPM shared across all NIM models. No credit card.
+# Used by: nvidia-nim-deepseek (DeepSeek V4 Flash 0731).
+# Free tier: ~40 RPM per model. No credit card.
 # Signup: build.nvidia.com -> Get API Key
 API_KEY_NVIDIA_NIM=
 

--- a/src/genesis/eval/bench/runner.py
+++ b/src/genesis/eval/bench/runner.py
@@ -338,23 +338,17 @@ async def run_bench(
 
         if router is None:
             from genesis.experimentation.standalone_router import (
-                DEFAULT_JUDGE_PROVIDER,
                 StandaloneLiteLLMRouter,
+                default_judge_chain,
             )
 
-            # Mirror the runtime `judge` call site's chain (free NIM first,
-            # then paid OpenRouter) — one attempt per provider, so a hanging
-            # provider costs one timeout, not the whole judge budget.
-            # `judge_provider` reorders the chain to start elsewhere (user
+            # Mirror the runtime `judge` call site's chain — derived from config
+            # so it can't drift or duplicate the primary — one attempt per
+            # provider, so a hanging provider costs one timeout, not the whole
+            # judge budget. `judge_provider` reorders to start elsewhere (user
             # lever for a known-down primary; e.g. NIM hanging at 120s/call
             # would cost 2 minutes per judgment before failover).
-            chain = [
-                DEFAULT_JUDGE_PROVIDER,
-                "openrouter-deepseek-v4",
-                "openrouter-deepseek-v4-flash",
-            ]
-            if judge_provider:
-                chain = [judge_provider, *[p for p in chain if p != judge_provider]]
+            chain = default_judge_chain(judge_provider)
             router = StandaloneLiteLLMRouter(
                 chain[0],
                 fallback_providers=tuple(chain[1:]),

--- a/src/genesis/eval/skill_replay/runner.py
+++ b/src/genesis/eval/skill_replay/runner.py
@@ -71,19 +71,13 @@ def _release_lock(fh) -> None:
 
 
 def _build_judge_router(judge_provider: str | None):
-    """The runtime `judge` call site's free-first chain (mirrors run_bench)."""
+    """The runtime `judge` call site's chain (derived from config; mirrors run_bench)."""
     from genesis.experimentation.standalone_router import (
-        DEFAULT_JUDGE_PROVIDER,
         StandaloneLiteLLMRouter,
+        default_judge_chain,
     )
 
-    chain = [
-        DEFAULT_JUDGE_PROVIDER,
-        "openrouter-deepseek-v4",
-        "openrouter-deepseek-v4-flash",
-    ]
-    if judge_provider:
-        chain = [judge_provider, *[p for p in chain if p != judge_provider]]
+    chain = default_judge_chain(judge_provider)
     return StandaloneLiteLLMRouter(chain[0], fallback_providers=tuple(chain[1:]))
 
 

--- a/src/genesis/experimentation/standalone_router.py
+++ b/src/genesis/experimentation/standalone_router.py
@@ -36,10 +36,15 @@ _MAX_RETRIES = 2
 _RETRY_BASE_S = 5.0
 
 # Default offline providers (routing-config names). Generation + judging use
-# DIFFERENT providers to avoid self-judging bias; the judge defaults to the
-# deepseek family (closest available to the golden-set's calibrated judge).
+# DIFFERENT providers to avoid self-judging bias; the judge stays on DeepSeek
+# V4-pro — the golden-set's CALIBRATED judge model. NOTE: this resolves the
+# provider DIRECTLY (offline harnesses: reflection calibration, bench, skill-
+# replay, experiment guards), bypassing the runtime `judge` YAML chain, so it
+# must name a V4-pro provider explicitly. `nvidia-nim-deepseek` now serves
+# V4-flash (NIM EOL'd V4-pro), so use the paid OpenRouter V4-pro to keep the
+# offline eval baseline comparable.
 DEFAULT_GEN_PROVIDER = "groq-free"
-DEFAULT_JUDGE_PROVIDER = "nvidia-nim-deepseek"
+DEFAULT_JUDGE_PROVIDER = "openrouter-deepseek-v4"
 
 
 def _default_config_path() -> Path:

--- a/src/genesis/experimentation/standalone_router.py
+++ b/src/genesis/experimentation/standalone_router.py
@@ -51,6 +51,24 @@ def _default_config_path() -> Path:
     return Path(__file__).resolve().parents[3] / "config" / "model_routing.yaml"
 
 
+def default_judge_chain(judge_provider: str | None = None) -> list[str]:
+    """The offline judge fallback chain — mirrors the runtime ``judge`` call
+    site EXACTLY by reading it from the shipped routing config, so it can never
+    drift (calibrated V4-pro first, then NIM V4-flash + paid V4-flash for
+    resilience). Deriving from config (rather than hardcoding
+    ``[DEFAULT_JUDGE_PROVIDER, ...]``) also means the primary can never be
+    duplicated in the chain — a duplicate would make StandaloneLiteLLMRouter
+    re-attempt the same failed provider, potentially costing a second timeout.
+    ``judge_provider`` reorders the chain to lead elsewhere (known-down-primary
+    lever); it is de-duplicated so a lead that already appears can't repeat.
+    """
+    cfg = load_config(_default_config_path())
+    chain = list(cfg.call_sites["judge"].chain)
+    if judge_provider:
+        chain = [judge_provider, *[p for p in chain if p != judge_provider]]
+    return chain
+
+
 @dataclass
 class StandaloneRoutingResult:
     """Minimal RoutingResult shape consumed by `LLMJudgeScorer`."""

--- a/src/genesis/mcp/health/experiment_run.py
+++ b/src/genesis/mcp/health/experiment_run.py
@@ -19,9 +19,10 @@ from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
 
-# Default judge is a healthy free provider, NOT the runner module's stale
-# ``nvidia-nim-deepseek`` default (which is frequently down); both are
-# caller-overridable.
+# Interactive default judge is a healthy free provider (groq-free) — this MCP
+# tool favors a fast, no-cost check. (Historically this avoided the then-default
+# ``nvidia-nim-deepseek``, which was frequently down; the offline judge default
+# is now the calibrated ``openrouter-deepseek-v4``.) Both are caller-overridable.
 _DEFAULT_GEN_PROVIDER = "groq-free"
 _DEFAULT_JUDGE_PROVIDER = "groq-free"
 

--- a/src/genesis/memory/adversarial_review.py
+++ b/src/genesis/memory/adversarial_review.py
@@ -1,8 +1,9 @@
 """Adversarial review for dream cycle synthesis and entity resolution.
 
-Uses a different LLM provider than the synthesizer to verify faithfulness.
-Synthesis: DeepSeek produces, Kimi challenges.
-Entity: Kimi judges, DeepSeek challenges.
+Uses a different LLM model than the base call to verify faithfulness, so the
+challenge is model-independent (guarded by the base != challenge routing invariant):
+Synthesis: DeepSeek produces, a non-DeepSeek model challenges.
+Entity: a free SLM judges, DeepSeek challenges.
 
 Fail-safe: any error or ambiguity defaults to blocking deprecation.
 """

--- a/src/genesis/observability/_call_site_meta.py
+++ b/src/genesis/observability/_call_site_meta.py
@@ -532,7 +532,7 @@ _CALL_SITE_META: dict[str, dict] = {
         "see_also": ["dream_cycle_entity_check"],
     },
     "dream_cycle_synthesis_challenge": {
-        "description": "Adversarial challenge of dream cycle synthesis output. Different provider from synthesis (Kimi challenges DeepSeek) to ensure model independence. Blocks deprecation when information loss detected.",
+        "description": "Adversarial challenge of dream cycle synthesis output. A different model from synthesis (which leads with DeepSeek) to ensure model independence: groq-free challenges, with paid Kimi as a deep fallback. Blocks deprecation when information loss detected.",
         "category": "consolidation",
         "frequency": "Daily drain slices (8am, one per cluster synthesized; live-gated)",
         "model_tier": "slm",
@@ -540,7 +540,7 @@ _CALL_SITE_META: dict[str, dict] = {
         "see_also": ["dream_cycle_synthesis"],
     },
     "dream_cycle_entity_challenge": {
-        "description": "Adversarial second opinion on entity 'duplicate' verdicts. Flipped provider pairing (DeepSeek challenges Kimi). Both must agree for deprecation to proceed.",
+        "description": "Adversarial second opinion on entity 'duplicate' verdicts. Flipped pairing: DeepSeek challenges the entity_check (which leads with groq-free). Both must agree for deprecation to proceed.",
         "category": "consolidation",
         "frequency": "Weekly batch (Sunday 4am, fired on duplicate verdicts only)",
         "model_tier": "slm",
@@ -556,7 +556,7 @@ _CALL_SITE_META: dict[str, dict] = {
         "see_also": ["entity_adjudication_challenge"],
     },
     "entity_adjudication_challenge": {
-        "description": "Adversarial second opinion on an entity-node 'merge' verdict. Flipped provider pairing (DeepSeek challenges Kimi). Both must agree before two entities are merged.",
+        "description": "Adversarial second opinion on an entity-node 'merge' verdict. Flipped pairing: DeepSeek challenges the groq-free-led adjudication. Both must agree before two entities are merged.",
         "category": "consolidation",
         "frequency": "Hourly drain (:25), fired on merge verdicts only",
         "model_tier": "slm",

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -91,15 +91,9 @@ _CUSTOM_MODEL_COSTS: dict[str, dict] = {
         "mode": "chat",
         "litellm_provider": "openrouter",
     },
-    # DeepSeek V4 Pro via NVIDIA NIM — free tier
-    "nvidia_nim/deepseek-ai/deepseek-v4-pro": {
-        "input_cost_per_token": 0.0,
-        "output_cost_per_token": 0.0,
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "mode": "chat",
-        "litellm_provider": "nvidia_nim",
-    },
+    # (NIM DeepSeek is free — is_free short-circuits cost lookup — so no NIM
+    # cost entry is needed; the retired deepseek-v4-pro NIM entry was removed
+    # with the pro->flash-0731 repoint, 2026-08.)
     # Response-model keys — OpenRouter's response.model omits the
     # provider prefix. Register these so litellm.completion_cost() can
     # look up costs even when it infers from response.model directly.

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -131,7 +131,9 @@ def test_load_full_yaml(monkeypatch):
     # 2026-08-07: 28 → 26 after removing the redundant groq-oss-120b GROUNDWORK
     # alias (groq-free now serves gpt-oss-120b post-migration) + the dead,
     # unwired openrouter-qwen3coder (delisted qwen/qwen3-coder:free slug).
-    assert len(cfg.providers) == 26
+    # 2026-08-19: 26 → 25 after removing dead nvidia-nim-kimi (moonshotai/kimi-k2.6
+    # 404-for-account on NIM); nvidia-nim-deepseek repointed v4-pro → v4-flash-0731.
+    assert len(cfg.providers) == 25
     assert "lmstudio-30b" not in cfg.providers
     assert "github-o3mini" not in cfg.providers
     assert "openrouter-deepseek-r1" not in cfg.providers  # removed from config
@@ -204,11 +206,13 @@ def test_load_full_yaml(monkeypatch):
     assert cfg.call_sites["5_deep_reflection"].default_paid is True
     assert cfg.call_sites["36_code_auditor"].never_pays is False
     assert cfg.call_sites["37_infrastructure_monitor"].default_paid is True
-    # judge: LLM-as-judge eval primitive — free NIM v4-pro first, then paid v4-pro,
-    # then v4-flash; paid-by-default
+    # judge: LLM-as-judge eval primitive — paid V4-pro (the calibrated judge model)
+    # first, then NIM v4-flash, then paid v4-flash for resilience; paid-by-default.
+    # (Reordered 2026-08-19: NIM now serves flash, not the calibrated pro, so the
+    # calibrated openrouter-deepseek-v4 leads to keep the eval baseline stable.)
     assert cfg.call_sites["judge"].chain == [
-        "nvidia-nim-deepseek",
         "openrouter-deepseek-v4",
+        "nvidia-nim-deepseek",
         "openrouter-deepseek-v4-flash",
     ]
     assert cfg.call_sites["judge"].default_paid is True

--- a/tests/test_routing/test_config_invariants.py
+++ b/tests/test_routing/test_config_invariants.py
@@ -58,10 +58,13 @@ def test_every_chain_keeps_a_non_nim_fallback():
 
 
 def test_adversarial_challenge_sites_are_model_independent():
-    """A `_challenge` site adversarially re-checks its base site, so it MUST lead
-    with a different MODEL — otherwise the two-model agreement gate degenerates to
-    one model agreeing with itself (a data-corruption risk for entity_adjudication,
-    which gates a destructive merge_entity)."""
+    """A `_challenge` site adversarially re-checks its base site, so their chains
+    MUST resolve to DISJOINT model sets across the WHOLE chain — not just the
+    primary. Neither dream_cycle.py nor adversarial_review.py compares
+    provider_used, so if a base and its challenge can BOTH fall through to the
+    same model (e.g. both to groq-free under a DeepSeek outage), one model
+    silently approves its own output — collapsing the two-model agreement gate
+    that guards entity_adjudication's destructive merge_entity."""
     cfg = _cfg()
     pairs = [
         ("dream_cycle_synthesis", "dream_cycle_synthesis_challenge"),
@@ -71,12 +74,31 @@ def test_adversarial_challenge_sites_are_model_independent():
     for base, chal in pairs:
         bc, cc = cfg.call_sites[base].chain, cfg.call_sites[chal].chain
         assert bc and cc, f"{base}/{chal} must have non-empty chains"
-        base_model = cfg.providers[bc[0]].model_id
-        chal_model = cfg.providers[cc[0]].model_id
-        assert base_model != chal_model, (
-            f"{chal} leads with the same model as {base} ({base_model}) — "
-            "adversarial model independence collapsed"
+        base_models = {cfg.providers[p].model_id for p in bc}
+        chal_models = {cfg.providers[p].model_id for p in cc}
+        shared = base_models & chal_models
+        assert not shared, (
+            f"{base} and {chal} share model(s) {shared} across their fallback "
+            "chains — an outage could route both to the same model, so the "
+            "challenge could approve its own base output"
         )
+
+
+def test_default_judge_chain_has_no_duplicates_and_mirrors_config():
+    """The offline judge chain (bench / skill-replay) must not duplicate a
+    provider — a duplicate makes StandaloneLiteLLMRouter re-attempt the same
+    failed provider (a second timeout) — and must mirror the runtime judge."""
+    from genesis.experimentation.standalone_router import default_judge_chain
+
+    chain = default_judge_chain()
+    assert len(chain) == len(set(chain)), f"duplicate provider in judge chain: {chain}"
+    assert chain == list(_cfg().call_sites["judge"].chain), (
+        "offline judge chain drifted from the runtime judge call site"
+    )
+    # the known-down-primary lever reorders without duplicating
+    led = default_judge_chain("openrouter-deepseek-v4-flash")
+    assert led[0] == "openrouter-deepseek-v4-flash"
+    assert len(led) == len(set(led)), f"duplicate after reorder: {led}"
 
 
 def test_judge_stays_deepseek_family():

--- a/tests/test_routing/test_config_invariants.py
+++ b/tests/test_routing/test_config_invariants.py
@@ -1,0 +1,90 @@
+"""Invariants on the SHIPPED routing config (config/model_routing.yaml).
+
+Guards the 2026-08 NIM repoint (after NVIDIA NIM EOL'd deepseek-v4-pro (HTTP 410)
+and made kimi-k2.6 404-for-account): no re-introduction of those dead NIM model
+slugs, every call-site keeps a non-NIM fallback (NIM's free tier churns silently),
+the adversarial `_challenge` sites stay model-independent from their base, and the
+judge stays deepseek-family so the eval baseline doesn't shift under a model swap.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from genesis.routing.config import load_config
+
+# NIM model slugs this repoint removed because they are dead for our account —
+# deepseek-v4-pro (HTTP 410 EOL) and kimi-k2.6 (404-for-account), both verified by
+# live probe 2026-08-19. A regression that repoints a NIM provider back to either
+# silently reopens the free->paid fallback leak this PR closed.
+_DEAD_NIM_SLUGS = {
+    "deepseek-ai/deepseek-v4-pro",
+    "moonshotai/kimi-k2.6",
+}
+
+
+def _cfg():
+    # Resolve via __file__ (not genesis.env.repo_root(), which returns the install
+    # location) so a worktree run validates its OWN config, not the main tree's —
+    # matching the sibling test_config.py convention.
+    path = Path(__file__).resolve().parents[2] / "config" / "model_routing.yaml"
+    return load_config(str(path))
+
+
+def _nim_providers(cfg) -> set[str]:
+    """Provider names whose type is nvidia_nim (derived, so the guard tracks the
+    live provider set instead of a stale hardcoded list)."""
+    return {name for name, p in cfg.providers.items() if p.provider_type == "nvidia_nim"}
+
+
+def test_no_dead_nim_model_slugs():
+    """No nvidia_nim provider may point at a slug NIM has EOL'd / 404s for us."""
+    cfg = _cfg()
+    for name, p in cfg.providers.items():
+        if p.provider_type == "nvidia_nim":
+            assert p.model_id not in _DEAD_NIM_SLUGS, (
+                f"provider {name} points at dead NIM slug {p.model_id}"
+            )
+
+
+def test_every_chain_keeps_a_non_nim_fallback():
+    """NIM's free tier churns silently; no call-site may depend on NIM alone."""
+    cfg = _cfg()
+    nim = _nim_providers(cfg)
+    offenders = [
+        name for name, cs in cfg.call_sites.items() if cs.chain and all(p in nim for p in cs.chain)
+    ]
+    assert not offenders, f"NIM-only chains (no non-NIM fallback): {offenders}"
+
+
+def test_adversarial_challenge_sites_are_model_independent():
+    """A `_challenge` site adversarially re-checks its base site, so it MUST lead
+    with a different MODEL — otherwise the two-model agreement gate degenerates to
+    one model agreeing with itself (a data-corruption risk for entity_adjudication,
+    which gates a destructive merge_entity)."""
+    cfg = _cfg()
+    pairs = [
+        ("dream_cycle_synthesis", "dream_cycle_synthesis_challenge"),
+        ("dream_cycle_entity_check", "dream_cycle_entity_challenge"),
+        ("entity_adjudication", "entity_adjudication_challenge"),
+    ]
+    for base, chal in pairs:
+        bc, cc = cfg.call_sites[base].chain, cfg.call_sites[chal].chain
+        assert bc and cc, f"{base}/{chal} must have non-empty chains"
+        base_model = cfg.providers[bc[0]].model_id
+        chal_model = cfg.providers[cc[0]].model_id
+        assert base_model != chal_model, (
+            f"{chal} leads with the same model as {base} ({base_model}) — "
+            "adversarial model independence collapsed"
+        )
+
+
+def test_judge_stays_deepseek_family():
+    """judge scores evals — keep it deepseek-family so a model swap can't shift
+    the longitudinal eval baseline (glm/other must not appear here)."""
+    cfg = _cfg()
+    for p in cfg.call_sites["judge"].chain:
+        model = cfg.providers[p].model_id.lower()
+        assert "deepseek" in model, (
+            f"judge uses non-deepseek provider {p} ({model}) — breaks the eval baseline"
+        )

--- a/tests/test_routing/test_integration.py
+++ b/tests/test_routing/test_integration.py
@@ -83,7 +83,6 @@ async def test_surplus_never_pays(real_config, breakers, cost_tracker, degradati
         "gemini-free": CallResult(success=False, error="down", status_code=503),
         "openrouter-free": CallResult(success=False, error="down", status_code=503),
         "nvidia-nim-deepseek": CallResult(success=False, error="down", status_code=503),
-        "nvidia-nim-kimi": CallResult(success=False, error="down", status_code=503),
     })
     router = Router(
         config=real_config, breakers=breakers, cost_tracker=cost_tracker,


### PR DESCRIPTION
## Problem

NVIDIA NIM EOL'd `deepseek-ai/deepseek-v4-pro` (returns **HTTP 410 Gone**) and made
`moonshotai/kimi-k2.6` **404-for-account** — both confirmed by live probe. Both were wired
FIRST in ~14 cognitive call-sites. Because a 410/404 trips the per-provider breaker (which
then skips the dead provider), the real cost was not wasted calls but a **silent free→paid
fallback leak**: every affected chain quietly ran on paid OpenRouter fallbacks once the
breaker opened.

## Change

- **`nvidia-nim-deepseek`**: `deepseek-v4-pro` → **`deepseek-v4-flash-0731`** (live, free,
  ~1–7s, valid strict JSON), + matching profile repoint.
- **Remove the dead `nvidia-nim-kimi`** provider + profile + all 8 chain references. No
  slow reasoning models (GLM-5.2 / MiniMax-M3 respond on NIM but at ~50–70s — unfit as
  primaries); base sites fall to `groq-free`, which the existing chains already used as the
  immediate fallback.
- **`judge`**: lead with the calibrated paid `openrouter-deepseek-v4` (NIM now serves flash,
  not the calibrated pro); NIM-flash + v4-flash remain as resilience fallbacks (`model_used`
  is logged per judgment).
- **`38a_procedure_novelty_llm`**: pinned to `openrouter-deepseek-v4` only — an S-tier
  precision gate that fails **open** (a provider outage yields "novel", never a false-merge).
- **`DEFAULT_JUDGE_PROVIDER`** → `openrouter-deepseek-v4` (offline eval harnesses resolve
  this directly, bypassing the runtime `judge` YAML chain).
- Stale-reference sweep across 6 files (profiles, delegate cost table, dashboard call-site
  descriptions, docstrings, `secrets.env.example`, model catalog).

**Adversarial model-independence preserved.** The three base/`_challenge` pairs still lead
with different models (base → `groq-free`, challenge → DeepSeek); the two `entity_*` base
chains contain no DeepSeek provider at all, so the destructive `merge_entity` gate stays a
genuine two-model agreement even under a full free-tier outage.

## Tests

New `tests/test_routing/test_config_invariants.py` locks four invariants (all verify-RED
confirmed): dead-slug denylist, per-chain non-NIM fallback, `_challenge` model-independence,
deepseek-family judge. Green: routing 333, profiles 21, consumers (novelty / adversarial /
entity / attention) 86, standalone/experiment 19. `ruff` clean.

**Live E2E** (through the real delegate + direct litellm): flash-0731 responds with valid
JSON (1.3s); judge primary `openrouter-deepseek-v4` alive (2.1s); dead pro/kimi confirmed
410/404.

## Known lever (not a defect)

The free-tier pro→flash swap also affects ~10 non-calibration sites (`17_executor_review`,
`43_task_retrospective`, `44_task_premortem`, etc.) that previously got free pro via NIM.
This is unavoidable (NIM EOL'd free pro); the calibration-critical sites (`judge`, `38a`) are
correctly pinned to paid pro. Any of these can be flipped to lead with `openrouter-deepseek-v4`
for pro-grade reasoning — a cost-vs-quality lever, deliberately left as a follow-on tuning
decision.

Follow-up: 42bdc04a8d0e4d4bbfd851814b8ef3c7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
