### PR TITLE
fix(hooks): offline allowlist so a transient ls-remote failure doesn't re-prompt an approved branch push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
-- **A scheduled job that has run repeatedly but never once succeeded now raises a
-  health alert.** Such a job was invisible to every alarm: the "silently failing"
+- **A transient `git ls-remote` failure no longer re-prompts an already-approved
+  branch push.** The push-approval hook prompts only on a branch's FIRST push; a
+  re-push of fixes to the same, already-published branch should be silent. But the
+  "already on the remote?" check was a live `git ls-remote` that fail-closes to a
+  prompt on any network hiccup, so a flaky network re-prompted every re-push. A new
+  stdlib allowlist (`scripts/hooks/push_allowlist.py`, state in
+  `~/.genesis/pushed_branches.json`) caches the confirmed-on-remote fact locally so
+  re-pushes are decided OFFLINE. It is keyed on (branch, remote push-URL set) — never
+  the remote name — so the same branch name on a different repo is never conflated,
+  and it is written ONLY on a live ls-remote HIT (which proves the branch is already
+  on the remote), so it can never authorize a genuine first push. Corrupt/absent
+  state and any error fail OPEN to the existing prompt path; entries expire after 90
+  days (a recorded branch stays trusted for that window even if its remote copy is
+  later deleted). Such a job was invisible to every alarm: the "silently failing"
   check needs a prior success to measure a gap against, and the consecutive-failure
   counter resets on every restart. So a job that failed from its very first run —
   e.g. a daily actuator whose external login expired on day one — could fail silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,9 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   on the remote), so it can never authorize a genuine first push. Corrupt/absent
   state and any error fail OPEN to the existing prompt path; entries expire after 90
   days (a recorded branch stays trusted for that window even if its remote copy is
-  later deleted). Such a job was invisible to every alarm: the "silently failing"
+  later deleted).
+- **A scheduled job that has run repeatedly but never once succeeded now raises a
+  health alert.** Such a job was invisible to every alarm: the "silently failing"
   check needs a prior success to measure a gap against, and the consecutive-failure
   counter resets on every restart. So a job that failed from its very first run —
   e.g. a daily actuator whose external login expired on day one — could fail silently

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -123,6 +123,19 @@ from shell_parse import (  # noqa: E402
     split_segments,
 )
 
+# Local push allowlist (offline re-push cache). SOFT dependency, guarded exactly
+# like the review_state import above: a module-LOAD exception must degrade to
+# None (→ the pure live-ls-remote republish path, i.e. today's behavior), NEVER
+# propagate — a raising import exits 1, which CC treats as non-blocking, silently
+# disabling EVERY fail-closed gate in this file. push_allowlist itself is
+# fail-open by contract (its calls never raise); None here only covers an
+# import-time breakage (absent module, SyntaxError). It can only ever RELAX a
+# re-push of a branch already confirmed on the remote — never a first push.
+try:
+    import push_allowlist  # noqa: E402 — scripts/hooks is on sys.path[0]
+except Exception:  # noqa: BLE001 — see the review_state guard's rationale (108-114)
+    push_allowlist = None
+
 # Sentinel: the effective cwd cannot be confidently resolved (a cd into a
 # variable/command-substitution, a subshell, or a target nested at depth>0).
 # Callers MUST fail closed on it — block the merge, do not soften a force push.
@@ -3128,14 +3141,39 @@ def main() -> int:
                     and cur
                     and cur not in ("main", "master")
                     and _push_targets_current_branch(push_segs[0], cur, push_remote, cwd=pcwd)
-                    and _push_is_republish(push_remote, cur, pcwd)
                 ):
+                    # This push plainly updates the current branch `cur`, so it
+                    # qualifies for the first-push-only relaxation IF `cur` is
+                    # already on the remote. Decide that via the LOCAL allowlist
+                    # first (offline — immune to the transient ls-remote failure
+                    # that otherwise fail-closes _push_is_republish to a re-prompt),
+                    # then fall back to the live ls-remote leg. On an ls-remote HIT,
+                    # RECORD the confirmed-on-remote fact so later re-pushes decide
+                    # offline. SECURITY: the allowlist is written ONLY here, ONLY on
+                    # an ls-remote HIT (which proves `cur` is on the remote → its
+                    # first push was already approved), so it can never authorize a
+                    # genuine first push; a broken/absent push_allowlist degrades to
+                    # the pure ls-remote path (import guarded to None above).
+                    urls = _remote_push_urls(push_remote, cwd=pcwd) if push_remote else set()
                     # Deferred (NOT an inline return) so any hard-block in a compound
                     # command still takes precedence — see push_allow_reason above.
-                    push_allow_reason = (
-                        f"re-push to '{cur}' (already on the remote — approved on "
-                        f"its first push); only the first push of a branch/PR prompts."
-                    )
+                    if push_allowlist is not None and push_allowlist.is_recorded(urls, cur):
+                        push_allow_reason = (
+                            f"re-push to '{cur}' (recorded as already on the remote — "
+                            f"approved on its first push); only the first push prompts."
+                        )
+                    elif _push_is_republish(push_remote, cur, pcwd):
+                        if push_allowlist is not None and urls:
+                            push_allowlist.record(urls, cur)
+                        push_allow_reason = (
+                            f"re-push to '{cur}' (already on the remote — approved on "
+                            f"its first push); only the first push of a branch/PR prompts."
+                        )
+                    else:
+                        ask_reason = (
+                            f"git push needs your approval before publishing externally "
+                            f"(target: {branch or 'default'})."
+                        )
                 else:
                     ask_reason = (
                         f"git push needs your approval before publishing externally "

--- a/scripts/hooks/push_allowlist.py
+++ b/scripts/hooks/push_allowlist.py
@@ -101,10 +101,13 @@ def _sanitize_url(url: str) -> str | None:
       ``file:///x``) → None (fall back to ls-remote).
     - scp-like ssh (``[user@]host:path``): git's OWN rule distinguishes this from a
       local path by "a ``:`` with NO ``/`` before it" (a slash before the first
-      colon means a local path). We honor that exactly, then strip any ``user@``
-      prefix. A colon that appears AFTER a slash (e.g. ``backups/2026-01-01T12:00/
-      repo.git``) is therefore a RELATIVE LOCAL path, not scp — critical, since a
-      relative path is ambiguous across worktrees.
+      colon means a local path). We honor that exactly and keep the FULL string
+      including any ``user@`` — the SSH login is part of the repo identity (the path
+      is relative to that login's home), so ``alice@host:r`` ≠ ``bob@host:r``; scp
+      has no password field, so nothing there is a credential to strip. A colon that
+      appears AFTER a slash (e.g. ``backups/2026-01-01T12:00/repo.git``) is therefore
+      a RELATIVE LOCAL path, not scp — critical, since a relative path is ambiguous
+      across worktrees.
     - Absolute local path (``/…``): stable, kept as-is.
     - RELATIVE local path (``../x``, ``./x``, ``~/x``, ``x/y.git``, ``x/y:z``): None.
       Git resolves it relative to each repo, so the same raw string can denote
@@ -139,11 +142,13 @@ def _sanitize_url(url: str) -> str | None:
     colon = u.find(":")
     slash = u.find("/")
     if colon > 0 and (slash == -1 or colon < slash) and not u.startswith((".", "~")):
-        authority = u[:colon]  # [user@]host
-        path = u[colon:]  # ':path'
-        if "@" in authority:  # strip scp userinfo (git@… etc.) — never persist it
-            authority = authority.rsplit("@", 1)[1]
-        return f"{authority}{path}" if authority else None
+        # Keep the FULL scp form incl. any ``user@``: the SSH login is part of the
+        # repo IDENTITY — an scp path is relative to that login's home on the host,
+        # so ``alice@host:repo`` and ``bob@host:repo`` are DIFFERENT repositories and
+        # must NOT collide to the same key. scp syntax has no password field, so
+        # there is no credential to strip here (unlike a scheme-URL ``user:<PAT>@``,
+        # handled above by urlsplit).
+        return u
     # Relative local path (incl. a colon that sits AFTER a slash) — do not key.
     return None
 

--- a/scripts/hooks/push_allowlist.py
+++ b/scripts/hooks/push_allowlist.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Local persistent allowlist of branches confirmed pushed to a remote.
+
+Consumed by ``git_push_guard.py``'s re-push gate. A branch whose FIRST push was
+approved (and which is therefore already on the remote) must not re-prompt on
+later pushes (user directive #1262). The canonical "already on the remote" check
+is a live ``git ls-remote``, but that is a network call that FAIL-CLOSES to a
+prompt on any transient failure — so a flaky network re-prompts an
+already-approved branch. This module caches the "confirmed on remote" fact
+LOCALLY so re-pushes are decided offline.
+
+SECURITY INVARIANT
+------------------
+This allowlist can only ever RELAX a re-push of a branch already confirmed
+present on the remote. The SOLE writer is ``git_push_guard`` on a live
+``ls-remote`` HIT — it records only branches ls-remote just proved are on the
+remote, i.e. branches whose first push was already approved. A never-pushed
+branch is never recorded, so its first push always prompts. Reads FAIL-OPEN to
+"not recorded" (→ fall back to ls-remote → prompt); a corrupt/absent/partial
+file can only cause an EXTRA prompt, never a silent first push.
+
+KEYING
+------
+Keyed on (branch name, remote PUSH-URL set) — NOT remote name (names vary per
+clone). A record matches only when the push's resolved push-urls INTERSECT the
+recorded set, so the same branch name on a DIFFERENT repo is never conflated. An
+empty push-url set (unresolvable remote) never matches and is never recorded.
+
+TRUST WINDOW (conscious acceptance)
+-----------------------------------
+A recorded entry is trusted for ``RETENTION_DAYS`` regardless of whether the
+remote branch still exists — checking liveness would reintroduce the network
+dependency this module exists to remove. Consequence: re-pushing a branch whose
+remote copy was deleted within the window (e.g. a merged PR whose branch was
+auto-deleted) is offline-allowed rather than re-prompted. Entries older than
+``RETENTION_DAYS`` are pruned on write, bounding the window.
+
+Stdlib-only (hooks must not import ``genesis.*``). FAIL-OPEN everywhere: any
+error degrades to "not recorded" / no-op and NEVER raises. A raising import or
+call from a hook would exit 1 → CC treats non-2 as non-blocking → every
+fail-closed gate in ``git_push_guard`` would silently vanish (see its
+``review_state`` soft-import at lines 109-115 for the same lesson).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+_VERSION = 1
+RETENTION_DAYS = 90
+
+
+def _state_path() -> Path:
+    """``<GENESIS_HOME or ~/.genesis>/pushed_branches.json``.
+
+    ``GENESIS_HOME`` IS the ``.genesis`` dir (mirrors ``genesis.env.genesis_home``);
+    unset → ``~/.genesis``.
+    """
+    base = os.environ.get("GENESIS_HOME")
+    root = Path(base).expanduser() if base else Path.home() / ".genesis"
+    return root / "pushed_branches.json"
+
+
+def _load(path: Path) -> dict:
+    """Parsed envelope, or a fresh empty one on ANY error (fail-open)."""
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict) and isinstance(data.get("branches"), dict):
+            return data
+    except Exception:
+        pass
+    return {"version": _VERSION, "branches": {}}
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _entry_is_fresh(entry: object, now: datetime) -> bool:
+    """Whether ``entry``'s ISO ``ts`` is within ``RETENTION_DAYS``.
+
+    A missing / non-string / unparseable ts → NOT fresh, so the entry is dropped
+    on the next write and read as "not recorded" — the safe direction (a
+    re-prompt, never a silent allow).
+    """
+    if not isinstance(entry, dict):
+        return False
+    ts = entry.get("ts")
+    if not isinstance(ts, str):
+        return False
+    try:
+        when = datetime.fromisoformat(ts)
+    except Exception:
+        return False
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=UTC)
+    return (now - when).days < RETENTION_DAYS
+
+
+def is_recorded(push_urls: set[str], branch: str) -> bool:
+    """True iff ``branch`` is recorded, still fresh, AND its recorded push-urls
+    INTERSECT ``push_urls``.
+
+    Empty ``push_urls`` (unresolvable remote) → False (fall back to ls-remote).
+    Any error → False (fail-open to the prompt path).
+    """
+    try:
+        if not push_urls or not branch:
+            return False
+        data = _load(_state_path())
+        entry = data.get("branches", {}).get(branch)
+        if not _entry_is_fresh(entry, _now()):
+            return False
+        recorded = entry.get("urls")
+        if not isinstance(recorded, list):
+            return False
+        return bool(set(recorded) & set(push_urls))
+    except Exception:
+        return False
+
+
+def record(push_urls: set[str], branch: str) -> None:
+    """Record ``branch`` as confirmed-on-remote for ``push_urls`` (REPLACE the
+    url set), pruning stale entries in the same write.
+
+    No-op if ``push_urls`` is empty (can't key it safely) or ``branch`` is falsy.
+    Atomic tmp-write + ``os.replace``. FAIL-OPEN — never raises. Concurrent
+    writers can at worst DROP an entry (last self-consistent map wins) → a
+    redundant prompt, never a phantom record.
+    """
+    try:
+        if not push_urls or not branch:
+            return
+        path = _state_path()
+        now = _now()
+        data = _load(path)  # fresh re-read minimizes the lost-update window
+        branches = data.setdefault("branches", {})
+        # Prune stale entries on every write — no separate GC job needed.
+        for name in [n for n, e in list(branches.items()) if not _entry_is_fresh(e, now)]:
+            del branches[name]
+        branches[branch] = {
+            "urls": sorted(push_urls),  # REPLACE, not union — tighter allowlist
+            "ts": now.isoformat(),
+        }
+        data["version"] = _VERSION
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".pushed_branches.", suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(data, fh, indent=2, sort_keys=True)
+            os.replace(tmp, path)
+        finally:
+            try:
+                if os.path.exists(tmp):
+                    os.unlink(tmp)
+            except Exception:
+                pass
+    except Exception:
+        return

--- a/scripts/hooks/push_allowlist.py
+++ b/scripts/hooks/push_allowlist.py
@@ -22,9 +22,15 @@ file can only cause an EXTRA prompt, never a silent first push.
 KEYING
 ------
 Keyed on (branch name, remote PUSH-URL set) — NOT remote name (names vary per
-clone). A record matches only when the push's resolved push-urls INTERSECT the
-recorded set, so the same branch name on a DIFFERENT repo is never conflated. An
-empty push-url set (unresolvable remote) never matches and is never recorded.
+clone). A record matches only when EVERY current push-url is covered by the
+recorded set (subset, not a partial intersection): git pushes to every configured
+push URL, so a newly-added destination must re-prompt rather than ride an old
+url's cache hit. The same branch name on a DIFFERENT repo is never conflated. URLs
+are SANITIZED before storing/matching — userinfo/credentials are stripped (a token
+in ``https://user:<PAT>@host`` is never persisted to the plaintext state file),
+and a RELATIVE local path (ambiguous across worktrees) makes the whole decision
+fall back to ls-remote. An empty push-url set (unresolvable remote) never matches
+and is never recorded.
 
 TRUST WINDOW (conscious acceptance)
 -----------------------------------
@@ -47,8 +53,9 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 _VERSION = 1
 RETENTION_DAYS = 90
@@ -81,6 +88,85 @@ def _now() -> datetime:
     return datetime.now(UTC)
 
 
+def _sanitize_url(url: str) -> str | None:
+    """A credential-free, STABLE key form of a push URL, or None if the URL must
+    NOT be used for an offline cache decision.
+
+    - Scheme URL (``scheme://[userinfo@]host/path``): parsed with the CANONICAL
+      stdlib ``urllib.parse.urlsplit`` (never a hand-rolled split of an unbounded
+      grammar). The key drops the ``userinfo`` (``https://user:<PAT>@host/repo`` →
+      ``https://host/repo``, so a token is never persisted or keyed on), lowercases
+      the case-insensitive scheme + host, preserves host port and IPv6 brackets and
+      the path, and drops the fragment. A form with no host (``https://user@/x``,
+      ``file:///x``) → None (fall back to ls-remote).
+    - scp-like ssh (``[user@]host:path``): git's OWN rule distinguishes this from a
+      local path by "a ``:`` with NO ``/`` before it" (a slash before the first
+      colon means a local path). We honor that exactly, then strip any ``user@``
+      prefix. A colon that appears AFTER a slash (e.g. ``backups/2026-01-01T12:00/
+      repo.git``) is therefore a RELATIVE LOCAL path, not scp — critical, since a
+      relative path is ambiguous across worktrees.
+    - Absolute local path (``/…``): stable, kept as-is.
+    - RELATIVE local path (``../x``, ``./x``, ``~/x``, ``x/y.git``, ``x/y:z``): None.
+      Git resolves it relative to each repo, so the same raw string can denote
+      DIFFERENT repositories across worktrees; the caller must fall back to
+      ls-remote (a prompt) rather than risk a cross-repo silent push.
+    """
+    if not isinstance(url, str) or not url.strip():
+        return None
+    u = url.strip()
+    # Scheme URL — parse with the CANONICAL stdlib parser, never a hand-split of an
+    # unbounded grammar. ``urlsplit`` lowercases the scheme + host, drops the
+    # userinfo (so an embedded ``user:<PAT>@`` token never reaches the key), and
+    # separates host/port/path/query correctly (incl. IPv6 literals).
+    if "://" in u:
+        try:
+            parts = urlsplit(u)
+            host = parts.hostname  # already lowercased, userinfo-stripped
+        except Exception:
+            return None
+        if not parts.scheme or not host:
+            return None  # no scheme/host (e.g. ``https://user@/x``, ``file:///…``) → don't key
+        if ":" in host:  # IPv6 literal — urlsplit strips the brackets; restore them
+            host = f"[{host}]"
+        if parts.port is not None:
+            host = f"{host}:{parts.port}"
+        # Credential-free rebuild: userinfo dropped, fragment dropped, path+query kept.
+        return urlunsplit((parts.scheme.lower(), host, parts.path, parts.query, ""))
+    # Absolute local path.
+    if u.startswith("/"):
+        return u
+    # scp-like ssh — only when a ':' appears with NO '/' before it (git's rule).
+    colon = u.find(":")
+    slash = u.find("/")
+    if colon > 0 and (slash == -1 or colon < slash) and not u.startswith((".", "~")):
+        authority = u[:colon]  # [user@]host
+        path = u[colon:]  # ':path'
+        if "@" in authority:  # strip scp userinfo (git@… etc.) — never persist it
+            authority = authority.rsplit("@", 1)[1]
+        return f"{authority}{path}" if authority else None
+    # Relative local path (incl. a colon that sits AFTER a slash) — do not key.
+    return None
+
+
+def _keyable_urls(push_urls: set[str]) -> set[str] | None:
+    """The sanitized, credential-free key set for ``push_urls`` — or None if the
+    set is empty OR ANY member is non-keyable (a relative local path).
+
+    None means "cannot decide offline": git pushes to EVERY push URL, so if even
+    one destination is ambiguous the whole push must fall back to ls-remote (a
+    prompt) rather than be offline-allowed or partially recorded.
+    """
+    if not push_urls:
+        return None
+    out: set[str] = set()
+    for u in push_urls:
+        s = _sanitize_url(u)
+        if s is None:
+            return None
+        out.add(s)
+    return out
+
+
 def _entry_is_fresh(entry: object, now: datetime) -> bool:
     """Whether ``entry``'s ISO ``ts`` is within ``RETENTION_DAYS``.
 
@@ -99,18 +185,30 @@ def _entry_is_fresh(entry: object, now: datetime) -> bool:
         return False
     if when.tzinfo is None:
         when = when.replace(tzinfo=UTC)
-    return (now - when).days < RETENTION_DAYS
+    # Require a NON-NEGATIVE age as well as < RETENTION_DAYS: a FUTURE ts (a clock
+    # that was ahead at record time and later corrected, or a tampered/corrupt
+    # state file) would otherwise read as fresh far beyond the window — its
+    # negative age has a negative ``.days``, which is always < RETENTION_DAYS.
+    return timedelta(0) <= (now - when) < timedelta(days=RETENTION_DAYS)
 
 
 def is_recorded(push_urls: set[str], branch: str) -> bool:
-    """True iff ``branch`` is recorded, still fresh, AND its recorded push-urls
-    INTERSECT ``push_urls``.
+    """True iff ``branch`` is recorded, still fresh, AND EVERY current push-url is
+    covered by the recorded set (subset, not a partial intersection).
 
-    Empty ``push_urls`` (unresolvable remote) → False (fall back to ls-remote).
-    Any error → False (fail-open to the prompt path).
+    Subset — not intersection — because git pushes to EVERY configured push URL:
+    if a new destination was added after recording, a partial-intersection hit
+    would silently publish the branch to that never-approved destination. Requiring
+    all current urls ⊆ recorded forces a re-prompt when a new push url appears.
+
+    Empty ``push_urls`` or any non-keyable (relative-path) url → False (fall back
+    to ls-remote). Any error → False (fail-open to the prompt path).
     """
     try:
-        if not push_urls or not branch:
+        if not branch:
+            return False
+        keyable = _keyable_urls(push_urls)
+        if not keyable:  # empty or an ambiguous relative-path url → can't decide offline
             return False
         data = _load(_state_path())
         entry = data.get("branches", {}).get(branch)
@@ -119,7 +217,7 @@ def is_recorded(push_urls: set[str], branch: str) -> bool:
         recorded = entry.get("urls")
         if not isinstance(recorded, list):
             return False
-        return bool(set(recorded) & set(push_urls))
+        return keyable <= set(recorded)
     except Exception:
         return False
 
@@ -128,13 +226,19 @@ def record(push_urls: set[str], branch: str) -> None:
     """Record ``branch`` as confirmed-on-remote for ``push_urls`` (REPLACE the
     url set), pruning stale entries in the same write.
 
-    No-op if ``push_urls`` is empty (can't key it safely) or ``branch`` is falsy.
-    Atomic tmp-write + ``os.replace``. FAIL-OPEN — never raises. Concurrent
-    writers can at worst DROP an entry (last self-consistent map wins) → a
-    redundant prompt, never a phantom record.
+    No-op if ``branch`` is falsy, ``push_urls`` is empty, or ANY url is non-keyable
+    (a relative local path — see ``_sanitize_url``): an ambiguous destination must
+    never be cached. Stored urls are SANITIZED (userinfo/credentials stripped) so
+    the plaintext state file never persists a token. Atomic tmp-write +
+    ``os.replace``. FAIL-OPEN — never raises. Concurrent writers can at worst DROP
+    an entry (last self-consistent map wins) → a redundant prompt, never a phantom
+    record.
     """
     try:
-        if not push_urls or not branch:
+        if not branch:
+            return
+        keyable = _keyable_urls(push_urls)
+        if not keyable:  # empty or an ambiguous relative-path url → don't cache
             return
         path = _state_path()
         now = _now()
@@ -144,7 +248,7 @@ def record(push_urls: set[str], branch: str) -> None:
         for name in [n for n, e in list(branches.items()) if not _entry_is_fresh(e, now)]:
             del branches[name]
         branches[branch] = {
-            "urls": sorted(push_urls),  # REPLACE, not union — tighter allowlist
+            "urls": sorted(keyable),  # sanitized, credential-free; REPLACE not union
             "ts": now.isoformat(),
         }
         data["version"] = _VERSION

--- a/tests/test_hooks/test_push_allowlist.py
+++ b/tests/test_hooks/test_push_allowlist.py
@@ -2,10 +2,14 @@
 
 The allowlist caches "branch X is confirmed on remote (push-urls U)" so a
 re-push is decided offline instead of via a network ls-remote. These tests pin
-the security-relevant invariants: it never matches an unrecorded branch, an
-empty/disjoint url set never matches, stale entries expire, and every read/write
-fails OPEN (a corrupt file can only cause a redundant prompt, never a phantom
-allow).
+the security-relevant invariants: it never matches an unrecorded branch; an
+empty/partial/relative url set never matches; a NEW push destination re-prompts
+(subset, not intersection); credentials embedded in a url are never persisted;
+stale/future entries expire; and every read/write fails OPEN (a corrupt file can
+only cause a redundant prompt, never a phantom allow).
+
+Test urls must be KEYABLE (scheme url, absolute path, or scp-like ssh) — a bare
+token like ``url-a`` is a RELATIVE path and is deliberately non-keyable.
 """
 
 from __future__ import annotations
@@ -19,6 +23,13 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "hooks"))
 import push_allowlist as pa  # noqa: E402
+
+# Keyable urls (stable across worktrees): scheme urls, an absolute path, scp ssh.
+A = "https://ex.com/a.git"
+B = "https://ex.com/b.git"
+C = "https://ex.com/c.git"
+SCP = "git@github.com:o/r.git"
+ABS = "/srv/git/a.git"
 
 
 @pytest.fixture
@@ -38,40 +49,147 @@ def _state(home: Path) -> Path:
 
 
 def test_record_then_is_recorded_roundtrip(home):
-    pa.record({"git@github.com:o/r.git"}, "feat/x")
-    assert pa.is_recorded({"git@github.com:o/r.git"}, "feat/x") is True
+    pa.record({SCP}, "feat/x")
+    assert pa.is_recorded({SCP}, "feat/x") is True
 
 
-def test_url_intersection_matches(home):
-    pa.record({"url-a", "url-b"}, "feat/x")
-    # A later push whose resolved url set overlaps the recorded set matches.
-    assert pa.is_recorded({"url-b", "url-c"}, "feat/x") is True
+def test_absolute_path_and_scheme_urls_are_keyable(home):
+    pa.record({ABS}, "feat/x")
+    assert pa.is_recorded({ABS}, "feat/x") is True
+
+
+def test_subset_matches_when_current_covered_by_recorded(home):
+    """A push whose url set is a SUBSET of the recorded set matches."""
+    pa.record({A, B}, "feat/x")
+    assert pa.is_recorded({A}, "feat/x") is True
+    assert pa.is_recorded({A, B}, "feat/x") is True
+
+
+def test_added_push_url_reprompts(home):
+    """SECURITY (#P2): git pushes to EVERY push url. A newly-added destination
+    must NOT ride an old url's cache hit — require subset, not intersection."""
+    pa.record({A}, "feat/x")
+    assert pa.is_recorded({A, B}, "feat/x") is False  # B was never recorded → prompt
 
 
 def test_disjoint_urls_do_not_match(home):
     """Same branch NAME, a different repo's url → NOT recorded (no conflation)."""
-    pa.record({"git@github.com:o/r.git"}, "feat/x")
-    assert pa.is_recorded({"git@github.com:other/repo.git"}, "feat/x") is False
+    pa.record({A}, "feat/x")
+    assert pa.is_recorded({B}, "feat/x") is False
 
 
 def test_empty_push_urls_never_matches_and_never_records(home):
-    # is_recorded with no urls → False (fall back to ls-remote).
-    pa.record({"url-a"}, "feat/x")
+    pa.record({A}, "feat/x")
     assert pa.is_recorded(set(), "feat/x") is False
-    # record with no urls → no-op (unresolvable remote can't be keyed).
     pa.record(set(), "feat/y")
     data = json.loads(_state(home).read_text())
     assert "feat/y" not in data["branches"]
 
 
 def test_unrecorded_branch_not_recorded(home):
-    pa.record({"url-a"}, "feat/x")
-    assert pa.is_recorded({"url-a"}, "feat/never-pushed") is False
+    pa.record({A}, "feat/x")
+    assert pa.is_recorded({A}, "feat/never-pushed") is False
 
 
 def test_empty_state_returns_false(home):
-    # No file at all → not recorded (fail-open to prompt).
-    assert pa.is_recorded({"url-a"}, "feat/x") is False
+    assert pa.is_recorded({A}, "feat/x") is False
+
+
+# ── #P2: relative local urls are non-keyable (cross-worktree ambiguity) ─
+
+
+def test_relative_url_not_recorded(home):
+    """A relative local push url (``../../remote.git``) resolves differently across
+    worktrees, so it must NOT be cached — record no-ops."""
+    pa.record({"../../remote.git"}, "feat/x")
+    assert not _state(home).exists() or "feat/x" not in json.loads(_state(home).read_text()).get(
+        "branches", {}
+    )
+
+
+def test_relative_url_never_matches(home):
+    pa.record({ABS}, "feat/x")
+    # A later push that resolves a relative url can't decide offline → False.
+    assert pa.is_recorded({"../../remote.git"}, "feat/x") is False
+
+
+def test_any_relative_url_in_set_blocks_offline_decision(home):
+    """If ANY current push url is relative/ambiguous, the WHOLE push falls back
+    (git pushes to every url, so one ambiguous destination taints the decision)."""
+    pa.record({A}, "feat/x")
+    assert pa.is_recorded({A, "./local.git"}, "feat/x") is False
+
+
+# ── #P2: credentials in urls are never persisted ───────────────────────
+
+
+def test_credentials_stripped_from_stored_url(home):
+    pa.record({"https://user:SECRETPAT@ex.com/a.git"}, "feat/x")
+    raw = _state(home).read_text()
+    assert "SECRETPAT" not in raw
+    assert "user:" not in raw
+    data = json.loads(raw)
+    assert data["branches"]["feat/x"]["urls"] == ["https://ex.com/a.git"]
+
+
+def test_credential_url_matches_sanitized_form(home):
+    """A push with an embedded credential matches a record of the same repo — both
+    are sanitized to the credential-free form, so matching still works."""
+    pa.record({"https://user:PAT@ex.com/a.git"}, "feat/x")
+    assert pa.is_recorded({"https://ex.com/a.git"}, "feat/x") is True
+    assert pa.is_recorded({"https://other:TOKEN@ex.com/a.git"}, "feat/x") is True
+
+
+# ── #CRITICAL: scp-vs-local disambiguation (git's slash-before-colon rule) ──
+
+
+def test_sanitize_url_classification_matrix():
+    """``_sanitize_url`` must match git's real scp-vs-local rule and strip creds."""
+    # scheme urls (canonical urlsplit): userinfo stripped, scheme+host lowercased
+    # (host is case-insensitive; path case preserved), empty host rejected, @ in
+    # path kept, multiple @ in authority collapsed to the host, IPv6 + port kept.
+    assert pa._sanitize_url("https://user:PAT@host/x.git") == "https://host/x.git"
+    assert pa._sanitize_url("HTTPS://Host/X") == "https://host/X"
+    assert pa._sanitize_url("https://GitHub.com/O/R.git") == "https://github.com/O/R.git"
+    assert pa._sanitize_url("https://host:443/x") == "https://host:443/x"
+    assert pa._sanitize_url("https://[::1]:22/x") == "https://[::1]:22/x"
+    assert pa._sanitize_url("ssh://user:pw@host:22/x") == "ssh://host:22/x"
+    assert pa._sanitize_url("https://user@/x") is None
+    assert pa._sanitize_url("https://a@b@host/x") == "https://host/x"
+    assert pa._sanitize_url("https://host/a@b") == "https://host/a@b"
+    # scp-like: ONLY when ':' has no '/' before it; userinfo stripped.
+    assert pa._sanitize_url("git@github.com:o/r.git") == "github.com:o/r.git"
+    assert pa._sanitize_url("host:path/x") == "host:path/x"
+    # absolute local path — stable.
+    assert pa._sanitize_url("/srv/git/a.git") == "/srv/git/a.git"
+    # RELATIVE local path with a colon AFTER a slash → NOT scp → None (the CRITICAL).
+    assert pa._sanitize_url("sub/dir:name") is None
+    assert pa._sanitize_url("backups/2026-01-01T12:00:00/repo.git") is None
+    assert pa._sanitize_url("../../remote.git") is None
+    assert pa._sanitize_url("./local.git") is None
+    assert pa._sanitize_url("~/repo.git") is None
+    assert pa._sanitize_url("") is None
+    assert pa._sanitize_url("   ") is None
+
+
+def test_relative_path_with_colon_not_offline_allowed(home):
+    """CRITICAL regression: a relative local path containing a colon (e.g. a
+    timestamped backup dir) must NOT be treated as a stable scp key — otherwise a
+    genuine first push to it could skip the prompt across worktrees."""
+    ambiguous = "backups/2026-01-01T12:00:00/repo.git"
+    pa.record({ambiguous}, "feat/x")  # non-keyable → must no-op
+    assert not _state(home).exists() or "feat/x" not in json.loads(_state(home).read_text()).get(
+        "branches", {}
+    )
+    assert pa.is_recorded({ambiguous}, "feat/x") is False
+
+
+def test_scp_userinfo_stripped_from_stored_url(home):
+    """An scp ``user@`` prefix is never persisted verbatim; matching still works."""
+    pa.record({"git@github.com:o/r.git"}, "feat/x")
+    data = json.loads(_state(home).read_text())
+    assert data["branches"]["feat/x"]["urls"] == ["github.com:o/r.git"]
+    assert pa.is_recorded({"git@github.com:o/r.git"}, "feat/x") is True
 
 
 # ── REPLACE semantics (C2) ────────────────────────────────────────────
@@ -80,12 +198,12 @@ def test_empty_state_returns_false(home):
 def test_rerecord_replaces_url_set(home):
     """A re-record REPLACES the url set (does not union) — a stale set-url --push
     ages out immediately rather than lingering in the trusted set."""
-    pa.record({"old-url"}, "feat/x")
-    pa.record({"new-url"}, "feat/x")
+    pa.record({A}, "feat/x")
+    pa.record({B}, "feat/x")
     data = json.loads(_state(home).read_text())
-    assert data["branches"]["feat/x"]["urls"] == ["new-url"]
-    assert pa.is_recorded({"old-url"}, "feat/x") is False
-    assert pa.is_recorded({"new-url"}, "feat/x") is True
+    assert data["branches"]["feat/x"]["urls"] == [B]
+    assert pa.is_recorded({A}, "feat/x") is False
+    assert pa.is_recorded({B}, "feat/x") is True
 
 
 # ── freshness / prune ─────────────────────────────────────────────────
@@ -97,30 +215,37 @@ def _write_state(home: Path, branches: dict) -> None:
 
 def test_stale_entry_is_not_recorded(home):
     old = (datetime.now(UTC) - timedelta(days=pa.RETENTION_DAYS + 1)).isoformat()
-    _write_state(home, {"feat/x": {"urls": ["url-a"], "ts": old}})
-    assert pa.is_recorded({"url-a"}, "feat/x") is False
+    _write_state(home, {"feat/x": {"urls": [A], "ts": old}})
+    assert pa.is_recorded({A}, "feat/x") is False
 
 
 def test_fresh_entry_just_inside_window_is_recorded(home):
     recent = (datetime.now(UTC) - timedelta(days=pa.RETENTION_DAYS - 1)).isoformat()
-    _write_state(home, {"feat/x": {"urls": ["url-a"], "ts": recent}})
-    assert pa.is_recorded({"url-a"}, "feat/x") is True
+    _write_state(home, {"feat/x": {"urls": [A], "ts": recent}})
+    assert pa.is_recorded({A}, "feat/x") is True
+
+
+def test_future_timestamp_is_not_fresh(home):
+    """SECURITY (#P2): a FUTURE ts (clock skew / tampered state) must NOT read as
+    fresh — its negative age would otherwise pass `< RETENTION_DAYS` forever."""
+    future = (datetime.now(UTC) + timedelta(days=5)).isoformat()
+    _write_state(home, {"feat/x": {"urls": [A], "ts": future}})
+    assert pa.is_recorded({A}, "feat/x") is False
 
 
 def test_stale_entries_pruned_on_write(home):
     old = (datetime.now(UTC) - timedelta(days=pa.RETENTION_DAYS + 5)).isoformat()
-    _write_state(home, {"stale/one": {"urls": ["u1"], "ts": old}})
-    # Recording a different branch prunes the stale one in the same write.
-    pa.record({"u2"}, "fresh/two")
+    _write_state(home, {"stale/one": {"urls": [C], "ts": old}})
+    pa.record({B}, "fresh/two")
     data = json.loads(_state(home).read_text())
     assert "stale/one" not in data["branches"]
     assert "fresh/two" in data["branches"]
 
 
 def test_missing_or_unparseable_ts_treated_as_stale(home):
-    _write_state(home, {"a": {"urls": ["u"]}, "b": {"urls": ["u"], "ts": "not-a-date"}})
-    assert pa.is_recorded({"u"}, "a") is False
-    assert pa.is_recorded({"u"}, "b") is False
+    _write_state(home, {"a": {"urls": [A]}, "b": {"urls": [A], "ts": "not-a-date"}})
+    assert pa.is_recorded({A}, "a") is False
+    assert pa.is_recorded({A}, "b") is False
 
 
 # ── fail-open on corruption ───────────────────────────────────────────
@@ -128,29 +253,29 @@ def test_missing_or_unparseable_ts_treated_as_stale(home):
 
 def test_corrupt_file_fails_open_to_false(home):
     _state(home).write_text("{ this is not json ]]")
-    assert pa.is_recorded({"url-a"}, "feat/x") is False
+    assert pa.is_recorded({A}, "feat/x") is False
 
 
 def test_record_overwrites_corrupt_file(home):
     _state(home).write_text("garbage")
-    pa.record({"url-a"}, "feat/x")  # must not raise; overwrites with a valid envelope
-    assert pa.is_recorded({"url-a"}, "feat/x") is True
+    pa.record({A}, "feat/x")  # must not raise; overwrites with a valid envelope
+    assert pa.is_recorded({A}, "feat/x") is True
 
 
 def test_non_dict_envelope_fails_open(home):
     _state(home).write_text(json.dumps([1, 2, 3]))
-    assert pa.is_recorded({"url-a"}, "feat/x") is False
+    assert pa.is_recorded({A}, "feat/x") is False
 
 
 # ── placement / hygiene ───────────────────────────────────────────────
 
 
 def test_state_lands_under_genesis_home(home):
-    pa.record({"url-a"}, "feat/x")
+    pa.record({A}, "feat/x")
     assert _state(home).exists()
 
 
 def test_no_tmp_files_left_behind(home):
-    pa.record({"url-a"}, "feat/x")
+    pa.record({A}, "feat/x")
     leftovers = list(home.glob(".pushed_branches.*.tmp"))
     assert leftovers == [], f"temp files not cleaned: {leftovers}"

--- a/tests/test_hooks/test_push_allowlist.py
+++ b/tests/test_hooks/test_push_allowlist.py
@@ -1,0 +1,156 @@
+"""Unit tests for scripts/hooks/push_allowlist.py — the local push allowlist.
+
+The allowlist caches "branch X is confirmed on remote (push-urls U)" so a
+re-push is decided offline instead of via a network ls-remote. These tests pin
+the security-relevant invariants: it never matches an unrecorded branch, an
+empty/disjoint url set never matches, stale entries expire, and every read/write
+fails OPEN (a corrupt file can only cause a redundant prompt, never a phantom
+allow).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "hooks"))
+import push_allowlist as pa  # noqa: E402
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Redirect the allowlist state file under a tmp GENESIS_HOME (never ~/.genesis)."""
+    gh = tmp_path / "genesis-home"
+    gh.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("GENESIS_HOME", str(gh))
+    return gh
+
+
+def _state(home: Path) -> Path:
+    return home / "pushed_branches.json"
+
+
+# ── roundtrip + keying ────────────────────────────────────────────────
+
+
+def test_record_then_is_recorded_roundtrip(home):
+    pa.record({"git@github.com:o/r.git"}, "feat/x")
+    assert pa.is_recorded({"git@github.com:o/r.git"}, "feat/x") is True
+
+
+def test_url_intersection_matches(home):
+    pa.record({"url-a", "url-b"}, "feat/x")
+    # A later push whose resolved url set overlaps the recorded set matches.
+    assert pa.is_recorded({"url-b", "url-c"}, "feat/x") is True
+
+
+def test_disjoint_urls_do_not_match(home):
+    """Same branch NAME, a different repo's url → NOT recorded (no conflation)."""
+    pa.record({"git@github.com:o/r.git"}, "feat/x")
+    assert pa.is_recorded({"git@github.com:other/repo.git"}, "feat/x") is False
+
+
+def test_empty_push_urls_never_matches_and_never_records(home):
+    # is_recorded with no urls → False (fall back to ls-remote).
+    pa.record({"url-a"}, "feat/x")
+    assert pa.is_recorded(set(), "feat/x") is False
+    # record with no urls → no-op (unresolvable remote can't be keyed).
+    pa.record(set(), "feat/y")
+    data = json.loads(_state(home).read_text())
+    assert "feat/y" not in data["branches"]
+
+
+def test_unrecorded_branch_not_recorded(home):
+    pa.record({"url-a"}, "feat/x")
+    assert pa.is_recorded({"url-a"}, "feat/never-pushed") is False
+
+
+def test_empty_state_returns_false(home):
+    # No file at all → not recorded (fail-open to prompt).
+    assert pa.is_recorded({"url-a"}, "feat/x") is False
+
+
+# ── REPLACE semantics (C2) ────────────────────────────────────────────
+
+
+def test_rerecord_replaces_url_set(home):
+    """A re-record REPLACES the url set (does not union) — a stale set-url --push
+    ages out immediately rather than lingering in the trusted set."""
+    pa.record({"old-url"}, "feat/x")
+    pa.record({"new-url"}, "feat/x")
+    data = json.loads(_state(home).read_text())
+    assert data["branches"]["feat/x"]["urls"] == ["new-url"]
+    assert pa.is_recorded({"old-url"}, "feat/x") is False
+    assert pa.is_recorded({"new-url"}, "feat/x") is True
+
+
+# ── freshness / prune ─────────────────────────────────────────────────
+
+
+def _write_state(home: Path, branches: dict) -> None:
+    _state(home).write_text(json.dumps({"version": 1, "branches": branches}))
+
+
+def test_stale_entry_is_not_recorded(home):
+    old = (datetime.now(UTC) - timedelta(days=pa.RETENTION_DAYS + 1)).isoformat()
+    _write_state(home, {"feat/x": {"urls": ["url-a"], "ts": old}})
+    assert pa.is_recorded({"url-a"}, "feat/x") is False
+
+
+def test_fresh_entry_just_inside_window_is_recorded(home):
+    recent = (datetime.now(UTC) - timedelta(days=pa.RETENTION_DAYS - 1)).isoformat()
+    _write_state(home, {"feat/x": {"urls": ["url-a"], "ts": recent}})
+    assert pa.is_recorded({"url-a"}, "feat/x") is True
+
+
+def test_stale_entries_pruned_on_write(home):
+    old = (datetime.now(UTC) - timedelta(days=pa.RETENTION_DAYS + 5)).isoformat()
+    _write_state(home, {"stale/one": {"urls": ["u1"], "ts": old}})
+    # Recording a different branch prunes the stale one in the same write.
+    pa.record({"u2"}, "fresh/two")
+    data = json.loads(_state(home).read_text())
+    assert "stale/one" not in data["branches"]
+    assert "fresh/two" in data["branches"]
+
+
+def test_missing_or_unparseable_ts_treated_as_stale(home):
+    _write_state(home, {"a": {"urls": ["u"]}, "b": {"urls": ["u"], "ts": "not-a-date"}})
+    assert pa.is_recorded({"u"}, "a") is False
+    assert pa.is_recorded({"u"}, "b") is False
+
+
+# ── fail-open on corruption ───────────────────────────────────────────
+
+
+def test_corrupt_file_fails_open_to_false(home):
+    _state(home).write_text("{ this is not json ]]")
+    assert pa.is_recorded({"url-a"}, "feat/x") is False
+
+
+def test_record_overwrites_corrupt_file(home):
+    _state(home).write_text("garbage")
+    pa.record({"url-a"}, "feat/x")  # must not raise; overwrites with a valid envelope
+    assert pa.is_recorded({"url-a"}, "feat/x") is True
+
+
+def test_non_dict_envelope_fails_open(home):
+    _state(home).write_text(json.dumps([1, 2, 3]))
+    assert pa.is_recorded({"url-a"}, "feat/x") is False
+
+
+# ── placement / hygiene ───────────────────────────────────────────────
+
+
+def test_state_lands_under_genesis_home(home):
+    pa.record({"url-a"}, "feat/x")
+    assert _state(home).exists()
+
+
+def test_no_tmp_files_left_behind(home):
+    pa.record({"url-a"}, "feat/x")
+    leftovers = list(home.glob(".pushed_branches.*.tmp"))
+    assert leftovers == [], f"temp files not cleaned: {leftovers}"

--- a/tests/test_hooks/test_push_allowlist.py
+++ b/tests/test_hooks/test_push_allowlist.py
@@ -157,8 +157,9 @@ def test_sanitize_url_classification_matrix():
     assert pa._sanitize_url("https://user@/x") is None
     assert pa._sanitize_url("https://a@b@host/x") == "https://host/x"
     assert pa._sanitize_url("https://host/a@b") == "https://host/a@b"
-    # scp-like: ONLY when ':' has no '/' before it; userinfo stripped.
-    assert pa._sanitize_url("git@github.com:o/r.git") == "github.com:o/r.git"
+    # scp-like: ONLY when ':' has no '/' before it; FULL form kept incl. user@
+    # (the SSH login is part of repo identity — scp path is relative to its home).
+    assert pa._sanitize_url("git@github.com:o/r.git") == "git@github.com:o/r.git"
     assert pa._sanitize_url("host:path/x") == "host:path/x"
     # absolute local path — stable.
     assert pa._sanitize_url("/srv/git/a.git") == "/srv/git/a.git"
@@ -184,12 +185,18 @@ def test_relative_path_with_colon_not_offline_allowed(home):
     assert pa.is_recorded({ambiguous}, "feat/x") is False
 
 
-def test_scp_userinfo_stripped_from_stored_url(home):
-    """An scp ``user@`` prefix is never persisted verbatim; matching still works."""
+def test_scp_user_is_part_of_the_key(home):
+    """The scp SSH login is repo identity, not a credential: it is kept in the key,
+    and two different logins to the same host:path must NOT collide (a relative scp
+    path resolves under each login's home = different repos)."""
     pa.record({"git@github.com:o/r.git"}, "feat/x")
     data = json.loads(_state(home).read_text())
-    assert data["branches"]["feat/x"]["urls"] == ["github.com:o/r.git"]
+    assert data["branches"]["feat/x"]["urls"] == ["git@github.com:o/r.git"]
     assert pa.is_recorded({"git@github.com:o/r.git"}, "feat/x") is True
+    # alice@host:repo and bob@host:repo are DIFFERENT repos → no offline conflation.
+    pa.record({"alice@host:repo.git"}, "feat/y")
+    assert pa.is_recorded({"bob@host:repo.git"}, "feat/y") is False
+    assert pa.is_recorded({"alice@host:repo.git"}, "feat/y") is True
 
 
 # ── REPLACE semantics (C2) ────────────────────────────────────────────

--- a/tests/test_hooks/test_push_create_override.py
+++ b/tests/test_hooks/test_push_create_override.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -698,3 +699,109 @@ def test_exec_flag_asks(published_feat):
     res = _run_at("git push --exec=/tmp/helper origin feat/x", published_feat)
     assert res.returncode == 0, res.stderr
     assert _decision(res) == "ask"
+
+
+# ── push_allowlist offline cache (the transient-ls-remote-failure fix) ─────────
+# The re-push gate's canonical "already on the remote?" check is a live
+# ``git ls-remote`` that FAIL-CLOSES to a prompt on any network failure, so a
+# transient failure re-prompts an already-approved branch (the #1262 gap).
+# ``push_allowlist`` caches the confirmed-on-remote fact LOCALLY so a re-push is
+# decided OFFLINE. These prove: a live HIT records the branch; a recorded branch
+# is allowed offline even when ls-remote CANNOT succeed; the SAME failure WITHOUT
+# a record still prompts (fail-closed); and a record for a DIFFERENT repo url does
+# not authorize an offline allow (no branch-name conflation across repos).
+
+
+@pytest.fixture(autouse=True)
+def _isolate_push_allowlist_home(tmp_path, monkeypatch):
+    """Redirect GENESIS_HOME to a per-test tmp dir.
+
+    The re-push gate now WRITES push_allowlist state under GENESIS_HOME on an
+    ls-remote HIT (and READS it for the offline fast-path), so without this every
+    test that reaches the re-push arm would read/pollute the developer's real
+    ``~/.genesis/pushed_branches.json`` (isolation lesson from #1406). ``_run`` /
+    ``_run_at`` copy ``os.environ`` into the subprocess, so the guard child sees
+    the same isolated home.
+    """
+    monkeypatch.setenv("GENESIS_HOME", str(tmp_path / "allowlist-home"))
+
+
+def _pa():
+    """Import the ``push_allowlist`` module under test (scripts/hooks)."""
+    sys.path.insert(0, str(_GUARD.parent))
+    import push_allowlist
+
+    return push_allowlist
+
+
+def _push_urls(clone: str) -> set[str]:
+    """origin's push-url SET exactly as the guard's ``_remote_push_urls`` resolves it."""
+    out = subprocess.run(
+        ["git", "-C", clone, "remote", "get-url", "--push", "--all", "origin"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return {ln.strip() for ln in out.stdout.splitlines() if ln.strip()}
+
+
+def test_republish_hit_records_branch(published_feat):
+    """A normal re-push (live ls-remote HIT) ALLOWS and RECORDS feat/x for later
+    offline decisions."""
+    pa = _pa()
+    res = _run_at("git push", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "allow"
+    assert pa.is_recorded(_push_urls(published_feat), "feat/x") is True
+
+
+def test_republish_offline_allow_when_ls_remote_fails(published_feat, tmp_path):
+    """Core RED→GREEN: with feat/x recorded, a re-push is ALLOWED OFFLINE even when
+    ls-remote cannot reach the remote (the transient-failure case #1262 mishandled).
+
+    Deleting the bare remote makes ``git ls-remote`` fail while leaving the url
+    config — and thus the allowlist key — intact, so the allow can ONLY come from
+    the local record."""
+    pa = _pa()
+    pa.record(_push_urls(published_feat), "feat/x")
+    shutil.rmtree(tmp_path / "remote.git")  # ls-remote now fails; url config unchanged
+    res = _run_at("git push", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "allow"
+
+
+def test_ls_remote_failure_without_record_asks(published_feat, tmp_path):
+    """Fail-closed: the SAME ls-remote failure but NOTHING recorded → PROMPT, never
+    a silent allow. Proves the offline allow above is caused by the record, not by
+    the ls-remote failure itself."""
+    shutil.rmtree(tmp_path / "remote.git")
+    res = _run_at("git push", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_recorded_wrong_repo_url_does_not_allow_offline(published_feat, tmp_path):
+    """URL-keying: a record for a DIFFERENT repo's url must not authorize feat/x
+    here. ls-remote failing + a disjoint-url record → PROMPT (no conflation)."""
+    pa = _pa()
+    pa.record({"git@github.com:someone/else.git"}, "feat/x")
+    shutil.rmtree(tmp_path / "remote.git")
+    res = _run_at("git push", published_feat)
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "ask"
+
+
+def test_integration_record_stays_under_isolated_home(published_feat, tmp_path):
+    """Hardening (security-review NOTE): guard against a future ``_run``/``_run_at``
+    refactor silently reintroducing the #1406 real-``~/.genesis`` leak class. The
+    gate now WRITES push_allowlist state on an ls-remote HIT; that write MUST land
+    under the isolated tmp GENESIS_HOME. If the subprocess ever stops inheriting
+    GENESIS_HOME, this fails loudly here instead of writing the developer's real
+    home."""
+    res = _run_at("git push", published_feat)  # live ls-remote HIT → records feat/x
+    assert res.returncode == 0, res.stderr
+    assert _decision(res) == "allow"
+    assert (tmp_path / "allowlist-home" / "pushed_branches.json").exists(), (
+        "record did not land under the isolated GENESIS_HOME — the guard subprocess "
+        "no longer inherits GENESIS_HOME? (real-~/.genesis leak risk)"
+    )


### PR DESCRIPTION
## Problem

The push-approval hook prompts only on a branch's **first** push; a re-push of
fixes to the same, already-published branch must be silent. But the "already on
the remote?" check is a live `git ls-remote` that fail-closes to a **prompt** on
any network hiccup, so a flaky network re-prompted every re-push — the
first-push-only guarantee was network-fragile.

## What this does

- **`scripts/hooks/push_allowlist.py`** (new, stdlib-only): a local allowlist
  that caches the confirmed-on-remote fact in `~/.genesis/pushed_branches.json`,
  so re-pushes are decided **offline**. `is_recorded` / `record`, keyed on
  `(branch, push-URL set)` — never the remote name, so the same branch name on a
  different repo is never conflated. 90-day prune on write; atomic
  `tmp` + `os.replace`; fail-open everywhere (a corrupt/absent file can only
  cause a redundant prompt).
- **`scripts/hooks/git_push_guard.py`**: the non-force re-push arm now checks the
  allowlist offline first, falls back to the live `ls-remote` leg, and records on
  a **HIT** (the sole writer). A guarded import degrades to the pure `ls-remote`
  path if the module is broken/absent — mirroring the existing `review_state`
  soft-import (a raising hook import exits 1 → CC treats non-2 as non-blocking →
  every fail-closed gate would silently vanish).

## Security invariant

The allowlist can **only** relax a re-push of a branch a live `ls-remote` just
proved is on the remote (i.e. already approved on its first push) — it can never
authorize a genuine first push. Force pushes, dispatched sessions, and pushes to
`main`/`master` are hard-blocked **before** this arm; the allow is deferred so a
compound `git push … && git commit --no-verify` still hard-blocks. A security
review of the diff confirmed the invariant holds (no CRITICAL/HIGH).

Consumer-side recording only — a pre-implementation architecture review found
that a PostToolUse recorder keyed on the current branch could mis-seed a
never-pushed branch into a silent first push; it was dropped, removing that
class entirely.

Conscious tradeoff (documented): a recorded branch stays trusted for the 90-day
window even if its remote copy is later deleted — a liveness check would
reintroduce the network dependency this change removes.

## Tests

16 unit (`test_push_allowlist.py`) + 5 integration (`test_push_create_override.py`,
including offline-allow when `ls-remote` fails, verify-RED'd RED→GREEN) + a
home-isolation guard. 93 push-gate + 593 sibling guard/`test_scripts` tests
green; ruff clean; no writes to the real `~/.genesis`.

Ledger: fb8b780245cc4e1b9e8a9160fbfaee54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NPVb1ckaMnde48hzvumyt
