### PR TITLE
fix(hooks): don't block a merge on a review finding that lands on a doc file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The merge gate no longer blocks on a review finding that lands on a
+  documentation file.** An inline `[P1]` finding anchored to a doc path
+  (`CHANGELOG`, `README`, `LICENSE`/`NOTICE`, `docs/**`, `*.rst`) is now surfaced
+  to stderr but does not block the merge — a changelog typo or README nit is not a
+  code defect. Safe by default: any non-doc path, a missing path, or an
+  executable/source file even under `docs/` (e.g. `docs/conf.py`) still blocks,
+  and the PR-level review-body gate is unchanged. Applies to `git_push_guard`'s
+  inline-findings scan on both the `--check-pr` and merge paths.
+
 - **The dashboard Surplus health tile no longer reads green while the surplus
   scheduler is wedged.** Its verdict previously came from an activity proxy that
   shows "idle" for a stalled scheduler, so a stuck surplus loop appeared healthy —

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -865,6 +865,54 @@ _MAINTAINER_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 # Badge/markup prefix stripped when rendering a finding's title line.
 _INLINE_MARKUP_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)|</?sub>|[*]{1,2}")
 
+# ── Documentation-path allowlist for review findings (ledger 54eb3752) ───────
+# A P1 inline finding on a DOCUMENTATION file is not a code defect and must not
+# block a merge (a CHANGELOG typo, a README wording nit). This is a FAIL-CLOSED
+# ALLOWLIST — a path is exempted only when it is provably prose; everything else
+# blocks. Prose is: (1) a known doc-named file (CHANGELOG/README/LICENSE/NOTICE/…)
+# with a doc or empty extension, at any depth; (2) any file with a documentation
+# extension (.md/.rst/.txt/…) UNDER a top-level ``docs/``; or (3) any ``*.rst``
+# anywhere. A random top-level ``NOTES.md``, ANY source/config/executable file
+# even under ``docs/`` (``docs/conf.py``, ``docs/build.rs``, ``docs/config.yaml``,
+# ``docs/Makefile``), a missing/empty path, or a path bearing a control character
+# is NON-doc and STILL BLOCKS — the gate never opens for a code path merely
+# mislabeled. Only the inline endpoint carries a per-file path; the review-BODY
+# gate is PR-level and stays unfiltered. (Denylist of code extensions was rejected
+# in review: it can't enumerate every source/config type — an allowlist fails
+# closed on the unknown.)
+_DOC_EXTS = {"md", "markdown", "rst", "txt", "adoc"}
+_DOC_STEMS = {
+    "changelog",
+    "readme",
+    "license",
+    "notice",
+    "copying",
+    "authors",
+    "contributing",
+}
+
+
+def _is_doc_path(path: str) -> bool:
+    """Whether a review finding's file *path* is documentation whose findings do
+    NOT block a merge. FAIL-CLOSED allowlist (see the section comment): anything
+    not provably prose — a source/config file under ``docs/``, a random top-level
+    ``*.md``, a missing path, or a control-char-bearing path — blocks."""
+    if not path or any(ord(c) < 0x20 for c in path):
+        return False  # empty or control-char-bearing → block (fail-closed)
+    base = path.rsplit("/", 1)[-1]
+    stem, dot, ext = base.rpartition(".")
+    ext = ext.lower() if dot else ""
+    stem_l = (stem if dot else base).lower()
+    # (1) A known doc-named file with a doc/empty extension, at any depth.
+    if stem_l in _DOC_STEMS and ext in _DOC_EXTS | {""}:
+        return True
+    # (2) A pure documentation format (reStructuredText) anywhere.
+    if ext == "rst":
+        return True
+    # (3) A documentation-extension file under a top-level docs/ directory.
+    return ext in _DOC_EXTS and path.startswith("docs/")
+
+
 # ── Direct-sqlite-write detection ────────────────────────────────────────────
 # Robust bare-keyword match (the historical approach). A SINGLE statement keyword
 # is inherently immune to shell quoting/escapes AND SQL comments BETWEEN tokens,
@@ -1074,7 +1122,7 @@ def _check_inline_review_findings(
         pr_num,
         repo,
         ".[] | {id: .id, reply_to: .in_reply_to_id, login: .user.login, "
-        "type: .user.type, assoc: .author_association, body: .body}",
+        "type: .user.type, assoc: .author_association, path: .path, body: .body}",
     )
     if raw is None:
         return _scan_unreadable("inline review comments")
@@ -1091,6 +1139,7 @@ def _check_inline_review_findings(
     }
     p1: list[str] = []
     p2: list[str] = []
+    doc_skipped: list[str] = []  # P1s on doc paths — surfaced, never blocking
     for c in raw:
         login, utype = c.get("login") or "", c.get("type") or ""
         body = c.get("body") or ""
@@ -1101,10 +1150,24 @@ def _check_inline_review_findings(
         if _INLINE_P1_RE.search(body):
             if c.get("id") in replied_to:
                 continue  # thread engaged — treated as acknowledged
+            if _is_doc_path(c.get("path") or ""):
+                # A P1 on a documentation file (ledger 54eb3752) is surfaced but
+                # does NOT block; a code file (incl. code under docs/) still does.
+                doc_skipped.append(_inline_title(body))
+                continue
             p1.append(_inline_title(body))
         elif _INLINE_P2_RE.search(body):
             p2.append(_inline_title(body))
 
+    if doc_skipped:
+        print(
+            f"NOTE: PR #{pr_num} — {len(doc_skipped)} inline [P1] finding(s) on "
+            f"documentation paths (CHANGELOG/README/LICENSE/NOTICE/docs/**/*.rst) "
+            f"NOT blocking:",
+            file=sys.stderr,
+        )
+        for title in doc_skipped[:5]:
+            print(f"  [doc P1] {title}", file=sys.stderr)
     if p2:
         print(
             f"WARNING: PR #{pr_num} has {len(p2)} inline [P2] review "

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -870,17 +870,23 @@ _INLINE_MARKUP_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)|</?sub>|[*]{1,2}")
 # block a merge (a CHANGELOG typo, a README wording nit). This is a FAIL-CLOSED
 # ALLOWLIST — a path is exempted only when it is provably prose; everything else
 # blocks. Prose is: (1) a known doc-named file (CHANGELOG/README/LICENSE/NOTICE/…)
-# with a doc or empty extension, at any depth; (2) any file with a documentation
-# extension (.md/.rst/.txt/…) UNDER a top-level ``docs/``; or (3) any ``*.rst``
-# anywhere. A random top-level ``NOTES.md``, ANY source/config/executable file
-# even under ``docs/`` (``docs/conf.py``, ``docs/build.rs``, ``docs/config.yaml``,
-# ``docs/Makefile``), a missing/empty path, or a path bearing a control character
-# is NON-doc and STILL BLOCKS — the gate never opens for a code path merely
-# mislabeled. Only the inline endpoint carries a per-file path; the review-BODY
-# gate is PR-level and stays unfiltered. (Denylist of code extensions was rejected
-# in review: it can't enumerate every source/config type — an allowlist fails
-# closed on the unknown.)
-_DOC_EXTS = {"md", "markdown", "rst", "txt", "adoc"}
+# with a doc/text/empty extension, at any depth; (2) any UNAMBIGUOUS documentation
+# extension (.md/.rst/.markdown/.adoc) UNDER a top-level ``docs/``; or (3) any
+# ``*.rst`` anywhere. A random top-level ``NOTES.md``, ANY source/config/executable
+# file even under ``docs/`` (``docs/conf.py``, ``docs/build.rs``, ``docs/config.yaml``,
+# ``docs/Makefile``), a missing/empty path, or a path bearing a control character is
+# NON-doc and STILL BLOCKS — the gate never opens for a code path merely mislabeled.
+# ``.txt`` is deliberately NOT a blanket doc extension: it is ambiguous (a build/dep
+# manifest — ``docs/requirements.txt``, ``docs/CMakeLists.txt`` — carries it too, and
+# this repo classifies such files as config), so ``.txt`` is prose ONLY on a known
+# doc-named stem (``LICENSE.txt``, ``README.txt``). Only the inline endpoint carries
+# a per-file path; the review-BODY gate is PR-level and stays unfiltered. (A denylist
+# of code extensions was rejected in review: it can't enumerate every source/config
+# type — an allowlist fails closed on the unknown.)
+_DOC_EXTS = {"md", "markdown", "rst", "adoc"}
+# Extensions permitted on a KNOWN doc-named stem only (rule 1). ``.txt``/empty are
+# safe here because the STEM already pins the file as prose (LICENSE, README).
+_DOC_STEM_EXTS = _DOC_EXTS | {"txt", ""}
 _DOC_STEMS = {
     "changelog",
     "readme",
@@ -895,21 +901,24 @@ _DOC_STEMS = {
 def _is_doc_path(path: str) -> bool:
     """Whether a review finding's file *path* is documentation whose findings do
     NOT block a merge. FAIL-CLOSED allowlist (see the section comment): anything
-    not provably prose — a source/config file under ``docs/``, a random top-level
-    ``*.md``, a missing path, or a control-char-bearing path — blocks."""
-    if not path or any(ord(c) < 0x20 for c in path):
+    not provably prose — a source/config/manifest file under ``docs/`` (incl. a
+    ``.txt`` build manifest), a random top-level ``*.md``, a missing path, or a
+    control-char-bearing path — blocks."""
+    # Reject the COMPLETE control-character range (Unicode Cc): C0 (<0x20), DEL
+    # (0x7F), and C1 (0x80-0x9F, incl. NEL 0x85 which ``gh --jq`` emits literally).
+    if not path or any(ord(c) < 0x20 or 0x7F <= ord(c) <= 0x9F for c in path):
         return False  # empty or control-char-bearing → block (fail-closed)
     base = path.rsplit("/", 1)[-1]
     stem, dot, ext = base.rpartition(".")
     ext = ext.lower() if dot else ""
     stem_l = (stem if dot else base).lower()
-    # (1) A known doc-named file with a doc/empty extension, at any depth.
-    if stem_l in _DOC_STEMS and ext in _DOC_EXTS | {""}:
+    # (1) A known doc-named file with a doc/text/empty extension, at any depth.
+    if stem_l in _DOC_STEMS and ext in _DOC_STEM_EXTS:
         return True
     # (2) A pure documentation format (reStructuredText) anywhere.
     if ext == "rst":
         return True
-    # (3) A documentation-extension file under a top-level docs/ directory.
+    # (3) An unambiguous documentation extension under a top-level docs/ directory.
     return ext in _DOC_EXTS and path.startswith("docs/")
 
 

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1183,14 +1183,17 @@ class TestCheckInlineReviewFindings:
             ),
         )
 
-    def _codex(self, cid, body, reply_to=None):
-        return {
+    def _codex(self, cid, body, reply_to=None, path=None):
+        d = {
             "id": cid,
             "reply_to": reply_to,
             "login": "chatgpt-codex-connector[bot]",
             "type": "Bot",
             "body": body,
         }
+        if path is not None:
+            d["path"] = path
+        return d
 
     def test_inline_p1_blocks_with_title(self, guard_module):
         with self._mock(guard_module, [self._codex(1, _P1_BODY)]):
@@ -1310,6 +1313,120 @@ class TestCheckInlineReviewFindings:
             block, _ = guard_module._check_inline_review_findings("100")
         # type=User AND not in the inline bot set → not an automated finding
         assert block is False
+
+    # ── doc-path allowlist (ledger 54eb3752) ─────────────────────────────
+    # A P1 whose inline finding sits on a DOCUMENTATION file does not block the
+    # merge; a code file — including a code file UNDER docs/ — still blocks. Safe
+    # default: any path not on the explicit allowlist blocks.
+    def test_inline_p1_on_changelog_does_not_block(self, guard_module, capsys):
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path="CHANGELOG.md")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert not block
+        assert "documentation" in capsys.readouterr().err.lower()
+
+    def test_inline_p1_on_readme_does_not_block(self, guard_module):
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path="README.md")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert not block
+
+    def test_inline_p1_under_docs_dir_does_not_block(self, guard_module):
+        with self._mock(
+            guard_module, [self._codex(1, _P1_BODY, path="docs/architecture/x.md")]
+        ):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert not block
+
+    def test_inline_p1_on_rst_does_not_block(self, guard_module):
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path="guide.rst")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert not block
+
+    def test_inline_p1_on_code_path_still_blocks(self, guard_module):
+        with self._mock(
+            guard_module, [self._codex(1, _P1_BODY, path="src/genesis/foo.py")]
+        ):
+            block, msg = guard_module._check_inline_review_findings("100")
+        assert block
+        assert "Make queue claim atomic" in msg
+
+    def test_inline_p1_on_random_md_still_blocks(self, guard_module):
+        # Safe default: a non-allowlisted *.md (not CHANGELOG/README, not under
+        # docs/) is NOT a doc → still blocks.
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path="NOTES.md")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block
+
+    def test_inline_p1_on_code_under_docs_still_blocks(self, guard_module):
+        # docs/conf.py is executable Python — a finding there must still block.
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path="docs/conf.py")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block
+
+    def test_inline_p1_missing_path_still_blocks(self, guard_module):
+        # A finding with no path (malformed/absent) fails SAFE → blocks.
+        with self._mock(guard_module, [self._codex(1, _P1_BODY)]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block
+
+    def test_mixed_doc_and_code_p1_blocks_naming_code(self, guard_module):
+        comments = [
+            self._codex(1, _P1_BODY, path="CHANGELOG.md"),
+            self._codex(
+                2,
+                "**<sub><sub>![P1 Badge](https://img.shields.io/badge/P1-red)"
+                "</sub></sub>  Real code defect in router**\n\nDetails.",
+                path="src/genesis/router.py",
+            ),
+        ]
+        with self._mock(guard_module, comments):
+            block, msg = guard_module._check_inline_review_findings("100")
+        assert block
+        assert "Real code defect in router" in msg
+        assert "Make queue claim atomic" not in msg  # the doc P1 is not listed
+
+    def test_jq_projects_path(self, guard_module):
+        # The test seam bypasses jq, so lock the projection by asserting the argv
+        # the production fetch sends includes `path: .path`.
+        with self._mock(guard_module, []) as run_mock:
+            guard_module._check_inline_review_findings("100")
+        argv = run_mock.call_args[0][0]
+        assert any("path: .path" in tok for tok in argv)
+
+    # Fail-closed allowlist (security review HIGH): a NON-prose extension under
+    # docs/ must still block — the exemption is an allowlist of doc extensions,
+    # NOT a denylist of a few known code extensions.
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "docs/build.rs",       # Rust source
+            "docs/config.yaml",    # CI/build config
+            "docs/notebook.ipynb", # Jupyter (contains code)
+            "docs/init.sql",       # SQL
+            "docs/Script.java",    # Java
+            "docs/deploy.ps1",     # PowerShell
+            "docs/Makefile",       # extensionless build file (now fail-closed)
+        ],
+    )
+    def test_inline_p1_non_prose_under_docs_still_blocks(self, guard_module, path):
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path=path)]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block, f"{path!r} under docs/ is not prose — must block"
+
+    def test_inline_p1_trailing_newline_path_blocks(self, guard_module):
+        # Security review LOW: a trailing newline must not defeat the exemption.
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path="docs/conf.py\n")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block
+
+    def test_inline_p1_on_license_no_ext_does_not_block(self, guard_module):
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path="LICENSE")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert not block
+
+    def test_inline_p1_on_docs_txt_does_not_block(self, guard_module):
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path="docs/guide.txt")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert not block
 
 
 class TestResolvePrNumber:

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1423,10 +1423,45 @@ class TestCheckInlineReviewFindings:
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
 
-    def test_inline_p1_on_docs_txt_does_not_block(self, guard_module):
-        with self._mock(guard_module, [self._codex(1, _P1_BODY, path="docs/guide.txt")]):
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "docs/requirements.txt",   # pip deps (repo classifies as config)
+            "docs/constraints.txt",    # pip constraints
+            "docs/CMakeLists.txt",     # CMake build
+            "docs/meson_options.txt",  # Meson build
+            "docs/guide.txt",          # plain .txt is ambiguous → fail-closed
+        ],
+    )
+    def test_inline_p1_txt_manifest_or_ambiguous_under_docs_blocks(
+        self, guard_module, path
+    ):
+        # Codex P1: `.txt` is NOT an unambiguous doc extension — a build/dep
+        # manifest carries it too. Only a known doc STEM (LICENSE.txt) is prose.
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path=path)]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block, f"{path!r} is an ambiguous .txt — must block"
+
+    @pytest.mark.parametrize("path", ["LICENSE.txt", "README.txt", "docs/README.txt"])
+    def test_inline_p1_known_stem_txt_does_not_block(self, guard_module, path):
+        # A doc-named STEM pins the file as prose, so .txt is safe there.
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path=path)]):
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "docs/guide\x7f.md",  # DEL
+            "docs/guide\x85.md",  # NEL (C1) — gh --jq emits literally
+            "docs/guide\x9f.md",  # C1 upper bound
+        ],
+    )
+    def test_inline_p1_c1_del_control_char_path_blocks(self, guard_module, path):
+        # Codex P2: reject the COMPLETE control range (DEL + C1), not just C0.
+        with self._mock(guard_module, [self._codex(1, _P1_BODY, path=path)]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block
 
 
 class TestResolvePrNumber:


### PR DESCRIPTION
## Don't block a merge on a review finding that lands on a documentation file

### The problem
`git_push_guard._check_inline_review_findings` (the merge gate that scans Codex
INLINE review comments) blocked a merge on ANY unresolved `[P1]`. A `[P1]`
anchored to a documentation file — a CHANGELOG typo, a README wording nit — is
not a code defect, yet it blocked the merge.

### The change
Add a **fail-closed** documentation-path allowlist. A finding whose file `.path`
is provably prose is surfaced to stderr but does not block:
- a `CHANGELOG`/`README`/`LICENSE`/`NOTICE`-named file (doc or no extension),
- any doc-extension file (`.md`/`.rst`/`.txt`/…) under a top-level `docs/`,
- any `*.rst` anywhere.

Everything else still blocks — a random top-level `*.md` (`NOTES.md`), ANY
source/config/executable file even under `docs/` (`docs/conf.py`, `docs/build.rs`,
`docs/config.yaml`), a missing path, or a path bearing a control character.

Only the inline endpoint (`pulls/N/comments`) carries a per-file path; the
PR-level review-body gate (`issues/N/comments`) has no file attribution and is
unchanged. The fail-closed unreadable/incomplete-read logic, the maintainer-reply
engagement check, and the P2 path are untouched.

### Safety
An allowlist, not a denylist: a code-extension denylist can't enumerate every
source/config type, so the unknown fails closed (blocks). Reviewed by
genesis-security-reviewer — an initial denylist draft was rejected for that
enumeration gap; the allowlist + control-char guard close both findings
(HIGH: non-prose under `docs/`; LOW: trailing-newline `.match` leak).

### Tests
`tests/test_hooks/test_merge_review_gate.py` — verify-RED confirmed: doc-path
P1s no longer block; non-prose-under-`docs/` and control-char paths still block;
a mixed doc+code PR blocks and names only the code finding; the jq projection is
locked.

Ledger: 54eb3752074d4afe9ccca244353ede8a
