### PR TITLE
feat(hooks): hook-surface merge teeth — Codex-at-head required, evidence-gated override

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -538,7 +538,7 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   `.claude/settings.json`, `.claude/hooks/**`) is the guard code itself: the merge gate
   (1) never classifies its stale-review delta as "review-trivial", and (2) refuses
   `# stale-review-override` unless recorded fallback-review evidence exists for the
-  EXACT head sha (`~/.genesis/override_review_evidence/<repo>__<pr>__<sha>.txt`). The override
+  EXACT head sha (`~/.genesis/override_review_evidence/<repo>__<pr>__<base12>__<sha>.txt`). The override
   procedure requires the user's explicit authorization, then a fallback adversarial
   review (local `codex exec` when quota allows, else genesis-architect), evidence
   recorded, then the merge re-run — the gate's block message walks through it.

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -526,22 +526,37 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   — ONLY.** This runs the SAME code path as the merge gate (strict fail-closed: a
   failed scan is never reported clean). NEVER hand-roll a `gh api pulls/N/comments`
   query to decide whether a PR is review-clean: a wrong filter's EMPTY result reads
-  exactly like "clean". Origin (2026-08-23, #1431/#1432): inline findings are authored
-  by `chatgpt-codex-connector[bot]` — WITH the `[bot]` suffix — while the review-summary
-  author has no suffix; a no-suffix filter returned empty and 13 real findings (10 P1)
-  were reported to the user as "review-clean" until the merge gate blocked. An empty
-  result from your own query is "my query found nothing", never "no findings exist".
-  Reviewed-SHA must equal the PR's current HEAD (the report checks this too).
+  exactly like "clean". Origin (2026-08-23, #1431/#1432): Codex authors BOTH its inline
+  findings AND its review-summary body as `chatgpt-codex-connector[bot]` — the REST
+  `user.login`, WITH the `[bot]` suffix. A hand-rolled filter keyed on a DIFFERENT login
+  (the GraphQL app login, which is not the REST login) matched nothing, and 13 real
+  findings (10 P1) were reported to the user as "review-clean" until the merge gate
+  blocked. An empty result from your own query is "my query found nothing", never "no
+  findings exist". Freshness is a SEPARATE gate, and it is NOT a blanket
+  reviewed-SHA-equals-HEAD rule: for a hook-surface or otherwise non-trivial delta a
+  current Codex review must COVER head (reviews-API `commit_id == head`, or a clean Codex
+  re-review comment naming head), but a trivial NON-hook delta may still merge on a stale
+  review — `--check-pr` reports that as `codex-at-head : ok (STALE review of <sha>, delta
+  since is trivial)`, a pass, not a block.
 - **Hook-surface PRs merge only with a current GitHub Codex review — mechanical.**
-  A PR touching the enforcement-hook surface (`scripts/hooks/**`,
-  `scripts/bash_safety_hook.sh`, `scripts/review_scope.py`, `scripts/review_state.py`,
-  `.claude/settings.json`, `.claude/hooks/**`) is the guard code itself: the merge gate
-  (1) never classifies its stale-review delta as "review-trivial", and (2) refuses
-  `# stale-review-override` unless recorded fallback-review evidence exists for the
-  EXACT head sha (`~/.genesis/override_review_evidence/<repo>__<pr>__<base12>__<sha>.txt`). The override
+  A PR touching the enforcement-hook surface (the guard code itself) gets no
+  stale-review leniency: the merge gate (1) never classifies its post-review delta as
+  "review-trivial", and (2) refuses `# stale-review-override` — regardless of Codex
+  head-freshness — unless recorded fallback-review evidence exists for the EXACT
+  base+head (`~/.genesis/override_review_evidence/<repo>__<pr>__<base12>__<sha>.txt`).
+  A current at-head Codex review does NOT substitute for that evidence: the same sigil
+  also waives `_check_base_is_default`, and the evidence identity binds the BASE tip,
+  which a head-only review cannot vouch for (a hook-surface PR retargeted to a
+  non-default base must be re-reviewed in that base's context). The surface is defined
+  authoritatively by `_HOOK_SURFACE_PREFIXES` + `_HOOK_SURFACE_FILES` in
+  `scripts/hooks/git_push_guard.py` (hook dirs, the global bash safety hook, the
+  review-scope/state modules, hook wiring in `.claude/settings.json`, and the tracked
+  configs the hooks read) — read those constants, kept exhaustive by the
+  `TestWiredHooksFenceGuardrail` test, rather than any hand-copied list. The override
   procedure requires the user's explicit authorization, then a fallback adversarial
   review (local `codex exec` when quota allows, else genesis-architect), evidence
-  recorded, then the merge re-run — the gate's block message walks through it.
+  recorded naming the head, then the merge re-run — the gate's block message walks
+  through it.
 - **One reviewer at a time — NEVER run two review agents simultaneously.** Run
   one reviewer (e.g. Codex), apply/verify its findings, then run the next
   reviewer (e.g. Claude) on the *fixed* code — sequential, never in parallel.

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -538,7 +538,7 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   `.claude/settings.json`, `.claude/hooks/**`) is the guard code itself: the merge gate
   (1) never classifies its stale-review delta as "review-trivial", and (2) refuses
   `# stale-review-override` unless recorded fallback-review evidence exists for the
-  EXACT head sha (`~/.genesis/override_review_evidence/<sha>.txt`). The override
+  EXACT head sha (`~/.genesis/override_review_evidence/<repo>__<pr>__<sha>.txt`). The override
   procedure requires the user's explicit authorization, then a fallback adversarial
   review (local `codex exec` when quota allows, else genesis-architect), evidence
   recorded, then the merge re-run — the gate's block message walks through it.

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -333,6 +333,30 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   canonical-parser lesson (regex→yaml, #1393). Loci today:
   `scripts/hooks/shell_parse.py` + `scripts/hooks/git_push_guard.py`.
 
+  **The boundary of the class — read this BEFORE you reason yourself out of it.**
+  The tar pit is NOT "who tokenizes the string." Delegating tokenization to
+  `shell_parse` and asking git for repo state does NOT exempt a guard: if the
+  guard's CORRECTNESS depends on modeling what a git command WILL DO — which
+  flags force, which operands are paths vs refs, which modes destroy, which
+  repo is targeted — it is argv→EFFECT mapping, and that mapping is the same
+  unbounded open-set surface as raw string parsing. This was reasoned around
+  once already (2026-08-23, PR #1432): the guard used the canonical tokenizer
+  and probed live git state, the author concluded "so it's not hand-rolling,"
+  and Codex returned **13 real findings (10 P1) — every one of them living in
+  the argv→effect layer**. The first architect finding of that shape (a
+  separated global value-flag bypass) was the CLASS signal and got
+  instance-patched; the next round found the rest of the class. n=1 IS the
+  signal: any reviewer finding that exposes a semantic-modeling gap in a guard
+  means STOP and re-architect — never patch the named instance.
+
+  **Decision test (verbatim, apply before shipping any guard):** could a git
+  flag you've never heard of change your guard's verdict? If yes, your claim
+  is open-set — redesign to closed-set token claims (exact-form whitelists /
+  literal token blocks) or to RECOVERABILITY (snapshot-then-allow, where a
+  miss degrades to the status quo instead of a broken guarantee). Do not ship
+  the open-set version and plan to harden it later; the review loop IS the
+  hardening loop, one bug per round, and it does not converge.
+
 ### Iterative-Refinement Discipline
 
 AI refinement cycles degrade code they were asked to "improve" — validation
@@ -498,6 +522,26 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   hand-rolled-parsing hunting, not a lint/secrets scan — and writes the evidence marker. This is
   the review that catches Round-1 bugs before Codex does; `/audit-changes` is only a light
   self-check.
+- **PR review-findings status = `python3 scripts/hooks/git_push_guard.py --check-pr <N>`
+  — ONLY.** This runs the SAME code path as the merge gate (strict fail-closed: a
+  failed scan is never reported clean). NEVER hand-roll a `gh api pulls/N/comments`
+  query to decide whether a PR is review-clean: a wrong filter's EMPTY result reads
+  exactly like "clean". Origin (2026-08-23, #1431/#1432): inline findings are authored
+  by `chatgpt-codex-connector[bot]` — WITH the `[bot]` suffix — while the review-summary
+  author has no suffix; a no-suffix filter returned empty and 13 real findings (10 P1)
+  were reported to the user as "review-clean" until the merge gate blocked. An empty
+  result from your own query is "my query found nothing", never "no findings exist".
+  Reviewed-SHA must equal the PR's current HEAD (the report checks this too).
+- **Hook-surface PRs merge only with a current GitHub Codex review — mechanical.**
+  A PR touching the enforcement-hook surface (`scripts/hooks/**`,
+  `scripts/bash_safety_hook.sh`, `scripts/review_scope.py`, `scripts/review_state.py`,
+  `.claude/settings.json`, `.claude/hooks/**`) is the guard code itself: the merge gate
+  (1) never classifies its stale-review delta as "review-trivial", and (2) refuses
+  `# stale-review-override` unless recorded fallback-review evidence exists for the
+  EXACT head sha (`~/.genesis/override_review_evidence/<sha>.txt`). The override
+  procedure requires the user's explicit authorization, then a fallback adversarial
+  review (local `codex exec` when quota allows, else genesis-architect), evidence
+  recorded, then the merge re-run — the gate's block message walks through it.
 - **One reviewer at a time — NEVER run two review agents simultaneously.** Run
   one reviewer (e.g. Codex), apply/verify its findings, then run the next
   reviewer (e.g. Claude) on the *fixed* code — sequential, never in parallel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Security
 
+- **Hook-surface PRs can no longer merge without a current GitHub Codex review.**
+  The merge gate's review-freshness check now treats any unreviewed delta touching
+  the enforcement-hook surface (`scripts/hooks/**`, the global bash safety hook,
+  the review-scope/state modules, hook wiring in `.claude/settings.json`,
+  `.claude/hooks/**`) as substantial — a small touch-up to a guard can no longer
+  slip through the review-trivial narrowing. The `# stale-review-override` escape
+  additionally requires recorded fallback-review evidence keyed to the PR's exact
+  head sha on this surface (fail-closed on unreadable diff or head), with the
+  block message documenting the authorized fallback procedure. Rationale: the hook
+  surface is the code the gates themselves run on — an unreviewed merge there
+  disarms every other gate. The genesis-development skill now also mandates
+  `git_push_guard.py --check-pr <N>` (the merge gate's own code path) as the only
+  way to report a PR's review-findings status.
+
 - **Observation content can no longer launder untrusted origin into privileged
   cognitive surfaces.** Observation rows now carry a definite origin stamped at the
   write boundary: the CRUD chokepoint classifies every writer (explicit origin →

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -98,6 +98,7 @@ import shlex
 import subprocess
 import sys
 import time
+import urllib.parse
 
 # Self-locate so `from hook_input import …` resolves both when CC runs this as a
 # script (sys.path[0] is this dir) AND when it is imported as a module for tests
@@ -1169,12 +1170,19 @@ def _pr_base_sha(pr_num: str, repo: str | None = None) -> str | None:
         ref = _pr_base_ref(pr_num, repo=repo)
         if not ref or any(c.isspace() for c in ref):
             return None
+        # URL-encode the ref before it becomes an API path component (Codex P2,
+        # round 2): a base branch name can carry characters that are structural in
+        # a URL path (`#` fragment, `?` query, `%`), and the ref is network-sourced
+        # (gh's baseRefName), so encode defensively. safe="/" preserves the slash
+        # in hierarchical branch names (`release/2.0`), which the commits/{ref}
+        # endpoint resolves directly.
+        ref_enc = urllib.parse.quote(ref, safe="/")
         try:
             result = subprocess.run(
                 [
                     "gh",
                     "api",
-                    f"repos/{repo or ':owner/:repo'}/commits/{ref}",
+                    f"repos/{repo or ':owner/:repo'}/commits/{ref_enc}",
                     "--jq",
                     ".sha",
                 ],
@@ -1598,6 +1606,18 @@ def _is_hook_surface_path(path: str) -> bool:
     return path in _HOOK_SURFACE_FILES or any(path.startswith(p) for p in _HOOK_SURFACE_PREFIXES)
 
 
+# A real fallback review (reviewer + findings + dispositions) is substantive; this
+# floor rejects a rubber-stamp / stray/boilerplate file at the evidence path (Codex
+# P2 round 2). Note the filename already binds repo+PR+base+head, so the content
+# check's marginal value is specifically catching a stale body copied to a correctly
+# named file. Anti-autopilot floor, NOT tamper-proof — the teeth are the human merge
+# + cloud reviewer (same threat model as review_state's evidence check).
+_MIN_OVERRIDE_EVIDENCE_CHARS = 200
+# Bound the read on the merge-gate hot path (the floor is 200 chars; any real review
+# fits easily) so an oversized file in the evidence dir can't be slurped into memory.
+_MAX_OVERRIDE_EVIDENCE_READ = 65536
+
+
 def _override_evidence_dir() -> str:
     """Directory holding fallback-review evidence files
     (``<repo>__<pr>__<base-tip-12>__<head-sha>.txt``).
@@ -1749,9 +1769,19 @@ def _hook_surface_override_check(pr_num: str, repo: str | None = None) -> tuple[
         _override_evidence_dir(), f"{repo_slug}__{pr_num}__{base[:12]}__{head}.txt"
     )
     try:
-        has_evidence = os.path.getsize(evidence_path) > 0
+        with open(evidence_path, encoding="utf-8", errors="replace") as _ef:
+            evidence_text = _ef.read(_MAX_OVERRIDE_EVIDENCE_READ)
     except OSError:
-        has_evidence = False
+        evidence_text = ""
+    # Validate the CONTENT, not just presence (Codex P2, round 2): a stray or
+    # rubber-stamp file at the right path must not waive the gate. Require a
+    # substantive review that NAMES the exact head it vouches for — the 12-hex
+    # head prefix must appear in the body (the procedure below instructs this),
+    # and the body must clear a minimum length. Fail-closed on a short/unbound file.
+    has_evidence = (
+        len(evidence_text.strip()) >= _MIN_OVERRIDE_EVIDENCE_CHARS
+        and head[:12] in evidence_text.lower()
+    )
     if has_evidence:
         # Residual TOCTOU, accepted as part of the force path's documented
         # "conscious unbound merge" contract: a push landing between this head
@@ -1779,7 +1809,8 @@ def _hook_surface_override_check(pr_num: str, repo: str | None = None) -> tuple[
             f"  2. Run a fallback adversarial review of the full PR diff: local "
             f"`codex exec` when quota allows, else a Claude Code adversarial "
             f"review (genesis-architect).\n"
-            f"  3. Record reviewer + findings + dispositions in:\n"
+            f"  3. Record reviewer + findings + dispositions — and reference the "
+            f"head sha {head[:12]} in the body — in:\n"
             f"       {evidence_path}\n"
             f"  4. Re-run this merge (same sigil). A new push changes the head "
             f"sha, and a base-branch change (retarget OR base advancing) "

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1446,7 +1446,13 @@ def _pr_base_sha(pr_num: str, repo: str | None = None) -> str | None:
     raw = os.environ.get("_TEST_GH_BASE_OID")
     if raw is None:
         ref = _pr_base_ref(pr_num, repo=repo)
-        if not ref or any(c.isspace() for c in ref):
+        # Reject only an ASCII control char or a plain ASCII space — Git's own ref
+        # rules (git check-ref-format) forbid exactly those, and they'd be garbage in
+        # a base branch name. Do NOT reject every Python str.isspace() code point
+        # (Codex P2, round 5): non-ASCII whitespace (e.g. U+00A0) is a LEGAL Git branch
+        # character, and rejecting it would falsely block the authorized
+        # fallback-evidence path for a legitimately-named branch.
+        if not ref or any(ord(c) < 0x20 or ord(c) == 0x7F or c == " " for c in ref):
             return None
         # GraphQL needs an explicit owner/name (no REST ``:owner/:repo`` placeholder).
         # Resolve the slug from the passed repo, else the cwd's base repo; fail-closed
@@ -2205,9 +2211,21 @@ def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | No
     for f in files:
         if not isinstance(f, dict):
             return None
-        for key in ("filename", "previous_filename"):
-            val = f.get(key)
-            if val and _is_hook_surface_path(str(val)):
+        # A record MUST carry a readable string ``filename`` — a missing/null/empty
+        # one means we cannot confirm this path is NOT a hook-surface file, so fail
+        # CLOSED (unclassifiable → the caller blocks a stale review) rather than skip
+        # it (Codex P2, round 5: a malformed compare record must not let a hook-surface
+        # delta read as review-trivial; ``gh --jq`` still builds an object when the
+        # upstream field is absent, so this shape is reachable). ``previous_filename``
+        # is optional, but when present must likewise be a non-empty string.
+        fn = f.get("filename")
+        if not isinstance(fn, str) or not fn:
+            return None
+        prev = f.get("previous_filename")
+        if prev is not None and (not isinstance(prev, str) or not prev):
+            return None
+        for val in (fn, prev):
+            if val and _is_hook_surface_path(val):
                 return "substantial"
     try:
         # review_scope lives in scripts/ (parent of scripts/hooks/). Lazy import ON

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -106,7 +106,6 @@ import shlex
 import subprocess
 import sys
 import time
-import urllib.parse
 
 # Self-locate so `from hook_input import …` resolves both when CC runs this as a
 # script (sys.path[0] is this dir) AND when it is imported as a module for tests
@@ -1427,30 +1426,64 @@ def _pr_base_sha(pr_num: str, repo: str | None = None) -> str | None:
     2026-08-23 against live PRs — three pre-merge PRs still reported the old
     tip while a post-merge control reported the new one). The evidence binding
     exists precisely for the base-advanced case, so it must read the branch
-    ref's current tip: resolve ``baseRefName`` (existing helper + seam), then
-    ``commits/{ref}``. Consumed by the hook-surface override evidence identity
-    (see _hook_surface_override_check). Tests inject via ``_TEST_GH_BASE_OID``.
+    ref's current tip.
+
+    Resolution is via GraphQL ``repository.ref(qualifiedName:"refs/heads/<branch>")``
+    with the branch passed as a raw-string VARIABLE — NOT the REST ``commits/{ref}``
+    endpoint (Codex #10). Interpolating a branch name into a URL path is ambiguous
+    and fragile in two ways the REST path could not fully close: (1) an UNqualified
+    ``commits/<name>`` resolves a same-named TAG or a branch literally named
+    ``heads/x`` to the WRONG ref (a wrong-tip evidence binding that stays valid
+    after the real base moves); (2) a name that is structural in a URL (``#``
+    fragment, ``?`` query, ``%`` escape) truncates the request. A fully-qualified
+    ``refs/heads/<branch>`` passed as a GraphQL variable is unambiguous (heads vs
+    tags) AND carries no URL-path interpolation at all, closing both classes at once.
+    A branch ref's ``target`` is always a Commit, so ``.target.oid`` is its live tip.
+
+    Consumed by the hook-surface override evidence identity (see
+    _hook_surface_override_check). Tests inject via ``_TEST_GH_BASE_OID``.
     """
     raw = os.environ.get("_TEST_GH_BASE_OID")
     if raw is None:
         ref = _pr_base_ref(pr_num, repo=repo)
         if not ref or any(c.isspace() for c in ref):
             return None
-        # URL-encode the ref before it becomes an API path component (Codex P2,
-        # round 2): a base branch name can carry characters that are structural in
-        # a URL path (`#` fragment, `?` query, `%`), and the ref is network-sourced
-        # (gh's baseRefName), so encode defensively. safe="/" preserves the slash
-        # in hierarchical branch names (`release/2.0`), which the commits/{ref}
-        # endpoint resolves directly.
-        ref_enc = urllib.parse.quote(ref, safe="/")
+        # GraphQL needs an explicit owner/name (no REST ``:owner/:repo`` placeholder).
+        # Resolve the slug from the passed repo, else the cwd's base repo; fail-closed
+        # if it can't be resolved or split. A non-str ``repo`` (an unresolved-repo
+        # sentinel) fails CLOSED here — never fall through to a cwd guess, and never
+        # reach _normalize_repo's ``str``-typed body with a non-str (would TypeError
+        # OUTSIDE the subprocess try). Belt-and-suspenders: callers already fail-closed
+        # on the sentinel before this runs.
+        if repo is not None and not isinstance(repo, str):
+            return None
+        slug = _normalize_repo(repo) if repo else _derive_repo_from_cwd(os.getcwd())
+        if not slug or "/" not in slug:
+            return None
+        owner, name = slug.split("/", 1)
+        query = (
+            "query($owner:String!,$name:String!,$ref:String!){"
+            "repository(owner:$owner,name:$name){ref(qualifiedName:$ref){target{oid}}}}"
+        )
         try:
             result = subprocess.run(
                 [
                     "gh",
                     "api",
-                    f"repos/{repo or ':owner/:repo'}/commits/{ref_enc}",
+                    "graphql",
+                    # -f (raw string), NOT -F: -F type-coerces and reads @file, which
+                    # would mangle a numeric-looking or @-leading branch name. -f keeps
+                    # every value a literal GraphQL String.
+                    "-f",
+                    f"query={query}",
+                    "-f",
+                    f"owner={owner}",
+                    "-f",
+                    f"name={name}",
+                    "-f",
+                    f"ref=refs/heads/{ref}",
                     "--jq",
-                    ".sha",
+                    ".data.repository.ref.target.oid",
                 ],
                 capture_output=True,
                 text=True,
@@ -1458,11 +1491,15 @@ def _pr_base_sha(pr_num: str, repo: str | None = None) -> str | None:
                 # stale-review-override path; fail direction is closed there.
                 timeout=_gh_timeout(6),
             )
+            # A missing branch → ``ref: null`` → jq emits the literal "null"; a GraphQL
+            # error → data null → same. Both, and any non-zero exit, fail closed below.
             raw = result.stdout if result.returncode == 0 else ""
         except Exception:
             return None
     sha = (raw or "").strip()
-    return sha or None
+    if not sha or sha == "null":
+        return None
+    return sha
 
 
 def _codex_reviews(pr_num: str, repo: str | None = None) -> list[dict] | None:
@@ -1853,6 +1890,7 @@ _HOOK_SURFACE_FILES = frozenset(
         "scripts/review_enforcement_commit.py",
         "scripts/review_enforcement_prompt.py",
         "scripts/review_invalidate_on_commit.py",
+        "scripts/surface_open_prs.py",
         "scripts/surface_pr_updates.py",
         # Hook-owned DECISION CONFIGURATION (Codex P2, round 1): these files
         # determine what the wired hooks enforce, and the ordinary
@@ -2205,7 +2243,10 @@ def _check_codex_reviewed_head(
     only on positive evidence. ``force`` (a ``# stale-review-override`` on the
     merge segment — deliberately NOT ``# review-override``, which waives the P1
     finding scans; the two boundaries are independent) is the conscious escape
-    (e.g. a genuine Codex outage).
+    (e.g. a genuine Codex outage). On the HOOK SURFACE ``force`` additionally
+    requires recorded fallback-review evidence regardless of head-freshness — the
+    same sigil waives ``_check_base_is_default`` and the evidence identity binds the
+    BASE, which a head-only review cannot vouch for (see Codex #9 disposition below).
 
     Returns ``(should_block, message, verified_head)`` — ``verified_head`` is the
     full head oid this check verified/classified against (when not blocked and
@@ -2220,6 +2261,17 @@ def _check_codex_reviewed_head(
         # evidence for the exact head is additionally required (fail-closed).
         # verified_head stays None on the pass path: the force path keeps its
         # documented "conscious unbound merge" contract (no --match-head bind).
+        #
+        # NOTE (Codex #9, dispositioned FALSE-POSITIVE 2026-08-26): #9 proposed
+        # skipping this evidence demand when a current at-head Codex review already
+        # exists. That is UNSAFE and was reverted: this force path is reached via
+        # # stale-review-override, which ALSO waives _check_base_is_default, and
+        # _hook_surface_override_check's evidence identity binds the BASE tip — which
+        # a head-only Codex review provably cannot vouch for (see _check_base_is_default's
+        # docstring: "GitHub's review object records no base, so freshness alone cannot
+        # see it"). Skipping evidence on a fresh review would let a hook-surface PR
+        # RETARGETED to a non-default base merge with no base-bound review. A fresh
+        # head-review is NOT a substitute for base-bound evidence here.
         blocked, msg = _hook_surface_override_check(pr_num, repo=repo)
         if blocked:
             return True, msg, None

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -43,6 +43,14 @@ review-CONTEXT gates (Codex-at-head freshness + base-is-default),
 ``# ci-override`` waives the CI gate. A session that genuinely needs several
 appends several (one trailing comment may carry multiple sigils).
 
+Hook-surface merge teeth (2026-08-23): a PR whose diff touches the
+ENFORCEMENT-HOOK surface (``_HOOK_SURFACE_PREFIXES``/``_HOOK_SURFACE_FILES`` —
+the code these gates themselves run on) gets stricter freshness handling: its
+stale-review delta is never "review-trivial", and ``# stale-review-override``
+alone cannot merge it — recorded fallback-review evidence keyed to the exact
+head sha is additionally required (``_hook_surface_override_check``; the block
+message documents the user-authorized fallback procedure).
+
 Scheduled Claude review markers
 -------------------------------
 A "scheduled Claude review" runs on the repo OWNER's GitHub account (NOT a bot) and must
@@ -1455,6 +1463,228 @@ def _latest_codex_clean_comment_sha(pr_num: str, repo: str | None = None) -> str
     return latest
 
 
+# ── Hook-surface merge teeth (2026-08-23, user decision) ─────────────────────
+# The ENFORCEMENT-HOOK surface is the code the merge/push/commit gates themselves
+# run on: an unreviewed change here disarms every other gate, so it gets stricter
+# review teeth than ordinary code. Two rules, both scoped to these paths:
+#   1. A stale-review delta touching this surface is NEVER "review-trivial"
+#      (_classify_post_review_delta): a "small single-file touch-up" to a guard
+#      is exactly the change that must not skip re-review.
+#   2. `# stale-review-override` alone cannot merge a hook-surface PR without a
+#      current GitHub Codex review — it additionally requires recorded
+#      fallback-review evidence keyed to the EXACT head sha
+#      (_hook_surface_override_check). The GitHub Codex review is the required
+#      evidence class (user decision, 2026-08-23); the fallback procedure
+#      (user-authorized local codex / Claude Code adversarial review) is the
+#      documented exception path, not a self-serve bypass.
+# WHY this exists (the origin story — keep it, it is the anti-rationalization):
+# on PR #1432 a hand-rolled findings query returned empty and was reported as
+# "review-clean" while 13 real Codex findings (10 P1) sat on the PR; only this
+# file's merge gate caught it. The lesson: the human-facing claim and the gate
+# MUST run the same code path, and the gate's own code must never merge
+# unreviewed. Tests: tests/test_hooks/test_git_push_guard_hook_surface.py.
+_HOOK_SURFACE_PREFIXES = ("scripts/hooks/", ".claude/hooks/")
+# EVERY hook wired in .claude/settings.json is fence surface — not only the
+# blocking gates: any script auto-executing inside sessions is enforcement-
+# adjacent (architect SHOULD-FIX 2026-08-23: the named-list-as-sample trap this
+# PR itself documents — review_enforcement_commit.py et al. lived outside the
+# original 4-file fence). Over-fencing costs only stricter review; a guardrail
+# test (test_git_push_guard_hook_surface.py) parses settings.json and FAILS CI
+# if a wired hook ever falls outside this fence, so the set is self-maintaining.
+_HOOK_SURFACE_FILES = frozenset(
+    {
+        "scripts/bash_safety_hook.sh",  # the global Bash chokepoint
+        "scripts/review_scope.py",  # substantiality classifier (feeds THIS gate)
+        "scripts/review_state.py",  # escalation counter + review markers
+        ".claude/settings.json",  # hook wiring (inline blob + matchers)
+        # scripts/-root hooks wired via .claude/hooks/genesis-hook (which
+        # resolves bare names as scripts/<name>); scripts/hooks/* wirings are
+        # covered by the prefix above.
+        "scripts/behavioral_linter.py",
+        "scripts/check_stale_pending.py",
+        "scripts/content_safety_hook.py",
+        "scripts/contribution_offer_hook.py",
+        "scripts/edit_failure_sensor.py",
+        "scripts/file_context_hook.py",
+        "scripts/file_modification_audit_hook.py",
+        "scripts/genesis_precompact.py",
+        "scripts/genesis_session_context.py",
+        "scripts/genesis_session_end.py",
+        "scripts/genesis_stop_hook.py",
+        "scripts/genesis_urgent_alerts.py",
+        "scripts/plan_bookmark_hook.py",
+        "scripts/pretool_check.py",
+        "scripts/proactive_memory_hook.py",
+        "scripts/procedure_advisor.py",
+        "scripts/review_enforcement_commit.py",
+        "scripts/review_enforcement_prompt.py",
+        "scripts/review_invalidate_on_commit.py",
+        "scripts/surface_pr_updates.py",
+    }
+)
+
+
+def _is_hook_surface_path(path: str) -> bool:
+    """True iff ``path`` (repo-relative, as GitHub reports it) is enforcement-hook
+    surface. Prefix matches are real path segments (``scripts/hooks/x``), never
+    substrings (``scripts/hooks_readme.md`` does not match)."""
+    return path in _HOOK_SURFACE_FILES or any(path.startswith(p) for p in _HOOK_SURFACE_PREFIXES)
+
+
+def _override_evidence_dir() -> str:
+    """Directory holding fallback-review evidence files (``<head-sha>.txt``).
+
+    ``GENESIS_OVERRIDE_REVIEW_EVIDENCE_DIR`` overrides (config knob + test seam);
+    default lives outside the repo so evidence survives worktree removal and is
+    never committed."""
+    return os.environ.get("GENESIS_OVERRIDE_REVIEW_EVIDENCE_DIR") or os.path.expanduser(
+        "~/.genesis/override_review_evidence"
+    )
+
+
+def _pr_changed_files(pr_num: str, repo: str | None = None) -> list[str] | None:
+    """Every filename the PR touches (including rename SOURCES via
+    ``previous_filename`` — a guard renamed OUT of scripts/hooks/ is a hook
+    change), or None on any API/parse error. GitHub caps ``pulls/N/files`` at
+    3000 entries; at the cap a hook file may sit beyond it → None (the caller
+    fails closed). Tests inject via ``_TEST_GH_PR_FILES`` (one JSON object per
+    line: ``{filename, previous_filename}``; the literal ``__error__`` simulates
+    an API error)."""
+    raw = os.environ.get("_TEST_GH_PR_FILES")
+    if raw == "__error__":
+        return None
+    if raw is None:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo or ':owner/:repo'}/pulls/{pr_num}/files",
+                    "--paginate",
+                    "--jq",
+                    ".[] | {filename: .filename, previous_filename: .previous_filename}",
+                ],
+                capture_output=True,
+                text=True,
+                # Merge-path timeout budget (see main()): this runs ONLY on the
+                # rare `# stale-review-override` path, so one paginated read
+                # stays inside the hook's wall-clock.
+                timeout=_gh_timeout(8),
+            )
+            if result.returncode != 0:
+                return None
+            raw = result.stdout
+        except Exception:
+            return None
+    files: list[str] = []
+    for line in (raw or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            return None  # malformed page → cannot vouch for the full file set
+        if not isinstance(obj, dict):
+            return None
+        for key in ("filename", "previous_filename"):
+            val = obj.get(key)
+            if val:
+                files.append(str(val))
+    if len(files) >= 3000:
+        return None  # pagination cap — a hook file may be hidden beyond it
+    return files
+
+
+def _hook_surface_override_check(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
+    """Gate the ``# stale-review-override`` escape on hook-surface PRs.
+
+    Returns ``(should_block, message)``. Fail direction is CLOSED throughout:
+    an unreadable diff or head sha blocks — this path exists precisely because
+    the normal review evidence is absent, so uncertainty must not widen the
+    escape. Non-hook-surface PRs pass untouched (the sigil keeps its normal
+    meaning there)."""
+    files = _pr_changed_files(pr_num, repo=repo)
+    if files is None:
+        return (
+            True,
+            (
+                f"could not read PR #{pr_num}'s changed files to scope the "
+                f"stale-review-override (hook-surface PRs need fallback-review "
+                f"evidence). Retry when GitHub answers — this read failing "
+                f"closed is deliberate."
+            ),
+        )
+    touched = sorted({f for f in files if _is_hook_surface_path(f)})
+    if not touched:
+        return False, ""
+    head = _pr_head_sha(pr_num, repo=repo)
+    if not head:
+        return (
+            True,
+            (
+                f"PR #{pr_num} touches the enforcement-hook surface "
+                f"({', '.join(touched[:4])}) but its head sha could not be read, "
+                f"so fallback-review evidence cannot be verified. Retry."
+            ),
+        )
+    head = head.strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{40}", head):
+        # A network-sourced string becomes a path component below — validate the
+        # exact oid shape (mirrors _SCHEDULED_REVIEW_HEAD_RE) so garbage blocks
+        # EXPLICITLY instead of via an accidental unmatchable filename.
+        return (
+            True,
+            (
+                f"PR #{pr_num}'s head sha read back malformed ({head[:24]!r}) — "
+                f"cannot key fallback-review evidence. Retry."
+            ),
+        )
+    evidence_path = os.path.join(_override_evidence_dir(), f"{head}.txt")
+    try:
+        has_evidence = os.path.getsize(evidence_path) > 0
+    except OSError:
+        has_evidence = False
+    if has_evidence:
+        # Residual TOCTOU, accepted as part of the force path's documented
+        # "conscious unbound merge" contract: a push landing between this head
+        # read and the merge would merge a head the evidence does not name. The
+        # window is seconds, re-running re-reads the head, and binding here
+        # would force --match-head-commit onto override merges — declined.
+        print(
+            f"NOTE: hook-surface override on PR #{pr_num} backed by fallback-review "
+            f"evidence at {evidence_path} (head {head[:12]}).",
+            file=sys.stderr,
+        )
+        return False, ""
+    return (
+        True,
+        (
+            f"'# stale-review-override' is NOT sufficient by itself here: PR "
+            f"#{pr_num}'s diff touches the ENFORCEMENT-HOOK surface "
+            f"({', '.join(touched[:4])}{', …' if len(touched) > 4 else ''}) — the "
+            f"code the merge/push gates themselves run on. Merging it without a "
+            f"current GitHub Codex review additionally requires recorded "
+            f"fallback-review evidence for the EXACT head {head[:12]}.\n"
+            f"Procedure (requires the user's explicit authorization — never "
+            f"self-serve):\n"
+            f"  1. Get the user's go-ahead for the override.\n"
+            f"  2. Run a fallback adversarial review of the full PR diff: local "
+            f"`codex exec` when quota allows, else a Claude Code adversarial "
+            f"review (genesis-architect).\n"
+            f"  3. Record reviewer + findings + dispositions in:\n"
+            f"       {evidence_path}\n"
+            f"  4. Re-run this merge (same sigil). A new push changes the head "
+            f"sha — re-review and re-key.\n"
+            f"WHY: 2026-08-23 — an unreviewed merge on this surface disarms every "
+            f"other gate; the GitHub Codex review is the required evidence class "
+            f"(user decision), and this file's own history (#1432: 13 findings "
+            f"invisible to a hand-rolled query) is the proof the gate must not "
+            f"trust the author's claim of cleanliness."
+        ),
+    )
+
+
 def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | None) -> str | None:
     """Substantiality of what HEAD adds OVER the Codex-reviewed SHA, via the compare API.
 
@@ -1525,6 +1755,17 @@ def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | No
         return None
     if len(files) >= 300:
         return "substantial"  # compare file cap hit → can't rule out substantial code
+    # Hook-surface teeth rule 1: a delta touching the enforcement-hook surface is
+    # NEVER review-trivial, no matter how small — see the block above
+    # _is_hook_surface_path for the why. Rename sources count (previous_filename):
+    # a guard renamed/moved out of scripts/hooks/ IS a hook change.
+    for f in files:
+        if not isinstance(f, dict):
+            return None
+        for key in ("filename", "previous_filename"):
+            val = f.get(key)
+            if val and _is_hook_surface_path(str(val)):
+                return "substantial"
     try:
         # review_scope lives in scripts/ (parent of scripts/hooks/). Lazy import ON
         # PURPOSE: an import failure must degrade THIS classification to None (the
@@ -1569,6 +1810,14 @@ def _check_codex_reviewed_head(
     cannot smuggle an unreviewed head through (TOCTOU — Codex P1, PR #1366).
     """
     if force:
+        # Hook-surface teeth rule 2: the sigil alone is not enough when the PR
+        # touches the enforcement-hook surface — recorded fallback-review
+        # evidence for the exact head is additionally required (fail-closed).
+        # verified_head stays None on the pass path: the force path keeps its
+        # documented "conscious unbound merge" contract (no --match-head bind).
+        blocked, msg = _hook_surface_override_check(pr_num, repo=repo)
+        if blocked:
+            return True, msg, None
         return False, "", None
     head = _pr_head_sha(pr_num, repo=repo)
     if not head:
@@ -3151,7 +3400,9 @@ def main() -> int:
                 # pre-gate repo/PR resolution above (6s each) — carries a tight
                 # per-call timeout (6-8s): pre-gates + fail-closed gates
                 # (derive 6 + resolve 6 + mergeable 8 + ci 8 + base 6+6 +
-                # freshness 6+8 + delta 8 = 62s absolute worst) each reach
+                # freshness 6+8 + delta 8 = 62s absolute worst; the FORCE
+                # branch swaps freshness+delta for its hook-surface evidence
+                # reads, files 8 + head 6 = strictly less) each reach
                 # their own block/allow decision at or inside the budget, and
                 # any ONE of them timing out fail-closes IMMEDIATELY (the
                 # additive worst case needs every call slow-but-successful);

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1020,6 +1020,12 @@ def _check_pr_review_findings(
                 "gh",
                 "api",
                 f"repos/{repo or ':owner/:repo'}/issues/{pr_num}/comments",
+                # --paginate (Codex P2, round 1): without it only the FIRST page
+                # (30 comments) is read — a blocking bot finding on a later page
+                # of a long PR thread would scan as "ok". With the array-form
+                # --jq, gh emits ONE array PER page (concatenated), which the
+                # raw_decode loop below parses.
+                "--paginate",
                 "--jq",
                 "[.[] | {login: .user.login, type: .user.type, body: .body}]",
             ],
@@ -1032,14 +1038,26 @@ def _check_pr_review_findings(
     except Exception:
         return _scan_unreadable(strict, "review-body comments")
 
-    output = result.stdout.strip()
+    output = (result.stdout or "").strip()
     if not output or output == "[]":
         return False, ""  # No comments at all — allow (quota-exhausted case)
 
-    # Parse JSON array of comments
+    # Parse comments: one JSON array per page, concatenated (`[..][..]` /
+    # newline-separated). raw_decode walks every array; a single-page (or
+    # test-injected) payload is just the one-array case of the same loop.
+    raw_comments: list = []
+    decoder = json.JSONDecoder()
+    pos = 0
     try:
-        raw_comments = json.loads(output)
-    except json.JSONDecodeError:
+        while pos < len(output):
+            chunk, end = decoder.raw_decode(output, pos)
+            if not isinstance(chunk, list):
+                return _scan_unreadable(strict, "review-body comments")
+            raw_comments.extend(chunk)
+            pos = end
+            while pos < len(output) and output[pos] in " \t\r\n":
+                pos += 1
+    except ValueError:  # includes json.JSONDecodeError
         return _scan_unreadable(strict, "review-body comments")  # malformed JSON
 
     # GitHub API can return "body": null for deleted comments —
@@ -1483,7 +1501,10 @@ def _latest_codex_clean_comment_sha(pr_num: str, repo: str | None = None) -> str
 # file's merge gate caught it. The lesson: the human-facing claim and the gate
 # MUST run the same code path, and the gate's own code must never merge
 # unreviewed. Tests: tests/test_hooks/test_git_push_guard_hook_surface.py.
-_HOOK_SURFACE_PREFIXES = ("scripts/hooks/", ".claude/hooks/")
+# config/behavioral_rules/ rides as a prefix: behavioral_linter.py loads every
+# YAML under it (decision config = enforcement surface, see the note in
+# _HOOK_SURFACE_FILES).
+_HOOK_SURFACE_PREFIXES = ("scripts/hooks/", ".claude/hooks/", "config/behavioral_rules/")
 # EVERY hook wired in .claude/settings.json is fence surface — not only the
 # blocking gates: any script auto-executing inside sessions is enforcement-
 # adjacent (architect SHOULD-FIX 2026-08-23: the named-list-as-sample trap this
@@ -1520,6 +1541,13 @@ _HOOK_SURFACE_FILES = frozenset(
         "scripts/review_enforcement_prompt.py",
         "scripts/review_invalidate_on_commit.py",
         "scripts/surface_pr_updates.py",
+        # Hook-owned DECISION CONFIGURATION (Codex P2, round 1): these files
+        # determine what the wired hooks enforce, and the ordinary
+        # substantiality classifier treats YAML as docs/config (review-trivial)
+        # — so a rewrite that removes blocking patterns could merge on a stale
+        # review. Config that drives enforcement is enforcement surface.
+        "config/protected_paths.yaml",  # pretool_check.py
+        "config/repo_topology.yaml",  # repo_routing_guard.py
     }
 )
 
@@ -1532,7 +1560,8 @@ def _is_hook_surface_path(path: str) -> bool:
 
 
 def _override_evidence_dir() -> str:
-    """Directory holding fallback-review evidence files (``<head-sha>.txt``).
+    """Directory holding fallback-review evidence files
+    (``<repo>__<pr>__<head-sha>.txt``).
 
     ``GENESIS_OVERRIDE_REVIEW_EVIDENCE_DIR`` overrides (config knob + test seam);
     default lives outside the repo so evidence survives worktree removal and is
@@ -1577,6 +1606,7 @@ def _pr_changed_files(pr_num: str, repo: str | None = None) -> list[str] | None:
         except Exception:
             return None
     files: list[str] = []
+    rows = 0
     for line in (raw or "").splitlines():
         line = line.strip()
         if not line:
@@ -1587,12 +1617,26 @@ def _pr_changed_files(pr_num: str, repo: str | None = None) -> list[str] | None:
             return None  # malformed page → cannot vouch for the full file set
         if not isinstance(obj, dict):
             return None
-        for key in ("filename", "previous_filename"):
-            val = obj.get(key)
-            if val:
-                files.append(str(val))
-    if len(files) >= 3000:
-        return None  # pagination cap — a hook file may be hidden beyond it
+        rows += 1
+        # Strict record shape (Codex P2, round 1): a null/empty/non-string
+        # filename means the record did NOT parse into a usable path — treating
+        # it as parsed could hide a hook file behind a degenerate row. Require
+        # a nonempty string filename; previous_filename may be None (no rename)
+        # or a nonempty string. Anything else → None → caller fails closed.
+        fname = obj.get("filename")
+        if not isinstance(fname, str) or not fname:
+            return None
+        files.append(fname)
+        prev = obj.get("previous_filename")
+        if prev is not None:
+            if not isinstance(prev, str) or not prev:
+                return None
+            files.append(prev)
+    if rows >= 3000:
+        # The cap applies to API ROWS, not the expanded path list (renames
+        # contribute two paths per row — Codex P2, round 1): at the documented
+        # 3000-entry endpoint cap a hook file may be hidden beyond it.
+        return None
     return files
 
 
@@ -1640,7 +1684,13 @@ def _hook_surface_override_check(pr_num: str, repo: str | None = None) -> tuple[
                 f"cannot key fallback-review evidence. Retry."
             ),
         )
-    evidence_path = os.path.join(_override_evidence_dir(), f"{head}.txt")
+    # Evidence identity = repo + PR + head (Codex P2, round 1): a commit sha
+    # alone does not identify the PR/base whose FULL diff the fallback review
+    # covered — the same head can appear on another PR or in a fork, and
+    # sha-only evidence would silently vouch there too. An unresolvable repo
+    # degrades to the "local" namespace (still PR- and head-bound).
+    repo_slug = (_normalize_repo(repo) or "local").replace("/", "_")
+    evidence_path = os.path.join(_override_evidence_dir(), f"{repo_slug}__{pr_num}__{head}.txt")
     try:
         has_evidence = os.path.getsize(evidence_path) > 0
     except OSError:

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1152,6 +1152,45 @@ def _pr_head_sha(pr_num: str, repo: str | None = None) -> str | None:
     return sha or None
 
 
+def _pr_base_sha(pr_num: str, repo: str | None = None) -> str | None:
+    """The LIVE tip oid of the PR's base branch, or None on any error.
+
+    Deliberately NOT ``pulls/N → .base.sha``: that field is a SNAPSHOT taken at
+    PR creation/retarget and does not advance with the base branch (measured
+    2026-08-23 against live PRs — three pre-merge PRs still reported the old
+    tip while a post-merge control reported the new one). The evidence binding
+    exists precisely for the base-advanced case, so it must read the branch
+    ref's current tip: resolve ``baseRefName`` (existing helper + seam), then
+    ``commits/{ref}``. Consumed by the hook-surface override evidence identity
+    (see _hook_surface_override_check). Tests inject via ``_TEST_GH_BASE_OID``.
+    """
+    raw = os.environ.get("_TEST_GH_BASE_OID")
+    if raw is None:
+        ref = _pr_base_ref(pr_num, repo=repo)
+        if not ref or any(c.isspace() for c in ref):
+            return None
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo or ':owner/:repo'}/commits/{ref}",
+                    "--jq",
+                    ".sha",
+                ],
+                capture_output=True,
+                text=True,
+                # Merge-path budget (see main()): runs ONLY on the rare
+                # stale-review-override path; fail direction is closed there.
+                timeout=_gh_timeout(6),
+            )
+            raw = result.stdout if result.returncode == 0 else ""
+        except Exception:
+            return None
+    sha = (raw or "").strip()
+    return sha or None
+
+
 def _codex_reviews(pr_num: str, repo: str | None = None) -> list[dict] | None:
     """EVERY Codex review record ``{commit_id, state}`` on the PR, oldest-first,
     or None on any API/parse error (distinct from ``[]`` = query succeeded, no
@@ -1561,7 +1600,7 @@ def _is_hook_surface_path(path: str) -> bool:
 
 def _override_evidence_dir() -> str:
     """Directory holding fallback-review evidence files
-    (``<repo>__<pr>__<head-sha>.txt``).
+    (``<repo>__<pr>__<base-tip-12>__<head-sha>.txt``).
 
     ``GENESIS_OVERRIDE_REVIEW_EVIDENCE_DIR`` overrides (config knob + test seam);
     default lives outside the repo so evidence survives worktree removal and is
@@ -1684,13 +1723,31 @@ def _hook_surface_override_check(pr_num: str, repo: str | None = None) -> tuple[
                 f"cannot key fallback-review evidence. Retry."
             ),
         )
-    # Evidence identity = repo + PR + head (Codex P2, round 1): a commit sha
-    # alone does not identify the PR/base whose FULL diff the fallback review
-    # covered — the same head can appear on another PR or in a fork, and
-    # sha-only evidence would silently vouch there too. An unresolvable repo
-    # degrades to the "local" namespace (still PR- and head-bound).
+    # Evidence identity = repo + PR + BASE + head (Codex P2s, rounds 1+2): a
+    # commit sha alone does not identify the PR/base whose FULL diff the
+    # fallback review covered — the same head can appear on another PR or in a
+    # fork, and (round 2) a retarget or advancing default branch changes the
+    # effective diff while head stays put; the sigil this path serves also
+    # waives _check_base_is_default, so base must be bound HERE. The bound value
+    # is the base branch's LIVE tip (never pulls/N.base.sha — a creation-time
+    # snapshot; see _pr_base_sha): binding to the live tip over-expires (any
+    # base move → re-record) — the safe direction on this rare, user-authorized
+    # path. Fail-closed on an unreadable base.
+    base = _pr_base_sha(pr_num, repo=repo)
+    if not base or not re.fullmatch(r"[0-9a-f]{40}", base.strip().lower()):
+        return (
+            True,
+            (
+                f"PR #{pr_num}'s BASE sha could not be read (or was malformed) — "
+                f"fallback-review evidence is base-bound and cannot be verified. "
+                f"Retry."
+            ),
+        )
+    base = base.strip().lower()
     repo_slug = (_normalize_repo(repo) or "local").replace("/", "_")
-    evidence_path = os.path.join(_override_evidence_dir(), f"{repo_slug}__{pr_num}__{head}.txt")
+    evidence_path = os.path.join(
+        _override_evidence_dir(), f"{repo_slug}__{pr_num}__{base[:12]}__{head}.txt"
+    )
     try:
         has_evidence = os.path.getsize(evidence_path) > 0
     except OSError:
@@ -1725,7 +1782,8 @@ def _hook_surface_override_check(pr_num: str, repo: str | None = None) -> tuple[
             f"  3. Record reviewer + findings + dispositions in:\n"
             f"       {evidence_path}\n"
             f"  4. Re-run this merge (same sigil). A new push changes the head "
-            f"sha — re-review and re-key.\n"
+            f"sha, and a base-branch change (retarget OR base advancing) "
+            f"re-keys too — re-review and re-record.\n"
             f"WHY: 2026-08-23 — an unreviewed merge on this surface disarms every "
             f"other gate; the GitHub Codex review is the required evidence class "
             f"(user decision), and this file's own history (#1432: 13 findings "

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -150,12 +150,34 @@ class TestFreshnessGate:
         assert block is False and head == HEAD
 
     def test_force_returns_no_verified_head(self, monkeypatch):
-        # Forced (# review-override) skips verification → no head to bind →
-        # the match-head requirement disengages too.
+        # Forced (# stale-review-override) on a NON-hook PR skips verification → no
+        # head to bind → the match-head requirement disengages too. (The benign
+        # non-hook default from _hermetic_pr_files makes the hook-surface evidence
+        # gate a no-op, so the force path returns allowed + unbound.)
         monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))
         block, _, head = _mod._check_codex_reviewed_head("1", force=True)
         assert block is False and head is None
+
+    def test_force_hook_surface_fresh_review_still_demands_evidence(self, monkeypatch, tmp_path):
+        # SECURITY LOCK — Codex #9 dispositioned FALSE-POSITIVE (2026-08-26). A fresh
+        # at-head Codex review must NOT skip the hook-surface evidence gate: the same
+        # # stale-review-override ALSO waives _check_base_is_default, and the evidence
+        # identity binds the BASE tip — which a head-only review provably cannot vouch
+        # for (a hook PR retargeted to a non-default base). So a hook-surface forced
+        # merge WITH a current review but NO recorded evidence still BLOCKS. Regression
+        # guard: a reverted "skip evidence when fresh" attempt opened a base-binding
+        # bypass; on that buggy code this test would have returned block=False.
+        monkeypatch.setenv("GENESIS_OVERRIDE_REVIEW_EVIDENCE_DIR", str(tmp_path))  # no evidence file
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            '{"filename": "scripts/hooks/git_push_guard.py", "previous_filename": null}',
+        )
+        monkeypatch.setenv("_TEST_GH_BASE_OID", STALE)  # hermetic base tip (no network)
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(HEAD))  # FRESH review at head
+        block, _, head = _mod._check_codex_reviewed_head("1", force=True)
+        assert block is True and head is None
 
 
 class TestMergeMatchHead:

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -18,6 +18,17 @@ from pathlib import Path
 
 import pytest
 
+
+@pytest.fixture(autouse=True)
+def _hermetic_pr_files(monkeypatch):
+    """Hermetic default for the hook-surface override gate's changed-files read:
+    without this, force-path tests hit a LIVE `gh api pulls/N/files` call —
+    green locally (gh authenticated; PR "1" of the cwd repo answers) and red in
+    CI (call fails -> fail-closed block). Tests override per-case."""
+    monkeypatch.setenv(
+        "_TEST_GH_PR_FILES", '{"filename": "src/benign.py", "previous_filename": null}'
+    )
+
 _WORKTREE = Path(__file__).resolve().parent.parent.parent
 _HOOKS_DIR = _WORKTREE / "scripts" / "hooks"
 _spec = importlib.util.spec_from_file_location("git_push_guard", _HOOKS_DIR / "git_push_guard.py")

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -485,6 +485,31 @@ class TestPostReviewDeltaClassify:
     def test_ahead_trivial_is_inline(self, monkeypatch):
         assert self._lvl(monkeypatch, _compare_json("ahead", [_code_file(additions=3)])) == "inline"
 
+    def test_malformed_filename_fails_closed_not_trivial(self, monkeypatch):
+        # Codex P2 (round 5): a compare record with a missing/null/empty `filename`
+        # must FAIL CLOSED (unclassifiable → None → block), never be silently skipped
+        # so an empty delta reads as review-trivial. Pre-fix, classify_compare_
+        # substantiality([{filename: None}]) returns "inline" (verified) → a hook-surface
+        # delta could merge on a stale review. Fail closed instead.
+        assert self._lvl(monkeypatch, _compare_json("ahead", [{"filename": None}])) is None
+        assert self._lvl(monkeypatch, _compare_json("ahead", [{"filename": ""}])) is None
+        assert self._lvl(monkeypatch, _compare_json("ahead", [{}])) is None  # key absent
+
+    def test_malformed_previous_filename_fails_closed(self, monkeypatch):
+        # A present-but-non-string `previous_filename` is also fail-closed (a rename
+        # record we cannot fully read must not be assumed trivial).
+        payload = _compare_json("ahead", [{"filename": "src/a.py", "previous_filename": 123}])
+        assert self._lvl(monkeypatch, payload) is None
+
+    def test_malformed_record_never_reads_as_inline_even_with_a_hook_file(self, monkeypatch):
+        # The exact fail-open Codex named: a malformed record alongside real files must
+        # never let the delta classify "inline". Fails closed (None) on the bad record
+        # before triviality is granted.
+        payload = _compare_json(
+            "ahead", [{"filename": None}, {"filename": "scripts/hooks/git_push_guard.py"}]
+        )
+        assert self._lvl(monkeypatch, payload) != "inline"
+
     def test_diverged_substantial_still_classifies(self, monkeypatch):
         # A rebase/force-push rewrite must NOT be assumed trivial.
         assert self._lvl(monkeypatch, _compare_json("diverged", [_code_file()])) == "substantial"

--- a/tests/test_hooks/test_git_push_guard_hook_surface.py
+++ b/tests/test_hooks/test_git_push_guard_hook_surface.py
@@ -33,6 +33,7 @@ _spec.loader.exec_module(_mod)
 
 HEAD = "0cd13afeb51025af5dc7bd24df1ffa57cd2babab"
 STALE = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+BASE = "b" * 40
 
 
 def _compare_json(*filenames, status="ahead", previous=None):
@@ -139,6 +140,7 @@ class TestOverrideEvidenceGate:
         self.dir = tmp_path / "override_evidence"
         monkeypatch.setenv("GENESIS_OVERRIDE_REVIEW_EVIDENCE_DIR", str(self.dir))
         monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_BASE_OID", BASE)
         monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")
 
     def test_non_hook_pr_force_passes_without_evidence(self, monkeypatch):
@@ -156,7 +158,7 @@ class TestOverrideEvidenceGate:
     def test_hook_pr_force_with_evidence_passes(self, monkeypatch, capsys):
         monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
         self.dir.mkdir(parents=True)
-        (self.dir / f"local__1__{HEAD}.txt").write_text(
+        (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text(
             "reviewer: claude-code adversarial (codex quota-dead)\nfindings: none\n"
         )
         should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
@@ -165,14 +167,14 @@ class TestOverrideEvidenceGate:
     def test_hook_pr_force_with_empty_evidence_blocks(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
         self.dir.mkdir(parents=True)
-        (self.dir / f"local__1__{HEAD}.txt").write_text("")
+        (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text("")
         should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
         assert should_block
 
     def test_hook_pr_force_evidence_for_wrong_sha_blocks(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
         self.dir.mkdir(parents=True)
-        (self.dir / f"local__1__{STALE}.txt").write_text("evidence for an older head\n")
+        (self.dir / f"local__1__{BASE[:12]}__{STALE}.txt").write_text("evidence for an older head\n")
         should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
         assert should_block
 
@@ -330,11 +332,12 @@ class TestRound1P2Regressions:
         d.mkdir()
         monkeypatch.setenv("GENESIS_OVERRIDE_REVIEW_EVIDENCE_DIR", str(d))
         monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_BASE_OID", BASE)
         monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")
         monkeypatch.setenv(
             "_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py")
         )
-        (d / f"ownera_repoa__1__{HEAD}.txt").write_text("evidence for repo A PR 1\n")
+        (d / f"ownera_repoa__1__{BASE[:12]}__{HEAD}.txt").write_text("evidence for repo A PR 1\n")
         blocked, msg, _ = _mod._check_codex_reviewed_head(
             "2", force=True, repo="ownerb/repob"
         )
@@ -343,3 +346,42 @@ class TestRound1P2Regressions:
             "1", force=True, repo="ownera/repoa"
         )
         assert not blocked
+
+
+class TestBaseBoundEvidence:
+    """Round-2 P2: evidence must be bound to the base that defined the
+    reviewed effective diff — a retarget/advancing base (same head) must not
+    be vouched for by old evidence."""
+
+    @pytest.fixture(autouse=True)
+    def _env(self, tmp_path, monkeypatch):
+        self.dir = tmp_path / "ev"
+        self.dir.mkdir()
+        monkeypatch.setenv("GENESIS_OVERRIDE_REVIEW_EVIDENCE_DIR", str(self.dir))
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py")
+        )
+
+    def test_evidence_for_old_base_blocks_after_base_moves(self, monkeypatch):
+        (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text("reviewed\n")
+        monkeypatch.setenv("_TEST_GH_BASE_OID", "c" * 40)  # base advanced
+        blocked, msg, _ = _mod._check_codex_reviewed_head("1", force=True)
+        assert blocked
+
+    def test_evidence_for_current_base_passes(self, monkeypatch):
+        (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text("reviewed\n")
+        monkeypatch.setenv("_TEST_GH_BASE_OID", BASE)
+        blocked, msg, _ = _mod._check_codex_reviewed_head("1", force=True)
+        assert not blocked
+
+    def test_unreadable_base_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_BASE_OID", "")
+        blocked, msg, _ = _mod._check_codex_reviewed_head("1", force=True)
+        assert blocked
+
+    def test_malformed_base_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_BASE_OID", "not-a-sha")
+        blocked, msg, _ = _mod._check_codex_reviewed_head("1", force=True)
+        assert blocked

--- a/tests/test_hooks/test_git_push_guard_hook_surface.py
+++ b/tests/test_hooks/test_git_push_guard_hook_surface.py
@@ -156,7 +156,7 @@ class TestOverrideEvidenceGate:
     def test_hook_pr_force_with_evidence_passes(self, monkeypatch, capsys):
         monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
         self.dir.mkdir(parents=True)
-        (self.dir / f"{HEAD}.txt").write_text(
+        (self.dir / f"local__1__{HEAD}.txt").write_text(
             "reviewer: claude-code adversarial (codex quota-dead)\nfindings: none\n"
         )
         should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
@@ -165,14 +165,14 @@ class TestOverrideEvidenceGate:
     def test_hook_pr_force_with_empty_evidence_blocks(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
         self.dir.mkdir(parents=True)
-        (self.dir / f"{HEAD}.txt").write_text("")
+        (self.dir / f"local__1__{HEAD}.txt").write_text("")
         should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
         assert should_block
 
     def test_hook_pr_force_evidence_for_wrong_sha_blocks(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
         self.dir.mkdir(parents=True)
-        (self.dir / f"{STALE}.txt").write_text("evidence for an older head\n")
+        (self.dir / f"local__1__{STALE}.txt").write_text("evidence for an older head\n")
         should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
         assert should_block
 
@@ -270,3 +270,76 @@ class TestWiredHooksFenceGuardrail:
             f"hooks wired in .claude/settings.json but OUTSIDE the merge-teeth "
             f"fence — add them to _HOOK_SURFACE_FILES in git_push_guard.py: {outside}"
         )
+
+
+class TestRound1P2Regressions:
+    """Codex round-1 P2s: record validation, row-count cap, config fence."""
+
+    def test_null_filename_record_fails_closed(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES", '{"filename": null, "previous_filename": null}'
+        )
+        assert _mod._pr_changed_files("1") is None
+
+    def test_empty_filename_record_fails_closed(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES", '{"filename": "", "previous_filename": null}'
+        )
+        assert _mod._pr_changed_files("1") is None
+
+    def test_non_string_previous_filename_fails_closed(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES", '{"filename": "a.py", "previous_filename": 7}'
+        )
+        assert _mod._pr_changed_files("1") is None
+
+    def test_cap_counts_rows_not_expanded_paths(self, monkeypatch):
+        # 1500 renames = 3000 expanded paths but only 1500 API rows — must NOT
+        # trip the 3000-row cap (the old expanded-path count false-closed here).
+        lines = "\n".join(
+            json.dumps({"filename": f"new{i}.py", "previous_filename": f"old{i}.py"})
+            for i in range(1500)
+        )
+        monkeypatch.setenv("_TEST_GH_PR_FILES", lines)
+        files = _mod._pr_changed_files("1")
+        assert files is not None
+        assert len(files) == 3000
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "config/protected_paths.yaml",
+            "config/repo_topology.yaml",
+            "config/behavioral_rules/no_hide_problems.yaml",
+            "config/behavioral_rules/some_future_rule.yaml",
+        ],
+    )
+    def test_hook_owned_config_is_fenced(self, path):
+        # Decision-driving config IS enforcement surface: the ordinary
+        # substantiality classifier treats YAML as review-trivial, so a
+        # rewrite removing blocking patterns could otherwise merge stale.
+        assert _mod._is_hook_surface_path(path)
+
+    def test_unrelated_config_not_fenced(self):
+        assert not _mod._is_hook_surface_path("config/genesis.yaml.example")
+
+    def test_evidence_identity_includes_repo_and_pr(self, tmp_path, monkeypatch):
+        # Codex P2: sha-only evidence would vouch across PRs/repos sharing a
+        # head. Evidence written for (repo A, PR 1) must NOT pass (repo B, PR 2).
+        d = tmp_path / "ev"
+        d.mkdir()
+        monkeypatch.setenv("GENESIS_OVERRIDE_REVIEW_EVIDENCE_DIR", str(d))
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py")
+        )
+        (d / f"ownera_repoa__1__{HEAD}.txt").write_text("evidence for repo A PR 1\n")
+        blocked, msg, _ = _mod._check_codex_reviewed_head(
+            "2", force=True, repo="ownerb/repob"
+        )
+        assert blocked
+        blocked, msg, _ = _mod._check_codex_reviewed_head(
+            "1", force=True, repo="ownera/repoa"
+        )
+        assert not blocked

--- a/tests/test_hooks/test_git_push_guard_hook_surface.py
+++ b/tests/test_hooks/test_git_push_guard_hook_surface.py
@@ -36,6 +36,18 @@ STALE = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 BASE = "b" * 40
 
 
+def _valid_evidence(head: str = HEAD) -> str:
+    """A conforming fallback-review evidence body: substantive (>= the guard's
+    _MIN_OVERRIDE_EVIDENCE_CHARS floor) and NAMING the head it vouches for."""
+    return (
+        "reviewer: claude-code adversarial review (genesis-architect; codex quota-dead).\n"
+        f"head reviewed: {head}\n"
+        "findings: P2 x2 — base-ref encoding, evidence content validation. "
+        "dispositions: both fixed and verified end-to-end; no BLOCKER/P1 remaining. "
+        "scope: full PR diff over scripts/hooks/git_push_guard.py.\n"
+    )
+
+
 def _compare_json(*filenames, status="ahead", previous=None):
     """_TEST_GH_COMPARE shape: the object _classify_post_review_delta fetches."""
     files = []
@@ -158,9 +170,7 @@ class TestOverrideEvidenceGate:
     def test_hook_pr_force_with_evidence_passes(self, monkeypatch, capsys):
         monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
         self.dir.mkdir(parents=True)
-        (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text(
-            "reviewer: claude-code adversarial (codex quota-dead)\nfindings: none\n"
-        )
+        (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text(_valid_evidence())
         should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
         assert not should_block
 
@@ -168,6 +178,26 @@ class TestOverrideEvidenceGate:
         monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
         self.dir.mkdir(parents=True)
         (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text("")
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert should_block
+
+    def test_hook_pr_force_short_evidence_blocks(self, monkeypatch):
+        # Content validation (Codex P2 round 2): a nonempty-but-trivial file at the
+        # right path (a rubber stamp) must not waive the gate.
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
+        self.dir.mkdir(parents=True)
+        (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text(f"ok {HEAD}\n")
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert should_block
+
+    def test_hook_pr_force_evidence_not_naming_head_blocks(self, monkeypatch):
+        # Substantive length but the body does not name the head it vouches for →
+        # the content is not bound to this head → blocks (Codex P2 round 2).
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
+        self.dir.mkdir(parents=True)
+        body = "reviewer: genesis-architect. findings: none. dispositions: n/a. " * 6
+        assert HEAD[:12] not in body.lower()
+        (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text(body)
         should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
         assert should_block
 
@@ -337,7 +367,7 @@ class TestRound1P2Regressions:
         monkeypatch.setenv(
             "_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py")
         )
-        (d / f"ownera_repoa__1__{BASE[:12]}__{HEAD}.txt").write_text("evidence for repo A PR 1\n")
+        (d / f"ownera_repoa__1__{BASE[:12]}__{HEAD}.txt").write_text(_valid_evidence())
         blocked, msg, _ = _mod._check_codex_reviewed_head(
             "2", force=True, repo="ownerb/repob"
         )
@@ -371,10 +401,11 @@ class TestBaseBoundEvidence:
         assert blocked
 
     def test_evidence_for_current_base_passes(self, monkeypatch):
-        (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text("reviewed\n")
+        (self.dir / f"local__1__{BASE[:12]}__{HEAD}.txt").write_text(_valid_evidence())
         monkeypatch.setenv("_TEST_GH_BASE_OID", BASE)
         blocked, msg, _ = _mod._check_codex_reviewed_head("1", force=True)
         assert not blocked
+
 
     def test_unreadable_base_blocks(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_BASE_OID", "")
@@ -385,3 +416,39 @@ class TestBaseBoundEvidence:
         monkeypatch.setenv("_TEST_GH_BASE_OID", "not-a-sha")
         blocked, msg, _ = _mod._check_codex_reviewed_head("1", force=True)
         assert blocked
+
+
+class TestBaseRefEncoding:
+    """Round-2 P2: the base ref becomes an API path component in _pr_base_sha, so
+    it must be URL-encoded (safe='/' preserves hierarchical branch slashes)."""
+
+    def _capture(self, monkeypatch, ref):
+        monkeypatch.delenv("_TEST_GH_BASE_OID", raising=False)  # force the ref path
+        monkeypatch.setenv("_TEST_GH_BASE_REF", ref)
+        captured = {}
+
+        def fake_run(argv, *a, **k):
+            captured["argv"] = argv
+
+            class _R:
+                returncode = 0
+                stdout = "a" * 40
+
+            return _R()
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        sha = _mod._pr_base_sha("1")
+        url = next(a for a in captured["argv"] if "commits/" in a)
+        return url, sha
+
+    def test_hierarchical_branch_slash_preserved(self, monkeypatch):
+        url, sha = self._capture(monkeypatch, "release/2.0")
+        assert url.endswith("commits/release/2.0")
+        assert sha == "a" * 40
+
+    def test_special_char_ref_encoded(self, monkeypatch):
+        # a '#' in a ref must not inject a fragment into the API path
+        url, _ = self._capture(monkeypatch, "feat/x#y")
+        path = url.split("commits/", 1)[1]
+        assert path == "feat/x%23y"
+        assert "#" not in path

--- a/tests/test_hooks/test_git_push_guard_hook_surface.py
+++ b/tests/test_hooks/test_git_push_guard_hook_surface.py
@@ -1,0 +1,272 @@
+"""Tests for the hook-surface merge teeth in git_push_guard.
+
+Two mechanical rules scoped to the enforcement-hook surface (scripts/hooks/**,
+bash_safety_hook.sh, review_scope/review_state, .claude/settings.json,
+.claude/hooks/**):
+
+1. A stale-review delta touching the hook surface is NEVER "review-trivial" —
+   a "small single-file touch-up" to an enforcement hook is exactly what must
+   not skip re-review (_classify_post_review_delta returns "substantial").
+2. ``# stale-review-override`` on a PR whose diff touches the hook surface
+   additionally requires a recorded fallback-review evidence file keyed to the
+   PR's EXACT head sha — the mechanical form of "override needs user
+   authorization + a fallback review (local codex / Claude Code adversarial)".
+
+Network-free via the _TEST_GH_* env-injection seams (mirrors the freshness
+tests in test_git_push_guard_codex_freshness.py).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parent.parent.parent
+_HOOKS_DIR = _WORKTREE / "scripts" / "hooks"
+_spec = importlib.util.spec_from_file_location("git_push_guard", _HOOKS_DIR / "git_push_guard.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+HEAD = "0cd13afeb51025af5dc7bd24df1ffa57cd2babab"
+STALE = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+
+def _compare_json(*filenames, status="ahead", previous=None):
+    """_TEST_GH_COMPARE shape: the object _classify_post_review_delta fetches."""
+    files = []
+    for name in filenames:
+        entry = {
+            "filename": name,
+            "additions": 2,
+            "deletions": 1,
+            "status": "modified",
+            "previous_filename": None,
+            "has_patch": True,
+        }
+        files.append(entry)
+    if previous:
+        files.append(
+            {
+                "filename": previous[1],
+                "additions": 0,
+                "deletions": 0,
+                "status": "renamed",
+                "previous_filename": previous[0],
+                "has_patch": False,
+            }
+        )
+    return json.dumps({"status": status, "files": files})
+
+
+def _files_jsonl(*filenames, previous=None):
+    """_TEST_GH_PR_FILES shape: one JSON object per line from pulls/N/files."""
+    lines = [json.dumps({"filename": f, "previous_filename": None}) for f in filenames]
+    if previous:
+        lines.append(json.dumps({"filename": previous[1], "previous_filename": previous[0]}))
+    return "\n".join(lines)
+
+
+class TestHookSurfaceMatcher:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "scripts/hooks/git_push_guard.py",
+            "scripts/hooks/shell_parse.py",
+            "scripts/hooks/newly_added_guard.py",
+            "scripts/bash_safety_hook.sh",
+            "scripts/review_scope.py",
+            "scripts/review_state.py",
+            ".claude/settings.json",
+            ".claude/hooks/genesis-hook",
+        ],
+    )
+    def test_hook_surface_paths_match(self, path):
+        assert _mod._is_hook_surface_path(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "src/genesis/cc/conversation.py",
+            "tests/test_hooks/test_git_push_guard_hook_surface.py",
+            "docs/architecture/CURRENT.md",
+            "scripts/backup.sh",
+            "scripts/hooks_readme.md",  # prefix must be a path segment, not a substring
+            ".claude/settings.local.json",
+            ".claude/skills/genesis-development/SKILL.md",
+        ],
+    )
+    def test_non_hook_surface_paths_do_not_match(self, path):
+        assert not _mod._is_hook_surface_path(path)
+
+
+class TestHookSurfaceDeltaNeverTrivial:
+    """Delta A: hook-surface files in the unreviewed compare force 'substantial'."""
+
+    def test_docs_only_delta_still_inline(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_COMPARE", _compare_json("README.md"))
+        assert _mod._classify_post_review_delta(STALE, HEAD, None) == "inline"
+
+    def test_hook_file_delta_is_substantial(self, monkeypatch):
+        # A tiny 2-line touch-up that review_scope would classify inline —
+        # but it touches an enforcement hook, so it is substantial by fiat.
+        monkeypatch.setenv("_TEST_GH_COMPARE", _compare_json("scripts/hooks/git_push_guard.py"))
+        assert _mod._classify_post_review_delta(STALE, HEAD, None) == "substantial"
+
+    def test_hook_file_mixed_with_docs_is_substantial(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_COMPARE", _compare_json("README.md", "scripts/bash_safety_hook.sh")
+        )
+        assert _mod._classify_post_review_delta(STALE, HEAD, None) == "substantial"
+
+    def test_rename_from_hook_surface_is_substantial(self, monkeypatch):
+        # A rename OUT of the hook surface (guard deleted/moved) is a hook change.
+        monkeypatch.setenv(
+            "_TEST_GH_COMPARE",
+            _compare_json(previous=("scripts/hooks/git_discard_guard.py", "attic/old.py")),
+        )
+        assert _mod._classify_post_review_delta(STALE, HEAD, None) == "substantial"
+
+
+class TestOverrideEvidenceGate:
+    """Delta B: # stale-review-override on a hook-surface PR needs evidence."""
+
+    @pytest.fixture(autouse=True)
+    def _evidence_dir(self, tmp_path, monkeypatch):
+        self.dir = tmp_path / "override_evidence"
+        monkeypatch.setenv("GENESIS_OVERRIDE_REVIEW_EVIDENCE_DIR", str(self.dir))
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")
+
+    def test_non_hook_pr_force_passes_without_evidence(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("src/genesis/cc/types.py"))
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert not should_block
+
+    def test_hook_pr_force_without_evidence_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert should_block
+        assert "fallback-review evidence" in msg
+        assert HEAD[:12] in msg  # message names the head the evidence must be keyed to
+
+    def test_hook_pr_force_with_evidence_passes(self, monkeypatch, capsys):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
+        self.dir.mkdir(parents=True)
+        (self.dir / f"{HEAD}.txt").write_text(
+            "reviewer: claude-code adversarial (codex quota-dead)\nfindings: none\n"
+        )
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert not should_block
+
+    def test_hook_pr_force_with_empty_evidence_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
+        self.dir.mkdir(parents=True)
+        (self.dir / f"{HEAD}.txt").write_text("")
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert should_block
+
+    def test_hook_pr_force_evidence_for_wrong_sha_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
+        self.dir.mkdir(parents=True)
+        (self.dir / f"{STALE}.txt").write_text("evidence for an older head\n")
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert should_block
+
+    def test_unreadable_pr_files_blocks(self, monkeypatch):
+        # fail-closed: if the diff can't be read, assume hook surface
+        monkeypatch.setenv("_TEST_GH_PR_FILES", "__error__")
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert should_block
+
+    def test_unreadable_head_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", "")
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert should_block
+
+    def test_rename_out_of_hook_surface_counts(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            _files_jsonl(previous=("scripts/hooks/git_discard_guard.py", "attic/x.py")),
+        )
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert should_block
+
+    def test_force_never_returns_verified_head(self, monkeypatch):
+        # the force path must keep its documented "conscious unbound merge"
+        # contract: no --match-head-commit binding is derived from it
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("README.md"))
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert not should_block
+        assert verified is None
+
+    def test_malformed_head_sha_blocks(self, monkeypatch):
+        # network-sourced string becomes a path component — garbage blocks
+        # explicitly, never a silently unmatchable filename
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files_jsonl("scripts/hooks/git_push_guard.py"))
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", "../../../etc/passwd")
+        should_block, msg, verified = _mod._check_codex_reviewed_head("1", force=True)
+        assert should_block
+
+
+class TestChangedFilesFailDirections:
+    """The three fail-closed parse paths of _pr_changed_files (architect NOTE 4)."""
+
+    def test_malformed_json_line_returns_none(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", "not json at all")
+        assert _mod._pr_changed_files("1") is None
+
+    def test_non_dict_line_returns_none(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", json.dumps(["a", "list"]))
+        assert _mod._pr_changed_files("1") is None
+
+    def test_pagination_cap_returns_none(self, monkeypatch):
+        lines = "\n".join(
+            json.dumps({"filename": f"src/f{i}.py", "previous_filename": None}) for i in range(3000)
+        )
+        monkeypatch.setenv("_TEST_GH_PR_FILES", lines)
+        assert _mod._pr_changed_files("1") is None
+
+
+class TestWiredHooksFenceGuardrail:
+    """Every hook wired in .claude/settings.json must be inside the merge-teeth
+    fence — a future wiring that falls outside it is a CI failure, keeping
+    _HOOK_SURFACE_FILES self-maintaining (architect SHOULD-FIX 2026-08-23: the
+    named-list-as-sample trap; review_enforcement_commit.py et al. lived outside
+    the original 4-file fence)."""
+
+    def _wired_hook_paths(self):
+        cfg = json.loads((_WORKTREE / ".claude" / "settings.json").read_text())
+        wired = set()
+        for entries in cfg.get("hooks", {}).values():
+            for entry in entries:
+                for h in entry.get("hooks", []):
+                    cmd = h.get("command", "")
+                    # ${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook <name>
+                    # resolves <name> as scripts/<name> (see genesis-hook:41)
+                    for m in re.finditer(r"genesis-hook\s+(\S+)", cmd):
+                        wired.add(f"scripts/{m.group(1)}")
+                    # direct bash/python wiring of a scripts/ path
+                    for m in re.finditer(
+                        r"(?:bash|python3?)\s+(?:\$\{?CLAUDE_PROJECT_DIR\}?/)?(scripts/\S+)",
+                        cmd,
+                    ):
+                        wired.add(m.group(1))
+        return wired
+
+    def test_wiring_discovery_is_not_vacuous(self):
+        wired = self._wired_hook_paths()
+        assert "scripts/hooks/git_push_guard.py" in wired
+        assert "scripts/review_enforcement_commit.py" in wired
+        assert len(wired) >= 20
+
+    def test_every_wired_hook_is_inside_the_fence(self):
+        outside = sorted(p for p in self._wired_hook_paths() if not _mod._is_hook_surface_path(p))
+        assert not outside, (
+            f"hooks wired in .claude/settings.json but OUTSIDE the merge-teeth "
+            f"fence — add them to _HOOK_SURFACE_FILES in git_push_guard.py: {outside}"
+        )

--- a/tests/test_hooks/test_git_push_guard_hook_surface.py
+++ b/tests/test_hooks/test_git_push_guard_hook_surface.py
@@ -419,11 +419,14 @@ class TestBaseBoundEvidence:
 
 
 class TestBaseRefEncoding:
-    """Round-2 P2: the base ref becomes an API path component in _pr_base_sha, so
-    it must be URL-encoded (safe='/' preserves hierarchical branch slashes)."""
+    """Codex #10: _pr_base_sha resolves the live base tip via GraphQL
+    ``ref(qualifiedName:"refs/heads/<branch>")`` with the branch as a RAW-STRING
+    variable — NOT a REST ``commits/{ref}`` URL. That closes both the heads/-vs-tag
+    ambiguity AND the URL-structural-char (`#`/`?`/`%`) truncation class at once,
+    because the branch name never enters a URL path."""
 
-    def _capture(self, monkeypatch, ref):
-        monkeypatch.delenv("_TEST_GH_BASE_OID", raising=False)  # force the ref path
+    def _capture(self, monkeypatch, ref, repo="o/r"):
+        monkeypatch.delenv("_TEST_GH_BASE_OID", raising=False)  # force the resolve path
         monkeypatch.setenv("_TEST_GH_BASE_REF", ref)
         captured = {}
 
@@ -437,18 +440,85 @@ class TestBaseRefEncoding:
             return _R()
 
         monkeypatch.setattr(_mod.subprocess, "run", fake_run)
-        sha = _mod._pr_base_sha("1")
-        url = next(a for a in captured["argv"] if "commits/" in a)
-        return url, sha
+        sha = _mod._pr_base_sha("1", repo=repo)
+        return captured.get("argv"), sha
 
-    def test_hierarchical_branch_slash_preserved(self, monkeypatch):
-        url, sha = self._capture(monkeypatch, "release/2.0")
-        assert url.endswith("commits/release/2.0")
+    def _ref_arg(self, argv):
+        # the raw-string GraphQL variable `-f ref=refs/heads/<branch>`
+        return next(a for a in argv if a.startswith("ref=refs/heads/"))
+
+    def test_uses_graphql_not_rest_commits(self, monkeypatch):
+        # RED anchor: old REST code produced a `commits/<ref>` path; the GraphQL
+        # path must carry NO `commits/` at all.
+        argv, sha = self._capture(monkeypatch, "main")
+        assert "graphql" in argv
+        assert not any("commits/" in str(a) for a in argv)
         assert sha == "a" * 40
 
-    def test_special_char_ref_encoded(self, monkeypatch):
-        # a '#' in a ref must not inject a fragment into the API path
-        url, _ = self._capture(monkeypatch, "feat/x#y")
-        path = url.split("commits/", 1)[1]
-        assert path == "feat/x%23y"
-        assert "#" not in path
+    def test_ref_qualified_as_heads_slash_preserved(self, monkeypatch):
+        argv, sha = self._capture(monkeypatch, "release/2.0")
+        assert self._ref_arg(argv) == "ref=refs/heads/release/2.0"
+        assert sha == "a" * 40
+
+    def test_hash_char_ref_passed_raw_not_encoded(self, monkeypatch):
+        # a '#' rides verbatim in a GraphQL string variable — no URL, so no %23
+        # encoding and no fragment truncation (the round-2/round-4 class).
+        argv, _ = self._capture(monkeypatch, "feat/x#y")
+        assert self._ref_arg(argv) == "ref=refs/heads/feat/x#y"
+
+    def test_heads_named_branch_disambiguated(self, monkeypatch):
+        # a branch literally named 'heads/release' qualifies to refs/heads/heads/release
+        # — it can never resolve refs/heads/release or a same-named tag.
+        argv, _ = self._capture(monkeypatch, "heads/release")
+        assert self._ref_arg(argv) == "ref=refs/heads/heads/release"
+
+    def test_uses_raw_field_flag_not_typed(self, monkeypatch):
+        # -f (raw string), never -F (type-coerces / reads @file): a numeric or
+        # @-leading branch name must stay a literal GraphQL String.
+        argv, _ = self._capture(monkeypatch, "123")
+        assert "-f" in argv
+        assert "-F" not in argv
+
+    def test_null_target_fails_closed(self, monkeypatch):
+        # GraphQL ref:null (missing branch) → jq emits "null" → None (fail-closed).
+        monkeypatch.delenv("_TEST_GH_BASE_OID", raising=False)
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "gone")
+
+        def fake_run(argv, *a, **k):
+            class _R:
+                returncode = 0
+                stdout = "null\n"
+
+            return _R()
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        assert _mod._pr_base_sha("1", repo="o/r") is None
+
+    def test_repo_none_resolves_slug_from_cwd(self, monkeypatch):
+        # repo=None → derive owner/name from the cwd's base repo (GraphQL has no
+        # :owner/:repo placeholder); a resolvable slug builds the query.
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "o/r")
+        argv, sha = self._capture(monkeypatch, "main", repo=None)
+        assert "owner=o" in argv
+        assert "name=r" in argv
+        assert sha == "a" * 40
+
+    def test_repo_none_unresolvable_fails_closed(self, monkeypatch):
+        # repo=None and an unresolvable cwd slug → None, with NO GraphQL call made.
+        monkeypatch.setenv("_TEST_GH_DERIVED_REPO", "")  # empty → _derive returns None
+        monkeypatch.delenv("_TEST_GH_BASE_OID", raising=False)
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "main")
+        called = {"n": 0}
+
+        def fake_run(argv, *a, **k):
+            called["n"] += 1
+
+            class _R:
+                returncode = 0
+                stdout = "x"
+
+            return _R()
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        assert _mod._pr_base_sha("1", repo=None) is None
+        assert called["n"] == 0  # slug unresolved → no GraphQL attempted

--- a/tests/test_hooks/test_git_push_guard_hook_surface.py
+++ b/tests/test_hooks/test_git_push_guard_hook_surface.py
@@ -522,3 +522,37 @@ class TestBaseRefEncoding:
         monkeypatch.setattr(_mod.subprocess, "run", fake_run)
         assert _mod._pr_base_sha("1", repo=None) is None
         assert called["n"] == 0  # slug unresolved → no GraphQL attempted
+
+    def test_non_ascii_whitespace_ref_is_accepted(self, monkeypatch):
+        # Codex P2 (round 5): U+00A0 (non-breaking space) is a LEGAL Git branch char —
+        # it must NOT be rejected (str.isspace() over-rejects it; that would falsely
+        # block the authorized evidence path). It rides through to the GraphQL variable.
+        argv, sha = self._capture(monkeypatch, "release 1")
+        assert self._ref_arg(argv) == "ref=refs/heads/release 1"
+        assert sha == "a" * 40
+
+    def _capture_no_call(self, monkeypatch, ref):
+        monkeypatch.delenv("_TEST_GH_BASE_OID", raising=False)
+        monkeypatch.setenv("_TEST_GH_BASE_REF", ref)
+        called = {"n": 0}
+
+        def fake_run(argv, *a, **k):
+            called["n"] += 1
+
+            class _R:
+                returncode = 0
+                stdout = "x"
+
+            return _R()
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        result = _mod._pr_base_sha("1", repo="o/r")
+        return result, called["n"]
+
+    def test_ascii_space_ref_rejected(self, monkeypatch):
+        # A plain ASCII space IS forbidden by Git's ref rules → fail closed, no call.
+        assert self._capture_no_call(monkeypatch, "release 1") == (None, 0)
+
+    def test_control_char_ref_rejected(self, monkeypatch):
+        # An ASCII control char is forbidden by Git's ref rules → fail closed, no call.
+        assert self._capture_no_call(monkeypatch, "rel\x01ease") == (None, 0)

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -35,6 +35,17 @@ from pathlib import Path
 
 import pytest
 
+
+@pytest.fixture(autouse=True)
+def _hermetic_pr_files(monkeypatch):
+    """Hermetic default for the hook-surface override gate's changed-files read:
+    without this, force-path tests hit a LIVE `gh api pulls/N/files` call —
+    green locally (gh authenticated; PR "1" of the cwd repo answers) and red in
+    CI (call fails -> fail-closed block). Tests override per-case."""
+    monkeypatch.setenv(
+        "_TEST_GH_PR_FILES", '{"filename": "src/benign.py", "previous_filename": null}'
+    )
+
 # Load the hook module directly from THIS worktree (mirrors the freshness suite),
 # so the corpus locks the behaviour of the code under test in-tree.
 _WORKTREE = Path(__file__).resolve().parent.parent.parent

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -16,6 +16,17 @@ from unittest.mock import patch
 
 import pytest
 
+
+@pytest.fixture(autouse=True)
+def _hermetic_pr_files(monkeypatch):
+    """Hermetic default for the hook-surface override gate's changed-files read:
+    without this, force-path tests hit a LIVE `gh api pulls/N/files` call —
+    green locally (gh authenticated; PR "1" of the cwd repo answers) and red in
+    CI (call fails -> fail-closed block). Tests override per-case."""
+    monkeypatch.setenv(
+        "_TEST_GH_PR_FILES", '{"filename": "src/benign.py", "previous_filename": null}'
+    )
+
 # Resolve the hook script path
 _SCRIPTS = Path(__file__).resolve().parents[2] / "scripts" / "hooks"
 _GUARD = _SCRIPTS / "git_push_guard.py"


### PR DESCRIPTION
## Why

A PR touching the enforcement-hook surface is the code the merge/push/commit gates themselves run on — an unreviewed merge there disarms every other gate. Two real incidents motivated mechanical teeth (not conventions): a PR with 13 real review findings (10 P1) was reported "review-clean" off a hand-rolled findings query whose wrong author-string filter returned empty, and only the merge gate caught it; and the freshness gate's review-trivial narrowing would have let a "small single-file touch-up" to a guard merge without re-review at all (verified against the unmodified gate).

## What

Two rules in `git_push_guard.py`'s review-freshness gate, scoped to the hook-surface fence (`scripts/hooks/**`, `.claude/hooks/**`, the global bash safety hook, review_scope/review_state, `.claude/settings.json`, and every `scripts/`-root hook wired via the hook dispatcher):

1. **Never review-trivial.** An unreviewed compare delta touching the fence always classifies substantial (rename sources included) — hook touch-ups can no longer slip the smart-delta narrowing.
2. **Evidence-gated override.** `# stale-review-override` alone no longer merges a fence-touching PR: recorded fallback-review evidence keyed to the exact head sha is additionally required, fail-closed on unreadable changed-files list (new `_pr_changed_files`, paginated, ≥3000-cap, malformed-line rejection), malformed head sha (oid fullmatch before it becomes a path component), or empty/wrong-sha evidence. The block message documents the authorized fallback procedure. Non-fence PRs keep the sigil's existing semantics; the force pass path keeps its documented unbound-merge contract (`verified_head=None`, test-pinned).

**Self-maintaining fence:** a guardrail test parses the hook wiring config, resolves every wired hook command, and fails CI if any wired hook falls outside the fence — a future wiring can't silently exit it. (Adversarial review found the original 4-file fence missed 20 wired `scripts/`-root hooks — the exact named-list-as-sample trap this change documents.)

**Skill updates (genesis-development):** review-findings status is checked ONLY via `git_push_guard.py --check-pr <N>` (the merge gate's own code path, strict fail-closed — never a hand-rolled `pulls/N/comments` query, whose wrong filter's empty result reads as clean); the hook-surface teeth + override procedure documented; the hand-rolled-parser trap now states the class boundary (argv→effect mapping is in the tar pit regardless of who tokenizes) + the decision test (could an unknown flag change your verdict? → closed-set claims or recoverability).

## Tests

New `tests/test_hooks/test_git_push_guard_hook_surface.py` (34): surface matcher with substring negatives, never-trivial deltas, override evidence block/pass/wrong-sha/empty, fail-closed parse paths, unbound-merge contract, wiring guardrail. Both behavioral deltas verify-RED against the unmodified gate. Affected merge-gate suites 424 passed; full test_hooks 1575 passed; ruff clean. Adversarially reviewed (genesis-architect): 1 SHOULD-FIX + 4 NOTEs, all fixed in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
