### PR TITLE
feat(hooks): required-CI-workflow identity in the merge gate (close the partial-rollup fail-open)

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -842,9 +842,16 @@ findings below, a gated `gh pr merge`:
 - **the CI gate** blocks red/pending checks; and — on the canonical public repo,
   where CI always runs — an `absent` CI state (a readable EMPTY check set = CI
   never ran, the tell of a conflicting branch or a dropped `pull_request` trigger)
-  also blocks, so an un-CI'd PR can't merge. An UNREADABLE CI read (`unknown`)
-  fails OPEN, and off the canonical repo `absent` fails open too (a repo may
-  legitimately have no CI). Waive with `# ci-override` (never `--admin`).
+  also blocks, so an un-CI'd PR can't merge. Likewise `incomplete` (a NON-empty
+  rollup whose present checks are green but a REQUIRED workflow contributed no
+  verdict — e.g. a lone green CodeQL after a workflow-specific trigger drop, or a
+  fully-SKIPPED suite): the required identity is the rollup `workflowName`, config
+  driven via `merge_gate.required_ci_workflows: [<names>]` in local `genesis.yaml`
+  (default `CI`; fail-closed to the default on any malformed/empty config — there
+  is no disable value). An UNREADABLE CI read (`unknown`) fails OPEN, and off the
+  canonical repo `absent`/`incomplete` fail open too (another repo may
+  legitimately have no CI, or a differently-named suite). Waive with
+  `# ci-override` (never `--admin`).
 - **Override sigils are split by boundary** so one waiver can't silently disarm
   an unrelated gate: `# review-override` waives ONLY the finding scans
   (review-body + inline P1s); `# stale-review-override` waives ONLY the
@@ -882,15 +889,28 @@ The review-findings gate specifically:
    A **404 from that endpoint means WRONG SLUG or PR number, never "no
    findings"** — a clean PR returns `[]`. The merge-gate hook only blocks
    ERROR/[P1]/HARD BLOCK, so unread P2s pass silently (2026-07-10: 8 real
-   P2s on the entity-layer PRs were merged past this exact way).
+   P2s on the entity-layer PRs were merged past this exact way). And the two
+   channels are INDEPENDENT: Codex can post a quota/usage-limit message as an
+   ISSUE comment while a later `@codex review` trigger delivers real inline
+   findings anyway — a quota message is evidence about that channel at that
+   moment, never proof Codex "can't review". After time passes, re-trigger and
+   check the INLINE endpoint before concluding quota-limited (2026-08-26: #1484's
+   real P2 arrived inline while the issue-comment channel still showed only the
+   earlier quota message).
 8. **A CONFLICTING PR silently suppresses the whole CI suite.** When a PR
    has a merge conflict with main, GitHub cannot build the merge ref, so
    `pull_request`-triggered workflows (the entire ci.yml suite) never run —
    while CodeQL still passes on the head SHA, making the check list LOOK
    green. A thin check list (only Analyze/CodeQL) means CHECK
-   `gh pr view N --json mergeable` — `CONFLICTING` needs a rebase before any
-   CI verdict exists at all (2026-07-16: #1089 sat conflict-suppressed
-   through three pushes; main had moved under it via concurrent sessions).
+   `gh pr view N --json mergeable` — `CONFLICTING` needs the base branch merged
+   in before any CI verdict exists at all (2026-07-16: #1089 sat
+   conflict-suppressed through three pushes; main had moved under it via
+   concurrent sessions). Since #1484 the merge gate ENFORCES this class
+   mechanically on the canonical repo: a fully-empty rollup reads `ci: absent`
+   and blocks, and a thin/partial rollup missing the required CI workflow reads
+   `ci: incomplete` and blocks (see the CI-gate bullet above) — the trap text
+   stays because the DIAGNOSIS (check `mergeable` first) is still the fastest
+   route to the cause.
 
 ## Reference Router
 

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -40,8 +40,12 @@ waiver cannot silently disarm an unrelated gate: ``# review-override`` waives th
 FINDING scans (review-body + inline P1s), ``# stale-review-override`` waives the
 review-CONTEXT gates (Codex-at-head freshness + base-is-default),
 ``# scheduled-review-override`` waives the SCHEDULED-Claude-review-at-head gate, and
-``# ci-override`` waives the CI gate. A session that genuinely needs several
-appends several (one trailing comment may carry multiple sigils).
+``# ci-override`` waives the CI gate — red/pending everywhere, plus (canonical repo
+only) "absent" (empty rollup: CI never ran) and "incomplete" (partial rollup: a
+REQUIRED workflow — ``merge_gate.required_ci_workflows`` in genesis.yaml, default
+``CI`` — contributed no verdict; see ``_required_ci_workflows``). A session that
+genuinely needs several appends several (one trailing comment may carry multiple
+sigils).
 
 Scheduled Claude review markers
 -------------------------------
@@ -704,6 +708,15 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
                         caller lets it pass. This is the state that catches a
                         conflicting branch / dropped ``pull_request`` trigger, which
                         would otherwise merge un-CI'd.
+      * ``"incomplete"`` — the rollup is NON-empty and nothing is red/pending, but a
+                        REQUIRED workflow (rollup ``workflowName``; config-driven via
+                        ``merge_gate.required_ci_workflows``, default ``CI`` — see
+                        _required_ci_workflows) never contributed a verdict. Closes the
+                        #1484-P2 partial-rollup residual: e.g. a lone green CodeQL with
+                        the CI suite absent (a workflow-specific trigger drop) must not
+                        read green. ``problem_checks`` carries the MISSING workflow
+                        names. Enforced like ``"absent"``: canonical repo only,
+                        waivable by ``# ci-override``.
       * ``"unknown"`` — could NOT determine: an API error, empty/no output, an
                         unparseable payload, or a non-empty payload with no CI-shaped
                         entries. Callers FAIL OPEN, because blocking a merge on our own
@@ -779,6 +792,12 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
     red: list[str] = []
     pending: list[str] = []
     saw_recognized = False
+    # Workflows that contributed a VERDICT on this head (casefolded ``workflowName``),
+    # for the required-identity check below. SKIPPED/NEUTRAL entries deliberately do
+    # NOT contribute — a fully-skipped required suite tested nothing. Legacy
+    # StatusContexts (no workflowName) contribute "" and can never satisfy a named
+    # required workflow (fail-closed on the Actions-only canonical repo).
+    workflows_ran: set[str] = set()
     for c in checks:
         if not isinstance(c, dict):
             continue
@@ -786,6 +805,7 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
         conclusion = c.get("conclusion")  # CheckRun
         status = c.get("status")  # CheckRun: QUEUED/IN_PROGRESS/COMPLETED/PENDING/…
         state = c.get("state")  # StatusContext: SUCCESS/FAILURE/PENDING/ERROR
+        wf_key = (c.get("workflowName") or "").strip().casefold()
         if conclusion in _CI_SKIP_CONCLUSIONS:
             saw_recognized = True
             continue
@@ -803,12 +823,28 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
                 # NO same-identity success at-or-after it (e.g. SUCCESS-then-cancel
                 # on an unchanged head) falls through and stays red.
                 saw_recognized = True
+                # A superseded duplicate implies a same-identity SUCCESS exists on
+                # this head, so the workflow demonstrably ran.
+                workflows_ran.add(wf_key)
                 continue
         if conclusion in _CI_RED_CONCLUSIONS or state in _CI_RED_STATES:
             saw_recognized = True
             red.append(name)
         elif conclusion in _CI_GREEN or state in _CI_GREEN:
+            # The ONLY branch (besides the superseded-cancel drop above, which implies
+            # a green sibling) that feeds workflows_ran: the required-identity check
+            # runs only when nothing is red/pending (those return first, and already
+            # block), so only PASSING verdicts can vouch that a required workflow ran.
+            # A COMPLETED run with a null conclusion (the benign ignore below) carries
+            # no verdict and deliberately does NOT vouch — fail-closed. Vouching is
+            # additionally gated on a CheckRun-shaped pass (``conclusion``): a
+            # StatusContext-shaped green (``state``) can't carry a real Actions
+            # workflowName, so an entry gluing state=SUCCESS to a workflowName key
+            # must not satisfy the required identity by construction (not merely by
+            # gh's current output shape).
             saw_recognized = True
+            if conclusion in _CI_GREEN:
+                workflows_ran.add(wf_key)
         elif status in _CI_TERMINAL_STATUSES:
             saw_recognized = True
             if conclusion is not None:
@@ -835,15 +871,19 @@ def _pr_ci_status(pr_num: str, repo: str | None = None) -> tuple[str, list[str]]
         return "pending", sorted(set(pending))
     if not saw_recognized:
         return "unknown", []  # payload had no CI-shaped entries
-    # KNOWN RESIDUAL (deferred, Codex #1484 P2): "green" here means every check that
-    # IS present concluded success — it does NOT assert the REQUIRED CI workflow ran.
-    # A partial rollup (e.g. only a green CodeQL, the CI suite absent) reads green.
-    # The "absent" branch above only catches a FULLY-empty rollup (the conflicting-
-    # branch symptom, where CI+CodeQL are both pull_request-gated and neither builds).
-    # Closing the partial case robustly needs a config-driven "required CI check
-    # identity" (a required-CI analogue of _required_scheduled_review_kinds) so it
-    # does NOT false-block an install whose CI is legitimately path-filtered/skipped
-    # for a docs-only PR. Tracked as a follow-up; not bundled here.
+    # Required-workflow identity (closes the #1484-P2 partial-rollup residual): every
+    # present check passed, but "green" must ALSO assert that each REQUIRED workflow
+    # (default "CI"; config lever merge_gate.required_ci_workflows for an install whose
+    # suite is named differently) actually contributed a passing verdict. Otherwise a
+    # workflow-specific trigger drop — e.g. a lone green CodeQL, the CI suite absent —
+    # reads green and merges an untested PR. (The "absent" branch above only catches a
+    # FULLY-empty rollup.) Canonical-scoping and the # ci-override valve are applied by
+    # the CALLERS, exactly as for "absent", so a non-canonical repo is never blocked
+    # by this identity policy.
+    required = _required_ci_workflows()
+    missing = sorted(w for w in required if w.strip().casefold() not in workflows_ran)
+    if missing:
+        return "incomplete", missing
     return "green", []
 
 
@@ -1994,6 +2034,106 @@ def _required_scheduled_review_kinds() -> tuple[str, ...]:
     # leaks (and any irreducible kind) is always required, even if config omits it.
     merged = list(dict.fromkeys([*kinds, *_IRREDUCIBLE_REQUIRED_SCHEDULED_REVIEW_KINDS]))
     return tuple(merged)
+
+
+# The GitHub Actions workflow name(s) whose PRESENCE in a PR's check rollup the CI
+# gate requires before trusting "green" (the required-CI analogue of the scheduled-
+# review kinds above). Default = the canonical repo's ci.yml `name: CI`. Unlike the
+# scheduled kinds there is NO irreducible floor and NO known-set whitelist: the
+# identity is install-specific free text (a fork's suite may be named anything), so
+# config must be able to REPLACE the set — but never to EMPTY it (see the validator).
+_DEFAULT_REQUIRED_CI_WORKFLOWS = ("CI",)
+
+
+def _validate_configured_workflows(items: object) -> list[str] | None:
+    """Validate a configured required-CI-workflow list. Returns the cleaned list
+    (stripped, deduped, case PRESERVED for display; matching is case-insensitive), or
+    None if ANYTHING is off — not a list, an EMPTY list, a non-string element, or a
+    blank element. None makes the caller fail CLOSED to the default. An empty list is
+    deliberately invalid: it would DISABLE the identity check entirely, and the
+    per-merge escape for a consciously CI-less merge is ``# ci-override``, not config
+    (non-canonical repos are already exempt via _scheduled_gate_applies)."""
+    if not isinstance(items, list) or not items:
+        return None
+    out: list[str] = []
+    for w in items:
+        if not isinstance(w, str):
+            return None  # wrong type (e.g. [123]) -> invalid -> default
+        ww = w.strip()
+        if not ww:
+            return None  # blank ([" "]) -> invalid -> default
+        out.append(ww)
+    return list(dict.fromkeys(out))
+
+
+def _required_ci_workflows() -> tuple[str, ...]:
+    """The GitHub Actions workflow names (rollup ``workflowName``) the CI gate REQUIRES
+    to have contributed a passing verdict before ``_pr_ci_status`` returns "green".
+
+    Default: ``("CI",)`` — the canonical repo's ci.yml workflow, which has NO paths
+    filters and therefore always runs on a PR to main. An install whose required suite
+    is named differently configures it locally (keeping install policy out of the
+    public default):
+
+        # ~/.genesis/config/genesis.yaml
+        merge_gate:
+          required_ci_workflows: [My Suite]
+
+    Fail-CLOSED toward the default: a missing key / unreadable file / parse error /
+    duplicate key / wrong type / EMPTY list / blank element ALL fall back to the full
+    default — there is no config value that disables the check. Because free-text
+    config can also EXPAND the required set (unlike the whitelist-relaxed scheduled
+    kinds, whose default is maximal), a fallback here can silently NARROW a stricter
+    declared policy — so when the key is visibly present but its value was discarded,
+    a NOTE is printed naming the substitution (the fallback itself is unchanged).
+    Test seam: ``_TEST_REQUIRED_CI_WORKFLOWS`` (comma-separated) overrides the config
+    file; a blank seam parses to an empty (=invalid) list and also yields the
+    default."""
+    raw = os.environ.get("_TEST_REQUIRED_CI_WORKFLOWS")
+    configured: list[str] | None = None
+    key_seen_in_file = False
+    if raw is not None:
+        configured = _validate_configured_workflows(
+            [w.strip() for w in raw.split(",") if w.strip()]
+        )
+    else:
+        try:
+            import yaml  # lazy: keep the hook import-light; the genesis venv has pyyaml
+
+            path = os.path.expanduser("~/.genesis/config/genesis.yaml")
+            with open(path) as fh:
+                text = fh.read()
+            # A textual sighting of the KEY LINE (not a comment/prose mention): if the
+            # value is then discarded (dup key, parse error, invalid shape), the
+            # operator DECLARED a policy we are about to substitute — that must not be
+            # silent. A key-absent file (the normal install) stays silent. Checked
+            # BEFORE the parse so a yaml error can't skip it.
+            key_seen_in_file = bool(re.search(r"(?m)^\s*required_ci_workflows\s*:", text))
+            # Same duplicate-key hazard as the scheduled kinds: yaml.safe_load keeps
+            # the LAST value silently, so a badly-merged file could swap the required
+            # identity. Line-scan the realistic cases and fail closed.
+            if (
+                len(re.findall(r"(?m)^merge_gate\s*:", text)) > 1
+                or len(re.findall(r"(?m)^\s*required_ci_workflows\s*:", text)) > 1
+            ):
+                raise ValueError("duplicate merge_gate/required_ci_workflows key")
+            cfg = yaml.safe_load(text) or {}
+            value = (cfg.get("merge_gate") or {}).get("required_ci_workflows")
+            configured = _validate_configured_workflows(value)
+        except Exception:
+            configured = None  # fail-closed: fall back to the default set below
+    if configured is None:
+        if key_seen_in_file:
+            print(
+                "NOTE: merge_gate.required_ci_workflows in ~/.genesis/config/"
+                "genesis.yaml is present but unreadable/invalid (duplicate key, "
+                "wrong type, empty list, or blank element) — enforcing the DEFAULT "
+                f"required set {_DEFAULT_REQUIRED_CI_WORKFLOWS} instead of your "
+                "configured value. Fix the config to restore your declared policy.",
+                file=sys.stderr,
+            )
+        return _DEFAULT_REQUIRED_CI_WORKFLOWS
+    return tuple(configured)
 
 
 def _canonical_public_repo() -> str | None:
@@ -3604,6 +3744,32 @@ def main() -> int:
                         "(consciously accepted).",
                         file=sys.stderr,
                     )
+                # "incomplete" = a NON-empty rollup whose present checks are green, but
+                # a REQUIRED workflow (default "CI") contributed no verdict — e.g. a
+                # lone green CodeQL after a workflow-specific trigger drop (#1484-P2).
+                # Same scoping + valve as "absent": canonical repo only, # ci-override.
+                elif ci_state == "incomplete" and _scheduled_gate_applies(merge_repo):
+                    if not ci_override:
+                        print(
+                            f"BLOCKED: required CI workflow(s) missing from PR "
+                            f"#{pr_num}'s check rollup: {', '.join(ci_bad[:6])}. The "
+                            "checks that ARE present are green, but the required "
+                            "workflow never ran — most often a workflow-specific "
+                            "trigger drop (push a commit or re-run the workflow to "
+                            "re-fire) or a fully-skipped suite. The required set comes "
+                            "from merge_gate.required_ci_workflows in "
+                            "~/.genesis/config/genesis.yaml (default: CI). If you are "
+                            "intentionally merging without it, append a trailing "
+                            "'# ci-override' (logged).",
+                            file=sys.stderr,
+                        )
+                        return 2
+                    print(
+                        f"NOTE: required CI workflow(s) missing on #{pr_num} "
+                        f"({', '.join(ci_bad[:6])}) — merging via # ci-override "
+                        "(consciously accepted).",
+                        file=sys.stderr,
+                    )
 
                 force_override = merge_seg.override
                 # The review-CONTEXT waiver (freshness + base gates) is a SEPARATE
@@ -3889,6 +4055,14 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
         # empty check set on the canonical repo blocks (CI never ran — likely a
         # conflicting branch or a dropped pull_request trigger).
         print("  ↳ BLOCK — no CI checks have run (empty check set); pull_request CI never fired.")
+        failures += 1
+    elif ci_state == "incomplete" and _scheduled_gate_applies(repo):
+        # Mirror the enforcement arm: a partial rollup missing a required workflow
+        # (merge_gate.required_ci_workflows, default CI) blocks on the canonical repo.
+        print(
+            "  ↳ BLOCK — required CI workflow(s) missing from the check rollup "
+            f"({', '.join(ci_bad[:6])}); the required suite never ran."
+        )
         failures += 1
     # Order mirrors the gate: base-invariant → freshness → finding scans, so a
     # review published mid-run can't pass freshness with its P1s unscanned.

--- a/tests/test_hooks/conftest.py
+++ b/tests/test_hooks/conftest.py
@@ -10,6 +10,21 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _pin_required_ci_workflows(monkeypatch):
+    """Pin the merge gate's required-CI-workflow identity policy to the shipped
+    default ("CI") for EVERY hook test. The required set is config-driven from the
+    host's ``~/.genesis/config/genesis.yaml`` (see git_push_guard.
+    _required_ci_workflows), so without this pin any test that seeds a green CI
+    rollup would have its green-vs-incomplete verdict depend on the dev box's local
+    config and go non-deterministic — a flaky-by-environment security-gate test is
+    how a real regression gets waved through as "known flake". Config-path behavior
+    has its own tests (TestRequiredCiWorkflowsConfig), which delete this seam;
+    per-test overrides (e.g. "CodeQL") simply setenv later and win."""
+    monkeypatch.setenv("_TEST_REQUIRED_CI_WORKFLOWS", "CI")
+    yield
+
+
 def _load_settings() -> dict:
     """Load .claude/settings.json from the repo root."""
     here = Path(__file__).resolve()

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -32,7 +32,9 @@ STALE = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 def _hermetic_codex_comments(monkeypatch):
     """Default: NO Codex issue-comments, so the clean-comment freshness fallback in
     ``_check_codex_reviewed_head`` is network-free unless a test opts in. Tests override
-    with their own ``monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", …)`` (later wins)."""
+    with their own ``monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", …)`` (later wins).
+    (The required-CI-workflow seam pin these green rollup fixtures rely on is the
+    shared autouse fixture in tests/test_hooks/conftest.py.)"""
     monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")
 
 
@@ -539,7 +541,8 @@ class TestMainLevelIntegration:
         monkeypatch.setenv("_TEST_GH_BASE_REF", "main")
         monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
         monkeypatch.setenv(
-            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "t", "conclusion": "SUCCESS"}])
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([{"name": "t", "workflowName": "CI", "conclusion": "SUCCESS"}]),
         )
         # A valid OWNER scheduled-review marker AT head, so the scheduled-review merge
         # gate is satisfied and these cases keep exercising the freshness/binding wiring
@@ -648,7 +651,8 @@ class TestStaleSigilDoesNotWaiveScanners:
         monkeypatch.setenv("_TEST_GH_BASE_REF", "main")
         monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
         monkeypatch.setenv(
-            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "t", "conclusion": "SUCCESS"}])
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([{"name": "t", "workflowName": "CI", "conclusion": "SUCCESS"}]),
         )
         # Scheduled review satisfied at head → the stale-override merge reaches the
         # finding scanner this test is about (not the new scheduled gate).

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -77,6 +77,9 @@ def _pin_canonical_public_repo(monkeypatch):
     in test_git_push_guard_codex_freshness.py."""
     monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", REPO)
     monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
+    # (The required-CI-workflow identity pin — _TEST_REQUIRED_CI_WORKFLOWS=CI,
+    # matching the _ci() fixture's workflowName — is the shared autouse fixture in
+    # tests/test_hooks/conftest.py.)
     yield
 
 
@@ -124,8 +127,12 @@ def _scheduled_marker(
 
 
 def _ci(conclusion: str = "SUCCESS") -> str:
-    """_TEST_GH_CI_ROLLUP shape — a JSON array of check-runs."""
-    return json.dumps([{"name": "test", "conclusion": conclusion, "status": "COMPLETED"}])
+    """_TEST_GH_CI_ROLLUP shape — a JSON array of check-runs. Carries the canonical
+    ``workflowName`` ("CI", matching the pinned required-identity policy) so the
+    default green rollup satisfies the required-workflow check like a real CI run."""
+    return json.dumps(
+        [{"name": "test", "workflowName": "CI", "conclusion": conclusion, "status": "COMPLETED"}]
+    )
 
 
 _INLINE_P1_LINE = json.dumps(
@@ -532,6 +539,71 @@ _CASES: list[tuple[str, object, int, str]] = [
         lambda mp: (
             mp.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/some-other-public-repo"),
             _run(mp, _merge_cmd(), ci="[]"),
+        )[1],
+        0,
+        "",
+    ),
+    # ── CI "incomplete" (partial rollup) — the #1484-P2 residual, now enforced: the
+    # checks that ARE present are green, but a REQUIRED workflow (default "CI", from
+    # merge_gate.required_ci_workflows) never contributed a verdict — e.g. a lone green
+    # CodeQL after a workflow-specific trigger drop. Canonical-scoped like "absent",
+    # waivable by the same conscious `# ci-override`. ──
+    (
+        "ci_incomplete_missing_required_workflow_blocks",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            ci=json.dumps(
+                [
+                    {
+                        "name": "Analyze (python)",
+                        "workflowName": "CodeQL",
+                        "conclusion": "SUCCESS",
+                        "status": "COMPLETED",
+                    }
+                ]
+            ),
+        ),
+        2,
+        "required CI workflow",
+    ),
+    (
+        "ci_incomplete_with_ci_override_continues",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(trailer="# ci-override"),
+            ci=json.dumps(
+                [
+                    {
+                        "name": "Analyze (python)",
+                        "workflowName": "CodeQL",
+                        "conclusion": "SUCCESS",
+                        "status": "COMPLETED",
+                    }
+                ]
+            ),
+        ),
+        0,
+        "consciously accepted",
+    ),
+    (
+        "ci_incomplete_off_canonical_fails_open_allows",
+        lambda mp: (
+            mp.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/some-other-public-repo"),
+            _run(
+                mp,
+                _merge_cmd(),
+                ci=json.dumps(
+                    [
+                        {
+                            "name": "Analyze (python)",
+                            "workflowName": "CodeQL",
+                            "conclusion": "SUCCESS",
+                            "status": "COMPLETED",
+                        }
+                    ]
+                ),
+            ),
         )[1],
         0,
         "",
@@ -1059,6 +1131,34 @@ def test_check_pr_report_ci_absent_off_canonical_does_not_fail(monkeypatch, caps
     rc = _mod.check_pr_report("100", repo=REPO)
     out = capsys.readouterr().out
     assert "no ci checks" not in out.lower()
+    assert rc == 0
+
+
+def test_check_pr_report_ci_incomplete_fails_verdict_on_canonical(monkeypatch, capsys):
+    """A partial rollup missing a required workflow ("incomplete") on the canonical repo
+    is a FAILURE line and flips the report's verdict — the report must not say green
+    while the enforcement arm would block (report/gate never disagree)."""
+    _report_env(monkeypatch, scheduled=_scheduled_marker(HEAD))
+    monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("incomplete", ["CI"]))
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", REPO)
+    rc = _mod.check_pr_report("100", repo=REPO)
+    out = capsys.readouterr().out
+    ci_line = next(ln for ln in out.splitlines() if ln.startswith("ci "))
+    assert "incomplete" in ci_line
+    assert "CI" in ci_line  # the missing workflow is named via problem_checks
+    assert "required ci workflow" in out.lower()  # the BLOCK hint line
+    assert rc == 1
+
+
+def test_check_pr_report_ci_incomplete_off_canonical_does_not_fail(monkeypatch, capsys):
+    """Off the canonical repo, "incomplete" stays fail-OPEN — another repo's CI may
+    legitimately be named differently (or not exist), so the report must not count it."""
+    _report_env(monkeypatch, scheduled=_scheduled_marker(HEAD))
+    monkeypatch.setattr(_mod, "_pr_ci_status", lambda n, repo=None: ("incomplete", ["CI"]))
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/some-other-public-repo")
+    rc = _mod.check_pr_report("100", repo=REPO)
+    out = capsys.readouterr().out
+    assert "required ci workflow" not in out.lower()
     assert rc == 0
 
 

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -79,6 +79,10 @@ def guard_module():
     return mod
 
 
+# (The required-CI-workflow seam pin lives in tests/test_hooks/conftest.py —
+# one shared autouse fixture, not a per-file replica.)
+
+
 def _rc(code: int) -> subprocess.CompletedProcess:
     """A fake CompletedProcess carrying just a returncode."""
     return subprocess.CompletedProcess(args=[], returncode=code)
@@ -1622,8 +1626,8 @@ class TestPrCiStatus:
         self._set(
             monkeypatch,
             [
-                {"name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"},
-                {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "lint", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
             ],
         )
         assert guard_module._pr_ci_status("1") == ("green", [])
@@ -1662,7 +1666,7 @@ class TestPrCiStatus:
         self._set(
             monkeypatch,
             [
-                {"name": "test", "conclusion": "SUCCESS"},
+                {"name": "test", "workflowName": "CI", "conclusion": "SUCCESS"},
                 {"name": "opt", "conclusion": "SKIPPED"},
                 {"name": "info", "conclusion": "NEUTRAL"},
             ],
@@ -1699,6 +1703,202 @@ class TestPrCiStatus:
         assert guard_module._pr_ci_status("1") == ("unknown", [])
 
 
+class TestPrCiStatusRequiredWorkflows:
+    """Required-CI-workflow identity (closes the #1484 P2 partial-rollup residual):
+    a NON-empty rollup whose present checks are all green must still assert that every
+    REQUIRED workflow (rollup ``workflowName``, config-driven, default ``CI``) actually
+    contributed a verdict — otherwise a workflow-specific trigger drop (e.g. only a
+    green CodeQL, the CI suite absent) reads green and merges an untested PR. Missing
+    required workflow(s) → the new ``"incomplete"`` state, carrying the missing names."""
+
+    @staticmethod
+    def _set(monkeypatch, checks):
+        monkeypatch.setenv("_TEST_GH_CI_ROLLUP", json.dumps(checks))
+
+    def test_codeql_only_is_incomplete(self, guard_module, monkeypatch):
+        # THE Codex-P2 payload: a lone green CodeQL, the CI suite entirely absent.
+        self._set(monkeypatch, [
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("incomplete", ["CI"])
+
+    def test_red_beats_incomplete(self, guard_module, monkeypatch):
+        # A red check blocks as red even when the required workflow is ALSO missing —
+        # red carries the more actionable verdict (and blocks regardless).
+        self._set(monkeypatch, [
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "FAILURE"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("red", ["Analyze (python)"])
+
+    def test_pending_beats_incomplete(self, guard_module, monkeypatch):
+        self._set(monkeypatch, [
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "IN_PROGRESS", "conclusion": None},
+        ])
+        assert guard_module._pr_ci_status("1") == ("pending", ["Analyze (python)"])
+
+    def test_required_present_only_as_skipped_is_incomplete(self, guard_module, monkeypatch):
+        # A required suite whose every entry SKIPPED tested nothing — skipped entries
+        # do not count as "ran". (On the canonical repo ci.yml has no paths filters,
+        # so a fully-skipped suite is anomalous, and # ci-override is the escape.)
+        self._set(monkeypatch, [
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SKIPPED"},
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("incomplete", ["CI"])
+
+    def test_statuscontext_only_is_incomplete(self, guard_module, monkeypatch):
+        # Legacy StatusContexts have no workflowName and can never satisfy a required
+        # workflow identity — fail-closed on the canonical (Actions-only) repo.
+        self._set(monkeypatch, [{"context": "legacy-ci", "state": "SUCCESS"}])
+        assert guard_module._pr_ci_status("1") == ("incomplete", ["CI"])
+
+    def test_statuscontext_green_with_workflowname_does_not_vouch(
+        self, guard_module, monkeypatch
+    ):
+        # Hardening (architect NOTE): a StatusContext-shaped green (state=SUCCESS)
+        # gluing on a workflowName key must NOT satisfy the required identity — only
+        # a CheckRun-shaped pass (conclusion=SUCCESS) vouches, by construction, not
+        # merely because gh's current schema lacks the field on StatusContexts.
+        self._set(monkeypatch, [{"context": "x", "state": "SUCCESS", "workflowName": "CI"}])
+        assert guard_module._pr_ci_status("1") == ("incomplete", ["CI"])
+
+    def test_match_is_case_insensitive(self, guard_module, monkeypatch):
+        monkeypatch.setenv("_TEST_REQUIRED_CI_WORKFLOWS", "ci")
+        self._set(monkeypatch, [
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("green", [])
+
+    def test_multi_required_one_missing_names_it(self, guard_module, monkeypatch):
+        monkeypatch.setenv("_TEST_REQUIRED_CI_WORKFLOWS", "CI,CodeQL")
+        self._set(monkeypatch, [
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("incomplete", ["CodeQL"])
+
+    def test_multi_required_all_present_is_green(self, guard_module, monkeypatch):
+        monkeypatch.setenv("_TEST_REQUIRED_CI_WORKFLOWS", "CI,CodeQL")
+        self._set(monkeypatch, [
+            {"name": "test", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("green", [])
+
+    def test_blank_seam_falls_back_to_default(self, guard_module, monkeypatch):
+        # "" parses to an empty list = invalid = fail CLOSED to the default ("CI").
+        # There is deliberately NO disable value — an empty required set would turn
+        # the identity check off entirely.
+        monkeypatch.setenv("_TEST_REQUIRED_CI_WORKFLOWS", "")
+        self._set(monkeypatch, [
+            {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ])
+        assert guard_module._pr_ci_status("1") == ("incomplete", ["CI"])
+
+    def test_absent_still_wins_over_incomplete(self, guard_module, monkeypatch):
+        # An EMPTY rollup is "absent" (zero checks), never "incomplete" (partial).
+        monkeypatch.setenv("_TEST_GH_CI_ROLLUP", "[]")
+        assert guard_module._pr_ci_status("1") == ("absent", [])
+
+
+class TestRequiredCiWorkflowsConfig:
+    """_required_ci_workflows(): config-driven required set, fail-CLOSED to the
+    default ("CI") on ANY malformed/ambiguous input — mirroring
+    _required_scheduled_review_kinds. These tests exercise the real file path, so
+    they delete the seam and point HOME at a tmp dir."""
+
+    @staticmethod
+    def _with_yaml(monkeypatch, tmp_path, text: str | None):
+        monkeypatch.delenv("_TEST_REQUIRED_CI_WORKFLOWS", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        if text is not None:
+            cfg = tmp_path / ".genesis" / "config"
+            cfg.mkdir(parents=True)
+            (cfg / "genesis.yaml").write_text(text)
+
+    def test_valid_config_replaces_default(self, guard_module, monkeypatch, tmp_path):
+        self._with_yaml(monkeypatch, tmp_path, "merge_gate:\n  required_ci_workflows: [My Suite]\n")
+        assert guard_module._required_ci_workflows() == ("My Suite",)
+
+    def test_multiple_deduped_order_preserved(self, guard_module, monkeypatch, tmp_path):
+        self._with_yaml(
+            monkeypatch, tmp_path,
+            "merge_gate:\n  required_ci_workflows: [CodeQL, CI, CodeQL]\n",
+        )
+        assert guard_module._required_ci_workflows() == ("CodeQL", "CI")
+
+    def test_missing_file_falls_back_to_default(self, guard_module, monkeypatch, tmp_path):
+        self._with_yaml(monkeypatch, tmp_path, None)
+        assert guard_module._required_ci_workflows() == ("CI",)
+
+    def test_missing_key_falls_back_to_default(self, guard_module, monkeypatch, tmp_path):
+        self._with_yaml(monkeypatch, tmp_path, "merge_gate:\n  required_scheduled_reviews: [leaks]\n")
+        assert guard_module._required_ci_workflows() == ("CI",)
+
+    def test_empty_list_is_invalid_no_disable(self, guard_module, monkeypatch, tmp_path):
+        # [] would DISABLE the identity check — fail closed to the default instead.
+        self._with_yaml(monkeypatch, tmp_path, "merge_gate:\n  required_ci_workflows: []\n")
+        assert guard_module._required_ci_workflows() == ("CI",)
+
+    def test_non_list_is_invalid(self, guard_module, monkeypatch, tmp_path):
+        self._with_yaml(monkeypatch, tmp_path, "merge_gate:\n  required_ci_workflows: CI\n")
+        assert guard_module._required_ci_workflows() == ("CI",)
+
+    def test_non_string_element_is_invalid(self, guard_module, monkeypatch, tmp_path):
+        self._with_yaml(monkeypatch, tmp_path, "merge_gate:\n  required_ci_workflows: [123]\n")
+        assert guard_module._required_ci_workflows() == ("CI",)
+
+    def test_blank_element_is_invalid(self, guard_module, monkeypatch, tmp_path):
+        self._with_yaml(monkeypatch, tmp_path, 'merge_gate:\n  required_ci_workflows: [" "]\n')
+        assert guard_module._required_ci_workflows() == ("CI",)
+
+    def test_duplicate_merge_gate_key_is_invalid(self, guard_module, monkeypatch, tmp_path):
+        # yaml.safe_load keeps the LAST duplicate silently — the line-scan guard must
+        # reject the ambiguous file rather than honor whichever copy wins.
+        self._with_yaml(
+            monkeypatch, tmp_path,
+            "merge_gate:\n  required_ci_workflows: [CI]\n"
+            "merge_gate:\n  required_ci_workflows: [Decoy]\n",
+        )
+        # yaml would honor the LAST copy ([Decoy]); fail-closed rejects the whole
+        # ambiguous file and returns the DEFAULT instead — never the decoy.
+        assert guard_module._required_ci_workflows() == ("CI",)
+
+    def test_duplicate_workflows_key_is_invalid(self, guard_module, monkeypatch, tmp_path):
+        self._with_yaml(
+            monkeypatch, tmp_path,
+            "merge_gate:\n  required_ci_workflows: [CI]\n  required_ci_workflows: [Decoy]\n",
+        )
+        assert guard_module._required_ci_workflows() == ("CI",)
+
+    def test_seam_overrides_file(self, guard_module, monkeypatch, tmp_path):
+        self._with_yaml(monkeypatch, tmp_path, "merge_gate:\n  required_ci_workflows: [FileSuite]\n")
+        monkeypatch.setenv("_TEST_REQUIRED_CI_WORKFLOWS", "SeamSuite")
+        assert guard_module._required_ci_workflows() == ("SeamSuite",)
+
+    def test_discarded_declared_policy_prints_note(self, guard_module, monkeypatch, tmp_path, capsys):
+        # Architect SHOULD-FIX: free-text config can EXPAND the required set, so a
+        # silent fallback-to-default would NARROW a declared stricter policy with no
+        # signal. A present-but-invalid key must say so on stderr.
+        self._with_yaml(monkeypatch, tmp_path, "merge_gate:\n  required_ci_workflows: []\n")
+        assert guard_module._required_ci_workflows() == ("CI",)
+        assert "required_ci_workflows" in capsys.readouterr().err
+
+    def test_key_absent_is_silent(self, guard_module, monkeypatch, tmp_path, capsys):
+        # The normal install (no key configured) must NOT warn — the default is the
+        # intended policy, not a substitution.
+        self._with_yaml(monkeypatch, tmp_path, "merge_gate:\n  required_scheduled_reviews: [leaks]\n")
+        assert guard_module._required_ci_workflows() == ("CI",)
+        assert capsys.readouterr().err == ""
+
+    def test_duplicate_key_prints_note(self, guard_module, monkeypatch, tmp_path, capsys):
+        self._with_yaml(
+            monkeypatch, tmp_path,
+            "merge_gate:\n  required_ci_workflows: [CI]\n  required_ci_workflows: [Decoy]\n",
+        )
+        assert guard_module._required_ci_workflows() == ("CI",)
+        assert "required_ci_workflows" in capsys.readouterr().err
+
+
 class TestPrCiStatusCancelSibling:
     """Concurrency-cancel dedup (approach B): a CANCELLED CheckRun is dropped IFF a
     check of the SAME identity (name + workflowName) concluded SUCCESS AT OR AFTER
@@ -1715,6 +1915,9 @@ class TestPrCiStatusCancelSibling:
     def test_cancel_with_success_sibling_is_green(self, guard_module, monkeypatch):
         # The ec925917 incident: concurrency-cancelled CodeQL dups (older) + their
         # successful re-runs (newer, same name + workflowName). Must read green.
+        # (Required-identity policy pinned to the fixture's actual workflow so the
+        # incident payload stays byte-faithful — CodeQL-only was the real rollup.)
+        monkeypatch.setenv("_TEST_REQUIRED_CI_WORKFLOWS", "CodeQL")
         self._set(monkeypatch, [
             {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "CANCELLED", "completedAt": "2026-08-21T10:00:00Z"},
             {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS", "completedAt": "2026-08-21T10:05:00Z"},
@@ -1957,13 +2160,72 @@ class TestCiGateEndToEnd:
 
     def test_green_ci_allowed(self, guard_module, monkeypatch):
         monkeypatch.setenv(
-            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "SUCCESS"}])
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([{"name": "test", "workflowName": "CI", "conclusion": "SUCCESS"}]),
         )
         self._patch_merge_ok(guard_module, monkeypatch)
         monkeypatch.setattr(
             guard_module,
             "read_payload",
             lambda: self._payload("gh pr merge 5 --squash --admin"),
+        )
+        assert guard_module.main() == 0
+
+    def test_incomplete_ci_blocks_exit_2(self, guard_module, monkeypatch, capsys):
+        # The #1484-P2 payload end-to-end: a lone green CodeQL (CI suite missing)
+        # must BLOCK the merge, naming the missing required workflow. Canonical
+        # scoping engages because an unresolved merge repo fails CLOSED.
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([
+                {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ]),
+        )
+        self._patch_merge_ok(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("gh pr merge 5 --squash --admin"),
+        )
+        rc = guard_module.main()
+        err = capsys.readouterr().err
+        assert rc == 2
+        assert "required CI workflow" in err
+        assert "CI" in err  # the missing workflow is named
+
+    def test_incomplete_ci_with_override_allowed(self, guard_module, monkeypatch, capsys):
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([
+                {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ]),
+        )
+        self._patch_merge_ok(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload("gh pr merge 5 --squash --admin  # ci-override"),
+        )
+        assert guard_module.main() == 0
+        assert "consciously accepted" in capsys.readouterr().err
+
+    def test_incomplete_ci_off_canonical_fails_open(self, guard_module, monkeypatch):
+        # Off the canonical repo the identity check must NOT block — another repo's
+        # CI may legitimately be named differently (or not exist at all).
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "owner/canonical-repo")
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([
+                {"name": "Analyze (python)", "workflowName": "CodeQL", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            ]),
+        )
+        self._patch_merge_ok(guard_module, monkeypatch)
+        monkeypatch.setattr(
+            guard_module,
+            "read_payload",
+            lambda: self._payload(
+                "gh pr merge 5 --repo octo/other-repo --squash --admin"
+            ),
         )
         assert guard_module.main() == 0
 
@@ -1994,7 +2256,7 @@ class TestCiStatusUnfinishedStates:
     def test_completed_null_conclusion_not_pending(self, guard_module, monkeypatch):
         self._set(monkeypatch, [
             {"name": "test", "status": "COMPLETED", "conclusion": None},
-            {"name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "lint", "workflowName": "CI", "status": "COMPLETED", "conclusion": "SUCCESS"},
         ])
         assert guard_module._pr_ci_status("1") == ("green", [])
 
@@ -2044,7 +2306,8 @@ class TestMergeableAllowlist:
     def _patch_downstream(self, guard_module, monkeypatch):
         # Everything AFTER mergeability passes, so only mergeability decides.
         monkeypatch.setenv(
-            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "SUCCESS"}])
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([{"name": "test", "workflowName": "CI", "conclusion": "SUCCESS"}]),
         )
         for name in ("_check_pr_review_findings", "_check_inline_review_findings"):
             monkeypatch.setattr(guard_module, name, lambda n, force=False, repo=None: (False, ""))
@@ -2118,7 +2381,8 @@ class TestRepoDerivationGate:
 
     def _patch_ok(self, guard_module, monkeypatch):
         monkeypatch.setenv(
-            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "SUCCESS"}])
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([{"name": "test", "workflowName": "CI", "conclusion": "SUCCESS"}]),
         )
         monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
         for name in ("_check_pr_review_findings", "_check_inline_review_findings"):
@@ -2326,7 +2590,8 @@ class TestGateOrdering:
         calls: list[str] = []
         monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
         monkeypatch.setenv(
-            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "SUCCESS"}])
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([{"name": "test", "workflowName": "CI", "conclusion": "SUCCESS"}]),
         )
         monkeypatch.setattr(
             guard_module,
@@ -2414,7 +2679,8 @@ class TestLowBFreshnessBackstop:
         reached = {"body": False}
         monkeypatch.setattr(guard_module, "_check_mergeable", lambda n, repo=None: "MERGEABLE")
         monkeypatch.setenv(
-            "_TEST_GH_CI_ROLLUP", json.dumps([{"name": "test", "conclusion": "SUCCESS"}])
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([{"name": "test", "workflowName": "CI", "conclusion": "SUCCESS"}]),
         )
         monkeypatch.setattr(
             guard_module, "_check_base_is_default", lambda n, force=False, repo=None: (False, "")


### PR DESCRIPTION
## What

Closes the partial-rollup fail-open in the CI merge gate (`scripts/hooks/git_push_guard.py`). The `absent` state added in #1484 only catches a FULLY-empty check rollup; a PARTIAL rollup — e.g. a lone green CodeQL with the CI workflow suite entirely missing after a workflow-specific `pull_request` trigger drop — still read `green`, so an untested PR could merge (this gate is the sole CI enforcement for `--admin` merges; the gap was a verified reviewer finding on #1484).

## How

- **New closed-set state `incomplete`**: rollup non-empty, nothing red/pending, but a REQUIRED workflow (case-insensitive match on rollup `workflowName`) contributed no CheckRun-shaped passing verdict. `problem_checks` carries the missing workflow names. SKIPPED/NEUTRAL entries, COMPLETED-with-null-conclusion entries, and StatusContext-shaped greens (even ones gluing on a `workflowName` key) deliberately do NOT vouch — fail-closed by construction, not by current API output shape.
- **Config-driven required set**: `merge_gate.required_ci_workflows` in the local `genesis.yaml` (default `CI` — the canonical ci.yml workflow, which has no `paths` filters). Fail-CLOSED to the default on ANY malformed/empty value; there is no disable value — the per-merge escape stays `# ci-override`. Because free-text config can also EXPAND the required set, a present-but-discarded key prints a NOTE naming the substitution (a key-absent file — the normal install — stays silent). Duplicate-key line scan + `_TEST_REQUIRED_CI_WORKFLOWS` seam mirror the `required_scheduled_reviews` reader.
- **Enforced at BOTH consumers** exactly like `absent`: the `main()` merge arm blocks (exit 2, waivable by the existing quote-aware, segment-bound `# ci-override`) and `check_pr_report` mirrors the failure — both canonical-repo-scoped via `_scheduled_gate_applies`, so an off-canonical repo (differently-named or no CI suite) is never false-blocked.

## Verification

- Test-first: verify-RED (18 new cases failed on unchanged code for the expected reasons) → 30+ new unit/E2E/characterization/report-mirror cases → **663 targeted tests pass**, ruff clean. The required-CI seam pin is one shared autouse fixture in `tests/test_hooks/conftest.py` (no per-file replicas); green rollup fixtures gain `workflowName`.
- Live E2E: seam-free config path returns `('incomplete', ['CI'])` for the CodeQL-only payload and `('green', [])` with CI present; real `--check-pr` against a merged PR with a full rollup still reads `ci: green` (happy path unregressed), and against a conflicting PR still reads `ci: absent` + BLOCK (no misfire into `incomplete`).
- Adversarial review (sequential, fresh-context architect + security): no BLOCKER, no CRITICAL/HIGH. Both SHOULD-FIXes (discarded-policy NOTE; shared seam pin) and the StatusContext-vouching hardening are applied and test-pinned in this diff.

Docs: SKILL.md CI-gate bullet documents the `incomplete` state + config lever; merge-trap notes updated (empty/partial rollups now mechanically enforced; review-bot quota messages and inline findings are independent channels).

Follow-up: b169076085fe4d6f841498e831ec7ec1
