### PR TITLE
fix(subprocess): repo-wide spawn-hardening sweep — shared guarded group-kill for launcher trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Subprocess timeouts no longer orphan helper process trees (repo-wide
+  sweep).** Several launchers Genesis runs (the code-review helper, the
+  headless/CLI/recovery-brain `claude` runners, promptfoo/pytest eval
+  scorers, deterministic step commands) fork their own children; on timeout
+  the old kills reached only the direct child, leaving the rest of the tree
+  running until reboot. All eight spawn sites — plus the original autonomy
+  reviewer, migrated off its private copy — now share one hardened guarded
+  group-kill (`genesis.util.proc_kill`): own process group via
+  `start_new_session` (never `preexec_fn` — post-fork deadlock risk in a
+  threaded server), `killpg` on the leader pid directly (immune to the
+  leader-already-reaped race), a `pgid<=1` safety guard, a bounded reap, and
+  a logged fallback when the group kill is refused. The contribution CLI
+  additionally group-kills on Ctrl+C so an interactive abort can't strand
+  its reviewer. The delivery `git push` — which runs under the autonomy
+  executor's single-slot semaphore — also gained a hard 300s bound, closing
+  the last unbounded subprocess wait on that critical path (a
+  network-stalled push could previously wedge all autonomy task execution).
+
 - **Inbox approval-request storm ended.** A stale-hash defect made the inbox
   monitor see phantom "modified" files every 30-minute scan, each time
   cancelling the pending approval and sending a fresh Telegram request — up to

--- a/src/genesis/autonomy/executor/deterministic.py
+++ b/src/genesis/autonomy/executor/deterministic.py
@@ -229,6 +229,12 @@ async def execute_deterministic_step(
                 timeout=_HARD_TIMEOUT_S,
             )
             await proc.wait()
+        except asyncio.CancelledError:
+            # Cancellation mid-step: the detached step tree sees no ambient
+            # signal — group-kill before propagating or it runs on.
+            kill_process_group(proc)
+            await reap_bounded(proc)
+            raise
         except TimeoutError:
             duration = time.monotonic() - start
             # Group-kill the hung tree (guarded pid-as-pgid), bounded reap.

--- a/src/genesis/autonomy/executor/deterministic.py
+++ b/src/genesis/autonomy/executor/deterministic.py
@@ -26,6 +26,7 @@ import time
 from pathlib import Path
 
 from genesis.autonomy.executor.types import StepResult, StepType
+from genesis.util.proc_kill import kill_process_group, reap_bounded
 
 logger = logging.getLogger(__name__)
 
@@ -211,6 +212,10 @@ async def execute_deterministic_step(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=str(cwd),
+            # Own session/group (setsid in the C helper) so the timeout kill
+            # can reap the WHOLE tree — step commands can fork (bash &, tox,
+            # pytest-xdist); killing only the direct child orphans those.
+            start_new_session=True,
         )
         # Read with stream limit to prevent memory exhaustion
         # Hard timeout prevents a hung subprocess from blocking the
@@ -226,12 +231,9 @@ async def execute_deterministic_step(
             await proc.wait()
         except TimeoutError:
             duration = time.monotonic() - start
-            # Kill the hung process
-            try:
-                proc.kill()
-                await proc.wait()
-            except ProcessLookupError:
-                pass
+            # Group-kill the hung tree (guarded pid-as-pgid), bounded reap.
+            kill_process_group(proc)
+            await reap_bounded(proc)
             logger.warning(
                 "Deterministic step %d timed out after %.0fs",
                 idx, duration,

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -85,6 +85,12 @@ async def _run_git_push(wt_path: Path, branch: str) -> tuple[int, str]:
         kill_process_group(proc)
         await reap_bounded(proc)
         return 128, f"git push timed out after {int(_GIT_PUSH_TIMEOUT_S)}s"
+    except asyncio.CancelledError:
+        # Cancellation mid-push: the detached git/ssh tree sees no ambient
+        # signal — group-kill before propagating or it runs on.
+        kill_process_group(proc)
+        await reap_bounded(proc)
+        raise
     return proc.returncode or 0, stderr.decode(errors="replace")
 
 

--- a/src/genesis/autonomy/executor/engine.py
+++ b/src/genesis/autonomy/executor/engine.py
@@ -37,6 +37,7 @@ from genesis.autonomy.executor.types import (
     validate_transition,
 )
 from genesis.feedback.bus import SignalType, record_outcome
+from genesis.util.proc_kill import kill_process_group, reap_bounded
 
 if TYPE_CHECKING:
     # Runtime import stays lazy inside _run_scope_gate (executor/__init__ ->
@@ -50,6 +51,41 @@ MAX_REVIEW_ITERATIONS = 2  # Amendment #4
 # Repo root: four parents up from executor/engine.py -> src/genesis/autonomy/executor
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _WORKTREE_BASE = _REPO_ROOT / ".claude" / "worktrees"
+
+# Hard bound for the delivery `git push`. _deliver runs under the executor's
+# Semaphore(1) (dispatcher._guarded_execute), so a network-stalled push with
+# no timeout wedges ALL autonomy — the same class the scope-gate's 60s bound
+# on local git ops (below) already guards. Push is a network op that can
+# legitimately take minutes on a large branch/slow link, hence 300s, and the
+# expiry degrades to the existing "Branch push failed" path (recoverable:
+# the branch can be pushed manually; the task itself is already complete).
+_GIT_PUSH_TIMEOUT_S = 300.0
+
+
+async def _run_git_push(wt_path: Path, branch: str) -> tuple[int, str]:
+    """Run the delivery ``git push`` with a hard timeout + group kill.
+
+    Returns ``(returncode, stderr_text)``; timeout returns ``(128, msg)``.
+    Spawned in its own session/group: when a push stalls it is usually git's
+    ssh/credential CHILD that is stuck — killing only git would orphan the
+    hung helper (the tree-leak class fixed repo-wide in this change).
+    """
+    proc = await asyncio.create_subprocess_exec(
+        "git", "push", "-u", "origin", branch,
+        cwd=str(wt_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        _, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_GIT_PUSH_TIMEOUT_S,
+        )
+    except TimeoutError:
+        kill_process_group(proc)
+        await reap_bounded(proc)
+        return 128, f"git push timed out after {int(_GIT_PUSH_TIMEOUT_S)}s"
+    return proc.returncode or 0, stderr.decode(errors="replace")
 
 
 class CCSessionExecutor:
@@ -1435,17 +1471,10 @@ class CCSessionExecutor:
             branch = f"task/{task_id[:8]}"
             pushed = False
             try:
-                proc = await asyncio.create_subprocess_exec(
-                    "git", "push", "-u", "origin", branch,
-                    cwd=str(wt_path),
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                _, stderr = await proc.communicate()
-                if proc.returncode != 0:
+                rc, push_err = await _run_git_push(wt_path, branch)
+                if rc != 0:
                     logger.warning(
-                        "Branch push failed for task %s: %s",
-                        task_id, stderr.decode(errors="replace"),
+                        "Branch push failed for task %s: %s", task_id, push_err,
                     )
                 else:
                     logger.info("Pushed branch %s for task %s", branch, task_id)

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -20,10 +20,11 @@ import math
 import os
 import re
 import shutil
-import signal
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
+
+from genesis.util.proc_kill import kill_process_group, reap_bounded
 
 if TYPE_CHECKING:
     from genesis.cc import AgentProvider
@@ -94,38 +95,10 @@ _CODEX_EXEC_TIMEOUT_S = _read_codex_timeout_s()
 # ``proc.wait()`` returns promptly — but the recovery path must not itself be
 # unbounded (a paused pipe transport with buffered data at cancel time is the
 # theoretical edge), or the timeout could re-create the executor wedge it exists
-# to prevent. 30s is far beyond any real SIGKILL-to-exit latency.
-_CODEX_KILL_REAP_TIMEOUT_S = 30.0
-
-
-def _kill_codex_process_tree(proc: asyncio.subprocess.Process) -> None:
-    """SIGKILL the whole process group led by *proc*.
-
-    codex is a Node launcher that spawns child processes; killing only the
-    direct PID can orphan them. The subprocess is spawned with
-    ``start_new_session=True``, so its process-group id *equals* ``proc.pid``
-    and — crucially — the kernel keeps that pgid reserved while ANY group member
-    is alive. We therefore signal ``proc.pid`` as the pgid **directly** rather
-    than via ``os.getpgid(proc.pid)``: once asyncio reaps the group *leader*
-    (which can happen while a descendant still holds a pipe, keeping
-    ``communicate()`` pending), ``getpgid`` would raise ``ProcessLookupError``
-    and a bare ``proc.kill()`` would no-op — leaking the very descendant this
-    guard exists to reap. The ``pgid <= 1`` guard refuses a container-wide kill.
-    """
-    pgid = proc.pid
-    if not pgid or pgid <= 1:
-        # No usable own-group id (should not happen with start_new_session);
-        # fall back to signalling just the direct child.
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-        return
-    try:
-        os.killpg(pgid, signal.SIGKILL)
-    except ProcessLookupError:
-        pass  # whole group already gone — nothing to reap
-    except (PermissionError, OSError):
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
+# to prevent. The tree-kill + bounded-reap machinery itself lives in
+# genesis.util.proc_kill (extracted from this module after PR #1409 — the
+# pid-as-pgid rationale, the pgid<=1 guard, and the leader-reaped race are
+# documented there, and every launcher spawn site now shares one hardened copy).
 
 
 # ---------------------------------------------------------------------------
@@ -538,14 +511,11 @@ class TaskReviewer:
                 "skipping codex link",
                 _CODEX_EXEC_TIMEOUT_S,
             )
-            _kill_codex_process_tree(proc)
+            kill_process_group(proc)
             # Bounded reap: the process is SIGKILLed so this returns promptly;
             # the bound guarantees the recovery path can't itself re-wedge on a
             # paused pipe transport.
-            with contextlib.suppress(Exception):
-                await asyncio.wait_for(
-                    proc.wait(), timeout=_CODEX_KILL_REAP_TIMEOUT_S,
-                )
+            await reap_bounded(proc)
             return None
         except OSError:
             logger.warning("review: codex exec communicate error", exc_info=True)

--- a/src/genesis/autonomy/executor/review.py
+++ b/src/genesis/autonomy/executor/review.py
@@ -517,6 +517,13 @@ class TaskReviewer:
             # paused pipe transport.
             await reap_bounded(proc)
             return None
+        except asyncio.CancelledError:
+            # Cancellation mid-verify: the detached codex tree sees no ambient
+            # signal — group-kill before propagating (final-audit F2; the
+            # eighth async site of the cancel sweep).
+            kill_process_group(proc)
+            await reap_bounded(proc)
+            raise
         except OSError:
             logger.warning("review: codex exec communicate error", exc_info=True)
             return None

--- a/src/genesis/cc/login_health.py
+++ b/src/genesis/cc/login_health.py
@@ -34,6 +34,8 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
+from genesis.util.proc_kill import kill_process_group, reap_bounded
+
 logger = logging.getLogger(__name__)
 
 _TOKEN_FILE = Path("~/.genesis/cc_oauth_token.env").expanduser()
@@ -122,14 +124,20 @@ async def probe_logged_out(cc_path: str = "claude", timeout_s: float = 15.0) -> 
             "--json",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.DEVNULL,
+            # Own group so the timeout can reap any node children too
+            # (mirrors the swept guardian/diagnosis.py probe).
+            start_new_session=True,
         )
         try:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
         except TimeoutError:
-            if proc.returncode is None:
-                proc.kill()
-                await proc.wait()
+            kill_process_group(proc)
+            await reap_bounded(proc)
             return False
+        except asyncio.CancelledError:
+            kill_process_group(proc)
+            await reap_bounded(proc)
+            raise
         try:
             logged_in = json.loads(stdout.decode("utf-8", errors="replace")).get(
                 "loggedIn",

--- a/src/genesis/contribution/review.py
+++ b/src/genesis/contribution/review.py
@@ -21,11 +21,14 @@ blocking decision here.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import shutil
 import subprocess
 from pathlib import Path
+
+from genesis.util.proc_kill import kill_process_group
 
 from .findings import ReviewResult
 
@@ -86,6 +89,12 @@ def _parse_verdict(text: str) -> tuple[bool, int, str]:
     return passed, finding_count, summary
 
 
+# Bound for the post-kill pipe drain: SIGKILL of the whole group means the
+# pipes close near-instantly; 30s is pure headroom so a pathological state
+# can't turn the timeout recovery itself into a hang.
+_CODEX_KILL_DRAIN_S = 30.0
+
+
 def _try_codex(diff: str, *, timeout: int = CODEX_TIMEOUT) -> ReviewResult | None:
     """Try the codex exec path. Returns None if codex is missing or errors."""
     if shutil.which("codex") is None:
@@ -97,36 +106,61 @@ def _try_codex(diff: str, *, timeout: int = CODEX_TIMEOUT) -> ReviewResult | Non
     # the single-argv length limit (P2-2 from the 6.1b.2 review) and
     # argv contents leak through `ps auxwww`. Codex exec with `-`
     # reads the prompt from stdin.
+    #
+    # Popen + start_new_session (not subprocess.run): codex is a Node
+    # launcher that forks workers — run()'s timeout kills only the direct
+    # child and orphans the tree. Own group → guarded killpg reaps it all.
     try:
-        proc = subprocess.run(
+        proc = subprocess.Popen(
             [
                 "codex", "exec", "-",
                 "-s", "read-only",
                 "-c", 'model_reasoning_effort="medium"',
                 "--json",
             ],
-            input=prompt,
-            capture_output=True,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            timeout=timeout,
-            check=False,
+            start_new_session=True,
         )
-    except subprocess.TimeoutExpired:
-        logger.warning("review: codex exec timed out after %ss", timeout)
-        return None
     except FileNotFoundError:
         return None
+    except OSError as exc:
+        logger.warning("review: codex spawn failed: %s", exc)
+        return None
+
+    try:
+        stdout, stderr = proc.communicate(input=prompt, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "review: codex exec timed out after %ss — killing process group",
+            timeout,
+        )
+        kill_process_group(proc)
+        with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+            proc.communicate(timeout=_CODEX_KILL_DRAIN_S)  # bounded drain/reap
+        return None
+    except BaseException:
+        # KeyboardInterrupt above all: start_new_session detached codex from
+        # the CLI's terminal group, so a human's Ctrl+C never reaches it —
+        # kill the group before propagating, or the interrupt itself leaks
+        # the tree.
+        kill_process_group(proc)
+        with contextlib.suppress(Exception):
+            proc.communicate(timeout=_CODEX_KILL_DRAIN_S)
+        raise
 
     if proc.returncode != 0:
         logger.warning(
             "review: codex exec rc=%s, stderr=%r",
-            proc.returncode, (proc.stderr or "")[:200],
+            proc.returncode, (stderr or "")[:200],
         )
         return None
 
     # codex --json emits JSONL; we want the final agent_message text
     pieces: list[str] = []
-    for line in proc.stdout.splitlines():
+    for line in stdout.splitlines():
         line = line.strip()
         if not line:
             continue

--- a/src/genesis/eval/gauntlet.py
+++ b/src/genesis/eval/gauntlet.py
@@ -214,6 +214,13 @@ async def _run_pytest(workdir: Path) -> tuple[int, str]:
         kill_process_group(proc)
         await reap_bounded(proc)
         return -1, "pytest scoring timed out"
+    except asyncio.CancelledError:
+        # Ctrl+C during scoring (asyncio.run cancels this task): with its own
+        # session pytest never sees the terminal SIGINT — group-kill before
+        # propagating or the tree runs on after the worktree is deleted.
+        kill_process_group(proc)
+        await reap_bounded(proc)
+        raise
     return proc.returncode, out.decode(errors="replace")
 
 

--- a/src/genesis/eval/gauntlet.py
+++ b/src/genesis/eval/gauntlet.py
@@ -58,6 +58,7 @@ from genesis.eval.types import (
     ScorerType,
     TaskCategory,
 )
+from genesis.util.proc_kill import kill_process_group, reap_bounded
 
 if TYPE_CHECKING:
     import aiosqlite
@@ -201,13 +202,17 @@ async def _run_pytest(workdir: Path) -> tuple[int, str]:
         cwd=str(workdir),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        # Own group so the timeout kill reaps forked test children too.
+        start_new_session=True,
     )
     try:
         out, _ = await asyncio.wait_for(proc.communicate(), timeout=_PYTEST_TIMEOUT_S)
     except TimeoutError:  # asyncio.TimeoutError is an alias of TimeoutError on 3.11+
-        with contextlib.suppress(ProcessLookupError):
-            proc.kill()
-        await proc.wait()
+        # Group-kill (guarded pid-as-pgid) + BOUNDED reap — a bare kill
+        # orphans forked test processes, and an unbounded wait() can hang
+        # the recovery itself.
+        kill_process_group(proc)
+        await reap_bounded(proc)
         return -1, "pytest scoring timed out"
     return proc.returncode, out.decode(errors="replace")
 

--- a/src/genesis/eval/promptfoo.py
+++ b/src/genesis/eval/promptfoo.py
@@ -8,6 +8,7 @@ Requires Node.js and promptfoo installed (`npx promptfoo` or global).
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import shlex
@@ -18,7 +19,12 @@ from pathlib import Path
 
 import yaml
 
+from genesis.util.proc_kill import kill_process_group
 from genesis.util.tmp import big_tmp_dir
+
+# Bound for the post-kill pipe drain (SIGKILL of the group closes the pipes
+# near-instantly; this is headroom, not a wait we expect to use).
+_KILL_DRAIN_S = 30.0
 
 logger = logging.getLogger(__name__)
 
@@ -75,15 +81,34 @@ async def compare_models(
         ]
         logger.info("Running promptfoo: %s", cmd_parts)
 
+        # Popen + start_new_session (not subprocess.run): promptfoo is a Node
+        # launcher (`npx promptfoo` → node → workers) — run()'s timeout kills
+        # only the direct child and orphans the tree. Own group → guarded
+        # killpg reaps it all.
         try:
-            proc = subprocess.run(
+            proc = subprocess.Popen(
                 cmd_parts,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=timeout_s,
                 cwd=tmpdir,
+                start_new_session=True,
             )
+        except OSError as exc:
+            return ComparisonReport(
+                model_a=model_a, model_b=model_b,
+                dataset=dataset_path.stem,
+                model_a_score=0, model_b_score=0,
+                winner="tie",
+                success=False,
+                error=f"promptfoo spawn failed: {exc}",
+            )
+        try:
+            stdout, stderr = proc.communicate(timeout=timeout_s)
         except subprocess.TimeoutExpired:
+            kill_process_group(proc)
+            with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+                proc.communicate(timeout=_KILL_DRAIN_S)  # bounded drain/reap
             return ComparisonReport(
                 model_a=model_a, model_b=model_b,
                 dataset=dataset_path.stem,
@@ -100,8 +125,8 @@ async def compare_models(
                 model_a_score=0, model_b_score=0,
                 winner="tie",
                 success=False,
-                error=f"promptfoo failed (rc={proc.returncode}): {proc.stderr[:500]}",
-                raw_output=proc.stdout[:2000],
+                error=f"promptfoo failed (rc={proc.returncode}): {stderr[:500]}",
+                raw_output=stdout[:2000],
             )
 
         # Parse output
@@ -115,7 +140,7 @@ async def compare_models(
                 winner="tie",
                 success=False,
                 error=f"failed to parse promptfoo output: {e}",
-                raw_output=proc.stdout[:2000],
+                raw_output=stdout[:2000],
             )
 
         return _parse_results(model_a, model_b, dataset_path.stem, results)

--- a/src/genesis/eval/promptfoo.py
+++ b/src/genesis/eval/promptfoo.py
@@ -117,6 +117,15 @@ async def compare_models(
                 success=False,
                 error=f"promptfoo timed out after {timeout_s}s",
             )
+        except BaseException:
+            # subprocess.run() killed the child on ANY exception (incl.
+            # Ctrl+C) — preserve that. With start_new_session the terminal
+            # SIGINT never reaches the detached node tree, so this handler
+            # is the only thing preventing an interrupt from leaking it.
+            kill_process_group(proc)
+            with contextlib.suppress(Exception):
+                proc.communicate(timeout=_KILL_DRAIN_S)
+            raise
 
         if proc.returncode != 0:
             return ComparisonReport(

--- a/src/genesis/experimentation/cc_router.py
+++ b/src/genesis/experimentation/cc_router.py
@@ -106,6 +106,7 @@ class CCCliRouter:
         # text, not Genesis's project context bleeding into the reflection.
         env["GENESIS_CC_SESSION"] = "1"
 
+        proc = None
         try:
             proc = await asyncio.create_subprocess_exec(
                 *args,
@@ -121,14 +122,25 @@ class CCCliRouter:
             out, err = await asyncio.wait_for(
                 proc.communicate(input=user.encode()), timeout=self._timeout_s,
             )
+        except asyncio.CancelledError:
+            # Cancellation: the detached child sees no ambient signal —
+            # group-kill before propagating or the tree leaks. proc may be
+            # unbound if the cancel landed during the spawn itself.
+            if proc is not None:
+                kill_process_group(proc)
+                await reap_bounded(proc)
+            raise
         except TimeoutError:
             logger.warning("cc-cli %s timed out after %ss", self._model, self._timeout_s)
             # claude spawns MCP/helper children — a bare proc.kill() orphans
             # them (they keep running + hold a subscription slot). Group-kill
             # via the shared guarded helper (pid-as-pgid, pgid>1 guard,
-            # direct-kill fallback), then a BOUNDED reap.
-            kill_process_group(proc)
-            await reap_bounded(proc)
+            # direct-kill fallback), then a BOUNDED reap. proc may be None if
+            # the spawn ITSELF raised ETIMEDOUT (TimeoutError is an OSError
+            # subclass) — degrade without a kill in that case.
+            if proc is not None:
+                kill_process_group(proc)
+                await reap_bounded(proc)
             return StandaloneRoutingResult(
                 success=False, content=None, model_id=self._model,
                 provider_used="cc-cli", error="timeout",

--- a/src/genesis/experimentation/cc_router.py
+++ b/src/genesis/experimentation/cc_router.py
@@ -15,7 +15,6 @@ Single-completion only (``-p``); no tools, no session resume.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 import os
 
@@ -27,6 +26,7 @@ from genesis.cc.types import (
     model_supports_effort,
 )
 from genesis.experimentation.standalone_router import StandaloneRoutingResult
+from genesis.util.proc_kill import kill_process_group, reap_bounded
 
 logger = logging.getLogger(__name__)
 
@@ -113,18 +113,22 @@ class CCCliRouter:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=env,
+                # Own session/group (setsid in the C helper — never
+                # preexec_fn: post-fork Python can deadlock in the threaded
+                # server) so the timeout below can killpg the whole tree.
+                start_new_session=True,
             )
             out, err = await asyncio.wait_for(
                 proc.communicate(input=user.encode()), timeout=self._timeout_s,
             )
         except TimeoutError:
             logger.warning("cc-cli %s timed out after %ss", self._model, self._timeout_s)
-            # Reap the orphaned claude process (else it keeps running + holds a
-            # subscription slot). Mirrors CCInvoker's timeout handling.
-            with contextlib.suppress(ProcessLookupError, OSError):
-                proc.kill()
-            with contextlib.suppress(Exception):
-                await proc.wait()
+            # claude spawns MCP/helper children — a bare proc.kill() orphans
+            # them (they keep running + hold a subscription slot). Group-kill
+            # via the shared guarded helper (pid-as-pgid, pgid>1 guard,
+            # direct-kill fallback), then a BOUNDED reap.
+            kill_process_group(proc)
+            await reap_bounded(proc)
             return StandaloneRoutingResult(
                 success=False, content=None, model_id=self._model,
                 provider_used="cc-cli", error="timeout",

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -595,6 +595,12 @@ class DiagnosisEngine:
             raise CCDiagnosisError(
                 f"CC timed out after {self._config.cc.timeout_s}s"
             ) from exc
+        except asyncio.CancelledError:
+            # Cancellation: the detached brain tree sees no ambient signal —
+            # group-kill before propagating or it runs on host-side.
+            kill_process_group(proc)
+            await reap_bounded(proc)
+            raise
 
         if proc.returncode != 0:
             stderr_text = stderr.decode("utf-8", errors="replace")[:300]
@@ -661,6 +667,10 @@ class DiagnosisEngine:
                 kill_process_group(proc)
                 await reap_bounded(proc)
                 return None  # ambiguous → inherit; fail-safe covers a real outage
+            except asyncio.CancelledError:
+                kill_process_group(proc)
+                await reap_bounded(proc)
+                raise
             try:
                 logged_in = json.loads(
                     stdout.decode("utf-8", errors="replace"),

--- a/src/genesis/guardian/diagnosis.py
+++ b/src/genesis/guardian/diagnosis.py
@@ -28,8 +28,13 @@ from genesis.cc.types import model_name_supports_effort
 from genesis.guardian.briefing import read_guardian_briefing
 from genesis.guardian.collector import DiagnosticSnapshot
 from genesis.guardian.config import GuardianConfig
+from genesis.util.proc_kill import kill_process_group, reap_bounded
 
 logger = logging.getLogger(__name__)
+
+# Bound for the `claude auth status` pre-flight probe: node startup + one
+# network round-trip, generous for a degraded host.
+_AUTH_PROBE_TIMEOUT_S = 15.0
 
 # Pre-flight memory thresholds.  Guardian must always attempt diagnosis
 # above the hard floor.  The systemd MemoryMax cap on the Guardian
@@ -569,6 +574,11 @@ class DiagnosisEngine:
             stderr=asyncio.subprocess.PIPE,
             cwd=str(work_dir),
             env=await self._resolve_cc_env(cc_path),
+            # Own session/group so the timeout below can reap the WHOLE
+            # claude tree — the agentic brain forks tool children, and a
+            # leaked tree on the host has no genesis-server cgroup to
+            # clean it up (setsid in the C helper; never preexec_fn).
+            start_new_session=True,
         )
 
         try:
@@ -577,9 +587,11 @@ class DiagnosisEngine:
                 timeout=self._config.cc.timeout_s,
             )
         except TimeoutError as exc:
-            if proc.returncode is None:
-                proc.kill()
-                await proc.wait()
+            # Group-kill (guarded pid-as-pgid — immune to the leader-reaped
+            # race) with a bounded reap; a bare proc.kill() orphans the
+            # brain's tool/MCP children.
+            kill_process_group(proc)
+            await reap_bounded(proc)
             raise CCDiagnosisError(
                 f"CC timed out after {self._config.cc.timeout_s}s"
             ) from exc
@@ -635,16 +647,19 @@ class DiagnosisEngine:
                 cc_path, "auth", "status", "--json",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.DEVNULL,
+                # Own group so the timeout can reap any node children too.
+                start_new_session=True,
             )
             try:
-                # 15s: node startup + a network round-trip, generous for a
+                # Node startup + a network round-trip, generous for a
                 # degraded host but bounded so a wedged probe can't hang the
                 # (already timeout-bounded) diagnosis. Never inherits the token.
-                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
+                stdout, _ = await asyncio.wait_for(
+                    proc.communicate(), timeout=_AUTH_PROBE_TIMEOUT_S,
+                )
             except TimeoutError:
-                if proc.returncode is None:
-                    proc.kill()
-                    await proc.wait()
+                kill_process_group(proc)
+                await reap_bounded(proc)
                 return None  # ambiguous → inherit; fail-safe covers a real outage
             try:
                 logged_in = json.loads(

--- a/src/genesis/session_awareness/headless.py
+++ b/src/genesis/session_awareness/headless.py
@@ -105,6 +105,12 @@ async def run_headless_json(
             kill_process_group(proc)
             await reap_bounded(proc)
             return {"status": "timeout"}
+        except asyncio.CancelledError:
+            # Task cancellation: the detached child sees no ambient signal —
+            # group-kill before propagating or the tree leaks.
+            kill_process_group(proc)
+            await reap_bounded(proc)
+            raise
         if proc.returncode != 0:
             return {"status": "failed", "reason": f"exit_{proc.returncode}"}
         return {"status": "ok", "stdout": stdout.decode(errors="replace")}

--- a/src/genesis/session_awareness/headless.py
+++ b/src/genesis/session_awareness/headless.py
@@ -10,8 +10,8 @@ extraction and keeps its own). Locked invariants carried over verbatim:
 - ``GENESIS_SESSION_ORIGIN`` popped — WS-3: never leak a session origin
   into the nested subprocess (mirrors ``CCInvoker._build_env``).
 - ONE timeout; on expiry the whole PROCESS GROUP is SIGKILLed (claude
-  spawns MCP children; killing only the parent orphans them) — with the
-  pgid>1 guard from ``cc/invoker.py``.
+  spawns MCP children; killing only the parent orphans them) via the
+  shared guarded helper (``genesis.util.proc_kill``).
 - Never raises: every outcome is a status dict.
 """
 
@@ -19,7 +19,8 @@ from __future__ import annotations
 
 import asyncio
 import os
-import signal
+
+from genesis.util.proc_kill import kill_process_group, reap_bounded
 
 
 def build_argv(
@@ -84,7 +85,10 @@ async def run_headless_json(
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             env=env,
-            preexec_fn=os.setpgrp,
+            # Own session/group (setsid in the C helper — never preexec_fn:
+            # post-fork Python can deadlock in the threaded server) so the
+            # timeout below can killpg the whole claude tree.
+            start_new_session=True,
         )
         try:
             stdout, _stderr = await asyncio.wait_for(
@@ -92,16 +96,14 @@ async def run_headless_json(
                 timeout=timeout_s,
             )
         except TimeoutError:
-            # claude spawns MCP/helper children — group-kill is mandatory
-            # (cc/invoker.py pattern, incl. the pgid>1 safety guard).
-            try:
-                pgid = os.getpgid(proc.pid)
-                if pgid <= 1:
-                    raise ValueError(f"Refusing killpg with pgid={pgid}")
-                os.killpg(pgid, signal.SIGKILL)
-            except (ProcessLookupError, PermissionError, ValueError, TypeError):
-                proc.kill()
-            await proc.wait()
+            # claude spawns MCP/helper children — group-kill is mandatory.
+            # kill_process_group signals proc.pid AS the pgid (never
+            # os.getpgid, which raises once the leader is reaped and would
+            # leak the children), with the pgid>1 guard + direct-kill
+            # fallback; the reap is bounded (a paused pipe transport can
+            # stall an unbounded wait()).
+            kill_process_group(proc)
+            await reap_bounded(proc)
             return {"status": "timeout"}
         if proc.returncode != 0:
             return {"status": "failed", "reason": f"exit_{proc.returncode}"}

--- a/src/genesis/util/proc_kill.py
+++ b/src/genesis/util/proc_kill.py
@@ -65,7 +65,12 @@ def kill_process_group(proc, sig: signal.Signals = signal.SIGKILL) -> None:
 
 
 async def reap_bounded(proc, timeout_s: float | None = None) -> None:
-    """Await ``proc.wait()`` with a hard bound; never raises.
+    """Await ``proc.wait()`` with a hard bound; never raises — except a
+    CancelledError arriving MID-reap, which propagates (suppress(Exception)
+    excludes BaseException). That is safe by construction: every call site
+    runs the synchronous ``kill_process_group`` first, so a second cancel
+    abandons only the wait, never the kill, and asyncio's child watcher
+    still reaps the leader.
 
     ``timeout_s=None`` resolves ``DEFAULT_REAP_TIMEOUT_S`` at call time (so
     tests can shrink it via the module attribute).

--- a/src/genesis/util/proc_kill.py
+++ b/src/genesis/util/proc_kill.py
@@ -1,0 +1,76 @@
+"""Process-group kill helpers for subprocess launchers.
+
+Genesis spawns several external LAUNCHERS (``codex``, ``claude``, ``git`` and
+its ssh/credential helpers, arbitrary step commands) that fork their own
+children. Killing only the direct child on timeout orphans the tree — the
+children reparent to pid 1 and keep running/spending until reboot. The safe
+pattern (hardened across three Codex review rounds on PR #1409):
+
+- Spawn with ``start_new_session=True`` — setsid is done async-signal-safely
+  inside the C subprocess helper. NEVER ``preexec_fn``: arbitrary post-fork
+  Python can deadlock in a multi-threaded parent (the genesis-server). The
+  child then LEADS its own session/process group, so its pgid == its pid.
+- On timeout, signal ``proc.pid`` AS the pgid directly. Never derive it via
+  ``os.getpgid(proc.pid)``: once the leader exits and is reaped (asyncio's
+  child watcher waitpid()s promptly), getpgid raises ProcessLookupError even
+  while descendants keep the group alive — the kernel reserves the pgid until
+  the LAST member dies, so ``killpg(pid)`` still reaps the survivors.
+- Bound the post-kill reap: a paused pipe transport can stall an unbounded
+  ``wait()``, turning the timeout recovery itself into a hang.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import signal
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REAP_TIMEOUT_S = 30.0
+
+
+def kill_process_group(proc, sig: signal.Signals = signal.SIGKILL) -> None:
+    """Signal the process group led by ``proc`` (Popen or asyncio Process).
+
+    ``proc`` must have been spawned with ``start_new_session=True`` so its pid
+    is its pgid. Guards: a non-int or <=1 pid never reaches killpg —
+    ``killpg(1, sig)`` equals ``kill(-1, sig)``: every process we own — and
+    falls back to the direct ``proc.kill()``. A vanished group
+    (ProcessLookupError) is success; any other OS refusal falls back to the
+    direct kill.
+    """
+    pgid = getattr(proc, "pid", None)
+    if not isinstance(pgid, int) or pgid <= 1:
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+        return
+    try:
+        os.killpg(pgid, sig)
+    except ProcessLookupError:
+        pass  # whole group already gone — success, silent by design
+    except OSError:
+        # A genuine OS refusal degrades to the known-bad direct kill (the
+        # tree can leak) — that must be VISIBLE, unlike the vanished-group
+        # case above.
+        logger.warning(
+            "killpg(%s) failed; falling back to direct kill (children may leak)",
+            pgid,
+            exc_info=True,
+        )
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()
+
+
+async def reap_bounded(proc, timeout_s: float | None = None) -> None:
+    """Await ``proc.wait()`` with a hard bound; never raises.
+
+    ``timeout_s=None`` resolves ``DEFAULT_REAP_TIMEOUT_S`` at call time (so
+    tests can shrink it via the module attribute).
+    """
+    if timeout_s is None:
+        timeout_s = DEFAULT_REAP_TIMEOUT_S
+    with contextlib.suppress(Exception):
+        await asyncio.wait_for(proc.wait(), timeout=timeout_s)

--- a/tests/proc_asserts.py
+++ b/tests/proc_asserts.py
@@ -1,0 +1,27 @@
+"""Shared assertion helpers for process-kill tests.
+
+``os.kill(pid, 0)`` SUCCEEDS on a zombie — on hosts whose pid 1 does not
+promptly reap orphans (minimal-init containers), a SIGKILLed grandchild can
+sit in state Z long enough to flake a bare ``ProcessLookupError`` assertion
+even though the group kill worked (Codex P2, PR #1415). "Terminated" for
+these tests means: gone, OR present only as a zombie.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def process_terminated(pid: int) -> bool:
+    """True iff *pid* is gone or is a zombie (dead, awaiting reap)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return True
+    try:
+        with open(f"/proc/{pid}/stat") as fh:
+            # field 3 (after the parenthesised comm, which may contain spaces)
+            state = fh.read().rsplit(")", 1)[1].split()[0]
+    except (FileNotFoundError, ProcessLookupError, IndexError):
+        return True
+    return state == "Z"

--- a/tests/test_autonomy/test_executor/test_deterministic.py
+++ b/tests/test_autonomy/test_executor/test_deterministic.py
@@ -210,7 +210,6 @@ class TestExecuteDeterministicStep:
         timeout kill must reap the whole process group, not just the direct
         child — otherwise the grandchild reparents to pid 1 and runs forever."""
         import asyncio
-        import os
 
         from genesis.autonomy.executor import deterministic as det
 
@@ -232,8 +231,9 @@ class TestExecuteDeterministicStep:
             grandchild = int(marker.read_text().strip())
             assert grandchild > 1  # explicit pid, never a default
             await asyncio.sleep(0.3)  # let SIGKILL land
-            with pytest.raises(ProcessLookupError):
-                os.kill(grandchild, 0)
+            from tests.proc_asserts import process_terminated
+
+            assert process_terminated(grandchild)  # gone-or-zombie
         finally:
             det._HARD_TIMEOUT_S = original
 
@@ -259,3 +259,30 @@ class TestStepTypeProperties:
     def test_deterministic_types_do_not_verify(self) -> None:
         for st in (StepType.BASH, StepType.TEST, StepType.GIT):
             assert st.verify_step is False, f"{st} should not require verification"
+
+
+@pytest.mark.asyncio
+async def test_cancel_reaps_tree_and_reraises(tmp_path: Path) -> None:
+    """Task cancellation mid-step must group-kill the step's tree before
+    propagating — with its own session, no ambient signal reaches it."""
+    import asyncio
+    import time
+
+    from tests.proc_asserts import process_terminated
+
+    marker = tmp_path / "gc_pid"
+    forker = tmp_path / "forker"
+    forker.write_text(f"#!/bin/bash\nsleep 600 &\necho $! > {marker}\nsleep 600\n")
+    forker.chmod(0o755)
+    step = {"idx": 0, "type": "bash", "command": str(forker)}
+    task = asyncio.get_running_loop().create_task(execute_deterministic_step(step))
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline and not (marker.exists() and marker.read_text().strip()):
+        await asyncio.sleep(0.05)
+    grandchild = int(marker.read_text().strip())
+    assert grandchild > 1
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.sleep(0.3)
+    assert process_terminated(grandchild)

--- a/tests/test_autonomy/test_executor/test_deterministic.py
+++ b/tests/test_autonomy/test_executor/test_deterministic.py
@@ -205,6 +205,38 @@ class TestExecuteDeterministicStep:
         finally:
             det._HARD_TIMEOUT_S = original
 
+    async def test_timeout_reaps_grandchildren(self, tmp_path: Path) -> None:
+        """A step command that FORKS (bash spawning a background child): the
+        timeout kill must reap the whole process group, not just the direct
+        child — otherwise the grandchild reparents to pid 1 and runs forever."""
+        import asyncio
+        import os
+
+        from genesis.autonomy.executor import deterministic as det
+
+        marker = tmp_path / "grandchild_pid"
+        # A project-script step (validate_command allows executables that are
+        # not bare interpreter names) that forks a background child then hangs.
+        forker = tmp_path / "forker"
+        forker.write_text(
+            f"#!/bin/bash\nsleep 600 &\necho $! > {marker}\nsleep 600\n"
+        )
+        forker.chmod(0o755)
+        original = det._HARD_TIMEOUT_S
+        try:
+            det._HARD_TIMEOUT_S = 1
+            step = {"idx": 0, "type": "bash", "command": str(forker)}
+            result = await execute_deterministic_step(step)
+            assert result.status == "failed"
+            assert "timed out" in result.blocker_description.lower()
+            grandchild = int(marker.read_text().strip())
+            assert grandchild > 1  # explicit pid, never a default
+            await asyncio.sleep(0.3)  # let SIGKILL land
+            with pytest.raises(ProcessLookupError):
+                os.kill(grandchild, 0)
+        finally:
+            det._HARD_TIMEOUT_S = original
+
 
 class TestStepTypeProperties:
     """Verify the new StepType properties."""

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -1580,3 +1580,74 @@ class TestLedgerAndBusEmits:
 
         assert await engine.execute("t-001") is True
         assert await self._predictions(db, "t-001") == []
+
+
+@pytest.mark.asyncio
+class TestRunGitPushBounded:
+    """The delivery `git push` runs under the executor's Semaphore(1) — a
+    network-stalled push with no timeout wedges ALL autonomy (the exact class
+    the scope-gate's 60s bound in this file already guards for local git ops).
+    _run_git_push must bound the wait and group-kill on expiry (git's own
+    ssh/credential child is what actually stalls — killing only git orphans
+    the hung helper)."""
+
+    async def test_success_passthrough(self, tmp_path, monkeypatch):
+        from genesis.autonomy.executor import engine as engine_mod
+
+        async def fake_exec(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"", b"pushed ok"))
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        rc, err = await engine_mod._run_git_push(tmp_path, "task/abc123")
+        assert rc == 0
+        assert "pushed ok" in err
+
+    async def test_timeout_degrades_and_group_kills(self, tmp_path, monkeypatch):
+        from genesis.autonomy.executor import engine as engine_mod
+
+        killpg_calls = []
+        monkeypatch.setattr(
+            "genesis.util.proc_kill.os.killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+        monkeypatch.setattr(engine_mod, "_GIT_PUSH_TIMEOUT_S", 0.05)
+
+        proc = MagicMock()
+        proc.pid = 88888  # explicit — never a mock default (killpg(1) trap)
+        proc.returncode = None
+
+        async def _hang(*a, **k):
+            await asyncio.sleep(600)
+
+        proc.communicate = _hang
+        proc.wait = AsyncMock(return_value=-9)
+
+        async def fake_exec(*args, **kwargs):
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        rc, err = await engine_mod._run_git_push(tmp_path, "task/abc123")
+        assert rc != 0
+        assert "timed out" in err
+        assert len(killpg_calls) == 1
+        assert killpg_calls[0][0] == 88888
+
+    async def test_spawned_in_new_session(self, tmp_path, monkeypatch):
+        from genesis.autonomy.executor import engine as engine_mod
+
+        captured = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured.update(kwargs)
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        await engine_mod._run_git_push(tmp_path, "task/abc123")
+        assert captured.get("start_new_session") is True
+        assert "preexec_fn" not in captured

--- a/tests/test_autonomy/test_executor/test_engine.py
+++ b/tests/test_autonomy/test_executor/test_engine.py
@@ -1651,3 +1651,36 @@ class TestRunGitPushBounded:
         await engine_mod._run_git_push(tmp_path, "task/abc123")
         assert captured.get("start_new_session") is True
         assert "preexec_fn" not in captured
+
+    async def test_cancel_group_kills_and_reraises(self, tmp_path, monkeypatch):
+        from genesis.autonomy.executor import engine as engine_mod
+
+        killpg_calls = []
+        monkeypatch.setattr(
+            "genesis.util.proc_kill.os.killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+        proc = MagicMock()
+        proc.pid = 88889
+        proc.returncode = None
+        started = asyncio.Event()
+
+        async def _hang(*a, **k):
+            started.set()
+            await asyncio.sleep(600)
+
+        proc.communicate = _hang
+        proc.wait = AsyncMock(return_value=-9)
+
+        async def fake_exec(*args, **kwargs):
+            return proc
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        task = asyncio.get_running_loop().create_task(
+            engine_mod._run_git_push(tmp_path, "task/abc123")
+        )
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert killpg_calls and killpg_calls[0][0] == 88889

--- a/tests/test_autonomy/test_executor/test_review.py
+++ b/tests/test_autonomy/test_executor/test_review.py
@@ -969,3 +969,46 @@ class TestFreshEyesPromptScoping:
         low = prompt.lower()
         assert "read the file" in low
         assert "run the tests" in low
+
+
+@pytest.mark.asyncio
+async def test_codex_cancel_group_kills_and_reraises(monkeypatch):
+    """Cancellation mid-verify must group-kill the detached codex tree before
+    propagating — the same class as the timeout path (final-audit F2)."""
+    monkeypatch.setattr(
+        "genesis.autonomy.executor.review.shutil.which",
+        lambda name: "/usr/bin/codex",
+    )
+    killpg_calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        "genesis.util.proc_kill.os.killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+    )
+    started = asyncio.Event()
+    fake_proc = MagicMock()
+    fake_proc.pid = 424244  # explicit — never a mock default
+    fake_proc.returncode = None
+
+    async def _hang(*a, **k):
+        started.set()
+        await asyncio.sleep(600)
+
+    fake_proc.communicate = _hang
+    fake_proc.wait = AsyncMock(return_value=-9)
+
+    async def _fake_exec(*_args, **_kwargs):
+        return fake_proc
+
+    monkeypatch.setattr(
+        "genesis.autonomy.executor.review.asyncio.create_subprocess_exec",
+        _fake_exec,
+    )
+    reviewer = TaskReviewer(router=AsyncMock())
+    task = asyncio.get_running_loop().create_task(
+        reviewer._verify_via_codex("deliverable", "reqs")
+    )
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert killpg_calls and killpg_calls[0][0] == 424244

--- a/tests/test_autonomy/test_executor/test_review.py
+++ b/tests/test_autonomy/test_executor/test_review.py
@@ -443,7 +443,7 @@ class TestVerifyViaCodex:
 
         killpg_calls: list[tuple[int, int]] = []
         monkeypatch.setattr(
-            "genesis.autonomy.executor.review.os.killpg",
+            "genesis.util.proc_kill.os.killpg",
             lambda pgid, sig: killpg_calls.append((pgid, sig)),
         )
 
@@ -493,7 +493,7 @@ class TestVerifyViaCodex:
 
         killpg_calls: list[tuple[int, int]] = []
         monkeypatch.setattr(
-            "genesis.autonomy.executor.review.os.killpg",
+            "genesis.util.proc_kill.os.killpg",
             lambda pgid, sig: killpg_calls.append((pgid, sig)),
         )
 
@@ -541,7 +541,7 @@ class TestVerifyViaCodex:
 
         killpg_calls: list[tuple[int, int]] = []
         monkeypatch.setattr(
-            "genesis.autonomy.executor.review.os.killpg",
+            "genesis.util.proc_kill.os.killpg",
             lambda pgid, sig: killpg_calls.append((pgid, sig)),
         )
 
@@ -601,10 +601,10 @@ class TestVerifyViaCodex:
             "genesis.autonomy.executor.review._CODEX_EXEC_TIMEOUT_S", 0.05,
         )
         monkeypatch.setattr(
-            "genesis.autonomy.executor.review._CODEX_KILL_REAP_TIMEOUT_S", 0.05,
+            "genesis.util.proc_kill.DEFAULT_REAP_TIMEOUT_S", 0.05,
         )
         monkeypatch.setattr(
-            "genesis.autonomy.executor.review.os.killpg", lambda pgid, sig: None,
+            "genesis.util.proc_kill.os.killpg", lambda pgid, sig: None,
         )
 
         async def _never_returns(*_args, **_kwargs):

--- a/tests/test_cc/test_login_health.py
+++ b/tests/test_cc/test_login_health.py
@@ -222,3 +222,38 @@ async def test_probe_uses_configured_cc_path(tmp_path, monkeypatch):
     )
     assert env == {"CLAUDE_CODE_OAUTH_TOKEN": "tok-x"}
     assert seen == ["/opt/custom/claude"]
+
+
+async def test_probe_timeout_group_kills_and_returns_false(monkeypatch):
+    """The auth probe spawns the `claude` launcher (node children) — its
+    timeout must group-kill via the shared guarded helper and stay ambiguous
+    (False), mirroring the swept guardian/diagnosis.py probe."""
+    import asyncio as _asyncio
+    from unittest.mock import AsyncMock, MagicMock
+
+    killpg_calls = []
+    monkeypatch.setattr(
+        "genesis.util.proc_kill.os.killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+    )
+    captured: dict = {}
+    proc = MagicMock()
+    proc.pid = 41414  # explicit — never a mock default (killpg(1) trap)
+    proc.returncode = None
+
+    async def _hang(*a, **k):
+        await _asyncio.sleep(600)
+
+    proc.communicate = _hang
+    proc.wait = AsyncMock(return_value=-9)
+
+    async def fake_exec(*args, **kwargs):
+        captured.update(kwargs)
+        return proc
+
+    monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec)
+    result = await login_health.probe_logged_out("claude", timeout_s=0.05)
+    assert result is False  # ambiguity → never inject
+    assert killpg_calls and killpg_calls[0][0] == 41414
+    assert captured.get("start_new_session") is True
+    assert "preexec_fn" not in captured

--- a/tests/test_contribution/test_review.py
+++ b/tests/test_contribution/test_review.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import json
 import subprocess
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from genesis.contribution import review
 
@@ -22,6 +24,16 @@ def _mk_codex_output(agent_text: str) -> str:
         json.dumps({"type": "turn.completed", "usage": {"input_tokens": 100, "output_tokens": 100}}),
     ]
     return "\n".join(lines)
+
+
+def _popen_mock(stdout: str = "", returncode: int = 0, pid: int = 54321) -> MagicMock:
+    """A Popen stand-in. pid is EXPLICIT — never rely on a mock default
+    (int(MagicMock().pid) coerces to 1 → the killpg(1) trap)."""
+    m = MagicMock()
+    m.pid = pid
+    m.returncode = returncode
+    m.communicate.return_value = (stdout, "")
+    return m
 
 
 def test_parse_verdict_pass():
@@ -57,12 +69,9 @@ def test_codex_missing_skipped():
 
 def test_codex_success_passed():
     output = _mk_codex_output("All good.\n\nVERDICT: PASS")
-    mock_proc = subprocess.CompletedProcess(
-        args=[], returncode=0, stdout=output, stderr="",
-    )
     with (
         patch("genesis.contribution.review.shutil.which", return_value="/fake/codex"),
-        patch("genesis.contribution.review.subprocess.run", return_value=mock_proc),
+        patch("genesis.contribution.review.subprocess.Popen", return_value=_popen_mock(output)),
     ):
         r = review._try_codex("diff")
     assert r is not None
@@ -75,12 +84,9 @@ def test_codex_success_failed():
     output = _mk_codex_output(
         "issue: bad import\nconcern: race condition\nVERDICT: FAIL"
     )
-    mock_proc = subprocess.CompletedProcess(
-        args=[], returncode=0, stdout=output, stderr="",
-    )
     with (
         patch("genesis.contribution.review.shutil.which", return_value="/fake/codex"),
-        patch("genesis.contribution.review.subprocess.run", return_value=mock_proc),
+        patch("genesis.contribution.review.subprocess.Popen", return_value=_popen_mock(output)),
     ):
         r = review._try_codex("diff")
     assert r is not None
@@ -89,38 +95,123 @@ def test_codex_success_failed():
 
 
 def test_codex_nonzero_returncode_returns_none():
-    mock_proc = subprocess.CompletedProcess(
-        args=[], returncode=1, stdout="", stderr="codex error",
-    )
     with (
         patch("genesis.contribution.review.shutil.which", return_value="/fake/codex"),
-        patch("genesis.contribution.review.subprocess.run", return_value=mock_proc),
+        patch(
+            "genesis.contribution.review.subprocess.Popen",
+            return_value=_popen_mock("", returncode=1),
+        ),
     ):
         r = review._try_codex("diff")
     assert r is None
 
 
 def test_codex_empty_output_returns_none():
-    mock_proc = subprocess.CompletedProcess(
-        args=[], returncode=0, stdout="", stderr="",
-    )
     with (
         patch("genesis.contribution.review.shutil.which", return_value="/fake/codex"),
-        patch("genesis.contribution.review.subprocess.run", return_value=mock_proc),
+        patch("genesis.contribution.review.subprocess.Popen", return_value=_popen_mock("")),
     ):
         r = review._try_codex("diff")
     assert r is None
 
 
-def test_codex_timeout_returns_none():
-    def raise_timeout(*a, **kw):
-        raise subprocess.TimeoutExpired(cmd="codex", timeout=300)
+def test_codex_spawn_oserror_returns_none():
     with (
         patch("genesis.contribution.review.shutil.which", return_value="/fake/codex"),
-        patch("genesis.contribution.review.subprocess.run", side_effect=raise_timeout),
+        patch(
+            "genesis.contribution.review.subprocess.Popen",
+            side_effect=OSError("spawn failed"),
+        ),
     ):
         r = review._try_codex("diff")
     assert r is None
+
+
+class TestCodexTimeoutTreeKill:
+    """Timeout must SIGKILL codex's whole process GROUP (codex is a Node
+    launcher — killing only the direct child orphans its workers), signalling
+    proc.pid AS the pgid (never os.getpgid — it raises once the leader is
+    reaped, leaking the tree), then drain with a BOUNDED communicate."""
+
+    def _run_timeout(self, proc: MagicMock):
+        with (
+            patch("genesis.contribution.review.shutil.which", return_value="/fake/codex"),
+            patch("genesis.contribution.review.subprocess.Popen", return_value=proc),
+            patch("genesis.util.proc_kill.os.killpg") as killpg,
+        ):
+            r = review._try_codex("diff")
+        return r, killpg
+
+    def test_timeout_group_kills_by_pid(self):
+        proc = _popen_mock(pid=54321)
+        proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="codex", timeout=300),
+            ("", ""),  # bounded drain
+        ]
+        r, killpg = self._run_timeout(proc)
+        assert r is None
+        killpg.assert_called_once()
+        assert killpg.call_args.args[0] == 54321
+        proc.kill.assert_not_called()
+
+    def test_timeout_pgid_guard_refuses_group_kill(self):
+        proc = _popen_mock(pid=1)
+        proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="codex", timeout=300),
+            ("", ""),
+        ]
+        r, killpg = self._run_timeout(proc)
+        assert r is None
+        killpg.assert_not_called()
+        proc.kill.assert_called_once()
+
+    def test_timeout_drain_is_bounded_and_survives_second_timeout(self):
+        proc = _popen_mock(pid=54321)
+        proc.communicate.side_effect = [
+            subprocess.TimeoutExpired(cmd="codex", timeout=300),
+            subprocess.TimeoutExpired(cmd="codex", timeout=30),  # drain times out too
+        ]
+        r, killpg = self._run_timeout(proc)
+        assert r is None  # still degrades, never raises
+        killpg.assert_called_once()
+        # the drain was attempted with a timeout kwarg (bounded, not blocking)
+        drain_call = proc.communicate.call_args_list[1]
+        assert drain_call.kwargs.get("timeout") is not None
+
+    def test_keyboard_interrupt_kills_group_and_propagates(self):
+        """start_new_session detaches codex from the CLI's terminal group, so
+        a human's Ctrl+C never reaches it — the handler must group-kill before
+        propagating, or the interrupt itself orphans the tree."""
+        proc = _popen_mock(pid=54321)
+        proc.communicate.side_effect = [KeyboardInterrupt(), ("", "")]
+        with (
+            patch("genesis.contribution.review.shutil.which", return_value="/fake/codex"),
+            patch("genesis.contribution.review.subprocess.Popen", return_value=proc),
+            patch("genesis.util.proc_kill.os.killpg") as killpg,
+            pytest.raises(KeyboardInterrupt),
+        ):
+            review._try_codex("diff")
+        killpg.assert_called_once()
+        assert killpg.call_args.args[0] == 54321
+
+
+def test_codex_spawned_in_new_session():
+    """codex must be spawned with start_new_session=True (own group for the
+    tree-kill) and NOT via preexec_fn (post-fork Python deadlock risk)."""
+    captured: dict = {}
+
+    def _fake_popen(*args, **kwargs):
+        captured.update(kwargs)
+        return _popen_mock(_mk_codex_output("ok\nVERDICT: PASS"))
+
+    with (
+        patch("genesis.contribution.review.shutil.which", return_value="/fake/codex"),
+        patch("genesis.contribution.review.subprocess.Popen", side_effect=_fake_popen),
+    ):
+        r = review._try_codex("diff")
+    assert r is not None
+    assert captured.get("start_new_session") is True
+    assert "preexec_fn" not in captured
 
 
 def test_cc_reviewer_always_none():

--- a/tests/test_eval/test_gauntlet.py
+++ b/tests/test_eval/test_gauntlet.py
@@ -7,6 +7,7 @@ real on trivial in-test fixtures. Regression + file-lock logic is unit-tested.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -413,3 +414,61 @@ async def test_pass_only_clears_matching_model():
         assert prop["status"] == "pending"
     finally:
         await conn.close()
+
+
+class TestRunPytestBounded:
+    """_run_pytest's timeout kill must reap the whole process GROUP (pytest
+    can fork) with a BOUNDED reap — the old bare proc.kill() + unbounded
+    proc.wait() is the tree-leak/recovery-hang class fixed repo-wide."""
+
+    async def test_timeout_group_kills_and_returns(self, monkeypatch, tmp_path):
+        import asyncio as _asyncio
+
+        from genesis.eval import gauntlet as g
+
+        killpg_calls = []
+        monkeypatch.setattr(
+            "genesis.util.proc_kill.os.killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+        monkeypatch.setattr(g, "_PYTEST_TIMEOUT_S", 0.05)
+
+        proc = MagicMock()
+        proc.pid = 66666  # explicit — never a mock default (killpg(1) trap)
+        proc.returncode = None
+
+        async def _hang(*a, **k):
+            await _asyncio.sleep(600)
+
+        proc.communicate = _hang
+        proc.wait = AsyncMock(return_value=-9)
+
+        async def fake_exec(*args, **kwargs):
+            return proc
+
+        monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec)
+        rc, out = await g._run_pytest(tmp_path)
+        assert rc == -1
+        assert "timed out" in out
+        assert len(killpg_calls) == 1
+        assert killpg_calls[0][0] == 66666
+
+    async def test_spawned_in_new_session(self, monkeypatch, tmp_path):
+        import asyncio as _asyncio
+
+        from genesis.eval import gauntlet as g
+
+        captured = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured.update(kwargs)
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.communicate = AsyncMock(return_value=(b"1 passed", None))
+            return proc
+
+        monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec)
+        rc, out = await g._run_pytest(tmp_path)
+        assert rc == 0
+        assert captured.get("start_new_session") is True
+        assert "preexec_fn" not in captured

--- a/tests/test_eval/test_gauntlet.py
+++ b/tests/test_eval/test_gauntlet.py
@@ -472,3 +472,41 @@ class TestRunPytestBounded:
         assert rc == 0
         assert captured.get("start_new_session") is True
         assert "preexec_fn" not in captured
+
+    async def test_cancel_group_kills_and_reraises(self, monkeypatch, tmp_path):
+        """Ctrl+C during scoring: asyncio cancels _run_pytest, and with the
+        detached session the terminal SIGINT never reaches pytest — the
+        handler must group-kill before re-raising or the tree leaks
+        (Codex P2, PR #1415)."""
+        import asyncio as _asyncio
+
+        from genesis.eval import gauntlet as g
+
+        killpg_calls = []
+        monkeypatch.setattr(
+            "genesis.util.proc_kill.os.killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+
+        proc = MagicMock()
+        proc.pid = 66667
+        proc.returncode = None
+        started = _asyncio.Event()
+
+        async def _hang(*a, **k):
+            started.set()
+            await _asyncio.sleep(600)
+
+        proc.communicate = _hang
+        proc.wait = AsyncMock(return_value=-9)
+
+        async def fake_exec(*args, **kwargs):
+            return proc
+
+        monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec)
+        task = _asyncio.get_running_loop().create_task(g._run_pytest(tmp_path))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(_asyncio.CancelledError):
+            await task
+        assert killpg_calls and killpg_calls[0][0] == 66667

--- a/tests/test_eval/test_promptfoo.py
+++ b/tests/test_eval/test_promptfoo.py
@@ -72,3 +72,24 @@ async def test_spawned_in_new_session_not_preexec(tmp_path: Path):
     assert report.success is False  # rc=1 path — spawn shape is what we assert
     assert captured.get("start_new_session") is True
     assert "preexec_fn" not in captured
+
+
+@pytest.mark.asyncio
+async def test_keyboard_interrupt_kills_group_and_propagates(tmp_path: Path):
+    """subprocess.run killed the child on ANY exception (incl. Ctrl+C); the
+    Popen migration must preserve that — and with start_new_session the
+    terminal SIGINT no longer reaches the tree ambiently, so the handler is
+    the only thing standing between Ctrl+C and a leaked promptfoo tree."""
+    proc = _popen_mock()
+    proc.communicate.side_effect = [KeyboardInterrupt(), ("", "")]
+    with (
+        patch("genesis.eval.promptfoo.subprocess.Popen", return_value=proc),
+        patch("genesis.util.proc_kill.os.killpg") as killpg,
+        pytest.raises(KeyboardInterrupt),
+    ):
+        await compare_models(
+            model_a="a", model_b="b",
+            dataset_path=tmp_path / "ds.yaml", timeout_s=600,
+        )
+    killpg.assert_called_once()
+    assert killpg.call_args.args[0] == 61234

--- a/tests/test_eval/test_promptfoo.py
+++ b/tests/test_eval/test_promptfoo.py
@@ -1,0 +1,74 @@
+"""Tests for genesis.eval.promptfoo subprocess handling.
+
+promptfoo (``npx promptfoo`` → node → workers) is a launcher: on timeout the
+old ``subprocess.run`` kill reached only the direct child and orphaned the
+worker tree — the class fixed repo-wide by the spawn-hardening sweep.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from genesis.eval.promptfoo import compare_models
+
+
+def _popen_mock(pid: int = 61234) -> MagicMock:
+    m = MagicMock()
+    m.pid = pid  # explicit — never a mock default (the killpg(1) trap)
+    m.returncode = 0
+    m.communicate.return_value = ("", "")
+    return m
+
+
+@pytest.mark.asyncio
+async def test_timeout_returns_failed_report_and_group_kills(tmp_path: Path):
+    proc = _popen_mock()
+    proc.communicate.side_effect = [
+        subprocess.TimeoutExpired(cmd="promptfoo", timeout=1),
+        ("", ""),  # bounded drain
+    ]
+    with (
+        patch("genesis.eval.promptfoo.subprocess.Popen", return_value=proc),
+        patch("genesis.util.proc_kill.os.killpg") as killpg,
+    ):
+        report = await compare_models(
+            model_a="a",
+            model_b="b",
+            dataset_path=tmp_path / "ds.yaml",
+            timeout_s=1,
+        )
+    assert report.success is False
+    assert "timed out" in (report.error or "")
+    killpg.assert_called_once()
+    assert killpg.call_args.args[0] == 61234
+    proc.kill.assert_not_called()
+    # the drain was attempted bounded, not blocking
+    assert proc.communicate.call_args_list[1].kwargs.get("timeout") is not None
+
+
+@pytest.mark.asyncio
+async def test_spawned_in_new_session_not_preexec(tmp_path: Path):
+    captured: dict = {}
+
+    def _fake_popen(*args, **kwargs):
+        captured.update(kwargs)
+        m = _popen_mock()
+        # rc != 0 short-circuits before output-file parsing
+        m.returncode = 1
+        m.communicate.return_value = ("", "boom")
+        return m
+
+    with patch("genesis.eval.promptfoo.subprocess.Popen", side_effect=_fake_popen):
+        report = await compare_models(
+            model_a="a",
+            model_b="b",
+            dataset_path=tmp_path / "ds.yaml",
+            timeout_s=1,
+        )
+    assert report.success is False  # rc=1 path — spawn shape is what we assert
+    assert captured.get("start_new_session") is True
+    assert "preexec_fn" not in captured

--- a/tests/test_experimentation/test_cc_router.py
+++ b/tests/test_experimentation/test_cc_router.py
@@ -168,3 +168,44 @@ async def test_spawned_in_new_session_not_preexec(monkeypatch):
     assert res.success is True
     assert captured.get("start_new_session") is True
     assert "preexec_fn" not in captured
+
+
+async def test_route_call_cancel_group_kills_and_reraises(monkeypatch):
+    """Cancellation mid-call must group-kill the detached claude tree before
+    propagating (same class as the timeout path)."""
+    killpg_calls = []
+    monkeypatch.setattr(
+        "genesis.util.proc_kill.os.killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+    )
+    started = asyncio.Event()
+
+    class _HangProc:
+        returncode = None
+        pid = 77778
+
+        async def communicate(self, input=None):
+            started.set()
+            await asyncio.sleep(600)
+
+        def kill(self):
+            pass
+
+        async def wait(self):
+            self.returncode = -9
+
+    async def fake_exec(*a, **k):
+        return _HangProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    router = CCCliRouter("haiku", timeout_s=600)
+    task = asyncio.get_running_loop().create_task(
+        router.route_call("gen", [{"role": "user", "content": "U"}])
+    )
+    await started.wait()
+    task.cancel()
+    import pytest as _pytest
+
+    with _pytest.raises(asyncio.CancelledError):
+        await task
+    assert killpg_calls and killpg_calls[0][0] == 77778

--- a/tests/test_experimentation/test_cc_router.py
+++ b/tests/test_experimentation/test_cc_router.py
@@ -79,17 +79,26 @@ async def test_route_call_subprocess_raises(monkeypatch):
     assert "no claude binary" in (res.error or "")
 
 
-async def test_route_call_timeout_kills_subprocess(monkeypatch):
-    killed = {"v": False}
+async def test_route_call_timeout_group_kills_subprocess(monkeypatch):
+    """Timeout must SIGKILL the whole process GROUP (claude spawns MCP/helper
+    children — a bare proc.kill() orphans them), signalling proc.pid AS the
+    pgid, with the direct kill only as the guard fallback."""
+    killpg_calls = []
+    monkeypatch.setattr(
+        "genesis.util.proc_kill.os.killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+    )
+    direct_killed = {"v": False}
 
     class _HangProc:
         returncode = None
+        pid = 77777  # explicit — never a mock default (killpg(1) trap)
 
         async def communicate(self, input=None):
             await asyncio.sleep(10)  # exceed the tiny timeout
 
         def kill(self):
-            killed["v"] = True
+            direct_killed["v"] = True
 
         async def wait(self):
             self.returncode = -9
@@ -104,4 +113,58 @@ async def test_route_call_timeout_kills_subprocess(monkeypatch):
     )
     assert res.success is False
     assert res.error == "timeout"
-    assert killed["v"] is True  # the orphaned claude proc was reaped
+    assert killpg_calls == [(77777, __import__("signal").SIGKILL)]
+    assert direct_killed["v"] is False  # group kill, not the bare fallback
+
+
+async def test_route_call_timeout_pgid_guard(monkeypatch):
+    """A pid<=1 (mock default / pathological) must never reach killpg —
+    fall back to the direct kill."""
+    killpg_calls = []
+    monkeypatch.setattr(
+        "genesis.util.proc_kill.os.killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+    )
+    direct_killed = {"v": False}
+
+    class _HangProc:
+        returncode = None
+        pid = 1
+
+        async def communicate(self, input=None):
+            await asyncio.sleep(10)
+
+        def kill(self):
+            direct_killed["v"] = True
+
+        async def wait(self):
+            self.returncode = -9
+
+    async def fake_exec(*a, **k):
+        return _HangProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    res = await CCCliRouter("haiku", timeout_s=0.05).route_call(
+        "gen", [{"role": "user", "content": "U"}],
+    )
+    assert res.error == "timeout"
+    assert killpg_calls == []
+    assert direct_killed["v"] is True
+
+
+async def test_spawned_in_new_session_not_preexec(monkeypatch):
+    """claude must be spawned with start_new_session=True (own group so the
+    timeout tree-kill can killpg it) and never via preexec_fn."""
+    captured = {}
+
+    async def fake_exec(*args, **kw):
+        captured.update(kw)
+        return _FakeProc(out=b"fine")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    res = await CCCliRouter("haiku").route_call("gen", [{"role": "user", "content": "U"}])
+    assert res.success is True
+    assert captured.get("start_new_session") is True
+    assert "preexec_fn" not in captured

--- a/tests/test_guardian/test_diagnosis.py
+++ b/tests/test_guardian/test_diagnosis.py
@@ -489,3 +489,106 @@ class TestInfraSectionIntegration:
         prompt = _build_diagnosis_prompt(_snap(container_status="Running"), "", "genesis")
         assert "Infrastructure Body Schema" not in prompt
         assert "Genesis Guardian" in prompt
+
+
+class TestCCSubprocessTreeKill:
+    """The recovery-brain `claude -p` is an agentic launcher (forks tool/MCP
+    children). Its timeout kill must reap the whole GROUP with a BOUNDED reap
+    — a leaked claude tree on the host has no genesis-server cgroup to clean
+    it. Same for the `claude auth status` pre-flight probe."""
+
+    @pytest.mark.asyncio
+    async def test_diagnosis_timeout_group_kills(self, tmp_path, monkeypatch) -> None:
+        import asyncio as _asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        from genesis.guardian.diagnosis import CCDiagnosisError
+
+        killpg_calls = []
+        monkeypatch.setattr(
+            "genesis.util.proc_kill.os.killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+
+        config = GuardianConfig()
+        config.cc.timeout_s = 1
+        config.cc.work_dir = str(tmp_path)
+        engine = DiagnosisEngine(config)
+        # The disk preflight probes the pool via its own subprocess — with
+        # create_subprocess_exec faked below it would "assume full" and refuse
+        # before ever spawning CC. Pin it healthy; the spawn is what we test.
+        monkeypatch.setattr(
+            "genesis.guardian.snapshots.SnapshotManager.check_pool_space",
+            AsyncMock(return_value=10.0),
+        )
+        # The auth pre-flight would also hit the faked hanging exec; pin it
+        # to the inherit-env default so the test reaches the diagnosis spawn.
+        monkeypatch.setattr(
+            "genesis.guardian.diagnosis.DiagnosisEngine._resolve_cc_env",
+            AsyncMock(return_value=None),
+        )
+
+        captured: dict = {}
+        proc = MagicMock()
+        proc.pid = 55555  # explicit — never a mock default (killpg(1) trap)
+        proc.returncode = None
+
+        async def _hang(*a, **k):
+            await _asyncio.sleep(600)
+
+        proc.communicate = _hang
+        proc.wait = AsyncMock(return_value=-9)
+
+        async def fake_exec(*args, **kwargs):
+            captured.update(kwargs)
+            return proc
+
+        monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec)
+        snap = _snap(container_status="Running")
+        with pytest.raises(CCDiagnosisError, match="timed out"):
+            await engine._diagnose_with_cc(snap, "signal summary")
+        assert len(killpg_calls) == 1
+        assert killpg_calls[0][0] == 55555
+        assert captured.get("start_new_session") is True
+        assert "preexec_fn" not in captured
+
+    @pytest.mark.asyncio
+    async def test_auth_probe_timeout_group_kills(self, tmp_path, monkeypatch) -> None:
+        import asyncio as _asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        killpg_calls = []
+        monkeypatch.setattr(
+            "genesis.util.proc_kill.os.killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+        # shrink the probe's 15s bound so the test is fast
+        monkeypatch.setattr(
+            "genesis.guardian.diagnosis._AUTH_PROBE_TIMEOUT_S", 0.05, raising=True,
+        )
+
+        config = GuardianConfig()
+        engine = DiagnosisEngine(config)
+
+        captured: dict = {}
+        proc = MagicMock()
+        proc.pid = 55556
+        proc.returncode = None
+
+        async def _hang(*a, **k):
+            await _asyncio.sleep(600)
+
+        proc.communicate = _hang
+        proc.wait = AsyncMock(return_value=-9)
+
+        async def fake_exec(*args, **kwargs):
+            captured.update(kwargs)
+            return proc
+
+        monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec)
+        env = await engine._resolve_cc_env("claude")
+        assert env is None  # ambiguous probe → inherit (unchanged contract)
+        assert len(killpg_calls) == 1
+        assert killpg_calls[0][0] == 55556
+        assert captured.get("start_new_session") is True
+        assert "preexec_fn" not in captured

--- a/tests/test_guardian/test_diagnosis.py
+++ b/tests/test_guardian/test_diagnosis.py
@@ -592,3 +592,37 @@ class TestCCSubprocessTreeKill:
         assert killpg_calls[0][0] == 55556
         assert captured.get("start_new_session") is True
         assert "preexec_fn" not in captured
+
+    @pytest.mark.asyncio
+    async def test_auth_probe_cancel_group_kills_and_reraises(self, monkeypatch) -> None:
+        import asyncio as _asyncio
+        from unittest.mock import AsyncMock, MagicMock
+
+        killpg_calls = []
+        monkeypatch.setattr(
+            "genesis.util.proc_kill.os.killpg",
+            lambda pgid, sig: killpg_calls.append((pgid, sig)),
+        )
+        proc = MagicMock()
+        proc.pid = 55557
+        proc.returncode = None
+        started = _asyncio.Event()
+
+        async def _hang(*a, **k):
+            started.set()
+            await _asyncio.sleep(600)
+
+        proc.communicate = _hang
+        proc.wait = AsyncMock(return_value=-9)
+
+        async def fake_exec(*args, **kwargs):
+            return proc
+
+        monkeypatch.setattr(_asyncio, "create_subprocess_exec", fake_exec)
+        engine = DiagnosisEngine(GuardianConfig())
+        task = _asyncio.get_running_loop().create_task(engine._resolve_cc_env("claude"))
+        await started.wait()
+        task.cancel()
+        with pytest.raises(_asyncio.CancelledError):
+            await task
+        assert killpg_calls and killpg_calls[0][0] == 55557

--- a/tests/test_session_awareness/test_headless.py
+++ b/tests/test_session_awareness/test_headless.py
@@ -7,13 +7,13 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import textwrap
 from pathlib import Path
 
 import pytest
 
 from genesis.session_awareness.headless import build_argv, run_headless_json
+from tests.proc_asserts import process_terminated
 
 MODEL = "claude-haiku-4-5-20251001"
 
@@ -105,8 +105,7 @@ async def test_timeout_group_kills_children(tmp_path):
     child_pid = int(marker.read_text())
     assert child_pid > 1  # explicit pid, never a mocked default
     await asyncio.sleep(0.2)  # let SIGKILL land
-    with pytest.raises(ProcessLookupError):
-        os.kill(child_pid, 0)  # signal 0 = existence probe
+    assert process_terminated(child_pid)  # gone-or-zombie (tests/proc_asserts)
 
 
 @pytest.mark.asyncio
@@ -134,8 +133,7 @@ async def test_timeout_reaps_grandchild_after_leader_exits(tmp_path):
     child_pid = int(marker.read_text())
     assert child_pid > 1
     await asyncio.sleep(0.3)  # let SIGKILL land
-    with pytest.raises(ProcessLookupError):
-        os.kill(child_pid, 0)
+    assert process_terminated(child_pid)  # gone-or-zombie (tests/proc_asserts)
 
 
 @pytest.mark.asyncio
@@ -197,3 +195,42 @@ async def test_timeout_reap_is_bounded(monkeypatch):
         timeout=10,  # the test bound: recovery must not hang
     )
     assert res == {"status": "timeout"}
+
+
+@pytest.mark.asyncio
+async def test_cancel_group_kills_and_reraises(monkeypatch):
+    """Task cancellation mid-call must group-kill the detached claude tree
+    before propagating — with its own session, no ambient signal reaches it."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    killpg_calls = []
+    monkeypatch.setattr(
+        "genesis.util.proc_kill.os.killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+    )
+    proc = MagicMock()
+    proc.pid = 424243
+    started = asyncio.Event()
+
+    async def _hang(*a, **k):
+        started.set()
+        await asyncio.sleep(600)
+
+    proc.communicate = _hang
+    proc.wait = AsyncMock(return_value=-9)
+
+    async def fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    task = asyncio.get_running_loop().create_task(
+        run_headless_json(
+            "p", model=MODEL, claude_path="claude",
+            no_mcp_config="/dev/null", timeout_s=600,
+        )
+    )
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert killpg_calls and killpg_calls[0][0] == 424243

--- a/tests/test_session_awareness/test_headless.py
+++ b/tests/test_session_awareness/test_headless.py
@@ -107,3 +107,93 @@ async def test_timeout_group_kills_children(tmp_path):
     await asyncio.sleep(0.2)  # let SIGKILL land
     with pytest.raises(ProcessLookupError):
         os.kill(child_pid, 0)  # signal 0 = existence probe
+
+
+@pytest.mark.asyncio
+async def test_timeout_reaps_grandchild_after_leader_exits(tmp_path):
+    """The leader EXITS while its grandchild holds the stdout pipe (so
+    communicate() never EOFs and the timeout fires). asyncio reaps the dead
+    leader, so an os.getpgid(proc.pid)-based kill raises ProcessLookupError
+    and the proc.kill() fallback no-ops — leaking the grandchild. The kill
+    must signal proc.pid AS the pgid (kernel reserves it while any member
+    lives) so the grandchild is reaped."""
+    marker = tmp_path / "child_pid"
+    fake = _fake_claude(
+        tmp_path,
+        f"""
+        import subprocess, sys
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(600)"])
+        open({str(marker)!r}, "w").write(str(child.pid))
+        sys.exit(0)  # leader exits; grandchild inherited stdout, pipe stays open
+        """,
+    )
+    res = await run_headless_json(
+        "p", model=MODEL, claude_path=fake, no_mcp_config="/dev/null", timeout_s=2
+    )
+    assert res == {"status": "timeout"}
+    child_pid = int(marker.read_text())
+    assert child_pid > 1
+    await asyncio.sleep(0.3)  # let SIGKILL land
+    with pytest.raises(ProcessLookupError):
+        os.kill(child_pid, 0)
+
+
+@pytest.mark.asyncio
+async def test_spawned_in_new_session_not_preexec(monkeypatch):
+    """The subprocess must get its own group via start_new_session=True
+    (setsid in the C helper) and NOT preexec_fn (arbitrary post-fork Python
+    can deadlock in the multi-threaded server)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    captured: dict = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured.update(kwargs)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"{}", b""))
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    res = await run_headless_json(
+        "p", model=MODEL, claude_path="claude", no_mcp_config="/dev/null", timeout_s=5
+    )
+    assert res["status"] == "ok"
+    assert captured.get("start_new_session") is True
+    assert "preexec_fn" not in captured
+
+
+@pytest.mark.asyncio
+async def test_timeout_reap_is_bounded(monkeypatch):
+    """After the group kill, the reap of the dead leader must be BOUNDED —
+    a paused pipe transport can stall an unbounded proc.wait() forever,
+    turning the timeout recovery itself into a hang."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setattr("genesis.util.proc_kill.os.killpg", lambda *a: None)
+    monkeypatch.setattr("genesis.util.proc_kill.DEFAULT_REAP_TIMEOUT_S", 0.2, raising=True)
+
+    proc = MagicMock()
+    proc.pid = 424242  # explicit — never a mock default (killpg(1) trap)
+
+    async def _hang(*a, **k):
+        await asyncio.sleep(600)
+
+    proc.communicate = _hang
+    proc.wait = _hang  # unbounded reap would hang here forever
+
+    async def fake_exec(*args, **kwargs):
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    res = await asyncio.wait_for(
+        run_headless_json(
+            "p",
+            model=MODEL,
+            claude_path="claude",
+            no_mcp_config="/dev/null",
+            timeout_s=0.1,
+        ),
+        timeout=10,  # the test bound: recovery must not hang
+    )
+    assert res == {"status": "timeout"}

--- a/tests/test_util/test_proc_kill.py
+++ b/tests/test_util/test_proc_kill.py
@@ -1,0 +1,122 @@
+"""Tests for genesis.util.proc_kill — the shared process-group kill helpers.
+
+Real-subprocess tests lock the two behaviors that matter (whole-group reap,
+and reap-after-the-leader-was-reaped — the getpgid trap from PR #1409 round
+3); mock tests lock the pgid<=1 safety guard (killpg(1) == kill every process
+we own — see the process_kill_safety procedure).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import subprocess
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from genesis.util.proc_kill import kill_process_group, reap_bounded
+
+
+def _group_alive(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def test_kills_whole_group_while_leader_alive(tmp_path):
+    marker = tmp_path / "child"
+    proc = subprocess.Popen(
+        ["bash", "-c", f"sleep 300 & echo $! > {marker}; sleep 300"],
+        start_new_session=True,
+    )
+    try:
+        deadline = time.monotonic() + 5
+        while not marker.exists() and time.monotonic() < deadline:
+            time.sleep(0.05)
+        child = int(marker.read_text().strip())
+        assert child > 1
+        kill_process_group(proc)
+        proc.wait(timeout=5)
+        time.sleep(0.2)
+        assert not _group_alive(proc.pid)
+        with pytest.raises(ProcessLookupError):
+            os.kill(child, 0)
+    finally:
+        kill_process_group(proc)
+
+
+def test_kills_survivors_after_leader_reaped(tmp_path):
+    """The leader exits and is waited on (reaped) while a child keeps the
+    group alive. os.getpgid(leader) would raise here; signalling proc.pid AS
+    the pgid must still reap the survivor (kernel reserves the pgid)."""
+    marker = tmp_path / "child"
+    proc = subprocess.Popen(
+        ["bash", "-c", f"sleep 300 & echo $! > {marker}; exit 0"],
+        start_new_session=True,
+    )
+    proc.wait(timeout=5)  # leader reaped — getpgid(proc.pid) now raises
+    deadline = time.monotonic() + 5
+    while not marker.exists() and time.monotonic() < deadline:
+        time.sleep(0.05)
+    child = int(marker.read_text().strip())
+    assert child > 1
+    with pytest.raises(ProcessLookupError):
+        os.getpgid(proc.pid)  # precondition: the trap is armed
+    kill_process_group(proc)
+    time.sleep(0.3)
+    with pytest.raises(ProcessLookupError):
+        os.kill(child, 0)
+
+
+def test_pgid_guard_refuses_low_pid(monkeypatch):
+    killed = []
+    monkeypatch.setattr(
+        "genesis.util.proc_kill.os.killpg",
+        lambda *a: killed.append(a),
+    )
+    proc = MagicMock()
+    proc.pid = 1
+    kill_process_group(proc)
+    assert killed == []
+    proc.kill.assert_called_once()
+
+
+def test_pgid_guard_refuses_non_int_pid(monkeypatch):
+    killed = []
+    monkeypatch.setattr(
+        "genesis.util.proc_kill.os.killpg",
+        lambda *a: killed.append(a),
+    )
+    proc = MagicMock()  # .pid left as a MagicMock attribute, not an int
+    kill_process_group(proc)
+    assert killed == []
+    proc.kill.assert_called_once()
+
+
+def test_killpg_signal_and_pid(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "genesis.util.proc_kill.os.killpg",
+        lambda pgid, sig: calls.append((pgid, sig)),
+    )
+    proc = MagicMock()
+    proc.pid = 54321
+    kill_process_group(proc)
+    assert calls == [(54321, signal.SIGKILL)]
+    proc.kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reap_bounded_returns_despite_hung_wait():
+    class _Hung:
+        async def wait(self):
+            await asyncio.sleep(600)
+
+    t0 = time.monotonic()
+    await reap_bounded(_Hung(), timeout_s=0.1)
+    assert time.monotonic() - t0 < 5

--- a/tests/test_util/test_proc_kill.py
+++ b/tests/test_util/test_proc_kill.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from genesis.util.proc_kill import kill_process_group, reap_bounded
+from tests.proc_asserts import process_terminated
 
 
 def _group_alive(pgid: int) -> bool:
@@ -36,16 +37,16 @@ def test_kills_whole_group_while_leader_alive(tmp_path):
     )
     try:
         deadline = time.monotonic() + 5
-        while not marker.exists() and time.monotonic() < deadline:
+        while time.monotonic() < deadline and not (marker.exists() and marker.read_text().strip()):
             time.sleep(0.05)
         child = int(marker.read_text().strip())
         assert child > 1
         kill_process_group(proc)
         proc.wait(timeout=5)
         time.sleep(0.2)
-        assert not _group_alive(proc.pid)
-        with pytest.raises(ProcessLookupError):
-            os.kill(child, 0)
+        # gone-or-zombie: os.kill(pid, 0) succeeds on a zombie, so a bare
+        # ProcessLookupError assertion flakes on minimal-init hosts
+        assert process_terminated(child)
     finally:
         kill_process_group(proc)
 
@@ -61,7 +62,7 @@ def test_kills_survivors_after_leader_reaped(tmp_path):
     )
     proc.wait(timeout=5)  # leader reaped — getpgid(proc.pid) now raises
     deadline = time.monotonic() + 5
-    while not marker.exists() and time.monotonic() < deadline:
+    while time.monotonic() < deadline and not (marker.exists() and marker.read_text().strip()):
         time.sleep(0.05)
     child = int(marker.read_text().strip())
     assert child > 1
@@ -69,8 +70,7 @@ def test_kills_survivors_after_leader_reaped(tmp_path):
         os.getpgid(proc.pid)  # precondition: the trap is armed
     kill_process_group(proc)
     time.sleep(0.3)
-    with pytest.raises(ProcessLookupError):
-        os.kill(child, 0)
+    assert process_terminated(child)  # gone-or-zombie (see tests/proc_asserts)
 
 
 def test_pgid_guard_refuses_low_pid(monkeypatch):


### PR DESCRIPTION
## Problem

Eight subprocess spawn sites run LAUNCHERS that fork their own children (codex/claude → node workers, MCP servers, tool children; promptfoo → node workers; pytest; forking step commands; git push → ssh/credential helpers). On timeout, the old kills reached only the direct child — the rest of the tree reparented to pid 1 and kept running (and spending) until reboot. Two of the sites were worse:

- `autonomy/executor/engine.py`'s delivery `git push` had **no timeout at all** while running under the executor's `Semaphore(1)` — a network-stalled push wedges all autonomy task execution (the same class #1409 closed for the codex verify link; the `_git` helper 130 lines below it already had a 60s bound with a comment citing exactly this rationale).
- `session_awareness/headless.py` had a tree-kill, but with both patterns #1409's review rounds retired: `preexec_fn=os.setpgrp` (post-fork deadlock risk in the threaded server) and `os.getpgid(proc.pid)` (raises once the leader is reaped → the fallback `proc.kill()` no-ops → descendants leak), plus an unbounded post-kill `wait()`.

## Fix

New shared helper **`genesis/util/proc_kill.py`** — the #1409-hardened pattern, one copy:
- spawn with `start_new_session=True` (setsid in the C helper; never `preexec_fn`),
- `kill_process_group(proc)`: `killpg` on `proc.pid` **directly** as the pgid (the kernel reserves it while any member lives — immune to the leader-reaped race), non-int/`<=1` pid guard → direct-kill fallback, vanished-group = silent success, genuine OS refusal = logged fallback,
- `reap_bounded(proc)`: post-kill reap bounded at 30s.

Applied to: `contribution/review.py::_try_codex` (run→Popen; also group-kills on **Ctrl+C**, since `start_new_session` detaches codex from the CLI's terminal group), `session_awareness/headless.py`, `experimentation/cc_router.py` (had no tree-kill at all), `autonomy/executor/engine.py` (extracted `_run_git_push`, 300s bound, degrades to the existing "Branch push failed" path), `autonomy/executor/deterministic.py`, `guardian/diagnosis.py` (recovery-brain spawn + auth-status probe), `eval/promptfoo.py`, `eval/gauntlet.py` (`_run_pytest`). `autonomy/executor/review.py` migrated off its private copy of the helper (drift risk; its guard also mishandled non-int pids).

## Tests / verification

- **Verify-RED throughout**: 23 tests seen failing on the pre-fix code first, including two real-subprocess reproductions (headless leader-exits leak; deterministic forked-grandchild orphan — the latter additionally mutation-verified: old kill → grandchild survives, new → reaped).
- Per-site: timeout→killpg(pid-as-pgid) spies with explicit mock pids, `pgid<=1` guard refusals, bounded-drain/reap assertions, spawn-kwargs locks (`start_new_session=True`, no `preexec_fn`), Ctrl+C group-kill propagation.
- **2580 tests green** across all seven touched test directories; ruff clean.
- **Live E2E with real process trees**: hung-tree, leader-exits, and cc_router cases all fully reaped in ~2s with zero survivors — including re-running both #1409 harnesses against the migrated shared-util path.

## Review

genesis-architect adversarial audit: SHIP-WITH-FIXES — all findings addressed in-branch: F1 (its class-completeness catch: the three guardian/eval sites above were missed by my first sweep and are now included, each verify-RED), F2 (the private-copy migration), F3 (logged killpg fallback). F4/F5 accepted as documented NOTEs (Ctrl+C residuals are self-limiting: SIGKILL of the CLI or an interrupt in the spawn→try window still EOFs codex's stdin and `codex exec` runs a finite job).

Deploy notes: several touched modules are server-imported → server restart on deploy. `guardian/diagnosis.py` reaches the host only via guardian redeploy (tracked for the deploy step, not assumed).

Ledger: 1e0b2ae1e74e4ac7940a1680f4442bdc
Follow-up: 33c6d4982dc14e3b9160a87c283aeabf

🤖 Generated with [Claude Code](https://claude.com/claude-code)