### PR TITLE
feat(ego): dispatch follow-through — force outcome review via ego_intentions

### DIFF
--- a/src/genesis/db/crud/ego_intentions.py
+++ b/src/genesis/db/crud/ego_intentions.py
@@ -26,24 +26,37 @@ async def create(
     reasoning: str = "",
     priority: str = "normal",
     max_cycles: int = 20,
+    origin: str = "ego",
+    proposal_id: str | None = None,
 ) -> str | None:
-    """Create a new intention. Returns id, or None if cap reached."""
-    count = await count_active(db, ego_source)
-    if count >= MAX_ACTIVE_PER_SOURCE:
-        logger.warning(
-            "Intention cap reached for %s (%d/%d) — rejecting",
-            ego_source, count, MAX_ACTIVE_PER_SOURCE,
-        )
-        return None
+    """Create a new intention. Returns id, or None if cap reached.
+
+    ``origin='ego'`` (LLM-created) rows count against MAX_ACTIVE_PER_SOURCE;
+    ``origin='system'`` rows (mechanical dispatch follow-through) bypass the
+    cap — it exists to stop the LLM hoarding slots, not to drop follow-through.
+    ``proposal_id`` at creation is the system row's source dispatch proposal
+    (dedup key); ``fire()`` later overwrites it with the fired proposal.
+    """
+    if origin not in ("ego", "system"):
+        origin = "ego"
+    if origin == "ego":
+        count = await count_active(db, ego_source, origin="ego")
+        if count >= MAX_ACTIVE_PER_SOURCE:
+            logger.warning(
+                "Intention cap reached for %s (%d/%d) — rejecting",
+                ego_source, count, MAX_ACTIVE_PER_SOURCE,
+            )
+            return None
 
     intention_id = uuid.uuid4().hex[:16]
     await db.execute(
         """INSERT INTO ego_intentions
            (id, content, trigger_condition, ego_source, status,
-            created_at, cycle_count, max_cycles, reasoning, priority)
-           VALUES (?, ?, ?, ?, 'active', ?, 0, ?, ?, ?)""",
+            created_at, cycle_count, max_cycles, reasoning, priority,
+            origin, proposal_id)
+           VALUES (?, ?, ?, ?, 'active', ?, 0, ?, ?, ?, ?, ?)""",
         (intention_id, content, trigger_condition, ego_source,
-         _now_iso(), max_cycles, reasoning, priority),
+         _now_iso(), max_cycles, reasoning, priority, origin, proposal_id),
     )
     # Caller should commit (batch with other operations).
     return intention_id
@@ -66,15 +79,42 @@ async def list_active(
 async def count_active(
     db: aiosqlite.Connection,
     ego_source: str,
+    *,
+    origin: str | None = None,
 ) -> int:
-    """Count active intentions for an ego source."""
-    cursor = await db.execute(
-        "SELECT COUNT(*) FROM ego_intentions "
-        "WHERE ego_source = ? AND status = 'active'",
-        (ego_source,),
-    )
+    """Count active intentions for an ego source.
+
+    ``origin`` filters to one origin class ('ego' | 'system'); None counts all.
+    """
+    if origin:
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM ego_intentions "
+            "WHERE ego_source = ? AND status = 'active' AND origin = ?",
+            (ego_source, origin),
+        )
+    else:
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM ego_intentions "
+            "WHERE ego_source = ? AND status = 'active'",
+            (ego_source,),
+        )
     row = await cursor.fetchone()
     return row[0] if row else 0
+
+
+async def has_active_for_proposal(
+    db: aiosqlite.Connection,
+    ego_source: str,
+    proposal_id: str,
+) -> bool:
+    """True if an ACTIVE intention already references this proposal (dedup)."""
+    cursor = await db.execute(
+        "SELECT 1 FROM ego_intentions "
+        "WHERE ego_source = ? AND status = 'active' AND proposal_id = ? "
+        "LIMIT 1",
+        (ego_source, proposal_id),
+    )
+    return await cursor.fetchone() is not None
 
 
 async def increment_cycle_count(
@@ -120,18 +160,22 @@ async def fire(
     """Mark an intention as fired. Returns True if updated.
 
     Caller should commit. If ego_source is provided, enforces
-    cross-ego isolation.
+    cross-ego isolation. COALESCE keeps a system row's creation-time
+    provenance (source dispatch proposal) when fired without a new
+    proposal_id.
     """
     if ego_source:
         cursor = await db.execute(
             "UPDATE ego_intentions SET status = 'fired', fired_at = ?, "
-            "proposal_id = ? WHERE id = ? AND status = 'active' AND ego_source = ?",
+            "proposal_id = COALESCE(?, proposal_id) "
+            "WHERE id = ? AND status = 'active' AND ego_source = ?",
             (_now_iso(), proposal_id, intention_id, ego_source),
         )
     else:
         cursor = await db.execute(
             "UPDATE ego_intentions SET status = 'fired', fired_at = ?, "
-            "proposal_id = ? WHERE id = ? AND status = 'active'",
+            "proposal_id = COALESCE(?, proposal_id) "
+            "WHERE id = ? AND status = 'active'",
             (_now_iso(), proposal_id, intention_id),
         )
     return cursor.rowcount > 0
@@ -187,6 +231,32 @@ async def renew(
             (intention_id,),
         )
     return cursor.rowcount > 0
+
+
+async def increment_unreviewed(
+    db: aiosqlite.Connection,
+    ego_source: str,
+    reviewed_ids: list[str],
+) -> int:
+    """Implicit-keep: bump cycle_count on active rows NOT in reviewed_ids.
+
+    Makes ``max_cycles`` a MECHANICAL TTL — a row the ego's review output
+    omits (or a cycle whose output drops the intentions block entirely)
+    still ages, so ``expire_overdue`` can reap it even under LLM
+    non-compliance. Returns rows bumped. Caller should commit.
+    """
+    ids = [i for i in reviewed_ids if i]
+    query = (
+        "UPDATE ego_intentions SET cycle_count = cycle_count + 1 "
+        "WHERE ego_source = ? AND status = 'active'"
+    )
+    params: list[str] = [ego_source]
+    if ids:
+        placeholders = ",".join("?" * len(ids))
+        query += f" AND id NOT IN ({placeholders})"
+        params.extend(ids)
+    cursor = await db.execute(query, params)
+    return cursor.rowcount
 
 
 async def expire_overdue(

--- a/src/genesis/db/migrations/0086_ego_intentions_origin.py
+++ b/src/genesis/db/migrations/0086_ego_intentions_origin.py
@@ -1,0 +1,46 @@
+"""Add ``origin`` to ego_intentions — dispatch follow-through provenance.
+
+B2b (dispatch follow-through): every terminal ego dispatch now creates a
+system-origin intention forcing the owning ego to review the outcome on its
+next cycle. The new column records who created a row:
+
+  - ``origin`` — 'ego' (LLM-created via the intentions output channel; counts
+    against ``MAX_ACTIVE_PER_SOURCE``) or 'system' (mechanical follow-through
+    created by the dispatch on_end hook; bypasses the cap so follow-through is
+    never silently dropped when the board is full). Existing rows are all
+    LLM-created and backfill to 'ego' via the DEFAULT.
+
+Additive + idempotent. The ALTER is PRAGMA/duplicate-guarded. Mirrored in
+``db/schema/_tables.py`` (CREATE carries the column) and
+``_migrate_add_columns`` (the create_all_tables base path), per
+schema_both_build_paths. The runner owns the transaction — no commit here.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='ego_intentions'"
+    )
+    if not await cursor.fetchone():
+        return  # fresh DB — create_all_tables already carries the column
+
+    cursor = await db.execute("PRAGMA table_info(ego_intentions)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "origin" not in cols:
+        await db.execute("ALTER TABLE ego_intentions ADD COLUMN origin TEXT NOT NULL DEFAULT 'ego'")
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='ego_intentions'"
+    )
+    if not await cursor.fetchone():
+        return
+    cursor = await db.execute("PRAGMA table_info(ego_intentions)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "origin" in cols:
+        await db.execute("ALTER TABLE ego_intentions DROP COLUMN origin")

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -215,6 +215,13 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
             "ON repo_pulse_annotations(tier, target_kind, item_id, pr_number)"
         )
 
+    # B2b dispatch follow-through: who created an intention — 'ego' (LLM,
+    # counts against MAX_ACTIVE_PER_SOURCE) or 'system' (mechanical dispatch
+    # follow-through, bypasses the cap). Mirrored in migration 0086.
+    await _try_alter(db,
+        "ALTER TABLE ego_intentions ADD COLUMN origin TEXT NOT NULL DEFAULT 'ego'",
+        "ego_intentions.origin")
+
     # Phase 9: thread_id on cc_sessions (for forum topic multi-session)
     await _try_alter(db,
         "ALTER TABLE cc_sessions ADD COLUMN thread_id TEXT",

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1138,12 +1138,15 @@ TABLES = {
                 CHECK (status IN ('active', 'fired', 'expired', 'withdrawn')),
             created_at        TEXT NOT NULL,
             fired_at          TEXT,
-            proposal_id       TEXT,                   -- FK to ego_proposals.id (set on fire)
+            proposal_id       TEXT,                   -- FK to ego_proposals.id (set on fire;
+                                                      -- system rows: source dispatch proposal, set at creation)
             cycle_count       INTEGER NOT NULL DEFAULT 0,
             max_cycles        INTEGER NOT NULL DEFAULT 20,
             reasoning         TEXT,
             priority          TEXT NOT NULL DEFAULT 'normal'
-                CHECK (priority IN ('low', 'normal', 'high'))
+                CHECK (priority IN ('low', 'normal', 'high')),
+            origin            TEXT NOT NULL DEFAULT 'ego'  -- 'ego' (LLM-created, capped) |
+                                                          -- 'system' (dispatch follow-through, uncapped)
         )
     """,
     # ── Intervention Journal ────────────────────────────────────────────────

--- a/src/genesis/ego/dispatch_followthrough.py
+++ b/src/genesis/ego/dispatch_followthrough.py
@@ -35,13 +35,28 @@ async def record_dispatch_followthrough(
     status: str,
     outcome: str = "",
     failed: bool = False,
+    parked: bool = False,
 ) -> str | None:
     """Create a follow-through intention for a terminal dispatch.
 
-    Returns the intention id, or None when skipped (unknown proposal, or an
-    active follow-through for this proposal already exists — dedup so a
-    re-dispatched proposal never piles rows). Caller commits.
+    Returns the intention id, or None when skipped: a rate/quota-PARKED
+    dispatch (not terminal — the resume fires the real follow-through), an
+    unknown proposal, or an active follow-through for this proposal already
+    existing (dedup so a re-dispatched proposal never piles rows). Caller commits.
     """
+    if parked:
+        # A rate/quota-parked dispatch is NOT terminal — creating a
+        # follow-through now would post a premature "failed" review. KNOWN GAP
+        # (follow-up 837f8b63): the resume does NOT currently re-fire it — the
+        # resume rewrites caller_context to `rate_limit_resume:<park_id>`,
+        # severing the `ego_proposal:` linkage the on_end hook gates on — so the
+        # parked class is uncovered until that reconnection lands.
+        # behavioral-lint: ignore no-hide-problems
+        logger.info(
+            "Dispatch follow-through withheld — proposal %s parked for resume",
+            proposal_id[:8],
+        )
+        return None
     proposal = await ego_crud.get_proposal(db, proposal_id)
     if proposal is None:
         logger.warning(
@@ -59,14 +74,35 @@ async def record_dispatch_followthrough(
         )
         return None
 
+    # Derive failure from the proposal's AUTHORITATIVE status too. A dispatch
+    # whose SESSION completed but whose deliverables failed post-dispatch
+    # verification is marked failed on the PROPOSAL
+    # (mark_proposal_verification_failed) — invisible to the caller's
+    # session-derived `failed` flag. Either signal means failed.
+    failed = failed or (proposal.get("status") or "").lower() == "failed"
+
     prop_summary = (proposal.get("content") or "").replace("\n", " ").strip()[:80]
-    outcome_summary = (outcome or "").replace("\n", " ").strip()[:120]
+    # The raw session OUTCOME text is intentionally NOT embedded in this content.
+    # This content lands in the owning ego's mandatory-review block — an
+    # authoritative, privileged context — and a research/interact dispatch's
+    # output is external_untrusted (it can echo web/browser content). Embedding
+    # it here would launder indirect prompt injection into a trusted instruction.
+    # status + the ego's own (first-party) proposal summary anchor the review;
+    # the ego reads the full outcome via the execution_outcome observation + the
+    # recallable dispatch memory.
     content = (
         f"Review dispatch outcome for proposal {proposal_id[:8]} "
         f"[{status}]: {prop_summary}"
-        + (f" — {outcome_summary}" if outcome_summary else "")
-        + ". Decide follow-through: step-2, retry, or close."
+        ". Decide follow-through: step-2, retry, or close."
     )
+    if outcome:
+        # Preview only in the (non-privileged) application log — never the
+        # ego-facing content above.
+        logger.debug(
+            "Follow-through for %s — outcome preview: %s",
+            proposal_id[:8],
+            outcome.replace("\n", " ").strip()[:80],
+        )
 
     iid = await ego_intentions.create(
         db,

--- a/src/genesis/ego/dispatch_followthrough.py
+++ b/src/genesis/ego/dispatch_followthrough.py
@@ -1,0 +1,92 @@
+"""Dispatch follow-through — force ego review of every terminal dispatch.
+
+B2b of the activation-loop program: a dispatched proposal that finishes
+(success OR failure) previously produced only an observation + memory that
+nothing was forced to read. This module creates a system-origin
+``ego_intentions`` row for the OWNING ego, so its next cycle's
+mandatory-review block makes it judge the outcome: step-2, retry, or close.
+
+Called from the ``_ego_dispatch_on_end`` hook (``runtime/init/ego.py``) —
+kept here as a module-level function so it is unit-testable outside the
+runtime closure. Caller owns the commit.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import aiosqlite
+
+from genesis.db.crud import ego as ego_crud
+from genesis.db.crud import ego_intentions
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK_EGO_SOURCE = "genesis_ego_cycle"
+
+_TRIGGER = "Next ego cycle — review this dispatch outcome and decide follow-through."
+
+
+async def record_dispatch_followthrough(
+    db: aiosqlite.Connection,
+    *,
+    proposal_id: str,
+    session_id: str,
+    status: str,
+    outcome: str = "",
+    failed: bool = False,
+) -> str | None:
+    """Create a follow-through intention for a terminal dispatch.
+
+    Returns the intention id, or None when skipped (unknown proposal, or an
+    active follow-through for this proposal already exists — dedup so a
+    re-dispatched proposal never piles rows). Caller commits.
+    """
+    proposal = await ego_crud.get_proposal(db, proposal_id)
+    if proposal is None:
+        logger.warning(
+            "Dispatch follow-through skipped — proposal %s not found",
+            proposal_id[:8],
+        )
+        return None
+
+    ego_source = proposal.get("ego_source") or _FALLBACK_EGO_SOURCE
+
+    if await ego_intentions.has_active_for_proposal(db, ego_source, proposal_id):
+        logger.info(
+            "Dispatch follow-through deduped — active intention already references proposal %s",
+            proposal_id[:8],
+        )
+        return None
+
+    prop_summary = (proposal.get("content") or "").replace("\n", " ").strip()[:80]
+    outcome_summary = (outcome or "").replace("\n", " ").strip()[:120]
+    content = (
+        f"Review dispatch outcome for proposal {proposal_id[:8]} "
+        f"[{status}]: {prop_summary}"
+        + (f" — {outcome_summary}" if outcome_summary else "")
+        + ". Decide follow-through: step-2, retry, or close."
+    )
+
+    iid = await ego_intentions.create(
+        db,
+        content=content,
+        trigger_condition=_TRIGGER,
+        ego_source=ego_source,
+        reasoning=(
+            f"Auto-created by dispatch on_end hook (session {session_id[:8]}); "
+            "every terminal dispatch gets one forced outcome review."
+        ),
+        priority="high" if failed else "normal",
+        max_cycles=3,
+        origin="system",
+        proposal_id=proposal_id,
+    )
+    if iid:
+        logger.info(
+            "Dispatch follow-through intention %s created for %s (proposal %s)",
+            iid,
+            ego_source,
+            proposal_id[:8],
+        )
+    return iid

--- a/src/genesis/ego/intentions_context.py
+++ b/src/genesis/ego/intentions_context.py
@@ -42,13 +42,18 @@ async def build_intentions_section(
         )
 
     cap = ego_intentions.MAX_ACTIVE_PER_SOURCE
-    remaining = max(0, cap - len(active))
+    # Only LLM-created ('ego' origin) rows consume the cap — system rows
+    # (dispatch follow-through) are mandatory-review but uncapped.
+    llm_count = sum(1 for item in active if item.get("origin", "ego") != "system")
+    remaining = max(0, cap - llm_count)
 
     lines = [
         "## Deferred Intentions (MANDATORY REVIEW)\n",
         f"**{len(active)} active intention(s).** You MUST review each "
         "one and include it in your `intentions.review` output — "
-        "action: `keep`, `fire`, `withdraw`, or `renew`.\n",
+        "action: `keep`, `fire`, `withdraw`, or `renew`. Items marked "
+        "[follow-through] are dispatch outcomes awaiting your judgment: "
+        "decide step-2, retry, or close (`withdraw` when nothing remains).\n",
     ]
 
     for item in active:
@@ -59,9 +64,14 @@ async def build_intentions_section(
         max_c = item["max_cycles"]
         priority = item["priority"]
         reasoning = (item.get("reasoning") or "")[:150]
+        tag = (
+            " [follow-through]"
+            if item.get("origin", "ego") == "system"
+            else ""
+        )
 
         lines.append(
-            f"- **[id:{iid}]** [{priority}] (cycle {cycles}/{max_c})"
+            f"- **[id:{iid}]**{tag} [{priority}] (cycle {cycles}/{max_c})"
         )
         lines.append(f"  Content: {content}")
         lines.append(f"  Trigger: {trigger}")

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1175,10 +1175,14 @@ class EgoSession:
                                 rd.get("id"), exc_info=True,
                             )
 
-            # 10d. Process deferred intentions (both egos)
+            # 10d. Process deferred intentions (both egos). Called even when
+            # the output drops the intentions block — expiry and the
+            # implicit-keep aging sweep must run every cycle so max_cycles
+            # is a mechanical TTL, not one dependent on LLM compliance.
             intentions_data = parsed.get("intentions")
-            if intentions_data and isinstance(intentions_data, dict):
-                await self._process_intentions(intentions_data)
+            if not isinstance(intentions_data, dict):
+                intentions_data = {}
+            await self._process_intentions(intentions_data)
 
             # 10e. Additive ego autonomy — the genesis ego's OWN goal lane
             # (origin='genesis_ego'). Both handlers hard-gate on source_tag
@@ -2767,6 +2771,7 @@ class EgoSession:
                 )
 
             # 2. Review existing intentions (filtered to this ego's source)
+            reviewed_ids: list[str] = []
             reviews = intentions_data.get("review", [])
             if isinstance(reviews, list):
                 for entry in reviews:
@@ -2776,6 +2781,7 @@ class EgoSession:
                     action = entry.get("action")
                     if not iid or action not in ("keep", "fire", "withdraw", "renew"):
                         continue
+                    reviewed_ids.append(iid)
 
                     if action == "keep":
                         new_count = await ego_intentions.increment_cycle_count(
@@ -2802,6 +2808,20 @@ class EgoSession:
                         )
                         if ok:
                             logger.info("Intention %s renewed (counter reset)", iid)
+
+            # 2b. Implicit-keep: age every active row the review output did
+            # NOT mention (kept rows were bumped explicitly; fired/withdrawn
+            # rows are no longer active; renewed rows are excluded so their
+            # reset sticks). Without this, an unmentioned row never ages and
+            # max_cycles depends on LLM compliance instead of mechanics.
+            bumped = await ego_intentions.increment_unreviewed(
+                self._db, self._source_tag, reviewed_ids,
+            )
+            if bumped:
+                logger.debug(
+                    "Implicit-keep aged %d unreviewed intention(s) for %s",
+                    bumped, self._source_tag,
+                )
 
             # 3. Create new intentions
             new_intentions = intentions_data.get("new", [])

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -367,6 +367,34 @@ async def init(rt: GenesisRuntime) -> None:
                                 "Failed to record goal progress",
                                 exc_info=True,
                             )
+
+                        # B2b follow-through: force the OWNING ego to review
+                        # this dispatch outcome on its next cycle (step-2,
+                        # retry, or close). Every terminal dispatch gets one;
+                        # dedup + cap bypass live in the helper/CRUD.
+                        try:
+                            from genesis.ego.dispatch_followthrough import (
+                                record_dispatch_followthrough,
+                            )
+
+                            _err = (_meta.get("error") or "").strip()
+                            _out = _err or (_meta.get("output_text") or "")
+                            _iid = await record_dispatch_followthrough(
+                                rt._db,
+                                proposal_id=caller_ctx.split("ego_proposal:")[-1],
+                                session_id=session_id,
+                                status=status,
+                                outcome=_out,
+                                failed=bool(_err) or status != "completed",
+                            )
+                            if _iid:
+                                # create() defers the commit to the caller.
+                                await rt._db.commit()
+                        except Exception:
+                            logger.warning(
+                                "Failed to create dispatch follow-through",
+                                exc_info=True,
+                            )
                 except Exception:
                     logger.warning(
                         "Failed to record ego dispatch outcome",

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -333,25 +333,17 @@ async def init(rt: GenesisRuntime) -> None:
                             _gid = _prop.get("goal_id") if _prop else None
                             if _gid:
                                 _content = (_prop.get("content") or "")[:60]
-                                # Extract outcome summary from session
-                                # metadata (stored by DirectSessionRunner
-                                # at direct_session.py:479,483).
-                                # Prefer error when present — DirectSession
-                                # calls complete() even on is_error=True;
-                                # only Python exceptions trigger fail().
-                                _error = (_meta.get("error") or "").strip()
-                                if _error:
-                                    _outcome = _error[:120]
-                                else:
-                                    _outcome = (_meta.get("output_text") or "")[:120]
-                                _outcome = _outcome.replace("\n", " ").strip()
-                                if _outcome:
-                                    _note = (
-                                        f"[{status}] {_content}: "
-                                        f"{_outcome} (session:{session_id[:8]})"
-                                    )
-                                else:
-                                    _note = f"[{status}] {_content} (session:{session_id[:8]})"
+                                # The raw session outcome is intentionally NOT
+                                # embedded in the goal-progress note. Progress
+                                # notes render into ego-surfaced goal context
+                                # (world_snapshot / user_context) — a privileged
+                                # surface — and a research/interact dispatch's
+                                # output is external_untrusted (indirect prompt-
+                                # injection risk). status + the (first-party)
+                                # proposal title + session id anchor the note;
+                                # the full outcome is on the execution_outcome
+                                # observation + the recallable dispatch memory.
+                                _note = f"[{status}] {_content} (session:{session_id[:8]})"
                                 await user_goals.add_progress_note(
                                     rt._db,
                                     _gid,
@@ -379,6 +371,20 @@ async def init(rt: GenesisRuntime) -> None:
 
                             _err = (_meta.get("error") or "").strip()
                             _out = _err or (_meta.get("output_text") or "")
+                            # A rate/quota-parked dispatch stamps park_id into
+                            # metadata (direct_session.py) and is NOT terminal.
+                            # Recording a follow-through now would misreport it
+                            # as failed, so the parked case is passed to the
+                            # helper to withhold. KNOWN GAP, tracked in follow-up
+                            # 837f8b63: the resume does NOT re-fire this, because
+                            # rate_limit_resume rewrites caller_context to
+                            # `rate_limit_resume:<park_id>`, severing the
+                            # `ego_proposal:` linkage this block gates on — so the
+                            # parked class stays uncovered until that reconnection
+                            # lands. Removing B2b's premature "failed" review is
+                            # still strictly better than shipping a false one.
+                            # behavioral-lint: ignore no-hide-problems
+                            _parked = bool(_meta.get("park_id"))
                             _iid = await record_dispatch_followthrough(
                                 rt._db,
                                 proposal_id=caller_ctx.split("ego_proposal:")[-1],
@@ -386,6 +392,7 @@ async def init(rt: GenesisRuntime) -> None:
                                 status=status,
                                 outcome=_out,
                                 failed=bool(_err) or status != "completed",
+                                parked=_parked,
                             )
                             if _iid:
                                 # create() defers the commit to the caller.

--- a/tests/ego/test_dispatch_followthrough.py
+++ b/tests/ego/test_dispatch_followthrough.py
@@ -60,11 +60,14 @@ class TestRecordDispatchFollowthrough:
         assert row["proposal_id"] == PROPOSAL_ID
         assert row["max_cycles"] == 3
         assert row["priority"] == "normal"
-        # Content carries what the ego needs to judge follow-through.
+        # Content carries what the ego needs to judge follow-through — status +
+        # the ego's own (first-party) proposal summary — but NOT the raw session
+        # outcome (that would launder external_untrusted content into the
+        # privileged mandatory-review block; see test_outcome_text_not_laundered).
         assert PROPOSAL_ID[:8] in row["content"]
         assert "completed" in row["content"]
-        assert "PR opened and merged" in row["content"]
         assert "Ship the ingestion retry fix" in row["content"]
+        assert "PR opened and merged" not in row["content"]
 
     @pytest.mark.asyncio
     async def test_null_ego_source_falls_back_to_genesis(self, db):
@@ -165,3 +168,70 @@ class TestRecordDispatchFollowthrough:
             failed=False,
         )
         assert iid is not None
+
+    @pytest.mark.asyncio
+    async def test_outcome_text_not_laundered_into_content(self, db):
+        """The raw dispatch outcome must NEVER reach the intention content — it
+        lands in the ego's privileged mandatory-review block, and a research/
+        interact dispatch's output is external_untrusted (Codex #1496 P2)."""
+        from genesis.db.crud import ego_intentions
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
+
+        await _seed_proposal(db, ego_source="user_ego_cycle")
+        await record_dispatch_followthrough(
+            db,
+            proposal_id=PROPOSAL_ID,
+            session_id="sess1234abcd",
+            status="completed",
+            outcome="OUTCOME_SENTINEL_XYZ web-sourced text",
+            failed=False,
+        )
+        row = (await ego_intentions.list_active(db, "user_ego_cycle"))[0]
+        assert "OUTCOME_SENTINEL_XYZ" not in row["content"]
+
+    @pytest.mark.asyncio
+    async def test_verification_failed_proposal_gets_high_priority(self, db):
+        """A dispatch whose SESSION completed but whose proposal was marked failed
+        (post-dispatch verification) must be treated as failed → high priority,
+        even though the caller's session-derived flag says failed=False (#1496 P2)."""
+        from genesis.db.crud import ego_intentions
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
+
+        # Proposal marked failed by verification, but the session "completed".
+        await db.execute(
+            """INSERT INTO ego_proposals
+               (id, action_type, content, status, created_at, ego_source)
+               VALUES (?, 'implement', 'Ship X', 'failed', ?, 'genesis_ego_cycle')""",
+            (PROPOSAL_ID, datetime.now(UTC).isoformat()),
+        )
+        await db.commit()
+        await record_dispatch_followthrough(
+            db,
+            proposal_id=PROPOSAL_ID,
+            session_id="sess1234abcd",
+            status="completed",
+            outcome="",
+            failed=False,
+        )
+        row = (await ego_intentions.list_active(db, "genesis_ego_cycle"))[0]
+        assert row["priority"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_parked_dispatch_skips_followthrough(self, db):
+        """A rate/quota-parked dispatch is NOT terminal — no follow-through now;
+        the resumed session's on_end fires the real one (Codex #1496 P2)."""
+        from genesis.db.crud import ego_intentions
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
+
+        await _seed_proposal(db, ego_source="user_ego_cycle")
+        iid = await record_dispatch_followthrough(
+            db,
+            proposal_id=PROPOSAL_ID,
+            session_id="sess1234abcd",
+            status="failed",
+            outcome="rate_limited: parked for resume",
+            failed=True,
+            parked=True,
+        )
+        assert iid is None
+        assert await ego_intentions.list_active(db, "user_ego_cycle") == []

--- a/tests/ego/test_dispatch_followthrough.py
+++ b/tests/ego/test_dispatch_followthrough.py
@@ -40,9 +40,8 @@ async def _seed_proposal(db, *, ego_source: str | None, pid: str = PROPOSAL_ID):
 class TestRecordDispatchFollowthrough:
     @pytest.mark.asyncio
     async def test_creates_intention_for_owning_ego(self, db):
-        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
-
         from genesis.db.crud import ego_intentions
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
 
         await _seed_proposal(db, ego_source="user_ego_cycle")
         iid = await record_dispatch_followthrough(
@@ -69,9 +68,8 @@ class TestRecordDispatchFollowthrough:
 
     @pytest.mark.asyncio
     async def test_null_ego_source_falls_back_to_genesis(self, db):
-        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
-
         from genesis.db.crud import ego_intentions
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
 
         await _seed_proposal(db, ego_source=None)
         iid = await record_dispatch_followthrough(
@@ -88,9 +86,8 @@ class TestRecordDispatchFollowthrough:
 
     @pytest.mark.asyncio
     async def test_failed_dispatch_gets_high_priority(self, db):
-        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
-
         from genesis.db.crud import ego_intentions
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
 
         await _seed_proposal(db, ego_source="genesis_ego_cycle")
         await record_dispatch_followthrough(
@@ -106,9 +103,8 @@ class TestRecordDispatchFollowthrough:
 
     @pytest.mark.asyncio
     async def test_dedup_second_dispatch_same_proposal(self, db):
-        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
-
         from genesis.db.crud import ego_intentions
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
 
         await _seed_proposal(db, ego_source="user_ego_cycle")
         first = await record_dispatch_followthrough(
@@ -149,9 +145,8 @@ class TestRecordDispatchFollowthrough:
     @pytest.mark.asyncio
     async def test_created_even_when_llm_cap_full(self, db):
         """The keystone must not silently drop when the ego's board is busy."""
-        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
-
         from genesis.db.crud import ego_intentions
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
 
         await _seed_proposal(db, ego_source="user_ego_cycle")
         for i in range(ego_intentions.MAX_ACTIVE_PER_SOURCE):

--- a/tests/ego/test_dispatch_followthrough.py
+++ b/tests/ego/test_dispatch_followthrough.py
@@ -1,0 +1,172 @@
+"""Tests for dispatch follow-through — ego_intentions rows forcing outcome review.
+
+Every terminal ego dispatch creates a system-origin intention for the owning
+ego so the next cycle MUST review the outcome (step-2, retry, or close).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import aiosqlite
+import pytest
+
+PROPOSAL_ID = "abc12345deadbeef"
+
+
+@pytest.fixture()
+async def db():
+    """In-memory DB with production ego_proposals + ego_intentions schemas."""
+    from genesis.db.schema import TABLES
+
+    async with aiosqlite.connect(":memory:") as conn:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute(TABLES["ego_proposals"])
+        await conn.execute(TABLES["ego_intentions"])
+        await conn.commit()
+        yield conn
+
+
+async def _seed_proposal(db, *, ego_source: str | None, pid: str = PROPOSAL_ID):
+    await db.execute(
+        """INSERT INTO ego_proposals
+           (id, action_type, content, status, created_at, ego_source)
+           VALUES (?, 'implement', 'Ship the ingestion retry fix', 'executed', ?, ?)""",
+        (pid, datetime.now(UTC).isoformat(), ego_source),
+    )
+    await db.commit()
+
+
+class TestRecordDispatchFollowthrough:
+    @pytest.mark.asyncio
+    async def test_creates_intention_for_owning_ego(self, db):
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
+
+        from genesis.db.crud import ego_intentions
+
+        await _seed_proposal(db, ego_source="user_ego_cycle")
+        iid = await record_dispatch_followthrough(
+            db,
+            proposal_id=PROPOSAL_ID,
+            session_id="sess1234abcd",
+            status="completed",
+            outcome="PR opened and merged",
+            failed=False,
+        )
+        assert iid is not None
+        items = await ego_intentions.list_active(db, "user_ego_cycle")
+        assert len(items) == 1
+        row = items[0]
+        assert row["origin"] == "system"
+        assert row["proposal_id"] == PROPOSAL_ID
+        assert row["max_cycles"] == 3
+        assert row["priority"] == "normal"
+        # Content carries what the ego needs to judge follow-through.
+        assert PROPOSAL_ID[:8] in row["content"]
+        assert "completed" in row["content"]
+        assert "PR opened and merged" in row["content"]
+        assert "Ship the ingestion retry fix" in row["content"]
+
+    @pytest.mark.asyncio
+    async def test_null_ego_source_falls_back_to_genesis(self, db):
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
+
+        from genesis.db.crud import ego_intentions
+
+        await _seed_proposal(db, ego_source=None)
+        iid = await record_dispatch_followthrough(
+            db,
+            proposal_id=PROPOSAL_ID,
+            session_id="sess1234abcd",
+            status="completed",
+            outcome="",
+            failed=False,
+        )
+        assert iid is not None
+        items = await ego_intentions.list_active(db, "genesis_ego_cycle")
+        assert len(items) == 1
+
+    @pytest.mark.asyncio
+    async def test_failed_dispatch_gets_high_priority(self, db):
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
+
+        from genesis.db.crud import ego_intentions
+
+        await _seed_proposal(db, ego_source="genesis_ego_cycle")
+        await record_dispatch_followthrough(
+            db,
+            proposal_id=PROPOSAL_ID,
+            session_id="sess1234abcd",
+            status="completed",
+            outcome="Tests failed: 3 errors in test_routing",
+            failed=True,
+        )
+        items = await ego_intentions.list_active(db, "genesis_ego_cycle")
+        assert items[0]["priority"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_dedup_second_dispatch_same_proposal(self, db):
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
+
+        from genesis.db.crud import ego_intentions
+
+        await _seed_proposal(db, ego_source="user_ego_cycle")
+        first = await record_dispatch_followthrough(
+            db,
+            proposal_id=PROPOSAL_ID,
+            session_id="sess1111aaaa",
+            status="completed",
+            outcome="run 1",
+            failed=False,
+        )
+        second = await record_dispatch_followthrough(
+            db,
+            proposal_id=PROPOSAL_ID,
+            session_id="sess2222bbbb",
+            status="completed",
+            outcome="run 2",
+            failed=False,
+        )
+        assert first is not None
+        assert second is None
+        items = await ego_intentions.list_active(db, "user_ego_cycle")
+        assert len(items) == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_proposal_returns_none(self, db):
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
+
+        iid = await record_dispatch_followthrough(
+            db,
+            proposal_id="does0not0exist00",
+            session_id="sess1234abcd",
+            status="completed",
+            outcome="",
+            failed=False,
+        )
+        assert iid is None
+
+    @pytest.mark.asyncio
+    async def test_created_even_when_llm_cap_full(self, db):
+        """The keystone must not silently drop when the ego's board is busy."""
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
+
+        from genesis.db.crud import ego_intentions
+
+        await _seed_proposal(db, ego_source="user_ego_cycle")
+        for i in range(ego_intentions.MAX_ACTIVE_PER_SOURCE):
+            assert await ego_intentions.create(
+                db,
+                content=f"Intention {i}",
+                trigger_condition=f"Trigger {i}",
+                ego_source="user_ego_cycle",
+            )
+        iid = await record_dispatch_followthrough(
+            db,
+            proposal_id=PROPOSAL_ID,
+            session_id="sess1234abcd",
+            status="completed",
+            outcome="done",
+            failed=False,
+        )
+        assert iid is not None

--- a/tests/ego/test_intentions.py
+++ b/tests/ego/test_intentions.py
@@ -11,27 +11,12 @@ import pytest
 
 @pytest.fixture()
 async def db(tmp_path):
-    """In-memory DB with ego_intentions table."""
+    """In-memory DB with the PRODUCTION ego_intentions schema (no drift)."""
+    from genesis.db.schema import TABLES
+
     async with aiosqlite.connect(":memory:") as conn:
         conn.row_factory = aiosqlite.Row
-        await conn.execute("""
-            CREATE TABLE ego_intentions (
-                id                TEXT PRIMARY KEY,
-                content           TEXT NOT NULL,
-                trigger_condition TEXT NOT NULL,
-                ego_source        TEXT NOT NULL,
-                status            TEXT NOT NULL DEFAULT 'active'
-                    CHECK (status IN ('active', 'fired', 'expired', 'withdrawn')),
-                created_at        TEXT NOT NULL,
-                fired_at          TEXT,
-                proposal_id       TEXT,
-                cycle_count       INTEGER NOT NULL DEFAULT 0,
-                max_cycles        INTEGER NOT NULL DEFAULT 20,
-                reasoning         TEXT,
-                priority          TEXT NOT NULL DEFAULT 'normal'
-                    CHECK (priority IN ('low', 'normal', 'high'))
-            )
-        """)
+        await conn.execute(TABLES["ego_intentions"])
         await conn.commit()
         yield conn
 
@@ -346,6 +331,292 @@ class TestContextInjection:
         )
         text = await build_intentions_section(db, "genesis_ego_cycle")
         assert "No active intentions" in text
+
+    @pytest.mark.asyncio
+    async def test_system_rows_do_not_consume_llm_slots(self, db):
+        """System follow-through rows render but don't eat the LLM's 5 slots."""
+        from genesis.db.crud import ego_intentions
+        from genesis.ego.intentions_context import build_intentions_section
+
+        await ego_intentions.create(
+            db,
+            content="Review dispatch outcome for proposal abc12345",
+            trigger_condition="Next ego cycle",
+            ego_source="user_ego_cycle",
+            origin="system",
+            proposal_id="abc12345deadbeef",
+        )
+        await ego_intentions.create(
+            db,
+            content="LLM-created intention",
+            trigger_condition="Some trigger",
+            ego_source="user_ego_cycle",
+        )
+        text = await build_intentions_section(db, "user_ego_cycle")
+        # Both rows are mandatory-review...
+        assert "2 active intention" in text
+        assert "Review dispatch outcome" in text
+        # ...the system row is labelled as follow-through...
+        assert "follow-through" in text
+        # ...but only the LLM row counts against the cap (5 - 1 = 4).
+        assert "4 slot(s) available" in text
+
+
+# ---------------------------------------------------------------------------
+# System-origin (dispatch follow-through) CRUD tests
+# ---------------------------------------------------------------------------
+
+
+class TestSystemOrigin:
+    @staticmethod
+    async def _fill_llm_cap(db, source="user_ego_cycle"):
+        from genesis.db.crud import ego_intentions
+
+        for i in range(ego_intentions.MAX_ACTIVE_PER_SOURCE):
+            iid = await ego_intentions.create(
+                db,
+                content=f"Intention {i}",
+                trigger_condition=f"Trigger {i}",
+                ego_source=source,
+            )
+            assert iid is not None
+
+    @pytest.mark.asyncio
+    async def test_system_origin_bypasses_cap(self, db):
+        """A system follow-through row is created even when the LLM cap is full."""
+        from genesis.db.crud import ego_intentions
+
+        await self._fill_llm_cap(db)
+        iid = await ego_intentions.create(
+            db,
+            content="Review dispatch outcome for proposal abc12345",
+            trigger_condition="Next ego cycle",
+            ego_source="user_ego_cycle",
+            origin="system",
+            proposal_id="abc12345deadbeef",
+        )
+        assert iid is not None
+        items = await ego_intentions.list_active(db, "user_ego_cycle")
+        assert len(items) == 6
+
+    @pytest.mark.asyncio
+    async def test_system_rows_do_not_count_toward_llm_cap(self, db):
+        """LLM creations still succeed when system rows are present."""
+        from genesis.db.crud import ego_intentions
+
+        for i in range(3):
+            await ego_intentions.create(
+                db,
+                content=f"Follow-through {i}",
+                trigger_condition="Next ego cycle",
+                ego_source="user_ego_cycle",
+                origin="system",
+                proposal_id=f"prop{i:012d}",
+            )
+        # All 5 LLM slots must still be open.
+        await self._fill_llm_cap(db)
+
+    @pytest.mark.asyncio
+    async def test_llm_cap_still_enforced(self, db):
+        """Default-origin creation is still capped at MAX_ACTIVE_PER_SOURCE."""
+        from genesis.db.crud import ego_intentions
+
+        await self._fill_llm_cap(db)
+        iid = await ego_intentions.create(
+            db,
+            content="One too many",
+            trigger_condition="Trigger",
+            ego_source="user_ego_cycle",
+        )
+        assert iid is None
+
+    @pytest.mark.asyncio
+    async def test_origin_and_proposal_id_persisted(self, db):
+        from genesis.db.crud import ego_intentions
+
+        await ego_intentions.create(
+            db,
+            content="Review dispatch outcome",
+            trigger_condition="Next ego cycle",
+            ego_source="genesis_ego_cycle",
+            origin="system",
+            proposal_id="feedfacecafebeef",
+        )
+        items = await ego_intentions.list_active(db, "genesis_ego_cycle")
+        assert items[0]["origin"] == "system"
+        assert items[0]["proposal_id"] == "feedfacecafebeef"
+
+    @pytest.mark.asyncio
+    async def test_default_origin_is_ego(self, db):
+        from genesis.db.crud import ego_intentions
+
+        await ego_intentions.create(
+            db,
+            content="Plain intention",
+            trigger_condition="Trigger",
+            ego_source="genesis_ego_cycle",
+        )
+        items = await ego_intentions.list_active(db, "genesis_ego_cycle")
+        assert items[0]["origin"] == "ego"
+
+    @pytest.mark.asyncio
+    async def test_has_active_for_proposal(self, db):
+        from genesis.db.crud import ego_intentions
+
+        assert not await ego_intentions.has_active_for_proposal(
+            db, "user_ego_cycle", "abc12345deadbeef"
+        )
+        await ego_intentions.create(
+            db,
+            content="Review dispatch outcome",
+            trigger_condition="Next ego cycle",
+            ego_source="user_ego_cycle",
+            origin="system",
+            proposal_id="abc12345deadbeef",
+        )
+        assert await ego_intentions.has_active_for_proposal(
+            db, "user_ego_cycle", "abc12345deadbeef"
+        )
+        # Different source is isolated; different proposal is distinct.
+        assert not await ego_intentions.has_active_for_proposal(
+            db, "genesis_ego_cycle", "abc12345deadbeef"
+        )
+        assert not await ego_intentions.has_active_for_proposal(
+            db, "user_ego_cycle", "0000000000000000"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fire_without_proposal_id_preserves_creation_ref(self, db):
+        """Firing with no proposal_id must not erase the system row's provenance."""
+        from genesis.db.crud import ego_intentions
+
+        iid = await ego_intentions.create(
+            db,
+            content="Review dispatch outcome",
+            trigger_condition="Next ego cycle",
+            ego_source="user_ego_cycle",
+            origin="system",
+            proposal_id="abc12345deadbeef",
+        )
+        ok = await ego_intentions.fire(db, iid, ego_source="user_ego_cycle")
+        assert ok is True
+        cursor = await db.execute(
+            "SELECT proposal_id FROM ego_intentions WHERE id = ?", (iid,)
+        )
+        row = await cursor.fetchone()
+        assert row["proposal_id"] == "abc12345deadbeef"
+
+    @pytest.mark.asyncio
+    async def test_increment_unreviewed_ages_unmentioned_rows(self, db):
+        """Implicit-keep: rows omitted from the review output still age."""
+        from genesis.db.crud import ego_intentions
+
+        reviewed = await ego_intentions.create(
+            db,
+            content="Reviewed row",
+            trigger_condition="T",
+            ego_source="user_ego_cycle",
+        )
+        unmentioned = await ego_intentions.create(
+            db,
+            content="Unmentioned row",
+            trigger_condition="T",
+            ego_source="user_ego_cycle",
+        )
+        other_source = await ego_intentions.create(
+            db,
+            content="Other ego's row",
+            trigger_condition="T",
+            ego_source="genesis_ego_cycle",
+        )
+        bumped = await ego_intentions.increment_unreviewed(
+            db, "user_ego_cycle", [reviewed]
+        )
+        assert bumped == 1
+        rows = {
+            r["id"]: r["cycle_count"]
+            for r in await db.execute_fetchall(
+                "SELECT id, cycle_count FROM ego_intentions"
+            )
+        }
+        assert rows[unmentioned] == 1
+        assert rows[reviewed] == 0  # excluded (explicit keep bumps separately)
+        assert rows[other_source] == 0  # cross-ego isolation
+
+    @pytest.mark.asyncio
+    async def test_increment_unreviewed_empty_reviewed_ages_all(self, db):
+        """LLM omitted the whole review block — every active row still ages."""
+        from genesis.db.crud import ego_intentions
+
+        a = await ego_intentions.create(
+            db, content="A", trigger_condition="T", ego_source="user_ego_cycle"
+        )
+        b = await ego_intentions.create(
+            db,
+            content="B",
+            trigger_condition="T",
+            ego_source="user_ego_cycle",
+            origin="system",
+            proposal_id="abc12345deadbeef",
+        )
+        bumped = await ego_intentions.increment_unreviewed(db, "user_ego_cycle", [])
+        assert bumped == 2
+        rows = {
+            r["id"]: r["cycle_count"]
+            for r in await db.execute_fetchall(
+                "SELECT id, cycle_count FROM ego_intentions"
+            )
+        }
+        assert rows[a] == 1 and rows[b] == 1
+
+    @pytest.mark.asyncio
+    async def test_increment_unreviewed_skips_inactive(self, db):
+        from genesis.db.crud import ego_intentions
+
+        iid = await ego_intentions.create(
+            db, content="A", trigger_condition="T", ego_source="user_ego_cycle"
+        )
+        await ego_intentions.withdraw(db, iid, ego_source="user_ego_cycle")
+        bumped = await ego_intentions.increment_unreviewed(db, "user_ego_cycle", [])
+        assert bumped == 0
+
+    @pytest.mark.asyncio
+    async def test_mechanical_ttl_system_row_expires_without_compliance(self, db):
+        """A follow-through row the ego NEVER reviews is reaped at max_cycles=3."""
+        from genesis.db.crud import ego_intentions
+
+        await ego_intentions.create(
+            db,
+            content="Review dispatch outcome",
+            trigger_condition="Next ego cycle",
+            ego_source="user_ego_cycle",
+            origin="system",
+            proposal_id="abc12345deadbeef",
+            max_cycles=3,
+        )
+        for _ in range(4):  # strict >: survives cycles 1-3, reaped at 4
+            await ego_intentions.increment_unreviewed(db, "user_ego_cycle", [])
+        expired = await ego_intentions.expire_overdue(db, "user_ego_cycle")
+        assert expired == 1
+        assert await ego_intentions.list_active(db, "user_ego_cycle") == []
+
+    @pytest.mark.asyncio
+    async def test_withdrawn_row_does_not_block_new_followthrough(self, db):
+        """Dedup only considers ACTIVE rows — a reviewed/closed one clears the way."""
+        from genesis.db.crud import ego_intentions
+
+        iid = await ego_intentions.create(
+            db,
+            content="Review dispatch outcome",
+            trigger_condition="Next ego cycle",
+            ego_source="user_ego_cycle",
+            origin="system",
+            proposal_id="abc12345deadbeef",
+        )
+        await ego_intentions.withdraw(db, iid, ego_source="user_ego_cycle")
+        assert not await ego_intentions.has_active_for_proposal(
+            db, "user_ego_cycle", "abc12345deadbeef"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

B2b of the activation-loop program (dispatch follow-through). A dispatched ego proposal that finished — success **or** failure — produced only an observation and a memory that nothing was forced to read, so dispatch outcomes rotted unreviewed (no step-2, no retry decision, no calibration). Now every terminal dispatch forces the **owning ego** to review the outcome on its next cycle.

## Mechanism

`_ego_dispatch_on_end` (the single dispatch-completion sink) calls a new unit-testable helper, `ego/dispatch_followthrough.py::record_dispatch_followthrough`, which creates a **system-origin `ego_intentions` row** for the proposal's `ego_source` (genesis fallback on NULL). The existing mandatory-review block then makes the next cycle judge it: step-2, retry, or close (`withdraw`).

- **Unconditional** on every terminal dispatch; `max_cycles=3` so unactioned rows self-expire; priority `high` when the dispatch failed.
- **Dedup per proposal** (active rows only) via `proposal_id` set at creation — a re-dispatched proposal never piles rows.
- **New `origin` column** (`'ego'`|`'system'`) on `ego_intentions`, added across all three schema build paths (fresh CREATE, `_migrate_add_columns`, numbered migration 0086). System rows **bypass** `MAX_ACTIVE_PER_SOURCE` — the cap exists to stop the LLM hoarding slots, not to drop mechanical follow-through; the LLM cap now counts `origin='ego'` rows only.
- `intentions_context` renders system rows with a `[follow-through]` tag + review guidance; the remaining-slots line counts LLM rows only.

## Tests / verification

TDD verify-RED (13 new tests failed pre-implementation) → GREEN; **104 passed** including the schema-parity and migration-runner guards; ruff clean. E2E against a live-DB copy: migration 0086 backfills 69 existing rows to `'ego'`; a real executed proposal routes to its owning ego; the dedup second call returns None; the context section renders the tag with slots unaffected. Cap-bypass is live-relevant: the user ego already carries 4 active LLM intentions on the current board.

## Review

genesis-architect adversarial pass: Ready, with 2 SHOULD-FIXes — both fixed in-PR with verify-RED locking tests: (1) `fire()` now COALESCEs `proposal_id` so firing a follow-through row keeps its source-dispatch provenance; (2) `max_cycles` is now a **mechanical** TTL — a new `increment_unreviewed` implicit-keep ages every active row the review output omits, and the `_process_intentions` call site runs unconditionally (expiry + aging even when the output drops the intentions block). Final: **251 passed** across the targeted ego + schema/migration suites.

Ledger: bc33f1281f944837aebeaa36742717db


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added system-generated follow-through intentions for completed dispatches.
  - Follow-through items now support proposal tracking, deduplication, priority escalation, and cap bypassing.
  - Intention reviews now display follow-through items and automatically age unreviewed intentions.
  - Goal-progress notes exclude raw dispatch output and errors.

- **Bug Fixes**
  - Preserved proposal links when intentions are fired without replacements.
  - Prevented duplicate follow-through records and excluded parked dispatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->