### PR TITLE
fix(hooks): parse shell redirects to close a push/commit gate fail-open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   and its target instead of leaking them into the parsed argv. Previously a
   *leading* redirect (`git 2>/dev/null push --force`, `git 2>&1 commit --no-verify`)
   made the parser read the redirect token as the git subcommand, so the push and
-  commit gates never recognized the command and skipped their approval checks. As
+  commit gates never recognized the command and skipped their approval checks. The
+  redirect target is measured as one complete shell word, so an escaped or
+  concatenated-quote space inside it (`git 2>err\ log push`,
+  `git 2>pre"a b"post push`) no longer hides the subcommand either. As
   a bonus, a targeted local `pytest` run that redirects output
   (`pytest tests/x.py 2>&1`) is no longer misclassified as a whole-suite run.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Security
 
+- **A leading shell redirect can no longer slip the push/commit approval gates.**
+  The shared command parser now recognizes shell redirections (`2>/dev/null`,
+  `> out.log`, `2>&1`, `&>log`, `>| f`, `< in`, `<<<`) and consumes the operator
+  and its target instead of leaking them into the parsed argv. Previously a
+  *leading* redirect (`git 2>/dev/null push --force`, `git 2>&1 commit --no-verify`)
+  made the parser read the redirect token as the git subcommand, so the push and
+  commit gates never recognized the command and skipped their approval checks. As
+  a bonus, a targeted local `pytest` run that redirects output
+  (`pytest tests/x.py 2>&1`) is no longer misclassified as a whole-suite run.
+
 - **Observation content can no longer launder untrusted origin into privileged
   cognitive surfaces.** Observation rows now carry a definite origin stamped at the
   write boundary: the CRUD chokepoint classifies every writer (explicit origin →

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -216,20 +216,36 @@ def split_segments(command: str) -> list[str]:
                 i = j
                 continue
             j0 = j
-            if j < n:  # measure ONE target token (quote-aware), else a bare op
-                if t in ("'", '"'):
-                    j += 1
-                    while j < n:
-                        if t == '"' and command[j] == "\\" and j + 1 < n:
+            if j < n and t not in _TARGET_STOP:
+                # Measure ONE complete shell word (the closed bash word grammar): a
+                # run of characters ended only by an UNQUOTED, UNESCAPED delimiter.
+                # A backslash escapes the next char (incl. a space); single/double
+                # quotes open a span that suppresses delimiters (with `\` active only
+                # inside double quotes), and adjacent quoted/plain runs concatenate
+                # into one word. Scanning the whole word — not stopping at the first
+                # escaped/quoted space — is what keeps `git 2>err\ log push` /
+                # `git 2>pre"a b"post push` from hiding the push/commit subcommand.
+                wq: str | None = None  # in-word quote state
+                while j < n:
+                    ch = command[j]
+                    if wq is not None:
+                        if wq == '"' and ch == "\\" and j + 1 < n:
                             j += 2
                             continue
-                        if command[j] == t:
-                            j += 1
-                            break
+                        if ch == wq:
+                            wq = None
                         j += 1
-                elif t not in _TARGET_STOP:
-                    while j < n and command[j] not in _TARGET_STOP:
+                        continue
+                    if ch == "\\" and j + 1 < n:  # unquoted backslash escapes next char
+                        j += 2
+                        continue
+                    if ch in ("'", '"'):  # a quote span begins (or concatenates)
+                        wq = ch
                         j += 1
+                        continue
+                    if ch in _TARGET_STOP:  # unquoted delimiter ends the word
+                        break
+                    j += 1
             # Strip ONLY a plain-filename target. A target that can carry a command
             # expansion — a ``$`` (``$(…)`` / bare ``$VAR``) or a backtick, in any
             # quoting — is LEFT in the segment text (rewind and let normal processing

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -12,6 +12,9 @@ naive approaches fail on, e.g.:
   push`` (MUST match),
 * a nested script ``bash -c 'git commit -n …'`` (the inner command MUST be
   seen),
+* a leading redirect ``git 2>/dev/null push`` / ``git 2>&1 commit`` whose
+  operator must NOT be mistaken for the subcommand (the push/commit gates MUST
+  still match — a leaking redirect once let these slip),
 * an approval comment ``# review-override`` that belongs to ONE command segment
   and must not authorize the next.
 
@@ -109,6 +112,37 @@ class Segment:
     depth: int = 0  # 0 = top level, >0 = inside a sh -c script
 
 
+def _redirect_operator_len(command: str, i: int) -> int | None:
+    """Length of a shell REDIRECT operator starting at ``command[i]``, else None.
+
+    The closed bash redirect grammar (operator only — a leading fd digit is
+    already buffered and the following target is consumed by the caller):
+    ``>`` ``>>`` ``>&`` ``>|`` ``<`` ``<<`` ``<<<`` ``<&`` ``&>`` ``&>>``.
+    A bare ``&`` (background) and a bare ``|`` (pipe) are NOT redirects — they
+    stay control operators. Process substitution ``>(…)``/``<(…)`` is
+    deliberately NOT treated as a redirect (see ``_substitutions``' documented
+    gap); ``>(`` returns length 1 here so the ``(`` is handled normally.
+    """
+    n = len(command)
+    c = command[i]
+    if c == "&":  # &> / &>> only — a lone '&' is the background control operator
+        if i + 1 < n and command[i + 1] == ">":
+            return 3 if (i + 2 < n and command[i + 2] == ">") else 2
+        return None
+    if c == ">":
+        nxt = command[i + 1] if i + 1 < n else ""
+        return 2 if nxt in (">", "&", "|") else 1
+    if c == "<":
+        if command[i + 1 : i + 3] == "<<":  # <<<
+            return 3
+        nxt = command[i + 1] if i + 1 < n else ""
+        return 2 if nxt in ("<", "&") else 1
+    return None
+
+
+_TARGET_STOP = (" ", "\t", "\n", ";", "|", "&", "<", ">", "(", ")")
+
+
 def split_segments(command: str) -> list[str]:
     """Split a command line into executed segments on shell operators.
 
@@ -116,6 +150,20 @@ def split_segments(command: str) -> list[str]:
     ``&&``, ``||``, ``;``, ``|``, ``&`` and newlines. A ``#`` comment (opened
     outside quotes) runs to end-of-line and is retained in the segment text so
     override detection can see it.
+
+    Redirect-aware: a redirection (``2>/dev/null``, ``> out.log``, ``2>&1``,
+    ``&>log``, ``>| f``, ``< in``, ``<<<here``) is consumed — operator AND target
+    — and kept OUT of the segment text, so a redirect neither leaks a phantom
+    positional into argv nor mis-splits on an embedded ``&``/``|`` (``2>&1`` used
+    to split on the ``&``, hiding a following ``git push`` in a bogus segment and
+    slipping the push gate). Only a PLAIN-filename target is stripped; a target that
+    can carry a command expansion (any ``$`` or backtick — ``2>$(rm x)``,
+    ``2>"$(rm x)"``, ``<<<"$(…)"``, ``2>$VAR``, ``<(…)``, ``>(…)``) is LEFT in the
+    text so the canonical ``_substitutions`` still sees any nested command (a
+    substitution used as a redirect target EXECUTES). Such a target's token then
+    stays in argv — a documented residual for this exotic form (these gates are
+    friction, not a sandbox); a bare ``2>/dev/null`` is a plain filename and IS
+    stripped, so the common push-gate fail-open stays closed.
     """
     segs: list[str] = []
     buf: list[str] = []
@@ -143,6 +191,60 @@ def split_segments(command: str) -> list[str]:
             segs.append("".join(buf))
             buf = []
             i += 2
+            continue
+        op_len = _redirect_operator_len(command, i)
+        if op_len is not None:
+            # Drop a standalone leading fd digit-run (the '2' of ` 2>`), but NOT a
+            # digit that ends a word (`push2>x` keeps 'push2' — never a fail-open
+            # onto a bare 'push'); '&>' never carries an fd prefix.
+            if c != "&":
+                k = len(buf)
+                while k > 0 and buf[k - 1].isdigit():
+                    k -= 1
+                if k < len(buf) and (k == 0 or buf[k - 1].isspace()):
+                    del buf[k:]
+            j = i + op_len
+            while j < n and command[j] in (" ", "\t"):  # gap before the target
+                j += 1
+            t = command[j] if j < n else ""
+            tnext = command[j + 1] if j + 1 < n else ""
+            # A process substitution as the target (`<(…)`, `>(…)`) begins with a
+            # metachar the plain consumer would stop on — leave it in the text (it
+            # executes, like any substitution); consume only the operator.
+            if t in ("<", ">") and tnext == "(":
+                buf.append(" ")
+                i = j
+                continue
+            j0 = j
+            if j < n:  # measure ONE target token (quote-aware), else a bare op
+                if t in ("'", '"'):
+                    j += 1
+                    while j < n:
+                        if t == '"' and command[j] == "\\" and j + 1 < n:
+                            j += 2
+                            continue
+                        if command[j] == t:
+                            j += 1
+                            break
+                        j += 1
+                elif t not in _TARGET_STOP:
+                    while j < n and command[j] not in _TARGET_STOP:
+                        j += 1
+            # Strip ONLY a plain-filename target. A target that can carry a command
+            # expansion — a ``$`` (``$(…)`` / bare ``$VAR``) or a backtick, in any
+            # quoting — is LEFT in the segment text (rewind and let normal processing
+            # re-scan it): this delegates ALL expansion/quoting semantics to the one
+            # canonical ``_substitutions`` parser (which expands ``$(…)`` unquoted and
+            # in double quotes so a nested command stays visible to the destructive
+            # guard, and correctly does NOT expand inside single quotes) instead of
+            # re-deciding them here. Only cost: such a target's token stays in argv —
+            # the pre-existing, documented residual for this exotic form.
+            if "$" in command[j0:j] or "`" in command[j0:j]:
+                buf.append(" ")
+                i = j0  # rewind — normal processing + _substitutions handle the target
+                continue
+            buf.append(" ")  # plain filename target — operator + target both dropped
+            i = j
             continue
         if c in (";", "|", "&", "\n"):
             segs.append("".join(buf))

--- a/tests/test_hooks/test_shell_parse.py
+++ b/tests/test_hooks/test_shell_parse.py
@@ -241,3 +241,158 @@ class TestGhPr:
 
     def test_not_gh(self):
         assert sp.gh_pr_subcommand(["git", "pr", "create"]) is None
+
+
+# ── shell redirects: fd leaks + &/| mis-splits ──────────────────────────
+#
+# split_segments had no redirect grammar, so (a) simple redirects leaked into
+# argv as phantom positionals and (b) `2>&1`/`&>`/`>|` mis-split on their
+# embedded `&`/`|`. Both are guard bypasses: a LEADING redirect made
+# git_subcommand return the redirect token, so `git 2>/dev/null push` slipped the
+# push gate. These lock the closed redirect grammar.
+
+
+class TestRedirects:
+    # --- SECURITY: a leading redirect must not hide the git subcommand ---
+    def test_leading_stderr_redirect_push_recognized(self):
+        argv = sp.analyze("git 2>/dev/null push origin main --force")[0].argv
+        assert sp.git_subcommand(argv) == "push"
+
+    def test_leading_redirect_push_blocked(self):
+        assert _push_blocked("git 2>/dev/null push origin main")
+
+    def test_leading_dup_redirect_push_blocked(self):
+        # `2>&1` splits on '&' under the old tokenizer, hiding push in a bogus seg
+        assert _push_blocked("git 2>&1 push origin main")
+
+    def test_leading_redirect_commit_no_verify(self):
+        assert _commit_nv(f"git 2>/dev/null commit '{NV}' -m x")
+
+    def test_leading_redirect_commit_recognized(self):
+        segs = sp.analyze("git 1>/dev/null commit -m x")
+        assert any(sp.git_subcommand(s.argv) == "commit" for s in segs)
+
+    # --- redirects stripped from argv ---
+    def test_glued_stderr_redirect_stripped(self):
+        assert sp.analyze("pytest tests/x.py 2>/dev/null")[0].argv == ["pytest", "tests/x.py"]
+
+    def test_separated_stdout_redirect_stripped(self):
+        assert sp.analyze("pytest tests/x.py > out.log")[0].argv == ["pytest", "tests/x.py"]
+
+    def test_append_redirect_stripped(self):
+        assert sp.analyze("pytest tests/x.py >> out.log")[0].argv == ["pytest", "tests/x.py"]
+
+    def test_combined_out_and_dup_redirect(self):
+        segs = sp.analyze("pytest tests/x.py > out.log 2>&1")
+        assert segs[0].argv == ["pytest", "tests/x.py"]
+        assert len(segs) == 1  # no bogus trailing '1' segment
+
+    def test_ampersand_redirect_stripped(self):
+        segs = sp.analyze("pytest tests/x.py &>log")
+        assert segs[0].argv == ["pytest", "tests/x.py"]
+        assert len(segs) == 1  # not split on the leading '&'
+
+    def test_ampersand_append_redirect_stripped(self):
+        assert sp.analyze("pytest tests/x.py &>> log")[0].argv == ["pytest", "tests/x.py"]
+
+    def test_noclobber_redirect_stripped(self):
+        segs = sp.analyze("pytest tests/x.py >| out")
+        assert segs[0].argv == ["pytest", "tests/x.py"]
+        assert len(segs) == 1  # not split on the embedded '|'
+
+    def test_input_redirect_stripped(self):
+        assert sp.analyze("pytest tests/x.py < in.txt")[0].argv == ["pytest", "tests/x.py"]
+
+    def test_herestring_redirect_stripped(self):
+        # a plain here-string target strips (operator + word). A $-bearing target is
+        # deliberately LEFT (see test_dollar_var_redirect_target_left_but_harmless).
+        assert sp.analyze("grep foo <<<plainword")[0].argv == ["grep", "foo"]
+
+    def test_fd_dup_target_stripped(self):
+        assert sp.analyze("pytest tests/x.py >&2")[0].argv == ["pytest", "tests/x.py"]
+
+    # --- pytest detection survives redirects ---
+    def test_pytest_detected_with_redirect(self):
+        assert sp.command_runs_pytest("python -m pytest tests/x.py -v 2>&1")
+        assert sp.command_runs_pytest("pytest tests/x.py 2>/dev/null")
+
+    # --- REGRESSION: real operators & quotes unaffected ---
+    def test_background_ampersand_still_splits(self):
+        exes = [s.exe for s in sp.analyze("sleep 1 & echo done")]
+        assert "sleep" in exes and "echo" in exes
+
+    def test_pipe_still_splits(self):
+        assert [s.exe for s in sp.analyze("cat x | grep y")] == ["cat", "grep"]
+
+    def test_redirect_char_in_quotes_preserved(self):
+        seg = sp.analyze('git commit -m "a > b | c"')[0]
+        assert sp.git_subcommand(seg.argv) == "commit"
+        assert "a > b | c" in seg.argv  # quoted metachars are one token, not stripped
+
+    def test_and_or_operators_unaffected(self):
+        assert sp.command_runs_pytest("ruff check . && pytest -q")
+
+    def test_redirect_then_pipe(self):
+        segs = sp.analyze("grep x f 2>/dev/null | wc -l")
+        assert [s.exe for s in segs] == ["grep", "wc"]
+        assert segs[0].argv == ["grep", "x", "f"]
+
+    def test_override_survives_redirect(self):
+        seg = sp.analyze("git push origin main > out.log # review-override")[0]
+        assert seg.override
+        assert sp.git_subcommand(seg.argv) == "push"
+
+    def test_word_ending_in_digit_not_treated_as_fd(self):
+        # `push2>x` — the digit is part of the word, not a standalone fd, so the
+        # command word 'push2' is preserved (no fail-open onto a bare 'push').
+        assert sp.git_subcommand(sp.analyze("git push2>x")[0].argv) == "push2"
+
+    # --- a substitution AS the redirect target still executes → stay visible ---
+    def test_cmd_substitution_redirect_target_keeps_rm_visible(self):
+        # `2>$(rm -rf x)` runs the rm to produce the filename. The nested rm MUST
+        # remain a visible segment for the destructive-command guard (regression:
+        # the target-consumer once ate the '$', hiding the substitution).
+        segs = sp.analyze("echo hi 2>$(rm -rf /tmp/genesis-x)")
+        assert any(s.exe == "rm" and "-rf" in s.argv for s in segs)
+
+    def test_backtick_substitution_redirect_target_keeps_command_visible(self):
+        segs = sp.analyze("echo hi 2>`rm -rf /tmp/genesis-x`")
+        assert any(s.exe == "rm" for s in segs)
+
+    def test_substitution_target_does_not_break_adjacent_plain_redirect(self):
+        # a plain redirect elsewhere still strips normally
+        assert sp.analyze("pytest tests/x.py 2>/dev/null")[0].argv == ["pytest", "tests/x.py"]
+
+    def test_double_quoted_substitution_redirect_target_keeps_rm_visible(self):
+        # bash expands $(…) inside DOUBLE quotes → the rm runs → must stay visible
+        segs = sp.analyze('echo hi 2>"$(rm -rf /tmp/genesis-x)"')
+        assert any(s.exe == "rm" for s in segs)
+
+    def test_herestring_double_quoted_substitution_keeps_rm_visible(self):
+        segs = sp.analyze('grep foo <<<"$(rm -rf /tmp/genesis-x)"')
+        assert any(s.exe == "rm" for s in segs)
+
+    def test_double_quoted_backtick_redirect_target_keeps_rm_visible(self):
+        segs = sp.analyze('echo x 2>"`rm -rf /tmp/genesis-x`"')
+        assert any(s.exe == "rm" for s in segs)
+
+    def test_single_quoted_substitution_redirect_target_correctly_hidden(self):
+        # bash does NOT expand inside SINGLE quotes → nothing runs → correct to hide
+        segs = sp.analyze("echo x 2>'$(rm -rf /tmp/genesis-x)'")
+        assert not any(s.exe == "rm" for s in segs)
+
+    def test_plain_quoted_filename_redirect_target_stripped(self):
+        # a quoted filename target with NO substitution strips normally
+        assert sp.analyze('pytest tests/x.py 2>"my log.txt"')[0].argv == ["pytest", "tests/x.py"]
+
+    def test_embedded_substitution_in_redirect_target_keeps_rm_visible(self):
+        # a substitution EMBEDDED in an otherwise-plain unquoted target (not at the
+        # first char) still expands and runs — must stay visible (round-3 variant).
+        segs = sp.analyze("echo hi 2>pre$(rm -rf /tmp/genesis-x)post")
+        assert any(s.exe == "rm" for s in segs)
+
+    def test_dollar_var_redirect_target_left_but_harmless(self):
+        # a bare $VAR target has no command substitution — left in text (no nested
+        # command to hide); documents the accepted argv-residual, not a regression.
+        segs = sp.analyze("echo hi 2>$LOGDIR/out")
+        assert not any(s.exe in ("rm", "rmdir") for s in segs)

--- a/tests/test_hooks/test_shell_parse.py
+++ b/tests/test_hooks/test_shell_parse.py
@@ -265,6 +265,24 @@ class TestRedirects:
         # `2>&1` splits on '&' under the old tokenizer, hiding push in a bogus seg
         assert _push_blocked("git 2>&1 push origin main")
 
+    def test_leading_redirect_escaped_space_target_push_blocked(self):
+        # bash: `error\ log` is ONE target word (escaped space) → the real command
+        # is `git push`. The target scan must consume the whole word, not stop at
+        # the escaped space (else the subcommand mis-reads as 'log' → fail-open).
+        cmd = r"git 2>error\ log push origin main"
+        assert sp.git_subcommand(sp.analyze(cmd)[0].argv) == "push"
+        assert _push_blocked(cmd)
+
+    def test_leading_redirect_concatenated_quote_target_push_blocked(self):
+        # bash: `pre"error log"post` is ONE word (concatenated quoting) → `git push`.
+        cmd = 'git 2>pre"error log"post push origin main'
+        assert sp.git_subcommand(sp.analyze(cmd)[0].argv) == "push"
+        assert _push_blocked(cmd)
+
+    def test_leading_redirect_escaped_space_target_commit_no_verify(self):
+        # same fail-open on the commit gate: `err\ log` is one target word.
+        assert _commit_nv(rf"git 2>err\ log commit '{NV}' -m x")
+
     def test_leading_redirect_commit_no_verify(self):
         assert _commit_nv(f"git 2>/dev/null commit '{NV}' -m x")
 
@@ -310,6 +328,14 @@ class TestRedirects:
 
     def test_fd_dup_target_stripped(self):
         assert sp.analyze("pytest tests/x.py >&2")[0].argv == ["pytest", "tests/x.py"]
+
+    def test_escaped_space_redirect_target_stripped(self):
+        # an escaped space keeps the target as ONE word → fully stripped from argv
+        assert sp.analyze(r"pytest tests/x.py 2>err\ log")[0].argv == ["pytest", "tests/x.py"]
+
+    def test_concatenated_quote_redirect_target_stripped(self):
+        # `pre"a b"post` is one concatenated word target → stripped whole
+        assert sp.analyze('pytest tests/x.py 2>pre"a b"post')[0].argv == ["pytest", "tests/x.py"]
 
     # --- pytest detection survives redirects ---
     def test_pytest_detected_with_redirect(self):


### PR DESCRIPTION
## Close a push/commit gate fail-open: parse shell redirects in the shared command parser

### The bug (live security fail-open)
`scripts/hooks/shell_parse.py::split_segments` had no redirect grammar, so:
- simple redirects leaked into the parsed argv (`git 2>/dev/null push` → argv `['git','2>/dev/null','push',…]`), and
- `2>&1` / `&>` / `>|` **mis-split** on their embedded `&`/`|`.

Effect: a **leading** redirect made `git_subcommand` return the redirect token instead of the subcommand, so `git 2>/dev/null push --force` and `git 2>&1 commit --no-verify` were **not recognized** — the push and commit approval gates silently skipped those commands. (Verified by hand: `git_subcommand` returned `'2>/dev/null'`, not `push`.) The same leak misclassified targeted local `pytest` runs that redirect output (`pytest x.py 2>&1`) as whole-suite runs.

### The fix
Teach `split_segments` the **closed** bash redirect grammar (`>`, `>>`, `>&`, `>|`, `<`, `<<`, `<<<`, `<&`, `&>`, `&>>`, with optional leading fd digit): consume the operator, keep it out of argv, and don't split on redirect-internal `&`/`|`.

Redirect **targets** are handled robust-by-construction to avoid a shell-word-parsing tail:
- a **plain filename** target is stripped (`2>/dev/null`, `2>"my log.txt"`);
- a target carrying a possible expansion — any `$` or backtick, in any quoting (`2>$(rm)`, `2>"$(rm)"`, `<<<"$(rm)"`, `2>pre$(rm)post`, `2>$VAR`) — is **left in the segment text**, so the single canonical `_substitutions` parser decides what executes. `_substitutions` expands `$(…)` unquoted and inside double quotes (nested command stays visible to `protected_paths_guard`) and correctly does **not** expand inside single quotes.

Every other function in the module is byte-unchanged; this is purely additive (`_redirect_operator_len`, `_TARGET_STOP`, one branch in the existing loop).

### Why it's safe
- **Security property closed:** `git 2>/dev/null push` → `git_subcommand == 'push'` (gate fires); `git 2>&1 commit --no-verify` → detected.
- **No new bypass / no rm-hiding:** the strip-vs-leave decision only ever deletes the exact slice it substring-checked for `$`/backtick — nothing beyond it is dropped, so no substitution can be hidden. A nested `rm` inside a redirect-target substitution stays visible in every quoting form (single-quote correctly hidden, matching bash).
- **Fail-open contract preserved:** no `raise` path added; all indexing bounds-guarded; 20,000-case fuzz → 0 exceptions/hangs; linear-time on 3000 chained redirects.

### Review
Three adversarial rounds (genesis-security-reviewer ×2 + genesis-architect), each finding re-derived from ground truth (pre/post diff vs `origin/main`, fuzz, live `analyze()`):
- Round 1 (CRITICAL, fixed): bare `2>$(rm)` target hid a nested rm.
- Round 2 (BLOCKER, fixed): quoted `2>"$(rm)"` / here-string variants still hid it → **redesigned** to the robust rule above.
- Round 3 (final, clean): `Ready to merge: Yes / DONE`; the sole WARNING is pre-existing and out of scope (below).

### Verification
- **788** consumer + parser tests green: `test_shell_parse`, `test_git_push_guard_*` (×3), `test_review_enforcement_commit`, `test_protected_paths_guard`, `test_concurrent_test_guard`, `test_full_suite_guard`, `test_merge_review_gate`, `test_value_flag_consistency`, `test_worktree_remote_guard`, `test_pre_push_privacy_review`. `ruff --no-cache` clean.
- Full rm-visibility quoting matrix + the two security fail-opens verified end-to-end against the real guards.

### Known residual (pre-existing, tracked — not this PR)
A `$`/backtick redirect target placed *before* the subcommand (`git 2>$(x) push`) still makes `git_subcommand` mis-read it, so the push gate doesn't fire on that segment (the nested command inside is still caught). Verified **identical** pre/post this change — not introduced here. Distinct mechanism (`git_subcommand`, not the redirect grammar); tracked as a `ready` follow-up to skip `$()`/backtick positionals the way `gh_pr_subcommand` already skips `-R o/r`.

Follow-up: 1c8d0fd2
