### PR TITLE
fix(dashboard): surface fail-open data lies — partial errors, vitals throughput, scheduler-probe warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   error, and fails loud (`unknown`) if the liveness data can't be read, never green.
   Thresholds are conservative (3h floor) so a normal quiet system never false-alarms.
 
+- **The Errors view no longer shows a clean "0 errors" when a data source is
+  actually down.** The unified-errors endpoint queried each source (events, dead
+  letters, deferred work, resolutions, alerts) behind a silent catch, so a DB/FTS
+  outage returned HTTP 200 with zero counts and read as "data is clean". It now
+  reports which sources failed (`partial` / `sources_failed`); the Errors tab shows
+  a "data may be incomplete" banner and suppresses the clean-state check, and the
+  overview attention list flags the degrade.
+- **Operational Vitals no longer reports embedding throughput as `0` on a query
+  failure.** A failed SQLite read for "Points written/24h" / "Pending queue"
+  previously wrote a literal `0`, indistinguishable from a real zero. It now
+  degrades to `—` with a `throughput_error` reason, distinct from Qdrant
+  reachability.
+- **A scheduler-heartbeat probe that cannot evaluate now surfaces a WARNING event
+  instead of failing silent.** The probe's exception path previously returned
+  `healthy` with no signal; it now emits a WARNING (visible on the Errors tab)
+  while deliberately keeping the probe result `healthy`, so the remediation engine
+  does not treat "can't evaluate" as a downed scheduler and page hourly.
+
 ### Changed
 
 - **Executor Gate 2 (`17_executor_review`) leads with paid DeepSeek V4-pro.**

--- a/src/genesis/dashboard/routes/errors.py
+++ b/src/genesis/dashboard/routes/errors.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 
 from flask import jsonify, request
 
 from genesis.dashboard._blueprint import _async_route, blueprint
+
+logger = logging.getLogger(__name__)
 
 
 @blueprint.route("/api/genesis/unified-errors")
@@ -20,7 +23,10 @@ async def unified_errors():
 
     rt = GenesisRuntime.instance()
     if not rt.is_bootstrapped or rt.db is None:
-        return jsonify({"groups": [], "active_alerts": [], "totals": {"events": 0, "dead_letters": 0, "deferred_failures": 0}})
+        # Backend not ready / DB unavailable: no error data could be loaded, so this
+        # is NOT a clean "0 errors" — flag it partial so the Errors tab shows the
+        # degraded banner instead of "data is clean".
+        return jsonify({"groups": [], "active_alerts": [], "totals": {"events": 0, "dead_letters": 0, "deferred_failures": 0}, "partial": True, "sources_failed": ["backend unavailable"]})
 
     since = request.args.get("since")
     if not since:
@@ -35,6 +41,9 @@ async def unified_errors():
     event_count = 0
     dl_count = 0
     dw_count = 0
+    # Each data source is queried independently; a failed source must be SURFACED
+    # (partial/sources_failed) so a DB/FTS outage can't read as a clean "0 errors".
+    sources_failed: list[str] = []
 
     groups: list[dict] = []
     try:
@@ -57,7 +66,8 @@ async def unified_errors():
                     "still_active": g["last_seen"] >= thirty_min_ago,
                 })
     except Exception:
-        pass
+        logger.warning("unified-errors: events source failed", exc_info=True)
+        sources_failed.append("events")
 
     try:
         dl_items = await dl_crud.query_recent(
@@ -90,7 +100,8 @@ async def unified_errors():
                 g["still_active"] = g["last_seen"] >= thirty_min_ago
             groups.extend(dl_groups.values())
     except Exception:
-        pass
+        logger.warning("unified-errors: dead_letters source failed", exc_info=True)
+        sources_failed.append("dead_letters")
 
     try:
         dw_items = await dw_crud.query_failed(
@@ -124,7 +135,8 @@ async def unified_errors():
                 g["still_active"] = g["last_seen"] >= thirty_min_ago
             groups.extend(dw_groups.values())
     except Exception:
-        pass
+        logger.warning("unified-errors: deferred_work source failed", exc_info=True)
+        sources_failed.append("deferred_work")
 
     try:
         cursor = await rt.db.execute("SELECT error_group_key, resolved_by, resolved_at, notes FROM resolved_errors")
@@ -137,7 +149,8 @@ async def unified_errors():
                 g["resolved_by"] = r["resolved_by"]
                 g["resolved_at"] = r["resolved_at"]
     except Exception:
-        pass
+        logger.warning("unified-errors: resolutions overlay failed", exc_info=True)
+        sources_failed.append("resolutions")
 
     groups.sort(key=lambda g: g["last_seen"], reverse=True)
 
@@ -146,7 +159,8 @@ async def unified_errors():
         from genesis.mcp.health_mcp import _impl_health_alerts
         active_alerts = await _impl_health_alerts(active_only=True)
     except Exception:
-        pass
+        logger.warning("unified-errors: active_alerts source failed", exc_info=True)
+        sources_failed.append("alerts")
 
     return jsonify({
         "groups": groups[:limit],
@@ -156,6 +170,8 @@ async def unified_errors():
             "dead_letters": dl_count,
             "deferred_failures": dw_count,
         },
+        "partial": bool(sources_failed),
+        "sources_failed": sources_failed,
     })
 
 

--- a/src/genesis/dashboard/routes/vitals.py
+++ b/src/genesis/dashboard/routes/vitals.py
@@ -148,7 +148,18 @@ async def operational_vitals():
 
 async def _build_qdrant_section(rt) -> dict:
     """Qdrant vector store: collections, points, real embedding throughput."""
-    section: dict = {"collections": [], "total_points": 0, "error": None}
+    # pending_queue/embedded_24h read from SQLite (a DIFFERENT dependency than
+    # Qdrant reachability, tracked by `error`); throughput_error surfaces a SQLite
+    # read failure so a failed query renders "—" + a reason, never a literal 0 that
+    # is indistinguishable from a real zero.
+    section: dict = {
+        "collections": [],
+        "total_points": 0,
+        "error": None,
+        "pending_queue": None,
+        "embedded_24h": None,
+        "throughput_error": None,
+    }
     try:
         async with httpx.AsyncClient(timeout=5) as client:
             collections_url = qdrant_collections_url()
@@ -210,7 +221,9 @@ async def _build_qdrant_section(rt) -> dict:
             row = await cursor.fetchone()
             section["pending_queue"] = row[0] if row else 0
         except Exception:
-            pass
+            section["pending_queue"] = None
+            section["throughput_error"] = "query failed"
+            logger.warning("Failed to query pending_embeddings queue", exc_info=True)
 
         # Real embedding throughput from activity_log (not just pending_embeddings)
         try:
@@ -222,7 +235,9 @@ async def _build_qdrant_section(rt) -> dict:
             row = await cursor.fetchone()
             section["embedded_24h"] = row[0] if row else 0
         except Exception:
-            section["embedded_24h"] = 0
+            section["embedded_24h"] = None
+            section["throughput_error"] = "query failed"
+            logger.warning("Failed to query embedding throughput", exc_info=True)
 
     return section
 

--- a/src/genesis/dashboard/templates/genesis_errors.html
+++ b/src/genesis/dashboard/templates/genesis_errors.html
@@ -22,6 +22,8 @@
         groups: [],
         activeAlerts: [],
         totals: { events: 0, dead_letters: 0, deferred_failures: 0 },
+        partial: false,
+        sourcesFailed: [],
         loading: true,
         error: null,
         lastSuccess: null,
@@ -70,6 +72,8 @@
               this.groups = data.groups || [];
               this.activeAlerts = data.active_alerts || [];
               this.totals = data.totals || { events: 0, dead_letters: 0, deferred_failures: 0 };
+              this.partial = data.partial || false;
+              this.sourcesFailed = data.sources_failed || [];
               this.error = null;
               this.finishFetch();
             } else {
@@ -233,6 +237,13 @@
 
         get totalErrors() {
           return this.totals.events + this.totals.dead_letters + this.totals.deferred_failures;
+        },
+
+        // The "data is clean" empty state is honest ONLY when every source loaded.
+        // A partial fetch that returned zero groups must not read as clean.
+        get showCleanState() {
+          return !this.loading && this.groups.length === 0
+            && this.fetchState !== 'fetch_error' && !this.partial;
         },
 
         get subsystems() {
@@ -642,6 +653,14 @@
       </div>
     </div>
 
+    <!-- Partial-data banner — one or more error sources did not load, so the
+         counts below are incomplete. -->
+    <div class="error-banner" x-show="$store.genesisErrors.partial" x-transition
+         style="background:#7a5c00; color:#fff;">
+      <span class="material-symbols-outlined">warning</span>
+      <span x-text="'Error data may be incomplete — sources not loaded: ' + ($store.genesisErrors.sourcesFailed || []).join(', ')"></span>
+    </div>
+
     <!-- Summary bar -->
     <div class="summary-bar" x-show="!$store.genesisErrors.loading">
       <div class="summary-stat">
@@ -789,7 +808,7 @@
     </div>
 
     <!-- Empty state -->
-    <div class="empty-state" x-show="!$store.genesisErrors.loading && $store.genesisErrors.groups.length === 0 && $store.genesisErrors.fetchState !== 'fetch_error'">
+    <div class="empty-state" x-show="$store.genesisErrors.showCleanState">
       <span class="material-symbols-outlined">check_circle</span>
       <span x-text="'No errors matching the last ' + $store.genesisErrors.filters.timeRange + '. Current data is clean.'"></span>
     </div>

--- a/src/genesis/dashboard/templates/partials/tabs/internals.html
+++ b/src/genesis/dashboard/templates/partials/tabs/internals.html
@@ -942,10 +942,6 @@
                         </span>
                       </div>
                     </template>
-                    <div style="display: flex; gap: 1rem; margin-top: 0.4rem; opacity: 0.8; font-size: 0.7rem;">
-                      <span x-text="'Points written/24h: ' + (v.qdrant?.embedded_24h ?? '—')"></span>
-                      <span x-text="'Pending queue: ' + (v.qdrant?.pending_queue ?? '—')"></span>
-                    </div>
                     <template x-if="(v.qdrant?.warnings || []).length > 0">
                       <div style="margin-top: 0.4rem;">
                         <template x-for="w in v.qdrant.warnings" :key="w">
@@ -955,6 +951,17 @@
                       </div>
                     </template>
                   </div>
+                </template>
+                <!-- Embedding throughput is read from SQLite — a DIFFERENT dependency
+                     than Qdrant reachability — so it renders regardless of the Qdrant
+                     error state and surfaces its own throughput_error. -->
+                <div style="display: flex; gap: 1rem; margin-top: 0.4rem; opacity: 0.8; font-size: 0.7rem;">
+                  <span x-text="'Points written/24h: ' + (v.qdrant?.embedded_24h ?? '—')"></span>
+                  <span x-text="'Pending queue: ' + (v.qdrant?.pending_queue ?? '—')"></span>
+                </div>
+                <template x-if="v.qdrant?.throughput_error">
+                  <div style="font-size: 0.68rem; color: #f0ad4e; margin-top: 0.2rem;"
+                       x-text="'Throughput unavailable: ' + v.qdrant.throughput_error"></div>
                 </template>
               </div>
             </div>

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -24,7 +24,7 @@
 
         configFiles: [],
         // providerActivity moved to operationalVitals
-        errorSummary: { groups: [], active_alerts: [], totals: { events: 0, dead_letters: 0, deferred_failures: 0 } },
+        errorSummary: { groups: [], active_alerts: [], totals: { events: 0, dead_letters: 0, deferred_failures: 0 }, partial: false, sources_failed: [] },
         budgets: [],
         // providerHealthSummary removed — provider data now in health.api_keys
         routingConfig: null,
@@ -4414,6 +4414,10 @@
           }
           if (activeGroups > 0) {
             items.push({ level: "warning", title: `${activeGroups} active error group${activeGroups === 1 ? "" : "s"}`, detail: "grouped warnings/errors across events, dead letters, or deferred work", href: "/genesis/errors" });
+          }
+          if (this.errorSummary.partial) {
+            const failed = (this.errorSummary.sources_failed || []).join(", ");
+            items.push({ level: "warning", title: "Error data incomplete", detail: `some error sources did not load (${failed}); counts may understate reality`, href: "/genesis/errors" });
           }
           if ((this.health.queues?.dead_letters || 0) > 0) {
             items.push({ level: "critical", title: `${this.health.queues.dead_letters} dead letters`, detail: "requests exhausted all fallback providers; open the errors view to inspect", href: "/genesis/errors" });

--- a/src/genesis/observability/health.py
+++ b/src/genesis/observability/health.py
@@ -301,6 +301,35 @@ async def probe_scheduler_heartbeats(
         )
     except Exception as exc:
         latency = (time.monotonic() - start) * 1000
+        # Surface the eval failure LOUDLY as a WARNING event (which persists to the
+        # events table and shows on the Errors tab) — but keep the ProbeResult
+        # HEALTHY. This probe's status is consumed ONLY by the remediation engine,
+        # which treats any non-HEALTHY status identically to DOWN (remediation.py
+        # _evaluate) and would fire the hourly scheduler_heartbeat_alert *outreach*
+        # on this "can't evaluate" branch. Emitting the event gives honest signal
+        # without that pager storm; flipping the status would only add noise (this
+        # probe feeds no dashboard tile).
+        # Not cooldown-gated: a persistent "can't evaluate" fault re-emits once per
+        # awareness tick, but repeats collapse under the Errors-tab event grouping
+        # and ride normal event pruning. Add a last-emitted gate only if that volume
+        # ever proves excessive (it hasn't — this branch fires only when job_health
+        # itself is unreadable, a rare hard fault).
+        try:
+            from genesis.observability.types import Severity, Subsystem
+            from genesis.runtime import GenesisRuntime
+
+            rt = GenesisRuntime.peek()
+            if rt is not None and rt.event_bus is not None:
+                await rt.event_bus.emit(
+                    Subsystem.HEALTH,
+                    Severity.WARNING,
+                    "scheduler_heartbeat_probe_error",
+                    f"scheduler-heartbeat probe could not evaluate: {exc}",
+                )
+        except Exception:
+            logger.debug(
+                "scheduler-heartbeat probe error-event emit failed", exc_info=True
+            )
         return ProbeResult(
             name="scheduler_heartbeats",
             status=ProbeStatus.HEALTHY,  # can't evaluate ≠ schedulers dead

--- a/tests/test_dashboard/test_errors_api.py
+++ b/tests/test_dashboard/test_errors_api.py
@@ -30,6 +30,21 @@ def _mock_rt(*, bootstrapped=True, db=True):
     return rt
 
 
+def _async_db():
+    """A db whose execute()/fetchall() are awaitable and return no rows.
+
+    The plain-MagicMock db in _mock_rt makes the resolutions overlay query
+    (``await rt.db.execute(...)``) raise, which the partial-tracking counts as a
+    failed source. Tests that assert on ``sources_failed`` need the resolutions
+    query to genuinely succeed so the ONE source under test is isolated.
+    """
+    db = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchall = AsyncMock(return_value=[])
+    db.execute = AsyncMock(return_value=cursor)
+    return db
+
+
 class TestUnifiedErrors:
     def test_not_bootstrapped(self, client):
         with patch("genesis.runtime.GenesisRuntime") as MockRT:
@@ -38,6 +53,9 @@ class TestUnifiedErrors:
             data = resp.get_json()
             assert data["groups"] == []
             assert data["totals"]["events"] == 0
+            # A not-ready backend loaded no error data — it must NOT read as clean.
+            assert data["partial"] is True
+            assert data["sources_failed"]
 
     def test_grouped_response(self, client):
         mock_groups = [
@@ -129,3 +147,44 @@ class TestUnifiedErrors:
             data = resp.get_json()
             assert data["totals"]["deferred_failures"] == 1
             assert any(g["source"] == "deferred_work" for g in data["groups"])
+
+
+class TestPartialDegradation:
+    """A data-source outage must be SURFACED (partial/sources_failed), never a
+    silent HTTP-200 '0 errors' that reads clean while the DB/FTS is down."""
+
+    def test_partial_flag_on_source_failure(self, client):
+        """One failing source → partial=True, that source named, endpoint still
+        200 with the OTHER sources intact (a partial view beats none)."""
+        rt = _mock_rt()
+        rt.db = _async_db()
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch("genesis.db.crud.events.query_grouped_errors", new_callable=AsyncMock, side_effect=RuntimeError("FTS down")),
+            patch("genesis.db.crud.dead_letter.query_recent", new_callable=AsyncMock, return_value=[]),
+            patch("genesis.db.crud.deferred_work.query_failed", new_callable=AsyncMock, return_value=[]),
+            patch("genesis.mcp.health_mcp._impl_health_alerts", new_callable=AsyncMock, return_value=[]),
+        ):
+            MockRT.instance.return_value = rt
+            resp = client.get("/api/genesis/unified-errors")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert data["partial"] is True
+            assert data["sources_failed"] == ["events"]
+
+    def test_no_partial_when_all_sources_ok(self, client):
+        """Healthy path → partial=False, sources_failed empty."""
+        rt = _mock_rt()
+        rt.db = _async_db()
+        with (
+            patch("genesis.runtime.GenesisRuntime") as MockRT,
+            patch("genesis.db.crud.events.query_grouped_errors", new_callable=AsyncMock, return_value=[]),
+            patch("genesis.db.crud.dead_letter.query_recent", new_callable=AsyncMock, return_value=[]),
+            patch("genesis.db.crud.deferred_work.query_failed", new_callable=AsyncMock, return_value=[]),
+            patch("genesis.mcp.health_mcp._impl_health_alerts", new_callable=AsyncMock, return_value=[]),
+        ):
+            MockRT.instance.return_value = rt
+            resp = client.get("/api/genesis/unified-errors")
+            data = resp.get_json()
+            assert data["partial"] is False
+            assert data["sources_failed"] == []

--- a/tests/test_dashboard/test_vitals_qdrant_section.py
+++ b/tests/test_dashboard/test_vitals_qdrant_section.py
@@ -1,0 +1,57 @@
+"""Tests for the Qdrant vitals section's honest degrade on a SQLite outage.
+
+The embedding-throughput reads (pending_queue / embedded_24h) hit SQLite — a
+DIFFERENT dependency than Qdrant reachability. On a query failure they must NOT
+report literal ``0`` (indistinguishable from a real zero, a green-reading lie);
+they degrade to ``None`` + a dedicated ``throughput_error``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from genesis.dashboard.routes.vitals import _build_qdrant_section
+
+
+class _NoQdrant:
+    """httpx.AsyncClient stand-in whose context entry fails, so the Qdrant HTTP
+    block is skipped (its error is set) and the SQLite throughput reads — the unit
+    under test, which run AFTER and independent of the Qdrant block — still run."""
+
+    async def __aenter__(self):
+        raise RuntimeError("no qdrant in test")
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _rt(*, execute):
+    rt = MagicMock()
+    db = MagicMock()
+    db.execute = execute
+    rt.db = db
+    return rt
+
+
+@pytest.mark.asyncio
+async def test_throughput_failure_is_none_not_zero():
+    with patch("genesis.dashboard.routes.vitals.httpx.AsyncClient", return_value=_NoQdrant()):
+        rt = _rt(execute=AsyncMock(side_effect=RuntimeError("db locked")))
+        section = await _build_qdrant_section(rt)
+    assert section["embedded_24h"] is None
+    assert section["pending_queue"] is None
+    assert section["throughput_error"]
+
+
+@pytest.mark.asyncio
+async def test_throughput_healthy_reports_counts():
+    cursor = MagicMock()
+    cursor.fetchone = AsyncMock(return_value=[7])
+    with patch("genesis.dashboard.routes.vitals.httpx.AsyncClient", return_value=_NoQdrant()):
+        rt = _rt(execute=AsyncMock(return_value=cursor))
+        section = await _build_qdrant_section(rt)
+    assert section["embedded_24h"] == 7
+    assert section["pending_queue"] == 7
+    assert section["throughput_error"] is None

--- a/tests/test_observability/test_health.py
+++ b/tests/test_observability/test_health.py
@@ -504,3 +504,31 @@ class TestProbeSchedulerHeartbeats:
         assert result.status == ProbeStatus.HEALTHY
         assert "no live runtime" in result.message
         inst.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_probe_exception_emits_warning_but_stays_healthy(self):
+        """A genuine probe-eval error is SURFACED as a WARNING event (which lands
+        on the Errors tab via the event bus) but the ProbeResult stays HEALTHY:
+        remediation treats any non-HEALTHY status identically to DOWN and would
+        fire an hourly outreach storm on a 'can't evaluate' branch. Honest signal,
+        zero new pager noise."""
+        from genesis.observability.types import Severity, Subsystem
+
+        class _RaisingJH:
+            def get(self, *a, **k):
+                raise RuntimeError("job_health corrupt")
+
+        bus = MagicMock()
+        bus.emit = AsyncMock()
+        stub_rt = MagicMock()
+        stub_rt.event_bus = bus
+        with patch("genesis.runtime.GenesisRuntime.peek", return_value=stub_rt):
+            result = await probe_scheduler_heartbeats(_RaisingJH(), clock=FROZEN_CLOCK)
+        assert result.status == ProbeStatus.HEALTHY
+        assert bus.emit.await_count == 1
+        # emit(subsystem, severity, event_type, message, **details) — positional
+        # or kw, so check the whole passed-value set.
+        args, kwargs = bus.emit.call_args
+        passed = {*args, *kwargs.values()}
+        assert Severity.WARNING in passed
+        assert Subsystem.HEALTH in passed


### PR DESCRIPTION
Third PR in the dashboard-honesty batch (after ego #1422 and surplus #1444): stop three **fail-open "silent green"** data lies so a degraded backend can't read as clean.

## Changes

**1. `unified_errors()` — partial-data surfacing.** Each data source (events, dead letters, deferred work, resolutions, alerts) was queried behind a silent `except: pass`, so a DB/FTS outage returned HTTP 200 with zero counts and read as "data is clean". Now each failure is tracked → additive `partial` / `sources_failed` (existing `groups`/`totals`/`active_alerts` shape untouched). The Errors tab shows a "data may be incomplete" banner and routes the clean-state check through a `showCleanState` getter (so a partial fetch with zero groups can't render "clean"); the not-ready early return is flagged partial too; the overview attention list flags the degrade.

**2. `_build_qdrant_section()` — no literal `0` on failure.** The SQLite embedding-throughput reads (`embedded_24h`, `pending_queue`) wrote a literal `0` on a query failure, indistinguishable from a real zero. Now they degrade to `None` + a dedicated `throughput_error`, kept distinct from Qdrant reachability (`error`), and the view renders the throughput row regardless of Qdrant state.

**3. `probe_scheduler_heartbeats()` exception path — surface, don't swallow.** Previously returned `healthy` with no signal. Now it emits a best-effort WARNING event (visible on the Errors tab) while **deliberately keeping the probe `healthy`**: this probe's status is consumed only by the remediation engine, which treats any non-`healthy` identically to `down` and would fire an hourly alert on a "can't evaluate" branch. Honest signal, no pager noise.

## Verification
- RED-first observed (5 tests failed for the right reasons), then **49 passing** across `test_errors_api.py`, `test_vitals_qdrant_section.py`, and the full `test_health.py` probe suite (regression clean). Ruff clean.
- genesis-architect adversarial review: DONE_WITH_CONCERNS, no CRITICAL. SHOULD-FIX (throughput block re-conflated with Qdrant reachability in the view) and one LOW (not-ready read clean) both fixed; one LOW (emit cooldown) doc-accepted with a falsifiable trigger.
- Live E2E on the running server to follow.

Ledger: d2ef1efce7304adfbfa1664c7a497b05