### PR TITLE
feat(scripts): tailscale SSH access doc + boot self-heal installer

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -172,6 +172,7 @@ Architecture Decision Records — load-bearing choices with context and rational
 - [Lessons Learned](reference/genesis-lessons-learned.md) — Hard-won project wisdom
 - [Project Rules](reference/genesis-project-rules.md) — Development conventions
 - [CC Compatibility](reference/cc-compatibility.md) — Claude Code integration notes
+- [Tailscale SSH Access](reference/tailscale-ssh-access.md) — Reaching your fleet's tmux slots over Tailscale; IP-keyed aliases + Windows after-reboot troubleshooting
 - [Portability & Recovery](reference/recovery-and-portability-workflow.md) — Backup and restore
 
 ---

--- a/docs/reference/tailscale-ssh-access.md
+++ b/docs/reference/tailscale-ssh-access.md
@@ -1,0 +1,122 @@
+# Tailscale SSH Access to Your Genesis Fleet
+
+How to reach a Genesis host (and its persistent Claude Code tmux slots) over
+Tailscale from any client device — and how to keep that access rock-solid across
+reboots on Windows clients with a busy network stack.
+
+## What this gives you
+
+Each Genesis host exposes numbered tmux **slots** and a **lobby** landing session
+over SSH. From a laptop or phone you type `ssh <host>-1` to land in a specific
+persistent session, or `ssh <host>-lobby` to open a picker of every live slot.
+The sessions live in tmux on the box, so a client reboot never kills them — one
+reconnect brings the whole fleet back in the state you left it.
+
+## Setup
+
+On each Genesis host, generate the client config snippet and paste it into your
+client's `~/.ssh/config` (Windows: `C:\Users\<you>\.ssh\config`):
+
+```bash
+./scripts/generate-ssh-config.sh
+```
+
+Copy the printed block into `~/.ssh/config` on every client device, **replacing**
+any earlier Genesis block for that host (don't append a second one — SSH uses the
+first matching block, so a stale one would win). Then:
+
+```
+ssh <host>-1        # a specific slot (any positive integer)
+ssh <host>-lobby    # the session picker → pick any live slot
+```
+
+Windows one-click: make a shortcut whose target is `wt.exe ssh <host>-lobby`
+(or `ssh.exe <host>-lobby`) and pin it to the taskbar.
+
+## Why the aliases are keyed on the Tailscale IP, not the MagicDNS name
+
+`generate-ssh-config.sh` writes each `HostName` as the host's **stable Tailscale
+IPv4**, not its `*.ts.net` MagicDNS name. A Tailscale IP is pinned per device and
+routes without the client's DNS resolver, so the config keeps working even when
+MagicDNS is disrupted on the client. This matters because MagicDNS is the fragile
+link on a busy Windows client (see below). Re-run the generator if a host's
+Tailscale IP ever changes (device removed and re-added to the tailnet).
+
+## Troubleshooting: SSH breaks after a reboot (Windows)
+
+**Symptom.** Right after a reboot/login, `ssh <host>-N` times out and/or plain
+tailnet names won't resolve (`ssh user@<name>` → "could not resolve hostname").
+After a while it starts working again on its own.
+
+**Cause.** Two things degrade for a window after boot, and both self-heal once
+Tailscale fully settles:
+
+1. **Cold tunnels.** Tailscale hasn't yet established the peer connections, so
+   even an IP-keyed alias times out until the tunnel warms.
+2. **MagicDNS applied late.** On a client with a **contended DNS stack** —
+   several DNS-managing VPNs installed, a large hosts-file ad/malware blocker,
+   and/or manually pinned DNS servers — Tailscale's MagicDNS write repeatedly
+   loses a race for the Windows DNS configuration at boot. Its health then shows
+   `dns-set-os-config-failed: The process cannot access the file because it is
+   being used by another process`, and tailnet **names** don't resolve until a
+   write finally wins.
+
+This is a client-side environmental race, not a Genesis or Tailscale defect — it
+tends to appear only on machines carrying a lot of network software.
+
+### Fix 1 — IP-key every alias (removes the DNS dependency)
+
+The generator already IP-keys the slot and lobby aliases. If you add **your own**
+hosts to `~/.ssh/config`, key those on the Tailscale IP too, so none of your SSH
+depends on MagicDNS:
+
+```
+# Instead of:  HostName my-box            (needs MagicDNS)
+# Use:         HostName 100.x.y.z         (the peer's Tailscale IP)
+```
+
+Find a peer's Tailscale IP with `tailscale ip -4 <peer>` or `tailscale status`.
+With every alias IP-keyed, the MagicDNS flap can no longer affect your SSH.
+
+### Fix 2 — Install the boot self-heal (closes the cold-tunnel window)
+
+`scripts/tailscale-ssh-selfheal.ps1` installs a scheduled task that, a short
+delay after each login, re-applies MagicDNS and pings every online tailnet peer
+to warm the tunnels — so the fleet is reachable within a few seconds of login
+instead of after an unpredictable settle. Run it once, in an **elevated**
+PowerShell on the client:
+
+```powershell
+# from the repo's scripts\ directory, elevated:
+.\tailscale-ssh-selfheal.ps1                 # install (default 45s post-login delay)
+.\tailscale-ssh-selfheal.ps1 -DelaySeconds 30
+.\tailscale-ssh-selfheal.ps1 -Uninstall      # remove it
+```
+
+It derives peers live from `tailscale status`, so it hardcodes nothing about your
+tailnet. Logs to `C:\ProgramData\GenesisNet\ts-selfheal.log`. Test without
+rebooting: `Start-ScheduledTask -TaskName GenesisTailscaleSelfHeal`, then read the
+log.
+
+### The battery gotcha (why a hand-rolled task may silently do nothing)
+
+On a **laptop**, Windows scheduled tasks default to *"don't start on battery
+power"* — a task created with a bare `schtasks /create` will sit **Queued** and
+never run while unplugged, with no error. The installer avoids this by using
+`Register-ScheduledTask` with `-AllowStartIfOnBatteries -DontStopIfGoingOnBatteries`.
+If you build your own task, set those or it will no-op on battery.
+
+### The cosmetic health warning
+
+Even after the fixes, Tailscale may still *show* `dns-set-os-config-failed`
+flapping if you keep the contended DNS stack (multiple VPNs, a big hosts blocker,
+pinned DNS). That warning no longer affects your SSH once every alias is
+IP-keyed — nothing you type relies on MagicDNS. If you want it gone at the root,
+reduce the contention: remove VPNs you don't use, move ad-blocking off the
+hosts file (e.g. to a DNS resolver), or let Tailscale manage DNS.
+
+## Reverting
+
+`generate-ssh-config.sh` only prints a snippet — you paste it, so reverting is
+editing your own `~/.ssh/config`. The self-heal task is removed with
+`.\tailscale-ssh-selfheal.ps1 -Uninstall`.

--- a/docs/reference/tailscale-ssh-access.md
+++ b/docs/reference/tailscale-ssh-access.md
@@ -94,9 +94,10 @@ PowerShell on the client:
 ```
 
 It derives peers live from `tailscale status`, so it hardcodes nothing about your
-tailnet. Logs to `C:\ProgramData\GenesisNet\ts-selfheal.log`. Test without
-rebooting: `Start-ScheduledTask -TaskName GenesisTailscaleSelfHeal`, then read the
-log.
+tailnet. Logs to `C:\ProgramData\GenesisNet\<TaskName>.log` (by default
+`GenesisTailscaleSelfHeal.log` — the installer prints the exact path on the `Log:`
+line). Test without rebooting: `Start-ScheduledTask -TaskName GenesisTailscaleSelfHeal`,
+then read that log.
 
 ### The battery gotcha (why a hand-rolled task may silently do nothing)
 

--- a/scripts/generate-ssh-config.sh
+++ b/scripts/generate-ssh-config.sh
@@ -6,6 +6,9 @@
 # into ~/.ssh/config on client devices.
 #
 # Usage: ./scripts/generate-ssh-config.sh
+#
+# Setup + troubleshooting (esp. flaky SSH after a Windows reboot, and the boot
+# self-heal helper): docs/reference/tailscale-ssh-access.md
 
 set -euo pipefail
 
@@ -91,3 +94,8 @@ echo "" >&2
 echo "Windows one-click: create a shortcut whose target is" >&2
 echo "    wt.exe ssh ${TS_HOSTNAME}-lobby     (or:  ssh.exe ${TS_HOSTNAME}-lobby)" >&2
 echo "then pin it to the taskbar — double-click reattaches the whole fleet." >&2
+echo "" >&2
+echo "These aliases are keyed on the Tailscale IP, so they don't need MagicDNS." >&2
+echo "Key any hosts YOU add to ~/.ssh/config on the peer's Tailscale IP too. If SSH" >&2
+echo "is flaky right after a Windows reboot, see the boot self-heal + troubleshooting" >&2
+echo "in docs/reference/tailscale-ssh-access.md." >&2

--- a/scripts/tailscale-ssh-selfheal.ps1
+++ b/scripts/tailscale-ssh-selfheal.ps1
@@ -1,0 +1,159 @@
+<#
+.SYNOPSIS
+  Install a battery-safe boot self-heal task for Tailscale SSH access (Windows client).
+
+.DESCRIPTION
+  On a Windows client with a contended DNS stack (several DNS-managing VPNs, a large
+  hosts-file ad/malware blocker, and/or manually pinned DNS servers), Tailscale's
+  MagicDNS/NRPT write can intermittently lose a race for the Windows DNS configuration
+  at boot. The result: for a window after login, peer tunnels stay cold and MagicDNS
+  names do not resolve, so SSH to your Genesis fleet times out until Tailscale settles.
+
+  This installs a scheduled task that, a short delay after each login, re-applies
+  MagicDNS and pings every ONLINE tailnet peer to warm the tunnels — closing that
+  window automatically. It derives peers live from `tailscale status`, so it hardcodes
+  nothing about your tailnet. Pair it with IP-keyed ssh aliases (generate-ssh-config.sh)
+  so your SSH never depends on MagicDNS in the first place.
+
+  See docs/reference/tailscale-ssh-access.md for the full picture.
+
+.PARAMETER DelaySeconds
+  Seconds to wait after login before healing. Default 45 (lets the boot storm settle).
+
+.PARAMETER TaskName
+  Scheduled task name. Default 'GenesisTailscaleSelfHeal'.
+
+.PARAMETER Uninstall
+  Remove the task and its generated files instead of installing.
+
+.NOTES
+  Windows-only. Run in an ELEVATED PowerShell (registering a SYSTEM task needs admin).
+  Requires Tailscale installed on this client. No-op-safe to re-run (idempotent).
+
+.EXAMPLE
+  .\tailscale-ssh-selfheal.ps1
+.EXAMPLE
+  .\tailscale-ssh-selfheal.ps1 -DelaySeconds 30
+.EXAMPLE
+  .\tailscale-ssh-selfheal.ps1 -Uninstall
+#>
+# behavioral-lint: ignore no-hide-problems
+#   Justification: the generated headless payload sets $ErrorActionPreference =
+#   'SilentlyContinue' ONLY so one transient peer error cannot abort warming the
+#   rest — it hides nothing. That task runs as SYSTEM with no console, so it logs
+#   EVERY outcome (successes and failures, with the real error text) to
+#   ts-selfheal.log; the log is the surface. Existence checks here use
+#   -ErrorAction SilentlyContinue by design (a not-yet-created task/file/log is a
+#   normal state, reported clearly). The installer itself fails loud ('Stop').
+[CmdletBinding()]
+param(
+    [ValidateRange(0, 3600)]
+    [int]$DelaySeconds = 45,
+    [string]$TaskName = 'GenesisTailscaleSelfHeal',
+    [switch]$Uninstall
+)
+
+$ErrorActionPreference = 'Stop'
+$dir        = Join-Path $env:ProgramData 'GenesisNet'
+$scriptPath = Join-Path $dir 'ts-selfheal.ps1'
+
+if ($Uninstall) {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+    Remove-Item $scriptPath -Force -ErrorAction SilentlyContinue
+    # Also remove the generated log and (if now empty) the GenesisNet directory,
+    # so uninstall genuinely removes "its generated files" as documented.
+    Remove-Item (Join-Path $dir 'ts-selfheal.log') -Force -ErrorAction SilentlyContinue
+    Remove-Item $dir -Force -ErrorAction SilentlyContinue  # no -Recurse: only removes it if empty
+    Write-Host "Removed task '$TaskName' and its generated files under $dir."
+    return
+}
+
+# Elevation is required to register a task that runs as SYSTEM.
+$identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principalCheck = [Security.Principal.WindowsPrincipal]::new($identity)
+if (-not $principalCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "Run this in an ELEVATED PowerShell (needed to register a SYSTEM scheduled task)."
+}
+
+New-Item -ItemType Directory -Path $dir -Force | Out-Null
+
+# The self-heal payload, run by the task as SYSTEM a short delay after each login.
+# Single-quoted here-string: nothing below is expanded at install time.
+$selfHeal = @'
+# ts-selfheal.ps1 (generated) — warm Tailscale tunnels + re-apply MagicDNS after login.
+#
+# Runs headless as SYSTEM with no console, so the log IS the surface: every branch
+# below records its outcome (success AND failure, with the real error text). We set
+# SilentlyContinue only so a single transient peer error cannot abort warming the
+# rest — NOT to swallow problems. Nothing is hidden; failures are logged explicitly.
+$ErrorActionPreference = 'SilentlyContinue'
+$dir = Join-Path $env:ProgramData 'GenesisNet'
+$log = Join-Path $dir 'ts-selfheal.log'
+function Log($m) { Add-Content -Path $log -Value ((Get-Date -Format o) + '  ' + $m) }
+# Cap the log so it can never grow without bound.
+if ((Get-Item $log -ErrorAction SilentlyContinue).Length -gt 1MB) { Remove-Item $log -Force -ErrorAction SilentlyContinue }
+Log 'self-heal run'
+
+$ts = (Get-Command tailscale.exe -ErrorAction SilentlyContinue).Source
+if (-not $ts) { $ts = Join-Path $env:ProgramFiles 'Tailscale\tailscale.exe' }
+if (-not (Test-Path $ts)) { Log "ABORT: tailscale.exe not found (looked at Get-Command and '$ts'). Is Tailscale installed?"; return }
+
+# 1. Re-apply MagicDNS. Bounded in a job so a DNS-config lock cannot hang the task.
+$j = Start-Job { param($t) & $t set --accept-dns=true 2>&1 } -ArgumentList $ts
+if (Wait-Job $j -Timeout 20) {
+    $out = (Receive-Job $j | Out-String).Trim()
+    if ($out) { Log "accept-dns re-applied (output: $out)" } else { Log 'accept-dns re-applied' }
+} else {
+    Log 'accept-dns did NOT complete within 20s (DNS config likely locked by another process); left as-is'
+    Stop-Job $j
+}
+Remove-Job $j -Force
+
+# 2. Warm every online peer so IP-keyed aliases connect immediately. Peers are
+#    read live from `tailscale status`, so nothing about the tailnet is hardcoded.
+$peers = @()
+try {
+    # Do NOT merge stderr (2>&1) into the JSON stream: a cosmetic tailscale
+    # warning line would break ConvertFrom-Json and zero out warming. stdout is
+    # pure JSON; stderr goes to the discarded error stream.
+    $status = & $ts status --json | ConvertFrom-Json
+    $peers  = @($status.Peer.PSObject.Properties.Value | Where-Object { $_.Online })
+    Log ("found {0} online peer(s) to warm" -f $peers.Count)
+} catch {
+    Log ("could not read peer list from 'tailscale status --json': " + $_.Exception.Message)
+}
+foreach ($p in $peers) {
+    $ip = ($p.TailscaleIPs | Where-Object { $_ -notmatch ':' } | Select-Object -First 1)
+    if (-not $ip) { Log ("no IPv4 for peer {0}; skipped" -f $p.HostName); continue }
+    $k = Start-Job { param($t, $i) & $t ping --timeout 3s --c 1 $i 2>&1 } -ArgumentList $ts, $ip
+    if (Wait-Job $k -Timeout 8) {
+        $r = (Receive-Job $k | Select-Object -First 1)
+        Log ("warm {0} ({1}): {2}" -f $p.HostName, $ip, $r)
+    } else {
+        Log ("warm {0} ({1}): no response within 8s" -f $p.HostName, $ip)
+        Stop-Job $k
+    }
+    Remove-Job $k -Force
+}
+Log 'done'
+'@
+Set-Content -Path $scriptPath -Value $selfHeal -Encoding ascii
+
+$action    = New-ScheduledTaskAction -Execute 'powershell.exe' `
+                -Argument "-NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`""
+$trigger   = New-ScheduledTaskTrigger -AtLogOn
+$trigger.Delay = "PT${DelaySeconds}S"
+$principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+# Battery-safe: laptops default to NOT running scheduled tasks on battery, which
+# silently leaves the task Queued and never fired. These settings override that.
+$settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+                -StartWhenAvailable -ExecutionTimeLimit (New-TimeSpan -Minutes 5)
+
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
+    -Principal $principal -Settings $settings -Force | Out-Null
+
+Write-Host "Installed '$TaskName' — runs $DelaySeconds s after each login (battery-safe)."
+Write-Host "Self-heal script: $scriptPath"
+Write-Host "Log:              $(Join-Path $dir 'ts-selfheal.log')"
+Write-Host "Test now:         Start-ScheduledTask -TaskName '$TaskName'   (then read the log)"
+Write-Host "Remove:           .\tailscale-ssh-selfheal.ps1 -Uninstall"

--- a/scripts/tailscale-ssh-selfheal.ps1
+++ b/scripts/tailscale-ssh-selfheal.ps1
@@ -21,13 +21,15 @@
   Seconds to wait after login before healing. Default 45 (lets the boot storm settle).
 
 .PARAMETER TaskName
-  Scheduled task name. Default 'GenesisTailscaleSelfHeal'.
+  Scheduled task name. Default 'GenesisTailscaleSelfHeal'. Each distinct sanitized name
+  gets its own payload + log file (<TaskName>.ps1 / <TaskName>.log under %ProgramData%\
+  GenesisNet), so separate installs do not clobber one another.
 
 .PARAMETER Uninstall
   Remove the task and its generated files instead of installing.
 
 .NOTES
-  Windows-only. Run in an ELEVATED PowerShell (registering a SYSTEM task needs admin).
+  Windows-only. Run in an ELEVATED PowerShell (a SYSTEM task needs admin to add/remove).
   Requires Tailscale installed on this client. No-op-safe to re-run (idempotent).
 
 .EXAMPLE
@@ -40,55 +42,68 @@
 # behavioral-lint: ignore no-hide-problems
 #   Justification: the generated headless payload sets $ErrorActionPreference =
 #   'SilentlyContinue' ONLY so one transient peer error cannot abort warming the
-#   rest — it hides nothing. That task runs as SYSTEM with no console, so it logs
-#   EVERY outcome (successes and failures, with the real error text) to
-#   ts-selfheal.log; the log is the surface. Existence checks here use
-#   -ErrorAction SilentlyContinue by design (a not-yet-created task/file/log is a
-#   normal state, reported clearly). The installer itself fails loud ('Stop').
+#   rest - it hides nothing. That task runs as SYSTEM with no console, so it logs
+#   EVERY outcome (successes and failures, with the real error text) to its log
+#   file; the log is the surface. Existence checks here use -ErrorAction
+#   SilentlyContinue by design (a not-yet-created task/file is a normal state, and
+#   the elevation gate below guarantees a real permission failure can't reach them).
+#   The installer itself fails loud ('Stop').
 [CmdletBinding()]
 param(
     [ValidateRange(0, 3600)]
     [int]$DelaySeconds = 45,
+    [ValidateNotNullOrEmpty()]
+    [ValidatePattern('[A-Za-z0-9]')]  # must contain at least one path-safe char
     [string]$TaskName = 'GenesisTailscaleSelfHeal',
     [switch]$Uninstall
 )
 
 $ErrorActionPreference = 'Stop'
-$dir        = Join-Path $env:ProgramData 'GenesisNet'
-$scriptPath = Join-Path $dir 'ts-selfheal.ps1'
+$dir = Join-Path $env:ProgramData 'GenesisNet'
+# Per-task payload/log names, keyed on a sanitized TaskName, so installs with distinct
+# names get distinct files. (Names differing only in sanitized characters collapse to
+# the same slug and would share files - avoid near-identical custom names.)
+$slug       = ($TaskName -replace '[^A-Za-z0-9_.-]', '_')
+$scriptPath = Join-Path $dir "$slug.ps1"
+$logPath    = Join-Path $dir "$slug.log"
+
+# Elevation is required to register OR remove a SYSTEM task. Enforce it BEFORE either
+# path, so uninstall can't silently no-op (access-denied swallowed) and then falsely
+# report success while the task keeps running.
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not ([Security.Principal.WindowsPrincipal]::new($identity)).IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "Run this in an ELEVATED PowerShell (adding/removing a SYSTEM scheduled task needs admin)."
+}
 
 if ($Uninstall) {
     Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction SilentlyContinue
+    # Only this task's own files (not a shared path), so uninstalling one custom
+    # task never breaks another. -ErrorAction SilentlyContinue now only absorbs the
+    # expected not-found case (elevation is already guaranteed above).
     Remove-Item $scriptPath -Force -ErrorAction SilentlyContinue
-    # Also remove the generated log and (if now empty) the GenesisNet directory,
-    # so uninstall genuinely removes "its generated files" as documented.
-    Remove-Item (Join-Path $dir 'ts-selfheal.log') -Force -ErrorAction SilentlyContinue
-    Remove-Item $dir -Force -ErrorAction SilentlyContinue  # no -Recurse: only removes it if empty
-    Write-Host "Removed task '$TaskName' and its generated files under $dir."
+    Remove-Item $logPath    -Force -ErrorAction SilentlyContinue
+    Remove-Item $dir -Force -ErrorAction SilentlyContinue  # no -Recurse: removed only if empty
+    Write-Host "Removed task '$TaskName' and its generated files ($slug.ps1 / $slug.log)."
     return
-}
-
-# Elevation is required to register a task that runs as SYSTEM.
-$identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
-$principalCheck = [Security.Principal.WindowsPrincipal]::new($identity)
-if (-not $principalCheck.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-    throw "Run this in an ELEVATED PowerShell (needed to register a SYSTEM scheduled task)."
 }
 
 New-Item -ItemType Directory -Path $dir -Force | Out-Null
 
 # The self-heal payload, run by the task as SYSTEM a short delay after each login.
-# Single-quoted here-string: nothing below is expanded at install time.
+# Single-quoted here-string: nothing below is expanded at install time. The payload
+# derives its own log path from $PSCommandPath at run time, so it matches this task's
+# per-slug script name without the installer injecting a path. Kept pure ASCII because
+# it is written with -Encoding ascii below.
 $selfHeal = @'
-# ts-selfheal.ps1 (generated) — warm Tailscale tunnels + re-apply MagicDNS after login.
+# (generated self-heal payload) warm Tailscale tunnels + re-apply MagicDNS after login.
 #
 # Runs headless as SYSTEM with no console, so the log IS the surface: every branch
 # below records its outcome (success AND failure, with the real error text). We set
 # SilentlyContinue only so a single transient peer error cannot abort warming the
-# rest — NOT to swallow problems. Nothing is hidden; failures are logged explicitly.
+# rest - NOT to swallow problems. Nothing is hidden; failures are logged explicitly.
 $ErrorActionPreference = 'SilentlyContinue'
-$dir = Join-Path $env:ProgramData 'GenesisNet'
-$log = Join-Path $dir 'ts-selfheal.log'
+$log = [System.IO.Path]::ChangeExtension($PSCommandPath, 'log')
 function Log($m) { Add-Content -Path $log -Value ((Get-Date -Format o) + '  ' + $m) }
 # Cap the log so it can never grow without bound.
 if ((Get-Item $log -ErrorAction SilentlyContinue).Length -gt 1MB) { Remove-Item $log -Force -ErrorAction SilentlyContinue }
@@ -99,41 +114,66 @@ if (-not $ts) { $ts = Join-Path $env:ProgramFiles 'Tailscale\tailscale.exe' }
 if (-not (Test-Path $ts)) { Log "ABORT: tailscale.exe not found (looked at Get-Command and '$ts'). Is Tailscale installed?"; return }
 
 # 1. Re-apply MagicDNS. Bounded in a job so a DNS-config lock cannot hang the task.
-$j = Start-Job { param($t) & $t set --accept-dns=true 2>&1 } -ArgumentList $ts
+#    Capture the CLI EXIT CODE - a job reaching a terminal state is not success; the
+#    daemon may not be ready in this exact post-login window and exit nonzero.
+$j = Start-Job { param($t) $o = & $t set --accept-dns=true 2>&1; [pscustomobject]@{ Code = $LASTEXITCODE; Out = ($o | Out-String) } } -ArgumentList $ts
 if (Wait-Job $j -Timeout 20) {
-    $out = (Receive-Job $j | Out-String).Trim()
-    if ($out) { Log "accept-dns re-applied (output: $out)" } else { Log 'accept-dns re-applied' }
+    $r = Receive-Job $j
+    $o = ($r.Out).Trim()
+    if ($r.Code -eq 0) {
+        if ($o) { Log "accept-dns re-applied (output: $o)" } else { Log 'accept-dns re-applied' }
+    } else {
+        Log "accept-dns FAILED (exit $($r.Code)): $o"
+    }
 } else {
     Log 'accept-dns did NOT complete within 20s (DNS config likely locked by another process); left as-is'
     Stop-Job $j
 }
 Remove-Job $j -Force
 
-# 2. Warm every online peer so IP-keyed aliases connect immediately. Peers are
-#    read live from `tailscale status`, so nothing about the tailnet is hardcoded.
+# 2. Warm online peers. Read live from `tailscale status` (nothing hardcoded). Warm
+#    with BOUNDED concurrency: Start-Job spawns a child powershell per peer, so an
+#    unthrottled fan-out would storm logon on a large tailnet. Process in chunks so at
+#    most $chunk run at once; each chunk is time-bounded, so total time stays sane and
+#    a big/slow tailnet cannot exceed the task's execution limit.
 $peers = @()
 try {
-    # Do NOT merge stderr (2>&1) into the JSON stream: a cosmetic tailscale
-    # warning line would break ConvertFrom-Json and zero out warming. stdout is
-    # pure JSON; stderr goes to the discarded error stream.
+    # Do NOT merge stderr (2>&1) into the JSON stream: a cosmetic tailscale warning
+    # line would break ConvertFrom-Json and zero out warming. stdout is pure JSON.
     $status = & $ts status --json | ConvertFrom-Json
     $peers  = @($status.Peer.PSObject.Properties.Value | Where-Object { $_.Online })
     Log ("found {0} online peer(s) to warm" -f $peers.Count)
 } catch {
     Log ("could not read peer list from 'tailscale status --json': " + $_.Exception.Message)
 }
+$targets = @()
 foreach ($p in $peers) {
     $ip = ($p.TailscaleIPs | Where-Object { $_ -notmatch ':' } | Select-Object -First 1)
     if (-not $ip) { Log ("no IPv4 for peer {0}; skipped" -f $p.HostName); continue }
-    $k = Start-Job { param($t, $i) & $t ping --timeout 3s --c 1 $i 2>&1 } -ArgumentList $ts, $ip
-    if (Wait-Job $k -Timeout 8) {
-        $r = (Receive-Job $k | Select-Object -First 1)
-        Log ("warm {0} ({1}): {2}" -f $p.HostName, $ip, $r)
-    } else {
-        Log ("warm {0} ({1}): no response within 8s" -f $p.HostName, $ip)
-        Stop-Job $k
+    $targets += [pscustomobject]@{ Name = $p.HostName; IP = $ip }
+}
+$chunk = 8
+for ($i = 0; $i -lt $targets.Count; $i += $chunk) {
+    $batch   = @($targets[$i..([math]::Min($i + $chunk - 1, $targets.Count - 1))])
+    $running = @()
+    foreach ($t in $batch) {
+        $job = Start-Job { param($exe, $ip) & $exe ping --timeout 3s --c 1 $ip 2>&1 } -ArgumentList $ts, $t.IP
+        if ($job) { $running += [pscustomobject]@{ Name = $t.Name; IP = $t.IP; Job = $job } }
+        else      { Log ("warm {0} ({1}): could not start job" -f $t.Name, $t.IP) }
     }
-    Remove-Job $k -Force
+    if ($running.Count -gt 0) {
+        $null = Wait-Job -Job @($running.Job) -Timeout 20
+        foreach ($e in $running) {
+            if ($e.Job.State -eq 'Completed') {
+                $res = (Receive-Job $e.Job | Select-Object -First 1)
+                Log ("warm {0} ({1}): {2}" -f $e.Name, $e.IP, $res)
+            } else {
+                Log ("warm {0} ({1}): no response within 20s" -f $e.Name, $e.IP)
+                Stop-Job $e.Job
+            }
+            Remove-Job $e.Job -Force
+        }
+    }
 }
 Log 'done'
 '@
@@ -146,14 +186,16 @@ $trigger.Delay = "PT${DelaySeconds}S"
 $principal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
 # Battery-safe: laptops default to NOT running scheduled tasks on battery, which
 # silently leaves the task Queued and never fired. These settings override that.
+# IgnoreNew: overlapping logons within the delay window don't run two racing copies.
 $settings  = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
-                -StartWhenAvailable -ExecutionTimeLimit (New-TimeSpan -Minutes 5)
+                -StartWhenAvailable -MultipleInstances IgnoreNew `
+                -ExecutionTimeLimit (New-TimeSpan -Minutes 10)
 
 Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger `
     -Principal $principal -Settings $settings -Force | Out-Null
 
-Write-Host "Installed '$TaskName' — runs $DelaySeconds s after each login (battery-safe)."
+Write-Host "Installed '$TaskName' - runs $DelaySeconds s after each login (battery-safe)."
 Write-Host "Self-heal script: $scriptPath"
-Write-Host "Log:              $(Join-Path $dir 'ts-selfheal.log')"
+Write-Host "Log:              $logPath"
 Write-Host "Test now:         Start-ScheduledTask -TaskName '$TaskName'   (then read the log)"
 Write-Host "Remove:           .\tailscale-ssh-selfheal.ps1 -Uninstall"


### PR DESCRIPTION
## What

Documents the Tailscale SSH fleet-access feature and adds a generic, battery-safe boot self-heal installer for Windows clients.

## Why

The SSH slot/lobby access (`generate-ssh-config.sh`) had no user-facing doc. On a Windows client with a contended DNS stack (several DNS-managing VPNs, a large hosts-file blocker, and/or manually pinned DNS servers), Tailscale's MagicDNS write intermittently loses a race for the Windows DNS configuration at boot — so peer tunnels stay cold and tailnet names don't resolve for a window after login, and SSH to the fleet times out until Tailscale settles.

## Changes

- **docs/reference/tailscale-ssh-access.md** (new) — setup + Windows after-reboot troubleshooting: IP-key aliases so SSH never depends on MagicDNS, the boot self-heal, the cosmetic `dns-set-os-config-failed` flap on a contended stack, and the on-battery scheduled-task gotcha (Windows tasks default to *not* running on battery).
- **scripts/tailscale-ssh-selfheal.ps1** (new) — installs a logon self-heal task that re-applies `accept-dns` and warms online peers so tunnels are hot after boot. Derives peers live from `tailscale status` (hardcodes nothing about the tailnet), battery-safe via `Register-ScheduledTask -AllowStartIfOnBatteries`, `-Uninstall` supported.
- **scripts/generate-ssh-config.sh** — pointer to the doc + an IP-key-your-own-hosts tip (comments + stderr only; existing tests unchanged).
- **docs/INDEX.md** — reference link.

## Testing / review

- `tests/test_scripts/test_generate_ssh_config.py` — 8/8 pass (generator behavior unchanged).
- PowerShell is not executable on the dev/CI host — the installer was reviewed statically.
- Adversarial review (genesis-architect): `DONE_WITH_CONCERNS`; 2 SHOULD-FIX + 1 note fixed (doc `ssh.exe` typo, `-Uninstall` log/dir cleanup, JSON-parse stderr merge). No runtime-path files touched.

## Deploy path

Docs + a client-side operator helper (like `generate-ssh-config.sh`) — reaches installs via `git pull`; nothing to activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011v5AJ2U5rqH9yCeum49DH8