### PR TITLE
fix(observability): git-health deep-fsck --no-reflogs + truthful alert

### DIFF
--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1743,24 +1743,47 @@ async def _check_git_health_deep(db) -> None:
     if db is None:
         return
     failures = ", ".join(report.failures)
+    # Truthful alert: surface the ACTUAL fsck stderr rather than a fixed
+    # "objects missing/corrupt → REVERT_CODE disabled" narrative. Both halves of
+    # that old text were false in practice: the failure may be any fsck problem
+    # (not necessarily object corruption), and the deep verdict does NOT gate
+    # REVERT_CODE — the guardian preflight uses a live cheap probe
+    # (guardian/git_watch.py::container_git_supports_revert), never this file.
+    # Collapse duplicate stderr lines and cap at 5 so a repeated error can't wall
+    # off the message.
+    stderr = (report.details.get("fsck_stderr") or "").strip()
+    detail_lines: list[str] = []
+    for line in stderr.splitlines():
+        line = line.strip()
+        if line and line not in detail_lines:
+            detail_lines.append(line)
+        if len(detail_lines) >= 5:
+            break
+    detail = ("\n" + "\n".join(detail_lines)) if detail_lines else ""
     try:
         created = await observations.create(
             db,
             id=str(uuid.uuid4()),
             source="git_health_monitor",
             type="infrastructure_alert",
-            # Slot tag + DB-level dedup (the only cross-process guard; see
-            # the cheap-probe counterpart above). NOTE deliberately NO extra
-            # alert cooldown here: the 24h run-interval already bounds this
-            # path to one alert per process-day, and probe sensitivity must
-            # stay unchanged — recovery hygiene, not detection damping.
+            # Slot tag + an explicit STABLE content_hash → DB-level dedup keys on
+            # the failure-CLASS, not the (now run-varying) stderr body. create()
+            # otherwise hashes `content`; since the body embeds live fsck stderr,
+            # two failures with differing stderr would NOT dedup and would pile up
+            # stale criticals — the exact accumulation the self-heal guards against.
+            # NO extra alert cooldown: the 24h run-interval bounds this to ~one
+            # alert per process-day, and the category-scoped self-heal clears the
+            # whole git_deep slot on recovery (resolve_by_source_and_type, above).
             category="git_deep",
             skip_if_duplicate=True,
+            content_hash=hashlib.sha256(
+                f"git_deep:{','.join(sorted(report.failures))}".encode()
+            ).hexdigest(),
             content=(
-                f"`git fsck --full` reported problems ({failures}) — objects are "
-                "missing or corrupt (incl. zeroed-but-present blobs), which disables "
-                "the guardian's REVERT_CODE lever. Diagnose and repair the local git "
-                "in ~/genesis — see docs/reference/recovery-and-portability-workflow.md."
+                f"`git fsck --full --no-reflogs` reported problems ({failures}) "
+                f"in ~/genesis.{detail}\n"
+                "Investigate with `scripts/git_repair.py` — see "
+                "docs/reference/recovery-and-portability-workflow.md."
             ),
             priority="critical",
             created_at=datetime.now(UTC).isoformat(),

--- a/src/genesis/observability/git_health.py
+++ b/src/genesis/observability/git_health.py
@@ -240,7 +240,21 @@ def _check_git_deep_sync(repo: Path) -> GitHealthReport:
     # present loose blob (the outage pattern) that --connectivity-only would miss
     # (that flag only checks reachability, not content). Missing/corrupt objects →
     # non-zero. Dangling objects → exit 0 (benign, not a failure).
-    rc, out, err = _run_git(repo, "fsck", "--no-progress", "--full", timeout=_DEEP_TIMEOUT_S)
+    #
+    # --no-reflogs: this check exists to detect OBJECT-content corruption reachable
+    # from refs; reflog integrity is irrelevant to it (and to REVERT_CODE, which the
+    # guardian gates on a live cheap probe, not this verdict). Without it, routine
+    # branch/worktree churn + gc leaves a branch reflog referencing a pruned commit,
+    # so `git fsck --full` prints "invalid reflog entry" and exits non-zero — firing
+    # a recurring FALSE "objects corrupt" CRITICAL (verified 2026-08-25: the recorded
+    # stderr was reflog noise, not corruption). --no-reflogs drops that class while
+    # still rehashing every object, so a real zeroed/missing blob still fails.
+    # Narrowing (intended): an object referenced ONLY by a reflog and by no ref/
+    # index is no longer scanned — outside this check's ref-reachable-corruption
+    # and REVERT_CODE scope.
+    rc, out, err = _run_git(
+        repo, "fsck", "--no-progress", "--full", "--no-reflogs", timeout=_DEEP_TIMEOUT_S
+    )
     if rc == -1:
         failures.append("fsck_timeout")
     elif rc != 0:

--- a/tests/test_awareness/test_git_health_check.py
+++ b/tests/test_awareness/test_git_health_check.py
@@ -109,9 +109,9 @@ async def test_probe_exception_never_raises(monkeypatch):
     await loop._check_git_health(object())
 
 
-def _deep_report(ok: bool, failures=None):
+def _deep_report(ok: bool, failures=None, details=None):
     return git_health.GitHealthReport(
-        ok=ok, failures=failures or [], details={}, kind="deep", checked_at="t"
+        ok=ok, failures=failures or [], details=details or {}, kind="deep", checked_at="t"
     )
 
 
@@ -162,6 +162,64 @@ class TestDeepCheck:
         assert kw["source"] == "git_health_monitor"
         assert "fsck --full" in kw["content"]
         assert "fsck_failed" in kw["content"]
+
+    @pytest.mark.asyncio
+    async def test_deep_alert_is_truthful_no_false_claims(self, monkeypatch):
+        # The alert must surface the ACTUAL fsck stderr and must NOT repeat the
+        # old hard-coded false narrative: "objects missing or corrupt" (it may be
+        # any fsck failure) and "disables the REVERT_CODE lever" (the deep verdict
+        # does not gate REVERT_CODE — the guardian preflight uses a live cheap
+        # probe). Verified 2026-08-25.
+        monkeypatch.setattr(
+            git_health,
+            "check_git_deep",
+            AsyncMock(
+                return_value=_deep_report(
+                    False,
+                    ["fsck_failed"],
+                    {"fsck_stderr": "error: sentinel-xyz object corrupt marker"},
+                )
+            ),
+        )
+        monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
+        obs = AsyncMock()
+        monkeypatch.setattr(loop.observations, "create", obs)
+
+        await loop._check_git_health_deep(object())
+
+        content = obs.call_args.kwargs["content"]
+        assert "sentinel-xyz" in content, "alert must show the real fsck stderr"
+        assert "REVERT_CODE" not in content, "must not repeat the false REVERT_CODE claim"
+        assert "missing or corrupt" not in content, "must not hard-code a corruption narrative"
+
+    @pytest.mark.asyncio
+    async def test_deep_alert_dedup_hash_stable_across_varying_stderr(self, monkeypatch):
+        # The alert BODY now shows run-varying fsck stderr, but the dedup identity
+        # must key on the stable failure-CLASS (create() dedups on content_hash) —
+        # else two transient failures with differing stderr both insert, piling up
+        # stale criticals the self-heal is meant to prevent. Lock the stable hash.
+        hashes: list[str | None] = []
+
+        async def _capture(*a, **k):
+            hashes.append(k.get("content_hash"))
+            return "id"
+
+        monkeypatch.setattr(loop.observations, "create", _capture)
+        monkeypatch.setattr(git_health, "write_git_health_verdict", lambda *a, **k: None)
+
+        for stderr in ("error: unable to read aaaa", "error: unable to read bbbb"):
+            loop._last_git_deep_run_at = None  # bypass the daily guard for the 2nd run
+            monkeypatch.setattr(
+                git_health,
+                "check_git_deep",
+                AsyncMock(
+                    return_value=_deep_report(False, ["fsck_failed"], {"fsck_stderr": stderr})
+                ),
+            )
+            await loop._check_git_health_deep(object())
+
+        assert hashes[0] is not None, "must pass an explicit stable content_hash"
+        assert hashes[0] == hashes[1], "dedup hash must be stable despite differing stderr"
 
     @pytest.mark.asyncio
     async def test_daily_guard_skips_second_run_within_window(self, monkeypatch):

--- a/tests/test_observability/test_git_health.py
+++ b/tests/test_observability/test_git_health.py
@@ -172,6 +172,37 @@ class TestDeepCheck:
         assert rep.ok is False
         assert "fsck_failed" in rep.failures
 
+    @pytest.mark.asyncio
+    async def test_invalid_reflog_entry_not_flagged(self, repo):
+        # Routine branch/worktree churn + gc can leave a branch reflog
+        # referencing a pruned commit; `git fsck --full` then prints "invalid
+        # reflog entry" and exits non-zero. That is NOT object corruption and is
+        # irrelevant to this check's object-integrity purpose (and to REVERT_CODE,
+        # which the guardian gates on a live cheap probe, not this verdict), so
+        # the deep scan runs with --no-reflogs and MUST NOT flag it. Root cause of
+        # the recurring false "objects corrupt" CRITICAL (verified 2026-08-25).
+        self._commit_file(repo)
+        subprocess.run(["git", "-C", str(repo), "branch", "feat"], check=True)
+        reflog = repo / ".git" / "logs" / "refs" / "heads" / "feat"
+        reflog.parent.mkdir(parents=True, exist_ok=True)
+        reflog.write_text(
+            "0000000000000000000000000000000000000000 "
+            "deadbeef00000000000000000000000000000000 t <t@t> 1600000000 +0000\tbogus\n"
+        )
+        # Lock WHY this test is meaningful: a reflog-CHECKING fsck DOES fail on this
+        # same repo, so the test goes red if --no-reflogs is ever dropped.
+        with_reflogs = subprocess.run(
+            ["git", "-C", str(repo), "fsck", "--no-progress", "--full"],
+            capture_output=True,
+            text=True,
+        )
+        assert with_reflogs.returncode != 0 and "invalid reflog entry" in with_reflogs.stderr, (
+            "precondition: the injected entry must make a reflog-checking fsck fail"
+        )
+        rep = await g.check_git_deep(repo)
+        assert rep.ok is True, f"reflog noise must not be flagged; failures={rep.failures}"
+        assert "fsck_failed" not in rep.failures
+
 
 class TestMountReadonly:
     def test_ro_and_rw_detection(self):


### PR DESCRIPTION
## What

The daily deep `git fsck --full` (`observability/git_health.py`) checks reflogs by default. Routine branch/worktree churn + gc can leave a branch reflog referencing a pruned commit, so fsck prints `invalid reflog entry` and exits non-zero — firing a recurring **false** "objects missing or corrupt" CRITICAL. The recorded failure stderr from the latest occurrence was reflog noise, not object corruption.

## Changes

- **`--no-reflogs` on the deep fsck.** This check exists to detect object-content corruption reachable from refs; reflog integrity is irrelevant to it. `--full --no-reflogs` still rehashes every object (real zeroed/missing reachable blobs still fail — corruption regression tests unchanged & green) but drops the reflog-noise false-positive class. Empirically verified: with reflogs → rc 2 `invalid reflog entry`; `--no-reflogs` → rc 0; a zeroed blob under `--no-reflogs` → rc 3. The intended narrowing (reflog-only-reachable objects) is documented.
- **Truthful alert** (`awareness/loop.py`). Surfaces the actual fsck stderr (deduped, ≤5 lines) instead of a hard-coded "objects missing/corrupt → REVERT_CODE disabled" narrative. Both claims were false: the failure may be any fsck problem, and the deep verdict does **not** gate REVERT_CODE — the preflight uses a live cheap probe (`guardian/git_watch.py::container_git_supports_revert`: HEAD + `git config --list` + writable `.git`, no fsck). Dedup identity is pinned to an explicit **stable** `content_hash` (failure-class, not the variable stderr body) so transient failures still collapse to one row.

## Tests / verification

- TDD verify-RED → GREEN. New tests: reflog-not-flagged (with a precondition lock that fails if `--no-reflogs` is dropped), truthful-alert (asserts real stderr present, no false claims), dedup-hash-stable-across-varying-stderr. Corruption regression tests unchanged & green. **42 passed, ruff clean.**
- E2E: `check_git_deep` on a live install → `ok=True`.
- genesis-architect adversarial review: 1 SHOULD-FIX (dedup key weakened by the now-variable body) resolved + test-locked; 2 NOTEs + 1 NIT addressed.
