### PR TITLE
feat(hooks): nudge when a session's memory MCP runs stale code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **A per-prompt nudge when a session's memory MCP is running stale code.** Each
+  Claude Code session's MCP subprocesses snapshot their code at spawn and never
+  reload, so a deploy landing mid-session leaves recall — and its current security
+  read-exclusions — on the old code until the session restarts (there is no
+  auto-restart). The UserPromptSubmit hook now emits a one-line nudge when this
+  session's MCP predates the last successful deploy, reusing the exact
+  `commit_identity.is_stale` verdict the dashboard stale-code badge uses (a session
+  *ahead* of the deploy, e.g. a manual `git pull`, is never flagged). Throttled per
+  session and fail-open: a fresh session stays silent, and any read/parse miss emits
+  nothing.
+
 ### Fixed
 
 - **The dashboard Surplus health tile no longer reads green while the surplus

--- a/scripts/genesis_urgent_alerts.py
+++ b/scripts/genesis_urgent_alerts.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
-"""UserPromptSubmit hook: temporal awareness + bookmark + shelve hints.
+"""UserPromptSubmit hook: per-prompt session-state tags.
 
-Runs before each user message is processed. Three responsibilities:
-1. Inject absolute timestamps for temporal awareness (session clock)
-2. Buffer user messages for session bookmarks (rolling last 5)
-3. Detect /shelve or /unshelve and inject soft hint for LLM
+Runs before each user message is processed. Emits one-line session-state
+tags to stdout (the harness prepends them to the prompt as context) and
+maintains session-scoped state files:
+1. Absolute timestamp / session clock (temporal awareness)
+2. Charter drift tag ([Charter: … | open: N]; chartered sessions only)
+3. MCP stale-code nudge — only when THIS session's MCP subprocesses run code
+   OLDER than the last deploy (they snapshot code at spawn and never reload;
+   there is no auto-restart, so the user is nudged to restart); throttled
+4. Rolling buffer of the last few user messages (for session bookmarks)
+5. /shelve|/unshelve soft hint
 
-This hook does NOT inject alerts into the prompt. Alerts are delivered
-via the Telegram outreach pipeline; injecting them into the CC session
-prompt was a duplicate channel that caused identical alerts to flood
-every prompt. Removed 2026-04-09. Filename retained for now to avoid
-churn in .claude/settings.json — TODO: rename to genesis_session_state.py
-in a follow-up cleanup.
+This hook does NOT inject Telegram-style OUTREACH alerts into the prompt —
+those flooded every prompt as a duplicate channel and were removed
+2026-04-09 (delivered via the outreach pipeline instead). The tags above are
+lightweight session STATE, each fail-open, not alerts. Filename retained to
+avoid churn in .claude/settings.json — TODO: rename to
+genesis_session_state.py in a follow-up cleanup.
 
 Reads hook input from stdin as JSON:
   {"session_id": "...", "prompt": "...", ...}
@@ -49,6 +55,11 @@ _MAX_BUFFER_LINES = 5
 _MAX_MSG_LENGTH = 200
 
 _SHELVE_PATTERN = re.compile(r"/(?:shelve|unshelve)\b", re.IGNORECASE)
+
+# Re-nudge a stale session at most this often (staleness persists until the
+# session restarts, but a single scrolled-away banner is easy to miss, so a
+# quiet periodic reminder is worth more than a once-ever one).
+_STALENESS_COOLDOWN_S = 3 * 3600
 
 
 def _get_session_start() -> str:
@@ -198,6 +209,175 @@ def _emit_charter_tag(session_id: str) -> None:
         return  # fail-open: a tag miss must never surface as an error
 
 
+def _claude_ancestor_pid() -> int | None:
+    """The owning interactive ``claude`` session pid for this hook, or None.
+
+    This hook runs as ``claude → genesis-hook launcher → python``, so the
+    session's ``claude`` process is an ANCESTOR (not necessarily the direct
+    parent). Walk the ppid chain (bounded, never loops on a cycle) to the first
+    ``comm == "claude"``. ``/proc/<pid>/{comm,stat}`` are world-readable — no
+    ptrace gate. Fail-open None on any read/parse failure (a nudge miss must
+    never cost the user)."""
+    pid = os.getpid()
+    for _ in range(16):
+        try:
+            comm = Path(f"/proc/{pid}/comm").read_text().strip()
+        except OSError:
+            return None
+        if comm == "claude":
+            return pid
+        try:
+            # After the last ')' (comm may contain spaces/')'): state=field3=idx0,
+            # ppid=field4=idx1.
+            ppid = int(Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[1])
+        except (OSError, ValueError, IndexError):
+            return None
+        if ppid <= 1 or ppid == pid:
+            return None
+        pid = ppid
+    return None
+
+
+def _last_successful_deploy(db_path: Path) -> tuple[str, str] | None:
+    """``(completed_at, new_commit)`` of the newest successful deploy, or None.
+
+    Read-only stdlib sqlite3 (``mode=ro`` URI — WAL-aware, never ``immutable=1``
+    which misses un-checkpointed writes), tight budget: runs on EVERY prompt.
+    Mirrors ``db.crud.update_history.last_successful_update`` exactly (same
+    ``status='success'`` filter + ``datetime(completed_at)`` ordering) but
+    stdlib-only so the hook never imports aiosqlite. None on any failure."""
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=0.5)
+        try:
+            conn.execute("PRAGMA busy_timeout=300")
+            row = conn.execute(
+                "SELECT completed_at, new_commit FROM update_history "
+                "WHERE status = 'success' ORDER BY datetime(completed_at) DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+    if not row or not row[0] or not row[1]:
+        return None
+    return str(row[0]), str(row[1])
+
+
+def _staleness_message(
+    spawn_commit: str, spawn_at: str, deploy: tuple[str, str] | None
+) -> str | None:
+    """The nudge line if this session's MCP code is BEHIND the deploy, else None.
+
+    ``deploy`` is ``(completed_at, new_commit)``. Delegates the verdict to
+    ``commit_identity.is_stale`` — the EXACT same leaf the dashboard stale-code
+    badge and the Part-A guard use, so all three can never disagree (a session
+    AHEAD of the last recorded deploy, e.g. a manual ``git pull``, is NOT
+    flagged). Pure (no IO) so the verdict+wording is unit-testable."""
+    from genesis.observability.commit_identity import is_stale
+
+    if not deploy:
+        return None
+    completed_at, new_commit = deploy
+    # Defense-in-depth: this value becomes LLM-visible prompt context, so only ever
+    # interpolate a real short/full SHA. update_history is deploy-pipeline-only today
+    # (no user-facing writer), but a hex guard removes the vector entirely rather
+    # than trusting provenance. Also fail-open (skip) on a malformed commit.
+    if not re.fullmatch(r"[0-9a-fA-F]{4,64}", new_commit or ""):
+        return None
+    if not is_stale(spawn_commit, spawn_at, completed_at, new_commit):
+        return None
+    date = str(completed_at)[:10]  # YYYY-MM-DD
+    return (
+        f"[⚠ Memory MCP stale: this session's MCP predates the {date} deploy "
+        f"(now {new_commit[:8]}) — restart the session to refresh recall "
+        f"+ security read-exclusions]"
+    )
+
+
+def _staleness_throttled(session_id: str, now: datetime) -> bool:
+    """True if a staleness nudge fired within the cooldown for this session.
+
+    Best-effort: an unreadable/absent/garbled marker → not throttled (emit),
+    consistent with the fail-open posture (better a repeat nudge than a missed
+    stale-code warning)."""
+    marker = _GENESIS_DIR / "sessions" / session_id / "staleness_last_nudge"
+    try:
+        last = datetime.fromisoformat(marker.read_text().strip())
+    except (OSError, ValueError):
+        return False
+    return (now - last).total_seconds() < _STALENESS_COOLDOWN_S
+
+
+def _record_staleness_nudge(session_id: str, now: datetime) -> bool:
+    """Stamp the per-session cooldown marker. Returns True iff it persisted.
+
+    A persistently unwritable ``~/.genesis/sessions/`` would otherwise let the
+    nudge print on EVERY prompt — the absent/unreadable-marker path in
+    ``_staleness_throttled`` reads as "not throttled" (fail-open toward emitting).
+    Returning False lets the caller SUPPRESS instead of spam, so a broken
+    filesystem degrades to silence, not a per-prompt banner."""
+    marker = _GENESIS_DIR / "sessions" / session_id / "staleness_last_nudge"
+    try:
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(now.isoformat())
+        return True
+    except OSError:
+        return False
+
+
+def _emit_staleness_nudge(session_id: str, now: datetime) -> None:
+    """One-line nudge when THIS session's MCP subprocesses run code OLDER than
+    the last deploy.
+
+    Each FastMCP subprocess snapshots its code at spawn and NEVER reloads; a
+    deploy landing MID-session (update.sh restarts genesis-server, NOT a live
+    session's MCPs) leaves recall — and its current security read-exclusions —
+    on stale code until the user restarts the session. There is no auto-restart,
+    so the remedy is a nudge. Identify this session's slot by matching the
+    walked ``claude`` pid against the ``mcp-spawn`` file plane (world-readable;
+    pid- AND start-time-validated by ``read_spawn_identity`` against a recycled
+    pid), then apply the shared ``is_stale`` verdict. Throttled per session;
+    wrapped fail-open so a miss never surfaces as an error and a fresh session
+    stays silent."""
+    try:
+        from genesis.observability.cc_slots import read_proc_start_iso
+        from genesis.observability.mcp_spawn_store import (
+            enumerate_spawn_slots,
+            read_spawn_identity,
+        )
+
+        pid = _claude_ancestor_pid()
+        if pid is None:
+            return
+        # Find THIS session's slot by matching its claude pid in the spawn plane
+        # (env GENESIS_SLOT would also work, but a pid match can't be fooled by an
+        # inherited/stale slot value and mirrors the dashboard badge's join).
+        slot = next((s for s, rpid, _sat in enumerate_spawn_slots() if rpid == pid), None)
+        if slot is None:
+            return
+        ident = read_spawn_identity(slot, pid, read_proc_start_iso(pid))
+        if ident is None:
+            return
+        root = os.environ.get("GENESIS_REPO_ROOT", "")
+        db = (Path(root) if root else Path.home() / "genesis") / "data" / "genesis.db"
+        msg = _staleness_message(ident[0], ident[1], _last_successful_deploy(db))
+        if not msg:
+            return
+        if _staleness_throttled(session_id, now):
+            return
+        # Persist the cooldown BEFORE printing: if the marker can't be written
+        # (unwritable session dir), suppress rather than spam the banner on every
+        # prompt — the absent-marker throttle path reads as "not throttled".
+        if not _record_staleness_nudge(session_id, now):
+            return
+        print(msg)
+        sys.stdout.flush()
+    except Exception:
+        return  # fail-open: a nudge miss must never surface as an error
+
+
 def main() -> None:
     # Skip if Genesis context is disabled
     if not _FLAG.exists():
@@ -223,6 +403,9 @@ def main() -> None:
         _emit_temporal_context(session_id, now)
         # 1b. Charter drift tag (chartered sessions only; fail-open)
         _emit_charter_tag(session_id)
+        # 1c. MCP stale-code nudge (only when this session's MCP is behind the
+        # last deploy; throttled; fail-open)
+        _emit_staleness_nudge(session_id, now)
 
     # 2. Buffer user message for bookmarks
     if session_id and prompt:

--- a/tests/test_scripts/test_urgent_alerts_staleness_nudge.py
+++ b/tests/test_scripts/test_urgent_alerts_staleness_nudge.py
@@ -1,0 +1,265 @@
+"""Tests for the MCP stale-code nudge in genesis_urgent_alerts.
+
+The nudge fires on EVERY prompt but must be SILENT unless this session's MCP
+subprocesses run code OLDER than the last deploy — so the omission matrix
+(fresh / ahead / no deploy / no spawn record / throttled / no session pid) is
+the contract that keeps it free, and it must reuse the SAME commit_identity
+verdict the dashboard badge uses (a session ahead of the deploy is never
+flagged). Fail-open throughout.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+_ua_spec = importlib.util.spec_from_file_location(
+    "genesis_urgent_alerts", _SCRIPTS_DIR / "genesis_urgent_alerts.py"
+)
+_ua = importlib.util.module_from_spec(_ua_spec)
+_ua_spec.loader.exec_module(_ua)
+
+SID = "sid-stale-1"
+PID = 424242
+PROC_START = "2026-08-15T00:00:00+00:00"
+SPAWN_AT = "2026-08-15T00:00:05+00:00"  # a beat after the process start
+SPAWN_COMMIT = "176f5b3b8bfd1e11907fafc92967fe1e956330b1"  # full SHA (rev-parse)
+DEPLOY_COMMIT = "87590955"  # short SHA (update_history.new_commit)
+DEPLOY_AT = "2026-08-21T19:48:50+00:00"  # AFTER spawn → behind → stale
+NOW = datetime(2026, 8, 25, 12, 0, 0, tzinfo=UTC)
+
+
+# ── _staleness_message (pure verdict + wording, no IO) ──────────────────────
+
+
+def test_message_stale_session_behind_deploy():
+    msg = _ua._staleness_message(SPAWN_COMMIT, SPAWN_AT, (DEPLOY_AT, DEPLOY_COMMIT))
+    assert msg is not None
+    assert "stale" in msg.lower()
+    assert "2026-08-21" in msg  # deploy date
+    assert DEPLOY_COMMIT[:8] in msg
+    assert msg.startswith("[") and msg.endswith("]")
+
+
+def test_message_fresh_same_commit_silent():
+    # spawn commit == deploy commit (prefix match via same_commit) → not stale
+    assert _ua._staleness_message(DEPLOY_COMMIT, SPAWN_AT, (DEPLOY_AT, DEPLOY_COMMIT)) is None
+
+
+def test_message_session_ahead_of_deploy_silent():
+    # spawn_at AFTER the deploy completed → session is ahead (manual git pull),
+    # NOT stale, even though commits differ.
+    ahead_spawn = "2026-08-22T00:00:00+00:00"
+    assert _ua._staleness_message(SPAWN_COMMIT, ahead_spawn, (DEPLOY_AT, DEPLOY_COMMIT)) is None
+
+
+def test_message_no_deploy_silent():
+    assert _ua._staleness_message(SPAWN_COMMIT, SPAWN_AT, None) is None
+
+
+def test_message_nonhex_commit_silent():
+    # defense-in-depth: a malformed new_commit must never reach LLM-visible context
+    assert _ua._staleness_message(SPAWN_COMMIT, SPAWN_AT, (DEPLOY_AT, "not-a-sha!!")) is None
+    assert _ua._staleness_message(SPAWN_COMMIT, SPAWN_AT, (DEPLOY_AT, "")) is None
+
+
+# ── _last_successful_deploy (read-only sqlite) ──────────────────────────────
+
+
+def _make_update_db(tmp_path: Path, rows: list[tuple[str, str, str]]) -> Path:
+    """rows = [(status, new_commit, completed_at), ...]."""
+    root = tmp_path / "repo"
+    (root / "data").mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(root / "data" / "genesis.db")
+    conn.execute(
+        "CREATE TABLE update_history (id TEXT, status TEXT, new_commit TEXT, completed_at TEXT)"
+    )
+    for i, (status, commit, completed) in enumerate(rows):
+        conn.execute(
+            "INSERT INTO update_history (id, status, new_commit, completed_at) VALUES (?,?,?,?)",
+            (f"u{i}", status, commit, completed),
+        )
+    conn.commit()
+    conn.close()
+    return root
+
+
+def test_last_deploy_newest_success(tmp_path):
+    root = _make_update_db(
+        tmp_path,
+        [
+            ("success", "aaaa1111", "2026-08-20T00:00:00+00:00"),
+            ("success", DEPLOY_COMMIT, DEPLOY_AT),  # newest success
+            ("failed", "bbbb2222", "2026-08-22T00:00:00+00:00"),  # newer but not success
+        ],
+    )
+    got = _ua._last_successful_deploy(root / "data" / "genesis.db")
+    assert got == (DEPLOY_AT, DEPLOY_COMMIT)
+
+
+def test_last_deploy_no_success_rows(tmp_path):
+    root = _make_update_db(tmp_path, [("failed", "bbbb2222", "2026-08-22T00:00:00+00:00")])
+    assert _ua._last_successful_deploy(root / "data" / "genesis.db") is None
+
+
+def test_last_deploy_missing_db(tmp_path):
+    assert _ua._last_successful_deploy(tmp_path / "nowhere" / "genesis.db") is None
+
+
+def test_last_deploy_missing_table(tmp_path):
+    root = tmp_path / "repo"
+    (root / "data").mkdir(parents=True)
+    sqlite3.connect(root / "data" / "genesis.db").close()
+    assert _ua._last_successful_deploy(root / "data" / "genesis.db") is None
+
+
+# ── throttle marker ─────────────────────────────────────────────────────────
+
+
+def test_throttle_absent_then_recorded(monkeypatch, tmp_path):
+    monkeypatch.setattr(_ua, "_GENESIS_DIR", tmp_path)
+    assert _ua._staleness_throttled(SID, NOW) is False  # no marker yet
+    assert _ua._record_staleness_nudge(SID, NOW) is True  # persisted
+    assert _ua._staleness_throttled(SID, NOW) is True  # within cooldown
+    # well past the cooldown → not throttled
+    later = NOW + timedelta(seconds=_ua._STALENESS_COOLDOWN_S + 60)
+    assert _ua._staleness_throttled(SID, later) is False
+
+
+def test_record_returns_false_when_unwritable(monkeypatch, tmp_path):
+    # A file where the "sessions" dir should be → mkdir of sessions/<id> fails.
+    monkeypatch.setattr(_ua, "_GENESIS_DIR", tmp_path)
+    (tmp_path / "sessions").write_text("not a dir")
+    assert _ua._record_staleness_nudge(SID, NOW) is False
+
+
+def test_throttle_garbled_marker_not_throttled(monkeypatch, tmp_path):
+    monkeypatch.setattr(_ua, "_GENESIS_DIR", tmp_path)
+    marker = tmp_path / "sessions" / SID / "staleness_last_nudge"
+    marker.parent.mkdir(parents=True)
+    marker.write_text("not-a-timestamp")
+    assert _ua._staleness_throttled(SID, NOW) is False
+
+
+# ── _emit_staleness_nudge (integration; spawn plane + /proc monkeypatched) ──
+
+
+def _wire(monkeypatch, tmp_path, *, pid, slots, ident, deploy_rows):
+    """Point every IO seam at fakes/tmp. `slots` = enumerate_spawn_slots result;
+    `ident` = read_spawn_identity result."""
+    import genesis.observability.cc_slots as cc_slots
+    import genesis.observability.mcp_spawn_store as sp
+
+    monkeypatch.setattr(_ua, "_GENESIS_DIR", tmp_path)
+    monkeypatch.setattr(_ua, "_claude_ancestor_pid", lambda: pid)
+    monkeypatch.setattr(sp, "enumerate_spawn_slots", lambda: slots)
+    monkeypatch.setattr(sp, "read_spawn_identity", lambda *a, **k: ident)
+    monkeypatch.setattr(cc_slots, "read_proc_start_iso", lambda _p: PROC_START)
+    root = _make_update_db(tmp_path, deploy_rows)
+    monkeypatch.setenv("GENESIS_REPO_ROOT", str(root))
+
+
+_STALE_ROWS = [("success", DEPLOY_COMMIT, DEPLOY_AT)]
+
+
+def test_emit_stale_prints_and_records(monkeypatch, capsys, tmp_path):
+    _wire(
+        monkeypatch,
+        tmp_path,
+        pid=PID,
+        slots=[("1", PID, SPAWN_AT)],
+        ident=(SPAWN_COMMIT, SPAWN_AT),
+        deploy_rows=_STALE_ROWS,
+    )
+    _ua._emit_staleness_nudge(SID, NOW)
+    out = capsys.readouterr().out
+    assert "stale" in out.lower() and DEPLOY_COMMIT[:8] in out
+    # marker recorded → second call within cooldown is silent
+    _ua._emit_staleness_nudge(SID, NOW)
+    assert capsys.readouterr().out == ""
+
+
+def test_emit_fresh_silent(monkeypatch, capsys, tmp_path):
+    _wire(
+        monkeypatch,
+        tmp_path,
+        pid=PID,
+        slots=[("1", PID, SPAWN_AT)],
+        ident=(DEPLOY_COMMIT, SPAWN_AT),  # same commit as deploy → not stale
+        deploy_rows=_STALE_ROWS,
+    )
+    _ua._emit_staleness_nudge(SID, NOW)
+    assert capsys.readouterr().out == ""
+
+
+def test_emit_no_claude_pid_silent(monkeypatch, capsys, tmp_path):
+    _wire(
+        monkeypatch,
+        tmp_path,
+        pid=None,
+        slots=[("1", PID, SPAWN_AT)],
+        ident=(SPAWN_COMMIT, SPAWN_AT),
+        deploy_rows=_STALE_ROWS,
+    )
+    _ua._emit_staleness_nudge(SID, NOW)
+    assert capsys.readouterr().out == ""
+
+
+def test_emit_pid_not_in_spawn_plane_silent(monkeypatch, capsys, tmp_path):
+    _wire(
+        monkeypatch,
+        tmp_path,
+        pid=PID,
+        slots=[("1", 999999, SPAWN_AT)],  # a DIFFERENT session's pid
+        ident=(SPAWN_COMMIT, SPAWN_AT),
+        deploy_rows=_STALE_ROWS,
+    )
+    _ua._emit_staleness_nudge(SID, NOW)
+    assert capsys.readouterr().out == ""
+
+
+def test_emit_unvalidated_ident_silent(monkeypatch, capsys, tmp_path):
+    # read_spawn_identity rejects (pid mismatch / recycled) → None → silent
+    _wire(
+        monkeypatch,
+        tmp_path,
+        pid=PID,
+        slots=[("1", PID, SPAWN_AT)],
+        ident=None,
+        deploy_rows=_STALE_ROWS,
+    )
+    _ua._emit_staleness_nudge(SID, NOW)
+    assert capsys.readouterr().out == ""
+
+
+def test_emit_throttled_silent(monkeypatch, capsys, tmp_path):
+    _wire(
+        monkeypatch,
+        tmp_path,
+        pid=PID,
+        slots=[("1", PID, SPAWN_AT)],
+        ident=(SPAWN_COMMIT, SPAWN_AT),
+        deploy_rows=_STALE_ROWS,
+    )
+    _ua._record_staleness_nudge(SID, NOW)  # pre-stamp the cooldown
+    _ua._emit_staleness_nudge(SID, NOW)
+    assert capsys.readouterr().out == ""
+
+
+def test_emit_suppressed_when_marker_unwritable(monkeypatch, capsys, tmp_path):
+    # If the cooldown marker can't persist, suppress rather than spam every prompt.
+    _wire(
+        monkeypatch,
+        tmp_path,
+        pid=PID,
+        slots=[("1", PID, SPAWN_AT)],
+        ident=(SPAWN_COMMIT, SPAWN_AT),
+        deploy_rows=_STALE_ROWS,
+    )
+    monkeypatch.setattr(_ua, "_record_staleness_nudge", lambda *a, **k: False)
+    _ua._emit_staleness_nudge(SID, NOW)
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Nudge a session when its memory MCP is running stale code

### The gap
Each Claude Code session's MCP subprocesses (memory, health, …) snapshot their
code at spawn and **never reload**. `update.sh` restarts only `genesis-server`,
so a deploy that lands **mid-session** silently leaves that session's recall —
and its current **security read-exclusions** (#1431/#1407) and FTS behavior
(#1403) — on the old code until the user restarts the session. There is no
auto-restart, and until now no signal: a long-lived session serves stale recall
indefinitely. (Measured live: sessions running 10–19 days / up to 18 recall-path
commits behind.)

### The change
A per-prompt `UserPromptSubmit` nudge in `scripts/genesis_urgent_alerts.py`. When
**this** session's MCP predates the last successful deploy, it prints one line:

```
[⚠ Memory MCP stale: this session's MCP predates the 2026-08-21 deploy (now 87590955) — restart the session to refresh recall + security read-exclusions]
```

- **Same verdict as the dashboard badge.** The stale/fresh decision is delegated
  to the shared `commit_identity.is_stale` leaf — the exact verdict Part-A's guard
  and the dashboard stale-code badge use, so the three can never disagree. A
  session **ahead** of the last recorded deploy (a manual `git pull`) is **not**
  flagged (the time-axis guard: `deploy_completed_at > spawn_at`).
- **Correct-session identity.** Walks the `/proc` ppid chain from the hook to this
  session's `claude` pid, then matches that pid against the `mcp-spawn` file plane
  (`enumerate_spawn_slots`) and validates via `read_spawn_identity` (pid + start-time,
  so a recycled pid from a dead session can't produce a false badge).
- **Per-prompt, not SessionStart** — the MCP is fresh at session start; it goes
  stale only when a deploy lands *during* the session.
- **Throttled + fail-open.** At most once per 3h per session; the whole path is
  wrapped so any read/parse miss (no spawn record, no deploy row, unreadable
  `/proc`, locked DB) emits nothing — a fresh session stays silent, and a nudge
  miss never surfaces as an error on a hook that runs on every prompt.

Read-only throughout (world-readable `/proc`, `mode=ro` sqlite); no new imports of
`fastmcp`/`aiosqlite` in the hook.

### Verification
- **16 tests** (`tests/test_scripts/test_urgent_alerts_staleness_nudge.py`): pure
  verdict (stale / fresh-same-commit / ahead / no-deploy), read-only deploy read
  (newest-success / no-success / missing db / missing table), throttle
  (absent→recorded→expired, garbled marker), and the integration omission matrix
  (stale→emits+records, fresh→silent, no-pid / pid-not-in-plane / unvalidated-ident
  / throttled→silent). **Verify-RED** confirmed by inverting `is_stale`.
- **E2E:** the real hook run against a live *genuinely stale* session emits the
  nudge; a session with no charter/no spawn record stays otherwise-quiet. `ruff`
  clean. Existing `genesis_urgent_alerts` charter-tag tests still green.

### Scope note
Nudge only — no auto-restart (update.sh doesn't own `claude` procs; restarting a
live session's MCP is delicate). Widening the server-side staleness guard to a
WARN tier on recall/reference reads is deferred (tabled follow-up).
