### PR TITLE
fix(hooks): skip $()/backtick redirect artifacts before the git subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A `$()`/backtick redirect target before a git subcommand no longer slips the
+  push/commit approval gates.** After the redirect-parsing fix, a substitution
+  redirect target (e.g. `git 2>$(cmd) push --force`, `git 2>\`cmd\` commit
+  --no-verify`) is deliberately left in the argv so the nested command stays
+  visible to the destructive-command guard — but it word-split into positional
+  tokens that `shell_parse.git_subcommand` mis-read as the subcommand (`'$(rm'`
+  instead of `push`), so `git_push_guard`'s push/commit gates skipped that segment.
+  `git_subcommand`/`commit_skips_hooks` now skip a `$()`/backtick/`$VAR` artifact
+  (paren- and backtick-balanced across word-split tokens) before reading the
+  subcommand. Bounded, per git_push_guard's threat model: an exotic body (a paren
+  or backtick nested inside a quote within the substitution) is a documented
+  residual — approval-gate friction, not a sandbox.
+
 - **The merge gate no longer blocks on a review finding that lands on a
   documentation file.** An inline `[P1]` finding anchored to a doc path
   (`CHANGELOG`, `README`, `LICENSE`/`NOTICE`, `docs/**`, `*.rst`) is now surfaced

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -578,9 +578,47 @@ def _nested_script(argv: list[str]) -> str:
 # ── git-specific helpers ────────────────────────────────────────────────
 
 
-def git_subcommand(argv: list[str]) -> str | None:
-    """The git subcommand for an argv whose executable is git, skipping git
-    global options (including ``-c KEY=VAL`` / ``-C DIR`` which take a value)."""
+def _skip_redirect_substitution(argv: list[str], start: int) -> int:
+    """Advance past a command-substitution / var artifact in *argv* beginning at
+    ``argv[start]`` — a ``$()``/backtick/``$VAR`` REDIRECT TARGET that
+    ``split_segments`` deliberately left in the segment text (so ``_substitutions``
+    still sees the nested command for the destructive-command guard) and that
+    word-splitting then scattered across tokens. Returns the index of the first
+    token AFTER the artifact.
+
+    Bounded: balances a ``$( … )`` body by paren depth and matches a ``` `…` ```
+    pair, both across word-split tokens; a bare ``$VAR`` skips alone. An exotic
+    body (a paren/backtick nested inside a quote WITHIN the substitution) is a
+    documented residual — this is an approval-gate friction layer, not a sandbox.
+    """
+    t = argv[start]
+    i = start + 1
+    if "$(" in t:  # $( … ) — balance parens across tokens
+        depth = t.count("(") - t.count(")")
+        while i < len(argv) and depth > 0:
+            depth += argv[i].count("(") - argv[i].count(")")
+            i += 1
+        return i
+    if "`" in t and t.count("`") % 2 == 1:  # `…` opener left unclosed in this token
+        while i < len(argv) and argv[i].count("`") % 2 == 0:
+            i += 1
+        if i < len(argv):
+            i += 1  # the token that closes the backtick pair
+        return i
+    return i  # a bare $VAR (or a self-closed `x`/$(x)) — skip the single token
+
+
+def _subcommand_index(argv: list[str]) -> int | None:
+    """Index of the git subcommand token in *argv* (``argv[0] == 'git'``), or None.
+
+    Skips git global options (+ their values, e.g. ``-C DIR`` / ``-c KEY=VAL``)
+    AND a command-substitution / var artifact left in argv by a ``$()``/backtick
+    redirect target — the latter must NOT be read as the subcommand, or a segment
+    like ``git 2>$(x) push --force`` resolves to ``$(x`` and slips the push/commit
+    approval gates (git_push_guard gates on ``git_subcommand(argv) == 'push'`` /
+    ``'commit'``). The nested command itself stays visible to the destructive-command
+    guard via ``_substitutions`` — this closes only the subcommand-misread.
+    """
     if not argv or _basename(argv[0]) != "git":
         return None
     i = 1
@@ -592,8 +630,19 @@ def git_subcommand(argv: list[str]) -> str | None:
         if t.startswith("-"):
             i += 1
             continue
-        return t
+        if t.startswith("$") or "$(" in t or "`" in t:
+            i = _skip_redirect_substitution(argv, i)
+            continue
+        return i
     return None
+
+
+def git_subcommand(argv: list[str]) -> str | None:
+    """The git subcommand for an argv whose executable is git, skipping git global
+    options (``-c KEY=VAL`` / ``-C DIR``) and ``$()``/backtick redirect-target
+    artifacts (see ``_subcommand_index``)."""
+    idx = _subcommand_index(argv)
+    return argv[idx] if idx is not None else None
 
 
 def gh_pr_subcommand(argv: list[str]) -> str | None:
@@ -634,20 +683,11 @@ def commit_skips_hooks(argv: list[str]) -> bool:
     Parses real argv tokens, so a quoted ``'--no-verify'`` counts and an
     attached message ``-minitial`` does NOT (that is ``-m initial``).
     """
-    if git_subcommand(argv) != "commit":
+    idx = _subcommand_index(argv)
+    if idx is None or argv[idx] != "commit":
         return False
-    # Advance past git global options (+ their values) to the "commit" token.
-    i = 1
-    while i < len(argv):
-        t = argv[i]
-        if t in _GIT_OPTS_WITH_ARG:
-            i += 2
-            continue
-        if t.startswith("-"):
-            i += 1
-            continue
-        break  # argv[i] == "commit"
-    i += 1  # move past "commit"
+    # idx already skipped git global options + any $()/backtick redirect artifact.
+    i = idx + 1  # move past "commit"
     while i < len(argv):
         tok = argv[i]
         if tok == "--":

--- a/tests/test_hooks/test_shell_parse.py
+++ b/tests/test_hooks/test_shell_parse.py
@@ -422,3 +422,48 @@ class TestRedirects:
         # command to hide); documents the accepted argv-residual, not a regression.
         segs = sp.analyze("echo hi 2>$LOGDIR/out")
         assert not any(s.exe in ("rm", "rmdir") for s in segs)
+
+
+class TestGitSubcommandSubstitutionSkip:
+    """A $()/backtick/$VAR redirect target BEFORE the git subcommand must not be
+    read as the subcommand — else git_push_guard's push/commit approval gates
+    (which key on git_subcommand(argv)) silently skip that segment. The nested
+    command stays visible to the destructive-command guard via _substitutions;
+    this closes only the subcommand-misread. (Residual from #1455's review.)"""
+
+    def _sub(self, cmd):
+        seg = next(s for s in sp.analyze(cmd) if s.exe == "git")
+        return sp.git_subcommand(seg.argv)
+
+    def _ci(self, cmd):
+        return any(sp.commit_skips_hooks(s.argv) for s in sp.analyze(cmd) if s.exe == "git")
+
+    def test_dollar_paren_before_push(self):
+        assert self._sub("git 2>$(rm x) push origin main --force") == "push"
+
+    def test_backtick_before_commit_no_verify(self):
+        assert self._ci("git 2>`x` commit --no-verify") is True
+
+    def test_multiword_substitution_before_commit(self):
+        assert self._sub("git 2>$(rm x y z) commit -n") == "commit"
+        assert self._ci("git 2>$(rm x y z) commit -n") is True
+
+    def test_bare_var_before_subcommand(self):
+        assert self._sub("git 2>$VAR status") == "status"
+
+    def test_substitution_only_no_subcommand(self):
+        seg = next(s for s in sp.analyze("git 2>$(rm x)") if s.exe == "git")
+        assert sp.git_subcommand(seg.argv) is None
+
+    def test_plain_commands_unregressed(self):
+        assert self._sub("git push") == "push"
+        assert self._sub("git commit --no-verify") == "commit"
+        assert self._ci("git commit --no-verify") is True
+        assert self._ci("git commit -m 'no verify here'") is False
+        assert self._sub("git -C /tmp -c a=b status") == "status"
+
+    def test_direct_argv_word_split_artifact(self):
+        # The $() body word-splits across argv tokens — both must be skipped.
+        assert sp.git_subcommand(["git", "$(rm", "x)", "push"]) == "push"
+        assert sp.git_subcommand(["git", "`rm", "x`", "commit"]) == "commit"
+        assert sp.commit_skips_hooks(["git", "$(rm", "x)", "commit", "--no-verify"]) is True


### PR DESCRIPTION
## Skip `$()`/backtick redirect artifacts before the git subcommand

Closes the residual flagged in #1455's review.

### The gap
`split_segments` deliberately leaves a `$()`/backtick redirect target in the segment text (so `_substitutions` still sees the nested command for the destructive-command guard). But that target **word-splits** into positional argv tokens, and `shell_parse.git_subcommand` returned the **first** such token as the subcommand:

```
git 2>$(rm x) push --force   → argv ['git','$(rm','x)','push',…] → git_subcommand = '$(rm'  (should be 'push')
git 2>`x` commit --no-verify → commit_skips_hooks = False                                  (should be True)
```

So `git_push_guard`'s push/commit approval gates — which key on `git_subcommand(argv) == 'push'`/`'commit'` — **skipped that segment**.

### The fix
A shared `_subcommand_index(argv)` (used by both `git_subcommand` and `commit_skips_hooks`) skips git global options **and** a `$()`/backtick/`$VAR` artifact before reading the subcommand. `_skip_redirect_substitution` balances a `$( … )` body by paren depth and matches a `` `…` `` pair, **both across word-split tokens**. The nested command stays visible to the destructive-command guard via `_substitutions` (untouched) — this closes only the subcommand-misread.

Bounded per `git_push_guard`'s threat model: an exotic body (a paren/backtick nested inside a quote *within* the substitution) is a documented residual — an approval-gate friction layer, not a sandbox.

### Safety
`genesis-security-reviewer`: **no CRITICAL/HIGH**. Proved structurally + via a **200,000-sample fuzz + ~130 adversarial cases** that the fix introduces **no new gate-miss** (the artifact-check can never fire on a real `push`/`commit` token, so any previously-correct resolution is unchanged); unbalanced `$(` fails safe (→ `None`, never an exception); the change is confined to subcommand-index resolution (`split_segments`/`_substitutions`/`_redirect_operator_len` untouched). One pre-existing, out-of-scope `split_segments` residual (a shell operator inside an unclosed substitution) is tracked as a follow-up.

### Tests
`tests/test_hooks/test_shell_parse.py::TestGitSubcommandSubstitutionSkip` — verify-RED confirmed. **430 tests** pass across `shell_parse` + all gate consumers (git_push_guard_repo, protected_paths, merge_review_gate).
