### PR TITLE
feat(ssh): one-click "lobby" door — IP-keyed, opens the session picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **One-click "lobby" terminal door — reattach the whole CC fleet after a client
+  reboot.** `generate-ssh-config.sh` now emits a dedicated `Host <host>-lobby`
+  block (placed ahead of the numeric-slot wildcard, since ssh takes the first
+  matching `RemoteCommand`) that attaches a stable `lobby` tmux session on the
+  same socket as the `cc-*` slots and opens straight into the session picker
+  (`choose-tree`). One reconnect brings every live session back — they persist in
+  tmux on the box, only the client died — pick any slot and jump in (`Ctrl-b s`
+  reopens the picker). All emitted blocks are keyed on the stable Tailscale IP
+  (not the MagicDNS name), so they keep resolving even when the client's DNS is
+  disrupted. `lobby` is not a `cc-N` name, so it never consumes a slot or trips
+  the slot cap, and numeric-slot routing through `cc-slot.sh` is unchanged. Pair
+  with one Windows Terminal shortcut (`wt.exe ssh <host>-lobby`) for a
+  one-double-click return to the whole fleet.
+
 - **Claude Code session exits are recorded.** When a CC session's process exits
   — a clean quit, a crash, or an OS/kill signal — its exit status (with a
   signal-decoded hint) and a tail of the terminal are written to

--- a/scripts/generate-ssh-config.sh
+++ b/scripts/generate-ssh-config.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # generate-ssh-config.sh — Generate client SSH config for tmux slot access.
 #
-# Auto-detects this machine's Tailscale hostname and outputs an SSH config
-# snippet to paste into ~/.ssh/config on client devices.
+# Auto-detects this machine's Tailscale identity and outputs an SSH config
+# snippet (keyed on the stable Tailscale IP, DNS-resolver-independent) to paste
+# into ~/.ssh/config on client devices.
 #
 # Usage: ./scripts/generate-ssh-config.sh
 
@@ -20,9 +21,16 @@ TS_JSON=$(tailscale status --self --json 2>/dev/null) || {
 
 TS_HOSTNAME=$(echo "$TS_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin)['Self']; print(d['DNSName'].split('.')[0])" 2>/dev/null)
 TS_DNSNAME=$(echo "$TS_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['Self']['DNSName'].rstrip('.'))" 2>/dev/null)
+# HostName is keyed on the stable Tailscale IPv4, NOT the MagicDNS name: the IP
+# is pinned per-device and routes without the client's DNS resolver, so the
+# config keeps working even when MagicDNS/NRPT is disrupted on the client (a
+# common Tailscale-on-Windows failure). The `${TS_HOSTNAME}-*` aliases are
+# unchanged — only the resolved address is an IP. Re-run this script if the
+# node's IP ever changes (device removed + re-added to the tailnet).
+TS_IP=$(echo "$TS_JSON" | python3 -c "import sys,json; ips=json.load(sys.stdin)['Self'].get('TailscaleIPs') or []; print(next((i for i in ips if ':' not in i), ''))" 2>/dev/null)
 
-if [[ -z "$TS_HOSTNAME" || -z "$TS_DNSNAME" ]]; then
-    echo "Error: Could not determine Tailscale hostname." >&2
+if [[ -z "$TS_HOSTNAME" || -z "$TS_DNSNAME" || -z "$TS_IP" ]]; then
+    echo "Error: Could not determine Tailscale identity (hostname/IPv4)." >&2
     exit 1
 fi
 
@@ -35,9 +43,31 @@ cat << SSHEOF
 # Paste into ~/.ssh/config on your client devices.
 # Usage: ssh ${TS_HOSTNAME}-1, ssh ${TS_HOSTNAME}-2, etc.
 # Each slot maps to a persistent tmux session with claude.
+# Or:    ssh ${TS_HOSTNAME}-lobby  → opens the session picker; pick any live slot.
+
+# One-click "lobby": a stable landing session that sees ALL live cc-* slots.
+# After a client/reboot, ONE reconnect here brings the whole fleet back — the
+# slots never died (they live in tmux on the box). It opens straight into the
+# session picker (choose-tree): pick a slot and jump into it, in the state you
+# left it; Ctrl-b s reopens the picker anytime.
+#
+# This specific block MUST precede the wildcard below: ssh uses the FIRST
+# matching RemoteCommand, and the wildcard would otherwise route
+# "${TS_HOSTNAME}-lobby" into cc-slot.sh, which rejects the non-numeric slot.
+# 'lobby' is not a cc-N name, so it never consumes a slot or the slot cap.
+# The RemoteCommand sets PATH (an ssh RemoteCommand does NOT source .bashrc), so
+# tmux resolves even where it is user-local — mirrors cc-slot.sh's toolchain PATH
+# so the lobby door matches the numeric-slot door's behavior.
+Host ${TS_HOSTNAME}-lobby
+    HostName ${TS_IP}
+    User ${REMOTE_USER}
+    RemoteCommand PATH="${REMOTE_HOME}/.n/bin:${REMOTE_HOME}/.bun/bin:${REMOTE_HOME}/.npm-global/bin:${REMOTE_HOME}/.local/bin:\$PATH" tmux -u new-session -A -s lobby \; choose-tree -Zs
+    RequestTTY yes
+    ServerAliveInterval 30
+    ServerAliveCountMax 6
 
 Host ${TS_HOSTNAME}-*
-    HostName ${TS_DNSNAME}
+    HostName ${TS_IP}
     User ${REMOTE_USER}
     RemoteCommand ${SLOT_SCRIPT} %n
     RequestTTY yes
@@ -46,11 +76,18 @@ Host ${TS_HOSTNAME}-*
 
 # Direct access (no slot, normal shell):
 # Host ${TS_HOSTNAME}
-#     HostName ${TS_DNSNAME}
+#     HostName ${TS_IP}
 #     User ${REMOTE_USER}
 # ────────────────────────────────────────────────────────────────
 SSHEOF
 
 echo "" >&2
-echo "Copy the above into ~/.ssh/config on your client devices." >&2
-echo "Then: ssh ${TS_HOSTNAME}-1   (or any positive integer)" >&2
+echo "Copy the above into ~/.ssh/config on your client devices — REPLACING any" >&2
+echo "earlier Genesis block for ${TS_HOSTNAME} (don't append a second one, or the" >&2
+echo "old block would win by ssh's first-match rule)." >&2
+echo "Then: ssh ${TS_HOSTNAME}-1        (a specific slot, or any positive integer)" >&2
+echo "  or: ssh ${TS_HOSTNAME}-lobby    (opens the session picker → pick any live slot)" >&2
+echo "" >&2
+echo "Windows one-click: create a shortcut whose target is" >&2
+echo "    wt.exe ssh ${TS_HOSTNAME}-lobby     (or:  ssh.exe ${TS_HOSTNAME}-lobby)" >&2
+echo "then pin it to the taskbar — double-click reattaches the whole fleet." >&2

--- a/tests/test_scripts/test_generate_ssh_config.py
+++ b/tests/test_scripts/test_generate_ssh_config.py
@@ -1,0 +1,151 @@
+"""generate-ssh-config.sh: the client SSH config it emits.
+
+The one-click "lobby" door (2026-08-14) adds a stable landing session that sees
+every live cc-* slot, so a single reconnect after a client/reboot brings the
+whole fleet back (the slots persist in tmux on the box). The load-bearing
+invariant is ORDERING: the specific ``Host <host>-lobby`` block must precede the
+``Host <host>-*`` wildcard, because ssh takes the FIRST matching RemoteCommand —
+if the wildcard came first, ``<host>-lobby`` would route into cc-slot.sh and be
+rejected as a non-numeric slot. These tests run the real script against a fake
+`tailscale` on PATH: ``TestLobbyDoor`` exercises what the script *emits*, and
+``TestSshResolution`` feeds that output to a real ``ssh -G`` so the actual
+first-match *resolution* (not merely text order) is verified.
+"""
+
+from __future__ import annotations
+
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_GEN = _REPO_ROOT / "scripts" / "generate-ssh-config.sh"
+
+# DNSName "testbox.tail1234.ts.net." -> TS_HOSTNAME "testbox"; TailscaleIPs ->
+# TS_IP "192.0.2.5" (the script picks the v4, filtering the v6 by ':'). HostName
+# in the emitted config is that IP, NOT the MagicDNS name (DNS-independent).
+# (RFC5737 TEST-NET / RFC3849 doc addresses — placeholders, not real hosts.)
+_FAKE_TAILSCALE = """#!/usr/bin/env bash
+if [[ "$*" == *--json* ]]; then
+  cat <<'JSON'
+{"Self": {"DNSName": "testbox.tail1234.ts.net.", "TailscaleIPs": ["192.0.2.5", "2001:db8::1"]}}
+JSON
+  exit 0
+fi
+exit 0
+"""
+
+
+@pytest.fixture()
+def gen(tmp_path):
+    """Run generate-ssh-config.sh with a fake `tailscale`; return the run fn."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "tailscale"
+    fake.write_text(_FAKE_TAILSCALE)
+    fake.chmod(fake.stat().st_mode | stat.S_IEXEC)
+
+    def run() -> subprocess.CompletedProcess:
+        env = {"PATH": f"{bin_dir}:/usr/bin:/bin"}
+        return subprocess.run(
+            ["bash", str(_GEN)],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    return run
+
+
+class TestLobbyDoor:
+    def test_emits_lobby_block(self, gen):
+        result = gen()
+        assert result.returncode == 0, result.stderr
+        out = result.stdout
+        assert "Host testbox-lobby" in out
+        # opens the session picker (choose-tree), not a bare shell
+        assert "tmux -u new-session -A -s lobby \\; choose-tree -Zs" in out
+        # PATH-prefixed so tmux resolves even when it's user-local (no .bashrc)
+        assert 'RemoteCommand PATH="' in out and "/.local/bin:" in out
+        assert "RequestTTY yes" in out
+
+    def test_hostname_is_tailscale_ip_not_magicdns(self, gen):
+        # HostName must be the stable Tailscale IP (DNS-resolver-independent),
+        # never the MagicDNS name — that dependency is the failure this avoids.
+        out = gen().stdout
+        assert "HostName 192.0.2.5" in out
+        assert "HostName testbox.tail1234.ts.net" not in out
+
+    def test_lobby_block_precedes_wildcard(self, gen):
+        # The correctness invariant: specific block first, or ssh routes
+        # <host>-lobby into cc-slot.sh (rejected as a non-numeric slot).
+        out = gen().stdout
+        assert out.index("Host testbox-lobby") < out.index("Host testbox-*"), (
+            "lobby block must appear before the wildcard block"
+        )
+
+    def test_wildcard_still_routes_slots_to_cc_slot(self, gen):
+        # The lobby door must not disturb numeric slot routing.
+        out = gen().stdout
+        assert "Host testbox-*" in out
+        assert "cc-slot.sh %n" in out
+
+    def test_lobby_alias_is_not_a_cc_slot_name(self, gen):
+        # 'lobby' must not look like cc-N (else it would count against the cap).
+        out = gen().stdout
+        assert "-s lobby" in out
+        assert "-s cc-" not in out  # the generator never hard-codes a cc-N session
+
+
+class TestSshResolution:
+    """Pin the ACTUAL ssh first-match semantics, not just text order.
+
+    The text-order assertion above is only a proxy: if ssh were "last value
+    wins" it would still pass while the feature broke. ``ssh -G`` resolves the
+    config exactly as a real connection would (without connecting), so this is
+    the load-bearing check. Skipped where ssh is unavailable.
+    """
+
+    @pytest.mark.skipif(shutil.which("ssh") is None, reason="ssh not on PATH")
+    def test_lobby_resolves_to_tmux_not_cc_slot(self, gen, tmp_path):
+        cfg = tmp_path / "sshcfg"
+        cfg.write_text(gen().stdout)
+        r = subprocess.run(
+            ["ssh", "-G", "-F", str(cfg), "testbox-lobby"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert r.returncode == 0, r.stderr
+        rc = [ln for ln in r.stdout.splitlines() if ln.lower().startswith("remotecommand ")]
+        assert len(rc) == 1, rc
+        # PATH-prefixed, opens the picker via tmux (choose-tree)
+        assert rc[0].startswith("remotecommand PATH=") and (
+            "tmux -u new-session -A -s lobby" in rc[0] and "choose-tree" in rc[0]
+        ), rc
+        # HostName resolves to the stable Tailscale IP, not the MagicDNS name.
+        hn = [ln for ln in r.stdout.splitlines() if ln.lower().startswith("hostname ")]
+        assert hn == ["hostname 192.0.2.5"], hn
+
+    @pytest.mark.skipif(shutil.which("ssh") is None, reason="ssh not on PATH")
+    def test_numeric_slot_still_resolves_to_cc_slot(self, gen, tmp_path):
+        cfg = tmp_path / "sshcfg"
+        cfg.write_text(gen().stdout)
+        r = subprocess.run(
+            ["ssh", "-G", "-F", str(cfg), "testbox-2"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert r.returncode == 0, r.stderr
+        rc = [ln for ln in r.stdout.splitlines() if ln.lower().startswith("remotecommand ")]
+        assert len(rc) == 1 and rc[0].endswith("cc-slot.sh testbox-2"), rc
+
+
+class TestScriptHygiene:
+    def test_syntax_clean(self):
+        subprocess.run(["bash", "-n", str(_GEN)], check=True, timeout=10)


### PR DESCRIPTION
One-click reattach to all persistent Claude Code tmux sessions after a client
reboot, over one SSH connection. The sessions persist server-side in tmux; only
the client dies on reboot — this is a client-entry convenience.

## Mechanism
`generate-ssh-config.sh` emits a `Host <host>-lobby` block **ahead of** the
numeric-slot wildcard (ssh uses the first matching `RemoteCommand`) that attaches
a stable `lobby` tmux session on the **same socket** as the `cc-*` slots and opens
straight into the session picker (`choose-tree`). `lobby` is not a `cc-N` name, so
it consumes no slot and never trips cc-slot.sh’s cap; numeric-slot routing is
unchanged.

- **HostName is keyed on the stable Tailscale IP**, not the MagicDNS name, so the
  config keeps resolving even when the client’s DNS/MagicDNS is disrupted (a real
  failure mode on Windows when the NRPT rule drops).
- The lobby `RemoteCommand` sets PATH (an ssh RemoteCommand doesn’t source
  `.bashrc`), mirroring `cc-slot.sh`, so `tmux` resolves even when user-local.

## Verification
- `tests/test_scripts/test_generate_ssh_config.py`: emission + real `ssh -G`
  first-match resolution (ordering, IP-not-MagicDNS, PATH-prefix + choose-tree,
  numeric → cc-slot.sh). 8 pass; `bash -n` + ruff clean.
- Adversarially reviewed (genesis-architect, three passes) + Codex clean on the
  prior iteration.

Supersedes #1401 (this is a clean single-commit re-creation to drop a
documentation-placeholder value from that PR’s intermediate commit history; the
code is byte-identical to #1401’s reviewed head).

🤖 Generated with [Claude Code](https://claude.com/claude-code)