### PR TITLE
fix(dashboard): empty-state loading gates for 5 low-traffic panels

### DIFF
--- a/src/genesis/dashboard/templates/partials/tabs/campaigns.html
+++ b/src/genesis/dashboard/templates/partials/tabs/campaigns.html
@@ -14,7 +14,13 @@
           Pause/resume, run one now, or edit cadence, model, effort, daily cap and jitter.
         </div>
 
-        <template x-if="$store.genesisDashboard.campaignsList.length === 0">
+        <template x-if="$store.genesisDashboard.panelState('campaigns') === 'loading'">
+          <div style="color: var(--color-text-secondary); padding: 1rem 0;">Loading…</div>
+        </template>
+        <template x-if="$store.genesisDashboard.panelState('campaigns') === 'error'">
+          <div style="color: #f0ad4e; padding: 1rem 0;">Couldn't load campaigns — will keep retrying.</div>
+        </template>
+        <template x-if="$store.genesisDashboard.campaignsList.length === 0 && !['loading','error'].includes($store.genesisDashboard.panelState('campaigns'))">
           <div style="color: var(--color-text-secondary); padding: 1rem 0;">No campaigns.</div>
         </template>
 

--- a/src/genesis/dashboard/templates/partials/tabs/knowledge.html
+++ b/src/genesis/dashboard/templates/partials/tabs/knowledge.html
@@ -45,7 +45,13 @@
               </template>
             </div>
           </template>
-          <template x-if="$store.genesisDashboard.watchlistEntries.length === 0">
+          <template x-if="$store.genesisDashboard.panelState('watchlist') === 'loading'">
+            <div style="font-size:0.74rem; color:var(--color-text-secondary); padding:0.5rem;">Loading…</div>
+          </template>
+          <template x-if="$store.genesisDashboard.panelState('watchlist') === 'error'">
+            <div style="font-size:0.74rem; color:#f0ad4e; padding:0.5rem;">Couldn't load tracked repositories — reload to retry.</div>
+          </template>
+          <template x-if="$store.genesisDashboard.watchlistEntries.length === 0 && !['loading','error'].includes($store.genesisDashboard.panelState('watchlist'))">
             <div style="font-size:0.74rem; color:var(--color-text-secondary); padding:0.5rem;">No tracked repositories loaded.</div>
           </template>
         </div>
@@ -280,7 +286,13 @@
 
       <!-- Recent Units -->
       <h4 style="margin-bottom: .5rem;">Recent Knowledge Units</h4>
-      <template x-if="$store.genesisDashboard.knowledgeRecent.length === 0">
+      <template x-if="$store.genesisDashboard.panelState('knowledgeRecent') === 'loading'">
+        <p style="color: var(--color-text-secondary);">Loading…</p>
+      </template>
+      <template x-if="$store.genesisDashboard.panelState('knowledgeRecent') === 'error'">
+        <p style="color: #f0ad4e;">Couldn't load knowledge units — reload to retry.</p>
+      </template>
+      <template x-if="$store.genesisDashboard.knowledgeRecent.length === 0 && !['loading','error'].includes($store.genesisDashboard.panelState('knowledgeRecent'))">
         <p style="color: var(--color-text-secondary);">No knowledge units ingested yet.</p>
       </template>
       <div style="display: flex; flex-direction: column; gap: .5rem;">

--- a/src/genesis/dashboard/templates/partials/tabs/overview.html
+++ b/src/genesis/dashboard/templates/partials/tabs/overview.html
@@ -1192,7 +1192,13 @@
 
         <!-- Capability Modules -->
         <h4 style="margin: 0 0 0.5rem 0; color: #ccc; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em;">Capability Modules</h4>
-        <template x-if="$store.genesisDashboard.modules.length === 0">
+        <template x-if="$store.genesisDashboard.panelState('modules') === 'loading'">
+          <div class="empty-state">Loading…</div>
+        </template>
+        <template x-if="$store.genesisDashboard.panelState('modules') === 'error'">
+          <div class="empty-state" style="color:#f0ad4e;">Couldn't load modules — will keep retrying.</div>
+        </template>
+        <template x-if="$store.genesisDashboard.modules.length === 0 && !['loading','error'].includes($store.genesisDashboard.panelState('modules'))">
           <div class="empty-state">No modules loaded.</div>
         </template>
         <template x-for="mod in $store.genesisDashboard.modules" :key="mod.name">
@@ -1241,7 +1247,13 @@
 
         <!-- Tool Providers -->
         <h4 style="margin: 1rem 0 0.5rem 0; color: #ccc; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.05em;">Tool Providers</h4>
-        <template x-if="$store.genesisDashboard.providersDetail.length === 0">
+        <template x-if="$store.genesisDashboard.panelState('providersDetail') === 'loading'">
+          <div class="empty-state">Loading…</div>
+        </template>
+        <template x-if="$store.genesisDashboard.panelState('providersDetail') === 'error'">
+          <div class="empty-state" style="color:#f0ad4e;">Couldn't load providers — will keep retrying.</div>
+        </template>
+        <template x-if="$store.genesisDashboard.providersDetail.length === 0 && !['loading','error'].includes($store.genesisDashboard.panelState('providersDetail'))">
           <div class="empty-state">No providers registered.</div>
         </template>
         <div style="display: grid; gap: 0.3rem;">

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -349,6 +349,9 @@
           comms: { state: "idle", lastSuccess: null, error: null },
           autonomyGrants: { state: "idle", lastSuccess: null, error: null },
           autonomySends: { state: "idle", lastSuccess: null, error: null },
+          campaigns: { state: "idle", lastSuccess: null, error: null },
+          watchlist: { state: "idle", lastSuccess: null, error: null },
+          knowledgeRecent: { state: "idle", lastSuccess: null, error: null },
         },
 
         // Polling interval IDs
@@ -432,13 +435,20 @@
 
         // ── Campaigns ──
         async fetchCampaigns() {
+          this.startFetch("campaigns");
           try {
             const resp = await fetchApi("/api/genesis/campaigns/list");
             if (resp && resp.ok) {
               const data = await resp.json();
               this.campaignsList = data.campaigns || [];
+              this.finishFetch("campaigns");
+            } else {
+              this.failFetch("campaigns", "Campaigns endpoint returned an error");
             }
-          } catch (e) { console.warn("fetchCampaigns failed:", e); }
+          } catch (e) {
+            console.warn("fetchCampaigns failed:", e);
+            this.failFetch("campaigns", "Failed to fetch campaigns");
+          }
         },
         async openCampaignDetail(name) {
           try {
@@ -1569,13 +1579,20 @@
 
         // ── Knowledge tab fetches ──────────────────────────────────
         async fetchKnowledgeRecent() {
+          this.startFetch("knowledgeRecent");
           try {
             const resp = await fetchApi("/api/genesis/knowledge/recent?limit=50");
             if (resp && resp.ok) {
               const data = await resp.json();
               this.knowledgeRecent = data.units || [];
+              this.finishFetch("knowledgeRecent");
+            } else {
+              this.failFetch("knowledgeRecent", "Knowledge-recent endpoint returned an error");
             }
-          } catch (e) { console.warn("Knowledge recent failed:", e); }
+          } catch (e) {
+            console.warn("Knowledge recent failed:", e);
+            this.failFetch("knowledgeRecent", "Failed to fetch recent knowledge");
+          }
         },
         async fetchKnowledgeStats() {
           try {
@@ -1585,10 +1602,19 @@
         },
         // ── Tracked repositories (recon watchlist) ──────────────────
         async fetchWatchlist() {
+          this.startFetch("watchlist");
           try {
             const resp = await fetchApi("/api/genesis/recon/watchlist");
-            if (resp && resp.ok) { this.watchlistEntries = (await resp.json()).entries || []; }
-          } catch (e) { console.warn("Watchlist fetch failed:", e); }
+            if (resp && resp.ok) {
+              this.watchlistEntries = (await resp.json()).entries || [];
+              this.finishFetch("watchlist");
+            } else {
+              this.failFetch("watchlist", "Watchlist endpoint returned an error");
+            }
+          } catch (e) {
+            console.warn("Watchlist fetch failed:", e);
+            this.failFetch("watchlist", "Failed to fetch watchlist");
+          }
         },
         async addWatchlistRepo() {
           this.watchlistSaving = true; this.watchlistMsg = null;


### PR DESCRIPTION
Extend the shipped P4 empty-state pattern (reference: the observations panel) to the remaining panels that flashed a false "No X" while their fetch was still in flight: campaigns, tracked repositories (watchlist), recent knowledge units, modules, and providers.

- `dashboard.js`: register `fetchState` entries for campaigns/watchlist/knowledgeRecent and wire `startFetch`/`finishFetch`/`failFetch` into their fetch functions (mirroring `fetchObservations`). modules/providersDetail were already wired — template-only there.
- templates: add `Loading…` and error rows and gate each `length === 0` empty state on `!['loading','error'].includes(panelState('<name>'))` so the empty state shows only after a successful fetch returns zero items.

watchlist and recent-knowledge are fetched once on tab open (no poll), so their error copy says "reload to retry" rather than the "will keep retrying" used by the polled panels — an accurate promise per panel.

Follow-up: 143f54a1f2a34a5b9b10b89ad34ef71e

🤖 Generated with [Claude Code](https://claude.com/claude-code)