### PR TITLE
fix(hooks): block a merge when CI never ran (readable-empty rollup)

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -839,6 +839,12 @@ findings below, a gated `gh pr merge`:
 - requires the PR base to equal the repo's default branch (retarget guard);
 - blocks unless mergeability is a definite `MERGEABLE` (a failed/unknown read
   does not merge).
+- **the CI gate** blocks red/pending checks; and — on the canonical public repo,
+  where CI always runs — an `absent` CI state (a readable EMPTY check set = CI
+  never ran, the tell of a conflicting branch or a dropped `pull_request` trigger)
+  also blocks, so an un-CI'd PR can't merge. An UNREADABLE CI read (`unknown`)
+  fails OPEN, and off the canonical repo `absent` fails open too (a repo may
+  legitimately have no CI). Waive with `# ci-override` (never `--admin`).
 - **Override sigils are split by boundary** so one waiver can't silently disarm
   an unrelated gate: `# review-override` waives ONLY the finding scans
   (review-body + inline P1s); `# stale-review-override` waives ONLY the

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -835,6 +835,15 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
         return "pending", sorted(set(pending))
     if not saw_recognized:
         return "unknown", []  # payload had no CI-shaped entries
+    # KNOWN RESIDUAL (deferred, Codex #1484 P2): "green" here means every check that
+    # IS present concluded success — it does NOT assert the REQUIRED CI workflow ran.
+    # A partial rollup (e.g. only a green CodeQL, the CI suite absent) reads green.
+    # The "absent" branch above only catches a FULLY-empty rollup (the conflicting-
+    # branch symptom, where CI+CodeQL are both pull_request-gated and neither builds).
+    # Closing the partial case robustly needs a config-driven "required CI check
+    # identity" (a required-CI analogue of _required_scheduled_review_kinds) so it
+    # does NOT false-block an install whose CI is legitimately path-filtered/skipped
+    # for a docs-only PR. Tracked as a follow-up; not bundled here.
     return "green", []
 
 

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -696,10 +696,19 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
                         (see _ci_identity + success_latest) — strict identity,
                         terminal completedAt comparison only, fail-closed.
       * ``"pending"`` — a check is still queued/running (and none are red)
-      * ``"unknown"`` — could not determine (API error, no checks, or an
-                        unrecognized payload shape) → callers FAIL OPEN, because
-                        blocking a merge on our own inability to read CI would be
-                        worse than the gap this gate closes.
+      * ``"absent"``  — a READABLE but genuinely EMPTY rollup (``[]``): zero checks
+                        exist, i.e. CI has NOT run. A DEFINITE fact, not a read
+                        failure — so the merge arm fail-CLOSES on it ON THE CANONICAL
+                        REPO (where CI always runs), waivable by ``# ci-override``.
+                        Off the canonical repo (which may legitimately have no CI) the
+                        caller lets it pass. This is the state that catches a
+                        conflicting branch / dropped ``pull_request`` trigger, which
+                        would otherwise merge un-CI'd.
+      * ``"unknown"`` — could NOT determine: an API error, empty/no output, an
+                        unparseable payload, or a non-empty payload with no CI-shaped
+                        entries. Callers FAIL OPEN, because blocking a merge on our own
+                        inability to read CI would be worse than the gap this closes.
+                        (Contrast with ``"absent"``: unreadable ≠ definitely-zero.)
 
     Tests inject via the ``_TEST_GH_CI_ROLLUP`` env var (a JSON array like
     ``gh pr view --json statusCheckRollup``) so no network is needed.
@@ -728,12 +737,23 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
             raw = result.stdout.strip()
         except Exception:
             return "unknown", []
+    if not raw:
+        # No output to read (empty stdout / unset seam): we cannot tell zero-checks
+        # from a silent read failure → fail-OPEN "unknown", never "absent".
+        return "unknown", []
     try:
-        checks = json.loads(raw) if raw else []
+        checks = json.loads(raw)
     except Exception:
         return "unknown", []
-    if not isinstance(checks, list) or not checks:
+    if not isinstance(checks, list):
         return "unknown", []
+    if not checks:
+        # A READABLE, genuinely-empty rollup: zero checks exist = CI has NOT run.
+        # Distinct from "unknown" (a read we could not complete) — this is a definite
+        # fact, so the canonical-repo merge arm fail-CLOSES on it (see main()): merging
+        # an empty-check PR is an un-CI'd merge. gh emits `[]` here when pull_request CI
+        # never fired (e.g. a conflicting branch suppresses the whole suite).
+        return "absent", []
 
     # First pass: for each strict identity (name, workflowName), the latest
     # `completedAt` among its SUCCESS CheckRuns on this head. A CANCELLED entry is
@@ -3485,6 +3505,13 @@ def main() -> int:
                         f"BLOCKED: PR #{pr_num} has merge conflicts. Resolve before merging.",
                         file=sys.stderr,
                     )
+                    print(
+                        "A conflicting branch ALSO suppresses all pull_request CI (GitHub "
+                        "cannot build the merge ref), so no CI runs until you merge the "
+                        "base branch (usually main) into your PR branch — that resolves "
+                        "both at once.",
+                        file=sys.stderr,
+                    )
                     return 2
                 if mergeable != "MERGEABLE":
                     # Allowlist (fail-CLOSED): anything that is not a definite
@@ -3499,7 +3526,10 @@ def main() -> int:
                         file=sys.stderr,
                     )
                     print(
-                        "GitHub may still be computing it, or the query failed. Wait and retry.",
+                        "GitHub may still be computing it, or the query failed. Wait and "
+                        "retry. A conflicting or still-computing branch also suppresses "
+                        "pull_request CI, so if CI never appears check "
+                        f"`gh pr view {pr_num} --json mergeable` first.",
                         file=sys.stderr,
                     )
                     return 2
@@ -3511,8 +3541,12 @@ def main() -> int:
                 # past a red `test` job — exactly how main was broken on
                 # 2026-07-28. Block red/pending CI unless a conscious, separate
                 # `# ci-override` is appended (never waived by --admin or
-                # # review-override). Fail-OPEN on "unknown" so a transient API
-                # hiccup can't wedge merges.
+                # # review-override). Fail-OPEN on "unknown" (a read we could not
+                # complete) so a transient API hiccup can't wedge merges — but
+                # fail-CLOSED on "absent" (a readable EMPTY check set = CI never ran)
+                # ON THE CANONICAL REPO (where CI always runs), so a conflicting branch
+                # or dropped pull_request trigger can't slip an un-CI'd merge through
+                # (handled just below).
                 ci_state, ci_bad = _pr_ci_status(pr_num, repo=merge_repo)
                 ci_override = has_trailing_override(merge_seg.raw, "ci-override")
                 if ci_state in ("red", "pending") and not ci_override:
@@ -3534,6 +3568,30 @@ def main() -> int:
                     print(
                         f"NOTE: CI {ci_state.upper()} on #{pr_num} "
                         f"({', '.join(ci_bad[:6])}) — merging via # ci-override "
+                        "(consciously accepted).",
+                        file=sys.stderr,
+                    )
+                # "absent" = a readable EMPTY check set (CI never ran). On the canonical
+                # public repo CI ALWAYS runs, so an empty set is anomalous → fail-CLOSED
+                # (a conflicting branch / dropped pull_request trigger would otherwise
+                # merge un-CI'd). Off the canonical repo (may legitimately have no CI)
+                # this stays fail-OPEN. Waived by the same conscious `# ci-override`.
+                # Scoped via the canonical-repo test (shared with the scheduled gate).
+                elif ci_state == "absent" and _scheduled_gate_applies(merge_repo):
+                    if not ci_override:
+                        print(
+                            f"BLOCKED: No CI checks have run on PR #{pr_num} (an empty "
+                            "check set). On the canonical repo CI always runs, so "
+                            "pull_request CI never fired — most often the branch was "
+                            "CONFLICTING (merge origin/main into it to resolve BOTH) or a "
+                            "trigger was dropped (push a commit to re-fire). Never merge "
+                            "an un-CI'd PR. If you are intentionally merging with no CI, "
+                            "append a trailing '# ci-override' (logged).",
+                            file=sys.stderr,
+                        )
+                        return 2
+                    print(
+                        f"NOTE: No CI checks on #{pr_num} — merging via # ci-override "
                         "(consciously accepted).",
                         file=sys.stderr,
                     )
@@ -3816,6 +3874,12 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     ci_state, ci_bad = _pr_ci_status(pr_num, repo=repo)
     print(f"ci             : {ci_state}{' (' + ', '.join(ci_bad[:6]) + ')' if ci_bad else ''}")
     if ci_state in ("red", "pending"):
+        failures += 1
+    elif ci_state == "absent" and _scheduled_gate_applies(repo):
+        # Mirror the enforcement arm so the report and gate never disagree: a readable
+        # empty check set on the canonical repo blocks (CI never ran — likely a
+        # conflicting branch or a dropped pull_request trigger).
+        print("  ↳ BLOCK — no CI checks have run (empty check set); pull_request CI never fired.")
         failures += 1
     # Order mirrors the gate: base-invariant → freshness → finding scans, so a
     # review published mid-run can't pass freshness with its P1s unscanned.

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -311,6 +311,14 @@ _CASES: list[tuple[str, object, int, str]] = [
         "merge conflicts",
     ),
     (
+        # Part B diagnostics: the CONFLICTING block must NAME the CI consequence —
+        # a conflicting branch suppresses pull_request CI until the base branch is merged in.
+        "mergeable_CONFLICTING_explains_ci_suppression",
+        lambda mp: _run(mp, _merge_cmd(), router=_router(mergeable="CONFLICTING")),
+        2,
+        "pull_request CI",
+    ),
+    (
         "mergeable_novel_state_blocks",
         lambda mp: _run(mp, _merge_cmd(), router=_router(mergeable="SOME_FUTURE_STATE")),
         2,
@@ -482,14 +490,16 @@ _CASES: list[tuple[str, object, int, str]] = [
         2,
         "review-body gate did not pass",
     ),
-    # (Codex-P2) CI-unknown is a deliberately fail-OPEN gate — empty/malformed CI reads
-    # must ALLOW, so the unified UNKNOWN->BLOCK aggregation can't regress them. NOTE: CI
-    # is not the ONLY fail-open path — the review-body and inline finding SCANS also fail
-    # open on an unreadable read (git_push_guard.py _scan_unreadable, non-strict). That
-    # scanner-unreadable path is a distinct axis carried to Slice 3 (PrFacts decision
-    # level, follow-up 086bd8e3), not exercised here.
+    # (Codex-P2) CI-"unknown" is a deliberately fail-OPEN gate — a read we could NOT
+    # complete (empty stdout / malformed JSON) must ALLOW, so a transient API hiccup
+    # can't wedge merges. This is DISTINCT from "absent" (a readable empty rollup =
+    # zero checks = CI genuinely did not run), which fail-CLOSES on the canonical repo
+    # (below). NOTE: CI is not the ONLY fail-open path — the review-body and inline
+    # finding SCANS also fail open on an unreadable read (git_push_guard.py
+    # _scan_unreadable, non-strict). That scanner-unreadable path is a distinct axis
+    # carried to Slice 3 (PrFacts decision level, follow-up 086bd8e3), not exercised here.
     (
-        "ci_empty_unknown_fails_open_allows",
+        "ci_empty_string_unknown_fails_open_allows",
         lambda mp: _run(mp, _merge_cmd(), ci=""),
         0,
         "",
@@ -497,6 +507,32 @@ _CASES: list[tuple[str, object, int, str]] = [
     (
         "ci_malformed_unknown_fails_open_allows",
         lambda mp: _run(mp, _merge_cmd(), ci="not-json"),
+        0,
+        "",
+    ),
+    # ── CI "absent" (readable empty rollup) — CI never ran. On the CANONICAL repo
+    # (where CI always runs) this fail-CLOSES: a conflicting branch or a dropped
+    # pull_request trigger leaves an empty check set, and merging it would be an
+    # UN-CI'd merge. Waivable by the same conscious `# ci-override`. Off the canonical
+    # repo (a repo that may legitimately have no CI) it stays fail-OPEN. ──
+    (
+        "ci_absent_on_canonical_blocks",
+        lambda mp: _run(mp, _merge_cmd(), ci="[]"),
+        2,
+        "No CI checks",
+    ),
+    (
+        "ci_absent_with_ci_override_continues",
+        lambda mp: _run(mp, _merge_cmd(trailer="# ci-override"), ci="[]"),
+        0,
+        "consciously accepted",
+    ),
+    (
+        "ci_absent_off_canonical_fails_open_allows",
+        lambda mp: (
+            mp.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/some-other-public-repo"),
+            _run(mp, _merge_cmd(), ci="[]"),
+        )[1],
         0,
         "",
     ),
@@ -997,6 +1033,33 @@ def test_check_pr_report_scheduled_absent_fails_verdict(monkeypatch, capsys):
     sched_line = next(ln for ln in out.splitlines() if ln.startswith("scheduled-claude"))
     assert "BLOCK" in sched_line
     assert rc == 1
+
+
+def test_check_pr_report_ci_absent_fails_verdict_on_canonical(monkeypatch, capsys):
+    """A readable-empty CI rollup ("absent") on the canonical repo is a FAILURE line and
+    flips the report's verdict — the report must not say "all gates pass" while the
+    enforcement arm would block an un-CI'd merge (report/gate never disagree)."""
+    _report_env(monkeypatch, scheduled=_scheduled_marker(HEAD))
+    monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("absent", []))
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", REPO)
+    rc = _mod.check_pr_report("100", repo=REPO)
+    out = capsys.readouterr().out
+    ci_line = next(ln for ln in out.splitlines() if ln.startswith("ci "))
+    assert "absent" in ci_line
+    assert "no ci checks" in out.lower()  # the BLOCK hint line
+    assert rc == 1
+
+
+def test_check_pr_report_ci_absent_off_canonical_does_not_fail(monkeypatch, capsys):
+    """Off the canonical repo, "absent" stays fail-OPEN — the report does NOT count it
+    as a failure (a repo that legitimately has no CI must not be false-blocked)."""
+    _report_env(monkeypatch, scheduled=_scheduled_marker(HEAD))
+    monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("absent", []))
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/some-other-public-repo")
+    rc = _mod.check_pr_report("100", repo=REPO)
+    out = capsys.readouterr().out
+    assert "no ci checks" not in out.lower()
+    assert rc == 0
 
 
 def test_check_pr_report_no_merge_with_when_scheduled_blocks(monkeypatch, capsys):

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1673,8 +1673,18 @@ class TestPrCiStatus:
         self._set(monkeypatch, [{"context": "legacy-ci", "state": "FAILURE"}])
         assert guard_module._pr_ci_status("1") == ("red", ["legacy-ci"])
 
-    def test_empty_is_unknown(self, guard_module, monkeypatch):
+    def test_empty_rollup_is_absent(self, guard_module, monkeypatch):
+        # A READABLE, genuinely-empty rollup ("[]") = zero checks = CI has not run.
+        # This is DISTINCT from "unknown" (could not read): it is a definite fact,
+        # so it is "absent" — the canonical-repo merge arm fail-CLOSES on it.
         monkeypatch.setenv("_TEST_GH_CI_ROLLUP", "[]")
+        assert guard_module._pr_ci_status("1") == ("absent", [])
+
+    def test_no_output_is_unknown(self, guard_module, monkeypatch):
+        # An EMPTY string (gh produced no output) is NOT a readable empty list — we
+        # cannot tell zero-checks from a silent read failure, so it stays fail-open
+        # "unknown", never "absent".
+        monkeypatch.setenv("_TEST_GH_CI_ROLLUP", "")
         assert guard_module._pr_ci_status("1") == ("unknown", [])
 
     def test_garbage_is_unknown(self, guard_module, monkeypatch):
@@ -1683,6 +1693,8 @@ class TestPrCiStatus:
 
     def test_non_ci_payload_is_unknown_fail_open(self, guard_module, monkeypatch):
         # e.g. a review-comment mock other tests inject — must not be read as red.
+        # A NON-empty payload with no CI-shaped entries stays "unknown" (we saw
+        # something but recognized no CI verdict) — NOT "absent" (which is zero checks).
         self._set(monkeypatch, [{"login": "codex", "body": "FAILURE somewhere"}])
         assert guard_module._pr_ci_status("1") == ("unknown", [])
 


### PR DESCRIPTION
## Problem

The merge gate failed **open** whenever `_pr_ci_status` returned `"unknown"`, and a readable-but-**empty** check set (zero checks = CI never ran) was conflated into `"unknown"`. So a `MERGEABLE` PR with no CI could merge **un-CI'd**.

This is exactly the failure mode a **conflicting branch** produces: GitHub can't build the `refs/pull/N/merge` ref, so the whole `pull_request` CI suite never runs and `statusCheckRollup` comes back `[]`. The conflicting case happens to be caught today by the mergeable gate, but any other `pull_request`-trigger drop on a non-conflicting branch would slip an un-CI'd merge through.

## Change

- **`_pr_ci_status` splits three ways** instead of collapsing everything to `"unknown"`:
  - no output / unparseable / non-list → `"unknown"` — a read we could **not complete**, so it stays fail-**open** (a transient API hiccup must not wedge merges);
  - a readable empty list `[]` → new `"absent"` — a **definite fact** that CI has not run.
- **The merge arm fail-CLOSES on `"absent"`** — but only on the canonical public repo (where CI always runs), waivable by the existing `# ci-override`. Off the canonical repo (which may legitimately have no CI) `"absent"` stays fail-open. This deliberate asymmetry: `red`/`pending` only ever fire when checks exist, but `"absent"` would fire on *every* merge of a no-CI repo, so it must be canonical-scoped.
- **`check_pr_report` mirrors the enforcement arm** so the `--check-pr` report and the gate never disagree.
- **Diagnostics**: the `CONFLICTING` and non-`MERGEABLE` block messages now name the cause — a conflicting/still-computing branch suppresses `pull_request` CI until the base branch is merged into the PR branch — so "CI never fired" is diagnosed at the point of the block instead of hunted for.

## Verification

- Test-first (verify-RED on each new test). Full state matrix `{green, red, pending, absent, unknown} × {on-, off-canonical}`, both `# ci-override` branches, and the report mirror are covered. 534 targeted tests pass across the five merge-gate / push-guard test files; `ruff` clean.
- **Live end-to-end** against a real open, conflicting PR whose `statusCheckRollup` is `[]`: it now resolves to `"absent"` and the report shows `ci : absent` + `BLOCK`; a green PR is unchanged.
- Adversarial architect + security review: no fail-open, no bypass, no report/gate disagreement.

Ledger: c6eba1367d7c496686ba78155fefe160
