### PR TITLE
fix(hooks): harden staleness-nudge throttle + SQLite-URI path encoding

### DIFF
--- a/scripts/genesis_urgent_alerts.py
+++ b/scripts/genesis_urgent_alerts.py
@@ -36,6 +36,7 @@ import sqlite3
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from urllib.request import pathname2url
 
 # Load secrets.env so USER_TIMEZONE and other env vars are available
 # before any genesis module imports (which may read os.environ at import time).
@@ -157,6 +158,20 @@ def _check_shelve_hint(prompt: str) -> None:
         sys.stdout.flush()
 
 
+def _ro_uri(db_path: Path) -> str:
+    """A WAL-aware read-only SQLite URI for ``db_path``, percent-encoding the path.
+
+    ``sqlite3.connect(f"file:{path}?mode=ro", uri=True)`` silently opens the WRONG
+    (empty) database if the filesystem path contains a URI-special char: a ``?`` or
+    ``#`` truncates the path there (verified — SQLite then reads a different file and
+    the query hits "no such table"), so the read fails closed to ``None`` on an install
+    whose repo path contains one. ``pathname2url`` percent-encodes the path (``?``→%3F,
+    ``#``→%23, space→%20, ``%``→%25); SQLite decodes it back, so the real DB opens.
+    Idempotent on an ordinary path (no special chars → unchanged).
+    """
+    return f"file:{pathname2url(str(db_path))}?mode=ro"
+
+
 def _emit_charter_tag(session_id: str) -> None:
     """One-line drift tag: [Charter: <mission|origin snippet> | open: N].
 
@@ -174,7 +189,7 @@ def _emit_charter_tag(session_id: str) -> None:
         db = (Path(root) if root else Path.home() / "genesis") / "data" / "genesis.db"
         if not db.exists():
             return
-        conn = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=0.5)
+        conn = sqlite3.connect(_ro_uri(db), uri=True, timeout=0.5)
         try:
             conn.execute("PRAGMA busy_timeout=300")
             row = conn.execute(
@@ -249,7 +264,7 @@ def _last_successful_deploy(db_path: Path) -> tuple[str, str] | None:
     if not db_path.exists():
         return None
     try:
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=0.5)
+        conn = sqlite3.connect(_ro_uri(db_path), uri=True, timeout=0.5)
         try:
             conn.execute("PRAGMA busy_timeout=300")
             row = conn.execute(
@@ -301,13 +316,21 @@ def _staleness_throttled(session_id: str, now: datetime) -> bool:
 
     Best-effort: an unreadable/absent/garbled marker → not throttled (emit),
     consistent with the fail-open posture (better a repeat nudge than a missed
-    stale-code warning)."""
+    stale-code warning). A marker timestamp in the FUTURE (clock stepped back, or a
+    hand-edited file) is likewise treated as NOT throttled: a negative elapsed is
+    always < cooldown, which would otherwise wedge the nudge OFF until wall-clock
+    catches up + a full cooldown — suppressing a genuine stale-code warning."""
     marker = _GENESIS_DIR / "sessions" / session_id / "staleness_last_nudge"
     try:
         last = datetime.fromisoformat(marker.read_text().strip())
-    except (OSError, ValueError):
+        elapsed = (now - last).total_seconds()
+    except (OSError, ValueError, TypeError):
+        # unreadable / garbled / tz-naive (aware-minus-naive raises TypeError) →
+        # not throttled (emit), fail-open toward surfacing the stale-code warning.
         return False
-    return (now - last).total_seconds() < _STALENESS_COOLDOWN_S
+    if elapsed < 0:
+        return False  # future marker → do not suppress; emit
+    return elapsed < _STALENESS_COOLDOWN_S
 
 
 def _record_staleness_nudge(session_id: str, now: datetime) -> bool:

--- a/tests/test_scripts/test_urgent_alerts_staleness_nudge.py
+++ b/tests/test_scripts/test_urgent_alerts_staleness_nudge.py
@@ -117,6 +117,25 @@ def test_last_deploy_missing_table(tmp_path):
     assert _ua._last_successful_deploy(root / "data" / "genesis.db") is None
 
 
+def test_ro_uri_encodes_special_chars_and_is_idempotent():
+    clean = "/home/u/genesis/data/genesis.db"
+    assert _ua._ro_uri(Path(clean)) == f"file:{clean}?mode=ro"  # ordinary path: unchanged
+    weird = _ua._ro_uri(Path("/a?b/c#d/genesis.db"))
+    assert weird.endswith("?mode=ro")
+    path_part = weird[len("file:") : -len("?mode=ro")]
+    # the ? and # that would truncate a raw file: URI must be percent-escaped
+    assert "?" not in path_part and "#" not in path_part
+    assert "%3F" in path_part.upper() and "%23" in path_part.upper()
+
+
+def test_last_deploy_reads_db_under_special_char_path(tmp_path):
+    # a repo path containing ? / # would truncate a raw `file:{path}?mode=ro` URI and
+    # silently read the WRONG (empty) db → None. The encoded URI opens the real db.
+    root = _make_update_db(tmp_path / "a?b#c", [("success", DEPLOY_COMMIT, DEPLOY_AT)])
+    got = _ua._last_successful_deploy(root / "data" / "genesis.db")
+    assert got == (DEPLOY_AT, DEPLOY_COMMIT)
+
+
 # ── throttle marker ─────────────────────────────────────────────────────────
 
 
@@ -128,6 +147,27 @@ def test_throttle_absent_then_recorded(monkeypatch, tmp_path):
     # well past the cooldown → not throttled
     later = NOW + timedelta(seconds=_ua._STALENESS_COOLDOWN_S + 60)
     assert _ua._staleness_throttled(SID, later) is False
+
+
+def test_throttle_future_marker_not_throttled(monkeypatch, tmp_path):
+    # a marker timestamp in the FUTURE (clock stepped back / hand-edited) must NOT
+    # suppress the nudge: a negative elapsed is always < cooldown and would otherwise
+    # wedge the stale-code warning OFF. (Old `(now-last) < cooldown` returned True here.)
+    monkeypatch.setattr(_ua, "_GENESIS_DIR", tmp_path)
+    marker = tmp_path / "sessions" / SID / "staleness_last_nudge"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text((NOW + timedelta(hours=5)).isoformat())
+    assert _ua._staleness_throttled(SID, NOW) is False
+
+
+def test_throttle_naive_marker_not_throttled(monkeypatch, tmp_path):
+    # a tz-NAIVE marker: aware `now` - naive `last` raises TypeError, which must
+    # fail-open to NOT throttled rather than propagate and suppress the nudge.
+    monkeypatch.setattr(_ua, "_GENESIS_DIR", tmp_path)
+    marker = tmp_path / "sessions" / SID / "staleness_last_nudge"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("2026-08-25T12:00:00")  # no tzinfo
+    assert _ua._staleness_throttled(SID, NOW) is False
 
 
 def test_record_returns_false_when_unwritable(monkeypatch, tmp_path):

--- a/tests/test_scripts/test_urgent_alerts_staleness_nudge.py
+++ b/tests/test_scripts/test_urgent_alerts_staleness_nudge.py
@@ -118,8 +118,15 @@ def test_last_deploy_missing_table(tmp_path):
 
 
 def test_ro_uri_encodes_special_chars_and_is_idempotent():
+    from urllib.parse import unquote, urlsplit
+
+    # An ordinary path is not over-encoded and round-trips. Accept both pathname2url
+    # spellings — 3.12 "file:/abs" and 3.14 "file:///abs" (empty authority) — since both
+    # are valid SQLite URIs that decode to the same path.
     clean = "/home/u/genesis/data/genesis.db"
-    assert _ua._ro_uri(Path(clean)) == f"file:{clean}?mode=ro"  # ordinary path: unchanged
+    uri = _ua._ro_uri(Path(clean))
+    assert uri.startswith("file:") and uri.endswith("?mode=ro")
+    assert unquote(urlsplit(uri[: -len("?mode=ro")]).path) == clean
     weird = _ua._ro_uri(Path("/a?b/c#d/genesis.db"))
     assert weird.endswith("?mode=ro")
     path_part = weird[len("file:") : -len("?mode=ro")]


### PR DESCRIPTION
Two fail-open hardening fixes to the per-prompt `genesis_urgent_alerts` hook (Codex P2s on #1460). Both fail toward **surfacing** the stale-code warning / opening the DB, never toward silence.

## 1. Future / naive-timestamp throttle
`_staleness_throttled` computed `(now - last).total_seconds() < cooldown`. A marker timestamp in the **future** (clock stepped back by NTP, or a hand-edited file) → negative elapsed → always `< cooldown` → the nudge was throttled **off** until wall-clock caught up plus a full cooldown, suppressing a genuine stale-code warning (a security signal: stale recall = missing current read-exclusions).

Fix: compute `elapsed` inside the `try`, treat a future marker (`elapsed < 0`) as **not** throttled, and widen the `except` to `TypeError` so a tz-naive marker (aware `now` − naive `last`) also fails open to emit rather than propagating.

## 2. SQLite-URI path encoding
`sqlite3.connect(f"file:{db}?mode=ro", uri=True)` silently opens the **wrong (empty)** database when the filesystem path contains a URI-special char. Ground-truthed against real `sqlite3`:

| path char | raw `file:` URI |
|---|---|
| `?`, `#` | **FAIL** — truncates the path → "no such table" |
| space, `%`, `&`, `=` | OK (tolerated) |

So an install whose repo path contains `?`/`#` silently reads the wrong DB → charter-tag and deploy reads fail closed to silence. New `_ro_uri()` percent-encodes the path via `pathname2url` (`?`→`%3F`, `#`→`%23`, …); SQLite decodes it back. **Idempotent** on an ordinary path (byte-identical URI), so no behavior change on real installs; WAL-aware `mode=ro` preserved. Both read sites route through the one helper.

Not a live bug on a clean install path — hardening for exotic paths.

## Tests
Verify-RED: reverting the code with the new tests in place fails all 3 (throttle returns True; `_ro_uri` absent; special-char path reads empty DB). With the fix → **32/32 green** across both `urgent_alerts` test files. Added a tz-naive-marker test for the widened except. `ruff --no-cache` clean.

Not bundled with the per-server spawn-identity fix (`0d0b5d17`), which touches the shared spawn plane + dashboard badge and gets its own PR.