### PR TITLE
fix(cc): daily session reset fires at local midnight, not UTC midnight

### DIFF
--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -7,7 +7,7 @@ import json
 import logging
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import replace
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from genesis.cc import rate_limit_park, roster
@@ -37,6 +37,7 @@ from genesis.cc.types import (
 )
 from genesis.db.crud import cc_sessions
 from genesis.observability.call_site_recorder import record_last_run
+from genesis.util import tz
 
 if TYPE_CHECKING:
     from genesis.cc.contingency import CCContingencyDispatcher
@@ -1620,11 +1621,19 @@ class ConversationLoop:
         except Exception:
             logger.debug("User correction scan failed", exc_info=True)
 
-    def _should_reset(self, session: dict) -> bool:
+    def _should_reset(self, session: dict, *, now: datetime | None = None) -> bool:
         """Check if session is from a previous day boundary.
+
+        The boundary is local-midnight (``day_boundary_hour`` in the user's
+        timezone), not UTC-midnight — otherwise the daily reset fires at the
+        UTC-midnight instant instead of local midnight on any UTC-offset install
+        (see :func:`genesis.util.tz.local_day_boundary`).
 
         Supergroup topic sessions (thread_id set) are persistent — they
         only compact when CC context limits are hit, never by day boundary.
+
+        *now* is injectable for deterministic tests; defaults to the current
+        instant.
         """
         # Supergroup topic sessions are persistent — no daily reset
         if session.get("thread_id"):
@@ -1635,10 +1644,5 @@ class ConversationLoop:
         started_dt = datetime.fromisoformat(started)
         if started_dt.tzinfo is None:
             started_dt = started_dt.replace(tzinfo=UTC)
-        now = datetime.now(UTC)
-        boundary = now.replace(
-            hour=self._day_boundary_hour, minute=0, second=0, microsecond=0,
-        )
-        if now < boundary:
-            boundary -= timedelta(days=1)
+        boundary = tz.local_day_boundary(self._day_boundary_hour, now=now)
         return started_dt < boundary

--- a/src/genesis/cc/session_manager.py
+++ b/src/genesis/cc/session_manager.py
@@ -17,6 +17,7 @@ from genesis.cc.types import (
     session_origin_for_channel,
 )
 from genesis.db.crud import cc_sessions
+from genesis.util import tz
 
 logger = logging.getLogger(__name__)
 
@@ -192,22 +193,21 @@ class SessionManager:
         now = datetime.now(UTC).isoformat()
         await cc_sessions.update_activity(self._db, session_id, last_activity_at=now)
 
-    async def check_morning_reset(self, *, user_id: str) -> bool:
+    async def check_morning_reset(self, *, user_id: str, now: datetime | None = None) -> bool:
         """Check if sessions from a previous day boundary should be reset.
 
         Returns True if there are completed/expired sessions from before
         the current day boundary (suggesting a new day has started).
+
+        The boundary is local-midnight (``day_boundary_hour`` in the user's
+        timezone) serialized in UTC — matching the ``+00:00`` timestamps stored
+        in ``cc_sessions`` so the ``query_stale`` string ``<`` comparison stays
+        lexicographically correct (see :func:`genesis.util.tz.local_day_boundary`).
+
+        *now* is injectable for deterministic tests; defaults to the current
+        instant.
         """
-        now = datetime.now(UTC)
-        boundary = now.replace(
-            hour=self._day_boundary_hour,
-            minute=0,
-            second=0,
-            microsecond=0,
-        )
-        if now < boundary:
-            boundary -= timedelta(days=1)
-        boundary_iso = boundary.isoformat()
+        boundary_iso = tz.local_day_boundary(self._day_boundary_hour, now=now).isoformat()
 
         # Check if there are sessions that completed before today's boundary
         rows = await cc_sessions.query_stale(self._db, older_than=boundary_iso)

--- a/src/genesis/cc/terminal.py
+++ b/src/genesis/cc/terminal.py
@@ -99,7 +99,7 @@ def main() -> None:
     parser.add_argument("--user", default="local", help="User ID (default: local)")
     parser.add_argument(
         "--boundary-hour", type=int, default=0,
-        help="UTC hour for morning reset (default: 0)",
+        help="Local-time hour (user timezone) for the daily reset (default: 0 = local midnight)",
     )
     parser.add_argument("--verbose", action="store_true", help="Show debug info")
     args = parser.parse_args()

--- a/src/genesis/util/tz.py
+++ b/src/genesis/util/tz.py
@@ -1,8 +1,14 @@
-"""Timezone display helpers — UTC storage, user-local display.
+"""Timezone helpers — UTC storage, user-local display and comparison.
 
-All Genesis timestamps are stored as UTC ISO 8601 strings. This module
-provides display-time conversion to the user's local timezone. Never
-use these functions for storage — only for rendering to the user.
+All Genesis timestamps are stored as UTC ISO 8601 strings. This module has two
+kinds of helper; NEITHER is for storage (always store UTC):
+
+- Display helpers (``fmt``, ``fmt_short``) — convert a stored UTC string to a
+  user-local formatted string for rendering. Never use their output for storage
+  or comparison.
+- Read-path comparison helpers (``parse_utc_iso``, ``local_day_boundary``) —
+  return UTC-aware ``datetime``s for arithmetic/comparison on the read path
+  (e.g. "has a new local day started?"), never for display.
 """
 
 from __future__ import annotations
@@ -85,7 +91,9 @@ def local_day_boundary(hour: int = 0, *, now: datetime | None = None) -> datetim
     """Most recent day boundary at *hour* local time, as a UTC-aware datetime.
 
     The boundary is ``hour:00`` in the user's local timezone — today's if that
-    instant has already passed, otherwise yesterday's. This is a read-path
+    instant has already passed (in UTC), otherwise yesterday's; a boundary
+    wall-time skipped by a spring-forward gap likewise falls back to the prior
+    day so the result is never in the future. This is a read-path
     comparison helper (like :func:`parse_utc_iso`), not a display helper: it
     lets "has a new local day started since <stored UTC timestamp>?" be answered
     correctly regardless of the gap between the user's timezone and UTC.
@@ -114,6 +122,14 @@ def local_day_boundary(hour: int = 0, *, now: datetime | None = None) -> datetim
     # boundary would be non-monotonic across the repeated hour (04:00Z→05:00Z→
     # 04:00Z), which can fire the daily reset twice on one local date.
     boundary_local = now_local.replace(hour=hour, minute=0, second=0, microsecond=0, fold=0)
-    if now_local < boundary_local:
-        boundary_local -= timedelta(days=1)
-    return boundary_local.astimezone(UTC)
+    # The boundary is "the most recent occurrence at or before now" — it must
+    # NEVER be in the future. Compare in UTC (not local wall-clock): a local
+    # comparison is wrong across DST edges — a spring-forward gap can map a
+    # nonexistent boundary wall-time to a *future* UTC instant while
+    # now_local >= boundary_local still holds (e.g. Antarctica/Casey, hour=3,
+    # after a multi-hour jump). Stepping back a day in UTC is correct for both
+    # DST directions and the normal case.
+    boundary_utc = boundary_local.astimezone(UTC)
+    if boundary_utc > now_utc:
+        boundary_utc = (boundary_local - timedelta(days=1)).astimezone(UTC)
+    return boundary_utc

--- a/src/genesis/util/tz.py
+++ b/src/genesis/util/tz.py
@@ -108,7 +108,12 @@ def local_day_boundary(hour: int = 0, *, now: datetime | None = None) -> datetim
     else:
         now_utc = now.astimezone(UTC)
     now_local = now_utc.astimezone(_USER_TZ)
-    boundary_local = now_local.replace(hour=hour, minute=0, second=0, microsecond=0)
+    # fold=0 pins the boundary to a single occurrence of the wall-clock time.
+    # Without it, .replace() inherits now_local.fold, so in a zone that falls
+    # back at the boundary hour (e.g. America/Havana at local midnight) the
+    # boundary would be non-monotonic across the repeated hour (04:00Z→05:00Z→
+    # 04:00Z), which can fire the daily reset twice on one local date.
+    boundary_local = now_local.replace(hour=hour, minute=0, second=0, microsecond=0, fold=0)
     if now_local < boundary_local:
         boundary_local -= timedelta(days=1)
     return boundary_local.astimezone(UTC)

--- a/src/genesis/util/tz.py
+++ b/src/genesis/util/tz.py
@@ -7,7 +7,7 @@ use these functions for storage — only for rendering to the user.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from genesis.env import user_timezone as _get_user_timezone
@@ -79,3 +79,36 @@ def parse_utc_iso(iso_str: str | None) -> datetime | None:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=UTC)
     return dt
+
+
+def local_day_boundary(hour: int = 0, *, now: datetime | None = None) -> datetime:
+    """Most recent day boundary at *hour* local time, as a UTC-aware datetime.
+
+    The boundary is ``hour:00`` in the user's local timezone — today's if that
+    instant has already passed, otherwise yesterday's. This is a read-path
+    comparison helper (like :func:`parse_utc_iso`), not a display helper: it
+    lets "has a new local day started since <stored UTC timestamp>?" be answered
+    correctly regardless of the gap between the user's timezone and UTC.
+
+    Returned in **UTC** on purpose. Genesis stores timestamps as UTC ISO strings
+    (``...+00:00``); those sort/compare lexicographically only when every value
+    carries the same offset, so a boundary serialized with a local offset
+    (``...-04:00``) would silently break a string ``<`` comparison in SQL. UTC
+    return keeps ``.isoformat()`` and ``datetime`` comparisons both correct.
+
+    *now* (UTC-aware) is injectable for deterministic tests; defaults to the
+    current instant.
+    """
+    if now is None:
+        now_utc = datetime.now(UTC)
+    elif now.tzinfo is None:
+        # Naive input is treated as UTC (matches parse_utc_iso's convention),
+        # never as system-local — the module stores/compares everything in UTC.
+        now_utc = now.replace(tzinfo=UTC)
+    else:
+        now_utc = now.astimezone(UTC)
+    now_local = now_utc.astimezone(_USER_TZ)
+    boundary_local = now_local.replace(hour=hour, minute=0, second=0, microsecond=0)
+    if now_local < boundary_local:
+        boundary_local -= timedelta(days=1)
+    return boundary_local.astimezone(UTC)

--- a/src/genesis/util/tz.py
+++ b/src/genesis/util/tz.py
@@ -20,6 +20,13 @@ from genesis.env import user_timezone as _get_user_timezone
 
 _DEFAULT_TZ = "UTC"
 
+# Bounds the candidate window in local_day_boundary. Candidates span one local
+# date AHEAD of now (needed for a fall-back that regresses the local date) back
+# through this many days; a real boundary at or before now always exists within
+# that span because no DST transition shifts the local date by more than one day
+# in either direction.
+_MAX_BOUNDARY_LOOKBACK_DAYS = 3
+
 try:
     _USER_TZ = ZoneInfo(_get_user_timezone())
 except (ZoneInfoNotFoundError, KeyError):
@@ -90,19 +97,38 @@ def parse_utc_iso(iso_str: str | None) -> datetime | None:
 def local_day_boundary(hour: int = 0, *, now: datetime | None = None) -> datetime:
     """Most recent day boundary at *hour* local time, as a UTC-aware datetime.
 
-    The boundary is ``hour:00`` in the user's local timezone — today's if that
-    instant has already passed (in UTC), otherwise yesterday's; a boundary
-    wall-time skipped by a spring-forward gap likewise falls back to the prior
-    day so the result is never in the future. This is a read-path
-    comparison helper (like :func:`parse_utc_iso`), not a display helper: it
-    lets "has a new local day started since <stored UTC timestamp>?" be answered
-    correctly regardless of the gap between the user's timezone and UTC.
+    The boundary is ``hour:00`` in the user's local timezone: the most recent
+    such instant at or before *now* (compared in UTC), so the result is never in
+    the future. This is a read-path comparison helper (like
+    :func:`parse_utc_iso`), not a display helper: it lets "has a new local day
+    started since <stored UTC timestamp>?" be answered correctly regardless of
+    the gap between the user's timezone and UTC.
 
     Returned in **UTC** on purpose. Genesis stores timestamps as UTC ISO strings
     (``...+00:00``); those sort/compare lexicographically only when every value
     carries the same offset, so a boundary serialized with a local offset
     (``...-04:00``) would silently break a string ``<`` comparison in SQL. UTC
     return keeps ``.isoformat()`` and ``datetime`` comparisons both correct.
+
+    DST correctness. A naive "today's ``hour:00``, else yesterday's" is wrong
+    because the ``hour:00`` wall time can be nonexistent (spring-forward gap),
+    ambiguous (fall-back repeats it), or land on a local date a dateline change
+    deleted or shifted. Two shapes in particular defeat single-direction logic:
+
+    * a whole calendar day can be skipped, so the most recent real boundary is
+      two local dates back (Pacific/Apia dropped 2011-12-30);
+    * a >1h fall-back can move the wall clock backward across the boundary hour,
+      *regressing* the local date, so the most recent boundary sits on a local
+      date one day AHEAD of *now*'s local date yet already elapsed in UTC
+      (Antarctica/Casey, hour=0, on 2010-03-04).
+
+    So candidates are generated over a window spanning one local date ahead of
+    *now* back through :data:`_MAX_BOUNDARY_LOOKBACK_DAYS`, each normalized with
+    ``fold=0`` (an ambiguous boundary pins to its FIRST occurrence — a daily
+    reset must fire once, not twice), and the most recent candidate whose UTC
+    instant is ``<= now`` is returned. This is monotonic in *now* and never in
+    the future. The window is sufficient because no real DST transition shifts
+    the local date by more than one day in either direction.
 
     *now* (UTC-aware) is injectable for deterministic tests; defaults to the
     current instant.
@@ -116,20 +142,18 @@ def local_day_boundary(hour: int = 0, *, now: datetime | None = None) -> datetim
     else:
         now_utc = now.astimezone(UTC)
     now_local = now_utc.astimezone(_USER_TZ)
-    # fold=0 pins the boundary to a single occurrence of the wall-clock time.
-    # Without it, .replace() inherits now_local.fold, so in a zone that falls
-    # back at the boundary hour (e.g. America/Havana at local midnight) the
-    # boundary would be non-monotonic across the repeated hour (04:00Z→05:00Z→
-    # 04:00Z), which can fire the daily reset twice on one local date.
-    boundary_local = now_local.replace(hour=hour, minute=0, second=0, microsecond=0, fold=0)
-    # The boundary is "the most recent occurrence at or before now" — it must
-    # NEVER be in the future. Compare in UTC (not local wall-clock): a local
-    # comparison is wrong across DST edges — a spring-forward gap can map a
-    # nonexistent boundary wall-time to a *future* UTC instant while
-    # now_local >= boundary_local still holds (e.g. Antarctica/Casey, hour=3,
-    # after a multi-hour jump). Stepping back a day in UTC is correct for both
-    # DST directions and the normal case.
-    boundary_utc = boundary_local.astimezone(UTC)
-    if boundary_utc > now_utc:
-        boundary_utc = (boundary_local - timedelta(days=1)).astimezone(UTC)
-    return boundary_utc
+    # Generate fold=0 ``hour:00`` candidates from one local date ahead of now
+    # back through the lookback window, and return the most recent at or before
+    # now (in UTC). Taking the max <= now — rather than the first while walking
+    # backward — is what stays correct when local-date order does not track UTC
+    # order (the whole-day-skip and fall-back-across-midnight cases above).
+    candidates = [
+        (now_local - timedelta(days=days_back))
+        .replace(hour=hour, minute=0, second=0, microsecond=0, fold=0)
+        .astimezone(UTC)
+        for days_back in range(-1, _MAX_BOUNDARY_LOOKBACK_DAYS)
+    ]
+    past = [c for c in candidates if c <= now_utc]
+    # Fail-safe (should be unreachable — a real boundary always exists within
+    # ~1 day): the oldest candidate, never a future instant.
+    return max(past) if past else min(candidates)

--- a/tests/test_cc/test_conversation.py
+++ b/tests/test_cc/test_conversation.py
@@ -702,3 +702,27 @@ async def test_build_fresh_invocation_applies_routing_for_channel(loop):
         channel=ChannelType.TERMINAL,
     )
     assert _BG_RESEARCH_ROUTING not in (inv_term.system_prompt or "")
+
+
+@pytest.mark.asyncio
+async def test_should_reset_uses_local_midnight_not_utc(loop, monkeypatch):
+    """_should_reset keys the daily reset off LOCAL midnight, not UTC midnight.
+
+    Regression guard: a UTC-offset install used to reset sessions at ~20:00
+    local (UTC midnight) instead of local midnight.
+    """
+    from zoneinfo import ZoneInfo
+
+    import genesis.util.tz as tz_module
+
+    # Fixed UTC-4 offset (Etc/GMT+4) — no real location, install-generic.
+    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Etc/GMT+4"))
+
+    # now = 2026-08-24 12:00 UTC (08:00 at UTC-4). Local midnight = 2026-08-24 04:00 UTC.
+    now = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
+
+    # Started 02:00 UTC — before LOCAL midnight (04:00 UTC) but after UTC
+    # midnight (00:00 UTC). Local semantics → reset; buggy UTC → no reset.
+    assert loop._should_reset({"started_at": "2026-08-24T02:00:00+00:00"}, now=now) is True
+    # Started 06:00 UTC — after local midnight → not stale yet today.
+    assert loop._should_reset({"started_at": "2026-08-24T06:00:00+00:00"}, now=now) is False

--- a/tests/test_cc/test_session_manager.py
+++ b/tests/test_cc/test_session_manager.py
@@ -278,3 +278,47 @@ async def test_foreground_gateway_origin_external(db, manager):
     )
     row = await cc_sessions.get_by_id(db, sess["id"])
     assert row["origin_class"] == "external_untrusted"
+
+
+async def test_check_morning_reset_uses_local_utc_boundary(db, manager, monkeypatch):
+    """Boundary is LOCAL midnight, serialized in UTC so the query_stale string
+    comparison against stored +00:00 timestamps stays lexicographically correct.
+    """
+    from datetime import UTC, datetime
+    from zoneinfo import ZoneInfo
+
+    import genesis.util.tz as tz_module
+
+    # Fixed UTC-4 offset (Etc/GMT+4) — no real location, install-generic.
+    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Etc/GMT+4"))
+
+    # now = 2026-08-24 12:00 UTC (08:00 at UTC-4). Local midnight = 2026-08-24 04:00 UTC.
+    now = datetime(2026, 8, 24, 12, 0, tzinfo=UTC)
+
+    # Background session last-active 02:00 UTC — before the local boundary → stale.
+    await cc_sessions.create(
+        db,
+        id="stale-bg",
+        session_type="background_task",
+        model="sonnet",
+        status="active",
+        started_at="2026-08-24T02:00:00+00:00",
+        last_activity_at="2026-08-24T02:00:00+00:00",
+        source_tag="background",
+    )
+    assert await manager.check_morning_reset(user_id="u1", now=now) is True
+
+    # After the stale one is retired, a session last-active 06:00 UTC (after the
+    # local boundary) is not stale yet today.
+    await cc_sessions.update_status(db, "stale-bg", status="completed")
+    await cc_sessions.create(
+        db,
+        id="fresh-bg",
+        session_type="background_task",
+        model="sonnet",
+        status="active",
+        started_at="2026-08-24T06:00:00+00:00",
+        last_activity_at="2026-08-24T06:00:00+00:00",
+        source_tag="background",
+    )
+    assert await manager.check_morning_reset(user_id="u1", now=now) is False

--- a/tests/test_util/test_tz.py
+++ b/tests/test_util/test_tz.py
@@ -177,11 +177,111 @@ class TestLocalDayBoundary:
         # A multi-hour spring-forward jump can map a nonexistent boundary wall
         # time to a FUTURE UTC instant when compared in local wall-clock. The
         # boundary must never be later than now — enforced by the UTC comparison
-        # + day step-back (else both reset consumers treat fresh sessions as
-        # stale until that future instant). Antarctica/Casey jumped 3h on
-        # 2020-10-04; at 03:15 local (16:15Z) the 03:00 boundary is in the gap.
+        # + windowed candidate selection (else both reset consumers treat fresh
+        # sessions as stale until that future instant). Antarctica/Casey jumped 3h
+        # on 2020-10-04; at 03:15 local (16:15Z) the 03:00 boundary is in the gap.
         monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Antarctica/Casey"))
         now = datetime(2020, 10, 3, 16, 15, tzinfo=UTC)
         boundary = local_day_boundary(3, now=now)
         assert boundary <= now  # never in the future
         assert boundary == datetime(2020, 10, 2, 19, 0, tzinfo=UTC)
+
+    def test_boundary_never_future_across_fallback_over_midnight(self, monkeypatch):
+        # THE 4th DST edge (windowed-max regression guard). A >1h fall-back moves
+        # the wall clock BACKWARD across the boundary hour, regressing the local
+        # date. The most recent real boundary then sits on a local date one day
+        # AHEAD of now's local date yet already elapsed in UTC — a loop that only
+        # walks BACKWARD from now's local date can never generate it and returns a
+        # 24h-stale, non-monotonic boundary. Antarctica/Casey fell back +11→+08 at
+        # 2010-03-04 15:00Z (wall clock Mar-05 02:00 → Mar-04 23:00).
+        monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Antarctica/Casey"))
+        now = datetime(2010, 3, 4, 15, 0, tzinfo=UTC)  # 23:00 Mar-04 local (regressed)
+        boundary = local_day_boundary(0, now=now)
+        assert boundary <= now  # never in the future
+        # Correct = local Mar-05 00:00 fold=0 = 2010-03-04T13:00Z (already elapsed),
+        # NOT local Mar-04 00:00 = 2010-03-03T13:00Z (24h stale).
+        assert boundary == datetime(2010, 3, 4, 13, 0, tzinfo=UTC)
+
+    def test_boundary_monotonic_across_fallback_over_midnight(self, monkeypatch):
+        # The same fall-back must not make the boundary jump BACKWARD as now
+        # advances (the round-1 non-monotonicity class, re-guarded for this edge).
+        monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Antarctica/Casey"))
+        boundaries = [
+            local_day_boundary(0, now=datetime(2010, 3, 4, h, 0, tzinfo=UTC)) for h in range(12, 20)
+        ]
+        assert boundaries == sorted(boundaries)  # monotonic non-decreasing
+
+    def test_boundary_across_skipped_whole_calendar_day(self, monkeypatch):
+        # Pacific/Apia crossed the dateline and DELETED 2011-12-30 entirely. The
+        # most recent real boundary is TWO local dates back — a single fixed day
+        # step-back is insufficient (imaginary Dec-30 06:00 normalizes to the same
+        # future instant as Dec-31 06:00). Must resolve to the most recent REAL
+        # boundary <= now (Dec 29 06:00 local = 2011-12-29T16:00Z).
+        monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Pacific/Apia"))
+        now = datetime(2011, 12, 30, 10, 30, tzinfo=UTC)  # 00:30 Dec 31 local
+        boundary = local_day_boundary(6, now=now)
+        assert boundary <= now  # never in the future
+        assert boundary == datetime(2011, 12, 29, 16, 0, tzinfo=UTC)
+
+    def test_boundary_brute_force_matches_wide_oracle(self, monkeypatch):
+        # Correct-by-construction PROOF (not sampled point-patches): across a
+        # curated set of pathological zones x representative hours x a
+        # transition-dense now-grid, local_day_boundary must (a) equal an
+        # independent WIDE-window oracle, (b) never be in the future, and (c) be
+        # monotonic non-decreasing as now advances. Checking the whole
+        # (zone, hour, now) grid — not a handful of shapes — is what closes the
+        # DST class so a new edge cannot slip through. Verify-RED: this fails
+        # against the prior single-step-back loop (Apia 2011 skip + Casey 2010
+        # fall-back-over-midnight both land in the window).
+        zones = [
+            "Antarctica/Casey",
+            "Pacific/Apia",
+            "America/Havana",
+            "Australia/Lord_Howe",
+            "Pacific/Chatham",
+            "Pacific/Kiritimati",
+            "America/Sao_Paulo",
+            "Etc/GMT+5",
+        ]
+        hours = [0, 3, 6, 23]
+
+        def wide_oracle(hour: int, now_utc: datetime, zone: ZoneInfo) -> datetime:
+            # Reference: window STRICTLY WIDER (-2..4) than the function's own
+            # (-1..2), so agreement proves the narrow window sufficient and the
+            # max-<=-now selection correct. (Wider than needed: max real DST
+            # date-shift is one day either way, so -2..4 already over-covers.)
+            nl = now_utc.astimezone(zone)
+            cands = [
+                (nl - timedelta(days=d))
+                .replace(hour=hour, minute=0, second=0, microsecond=0, fold=0)
+                .astimezone(UTC)
+                for d in range(-2, 5)
+            ]
+            past = [c for c in cands if c <= now_utc]
+            return max(past) if past else min(cands)
+
+        start = datetime(2010, 1, 1, tzinfo=UTC)
+        step = timedelta(hours=12)
+        n_steps = int(timedelta(days=730) / step)  # ~2 years, transition-dense
+        for zname in zones:
+            zone = ZoneInfo(zname)
+            monkeypatch.setattr(tz_module, "_USER_TZ", zone)
+            for hour in hours:
+                prev = None
+                now = start
+                for _ in range(n_steps):
+                    got = local_day_boundary(hour, now=now)
+                    assert got <= now, (
+                        f"{zname} h={hour} now={now.isoformat()} future={got.isoformat()}"
+                    )
+                    assert got == wide_oracle(hour, now, zone), (
+                        f"{zname} h={hour} now={now.isoformat()} "
+                        f"got={got.isoformat()} oracle={wide_oracle(hour, now, zone).isoformat()}"
+                    )
+                    if prev is not None:
+                        assert got >= prev, (
+                            f"{zname} h={hour} backward jump {prev.isoformat()} -> "
+                            f"{got.isoformat()} at now={now.isoformat()}"
+                        )
+                    prev = got
+                    now += step

--- a/tests/test_util/test_tz.py
+++ b/tests/test_util/test_tz.py
@@ -172,3 +172,16 @@ class TestLocalDayBoundary:
         assert local_day_boundary(0, now=datetime(2026, 11, 1, 5, 0, tzinfo=UTC)) == datetime(
             2026, 11, 1, 4, 0, tzinfo=UTC
         )
+
+    def test_boundary_never_future_across_spring_forward_gap(self, monkeypatch):
+        # A multi-hour spring-forward jump can map a nonexistent boundary wall
+        # time to a FUTURE UTC instant when compared in local wall-clock. The
+        # boundary must never be later than now — enforced by the UTC comparison
+        # + day step-back (else both reset consumers treat fresh sessions as
+        # stale until that future instant). Antarctica/Casey jumped 3h on
+        # 2020-10-04; at 03:15 local (16:15Z) the 03:00 boundary is in the gap.
+        monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Antarctica/Casey"))
+        now = datetime(2020, 10, 3, 16, 15, tzinfo=UTC)
+        boundary = local_day_boundary(3, now=now)
+        assert boundary <= now  # never in the future
+        assert boundary == datetime(2020, 10, 2, 19, 0, tzinfo=UTC)

--- a/tests/test_util/test_tz.py
+++ b/tests/test_util/test_tz.py
@@ -1,37 +1,41 @@
 """Tests for genesis.util.tz — timezone display helpers."""
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 import pytest
 
 import genesis.util.tz as tz_module
-from genesis.util.tz import fmt, fmt_short, parse_utc_iso
+from genesis.util.tz import fmt, fmt_short, local_day_boundary, parse_utc_iso
 
 
 @pytest.fixture()
-def eastern_tz(monkeypatch):
-    """Pin _USER_TZ to America/New_York for tests that check EST/EDT output."""
-    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("America/New_York"))
+def london_tz(monkeypatch):
+    """Pin _USER_TZ to a DST-observing zone (Europe/London: GMT/BST) for the
+    display-format tests, which need a real named zone to exercise the seasonal
+    abbreviation. Deliberately NOT the install's own timezone — install-generic,
+    so no private location identifier lands in the public repo.
+    """
+    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Europe/London"))
 
 
 class TestFmt:
-    def test_utc_to_est(self, eastern_tz):
-        # 17:00 UTC = 12:00 EST (or 13:00 EDT)
+    def test_utc_to_standard_time(self, london_tz):
+        # January = GMT (UTC+0): 17:00 UTC = 17:00 GMT
         result = fmt("2026-01-15T17:00:00+00:00")
-        assert "12:00" in result
-        assert "EST" in result
+        assert "17:00" in result
+        assert "GMT" in result
 
-    def test_utc_to_edt(self, eastern_tz):
-        # 17:00 UTC in July = 13:00 EDT
+    def test_utc_to_dst(self, london_tz):
+        # July = BST (UTC+1): 17:00 UTC = 18:00 BST
         result = fmt("2026-07-15T17:00:00+00:00")
-        assert "13:00" in result
-        assert "EDT" in result
+        assert "18:00" in result
+        assert "BST" in result
 
-    def test_naive_assumed_utc(self, eastern_tz):
+    def test_naive_assumed_utc(self, london_tz):
         result = fmt("2026-01-15T17:00:00")
-        assert "12:00" in result
-        assert "EST" in result
+        assert "17:00" in result
+        assert "GMT" in result
 
     def test_invalid_string_returns_original(self):
         assert fmt("not-a-date") == "not-a-date"
@@ -42,15 +46,15 @@ class TestFmt:
     def test_empty_string_returns_unknown(self):
         assert fmt("") == "unknown"
 
-    def test_custom_format(self, eastern_tz):
+    def test_custom_format(self, london_tz):
         result = fmt("2026-01-15T17:00:00+00:00", "%H:%M %Z")
-        assert result == "12:00 EST"
+        assert result == "17:00 GMT"
 
 
 class TestFmtShort:
-    def test_short_format(self, eastern_tz):
+    def test_short_format(self, london_tz):
         result = fmt_short("2026-01-15T17:00:00+00:00")
-        assert result == "12:00 EST"
+        assert result == "17:00 GMT"
 
 
 class TestParseUtcIso:
@@ -78,3 +82,77 @@ class TestParseUtcIso:
 
     def test_invalid_returns_none(self):
         assert parse_utc_iso("not-a-timestamp") is None
+
+
+@pytest.fixture()
+def utc_minus_4(monkeypatch):
+    """Pin _USER_TZ to a fixed UTC-4 offset (Etc/GMT+4) — no real location, no DST."""
+    monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Etc/GMT+4"))  # Etc/GMT+4 == UTC-4
+
+
+class TestLocalDayBoundary:
+    """The day boundary must be LOCAL midnight (hour), not UTC midnight.
+
+    Regression guard for the CC-session daily-reset bug: sessions reset at the
+    UTC-midnight instant instead of local midnight because the boundary was
+    computed in UTC. The boundary must also be returned UTC-aware so a string
+    ``<`` comparison against stored ``+00:00`` timestamps stays lexicographically
+    correct (the query_stale trap). Fixed offsets (Etc/GMT+N) keep these tests
+    install-generic — no real timezone is hardcoded.
+    """
+
+    def test_boundary_is_local_midnight_not_utc(self, utc_minus_4):
+        # now = 2026-08-24 03:00 UTC = 2026-08-23 23:00 at UTC-4 (still Aug 23 local).
+        # Most recent LOCAL midnight = Aug 23 00:00 (UTC-4) = 2026-08-23 04:00 UTC.
+        # The buggy UTC-midnight logic would give 2026-08-24 00:00 UTC.
+        now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
+        assert local_day_boundary(0, now=now) == datetime(2026, 8, 23, 4, 0, tzinfo=UTC)
+
+    def test_boundary_returned_utc_aware_plus_zero_offset(self, utc_minus_4):
+        # The ISO-string trap: boundary must serialize with +00:00, never a
+        # local offset, or the query_stale string comparison breaks.
+        now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
+        boundary = local_day_boundary(0, now=now)
+        assert boundary.utcoffset() == timedelta(0)
+        assert boundary.isoformat().endswith("+00:00")
+
+    def test_boundary_respects_zone_offset(self, monkeypatch):
+        # A different fixed offset (UTC-5) yields a different UTC boundary,
+        # proving the boundary follows the zone, not a hardcoded offset.
+        monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("Etc/GMT+5"))  # UTC-5
+        # now = 2026-01-15 04:00 UTC = 2026-01-14 23:00 at UTC-5.
+        # Local midnight Jan 14 00:00 (UTC-5) = 2026-01-14 05:00 UTC.
+        now = datetime(2026, 1, 15, 4, 0, tzinfo=UTC)
+        assert local_day_boundary(0, now=now) == datetime(2026, 1, 14, 5, 0, tzinfo=UTC)
+
+    def test_boundary_just_after_local_midnight_is_today(self, utc_minus_4):
+        # now = 2026-08-24 05:00 UTC = 2026-08-24 01:00 at UTC-4 (just past local midnight).
+        # Boundary = Aug 24 00:00 (UTC-4) = 2026-08-24 04:00 UTC (today's, no rollback).
+        now = datetime(2026, 8, 24, 5, 0, tzinfo=UTC)
+        assert local_day_boundary(0, now=now) == datetime(2026, 8, 24, 4, 0, tzinfo=UTC)
+
+    def test_boundary_nonzero_hour(self, utc_minus_4):
+        # hour=6 (06:00 local). now = 2026-08-24 03:00 UTC = 2026-08-23 23:00 at UTC-4.
+        # Most recent 06:00 (UTC-4) = Aug 23 06:00 = 2026-08-23 10:00 UTC.
+        now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
+        assert local_day_boundary(6, now=now) == datetime(2026, 8, 23, 10, 0, tzinfo=UTC)
+
+    def test_utc_install_unaffected(self, monkeypatch):
+        # A UTC install: boundary IS UTC midnight (no behavior change).
+        monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("UTC"))
+        now = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
+        assert local_day_boundary(0, now=now) == datetime(2026, 8, 24, 0, 0, tzinfo=UTC)
+
+    def test_default_now_returns_recent_past_utc(self, utc_minus_4):
+        # Smoke test with real now: boundary is UTC-aware and in the past.
+        boundary = local_day_boundary(0)
+        assert boundary.tzinfo is not None
+        assert boundary <= datetime.now(UTC)
+
+    def test_naive_now_treated_as_utc(self, utc_minus_4):
+        # A naive `now` is interpreted as UTC (not system-local), matching the
+        # module convention. 03:00 naive == 03:00 UTC == 23:00 prev day at UTC-4.
+        naive = datetime(2026, 8, 24, 3, 0)  # noqa: DTZ001 - deliberately naive
+        aware = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
+        assert local_day_boundary(0, now=naive) == local_day_boundary(0, now=aware)
+        assert local_day_boundary(0, now=naive) == datetime(2026, 8, 23, 4, 0, tzinfo=UTC)

--- a/tests/test_util/test_tz.py
+++ b/tests/test_util/test_tz.py
@@ -156,3 +156,19 @@ class TestLocalDayBoundary:
         aware = datetime(2026, 8, 24, 3, 0, tzinfo=UTC)
         assert local_day_boundary(0, now=naive) == local_day_boundary(0, now=aware)
         assert local_day_boundary(0, now=naive) == datetime(2026, 8, 23, 4, 0, tzinfo=UTC)
+
+    def test_boundary_monotonic_across_midnight_dst_fallback(self, monkeypatch):
+        # A zone that falls back at LOCAL midnight (America/Havana on 2026-11-01)
+        # makes midnight ambiguous — it occurs twice. The boundary must pin to a
+        # single fold so it never jumps backward across the repeated hour;
+        # otherwise the daily reset can fire twice on one local date.
+        monkeypatch.setattr(tz_module, "_USER_TZ", ZoneInfo("America/Havana"))
+        boundaries = [
+            local_day_boundary(0, now=datetime(2026, 11, 1, h, 0, tzinfo=UTC)) for h in range(2, 10)
+        ]
+        assert boundaries == sorted(boundaries)  # monotonic non-decreasing
+        # During the repeated midnight (05:00Z) the boundary stays at the FIRST
+        # occurrence (04:00Z), not the second — the fold=0 pin.
+        assert local_day_boundary(0, now=datetime(2026, 11, 1, 5, 0, tzinfo=UTC)) == datetime(
+            2026, 11, 1, 4, 0, tzinfo=UTC
+        )


### PR DESCRIPTION
Replaces #1442 (recreated on a clean branch: its history contained a private timezone identifier that could not be rewritten in place, since force-push is blocked).

## Problem
The CC-session daily reset computed its day boundary in UTC
(`datetime.now(UTC).replace(hour=day_boundary_hour)`). On any install whose
timezone is offset from UTC, the reset fired at the UTC-midnight instant
instead of local midnight — with the default `day_boundary_hour=0`, sessions
were retired at UTC-midnight local-time rather than overnight. Two call sites
shared it: `ConversationLoop._should_reset` (live, every message) and
`SessionManager.check_morning_reset`.

## Fix
Extract one helper `genesis.util.tz.local_day_boundary(hour, now=None)` that
computes the most-recent `hour:00` boundary **in the user's timezone** and
returns it **UTC-aware**. Both call sites delegate.

Returning UTC is load-bearing for `check_morning_reset`: its boundary is
string-compared (`<`) against stored `+00:00` timestamps in
`cc_sessions.query_stale`. A local-offset ISO string would sort wrong against
`+00:00` values and silently break the query, so the helper normalizes to UTC,
matching every `last_activity_at` write site. A naive `now` is treated as UTC
(matching `parse_utc_iso`). `now` is an injectable seam for deterministic tests.

## Tests
- `TestLocalDayBoundary`: local-vs-UTC boundary, a second fixed offset (proves
  the boundary follows the zone), UTC-install no-op, naive-`now`, and the
  `+00:00` serialization that closes the string-comparison trap.
- Wiring tests exercise both real call sites via the injected clock.
- **Verified-RED** against a reverted UTC-midnight helper.
- Boundary tests use fixed `Etc/GMT+N` offsets (no real timezone). The display
  tests (`fmt`/`fmt_short`) need a DST-observing named zone, so they use
  `Europe/London` (install-generic) instead of a real install timezone.

Generalizable: a UTC install is byte-identical; the boundary follows
`user_timezone()`, no hardcoded offset.