### PR TITLE
feat(dashboard): page-top banner when backups are unconfigured or failing

### DIFF
--- a/src/genesis/dashboard/templates/partials/chrome/header.html
+++ b/src/genesis/dashboard/templates/partials/chrome/header.html
@@ -148,3 +148,9 @@
         <button @click="$store.genesisDashboard.pwNudgeDismissed = true" title="Dismiss" style="background:none;border:none;color:var(--color-text-secondary,#888);cursor:pointer;font-size:1rem;line-height:1;">✕</button>
       </div>
     </template>
+    <!-- Backup-status banner: shows when backups are unconfigured, have never run, or
+         the last run failed; hidden when healthy. Source: /api/genesis/backup/status. -->
+    <template x-if="$store.genesisDashboard.backupBanner()">
+      <div :style="`background:${$store.genesisDashboard.backupBanner().bg}; border:1px solid ${$store.genesisDashboard.backupBanner().border}; border-radius:6px; padding:0.5rem 1rem; margin:0.25rem 0.5rem; font-size:0.82rem; font-weight:600; color:${$store.genesisDashboard.backupBanner().color}; text-align:center;`"
+           x-text="'💾 ' + $store.genesisDashboard.backupBanner().text"></div>
+    </template>

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -1948,12 +1948,15 @@
             return { ...crit, text: 'The last backup run failed' + (lb.failure_reason ? ' (' + lb.failure_reason + ')' : '') + ' — check the Backup tab.' };
           }
 
-          // 2. Not configured. Key on the SAVED repo setting (backupConfig.repo),
-          //    an existing clone, or a prior run — NOT status.repo alone (null until
-          //    a clone exists, so a saved-but-not-yet-cloned repo would wrongly read
-          //    as unconfigured), and NOT status.configured (that is just "the backup
+          // 2. Not configured. Key on the SAVED repo setting (backupConfig.repo) or
+          //    an existing clone (status.repo_configured / status.repo) — CURRENT
+          //    configuration signals only. NOT a prior run (last_backup): a stale
+          //    successful record survives clone/secrets removal, and backup.sh cannot
+          //    recreate the clone without the repo setting, so a lingering run must not
+          //    mask the unconfigured state (Codex P2, round 4). NOT status.repo alone
+          //    (null until a clone exists), and NOT status.configured (just "the backup
           //    script is installed" — true on every install, so it never fires).
-          const configured = !!((cfg && cfg.repo) || bs.repo_configured || bs.repo || lb);
+          const configured = !!((cfg && cfg.repo) || bs.repo_configured || bs.repo);
           if (!configured) {
             return { ...warn, text: 'Backups are not configured — your data is not being backed up. Set one up on the Backup tab.' };
           }
@@ -2058,27 +2061,39 @@
           } catch (e) { alert("Trigger failed: " + e.message); }
         },
         async fetchBackupConfig() {
-          try {
-            const resp = await fetchApi("/api/genesis/backup/config");
-            if (resp && resp.ok) {
-              const c = await resp.json();
-              this.backupConfig = c;
-              const f = this.backupConfigForm;
-              f.repo = c.repo || '';
-              f.tier2_backend = c.tier2_backend || 'none';
-              f.local_path = c.local_path || '';
-              f.nas = c.nas || '';
-              f.nas_user = c.nas_user || '';
-              // A "custom"/null server interval can't be a preset dropdown value;
-              // default the control to 6h but DON'T mark dirty, so a plain Save
-              // never rewrites a hand-edited schedule (scheduleDirty gates it).
-              f.schedule_interval = (c.schedule_interval && c.schedule_interval !== 'custom')
-                ? c.schedule_interval : '6h';
-              f.schedule_enabled = c.schedule_enabled !== false;
-              this.scheduleDirty = false;   // loaded state is not a user change
-              // passphrase / nas_pass are write-only — never populated.
-            }
-          } catch (e) { console.warn("Backup config fetch failed:", e); }
+          // Single-flight guard: onOpen() (every page open) and Backup-tab activation
+          // both call this, so two responses can be in flight at once. Each rewrites
+          // every form field and resets scheduleDirty below, so a slower duplicate
+          // landing after the user starts editing would silently discard those edits.
+          // Coalesce concurrent callers onto one in-flight request → the form hydrates
+          // exactly once per open. Does NOT cache: the guard clears on completion, so a
+          // later explicit refresh (e.g. post-save re-fetch) still runs fresh.
+          if (this._backupConfigFetch) return this._backupConfigFetch;
+          this._backupConfigFetch = (async () => {
+            try {
+              const resp = await fetchApi("/api/genesis/backup/config");
+              if (resp && resp.ok) {
+                const c = await resp.json();
+                this.backupConfig = c;
+                const f = this.backupConfigForm;
+                f.repo = c.repo || '';
+                f.tier2_backend = c.tier2_backend || 'none';
+                f.local_path = c.local_path || '';
+                f.nas = c.nas || '';
+                f.nas_user = c.nas_user || '';
+                // A "custom"/null server interval can't be a preset dropdown value;
+                // default the control to 6h but DON'T mark dirty, so a plain Save
+                // never rewrites a hand-edited schedule (scheduleDirty gates it).
+                f.schedule_interval = (c.schedule_interval && c.schedule_interval !== 'custom')
+                  ? c.schedule_interval : '6h';
+                f.schedule_enabled = c.schedule_enabled !== false;
+                this.scheduleDirty = false;   // loaded state is not a user change
+                // passphrase / nas_pass are write-only — never populated.
+              }
+            } catch (e) { console.warn("Backup config fetch failed:", e); }
+            finally { this._backupConfigFetch = null; }
+          })();
+          return this._backupConfigFetch;
         },
         async saveBackupConfig() {
           this.backupConfigSaving = true;

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -353,6 +353,7 @@
 
         // Polling interval IDs
         _healthInterval: null,
+        _backupInterval: null,
         _activityInterval: null,
 
         _sessionsInterval: null,
@@ -656,6 +657,12 @@
 
           this.loading = false;
 
+          // Fire-and-forget: drives the page-top backup banner. Must NOT gate initial
+          // paint — the /backup/status route shells out to git + systemctl, and
+          // backupBanner() is null-safe until backupStatus resolves (banner just
+          // appears once it does).
+          this.fetchBackupStatus();
+
           // Always-on polling: health snapshot drives the attention strip on all tabs.
           // Uses probabilistic skip when server is failing to reduce load during
           // recovery (exponential backoff is in api.js; this reduces poll frequency).
@@ -671,10 +678,17 @@
             this.fetchEgoStatus();
             this.fetchObservationsSummary();
           }, 15000);
+
+          // Backup status changes slowly (6h cadence) and its route shells out to
+          // systemctl, so refresh the banner on a slow, separate cadence rather than
+          // the 15s health poll — catches an unattended scheduled-backup failure
+          // without a reload, at negligible cost.
+          this._backupInterval = setInterval(() => this.fetchBackupStatus(), 180000);
         },
 
         cleanup() {
           if (this._healthInterval) clearInterval(this._healthInterval);
+          if (this._backupInterval) clearInterval(this._backupInterval);
           for (const tab of ["overview", "chat", "internals", "config", "work", "observations", "traces", "autonomy"]) {
             this._stopTabIntervals(tab);
           }
@@ -1907,6 +1921,21 @@
           // start) — the timer won't fire, so "Active" would misreport. Say so.
           if (!active) return { text: 'Scheduled, but the timer is not running', color: '#ffb74d' };
           return { text: 'Active', color: '#81c784' };
+        },
+        // Page-top banner: surface a barren/failed backup state on every tab so it
+        // isn't invisible. Returns a styled {text,color,bg,border} for a problem
+        // state (unconfigured / never-run / last run failed), or null when backups
+        // are healthy (banner hidden). Reads /api/genesis/backup/status.
+        backupBanner() {
+          const bs = this.backupStatus;
+          if (!bs) return null;  // not loaded yet — no banner
+          const lb = bs.last_backup;
+          const warn = { color: '#f0ad4e', bg: 'rgba(240,173,78,0.15)', border: '#f0ad4e' };
+          const crit = { color: '#d9534f', bg: 'rgba(217,83,79,0.15)', border: '#d9534f' };
+          if (!bs.repo) return { ...warn, text: 'Backups are not configured — your data is not being backed up. Set one up on the Backup tab.' };
+          if (!lb) return { ...warn, text: 'Backups are configured but have never run — check the Backup tab.' };
+          if (!lb.success) return { ...crit, text: 'The last backup run failed' + (lb.failure_reason ? ' (' + lb.failure_reason + ')' : '') + ' — check the Backup tab.' };
+          return null;  // healthy (active / scheduled / on-demand) — no banner
         },
         // "every 6 hours · last 12:10 PM ✓ · next 6:10 PM" — the at-a-glance line.
         backupScheduleLine() {

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -660,8 +660,12 @@
           // Fire-and-forget: drives the page-top backup banner. Must NOT gate initial
           // paint — the /backup/status route shells out to git + systemctl, and
           // backupBanner() is null-safe until backupStatus resolves (banner just
-          // appears once it does).
+          // appears once it does). fetchBackupConfig() runs here too (not only on the
+          // Backup tab) so the banner's "configured" check can see the SAVED repo
+          // setting (backupConfig.repo) on every tab — otherwise a saved-but-not-yet-
+          // cloned repo would read as unconfigured until the Backup tab is opened.
           this.fetchBackupStatus();
+          this.fetchBackupConfig();
 
           // Always-on polling: health snapshot drives the attention strip on all tabs.
           // Uses probabilistic skip when server is failing to reduce load during
@@ -1923,10 +1927,11 @@
           return { text: 'Active', color: '#81c784' };
         },
         // Page-top banner: surface a barren/failed backup state on every tab so it
-        // isn't invisible. Returns a styled {text,color,bg,border} for a problem
-        // state, or null when backups are healthy (banner hidden). Mirrors the
-        // states backupHeadline() models, with correct precedence (a recorded
-        // FAILURE outranks "unconfigured"). Reads /api/genesis/backup/{status,config}.
+        // isn't invisible. Returns a styled {text,color,bg,border} for a problem state
+        // (failure, unconfigured, never-run, stopped/overdue timer, stale backup,
+        // incomplete off-site), or null when the backup is healthy or a deliberate
+        // on-demand run is recent. Precedence: a recorded FAILURE outranks
+        // "unconfigured". Reads /api/genesis/backup/{status,config}.
         backupBanner() {
           const bs = this.backupStatus;
           if (!bs) return null;  // status not loaded yet — no banner
@@ -1965,15 +1970,22 @@
             return { ...warn, text: 'Backups are scheduled but the timer is not running — unattended backups have stopped. Check the Backup tab.' };
           }
 
-          // 5. Scheduled and active, but the last success is far past the interval —
-          //    the timer is wedged / not firing. Conservative threshold (2 missed
-          //    cycles + 1h grace); skipped when the interval is unknown so a custom
-          //    schedule never false-alarms.
+          // 5. Staleness floor: the last successful backup is too old. This does NOT
+          //    require an enabled schedule — an abandoned backup on a disabled or
+          //    custom schedule is exactly the silent-failure state the banner targets.
+          //    (backupHeadline shows "on demand only" for a disabled schedule; a
+          //    banner would over-nag every unscheduled install, so we warn ONLY once
+          //    genuinely stale.) Floor = 2 missed cycles + 1h grace for a known
+          //    interval, else a conservative 7-day floor (unscheduled / custom /
+          //    unknown interval). Also subsumes the wedged-active-timer case.
           const intervalHours = { '3h': 3, '6h': 6, '12h': 12, daily: 24 }[sch && sch.interval];
-          if (sch && sch.enabled && intervalHours && lb.timestamp) {
+          if (lb.timestamp) {
             const ageH = (Date.now() - new Date(lb.timestamp).getTime()) / 3600000;
-            if (ageH > intervalHours * 2 + 1) {
-              return { ...warn, text: 'Backups are overdue — the last successful backup was about ' + Math.round(ageH) + 'h ago, well past the ' + intervalHours + 'h schedule. Check the Backup tab.' };
+            const scheduled = !!(sch && sch.enabled && intervalHours);
+            const floorH = scheduled ? intervalHours * 2 + 1 : 24 * 7;
+            if (ageH > floorH) {
+              const detail = scheduled ? ', well past the ' + intervalHours + 'h schedule' : '';
+              return { ...warn, text: 'Backups are overdue — the last successful backup was about ' + Math.round(ageH) + 'h ago' + detail + '. Check the Backup tab.' };
             }
           }
 
@@ -1989,9 +2001,15 @@
 
           // 7. Off-site (Tier-2) copy is configured but the last run did not complete
           //    it: the local backup succeeded but the off-site recovery copy is
-          //    incomplete (tier2_status != 'ok' or offsite_confirmed === false).
-          if (lb.tier2_backend && lb.tier2_backend !== 'none' &&
-              (lb.tier2_status !== 'ok' || lb.offsite_confirmed === false)) {
+          //    incomplete. Read the RESOLVED destination (bs.destinations.tier2, whose
+          //    backend falls back to _resolved_backend() in backup.py), NOT the raw
+          //    last_backup.tier2_backend — a legacy status file predating that field
+          //    would otherwise skip the warning even while a configured NAS is
+          //    incomplete. Require an explicit incompleteness signal (a non-ok status
+          //    or offsite_confirmed === false) so an info-less legacy record stays quiet.
+          const t2 = bs.destinations && bs.destinations.tier2;
+          if (t2 && t2.backend && t2.backend !== 'none' &&
+              ((t2.status && t2.status !== 'ok') || t2.confirmed === false)) {
             return { ...warn, text: 'The off-site backup copy is incomplete — your local backup succeeded but the off-site copy did not finish. Check the Backup tab.' };
           }
 

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -1924,18 +1924,78 @@
         },
         // Page-top banner: surface a barren/failed backup state on every tab so it
         // isn't invisible. Returns a styled {text,color,bg,border} for a problem
-        // state (unconfigured / never-run / last run failed), or null when backups
-        // are healthy (banner hidden). Reads /api/genesis/backup/status.
+        // state, or null when backups are healthy (banner hidden). Mirrors the
+        // states backupHeadline() models, with correct precedence (a recorded
+        // FAILURE outranks "unconfigured"). Reads /api/genesis/backup/{status,config}.
         backupBanner() {
           const bs = this.backupStatus;
-          if (!bs) return null;  // not loaded yet — no banner
+          if (!bs) return null;  // status not loaded yet — no banner
           const lb = bs.last_backup;
+          const sch = bs.schedule;
+          const cfg = this.backupConfig;
           const warn = { color: '#f0ad4e', bg: 'rgba(240,173,78,0.15)', border: '#f0ad4e' };
           const crit = { color: '#d9534f', bg: 'rgba(217,83,79,0.15)', border: '#d9534f' };
-          if (!bs.repo) return { ...warn, text: 'Backups are not configured — your data is not being backed up. Set one up on the Backup tab.' };
-          if (!lb) return { ...warn, text: 'Backups are configured but have never run — check the Backup tab.' };
-          if (!lb.success) return { ...crit, text: 'The last backup run failed' + (lb.failure_reason ? ' (' + lb.failure_reason + ')' : '') + ' — check the Backup tab.' };
-          return null;  // healthy (active / scheduled / on-demand) — no banner
+
+          // 1. A recorded FAILURE outranks everything — a failed run (including a
+          //    failed initial clone) is the most urgent state and must not be
+          //    masked by the "unconfigured" check below.
+          if (lb && lb.success === false) {
+            return { ...crit, text: 'The last backup run failed' + (lb.failure_reason ? ' (' + lb.failure_reason + ')' : '') + ' — check the Backup tab.' };
+          }
+
+          // 2. Not configured. Key on the SAVED repo setting (backupConfig.repo),
+          //    an existing clone, or a prior run — NOT status.repo alone (null until
+          //    a clone exists, so a saved-but-not-yet-cloned repo would wrongly read
+          //    as unconfigured), and NOT status.configured (that is just "the backup
+          //    script is installed" — true on every install, so it never fires).
+          const configured = !!((cfg && cfg.repo) || bs.repo_configured || bs.repo || lb);
+          if (!configured) {
+            return { ...warn, text: 'Backups are not configured — your data is not being backed up. Set one up on the Backup tab.' };
+          }
+
+          // 3. Configured, but no backup has ever run.
+          if (!lb) {
+            return { ...warn, text: 'Backups are configured but have never run — check the Backup tab.' };
+          }
+
+          // 4. Scheduled but the timer is not running (stopped out-of-band / failed
+          //    to start): unattended backups have silently stopped even though the
+          //    last run succeeded.
+          if (sch && sch.enabled && !sch.active) {
+            return { ...warn, text: 'Backups are scheduled but the timer is not running — unattended backups have stopped. Check the Backup tab.' };
+          }
+
+          // 5. Scheduled and active, but the last success is far past the interval —
+          //    the timer is wedged / not firing. Conservative threshold (2 missed
+          //    cycles + 1h grace); skipped when the interval is unknown so a custom
+          //    schedule never false-alarms.
+          const intervalHours = { '3h': 3, '6h': 6, '12h': 12, daily: 24 }[sch && sch.interval];
+          if (sch && sch.enabled && intervalHours && lb.timestamp) {
+            const ageH = (Date.now() - new Date(lb.timestamp).getTime()) / 3600000;
+            if (ageH > intervalHours * 2 + 1) {
+              return { ...warn, text: 'Backups are overdue — the last successful backup was about ' + Math.round(ageH) + 'h ago, well past the ' + intervalHours + 'h schedule. Check the Backup tab.' };
+            }
+          }
+
+          // 6. Tier-1 (GitHub) push did not complete — the last run's local backup
+          //    succeeded but commits are not replicated to the remote. Reachable with
+          //    success === true: a prior run's push failed, and today's run had
+          //    nothing new to commit, so no failure_reason is set (backup.sh). The
+          //    primary off-site replica is stale. Strict === false so a legacy status
+          //    file lacking the field never false-fires.
+          if (lb.tier1_pushed === false) {
+            return { ...warn, text: 'Backups are not fully replicated to GitHub — the last run succeeded locally but commits are not pushed to the remote. Check the Backup tab.' };
+          }
+
+          // 7. Off-site (Tier-2) copy is configured but the last run did not complete
+          //    it: the local backup succeeded but the off-site recovery copy is
+          //    incomplete (tier2_status != 'ok' or offsite_confirmed === false).
+          if (lb.tier2_backend && lb.tier2_backend !== 'none' &&
+              (lb.tier2_status !== 'ok' || lb.offsite_confirmed === false)) {
+            return { ...warn, text: 'The off-site backup copy is incomplete — your local backup succeeded but the off-site copy did not finish. Check the Backup tab.' };
+          }
+
+          return null;  // healthy — no banner
         },
         // "every 6 hours · last 12:10 PM ✓ · next 6:10 PM" — the at-a-glance line.
         backupScheduleLine() {


### PR DESCRIPTION
Backup health had no page-level visibility — a barren or failing backup state was only apparent on the Backup tab. Add a persistent header banner (reusing the existing system-banner pattern) that surfaces on every tab when backups are unconfigured, have never run, or the last run failed, and stays hidden when backups are healthy.

- `dashboard.js`: `backupBanner()` computed returns a styled `{text,color,bg,border}` for a problem state or null when healthy (null-safe before the first fetch, so no flash). Fetched fire-and-forget on load (NOT awaited — the `/backup/status` route shells out to git + systemctl, and must not gate initial paint) plus a slow 180s refresh so an unattended scheduled-backup failure surfaces without a reload.
- `header.html`: the banner template, warn (unconfigured / never-run) vs crit (last run failed) styling.

Data comes from the existing `/api/genesis/backup/status` route (no backend change). Message text is rendered via `x-text` (no HTML injection).

Follow-up: c50d288254244ddfaf9a8165e44aaec9

🤖 Generated with [Claude Code](https://claude.com/claude-code)