### PR TITLE
fix(hooks): lock duplicated value-flag specs against drift + fix privacy hook --super-prefix (E2)

### DIFF
--- a/scripts/hooks/pre_push_privacy_review.py
+++ b/scripts/hooks/pre_push_privacy_review.py
@@ -51,7 +51,18 @@ _SRC = Path(__file__).resolve().parents[2] / "src"
 if _SRC.is_dir():
     sys.path.insert(0, str(_SRC))
 
-_GIT_GLOBAL_VALUE_OPTS = ("-C", "-c", "--git-dir", "--work-tree", "--namespace")
+# git global options that consume the FOLLOWING token as their value. Kept
+# identical to the copies in git_push_guard/shell_parse/review_enforcement_commit
+# (locked by tests/test_hooks/test_value_flag_consistency.py) — a missing member
+# here silently skips the advisory scan on that command form.
+_GIT_GLOBAL_VALUE_OPTS = (
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--super-prefix",
+)
 _PUSH_VALUE_FLAGS = ("-o", "--push-option", "--repo", "--receive-pack", "--exec")
 _MAX_LINES = 20
 # Total wall-clock budget for ALL git calls in one invocation, and a per-call

--- a/tests/test_hooks/test_pre_push_privacy_review.py
+++ b/tests/test_hooks/test_pre_push_privacy_review.py
@@ -68,6 +68,23 @@ def test_push_remote_compound_command():
     assert hook._push_remote("git push | tee log.txt") == ""
 
 
+def test_push_remote_skips_super_prefix_value():
+    # `git --super-prefix <path> push <remote>`: --super-prefix consumes its
+    # value. If the parser does not skip that value it lands on the path token,
+    # never sees `push`, and misreads the command as "not a push" → the advisory
+    # scan silently SKIPS. The privacy hook's git-global value-flag set was
+    # missing --super-prefix (the guard + shell_parse copies already had it);
+    # locked identical by test_value_flag_consistency.
+    assert hook._push_remote("git --super-prefix /tmp/sp push origin main") == "origin"
+
+
+def test_effective_cwd_skips_super_prefix_to_find_dash_C():
+    # --super-prefix must be consumed WITH its value so a following `-C <dir>` is
+    # still found — otherwise the push is scanned against the wrong cwd.
+    cwd = hook._effective_cwd("git --super-prefix /tmp/sp -C /work push origin main", "/payload")
+    assert cwd == "/work"
+
+
 # ── _scan (reuses the sanitizer's cheap regex scanners) ────────────────
 
 

--- a/tests/test_hooks/test_value_flag_consistency.py
+++ b/tests/test_hooks/test_value_flag_consistency.py
@@ -1,0 +1,85 @@
+"""Consistency LOCK for the value-flag specs duplicated across the guard hooks.
+
+The pr-merge / push / commit guards each carry their OWN copy of the gh/git
+"value-flag" sets — the flags that consume the FOLLOWING argv token as their
+value (so a scan for a positional/binding does not misread that value). Those
+copies MUST stay identical across files: a flag added to one copy but not the
+others is exactly the parse divergence that let the separated ``-R`` form
+bypass every fail-closed merge gate (``gh pr -R o/r merge N --admin``, #1385
+round-5).
+
+This test is the drift TRIP-WIRE. Physical de-duplication (one shared spec) is
+deliberately deferred to the gate-core extraction (S3) — which restructures
+these files anyway; until then this lock makes the next silent drift a RED CI
+check instead of a live bypass.
+
+If this test FAILS: you changed ONE copy of a value-flag set. Update ALL copies
+named in the failing assertion so they match again — they are intentionally
+identical, not coincidentally so.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[2]
+# The guard hooks live in scripts/hooks/ (shell_parse, git_push_guard,
+# pre_push_privacy_review) and scripts/ (review_enforcement_commit); the privacy
+# hook also imports genesis.contribution.sanitize, so src/ must be importable.
+for _p in ("scripts/hooks", "scripts", "src"):
+    _abs = str(_ROOT / _p)
+    if _abs not in sys.path:
+        sys.path.insert(0, _abs)
+
+import git_push_guard as gpg  # noqa: E402
+import pre_push_privacy_review as ppr  # noqa: E402
+import review_enforcement_commit as rec  # noqa: E402
+import shell_parse as sp  # noqa: E402
+
+# git global options that consume the FOLLOWING token as their value. Every copy
+# below MUST equal this canonical set (compared as a set — a copy may be a
+# frozenset or a tuple; only membership matters).
+_CANONICAL_GIT_GLOBAL_VALUE_FLAGS = frozenset(
+    {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix"}
+)
+# git push flags that consume the FOLLOWING token as their value.
+_CANONICAL_PUSH_VALUE_FLAGS = frozenset(
+    {"-o", "--push-option", "--repo", "--receive-pack", "--exec"}
+)
+
+
+def test_git_global_value_flags_identical_across_all_copies():
+    """The four git-global value-flag copies must be byte-identical (as sets)."""
+    copies = {
+        "git_push_guard._GIT_GLOBAL_VALUE_FLAGS": gpg._GIT_GLOBAL_VALUE_FLAGS,
+        "shell_parse._GIT_OPTS_WITH_ARG": sp._GIT_OPTS_WITH_ARG,
+        "review_enforcement_commit._GIT_GLOBAL_VALUE_FLAGS": rec._GIT_GLOBAL_VALUE_FLAGS,
+        "pre_push_privacy_review._GIT_GLOBAL_VALUE_OPTS": ppr._GIT_GLOBAL_VALUE_OPTS,
+    }
+    for name, spec in copies.items():
+        members = set(spec)
+        assert members == set(_CANONICAL_GIT_GLOBAL_VALUE_FLAGS), (
+            f"{name} drifted from the canonical git-global value-flag set. "
+            f"All copies MUST stay identical — update every one of "
+            f"{sorted(copies)}. "
+            f"Missing={set(_CANONICAL_GIT_GLOBAL_VALUE_FLAGS) - members}, "
+            f"Extra={members - set(_CANONICAL_GIT_GLOBAL_VALUE_FLAGS)}"
+        )
+
+
+def test_push_value_flags_identical_across_all_copies():
+    """The two git-push value-flag copies must be byte-identical (as sets)."""
+    copies = {
+        "git_push_guard._PUSH_VALUE_FLAGS": gpg._PUSH_VALUE_FLAGS,
+        "pre_push_privacy_review._PUSH_VALUE_FLAGS": ppr._PUSH_VALUE_FLAGS,
+    }
+    for name, spec in copies.items():
+        members = set(spec)
+        assert members == set(_CANONICAL_PUSH_VALUE_FLAGS), (
+            f"{name} drifted from the canonical git-push value-flag set. "
+            f"All copies MUST stay identical — update every one of "
+            f"{sorted(copies)}. "
+            f"Missing={set(_CANONICAL_PUSH_VALUE_FLAGS) - members}, "
+            f"Extra={members - set(_CANONICAL_PUSH_VALUE_FLAGS)}"
+        )


### PR DESCRIPTION
## What

The pr-merge / push / commit guard hooks each carry their **own copy** of the gh/git "value-flag" sets — flags that consume the *following* argv token as their value. Those copies must stay identical: a flag present in one copy but missing from another is the parse divergence that let the separated `-R` form bypass every fail-closed merge gate (#1385). This PR locks them and fixes the one live divergence.

## Changes

1. **Drift trip-wire** — `tests/test_hooks/test_value_flag_consistency.py` asserts membership equality (compared as `set()`, so frozenset-vs-tuple type differences don't matter) for the two cross-file-duplicated families:
   - git-global 6-set across 4 copies (`git_push_guard`, `shell_parse`, `review_enforcement_commit`, `pre_push_privacy_review`);
   - push 5-set across 2 copies (`git_push_guard`, `pre_push_privacy_review`).

   Physical de-duplication is intentionally deferred to the gate-core extraction; until then this makes the next silent drift a red CI check instead of a live bypass.

2. **Fix the one live divergence** — the privacy advisory hook's git-global set was missing `--super-prefix` (the guard + `shell_parse` copies already had it). Without it, `git --super-prefix <path> push origin` was misread as "not a push" and the leak-scan silently skipped. Adding it fixes both `_push_remote` and `_effective_cwd`. Advisory/non-blocking hook — strictly a correctness improvement.

## Testing

- **RED-first**: the git-global lock and both `--super-prefix` behavior tests fail on the pre-fix code for the right reasons; the fix flips them green. The push lock (already consistent) was verify-RED'd by in-memory mutation.
- `tests/test_hooks/` + `tests/test_scripts/` = **2709 passed**; `ruff --no-cache` clean.
- E2E on fresh import: `_push_remote('git --super-prefix … push origin main')` → `origin`; `_effective_cwd` → the `-C` dir; regressions intact.

## Deferred

Review surfaced a **third** drifting family — `shell_parse._COMMIT_ARG_FLAGS` is missing `-t` vs `review_enforcement_commit._COMMIT_ARG_SHORT`. It is safe-directioned (only spurious commit-gate false-positives, never a hidden `--no-verify`) and is a behavior change to the fail-closed commit gate, so it is tracked as a separate follow-up rather than folded into this test-focused slice.
