### PR TITLE
feat(cc): interactive slots survive a dead login via the setup-token

### DIFF
--- a/docs/architecture/shared-artifacts.md
+++ b/docs/architecture/shared-artifacts.md
@@ -29,9 +29,12 @@ enrolled artifacts by their consumer set — it is not a general prose↔code ch
 ### `cc_oauth_token.env` — fallback CC OAuth setup-token
 
 A `claude setup-token` credential (`~/.genesis/cc_oauth_token.env`, synced to the
-host shared mount) injected as `CLAUDE_CODE_OAUTH_TOKEN` **only** when a primary
-`claude login` is confirmed dead. Written by `scripts/store_cc_token.sh`; accessed
-directly by filename *and* transitively via `credential_bridge.load_cc_oauth_token()`.
+host shared mount) injected as `CLAUDE_CODE_OAUTH_TOKEN` when a primary
+`claude login` is confirmed dead — with ONE documented exception: the
+interactive-slot `GENESIS_CC_SLOT_OAUTH=always` lever (see `cc-slot.sh` below)
+deliberately injects over a live login too. Written by `scripts/store_cc_token.sh`;
+accessed directly by filename *and* transitively via
+`credential_bridge.load_cc_oauth_token()` / `login_health.read_fallback_token()`.
 
 ```yaml shared-artifact
 artifact: cc_oauth_token.env
@@ -39,6 +42,7 @@ documented_in: scripts/store_cc_token.sh
 match_literals: [cc_oauth_token.env, load_cc_oauth_token]
 readers:
   - src/genesis/cc/login_health.py
+  - src/genesis/cc/login_gate.py
   - src/genesis/guardian/diagnosis.py
   - src/genesis/onboarding/floor.py
   - scripts/guardian-gateway.sh
@@ -49,14 +53,20 @@ allowlist:
 
 - `cc/login_health.py` — injects it into the container's own CC sessions
   (foreground + background) when the container login is hard-expired.
+- `cc/login_gate.py` — the interactive-slot decision gate: reads the token (via
+  `read_fallback_token`) to decide whether a slot should inject it, applying the
+  invoker's fallback exclusions (fail-closed lever, competing-auth, stale-token).
 - `guardian/diagnosis.py` — injects it into the host Guardian recovery brain when
   the host's own login is dead (transitive, via the loader).
 - `onboarding/floor.py` — reads it as an auth-present signal at bootstrap.
 - `scripts/guardian-gateway.sh` — references the synced host copy.
-- `scripts/cc-slot.sh` — on interactive slot CREATE, when the primary login is
-  dead (decision via `genesis.cc.login_gate`, which reuses `login_health`),
-  extracts the token INSIDE the pane shell and exports `CLAUDE_CODE_OAUTH_TOKEN`
-  so the session survives without a re-login prompt (login-dead-conditional;
-  lever `GENESIS_CC_SLOT_OAUTH`).
+- `scripts/cc-slot.sh` — on interactive slot CREATE, decides via
+  `genesis.cc.login_gate` (a faithful mirror of the invoker's fallback contract:
+  fail-closed lever, competing-auth/peer-route exclusion, stale-token exclusion),
+  then extracts the token INSIDE the pane shell with the same parser
+  (`login_health.read_fallback_token`) and exports `CLAUDE_CODE_OAUTH_TOKEN` so
+  the session survives without a re-login prompt. Default `conditional` (inject
+  only when the login is dead); `always` overrides a live login (loses Remote
+  Control / connectors); `off` disables. Lever `GENESIS_CC_SLOT_OAUTH`.
 - `guardian/credential_bridge.py` (allowlist) — the loader/propagator home
   (`load_cc_oauth_token`, `_CC_TOKEN_SOURCE`), not a business consumer.

--- a/docs/architecture/shared-artifacts.md
+++ b/docs/architecture/shared-artifacts.md
@@ -42,6 +42,7 @@ readers:
   - src/genesis/guardian/diagnosis.py
   - src/genesis/onboarding/floor.py
   - scripts/guardian-gateway.sh
+  - scripts/cc-slot.sh
 allowlist:
   - src/genesis/guardian/credential_bridge.py
 ```
@@ -52,5 +53,10 @@ allowlist:
   the host's own login is dead (transitive, via the loader).
 - `onboarding/floor.py` — reads it as an auth-present signal at bootstrap.
 - `scripts/guardian-gateway.sh` — references the synced host copy.
+- `scripts/cc-slot.sh` — on interactive slot CREATE, when the primary login is
+  dead (decision via `genesis.cc.login_gate`, which reuses `login_health`),
+  extracts the token INSIDE the pane shell and exports `CLAUDE_CODE_OAUTH_TOKEN`
+  so the session survives without a re-login prompt (login-dead-conditional;
+  lever `GENESIS_CC_SLOT_OAUTH`).
 - `guardian/credential_bridge.py` (allowlist) — the loader/propagator home
   (`load_cc_oauth_token`, `_CC_TOKEN_SOURCE`), not a business consumer.

--- a/docs/architecture/shared-artifacts.md
+++ b/docs/architecture/shared-artifacts.md
@@ -39,7 +39,7 @@ accessed directly by filename *and* transitively via
 ```yaml shared-artifact
 artifact: cc_oauth_token.env
 documented_in: scripts/store_cc_token.sh
-match_literals: [cc_oauth_token.env, load_cc_oauth_token]
+match_literals: [cc_oauth_token.env, load_cc_oauth_token, read_fallback_token]
 readers:
   - src/genesis/cc/login_health.py
   - src/genesis/cc/login_gate.py

--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -107,12 +107,16 @@ Two mechanisms make this observable and survivable without host access:
    script warns if the source is group/other-readable). The credential-bridge awareness tick
    syncs it to the host shared mount
    (`~/.local/state/genesis-guardian/shared/guardian/cc_oauth_token.env`). It is
-   a **shared fallback** read by two consumers, each of which injects it via
+   a **shared fallback** read by several consumers, each of which injects it via
    `CLAUDE_CODE_OAUTH_TOKEN` **only** when its own login is confirmed dead: the
    **host** Guardian recovery brain (`diagnosis.py`, gated on a pre-flight
-   `claude auth status`) and the **container's own** CC sessions
-   (`cc/login_health.py`, wired at `cc/invoker.py`). A healthy login is never
-   overridden. Remove it with `scripts/store_cc_token.sh --remove`. The
+   `claude auth status`), the **container's own** CC sessions
+   (`cc/login_health.py`, wired at `cc/invoker.py`), and **interactive slots**
+   (`cc/login_gate.py`, wired at `scripts/cc-slot.sh`). A healthy login is never
+   overridden — except the interactive-slot `GENESIS_CC_SLOT_OAUTH=always` lever,
+   which deliberately injects over a live login (losing Remote Control / claude.ai
+   connectors until it is set back to `conditional` and the slot restarts). Remove
+   it with `scripts/store_cc_token.sh --remove`. The
    authoritative consumer list is CI-enforced in
    `docs/architecture/shared-artifacts.md`.
 

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -231,13 +231,16 @@ fi
 # stop) may reap the wrapper before the trailer runs — the watchgod OOM sampler
 # covers that subset. Capture is best-effort and never alters the exit code.
 # `\$` defers expansion to the pane's shell; the `${...}` expand here in cc-slot.sh.
-# The `{ ${_OAUTH_SRC}claude …; }` brace group keeps claude UNDER the `cd &&`
-# guard: `_OAUTH_SRC` ends in `;`, so an un-grouped `cd $ROOT && <prefix>; claude`
-# would bind the `&&` to the prefix only and launch claude even when cd fails.
-# Do NOT unwrap it (test_cd_guard_skips_claude_on_bad_cd).
+# The token-prep prefix `${_OAUTH_SRC}` goes BEFORE `cd` so the original
+# `cd $ROOT && claude` guard stays intact: `_OAUTH_SRC` ends in `;`, so placing it
+# after the `&&` (`cd $ROOT && <prefix>; claude`) would bind the `&&` to the prefix
+# only and launch claude even when cd fails. The prefix is cwd-independent (absolute
+# python path, home-anchored token file), and if the repo is gone that python is too
+# → the read silently no-ops before cd fails. Do NOT move it after the `&&`
+# (test_cd_guard_skips_claude_on_bad_cd).
 exec tmux -u new-session -A -s "$SESSION_NAME" \
     -e "GENESIS_SLOT=${SLOT}" \
     -e "GENESIS_CC_PERMISSION_MODE=${GENESIS_CC_PERMISSION_MODE:-auto}" \
     -e "CLAUDE_CODE_TMPDIR=$CLAUDE_CODE_TMPDIR" \
     -e "LANG=$LANG" \
-    "cd ${GENESIS_ROOT} && { ${_OAUTH_SRC}claude ${CC_PERM_FLAG}${CLAUDE_ARGS_Q}; }; __ec=\$?; ${GENESIS_ROOT}/scripts/cc_exit_capture.sh ${SLOT} \$__ec >/dev/null 2>&1; exit \$__ec"
+    "${_OAUTH_SRC}cd ${GENESIS_ROOT} && claude ${CC_PERM_FLAG}${CLAUDE_ARGS_Q}; __ec=\$?; ${GENESIS_ROOT}/scripts/cc_exit_capture.sh ${SLOT} \$__ec >/dev/null 2>&1; exit \$__ec"

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -189,32 +189,31 @@ fi
 # docs/architecture/shared-artifacts.md.
 _OAUTH_SRC=""
 _slot_oauth_mode="${GENESIS_CC_SLOT_OAUTH:-conditional}"
-_slot_oauth_mode="${_slot_oauth_mode,,}"   # normalize case so bash + the gate agree
+_slot_oauth_mode="${_slot_oauth_mode,,}"   # normalize; the gate is the value authority
 if [ "$_SESSION_EXISTS" = "0" ] && [ "$_slot_oauth_mode" != "off" ] && [ "$_HAS_BARE" = "0" ]; then
-    # Gate exits 0 = inject. `if` guard keeps a non-zero exit from aborting the
-    # launch under `set -e`; `timeout 30` bounds a hung probe (the gate's own
-    # 15s probe timeout + interpreter startup) so a human's slot never wedges.
-    # Hand the RESOLVED mode to the gate via `env`: a plain
+    # The gate both DECIDES and AUTHORS the notice: on inject it exits 0 and
+    # prints the mode-appropriate human notice to stdout — captured here so the
+    # notice text lives in ONE place (no bash/gate divergence), and so lever
+    # semantics (unknown value → fail-closed, peer-route/override exclusion,
+    # stale-token exclusion) are enforced solely in genesis.cc.login_gate, a
+    # faithful mirror of CCInvoker's fallback contract. `if …; then` keeps a
+    # non-zero exit from aborting the launch under `set -e`; `timeout 30` bounds
+    # a hung probe. `env` hands the resolved mode across (a plain
     # `GENESIS_CC_SLOT_OAUTH=always` in ~/.genesis/cc-slot.env is a non-exported
-    # shell var, so the Python subprocess would otherwise never see it and would
-    # default to `conditional` — silently breaking `always`.
-    if timeout 30 env GENESIS_CC_SLOT_OAUTH="$_slot_oauth_mode" "${GENESIS_ROOT}/.venv/bin/python" -m genesis.cc.login_gate; then
-        if [ "$_slot_oauth_mode" = "always" ]; then
-            _oauth_notice="Genesis: forced onto the setup-token (GENESIS_CC_SLOT_OAUTH=always) — Remote Control and claude.ai connectors are OFF; set the lever to conditional and restart this slot to use /login. Local MCP servers still work."
-        else
-            _oauth_notice="Genesis: primary CC login is dead — running on the stored setup-token. Remote Control and claude.ai connectors are OFF until you /login. Local MCP servers still work."
-        fi
-        # Shell-quote the notice so it cannot break out of the pane command
-        # string — the notice text is static today, but %q makes ANY future edit
-        # (a quote, backtick, or $) injection-proof by construction, not by luck.
+    # shell var the subprocess would otherwise never see).
+    if _oauth_notice=$(timeout 30 env GENESIS_CC_SLOT_OAUTH="$_slot_oauth_mode" \
+            "${GENESIS_ROOT}/.venv/bin/python" -m genesis.cc.login_gate); then
+        # %q so the notice cannot break out of the pane command string (any
+        # future notice edit is injection-proof by construction, not by luck).
         _notice_q=$(printf '%q' "$_oauth_notice")
-        # Runs in the PANE shell: extract ONLY the token var (not a full source —
-        # avoids evaluating the file as shell / exporting GENESIS_CC_TOKEN_CREATED_AT),
-        # export it so claude inherits it, then print the (shell-quoted) notice to
-        # stderr. Never echoes the token value. `$(...)`, `~`, and the file read all
-        # defer to the pane shell (the `\$` / literal single-quotes keep them
-        # unexpanded here); ${_notice_q} is already a safe single shell word.
-        _OAUTH_SRC="if [ -r ~/.genesis/cc_oauth_token.env ]; then export CLAUDE_CODE_OAUTH_TOKEN=\"\$(sed -n 's/^CLAUDE_CODE_OAUTH_TOKEN=//p' ~/.genesis/cc_oauth_token.env)\"; printf '%s\\n' ${_notice_q} >&2; fi; "
+        # Runs in the PANE shell: read the token with the SAME parser the gate
+        # used (login_health.read_fallback_token — no sed/parser divergence),
+        # export it ONLY when non-empty (a failed/empty read never exports a
+        # blank credential), then echo the notice to stderr. The token flows
+        # python-stdout → $(...) → a shell var → the process ENV, never any argv
+        # (no ps/scrollback leak). `$(...)`, `\$`, and the literal single-quoted
+        # python defer to the pane shell; ${GENESIS_ROOT}/${_notice_q} expand here.
+        _OAUTH_SRC="_gt=\"\$(\"${GENESIS_ROOT}/.venv/bin/python\" -c 'import sys; from genesis.cc.login_health import read_fallback_token as r; sys.stdout.write(r() or str())' 2>/dev/null)\"; if [ -n \"\$_gt\" ]; then export CLAUDE_CODE_OAUTH_TOKEN=\"\$_gt\"; printf '%s\\n' ${_notice_q} >&2; fi; unset _gt; "
     fi
 fi
 

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -189,11 +189,16 @@ fi
 # docs/architecture/shared-artifacts.md.
 _OAUTH_SRC=""
 _slot_oauth_mode="${GENESIS_CC_SLOT_OAUTH:-conditional}"
+_slot_oauth_mode="${_slot_oauth_mode,,}"   # normalize case so bash + the gate agree
 if [ "$_SESSION_EXISTS" = "0" ] && [ "$_slot_oauth_mode" != "off" ] && [ "$_HAS_BARE" = "0" ]; then
     # Gate exits 0 = inject. `if` guard keeps a non-zero exit from aborting the
     # launch under `set -e`; `timeout 30` bounds a hung probe (the gate's own
     # 15s probe timeout + interpreter startup) so a human's slot never wedges.
-    if timeout 30 "${GENESIS_ROOT}/.venv/bin/python" -m genesis.cc.login_gate; then
+    # Hand the RESOLVED mode to the gate via `env`: a plain
+    # `GENESIS_CC_SLOT_OAUTH=always` in ~/.genesis/cc-slot.env is a non-exported
+    # shell var, so the Python subprocess would otherwise never see it and would
+    # default to `conditional` — silently breaking `always`.
+    if timeout 30 env GENESIS_CC_SLOT_OAUTH="$_slot_oauth_mode" "${GENESIS_ROOT}/.venv/bin/python" -m genesis.cc.login_gate; then
         if [ "$_slot_oauth_mode" = "always" ]; then
             _oauth_notice="Genesis: forced onto the setup-token (GENESIS_CC_SLOT_OAUTH=always) — Remote Control and claude.ai connectors are OFF; set the lever to conditional and restart this slot to use /login. Local MCP servers still work."
         else

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -231,9 +231,13 @@ fi
 # stop) may reap the wrapper before the trailer runs — the watchgod OOM sampler
 # covers that subset. Capture is best-effort and never alters the exit code.
 # `\$` defers expansion to the pane's shell; the `${...}` expand here in cc-slot.sh.
+# The `{ ${_OAUTH_SRC}claude …; }` brace group keeps claude UNDER the `cd &&`
+# guard: `_OAUTH_SRC` ends in `;`, so an un-grouped `cd $ROOT && <prefix>; claude`
+# would bind the `&&` to the prefix only and launch claude even when cd fails.
+# Do NOT unwrap it (test_cd_guard_skips_claude_on_bad_cd).
 exec tmux -u new-session -A -s "$SESSION_NAME" \
     -e "GENESIS_SLOT=${SLOT}" \
     -e "GENESIS_CC_PERMISSION_MODE=${GENESIS_CC_PERMISSION_MODE:-auto}" \
     -e "CLAUDE_CODE_TMPDIR=$CLAUDE_CODE_TMPDIR" \
     -e "LANG=$LANG" \
-    "cd ${GENESIS_ROOT} && ${_OAUTH_SRC}claude ${CC_PERM_FLAG}${CLAUDE_ARGS_Q}; __ec=\$?; ${GENESIS_ROOT}/scripts/cc_exit_capture.sh ${SLOT} \$__ec >/dev/null 2>&1; exit \$__ec"
+    "cd ${GENESIS_ROOT} && { ${_OAUTH_SRC}claude ${CC_PERM_FLAG}${CLAUDE_ARGS_Q}; }; __ec=\$?; ${GENESIS_ROOT}/scripts/cc_exit_capture.sh ${SLOT} \$__ec >/dev/null 2>&1; exit \$__ec"

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -106,8 +106,11 @@ existing=$(tmux list-sessions -F '#{session_name}' 2>/dev/null \
            | grep -cE "^${SESSION_PREFIX}-[0-9]+$" || true)
 
 # Reattaching to existing session — always allow ('=' = exact-name match)
+_SESSION_EXISTS=0
 if tmux has-session -t "=$SESSION_NAME" 2>/dev/null; then
-    :  # bypass cap check
+    _SESSION_EXISTS=1  # bypass cap check; also skips the OAuth gate below —
+                       # attach does NOT re-run the pane command, so any token
+                       # injection would be moot (and would waste a probe).
 elif [[ $existing -ge $max_sessions ]]; then
     echo "ERROR: Session cap reached (${existing}/${max_sessions} active)." >&2
     echo "RAM: ${avail_mb}MB available, ${RESERVED_MB}MB reserved, ${PER_SESSION_MB}MB/session" >&2
@@ -138,6 +141,10 @@ export CLAUDE_CODE_TMPDIR="$HOME/.genesis/cc-tmp"
 # --dangerously-skip-permissions, set GENESIS_CC_PERMISSION_MODE=bypass. SSH
 # RemoteCommand does not source .bashrc, so this script also reads an optional
 # ~/.genesis/cc-slot.env (e.g. a single line: GENESIS_CC_PERMISSION_MODE=bypass).
+# That file is also where the OAuth-durability lever lives:
+# GENESIS_CC_SLOT_OAUTH=conditional (default) | always | off — set `off` for a
+# slot that must keep Remote Control / claude.ai connectors even after the login
+# dies (see the OAuth block below).
 # Headless/autonomous CC sessions (CCInvoker -p) keep bypass separately — no
 # human is present to answer a prompt.
 if [ -f "${HOME}/.genesis/cc-slot.env" ]; then
@@ -157,14 +164,48 @@ esac
 # A caller-supplied permission flag suppresses CC_PERM_FLAG so claude never
 # receives two conflicting permission arguments.
 CLAUDE_ARGS_Q=""
+_HAS_BARE=0
 if [[ ${#CLAUDE_EXTRA_ARGS[@]} -gt 0 ]]; then
     for arg in "${CLAUDE_EXTRA_ARGS[@]}"; do
         case "$arg" in
             --dangerously-skip-permissions|--permission-mode|--permission-mode=*)
                 CC_PERM_FLAG="" ;;
         esac
+        # --bare ignores CLAUDE_CODE_OAUTH_TOKEN (CC auth precedence), so
+        # injecting the setup-token would be inert — skip the OAuth gate below.
+        [ "$arg" = "--bare" ] && _HAS_BARE=1
     done
     CLAUDE_ARGS_Q=$(printf ' %q' "${CLAUDE_EXTRA_ARGS[@]}")
+fi
+
+# --- OAuth login durability (login-dead-conditional; WS-1) -------------------
+# On slot CREATE only: if the interactive /login is dead, continue this pane on
+# the stored 1-year setup-token so the session survives without a re-login
+# prompt. genesis.cc.login_gate makes the decision (reusing login_health's
+# shared login-dead gate — one authority, same as CCInvoker); the token itself
+# is read INSIDE the pane shell (never in any argv/ps) via a conditional prefix
+# on the command string. Lever GENESIS_CC_SLOT_OAUTH=conditional(default)|always|off.
+# cc-slot.sh is a registered reader of cc_oauth_token.env — see
+# docs/architecture/shared-artifacts.md.
+_OAUTH_SRC=""
+_slot_oauth_mode="${GENESIS_CC_SLOT_OAUTH:-conditional}"
+if [ "$_SESSION_EXISTS" = "0" ] && [ "$_slot_oauth_mode" != "off" ] && [ "$_HAS_BARE" = "0" ]; then
+    # Gate exits 0 = inject. `if` guard keeps a non-zero exit from aborting the
+    # launch under `set -e`; `timeout 30` bounds a hung probe (the gate's own
+    # 15s probe timeout + interpreter startup) so a human's slot never wedges.
+    if timeout 30 "${GENESIS_ROOT}/.venv/bin/python" -m genesis.cc.login_gate; then
+        if [ "$_slot_oauth_mode" = "always" ]; then
+            _oauth_notice="Genesis: forced onto the setup-token (GENESIS_CC_SLOT_OAUTH=always) — Remote Control and claude.ai connectors are OFF; set the lever to conditional and restart this slot to use /login. Local MCP servers still work."
+        else
+            _oauth_notice="Genesis: primary CC login is dead — running on the stored setup-token. Remote Control and claude.ai connectors are OFF until you /login. Local MCP servers still work."
+        fi
+        # Runs in the PANE shell: extract ONLY the token var (not a full source —
+        # avoids evaluating the file as shell / exporting GENESIS_CC_TOKEN_CREATED_AT),
+        # export it so claude inherits it, then print the notice to stderr. Never
+        # echoes the token value. `$(...)`, `~`, and the file read all defer to
+        # the pane shell (the `\$` / literal single-quotes keep them unexpanded here).
+        _OAUTH_SRC="if [ -r ~/.genesis/cc_oauth_token.env ]; then export CLAUDE_CODE_OAUTH_TOKEN=\"\$(sed -n 's/^CLAUDE_CODE_OAUTH_TOKEN=//p' ~/.genesis/cc_oauth_token.env)\"; printf '%s\\n' \"${_oauth_notice}\" >&2; fi; "
+    fi
 fi
 
 # -u: force UTF-8 output even if a future client's locale detection fails.
@@ -186,4 +227,4 @@ exec tmux -u new-session -A -s "$SESSION_NAME" \
     -e "GENESIS_CC_PERMISSION_MODE=${GENESIS_CC_PERMISSION_MODE:-auto}" \
     -e "CLAUDE_CODE_TMPDIR=$CLAUDE_CODE_TMPDIR" \
     -e "LANG=$LANG" \
-    "cd ${GENESIS_ROOT} && claude ${CC_PERM_FLAG}${CLAUDE_ARGS_Q}; __ec=\$?; ${GENESIS_ROOT}/scripts/cc_exit_capture.sh ${SLOT} \$__ec >/dev/null 2>&1; exit \$__ec"
+    "cd ${GENESIS_ROOT} && ${_OAUTH_SRC}claude ${CC_PERM_FLAG}${CLAUDE_ARGS_Q}; __ec=\$?; ${GENESIS_ROOT}/scripts/cc_exit_capture.sh ${SLOT} \$__ec >/dev/null 2>&1; exit \$__ec"

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -199,12 +199,17 @@ if [ "$_SESSION_EXISTS" = "0" ] && [ "$_slot_oauth_mode" != "off" ] && [ "$_HAS_
         else
             _oauth_notice="Genesis: primary CC login is dead — running on the stored setup-token. Remote Control and claude.ai connectors are OFF until you /login. Local MCP servers still work."
         fi
+        # Shell-quote the notice so it cannot break out of the pane command
+        # string — the notice text is static today, but %q makes ANY future edit
+        # (a quote, backtick, or $) injection-proof by construction, not by luck.
+        _notice_q=$(printf '%q' "$_oauth_notice")
         # Runs in the PANE shell: extract ONLY the token var (not a full source —
         # avoids evaluating the file as shell / exporting GENESIS_CC_TOKEN_CREATED_AT),
-        # export it so claude inherits it, then print the notice to stderr. Never
-        # echoes the token value. `$(...)`, `~`, and the file read all defer to
-        # the pane shell (the `\$` / literal single-quotes keep them unexpanded here).
-        _OAUTH_SRC="if [ -r ~/.genesis/cc_oauth_token.env ]; then export CLAUDE_CODE_OAUTH_TOKEN=\"\$(sed -n 's/^CLAUDE_CODE_OAUTH_TOKEN=//p' ~/.genesis/cc_oauth_token.env)\"; printf '%s\\n' \"${_oauth_notice}\" >&2; fi; "
+        # export it so claude inherits it, then print the (shell-quoted) notice to
+        # stderr. Never echoes the token value. `$(...)`, `~`, and the file read all
+        # defer to the pane shell (the `\$` / literal single-quotes keep them
+        # unexpanded here); ${_notice_q} is already a safe single shell word.
+        _OAUTH_SRC="if [ -r ~/.genesis/cc_oauth_token.env ]; then export CLAUDE_CODE_OAUTH_TOKEN=\"\$(sed -n 's/^CLAUDE_CODE_OAUTH_TOKEN=//p' ~/.genesis/cc_oauth_token.env)\"; printf '%s\\n' ${_notice_q} >&2; fi; "
     fi
 fi
 

--- a/scripts/store_cc_token.sh
+++ b/scripts/store_cc_token.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 # store_cc_token.sh — intake a `claude setup-token` OAuth token used as a
-# FALLBACK CC credential, by two consumers, when a primary `claude login` dies.
+# FALLBACK CC credential, by several consumers, when a primary `claude login` dies.
 #
 # The token (a 1-year `claude setup-token`, used via CLAUDE_CODE_OAUTH_TOKEN —
 # NOT an ANTHROPIC_API_KEY) is stored 0600 to a DEDICATED container file and
 # synced to the host shared mount by the credential-bridge awareness tick. It is
 # a SHARED fallback, read by consumers on BOTH the host (the Guardian recovery
 # brain, via guardian/diagnosis.py) AND the container itself (its own CC sessions,
-# foreground + background, via cc/login_health.py) — each injecting it only as a
-# fallback when its own login is down (see those modules for the exact activation
-# gate); a HEALTHY login is never overridden. It is NOT host-Guardian-only. The
+# foreground + background, via cc/login_health.py, AND interactive cc-slot.sh panes
+# via cc/login_gate.py) — each injecting it only as a fallback when its own login is
+# down (see those modules for the exact activation gate); a HEALTHY login is never
+# overridden, EXCEPT the interactive-slot `GENESIS_CC_SLOT_OAUTH=always` lever, which
+# deliberately injects over a live login. It is NOT host-Guardian-only. The
 # authoritative, CI-enforced consumer list lives in
 # docs/architecture/shared-artifacts.md (checked by
 # scripts/check_shared_artifact_consumers.py) — update THAT when a consumer changes.

--- a/src/genesis/cc/login_gate.py
+++ b/src/genesis/cc/login_gate.py
@@ -101,8 +101,12 @@ async def _decide() -> str | None:
     if mode == "off":
         return None
     if mode not in _VALID_MODES:
+        # Do NOT echo the raw lever value — CodeQL's clear-text-logging taint
+        # rule flags ANY env-var value reaching a log as sensitive (false
+        # positive here: the lever is conditional/always/off, never a secret),
+        # and the value adds nothing the allowed-set line doesn't.
         print(
-            f"Genesis: unknown GENESIS_CC_SLOT_OAUTH={mode!r} — not injecting "
+            "Genesis: unknown GENESIS_CC_SLOT_OAUTH value — not injecting "
             "(allowed: conditional, always, off).",
             file=sys.stderr,
             flush=True,

--- a/src/genesis/cc/login_gate.py
+++ b/src/genesis/cc/login_gate.py
@@ -69,7 +69,8 @@ _COMPETING_AUTH_ENV = (
 
 _NOTICE_CONDITIONAL = (
     "Genesis: primary CC login is dead — running on the stored setup-token. "
-    "Remote Control and claude.ai connectors are OFF until you /login. "
+    "Remote Control and claude.ai connectors are OFF; run /login, then restart "
+    "this slot to use them (the setup-token overrides /login in this session). "
     "Local MCP servers still work."
 )
 _NOTICE_ALWAYS = (
@@ -126,7 +127,23 @@ async def _decide() -> str | None:
 
     if mode == "always":
         token = login_health.read_fallback_token()
-        if token is None or login_health.fallback_token_is_stale():
+        if token is None:
+            print(
+                "Genesis: GENESIS_CC_SLOT_OAUTH=always but no setup-token is "
+                "stored (~/.genesis/cc_oauth_token.env) — starting on the normal "
+                "login. Provision it: `claude setup-token` + scripts/store_cc_token.sh.",
+                file=sys.stderr,
+                flush=True,
+            )
+            return None
+        if login_health.fallback_token_is_stale():
+            print(
+                "Genesis: GENESIS_CC_SLOT_OAUTH=always but the stored setup-token "
+                "is past its ~1-year life — not injecting a known-dead credential. "
+                "Refresh it: `claude setup-token` + scripts/store_cc_token.sh.",
+                file=sys.stderr,
+                flush=True,
+            )
             return None
         return _NOTICE_ALWAYS
 

--- a/src/genesis/cc/login_gate.py
+++ b/src/genesis/cc/login_gate.py
@@ -4,23 +4,34 @@
 inject the stored 1-year setup-token (``CLAUDE_CODE_OAUTH_TOKEN``) so an
 interactive session survives a dead ``/login`` without a re-login prompt.
 
-Contract: exit 0 = inject, exit 1 = do NOT inject. Prints NOTHING sensitive
-(never the token). Fails CLOSED — any error → exit 1 (the slot keeps its normal
-login behavior; a dead login just prompts ``/login`` as it does today).
+Contract: exit 0 = inject, exit 1 = do NOT inject. On exit 0 the gate prints the
+human-facing notice (which the pane echoes to stderr) to STDOUT — and NOTHING
+sensitive (never the token). Fails CLOSED — any error → exit 1 (the slot keeps
+its normal login behavior; a dead login just prompts ``/login`` as today).
 
-Decision authority is SHARED, not re-implemented: the ``conditional`` mode calls
-``login_health.fallback_env_if_login_dead`` — the same gate CCInvoker uses
-(invoker.py) — so the container never grows two divergent notions of "login is
-dead" (per the leaky per-consumer-classification lesson).
+This gate is the SINGLE authority for the whole slot-fallback decision, and a
+faithful mirror of ``CCInvoker._apply_login_fallback`` (invoker.py). Beyond the
+shared ``login_health.fallback_env_if_login_dead`` gate it also enforces:
+
+- **Fail-closed lever**: only ``conditional`` / ``always`` / ``off`` inject as
+  documented; any other value (a typo like ``of``) is rejected, not silently
+  treated as ``conditional``.
+- **Competing-auth exclusion**: never inject when another auth mechanism is in
+  play — a peer-route (``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_AUTH_TOKEN``), an API
+  key (``ANTHROPIC_API_KEY``), an already-present ``CLAUDE_CODE_OAUTH_TOKEN``, or
+  a custom ``CLAUDE_CONFIG_DIR``. This preserves the invoker's credential-
+  isolation contract (the Anthropic setup-token must never travel toward a
+  third-party endpoint), for BOTH ``conditional`` and ``always``.
+- **Stale-token exclusion**: a setup-token past its ~1-year life is treated as
+  absent (shared ``login_health.fallback_token_is_stale``), for both modes.
 
 Lever ``GENESIS_CC_SLOT_OAUTH``:
 - ``conditional`` (default): inject ONLY when the interactive login is
   hard-expired AND a live ``claude auth status`` probe confirms logged-out.
-  Preserves Remote Control + claude.ai connectors while the login is alive
-  (the env var is simply absent then, so CC uses ``/login``).
-- ``always``: inject whenever a setup-token exists, bypassing the login gate.
-  Overrides even a live login (loses connectors until the lever is set back to
-  ``conditional`` and the slot restarts).
+  Preserves Remote Control + claude.ai connectors while the login is alive.
+- ``always``: inject whenever a (fresh) setup-token exists, bypassing the login
+  gate. Overrides even a live login (loses connectors until the lever is set
+  back to ``conditional`` and the slot restarts).
 - ``off``: never inject (kill switch / per-slot opt-out).
 
 The 60s probe cache in ``login_health`` is per-process, so it does NOT amortize
@@ -35,23 +46,85 @@ import asyncio
 import os
 import sys
 
+_VALID_MODES = ("conditional", "always", "off")
+
+# Env markers that mean "another auth mechanism owns this session" — the exact
+# set CCInvoker._apply_login_fallback excludes (invoker.py). Full parity: never
+# cross the Anthropic setup-token into a peer-routed (ANTHROPIC_BASE_URL/
+# AUTH_TOKEN) or alternately-authed (ANTHROPIC_API_KEY) process, never clobber an
+# already-present CLAUDE_CODE_OAUTH_TOKEN, and never inject over a custom
+# CLAUDE_CONFIG_DIR. The last matters because read_fallback_token() reads ONE
+# fixed, global token (~/.genesis/cc_oauth_token.env) — NOT config-dir-scoped —
+# so a slot pointed at a different Claude identity via CLAUDE_CONFIG_DIR must not
+# be silently re-authed as the primary operator. Normal slots never set it, so
+# this only excludes deliberately custom-config-dir slots (same tradeoff the
+# invoker accepts).
+_COMPETING_AUTH_ENV = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CONFIG_DIR",
+)
+
+_NOTICE_CONDITIONAL = (
+    "Genesis: primary CC login is dead — running on the stored setup-token. "
+    "Remote Control and claude.ai connectors are OFF until you /login. "
+    "Local MCP servers still work."
+)
+_NOTICE_ALWAYS = (
+    "Genesis: forced onto the setup-token (GENESIS_CC_SLOT_OAUTH=always) — "
+    "Remote Control and claude.ai connectors are OFF; set the lever to "
+    "conditional and restart this slot to use /login. Local MCP servers still work."
+)
+
 
 def _mode() -> str:
     return (os.environ.get("GENESIS_CC_SLOT_OAUTH") or "conditional").strip().lower()
 
 
-async def _should_inject() -> bool:
-    """True iff this slot should inject the setup-token, per the lever."""
+def _competing_auth() -> str | None:
+    """Name of a competing-auth env var that is set (non-empty), else None."""
+    for name in _COMPETING_AUTH_ENV:
+        if os.environ.get(name):
+            return name
+    return None
+
+
+async def _decide() -> str | None:
+    """Return the notice to show if this slot should inject, else None."""
     # Imported lazily so the module stays cheap to import and the gate's only
     # heavy dependency (login_health → asyncio/subprocess) loads on demand.
     from genesis.cc import login_health
 
     mode = _mode()
     if mode == "off":
-        return False
+        return None
+    if mode not in _VALID_MODES:
+        print(
+            f"Genesis: unknown GENESIS_CC_SLOT_OAUTH={mode!r} — not injecting "
+            "(allowed: conditional, always, off).",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
+
+    # Never inject over a competing auth mechanism (credential-isolation parity
+    # with the invoker) — applies to BOTH conditional and always.
+    competing = _competing_auth()
+    if competing:
+        print(
+            f"Genesis: {competing} is set — leaving auth to it, not injecting the setup-token.",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
 
     if mode == "always":
-        return login_health.read_fallback_token() is not None
+        token = login_health.read_fallback_token()
+        if token is None or login_health.fallback_token_is_stale():
+            return None
+        return _NOTICE_ALWAYS
 
     # conditional (default): reuse the shared login-dead gate. Wrap the probe so
     # the ONE case where it actually runs (login already hard-dead) emits a
@@ -68,14 +141,20 @@ async def _should_inject() -> bool:
         return await login_health.probe_logged_out(cc_path)
 
     env = await login_health.fallback_env_if_login_dead(probe=probe, cc_path=cc_path)
-    return env is not None
+    return _NOTICE_CONDITIONAL if env is not None else None
 
 
 def main() -> int:
     try:
-        return 0 if asyncio.run(_should_inject()) else 1
+        notice = asyncio.run(_decide())
     except Exception:  # noqa: BLE001 — fail-closed: never inject on error
         return 1
+    if notice is None:
+        return 1
+    # STDOUT carries ONLY the human notice (never the token); cc-slot.sh captures
+    # it and the pane echoes it to stderr.
+    print(notice)
+    return 0
 
 
 if __name__ == "__main__":

--- a/src/genesis/cc/login_gate.py
+++ b/src/genesis/cc/login_gate.py
@@ -1,0 +1,82 @@
+"""Interactive-slot OAuth decision gate — `python -m genesis.cc.login_gate`.
+
+`scripts/cc-slot.sh` runs this on slot CREATE to decide whether the pane should
+inject the stored 1-year setup-token (``CLAUDE_CODE_OAUTH_TOKEN``) so an
+interactive session survives a dead ``/login`` without a re-login prompt.
+
+Contract: exit 0 = inject, exit 1 = do NOT inject. Prints NOTHING sensitive
+(never the token). Fails CLOSED — any error → exit 1 (the slot keeps its normal
+login behavior; a dead login just prompts ``/login`` as it does today).
+
+Decision authority is SHARED, not re-implemented: the ``conditional`` mode calls
+``login_health.fallback_env_if_login_dead`` — the same gate CCInvoker uses
+(invoker.py) — so the container never grows two divergent notions of "login is
+dead" (per the leaky per-consumer-classification lesson).
+
+Lever ``GENESIS_CC_SLOT_OAUTH``:
+- ``conditional`` (default): inject ONLY when the interactive login is
+  hard-expired AND a live ``claude auth status`` probe confirms logged-out.
+  Preserves Remote Control + claude.ai connectors while the login is alive
+  (the env var is simply absent then, so CC uses ``/login``).
+- ``always``: inject whenever a setup-token exists, bypassing the login gate.
+  Overrides even a live login (loses connectors until the lever is set back to
+  ``conditional`` and the slot restarts).
+- ``off``: never inject (kill switch / per-slot opt-out).
+
+The 60s probe cache in ``login_health`` is per-process, so it does NOT amortize
+across separate slot launches — each launch is a fresh process. That is fine:
+the cheap ``credentials.json`` timestamp gate short-circuits before the probe on
+a healthy login, so the common case never spawns a subprocess.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+
+def _mode() -> str:
+    return (os.environ.get("GENESIS_CC_SLOT_OAUTH") or "conditional").strip().lower()
+
+
+async def _should_inject() -> bool:
+    """True iff this slot should inject the setup-token, per the lever."""
+    # Imported lazily so the module stays cheap to import and the gate's only
+    # heavy dependency (login_health → asyncio/subprocess) loads on demand.
+    from genesis.cc import login_health
+
+    mode = _mode()
+    if mode == "off":
+        return False
+
+    if mode == "always":
+        return login_health.read_fallback_token() is not None
+
+    # conditional (default): reuse the shared login-dead gate. Wrap the probe so
+    # the ONE case where it actually runs (login already hard-dead) emits a
+    # progress line — a healthy login short-circuits before the probe and stays
+    # silent, so a new slot never hangs mysteriously while auth is checked.
+    cc_path = os.environ.get("GENESIS_CC_BIN") or "claude"
+
+    async def probe() -> bool:
+        print(
+            "Genesis: primary CC login expired — checking auth status…",
+            file=sys.stderr,
+            flush=True,
+        )
+        return await login_health.probe_logged_out(cc_path)
+
+    env = await login_health.fallback_env_if_login_dead(probe=probe, cc_path=cc_path)
+    return env is not None
+
+
+def main() -> int:
+    try:
+        return 0 if asyncio.run(_should_inject()) else 1
+    except Exception:  # noqa: BLE001 — fail-closed: never inject on error
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/genesis/cc/login_health.py
+++ b/src/genesis/cc/login_health.py
@@ -7,14 +7,18 @@ Background sessions ride the same credentials, so a lapsed login silently
 kills autonomy. (Discovered 2026-08-18: nothing anywhere read
 ``refreshTokenExpiresAt``.)
 
-Two consumers:
+Three consumers:
 
 - the awareness check ``_check_cc_login_expiry`` (warns days ahead via the
   standard critical-observation → Telegram path);
 - the invoker's fallback injection: when the login is HARD-expired and a live
   ``claude auth status`` probe CONFIRMS logged-out, CC invocations (foreground turns and
 background dispatches alike) get ``CLAUDE_CODE_OAUTH_TOKEN`` from the operator's stored 1-year setup-token
-  (``~/.genesis/cc_oauth_token.env``, written by ``scripts/store_cc_token.sh``).
+  (``~/.genesis/cc_oauth_token.env``, written by ``scripts/store_cc_token.sh``);
+- the interactive-slot gate ``cc/login_gate.py`` (a faithful mirror of the
+  invoker's fallback contract) — reuses ``fallback_env_if_login_dead`` /
+  ``read_fallback_token`` / ``fallback_token_is_stale`` to decide whether a
+  ``scripts/cc-slot.sh`` pane should inject the setup-token.
 
 The injection mirrors the host guardian's honest boundary
 (``guardian/diagnosis.py``): the env token OVERRIDES a stored login, so it is
@@ -117,11 +121,15 @@ def read_fallback_token() -> str | None:
 
 
 def fallback_token_created_at() -> datetime | None:
-    """The setup-token's stored creation time (UTC), or None when unknown.
+    """The setup-token's stored INTAKE time (UTC), or None when unknown.
 
-    Reads ``GENESIS_CC_TOKEN_CREATED_AT`` (unix seconds) written alongside the
-    token by ``store_cc_token.sh``. A missing/unparseable value is "unknown",
-    never an error.
+    Reads ``GENESIS_CC_TOKEN_CREATED_AT`` (unix seconds) — the moment
+    ``store_cc_token.sh`` STORED the token (``date +%s`` at intake), NOT the
+    token's issuance time. The token is an opaque ``sk-ant-oat`` bearer string
+    with no client-readable ``iat``/``exp``, so intake is the only timestamp we
+    have; it equals issuance for the documented ``claude setup-token | store``
+    pipe, but the ``--file`` deferred path can make it LATER than issuance. A
+    missing/unparseable value is "unknown", never an error.
     """
     try:
         for line in _TOKEN_FILE.read_text().splitlines():
@@ -135,12 +143,17 @@ def fallback_token_created_at() -> datetime | None:
 
 
 def fallback_token_is_stale(*, now: datetime | None = None) -> bool:
-    """True ONLY when the setup-token is PROVABLY past its ~1-year lifetime.
+    """True when the setup-token is past a COARSE ~1-year age keyed on INTAKE time.
 
-    Fail-safe direction: an unknown/unparseable creation time returns False
-    (don't block a possibly-valid token) — only a creation time we can read AND
-    that is older than the lifetime blocks injection. This mirrors the probe's
-    "ambiguity never acts" stance.
+    This is a safety net, not an exact-expiry check: the token is opaque
+    (``sk-ant-oat``, no readable ``exp``), so age is measured from the stored
+    INTAKE timestamp (see ``fallback_token_created_at``), which approximates —
+    but for the ``--file`` deferred path may UNDER-state — the real token age.
+    Fail-safe direction: an unknown/unparseable intake time returns False (don't
+    block a possibly-valid token) — only an intake time we can read AND that is
+    older than the lifetime blocks injection. This mirrors the probe's
+    "ambiguity never acts" stance; the primary gate remains the live login-dead
+    detection in ``fallback_env_if_login_dead``, not this coarse age bound.
     """
     created = fallback_token_created_at()
     if created is None:

--- a/src/genesis/cc/login_health.py
+++ b/src/genesis/cc/login_health.py
@@ -40,6 +40,11 @@ logger = logging.getLogger(__name__)
 
 _TOKEN_FILE = Path("~/.genesis/cc_oauth_token.env").expanduser()
 
+# `claude setup-token` mints a ~1-year OAuth token. Injecting one past that life
+# exports a known-dead credential (CC then errors instead of falling back to the
+# normal /login prompt), so the fallback treats a provably-old token as absent.
+_SETUP_TOKEN_LIFETIME_S = 365 * 24 * 3600
+
 # Confirmed-logged-out probe results are cached briefly so a burst of
 # background dispatches during an outage doesn't spawn a probe subprocess
 # each. A successful /login rewrites credentials.json with a future expiry,
@@ -111,6 +116,39 @@ def read_fallback_token() -> str | None:
     return None
 
 
+def fallback_token_created_at() -> datetime | None:
+    """The setup-token's stored creation time (UTC), or None when unknown.
+
+    Reads ``GENESIS_CC_TOKEN_CREATED_AT`` (unix seconds) written alongside the
+    token by ``store_cc_token.sh``. A missing/unparseable value is "unknown",
+    never an error.
+    """
+    try:
+        for line in _TOKEN_FILE.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("GENESIS_CC_TOKEN_CREATED_AT="):
+                raw = line.split("=", 1)[1].strip().strip('"').strip("'")
+                return datetime.fromtimestamp(int(raw), tz=UTC)
+    except (OSError, ValueError, OverflowError):
+        return None
+    return None
+
+
+def fallback_token_is_stale(*, now: datetime | None = None) -> bool:
+    """True ONLY when the setup-token is PROVABLY past its ~1-year lifetime.
+
+    Fail-safe direction: an unknown/unparseable creation time returns False
+    (don't block a possibly-valid token) — only a creation time we can read AND
+    that is older than the lifetime blocks injection. This mirrors the probe's
+    "ambiguity never acts" stance.
+    """
+    created = fallback_token_created_at()
+    if created is None:
+        return False
+    now = now or datetime.now(UTC)
+    return (now - created).total_seconds() >= _SETUP_TOKEN_LIFETIME_S
+
+
 async def probe_logged_out(cc_path: str = "claude", timeout_s: float = 15.0) -> bool:
     """Return True ONLY when ``claude auth status --json`` CONFIRMS
     ``loggedIn: false``. Timeouts, unparseable output, and any other state
@@ -154,6 +192,7 @@ async def fallback_env_if_login_dead(
     *,
     probe=None,
     token_reader=read_fallback_token,
+    token_is_stale=fallback_token_is_stale,
     cc_path: str = "claude",
 ) -> dict[str, str] | None:
     """Env additions for a background CC invocation, or None (the common case).
@@ -162,7 +201,8 @@ async def fallback_env_if_login_dead(
     1. refresh token HARD-expired per credentials.json (cheap file read; a
        working or merely-near-expiry login never proceeds);
     2. live probe CONFIRMS logged-out (cached _PROBE_CACHE_TTL_S seconds);
-    3. a stored setup-token exists.
+    3. a stored setup-token exists AND is not provably past its ~1-year life
+       (injecting a known-dead token is worse than leaving the /login prompt).
     """
     if probe is None:
         # Bind the probe to the CALLER'S configured executable — probing a
@@ -193,6 +233,14 @@ async def fallback_env_if_login_dead(
             "setup-token is stored (~/.genesis/cc_oauth_token.env) — background "
             "sessions will fail until /login or `claude setup-token` + "
             "scripts/store_cc_token.sh",
+        )
+        return None
+
+    if token_is_stale():
+        logger.warning(
+            "CC login expired + confirmed logged-out, but the stored setup-token "
+            "is itself past its ~1-year lifetime — NOT injecting a known-dead "
+            "credential. Refresh it: `claude setup-token` + scripts/store_cc_token.sh",
         )
         return None
 

--- a/tests/test_cc/test_login_gate.py
+++ b/tests/test_cc/test_login_gate.py
@@ -1,17 +1,16 @@
 """Tests for the interactive-slot OAuth decision gate (genesis.cc.login_gate).
 
-The gate is the CLI that scripts/cc-slot.sh runs on slot CREATE to decide
-whether to inject the stored setup-token. It reuses
-login_health.fallback_env_if_login_dead as the single decision authority, so
-these tests exercise the lever branches + the login-dead-conditional path
-through that shared gate.
+The gate is a faithful mirror of CCInvoker's fallback contract for interactive
+slots. `_decide()` returns the human notice string when the slot should inject,
+or None otherwise; `main()` maps that to exit 0/1 and prints the notice.
 
 Isolation notes:
-- CLAUDE_CONFIG_DIR is pointed at tmp so credentials.json is per-test.
+- CLAUDE_CONFIG_DIR → tmp so credentials.json is per-test.
 - login_health._TOKEN_FILE is monkeypatched (NOT read_fallback_token), because
   fallback_env_if_login_dead captured read_fallback_token as a default arg at
   import time — patching the file makes the REAL reader read our fixture, which
   is exactly the path the gate takes (it never passes token_reader).
+- competing-auth env vars are cleared so the runner's own env can't skip the gate.
 """
 
 from __future__ import annotations
@@ -37,19 +36,26 @@ def _write_creds(config_dir, *, refresh_expires_ms: int | None) -> None:
     )
 
 
-def _write_token(path, *, present: bool) -> None:
+def _write_token(path, *, present: bool, age_days: float = 1.0) -> None:
+    """Write the token file with a now-relative created_at (avoids a wall-clock
+    time-bomb): age_days<365 = fresh, >365 = stale."""
     if present:
+        created = int((datetime.now(UTC) - timedelta(days=age_days)).timestamp())
         path.write_text(
-            "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-testtoken\n"
-            "GENESIS_CC_TOKEN_CREATED_AT=1700000000\n",
+            f"CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-testtoken\n"
+            f"GENESIS_CC_TOKEN_CREATED_AT={created}\n",
         )
 
 
 @pytest.fixture(autouse=True)
 def _isolated(tmp_path, monkeypatch):
-    """Per-test credentials.json + token file; clear the probe cache."""
-    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    # Isolate credentials.json by patching the resolver directly — NOT by setting
+    # CLAUDE_CONFIG_DIR, which the gate now (correctly) treats as competing-auth.
+    creds = tmp_path / ".credentials.json"
+    monkeypatch.setattr(login_health, "credentials_path", lambda: creds)
     monkeypatch.delenv("GENESIS_CC_SLOT_OAUTH", raising=False)
+    for name in login_gate._COMPETING_AUTH_ENV:
+        monkeypatch.delenv(name, raising=False)
     token_file = tmp_path / "cc_oauth_token.env"
     monkeypatch.setattr(login_health, "_TOKEN_FILE", token_file)
     login_health.reset_probe_cache()
@@ -63,102 +69,154 @@ def _patch_probe(monkeypatch, *, logged_out: bool) -> None:
     monkeypatch.setattr(login_health, "probe_logged_out", _probe)
 
 
+def _expired(days: int = 1):
+    return _ms(datetime.now(UTC) - timedelta(hours=days * 24))
+
+
+def _future(days: int = 5):
+    return _ms(datetime.now(UTC) + timedelta(days=days))
+
+
 # --- conditional mode (the default / chosen model) -------------------------
 
 
 @pytest.mark.asyncio
 async def test_conditional_no_inject_when_login_alive(_isolated, monkeypatch):
     config_dir, token_file = _isolated
-    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=5)))
+    _write_creds(config_dir, refresh_expires_ms=_future())
     _write_token(token_file, present=True)
-    _patch_probe(monkeypatch, logged_out=True)  # even if probe would say out
-    assert await login_gate._should_inject() is False
+    _patch_probe(monkeypatch, logged_out=True)
+    assert await login_gate._decide() is None
 
 
 @pytest.mark.asyncio
 async def test_conditional_injects_when_expired_and_logged_out(_isolated, monkeypatch):
     config_dir, token_file = _isolated
-    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)))
+    _write_creds(config_dir, refresh_expires_ms=_expired())
     _write_token(token_file, present=True)
     _patch_probe(monkeypatch, logged_out=True)
-    assert await login_gate._should_inject() is True
+    assert await login_gate._decide() == login_gate._NOTICE_CONDITIONAL
 
 
 @pytest.mark.asyncio
 async def test_conditional_no_inject_when_probe_ambiguous(_isolated, monkeypatch):
     config_dir, token_file = _isolated
-    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)))
+    _write_creds(config_dir, refresh_expires_ms=_expired())
     _write_token(token_file, present=True)
-    _patch_probe(monkeypatch, logged_out=False)  # not confirmed logged-out
-    assert await login_gate._should_inject() is False
+    _patch_probe(monkeypatch, logged_out=False)
+    assert await login_gate._decide() is None
 
 
 @pytest.mark.asyncio
 async def test_conditional_no_inject_when_no_token(_isolated, monkeypatch):
     config_dir, token_file = _isolated
-    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)))
+    _write_creds(config_dir, refresh_expires_ms=_expired())
     _write_token(token_file, present=False)
     _patch_probe(monkeypatch, logged_out=True)
-    assert await login_gate._should_inject() is False
+    assert await login_gate._decide() is None
 
 
-# --- off (kill switch) ------------------------------------------------------
+@pytest.mark.asyncio
+async def test_conditional_no_inject_when_token_stale(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_expired())
+    _write_token(token_file, present=True, age_days=400)  # past ~1yr life
+    _patch_probe(monkeypatch, logged_out=True)
+    assert await login_gate._decide() is None
+
+
+# --- off / unknown lever (fail-closed) --------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_off_never_injects(_isolated, monkeypatch):
     config_dir, token_file = _isolated
-    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)))
+    _write_creds(config_dir, refresh_expires_ms=_expired())
     _write_token(token_file, present=True)
     _patch_probe(monkeypatch, logged_out=True)
     monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "off")
-    assert await login_gate._should_inject() is False
+    assert await login_gate._decide() is None
 
 
-# --- always (force onto token, bypass login gate) ---------------------------
+@pytest.mark.asyncio
+async def test_unknown_lever_fails_closed(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_expired())
+    _write_token(token_file, present=True)
+    _patch_probe(monkeypatch, logged_out=True)
+    monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "of")  # typo of "off"
+    assert await login_gate._decide() is None
+
+
+# --- competing-auth exclusion (invoker parity) ------------------------------
+
+
+@pytest.mark.parametrize("var", login_gate._COMPETING_AUTH_ENV)
+@pytest.mark.asyncio
+async def test_competing_auth_blocks_injection(_isolated, monkeypatch, var):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_expired())
+    _write_token(token_file, present=True)
+    _patch_probe(monkeypatch, logged_out=True)
+    monkeypatch.setenv(var, "something")
+    # Even in always mode (which bypasses the login gate), a competing auth blocks.
+    monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "always")
+    assert await login_gate._decide() is None
+
+
+# --- always mode ------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_always_injects_regardless_of_live_login(_isolated, monkeypatch):
     config_dir, token_file = _isolated
-    # Login is ALIVE — always mode still injects because a token exists.
-    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=5)))
+    _write_creds(config_dir, refresh_expires_ms=_future())  # login ALIVE
     _write_token(token_file, present=True)
     monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "always")
-    assert await login_gate._should_inject() is True
+    assert await login_gate._decide() == login_gate._NOTICE_ALWAYS
+
+
+@pytest.mark.asyncio
+async def test_always_refuses_stale_token(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_future())
+    _write_token(token_file, present=True, age_days=400)
+    monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "always")
+    assert await login_gate._decide() is None
 
 
 @pytest.mark.asyncio
 async def test_always_no_inject_when_no_token(_isolated, monkeypatch):
     config_dir, token_file = _isolated
-    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=5)))
+    _write_creds(config_dir, refresh_expires_ms=_future())
     _write_token(token_file, present=False)
     monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "always")
-    assert await login_gate._should_inject() is False
+    assert await login_gate._decide() is None
 
 
-# --- main() exit codes + fail-closed ---------------------------------------
+# --- main() exit codes + notice on stdout + fail-closed ---------------------
 
 
-def test_main_returns_1_when_not_injecting(_isolated, monkeypatch):
+def test_main_returns_1_when_not_injecting(_isolated, capsys):
     config_dir, token_file = _isolated
-    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=5)))
+    _write_creds(config_dir, refresh_expires_ms=_future())
     _write_token(token_file, present=True)
     assert login_gate.main() == 1
+    assert capsys.readouterr().out == ""  # nothing on stdout when not injecting
 
 
-def test_main_returns_0_when_injecting(_isolated, monkeypatch):
+def test_main_returns_0_and_prints_notice_when_injecting(_isolated, monkeypatch, capsys):
     config_dir, token_file = _isolated
-    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)))
+    _write_creds(config_dir, refresh_expires_ms=_expired())
     _write_token(token_file, present=True)
     _patch_probe(monkeypatch, logged_out=True)
     assert login_gate.main() == 0
+    assert login_gate._NOTICE_CONDITIONAL in capsys.readouterr().out
 
 
 def test_main_fails_closed_on_error(_isolated, monkeypatch):
-    # Any unexpected error in the decision path must NOT inject (status quo).
     async def _boom():
         raise RuntimeError("boom")
 
-    monkeypatch.setattr(login_gate, "_should_inject", _boom)
+    monkeypatch.setattr(login_gate, "_decide", _boom)
     assert login_gate.main() == 1

--- a/tests/test_cc/test_login_gate.py
+++ b/tests/test_cc/test_login_gate.py
@@ -125,6 +125,14 @@ async def test_conditional_no_inject_when_token_stale(_isolated, monkeypatch):
     assert await login_gate._decide() is None
 
 
+def test_conditional_notice_directs_restart_not_just_login():
+    # After a conditional inject, CLAUDE_CODE_OAUTH_TOKEN overrides /login for the
+    # process lifetime, so /login alone can't restore connectors — the notice MUST
+    # tell the user to restart the slot (parity with the always notice).
+    assert "restart" in login_gate._NOTICE_CONDITIONAL
+    assert "restart" in login_gate._NOTICE_ALWAYS
+
+
 # --- off / unknown lever (fail-closed) --------------------------------------
 
 
@@ -177,21 +185,24 @@ async def test_always_injects_regardless_of_live_login(_isolated, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_always_refuses_stale_token(_isolated, monkeypatch):
+async def test_always_refuses_stale_token(_isolated, monkeypatch, capsys):
     config_dir, token_file = _isolated
     _write_creds(config_dir, refresh_expires_ms=_future())
     _write_token(token_file, present=True, age_days=400)
     monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "always")
     assert await login_gate._decide() is None
+    # always mode must EXPLAIN why it did not inject (parity with other branches).
+    assert "past its ~1-year life" in capsys.readouterr().err
 
 
 @pytest.mark.asyncio
-async def test_always_no_inject_when_no_token(_isolated, monkeypatch):
+async def test_always_no_inject_when_no_token(_isolated, monkeypatch, capsys):
     config_dir, token_file = _isolated
     _write_creds(config_dir, refresh_expires_ms=_future())
     _write_token(token_file, present=False)
     monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "always")
     assert await login_gate._decide() is None
+    assert "no setup-token is stored" in capsys.readouterr().err
 
 
 # --- main() exit codes + notice on stdout + fail-closed ---------------------

--- a/tests/test_cc/test_login_gate.py
+++ b/tests/test_cc/test_login_gate.py
@@ -1,0 +1,164 @@
+"""Tests for the interactive-slot OAuth decision gate (genesis.cc.login_gate).
+
+The gate is the CLI that scripts/cc-slot.sh runs on slot CREATE to decide
+whether to inject the stored setup-token. It reuses
+login_health.fallback_env_if_login_dead as the single decision authority, so
+these tests exercise the lever branches + the login-dead-conditional path
+through that shared gate.
+
+Isolation notes:
+- CLAUDE_CONFIG_DIR is pointed at tmp so credentials.json is per-test.
+- login_health._TOKEN_FILE is monkeypatched (NOT read_fallback_token), because
+  fallback_env_if_login_dead captured read_fallback_token as a default arg at
+  import time — patching the file makes the REAL reader read our fixture, which
+  is exactly the path the gate takes (it never passes token_reader).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from genesis.cc import login_gate, login_health
+
+
+def _ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+def _write_creds(config_dir, *, refresh_expires_ms: int | None) -> None:
+    oauth: dict = {}
+    if refresh_expires_ms is not None:
+        oauth["refreshTokenExpiresAt"] = refresh_expires_ms
+    (config_dir / ".credentials.json").write_text(
+        json.dumps({"claudeAiOauth": oauth}),
+    )
+
+
+def _write_token(path, *, present: bool) -> None:
+    if present:
+        path.write_text(
+            "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-testtoken\n"
+            "GENESIS_CC_TOKEN_CREATED_AT=1700000000\n",
+        )
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    """Per-test credentials.json + token file; clear the probe cache."""
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    monkeypatch.delenv("GENESIS_CC_SLOT_OAUTH", raising=False)
+    token_file = tmp_path / "cc_oauth_token.env"
+    monkeypatch.setattr(login_health, "_TOKEN_FILE", token_file)
+    login_health.reset_probe_cache()
+    return tmp_path, token_file
+
+
+def _patch_probe(monkeypatch, *, logged_out: bool) -> None:
+    async def _probe(cc_path: str = "claude") -> bool:
+        return logged_out
+
+    monkeypatch.setattr(login_health, "probe_logged_out", _probe)
+
+
+# --- conditional mode (the default / chosen model) -------------------------
+
+
+@pytest.mark.asyncio
+async def test_conditional_no_inject_when_login_alive(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=5)))
+    _write_token(token_file, present=True)
+    _patch_probe(monkeypatch, logged_out=True)  # even if probe would say out
+    assert await login_gate._should_inject() is False
+
+
+@pytest.mark.asyncio
+async def test_conditional_injects_when_expired_and_logged_out(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)))
+    _write_token(token_file, present=True)
+    _patch_probe(monkeypatch, logged_out=True)
+    assert await login_gate._should_inject() is True
+
+
+@pytest.mark.asyncio
+async def test_conditional_no_inject_when_probe_ambiguous(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)))
+    _write_token(token_file, present=True)
+    _patch_probe(monkeypatch, logged_out=False)  # not confirmed logged-out
+    assert await login_gate._should_inject() is False
+
+
+@pytest.mark.asyncio
+async def test_conditional_no_inject_when_no_token(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)))
+    _write_token(token_file, present=False)
+    _patch_probe(monkeypatch, logged_out=True)
+    assert await login_gate._should_inject() is False
+
+
+# --- off (kill switch) ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_off_never_injects(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)))
+    _write_token(token_file, present=True)
+    _patch_probe(monkeypatch, logged_out=True)
+    monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "off")
+    assert await login_gate._should_inject() is False
+
+
+# --- always (force onto token, bypass login gate) ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_always_injects_regardless_of_live_login(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    # Login is ALIVE — always mode still injects because a token exists.
+    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=5)))
+    _write_token(token_file, present=True)
+    monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "always")
+    assert await login_gate._should_inject() is True
+
+
+@pytest.mark.asyncio
+async def test_always_no_inject_when_no_token(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=5)))
+    _write_token(token_file, present=False)
+    monkeypatch.setenv("GENESIS_CC_SLOT_OAUTH", "always")
+    assert await login_gate._should_inject() is False
+
+
+# --- main() exit codes + fail-closed ---------------------------------------
+
+
+def test_main_returns_1_when_not_injecting(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) + timedelta(days=5)))
+    _write_token(token_file, present=True)
+    assert login_gate.main() == 1
+
+
+def test_main_returns_0_when_injecting(_isolated, monkeypatch):
+    config_dir, token_file = _isolated
+    _write_creds(config_dir, refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)))
+    _write_token(token_file, present=True)
+    _patch_probe(monkeypatch, logged_out=True)
+    assert login_gate.main() == 0
+
+
+def test_main_fails_closed_on_error(_isolated, monkeypatch):
+    # Any unexpected error in the decision path must NOT inject (status quo).
+    async def _boom():
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(login_gate, "_should_inject", _boom)
+    assert login_gate.main() == 1

--- a/tests/test_cc/test_login_health.py
+++ b/tests/test_cc/test_login_health.py
@@ -32,6 +32,9 @@ def _ms(dt: datetime) -> int:
 @pytest.fixture(autouse=True)
 def _isolated_config(tmp_path, monkeypatch):
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path))
+    # Point the token file at tmp so the staleness check (fallback_token_is_stale)
+    # never reads the real ~/.genesis token — hermetic + no wall-clock time-bomb.
+    monkeypatch.setattr(login_health, "_TOKEN_FILE", tmp_path / "cc_oauth_token.env")
     login_health.reset_probe_cache()
     return tmp_path
 
@@ -125,6 +128,48 @@ async def test_no_token_file_no_injection(tmp_path):
     env = await login_health.fallback_env_if_login_dead(
         probe=confirmed_out,
         token_reader=lambda: None,
+    )
+    assert env is None
+
+
+def _write_token_file(tmp_path, *, created_age_days: float | None) -> None:
+    lines = ["CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-x"]
+    if created_age_days is not None:
+        created = int((datetime.now(UTC) - timedelta(days=created_age_days)).timestamp())
+        lines.append(f"GENESIS_CC_TOKEN_CREATED_AT={created}")
+    (tmp_path / "cc_oauth_token.env").write_text("\n".join(lines) + "\n")
+
+
+def test_fallback_token_created_at_and_staleness(tmp_path):
+    # Fresh token → readable created_at, not stale.
+    _write_token_file(tmp_path, created_age_days=10)
+    assert login_health.fallback_token_created_at() is not None
+    assert login_health.fallback_token_is_stale() is False
+    # Past ~1yr → stale.
+    _write_token_file(tmp_path, created_age_days=400)
+    assert login_health.fallback_token_is_stale() is True
+    # Unknown created_at (field absent) → NOT stale (never block on ambiguity).
+    _write_token_file(tmp_path, created_age_days=None)
+    assert login_health.fallback_token_created_at() is None
+    assert login_health.fallback_token_is_stale() is False
+
+
+@pytest.mark.asyncio
+async def test_no_injection_when_token_is_stale(tmp_path):
+    """Login dead + confirmed logged-out + token present, but the setup-token is
+    itself past its ~1-year life → do NOT inject a known-dead credential."""
+    _write_creds(
+        tmp_path,
+        refresh_expires_ms=_ms(datetime.now(UTC) - timedelta(hours=1)),
+    )
+
+    async def confirmed_out():
+        return True
+
+    env = await login_health.fallback_env_if_login_dead(
+        probe=confirmed_out,
+        token_reader=lambda: "tok-x",
+        token_is_stale=lambda: True,
     )
     assert env is None
 

--- a/tests/test_scripts/test_cc_slot_oauth.py
+++ b/tests/test_scripts/test_cc_slot_oauth.py
@@ -1,12 +1,11 @@
 """Guards for the cc-slot.sh OAuth-durability wiring (WS-1).
 
-Two layers:
-- static asserts that the gate is wired the safe way (venv python, reattach-
-  gated, single-var extraction, NO token via `tmux -e`);
-- a dynamic test that pulls the ACTUAL `_OAUTH_SRC` prefix line out of the
-  script and runs it, proving the token is not materialized when the string is
-  built (no argv/ps leak) but IS exported when the pane shell runs it, and that
-  the second var in the token file does not leak into the env.
+Static asserts that the gate is wired the safe way (venv python, lever handed
+via env, reattach/--bare skip, gate-authored notice captured from stdout, token
+read with the SAME parser as the decision, non-empty export guard, NO token via
+`tmux -e`), plus a dynamic test that runs the ACTUAL `_OAUTH_SRC` line and proves
+the token is not materialized when the string is built (no argv/ps leak) but IS
+exported when the pane shell runs it, with the notice on stderr only.
 
 The full launch path (exec tmux) is covered by the live E2E slot test, not here.
 """
@@ -14,12 +13,14 @@ The full launch path (exec tmux) is covered by the live E2E slot test, not here.
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 _REPO = Path(__file__).resolve().parents[2]
 _CC_SLOT = _REPO / "scripts" / "cc-slot.sh"
+_SRC = _REPO / "src"
 
 
 @pytest.fixture(scope="module")
@@ -27,129 +28,131 @@ def script_text() -> str:
     return _CC_SLOT.read_text()
 
 
-def test_gate_wired_via_venv_python(script_text):
-    # Must call the gate through the venv interpreter (cc-slot.sh's PATH has no
-    # venv, so bare `python` would be genesis-less and fail).
+def test_gate_wired_via_venv_python_with_env_lever(script_text):
     assert '/.venv/bin/python" -m genesis.cc.login_gate' in script_text
-    assert "genesis.cc.login_gate" in script_text
+    # The resolved lever is handed to the subprocess (a non-exported cc-slot.env
+    # var would otherwise never reach it).
+    assert 'env GENESIS_CC_SLOT_OAUTH="$_slot_oauth_mode"' in script_text
 
 
-def test_gate_skipped_on_reattach(script_text):
-    # Reattach (session already exists) must not run the gate.
-    assert "_SESSION_EXISTS" in script_text
+def test_notice_captured_from_gate_stdout(script_text):
+    # The gate authors the notice (single authority) — cc-slot captures it.
+    assert "_oauth_notice=$(timeout 30 env GENESIS_CC_SLOT_OAUTH=" in script_text
+    # No hard-coded notice branch in bash anymore.
+    assert 'if [ "$_slot_oauth_mode" = "always" ]; then' not in script_text
+
+
+def test_gate_skipped_on_reattach_and_bare(script_text):
     assert '[ "$_SESSION_EXISTS" = "0" ]' in script_text
-
-
-def test_bare_slots_skip_injection(script_text):
-    # --bare ignores the token, so injection must be skipped there.
-    assert "_HAS_BARE" in script_text
+    assert '[ "$_HAS_BARE" = "0" ]' in script_text
     assert '"--bare"' in script_text
 
 
-def test_single_var_extraction_not_full_source(script_text):
-    # Extract ONLY the token var (S2) — never `. source` the whole file.
-    assert "sed -n 's/^CLAUDE_CODE_OAUTH_TOKEN=//p'" in script_text
+def test_pane_uses_same_parser_not_sed(script_text):
+    # Single parser: pane reads via login_health.read_fallback_token, NOT a
+    # divergent sed/whole-file source.
+    assert "read_fallback_token" in script_text
+    assert "sed -n 's/^CLAUDE_CODE_OAUTH_TOKEN=" not in script_text
     assert ". ~/.genesis/cc_oauth_token.env" not in script_text
-    assert ". $HOME/.genesis/cc_oauth_token.env" not in script_text
+
+
+def test_non_empty_export_guard(script_text):
+    # Never export a blank credential if the read fails/empties. (The guard lives
+    # inside the double-quoted _OAUTH_SRC assignment, so it is backslash-escaped
+    # in the file.)
+    assert r"if [ -n \"\$_gt\" ]; then export CLAUDE_CODE_OAUTH_TOKEN=" in script_text
 
 
 def test_no_token_leak_via_tmux_e(script_text):
-    # The token must NEVER be passed as a `tmux -e` value (would land in argv/ps).
     assert '-e "CLAUDE_CODE_OAUTH_TOKEN' not in script_text
     assert "-e CLAUDE_CODE_OAUTH_TOKEN" not in script_text
 
 
 def test_pane_command_interpolates_oauth_prefix(script_text):
-    # The pane command string must include the prefix before `claude`.
     assert "${_OAUTH_SRC}claude " in script_text
-
-
-def test_gate_receives_lever_via_env(script_text):
-    # A plain `GENESIS_CC_SLOT_OAUTH=always` in cc-slot.env is a non-exported
-    # shell var; the gate subprocess must be handed the resolved mode explicitly
-    # via `env`, or `always` silently degrades to `conditional`.
-    assert 'env GENESIS_CC_SLOT_OAUTH="$_slot_oauth_mode"' in script_text
 
 
 def _extract_oauth_src_line(script_text: str) -> str:
     for line in script_text.splitlines():
-        if line.lstrip().startswith('_OAUTH_SRC="if'):
+        if line.lstrip().startswith('_OAUTH_SRC="_gt='):
             return line.strip()
     raise AssertionError("could not find the _OAUTH_SRC assignment in cc-slot.sh")
 
 
-def test_prefix_defers_build_and_exports_in_pane(tmp_path, script_text):
-    """Run the ACTUAL prefix line: no build-time leak, correct pane export."""
-    home = tmp_path
-    (home / ".genesis").mkdir()
-    (home / ".genesis" / "cc_oauth_token.env").write_text(
-        "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-DYNTOKEN\nGENESIS_CC_TOKEN_CREATED_AT=1700000000\n",
-    )
-    oauth_src_line = _extract_oauth_src_line(script_text)
+def _pane_line(script_text: str) -> str:
+    """The real _OAUTH_SRC line with the venv python swapped for this test's
+    interpreter (so the pane subprocess can import genesis via PYTHONPATH)."""
+    line = _extract_oauth_src_line(script_text)
+    return line.replace("${GENESIS_ROOT}/.venv/bin/python", sys.executable)
 
-    harness = f"""
-set -u
-_oauth_notice="Genesis: test notice, no connectors"
-_notice_q=$(printf '%q' "$_oauth_notice")
-{oauth_src_line}
-# 1) build-time: the token value must NOT appear in the built string
-case "$_OAUTH_SRC" in
-  *DYNTOKEN*) echo "BUILD_LEAK"; exit 3;;
-esac
-# 2) pane execution: run the prefix, then report the resulting env
-eval "$_OAUTH_SRC"
-printf 'TOKEN=[%s]\\n' "${{CLAUDE_CODE_OAUTH_TOKEN:-}}"
-printf 'CREATED=[%s]\\n' "${{GENESIS_CC_TOKEN_CREATED_AT:-}}"
-"""
-    proc = subprocess.run(
-        ["bash", "-c", harness],
+
+def _run_pane(harness_body: str, home: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", harness_body],
         cwd=str(home),
-        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin", "PYTHONPATH": str(_SRC)},
         capture_output=True,
         text=True,
     )
-    assert proc.returncode == 0, f"harness failed: {proc.stdout}\n{proc.stderr}"
-    assert "BUILD_LEAK" not in proc.stdout, "token materialized when building the string"
-    assert "TOKEN=[sk-ant-oat-DYNTOKEN]" in proc.stdout, proc.stdout
-    # The second var in the file must NOT be exported (single-var extraction).
-    assert "CREATED=[]" in proc.stdout, proc.stdout
-    # The notice goes to stderr, and must never contain the token value.
-    assert "sk-ant-oat-DYNTOKEN" not in proc.stderr
 
 
-def test_notice_text_cannot_inject_shell(tmp_path, script_text):
-    """A notice string with quotes/`/$ must never break out of the command.
-
-    Regression guard for the %q hardening: even if a future edit gives the
-    notice a `"`/backtick/`$`-laden value, building + running the real
-    _OAUTH_SRC line must NOT execute an injected command. Seeds a payload that
-    would `touch` a canary and asserts the canary never appears.
-    """
+def test_prefix_defers_build_and_exports_in_pane(tmp_path, script_text):
     home = tmp_path
     (home / ".genesis").mkdir()
     (home / ".genesis" / "cc_oauth_token.env").write_text(
         "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-DYNTOKEN\nGENESIS_CC_TOKEN_CREATED_AT=1\n",
     )
-    canary = home / "PWNED"
-    oauth_src_line = _extract_oauth_src_line(script_text)
-    # A malicious notice: closes a naive double-quote, runs a command, re-opens.
-    payload = f'evil"; touch {canary}; echo "$(touch {canary})`touch {canary}`'
+    pane_line = _pane_line(script_text)
+    harness = f"""
+set -u
+_oauth_notice="Genesis: test notice, no connectors"
+_notice_q=$(printf '%q' "$_oauth_notice")
+{pane_line}
+case "$_OAUTH_SRC" in *DYNTOKEN*) echo BUILD_LEAK; exit 3;; esac
+eval "$_OAUTH_SRC"
+printf 'TOKEN=[%s]\\n' "${{CLAUDE_CODE_OAUTH_TOKEN:-}}"
+"""
+    proc = _run_pane(harness, home)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert "BUILD_LEAK" not in proc.stdout, "token materialized when building the string"
+    assert "TOKEN=[sk-ant-oat-DYNTOKEN]" in proc.stdout, proc.stdout
+    assert "sk-ant-oat-DYNTOKEN" not in proc.stderr, "token leaked to stderr"
 
+
+def test_missing_token_does_not_export_blank(tmp_path, script_text):
+    home = tmp_path
+    (home / ".genesis").mkdir()  # no token file
+    pane_line = _pane_line(script_text)
+    harness = f"""
+set -u
+_oauth_notice="x"
+_notice_q=$(printf '%q' "$_oauth_notice")
+{pane_line}
+eval "$_OAUTH_SRC"
+printf 'TOKEN=[%s]\\n' "${{CLAUDE_CODE_OAUTH_TOKEN:-}}"
+"""
+    proc = _run_pane(harness, home)
+    assert "TOKEN=[]" in proc.stdout, proc.stdout  # non-empty guard held
+
+
+def test_notice_text_cannot_inject_shell(tmp_path, script_text):
+    """Regression for the %q hardening: a hostile notice must not execute."""
+    home = tmp_path
+    (home / ".genesis").mkdir()
+    (home / ".genesis" / "cc_oauth_token.env").write_text(
+        "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-DYNTOKEN\n",
+    )
+    canary = home / "PWNED"
+    pane_line = _pane_line(script_text)
+    payload = f'evil"; touch {canary}; echo "$(touch {canary})`touch {canary}`'
     harness = f"""
 set -u
 _oauth_notice={payload!r}
 _notice_q=$(printf '%q' "$_oauth_notice")
-{oauth_src_line}
+{pane_line}
 eval "$_OAUTH_SRC"
 printf 'TOKEN=[%s]\\n' "${{CLAUDE_CODE_OAUTH_TOKEN:-}}"
 """
-    proc = subprocess.run(
-        ["bash", "-c", harness],
-        cwd=str(home),
-        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
-        capture_output=True,
-        text=True,
-    )
+    proc = _run_pane(harness, home)
     assert not canary.exists(), "notice text injected a shell command (canary created)"
-    # The token export must still work despite the hostile notice.
     assert "TOKEN=[sk-ant-oat-DYNTOKEN]" in proc.stdout, proc.stdout

--- a/tests/test_scripts/test_cc_slot_oauth.py
+++ b/tests/test_scripts/test_cc_slot_oauth.py
@@ -69,14 +69,16 @@ def test_no_token_leak_via_tmux_e(script_text):
 
 
 def test_pane_command_interpolates_oauth_prefix(script_text):
-    assert "${_OAUTH_SRC}claude " in script_text
+    # The token-prep prefix runs BEFORE cd, leaving the `cd && claude` guard intact.
+    assert "${_OAUTH_SRC}cd ${GENESIS_ROOT} && claude " in script_text
 
 
-def test_claude_grouped_behind_cd_guard(script_text):
-    # `_OAUTH_SRC` ends in `;`, so without a brace group `cd $ROOT && <prefix>;
-    # claude` binds the `&&` to the prefix only and claude runs even if cd fails.
-    # The `{ ...; }` keeps claude under the cd-guard.
-    assert "cd ${GENESIS_ROOT} && { ${_OAUTH_SRC}claude " in script_text
+def test_claude_stays_under_cd_guard(script_text):
+    # `_OAUTH_SRC` ends in `;`. Placing it AFTER the `&&` (`cd $ROOT && <prefix>;
+    # claude`) would bind the `&&` to the prefix only and run claude even if cd
+    # fails. Keeping the prefix BEFORE cd preserves the original `cd && claude` guard.
+    assert "${_OAUTH_SRC}cd ${GENESIS_ROOT} && claude " in script_text
+    assert "&& { ${_OAUTH_SRC}claude" not in script_text  # not the brace-group shape
 
 
 def _extract_oauth_src_line(script_text: str) -> str:
@@ -143,9 +145,10 @@ printf 'TOKEN=[%s]\\n' "${{CLAUDE_CODE_OAUTH_TOKEN:-}}"
 
 
 def _extract_launch_line(script_text: str) -> str:
-    """The tmux pane-command argument (the `"cd ${GENESIS_ROOT} && …"` string)."""
+    """The tmux pane-command argument (the `"${_OAUTH_SRC}cd ${GENESIS_ROOT} && …"`
+    string)."""
     for line in script_text.splitlines():
-        if line.lstrip().startswith('"cd ${GENESIS_ROOT} &&'):
+        if line.lstrip().startswith('"${_OAUTH_SRC}cd ${GENESIS_ROOT} &&'):
             return line.strip()
     raise AssertionError("could not find the exec-tmux pane command in cc-slot.sh")
 

--- a/tests/test_scripts/test_cc_slot_oauth.py
+++ b/tests/test_scripts/test_cc_slot_oauth.py
@@ -1,0 +1,109 @@
+"""Guards for the cc-slot.sh OAuth-durability wiring (WS-1).
+
+Two layers:
+- static asserts that the gate is wired the safe way (venv python, reattach-
+  gated, single-var extraction, NO token via `tmux -e`);
+- a dynamic test that pulls the ACTUAL `_OAUTH_SRC` prefix line out of the
+  script and runs it, proving the token is not materialized when the string is
+  built (no argv/ps leak) but IS exported when the pane shell runs it, and that
+  the second var in the token file does not leak into the env.
+
+The full launch path (exec tmux) is covered by the live E2E slot test, not here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_CC_SLOT = _REPO / "scripts" / "cc-slot.sh"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return _CC_SLOT.read_text()
+
+
+def test_gate_wired_via_venv_python(script_text):
+    # Must call the gate through the venv interpreter (cc-slot.sh's PATH has no
+    # venv, so bare `python` would be genesis-less and fail).
+    assert '/.venv/bin/python" -m genesis.cc.login_gate' in script_text
+    assert "genesis.cc.login_gate" in script_text
+
+
+def test_gate_skipped_on_reattach(script_text):
+    # Reattach (session already exists) must not run the gate.
+    assert "_SESSION_EXISTS" in script_text
+    assert '[ "$_SESSION_EXISTS" = "0" ]' in script_text
+
+
+def test_bare_slots_skip_injection(script_text):
+    # --bare ignores the token, so injection must be skipped there.
+    assert "_HAS_BARE" in script_text
+    assert '"--bare"' in script_text
+
+
+def test_single_var_extraction_not_full_source(script_text):
+    # Extract ONLY the token var (S2) — never `. source` the whole file.
+    assert "sed -n 's/^CLAUDE_CODE_OAUTH_TOKEN=//p'" in script_text
+    assert ". ~/.genesis/cc_oauth_token.env" not in script_text
+    assert ". $HOME/.genesis/cc_oauth_token.env" not in script_text
+
+
+def test_no_token_leak_via_tmux_e(script_text):
+    # The token must NEVER be passed as a `tmux -e` value (would land in argv/ps).
+    assert '-e "CLAUDE_CODE_OAUTH_TOKEN' not in script_text
+    assert "-e CLAUDE_CODE_OAUTH_TOKEN" not in script_text
+
+
+def test_pane_command_interpolates_oauth_prefix(script_text):
+    # The pane command string must include the prefix before `claude`.
+    assert "${_OAUTH_SRC}claude " in script_text
+
+
+def _extract_oauth_src_line(script_text: str) -> str:
+    for line in script_text.splitlines():
+        if line.lstrip().startswith('_OAUTH_SRC="if'):
+            return line.strip()
+    raise AssertionError("could not find the _OAUTH_SRC assignment in cc-slot.sh")
+
+
+def test_prefix_defers_build_and_exports_in_pane(tmp_path, script_text):
+    """Run the ACTUAL prefix line: no build-time leak, correct pane export."""
+    home = tmp_path
+    (home / ".genesis").mkdir()
+    (home / ".genesis" / "cc_oauth_token.env").write_text(
+        "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-DYNTOKEN\nGENESIS_CC_TOKEN_CREATED_AT=1700000000\n",
+    )
+    oauth_src_line = _extract_oauth_src_line(script_text)
+
+    harness = f"""
+set -u
+_oauth_notice="Genesis: test notice, no connectors"
+{oauth_src_line}
+# 1) build-time: the token value must NOT appear in the built string
+case "$_OAUTH_SRC" in
+  *DYNTOKEN*) echo "BUILD_LEAK"; exit 3;;
+esac
+# 2) pane execution: run the prefix, then report the resulting env
+eval "$_OAUTH_SRC"
+printf 'TOKEN=[%s]\\n' "${{CLAUDE_CODE_OAUTH_TOKEN:-}}"
+printf 'CREATED=[%s]\\n' "${{GENESIS_CC_TOKEN_CREATED_AT:-}}"
+"""
+    proc = subprocess.run(
+        ["bash", "-c", harness],
+        cwd=str(home),
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"harness failed: {proc.stdout}\n{proc.stderr}"
+    assert "BUILD_LEAK" not in proc.stdout, "token materialized when building the string"
+    assert "TOKEN=[sk-ant-oat-DYNTOKEN]" in proc.stdout, proc.stdout
+    # The second var in the file must NOT be exported (single-var extraction).
+    assert "CREATED=[]" in proc.stdout, proc.stdout
+    # The notice goes to stderr, and must never contain the token value.
+    assert "sk-ant-oat-DYNTOKEN" not in proc.stderr

--- a/tests/test_scripts/test_cc_slot_oauth.py
+++ b/tests/test_scripts/test_cc_slot_oauth.py
@@ -83,6 +83,7 @@ def test_prefix_defers_build_and_exports_in_pane(tmp_path, script_text):
     harness = f"""
 set -u
 _oauth_notice="Genesis: test notice, no connectors"
+_notice_q=$(printf '%q' "$_oauth_notice")
 {oauth_src_line}
 # 1) build-time: the token value must NOT appear in the built string
 case "$_OAUTH_SRC" in
@@ -107,3 +108,41 @@ printf 'CREATED=[%s]\\n' "${{GENESIS_CC_TOKEN_CREATED_AT:-}}"
     assert "CREATED=[]" in proc.stdout, proc.stdout
     # The notice goes to stderr, and must never contain the token value.
     assert "sk-ant-oat-DYNTOKEN" not in proc.stderr
+
+
+def test_notice_text_cannot_inject_shell(tmp_path, script_text):
+    """A notice string with quotes/`/$ must never break out of the command.
+
+    Regression guard for the %q hardening: even if a future edit gives the
+    notice a `"`/backtick/`$`-laden value, building + running the real
+    _OAUTH_SRC line must NOT execute an injected command. Seeds a payload that
+    would `touch` a canary and asserts the canary never appears.
+    """
+    home = tmp_path
+    (home / ".genesis").mkdir()
+    (home / ".genesis" / "cc_oauth_token.env").write_text(
+        "CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat-DYNTOKEN\nGENESIS_CC_TOKEN_CREATED_AT=1\n",
+    )
+    canary = home / "PWNED"
+    oauth_src_line = _extract_oauth_src_line(script_text)
+    # A malicious notice: closes a naive double-quote, runs a command, re-opens.
+    payload = f'evil"; touch {canary}; echo "$(touch {canary})`touch {canary}`'
+
+    harness = f"""
+set -u
+_oauth_notice={payload!r}
+_notice_q=$(printf '%q' "$_oauth_notice")
+{oauth_src_line}
+eval "$_OAUTH_SRC"
+printf 'TOKEN=[%s]\\n' "${{CLAUDE_CODE_OAUTH_TOKEN:-}}"
+"""
+    proc = subprocess.run(
+        ["bash", "-c", harness],
+        cwd=str(home),
+        env={"HOME": str(home), "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+    assert not canary.exists(), "notice text injected a shell command (canary created)"
+    # The token export must still work despite the hostile notice.
+    assert "TOKEN=[sk-ant-oat-DYNTOKEN]" in proc.stdout, proc.stdout

--- a/tests/test_scripts/test_cc_slot_oauth.py
+++ b/tests/test_scripts/test_cc_slot_oauth.py
@@ -72,6 +72,13 @@ def test_pane_command_interpolates_oauth_prefix(script_text):
     assert "${_OAUTH_SRC}claude " in script_text
 
 
+def test_claude_grouped_behind_cd_guard(script_text):
+    # `_OAUTH_SRC` ends in `;`, so without a brace group `cd $ROOT && <prefix>;
+    # claude` binds the `&&` to the prefix only and claude runs even if cd fails.
+    # The `{ ...; }` keeps claude under the cd-guard.
+    assert "cd ${GENESIS_ROOT} && { ${_OAUTH_SRC}claude " in script_text
+
+
 def _extract_oauth_src_line(script_text: str) -> str:
     for line in script_text.splitlines():
         if line.lstrip().startswith('_OAUTH_SRC="_gt='):
@@ -133,6 +140,70 @@ printf 'TOKEN=[%s]\\n' "${{CLAUDE_CODE_OAUTH_TOKEN:-}}"
 """
     proc = _run_pane(harness, home)
     assert "TOKEN=[]" in proc.stdout, proc.stdout  # non-empty guard held
+
+
+def _extract_launch_line(script_text: str) -> str:
+    """The tmux pane-command argument (the `"cd ${GENESIS_ROOT} && …"` string)."""
+    for line in script_text.splitlines():
+        if line.lstrip().startswith('"cd ${GENESIS_ROOT} &&'):
+            return line.strip()
+    raise AssertionError("could not find the exec-tmux pane command in cc-slot.sh")
+
+
+def _run_cd_guard(script_text: str, root: str, canary: Path, fakebin: Path):
+    """Run the REAL pane launch string with a fake `claude` (touches the canary)
+    and a `;`-terminated _OAUTH_SRC (mimics the real prefix). Returns (rc, canary_exists).
+    """
+    launch = _extract_launch_line(script_text)
+    harness = f"""
+set -u
+export PATH="{fakebin}:/usr/bin:/bin"
+export CDGUARD_CANARY={str(canary)!r}
+GENESIS_ROOT={root!r}
+_OAUTH_SRC="export CDGUARD_PREFIX_RAN=1; "
+CC_PERM_FLAG=""
+CLAUDE_ARGS_Q=""
+SLOT="test"
+pane_cmd={launch}
+bash -c "$pane_cmd"
+echo "PANE_EXIT=$?"
+"""
+    proc = subprocess.run(
+        ["bash", "-c", harness],
+        capture_output=True,
+        text=True,
+    )
+    return proc, canary.exists()
+
+
+def test_cd_guard_skips_claude_on_bad_cd(tmp_path, script_text):
+    """With a `;`-terminated _OAUTH_SRC, a FAILED cd must not launch claude — and a
+    SUCCESSFUL cd must. Proves the `{ …; }` grouping (verify-RED vs the un-grouped
+    `cd && <prefix>; claude`, which runs claude regardless of cd)."""
+    fakebin = tmp_path / "bin"
+    fakebin.mkdir()
+    fake_claude = fakebin / "claude"
+    fake_claude.write_text('#!/usr/bin/env bash\ntouch "$CDGUARD_CANARY"\nexit 0\n')
+    fake_claude.chmod(0o755)
+
+    # bad cd → claude NOT run, pane exits with cd's failure code
+    canary_bad = tmp_path / "PANE_RAN_BAD"
+    proc_bad, ran_bad = _run_cd_guard(
+        script_text,
+        str(tmp_path / "does-not-exist"),
+        canary_bad,
+        fakebin,
+    )
+    assert not ran_bad, f"claude ran despite a failed cd\n{proc_bad.stdout}\n{proc_bad.stderr}"
+    assert "PANE_EXIT=0" not in proc_bad.stdout, proc_bad.stdout
+
+    # good cd → claude DOES run, pane exits 0
+    good_root = tmp_path / "good"
+    good_root.mkdir()
+    canary_good = tmp_path / "PANE_RAN_GOOD"
+    proc_good, ran_good = _run_cd_guard(script_text, str(good_root), canary_good, fakebin)
+    assert ran_good, f"claude did not run on a good cd\n{proc_good.stdout}\n{proc_good.stderr}"
+    assert "PANE_EXIT=0" in proc_good.stdout, proc_good.stdout
 
 
 def test_notice_text_cannot_inject_shell(tmp_path, script_text):

--- a/tests/test_scripts/test_cc_slot_oauth.py
+++ b/tests/test_scripts/test_cc_slot_oauth.py
@@ -64,6 +64,13 @@ def test_pane_command_interpolates_oauth_prefix(script_text):
     assert "${_OAUTH_SRC}claude " in script_text
 
 
+def test_gate_receives_lever_via_env(script_text):
+    # A plain `GENESIS_CC_SLOT_OAUTH=always` in cc-slot.env is a non-exported
+    # shell var; the gate subprocess must be handed the resolved mode explicitly
+    # via `env`, or `always` silently degrades to `conditional`.
+    assert 'env GENESIS_CC_SLOT_OAUTH="$_slot_oauth_mode"' in script_text
+
+
 def _extract_oauth_src_line(script_text: str) -> str:
     for line in script_text.splitlines():
         if line.lstrip().startswith('_OAUTH_SRC="if'):


### PR DESCRIPTION
## Problem

Interactive Claude Code "slot" sessions (`scripts/cc-slot.sh` tmux panes) hit a
forced re-login whenever the stored `/login` refresh token reaches its fixed
lifetime — the credential can't be refreshed past that point, so every request
fails until an interactive `/login`. The autonomous `CCInvoker` path already
self-heals (`login_health.fallback_env_if_login_dead`), but interactive slots
consumed none of it, so a human sitting in a slot got the re-login wall.

## Solution — login-dead-conditional

Wire the *same* shared gate into slot launch. Inject the stored long-lived
setup-token (`CLAUDE_CODE_OAUTH_TOKEN`, from `~/.genesis/cc_oauth_token.env`)
**only** when the primary login is hard-dead *and* a live `claude auth status`
probe confirms logged-out. While the login is alive the env var is simply
absent, so per CC's documented auth precedence the session uses `/login` and
keeps Remote Control / claude.ai connectors; those are unavailable anyway once
the login dies (local MCP servers keep working under token auth).

## Changes

- **`src/genesis/cc/login_gate.py`** (new) — decision CLI (`exit 0`=inject,
  `1`=don't; fails closed). Reuses `fallback_env_if_login_dead` as the single
  decision authority — no reimplemented login-dead logic. Lever
  `GENESIS_CC_SLOT_OAUTH=conditional`(default)`|always|off`.
- **`scripts/cc-slot.sh`** — runs the gate on slot CREATE only (skips reattach
  and `--bare`); calls the venv interpreter explicitly; reads the token **inside
  the pane shell** via single-var extraction (never on any process argv/`ps`, no
  whole-file `source`); prints a lever-aware connectors-off notice to stderr,
  `%q`-escaped so the notice text can't break out of the command string.
- **`docs/architecture/shared-artifacts.md`** — registers `cc-slot.sh` as a
  reader of `cc_oauth_token.env` (keeps the CI consumer-drift guard accurate).
- **Tests** — gate lever/branch matrix; cc-slot static wiring + a dynamic
  no-leak/export check and a shell-injection regression, both bound to the real
  extracted script line.

## Safety / scope

- Token is never placed on argv/`ps`/`/proc/<pid>/cmdline` — only in the pane
  process environment (same-uid, the operator's own interactive session; local
  MCP children only, no cross-session/peer/third-party path).
- Fails closed: any gate error → no injection → status-quo behavior. Never
  injects over a working or ambiguous login.
- Scope is interactive slots only; the autonomous invoker path is unchanged.
- Interactive sessions honoring `CLAUDE_CODE_OAUTH_TOKEN` is the CLI's
  documented auth-precedence behavior; validated with a live slot post-deploy.
