### PR TITLE
fix(hooks): strip expansion redirect targets from argv so push/commit gates can't be spoofed

### DIFF
--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -28,7 +28,8 @@ from __future__ import annotations
 
 import re
 import shlex
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import NamedTuple
 
 # Leading wrappers whose trailing arguments are the real command to inspect.
 # Per wrapper: (option flags that consume a following value token, count of bare
@@ -120,6 +121,9 @@ class Segment:
     override: bool  # a trailing `# review-override` shell comment on this segment
     raw: str  # the raw segment text (for messages)
     depth: int = 0  # 0 = top level, >0 = inside a sh -c script
+    redirects: list[str] = field(
+        default_factory=list
+    )  # expansion redirect targets excised from argv
 
 
 def _redirect_operator_len(command: str, i: int) -> int | None:
@@ -153,38 +157,118 @@ def _redirect_operator_len(command: str, i: int) -> int | None:
 _TARGET_STOP = (" ", "\t", "\n", ";", "|", "&", "<", ">", "(", ")")
 
 
-def split_segments(command: str) -> list[str]:
-    """Split a command line into executed segments on shell operators.
+class _ParsedSegment(NamedTuple):
+    """A split segment with two text views.
 
-    Quote-aware: an operator inside a quoted string does not split. Splits on
-    ``&&``, ``||``, ``;``, ``|``, ``&`` and newlines. A ``#`` comment (opened
-    outside quotes) runs to end-of-line and is retained in the segment text so
-    override detection can see it.
-
-    Redirect-aware: a redirection (``2>/dev/null``, ``> out.log``, ``2>&1``,
-    ``&>log``, ``>| f``, ``< in``, ``<<<here``) is consumed — operator AND target
-    — and kept OUT of the segment text, so a redirect neither leaks a phantom
-    positional into argv nor mis-splits on an embedded ``&``/``|`` (``2>&1`` used
-    to split on the ``&``, hiding a following ``git push`` in a bogus segment and
-    slipping the push gate). Only a PLAIN-filename target is stripped; a target that
-    can carry a command expansion (any ``$`` or backtick — ``2>$(rm x)``,
-    ``2>"$(rm x)"``, ``<<<"$(…)"``, ``2>$VAR``, ``<(…)``, ``>(…)``) is LEFT in the
-    text so the canonical ``_substitutions`` still sees any nested command (a
-    substitution used as a redirect target EXECUTES). Such a target's token then
-    stays in argv — a documented residual for this exotic form (these gates are
-    friction, not a sandbox); a bare ``2>/dev/null`` is a plain filename and IS
-    stripped, so the common push-gate fail-open stays closed.
+    ``raw`` is byte-identical to what ``split_segments`` has always returned (the
+    executed-segment string, comment retained; an EXPANSION-carrying redirect target
+    is retained so ``_substitutions`` still sees the nested command it EXECUTES).
+    ``argv_src`` is ``raw`` with every redirect operator+target removed — the string
+    ``analyze`` tokenizes into argv, so a redirect target can never spoof the
+    subcommand. ``redirects`` are the expansion operator-target words excised from
+    ``argv_src`` (observability).
     """
-    segs: list[str] = []
-    buf: list[str] = []
+
+    raw: str
+    argv_src: str
+    redirects: tuple[str, ...]
+
+
+def _redirect_target_end(command: str, j0: int, n: int) -> int:
+    """Index just past ONE complete redirect-target word starting at ``command[j0]``.
+
+    Bash word grammar for a redirect target: a run ended only by an UNQUOTED,
+    UNESCAPED metacharacter (whitespace or one of ``; | & < > ( )``). A backslash
+    escapes the next char; single/double quotes open a span that suppresses
+    metacharacters (``\\`` active only inside double quotes); a paren-balanced
+    ``$(…)`` command substitution and a ``` `…` ``` backtick substitution are PART of
+    the word (their inner ``(``/``)`` and spaces do NOT end it). This is BOUNDARY
+    detection only — expansion SEMANTICS stay with the canonical ``_substitutions``
+    parser. It generalises the earlier quote-aware scanner (which stopped at a bare
+    ``(``) so an UNQUOTED ``2>$(rm x)`` is measured as one word and excised from argv
+    whole, not just its leading ``$``.
+    """
+    j = j0
+    wq: str | None = None  # in-word quote state
+    while j < n:
+        ch = command[j]
+        if wq is not None:
+            if wq == '"' and ch == "\\" and j + 1 < n:
+                j += 2
+                continue
+            if ch == wq:
+                wq = None
+            j += 1
+            continue
+        if ch == "\\" and j + 1 < n:  # unquoted backslash escapes the next char
+            j += 2
+            continue
+        if ch in ("'", '"'):  # a quote span begins (or concatenates)
+            wq = ch
+            j += 1
+            continue
+        if ch == "$" and j + 1 < n and command[j + 1] == "(":  # $(…) command sub
+            depth, j = 1, j + 2
+            while j < n and depth > 0:
+                cj = command[j]
+                if cj == "(":
+                    depth += 1
+                elif cj == ")":
+                    depth -= 1
+                j += 1
+            continue
+        if ch == "`":  # `…` backtick sub — to the matching backtick (or EOL)
+            close = command.find("`", j + 1)
+            j = close + 1 if close != -1 else n
+            continue
+        if ch in _TARGET_STOP:  # unquoted metacharacter ends the word
+            break
+        j += 1
+    return j
+
+
+def parse_segments(command: str) -> list[_ParsedSegment]:
+    """Split a command line into executed segments, returning per segment BOTH the raw
+    text and a redirect-STRIPPED argv source (see ``_ParsedSegment``).
+
+    Quote-aware: an operator inside a quoted string does not split. Splits on ``&&``,
+    ``||``, ``;``, ``|``, ``&`` and newlines. A ``#`` comment (opened outside quotes)
+    runs to end-of-line and is retained in ``raw`` so override detection can see it.
+
+    Redirect-aware: a redirection (``2>/dev/null``, ``> out.log``, ``2>&1``, ``&>log``,
+    ``>| f``, ``< in``, ``<<<here``) is consumed — operator AND target. A PLAIN-filename
+    target is dropped from BOTH views. A target that can carry a command expansion (any
+    ``$`` or backtick — ``2>$(rm x)``, ``2>"$(rm x)"``, ``2>$VAR``, backtick) is KEPT in
+    ``raw`` (so ``_substitutions`` still sees the nested command a substitution redirect
+    target EXECUTES) but EXCLUDED from ``argv_src`` — so it can no longer leak into argv
+    and spoof ``git_subcommand``/``commit_skips_hooks`` (the push/commit fail-open this
+    split closes). Process substitution ``<(…)``/``>(…)`` stays in BOTH (documented gap).
+    ``raw`` stays byte-identical to the historical ``split_segments`` output for every
+    ordinary command (the cwd/occurrence consumers match ``Segment.raw`` against a fresh
+    re-split; locked by a golden test over a broad corpus). ONE intentional difference
+    from the pre-#1455 scanner: a ``$(…)``/backtick target that contains an UNQUOTED
+    control operator (``;`` ``&&`` ``||`` ``|``) is now paren-balanced into ONE segment
+    instead of mis-split on that operator — which CLOSES an additional fail-open (HEAD
+    mis-split ``git 2>$(a; b) push`` into ``git  $(a`` + ``b) push`` so ``git_subcommand``
+    never saw the ``push``); the nested ``a``/``b`` still surface via ``_substitutions``.
+    So ``raw`` is byte-identical EXCEPT it is strictly SAFER on this class — never the
+    other direction (locked by the ``$(;)``/``$(&&)``/``$(|)`` cases in the redirect-argv
+    test's EXPLOITS).
+    """
+    pairs: list[tuple[str, str, list[str]]] = []
+    raw_buf: list[str] = []
+    argv_buf: list[str] = []
+    redirs: list[str] = []
     i, n = 0, len(command)
     quote: str | None = None
     while i < n:
         c = command[i]
         if quote:
-            buf.append(c)
+            raw_buf.append(c)
+            argv_buf.append(c)
             if quote == '"' and c == "\\" and i + 1 < n:
-                buf.append(command[i + 1])
+                raw_buf.append(command[i + 1])
+                argv_buf.append(command[i + 1])
                 i += 2
                 continue
             if c == quote:
@@ -193,94 +277,80 @@ def split_segments(command: str) -> list[str]:
             continue
         if c in ("'", '"'):
             quote = c
-            buf.append(c)
+            raw_buf.append(c)
+            argv_buf.append(c)
             i += 1
             continue
         two = command[i : i + 2]
         if two in ("&&", "||"):
-            segs.append("".join(buf))
-            buf = []
+            pairs.append(("".join(raw_buf), "".join(argv_buf), list(redirs)))
+            raw_buf, argv_buf, redirs = [], [], []
             i += 2
             continue
         op_len = _redirect_operator_len(command, i)
         if op_len is not None:
-            # Drop a standalone leading fd digit-run (the '2' of ` 2>`), but NOT a
-            # digit that ends a word (`push2>x` keeps 'push2' — never a fail-open
-            # onto a bare 'push'); '&>' never carries an fd prefix.
+            # Drop a standalone leading fd digit-run from BOTH buffers (the '2' of
+            # ` 2>`), but NOT a digit that ends a word (`push2>x` keeps 'push2'). The
+            # trailing digits are mirrored in both buffers, so remove the same count.
             if c != "&":
-                k = len(buf)
-                while k > 0 and buf[k - 1].isdigit():
+                k = len(raw_buf)
+                while k > 0 and raw_buf[k - 1].isdigit():
                     k -= 1
-                if k < len(buf) and (k == 0 or buf[k - 1].isspace()):
-                    del buf[k:]
+                if k < len(raw_buf) and (k == 0 or raw_buf[k - 1].isspace()):
+                    ndel = len(raw_buf) - k
+                    del raw_buf[k:]
+                    del argv_buf[len(argv_buf) - ndel :]
             j = i + op_len
             while j < n and command[j] in (" ", "\t"):  # gap before the target
                 j += 1
             t = command[j] if j < n else ""
             tnext = command[j + 1] if j + 1 < n else ""
             # A process substitution as the target (`<(…)`, `>(…)`) begins with a
-            # metachar the plain consumer would stop on — leave it in the text (it
+            # metachar the plain consumer would stop on — leave it in BOTH views (it
             # executes, like any substitution); consume only the operator.
             if t in ("<", ">") and tnext == "(":
-                buf.append(" ")
+                raw_buf.append(" ")
+                argv_buf.append(" ")
                 i = j
                 continue
             j0 = j
             if j < n and t not in _TARGET_STOP:
-                # Measure ONE complete shell word (the closed bash word grammar): a
-                # run of characters ended only by an UNQUOTED, UNESCAPED delimiter.
-                # A backslash escapes the next char (incl. a space); single/double
-                # quotes open a span that suppresses delimiters (with `\` active only
-                # inside double quotes), and adjacent quoted/plain runs concatenate
-                # into one word. Scanning the whole word — not stopping at the first
-                # escaped/quoted space — is what keeps `git 2>err\ log push` /
-                # `git 2>pre"a b"post push` from hiding the push/commit subcommand.
-                wq: str | None = None  # in-word quote state
-                while j < n:
-                    ch = command[j]
-                    if wq is not None:
-                        if wq == '"' and ch == "\\" and j + 1 < n:
-                            j += 2
-                            continue
-                        if ch == wq:
-                            wq = None
-                        j += 1
-                        continue
-                    if ch == "\\" and j + 1 < n:  # unquoted backslash escapes next char
-                        j += 2
-                        continue
-                    if ch in ("'", '"'):  # a quote span begins (or concatenates)
-                        wq = ch
-                        j += 1
-                        continue
-                    if ch in _TARGET_STOP:  # unquoted delimiter ends the word
-                        break
-                    j += 1
-            # Strip ONLY a plain-filename target. A target that can carry a command
-            # expansion — a ``$`` (``$(…)`` / bare ``$VAR``) or a backtick, in any
-            # quoting — is LEFT in the segment text (rewind and let normal processing
-            # re-scan it): this delegates ALL expansion/quoting semantics to the one
-            # canonical ``_substitutions`` parser (which expands ``$(…)`` unquoted and
-            # in double quotes so a nested command stays visible to the destructive
-            # guard, and correctly does NOT expand inside single quotes) instead of
-            # re-deciding them here. Only cost: such a target's token stays in argv —
-            # the pre-existing, documented residual for this exotic form.
-            if "$" in command[j0:j] or "`" in command[j0:j]:
-                buf.append(" ")
-                i = j0  # rewind — normal processing + _substitutions handle the target
-                continue
-            buf.append(" ")  # plain filename target — operator + target both dropped
+                j = _redirect_target_end(command, j0, n)
+            target = command[j0:j]
+            if "$" in target or "`" in target:
+                # Expansion-carrying target: KEEP in raw (nested command stays visible
+                # to the destructive guard via _substitutions), EXCLUDE from argv_src so
+                # it cannot spoof the subcommand. Record it for observability.
+                raw_buf.append(" ")
+                raw_buf.append(target)
+                argv_buf.append(" ")
+                redirs.append(target)
+            else:  # plain filename target — dropped from both views
+                raw_buf.append(" ")
+                argv_buf.append(" ")
             i = j
             continue
         if c in (";", "|", "&", "\n"):
-            segs.append("".join(buf))
-            buf = []
+            pairs.append(("".join(raw_buf), "".join(argv_buf), list(redirs)))
+            raw_buf, argv_buf, redirs = [], [], []
             i += 1
             continue
-        buf.append(c)
+        raw_buf.append(c)
+        argv_buf.append(c)
         i += 1
-    segs.append("".join(buf))
-    return [s.strip() for s in segs if s.strip()]
+    pairs.append(("".join(raw_buf), "".join(argv_buf), list(redirs)))
+    return [
+        _ParsedSegment(raw=r.strip(), argv_src=a.strip(), redirects=tuple(d))
+        for (r, a, d) in pairs
+        if r.strip()  # filter on RAW — keeps the exact set/alignment split_segments had
+    ]
+
+
+def split_segments(command: str) -> list[str]:
+    """Executed-segment raw strings — a thin, byte-identical view over
+    ``parse_segments`` (all redirect/quote/comment semantics live there). Kept as the
+    stable ``list[str]`` API the cwd/occurrence consumers iterate."""
+    return [p.raw for p in parse_segments(command)]
 
 
 def _strip_trailing_comment(seg: str) -> str:
@@ -523,17 +593,24 @@ def analyze(command: str) -> list[Segment]:
     commands are surfaced (the parent's override propagates to them).
     """
     out: list[Segment] = []
-    for raw in split_segments(command):
+    for seg in parse_segments(command):
+        raw = seg.raw
         override = _has_trailing_override(raw)
-        argv = _strip_wrappers(_argv(raw))
+        # argv is tokenized from the redirect-STRIPPED source, so a redirect target
+        # (incl. an expansion one) can never become argv[1] and spoof the subcommand.
+        argv = _strip_wrappers(_argv(seg.argv_src))
         exe = _basename(argv[0]) if argv else ""
-        out.append(Segment(exe=exe, argv=argv, override=override, raw=raw))
+        out.append(
+            Segment(exe=exe, argv=argv, override=override, raw=raw, redirects=list(seg.redirects))
+        )
         nested = []
         if exe in _NESTED:
             script = _nested_script(argv)
             if script:
                 nested.append(script)
-        nested.extend(_substitutions(raw))  # $(...) / `...` bodies also execute
+        # $(...) / `...` bodies also execute — parsed from RAW, which STILL carries any
+        # expansion redirect target, so a nested command stays visible to the guards.
+        nested.extend(_substitutions(raw))
         for script in nested:
             for inner in analyze(script):
                 out.append(
@@ -543,6 +620,7 @@ def analyze(command: str) -> list[Segment]:
                         override=override or inner.override,
                         raw=inner.raw,
                         depth=inner.depth + 1,
+                        redirects=inner.redirects,
                     )
                 )
     return out

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -174,19 +174,69 @@ class _ParsedSegment(NamedTuple):
     redirects: tuple[str, ...]
 
 
+def _command_sub_end(command: str, i: int, n: int) -> int:
+    """Index just past the matching ``)`` of a ``$(…)`` command substitution that
+    opens at ``command[i:i+2] == "$("``.
+
+    QUOTE-, ESCAPE-, and NESTING-aware: a ``)`` inside a single/double-quoted span,
+    or backslash-escaped, is DATA — it does NOT close the substitution; a nested
+    ``$(…)``/``(…)`` bumps the paren depth; a ``` `…` ``` backtick span is skipped
+    whole. This bounds the sub at its TRUE close so a following control operator
+    (``&& rm``) can never be swallowed into a redirect target (the Codex-P1
+    regression a paren-only balancer caused). Fail-open: an UNTERMINATED sub returns
+    ``n`` (consume to EOL) — it never raises (the module's no-crash contract).
+
+    Shared by ``_redirect_target_end`` (target boundary) and ``_substitutions``
+    (body extraction) so the two agree on where a ``$()`` ends — one scanner, not
+    two divergent paren-counters.
+    """
+    depth, j = 1, i + 2
+    q: str | None = None  # in-body quote state
+    while j < n:
+        ch = command[j]
+        if q is not None:
+            if q == '"' and ch == "\\" and j + 1 < n:  # \ escapes only inside "…"
+                j += 2
+                continue
+            if ch == q:
+                q = None
+            j += 1
+            continue
+        if ch == "\\" and j + 1 < n:  # unquoted backslash escapes the next char
+            j += 2
+            continue
+        if ch in ("'", '"'):  # a quoted span begins — its inner ) is data
+            q = ch
+            j += 1
+            continue
+        if ch == "`":  # nested backtick span — skip to its close (or EOL)
+            close = command.find("`", j + 1)
+            j = close + 1 if close != -1 else n
+            continue
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                return j + 1
+        j += 1
+    return n  # unterminated — fail-open to EOL, never raise
+
+
 def _redirect_target_end(command: str, j0: int, n: int) -> int:
     """Index just past ONE complete redirect-target word starting at ``command[j0]``.
 
     Bash word grammar for a redirect target: a run ended only by an UNQUOTED,
     UNESCAPED metacharacter (whitespace or one of ``; | & < > ( )``). A backslash
     escapes the next char; single/double quotes open a span that suppresses
-    metacharacters (``\\`` active only inside double quotes); a paren-balanced
-    ``$(…)`` command substitution and a ``` `…` ``` backtick substitution are PART of
-    the word (their inner ``(``/``)`` and spaces do NOT end it). This is BOUNDARY
-    detection only — expansion SEMANTICS stay with the canonical ``_substitutions``
-    parser. It generalises the earlier quote-aware scanner (which stopped at a bare
-    ``(``) so an UNQUOTED ``2>$(rm x)`` is measured as one word and excised from argv
-    whole, not just its leading ``$``.
+    metacharacters (``\\`` active only inside double quotes); a ``$(…)`` command
+    substitution (bounded QUOTE/ESCAPE/NESTING-aware via ``_command_sub_end`` — a
+    ``)`` inside a quoted operand does NOT close it) and a ``` `…` ``` backtick
+    substitution are PART of the word (their inner ``(``/``)`` and spaces do NOT end
+    it). This is BOUNDARY detection only — expansion SEMANTICS stay with the
+    canonical ``_substitutions`` parser. It generalises the earlier quote-aware
+    scanner (which stopped at a bare ``(``) so an UNQUOTED ``2>$(rm x)`` is measured
+    as one word and excised from argv whole, not just its leading ``$``.
     """
     j = j0
     wq: str | None = None  # in-word quote state
@@ -208,14 +258,7 @@ def _redirect_target_end(command: str, j0: int, n: int) -> int:
             j += 1
             continue
         if ch == "$" and j + 1 < n and command[j + 1] == "(":  # $(…) command sub
-            depth, j = 1, j + 2
-            while j < n and depth > 0:
-                cj = command[j]
-                if cj == "(":
-                    depth += 1
-                elif cj == ")":
-                    depth -= 1
-                j += 1
+            j = _command_sub_end(command, j, n)  # quote/escape/nesting-aware close
             continue
         if ch == "`":  # `…` backtick sub — to the matching backtick (or EOL)
             close = command.find("`", j + 1)
@@ -668,11 +711,15 @@ def _substitutions(text: str) -> list[str]:
     """Command-substitution bodies — ``$(…)`` and ``` `…` ``` — which also run.
 
     Only single-quoted spans block substitution (``$()`` still expands inside
-    double quotes). Nested ``$()`` is balanced by paren depth. Best-effort:
-    exotic forms (process substitution ``<(…)``, ANSI-C ``$'…'`` scripts, ``env
-    -S`` string-splitting, shell aliases/functions) are NOT parsed — this guard
-    is an approval/friction layer, not a sandbox, and fails toward over-matching
-    on the common forms rather than pretending to cover every shell construct.
+    double quotes). A ``$()`` body is bounded QUOTE/ESCAPE/NESTING-aware via the
+    shared ``_command_sub_end`` — a ``)`` inside a quoted operand of the body is
+    DATA, so the body is extracted to its TRUE close (the same scanner the redirect-
+    target boundary uses, so the two never disagree on where a ``$()`` ends).
+    Best-effort: exotic forms (process substitution ``<(…)``, ANSI-C ``$'…'``
+    scripts, ``env -S`` string-splitting, shell aliases/functions) are NOT parsed —
+    this guard is an approval/friction layer, not a sandbox, and fails toward
+    over-matching on the common forms rather than pretending to cover every shell
+    construct.
     """
     subs: list[str] = []
     i, n = 0, len(text)
@@ -689,16 +736,9 @@ def _substitutions(text: str) -> list[str]:
             i += 1
             continue
         if c == "$" and i + 1 < n and text[i + 1] == "(":
-            depth, j = 1, i + 2
-            start = j
-            while j < n and depth > 0:
-                if text[j] == "(":
-                    depth += 1
-                elif text[j] == ")":
-                    depth -= 1
-                j += 1
-            subs.append(text[start : j - 1])
-            i = j
+            end = _command_sub_end(text, i, n)  # index past matching ')'
+            subs.append(text[i + 2 : end - 1])  # body between $( and )
+            i = end
             continue
         if c == "`":
             j = text.find("`", i + 1)

--- a/tests/test_hooks/_split_segments_golden.json
+++ b/tests/test_hooks/_split_segments_golden.json
@@ -1,0 +1,155 @@
+{
+  "git 2>/dev/null push": [
+    "git   push"
+  ],
+  "git > out.log push": [
+    "git   push"
+  ],
+  "git >>out.log push": [
+    "git   push"
+  ],
+  "git 2>&1 push": [
+    "git   push"
+  ],
+  "git &>log push": [
+    "git   push"
+  ],
+  "git &>>log push": [
+    "git   push"
+  ],
+  "git >|out push": [
+    "git   push"
+  ],
+  "git <in push": [
+    "git   push"
+  ],
+  "git <<<here push": [
+    "git   push"
+  ],
+  "echo hi 1>o 2>e": [
+    "echo hi"
+  ],
+  "git 2>'$(rm x)' push": [
+    "git  '$(rm x)' push"
+  ],
+  "git 2>\"`rm x`\" push": [
+    "git  \"`rm x`\" push"
+  ],
+  "git 2>$'a b' push": [
+    "git  $'a b' push"
+  ],
+  "git 2>a$(echo x)b push": [
+    "git  a$(echo x)b push"
+  ],
+  "git 2>$(rm x) push": [
+    "git  $(rm x) push"
+  ],
+  "git 22>$(rm x) push": [
+    "git  $(rm x) push"
+  ],
+  "git 3>$(rm x) push": [
+    "git  $(rm x) push"
+  ],
+  "git push2>$(rm x)": [
+    "git push2 $(rm x)"
+  ],
+  "git 2>\"$(rm x); rm y\" push": [
+    "git  \"$(rm x); rm y\" push"
+  ],
+  "echo hi 2>$(rm -rf /tmp/x)a\\ b": [
+    "echo hi  $(rm -rf /tmp/x)a\\ b"
+  ],
+  "git 2>err\\ log push": [
+    "git   push"
+  ],
+  "git 2>pre\"a b\"post push": [
+    "git   push"
+  ],
+  "diff <(a) <(b)": [
+    "diff  (a)  (b)"
+  ],
+  "tee >(cat) < in": [
+    "tee  (cat)"
+  ],
+  "git 2>": [
+    "git"
+  ],
+  "git 2>'unterminated push": [
+    "git"
+  ],
+  "git 2>\"$(rm x": [
+    "git  \"$(rm x"
+  ],
+  "git 2>'$(rm x": [
+    "git  '$(rm x"
+  ],
+  "git 12>&34 push": [
+    "git   push"
+  ],
+  "cat 3< in": [
+    "cat"
+  ],
+  "git 2>$(a)3>b": [
+    "git  $(a)3"
+  ],
+  "git 2>$(a)>b push": [
+    "git  $(a)  push"
+  ],
+  "git 1>$(a) 2>$(b) push": [
+    "git  $(a)  $(b) push"
+  ],
+  "git 2>${VAR} push": [
+    "git  ${VAR} push"
+  ],
+  "git 2>$VAR push": [
+    "git  $VAR push"
+  ],
+  "echo \"$(rm x)\"": [
+    "echo \"$(rm x)\""
+  ],
+  "git commit -m \"2>x\"": [
+    "git commit -m \"2>x\""
+  ],
+  "ruff check . && pytest -q": [
+    "ruff check .",
+    "pytest -q"
+  ],
+  "a | b ; c && d || e": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "e"
+  ],
+  "bash -c 'git 2>/dev/null push'": [
+    "bash -c 'git 2>/dev/null push'"
+  ],
+  "grep '2>x' file": [
+    "grep '2>x' file"
+  ],
+  "echo 'a && b' ; echo done": [
+    "echo 'a && b'",
+    "echo done"
+  ],
+  "cd /wt && git 2>\"$(rm x)\" push": [
+    "cd /wt",
+    "git  \"$(rm x)\" push"
+  ],
+  "git -C /wt merge a && git 2>\"$(rm x)\" merge b": [
+    "git -C /wt merge a",
+    "git  \"$(rm x)\" merge b"
+  ],
+  "git 2>\"$(rm x)\" commit -m a && git commit -m b": [
+    "git  \"$(rm x)\" commit -m a",
+    "git commit -m b"
+  ],
+  "git 2>\"$(rm x)\" commit -n": [
+    "git  \"$(rm x)\" commit -n"
+  ],
+  "git push origin main --force": [
+    "git push origin main --force"
+  ],
+  "pytest tests/foo.py --basetemp /wt": [
+    "pytest tests/foo.py --basetemp /wt"
+  ]
+}

--- a/tests/test_hooks/test_protected_paths_guard.py
+++ b/tests/test_hooks/test_protected_paths_guard.py
@@ -289,3 +289,40 @@ class TestPayloadEdges:
             env=env,
         )
         assert r.returncode == 0
+
+
+class TestQuotedParenRedirectTargetRegression:
+    """Codex P1 (2026-08-26): shell_parse's quote-blind ``$()`` balancer
+    (``_redirect_target_end``) mis-bounded a ``$(…)`` redirect target whose body
+    held a QUOTED or ESCAPED ``)``, dumping back into the quote-aware outer word-
+    scan mid-string so a following ``&& rm <protected>`` was consumed INTO the
+    redirect target — ``analyze()`` then emitted no ``rm`` segment and this guard
+    went blind. Verified against the real guard: pre-fix these PASS THROUGH
+    (returncode 0); the ``rm`` after the redirect MUST be seen and blocked."""
+
+    def test_single_quoted_paren_target_then_rm_dir_blocks(self, fake_home):
+        r = _run(f"echo ok 2>$(printf ')') && rm -rf {H}/genesis/data", fake_home)
+        assert r.returncode != 0, (
+            f"protected-dir rm slipped past guard: out={r.stdout!r} err={r.stderr!r}"
+        )
+
+    def test_codex_exact_db_file_deletion_blocks(self, fake_home):
+        # Codex's exact reported command form (a specific protected FILE).
+        r = _run(f"echo ok 2>$(printf ')') && rm {H}/genesis/data/genesis.db", fake_home)
+        assert r.returncode != 0, (
+            f"production-DB deletion slipped past guard: out={r.stdout!r} err={r.stderr!r}"
+        )
+
+    def test_double_quoted_paren_target_then_rm_ancestor_blocks(self, fake_home):
+        r = _run(f'echo ok 2>$(echo ")") && rm -rf {H}/genesis', fake_home)
+        assert r.returncode != 0, (
+            f"protected-ancestor rm slipped past guard: out={r.stdout!r} err={r.stderr!r}"
+        )
+
+    def test_quoted_paren_target_without_protected_rm_still_allowed(self, fake_home):
+        # The fix must SPLIT the segment correctly, NOT over-block: no protected
+        # target here, so the command stays allowed (guards against over-gating).
+        r = _run("echo ok 2>$(printf ')') && echo done", fake_home)
+        assert r.returncode == 0, (
+            f"benign command wrongly blocked: out={r.stdout!r} err={r.stderr!r}"
+        )

--- a/tests/test_hooks/test_shell_parse_redirect_argv.py
+++ b/tests/test_hooks/test_shell_parse_redirect_argv.py
@@ -201,3 +201,50 @@ def test_dual_buffer_no_desync_under_fd_expansion_adjacency():
     assert sp.git_subcommand(seg.argv) == "push"
     assert {"a", "b", "c", "d"} <= {s.exe for s in sp.analyze(cmd)}
     assert [s.raw for s in sp.analyze(cmd) if s.depth == 0] == sp.split_segments(cmd)
+
+
+# ── Codex P1 (2026-08-26): quote-aware $() target boundary ────────────────────
+# The $()/backtick target balancer must respect quotes/escapes: a `)` inside a
+# single/double-quoted span (or escaped) inside the $() body is DATA, not the
+# close. The quote-blind balancer closed the $() early, then the outer word-scan
+# treated the trailing quote as an opener and SWALLOWED a following `&& rm`/`&&
+# git push`/`commit -n` into the redirect target — analyze() emitted no segment
+# for the following command, blinding the destructive/push/commit guards. Each
+# case must keep the following command a SEPARATE, visible depth-0 segment.
+# (cmd, following exe, its git subcommand or None, commit_skips_hooks)
+QUOTED_PAREN_FOLLOWING_CMD = [
+    ("echo ok 2>$(printf ')') && rm /x/y", "rm", None, False),  # Codex single-quote form
+    ('echo ok 2>$(echo ")") && rm /x/y', "rm", None, False),  # double-quote form
+    ("echo ok 2>$(printf ')') && git push origin main --force", "git", "push", False),
+    ("echo ok 2>$(printf ')') && git commit --no-verify", "git", "commit", True),
+]
+
+
+@pytest.mark.parametrize("cmd,exe,sub,skips", QUOTED_PAREN_FOLLOWING_CMD)
+def test_quoted_paren_target_does_not_swallow_following_command(cmd, exe, sub, skips):
+    segs = sp.analyze(cmd)
+    hit = next((s for s in segs if s.depth == 0 and s.exe == exe), None)
+    assert hit is not None, (
+        f"{exe!r} segment swallowed by redirect target: {[(s.exe, s.argv) for s in segs]}"
+    )
+    if sub is not None:
+        assert sp.git_subcommand(hit.argv) == sub
+        assert sp.commit_skips_hooks(hit.argv) is skips
+
+
+def test_rm_inside_quoted_paren_sub_still_surfaces():
+    """The already-safe direction stays safe: an rm INSIDE a $() whose operand
+    carries a quoted `)` still surfaces via _substitutions, and the trailing
+    subcommand still reads correctly."""
+    cmd = 'git 2>$(rm ")" /x) push'
+    segs = sp.analyze(cmd)
+    assert "rm" in {s.exe for s in segs}
+    git_seg = next(s for s in segs if s.exe == "git")
+    assert sp.git_subcommand(git_seg.argv) == "push"
+
+
+def test_quoted_paren_target_golden_raw_still_resplittable():
+    """raw invariant holds through the quoted-paren target: depth-0 Segment.raw ==
+    a fresh split_segments (the cwd/occurrence consumers depend on it)."""
+    for cmd, *_ in QUOTED_PAREN_FOLLOWING_CMD:
+        assert [s.raw for s in sp.analyze(cmd) if s.depth == 0] == sp.split_segments(cmd), cmd

--- a/tests/test_hooks/test_shell_parse_redirect_argv.py
+++ b/tests/test_hooks/test_shell_parse_redirect_argv.py
@@ -1,0 +1,203 @@
+"""Redirect-target argv/raw separation (follow-up 1c8d0fd2).
+
+A redirect target that carries a command expansion — ``$(…)`` / backtick / ``$'…'`` /
+a quoted span — is LEFT in the segment ``raw`` (so ``_substitutions`` keeps a nested
+``rm`` visible to protected_paths_guard), but under the pre-fix parser it also leaked
+into ``argv`` and spoofed ``git_subcommand`` → the push and commit gates keyed on the
+exact subcommand and never fired (fail-OPEN). This locks:
+
+  1. ``argv`` is sourced from a redirect-STRIPPED view → the right subcommand;
+  2. ``raw`` (hence ``split_segments``) is byte-identical to before for ordinary
+     commands (three gate files match ``Segment.raw`` against a fresh re-split for
+     cwd/occurrence tracking — any UNINTENDED drift silently breaks them). The lone
+     intended difference: a ``$(…)``/backtick target with an unquoted control operator
+     (``;``/``&&``/``||``/``|``) is paren-balanced into one segment — strictly SAFER
+     than HEAD (which mis-split it, missing the push/commit) — locked via EXPLOITS;
+  3. the nested command stays visible where bash would actually run it.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "hooks"))
+import shell_parse as sp  # noqa: E402
+
+_GOLDEN = Path(__file__).resolve().parent / "_split_segments_golden.json"
+
+# ── Byte-identical corpus: split_segments(cmd) MUST NOT change ───────────────
+CORPUS: list[str] = [
+    # plain targets (stripped from raw today)
+    "git 2>/dev/null push",
+    "git > out.log push",
+    "git >>out.log push",
+    "git 2>&1 push",
+    "git &>log push",
+    "git &>>log push",
+    "git >|out push",
+    "git <in push",
+    "git <<<here push",
+    "echo hi 1>o 2>e",
+    # expansion targets (retained in raw)
+    "git 2>'$(rm x)' push",
+    'git 2>"`rm x`" push',
+    "git 2>$'a b' push",
+    "git 2>a$(echo x)b push",
+    "git 2>$(rm x) push",
+    "git 22>$(rm x) push",
+    "git 3>$(rm x) push",
+    "git push2>$(rm x)",
+    'git 2>"$(rm x); rm y" push',
+    "echo hi 2>$(rm -rf /tmp/x)a\\ b",
+    # escaped / concatenated-quote targets (PR-1 word scanner)
+    "git 2>err\\ log push",
+    'git 2>pre"a b"post push',
+    # process substitution (documented gap — target stays)
+    "diff <(a) <(b)",
+    "tee >(cat) < in",
+    # exotic / degenerate
+    "git 2>",
+    "git 2>'unterminated push",
+    'git 2>"$(rm x',
+    "git 2>'$(rm x",
+    "git 12>&34 push",
+    "cat 3< in",
+    # expansion-then-fd / param-expansion adjacency (the subtlest raw-drift risk)
+    "git 2>$(a)3>b",
+    "git 2>$(a)>b push",
+    "git 1>$(a) 2>$(b) push",
+    "git 2>${VAR} push",
+    "git 2>$VAR push",
+    'echo "$(rm x)"',
+    'git commit -m "2>x"',
+    # chained + quoting + nesting
+    "ruff check . && pytest -q",
+    "a | b ; c && d || e",
+    "bash -c 'git 2>/dev/null push'",
+    "grep '2>x' file",
+    "echo 'a && b' ; echo done",
+    'cd /wt && git 2>"$(rm x)" push',
+    'git -C /wt merge a && git 2>"$(rm x)" merge b',
+    'git 2>"$(rm x)" commit -m a && git commit -m b',
+    'git 2>"$(rm x)" commit -n',
+    # no redirect at all
+    "git push origin main --force",
+    "pytest tests/foo.py --basetemp /wt",
+]
+
+
+# ── (1)+(2) byte-identical raw contract ─────────────────────────────────────
+def test_split_segments_byte_identical_to_golden():
+    """split_segments over the corpus reproduces the frozen pre-change output."""
+    golden = json.loads(_GOLDEN.read_text())
+    for cmd, expected in golden.items():
+        assert sp.split_segments(cmd) == expected, cmd
+
+
+@pytest.mark.parametrize("cmd", CORPUS)
+def test_analyze_depth0_raw_equals_split_segments(cmd):
+    """The invariant the cwd/occurrence consumers rely on: a depth-0 Segment.raw is
+    exactly an element of a fresh split_segments(cmd)."""
+    assert [s.raw for s in sp.analyze(cmd) if s.depth == 0] == sp.split_segments(cmd)
+
+
+# ── (3) argv is redirect-stripped; nested command stays visible ─────────────
+# (cmd, expected git_subcommand, commit_skips_hooks, nested exe bash would run or None)
+EXPLOITS = [
+    ("git 2>'$(rm x)' push", "push", False, None),  # single-quote: bash does NOT expand
+    ('git 2>"`rm x`" push', "push", False, "rm"),  # dquote backtick: expands
+    ("git 2>$'a b' push", "push", False, None),  # ANSI-C quote, no substitution
+    ("git 2>a$(echo x)b push", "push", False, "echo"),
+    ("git 2>$(rm x) push", "push", False, "rm"),
+    ("git 22>$(rm x) push", "push", False, "rm"),  # multi-digit fd
+    ("git 3>$(rm x) push", "push", False, "rm"),  # non-1/2 fd
+    ('git 2>"$(rm x); rm y" push', "push", False, "rm"),  # $() closes at first )
+    ("git 2>'$(rm x)' commit --no-verify", "commit", True, None),
+    ('git 2>"`rm x`" commit -n', "commit", True, "rm"),
+    # $(...) target with an UNQUOTED control operator: the pre-#1455 scanner mis-split
+    # on the operator (`git  $(a` + `b) push`) so git_subcommand saw '$(a' and the push
+    # gate MISSED it; the paren-balancer keeps it one segment → correct subcommand, and
+    # a/b still surface via _substitutions. Strictly SAFER than HEAD — locked here so a
+    # future scanner "simplification" cannot silently re-open this fail-open class.
+    ("git >|$(a; b) push", "push", False, "a"),
+    ("git 2>$(a && b) commit --no-verify", "commit", True, "a"),
+    ("git 2>$(a | b) push", "push", False, "a"),
+]
+
+
+@pytest.mark.parametrize("cmd,sub,skips,nested_exe", EXPLOITS)
+def test_redirect_target_does_not_spoof_subcommand(cmd, sub, skips, nested_exe):
+    segs = sp.analyze(cmd)
+    top = [s for s in segs if s.depth == 0]
+    git_seg = next(s for s in top if s.exe == "git")
+    assert sp.git_subcommand(git_seg.argv) == sub, git_seg.argv
+    assert sp.commit_skips_hooks(git_seg.argv) is skips
+    exes = {s.exe for s in segs}
+    if nested_exe:
+        assert nested_exe in exes, f"nested {nested_exe} must stay visible: {exes}"
+    else:
+        # a single-quoted / ANSI-C target is not expanded by bash → no rm/echo runs
+        assert "rm" not in exes
+
+
+def test_fd_digit_word_boundary_preserved():
+    # a digit that ENDS a word is part of that word, then a redirect on it:
+    # `git push2>$(rm x)` → subcommand 'push2' (NOT 'push', NOT a residue token).
+    seg = next(s for s in sp.analyze("git push2>$(rm x)") if s.exe == "git")
+    assert sp.git_subcommand(seg.argv) == "push2"
+    assert "rm" in {s.exe for s in sp.analyze("git push2>$(rm x)")}
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        'git 2>"$(rm x',  # unterminated dquote+paren
+        "git 2>'$(rm x",  # unterminated squote
+        "git 2>`rm x push",  # unterminated backtick
+    ],
+)
+def test_unterminated_target_no_crash_no_spoof(cmd):
+    segs = sp.analyze(cmd)  # must not raise
+    git_seg = next((s for s in segs if s.exe == "git"), None)
+    if git_seg is not None:
+        sub = sp.git_subcommand(git_seg.argv)
+        # a broken/unterminated target must not resolve to a real push/commit, and must
+        # not leave an expansion residue masquerading as the subcommand.
+        assert sub not in ("push", "commit")
+        assert sub is None or ("$" not in sub and "`" not in sub)
+
+
+# ── (§6) three-consumer raw-equality through redirect-carrying compounds ─────
+@pytest.mark.parametrize(
+    "cmd,pred",
+    [
+        ('cd /wt && git 2>"$(rm x)" push', lambda s: sp.git_subcommand(s.argv) == "push"),
+        (
+            'git 2>"$(rm x)" commit -m a && git commit -m b',
+            lambda s: sp.git_subcommand(s.argv) == "commit",
+        ),
+        ('git 2>"$(rm x)" commit -n', lambda s: sp.git_subcommand(s.argv) == "commit"),
+    ],
+)
+def test_consumer_raw_is_resplittable(cmd, pred):
+    """Every matched Segment.raw is an element of a fresh split_segments(cmd) — the
+    exact property _effective_cwd / occurrence-indexing / invalidate loops depend on."""
+    fresh = sp.split_segments(cmd)
+    for s in sp.analyze(cmd):
+        if s.depth == 0 and s.exe == "git" and pred(s):
+            assert s.raw in fresh
+
+
+def test_dual_buffer_no_desync_under_fd_expansion_adjacency():
+    """Stress the mirrored fd-digit deletion against expansion-target divergence (the
+    argv_buf/raw_buf suffix-identical invariant): many spaced $()-redirects then push.
+    argv must exclude every target (→ 'push'), all bodies stay visible, raw resplittable."""
+    cmd = "git 1>$(a) 2>$(b) 3>$(c) 4>$(d) push"
+    seg = next(s for s in sp.analyze(cmd) if s.exe == "git")
+    assert sp.git_subcommand(seg.argv) == "push"
+    assert {"a", "b", "c", "d"} <= {s.exe for s in sp.analyze(cmd)}
+    assert [s.raw for s in sp.analyze(cmd) if s.depth == 0] == sp.split_segments(cmd)


### PR DESCRIPTION
## Problem (fail-open on two security gates)
An expansion-carrying redirect **target** — `$(...)`/backtick/`$'...'`/quoted, e.g. `git 2>'$(rm x)' push` or `git 2>$(rm x) commit --no-verify` — was left in the segment `raw` **and** leaked into `argv`, so `git_subcommand`/`commit_skips_hooks` read the residue token (`'$(rm'`) instead of `push`/`commit`. `git_push_guard` and `review_enforcement_commit` both exact-match the subcommand with no fail-closed net, so **the push and commit approval gates silently never fired**. This is the last residual of the redirect fail-open class #1455 opened.

## Fix (Option B — split argv-source from raw)
`split_segments` becomes a **byte-identical thin wrapper** over a new `parse_segments()` that yields per segment both:
- `raw` — unchanged (the expansion target is retained, so `_substitutions` still sees the nested command a substitution redirect target **executes**);
- `argv_src` — `raw` minus every redirect operator+target.

`analyze()` sources argv from `argv_src`, so a redirect target can never become `argv[1]` and spoof the subcommand. `_substitutions(raw)` is untouched → a nested `rm` stays visible to `protected_paths_guard` **by construction** (no rm-visibility regression). A new `_redirect_target_end()` balances `$(...)`/backticks/quotes to measure the full target word (the pre-#1455 word-scanner stopped at a bare `(`, so an unquoted `$(rm x)` was only partly excised); the rewind is removed.

## raw stays byte-identical (with one strictly-safer exception)
Locked by a golden test over 48 inputs (incl. fd-adjacency/param-expansion exotics), generated from the HEAD parser. The **one** intended difference: a `$(...)`/backtick target containing an **unquoted** control operator (`;` `&&` `||` `|`) is now paren-balanced into one segment — **strictly safer** than HEAD, which mis-split it (`git >|$(a; b) push` → subcommand `'$(a'`, push gate missed). Locked in `EXPLOITS`.

## Composes with #1457
Built alongside #1457 (control-structure resolution). Zero file-overlap (`_strip_wrappers`/`_CMD_POSITION_WORDS` vs `parse_segments`/`analyze`); rebased onto it. Together they catch **stacked** evasions neither catches alone: `(git 2>$(rm x) push)`, `if true; then git 2>$(rm x) push; fi`, `! git 2>\`rm x\` commit -n` → all resolve to `push`/`commit` with the `rm` still surfaced.

## Verification
- **genesis-security-reviewer** (refute-by-default): no CRITICAL, no live gate-bypass after ~350k differential-fuzz vs HEAD + real-bash/fake-git/fake-rm ground truth; 0 regressions, ~150+ cases where this catches a push/commit HEAD misses.
- Verify-RED (10 exploit subcommand asserts red pre-fix → green); **70 new + 121 shell_parse (incl. #1457's) + 391 consumer tests green**; ruff clean.
- E2E: gates fire on every exploit form ($()/backtick/concat/fd/subshell/control-structure); `protected_paths_guard` still blocks a destructive `rm` hidden in a redirect target; `push2>…` keeps `push2`.
- Pre-existing recursion-DoS on deeply-nested `$(...)` and `$'...'` ANSI-C boundary (both on HEAD too) → tabled follow-up.