### PR TITLE
fix(observability): surface subsystem total-cessation (alert + ego tile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A dead subsystem scheduler no longer reads "healthy" on the dashboard.** When
+  a background subsystem's scheduler/loop stops firing entirely (total cessation),
+  its heartbeat pulse goes silent — but nothing turned that into a signal, so the
+  Ego tile (and the rollup badge) could show green while the egos were dead, and no
+  alert was raised. Now the Errors view raises a `subsystem_stale:<name>` alert when
+  a heartbeat-emitting subsystem (ego, surplus, inbox, dashboard, outreach) goes
+  overdue past its threshold (ego → critical, the rest → warning), and the Ego tile
+  flips to error ("scheduler stopped — no heartbeat in Nh"), failing loud
+  (`unknown`) if the signal can't be read. This complements the existing
+  "running-but-failing" job alarms, which cannot see a job that has stopped running
+  at all. Note: only the pulse-emitting subsystems get stopped-firing detection;
+  other scheduled jobs keep the existing failure-gap alarms.
 - **The dashboard Surplus health tile no longer reads green while the surplus
   scheduler is wedged.** Its verdict previously came from an activity proxy that
   shows "idle" for a stalled scheduler, so a stuck surplus loop appeared healthy —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,13 +39,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   its heartbeat pulse goes silent — but nothing turned that into a signal, so the
   Ego tile (and the rollup badge) could show green while the egos were dead, and no
   alert was raised. Now the Errors view raises a `subsystem_stale:<name>` alert when
-  a heartbeat-emitting subsystem (ego, surplus, inbox, dashboard, outreach) goes
-  overdue past its threshold (ego → critical, the rest → warning), and the Ego tile
-  flips to error ("scheduler stopped — no heartbeat in Nh"), failing loud
-  (`unknown`) if the signal can't be read. This complements the existing
+  the ego (→ critical), inbox, or dashboard (→ warning) scheduler goes overdue past
+  its threshold, and the Ego tile flips to error ("scheduler stopped — no heartbeat
+  in Nh"), failing loud (`unknown`) if the signal can't be read. The alert is
+  pause-aware — a deliberately paused Genesis no longer false-alarms — and never
+  fires on a merely idle or freshly-booted install. This complements the existing
   "running-but-failing" job alarms, which cannot see a job that has stopped running
-  at all. Note: only the pulse-emitting subsystems get stopped-firing detection;
-  other scheduled jobs keep the existing failure-gap alarms.
+  at all. (Surplus already surfaces a wedged/dead loop via its own dashboard tile;
+  outreach total-cessation is tracked separately, since its heartbeat only runs once
+  a messaging channel is configured.)
 - **The merge gate no longer blocks on a review finding that lands on a
   documentation file.** An inline `[P1]` finding anchored to a doc path
   (`CHANGELOG`, `README`, `LICENSE`/`NOTICE`, `docs/**`, `*.rst`) is now surfaced

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -164,15 +164,31 @@ async def ego_status():
     ego_heartbeat_age_s = None
     ego_heartbeat_error = False
     try:
-        from genesis.mcp.health.manifest import compute_heartbeat_staleness
+        from datetime import UTC, datetime
+
+        from genesis.mcp.health.manifest import (
+            HEARTBEAT_EXPECTED,
+            compute_heartbeat_staleness,
+        )
 
         hb = await compute_heartbeat_staleness("ego", db=rt._db, raise_on_error=True)
         status = hb.get("status")
         ego_heartbeat_stale = status == "overdue"
         ego_heartbeat_age_s = hb.get("age_seconds")
-        # unknown (unparseable ts) can't confirm liveness → surface as error, not
-        # healthy.
+        # unknown (unparseable/future ts) can't confirm liveness → error, not healthy.
         ego_heartbeat_error = status == "unknown"
+        # no_heartbeat = NO pulse on record. ego emits a "start" pulse at bootstrap
+        # (cadence.py:302), so past a short boot-grace window this is a real absence
+        # (never-started / lost), NOT a healthy tile. Within the grace window (just
+        # after boot, ego's first pulse pending) it is benign. A None boot stamp
+        # (degraded boot) → no grace → treat as error (fail-loud, the safe way). (P2-5)
+        if status == "no_heartbeat":
+            _booted_at = getattr(rt, "_bootstrap_completed_at", None)
+            _grace_s = HEARTBEAT_EXPECTED["ego"][0] + 60  # one pulse interval + margin
+            within_grace = False
+            if _booted_at is not None:
+                within_grace = (datetime.now(UTC) - _booted_at).total_seconds() < _grace_s
+            ego_heartbeat_error = not within_grace
     except Exception:
         import logging as _logging
 

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -147,6 +147,38 @@ async def ego_status():
     user_cadence = await _cadence_snapshot(rt._ego_cadence_manager)
     genesis_cadence = await _cadence_snapshot(rt._genesis_ego_cadence_manager)
 
+    # Total-cessation (scheduler-death) tile signal. The per-ego intent-lag
+    # liveness (``stalled`` above) is BLIND to it: when a cadence scheduler dies,
+    # last_proactive_fire and last_success freeze together, the lag never opens,
+    # and the verdict stays healthy (see ego.liveness coverage boundary). The
+    # dedicated 5-min ego_heartbeat pulse keeps beating through a consumer/gate
+    # deadlock and stops ONLY on scheduler death, so its staleness is the honest
+    # total-cessation signal — reading the SAME signal + 4h threshold as the
+    # subsystem_stale:ego alert, so tile and alert can never disagree.
+    # SCHEDULER-LEVEL: the Subsystem.EGO heartbeat is shared across both ego
+    # managers, so it goes stale only when BOTH stop (or the process dies);
+    # single-ego cessation needs per-ego heartbeat tagging (follow-up).
+    # raise_on_error=True → a broken read fails LOUD (unknown), never a spurious
+    # healthy tile.
+    ego_heartbeat_stale = False
+    ego_heartbeat_age_s = None
+    ego_heartbeat_error = False
+    try:
+        from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+        hb = await compute_heartbeat_staleness("ego", db=rt._db, raise_on_error=True)
+        status = hb.get("status")
+        ego_heartbeat_stale = status == "overdue"
+        ego_heartbeat_age_s = hb.get("age_seconds")
+        # unknown (unparseable ts) can't confirm liveness → surface as error, not
+        # healthy.
+        ego_heartbeat_error = status == "unknown"
+    except Exception:
+        import logging as _logging
+
+        _logging.getLogger(__name__).debug("ego heartbeat-staleness read failed", exc_info=True)
+        ego_heartbeat_error = True
+
     # Genesis ego config — uses dedicated config fields
     genesis_ego_config = {
         "model": "sonnet",
@@ -200,6 +232,11 @@ async def ego_status():
             "uncompacted_cycles": uncompacted,
             "shadow_morning_report": config.shadow_morning_report,
             "board_size": config.board_size,
+            # Scheduler-level total-cessation signal (egoSemantic flips the tile
+            # + rollup red on stale; unknown/error → unknown, never a green lie).
+            "ego_heartbeat_stale": ego_heartbeat_stale,
+            "ego_heartbeat_age_s": ego_heartbeat_age_s,
+            "ego_heartbeat_error": ego_heartbeat_error,
             "egos": egos,
         }
     )

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -3771,6 +3771,23 @@
           const ge = ego.egos?.genesis_ego;
           const ueCad = ue?.cadence;
           const geCad = ge?.cadence;
+          // Total-cessation (scheduler death): the ego_heartbeat pulse went stale.
+          // The MOST authoritative ego signal — evaluate it BEFORE the auxiliary
+          // per-ego liveness/gated collectors below, so a CONFIRMED dead scheduler
+          // still turns the tile red even when an unrelated collector is degraded
+          // (otherwise a confirmed death gets masked as "unknown"). Fail-LOUD on a
+          // broken read (unknown), then flag a genuinely dead scheduler as error.
+          // Blind spot the per-ego intent-lag `stalled` below cannot see — on total
+          // cessation both ego timestamps freeze together, the lag never opens, and
+          // the tile would otherwise read green (the 3-day-dead-ego-shows-healthy
+          // bug). Scheduler-level: shared across both ego managers (see routes/ego.py).
+          if (ego.ego_heartbeat_error) {
+            return { state: "unknown", reason: "ego heartbeat data unavailable (read error)" };
+          }
+          if (ego.ego_heartbeat_stale) {
+            const hrs = ego.ego_heartbeat_age_s ? Math.round(ego.ego_heartbeat_age_s / 3600) : "?";
+            return { state: "error", reason: `ego scheduler stopped — no heartbeat in ${hrs}h` };
+          }
           // Fail-LOUD, not fail-green: if the liveness/gated read itself errored,
           // `stalled` defaulted to false — surfacing that as healthy would
           // recreate the exact false-green this instrumentation exists to kill.
@@ -3778,20 +3795,6 @@
           if (ueCad?.liveness_error || geCad?.liveness_error ||
               ueCad?.gated_error || geCad?.gated_error) {
             return { state: "unknown", reason: "ego liveness data unavailable (read error)" };
-          }
-          // Total-cessation (scheduler death): the ego_heartbeat pulse went stale.
-          // Fail-LOUD on a broken read (unknown), then flag a genuinely dead
-          // scheduler as error. This is the blind spot the per-ego intent-lag
-          // `stalled` below cannot see — on total cessation both ego timestamps
-          // freeze together, the lag never opens, and the tile would otherwise
-          // read green (the 3-day-dead-ego-shows-healthy bug). Scheduler-level:
-          // shared across both ego managers (see routes/ego.py).
-          if (ego.ego_heartbeat_error) {
-            return { state: "unknown", reason: "ego heartbeat data unavailable (read error)" };
-          }
-          if (ego.ego_heartbeat_stale) {
-            const hrs = ego.ego_heartbeat_age_s ? Math.round(ego.ego_heartbeat_age_s / 3600) : "?";
-            return { state: "error", reason: `ego scheduler stopped — no heartbeat in ${hrs}h` };
           }
           // Circuit breaker on either ego
           if (ueCad?.consecutive_failures >= 3 || geCad?.consecutive_failures >= 3) {

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -3779,6 +3779,20 @@
               ueCad?.gated_error || geCad?.gated_error) {
             return { state: "unknown", reason: "ego liveness data unavailable (read error)" };
           }
+          // Total-cessation (scheduler death): the ego_heartbeat pulse went stale.
+          // Fail-LOUD on a broken read (unknown), then flag a genuinely dead
+          // scheduler as error. This is the blind spot the per-ego intent-lag
+          // `stalled` below cannot see — on total cessation both ego timestamps
+          // freeze together, the lag never opens, and the tile would otherwise
+          // read green (the 3-day-dead-ego-shows-healthy bug). Scheduler-level:
+          // shared across both ego managers (see routes/ego.py).
+          if (ego.ego_heartbeat_error) {
+            return { state: "unknown", reason: "ego heartbeat data unavailable (read error)" };
+          }
+          if (ego.ego_heartbeat_stale) {
+            const hrs = ego.ego_heartbeat_age_s ? Math.round(ego.ego_heartbeat_age_s / 3600) : "?";
+            return { state: "error", reason: `ego scheduler stopped — no heartbeat in ${hrs}h` };
+          }
           // Circuit breaker on either ego
           if (ueCad?.consecutive_failures >= 3 || geCad?.consecutive_failures >= 3) {
             const which = (ueCad?.consecutive_failures >= 3 ? "CEO" : "") +

--- a/src/genesis/db/crud/events.py
+++ b/src/genesis/db/crud/events.py
@@ -155,12 +155,31 @@ async def prune(
     *,
     older_than: str,
     event_type: str | None = None,
+    keep_latest_per_subsystem: bool = False,
 ) -> int:
     """Delete events older than the given ISO timestamp. Returns count deleted.
 
     If *event_type* is provided, only events of that type are pruned.
+
+    *keep_latest_per_subsystem* (heartbeat GC): retain the single most-recent row
+    per subsystem even when it is older than the cutoff, so a liveness consumer
+    that reads "the last pulse" (``compute_heartbeat_staleness``) can still tell a
+    subsystem dead longer than the retention window from one that never pulsed.
+    Without it, a scheduler dead > the window loses its sole pulse and silently
+    reverts to ``no_heartbeat`` (false green). Requires *event_type* (the caller
+    is the per-type heartbeat GC); ignored otherwise.
     """
-    if event_type is not None:
+    if event_type is not None and keep_latest_per_subsystem:
+        # Delete old rows EXCEPT the newest per subsystem (a row is kept when its
+        # timestamp equals the per-subsystem max — strict ``<`` so ties are kept).
+        cursor = await db.execute(
+            "DELETE FROM events WHERE event_type = ? AND timestamp < ? "
+            "AND timestamp < (SELECT MAX(e2.timestamp) FROM events e2 "
+            "WHERE e2.event_type = events.event_type "
+            "AND e2.subsystem = events.subsystem)",
+            (event_type, older_than),
+        )
+    elif event_type is not None:
         cursor = await db.execute(
             "DELETE FROM events WHERE event_type = ? AND timestamp < ?",
             (event_type, older_than),

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -967,7 +967,10 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
     # fresh, never-bootstrapped install.)
     _stale_read_failed: list[str] = []
     try:
-        from genesis.mcp.health.manifest import compute_heartbeat_staleness
+        from genesis.mcp.health.manifest import (
+            _subsystem_enabled,
+            compute_heartbeat_staleness,
+        )
 
         _stale_db = _service._db if _service else None
         for _hb_name in ("ego", "inbox", "dashboard"):
@@ -1008,7 +1011,11 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 current_ids.add(alert_id)
                 continue
             if _status != "overdue":
-                # alive / paused / no_heartbeat (empty-state) → no alert
+                # alive / paused / resuming / no_heartbeat (empty-state) → no alert
+                continue
+            if not _subsystem_enabled(_hb_name):
+                # Intentionally DISABLED after having pulsed → its retained stale pulse
+                # is deliberate, not a death; suppress the (else permanent) alert.
                 continue
             _age = int(_hb.get("age_seconds") or 0)
             _last_seen = str(_hb.get("last_seen") or "")[:19]

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -939,6 +939,48 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             # operational fault, not an expected-absent-table case, so ERROR.
             logger.error("Never-succeeded job alert check failed", exc_info=True)
 
+    # ── Stopped-firing subsystems (total-cessation) ──────────────────
+    # Each heartbeat-emitting subsystem pulses a durable ``heartbeat`` event
+    # every cycle; when that pulse goes overdue past its per-subsystem threshold
+    # the scheduler/loop has stopped — a SILENT death the failure-gap alarms
+    # above cannot see (those need a RUNNING-but-failing job; a stopped job never
+    # advances last_run either). Complements job_stale/job_never_succeeded.
+    # reflection is excluded (its pulse is emitted by the awareness loop, so it
+    # re-detects awareness/DB liveness, not reflection-engine death); awareness
+    # has its own more-precise ``awareness:tick_overdue`` alert above. ego →
+    # CRITICAL (a dead ego scheduler is the failure this batch began with), the
+    # rest → WARNING. Coverage cap: the ~90 non-pulse scheduled jobs get ONLY the
+    # failure-gap signals above — no durable per-job schedule source exists to
+    # detect their stopped-firing (in-memory jobstore; IntervalTrigger resets on
+    # restart). The shared ``compute_heartbeat_staleness`` reads the same signal
+    # the ego dashboard tile does, so alert and tile can never disagree.
+    try:
+        from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+        for _hb_name in ("ego", "surplus", "inbox", "dashboard", "outreach"):
+            _hb = await compute_heartbeat_staleness(_hb_name)
+            if _hb.get("status") != "overdue":
+                continue  # alive / no_heartbeat (empty-state) / unknown → no alert
+            _age = int(_hb.get("age_seconds") or 0)
+            _last_seen = str(_hb.get("last_seen") or "")[:19]
+            alert_id = f"subsystem_stale:{_hb_name}"
+            alerts.append(
+                {
+                    "id": alert_id,
+                    "severity": "CRITICAL" if _hb_name == "ego" else "WARNING",
+                    "message": (
+                        f"Subsystem '{_hb_name}' heartbeat overdue — no pulse in "
+                        f"{_age}s (last seen {_last_seen}); its scheduler/loop may "
+                        f"have died"
+                    ),
+                }
+            )
+            current_ids.add(alert_id)
+    except Exception:
+        # Own try/except so a pulse-staleness read failure can't blind the other
+        # alert blocks; ERROR-logged (never a silent green).
+        logger.error("Subsystem pulse-staleness alert check failed", exc_info=True)
+
     # ── Genesis update available ─────────────────────────────────────
     if _service and _service._db:
         try:

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -940,27 +940,76 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
             logger.error("Never-succeeded job alert check failed", exc_info=True)
 
     # ── Stopped-firing subsystems (total-cessation) ──────────────────
-    # Each heartbeat-emitting subsystem pulses a durable ``heartbeat`` event
-    # every cycle; when that pulse goes overdue past its per-subsystem threshold
-    # the scheduler/loop has stopped — a SILENT death the failure-gap alarms
-    # above cannot see (those need a RUNNING-but-failing job; a stopped job never
+    # Each subsystem below pulses a durable ``heartbeat`` event whose emission is
+    # independent of pause (ego: dedicated ego_heartbeat job; dashboard: dedicated
+    # daemon thread) or is downgraded to "paused" while paused (inbox, whose pulse
+    # stops behind ``if paused: return`` — handled in compute_heartbeat_staleness).
+    # When that pulse goes overdue past its per-subsystem threshold the
+    # scheduler/loop has stopped — a SILENT death the failure-gap alarms above
+    # cannot see (those need a RUNNING-but-failing job; a stopped job never
     # advances last_run either). Complements job_stale/job_never_succeeded.
-    # reflection is excluded (its pulse is emitted by the awareness loop, so it
-    # re-detects awareness/DB liveness, not reflection-engine death); awareness
-    # has its own more-precise ``awareness:tick_overdue`` alert above. ego →
-    # CRITICAL (a dead ego scheduler is the failure this batch began with), the
-    # rest → WARNING. Coverage cap: the ~90 non-pulse scheduled jobs get ONLY the
-    # failure-gap signals above — no durable per-job schedule source exists to
-    # detect their stopped-firing (in-memory jobstore; IntervalTrigger resets on
-    # restart). The shared ``compute_heartbeat_staleness`` reads the same signal
-    # the ego dashboard tile does, so alert and tile can never disagree.
+    # SET = ego (CRITICAL — the dead-ego-scheduler failure this batch began with)
+    # + inbox + dashboard (WARNING). EXCLUDED: surplus — PR-B's shipped tile
+    # already flips red on a wedged/dead surplus via its finer job_health signal,
+    # and surplus's event-heartbeat is load-fragile (loop-END emit gaps under a
+    # 15-30min dispatch); outreach — its pulse is config-gated (never fires on a
+    # Telegram-less install; a once-Telegram-then-removed install would fire a
+    # permanent unresolvable alert), so it is a false-alarm trap (follow-up: give
+    # outreach a dedicated pause-independent heartbeat). reflection — its pulse is
+    # the awareness loop, not reflection-engine liveness; awareness — has the more
+    # precise ``awareness:tick_overdue`` above. Coverage cap: the ~90 non-pulse
+    # scheduled jobs get ONLY the failure-gap signals above. The shared
+    # ``compute_heartbeat_staleness`` reads the same signal the ego dashboard tile
+    # does, so alert and tile agree on the OVERDUE verdict. (They diverge by design
+    # on ``no_heartbeat``: the tile applies a boot-grace and flips to error past it,
+    # while the alert path treats no-pulse-ever as empty-state — a once-run subsystem
+    # always retains a pulse via keep_latest GC, so this only differs on a truly
+    # fresh, never-bootstrapped install.)
+    _stale_read_failed: list[str] = []
     try:
         from genesis.mcp.health.manifest import compute_heartbeat_staleness
 
-        for _hb_name in ("ego", "surplus", "inbox", "dashboard", "outreach"):
-            _hb = await compute_heartbeat_staleness(_hb_name)
-            if _hb.get("status") != "overdue":
-                continue  # alive / no_heartbeat (empty-state) / unknown → no alert
+        _stale_db = _service._db if _service else None
+        for _hb_name in ("ego", "inbox", "dashboard"):
+            try:
+                # raise_on_error=True → a read failure fails LOUD (handled below by
+                # preserving any open alert), never a silent green that lets
+                # reconcile auto-resolve a genuinely-open subsystem_stale alert.
+                _hb = await compute_heartbeat_staleness(_hb_name, db=_stale_db, raise_on_error=True)
+            except Exception:
+                logger.error(
+                    "Pulse-staleness read failed for subsystem %s", _hb_name, exc_info=True
+                )
+                _stale_read_failed.append(_hb_name)
+                continue
+            _status = _hb.get("status")
+            if _status == "unknown":
+                # Unreadable pulse (corrupt / materially-future timestamp) → liveness
+                # cannot be confirmed. Surface LOUDLY as a WARNING (honest: "can't
+                # tell", NOT "died" — distinct id from subsystem_stale) instead of a
+                # silent skip; auto-resolves when a fresh parseable pulse lands.
+                logger.error(
+                    "Subsystem %s heartbeat unreadable (unknown) — liveness unconfirmable",
+                    _hb_name,
+                )
+                _unk_last = str(_hb.get("last_seen") or "")[:40]
+                alert_id = f"subsystem_heartbeat_unknown:{_hb_name}"
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "WARNING",
+                        "message": (
+                            f"Subsystem '{_hb_name}' heartbeat is unreadable (corrupt "
+                            f"or clock-skewed timestamp '{_unk_last}') — liveness "
+                            f"cannot be confirmed"
+                        ),
+                    }
+                )
+                current_ids.add(alert_id)
+                continue
+            if _status != "overdue":
+                # alive / paused / no_heartbeat (empty-state) → no alert
+                continue
             _age = int(_hb.get("age_seconds") or 0)
             _last_seen = str(_hb.get("last_seen") or "")[:19]
             alert_id = f"subsystem_stale:{_hb_name}"
@@ -976,6 +1025,41 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 }
             )
             current_ids.add(alert_id)
+
+        # Fail-open guard (P2-4): a subsystem whose staleness read FAILED this tick
+        # is in an unknown state — we must NOT let the reconcile writer auto-resolve
+        # a genuinely-open subsystem_stale alert for it on a transient read blip.
+        # The reconcile writer (awareness/loop.py:158-168) builds its active-set
+        # from this ``alerts`` LIST (it does not consult current_ids), so RE-EMIT
+        # the already-open alert (reconstructed from its open row) — keeping it both
+        # open and displayed — for only the SPECIFIC failed subsystems (ones that
+        # read fine resolve/alert normally).
+        if _stale_read_failed and _service and _service._db:
+            try:
+                from genesis.db.crud import alert_events as _ae
+
+                _open_rows = {r.get("alert_id", ""): r for r in await _ae.list_open(_service._db)}
+                # Preserve BOTH alert families this block can emit for the subsystem
+                # (subsystem_stale: overdue, subsystem_heartbeat_unknown: unreadable) —
+                # otherwise the omitted family flaps (auto-resolved by the reconciler
+                # on the failed tick, re-opened on the next successful one).
+                for _n in _stale_read_failed:
+                    for _aid in (f"subsystem_stale:{_n}", f"subsystem_heartbeat_unknown:{_n}"):
+                        _row = _open_rows.get(_aid)
+                        if _row is not None:
+                            alerts.append(
+                                {
+                                    "id": _aid,
+                                    "severity": _row.get("severity", "WARNING"),
+                                    "message": _row.get("message", ""),
+                                }
+                            )
+                            current_ids.add(_aid)  # lockstep, for alert-history dedup
+            except Exception:
+                logger.error(
+                    "Preserving open subsystem-heartbeat alerts on read failure failed",
+                    exc_info=True,
+                )
     except Exception:
         # Own try/except so a pulse-staleness read failure can't blind the other
         # alert blocks; ERROR-logged (never a silent green).

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import aiosqlite
@@ -157,7 +157,11 @@ async def _impl_bootstrap_manifest() -> dict:
 HEARTBEAT_EXPECTED = {
     "awareness": (300, 360),      # 5 min tick, error at 6 min
     "surplus": (300, 600),
-    "inbox": (1800, 3600),
+    # inbox checks every 30 min (inbox/types.py check_interval_seconds=1800).
+    # overdue=4× (7200s) so one slow/skipped check doesn't false-fire; a 2×
+    # (3600s) threshold was too tight. (Assumes the default interval; a custom
+    # check_interval_seconds should scale this — derive-from-config is a nicety.)
+    "inbox": (1800, 7200),
     # Reflections only fire when signals warrant; calm periods can be quiet
     # for hours. An idle alive-pulse (awareness loop) keeps this fresh during
     # legitimate idle, so overdue=4h (matches ego) avoids false "dark" alarms.
@@ -165,21 +169,84 @@ HEARTBEAT_EXPECTED = {
     # (6 min), the cc resilience axis, and the deferred-work backlog.
     "reflection": (600, 14400),
     "outreach": (86400, 172800),
-    "dashboard": (120, 240),
+    "dashboard": (120, 600),      # 60s daemon-thread pulse; overdue at 10× (was 4×)
     "ego": (300, 14400),          # 5-min liveness pulse (ego_heartbeat job), overdue at 4h
 }
 
+# Subsystems whose heartbeat is emitted only AFTER their loop's
+# ``if paused: return`` guard — so a deliberately-paused Genesis stops their
+# pulse and they would false-read as dead. VERIFIED emit-after-pause sites:
+# surplus (surplus/scheduler.py:823-853) and inbox (inbox/monitor.py:2120-2154).
+# ego (dedicated ``ego_heartbeat`` job) and dashboard (dedicated daemon thread)
+# pulse THROUGH pause, so they are NOT here — an overdue-while-paused for them is
+# a genuine scheduler death that must still surface. See compute_heartbeat_staleness.
+_PAUSE_GATED_HEARTBEATS = frozenset({"surplus", "inbox"})
+
+# A heartbeat more than this far in the FUTURE (clock skew / corrupt row) cannot
+# confirm liveness → verdict "unknown", never a false "alive" from a negative age.
+# Mirrors observability/liveness.py FUTURE_SKEW_TOLERANCE_MINUTES (kept local to
+# avoid an import cycle into that module from the health manifest).
+_FUTURE_SKEW_TOLERANCE_S = 5 * 60
+
+
+def _read_global_paused() -> bool:
+    """Best-effort read of the global runtime pause flag (never constructs a
+    zombie singleton; defaults to NOT-paused so a read failure surfaces the
+    alert rather than silently masking a real death)."""
+    try:
+        from genesis.runtime import GenesisRuntime
+
+        rt = GenesisRuntime.peek()
+        return bool(rt.paused) if rt is not None else False
+    except Exception:
+        logger.debug("global pause read failed; treating as not-paused", exc_info=True)
+        return False
+
+
+def _freshest_timestamp(
+    a: str | None, b: str | None, *, not_after: datetime | None = None
+) -> str | None:
+    """Return the freshest USABLE ISO timestamp (tolerant of None/unparseable).
+
+    The durable ``events`` row and the in-memory event-bus ring can each hold the
+    newest pulse — the ring updates synchronously while the DB persists
+    fire-and-forget, so a fresh pulse can live only in the ring for a moment. Take
+    the freshest so a DB-lagged read never false-REDs a live subsystem (P2-2).
+
+    ``not_after`` (typically now + skew tolerance) marks a value as materially
+    future/corrupt: such a candidate must NOT win over a valid non-future one, or a
+    corrupt future DB row would mask a fresh ring pulse and yield a false "unknown".
+    A future/unparseable value is returned ONLY as a last resort (sole candidate),
+    so the caller still surfaces "unknown" rather than a spurious "alive"."""
+    best: str | None = None  # freshest qualifying (parseable, not materially-future)
+    best_dt: datetime | None = None
+    fallback: str | None = None  # any value at all, if nothing qualifies
+    for ts in (a, b):
+        if not ts:
+            continue
+        if fallback is None:
+            fallback = ts
+        try:
+            dt = datetime.fromisoformat(ts)
+        except (ValueError, TypeError):
+            continue
+        if not_after is not None and dt > not_after:
+            continue  # materially-future/corrupt → never beats a valid non-future one
+        if best_dt is None or dt > best_dt:
+            best, best_dt = ts, dt
+    return best if best is not None else fallback
+
 
 async def compute_heartbeat_staleness(
-    name: str, db=None, raise_on_error: bool = False
+    name: str, db=None, raise_on_error: bool = False, paused: bool | None = None
 ) -> dict:
     """Staleness verdict for ONE heartbeat-emitting subsystem.
 
-    Reads the latest durable ``heartbeat`` event for *name* (falling back to the
-    in-memory event-bus ring) and compares its age to the subsystem's overdue
-    threshold in :data:`HEARTBEAT_EXPECTED`. Returns the same per-subsystem shape
-    :func:`_impl_subsystem_heartbeats` yields:
-    ``{status: alive|overdue|no_heartbeat|unknown, last_seen, age_seconds?}``.
+    Reads the latest durable ``heartbeat`` event for *name* AND the in-memory
+    event-bus ring, uses the FRESHEST of the two, and compares its age to the
+    subsystem's overdue threshold in :data:`HEARTBEAT_EXPECTED`. Returns the same
+    per-subsystem shape :func:`_impl_subsystem_heartbeats` yields:
+    ``{status: alive|overdue|paused|no_heartbeat|unknown, last_seen, age_seconds?}``.
 
     *db* defaults to the health service's connection; a caller with its own
     runtime connection (e.g. the ego dashboard route) passes it explicitly.
@@ -191,6 +258,15 @@ async def compute_heartbeat_staleness(
     rather than paint a healthy tile over a broken read. (Truly unexpected
     exception types always propagate — matching the original display behavior of
     surfacing ``is_error`` rather than silently dropping a real bug.)
+
+    *paused*: for a :data:`_PAUSE_GATED_HEARTBEATS` subsystem (surplus/inbox,
+    whose pulse stops behind their loop's ``if paused: return``), a would-be
+    ``overdue`` verdict while Genesis is globally paused is downgraded to
+    ``paused`` — a deliberately-paused subsystem is not a dead one. ``None`` (the
+    default) reads the live global pause flag; callers may pass an explicit bool
+    (tests, or a caller that already read it). Non-pause-gated subsystems
+    (ego/dashboard) pulse THROUGH pause, so an ``overdue`` for them is a real
+    death and is never downgraded.
 
     An unknown *name* (not in the threshold table) → ``no_heartbeat``; never raises
     for that reason.
@@ -207,7 +283,7 @@ async def compute_heartbeat_staleness(
         db = _service._db if _service else None
     _event_bus = health_mcp_mod._event_bus
 
-    last_ts = None
+    db_ts = None
     if db is not None:
         try:
             from genesis.db.crud import events as events_crud
@@ -216,7 +292,7 @@ async def compute_heartbeat_staleness(
                 db, subsystem=name, event_type="heartbeat", limit=1
             )
             if rows:
-                last_ts = rows[0].get("timestamp")
+                db_ts = rows[0].get("timestamp")
         except (aiosqlite.Error, ImportError, AttributeError, TimeoutError):
             # Narrow catch: DB query failure (aiosqlite.Error, TimeoutError),
             # broken import chain (ImportError), or malformed row shape
@@ -232,7 +308,8 @@ async def compute_heartbeat_staleness(
             if raise_on_error:
                 raise
 
-    if not last_ts and _event_bus is not None and hasattr(_event_bus, "_ring"):
+    ring_ts = None
+    if _event_bus is not None and hasattr(_event_bus, "_ring"):
         for event in reversed(_event_bus._ring):
             sub_val = (
                 event.subsystem.value
@@ -240,20 +317,42 @@ async def compute_heartbeat_staleness(
                 else str(event.subsystem)
             )
             if sub_val == name and event.event_type == "heartbeat":
-                last_ts = event.timestamp
+                ring_ts = event.timestamp
                 break
+
+    # Use the freshest of the durable row and the in-memory ring — a DB-lagged
+    # read must never false-RED a subsystem that just pulsed (P2-2) — but a corrupt
+    # future row must not mask a valid fresh pulse, so exclude materially-future
+    # candidates from winning (N-2).
+    _now = datetime.now(UTC)
+    last_ts = _freshest_timestamp(
+        db_ts, ring_ts, not_after=_now + timedelta(seconds=_FUTURE_SKEW_TOLERANCE_S)
+    )
 
     if last_ts is None:
         return {"status": "no_heartbeat", "last_seen": None}
     try:
-        age_s = (datetime.now(UTC) - datetime.fromisoformat(last_ts)).total_seconds()
-        return {
-            "status": "overdue" if age_s > overdue_s else "alive",
-            "last_seen": last_ts,
-            "age_seconds": round(age_s, 1),
-        }
+        age_s = (_now - datetime.fromisoformat(last_ts)).total_seconds()
     except (ValueError, TypeError):
         return {"status": "unknown", "last_seen": last_ts}
+
+    # A pulse materially in the future (clock skew / corrupt row) cannot confirm
+    # liveness → unknown, never a false "alive" from a negative age (P2-3).
+    if age_s < -_FUTURE_SKEW_TOLERANCE_S:
+        return {"status": "unknown", "last_seen": last_ts}
+
+    if age_s <= overdue_s:
+        return {"status": "alive", "last_seen": last_ts, "age_seconds": round(age_s, 1)}
+
+    # Overdue. For a pause-gated subsystem, a globally-paused Genesis is NOT a
+    # dead one — its pulse legitimately stops on pause. Downgrade to a non-overdue
+    # "paused" verdict so no consumer (alert / morning report / tile) reads it as
+    # death. ego/dashboard pulse through pause, so they are never downgraded.
+    if name in _PAUSE_GATED_HEARTBEATS:
+        is_paused = paused if paused is not None else _read_global_paused()
+        if is_paused:
+            return {"status": "paused", "last_seen": last_ts, "age_seconds": round(age_s, 1)}
+    return {"status": "overdue", "last_seen": last_ts, "age_seconds": round(age_s, 1)}
 
 
 async def _impl_subsystem_heartbeats() -> dict:

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -220,25 +220,80 @@ def _read_global_paused() -> bool:
         return False
 
 
+def _subsystem_enabled(name: str) -> bool:
+    """Best-effort: is this subsystem configured to run?
+
+    A subsystem DISABLED after it had already pulsed keeps a retained final heartbeat
+    that would otherwise age into a PERMANENT cessation alert (a disabled ego → a
+    permanent CRITICAL) — its stale pulse is intentional, not a death. Defaults True
+    (fail toward surfacing); only subsystems with a real disable switch are checked.
+    (Generalizing to inbox/dashboard + the never-started case is the bootstrap-manifest
+    follow-up.)"""
+    try:
+        if name == "ego":
+            from genesis.ego.config import load_ego_config
+
+            return bool(load_ego_config().enabled)
+    except Exception:
+        logger.debug("subsystem-enabled read failed for %s", name, exc_info=True)
+    return True
+
+
 def _newest_valid_ts(candidates_newest_first, *, now: datetime) -> tuple[str | None, bool]:
     """Pick the newest USABLE heartbeat ISO from an ordered (newest-first) iterable.
 
-    Returns ``(iso, saw_any)``: *iso* is the newest candidate that parses to an aware
-    UTC datetime no more than the skew tolerance in the future (the shared
-    ``parse_iso_utc`` normalizes naive values, fixing mixed-awareness TypeErrors);
-    *saw_any* is True iff any candidate string was seen at all (used to tell a
-    corrupt-but-present pulse — ``unknown`` — from a fresh install — ``no_heartbeat``).
-    A materially-future or unparseable candidate is skipped, never chosen."""
+    Returns ``(iso, saw_any)``: *iso* is the candidate with the newest PARSED UTC
+    instant that is no more than the skew tolerance in the future — compared BY
+    INSTANT (via the shared ``parse_iso_utc``, which normalizes naive values), NOT by
+    the caller's textual order, since a textual ``ORDER BY`` is not chronological when
+    rows carry different UTC offsets (e.g. ``15:00+00:00`` sorts ahead of the actually-
+    later ``11:30-04:00``). *saw_any* is True iff any candidate string was seen at all
+    (used to tell a corrupt-but-present pulse — ``unknown`` — from a fresh install —
+    ``no_heartbeat``). A materially-future or unparseable candidate is never chosen."""
     bound = now + timedelta(minutes=FUTURE_SKEW_TOLERANCE_MINUTES)
     saw_any = False
+    best_iso: str | None = None
+    best_dt: datetime | None = None
     for iso in candidates_newest_first:
         if not iso:
             continue
         saw_any = True
         dt = parse_iso_utc(iso)
-        if dt is not None and dt <= bound:
-            return iso, saw_any
-    return None, saw_any
+        if dt is not None and dt <= bound and (best_dt is None or dt > best_dt):
+            best_iso, best_dt = iso, dt
+    return best_iso, saw_any
+
+
+async def _post_resume_grace_active(db, *, name: str, now: datetime, interval_s: int) -> bool:
+    """True if Genesis resumed from a pause within this subsystem's expected interval
+    (+ a scheduler-timing buffer).
+
+    A pause-gated subsystem's pulse legitimately stops during a pause and does not
+    refresh until its next cycle AFTER resume — so an overdue pulse in that window is a
+    bounded post-resume transient, NOT a death (``observability/liveness.py`` documents
+    that any PUSH alert built on a pulse must anchor to a resume/boot grace). Reads the
+    latest durable ``runtime``/``resume`` event, so it works cross-process (the standalone
+    health MCP sees the same events table). No resume on record → no grace."""
+    if db is None:
+        return False
+    try:
+        from genesis.db.crud import events as events_crud
+
+        rows = await events_crud.query(
+            db, subsystem="runtime", event_type="resume", limit=_HEARTBEAT_SCAN_LIMIT
+        )
+        # Same textual-ORDER-BY trap #240 fixes for heartbeats: pick the newest resume
+        # by PARSED instant, not textual order (resume ts are UTC today, but don't rely
+        # on that invariant here either).
+        resume_iso, _ = _newest_valid_ts([r.get("timestamp") for r in rows], now=now)
+        resume_dt = parse_iso_utc(resume_iso) if resume_iso else None
+        if resume_dt is None:
+            return False
+        grace_s = interval_s + 120  # one expected interval + scheduler-timing slack
+        return 0 <= (now - resume_dt).total_seconds() < grace_s
+    except (aiosqlite.Error, ImportError, AttributeError, TimeoutError):
+        logger.debug("post-resume grace check failed for %s", name, exc_info=True)
+        return False
 
 
 async def compute_heartbeat_staleness(
@@ -369,6 +424,10 @@ async def compute_heartbeat_staleness(
         is_paused = paused if paused is not None else _read_global_paused()
         if is_paused:
             return {"status": "paused", "last_seen": last_ts, "age_seconds": round(age_s, 1)}
+        # Just resumed from a >threshold pause: the pulse hasn't had a cycle to refresh
+        # yet → bounded transient, not a death. Non-alerting "resuming" verdict.
+        if await _post_resume_grace_active(db, name=name, now=_now, interval_s=_interval_s):
+            return {"status": "resuming", "last_seen": last_ts, "age_seconds": round(age_s, 1)}
     return {"status": "overdue", "last_seen": last_ts, "age_seconds": round(age_s, 1)}
 
 

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -12,6 +12,7 @@ import aiosqlite
 from genesis.env import db_busy_timeout_ms
 from genesis.mcp.health import mcp  # noqa: E402
 from genesis.mcp.health.constants import JOB_STALE_GAP_DAYS
+from genesis.observability.liveness import FUTURE_SKEW_TOLERANCE_MINUTES, parse_iso_utc
 
 logger = logging.getLogger(__name__)
 
@@ -182,59 +183,62 @@ HEARTBEAT_EXPECTED = {
 # a genuine scheduler death that must still surface. See compute_heartbeat_staleness.
 _PAUSE_GATED_HEARTBEATS = frozenset({"surplus", "inbox"})
 
-# A heartbeat more than this far in the FUTURE (clock skew / corrupt row) cannot
-# confirm liveness → verdict "unknown", never a false "alive" from a negative age.
-# Mirrors observability/liveness.py FUTURE_SKEW_TOLERANCE_MINUTES (kept local to
-# avoid an import cycle into that module from the health manifest).
-_FUTURE_SKEW_TOLERANCE_S = 5 * 60
+# How many recent heartbeat rows to scan for the newest USABLE pulse. >1 so a few
+# unparseable / materially-future rows (which sort FIRST under the events table's
+# TEXT ``ORDER BY timestamp DESC`` — a "2099-.." or "not-a-date" value) can't hide
+# the valid pulses beneath them and pin a LIMIT-1 read on a bad row forever (#9). A
+# window with NO valid non-future row → ``unknown`` (corrupt) or ``no_heartbeat``
+# (empty), never a spurious verdict off the bad row. Residual (bounded, surfaced,
+# not silent): if MORE than this many future/unparseable rows sort ahead of the
+# newest valid pulse it reads ``unknown`` until they age out — needs sustained
+# future-timestamp corruption, which the keep-latest GC otherwise bounds.
+_HEARTBEAT_SCAN_LIMIT = 25
+
+# Path of the cross-process pause file (single source of truth for pause; the
+# standalone health MCP has no bootstrapped GenesisRuntime, so peek() is None there).
+_PAUSE_FILE = Path.home() / ".genesis" / "paused.json"
 
 
 def _read_global_paused() -> bool:
-    """Best-effort read of the global runtime pause flag (never constructs a
-    zombie singleton; defaults to NOT-paused so a read failure surfaces the
-    alert rather than silently masking a real death)."""
-    try:
-        from genesis.runtime import GenesisRuntime
+    """Global pause state, read cross-process-safe from the persisted pause file.
 
-        rt = GenesisRuntime.peek()
-        return bool(rt.paused) if rt is not None else False
+    Pause is persisted to ``~/.genesis/paused.json`` (present with ``paused:true``
+    when paused, ABSENT when not — see runtime/_pause_state.py) — the source of
+    truth EVERY process sees, including the standalone health MCP, whose
+    ``StandaloneHealthDataService`` has no bootstrapped GenesisRuntime (so a
+    runtime-singleton read would always return not-paused there and false-alarm a
+    paused subsystem). Absent file / read error → not-paused, so a read failure
+    surfaces the alert (fail-loud) rather than masking a real death."""
+    try:
+        if not _PAUSE_FILE.exists():
+            return False
+        import json
+
+        return bool(json.loads(_PAUSE_FILE.read_text()).get("paused", False))
     except Exception:
         logger.debug("global pause read failed; treating as not-paused", exc_info=True)
         return False
 
 
-def _freshest_timestamp(
-    a: str | None, b: str | None, *, not_after: datetime | None = None
-) -> str | None:
-    """Return the freshest USABLE ISO timestamp (tolerant of None/unparseable).
+def _newest_valid_ts(candidates_newest_first, *, now: datetime) -> tuple[str | None, bool]:
+    """Pick the newest USABLE heartbeat ISO from an ordered (newest-first) iterable.
 
-    The durable ``events`` row and the in-memory event-bus ring can each hold the
-    newest pulse — the ring updates synchronously while the DB persists
-    fire-and-forget, so a fresh pulse can live only in the ring for a moment. Take
-    the freshest so a DB-lagged read never false-REDs a live subsystem (P2-2).
-
-    ``not_after`` (typically now + skew tolerance) marks a value as materially
-    future/corrupt: such a candidate must NOT win over a valid non-future one, or a
-    corrupt future DB row would mask a fresh ring pulse and yield a false "unknown".
-    A future/unparseable value is returned ONLY as a last resort (sole candidate),
-    so the caller still surfaces "unknown" rather than a spurious "alive"."""
-    best: str | None = None  # freshest qualifying (parseable, not materially-future)
-    best_dt: datetime | None = None
-    fallback: str | None = None  # any value at all, if nothing qualifies
-    for ts in (a, b):
-        if not ts:
+    Returns ``(iso, saw_any)``: *iso* is the newest candidate that parses to an aware
+    UTC datetime no more than the skew tolerance in the future (the shared
+    ``parse_iso_utc`` normalizes naive values, fixing mixed-awareness TypeErrors);
+    *saw_any* is True iff any candidate string was seen at all (used to tell a
+    corrupt-but-present pulse — ``unknown`` — from a fresh install — ``no_heartbeat``).
+    A materially-future or unparseable candidate is skipped, never chosen."""
+    bound = now + timedelta(minutes=FUTURE_SKEW_TOLERANCE_MINUTES)
+    saw_any = False
+    for iso in candidates_newest_first:
+        if not iso:
             continue
-        if fallback is None:
-            fallback = ts
-        try:
-            dt = datetime.fromisoformat(ts)
-        except (ValueError, TypeError):
-            continue
-        if not_after is not None and dt > not_after:
-            continue  # materially-future/corrupt → never beats a valid non-future one
-        if best_dt is None or dt > best_dt:
-            best, best_dt = ts, dt
-    return best if best is not None else fallback
+        saw_any = True
+        dt = parse_iso_utc(iso)
+        if dt is not None and dt <= bound:
+            return iso, saw_any
+    return None, saw_any
 
 
 async def compute_heartbeat_staleness(
@@ -283,16 +287,26 @@ async def compute_heartbeat_staleness(
         db = _service._db if _service else None
     _event_bus = health_mcp_mod._event_bus
 
-    db_ts = None
+    _now = datetime.now(UTC)
+
+    # Durable candidates: a WINDOW of the newest heartbeat rows (not just LIMIT 1).
+    # A corrupt / materially-future timestamp sorts FIRST under the events table's
+    # TEXT ``ORDER BY timestamp DESC``, so a single-row read could pin the verdict on
+    # a bad row forever; scanning a window lets ``_newest_valid_ts`` skip past the bad
+    # rows to the newest genuinely-usable pulse (#9). A window with only future /
+    # unparseable rows → unknown (surfaced, per the liveness contract), never silent.
+    db_candidates: list[str | None] = []
     if db is not None:
         try:
             from genesis.db.crud import events as events_crud
 
             rows = await events_crud.query(
-                db, subsystem=name, event_type="heartbeat", limit=1
+                db,
+                subsystem=name,
+                event_type="heartbeat",
+                limit=_HEARTBEAT_SCAN_LIMIT,
             )
-            if rows:
-                db_ts = rows[0].get("timestamp")
+            db_candidates = [r.get("timestamp") for r in rows]
         except (aiosqlite.Error, ImportError, AttributeError, TimeoutError):
             # Narrow catch: DB query failure (aiosqlite.Error, TimeoutError),
             # broken import chain (ImportError), or malformed row shape
@@ -308,7 +322,9 @@ async def compute_heartbeat_staleness(
             if raise_on_error:
                 raise
 
-    ring_ts = None
+    # In-memory ring: a fresher not-yet-persisted pulse (the DB write is async),
+    # newest-first.
+    ring_candidates: list[str | None] = []
     if _event_bus is not None and hasattr(_event_bus, "_ring"):
         for event in reversed(_event_bus._ring):
             sub_val = (
@@ -317,29 +333,30 @@ async def compute_heartbeat_staleness(
                 else str(event.subsystem)
             )
             if sub_val == name and event.event_type == "heartbeat":
-                ring_ts = event.timestamp
-                break
+                ring_candidates.append(event.timestamp)
 
-    # Use the freshest of the durable row and the in-memory ring — a DB-lagged
-    # read must never false-RED a subsystem that just pulsed (P2-2) — but a corrupt
-    # future row must not mask a valid fresh pulse, so exclude materially-future
-    # candidates from winning (N-2).
-    _now = datetime.now(UTC)
-    last_ts = _freshest_timestamp(
-        db_ts, ring_ts, not_after=_now + timedelta(seconds=_FUTURE_SKEW_TOLERANCE_S)
-    )
+    # Newest USABLE pulse across both sources — freshest wins (P2-2), naive values
+    # normalized (fixes mixed-awareness TypeError), materially-future / unparseable
+    # skipped. saw_* records whether a candidate string existed at all, so a
+    # corrupt-but-present pulse (unknown) is told from a fresh install (no_heartbeat).
+    db_ts, saw_db = _newest_valid_ts(db_candidates, now=_now)
+    ring_ts, saw_ring = _newest_valid_ts(ring_candidates, now=_now)
+    last_ts = None
+    last_dt: datetime | None = None
+    for cand in (db_ts, ring_ts):
+        if cand is None:
+            continue
+        cand_dt = parse_iso_utc(cand)
+        if cand_dt is not None and (last_dt is None or cand_dt > last_dt):
+            last_ts, last_dt = cand, cand_dt
 
-    if last_ts is None:
-        return {"status": "no_heartbeat", "last_seen": None}
-    try:
-        age_s = (_now - datetime.fromisoformat(last_ts)).total_seconds()
-    except (ValueError, TypeError):
-        return {"status": "unknown", "last_seen": last_ts}
+    if last_ts is None or last_dt is None:
+        # No usable pulse. A candidate WAS present but unusable → unknown (can't
+        # confirm liveness); nothing at all → no_heartbeat (fresh-install empty-state).
+        status = "unknown" if (saw_db or saw_ring) else "no_heartbeat"
+        return {"status": status, "last_seen": None}
 
-    # A pulse materially in the future (clock skew / corrupt row) cannot confirm
-    # liveness → unknown, never a false "alive" from a negative age (P2-3).
-    if age_s < -_FUTURE_SKEW_TOLERANCE_S:
-        return {"status": "unknown", "last_seen": last_ts}
+    age_s = (_now - last_dt).total_seconds()
 
     if age_s <= overdue_s:
         return {"status": "alive", "last_seen": last_ts, "age_seconds": round(age_s, 1)}

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -148,83 +148,118 @@ async def _impl_bootstrap_manifest() -> dict:
         }
 
 
-async def _impl_subsystem_heartbeats() -> dict:
+# (expected_interval_s, overdue_threshold_s) per heartbeat-emitting subsystem.
+# ONE source of truth for the subsystem_heartbeats display tool, the
+# ``subsystem_stale:<name>`` pulse-staleness alert (errors.py), and the ego
+# dashboard tile (routes/ego.py) — so those surfaces can never disagree.
+# ``expected_interval_s`` is currently informational; ``overdue_s`` drives the
+# verdict.
+HEARTBEAT_EXPECTED = {
+    "awareness": (300, 360),      # 5 min tick, error at 6 min
+    "surplus": (300, 600),
+    "inbox": (1800, 3600),
+    # Reflections only fire when signals warrant; calm periods can be quiet
+    # for hours. An idle alive-pulse (awareness loop) keeps this fresh during
+    # legitimate idle, so overdue=4h (matches ego) avoids false "dark" alarms.
+    # A real reflection outage surfaces faster via the awareness heartbeat
+    # (6 min), the cc resilience axis, and the deferred-work backlog.
+    "reflection": (600, 14400),
+    "outreach": (86400, 172800),
+    "dashboard": (120, 240),
+    "ego": (300, 14400),          # 5-min liveness pulse (ego_heartbeat job), overdue at 4h
+}
+
+
+async def compute_heartbeat_staleness(
+    name: str, db=None, raise_on_error: bool = False
+) -> dict:
+    """Staleness verdict for ONE heartbeat-emitting subsystem.
+
+    Reads the latest durable ``heartbeat`` event for *name* (falling back to the
+    in-memory event-bus ring) and compares its age to the subsystem's overdue
+    threshold in :data:`HEARTBEAT_EXPECTED`. Returns the same per-subsystem shape
+    :func:`_impl_subsystem_heartbeats` yields:
+    ``{status: alive|overdue|no_heartbeat|unknown, last_seen, age_seconds?}``.
+
+    *db* defaults to the health service's connection; a caller with its own
+    runtime connection (e.g. the ego dashboard route) passes it explicitly.
+
+    *raise_on_error*: by default a caught query error is ERROR-logged and the
+    verdict degrades to ``no_heartbeat`` (best-effort, as the display/alert paths
+    want). A caller that renders a POSITIVE health assertion (the ego tile) passes
+    ``True`` so the read failure RE-RAISES and it can fail loud (surface unknown)
+    rather than paint a healthy tile over a broken read. (Truly unexpected
+    exception types always propagate — matching the original display behavior of
+    surfacing ``is_error`` rather than silently dropping a real bug.)
+
+    An unknown *name* (not in the threshold table) → ``no_heartbeat``; never raises
+    for that reason.
+    """
     import genesis.mcp.health_mcp as health_mcp_mod
 
-    _service = health_mcp_mod._service
+    entry = HEARTBEAT_EXPECTED.get(name)
+    if entry is None:
+        return {"status": "no_heartbeat", "last_seen": None}
+    _interval_s, overdue_s = entry
+
+    if db is None:
+        _service = health_mcp_mod._service
+        db = _service._db if _service else None
     _event_bus = health_mcp_mod._event_bus
 
-    # (expected_interval_s, overdue_threshold_s)
-    expected = {
-        "awareness": (300, 360),      # 5 min tick, error at 6 min
-        "surplus": (300, 600),
-        "inbox": (1800, 3600),
-        # Reflections only fire when signals warrant; calm periods can be quiet
-        # for hours. An idle alive-pulse (awareness loop) keeps this fresh during
-        # legitimate idle, so overdue=4h (matches ego) avoids false "dark" alarms.
-        # A real reflection outage surfaces faster via the awareness heartbeat
-        # (6 min), the cc resilience axis, and the deferred-work backlog.
-        "reflection": (600, 14400),
-        "outreach": (86400, 172800),
-        "dashboard": (120, 240),
-        "ego": (300, 14400),          # 5-min liveness pulse (ego_heartbeat job), overdue at 4h
+    last_ts = None
+    if db is not None:
+        try:
+            from genesis.db.crud import events as events_crud
+
+            rows = await events_crud.query(
+                db, subsystem=name, event_type="heartbeat", limit=1
+            )
+            if rows:
+                last_ts = rows[0].get("timestamp")
+        except (aiosqlite.Error, ImportError, AttributeError, TimeoutError):
+            # Narrow catch: DB query failure (aiosqlite.Error, TimeoutError),
+            # broken import chain (ImportError), or malformed row shape
+            # (AttributeError). Log at ERROR — a heartbeat probe failure against a
+            # wired DB is an operational failure. A POSITIVE-assertion caller
+            # (the ego tile) sets raise_on_error so this fails loud (unknown)
+            # instead of a spurious healthy tile; the display/alert callers
+            # degrade to no_heartbeat (absence, logged). Unexpected exception
+            # types still bubble on purpose (FastMCP is_error over a silent drop).
+            logger.error(
+                "Heartbeat timestamp query failed for subsystem %s", name, exc_info=True
+            )
+            if raise_on_error:
+                raise
+
+    if not last_ts and _event_bus is not None and hasattr(_event_bus, "_ring"):
+        for event in reversed(_event_bus._ring):
+            sub_val = (
+                event.subsystem.value
+                if hasattr(event.subsystem, "value")
+                else str(event.subsystem)
+            )
+            if sub_val == name and event.event_type == "heartbeat":
+                last_ts = event.timestamp
+                break
+
+    if last_ts is None:
+        return {"status": "no_heartbeat", "last_seen": None}
+    try:
+        age_s = (datetime.now(UTC) - datetime.fromisoformat(last_ts)).total_seconds()
+        return {
+            "status": "overdue" if age_s > overdue_s else "alive",
+            "last_seen": last_ts,
+            "age_seconds": round(age_s, 1),
+        }
+    except (ValueError, TypeError):
+        return {"status": "unknown", "last_seen": last_ts}
+
+
+async def _impl_subsystem_heartbeats() -> dict:
+    return {
+        name: await compute_heartbeat_staleness(name) for name in HEARTBEAT_EXPECTED
     }
-
-    result = {}
-    now = datetime.now(UTC)
-
-    for name, (_interval_s, overdue_s) in expected.items():
-        last_ts = None
-
-        if _service and _service._db:
-            try:
-                from genesis.db.crud import events as events_crud
-
-                rows = await events_crud.query(
-                    _service._db,
-                    subsystem=name,
-                    event_type="heartbeat",
-                    limit=1,
-                )
-                if rows:
-                    last_ts = rows[0].get("timestamp")
-            except (aiosqlite.Error, ImportError, AttributeError, TimeoutError):
-                # Narrow catch: DB query failure (aiosqlite.Error,
-                # TimeoutError), broken import chain for events_crud
-                # (ImportError), or malformed row shape on access
-                # (AttributeError). Log at ERROR per observability
-                # rules — a heartbeat probe failure against a wired
-                # service is an operational failure, not tracing
-                # noise. Unexpected exception types bubble up on
-                # purpose: we'd rather see ``is_error=True`` on the
-                # FastMCP result than silently drop a real bug.
-                logger.error(
-                    "Heartbeat timestamp query failed for subsystem %s",
-                    name, exc_info=True,
-                )
-
-        if not last_ts and _event_bus and hasattr(_event_bus, "_ring"):
-            for event in reversed(_event_bus._ring):
-                sub_val = event.subsystem.value if hasattr(event.subsystem, "value") else str(event.subsystem)
-                if sub_val == name and event.event_type == "heartbeat":
-                    last_ts = event.timestamp
-                    break
-
-        if last_ts is None:
-            result[name] = {"status": "no_heartbeat", "last_seen": None}
-        else:
-            try:
-                age_s = (now - datetime.fromisoformat(last_ts)).total_seconds()
-                overdue = age_s > overdue_s
-                result[name] = {
-                    "status": "overdue" if overdue else "alive",
-                    "last_seen": last_ts,
-                    "age_seconds": round(age_s, 1),
-                }
-            except (ValueError, TypeError):
-                result[name] = {"status": "unknown", "last_seen": last_ts}
-
-    return result
 
 
 async def _impl_job_health() -> dict:

--- a/src/genesis/observability/liveness.py
+++ b/src/genesis/observability/liveness.py
@@ -53,7 +53,13 @@ STALL_FLOOR_MINUTES = 3 * 60
 FUTURE_SKEW_TOLERANCE_MINUTES = 5
 
 
-def _parse(iso: str | None) -> datetime | None:
+def parse_iso_utc(iso: str | None) -> datetime | None:
+    """Parse an ISO timestamp to an aware UTC datetime, or None if unusable.
+
+    The shared timestamp parser for the liveness/heartbeat layer: a naive value is
+    normalized to UTC (so a later ``dt > aware`` comparison never raises TypeError),
+    and an empty/unparseable value returns None. Reused by the heartbeat-staleness
+    helper so both read timestamps identically (see mcp/health/manifest.py)."""
     if not iso:
         return None
     try:
@@ -61,6 +67,10 @@ def _parse(iso: str | None) -> datetime | None:
     except (ValueError, TypeError):
         return None
     return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt
+
+
+# Back-compat internal alias (this module's own call sites).
+_parse = parse_iso_utc
 
 
 def stall_threshold_minutes(current_interval_minutes: float) -> float:

--- a/src/genesis/observability/types.py
+++ b/src/genesis/observability/types.py
@@ -35,6 +35,11 @@ class Subsystem(StrEnum):
     OBSERVABILITY = "observability"
     GUARDIAN = "guardian"
     SENTINEL = "sentinel"
+    # The GenesisRuntime itself — pause/resume events (runtime/_pause_state.py).
+    # Was referenced there without being defined, so the emit raised AttributeError
+    # and was swallowed → pause/resume events were never recorded. Defining it
+    # restores that intended historical-visibility record.
+    RUNTIME = "runtime"
 
 
 class ProbeStatus(StrEnum):

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -920,6 +920,11 @@ class MorningReportGenerator:
         section entirely. This is not a standing checklist.
         """
         lines: list[str] = []
+        # Subsystems already surfaced via a ``subsystem_stale:<name>`` alert in the
+        # health-alerts block below — the heartbeat-staleness block must not list
+        # them a SECOND time (P2-6 dedup). Populated from the alerts actually
+        # emitted, so it stays correct if the alert set changes.
+        stale_alert_names: set[str] = set()
 
         # Health alerts (call sites down, queue depth, resilience warnings)
         try:
@@ -941,15 +946,22 @@ class MorningReportGenerator:
                         f"- **{severity}**: {a.get('message', 'Unknown')} "
                         f"(id: {alert_id})"
                     )
+                    if alert_id.startswith("subsystem_stale:"):
+                        stale_alert_names.add(alert_id.split(":", 1)[1])
         except Exception:
             logger.warning("Failed to query health alerts for morning report", exc_info=True)
 
-        # Subsystem heartbeat staleness (detects silent deaths)
+        # Subsystem heartbeat staleness (detects silent deaths). Covers subsystems
+        # NOT already alerted above (e.g. surplus/outreach have a heartbeat but no
+        # subsystem_stale alert) — the alerted ones are skipped to avoid a duplicate
+        # line. A "paused" verdict is legitimately quiet (not overdue) → skipped.
         try:
             from genesis.mcp.health.manifest import _impl_subsystem_heartbeats
 
             heartbeats = await _impl_subsystem_heartbeats()
             for name, info in heartbeats.items():
+                if name in stale_alert_names:
+                    continue  # already surfaced via its subsystem_stale alert above
                 if info.get("status") == "overdue":
                     age = info.get("age_seconds", 0)
                     age_h = age / 3600 if age else 0

--- a/src/genesis/sentinel/remediation_map.py
+++ b/src/genesis/sentinel/remediation_map.py
@@ -272,17 +272,27 @@ UNMAPPED_BY_DESIGN: dict[str, str] = {
         "human to fix at the source; the firefighter is never woken for it."
     ),
     "subsystem_stale:": (
-        "A heartbeat-emitting subsystem (ego/surplus/inbox/dashboard/outreach) "
-        "stopped pulsing — total cessation of its scheduler/loop. The cause is "
-        "heterogeneous and NOT reliably restart-fixable: the motivating case was "
-        "an ego cadence DEADLOCK (a pending-approval pre-flight, fixed in code by "
-        "#1422), where a container.services restart would not clear it and could "
-        "restart-loop (contrast awareness:tick_overdue / job_stale:, which are "
-        "genuine restartable wedges). So it stays a user-visible health alert "
-        "(ego CRITICAL, the rest WARNING) + a red ego tile for a human to "
-        "diagnose the specific cause; the firefighter is never woken for it. "
-        "(This is a surfacing signal — PR-C adds no autonomous remediation "
-        "authority.)"
+        "A heartbeat-emitting subsystem (ego/inbox/dashboard — surplus and "
+        "outreach are deliberately excluded: surplus is covered by its own "
+        "dashboard tile, outreach's pulse is config-gated) stopped pulsing — total "
+        "cessation of its scheduler/loop. The cause is heterogeneous and NOT "
+        "reliably restart-fixable: the motivating case was an ego cadence DEADLOCK "
+        "(a pending-approval pre-flight, fixed in code by #1422), where a "
+        "container.services restart would not clear it and could restart-loop "
+        "(contrast awareness:tick_overdue / job_stale:, which are genuine "
+        "restartable wedges). So it stays a user-visible health alert (ego "
+        "CRITICAL, the rest WARNING) + a red ego tile for a human to diagnose the "
+        "specific cause; the firefighter is never woken for it. (This is a "
+        "surfacing signal — PR-C adds no autonomous remediation authority.)"
+    ),
+    "subsystem_heartbeat_unknown:": (
+        "A heartbeat-emitting subsystem's last pulse row is UNREADABLE (corrupt "
+        "timestamp or a materially-future one from a backward clock jump) — so its "
+        "liveness cannot be confirmed. Surface-only (WARNING), never restart-fixable "
+        "by the firefighter: a corrupt row / clock skew is a data-integrity anomaly, "
+        "not a wedged service. Auto-resolves when a fresh parseable pulse lands. "
+        "Distinct from subsystem_stale: (which asserts a probable DEATH) — this "
+        "asserts only that we cannot tell."
     ),
 }
 

--- a/src/genesis/sentinel/remediation_map.py
+++ b/src/genesis/sentinel/remediation_map.py
@@ -271,6 +271,19 @@ UNMAPPED_BY_DESIGN: dict[str, str] = {
         "IS restartable). It stays a user-visible WARNING health alert for a "
         "human to fix at the source; the firefighter is never woken for it."
     ),
+    "subsystem_stale:": (
+        "A heartbeat-emitting subsystem (ego/surplus/inbox/dashboard/outreach) "
+        "stopped pulsing — total cessation of its scheduler/loop. The cause is "
+        "heterogeneous and NOT reliably restart-fixable: the motivating case was "
+        "an ego cadence DEADLOCK (a pending-approval pre-flight, fixed in code by "
+        "#1422), where a container.services restart would not clear it and could "
+        "restart-loop (contrast awareness:tick_overdue / job_stale:, which are "
+        "genuine restartable wedges). So it stays a user-visible health alert "
+        "(ego CRITICAL, the rest WARNING) + a red ego tile for a human to "
+        "diagnose the specific cause; the firefighter is never woken for it. "
+        "(This is a surfacing signal — PR-C adds no autonomous remediation "
+        "authority.)"
+    ),
 }
 
 

--- a/src/genesis/surplus/jobs/gates.py
+++ b/src/genesis/surplus/jobs/gates.py
@@ -267,7 +267,13 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
     except Exception:
         logger.warning("GC: FTS/metadata tripwire failed", exc_info=True)
 
-    # GC: rotate heartbeat events older than 7 days
+    # GC: rotate heartbeat events older than 7 days, but KEEP the most-recent
+    # pulse per subsystem — the pulse-staleness detector (compute_heartbeat_
+    # staleness) reads "the last pulse" to tell a scheduler dead > the window
+    # from one that never pulsed. Pruning the sole old pulse would revert a
+    # long-dead subsystem to a false ``no_heartbeat``/green (the exact lie the
+    # subsystem_stale alert + ego tile exist to kill). One retained row per
+    # subsystem is negligible volume.
     try:
         from genesis.db.crud import events as events_crud
 
@@ -276,6 +282,7 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
             db,
             older_than=hb_cutoff,
             event_type="heartbeat",
+            keep_latest_per_subsystem=True,
         )
         if hb_purged:
             logger.info("Pruned %d heartbeat events older than 7d", hb_purged)

--- a/tests/test_dashboard/test_ego_routes.py
+++ b/tests/test_dashboard/test_ego_routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -360,4 +361,88 @@ class TestEgoRevisionGuard:
                 json={"status": "approved", "revision_num": 2},
             )
         assert resp.status_code == 404
+
+
+# ── /api/genesis/ego/status — heartbeat total-cessation tile signal ──────────
+
+_EGO_CONFIG = SimpleNamespace(
+    enabled=True, model="opus", default_effort="high",
+    morning_report_effort="high", cadence_minutes=90, max_interval_minutes=4320,
+    morning_report_enabled=True, genesis_cadence_minutes=90,
+    genesis_max_interval_minutes=4320, shadow_morning_report=False, board_size=5,
+)
+
+
+def _status_response(client, *, hb_return=None, hb_side_effect=None):
+    """Hit /ego/status with the ego-heartbeat-staleness read stubbed.
+
+    Mirrors the full ego_status dependency surface so the endpoint returns 200
+    and we can assert the new top-level heartbeat fields are wired into the JSON.
+    """
+    rt = _mock_runtime()
+    rt._genesis_ego_cadence_manager = None  # keep the cadence snapshot JSON-safe
+    hb_mock = (
+        AsyncMock(side_effect=hb_side_effect)
+        if hb_side_effect is not None
+        else AsyncMock(return_value=hb_return)
+    )
+    with (
+        patch("genesis.runtime.GenesisRuntime") as MockRT,
+        patch("genesis.ego.config.load_ego_config", return_value=_EGO_CONFIG),
+        patch("genesis.db.crud.ego.daily_ego_cost", new=AsyncMock(return_value=0.0)),
+        patch("genesis.db.crud.ego.get_state", new=AsyncMock(return_value=None)),
+        patch("genesis.db.crud.ego.list_recent_cycles", new=AsyncMock(return_value=[])),
+        patch("genesis.db.crud.ego.list_pending_proposals", new=AsyncMock(return_value=[])),
+        patch("genesis.db.crud.ego.count_uncompacted", new=AsyncMock(return_value=0)),
+        patch("genesis.db.crud.ego.daily_dispatch_cost", new=AsyncMock(return_value=0.0)),
+        patch("genesis.db.crud.ego.rolling_daily_ego_cost", new=AsyncMock(return_value=0.0)),
+        patch("genesis.db.crud.ego.has_pending_cli_approval", new=AsyncMock(return_value=False)),
+        patch("genesis.mcp.health.manifest.compute_heartbeat_staleness", new=hb_mock),
+    ):
+        MockRT.instance.return_value = rt
+        return client.get("/api/genesis/ego/status")
+
+
+class TestEgoStatusHeartbeat:
+    """The ego tile flips red on scheduler-death (heartbeat staleness), fails
+    loud on a broken read, and never false-reds a fresh install."""
+
+    def test_alive_heartbeat_not_stale(self, client):
+        resp = _status_response(
+            client, hb_return={"status": "alive", "age_seconds": 12.0, "last_seen": "x"}
+        )
+        data = resp.get_json()
+        assert data["ego_heartbeat_stale"] is False
+        assert data["ego_heartbeat_error"] is False
+        assert data["ego_heartbeat_age_s"] == 12.0
+
+    def test_overdue_heartbeat_is_stale(self, client):
+        resp = _status_response(
+            client, hb_return={"status": "overdue", "age_seconds": 18000.0, "last_seen": "x"}
+        )
+        data = resp.get_json()
+        assert data["ego_heartbeat_stale"] is True
+        assert data["ego_heartbeat_error"] is False
+
+    def test_no_heartbeat_empty_state_not_stale(self, client):
+        resp = _status_response(
+            client, hb_return={"status": "no_heartbeat", "last_seen": None}
+        )
+        data = resp.get_json()
+        assert data["ego_heartbeat_stale"] is False
+        assert data["ego_heartbeat_error"] is False
+
+    def test_unknown_status_is_error(self, client):
+        resp = _status_response(
+            client, hb_return={"status": "unknown", "last_seen": "bad"}
+        )
+        data = resp.get_json()
+        assert data["ego_heartbeat_error"] is True
+        assert data["ego_heartbeat_stale"] is False
+
+    def test_read_exception_fails_loud(self, client):
+        resp = _status_response(client, hb_side_effect=RuntimeError("db down"))
+        data = resp.get_json()
+        assert data["ego_heartbeat_error"] is True
+        assert data["ego_heartbeat_stale"] is False
 

--- a/tests/test_dashboard/test_ego_routes.py
+++ b/tests/test_dashboard/test_ego_routes.py
@@ -373,14 +373,23 @@ _EGO_CONFIG = SimpleNamespace(
 )
 
 
-def _status_response(client, *, hb_return=None, hb_side_effect=None):
+def _status_response(client, *, hb_return=None, hb_side_effect=None, booted_ago_s=0.0):
     """Hit /ego/status with the ego-heartbeat-staleness read stubbed.
 
     Mirrors the full ego_status dependency surface so the endpoint returns 200
     and we can assert the new top-level heartbeat fields are wired into the JSON.
+
+    ``booted_ago_s`` sets ``rt._bootstrap_completed_at`` that many seconds ago
+    (the P2-5 no_heartbeat boot-grace hook); ``None`` sets it to None (degraded
+    boot). Default 0.0 = just booted (within grace).
     """
+    from datetime import UTC, datetime, timedelta
+
     rt = _mock_runtime()
     rt._genesis_ego_cadence_manager = None  # keep the cadence snapshot JSON-safe
+    rt._bootstrap_completed_at = (
+        None if booted_ago_s is None else datetime.now(UTC) - timedelta(seconds=booted_ago_s)
+    )
     hb_mock = (
         AsyncMock(side_effect=hb_side_effect)
         if hb_side_effect is not None
@@ -424,13 +433,33 @@ class TestEgoStatusHeartbeat:
         assert data["ego_heartbeat_stale"] is True
         assert data["ego_heartbeat_error"] is False
 
-    def test_no_heartbeat_empty_state_not_stale(self, client):
+    def test_no_heartbeat_within_boot_grace_not_error(self, client):
+        """Just after boot (ego's first pulse pending), no_heartbeat is benign —
+        not stale, not error (P2-5 grace)."""
         resp = _status_response(
-            client, hb_return={"status": "no_heartbeat", "last_seen": None}
+            client, hb_return={"status": "no_heartbeat", "last_seen": None}, booted_ago_s=5.0
         )
         data = resp.get_json()
         assert data["ego_heartbeat_stale"] is False
         assert data["ego_heartbeat_error"] is False
+
+    def test_no_heartbeat_past_boot_grace_is_error(self, client):
+        """Long after boot with STILL no pulse on record → real absence, surfaced
+        as error (unknown), never a green tile (P2-5)."""
+        resp = _status_response(
+            client, hb_return={"status": "no_heartbeat", "last_seen": None}, booted_ago_s=3600.0
+        )
+        data = resp.get_json()
+        assert data["ego_heartbeat_stale"] is False
+        assert data["ego_heartbeat_error"] is True
+
+    def test_no_heartbeat_degraded_boot_is_error(self, client):
+        """No boot stamp (degraded boot) → no grace → fail-loud to error (P2-5)."""
+        resp = _status_response(
+            client, hb_return={"status": "no_heartbeat", "last_seen": None}, booted_ago_s=None
+        )
+        data = resp.get_json()
+        assert data["ego_heartbeat_error"] is True
 
     def test_unknown_status_is_error(self, client):
         resp = _status_response(

--- a/tests/test_mcp/test_subsystem_staleness.py
+++ b/tests/test_mcp/test_subsystem_staleness.py
@@ -4,11 +4,18 @@ Two surfaces, one shared signal (``compute_heartbeat_staleness``):
   - ``_impl_health_alerts`` emits a ``subsystem_stale:<name>`` alert when a
     heartbeat-emitting subsystem's last durable ``heartbeat`` event is older
     than its per-subsystem overdue threshold (its scheduler/loop stopped — a
-    silent death the failure-gap job alarms cannot see). ego → CRITICAL, the
-    other four → WARNING. reflection is excluded (its pulse is emitted by the
-    awareness loop) and awareness is excluded (it has ``awareness:tick_overdue``).
+    silent death the failure-gap job alarms cannot see). The alert set is
+    ``ego`` (CRITICAL) + ``inbox`` + ``dashboard`` (WARNING). **surplus** is
+    dropped (PR-B's shipped tile already flips red on a wedged/dead surplus via
+    its job_health signal) and **outreach** is dropped (its pulse is
+    config-gated — never fires on a Telegram-less install). reflection/awareness
+    stay excluded (reflection's pulse tracks the awareness loop; awareness has
+    ``awareness:tick_overdue``).
   - ``compute_heartbeat_staleness`` — the pure per-subsystem verdict the alert
-    AND the ego dashboard tile both read, so the two can never disagree.
+    AND the ego dashboard tile both read, so the two can never disagree. It is
+    pause-aware for the pause-gated subsystems ({surplus, inbox}, whose pulse
+    stops behind their loop's ``if paused: return``) and fails loud on a corrupt
+    or future timestamp.
 
 Exercised against a REAL in-memory SQLite ``events`` table so the crud query +
 threshold math are tested, not mocked away.
@@ -17,6 +24,7 @@ threshold math are tested, not mocked away.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiosqlite
@@ -91,6 +99,36 @@ async def test_staleness_unparseable_timestamp_is_unknown(db):
 
 
 @pytest.mark.asyncio
+async def test_staleness_future_timestamp_is_unknown(db):
+    """A pulse materially in the FUTURE (clock skew / corrupt row) cannot confirm
+    liveness → unknown, never a false 'alive' from a negative age (P2-3)."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "ego", age_seconds=-3600)  # 1h in the future
+    hb = await compute_heartbeat_staleness("ego", db=db)
+    assert hb["status"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_staleness_uses_freshest_of_db_and_ring(db):
+    """A fresh in-memory ring pulse beats a stale DB row (the ring updates
+    synchronously; the DB persists fire-and-forget) → alive, not overdue (P2-2)."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    # DB has an OVERDUE ego pulse (5h), ring has a FRESH one (10s).
+    await _seed_heartbeat(db, "ego", age_seconds=5 * 3600)
+    fresh_event = SimpleNamespace(
+        subsystem=SimpleNamespace(value="ego"),
+        event_type="heartbeat",
+        timestamp=_iso_ago(10),
+    )
+    fake_bus = SimpleNamespace(_ring=[fresh_event])
+    with patch("genesis.mcp.health_mcp._event_bus", fake_bus):
+        hb = await compute_heartbeat_staleness("ego", db=db)
+    assert hb["status"] == "alive"  # freshest wins, not the stale DB row
+
+
+@pytest.mark.asyncio
 async def test_staleness_unknown_subsystem_is_no_heartbeat(db):
     """A name not in the threshold table degrades to no_heartbeat, never raises."""
     from genesis.mcp.health.manifest import compute_heartbeat_staleness
@@ -132,29 +170,115 @@ async def test_staleness_read_error_raises_when_requested():
         await compute_heartbeat_staleness("ego", db=bad_db, raise_on_error=True)
 
 
-# ── subsystem_stale alert (via _impl_health_alerts) ──────────────────────────
+# ── pause-guard (pause-gated subsystems only) ────────────────────────────────
 
 
-async def _run_alerts_with_db(db):
-    """Run the real _compute_alerts path with `db` as the health service DB."""
+@pytest.mark.asyncio
+async def test_staleness_paused_downgrades_surplus(db):
+    """surplus's pulse stops behind ``if paused: return`` — so an overdue surplus
+    while globally paused is NOT dead → downgraded to 'paused', not 'overdue'."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "surplus", age_seconds=2 * 3600)  # > 600 threshold
+    hb = await compute_heartbeat_staleness("surplus", db=db, paused=True)
+    assert hb["status"] == "paused"
+
+
+@pytest.mark.asyncio
+async def test_staleness_paused_downgrades_inbox(db):
+    """inbox is pause-gated too → overdue-while-paused downgrades to 'paused'."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "inbox", age_seconds=3 * 3600)  # > 7200 threshold
+    hb = await compute_heartbeat_staleness("inbox", db=db, paused=True)
+    assert hb["status"] == "paused"
+
+
+@pytest.mark.asyncio
+async def test_staleness_paused_does_not_downgrade_ego(db):
+    """ego's heartbeat pulses THROUGH pause (dedicated job) — so an overdue ego
+    even while paused is a genuine scheduler death and stays 'overdue'."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "ego", age_seconds=5 * 3600)
+    hb = await compute_heartbeat_staleness("ego", db=db, paused=True)
+    assert hb["status"] == "overdue"
+
+
+@pytest.mark.asyncio
+async def test_staleness_not_paused_still_overdue(db):
+    """A pause-gated subsystem overdue while NOT paused → overdue (real stall)."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "inbox", age_seconds=3 * 3600)
+    hb = await compute_heartbeat_staleness("inbox", db=db, paused=False)
+    assert hb["status"] == "overdue"
+
+
+# ── loosened thresholds (near-zero false-reds) ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inbox_threshold_loosened_no_false_fire_at_90min(db):
+    """inbox check interval is 30min; a 90min gap (one slow/skipped check) is
+    within the loosened 4× (7200s) threshold → alive, not a false overdue."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "inbox", age_seconds=90 * 60)  # 90min — one skip
+    assert (await compute_heartbeat_staleness("inbox", db=db))["status"] == "alive"
+
+
+@pytest.mark.asyncio
+async def test_inbox_overdue_past_threshold(db):
+    """A 2.5h inbox gap (> the 7200s threshold) is genuinely stale → overdue."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "inbox", age_seconds=150 * 60)  # 2.5h
+    assert (await compute_heartbeat_staleness("inbox", db=db))["status"] == "overdue"
+
+
+@pytest.mark.asyncio
+async def test_dashboard_threshold_loosened(db):
+    """dashboard pulses every 60s; overdue at 600s (10×), not 240s (4×)."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "dashboard", age_seconds=5 * 60)  # 5min → alive
+    assert (await compute_heartbeat_staleness("dashboard", db=db))["status"] == "alive"
+
+
+# ── subsystem_stale alert (via _impl_health_alerts / _compute_alerts) ─────────
+
+
+def _snapshot():
+    return {
+        "call_sites": {},
+        "infrastructure": {},
+        "cc_sessions": {},
+        "queues": {},
+        "awareness": {},
+        "services": {},
+    }
+
+
+async def _run_alerts_with_db(db, *, paused: bool = False):
+    """Run the real _compute_alerts path with `db` as the health service DB.
+
+    ``paused`` patches the runtime pause flag the helper reads for pause-gated
+    subsystems (deterministic — never depends on a leaked singleton).
+    """
+    from genesis.runtime._core import GenesisRuntime
+
     svc = MagicMock()
     svc._db = db
-    svc.snapshot = AsyncMock(
-        return_value={
-            "call_sites": {},
-            "infrastructure": {},
-            "cc_sessions": {},
-            "queues": {},
-            "awareness": {},
-            "services": {},
-        }
-    )
+    svc.snapshot = AsyncMock(return_value=_snapshot())
+    stub_rt = SimpleNamespace(paused=paused)
     with (
         patch("genesis.mcp.health_mcp._service", svc),
         patch("genesis.mcp.health_mcp._activity_tracker", None),
         patch("genesis.mcp.health_mcp._job_retry_registry", None),
         patch("genesis.mcp.health_mcp._alert_history", {}),
         patch("genesis.mcp.health_mcp._event_bus", None),
+        patch.object(GenesisRuntime, "peek", return_value=stub_rt),
     ):
         from genesis.mcp.health.errors import _impl_health_alerts
 
@@ -178,28 +302,73 @@ async def test_ego_cessation_alerts_critical(db):
 
 
 @pytest.mark.asyncio
-async def test_non_ego_cessation_alerts_warning(db):
-    """A stalled inbox (2h old vs 1h threshold) → subsystem_stale:inbox WARNING."""
-    await _seed_heartbeat(db, "inbox", age_seconds=2 * 3600)
+async def test_unknown_heartbeat_surfaces_warning_not_silent(db):
+    """An UNREADABLE ego heartbeat (corrupt/clock-skewed ts) → a WARNING
+    subsystem_heartbeat_unknown:ego ('liveness cannot be confirmed'), never a silent
+    skip and never a mislabeled subsystem_stale:ego (which would assert death)."""
+    await db.execute(
+        "INSERT INTO events (id, timestamp, subsystem, severity, event_type, "
+        "message, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("u1", "not-a-date", "ego", "debug", "heartbeat", "bad", "not-a-date"),
+    )
+    await db.commit()
     alerts = await _run_alerts_with_db(db)
-    stale = _stale(alerts)
-    inbox = next((a for a in stale if a["id"] == "subsystem_stale:inbox"), None)
+    ids = {a["id"] for a in alerts}
+    assert "subsystem_heartbeat_unknown:ego" in ids
+    unk = next(a for a in alerts if a["id"] == "subsystem_heartbeat_unknown:ego")
+    assert unk["severity"] == "WARNING"
+    assert "subsystem_stale:ego" not in ids  # not mislabeled as a death
+
+
+@pytest.mark.asyncio
+async def test_inbox_cessation_alerts_warning(db):
+    """A stalled inbox (3h old vs 2h threshold) → subsystem_stale:inbox WARNING."""
+    await _seed_heartbeat(db, "inbox", age_seconds=3 * 3600)
+    alerts = await _run_alerts_with_db(db)
+    inbox = next((a for a in _stale(alerts) if a["id"] == "subsystem_stale:inbox"), None)
     assert inbox is not None
     assert inbox["severity"] == "WARNING"
 
 
 @pytest.mark.asyncio
-async def test_alive_subsystem_does_not_alert(db):
-    """A freshly-pulsing subsystem emits no subsystem_stale alert."""
-    await _seed_heartbeat(db, "surplus", age_seconds=5)
+async def test_dashboard_cessation_alerts_warning(db):
+    """A stalled dashboard (11min vs 10min threshold) → subsystem_stale:dashboard."""
+    await _seed_heartbeat(db, "dashboard", age_seconds=11 * 60)
+    alerts = await _run_alerts_with_db(db)
+    dash = next((a for a in _stale(alerts) if a["id"] == "subsystem_stale:dashboard"), None)
+    assert dash is not None
+    assert dash["severity"] == "WARNING"
+
+
+@pytest.mark.asyncio
+async def test_surplus_dropped_from_alert_set(db):
+    """surplus is DROPPED from the alert set (PR-B's tile already covers it) —
+    even a badly-overdue surplus emits NO subsystem_stale:surplus."""
+    await _seed_heartbeat(db, "surplus", age_seconds=3 * 3600)  # ≫ 600 threshold
     alerts = await _run_alerts_with_db(db)
     assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:surplus"]
 
 
 @pytest.mark.asyncio
+async def test_outreach_dropped_from_alert_set(db):
+    """outreach is DROPPED (config-gated pulse → false-alarm trap) — even a
+    3-day-old outreach heartbeat emits NO subsystem_stale:outreach."""
+    await _seed_heartbeat(db, "outreach", age_seconds=3 * 86400)  # ≫ 172800 threshold
+    alerts = await _run_alerts_with_db(db)
+    assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:outreach"]
+
+
+@pytest.mark.asyncio
+async def test_alive_subsystem_does_not_alert(db):
+    """A freshly-pulsing alert-set subsystem emits no subsystem_stale alert."""
+    await _seed_heartbeat(db, "inbox", age_seconds=10)
+    alerts = await _run_alerts_with_db(db)
+    assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:inbox"]
+
+
+@pytest.mark.asyncio
 async def test_reflection_is_excluded(db):
-    """reflection is DROPPED from the alert set (its pulse tracks the awareness
-    loop, not reflection-engine liveness) even when overdue."""
+    """reflection is not in the alert set even when overdue."""
     await _seed_heartbeat(db, "reflection", age_seconds=5 * 3600)  # > 14400 threshold
     alerts = await _run_alerts_with_db(db)
     assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:reflection"]
@@ -222,17 +391,169 @@ async def test_empty_state_no_alerts(db):
 
 
 @pytest.mark.asyncio
+async def test_paused_inbox_is_suppressed(db):
+    """A globally-paused Genesis must NOT alert on inbox (its pulse legitimately
+    stops on pause) — the helper downgrades it, so no subsystem_stale:inbox."""
+    await _seed_heartbeat(db, "inbox", age_seconds=3 * 3600)
+    alerts = await _run_alerts_with_db(db, paused=True)
+    assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:inbox"]
+
+
+@pytest.mark.asyncio
+async def test_paused_ego_still_alerts(db):
+    """ego pulses through pause → a dead ego while paused STILL alerts (a paused
+    box must not mask a genuinely dead ego scheduler)."""
+    await _seed_heartbeat(db, "ego", age_seconds=5 * 3600)
+    alerts = await _run_alerts_with_db(db, paused=True)
+    assert any(a["id"] == "subsystem_stale:ego" for a in _stale(alerts))
+
+
+@pytest.mark.asyncio
+async def test_read_error_preserves_open_alert(db):
+    """P2-4 fail-open fix: if the staleness read for a subsystem RAISES, a
+    genuinely-open subsystem_stale alert for it must be PRESERVED in current_ids
+    (so reconcile can't auto-resolve a real death on a transient read blip)."""
+    from genesis.db.crud import alert_events as ae_crud
+    from genesis.runtime._core import GenesisRuntime
+
+    # An open subsystem_stale:inbox already on the durable open-set.
+    await ae_crud.reconcile_open_set(
+        db,
+        active=[
+            {
+                "alert_id": "subsystem_stale:inbox",
+                "source": "health",
+                "severity": "WARNING",
+                "message": "inbox overdue",
+            }
+        ],
+        now=datetime.now(UTC).isoformat(),
+    )
+
+    async def _raise_for_inbox(name, **kwargs):
+        if name == "inbox":
+            raise aiosqlite.OperationalError("boom")
+        return {"status": "alive", "last_seen": _iso_ago(10), "age_seconds": 10.0}
+
+    svc = MagicMock()
+    svc._db = db
+    svc.snapshot = AsyncMock(return_value=_snapshot())
+    stub_rt = SimpleNamespace(paused=False)
+    with (
+        patch("genesis.mcp.health_mcp._service", svc),
+        patch("genesis.mcp.health_mcp._activity_tracker", None),
+        patch("genesis.mcp.health_mcp._job_retry_registry", None),
+        patch("genesis.mcp.health_mcp._alert_history", {}),
+        patch("genesis.mcp.health_mcp._event_bus", None),
+        patch.object(GenesisRuntime, "peek", return_value=stub_rt),
+        patch(
+            "genesis.mcp.health.manifest.compute_heartbeat_staleness",
+            new=AsyncMock(side_effect=_raise_for_inbox),
+        ),
+    ):
+        from genesis.mcp.health.errors import _compute_alerts
+
+        alerts, current_ids = await _compute_alerts()
+
+    alert_ids = {a["id"] for a in alerts}
+    # The open inbox alert is RE-EMITTED into the alerts list — that is the
+    # container the reconcile writer builds its active-set from (loop.py:158-166),
+    # so the read blip cannot auto-resolve a genuinely-open death alert. It is also
+    # in current_ids (lockstep with every other emit, for alert-history dedup).
+    assert "subsystem_stale:inbox" in alert_ids
+    assert "subsystem_stale:inbox" in current_ids
+    # ego/dashboard read fine and are alive → NOT re-emitted / not open.
+    assert "subsystem_stale:ego" not in alert_ids
+    assert "subsystem_stale:dashboard" not in alert_ids
+
+
+async def _compute_alerts_with_hb_side_effect(db, side_effect):
+    """Run the real _compute_alerts with compute_heartbeat_staleness stubbed to
+    `side_effect` (e.g. raise for one subsystem). Returns (alerts, current_ids)."""
+    from genesis.runtime._core import GenesisRuntime
+
+    svc = MagicMock()
+    svc._db = db
+    svc.snapshot = AsyncMock(return_value=_snapshot())
+    stub_rt = SimpleNamespace(paused=False)
+    with (
+        patch("genesis.mcp.health_mcp._service", svc),
+        patch("genesis.mcp.health_mcp._activity_tracker", None),
+        patch("genesis.mcp.health_mcp._job_retry_registry", None),
+        patch("genesis.mcp.health_mcp._alert_history", {}),
+        patch("genesis.mcp.health_mcp._event_bus", None),
+        patch.object(GenesisRuntime, "peek", return_value=stub_rt),
+        patch(
+            "genesis.mcp.health.manifest.compute_heartbeat_staleness",
+            new=AsyncMock(side_effect=side_effect),
+        ),
+    ):
+        from genesis.mcp.health.errors import _compute_alerts
+
+        return await _compute_alerts()
+
+
+@pytest.mark.asyncio
+async def test_read_error_preserves_open_unknown_alert(db):
+    """SF-1: the fail-open guard preserves BOTH alert families the block emits — an
+    open subsystem_heartbeat_unknown alert must not flap (auto-resolve) on a
+    read-failure tick, only the subsystem_stale family."""
+    from genesis.db.crud import alert_events as ae_crud
+
+    await ae_crud.reconcile_open_set(
+        db,
+        active=[
+            {
+                "alert_id": "subsystem_heartbeat_unknown:inbox",
+                "source": "health",
+                "severity": "WARNING",
+                "message": "inbox heartbeat unreadable",
+            }
+        ],
+        now=datetime.now(UTC).isoformat(),
+    )
+
+    async def _raise_for_inbox(name, **kwargs):
+        if name == "inbox":
+            raise aiosqlite.OperationalError("boom")
+        return {"status": "alive", "last_seen": _iso_ago(10), "age_seconds": 10.0}
+
+    alerts, current_ids = await _compute_alerts_with_hb_side_effect(db, _raise_for_inbox)
+    alert_ids = {a["id"] for a in alerts}
+    assert "subsystem_heartbeat_unknown:inbox" in alert_ids  # preserved, not flapped
+    assert "subsystem_heartbeat_unknown:inbox" in current_ids
+
+
+@pytest.mark.asyncio
+async def test_freshest_ignores_corrupt_future_db_row(db):
+    """N-2: a corrupt FUTURE db heartbeat must not mask a valid fresh ring pulse —
+    the subsystem reads alive, not a false unknown."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "ego", age_seconds=-3600)  # DB row 1h in the FUTURE
+    fresh_event = SimpleNamespace(
+        subsystem=SimpleNamespace(value="ego"),
+        event_type="heartbeat",
+        timestamp=_iso_ago(10),  # valid fresh ring pulse
+    )
+    fake_bus = SimpleNamespace(_ring=[fresh_event])
+    with patch("genesis.mcp.health_mcp._event_bus", fake_bus):
+        hb = await compute_heartbeat_staleness("ego", db=db)
+    assert hb["status"] == "alive"
+
+
+@pytest.mark.asyncio
 async def test_helper_failure_isolated_from_other_alerts(db):
-    """If the pulse-staleness block raises, the OTHER alerts still compute (its
-    own try/except isolates it) and it is ERROR-logged, never a silent green."""
+    """If the pulse-staleness block raises wholesale, the OTHER alerts still
+    compute (its own try/except isolates it) — never a silent crash/green."""
     await _seed_heartbeat(db, "ego", age_seconds=5 * 3600)
     with patch(
         "genesis.mcp.health.manifest.compute_heartbeat_staleness",
         new=AsyncMock(side_effect=RuntimeError("boom")),
     ):
-        # Should not raise; alerts list still returns (other blocks intact).
         alerts = await _run_alerts_with_db(db)
-    assert _stale(alerts) == []  # block failed → no subsystem_stale alerts, but no crash
+    # Block failed for every subsystem, none open on the durable set → none emitted.
+    assert _stale(alerts) == []
 
 
 # ── heartbeat GC preserves the last pulse (durable staleness signal) ─────────

--- a/tests/test_mcp/test_subsystem_staleness.py
+++ b/tests/test_mcp/test_subsystem_staleness.py
@@ -1,0 +1,295 @@
+"""Tests for pulse-staleness (total-cessation) surfacing.
+
+Two surfaces, one shared signal (``compute_heartbeat_staleness``):
+  - ``_impl_health_alerts`` emits a ``subsystem_stale:<name>`` alert when a
+    heartbeat-emitting subsystem's last durable ``heartbeat`` event is older
+    than its per-subsystem overdue threshold (its scheduler/loop stopped — a
+    silent death the failure-gap job alarms cannot see). ego → CRITICAL, the
+    other four → WARNING. reflection is excluded (its pulse is emitted by the
+    awareness loop) and awareness is excluded (it has ``awareness:tick_overdue``).
+  - ``compute_heartbeat_staleness`` — the pure per-subsystem verdict the alert
+    AND the ego dashboard tile both read, so the two can never disagree.
+
+Exercised against a REAL in-memory SQLite ``events`` table so the crud query +
+threshold math are tested, not mocked away.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiosqlite
+import pytest
+
+
+def _iso_ago(seconds: float) -> str:
+    return (datetime.now(UTC) - timedelta(seconds=seconds)).isoformat()
+
+
+async def _seed_heartbeat(db, subsystem: str, age_seconds: float) -> None:
+    from genesis.db.crud import events as events_crud
+
+    await events_crud.insert(
+        db,
+        subsystem=subsystem,
+        severity="debug",
+        event_type="heartbeat",
+        message=f"{subsystem} pulse",
+        timestamp=_iso_ago(age_seconds),
+    )
+
+
+# ── compute_heartbeat_staleness (the shared signal) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_staleness_overdue(db):
+    """A pulse older than the subsystem's overdue threshold → status overdue."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    # ego threshold is 14400s (4h); 5h old → overdue.
+    await _seed_heartbeat(db, "ego", age_seconds=5 * 3600)
+    hb = await compute_heartbeat_staleness("ego", db=db)
+    assert hb["status"] == "overdue"
+    assert hb["age_seconds"] > 14400
+
+
+@pytest.mark.asyncio
+async def test_staleness_alive(db):
+    """A fresh pulse well within threshold → status alive."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "surplus", age_seconds=10)
+    hb = await compute_heartbeat_staleness("surplus", db=db)
+    assert hb["status"] == "alive"
+
+
+@pytest.mark.asyncio
+async def test_staleness_no_heartbeat_empty_state(db):
+    """No pulse ever (fresh install) → no_heartbeat, never 'stalled'."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    hb = await compute_heartbeat_staleness("ego", db=db)
+    assert hb["status"] == "no_heartbeat"
+    assert hb["last_seen"] is None
+
+
+@pytest.mark.asyncio
+async def test_staleness_unparseable_timestamp_is_unknown(db):
+    """A corrupt timestamp → unknown (never silently 'alive')."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await db.execute(
+        "INSERT INTO events (id, timestamp, subsystem, severity, event_type, "
+        "message, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("x1", "not-a-date", "ego", "debug", "heartbeat", "bad", "not-a-date"),
+    )
+    await db.commit()
+    hb = await compute_heartbeat_staleness("ego", db=db)
+    assert hb["status"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_staleness_unknown_subsystem_is_no_heartbeat(db):
+    """A name not in the threshold table degrades to no_heartbeat, never raises."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    hb = await compute_heartbeat_staleness("not_a_subsystem", db=db)
+    assert hb["status"] == "no_heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_staleness_read_error_default_degrades_and_logs():
+    """Default (alert/display callers): a query error is ERROR-logged and the
+    verdict degrades to no_heartbeat — the read failure is recorded, and the
+    verdict is never a spurious 'alive'."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    bad_db = MagicMock()
+    bad_db.execute_fetchall = AsyncMock(side_effect=aiosqlite.OperationalError("db exploded"))
+    with (
+        patch("genesis.mcp.health_mcp._service", None),
+        patch("genesis.mcp.health_mcp._event_bus", None),
+    ):
+        hb = await compute_heartbeat_staleness("ego", db=bad_db)
+    assert hb["status"] == "no_heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_staleness_read_error_raises_when_requested():
+    """Tile caller (raise_on_error=True): a query error RE-RAISES so the caller
+    fails loud (surfaces unknown) instead of a healthy tile on a broken read."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    bad_db = MagicMock()
+    bad_db.execute_fetchall = AsyncMock(side_effect=aiosqlite.OperationalError("db exploded"))
+    with (
+        patch("genesis.mcp.health_mcp._service", None),
+        patch("genesis.mcp.health_mcp._event_bus", None),
+        pytest.raises(aiosqlite.OperationalError),
+    ):
+        await compute_heartbeat_staleness("ego", db=bad_db, raise_on_error=True)
+
+
+# ── subsystem_stale alert (via _impl_health_alerts) ──────────────────────────
+
+
+async def _run_alerts_with_db(db):
+    """Run the real _compute_alerts path with `db` as the health service DB."""
+    svc = MagicMock()
+    svc._db = db
+    svc.snapshot = AsyncMock(
+        return_value={
+            "call_sites": {},
+            "infrastructure": {},
+            "cc_sessions": {},
+            "queues": {},
+            "awareness": {},
+            "services": {},
+        }
+    )
+    with (
+        patch("genesis.mcp.health_mcp._service", svc),
+        patch("genesis.mcp.health_mcp._activity_tracker", None),
+        patch("genesis.mcp.health_mcp._job_retry_registry", None),
+        patch("genesis.mcp.health_mcp._alert_history", {}),
+        patch("genesis.mcp.health_mcp._event_bus", None),
+    ):
+        from genesis.mcp.health.errors import _impl_health_alerts
+
+        return await _impl_health_alerts(active_only=True)
+
+
+def _stale(alerts):
+    return [a for a in alerts if a.get("id", "").startswith("subsystem_stale:")]
+
+
+@pytest.mark.asyncio
+async def test_ego_cessation_alerts_critical(db):
+    """A dead ego scheduler (heartbeat 5h old) → subsystem_stale:ego CRITICAL."""
+    await _seed_heartbeat(db, "ego", age_seconds=5 * 3600)
+    alerts = await _run_alerts_with_db(db)
+    stale = _stale(alerts)
+    assert any(a["id"] == "subsystem_stale:ego" for a in stale)
+    ego = next(a for a in stale if a["id"] == "subsystem_stale:ego")
+    assert ego["severity"] == "CRITICAL"
+    assert "ego" in ego["message"]
+
+
+@pytest.mark.asyncio
+async def test_non_ego_cessation_alerts_warning(db):
+    """A stalled inbox (2h old vs 1h threshold) → subsystem_stale:inbox WARNING."""
+    await _seed_heartbeat(db, "inbox", age_seconds=2 * 3600)
+    alerts = await _run_alerts_with_db(db)
+    stale = _stale(alerts)
+    inbox = next((a for a in stale if a["id"] == "subsystem_stale:inbox"), None)
+    assert inbox is not None
+    assert inbox["severity"] == "WARNING"
+
+
+@pytest.mark.asyncio
+async def test_alive_subsystem_does_not_alert(db):
+    """A freshly-pulsing subsystem emits no subsystem_stale alert."""
+    await _seed_heartbeat(db, "surplus", age_seconds=5)
+    alerts = await _run_alerts_with_db(db)
+    assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:surplus"]
+
+
+@pytest.mark.asyncio
+async def test_reflection_is_excluded(db):
+    """reflection is DROPPED from the alert set (its pulse tracks the awareness
+    loop, not reflection-engine liveness) even when overdue."""
+    await _seed_heartbeat(db, "reflection", age_seconds=5 * 3600)  # > 14400 threshold
+    alerts = await _run_alerts_with_db(db)
+    assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:reflection"]
+
+
+@pytest.mark.asyncio
+async def test_awareness_not_duplicated(db):
+    """awareness overdue is covered by awareness:tick_overdue, NOT a
+    subsystem_stale:awareness duplicate."""
+    await _seed_heartbeat(db, "awareness", age_seconds=5 * 3600)
+    alerts = await _run_alerts_with_db(db)
+    assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:awareness"]
+
+
+@pytest.mark.asyncio
+async def test_empty_state_no_alerts(db):
+    """Fresh install (no heartbeat events at all) → no subsystem_stale alerts."""
+    alerts = await _run_alerts_with_db(db)
+    assert _stale(alerts) == []
+
+
+@pytest.mark.asyncio
+async def test_helper_failure_isolated_from_other_alerts(db):
+    """If the pulse-staleness block raises, the OTHER alerts still compute (its
+    own try/except isolates it) and it is ERROR-logged, never a silent green."""
+    await _seed_heartbeat(db, "ego", age_seconds=5 * 3600)
+    with patch(
+        "genesis.mcp.health.manifest.compute_heartbeat_staleness",
+        new=AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        # Should not raise; alerts list still returns (other blocks intact).
+        alerts = await _run_alerts_with_db(db)
+    assert _stale(alerts) == []  # block failed → no subsystem_stale alerts, but no crash
+
+
+# ── heartbeat GC preserves the last pulse (durable staleness signal) ─────────
+
+
+@pytest.mark.asyncio
+async def test_gc_keeps_latest_heartbeat_keeps_dead_subsystem_detectable(db):
+    """The 7-day heartbeat GC must KEEP the most-recent pulse per subsystem, so a
+    scheduler dead LONGER than the retention window stays detectable — its last
+    pulse is not pruned into a false ``no_heartbeat``/green."""
+    from genesis.db.crud import events as events_crud
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    # ego died 10 days ago — its ONLY pulse is older than the 7-day GC cutoff.
+    await _seed_heartbeat(db, "ego", age_seconds=10 * 86400)
+    cutoff = (datetime.now(UTC) - timedelta(days=7)).isoformat()
+    await events_crud.prune(
+        db, older_than=cutoff, event_type="heartbeat", keep_latest_per_subsystem=True
+    )
+
+    hb = await compute_heartbeat_staleness("ego", db=db)
+    assert hb["status"] == "overdue"  # last pulse survived → still detectably dead
+
+
+@pytest.mark.asyncio
+async def test_gc_without_keep_latest_would_lose_the_signal(db):
+    """Control: the OLD prune (keep_latest_per_subsystem=False) deletes the sole
+    old pulse → the dead subsystem reverts to no_heartbeat. This is the hole the
+    keep-latest fix closes; asserting it makes the fix's value explicit."""
+    from genesis.db.crud import events as events_crud
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "ego", age_seconds=10 * 86400)
+    cutoff = (datetime.now(UTC) - timedelta(days=7)).isoformat()
+    await events_crud.prune(db, older_than=cutoff, event_type="heartbeat")
+
+    hb = await compute_heartbeat_staleness("ego", db=db)
+    assert hb["status"] == "no_heartbeat"  # sole pulse pruned → signal lost (the bug)
+
+
+@pytest.mark.asyncio
+async def test_gc_keeps_only_newest_and_still_prunes_older(db):
+    """keep-latest retains exactly the single newest pulse per subsystem; older
+    pulses past the cutoff are still pruned (volume stays bounded)."""
+    from genesis.db.crud import events as events_crud
+
+    await _seed_heartbeat(db, "ego", age_seconds=12 * 86400)  # older → prunable
+    await _seed_heartbeat(db, "ego", age_seconds=9 * 86400)  # newest → retained
+    await _seed_heartbeat(db, "surplus", age_seconds=8 * 86400)  # sole → retained
+    cutoff = (datetime.now(UTC) - timedelta(days=7)).isoformat()
+    await events_crud.prune(
+        db, older_than=cutoff, event_type="heartbeat", keep_latest_per_subsystem=True
+    )
+
+    ego_rows = await events_crud.query(db, subsystem="ego", event_type="heartbeat", limit=10)
+    surplus_rows = await events_crud.query(
+        db, subsystem="surplus", event_type="heartbeat", limit=10
+    )
+    assert len(ego_rows) == 1  # only the newest ego pulse kept
+    assert len(surplus_rows) == 1  # the sole surplus pulse kept

--- a/tests/test_mcp/test_subsystem_staleness.py
+++ b/tests/test_mcp/test_subsystem_staleness.py
@@ -260,6 +260,103 @@ async def test_staleness_not_paused_still_overdue(db):
     assert hb["status"] == "overdue"
 
 
+# ── #240 newest-by-parsed-instant (mixed UTC offsets) ────────────────────────
+
+
+def test_newest_valid_ts_picks_by_instant_not_text():
+    """Textual ORDER BY is not chronological across UTC offsets — pick the newest
+    PARSED instant, not the textually-first row (#240)."""
+    from genesis.mcp.health.manifest import _newest_valid_ts
+
+    now = datetime(2026, 8, 25, 20, 0, tzinfo=UTC)
+    a = "2026-08-25T15:00:00+00:00"  # 15:00 UTC — sorts textually AFTER b ("15" > "11")
+    b = "2026-08-25T11:30:00-04:00"  # 15:30 UTC — chronologically LATER, sorts first-text
+    # In textual-DESC order the query returns `a` first; the newer instant is `b`.
+    iso, saw = _newest_valid_ts([a, b], now=now)
+    assert iso == b
+    assert saw is True
+
+
+# ── #372 post-resume grace (pause-gated) ─────────────────────────────────────
+
+
+async def _seed_resume(db, age_seconds: float) -> None:
+    from genesis.db.crud import events as events_crud
+
+    await events_crud.insert(
+        db,
+        subsystem="runtime",
+        severity="info",
+        event_type="resume",
+        message="Resumed",
+        timestamp=_iso_ago(age_seconds),
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_resume_grace_suppresses_pause_gated_overdue(db):
+    """Just after resuming from a >threshold pause, a pause-gated subsystem's stale
+    pulse hasn't refreshed yet → 'resuming' (non-alerting), not 'overdue' (#372)."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "inbox", age_seconds=3 * 3600)  # > 7200 threshold
+    await _seed_resume(db, age_seconds=60)  # resumed 1 min ago
+    hb = await compute_heartbeat_staleness("inbox", db=db, paused=False)
+    assert hb["status"] == "resuming"
+
+
+@pytest.mark.asyncio
+async def test_overdue_fires_after_resume_grace_expires(db):
+    """Once the post-resume grace (interval + buffer) has elapsed with STILL no fresh
+    pulse, it is a genuine stall → overdue (#372 does not mask a real death)."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "inbox", age_seconds=3 * 3600)
+    await _seed_resume(db, age_seconds=3600)  # resumed 1h ago (> inbox 1800+120 grace)
+    hb = await compute_heartbeat_staleness("inbox", db=db, paused=False)
+    assert hb["status"] == "overdue"
+
+
+@pytest.mark.asyncio
+async def test_no_resume_event_no_grace(db):
+    """With no resume on record, a pause-gated overdue is a normal stall → overdue."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "inbox", age_seconds=3 * 3600)
+    hb = await compute_heartbeat_staleness("inbox", db=db, paused=False)
+    assert hb["status"] == "overdue"
+
+
+# ── #973 disabled-subsystem suppression ──────────────────────────────────────
+
+
+def test_subsystem_enabled_defaults_true_and_reads_ego_config():
+    """_subsystem_enabled defaults True (fail toward surfacing) and honors ego's
+    disable switch (#973)."""
+    from types import SimpleNamespace as _NS
+
+    from genesis.mcp.health import manifest as _m
+
+    assert _m._subsystem_enabled("inbox") is True  # no disable switch → True
+    with patch("genesis.ego.config.load_ego_config", return_value=_NS(enabled=False)):
+        assert _m._subsystem_enabled("ego") is False
+    with patch("genesis.ego.config.load_ego_config", return_value=_NS(enabled=True)):
+        assert _m._subsystem_enabled("ego") is True
+
+
+@pytest.mark.asyncio
+async def test_disabled_ego_suppresses_cessation_alert(db):
+    """A DISABLED ego with a retained stale pulse must NOT raise a (permanent)
+    subsystem_stale:ego CRITICAL — the stale pulse is intentional, not a death (#973)."""
+    await _seed_heartbeat(db, "ego", age_seconds=5 * 3600)
+    with patch(
+        "genesis.mcp.health.manifest._subsystem_enabled",
+        side_effect=lambda n: n != "ego",
+    ):
+        alerts = await _run_alerts_with_db(db)
+    assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:ego"]
+
+
 # ── loosened thresholds (near-zero false-reds) ───────────────────────────────
 
 

--- a/tests/test_mcp/test_subsystem_staleness.py
+++ b/tests/test_mcp/test_subsystem_staleness.py
@@ -129,6 +129,51 @@ async def test_staleness_uses_freshest_of_db_and_ring(db):
 
 
 @pytest.mark.asyncio
+async def test_corrupt_future_row_does_not_hide_valid_pulse(db):
+    """A materially-future heartbeat sorts FIRST under the events table's TEXT
+    ORDER BY, but the window scan still finds the newest valid pulse beneath it →
+    alive, never a stuck/never-resolving verdict off the bad row (#9)."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "ego", age_seconds=-100 * 365 * 86400)  # ~century in future
+    await _seed_heartbeat(db, "ego", age_seconds=30)  # fresh valid pulse beneath it
+    hb = await compute_heartbeat_staleness("ego", db=db)
+    assert hb["status"] == "alive"
+
+
+@pytest.mark.asyncio
+async def test_naive_timestamp_normalized_not_crash(db):
+    """A naive (tz-less) heartbeat timestamp is normalized to UTC by the shared
+    parser, not a TypeError that breaks the whole helper (#8)."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    naive = datetime.now(UTC).replace(tzinfo=None).isoformat()  # no offset
+    await db.execute(
+        "INSERT INTO events (id, timestamp, subsystem, severity, event_type, "
+        "message, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("n1", naive, "ego", "debug", "heartbeat", "naive", naive),
+    )
+    await db.commit()
+    hb = await compute_heartbeat_staleness("ego", db=db)
+    assert hb["status"] == "alive"  # normalized + recent → alive, not unknown/crash
+
+
+def test_read_global_paused_reads_persisted_file(tmp_path):
+    """_read_global_paused reads the persisted pause file (the cross-process source
+    of truth), NOT the in-memory runtime singleton — so the pause-guard works in the
+    standalone health MCP where no GenesisRuntime is bootstrapped (#7)."""
+    from genesis.mcp.health import manifest as _m
+
+    pf = tmp_path / "paused.json"
+    with patch.object(_m, "_PAUSE_FILE", pf):
+        assert _m._read_global_paused() is False  # absent file → not paused
+        pf.write_text('{"paused": true}')
+        assert _m._read_global_paused() is True
+        pf.write_text('{"paused": false}')
+        assert _m._read_global_paused() is False
+
+
+@pytest.mark.asyncio
 async def test_staleness_unknown_subsystem_is_no_heartbeat(db):
     """A name not in the threshold table degrades to no_heartbeat, never raises."""
     from genesis.mcp.health.manifest import compute_heartbeat_staleness
@@ -263,22 +308,19 @@ def _snapshot():
 async def _run_alerts_with_db(db, *, paused: bool = False):
     """Run the real _compute_alerts path with `db` as the health service DB.
 
-    ``paused`` patches the runtime pause flag the helper reads for pause-gated
-    subsystems (deterministic — never depends on a leaked singleton).
+    ``paused`` stubs the persisted-pause read the helper uses for pause-gated
+    subsystems (deterministic — never touches the real ~/.genesis/paused.json).
     """
-    from genesis.runtime._core import GenesisRuntime
-
     svc = MagicMock()
     svc._db = db
     svc.snapshot = AsyncMock(return_value=_snapshot())
-    stub_rt = SimpleNamespace(paused=paused)
     with (
         patch("genesis.mcp.health_mcp._service", svc),
         patch("genesis.mcp.health_mcp._activity_tracker", None),
         patch("genesis.mcp.health_mcp._job_retry_registry", None),
         patch("genesis.mcp.health_mcp._alert_history", {}),
         patch("genesis.mcp.health_mcp._event_bus", None),
-        patch.object(GenesisRuntime, "peek", return_value=stub_rt),
+        patch("genesis.mcp.health.manifest._read_global_paused", return_value=paused),
     ):
         from genesis.mcp.health.errors import _impl_health_alerts
 
@@ -470,19 +512,16 @@ async def test_read_error_preserves_open_alert(db):
 async def _compute_alerts_with_hb_side_effect(db, side_effect):
     """Run the real _compute_alerts with compute_heartbeat_staleness stubbed to
     `side_effect` (e.g. raise for one subsystem). Returns (alerts, current_ids)."""
-    from genesis.runtime._core import GenesisRuntime
-
     svc = MagicMock()
     svc._db = db
     svc.snapshot = AsyncMock(return_value=_snapshot())
-    stub_rt = SimpleNamespace(paused=False)
     with (
         patch("genesis.mcp.health_mcp._service", svc),
         patch("genesis.mcp.health_mcp._activity_tracker", None),
         patch("genesis.mcp.health_mcp._job_retry_registry", None),
         patch("genesis.mcp.health_mcp._alert_history", {}),
         patch("genesis.mcp.health_mcp._event_bus", None),
-        patch.object(GenesisRuntime, "peek", return_value=stub_rt),
+        patch("genesis.mcp.health.manifest._read_global_paused", return_value=False),
         patch(
             "genesis.mcp.health.manifest.compute_heartbeat_staleness",
             new=AsyncMock(side_effect=side_effect),

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -1,6 +1,6 @@
 """Tests for morning report generator."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import aiosqlite
 import pytest
@@ -69,6 +69,43 @@ async def test_generate_returns_outreach_request(db, mock_health, mock_drafter):
     assert req.signal_type == "morning_report"
     assert req.salience_score == 0.0
     assert "morning" in req.topic.lower() or "report" in req.topic.lower()
+
+
+@pytest.mark.asyncio
+async def test_critical_issues_dedupes_subsystem_stale(db, mock_health, mock_drafter):
+    """A subsystem already surfaced as a subsystem_stale:<name> alert is NOT listed
+    a second time by the heartbeat-staleness block (P2-6 dedup). A subsystem with a
+    heartbeat but NO alert (surplus) is still surfaced once."""
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    alerts = [
+        {
+            "id": "subsystem_stale:inbox",
+            "severity": "WARNING",
+            "message": "Subsystem 'inbox' heartbeat overdue — no pulse in 9000s",
+        },
+    ]
+    heartbeats = {
+        "inbox": {"status": "overdue", "age_seconds": 9000, "last_seen": "x"},
+        "surplus": {"status": "overdue", "age_seconds": 5000, "last_seen": "y"},
+    }
+    with (
+        patch(
+            "genesis.mcp.health_mcp._impl_health_alerts",
+            new=AsyncMock(return_value=alerts),
+        ),
+        patch(
+            "genesis.mcp.health.manifest._impl_subsystem_heartbeats",
+            new=AsyncMock(return_value=heartbeats),
+        ),
+    ):
+        text = await gen._get_critical_issues()
+
+    assert text is not None
+    # inbox appears exactly once — via its alert line, NOT duplicated by the hb block.
+    assert text.count("'inbox'") == 1
+    assert "subsystem_stale:inbox" in text
+    # surplus has a heartbeat but no alert → still surfaced once by the hb block.
+    assert "'surplus'" in text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Make a dead subsystem scheduler stop reading "healthy"

Third of the observability-honesty batch (B #1444 → D #1459 → **C**). Adds the total-cessation
signal that #1422's ego intent-lag deliberately cannot catch (its docstring names this monitor as
the fix): when a background subsystem's scheduler/loop stops firing *entirely*, its heartbeat pulse
goes silent — previously nothing turned that into a signal, so the Ego tile + rollup could read green
while the egos were dead.

### What it does
- **Alert set = ego (CRITICAL) + inbox + dashboard (WARNING).** A `subsystem_stale:<name>` alert
  fires when the pulse goes overdue past its per-subsystem threshold; the ego tile + worst-of-7 rollup
  flip to error. **surplus** is excluded (PR-B #1444's tile already flips red on a wedged/dead surplus
  via its finer job_health signal) and **outreach** is excluded (its heartbeat is config-gated — see
  follow-up).
- **Pause-aware, idle-safe, boot-safe.** The pause-gated subsystems ({surplus, inbox}, whose pulse
  stops behind their loop's `if paused: return`) are downgraded to `paused` while Genesis is globally
  paused — reaching every consumer (alert, tile, morning report) via the shared
  `compute_heartbeat_staleness` helper. ego/dashboard pulse through pause by construction.
- **Never a silent green.** Freshest-of-durable-row-and-ring (excluding materially-future rows);
  future-skew/corrupt timestamp → `unknown`; an unreadable pulse surfaces loudly as WARNING
  `subsystem_heartbeat_unknown:<name>` (honest "can't confirm", not "died"); a read failure re-emits
  any open alert so a transient blip can't auto-resolve a real death; ego `no_heartbeat` past a
  boot-grace window → error, not a green tile.
- Thresholds loosened for near-zero false-reds (inbox 1h→2h = 4× the 30-min check; dashboard
  4min→10min = 10× the 60s pulse). Does **not** page (verified absent from the escalation whitelist).

### Scope / safety
Health/observability/dashboard layer only — **zero subsystem-loop edits** (per the "guard the consumer"
decision). No autonomy-gate / secrets / SQL / external-input surface.

### Review
2× genesis-architect (DONE_WITH_CONCERNS, no blocker) + a fresh-context exhaustive whole-class audit;
every finding fixed or documented-accepted. 179 targeted tests green, ruff clean. RED-first throughout.

Closes the ego total-cessation follow-up.

Ledger: 8f36a9371e884fcfb5631b67d26d5fe4
Follow-up: d765269d16d44e8182e0647a3458c544
