### PR TITLE
fix(hooks): run main-tree hook scripts from worktree sessions (close fleet drift)

### DIFF
--- a/.claude/hooks/genesis-hook
+++ b/.claude/hooks/genesis-hook
@@ -20,10 +20,21 @@ GENESIS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # `git worktree list | head`: head closes the pipe after one line, so with many
 # worktrees git gets SIGPIPE, and under `set -euo pipefail` that silently kills
 # this launcher (exit 141, no stderr), breaking every hook in the worktree.
-_common_dir="$(cd "$GENESIS_ROOT" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null)" || _common_dir=""
+# `env -u` scrubs ambient Git location overrides for THIS discovery: an exported
+# GIT_DIR / GIT_WORK_TREE / GIT_COMMON_DIR would otherwise resolve an UNRELATED repo
+# despite the `cd`, redirecting every hook (security gates included) to a foreign
+# checkout's same-named script.
+_common_dir="$(cd "$GENESIS_ROOT" 2>/dev/null && env -u GIT_DIR -u GIT_WORK_TREE -u GIT_COMMON_DIR git rev-parse --git-common-dir 2>/dev/null)" || _common_dir=""
 MAIN_ROOT=""
 if [[ -n "$_common_dir" ]]; then
     MAIN_ROOT="$(cd "$GENESIS_ROOT" 2>/dev/null && cd "$(dirname "$_common_dir")" 2>/dev/null && pwd)" || MAIN_ROOT=""
+fi
+# Trust MAIN_ROOT only if it actually looks like a Genesis checkout. A
+# `--separate-git-dir` clone makes `--git-common-dir` point at external metadata
+# whose parent is NOT the worktree root, which would send hooks to a bogus path;
+# require a `scripts/` dir there, else fall back to GENESIS_ROOT (the non-worktree path).
+if [[ -n "$MAIN_ROOT" && ! -d "$MAIN_ROOT/scripts" ]]; then
+    MAIN_ROOT=""
 fi
 
 # Resolve the hook SCRIPT ROOT: the MAIN worktree by default, so every session

--- a/.claude/hooks/genesis-hook
+++ b/.claude/hooks/genesis-hook
@@ -14,31 +14,53 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GENESIS_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# Find the Python venv. In a worktree, .venv lives in the main repo, not here.
-PYTHON="$GENESIS_ROOT/.venv/bin/python"
-if [[ ! -x "$PYTHON" ]]; then
-    # Worktree: .venv lives in the MAIN repo. Resolve the main worktree root via
-    # `git rev-parse --git-common-dir` (the main repo's .git; its parent is the
-    # main worktree root). Do NOT use `git worktree list | head` here: head closes
-    # the pipe after one line, so with many worktrees git gets SIGPIPE, and under
-    # `set -euo pipefail` that silently kills this launcher (exit 141, no stderr),
-    # breaking every hook in the worktree.
-    _common_dir="$(cd "$GENESIS_ROOT" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null)" || _common_dir=""
-    MAIN_ROOT=""
-    if [[ -n "$_common_dir" ]]; then
-        MAIN_ROOT="$(cd "$GENESIS_ROOT" 2>/dev/null && cd "$(dirname "$_common_dir")" 2>/dev/null && pwd)" || MAIN_ROOT=""
+# Resolve the MAIN worktree root ONCE — used for BOTH the venv fallback and the
+# hook-script path. In a worktree, `git rev-parse --git-common-dir` gives the
+# main repo's .git; its parent is the main worktree root. Do NOT use
+# `git worktree list | head`: head closes the pipe after one line, so with many
+# worktrees git gets SIGPIPE, and under `set -euo pipefail` that silently kills
+# this launcher (exit 141, no stderr), breaking every hook in the worktree.
+_common_dir="$(cd "$GENESIS_ROOT" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null)" || _common_dir=""
+MAIN_ROOT=""
+if [[ -n "$_common_dir" ]]; then
+    MAIN_ROOT="$(cd "$GENESIS_ROOT" 2>/dev/null && cd "$(dirname "$_common_dir")" 2>/dev/null && pwd)" || MAIN_ROOT=""
+fi
+
+# Resolve the hook SCRIPT ROOT: the MAIN worktree by default, so every session
+# runs the CURRENT hook + policy. Git-tracked hooks otherwise DRIFT per branch —
+# a worktree session runs whatever hook version its branch froze until it rebases,
+# so a worktree can enforce an OUTDATED security gate (measured 2026-08: 60 of 70
+# worktrees ran a stale, warn-only full_suite_guard). Escape hatch:
+# GENESIS_HOOK_DEV_LOCAL=1 runs the worktree's OWN copy — for deliberately testing
+# a hook change live in-worktree; it is ANNOUNCED on stderr so it is never a
+# silent downgrade of the whole session's gates. Fallback to GENESIS_ROOT when
+# MAIN_ROOT is unresolvable (a non-worktree install, or not a git repo).
+HOOK_ROOT="$GENESIS_ROOT"
+if [[ -n "$MAIN_ROOT" && "${GENESIS_HOOK_DEV_LOCAL:-}" != "1" ]]; then
+    HOOK_ROOT="$MAIN_ROOT"
+elif [[ -n "$MAIN_ROOT" && "${GENESIS_HOOK_DEV_LOCAL:-}" == "1" ]]; then
+    echo "genesis-hook: GENESIS_HOOK_DEV_LOCAL=1 — running the WORKTREE-local hook copy (not main-tree)" >&2
+fi
+
+# Find the Python venv, co-located with the hook tree (HOOK_ROOT) so the script
+# and its interpreter/site-packages come from the SAME tree. A worktree rarely
+# has its own .venv (worktrees never pip-install), so fall back to the other
+# known roots rather than fail.
+PYTHON=""
+for _root in "$HOOK_ROOT" "$MAIN_ROOT" "$GENESIS_ROOT"; do
+    if [[ -n "$_root" && -x "$_root/.venv/bin/python" ]]; then
+        PYTHON="$_root/.venv/bin/python"
+        break
     fi
-    if [[ -n "$MAIN_ROOT" && -x "$MAIN_ROOT/.venv/bin/python" ]]; then
-        PYTHON="$MAIN_ROOT/.venv/bin/python"
-    else
-        echo "ERROR: Genesis venv not found at $GENESIS_ROOT/.venv/bin/python" >&2
-        echo "Run: cd $GENESIS_ROOT && python -m venv .venv && pip install -e ." >&2
-        exit 1
-    fi
+done
+if [[ -z "$PYTHON" ]]; then
+    echo "ERROR: Genesis venv not found (looked in HOOK_ROOT/MAIN_ROOT/GENESIS_ROOT/.venv/bin/python)" >&2
+    echo "Run: cd $GENESIS_ROOT && python -m venv .venv && pip install -e ." >&2
+    exit 1
 fi
 
 SCRIPT_NAME="${1:?Usage: genesis-hook <script_name.py> [args...]}"
-SCRIPT_PATH="$GENESIS_ROOT/scripts/$SCRIPT_NAME"
+SCRIPT_PATH="$HOOK_ROOT/scripts/$SCRIPT_NAME"
 
 if [[ ! -f "$SCRIPT_PATH" ]]; then
     echo "ERROR: Hook script not found: $SCRIPT_PATH" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Worktree sessions now run the main-tree hook scripts, not their branch-frozen
+  copies.** The `genesis-hook` launcher resolved each hook from the *current*
+  worktree, so a git-tracked hook (security gates included) ran whatever version
+  its branch had frozen — a worktree could silently enforce an outdated/weaker
+  gate until it rebased (measured: 60 of 70 worktrees ran a stale, warn-only
+  `full_suite_guard`). The launcher now resolves the hook script from the main
+  worktree (reusing the `git rev-parse --git-common-dir` plumbing already used for
+  the venv), so every session runs the current hook + policy. Escape hatch:
+  `GENESIS_HOOK_DEV_LOCAL=1` runs the worktree's own copy for testing a hook change
+  live. Forward-looking: a worktree benefits once it carries the fixed launcher
+  (new or rebased); pre-fix branches keep running their frozen launcher until they
+  rebase, and the stale count decays as the reaper reaps and branches rebase.
+
 - **The merge gate no longer blocks on a review finding that lands on a
   documentation file.** An inline `[P1]` finding anchored to a doc path
   (`CHANGELOG`, `README`, `LICENSE`/`NOTICE`, `docs/**`, `*.rst`) is now surfaced

--- a/tests/test_scripts/test_genesis_hook_wrapper.py
+++ b/tests/test_scripts/test_genesis_hook_wrapper.py
@@ -135,3 +135,60 @@ def test_script_path_resolves_from_main_root_in_code():
     assert "HOOK_ROOT" in code
     assert 'SCRIPT_PATH="$HOOK_ROOT/scripts/$SCRIPT_NAME"' in code
     assert "GENESIS_HOOK_DEV_LOCAL" in code
+
+
+def test_ambient_git_dir_env_ignored_for_hook_discovery(tmp_path):
+    """An exported GIT_DIR must NOT redirect hook resolution to a foreign repo —
+    otherwise an ambient Git env could point every hook (security gates included)
+    at a foreign checkout's same-named script. The launcher scrubs GIT_* for the
+    git-common-dir discovery."""
+    main, wt = _make_main_and_worktree(tmp_path)
+    foreign = tmp_path / "foreign"
+    (foreign / ".claude" / "hooks").mkdir(parents=True)
+    (foreign / "scripts").mkdir()
+    shutil.copy(_WRAPPER, foreign / ".claude" / "hooks" / "genesis-hook")
+    (foreign / "scripts" / "probe.py").write_text("print('FOREIGN')\n")
+    genv = {
+        **os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    subprocess.run(["git", "init", "-q"], cwd=foreign, check=True, env=genv)
+    env = {k: v for k, v in os.environ.items() if k != "GENESIS_HOOK_DEV_LOCAL"}
+    env["GIT_DIR"] = str(foreign / ".git")  # ambient override pointing at the foreign repo
+    proc = subprocess.run(
+        [str(wt / ".claude" / "hooks" / "genesis-hook"), "probe.py"],
+        stdin=subprocess.DEVNULL, capture_output=True, text=True, env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "MAIN", f"ambient GIT_DIR leaked into discovery: {proc.stdout!r}"
+
+
+def test_separate_git_dir_falls_back_to_own_scripts(tmp_path):
+    """A `git init --separate-git-dir` checkout makes `--git-common-dir` return
+    external metadata whose parent has no `scripts/`; the launcher must REJECT that
+    MAIN_ROOT and fall back to running its OWN copy, not resolve a bogus path."""
+    workdir = tmp_path / "work"
+    (workdir / ".claude" / "hooks").mkdir(parents=True)
+    (workdir / "scripts").mkdir()
+    shutil.copy(_WRAPPER, workdir / ".claude" / "hooks" / "genesis-hook")
+    (workdir / ".claude" / "hooks" / "genesis-hook").chmod(0o755)
+    (workdir / "scripts" / "probe.py").write_text("print('OWN')\n")
+    vb = workdir / ".venv" / "bin"
+    vb.mkdir(parents=True)
+    (vb / "python").symlink_to(sys.executable)
+    sepgit = tmp_path / "sepmeta" / "gitdir"
+    sepgit.parent.mkdir(parents=True)  # git init --separate-git-dir requires the parent to exist
+    genv = {
+        **os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    subprocess.run(
+        ["git", "init", "-q", f"--separate-git-dir={sepgit}", str(workdir)], check=True, env=genv
+    )
+    env = {k: v for k, v in os.environ.items() if k != "GENESIS_HOOK_DEV_LOCAL"}
+    proc = subprocess.run(
+        [str(workdir / ".claude" / "hooks" / "genesis-hook"), "probe.py"],
+        stdin=subprocess.DEVNULL, capture_output=True, text=True, env=env,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "OWN", f"resolved a bogus MAIN_ROOT: {proc.stdout!r}"

--- a/tests/test_scripts/test_genesis_hook_wrapper.py
+++ b/tests/test_scripts/test_genesis_hook_wrapper.py
@@ -9,7 +9,9 @@ hook in that worktree. Fixed by resolving the main worktree via
 """
 
 import os
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 _WRAPPER = Path(__file__).resolve().parents[2] / ".claude" / "hooks" / "genesis-hook"
@@ -55,3 +57,81 @@ def test_wrapper_never_sigpipes_on_invocation():
             env=env,
         )
         assert proc.returncode != 141, f"SIGPIPE (141)! stderr={proc.stderr!r}"
+
+
+# ── main-tree hook resolution (fleet-drift fix, 2026-08) ─────────────────────
+
+
+def _make_main_and_worktree(tmp_path):
+    """A fake main repo + a linked worktree, each with a DIFFERENT scripts/probe.py."""
+    main = tmp_path / "main"
+    (main / ".claude" / "hooks").mkdir(parents=True)
+    (main / "scripts").mkdir()
+    shutil.copy(_WRAPPER, main / ".claude" / "hooks" / "genesis-hook")
+    (main / ".claude" / "hooks" / "genesis-hook").chmod(0o755)
+    (main / "scripts" / "probe.py").write_text("print('MAIN')\n")
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=main, check=True, env=env)
+    subprocess.run(["git", "add", "-A"], cwd=main, check=True, env=env)
+    subprocess.run(["git", "commit", "-qm", "init"], cwd=main, check=True, env=env)
+    wt = tmp_path / "wt"
+    subprocess.run(["git", "worktree", "add", "-q", str(wt)], cwd=main, check=True, env=env)
+    # Divergent (uncommitted) worktree probe — simulates a branch-frozen hook copy.
+    (wt / "scripts" / "probe.py").write_text("print('WORKTREE')\n")
+    # venv lives in MAIN only (worktrees never pip-install); created AFTER the
+    # worktree checkout so it stays untracked and absent from the worktree.
+    venv_bin = main / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "python").symlink_to(sys.executable)
+    return main, wt
+
+
+def _invoke(root, *, dev_local=False):
+    env = {k: v for k, v in os.environ.items() if k != "GENESIS_HOOK_DEV_LOCAL"}
+    if dev_local:
+        env["GENESIS_HOOK_DEV_LOCAL"] = "1"
+    return subprocess.run(
+        [str(root / ".claude" / "hooks" / "genesis-hook"), "probe.py"],
+        stdin=subprocess.DEVNULL, capture_output=True, text=True, env=env,
+    )
+
+
+def test_worktree_session_runs_MAIN_tree_hook(tmp_path):
+    """A worktree session must run the MAIN-tree hook copy, not its branch-frozen
+    one — otherwise a stale/weaker security gate stays live until the branch rebases."""
+    _main, wt = _make_main_and_worktree(tmp_path)
+    proc = _invoke(wt)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "MAIN", f"ran the worktree copy: {proc.stdout!r}"
+
+
+def test_dev_local_override_runs_worktree_hook(tmp_path):
+    """GENESIS_HOOK_DEV_LOCAL=1 runs the worktree's OWN copy (for testing a hook
+    change live in-worktree)."""
+    _main, wt = _make_main_and_worktree(tmp_path)
+    proc = _invoke(wt, dev_local=True)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "WORKTREE"
+    # The override is ANNOUNCED (never a silent downgrade of the session's gates).
+    assert "GENESIS_HOOK_DEV_LOCAL" in proc.stderr
+
+
+def test_main_tree_install_runs_its_own_hook(tmp_path):
+    """A normal (non-worktree) install: MAIN_ROOT resolves to its own root."""
+    main, _wt = _make_main_and_worktree(tmp_path)
+    proc = _invoke(main)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "MAIN"
+
+
+def test_script_path_resolves_from_main_root_in_code():
+    """Code-level lock: the hook script path is built from HOOK_ROOT (main-tree),
+    with the dev-local escape hatch."""
+    code = _code_only()
+    assert "HOOK_ROOT" in code
+    assert 'SCRIPT_PATH="$HOOK_ROOT/scripts/$SCRIPT_NAME"' in code
+    assert "GENESIS_HOOK_DEV_LOCAL" in code


### PR DESCRIPTION
## Run main-tree hook scripts from worktree sessions (close hook fleet drift)

### The bug
`.claude/hooks/genesis-hook` — the bash launcher every Genesis hook runs through — resolved each hook from the **current** worktree (`SCRIPT_PATH="$GENESIS_ROOT/scripts/…"`). So a worktree session ran that branch's **frozen** copy of every git-tracked hook — security gates included — until the branch rebased. A worktree could therefore enforce an **outdated/weaker** gate.

**Measured:** across the 70 worktrees carrying `full_suite_guard.py`, only main + 10 run the current (blocking) version; **60 run older variants**, the dominant one warn-only (prints, `exit 0`, cannot block).

### The fix
Resolve the hook script from the **main worktree**, reusing the `git rev-parse --git-common-dir` plumbing already used for the venv (hoisted to unconditional). `PYTHON` is now co-located with the hook tree (`HOOK_ROOT → MAIN_ROOT → GENESIS_ROOT`) so the script and its interpreter come from the **same** tree.

- **Default:** hooks run from main — every session on the current hook + policy.
- **Escape hatch:** `GENESIS_HOOK_DEV_LOCAL=1` runs the worktree's own copy for testing a hook change live — **announced on stderr**, never a silent downgrade.
- **Fallback:** `GENESIS_ROOT` when `MAIN_ROOT` is unresolvable (non-worktree install / not a git repo).

### Scope (honest)
Forward-looking: a worktree benefits once it **carries** the fixed launcher (new or rebased). A worktree on a pre-fix branch still runs its frozen launcher until it rebases; the stale count decays as the reaper reaps and branches rebase. Not a retroactive fix for stuck branches.

### Safety
`set -euo pipefail` preserved (no new pipe → no SIGPIPE regression; all vars quoted; guarded rev-parse). Reviewed by `genesis-security-reviewer` — no CRITICAL; 3 WARNINGs resolved (rebase past #1455; announce the dev-local override; co-locate PYTHON with HOOK_ROOT).

### Tests
`tests/test_scripts/test_genesis_hook_wrapper.py` — verify-RED proven (the old launcher runs the worktree copy): worktree→MAIN, dev-local→WORKTREE + stderr announcement, main-install→own, plus a code-level lock and the 3 pre-existing SIGPIPE regressions. 7/7 pass.
