### PR TITLE
fix(hooks): block full-suite/whole-directory local pytest runs; fix concurrent-guard quoted-pipe FP

### DIFF
--- a/scripts/hooks/concurrent_test_guard.py
+++ b/scripts/hooks/concurrent_test_guard.py
@@ -21,22 +21,22 @@ invoked with `-m pytest`.
 from __future__ import annotations
 
 import os
-import re
 import sys
 
 # Self-locate so hook_input resolves whether run as a script or imported (tests).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import field, read_payload  # noqa: E402
+from shell_parse import command_runs_pytest  # noqa: E402
 
 
 def _command_runs_pytest(cmd: str) -> bool:
-    """Check if a shell command will invoke pytest (any variant)."""
-    # Match pytest as a standalone command or as a module invocation.
-    # Covers: pytest, python -m pytest, python3 -m pytest, chained commands,
-    # and env-var prefixed invocations (PYTHONPATH=src pytest ...).
-    # Does NOT match: "grep pytest", "cat pytest.ini", etc. — requires word boundary.
-    # The (?:\w+=\S*\s+)* handles env var assignments before the command.
-    return bool(re.search(r"(?:^|&&|;|\|)\s*(?:\w+=\S*\s+)*(?:python3?\s+-m\s+)?pytest\b", cmd))
+    """Whether a shell command will invoke pytest (any variant), quote-aware.
+
+    Delegates to the canonical shell parser so a ``pytest`` mentioned only inside a
+    quoted argument — e.g. ``grep 'a|pytest' f`` — is NOT treated as a run (the old
+    raw-regex scan matched the ``|pytest`` inside such a grep pattern and false-blocked).
+    """
+    return command_runs_pytest(cmd)
 
 
 def _argv_is_pytest(argv: list[str]) -> bool:

--- a/scripts/hooks/full_suite_guard.py
+++ b/scripts/hooks/full_suite_guard.py
@@ -1,105 +1,99 @@
-"""PreToolUse hook: warn when running full pytest suite without a specific path.
+"""PreToolUse hook: BLOCK a full-suite / whole-directory local pytest run.
 
-Running the entire test suite (5900+ tests, ~10 min) during iterative
-development wastes time.  Targeted tests (specific file or directory)
-run in seconds.  This hook detects bare `pytest` or `pytest -v` (no
-test path) and warns the user.
+Running a whole test directory locally on this shared box (let alone ``tests/``)
+duplicates CI's authoritative full run and starves the live Genesis services —
+which repeatedly OOM-killed the run mid-suite. Targeted local testing is a
+SPECIFIC file (or a ``-k``/``-m`` selector); CI runs the full suite on every push.
 
-Allowed without warning:
-  - pytest tests/specific_file.py
-  - pytest tests/some_dir/ -v
-  - ruff check . && pytest -v  (pre-commit pattern — allowed)
-  - Commands with explicit path arguments
+This hook BLOCKS (exit 2) a pytest segment that targets no specific ``.py`` file
+and no ``-k``/``-m`` selector — i.e. bare ``pytest`` / ``pytest -v`` or a bare
+directory like ``tests/`` or ``tests/test_scripts/``. Detection routes through
+``shell_parse.analyze`` (quote-aware), so a ``|pytest`` inside a quoted argument
+is not misread as a run.
 
-Blocked with warning:
-  - pytest -v
-  - python -m pytest -q
-  - pytest --tb=short  (flags only, no path)
+Allowed:
+  - pytest tests/foo/test_bar.py            (a specific file / nodeid)
+  - pytest tests/foo -k test_bar            (a -k/-m selector narrows the run)
+  - pytest tests/ -q  # full-suite-ok       (explicit override)
+Blocked:
+  - pytest -v                               (no path at all)
+  - python -m pytest tests/test_scripts/    (a whole directory)
 """
 
 from __future__ import annotations
 
-import json
 import os
-import re
 import sys
 
-# Self-locate so `from hook_input import …` resolves both when CC runs this as a
-# script and when it is imported as a module for tests (importlib does not add
-# the file's dir to sys.path).
+# Self-locate so the sibling imports resolve whether CC runs this as a script or
+# it is imported as a module for tests.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import field, read_payload  # noqa: E402
-
-# Flags that pytest accepts (non-exhaustive but covers common ones).
-# Used to distinguish "pytest -v" (no path) from "pytest tests/foo.py -v".
-_PYTEST_FLAGS = re.compile(
-    r"^-[a-zA-Z]"  # short flags: -v, -x, -q, -s, etc.
-    r"|^--[a-z]"  # long flags: --verbose, --tb=short, etc.
-    r"|^[0-9]"  # bare numbers (unlikely but safe to skip)
+from shell_parse import (  # noqa: E402
+    Segment,
+    analyze,
+    has_trailing_override,
+    is_pytest_invocation,
 )
 
+_OVERRIDE = "full-suite-ok"
 
-def _is_full_suite(cmd: str) -> bool:
-    """Return True if cmd runs pytest without a specific test path."""
-    # Split on && and ; to handle chained commands
-    parts = re.split(r"&&|;", cmd)
-    for part in parts:
-        part = part.strip()
-        # Find the pytest invocation
-        match = re.search(
-            r"(?:\w+=\S*\s+)*(?:python3?\s+-m\s+)?pytest\b(.*)",
-            part,
-        )
-        if not match:
-            continue
+# pytest flags that consume the FOLLOWING token as their value (so that value is
+# not a positional path). Non-exhaustive but covers the common ones; an unlisted
+# value-flag only risks fail-OPEN (not blocking), never a wrong block.
+_VALUE_FLAGS = {
+    "-p",
+    "--tb",
+    "--timeout",
+    "--rootdir",
+    "-c",
+    "-W",
+    "--override-ini",
+    "-o",
+    "--deselect",
+    "--ignore",
+    "--ignore-glob",
+    "--maxfail",
+    "-n",
+}
 
-        args_str = match.group(1).strip()
-        if not args_str:
-            return True  # bare "pytest" with no args
 
-        # Split remaining args and check if any is a path (not a flag) OR a
-        # -k/-m selector with a value (a targeted subset, NOT the full suite).
-        args = args_str.split()
-        has_path = False
-        has_selector = False
-        i = 0
-        while i < len(args):
-            arg = args[i]
-            if arg in (">", "2>&1", "|"):
-                break  # redirection/pipe — stop parsing
-            if arg.startswith("-"):
-                # A -k/-m selector (separate value or =form) narrows the run to
-                # a named subset — treating it as "full suite" was a cosmetic FP.
-                _sep_val = arg in ("-k", "-m") and i + 1 < len(args)
-                # `--markers=…` is not a real pytest invocation (bare --markers
-                # just lists markers), so it is not a selector; --keyword is the
-                # long form of -k and stays.
-                _eq_form = arg.startswith(("-k", "-m", "--keyword")) and "=" in arg
-                _glued = arg.startswith(("-k", "-m")) and len(arg) > 2 and "=" not in arg
-                if _sep_val or _eq_form or _glued:
-                    has_selector = True
-                # Flag — skip it (and its value if it takes one)
-                if arg in (
-                    "-k",
-                    "-m",
-                    "--tb",
-                    "-p",
-                    "--timeout",
-                    "--rootdir",
-                    "-c",
-                    "--co",
-                    "-W",
-                    "--override-ini",
-                ):
-                    i += 1  # skip the next arg too (flag value)
-            elif "/" in arg or arg.endswith(".py"):
-                has_path = True
-                break
+def _pytest_args(seg: Segment) -> list[str]:
+    """Positional+flag args AFTER the pytest command word (entrypoint stripped)."""
+    argv = seg.argv
+    if seg.exe == "pytest":
+        return argv[1:]  # drop argv[0] entrypoint (may be a /path/to/pytest)
+    for i, tok in enumerate(argv):
+        if tok == "-m" and i + 1 < len(argv) and argv[i + 1] == "pytest":
+            return argv[i + 2 :]
+    return argv  # unreachable when is_pytest_invocation(seg) is True
+
+
+def _targets_specific_test(args: list[str]) -> bool:
+    """True if args name a specific ``.py`` file/nodeid OR carry a -k/-m selector.
+
+    False for a bare run or directory-only args — the case this hook blocks.
+    """
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg.startswith("-"):
+            # a -k/-m selector (separate value, =form, or glued) narrows the run
+            if arg in ("-k", "-m") or arg.startswith(("-k", "-m", "--keyword")):
+                return True
+            if arg == "--pyargs":  # --pyargs pkg.mod → import-path targeting = a targeted run
+                return True
+            if arg in _VALUE_FLAGS:
+                i += 2  # skip the flag AND its value
+                continue
             i += 1
-
-        if not has_path and not has_selector:
+            continue
+        # A real .py file or nodeid — NOT a mere substring, so a directory like
+        # tests/.pytest_cache/ or foo.python_stuff/ does not defeat the block.
+        if arg.endswith(".py") or ".py::" in arg:
             return True
-
+        # a bare directory / non-file positional path → not targeted; keep scanning
+        i += 1
     return False
 
 
@@ -107,27 +101,30 @@ def main() -> None:
     cmd = field(read_payload(), "command")
     if not cmd:
         return
+    try:
+        segments = analyze(cmd)
+    except Exception:
+        return  # parse failure → fail open; never wrongly block a legit command
 
-    # Only care about commands that run pytest
-    if not re.search(r"(?:^|&&|;|\|)\s*(?:\w+=\S*\s+)*(?:python3?\s+-m\s+)?pytest\b", cmd):
+    pytest_segs = [s for s in segments if is_pytest_invocation(s)]
+    if not pytest_segs:
+        return
+    if any(has_trailing_override(s.raw, _OVERRIDE) for s in segments):
+        return  # explicit opt-in to a local full/dir run
+
+    # Block if ANY pytest segment is a non-targeted (bare or directory) run.
+    if all(_targets_specific_test(_pytest_args(s)) for s in pytest_segs):
         return
 
-    if _is_full_suite(cmd):
-        msg = json.dumps(
-            {
-                "hookSpecificOutput": {
-                    "hookEventName": "PreToolUse",
-                    "additionalContext": (
-                        "WARNING: You are about to run the FULL test suite (5900+ tests, ~10 min). "
-                        "During development, run only the specific test files for your changes. "
-                        "The full suite should run ONCE at pre-commit time, not during iteration. "
-                        "If this IS the pre-commit run, proceed. Otherwise, target your tests: "
-                        "pytest tests/path/to/specific_test.py -v"
-                    ),
-                }
-            }
-        )
-        print(msg)
+    print(
+        "BLOCKED: full-suite / whole-directory pytest run. On this shared box the "
+        "full suite duplicates CI and starves the live services (it was OOM-killed "
+        "mid-run). Target a specific file (pytest tests/path/test_x.py) or a -k/-m "
+        "selector, and let CI run the full suite on push. If you truly need the "
+        f"local full run, append '# {_OVERRIDE}' to the command.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/full_suite_guard.py
+++ b/scripts/hooks/full_suite_guard.py
@@ -70,31 +70,36 @@ def _pytest_args(seg: Segment) -> list[str]:
 
 
 def _targets_specific_test(args: list[str]) -> bool:
-    """True if args name a specific ``.py`` file/nodeid OR carry a -k/-m selector.
+    """True if this pytest arg list is a TARGETED run (allow), False for a bare or
+    directory-touching run (block).
 
-    False for a bare run or directory-only args — the case this hook blocks.
+    Targeted = a -k/-m/--pyargs selector, OR at least one specific .py file/nodeid
+    and NO bare-directory positional. A file mixed with a directory
+    (``pytest tests/foo.py tests/``) still runs the whole directory, so it blocks.
     """
+    has_selector = False
+    has_file = False
+    has_dir = False
     i = 0
     while i < len(args):
         arg = args[i]
         if arg.startswith("-"):
             # a -k/-m selector (separate value, =form, or glued) narrows the run
-            if arg in ("-k", "-m") or arg.startswith(("-k", "-m", "--keyword")):
-                return True
-            if arg == "--pyargs":  # --pyargs pkg.mod → import-path targeting = a targeted run
-                return True
-            if arg in _VALUE_FLAGS:
+            if arg in ("-k", "-m") or arg.startswith(("-k", "-m", "--keyword")) or arg == "--pyargs":
+                has_selector = True
+            elif arg in _VALUE_FLAGS:
                 i += 2  # skip the flag AND its value
                 continue
             i += 1
             continue
         # A real .py file or nodeid — NOT a mere substring, so a directory like
-        # tests/.pytest_cache/ or foo.python_stuff/ does not defeat the block.
+        # tests/.pytest_cache/ or foo.python_stuff/ counts as a directory, not a file.
         if arg.endswith(".py") or ".py::" in arg:
-            return True
-        # a bare directory / non-file positional path → not targeted; keep scanning
+            has_file = True
+        else:
+            has_dir = True  # a bare directory / non-file positional path
         i += 1
-    return False
+    return has_selector or (has_file and not has_dir)
 
 
 def main() -> None:

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -364,9 +364,21 @@ def is_pytest_invocation(seg: Segment) -> bool:
         return True
     if seg.exe.startswith("python"):
         argv = seg.argv
-        for i, tok in enumerate(argv):
-            if tok == "-m" and i + 1 < len(argv) and argv[i + 1] == "pytest":
-                return True
+        i = 1
+        while i < len(argv):
+            tok = argv[i]
+            if tok == "-m":  # `python -m pytest …`
+                return i + 1 < len(argv) and argv[i + 1] == "pytest"
+            if tok in ("-c", "-W", "-X"):  # flags that consume the next token
+                i += 2
+                continue
+            if tok.startswith("-"):
+                i += 1
+                continue
+            # First non-flag = the program python runs. Only a pytest console-script
+            # entrypoint (a /path/.../pytest) is a pytest run; `python script.py …`
+            # is NOT, even if `-m pytest` appears later as the SCRIPT's own args.
+            return "/" in tok and _basename(tok) == "pytest"
     return False
 
 

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -352,6 +352,32 @@ def analyze(command: str) -> list[Segment]:
     return out
 
 
+def is_pytest_invocation(seg: Segment) -> bool:
+    """Whether a parsed Segment IS a pytest run (not a mere textual mention).
+
+    True for the ``pytest`` entrypoint (``pytest …``, ``/venv/bin/pytest …``) or a
+    python interpreter invoked with ``-m pytest``. Because ``analyze`` splits
+    quote-aware, a ``|pytest`` inside a quoted argument — e.g. ``grep 'a|pytest' f``
+    — is NOT a pytest segment here, unlike a raw-regex scan of the command string.
+    """
+    if seg.exe == "pytest":
+        return True
+    if seg.exe.startswith("python"):
+        argv = seg.argv
+        for i, tok in enumerate(argv):
+            if tok == "-m" and i + 1 < len(argv) and argv[i + 1] == "pytest":
+                return True
+    return False
+
+
+def command_runs_pytest(command: str) -> bool:
+    """Whether any executed segment of ``command`` is a pytest run (quote-aware)."""
+    try:
+        return any(is_pytest_invocation(s) for s in analyze(command))
+    except Exception:
+        return False  # parse failure → fail open (a convenience check, never a gate)
+
+
 def _substitutions(text: str) -> list[str]:
     """Command-substitution bodies — ``$(…)`` and ``` `…` ``` — which also run.
 

--- a/tests/test_hooks/test_concurrent_test_guard.py
+++ b/tests/test_hooks/test_concurrent_test_guard.py
@@ -89,7 +89,8 @@ class TestArgvClassifier:
 
 
 class TestCommandMatcher:
-    """The Bash-command matcher is unchanged — spot-check its boundaries."""
+    """The Bash-command matcher now routes through shell_parse.command_runs_pytest
+    (quote-aware) — spot-check its boundaries, incl. the quoted-pipe false-positive."""
 
     def test_plain_pytest(self):
         assert _command_runs_pytest("pytest tests/foo.py")
@@ -108,6 +109,12 @@ class TestCommandMatcher:
 
     def test_cat_ini_not_matched(self):
         assert not _command_runs_pytest("cat pytest.ini")
+
+    def test_pytest_inside_quoted_grep_pattern_not_matched(self):
+        # The bug this fixes: a `|pytest` inside a quoted grep/regex pattern used to
+        # match the raw-regex scan (| read as a shell pipe) and false-block.
+        assert not _command_runs_pytest('grep -rniE "full_suite|pytest|x" file')
+        assert not _command_runs_pytest("rg -n 'a|pytest|b' scripts/")
 
 
 def _run_guard(command: str) -> subprocess.CompletedProcess:

--- a/tests/test_hooks/test_deliverable_and_fullsuite.py
+++ b/tests/test_hooks/test_deliverable_and_fullsuite.py
@@ -1,9 +1,8 @@
-"""Tests for the two small C-item guard fixes (PR-Guards):
+"""Tests for deliverable_gate_guard: a marker stuck at rendered_unverified past
+24h is treated as abandoned (allow with a warning) instead of wedging Stop forever.
 
-* deliverable_gate_guard: a marker stuck at rendered_unverified past 24h is
-  treated as abandoned (allow with a warning) instead of wedging Stop forever.
-* full_suite_guard: a -k/-m selector run is a targeted subset, not the full
-  suite (cosmetic false-positive fix).
+(full_suite_guard's selector/targeting tests moved to test_full_suite_guard.py when
+that hook was rewritten to block whole-directory runs.)
 """
 
 from __future__ import annotations
@@ -26,7 +25,6 @@ def _load(name: str):
 
 
 _dgg = _load("deliverable_gate_guard")
-_fsg = _load("full_suite_guard")
 
 
 # --- deliverable_gate_guard staleness escape ---
@@ -66,47 +64,3 @@ class TestDeliverableStaleness:
     def test_other_session_marker_never_blocks(self, tmp_path):
         _write_marker(tmp_path, "sess1", "rendered_unverified", age_seconds=60)
         assert _dgg._decide({"session_id": "sess2"}, tmp_path) == 0
-
-
-# --- full_suite_guard -k/-m selector ---
-
-
-class TestFullSuiteSelector:
-    def test_bare_pytest_is_full_suite(self):
-        assert _fsg._is_full_suite("pytest") is True
-
-    def test_pytest_v_is_full_suite(self):
-        assert _fsg._is_full_suite("pytest -v") is True
-
-    def test_k_selector_not_full_suite(self):
-        assert _fsg._is_full_suite("pytest -k test_foo") is False
-
-    def test_k_selector_quoted_expr(self):
-        assert _fsg._is_full_suite('pytest -k "test_foo or test_bar"') is False
-
-    def test_m_selector_not_full_suite(self):
-        assert _fsg._is_full_suite("pytest -m slow") is False
-
-    def test_k_equals_form(self):
-        assert _fsg._is_full_suite("pytest -k=test_foo") is False
-
-    def test_keyword_long_form(self):
-        assert _fsg._is_full_suite("pytest --keyword=test_foo") is False
-
-    def test_path_still_recognized(self):
-        assert _fsg._is_full_suite("pytest tests/test_x.py") is False
-
-    def test_glued_k_selector(self):
-        """Glued short form `-kfoo` is a selector, not the full suite (NOTE 4)."""
-        assert _fsg._is_full_suite("pytest -kfoo") is False
-
-    def test_glued_m_selector(self):
-        assert _fsg._is_full_suite("pytest -mslow") is False
-
-    def test_k_without_value_is_full_suite(self):
-        """A dangling -k with no value is not a real selection."""
-        assert _fsg._is_full_suite("pytest -k") is True
-
-    def test_tb_flag_alone_is_full_suite(self):
-        """--tb=short with no path/selector is still the full suite."""
-        assert _fsg._is_full_suite("pytest --tb=short") is True

--- a/tests/test_hooks/test_full_suite_guard.py
+++ b/tests/test_hooks/test_full_suite_guard.py
@@ -1,0 +1,136 @@
+"""Tests for scripts/hooks/full_suite_guard.py — block full-suite / whole-directory
+local pytest runs (targeted = a specific file or a -k/-m selector).
+
+The prior guard only warned on path-LESS pytest and treated any arg containing '/'
+as targeted, so a whole-directory run like `pytest tests/test_scripts/` (1285 tests)
+sailed through silently. This guard blocks bare/dir runs (exit 2) with an explicit
+`# full-suite-ok` override.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_WORKTREE = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _WORKTREE / "scripts" / "hooks" / "full_suite_guard.py"
+_PYTHON = sys.executable
+
+_spec = importlib.util.spec_from_file_location("full_suite_guard", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+class TestTargetsSpecificTest:
+    """Pure-function matrix: does an arg list target a specific test (allow) or is
+    it a bare/directory run (block)?"""
+
+    def test_specific_file(self):
+        assert _mod._targets_specific_test(["tests/foo/test_bar.py"])
+
+    def test_nodeid(self):
+        assert _mod._targets_specific_test(["tests/foo/test_bar.py::test_x"])
+
+    def test_k_selector_separate(self):
+        assert _mod._targets_specific_test(["tests/", "-k", "test_bar"])
+
+    def test_k_selector_glued(self):
+        assert _mod._targets_specific_test(["-ktest_bar"])
+
+    def test_m_selector(self):
+        assert _mod._targets_specific_test(["-m", "slow"])
+
+    def test_bare_no_args(self):
+        assert not _mod._targets_specific_test([])
+
+    def test_flags_only(self):
+        assert not _mod._targets_specific_test(["-v", "-q"])
+
+    def test_directory_only(self):
+        assert not _mod._targets_specific_test(["tests/test_scripts/"])
+
+    def test_value_flag_then_dir(self):
+        # -p consumes 'no:cacheprovider'; the remaining positional is a directory
+        assert not _mod._targets_specific_test(
+            ["tests/test_scripts/", "-q", "-p", "no:cacheprovider"]
+        )
+
+    def test_value_flag_then_file(self):
+        assert _mod._targets_specific_test(["-p", "no:cacheprovider", "tests/foo.py"])
+
+    def test_dir_with_dotpy_substring_not_targeted(self):
+        # a directory that merely CONTAINS '.py' must not read as a file target
+        assert not _mod._targets_specific_test(["tests/.pytest_cache/"])
+        assert not _mod._targets_specific_test(["tests/foo.python_stuff/"])
+
+    def test_pyargs_is_targeted(self):
+        assert _mod._targets_specific_test(["--pyargs", "genesis.tests.test_mod"])
+
+
+def _run_guard(command: str) -> subprocess.CompletedProcess:
+    payload = json.dumps({"tool_input": {"command": command}, "tool_name": "Bash"})
+    return subprocess.run(
+        [_PYTHON, str(_SCRIPT)], input=payload, capture_output=True, text=True, timeout=15
+    )
+
+
+class TestEndToEnd:
+    # --- blocked: bare / whole-directory runs ---
+    def test_bare_pytest_blocks(self):
+        r = _run_guard("pytest -v")
+        assert r.returncode == 2
+        assert "BLOCKED" in r.stderr
+
+    def test_whole_suite_root_blocks(self):
+        assert _run_guard("pytest tests/").returncode == 2
+
+    def test_directory_run_blocks(self):
+        # the exact shape of the mistake this hook exists to prevent
+        assert (
+            _run_guard("python -m pytest tests/test_scripts/ -q -p no:cacheprovider").returncode
+            == 2
+        )
+
+    def test_chained_full_suite_blocks(self):
+        assert _run_guard("ruff check . && pytest -q").returncode == 2
+
+    # --- allowed: targeted runs ---
+    def test_specific_file_allowed(self):
+        r = _run_guard("pytest tests/test_hooks/test_full_suite_guard.py")
+        assert r.returncode == 0, r.stderr
+
+    def test_nodeid_allowed(self):
+        assert _run_guard("pytest tests/foo/test_bar.py::test_x -q").returncode == 0
+
+    def test_selector_allowed(self):
+        assert _run_guard("pytest tests/ -k test_bar").returncode == 0
+
+    def test_file_after_value_flag_allowed(self):
+        assert _run_guard("python -m pytest -p no:cacheprovider tests/foo.py").returncode == 0
+
+    # --- override + non-pytest ---
+    def test_override_allows_dir_run(self):
+        r = _run_guard("pytest tests/test_scripts/ -q  # full-suite-ok")
+        assert r.returncode == 0, r.stderr
+
+    def test_non_pytest_command_ignored(self):
+        r = _run_guard("git status")
+        assert r.returncode == 0
+        assert r.stderr == ""
+
+    def test_pytest_mention_in_quoted_grep_ignored(self):
+        # must not fire on a grep whose pattern merely mentions pytest
+        r = _run_guard("grep -rniE 'a|pytest|b' scripts/")
+        assert r.returncode == 0
+
+    def test_dotpy_substring_dir_blocks(self):
+        # a directory containing '.py' as a substring must NOT bypass the block
+        assert _run_guard("pytest tests/.pytest_cache/").returncode == 2
+        assert _run_guard("python -m pytest tests/foo.python_stuff/").returncode == 2
+
+    def test_pyargs_run_allowed(self):
+        r = _run_guard("pytest --pyargs genesis.tests.test_mod")
+        assert r.returncode == 0, r.stderr

--- a/tests/test_hooks/test_full_suite_guard.py
+++ b/tests/test_hooks/test_full_suite_guard.py
@@ -69,6 +69,15 @@ class TestTargetsSpecificTest:
     def test_pyargs_is_targeted(self):
         assert _mod._targets_specific_test(["--pyargs", "genesis.tests.test_mod"])
 
+    def test_file_mixed_with_dir_not_targeted(self):
+        # a specific file AND a bare directory still runs the whole directory → block
+        assert not _mod._targets_specific_test(["tests/foo.py", "tests/"])
+        assert not _mod._targets_specific_test(["tests/", "tests/foo.py"])
+
+    def test_selector_with_dir_still_targeted(self):
+        # a -k/-m selector narrows the run even when a directory is present
+        assert _mod._targets_specific_test(["tests/", "-k", "test_bar"])
+
 
 def _run_guard(command: str) -> subprocess.CompletedProcess:
     payload = json.dumps({"tool_input": {"command": command}, "tool_name": "Bash"})
@@ -134,3 +143,7 @@ class TestEndToEnd:
     def test_pyargs_run_allowed(self):
         r = _run_guard("pytest --pyargs genesis.tests.test_mod")
         assert r.returncode == 0, r.stderr
+
+    def test_file_plus_dir_blocks(self):
+        # a file mixed with a whole directory runs the dir → must block
+        assert _run_guard("pytest tests/foo/test_bar.py tests/").returncode == 2

--- a/tests/test_hooks/test_shell_parse.py
+++ b/tests/test_hooks/test_shell_parse.py
@@ -25,6 +25,38 @@ def _commit_nv(cmd: str) -> bool:
     return any(sp.commit_skips_hooks(s.argv) for s in sp.analyze(cmd))
 
 
+# ── pytest-invocation detection (shared by the test guards) ─────────────
+
+
+class TestPytestDetection:
+    def test_bare_pytest(self):
+        assert sp.command_runs_pytest("pytest tests/")
+
+    def test_python_m_pytest(self):
+        assert sp.command_runs_pytest("python -m pytest tests/x.py")
+
+    def test_env_prefixed(self):
+        assert sp.command_runs_pytest("PYTHONPATH=src pytest tests/")
+
+    def test_chained(self):
+        assert sp.command_runs_pytest("ruff check . && pytest -q")
+
+    def test_venv_path_entrypoint(self):
+        seg = sp.analyze("/home/u/genesis/.venv/bin/pytest -q")[0]
+        assert sp.is_pytest_invocation(seg)
+
+    def test_grep_word_not_matched(self):
+        assert not sp.command_runs_pytest("grep pytest scripts/foo.py")
+
+    def test_pytest_in_quoted_pipe_pattern_not_matched(self):
+        # the quoted-| false positive: `|pytest` inside a grep pattern is not a run
+        assert not sp.command_runs_pytest('grep -rniE "full_suite|pytest|x" f')
+        assert not sp.command_runs_pytest("rg -n 'a|pytest|b' scripts/")
+
+    def test_pytest_cov_module_not_matched(self):
+        assert not sp.command_runs_pytest("python -m pytest_cov")
+
+
 # ── git subcommand resolution through wrappers ──────────────────────────
 
 

--- a/tests/test_hooks/test_shell_parse.py
+++ b/tests/test_hooks/test_shell_parse.py
@@ -56,6 +56,18 @@ class TestPytestDetection:
     def test_pytest_cov_module_not_matched(self):
         assert not sp.command_runs_pytest("python -m pytest_cov")
 
+    def test_python_script_with_m_pytest_args_not_matched(self):
+        # `-m pytest` here are the SCRIPT's own args, not python's — not a pytest run
+        assert not sp.command_runs_pytest("python script.py -m pytest")
+
+    def test_python_running_pytest_entrypoint_matched(self):
+        # python executing the pytest console-script (a /path/.../pytest) IS a run
+        seg = sp.analyze("python /venv/bin/pytest -q")[0]
+        assert sp.is_pytest_invocation(seg)
+
+    def test_python_flags_before_m_pytest_matched(self):
+        assert sp.command_runs_pytest("python -X faulthandler -m pytest tests/x.py")
+
 
 # ── git subcommand resolution through wrappers ──────────────────────────
 

--- a/tests/test_hooks/test_shell_parse.py
+++ b/tests/test_hooks/test_shell_parse.py
@@ -42,7 +42,7 @@ class TestPytestDetection:
         assert sp.command_runs_pytest("ruff check . && pytest -q")
 
     def test_venv_path_entrypoint(self):
-        seg = sp.analyze("/home/u/genesis/.venv/bin/pytest -q")[0]
+        seg = sp.analyze("/venv/bin/pytest -q")[0]
         assert sp.is_pytest_invocation(seg)
 
     def test_grep_word_not_matched(self):


### PR DESCRIPTION
## Problem

`full_suite_guard.py` (a CC PreToolUse hook) exists to discourage running the full test suite locally — CI runs it authoritatively on every push, and a local full run duplicates that work and starves the shared box (it OOM-killed the run mid-suite). But the guard only warned on path-LESS `pytest` and treated any arg containing `/` as "targeted", so a whole-directory run like `pytest tests/test_scripts/` (1285 tests) sailed through silently.

Separately, `concurrent_test_guard.py` matched `pytest` via a raw regex that read a `|` inside a quoted grep pattern as a shell pipe, false-blocking commands like `grep -E 'a|pytest|b' file`.

## What this does

- **full_suite_guard**: warn → **BLOCK** (exit 2) on a pytest run that targets no specific `.py` file and no `-k`/`-m`/`--pyargs` selector (bare `pytest`, `pytest -v`, or a bare directory). Explicit `# full-suite-ok` override for the rare local full run. Detection routes through the quote-aware `shell_parse.analyze`.
- **concurrent_test_guard**: `_command_runs_pytest` delegates to `shell_parse.command_runs_pytest`, fixing the quoted-`|pytest` false-block.
- **shell_parse**: two additive helpers (`is_pytest_invocation`, `command_runs_pytest`); no existing symbol changed.
- Adds the missing `test_full_suite_guard.py`.

## Testing

- 101 hook tests green (new `test_full_suite_guard.py` covers block/allow/override + the quoted-grep case); 330 `shell_parse`-consumer tests green (`git_push_guard` etc. — the additive change is non-regressive); ruff clean.

## Review

Pre-push `genesis-architect` found and I fixed a BLOCKER (a sibling test still calling the removed `_is_full_suite` → 12 CI failures), a `.py`-substring directory bypass, and a `--pyargs` false-block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
