### PR TITLE
fix(hooks): full-suite guard consumes path-valued pytest flags (no false block)

### DIFF
--- a/scripts/hooks/full_suite_guard.py
+++ b/scripts/hooks/full_suite_guard.py
@@ -14,10 +14,12 @@ is not misread as a run.
 Allowed:
   - pytest tests/foo/test_bar.py            (a specific file / nodeid)
   - pytest tests/foo -k test_bar            (a -k/-m selector narrows the run)
+  - pytest tests/foo.py --basetemp /wt      (a path-valued flag's value is not a target)
   - pytest tests/ -q  # full-suite-ok       (explicit override)
 Blocked:
   - pytest -v                               (no path at all)
   - python -m pytest tests/test_scripts/    (a whole directory)
+  - pytest tests/foo.py tests/              (a file + a whole dir still runs the dir)
 """
 
 from __future__ import annotations
@@ -38,23 +40,38 @@ from shell_parse import (  # noqa: E402
 
 _OVERRIDE = "full-suite-ok"
 
-# pytest flags that consume the FOLLOWING token as their value (so that value is
-# not a positional path). Non-exhaustive but covers the common ones; an unlisted
-# value-flag only risks fail-OPEN (not blocking), never a wrong block.
+# pytest flags that consume the FOLLOWING token as their value, so that value is not
+# mistaken for a positional. This matters because _targets_specific_test blocks on a
+# bare-directory positional: a path/glob-valued flag's separate-token value
+# (``--basetemp /wt``, ``--doctest-glob '*.py'``) would otherwise look like a directory
+# (a WRONG block) or a .py file (a FAIL-OPEN). The path/glob-valued built-ins below are
+# taken from ``pytest --help``. Non-exhaustive BY DESIGN: an UNLISTED value-flag whose
+# separate-token value is a non-.py string falls back to a safe BLOCK (a false-block,
+# overridable with ``# full-suite-ok``) — never a fail-open. The one fail-open risk is a
+# value ENDING in .py, so the .py-glob flag ``--doctest-glob`` is listed explicitly.
 _VALUE_FLAGS = {
+    # config + common plugin flags (values are not paths)
     "-p",
-    "--tb",
-    "--timeout",
-    "--rootdir",
     "-c",
     "-W",
-    "--override-ini",
     "-o",
+    "-n",
+    "--tb",
+    "--timeout",
+    "--override-ini",
     "--deselect",
+    "--maxfail",
+    # path / dir / glob-valued built-ins (pytest --help) — the false-block-prone ones
+    "--rootdir",
+    "--basetemp",
+    "--confcutdir",
+    "--config-file",
     "--ignore",
     "--ignore-glob",
-    "--maxfail",
-    "-n",
+    "--doctest-glob",
+    "--junit-xml",
+    "--junitxml",
+    "--log-file",
 }
 
 
@@ -75,7 +92,12 @@ def _targets_specific_test(args: list[str]) -> bool:
 
     Targeted = a -k/-m/--pyargs selector, OR at least one specific .py file/nodeid
     and NO bare-directory positional. A file mixed with a directory
-    (``pytest tests/foo.py tests/``) still runs the whole directory, so it blocks.
+    (``pytest tests/foo.py tests/``) still runs the WHOLE directory — pytest UNIONS
+    positionals, so a named file does not narrow the run; it remains the OOM-inducing
+    full run this guard exists to stop, and therefore blocks. Distinguishing a real
+    directory positional from a value-flag's path value (``--basetemp /wt``) is the job
+    of ``_VALUE_FLAGS`` (which consumes the value); an unlisted value-flag falls back to
+    a safe BLOCK, never a fail-open (see the ``_VALUE_FLAGS`` note).
     """
     has_selector = False
     has_file = False

--- a/tests/test_hooks/test_full_suite_guard.py
+++ b/tests/test_hooks/test_full_suite_guard.py
@@ -70,9 +70,24 @@ class TestTargetsSpecificTest:
         assert _mod._targets_specific_test(["--pyargs", "genesis.tests.test_mod"])
 
     def test_file_mixed_with_dir_not_targeted(self):
-        # a specific file AND a bare directory still runs the whole directory → block
+        # a specific file AND a bare directory still runs the WHOLE directory (pytest
+        # unions positionals) → the OOM-inducing full run → block.
         assert not _mod._targets_specific_test(["tests/foo.py", "tests/"])
         assert not _mod._targets_specific_test(["tests/", "tests/foo.py"])
+
+    def test_value_flag_path_value_then_file_allowed(self):
+        # A path/glob-valued flag now in _VALUE_FLAGS (--basetemp/--confcutdir) consumes
+        # its value, so the value is NOT mistaken for a directory positional and does not
+        # wrongly block a run that names a real .py file. (The friction bug this PR fixes.)
+        assert _mod._targets_specific_test(["tests/foo.py", "--basetemp", "/wt/.pytmp"])
+        assert _mod._targets_specific_test(["--confcutdir", "/wt", "tests/foo.py"])
+
+    def test_value_flag_dotpy_value_alone_still_blocks(self):
+        # _VALUE_FLAGS earns its keep on the fail-OPEN direction too: a value ENDING in
+        # .py (`-p foo.py`, `--doctest-glob '*.py'`) is the flag's value, not a test
+        # target, so a bare run must still BLOCK — the value must not fake a `.py` file.
+        assert not _mod._targets_specific_test(["-p", "foo.py"])
+        assert not _mod._targets_specific_test(["--doctest-glob", "*.py"])
 
     def test_selector_with_dir_still_targeted(self):
         # a -k/-m selector narrows the run even when a directory is present
@@ -145,5 +160,26 @@ class TestEndToEnd:
         assert r.returncode == 0, r.stderr
 
     def test_file_plus_dir_blocks(self):
-        # a file mixed with a whole directory runs the dir → must block
+        # a file mixed with a whole directory runs the dir (pytest unions positionals)
+        # → the OOM full run → must block (would fail-OPEN under `has_selector or has_file`).
         assert _run_guard("pytest tests/foo/test_bar.py tests/").returncode == 2
+
+    def test_doctest_glob_py_value_with_dir_blocks(self):
+        # a .py-glob flag value must not fake a file target and let a whole-dir run pass:
+        # --doctest-glob consumes '*.py', leaving a bare tests/ directory run → block.
+        assert _run_guard("pytest --doctest-glob '*.py' tests/").returncode == 2
+
+    def test_value_flag_path_then_file_allowed_e2e(self):
+        # the friction bug end-to-end: a path-valued flag (--basetemp) no longer
+        # false-blocks a run that names a specific file.
+        r = _run_guard("pytest tests/test_hooks/test_full_suite_guard.py --basetemp /tmp/x")
+        assert r.returncode == 0, r.stderr
+
+    def test_redirect_then_file_allowed(self):
+        # post-#1455 a redirect (2>&1) is stripped from argv, so a named file still allows.
+        assert _run_guard("pytest tests/foo/test_bar.py 2>&1").returncode == 0
+
+    def test_redirect_target_py_no_file_still_blocks(self):
+        # post-#1455 the redirect TARGET (errors.py) is stripped from argv, so this is a
+        # bare pytest → BLOCK (no phantom .py file target).
+        assert _run_guard("pytest 2> errors.py").returncode == 2


### PR DESCRIPTION
## Problem
`full_suite_guard.py` blocks accidental full-suite / whole-directory local pytest runs (they OOM-starve the live services on this shared box). Its `_VALUE_FLAGS` set omitted pytest's **path/glob-valued** flags, so a separate-token value like `pytest tests/foo.py --basetemp /wt` left `/wt` as a stray positional → `has_dir=True` → `has_file and not has_dir` = `False` → the run was **wrongly blocked** even though it named a specific file. The `_VALUE_FLAGS` comment claiming "never a wrong block" was provably false.

## Fix
- **Keep** the proven block-on-directory rule `has_selector or (has_file and not has_dir)`. A named file mixed with a real directory (`pytest foo.py tests/`) still runs the **whole** directory — pytest unions positionals — so it must still block; that is the exact OOM run the guard exists to stop.
- **Complete** `_VALUE_FLAGS` with the path/glob-valued built-ins from `pytest --help`: `--basetemp`, `--confcutdir`, `--config-file`, `--doctest-glob`, `--junit-xml`/`--junitxml`, `--log-file` (joining the existing `--rootdir`/`--ignore`/`--ignore-glob`). A path-valued flag's value is now consumed, not mistaken for a directory positional.

## Fail direction (safe by design)
An **unlisted** value-flag whose separate-token value is a non-`.py` string falls back to a **BLOCK** (a false-block, overridable with `# full-suite-ok`) — never a fail-open. The one `.py`-value fail-open vector (`--doctest-glob '*.py'`) is closed by listing `--doctest-glob`.

Behavior matrix (live classifier):

| command | verdict |
|---|---|
| `pytest tests/foo.py --basetemp /wt` | ALLOW (bug fixed) |
| `pytest foo.py tests/` | BLOCK (whole-dir OOM run) |
| `pytest --doctest-glob '*.py' tests/` | BLOCK |
| `pytest --doctest-glob '*.py'` | BLOCK (no phantom file target) |
| `pytest tests/` / `pytest -v` | BLOCK |
| `pytest tests/foo.py` / `... -k x` | ALLOW |

## Design note
An independent adversarial review drove this: an earlier `has_selector or has_file` variant (drop `has_dir`) was **refuted** for re-opening the OOM hole on `pytest foo.py tests/` and `pytest --doctest-glob '*.py' tests/`, so the block-on-dir rule was retained and the fix moved to value-flag consumption.

## Tests
Verify-RED: with the rule restored but the flags absent, the 3 friction tests fail; adding the flags → **34/34 green**. The unsafe `file+dir → allow` tests were reverted to assert BLOCK, and a `--doctest-glob`-with-dir regression lock was added. `ruff --no-cache` clean.