### PR TITLE
feat(hooks): configurable required scheduled-review kinds (leaks irreducible)

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -823,10 +823,14 @@ findings below, a gated `gh pr merge`:
   Claude review (a `/schedule` cloud routine) posts as the repo OWNER's account and
   must carry a marker `<!-- genesis-scheduled-review: head=<full-40-hex-sha> kind=<name> -->`
   naming the exact head it reviewed AND which routine it is (`kind`). The gate blocks
-  unless an owner-authored marker for EVERY kind in `_REQUIRED_SCHEDULED_REVIEW_KINDS`
-  (currently `code-review` + `leaks`) names the PR's current head — so if any required
-  routine never ran, ran on a stale commit, or was rate-limited, the merge blocks
-  (naming the missing kinds). If a routine is pending or rate-limited, wait for it, or
+  unless an owner-authored marker for EVERY effective required kind
+  (`_required_scheduled_review_kinds()` — DEFAULT `code-review` + `leaks`; the leak/secret
+  scanner is irreducible and always required; an install may relax the OPTIONAL kinds to
+  ADVISORY via `merge_gate.required_scheduled_reviews: [<kinds>]` in local `genesis.yaml`)
+  names the PR's current head — so if any required routine never ran, ran on a stale
+  commit, or was rate-limited, the merge blocks (naming the missing kinds). An ADVISORY
+  routine still posts its review on the PR to be read/addressed, but its absence does not
+  block. If a required routine is pending or rate-limited, wait for it, or
   append `# scheduled-review-override` to merge anyway (the conscious "merge without the
   scheduled reviews" case). The marker means "ran **clean**", not merely "ran": a
   review whose body carries a blocking finding (`[P1]`/`HARD BLOCK`/`### ERROR`, unless a

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1804,6 +1804,29 @@ _DEFAULT_REQUIRED_SCHEDULED_REVIEW_KINDS = ("code-review", "leaks")
 # The leak/secret scanner is IRREDUCIBLE: always required, never removable by config. A
 # secret reaching a public repo is irreversible, so no local policy may waive it.
 _IRREDUCIBLE_REQUIRED_SCHEDULED_REVIEW_KINDS = ("leaks",)
+# Every kind an install is ALLOWED to name in config. A configured kind outside this set
+# (a typo, a wrong type, a stale routine name) can never be satisfied by a real marker, so
+# the whole config is treated as invalid and we fail closed to the default rather than let
+# it either wedge merges forever or silently narrow the required set.
+_KNOWN_SCHEDULED_REVIEW_KINDS = ("code-review", "leaks")
+
+
+def _validate_configured_kinds(items: object) -> list[str] | None:
+    """Lowercase + validate a configured kind list. Returns the cleaned list (possibly
+    empty, meaning "only the irreducible kinds"), or None if ANYTHING is off — not a list,
+    a non-string element, a blank element, or an unknown kind. None makes the caller fail
+    CLOSED to the full default rather than honor a malformed/ambiguous relaxation."""
+    if not isinstance(items, list):
+        return None
+    out: list[str] = []
+    for k in items:
+        if not isinstance(k, str):
+            return None  # wrong type (e.g. [123]) -> invalid -> default
+        kk = k.strip().lower()  # normalize to the lowercase marker grammar
+        if not kk or kk not in _KNOWN_SCHEDULED_REVIEW_KINDS:
+            return None  # blank ([" "]) or unknown ([foo]) -> invalid -> default
+        out.append(kk)
+    return out
 
 
 def _required_scheduled_review_kinds() -> tuple[str, ...]:
@@ -1821,25 +1844,36 @@ def _required_scheduled_review_kinds() -> tuple[str, ...]:
 
     The leak/secret scanner (``_IRREDUCIBLE_...``) is ALWAYS unioned in and CANNOT be
     dropped by config. Fail-CLOSED toward MORE review: a missing key / unreadable file /
-    parse error falls back to the full default set, never to fewer kinds. Test seam:
+    parse error / duplicate key / wrong-type / blank / unknown kind ALL fall back to the
+    full default set, never to fewer kinds. Configured kinds are validated against
+    ``_KNOWN_SCHEDULED_REVIEW_KINDS`` and lowercased to the marker grammar. Test seam:
     ``_TEST_REQUIRED_SCHEDULED_REVIEWS`` (comma-separated) overrides the config file.
     """
-    # Kinds are LOWERCASED to match the marker grammar (kind= is lowercase-only, see
-    # _SCHEDULED_REVIEW_KIND_RE): a mis-cased config entry must not become a kind no
-    # marker can ever satisfy (which would silently wedge that gate forever).
     raw = os.environ.get("_TEST_REQUIRED_SCHEDULED_REVIEWS")
     configured: list[str] | None = None
     if raw is not None:
-        configured = [k.strip().lower() for k in raw.split(",") if k.strip()]
+        # Test seam: comma-list; empties dropped so "" means "only the irreducible kinds".
+        configured = _validate_configured_kinds([k.strip() for k in raw.split(",") if k.strip()])
     else:
         try:
             import yaml  # lazy: keep the hook import-light; the genesis venv has pyyaml
 
-            with open(os.path.expanduser("~/.genesis/config/genesis.yaml")) as fh:
-                cfg = yaml.safe_load(fh) or {}
-            val = (cfg.get("merge_gate") or {}).get("required_scheduled_reviews")
-            if isinstance(val, list):
-                configured = [str(k).strip().lower() for k in val if str(k).strip()]
+            path = os.path.expanduser("~/.genesis/config/genesis.yaml")
+            with open(path) as fh:
+                text = fh.read()
+            # yaml.safe_load silently keeps the LAST value for a repeated key, so a
+            # badly-merged file (two merge_gate: or required_scheduled_reviews: lines)
+            # could quietly narrow the required set. Catch the realistic cases with a
+            # line scan (the repo's idiom — no unsafe custom Loader) and fail closed.
+            if (
+                len(re.findall(r"(?m)^merge_gate\s*:", text)) > 1
+                or len(re.findall(r"(?m)^\s*required_scheduled_reviews\s*:", text)) > 1
+            ):
+                raise ValueError("duplicate merge_gate/required_scheduled_reviews key")
+            cfg = yaml.safe_load(text) or {}
+            configured = _validate_configured_kinds(
+                (cfg.get("merge_gate") or {}).get("required_scheduled_reviews")
+            )
         except Exception:
             configured = None  # fail-closed: fall back to the full default set below
     kinds = configured if configured is not None else list(_DEFAULT_REQUIRED_SCHEDULED_REVIEW_KINDS)

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -50,17 +50,21 @@ post a comment (issue comment) or PR review whose body contains a marker
 ``<!-- genesis-scheduled-review: head=<full-40-hex-sha> kind=<name> -->`` naming the exact
 head it reviewed AND which routine it was (``kind``). The merge gate
 (``_check_scheduled_claude_reviewed_head``) blocks unless an owner-authored marker for
-EVERY kind in ``_REQUIRED_SCHEDULED_REVIEW_KINDS`` (currently code-review + leaks) names
+EVERY effective required kind (``_required_scheduled_review_kinds()`` — DEFAULT
+code-review + leaks, with the leak scanner irreducible; an install may relax the optional
+kinds to advisory via ``merge_gate.required_scheduled_reviews`` in genesis.yaml) names
 the PR's CURRENT head — so if any required routine never ran, ran on a stale commit, or
-was rate-limited, the merge is blocked (naming the missing kinds). SCOPE: this gate
+was rate-limited, the merge is blocked (naming the missing kinds). An ADVISORY routine
+(one relaxed out of the required set locally) still posts its review on the PR to be read
+and addressed, but its absence does not block. SCOPE: this gate
 enforces ONLY when the merge targets the configured PUBLIC repo — the declared
 ``github.user``/``github.public_repo`` in ``~/.genesis/config/genesis.yaml``
 (``_scheduled_gate_applies`` / ``_canonical_public_repo``). A merge to any OTHER repo
 (a private fork, the voice repo, backups) no-ops, since the required ``/schedule``
 routines run only on the public repo. Deployment note: on the public repo the required
 routines ARE configured (the deploy precondition); a clone that runs on its own public
-repo without a producer uses `# scheduled-review-override` (or removes/edits
-`_REQUIRED_SCHEDULED_REVIEW_KINDS`) — the override valve is the escape by design, not an
+repo without a producer uses `# scheduled-review-override` (or relaxes the optional kinds
+via ``merge_gate.required_scheduled_reviews``) — the override valve is the escape by design, not an
 opt-in flag. Fail-closed on scope uncertainty: if the canonical repo is undeterminable
 the gate ENGAGES rather than silently disarming.
 A DISMISSED or PENDING (draft) review no longer vouches (its marker is ignored), mirroring
@@ -1778,7 +1782,7 @@ def _check_codex_reviewed_head(
 # conscious "merge without a scheduled review" case — it didn't run / is rate-limited).
 # A scheduled-review marker is an HTML comment ``<!-- genesis-scheduled-review:
 # head=<40hex> kind=<name> -->``. Each SCHEDULED routine stamps its own ``kind`` so
-# the gate can require that EVERY routine in ``_REQUIRED_SCHEDULED_REVIEW_KINDS`` ran
+# the gate can require that EVERY routine in ``_required_scheduled_review_kinds()`` ran
 # on the current head — a single routine's marker no longer satisfies the gate on its
 # own. head/kind are parsed from the marker BLOCK (order-tolerant) and BOTH must be
 # present in the SAME marker to count.
@@ -1792,10 +1796,56 @@ _SCHEDULED_REVIEW_BLOCK_RE = re.compile(
 _SCHEDULED_REVIEW_HEAD_RE = re.compile(r"\bhead=([0-9a-f]{40})(?=\s|\Z)")
 _SCHEDULED_REVIEW_KIND_RE = re.compile(r"\bkind=([a-z0-9][a-z0-9._-]*)(?=\s|\Z)")
 
-# Every scheduled routine whose completion the merge gate requires, by ``kind``. A PR
-# merges only when a valid owner-authored marker for EACH of these names the current
-# head. Change this tuple to add/remove required routines.
-_REQUIRED_SCHEDULED_REVIEW_KINDS = ("code-review", "leaks")
+# Default scheduled-review kinds the merge gate REQUIRES at head. A PR merges only when
+# a valid owner-authored marker for EACH effective required kind names the current head.
+# The DEFAULT is the full set (shipped to every install, unchanged); an install may relax
+# the OPTIONAL kinds locally — see _required_scheduled_review_kinds() for the lever.
+_DEFAULT_REQUIRED_SCHEDULED_REVIEW_KINDS = ("code-review", "leaks")
+# The leak/secret scanner is IRREDUCIBLE: always required, never removable by config. A
+# secret reaching a public repo is irreversible, so no local policy may waive it.
+_IRREDUCIBLE_REQUIRED_SCHEDULED_REVIEW_KINDS = ("leaks",)
+
+
+def _required_scheduled_review_kinds() -> tuple[str, ...]:
+    """The scheduled-review kinds the merge gate REQUIRES at head, as a tuple.
+
+    Default is the full set (``code-review`` + ``leaks``) — shipped unchanged to every
+    install. An install MAY relax the OPTIONAL kinds (e.g. make the structural
+    code-review ADVISORY, so its absence no longer blocks — its review still posts on the
+    PR to be read/addressed if it ran) via LOCAL config, keeping install policy out of the
+    public default:
+
+        # ~/.genesis/config/genesis.yaml
+        merge_gate:
+          required_scheduled_reviews: [leaks]
+
+    The leak/secret scanner (``_IRREDUCIBLE_...``) is ALWAYS unioned in and CANNOT be
+    dropped by config. Fail-CLOSED toward MORE review: a missing key / unreadable file /
+    parse error falls back to the full default set, never to fewer kinds. Test seam:
+    ``_TEST_REQUIRED_SCHEDULED_REVIEWS`` (comma-separated) overrides the config file.
+    """
+    # Kinds are LOWERCASED to match the marker grammar (kind= is lowercase-only, see
+    # _SCHEDULED_REVIEW_KIND_RE): a mis-cased config entry must not become a kind no
+    # marker can ever satisfy (which would silently wedge that gate forever).
+    raw = os.environ.get("_TEST_REQUIRED_SCHEDULED_REVIEWS")
+    configured: list[str] | None = None
+    if raw is not None:
+        configured = [k.strip().lower() for k in raw.split(",") if k.strip()]
+    else:
+        try:
+            import yaml  # lazy: keep the hook import-light; the genesis venv has pyyaml
+
+            with open(os.path.expanduser("~/.genesis/config/genesis.yaml")) as fh:
+                cfg = yaml.safe_load(fh) or {}
+            val = (cfg.get("merge_gate") or {}).get("required_scheduled_reviews")
+            if isinstance(val, list):
+                configured = [str(k).strip().lower() for k in val if str(k).strip()]
+        except Exception:
+            configured = None  # fail-closed: fall back to the full default set below
+    kinds = configured if configured is not None else list(_DEFAULT_REQUIRED_SCHEDULED_REVIEW_KINDS)
+    # leaks (and any irreducible kind) is always required, even if config omits it.
+    merged = list(dict.fromkeys([*kinds, *_IRREDUCIBLE_REQUIRED_SCHEDULED_REVIEW_KINDS]))
+    return tuple(merged)
 
 
 def _canonical_public_repo() -> str | None:
@@ -1983,7 +2033,7 @@ def _check_scheduled_claude_reviewed_head(
 ) -> str | None:
     """Block a merge unless EVERY required scheduled Claude review (by the repo OWNER)
     has run on the PR's CURRENT head. Returns ``None`` when a valid owner marker for
-    each kind in ``_REQUIRED_SCHEDULED_REVIEW_KINDS`` names ``head_sha`` exactly (full
+    each kind in ``_required_scheduled_review_kinds()`` names ``head_sha`` exactly (full
     40-char), else a BLOCK MESSAGE naming the MISSING kinds.
 
     Fail-CLOSED — this gate never passes on absence of positive evidence: if the head
@@ -2026,12 +2076,13 @@ def _check_scheduled_claude_reviewed_head(
             f"Retry, or append '# scheduled-review-override' to merge anyway."
         )
     kinds_here = markers.get(head, set())
-    missing = [k for k in _REQUIRED_SCHEDULED_REVIEW_KINDS if k not in kinds_here]
+    required = _required_scheduled_review_kinds()
+    missing = [k for k in required if k not in kinds_here]
     if not missing:
         return None
     return (
         f"scheduled Claude review(s) missing at head {head[:12]}: {', '.join(missing)} "
-        f"(required: {', '.join(_REQUIRED_SCHEDULED_REVIEW_KINDS)}; present: "
+        f"(required: {', '.join(required)}; present: "
         f"{', '.join(sorted(kinds_here)) or 'none'}).\n"
         f"Each routine posts a comment/review carrying "
         f"'<!-- genesis-scheduled-review: head=<sha> kind=<name> -->' once it runs on THIS "

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1002,6 +1002,44 @@ class TestRequiredScheduledReviewKinds:
         monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "Code-Review,LEAKS")
         assert _mod._required_scheduled_review_kinds() == ("code-review", "leaks")
 
+    def test_env_unknown_kind_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "bogus")
+        assert _mod._required_scheduled_review_kinds() == ("code-review", "leaks")
+
+    @staticmethod
+    def _write_cfg(tmp_path, monkeypatch, body):
+        monkeypatch.delenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", raising=False)
+        cfgdir = tmp_path / ".genesis" / "config"
+        cfgdir.mkdir(parents=True)
+        (cfgdir / "genesis.yaml").write_text(body)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+    def test_config_wrong_type_element_fails_closed(self, monkeypatch, tmp_path):
+        self._write_cfg(tmp_path, monkeypatch, "merge_gate:\n  required_scheduled_reviews: [123]\n")
+        assert _mod._required_scheduled_review_kinds() == ("code-review", "leaks")
+
+    def test_config_blank_element_fails_closed(self, monkeypatch, tmp_path):
+        self._write_cfg(tmp_path, monkeypatch, "merge_gate:\n  required_scheduled_reviews: [' ']\n")
+        assert _mod._required_scheduled_review_kinds() == ("code-review", "leaks")
+
+    def test_config_unknown_kind_fails_closed(self, monkeypatch, tmp_path):
+        self._write_cfg(tmp_path, monkeypatch, "merge_gate:\n  required_scheduled_reviews: [foo]\n")
+        assert _mod._required_scheduled_review_kinds() == ("code-review", "leaks")
+
+    def test_config_empty_list_is_leaks_only(self, monkeypatch, tmp_path):
+        self._write_cfg(tmp_path, monkeypatch, "merge_gate:\n  required_scheduled_reviews: []\n")
+        assert _mod._required_scheduled_review_kinds() == ("leaks",)
+
+    def test_duplicate_key_fails_closed(self, monkeypatch, tmp_path):
+        # A badly-merged file with two merge_gate blocks whose last says [leaks] must
+        # NOT silently drop code-review; duplicate keys fail closed to the default.
+        body = (
+            "merge_gate:\n  required_scheduled_reviews: [code-review, leaks]\n"
+            "merge_gate:\n  required_scheduled_reviews: [leaks]\n"
+        )
+        self._write_cfg(tmp_path, monkeypatch, body)
+        assert _mod._required_scheduled_review_kinds() == ("code-review", "leaks")
+
     def test_reads_config_file(self, monkeypatch, tmp_path):
         monkeypatch.delenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", raising=False)
         cfgdir = tmp_path / ".genesis" / "config"

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -47,8 +47,7 @@ def _scheduled_marker(head=HEAD, *, login="owner", author_association="OWNER"):
     satisfied and these freshness/binding cases exercise their own target
     (author_association=OWNER satisfies the trust check regardless of derived repo owner)."""
     markers = "\n".join(
-        f"<!-- genesis-scheduled-review: head={head} kind={k} -->"
-        for k in ("code-review", "leaks")
+        f"<!-- genesis-scheduled-review: head={head} kind={k} -->" for k in ("code-review", "leaks")
     )
     body = "Scheduled review complete.\n" + markers
     return json.dumps({"login": login, "author_association": author_association, "body": body})
@@ -796,7 +795,9 @@ class TestReportFreshnessUnreadable:
             _mod, "_check_inline_review_findings", lambda n, repo=None, force=False: (False, "")
         )
         # freshness gate passes (allowed), but the relabel re-reads fail (None)
-        monkeypatch.setattr(_mod, "_check_codex_reviewed_head", lambda n, repo=None: (False, "", HEAD))
+        monkeypatch.setattr(
+            _mod, "_check_codex_reviewed_head", lambda n, repo=None: (False, "", HEAD)
+        )
         monkeypatch.setattr(_mod, "_latest_codex_reviewed_sha", lambda n, repo=None: None)
         monkeypatch.setattr(_mod, "_pr_head_sha", lambda n, repo=None: None)
         _mod.check_pr_report("5")
@@ -810,11 +811,19 @@ class TestCleanCommentParsing:
 
     @pytest.mark.parametrize(
         "flavour",
-        ["Swish!", "You're on a roll.", "Keep them coming!", ":rocket:", "What shall we delve into next?"],
+        [
+            "Swish!",
+            "You're on a roll.",
+            "Keep them coming!",
+            ":rocket:",
+            "What shall we delve into next?",
+        ],
     )
     def test_parses_all_flavour_variants(self, monkeypatch, flavour):
         # Anchor is the STABLE prefix "Didn't find any major issues", not the flavour.
-        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl("0cd13afeb5", flavour=flavour))
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl("0cd13afeb5", flavour=flavour)
+        )
         assert _mod._latest_codex_clean_comment_sha("1") == "0cd13afeb5"
 
     def test_latest_clean_comment_wins(self, monkeypatch):
@@ -829,8 +838,11 @@ class TestCleanCommentParsing:
 
     def test_clean_marker_without_sha_is_none(self, monkeypatch):
         body = json.dumps(
-            {"login": "chatgpt-codex-connector[bot]", "type": "Bot",
-             "body": "Codex Review: Didn't find any major issues. Swish!"}
+            {
+                "login": "chatgpt-codex-connector[bot]",
+                "type": "Bot",
+                "body": "Codex Review: Didn't find any major issues. Swish!",
+            }
         )
         monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", body)
         assert _mod._latest_codex_clean_comment_sha("1") is None  # fail-closed
@@ -838,15 +850,19 @@ class TestCleanCommentParsing:
     def test_sha_without_clean_marker_is_none(self, monkeypatch):
         # A FINDINGS comment carries a Reviewed-commit line but no clean marker.
         body = json.dumps(
-            {"login": "chatgpt-codex-connector[bot]", "type": "Bot",
-             "body": "### Codex Review\n[P1] a real bug\n\n**Reviewed commit:** `0cd13afeb5`"}
+            {
+                "login": "chatgpt-codex-connector[bot]",
+                "type": "Bot",
+                "body": "### Codex Review\n[P1] a real bug\n\n**Reviewed commit:** `0cd13afeb5`",
+            }
         )
         monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", body)
         assert _mod._latest_codex_clean_comment_sha("1") is None
 
     def test_non_codex_author_ignored(self, monkeypatch):
         monkeypatch.setenv(
-            "_TEST_GH_CODEX_COMMENTS", _clean_comment_jsonl("0cd13afeb5", login="attacker", user_type="User")
+            "_TEST_GH_CODEX_COMMENTS",
+            _clean_comment_jsonl("0cd13afeb5", login="attacker", user_type="User"),
         )
         assert _mod._latest_codex_clean_comment_sha("1") is None
 
@@ -893,8 +909,13 @@ class TestCleanCommentFreshness:
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
         monkeypatch.setenv(
             "_TEST_GH_CODEX_COMMENTS",
-            json.dumps({"login": "chatgpt-codex-connector[bot]", "type": "Bot",
-                        "body": "Codex Review: Didn't find any major issues. Swish!"}),
+            json.dumps(
+                {
+                    "login": "chatgpt-codex-connector[bot]",
+                    "type": "Bot",
+                    "body": "Codex Review: Didn't find any major issues. Swish!",
+                }
+            ),
         )
         block, _, _ = _mod._check_codex_reviewed_head("1")
         assert block is True  # fail-closed: marker alone never vouches
@@ -904,8 +925,13 @@ class TestCleanCommentFreshness:
         monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", "")
         monkeypatch.setenv(
             "_TEST_GH_CODEX_COMMENTS",
-            json.dumps({"login": "chatgpt-codex-connector[bot]", "type": "Bot",
-                        "body": f"### Codex Review\n[P1] bug\n\n**Reviewed commit:** `{HEAD[:10]}`"}),
+            json.dumps(
+                {
+                    "login": "chatgpt-codex-connector[bot]",
+                    "type": "Bot",
+                    "body": f"### Codex Review\n[P1] bug\n\n**Reviewed commit:** `{HEAD[:10]}`",
+                }
+            ),
         )
         block, _, _ = _mod._check_codex_reviewed_head("1")
         assert block is True
@@ -936,8 +962,92 @@ class TestCleanCommentFreshness:
         monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
         monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("green", []))
         monkeypatch.setattr(_mod, "_check_base_is_default", lambda n, repo=None: (False, ""))
-        monkeypatch.setattr(_mod, "_check_pr_review_findings", lambda n, repo=None, force=False: (False, ""))
-        monkeypatch.setattr(_mod, "_check_inline_review_findings", lambda n, repo=None, force=False: (False, ""))
+        monkeypatch.setattr(
+            _mod, "_check_pr_review_findings", lambda n, repo=None, force=False: (False, "")
+        )
+        monkeypatch.setattr(
+            _mod, "_check_inline_review_findings", lambda n, repo=None, force=False: (False, "")
+        )
         _mod.check_pr_report("1")
         out = capsys.readouterr().out
         assert "clean comment at head" in out
+
+
+class TestRequiredScheduledReviewKinds:
+    """The config lever: default = both required; leaks is irreducible; local config
+    (or the _TEST_ seam) may relax the OPTIONAL kinds to advisory. Fails CLOSED (to the
+    full default set) on any unreadable/malformed config."""
+
+    def test_default_is_both_when_unconfigured(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))  # no genesis.yaml -> default
+        assert _mod._required_scheduled_review_kinds() == ("code-review", "leaks")
+
+    def test_env_seam_relaxes_to_leaks_only(self, monkeypatch):
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+        assert _mod._required_scheduled_review_kinds() == ("leaks",)
+
+    def test_leaks_is_irreducible(self, monkeypatch):
+        # config omits leaks -> still forced in (secret scanner never removable)
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review")
+        assert _mod._required_scheduled_review_kinds() == ("code-review", "leaks")
+
+    def test_empty_config_is_leaks_only(self, monkeypatch):
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "")
+        assert _mod._required_scheduled_review_kinds() == ("leaks",)
+
+    def test_kinds_are_lowercased(self, monkeypatch):
+        # mis-cased config must normalize to the lowercase marker grammar, else it
+        # names a kind no real marker can satisfy and silently wedges the gate.
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "Code-Review,LEAKS")
+        assert _mod._required_scheduled_review_kinds() == ("code-review", "leaks")
+
+    def test_reads_config_file(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", raising=False)
+        cfgdir = tmp_path / ".genesis" / "config"
+        cfgdir.mkdir(parents=True)
+        (cfgdir / "genesis.yaml").write_text("merge_gate:\n  required_scheduled_reviews: [leaks]\n")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert _mod._required_scheduled_review_kinds() == ("leaks",)
+
+    def test_malformed_config_fails_closed_to_default(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", raising=False)
+        cfgdir = tmp_path / ".genesis" / "config"
+        cfgdir.mkdir(parents=True)
+        (cfgdir / "genesis.yaml").write_text("merge_gate: [unterminated\n")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert _mod._required_scheduled_review_kinds() == ("code-review", "leaks")
+
+
+class TestScheduledGateUsesRequiredKinds:
+    """The gate consumes _required_scheduled_review_kinds(): a relaxed (advisory)
+    code-review no longer blocks, the default still requires it, and leaks blocks even
+    when config tries to omit it."""
+
+    @staticmethod
+    def _marker(*kinds, head=HEAD):
+        body = "scheduled review done.\n" + "\n".join(
+            f"<!-- genesis-scheduled-review: head={head} kind={k} -->" for k in kinds
+        )
+        return json.dumps({"login": "owner", "author_association": "OWNER", "body": body})
+
+    def _setup(self, monkeypatch, present_kinds, required_env):
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", self._marker(*present_kinds))
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", required_env)
+
+    def test_relaxed_leaks_only_passes_without_code_review(self, monkeypatch):
+        self._setup(monkeypatch, ["leaks"], "leaks")
+        assert (
+            _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub") is None
+        )
+
+    def test_default_blocks_when_code_review_missing(self, monkeypatch):
+        self._setup(monkeypatch, ["leaks"], "code-review,leaks")
+        msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+        assert msg and "code-review" in msg
+
+    def test_leaks_irreducible_blocks_even_if_config_omits_it(self, monkeypatch):
+        self._setup(monkeypatch, ["code-review"], "code-review")  # config omits leaks
+        msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+        assert msg and "leaks" in msg

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -67,8 +67,16 @@ def _pin_canonical_public_repo(monkeypatch):
     public repo to the corpus's merge target (``REPO``) via the ``_TEST_CANONICAL_
     PUBLIC_REPO`` seam, so EVERY case deterministically ENGAGES the scheduled gate
     on every host. The off-public-repo NO-OP is exercised by its own case, which
-    overrides this seam to a different repo."""
+    overrides this seam to a different repo.
+
+    Also pin ``_TEST_REQUIRED_SCHEDULED_REVIEWS`` to the DEFAULT policy
+    (code-review + leaks): the required-kinds are now config-driven from the same
+    ``genesis.yaml``, so without this pin the corpus (which asserts the default
+    both-required behavior) would read the host's real local override and go
+    non-deterministic. The relaxed/advisory path is covered by its own unit tests
+    in test_git_push_guard_codex_freshness.py."""
     monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", REPO)
+    monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
     yield
 
 


### PR DESCRIPTION
## What

Makes the merge gate's required **scheduled-review kinds** configurable via local config instead of a hardcoded tuple, so an install can relax the structural **code-review** routine to *advisory* — without weakening the public default or the secret scanner.

## Why

The scheduled `code-review` and `leaks` routines are quota-capped; when `code-review` is rate-limited it blocks merges even though an equivalent adversarial pass (genesis-architect / the local review-depth gate) already ran. Operators should be able to make code-review advisory locally while keeping the secret scanner mandatory — a secret reaching a public repo is irreversible.

## Changes

- **`scripts/hooks/git_push_guard.py`** — new `_required_scheduled_review_kinds()`:
  - reads `merge_gate.required_scheduled_reviews` (a list) from `~/.genesis/config/genesis.yaml`;
  - **DEFAULT unchanged** (`code-review` + `leaks`) — no install that doesn't set the key is affected;
  - **`leaks` is irreducible** — always unioned in, never removable by config;
  - **fail-closed** to the full default on any missing / unreadable / malformed / wrong-type config; kinds lowercased to the marker grammar.
  - The check function consumes it; report path and merge-block path share the one decision.
- **`SKILL.md`** — documents the lever generically.
- **Tests** — `TestRequiredScheduledReviewKinds` + `TestScheduledGateUsesRequiredKinds` (default=both, relax→leaks-only, leaks-irreducible-even-if-omitted, empty/malformed→fail-closed, case-insensitive, gate integration); pinned the pre-existing characterization corpus's autouse fixture to the default policy so it stays install-agnostic.

## Review

Adversarial security review (genesis-security-reviewer): **fail-open enumeration all-clear** — `leaks` cannot be dropped on any branch. Found + fixed a HIGH (characterization-corpus test isolation) and a WARNING (config case-sensitivity). Lever unit + gate-integration + char-corpus tests green; ruff clean.

## Deploy path

Runtime hook — lands on next CC session start after `git pull`. Public default is byte-identical; per-install policy lives only in local `genesis.yaml` (not in this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011v5AJ2U5rqH9yCeum49DH8