### PR TITLE
feat(contribution): opt-in autonomous posting for the Contributor Work-Log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **The Contributor Work-Log can post curated newcomer issues autonomously
+  (opt-in).** A new `require_approval: false` lever lets the curator's
+  privacy-vetted issues post without a per-item approval prompt — Genesis is the
+  gate (the fail-closed privacy scan still runs on every draft, and the row never
+  surfaces as an approval request). A cautious-rollout `max_posts_per_day` cap
+  limits how many issues post per rolling 24h, so a bad batch surfaces one at a
+  time rather than all at once; `mode: off` (or `GENESIS_CONTRIBUTOR_WORKLOG_DISABLED`)
+  stops posting instantly and freezes the queue. Ships SAFE — `require_approval`
+  defaults true, so a fresh install still requires human approval before any post.
+
 ### Fixed
 
 - **The dashboard Surplus health tile no longer reads green while the surplus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   surfaces as an approval request). A cautious-rollout `max_posts_per_day` cap
   limits how many issues post per rolling 24h, so a bad batch surfaces one at a
   time rather than all at once; `mode: off` (or `GENESIS_CONTRIBUTOR_WORKLOG_DISABLED`)
-  stops posting instantly and freezes the queue. Ships SAFE — `require_approval`
-  defaults true, so a fresh install still requires human approval before any post.
+  halts posting — re-checked immediately before each create — and freezes the queue.
+  Ships SAFE — `require_approval` defaults true, and it is overlay-file-only (not a
+  one-call settings/dashboard toggle), so a fresh install always requires human approval.
 
 ### Fixed
 

--- a/config/contributor_worklog.yaml
+++ b/config/contributor_worklog.yaml
@@ -46,6 +46,10 @@ max_held: 25
 # missing key, or any other value keeps human approval ON. This is a POSTURE flag,
 # NOT the stop switch: the stop is `mode: off` / GENESIS_CONTRIBUTOR_WORKLOG_DISABLED
 # (which freezes the drain, including already-approved held rows).
+# OVERLAY-ONLY: this key is deliberately NOT accepted by settings_update() or the
+# dashboard — disabling an approval gate on irreversible public posting must be a
+# conscious edit of the gitignored ~/.genesis/config/contributor_worklog.local.yaml
+# overlay, never a single unconfirmed API/dashboard call.
 require_approval: true
 
 # Cautious-rollout rate cap: the maximum number of issues the drain will actually

--- a/config/contributor_worklog.yaml
+++ b/config/contributor_worklog.yaml
@@ -33,3 +33,24 @@ retention_days: 30
 # this many rows are still `held` (awaiting owner review). Keeps the approval
 # queue bounded so drafts don't pile up faster than they're reviewed.
 max_held: 25
+
+# Per-item human approval before the drain may post an issue.
+#   true  — (default, SHIP-SAFE) every proposed issue waits for an explicit owner
+#           approval on the dashboard; a fresh clone NEVER auto-posts to its public
+#           repo. Leave this true unless you deliberately want autonomous posting.
+#   false — autonomous (Genesis-vetted) posting: `contributor_issue_propose`
+#           resolves its own approval server-side, so an approved hold posts on the
+#           next `live` drain (no human in the loop). scan_prose (the fail-closed
+#           privacy scan) still runs, and `max_posts_per_day` still caps the rate.
+# FAIL-CLOSED: only an explicit boolean `false` disables the gate — a typo, a
+# missing key, or any other value keeps human approval ON. This is a POSTURE flag,
+# NOT the stop switch: the stop is `mode: off` / GENESIS_CONTRIBUTOR_WORKLOG_DISABLED
+# (which freezes the drain, including already-approved held rows).
+require_approval: true
+
+# Cautious-rollout rate cap: the maximum number of issues the drain will actually
+# POST to GitHub per rolling 24h window (dry-runs don't count). Excess approved
+# holds wait for the next window. Bounds blast radius so a bad batch surfaces one
+# issue at a time, not all at once. Coerced to a safe positive default if
+# mistyped / 0 / negative (the cap can never be removed by a bad value).
+max_posts_per_day: 2

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -425,7 +425,7 @@ gated — that contract is one-directional.
 ```yaml subsystem-map
 entry: autonomy-egress
 modules: [autonomy, outreach, distribution, content, campaigns]
-verified: 2f0239cb 2026-08-07
+verified: d50f37ad 2026-08-25
 ```
 
 - **The chokepoint is `outreach/pipeline.py _deliver`** — ~12 send paths
@@ -447,14 +447,22 @@ verified: 2f0239cb 2026-08-07
   curator-drafted issue via the fail-closed `contribution/sanitize.py scan_prose`
   (title+body+labels — every string that egresses), then HOLDS it: the
   `approval_requests` row FIRST, then `pending_issue_posts` (mirroring the email
-  gate). Each hold is per-item owner-approved on the dashboard (excluded from
-  `approve_all_pending`, like email). The `contributor_issue_watcher` drain
+  gate). By default each hold is per-item owner-approved on the dashboard (excluded
+  from `approve_all_pending`, like email). **Autonomous posture (opt-in,
+  `require_approval: false`):** the propose tool resolves its OWN approval
+  server-side (`resolved_by="genesis:contributor-worklog"`, fail-CLOSED — only an
+  explicit boolean false disables the human gate; default true so a fresh clone
+  never auto-posts), so the curator posts without a human — Genesis is the vetting
+  authority (scan_prose + the rate cap). The `contributor_issue_watcher` drain
   (every 5 min, learning scheduler) resolves approved holds under the
   `contributor_worklog` mode lever (`autonomy/contributor_worklog_config.py`,
   default `propose_only`): `live` → `gh issue create` (shadow-gated door
   `observe_github_issue_create`, `mark_posted` BEFORE `mark_consumed` +
-  pre-post `gh issue list` dedup for idempotency); `propose_only` → dry-run
-  terminal (never posts). Terminal rows pruned >30d via
+  pre-post `gh issue list` dedup for idempotency), rate-limited by
+  `max_posts_per_day` (rolling-24h `count_posted_since`, per-row before the create
+  so N approved rows in one tick are bounded; cautious-rollout brake); `propose_only`
+  → dry-run terminal (never posts). The STOP is `mode: off` / the env kill (freezes
+  the drain, incl. approved held rows). Terminal rows pruned >30d via
   `scripts/prune_contributor_issue_posts.py`; held rows never pruned. The
   curator campaigns are LOCAL user data (uncommitted).
 - **`content/egress.py gate()` is LIVE** in the pipeline: anti-slop scrub +

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -425,7 +425,7 @@ gated — that contract is one-directional.
 ```yaml subsystem-map
 entry: autonomy-egress
 modules: [autonomy, outreach, distribution, content, campaigns]
-verified: d50f37ad 2026-08-25
+verified: d8204a0c 2026-08-25
 ```
 
 - **The chokepoint is `outreach/pipeline.py _deliver`** — ~12 send paths

--- a/src/genesis/autonomy/approval.py
+++ b/src/genesis/autonomy/approval.py
@@ -18,9 +18,12 @@ logger = logging.getLogger(__name__)
 class ApprovalManager:
     """Gate mechanism for actions that require explicit human approval.
 
-    Key invariant: **no auto-approve path exists.**  Timeout always means
-    reject/expire.  Irreversible actions use ``timeout_seconds=None`` (wait
-    forever) and therefore never auto-expire.
+    Key invariant: **timeout never auto-approves.**  A timed-out request always
+    resolves to reject/expire; irreversible actions use ``timeout_seconds=None``
+    (wait forever) and therefore never auto-expire. (A caller MAY resolve a request
+    ``approved`` explicitly server-side — see :meth:`resolve` — but only a
+    deliberate, fail-closed-gated writer does so; timeout itself is never an
+    approval.)
     """
 
     def __init__(
@@ -97,6 +100,14 @@ class ApprovalManager:
         """Resolve a pending request (approved/rejected/expired/cancelled).
 
         Returns ``False`` if the request was not found or was not pending.
+
+        Human resolutions pass a channel ``resolved_by`` (``telegram:``/
+        ``dashboard``/…). An AUTONOMOUS server-side approval is allowed too, but
+        only behind a deliberate fail-closed gate: ``mcp/health/contributor_issue``
+        calls this with ``resolved_by="genesis:contributor-worklog"`` when the
+        ``contributor_worklog.require_approval`` lever is explicitly ``False``.
+        ``genesis:*`` resolutions classify as ``system`` (never human-earned
+        authority) — see ``db/crud/approval_requests.classify_resolver``.
         """
         now_iso = datetime.now(UTC).isoformat()
 

--- a/src/genesis/autonomy/contributor_issue_watcher.py
+++ b/src/genesis/autonomy/contributor_issue_watcher.py
@@ -39,11 +39,13 @@ import json
 import logging
 import re
 import subprocess
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from genesis.autonomy import shadow_gate
 from genesis.autonomy.contributor_worklog_config import (
     effective_mode,
+    knob_int,
+    load_config,
     normalize_title,
 )
 from genesis.db.crud import approval_requests as approval_crud
@@ -150,7 +152,9 @@ def _labels_of(row: dict) -> list[str]:
         return []
 
 
-async def _resolve_approved(rt_db, row: dict, mode: str, now: str) -> bool:
+async def _resolve_approved(
+    rt_db, row: dict, mode: str, now: str, *, max_posts_per_day: int
+) -> bool:
     """Handle an approved hold. *mode* is the CURRENT lever (``effective_mode``
     at this tick); ``row['mode']`` is the lever STAMPED at propose time. Returns
     True iff the row was resolved (posted / dry-run / adopted); returns False
@@ -215,6 +219,26 @@ async def _resolve_approved(rt_db, row: dict, mode: str, now: str) -> bool:
             return True
         return False
 
+    # Cautious-rollout rate cap: bound real CREATEs per rolling 24h. Enforced HERE —
+    # AFTER the adopt branch (the ADOPTING row is never gated by the cap, so
+    # crash-recovery always reconciles; the real issue it reconciles still counts
+    # toward the window) and BEFORE the create. Re-counted per row from the durable
+    # ``posted`` rows, so N approved rows
+    # in one drain tick are correctly bounded (each ``mark_posted`` commits → the next
+    # row's count includes it) and the count survives a mid-window restart. At the cap
+    # → leave held, retry next window. ``max_posts_per_day`` is knob_int-coerced ≥ 1 by
+    # the caller, so a mistyped/0/negative value can never uncap the poster.
+    since = (datetime.fromisoformat(now) - timedelta(hours=24)).isoformat()
+    posted_recent = await pip.count_posted_since(rt_db, since=since)
+    if posted_recent >= max_posts_per_day:
+        logger.info(
+            "Contributor issue %s deferred — daily post cap reached (%d/%d in last 24h)",
+            row["id"],
+            posted_recent,
+            max_posts_per_day,
+        )
+        return False
+
     # Observe the egress, THEN post. mark_posted BEFORE mark_consumed so a crash
     # after the post can't re-post (the row leaves 'held').
     await shadow_gate.observe_github_issue_create(
@@ -249,6 +273,11 @@ async def drain_pending_issue_posts(rt: object) -> int:
     if mode == "off":
         return 0
 
+    # Rate-cap VALUE read once per tick (live, no cache); the per-row COUNT that
+    # actually enforces it lives in _resolve_approved. knob_int coerces a
+    # bad/0/negative value to a safe positive default — the cap can never be uncapped.
+    cap = knob_int(load_config(), "max_posts_per_day")
+
     resolved = 0
     for row in await pip.list_held(db):
         now = datetime.now(UTC).isoformat()
@@ -276,7 +305,7 @@ async def drain_pending_issue_posts(rt: object) -> int:
                     row["id"],
                 )
                 continue
-            if await _resolve_approved(db, row, mode, now):
+            if await _resolve_approved(db, row, mode, now, max_posts_per_day=cap):
                 resolved += 1
         elif status in ("rejected", "cancelled"):
             if await pip.mark_rejected(db, row["id"], rejected_at=now):

--- a/src/genesis/autonomy/contributor_issue_watcher.py
+++ b/src/genesis/autonomy/contributor_issue_watcher.py
@@ -84,6 +84,19 @@ def _issue_number_from_url(url: str) -> int | None:
     return int(m.group(1)) if m else None
 
 
+def _normalize_ts(raw: str | None) -> str | None:
+    """Normalize a GitHub ``Z``-suffixed timestamp to the same ``+00:00`` isoformat as
+    ``datetime.now(UTC).isoformat()``, so ``posted_at`` stays format-uniform for the
+    string comparison in ``count_posted_since``. Returns None on a missing/malformed
+    value (the caller falls back to ``now`` — fail-safe: counts toward the cap)."""
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(str(raw).replace("Z", "+00:00")).isoformat()
+    except (ValueError, TypeError):
+        return None
+
+
 def _find_open_issue_by_title(repo: str, title_norm: str) -> tuple[bool, dict | None]:
     """Look for an OPEN issue on *repo* whose normalized title matches. Returns
     ``(ok, issue|None)`` — ``ok=False`` means the lookup itself failed (caller
@@ -105,7 +118,7 @@ def _find_open_issue_by_title(repo: str, title_norm: str) -> tuple[bool, dict | 
             "--state",
             "open",
             "--json",
-            "number,title,url",
+            "number,title,url,createdAt",
             "--limit",
             "200",
         ]
@@ -207,8 +220,23 @@ async def _resolve_approved(
         # Already open (a prior cycle posted then crashed before mark_posted, OR a
         # human/other path opened it). Adopt it — idempotent, no second issue.
         num = existing.get("number") or _issue_number_from_url(existing.get("url", ""))
+        # Stamp the ADOPTED issue's OWN creation time as posted_at (not ``now``) so an
+        # old/human-made issue we merely reconcile does NOT consume the cautious-rollout
+        # daily cap — the cap counts issues actually CREATED in the window. A
+        # crash-recovery adopt (we created it seconds ago) has a recent createdAt, so it
+        # still counts correctly; a missing createdAt falls back to ``now`` (fail-safe:
+        # counts, i.e. under-posts).
+        # KNOWN INTERACTION (accepted): an old posted_at also makes prune_terminal
+        # (COALESCE(posted_at,…)) reap this tracking row earlier than the 30d retention.
+        # Bounded/safe — the pre-post open-issue dedup (_find_open_issue_by_title,
+        # state=open) still backstops a re-proposal of the same title, so an early-pruned
+        # adopt cannot produce a duplicate OPEN issue.
+        # Normalize gh's `Z` suffix to the same `+00:00` isoformat as ``now`` so the
+        # string `posted_at >= since` comparison in count_posted_since is format-uniform
+        # (no Z-vs-+00:00 footgun); a malformed value falls back to ``now`` (fail-safe).
+        adopt_ts = _normalize_ts(existing.get("createdAt")) or now
         if await pip.mark_posted(
-            rt_db, row["id"], issue_number=num, issue_url=existing.get("url"), posted_at=now
+            rt_db, row["id"], issue_number=num, issue_url=existing.get("url"), posted_at=adopt_ts
         ):
             await approval_crud.mark_consumed(rt_db, row["request_id"], consumed_at=now)
             logger.info(
@@ -237,6 +265,14 @@ async def _resolve_approved(
             posted_recent,
             max_posts_per_day,
         )
+        return False
+
+    # Kill-switch recheck: re-read the mode LIVE immediately before the external
+    # create so a ``mode: off`` / env-kill flipped mid-tick halts THIS post too — not
+    # just at the next tick boundary. Makes the STOP effective per-create, so the
+    # worst a mid-tick flip can leak is an in-flight create already past this point.
+    if effective_mode() != "live":
+        logger.info("Contributor issue %s deferred — lever no longer live at post time", row["id"])
         return False
 
     # Observe the egress, THEN post. mark_posted BEFORE mark_consumed so a crash

--- a/src/genesis/autonomy/contributor_worklog_config.py
+++ b/src/genesis/autonomy/contributor_worklog_config.py
@@ -24,6 +24,16 @@ drain) — folded into :func:`effective_mode` here rather than a separate
 hook, because both consumers read config directly (repo_pulse's hook could
 not, hence its split lever).
 
+Autonomous posting (opt-in): :func:`require_approval` (default ``True``, fail-
+CLOSED) governs whether a proposed issue needs an explicit human approval before
+the drain may post it. A fresh clone keeps the human gate; only a deliberate
+``require_approval: false`` overlay lets the curator post autonomously (still
+behind ``scan_prose`` + the ``mode`` lever). ``max_posts_per_day`` (knob_int) caps
+the POST rate for a cautious rollout — excess approved holds wait for the next
+window. The emergency STOP is ``mode: off`` / the env kill (freezes the drain,
+including already-approved held rows); ``require_approval`` is a posture flag, not
+the brake.
+
 Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only.
 ``approval_gate`` / the MCP tool / the drain import the constants + mode from
 here, never the reverse (one-way).
@@ -73,11 +83,17 @@ DEFAULTS: dict[str, Any] = {
     "mode": "propose_only",  # ship posture: propose + approve, but NEVER auto-post
     "retention_days": 30,  # terminal rows (posted/rejected/expired/dry_run) pruned after this
     "max_held": 25,  # backpressure: the tool refuses new proposals past this many holds
+    "require_approval": True,  # SHIP-SAFE: a fresh clone keeps the human per-item gate; only
+    # THIS install's overlay flips it False to let the curator post autonomously (see
+    # require_approval() — fail-closed: only an explicit boolean False disables the gate).
+    "max_posts_per_day": 2,  # cautious-rollout cap: max autonomous posts per rolling 24h window
+    # (knob_int-coerced, so a mistyped/0/negative value can never UNCAP the poster).
 }
 
 _INT_KNOBS = (
     "retention_days",
     "max_held",
+    "max_posts_per_day",
 )
 
 
@@ -139,6 +155,26 @@ def effective_mode() -> str:
         logger.warning("contributor_worklog has invalid mode %r — degrading to propose_only", mode)
         return "propose_only"
     return mode
+
+
+def require_approval() -> bool:
+    """Whether a proposed issue draft needs an explicit human approval before the
+    poster drain may post it — read live (no cache), like :func:`effective_mode`.
+
+    FAIL-CLOSED (the security-critical direction): only an EXPLICIT boolean
+    ``False`` disables the human gate. A missing key, ``None``, a typo, or any
+    non-``False`` value keeps the gate ON — a public-repo post must never go
+    un-gated by a config accident. So the DEFAULT (``True``) means a fresh clone
+    always requires human approval; only a deliberate ``require_approval: false``
+    in this install's overlay enables autonomous (Genesis-vetted) posting.
+
+    NOTE: this is a POSTURE flag, not the emergency stop. Flipping it back to
+    ``True`` re-gates only NEW proposals — a row already auto-approved and still
+    ``held`` will still post. The true stop is ``mode: off`` / the env kill
+    switch, which freezes the drain (and thus every held row). See
+    :func:`effective_mode`.
+    """
+    return load_config().get("require_approval", True) is not False
 
 
 def knob_int(cfg: dict[str, Any], key: str) -> int:

--- a/src/genesis/db/crud/approval_requests.py
+++ b/src/genesis/db/crud/approval_requests.py
@@ -20,7 +20,9 @@ import aiosqlite
 #           manual:* (operator sessions), "user" (autonomy/approval.py default)
 #   system: "system" (approval.py cancel()), timeout_auto_expire
 #           (approval_gate.py), alarm_cleared (sentinel/dispatcher.py),
-#           cleanup:* (housekeeping jobs)
+#           cleanup:* (housekeeping jobs), genesis:* (autonomous Genesis-vetted
+#           self-approvals, e.g. genesis:contributor-worklog in
+#           mcp/health/contributor_issue.py when require_approval is off)
 #   blank/None → system: bulk expiry (expire_timed_out below) never writes
 #           resolved_by — no human acted on those rows.
 HUMAN_RESOLVER_PREFIXES: tuple[str, ...] = (
@@ -35,6 +37,7 @@ SYSTEM_RESOLVER_PREFIXES: tuple[str, ...] = (
     "timeout_auto_expire",
     "cleanup:",
     "alarm_cleared",
+    "genesis:",  # autonomous Genesis-vetted self-approval (NOT human-earned authority)
 )
 
 

--- a/src/genesis/db/crud/pending_issue_posts.py
+++ b/src/genesis/db/crud/pending_issue_posts.py
@@ -102,6 +102,24 @@ async def mark_posted(
     return cursor.rowcount > 0
 
 
+async def count_posted_since(db: aiosqlite.Connection, *, since: str) -> int:
+    """Number of issues actually POSTED to GitHub at/after ``since`` (ISO-UTC ts) —
+    the poster drain's rolling-window rate-limit count (cautious-rollout cap).
+
+    Counts ``status='posted'`` only, so ``dry_run`` holds (propose_only) never
+    consume a slot and the count is reconstructed from the durable table (survives
+    a mid-window restart — an in-memory counter would not). Mirrors
+    ``autonomous_email_sends.count_for_cell_since``. Global (not repo-scoped): the
+    cautious-rollout intent is total owner exposure, and this install posts to one
+    repo — global generalizes cleanly to a multi-repo future."""
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM pending_issue_posts WHERE status = 'posted' AND posted_at >= ?",
+        (since,),
+    )
+    row = await cursor.fetchone()
+    return int(row[0]) if row else 0
+
+
 async def list_dedup_active(db: aiosqlite.Connection, repo: str) -> list[dict]:
     """Rows in *repo* that should block a duplicate proposal: still awaiting
     owner review ('held') or already live ('posted'). ``dry_run`` deliberately

--- a/src/genesis/mcp/health/contributor_issue.py
+++ b/src/genesis/mcp/health/contributor_issue.py
@@ -6,9 +6,16 @@ GitHub issue and calls this tool. Here — NOT in the untrusted curator subproce
 — the draft passes the fail-closed prose sanitizer
 (:func:`genesis.contribution.scan_prose`), and only if clean is it parked in
 ``pending_issue_posts`` (status='held') with a linked ``approval_requests`` row.
-The owner reviews the FULL body + approves/rejects per item on the dashboard; a
-separate poster drain (``contributor_issue_watcher``) posts it below the gate on
-approval (in ``live`` mode) or dry-runs it (in ``propose_only``).
+By default the owner reviews the FULL body + approves/rejects per item on the
+dashboard; a separate poster drain (``contributor_issue_watcher``) posts it below
+the gate on approval (in ``live`` mode) or dry-runs it (in ``propose_only``).
+
+Autonomous posture (this install's opt-in): when ``require_approval`` is false,
+this tool resolves its OWN approval server-side (``resolved_by=
+"genesis:contributor-worklog"``) so the drain posts without a human — Genesis is
+the vetting authority (``scan_prose`` here + the curator's rewrite + the
+``max_posts_per_day`` drain cap). The row never sits ``pending``, so nothing
+surfaces as an owner approval request.
 
 Mirrors the WS-8 email autonomy gate exactly (two-row create, approval FIRST so
 a crash never orphans a hold). DB access mirrors ``evo_run`` — the long-lived
@@ -34,7 +41,9 @@ from genesis.autonomy.contributor_worklog_config import (
     knob_int,
     load_config,
     normalize_title,
+    require_approval,
 )
+from genesis.autonomy.types import ApprovalStatus
 from genesis.contribution import scan_prose
 from genesis.contribution.findings import Severity
 from genesis.db.crud import pending_issue_posts as pip
@@ -75,6 +84,20 @@ async def _impl_contributor_issue_propose(
     repo = (repo or "").strip() or _default_repo()
     if "/" not in repo:
         return {"status": "error", "reason": f"repo must be owner/name, got {repo!r}"}
+    # Autonomous posture (require_approval off): the untrusted curator's repo
+    # override loses its human-review backstop, so pin the destination to this
+    # install's configured public repo — Genesis vets DESTINATION, not just content.
+    human_required = require_approval()
+    if not human_required:
+        default_repo = _default_repo()
+        if repo != default_repo:
+            logger.warning(
+                "contributor_issue_propose: autonomous mode ignores curator repo "
+                "override %r → pinning to %r",
+                repo,
+                default_repo,
+            )
+            repo = default_repo
     source_ref = (source_follow_up_id or "").strip() or None
     label_list = [str(x).strip() for x in (labels or []) if str(x).strip()]
 
@@ -161,20 +184,54 @@ async def _impl_contributor_issue_propose(
         mode,
         source,
     )
+
+    # Autonomous (Genesis-vetted) posture — resolve our OWN approval server-side so
+    # the drain treats the hold as approved without a human in the loop. FAIL-CLOSED:
+    # only an explicit ``require_approval: false`` in this install's overlay reaches
+    # here; every other value keeps the human gate (require_approval() default True).
+    # scan_prose already passed above (the fail-closed privacy gate); the curator
+    # LLM's self-vetting + the ``max_posts_per_day`` drain cap are the remaining
+    # backstops. The row never sits ``pending``, so it never surfaces as an approval
+    # request on the dashboard / morning report. This is a POSTURE flag, NOT the stop
+    # switch — the brake is ``mode: off`` / the env kill (freezes the drain).
+    auto_approved = not human_required
+    # Fail-safe: if resolve() reports the row was not pending (impossible for a
+    # just-created timeout_seconds=None request, but guard anyway), leave it for a
+    # human rather than claim auto_approved — DB state and the returned message must
+    # never diverge. Short-circuit: resolve() is not called when the human gate is on.
+    if auto_approved and not await approval.resolve(
+        request_id,
+        status=ApprovalStatus.APPROVED,
+        resolved_by="genesis:contributor-worklog",
+    ):
+        logger.warning(
+            "contributor_issue_propose: auto-approve resolve failed for %s — left pending",
+            request_id,
+        )
+        auto_approved = False
+
+    if auto_approved:
+        message = (
+            "Auto-approved (Genesis-vetted); will post autonomously on the next "
+            "drain tick (live mode, within the daily cap)."
+            if mode == "live"
+            else "Auto-approved (Genesis-vetted) but propose_only — dry-run terminal, "
+            "not posted. Flip the lever to live to post."
+        )
+    else:
+        message = "Issue draft held for owner approval on the dashboard. " + (
+            "It will post on approval (live mode)."
+            if mode == "live"
+            else "On approval it is dry-run only (propose_only) — flip to live to post."
+        )
     return {
         "status": "held",
         "pending_id": pending_id,
         "request_id": request_id,
         "repo": repo,
         "mode": mode,
-        "message": (
-            "Issue draft held for owner approval on the dashboard. "
-            + (
-                "It will post on approval (live mode)."
-                if mode == "live"
-                else "On approval it is dry-run only (propose_only) — flip to live to post."
-            )
-        ),
+        "auto_approved": auto_approved,
+        "message": message,
     }
 
 

--- a/src/genesis/mcp/health/contributor_issue.py
+++ b/src/genesis/mcp/health/contributor_issue.py
@@ -82,8 +82,6 @@ async def _impl_contributor_issue_propose(
         return {"status": "error", "reason": f"source must be follow_up|codebase, got {source!r}"}
 
     repo = (repo or "").strip() or _default_repo()
-    if "/" not in repo:
-        return {"status": "error", "reason": f"repo must be owner/name, got {repo!r}"}
     # Autonomous posture (require_approval off): the untrusted curator's repo
     # override loses its human-review backstop, so pin the destination to this
     # install's configured public repo — Genesis vets DESTINATION, not just content.
@@ -98,6 +96,12 @@ async def _impl_contributor_issue_propose(
                 default_repo,
             )
             repo = default_repo
+    # Validate the FINAL repo value — AFTER any autonomous pin — so a bare
+    # ``_default_repo()`` (configured owner absent → no ``owner/`` prefix) is
+    # rejected here instead of creating a hold the drain would send to an invalid
+    # ``gh --repo`` and retry forever.
+    if "/" not in repo:
+        return {"status": "error", "reason": f"repo must be owner/name, got {repo!r}"}
     source_ref = (source_follow_up_id or "").strip() or None
     label_list = [str(x).strip() for x in (labels or []) if str(x).strip()]
 

--- a/src/genesis/mcp/health/contributor_issue.py
+++ b/src/genesis/mcp/health/contributor_issue.py
@@ -96,11 +96,13 @@ async def _impl_contributor_issue_propose(
                 default_repo,
             )
             repo = default_repo
-    # Validate the FINAL repo value — AFTER any autonomous pin — so a bare
-    # ``_default_repo()`` (configured owner absent → no ``owner/`` prefix) is
-    # rejected here instead of creating a hold the drain would send to an invalid
-    # ``gh --repo`` and retry forever.
-    if "/" not in repo:
+    # Validate the FINAL repo value — AFTER any autonomous pin — so a malformed
+    # destination is rejected here instead of creating a hold the drain would send to
+    # an invalid ``gh --repo`` and retry forever (consuming max_held). Require every
+    # slash-separated component non-empty: ``owner/`` , ``/repo`` , ``/`` , ``a//b``
+    # are all rejected, while ``owner/name`` (and gh's ``host/owner/repo``) pass.
+    _parts = repo.split("/")
+    if len(_parts) < 2 or not all(_parts):
         return {"status": "error", "reason": f"repo must be owner/name, got {repo!r}"}
     source_ref = (source_follow_up_id or "").strip() or None
     label_list = [str(x).strip() for x in (labels or []) if str(x).strip()]

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -1314,13 +1314,14 @@ def _validate_contributor_worklog(changes: dict) -> list[str]:
     from genesis.autonomy.contributor_worklog_config import _INT_KNOBS, MODES
 
     errors: list[str] = []
-    valid_keys = ("enabled", "mode", *_INT_KNOBS)
+    _BOOL_KEYS = ("enabled", "require_approval")
+    valid_keys = (*_BOOL_KEYS, "mode", *_INT_KNOBS)
     for key, value in changes.items():
         if key not in valid_keys:
             errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
-        elif key == "enabled":
+        elif key in _BOOL_KEYS:
             if not isinstance(value, bool):
-                errors.append("'enabled' must be a boolean")
+                errors.append(f"'{key}' must be a boolean")
         elif key == "mode":
             if value not in MODES:
                 errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -146,6 +146,11 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         config_filename="contributor_worklog.yaml",
         readonly=False,
         needs_restart=False,  # drain re-reads each tick
+        # require_approval is overlay-only (the validator rejects it): strip it from
+        # the settings GET too, so a whole-config dashboard PUT can never echo it back
+        # and 422 the entire save. Disabling this approval gate must be a deliberate
+        # overlay-file edit, never a UI round-trip.
+        hidden_fields=frozenset({"require_approval"}),
     ),
     "memory_integrity": SettingsDomain(
         name="memory_integrity",
@@ -1314,7 +1319,12 @@ def _validate_contributor_worklog(changes: dict) -> list[str]:
     from genesis.autonomy.contributor_worklog_config import _INT_KNOBS, MODES
 
     errors: list[str] = []
-    _BOOL_KEYS = ("enabled", "require_approval")
+    _BOOL_KEYS = ("enabled",)
+    # NOTE: `require_approval` is DELIBERATELY not settings-writable. It disables an
+    # approval gate on irreversible public posting, so flipping it must be a
+    # conscious config-file edit (the gitignored ~/.genesis overlay), never a single
+    # unconfirmed settings_update() / dashboard PUT. Rejecting it here (as an unknown
+    # key) closes both mutation paths; the overlay is read directly by require_approval().
     valid_keys = (*_BOOL_KEYS, "mode", *_INT_KNOBS)
     for key, value in changes.items():
         if key not in valid_keys:

--- a/tests/test_autonomy/test_contributor_issue_watcher.py
+++ b/tests/test_autonomy/test_contributor_issue_watcher.py
@@ -461,6 +461,64 @@ async def test_adopt_not_blocked_by_cap(db, monkeypatch):
     assert row["issue_number"] == 7  # adopted the existing issue despite the cap
 
 
+@pytest.mark.asyncio
+async def test_adopt_old_issue_does_not_consume_cap(db, monkeypatch):
+    """Codex P2: adopting an OLD/human-made issue stamps ITS creation time as
+    posted_at, so it does NOT burn a daily-cap slot — only issues created in the
+    window count. Here an old adopt + a real create both resolve under cap=1."""
+    _mode(monkeypatch, "live")
+    _cap(monkeypatch, 1)
+    old = "2020-01-01T00:00:00Z"
+    existing = json.dumps(
+        [
+            {
+                "number": 7,
+                "title": "old adopt",
+                "url": f"https://github.com/{_REPO}/issues/7",
+                "createdAt": old,
+            }
+        ]
+    )
+    gh = _FakeGh(list_out=existing)
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid1, rid1, mgr = await _seed_held(db, title="old adopt", mode="live")
+    await mgr.resolve(rid1, status="approved")
+    pid2, rid2, _ = await _seed_held(db, title="a real new post", mode="live")
+    await mgr.resolve(rid2, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 2  # both resolve
+    row1 = await pip.get_by_id(db, pid1)
+    assert row1["status"] == "posted"
+    # adopt stamped the OLD creation time (normalized Z -> +00:00), so it's out of window
+    assert row1["posted_at"].startswith("2020-01-01T00:00:00")
+    row2 = await pip.get_by_id(db, pid2)
+    assert row2["status"] == "posted"  # the real create was NOT deferred by the adopt
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_recheck_halts_mid_tick(db, monkeypatch):
+    """Codex P2: a mode flip to off DURING a tick halts the create — the mode is
+    re-read live immediately before the external create, not just once per tick."""
+    calls = {"n": 0}
+
+    def _flip():
+        calls["n"] += 1
+        return "live" if calls["n"] == 1 else "off"  # live at drain top, off at pre-create recheck
+
+    monkeypatch.setattr(ciw, "effective_mode", _flip)
+    _cap(monkeypatch, 5)
+    gh = _FakeGh(list_out="[]")
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid, rid, mgr = await _seed_held(db, mode="live")
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 0
+    assert not gh.created()  # create halted by the mid-tick kill
+    assert (await pip.get_by_id(db, pid))["status"] == "held"  # left held → retries when live
+
+
 # ── end-to-end: propose (auto-approve) → drain (post), no human ─────────────
 
 
@@ -480,6 +538,10 @@ async def test_e2e_autoapprove_then_drain_posts(db, tmp_path, monkeypatch):
     monkeypatch.setattr(ci, "effective_mode", lambda: "live")
     monkeypatch.setattr(ci, "load_config", lambda: {"max_held": 25})
     monkeypatch.setattr(ci, "require_approval", lambda: False)
+    # Install-agnostic: the autonomous pin calls _default_repo(); on a fresh clone
+    # (no github config) that returns a bare name and would error. Pin it to _REPO so
+    # the test exercises the post path, not the empty-config edge (covered elsewhere).
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)
     res = await ci._impl_contributor_issue_propose(
         db, title="Autonomous newcomer task", body="A clean, public-safe task.", repo=_REPO
     )

--- a/tests/test_autonomy/test_contributor_issue_watcher.py
+++ b/tests/test_autonomy/test_contributor_issue_watcher.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from datetime import UTC, datetime
 
 import aiosqlite
 import pytest
@@ -327,3 +328,173 @@ async def test_off_mode_short_circuits(db, monkeypatch):
 async def test_no_db_returns_zero(monkeypatch):
     _mode(monkeypatch, "live")
     assert await ciw.drain_pending_issue_posts(_RT(None)) == 0
+
+
+# ── cautious-rollout rate cap (max_posts_per_day) ──────────────────────────
+
+
+def _cap(monkeypatch, n: int):
+    """Force the per-tick post cap to *n* (drain reads it via load_config)."""
+    monkeypatch.setattr(ciw, "load_config", lambda: {"max_posts_per_day": n})
+
+
+async def _seed_posted(db, *, title, posted_at):
+    """A row already POSTED (counts toward the rolling cap). No approval needed —
+    count_posted_since counts status='posted' directly."""
+    pid = str(uuid.uuid4())
+    await pip.create(
+        db,
+        id=pid,
+        request_id=str(uuid.uuid4()),
+        repo=_REPO,
+        title=title,
+        body="b",
+        source="codebase",
+        cell_domain="github",
+        cell_verb="issue_create",
+        cell_risk_class="bulk",
+        held_at="2026-08-07T00:00:00",
+        mode="live",
+    )
+    await pip.mark_posted(db, pid, issue_number=1, issue_url="u", posted_at=posted_at)
+    return pid
+
+
+@pytest.mark.asyncio
+async def test_rate_cap_defers_when_at_limit(db, monkeypatch):
+    """At the cap, a ready live row is NOT posted — left held to retry next window."""
+    _mode(monkeypatch, "live")
+    _cap(monkeypatch, 1)
+    gh = _FakeGh(list_out="[]")
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    await _seed_posted(db, title="Already posted today", posted_at=datetime.now(UTC).isoformat())
+    pid, rid, mgr = await _seed_held(db, title="Next in line", mode="live")
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 0
+    assert not gh.created()  # cap reached → no CREATE
+    assert (await pip.get_by_id(db, pid))["status"] == "held"  # left held → retries
+    assert (await ar.get_by_id(db, rid))["consumed_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_rate_cap_allows_under_limit(db, monkeypatch):
+    _mode(monkeypatch, "live")
+    _cap(monkeypatch, 2)
+    gh = _FakeGh(list_out="[]")
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    await _seed_posted(db, title="One already", posted_at=datetime.now(UTC).isoformat())
+    pid, rid, mgr = await _seed_held(db, title="Under the cap", mode="live")
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 1
+    assert gh.created()
+    assert (await pip.get_by_id(db, pid))["status"] == "posted"
+
+
+@pytest.mark.asyncio
+async def test_rate_cap_bounds_a_single_tick(db, monkeypatch):
+    """Two ready live rows in ONE tick with cap=1 → exactly ONE posts; the per-row
+    count includes the one just posted this tick (mark_posted commits per row)."""
+    _mode(monkeypatch, "live")
+    _cap(monkeypatch, 1)
+    gh = _FakeGh(list_out="[]")
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    pid1, rid1, mgr = await _seed_held(db, title="First to post", mode="live")
+    await mgr.resolve(rid1, status="approved")
+    pid2, rid2, _ = await _seed_held(db, title="Second, over cap", mode="live")
+    await mgr.resolve(rid2, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 1  # only one resolved
+    statuses = {
+        (await pip.get_by_id(db, pid1))["status"],
+        (await pip.get_by_id(db, pid2))["status"],
+    }
+    assert statuses == {"posted", "held"}  # one posted, one deferred
+
+
+@pytest.mark.asyncio
+async def test_rate_cap_ignores_dry_runs(db, monkeypatch):
+    """dry_run holds (propose_only) never consume a slot — count is status='posted'."""
+    _mode(monkeypatch, "live")
+    _cap(monkeypatch, 1)
+    gh = _FakeGh(list_out="[]")
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    # a dry-run row exists but must NOT count against the cap
+    drpid, drrid, drmgr = await _seed_held(db, title="A dry run", mode="propose_only")
+    await drmgr.resolve(drrid, status="approved")
+    # drain once in propose_only? no — just mark it dry_run directly to isolate the cap
+    await pip.mark_dry_run(db, drpid, dry_run_at=datetime.now(UTC).isoformat())
+    pid, rid, mgr = await _seed_held(db, title="A real post", mode="live")
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 1
+    assert gh.created()  # cap not consumed by the dry_run → posts
+    assert (await pip.get_by_id(db, pid))["status"] == "posted"
+
+
+@pytest.mark.asyncio
+async def test_adopt_not_blocked_by_cap(db, monkeypatch):
+    """Crash-recovery adopt (an issue already open on the repo) must reconcile even
+    at the cap — the cap gates CREATEs, not the idempotent adopt (which is BEFORE
+    the cap check)."""
+    _mode(monkeypatch, "live")
+    _cap(monkeypatch, 1)
+    existing = json.dumps(
+        [{"number": 7, "title": "adopt me", "url": f"https://github.com/{_REPO}/issues/7"}]
+    )
+    gh = _FakeGh(list_out=existing)
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    await _seed_posted(db, title="At the cap already", posted_at=datetime.now(UTC).isoformat())
+    pid, rid, mgr = await _seed_held(db, title="Adopt me", mode="live")
+    await mgr.resolve(rid, status="approved")
+
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 1
+    assert not gh.created()  # adopted, not created
+    row = await pip.get_by_id(db, pid)
+    assert row["status"] == "posted"
+    assert row["issue_number"] == 7  # adopted the existing issue despite the cap
+
+
+# ── end-to-end: propose (auto-approve) → drain (post), no human ─────────────
+
+
+@pytest.mark.asyncio
+async def test_e2e_autoapprove_then_drain_posts(db, tmp_path, monkeypatch):
+    """Integration of the full autonomous path: require_approval=False → the propose
+    tool auto-approves its own hold → the drain posts it (live, under cap) with NO
+    human in the loop. Guards against a future refactor decoupling the two halves."""
+    from genesis.mcp.health import contributor_issue as ci
+
+    # scan_prose fails closed on a missing fingerprint file — point at a present empty one.
+    fp = tmp_path / "fingerprints.txt"
+    fp.write_text("")
+    monkeypatch.setenv("GENESIS_RELEASE_FINGERPRINTS", str(fp))
+
+    # propose side: live + autonomous posture
+    monkeypatch.setattr(ci, "effective_mode", lambda: "live")
+    monkeypatch.setattr(ci, "load_config", lambda: {"max_held": 25})
+    monkeypatch.setattr(ci, "require_approval", lambda: False)
+    res = await ci._impl_contributor_issue_propose(
+        db, title="Autonomous newcomer task", body="A clean, public-safe task.", repo=_REPO
+    )
+    assert res["status"] == "held"
+    assert res["auto_approved"] is True
+    assert (await ar.get_by_id(db, res["request_id"]))["status"] == "approved"
+
+    # drain side: live, cap not reached, gh mocked → posts with no human approval
+    _mode(monkeypatch, "live")
+    _cap(monkeypatch, 2)
+    gh = _FakeGh(list_out="[]")
+    monkeypatch.setattr(ciw, "_run_gh", gh)
+    n = await ciw.drain_pending_issue_posts(_RT(db))
+    assert n == 1
+    assert gh.created()  # posted end-to-end, never touched by a human
+    row = await pip.get_by_id(db, res["pending_id"])
+    assert row["status"] == "posted"
+    assert row["issue_number"] == 42

--- a/tests/test_autonomy/test_contributor_worklog_config.py
+++ b/tests/test_autonomy/test_contributor_worklog_config.py
@@ -209,14 +209,27 @@ def test_domain_registered():
     assert "contributor_worklog" in _DOMAIN_VALIDATORS
 
 
+def test_require_approval_is_hidden_and_not_writable():
+    """SECURITY guard (not cosmetic): `require_approval` must be BOTH stripped from the
+    settings GET (`hidden_fields`, so a whole-config dashboard PUT can't echo it back)
+    AND rejected by the validator (so no unconfirmed settings_update/PUT can disable the
+    approval gate). Disabling it is an overlay-FILE-only act. A refactor that treats
+    hidden_fields as UI-cosmetic — or re-adds the key to the writable set — fails here."""
+    d = _DOMAIN_REGISTRY["contributor_worklog"]
+    assert "require_approval" in d.hidden_fields  # GET-strip
+    assert _validate_contributor_worklog(
+        {"require_approval": False}
+    )  # PUT-reject (non-empty errors)
+    assert _validate_contributor_worklog({"require_approval": True})
+
+
 def test_validator_accepts_valid_changes():
     assert _validate_contributor_worklog({"enabled": False}) == []
     assert _validate_contributor_worklog({"mode": "off"}) == []
     assert _validate_contributor_worklog({"mode": "propose_only"}) == []
     assert _validate_contributor_worklog({"mode": "live"}) == []
     assert _validate_contributor_worklog({"retention_days": 60, "max_held": 5}) == []
-    assert _validate_contributor_worklog({"require_approval": False}) == []
-    assert _validate_contributor_worklog({"require_approval": True, "max_posts_per_day": 3}) == []
+    assert _validate_contributor_worklog({"max_posts_per_day": 3}) == []
 
 
 def test_validator_rejects_bad_values():
@@ -225,9 +238,16 @@ def test_validator_rejects_bad_values():
     assert _validate_contributor_worklog({"retention_days": 0})
     assert _validate_contributor_worklog({"max_held": True})
     assert _validate_contributor_worklog({"bogus": 1})
-    assert _validate_contributor_worklog({"require_approval": "yes"})  # must be a boolean
     assert _validate_contributor_worklog({"max_posts_per_day": 0})  # positive int only
     assert _validate_contributor_worklog({"max_posts_per_day": True})
+
+
+def test_validator_rejects_require_approval_overlay_only():
+    """`require_approval` is NOT settings-writable — disabling an approval gate on
+    public posting must be a deliberate overlay-file edit, not an unconfirmed
+    settings_update()/dashboard call. Both values are rejected as an unknown key."""
+    assert _validate_contributor_worklog({"require_approval": False})
+    assert _validate_contributor_worklog({"require_approval": True})
 
 
 def test_base_config_file_matches_defaults():

--- a/tests/test_autonomy/test_contributor_worklog_config.py
+++ b/tests/test_autonomy/test_contributor_worklog_config.py
@@ -123,6 +123,60 @@ def test_knobs_reject_garbage_toward_defaults(config_dirs):
     assert cwc.knob_int(cfg, "max_held") == cwc.DEFAULTS["max_held"]
 
 
+def test_max_posts_per_day_knob(config_dirs):
+    """The rate cap reads through knob_int: honored when a valid positive int,
+    else coerced to the safe default — a bad value can NEVER uncap the poster."""
+    base, _ = config_dirs
+    base.write_text("max_posts_per_day: 5\n")
+    assert cwc.knob_int(cwc.load_config(), "max_posts_per_day") == 5
+    for bad in ("max_posts_per_day: 0", "max_posts_per_day: -1", "max_posts_per_day: true"):
+        base.write_text(bad + "\n")
+        assert (
+            cwc.knob_int(cwc.load_config(), "max_posts_per_day")
+            == cwc.DEFAULTS["max_posts_per_day"]
+        )
+
+
+# ── require_approval (fail-CLOSED: only an explicit boolean False disables) ──
+
+
+def test_require_approval_defaults_true(config_dirs):
+    """A fresh clone with no config keeps the human gate ON — never auto-posts."""
+    assert cwc.require_approval() is True
+
+
+def test_require_approval_explicit_false_disables(config_dirs):
+    base, _ = config_dirs
+    base.write_text("require_approval: false\n")
+    assert cwc.require_approval() is False
+
+
+def test_require_approval_fail_closed_on_garbage(config_dirs):
+    """Only an explicit boolean False disables the gate. A typo, a non-bool int,
+    or a stray string all keep human approval ON (fail-closed) — a public-repo
+    post must never go un-gated by a config accident."""
+    base, _ = config_dirs
+    for val in ("require_approval: maybe", "require_approval: 0", "require_approval: 'false'"):
+        base.write_text(val + "\n")
+        assert cwc.require_approval() is True, val
+
+
+def test_require_approval_overlay_disables(config_dirs):
+    """This install's overlay is how autonomous posting is opted into."""
+    base, overlay = config_dirs
+    base.write_text("mode: live\n")  # base keeps the default (approval required)
+    overlay.write_text("require_approval: false\n")
+    assert cwc.require_approval() is False
+
+
+def test_require_approval_read_live_no_cache(config_dirs):
+    base, _ = config_dirs
+    base.write_text("require_approval: false\n")
+    assert cwc.require_approval() is False
+    base.write_text("require_approval: true\n")
+    assert cwc.require_approval() is True  # next call re-reads
+
+
 # ── constants (imported by the MCP tool, drain, and approve-all exclusion) ─
 
 
@@ -161,6 +215,8 @@ def test_validator_accepts_valid_changes():
     assert _validate_contributor_worklog({"mode": "propose_only"}) == []
     assert _validate_contributor_worklog({"mode": "live"}) == []
     assert _validate_contributor_worklog({"retention_days": 60, "max_held": 5}) == []
+    assert _validate_contributor_worklog({"require_approval": False}) == []
+    assert _validate_contributor_worklog({"require_approval": True, "max_posts_per_day": 3}) == []
 
 
 def test_validator_rejects_bad_values():
@@ -169,6 +225,9 @@ def test_validator_rejects_bad_values():
     assert _validate_contributor_worklog({"retention_days": 0})
     assert _validate_contributor_worklog({"max_held": True})
     assert _validate_contributor_worklog({"bogus": 1})
+    assert _validate_contributor_worklog({"require_approval": "yes"})  # must be a boolean
+    assert _validate_contributor_worklog({"max_posts_per_day": 0})  # positive int only
+    assert _validate_contributor_worklog({"max_posts_per_day": True})
 
 
 def test_base_config_file_matches_defaults():

--- a/tests/test_db/test_approval_resolver_classes.py
+++ b/tests/test_db/test_approval_resolver_classes.py
@@ -49,6 +49,9 @@ _CASES = [
     ("timeout_auto_expire", "system"),
     # system: sentinel alarm clear (sentinel/dispatcher.py ~:1767)
     ("alarm_cleared", "system"),
+    # system: autonomous Genesis self-approval (mcp/health/contributor_issue.py,
+    # require_approval off) — NOT human-earned authority.
+    ("genesis:contributor-worklog", "system"),
     # system: housekeeping jobs
     ("cleanup:self-send-spam", "system"),
     ("cleanup:orphaned-pre-fix-approval", "system"),

--- a/tests/test_db/test_pending_issue_posts.py
+++ b/tests/test_db/test_pending_issue_posts.py
@@ -265,6 +265,43 @@ class TestCrud:
         assert (await pip.get_by_id(db, "p1"))["status"] == "posted"
 
     @pytest.mark.asyncio
+    async def test_count_posted_since(self, db):
+        """The rate-cap count: only status='posted' rows with posted_at >= since.
+        dry_run / held / rejected rows and out-of-window posts are excluded."""
+        # in-window posted (x2)
+        await pip.create(db, **{**_ROW, "id": "a", "request_id": "ra"})
+        await pip.mark_posted(
+            db, "a", issue_number=1, issue_url="u", posted_at="2026-08-07T12:00:00"
+        )
+        await pip.create(db, **{**_ROW, "id": "b", "request_id": "rb"})
+        await pip.mark_posted(
+            db, "b", issue_number=2, issue_url="u", posted_at="2026-08-07T13:00:00"
+        )
+        # out-of-window posted (before `since`)
+        await pip.create(db, **{**_ROW, "id": "old", "request_id": "ro"})
+        await pip.mark_posted(
+            db, "old", issue_number=3, issue_url="u", posted_at="2026-08-05T00:00:00"
+        )
+        # dry_run + held + rejected must NOT count
+        await pip.create(db, **{**_ROW, "id": "dr", "request_id": "rdr"})
+        await pip.mark_dry_run(db, "dr", dry_run_at="2026-08-07T12:30:00")
+        await pip.create(db, **{**_ROW, "id": "held", "request_id": "rh"})  # stays held
+        await pip.create(db, **{**_ROW, "id": "rej", "request_id": "rr"})
+        await pip.mark_rejected(db, "rej", rejected_at="2026-08-07T12:30:00")
+
+        since = "2026-08-07T00:00:00"
+        assert await pip.count_posted_since(db, since=since) == 2
+        # a since AFTER both posts → zero
+        assert await pip.count_posted_since(db, since="2026-08-08T00:00:00") == 0
+        # empty-table / first-run → zero (fresh install correctness)
+        async with aiosqlite.connect(":memory:") as fresh:
+            fresh.row_factory = aiosqlite.Row
+            from genesis.db.schema import create_all_tables
+
+            await create_all_tables(fresh)
+            assert await pip.count_posted_since(fresh, since=since) == 0
+
+    @pytest.mark.asyncio
     async def test_mark_dry_run_once(self, db):
         # propose_only path: an approved hold is dry-run-terminal — shadow-observed
         # once, marked 'dry_run', and NEVER posted (flipping the lever to 'live'

--- a/tests/test_mcp/test_contributor_issue.py
+++ b/tests/test_mcp/test_contributor_issue.py
@@ -302,6 +302,17 @@ async def test_bad_repo_error(db, live):
     assert res["status"] == "error"
 
 
+@pytest.mark.asyncio
+async def test_malformed_repo_components_rejected(db, live):
+    """repo must have non-empty owner AND name — a slug with an empty component
+    ('owner/', '/repo', '/', 'a//b') errors with NO row, so the drain never retries
+    an invalid `gh --repo` forever (Codex round-3 P2)."""
+    for bad in ("owner/", "/repo", "/", "a//b"):
+        res = await ci._impl_contributor_issue_propose(db, title="t title", body="b body", repo=bad)
+        assert res["status"] == "error", bad
+    assert await pip.list_held(db) == []
+
+
 # ── batch approve-all must NEVER sweep a held issue (public-repo write) ─────
 
 

--- a/tests/test_mcp/test_contributor_issue.py
+++ b/tests/test_mcp/test_contributor_issue.py
@@ -164,6 +164,23 @@ async def test_autonomous_pins_repo_to_default(db, live, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_autonomous_bare_default_repo_errors(db, live, monkeypatch):
+    """Codex P2 regression: if the configured owner is absent, _default_repo() is a
+    bare name (no owner/); the autonomous pin must NOT create a hold with a malformed
+    --repo — the final repo value is validated AFTER pinning, so this errors with no
+    row (else the drain retries an invalid `gh --repo` forever)."""
+    monkeypatch.setattr(ci, "require_approval", lambda: False)
+    monkeypatch.setattr(ci, "_default_repo", lambda: "GENesis-AGI")  # bare, owner absent
+    res = await ci._impl_contributor_issue_propose(
+        db, title="x title", body="y body", repo="WingedGuardian/GENesis-AGI"
+    )
+    assert res["status"] == "error"
+    assert await pip.list_held(db) == []
+    cur = await db.execute("SELECT COUNT(*) FROM approval_requests")
+    assert (await cur.fetchone())[0] == 0
+
+
+@pytest.mark.asyncio
 async def test_human_posture_keeps_curator_repo(db, live, monkeypatch):
     """With the human gate ON (default), a curator-supplied repo is kept — a human
     reviews the destination before it posts, so no pin is needed."""

--- a/tests/test_mcp/test_contributor_issue.py
+++ b/tests/test_mcp/test_contributor_issue.py
@@ -100,6 +100,81 @@ async def test_propose_only_message_hints_dry_run(db, monkeypatch):
     assert "dry-run" in res["message"].lower()
 
 
+# ── autonomous posture: require_approval=False auto-resolves at propose ─────
+
+
+@pytest.mark.asyncio
+async def test_auto_approved_when_require_approval_false(db, live, monkeypatch):
+    """With the human gate off (this install's opt-in), propose resolves its OWN
+    approval server-side so the drain treats the hold as approved without a human.
+    scan_prose still ran (the row exists = it passed). The approval never sits
+    `pending`, so it never surfaces as an approval request."""
+    monkeypatch.setattr(ci, "require_approval", lambda: False)
+    res = await _propose(db, title="Add a util test", body="Cover the empty-input case.")
+    assert res["status"] == "held"
+    assert res["auto_approved"] is True
+    assert "auto-approved" in res["message"].lower()
+
+    appr = await ar.get_by_id(db, res["request_id"])
+    assert appr["status"] == "approved"
+    assert appr["resolved_by"] == "genesis:contributor-worklog"
+
+
+@pytest.mark.asyncio
+async def test_requires_approval_leaves_pending(db, live):
+    """Default posture (require_approval True via the `live` fixture's config,
+    which omits the key → default True): the approval stays pending for a human."""
+    res = await _propose(db, title="Another task", body="Needs owner sign-off.")
+    assert res["status"] == "held"
+    assert res["auto_approved"] is False
+    assert (await ar.get_by_id(db, res["request_id"]))["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_auto_approved_propose_only_is_dry_run_terminal(db, monkeypatch):
+    """Auto-approve in propose_only: the approval is resolved, but the ROW is
+    stamped propose_only → the drain will dry-run it (terminal, 0 posts). Lets a
+    propose_only curator run self-complete for inspection with no human, no post."""
+    monkeypatch.setattr(ci, "effective_mode", lambda: "propose_only")
+    monkeypatch.setattr(ci, "load_config", lambda: {"max_held": 25})
+    monkeypatch.setattr(ci, "require_approval", lambda: False)
+    res = await _propose(db, title="Dry-run task", body="Should not post.")
+    assert res["status"] == "held"
+    assert res["auto_approved"] is True
+    assert res["mode"] == "propose_only"
+    assert "dry-run" in res["message"].lower()
+    row = await pip.get_by_id(db, res["pending_id"])
+    assert row["mode"] == "propose_only"  # dry-run-terminal stamp preserved
+    assert (await ar.get_by_id(db, res["request_id"]))["status"] == "approved"
+
+
+@pytest.mark.asyncio
+async def test_autonomous_pins_repo_to_default(db, live, monkeypatch):
+    """Under autonomous posting the UNTRUSTED curator cannot redirect the post to
+    another repo — the destination is pinned to this install's configured repo
+    (Genesis vets destination, not just content)."""
+    monkeypatch.setattr(ci, "require_approval", lambda: False)
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)
+    res = await ci._impl_contributor_issue_propose(
+        db, title="Redirect attempt", body="A clean body.", repo="attacker/other-repo"
+    )
+    assert res["status"] == "held"
+    assert res["repo"] == _REPO  # pinned, not attacker/other-repo
+    assert (await pip.get_by_id(db, res["pending_id"]))["repo"] == _REPO
+
+
+@pytest.mark.asyncio
+async def test_human_posture_keeps_curator_repo(db, live, monkeypatch):
+    """With the human gate ON (default), a curator-supplied repo is kept — a human
+    reviews the destination before it posts, so no pin is needed."""
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)
+    res = await ci._impl_contributor_issue_propose(
+        db, title="Other repo task", body="A clean body.", repo="WingedGuardian/GENesis-Voice"
+    )
+    assert res["status"] == "held"
+    assert res["repo"] == "WingedGuardian/GENesis-Voice"  # not pinned under human review
+
+
 # ── fail-closed sanitizer ─────────────────────────────────────────────────
 
 

--- a/tests/test_mcp/test_contributor_issue.py
+++ b/tests/test_mcp/test_contributor_issue.py
@@ -110,6 +110,9 @@ async def test_auto_approved_when_require_approval_false(db, live, monkeypatch):
     scan_prose still ran (the row exists = it passed). The approval never sits
     `pending`, so it never surfaces as an approval request."""
     monkeypatch.setattr(ci, "require_approval", lambda: False)
+    # Install-agnostic: autonomous mode pins repo to _default_repo(); on a config-less
+    # CI clone that's a bare name and would error. Pin it to a valid slug.
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)
     res = await _propose(db, title="Add a util test", body="Cover the empty-input case.")
     assert res["status"] == "held"
     assert res["auto_approved"] is True
@@ -138,6 +141,7 @@ async def test_auto_approved_propose_only_is_dry_run_terminal(db, monkeypatch):
     monkeypatch.setattr(ci, "effective_mode", lambda: "propose_only")
     monkeypatch.setattr(ci, "load_config", lambda: {"max_held": 25})
     monkeypatch.setattr(ci, "require_approval", lambda: False)
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)  # install-agnostic (see above)
     res = await _propose(db, title="Dry-run task", body="Should not post.")
     assert res["status"] == "held"
     assert res["auto_approved"] is True


### PR DESCRIPTION
## Summary

Adds an **opt-in autonomous posting** posture to the Contributor Work-Log so a curator campaign can post privacy-vetted newcomer issues to the public repo without a per-item human approval — governed by three guards the user asked for: **Genesis is the gate** (the fail-closed `scan_prose` privacy scan still runs on every draft), a **cautious-rollout post-rate cap**, and the existing **kill switch**.

Ships SAFE by construction: `require_approval` defaults `true`, so a fresh clone still requires human approval and never auto-posts to its public repo.

## What changed

- **`require_approval` lever** (`contributor_worklog_config.py`) — FAIL-CLOSED: only an explicit boolean `false` disables the human gate (`get("require_approval", True) is not False`); a missing key / typo / non-bool keeps approval ON. Default `True`.
- **Auto-resolve at propose** (`mcp/health/contributor_issue.py`) — when `require_approval` is false, the propose tool resolves its OWN approval server-side (`resolved_by="genesis:contributor-worklog"`), so the drain posts without a human. `scan_prose` is unchanged and still runs *before* any row is created — nothing egresses unscanned. The row never sits `pending`, so it never surfaces as an approval request.
- **`max_posts_per_day` rate cap** (`contributor_issue_watcher.py` drain + new `pending_issue_posts.count_posted_since` CRUD) — enforced per-row, after the idempotent adopt branch and before the create, as a rolling-24h `status='posted'` count. Bounds a single drain tick (each `mark_posted` commits, so the next row's count includes it). `knob_int`-coerced so a mistyped/0/negative value can never uncap. Mirrors the `autonomous_email_sends` rate-limit precedent; no new store.
- **Settings validator** accepts the two new knobs (`require_approval` bool, `max_posts_per_day` positive int).
- The STOP switch is `mode: off` / `GENESIS_CONTRIBUTOR_WORKLOG_DISABLED` (freezes the drain, including already-approved held rows) — documented as the brake; `require_approval` is a posture flag, not an emergency stop.

## Design notes

- The auto-resolve seam keeps the approval row (audit trail) and the whole existing drain/dedup/dry-run machinery intact — the change is reversible by flipping one flag. `resolve()` has no notify-on-approve side effect.
- Dry-run-terminal invariant preserved: `require_approval=false` + `propose_only` auto-approves but the row is stamped `propose_only`, so the drain dry-runs it (0 posts) — lets a propose_only curator run self-complete for inspection.
- Generalizable: default-safe for any clone; no install-specific literals; retention already covered (existing prune); the cap reuses the existing table.

## Testing

- [x] ruff clean on all changed files.
- [x] **74 targeted tests pass** (config 24, CRUD 17, propose 16, drain 17), incl. new coverage: `require_approval` fail-closed on garbage, `max_posts_per_day` knob coercion, validator accept/reject, `count_posted_since` (window + dry-run/held exclusion + empty-state), auto-resolve (live / propose_only-dry-run / requires-approval-pending), rate cap (defers-at-limit / allows-under / bounds-single-tick / ignores-dry-runs / adopt-not-blocked).
- [x] **verify-RED** on both novel behaviors: neutralizing the cap fails the two blocking cap tests; a fail-open `require_approval` fails the fail-closed test.
- Reviews: genesis-architect (design + post-impl) + genesis-security-reviewer.

## Deploy

Runtime code (drain) → server restart; MCP tool (auto-resolve) → next CC session. **Restart the server before/with the MCP tool going live** so the rate cap is never absent while auto-approve is active. Config defaults ship in `config/contributor_worklog.yaml`; this install opts in via the gitignored overlay (`require_approval: false`, `max_posts_per_day`, `mode: live`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
