### PR TITLE
fix(observability): surface campaign last_tick so idle-skipping reads as active

### DIFF
--- a/src/genesis/mcp/health/campaign_tools.py
+++ b/src/genesis/mcp/health/campaign_tools.py
@@ -160,11 +160,20 @@ async def _impl_campaign_list(status_filter: str | None = None) -> dict:
         campaigns = await crud.list_campaigns(db, status_filter=status_filter)
         items = []
         for c in campaigns:
+            # last_run_at only advances on SUBSTANTIVE runs, so an idle-skipping
+            # campaign (skips every cadence via a pre-check) reads as stalled.
+            # Surface last_tick (most recent tick of any outcome) so "active,
+            # idle-skipping" is distinguishable from "dead". Newest-first.
+            latest = await crud.list_runs(db, c["id"], limit=1)
+            tick = latest[0] if latest else None
             items.append({
                 "name": c["name"],
                 "status": c["status"],
                 "cadence": c["cron_cadence"],
                 "last_run": c.get("last_run_at"),
+                "last_tick": tick["started_at"] if tick else None,
+                "last_tick_outcome": tick["outcome"] if tick else None,
+                "last_skip_reason": tick.get("skip_reason") if tick else None,
                 "total_runs": c["total_runs"],
                 "total_cost": f"${c['total_cost_usd']:.2f}",
                 "model": c["model"],
@@ -201,6 +210,11 @@ async def _impl_campaign_status(name: str) -> dict:
         # Filter internal keys from state display
         visible_state = {k: v for k, v in state.items() if not k.startswith("_")}
 
+        # last_run_at only advances on SUBSTANTIVE runs; last_tick is the most
+        # recent tick of ANY outcome (runs is newest-first) so an idle-skipping
+        # campaign is legible as "active, skipping" rather than stalled.
+        tick = runs[0] if runs else None
+
         return {
             "name": campaign["name"],
             "status": campaign["status"],
@@ -211,6 +225,9 @@ async def _impl_campaign_status(name: str) -> dict:
             "max_daily_cost": f"${campaign['max_daily_cost_usd']:.2f}",
             "state": visible_state,
             "last_run": campaign.get("last_run_at"),
+            "last_tick": tick["started_at"] if tick else None,
+            "last_tick_outcome": tick["outcome"] if tick else None,
+            "last_skip_reason": tick.get("skip_reason") if tick else None,
             "total_runs": campaign["total_runs"],
             "total_cost": f"${campaign['total_cost_usd']:.2f}",
             "recent_runs": [

--- a/tests/test_mcp/test_campaign_tools.py
+++ b/tests/test_mcp/test_campaign_tools.py
@@ -281,3 +281,86 @@ class TestWiredDbPath:
         finally:
             ct_mod._db = old_db
             ct_mod._runner = old_runner
+
+
+class TestLastTick:
+    """`last_tick` surfaces the most recent tick of ANY outcome. `last_run_at`
+    only advances on substantive runs, so an idle-skipping campaign (skips every
+    cadence via a pre-check) shows a stale `last_run` and reads as stalled — the
+    tick fields make "active, idle-skipping" visible."""
+
+    @staticmethod
+    async def _seed_old_run_and_recent_skip(db):
+        # Old substantive success + a RECENT skip (the real idle-gated pattern).
+        await db.execute(
+            "INSERT INTO campaign_runs "
+            "(id, campaign_id, started_at, outcome, skip_reason, cost_usd) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("run-old", "test-id-1", "2026-06-01T10:00:00+00:00", "success", None, 0.5),
+        )
+        await db.execute(
+            "INSERT INTO campaign_runs "
+            "(id, campaign_id, started_at, outcome, skip_reason, cost_usd) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "run-skip", "test-id-1", "2026-08-25T22:00:00+00:00",
+                "skip", "no new github activity", 0.0,
+            ),
+        )
+        # last_run_at only advanced on the substantive run.
+        await db.execute(
+            "UPDATE campaigns SET last_run_at = ? WHERE id = ?",
+            ("2026-06-01T10:00:00+00:00", "test-id-1"),
+        )
+        await db.commit()
+
+    @pytest.mark.asyncio
+    async def test_status_surfaces_last_tick_when_idle_skipping(self, _test_db):
+        await self._seed_old_run_and_recent_skip(_test_db)
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = _test_db
+            ct_mod._runner = None
+            with patch.object(ct_mod, "_get_db") as mock_get:
+                result = await ct_mod._impl_campaign_status("test-campaign")
+            mock_get.assert_not_called()
+            assert result["last_run"] == "2026-06-01T10:00:00+00:00"  # stale
+            assert result["last_tick"] == "2026-08-25T22:00:00+00:00"  # fresh
+            assert result["last_tick_outcome"] == "skip"
+            assert result["last_skip_reason"] == "no new github activity"
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+    @pytest.mark.asyncio
+    async def test_list_surfaces_last_tick(self, _test_db):
+        await self._seed_old_run_and_recent_skip(_test_db)
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = _test_db
+            ct_mod._runner = None
+            with patch.object(ct_mod, "_get_db"):
+                result = await ct_mod._impl_campaign_list()
+            c = result["campaigns"][0]
+            assert c["last_run"] == "2026-06-01T10:00:00+00:00"
+            assert c["last_tick"] == "2026-08-25T22:00:00+00:00"
+            assert c["last_tick_outcome"] == "skip"
+            assert c["last_skip_reason"] == "no new github activity"
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner
+
+    @pytest.mark.asyncio
+    async def test_last_tick_none_when_no_runs(self, _test_db):
+        # A brand-new campaign with zero runs: tick fields are None, not a crash.
+        old_db, old_runner = ct_mod._db, ct_mod._runner
+        try:
+            ct_mod._db = _test_db
+            ct_mod._runner = None
+            with patch.object(ct_mod, "_get_db"):
+                result = await ct_mod._impl_campaign_status("test-campaign")
+            assert result["last_tick"] is None
+            assert result["last_tick_outcome"] is None
+        finally:
+            ct_mod._db = old_db
+            ct_mod._runner = old_runner


### PR DESCRIPTION
## What

`campaign_list` / `campaign_status` surfaced `last_run_at`, which only advances on **substantive** runs. A campaign that idle-skips every cadence (e.g. a `github_activity_pending` pre-check gating the LLM session) therefore reads as **stalled** though it ticks fine every interval — a misleading "looks-dead" signal on a healthy campaign.

## Changes

Add `last_tick` / `last_tick_outcome` / `last_skip_reason` to both MCP tools, derived from the most recent `campaign_runs` row (`crud.list_runs` is newest-first). **Read-side only, no schema change.** `campaign_status` reuses its existing `runs` query (zero extra query); `campaign_list` adds one `list_runs(limit=1)` per campaign (campaign counts are single-digit).

## Tests / review

TDD verify-RED (`KeyError: 'last_tick'`) → GREEN; **13 passed**, ruff clean. genesis-architect review clean (all 6 probes verified: newest-first ordering, dict/`.get()` safety, additive backward-compat, N+1 acceptable, tests non-tautological). A parity gap on the **dashboard** campaigns-list route (`routes/campaigns.py:107` — same staleness, a different surface, no `recent_runs` to derive from client-side) is tracked as a follow-up rather than bundled here.
