### PR TITLE
fix(recon): analyze the whole changelog range on a multi-release CC jump

### DIFF
--- a/src/genesis/learning/signals/cc_version.py
+++ b/src/genesis/learning/signals/cc_version.py
@@ -9,15 +9,10 @@ import re
 import shutil
 import uuid
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
 
 import aiosqlite
 
 from genesis.awareness.types import SignalReading
-from genesis.util.tasks import tracked_task
-
-if TYPE_CHECKING:
-    from genesis.routing.router import Router
 
 logger = logging.getLogger(__name__)
 
@@ -25,30 +20,35 @@ logger = logging.getLogger(__name__)
 class CCVersionCollector:
     """Detects CC version changes by comparing against last-known version.
 
-    When a version change is detected:
-    - Runs CCUpdateAnalyzer to fetch changelog and classify impact
-    - Stores analysis as a recon finding BEFORE returning the signal
+    DETECT-AND-RECORD ONLY — this collector deliberately does NO impact
+    analysis. When a version change is detected it:
+    - Stores a ``version_change`` observation and advances the baseline
     - Emits signal value=1.0 (triggers depth escalation in awareness loop)
 
-    On first run or no change: emits 0.0.
+    On first run or no change: emits 0.0, and (when unchanged) checks the npm
+    registry for an available newer version (``cc_version_available``).
+
+    **Why no impact analysis here.** Running ``CCUpdateAnalyzer`` from this
+    collector was removed deliberately: analysis is a variable-cost,
+    multi-LLM-call operation, and every way of driving it from a signal tick
+    was a reliability bug — awaited inline it blocks the awareness tick and a
+    fixed caller deadline cancels it (storing NO finding on exactly the large
+    multi-release jump it exists for), while dispatched as a background task it
+    is lost on shutdown (the baseline has already advanced, so it never
+    retries). CC updates on this system are DELIBERATE (the auto-updater is
+    disabled — the pin is the only mover), so impact analysis belongs to paths
+    that are idempotent and retryable, not to a hot detection tick:
+    - ``recon_cc_update_check`` MCP — on-demand analysis (alerts), and
+    - the daily pre-eval job — proactively caches per-version verdicts BEFORE
+      a version is adopted,
+    with the cc-update skill's mandatory full-changelog read at bump time.
+    Detection stays here because it must be cheap and always succeed.
     """
 
     signal_name = "cc_version_changed"
 
-    def __init__(
-        self,
-        db: aiosqlite.Connection,
-        router: Router | None = None,
-        pipeline_getter: object | None = None,
-        memory_store_getter: object | None = None,
-    ) -> None:
+    def __init__(self, db: aiosqlite.Connection) -> None:
         self._db = db
-        self._router = router
-        # Accept callables that return dependencies (lazy resolution).
-        # This avoids init ordering issues — outreach/memory may not be
-        # ready yet when the learning subsystem is constructed.
-        self._pipeline_getter = pipeline_getter
-        self._memory_store_getter = memory_store_getter
 
     async def collect(self) -> SignalReading:
         now = datetime.now(UTC).isoformat()
@@ -87,25 +87,10 @@ class CCVersionCollector:
                     "Failed to store CC version change %s -> %s",
                     last_known, current, exc_info=True,
                 )
-            # Impact analysis is best-effort ENRICHMENT, dispatched OFF the signal
-            # loop. The version-change observation is already persisted above; and
-            # analyze() is now map-reduce (up to _MAX_CHUNKS rate-gated LLM calls),
-            # so awaiting it inline would both (a) block the whole awareness signal
-            # tick for the analysis duration and (b) force a fixed caller deadline
-            # that — on an install whose only keyed free provider is RPM-limited —
-            # cancels the analysis and stores NO finding on the exact large-jump
-            # case it exists for. A tracked background task removes both: the tick
-            # returns immediately and the finding lands when analysis completes.
-            # _analyze_update catches + logs its own failures at WARNING (incl. the
-            # 600s timeout); tracked_task's done-callback is only the backstop for an
-            # unexpected escape. Retention is NOT provided by tracked_task (it keeps
-            # no registry) — the coroutine stays alive via its await-chain (each
-            # awaited fetch/LLM/DB future back-references the task); keep its first
-            # step an awaited loop future, or GC-mid-run risk returns.
-            tracked_task(
-                self._analyze_update(last_known, current),
-                name="cc-version-impact-analysis",
-            )
+            # NO impact analysis here, by design — see the class docstring. The
+            # version_change observation above is the durable record; analysis
+            # belongs to the idempotent/retryable paths (recon_cc_update_check
+            # MCP, the daily pre-eval job), never to this detection tick.
             logger.info("CC version changed: %s -> %s", last_known, current)
             return SignalReading(
                 name=self.signal_name,
@@ -281,39 +266,3 @@ class CCVersionCollector:
             return tuple(int(x) for x in m.group().split(".")) if m else ()
 
         return _parse(candidate) > _parse(baseline)
-
-    async def _analyze_update(self, old: str, new: str) -> None:
-        """Run CCUpdateAnalyzer to fetch changelog and classify impact.
-
-        Best-effort: if analysis fails or times out, the version change
-        observation is already stored and the signal still fires.
-        """
-        try:
-            from genesis.recon.cc_update_analyzer import CCUpdateAnalyzer
-
-            pipeline = self._pipeline_getter() if callable(self._pipeline_getter) else None
-            memory_store = self._memory_store_getter() if callable(self._memory_store_getter) else None
-            analyzer = CCUpdateAnalyzer(
-                db=self._db, router=self._router,
-                pipeline=pipeline, memory_store=memory_store,
-            )
-            # 600s SAFETY bound — this runs in a tracked background task (see
-            # collect()), NOT on the signal-tick critical path, so a generous cap is
-            # free: it bounds only a genuinely-hung analyze (wedged gather / stuck
-            # subprocess) while never cancelling legitimate work. analyze() is now
-            # map-reduce — up to _MAX_CHUNKS rate-gated LLM calls — whose worst
-            # realistic wall-clock (all chunks serialized on a single 4-RPM provider:
-            # ~_MAX_CHUNKS*15s + fetch) is well under 600s, and 600s is well under the
-            # 900s watchdog. Per-call router timeouts already bound each individual
-            # call. The old inline 30s made the big multi-release jump the FAILURE
-            # case (deadline cancelled it before the finding stored); off-path + 600s
-            # removes that class entirely.
-            result = await asyncio.wait_for(analyzer.analyze(old, new), timeout=600)
-            logger.info(
-                "CC update analysis complete: %s → %s [%s]",
-                old, new, result.get("impact", "unknown"),
-            )
-        except TimeoutError:
-            logger.warning("CC update analysis timed out for %s → %s", old, new)
-        except Exception:
-            logger.warning("CC update analysis failed", exc_info=True)

--- a/src/genesis/learning/signals/cc_version.py
+++ b/src/genesis/learning/signals/cc_version.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import aiosqlite
 
 from genesis.awareness.types import SignalReading
+from genesis.util.tasks import tracked_task
 
 if TYPE_CHECKING:
     from genesis.routing.router import Router
@@ -81,12 +82,30 @@ class CCVersionCollector:
         if current != last_known:
             try:
                 await self._store_version_change(last_known, current)
-                await self._analyze_update(last_known, current)
             except Exception:
                 logger.warning(
-                    "Failed to store/analyze CC version change %s -> %s",
+                    "Failed to store CC version change %s -> %s",
                     last_known, current, exc_info=True,
                 )
+            # Impact analysis is best-effort ENRICHMENT, dispatched OFF the signal
+            # loop. The version-change observation is already persisted above; and
+            # analyze() is now map-reduce (up to _MAX_CHUNKS rate-gated LLM calls),
+            # so awaiting it inline would both (a) block the whole awareness signal
+            # tick for the analysis duration and (b) force a fixed caller deadline
+            # that — on an install whose only keyed free provider is RPM-limited —
+            # cancels the analysis and stores NO finding on the exact large-jump
+            # case it exists for. A tracked background task removes both: the tick
+            # returns immediately and the finding lands when analysis completes.
+            # _analyze_update catches + logs its own failures at WARNING (incl. the
+            # 600s timeout); tracked_task's done-callback is only the backstop for an
+            # unexpected escape. Retention is NOT provided by tracked_task (it keeps
+            # no registry) — the coroutine stays alive via its await-chain (each
+            # awaited fetch/LLM/DB future back-references the task); keep its first
+            # step an awaited loop future, or GC-mid-run risk returns.
+            tracked_task(
+                self._analyze_update(last_known, current),
+                name="cc-version-impact-analysis",
+            )
             logger.info("CC version changed: %s -> %s", last_known, current)
             return SignalReading(
                 name=self.signal_name,
@@ -278,7 +297,18 @@ class CCVersionCollector:
                 db=self._db, router=self._router,
                 pipeline=pipeline, memory_store=memory_store,
             )
-            result = await asyncio.wait_for(analyzer.analyze(old, new), timeout=30)
+            # 600s SAFETY bound — this runs in a tracked background task (see
+            # collect()), NOT on the signal-tick critical path, so a generous cap is
+            # free: it bounds only a genuinely-hung analyze (wedged gather / stuck
+            # subprocess) while never cancelling legitimate work. analyze() is now
+            # map-reduce — up to _MAX_CHUNKS rate-gated LLM calls — whose worst
+            # realistic wall-clock (all chunks serialized on a single 4-RPM provider:
+            # ~_MAX_CHUNKS*15s + fetch) is well under 600s, and 600s is well under the
+            # 900s watchdog. Per-call router timeouts already bound each individual
+            # call. The old inline 30s made the big multi-release jump the FAILURE
+            # case (deadline cancelled it before the finding stored); off-path + 600s
+            # removes that class entirely.
+            result = await asyncio.wait_for(analyzer.analyze(old, new), timeout=600)
             logger.info(
                 "CC update analysis complete: %s → %s [%s]",
                 old, new, result.get("impact", "unknown"),

--- a/src/genesis/recon/cc_update_analyzer.py
+++ b/src/genesis/recon/cc_update_analyzer.py
@@ -1,8 +1,16 @@
 """CC Update Analyzer — fetch changelog, classify impact, alert if needed.
 
-Triggered when CCVersionCollector detects a version change. Two paths:
-1. Deep reflection context includes version_change observation, calls recon MCP tool
-2. Recon MCP tool `recon_cc_update_check` triggers directly
+Entry points (all on-demand or scheduled — NEVER a hot signal tick):
+1. Recon MCP tool ``recon_cc_update_check(old, new)`` — the on-demand path;
+   analyses a range and ALERTS on action_needed/breaking.
+2. The daily CC pre-eval job — composes this analyzer's fetch + LLM classify to
+   cache a per-version verdict BEFORE a version is adopted (no alert).
+3. Deep-reflection context surfaces the ``version_change`` observation and can
+   call the recon MCP tool.
+
+``CCVersionCollector`` deliberately does NOT call this: it is detect-and-record
+only, because driving a variable-cost multi-LLM analysis from a signal tick was
+a reliability bug in every form (see that class's docstring).
 """
 
 from __future__ import annotations

--- a/src/genesis/recon/cc_update_analyzer.py
+++ b/src/genesis/recon/cc_update_analyzer.py
@@ -30,16 +30,22 @@ _CHANGELOG_URL = (
     "https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md"
 )
 # Multi-release ranges are analyzed map-reduce: the changelog is split into
-# context-safe CHUNKS on release boundaries, each chunk is classified by one
-# LLM call, and the per-chunk verdicts are aggregated (max severity). This
-# never drops a release — a real CC bump spans ~20-35k tokens of changelog
-# (measured), too large for one call, and any release in the range can carry a
-# regression. _CHUNK_BUDGET is per-chunk chars (~12k tokens, safe for any model
-# in the analysis router chain). _MAX_CHUNKS bounds the LLM fan-out for a
-# pathological range (e.g. a 2.0.x -> latest jump); at ~48k/chunk it covers a
-# full-minor span, so a normal bump never hits it. When it does, the newest
-# chunks are kept and a LOUD marker names the omission.
-_CHUNK_BUDGET = 48000
+# context-safe CHUNKS, each chunk is classified by one LLM call, and the
+# per-chunk verdicts are aggregated (max severity). This never drops a release —
+# a real CC bump spans ~20-35k tokens of changelog (measured), too large for one
+# call, and any release in the range can carry a regression.
+#
+# _CHUNK_BUDGET is per-chunk chars and is sized to the SMALLEST-capacity provider
+# in the `cc_update_analysis` chain so a chunk is servable by EVERY provider it
+# could route to (primary, fallback, or offset-distributed — see _analyze_range).
+# The binding limit is groq-free / gpt-oss-120b at 8000 TPM (config/
+# model_profiles.yaml, free-text `limits:` — not machine-readable), and its
+# reasoning tokens inflate TPM further; 16k chars ~= 4k input tokens leaves room
+# for the ~600-token prompt + output + reasoning under 8000 TPM. If the chain's
+# min-TPM provider changes, re-derive here. _MAX_CHUNKS bounds the LLM fan-out for
+# a pathological range; when it bites, the newest chunks are kept and a LOUD
+# marker names the omission (never a silent cut).
+_CHUNK_BUDGET = 16000
 _MAX_CHUNKS = 12
 
 # Impact levels for CC updates
@@ -47,6 +53,12 @@ IMPACT_NONE = "none"
 IMPACT_INFORMATIONAL = "informational"
 IMPACT_ACTION_NEEDED = "action_needed"
 IMPACT_BREAKING = "breaking"
+# The closed set an LLM impact classification must belong to. Output outside this
+# set is untrustworthy — the boundary normalizer (_coerce_analysis) rejects it to
+# the keyword fallback rather than propagating an unvalidated severity.
+_VALID_IMPACTS = frozenset(
+    {IMPACT_NONE, IMPACT_INFORMATIONAL, IMPACT_ACTION_NEEDED, IMPACT_BREAKING}
+)
 
 _ANALYSIS_PROMPT = """\
 Analyze this Claude Code version change for impact on Genesis (an autonomous AI
@@ -181,15 +193,19 @@ class CCUpdateAnalyzer:
         chunks = self._chunk_changelog(changelog)
         if not chunks:
             return self._fallback_analysis(old_version, new_version, changelog)
-        # Fan the chunk classifications out CONCURRENTLY: the caller in the
-        # awareness signal path wraps analyze() in a 30s timeout, and N
-        # sequential free-tier LLM calls would blow it on the exact multi-release
-        # jump this fix exists for. gather makes wall-clock ~= one call.
-        # _llm_analyze never raises (it returns _fallback_analysis on any error),
-        # so no chunk can poison the gather.
+        # Fan the chunk classifications out CONCURRENTLY, and DISTRIBUTE them across
+        # the provider chain with a per-chunk ``chain_offset``. The router paces each
+        # provider by its RPM via a rate gate, so gathering N calls that all enter at
+        # the same first provider (mistral-large-free, 4 RPM = 15s apart) would
+        # serialize them and blow the caller's deadline on the exact multi-release
+        # jump this fix targets. ``chain_offset=i`` rotates chunk i to start at
+        # chain[i % len(chain)] (independent rate gates), so up to len(chain) chunks
+        # run truly concurrently. Mirrors the established pattern in
+        # knowledge/distillation.py and eval/j9_batch.py. _llm_analyze never raises
+        # (returns _fallback_analysis on any error), so no chunk can poison the gather.
         analyses = list(await asyncio.gather(*(
-            self._llm_analyze(old_version, new_version, chunk)
-            for chunk in chunks
+            self._llm_analyze(old_version, new_version, chunk, chain_offset=i)
+            for i, chunk in enumerate(chunks)
         )))
         return self._aggregate_analyses(analyses, old_version, new_version)
 
@@ -399,53 +415,139 @@ class CCUpdateAnalyzer:
             selected.append(changelog_md[start:end].strip())
         return "\n\n".join(selected)
 
+    @staticmethod
+    def _length_split(text: str, budget: int) -> list[str]:
+        """Split *text* into pieces of at most ``budget`` chars. Pure.
+
+        Prefers to break on a newline in the last fifth of the window so a piece
+        rarely cuts mid-line; falls back to a hard char cut when no boundary is
+        available (a single line longer than ``budget``). This is the size-bound
+        of last resort — it applies to any unit the section packer can't keep
+        whole (an oversized release section, or the header-less ``[PARTIAL]``
+        fallback body), so NO path escapes the budget.
+        """
+        text = text.strip()
+        if len(text) <= budget:
+            return [text] if text else []
+        pieces: list[str] = []
+        i, n = 0, len(text)
+        while i < n:
+            end = min(i + budget, n)
+            if end < n:
+                floor = i + (budget * 4 // 5)
+                nl = text.rfind("\n", floor, end)
+                if nl > i:
+                    end = nl
+            piece = text[i:end].strip()
+            if piece:
+                pieces.append(piece)
+            i = end  # end > i always (budget >= 1), so this makes progress
+        return pieces
+
     @classmethod
     def _chunk_changelog(
         cls, changelog: str, budget: int = _CHUNK_BUDGET, max_chunks: int = _MAX_CHUNKS,
     ) -> list[str]:
         """Split a concatenated changelog into context-safe chunks.
 
-        Whole ``## X.Y.Z`` release sections are never split across chunks — each
-        chunk holds as many consecutive sections as fit ``budget`` chars.
-        Chunks keep the changelog's order (newest first). Capped at
-        ``max_chunks`` to bound the LLM fan-out on a pathological range; when the
-        cap bites, the newest chunks are kept and a LOUD marker is appended
-        naming the dropped chunk count (never a silent cut). Text with no
-        ``## X.Y.Z`` header is returned as a single chunk (e.g. the ``[PARTIAL]``
-        single-version fallback).
+        Whole ``## X.Y.Z`` release sections are kept together where they fit — each
+        chunk holds as many consecutive sections as fit ``budget`` chars. Any single
+        unit larger than ``budget`` (an oversized release section, OR the header-less
+        ``[PARTIAL]`` fallback body) is length-split by :meth:`_length_split`, so NO
+        chunk ever exceeds the budget — the size bound holds on every path, not just
+        the header path. Chunks keep the changelog's order (newest first). Capped at
+        ``max_chunks``; when the cap bites, the newest chunks are kept and a LOUD
+        marker names the dropped chunk count (never a silent cut).
         """
+        if not changelog.strip():
+            return []
         header_re = re.compile(r"^##\s+\d+\.\d+\.\d+\b", re.MULTILINE)
         starts = [m.start() for m in header_re.finditer(changelog)]
-        if not starts:
-            return [changelog] if changelog.strip() else []
-        sections = [
-            changelog[s:(starts[i + 1] if i + 1 < len(starts) else len(changelog))].strip()
-            for i, s in enumerate(starts)
-        ]
+        if starts:
+            raw_units = [
+                changelog[s:(starts[i + 1] if i + 1 < len(starts) else len(changelog))].strip()
+                for i, s in enumerate(starts)
+            ]
+        else:
+            # No release headers (e.g. the [PARTIAL] single-version fallback body):
+            # one unit, still length-bounded below.
+            raw_units = [changelog.strip()]
+        # Guarantee every unit fits the budget BEFORE packing (oversized section or
+        # header-less body -> split by the same mechanism).
+        units: list[str] = []
+        for u in raw_units:
+            units.extend(cls._length_split(u, budget) if len(u) > budget else [u])
         chunks: list[str] = []
         cur: list[str] = []
         cur_len = 0
-        for sec in sections:
-            if cur and cur_len + len(sec) > budget:
+        for unit in units:
+            if cur and cur_len + len(unit) > budget:
                 chunks.append("\n\n".join(cur))
                 cur, cur_len = [], 0
-            cur.append(sec)
-            cur_len += len(sec) + 2
+            cur.append(unit)
+            cur_len += len(unit) + 2
         if cur:
             chunks.append("\n\n".join(cur))
         if len(chunks) > max_chunks:
             dropped = len(chunks) - max_chunks
             chunks = chunks[:max_chunks]
-            chunks[-1] += (
+            marker = (
                 f"\n\n[... {dropped} older changelog chunk(s) omitted — range too "
                 f"large for a single analysis pass; review older releases manually]"
             )
+            # Preserve the size-bound invariant: trim the last kept chunk so
+            # chunk+marker still fits budget (it is already the OLDEST kept chunk,
+            # so trimming its tail sheds the least-relevant content).
+            if len(chunks[-1]) + len(marker) > budget:
+                chunks[-1] = chunks[-1][: max(0, budget - len(marker))]
+            chunks[-1] += marker
         return chunks
+
+    @staticmethod
+    def _coerce_analysis(parsed: object) -> dict | None:
+        """Normalize an untrusted LLM analysis payload, or None if unusable.
+
+        Returns ``{impact: <valid enum>, summary: str, details: str}`` when *parsed*
+        is a dict carrying an impact in the closed enum set; returns None when the
+        payload is not a dict OR the impact is outside the enum (the caller then
+        falls back to keyword heuristics rather than propagating an unvalidated
+        severity). Non-str ``summary``/``details`` are coerced to str — the reducer
+        (``_aggregate_analyses``), knowledge-ingest (``_ingest_to_knowledge``), and
+        ``_alert`` all index/``.strip()`` these fields, so a model that emits a
+        number/list/object there must be sanitized at THIS single boundary, not
+        crash three consumers downstream.
+        """
+        if not isinstance(parsed, dict):
+            return None
+        impact = parsed.get("impact")
+        # isinstance guard FIRST: an unhashable impact (list/dict from a malformed
+        # model) would raise TypeError on `in frozenset`; return None so the caller
+        # takes the intended keyword-fallback branch instead of the generic except.
+        if not isinstance(impact, str) or impact not in _VALID_IMPACTS:
+            return None
+
+        def _as_str(v: object) -> str:
+            return v if isinstance(v, str) else ("" if v is None else str(v))
+
+        return {
+            "impact": impact,
+            "summary": _as_str(parsed.get("summary")),
+            "details": _as_str(parsed.get("details")),
+        }
 
     async def _llm_analyze(
         self, old_version: str, new_version: str, changelog: str,
+        *, chain_offset: int = 0,
     ) -> dict:
-        """Use LLM to classify the update impact."""
+        """Use an LLM to classify the update impact.
+
+        ``chain_offset`` rotates the provider chain so concurrent chunk calls (see
+        :meth:`_analyze_range`) don't all serialize on the first provider's rate
+        gate. The return is ALWAYS the normalized contract
+        ``{impact: <enum>, summary: str, details: str}`` — untrusted LLM output is
+        coerced/rejected at this single boundary (:meth:`_coerce_analysis`) so every
+        downstream consumer is safe by construction.
+        """
         prompt = _ANALYSIS_PROMPT.format(
             old_version=old_version,
             new_version=new_version,
@@ -456,17 +558,16 @@ class CCUpdateAnalyzer:
         try:
             # cc_update_analysis — analyzes CC version changelogs for impact on
             # Genesis hooks/integrations. Non-numeric ID by intent.
-            result = await self._router.route_call("cc_update_analysis", messages)
+            result = await self._router.route_call(
+                "cc_update_analysis", messages, chain_offset=chain_offset,
+            )
             if result.success and result.content:
-                parsed = json.loads(result.content)
-                # Free-tier models sometimes emit a bare string/array; the
-                # reducer requires a dict, so validate the shape at the boundary
-                # rather than crashing _aggregate_analyses downstream.
-                if isinstance(parsed, dict):
-                    return parsed
+                normalized = self._coerce_analysis(json.loads(result.content))
+                if normalized is not None:
+                    return normalized
                 logger.warning(
-                    "LLM analysis returned non-object JSON (%s) — using fallback",
-                    type(parsed).__name__,
+                    "LLM analysis payload not usable (non-dict or invalid impact) "
+                    "— using keyword fallback",
                 )
         except json.JSONDecodeError:
             logger.warning("LLM analysis returned non-JSON response", exc_info=True)

--- a/src/genesis/recon/cc_update_analyzer.py
+++ b/src/genesis/recon/cc_update_analyzer.py
@@ -11,6 +11,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -25,6 +26,21 @@ logger = logging.getLogger(__name__)
 
 _GH_TIMEOUT = 15  # seconds
 _CC_REPO = "anthropics/claude-code"
+_CHANGELOG_URL = (
+    "https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md"
+)
+# Multi-release ranges are analyzed map-reduce: the changelog is split into
+# context-safe CHUNKS on release boundaries, each chunk is classified by one
+# LLM call, and the per-chunk verdicts are aggregated (max severity). This
+# never drops a release — a real CC bump spans ~20-35k tokens of changelog
+# (measured), too large for one call, and any release in the range can carry a
+# regression. _CHUNK_BUDGET is per-chunk chars (~12k tokens, safe for any model
+# in the analysis router chain). _MAX_CHUNKS bounds the LLM fan-out for a
+# pathological range (e.g. a 2.0.x -> latest jump); at ~48k/chunk it covers a
+# full-minor span, so a normal bump never hits it. When it does, the newest
+# chunks are kept and a LOUD marker names the omission.
+_CHUNK_BUDGET = 48000
+_MAX_CHUNKS = 12
 
 # Impact levels for CC updates
 IMPACT_NONE = "none"
@@ -117,16 +133,18 @@ class CCUpdateAnalyzer:
         self._memory_store = memory_store
 
     async def analyze(self, old_version: str, new_version: str) -> dict:
-        """Analyze a CC version change.
+        """Analyze a CC version change across the WHOLE ``(old, new]`` range.
 
-        Returns dict with: impact, summary, details, finding_id.
+        Returns dict with: impact, summary, details, finding_id. A multi-release
+        jump is analyzed map-reduce (chunk -> per-chunk LLM classification ->
+        aggregate by max severity) so no intervening release is missed.
         """
-        # 1. Fetch changelog
+        # 1. Fetch the full changelog range (all intervening releases).
         changelog = await self._fetch_changelog(old_version, new_version)
 
-        # 2. LLM analysis (if router available)
+        # 2. Map-reduce LLM analysis (if router available).
         if self._router and changelog:
-            analysis = await self._llm_analyze(old_version, new_version, changelog)
+            analysis = await self._analyze_range(old_version, new_version, changelog)
         else:
             analysis = {
                 "impact": IMPACT_INFORMATIONAL,
@@ -134,15 +152,85 @@ class CCUpdateAnalyzer:
                 "details": changelog or "Changelog not available",
             }
 
-        # 3. Store as recon finding (always include raw changelog)
-        finding_id = await self._store_finding(old_version, new_version, analysis, changelog)
+        # 3. Store as recon finding. The observation/KB keep a bounded changelog
+        #    preview (a full multi-release range can be ~100KB — the LLM-derived
+        #    `details` is the durable value); the observation truncates further.
+        stored_changelog = changelog[:8000] if changelog else ""
+        finding_id = await self._store_finding(
+            old_version, new_version, analysis, stored_changelog,
+        )
         analysis["finding_id"] = finding_id
 
-        # 4. Alert if action_needed or breaking
+        # 4. Alert if action_needed or breaking.
         if analysis.get("impact") in (IMPACT_ACTION_NEEDED, IMPACT_BREAKING):
             await self._alert(analysis, old_version, new_version)
 
         return analysis
+
+    async def _analyze_range(
+        self, old_version: str, new_version: str, changelog: str,
+    ) -> dict:
+        """Map-reduce the changelog: classify each chunk, aggregate by severity.
+
+        One LLM call per chunk (each within a safe context budget); the verdicts
+        are reduced to a single ``{impact, summary, details}`` with the overall
+        impact = highest severity across chunks. A single-chunk range (the common
+        small bump) returns that chunk's analysis verbatim, preserving the prior
+        single-call behaviour and contract.
+        """
+        chunks = self._chunk_changelog(changelog)
+        if not chunks:
+            return self._fallback_analysis(old_version, new_version, changelog)
+        # Fan the chunk classifications out CONCURRENTLY: the caller in the
+        # awareness signal path wraps analyze() in a 30s timeout, and N
+        # sequential free-tier LLM calls would blow it on the exact multi-release
+        # jump this fix exists for. gather makes wall-clock ~= one call.
+        # _llm_analyze never raises (it returns _fallback_analysis on any error),
+        # so no chunk can poison the gather.
+        analyses = list(await asyncio.gather(*(
+            self._llm_analyze(old_version, new_version, chunk)
+            for chunk in chunks
+        )))
+        return self._aggregate_analyses(analyses, old_version, new_version)
+
+    @classmethod
+    def _aggregate_analyses(
+        cls, analyses: list[dict], old_version: str, new_version: str,
+    ) -> dict:
+        """Reduce per-chunk analyses to one verdict. Pure.
+
+        Overall impact = the highest severity seen in any chunk. Details are the
+        per-chunk details, highest-severity first, each tagged with its impact so
+        the aggregate stays traceable. A single analysis is returned unchanged.
+        """
+        if len(analyses) == 1:
+            return dict(analyses[0])
+        rank = {
+            IMPACT_NONE: 0,
+            IMPACT_INFORMATIONAL: 1,
+            IMPACT_ACTION_NEEDED: 2,
+            IMPACT_BREAKING: 3,
+        }
+
+        def _rank(a: dict) -> int:
+            return rank.get(a.get("impact", IMPACT_INFORMATIONAL), 1)
+
+        overall = max(analyses, key=_rank).get("impact", IMPACT_INFORMATIONAL)
+        ordered = sorted(analyses, key=_rank, reverse=True)
+        parts: list[str] = []
+        for a in ordered:
+            detail = (a.get("details") or "").strip()
+            if detail:
+                parts.append(f"[{a.get('impact', '?')}] {a.get('summary', '')}\n{detail}")
+        details = "\n\n".join(parts)
+        top = ordered[0]
+        summary = (
+            f"CC {old_version} -> {new_version}: analyzed across {len(analyses)} "
+            f"changelog chunks; overall impact {overall}."
+        )
+        if top.get("summary"):
+            summary += f" Highest-severity item: {top['summary']}"
+        return {"impact": overall, "summary": summary, "details": details}
 
     @staticmethod
     def _version_to_tag(version: str) -> str:
@@ -155,10 +243,79 @@ class CCUpdateAnalyzer:
         return f"v{bare}" if not bare.startswith("v") else bare
 
     async def _fetch_changelog(self, old_version: str, new_version: str) -> str:
-        """Fetch release notes from GitHub via ``gh api``.
+        """Changelog covering ``(old_version, new_version]`` — the WHOLE range.
 
-        Uses create_subprocess_exec (no shell) with a timeout. Falls back to
-        empty string on any failure.
+        Primary source is the repo's raw ``CHANGELOG.md``, from which every
+        release section in the range is extracted, so a multi-release jump is
+        analyzed against ALL intervening releases (not just the newest — the
+        bug this replaces). Falls back to the GitHub releases API for the single
+        ``new_version`` body, LOUDLY marked ``[PARTIAL]``, when the CHANGELOG
+        cannot be fetched or yields no sections in range (downgrade, equal
+        versions, or an unpublished target) — so a degraded analysis is visible
+        rather than a silent regression to single-version behaviour. Returns
+        "" only when both sources fail.
+        """
+        md = await self._fetch_changelog_md()
+        if md:
+            sections = self._extract_sections_in_range(md, old_version, new_version)
+            if sections:
+                return sections
+            logger.info(
+                "CHANGELOG.md fetched but no release sections in range %s..%s "
+                "(downgrade, equal versions, or unpublished target) — "
+                "using single-version fallback",
+                old_version, new_version,
+            )
+        body = await self._fetch_release_body(new_version)
+        if body:
+            return (
+                f"[PARTIAL] Full {old_version} -> {new_version} changelog range "
+                f"was unavailable; showing only the {new_version} release "
+                f"notes:\n\n{body}"
+            )
+        return ""
+
+    async def _fetch_changelog_md(self) -> str:
+        """Fetch the raw ``CHANGELOG.md``. Empty string on any failure.
+
+        Uses ``curl`` via create_subprocess_exec (no shell) with a timeout;
+        curl is more universally present than ``gh`` and needs no auth for a
+        public raw file. Any failure degrades to the ``gh`` releases fallback.
+        """
+        proc = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "curl", "-fsSL", _CHANGELOG_URL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=_GH_TIMEOUT,
+            )
+            if proc.returncode != 0:
+                logger.warning(
+                    "CHANGELOG.md fetch failed (rc=%s): %s",
+                    proc.returncode,
+                    stderr.decode("utf-8", errors="replace")[:200],
+                )
+                return ""
+            return stdout.decode("utf-8", errors="replace")
+        except TimeoutError:
+            logger.warning("CHANGELOG.md fetch timed out")
+            if proc is not None:
+                with contextlib.suppress(ProcessLookupError):
+                    proc.kill()
+            return ""
+        except Exception:
+            logger.debug("Failed to fetch CHANGELOG.md", exc_info=True)
+            return ""
+
+    async def _fetch_release_body(self, new_version: str) -> str:
+        """Single-version release body from the GitHub releases API (fallback).
+
+        The former primary path, retained as a loud fallback. Uses
+        create_subprocess_exec (no shell) with a timeout. Returns "" when no
+        release in the latest window matches ``new_version``.
         """
         tag = self._version_to_tag(new_version)
         proc = None
@@ -189,10 +346,7 @@ class CCUpdateAnalyzer:
                 if not isinstance(release, dict):
                     continue
                 if release.get("tag_name") == tag:
-                    body = release.get("body", "") or ""
-                    if len(body) > 1000:
-                        body = body[:1000] + "\n... (truncated)"
-                    return body
+                    return release.get("body", "") or ""
 
             logger.debug("No release matching tag %s in latest 5 releases", tag)
             return ""
@@ -203,8 +357,90 @@ class CCUpdateAnalyzer:
                     proc.kill()
             return ""
         except Exception:
-            logger.debug("Failed to fetch changelog from GitHub", exc_info=True)
+            logger.debug("Failed to fetch release body from GitHub", exc_info=True)
             return ""
+
+    @staticmethod
+    def _semver_tuple(version: str) -> tuple[int, ...]:
+        """Numeric ``(major, minor, patch, ...)`` tuple from a version string.
+
+        Strips a leading ``v`` and any ``" (Claude Code)"`` suffix. Returns
+        ``()`` when no numeric version is present (sorts lowest).
+        """
+        m = re.search(r"\d+(?:\.\d+)*", version)
+        return tuple(int(x) for x in m.group().split(".")) if m else ()
+
+    @classmethod
+    def _extract_sections_in_range(
+        cls, changelog_md: str, old_version: str, new_version: str,
+    ) -> str:
+        """Concatenate EVERY ``## X.Y.Z`` section with ``old < version <= new``.
+
+        Pure function (no I/O). Sections keep the CHANGELOG's own order (newest
+        first). Only ``## X.Y.Z`` headers actually present are matched, so
+        skipped version numbers are handled naturally. No size cap here — the
+        full range is returned so the analyzer's map-reduce chunker
+        (:meth:`_chunk_changelog`) can cover every release without dropping any.
+        Returns "" when the range contains no sections (equal versions,
+        downgrade, or unpublished target) — the caller then falls back to the
+        single-version path.
+        """
+        old_t = cls._semver_tuple(old_version)
+        new_t = cls._semver_tuple(new_version)
+        header_re = re.compile(r"^##\s+(\d+\.\d+\.\d+)\b.*$", re.MULTILINE)
+        matches = list(header_re.finditer(changelog_md))
+        selected: list[str] = []
+        for i, m in enumerate(matches):
+            ver_t = cls._semver_tuple(m.group(1))
+            if not (old_t < ver_t <= new_t):
+                continue
+            start = m.start()
+            end = matches[i + 1].start() if i + 1 < len(matches) else len(changelog_md)
+            selected.append(changelog_md[start:end].strip())
+        return "\n\n".join(selected)
+
+    @classmethod
+    def _chunk_changelog(
+        cls, changelog: str, budget: int = _CHUNK_BUDGET, max_chunks: int = _MAX_CHUNKS,
+    ) -> list[str]:
+        """Split a concatenated changelog into context-safe chunks.
+
+        Whole ``## X.Y.Z`` release sections are never split across chunks — each
+        chunk holds as many consecutive sections as fit ``budget`` chars.
+        Chunks keep the changelog's order (newest first). Capped at
+        ``max_chunks`` to bound the LLM fan-out on a pathological range; when the
+        cap bites, the newest chunks are kept and a LOUD marker is appended
+        naming the dropped chunk count (never a silent cut). Text with no
+        ``## X.Y.Z`` header is returned as a single chunk (e.g. the ``[PARTIAL]``
+        single-version fallback).
+        """
+        header_re = re.compile(r"^##\s+\d+\.\d+\.\d+\b", re.MULTILINE)
+        starts = [m.start() for m in header_re.finditer(changelog)]
+        if not starts:
+            return [changelog] if changelog.strip() else []
+        sections = [
+            changelog[s:(starts[i + 1] if i + 1 < len(starts) else len(changelog))].strip()
+            for i, s in enumerate(starts)
+        ]
+        chunks: list[str] = []
+        cur: list[str] = []
+        cur_len = 0
+        for sec in sections:
+            if cur and cur_len + len(sec) > budget:
+                chunks.append("\n\n".join(cur))
+                cur, cur_len = [], 0
+            cur.append(sec)
+            cur_len += len(sec) + 2
+        if cur:
+            chunks.append("\n\n".join(cur))
+        if len(chunks) > max_chunks:
+            dropped = len(chunks) - max_chunks
+            chunks = chunks[:max_chunks]
+            chunks[-1] += (
+                f"\n\n[... {dropped} older changelog chunk(s) omitted — range too "
+                f"large for a single analysis pass; review older releases manually]"
+            )
+        return chunks
 
     async def _llm_analyze(
         self, old_version: str, new_version: str, changelog: str,
@@ -222,7 +458,16 @@ class CCUpdateAnalyzer:
             # Genesis hooks/integrations. Non-numeric ID by intent.
             result = await self._router.route_call("cc_update_analysis", messages)
             if result.success and result.content:
-                return json.loads(result.content)
+                parsed = json.loads(result.content)
+                # Free-tier models sometimes emit a bare string/array; the
+                # reducer requires a dict, so validate the shape at the boundary
+                # rather than crashing _aggregate_analyses downstream.
+                if isinstance(parsed, dict):
+                    return parsed
+                logger.warning(
+                    "LLM analysis returned non-object JSON (%s) — using fallback",
+                    type(parsed).__name__,
+                )
         except json.JSONDecodeError:
             logger.warning("LLM analysis returned non-JSON response", exc_info=True)
         except Exception:

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -381,12 +381,9 @@ def build_learning_collectors(rt: GenesisRuntime) -> list:
             rt._db,
             pipeline_getter=lambda: rt._outreach_pipeline,
         ),
-        CCVersionCollector(
-            rt._db,
-            router=rt._router,
-            pipeline_getter=lambda: rt._outreach_pipeline,
-            memory_store_getter=lambda: rt._memory_store,
-        ),
+        # Detect-and-record only — no router/pipeline/memory_store: this
+        # collector deliberately runs no impact analysis (see its docstring).
+        CCVersionCollector(rt._db),
         ProcessHealthCollector(),
         UserGoalStalenessCollector(rt._db),
         UserSessionPatternCollector(rt._db),

--- a/tests/test_learning/test_cc_version_collector.py
+++ b/tests/test_learning/test_cc_version_collector.py
@@ -54,6 +54,39 @@ def _mock_version(version: str):
     )
 
 
+def _capture_tracked_task(store: list):
+    """Stand in for tracked_task: capture the coroutine so the test can drive it.
+
+    Impact analysis is now dispatched OFF the signal loop via tracked_task, so
+    collect() returns before it runs. Tests capture the coroutine and either await
+    it (to assert analysis behaviour) or close() it (to assert collect() did NOT
+    block on it).
+    """
+    def _fake(coro, **kwargs):
+        store.append(coro)
+        return MagicMock()  # stand-in Task; the test drives the coroutine
+
+    return _fake
+
+
+@pytest.fixture(autouse=True)
+def _no_real_background_analysis():
+    """Neutralize the backgrounded impact analysis by default.
+
+    collect() now dispatches impact analysis via tracked_task; a version-change
+    test that doesn't care about analysis would otherwise spawn a REAL background
+    task doing subprocess/network I/O that lingers past the test's event loop
+    ("Event loop is closed"). This closes the coroutine instead. Tests that DO
+    assert analysis behaviour re-patch tracked_task within their own ``with``.
+    """
+    def _close(coro, **kwargs):
+        coro.close()
+        return MagicMock()
+
+    with patch("genesis.learning.signals.cc_version.tracked_task", _close):
+        yield
+
+
 class TestVersionDetection:
     """CC version change detection."""
 
@@ -157,12 +190,17 @@ class TestAnalyzerIntegration:
         with _mock_version("1.0.0"):
             await collector.collect()  # Store initial
 
+        tasks: list = []
         with (
             _mock_version("1.1.0"),
             patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
+            patch("genesis.learning.signals.cc_version.tracked_task",
+                  _capture_tracked_task(tasks)),
         ):
             MockAnalyzer.return_value.analyze = mock_analyze
             reading = await collector.collect()
+            for coro in tasks:  # run the backgrounded impact analysis
+                await coro
 
         assert reading.value == 1.0
         MockAnalyzer.assert_called_once_with(db=db, router=router, pipeline=None, memory_store=None)
@@ -184,8 +222,8 @@ class TestAnalyzerIntegration:
         MockAnalyzer.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_analyzer_timeout_still_signals(self, db) -> None:
-        """When analyzer times out, signal still fires with value=1.0."""
+    async def test_slow_analysis_does_not_block_signal(self, db) -> None:
+        """A slow analysis runs OFF the signal loop — collect() returns immediately."""
         router = MagicMock()
         collector = CCVersionCollector(db, router=router)
 
@@ -195,16 +233,23 @@ class TestAnalyzerIntegration:
         async def slow_analyze(*args, **kwargs):
             await asyncio.sleep(999)
 
+        tasks: list = []
         with (
             _mock_version("1.1.0"),
             patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
-            patch("genesis.learning.signals.cc_version.asyncio.wait_for", side_effect=TimeoutError),
+            patch("genesis.learning.signals.cc_version.tracked_task",
+                  _capture_tracked_task(tasks)),
         ):
             MockAnalyzer.return_value.analyze = AsyncMock(side_effect=slow_analyze)
+            # If analysis were still inline this would hang on sleep(999); it returns
+            # at once because analysis is dispatched to a background task.
             reading = await collector.collect()
 
         assert reading.value == 1.0
         assert reading.failed is False
+        assert len(tasks) == 1  # analysis WAS dispatched, just not awaited here
+        for coro in tasks:  # discard the slow coro without running it
+            coro.close()
 
     @pytest.mark.asyncio
     async def test_analyzer_exception_still_signals(self, db) -> None:
@@ -215,12 +260,19 @@ class TestAnalyzerIntegration:
         with _mock_version("1.0.0"):
             await collector.collect()
 
+        tasks: list = []
         with (
             _mock_version("1.1.0"),
             patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
+            patch("genesis.learning.signals.cc_version.tracked_task",
+                  _capture_tracked_task(tasks)),
         ):
             MockAnalyzer.return_value.analyze = AsyncMock(side_effect=RuntimeError("boom"))
             reading = await collector.collect()
+            # The backgrounded analysis raises internally; _analyze_update swallows
+            # it, so awaiting the coro completes cleanly and the signal is unaffected.
+            for coro in tasks:
+                await coro
 
         assert reading.value == 1.0
         assert reading.failed is False
@@ -235,12 +287,17 @@ class TestAnalyzerIntegration:
         with _mock_version("1.0.0"):
             await collector.collect()
 
+        tasks: list = []
         with (
             _mock_version("1.1.0"),
             patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
+            patch("genesis.learning.signals.cc_version.tracked_task",
+                  _capture_tracked_task(tasks)),
         ):
             MockAnalyzer.return_value.analyze = mock_analyze
             reading = await collector.collect()
+            for coro in tasks:
+                await coro
 
         assert reading.value == 1.0
         # Analyzer is called with router=None — it works without LLM, just stores basic finding
@@ -298,12 +355,17 @@ class TestAnalyzerIntegration:
         with _mock_version("1.0.0"):
             await collector.collect()
 
+        tasks: list = []
         with (
             _mock_version("1.1.0"),
             patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
+            patch("genesis.learning.signals.cc_version.tracked_task",
+                  _capture_tracked_task(tasks)),
         ):
             MockAnalyzer.return_value.analyze = mock_analyze
             await collector.collect()
+            for coro in tasks:
+                await coro
 
         MockAnalyzer.assert_called_once_with(db=db, router=router, pipeline=mock_pipeline, memory_store=None)
 

--- a/tests/test_learning/test_cc_version_collector.py
+++ b/tests/test_learning/test_cc_version_collector.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import aiosqlite
 import pytest
@@ -41,50 +40,11 @@ def collector(db):
     return CCVersionCollector(db)
 
 
-@pytest.fixture()
-def collector_with_pipeline(db):
-    mock_pipeline = MagicMock()
-    return CCVersionCollector(db, pipeline_getter=lambda: mock_pipeline), mock_pipeline
-
-
 def _mock_version(version: str):
     """Patch _get_cc_version to return a fixed string."""
     return patch.object(
         CCVersionCollector, "_get_cc_version", new_callable=AsyncMock, return_value=version,
     )
-
-
-def _capture_tracked_task(store: list):
-    """Stand in for tracked_task: capture the coroutine so the test can drive it.
-
-    Impact analysis is now dispatched OFF the signal loop via tracked_task, so
-    collect() returns before it runs. Tests capture the coroutine and either await
-    it (to assert analysis behaviour) or close() it (to assert collect() did NOT
-    block on it).
-    """
-    def _fake(coro, **kwargs):
-        store.append(coro)
-        return MagicMock()  # stand-in Task; the test drives the coroutine
-
-    return _fake
-
-
-@pytest.fixture(autouse=True)
-def _no_real_background_analysis():
-    """Neutralize the backgrounded impact analysis by default.
-
-    collect() now dispatches impact analysis via tracked_task; a version-change
-    test that doesn't care about analysis would otherwise spawn a REAL background
-    task doing subprocess/network I/O that lingers past the test's event loop
-    ("Event loop is closed"). This closes the coroutine instead. Tests that DO
-    assert analysis behaviour re-patch tracked_task within their own ``with``.
-    """
-    def _close(coro, **kwargs):
-        coro.close()
-        return MagicMock()
-
-    with patch("genesis.learning.signals.cc_version.tracked_task", _close):
-        yield
 
 
 class TestVersionDetection:
@@ -176,133 +136,74 @@ class TestVersionDetection:
         assert reading.failed is False
 
 
-class TestAnalyzerIntegration:
-    """Verify CCUpdateAnalyzer is called on version change."""
+class TestNoImpactAnalysis:
+    """The collector is DETECT-AND-RECORD ONLY — it must never run analysis.
+
+    Impact analysis was deliberately removed from this collector: driving a
+    variable-cost multi-LLM operation from a signal tick was a reliability bug in
+    every form (awaited inline, a fixed caller deadline cancelled it and stored NO
+    finding on exactly the big multi-release jump it existed for; dispatched as a
+    background task, it was lost on shutdown after the baseline had already
+    advanced, so it never retried). Analysis now lives on the on-demand
+    ``recon_cc_update_check`` MCP path and the idempotent daily pre-eval job.
+    """
 
     @pytest.mark.asyncio
-    async def test_analyzer_called_on_version_change(self, db) -> None:
-        """When router is provided and version changes, analyzer runs."""
-        router = MagicMock()
-        collector = CCVersionCollector(db, router=router)
-
-        mock_analyze = AsyncMock(return_value={"impact": "informational", "finding_id": "f-1"})
-
+    async def test_version_change_records_without_invoking_analyzer(self, collector, db) -> None:
+        """A version change records + signals 1.0 and NEVER touches the analyzer."""
         with _mock_version("1.0.0"):
-            await collector.collect()  # Store initial
+            await collector.collect()  # establish baseline
 
-        tasks: list = []
         with (
             _mock_version("1.1.0"),
             patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
-            patch("genesis.learning.signals.cc_version.tracked_task",
-                  _capture_tracked_task(tasks)),
         ):
-            MockAnalyzer.return_value.analyze = mock_analyze
             reading = await collector.collect()
-            for coro in tasks:  # run the backgrounded impact analysis
-                await coro
 
         assert reading.value == 1.0
-        MockAnalyzer.assert_called_once_with(db=db, router=router, pipeline=None, memory_store=None)
-        mock_analyze.assert_awaited_once_with("1.0.0", "1.1.0")
-
-    @pytest.mark.asyncio
-    async def test_analyzer_not_called_without_version_change(self, db) -> None:
-        """No version change means no analyzer call."""
-        router = MagicMock()
-        collector = CCVersionCollector(db, router=router)
-
-        with (
-            _mock_version("1.0.0"),
-            patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
-        ):
-            await collector.collect()  # First run
-            await collector.collect()  # Same version
-
+        assert reading.failed is False
+        # The durable record is written...
+        cursor = await db.execute(
+            "SELECT content FROM observations WHERE type = 'version_change'"
+        )
+        row = await cursor.fetchone()
+        assert row is not None
+        data = json.loads(row["content"])
+        assert data["old_version"] == "1.0.0"
+        assert data["new_version"] == "1.1.0"
+        # ...and the analyzer is never constructed or called.
         MockAnalyzer.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_slow_analysis_does_not_block_signal(self, db) -> None:
-        """A slow analysis runs OFF the signal loop — collect() returns immediately."""
-        router = MagicMock()
-        collector = CCVersionCollector(db, router=router)
+    def test_collector_exposes_no_analysis_surface(self) -> None:
+        """The analysis method and the params that fed it are gone for good.
 
-        with _mock_version("1.0.0"):
-            await collector.collect()
+        Guards the REMOVAL itself: a refactor that reintroduces _analyze_update —
+        or the router/pipeline/memory_store wiring that existed only to feed it —
+        would resurrect the lifecycle-bug class this removal eliminated.
+        """
+        import inspect
 
-        async def slow_analyze(*args, **kwargs):
-            await asyncio.sleep(999)
-
-        tasks: list = []
-        with (
-            _mock_version("1.1.0"),
-            patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
-            patch("genesis.learning.signals.cc_version.tracked_task",
-                  _capture_tracked_task(tasks)),
-        ):
-            MockAnalyzer.return_value.analyze = AsyncMock(side_effect=slow_analyze)
-            # If analysis were still inline this would hang on sleep(999); it returns
-            # at once because analysis is dispatched to a background task.
-            reading = await collector.collect()
-
-        assert reading.value == 1.0
-        assert reading.failed is False
-        assert len(tasks) == 1  # analysis WAS dispatched, just not awaited here
-        for coro in tasks:  # discard the slow coro without running it
-            coro.close()
+        assert not hasattr(CCVersionCollector, "_analyze_update")
+        params = set(inspect.signature(CCVersionCollector.__init__).parameters)
+        assert params == {"self", "db"}
 
     @pytest.mark.asyncio
-    async def test_analyzer_exception_still_signals(self, db) -> None:
-        """When analyzer raises, signal still fires with value=1.0."""
-        router = MagicMock()
-        collector = CCVersionCollector(db, router=router)
-
+    async def test_change_signals_once_then_resets(self, collector) -> None:
+        """The baseline advances, so the change is a one-shot event signal."""
         with _mock_version("1.0.0"):
             await collector.collect()
-
-        tasks: list = []
+        with _mock_version("1.1.0"):
+            first = await collector.collect()
         with (
             _mock_version("1.1.0"),
-            patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
-            patch("genesis.learning.signals.cc_version.tracked_task",
-                  _capture_tracked_task(tasks)),
+            patch.object(
+                CCVersionCollector, "_check_registry_version", new_callable=AsyncMock,
+            ),
         ):
-            MockAnalyzer.return_value.analyze = AsyncMock(side_effect=RuntimeError("boom"))
-            reading = await collector.collect()
-            # The backgrounded analysis raises internally; _analyze_update swallows
-            # it, so awaiting the coro completes cleanly and the signal is unaffected.
-            for coro in tasks:
-                await coro
+            second = await collector.collect()
 
-        assert reading.value == 1.0
-        assert reading.failed is False
-
-    @pytest.mark.asyncio
-    async def test_no_router_analyzer_runs_without_llm(self, db) -> None:
-        """Without router, analyzer runs but falls back to non-LLM path."""
-        collector = CCVersionCollector(db)  # No router
-
-        mock_analyze = AsyncMock(return_value={"impact": "informational", "finding_id": "f-2"})
-
-        with _mock_version("1.0.0"):
-            await collector.collect()
-
-        tasks: list = []
-        with (
-            _mock_version("1.1.0"),
-            patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
-            patch("genesis.learning.signals.cc_version.tracked_task",
-                  _capture_tracked_task(tasks)),
-        ):
-            MockAnalyzer.return_value.analyze = mock_analyze
-            reading = await collector.collect()
-            for coro in tasks:
-                await coro
-
-        assert reading.value == 1.0
-        # Analyzer is called with router=None — it works without LLM, just stores basic finding
-        MockAnalyzer.assert_called_once_with(db=db, router=None, pipeline=None, memory_store=None)
-        mock_analyze.assert_awaited_once_with("1.0.0", "1.1.0")
+        assert first.value == 1.0
+        assert second.value == 0.0
 
     @pytest.mark.asyncio
     async def test_registry_check_runs_on_no_change(self, db) -> None:
@@ -343,31 +244,6 @@ class TestAnalyzerIntegration:
         assert reading.value == 0.0
         assert reading.failed is False
 
-    @pytest.mark.asyncio
-    async def test_pipeline_threaded_to_analyzer(self, db) -> None:
-        """Pipeline getter is resolved and passed through to CCUpdateAnalyzer."""
-        router = MagicMock()
-        mock_pipeline = MagicMock()
-        collector = CCVersionCollector(db, router=router, pipeline_getter=lambda: mock_pipeline)
-
-        mock_analyze = AsyncMock(return_value={"impact": "informational", "finding_id": "f-3"})
-
-        with _mock_version("1.0.0"):
-            await collector.collect()
-
-        tasks: list = []
-        with (
-            _mock_version("1.1.0"),
-            patch("genesis.recon.cc_update_analyzer.CCUpdateAnalyzer") as MockAnalyzer,
-            patch("genesis.learning.signals.cc_version.tracked_task",
-                  _capture_tracked_task(tasks)),
-        ):
-            MockAnalyzer.return_value.analyze = mock_analyze
-            await collector.collect()
-            for coro in tasks:
-                await coro
-
-        MockAnalyzer.assert_called_once_with(db=db, router=router, pipeline=mock_pipeline, memory_store=None)
 
 
 class TestRegistryCheck:

--- a/tests/test_recon/test_cc_update_analyzer.py
+++ b/tests/test_recon/test_cc_update_analyzer.py
@@ -817,3 +817,124 @@ class TestKnowledgeIngestion:
         assert "Fixed --bare MCP bug" in body
         assert "## Raw changelog" in body
         assert "bare fix" in body
+
+
+class TestHardeningClassA_SizeBounding:
+    """Every chunk fed to an LLM call must fit the smallest provider's budget."""
+
+    def test_chunk_budget_fits_smallest_provider_tpm(self) -> None:
+        # groq-free (gpt-oss-120b) caps at 8000 TPM; a chunk must leave room for
+        # the ~600-token prompt + output + reasoning inflation. ~16k chars ~= 4k tokens.
+        from genesis.recon.cc_update_analyzer import _CHUNK_BUDGET
+
+        assert _CHUNK_BUDGET <= 20000
+
+    def test_headerless_body_over_budget_is_length_split(self) -> None:
+        # The [PARTIAL] fallback body has no `## X.Y.Z` headers; it must still be
+        # bounded, not returned as one oversized chunk.
+        body = "[PARTIAL] " + ("word " * 8000)  # ~40k chars, no headers
+        chunks = CCUpdateAnalyzer._chunk_changelog(body, budget=16000, max_chunks=12)
+        assert len(chunks) >= 2
+        assert all(len(c) <= 16000 for c in chunks)
+
+    def test_oversized_single_section_is_length_split(self) -> None:
+        # A single release section larger than budget must be split, not emitted whole.
+        big_section = "## 2.1.99\n\n" + ("x " * 12000)  # ~24k chars in one section
+        chunks = CCUpdateAnalyzer._chunk_changelog(big_section, budget=16000, max_chunks=12)
+        assert len(chunks) >= 2
+        assert all(len(c) <= 16000 for c in chunks)
+
+    def test_small_changelog_stays_single_chunk(self) -> None:
+        # Regression guard: a normal small bump must still be one chunk.
+        cl = "## 2.1.5\n\n- a\n\n## 2.1.4\n\n- b"
+        chunks = CCUpdateAnalyzer._chunk_changelog(cl, budget=16000, max_chunks=12)
+        assert len(chunks) == 1
+
+    def test_maxchunks_marker_keeps_last_chunk_within_budget(self) -> None:
+        # When the cap bites and the last kept chunk is already at budget, the loud
+        # omission marker must NOT push it over budget (invariant holds on the
+        # omission path too).
+        sections = "".join(f"## 2.1.{n}\n\n" + ("q" * 15980) + "\n\n" for n in range(30, 0, -1))
+        chunks = CCUpdateAnalyzer._chunk_changelog(sections, budget=16000, max_chunks=3)
+        assert len(chunks) == 3
+        assert "omitted" in chunks[-1]  # loud marker present
+        assert all(len(c) <= 16000 for c in chunks)  # and still within budget
+
+
+class TestHardeningClassB_ChainDistribution:
+    """N gathered route_calls must distribute across the chain, not serialize."""
+
+    @pytest.mark.asyncio
+    async def test_each_chunk_gets_distinct_chain_offset(self, db) -> None:
+        router = AsyncMock()
+        router.route_call = AsyncMock(return_value=_llm(IMPACT_INFORMATIONAL, "s", "d"))
+        analyzer = CCUpdateAnalyzer(db=db, router=router)
+        with patch.object(analyzer, "_chunk_changelog", return_value=["c0", "c1", "c2"]):
+            await analyzer._analyze_range("2.1.3", "2.1.9", "irrelevant")
+        offsets = sorted(
+            call.kwargs.get("chain_offset", 0)
+            for call in router.route_call.await_args_list
+        )
+        assert offsets == [0, 1, 2]  # distributed across the chain, not all 0
+
+
+class TestHardeningClassC_OutputNormalization:
+    """Untrusted LLM JSON is normalized to the full contract at one boundary."""
+
+    @pytest.mark.asyncio
+    async def test_list_impact_dict_falls_back_no_crash(self, db) -> None:
+        # A dict with an unhashable (list) impact must NOT reach the reducer.
+        bad = MagicMock()
+        bad.success = True
+        bad.content = json.dumps({"impact": ["breaking"], "summary": "s", "details": "d"})
+        router = AsyncMock()
+        router.route_call = AsyncMock(return_value=bad)
+        analyzer = CCUpdateAnalyzer(db=db, router=router)
+        out = await analyzer._llm_analyze("2.1.4", "2.1.5", "Fixed a leak")
+        assert isinstance(out, dict)
+        assert out["impact"] in (IMPACT_INFORMATIONAL, IMPACT_ACTION_NEEDED)
+        assert isinstance(out["summary"], str) and isinstance(out["details"], str)
+
+    @pytest.mark.asyncio
+    async def test_numeric_fields_coerced_to_str(self, db) -> None:
+        # Valid impact but non-str summary/details must be coerced, not passed through.
+        bad = MagicMock()
+        bad.success = True
+        bad.content = json.dumps({"impact": IMPACT_BREAKING, "summary": 42, "details": 99})
+        router = AsyncMock()
+        router.route_call = AsyncMock(return_value=bad)
+        analyzer = CCUpdateAnalyzer(db=db, router=router)
+        out = await analyzer._llm_analyze("2.1.4", "2.1.5", "x")
+        assert out["impact"] == IMPACT_BREAKING
+        assert isinstance(out["summary"], str) and isinstance(out["details"], str)
+
+    @pytest.mark.asyncio
+    async def test_multichunk_malformed_payload_end_to_end_no_crash(self, db) -> None:
+        # The reducer/ingest/alert must survive a malformed chunk payload end to end.
+        good = _llm(IMPACT_INFORMATIONAL, "A", "dA")
+        bad = MagicMock()
+        bad.success = True
+        bad.content = json.dumps({"impact": {"x": 1}, "details": [1, 2], "summary": None})
+        router = AsyncMock()
+        router.route_call = AsyncMock(side_effect=[good, bad])
+        analyzer = CCUpdateAnalyzer(db=db, router=router)
+        with patch.object(analyzer, "_fetch_changelog", new_callable=AsyncMock,
+                          return_value="## 2.1.5\n- x"), \
+             patch.object(analyzer, "_chunk_changelog", return_value=["c1", "c2"]):
+            result = await analyzer.analyze("2.1.3", "2.1.5")
+        assert isinstance(result["impact"], str)
+        assert "finding_id" in result
+
+    def test_coerce_returns_none_on_unhashable_impact(self) -> None:
+        # An unhashable impact must return None (-> fallback), never raise on the
+        # `in frozenset` membership test.
+        assert CCUpdateAnalyzer._coerce_analysis({"impact": ["breaking"], "summary": "s"}) is None
+        assert CCUpdateAnalyzer._coerce_analysis({"impact": {"x": 1}}) is None
+        assert CCUpdateAnalyzer._coerce_analysis("not a dict") is None
+        assert CCUpdateAnalyzer._coerce_analysis({"summary": "no impact key"}) is None
+
+    def test_coerce_normalizes_valid_payload_to_str_fields(self) -> None:
+        out = CCUpdateAnalyzer._coerce_analysis(
+            {"impact": IMPACT_BREAKING, "summary": 42, "details": None},
+        )
+        assert out == {"impact": IMPACT_BREAKING, "summary": "42", "details": ""}

--- a/tests/test_recon/test_cc_update_analyzer.py
+++ b/tests/test_recon/test_cc_update_analyzer.py
@@ -16,6 +16,14 @@ from genesis.recon.cc_update_analyzer import (
 )
 
 
+def _llm(impact: str, summary: str, details: str) -> MagicMock:
+    """Build a mock router result carrying an analyzer JSON payload."""
+    r = MagicMock()
+    r.success = True
+    r.content = json.dumps({"impact": impact, "summary": summary, "details": details})
+    return r
+
+
 @pytest.fixture()
 async def db():
     """In-memory SQLite with the full production schema.
@@ -129,119 +137,338 @@ class TestAnalysis:
         assert result["impact"] == IMPACT_INFORMATIONAL
 
 
-class TestChangelogFetch:
-    """GitHub-based changelog fetching."""
+class TestChangelogRangeFetch:
+    """Range-aware fetch: CHANGELOG.md primary, releases-API single-version fallback."""
+
+    # Newest-first, mirroring the real CHANGELOG.md ordering.
+    _MULTI = (
+        "## 2.1.220\n\n- fix twenty\n\n"
+        "## 2.1.219\n\n- Added Opus 5\n- fix nineteen\n\n"
+        "## 2.1.218\n\n- old fix\n"
+    )
 
     @pytest.mark.asyncio
-    async def test_fetch_parses_matching_release(self, db) -> None:
-        """Fetches body from release matching the version tag."""
+    async def test_range_extracts_all_intervening_releases(self, db) -> None:
+        """A multi-release jump analyzes EVERY release in (old, new] — the bug fix."""
+        analyzer = CCUpdateAnalyzer(db=db)
+        with patch.object(analyzer, "_fetch_changelog_md",
+                          new_callable=AsyncMock, return_value=self._MULTI):
+            result = await analyzer._fetch_changelog("2.1.218", "2.1.220")
+        assert "2.1.220" in result
+        # The intervening release is NOT skipped (the whole point):
+        assert "2.1.219" in result and "Added Opus 5" in result
+        assert "2.1.218" not in result  # old bound is exclusive
+
+    @pytest.mark.asyncio
+    async def test_range_respects_claude_version_suffix(self, db) -> None:
+        analyzer = CCUpdateAnalyzer(db=db)
+        with patch.object(analyzer, "_fetch_changelog_md",
+                          new_callable=AsyncMock, return_value=self._MULTI):
+            result = await analyzer._fetch_changelog(
+                "2.1.218 (Claude Code)", "2.1.219 (Claude Code)",
+            )
+        assert "2.1.219" in result
+        assert "2.1.220" not in result  # above the new bound
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_release_body_marked_partial(self, db) -> None:
+        """CHANGELOG unavailable -> single-version body, LOUDLY marked PARTIAL."""
+        analyzer = CCUpdateAnalyzer(db=db)
+        with patch.object(analyzer, "_fetch_changelog_md",
+                          new_callable=AsyncMock, return_value=""), \
+             patch.object(analyzer, "_fetch_release_body",
+                          new_callable=AsyncMock, return_value="only new notes"):
+            result = await analyzer._fetch_changelog("1.0.0", "1.1.0")
+        assert "only new notes" in result
+        assert "[PARTIAL]" in result
+
+    @pytest.mark.asyncio
+    async def test_fallback_when_range_empty(self, db) -> None:
+        """CHANGELOG fetched but no sections in range (equal/downgrade) -> fallback."""
+        analyzer = CCUpdateAnalyzer(db=db)
+        with patch.object(analyzer, "_fetch_changelog_md",
+                          new_callable=AsyncMock, return_value=self._MULTI), \
+             patch.object(analyzer, "_fetch_release_body",
+                          new_callable=AsyncMock, return_value="new only") as rb:
+            result = await analyzer._fetch_changelog("2.1.220", "2.1.220")
+        rb.assert_awaited_once()
+        assert "[PARTIAL]" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_both_sources_fail(self, db) -> None:
+        analyzer = CCUpdateAnalyzer(db=db)
+        with patch.object(analyzer, "_fetch_changelog_md",
+                          new_callable=AsyncMock, return_value=""), \
+             patch.object(analyzer, "_fetch_release_body",
+                          new_callable=AsyncMock, return_value=""):
+            result = await analyzer._fetch_changelog("1.0.0", "1.1.0")
+        assert result == ""
+
+
+class TestChangelogMdFetch:
+    """The raw CHANGELOG.md fetch (curl)."""
+
+    @pytest.mark.asyncio
+    async def test_md_fetch_success(self, db) -> None:
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"## 2.1.5\n- x", b""))
+        mock_proc.returncode = 0
+        analyzer = CCUpdateAnalyzer(db=db)
+        with patch("genesis.recon.cc_update_analyzer.asyncio.create_subprocess_exec",
+                   return_value=mock_proc):
+            result = await analyzer._fetch_changelog_md()
+        assert "2.1.5" in result
+
+    @pytest.mark.asyncio
+    async def test_md_fetch_empty_on_failure(self, db) -> None:
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b"404"))
+        mock_proc.returncode = 22
+        analyzer = CCUpdateAnalyzer(db=db)
+        with patch("genesis.recon.cc_update_analyzer.asyncio.create_subprocess_exec",
+                   return_value=mock_proc):
+            assert await analyzer._fetch_changelog_md() == ""
+
+    @pytest.mark.asyncio
+    async def test_md_fetch_empty_on_timeout(self, db) -> None:
+        mock_proc = AsyncMock()
+        mock_proc.kill = MagicMock()
+        analyzer = CCUpdateAnalyzer(db=db)
+        with patch("genesis.recon.cc_update_analyzer.asyncio.create_subprocess_exec",
+                   return_value=mock_proc), \
+             patch("genesis.recon.cc_update_analyzer.asyncio.wait_for",
+                   side_effect=TimeoutError):
+            assert await analyzer._fetch_changelog_md() == ""
+        mock_proc.kill.assert_called_once()
+
+
+class TestReleaseBodyFallback:
+    """The releases-API single-version fallback (_fetch_release_body)."""
+
+    @pytest.mark.asyncio
+    async def test_parses_matching_release(self, db) -> None:
         releases = json.dumps([
             {"tag_name": "v1.1.0", "body": "## What's changed\n\n- Added feature X"},
             {"tag_name": "v1.0.0", "body": "Old release"},
         ])
-
         mock_proc = AsyncMock()
         mock_proc.communicate = AsyncMock(return_value=(releases.encode(), b""))
         mock_proc.returncode = 0
-
         analyzer = CCUpdateAnalyzer(db=db)
-
         with patch("genesis.recon.cc_update_analyzer.asyncio.create_subprocess_exec",
-                    return_value=mock_proc):
-            result = await analyzer._fetch_changelog("1.0.0", "1.1.0")
-
+                   return_value=mock_proc):
+            result = await analyzer._fetch_release_body("1.1.0")
         assert "Added feature X" in result
 
     @pytest.mark.asyncio
-    async def test_fetch_handles_claude_version_format(self, db) -> None:
-        """Strips ' (Claude Code)' suffix from version when matching tags."""
-        releases = json.dumps([
-            {"tag_name": "v2.1.84", "body": "PowerShell tool added"},
-        ])
-
+    async def test_handles_claude_version_format(self, db) -> None:
+        releases = json.dumps([{"tag_name": "v2.1.84", "body": "PowerShell tool added"}])
         mock_proc = AsyncMock()
         mock_proc.communicate = AsyncMock(return_value=(releases.encode(), b""))
         mock_proc.returncode = 0
-
         analyzer = CCUpdateAnalyzer(db=db)
-
         with patch("genesis.recon.cc_update_analyzer.asyncio.create_subprocess_exec",
-                    return_value=mock_proc):
-            result = await analyzer._fetch_changelog("2.1.83 (Claude Code)", "2.1.84 (Claude Code)")
-
+                   return_value=mock_proc):
+            result = await analyzer._fetch_release_body("2.1.84 (Claude Code)")
         assert "PowerShell" in result
 
     @pytest.mark.asyncio
-    async def test_fetch_returns_empty_on_gh_failure(self, db) -> None:
-        """Returns empty string when gh CLI fails."""
+    async def test_empty_on_gh_failure(self, db) -> None:
         mock_proc = AsyncMock()
         mock_proc.communicate = AsyncMock(return_value=(b"", b"auth required"))
         mock_proc.returncode = 1
-
         analyzer = CCUpdateAnalyzer(db=db)
-
         with patch("genesis.recon.cc_update_analyzer.asyncio.create_subprocess_exec",
-                    return_value=mock_proc):
-            result = await analyzer._fetch_changelog("1.0.0", "1.1.0")
-
-        assert result == ""
+                   return_value=mock_proc):
+            assert await analyzer._fetch_release_body("1.1.0") == ""
 
     @pytest.mark.asyncio
-    async def test_fetch_returns_empty_on_timeout(self, db) -> None:
-        """Returns empty string on timeout."""
-        mock_proc = AsyncMock()
-        mock_proc.kill = MagicMock()
-
-        analyzer = CCUpdateAnalyzer(db=db)
-
-        with patch("genesis.recon.cc_update_analyzer.asyncio.create_subprocess_exec",
-                    return_value=mock_proc), \
-             patch("genesis.recon.cc_update_analyzer.asyncio.wait_for",
-                    side_effect=TimeoutError):
-            result = await analyzer._fetch_changelog("1.0.0", "1.1.0")
-
-        assert result == ""
-        mock_proc.kill.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_fetch_returns_empty_when_tag_not_found(self, db) -> None:
-        """Returns empty string when no release matches the version tag."""
-        releases = json.dumps([
-            {"tag_name": "v2.0.0", "body": "Different version"},
-        ])
-
+    async def test_empty_when_tag_not_found(self, db) -> None:
+        releases = json.dumps([{"tag_name": "v2.0.0", "body": "Different version"}])
         mock_proc = AsyncMock()
         mock_proc.communicate = AsyncMock(return_value=(releases.encode(), b""))
         mock_proc.returncode = 0
-
         analyzer = CCUpdateAnalyzer(db=db)
-
         with patch("genesis.recon.cc_update_analyzer.asyncio.create_subprocess_exec",
-                    return_value=mock_proc):
-            result = await analyzer._fetch_changelog("1.0.0", "1.1.0")
+                   return_value=mock_proc):
+            assert await analyzer._fetch_release_body("1.1.0") == ""
 
-        assert result == ""
+
+class TestSectionExtraction:
+    """Pure range extraction from CHANGELOG.md text (no I/O)."""
+
+    _MD = (
+        "# Changelog\n\n"
+        "## 2.1.245\n\n- glibc fix\n\n"
+        "## 2.1.243\n\n- Loops breakdown\n\n"
+        "## 2.1.233\n\n- Todo tools removed on newer models\n\n"
+        "## 2.1.218\n\n- baseline\n"
+    )
+
+    def test_range_is_old_exclusive_new_inclusive(self) -> None:
+        r = CCUpdateAnalyzer._extract_sections_in_range(self._MD, "2.1.218", "2.1.245")
+        assert "2.1.245" in r and "2.1.243" in r and "2.1.233" in r
+        assert "- baseline" not in r  # old (2.1.218) section excluded
+        assert "Todo tools removed" in r  # a middle release is present, not skipped
+
+    def test_upper_bound_inclusive_excludes_above(self) -> None:
+        r = CCUpdateAnalyzer._extract_sections_in_range(self._MD, "2.1.218", "2.1.233")
+        assert "2.1.233" in r
+        assert "2.1.243" not in r and "2.1.245" not in r
+
+    def test_skipped_version_numbers_handled(self) -> None:
+        # 2.1.244 does not exist; asking up to it still yields 2.1.243 (present).
+        r = CCUpdateAnalyzer._extract_sections_in_range(self._MD, "2.1.218", "2.1.244")
+        assert "2.1.243" in r and "2.1.245" not in r
+
+    def test_empty_when_no_sections_in_range(self) -> None:
+        assert CCUpdateAnalyzer._extract_sections_in_range(self._MD, "2.1.245", "2.1.245") == ""
+        assert CCUpdateAnalyzer._extract_sections_in_range(self._MD, "2.1.245", "2.1.243") == ""
+
+    def test_full_range_returned_uncapped(self) -> None:
+        # No size cap in extraction — the chunker covers everything downstream.
+        big = "".join(
+            f"## 2.1.{n}\n\n" + ("x" * 5000) + "\n\n"
+            for n in range(309, 299, -1)
+        )
+        r = CCUpdateAnalyzer._extract_sections_in_range(big, "2.1.299", "2.1.309")
+        # every in-range release present; nothing omitted at this layer
+        for n in range(300, 310):
+            assert f"## 2.1.{n}" in r
+        assert "omitted" not in r
+
+
+class TestChunking:
+    """Context-safe chunking of the concatenated changelog (map step)."""
+
+    def test_packs_sections_under_budget_into_one_chunk(self) -> None:
+        cl = "## 2.1.5\n\n- a\n\n## 2.1.4\n\n- b\n\n## 2.1.3\n\n- c"
+        chunks = CCUpdateAnalyzer._chunk_changelog(cl, budget=10000, max_chunks=12)
+        assert len(chunks) == 1
+        assert "2.1.5" in chunks[0] and "2.1.3" in chunks[0]
+
+    def test_splits_on_release_boundaries_when_over_budget(self) -> None:
+        cl = "".join(f"## 2.1.{n}\n\n" + ("x" * 5000) + "\n\n" for n in (7, 6, 5))
+        chunks = CCUpdateAnalyzer._chunk_changelog(cl, budget=8000, max_chunks=12)
+        assert len(chunks) >= 2
+        # every section is intact somewhere — no release dropped or split away
+        joined = "\n".join(chunks)
+        for n in (7, 6, 5):
+            assert f"## 2.1.{n}" in joined
+
+    def test_max_chunks_cap_keeps_newest_with_loud_marker(self) -> None:
+        cl = "".join(f"## 2.1.{n}\n\n" + ("x" * 5000) + "\n\n" for n in range(20, 0, -1))
+        chunks = CCUpdateAnalyzer._chunk_changelog(cl, budget=6000, max_chunks=3)
+        assert len(chunks) == 3
+        assert "## 2.1.20" in chunks[0]  # newest kept
+        assert "omitted" in chunks[-1]   # loud marker, never a silent cut
+
+    def test_no_headers_returns_single_chunk(self) -> None:
+        assert CCUpdateAnalyzer._chunk_changelog("[PARTIAL] just notes") == [
+            "[PARTIAL] just notes",
+        ]
+
+    def test_empty_returns_no_chunks(self) -> None:
+        assert CCUpdateAnalyzer._chunk_changelog("   ") == []
+
+
+class TestRangeAnalysis:
+    """Map-reduce analysis: per-chunk classification aggregated by severity."""
 
     @pytest.mark.asyncio
-    async def test_fetch_truncates_long_body(self, db) -> None:
-        """Release body over 1000 chars is truncated."""
-        long_body = "x" * 1500
-        releases = json.dumps([
-            {"tag_name": "v1.1.0", "body": long_body},
+    async def test_range_analysis_aggregates_max_severity(self, db) -> None:
+        router = AsyncMock()
+        router.route_call = AsyncMock(side_effect=[
+            _llm(IMPACT_INFORMATIONAL, "chunk A", "details A"),
+            _llm(IMPACT_BREAKING, "chunk B removed --resume", "details B"),
         ])
+        analyzer = CCUpdateAnalyzer(db=db, router=router)
+        with patch.object(analyzer, "_chunk_changelog",
+                          return_value=["chunk1", "chunk2"]):
+            out = await analyzer._analyze_range("2.1.3", "2.1.5", "irrelevant")
+        assert out["impact"] == IMPACT_BREAKING          # worst chunk wins
+        assert router.route_call.await_count == 2        # one LLM call per chunk
+        assert "details B" in out["details"]             # merged details retained
 
-        mock_proc = AsyncMock()
-        mock_proc.communicate = AsyncMock(return_value=(releases.encode(), b""))
-        mock_proc.returncode = 0
+    @pytest.mark.asyncio
+    async def test_analyze_multichunk_stores_high_priority(self, db) -> None:
+        router = AsyncMock()
+        router.route_call = AsyncMock(side_effect=[
+            _llm(IMPACT_INFORMATIONAL, "A", "dA"),
+            _llm(IMPACT_BREAKING, "B", "dB"),
+        ])
+        analyzer = CCUpdateAnalyzer(db=db, router=router)
+        with patch.object(analyzer, "_fetch_changelog",
+                          new_callable=AsyncMock, return_value="## 2.1.5\n- x"), \
+             patch.object(analyzer, "_chunk_changelog",
+                          return_value=["c1", "c2"]):
+            result = await analyzer.analyze("2.1.3", "2.1.5")
+        assert result["impact"] == IMPACT_BREAKING
+        cursor = await db.execute(
+            "SELECT priority FROM observations WHERE id = ?", (result["finding_id"],),
+        )
+        assert (await cursor.fetchone())[0] == "high"
 
-        analyzer = CCUpdateAnalyzer(db=db)
+    @pytest.mark.asyncio
+    async def test_single_chunk_passthrough_verbatim(self, db) -> None:
+        """A small (single-chunk) bump keeps the prior single-call behaviour."""
+        router = AsyncMock()
+        router.route_call = AsyncMock(return_value=_llm(IMPACT_ACTION_NEEDED, "solo", "d"))
+        analyzer = CCUpdateAnalyzer(db=db, router=router)
+        with patch.object(analyzer, "_fetch_changelog",
+                          new_callable=AsyncMock, return_value="## 2.1.5\n- x"):
+            result = await analyzer.analyze("2.1.4", "2.1.5")
+        assert result["impact"] == IMPACT_ACTION_NEEDED
+        assert result["summary"] == "solo"           # verbatim, not the rollup form
+        assert router.route_call.await_count == 1
 
-        with patch("genesis.recon.cc_update_analyzer.asyncio.create_subprocess_exec",
-                    return_value=mock_proc):
-            result = await analyzer._fetch_changelog("1.0.0", "1.1.0")
+    @pytest.mark.asyncio
+    async def test_non_dict_llm_payload_falls_back(self, db) -> None:
+        """A free model emitting bare-string/array JSON must not crash the reducer."""
+        router = AsyncMock()
+        bad = MagicMock()
+        bad.success = True
+        bad.content = json.dumps("done")  # valid JSON, but a str — not an object
+        router.route_call = AsyncMock(return_value=bad)
+        analyzer = CCUpdateAnalyzer(db=db, router=router)
+        # _llm_analyze must return the structured fallback dict, never the str
+        out = await analyzer._llm_analyze("2.1.4", "2.1.5", "Fixed a memory leak")
+        assert isinstance(out, dict)
+        assert out["impact"] == IMPACT_INFORMATIONAL
+        # and analyze() end-to-end does not raise on the non-dict payload
+        with patch.object(analyzer, "_fetch_changelog",
+                          new_callable=AsyncMock, return_value="## 2.1.5\n- x"):
+            result = await analyzer.analyze("2.1.4", "2.1.5")
+        assert result["impact"] == IMPACT_INFORMATIONAL
 
-        assert len(result) < 1500
-        assert result.endswith("(truncated)")
+    @pytest.mark.asyncio
+    async def test_multichunk_summary_rollup_format(self, db) -> None:
+        router = AsyncMock()
+        router.route_call = AsyncMock(side_effect=[
+            _llm(IMPACT_INFORMATIONAL, "A", "dA"),
+            _llm(IMPACT_ACTION_NEEDED, "B needs care", "dB"),
+        ])
+        analyzer = CCUpdateAnalyzer(db=db, router=router)
+        with patch.object(analyzer, "_chunk_changelog", return_value=["c1", "c2"]):
+            out = await analyzer._analyze_range("2.1.3", "2.1.5", "x")
+        assert "analyzed across 2 changelog chunks" in out["summary"]
+        assert "Highest-severity item: B needs care" in out["summary"]
+
+
+class TestSemverTuple:
+    """Version-string -> numeric tuple."""
+
+    def test_plain(self) -> None:
+        assert CCUpdateAnalyzer._semver_tuple("2.1.84") == (2, 1, 84)
+
+    def test_suffix_and_prefix(self) -> None:
+        assert CCUpdateAnalyzer._semver_tuple("v2.1.84 (Claude Code)") == (2, 1, 84)
+
+    def test_ordering_numeric_not_lexical(self) -> None:
+        assert CCUpdateAnalyzer._semver_tuple("2.1.9") < CCUpdateAnalyzer._semver_tuple("2.1.10")
+
+    def test_empty_on_nonversion(self) -> None:
+        assert CCUpdateAnalyzer._semver_tuple("not a version") == ()
 
 
 class TestVersionToTag:


### PR DESCRIPTION
## Problem

`CCUpdateAnalyzer.analyze()` fetched only the **single `new_version` release body**,
so a multi-release jump (e.g. `2.1.218 → 2.1.245`, 24 releases) was impact-classified
off one release's notes — every intervening release was invisible. A regression or
breaking change introduced in a middle release could not be surfaced.

## Fix

`_fetch_changelog` now pulls the raw `CHANGELOG.md` and extracts every `## X.Y.Z`
section in `(old, new]`. Multi-release ranges are analyzed **map-reduce**:

- `_chunk_changelog` splits the concatenated range into context-safe chunks on
  release boundaries — never splitting or dropping a release; a pathological range
  is capped with a **loud** omission marker (never a silent cut).
- `_analyze_range` classifies each chunk concurrently (`asyncio.gather`) so
  wall-clock ≈ one call (the awareness caller wraps `analyze()` in a short timeout).
- `_aggregate_analyses` reduces per-chunk verdicts to one, overall impact = highest
  severity across chunks, details ordered severity-first.

A single-chunk range returns the chunk analysis **verbatim**, preserving the prior
single-call behaviour and the `{impact, summary, details, finding_id}` contract.
When `CHANGELOG.md` is unavailable it falls back to the releases-API single-version
body, loudly marked `[PARTIAL]`, rather than silently regressing. LLM output is
dict-guarded at the boundary before the reducer.

## Testing

- 66 targeted tests green (`tests/test_recon/test_cc_update_analyzer.py`); ruff clean.
- Range extraction is old-exclusive / new-inclusive; skipped version numbers handled;
  chunk cap keeps newest + loud marker; non-dict LLM payload falls back without crashing.
- Measured on the real changelog: `218 → 245` spans 24 releases (~80KB) across 2 chunks
  with every release preserved.

Follow-up: 223b46b79e4f4c85aabee39faea47313


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Impact analysis now evaluates complete version ranges from the changelog.
  - Large release ranges are processed in manageable sections and combined by highest detected impact.
  - Changelog retrieval supports full release history with a visible fallback when only partial information is available.

- **Bug Fixes**
  - Improved handling of malformed analysis results and incomplete changelog data.
  - Version changes are recorded and signaled reliably without duplicate notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->