### PR TITLE
chore(cc): trim redundant SessionStart context injection

### DIFF
--- a/.claude/hooks/cbm-session-reminder.sh
+++ b/.claude/hooks/cbm-session-reminder.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Code intelligence session reminder — lists available tool layers.
 #
-# Fires on SessionStart (startup/resume/clear/compact).
+# Fires on SessionStart (startup/resume/clear).
 # Informational only, points to the full decision guide.
 
 cat << 'REMINDER'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,7 @@
                 ]
             },
             {
-                "matcher": "startup|resume|clear|compact",
+                "matcher": "startup|resume|clear",
                 "hooks": [
                     {
                         "type": "command",

--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -629,20 +629,24 @@ def main() -> None:
             lines = ["## Genesis Capabilities\n"]
             for cname, cinfo in caps.items():
                 cstatus = cinfo.get("status", "unknown")
-                cdesc = cinfo.get("description", cname)
+                cdesc = cinfo.get("description") or ""
+                # Drop the description when it's absent or merely repeats the
+                # capability name: a registry entry with no real description
+                # renders as "reflex: reflex" (or, namespaced, "module:architect:
+                # architect") — pure noise. The name still lists.
+                _cname_tail = cname.split(":")[-1]
+                desc_part = f": {cdesc}" if cdesc and cdesc not in (cname, _cname_tail) else ""
                 if cstatus == "active":
-                    lines.append(f"- **{cname}**: {cdesc}")
+                    lines.append(f"- **{cname}**{desc_part}")
                 else:
                     cerr = cinfo.get("error", "")
                     suffix = f" — Error: {cerr}" if cerr else ""
-                    lines.append(f"- **{cname}** [{cstatus}]: {cdesc}{suffix}")
+                    lines.append(f"- **{cname}** [{cstatus}]{desc_part}{suffix}")
+            # The full MCP tool list is injected separately by CC; a hardcoded
+            # partial list here is redundant + goes stale, so only the Skill
+            # Library pointer (not injected elsewhere) is kept.
             lines.append(
-                "\n**MCP Tools:** memory_recall/memory_store, "
-                "health_status/health_errors/health_alerts, "
-                "session_config, "
-                "outreach_queue/outreach_digest, recon tools, "
-                "bookmark_shelve/bookmark_unshelve.\n\n"
-                "**Skill Library:** Browse `src/genesis/skills/` or "
+                "\n**Skill Library:** Browse `src/genesis/skills/` or "
                 "`~/.genesis/skill-library/` for specialized skills "
                 "(research, outreach, browser automation, etc.). "
                 "The skill injection hook nudges you when one matches."


### PR DESCRIPTION
## What

Three zero-information-loss trims to the SessionStart context injection, reducing
per-session token cost without touching any behavior-shaping content. Surfaced by a
context-bloat measurement of the injected context (follow-up `ecaeb44f`, the low-risk
mechanical tier).

- **Capability render** (`scripts/genesis_session_context.py`): drop the description
  when it is absent or merely repeats the capability name — or its namespaced tail. A
  registry entry with no real description rendered `reflex: reflex` /
  `module:architect: architect` (pure noise). Every capability still lists (name-only
  when it has no real description); **none dropped** (41 → 41).
- **Remove the hardcoded `MCP Tools:` one-liner**: a stale partial list of ~10 of 181
  tools, redundant with the tool schemas the client injects and the `Tools` section
  above it. The Skill Library pointer (not injected elsewhere) is retained.
- **Drop `compact` from the `cbm-session-reminder` SessionStart matcher**
  (`.claude/settings.json`): the code-intelligence banner is fully covered by the Code
  Intelligence section that is re-injected on compaction, so re-firing it every
  compaction is redundant. The capability/context block itself still fires on compact,
  so nothing else is lost.

## Impact

~110–130 tokens/SessionStart + ~185 tokens/compaction. Small by design — the larger
savings live in behavior-shaping content files, intentionally left untouched here
(they need separate review).

## Verification

- Render measured against the live capability registry: 41 → 41 capabilities, 9
  name-repeating descriptions collapsed to name-only, `MCP Tools:` line removed.
- Settings JSON re-parses valid; matcher isolated to the single `cbm-session-reminder`
  entry (sibling hooks unaffected).
- ruff clean; 41 session_context tests pass.
- Independent adversarial review: no CRITICAL/HIGH findings; the one NOTE
  (namespaced-tail self-repeats) is folded into this change.

Part of the context-bloat report follow-up (`ecaeb44f`) — the mechanical tier only;
the follow-up stays open for the content-file decisions.
