### PR TITLE
fix(dashboard): ego modal header shows real health, not fetch-load state

### DIFF
--- a/src/genesis/dashboard/templates/partials/modals/ego.html
+++ b/src/genesis/dashboard/templates/partials/modals/ego.html
@@ -24,6 +24,17 @@
           <div class="panel-status-detail" style="margin-bottom: 0.75rem;"
                x-text="$store.genesisDashboard.egoSemantic().reason"></div>
         </template>
+        <!-- Stale-refresh warning: the header dot now shows egoSemantic() health
+             (last-known), NOT whether THIS modal's live refresh succeeded. When
+             the modal's own fetch fails AFTER egoStatus is already populated (the
+             normal path — the overview card loads it before the modal opens), the
+             body error placeholder below is suppressed by its !egoStatus guard, so
+             the refresh failure would otherwise be invisible. Surface it here. -->
+        <template x-if="$store.genesisDashboard.egoModal.fetch.state === 'error' && $store.genesisDashboard.egoStatus">
+          <div class="inline-warning" style="margin-bottom: 0.75rem;">
+            ⚠ Live refresh failed — showing last known state.
+          </div>
+        </template>
         <!-- Loading -->
         <div x-show="$store.genesisDashboard.egoModal.fetch.state === 'loading' && !$store.genesisDashboard.egoStatus"
              style="text-align: center; padding: 2rem; color: var(--color-text-secondary);">Loading...</div>

--- a/src/genesis/dashboard/templates/partials/modals/ego.html
+++ b/src/genesis/dashboard/templates/partials/modals/ego.html
@@ -6,17 +6,23 @@
     <div class="config-modal" style="max-width: 900px;">
       <div class="config-modal-header">
         <span>Ego — Autonomous Decision Cycle</span>
+        <!-- Health verdict, NOT fetch-load state: the header dot/label/detail
+             render the SAME egoSemantic() verdict as the overview tile, so the
+             two surfaces can never disagree (a green "healthy" here used to mean
+             only "the modal's data loaded"). Load failures still surface in the
+             modal body's error placeholder below; egoSemantic() safely returns
+             "unknown" (gray) before egoStatus resolves — never a false green. -->
         <span class="panel-status">
-          <span class="status-dot" :style="`background:${$store.genesisDashboard.modalStateColor($store.genesisDashboard.egoModal)}`"></span>
-          <span x-text="$store.genesisDashboard.modalStateLabel($store.genesisDashboard.egoModal)"></span>
+          <span class="status-dot" :style="`background:${$store.genesisDashboard.semanticStateColor($store.genesisDashboard.egoSemantic().state)}`"></span>
+          <span x-text="$store.genesisDashboard.egoSemantic().state"></span>
         </span>
         <button @click="$store.genesisDashboard.egoModal.open = false">&times;</button>
       </div>
       <div class="config-modal-body">
         <!-- Status detail -->
-        <template x-if="$store.genesisDashboard.modalStatusDetail($store.genesisDashboard.egoModal)">
+        <template x-if="$store.genesisDashboard.egoSemantic().reason">
           <div class="panel-status-detail" style="margin-bottom: 0.75rem;"
-               x-text="$store.genesisDashboard.modalStatusDetail($store.genesisDashboard.egoModal)"></div>
+               x-text="$store.genesisDashboard.egoSemantic().reason"></div>
         </template>
         <!-- Loading -->
         <div x-show="$store.genesisDashboard.egoModal.fetch.state === 'loading' && !$store.genesisDashboard.egoStatus"


### PR DESCRIPTION
## What

The ego detail modal's header status dot/label/detail called `modalStateColor/modalStateLabel/modalStatusDetail(egoModal)` — which reflect only the modal's **HTTP fetch-load state** (`finishModalFetch` literally sets `state="healthy"` on any successful load), **not ego health**. So the modal read a green "healthy" while the overview tile correctly read "error / CEO stalled" from `egoSemantic()`. Two surfaces, same visual language (colored dot + word), different meanings — the modal's was a reassurance that only meant "the data loaded".

## Fix

Point the modal header at the **same `egoSemantic()` verdict the tile uses** — `semanticStateColor(egoSemantic().state)` + `.state` + `.reason` — so the modal and tile can never disagree again. Reuses existing sibling store methods (no new member; JS integrity guard green). `egoSemantic()` reads `egoStatus`, which the modal's `fetchEgoDetail()` already loads on open, and returns `unknown` (gray) before it resolves — never a false green. Genuine data-load failures still surface in the modal body's error placeholder. Matches the existing config inline-ego-row (`config.html:289`) and overview-tile precedent.

## Verification

JS/store integrity guard (`test_webui_js_integrity.py`) green; header-binding sanity asserted (semantic bindings present, old fetch-state dot removed). Real verification is the **post-deploy browser E2E**: open the ego modal, confirm the header dot/label equals the tile's verdict (and goes red together when the ego is genuinely stalled). Small targeted template change — architect review skipped per the genesis-development skill.

Part of the C5 ego-liveness signal-hygiene cluster (sibling of the stall-detector grace fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Ego modal’s status indicator to show the correct semantic color and label.
  - Added the relevant explanation when a status reason is available.
  - Added a warning when refreshing the modal fails, while retaining previously loaded status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->