### PR TITLE
fix(install): apply memory-resilience provisioning on fresh container installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Fresh container installs now get OOM/fork-wedge protection.**
+  `scripts/install.sh` (the fresh-container path) never applied the
+  memory-resilience provisioning (systemd-oomd pressure-kill, swap invariant,
+  raised per-user-slice `TasksMax`) that `bootstrap.sh` and `update.sh` already
+  did — so a freshly installed box sat unprotected against the OOM-thrash /
+  `Cannot fork` wedge until its first `update.sh` run. It now applies the same
+  idempotent, adaptive provisioning at install time.
+
 - **The core Claude Code spawner now uses the shared hardened group-kill.**
   `cc/invoker.py` — the launcher behind every CC session Genesis runs — carried
   the patterns the repo-wide sweep retired everywhere else: `preexec_fn` spawns,

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1460,7 +1460,7 @@ verified: 3c514f3e 2026-08-10
   don't merge them. Memory-resilience invariants are first-class facts:
   container `cgroup_memory_swap_max` (tri-state — "0" IS the 2026-07 wedge
   state) + `oomd_user_slice_kill` (config-plane scan of user.slice.d drop-ins,
-  laid down by `scripts/lib/memory_resilience.sh` from bootstrap/update) and
+  laid down by `scripts/lib/memory_resilience.sh` from install/bootstrap/update) and
   host-plane `swap_total_kb`, so the annotation layer flags unprotected
   installs (see docs/reference/memory-resilience.md). Network-resilience
   invariants are first-class too: container `networkd_keep_configuration` +

--- a/docs/reference/memory-resilience.md
+++ b/docs/reference/memory-resilience.md
@@ -23,9 +23,9 @@ The fingerprint, if you're diagnosing it live:
 
 ## What Genesis sets up (and what it only warns about)
 
-`scripts/lib/memory_resilience.sh` runs from `bootstrap.sh` on fresh installs
-and from every `update.sh` (which re-runs bootstrap), so existing installs
-retrofit automatically. It is idempotent and **adaptive — every threshold is a
+`scripts/lib/memory_resilience.sh` runs from `install.sh` and `bootstrap.sh` on
+fresh installs and from every `update.sh` (which re-runs bootstrap), so existing
+installs retrofit automatically. It is idempotent and **adaptive — every threshold is a
 pressure percentage, never an absolute byte value**, so the same config
 right-sizes from a small VPS to a large workstation:
 
@@ -106,7 +106,7 @@ budget is exhausted well before memory/CPU/disk, so new processes fail with
 **`Cannot fork`** while every other axis reads green.
 
 `pid_budget_apply` (in `scripts/lib/memory_resilience.sh`, run from
-`bootstrap.sh`/`update.sh` alongside the oomd setup) lays down
+`install.sh`/`bootstrap.sh`/`update.sh` alongside the oomd setup) lays down
 `/etc/systemd/system/user-.slice.d/90-genesis-tasksmax.conf` →
 **`TasksMax=60%`**. Like the pressure thresholds it is a **percentage, not an
 absolute count**, so it self-calibrates to each box's own budget. **60%, not

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1195,6 +1195,33 @@ if [ -f "$SYSTEMD_USER_DIR/genesis-server.service" ]; then
     fi
 fi
 
+# --- Memory resilience (systemd-oomd pressure-kill + swap invariant + PID ceiling) ---
+# Fresh-install parity with bootstrap.sh/update.sh: without this block a fresh
+# container install sat unprotected against the OOM-thrash / fork-exhaustion
+# wedge, with NO automatic trigger to run update.sh. Guarded so a tree missing
+# the lib degrades (warns) rather than aborting under `set -euo pipefail` — the
+# lib's own never-abort contract. Uses install.sh's own `_install_pkg` idiom
+# (bootstrap's `install_pkg` is undefined here). See scripts/lib/memory_resilience.sh.
+if [[ -f "$SCRIPT_DIR/lib/memory_resilience.sh" ]]; then
+    # systemd-oomd is a SEPARATE apt/dnf package; memory_resilience_apply
+    # silently skips pressure-kill setup when it's absent, so provision it
+    # BEFORE sourcing/applying the lib (install → apply order). _install_pkg is
+    # idempotent and degrades to a warning; the lib still guards on PSI/systemd
+    # independently. (dnf: oomd ships inside systemd; the subpackage is
+    # systemd-oomd-defaults.)
+    _install_pkg systemd-oomd systemd-oomd-defaults || echo "  WARNING: Could not install systemd-oomd — if the next step reports 'systemd-oomd not available', pressure-kill protection is off."
+    # shellcheck source=lib/memory_resilience.sh
+    source "$SCRIPT_DIR/lib/memory_resilience.sh"
+    memory_resilience_apply
+    # PID/task ceiling: raise the per-user-slice TasksMax above systemd's stock
+    # 33% default (the fork-exhaustion blind spot). Same lib, same never-abort
+    # contract; surfaces via the posture check (pid_ceiling_effective_ok) when
+    # sudo/etc is unavailable.
+    pid_budget_apply
+else
+    echo "  WARNING: lib/memory_resilience.sh missing — skipping OOM-resilience setup"
+fi
+
 # Infrastructure report
 echo ""
 echo "    === Infrastructure Report ==="

--- a/scripts/lib/memory_resilience.sh
+++ b/scripts/lib/memory_resilience.sh
@@ -18,10 +18,11 @@
 #
 # Degrades gracefully: no systemd, no systemd-oomd, no PSI, or no usable
 # sudo each produce a one-line skip note and rc=0 — this must never abort
-# bootstrap.sh/update.sh under `set -e`.
+# install.sh/bootstrap.sh/update.sh under `set -e`.
 #
-# Sourced by scripts/bootstrap.sh (fresh installs) and scripts/update.sh
-# (existing installs retrofit on their next update). Idempotent: unchanged
+# Sourced by scripts/install.sh + scripts/bootstrap.sh (fresh installs) and
+# scripts/update.sh (existing installs retrofit on their next update).
+# Idempotent: unchanged
 # drop-ins are left untouched and produce no systemd churn.
 #
 # Test seams (defaults are the real system paths; pytest overrides these and

--- a/tests/test_scripts/test_memory_resilience.py
+++ b/tests/test_scripts/test_memory_resilience.py
@@ -10,12 +10,14 @@ invariant check (vantage-aware: container vs bare/VM).
 
 from __future__ import annotations
 
+import re
 import subprocess
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LIB = REPO_ROOT / "scripts" / "lib" / "memory_resilience.sh"
 BOOTSTRAP = REPO_ROOT / "scripts" / "bootstrap.sh"
+INSTALL = REPO_ROOT / "scripts" / "install.sh"
 
 _SUDO_STUB = """#!/bin/bash
 # Passthrough sudo: "-n true" honors $SUDO_N_RC (0 = passwordless ok).
@@ -265,6 +267,46 @@ def test_update_sh_wires_the_lib_visibly():
     text = (REPO_ROOT / "scripts" / "update.sh").read_text()
     assert "lib/memory_resilience.sh" in text
     assert text.count("memory_resilience_apply") >= 1
+
+
+def test_install_wires_the_lib():
+    # install.sh (the fresh-container path) must apply memory-resilience too —
+    # bootstrap.sh and update.sh did, but install.sh did not, so a fresh
+    # container install sat unprotected against the OOM/fork wedge with NO
+    # automatic trigger to run update.sh (the salvaged red-team gap).
+    text = INSTALL.read_text()
+    assert 'source "$SCRIPT_DIR/lib/memory_resilience.sh"' in text
+    assert "memory_resilience_apply" in text
+    assert "pid_budget_apply" in text
+
+
+def test_install_provisions_the_oomd_package_with_its_own_idiom():
+    """install.sh must provision systemd-oomd BEFORE applying the lib — using
+    install.sh's OWN package helper (``_install_pkg``), never bootstrap's bare
+    ``install_pkg``.
+
+    install.sh defines ``_install_pkg``/``_PKG_MGR`` (underscore-prefixed); it
+    has no ``install_pkg``. A verbatim copy of bootstrap's block would call an
+    undefined function and hard-abort a fresh install under ``set -euo
+    pipefail``. Lock the idiom and the install→apply ordering.
+    """
+    text = INSTALL.read_text()
+    assert "_install_pkg systemd-oomd" in text
+    # No BARE install_pkg call (not preceded by the underscore) — that function
+    # is undefined in install.sh and would abort the run.
+    assert re.search(r"(?<!_)install_pkg systemd-oomd", text) is None
+    # Ordering: provision must precede sourcing/applying the lib, or the first
+    # run still skips pressure-kill setup (oomd-absent → silent skip).
+    source_line = 'source "$SCRIPT_DIR/lib/memory_resilience.sh"'
+    assert text.index("_install_pkg systemd-oomd") < text.index(source_line)
+
+
+def test_install_guards_the_lib_source():
+    # The block must be guarded so a tree missing the lib degrades (echoes a
+    # warning) instead of aborting install.sh — mirrors bootstrap's guard and
+    # relies on the lib's own never-abort contract.
+    text = INSTALL.read_text()
+    assert '[[ -f "$SCRIPT_DIR/lib/memory_resilience.sh" ]]' in text
 
 
 # ── pid_budget_apply (per-user-slice TasksMax=60% provisioning) ──────────────


### PR DESCRIPTION
## What

`scripts/install.sh` (the fresh-container installer) never applied the
memory-resilience provisioning that `bootstrap.sh` and `update.sh` already do —
systemd-oomd pressure-kill, the swap invariant, and the raised per-user-slice
`TasksMax`. Because nothing auto-runs `update.sh` after a fresh install, a newly
installed box sat unprotected against the OOM-thrash / `Cannot fork` wedge until
its first manual update.

This inserts a guarded block into install.sh Step 11 that mirrors
`bootstrap.sh`, using install.sh's **own** `_install_pkg` idiom — bootstrap's
bare `install_pkg` is undefined in install.sh, so a verbatim copy would
hard-abort a fresh install under `set -euo pipefail`.

## Why it's safe

- The lib entrypoints (`memory_resilience_apply`, `pid_budget_apply`) are
  contractually always-return-0; `_install_pkg … || echo` neutralizes a failed
  package install. The block cannot abort the installer.
- Verified by an isolated dry-run: oomd-installs, oomd-install-fails, and
  re-run cases all exit 0 with the lib taking its clean skip path.
- 3 new locking tests in `test_memory_resilience.py` (idiom, install→apply
  ordering, guard) — verified RED before the fix, green after (24 passed).
- Adversarial review (genesis-architect, fresh context): no BLOCKER/SHOULD-FIX;
  two NOTE-level doc-staleness gaps it surfaced are fixed in this PR.

## Scope

Closes gap **(a)** of follow-up `d7ffc73b`. The **(b)** consolidation of the
13+ other `install.sh` ↔ `bootstrap.sh` provisioning gaps remains open as
separate work.

## Docs

Corrected `docs/reference/memory-resilience.md`, `docs/architecture/CURRENT.md`,
and the lib header to list `install.sh` as a third caller. CHANGELOG entry added.

Ledger: ccc9b74c788c49f89064777f902551ca
