### PR TITLE
feat(repo-pulse): age-stale open-PR SessionStart surface (Workstream B)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,7 @@
                 ]
             },
             {
-                "matcher": "startup|resume|clear",
+                "matcher": "startup|resume",
                 "hooks": [
                     {
                         "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,6 +40,16 @@
                 ]
             },
             {
+                "matcher": "startup|resume|clear",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook surface_open_prs.py",
+                        "timeout": 10
+                    }
+                ]
+            },
+            {
                 "matcher": "startup|resume|clear|compact",
                 "hooks": [
                     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   `GENESIS_REPO_PULSE_DISABLED` gate matches the exact `1` the worker honors (a
   looser truthy set would half-disable the subsystem). `mode: off` / `enabled:
   false` are full-worker stops (all lanes); `open_pr_enabled` is the lane-only knob.
+  The surface's freshness TTL now derives from `min_interval_minutes` (2×, 1-day
+  floor) so a large debounce (≥1 day) can't expire the cache before the worker is
+  allowed to refresh it and silently suppress the surface for the whole window.
 
 - **The Contributor Work-Log can post curated newcomer issues autonomously
   (opt-in).** A new `require_approval: false` lever lets the curator's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   forever). Levers under the `repo_pulse` settings domain (`open_pr_enabled`,
   `open_pr_stale_days`, `max_open_prs`, `open_pr_resurface_days`,
   `open_pr_max_surface`); `GENESIS_REPO_PULSE_DISABLED` / `enabled: false` stop it.
+  Robustness (review round): the fetch now sorts `sort:updated-asc` so a capped
+  window (>`max_open_prs` open PRs) keeps the STALEST end — the lane's target —
+  instead of gh's newest-first default that would drop aged PRs indefinitely; the
+  cache/seen sidecars anchor on `genesis_home()` (honors `GENESIS_HOME`) so a
+  relocated install keeps writer + reader in sync; and the hook's
+  `GENESIS_REPO_PULSE_DISABLED` gate matches the exact `1` the worker honors (a
+  looser truthy set would half-disable the subsystem). `mode: off` / `enabled:
+  false` are full-worker stops (all lanes); `open_pr_enabled` is the lane-only knob.
 
 - **The Contributor Work-Log can post curated newcomer issues autonomously
   (opt-in).** A new `require_approval: false` lever lets the curator's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Session-start surface for age-stale open PRs.** The repo-pulse worker now
+  also caches the open-PR set each boundary, and a SessionStart hook lists the
+  ones idle past a threshold (default 7 days) as one passive inline line —
+  `[Open PRs] 3 open PRs idle ≥7d — #1379 (12d) · #1223 (12d, dependabot) …`.
+  Visibility only: no CI/review state, never "ready to merge", no Telegram, no
+  follow-up rows, no auto-merge. Age-based by design (no `reviewDecision`/status
+  reducer — those carry no signal for owner PRs that sit at `REVIEW_REQUIRED`
+  forever). Levers under the `repo_pulse` settings domain (`open_pr_enabled`,
+  `open_pr_stale_days`, `max_open_prs`, `open_pr_resurface_days`,
+  `open_pr_max_surface`); `GENESIS_REPO_PULSE_DISABLED` / `enabled: false` stop it.
+
 - **A per-prompt nudge when a session's memory MCP is running stale code.** Each
   Claude Code session's MCP subprocesses snapshot their code at spawn and never
   reload, so a deploy landing mid-session leaves recall — and its current security

--- a/config/repo_pulse.yaml
+++ b/config/repo_pulse.yaml
@@ -67,8 +67,9 @@ open_pr_stale_days: 7
 # gh --limit for the open-PR fetch (separate from max_prs, which is merged-only).
 max_open_prs: 50
 
-# A still-stale PR that was already surfaced re-appears once it has been on the
-# seen-map this many days (then ages out and stops nagging).
+# Keep surfacing a still-stale PR for this many days AFTER it is first shown, then
+# go quiet (until it leaves the stalled set and returns as a fresh episode). This
+# is a nag-window duration, NOT a re-appear-after delay.
 open_pr_resurface_days: 7
 
 # Max PRs listed inline per session (the rest collapse to "+N more").

--- a/config/repo_pulse.yaml
+++ b/config/repo_pulse.yaml
@@ -47,3 +47,29 @@ max_proposals_per_run: 10
 # Proposals below this confidence are stored but never surfaced at charter
 # injection (the dashboard still shows them).
 inject_confidence_floor: 0.7
+
+# ── Open-PR lane (session-manager PR-4c) ────────────────────────────────────
+# An age-based, passive inline surface: the worker fetches the OPEN-PR set into
+# ~/.genesis/repo_pulse/open_prs.json each non-debounced boundary, and the
+# SessionStart hook (surface_open_prs.py) shows the age-stale ones as one line.
+# It is visibility-only — NO CI/review state, never "ready to merge", no
+# Telegram, no follow-up rows, no auto-merge. GENESIS_REPO_PULSE_DISABLED and
+# `enabled: false` both stop it (the hook and the worker respectively).
+
+# Master switch for the open-PR lane specifically (independent of the fuzzy/
+# exact merged-PR tiers above).
+open_pr_enabled: true
+
+# A PR whose last update (updatedAt) is at least this many days ago is "stale"
+# and eligible to surface.
+open_pr_stale_days: 7
+
+# gh --limit for the open-PR fetch (separate from max_prs, which is merged-only).
+max_open_prs: 50
+
+# A still-stale PR that was already surfaced re-appears once it has been on the
+# seen-map this many days (then ages out and stops nagging).
+open_pr_resurface_days: 7
+
+# Max PRs listed inline per session (the rest collapse to "+N more").
+open_pr_max_surface: 5

--- a/config/repo_pulse.yaml
+++ b/config/repo_pulse.yaml
@@ -53,11 +53,22 @@ inject_confidence_floor: 0.7
 # ~/.genesis/repo_pulse/open_prs.json each non-debounced boundary, and the
 # SessionStart hook (surface_open_prs.py) shows the age-stale ones as one line.
 # It is visibility-only — NO CI/review state, never "ready to merge", no
-# Telegram, no follow-up rows, no auto-merge. GENESIS_REPO_PULSE_DISABLED and
-# `enabled: false` both stop it (the hook and the worker respectively).
+# Telegram, no follow-up rows, no auto-merge.
+#
+# What stops this lane, by lever:
+#   GENESIS_REPO_PULSE_DISABLED=1 — hook-level kill of the SessionStart surface.
+#   open_pr_enabled: false        — disables ONLY this lane; the merged-PR lanes
+#                                   keep running (the lane-specific knob).
+#   enabled: false / mode: off    — FULL-worker stops: the worker exits before
+#                                   any lane runs, so the open-PR cache stops
+#                                   refreshing too (and the surface goes quiet
+#                                   once the cache ages past its freshness TTL).
+# So `open_pr_enabled` is independent of the fuzzy/exact MERGED tiers, but not of
+# the master/mode switches. There is no "merged-off but open-PR-on" combination
+# in v1 — `mode: off` is a full stop, not a merged-only lever.
 
-# Master switch for the open-PR lane specifically (independent of the fuzzy/
-# exact merged-PR tiers above).
+# Lane-specific master switch (separate from the fuzzy/exact merged-PR tiers
+# above; the enabled/mode full-worker stops still apply on top).
 open_pr_enabled: true
 
 # A PR whose last update (updatedAt) is at least this many days ago is "stale"

--- a/scripts/surface_open_prs.py
+++ b/scripts/surface_open_prs.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""SessionStart hook: surface age-stale OPEN PRs inline (session-manager PR-4c).
+
+The repo-pulse worker fetches the open-PR set into a home-anchored cache each
+non-debounced boundary; this hook reads that cache, computes staleness against a
+FRESH ``now``, and surfaces the age-stale ones passively inline as one line:
+
+    [Open PRs] 3 open PRs idle >=7d — #1379 (12d) · #1223 (12d, dependabot) ·
+    #1406 (8d, draft). Ask "show PRs" to review.
+
+Worker = fetch-only; this hook owns ALL display logic + the seen-map, so the
+surface is always computed against the current clock (never a stale snapshot's).
+Its stdout becomes context visible to Claude at session start (same contract as
+scripts/surface_pr_updates.py). The whole body is fail-open: any error, missing
+cache, stale cache, or disabled config -> print nothing, never block session start.
+It NEVER prints CI/review state or "ready to merge" — a visibility nudge only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import UTC, datetime
+
+# The cache is only ever as fresh as the worker's last successful run. A snapshot
+# older than this is treated as a dead/degraded worker and NOT surfaced (a stale
+# open-PR list is worse than none).
+_MAX_CACHE_AGE_S = 86400  # 1 day
+
+
+def main() -> None:
+    # Cheapest gates first — before importing genesis modules.
+    if os.environ.get("GENESIS_REPO_PULSE_DISABLED", "").lower() in ("1", "true", "yes"):
+        return
+    # Genesis-dispatched (background) sessions must not consume the human's
+    # surface — leave the seen-map untouched so the next FOREGROUND session sees it.
+    if os.environ.get("GENESIS_CC_SESSION") == "1":
+        return
+
+    repo_src = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src")
+    if repo_src not in sys.path:
+        sys.path.insert(0, repo_src)
+
+    try:
+        from genesis.session_awareness import pr_watch, repo_pulse
+        from genesis.session_awareness import repo_pulse_config as pulse_cfg
+
+        cfg = pulse_cfg.load_config()
+        if pulse_cfg.effective_mode() == "off" or not cfg.get("open_pr_enabled", True):
+            return
+
+        cache_path = repo_pulse.open_prs_cache_path()
+        if not cache_path.exists():
+            return  # worker hasn't populated it yet (e.g. first boundary)
+        try:
+            data = json.loads(cache_path.read_text())
+        except Exception:
+            return
+        prs = data.get("prs") if isinstance(data, dict) else None
+        if not isinstance(prs, list) or not prs:
+            return
+
+        now = datetime.now(UTC)
+        # Freshness TTL: never surface a dead worker's stale snapshot.
+        computed = pr_watch._parse_ts(data.get("computed_at"))
+        if computed is None or (now - computed).total_seconds() > _MAX_CACHE_AGE_S:
+            return
+
+        stale_days = pulse_cfg.knob_int(cfg, "open_pr_stale_days")
+        resurface = pulse_cfg.knob_int(cfg, "open_pr_resurface_days")
+        max_surface = pulse_cfg.knob_int(cfg, "open_pr_max_surface")
+
+        stalled = repo_pulse.select_stalled_open_prs(prs, now=now, stale_days=stale_days)
+        if not stalled:
+            return
+
+        seen_path = repo_pulse.open_prs_seen_path()
+        surfaced, _existed = pr_watch.load_sidecar(seen_path)
+        lines, new_surfaced = pr_watch.select_to_surface(
+            stalled,
+            surfaced,
+            now,
+            resurface,
+            max_surface,
+            id_getter=lambda p: str(p["number"]),
+            renderer=repo_pulse.format_open_pr_clause,
+        )
+        # Persist seen-state even when nothing new to show (records baselines).
+        pr_watch.save_sidecar(seen_path, new_surfaced)
+
+        text = repo_pulse.format_open_pr_injection(lines, stale_days)
+        if text:
+            print(text)
+            sys.stdout.flush()
+    except Exception:
+        return  # Never block session start.
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/surface_open_prs.py
+++ b/scripts/surface_open_prs.py
@@ -66,9 +66,14 @@ def main() -> None:
             return  # malformed cache — nothing to compute or prune against
 
         now = datetime.now(UTC)
-        # Freshness TTL: never surface (or prune against) a dead worker's stale snapshot.
+        # Freshness TTL: never surface (or prune against) a dead worker's stale
+        # snapshot. Derive the allowance from the debounce cadence (2x, floored at
+        # 1 day) so a large `min_interval_minutes` (>=1440) can't expire the cache
+        # BEFORE the worker is even allowed to refresh it — which would otherwise
+        # suppress the surface for the whole debounce window (Codex P2).
+        ttl_s = max(_MAX_CACHE_AGE_S, pulse_cfg.knob_int(cfg, "min_interval_minutes") * 60 * 2)
         computed = pr_watch._parse_ts(data.get("computed_at"))
-        if computed is None or (now - computed).total_seconds() > _MAX_CACHE_AGE_S:
+        if computed is None or (now - computed).total_seconds() > ttl_s:
             return
 
         stale_days = pulse_cfg.knob_int(cfg, "open_pr_stale_days")

--- a/scripts/surface_open_prs.py
+++ b/scripts/surface_open_prs.py
@@ -58,11 +58,11 @@ def main() -> None:
         except Exception:
             return
         prs = data.get("prs") if isinstance(data, dict) else None
-        if not isinstance(prs, list) or not prs:
-            return
+        if not isinstance(prs, list):
+            return  # malformed cache — nothing to compute or prune against
 
         now = datetime.now(UTC)
-        # Freshness TTL: never surface a dead worker's stale snapshot.
+        # Freshness TTL: never surface (or prune against) a dead worker's stale snapshot.
         computed = pr_watch._parse_ts(data.get("computed_at"))
         if computed is None or (now - computed).total_seconds() > _MAX_CACHE_AGE_S:
             return
@@ -71,25 +71,36 @@ def main() -> None:
         resurface = pulse_cfg.knob_int(cfg, "open_pr_resurface_days")
         max_surface = pulse_cfg.knob_int(cfg, "open_pr_max_surface")
 
+        # Namespace the seen-map by the cache's live repo slug so a PR number from a
+        # DIFFERENT repo (a re-pointed remote / fork) can't collide with an aged-out
+        # entry of the same number (Codex P2).
+        repo_slug = str(data.get("repo") or "?")
         stalled = repo_pulse.select_stalled_open_prs(prs, now=now, stale_days=stale_days)
-        if not stalled:
-            return
 
         seen_path = repo_pulse.open_prs_seen_path()
         surfaced, _existed = pr_watch.load_sidecar(seen_path)
+        # ALWAYS rebuild the seen-map from the CURRENT stalled set — even when it is
+        # empty — so an entry for a PR that has left the stalled set is dropped; keeping
+        # its old first_ts would wrongly age it out and it would not resurface when it
+        # goes stale again (Codex P2). select_to_surface([]) returns an empty map, which
+        # is the correct pruned state.
         lines, new_surfaced = pr_watch.select_to_surface(
             stalled,
             surfaced,
             now,
             resurface,
             max_surface,
-            id_getter=lambda p: str(p["number"]),
+            id_getter=lambda p: f"{repo_slug}#{p['number']}",
             renderer=repo_pulse.format_open_pr_clause,
         )
-        # Persist seen-state even when nothing new to show (records baselines).
         pr_watch.save_sidecar(seen_path, new_surfaced)
 
-        text = repo_pulse.format_open_pr_injection(lines, stale_days)
+        # A capped fetch (>max_open_prs open PRs) does not cover the whole open set —
+        # render the count as a floor (≥N) so it is reported honestly as a lower bound,
+        # never a silent exact count (Codex P2).
+        text = repo_pulse.format_open_pr_injection(
+            lines, stale_days, capped=bool(data.get("limit_hit"))
+        )
         if text:
             print(text)
             sys.stdout.flush()

--- a/scripts/surface_open_prs.py
+++ b/scripts/surface_open_prs.py
@@ -30,8 +30,12 @@ _MAX_CACHE_AGE_S = 86400  # 1 day
 
 
 def main() -> None:
-    # Cheapest gates first — before importing genesis modules.
-    if os.environ.get("GENESIS_REPO_PULSE_DISABLED", "").lower() in ("1", "true", "yes"):
+    # Cheapest gates first — before importing genesis modules. Match the EXACT
+    # "1" the other two consumers honor (repo_pulse_worker.py, genesis_session_
+    # context.py) and the value the yaml documents (GENESIS_REPO_PULSE_DISABLED=1);
+    # a looser truthy set here would let `=true` silence THIS surface while the
+    # detached worker kept doing gh/DB work — a partial, misleading kill switch.
+    if os.environ.get("GENESIS_REPO_PULSE_DISABLED") == "1":
         return
     # Genesis-dispatched (background) sessions must not consume the human's
     # surface — leave the seen-map untouched so the next FOREGROUND session sees it.

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -1286,13 +1286,13 @@ def _validate_repo_pulse(changes: dict) -> list[str]:
     from genesis.session_awareness.repo_pulse_config import _INT_KNOBS, MODES
 
     errors: list[str] = []
-    valid_keys = ("enabled", "mode", *_INT_KNOBS, "inject_confidence_floor")
+    valid_keys = ("enabled", "open_pr_enabled", "mode", *_INT_KNOBS, "inject_confidence_floor")
     for key, value in changes.items():
         if key not in valid_keys:
             errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
-        elif key == "enabled":
+        elif key in ("enabled", "open_pr_enabled"):
             if not isinstance(value, bool):
-                errors.append("'enabled' must be a boolean")
+                errors.append(f"'{key}' must be a boolean")
         elif key == "mode":
             if value not in MODES:
                 errors.append(f"'mode' must be one of {', '.join(MODES)}; got {value!r}")

--- a/src/genesis/session_awareness/pr_watch.py
+++ b/src/genesis/session_awareness/pr_watch.py
@@ -30,6 +30,7 @@ import json
 import logging
 import os
 import tempfile
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -157,25 +158,34 @@ def select_to_surface(
     now: datetime,
     resurface_days: int,
     max_surface: int,
+    *,
+    id_getter: Callable[[dict[str, Any]], str] | None = None,
+    renderer: Callable[[dict[str, Any]], str] | None = None,
 ) -> tuple[list[str], dict[str, dict[str, Any]]]:
-    """Decide which notifications to surface this run and compute the next
-    sidecar.
+    """Decide which items to surface this run and compute the next sidecar.
 
-    Per notification (already lookback-filtered, newest first):
+    Per item (already lookback/staleness-filtered, most-relevant first):
     - unseen -> surface, record first_ts=now
     - seen, first surfaced <= resurface_days ago -> resurface
     - seen, aged past resurface_days -> keep in sidecar, do NOT surface
 
-    The next sidecar is built ONLY from the current notification set, so any id
-    that has fallen outside the lookback window is pruned automatically (no
-    unbounded growth, no retention step).
+    The next sidecar is built ONLY from the current item set, so any id that has
+    fallen outside the window is pruned automatically (no unbounded growth, no
+    retention step).
+
+    ``id_getter``/``renderer`` default to the steward-notification shape
+    (``str(n["id"])`` / ``render_clause``); the open-PR lane passes its own
+    (``str(pr["number"])`` / ``format_open_pr_clause``) so this surface/seen-map
+    logic is REUSED, not forked.
     """
+    key_of = id_getter or (lambda n: str(n["id"]))
+    render = renderer or render_clause
     resurface_cutoff = now.timestamp() - resurface_days * 86400
     new_surfaced: dict[str, dict[str, Any]] = {}
     to_show: list[dict[str, Any]] = []
 
     for n in notifs:
-        nid = str(n["id"])
+        nid = key_of(n)
         prev = surfaced.get(nid)
         if prev is None:
             new_surfaced[nid] = {"first_ts": now.isoformat()}
@@ -186,7 +196,7 @@ def select_to_surface(
         if first_ts.timestamp() >= resurface_cutoff:
             to_show.append(n)
 
-    lines = [render_clause(n) for n in to_show[: max(max_surface, 0)]]
+    lines = [render(n) for n in to_show[: max(max_surface, 0)]]
     overflow = len(to_show) - len(lines)
     if overflow > 0:
         lines.append(f"+{overflow} more")

--- a/src/genesis/session_awareness/pr_watch.py
+++ b/src/genesis/session_awareness/pr_watch.py
@@ -192,7 +192,12 @@ def select_to_surface(
             to_show.append(n)
             continue
         first_ts = _parse_ts(prev.get("first_ts")) or now
-        new_surfaced[nid] = {"first_ts": prev.get("first_ts") or now.isoformat()}
+        # Persist a VALID prior first_ts verbatim; HEAL an unparseable/corrupt one to
+        # now so a torn/tampered sidecar entry cannot nag every session forever
+        # (the show decision above already heals; this heals the persisted value).
+        new_surfaced[nid] = {
+            "first_ts": prev.get("first_ts") if _parse_ts(prev.get("first_ts")) else now.isoformat()
+        }
         if first_ts.timestamp() >= resurface_cutoff:
             to_show.append(n)
 

--- a/src/genesis/session_awareness/repo_pulse.py
+++ b/src/genesis/session_awareness/repo_pulse.py
@@ -24,8 +24,13 @@ Two tiers, two postures:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import re
+from datetime import datetime
+from pathlib import Path
+
+from genesis.session_awareness.pr_watch import _parse_ts
 
 PULSE_MODEL = "claude-haiku-4-5-20251001"  # arbiter/extractor smoke-tested contract
 # 240s (was 120): live E2E measured 67s/122s/84s per call with TTFT alone
@@ -318,3 +323,103 @@ def _parse_match(match: object, n_items: int, n_prs: int) -> dict | None:
         "confidence": round(float(confidence), 4),
         "reason": reason.strip()[:300],
     }
+
+
+# ── Open-PR lane (session-manager PR-4c): age-stale open-PR surface ──────────
+# The worker fetches the open-PR set into a home-anchored cache; the SessionStart
+# hook reads it, computes staleness client-side, and surfaces the age-stale ones
+# passively inline. Pure functions (no I/O) live here; the cache/seen PATHS are
+# home-anchored so the worker (writer) and hook (reader) agree without threading
+# the worker's state root through the hook.
+
+
+def _pulse_home() -> Path:
+    """Home-anchored repo-pulse state dir (matches the worker's ``_pulse_root``)."""
+    return Path.home() / ".genesis" / "repo_pulse"
+
+
+def open_prs_cache_path() -> Path:
+    """Worker-owned raw open-PR snapshot (fetch cache)."""
+    return _pulse_home() / "open_prs.json"
+
+
+def open_prs_seen_path() -> Path:
+    """Hook-owned seen-map for the open-PR surface (self-pruning sidecar)."""
+    return _pulse_home() / "open_prs_seen.json"
+
+
+def _is_bot_author(author: dict) -> bool:
+    """Whether a PR author is a bot — trust gh's ``is_bot`` flag, fall back to a
+    ``[bot]`` login suffix (dependabot/renovate)."""
+    if not isinstance(author, dict):
+        return False
+    if author.get("is_bot"):
+        return True
+    return str(author.get("login") or "").endswith("[bot]")
+
+
+def select_stalled_open_prs(prs: list[dict], *, now: datetime, stale_days: int) -> list[dict]:
+    """Annotate open PRs with ``stale_days`` (``updatedAt`` vs the INJECTED
+    ``now`` — no wall-clock read) and keep those idle for >= ``stale_days``,
+    stalest first. A row with an unparseable ``updatedAt`` is skipped (can't age
+    it). Purely age + list-fields — NO CI/review inference (honest to what
+    ``gh pr list`` returns)."""
+    out: list[dict] = []
+    for pr in prs:
+        if not isinstance(pr, dict) or not isinstance(pr.get("number"), int):
+            continue
+        updated = _parse_ts(pr.get("updatedAt"))
+        if updated is None:
+            continue
+        age_days = (now - updated).total_seconds() / 86400.0
+        if age_days < stale_days:
+            continue
+        author = pr.get("author") if isinstance(pr.get("author"), dict) else {}
+        out.append(
+            {
+                "number": pr["number"],
+                "title": str(pr.get("title") or ""),
+                "url": str(pr.get("url") or ""),
+                "stale_days": int(age_days),
+                "is_draft": bool(pr.get("isDraft")),
+                "mergeable": pr.get("mergeable"),
+                "is_bot": _is_bot_author(author),
+                "author_login": str(author.get("login") or ""),
+            }
+        )
+    out.sort(key=lambda p: p["stale_days"], reverse=True)
+    return out
+
+
+def format_open_pr_clause(pr: dict) -> str:
+    """One open PR → a short clause, e.g. ``#1379 (12d, dependabot, draft)``.
+    NEVER prints CI state or 'ready to merge' — age + coarse tags only."""
+    tags: list[str] = []
+    if pr.get("is_bot"):
+        login = str(pr.get("author_login") or "").lower()
+        tags.append("dependabot" if "dependabot" in login else "bot")
+    if pr.get("is_draft"):
+        tags.append("draft")
+    suffix = f", {', '.join(tags)}" if tags else ""
+    return f"#{pr['number']} ({pr['stale_days']}d{suffix})"
+
+
+def format_open_pr_injection(lines: list[str], stale_days: int) -> str:
+    """The single inline line for the open-PR surface. Empty -> ''. The header
+    count is the TRUE total (shown clauses + any '+N more' overflow). NEVER says
+    'ready to merge' — a visibility nudge, not a merge signal."""
+    if not lines:
+        return ""
+    shown = [ln for ln in lines if not ln.startswith("+")]
+    overflow = 0
+    for ln in lines:
+        if ln.startswith("+") and ln.endswith(" more"):
+            with contextlib.suppress(ValueError):
+                overflow = int(ln[1 : -len(" more")])
+    total = len(shown) + overflow
+    noun = "PR" if total == 1 else "PRs"
+    return (
+        f"[Open PRs] {total} open {noun} idle ≥{stale_days}d — "
+        + " · ".join(lines)
+        + '. Ask "show PRs" to review.'
+    )

--- a/src/genesis/session_awareness/repo_pulse.py
+++ b/src/genesis/session_awareness/repo_pulse.py
@@ -404,10 +404,12 @@ def format_open_pr_clause(pr: dict) -> str:
     return f"#{pr['number']} ({pr['stale_days']}d{suffix})"
 
 
-def format_open_pr_injection(lines: list[str], stale_days: int) -> str:
+def format_open_pr_injection(lines: list[str], stale_days: int, *, capped: bool = False) -> str:
     """The single inline line for the open-PR surface. Empty -> ''. The header
-    count is the TRUE total (shown clauses + any '+N more' overflow). NEVER says
-    'ready to merge' — a visibility nudge, not a merge signal."""
+    count is the TRUE total (shown clauses + any '+N more' overflow). When ``capped``
+    (the worker's fetch hit its limit, so the open set is only partially known) the
+    count is rendered as a floor (``≥N``) — an honest lower bound, never a silent
+    exact count. NEVER says 'ready to merge' — a visibility nudge, not a merge signal."""
     if not lines:
         return ""
     shown = [ln for ln in lines if not ln.startswith("+")]
@@ -418,8 +420,9 @@ def format_open_pr_injection(lines: list[str], stale_days: int) -> str:
                 overflow = int(ln[1 : -len(" more")])
     total = len(shown) + overflow
     noun = "PR" if total == 1 else "PRs"
+    count = f"≥{total}" if capped else str(total)
     return (
-        f"[Open PRs] {total} open {noun} idle ≥{stale_days}d — "
+        f"[Open PRs] {count} open {noun} idle ≥{stale_days}d — "
         + " · ".join(lines)
         + '. Ask "show PRs" to review.'
     )

--- a/src/genesis/session_awareness/repo_pulse.py
+++ b/src/genesis/session_awareness/repo_pulse.py
@@ -30,6 +30,7 @@ import re
 from datetime import datetime
 from pathlib import Path
 
+from genesis.env import genesis_home
 from genesis.session_awareness.pr_watch import _parse_ts
 
 PULSE_MODEL = "claude-haiku-4-5-20251001"  # arbiter/extractor smoke-tested contract
@@ -334,8 +335,12 @@ def _parse_match(match: object, n_items: int, n_prs: int) -> dict | None:
 
 
 def _pulse_home() -> Path:
-    """Home-anchored repo-pulse state dir (matches the worker's ``_pulse_root``)."""
-    return Path.home() / ".genesis" / "repo_pulse"
+    """Repo-pulse state dir (matches the worker's ``_pulse_root``). Anchored on
+    the canonical ``genesis_home()`` — which honors ``GENESIS_HOME`` — so a
+    relocated install keeps its runtime state together and the worker (writer)
+    and hook (reader) resolve the SAME directory (a bare ``Path.home()`` would
+    split them apart whenever ``GENESIS_HOME`` is set)."""
+    return genesis_home() / "repo_pulse"
 
 
 def open_prs_cache_path() -> Path:

--- a/src/genesis/session_awareness/repo_pulse_config.py
+++ b/src/genesis/session_awareness/repo_pulse_config.py
@@ -54,6 +54,12 @@ DEFAULTS: dict[str, Any] = {
     "max_items": 40,  # open ledger rows fed to the fuzzy judge
     "max_proposals_per_run": 10,  # fuzzy annotations stored per run
     "inject_confidence_floor": 0.7,  # proposals below this never surface
+    # Open-PR lane (session-manager PR-4c): age-stale open-PR surface.
+    "open_pr_enabled": True,  # master switch for the open-PR lane (bool)
+    "open_pr_stale_days": 7,  # a PR idle >= this many days is "stale"
+    "max_open_prs": 50,  # gh --limit for the open-PR fetch
+    "open_pr_resurface_days": 7,  # re-surface a still-stale PR after this long
+    "open_pr_max_surface": 5,  # max PRs shown inline per session
 }
 
 _INT_KNOBS = (
@@ -62,6 +68,10 @@ _INT_KNOBS = (
     "max_prs",
     "max_items",
     "max_proposals_per_run",
+    "open_pr_stale_days",
+    "max_open_prs",
+    "open_pr_resurface_days",
+    "open_pr_max_surface",
 )
 
 

--- a/src/genesis/session_awareness/repo_pulse_config.py
+++ b/src/genesis/session_awareness/repo_pulse_config.py
@@ -58,7 +58,7 @@ DEFAULTS: dict[str, Any] = {
     "open_pr_enabled": True,  # master switch for the open-PR lane (bool)
     "open_pr_stale_days": 7,  # a PR idle >= this many days is "stale"
     "max_open_prs": 50,  # gh --limit for the open-PR fetch
-    "open_pr_resurface_days": 7,  # re-surface a still-stale PR after this long
+    "open_pr_resurface_days": 7,  # keep surfacing a still-stale PR for this many days after first shown, then go quiet
     "open_pr_max_surface": 5,  # max PRs shown inline per session
 }
 

--- a/src/genesis/session_awareness/repo_pulse_gh.py
+++ b/src/genesis/session_awareness/repo_pulse_gh.py
@@ -143,3 +143,57 @@ async def list_merged_prs(
     ]
     prs.sort(key=lambda p: p["mergedAt"])
     return {"repo": repo, "prs": prs, "limit_hit": len(raw) >= limit}
+
+
+# Open-PR lane fields (session-manager PR-4c). Deliberately NOT PR_FIELDS
+# (merged-only): the open-PR surface keys on updatedAt for age, the author's
+# ``is_bot`` flag for the dependabot tag, and isDraft/mergeable for the clause.
+# NO statusCheckRollup / reviewDecision — the surface is age-based only (every
+# owner PR reads REVIEW_REQUIRED forever, so it carries no signal).
+OPEN_PR_FIELDS = "number,title,url,isDraft,mergeable,updatedAt,createdAt,author"
+
+
+async def list_open_prs(
+    *,
+    limit: int = 50,
+    repo: str | None = None,
+    runner: Runner | None = None,
+) -> dict:
+    """Enumerate OPEN PRs for the age-stale SessionStart surface.
+
+    Returns ``{"repo", "prs", "limit_hit"}`` (prs in gh's default order — the
+    hook computes ``stale_days`` client-side, so no sort dependency here), or
+    ``{"error": ...}`` without raising. Rows missing an int ``number`` are
+    dropped (gh contract violation, not a crash). Slug resolves LIVE (same
+    stale-config hardening as ``list_merged_prs``).
+    """
+    run = runner or _default_runner
+    if repo is None:
+        repo = await resolve_repo(run)
+        if repo is None:
+            return {"error": "repo slug resolve failed"}
+    rc, out, err = await run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--json",
+            OPEN_PR_FIELDS,
+            "--limit",
+            str(limit),
+        ]
+    )
+    if rc != 0:
+        return {"error": f"open pr list failed (rc={rc}): {err.strip()[:400]}"}
+    try:
+        raw = json.loads(out)
+    except json.JSONDecodeError as exc:
+        return {"error": f"open pr list returned invalid JSON: {exc}"}
+    if not isinstance(raw, list):
+        return {"error": "open pr list returned a non-list payload"}
+    prs = [pr for pr in raw if isinstance(pr, dict) and isinstance(pr.get("number"), int)]
+    return {"repo": repo, "prs": prs, "limit_hit": len(raw) >= limit}

--- a/src/genesis/session_awareness/repo_pulse_gh.py
+++ b/src/genesis/session_awareness/repo_pulse_gh.py
@@ -161,11 +161,21 @@ async def list_open_prs(
 ) -> dict:
     """Enumerate OPEN PRs for the age-stale SessionStart surface.
 
-    Returns ``{"repo", "prs", "limit_hit"}`` (prs in gh's default order — the
-    hook computes ``stale_days`` client-side, so no sort dependency here), or
-    ``{"error": ...}`` without raising. Rows missing an int ``number`` are
+    Returns ``{"repo", "prs", "limit_hit"}`` (fetched STALEST-first — see below),
+    or ``{"error": ...}`` without raising. Rows missing an int ``number`` are
     dropped (gh contract violation, not a crash). Slug resolves LIVE (same
     stale-config hardening as ``list_merged_prs``).
+
+    ``--search "sort:updated-asc"`` fetches least-recently-updated FIRST, so a
+    capped window (``len(prs) == limit`` on a repo with >``limit`` open PRs) keeps
+    the STALEST end — the lane's whole target — rather than gh's default
+    newest-first order, which would silently drop exactly the aged PRs this
+    surface exists to raise (and could hide them indefinitely). Any PR omitted by
+    the cap is then strictly newer than every fetched one, so it cannot be stale;
+    the client-side ``stale_days`` filter over this window is complete for the
+    stale set (the ``≥N`` count floor stays honest when >``limit`` PRs are stale).
+    Unlike merged enumeration (GitHub search cannot sort by mergedAt asc), open
+    PRs sort by ``updatedAt`` fine — verified live against gh 2.x.
     """
     run = runner or _default_runner
     if repo is None:
@@ -181,6 +191,8 @@ async def list_open_prs(
             repo,
             "--state",
             "open",
+            "--search",
+            "sort:updated-asc",
             "--json",
             OPEN_PR_FIELDS,
             "--limit",

--- a/src/genesis/session_awareness/repo_pulse_worker.py
+++ b/src/genesis/session_awareness/repo_pulse_worker.py
@@ -51,6 +51,7 @@ from genesis.session_awareness.repo_pulse import (
     build_fuzzy_prompt,
     match_exact,
     match_followup,
+    open_prs_cache_path,
     parse_matches,
 )
 from genesis.session_awareness.repo_pulse_config import (
@@ -58,7 +59,7 @@ from genesis.session_awareness.repo_pulse_config import (
     knob_int,
     load_config,
 )
-from genesis.session_awareness.repo_pulse_gh import list_merged_prs
+from genesis.session_awareness.repo_pulse_gh import list_merged_prs, list_open_prs
 
 CURSOR_FILENAME = "cursor.json"
 LOCK_FILENAME = "pulse.lock"
@@ -465,6 +466,35 @@ async def _run_locked(
     cursor_before = cursor.get("last_merged_at")
     now_iso = _now()
     detail_notes: list[str] = []
+
+    # ── Open-PR lane (session-manager PR-4c) ─────────────────────────────────
+    # Fetch the open-PR set into a home-anchored cache for the SessionStart
+    # surface. Placed HERE — after the debounce gate, before the merged-PR
+    # enumeration and its no_new_prs/failed early-returns — because open PRs go
+    # stale on WALL-CLOCK, not on new merges: behind those early-returns the cache
+    # would never refresh on a boundary with no newly-merged PRs. Own try/except
+    # (a gh/parse failure must never skip the merged lanes or _record_run); it
+    # NEVER touches the cursor and writes only the fetch cache. A failure is
+    # surfaced on the run row's detail (this module reports via DB telemetry, not
+    # logging).
+    if cfg.get("open_pr_enabled", True):
+        try:
+            open_listing = await list_open_prs(limit=knob_int(cfg, "max_open_prs"))
+            if "error" in open_listing:
+                detail_notes.append(f"open_pr_lane: {str(open_listing['error'])[:120]}")
+            else:
+                _atomic_write_json(
+                    open_prs_cache_path(),
+                    {
+                        "version": 1,
+                        "computed_at": now_iso,
+                        "repo": open_listing["repo"],
+                        "prs": open_listing["prs"],
+                        "limit_hit": open_listing["limit_hit"],
+                    },
+                )
+        except Exception as exc:  # never break the merged lanes / _record_run
+            detail_notes.append(f"open_pr_lane_failed: {str(exc)[:120]}")
 
     reconciled = await _reconcile(db_path, now_iso)
     if reconciled:

--- a/src/genesis/session_awareness/repo_pulse_worker.py
+++ b/src/genesis/session_awareness/repo_pulse_worker.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from genesis.db.crud import follow_ups as followups_crud
 from genesis.db.crud import repo_pulse as pulse_crud
 from genesis.db.crud.session_charters import ledger_all, ledger_update
-from genesis.env import genesis_db_path
+from genesis.env import genesis_db_path, genesis_home
 from genesis.session_awareness.headless import run_headless_json
 from genesis.session_awareness.repo_pulse import (
     PROMPT_VERSION,
@@ -71,7 +71,10 @@ STALE_PROPOSAL_DAYS = 30
 
 
 def _pulse_root() -> Path:
-    return Path.home() / ".genesis" / "repo_pulse"
+    # genesis_home() (honors GENESIS_HOME), NOT a bare Path.home(), so a relocated
+    # install persists the lock/cursor + the open-PR cache/seen sidecars together —
+    # and the reader hook (repo_pulse._pulse_home) resolves the SAME directory.
+    return genesis_home() / "repo_pulse"
 
 
 def _now_dt() -> datetime:

--- a/tests/test_scripts/test_surface_open_prs.py
+++ b/tests/test_scripts/test_surface_open_prs.py
@@ -50,13 +50,24 @@ def _write_cache(home: Path, prs, *, age_hours=0, repo="o/r", capped=False) -> N
     )
 
 
-def _run(home: Path, *, disabled=False, cc_session=False) -> str:
+def _run(
+    home: Path,
+    *,
+    disabled=False,
+    disabled_raw: str | None = None,
+    genesis_home: Path | None = None,
+    cc_session=False,
+) -> str:
     env = os.environ.copy()
     env["HOME"] = str(home)
     env["PYTHONPATH"] = str(_SRC)
     env.pop("GENESIS_REPO_ROOT", None)
     env.pop("GENESIS_HOME", None)
-    if disabled:
+    if genesis_home is not None:
+        env["GENESIS_HOME"] = str(genesis_home)
+    if disabled_raw is not None:
+        env["GENESIS_REPO_PULSE_DISABLED"] = disabled_raw
+    elif disabled:
         env["GENESIS_REPO_PULSE_DISABLED"] = "1"
     else:
         env.pop("GENESIS_REPO_PULSE_DISABLED", None)
@@ -108,6 +119,44 @@ def test_env_kill_switch_silences(tmp_path):
     home = tmp_path / "home"
     _write_cache(home, [_openpr(1379, 12)])
     assert _run(home, disabled=True).strip() == ""
+
+
+def test_env_kill_switch_only_exact_one(tmp_path):
+    """The kill switch honors ONLY the exact "1" — the value the worker and
+    genesis_session_context honor and the yaml documents. A looser truthy set
+    here would silence THIS surface while the worker kept running: a partial,
+    misleading kill switch. So `=true`/`=yes` must NOT suppress."""
+    home = tmp_path / "home"
+    _write_cache(home, [_openpr(1379, 12)])
+    for raw in ("true", "yes", "TRUE", "on", "0", "2"):
+        assert "[Open PRs]" in _run(home, disabled_raw=raw), f"{raw!r} wrongly suppressed"
+    # the documented value still silences it
+    assert _run(home, disabled_raw="1").strip() == ""
+
+
+def test_honors_genesis_home(tmp_path):
+    """A relocated install (GENESIS_HOME set) reads the cache from under it, not
+    $HOME/.genesis — the worker writes there too, so the surface must follow."""
+    home = tmp_path / "home"  # deliberately EMPTY (no cache here)
+    ghome = tmp_path / "relocated"
+    cache = ghome / "repo_pulse" / "open_prs.json"
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    computed = datetime.now(UTC).isoformat()
+    cache.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "computed_at": computed,
+                "repo": "o/r",
+                "prs": [_openpr(1379, 12)],
+                "limit_hit": False,
+            }
+        )
+    )
+    out = _run(home, genesis_home=ghome)
+    assert "#1379 (12d)" in out
+    # and the seen-map is written under GENESIS_HOME too (not $HOME)
+    assert (ghome / "repo_pulse" / "open_prs_seen.json").exists()
 
 
 def test_dispatched_session_silent_and_leaves_seen_untouched(tmp_path):

--- a/tests/test_scripts/test_surface_open_prs.py
+++ b/tests/test_scripts/test_surface_open_prs.py
@@ -39,13 +39,13 @@ def _seen_path(home: Path) -> Path:
     return home / ".genesis" / "repo_pulse" / "open_prs_seen.json"
 
 
-def _write_cache(home: Path, prs, *, age_hours=0) -> None:
+def _write_cache(home: Path, prs, *, age_hours=0, repo="o/r", capped=False) -> None:
     computed = (datetime.now(UTC) - timedelta(hours=age_hours)).isoformat()
     cache = _cache_path(home)
     cache.parent.mkdir(parents=True, exist_ok=True)
     cache.write_text(
         json.dumps(
-            {"version": 1, "computed_at": computed, "repo": "o/r", "prs": prs, "limit_hit": False}
+            {"version": 1, "computed_at": computed, "repo": repo, "prs": prs, "limit_hit": capped}
         )
     )
 
@@ -124,3 +124,31 @@ def test_resurfaces_on_second_run(tmp_path):
     first = _run(home)
     second = _run(home)  # within resurface window
     assert "[Open PRs]" in first and "[Open PRs]" in second
+
+
+def test_capped_cache_shows_floor_count(tmp_path):
+    home = tmp_path / "home"
+    _write_cache(home, [_openpr(1379, 12), _openpr(1223, 9)], capped=True)
+    out = _run(home)
+    assert out.startswith("[Open PRs] ≥2 open PRs idle")  # ≥2, a floor
+
+
+def test_seen_map_namespaced_by_repo(tmp_path):
+    home = tmp_path / "home"
+    _write_cache(home, [_openpr(1379, 12)], repo="owner/therepo")
+    _run(home)
+    surfaced = json.loads(_seen_path(home).read_text())["surfaced"]
+    assert "owner/therepo#1379" in surfaced  # keyed by repo slug + number
+
+
+def test_seen_map_pruned_when_pr_no_longer_stalled(tmp_path):
+    home = tmp_path / "home"
+    # 1st run: stale → surfaced + recorded.
+    _write_cache(home, [_openpr(1379, 12)])
+    assert "#1379" in _run(home)
+    assert "o/r#1379" in json.loads(_seen_path(home).read_text())["surfaced"]
+    # 2nd run: same PR now recent (not stalled) → its entry is PRUNED, so a later
+    # re-stale is a fresh episode rather than a wrongly-aged-out suppression.
+    _write_cache(home, [_openpr(1379, 2)])  # 2d < 7d threshold
+    _run(home)
+    assert "o/r#1379" not in json.loads(_seen_path(home).read_text())["surfaced"]

--- a/tests/test_scripts/test_surface_open_prs.py
+++ b/tests/test_scripts/test_surface_open_prs.py
@@ -105,6 +105,32 @@ def test_stale_cache_not_surfaced(tmp_path):
     assert _run(home).strip() == ""
 
 
+def _write_local_overlay(home: Path, text: str) -> None:
+    cfg = home / ".genesis" / "config" / "repo_pulse.local.yaml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(text)
+
+
+def test_ttl_scales_with_large_debounce(tmp_path):
+    """When min_interval_minutes >= 1440 the worker can only refresh at most
+    daily, so a fixed 1-day TTL would suppress the surface for the whole debounce
+    window. The TTL derives from the debounce (2x), so a 30h-old cache under a
+    2-day debounce is STILL surfaced (old fixed-86400 TTL would suppress it)."""
+    home = tmp_path / "home"
+    _write_local_overlay(home, "min_interval_minutes: 2880\n")  # 2 days
+    _write_cache(home, [_openpr(1379, 12)], age_hours=30)  # >1 day, < 2*2day TTL
+    assert "#1379 (12d)" in _run(home)
+
+
+def test_ttl_default_debounce_still_caps_at_one_day(tmp_path):
+    """With the default 30-min debounce the 1-day floor still governs: a 48h-old
+    cache stays suppressed (the derived TTL never drops BELOW the 1-day floor)."""
+    home = tmp_path / "home"
+    _write_local_overlay(home, "min_interval_minutes: 30\n")
+    _write_cache(home, [_openpr(1379, 12)], age_hours=48)
+    assert _run(home).strip() == ""
+
+
 def test_no_stale_prs_silent(tmp_path):
     home = tmp_path / "home"
     _write_cache(home, [_openpr(1, 2), _openpr(2, 3)])  # all recent

--- a/tests/test_scripts/test_surface_open_prs.py
+++ b/tests/test_scripts/test_surface_open_prs.py
@@ -1,0 +1,126 @@
+"""E2E: the surface_open_prs SessionStart hook script.
+
+Drives the real script as a subprocess with a temp HOME (the open-PR cache +
+seen-map are Path.home()-anchored, matching the worker's _pulse_root). No
+network, no live services — the worker's fetch cache is synthesized on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "surface_open_prs.py"
+_SRC = Path(__file__).resolve().parents[2] / "src"
+
+
+def _openpr(number, days_idle, *, login="human", is_bot=False):
+    updated = (datetime.now(UTC) - timedelta(days=days_idle)).isoformat()
+    return {
+        "number": number,
+        "title": "t",
+        "url": f"https://x/pull/{number}",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "updatedAt": updated,
+        "author": {"login": login, "is_bot": is_bot},
+    }
+
+
+def _cache_path(home: Path) -> Path:
+    return home / ".genesis" / "repo_pulse" / "open_prs.json"
+
+
+def _seen_path(home: Path) -> Path:
+    return home / ".genesis" / "repo_pulse" / "open_prs_seen.json"
+
+
+def _write_cache(home: Path, prs, *, age_hours=0) -> None:
+    computed = (datetime.now(UTC) - timedelta(hours=age_hours)).isoformat()
+    cache = _cache_path(home)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps(
+            {"version": 1, "computed_at": computed, "repo": "o/r", "prs": prs, "limit_hit": False}
+        )
+    )
+
+
+def _run(home: Path, *, disabled=False, cc_session=False) -> str:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PYTHONPATH"] = str(_SRC)
+    env.pop("GENESIS_REPO_ROOT", None)
+    env.pop("GENESIS_HOME", None)
+    if disabled:
+        env["GENESIS_REPO_PULSE_DISABLED"] = "1"
+    else:
+        env.pop("GENESIS_REPO_PULSE_DISABLED", None)
+    if cc_session:
+        env["GENESIS_CC_SESSION"] = "1"
+    else:
+        env.pop("GENESIS_CC_SESSION", None)
+    proc = subprocess.run(
+        [sys.executable, str(_SCRIPT)], env=env, capture_output=True, text=True, timeout=60
+    )
+    return proc.stdout
+
+
+def test_surfaces_stale_open_prs(tmp_path):
+    home = tmp_path / "home"
+    _write_cache(home, [_openpr(1379, 12), _openpr(1223, 9), _openpr(1406, 2)])
+    out = _run(home)
+    assert "[Open PRs]" in out
+    assert "#1379 (12d)" in out and "#1223 (9d)" in out
+    assert "#1406" not in out  # 2d idle < 7d threshold
+    assert "ready to merge" not in out.lower()
+    assert _seen_path(home).exists()
+
+
+def test_bot_tag_in_clause(tmp_path):
+    home = tmp_path / "home"
+    _write_cache(home, [_openpr(1223, 10, login="dependabot[bot]", is_bot=True)])
+    out = _run(home)
+    assert "#1223 (10d, dependabot)" in out
+
+
+def test_stale_cache_not_surfaced(tmp_path):
+    home = tmp_path / "home"
+    _write_cache(home, [_openpr(1379, 12)], age_hours=48)  # snapshot >1 day old
+    assert _run(home).strip() == ""
+
+
+def test_no_stale_prs_silent(tmp_path):
+    home = tmp_path / "home"
+    _write_cache(home, [_openpr(1, 2), _openpr(2, 3)])  # all recent
+    assert _run(home).strip() == ""
+
+
+def test_missing_cache_fail_open(tmp_path):
+    assert _run(tmp_path / "home").strip() == ""  # no cache written
+
+
+def test_env_kill_switch_silences(tmp_path):
+    home = tmp_path / "home"
+    _write_cache(home, [_openpr(1379, 12)])
+    assert _run(home, disabled=True).strip() == ""
+
+
+def test_dispatched_session_silent_and_leaves_seen_untouched(tmp_path):
+    home = tmp_path / "home"
+    _write_cache(home, [_openpr(1379, 12)])
+    out = _run(home, cc_session=True)
+    assert out.strip() == ""
+    assert not _seen_path(home).exists()  # never touched
+
+
+def test_resurfaces_on_second_run(tmp_path):
+    home = tmp_path / "home"
+    _write_cache(home, [_openpr(1379, 12)])
+    first = _run(home)
+    second = _run(home)  # within resurface window
+    assert "[Open PRs]" in first and "[Open PRs]" in second

--- a/tests/test_session_awareness/test_pr_watch.py
+++ b/tests/test_session_awareness/test_pr_watch.py
@@ -205,3 +205,32 @@ def test_format_injection_singular_plural_and_overflow():
     with_overflow = pr_watch.format_injection(["a (Jul 1)", "+4 more"])
     assert "5 external-PR updates " in with_overflow
     assert "+4 more" in with_overflow
+
+
+# ── select_to_surface parameterization (open-PR lane reuse, not fork) ────────
+
+
+def test_select_to_surface_custom_id_getter_and_renderer():
+    """The open-PR lane reuses this surface/seen-map logic with its own id-getter
+    (pr number) and renderer — proving it is parameterized, not forked."""
+    items = [{"number": 1379, "stale_days": 12}, {"number": 1223, "stale_days": 9}]
+    lines, new = pr_watch.select_to_surface(
+        items,
+        {},
+        NOW,
+        10,
+        5,
+        id_getter=lambda p: str(p["number"]),
+        renderer=lambda p: f"#{p['number']} ({p['stale_days']}d)",
+    )
+    assert lines == ["#1379 (12d)", "#1223 (9d)"]
+    # seen-map keyed on the custom id
+    assert set(new.keys()) == {"1379", "1223"}
+
+
+def test_select_to_surface_defaults_unchanged():
+    """Omitting id_getter/renderer preserves the steward-notification behavior."""
+    notifs = [{"id": 7, "topic": "PR steward: merged", "delivered_at": NOW.isoformat()}]
+    lines, new = pr_watch.select_to_surface(notifs, {}, NOW, 10, 5)
+    assert set(new.keys()) == {"7"}
+    assert lines and lines[0].startswith("PR steward: merged")

--- a/tests/test_session_awareness/test_repo_pulse.py
+++ b/tests/test_session_awareness/test_repo_pulse.py
@@ -416,6 +416,16 @@ def test_open_pr_paths_are_home_anchored():
     assert rp.open_prs_cache_path().parent.name == "repo_pulse"
 
 
+def test_open_pr_paths_honor_genesis_home(monkeypatch, tmp_path):
+    """A relocated install (GENESIS_HOME set) must anchor the cache/seen sidecars
+    under it — matching genesis.env.genesis_home() and the worker's _pulse_root —
+    not a bare Path.home(), or writer (worker) and reader (hook) split apart."""
+    relocated = tmp_path / "relocated_home"
+    monkeypatch.setenv("GENESIS_HOME", str(relocated))
+    assert rp.open_prs_cache_path() == relocated / "repo_pulse" / "open_prs.json"
+    assert rp.open_prs_seen_path() == relocated / "repo_pulse" / "open_prs_seen.json"
+
+
 def test_format_open_pr_injection_capped_shows_floor():
     text = rp.format_open_pr_injection(["#1 (12d)", "#2 (9d)"], 7, capped=True)
     assert text.startswith("[Open PRs] ≥2 open PRs idle ≥7d — ")

--- a/tests/test_session_awareness/test_repo_pulse.py
+++ b/tests/test_session_awareness/test_repo_pulse.py
@@ -8,6 +8,7 @@ fuzzy prompt, and the fail-closed echo-numbers-only verdict parse.
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 
 from genesis.session_awareness import repo_pulse as rp
 
@@ -333,3 +334,83 @@ def test_followup_marker_must_be_line_anchored():
     # (the `\r` before `\n` is normalized away), else auto-absorb silently dies
     for body in (f"Follow-up: {FOLLOWUP}\r\n", f"done\r\nFollow-up: {FOLLOWUP}\r\nmore\r\n"):
         assert [m["via"] for m in rp.match_followup([_pr(body=body)], [_fu()])] == ["marker"], body
+
+
+# ── Open-PR lane (session-manager PR-4c): stalled-selection + formatting ─────
+
+NOW = datetime(2026, 8, 21, tzinfo=UTC)
+
+
+def _openpr(number, days_idle, *, is_bot=False, login="human", draft=False):
+    updated = (NOW - timedelta(days=days_idle)).isoformat()
+    return {
+        "number": number,
+        "title": f"pr {number}",
+        "url": f"https://x/pull/{number}",
+        "isDraft": draft,
+        "mergeable": "MERGEABLE",
+        "updatedAt": updated,
+        "author": {"login": login, "is_bot": is_bot},
+    }
+
+
+def test_select_stalled_filters_by_age_with_injected_now():
+    prs = [_openpr(1, 12), _openpr(2, 3), _openpr(3, 8)]
+    out = rp.select_stalled_open_prs(prs, now=NOW, stale_days=7)
+    # only #1 (12d) and #3 (8d) are stale; #2 (3d) excluded
+    assert [p["number"] for p in out] == [1, 3]  # stalest first
+    assert out[0]["stale_days"] == 12 and out[1]["stale_days"] == 8
+
+
+def test_select_stalled_skips_unparseable_updated_at():
+    prs = [{"number": 9, "updatedAt": "not-a-date", "author": {}}, _openpr(1, 10)]
+    out = rp.select_stalled_open_prs(prs, now=NOW, stale_days=7)
+    assert [p["number"] for p in out] == [1]
+
+
+def test_select_stalled_bot_detection():
+    prs = [
+        _openpr(1, 10, is_bot=True, login="dependabot[bot]"),
+        _openpr(2, 10, is_bot=False, login="app/dependabot"),  # suffix miss, flag off
+        _openpr(3, 10, is_bot=False, login="dependabot[bot]"),  # suffix catches
+    ]
+    out = {p["number"]: p for p in rp.select_stalled_open_prs(prs, now=NOW, stale_days=7)}
+    assert out[1]["is_bot"] is True
+    assert out[2]["is_bot"] is False
+    assert out[3]["is_bot"] is True
+
+
+def test_select_stalled_drops_malformed_rows():
+    prs = ["x", {"no_number": 1}, {"number": "5", "updatedAt": NOW.isoformat()}, _openpr(1, 10)]
+    out = rp.select_stalled_open_prs(prs, now=NOW, stale_days=7)
+    assert [p["number"] for p in out] == [1]
+
+
+def test_format_open_pr_clause_tags():
+    assert rp.format_open_pr_clause({"number": 7, "stale_days": 12}) == "#7 (12d)"
+    dep = {"number": 8, "stale_days": 12, "is_bot": True, "author_login": "dependabot[bot]"}
+    assert rp.format_open_pr_clause(dep) == "#8 (12d, dependabot)"
+    draft = {"number": 9, "stale_days": 4, "is_draft": True}
+    assert rp.format_open_pr_clause(draft) == "#9 (4d, draft)"
+    bot = {"number": 10, "stale_days": 5, "is_bot": True, "author_login": "some-bot[bot]"}
+    assert rp.format_open_pr_clause(bot) == "#10 (5d, bot)"
+
+
+def test_format_open_pr_injection_empty_and_shape():
+    assert rp.format_open_pr_injection([], 7) == ""
+    text = rp.format_open_pr_injection(["#1 (12d)", "#2 (9d, dependabot)"], 7)
+    assert text.startswith("[Open PRs] 2 open PRs idle ≥7d — ")
+    assert "#1 (12d)" in text and "ready to merge" not in text.lower()
+
+
+def test_format_open_pr_injection_counts_overflow_in_header():
+    text = rp.format_open_pr_injection(["#1 (12d)", "+4 more"], 7)
+    # true total = 1 shown + 4 overflow = 5
+    assert text.startswith("[Open PRs] 5 open PRs idle ≥7d — ")
+
+
+def test_open_pr_paths_are_home_anchored():
+    assert rp.open_prs_cache_path().name == "open_prs.json"
+    assert rp.open_prs_seen_path().name == "open_prs_seen.json"
+    assert rp.open_prs_cache_path().parent == rp.open_prs_seen_path().parent
+    assert rp.open_prs_cache_path().parent.name == "repo_pulse"

--- a/tests/test_session_awareness/test_repo_pulse.py
+++ b/tests/test_session_awareness/test_repo_pulse.py
@@ -414,3 +414,10 @@ def test_open_pr_paths_are_home_anchored():
     assert rp.open_prs_seen_path().name == "open_prs_seen.json"
     assert rp.open_prs_cache_path().parent == rp.open_prs_seen_path().parent
     assert rp.open_prs_cache_path().parent.name == "repo_pulse"
+
+
+def test_format_open_pr_injection_capped_shows_floor():
+    text = rp.format_open_pr_injection(["#1 (12d)", "#2 (9d)"], 7, capped=True)
+    assert text.startswith("[Open PRs] ≥2 open PRs idle ≥7d — ")
+    # uncapped stays an exact count
+    assert rp.format_open_pr_injection(["#1 (12d)"], 7).startswith("[Open PRs] 1 open PR idle")

--- a/tests/test_session_awareness/test_repo_pulse_config.py
+++ b/tests/test_session_awareness/test_repo_pulse_config.py
@@ -160,3 +160,29 @@ def test_base_config_file_is_valid_live():
     base = Path(__file__).parents[2] / "config" / "repo_pulse.yaml"
     cfg = yaml.safe_load(base.read_text())
     assert cfg == rpc.DEFAULTS
+
+
+# ── Open-PR lane knobs (session-manager PR-4c) ──────────────────────────────
+
+
+def test_open_pr_knob_defaults():
+    cfg = dict(rpc.DEFAULTS)
+    assert cfg["open_pr_enabled"] is True
+    assert rpc.knob_int(cfg, "open_pr_stale_days") == 7
+    assert rpc.knob_int(cfg, "max_open_prs") == 50
+    assert rpc.knob_int(cfg, "open_pr_resurface_days") == 7
+    assert rpc.knob_int(cfg, "open_pr_max_surface") == 5
+
+
+def test_validator_accepts_open_pr_knobs():
+    assert _validate_repo_pulse({"open_pr_enabled": True}) == []
+    assert _validate_repo_pulse({"open_pr_enabled": False}) == []
+    assert _validate_repo_pulse({"open_pr_stale_days": 3, "max_open_prs": 100}) == []
+    assert _validate_repo_pulse({"open_pr_resurface_days": 5, "open_pr_max_surface": 3}) == []
+
+
+def test_validator_rejects_bad_open_pr_knobs():
+    assert _validate_repo_pulse({"open_pr_enabled": "yes"})  # bool required
+    assert _validate_repo_pulse({"open_pr_stale_days": True})  # bool is not a valid int
+    assert _validate_repo_pulse({"max_open_prs": 0})  # must be positive
+    assert _validate_repo_pulse({"open_pr_max_surface": -1})

--- a/tests/test_session_awareness/test_repo_pulse_gh.py
+++ b/tests/test_session_awareness/test_repo_pulse_gh.py
@@ -147,6 +147,9 @@ async def test_list_open_prs_requests_open_state_and_fields():
     assert {p["number"] for p in out["prs"]} == {1, 2}
     pr_argv = run.calls[1]
     assert "--state" in pr_argv and pr_argv[pr_argv.index("--state") + 1] == "open"
+    # Stalest-first: a capped window must keep the aged PRs (the lane's target),
+    # never gh's default newest-first order that would drop them.
+    assert "--search" in pr_argv and pr_argv[pr_argv.index("--search") + 1] == "sort:updated-asc"
     joined = " ".join(pr_argv)
     assert "updatedAt" in joined and "author" in joined and "isDraft" in joined
     # age-based ONLY: never queries CI/review state

--- a/tests/test_session_awareness/test_repo_pulse_gh.py
+++ b/tests/test_session_awareness/test_repo_pulse_gh.py
@@ -117,3 +117,84 @@ async def test_malformed_pr_rows_dropped():
     # limit_hit reflects the RAW count — a capped window full of junk is
     # still a capped window
     assert out["limit_hit"] is False
+
+
+# ── list_open_prs (session-manager PR-4c open-PR lane) ──────────────────────
+
+
+def _open_pr(number, updated, **extra):
+    d = {
+        "number": number,
+        "title": "t",
+        "url": f"https://x/pull/{number}",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "updatedAt": updated,
+        "createdAt": updated,
+        "author": {"login": "human", "is_bot": False},
+    }
+    d.update(extra)
+    return d
+
+
+@pytest.mark.asyncio
+async def test_list_open_prs_requests_open_state_and_fields():
+    prs = [_open_pr(2, "2026-08-10T00:00:00Z"), _open_pr(1, "2026-08-01T00:00:00Z")]
+    run = _fake_runner({"repo": (0, "owner/real-repo\n", ""), "pr": (0, json.dumps(prs), "")})
+    out = await gh.list_open_prs(runner=run)
+    assert out["repo"] == "owner/real-repo"
+    assert out["limit_hit"] is False
+    assert {p["number"] for p in out["prs"]} == {1, 2}
+    pr_argv = run.calls[1]
+    assert "--state" in pr_argv and pr_argv[pr_argv.index("--state") + 1] == "open"
+    joined = " ".join(pr_argv)
+    assert "updatedAt" in joined and "author" in joined and "isDraft" in joined
+    # age-based ONLY: never queries CI/review state
+    assert "statusCheckRollup" not in joined and "reviewDecision" not in joined
+
+
+@pytest.mark.asyncio
+async def test_list_open_prs_explicit_repo_skips_resolve():
+    run = _fake_runner({"pr": (0, "[]", "")})
+    out = await gh.list_open_prs(repo="o/r", runner=run)
+    assert out == {"repo": "o/r", "prs": [], "limit_hit": False}
+    assert len(run.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_list_open_prs_failures_are_errors_not_raise():
+    for responses in (
+        {"pr": (1, "", "HTTP 502")},
+        {"pr": (0, "not json", "")},
+        {"pr": (0, '{"a": 1}', "")},
+    ):
+        run = _fake_runner(responses)
+        out = await gh.list_open_prs(repo="o/r", runner=run)
+        assert "error" in out
+
+
+@pytest.mark.asyncio
+async def test_list_open_prs_slug_resolve_failure_is_error():
+    run = _fake_runner({"repo": (1, "", "not a git repo")})
+    out = await gh.list_open_prs(runner=run)
+    assert out == {"error": "repo slug resolve failed"}
+
+
+@pytest.mark.asyncio
+async def test_list_open_prs_malformed_rows_dropped():
+    raw = [
+        _open_pr(1, "2026-08-01T00:00:00Z"),
+        {"number": "2", "updatedAt": "2026-08-02T00:00:00Z"},  # str number
+        "not a dict",
+    ]
+    run = _fake_runner({"pr": (0, json.dumps(raw), "")})
+    out = await gh.list_open_prs(repo="o/r", runner=run)
+    assert [p["number"] for p in out["prs"]] == [1]
+
+
+@pytest.mark.asyncio
+async def test_list_open_prs_limit_hit_is_loud():
+    prs = [_open_pr(i, "2026-08-01T00:00:00Z") for i in range(3)]
+    run = _fake_runner({"pr": (0, json.dumps(prs), "")})
+    out = await gh.list_open_prs(repo="o/r", limit=3, runner=run)
+    assert out["limit_hit"] is True

--- a/tests/test_session_awareness/test_repo_pulse_worker.py
+++ b/tests/test_session_awareness/test_repo_pulse_worker.py
@@ -49,6 +49,16 @@ def pulse_root(tmp_path, monkeypatch) -> Path:
     return root
 
 
+def test_pulse_root_honors_genesis_home(monkeypatch, tmp_path):
+    """The worker's state root must anchor on genesis_home() (honors GENESIS_HOME)
+    — the SAME resolver the reader hook uses — so a relocated install keeps the
+    lock/cursor + open-PR cache together instead of writing to a bare Path.home()
+    the hook would never read."""
+    relocated = tmp_path / "relocated_home"
+    monkeypatch.setenv("GENESIS_HOME", str(relocated))
+    assert rpw._pulse_root() == relocated / "repo_pulse"
+
+
 @pytest.fixture
 def live_mode(monkeypatch):
     monkeypatch.setattr(rpw, "effective_mode", lambda: "live")

--- a/tests/test_session_awareness/test_repo_pulse_worker.py
+++ b/tests/test_session_awareness/test_repo_pulse_worker.py
@@ -43,6 +43,9 @@ def pulse_root(tmp_path, monkeypatch) -> Path:
     root = tmp_path / "repo_pulse"
     monkeypatch.setattr(rpw, "_pulse_root", lambda: root)
     monkeypatch.setattr(rpw, "load_config", lambda: dict(DEFAULTS))
+    # The open-PR lane writes a HOME-anchored cache; redirect it into tmp so the
+    # lane (which now runs on every non-debounced worker run) never touches $HOME.
+    monkeypatch.setattr(rpw, "open_prs_cache_path", lambda: root / "open_prs.json")
     return root
 
 
@@ -82,6 +85,20 @@ def _gh(prs, *, limit_hit=False, error=None, repo="owner/repo"):
             "prs": sorted(prs, key=lambda p: p["mergedAt"]),
             "limit_hit": limit_hit,
         }
+
+    fake.calls = calls
+    return fake
+
+
+def _open_gh(prs, *, limit_hit=False, error=None, repo="owner/repo"):
+    """Fake list_open_prs — canned open-PR listing; records calls."""
+    calls: list[dict] = []
+
+    async def fake(**kwargs):
+        calls.append(kwargs)
+        if error is not None:
+            return {"error": error}
+        return {"repo": repo, "prs": list(prs), "limit_hit": limit_hit}
 
     fake.calls = calls
     return fake
@@ -152,8 +169,11 @@ def _write_cursor_file(root: Path, **data):
     (root / rpw.CURSOR_FILENAME).write_text(json.dumps(base))
 
 
-async def _run(db_path, monkeypatch, *, gh, headless=None, force=True, **kw):
+async def _run(db_path, monkeypatch, *, gh, headless=None, force=True, open_gh=None, **kw):
     monkeypatch.setattr(rpw, "list_merged_prs", gh)
+    # The open-PR lane runs on every non-debounced worker run — default it to an
+    # empty valid listing so unrelated tests never reach the real gh CLI.
+    monkeypatch.setattr(rpw, "list_open_prs", open_gh or _open_gh([]))
     monkeypatch.setattr(rpw, "run_headless_json", headless or _headless([]))
     return await rpw.run_pulse_worker(trigger="manual", force=force, db_path=db_path, **kw)
 
@@ -816,3 +836,55 @@ async def test_followup_absorb_and_annotation_are_atomic(
     anns = await _anns(db_path, target_kind="follow_up")
     assert len(anns) == 1
     assert anns[0]["status"] == "applied"
+
+
+# ── Open-PR lane (session-manager PR-4c) ────────────────────────────────────
+
+
+def _openpr(number=1379, updated="2026-08-01T00:00:00Z"):
+    return {
+        "number": number,
+        "title": "t",
+        "url": f"https://x/pull/{number}",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "updatedAt": updated,
+        "author": {"login": "human", "is_bot": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_open_pr_lane_writes_snapshot(pulse_root, db_path, monkeypatch, live_mode):
+    open_gh = _open_gh([_openpr(1379), _openpr(1223)])
+    await _run(db_path, monkeypatch, gh=_gh([_pr()]), open_gh=open_gh)
+    cache = pulse_root / "open_prs.json"
+    assert cache.exists()
+    data = json.loads(cache.read_text())
+    assert {p["number"] for p in data["prs"]} == {1379, 1223}
+    assert data["repo"] == "owner/repo"
+    assert data["computed_at"]  # stamped for the hook's freshness TTL
+    assert open_gh.calls  # the lane actually fetched
+
+
+@pytest.mark.asyncio
+async def test_open_pr_lane_disabled_writes_no_snapshot(
+    pulse_root, db_path, monkeypatch, live_mode
+):
+    monkeypatch.setattr(rpw, "load_config", lambda: dict(DEFAULTS, open_pr_enabled=False))
+    open_gh = _open_gh([_openpr()])
+    await _run(db_path, monkeypatch, gh=_gh([_pr()]), open_gh=open_gh)
+    assert not (pulse_root / "open_prs.json").exists()
+    assert not open_gh.calls  # lane skipped before any fetch
+
+
+@pytest.mark.asyncio
+async def test_open_pr_lane_failure_keeps_merged_lane_and_records(
+    pulse_root, db_path, monkeypatch, live_mode
+):
+    # A gh failure in the open-PR lane must NOT skip the merged lanes or _record_run.
+    open_gh = _open_gh([], error="HTTP 502")
+    await _run(db_path, monkeypatch, gh=_gh([_pr(body="no marker")]), open_gh=open_gh)
+    runs = await _runs(db_path)
+    assert runs, "merged lane must still record a run row despite the open-PR failure"
+    assert not (pulse_root / "open_prs.json").exists()  # no cache written on error
+    assert any("open_pr_lane" in (r.get("detail") or "") for r in runs)


### PR DESCRIPTION
## Age-stale open-PR SessionStart surface (session-manager PR-4c / Workstream B)

### Why
Nothing re-surfaced the *pile* of open PRs, so ready or rotting ones went unnoticed for weeks. This adds a passive, age-based visibility nudge.

### What
The repo-pulse worker now also caches the open-PR set each boundary; a new SessionStart hook reads it, computes staleness against a fresh clock, and prints **one** line:

```
[Open PRs] 3 open PRs idle ≥7d — #1379 (12d) · #1223 (12d, dependabot) · #1406 (8d, draft). Ask "show PRs" to review.
```

**Visibility only** — no CI/review state, never "ready to merge", no Telegram, no follow-up rows, no auto-merge. **Age-based by design**: no `reviewDecision`/status reducer (every owner PR sits at `REVIEW_REQUIRED` forever, so those carry no signal).

### Design
- **Worker = fetch-only; hook = all display + seen-map**, so the surface is always computed against the current clock, never a stale snapshot's.
- The lane runs in its **own try/except** right after the debounce gate and **before** the merged-PR enumeration's early-returns (open PRs go stale on wall-clock, not on merges), and **never touches the cursor**.
- Fail-open throughout; a home-anchored cache (`~/.genesis/repo_pulse/open_prs.json`) + a self-pruning seen-map; a 1-day freshness TTL skips a dead worker's snapshot.
- `pr_watch.select_to_surface` was **parameterized** (optional `id_getter`/`renderer`) and reused, not forked.

### Surface / injection safety
The printed line interpolates only the integer PR number, integer `stale_days`, and fixed tag literals (`draft`/`bot`/`dependabot`) — **no** untrusted GitHub string (title, url, raw login) reaches the session-injected line.

### Levers
`repo_pulse` settings domain: `open_pr_enabled` (bool), `open_pr_stale_days`, `max_open_prs`, `open_pr_resurface_days`, `open_pr_max_surface`. `GENESIS_REPO_PULSE_DISABLED` / `enabled: false` stop it.

### Review & tests
- `genesis-architect` (design — lane-placement BLOCKER + 5 fixes applied) and `genesis-security-reviewer` (clean — no CRITICAL/WARNING; injection surface, fail-open, path agreement, freshness TTL, back-compat, validation all confirmed).
- **136 tests** (pure selectors/fetcher via fake Runner, the worker lane, config/validator, the real hook driven as a subprocess) + a **live E2E** against the real repo (surfaced the true 14d-idle dependabot PR, excluded 11 recent).
