### PR TITLE
fix(hooks): paginate the review-body finding scan (close a live merge fail-open)

### DIFF
--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -842,6 +842,13 @@ _INLINE_REVIEW_BOTS = {
     "chatgpt-codex-connector[bot]",
     "github-advanced-security[bot]",
 }
+# A reply "engages" (silences) an inline P1 finding ONLY when authored by someone with
+# repository authority — otherwise any GitHub account (a throwaway, or the PR author on
+# their own PR) could post a one-word reply and clear a real P1 (PR #1434 security
+# review, LOW-a). GitHub's author_association on a PR review comment; these three denote
+# push/triage authority. A reply from NONE / FIRST_TIME_CONTRIBUTOR / CONTRIBUTOR does
+# NOT count as acknowledgement.
+_MAINTAINER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 # Badge/markup prefix stripped when rendering a finding's title line.
 _INLINE_MARKUP_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)|</?sub>|[*]{1,2}")
 
@@ -888,24 +895,146 @@ def _is_sqlite_write(cmd: str) -> bool:
 
 def _inline_title(body: str) -> str:
     """First readable line of an inline finding body."""
-    first = _INLINE_MARKUP_RE.sub("", body).strip().splitlines()
+    # split("\n") not splitlines(): a NEL (U+0085) inside the body must not shift
+    # which line is shown as the title (consistent with the JSONL parser).
+    first = _INLINE_MARKUP_RE.sub("", body).strip().split("\n")
     return (first[0].strip() if first else "")[:120]
 
 
-def _scan_unreadable(strict: bool, what: str) -> tuple[bool, str]:
+def _scan_unreadable(what: str) -> tuple[bool, str]:
     """Return value for a finding scan that could NOT be read — a gh error,
     timeout, or malformed JSON — as distinct from a scan that ran and found
     nothing (an empty result / Codex quota, which stays clean either way).
 
-    Enforcement (``strict=False``, the default) fails OPEN: a transient gh error
-    must not wedge merges, and the freshness gate already requires a review to
-    EXIST at the head. Report mode (``strict=True``) fails CLOSED so the canonical
-    ``--check-pr`` report never presents an UNREADABLE scan as "ok" / emits a
-    false "all gates pass" (Codex P2, PR #1366).
+    ALWAYS fails CLOSED (blocks): an unreadable or incomplete scan is treated as
+    "not clean, retry", NEVER as a silent pass. This closes the CRITICAL fail-open
+    (PR #1434 security review): a comment-flood, a budget-starved scan, or GitHub
+    secondary rate-limiting on a burst of sequential gh calls could terminate the
+    scan early (page cap / drained merge deadline / API error). The old fail-OPEN
+    merge path then returned "clean" and the merge sailed through with an UNSEEN
+    newest finding. The freshness gate (``_check_codex_reviewed_head``) reads a
+    DIFFERENT surface (the Reviews API) and does not catch it. Fail-closed makes the
+    completeness of the read irrelevant to safety — an unreadable scan blocks, and
+    ``# review-override`` remains the conscious escape hatch for a transient gh error.
     """
-    if strict:
-        return True, f"could not read {what} — review status UNREADABLE (retry), not clean."
-    return False, ""
+    return True, f"could not read {what} — review status UNREADABLE (retry), not clean."
+
+
+# Page size for the comment-fetch loop. MUST be the pagination signal's basis: a
+# page returning fewer than this many rows is the last page. It must exceed any
+# test's fixed comment count so a mocked `return_value` (same rows every call)
+# terminates after one page instead of looping forever.
+_COMMENTS_PER_PAGE = 100
+# Backstop against an unbounded loop (a real PR never approaches this; a mocked
+# return_value of exactly _COMMENTS_PER_PAGE rows would otherwise never terminate).
+_MAX_COMMENT_PAGES = 100
+
+
+def _fetch_comments_paged(
+    endpoint: str,
+    pr_num: str,
+    repo: str | None,
+    jq: str,
+    extra_params: list[str] | None = None,
+) -> tuple[list[dict] | None, bool]:
+    """Fetch ALL pages of a PR comments endpoint as parsed JSON objects.
+
+    Pages through ``gh api repos/<repo>/<endpoint> -X GET -f per_page=100 -f page=N
+    --jq <jq>`` (query params via ``-f``; the endpoint token keeps its ``…/comments``
+    suffix so the char-router's ``endswith("/comments")`` still matches). ``gh --jq``
+    emits one compact JSON object per line — JSONL — across the page.
+
+    ``extra_params`` — additional ``-f key=value`` query args (already tokenized as a
+    flat list) merged into every page request. Used to fetch newest-first
+    (``sort=created direction=desc``) on the ``pulls/*/comments`` endpoint, which honors
+    it, so a partially-read scan sees the most recent findings first. The
+    ``issues/*/comments`` endpoint IGNORES sort/direction, so this stays opt-in per
+    caller rather than a blanket default.
+
+    Returns ``(objects, complete)``:
+      - ``(None, False)``  — the FIRST page could not be read (gh error/exception):
+        the caller has NO data → treat as UNREADABLE.
+      - ``(accumulated, False)`` — a LATER page failed: the caller keeps what it saw
+        (so a blocking finding on an earlier page still stands) but knows the read is
+        INCOMPLETE and cannot confirm the ABSENCE of a newer finding.
+      - ``(accumulated, True)`` — every page read (a page with < per_page rows, or an
+        empty page, is the last).
+
+    NEL-safe: splits on ``"\\n"`` only — NOT ``str.splitlines()``, which also breaks on
+    U+0085 (NEL) that ``gh --jq`` emits literally inside a JSON string. One NEL-bearing
+    comment would otherwise fragment the JSONL, fail ``json.loads``, and be SILENTLY
+    dropped — a real finding missing from an otherwise-complete read, which fail-closed
+    cannot catch (the read looks complete). Non-dict lines are dropped (Codex P2 — a
+    bare string/number line never masquerades as a comment).
+
+    Each page uses ``_gh_timeout(8)`` AND the loop checks the shared merge deadline
+    BETWEEN pages, so it self-bounds under the wall-clock in BOTH failure modes: a
+    slow/hung gh call fails fast at the floored per-call timeout, AND a flood of pages
+    that each SUCCEED fast cannot keep spawning calls past the budget. Either way the
+    partial read is returned as incomplete → the caller fails CLOSED.
+    """
+    acc: list[dict] = []
+    page = 1
+    while page <= _MAX_COMMENT_PAGES:
+        # Respect the shared merge deadline BETWEEN pages, not only via each call's
+        # timeout (HIGH, PR #1434 security review). A comment-flood — thousands of
+        # pre-seeded comments, and reads are NOT write-rate-limited — makes every page
+        # SUCCEED fast; the per-call timeout alone never stops the loop, so it would keep
+        # spawning gh calls past the 45s budget and blow the hook's ~60s SIGKILL ceiling.
+        # A hook killed mid-gate "fails toward tool runs" (see main's budget note) — an
+        # EXTERNAL fail-open the in-function fail-closed logic can't see. Out of budget →
+        # return what we have as INCOMPLETE (page 1 → None) → the caller blocks.
+        if _merge_deadline is not None and time.monotonic() >= _merge_deadline:
+            return (None if page == 1 else acc), False
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo or ':owner/:repo'}/{endpoint}",
+                    "-X",
+                    "GET",
+                    "-f",
+                    f"per_page={_COMMENTS_PER_PAGE}",
+                    "-f",
+                    f"page={page}",
+                    *(extra_params or []),
+                    "--jq",
+                    jq,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=_gh_timeout(8),  # merge-path budget (see main): self-bounding
+            )
+        except Exception:
+            return (None if page == 1 else acc), False  # page-1 fail = no data
+        if result.returncode != 0:
+            return (None if page == 1 else acc), False
+        # NEL-safe split; count RAW non-empty lines for the pagination signal (a
+        # dropped malformed line must not prematurely signal "last page").
+        lines = [ln for ln in result.stdout.split("\n") if ln.strip()]
+        parsed_ok = 0
+        for ln in lines:
+            try:
+                obj = json.loads(ln)
+            except Exception:
+                continue
+            parsed_ok += 1
+            if isinstance(obj, dict):
+                acc.append(obj)
+        # A NON-EMPTY page whose every line failed to parse as JSON is a MALFORMED
+        # response (not a genuine "zero comments" page) — treat as unreadable rather than
+        # letting a garbage body masquerade as a clean short page that ends the scan (LOW,
+        # PR #1434 defense-in-depth: preserves the pre-diff whole-body JSONDecodeError guard
+        # for the per-line model). returncode==0 with an unparseable body is unusual (gh
+        # --jq normally exits non-zero), so this is belt-and-suspenders.
+        if lines and parsed_ok == 0:
+            return (None if page == 1 else acc), False
+        if len(lines) < _COMMENTS_PER_PAGE:
+            return acc, True  # short/empty page → last page
+        page += 1
+    # Hit the page backstop — treat as incomplete (cannot confirm we saw everything).
+    return acc, False
 
 
 def _check_inline_review_findings(
@@ -913,44 +1042,44 @@ def _check_inline_review_findings(
     *,
     force: bool = False,
     repo: str | None = None,
-    strict: bool = False,
 ) -> tuple[bool, str]:
     """Scan INLINE review comments for P1/P2 badge findings.
 
-    Returns (should_block, message). P1 findings block unless their
-    thread has a reply (engagement = read) or the merge carries
-    '# review-override'. P2 findings never block but are printed to
-    stderr one per line — the session must consciously accept them.
-    On an UNREADABLE scan (gh error/timeout/malformed): enforcement fails OPEN;
-    ``strict`` (report mode) fails CLOSED — see ``_scan_unreadable``.
+    Returns (should_block, message). P1 findings block unless their thread has a
+    MAINTAINER reply (engagement = a reviewer read it) or the merge carries
+    '# review-override'. P2 findings never block but are printed to stderr one per
+    line — the session must consciously accept them. An UNREADABLE or INCOMPLETE scan
+    (gh error/timeout/malformed/clipped budget) ALWAYS blocks (fail-closed — see
+    ``_scan_unreadable``); '# review-override' is the conscious escape hatch.
     """
     if force:
         return False, ""  # override NOTE already printed by the body gate
-    try:
-        # --paginate: findings beyond the first REST page (30 comments)
-        # must still gate. With a per-element jq filter, gh emits one
-        # compact JSON object per line across ALL pages.
-        result = subprocess.run(
-            [
-                "gh",
-                "api",
-                f"repos/{repo or ':owner/:repo'}/pulls/{pr_num}/comments",
-                "--paginate",
-                "--jq",
-                ".[] | {id: .id, reply_to: .in_reply_to_id, "
-                "login: .user.login, type: .user.type, body: .body}",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=_gh_timeout(8),  # merge-path budget (see main): advisory scan, fail-open
-        )
-        if result.returncode != 0:
-            return _scan_unreadable(strict, "inline review comments")
-        raw = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
-    except Exception:
-        return _scan_unreadable(strict, "inline review comments")
+    # Paginate via the shared helper (findings beyond the first REST page must still
+    # gate); it accumulates ALL pages as parsed dicts, NEL-safe. ``raw is None`` = the
+    # first page was unreadable; ``complete`` False = a later page failed. Newest-first
+    # (pulls/comments honors sort/direction) so a partial read sees recent findings
+    # first. ``assoc`` = author_association, for the maintainer-reply engagement check.
+    raw, complete = _fetch_comments_paged(
+        f"pulls/{pr_num}/comments",
+        pr_num,
+        repo,
+        ".[] | {id: .id, reply_to: .in_reply_to_id, login: .user.login, "
+        "type: .user.type, assoc: .author_association, body: .body}",
+        ["-f", "sort=created", "-f", "direction=desc"],
+    )
+    if raw is None:
+        return _scan_unreadable("inline review comments")
 
-    replied_to = {c.get("reply_to") for c in raw if c.get("reply_to")}
+    # Build replied_to over ALL accumulated pages BEFORE classifying, so a P1 on an
+    # early page acknowledged by a reply on a later page is treated as engaged (never
+    # per-page — that would false-block a genuinely-acked finding). Count ONLY replies
+    # from a MAINTAINER (author_association in _MAINTAINER_ASSOCIATIONS): a non-authority
+    # reply must not silence a real P1 (LOW-a).
+    replied_to = {
+        c.get("reply_to")
+        for c in raw
+        if c.get("reply_to") and c.get("assoc") in _MAINTAINER_ASSOCIATIONS
+    }
     p1: list[str] = []
     p2: list[str] = []
     for c in raw:
@@ -982,21 +1111,28 @@ def _check_inline_review_findings(
             f"Fix and reply in-thread, or append '# review-override' "
             f"to the merge command to acknowledge and proceed."
         )
+    # No unresolved P1 among what we read. If the read is INCOMPLETE (a later page
+    # failed), a P1 could exist on an unread page — fail per _scan_unreadable rather
+    # than report a clean scan.
+    if not complete:
+        return _scan_unreadable("inline review comments (incomplete read)")
     return False, ""
 
 
 def _check_pr_review_findings(
-    pr_num: str, *, force: bool = False, repo: str | None = None, strict: bool = False
+    pr_num: str, *, force: bool = False, repo: str | None = None
 ) -> tuple[bool, str]:
     """Check PR comments for unresolved automated review findings.
 
     Returns (should_block, message).
 
-    On an UNREADABLE scan (gh error/timeout/malformed JSON), enforcement fails
-    OPEN — the hook must never become a single point of failure for merges — while
-    ``strict`` (report mode) fails CLOSED so ``--check-pr`` never reports a failed
-    scan as clean (see ``_scan_unreadable``). An empty result (no comments / Codex
-    quota) is clean either way.
+    An UNREADABLE or INCOMPLETE scan (gh error/timeout/malformed JSON, or a clipped
+    budget) ALWAYS blocks (fail-closed — see ``_scan_unreadable``): the hook must never
+    silently pass a merge past a scan it could not complete, since the newest finding
+    may sit on the page it failed to read. An empty result that was read COMPLETELY (no
+    comments / Codex quota) is clean; the freshness gate separately requires a CURRENT
+    review to EXIST. '# review-override' is the conscious escape hatch for a transient
+    gh error.
     """
     if force:
         print(
@@ -1005,83 +1141,73 @@ def _check_pr_review_findings(
         )
         return False, ""
 
-    try:
-        # --paginate: a review-body finding beyond the first REST page (30
-        # comments) must still gate — without it a [P1]/ERROR on page 2+ was
-        # silently dropped and the merge sailed through (a live fail-open: this
-        # scan runs on the merge path with strict=False). With a per-element jq
-        # filter, gh emits one compact JSON object per line across ALL pages
-        # (mirrors _check_inline_review_findings, which already paginates).
-        result = subprocess.run(
-            [
-                "gh",
-                "api",
-                f"repos/{repo or ':owner/:repo'}/issues/{pr_num}/comments",
-                "--paginate",
-                "--jq",
-                ".[] | {login: .user.login, type: .user.type, body: .body}",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=_gh_timeout(8),  # merge-path budget (see main): advisory scan, fail-open
-        )
-        if result.returncode != 0:
-            return _scan_unreadable(strict, "review-body comments")  # gh error
-        raw_comments = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
-    except Exception:
-        return _scan_unreadable(strict, "review-body comments")  # gh error / malformed JSONL
+    # Paginate via the shared helper (a review-body finding beyond the first REST
+    # page must still gate). ``comments is None`` = the first page was unreadable;
+    # ``complete`` False = a later page failed.
+    comments, complete = _fetch_comments_paged(
+        f"issues/{pr_num}/comments",
+        pr_num,
+        repo,
+        # Only login + body are read below (the verdict-bearing walk keys on the
+        # recognized-bot login, not user.type — unlike the inline scanner which still
+        # projects type for its Bot-vs-User check).
+        ".[] | {login: .user.login, body: .body}",
+    )
+    if comments is None:
+        return _scan_unreadable("review-body comments")  # first page unreadable
 
-    # An empty result is clean either way. The freshness gate
-    # (_check_codex_reviewed_head) separately requires a CURRENT review to EXIST
-    # at head, so "no comments here" is not the merge-safety rationale — it just
-    # means there is no finding to block on.
-    if not raw_comments:
-        return False, ""
-
-    # GitHub API can return "body": null for deleted comments —
-    # use `or ""` to coerce None to empty string (get's default only
-    # fires when the key is absent, not when the value is None).
-    comments: list[tuple[str, str, str]] = [
-        (c.get("login") or "", c.get("type") or "", c.get("body") or "") for c in raw_comments
-    ]
-
-    if not comments:
-        return False, ""
-
-    # Walk comments in reverse (most recent first). The last review
-    # comment determines the state — if findings were addressed and a
-    # re-review posted, the newer clean review wins.
-    for login, user_type, body in reversed(comments):
-        # Only check bot comments (automated reviews)
-        if user_type != "Bot" and login not in _REVIEW_BOTS:
+    # Walk comments in reverse (most recent first). Only a VERDICT-BEARING comment
+    # from a recognized review bot sets the state: one matching a BLOCKING marker
+    # (→ block) or a CLEAN marker (→ clean). Any other comment — a CI/status bot
+    # notice (e.g. github-actions), bot chit-chat, or an unrecognized author — is
+    # SKIPPED, never treated as the "newest clean review".
+    #
+    # This closes the fail-open (Codex P1) where the old terminal clause
+    # ``if is_clean or not blocking_matches: return clean`` let ANY marker-less
+    # comment from a Bot-typed account (Dependabot, or github-actions — which is IN
+    # _REVIEW_BOTS) end the walk clean, silently clearing an earlier ERROR. Requiring
+    # a recognized verdict marker closes BOTH the unrecognized-bot and the
+    # recognized-but-non-verdict (status-comment) masking paths.
+    for c in reversed(comments):
+        login = c.get("login") or ""
+        body = c.get("body") or ""  # GitHub returns null body for deleted comments
+        # Only recognized review bots set the verdict.
+        if login not in _REVIEW_BOTS:
             continue
-
-        # Skip Codex quota-exhausted messages (not a real review)
+        # Codex quota-exhausted messages are not a review.
         if "reached your Codex usage limits" in body and not any(
             p.search(body) for p in _BLOCKING_PATTERNS
         ):
             continue
 
-        # Check if this review is clean
         is_clean = any(p.search(body) for p in _CLEAN_PATTERNS)
-
-        # Check for blocking findings
         blocking_matches = [p.pattern for p in _BLOCKING_PATTERNS if p.search(body)]
 
         if blocking_matches and not is_clean:
-            # Found unresolved findings in the most recent review
+            # A seen finding stands even on an incomplete read (fail-closed on an
+            # observed blocking result — Codex P1: a later-page failure must not
+            # erase an already-observed finding).
             return True, (
                 f"Automated review has unresolved findings.\n"
                 f"Matched patterns: {', '.join(blocking_matches[:3])}\n"
                 f"Fix the findings, or append '# review-override' to "
                 f"the merge command to acknowledge and proceed."
             )
+        if is_clean:
+            # An explicit clean verdict ends the walk — but trust it only on a
+            # COMPLETE read. On an incomplete read the pages we have are the
+            # EARLIEST, so a newer finding could sit on an unread page.
+            if complete:
+                return False, ""
+            return _scan_unreadable("review-body comments (incomplete read)")
+        # Neither blocking nor clean → not a verdict comment → keep walking.
 
-        if is_clean or not blocking_matches:
-            # Most recent review is clean or has no blocking findings
-            return False, ""
-
-    # No bot review comments found — allow (no review posted)
+    # No verdict-bearing finding among the comments we read. On an INCOMPLETE read a
+    # newer finding could exist on an unread page — fail per _scan_unreadable rather
+    # than report clean. An empty/complete result is clean: the freshness gate
+    # (_check_codex_reviewed_head) separately requires a CURRENT review to EXIST.
+    if not complete:
+        return _scan_unreadable("review-body comments (incomplete read)")
     return False, ""
 
 
@@ -1858,21 +1984,18 @@ def _check_scheduled_claude_reviewed_head(
     repo: str | None = None,
     *,
     force: bool = False,
-    strict: bool = False,
 ) -> str | None:
     """Block a merge unless EVERY required scheduled Claude review (by the repo OWNER)
     has run on the PR's CURRENT head. Returns ``None`` when a valid owner marker for
     each kind in ``_REQUIRED_SCHEDULED_REVIEW_KINDS`` names ``head_sha`` exactly (full
     40-char), else a BLOCK MESSAGE naming the MISSING kinds.
 
-    Fail-CLOSED in BOTH modes — this gate never passes on absence of positive
-    evidence: if the head cannot be read, or the comment/review fetch errors
-    (``_scheduled_review_markers`` → None), the merge is BLOCKED. A read that simply
-    does not carry every required kind at this head (a routine didn't run, ran on a
-    stale commit, or was rate-limited) also blocks. ``strict`` is accepted for interface
-    parity with the finding scanners (``check_pr_report`` passes it); the block/pass
-    decision is identical in both modes precisely BECAUSE enforcement already fails
-    closed, so the report can never issue a false all-clear here.
+    Fail-CLOSED — this gate never passes on absence of positive evidence: if the head
+    cannot be read, or the comment/review fetch errors (``_scheduled_review_markers`` →
+    None), the merge is BLOCKED. A read that simply does not carry every required kind
+    at this head (a routine didn't run, ran on a stale commit, or was rate-limited) also
+    blocks. The merge path and the report path share this single fail-closed decision,
+    so the report can never issue a false all-clear here.
 
     SCOPE: this gate enforces ONLY for a merge targeting the configured PUBLIC repo
     (``_scheduled_gate_applies`` / ``_canonical_public_repo``). A merge to any other
@@ -3281,11 +3404,12 @@ def main() -> int:
                 # rejected if the head moved), making check→merge atomic. Only
                 # engaged when the freshness check ran (not # stale-review-override).
                 # Placed IMMEDIATELY after the freshness gate — BEFORE the two
-                # advisory network scanners below — so a hook wall-clock SIGKILL
-                # during a slow scan can never skip the binding enforcement (it
-                # needs only argv + verified_head, no gh call): a clipped scanner
-                # nets its own fail-open outcome, but a clipped BINDING would have
-                # re-opened the unbound-merge race this block exists to close.
+                # network scanners below — so a hook wall-clock SIGKILL during a slow
+                # scan can never skip the binding enforcement (it needs only argv +
+                # verified_head, no gh call). The scanners now fail CLOSED on a clipped
+                # budget, but a SIGKILL kills the whole hook (which "fails toward tool
+                # runs"), so the binding — the one gate that closes the unbound-merge
+                # TOCTOU race — must run first, while budget is guaranteed.
                 if verified_head:
                     bind_msg = _require_match_head(
                         merge_seg.argv, pr_num, verified_head, merge_repo, "Codex-verified"
@@ -3303,8 +3427,10 @@ def main() -> int:
                     repo=merge_repo,
                 )
                 if should_block:
+                    # Blocks on EITHER an unresolved finding OR an unreadable/incomplete
+                    # scan (fail-closed) — review_msg states which.
                     print(
-                        f"BLOCKED: PR #{pr_num} has unresolved review findings.",
+                        f"BLOCKED: PR #{pr_num} — review-body gate did not pass.",
                         file=sys.stderr,
                     )
                     print(review_msg, file=sys.stderr)
@@ -3319,20 +3445,20 @@ def main() -> int:
                 )
                 if should_block:
                     print(
-                        f"BLOCKED: PR #{pr_num} has unresolved INLINE review findings.",
+                        f"BLOCKED: PR #{pr_num} — inline review gate did not pass.",
                         file=sys.stderr,
                     )
                     print(inline_msg, file=sys.stderr)
                     return 2
 
-                # Scheduled Claude review at HEAD — its OWN always-fail-closed gate with
-                # its OWN sigil (# scheduled-review-override waives ONLY this gate; independent
-                # of # stale-review-override). Deliberately placed LAST — after the review-body
-                # + inline finding scanners, which fail OPEN on a clipped budget. This gate
-                # fails CLOSED, so if the shared merge-gate deadline is exhausted here it BLOCKS
-                # (safe); running it before the scanners could instead starve THEM into their
-                # 1s floor → fail-open → a merge with unresolved findings slipping through. Uses
-                # verified_head from the Codex gate (None under # stale-review-override → re-read).
+                # Scheduled Claude review at HEAD — its OWN fail-closed gate with its OWN
+                # sigil (# scheduled-review-override waives ONLY this gate; independent of
+                # # stale-review-override). Placed LAST, but ordering is no longer
+                # safety-critical: the review-body + inline scanners now ALSO fail CLOSED
+                # on a clipped budget (PR #1434 removed their fail-open), so a drained
+                # merge-gate deadline BLOCKS at whichever gate hits its 1s floor first —
+                # never a silent pass. Uses verified_head from the Codex gate (None under
+                # # stale-review-override → re-read).
                 sched_override = has_trailing_override(merge_seg.raw, "scheduled-review-override")
                 # Provision-or-surface: the scheduled gate no-ops off the configured
                 # public repo (by design). A SILENT no-op would hide a drifted
@@ -3478,16 +3604,15 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     REST endpoint — `chatgpt-codex-connector` vs `…[bot]` — matched nothing,
     and the empty result was reported as "Codex clean" while 5 P2 findings sat
     unread). Report and enforcement share these functions, so a bug in one is a
-    bug in both. The ONE deliberate divergence: the report runs the finding scans
-    in ``strict`` mode, so an UNREADABLE scan (gh error) shows as a failure here
-    rather than fail-open as enforcement does — the report must never issue a
-    false all-clear.
+    bug in both. Both run the finding scans FAIL-CLOSED — an UNREADABLE or INCOMPLETE
+    scan (gh error / clipped budget) shows as a failure here and BLOCKS a merge there;
+    neither ever issues a false all-clear (PR #1434 removed the old merge-path fail-open).
 
     Prints one line per gate; returns 0 when every gate would pass, 1 otherwise.
     (Same CHECKS as enforcement, but the internal ORDER may differ — e.g. the merge
-    arm runs the scheduled gate LAST, after the finding scanners, for budget reasons;
-    the report is order-independent because every scan here is strict=True, so a clipped
-    scan is a failure line rather than a fail-open pass regardless of position.)
+    arm runs the scheduled gate LAST, after the finding scanners; the report is
+    order-independent because every scan fails CLOSED, so a clipped scan is a failure
+    line regardless of position.)
     """
     failures = 0
     mergeable = _check_mergeable(pr_num, repo=repo)
@@ -3540,9 +3665,8 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     print(f"codex-at-head  : {label}")
     failures += 1 if blocked else 0
     # Scheduled Claude review at HEAD — the SAME always-fail-closed gate the merge arm
-    # enforces (shared function, strict mode). It reads the head itself (no head in
-    # hand here). A missing/stale/unreadable scheduled review is a FAILURE line, never a
-    # false all-clear — the report must not diverge from enforcement.
+    # enforces (shared function). A missing/stale/unreadable scheduled review is a
+    # FAILURE line, never a false all-clear — the report must not diverge from enforcement.
     # Pass the Codex-verified head (as the enforcement path does) so the report is a
     # COHERENT snapshot: if the head moved mid-report, the scheduled check binds to the
     # same head the printed merge-with command does, not an independently re-read newer one.
@@ -3551,17 +3675,17 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     if not _scheduled_gate_applies(repo):
         print("scheduled-claude: n/a (scoped to the public repo only)")
     else:
-        sched_msg = _check_scheduled_claude_reviewed_head(pr_num, verified_head, repo, strict=True)
+        sched_msg = _check_scheduled_claude_reviewed_head(pr_num, verified_head, repo)
         print(
             f"scheduled-claude: {'BLOCK — ' + sched_msg.splitlines()[0] if sched_msg else 'ok (at head)'}"
         )
         failures += 1 if sched_msg else 0
-    # strict=True: a scan that could not be READ (gh error/malformed) must show as
-    # a failure here, never as "ok" — the report must not issue a false all-clear.
-    blocked, msg = _check_pr_review_findings(pr_num, repo=repo, strict=True)
+    # Fail-closed (the only mode now): a scan that could not be READ (gh error/malformed)
+    # shows as a failure here, never as "ok" — the report must not issue a false all-clear.
+    blocked, msg = _check_pr_review_findings(pr_num, repo=repo)
     print(f"review-body    : {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok'}")
     failures += 1 if blocked else 0
-    blocked, msg = _check_inline_review_findings(pr_num, repo=repo, strict=True)
+    blocked, msg = _check_inline_review_findings(pr_num, repo=repo)
     print(
         f"inline-findings: {'BLOCK — ' + msg.splitlines()[0] if blocked else 'ok (P2s, if any, printed above)'}"
     )

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -935,21 +935,17 @@ def _fetch_comments_paged(
     pr_num: str,
     repo: str | None,
     jq: str,
-    extra_params: list[str] | None = None,
 ) -> tuple[list[dict] | None, bool]:
     """Fetch ALL pages of a PR comments endpoint as parsed JSON objects.
 
     Pages through ``gh api repos/<repo>/<endpoint> -X GET -f per_page=100 -f page=N
     --jq <jq>`` (query params via ``-f``; the endpoint token keeps its ``…/comments``
     suffix so the char-router's ``endswith("/comments")`` still matches). ``gh --jq``
-    emits one compact JSON object per line — JSONL — across the page.
-
-    ``extra_params`` — additional ``-f key=value`` query args (already tokenized as a
-    flat list) merged into every page request. Used to fetch newest-first
-    (``sort=created direction=desc``) on the ``pulls/*/comments`` endpoint, which honors
-    it, so a partially-read scan sees the most recent findings first. The
-    ``issues/*/comments`` endpoint IGNORES sort/direction, so this stays opt-in per
-    caller rather than a blanket default.
+    emits one compact JSON object per line — JSONL — across the page. Pages are fetched
+    in the endpoint's default ASCENDING (oldest-first) order — both callers accumulate
+    ALL pages, so order does not affect the verdict, and ascending means a comment
+    appended during the scan lands on the last page (reached) rather than shifting a
+    never-revisited first page under descending paging.
 
     Returns ``(objects, complete)``:
       - ``(None, False)``  — the FIRST page could not be read (gh error/exception):
@@ -998,7 +994,6 @@ def _fetch_comments_paged(
                     f"per_page={_COMMENTS_PER_PAGE}",
                     "-f",
                     f"page={page}",
-                    *(extra_params or []),
                     "--jq",
                     jq,
                 ],
@@ -1056,16 +1051,17 @@ def _check_inline_review_findings(
         return False, ""  # override NOTE already printed by the body gate
     # Paginate via the shared helper (findings beyond the first REST page must still
     # gate); it accumulates ALL pages as parsed dicts, NEL-safe. ``raw is None`` = the
-    # first page was unreadable; ``complete`` False = a later page failed. Newest-first
-    # (pulls/comments honors sort/direction) so a partial read sees recent findings
-    # first. ``assoc`` = author_association, for the maintainer-reply engagement check.
+    # first page was unreadable; ``complete`` False = a later page failed. Fetch in the
+    # endpoint's default ASCENDING (oldest-first) order: a P1 appended DURING the scan
+    # lands on the last page, which sequential ascending pagination reaches — descending
+    # (newest-first) page-number paging would never revisit page 1 to see it on a >100-
+    # comment PR. ``assoc`` = author_association, for the maintainer-reply engagement check.
     raw, complete = _fetch_comments_paged(
         f"pulls/{pr_num}/comments",
         pr_num,
         repo,
         ".[] | {id: .id, reply_to: .in_reply_to_id, login: .user.login, "
         "type: .user.type, assoc: .author_association, body: .body}",
-        ["-f", "sort=created", "-f", "direction=desc"],
     )
     if raw is None:
         return _scan_unreadable("inline review comments")

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1006,14 +1006,20 @@ def _check_pr_review_findings(
         return False, ""
 
     try:
-        # Fetch comments as JSON array with author info
+        # --paginate: a review-body finding beyond the first REST page (30
+        # comments) must still gate — without it a [P1]/ERROR on page 2+ was
+        # silently dropped and the merge sailed through (a live fail-open: this
+        # scan runs on the merge path with strict=False). With a per-element jq
+        # filter, gh emits one compact JSON object per line across ALL pages
+        # (mirrors _check_inline_review_findings, which already paginates).
         result = subprocess.run(
             [
                 "gh",
                 "api",
                 f"repos/{repo or ':owner/:repo'}/issues/{pr_num}/comments",
+                "--paginate",
                 "--jq",
-                "[.[] | {login: .user.login, type: .user.type, body: .body}]",
+                ".[] | {login: .user.login, type: .user.type, body: .body}",
             ],
             capture_output=True,
             text=True,
@@ -1021,18 +1027,16 @@ def _check_pr_review_findings(
         )
         if result.returncode != 0:
             return _scan_unreadable(strict, "review-body comments")  # gh error
+        raw_comments = [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
     except Exception:
-        return _scan_unreadable(strict, "review-body comments")
+        return _scan_unreadable(strict, "review-body comments")  # gh error / malformed JSONL
 
-    output = result.stdout.strip()
-    if not output or output == "[]":
-        return False, ""  # No comments at all — allow (quota-exhausted case)
-
-    # Parse JSON array of comments
-    try:
-        raw_comments = json.loads(output)
-    except json.JSONDecodeError:
-        return _scan_unreadable(strict, "review-body comments")  # malformed JSON
+    # An empty result is clean either way. The freshness gate
+    # (_check_codex_reviewed_head) separately requires a CURRENT review to EXIST
+    # at head, so "no comments here" is not the merge-safety rationale — it just
+    # means there is no finding to block on.
+    if not raw_comments:
+        return False, ""
 
     # GitHub API can return "body": null for deleted comments —
     # use `or ""` to coerce None to empty string (get's default only

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -677,7 +677,7 @@ class TestStaleSigilDoesNotWaiveScanners:
         )
         rc = _mod.main()
         assert rc == 2  # freshness waived, but the P1 findings gate still blocks
-        assert "unresolved review findings" in capsys.readouterr().err
+        assert "review-body gate did not pass" in capsys.readouterr().err
 
 
 class TestCheckPrRepoArg:
@@ -726,10 +726,10 @@ class TestCheckPrReportFreshnessLabel:
         monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("green", []))
         monkeypatch.setattr(_mod, "_check_base_is_default", lambda n, repo=None: (False, ""))
         monkeypatch.setattr(
-            _mod, "_check_pr_review_findings", lambda n, repo=None, strict=False: (False, "")
+            _mod, "_check_pr_review_findings", lambda n, repo=None, force=False: (False, "")
         )
         monkeypatch.setattr(
-            _mod, "_check_inline_review_findings", lambda n, repo=None, strict=False: (False, "")
+            _mod, "_check_inline_review_findings", lambda n, repo=None, force=False: (False, "")
         )
         _mod.check_pr_report("5")
         return capsys.readouterr().out
@@ -790,10 +790,10 @@ class TestReportFreshnessUnreadable:
         monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("green", []))
         monkeypatch.setattr(_mod, "_check_base_is_default", lambda n, repo=None: (False, ""))
         monkeypatch.setattr(
-            _mod, "_check_pr_review_findings", lambda n, repo=None, strict=False: (False, "")
+            _mod, "_check_pr_review_findings", lambda n, repo=None, force=False: (False, "")
         )
         monkeypatch.setattr(
-            _mod, "_check_inline_review_findings", lambda n, repo=None, strict=False: (False, "")
+            _mod, "_check_inline_review_findings", lambda n, repo=None, force=False: (False, "")
         )
         # freshness gate passes (allowed), but the relabel re-reads fail (None)
         monkeypatch.setattr(_mod, "_check_codex_reviewed_head", lambda n, repo=None: (False, "", HEAD))
@@ -936,8 +936,8 @@ class TestCleanCommentFreshness:
         monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
         monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("green", []))
         monkeypatch.setattr(_mod, "_check_base_is_default", lambda n, repo=None: (False, ""))
-        monkeypatch.setattr(_mod, "_check_pr_review_findings", lambda n, repo=None, strict=False: (False, ""))
-        monkeypatch.setattr(_mod, "_check_inline_review_findings", lambda n, repo=None, strict=False: (False, ""))
+        monkeypatch.setattr(_mod, "_check_pr_review_findings", lambda n, repo=None, force=False: (False, ""))
+        monkeypatch.setattr(_mod, "_check_inline_review_findings", lambda n, repo=None, force=False: (False, ""))
         _mod.check_pr_report("1")
         out = capsys.readouterr().out
         assert "clean comment at head" in out

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -365,7 +365,7 @@ _CASES: list[tuple[str, object, int, str]] = [
         "inline_P1_finding_blocks",
         lambda mp: _run(mp, _merge_cmd(), router=_router(inline_lines=_INLINE_P1_LINE)),
         2,
-        "INLINE review findings",
+        "inline review gate did not pass",
     ),
     # ── ORDERING: freshness runs BEFORE the finding scans. With BOTH a missing
     #    review AND a would-be inline P1, the block message must be the FRESHNESS
@@ -411,7 +411,7 @@ _CASES: list[tuple[str, object, int, str]] = [
         "review_body_P1_finding_blocks",
         lambda mp: _run(mp, _merge_cmd(), router=_router(review_lines=_REVIEW_BODY_P1)),
         2,
-        "unresolved review findings",
+        "review-body gate did not pass",
     ),
     # ── override-sigil INDEPENDENCE (F3 — highest-risk gap: the extraction's
     #    unified force-plumbing must NOT collapse the two sigils into one) ──
@@ -472,7 +472,7 @@ _CASES: list[tuple[str, object, int, str]] = [
             router=_router(review_lines=_REVIEW_BODY_P1),
         ),
         2,
-        "unresolved review findings",
+        "review-body gate did not pass",
     ),
     # (Codex-P2) CI-unknown is a deliberately fail-OPEN gate — empty/malformed CI reads
     # must ALLOW, so the unified UNKNOWN->BLOCK aggregation can't regress them. NOTE: CI
@@ -545,7 +545,7 @@ _CASES: list[tuple[str, object, int, str]] = [
             router=_router(inline_lines=_INLINE_P1_LINE),
         ),
         2,
-        "INLINE review findings",
+        "inline review gate did not pass",
     ),
     # (Codex-P1 3788128908) `# ci-override` is scoped to the CI gate ALONE — it must not
     # act as a global force. The existing `ci_red_with_ci_override_continues` case has
@@ -563,7 +563,7 @@ _CASES: list[tuple[str, object, int, str]] = [
             router=_router(inline_lines=_INLINE_P1_LINE),
         ),
         2,
-        "INLINE review findings",
+        "inline review gate did not pass",
     ),
     (
         "ci_override_does_NOT_waive_review_body_findings_blocks",
@@ -574,7 +574,7 @@ _CASES: list[tuple[str, object, int, str]] = [
             router=_router(review_lines=_REVIEW_BODY_P1),
         ),
         2,
-        "unresolved review findings",
+        "review-body gate did not pass",
     ),
     (
         # ci_override must not waive FRESHNESS either (freshness reads stale_override, not
@@ -961,10 +961,10 @@ def _report_env(monkeypatch, *, scheduled: str, head: str = HEAD):
     monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("green", []))
     monkeypatch.setattr(_mod, "_check_base_is_default", lambda n, repo=None: (False, ""))
     monkeypatch.setattr(
-        _mod, "_check_pr_review_findings", lambda n, repo=None, strict=False: (False, "")
+        _mod, "_check_pr_review_findings", lambda n, repo=None, force=False: (False, "")
     )
     monkeypatch.setattr(
-        _mod, "_check_inline_review_findings", lambda n, repo=None, strict=False: (False, "")
+        _mod, "_check_inline_review_findings", lambda n, repo=None, force=False: (False, "")
     )
 
 

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -129,9 +129,11 @@ _INLINE_P1_LINE = json.dumps(
         "body": "![P1 Badge](x) something is broken",
     }
 )
-# A review-BODY comment carrying a blocking [P1] marker (issues/N/comments; JSON array).
+# A review-BODY comment carrying a blocking [P1] marker (issues/N/comments). The code
+# now fetches this endpoint with `--paginate --jq '.[] | {…}'`, so gh emits one compact
+# JSON object per line (JSONL), NOT a JSON array — mirror that here.
 _REVIEW_BODY_P1 = json.dumps(
-    [{"login": "chatgpt-codex-connector[bot]", "type": "Bot", "body": "[P1] real defect"}]
+    {"login": "chatgpt-codex-connector[bot]", "type": "Bot", "body": "[P1] real defect"}
 )
 # An inline P2 badge comment — warns but does NOT block.
 _INLINE_P2_LINE = json.dumps(
@@ -159,7 +161,7 @@ def _router(
     mergeable: str = "MERGEABLE",
     mergeable_rc: int = 0,
     inline_lines: str = "",
-    review_array: str = "[]",
+    review_lines: str = "",
     calls: list | None = None,
 ):
     """A ``subprocess.run`` stand-in for the three un-seamed gh calls on the merge
@@ -192,10 +194,10 @@ def _router(
         if any("/pulls/" in a and a.endswith("/comments") for a in parts):
             _rec("inline")
             return _proc(0, inline_lines)
-        # gh api repos/<repo>/issues/<pr>/comments → REVIEW-BODY findings (json array)
+        # gh api repos/<repo>/issues/<pr>/comments → REVIEW-BODY findings (one json obj/line)
         if any("/issues/" in a and a.endswith("/comments") for a in parts):
             _rec("review-body")
-            return _proc(0, review_array)
+            return _proc(0, review_lines)
         return _proc(0, "")
 
     return run
@@ -407,7 +409,7 @@ _CASES: list[tuple[str, object, int, str]] = [
     #    BEFORE the inline scan — a reorder the extraction could make undetected) ──
     (
         "review_body_P1_finding_blocks",
-        lambda mp: _run(mp, _merge_cmd(), router=_router(review_array=_REVIEW_BODY_P1)),
+        lambda mp: _run(mp, _merge_cmd(), router=_router(review_lines=_REVIEW_BODY_P1)),
         2,
         "unresolved review findings",
     ),
@@ -427,7 +429,7 @@ _CASES: list[tuple[str, object, int, str]] = [
         lambda mp: _run(
             mp,
             _merge_cmd(trailer="# review-override"),
-            router=_router(review_array=_REVIEW_BODY_P1),
+            router=_router(review_lines=_REVIEW_BODY_P1),
         ),
         0,
         "",
@@ -467,7 +469,7 @@ _CASES: list[tuple[str, object, int, str]] = [
             mp,
             _merge_cmd(match=None, trailer="# stale-review-override"),
             reviews="",
-            router=_router(review_array=_REVIEW_BODY_P1),
+            router=_router(review_lines=_REVIEW_BODY_P1),
         ),
         2,
         "unresolved review findings",
@@ -569,7 +571,7 @@ _CASES: list[tuple[str, object, int, str]] = [
             mp,
             _merge_cmd(trailer="# ci-override"),
             ci=_ci("FAILURE"),
-            router=_router(review_array=_REVIEW_BODY_P1),
+            router=_router(review_lines=_REVIEW_BODY_P1),
         ),
         2,
         "unresolved review findings",
@@ -872,7 +874,7 @@ def test_findings_not_fetched_when_freshness_blocks(monkeypatch):
         monkeypatch,
         _merge_cmd(),
         reviews="",  # no current review → freshness blocks
-        router=_router(inline_lines=_INLINE_P1_LINE, review_array=_REVIEW_BODY_P1, calls=calls),
+        router=_router(inline_lines=_INLINE_P1_LINE, review_lines=_REVIEW_BODY_P1, calls=calls),
     )
     assert rc == 2
     labels = [label for label, _argv in calls]
@@ -934,7 +936,7 @@ def test_e3_stale_override_gates_positional_pr_not_flag_value(monkeypatch):
             return _proc(0, _INLINE_P1_LINE if hit else "")
         if any("/issues/" in a and a.endswith("/comments") for a in parts):
             calls.append(("review-body", tuple(parts)))
-            return _proc(0, "[]")
+            return _proc(0, "")  # no review-body comments (JSONL: empty output)
         return _proc(0, "")
 
     cmd = "gh pr merge --subject 123 5 --repo owner/repo --squash --admin  # stale-review-override"

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1266,19 +1266,20 @@ class TestCheckInlineReviewFindings:
         assert "per_page=100" in argv
         assert "page=1" in argv
 
-    def test_inline_fetch_requests_newest_first(self, guard_module):
-        # pulls/comments honors sort/direction; fetching newest-first means a partial
-        # read (later page fails) still sees the most recent findings first.
+    def test_inline_fetch_uses_default_ascending_order(self, guard_module):
+        # The inline scan fetches in the endpoint's DEFAULT ascending (oldest-first)
+        # order — NO sort/direction params. Descending (newest-first) page-number paging
+        # would never revisit page 1, so a P1 appended mid-scan on a >100-comment PR
+        # could go unseen (Codex P2). Ascending puts an appended comment on the last
+        # page, which sequential pagination reaches.
         with self._mock(guard_module, []) as run_mock:
             guard_module._check_inline_review_findings("100")
         argv = run_mock.call_args[0][0]
-        assert "sort=created" in argv
-        assert "direction=desc" in argv
-        # …on the pulls (inline) endpoint specifically.
+        assert "sort=created" not in argv
+        assert "direction=desc" not in argv
         assert any("pulls/100/comments" in tok for tok in argv)
 
-    def test_body_fetch_does_not_request_sort(self, guard_module):
-        # issues/comments IGNORES sort/direction — don't send params it won't honor.
+    def test_body_fetch_uses_default_ascending_order(self, guard_module):
         with patch.object(
             guard_module.subprocess, "run",
             return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -806,7 +806,9 @@ class TestCheckPrReviewFindings:
             should_block, _ = guard_module._check_pr_review_findings("100")
             gh_argv = mock_run.call_args.args[0]
         assert should_block
-        assert "--paginate" in gh_argv
+        # Paged fetch requests explicit query params (per_page/page), not --paginate.
+        assert "per_page=100" in gh_argv
+        assert "page=1" in gh_argv
 
     def test_clean_review_allows_merge(self, guard_module):
         """Review comment with CLEAN verdict → allow."""
@@ -923,8 +925,8 @@ class TestCheckPrReviewFindings:
         should_block, msg = guard_module._check_pr_review_findings("100", force=True)
         assert not should_block
 
-    def test_api_error_fails_open(self, guard_module):
-        """gh api returning error → fail-open (allow merge)."""
+    def test_api_error_fails_closed(self, guard_module):
+        """gh api returning error → fail-CLOSED (block; unreadable scan, PR #1434)."""
         with patch.object(guard_module.subprocess, "run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
                 args=[],
@@ -933,14 +935,16 @@ class TestCheckPrReviewFindings:
                 stderr="API error",
             )
             should_block, msg = guard_module._check_pr_review_findings("100")
-        assert not should_block
+        assert should_block
+        assert "UNREADABLE" in msg
 
-    def test_api_timeout_fails_open(self, guard_module):
-        """gh api timeout → fail-open."""
+    def test_api_timeout_fails_closed(self, guard_module):
+        """gh api timeout → fail-CLOSED (block; unreadable scan, PR #1434)."""
         with patch.object(guard_module.subprocess, "run") as mock_run:
             mock_run.side_effect = subprocess.TimeoutExpired(cmd="gh", timeout=15)
             should_block, msg = guard_module._check_pr_review_findings("100")
-        assert not should_block
+        assert should_block
+        assert "UNREADABLE" in msg
 
     def test_newer_clean_review_overrides_old_error(self, guard_module):
         """When latest bot comment is clean, old ERROR is considered resolved."""
@@ -1201,7 +1205,8 @@ class TestCheckInlineReviewFindings:
         err = capsys.readouterr().err
         assert "[P2] Preserve multi-word ledger keys" in err
 
-    def test_replied_p1_is_acknowledged(self, guard_module):
+    def test_replied_p1_is_acknowledged_by_maintainer(self, guard_module):
+        """A MAINTAINER reply (author_association OWNER/MEMBER/COLLABORATOR) acks a P1."""
         comments = [
             self._codex(1, _P1_BODY),
             {
@@ -1209,12 +1214,33 @@ class TestCheckInlineReviewFindings:
                 "reply_to": 1,
                 "login": "WingedGuardian",
                 "type": "User",
+                "assoc": "OWNER",
                 "body": "Fixed in abc123.",
             },
         ]
         with self._mock(guard_module, comments):
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
+
+    def test_non_maintainer_reply_does_not_acknowledge_p1(self, guard_module):
+        """LOW-a: a reply from a non-authority account (NONE / throwaway / PR author
+        with no push rights) must NOT silence a real P1 — it still blocks."""
+        for assoc in ("NONE", "FIRST_TIME_CONTRIBUTOR", "CONTRIBUTOR", None):
+            comments = [
+                self._codex(1, _P1_BODY),
+                {
+                    "id": 2,
+                    "reply_to": 1,
+                    "login": "drive-by-account",
+                    "type": "User",
+                    "assoc": assoc,
+                    "body": "lgtm",
+                },
+            ]
+            with self._mock(guard_module, comments):
+                block, msg = guard_module._check_inline_review_findings("100")
+            assert block, f"assoc={assoc!r} should NOT acknowledge the P1"
+            assert "Make queue claim atomic" in msg
 
     def test_force_override_allows(self, guard_module):
         block, _ = guard_module._check_inline_review_findings(
@@ -1223,17 +1249,45 @@ class TestCheckInlineReviewFindings:
         )
         assert not block
 
-    def test_api_error_fails_open(self, guard_module):
+    def test_api_error_fails_closed(self, guard_module):
+        """Unreadable inline scan → fail-CLOSED (block; PR #1434)."""
         with self._mock(guard_module, [], rc=1):
-            block, _ = guard_module._check_inline_review_findings("100")
-        assert not block
+            block, msg = guard_module._check_inline_review_findings("100")
+        assert block
+        assert "UNREADABLE" in msg
 
     def test_gh_call_paginates(self, guard_module):
         # Findings beyond REST page 1 (30 comments) must still gate —
         # the very first PR through this gate (#996) drew a P1 for it.
+        # The paged fetch requests explicit per_page/page query params.
         with self._mock(guard_module, []) as run_mock:
             guard_module._check_inline_review_findings("100")
-        assert "--paginate" in run_mock.call_args[0][0]
+        argv = run_mock.call_args[0][0]
+        assert "per_page=100" in argv
+        assert "page=1" in argv
+
+    def test_inline_fetch_requests_newest_first(self, guard_module):
+        # pulls/comments honors sort/direction; fetching newest-first means a partial
+        # read (later page fails) still sees the most recent findings first.
+        with self._mock(guard_module, []) as run_mock:
+            guard_module._check_inline_review_findings("100")
+        argv = run_mock.call_args[0][0]
+        assert "sort=created" in argv
+        assert "direction=desc" in argv
+        # …on the pulls (inline) endpoint specifically.
+        assert any("pulls/100/comments" in tok for tok in argv)
+
+    def test_body_fetch_does_not_request_sort(self, guard_module):
+        # issues/comments IGNORES sort/direction — don't send params it won't honor.
+        with patch.object(
+            guard_module.subprocess, "run",
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr=""),
+        ) as run_mock:
+            guard_module._check_pr_review_findings("100")
+        argv = run_mock.call_args[0][0]
+        assert "sort=created" not in argv
+        assert "direction=desc" not in argv
+        assert any("issues/100/comments" in tok for tok in argv)
 
     def test_p1_beyond_first_page_blocks(self, guard_module):
         filler = [self._codex(i, "note") for i in range(1, 32)]
@@ -2023,33 +2077,23 @@ class TestRepoDerivationGate:
         assert seen["repo"] is None  # not derived → cwd repo (unchanged behavior)
 
 
-class TestStrictScanMode:
-    """F-report (Codex P2, round 6): a finding scan that could not be READ (gh
-    error/timeout/malformed) must not be reported as clean. Report mode passes
-    strict=True → an unreadable scan blocks/fails; enforcement (default) stays
-    fail-open for Codex-quota/outage tolerance. An EMPTY result (quota) is clean
-    in both modes."""
+class TestUnreadableScanFailsClosed:
+    """PR #1434: a finding scan that could not be READ (gh error/timeout/malformed)
+    or completed (clipped budget) ALWAYS fails CLOSED — it blocks a merge and shows as
+    a failure line in the report. The old fail-OPEN merge path (a silent pass) was the
+    CRITICAL. An EMPTY result read COMPLETELY (Codex quota / no comments) stays clean."""
 
-    def test_body_error_fails_closed_when_strict(self, guard_module):
+    def test_body_error_fails_closed(self, guard_module):
         with patch.object(
             guard_module.subprocess,
             "run",
             return_value=subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="x"),
         ):
-            block, msg = guard_module._check_pr_review_findings("1", strict=True)
+            block, msg = guard_module._check_pr_review_findings("1")
         assert block is True and "unreadable" in msg.lower()
 
-    def test_body_error_fails_open_by_default(self, guard_module):
-        with patch.object(
-            guard_module.subprocess,
-            "run",
-            return_value=subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="x"),
-        ):
-            block, _ = guard_module._check_pr_review_findings("1")
-        assert block is False
-
-    def test_body_empty_is_clean_even_when_strict(self, guard_module):
-        # Empty (quota / no comments) is NOT an error — clean in both modes.
+    def test_body_empty_is_clean(self, guard_module):
+        # Empty (quota / no comments) is NOT an error — a complete empty read is clean.
         # Under `--paginate --jq '.[] | {…}'` gh emits nothing (not "[]") for
         # zero comments, so the empty output is an empty string.
         with patch.object(
@@ -2057,26 +2101,17 @@ class TestStrictScanMode:
             "run",
             return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
         ):
-            block, _ = guard_module._check_pr_review_findings("1", strict=True)
+            block, _ = guard_module._check_pr_review_findings("1")
         assert block is False
 
-    def test_inline_error_fails_closed_when_strict(self, guard_module):
+    def test_inline_error_fails_closed(self, guard_module):
         with patch.object(
             guard_module.subprocess,
             "run",
             return_value=subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="x"),
         ):
-            block, msg = guard_module._check_inline_review_findings("1", strict=True)
+            block, msg = guard_module._check_inline_review_findings("1")
         assert block is True and "unreadable" in msg.lower()
-
-    def test_inline_error_fails_open_by_default(self, guard_module):
-        with patch.object(
-            guard_module.subprocess,
-            "run",
-            return_value=subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="x"),
-        ):
-            block, _ = guard_module._check_inline_review_findings("1")
-        assert block is False
 
     def test_report_counts_unreadable_scan_as_failure(self, guard_module, monkeypatch, capsys):
         # The canonical report must not print "all gates pass" when a scan errored.
@@ -2090,18 +2125,16 @@ class TestStrictScanMode:
             "_check_codex_reviewed_head",
             lambda n, force=False, repo=None: (False, "", "h"),
         )
-        # Body scan errors (strict → block); inline clean.
+        # Body scan unreadable → block (fail-closed); inline clean.
         monkeypatch.setattr(
             guard_module,
             "_check_pr_review_findings",
-            lambda n, repo=None, strict=False: (True, "could not read review-body comments")
-            if strict
-            else (False, ""),
+            lambda n, repo=None: (True, "could not read review-body comments"),
         )
         monkeypatch.setattr(
             guard_module,
             "_check_inline_review_findings",
-            lambda n, repo=None, strict=False: (False, ""),
+            lambda n, repo=None: (False, ""),
         )
         assert guard_module.check_pr_report("5") == 1
         out = capsys.readouterr().out
@@ -2185,16 +2218,59 @@ class TestGateOrdering:
         monkeypatch.setattr(
             guard_module,
             "_check_pr_review_findings",
-            lambda n, repo=None, strict=False: (calls.append("body"), (False, ""))[1],
+            lambda n, repo=None: (calls.append("body"), (False, ""))[1],
         )
         monkeypatch.setattr(
             guard_module,
             "_check_inline_review_findings",
-            lambda n, repo=None, strict=False: (calls.append("inline"), (False, ""))[1],
+            lambda n, repo=None: (calls.append("inline"), (False, ""))[1],
         )
         guard_module.check_pr_report("5")
         assert calls.index("freshness") < calls.index("body")
         assert calls.index("freshness") < calls.index("inline")
+
+
+class TestLowBFreshnessBackstop:
+    """PR #1434 LOW-b (verify-only): the review-body reverse-walk can fall through a
+    non-verdict newest comment to an OLDER stale CLEAN verdict and report clean. That is
+    NOT sufficient to authorize a merge on its own — the freshness gate
+    (_check_codex_reviewed_head) independently requires a CURRENT review at HEAD and runs
+    BEFORE the finding scans. So a stale-clean body scan cannot smuggle a merge past a
+    head with no current review: freshness blocks first. This test pins that backstop."""
+
+    def _payload(self, cmd):
+        return {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": cmd},
+        }
+
+    def test_stale_clean_body_scan_blocked_by_freshness(self, guard_module, monkeypatch):
+        reached = {"body": False}
+        monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "SUCCESS"}])
+        )
+        monkeypatch.setattr(
+            guard_module, "_check_base_is_default", lambda n, force=False, repo=None: (False, "")
+        )
+        # Freshness FAILS: no current Codex review at head (the realistic stale-head case).
+        monkeypatch.setattr(
+            guard_module,
+            "_check_codex_reviewed_head",
+            lambda n, force=False, repo=None: (True, "no current review at head", None),
+        )
+        # Body scan WOULD return stale-clean — but must never be reached / never decisive.
+        def _body(n, force=False, repo=None):
+            reached["body"] = True
+            return (False, "")
+        monkeypatch.setattr(guard_module, "_check_pr_review_findings", _body)
+        monkeypatch.setattr(
+            guard_module, "read_payload", lambda: self._payload("gh pr merge 5 --squash --admin")
+        )
+        # Merge is BLOCKED by freshness, despite the body scan being clean.
+        assert guard_module.main() == 2
+        assert reached["body"] is False  # freshness gated first — stale-clean never decided it
 
 
 class TestMultiMergeBlocked:
@@ -2213,3 +2289,199 @@ class TestMultiMergeBlocked:
     def test_single_merge_not_tripped_by_multi_guard(self):
         res = _run_guard("gh pr merge 1 --squash --admin")
         assert "multiple publish/merge" not in res.stderr
+
+
+_NEL = "\u0085"  # Unicode NEL: splitlines() breaks on it, split("\n") does not
+
+
+def _cp(rows, rc=0):
+    """A CompletedProcess whose stdout is JSONL of the given already-serialized rows."""
+    return subprocess.CompletedProcess(args=[], returncode=rc, stdout="\n".join(rows), stderr="")
+
+
+class TestFetchCommentsPaged:
+    """The shared paginated comment-fetch primitive (_fetch_comments_paged):
+    accumulates pages, distinguishes first-page vs later-page failure, is NEL-safe,
+    and drops non-dict lines (Codex A: P1b partial-read + P2 NEL/non-dict)."""
+
+    def test_accumulates_across_pages_until_short_page(self, guard_module):
+        p1 = [json.dumps({"login": "a", "body": f"c{i}"}) for i in range(100)]  # full → fetch p2
+        p2 = [json.dumps({"login": "a", "body": f"d{i}"}) for i in range(50)]   # short → last
+        with patch.object(guard_module.subprocess, "run", side_effect=[_cp(p1), _cp(p2)]):
+            objs, complete = guard_module._fetch_comments_paged("issues/1/comments", "1", None, ".[]")
+        assert len(objs) == 150
+        assert complete is True
+
+    def test_first_page_error_returns_none_incomplete(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", return_value=_cp([], rc=1)):
+            objs, complete = guard_module._fetch_comments_paged("issues/1/comments", "1", None, ".[]")
+        assert objs is None and complete is False
+
+    def test_first_page_exception_returns_none_incomplete(self, guard_module):
+        with patch.object(guard_module.subprocess, "run",
+                          side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=8)):
+            objs, complete = guard_module._fetch_comments_paged("issues/1/comments", "1", None, ".[]")
+        assert objs is None and complete is False
+
+    def test_later_page_failure_keeps_accumulated_but_incomplete(self, guard_module):
+        p1 = [json.dumps({"login": "a", "body": f"c{i}"}) for i in range(100)]
+        with patch.object(guard_module.subprocess, "run",
+                          side_effect=[_cp(p1), subprocess.TimeoutExpired(cmd="gh", timeout=8)]):
+            objs, complete = guard_module._fetch_comments_paged("issues/1/comments", "1", None, ".[]")
+        assert len(objs) == 100 and complete is False
+
+    def test_nel_inside_body_does_not_fragment(self, guard_module):
+        # A raw U+0085 (NEL) inside a JSON string must NOT split the JSONL line
+        # (splitlines would → both fragments fail json.loads → the comment is lost).
+        line = json.dumps({"login": "a", "body": "head" + _NEL + "tail"}, ensure_ascii=False)
+        assert "" + _NEL + "" in line  # the raw NEL is present in the emitted line
+        with patch.object(guard_module.subprocess, "run", return_value=_cp([line])):
+            objs, complete = guard_module._fetch_comments_paged("issues/1/comments", "1", None, ".[]")
+        assert len(objs) == 1 and objs[0]["body"] == "head" + _NEL + "tail" and complete is True
+
+    def test_non_dict_lines_dropped(self, guard_module):
+        rows = [json.dumps({"login": "a", "body": "ok"}), json.dumps("bare string"), json.dumps(42)]
+        with patch.object(guard_module.subprocess, "run", return_value=_cp(rows)):
+            objs, complete = guard_module._fetch_comments_paged("issues/1/comments", "1", None, ".[]")
+        assert objs == [{"login": "a", "body": "ok"}] and complete is True
+
+    def test_out_of_budget_before_page1_blocks_without_calling_gh(self, guard_module, monkeypatch):
+        # HIGH (PR #1434): an already-expired merge deadline stops the loop BEFORE any gh
+        # call — page 1 → (None, incomplete) → caller fails closed. No unbounded gh spawns.
+        monkeypatch.setattr(guard_module, "_merge_deadline", guard_module.time.monotonic() - 1.0)
+        with patch.object(guard_module.subprocess, "run") as run_mock:
+            objs, complete = guard_module._fetch_comments_paged("issues/1/comments", "1", None, ".[]")
+        assert objs is None and complete is False
+        run_mock.assert_not_called()
+
+    def test_budget_exhausted_mid_flood_stops_early(self, guard_module, monkeypatch):
+        # A comment-flood where every page SUCCEEDS fast: the between-page deadline check
+        # must stop the loop once the budget is spent, returning INCOMPLETE (fail-closed),
+        # instead of spawning all 100 pages and blowing the hook's wall-clock.
+        full = [json.dumps({"login": "a", "body": f"c{i}"}) for i in range(100)]  # full → wants next
+        clock = {"t": 0.0}
+        monkeypatch.setattr(guard_module.time, "monotonic", lambda: clock["t"])
+        monkeypatch.setattr(guard_module, "_merge_deadline", 5.0)
+        def run_and_advance(*a, **k):
+            clock["t"] += 3.0  # each page burns 3s; 5s deadline crossed after 2 pages
+            return _cp(full)
+        with patch.object(guard_module.subprocess, "run", side_effect=run_and_advance) as run_mock:
+            objs, complete = guard_module._fetch_comments_paged("issues/1/comments", "1", None, ".[]")
+        assert complete is False  # stopped early → incomplete → caller blocks
+        assert run_mock.call_count < guard_module._MAX_COMMENT_PAGES  # NOT all 100 pages
+        assert len(objs) == 200  # two full pages read before the budget gate fired
+
+    def test_all_unparseable_page_is_unreadable(self, guard_module):
+        # LOW (PR #1434 defense-in-depth): a non-empty page whose every line fails
+        # json.loads (malformed body, rc==0) is unreadable, NOT a clean short page.
+        garbage = _cp(["this is not json", "{broken", "<html>error</html>"])
+        with patch.object(guard_module.subprocess, "run", return_value=garbage):
+            objs, complete = guard_module._fetch_comments_paged("issues/1/comments", "1", None, ".[]")
+        assert objs is None and complete is False
+
+
+_BODY_ERR = "### ERROR — raw SQL in production code"
+
+
+def _body_out(triples):
+    """gh output for the review-body scanner: (login, type, body) triples, oldest→newest."""
+    return _cp([json.dumps({"login": lg, "type": tp, "body": bd}) for lg, tp, bd in triples])
+
+
+def _codex_page_newest(newest_login, newest_body):
+    """A FULL page (100 rows: 99 codex notes + 1 newest) so the helper fetches page 2."""
+    rows = [json.dumps({"login": "chatgpt-codex-connector[bot]", "type": "Bot", "body": f"note {i}"})
+            for i in range(99)]
+    rows.append(json.dumps({"login": newest_login, "type": "Bot", "body": newest_body}))
+    return _cp(rows)
+
+
+class TestReviewBodyVerdictBearing:
+    """Review-body scanner: only a recognized review bot's verdict marker sets state
+    (Codex A P1a — a non-verdict status/dependabot comment no longer masks a finding),
+    NEL bodies parse (P2), and a seen finding survives an incomplete read (P1b)."""
+
+    def test_github_actions_status_after_error_still_blocks(self, guard_module):
+        # github-actions[bot] is IN _REVIEW_BOTS but its CI comment carries no verdict
+        # marker; newer than the codex ERROR, it must NOT clear the finding.
+        with patch.object(guard_module.subprocess, "run", return_value=_body_out([
+            ("chatgpt-codex-connector[bot]", "Bot", _BODY_ERR),
+            ("github-actions[bot]", "Bot", "CI run succeeded — all checks green."),
+        ])):
+            block, _ = guard_module._check_pr_review_findings("100")
+        assert block
+
+    def test_dependabot_comment_after_error_still_blocks(self, guard_module):
+        with patch.object(guard_module.subprocess, "run", return_value=_body_out([
+            ("chatgpt-codex-connector[bot]", "Bot", _BODY_ERR),
+            ("dependabot[bot]", "Bot", "Bumped urllib3 from 2.0 to 2.1."),
+        ])):
+            block, _ = guard_module._check_pr_review_findings("100")
+        assert block
+
+    def test_nel_in_error_body_parses_and_blocks(self, guard_module):
+        line = json.dumps(
+            {"login": "chatgpt-codex-connector[bot]", "type": "Bot",
+             "body": _BODY_ERR + "" + _NEL + " (see thread)"},
+            ensure_ascii=False,
+        )
+        assert "" + _NEL + "" in line
+        with patch.object(guard_module.subprocess, "run",
+                          return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=line, stderr="")):
+            block, _ = guard_module._check_pr_review_findings("100")
+        assert block
+
+    def test_finding_on_page1_survives_later_page_timeout(self, guard_module):
+        with patch.object(guard_module.subprocess, "run",
+                          side_effect=[_codex_page_newest("chatgpt-codex-connector[bot]", _BODY_ERR),
+                                       subprocess.TimeoutExpired(cmd="gh", timeout=8)]):
+            block, _ = guard_module._check_pr_review_findings("100")
+        assert block  # the seen ERROR stands despite the later-page timeout
+
+    def test_clean_page1_incomplete_read_fails_closed(self, guard_module):
+        # Newest verdict is clean, but a later page failed → cannot confirm no newer
+        # finding. Fail-closed (PR #1434): the incomplete read BLOCKS, not a silent pass.
+        def se():
+            return [_codex_page_newest("chatgpt-codex-connector[bot]", "VERDICT: PASS"),
+                    subprocess.TimeoutExpired(cmd="gh", timeout=8)]
+        with patch.object(guard_module.subprocess, "run", side_effect=se()):
+            block, msg = guard_module._check_pr_review_findings("100")
+        assert block is True
+        assert "unreadable" in msg.lower()
+
+
+class TestInlinePaginationRobustness:
+    """Inline scanner shares the paged fetch: NEL bodies parse, and a P1 on an early
+    page survives a later-page failure; no-P1 + incomplete read fails closed in strict."""
+
+    def _codex(self, cid, body, reply_to=None):
+        return {"id": cid, "reply_to": reply_to, "login": "chatgpt-codex-connector[bot]",
+                "type": "Bot", "body": body}
+
+    def test_nel_in_inline_p1_parses_and_blocks(self, guard_module):
+        c = self._codex(1, _P1_BODY.replace("Details here.", "Details" + _NEL + "here."))
+        line = json.dumps(c, ensure_ascii=False)
+        assert "" + _NEL + "" in line
+        with patch.object(guard_module.subprocess, "run",
+                          return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=line, stderr="")):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block
+
+    def test_p1_on_page1_survives_later_page_timeout(self, guard_module):
+        rows = [json.dumps(self._codex(i, "note")) for i in range(99)]
+        rows.append(json.dumps(self._codex(99, _P1_BODY)))  # newest, full page → fetch p2
+        with patch.object(guard_module.subprocess, "run",
+                          side_effect=[_cp(rows), subprocess.TimeoutExpired(cmd="gh", timeout=8)]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block
+
+    def test_no_p1_incomplete_read_fails_closed(self, guard_module):
+        rows = [json.dumps(self._codex(i, "just a note")) for i in range(100)]  # full page, no P1
+        def se():
+            return [_cp(rows), subprocess.TimeoutExpired(cmd="gh", timeout=8)]
+        # No P1 seen, but a later page failed → cannot confirm absence. Fail-closed
+        # (PR #1434): the incomplete read BLOCKS.
+        with patch.object(guard_module.subprocess, "run", side_effect=se()):
+            block, msg = guard_module._check_inline_review_findings("100")
+        assert block is True
+        assert "unreadable" in msg.lower()

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -759,9 +759,12 @@ class TestCheckPrReviewFindings:
     """Unit tests for _check_pr_review_findings()."""
 
     def _make_gh_output(self, comments: list[tuple[str, str, str]]) -> str:
-        """Build mock gh api JSON output: [{login, type, body}, ...]."""
-        return json.dumps(
-            [{"login": login, "type": utype, "body": body} for login, utype, body in comments]
+        """Build mock ``gh api --paginate --jq '.[] | {…}'`` output: one compact
+        JSON object per line (JSONL), matching the per-element jq the code now
+        uses. An empty list yields "" (gh emits nothing for zero comments)."""
+        return "\n".join(
+            json.dumps({"login": login, "type": utype, "body": body})
+            for login, utype, body in comments
         )
 
     def test_no_comments_allows_merge(self, guard_module):
@@ -776,6 +779,34 @@ class TestCheckPrReviewFindings:
             should_block, msg = guard_module._check_pr_review_findings("100")
         assert not should_block
         assert msg == ""
+
+    def test_paginated_multiline_findings_parsed_and_blocked(self, guard_module):
+        """Regression: issues/N/comments must be fetched with --paginate and
+        parsed as per-line JSONL.
+
+        Without --paginate a [P1]/ERROR beyond the first REST page (30 comments)
+        was silently dropped and the merge — this scan runs on the live merge
+        path with strict=False — sailed through; the old whole-body json.loads
+        also choked on the JSONL that --paginate emits (→ _scan_unreadable →
+        fail-open). Feed a multi-line JSONL response whose most-recent comment
+        carries an ERROR and assert the gate blocks AND that --paginate is
+        actually requested.
+        """
+        output = self._make_gh_output(
+            [
+                ("chatgpt-codex-connector[bot]", "Bot", "## Structural Review\n\nEarlier note."),
+                ("chatgpt-codex-connector[bot]", "Bot", "### ERROR — raw SQL in production code"),
+            ]
+        )
+        assert "\n" in output  # guard: genuinely multi-line JSONL, not a single array blob
+        with patch.object(guard_module.subprocess, "run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=output, stderr="",
+            )
+            should_block, _ = guard_module._check_pr_review_findings("100")
+            gh_argv = mock_run.call_args.args[0]
+        assert should_block
+        assert "--paginate" in gh_argv
 
     def test_clean_review_allows_merge(self, guard_module):
         """Review comment with CLEAN verdict → allow."""
@@ -1023,10 +1054,10 @@ class TestCheckPrReviewFindings:
 
     def test_null_body_fails_open(self, guard_module):
         """GitHub API returning body: null should not crash."""
+        # JSONL (one object per line) to match the per-element --jq the code uses;
+        # body: null must coerce to "" rather than crash.
         output = json.dumps(
-            [
-                {"login": "chatgpt-codex-connector[bot]", "type": "Bot", "body": None},
-            ]
+            {"login": "chatgpt-codex-connector[bot]", "type": "Bot", "body": None}
         )
         with patch.object(guard_module.subprocess, "run") as mock_run:
             mock_run.return_value = subprocess.CompletedProcess(
@@ -2019,10 +2050,12 @@ class TestStrictScanMode:
 
     def test_body_empty_is_clean_even_when_strict(self, guard_module):
         # Empty (quota / no comments) is NOT an error — clean in both modes.
+        # Under `--paginate --jq '.[] | {…}'` gh emits nothing (not "[]") for
+        # zero comments, so the empty output is an empty string.
         with patch.object(
             guard_module.subprocess,
             "run",
-            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="[]"),
+            return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=""),
         ):
             block, _ = guard_module._check_pr_review_findings("1", strict=True)
         assert block is False


### PR DESCRIPTION
## Problem

The merge-review gate could **fail open**. The finding scanners
(`_check_pr_review_findings` / `_check_inline_review_findings`) ran on the live
merge path with `strict=False`, so any scan that could not be *completed* returned
"clean" and the merge proceeded:

- the review-body scan fetched only the first REST page (a `[P1]`/ERROR on page 2+
  was silently dropped);
- a comment-flood, a budget-starved scan, GitHub secondary rate-limiting, or a
  page-cap hit all terminated the scan early → treated as clean.

The Codex freshness gate reads a different surface (the Reviews API) and did not
catch this.

## Fix

**Fail-closed is now the only mode.** The `strict` parameter is removed entirely —
an unreadable or incomplete scan **always blocks**, on both the merge path and the
`--check-pr` report, with `# review-override` as the conscious escape hatch.

- `_fetch_comments_paged` paginates all pages (NEL-safe, non-dict lines dropped),
  checks the shared merge deadline **between pages** (so a flood of fast-succeeding
  pages can't blow the hook's wall-clock — which a SIGKILL would turn into an
  external fail-open), and treats an all-lines-unparseable page as unreadable.
- An inline **P1** finding is "acknowledged" only by a reply from a **maintainer**
  (`author_association` OWNER/MEMBER/COLLABORATOR) — previously any account's reply
  could silence it.
- The inline scanner fetches **newest-first** (`pulls/comments` honors
  `sort`/`direction`), so a partial read surfaces the most recent findings first.
- Removed the now-vestigial `strict` from the scheduled-review gate (its only
  justification was parity with the finding scanners).

## Verification

- Full `tests/test_hooks/` suite: **1565 passed**.
- `genesis-security-reviewer`: **CONFIRMED** the fail-open CRITICAL is closed with no
  new holes; a HIGH (unbounded flood wall-clock) and a LOW (garbage-page masquerade)
  found mid-review were both fixed and re-confirmed.
- `genesis-architect`: clean after the `strict` cleanup.
- verify-RED on every new behavior (fail-closed flip, maintainer gating, newest-first,
  deadline + garbage guards).

Follow-up: c26f4543cda74f1da63d956f751c50bd