### PR TITLE
fix(cc): daily session reset fires at local midnight, not UTC midnight

### DIFF
--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -7,7 +7,7 @@ import json
 import logging
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from genesis.cc import rate_limit_park, roster
@@ -37,6 +37,7 @@ from genesis.cc.types import (
 )
 from genesis.db.crud import cc_sessions
 from genesis.observability.call_site_recorder import record_last_run
+from genesis.util import tz
 
 if TYPE_CHECKING:
     from genesis.cc.contingency import CCContingencyDispatcher
@@ -1620,11 +1621,19 @@ class ConversationLoop:
         except Exception:
             logger.debug("User correction scan failed", exc_info=True)
 
-    def _should_reset(self, session: dict) -> bool:
+    def _should_reset(self, session: dict, *, now: datetime | None = None) -> bool:
         """Check if session is from a previous day boundary.
+
+        The boundary is local-midnight (``day_boundary_hour`` in the user's
+        timezone), not UTC-midnight — otherwise the daily reset fires at
+        ~20:00 local instead of local midnight for a UTC-offset install
+        (see :func:`genesis.util.tz.local_day_boundary`).
 
         Supergroup topic sessions (thread_id set) are persistent — they
         only compact when CC context limits are hit, never by day boundary.
+
+        *now* is injectable for deterministic tests; defaults to the current
+        instant.
         """
         # Supergroup topic sessions are persistent — no daily reset
         if session.get("thread_id"):
@@ -1635,10 +1644,5 @@ class ConversationLoop:
         started_dt = datetime.fromisoformat(started)
         if started_dt.tzinfo is None:
             started_dt = started_dt.replace(tzinfo=UTC)
-        now = datetime.now(UTC)
-        boundary = now.replace(
-            hour=self._day_boundary_hour, minute=0, second=0, microsecond=0,
-        )
-        if now < boundary:
-            boundary -= timedelta(days=1)
+        boundary = tz.local_day_boundary(self._day_boundary_hour, now=now)
         return started_dt < boundary

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -1625,8 +1625,8 @@ class ConversationLoop:
         """Check if session is from a previous day boundary.
 
         The boundary is local-midnight (``day_boundary_hour`` in the user's
-        timezone), not UTC-midnight — otherwise the daily reset fires at
-        ~20:00 local instead of local midnight for a UTC-offset install
+        timezone), not UTC-midnight — otherwise the daily reset fires at the
+        UTC-midnight instant instead of local midnight on any UTC-offset install
         (see :func:`genesis.util.tz.local_day_boundary`).
 
         Supergroup topic sessions (thread_id set) are persistent — they

--- a/src/genesis/cc/session_manager.py
+++ b/src/genesis/cc/session_manager.py
@@ -17,6 +17,7 @@ from genesis.cc.types import (
     session_origin_for_channel,
 )
 from genesis.db.crud import cc_sessions
+from genesis.util import tz
 
 logger = logging.getLogger(__name__)
 
@@ -192,22 +193,21 @@ class SessionManager:
         now = datetime.now(UTC).isoformat()
         await cc_sessions.update_activity(self._db, session_id, last_activity_at=now)
 
-    async def check_morning_reset(self, *, user_id: str) -> bool:
+    async def check_morning_reset(self, *, user_id: str, now: datetime | None = None) -> bool:
         """Check if sessions from a previous day boundary should be reset.
 
         Returns True if there are completed/expired sessions from before
         the current day boundary (suggesting a new day has started).
+
+        The boundary is local-midnight (``day_boundary_hour`` in the user's
+        timezone) serialized in UTC — matching the ``+00:00`` timestamps stored
+        in ``cc_sessions`` so the ``query_stale`` string ``<`` comparison stays
+        lexicographically correct (see :func:`genesis.util.tz.local_day_boundary`).
+
+        *now* is injectable for deterministic tests; defaults to the current
+        instant.
         """
-        now = datetime.now(UTC)
-        boundary = now.replace(
-            hour=self._day_boundary_hour,
-            minute=0,
-            second=0,
-            microsecond=0,
-        )
-        if now < boundary:
-            boundary -= timedelta(days=1)
-        boundary_iso = boundary.isoformat()
+        boundary_iso = tz.local_day_boundary(self._day_boundary_hour, now=now).isoformat()
 
         # Check if there are sessions that completed before today's boundary
         rows = await cc_sessions.query_stale(self._db, older_than=boundary_iso)

--- a/src/genesis/util/tz.py
+++ b/src/genesis/util/tz.py
@@ -7,7 +7,7 @@ use these functions for storage — only for rendering to the user.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from genesis.env import user_timezone as _get_user_timezone
@@ -79,3 +79,29 @@ def parse_utc_iso(iso_str: str | None) -> datetime | None:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
     return dt
+
+
+def local_day_boundary(hour: int = 0, *, now: datetime | None = None) -> datetime:
+    """Most recent day boundary at *hour* local time, as a UTC-aware datetime.
+
+    The boundary is ``hour:00`` in the user's local timezone — today's if that
+    instant has already passed, otherwise yesterday's. This is a read-path
+    comparison helper (like :func:`parse_utc_iso`), not a display helper: it
+    lets "has a new local day started since <stored UTC timestamp>?" be answered
+    correctly regardless of the gap between the user's timezone and UTC.
+
+    Returned in **UTC** on purpose. Genesis stores timestamps as UTC ISO strings
+    (``...+00:00``); those sort/compare lexicographically only when every value
+    carries the same offset, so a boundary serialized with a local offset
+    (``...-04:00``) would silently break a string ``<`` comparison in SQL. UTC
+    return keeps ``.isoformat()`` and ``datetime`` comparisons both correct.
+
+    *now* (UTC-aware) is injectable for deterministic tests; defaults to the
+    current instant.
+    """
+    now_utc = now.astimezone(UTC) if now is not None else datetime.now(UTC)
+    now_local = now_utc.astimezone(_USER_TZ)
+    boundary_local = now_local.replace(hour=hour, minute=0, second=0, microsecond=0)
+    if now_local < boundary_local:
+        boundary_local -= timedelta(days=1)
+    return boundary_local.astimezone(UTC)

--- a/tests/test_cc/test_conversation.py
+++ b/tests/test_cc/test_conversation.py
@@ -702,3 +702,26 @@ async def test_build_fresh_invocation_applies_routing_for_channel(loop):
         channel=ChannelType.TERMINAL,
     )
     assert _BG_RESEARCH_ROUTING not in (inv_term.system_prompt or "")
+
+
+@pytest.mark.asyncio
+async def test_should_reset_uses_local_midnight_not_utc(loop, monkeypatch):
+    """_should_reset keys the daily reset off LOCAL midnight, not UTC midnight.
+
+    Regression guard: a UTC-offset install used to reset sessions at ~20:00
+    local (UTC midnight) instead of local midnight.
+    """
+    from zoneinfo import ZoneInfo
+
+    import genesis.util.tz as tz_module
+
+    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("America/New_York"))
+
+    # now = 2026-08-24 12:00 UTC (08:00 EDT). Local midnight = 2026-08-24 04:00 UTC.
+    now = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
+
+    # Started 02:00 UTC — before LOCAL midnight (04:00 UTC) but after UTC
+    # midnight (00:00 UTC). Local semantics → reset; buggy UTC → no reset.
+    assert loop._should_reset({"started_at": "2026-08-24T02:00:00+00:00"}, now=now) is True
+    # Started 06:00 UTC — after local midnight → not stale yet today.
+    assert loop._should_reset({"started_at": "2026-08-24T06:00:00+00:00"}, now=now) is False

--- a/tests/test_cc/test_conversation.py
+++ b/tests/test_cc/test_conversation.py
@@ -715,9 +715,10 @@ async def test_should_reset_uses_local_midnight_not_utc(loop, monkeypatch):
 
     import genesis.util.tz as tz_module
 
-    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("America/New_York"))
+    # Fixed UTC-4 offset (Etc/GMT+4) — no real location, install-generic.
+    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Etc/GMT+4"))
 
-    # now = 2026-08-24 12:00 UTC (08:00 EDT). Local midnight = 2026-08-24 04:00 UTC.
+    # now = 2026-08-24 12:00 UTC (08:00 at UTC-4). Local midnight = 2026-08-24 04:00 UTC.
     now = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
 
     # Started 02:00 UTC — before LOCAL midnight (04:00 UTC) but after UTC

--- a/tests/test_cc/test_session_manager.py
+++ b/tests/test_cc/test_session_manager.py
@@ -289,9 +289,10 @@ async def test_check_morning_reset_uses_local_utc_boundary(db, manager, monkeypa
 
     import genesis.util.tz as tz_module
 
-    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("America/New_York"))
+    # Fixed UTC-4 offset (Etc/GMT+4) — no real location, install-generic.
+    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Etc/GMT+4"))
 
-    # now = 2026-08-24 12:00 UTC (08:00 EDT). Local midnight = 2026-08-24 04:00 UTC.
+    # now = 2026-08-24 12:00 UTC (08:00 at UTC-4). Local midnight = 2026-08-24 04:00 UTC.
     now = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
 
     # Background session last-active 02:00 UTC — before the local boundary → stale.

--- a/tests/test_cc/test_session_manager.py
+++ b/tests/test_cc/test_session_manager.py
@@ -278,3 +278,46 @@ async def test_foreground_gateway_origin_external(db, manager):
     )
     row = await cc_sessions.get_by_id(db, sess["id"])
     assert row["origin_class"] == "external_untrusted"
+
+
+async def test_check_morning_reset_uses_local_utc_boundary(db, manager, monkeypatch):
+    """Boundary is LOCAL midnight, serialized in UTC so the query_stale string
+    comparison against stored +00:00 timestamps stays lexicographically correct.
+    """
+    from datetime import UTC, datetime
+    from zoneinfo import ZoneInfo
+
+    import genesis.util.tz as tz_module
+
+    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("America/New_York"))
+
+    # now = 2026-08-24 12:00 UTC (08:00 EDT). Local midnight = 2026-08-24 04:00 UTC.
+    now = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
+
+    # Background session last-active 02:00 UTC — before the local boundary → stale.
+    await cc_sessions.create(
+        db,
+        id="stale-bg",
+        session_type="background_task",
+        model="sonnet",
+        status="active",
+        started_at="2026-08-24T02:00:00+00:00",
+        last_activity_at="2026-08-24T02:00:00+00:00",
+        source_tag="background",
+    )
+    assert await manager.check_morning_reset(user_id="u1", now=now) is True
+
+    # After the stale one is retired, a session last-active 06:00 UTC (after the
+    # local boundary) is not stale yet today.
+    await cc_sessions.update_status(db, "stale-bg", status="completed")
+    await cc_sessions.create(
+        db,
+        id="fresh-bg",
+        session_type="background_task",
+        model="sonnet",
+        status="active",
+        started_at="2026-08-24T06:00:00+00:00",
+        last_activity_at="2026-08-24T06:00:00+00:00",
+        source_tag="background",
+    )
+    assert await manager.check_morning_reset(user_id="u1", now=now) is False

--- a/tests/test_util/test_tz.py
+++ b/tests/test_util/test_tz.py
@@ -1,12 +1,12 @@
 """Tests for genesis.util.tz — timezone display helpers."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import pytest
 
 import genesis.util.tz as tz_module
-from genesis.util.tz import fmt, fmt_short, parse_utc_iso
+from genesis.util.tz import fmt, fmt_short, local_day_boundary, parse_utc_iso
 
 
 @pytest.fixture()
@@ -78,3 +78,61 @@ class TestParseUtcIso:
 
     def test_invalid_returns_none(self):
         assert parse_utc_iso("not-a-timestamp") is None
+
+
+class TestLocalDayBoundary:
+    """The day boundary must be LOCAL midnight (hour), not UTC midnight.
+
+    Regression guard for the CC-session daily-reset bug: sessions reset at
+    ~20:00 ET instead of local midnight because the boundary was computed in
+    UTC. The boundary must also be returned UTC-aware so a string ``<``
+    comparison against stored ``+00:00`` timestamps stays lexicographically
+    correct (the query_stale trap).
+    """
+
+    def test_boundary_is_local_midnight_not_utc(self, eastern_tz):
+        # now = 2026-08-24 03:00 UTC = 2026-08-23 23:00 EDT (still Aug 23 local).
+        # Most recent LOCAL midnight = Aug 23 00:00 EDT = 2026-08-23 04:00 UTC.
+        # The buggy UTC-midnight logic would give 2026-08-24 00:00 UTC.
+        now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
+        assert local_day_boundary(0, now=now) == datetime(2026, 8, 23, 4, 0, tzinfo=UTC)
+
+    def test_boundary_returned_utc_aware_plus_zero_offset(self, eastern_tz):
+        # The ISO-string trap: boundary must serialize with +00:00, never a
+        # local offset, or the query_stale string comparison breaks.
+        now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
+        boundary = local_day_boundary(0, now=now)
+        assert boundary.utcoffset() == timedelta(0)
+        assert boundary.isoformat().endswith("+00:00")
+
+    def test_boundary_dst_winter_est(self, eastern_tz):
+        # January: EST is UTC-5. now = 2026-01-15 04:00 UTC = 2026-01-14 23:00 EST.
+        # Local midnight Jan 14 00:00 EST = 2026-01-14 05:00 UTC.
+        now = datetime(2026, 1, 15, 4, 0, tzinfo=UTC)
+        assert local_day_boundary(0, now=now) == datetime(2026, 1, 14, 5, 0, tzinfo=UTC)
+
+    def test_boundary_just_after_local_midnight_is_today(self, eastern_tz):
+        # now = 2026-08-24 05:00 UTC = 2026-08-24 01:00 EDT (just past local midnight).
+        # Boundary = Aug 24 00:00 EDT = 2026-08-24 04:00 UTC (today's, no rollback).
+        now = datetime(2026, 8, 24, 5, 0, tzinfo=UTC)
+        assert local_day_boundary(0, now=now) == datetime(2026, 8, 24, 4, 0, tzinfo=UTC)
+
+    def test_boundary_nonzero_hour(self, eastern_tz):
+        # hour=6 (06:00 local). now = 2026-08-24 03:00 UTC = 2026-08-23 23:00 EDT.
+        # Most recent 06:00 EDT = Aug 23 06:00 EDT = 2026-08-23 10:00 UTC.
+        now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
+        assert local_day_boundary(6, now=now) == datetime(2026, 8, 23, 10, 0, tzinfo=UTC)
+
+    def test_utc_install_unaffected(self, monkeypatch):
+        # A UTC install: boundary IS UTC midnight (no behavior change).
+        import genesis.util.tz as tz_module
+
+        monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("UTC"))
+        now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
+        assert local_day_boundary(0, now=now) == datetime(2026, 8, 24, 0, 0, tzinfo=UTC)
+
+    def test_default_now_returns_recent_past_utc(self, eastern_tz):
+        # Smoke test with real now: boundary is UTC-aware and in the past.
+        boundary = local_day_boundary(0)
+        assert boundary.tzinfo is not None
+        assert boundary <= datetime.now(UTC)

--- a/tests/test_util/test_tz.py
+++ b/tests/test_util/test_tz.py
@@ -80,24 +80,31 @@ class TestParseUtcIso:
         assert parse_utc_iso("not-a-timestamp") is None
 
 
+@pytest.fixture()
+def utc_minus_4(monkeypatch):
+    """Pin _USER_TZ to a fixed UTC-4 offset (Etc/GMT+4) — no real location, no DST."""
+    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Etc/GMT+4"))  # Etc/GMT+4 == UTC-4
+
+
 class TestLocalDayBoundary:
     """The day boundary must be LOCAL midnight (hour), not UTC midnight.
 
-    Regression guard for the CC-session daily-reset bug: sessions reset at
-    ~20:00 ET instead of local midnight because the boundary was computed in
-    UTC. The boundary must also be returned UTC-aware so a string ``<``
-    comparison against stored ``+00:00`` timestamps stays lexicographically
-    correct (the query_stale trap).
+    Regression guard for the CC-session daily-reset bug: sessions reset at the
+    UTC-midnight instant instead of local midnight because the boundary was
+    computed in UTC. The boundary must also be returned UTC-aware so a string
+    ``<`` comparison against stored ``+00:00`` timestamps stays lexicographically
+    correct (the query_stale trap). Fixed offsets (Etc/GMT+N) keep these tests
+    install-generic — no real timezone is hardcoded.
     """
 
-    def test_boundary_is_local_midnight_not_utc(self, eastern_tz):
-        # now = 2026-08-24 03:00 UTC = 2026-08-23 23:00 EDT (still Aug 23 local).
-        # Most recent LOCAL midnight = Aug 23 00:00 EDT = 2026-08-23 04:00 UTC.
+    def test_boundary_is_local_midnight_not_utc(self, utc_minus_4):
+        # now = 2026-08-24 03:00 UTC = 2026-08-23 23:00 at UTC-4 (still Aug 23 local).
+        # Most recent LOCAL midnight = Aug 23 00:00 (UTC-4) = 2026-08-23 04:00 UTC.
         # The buggy UTC-midnight logic would give 2026-08-24 00:00 UTC.
         now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
         assert local_day_boundary(0, now=now) == datetime(2026, 8, 23, 4, 0, tzinfo=UTC)
 
-    def test_boundary_returned_utc_aware_plus_zero_offset(self, eastern_tz):
+    def test_boundary_returned_utc_aware_plus_zero_offset(self, utc_minus_4):
         # The ISO-string trap: boundary must serialize with +00:00, never a
         # local offset, or the query_stale string comparison breaks.
         now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
@@ -105,33 +112,34 @@ class TestLocalDayBoundary:
         assert boundary.utcoffset() == timedelta(0)
         assert boundary.isoformat().endswith("+00:00")
 
-    def test_boundary_dst_winter_est(self, eastern_tz):
-        # January: EST is UTC-5. now = 2026-01-15 04:00 UTC = 2026-01-14 23:00 EST.
-        # Local midnight Jan 14 00:00 EST = 2026-01-14 05:00 UTC.
+    def test_boundary_respects_zone_offset(self, monkeypatch):
+        # A different fixed offset (UTC-5) yields a different UTC boundary,
+        # proving the boundary follows the zone, not a hardcoded offset.
+        monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Etc/GMT+5"))  # UTC-5
+        # now = 2026-01-15 04:00 UTC = 2026-01-14 23:00 at UTC-5.
+        # Local midnight Jan 14 00:00 (UTC-5) = 2026-01-14 05:00 UTC.
         now = datetime(2026, 1, 15, 4, 0, tzinfo=UTC)
         assert local_day_boundary(0, now=now) == datetime(2026, 1, 14, 5, 0, tzinfo=UTC)
 
-    def test_boundary_just_after_local_midnight_is_today(self, eastern_tz):
-        # now = 2026-08-24 05:00 UTC = 2026-08-24 01:00 EDT (just past local midnight).
-        # Boundary = Aug 24 00:00 EDT = 2026-08-24 04:00 UTC (today's, no rollback).
+    def test_boundary_just_after_local_midnight_is_today(self, utc_minus_4):
+        # now = 2026-08-24 05:00 UTC = 2026-08-24 01:00 at UTC-4 (just past local midnight).
+        # Boundary = Aug 24 00:00 (UTC-4) = 2026-08-24 04:00 UTC (today's, no rollback).
         now = datetime(2026, 8, 24, 5, 0, tzinfo=UTC)
         assert local_day_boundary(0, now=now) == datetime(2026, 8, 24, 4, 0, tzinfo=UTC)
 
-    def test_boundary_nonzero_hour(self, eastern_tz):
-        # hour=6 (06:00 local). now = 2026-08-24 03:00 UTC = 2026-08-23 23:00 EDT.
-        # Most recent 06:00 EDT = Aug 23 06:00 EDT = 2026-08-23 10:00 UTC.
+    def test_boundary_nonzero_hour(self, utc_minus_4):
+        # hour=6 (06:00 local). now = 2026-08-24 03:00 UTC = 2026-08-23 23:00 at UTC-4.
+        # Most recent 06:00 (UTC-4) = Aug 23 06:00 = 2026-08-23 10:00 UTC.
         now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
         assert local_day_boundary(6, now=now) == datetime(2026, 8, 23, 10, 0, tzinfo=UTC)
 
     def test_utc_install_unaffected(self, monkeypatch):
         # A UTC install: boundary IS UTC midnight (no behavior change).
-        import genesis.util.tz as tz_module
-
         monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("UTC"))
         now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
         assert local_day_boundary(0, now=now) == datetime(2026, 8, 24, 0, 0, tzinfo=UTC)
 
-    def test_default_now_returns_recent_past_utc(self, eastern_tz):
+    def test_default_now_returns_recent_past_utc(self, utc_minus_4):
         # Smoke test with real now: boundary is UTC-aware and in the past.
         boundary = local_day_boundary(0)
         assert boundary.tzinfo is not None


### PR DESCRIPTION
## Problem
The CC-session daily reset computed its day boundary in UTC:
`datetime.now(UTC).replace(hour=day_boundary_hour)`. On any install whose
timezone is offset from UTC, the reset fired at UTC-midnight instead of local
midnight — e.g. ~20:00 for a US-Eastern install with the default
`day_boundary_hour=0`. Sessions were being retired mid-evening rather than
overnight.

Two call sites shared the bug: `ConversationLoop._should_reset` (the live path,
hit on every message) and `SessionManager.check_morning_reset`.

## Fix
Extract one helper, `genesis.util.tz.local_day_boundary(hour, now=None)`, that
computes the most-recent `hour:00` boundary **in the user's timezone** and
returns it **UTC-aware**. Both call sites delegate.

Returning UTC is load-bearing for `check_morning_reset`: its boundary is
serialized and string-compared (`<`) against stored `+00:00` timestamps inside
`cc_sessions.query_stale`. A local-offset ISO string (`...-04:00`) would sort
lexicographically wrong against `+00:00` values and silently break the query —
so the helper normalizes to UTC, matching every `last_activity_at` write site
(all `datetime.now(UTC).isoformat()`).

`now` is an injectable seam (defaults to the current instant) so the boundary
logic is deterministically testable without a time-freezing dependency.

## Tests
- `TestLocalDayBoundary`: local-vs-UTC boundary, DST correctness (EST vs EDT),
  UTC-install no-op (byte-identical behavior), and the `+00:00` serialization
  that closes the string-comparison trap.
- Wiring tests exercise both real call sites via the injected clock.
- **Verified-RED**: reverting the helper to the old UTC-midnight computation
  fails exactly the 4 distinguishing tests; the fix makes them pass.

Generalizable: a UTC install is unaffected; the boundary follows
`user_timezone()`, no hardcoded offset.