### PR TITLE
fix(scripts): fail-closed inbox vault-sync cleanup (core; seen-ledger deferred)

### DIFF
--- a/scripts/inbox_sync.sh
+++ b/scripts/inbox_sync.sh
@@ -10,12 +10,8 @@
 # Response files use .genesis.md suffix (sibling to source files).
 # No subdirectory needed — everything lives in the same folder.
 #
-# Local state files (all ".genesis-*", excluded from the step-1 mirror so the
-# sync can never delete its own state — the old in-mirror response counter was
-# deleted every cycle for months before this was caught):
-#   .genesis-seen        names ever seen in a HEALTHY vault listing (deletion
-#                        evidence: only a file the vault once had can be
-#                        "deleted from the vault")
+# Local state files (".genesis-*", excluded from the step-1 mirror so the sync
+# can never delete its own state):
 #   .genesis-lsf-stderr  stderr of the last listing attempt (kept out of the
 #                        listing data so error text can never join a
 #                        membership decision)
@@ -48,45 +44,42 @@ fi
         --verbose 2>&1
 
     # 2. Detect user-deleted .genesis.md files:
-    #    If a local .genesis.md file is >10min old, was seen on the vault at
-    #    least once (a push we KNOW succeeded), but is missing from a HEALTHY
-    #    vault listing — the user deleted it in Obsidian; clean up locally too.
-    #    Grace period: cron runs every 5min, so new files get pushed within
-    #    5min; after 10min an unlisted-but-seen file must be a user deletion.
+    #    A local .genesis.md file >10min old that is missing from a HEALTHY
+    #    vault listing was deleted by the user in Obsidian; clean it up locally.
+    #    Grace period: cron runs every 5min, so new files push within 5min;
+    #    after 10min an unlisted file is treated as a user deletion.
     #
-    #    FAIL-CLOSED (2026-08-24): the listing below is the sole evidence for
-    #    "the user deleted this". If `rclone lsf` fails (Dropbox API outage),
-    #    an empty listing must NEVER be read as "everything was deleted" —
-    #    on 2026-07-29 exactly that wiped all 150 local response files and
-    #    reset the response counter. A skipped cleanup cycle is harmless
-    #    (the next healthy cycle catches real deletions); a false-positive
-    #    wipe is not. The .genesis-seen requirement closes the sibling hole:
-    #    a response the push step never landed (quota/upload failures while
-    #    the listing stays healthy) is absent from the vault WITHOUT being a
-    #    user deletion — it must be retried, not reaped. Bulk deletions on a
-    #    HEALTHY listing are still honored (a blocked bulk delete would
-    #    resurrect user-deleted files via the push in step 3) but logged
-    #    loudly for the audit trail.
+    #    FAIL-CLOSED (2026-08-24): the listing is the sole evidence for "the
+    #    user deleted this". If `rclone lsf` fails (Dropbox API outage), an
+    #    empty listing must NEVER be read as "everything was deleted" — on
+    #    2026-07-29 exactly that wiped all 150 local response files and reset
+    #    the response counter. On a failed listing we skip cleanup AND hold
+    #    back the push of >grace-age files (step 3), so an old local copy of a
+    #    vault-side deletion cannot be re-uploaded (resurrected) before the
+    #    next healthy cycle cleans it. Bulk deletions on a HEALTHY listing are
+    #    still honored (blocking would resurrect user-deleted files via the
+    #    push) but logged loudly.
+    #
+    #    KNOWN LIMITATION (deferred, tracked): a response whose push never
+    #    landed (upload fails while the listing stays healthy) is absent from
+    #    the vault WITHOUT being a user deletion, and is reaped after the grace
+    #    period. Protecting that edge needs a durable "seen on the vault"
+    #    ledger — deferred to its own change. This behavior is no worse than
+    #    the pre-2026-08-24 script (which had neither the ledger nor fail-closed).
     LSF_ERR="$LOCAL_PATH/.genesis-lsf-stderr"
-    SEEN="$LOCAL_PATH/.genesis-seen"
+    PUSH_MAX_AGE=""
     # Never write state through a pre-planted symlink (defense-in-depth;
-    # single-tenant box, but rm -f is free and rm does not follow symlinks)
-    rm -f -- "$LSF_ERR" "$SEEN.tmp"
+    # single-tenant box, but rm -f is free and rm does not follow symlinks).
+    rm -f -- "$LSF_ERR"
     if REMOTE_GENESIS=$(rclone lsf "dropbox:$DROPBOX_PATH" --include "*.genesis.md" 2>"$LSF_ERR"); then
         remote_count=$(printf '%s\n' "$REMOTE_GENESIS" | grep -c . || true)
-        # Record every vault-listed name as "seen on the vault at least once"
-        { [ -f "$SEEN" ] && cat "$SEEN"; printf '%s\n' "$REMOTE_GENESIS"; } \
-            | grep . | LC_ALL=C sort -u > "$SEEN.tmp" && mv "$SEEN.tmp" "$SEEN"
         cleaned=0
         for f in "$LOCAL_PATH"/*.genesis.md; do
             [ -f "$f" ] || continue
             fname=$(basename -- "$f")
+            # Filename is DATA, never grep/rm options: grep -qxF -- / rm --.
             if ! printf '%s\n' "$REMOTE_GENESIS" | grep -qxF -- "$fname"; then
-                # Absent from the vault: only a user deletion if the vault
-                # ever had it — otherwise it's an un-landed push (keep and
-                # let step 3 retry it).
-                if grep -qxF -- "$fname" "$SEEN" 2>/dev/null \
-                    && [ "$(find "$f" -mmin +10 2>/dev/null)" ]; then
+                if [ "$(find "$f" -mmin +10 2>/dev/null)" ]; then
                     if rm -- "$f"; then
                         # Control chars stripped from the audit line (log
                         # injection defense-in-depth); UTF-8 titles intact.
@@ -102,13 +95,26 @@ fi
         fi
     else
         lsf_rc=$?
-        echo "SKIP cleanup: vault listing failed (rc=$lsf_rc) — refusing to treat an empty listing as mass deletion. rclone stderr: $(tr -d '[:cntrl:]' < "$LSF_ERR" 2>/dev/null)"
+        # Listing unhealthy: hold back the push of >grace-age files so an old
+        # local copy of a vault-side deletion cannot be resurrected. Fresh
+        # responses (<10min) still ship promptly.
+        PUSH_MAX_AGE="10m"
+        echo "SKIP cleanup: vault listing failed (rc=$lsf_rc) — refusing to treat an empty listing as mass deletion; holding back push of >${PUSH_MAX_AGE} files. rclone stderr: $(tr -d '[:cntrl:]' < "$LSF_ERR" 2>/dev/null)"
     fi
 
-    # 3. Push: local .genesis.md files → Dropbox (responses back to vault)
-    rclone copy "$LOCAL_PATH" "dropbox:$DROPBOX_PATH" \
-        --include "*.genesis.md" \
-        --verbose 2>&1
+    # 3. Push: local .genesis.md files → Dropbox (responses back to vault).
+    #    On a failed-listing cycle PUSH_MAX_AGE gates this to fresh files only
+    #    (see step 2) so a not-yet-cleaned deletion can't be re-uploaded.
+    if [ -n "$PUSH_MAX_AGE" ]; then
+        rclone copy "$LOCAL_PATH" "dropbox:$DROPBOX_PATH" \
+            --include "*.genesis.md" \
+            --max-age "$PUSH_MAX_AGE" \
+            --verbose 2>&1
+    else
+        rclone copy "$LOCAL_PATH" "dropbox:$DROPBOX_PATH" \
+            --include "*.genesis.md" \
+            --verbose 2>&1
+    fi
 
     echo "--- done ---"
 } >> "$LOG" 2>&1

--- a/scripts/inbox_sync.sh
+++ b/scripts/inbox_sync.sh
@@ -9,6 +9,16 @@
 #
 # Response files use .genesis.md suffix (sibling to source files).
 # No subdirectory needed — everything lives in the same folder.
+#
+# Local state files (all ".genesis-*", excluded from the step-1 mirror so the
+# sync can never delete its own state — the old in-mirror response counter was
+# deleted every cycle for months before this was caught):
+#   .genesis-seen        names ever seen in a HEALTHY vault listing (deletion
+#                        evidence: only a file the vault once had can be
+#                        "deleted from the vault")
+#   .genesis-lsf-stderr  stderr of the last listing attempt (kept out of the
+#                        listing data so error text can never join a
+#                        membership decision)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -18,31 +28,82 @@ LOG="${GENESIS_INBOX_SYNC_LOG:-$REPO_DIR/logs/inbox_sync.log}"
 
 mkdir -p "$(dirname "$LOG")" "$LOCAL_PATH"
 
+# Single-flight: an API outage can stretch a cycle past the 5-min cron period
+# (rclone retries); overlapping runs would interleave deletions and log lines.
+exec 9>"$LOG.lock"
+if ! flock -n 9; then
+    echo "--- $(date -u +%Y-%m-%dT%H:%M:%SZ) overlap: previous run still active, skipping ---" >> "$LOG"
+    exit 0
+fi
+
 {
     echo "--- $(date -u +%Y-%m-%dT%H:%M:%SZ) ---"
 
     # 1. Pull: Dropbox → local (get new files from Obsidian, skip .genesis.md
-    #    so we don't overwrite local responses before push)
+    #    so we don't overwrite local responses before push, and skip local
+    #    ".genesis-*" state so the mirror never deletes it)
     rclone sync "dropbox:$DROPBOX_PATH" "$LOCAL_PATH" \
         --exclude "*.genesis.md" \
+        --exclude ".genesis-*" \
         --verbose 2>&1
 
     # 2. Detect user-deleted .genesis.md files:
-    #    If a local .genesis.md file is >10min old (already pushed at least once)
-    #    but missing from Dropbox, the user deleted it — clean up locally too.
-    #    Grace period: cron runs every 5min, so new files get pushed within 5min.
-    #    After 10min, if still not on Dropbox, user must have deleted it.
-    REMOTE_GENESIS=$(rclone lsf "dropbox:$DROPBOX_PATH" --include "*.genesis.md" 2>/dev/null || true)
-    for f in "$LOCAL_PATH"/*.genesis.md; do
-        [ -f "$f" ] || continue
-        fname=$(basename "$f")
-        if ! echo "$REMOTE_GENESIS" | grep -qxF "$fname"; then
-            if [ "$(find "$f" -mmin +10 2>/dev/null)" ]; then
-                echo "Cleaned up (deleted from vault): $fname"
-                rm "$f"
+    #    If a local .genesis.md file is >10min old, was seen on the vault at
+    #    least once (a push we KNOW succeeded), but is missing from a HEALTHY
+    #    vault listing — the user deleted it in Obsidian; clean up locally too.
+    #    Grace period: cron runs every 5min, so new files get pushed within
+    #    5min; after 10min an unlisted-but-seen file must be a user deletion.
+    #
+    #    FAIL-CLOSED (2026-08-24): the listing below is the sole evidence for
+    #    "the user deleted this". If `rclone lsf` fails (Dropbox API outage),
+    #    an empty listing must NEVER be read as "everything was deleted" —
+    #    on 2026-07-29 exactly that wiped all 150 local response files and
+    #    reset the response counter. A skipped cleanup cycle is harmless
+    #    (the next healthy cycle catches real deletions); a false-positive
+    #    wipe is not. The .genesis-seen requirement closes the sibling hole:
+    #    a response the push step never landed (quota/upload failures while
+    #    the listing stays healthy) is absent from the vault WITHOUT being a
+    #    user deletion — it must be retried, not reaped. Bulk deletions on a
+    #    HEALTHY listing are still honored (a blocked bulk delete would
+    #    resurrect user-deleted files via the push in step 3) but logged
+    #    loudly for the audit trail.
+    LSF_ERR="$LOCAL_PATH/.genesis-lsf-stderr"
+    SEEN="$LOCAL_PATH/.genesis-seen"
+    # Never write state through a pre-planted symlink (defense-in-depth;
+    # single-tenant box, but rm -f is free and rm does not follow symlinks)
+    rm -f -- "$LSF_ERR" "$SEEN.tmp"
+    if REMOTE_GENESIS=$(rclone lsf "dropbox:$DROPBOX_PATH" --include "*.genesis.md" 2>"$LSF_ERR"); then
+        remote_count=$(printf '%s\n' "$REMOTE_GENESIS" | grep -c . || true)
+        # Record every vault-listed name as "seen on the vault at least once"
+        { [ -f "$SEEN" ] && cat "$SEEN"; printf '%s\n' "$REMOTE_GENESIS"; } \
+            | grep . | LC_ALL=C sort -u > "$SEEN.tmp" && mv "$SEEN.tmp" "$SEEN"
+        cleaned=0
+        for f in "$LOCAL_PATH"/*.genesis.md; do
+            [ -f "$f" ] || continue
+            fname=$(basename -- "$f")
+            if ! printf '%s\n' "$REMOTE_GENESIS" | grep -qxF -- "$fname"; then
+                # Absent from the vault: only a user deletion if the vault
+                # ever had it — otherwise it's an un-landed push (keep and
+                # let step 3 retry it).
+                if grep -qxF -- "$fname" "$SEEN" 2>/dev/null \
+                    && [ "$(find "$f" -mmin +10 2>/dev/null)" ]; then
+                    if rm -- "$f"; then
+                        # Control chars stripped from the audit line (log
+                        # injection defense-in-depth); UTF-8 titles intact.
+                        echo "Cleaned up (deleted from vault): $(printf '%s' "$fname" | tr -d '[:cntrl:]')"
+                        cleaned=$((cleaned + 1))
+                    fi
+                fi
             fi
+        done
+        echo "Cleanup pass: vault listing $remote_count response file(s), cleaned $cleaned"
+        if [ "$cleaned" -gt 5 ]; then
+            echo "WARNING: bulk cleanup — $cleaned response files removed in one cycle (vault listing was healthy; verify this matches a deliberate Obsidian cleanup)"
         fi
-    done
+    else
+        lsf_rc=$?
+        echo "SKIP cleanup: vault listing failed (rc=$lsf_rc) — refusing to treat an empty listing as mass deletion. rclone stderr: $(tr -d '[:cntrl:]' < "$LSF_ERR" 2>/dev/null)"
+    fi
 
     # 3. Push: local .genesis.md files → Dropbox (responses back to vault)
     rclone copy "$LOCAL_PATH" "dropbox:$DROPBOX_PATH" \

--- a/tests/test_scripts/test_inbox_sync.py
+++ b/tests/test_scripts/test_inbox_sync.py
@@ -7,17 +7,16 @@ deleted every local `*.genesis.md` response file (150 in one cycle) as
 "deleted from vault" — a false positive that reset the response counter and
 caused silent overwrites of already-delivered files in the user's vault.
 
-Also locked here (2026-08-24 adversarial review):
-- deletion requires the file to have been SEEN on the vault at least once
-  (a healthy listing containing it), so a push that never landed is retried,
-  not reaped;
+Also locked here:
+- on a failed listing the step-3 push is age-gated so an old local copy of a
+  vault-side deletion cannot be re-uploaded (resurrected) before the next
+  healthy cycle can clean it;
 - filenames are handled as data (leading dash, spaces, ``&``, apostrophes —
   the live vault's actual shapes), never as grep/rm options;
 - listing stderr stays out of the membership data.
 
-The intended behavior being preserved: a response file the user genuinely
-deleted in Obsidian (absent from a HEALTHY listing, previously seen on the
-vault, older than the 10-minute grace period) is still cleaned up locally.
+A durable "seen on the vault" ledger (never-landed-push protection) is
+deliberately NOT part of this change — deferred to its own PR.
 
 Runs the REAL script with a fake `rclone` on PATH (behavior driven by env).
 """
@@ -104,18 +103,18 @@ def _run(env: dict) -> subprocess.CompletedProcess:
     )
 
 
+def _copy_calls(call_log: Path) -> list[str]:
+    return [c for c in call_log.read_text().splitlines() if c.startswith("rclone copy")]
+
+
 def test_lsf_failure_skips_cleanup_entirely(tmp_path):
     """REPRO of the 2026-07-29 wipe: listing fails → NOTHING may be deleted.
 
     Also asserts the SKIP line carries the diagnostics (rc + rclone stderr)."""
     env, inbox, log, _ = _setup(tmp_path)
     kept = [_old_response_file(inbox, f"Genesis-{n}.genesis.md") for n in (1, 2, 3)]
-    # Make every file eligible for deletion were the gate broken: seen before
-    _set_listing(env, [f.name for f in kept])
-    r = _run(env)
-    assert r.returncode == 0, r.stderr
-
     env["RCLONE_LSF_RC"] = "7"  # Dropbox API outage: lsf fails
+
     r = _run(env)
 
     assert r.returncode == 0, r.stderr
@@ -128,8 +127,11 @@ def test_lsf_failure_skips_cleanup_entirely(tmp_path):
     assert "simulated outage" in body, "SKIP line must carry rclone's stderr"
 
 
-def test_lsf_failure_still_pushes_responses(tmp_path):
-    """A failed listing must not block step 3 — responses still reach the vault."""
+def test_failed_listing_push_is_age_gated(tmp_path):
+    """On a failed-listing cycle the push must be gated to fresh files
+    (--max-age) — otherwise an old local copy of a file the user just deleted
+    on the vault is silently re-uploaded (resurrection), because cleanup is
+    skipped but the push still runs."""
     env, inbox, _, call_log = _setup(tmp_path)
     _old_response_file(inbox, "Genesis-1.genesis.md")
     env["RCLONE_LSF_RC"] = "1"
@@ -137,26 +139,37 @@ def test_lsf_failure_still_pushes_responses(tmp_path):
     r = _run(env)
 
     assert r.returncode == 0, r.stderr
-    calls = call_log.read_text()
-    assert "rclone copy" in calls, "push step skipped after a failed listing"
+    calls = _copy_calls(call_log)
+    assert calls, "push step did not run after a failed listing"
+    assert "--max-age" in calls[-1], (
+        "failed-listing push not age-gated — old files can resurrect deletions"
+    )
 
 
-def test_healthy_listing_still_cleans_user_deleted_file(tmp_path):
+def test_healthy_cycle_push_not_age_gated(tmp_path):
+    """A healthy cycle must push ALL responses (no age gate)."""
+    env, inbox, _, call_log = _setup(tmp_path)
+    _old_response_file(inbox, "Genesis-1.genesis.md")
+    _set_listing(env, ["Genesis-1.genesis.md"])
+
+    r = _run(env)
+
+    assert r.returncode == 0, r.stderr
+    calls = _copy_calls(call_log)
+    assert calls and "--max-age" not in calls[-1], (
+        "healthy-cycle push must NOT be age-gated (all responses ship)"
+    )
+
+
+def test_healthy_listing_cleans_user_deleted_file(tmp_path):
     """Intent lock, with the live corpus's filename shapes (spaces/&/'):
-
-    cycle 1: both files listed (seen recorded);
-    cycle 2: one vanishes from a healthy listing → user deletion → cleaned;
-    the still-listed one stays."""
+    a file absent from a HEALTHY listing and older than grace is a user
+    deletion → cleaned; a still-listed file stays."""
     env, inbox, log, _ = _setup(tmp_path)
     gone = _old_response_file(inbox, "My todos & musings-1.genesis.md")
     stays = _old_response_file(inbox, "Jay's Notes-2.genesis.md")
+    _set_listing(env, [stays.name])  # user deleted the first in Obsidian
 
-    _set_listing(env, [gone.name, stays.name])
-    r = _run(env)
-    assert r.returncode == 0, r.stderr
-    assert gone.exists() and stays.exists()
-
-    _set_listing(env, [stays.name])
     r = _run(env)
 
     assert r.returncode == 0, r.stderr
@@ -178,30 +191,10 @@ def test_leading_dash_name_kept_when_listed(tmp_path):
         "leading-dash filename deleted despite being in a healthy listing (grep read it as options)"
     )
 
-    # And when it truly disappears from the vault, it IS cleaned up.
-    _set_listing(env, [])
+    _set_listing(env, [])  # now genuinely gone from the vault
     r = _run(env)
     assert r.returncode == 0, r.stderr
     assert not dashy.exists()
-
-
-def test_never_pushed_file_is_not_reaped(tmp_path):
-    """Push-failure protection: a response the vault has NEVER listed (push
-    kept failing while the listing stayed healthy) is not a user deletion —
-    it must survive to be retried, not be reaped at the grace period."""
-    env, inbox, log, _ = _setup(tmp_path)
-    unlanded = _old_response_file(inbox, "Genesis-200.genesis.md")
-    _set_listing(env, [])  # healthy, but the push never landed the file
-
-    for _ in range(2):
-        r = _run(env)
-        assert r.returncode == 0, r.stderr
-
-    assert unlanded.exists(), (
-        "never-vault-listed response reaped as a 'user deletion' — "
-        "push failures must be retried, not destroyed"
-    )
-    assert "Cleaned up" not in log.read_text()
 
 
 def test_grace_period_keeps_recent_unpushed_file(tmp_path):
@@ -209,7 +202,8 @@ def test_grace_period_keeps_recent_unpushed_file(tmp_path):
     env, inbox, _, _ = _setup(tmp_path)
     fresh = inbox / "Genesis-9.genesis.md"
     fresh.write_text("just written, not yet pushed\n")
-    # healthy but empty listing
+    _set_listing(env, [])  # healthy but empty listing
+
     r = _run(env)
 
     assert r.returncode == 0, r.stderr
@@ -220,12 +214,8 @@ def test_bulk_deletion_on_healthy_listing_warns_but_proceeds(tmp_path):
     """A large legit cleanup still works (no resurrection loop) but logs loudly."""
     env, inbox, log, _ = _setup(tmp_path)
     files = [_old_response_file(inbox, f"Genesis-{n}.genesis.md") for n in range(1, 9)]
+    _set_listing(env, [])  # user deleted all of them in Obsidian
 
-    _set_listing(env, [f.name for f in files])  # cycle 1: all on vault (seen)
-    r = _run(env)
-    assert r.returncode == 0, r.stderr
-
-    _set_listing(env, [])  # cycle 2: user deleted all of them in Obsidian
     r = _run(env)
 
     assert r.returncode == 0, r.stderr
@@ -235,20 +225,21 @@ def test_bulk_deletion_on_healthy_listing_warns_but_proceeds(tmp_path):
     assert "WARNING: bulk cleanup" in body, "expected loud bulk-deletion warning"
 
 
-def test_state_files_excluded_from_mirror_and_not_pushed(tmp_path):
+def test_state_file_excluded_from_mirror_and_not_pushed(tmp_path):
     """The step-1 sync must carry --exclude '.genesis-*' so the mirror can
-    never delete the sync's own state files (the in-mirror response counter
-    was deleted every cycle for months)."""
+    never delete the sync's own state (the in-mirror response counter was
+    deleted every cycle); and .genesis-* is never pushed to the vault."""
     env, inbox, _, call_log = _setup(tmp_path)
     _set_listing(env, [])
     r = _run(env)
 
     assert r.returncode == 0, r.stderr
-    calls = call_log.read_text()
-    sync_calls = [c for c in calls.splitlines() if c.startswith("rclone sync")]
-    assert sync_calls, "step-1 sync not invoked"
-    assert "--exclude .genesis-*" in sync_calls[0], (
+    calls = call_log.read_text().splitlines()
+    sync_calls = [c for c in calls if c.startswith("rclone sync")]
+    assert sync_calls and "--exclude .genesis-*" in sync_calls[0], (
         "step-1 sync missing --exclude .genesis-* — the mirror will delete local state files"
     )
-    # State files themselves exist after a healthy cycle
-    assert (inbox / ".genesis-seen").exists()
+    copy_calls = _copy_calls(call_log)
+    assert copy_calls and "--include *.genesis.md" in copy_calls[0], (
+        "push must be scoped to *.genesis.md so .genesis-* state is never pushed"
+    )

--- a/tests/test_scripts/test_inbox_sync.py
+++ b/tests/test_scripts/test_inbox_sync.py
@@ -1,0 +1,254 @@
+"""Tests for scripts/inbox_sync.sh — vault↔local response-file sync.
+
+Focus: the cleanup step (step 2) must be FAIL-CLOSED on the vault listing.
+Regression under test (2026-07-29 incident): when `rclone lsf` failed during a
+Dropbox API outage, `REMOTE_GENESIS` silently became empty and the cleanup loop
+deleted every local `*.genesis.md` response file (150 in one cycle) as
+"deleted from vault" — a false positive that reset the response counter and
+caused silent overwrites of already-delivered files in the user's vault.
+
+Also locked here (2026-08-24 adversarial review):
+- deletion requires the file to have been SEEN on the vault at least once
+  (a healthy listing containing it), so a push that never landed is retried,
+  not reaped;
+- filenames are handled as data (leading dash, spaces, ``&``, apostrophes —
+  the live vault's actual shapes), never as grep/rm options;
+- listing stderr stays out of the membership data.
+
+The intended behavior being preserved: a response file the user genuinely
+deleted in Obsidian (absent from a HEALTHY listing, previously seen on the
+vault, older than the 10-minute grace period) is still cleaned up locally.
+
+Runs the REAL script with a fake `rclone` on PATH (behavior driven by env).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "inbox_sync.sh"
+_BASE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
+
+_FAKE_RCLONE = """#!/bin/bash
+# Fake rclone for inbox_sync.sh tests. Dispatch on subcommand.
+echo "rclone $*" >> "$RCLONE_CALL_LOG"
+case "$1" in
+  lsf)
+    if [ "${RCLONE_LSF_RC:-0}" -ne 0 ]; then
+      echo "simulated outage: dial tcp: lookup api.dropboxapi.com: i/o timeout" >&2
+      exit "$RCLONE_LSF_RC"
+    fi
+    if [ -n "${RCLONE_LSF_OUTPUT_FILE:-}" ] && [ -f "$RCLONE_LSF_OUTPUT_FILE" ]; then
+      cat "$RCLONE_LSF_OUTPUT_FILE"
+    fi
+    ;;
+  sync|copy)
+    exit 0
+    ;;
+esac
+exit 0
+"""
+
+
+def _setup(tmp_path: Path) -> tuple[dict, Path, Path, Path]:
+    """Create shim bin, local inbox dir, log path; return (env, inbox, log, call_log)."""
+    shim_bin = tmp_path / "bin"
+    shim_bin.mkdir()
+    rclone = shim_bin / "rclone"
+    rclone.write_text(_FAKE_RCLONE)
+    rclone.chmod(0o755)
+
+    inbox = tmp_path / "inbox"
+    inbox.mkdir()
+    log = tmp_path / "inbox_sync.log"
+    call_log = tmp_path / "rclone_calls.log"
+    call_log.write_text("")
+    lsf_out = tmp_path / "lsf_output.txt"
+    lsf_out.write_text("")
+
+    env = {
+        "PATH": f"{shim_bin}:{_BASE_PATH}",
+        "HOME": str(tmp_path),
+        "GENESIS_INBOX_PATH": str(inbox),
+        "GENESIS_INBOX_SYNC_LOG": str(log),
+        "RCLONE_CALL_LOG": str(call_log),
+        "RCLONE_LSF_OUTPUT_FILE": str(lsf_out),
+    }
+    return env, inbox, log, call_log
+
+
+def _old_response_file(inbox: Path, name: str) -> Path:
+    """Create a response file older than the 10-minute grace period."""
+    f = inbox / name
+    f.write_text("response body\n")
+    old = time.time() - 20 * 60
+    os.utime(f, (old, old))
+    return f
+
+
+def _set_listing(env: dict, names: list[str]) -> None:
+    Path(env["RCLONE_LSF_OUTPUT_FILE"]).write_text(
+        "".join(f"{n}\n" for n in names),
+    )
+
+
+def _run(env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["/bin/bash", str(_SCRIPT)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_lsf_failure_skips_cleanup_entirely(tmp_path):
+    """REPRO of the 2026-07-29 wipe: listing fails → NOTHING may be deleted.
+
+    Also asserts the SKIP line carries the diagnostics (rc + rclone stderr)."""
+    env, inbox, log, _ = _setup(tmp_path)
+    kept = [_old_response_file(inbox, f"Genesis-{n}.genesis.md") for n in (1, 2, 3)]
+    # Make every file eligible for deletion were the gate broken: seen before
+    _set_listing(env, [f.name for f in kept])
+    r = _run(env)
+    assert r.returncode == 0, r.stderr
+
+    env["RCLONE_LSF_RC"] = "7"  # Dropbox API outage: lsf fails
+    r = _run(env)
+
+    assert r.returncode == 0, r.stderr
+    for f in kept:
+        assert f.exists(), f"{f.name} was wiped on a failed listing (fail-open bug)"
+    body = log.read_text()
+    assert "Cleaned up (deleted from vault)" not in body
+    assert "SKIP cleanup" in body, "expected a loud skip marker in the sync log"
+    assert "rc=7" in body, "SKIP line must carry the listing exit code"
+    assert "simulated outage" in body, "SKIP line must carry rclone's stderr"
+
+
+def test_lsf_failure_still_pushes_responses(tmp_path):
+    """A failed listing must not block step 3 — responses still reach the vault."""
+    env, inbox, _, call_log = _setup(tmp_path)
+    _old_response_file(inbox, "Genesis-1.genesis.md")
+    env["RCLONE_LSF_RC"] = "1"
+
+    r = _run(env)
+
+    assert r.returncode == 0, r.stderr
+    calls = call_log.read_text()
+    assert "rclone copy" in calls, "push step skipped after a failed listing"
+
+
+def test_healthy_listing_still_cleans_user_deleted_file(tmp_path):
+    """Intent lock, with the live corpus's filename shapes (spaces/&/'):
+
+    cycle 1: both files listed (seen recorded);
+    cycle 2: one vanishes from a healthy listing → user deletion → cleaned;
+    the still-listed one stays."""
+    env, inbox, log, _ = _setup(tmp_path)
+    gone = _old_response_file(inbox, "My todos & musings-1.genesis.md")
+    stays = _old_response_file(inbox, "Jay's Notes-2.genesis.md")
+
+    _set_listing(env, [gone.name, stays.name])
+    r = _run(env)
+    assert r.returncode == 0, r.stderr
+    assert gone.exists() and stays.exists()
+
+    _set_listing(env, [stays.name])
+    r = _run(env)
+
+    assert r.returncode == 0, r.stderr
+    assert not gone.exists(), "genuine user deletion no longer honored"
+    assert stays.exists()
+    assert "Cleaned up (deleted from vault): My todos & musings-1.genesis.md" in log.read_text()
+
+
+def test_leading_dash_name_kept_when_listed(tmp_path):
+    """A leading-dash filename is DATA, not grep options: when the healthy
+    listing contains it, it must be kept (grep -qxF -- regression)."""
+    env, inbox, _, _ = _setup(tmp_path)
+    dashy = _old_response_file(inbox, "-x notes-1.genesis.md")
+    _set_listing(env, [dashy.name])
+
+    r = _run(env)
+    assert r.returncode == 0, r.stderr
+    assert dashy.exists(), (
+        "leading-dash filename deleted despite being in a healthy listing (grep read it as options)"
+    )
+
+    # And when it truly disappears from the vault, it IS cleaned up.
+    _set_listing(env, [])
+    r = _run(env)
+    assert r.returncode == 0, r.stderr
+    assert not dashy.exists()
+
+
+def test_never_pushed_file_is_not_reaped(tmp_path):
+    """Push-failure protection: a response the vault has NEVER listed (push
+    kept failing while the listing stayed healthy) is not a user deletion —
+    it must survive to be retried, not be reaped at the grace period."""
+    env, inbox, log, _ = _setup(tmp_path)
+    unlanded = _old_response_file(inbox, "Genesis-200.genesis.md")
+    _set_listing(env, [])  # healthy, but the push never landed the file
+
+    for _ in range(2):
+        r = _run(env)
+        assert r.returncode == 0, r.stderr
+
+    assert unlanded.exists(), (
+        "never-vault-listed response reaped as a 'user deletion' — "
+        "push failures must be retried, not destroyed"
+    )
+    assert "Cleaned up" not in log.read_text()
+
+
+def test_grace_period_keeps_recent_unpushed_file(tmp_path):
+    """A response newer than 10min missing from the vault is NOT deleted."""
+    env, inbox, _, _ = _setup(tmp_path)
+    fresh = inbox / "Genesis-9.genesis.md"
+    fresh.write_text("just written, not yet pushed\n")
+    # healthy but empty listing
+    r = _run(env)
+
+    assert r.returncode == 0, r.stderr
+    assert fresh.exists()
+
+
+def test_bulk_deletion_on_healthy_listing_warns_but_proceeds(tmp_path):
+    """A large legit cleanup still works (no resurrection loop) but logs loudly."""
+    env, inbox, log, _ = _setup(tmp_path)
+    files = [_old_response_file(inbox, f"Genesis-{n}.genesis.md") for n in range(1, 9)]
+
+    _set_listing(env, [f.name for f in files])  # cycle 1: all on vault (seen)
+    r = _run(env)
+    assert r.returncode == 0, r.stderr
+
+    _set_listing(env, [])  # cycle 2: user deleted all of them in Obsidian
+    r = _run(env)
+
+    assert r.returncode == 0, r.stderr
+    for f in files:
+        assert not f.exists(), "healthy-listing deletions must still be honored"
+    body = log.read_text()
+    assert "WARNING: bulk cleanup" in body, "expected loud bulk-deletion warning"
+
+
+def test_state_files_excluded_from_mirror_and_not_pushed(tmp_path):
+    """The step-1 sync must carry --exclude '.genesis-*' so the mirror can
+    never delete the sync's own state files (the in-mirror response counter
+    was deleted every cycle for months)."""
+    env, inbox, _, call_log = _setup(tmp_path)
+    _set_listing(env, [])
+    r = _run(env)
+
+    assert r.returncode == 0, r.stderr
+    calls = call_log.read_text()
+    sync_calls = [c for c in calls.splitlines() if c.startswith("rclone sync")]
+    assert sync_calls, "step-1 sync not invoked"
+    assert "--exclude .genesis-*" in sync_calls[0], (
+        "step-1 sync missing --exclude .genesis-* — the mirror will delete local state files"
+    )
+    # State files themselves exist after a healthy cycle
+    assert (inbox / ".genesis-seen").exists()


### PR DESCRIPTION
## Problem

`scripts/inbox_sync.sh` (5-min cron) cleans up local response files the user deleted in the vault. Its deletion evidence was fail-OPEN: when the `rclone lsf` listing failed (cloud API outage), an empty listing was read as "the user deleted every response file" and wiped all 150 in one cycle (7/29 incident, + 3 recurrences). That reset response numbering and silently overwrote already-delivered vault files.

## What this does (core)

- **Fail-closed cleanup**: a failed listing SKIPs cleanup loudly (rc + stderr) instead of reaping everything.
- **Push age-gate on failed listing** (`--max-age 10m`): an old local copy of a vault-side deletion can't be re-uploaded (resurrected) before the next healthy cycle cleans it.
- **`--exclude ".genesis-*"`** on the mirror so the sync can't delete its own state.
- **Filename-as-data hardening**: `grep -qxF --`, `rm --`, `basename --`; listing stderr split to a state file; control chars stripped from audit lines; `flock` single-flight; bulk-cleanup (>5) WARNING (still honored).

## Deferred (own PR)

A durable "seen on the vault" ledger to protect a response whose push never landed (upload fails while the listing stays healthy) from grace-period reaping. That incremental design churned the 3-round review escalation cap, so per an explicit decision the fail-closed core ships now and the ledger is split out (tracked; robust rebuild design captured). The deferred edge is no worse than the pre-2026-08-24 script; the incident (mass wipe) is fixed here.

## Testing

8 tests vs the REAL script with a fake `rclone` shim (verify-RED for the fail-open wipe, push age-gate, leading-dash, state-file exclude). Functionally verified via a bash harness; CI runs pytest authoritatively.

## Review

genesis-architect + genesis-security-reviewer on the fail-closed core (no CRITICAL/HIGH/MEDIUM); F1 push-gate from a by-execution audit.

Ledger: 852664d365284036bf75d9406ba7b8e9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
