### PR TITLE
feat(dashboard): server-authoritative backup-health banner (supersedes #1437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Page-top backup-health banner (server-authoritative).** The dashboard now
+  surfaces a page-top banner when backups need attention — unconfigured, never run,
+  last run failed, timer stopped, overdue, replication incomplete, or an unreadable
+  status record — and stays hidden when healthy. The health verdict
+  (`{state, code, reason}`) is computed once on the server in
+  `routes/backup.py::_backup_health` and added to `/api/genesis/backup/status`; the
+  client only renders it. Computing it server-side removes the client-side
+  fetch-coordination and clock-skew failure modes entirely, keys "configured" and
+  the off-site-incomplete check on current signals (a real `.git` clone, the
+  resolved Tier-2 backend) rather than a stale status record, treats a malformed
+  status record as unreadable instead of healthy, and does not false-flag a valid
+  custom schedule as overdue. The failure reason rendered on the (unauthenticated)
+  status route is sanitized to strip home-directory paths.
 - **One-click "lobby" terminal door — reattach the whole CC fleet after a client
   reboot.** `generate-ssh-config.sh` now emits a dedicated `Host <host>-lobby`
   block (placed ahead of the numeric-slot wildcard, since ssh takes the first

--- a/src/genesis/dashboard/routes/backup.py
+++ b/src/genesis/dashboard/routes/backup.py
@@ -92,6 +92,7 @@ _BACKENDS = {"none", "local", "smb"}
 _NAS_RE = re.compile(r"^//[^/\s]+/[^\s]+$")
 _REPO_RE = re.compile(r"^(https?://|git@|ssh://).+")
 _ONCALENDAR_RE = re.compile(r"OnCalendar=(.+?)\s*;")
+_SYSTEMD_TS_RE = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})")
 
 
 # ── Helpers ───────────────────────────────────────────────────────────
@@ -163,7 +164,10 @@ def _timer_state() -> dict:
     """Backup schedule state read from the systemd user timer (source of truth).
 
     Best-effort: any systemctl failure degrades to a disabled/None reading rather
-    than raising — the status route must never 500 on a schedule probe.
+    than raising — the status route must never 500 on a schedule probe. That
+    degraded reading is indistinguishable from a genuinely-disabled timer UNLESS
+    a caller checks ``probe_ok`` first — ``False`` means "unknown", not
+    "disabled"/"overdue-by-the-loose-fallback"; see its use in `_backup_health`.
     """
     state = {
         "mechanism": "systemd-timer",
@@ -172,13 +176,18 @@ def _timer_state() -> dict:
         "next_run": None,
         "last_trigger": None,
         "interval": None,
+        "probe_ok": True,
     }
     r = _systemctl("is-enabled", _TIMER_UNIT)
     if r is not None:
         state["enabled"] = r.stdout.strip() == "enabled"
+    else:
+        state["probe_ok"] = False
     r = _systemctl("is-active", _TIMER_UNIT)
     if r is not None:
         state["active"] = r.stdout.strip() == "active"
+    else:
+        state["probe_ok"] = False
     r = _systemctl(
         "show",
         _TIMER_UNIT,
@@ -194,6 +203,8 @@ def _timer_state() -> dict:
         state["next_run"] = props.get("NextElapseUSecRealtime") or None
         state["last_trigger"] = props.get("LastTriggerUSec") or None
         state["interval"] = _interval_from_calendar(props.get("TimersCalendar"))
+    else:
+        state["probe_ok"] = False
     return state
 
 
@@ -259,7 +270,12 @@ def _resolved_backend() -> str:
 
     b = (_key_value("GENESIS_BACKUP_TIER2_BACKEND") or "").strip()
     if b:
-        return b
+        # Clamp to the allowlist even though the dashboard's own write path
+        # (backup_config_set) already validates it — secrets.env is an
+        # operator-editable file by design, so a value written any other way
+        # (hand edit, legacy install, future script) must not flow unvalidated
+        # into the unauthenticated /status and /config GET responses.
+        return b if b in _BACKENDS else "none"
     if (_key_value("GENESIS_BACKUP_NAS") or "").strip():
         return "smb"
     return "none"
@@ -282,7 +298,16 @@ def _destinations(status: dict | None, repo: str | None) -> dict:
         "pushed": status.get("tier1_pushed"),
         "last": status.get("timestamp"),
     }
+    # `status` is backup_status.json — untrusted-by-construction (operator-
+    # editable/corruptible), same as the failure_reason field _scrub_reason
+    # guards. `_resolved_backend()` already clamps ITS OWN source
+    # (GENESIS_BACKUP_TIER2_BACKEND) to the allowlist, but that clamp doesn't
+    # cover THIS field — clamp again here so a malformed status file can't
+    # smuggle an arbitrary value into `tier2["backend"]` on the unauthenticated
+    # /status route.
     backend = status.get("tier2_backend") or _resolved_backend()
+    if backend not in _BACKENDS:
+        backend = "none"
     tier2 = {
         "backend": backend,
         "status": status.get("tier2_status"),
@@ -303,13 +328,20 @@ def _destinations(status: dict | None, repo: str | None) -> dict:
 _INTERVAL_HOURS = {"3h": 3, "6h": 6, "12h": 12, "daily": 24}
 
 
-def _scrub_reason(text: str | None) -> str | None:
+def _scrub_reason(text: object) -> str | None:
     """Sanitize a failure_reason for the UNAUTHENTICATED banner.
 
     ``backup.sh`` only JSON-escapes the reason; it can still embed a home path
     (which carries a username) or raw gpg output. Strip ``/home/<user>`` → ``~``
     and cap the length before it is rendered on the unauth ``/status`` route.
+
+    Accepts ``object``, not just ``str | None``: ``backup_status.json`` is
+    untrusted-by-construction (operator-editable / corruptible), and a truthy
+    NON-STRING value (a list/dict/int from a malformed record) must degrade to
+    ``None`` rather than crash ``.replace()`` and 500 this unauthenticated route.
     """
+    if not isinstance(text, str):
+        return None
     if not text:
         return text
     scrubbed = text.replace(str(_HOME), "~")
@@ -319,16 +351,43 @@ def _scrub_reason(text: str | None) -> str | None:
     return scrubbed
 
 
-def _parse_usec(value: str | None) -> datetime | None:
-    """systemd ``…USec`` (microseconds since epoch, decimal string) → aware
-    datetime, or ``None`` for empty/``infinity``/unparseable values."""
+def _parse_systemd_timestamp(value: str | None) -> datetime | None:
+    """Parse systemd's human-formatted timer timestamp into an aware UTC datetime.
+
+    ``systemctl show -p NextElapseUSecRealtime`` returns a LOCALE/TZ-formatted
+    string like ``"Fri 2026-07-10 18:10:00 EDT"`` — verified live against a real
+    ``systemctl --user show genesis-backup.timer`` and matching this file's own
+    test fixture — NEVER a raw epoch. Only the numeric ``YYYY-MM-DD HH:MM:SS``
+    portion is extracted (via ``_SYSTEMD_TS_RE``) — the weekday name and tz
+    abbreviation are both dropped rather than parsed: Python's ``%a``/``%Z``
+    strptime directives only recognize English tokens, but ``systemctl_env()``
+    copies this process's ``LC_TIME``/``LANG`` unmodified into the subprocess, so
+    a non-English-locale host could otherwise render a weekday `strptime` can't
+    match. The naive numeric timestamp is converted via ``.astimezone(UTC)``,
+    which treats a naive datetime as system-local.
+
+    KNOWN LIMITATION: dropping the tz abbreviation means the one hour/year a
+    local wall-clock time occurs TWICE (the DST fall-back fold) is ambiguous —
+    ``.astimezone()`` always resolves to the FIRST (pre-transition) occurrence,
+    which can be up to 1h off from what systemd meant (confirmed:
+    ``datetime.strptime("2026-11-01 01:30:00", ...).astimezone(UTC)`` picks
+    ``fold=0``/EDT even when systemd meant the EST occurrence). Deliberately
+    not fixed with a hardcoded abbreviation→offset map (abbreviations like
+    "IST" aren't globally unique across timezones, so a map would be both
+    incomplete and install-specific) — acceptable because the only consumer is
+    the ``next_run``-in-the-future check against a 7-DAY (168h) overdue floor,
+    where a 1h skew is immaterial, and the ambiguity self-corrects within the
+    hour on the next poll.
+    """
     if not value:
         return None
     v = value.strip()
-    if not v.isdigit():
+    m = _SYSTEMD_TS_RE.search(v)
+    if not m:
         return None
     try:
-        return datetime.fromtimestamp(int(v) / 1_000_000, tz=UTC)
+        naive = datetime.strptime(m.group(1), "%Y-%m-%d %H:%M:%S")
+        return naive.astimezone(UTC)
     except (ValueError, OverflowError, OSError):
         return None
 
@@ -396,49 +455,62 @@ def _backup_health(
             "reason": "The last backup status record is unreadable — check the Backup tab.",
         }
 
-    # 5. Scheduled but the timer is not running (stopped out-of-band / failed to
-    #    start): unattended backups have silently stopped even though the last run
-    #    succeeded.
-    if sch.get("enabled") and not sch.get("active"):
-        return {
-            "state": "warn",
-            "code": "timer_stopped",
-            "reason": "Backups are scheduled but the timer is not running — unattended "
-            "backups have stopped. Check the Backup tab.",
-        }
+    # 5/6. Schedule-dependent checks (timer_stopped, overdue) — gated on the
+    #    schedule probe having actually succeeded. When `probe_ok` is False
+    #    (systemctl/D-Bus unreachable), `enabled`/`active`/`interval` all read as
+    #    their zero-value defaults, indistinguishable from a genuinely-disabled
+    #    timer — so these two checks must NOT run on unverified data (an active
+    #    timer's overdue-ness would otherwise silently fall through to the loose
+    #    7-day fallback for up to 7 days). tier1_unpushed/tier2_incomplete below
+    #    do NOT read `sch` at all, so they stay reachable regardless of probe_ok —
+    #    a transient systemctl outage must not mask an unrelated, already-known
+    #    push/off-site problem.
+    if sch.get("probe_ok") is not False:
+        # 5. Scheduled but the timer is not running (stopped out-of-band / failed
+        #    to start): unattended backups have silently stopped even though the
+        #    last run succeeded.
+        if sch.get("enabled") and not sch.get("active"):
+            return {
+                "state": "warn",
+                "code": "timer_stopped",
+                "reason": "Backups are scheduled but the timer is not running — unattended "
+                "backups have stopped. Check the Backup tab.",
+            }
 
-    # 6. Overdue — the last successful backup is too old. For a KNOWN enabled
-    #    interval use a pure age floor (interval*2 + 1h): an active timer can
-    #    silently SKIP runs, leaving a stale timestamp while `next_run` is still in
-    #    the future, so a future next_run does NOT prove recency there. For a
-    #    custom/unknown/disabled schedule use a 7-day floor but suppress when a
-    #    valid future `next_run` exists — a monthly custom timer legitimately runs
-    #    less often than weekly and is not overdue.
-    ts = lb.get("timestamp")
-    if ts:
-        try:
-            age_h = (datetime.now(UTC) - datetime.fromisoformat(ts)).total_seconds() / 3600
-        except (ValueError, TypeError):
-            age_h = None
-        if age_h is not None:
-            interval_h = _INTERVAL_HOURS.get(sch.get("interval")) if sch.get("enabled") else None
-            if interval_h:
-                floor_h: float = interval_h * 2 + 1
-                overdue = age_h > floor_h
-                detail = f", well past the {interval_h}h schedule"
-            else:
-                floor_h = 24 * 7
-                next_run = _parse_usec(sch.get("next_run"))
-                next_run_future = next_run is not None and next_run > datetime.now(UTC)
-                overdue = age_h > floor_h and not next_run_future
-                detail = ""
-            if overdue:
-                return {
-                    "state": "warn",
-                    "code": "overdue",
-                    "reason": "Backups are overdue — the last successful backup was about "
-                    f"{round(age_h)}h ago{detail}. Check the Backup tab.",
-                }
+        # 6. Overdue — the last successful backup is too old. For a KNOWN enabled
+        #    interval use a pure age floor (interval*2 + 1h): an active timer can
+        #    silently SKIP runs, leaving a stale timestamp while `next_run` is
+        #    still in the future, so a future next_run does NOT prove recency
+        #    there. For a custom/unknown/disabled schedule use a 7-day floor but
+        #    suppress when a valid future `next_run` exists — a monthly custom
+        #    timer legitimately runs less often than weekly and is not overdue.
+        ts = lb.get("timestamp")
+        if ts:
+            try:
+                age_h = (datetime.now(UTC) - datetime.fromisoformat(ts)).total_seconds() / 3600
+            except (ValueError, TypeError):
+                age_h = None
+            if age_h is not None:
+                interval_h = (
+                    _INTERVAL_HOURS.get(sch.get("interval")) if sch.get("enabled") else None
+                )
+                if interval_h:
+                    floor_h: float = interval_h * 2 + 1
+                    overdue = age_h > floor_h
+                    detail = f", well past the {interval_h}h schedule"
+                else:
+                    floor_h = 24 * 7
+                    next_run = _parse_systemd_timestamp(sch.get("next_run"))
+                    next_run_future = next_run is not None and next_run > datetime.now(UTC)
+                    overdue = age_h > floor_h and not next_run_future
+                    detail = ""
+                if overdue:
+                    return {
+                        "state": "warn",
+                        "code": "overdue",
+                        "reason": "Backups are overdue — the last successful backup was about "
+                        f"{round(age_h)}h ago{detail}. Check the Backup tab.",
+                    }
 
     # 7. Tier-1 (GitHub) push did not complete — the local backup succeeded but
     #    commits are not replicated to the remote (a prior push failed and today's
@@ -458,6 +530,21 @@ def _backup_health(
     #    legacy record stays quiet.
     if resolved_backend and resolved_backend != "none":
         t2 = (destinations or {}).get("tier2") or {}
+        # 8a. The last CONFIRMED run was against a DIFFERENT backend than the one
+        #     currently resolved (e.g. switched smb → local via /config). Reusing
+        #     that stale confirmed/status would call the new, never-yet-run backend
+        #     healthy. A recorded backend that matches (or an old record with none
+        #     recorded at all) falls through to the normal incompleteness check.
+        recorded_backend = lb.get("tier2_backend")
+        if recorded_backend and recorded_backend != resolved_backend:
+            return {
+                "state": "warn",
+                "code": "tier2_incomplete",
+                "reason": "The off-site backend was changed to "
+                f"'{resolved_backend}' and has not been confirmed yet — the last "
+                "confirmed off-site copy was to a different backend. Check the "
+                "Backup tab.",
+            }
         status = t2.get("status")
         if (status is not None and status != "ok") or t2.get("confirmed") is False:
             return {
@@ -466,6 +553,20 @@ def _backup_health(
                 "reason": "The off-site backup copy is incomplete — your local backup "
                 "succeeded but the off-site copy did not finish. Check the Backup tab.",
             }
+
+    # 9. The schedule probe itself failed (systemctl/D-Bus unreachable) and
+    #    nothing more specific above already explained the banner — report the
+    #    probe failure itself as a LAST RESORT, rather than silently reading
+    #    healthy. Fail-closed: an unknown dependency state must never look
+    #    "healthy" — but a probe outage must also not MASK an unrelated,
+    #    already-known tier1/tier2 problem, hence this runs only after those.
+    if sch.get("probe_ok") is False:
+        return {
+            "state": "warn",
+            "code": "schedule_probe_failed",
+            "reason": "Could not verify the backup schedule (systemctl probe failed) — "
+            "check the Backup tab.",
+        }
 
     return {"state": "ok", "code": "healthy", "reason": ""}
 

--- a/src/genesis/dashboard/routes/backup.py
+++ b/src/genesis/dashboard/routes/backup.py
@@ -23,6 +23,7 @@ import os
 import re
 import subprocess
 import urllib.parse
+from datetime import UTC, datetime
 from pathlib import Path
 
 from flask import jsonify, request
@@ -297,6 +298,178 @@ def _destinations(status: dict | None, repo: str | None) -> dict:
     return {"tier1": tier1, "tier2": tier2}
 
 
+# ── Health verdict (server-authoritative banner state) ────────────────
+
+_INTERVAL_HOURS = {"3h": 3, "6h": 6, "12h": 12, "daily": 24}
+
+
+def _scrub_reason(text: str | None) -> str | None:
+    """Sanitize a failure_reason for the UNAUTHENTICATED banner.
+
+    ``backup.sh`` only JSON-escapes the reason; it can still embed a home path
+    (which carries a username) or raw gpg output. Strip ``/home/<user>`` → ``~``
+    and cap the length before it is rendered on the unauth ``/status`` route.
+    """
+    if not text:
+        return text
+    scrubbed = text.replace(str(_HOME), "~")
+    scrubbed = re.sub(r"/home/[^/\s]+", "~", scrubbed)
+    if len(scrubbed) > 200:
+        scrubbed = scrubbed[:199] + "…"
+    return scrubbed
+
+
+def _parse_usec(value: str | None) -> datetime | None:
+    """systemd ``…USec`` (microseconds since epoch, decimal string) → aware
+    datetime, or ``None`` for empty/``infinity``/unparseable values."""
+    if not value:
+        return None
+    v = value.strip()
+    if not v.isdigit():
+        return None
+    try:
+        return datetime.fromtimestamp(int(v) / 1_000_000, tz=UTC)
+    except (ValueError, OverflowError, OSError):
+        return None
+
+
+def _backup_health(
+    last_backup: dict | None,
+    schedule: dict | None,
+    destinations: dict | None,
+    *,
+    configured: bool,
+    resolved_backend: str,
+) -> dict:
+    """One authoritative backup-health verdict for the page-top banner.
+
+    Returns ``{"state": "ok"|"warn"|"critical", "code": <slug>, "reason": <text>}``
+    — precedence, first match wins. Computed server-side so the banner has ZERO
+    client-side coordination: no dependency on a second config fetch (the client
+    ``backupConfig``), and no client-clock staleness math. ``state == "ok"`` means
+    the banner is hidden.
+    """
+    lb = last_backup if isinstance(last_backup, dict) else None
+    sch = schedule or {}
+
+    # 1. Recorded FAILURE (success explicitly False) — the most urgent state.
+    if lb is not None and lb.get("success") is False:
+        reason = "The last backup run failed"
+        fr = _scrub_reason(lb.get("failure_reason"))
+        if fr:
+            reason += f" ({fr})"
+        return {
+            "state": "critical",
+            "code": "failed",
+            "reason": reason + " — check the Backup tab.",
+        }
+
+    # 2. Not configured — CURRENT signals only (a saved repo setting or a real
+    #    clone), never a lingering prior run: a stale success record survives clone
+    #    or secrets removal, and backup.sh cannot recreate the clone without the
+    #    repo setting, so it must not mask the unconfigured state. Checked BEFORE the
+    #    malformed-record branch so an abandoned install carrying a leftover garbage
+    #    record still gets the more actionable "not configured" message.
+    if not configured:
+        return {
+            "state": "warn",
+            "code": "unconfigured",
+            "reason": "Backups are not configured — your data is not being backed up. "
+            "Set one up on the Backup tab.",
+        }
+
+    # 3. Configured, but no backup has ever run.
+    if lb is None:
+        return {
+            "state": "warn",
+            "code": "never_run",
+            "reason": "Backups are configured but have never run — check the Backup tab.",
+        }
+
+    # 4. A present-but-malformed record (valid JSON, no boolean `success`) must not
+    #    slip through to "healthy" — a `{}` or operator-repaired record reads as
+    #    unreadable, not clean. (lb is non-None here — branch 3 handled None.)
+    if not isinstance(lb.get("success"), bool):
+        return {
+            "state": "warn",
+            "code": "unreadable_status",
+            "reason": "The last backup status record is unreadable — check the Backup tab.",
+        }
+
+    # 5. Scheduled but the timer is not running (stopped out-of-band / failed to
+    #    start): unattended backups have silently stopped even though the last run
+    #    succeeded.
+    if sch.get("enabled") and not sch.get("active"):
+        return {
+            "state": "warn",
+            "code": "timer_stopped",
+            "reason": "Backups are scheduled but the timer is not running — unattended "
+            "backups have stopped. Check the Backup tab.",
+        }
+
+    # 6. Overdue — the last successful backup is too old. For a KNOWN enabled
+    #    interval use a pure age floor (interval*2 + 1h): an active timer can
+    #    silently SKIP runs, leaving a stale timestamp while `next_run` is still in
+    #    the future, so a future next_run does NOT prove recency there. For a
+    #    custom/unknown/disabled schedule use a 7-day floor but suppress when a
+    #    valid future `next_run` exists — a monthly custom timer legitimately runs
+    #    less often than weekly and is not overdue.
+    ts = lb.get("timestamp")
+    if ts:
+        try:
+            age_h = (datetime.now(UTC) - datetime.fromisoformat(ts)).total_seconds() / 3600
+        except (ValueError, TypeError):
+            age_h = None
+        if age_h is not None:
+            interval_h = _INTERVAL_HOURS.get(sch.get("interval")) if sch.get("enabled") else None
+            if interval_h:
+                floor_h: float = interval_h * 2 + 1
+                overdue = age_h > floor_h
+                detail = f", well past the {interval_h}h schedule"
+            else:
+                floor_h = 24 * 7
+                next_run = _parse_usec(sch.get("next_run"))
+                next_run_future = next_run is not None and next_run > datetime.now(UTC)
+                overdue = age_h > floor_h and not next_run_future
+                detail = ""
+            if overdue:
+                return {
+                    "state": "warn",
+                    "code": "overdue",
+                    "reason": "Backups are overdue — the last successful backup was about "
+                    f"{round(age_h)}h ago{detail}. Check the Backup tab.",
+                }
+
+    # 7. Tier-1 (GitHub) push did not complete — the local backup succeeded but
+    #    commits are not replicated to the remote (a prior push failed and today's
+    #    run had nothing new to commit, so `success` stays True).
+    if lb.get("tier1_pushed") is False:
+        return {
+            "state": "warn",
+            "code": "tier1_unpushed",
+            "reason": "Backups are not fully replicated to GitHub — the last run succeeded "
+            "locally but commits are not pushed to the remote. Check the Backup tab.",
+        }
+
+    # 8. Off-site (Tier-2) copy configured but incomplete. Gate on the RESOLVED
+    #    backend (CURRENT config), not the last status record's `tier2_backend`: a
+    #    Tier-2 backend disabled after a partial run must not keep warning off a
+    #    stale record. Require an explicit incompleteness signal so an info-less
+    #    legacy record stays quiet.
+    if resolved_backend and resolved_backend != "none":
+        t2 = (destinations or {}).get("tier2") or {}
+        status = t2.get("status")
+        if (status is not None and status != "ok") or t2.get("confirmed") is False:
+            return {
+                "state": "warn",
+                "code": "tier2_incomplete",
+                "reason": "The off-site backup copy is incomplete — your local backup "
+                "succeeded but the off-site copy did not finish. Check the Backup tab.",
+            }
+
+    return {"state": "ok", "code": "healthy", "reason": ""}
+
+
 # ── Routes ────────────────────────────────────────────────────────────
 
 
@@ -320,6 +493,12 @@ def backup_status():
                 # Allowlist projection — a future field in backup.sh's status
                 # line cannot auto-leak through this unauthenticated route.
                 last_backup = {k: v for k, v in raw.items() if k in _STATUS_SAFE_FIELDS}
+                # failure_reason can embed a home path (which carries a username) or
+                # raw gpg output; scrub it HERE so the sanitized value is the only one
+                # that ever reaches this unauthenticated response — the banner reason
+                # and this raw field must not disagree.
+                if last_backup.get("failure_reason"):
+                    last_backup["failure_reason"] = _scrub_reason(last_backup["failure_reason"])
         except (json.JSONDecodeError, OSError):
             last_backup = None
     result["last_backup"] = last_backup
@@ -327,6 +506,21 @@ def backup_status():
     result["repo"] = _backup_repo_url()
     result["schedule"] = _timer_state()
     result["destinations"] = _destinations(last_backup, result["repo"])
+
+    # Server-authoritative health verdict for the page-top banner. `configured`
+    # uses CURRENT signals only — a saved repo setting, a real clone (`.git`, not
+    # just the directory), or a resolvable origin — never a lingering prior run.
+    from genesis.dashboard.routes.secrets import _key_value
+
+    repo_setting = (_key_value("GENESIS_BACKUP_REPO") or "").strip()
+    configured = bool(repo_setting or (_BACKUP_DIR / ".git").is_dir() or result["repo"])
+    result["backup_health"] = _backup_health(
+        last_backup,
+        result["schedule"],
+        result["destinations"],
+        configured=configured,
+        resolved_backend=_resolved_backend(),
+    )
 
     return jsonify(result)
 

--- a/src/genesis/dashboard/templates/partials/chrome/header.html
+++ b/src/genesis/dashboard/templates/partials/chrome/header.html
@@ -148,3 +148,11 @@
         <button @click="$store.genesisDashboard.pwNudgeDismissed = true" title="Dismiss" style="background:none;border:none;color:var(--color-text-secondary,#888);cursor:pointer;font-size:1rem;line-height:1;">✕</button>
       </div>
     </template>
+    <!-- Backup-health banner: shows when backups are unconfigured, have never run,
+         the last run failed, the timer stopped, backups are overdue, or replication
+         is incomplete; hidden when healthy. Health is computed server-side
+         (routes/backup.py::_backup_health); the client only renders the verdict. -->
+    <template x-if="$store.genesisDashboard.backupBanner()">
+      <div :style="`background:${$store.genesisDashboard.backupBanner().bg}; border:1px solid ${$store.genesisDashboard.backupBanner().border}; border-radius:6px; padding:0.5rem 1rem; margin:0.25rem 0.5rem; font-size:0.82rem; font-weight:600; color:${$store.genesisDashboard.backupBanner().color}; text-align:center;`"
+           x-text="'💾 ' + $store.genesisDashboard.backupBanner().text"></div>
+    </template>

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -356,6 +356,7 @@
 
         // Polling interval IDs
         _healthInterval: null,
+        _backupInterval: null,
         _activityInterval: null,
 
         _sessionsInterval: null,
@@ -681,10 +682,23 @@
             this.fetchEgoStatus();
             this.fetchObservationsSummary();
           }, 15000);
+
+          // Fire-and-forget: drives the page-top backup banner on every tab. Must
+          // NOT gate initial paint — /backup/status shells out to git + systemctl,
+          // and backupBanner() is null-safe until backupStatus resolves (the banner
+          // just appears once it does). The banner reads the server-computed
+          // backup_health only — it does NOT depend on backupConfig, so there is no
+          // status/config fetch race and no need to fetch the config here.
+          this.fetchBackupStatus();
+          // Backup state changes slowly (6h cadence) and the route shells out to
+          // systemctl, so poll on a slow, separate cadence — catches an unattended
+          // scheduled-backup failure without a reload, at negligible cost.
+          this._backupInterval = setInterval(() => this.fetchBackupStatus(), 180000);
         },
 
         cleanup() {
           if (this._healthInterval) clearInterval(this._healthInterval);
+          if (this._backupInterval) clearInterval(this._backupInterval);
           for (const tab of ["overview", "chat", "internals", "config", "work", "observations", "traces", "autonomy"]) {
             this._stopTabIntervals(tab);
           }
@@ -1957,6 +1971,19 @@
           // start) — the timer won't fire, so "Active" would misreport. Say so.
           if (!active) return { text: 'Scheduled, but the timer is not running', color: '#ffb74d' };
           return { text: 'Active', color: '#81c784' };
+        },
+        // Page-top banner: render the server-computed backup_health verdict. ALL
+        // health logic (precedence, staleness math, tier/backend resolution) lives
+        // server-side in routes/backup.py::_backup_health — the client only maps
+        // state → colour. Returns a styled {text,color,bg,border} for a warn/critical
+        // state, or null when healthy or backupStatus has not loaded yet.
+        backupBanner() {
+          const bh = this.backupStatus && this.backupStatus.backup_health;
+          if (!bh || bh.state === 'ok') return null;
+          const s = bh.state === 'critical'
+            ? { color: '#d9534f', bg: 'rgba(217,83,79,0.15)', border: '#d9534f' }
+            : { color: '#f0ad4e', bg: 'rgba(240,173,78,0.15)', border: '#f0ad4e' };
+          return { ...s, text: bh.reason };
         },
         // "every 6 hours · last 12:10 PM ✓ · next 6:10 PM" — the at-a-glance line.
         backupScheduleLine() {

--- a/tests/test_dashboard/test_backup_config_api.py
+++ b/tests/test_dashboard/test_backup_config_api.py
@@ -199,10 +199,17 @@ def test_set_timer_enabled_false_disables_now():
 def test_calendar_maps_are_consistent():
     """Every short OnCalendar we WRITE must normalise (per systemd) to exactly
     the long form we READ back — guards the two hand-maintained maps drifting."""
-    from genesis.dashboard.routes.backup import _CALENDAR_TO_INTERVAL, _INTERVAL_TO_CALENDAR
+    from genesis.dashboard.routes.backup import (
+        _CALENDAR_TO_INTERVAL,
+        _INTERVAL_HOURS,
+        _INTERVAL_TO_CALENDAR,
+    )
 
-    # Both maps describe the same 4 presets.
+    # All three preset maps describe the same known intervals — _INTERVAL_HOURS
+    # (the overdue-floor map) must not silently drift from the schedule maps, or a
+    # renamed/added preset falls through to the weaker 7-day custom floor.
     assert set(_INTERVAL_TO_CALENDAR) == set(_CALENDAR_TO_INTERVAL.values())
+    assert set(_INTERVAL_HOURS) == set(_INTERVAL_TO_CALENDAR)
     for key, short in _INTERVAL_TO_CALENDAR.items():
         out = subprocess.run(
             ["systemd-analyze", "calendar", short], capture_output=True, text=True, timeout=10
@@ -658,3 +665,239 @@ def test_sensitive_re_masks_backup_nas_pass():
     assert not _SENSITIVE_RE.search("GENESIS_BACKUP_NAS_SHARE")
     assert not _SENSITIVE_RE.search("GENESIS_BACKUP_NAS_USER")
     assert not _SENSITIVE_RE.search("GENESIS_BACKUP_LOCAL_PATH")
+
+
+# ── _backup_health (server-authoritative banner verdict) ──────────────
+# Seed timestamps NOW-RELATIVE, never absolute literals: an absolute date + a
+# now()-based age check is a wall-clock time-bomb that flips to failing once the
+# calendar crosses the threshold.
+from datetime import UTC, datetime, timedelta  # noqa: E402
+
+
+def _iso_ago(**kw) -> str:
+    return (datetime.now(UTC) - timedelta(**kw)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _usec_from_now(**kw) -> str:
+    dt = datetime.now(UTC) + timedelta(**kw)
+    return str(int(dt.timestamp() * 1_000_000))
+
+
+def _health(lb, sch, dest, configured=True, resolved_backend="none"):
+    from genesis.dashboard.routes.backup import _backup_health
+
+    return _backup_health(lb, sch, dest, configured=configured, resolved_backend=resolved_backend)
+
+
+def _sch(enabled=True, active=True, interval="6h", next_run=None):
+    return {"enabled": enabled, "active": active, "interval": interval, "next_run": next_run}
+
+
+def _healthy_lb():
+    return {"success": True, "timestamp": _iso_ago(hours=1), "tier1_pushed": True}
+
+
+def test_health_healthy_hides_banner():
+    r = _health(
+        _healthy_lb(), _sch(next_run=_usec_from_now(hours=5)), {"tier2": {"backend": "none"}}
+    )
+    assert r["state"] == "ok" and r["code"] == "healthy"
+
+
+def test_health_failed_is_critical():
+    lb = {
+        "success": False,
+        "failure_reason": "Qdrant backup failed",
+        "timestamp": _iso_ago(hours=1),
+    }
+    r = _health(lb, _sch(), {})
+    assert r["state"] == "critical" and r["code"] == "failed"
+    assert "Qdrant backup failed" in r["reason"]
+
+
+def test_health_failed_scrubs_home_path():
+    lb = {"success": False, "failure_reason": "gpg: keyring /home/operator/.gnupg/x failed"}
+    r = _health(lb, _sch(), {})
+    assert "/home/operator" not in r["reason"] and "~" in r["reason"]
+
+
+def test_health_failure_outranks_unconfigured():
+    # A recorded failure is the most urgent state — it must not be masked by the
+    # unconfigured check even when configured is False.
+    lb = {"success": False, "failure_reason": "boom"}
+    r = _health(lb, _sch(), {}, configured=False)
+    assert r["code"] == "failed"
+
+
+def test_health_malformed_record_is_unreadable():
+    # #12: a valid-JSON record lacking a boolean `success` must not read healthy.
+    assert _health({}, _sch(), {})["code"] == "unreadable_status"
+    assert _health({"timestamp": _iso_ago(hours=1)}, _sch(), {})["code"] == "unreadable_status"
+
+
+def test_health_unconfigured_masks_stale_success():
+    # #1/#6: a lingering successful run must not suppress the unconfigured banner.
+    r = _health(_healthy_lb(), _sch(), {}, configured=False)
+    assert r["state"] == "warn" and r["code"] == "unconfigured"
+
+
+def test_health_never_run():
+    r = _health(None, _sch(), {}, configured=True)
+    assert r["code"] == "never_run"
+
+
+def test_health_timer_stopped():
+    # #2: enabled schedule, timer not running, last run succeeded.
+    r = _health(_healthy_lb(), _sch(enabled=True, active=False), {})
+    assert r["code"] == "timer_stopped"
+
+
+def test_health_overdue_known_interval():
+    # #2: active 6h timer, last success 20h ago (missed cycles) → overdue.
+    lb = {"success": True, "timestamp": _iso_ago(hours=20), "tier1_pushed": True}
+    r = _health(lb, _sch(interval="6h", next_run=_usec_from_now(hours=5)), {})
+    assert r["code"] == "overdue"
+    # A future next_run does NOT rescue a known short interval (an active timer can
+    # silently SKIP runs), so overdue still fires.
+
+
+def test_health_not_overdue_within_known_floor():
+    lb = {"success": True, "timestamp": _iso_ago(hours=5), "tier1_pushed": True}
+    r = _health(
+        lb, _sch(interval="6h", next_run=_usec_from_now(hours=1)), {"tier2": {"backend": "none"}}
+    )
+    assert r["state"] == "ok"
+
+
+def test_health_custom_not_overdue_with_future_next_run():
+    # #13: a monthly custom schedule 10 days old is NOT overdue while its next run
+    # is still weeks away.
+    lb = {"success": True, "timestamp": _iso_ago(days=10), "tier1_pushed": True}
+    sch = _sch(interval="custom", next_run=_usec_from_now(days=20))
+    assert _health(lb, sch, {"tier2": {"backend": "none"}})["state"] == "ok"
+
+
+def test_health_custom_overdue_without_next_run():
+    lb = {"success": True, "timestamp": _iso_ago(days=10), "tier1_pushed": True}
+    sch = _sch(interval="custom", next_run=None)
+    assert _health(lb, sch, {})["code"] == "overdue"
+
+
+def test_health_tier1_unpushed():
+    # #3: local backup succeeded but commits are not on the remote.
+    lb = {"success": True, "timestamp": _iso_ago(hours=1), "tier1_pushed": False}
+    assert _health(lb, _sch(next_run=_usec_from_now(hours=5)), {})["code"] == "tier1_unpushed"
+
+
+def test_health_tier2_incomplete_partial():
+    dest = {"tier2": {"backend": "smb", "status": "partial", "confirmed": False}}
+    r = _health(_healthy_lb(), _sch(next_run=_usec_from_now(hours=5)), dest, resolved_backend="smb")
+    assert r["code"] == "tier2_incomplete"
+
+
+def test_health_tier2_incomplete_confirmed_false():
+    dest = {"tier2": {"backend": "smb", "status": "ok", "confirmed": False}}
+    r = _health(_healthy_lb(), _sch(next_run=_usec_from_now(hours=5)), dest, resolved_backend="smb")
+    assert r["code"] == "tier2_incomplete"
+
+
+def test_health_tier2_ignored_when_backend_disabled():
+    # #11: Tier-2 disabled after a partial run — a stale status record must not keep
+    # warning. Gate on the RESOLVED (current) backend, not the record's tier2_backend.
+    dest = {"tier2": {"backend": "smb", "status": "partial", "confirmed": False}}
+    r = _health(
+        _healthy_lb(), _sch(next_run=_usec_from_now(hours=5)), dest, resolved_backend="none"
+    )
+    assert r["state"] == "ok"
+
+
+def test_health_unparseable_timestamp_does_not_raise():
+    lb = {"success": True, "timestamp": "not-a-date", "tier1_pushed": True}
+    r = _health(lb, _sch(next_run=_usec_from_now(hours=5)), {"tier2": {"backend": "none"}})
+    assert r["state"] == "ok"  # overdue math skipped, not crashed
+
+
+def test_scrub_reason():
+    from genesis.dashboard.routes.backup import _HOME, _scrub_reason
+
+    assert _scrub_reason(None) is None
+    assert _scrub_reason("") == ""
+    assert _scrub_reason("err /home/bob/data") == "err ~/data"
+    assert str(_HOME) not in _scrub_reason(f"x {_HOME}/y")
+    long = _scrub_reason("z" * 500)
+    assert len(long) <= 200 and long.endswith("…")
+
+
+def test_parse_usec():
+    from genesis.dashboard.routes.backup import _parse_usec
+
+    assert _parse_usec(None) is None
+    assert _parse_usec("") is None
+    assert _parse_usec("infinity") is None
+    assert _parse_usec("abc") is None
+    dt = _parse_usec("1756070400000000")
+    assert dt is not None and dt.tzinfo is not None
+
+
+# ── GET status: backup_health wiring (incl. #10 real-clone configured) ─
+def test_status_includes_backup_health_healthy(client, tmp_path):
+    status = {
+        "success": True,
+        "timestamp": _iso_ago(hours=1),
+        "tier1_pushed": True,
+        "tier2_status": "ok",
+    }
+    patches = _status_env(tmp_path, status, authed=True)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(
+            f"{_SEC}._key_value",
+            side_effect=lambda k: "https://example/r.git" if k == "GENESIS_BACKUP_REPO" else "",
+        ),
+    ):
+        data = client.get("/api/genesis/backup/status").get_json()
+    assert data["backup_health"]["code"] == "healthy"
+
+
+def test_status_backup_health_unconfigured_needs_real_clone(client, tmp_path):
+    # #10: _BACKUP_DIR exists but has no .git, no repo setting → unconfigured.
+    status = {"success": True, "timestamp": _iso_ago(hours=1), "tier1_pushed": True}
+    patches = _status_env(tmp_path, status, authed=True)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(f"{_SEC}._key_value", side_effect=lambda k: ""),
+    ):
+        data = client.get("/api/genesis/backup/status").get_json()
+    assert data["backup_health"]["code"] == "unconfigured"
+
+
+def test_status_scrubs_home_path_from_entire_body(client, tmp_path):
+    # A failed backup's failure_reason can embed a home path (username). It must be
+    # absent from the ENTIRE unauthenticated /status body — not just backup_health,
+    # but the sibling last_backup.failure_reason field too.
+    status = {
+        "success": False,
+        "timestamp": _iso_ago(hours=1),
+        "failure_reason": "gpg: keyring /home/operator/.gnupg/pubring.kbx failed",
+    }
+    patches = _status_env(tmp_path, status, authed=False)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(f"{_SEC}._key_value", side_effect=lambda k: ""),
+    ):
+        data = client.get("/api/genesis/backup/status").get_json()
+    assert "/home/operator" not in str(data)
+    assert data["last_backup"]["failure_reason"] and "~" in data["last_backup"]["failure_reason"]
+    assert data["backup_health"]["code"] == "failed"

--- a/tests/test_dashboard/test_backup_config_api.py
+++ b/tests/test_dashboard/test_backup_config_api.py
@@ -100,6 +100,7 @@ def test_timer_state_parses_enabled_active():
     assert st["interval"] == "6h"
     assert "18:10:00" in st["next_run"]
     assert "12:10:00" in st["last_trigger"]
+    assert st["probe_ok"] is True
 
 
 def test_timer_state_disabled_inactive():
@@ -123,6 +124,9 @@ def test_timer_state_disabled_inactive():
     assert st["enabled"] is False and st["active"] is False
     assert st["next_run"] is None and st["last_trigger"] is None
     assert st["interval"] == "6h"
+    # All 3 probes SUCCEEDED (returned a real result, just "disabled"/"inactive")
+    # — this is a trustworthy "genuinely disabled" reading, not a probe failure.
+    assert st["probe_ok"] is True
 
 
 def test_timer_state_survives_systemctl_failure():
@@ -137,7 +141,31 @@ def test_timer_state_survives_systemctl_failure():
         "next_run": None,
         "last_trigger": None,
         "interval": None,
+        "probe_ok": False,
     }
+
+
+def test_timer_state_probe_ok_false_on_partial_failure():
+    """#L424: a partial probe failure (systemctl works for is-enabled/is-active but
+    times out on `show`) must NOT be indistinguishable from a genuinely disabled
+    timer — enabled=True/active=True here (real, trustworthy), but probe_ok must
+    still flag that interval/next_run are unknown, not absent-because-disabled."""
+    from genesis.dashboard.routes.backup import _timer_state
+
+    def fake_run(argv, **kw):
+        sub = argv[2]
+        if sub == "is-enabled":
+            return _proc("enabled\n")
+        if sub == "is-active":
+            return _proc("active\n")
+        if sub == "show":
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=5)
+        return _proc("", returncode=1)
+
+    with patch(f"{_BK}.subprocess.run", side_effect=fake_run):
+        st = _timer_state()
+    assert st["enabled"] is True and st["active"] is True
+    assert st["probe_ok"] is False
 
 
 # ── _set_timer_schedule (writes reset drop-in) ────────────────────────
@@ -607,6 +635,38 @@ def test_resolved_backend_backward_compat():
         assert bk._resolved_backend() == "none"
 
 
+def test_resolved_backend_clamps_out_of_allowlist_value():
+    # Security review (PR #1453): secrets.env is operator-editable, so a value
+    # outside {"none","local","smb"} written any way OTHER than the dashboard's
+    # own validated /config POST (hand edit, legacy install) must not flow
+    # unvalidated into the unauthenticated /status and /config GET responses.
+    from genesis.dashboard.routes import backup as bk
+
+    with patch(
+        f"{_SEC}._key_value",
+        side_effect=lambda k: "rsync" if k == "GENESIS_BACKUP_TIER2_BACKEND" else "",
+    ):
+        assert bk._resolved_backend() == "none"
+
+
+def test_destinations_clamps_status_file_backend():
+    # Fresh-context audit (PR #1453): _resolved_backend()'s allowlist clamp
+    # covers ONLY its own secrets.env read — it does NOT cover the OTHER
+    # untrusted source _destinations() reads first: backup_status.json's own
+    # tier2_backend field (backup.sh-written but untrusted-by-construction,
+    # same class as failure_reason). Must clamp at the point of use too, so a
+    # malformed status record can't smuggle an arbitrary value into the
+    # unauthenticated /status response's destinations.tier2.backend.
+    from genesis.dashboard.routes import backup as bk
+
+    with patch(f"{_SEC}._key_value", return_value=""):
+        d = bk._destinations({"tier2_backend": "rsync"}, repo=None)
+    assert d["tier2"]["backend"] == "none"
+    with patch(f"{_SEC}._key_value", return_value=""):
+        d = bk._destinations({"tier2_backend": 12345}, repo=None)
+    assert d["tier2"]["backend"] == "none"
+
+
 def test_get_config_backend_backward_compat(client):
     """A NAS-only install (no explicit selector) must report backend 'smb', not
     'none' — otherwise the form misleads and a save could write TIER2_BACKEND=none
@@ -678,9 +738,14 @@ def _iso_ago(**kw) -> str:
     return (datetime.now(UTC) - timedelta(**kw)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _usec_from_now(**kw) -> str:
-    dt = datetime.now(UTC) + timedelta(**kw)
-    return str(int(dt.timestamp() * 1_000_000))
+def _systemd_ts_from_now(**kw) -> str:
+    """A ``next_run``/``last_trigger`` value in systemd's REAL ``systemctl show``
+    format (``"Fri 2026-07-10 18:10:00 EDT"``) — verified live against this host's
+    own ``systemctl --user show genesis-backup.timer`` output, and matching this
+    PR's own fixture at ``test_timer_state_parses_enabled_active``. NOT a raw
+    epoch — systemd never emits one for this property."""
+    dt = datetime.now().astimezone() + timedelta(**kw)
+    return dt.strftime("%a %Y-%m-%d %H:%M:%S %Z")
 
 
 def _health(lb, sch, dest, configured=True, resolved_backend="none"):
@@ -689,8 +754,14 @@ def _health(lb, sch, dest, configured=True, resolved_backend="none"):
     return _backup_health(lb, sch, dest, configured=configured, resolved_backend=resolved_backend)
 
 
-def _sch(enabled=True, active=True, interval="6h", next_run=None):
-    return {"enabled": enabled, "active": active, "interval": interval, "next_run": next_run}
+def _sch(enabled=True, active=True, interval="6h", next_run=None, probe_ok=True):
+    return {
+        "enabled": enabled,
+        "active": active,
+        "interval": interval,
+        "next_run": next_run,
+        "probe_ok": probe_ok,
+    }
 
 
 def _healthy_lb():
@@ -699,7 +770,7 @@ def _healthy_lb():
 
 def test_health_healthy_hides_banner():
     r = _health(
-        _healthy_lb(), _sch(next_run=_usec_from_now(hours=5)), {"tier2": {"backend": "none"}}
+        _healthy_lb(), _sch(next_run=_systemd_ts_from_now(hours=5)), {"tier2": {"backend": "none"}}
     )
     assert r["state"] == "ok" and r["code"] == "healthy"
 
@@ -752,10 +823,63 @@ def test_health_timer_stopped():
     assert r["code"] == "timer_stopped"
 
 
+def test_health_probe_failed_reports_schedule_probe_failed():
+    # L424: systemctl/D-Bus unreachable → enabled/active read as False defaults,
+    # indistinguishable from "genuinely disabled" without probe_ok. Must surface
+    # as its own state, not silently fall through to the loose 7-day floor (which
+    # could mask an actually-overdue 6h timer for up to 7 days).
+    lb = {"success": True, "timestamp": _iso_ago(hours=20), "tier1_pushed": True}
+    sch = _sch(enabled=False, active=False, interval=None, probe_ok=False)
+    r = _health(lb, sch, {"tier2": {"backend": "none"}})
+    assert r["state"] == "warn" and r["code"] == "schedule_probe_failed"
+
+
+def test_health_probe_ok_true_does_not_trip_new_branch():
+    # Sanity: a trustworthy "genuinely disabled, never scheduled" reading (probe_ok
+    # True) must NOT be swept into the new probe-failed branch.
+    lb = {"success": True, "timestamp": _iso_ago(hours=1), "tier1_pushed": True}
+    sch = _sch(enabled=False, active=False, interval=None, probe_ok=True)
+    r = _health(lb, sch, {"tier2": {"backend": "none"}})
+    assert r["code"] != "schedule_probe_failed"
+
+
+def test_health_probe_failed_does_not_mask_tier1_unpushed():
+    # Architect review (PR #1453): tier1_unpushed/tier2_incomplete read `lb`/
+    # `destinations` only, never `sch` — a coincident schedule-probe outage must
+    # not hide an already-known, unrelated GitHub-push failure behind the vaguer
+    # "couldn't verify schedule" banner. The MORE SPECIFIC condition wins.
+    lb = {"success": True, "timestamp": _iso_ago(hours=1), "tier1_pushed": False}
+    sch = _sch(enabled=False, active=False, interval=None, probe_ok=False)
+    r = _health(lb, sch, {"tier2": {"backend": "none"}})
+    assert r["code"] == "tier1_unpushed"
+
+
+def test_health_probe_failed_does_not_mask_tier2_incomplete():
+    lb = {
+        "success": True,
+        "timestamp": _iso_ago(hours=1),
+        "tier1_pushed": True,
+        "tier2_backend": "smb",
+    }
+    sch = _sch(enabled=False, active=False, interval=None, probe_ok=False)
+    dest = {"tier2": {"backend": "smb", "status": "partial", "confirmed": False}}
+    r = _health(lb, sch, dest, resolved_backend="smb")
+    assert r["code"] == "tier2_incomplete"
+
+
+def test_health_probe_failed_surfaces_when_nothing_more_specific():
+    # The fallback: probe_ok False with NO tier1/tier2 problem still surfaces —
+    # a schedule-probe outage must never silently read as "healthy".
+    lb = {"success": True, "timestamp": _iso_ago(hours=1), "tier1_pushed": True}
+    sch = _sch(enabled=False, active=False, interval=None, probe_ok=False)
+    r = _health(lb, sch, {"tier2": {"backend": "none"}})
+    assert r["state"] == "warn" and r["code"] == "schedule_probe_failed"
+
+
 def test_health_overdue_known_interval():
     # #2: active 6h timer, last success 20h ago (missed cycles) → overdue.
     lb = {"success": True, "timestamp": _iso_ago(hours=20), "tier1_pushed": True}
-    r = _health(lb, _sch(interval="6h", next_run=_usec_from_now(hours=5)), {})
+    r = _health(lb, _sch(interval="6h", next_run=_systemd_ts_from_now(hours=5)), {})
     assert r["code"] == "overdue"
     # A future next_run does NOT rescue a known short interval (an active timer can
     # silently SKIP runs), so overdue still fires.
@@ -764,7 +888,9 @@ def test_health_overdue_known_interval():
 def test_health_not_overdue_within_known_floor():
     lb = {"success": True, "timestamp": _iso_ago(hours=5), "tier1_pushed": True}
     r = _health(
-        lb, _sch(interval="6h", next_run=_usec_from_now(hours=1)), {"tier2": {"backend": "none"}}
+        lb,
+        _sch(interval="6h", next_run=_systemd_ts_from_now(hours=1)),
+        {"tier2": {"backend": "none"}},
     )
     assert r["state"] == "ok"
 
@@ -773,7 +899,7 @@ def test_health_custom_not_overdue_with_future_next_run():
     # #13: a monthly custom schedule 10 days old is NOT overdue while its next run
     # is still weeks away.
     lb = {"success": True, "timestamp": _iso_ago(days=10), "tier1_pushed": True}
-    sch = _sch(interval="custom", next_run=_usec_from_now(days=20))
+    sch = _sch(interval="custom", next_run=_systemd_ts_from_now(days=20))
     assert _health(lb, sch, {"tier2": {"backend": "none"}})["state"] == "ok"
 
 
@@ -786,18 +912,22 @@ def test_health_custom_overdue_without_next_run():
 def test_health_tier1_unpushed():
     # #3: local backup succeeded but commits are not on the remote.
     lb = {"success": True, "timestamp": _iso_ago(hours=1), "tier1_pushed": False}
-    assert _health(lb, _sch(next_run=_usec_from_now(hours=5)), {})["code"] == "tier1_unpushed"
+    assert _health(lb, _sch(next_run=_systemd_ts_from_now(hours=5)), {})["code"] == "tier1_unpushed"
 
 
 def test_health_tier2_incomplete_partial():
     dest = {"tier2": {"backend": "smb", "status": "partial", "confirmed": False}}
-    r = _health(_healthy_lb(), _sch(next_run=_usec_from_now(hours=5)), dest, resolved_backend="smb")
+    r = _health(
+        _healthy_lb(), _sch(next_run=_systemd_ts_from_now(hours=5)), dest, resolved_backend="smb"
+    )
     assert r["code"] == "tier2_incomplete"
 
 
 def test_health_tier2_incomplete_confirmed_false():
     dest = {"tier2": {"backend": "smb", "status": "ok", "confirmed": False}}
-    r = _health(_healthy_lb(), _sch(next_run=_usec_from_now(hours=5)), dest, resolved_backend="smb")
+    r = _health(
+        _healthy_lb(), _sch(next_run=_systemd_ts_from_now(hours=5)), dest, resolved_backend="smb"
+    )
     assert r["code"] == "tier2_incomplete"
 
 
@@ -806,14 +936,44 @@ def test_health_tier2_ignored_when_backend_disabled():
     # warning. Gate on the RESOLVED (current) backend, not the record's tier2_backend.
     dest = {"tier2": {"backend": "smb", "status": "partial", "confirmed": False}}
     r = _health(
-        _healthy_lb(), _sch(next_run=_usec_from_now(hours=5)), dest, resolved_backend="none"
+        _healthy_lb(), _sch(next_run=_systemd_ts_from_now(hours=5)), dest, resolved_backend="none"
     )
+    assert r["state"] == "ok"
+
+
+def test_health_tier2_backend_changed_since_last_run():
+    # L462: the last recorded run was against "smb" and was fully confirmed; the
+    # backend is then switched to "local" (a real, supported /config action) BEFORE
+    # any backup has run against it. The stale smb confirmed=True/status=ok values
+    # must not be reused to call "local" healthy — nothing has ever verified it.
+    lb = {
+        "success": True,
+        "timestamp": _iso_ago(hours=1),
+        "tier1_pushed": True,
+        "tier2_backend": "smb",
+    }
+    dest = {"tier2": {"backend": "local", "status": "ok", "confirmed": True}}
+    r = _health(lb, _sch(next_run=_systemd_ts_from_now(hours=5)), dest, resolved_backend="local")
+    assert r["state"] == "warn" and r["code"] == "tier2_incomplete"
+
+
+def test_health_tier2_same_backend_stays_healthy():
+    # Control for the above: when the recorded backend MATCHES the resolved one,
+    # a genuinely confirmed run must still read healthy (no false regression).
+    lb = {
+        "success": True,
+        "timestamp": _iso_ago(hours=1),
+        "tier1_pushed": True,
+        "tier2_backend": "smb",
+    }
+    dest = {"tier2": {"backend": "smb", "status": "ok", "confirmed": True}}
+    r = _health(lb, _sch(next_run=_systemd_ts_from_now(hours=5)), dest, resolved_backend="smb")
     assert r["state"] == "ok"
 
 
 def test_health_unparseable_timestamp_does_not_raise():
     lb = {"success": True, "timestamp": "not-a-date", "tier1_pushed": True}
-    r = _health(lb, _sch(next_run=_usec_from_now(hours=5)), {"tier2": {"backend": "none"}})
+    r = _health(lb, _sch(next_run=_systemd_ts_from_now(hours=5)), {"tier2": {"backend": "none"}})
     assert r["state"] == "ok"  # overdue math skipped, not crashed
 
 
@@ -828,15 +988,33 @@ def test_scrub_reason():
     assert len(long) <= 200 and long.endswith("…")
 
 
-def test_parse_usec():
-    from genesis.dashboard.routes.backup import _parse_usec
+def test_scrub_reason_non_string_does_not_crash():
+    # L392: a malformed/corrupted status file can carry a truthy NON-STRING
+    # failure_reason (e.g. a JSON list or int); `not text` alone does not catch
+    # that, and `.replace()` on it would 500 the UNAUTHENTICATED /status route.
+    from genesis.dashboard.routes.backup import _scrub_reason
 
-    assert _parse_usec(None) is None
-    assert _parse_usec("") is None
-    assert _parse_usec("infinity") is None
-    assert _parse_usec("abc") is None
-    dt = _parse_usec("1756070400000000")
+    assert _scrub_reason([1, 2, 3]) is None  # type: ignore[arg-type]
+    assert _scrub_reason(404) is None  # type: ignore[arg-type]
+    assert _scrub_reason({"x": "y"}) is None  # type: ignore[arg-type]
+
+
+def test_parse_systemd_timestamp():
+    from genesis.dashboard.routes.backup import _parse_systemd_timestamp
+
+    assert _parse_systemd_timestamp(None) is None
+    assert _parse_systemd_timestamp("") is None
+    assert _parse_systemd_timestamp("infinity") is None
+    assert _parse_systemd_timestamp("n/a") is None
+    assert _parse_systemd_timestamp("abc") is None
+    # Real `systemctl show` format (verified live + this PR's own fixture) — NEVER
+    # a raw epoch. Must parse and land within a few seconds of the true instant.
+    target = datetime.now(UTC) + timedelta(hours=5)
+    dt = _parse_systemd_timestamp(_systemd_ts_from_now(hours=5))
     assert dt is not None and dt.tzinfo is not None
+    assert abs((dt - target).total_seconds()) < 5
+    # This PR's own fixture string must parse without raising.
+    assert _parse_systemd_timestamp("Fri 2026-07-10 18:10:00 EDT") is not None
 
 
 # ── GET status: backup_health wiring (incl. #10 real-clone configured) ─
@@ -900,4 +1078,27 @@ def test_status_scrubs_home_path_from_entire_body(client, tmp_path):
         data = client.get("/api/genesis/backup/status").get_json()
     assert "/home/operator" not in str(data)
     assert data["last_backup"]["failure_reason"] and "~" in data["last_backup"]["failure_reason"]
+    assert data["backup_health"]["code"] == "failed"
+
+
+def test_status_non_string_failure_reason_does_not_500(client, tmp_path):
+    # L392: a malformed/corrupted backup_status.json with a truthy NON-STRING
+    # failure_reason must not 500 the UNAUTHENTICATED /status route.
+    status = {
+        "success": False,
+        "timestamp": _iso_ago(hours=1),
+        "failure_reason": ["unexpected", "list"],
+    }
+    patches = _status_env(tmp_path, status, authed=False)
+    with (
+        patches[0],
+        patches[1],
+        patches[2],
+        patches[3],
+        patches[4],
+        patch(f"{_SEC}._key_value", side_effect=lambda k: ""),
+    ):
+        resp = client.get("/api/genesis/backup/status")
+    assert resp.status_code == 200
+    data = resp.get_json()
     assert data["backup_health"]["code"] == "failed"


### PR DESCRIPTION
## What

Moves the dashboard backup-health banner from a client-side precedence ladder to a
single server-authoritative pure function. `routes/backup.py::_backup_health` computes
`{state, code, reason}` and adds it to `/api/genesis/backup/status`; the banner
(`header.html` + `dashboard.js::backupBanner()`) just renders it.

**Supersedes #1437** (the client-side version). This resolves that PR's full set of
review findings by construction + design rather than porting the client ladder:

- **Client fetch-coordination findings** (status/config race, form re-hydration
  clobber) vanish — the banner no longer depends on the backup-config fetch at all
  (dropped the on-open config fetch; the Backup tab still hydrates its own form).
- **Semantic findings**: `configured` keys on a real `.git` clone (not bare `is_dir()`);
  the off-site-incomplete check gates on the **resolved** Tier-2 backend, not a stale
  status record; a malformed `{}` status record reads as *unreadable*, not healthy; a
  valid custom schedule with a future next-run is not false-flagged overdue (while a
  known-interval active timer that silently skips runs still flags).

## Security

`failure_reason` is served on the **unauthenticated** status route and can embed a
home-directory path (username). It's now sanitized (`/home/<user>` → `~`) at the
allowlist-projection seam, so the raw sibling field and the banner copy both carry the
scrubbed value — not just the banner. (The field was already served unauthenticated
before this change; this closes the path leak.)

## Review

- genesis-security-reviewer + genesis-architect both reviewed; both independently
  flagged the raw-`failure_reason` leak (now fixed) and otherwise approved. Architect
  NOTEs applied: preset-map drift guard added to the consistency test; precedence
  reorder for a more actionable message.
- `x-text` (textContent) render + fixed-map `:style` — no XSS/CSS-injection.

## Test

- 18 new state-table cases in `tests/test_dashboard/test_backup_config_api.py`
  (one per health code + malformed record + resolved-backend gating + real-clone
  `configured` + whole-body scrub + preset drift guard). **53 passed**, ruff clean.
  Verify-RED confirmed on the newly-designed branches.
- Real-data E2E: `GET /api/genesis/backup/status` → `backup_health: {code: healthy}`
  on a recently-backed-up host, with no home path anywhere in the response body.
- Full Alpine served-visual check is post-deploy (the live dashboard runs the prior JS
  until this ships).


Follow-up: 62c598ed416e4e4eb9a86195fe90245b
