### PR TITLE
feat(hooks): mandatory scheduled-Claude-review merge gate

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -819,15 +819,17 @@ findings below, a gated `gh pr merge`:
   touch-up) — the merge is then still bound to the exact head that was
   classified. A substantial or unclassifiable delta blocks; an ABSENT review
   always blocks;
-- requires a **scheduled Claude review at the current head**. A scheduled Claude
-  review (a `/schedule` cloud routine) posts as the repo OWNER's account and must
-  carry the marker `<!-- genesis-scheduled-review: head=<full-40-hex-sha> -->`
-  naming the exact head it reviewed. The gate blocks unless an owner-authored
-  marker names the PR's current head — so a review that never ran, ran on a stale
-  commit, or was rate-limited cannot slip a merge through. If it's pending or rate-
-  limited, wait for it, or append `# scheduled-review-override` to merge anyway
-  (the conscious "merge without a scheduled review" case). Fail-closed: an
-  unreadable comments/reviews fetch BLOCKS (never a false all-clear);
+- requires **every scheduled Claude review at the current head**. Each scheduled
+  Claude review (a `/schedule` cloud routine) posts as the repo OWNER's account and
+  must carry a marker `<!-- genesis-scheduled-review: head=<full-40-hex-sha> kind=<name> -->`
+  naming the exact head it reviewed AND which routine it is (`kind`). The gate blocks
+  unless an owner-authored marker for EVERY kind in `_REQUIRED_SCHEDULED_REVIEW_KINDS`
+  (currently `code-review` + `leaks`) names the PR's current head — so if any required
+  routine never ran, ran on a stale commit, or was rate-limited, the merge blocks
+  (naming the missing kinds). If a routine is pending or rate-limited, wait for it, or
+  append `# scheduled-review-override` to merge anyway (the conscious "merge without the
+  scheduled reviews" case). Fail-closed: an unreadable comments/reviews fetch BLOCKS
+  (never a false all-clear);
 - requires the PR base to equal the repo's default branch (retarget guard);
 - blocks unless mergeability is a definite `MERGEABLE` (a failed/unknown read
   does not merge).

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -788,8 +788,11 @@ outlives its incident is a bug.
 **Canonical pre-merge check:** run
 `python3 scripts/hooks/git_push_guard.py --check-pr <N> [--repo OWNER/REPO]`
 BEFORE proposing a merge. It runs the SAME functions the enforcement gate uses
-(mergeable → CI → base-invariant → Codex-freshness → review-body → inline
-findings), so the report and the gate can never disagree — never hand-roll a
+(mergeable → CI → base-invariant → Codex-freshness → scheduled-Claude-review →
+review-body → inline findings), so the report and the gate can never disagree —
+this `--check-pr` read IS the mandatory pre-merge step: **always run it and read
+the PR's automated-review comments (Codex, leak/CI, the scheduled Claude review)
+before any merge** — never hand-roll a
 gh/jq review check (a hand-rolled query once used the GraphQL bot login on the
 REST endpoint, matched nothing, and reported "Codex clean" while P2s sat unread).
 When all gates pass it prints the exact atomic merge command to copy
@@ -816,13 +819,23 @@ findings below, a gated `gh pr merge`:
   touch-up) — the merge is then still bound to the exact head that was
   classified. A substantial or unclassifiable delta blocks; an ABSENT review
   always blocks;
+- requires a **scheduled Claude review at the current head**. A scheduled Claude
+  review (a `/schedule` cloud routine) posts as the repo OWNER's account and must
+  carry the marker `<!-- genesis-scheduled-review: head=<full-40-hex-sha> -->`
+  naming the exact head it reviewed. The gate blocks unless an owner-authored
+  marker names the PR's current head — so a review that never ran, ran on a stale
+  commit, or was rate-limited cannot slip a merge through. If it's pending or rate-
+  limited, wait for it, or append `# scheduled-review-override` to merge anyway
+  (the conscious "merge without a scheduled review" case). Fail-closed: an
+  unreadable comments/reviews fetch BLOCKS (never a false all-clear);
 - requires the PR base to equal the repo's default branch (retarget guard);
 - blocks unless mergeability is a definite `MERGEABLE` (a failed/unknown read
   does not merge).
 - **Override sigils are split by boundary** so one waiver can't silently disarm
   an unrelated gate: `# review-override` waives ONLY the finding scans
   (review-body + inline P1s); `# stale-review-override` waives ONLY the
-  review-context gates (Codex-at-head freshness + base-invariant); CI is
+  review-context gates (Codex-at-head freshness + base-invariant);
+  `# scheduled-review-override` waives ONLY the scheduled-Claude-review gate; CI is
   `# ci-override`. Append several sigils in one trailing comment when several
   waivers are genuinely intended — but the right fix for a stale review is
   `@codex review`, not the sigil.

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -828,8 +828,10 @@ findings below, a gated `gh pr merge`:
   routine never ran, ran on a stale commit, or was rate-limited, the merge blocks
   (naming the missing kinds). If a routine is pending or rate-limited, wait for it, or
   append `# scheduled-review-override` to merge anyway (the conscious "merge without the
-  scheduled reviews" case). Fail-closed: an unreadable comments/reviews fetch BLOCKS
-  (never a false all-clear);
+  scheduled reviews" case). The marker means "ran **clean**", not merely "ran": a
+  review whose body carries a blocking finding (`[P1]`/`HARD BLOCK`/`### ERROR`, unless a
+  clean verdict overrides) is rejected, and DISMISSED/PENDING(draft) reviews don't count.
+  Fail-closed: an unreadable comments/reviews fetch BLOCKS (never a false all-clear);
 - requires the PR base to equal the repo's default branch (retarget guard);
 - blocks unless mergeability is a definite `MERGEABLE` (a failed/unknown read
   does not merge).

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -38,9 +38,30 @@ exceed the model (defense-in-depth), which is fine; they are not an invitation t
 chase every argv-shaping edge. Conscious escapes are split by boundary so one
 waiver cannot silently disarm an unrelated gate: ``# review-override`` waives the
 FINDING scans (review-body + inline P1s), ``# stale-review-override`` waives the
-review-CONTEXT gates (Codex-at-head freshness + base-is-default), and
+review-CONTEXT gates (Codex-at-head freshness + base-is-default),
+``# scheduled-review-override`` waives the SCHEDULED-Claude-review-at-head gate, and
 ``# ci-override`` waives the CI gate. A session that genuinely needs several
 appends several (one trailing comment may carry multiple sigils).
+
+Scheduled Claude review marker
+------------------------------
+A "scheduled Claude review" runs on the repo OWNER's GitHub account (NOT a bot) and
+must post a comment (issue comment) or PR review whose body contains the marker
+``<!-- genesis-scheduled-review: head=<full-40-hex-sha> -->`` naming the exact head
+commit it reviewed. The merge gate (``_check_scheduled_claude_reviewed_head``) blocks
+unless such a marker, authored by the owner, names the PR's CURRENT head — so a review
+that never ran, ran on a stale commit, or was rate-limited cannot slip a merge through.
+On the normal path this is ATOMIC: the Codex-freshness gate's ``--match-head-commit``
+binding pins the merge to the very head the marker was verified at, so a race with a new
+push cannot swap in an unreviewed head. Under ``# stale-review-override`` (which waives
+that binding for ALL gates — a conscious "merge without current verification" choice) the
+scheduled check is point-in-time, matching the reduced posture the operator already opted
+into; it is not additionally head-bound there.
+The marker is the trust anchor (single-author, non-adversarial threat model): this gate
+defends against a review that did not run at HEAD, NOT against the owner's own review
+automation being manipulated (e.g. prompt-injected by attacker-controlled PR content) into
+posting a false marker — that guarantee lives in the scheduled-review producer, which must
+not treat untrusted PR content as instructions when composing its comment body.
 """
 
 from __future__ import annotations
@@ -1497,6 +1518,180 @@ def _check_codex_reviewed_head(
     return False, "", head
 
 
+# ── Scheduled Claude review FRESHNESS (a review by the repo OWNER, at HEAD) ──
+# A separate, always-fail-closed gate: a "scheduled Claude review" runs on the repo
+# OWNER's account (NOT a bot) and posts a comment/review body carrying the marker
+# ``<!-- genesis-scheduled-review: head=<full-40-hex-sha> -->``. The gate blocks a
+# merge unless such a marker — authored by the owner — names the PR's CURRENT head.
+# The marker is the trust anchor (single-author, non-adversarial model): a spoofed
+# marker needs the owner's account. Waived by ``# scheduled-review-override`` (the
+# conscious "merge without a scheduled review" case — it didn't run / is rate-limited).
+_SCHEDULED_REVIEW_MARKER_RE = re.compile(
+    r"<!--\s*genesis-scheduled-review:\s*head=([0-9a-f]{40})\s*-->"
+)
+
+
+def _parse_scheduled_jsonl(raw: str | None) -> list[dict]:
+    """Parse the ``{login, author_association, body}`` JSONL shape into a list of
+    dicts, SKIPPING any malformed/non-object line (fail-closed: a dropped line can
+    only make a marker go UNSEEN → a false block, never a false pass). Mirrors
+    ``_codex_reviews``' per-line tolerance."""
+    rows: list[dict] = []
+    for line in (raw or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(obj, dict):
+            rows.append(obj)
+    return rows
+
+
+def _scheduled_review_rows(pr_num: str, repo: str | None = None) -> list[dict] | None:
+    """Combined ``{login, author_association, body}`` rows from BOTH the PR's issue
+    comments AND its review bodies, or ``None`` on any API error (distinct from an
+    empty list = query succeeded, nothing there — the caller fail-closes on both, but
+    the None case is the UNREADABLE one).
+
+    Both endpoints are ``--paginate``d (a marker beyond the first REST page must still
+    count). If EITHER endpoint fails to read, the whole result is ``None``: a marker we
+    could not see must not be assumed absent-and-safe — it is UNREADABLE, and this gate
+    fails closed. Test seam: ``_TEST_GH_SCHEDULED_COMMENTS`` (one JSON object per line,
+    combining both sources) is read INSTEAD of gh when set — mirrors
+    ``_TEST_GH_CODEX_COMMENTS``. Fail-safe: None on any subprocess/exception.
+    """
+    raw = os.environ.get("_TEST_GH_SCHEDULED_COMMENTS")
+    if raw is not None:
+        return _parse_scheduled_jsonl(raw)
+    rows: list[dict] = []
+    for path in (
+        f"repos/{repo or ':owner/:repo'}/issues/{pr_num}/comments",
+        f"repos/{repo or ':owner/:repo'}/pulls/{pr_num}/reviews",
+    ):
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    path,
+                    "--paginate",
+                    "--jq",
+                    ".[] | {login: .user.login, author_association: .author_association, "
+                    "body: .body}",
+                ],
+                capture_output=True,
+                text=True,
+                # See the merge-path timeout budget note in main(): fail-safe → None.
+                timeout=_gh_timeout(8),
+            )
+            if result.returncode != 0:
+                return None
+        except Exception:
+            return None
+        rows.extend(_parse_scheduled_jsonl(result.stdout))
+    return rows
+
+
+def _scheduled_review_head_shas(pr_num: str, repo: str | None = None) -> set[str] | None:
+    """The SET of full 40-hex head shas named in valid scheduled-review markers on the
+    PR, or ``None`` on an UNREADABLE fetch (the caller fail-closes on both None and an
+    empty set — None only distinguishes "could not read" from "read, no marker").
+
+    A marker is trusted only when its author is the repo OWNER: ``login == owner`` OR
+    ``author_association == "OWNER"`` (belt-and-suspenders — the marker itself is the
+    trust anchor in the single-author, non-adversarial model). The owner login is the
+    first segment of ``(repo or derived)``; ``derived`` is gh's repo for the cwd when no
+    explicit repo was passed. When the owner cannot be determined the ``login`` arm is
+    simply never satisfied and the ``author_association`` arm still gates.
+    """
+    rows = _scheduled_review_rows(pr_num, repo=repo)
+    if rows is None:
+        return None
+    try:
+        owner_repo = repo or _derive_repo_from_cwd(os.getcwd())
+    except Exception:
+        owner_repo = repo
+    owner = (owner_repo.split("/")[0] if owner_repo else "").lower() or None
+    shas: set[str] = set()
+    for row in rows:
+        login = (row.get("login") or "").lower()
+        assoc = (row.get("author_association") or "").upper()
+        if login != owner and assoc != "OWNER":
+            continue  # not the repo owner — not a trusted scheduled review
+        body = row.get("body") or ""
+        # Defense-in-depth follow-up: for rows sourced from /pulls/N/reviews we could
+        # ALSO cross-check GitHub's authoritative `commit_id` against the marker sha
+        # (issue comments carry no commit_id). Deferred (LOW): the marker sha is already
+        # matched EXACTLY against the authoritative HEAD by the caller, so a stale marker
+        # cannot pass; this would only catch a buggy reviewer templating a wrong sha.
+        for sha in _SCHEDULED_REVIEW_MARKER_RE.findall(body):
+            shas.add(sha.lower())
+    return shas
+
+
+def _check_scheduled_claude_reviewed_head(
+    pr_num: str,
+    head_sha: str | None = None,
+    repo: str | None = None,
+    *,
+    force: bool = False,
+    strict: bool = False,
+) -> str | None:
+    """Block a merge unless a scheduled Claude review (by the repo OWNER) has run on
+    the PR's CURRENT head. Returns ``None`` when a valid marker names ``head_sha``
+    exactly (full 40-char), else a BLOCK MESSAGE string.
+
+    Fail-CLOSED in BOTH modes — this gate never passes on absence of positive
+    evidence: if the head cannot be read, or the comment/review fetch errors
+    (``_scheduled_review_head_shas`` → None), the merge is BLOCKED. A read that simply
+    does not name this head (the review didn't run, ran on a stale commit, or was
+    rate-limited) also blocks. ``strict`` is accepted for interface parity with the
+    finding scanners (``check_pr_report`` passes it); the block/pass decision is
+    identical in both modes precisely BECAUSE enforcement already fails closed, so the
+    report can never issue a false all-clear here.
+
+    ``head_sha`` (the caller's authoritative head) is used when given; otherwise the
+    head is read via ``_pr_head_sha`` (so ``check_pr_report`` and a stale-review-forced
+    merge can both call it without a head in hand). ``force`` (a
+    ``# scheduled-review-override`` on the merge segment — an INDEPENDENT sigil from
+    ``# stale-review-override``, which waives the Codex freshness gate) waives this gate
+    for the conscious "merge without a scheduled review" case (e.g. it is down / rate
+    limited).
+    """
+    if force:
+        return None  # waived by # scheduled-review-override
+    head = (head_sha or "").strip().lower()
+    if not head:
+        head = (_pr_head_sha(pr_num, repo=repo) or "").strip().lower()
+    if not head:
+        return (
+            f"could not read PR #{pr_num}'s head commit to verify a scheduled Claude "
+            f"review (GitHub query failed).\n"
+            f"Retry, or append '# scheduled-review-override' to merge anyway."
+        )
+    shas = _scheduled_review_head_shas(pr_num, repo=repo)
+    if shas is None:
+        return (
+            f"could not read PR #{pr_num}'s comments/reviews to verify a scheduled Claude "
+            f"review at head {head[:12]} — review status UNREADABLE (retry), not clean.\n"
+            f"Retry, or append '# scheduled-review-override' to merge anyway."
+        )
+    if head in shas:
+        return None
+    return (
+        f"no scheduled Claude review found for PR #{pr_num} at head {head[:12]} (it may be "
+        f"pending or rate-limited).\n"
+        f"The scheduled review posts a comment/review carrying "
+        f"'<!-- genesis-scheduled-review: head=<sha> -->' once it runs on THIS exact commit "
+        f"(Claude does NOT auto-review a later fix-commit) — wait for it to run on the "
+        f"current head, or append '# scheduled-review-override' to merge without a scheduled "
+        f"Claude review."
+    )
+
+
 def _pr_base_ref(pr_num: str, repo: str | None = None) -> str | None:
     """The branch this PR MERGES INTO (``baseRefName``), or None on any error.
 
@@ -1731,6 +1926,44 @@ def _merge_has_shadow_flag(argv: list[str]) -> bool:
                 if ch in _GH_MERGE_VALUE_SHORTS:
                     break  # a value-short (e.g. -R): the rest is its glued value
     return False
+
+
+def _require_match_head(
+    merge_argv: list[str],
+    pr_num: str,
+    bind_head: str,
+    repo: str | None,
+    source: str,
+) -> str | None:
+    """Enforce the TOCTOU binding: the merge must carry ``--match-head-commit`` equal to
+    ``bind_head`` (a race with a new push then merges an UNREVIEWED head, which GitHub
+    rejects server-side). Returns None when bound correctly, else a BLOCK MESSAGE.
+    ``source`` names the gate whose head we bind to (e.g. "Codex-verified",
+    "scheduled-review-verified"). Shared by every gate that verifies a specific head so
+    a passing check is always atomically pinned to the sha it verified.
+    """
+    # Content value-flags can smuggle a --match-head-commit token as their VALUE
+    # (gh takes it as text → no binding) and have no use on a gated squash-merge.
+    if _merge_has_shadow_flag(merge_argv):
+        return (
+            "--body/--subject/--body-file/--author-email are not allowed on a gated "
+            "merge — they can shadow the --match-head-commit binding. Remove them "
+            "(set a squash message via the GitHub UI if needed)."
+        )
+    match_head = _merge_match_head(merge_argv)
+    if match_head is None:
+        return (
+            f"merge must be bound to the {source} head commit so a race with a new "
+            f"push cannot merge an unreviewed head. Re-run with:\n"
+            f"  {_suggested_merge_cmd(pr_num, bind_head, repo)}"
+        )
+    if match_head.strip().lower() != bind_head:
+        return (
+            f"--match-head-commit {match_head[:12]} does not equal the {source} head "
+            f"{bind_head[:12]} — the branch moved (or the sha is stale). Re-verify and "
+            f"use the current verified head."
+        )
+    return None
 
 
 def _is_dispatched() -> bool:
@@ -2825,40 +3058,35 @@ def main() -> int:
                 # nets its own fail-open outcome, but a clipped BINDING would have
                 # re-opened the unbound-merge race this block exists to close.
                 if verified_head:
-                    # Fail-closed belt: content value-flags can smuggle a
-                    # --match-head-commit token as their VALUE (gh takes it as
-                    # text → no binding) and have no use on a gated squash-merge.
-                    if _merge_has_shadow_flag(merge_seg.argv):
-                        print(
-                            "BLOCKED: --body/--subject/--body-file/--author-email are "
-                            "not allowed on a gated merge — they can shadow the "
-                            "--match-head-commit binding. Remove them (set a squash "
-                            "message via the GitHub UI if needed).",
-                            file=sys.stderr,
-                        )
+                    bind_msg = _require_match_head(
+                        merge_seg.argv, pr_num, verified_head, merge_repo, "Codex-verified"
+                    )
+                    if bind_msg:
+                        print("BLOCKED: " + bind_msg, file=sys.stderr)
                         return 2
-                    match_head = _merge_match_head(merge_seg.argv)
-                    if match_head is None:
-                        print(
-                            "BLOCKED: merge must be bound to the Codex-verified head "
-                            "commit so a race with a new push cannot merge an "
-                            "unreviewed head. Re-run with:",
-                            file=sys.stderr,
-                        )
-                        print(
-                            "  " + _suggested_merge_cmd(pr_num, verified_head, merge_repo),
-                            file=sys.stderr,
-                        )
-                        return 2
-                    if match_head.strip().lower() != verified_head:
-                        print(
-                            f"BLOCKED: --match-head-commit {match_head[:12]} does not "
-                            f"equal the Codex-verified head {verified_head[:12]} — the "
-                            f"branch moved (or the sha is stale). Re-verify and use "
-                            f"the current verified head.",
-                            file=sys.stderr,
-                        )
-                        return 2
+
+                # Scheduled Claude review at HEAD — a review by the repo OWNER (NOT a
+                # bot) must carry a marker naming the current head. Runs AFTER the Codex
+                # freshness + TOCTOU binding, and is its OWN always-fail-closed gate with
+                # its OWN sigil: # scheduled-review-override waives ONLY this gate, and is
+                # INDEPENDENT of # stale-review-override (which waives the Codex freshness
+                # + base gates). Pass verified_head when the Codex gate produced one (the
+                # current head); under # stale-review-override that is None, so the gate
+                # re-reads the head itself — this gate is not waived by the stale sigil.
+                sched_override = has_trailing_override(merge_seg.raw, "scheduled-review-override")
+                sched_msg = _check_scheduled_claude_reviewed_head(
+                    pr_num,
+                    verified_head,
+                    merge_repo,
+                    force=sched_override,
+                )
+                if sched_msg:
+                    print(
+                        f"BLOCKED: PR #{pr_num} — no scheduled Claude review at the current head.",
+                        file=sys.stderr,
+                    )
+                    print(sched_msg, file=sys.stderr)
+                    return 2
 
                 # Unresolved review findings (review body) — AFTER freshness +
                 # binding (see the ordering note above). Waived by
@@ -3066,6 +3294,15 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     if not blocked and verified_head:
         print("merge-with     : " + _suggested_merge_cmd(pr_num, verified_head, repo))
     failures += 1 if blocked else 0
+    # Scheduled Claude review at HEAD — the SAME always-fail-closed gate the merge arm
+    # enforces (shared function, strict mode). It reads the head itself (no head in
+    # hand here). A missing/stale/unreadable scheduled review is a FAILURE line, never a
+    # false all-clear — the report must not diverge from enforcement.
+    sched_msg = _check_scheduled_claude_reviewed_head(pr_num, None, repo, strict=True)
+    print(
+        f"scheduled-claude: {'BLOCK — ' + sched_msg.splitlines()[0] if sched_msg else 'ok (at head)'}"
+    )
+    failures += 1 if sched_msg else 0
     # strict=True: a scan that could not be READ (gh error/malformed) must show as
     # a failure here, never as "ok" — the report must not issue a false all-clear.
     blocked, msg = _check_pr_review_findings(pr_num, repo=repo, strict=True)

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1537,8 +1537,12 @@ def _check_codex_reviewed_head(
 _SCHEDULED_REVIEW_BLOCK_RE = re.compile(
     r"<!--\s*genesis-scheduled-review:\s*(.*?)\s*-->", re.DOTALL
 )
-_SCHEDULED_REVIEW_HEAD_RE = re.compile(r"\bhead=([0-9a-f]{40})\b")
-_SCHEDULED_REVIEW_KIND_RE = re.compile(r"\bkind=([a-z0-9][a-z0-9._-]*)")
+# The value must be TERMINATED by whitespace or the end of the marker block — NOT a
+# mere word boundary. Otherwise a status-suffixed producer output like `head=<sha>/failed`
+# or `kind=leaks/failed` would have its valid PREFIX captured and counted as a clean marker,
+# violating fail-closed (a failed/corrupt routine run must NOT satisfy the gate).
+_SCHEDULED_REVIEW_HEAD_RE = re.compile(r"\bhead=([0-9a-f]{40})(?=\s|\Z)")
+_SCHEDULED_REVIEW_KIND_RE = re.compile(r"\bkind=([a-z0-9][a-z0-9._-]*)(?=\s|\Z)")
 
 # Every scheduled routine whose completion the merge gate requires, by ``kind``. A PR
 # merges only when a valid owner-authored marker for EACH of these names the current

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -52,10 +52,17 @@ head it reviewed AND which routine it was (``kind``). The merge gate
 (``_check_scheduled_claude_reviewed_head``) blocks unless an owner-authored marker for
 EVERY kind in ``_REQUIRED_SCHEDULED_REVIEW_KINDS`` (currently code-review + leaks) names
 the PR's CURRENT head — so if any required routine never ran, ran on a stale commit, or
-was rate-limited, the merge is blocked (naming the missing kinds). Deployment note: this
-gate is scoped to the canonical repo's own merge workflow, where the required `/schedule`
-routines ARE configured (the deploy precondition); a clone that has not set up a producer
-uses `# scheduled-review-override` (or removes/edits `_REQUIRED_SCHEDULED_REVIEW_KINDS`).
+was rate-limited, the merge is blocked (naming the missing kinds). SCOPE: this gate
+enforces ONLY when the merge targets the configured PUBLIC repo — the declared
+``github.user``/``github.public_repo`` in ``~/.genesis/config/genesis.yaml``
+(``_scheduled_gate_applies`` / ``_canonical_public_repo``). A merge to any OTHER repo
+(a private fork, the voice repo, backups) no-ops, since the required ``/schedule``
+routines run only on the public repo. Deployment note: on the public repo the required
+routines ARE configured (the deploy precondition); a clone that runs on its own public
+repo without a producer uses `# scheduled-review-override` (or removes/edits
+`_REQUIRED_SCHEDULED_REVIEW_KINDS`) — the override valve is the escape by design, not an
+opt-in flag. Fail-closed on scope uncertainty: if the canonical repo is undeterminable
+the gate ENGAGES rather than silently disarming.
 A DISMISSED or PENDING (draft) review no longer vouches (its marker is ignored), mirroring
 the Codex path. The marker means "ran CLEAN", not merely "ran": a review whose body carries a
 blocking finding ([P1]/HARD BLOCK/### ERROR, unless a clean marker overrides — the same rule
@@ -1558,6 +1565,62 @@ _SCHEDULED_REVIEW_KIND_RE = re.compile(r"\bkind=([a-z0-9][a-z0-9._-]*)(?=\s|\Z)"
 _REQUIRED_SCHEDULED_REVIEW_KINDS = ("code-review", "leaks")
 
 
+def _canonical_public_repo() -> str | None:
+    """The ONE public repo the scheduled-review gate is scoped to, as ``owner/repo``
+    (normalized, case-preserved), or None if it cannot be determined.
+
+    Source: the DECLARED ``github.user``/``github.public_repo`` in
+    ``~/.genesis/config/genesis.yaml`` — install-agnostic and cwd-independent (the
+    identity of "the public repo" does not depend on which checkout a merge runs
+    from). Read locally (no ``gh``/network call — this is on the merge hot path).
+    Any read/parse failure returns None; the caller then fails CLOSED (see
+    ``_scheduled_gate_applies``). Test seam: ``_TEST_CANONICAL_PUBLIC_REPO`` (an
+    ``owner/repo`` string, or empty to force the undeterminable/None branch) is
+    honored INSTEAD of the config file when set — the config lives outside the repo
+    and is absent in CI, so the gate's scope must be injectable to test
+    deterministically."""
+    override = os.environ.get("_TEST_CANONICAL_PUBLIC_REPO")
+    if override is not None:
+        return _normalize_repo(override) if override.strip() else None
+    path = os.path.expanduser("~/.genesis/config/genesis.yaml")
+    try:
+        import yaml  # lazy: keep the hook import-light; the genesis venv has pyyaml
+
+        with open(path) as fh:
+            cfg = yaml.safe_load(fh) or {}
+        gh = cfg.get("github") or {}
+        user = (gh.get("user") or "").strip()
+        repo = (gh.get("public_repo") or "").strip()
+        if user and repo:
+            return _normalize_repo(f"{user}/{repo}")
+    except Exception:
+        return None
+    return None
+
+
+def _scheduled_gate_applies(repo: str | None) -> bool:
+    """Whether the scheduled-review gate ENFORCES for a merge targeting ``repo``.
+
+    The gate is scoped to the configured PUBLIC repo ONLY — the user's directive:
+    "these are ALL only requirements for the genesis public repo — not pushing work
+    anywhere else." The required ``/schedule`` routines run only on that repo, so a
+    ``gh pr merge`` targeting any OTHER repo (a private fork, the voice repo,
+    backups) must NOT be blocked on their markers.
+
+    Fail-CLOSED bias: only a target that RESOLVES to a repo DIFFERENT from the
+    canonical public one no-ops. If the canonical repo is undeterminable, or the
+    target is unknown, ENGAGE — silently skipping on uncertainty would be an
+    evasion path on the very repo the gate protects."""
+    canonical = _canonical_public_repo()
+    if not canonical or not repo:
+        return True  # uncertain → enforce (never silently disarm the gate)
+    target = _normalize_repo(repo)
+    if target is None:
+        return True  # unnormalizable target → enforce (fail-closed; unreachable in
+        # practice — an unresolved merge repo already blocks upstream)
+    return target.strip().lower() == canonical.strip().lower()
+
+
 def _parse_scheduled_jsonl(raw: str | None) -> list[dict]:
     """Parse the ``{login, author_association, body}`` JSONL shape into a list of
     dicts, SKIPPING any malformed/non-object line (fail-closed: a dropped line can
@@ -1700,6 +1763,12 @@ def _check_scheduled_claude_reviewed_head(
     decision is identical in both modes precisely BECAUSE enforcement already fails
     closed, so the report can never issue a false all-clear here.
 
+    SCOPE: this gate enforces ONLY for a merge targeting the configured PUBLIC repo
+    (``_scheduled_gate_applies`` / ``_canonical_public_repo``). A merge to any other
+    repo (a private fork, the voice repo, backups) returns None (no-op) — the
+    required routines run only on the public repo, so they cannot be required
+    elsewhere.
+
     ``head_sha`` (the caller's authoritative head) is used when given; otherwise the
     head is read via ``_pr_head_sha``. ``force`` (a ``# scheduled-review-override`` on
     the merge segment — an INDEPENDENT sigil from ``# stale-review-override``) waives
@@ -1708,6 +1777,8 @@ def _check_scheduled_claude_reviewed_head(
     """
     if force:
         return None  # waived by # scheduled-review-override
+    if not _scheduled_gate_applies(repo):
+        return None  # out of scope: merge targets a repo other than the public one
     head = (head_sha or "").strip().lower()
     if not head:
         head = (_pr_head_sha(pr_num, repo=repo) or "").strip().lower()
@@ -3152,6 +3223,19 @@ def main() -> int:
                 # 1s floor → fail-open → a merge with unresolved findings slipping through. Uses
                 # verified_head from the Codex gate (None under # stale-review-override → re-read).
                 sched_override = has_trailing_override(merge_seg.raw, "scheduled-review-override")
+                # Provision-or-surface: the scheduled gate no-ops off the configured
+                # public repo (by design). A SILENT no-op would hide a drifted
+                # genesis.yaml (canonical != the real public repo) disarming the gate
+                # on the repo it protects — so surface WHY it didn't apply. Advisory
+                # only (never blocks); skipped under the override (already a conscious
+                # waive). The report path shows the same via its "n/a" line.
+                if not sched_override and not _scheduled_gate_applies(merge_repo):
+                    print(
+                        f"NOTE: scheduled-review gate n/a for PR #{pr_num} — merge "
+                        f"targets {merge_repo}, not the configured public repo "
+                        f"({_canonical_public_repo() or 'undetermined'}).",
+                        file=sys.stderr,
+                    )
                 sched_msg = _check_scheduled_claude_reviewed_head(
                     pr_num,
                     verified_head,
@@ -3351,11 +3435,16 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     # Pass the Codex-verified head (as the enforcement path does) so the report is a
     # COHERENT snapshot: if the head moved mid-report, the scheduled check binds to the
     # same head the printed merge-with command does, not an independently re-read newer one.
-    sched_msg = _check_scheduled_claude_reviewed_head(pr_num, verified_head, repo, strict=True)
-    print(
-        f"scheduled-claude: {'BLOCK — ' + sched_msg.splitlines()[0] if sched_msg else 'ok (at head)'}"
-    )
-    failures += 1 if sched_msg else 0
+    # Scoped to the public repo only (mirrors enforcement) — print an honest n/a rather
+    # than a misleading "ok" when the target is some other repo.
+    if not _scheduled_gate_applies(repo):
+        print("scheduled-claude: n/a (scoped to the public repo only)")
+    else:
+        sched_msg = _check_scheduled_claude_reviewed_head(pr_num, verified_head, repo, strict=True)
+        print(
+            f"scheduled-claude: {'BLOCK — ' + sched_msg.splitlines()[0] if sched_msg else 'ok (at head)'}"
+        )
+        failures += 1 if sched_msg else 0
     # strict=True: a scan that could not be READ (gh error/malformed) must show as
     # a failure here, never as "ok" — the report must not issue a false all-clear.
     blocked, msg = _check_pr_review_findings(pr_num, repo=repo, strict=True)

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -52,7 +52,11 @@ head it reviewed AND which routine it was (``kind``). The merge gate
 (``_check_scheduled_claude_reviewed_head``) blocks unless an owner-authored marker for
 EVERY kind in ``_REQUIRED_SCHEDULED_REVIEW_KINDS`` (currently code-review + leaks) names
 the PR's CURRENT head — so if any required routine never ran, ran on a stale commit, or
-was rate-limited, the merge is blocked (naming the missing kinds).
+was rate-limited, the merge is blocked (naming the missing kinds). Deployment note: this
+gate is scoped to the canonical repo's own merge workflow, where the required `/schedule`
+routines ARE configured (the deploy precondition); a clone that has not set up a producer
+uses `# scheduled-review-override` (or removes/edits `_REQUIRED_SCHEDULED_REVIEW_KINDS`).
+A DISMISSED review no longer vouches (its marker is ignored), mirroring the Codex path.
 On the normal path this is ATOMIC: the Codex-freshness gate's ``--match-head-commit``
 binding pins the merge to the very head the marker was verified at, so a race with a new
 push cannot swap in an unreviewed head. Under ``# stale-review-override`` (which waives
@@ -1599,7 +1603,7 @@ def _scheduled_review_rows(pr_num: str, repo: str | None = None) -> list[dict] |
                     "--paginate",
                     "--jq",
                     ".[] | {login: .user.login, author_association: .author_association, "
-                    "body: .body}",
+                    "body: .body, state: .state}",  # .state present on reviews, null on issue comments
                 ],
                 capture_output=True,
                 text=True,
@@ -1640,6 +1644,11 @@ def _scheduled_review_markers(pr_num: str, repo: str | None = None) -> dict[str,
         assoc = (row.get("author_association") or "").upper()
         if login != owner and assoc != "OWNER":
             continue  # not the repo owner — not a trusted scheduled review
+        # A DISMISSED review no longer vouches for its commit (mirrors the Codex-freshness
+        # path). `state` is present on /pulls/N/reviews rows and null on issue comments,
+        # so this only drops dismissed reviews; issue comments remain state-less.
+        if (row.get("state") or "").upper() == "DISMISSED":
+            continue
         body = row.get("body") or ""
         # Defense-in-depth follow-up: for rows from /pulls/N/reviews we could ALSO
         # cross-check GitHub's authoritative `commit_id` vs the marker sha (issue comments
@@ -3322,7 +3331,10 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     # enforces (shared function, strict mode). It reads the head itself (no head in
     # hand here). A missing/stale/unreadable scheduled review is a FAILURE line, never a
     # false all-clear — the report must not diverge from enforcement.
-    sched_msg = _check_scheduled_claude_reviewed_head(pr_num, None, repo, strict=True)
+    # Pass the Codex-verified head (as the enforcement path does) so the report is a
+    # COHERENT snapshot: if the head moved mid-report, the scheduled check binds to the
+    # same head the printed merge-with command does, not an independently re-read newer one.
+    sched_msg = _check_scheduled_claude_reviewed_head(pr_num, verified_head, repo, strict=True)
     print(
         f"scheduled-claude: {'BLOCK — ' + sched_msg.splitlines()[0] if sched_msg else 'ok (at head)'}"
     )

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -56,7 +56,11 @@ was rate-limited, the merge is blocked (naming the missing kinds). Deployment no
 gate is scoped to the canonical repo's own merge workflow, where the required `/schedule`
 routines ARE configured (the deploy precondition); a clone that has not set up a producer
 uses `# scheduled-review-override` (or removes/edits `_REQUIRED_SCHEDULED_REVIEW_KINDS`).
-A DISMISSED review no longer vouches (its marker is ignored), mirroring the Codex path.
+A DISMISSED or PENDING (draft) review no longer vouches (its marker is ignored), mirroring
+the Codex path. The marker means "ran CLEAN", not merely "ran": a review whose body carries a
+blocking finding ([P1]/HARD BLOCK/### ERROR, unless a clean marker overrides — the same rule
+the finding scanners use) is rejected, so a scheduled reviewer that explicitly BLOCKED cannot
+stamp a passing marker (owner-authored bodies are not seen by the bot-only finding scanners).
 On the normal path this is ATOMIC: the Codex-freshness gate's ``--match-head-commit``
 binding pins the merge to the very head the marker was verified at, so a race with a new
 push cannot swap in an unreviewed head. Under ``# stale-review-override`` (which waives
@@ -1651,6 +1655,16 @@ def _scheduled_review_markers(pr_num: str, repo: str | None = None) -> dict[str,
         if (row.get("state") or "").upper() in ("DISMISSED", "PENDING"):
             continue
         body = row.get("body") or ""
+        # The marker must mean "ran CLEAN", not merely "ran": a scheduled review whose body
+        # CONTAINS a blocking finding ([P1]/HARD BLOCK/### ERROR, unless a clean marker
+        # overrides — same "clean wins" rule the finding scanners use) does NOT satisfy the
+        # gate. Owner-authored review bodies are never seen by _check_pr_review_findings
+        # (bots only), so without this a scheduled reviewer that explicitly BLOCKED would
+        # still stamp its marker and slip the merge through.
+        if any(p.search(body) for p in _BLOCKING_PATTERNS) and not any(
+            c.search(body) for c in _CLEAN_PATTERNS
+        ):
+            continue
         # Defense-in-depth follow-up: for rows from /pulls/N/reviews we could ALSO
         # cross-check GitHub's authoritative `commit_id` vs the marker sha (issue comments
         # carry none). Deferred (LOW): the marker sha is matched EXACTLY vs the authoritative

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -43,14 +43,16 @@ review-CONTEXT gates (Codex-at-head freshness + base-is-default),
 ``# ci-override`` waives the CI gate. A session that genuinely needs several
 appends several (one trailing comment may carry multiple sigils).
 
-Scheduled Claude review marker
-------------------------------
-A "scheduled Claude review" runs on the repo OWNER's GitHub account (NOT a bot) and
-must post a comment (issue comment) or PR review whose body contains the marker
-``<!-- genesis-scheduled-review: head=<full-40-hex-sha> -->`` naming the exact head
-commit it reviewed. The merge gate (``_check_scheduled_claude_reviewed_head``) blocks
-unless such a marker, authored by the owner, names the PR's CURRENT head — so a review
-that never ran, ran on a stale commit, or was rate-limited cannot slip a merge through.
+Scheduled Claude review markers
+-------------------------------
+A "scheduled Claude review" runs on the repo OWNER's GitHub account (NOT a bot) and must
+post a comment (issue comment) or PR review whose body contains a marker
+``<!-- genesis-scheduled-review: head=<full-40-hex-sha> kind=<name> -->`` naming the exact
+head it reviewed AND which routine it was (``kind``). The merge gate
+(``_check_scheduled_claude_reviewed_head``) blocks unless an owner-authored marker for
+EVERY kind in ``_REQUIRED_SCHEDULED_REVIEW_KINDS`` (currently code-review + leaks) names
+the PR's CURRENT head — so if any required routine never ran, ran on a stale commit, or
+was rate-limited, the merge is blocked (naming the missing kinds).
 On the normal path this is ATOMIC: the Codex-freshness gate's ``--match-head-commit``
 binding pins the merge to the very head the marker was verified at, so a race with a new
 push cannot swap in an unreviewed head. Under ``# stale-review-override`` (which waives
@@ -1526,9 +1528,22 @@ def _check_codex_reviewed_head(
 # The marker is the trust anchor (single-author, non-adversarial model): a spoofed
 # marker needs the owner's account. Waived by ``# scheduled-review-override`` (the
 # conscious "merge without a scheduled review" case — it didn't run / is rate-limited).
-_SCHEDULED_REVIEW_MARKER_RE = re.compile(
-    r"<!--\s*genesis-scheduled-review:\s*head=([0-9a-f]{40})\s*-->"
+# A scheduled-review marker is an HTML comment ``<!-- genesis-scheduled-review:
+# head=<40hex> kind=<name> -->``. Each SCHEDULED routine stamps its own ``kind`` so
+# the gate can require that EVERY routine in ``_REQUIRED_SCHEDULED_REVIEW_KINDS`` ran
+# on the current head — a single routine's marker no longer satisfies the gate on its
+# own. head/kind are parsed from the marker BLOCK (order-tolerant) and BOTH must be
+# present in the SAME marker to count.
+_SCHEDULED_REVIEW_BLOCK_RE = re.compile(
+    r"<!--\s*genesis-scheduled-review:\s*(.*?)\s*-->", re.DOTALL
 )
+_SCHEDULED_REVIEW_HEAD_RE = re.compile(r"\bhead=([0-9a-f]{40})\b")
+_SCHEDULED_REVIEW_KIND_RE = re.compile(r"\bkind=([a-z0-9][a-z0-9._-]*)")
+
+# Every scheduled routine whose completion the merge gate requires, by ``kind``. A PR
+# merges only when a valid owner-authored marker for EACH of these names the current
+# head. Change this tuple to add/remove required routines.
+_REQUIRED_SCHEDULED_REVIEW_KINDS = ("code-review", "leaks")
 
 
 def _parse_scheduled_jsonl(raw: str | None) -> list[dict]:
@@ -1595,17 +1610,17 @@ def _scheduled_review_rows(pr_num: str, repo: str | None = None) -> list[dict] |
     return rows
 
 
-def _scheduled_review_head_shas(pr_num: str, repo: str | None = None) -> set[str] | None:
-    """The SET of full 40-hex head shas named in valid scheduled-review markers on the
-    PR, or ``None`` on an UNREADABLE fetch (the caller fail-closes on both None and an
-    empty set — None only distinguishes "could not read" from "read, no marker").
+def _scheduled_review_markers(pr_num: str, repo: str | None = None) -> dict[str, set[str]] | None:
+    """Map of ``head-sha -> {kinds}`` from valid owner-authored scheduled-review markers
+    on the PR, or ``None`` on an UNREADABLE fetch (the caller fail-closes on both None
+    and an empty map — None only distinguishes "could not read" from "read, no marker").
 
     A marker is trusted only when its author is the repo OWNER: ``login == owner`` OR
     ``author_association == "OWNER"`` (belt-and-suspenders — the marker itself is the
     trust anchor in the single-author, non-adversarial model). The owner login is the
     first segment of ``(repo or derived)``; ``derived`` is gh's repo for the cwd when no
-    explicit repo was passed. When the owner cannot be determined the ``login`` arm is
-    simply never satisfied and the ``author_association`` arm still gates.
+    explicit repo was passed. Each marker BLOCK must carry BOTH ``head=<40hex>`` and
+    ``kind=<name>`` to count (order-tolerant); the ``kind`` is recorded under that head.
     """
     rows = _scheduled_review_rows(pr_num, repo=repo)
     if rows is None:
@@ -1615,21 +1630,24 @@ def _scheduled_review_head_shas(pr_num: str, repo: str | None = None) -> set[str
     except Exception:
         owner_repo = repo
     owner = (owner_repo.split("/")[0] if owner_repo else "").lower() or None
-    shas: set[str] = set()
+    by_head: dict[str, set[str]] = {}
     for row in rows:
         login = (row.get("login") or "").lower()
         assoc = (row.get("author_association") or "").upper()
         if login != owner and assoc != "OWNER":
             continue  # not the repo owner — not a trusted scheduled review
         body = row.get("body") or ""
-        # Defense-in-depth follow-up: for rows sourced from /pulls/N/reviews we could
-        # ALSO cross-check GitHub's authoritative `commit_id` against the marker sha
-        # (issue comments carry no commit_id). Deferred (LOW): the marker sha is already
-        # matched EXACTLY against the authoritative HEAD by the caller, so a stale marker
-        # cannot pass; this would only catch a buggy reviewer templating a wrong sha.
-        for sha in _SCHEDULED_REVIEW_MARKER_RE.findall(body):
-            shas.add(sha.lower())
-    return shas
+        # Defense-in-depth follow-up: for rows from /pulls/N/reviews we could ALSO
+        # cross-check GitHub's authoritative `commit_id` vs the marker sha (issue comments
+        # carry none). Deferred (LOW): the marker sha is matched EXACTLY vs the authoritative
+        # HEAD by the caller, so a stale marker can't pass; this only catches a buggy reviewer.
+        for block in _SCHEDULED_REVIEW_BLOCK_RE.findall(body):
+            head_m = _SCHEDULED_REVIEW_HEAD_RE.search(block)
+            kind_m = _SCHEDULED_REVIEW_KIND_RE.search(block)
+            if not head_m or not kind_m:
+                continue  # a marker must name both a head AND a kind to count
+            by_head.setdefault(head_m.group(1).lower(), set()).add(kind_m.group(1).lower())
+    return by_head
 
 
 def _check_scheduled_claude_reviewed_head(
@@ -1640,26 +1658,25 @@ def _check_scheduled_claude_reviewed_head(
     force: bool = False,
     strict: bool = False,
 ) -> str | None:
-    """Block a merge unless a scheduled Claude review (by the repo OWNER) has run on
-    the PR's CURRENT head. Returns ``None`` when a valid marker names ``head_sha``
-    exactly (full 40-char), else a BLOCK MESSAGE string.
+    """Block a merge unless EVERY required scheduled Claude review (by the repo OWNER)
+    has run on the PR's CURRENT head. Returns ``None`` when a valid owner marker for
+    each kind in ``_REQUIRED_SCHEDULED_REVIEW_KINDS`` names ``head_sha`` exactly (full
+    40-char), else a BLOCK MESSAGE naming the MISSING kinds.
 
     Fail-CLOSED in BOTH modes — this gate never passes on absence of positive
     evidence: if the head cannot be read, or the comment/review fetch errors
-    (``_scheduled_review_head_shas`` → None), the merge is BLOCKED. A read that simply
-    does not name this head (the review didn't run, ran on a stale commit, or was
-    rate-limited) also blocks. ``strict`` is accepted for interface parity with the
-    finding scanners (``check_pr_report`` passes it); the block/pass decision is
-    identical in both modes precisely BECAUSE enforcement already fails closed, so the
-    report can never issue a false all-clear here.
+    (``_scheduled_review_markers`` → None), the merge is BLOCKED. A read that simply
+    does not carry every required kind at this head (a routine didn't run, ran on a
+    stale commit, or was rate-limited) also blocks. ``strict`` is accepted for interface
+    parity with the finding scanners (``check_pr_report`` passes it); the block/pass
+    decision is identical in both modes precisely BECAUSE enforcement already fails
+    closed, so the report can never issue a false all-clear here.
 
     ``head_sha`` (the caller's authoritative head) is used when given; otherwise the
-    head is read via ``_pr_head_sha`` (so ``check_pr_report`` and a stale-review-forced
-    merge can both call it without a head in hand). ``force`` (a
-    ``# scheduled-review-override`` on the merge segment — an INDEPENDENT sigil from
-    ``# stale-review-override``, which waives the Codex freshness gate) waives this gate
-    for the conscious "merge without a scheduled review" case (e.g. it is down / rate
-    limited).
+    head is read via ``_pr_head_sha``. ``force`` (a ``# scheduled-review-override`` on
+    the merge segment — an INDEPENDENT sigil from ``# stale-review-override``) waives
+    this gate for the conscious "merge without the scheduled reviews" case (e.g. a
+    routine is down / rate-limited).
     """
     if force:
         return None  # waived by # scheduled-review-override
@@ -1668,27 +1685,29 @@ def _check_scheduled_claude_reviewed_head(
         head = (_pr_head_sha(pr_num, repo=repo) or "").strip().lower()
     if not head:
         return (
-            f"could not read PR #{pr_num}'s head commit to verify a scheduled Claude "
-            f"review (GitHub query failed).\n"
+            f"could not read PR #{pr_num}'s head commit to verify the scheduled Claude "
+            f"reviews (GitHub query failed).\n"
             f"Retry, or append '# scheduled-review-override' to merge anyway."
         )
-    shas = _scheduled_review_head_shas(pr_num, repo=repo)
-    if shas is None:
+    markers = _scheduled_review_markers(pr_num, repo=repo)
+    if markers is None:
         return (
-            f"could not read PR #{pr_num}'s comments/reviews to verify a scheduled Claude "
-            f"review at head {head[:12]} — review status UNREADABLE (retry), not clean.\n"
+            f"could not read PR #{pr_num}'s comments/reviews to verify the scheduled Claude "
+            f"reviews at head {head[:12]} — review status UNREADABLE (retry), not clean.\n"
             f"Retry, or append '# scheduled-review-override' to merge anyway."
         )
-    if head in shas:
+    kinds_here = markers.get(head, set())
+    missing = [k for k in _REQUIRED_SCHEDULED_REVIEW_KINDS if k not in kinds_here]
+    if not missing:
         return None
     return (
-        f"no scheduled Claude review found for PR #{pr_num} at head {head[:12]} (it may be "
-        f"pending or rate-limited).\n"
-        f"The scheduled review posts a comment/review carrying "
-        f"'<!-- genesis-scheduled-review: head=<sha> -->' once it runs on THIS exact commit "
-        f"(Claude does NOT auto-review a later fix-commit) — wait for it to run on the "
-        f"current head, or append '# scheduled-review-override' to merge without a scheduled "
-        f"Claude review."
+        f"scheduled Claude review(s) missing at head {head[:12]}: {', '.join(missing)} "
+        f"(required: {', '.join(_REQUIRED_SCHEDULED_REVIEW_KINDS)}; present: "
+        f"{', '.join(sorted(kinds_here)) or 'none'}).\n"
+        f"Each routine posts a comment/review carrying "
+        f"'<!-- genesis-scheduled-review: head=<sha> kind=<name> -->' once it runs on THIS "
+        f"exact commit — wait for the missing routine(s) to run on the current head, or "
+        f"append '# scheduled-review-override' to merge without them."
     )
 
 
@@ -3082,7 +3101,8 @@ def main() -> int:
                 )
                 if sched_msg:
                     print(
-                        f"BLOCKED: PR #{pr_num} — no scheduled Claude review at the current head.",
+                        f"BLOCKED: PR #{pr_num} — required scheduled Claude review(s) "
+                        f"missing at the current head.",
                         file=sys.stderr,
                     )
                     print(sched_msg, file=sys.stderr)

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1644,10 +1644,11 @@ def _scheduled_review_markers(pr_num: str, repo: str | None = None) -> dict[str,
         assoc = (row.get("author_association") or "").upper()
         if login != owner and assoc != "OWNER":
             continue  # not the repo owner — not a trusted scheduled review
-        # A DISMISSED review no longer vouches for its commit (mirrors the Codex-freshness
-        # path). `state` is present on /pulls/N/reviews rows and null on issue comments,
-        # so this only drops dismissed reviews; issue comments remain state-less.
-        if (row.get("state") or "").upper() == "DISMISSED":
+        # A DISMISSED review no longer vouches, and a PENDING review is an UNPUBLISHED
+        # draft that never ran publicly — neither should satisfy the gate (mirrors the
+        # Codex-freshness path). `state` is present on /pulls/N/reviews rows and null on
+        # issue comments, so this only drops review rows; issue comments remain state-less.
+        if (row.get("state") or "").upper() in ("DISMISSED", "PENDING"):
             continue
         body = row.get("body") or ""
         # Defense-in-depth follow-up: for rows from /pulls/N/reviews we could ALSO
@@ -3097,30 +3098,6 @@ def main() -> int:
                         print("BLOCKED: " + bind_msg, file=sys.stderr)
                         return 2
 
-                # Scheduled Claude review at HEAD — a review by the repo OWNER (NOT a
-                # bot) must carry a marker naming the current head. Runs AFTER the Codex
-                # freshness + TOCTOU binding, and is its OWN always-fail-closed gate with
-                # its OWN sigil: # scheduled-review-override waives ONLY this gate, and is
-                # INDEPENDENT of # stale-review-override (which waives the Codex freshness
-                # + base gates). Pass verified_head when the Codex gate produced one (the
-                # current head); under # stale-review-override that is None, so the gate
-                # re-reads the head itself — this gate is not waived by the stale sigil.
-                sched_override = has_trailing_override(merge_seg.raw, "scheduled-review-override")
-                sched_msg = _check_scheduled_claude_reviewed_head(
-                    pr_num,
-                    verified_head,
-                    merge_repo,
-                    force=sched_override,
-                )
-                if sched_msg:
-                    print(
-                        f"BLOCKED: PR #{pr_num} — required scheduled Claude review(s) "
-                        f"missing at the current head.",
-                        file=sys.stderr,
-                    )
-                    print(sched_msg, file=sys.stderr)
-                    return 2
-
                 # Unresolved review findings (review body) — AFTER freshness +
                 # binding (see the ordering note above). Waived by
                 # # review-override (the FINDINGS sigil — not the stale one).
@@ -3150,6 +3127,30 @@ def main() -> int:
                         file=sys.stderr,
                     )
                     print(inline_msg, file=sys.stderr)
+                    return 2
+
+                # Scheduled Claude review at HEAD — its OWN always-fail-closed gate with
+                # its OWN sigil (# scheduled-review-override waives ONLY this gate; independent
+                # of # stale-review-override). Deliberately placed LAST — after the review-body
+                # + inline finding scanners, which fail OPEN on a clipped budget. This gate
+                # fails CLOSED, so if the shared merge-gate deadline is exhausted here it BLOCKS
+                # (safe); running it before the scanners could instead starve THEM into their
+                # 1s floor → fail-open → a merge with unresolved findings slipping through. Uses
+                # verified_head from the Codex gate (None under # stale-review-override → re-read).
+                sched_override = has_trailing_override(merge_seg.raw, "scheduled-review-override")
+                sched_msg = _check_scheduled_claude_reviewed_head(
+                    pr_num,
+                    verified_head,
+                    merge_repo,
+                    force=sched_override,
+                )
+                if sched_msg:
+                    print(
+                        f"BLOCKED: PR #{pr_num} — required scheduled Claude review(s) "
+                        f"missing at the current head.",
+                        file=sys.stderr,
+                    )
+                    print(sched_msg, file=sys.stderr)
                     return 2
 
         # ── sqlite3 write operations ────────────────────────────────
@@ -3274,6 +3275,10 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     false all-clear.
 
     Prints one line per gate; returns 0 when every gate would pass, 1 otherwise.
+    (Same CHECKS as enforcement, but the internal ORDER may differ — e.g. the merge
+    arm runs the scheduled gate LAST, after the finding scanners, for budget reasons;
+    the report is order-independent because every scan here is strict=True, so a clipped
+    scan is a failure line rather than a fail-open pass regardless of position.)
     """
     failures = 0
     mergeable = _check_mergeable(pr_num, repo=repo)
@@ -3324,8 +3329,6 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
         else:
             label = "ok (current)"
     print(f"codex-at-head  : {label}")
-    if not blocked and verified_head:
-        print("merge-with     : " + _suggested_merge_cmd(pr_num, verified_head, repo))
     failures += 1 if blocked else 0
     # Scheduled Claude review at HEAD — the SAME always-fail-closed gate the merge arm
     # enforces (shared function, strict mode). It reads the head itself (no head in
@@ -3349,6 +3352,11 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
         f"inline-findings: {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (P2s, if any, printed above)'}"
     )
     failures += 1 if blocked else 0
+    # Emit the actionable merge command ONLY when EVERY gate passed — printing it earlier
+    # (right after codex-at-head) suggested a mergeable PR even when the scheduled or finding
+    # gate below would block. Bound to the Codex-verified head (the TOCTOU pin).
+    if failures == 0 and verified_head:
+        print("merge-with     : " + _suggested_merge_cmd(pr_num, verified_head, repo))
     print(
         "verdict        :",
         "MERGEABLE (all gates pass)" if failures == 0 else f"{failures} gate(s) would block",

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -199,6 +199,7 @@ _KNOWN_SIGILS = (
     "escalation-ack",
     "ci-override",
     "stale-review-override",
+    "scheduled-review-override",
 )
 
 

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -42,10 +42,15 @@ def _reviews_jsonl(*commit_ids, login="chatgpt-codex-connector[bot]"):
 
 
 def _scheduled_marker(head=HEAD, *, login="owner", author_association="OWNER"):
-    """_TEST_GH_SCHEDULED_COMMENTS shape — one OWNER-authored row carrying the
-    scheduled-review marker naming ``head`` (author_association=OWNER satisfies the
-    trust check regardless of the derived repo owner)."""
-    body = f"Scheduled review complete.\n<!-- genesis-scheduled-review: head={head} -->"
+    """_TEST_GH_SCHEDULED_COMMENTS shape — one OWNER-authored row carrying a marker for
+    EVERY required kind (code-review + leaks) naming ``head``, so the scheduled gate is
+    satisfied and these freshness/binding cases exercise their own target
+    (author_association=OWNER satisfies the trust check regardless of derived repo owner)."""
+    markers = "\n".join(
+        f"<!-- genesis-scheduled-review: head={head} kind={k} -->"
+        for k in ("code-review", "leaks")
+    )
+    body = "Scheduled review complete.\n" + markers
     return json.dumps({"login": login, "author_association": author_association, "body": body})
 
 

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -41,6 +41,14 @@ def _reviews_jsonl(*commit_ids, login="chatgpt-codex-connector[bot]"):
     return "\n".join(json.dumps({"login": login, "commit_id": cid}) for cid in commit_ids)
 
 
+def _scheduled_marker(head=HEAD, *, login="owner", author_association="OWNER"):
+    """_TEST_GH_SCHEDULED_COMMENTS shape — one OWNER-authored row carrying the
+    scheduled-review marker naming ``head`` (author_association=OWNER satisfies the
+    trust check regardless of the derived repo owner)."""
+    body = f"Scheduled review complete.\n<!-- genesis-scheduled-review: head={head} -->"
+    return json.dumps({"login": login, "author_association": author_association, "body": body})
+
+
 def _clean_comment_jsonl(
     short_sha, *, login="chatgpt-codex-connector[bot]", user_type="Bot", flavour="Swish!"
 ):
@@ -529,6 +537,10 @@ class TestMainLevelIntegration:
         monkeypatch.setenv(
             "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "t", "conclusion": "SUCCESS"}])
         )
+        # A valid OWNER scheduled-review marker AT head, so the scheduled-review merge
+        # gate is satisfied and these cases keep exercising the freshness/binding wiring
+        # they target (not the new gate).
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _scheduled_marker(HEAD))
         monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
         monkeypatch.setattr(
             _mod, "_check_pr_review_findings", lambda n, force=False, repo=None: (False, "")
@@ -634,6 +646,9 @@ class TestStaleSigilDoesNotWaiveScanners:
         monkeypatch.setenv(
             "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "t", "conclusion": "SUCCESS"}])
         )
+        # Scheduled review satisfied at head → the stale-override merge reaches the
+        # finding scanner this test is about (not the new scheduled gate).
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _scheduled_marker(HEAD))
         monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
         # Scanner stub blocks UNLESS its own force (i.e. # review-override) is set.
         monkeypatch.setattr(

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -59,6 +59,19 @@ def _reset_merge_deadline():
     _mod._merge_deadline = None
 
 
+@pytest.fixture(autouse=True)
+def _pin_canonical_public_repo(monkeypatch):
+    """The scheduled-review gate is scoped to the configured PUBLIC repo, read from
+    ``~/.genesis/config/genesis.yaml`` — which exists on a dev box but NOT in CI,
+    so the gate's SCOPE is environment-dependent unless pinned. Fix the canonical
+    public repo to the corpus's merge target (``REPO``) via the ``_TEST_CANONICAL_
+    PUBLIC_REPO`` seam, so EVERY case deterministically ENGAGES the scheduled gate
+    on every host. The off-public-repo NO-OP is exercised by its own case, which
+    overrides this seam to a different repo."""
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", REPO)
+    yield
+
+
 # ── injection helpers ────────────────────────────────────────────────
 
 
@@ -607,6 +620,31 @@ _CASES: list[tuple[str, object, int, str]] = [
         2,
         "scheduled Claude review(s) missing",
     ),
+    # SCOPE: the gate is scoped to the configured PUBLIC repo only. Same absent-marker
+    # scenario as above, but the merge targets a repo OTHER than the canonical public
+    # one → the gate NO-OPS and the merge is ALLOWED (the required routines run only on
+    # the public repo, so they cannot be required elsewhere). Verify-RED: without the
+    # scope guard this blocks exactly like ``scheduled_review_absent_blocks``.
+    (
+        "scheduled_review_absent_off_public_repo_allows",
+        lambda mp: (
+            mp.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/some-other-public-repo"),
+            _run(mp, _merge_cmd(), scheduled=""),
+        )[1],
+        0,
+        "",
+    ),
+    # SCOPE, converse: an UNDETERMINABLE canonical repo (empty seam → None) fails CLOSED
+    # — the gate ENGAGES rather than silently disarming, so an absent marker still blocks.
+    (
+        "scheduled_review_absent_uncertain_scope_blocks",
+        lambda mp: (
+            mp.setenv("_TEST_CANONICAL_PUBLIC_REPO", ""),
+            _run(mp, _merge_cmd(), scheduled=""),
+        )[1],
+        2,
+        "scheduled Claude review(s) missing",
+    ),
     # A marker from a NON-owner author (login != owner, association != OWNER) is NOT
     # trusted → treated as absent → block.
     (
@@ -970,3 +1008,77 @@ def test_check_pr_report_prints_merge_with_when_all_pass(monkeypatch, capsys):
     assert "merge-with" in out
     assert "--match-head-commit" in out
     assert rc == 0
+
+
+def test_check_pr_report_scheduled_na_off_public_repo(monkeypatch, capsys):
+    """Off the public repo the report prints an honest ``n/a`` for the scheduled line
+    (not a misleading ``ok``) and the gate does NOT count as a failure — even with NO
+    marker present, since the gate is out of scope there."""
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/some-other-public-repo")
+    _report_env(monkeypatch, scheduled="")  # no marker at all
+    rc = _mod.check_pr_report("100", repo=REPO)
+    out = capsys.readouterr().out
+    sched_line = next(ln for ln in out.splitlines() if ln.startswith("scheduled-claude"))
+    assert "n/a" in sched_line and "public repo" in sched_line
+    assert "BLOCK" not in sched_line
+    assert rc == 0  # scheduled no-op does not fail the verdict off the public repo
+
+
+# ── scope helpers (unit) ─────────────────────────────────────────────
+def test_scheduled_gate_applies_matches_public_repo(monkeypatch):
+    """The gate ENGAGES iff the merge target IS the canonical public repo."""
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/public")
+    assert _mod._scheduled_gate_applies("owner/public") is True
+    assert _mod._scheduled_gate_applies("OWNER/PUBLIC") is True  # case-insensitive
+    assert _mod._scheduled_gate_applies("https://github.com/owner/public") is True  # normalized
+    assert _mod._scheduled_gate_applies("owner/other") is False  # a different repo no-ops
+
+
+def test_scheduled_gate_applies_fails_closed_on_uncertainty(monkeypatch):
+    """Undeterminable canonical repo (None) or unknown target → ENGAGE (never silently
+    disarm the gate on the repo it protects)."""
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "")  # → None
+    assert _mod._scheduled_gate_applies("owner/anything") is True
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/public")
+    assert _mod._scheduled_gate_applies(None) is True
+    assert _mod._scheduled_gate_applies("") is True
+
+
+def test_canonical_public_repo_seam(monkeypatch):
+    """The seam yields a normalized owner/repo, or None when empty (the fail-closed
+    branch)."""
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "WingedGuardian/GENesis-AGI")
+    assert _mod._canonical_public_repo() == "WingedGuardian/GENesis-AGI"
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "")
+    assert _mod._canonical_public_repo() is None
+
+
+def test_canonical_public_repo_reads_genesis_yaml(monkeypatch, tmp_path):
+    """Direct coverage of the config-file read path (not the seam): the canonical
+    repo is the declared github.user/public_repo, and a missing file fails closed
+    to None."""
+    monkeypatch.delenv("_TEST_CANONICAL_PUBLIC_REPO", raising=False)
+    cfg = tmp_path / "genesis.yaml"
+    cfg.write_text("github:\n  user: WingedGuardian\n  public_repo: GENesis-AGI\n")
+    monkeypatch.setattr(_mod.os.path, "expanduser", lambda p: str(cfg))
+    assert _mod._canonical_public_repo() == "WingedGuardian/GENesis-AGI"
+    # Missing/unreadable config → None (fail-closed → gate engages).
+    monkeypatch.setattr(_mod.os.path, "expanduser", lambda p: str(tmp_path / "absent.yaml"))
+    assert _mod._canonical_public_repo() is None
+    # A github section missing the keys → None too.
+    cfg.write_text("github:\n  user: WingedGuardian\n")  # no public_repo
+    monkeypatch.setattr(_mod.os.path, "expanduser", lambda p: str(cfg))
+    assert _mod._canonical_public_repo() is None
+
+
+def test_enforcement_surfaces_note_on_off_public_repo_no_op(monkeypatch, capsys):
+    """Provision-or-surface: when the scheduled gate no-ops because the merge targets
+    a repo other than the canonical public one, the ENFORCEMENT path emits an advisory
+    stderr NOTE (naming both repos) rather than silently disarming — so a drifted
+    genesis.yaml is visible. The merge still proceeds (exit 0)."""
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/some-other-public-repo")
+    rc = _run(monkeypatch, _merge_cmd(), scheduled="")  # no marker, but off-repo → allow
+    err = capsys.readouterr().err
+    assert rc == 0
+    assert "scheduled-review gate n/a" in err
+    assert "owner/some-other-public-repo" in err  # names the canonical public repo

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -87,14 +87,18 @@ def _scheduled_marker(
     *,
     login: str = "owner",
     author_association: str = "OWNER",
+    kinds: tuple[str, ...] = ("code-review", "leaks"),
 ) -> str:
     """_TEST_GH_SCHEDULED_COMMENTS shape — one OWNER-authored comment/review row whose
-    body carries the scheduled-review marker naming ``head``. One JSON object per line.
+    body carries one scheduled-review marker per ``kind`` naming ``head``. One JSON object
+    per line. The DEFAULT carries BOTH required kinds (code-review + leaks), so every
+    pre-existing case satisfies the gate; scheduled-gate cases pass explicit ``kinds``.
 
     ``login``/``author_association`` model the trust check: a row is accepted only when
     ``login == <repo owner>`` OR ``author_association == "OWNER"``. The repo owner here is
     ``owner`` (``REPO = "owner/repo"``), so the default satisfies BOTH arms."""
-    body = f"Scheduled review complete.\n<!-- genesis-scheduled-review: head={head} -->"
+    markers = "\n".join(f"<!-- genesis-scheduled-review: head={head} kind={k} -->" for k in kinds)
+    body = "Scheduled review complete.\n" + markers
     return json.dumps({"login": login, "author_association": author_association, "body": body})
 
 
@@ -594,14 +598,14 @@ _CASES: list[tuple[str, object, int, str]] = [
         "scheduled_review_stale_sha_blocks",
         lambda mp: _run(mp, _merge_cmd(), scheduled=_scheduled_marker(STALE)),
         2,
-        "no scheduled Claude review",
+        "scheduled Claude review(s) missing",
     ),
     # No scheduled review at all (didn't run / rate-limited) → fail-closed block.
     (
         "scheduled_review_absent_blocks",
         lambda mp: _run(mp, _merge_cmd(), scheduled=""),
         2,
-        "no scheduled Claude review",
+        "scheduled Claude review(s) missing",
     ),
     # A marker from a NON-owner author (login != owner, association != OWNER) is NOT
     # trusted → treated as absent → block.
@@ -613,7 +617,7 @@ _CASES: list[tuple[str, object, int, str]] = [
             scheduled=_scheduled_marker(HEAD, login="randouser", author_association="CONTRIBUTOR"),
         ),
         2,
-        "no scheduled Claude review",
+        "scheduled Claude review(s) missing",
     ),
     # Owner-login match is case-INSENSITIVE (GitHub logins are canonically cased, but
     # fold both sides as defense-in-depth): a marker whose login differs only in case
@@ -627,6 +631,23 @@ _CASES: list[tuple[str, object, int, str]] = [
         ),
         0,
         "",
+    ),
+    # BOTH required kinds must be present at head: a marker for only code-review (leaks
+    # routine did not run) blocks, naming the missing kind.
+    (
+        "scheduled_review_only_code_review_blocks_missing_leaks",
+        lambda mp: _run(
+            mp, _merge_cmd(), scheduled=_scheduled_marker(HEAD, kinds=("code-review",))
+        ),
+        2,
+        "leaks",
+    ),
+    # ...and only leaks (code-review routine did not run) blocks too.
+    (
+        "scheduled_review_only_leaks_blocks_missing_code_review",
+        lambda mp: _run(mp, _merge_cmd(), scheduled=_scheduled_marker(HEAD, kinds=("leaks",))),
+        2,
+        "code-review",
     ),
     # The # scheduled-review-override sigil consciously waives the gate → an absent
     # scheduled review still merges.
@@ -648,7 +669,7 @@ _CASES: list[tuple[str, object, int, str]] = [
             scheduled="",
         ),
         2,
-        "no scheduled Claude review",
+        "scheduled Claude review(s) missing",
     ),
     # # scheduled-review-override waives ONLY the scheduled gate, NOT Codex freshness:
     # a no-review PR still blocks on freshness (which runs first).

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -690,6 +690,28 @@ _CASES: list[tuple[str, object, int, str]] = [
         2,
         "leaks",  # the suffixed leaks kind is not captured → missing
     ),
+    # A DISMISSED owner review no longer vouches — its marker (even for all kinds at head)
+    # is ignored, so the gate blocks (mirrors the Codex-freshness dismissed handling).
+    (
+        "scheduled_review_dismissed_blocks",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            scheduled=json.dumps(
+                {
+                    "login": "owner",
+                    "author_association": "OWNER",
+                    "state": "DISMISSED",
+                    "body": (
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=code-review -->\n"
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
+                    ),
+                }
+            ),
+        ),
+        2,
+        "scheduled Claude review(s) missing",
+    ),
     # The # scheduled-review-override sigil consciously waives the gate → an absent
     # scheduled review still merges.
     (

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -82,6 +82,22 @@ def _reviews_jsonl(
     return "\n".join(rows)
 
 
+def _scheduled_marker(
+    head: str = HEAD,
+    *,
+    login: str = "owner",
+    author_association: str = "OWNER",
+) -> str:
+    """_TEST_GH_SCHEDULED_COMMENTS shape — one OWNER-authored comment/review row whose
+    body carries the scheduled-review marker naming ``head``. One JSON object per line.
+
+    ``login``/``author_association`` model the trust check: a row is accepted only when
+    ``login == <repo owner>`` OR ``author_association == "OWNER"``. The repo owner here is
+    ``owner`` (``REPO = "owner/repo"``), so the default satisfies BOTH arms."""
+    body = f"Scheduled review complete.\n<!-- genesis-scheduled-review: head={head} -->"
+    return json.dumps({"login": login, "author_association": author_association, "body": body})
+
+
 def _ci(conclusion: str = "SUCCESS") -> str:
     """_TEST_GH_CI_ROLLUP shape — a JSON array of check-runs."""
     return json.dumps([{"name": "test", "conclusion": conclusion, "status": "COMPLETED"}])
@@ -203,6 +219,7 @@ def _run(
     base: str = "main",
     default: str = "main",
     compare: str | None = None,
+    scheduled: str | None = None,
     router=None,
 ) -> int:
     """Drive ``main()`` in-process: granular seams via env, un-seamed gh via the
@@ -216,6 +233,12 @@ def _run(
     monkeypatch.setenv("_TEST_GH_BASE_REF", base)
     monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", default)
     monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")  # no clean-comment fallback unless asked
+    # Default: a valid OWNER-authored scheduled-review marker AT head, so every
+    # pre-existing case stays behaviour-identical (mirrors the default codex review
+    # above). Scheduled-gate cases pass an explicit ``scheduled=`` to override.
+    monkeypatch.setenv(
+        "_TEST_GH_SCHEDULED_COMMENTS", _scheduled_marker(head) if scheduled is None else scheduled
+    )
     if compare is not None:
         monkeypatch.setenv("_TEST_GH_COMPARE", compare)  # smart-delta seam (opt-in)
     monkeypatch.setattr(_mod.subprocess, "run", router or _router())
@@ -558,6 +581,83 @@ _CASES: list[tuple[str, object, int, str]] = [
         2,
         "has not reviewed the current head",
     ),
+    # ── Scheduled Claude review gate (owner-authored marker at HEAD) ──
+    # An owner marker naming the CURRENT head → the gate is satisfied → merge allowed.
+    (
+        "scheduled_review_at_head_allows",
+        lambda mp: _run(mp, _merge_cmd(), scheduled=_scheduled_marker(HEAD)),
+        0,
+        "",
+    ),
+    # A marker naming a STALE sha does NOT vouch for the current head → block.
+    (
+        "scheduled_review_stale_sha_blocks",
+        lambda mp: _run(mp, _merge_cmd(), scheduled=_scheduled_marker(STALE)),
+        2,
+        "no scheduled Claude review",
+    ),
+    # No scheduled review at all (didn't run / rate-limited) → fail-closed block.
+    (
+        "scheduled_review_absent_blocks",
+        lambda mp: _run(mp, _merge_cmd(), scheduled=""),
+        2,
+        "no scheduled Claude review",
+    ),
+    # A marker from a NON-owner author (login != owner, association != OWNER) is NOT
+    # trusted → treated as absent → block.
+    (
+        "scheduled_review_non_owner_author_blocks",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            scheduled=_scheduled_marker(HEAD, login="randouser", author_association="CONTRIBUTOR"),
+        ),
+        2,
+        "no scheduled Claude review",
+    ),
+    # Owner-login match is case-INSENSITIVE (GitHub logins are canonically cased, but
+    # fold both sides as defense-in-depth): a marker whose login differs only in case
+    # from the repo owner, with a non-OWNER association, is still trusted → allows.
+    (
+        "scheduled_review_owner_login_case_insensitive_allows",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            scheduled=_scheduled_marker(HEAD, login="OWNER", author_association="NONE"),
+        ),
+        0,
+        "",
+    ),
+    # The # scheduled-review-override sigil consciously waives the gate → an absent
+    # scheduled review still merges.
+    (
+        "scheduled_override_waives_absent_review_allows",
+        lambda mp: _run(mp, _merge_cmd(trailer="# scheduled-review-override"), scheduled=""),
+        0,
+        "",
+    ),
+    # ── sigil INDEPENDENCE: the scheduled sigil and the stale sigil are separate ──
+    # # stale-review-override waives Codex freshness+base, NOT the scheduled gate: an
+    # absent scheduled review still blocks even with a fresh-review waiver.
+    (
+        "stale_override_does_NOT_waive_scheduled_blocks",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(match=None, trailer="# stale-review-override"),
+            reviews="",
+            scheduled="",
+        ),
+        2,
+        "no scheduled Claude review",
+    ),
+    # # scheduled-review-override waives ONLY the scheduled gate, NOT Codex freshness:
+    # a no-review PR still blocks on freshness (which runs first).
+    (
+        "scheduled_override_does_NOT_waive_freshness_blocks",
+        lambda mp: _run(mp, _merge_cmd(trailer="# scheduled-review-override"), reviews=""),
+        2,
+        "has not reviewed the current head",
+    ),
 ]
 
 
@@ -657,3 +757,44 @@ def test_e3_stale_override_gates_positional_pr_not_flag_value(monkeypatch):
     assert not any(f"repos/{REPO}/pulls/123/comments" in parts for parts in inline), (
         f"findings scanned the WRONG PR (123, the --subject value): {inline}"
     )
+
+
+def _report_env(monkeypatch, *, scheduled: str, head: str = HEAD):
+    """Seed every OTHER gate green so ``check_pr_report`` isolates the scheduled line.
+    The scheduled gate itself runs for real against the ``scheduled`` seam."""
+    monkeypatch.setenv("_TEST_GH_HEAD_SHA", head)
+    monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(head))
+    monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")
+    monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", scheduled)
+    monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+    monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("green", []))
+    monkeypatch.setattr(_mod, "_check_base_is_default", lambda n, repo=None: (False, ""))
+    monkeypatch.setattr(
+        _mod, "_check_pr_review_findings", lambda n, repo=None, strict=False: (False, "")
+    )
+    monkeypatch.setattr(
+        _mod, "_check_inline_review_findings", lambda n, repo=None, strict=False: (False, "")
+    )
+
+
+def test_check_pr_report_includes_scheduled_line_ok(monkeypatch, capsys):
+    """The canonical report prints a ``scheduled-claude`` line and PASSES when an
+    owner marker names the current head (shares the enforcement function, strict mode)."""
+    _report_env(monkeypatch, scheduled=_scheduled_marker(HEAD))
+    rc = _mod.check_pr_report("100", repo=REPO)
+    out = capsys.readouterr().out
+    assert "scheduled-claude:" in out
+    sched_line = next(ln for ln in out.splitlines() if ln.startswith("scheduled-claude"))
+    assert "ok (at head)" in sched_line
+    assert rc == 0
+
+
+def test_check_pr_report_scheduled_absent_fails_verdict(monkeypatch, capsys):
+    """An absent scheduled review is a FAILURE line and flips the report's verdict —
+    the report must not diverge from the always-fail-closed enforcement gate."""
+    _report_env(monkeypatch, scheduled="")
+    rc = _mod.check_pr_report("100", repo=REPO)
+    out = capsys.readouterr().out
+    sched_line = next(ln for ln in out.splitlines() if ln.startswith("scheduled-claude"))
+    assert "BLOCK" in sched_line
+    assert rc == 1

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -712,6 +712,28 @@ _CASES: list[tuple[str, object, int, str]] = [
         2,
         "scheduled Claude review(s) missing",
     ),
+    # A PENDING review is an unpublished DRAFT — its marker (even for all kinds at head)
+    # must NOT satisfy the gate (a producer that created but never submitted the review).
+    (
+        "scheduled_review_pending_draft_blocks",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            scheduled=json.dumps(
+                {
+                    "login": "owner",
+                    "author_association": "OWNER",
+                    "state": "PENDING",
+                    "body": (
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=code-review -->\n"
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
+                    ),
+                }
+            ),
+        ),
+        2,
+        "scheduled Claude review(s) missing",
+    ),
     # The # scheduled-review-override sigil consciously waives the gate → an absent
     # scheduled review still merges.
     (
@@ -882,3 +904,24 @@ def test_check_pr_report_scheduled_absent_fails_verdict(monkeypatch, capsys):
     sched_line = next(ln for ln in out.splitlines() if ln.startswith("scheduled-claude"))
     assert "BLOCK" in sched_line
     assert rc == 1
+
+
+def test_check_pr_report_no_merge_with_when_scheduled_blocks(monkeypatch, capsys):
+    """The actionable ``merge-with`` command must NOT be printed when a later gate (the
+    scheduled review) would block — otherwise the report suggests a mergeable PR that is
+    not. (Codex P2: merge-with was emitted right after codex-at-head, before this gate.)"""
+    _report_env(monkeypatch, scheduled="")  # scheduled gate blocks
+    rc = _mod.check_pr_report("100", repo=REPO)
+    out = capsys.readouterr().out
+    assert "merge-with" not in out, "merge-with printed despite a blocking scheduled gate"
+    assert rc == 1
+
+
+def test_check_pr_report_prints_merge_with_when_all_pass(monkeypatch, capsys):
+    """When EVERY gate passes, the report prints the bound merge-with command."""
+    _report_env(monkeypatch, scheduled=_scheduled_marker(HEAD))
+    rc = _mod.check_pr_report("100", repo=REPO)
+    out = capsys.readouterr().out
+    assert "merge-with" in out
+    assert "--match-head-commit" in out
+    assert rc == 0

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -734,6 +734,51 @@ _CASES: list[tuple[str, object, int, str]] = [
         2,
         "scheduled Claude review(s) missing",
     ),
+    # The marker means "ran CLEAN": a review whose body carries a blocking finding
+    # ([P1]/HARD BLOCK/### ERROR) is rejected even with both markers at head → block.
+    (
+        "scheduled_review_with_blocking_finding_blocks",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            scheduled=json.dumps(
+                {
+                    "login": "owner",
+                    "author_association": "OWNER",
+                    "body": (
+                        "### ERROR\n[P1] null deref in foo()\n"
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=code-review -->\n"
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
+                    ),
+                }
+            ),
+        ),
+        2,
+        "scheduled Claude review(s) missing",
+    ),
+    # Clean-wins: a body that MENTIONS a blocking token but also carries a clean verdict
+    # (VERDICT: PASS) is treated as clean → the markers count → allow. (Same rule as the
+    # bot finding scanners.)
+    (
+        "scheduled_review_blocking_mention_but_clean_verdict_allows",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            scheduled=json.dumps(
+                {
+                    "login": "owner",
+                    "author_association": "OWNER",
+                    "body": (
+                        "Scanned for [P1] issues — VERDICT: PASS\n"
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=code-review -->\n"
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
+                    ),
+                }
+            ),
+        ),
+        0,
+        "",
+    ),
     # The # scheduled-review-override sigil consciously waives the gate → an absent
     # scheduled review still merges.
     (

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -649,6 +649,47 @@ _CASES: list[tuple[str, object, int, str]] = [
         2,
         "code-review",
     ),
+    # A status-suffixed value (`head=<sha>/failed`, `kind=leaks/failed`) must NOT be
+    # captured as a clean prefix — the value has to be terminated by whitespace or the
+    # marker-block end, else a failed/corrupt routine output would satisfy the gate.
+    (
+        "scheduled_review_suffixed_head_blocks",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            scheduled=json.dumps(
+                {
+                    "login": "owner",
+                    "author_association": "OWNER",
+                    "body": (
+                        f"<!-- genesis-scheduled-review: head={HEAD}/failed kind=code-review -->\n"
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
+                    ),
+                }
+            ),
+        ),
+        2,
+        "code-review",  # the suffixed code-review head is not captured → missing
+    ),
+    (
+        "scheduled_review_suffixed_kind_blocks",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            scheduled=json.dumps(
+                {
+                    "login": "owner",
+                    "author_association": "OWNER",
+                    "body": (
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks/failed -->\n"
+                        f"<!-- genesis-scheduled-review: head={HEAD} kind=code-review -->"
+                    ),
+                }
+            ),
+        ),
+        2,
+        "leaks",  # the suffixed leaks kind is not captured → missing
+    ),
     # The # scheduled-review-override sigil consciously waives the gate → an absent
     # scheduled review still merges.
     (

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1527,6 +1527,12 @@ class TestCiGateEndToEnd:
             "_check_base_is_default",
             lambda n, force=False, repo=None: (False, ""),
         )
+        # Scheduled-Claude-review gate is a real network check too — pass-through.
+        monkeypatch.setattr(
+            guard_module,
+            "_check_scheduled_claude_reviewed_head",
+            lambda n, head=None, repo=None, force=False, strict=False: None,
+        )
 
     def test_red_ci_blocks_exit_2(self, guard_module, monkeypatch, capsys):
         monkeypatch.setenv(
@@ -1636,6 +1642,11 @@ class TestMergeableAllowlist:
             "_check_codex_reviewed_head",
             lambda n, force=False, repo=None: (False, "", None),
         )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_scheduled_claude_reviewed_head",
+            lambda n, head=None, repo=None, force=False, strict=False: None,
+        )
 
     @pytest.mark.parametrize("bad", [None, "", "UNKNOWN", "SOMETHING_NEW"])
     def test_non_mergeable_blocks(self, guard_module, monkeypatch, bad):
@@ -1705,6 +1716,11 @@ class TestRepoDerivationGate:
             guard_module,
             "_check_codex_reviewed_head",
             lambda n, force=False, repo=None: (False, "", None),
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_scheduled_claude_reviewed_head",
+            lambda n, head=None, repo=None, force=False, strict=False: None,
         )
 
     def test_derived_repo_threads_into_gates(self, guard_module, monkeypatch):
@@ -1926,6 +1942,14 @@ class TestGateOrdering:
             guard_module,
             "_check_codex_reviewed_head",
             lambda n, force=False, repo=None: (calls.append("freshness"), (False, "", None))[1],
+        )
+        monkeypatch.setattr(
+            guard_module,
+            "_check_scheduled_claude_reviewed_head",
+            lambda n, head=None, repo=None, force=False, strict=False: (
+                calls.append("scheduled"),
+                None,
+            )[1],
         )
         monkeypatch.setattr(
             guard_module,

--- a/tests/test_hooks/test_shell_parse.py
+++ b/tests/test_hooks/test_shell_parse.py
@@ -119,6 +119,16 @@ class TestOverride:
             seg = sp.analyze(cmd)[0].raw
             assert sp.has_trailing_override(seg, sigil="audit-ack"), cmd
             assert sp.has_trailing_override(seg, sigil="depth-ack"), cmd
+        # Every merge-gate sigil must be in _KNOWN_SIGILS or it ENDS the leading run and
+        # silently breaks combined waivers. scheduled-review-override (newest) combined
+        # with stale-review-override: BOTH must still resolve regardless of order.
+        for cmd in (
+            "gh pr merge 1 --squash --admin # stale-review-override scheduled-review-override",
+            "gh pr merge 1 --squash --admin # scheduled-review-override stale-review-override",
+        ):
+            seg = sp.analyze(cmd)[0].raw
+            assert sp.has_trailing_override(seg, sigil="stale-review-override"), cmd
+            assert sp.has_trailing_override(seg, sigil="scheduled-review-override"), cmd
 
     def test_multi_token_still_rejects_prefix_of_longer_token(self):
         # The multi-token scan must NOT loosen the exact-token guard: a sigil that is a


### PR DESCRIPTION
## What

Adds the **fourth** automated-review signal to the pre-merge gate
(`scripts/hooks/git_push_guard.py`). The gate already hard-blocks `gh pr merge`
on **Codex-review-at-HEAD**, **CI status**, and **leaks** (via the blocking
`leak-detector` CI job). This adds the missing one: a **scheduled Claude review**
must have run on the PR's current head.

A scheduled Claude review (a `/schedule` cloud routine) posts as the repo
**OWNER's** account (not a bot), so it's detected by a marker it emits:

```
<!-- genesis-scheduled-review: head=<full-40-hex-sha> -->
```

`gh pr merge` is **blocked** unless an owner-authored marker names the PR's
current head — so a review that never ran, ran on a stale commit, or was
rate-limited can't slip a merge through. If it's pending/rate-limited, wait, or
append **`# scheduled-review-override`** to merge anyway (an independent sigil —
one waiver never disarms another gate).

## Why

Completes the "check every automated PR review before merge" guarantee as a
**mandatory, enforced** step rather than a manual habit. The `--check-pr` report
and the enforcement gate share the same functions, so they can never diverge.

## Design / safety

- Fail-**closed** everywhere: an unreadable head or comments/reviews fetch
  **blocks** (never a false all-clear); absent/stale markers block.
- Owner-trust: `login == repo-owner OR author_association == "OWNER"`
  (case-insensitive). The marker is the trust anchor (single-author,
  non-adversarial model — see the docstring caveat re: the producer).
- Wired into both the merge stack (after Codex freshness + the `--match-head-commit`
  TOCTOU binding) and `check_pr_report`.
- **Atomic on the normal path:** the Codex `--match-head-commit` binding pins the
  merge to the same head the marker was verified at. Under `# stale-review-override`
  (a conscious waiver of atomic binding for all gates) the check is point-in-time —
  documented, consistent with that sigil's existing semantics.
- `_KNOWN_SIGILS` updated (its own sync invariant) so combined waivers keep working;
  extracted `_require_match_head` (DRY) reused by the Codex path.

## Security review

`genesis-security-reviewer` (adversarial): **no fail-open** in the gate's logic.
One **HIGH** (a docstring over-claim about atomicity under `# stale-review-override`)
resolved by making the claim honest + consistent. LOWs fixed (`_KNOWN_SIGILS` sync,
case-fold) or documented (commit_id defense-in-depth follow-up; producer prompt-injection
dependency).

## Tests

**391** gate-suite tests pass (`test_merge_gate_characterization`, `test_shell_parse`,
`test_merge_review_gate`, `test_git_push_guard_codex_freshness`), `ruff` clean. New cases:
marker-at-head allows; stale/absent/non-owner block; override waives; sigil independence;
owner case-insensitive; combined-sigil; `check_pr_report` scheduled-claude line.

## Operator action required

Add the marker line to your `/schedule` Claude PR-review prompt so it stamps the
head it reviewed, e.g.:

> After completing the review, post a PR comment ending with exactly this line
> (fill in the full 40-char commit sha you reviewed):
> `<!-- genesis-scheduled-review: head=<HEAD_SHA> -->`

## Deploy path

Hook change — takes effect on the next CC session start (hooks are re-read per
session). Additive; no runtime/migration impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
