### PR TITLE
chore(settings): disable AI-authorship attribution on commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,6 +4,11 @@
         "DISABLE_UPDATES": "1"
     },
     "cleanupPeriodDays": 180,
+    "attribution": {
+        "commit": "",
+        "pr": "",
+        "sessionUrl": false
+    },
     "hooks": {
         "SessionStart": [
             {


### PR DESCRIPTION
## What
Adds an `attribution` block to the project-tracked `.claude/settings.json` so Claude Code no longer stamps AI-authorship onto git history:

```json
"attribution": { "commit": "", "pr": "", "sessionUrl": false }
```

- `attribution.commit: ""` — removes the `Co-Authored-By: Claude …` commit trailer.
- `attribution.pr: ""` — removes the "🤖 Generated with Claude Code" line from PR descriptions.
- `attribution.sessionUrl: false` — omits the claude.ai session link from cloud/Remote-Control commits.

## Why
The attribution adds no value on this repo. Because `.claude/settings.json` is project-scoped and committed, this applies to **every clone** (all installs), effective at the next session start — not just one machine.

## Notes
- `includeCoAuthoredBy` is deprecated upstream; `attribution.{commit,pr}` is the current mechanism (verified against the Claude Code settings reference). Empty string is the documented way to hide each.
- Config-only, single file. No functional impact beyond attribution text.