### PR TITLE
feat(scripts): shared-artifact consumer-drift guard + store_cc_token.sh data-repair/--file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,23 @@ jobs:
       - name: Subsystem-map drift guard
         run: python scripts/check_subsystem_map.py
 
+  shared-artifact-consumer-check:
+    # Shared-artifact registry guard: docs/architecture/shared-artifacts.md must
+    # declare every code consumer of each registered artifact — a NEW consumer a
+    # documenting file never learned about is a doc that lies → error. The reader
+    # diff is a fixed-string content scan of src/ + scripts/, so no git history is
+    # needed (no fetch-depth: 0). See scripts/check_shared_artifact_consumers.py.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install checker dependency
+        run: pip install pyyaml
+      - name: Shared-artifact consumer drift guard
+        run: python scripts/check_shared_artifact_consumers.py
+
   hook-versions-check:
     # Completeness backstop for .genesis-hook-versions: every version of a
     # tracked git hook that ever shipped on main must be recorded, or a

--- a/docs/architecture/shared-artifacts.md
+++ b/docs/architecture/shared-artifacts.md
@@ -1,0 +1,56 @@
+# Shared-Artifact Consumer Registry
+
+Some artifacts — credential files, shared config — are read by several modules,
+and a doc (usually the writer) describes *who* consumes them. When a new consumer
+is added and that doc is not updated, the doc silently **lies**, and a session
+that grounds on it can state a false fact about the system.
+
+This registry is the deterministic backstop, enforced in CI by
+`scripts/check_shared_artifact_consumers.py`. Each `yaml shared-artifact` fenced
+block declares an artifact and its consumers; the guard fails (exit 1) when the
+declared `readers` diverge from the code that actually references the artifact
+under `src/` and `scripts/`. Fields (`artifact`, `documented_in`, `match_literals`,
+`readers`, `allowlist`) and their semantics are documented in that script's module
+docstring — read it before adding an entry.
+
+> **Editing note:** the guard scans this file with a raw regex, so it treats every
+> `yaml shared-artifact` fenced block as a live entry. Keep this file to real
+> entries only — put format examples in the guard script, never here.
+
+`match_literals` carries **two kinds** of signal so both access patterns are seen:
+the **filename** literal (direct file access) and the canonical **loader symbol**
+(transitive access through the accessor function). Both are plain substrings, so no
+LSP or code-graph is needed in CI. Prose is not a consumer and tests reference
+artifacts as fixtures, so only `src/` and `scripts/` are scanned. This guards
+enrolled artifacts by their consumer set — it is not a general prose↔code checker.
+
+## Registered artifacts
+
+### `cc_oauth_token.env` — fallback CC OAuth setup-token
+
+A `claude setup-token` credential (`~/.genesis/cc_oauth_token.env`, synced to the
+host shared mount) injected as `CLAUDE_CODE_OAUTH_TOKEN` **only** when a primary
+`claude login` is confirmed dead. Written by `scripts/store_cc_token.sh`; accessed
+directly by filename *and* transitively via `credential_bridge.load_cc_oauth_token()`.
+
+```yaml shared-artifact
+artifact: cc_oauth_token.env
+documented_in: scripts/store_cc_token.sh
+match_literals: [cc_oauth_token.env, load_cc_oauth_token]
+readers:
+  - src/genesis/cc/login_health.py
+  - src/genesis/guardian/diagnosis.py
+  - src/genesis/onboarding/floor.py
+  - scripts/guardian-gateway.sh
+allowlist:
+  - src/genesis/guardian/credential_bridge.py
+```
+
+- `cc/login_health.py` — injects it into the container's own CC sessions
+  (foreground + background) when the container login is hard-expired.
+- `guardian/diagnosis.py` — injects it into the host Guardian recovery brain when
+  the host's own login is dead (transitive, via the loader).
+- `onboarding/floor.py` — reads it as an auth-present signal at bootstrap.
+- `scripts/guardian-gateway.sh` — references the synced host copy.
+- `guardian/credential_bridge.py` (allowlist) — the loader/propagator home
+  (`load_cc_oauth_token`, `_CC_TOKEN_SOURCE`), not a business consumer.

--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -99,18 +99,28 @@ Two mechanisms make this observable and survivable without host access:
    only booleans and an age.
 
 2. **Fallback setup-token (optional, lazy).** Mint a 1-year token from ANY
-   machine with `claude setup-token` and pipe it to `scripts/store_cc_token.sh`
-   in the container (stdin only — never an argument). The credential-bridge
-   awareness tick syncs it to the host shared mount
-   (`~/.local/state/genesis-guardian/shared/guardian/cc_oauth_token.env`), and
-   `diagnosis.py` injects it via `CLAUDE_CODE_OAUTH_TOKEN` **only** when a
-   pre-flight `claude auth status` confirms the host's own login is dead — a
-   working login is never overridden. Remove it with
-   `scripts/store_cc_token.sh --remove`.
+   machine with `claude setup-token` and give it to `scripts/store_cc_token.sh`
+   in the container — pipe it on stdin, or (the interactive `setup-token` makes
+   piping awkward) write it to a file and pass `--file /path/to/token`, never a
+   bare argument. Create that file `0600` — e.g. `(umask 077; claude setup-token
+   > tok)` — and `rm` it after storing; it holds the raw token in plaintext (the
+   script warns if the source is group/other-readable). The credential-bridge awareness tick
+   syncs it to the host shared mount
+   (`~/.local/state/genesis-guardian/shared/guardian/cc_oauth_token.env`). It is
+   a **shared fallback** read by two consumers, each of which injects it via
+   `CLAUDE_CODE_OAUTH_TOKEN` **only** when its own login is confirmed dead: the
+   **host** Guardian recovery brain (`diagnosis.py`, gated on a pre-flight
+   `claude auth status`) and the **container's own** CC sessions
+   (`cc/login_health.py`, wired at `cc/invoker.py`). A healthy login is never
+   overridden. Remove it with `scripts/store_cc_token.sh --remove`. The
+   authoritative consumer list is CI-enforced in
+   `docs/architecture/shared-artifacts.md`.
 
    The token lives in a **dedicated** file, never `secrets.env` (which is
-   `load_dotenv`'d with `override=True` and would hijack the *container's* own
-   CC auth). It is a subscription-OAuth token, **not** an `ANTHROPIC_API_KEY` —
+   `load_dotenv`'d with `override=True` and would *unconditionally* set
+   `CLAUDE_CODE_OAUTH_TOKEN` for every process that loads it, hijacking a
+   *healthy* container login; the dedicated file is injected conditionally
+   instead). It is a subscription-OAuth token, **not** an `ANTHROPIC_API_KEY` —
    the no-API-key posture is unchanged.
 
 You can mint the token proactively at install, or defer it entirely: the first

--- a/scripts/check_shared_artifact_consumers.py
+++ b/scripts/check_shared_artifact_consumers.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Shared-artifact consumer-drift guard — a registered artifact's documented
+consumer set must match the code that actually references it.
+
+Some artifacts (credential files, shared config) are read by several modules,
+and the doc that describes the artifact enumerates its consumers. When a NEW
+consumer is added and that doc is not updated, the doc silently lies — and a
+session that grounds on it can state a false fact about the system (origin:
+2026-08-19, store_cc_token.sh's header framed the CC OAuth token as
+host-Guardian-only after cc/login_health.py added a container-session consumer;
+nothing detected the drift, and a later reply repeated the stale claim).
+
+This guard is the deterministic CI backstop. For each ``yaml shared-artifact``
+block in docs/architecture/shared-artifacts.md it:
+
+  * computes the ACTUAL consumer set — every file under src/ and scripts/ that
+    contains ANY of the entry's ``match_literals`` as a FIXED substring (never a
+    regex — no CLI/argv grammar to re-implement), minus the ``allowlist`` and the
+    ``documented_in`` writer/doc;
+  * diffs that against the DECLARED ``readers`` list, both directions:
+      - an actual consumer not in ``readers`` → hard ``::error::`` (exit 1);
+      - a declared reader that no longer references the artifact → hard
+        ``::error::`` (exit 1) — the registry lies.
+
+Two ``match_literals`` cover the two ways code reaches an artifact: the FILENAME
+literal (direct file access) and the canonical LOADER SYMBOL (transitive access
+through the accessor function) — e.g. ``[cc_oauth_token.env, load_cc_oauth_token]``
+so both cc/login_health.py (reads the file) and guardian/diagnosis.py (calls the
+loader) are seen. Both are plain substrings, so no LSP is needed in CI.
+
+The ``documented_in`` file must itself point readers to this registry (the guard
+checks it contains the registry's filename), so the human-facing doc routes to the
+CI-checked source of truth instead of maintaining a parallel prose consumer list
+that can silently drift — that prose is exactly what drifted in the origin incident.
+
+Scope: this guards only ENROLLED artifacts by declared-vs-actual consumer set.
+It is NOT a general prose↔code drift checker (that is unbounded). A prose
+freshness stamp is intentionally out of scope for now (keeps the CI job
+history-free — no fetch-depth: 0).
+
+Known limitation (accepted): a consumer that reaches an artifact ONLY via an
+alias/wrapper of the loader — containing neither ``match_literal`` — is not seen.
+Enumerate consumers when enrolling; if such a wrapper appears, add its symbol to
+``match_literals``.
+
+Usage:  python scripts/check_shared_artifact_consumers.py   (exit 0 = clean, 1 = drift)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+REGISTRY_PATH = Path("docs/architecture/shared-artifacts.md")
+# Code roots scanned for consumers. Docs/tests are intentionally NOT scanned:
+# prose is not a consumer, and tests reference artifacts as fixtures.
+SCAN_ROOTS = ["src", "scripts"]
+_SKIP_DIRS = {"__pycache__", ".git", "node_modules", ".mypy_cache", ".ruff_cache"}
+# This guard is the enforcement mechanism, never a consumer — exclude it from
+# every entry's scan so example literals in its own docstring don't self-flag.
+# Basename-derived so it tracks a rename within scripts/.
+_GUARD_SELF = f"scripts/{Path(__file__).name}"
+
+_BLOCK_RE = re.compile(r"^```yaml[ \t]+shared-artifact[ \t]*\n(.*?)^```", re.M | re.S)
+
+
+@dataclass
+class Entry:
+    """One ``yaml shared-artifact`` block: an artifact and its declared consumers."""
+
+    artifact: str
+    documented_in: str
+    match_literals: list[str]
+    readers: list[str]
+    allowlist: list[str] = field(default_factory=list)
+
+
+def parse_registry(text: str) -> tuple[list[Entry], list[str]]:
+    """Parse every ``yaml shared-artifact`` fenced block → (entries, errors)."""
+    entries: list[Entry] = []
+    errors: list[str] = []
+    for i, match in enumerate(_BLOCK_RE.finditer(text), start=1):
+        try:
+            data = yaml.safe_load(match.group(1))
+        except yaml.YAMLError as exc:
+            errors.append(f"block #{i}: invalid yaml ({exc})".replace("\n", " "))
+            continue
+        if not isinstance(data, dict):
+            errors.append(f"block #{i}: expected a mapping, got {type(data).__name__}")
+            continue
+        artifact = data.get("artifact")
+        documented_in = data.get("documented_in")
+        literals = data.get("match_literals")
+        readers = data.get("readers")
+        allowlist = data.get("allowlist", [])
+        if not artifact or not isinstance(artifact, str):
+            errors.append(f"block #{i}: missing 'artifact' name")
+            continue
+        if not documented_in or not isinstance(documented_in, str):
+            errors.append(f"artifact '{artifact}': missing 'documented_in' path")
+            continue
+        if not literals or not isinstance(literals, list):
+            errors.append(f"artifact '{artifact}': missing or empty 'match_literals' list")
+            continue
+        if any(str(x) == "" for x in literals):
+            errors.append(
+                f"artifact '{artifact}': 'match_literals' has an empty string (matches every file)"
+            )
+            continue
+        if readers is None or not isinstance(readers, list):
+            errors.append(f"artifact '{artifact}': missing 'readers' list (use [] if none)")
+            continue
+        if not isinstance(allowlist, list):
+            errors.append(f"artifact '{artifact}': 'allowlist' must be a list")
+            continue
+        entries.append(
+            Entry(
+                artifact=artifact,
+                documented_in=documented_in,
+                match_literals=[str(x) for x in literals],
+                readers=[str(x) for x in readers],
+                allowlist=[str(x) for x in allowlist],
+            )
+        )
+    return entries, errors
+
+
+def actual_consumers(
+    base: Path, scan_roots: list[str], literals: list[str], excluded: set[str]
+) -> set[str]:
+    """Repo-relative paths of files under scan_roots containing ANY literal (fixed substring).
+
+    ``excluded`` (the writer/doc + allowlist, as posix relpaths) are dropped.
+    Fixed-substring match — a literal is data, never a regex. Unreadable files are
+    skipped, never fatal.
+    """
+    found: set[str] = set()
+    for root in scan_roots:
+        root_dir = base / root
+        if not root_dir.is_dir():
+            continue
+        for path in root_dir.rglob("*"):
+            if not path.is_file():
+                continue
+            if any(part in _SKIP_DIRS for part in path.relative_to(base).parts):
+                continue
+            rel = path.relative_to(base).as_posix()
+            if rel in excluded:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if any(lit in text for lit in literals):
+                found.add(rel)
+    return found
+
+
+def check_consumers(entry: Entry, actual: set[str]) -> tuple[set[str], set[str]]:
+    """(undeclared, stale): actual-not-declared, and declared-not-actual."""
+    declared = set(entry.readers)
+    return actual - declared, declared - actual
+
+
+def main() -> int:
+    if not REGISTRY_PATH.is_file():
+        print(f"::error::shared-artifact guard: {REGISTRY_PATH} not found (run from repo root)")
+        return 1
+
+    entries, errors = parse_registry(REGISTRY_PATH.read_text(encoding="utf-8"))
+    for err in errors:
+        print(f"::error::{REGISTRY_PATH}: {err}")
+
+    problems = 0
+    base = Path.cwd()
+    for entry in entries:
+        # documented_in must ROUTE to this registry rather than maintain a parallel
+        # prose consumer list that CI can't check (that prose is exactly what drifts).
+        doc = Path(entry.documented_in)
+        if not doc.is_file():
+            print(
+                f"::error::{REGISTRY_PATH}: artifact '{entry.artifact}' documented_in "
+                f"'{entry.documented_in}' does not exist."
+            )
+            problems += 1
+        elif REGISTRY_PATH.name not in doc.read_text(encoding="utf-8", errors="ignore"):
+            print(
+                f"::error::{REGISTRY_PATH}: artifact '{entry.artifact}' documented_in "
+                f"'{entry.documented_in}' must point readers to the authoritative registry "
+                f"({REGISTRY_PATH.name}) instead of only re-enumerating consumers in prose."
+            )
+            problems += 1
+
+        excluded = set(entry.allowlist) | {entry.documented_in, _GUARD_SELF}
+        actual = actual_consumers(base, SCAN_ROOTS, entry.match_literals, excluded)
+        undeclared, stale = check_consumers(entry, actual)
+        for path in sorted(undeclared):
+            print(
+                f"::error::{REGISTRY_PATH}: artifact '{entry.artifact}' has an UNDECLARED "
+                f"consumer '{path}' — it references the artifact but is not in the entry's "
+                f"'readers'. Add it, and update {entry.documented_in} if the consumer story changed."
+            )
+            problems += 1
+        for path in sorted(stale):
+            print(
+                f"::error::{REGISTRY_PATH}: artifact '{entry.artifact}' lists reader '{path}', "
+                f"which no longer references it (file gone or reference removed) — the registry "
+                f"lies; update the entry (and {entry.documented_in})."
+            )
+            problems += 1
+
+    if errors or problems:
+        return 1
+    print(f"Shared-artifact guard: CLEAN ({len(entries)} artifact(s) checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_shared_artifact_consumers.py
+++ b/scripts/check_shared_artifact_consumers.py
@@ -44,10 +44,16 @@ freshness stamp is intentionally out of scope for now (keeps the CI job
 history-free — no fetch-depth: 0). SCAN_ROOTS is fixed to src/ + scripts/: an
 artifact whose consumers live outside those roots must extend SCAN_ROOTS too.
 
-Known limitation (accepted): a consumer that reaches an artifact ONLY via an
-alias/wrapper of the loader — containing neither ``match_literal`` — is not seen.
-Enumerate consumers when enrolling; if such a wrapper appears, add its symbol to
-``match_literals``.
+Known limitations (accepted — both inherent to fixed-substring matching, and both
+FAIL-SAFE, never a wrong-green on an undeclared consumer):
+  * a consumer that reaches an artifact ONLY via an alias/wrapper of the loader —
+    containing neither ``match_literal`` — is not seen. Enumerate consumers when
+    enrolling; if such a wrapper appears, add its symbol to ``match_literals``.
+  * a literal that survives only in a COMMENT (a declared reader kept a comment
+    mention after dropping the real access) reads as still-consuming, so that reader
+    is not flagged stale. Distinguishing code from comments needs per-language
+    parsing (an unbounded surface); the failure direction is benign — a stale reader
+    is retained in the doc, never a real consumer missed.
 
 Usage:  python scripts/check_shared_artifact_consumers.py   (exit 0 = clean, 1 = drift)
 """
@@ -110,7 +116,12 @@ def parse_registry(text: str) -> tuple[list[Entry], list[str]]:
     """Parse every ``yaml shared-artifact`` fenced block → (entries, errors)."""
     entries: list[Entry] = []
     errors: list[str] = []
+    matched = 0
+    # Count fence OPENINGS: an opener with no matching close never becomes a block,
+    # so if any opener is unmatched a malformed/unclosed block was silently skipped.
+    open_fences = len(re.findall(r"(?m)^```yaml[ \t]+shared-artifact\b", text))
     for i, match in enumerate(_BLOCK_RE.finditer(text), start=1):
+        matched += 1
         raw = match.group(1)
         try:
             data = yaml.safe_load(raw)
@@ -164,6 +175,11 @@ def parse_registry(text: str) -> tuple[list[Entry], list[str]]:
                 allowlist=[str(x) for x in allowlist],
             )
         )
+    if open_fences > matched:
+        errors.append(
+            f"{open_fences - matched} 'yaml shared-artifact' fence(s) opened but did not "
+            f"close/parse (malformed or unclosed block) — refusing rather than silently skipping."
+        )
     return entries, errors
 
 
@@ -177,26 +193,25 @@ def actual_consumers(
     """Repo-relative paths of files under scan_roots containing ANY literal (fixed substring).
 
     ``excluded`` (the writer/doc + allowlist, as posix relpaths) are dropped.
-    Fixed-substring match — a literal is data, never a regex. Follows symlinked
-    directories (with a realpath loop guard) so a consumer behind a symlink is not
-    silently missed. ``on_error`` (if given) is called with the OSError when a
-    directory cannot be listed, so the caller can fail closed instead of going
-    silently blind; unreadable individual files are skipped.
+    Fixed-substring match — a literal is data, never a regex. Symlinked directories
+    under a scan root are NOT traversed (os.walk followlinks=False); each is instead
+    reported via ``on_error`` so the caller fails CLOSED — a consumer behind a
+    symlink is surfaced loudly, never silently missed, and there is no real-vs-symlink
+    path-attribution ambiguity. ``on_error`` is also called when a directory cannot be
+    listed; unreadable individual files are skipped.
     """
     found: set[str] = set()
-    seen_dirs: set[str] = set()  # realpaths — loop guard for followlinks
-    walk_error = on_error if on_error is not None else (lambda _exc: None)
+    report = on_error if on_error is not None else (lambda _exc: None)
     for root in scan_roots:
         root_dir = base / root
         if not root_dir.is_dir():
             continue
-        for dirpath, dirnames, filenames in os.walk(root_dir, followlinks=True, onerror=walk_error):
-            real = os.path.realpath(dirpath)
-            if real in seen_dirs:
-                dirnames[:] = []  # already walked via its real path — don't re-descend/loop
-                continue
-            seen_dirs.add(real)
+        for dirpath, dirnames, filenames in os.walk(root_dir, onerror=report):
             dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+            for d in list(dirnames):
+                if (Path(dirpath) / d).is_symlink():
+                    rel = (Path(dirpath) / d).relative_to(base).as_posix()
+                    report(OSError(f"symlinked directory not traversed: {rel}"))
             for name in filenames:
                 path = Path(dirpath) / name
                 rel = path.relative_to(base).as_posix()

--- a/scripts/check_shared_artifact_consumers.py
+++ b/scripts/check_shared_artifact_consumers.py
@@ -33,10 +33,16 @@ checks it contains the registry's filename), so the human-facing doc routes to t
 CI-checked source of truth instead of maintaining a parallel prose consumer list
 that can silently drift — that prose is exactly what drifted in the origin incident.
 
+The guard fails CLOSED: a registry that parses to zero blocks, a duplicate/invalid
+key, an unreadable directory under a scan root, or an unrecognised shape all block
+(exit 1) rather than reporting CLEAN. The consumer scan follows symlinked dirs
+(with a loop guard) so a consumer behind a symlink is not silently missed.
+
 Scope: this guards only ENROLLED artifacts by declared-vs-actual consumer set.
 It is NOT a general prose↔code drift checker (that is unbounded). A prose
 freshness stamp is intentionally out of scope for now (keeps the CI job
-history-free — no fetch-depth: 0).
+history-free — no fetch-depth: 0). SCAN_ROOTS is fixed to src/ + scripts/: an
+artifact whose consumers live outside those roots must extend SCAN_ROOTS too.
 
 Known limitation (accepted): a consumer that reaches an artifact ONLY via an
 alias/wrapper of the loader — containing neither ``match_literal`` — is not seen.
@@ -48,6 +54,7 @@ Usage:  python scripts/check_shared_artifact_consumers.py   (exit 0 = clean, 1 =
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -68,6 +75,26 @@ _GUARD_SELF = f"scripts/{Path(__file__).name}"
 _BLOCK_RE = re.compile(r"^```yaml[ \t]+shared-artifact[ \t]*\n(.*?)^```", re.M | re.S)
 
 
+def _duplicate_top_level_keys(raw: str) -> list[str]:
+    """Top-level mapping keys that appear more than once in a block.
+
+    ``yaml.safe_load`` silently keeps the last value for a repeated key, so a
+    badly-resolved merge conflict (two ``match_literals:`` lines) would silently
+    narrow the literal set and blind the scan. A column-0 ``key:`` scan catches
+    that realistic case without resorting to an unsafe custom yaml Loader.
+    """
+    seen: set[str] = set()
+    dups: list[str] = []
+    for line in raw.splitlines():
+        m = re.match(r"([A-Za-z_][\w-]*):", line)  # column 0 → a top-level key
+        if m:
+            key = m.group(1)
+            if key in seen:
+                dups.append(key)
+            seen.add(key)
+    return dups
+
+
 @dataclass
 class Entry:
     """One ``yaml shared-artifact`` block: an artifact and its declared consumers."""
@@ -84,13 +111,21 @@ def parse_registry(text: str) -> tuple[list[Entry], list[str]]:
     entries: list[Entry] = []
     errors: list[str] = []
     for i, match in enumerate(_BLOCK_RE.finditer(text), start=1):
+        raw = match.group(1)
         try:
-            data = yaml.safe_load(match.group(1))
+            data = yaml.safe_load(raw)
         except yaml.YAMLError as exc:
             errors.append(f"block #{i}: invalid yaml ({exc})".replace("\n", " "))
             continue
         if not isinstance(data, dict):
             errors.append(f"block #{i}: expected a mapping, got {type(data).__name__}")
+            continue
+        dups = _duplicate_top_level_keys(raw)
+        if dups:
+            errors.append(
+                f"block #{i}: duplicate key(s) {sorted(set(dups))} — refusing "
+                f"(safe_load's last-wins would silently drop config)"
+            )
             continue
         artifact = data.get("artifact")
         documented_in = data.get("documented_in")
@@ -106,7 +141,10 @@ def parse_registry(text: str) -> tuple[list[Entry], list[str]]:
         if not literals or not isinstance(literals, list):
             errors.append(f"artifact '{artifact}': missing or empty 'match_literals' list")
             continue
-        if any(str(x) == "" for x in literals):
+        if not all(isinstance(x, str) for x in literals):
+            errors.append(f"artifact '{artifact}': every 'match_literals' entry must be a string")
+            continue
+        if any(x == "" for x in literals):
             errors.append(
                 f"artifact '{artifact}': 'match_literals' has an empty string (matches every file)"
             )
@@ -130,33 +168,46 @@ def parse_registry(text: str) -> tuple[list[Entry], list[str]]:
 
 
 def actual_consumers(
-    base: Path, scan_roots: list[str], literals: list[str], excluded: set[str]
+    base: Path,
+    scan_roots: list[str],
+    literals: list[str],
+    excluded: set[str],
+    on_error=None,
 ) -> set[str]:
     """Repo-relative paths of files under scan_roots containing ANY literal (fixed substring).
 
     ``excluded`` (the writer/doc + allowlist, as posix relpaths) are dropped.
-    Fixed-substring match — a literal is data, never a regex. Unreadable files are
-    skipped, never fatal.
+    Fixed-substring match — a literal is data, never a regex. Follows symlinked
+    directories (with a realpath loop guard) so a consumer behind a symlink is not
+    silently missed. ``on_error`` (if given) is called with the OSError when a
+    directory cannot be listed, so the caller can fail closed instead of going
+    silently blind; unreadable individual files are skipped.
     """
     found: set[str] = set()
+    seen_dirs: set[str] = set()  # realpaths — loop guard for followlinks
+    walk_error = on_error if on_error is not None else (lambda _exc: None)
     for root in scan_roots:
         root_dir = base / root
         if not root_dir.is_dir():
             continue
-        for path in root_dir.rglob("*"):
-            if not path.is_file():
+        for dirpath, dirnames, filenames in os.walk(root_dir, followlinks=True, onerror=walk_error):
+            real = os.path.realpath(dirpath)
+            if real in seen_dirs:
+                dirnames[:] = []  # already walked via its real path — don't re-descend/loop
                 continue
-            if any(part in _SKIP_DIRS for part in path.relative_to(base).parts):
-                continue
-            rel = path.relative_to(base).as_posix()
-            if rel in excluded:
-                continue
-            try:
-                text = path.read_text(encoding="utf-8", errors="ignore")
-            except OSError:
-                continue
-            if any(lit in text for lit in literals):
-                found.add(rel)
+            seen_dirs.add(real)
+            dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+            for name in filenames:
+                path = Path(dirpath) / name
+                rel = path.relative_to(base).as_posix()
+                if rel in excluded:
+                    continue
+                try:
+                    content = path.read_text(encoding="utf-8", errors="ignore")
+                except OSError:
+                    continue
+                if any(lit in content for lit in literals):
+                    found.add(rel)
     return found
 
 
@@ -171,12 +222,30 @@ def main() -> int:
         print(f"::error::shared-artifact guard: {REGISTRY_PATH} not found (run from repo root)")
         return 1
 
-    entries, errors = parse_registry(REGISTRY_PATH.read_text(encoding="utf-8"))
+    try:
+        text = REGISTRY_PATH.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"::error::{REGISTRY_PATH}: could not read the registry ({exc}).")
+        return 1
+
+    entries, errors = parse_registry(text)
     for err in errors:
         print(f"::error::{REGISTRY_PATH}: {err}")
+    if not entries and not errors:
+        # Fail CLOSED: the registry file exists but yielded no blocks — it was
+        # emptied, a fence is malformed/unclosed, or the file has CRLF endings the
+        # block regex does not match. Reporting "CLEAN (0 artifacts)" would be a
+        # wrong-green on the guard.
+        print(
+            f"::error::{REGISTRY_PATH}: no 'yaml shared-artifact' blocks parsed — the registry "
+            f"is empty, a fence is malformed/unclosed, or the file has CRLF line endings. "
+            f"Guard fails closed rather than passing."
+        )
+        return 1
 
     problems = 0
     base = Path.cwd()
+    scan_errors: list[str] = []
     for entry in entries:
         # documented_in must ROUTE to this registry rather than maintain a parallel
         # prose consumer list that CI can't check (that prose is exactly what drifts).
@@ -196,7 +265,9 @@ def main() -> int:
             problems += 1
 
         excluded = set(entry.allowlist) | {entry.documented_in, _GUARD_SELF}
-        actual = actual_consumers(base, SCAN_ROOTS, entry.match_literals, excluded)
+        actual = actual_consumers(
+            base, SCAN_ROOTS, entry.match_literals, excluded, on_error=scan_errors.append
+        )
         undeclared, stale = check_consumers(entry, actual)
         for path in sorted(undeclared):
             print(
@@ -212,6 +283,15 @@ def main() -> int:
                 f"lies; update the entry (and {entry.documented_in})."
             )
             problems += 1
+
+    # Fail CLOSED on any directory the scan could not read — a swallowed dir could
+    # hide an undeclared consumer, which is the exact wrong-green the guard prevents.
+    for exc in scan_errors:
+        print(
+            f"::error::{REGISTRY_PATH}: consumer scan could not read a path ({exc}) — "
+            f"guard fails closed rather than reporting an incomplete-but-clean scan."
+        )
+        problems += 1
 
     if errors or problems:
         return 1

--- a/scripts/store_cc_token.sh
+++ b/scripts/store_cc_token.sh
@@ -1,23 +1,31 @@
 #!/usr/bin/env bash
-# store_cc_token.sh — intake a `claude setup-token` OAuth token for the host
-# Guardian recovery brain's FALLBACK authentication.
+# store_cc_token.sh — intake a `claude setup-token` OAuth token used as a
+# FALLBACK CC credential, by two consumers, when a primary `claude login` dies.
 #
-# The host Guardian's `claude -p` recovery brain authenticates via a one-time
-# manual `claude login` (no refresh). If that login dies, the brain goes dark.
-# A `claude setup-token` 1-year OAuth token (used via CLAUDE_CODE_OAUTH_TOKEN —
-# NOT an ANTHROPIC_API_KEY) stored here is synced to the host by the
-# credential-bridge awareness tick and injected by diagnosis.py ONLY as a
-# fallback when the host's own login is dead (a working login is never touched).
+# The token (a 1-year `claude setup-token`, used via CLAUDE_CODE_OAUTH_TOKEN —
+# NOT an ANTHROPIC_API_KEY) is stored 0600 to a DEDICATED container file and
+# synced to the host shared mount by the credential-bridge awareness tick. It is
+# a SHARED fallback, read by consumers on BOTH the host (the Guardian recovery
+# brain, via guardian/diagnosis.py) AND the container itself (its own CC sessions,
+# foreground + background, via cc/login_health.py) — each injecting it ONLY when
+# its own login is confirmed dead; a HEALTHY login is never overridden. It is NOT
+# host-Guardian-only. The authoritative, CI-enforced consumer list lives in
+# docs/architecture/shared-artifacts.md (checked by
+# scripts/check_shared_artifact_consumers.py) — update THAT when a consumer changes.
 #
-# The token is read from STDIN ONLY (never argv — no shell-history / ps leak),
-# written 0600 to a DEDICATED file (NOT secrets.env, which is load_dotenv'd with
-# override=True and would hijack the container's own CC auth — see
-# credential_bridge.py), and stamped with its creation epoch. This script prints
-# ZERO token material.
+# The token is read from STDIN or a --file PATH (never a bare argv token — no
+# shell-history / ps leak); with --file, create the source 0600 (`umask 077`) and
+# `rm` it after, since it holds the raw token in plaintext. It is written 0600 to
+# a DEDICATED file — NOT secrets.env,
+# which is load_dotenv'd with override=True and would UNCONDITIONALLY set
+# CLAUDE_CODE_OAUTH_TOKEN for every process that loads it, hijacking a HEALTHY
+# container login (the dedicated file is instead injected conditionally by
+# cc/login_health.py). This script prints ZERO token material.
 #
 # Usage:
-#   claude setup-token | scripts/store_cc_token.sh     # store (stdin only)
-#   scripts/store_cc_token.sh --remove                 # remove everywhere
+#   claude setup-token | scripts/store_cc_token.sh      # store (stdin)
+#   scripts/store_cc_token.sh --file /path/to/token      # store from a file
+#   scripts/store_cc_token.sh --remove                  # remove everywhere
 #   scripts/store_cc_token.sh --help
 
 set -euo pipefail
@@ -48,9 +56,28 @@ TOKEN_FILE="${HOME}/.genesis/cc_oauth_token.env"
 SHARED_FILE="${HOME}/.genesis/shared/guardian/cc_oauth_token.env"
 
 usage() {
-    sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+    # Print the leading comment block (the header, after the shebang) up to the
+    # first non-comment line — robust to the header's length (do NOT hardcode a
+    # line range; that silently over-reads into code when the header grows).
+    awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "$0"
 }
 
+read_first_token() {
+    # Emit the first non-empty, whitespace-stripped line from stdin (setup-token
+    # prints one token line). A trailing line without a newline is handled by the
+    # `|| [ -n "$line" ]` guard.
+    local line token=""
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="$(printf '%s' "$line" | tr -d '[:space:]')"
+        if [ -n "$line" ]; then
+            token="$line"
+            break
+        fi
+    done
+    printf '%s' "$token"
+}
+
+TOKEN=""
 case "${1:-}" in
     -h|--help)
         usage
@@ -72,35 +99,46 @@ case "${1:-}" in
         fi
         exit 0
         ;;
+    --file)
+        # Read from a file instead of stdin. The token never touches argv (only
+        # the PATH does), so there is no shell-history / ps leak.
+        if [ -z "${2:-}" ]; then
+            echo "ERROR: --file requires a PATH argument." >&2
+            echo "  $0 --file /path/to/token-file" >&2
+            exit 1
+        fi
+        if [ ! -f "$2" ] || [ ! -r "$2" ]; then
+            echo "ERROR: --file: '$2' is not a readable regular file." >&2
+            exit 1
+        fi
+        # Non-fatal nudge: the source file holds the raw token in plaintext. If it
+        # is readable by group/other (e.g. created under the default umask 022) it
+        # was an exposure — advise creating it 0600 and removing it after.
+        if [ -n "$(find "$2" -maxdepth 0 -perm /077 2>/dev/null)" ]; then
+            echo "WARNING: '$2' is readable by group/other — the token sat there in plaintext." >&2
+            echo "         Create it with 'umask 077' (or 'install -m 600') and 'rm' it after storing." >&2
+        fi
+        TOKEN="$(read_first_token < "$2")"
+        ;;
     "")
-        : # fall through to stdin intake
+        if [ -t 0 ]; then
+            echo "ERROR: token must be piped via stdin or supplied with --file, e.g.:" >&2
+            echo "  claude setup-token | $0" >&2
+            echo "  $0 --file /path/to/token-file" >&2
+            exit 1
+        fi
+        TOKEN="$(read_first_token)"
         ;;
     *)
-        echo "ERROR: unknown argument '$1'. Token must be piped via stdin — never passed as an argument." >&2
+        echo "ERROR: unknown argument '$1'. The token comes from stdin or --file PATH — never a bare argument." >&2
         echo "  claude setup-token | $0" >&2
+        echo "  $0 --file /path/to/token-file" >&2
         exit 1
         ;;
 esac
 
-if [ -t 0 ]; then
-    echo "ERROR: token must be piped via stdin (never an argument), e.g.:" >&2
-    echo "  claude setup-token | $0" >&2
-    exit 1
-fi
-
-# Read the first non-empty line (setup-token prints one token line). Trailing
-# no-newline is handled by the `|| [ -n "$line" ]` guard.
-TOKEN=""
-while IFS= read -r line || [ -n "$line" ]; do
-    line="$(printf '%s' "$line" | tr -d '[:space:]')"
-    if [ -n "$line" ]; then
-        TOKEN="$line"
-        break
-    fi
-done
-
 if [ -z "$TOKEN" ]; then
-    echo "ERROR: no token received on stdin." >&2
+    echo "ERROR: no token received (stdin/--file was empty)." >&2
     exit 1
 fi
 

--- a/scripts/store_cc_token.sh
+++ b/scripts/store_cc_token.sh
@@ -7,9 +7,10 @@
 # synced to the host shared mount by the credential-bridge awareness tick. It is
 # a SHARED fallback, read by consumers on BOTH the host (the Guardian recovery
 # brain, via guardian/diagnosis.py) AND the container itself (its own CC sessions,
-# foreground + background, via cc/login_health.py) — each injecting it ONLY when
-# its own login is confirmed dead; a HEALTHY login is never overridden. It is NOT
-# host-Guardian-only. The authoritative, CI-enforced consumer list lives in
+# foreground + background, via cc/login_health.py) — each injecting it only as a
+# fallback when its own login is down (see those modules for the exact activation
+# gate); a HEALTHY login is never overridden. It is NOT host-Guardian-only. The
+# authoritative, CI-enforced consumer list lives in
 # docs/architecture/shared-artifacts.md (checked by
 # scripts/check_shared_artifact_consumers.py) — update THAT when a consumer changes.
 #
@@ -62,18 +63,26 @@ usage() {
     awk 'NR==1 {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' "$0"
 }
 
-read_first_token() {
-    # Emit the first non-empty, whitespace-stripped line from stdin (setup-token
-    # prints one token line). A trailing line without a newline is handled by the
-    # `|| [ -n "$line" ]` guard.
-    local line token=""
+read_token() {
+    # Concatenate ALL non-whitespace from stdin into one token. A real setup-token
+    # is a single line, but a copy-paste from a wrapped terminal can inject hard
+    # newlines mid-token — stripping all whitespace rejoins it, instead of silently
+    # storing only the first fragment (which would arm a BROKEN fallback credential
+    # and only fail later, during an outage). Warn (stderr, never stdout, so the
+    # captured token stays clean) if the input spanned >1 non-empty line, so a
+    # genuinely multi-value paste is visible rather than silently merged.
+    local line token="" nonempty=0
     while IFS= read -r line || [ -n "$line" ]; do
         line="$(printf '%s' "$line" | tr -d '[:space:]')"
         if [ -n "$line" ]; then
-            token="$line"
-            break
+            nonempty=$((nonempty + 1))
+            token="$token$line"
         fi
     done
+    if [ "$nonempty" -gt 1 ]; then
+        echo "WARNING: input spanned $nonempty non-empty lines — concatenated into one token." >&2
+        echo "         A setup-token is a single line; verify the stored value is correct." >&2
+    fi
     printf '%s' "$token"
 }
 
@@ -114,11 +123,12 @@ case "${1:-}" in
         # Non-fatal nudge: the source file holds the raw token in plaintext. If it
         # is readable by group/other (e.g. created under the default umask 022) it
         # was an exposure — advise creating it 0600 and removing it after.
-        if [ -n "$(find "$2" -maxdepth 0 -perm /077 2>/dev/null)" ]; then
+        src_mode="$(stat -c '%a' -- "$2" 2>/dev/null || true)"
+        if [ -n "$src_mode" ] && [ "$(( 0${src_mode} & 077 ))" -ne 0 ]; then
             echo "WARNING: '$2' is readable by group/other — the token sat there in plaintext." >&2
             echo "         Create it with 'umask 077' (or 'install -m 600') and 'rm' it after storing." >&2
         fi
-        TOKEN="$(read_first_token < "$2")"
+        TOKEN="$(read_token < "$2")"
         ;;
     "")
         if [ -t 0 ]; then
@@ -127,7 +137,7 @@ case "${1:-}" in
             echo "  $0 --file /path/to/token-file" >&2
             exit 1
         fi
-        TOKEN="$(read_first_token)"
+        TOKEN="$(read_token)"
         ;;
     *)
         echo "ERROR: unknown argument '$1'. The token comes from stdin or --file PATH — never a bare argument." >&2

--- a/scripts/store_cc_token.sh
+++ b/scripts/store_cc_token.sh
@@ -64,26 +64,26 @@ usage() {
 }
 
 read_token() {
-    # Concatenate ALL non-whitespace from stdin into one token. A real setup-token
-    # is a single line, but a copy-paste from a wrapped terminal can inject hard
-    # newlines mid-token — stripping all whitespace rejoins it, instead of silently
-    # storing only the first fragment (which would arm a BROKEN fallback credential
-    # and only fail later, during an outage). Warn (stderr, never stdout, so the
-    # captured token stays clean) if the input spanned >1 non-empty line, so a
-    # genuinely multi-value paste is visible rather than silently merged.
-    local line token="" nonempty=0
+    # Read stdin into globals: TOKEN (all non-whitespace concatenated), _nonempty
+    # (count of non-empty lines) and _complete (count of lines that each look like a
+    # WHOLE token). A real setup-token is a single line; a wrapped copy-paste can
+    # inject hard newlines mid-token, so concatenation rejoins it rather than storing
+    # only the first fragment. But two lines that EACH look complete are two distinct
+    # tokens, not a wrap — the caller refuses those (concatenating them would store a
+    # garbage credential). Runs in the current shell (no subshell) so it can set
+    # globals; the token never reaches stdout.
+    TOKEN=""
+    _nonempty=0
+    _complete=0
+    local line
     while IFS= read -r line || [ -n "$line" ]; do
         line="$(printf '%s' "$line" | tr -d '[:space:]')"
         if [ -n "$line" ]; then
-            nonempty=$((nonempty + 1))
-            token="$token$line"
+            _nonempty=$((_nonempty + 1))
+            case "$line" in sk-ant-oat*) _complete=$((_complete + 1)) ;; esac
+            TOKEN="$TOKEN$line"
         fi
     done
-    if [ "$nonempty" -gt 1 ]; then
-        echo "WARNING: input spanned $nonempty non-empty lines — concatenated into one token." >&2
-        echo "         A setup-token is a single line; verify the stored value is correct." >&2
-    fi
-    printf '%s' "$token"
 }
 
 TOKEN=""
@@ -128,7 +128,7 @@ case "${1:-}" in
             echo "WARNING: '$2' is readable by group/other — the token sat there in plaintext." >&2
             echo "         Create it with 'umask 077' (or 'install -m 600') and 'rm' it after storing." >&2
         fi
-        TOKEN="$(read_token < "$2")"
+        read_token < "$2"
         ;;
     "")
         if [ -t 0 ]; then
@@ -137,7 +137,7 @@ case "${1:-}" in
             echo "  $0 --file /path/to/token-file" >&2
             exit 1
         fi
-        TOKEN="$(read_token)"
+        read_token
         ;;
     *)
         echo "ERROR: unknown argument '$1'. The token comes from stdin or --file PATH — never a bare argument." >&2
@@ -147,9 +147,19 @@ case "${1:-}" in
         ;;
 esac
 
+if [ "${_complete:-0}" -gt 1 ]; then
+    echo "ERROR: input has ${_complete} complete tokens (each starts with 'sk-ant-oat') — supply exactly one." >&2
+    exit 1
+fi
+
 if [ -z "$TOKEN" ]; then
     echo "ERROR: no token received (stdin/--file was empty)." >&2
     exit 1
+fi
+
+if [ "${_nonempty:-0}" -gt 1 ]; then
+    echo "WARNING: input spanned ${_nonempty} non-empty lines — concatenated into one token." >&2
+    echo "         A setup-token is a single line; verify the stored value is correct." >&2
 fi
 
 # Sanity-check the shape but do not hard-fail (the CLI format could evolve).

--- a/tests/test_scripts/test_check_shared_artifact_consumers.py
+++ b/tests/test_scripts/test_check_shared_artifact_consumers.py
@@ -16,8 +16,11 @@ the real repo layout.
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _spec = importlib.util.spec_from_file_location(
@@ -316,6 +319,99 @@ def test_flags_documented_in_missing_file(tmp_path):
     assert "does not exist" in out
 
 
+def test_empty_registry_fails_closed(tmp_path):
+    """A registry that parses to zero blocks (emptied) must fail closed, not CLEAN."""
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "# prose only, no shared-artifact blocks\n",
+    )
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 1
+    assert "no 'yaml shared-artifact' blocks" in out
+
+
+def test_unclosed_fence_fails_closed(tmp_path):
+    """A malformed/unclosed fence matches no block (0 entries, 0 errors) → fail closed."""
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "```yaml shared-artifact\nartifact: x\ndocumented_in: d\nmatch_literals: [x]\nreaders: []\n",
+    )  # no closing ``` fence
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 1
+
+
+def _registry_and_writer(tmp_path, match_literals="[cc_oauth_token.env]"):
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "```yaml shared-artifact\nartifact: cc_oauth_token.env\n"
+        "documented_in: scripts/store_cc_token.sh\n"
+        f"match_literals: {match_literals}\nreaders: []\nallowlist: []\n```\n",
+    )
+    _write(
+        tmp_path,
+        "scripts/store_cc_token.sh",
+        "F=cc_oauth_token.env  # docs/architecture/shared-artifacts.md\n",
+    )
+
+
+def test_symlinked_dir_consumer_is_seen(tmp_path):
+    """A consumer reachable only through a symlinked directory under a scan root
+    must still be caught (rglob does not descend into symlinked dirs → fail-open)."""
+    _registry_and_writer(tmp_path)
+    ext = tmp_path / "external"
+    ext.mkdir()
+    (ext / "hidden_consumer.py").write_text("P = 'cc_oauth_token.env'\n")
+    (tmp_path / "src").mkdir(exist_ok=True)
+    (tmp_path / "src" / "linkdir").symlink_to(ext, target_is_directory=True)
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 1
+    assert "hidden_consumer.py" in out
+
+
+def test_unreadable_dir_fails_closed(tmp_path):
+    """A directory the scan cannot read must fail closed (it could hide an undeclared
+    consumer), not be silently skipped."""
+    if os.geteuid() == 0:
+        pytest.skip("root ignores directory permissions")
+    _registry_and_writer(tmp_path)
+    secret = tmp_path / "src" / "secret"
+    secret.mkdir(parents=True)
+    (secret / "hidden.py").write_text("cc_oauth_token.env\n")
+    secret.chmod(0o000)
+    try:
+        rc, out = _run_main_over(tmp_path)
+    finally:
+        secret.chmod(0o755)  # restore so tmp cleanup can remove it
+    assert rc == 1
+    assert "fails closed" in out
+
+
+def test_duplicate_top_level_key_errors():
+    """A duplicate top-level key (a merge-conflict artifact) must error, not let
+    safe_load's last-wins silently narrow the literal set."""
+    raw = (
+        "```yaml shared-artifact\nartifact: a\ndocumented_in: d\n"
+        "match_literals: [cc_oauth_token.env, load_cc_oauth_token]\n"
+        "match_literals: [load_cc_oauth_token]\nreaders: []\n```\n"
+    )
+    _, errors = csac.parse_registry(raw)
+    assert len(errors) == 1
+    assert "duplicate" in errors[0].lower()
+
+
+def test_nonstring_literal_errors():
+    raw = (
+        "```yaml shared-artifact\nartifact: a\ndocumented_in: d\n"
+        "match_literals: [[a, b], c]\nreaders: []\n```\n"
+    )
+    _, errors = csac.parse_registry(raw)
+    assert len(errors) == 1
+    assert "string" in errors[0].lower()
+
+
 # --- integration harness: run main() with REGISTRY_PATH + SCAN_ROOTS pointed at tmp_path ---
 
 
@@ -327,7 +423,6 @@ def _run_main_over(base: Path):
     """
     import contextlib
     import io
-    import os
 
     buf = io.StringIO()
     cwd = os.getcwd()

--- a/tests/test_scripts/test_check_shared_artifact_consumers.py
+++ b/tests/test_scripts/test_check_shared_artifact_consumers.py
@@ -357,9 +357,10 @@ def _registry_and_writer(tmp_path, match_literals="[cc_oauth_token.env]"):
     )
 
 
-def test_symlinked_dir_consumer_is_seen(tmp_path):
-    """A consumer reachable only through a symlinked directory under a scan root
-    must still be caught (rglob does not descend into symlinked dirs → fail-open)."""
+def test_symlinked_dir_fails_closed(tmp_path):
+    """A symlinked directory under a scan root is not traversed; it must be surfaced
+    as a fail-closed error (a consumer behind it would otherwise be invisible), with
+    no real-vs-symlink path-attribution ambiguity."""
     _registry_and_writer(tmp_path)
     ext = tmp_path / "external"
     ext.mkdir()
@@ -368,7 +369,33 @@ def test_symlinked_dir_consumer_is_seen(tmp_path):
     (tmp_path / "src" / "linkdir").symlink_to(ext, target_is_directory=True)
     rc, out = _run_main_over(tmp_path)
     assert rc == 1
-    assert "hidden_consumer.py" in out
+    assert "symlinked directory" in out
+    assert "src/linkdir" in out
+
+
+def test_malformed_fence_among_valid_fails_closed(tmp_path):
+    """A valid entry followed by an unclosed fence: the malformed block is silently
+    skipped by the regex, so a newly-added artifact would be unguarded. The guard
+    must fail closed (openers != parsed blocks)."""
+    _write(tmp_path, "src/genesis/cc/login_health.py", "T = 'cc_oauth_token.env'\n")
+    _write(
+        tmp_path,
+        "scripts/store_cc_token.sh",
+        "F=cc_oauth_token.env  # docs/architecture/shared-artifacts.md\n",
+    )
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "```yaml shared-artifact\nartifact: cc_oauth_token.env\n"
+        "documented_in: scripts/store_cc_token.sh\n"
+        "match_literals: [cc_oauth_token.env]\n"
+        "readers:\n  - src/genesis/cc/login_health.py\n"
+        "allowlist: []\n```\n\n"
+        "```yaml shared-artifact\nartifact: other.env\n",  # second opener, never closed
+    )
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 1
+    assert "fence" in out.lower()
 
 
 def test_unreadable_dir_fails_closed(tmp_path):

--- a/tests/test_scripts/test_check_shared_artifact_consumers.py
+++ b/tests/test_scripts/test_check_shared_artifact_consumers.py
@@ -1,0 +1,340 @@
+"""Tests for scripts/check_shared_artifact_consumers.py — shared-artifact drift guard.
+
+The guard parses the fenced ``yaml shared-artifact`` blocks in
+docs/architecture/shared-artifacts.md and, for each registered artifact, diffs the
+DECLARED consumer set (``readers``) against the ACTUAL set of code files under
+src/ and scripts/ that reference any of the artifact's ``match_literals`` (fixed
+substrings). A consumer that appears in the code but not the registry, or a
+declared reader that no longer references the artifact, is a hard error — that is
+the drift that let store_cc_token.sh's header go stale when login_health.py added
+a second consumer (2026-08-19).
+
+Tests use synthetic registries and source trees under tmp_path; no test depends on
+the real repo layout.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "check_shared_artifact_consumers",
+    _REPO_ROOT / "scripts" / "check_shared_artifact_consumers.py",
+)
+csac = importlib.util.module_from_spec(_spec)
+sys.modules["check_shared_artifact_consumers"] = csac  # @dataclass __module__ resolves here
+_spec.loader.exec_module(csac)
+
+
+# One well-formed entry: the token file, both literals, four declared readers, the
+# loader-home + writer allowlisted. A second, untagged yaml block that must be ignored.
+REGISTRY_ONE = """# Shared artifacts
+
+## CC OAuth token
+
+```yaml shared-artifact
+artifact: cc_oauth_token.env
+documented_in: scripts/store_cc_token.sh
+match_literals: [cc_oauth_token.env, load_cc_oauth_token]
+readers:
+  - src/genesis/cc/login_health.py
+  - src/genesis/guardian/diagnosis.py
+allowlist:
+  - src/genesis/guardian/credential_bridge.py
+```
+
+```yaml
+not_a_registry_block: ignored because it has no shared-artifact tag
+```
+"""
+
+
+def _write(base: Path, rel: str, text: str) -> None:
+    p = base / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+# --- parse_registry ---
+
+
+def test_parse_registry_reads_tagged_blocks_only():
+    entries, errors = csac.parse_registry(REGISTRY_ONE)
+    assert errors == []
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.artifact == "cc_oauth_token.env"
+    assert e.documented_in == "scripts/store_cc_token.sh"
+    assert e.match_literals == ["cc_oauth_token.env", "load_cc_oauth_token"]
+    assert e.readers == ["src/genesis/cc/login_health.py", "src/genesis/guardian/diagnosis.py"]
+    assert e.allowlist == ["src/genesis/guardian/credential_bridge.py"]
+
+
+def test_parse_registry_flags_missing_required_fields():
+    for raw in (
+        "```yaml shared-artifact\ndocumented_in: d\nmatch_literals: [x]\nreaders: []\n```\n",  # no artifact
+        "```yaml shared-artifact\nartifact: a\ndocumented_in: d\nreaders: []\n```\n",  # no match_literals
+        "```yaml shared-artifact\nartifact: a\ndocumented_in: d\nmatch_literals: [x]\n```\n",  # no readers key
+        "```yaml shared-artifact\nartifact: a\nmatch_literals: [x]\nreaders: []\n```\n",  # no documented_in
+    ):
+        _, errors = csac.parse_registry(raw)
+        assert len(errors) == 1, raw
+
+
+def test_parse_registry_flags_empty_match_literals():
+    raw = "```yaml shared-artifact\nartifact: a\ndocumented_in: d\nmatch_literals: []\nreaders: []\n```\n"
+    _, errors = csac.parse_registry(raw)
+    assert len(errors) == 1
+
+
+def test_parse_registry_flags_empty_literal_string():
+    # an empty-string literal would match every file — reject it
+    raw = "```yaml shared-artifact\nartifact: a\ndocumented_in: d\nmatch_literals: ['', x]\nreaders: []\n```\n"
+    _, errors = csac.parse_registry(raw)
+    assert len(errors) == 1
+
+
+# --- actual_consumers (the fixed-string scan) ---
+
+
+def test_actual_consumers_finds_literal_matches_minus_excluded(tmp_path):
+    _write(tmp_path, "src/pkg/reader_a.py", "path = 'cc_oauth_token.env'\n")
+    _write(tmp_path, "src/pkg/loader_user.py", "from x import load_cc_oauth_token\n")
+    _write(tmp_path, "src/pkg/unrelated.py", "print('nothing here')\n")
+    _write(tmp_path, "scripts/writer.sh", "TOKEN=cc_oauth_token.env\n")
+    got = csac.actual_consumers(
+        tmp_path,
+        ["src", "scripts"],
+        ["cc_oauth_token.env", "load_cc_oauth_token"],
+        excluded={"scripts/writer.sh"},  # the writer is excluded
+    )
+    assert got == {"src/pkg/reader_a.py", "src/pkg/loader_user.py"}
+
+
+def test_actual_consumers_matches_fixed_string_not_regex(tmp_path):
+    # A literal with regex metacharacters must match verbatim, not as a pattern.
+    _write(tmp_path, "src/pkg/a.py", "x = 'a.b.env'\n")
+    _write(tmp_path, "src/pkg/b.py", "x = 'axbyenv'\n")  # would match the regex a.b.env, must NOT
+    got = csac.actual_consumers(tmp_path, ["src"], ["a.b.env"], excluded=set())
+    assert got == {"src/pkg/a.py"}
+
+
+def test_actual_consumers_skips_unreadable_gracefully(tmp_path):
+    _write(tmp_path, "src/pkg/a.py", "cc_oauth_token.env\n")
+    # a directory that looks like a file target is simply walked, not read; ensure no crash
+    (tmp_path / "src" / "pkg" / "__pycache__").mkdir(parents=True)
+    (tmp_path / "src" / "pkg" / "__pycache__" / "junk.pyc").write_bytes(
+        b"\x00\x01cc_oauth_token.env"
+    )
+    got = csac.actual_consumers(tmp_path, ["src"], ["cc_oauth_token.env"], excluded=set())
+    assert "src/pkg/a.py" in got
+
+
+# --- check_consumers (both-direction diff) ---
+
+
+def test_flags_undeclared_direct_consumer_reconstructs_incident(tmp_path):
+    """The exact 2026-08-19 shape: a NEW direct reader (login_health) appears in code
+    but the registry (frozen at the pre-incident reader set) does not list it."""
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "```yaml shared-artifact\nartifact: cc_oauth_token.env\n"
+        "documented_in: scripts/store_cc_token.sh\n"
+        "match_literals: [cc_oauth_token.env, load_cc_oauth_token]\n"
+        "readers:\n  - src/genesis/guardian/diagnosis.py\n"  # pre-incident: only the host consumer
+        "allowlist:\n  - src/genesis/guardian/credential_bridge.py\n```\n",
+    )
+    _write(tmp_path, "src/genesis/guardian/diagnosis.py", "from x import load_cc_oauth_token\n")
+    _write(tmp_path, "src/genesis/guardian/credential_bridge.py", "P = 'cc_oauth_token.env'\n")
+    _write(
+        tmp_path,
+        "scripts/store_cc_token.sh",
+        "F='cc_oauth_token.env'  # authoritative list: docs/architecture/shared-artifacts.md\n",
+    )
+    # the new consumer the header never learned about:
+    _write(
+        tmp_path, "src/genesis/cc/login_health.py", "T = Path('~/.genesis/cc_oauth_token.env')\n"
+    )
+
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 1
+    assert "::error::" in out
+    assert "src/genesis/cc/login_health.py" in out
+
+
+def test_transitive_consumer_via_loader_symbol_is_caught(tmp_path):
+    """A consumer that reaches the file ONLY through the loader function (no filename
+    literal) must still be caught — this is why match_literals carries the loader symbol.
+    Locks the two-literal design: with the filename literal alone this would be missed."""
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "```yaml shared-artifact\nartifact: cc_oauth_token.env\n"
+        "documented_in: scripts/store_cc_token.sh\n"
+        "match_literals: [cc_oauth_token.env, load_cc_oauth_token]\n"
+        "readers:\n  - src/genesis/cc/login_health.py\n"
+        "allowlist:\n  - src/genesis/guardian/credential_bridge.py\n```\n",
+    )
+    _write(tmp_path, "src/genesis/cc/login_health.py", "T = '~/.genesis/cc_oauth_token.env'\n")
+    _write(
+        tmp_path, "src/genesis/guardian/credential_bridge.py", "def load_cc_oauth_token(): ...\n"
+    )
+    _write(
+        tmp_path,
+        "scripts/store_cc_token.sh",
+        "F='cc_oauth_token.env'  # authoritative list: docs/architecture/shared-artifacts.md\n",
+    )
+    # transitive consumer: references ONLY the loader symbol, never the filename
+    _write(
+        tmp_path,
+        "src/genesis/guardian/diagnosis.py",
+        "from genesis.guardian.credential_bridge import load_cc_oauth_token\n",
+    )
+
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 1
+    assert "src/genesis/guardian/diagnosis.py" in out
+
+
+def test_flags_stale_declared_reader(tmp_path):
+    """A declared reader that no longer references the artifact (removed or gone) is an error."""
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "```yaml shared-artifact\nartifact: cc_oauth_token.env\n"
+        "documented_in: scripts/store_cc_token.sh\n"
+        "match_literals: [cc_oauth_token.env]\n"
+        "readers:\n  - src/genesis/cc/login_health.py\n  - src/genesis/gone/removed.py\n"
+        "allowlist: []\n```\n",
+    )
+    _write(tmp_path, "src/genesis/cc/login_health.py", "T = 'cc_oauth_token.env'\n")
+    _write(
+        tmp_path,
+        "scripts/store_cc_token.sh",
+        "F='cc_oauth_token.env'  # authoritative list: docs/architecture/shared-artifacts.md\n",
+    )
+    # src/genesis/gone/removed.py does not exist → stale declared reader
+
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 1
+    assert "src/genesis/gone/removed.py" in out
+
+
+def test_clean_when_declared_matches_actual(tmp_path):
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "```yaml shared-artifact\nartifact: cc_oauth_token.env\n"
+        "documented_in: scripts/store_cc_token.sh\n"
+        "match_literals: [cc_oauth_token.env, load_cc_oauth_token]\n"
+        "readers:\n  - src/genesis/cc/login_health.py\n  - src/genesis/guardian/diagnosis.py\n"
+        "allowlist:\n  - src/genesis/guardian/credential_bridge.py\n```\n",
+    )
+    _write(tmp_path, "src/genesis/cc/login_health.py", "T = 'cc_oauth_token.env'\n")
+    _write(tmp_path, "src/genesis/guardian/diagnosis.py", "from x import load_cc_oauth_token\n")
+    _write(
+        tmp_path,
+        "src/genesis/guardian/credential_bridge.py",
+        "P='cc_oauth_token.env'\ndef load_cc_oauth_token(): ...\n",
+    )  # allowlisted loader home
+    _write(
+        tmp_path,
+        "scripts/store_cc_token.sh",
+        "F='cc_oauth_token.env'  # authoritative list: docs/architecture/shared-artifacts.md\n",
+    )  # documented_in
+
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 0, out
+    assert "CLEAN" in out
+
+
+def test_guard_self_is_excluded(tmp_path):
+    """The guard script itself references the literals in its own docstring examples;
+    as the enforcement mechanism it must never count as a consumer."""
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "```yaml shared-artifact\nartifact: cc_oauth_token.env\n"
+        "documented_in: scripts/store_cc_token.sh\n"
+        "match_literals: [cc_oauth_token.env]\n"
+        "readers:\n  - src/genesis/cc/login_health.py\n"
+        "allowlist: []\n```\n",
+    )
+    _write(tmp_path, "src/genesis/cc/login_health.py", "T = 'cc_oauth_token.env'\n")
+    _write(
+        tmp_path,
+        "scripts/store_cc_token.sh",
+        "F='cc_oauth_token.env'  # authoritative list: docs/architecture/shared-artifacts.md\n",
+    )
+    # the guard's own file, carrying the literal in an example — must be self-excluded
+    _write(
+        tmp_path, "scripts/check_shared_artifact_consumers.py", "EXAMPLE = 'cc_oauth_token.env'\n"
+    )
+
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 0, out
+    assert "check_shared_artifact_consumers.py" not in out
+
+
+def test_flags_documented_in_missing_registry_pointer(tmp_path):
+    """documented_in must route readers to the registry; a prose-only doc that never
+    references it is flagged — otherwise the parallel prose list drifts unchecked."""
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "```yaml shared-artifact\nartifact: cc_oauth_token.env\n"
+        "documented_in: scripts/store_cc_token.sh\n"
+        "match_literals: [cc_oauth_token.env]\n"
+        "readers:\n  - src/genesis/cc/login_health.py\n"
+        "allowlist: []\n```\n",
+    )
+    _write(tmp_path, "src/genesis/cc/login_health.py", "T = 'cc_oauth_token.env'\n")
+    # documented_in exists but never points to the registry
+    _write(tmp_path, "scripts/store_cc_token.sh", "F='cc_oauth_token.env'  # no pointer\n")
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 1
+    assert "authoritative registry" in out
+
+
+def test_flags_documented_in_missing_file(tmp_path):
+    _write(
+        tmp_path,
+        "docs/architecture/shared-artifacts.md",
+        "```yaml shared-artifact\nartifact: cc_oauth_token.env\n"
+        "documented_in: scripts/nonexistent.sh\n"
+        "match_literals: [cc_oauth_token.env]\n"
+        "readers:\n  - src/genesis/cc/login_health.py\n"
+        "allowlist: []\n```\n",
+    )
+    _write(tmp_path, "src/genesis/cc/login_health.py", "T = 'cc_oauth_token.env'\n")
+    rc, out = _run_main_over(tmp_path)
+    assert rc == 1
+    assert "does not exist" in out
+
+
+# --- integration harness: run main() with REGISTRY_PATH + SCAN_ROOTS pointed at tmp_path ---
+
+
+def _run_main_over(base: Path):
+    """Run the real main() against a synthetic tree by chdir'ing into it.
+
+    main() resolves REGISTRY_PATH and SCAN_ROOTS relative to cwd, so chdir is all
+    that's needed — no patching (and no recursion risk from stubbing the scanner).
+    """
+    import contextlib
+    import io
+    import os
+
+    buf = io.StringIO()
+    cwd = os.getcwd()
+    try:
+        os.chdir(base)
+        with contextlib.redirect_stdout(buf):
+            rc = csac.main()
+    finally:
+        os.chdir(cwd)
+    return rc, buf.getvalue()

--- a/tests/test_scripts/test_store_cc_token.py
+++ b/tests/test_scripts/test_store_cc_token.py
@@ -246,6 +246,21 @@ def test_multiline_token_concatenates_and_warns(tmp_path):
     assert "spanned 2 non-empty lines" in r.stderr
 
 
+def test_multiple_complete_tokens_refused(tmp_path):
+    """Two lines that EACH look like a whole token are distinct tokens, not a wrap —
+    refuse rather than concatenate them into a garbage credential."""
+    home = tmp_path / "home"
+    home.mkdir()
+    src = tmp_path / "intoken"
+    src.write_text("sk-ant-oat01-aaaaaa\nsk-ant-oat01-bbbbbb\n")
+    src.chmod(0o600)
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, "", "--file", str(src))
+    assert r.returncode == 1
+    assert "complete tokens" in r.stderr.lower()
+    assert not (home / ".genesis" / "cc_oauth_token.env").exists()
+
+
 def test_help_lists_file_option_without_leaking_code(tmp_path):
     """--help prints only the header block (robust to its length), not script code."""
     env = {"PATH": _BASE_PATH, "HOME": str(tmp_path)}

--- a/tests/test_scripts/test_store_cc_token.py
+++ b/tests/test_scripts/test_store_cc_token.py
@@ -136,3 +136,79 @@ def test_remove_is_clean_when_absent(tmp_path):
     r = _run(env, "", "--remove")
     assert r.returncode == 0, r.stderr
     assert "nothing to remove" in r.stdout.lower()
+
+
+def test_file_intake_stores_token(tmp_path):
+    """--file PATH reads the token from a file (the fix for the broken interactive
+    `claude setup-token | store_cc_token.sh` pipe flow)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    src = tmp_path / "intoken"
+    src.write_text(_TOKEN + "\n")
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, "", "--file", str(src))
+    assert r.returncode == 0, r.stderr
+    token_file = home / ".genesis" / "cc_oauth_token.env"
+    assert token_file.exists()
+    assert oct(token_file.stat().st_mode & 0o777) == "0o600"
+    assert f"CLAUDE_CODE_OAUTH_TOKEN={_TOKEN}" in token_file.read_text()
+    assert _TOKEN not in r.stdout  # the token value never appears in stdout
+
+
+def test_file_intake_missing_file_errors(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, "", "--file", str(tmp_path / "does_not_exist"))
+    assert r.returncode == 1
+    assert "readable regular file" in r.stderr.lower()
+    assert not (home / ".genesis" / "cc_oauth_token.env").exists()
+
+
+def test_file_intake_requires_path(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, "", "--file")
+    assert r.returncode == 1
+    assert "requires a path" in r.stderr.lower()
+    assert not (home / ".genesis" / "cc_oauth_token.env").exists()
+
+
+def test_file_intake_warns_on_group_or_other_readable(tmp_path):
+    """The token sits in the source file as plaintext; warn (non-fatal) if that file
+    is readable by group/other (e.g. created under the default umask 022)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    src = tmp_path / "intoken"
+    src.write_text(_TOKEN + "\n")
+    src.chmod(0o644)
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, "", "--file", str(src))
+    assert r.returncode == 0, r.stderr
+    assert "group/other" in r.stderr.lower()
+    assert (
+        home / ".genesis" / "cc_oauth_token.env"
+    ).exists()  # still stored (warning is non-fatal)
+    assert _TOKEN not in r.stdout
+
+
+def test_file_intake_quiet_on_0600_source(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    src = tmp_path / "intoken"
+    src.write_text(_TOKEN + "\n")
+    src.chmod(0o600)
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, "", "--file", str(src))
+    assert r.returncode == 0, r.stderr
+    assert "group/other" not in r.stderr.lower()
+
+
+def test_help_lists_file_option_without_leaking_code(tmp_path):
+    """--help prints only the header block (robust to its length), not script code."""
+    env = {"PATH": _BASE_PATH, "HOME": str(tmp_path)}
+    r = _run(env, "", "--help")
+    assert r.returncode == 0
+    assert "--file" in r.stdout
+    assert "set -euo pipefail" not in r.stdout

--- a/tests/test_scripts/test_store_cc_token.py
+++ b/tests/test_scripts/test_store_cc_token.py
@@ -205,6 +205,47 @@ def test_file_intake_quiet_on_0600_source(tmp_path):
     assert "group/other" not in r.stderr.lower()
 
 
+def test_file_intake_leading_dash_path(tmp_path):
+    """A source path with a leading dash must not break the permission check
+    (`find` would misparse `-tok` as an expression; `stat --` handles it)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    dashfile = tmp_path / "-tok"
+    dashfile.write_text(_TOKEN + "\n")
+    dashfile.chmod(0o600)
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = subprocess.run(
+        ["/bin/bash", str(_SCRIPT), "--file", "-tok"],
+        env=env,
+        cwd=str(tmp_path),  # so "-tok" is a relative leading-dash path
+        input="",
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, f"stderr={r.stderr!r}"
+    assert (home / ".genesis" / "cc_oauth_token.env").exists()
+    assert "group/other" not in r.stderr.lower()  # 0600 source → no warning, no parse error
+
+
+def test_multiline_token_concatenates_and_warns(tmp_path):
+    """A line-wrapped token (a hard newline mid-token from a wrapped paste) must be
+    rejoined into the full token, not silently truncated to the first line, and the
+    multi-line case must warn."""
+    home = tmp_path / "home"
+    home.mkdir()
+    src = tmp_path / "intoken"
+    src.write_text("sk-ant-oat01-abcdefgh\nijklmnop\n")  # token split across two lines
+    src.chmod(0o600)
+    env = {"PATH": _BASE_PATH, "HOME": str(home)}
+    r = _run(env, "", "--file", str(src))
+    assert r.returncode == 0, r.stderr
+    body = (home / ".genesis" / "cc_oauth_token.env").read_text()
+    assert (
+        "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-abcdefghijklmnop" in body
+    )  # rejoined, not truncated
+    assert "spanned 2 non-empty lines" in r.stderr
+
+
 def test_help_lists_file_option_without_leaking_code(tmp_path):
     """--help prints only the header block (robust to its length), not script code."""
     env = {"PATH": _BASE_PATH, "HOME": str(tmp_path)}


### PR DESCRIPTION
## Problem

Some artifacts (credential files, shared config) are read by several modules, and a doc enumerates the consumers. When a consumer is added and that doc isn't updated, the doc silently lies — and a session that grounds on it can state a false fact about the system. Origin: `store_cc_token.sh`'s header framed the CC OAuth token as host-Guardian-only after `cc/login_health.py` added a container-session consumer (2026-08-19); nothing detected the drift.

## What this does

**Deterministic drift guard** (`scripts/check_shared_artifact_consumers.py` + `docs/architecture/shared-artifacts.md` registry + CI job `shared-artifact-consumer-check`): per registered artifact, diffs the declared `readers` against the files under `src/`+`scripts/` that reference any `match_literals` (fixed substrings — the filename **and** the canonical loader symbol, so direct *and* transitive-via-loader consumers are caught without an LSP). Divergence blocks (exit 1). `documented_in` must route readers to the registry, so the human doc points at the CI-checked source instead of a parallel prose list that drifts.

**Data-repair** (lands with the guard + an incident-reconstruct test): `store_cc_token.sh`'s header now names both fallback consumers (host Guardian + the container's own CC sessions) and defers the authoritative list to the registry; adds `--file PATH` intake (the interactive `setup-token | store_cc_token.sh` pipe is broken), a robust `usage()` (was a hardcoded line range that over-read into code), and a group/other-readable warning on the `--file` source. `docs/reference/recovery-and-portability-workflow.md` updated to match.

## Scope / limits

Guards only enrolled artifacts by consumer set — not a general prose↔code checker (that is unbounded). Accepted limitation: a consumer reaching an artifact only via an alias/wrapper of the loader (containing neither literal) is not detected; enumerate consumers on enrollment.

## Testing

- 14 guard unit tests + 12 token-script tests; full `tests/test_scripts/` = 1285 passed; `ruff` clean; `bash -n` clean.
- Guard runs CLEAN against the tree; a pre-incident registry reproduction catches `src/genesis/cc/login_health.py` — proof it would have caught the original drift.

## Review

Pre-push adversarial, sequential: `genesis-architect` (SHOULD-FIX: `documented_in` was decorative + prose re-enumeration unchecked → fixed by enforcing `documented_in` routes to the registry) then `genesis-security-reviewer` (MEDIUM: `--file` plaintext exposure → fixed with a permission warning + secure-pattern guidance; no CRITICAL/HIGH).

Ledger: cf318653040441e0b5b3b84a88eaed5f

🤖 Generated with [Claude Code](https://claude.com/claude-code)
