### PR TITLE
test(campaigns): defuse wall-clock time-bomb in park-status tests

### DIFF
--- a/tests/test_campaigns/test_runner.py
+++ b/tests/test_campaigns/test_runner.py
@@ -362,11 +362,20 @@ class TestParkAwareSessionStatus:
     async def _seed_failed_parked_session(self, db, park_status: str):
         from genesis.db.crud import cc_sessions
 
+        # Seed the park NOW-RELATIVE, not with an absolute literal. _check_session_status
+        # ages the park's created_at against the REAL wall clock (runner.py:430,
+        # `datetime.now(UTC) - created > _PARK_WAIT_BOUND`, bound = 7 days) and there is no
+        # injectable now, so a fixed seed like "2026-08-17" silently works only until the
+        # calendar crosses the bound, then flips these "still running" tests to failing (a
+        # wall-clock time-bomb). A recent seed keeps the park within its wait window on any
+        # run date. (The over-bound tests below deliberately UPDATE created_at to an old
+        # value afterward, so this recent default does not affect them.)
+        recent = datetime.now(UTC).isoformat()
         await cc_sessions.create(
             db, id="camp-sess-1", session_type="background_task",
             model="sonnet", effort="medium", source_tag="campaign",
-            started_at="2026-08-17T10:00:00+00:00",
-            last_activity_at="2026-08-17T10:00:00+00:00",
+            started_at=recent,
+            last_activity_at=recent,
         )
         await db.execute(
             "UPDATE cc_sessions SET status='failed', metadata=? WHERE id=?",
@@ -376,8 +385,7 @@ class TestParkAwareSessionStatus:
             """INSERT INTO cc_rate_limit_parks
                (id, kind, dedup_key, payload_json, status, created_at, updated_at)
                VALUES (?, 'direct_session', 'dk1', '{}', ?, ?, ?)""",
-            ("rlp-test0001", park_status,
-             "2026-08-17T10:00:00+00:00", "2026-08-17T10:00:00+00:00"),
+            ("rlp-test0001", park_status, recent, recent),
         )
         await db.commit()
 


### PR DESCRIPTION
## Problem

`tests/test_campaigns/test_runner.py::TestParkAwareSessionStatus` seeded a
`cc_rate_limit_parks` row with a **fixed** literal `created_at="2026-08-17T10:00:00Z"`.
The production path under test ages that timestamp against the **real wall clock** —
`runner.py:430` `datetime.now(UTC) - created > _PARK_WAIT_BOUND` (bound = 7 days), with no
injectable clock. So the "reads as still running" tests passed only for **7 days** after
the seed date, then flipped to failing on **2026-08-24** — reddening the `test` CI job for
every open PR, not just this one.

This is a **wall-clock time-bomb**: an absolute seed compared against `now()` with a
threshold works when written, then detonates once the calendar crosses the threshold.

## Fix

Seed the park (and the session's `started_at`/`last_activity_at`) **now-relative**, so it
always sits inside its 7-day wait window on any run date, with a comment explaining why (to
prevent re-hardcoding). The over-bound tests, which deliberately backdate `created_at`
afterward, are unaffected — a fixed *old* date stays always-over-bound and never flips.

## Whole-class sweep

Rather than fix only the site on fire, the entire class was swept (four parallel triage
agents traced every absolute datetime literal seeded into test state across the tree to its
production consumer, plus an adversarial cross-check of production staleness windows longer
than a week). **This was the only wall-clock time-bomb found** — the codebase otherwise
injects clocks (`now=`/`clock=`) or seeds now-relative.

## Verification

- Reproduced RED (both tests fail today with the literal seed) → GREEN after the fix.
- `tests/test_campaigns/test_runner.py` = 30 passed; verify-RED done (reverted → fail →
  restored → pass); `ruff` clean.
- Unblocks the `test` CI job for #1434 and #1437, whose only failure was this bomb.

Follow-up: 202367ef817345f6ab692da401a81b73
