### PR TITLE
feat(routing): executor Gate 2 (17) leads with paid V4-pro (quality lever)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Changed
+
+- **Executor Gate 2 (`17_executor_review`) leads with paid DeepSeek V4-pro.**
+  After the NIM repoint moved the free NIM tier from V4-pro to V4-flash, this
+  deliverable-quality gate now leads with the paid `openrouter-deepseek-v4`
+  (pro-grade) for maximum review quality, with free NIM flash + paid v4-flash +
+  qwen as fallbacks. A deliberate cost-vs-quality lever on a quality-critical
+  gate; the other repointed sites stay on free flash.
+
 ### Fixed
 
 - **Dead NVIDIA NIM models retired from routing (silent free→paid fallback leak

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -351,11 +351,15 @@ call_sites:
     default_paid: true
     dispatch: cli
     cc_model: Sonnet
+  # Executor Gate 2 deliverable-quality review leads with paid V4-pro
+  # (openrouter-deepseek-v4): a user-chosen pro-grade lever for this quality gate,
+  # since NIM's free tier now serves flash (not pro) after the 2026-08 repoint.
+  # Free NIM flash + paid v4-flash + qwen remain as fallbacks.
   17_executor_review:
     chain:
+    - openrouter-deepseek-v4
     - nvidia-nim-deepseek
     - openrouter-deepseek-v4-flash
-    - openrouter-deepseek-v4
     - openrouter-qwen36plus
     default_paid: true
     description: "Task executor Gate 2 — cross-vendor quality review of deliverables. Renamed from 17_fresh_eyes_review 2026-05-10 (disambiguates from outreach pre-send check at 23_outreach_review)."


### PR DESCRIPTION
## What

Follow-up to the NIM repoint (#1414). That change moved NIM's free tier from DeepSeek
V4-pro (EOL'd) to V4-flash, which dropped `17_executor_review` — the executor's Gate 2
deliverable-quality review — from free pro to free flash. This flips it to lead with the
paid, calibrated `openrouter-deepseek-v4` (V4-pro) for maximum review quality:

```
17_executor_review: [openrouter-deepseek-v4 (pro), nvidia-nim-deepseek (flash),
                     openrouter-deepseek-v4-flash, openrouter-qwen36plus]
```

Free NIM flash + paid v4-flash + qwen remain as fallbacks (`default_paid: true` unchanged).

## Why only 17

`20_adversarial_counterargument` (Gate 3) is deliberately left unchanged — it already leads
with `openrouter-gpt55` (GPT-5.5, frontier paid), so it was never quality-regressed by the
repoint. Flipping it to deepseek-pro would be a lateral downgrade and would collapse the
model diversity between Gate 2 and Gate 3. The other repointed sites stay on free flash.

## Verification

Config loads; 17's primary resolves to `deepseek/deepseek-v4-pro` (paid). No test pins 17's
chain content (the executor-review tests mock by call-site name; the api-keys test uses a
synthetic fixture), so the reorder breaks no assertion. Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
