### PR TITLE
fix(cc): make ego dispatch outcomes recallable (success + untagged)

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -1118,6 +1118,16 @@ class DirectSessionRunner:
             return
         proposal_id = request.caller_context.split(":", 1)[1]
         advisories: list[str] = []
+        # WS-3: a dispatch outcome inherits the SESSION's provenance. A
+        # research/interact/etc. dispatch is external_untrusted — its output can
+        # echo web/browser content, and these outcome memories are now
+        # default-recallable (source_subsystem dropped), so an unstamped one
+        # would default to first_party and bypass recall-time external-content
+        # handling (a laundered indirect prompt injection). Stamp it with the
+        # SAME origin the session's own memories carry (see _PROFILE_ORIGIN use
+        # at session launch). memory_class="fact" pins these as operational
+        # facts so a summary echoing MUST/NEVER isn't misfiled as a rule.
+        dispatch_origin = _PROFILE_ORIGIN.get(request.profile)
         try:
             from genesis.db.crud.ego import (
                 mark_proposal_verification_failed,
@@ -1154,6 +1164,8 @@ class DirectSessionRunner:
                                 source="ego_dispatch_verification",
                                 tags=["ego", "verification_failure"],
                                 memory_type="episodic",
+                                memory_class="fact",
+                                origin_class=dispatch_origin,
                                 wing="autonomy",
                                 room="ego",
                             )
@@ -1207,6 +1219,8 @@ class DirectSessionRunner:
                         source="ego_dispatch_outcome",
                         tags=["ego", outcome_tag],
                         memory_type="episodic",
+                        memory_class="fact",
+                        origin_class=dispatch_origin,
                         wing="autonomy",
                         room="ego",
                     )

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -1156,7 +1156,6 @@ class DirectSessionRunner:
                                 memory_type="episodic",
                                 wing="autonomy",
                                 room="ego",
-                                source_subsystem="ego",
                             )
                     except Exception:
                         logger.debug(
@@ -1188,22 +1187,31 @@ class DirectSessionRunner:
                 success=result.success,
                 summary=summary,
             )
-            # On failure: create observation so ego sees it next cycle
-            if not result.success:
-                try:
-                    store = getattr(self._rt, "_memory_store", None)
-                    if store is not None:
-                        await store.store(
-                            content=(f"Ego dispatch FAILED for proposal {proposal_id}: {summary}"),
-                            source="ego_dispatch_outcome",
-                            tags=["ego", "dispatch_failure"],
-                            memory_type="episodic",
-                            wing="autonomy",
-                            room="ego",
-                            source_subsystem="ego",
-                        )
-                except Exception:
-                    logger.debug("Failed to store failure observation", exc_info=True)
+            # Record the dispatch outcome (BOTH polarities) as a retrievable
+            # memory so the ego and later CC sessions can recall what happened to
+            # a dispatch — not just failures. Stored WITHOUT source_subsystem: a
+            # dispatch outcome is operational history, not internal decisional
+            # output, so it must stay in default recall / the proactive hook
+            # (classified in test_store_subsystem_coverage's USER_CONTEXT_ALLOWLIST).
+            try:
+                store = getattr(self._rt, "_memory_store", None)
+                if store is not None:
+                    if result.success:
+                        content = f"Ego dispatch SUCCEEDED for proposal {proposal_id}: {summary}"
+                        outcome_tag = "dispatch_success"
+                    else:
+                        content = f"Ego dispatch FAILED for proposal {proposal_id}: {summary}"
+                        outcome_tag = "dispatch_failure"
+                    await store.store(
+                        content=content,
+                        source="ego_dispatch_outcome",
+                        tags=["ego", outcome_tag],
+                        memory_type="episodic",
+                        wing="autonomy",
+                        room="ego",
+                    )
+            except Exception:
+                logger.debug("Failed to store dispatch outcome observation", exc_info=True)
         except Exception:
             logger.warning(
                 "Failed to record proposal outcome for %s",

--- a/tests/test_cc/test_direct_session.py
+++ b/tests/test_cc/test_direct_session.py
@@ -542,3 +542,75 @@ async def test_record_outcome_missing_file_marks_failed(db, tmp_path):
     prop = await get_proposal(db, "prop-miss")
     assert prop["status"] == "failed"
     assert "verification_failed" in (prop["user_response"] or "")
+
+
+# --- dispatch-outcome recall visibility (B2a) ---
+#
+# Dispatch outcomes must be RETRIEVABLE by default recall / the proactive hook so
+# the ego (and CC sessions) can recall what happened to a dispatch. Two gaps this
+# locks: (1) a SUCCESSFUL dispatch wrote no memory at all; (2) the failure memory
+# was tagged source_subsystem="ego", which EXCLUDES it from default recall. The
+# fix stores both polarities WITHOUT source_subsystem (operational history, not
+# internal decisional output — classified in test_store_subsystem_coverage's
+# USER_CONTEXT_ALLOWLIST).
+
+
+class _RecordingStore:
+    """Fake MemoryStore implementing the real .store(**kwargs) contract."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def store(self, **kwargs):
+        self.calls.append(kwargs)
+        return "mem-id"
+
+
+def _recording_runner(db, store):
+    from types import SimpleNamespace
+
+    return DirectSessionRunner(
+        invoker=AsyncMock(),
+        session_manager=AsyncMock(),
+        config_builder=AsyncMock(),
+        runtime=SimpleNamespace(_db=db, _memory_store=store),
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_success_writes_recallable_memory(db):
+    """A successful dispatch must write a memory tagged dispatch_success, and it
+    must be recallable (NO source_subsystem, else default recall excludes it)."""
+    from genesis.db.crud.ego import create_proposal
+
+    store = _RecordingStore()
+    await create_proposal(db, id="prop-ok", action_type="dispatch", content="x", status="executed")
+    req = DirectSessionRequest(prompt="t", caller_context="ego_proposal:prop-ok")
+    res = DirectSessionResult(session_id="s-ok", success=True, output_text="all done")
+    await _recording_runner(db, store)._record_proposal_outcome(req, res)
+
+    succ = [c for c in store.calls if "dispatch_success" in (c.get("tags") or [])]
+    assert len(succ) == 1, "a successful dispatch must write exactly one outcome memory"
+    assert "prop-ok" in succ[0].get("content", "")
+    assert succ[0].get("source_subsystem") is None, (
+        "dispatch outcome memories must be recallable — no source_subsystem tag"
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_failure_memory_is_recallable(db):
+    """A failed dispatch's memory must also be recallable (untagged), symmetric
+    with success — today it is tagged source_subsystem='ego' and hidden."""
+    from genesis.db.crud.ego import create_proposal
+
+    store = _RecordingStore()
+    await create_proposal(db, id="prop-bad", action_type="dispatch", content="x", status="executed")
+    req = DirectSessionRequest(prompt="t", caller_context="ego_proposal:prop-bad")
+    res = DirectSessionResult(session_id="s-bad", success=False, output_text="it broke")
+    await _recording_runner(db, store)._record_proposal_outcome(req, res)
+
+    fail = [c for c in store.calls if "dispatch_failure" in (c.get("tags") or [])]
+    assert len(fail) == 1, "a failed dispatch must write exactly one outcome memory"
+    assert fail[0].get("source_subsystem") is None, (
+        "dispatch outcome memories must be recallable — no source_subsystem tag"
+    )

--- a/tests/test_cc/test_direct_session.py
+++ b/tests/test_cc/test_direct_session.py
@@ -614,3 +614,100 @@ async def test_record_outcome_failure_memory_is_recallable(db):
     assert fail[0].get("source_subsystem") is None, (
         "dispatch outcome memories must be recallable — no source_subsystem tag"
     )
+
+
+# --- WS-3 provenance: dispatch outcomes inherit the SESSION's origin (Codex #1487) ---
+#
+# A research/interact/etc. dispatch is external_untrusted — its output can echo
+# web/browser content. These outcome memories are now default-recallable (the
+# source_subsystem drop above), so an UNSTAMPED one defaults to first_party and
+# bypasses recall-time external-content handling: a laundered indirect prompt
+# injection into later proactive sessions. The outcome store must carry the SAME
+# origin the session's own memories carry, and pin memory_class="fact" so a
+# summary echoing MUST/NEVER isn't heuristically misfiled as a rule.
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_stamps_external_untrusted_origin(db):
+    """A research-profile dispatch outcome is stored external_untrusted, not the
+    first_party default — else it launders external content into default recall."""
+    from genesis.db.crud.ego import create_proposal
+
+    store = _RecordingStore()
+    await create_proposal(db, id="prop-ext", action_type="dispatch", content="x", status="executed")
+    req = DirectSessionRequest(
+        prompt="t", profile="research", caller_context="ego_proposal:prop-ext"
+    )
+    res = DirectSessionResult(
+        session_id="s-ext", success=True, output_text="web-sourced findings summary"
+    )
+    await _recording_runner(db, store)._record_proposal_outcome(req, res)
+
+    out = [c for c in store.calls if c.get("source") == "ego_dispatch_outcome"]
+    assert len(out) == 1
+    assert out[0].get("origin_class") == "external_untrusted", (
+        "a research (external_untrusted) dispatch outcome must NOT be stored first_party"
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_first_party_profile_leaves_origin_none(db):
+    """An observe-profile (first-party) dispatch passes origin_class=None so the
+    store's own derive_origin_class resolves first_party — no over-stamping."""
+    from genesis.db.crud.ego import create_proposal
+
+    store = _RecordingStore()
+    await create_proposal(db, id="prop-fp", action_type="dispatch", content="x", status="executed")
+    req = DirectSessionRequest(prompt="t", profile="observe", caller_context="ego_proposal:prop-fp")
+    res = DirectSessionResult(session_id="s-fp", success=True, output_text="ok")
+    await _recording_runner(db, store)._record_proposal_outcome(req, res)
+
+    out = [c for c in store.calls if c.get("source") == "ego_dispatch_outcome"]
+    assert len(out) == 1
+    assert out[0].get("origin_class") is None
+
+
+@pytest.mark.asyncio
+async def test_record_outcome_pins_fact_memory_class(db):
+    """Dispatch outcomes pin memory_class='fact' — an outcome whose summary echoes
+    a rule-like phrase (MUST/NEVER) must not be heuristically misfiled as a rule."""
+    from genesis.db.crud.ego import create_proposal
+
+    store = _RecordingStore()
+    await create_proposal(db, id="prop-mc", action_type="dispatch", content="x", status="executed")
+    req = DirectSessionRequest(prompt="t", caller_context="ego_proposal:prop-mc")
+    res = DirectSessionResult(
+        session_id="s-mc", success=True, output_text="You MUST NEVER skip the gate"
+    )
+    await _recording_runner(db, store)._record_proposal_outcome(req, res)
+
+    out = [c for c in store.calls if c.get("source") == "ego_dispatch_outcome"]
+    assert len(out) == 1
+    assert out[0].get("memory_class") == "fact"
+
+
+@pytest.mark.asyncio
+async def test_verification_failure_memory_stamps_origin_and_class(db, tmp_path):
+    """The verification-failure outcome store (the OTHER recallable outcome write)
+    is stamped the same way — external_untrusted origin + fact class."""
+    from genesis.db.crud.ego import create_proposal
+
+    store = _RecordingStore()
+    await create_proposal(
+        db,
+        id="prop-vf",
+        action_type="dispatch",
+        content="x",
+        status="executed",
+        expected_outputs=json.dumps({"files": [str(tmp_path / "never-written.md")]}),
+    )
+    req = DirectSessionRequest(
+        prompt="t", profile="research", caller_context="ego_proposal:prop-vf"
+    )
+    res = DirectSessionResult(session_id="s-vf", success=True, output_text="claims done")
+    await _recording_runner(db, store)._record_proposal_outcome(req, res)
+
+    vf = [c for c in store.calls if c.get("source") == "ego_dispatch_verification"]
+    assert len(vf) == 1
+    assert vf[0].get("origin_class") == "external_untrusted"
+    assert vf[0].get("memory_class") == "fact"

--- a/tests/test_memory/test_store_subsystem_coverage.py
+++ b/tests/test_memory/test_store_subsystem_coverage.py
@@ -65,6 +65,7 @@ USER_CONTEXT_ALLOWLIST: dict[str, str] = {
     # now land as extractable transcripts (W0.5), so there is no .store() call
     # here to classify.
     "channels/voice/genesis_bridge.py::_remember": "user-spoken fact via the voice remember tool (first-party user content; must stay in recall)",
+    "cc/direct_session.py::_record_proposal_outcome": "ego dispatch outcomes (success/failure/verification) are operational history, not internal decisional output — must stay in default recall + the proactive hook so the ego and CC sessions can recall what happened to a dispatch (B2a)",
     "eval/longmemeval/ingest.py::ingest_haystack": "LongMemEval benchmark haystack ingest into an EPHEMERAL throwaway store "
     "(first_party user-history content; never touches prod; not a subsystem)",
     "knowledge/ingest_upload.py::_store_as_is": "user-uploaded knowledge_base content (external-world, recallable)",


### PR DESCRIPTION
## Problem
Ego dispatch outcomes weren't retrievable by default recall / the proactive hook:
- **Successful** dispatches wrote no memory at all (only failures did).
- Failure/verification-failure memories were tagged \`source_subsystem="ego"\`, which excludes them from default recall (\`memory/retrieval.py\` \`_KNOWN_SUBSYSTEMS\`) and forces them FTS5-only (no vector embedding).

So neither the ego nor a later CC session could recall "what happened to that dispatch" on the success path — and failures were hidden from default recall too.

## Fix
\`_record_proposal_outcome\` now writes **both** polarities as an episodic memory **without** \`source_subsystem\` — a dispatch outcome is operational history, not internal decisional output, so it stays in default recall + the proactive hook (and now embeds to the vector store, so it is vector-recallable). The writer is registered in \`test_store_subsystem_coverage\`'s \`USER_CONTEXT_ALLOWLIST\`. The ego's separate observations-table awareness path (\`_ego_dispatch_on_end\`) is untouched.

## Tests
TDD: two locking tests verified RED (success wrote nothing; failure tagged \`ego\`) then GREEN. Affected set green: \`test_direct_session.py\` + \`test_store_subsystem_coverage.py\` + \`test_origin_class.py\` (66 passed).

## Review
Adversarial genesis-architect audit: CLEAN / Ready to merge: Yes. Verified no consumer relies on the exclusion, origin_class unchanged (first_party), all three store sites untagged, ego awareness path untouched.

## Deploy path
Runtime code — pull + server restart.

Part of the ego dispatch/proposal lifecycle work (activation loop + ego pilot; slice B2a).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dispatch outcomes are now saved as recallable factual memories for both successful and failed dispatches.
  * Outcome memories retain the dispatched profile’s provenance and session origin.
  * Verification-failure outcomes now include the same factual classification and provenance details.

* **Bug Fixes**
  * External research outcomes are correctly marked as untrusted.
  * First-party observations no longer receive an incorrectly derived origin.
  * Internal subsystem metadata is excluded from outcome memories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->