### PR TITLE
fix(hooks): dedup concurrency-cancelled CI check-runs in the merge gate

### DIFF
--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -597,16 +597,31 @@ def _check_mergeable(pr_num: str, repo: str | None = None) -> str | None:
         return None  # unreadable → caller treats as non-MERGEABLE → blocks
 
 
-# Check-run conclusions / statuses that mean the CI is NOT green.
-_CI_RED_CONCLUSIONS = {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "STARTUP_FAILURE"}
+# Check-run conclusions / statuses that mean the CI is NOT green. STALE is a real
+# GitHub conclusion (a superseded/outdated run — NOT a pass) and is red; any OTHER
+# unrecognized *terminal* conclusion also fails closed to red in the classify loop,
+# so no unenumerated conclusion value can be silently mistaken for green.
+_CI_RED_CONCLUSIONS = {
+    "FAILURE",
+    "CANCELLED",
+    "TIMED_OUT",
+    "ACTION_REQUIRED",
+    "STARTUP_FAILURE",
+    "STALE",
+}
 _CI_RED_STATES = {"FAILURE", "ERROR"}  # legacy StatusContext state
 _CI_SKIP_CONCLUSIONS = {"SKIPPED", "NEUTRAL"}
 _CI_GREEN = {"SUCCESS"}
+# Legacy StatusContext states meaning "not finished" → block as pending. EXPECTED =
+# a required context that has not reported a status yet (not started); it must not
+# read green. (A CheckRun uses `status` for this; a StatusContext uses `state`.)
+_CI_PENDING_STATES = {"PENDING", "EXPECTED"}
 # A CANCELLED check-run carries NO pass/fail verdict — the run was aborted,
 # almost always by a `concurrency: cancel-in-progress` supersession, which leaves
 # the cancelled dup attached to the head commit. It is red BY DEFAULT (it is also
 # in _CI_RED_CONCLUSIONS), and dropped ONLY when a check of the SAME identity
-# (name + workflowName, see _ci_identity) also concluded SUCCESS on this head.
+# (name + workflowName, see _ci_identity) concluded SUCCESS at-or-after it on this
+# head (so a SUCCESS-then-cancel re-run on an unchanged head still blocks).
 # Deliberately scoped to CANCELLED alone: FAILURE/TIMED_OUT/ACTION_REQUIRED/
 # STARTUP_FAILURE carry real verdicts and always block, even with a success sibling.
 _CI_CANCEL_CONCLUSIONS = {"CANCELLED"}
@@ -657,11 +672,12 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
     Returns ``(state, problem_checks)`` where state is one of:
       * ``"green"``   — every non-skipped check concluded SUCCESS
       * ``"red"``     — at least one check failed/timed-out, or was cancelled
-                        with NO same-identity SUCCESS on this head. A CANCELLED
-                        CheckRun whose (name, workflowName) identity also has a
-                        SUCCESS is a superseded `concurrency: cancel-in-progress`
-                        duplicate and is dropped (see _ci_identity) — strict
-                        identity, set-membership only, no time-ordering.
+                        with NO same-identity SUCCESS completing at-or-after it.
+                        A CANCELLED CheckRun that a same (name, workflowName)
+                        SUCCESS completed at-or-after is a superseded
+                        `concurrency: cancel-in-progress` duplicate and is dropped
+                        (see _ci_identity + success_latest) — strict identity,
+                        terminal completedAt comparison only, fail-closed.
       * ``"pending"`` — a check is still queued/running (and none are red)
       * ``"unknown"`` — could not determine (API error, no checks, or an
                         unrecognized payload shape) → callers FAIL OPEN, because
@@ -702,19 +718,26 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
     if not isinstance(checks, list) or not checks:
         return "unknown", []
 
-    # First pass: strict identities (name, workflowName) that concluded SUCCESS on
-    # this head — the sibling set used to drop superseded concurrency-cancel
-    # duplicates. Only GitHub Actions CheckRuns with a resolvable identity qualify
-    # (see _ci_identity); legacy StatusContexts and non-Actions checks never serve
-    # as siblings. Set-membership ONLY — deliberately no time-ordering (that
-    # surface was the pulled #1420 attempt's finding-magnet).
-    success_ids = {
-        ident
-        for c in checks
-        if isinstance(c, dict)
-        and c.get("conclusion") in _CI_GREEN
-        and (ident := _ci_identity(c)) is not None
-    }
+    # First pass: for each strict identity (name, workflowName), the latest
+    # `completedAt` among its SUCCESS CheckRuns on this head. A CANCELLED entry is
+    # a superseded concurrency-cancel duplicate ONLY if a SUCCESS of the same
+    # identity completed AT OR AFTER it (see the drop branch). Only GitHub Actions
+    # CheckRuns with a resolvable identity AND a completedAt contribute; legacy
+    # StatusContexts, non-Actions checks, and timestampless successes never serve
+    # as siblings. This is NOT the #1420 finding-magnet: that sorted the WHOLE set
+    # (incl. QUEUED runs with null startedAt) to pick a global "latest"; here both
+    # sides of the comparison are terminal COMPLETED runs that always carry a
+    # completedAt, and every unresolvable case fails CLOSED (stays red).
+    success_latest: dict[tuple[str, str], str] = {}
+    for c in checks:
+        if not isinstance(c, dict) or c.get("conclusion") not in _CI_GREEN:
+            continue
+        ident = _ci_identity(c)
+        ts = (c.get("completedAt") or "").strip()
+        if ident is None or not ts:
+            continue
+        if ts > success_latest.get(ident, ""):
+            success_latest[ident] = ts
 
     red: list[str] = []
     pending: list[str] = []
@@ -731,15 +754,17 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
             continue
         if conclusion in _CI_CANCEL_CONCLUSIONS:
             ident = _ci_identity(c)
-            if ident is not None and ident in success_ids:
-                # Superseded concurrency-cancel duplicate: a run of this EXACT
-                # identity (name + workflowName) concluded SUCCESS on this head, so
-                # the cancelled entry is a `cancel-in-progress` leftover with no
+            cts = (c.get("completedAt") or "").strip()
+            if ident is not None and cts and success_latest.get(ident, "") >= cts:
+                # Superseded concurrency-cancel duplicate: a SUCCESS of this EXACT
+                # identity (name + workflowName) completed AT OR AFTER this cancel,
+                # so the cancelled entry is a `cancel-in-progress` leftover with no
                 # verdict of its own — drop it. Wrong-green-impossible:
-                # FAILURE/TIMED_OUT are not in _CI_CANCEL_CONCLUSIONS (still red),
+                # FAILURE/TIMED_OUT are not in _CI_CANCEL_CONCLUSIONS (still red);
                 # an in-flight re-run is a non-terminal entry that still counts
-                # pending below, and a cancel with no resolvable identity or no
-                # same-identity success falls through and stays red.
+                # pending below; and a cancel with no identity, no completedAt, or
+                # NO same-identity success at-or-after it (e.g. SUCCESS-then-cancel
+                # on an unchanged head) falls through and stays red.
                 saw_recognized = True
                 continue
         if conclusion in _CI_RED_CONCLUSIONS or state in _CI_RED_STATES:
@@ -748,14 +773,21 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
         elif conclusion in _CI_GREEN or state in _CI_GREEN:
             saw_recognized = True
         elif status in _CI_TERMINAL_STATUSES:
-            # COMPLETED with an unrecognized/None conclusion — treat as done,
-            # don't fabricate pending; ignore this entry.
             saw_recognized = True
-        elif status is not None or state == "PENDING":
+            if conclusion is not None:
+                # A COMPLETED run with a conclusion we DON'T recognize (a value
+                # GitHub adds later) is NOT a pass — fail CLOSED to red, never
+                # silently ignore. This mirrors the not-terminal ⇒ pending
+                # inversion below so no unenumerated *terminal* conclusion can read
+                # green. (conclusion is None ⇒ genuinely no verdict data: keep the
+                # benign ignore — distinct from a named value we simply don't map.)
+                red.append(name)
+        elif status is not None or state in _CI_PENDING_STATES:
             # ANY non-terminal CheckRun status (QUEUED/IN_PROGRESS/PENDING/
-            # WAITING/REQUESTED/…) or a PENDING StatusContext is unfinished →
-            # block. Enumerating "known pending" states would silently miss new
-            # ones (P1 review finding), so we invert: not-terminal ⇒ pending.
+            # WAITING/REQUESTED/…) or an unfinished StatusContext state
+            # (PENDING/EXPECTED) is unfinished → block. Enumerating "known pending"
+            # states would silently miss new ones (P1 review finding), so we
+            # invert: not-terminal ⇒ pending.
             saw_recognized = True
             pending.append(name)
         # else: no status/state/conclusion at all — unrecognized shape, ignore

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -602,10 +602,53 @@ _CI_RED_CONCLUSIONS = {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "
 _CI_RED_STATES = {"FAILURE", "ERROR"}  # legacy StatusContext state
 _CI_SKIP_CONCLUSIONS = {"SKIPPED", "NEUTRAL"}
 _CI_GREEN = {"SUCCESS"}
+# A CANCELLED check-run carries NO pass/fail verdict — the run was aborted,
+# almost always by a `concurrency: cancel-in-progress` supersession, which leaves
+# the cancelled dup attached to the head commit. It is red BY DEFAULT (it is also
+# in _CI_RED_CONCLUSIONS), and dropped ONLY when a check of the SAME identity
+# (name + workflowName, see _ci_identity) also concluded SUCCESS on this head.
+# Deliberately scoped to CANCELLED alone: FAILURE/TIMED_OUT/ACTION_REQUIRED/
+# STARTUP_FAILURE carry real verdicts and always block, even with a success sibling.
+_CI_CANCEL_CONCLUSIONS = {"CANCELLED"}
 # The only CheckRun.status that means "finished". Everything else
 # (QUEUED/IN_PROGRESS/PENDING/WAITING/REQUESTED/…) is treated as unfinished, so
 # a new/renamed non-terminal state can never be silently mistaken for green.
 _CI_TERMINAL_STATUSES = {"COMPLETED"}
+
+# Display label for a rollup entry that has neither a CheckRun `name` nor a
+# StatusContext `context` — used only for the human-facing problem-check list.
+_CI_NAMELESS = "check"
+
+
+def _check_name(c: dict) -> str:
+    """Human-facing display label for one statusCheckRollup entry: a CheckRun
+    ``name`` or a legacy StatusContext ``context``, falling back to _CI_NAMELESS.
+    Used only to build the problem-check list — NOT the sibling-match key (that is
+    _ci_identity, which is stricter)."""
+    return c.get("name") or c.get("context") or _CI_NAMELESS
+
+
+def _ci_identity(c: dict) -> tuple[str, str] | None:
+    """Strict same-check identity for the concurrency-cancel sibling match:
+    ``(name, workflowName)`` for a GitHub Actions CheckRun, or ``None`` when the
+    entry cannot be identity-matched — a legacy StatusContext (no workflowName) or
+    a CheckRun from a non-Actions app (empty workflowName). ``None`` means the
+    entry is NEVER a sibling and NEVER droppable → it fails CLOSED (a cancel with
+    no resolvable identity stays red).
+
+    Keying on name ALONE would be unsafe: this gate forces `--admin`, which
+    bypasses GitHub's server-side required-status-checks, so _pr_ci_status is the
+    SOLE CI enforcement for every merge it allows. A bare-name match would let a
+    same-named SUCCESS from a DIFFERENT workflow (an accidental collision, or a
+    decoy job) mask a genuinely-cancelled required check → wrong-green. Requiring
+    workflowName to match scopes the drop to a true same-job re-run — the only
+    thing `cancel-in-progress` produces. Still pure set-membership: no
+    time-ordering (that surface was the pulled #1420 finding-magnet)."""
+    name = (c.get("name") or "").strip()
+    wf = (c.get("workflowName") or "").strip()
+    if name and wf:
+        return (name, wf)
+    return None
 
 
 def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]:
@@ -613,7 +656,12 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
 
     Returns ``(state, problem_checks)`` where state is one of:
       * ``"green"``   — every non-skipped check concluded SUCCESS
-      * ``"red"``     — at least one check failed/cancelled/timed-out
+      * ``"red"``     — at least one check failed/timed-out, or was cancelled
+                        with NO same-identity SUCCESS on this head. A CANCELLED
+                        CheckRun whose (name, workflowName) identity also has a
+                        SUCCESS is a superseded `concurrency: cancel-in-progress`
+                        duplicate and is dropped (see _ci_identity) — strict
+                        identity, set-membership only, no time-ordering.
       * ``"pending"`` — a check is still queued/running (and none are red)
       * ``"unknown"`` — could not determine (API error, no checks, or an
                         unrecognized payload shape) → callers FAIL OPEN, because
@@ -654,19 +702,46 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
     if not isinstance(checks, list) or not checks:
         return "unknown", []
 
+    # First pass: strict identities (name, workflowName) that concluded SUCCESS on
+    # this head — the sibling set used to drop superseded concurrency-cancel
+    # duplicates. Only GitHub Actions CheckRuns with a resolvable identity qualify
+    # (see _ci_identity); legacy StatusContexts and non-Actions checks never serve
+    # as siblings. Set-membership ONLY — deliberately no time-ordering (that
+    # surface was the pulled #1420 attempt's finding-magnet).
+    success_ids = {
+        ident
+        for c in checks
+        if isinstance(c, dict)
+        and c.get("conclusion") in _CI_GREEN
+        and (ident := _ci_identity(c)) is not None
+    }
+
     red: list[str] = []
     pending: list[str] = []
     saw_recognized = False
     for c in checks:
         if not isinstance(c, dict):
             continue
-        name = c.get("name") or c.get("context") or "check"
+        name = _check_name(c)
         conclusion = c.get("conclusion")  # CheckRun
         status = c.get("status")  # CheckRun: QUEUED/IN_PROGRESS/COMPLETED/PENDING/…
         state = c.get("state")  # StatusContext: SUCCESS/FAILURE/PENDING/ERROR
         if conclusion in _CI_SKIP_CONCLUSIONS:
             saw_recognized = True
             continue
+        if conclusion in _CI_CANCEL_CONCLUSIONS:
+            ident = _ci_identity(c)
+            if ident is not None and ident in success_ids:
+                # Superseded concurrency-cancel duplicate: a run of this EXACT
+                # identity (name + workflowName) concluded SUCCESS on this head, so
+                # the cancelled entry is a `cancel-in-progress` leftover with no
+                # verdict of its own — drop it. Wrong-green-impossible:
+                # FAILURE/TIMED_OUT are not in _CI_CANCEL_CONCLUSIONS (still red),
+                # an in-flight re-run is a non-terminal entry that still counts
+                # pending below, and a cancel with no resolvable identity or no
+                # same-identity success falls through and stays red.
+                saw_recognized = True
+                continue
         if conclusion in _CI_RED_CONCLUSIONS or state in _CI_RED_STATES:
             saw_recognized = True
             red.append(name)

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1451,24 +1451,25 @@ class TestPrCiStatus:
 
 class TestPrCiStatusCancelSibling:
     """Concurrency-cancel dedup (approach B): a CANCELLED CheckRun is dropped IFF a
-    check of the SAME identity (name + workflowName) also concluded SUCCESS on this
-    head — no time-ordering, so a superseded `cancel-in-progress` duplicate can't
-    stick the gate red while its own re-run passed. Wrong-green-impossible: only
-    CANCELLED (no verdict) is dropped, only for a true same-job re-run, and a cancel
-    with no resolvable identity or no same-identity success stays red."""
+    check of the SAME identity (name + workflowName) concluded SUCCESS AT OR AFTER
+    it — so a superseded `cancel-in-progress` duplicate (cancel older than its
+    re-run's success) drops, but a SUCCESS-then-cancel re-run on an unchanged head
+    still blocks. Both sides are terminal COMPLETED runs (always carry completedAt);
+    every unresolvable case (no identity, no completedAt, no later success) fails
+    closed to red."""
 
     @staticmethod
     def _set(monkeypatch, checks):
         monkeypatch.setenv("_TEST_GH_CI_ROLLUP", json.dumps(checks))
 
     def test_cancel_with_success_sibling_is_green(self, guard_module, monkeypatch):
-        # The ec925917 incident: concurrency-cancelled CodeQL dups + their
-        # successful re-runs (same name + workflowName). Must read green.
+        # The ec925917 incident: concurrency-cancelled CodeQL dups (older) + their
+        # successful re-runs (newer, same name + workflowName). Must read green.
         self._set(monkeypatch, [
-            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "CANCELLED"},
-            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
-            {"name": "Analyze (actions)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "CANCELLED"},
-            {"name": "Analyze (actions)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "CANCELLED", "completedAt": "2026-08-21T10:00:00Z"},
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "2026-08-21T10:05:00Z"},
+            {"name": "Analyze (actions)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "CANCELLED", "completedAt": "2026-08-21T10:00:00Z"},
+            {"name": "Analyze (actions)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "2026-08-21T10:05:00Z"},
         ])
         assert guard_module._pr_ci_status("1") == ("green", [])
 
@@ -1486,17 +1487,17 @@ class TestPrCiStatusCancelSibling:
         # check. Identity is (name, workflowName), so this stays red. Under a
         # bare-name match this would wrongly go green.
         self._set(monkeypatch, [
-            {"name": "test-suite", "workflowName": "real-ci", "status": "COMPLETED", "conclusion": "CANCELLED"},
-            {"name": "test-suite", "workflowName": "decoy", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "test-suite", "workflowName": "real-ci", "status": "COMPLETED", "conclusion": "CANCELLED", "completedAt": "2026-08-21T10:00:00Z"},
+            {"name": "test-suite", "workflowName": "decoy", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "2026-08-21T10:05:00Z"},
         ])
         assert guard_module._pr_ci_status("1") == ("red", ["test-suite"])
 
     def test_cancel_without_workflowname_stays_red(self, guard_module, monkeypatch):
         # Fail-closed: a CANCELLED entry with no resolvable workflowName has no
-        # identity, so even a same-name SUCCESS cannot drop it — stays red.
+        # identity, so even a later same-name SUCCESS cannot drop it — stays red.
         self._set(monkeypatch, [
-            {"name": "x", "status": "COMPLETED", "conclusion": "CANCELLED"},
-            {"name": "x", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "x", "status": "COMPLETED", "conclusion": "CANCELLED", "completedAt": "2026-08-21T10:00:00Z"},
+            {"name": "x", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "2026-08-21T10:05:00Z"},
         ])
         assert guard_module._pr_ci_status("1") == ("red", ["x"])
 
@@ -1513,8 +1514,8 @@ class TestPrCiStatusCancelSibling:
         # Dropping a cancelled-with-sibling must never hide a DIFFERENT check's
         # real failure — the core wrong-green guard.
         self._set(monkeypatch, [
-            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "CANCELLED"},
-            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "CANCELLED", "completedAt": "2026-08-21T10:00:00Z"},
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "2026-08-21T10:05:00Z"},
             {"name": "lint", "workflowName": "CI", "status": "COMPLETED", "conclusion": "FAILURE"},
         ])
         assert guard_module._pr_ci_status("1") == ("red", ["lint"])
@@ -1542,8 +1543,8 @@ class TestPrCiStatusCancelSibling:
         # Dropping a cancelled-with-sibling must not swallow an UNRELATED pending
         # check — the merge still blocks on the in-flight one.
         self._set(monkeypatch, [
-            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "CANCELLED"},
-            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "CANCELLED", "completedAt": "2026-08-21T10:00:00Z"},
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "2026-08-21T10:05:00Z"},
             {"name": "deploy", "workflowName": "CI", "status": "IN_PROGRESS", "conclusion": None},
         ])
         assert guard_module._pr_ci_status("1") == ("pending", ["deploy"])
@@ -1557,6 +1558,27 @@ class TestPrCiStatusCancelSibling:
             {"status": "COMPLETED", "conclusion": "CANCELLED"},
         ])
         assert guard_module._pr_ci_status("1") == ("red", ["check"])
+
+    def test_success_then_cancel_on_unchanged_head_stays_red(self, guard_module, monkeypatch):
+        # Codex P1: a job passed (older), then was re-run on the UNCHANGED head and
+        # that re-run was CANCELLED (newer). The latest attempt never passed, so the
+        # cancel is NOT superseded by a later success → stays red. Under a bare
+        # set-membership match (no completedAt) this wrongly returned green.
+        self._set(monkeypatch, [
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "2026-08-21T10:00:00Z"},
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "CANCELLED", "completedAt": "2026-08-21T10:05:00Z"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["test"])
+
+    def test_cancel_without_completedat_stays_red(self, guard_module, monkeypatch):
+        # Fail-closed: a CANCELLED entry with no completedAt can't be proven
+        # superseded (no timestamp to order it), so even a same-identity SUCCESS
+        # does not drop it — stays red.
+        self._set(monkeypatch, [
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "2026-08-21T10:05:00Z"},
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "CANCELLED"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["test"])
 
 
 class TestCiOverrideSigil:
@@ -1697,8 +1719,11 @@ class TestCiGateEndToEnd:
 
 
 class TestCiStatusUnfinishedStates:
-    """P1 fix: ANY non-terminal check status counts as pending (not just
-    QUEUED/IN_PROGRESS) — a new/renamed unfinished state can't read as green."""
+    """Full enumeration of GitHub's status/conclusion/state domains — no
+    unenumerated value may read green: ANY non-terminal status ⇒ pending; an
+    unrecognized *terminal* conclusion (e.g. STALE, or a value GitHub adds later)
+    ⇒ red (fail-closed); a legacy EXPECTED context ⇒ pending. A null conclusion on
+    a COMPLETED run is genuine no-verdict data and stays a benign ignore."""
 
     @staticmethod
     def _set(monkeypatch, checks):
@@ -1722,6 +1747,35 @@ class TestCiStatusUnfinishedStates:
             {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
         ])
         assert guard_module._pr_ci_status("1") == ("green", [])
+
+    def test_stale_conclusion_is_red(self, guard_module, monkeypatch):
+        # STALE = a superseded/outdated run (GitHub's own term) — NOT a pass. On a
+        # gate that forces --admin (sole CI enforcement) it must block, not read
+        # green. Under the prior code this silently ignored → green.
+        self._set(monkeypatch, [
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "STALE"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["Analyze (python)"])
+
+    def test_stale_mixed_with_success_still_red(self, guard_module, monkeypatch):
+        self._set(monkeypatch, [
+            {"name": "codeql", "status": "COMPLETED", "conclusion": "STALE"},
+            {"name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["codeql"])
+
+    def test_unrecognized_terminal_conclusion_fails_closed_red(self, guard_module, monkeypatch):
+        # A COMPLETED run with a conclusion GitHub adds later must fail closed to
+        # red, never silently ignore (the class root cause behind the STALE gap).
+        self._set(monkeypatch, [{"name": "test", "status": "COMPLETED", "conclusion": "SOME_FUTURE_VERDICT"}])
+        assert guard_module._pr_ci_status("1") == ("red", ["test"])
+
+    def test_expected_statuscontext_is_pending(self, guard_module, monkeypatch):
+        # A legacy StatusContext EXPECTED (a required context that hasn't reported
+        # yet) must read pending, not fall through to unknown (which callers treat
+        # as non-blocking).
+        self._set(monkeypatch, [{"context": "ci/required", "state": "EXPECTED"}])
+        assert guard_module._pr_ci_status("1") == ("pending", ["ci/required"])
 
 
 class TestMergeableAllowlist:

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1449,6 +1449,116 @@ class TestPrCiStatus:
         assert guard_module._pr_ci_status("1") == ("unknown", [])
 
 
+class TestPrCiStatusCancelSibling:
+    """Concurrency-cancel dedup (approach B): a CANCELLED CheckRun is dropped IFF a
+    check of the SAME identity (name + workflowName) also concluded SUCCESS on this
+    head — no time-ordering, so a superseded `cancel-in-progress` duplicate can't
+    stick the gate red while its own re-run passed. Wrong-green-impossible: only
+    CANCELLED (no verdict) is dropped, only for a true same-job re-run, and a cancel
+    with no resolvable identity or no same-identity success stays red."""
+
+    @staticmethod
+    def _set(monkeypatch, checks):
+        monkeypatch.setenv("_TEST_GH_CI_ROLLUP", json.dumps(checks))
+
+    def test_cancel_with_success_sibling_is_green(self, guard_module, monkeypatch):
+        # The ec925917 incident: concurrency-cancelled CodeQL dups + their
+        # successful re-runs (same name + workflowName). Must read green.
+        self._set(monkeypatch, [
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "CANCELLED"},
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "Analyze (actions)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "CANCELLED"},
+            {"name": "Analyze (actions)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("green", [])
+
+    def test_cancel_without_success_sibling_stays_red(self, guard_module, monkeypatch):
+        # A genuine cancel with no same-identity success still blocks the merge.
+        self._set(monkeypatch, [
+            {"name": "Analyze", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "CANCELLED"},
+            {"name": "lint", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["Analyze"])
+
+    def test_cross_workflow_same_name_does_not_drop(self, guard_module, monkeypatch):
+        # SECURITY (HIGH lock): a same-NAME success from a DIFFERENT workflow is
+        # NOT a valid sibling and must not mask a genuinely-cancelled required
+        # check. Identity is (name, workflowName), so this stays red. Under a
+        # bare-name match this would wrongly go green.
+        self._set(monkeypatch, [
+            {"name": "test-suite", "workflowName": "real-ci", "status": "COMPLETED", "conclusion": "CANCELLED"},
+            {"name": "test-suite", "workflowName": "decoy", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["test-suite"])
+
+    def test_cancel_without_workflowname_stays_red(self, guard_module, monkeypatch):
+        # Fail-closed: a CANCELLED entry with no resolvable workflowName has no
+        # identity, so even a same-name SUCCESS cannot drop it — stays red.
+        self._set(monkeypatch, [
+            {"name": "x", "status": "COMPLETED", "conclusion": "CANCELLED"},
+            {"name": "x", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["x"])
+
+    def test_cancel_plus_inflight_rerun_never_green(self, guard_module, monkeypatch):
+        # Cancel + an in-flight re-run of the same identity, no success yet → must
+        # NOT read green (the re-run is still running; nothing has passed).
+        self._set(monkeypatch, [
+            {"name": "Analyze", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "CANCELLED"},
+            {"name": "Analyze", "workflowName": "CodeQL", "status": "IN_PROGRESS", "conclusion": None},
+        ])
+        assert guard_module._pr_ci_status("1")[0] != "green"
+
+    def test_cancel_sibling_does_not_launder_other_failure(self, guard_module, monkeypatch):
+        # Dropping a cancelled-with-sibling must never hide a DIFFERENT check's
+        # real failure — the core wrong-green guard.
+        self._set(monkeypatch, [
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "CANCELLED"},
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "lint", "workflowName": "CI", "status": "COMPLETED", "conclusion": "FAILURE"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["lint"])
+
+    def test_timed_out_with_success_sibling_still_red(self, guard_module, monkeypatch):
+        # Scope lock: ONLY CANCELLED is laundered. TIMED_OUT carries a real
+        # verdict and still blocks even with a same-identity success.
+        self._set(monkeypatch, [
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "TIMED_OUT"},
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["test"])
+
+    def test_statuscontext_success_does_not_drop_checkrun_cancel(self, guard_module, monkeypatch):
+        # A legacy StatusContext SUCCESS (no workflowName) has no CheckRun identity
+        # and is NOT a valid sibling for a CheckRun CANCELLED of the same name —
+        # the cancel stays red (closes the cross-shape collision surface).
+        self._set(monkeypatch, [
+            {"context": "ci/legacy", "state": "SUCCESS"},
+            {"name": "ci/legacy", "workflowName": "CI", "status": "COMPLETED", "conclusion": "CANCELLED"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["ci/legacy"])
+
+    def test_pending_preserved_when_sibling_dropped(self, guard_module, monkeypatch):
+        # Dropping a cancelled-with-sibling must not swallow an UNRELATED pending
+        # check — the merge still blocks on the in-flight one.
+        self._set(monkeypatch, [
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "CANCELLED"},
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "deploy", "workflowName": "CI", "status": "IN_PROGRESS", "conclusion": None},
+        ])
+        assert guard_module._pr_ci_status("1") == ("pending", ["deploy"])
+
+    def test_nameless_cancel_not_dropped_by_nameless_success(self, guard_module, monkeypatch):
+        # Entries with no name/workflowName have no identity (_ci_identity → None)
+        # and are excluded from the sibling set — a nameless SUCCESS can't license
+        # dropping a nameless CANCELLED. Stays red (fail-safe over-block).
+        self._set(monkeypatch, [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "COMPLETED", "conclusion": "CANCELLED"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["check"])
+
+
 class TestCiOverrideSigil:
     """The `# ci-override` sigil is quote-aware and (at the call site) bound to
     the merge segment — it cannot be spoofed from a quoted --body or a chained


### PR DESCRIPTION
## Problem

`_pr_ci_status` (the CI gate on `gh pr merge`) classified every `statusCheckRollup`
entry independently, and `CANCELLED` is treated as red. When a
`concurrency: cancel-in-progress` run is superseded, its cancelled check-runs stay
attached to the head commit, so the gate read **red forever** even though the same
check's re-run concluded `SUCCESS` (measured on a real merge; cleared only by
manually re-running the cancelled job).

## Fix

Drop a `CANCELLED` CheckRun iff a check of the same `(name, workflowName)` identity
concluded `SUCCESS` on this head; otherwise it stays red. Pure set-membership —
**no time-ordering** (that surface caused a prior review loop).

Scoping by `workflowName` (not bare `name`) is deliberate and security-relevant:
this gate forces `gh pr merge --admin`, which bypasses GitHub's server-side
required-status-checks, so `_pr_ci_status` is the **sole** CI enforcement for every
merge it allows. A bare-name match would let a same-named `SUCCESS` from a
*different* workflow mask a genuinely-cancelled required check (wrong-green).
`(name, workflowName)` scopes the drop to a true same-job re-run — the only thing
`cancel-in-progress` produces — and fails closed when `workflowName` is absent.

## Safety

Wrong-green-impossible for realistic inputs: only `CANCELLED` (which carries no
verdict) is dropped; `FAILURE`/`TIMED_OUT` stay red; in-flight re-runs stay
pending; a cancel with no resolvable identity stays red. Residual (LOW,
documented-accept): a duplicate job `name:` inside the *same* gating workflow could
still collide — but that requires editing the CI definition itself, a strictly
higher bar, and such an actor can defeat CI more trivially. `gh pr view` exposes no
stronger identity field; a follow-up is filed for a `gh api …/check-runs` identity
rework.

## Testing

- TDD verify-RED observed (the pre-fix file fails the new tests for the right
  reason; independently confirmed by an adversarial security review that swapped
  the pre-fix file against the new tests).
- 10 new `TestPrCiStatusCancelSibling` cases incl. cross-workflow, no-workflowName,
  and fail-closed locks.
- `tests/test_hooks/` full: 1539 passed. `test_merge_review_gate.py`: 210 passed.
  `ruff` clean.
- Reviewed by genesis-architect + genesis-security-reviewer (two rounds); a HIGH
  (name-collision wrong-green) was found and fixed, no CRITICAL/HIGH remaining.

Follow-up: 121acade351b44f88f52130ed3785fff
