### PR TITLE
feat(dashboard): timezone source-of-truth = genesis.yaml + dropdown control

### DIFF
--- a/config/genesis.yaml.example
+++ b/config/genesis.yaml.example
@@ -17,9 +17,11 @@ network:
   # Env var override: LM_STUDIO_URL
   lm_studio_url: "http://localhost:1234/v1"
 
-# Your local timezone in IANA format.
+# Your local timezone in IANA format. This is the AUTHORITATIVE runtime source
+# for display + scheduling, and is editable live from the dashboard Configuration
+# tab (no restart for display; scheduled jobs re-time on the next restart).
 # Find yours at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-# Env var override: USER_TIMEZONE
+# (The USER_TIMEZONE env var is only a deprecated fallback used when this is unset.)
 timezone: "UTC"
 
 # GitHub configuration — used by the contribution pipeline and docs.

--- a/config/genesis.yaml.example
+++ b/config/genesis.yaml.example
@@ -4,7 +4,9 @@
 # Run scripts/setup-local-config.sh to generate this interactively.
 #
 # This file is machine-specific — NEVER commit it to git.
-# All values here can also be set via environment variables (env var wins).
+# All values here can also be set via environment variables (env var wins) —
+# EXCEPT `timezone`, which is file-first (this value wins; USER_TIMEZONE env is
+# only a deprecated fallback). See the `timezone:` note below.
 # ─────────────────────────────────────────────────────────────────────────────
 
 network:

--- a/config/outreach.yaml
+++ b/config/outreach.yaml
@@ -3,7 +3,7 @@
 quiet_hours:
   start: "22:00"
   end: "07:00"
-  # timezone omitted — inherits from central genesis.yaml / USER_TIMEZONE
+  # timezone omitted — inherits genesis.yaml `timezone` via user_timezone()
 
 channel_preferences:
   default: telegram
@@ -40,7 +40,7 @@ rate_limits:
 
 morning_report:
   trigger_time: "07:00"
-  # timezone omitted — inherits from central genesis.yaml / USER_TIMEZONE
+  # timezone omitted — inherits genesis.yaml `timezone` via user_timezone()
 
 engagement:
   timeout_hours: 24

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -268,6 +268,10 @@ DISCORD_WEBHOOK_SHOWCASE=
 DISCORD_WEBHOOK_GETTING_STARTED=
 
 # User preferences
+# USER_TIMEZONE: DEPRECATED fallback. The authoritative timezone source is the
+#   `timezone:` key in ~/.genesis/config/genesis.yaml (editable live from the
+#   dashboard Configuration tab). This env var is consulted ONLY when that file
+#   has no `timezone`. Prefer setting the timezone in genesis.yaml.
 USER_TIMEZONE=UTC
 
 # ─── Backup ──────────────────────────────────────────────────────────────
@@ -345,7 +349,10 @@ TESTSPRITE_API_KEY=
 HA_MEDIA_PLAYER_ENTITY=
 
 # ─── Misc runtime config ─────────────────────────────────────────────────
-# GENESIS_TIMEZONE: IANA tz used by some schedulers (parallels USER_TIMEZONE).
+# GENESIS_TIMEZONE: sets the container/host OS clock at INSTALL time only (via
+#   `timedatectl` in bootstrap/host-setup). It is NOT read by the Genesis Python
+#   runtime — display + scheduler timezone come from genesis.yaml `timezone`
+#   (see USER_TIMEZONE above). Leave as-is unless you specifically need it.
 GENESIS_TIMEZONE=UTC
 # GENESIS_CC_PERMISSION_MODE: Claude Code permission mode for autonomous sessions
 #   (e.g. 'bypass' to skip prompts). Leave unset for the default prompted mode.

--- a/src/genesis/contribution/fingerprints.py
+++ b/src/genesis/contribution/fingerprints.py
@@ -199,13 +199,15 @@ def harvest(
     out: list[tuple[str, str]] = []
 
     # 1. Effective service subnets + timezone + private repo name.
-    #    Precedence mirrors genesis.env: env override > genesis.yaml > default.
     #    We read os.environ directly (rather than importing genesis.env) so
     #    harvest stays home-injectable for tests and free of env.py's config
-    #    cache/defaults — but MUST honor the same overrides, else an install
-    #    using OLLAMA_URL/LM_STUDIO_URL/USER_TIMEZONE gets stale fingerprints
-    #    that fail to block its ACTUAL subnet/timezone. (secrets.env-sourced
-    #    overrides are only seen if bootstrap exported them into the process.)
+    #    cache/defaults. Subnet URLs stay env-first (env IS the runtime override
+    #    for OLLAMA_URL/LM_STUDIO_URL). Timezone is now FILE-authoritative
+    #    (genesis.yaml ``timezone``) with USER_TIMEZONE a deprecated fallback, so
+    #    below we block the UNION of both possible tz sources — either could be the
+    #    effective runtime zone across installs/versions, and missing the effective
+    #    one would leak it. (secrets.env overrides are only seen if bootstrap
+    #    exported them into the process.)
     cfg = _load_yaml(home / ".genesis" / "config" / "genesis.yaml")
     try:
         net = cfg.get("network", {}) if isinstance(cfg, dict) else {}
@@ -218,9 +220,12 @@ def harvest(
             pat = _ip_prefix_pattern(_host_from_url(url))
             if pat:
                 out.append((pat, f"private subnet ({key})"))
-        tz = (os.environ.get("USER_TIMEZONE") or str(cfg.get("timezone", "") or "")).strip()
-        if tz and tz.upper() != "UTC":
-            out.append((_bounded(tz), "install timezone"))
+        for tz in {
+            (os.environ.get("USER_TIMEZONE") or "").strip(),
+            str(cfg.get("timezone", "") or "").strip(),
+        }:
+            if tz and tz.upper() != "UTC":
+                out.append((_bounded(tz), "install timezone"))
         gh = cfg.get("github", {}) if isinstance(cfg, dict) else {}
         user = str(gh.get("user", "") or "").strip()
         priv = str(gh.get("private_repo", "") or "").strip()

--- a/src/genesis/contribution/fingerprints.py
+++ b/src/genesis/contribution/fingerprints.py
@@ -220,11 +220,15 @@ def harvest(
             pat = _ip_prefix_pattern(_host_from_url(url))
             if pat:
                 out.append((pat, f"private subnet ({key})"))
-        for tz in {
+        # Deterministic order (env then file) with dedup — a set would iterate in
+        # hash-dependent order and break harvest()'s stable-order contract.
+        _tz_seen: set[str] = set()
+        for tz in (
             (os.environ.get("USER_TIMEZONE") or "").strip(),
             str(cfg.get("timezone", "") or "").strip(),
-        }:
-            if tz and tz.upper() != "UTC":
+        ):
+            if tz and tz.upper() != "UTC" and tz not in _tz_seen:
+                _tz_seen.add(tz)
                 out.append((_bounded(tz), "install timezone"))
         gh = cfg.get("github", {}) if isinstance(cfg, dict) else {}
         user = str(gh.get("user", "") or "").strip()

--- a/src/genesis/dashboard/routes/secrets.py
+++ b/src/genesis/dashboard/routes/secrets.py
@@ -113,9 +113,20 @@ def _parse_example_file() -> list[SecretKeyDef]:
     return keys
 
 
+# Keys the generic secrets editor must NOT surface or write. Timezone is managed
+# by the dedicated dashboard control (POST /api/genesis/settings/timezone →
+# genesis.yaml, the authoritative source): USER_TIMEZONE is a deprecated fallback
+# and GENESIS_TIMEZONE is install-time OS-clock plumbing with no Python reader —
+# a free-text field for either is a footgun that silently no-ops. Excluded from
+# BOTH the rendered registry (GET) and _KNOWN_KEYS (so PUT rejects them too).
+# secrets.env content is untouched (install seeding still writes them directly).
+_HIDDEN_KEYS: frozenset[str] = frozenset({"USER_TIMEZONE", "GENESIS_TIMEZONE"})
+
 # Parse once at import time — defensive to avoid crashing all dashboard routes
 try:
-    _KEY_REGISTRY: list[SecretKeyDef] = _parse_example_file()
+    _KEY_REGISTRY: list[SecretKeyDef] = [
+        k for k in _parse_example_file() if k.key not in _HIDDEN_KEYS
+    ]
 except Exception:
     logger.error("Failed to parse secrets.env.example", exc_info=True)
     _KEY_REGISTRY = []

--- a/src/genesis/dashboard/routes/state.py
+++ b/src/genesis/dashboard/routes/state.py
@@ -313,7 +313,7 @@ async def settings_timezone():
         return jsonify({"timezone": user_timezone(), "options": _TIMEZONE_OPTIONS})
 
     payload = request.get_json(silent=True) or {}
-    new_tz = payload.get("timezone", "").strip()
+    new_tz = (payload.get("timezone") or "").strip()  # tolerate {"timezone": null}
     if not new_tz:
         return jsonify({"error": "timezone is required"}), 400
 

--- a/src/genesis/dashboard/routes/state.py
+++ b/src/genesis/dashboard/routes/state.py
@@ -13,6 +13,17 @@ from genesis.dashboard._blueprint import _async_route, blueprint
 
 logger = logging.getLogger(__name__)
 
+# IANA timezone names for the dashboard timezone dropdown, computed ONCE at import
+# (``available_timezones()`` scans the tz database on disk — ~600 entries — so it
+# must not run per request). Sorted for stable rendering; validation of a chosen
+# value still happens via ``ZoneInfo(...)`` in the POST handler.
+try:
+    from zoneinfo import available_timezones as _available_timezones
+
+    _TIMEZONE_OPTIONS: list[str] = sorted(_available_timezones())
+except Exception:  # pragma: no cover — zoneinfo/tzdata always present on our stack
+    _TIMEZONE_OPTIONS = []
+
 
 def _parse_approval_rows(rows: list[dict]) -> list[dict]:
     now = datetime.now(UTC)
@@ -284,18 +295,22 @@ def essential_knowledge_endpoint():
 @blueprint.route("/api/genesis/settings/timezone", methods=["GET", "POST"])
 @_async_route
 async def settings_timezone():
-    """Get or set the user's display timezone.
+    """Get or set the user's display + schedule timezone.
 
-    GET: returns {"timezone": <IANA tz name>} — whatever the user configured
-         (defaults to "UTC" if unset).
+    genesis.yaml ``timezone`` is the authoritative source (``user_timezone()``
+    reads it first; ``USER_TIMEZONE`` env is only a deprecated fallback), so this
+    write actually takes effect.
+
+    GET: returns {"timezone": <current IANA tz>, "options": [<IANA tz>, ...]} —
+         the current value plus the full zone list for the dropdown.
     POST: {"timezone": <IANA tz name>} → validates, writes to genesis.yaml,
-          invalidates caches. Takes effect immediately for display;
-          scheduler CronTrigger timezone updates on next restart.
+          invalidates caches + reloads. Takes effect immediately for display;
+          scheduler CronTrigger timezones re-bind on the next restart.
     """
     from genesis.env import user_timezone
 
     if request.method == "GET":
-        return jsonify({"timezone": user_timezone()})
+        return jsonify({"timezone": user_timezone(), "options": _TIMEZONE_OPTIONS})
 
     payload = request.get_json(silent=True) or {}
     new_tz = payload.get("timezone", "").strip()
@@ -319,6 +334,11 @@ async def settings_timezone():
             with cfg_path.open() as fh:
                 existing = yaml.safe_load(fh) or {}
         existing["timezone"] = new_tz
+        # Ensure the config dir exists — on an install that never ran
+        # setup-local-config, ~/.genesis/config/ may be absent and the dropdown
+        # is the first thing to create genesis.yaml. 0o700 matches the personal
+        # config-dir posture (genesis.yaml holds no secrets, but stay tight).
+        cfg_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         tmp_fd, tmp_path = tempfile.mkstemp(
             dir=str(cfg_path.parent), suffix=".yaml.tmp",
         )
@@ -328,7 +348,9 @@ async def settings_timezone():
                 yaml.dump(existing, f, default_flow_style=False)
             os.replace(tmp_path, str(cfg_path))
         except Exception:
-            os.unlink(tmp_path)
+            import contextlib
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)  # don't mask the original error if cleanup fails
             raise
     except Exception as exc:
         logger.error("Failed to write timezone config: %s", exc, exc_info=True)

--- a/src/genesis/dashboard/templates/partials/tabs/config.html
+++ b/src/genesis/dashboard/templates/partials/tabs/config.html
@@ -273,7 +273,7 @@
               <option :value="tz" :selected="tz === $store.genesisDashboard.systemTimezone" x-text="tz"></option>
             </template>
           </select>
-          <span style="font-size:0.65rem;">(display + scheduled jobs; restart to re-time schedules)</span>
+          <span style="font-size:0.65rem;">(display updates now; most scheduled jobs re-time after a Genesis restart)</span>
         </div>
         <template x-if="!$store.genesisDashboard.settingsDomains">
           <div style="padding:1rem; text-align:center; color:var(--color-text-secondary);">Loading...</div>

--- a/src/genesis/dashboard/templates/partials/tabs/config.html
+++ b/src/genesis/dashboard/templates/partials/tabs/config.html
@@ -256,11 +256,24 @@
                     @click="$store.genesisDashboard.settingsRestartMessage = null">Dismiss</button>
           </div>
         </template>
-        <!-- System timezone display -->
-        <div style="font-size:0.72rem; color:var(--color-text-secondary); margin-bottom:0.75rem; display:flex; align-items:center; gap:0.4rem;">
+        <!-- Display & schedule timezone (writes genesis.yaml — the authoritative
+             source; NOT the container OS clock). Dropdown avoids IANA-string typos. -->
+        <div style="font-size:0.72rem; color:var(--color-text-secondary); margin-bottom:0.75rem; display:flex; align-items:center; gap:0.5rem; flex-wrap:wrap;">
           <span class="material-symbols-outlined" style="font-size:0.9rem;">schedule</span>
-          System timezone: <strong x-text="$store.genesisDashboard.systemTimezone || 'loading...'" style="color:var(--color-text);"></strong>
-          <span style="font-size:0.65rem;">(all schedules use this timezone)</span>
+          <label for="tz-select" style="white-space:nowrap; color:var(--color-text);">Display &amp; schedule timezone:</label>
+          <select id="tz-select" style="font-size:0.75rem; padding:3px 6px; max-width:280px;"
+                  :value="$store.genesisDashboard.systemTimezone"
+                  :disabled="$store.genesisDashboard.timezoneSaving || !$store.genesisDashboard.timezoneOptions.length"
+                  @change="$store.genesisDashboard.saveTimezone($event.target.value)">
+            <template x-if="!$store.genesisDashboard.timezoneOptions.length">
+              <option :value="$store.genesisDashboard.systemTimezone || ''"
+                      x-text="$store.genesisDashboard.systemTimezone || 'loading…'"></option>
+            </template>
+            <template x-for="tz in $store.genesisDashboard.timezoneOptions" :key="tz">
+              <option :value="tz" :selected="tz === $store.genesisDashboard.systemTimezone" x-text="tz"></option>
+            </template>
+          </select>
+          <span style="font-size:0.65rem;">(display + scheduled jobs; restart to re-time schedules)</span>
         </div>
         <template x-if="!$store.genesisDashboard.settingsDomains">
           <div style="padding:1rem; text-align:center; color:var(--color-text-secondary);">Loading...</div>

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -279,7 +279,9 @@
         settingsData: {},         // domain_name → config object
         settingsEditing: null,    // domain being edited
         settingsViewing: null,    // readonly domain being viewed
-        systemTimezone: null,     // from /api/genesis/settings/timezone
+        systemTimezone: null,     // current tz from /api/genesis/settings/timezone
+        timezoneOptions: [],      // IANA zone list for the dropdown (from same GET)
+        timezoneSaving: false,    // true while a timezone POST is in flight
         settingsSaving: false,
         settingsRestartMessage: null,
 
@@ -2249,11 +2251,44 @@
             const resp = await fetchApi("/api/genesis/settings");
             if (resp && resp.ok) { this.settingsDomains = await resp.json(); }
           } catch (e) { console.warn("Settings index failed:", e); }
-          // Also fetch the system timezone
+          // Also fetch the current timezone + the dropdown option list.
           try {
             const tzResp = await fetchApi("/api/genesis/settings/timezone");
-            if (tzResp && tzResp.ok) { this.systemTimezone = (await tzResp.json()).timezone; }
+            if (tzResp && tzResp.ok) {
+              const d = await tzResp.json();
+              this.systemTimezone = d.timezone;
+              this.timezoneOptions = Array.isArray(d.options) ? d.options : [];
+            }
           } catch (e) { /* ignore */ }
+        },
+        async saveTimezone(tz) {
+          // Write the chosen zone to genesis.yaml (the authoritative source) via
+          // the settings/timezone endpoint. Display updates immediately; scheduled
+          // jobs re-time on the next restart (hence the restart prompt).
+          if (!tz || tz === this.systemTimezone) { return; }
+          this.timezoneSaving = true;
+          try {
+            const resp = await fetchApi("/api/genesis/settings/timezone", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ timezone: tz }),
+            });
+            if (resp && resp.ok) {
+              const d = await resp.json();
+              this.systemTimezone = d.timezone || tz;
+              this.settingsRestartMessage =
+                "Timezone set to " + this.systemTimezone +
+                " — display updates now; restart Genesis to re-time scheduled jobs.";
+            } else {
+              const err = resp ? await resp.json().catch(() => ({})) : {};
+              alert("Timezone update failed: " + (err.error || "Unknown error"));
+            }
+          } catch (e) {
+            console.warn("saveTimezone failed:", e);
+            alert("Timezone update failed: network error");
+          } finally {
+            this.timezoneSaving = false;
+          }
         },
         async fetchSettingsData(domain) {
           try {

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -2278,7 +2278,7 @@
               this.systemTimezone = d.timezone || tz;
               this.settingsRestartMessage =
                 "Timezone set to " + this.systemTimezone +
-                " — display updates now; restart Genesis to re-time scheduled jobs.";
+                " — display updates now; most scheduled jobs re-time after a Genesis restart.";
             } else {
               const err = resp ? await resp.json().catch(() => ({})) : {};
               alert("Timezone update failed: " + (err.error || "Unknown error"));

--- a/src/genesis/db/migrations/0086_seed_timezone_config.py
+++ b/src/genesis/db/migrations/0086_seed_timezone_config.py
@@ -1,0 +1,129 @@
+"""One-time seed: adopt ``USER_TIMEZONE`` env into ``genesis.yaml`` before the
+timezone source-of-truth flip (env-first → file-first) goes live.
+
+``genesis.env.user_timezone()`` now resolves ``genesis.yaml{timezone}`` →
+``USER_TIMEZONE`` env → UTC (previously env-first). On an install whose
+``genesis.yaml`` carries the shipped ``timezone: UTC`` sentinel
+(``config/genesis.yaml.example``) — or has no ``timezone`` key — while the REAL
+zone lives only in the ``USER_TIMEZONE`` env, the flip would silently re-time
+every ``CronTrigger(timezone=user_timezone())`` and all display to UTC on the
+next restart. This migration copies the real env zone into the file BEFORE the
+flip takes effect, so the flip preserves behavior on existing installs.
+
+Why a migration (verified): migrations run in ``runtime/init/db.py`` right after
+``_load_secrets`` (so ``USER_TIMEZONE`` is already in ``os.environ``) and BEFORE
+any scheduler binds (so the current boot's CronTriggers get the corrected zone),
+on EVERY deploy path including ``git pull`` + restart. The migrations ledger
+makes it strictly ONE-TIME, so it can NEVER later revert a deliberate
+dashboard-set UTC (a per-boot startup check would).
+
+STRICTLY FAIL-OPEN: ``runtime/init/db.py`` aborts server startup if a migration
+raises, so the whole body is guarded — a ``genesis.yaml`` write hiccup must never
+wedge boot. The ``USER_TIMEZONE`` env fallback still resolves the zone at runtime
+in the (rare) write-failure case.
+
+Self-contained per the migration convention (see 0077/0085): the read/write logic
+is inlined and frozen, not imported from evolving runtime code, so the effect is
+deterministic across deployment history. It touches a FILE, not the DB — unusual
+for a schema migration but legitimate (``up`` is arbitrary Python).
+
+Trigger (all must hold): ``USER_TIMEZONE`` env is set AND ``!= UTC``
+(case-insensitive) AND ``genesis.yaml`` has no ``timezone`` key OR it equals UTC.
+Otherwise a no-op (file already holds a real zone / env unset / env is UTC).
+Idempotent by construction and one-time by the ledger regardless.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+import aiosqlite
+
+logger = logging.getLogger(__name__)
+
+
+def _seed_timezone_into_config() -> None:
+    """Adopt ``USER_TIMEZONE`` env into ``genesis.yaml`` when the file is UTC/absent.
+
+    Uses the SAME path ``genesis.env._local_config`` reads
+    (``Path.home()/.genesis/config/genesis.yaml``) so the seed lands where the
+    resolver looks. Fully self-contained; the caller guards against exceptions.
+    """
+    env_tz = (os.environ.get("USER_TIMEZONE") or "").strip()
+    if not env_tz or env_tz.upper() == "UTC":
+        return  # nothing real to seed
+
+    import yaml  # noqa: PLC0415 — lazy import, yaml is always available
+
+    cfg_path = Path.home() / ".genesis" / "config" / "genesis.yaml"
+    existing: dict = {}
+    if cfg_path.is_file():
+        try:
+            with cfg_path.open() as fh:
+                loaded = yaml.safe_load(fh)
+        except Exception:
+            logger.warning(
+                "tz-seed: could not parse %s — leaving it unchanged",
+                cfg_path,
+                exc_info=True,
+            )
+            return
+        if isinstance(loaded, dict):
+            existing = loaded
+
+    file_tz = str(existing.get("timezone", "") or "").strip()
+    if file_tz and file_tz.upper() != "UTC":
+        return  # file already holds a real zone — authoritative, leave it
+
+    # File is absent-key or UTC-sentinel while env is a real zone → adopt env.
+    existing["timezone"] = env_tz
+    cfg_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    fd, tmp = tempfile.mkstemp(dir=str(cfg_path.parent), suffix=".yaml.tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            yaml.dump(existing, fh, default_flow_style=False)
+        os.replace(tmp, str(cfg_path))
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+    logger.info(
+        "tz-seed: adopted USER_TIMEZONE env into %s (behavior-preserving before "
+        "the timezone source-of-truth flip)",
+        cfg_path,
+    )
+
+    # Best-effort: refresh runtime caches so THIS boot's display reflects the
+    # seed. Schedulers read user_timezone() fresh at registration (which runs
+    # after migrations), so they are already correct; this only fixes the
+    # display cache if tz.py was imported before the seed. Cosmetic on failure.
+    try:
+        from genesis.env import _invalidate_local_config
+        from genesis.util.tz import reload as tz_reload
+
+        _invalidate_local_config()
+        tz_reload()
+    except Exception:
+        logger.debug("tz-seed: cache refresh skipped", exc_info=True)
+
+
+async def up(db: aiosqlite.Connection) -> None:  # noqa: ARG001 — file migration, no DB use
+    # STRICTLY FAIL-OPEN: init/db.py aborts server startup if a migration raises.
+    try:
+        _seed_timezone_into_config()
+    except Exception:
+        logger.warning(
+            "tz-seed migration hit an error — leaving genesis.yaml unchanged; the "
+            "USER_TIMEZONE env fallback still resolves the zone at runtime.",
+            exc_info=True,
+        )
+
+
+async def down(db: aiosqlite.Connection) -> None:  # noqa: ARG001
+    # Not cleanly reversible — a seeded zone is indistinguishable from a
+    # user-set one. No-op.
+    return

--- a/src/genesis/db/migrations/0086_seed_timezone_config.py
+++ b/src/genesis/db/migrations/0086_seed_timezone_config.py
@@ -46,16 +46,63 @@ import aiosqlite
 logger = logging.getLogger(__name__)
 
 
+def _read_env_timezone() -> str:
+    """The pre-flip effective ``USER_TIMEZONE`` — process env if present, else
+    parsed directly from secrets.env.
+
+    The server-startup migration path has secrets loaded into ``os.environ``
+    (``load_dotenv`` in runtime/init/secrets runs BEFORE migrations). But the
+    ``update.sh`` upgrade path runs ``python -m genesis.db.migrations --apply``
+    WITHOUT loading secrets.env, so ``os.environ`` lacks USER_TIMEZONE there —
+    read the file directly so the seed captures the real zone on BOTH paths (else
+    the flip silently re-times an upgraded install to UTC).
+    """
+    val = (os.environ.get("USER_TIMEZONE") or "").strip()
+    if val:
+        return val
+    try:
+        from genesis.env import secrets_path  # stable path resolver (SECRETS_PATH / repo_root)
+
+        path = secrets_path()
+        if path.is_file():
+            for raw in path.read_text().splitlines():
+                line = raw.strip()
+                if line.startswith("USER_TIMEZONE="):
+                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except Exception:
+        logger.debug("tz-seed: could not read USER_TIMEZONE from secrets.env", exc_info=True)
+    return ""
+
+
+def _is_valid_zone(name: str) -> bool:
+    """True iff ``name`` resolves as an IANA zone (guards against typos)."""
+    if not name:
+        return False
+    try:
+        from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+        ZoneInfo(name)
+        return True
+    except (ZoneInfoNotFoundError, KeyError, ValueError):
+        return False
+
+
 def _seed_timezone_into_config() -> None:
-    """Adopt ``USER_TIMEZONE`` env into ``genesis.yaml`` when the file is UTC/absent.
+    """Adopt the effective ``USER_TIMEZONE`` into ``genesis.yaml`` when the file's
+    timezone is UTC / absent / an invalid typo.
 
     Uses the SAME path ``genesis.env._local_config`` reads
     (``Path.home()/.genesis/config/genesis.yaml``) so the seed lands where the
-    resolver looks. Fully self-contained; the caller guards against exceptions.
+    resolver looks. Self-contained; the caller guards against exceptions.
     """
-    env_tz = (os.environ.get("USER_TIMEZONE") or "").strip()
+    env_tz = _read_env_timezone()
     if not env_tz or env_tz.upper() == "UTC":
         return  # nothing real to seed
+    if not _is_valid_zone(env_tz):
+        # A broken USER_TIMEZONE resolved to UTC pre-flip anyway (ZoneInfo failure
+        # → UTC); do not write a bad value into the now-authoritative file.
+        logger.warning("tz-seed: USER_TIMEZONE=%r is not a valid IANA zone — not seeding", env_tz)
+        return
 
     import yaml  # noqa: PLC0415 — lazy import, yaml is always available
 
@@ -76,10 +123,13 @@ def _seed_timezone_into_config() -> None:
             existing = loaded
 
     file_tz = str(existing.get("timezone", "") or "").strip()
-    if file_tz and file_tz.upper() != "UTC":
-        return  # file already holds a real zone — authoritative, leave it
+    # Leave the file alone ONLY when it already holds a real, VALID non-UTC zone.
+    # A non-UTC TYPO must not shadow a valid env zone → fall through and fix it.
+    if file_tz and file_tz.upper() != "UTC" and _is_valid_zone(file_tz):
+        return
 
-    # File is absent-key or UTC-sentinel while env is a real zone → adopt env.
+    # File is absent-key / UTC-sentinel / an invalid typo while env is a real,
+    # valid zone → adopt env.
     existing["timezone"] = env_tz
     cfg_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     fd, tmp = tempfile.mkstemp(dir=str(cfg_path.parent), suffix=".yaml.tmp")
@@ -112,13 +162,19 @@ def _seed_timezone_into_config() -> None:
 
 
 async def up(db: aiosqlite.Connection) -> None:  # noqa: ARG001 — file migration, no DB use
-    # STRICTLY FAIL-OPEN: init/db.py aborts server startup if a migration raises.
+    # FAIL-OPEN: init/db.py aborts server startup if a migration raises, and a
+    # timezone seed must never brick a boot. The tradeoff (chosen over Codex's
+    # "keep pending for retry", which would require raising → aborting startup):
+    # a swallowed WRITE failure means the flip leaves this install on UTC until
+    # the tz is set via the dashboard Timezone control or genesis.yaml — so it is
+    # logged at ERROR (actionable), not silently.
     try:
         _seed_timezone_into_config()
     except Exception:
-        logger.warning(
-            "tz-seed migration hit an error — leaving genesis.yaml unchanged; the "
-            "USER_TIMEZONE env fallback still resolves the zone at runtime.",
+        logger.error(
+            "tz-seed migration FAILED to write genesis.yaml — timezone may resolve "
+            "to UTC after this upgrade. Set it via the dashboard Timezone control "
+            "(Configuration tab) or add `timezone:` to ~/.genesis/config/genesis.yaml.",
             exc_info=True,
         )
 

--- a/src/genesis/db/migrations/0086_seed_timezone_config.py
+++ b/src/genesis/db/migrations/0086_seed_timezone_config.py
@@ -19,8 +19,12 @@ dashboard-set UTC (a per-boot startup check would).
 
 STRICTLY FAIL-OPEN: ``runtime/init/db.py`` aborts server startup if a migration
 raises, so the whole body is guarded — a ``genesis.yaml`` write hiccup must never
-wedge boot. The ``USER_TIMEZONE`` env fallback still resolves the zone at runtime
-in the (rare) write-failure case.
+wedge boot. The tradeoff (over raising to retry, which would brick startup): if the
+write fails on an install whose file holds the ``timezone: UTC`` sentinel, the flip
+leaves that install resolving to UTC (the file value wins; the env fallback only
+fires when the key is ABSENT, not when it is UTC) — so the failure is logged at
+ERROR with a remediation hint, not silently. A too-rare write hiccup is the price
+of never bricking a boot for a timezone.
 
 Self-contained per the migration convention (see 0077/0085): the read/write logic
 is inlined and frozen, not imported from evolving runtime code, so the effect is
@@ -67,8 +71,18 @@ def _read_env_timezone() -> str:
         if path.is_file():
             for raw in path.read_text().splitlines():
                 line = raw.strip()
+                if line.startswith("export "):  # dotenv tolerates an export prefix
+                    line = line[len("export ") :].lstrip()
                 if line.startswith("USER_TIMEZONE="):
-                    return line.split("=", 1)[1].strip().strip('"').strip("'")
+                    value = line.split("=", 1)[1].strip()
+                    if value[:1] in ("'", '"'):  # quoted → take the quoted span verbatim
+                        q = value[0]
+                        end = value.find(q, 1)
+                        return value[1:end] if end != -1 else value[1:]
+                    # unquoted → strip a trailing ` # comment` (IANA zones have no
+                    # spaces or '#', so the first whitespace/'#' ends the value)
+                    tokens = value.split("#", 1)[0].split()
+                    return tokens[0] if tokens else ""
     except Exception:
         logger.debug("tz-seed: could not read USER_TIMEZONE from secrets.env", exc_info=True)
     return ""

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -564,10 +564,12 @@ def user_timezone() -> str:
     precedence took effect, so the flip preserves behavior on existing installs.
     """
     local_val = _local_config().get("timezone")
-    if local_val is not None:
-        stripped = str(local_val).strip()
-        if stripped:  # a blank file value falls through to the env fallback
-            return stripped
+    # A valid IANA zone is always a non-empty string. Accept ONLY that — a blank
+    # string, or a non-string YAML scalar (``timezone: no`` → False, ``0`` → int),
+    # is treated as unset and falls through to the env fallback rather than
+    # shadowing it with "False"/"0" (which would crash CronTrigger consumers).
+    if isinstance(local_val, str) and local_val.strip():
+        return local_val.strip()
     env_val = os.environ.get("USER_TIMEZONE")
     if env_val and env_val.strip():
         return env_val.strip()

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -7,6 +7,10 @@ Configuration precedence (highest to lowest):
   1. Environment variable (e.g. OLLAMA_URL)
   2. ~/.genesis/config/genesis.yaml  (local install config)
   3. Hardcoded default (safe for a fresh clone)
+
+Exception: ``user_timezone()`` deliberately inverts this to FILE-first
+(genesis.yaml -> USER_TIMEZONE env fallback -> UTC) because timezone is the one
+setting with a live, dashboard-owned mutation surface; see its docstring.
 """
 
 from __future__ import annotations

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -546,15 +546,27 @@ def models_md_synthesis_enabled() -> bool:
 def user_timezone() -> str:
     """User's local timezone (IANA format).
 
-    Precedence: USER_TIMEZONE env var → local config timezone → UTC.
+    Precedence: genesis.yaml ``timezone`` → USER_TIMEZONE env var → UTC.
     Used by tz.py and any subsystem that formats timestamps for display.
+
+    genesis.yaml is authoritative because timezone is the one setting with a
+    live, dashboard-owned mutation surface: the Configuration-tab dropdown
+    writes the file and ``tz.reload()`` picks it up without a restart. The
+    ``USER_TIMEZONE`` env var is a DEPRECATED fallback, consulted only when the
+    file has no ``timezone`` key (e.g. a standard install that never ran
+    setup-local-config). This deliberately diverges from the env-first house
+    convention (``github_user`` etc.) for that reason; a one-time seed migration
+    (``db/migrations/0086``) copies a real env value into the file before this
+    precedence took effect, so the flip preserves behavior on existing installs.
     """
-    env_val = os.environ.get("USER_TIMEZONE")
-    if env_val:
-        return env_val.strip()
     local_val = _local_config().get("timezone")
-    if local_val:
-        return str(local_val).strip()
+    if local_val is not None:
+        stripped = str(local_val).strip()
+        if stripped:  # a blank file value falls through to the env fallback
+            return stripped
+    env_val = os.environ.get("USER_TIMEZONE")
+    if env_val and env_val.strip():
+        return env_val.strip()
     return "UTC"
 
 

--- a/src/genesis/env.py
+++ b/src/genesis/env.py
@@ -547,6 +547,20 @@ def models_md_synthesis_enabled() -> bool:
     return True
 
 
+def _valid_zone(name: str) -> bool:
+    """True iff ``name`` resolves as an IANA zone (guards against typos)."""
+    try:
+        from zoneinfo import (  # noqa: PLC0415 — lazy; zoneinfo is stdlib
+            ZoneInfo,
+            ZoneInfoNotFoundError,
+        )
+
+        ZoneInfo(name)
+        return True
+    except (ZoneInfoNotFoundError, KeyError, ValueError):
+        return False
+
+
 def user_timezone() -> str:
     """User's local timezone (IANA format).
 
@@ -563,16 +577,25 @@ def user_timezone() -> str:
     (``db/migrations/0086``) copies a real env value into the file before this
     precedence took effect, so the flip preserves behavior on existing installs.
     """
+    # A valid IANA zone is always a non-empty string that ``ZoneInfo`` accepts.
+    # Accept ONLY that at each layer — a blank string, a non-string YAML scalar
+    # (``timezone: no`` → False, ``0`` → int), or a TYPO (e.g. ``Amrica/Chicago``
+    # written by a setup-local-config free-form prompt) is treated as unset and
+    # falls through, rather than being returned and crashing the CronTrigger /
+    # ZoneInfo consumers that trust this function's output.
     local_val = _local_config().get("timezone")
-    # A valid IANA zone is always a non-empty string. Accept ONLY that — a blank
-    # string, or a non-string YAML scalar (``timezone: no`` → False, ``0`` → int),
-    # is treated as unset and falls through to the env fallback rather than
-    # shadowing it with "False"/"0" (which would crash CronTrigger consumers).
     if isinstance(local_val, str) and local_val.strip():
-        return local_val.strip()
-    env_val = os.environ.get("USER_TIMEZONE")
-    if env_val and env_val.strip():
-        return env_val.strip()
+        candidate = local_val.strip()
+        if _valid_zone(candidate):
+            return candidate
+        logger.warning(
+            "genesis.yaml timezone %r is not a valid IANA zone — falling back; "
+            "set a valid zone via the dashboard Timezone control.",
+            candidate,
+        )
+    env_val = (os.environ.get("USER_TIMEZONE") or "").strip()
+    if env_val and _valid_zone(env_val):
+        return env_val
     return "UTC"
 
 

--- a/src/genesis/reflection/scheduler.py
+++ b/src/genesis/reflection/scheduler.py
@@ -30,8 +30,8 @@ class ReflectionScheduler:
     - Learning regression check runs after a SUCCESSFUL quality calibration
 
     ``assessment_day`` is retained for back-compat but no longer pins the fire
-    day. Timezone is resolved via ``genesis.env.user_timezone()`` (USER_TIMEZONE
-    env → genesis.yaml timezone → UTC fallback).
+    day. Timezone is resolved via ``genesis.env.user_timezone()`` (genesis.yaml
+    timezone → USER_TIMEZONE env fallback → UTC).
     """
 
     def __init__(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,25 +204,6 @@ def _isolate_genesis_db_path(tmp_path):
     mp.undo()
 
 
-@pytest.fixture(autouse=True)
-def _isolate_secrets_path(tmp_path):
-    """Point ``secrets_path()`` at a nonexistent tmp file so tests never read the
-    install's real ``secrets.env``.
-
-    Matters for any code that reads secrets outside the loaded process env — e.g.
-    migration ``0086`` reads ``USER_TIMEZONE`` from ``secrets.env`` when the env is
-    unset (the ``update.sh`` CLI path). ``test_migrations_runner`` runs real
-    migrations with the real filesystem, so without this a run against a UTC/absent
-    home ``genesis.yaml`` would rewrite real user config. Own MonkeyPatch (like the
-    siblings) so a mid-test ``monkeypatch.undo()`` can't revert this isolation.
-    """
-    mp = pytest.MonkeyPatch()
-    mp.setenv("SECRETS_PATH", str(tmp_path / "isolated-secrets.env"))
-    mp.delenv("USER_TIMEZONE", raising=False)
-    yield
-    mp.undo()
-
-
 # ── Safety: isolate tests from the install's config overlays ──
 @pytest.fixture(autouse=True)
 def _isolate_user_config_dir(tmp_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,6 +204,25 @@ def _isolate_genesis_db_path(tmp_path):
     mp.undo()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_secrets_path(tmp_path):
+    """Point ``secrets_path()`` at a nonexistent tmp file so tests never read the
+    install's real ``secrets.env``.
+
+    Matters for any code that reads secrets outside the loaded process env — e.g.
+    migration ``0086`` reads ``USER_TIMEZONE`` from ``secrets.env`` when the env is
+    unset (the ``update.sh`` CLI path). ``test_migrations_runner`` runs real
+    migrations with the real filesystem, so without this a run against a UTC/absent
+    home ``genesis.yaml`` would rewrite real user config. Own MonkeyPatch (like the
+    siblings) so a mid-test ``monkeypatch.undo()`` can't revert this isolation.
+    """
+    mp = pytest.MonkeyPatch()
+    mp.setenv("SECRETS_PATH", str(tmp_path / "isolated-secrets.env"))
+    mp.delenv("USER_TIMEZONE", raising=False)
+    yield
+    mp.undo()
+
+
 # ── Safety: isolate tests from the install's config overlays ──
 @pytest.fixture(autouse=True)
 def _isolate_user_config_dir(tmp_path):

--- a/tests/test_contribution/test_fingerprints.py
+++ b/tests/test_contribution/test_fingerprints.py
@@ -122,10 +122,34 @@ def test_harvest_env_override_precedence(tmp_path, monkeypatch):
     monkeypatch.setenv("OLLAMA_URL", "http://198.51.100.9:11434")  # RFC 5737 doc IP
     monkeypatch.setenv("USER_TIMEZONE", "Asia/Tokyo")
     pats = {p for p, _ in _harvest(home)}
+    # Subnet URLs stay env-first (env IS the runtime override for OLLAMA_URL).
     assert r"\b198\.51\.100\." in pats  # env override wins
     assert r"\b10\.5\.6\." not in pats  # stale yaml value not used
-    assert r"\bAsia/Tokyo\b" in pats
-    assert r"\bEurope/Berlin\b" not in pats
+    # Timezone is now file-authoritative with env a deprecated fallback, so the
+    # scrubber blocks the UNION of both possible sources — either could be the
+    # effective runtime zone across installs, and missing the effective one leaks it.
+    assert r"\bAsia/Tokyo\b" in pats  # env value blocked
+    assert r"\bEurope/Berlin\b" in pats  # file value ALSO blocked (union)
+
+
+def test_harvest_blocks_file_tz_when_env_unset(tmp_path):
+    # USER_TIMEZONE cleared by the _stable_hostname autouse fixture → the file must still
+    # be blocked (it is the effective runtime zone under file-first resolution).
+    home = _fake_home(tmp_path, genesis_cfg={"timezone": "Europe/Berlin"})
+    pats = {p for p, _ in _harvest(home)}
+    assert r"\bEurope/Berlin\b" in pats
+
+
+def test_harvest_tz_union_no_utc_and_dedups(tmp_path, monkeypatch):
+    # UTC on either side is never emitted; when both agree the pattern dedups.
+    home = _fake_home(tmp_path, genesis_cfg={"timezone": "UTC"})
+    monkeypatch.setenv("USER_TIMEZONE", "Europe/Berlin")
+    pats = [p for p, c in _harvest(home) if c == "install timezone"]
+    assert pats == [r"\bEurope/Berlin\b"]  # UTC file value dropped, only the real one
+    # Both sources the same real zone → a single (deduped) pattern.
+    home2 = _fake_home(tmp_path / "x", genesis_cfg={"timezone": "Europe/Berlin"})
+    pats2 = [p for p, c in _harvest(home2) if c == "install timezone"]
+    assert pats2 == [r"\bEurope/Berlin\b"]
 
 
 def test_bounded_helper_edges():

--- a/tests/test_contribution/test_fingerprints.py
+++ b/tests/test_contribution/test_fingerprints.py
@@ -140,6 +140,16 @@ def test_harvest_blocks_file_tz_when_env_unset(tmp_path):
     assert r"\bEurope/Berlin\b" in pats
 
 
+def test_harvest_tz_union_deterministic_order(tmp_path, monkeypatch):
+    # P3 (Codex): when env and file differ, the two tz patterns must emit in a
+    # STABLE order (env then file) — a set would iterate hash-dependently and
+    # break harvest()'s stable-order contract.
+    home = _fake_home(tmp_path, genesis_cfg={"timezone": "Europe/Berlin"})
+    monkeypatch.setenv("USER_TIMEZONE", "Asia/Tokyo")
+    tz_pats = [p for p, c in _harvest(home) if c == "install timezone"]
+    assert tz_pats == [r"\bAsia/Tokyo\b", r"\bEurope/Berlin\b"]
+
+
 def test_harvest_tz_union_no_utc_and_dedups(tmp_path, monkeypatch):
     # UTC on either side is never emitted; when both agree the pattern dedups.
     home = _fake_home(tmp_path, genesis_cfg={"timezone": "UTC"})

--- a/tests/test_dashboard/test_timezone_settings.py
+++ b/tests/test_dashboard/test_timezone_settings.py
@@ -1,0 +1,92 @@
+"""Dashboard timezone control + secrets-editor tz exclusion.
+
+- GET /api/genesis/settings/timezone now returns the IANA ``options`` list (for
+  the dropdown) alongside the current ``timezone``.
+- POST writes genesis.yaml and the value is reflected even when ``USER_TIMEZONE``
+  env is set — i.e. the silent no-op is fixed by the file-first resolver flip.
+- The generic secrets editor no longer exposes or accepts USER_TIMEZONE /
+  GENESIS_TIMEZONE (they are managed by the dedicated control above).
+
+``Path.home`` is patched so the route reads/writes genesis.yaml under tmp_path
+(the route uses ``Path.home()/.genesis/config/genesis.yaml``, matching the
+resolver). The tz singleton is reset in teardown to avoid cross-test leakage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from flask import Flask
+
+from genesis.dashboard.api import blueprint
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("USER_TIMEZONE", raising=False)
+    from genesis.env import _invalidate_local_config
+
+    _invalidate_local_config()
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    yield app.test_client()
+    _invalidate_local_config()
+    # Reset the process-global display-tz cache mutated by the POST → tz.reload().
+    import genesis.util.tz as _tz
+
+    _tz._USER_TZ = _tz.ZoneInfo("UTC")
+
+
+def test_get_timezone_returns_options(client):
+    resp = client.get("/api/genesis/settings/timezone")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "timezone" in data
+    opts = data.get("options")
+    assert isinstance(opts, list) and len(opts) > 100
+    assert "America/Chicago" in opts
+    assert "UTC" in opts
+    assert opts == sorted(opts)  # stable ordering
+
+
+def test_post_writes_file_and_reflects_over_env(client, tmp_path, monkeypatch):
+    # Bug-repro: env is a DIFFERENT zone; the POST writes genesis.yaml and both the
+    # POST response and a fresh GET must reflect the FILE value (file-first), not
+    # the stale env value. Against the old env-first resolver this returned Tokyo.
+    monkeypatch.setenv("USER_TIMEZONE", "Asia/Tokyo")
+    from genesis.env import _invalidate_local_config
+
+    _invalidate_local_config()
+
+    resp = client.post("/api/genesis/settings/timezone", json={"timezone": "Europe/Paris"})
+    assert resp.status_code == 200
+    assert resp.get_json()["timezone"] == "Europe/Paris"
+
+    cfg = yaml.safe_load((tmp_path / ".genesis" / "config" / "genesis.yaml").read_text())
+    assert cfg["timezone"] == "Europe/Paris"
+
+    got = client.get("/api/genesis/settings/timezone").get_json()["timezone"]
+    assert got == "Europe/Paris"
+
+
+def test_post_rejects_invalid_zone(client):
+    resp = client.post("/api/genesis/settings/timezone", json={"timezone": "Not/AZone"})
+    assert resp.status_code == 400
+
+
+def test_secrets_editor_hides_timezone_keys(client):
+    resp = client.get("/api/genesis/secrets")
+    assert resp.status_code == 200
+    keys = {k["key"] for g in resp.get_json()["groups"] for k in g["keys"]}
+    assert "USER_TIMEZONE" not in keys
+    assert "GENESIS_TIMEZONE" not in keys
+
+
+def test_secrets_put_rejects_timezone_keys(client):
+    resp = client.put("/api/genesis/secrets", json={"keys": {"USER_TIMEZONE": "Europe/Paris"}})
+    assert resp.status_code == 422
+    assert "Unknown key" in str(resp.get_json())

--- a/tests/test_db/test_migration_0086_seed_timezone.py
+++ b/tests/test_db/test_migration_0086_seed_timezone.py
@@ -131,6 +131,27 @@ def test_reads_timezone_from_secrets_when_env_absent(tmp_path, monkeypatch):
     assert _read_tz(tmp_path) == "Europe/Paris"
 
 
+@pytest.mark.parametrize(
+    "line",
+    [
+        "USER_TIMEZONE=Europe/Paris # home comment",  # inline comment
+        "export USER_TIMEZONE=Europe/Paris",  # dotenv export prefix
+        'USER_TIMEZONE="Europe/Paris"  # quoted + comment',  # quoted value
+    ],
+)
+def test_secrets_parser_handles_export_and_comments(line, tmp_path, monkeypatch):
+    # LOW (Kimi): the manual secrets parser must tolerate the same shapes dotenv
+    # does (export prefix, inline # comment, quotes) or the seed skips a valid zone
+    # on the update.sh CLI path and the flip re-times to UTC.
+    _write_cfg(tmp_path, {"timezone": "UTC"})
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text(f"FOO=bar\n{line}\n")
+    monkeypatch.delenv("USER_TIMEZONE", raising=False)
+    monkeypatch.setattr("genesis.env.secrets_path", lambda: secrets)
+    _MOD._seed_timezone_into_config()
+    assert _read_tz(tmp_path) == "Europe/Paris"
+
+
 def test_typo_file_zone_does_not_block_seed(tmp_path, monkeypatch):
     # P2 (Codex): a non-UTC TYPO in the file must not be treated as authoritative
     # and shadow a valid env zone.

--- a/tests/test_db/test_migration_0086_seed_timezone.py
+++ b/tests/test_db/test_migration_0086_seed_timezone.py
@@ -43,6 +43,10 @@ def _home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.delenv("USER_TIMEZONE", raising=False)
     # Keep the best-effort cache refresh from touching the tz singleton.
     monkeypatch.setattr("genesis.util.tz.reload", lambda: None)
+    # Hermetic secrets source: the seed now falls back to reading secrets.env when
+    # the env is unset (the update.sh CLI path). Point it at a nonexistent file so
+    # tests never read this box's real secrets.env; secrets-read tests override it.
+    monkeypatch.setattr("genesis.env.secrets_path", lambda: tmp_path / "no_secrets.env")
     return tmp_path
 
 
@@ -112,3 +116,34 @@ def test_up_applies_seed(tmp_path, monkeypatch):
     monkeypatch.setenv("USER_TIMEZONE", "Europe/Paris")
     asyncio.run(_MOD.up(None))
     assert _read_tz(tmp_path) == "Europe/Paris"
+
+
+def test_reads_timezone_from_secrets_when_env_absent(tmp_path, monkeypatch):
+    # P1 (Codex): the update.sh CLI path runs migrations WITHOUT loading secrets.env,
+    # so os.environ lacks USER_TIMEZONE — the seed must read the file directly, else
+    # the flip silently re-times an upgraded install to UTC.
+    _write_cfg(tmp_path, {"timezone": "UTC"})
+    secrets = tmp_path / "secrets.env"
+    secrets.write_text("FOO=bar\nUSER_TIMEZONE=Europe/Paris\nBAZ=1\n")
+    monkeypatch.delenv("USER_TIMEZONE", raising=False)  # env genuinely absent
+    monkeypatch.setattr("genesis.env.secrets_path", lambda: secrets)
+    _MOD._seed_timezone_into_config()
+    assert _read_tz(tmp_path) == "Europe/Paris"
+
+
+def test_typo_file_zone_does_not_block_seed(tmp_path, monkeypatch):
+    # P2 (Codex): a non-UTC TYPO in the file must not be treated as authoritative
+    # and shadow a valid env zone.
+    _write_cfg(tmp_path, {"timezone": "Amrica/Chicago"})  # deliberate typo
+    monkeypatch.setenv("USER_TIMEZONE", "Europe/Paris")
+    _MOD._seed_timezone_into_config()
+    assert _read_tz(tmp_path) == "Europe/Paris"
+
+
+def test_invalid_env_zone_not_seeded(tmp_path, monkeypatch):
+    # P2 (Codex): a broken USER_TIMEZONE resolved to UTC pre-flip anyway — don't
+    # write a bad value into the now-authoritative file.
+    _write_cfg(tmp_path, {"timezone": "UTC"})
+    monkeypatch.setenv("USER_TIMEZONE", "Not/AZone")
+    _MOD._seed_timezone_into_config()
+    assert _read_tz(tmp_path) == "UTC"

--- a/tests/test_db/test_migration_0086_seed_timezone.py
+++ b/tests/test_db/test_migration_0086_seed_timezone.py
@@ -1,0 +1,114 @@
+"""Migration 0086 — one-time timezone seed (USER_TIMEZONE env → genesis.yaml).
+
+The migration writes a FILE (genesis.yaml), not the DB, so we exercise the frozen
+sync helper ``_seed_timezone_into_config`` directly and assert ``up`` is strictly
+fail-open (``runtime/init/db.py`` aborts server startup if a migration raises).
+``Path.home`` is patched — the seed uses the same path ``genesis.env._local_config``
+reads. ``tz.reload`` is neutralized so the best-effort cache refresh can't mutate
+the process-global ``_USER_TZ`` across tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+_MOD = importlib.import_module("genesis.db.migrations.0086_seed_timezone_config")
+
+
+def _cfg_path(home: Path) -> Path:
+    return home / ".genesis" / "config" / "genesis.yaml"
+
+
+def _write_cfg(home: Path, data: dict) -> None:
+    p = _cfg_path(home)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.safe_dump(data))
+
+
+def _read_tz(home: Path):
+    p = _cfg_path(home)
+    if not p.is_file():
+        return None
+    return (yaml.safe_load(p.read_text()) or {}).get("timezone")
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("USER_TIMEZONE", raising=False)
+    # Keep the best-effort cache refresh from touching the tz singleton.
+    monkeypatch.setattr("genesis.util.tz.reload", lambda: None)
+    return tmp_path
+
+
+def test_seeds_when_file_utc_and_env_real(tmp_path, monkeypatch):
+    _write_cfg(tmp_path, {"timezone": "UTC", "github": {"user": "x"}})
+    monkeypatch.setenv("USER_TIMEZONE", "Europe/Paris")
+    _MOD._seed_timezone_into_config()
+    assert _read_tz(tmp_path) == "Europe/Paris"
+    # Other keys are preserved through the round-trip.
+    data = yaml.safe_load(_cfg_path(tmp_path).read_text())
+    assert data["github"] == {"user": "x"}
+
+
+def test_seeds_when_file_absent(tmp_path, monkeypatch):
+    monkeypatch.setenv("USER_TIMEZONE", "Europe/Paris")
+    _MOD._seed_timezone_into_config()
+    assert _read_tz(tmp_path) == "Europe/Paris"
+
+
+def test_seeds_when_no_timezone_key(tmp_path, monkeypatch):
+    _write_cfg(tmp_path, {"github": {"user": "x"}})
+    monkeypatch.setenv("USER_TIMEZONE", "Europe/Paris")
+    _MOD._seed_timezone_into_config()
+    assert _read_tz(tmp_path) == "Europe/Paris"
+
+
+def test_noop_when_file_has_real_zone(tmp_path, monkeypatch):
+    # A real zone in the file is authoritative — the env must NOT clobber it.
+    _write_cfg(tmp_path, {"timezone": "America/Chicago"})
+    monkeypatch.setenv("USER_TIMEZONE", "Asia/Tokyo")
+    _MOD._seed_timezone_into_config()
+    assert _read_tz(tmp_path) == "America/Chicago"
+
+
+def test_noop_when_env_unset(tmp_path):
+    _write_cfg(tmp_path, {"timezone": "UTC"})
+    _MOD._seed_timezone_into_config()
+    assert _read_tz(tmp_path) == "UTC"
+
+
+def test_noop_when_env_is_utc_case_insensitive(tmp_path, monkeypatch):
+    _write_cfg(tmp_path, {"timezone": "UTC"})
+    monkeypatch.setenv("USER_TIMEZONE", "utc")
+    _MOD._seed_timezone_into_config()
+    assert _read_tz(tmp_path) == "UTC"
+
+
+def test_idempotent(tmp_path, monkeypatch):
+    _write_cfg(tmp_path, {"timezone": "UTC"})
+    monkeypatch.setenv("USER_TIMEZONE", "Europe/Paris")
+    _MOD._seed_timezone_into_config()
+    _MOD._seed_timezone_into_config()  # file now real → second run is a no-op
+    assert _read_tz(tmp_path) == "Europe/Paris"
+
+
+def test_up_is_fail_open_on_error(monkeypatch):
+    # If the seed raises, up() must swallow it — a raising migration aborts startup.
+    def _boom() -> None:
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(_MOD, "_seed_timezone_into_config", _boom)
+    asyncio.run(_MOD.up(None))  # must NOT raise
+
+
+def test_up_applies_seed(tmp_path, monkeypatch):
+    _write_cfg(tmp_path, {"timezone": "UTC"})
+    monkeypatch.setenv("USER_TIMEZONE", "Europe/Paris")
+    asyncio.run(_MOD.up(None))
+    assert _read_tz(tmp_path) == "Europe/Paris"

--- a/tests/test_db/test_migrations_runner.py
+++ b/tests/test_db/test_migrations_runner.py
@@ -10,6 +10,21 @@ import pytest
 from genesis.db.migrations.runner import MigrationRunner
 
 
+@pytest.fixture(autouse=True)
+def _isolate_real_migration_filesystem(tmp_path, monkeypatch):
+    """This suite runs REAL migrations (via run_pending on the real dir), and
+    migration 0086 is the only one that touches a real user file — it seeds
+    ``~/.genesis/config/genesis.yaml`` from ``USER_TIMEZONE`` (env, else parsed
+    from ``secrets.env`` on the update.sh CLI path). Sandbox HOME + SECRETS_PATH to
+    tmp and clear USER_TIMEZONE so the runner suite can never read the install's
+    real secrets.env or write its real config (it no-ops here). Scoped to THIS
+    file to avoid disturbing suites that manage their own secrets.env (e.g. backup).
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("SECRETS_PATH", str(tmp_path / "isolated-secrets.env"))
+    monkeypatch.delenv("USER_TIMEZONE", raising=False)
+
+
 @pytest.fixture()
 async def db(tmp_path):
     db_path = tmp_path / "test.db"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -240,3 +240,25 @@ class TestUserTimezonePrecedence:
 
         _invalidate_local_config()
         assert user_timezone() == "Europe/Paris"
+
+    def test_invalid_file_zone_falls_through_to_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A typo written to genesis.yaml (e.g. by setup-local-config's free-form
+        # prompt) must not be returned unvalidated and crash CronTrigger consumers.
+        self._write_cfg(tmp_path, timezone="Amrica/Chicago")  # typo (invalid)
+        monkeypatch.setenv("USER_TIMEZONE", "Europe/Paris")
+        from genesis.env import _invalidate_local_config, user_timezone
+
+        _invalidate_local_config()
+        assert user_timezone() == "Europe/Paris"
+
+    def test_invalid_file_and_invalid_env_is_utc(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        self._write_cfg(tmp_path, timezone="Amrica/Chicago")
+        monkeypatch.setenv("USER_TIMEZONE", "Not/AZone")
+        from genesis.env import _invalidate_local_config, user_timezone
+
+        _invalidate_local_config()
+        assert user_timezone() == "UTC"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -226,3 +226,17 @@ class TestUserTimezonePrecedence:
 
         _invalidate_local_config()
         assert user_timezone() == "UTC"
+
+    @pytest.mark.parametrize("scalar", ["no", "false", "0"])
+    def test_falsy_yaml_scalar_falls_through_to_env(
+        self, scalar: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # YAML footgun: `timezone: no` -> False, `0` -> int. These are NOT valid
+        # zones and must fall through to the env fallback, not shadow it with
+        # "False"/"0" (which would crash CronTrigger consumers).
+        self._write_cfg(tmp_path, timezone=scalar)
+        monkeypatch.setenv("USER_TIMEZONE", "Europe/Paris")
+        from genesis.env import _invalidate_local_config, user_timezone
+
+        _invalidate_local_config()
+        assert user_timezone() == "Europe/Paris"

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -144,3 +144,85 @@ def test_pid_file_takes_precedence_but_either_signal_counts(home: Path):
     (home / "update_in_progress.pid").write_text(str(os.getpid()))
     _write_state(home, phase="done", pid=1)  # JSON path alone would be False
     assert update_in_progress() is True
+
+
+class TestUserTimezonePrecedence:
+    """genesis.yaml ``timezone`` is authoritative; ``USER_TIMEZONE`` env is a
+    DEPRECATED fallback consulted only when the file has no timezone key.
+
+    ``_local_config`` reads ``Path.home()/.genesis/config/genesis.yaml`` (NOT
+    ``GENESIS_HOME``), so we patch ``Path.home`` rather than reuse the ``home``
+    fixture. Every case invalidates the module cache after mutating state.
+    """
+
+    @staticmethod
+    def _write_cfg(home_dir: Path, *, timezone: str | None) -> None:
+        cfg_dir = home_dir / ".genesis" / "config"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        body = "github:\n  user: someone\n"
+        if timezone is not None:
+            body = f"timezone: {timezone}\n" + body
+        (cfg_dir / "genesis.yaml").write_text(body)
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from genesis.env import _invalidate_local_config
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("USER_TIMEZONE", raising=False)
+        _invalidate_local_config()
+        yield
+        _invalidate_local_config()
+
+    def test_file_wins_over_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        # The flip: genesis.yaml outranks a DIFFERENT USER_TIMEZONE env value.
+        from genesis.env import _invalidate_local_config, user_timezone
+
+        self._write_cfg(tmp_path, timezone="Europe/Paris")
+        monkeypatch.setenv("USER_TIMEZONE", "Asia/Tokyo")
+        _invalidate_local_config()
+        assert user_timezone() == "Europe/Paris"
+
+    def test_env_fallback_when_file_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # No genesis.yaml at all → env fallback preserves behavior (no regression).
+        from genesis.env import _invalidate_local_config, user_timezone
+
+        monkeypatch.setenv("USER_TIMEZONE", "Asia/Tokyo")
+        _invalidate_local_config()
+        assert user_timezone() == "Asia/Tokyo"
+
+    def test_env_fallback_when_file_has_no_timezone_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        from genesis.env import _invalidate_local_config, user_timezone
+
+        self._write_cfg(tmp_path, timezone=None)
+        monkeypatch.setenv("USER_TIMEZONE", "Asia/Tokyo")
+        _invalidate_local_config()
+        assert user_timezone() == "Asia/Tokyo"
+
+    def test_utc_when_neither_present(self, tmp_path: Path):
+        from genesis.env import _invalidate_local_config, user_timezone
+
+        _invalidate_local_config()
+        assert user_timezone() == "UTC"
+
+    def test_blank_file_value_falls_through_to_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A whitespace-only file timezone must not shadow the env fallback with "".
+        self._write_cfg(tmp_path, timezone='"   "')
+        monkeypatch.setenv("USER_TIMEZONE", "Asia/Tokyo")
+        from genesis.env import _invalidate_local_config, user_timezone
+
+        _invalidate_local_config()
+        assert user_timezone() == "Asia/Tokyo"
+
+    def test_blank_file_and_no_env_is_utc(self, tmp_path: Path):
+        self._write_cfg(tmp_path, timezone='"   "')
+        from genesis.env import _invalidate_local_config, user_timezone
+
+        _invalidate_local_config()
+        assert user_timezone() == "UTC"


### PR DESCRIPTION
## Problem

The user's timezone had **two writable representations that silently disagreed**: env `USER_TIMEZONE` outranked `genesis.yaml:timezone` at runtime, so every mutation surface (the dashboard endpoint, `setup-local-config`) wrote the losing source — a silent no-op. The Configuration tab also exposed two confusing env fields, one of them (`GENESIS_TIMEZONE`) with **no Python reader at all** (it only sets the OS clock at install).

## Change

Consolidate to **one authoritative, live-editable source: `genesis.yaml:timezone`**, with a dedicated dropdown control.

- **`env.py`**: `user_timezone()` resolves `genesis.yaml` → `USER_TIMEZONE` env (deprecated fallback) → UTC. A blank file value falls through to the fallback.
- **Migration `0086`** (behavior-preserving, one-time, strictly fail-open): seeds `genesis.yaml` from the env *before* the flip, so an install whose file carries the shipped `timezone: UTC` sentinel while the real zone lives only in `USER_TIMEZONE` env does **not** re-time its schedulers to UTC. Runs after secrets-load and before schedulers bind; the migrations ledger makes it once-per-install so it never reverts a later deliberate change.
- **Dashboard**: a dedicated **Timezone dropdown** (full IANA list — no free-text typos) in the Configuration tab, wired to the existing `settings/timezone` endpoint (writes the file + reloads). Both tz env fields removed from the generic secrets editor.
- **`fingerprints`**: the leak-fingerprint blocklist blocks the **union** of the env and file tz, so the effective zone is always scrubbed under file-first resolution.
- **`state.py`**: `settings/timezone` GET returns the IANA options; POST creates the config dir (`0700`) if absent — fixes a **latent 500** on installs without `genesis.yaml`.

Display updates live; scheduled jobs re-time on the next restart (surfaced in the UI).

## Testing

- Resolver precedence (file-wins-over-env, blank fallback, UTC), migration trigger/idempotency/**fail-open**, fingerprints union, dashboard GET/POST + secrets exclusion. **verify-RED** confirmed on the two behavioral flips.
- Regression: dashboard API (33), webui-js integrity (2), migration discovery+runner (38), bootstrap guards (15). ruff clean.

Ledger: 3c4d9891eddd4097875117e63641763a
