### PR TITLE
docs(review): historical/removed behavior in comments is not a current bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,13 @@ not to confirm:
   and does not break existing behavior; a finding whose "fix" regresses something is
   itself a finding. Verify claims against the code — a stated mechanism can be wrong
   even when the concern is real.
+- **Historical/removed behavior quoted in comments is not a current bug.** A fix's
+  comments and commit messages routinely *quote the old vulnerable pattern* to justify
+  the change ("this closes the fail-open where `strict=False` let it through"; "NEL-safe:
+  splits on `\n`, NOT `splitlines()`"). Before flagging a concern, confirm the pattern
+  exists in the **current code** — grep the code, not the prose. A symbol or clause that
+  appears ONLY inside a comment describing what was removed is a FALSE POSITIVE, not a
+  P1/P2; flagging it re-opens a closed loop round after round.
 - **Calibrate severity to the code's DECLARED threat model — do not harden low-stakes
   code ad infinitum.** Adversarial rigor above stays FULL for high-consequence surfaces
   (auth, credentials, financial, data-loss, external input, approval gates). But a


### PR DESCRIPTION
## What

Adds one bullet to the **Code Review Mandate (adversarial)** section of `AGENTS.md`:
reviewers must confirm a flagged pattern exists in the **current code** before filing
it. A symbol or clause that appears only inside a comment describing what a fix
*removed* is a false positive, not a P1/P2.

## Why

`AGENTS.md` is the cross-tool reviewer entry point (Codex reads it and cites it in
findings). A recent review loop produced repeated false positives where a fix's
explanatory comments quoted the old vulnerable patterns (`strict=False`,
`splitlines()`) to justify the change, and the reviewer flagged those *descriptions*
as live vulnerabilities — even though grep confirmed the symbols were absent from the
current code. This bullet closes that loop at the reviewer-instruction layer.

## Scope

Docs-only, single bullet, in the hand-curated region above the `genesis:skills`
markers (the auto-generated block is untouched; `export_agents_md.py` rewrites only
between the markers, verified).

## Test

Read-through; no code paths affected.
