### PR TITLE
fix(observability): ego stall detector — grace after CLI-approval gate release

### DIFF
--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -895,6 +895,10 @@ async def _check_ego_liveness(db) -> None:
                     db,
                     f"last_proactive_fire:{source_tag}",
                 )
+                last_gated = await ego_crud.get_state(
+                    db,
+                    f"last_gated:{source_tag}",
+                )
                 gated = (
                     await ego_crud.has_pending_cli_approval(db, source_tag) if gate_on else False
                 )
@@ -903,6 +907,7 @@ async def _check_ego_liveness(db) -> None:
                     last_intent_at=last_intent,
                     current_interval_minutes=mgr.current_interval_minutes,
                     gated=gated,
+                    last_gated_at=last_gated,
                 )
             except Exception:
                 logger.debug(

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -124,11 +124,16 @@ async def ego_status():
                 rt._db,
                 f"last_proactive_fire:{mgr.source_tag}",
             )
+            last_gated = await ego_crud.get_state(
+                rt._db,
+                f"last_gated:{mgr.source_tag}",
+            )
             live = compute_ego_liveness(
                 last_success_at=last_success,
                 last_intent_at=last_intent,
                 current_interval_minutes=mgr.current_interval_minutes,
                 gated=bool(snap.get("gated")),
+                last_gated_at=last_gated,
             )
             snap["last_success_at"] = live.last_success_at
             snap["stalled"] = live.stalled

--- a/src/genesis/ego/cadence.py
+++ b/src/genesis/ego/cadence.py
@@ -153,6 +153,7 @@ class EgoCadenceManager:
         # floor throttles overnight ticks relative to this.
         self._last_proactive_fire_at: datetime | None = None
 
+
         # Prevent concurrent cycles (interval + morning could overlap)
         self._lock = asyncio.Lock()
 
@@ -1165,6 +1166,11 @@ class EgoCadenceManager:
                 await asyncio.sleep(2)  # Brief batch window
                 status = await self._process_signals()
                 if status == "gated":
+                    # Record the gate-hold moment so the liveness gate-RELEASE
+                    # grace excuses the unblocked cycle's catch-up window (the
+                    # instant `gated` flips False at approval, `last_success`
+                    # still trails until the cycle completes).
+                    await self._mark_gated()
                     # Signals remain queued (pre-drain gate) or were requeued
                     # (dispatch block). The notify event is still set, so wait
                     # out a retry window instead of spinning — a resolved
@@ -1587,6 +1593,34 @@ class EgoCadenceManager:
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=UTC)
         self._last_proactive_fire_at = parsed
+
+    async def _mark_gated(self) -> None:
+        """Record 'the consumer was held on a gate just now' to
+        ``ego_state last_gated:<tag>`` — read directly from the DB by the
+        dashboard + awareness liveness surfaces to grant the gate-RELEASE
+        grace. Persisted (not just in-memory), so the grace survives restarts.
+
+        SAFETY INVARIANT (load-bearing — do NOT break): this must fire ONLY
+        from the top of the consumer loop on a "gated" return. That is what
+        keeps the grace from ever masking a REAL deadlock: a wedged cycle
+        blocks inside the cycle lock (``_process_signals`` → ``run_unified_cycle``)
+        and never loops back here, so ``last_gated`` stops refreshing and the
+        grace expires — the stall then fires one interval late, never *never*.
+        A future change that refreshes this from inside a running cycle, or via
+        a watchdog that re-pumps the loop, would VOID the no-masking guarantee.
+
+        Best-effort — a persistence failure must never break the loop.
+        """
+        try:
+            from genesis.db.crud import ego as ego_crud
+
+            await ego_crud.set_state(
+                self._db,
+                key=f"last_gated:{self._session._source_tag}",
+                value=datetime.now(UTC).isoformat(),
+            )
+        except Exception:
+            logger.debug("Failed to persist last gated-at", exc_info=True)
 
     async def _update_interval(self, *, had_proposals: bool) -> None:
         """Adjust cycle interval based on productivity and user recency.

--- a/src/genesis/ego/liveness.py
+++ b/src/genesis/ego/liveness.py
@@ -21,7 +21,13 @@ circuit open, bootstrap/floor not met) prevents an *intent* from being recorded
 in the first place, so it is excluded BY CONSTRUCTION — no per-condition
 enumeration, and no false "stalled" for a legitimately-quiet ego. ``gated``
 (a pending approval: intent recorded, but legitimately awaiting the user) is the
-one non-completing state that IS recorded, so it is excluded explicitly. A fresh
+one non-completing state that IS recorded, so it is excluded explicitly — and
+because the CLI approval gate lives at the CONSUMER (after ``_on_tick`` already
+pushed the signal), the intent advances during a hold. ``last_gated_at``
+(``ego_state last_gated:<tag>``, set whenever the consumer is held) closes the
+gate-RELEASE race: for one cadence interval after the last hold, the unblocked
+cycle's catch-up window is excused, so the instant ``gated`` flips False at
+approval does not read as a stall while ``last_success`` catches up. A fresh
 install (no intent or no completed cycle yet) is never stalled.
 
 **Coverage boundary (deliberate) — narrow edges tracked for the complementary
@@ -42,6 +48,14 @@ ego-heartbeat-staleness monitor (follow-up):**
   while the last completion is still old, so the lag reads high for the seconds/
   minutes until that cycle completes. Self-clears within one cycle; the hourly
   alert (if it happens to sample that window) self-resolves next tick.
+- A real consumer-wedge that BEGINS within the gate-release grace (≤ one cadence
+  interval, floored at ``_GATE_RELEASE_GRACE_FLOOR_MINUTES``, after a legitimate
+  gated period) is masked until the grace expires — a bounded add-on to the
+  already-large ``4×interval / 3h-floor`` threshold. Bounded because a wedged
+  consumer stops refreshing ``last_gated`` (it blocks in the cycle lock and
+  never returns to ``_mark_gated``), so the grace lapses and the stall fires one
+  interval late, never *never*. Total cessation remains the ``ego_heartbeat``
+  monitor's half.
 
 Pure and DB-free so it is trivially unit-testable; callers read the two
 timestamps and pass them in. Shared by the dashboard status endpoint and the
@@ -62,6 +76,12 @@ from genesis.observability.liveness import (  # noqa: F401  (re-exported)
     STALL_INTERVAL_MULTIPLE,
     stall_threshold_minutes,
 )
+
+# Minimum gate-release grace: the worst-case gate-release→completion window —
+# the consumer's ~5m gated-retry gap plus one ego cycle (2400s / 40m hard
+# timeout, ego/session.py). ``grace = max(interval, this)`` so a short-cadence
+# config never grants a grace shorter than a single cycle can take to complete.
+_GATE_RELEASE_GRACE_FLOOR_MINUTES = 60.0
 
 
 @dataclass(frozen=True)
@@ -91,6 +111,7 @@ def compute_ego_liveness(
     last_intent_at: str | None,
     current_interval_minutes: float,
     gated: bool,
+    last_gated_at: str | None = None,
     now: datetime | None = None,
 ) -> EgoLiveness:
     """Return the liveness verdict for one ego from its intent/completion pair.
@@ -100,6 +121,16 @@ def compute_ego_liveness(
     ``job_health.last_success``. Stalled iff (not ``gated``) and the intent leads
     completion by more than the conservative threshold. ``None`` for either (no
     proactive attempt yet, or no completed cycle yet) → never stalled.
+
+    ``last_gated_at`` is ``ego_state last_gated:<tag>`` — the last time the
+    consumer was held on a gate (CLI approval, pause, global-pause, circuit).
+    It closes the **gate-RELEASE race**: a long approval hold correctly
+    suppresses stalled via ``gated`` while it lasts, but at release ``gated``
+    flips False the instant the approval resolves while ``last_success`` can't
+    advance until the now-unblocked cycle dispatches and completes (its full
+    runtime). For one cadence interval after the ego was last gate-held, that
+    catch-up window is excused. A never-gated real deadlock (``last_gated_at``
+    None/old) is unaffected.
     """
     now = now or datetime.now(UTC)
     threshold = stall_threshold_minutes(current_interval_minutes)
@@ -117,6 +148,28 @@ def compute_ego_liveness(
 
     if gated:
         return EgoLiveness(last_success_at, False, lag, threshold, None)
+
+    # Gate-release grace: within one cadence interval of the last gate-hold, the
+    # unblocked cycle is still catching up — not a stall. Grace tracks the
+    # interval (the genesis ego's 240m cadence gets a 240m grace); a degenerate
+    # interval falls back to the hard floor so grace is never zero.
+    gated_at = _parse(last_gated_at)
+    if gated_at is not None:
+        try:
+            grace = float(current_interval_minutes)
+        except (TypeError, ValueError):
+            grace = 0.0
+        # Never shorter than one full gate-release→completion: the consumer's
+        # gated-retry gap plus one ego cycle (2400s / 40m hard timeout). Floors
+        # a short-cadence (or degenerate/0) interval so a slow post-approval
+        # cycle can't re-expose the false positive.
+        grace = max(grace, _GATE_RELEASE_GRACE_FLOOR_MINUTES)
+        since_gated = (now - gated_at).total_seconds() / 60.0
+        # Future last_gated (clock skew / corrupt row) → since_gated < 0 → fall
+        # through to the lag check: a safety monitor fails TOWARD detection.
+        if 0 <= since_gated <= grace:
+            return EgoLiveness(last_success_at, False, lag, threshold, None)
+
     if lag > threshold:
         hours = lag / 60.0
         reason = (

--- a/tests/ego/test_liveness.py
+++ b/tests/ego/test_liveness.py
@@ -23,12 +23,20 @@ def _iso(minutes_ago: float) -> str:
     return (NOW - timedelta(minutes=minutes_ago)).isoformat()
 
 
-def _live(*, success_min_ago, intent_min_ago, interval=90, gated=False):
+def _live(
+    *,
+    success_min_ago,
+    intent_min_ago,
+    interval=90,
+    gated=False,
+    gated_min_ago=None,
+):
     return compute_ego_liveness(
         last_success_at=None if success_min_ago is None else _iso(success_min_ago),
         last_intent_at=None if intent_min_ago is None else _iso(intent_min_ago),
         current_interval_minutes=interval,
         gated=gated,
+        last_gated_at=None if gated_min_ago is None else _iso(gated_min_ago),
         now=NOW,
     )
 
@@ -79,7 +87,8 @@ def test_transient_lag_under_threshold_not_stalled():
 
 
 def test_floor_applies_to_short_cadence():
-    """A 90m interval yields the 3h floor (4*90m=6h dominates here actually)."""
+    """A 90m interval yields a 6h threshold (4*90m=360m dominates the 3h floor);
+    the floor only wins for cadences shorter than 45m."""
     assert stall_threshold_minutes(90) == max(90 * 4, STALL_FLOOR_MINUTES)
 
 
@@ -97,3 +106,121 @@ def test_degenerate_interval_uses_floor():
     threshold."""
     assert stall_threshold_minutes(0) == STALL_FLOOR_MINUTES
     assert stall_threshold_minutes(-5) == STALL_FLOOR_MINUTES
+
+
+# ---------------------------------------------------------------------------
+# Grace after gate-release — the CLI-approval-release race (C5b)
+#
+# A long CLI-approval hold suppresses stalled via `gated` while it lasts. The
+# false-positive is the RACE at release: `gated` flips False the instant the
+# approval resolves, but `last_success` can't advance until the now-unblocked
+# cycle completes (dispatch + runtime). In that window: not-gated + stale
+# completion + old intent → a false "stalled". Grace = one cadence interval
+# after the ego was last gate-held covers the release→completion gap; a
+# never-gated real deadlock is unaffected.
+# ---------------------------------------------------------------------------
+
+
+def test_recent_gate_release_not_stalled():
+    """Release race: approval just resolved (gated_min_ago=1), completion still
+    stale (6h), intent recent — WITHOUT the grace this reads stalled. Within one
+    interval of the gate release → NOT stalled."""
+    v = _live(
+        success_min_ago=6 * 60 + 30,
+        intent_min_ago=5,
+        interval=90,
+        gated_min_ago=1,
+    )
+    assert v.stalled is False
+
+
+def test_gate_release_grace_expired_is_stalled():
+    """Long after the gate released (2 intervals), a still-stale completion is a
+    genuine stall — grace does not mask a real problem indefinitely."""
+    v = _live(
+        success_min_ago=6 * 60 + 30,
+        intent_min_ago=5,
+        interval=90,
+        gated_min_ago=180,
+    )
+    assert v.stalled is True
+    assert v.reason and "actively cycling" in v.reason
+
+
+def test_never_gated_deadlock_still_stalled():
+    """A real deadlock (never gate-held: last_gated_at None) still fires — the
+    grace only applies to a recently-gated ego."""
+    v = _live(
+        success_min_ago=3 * 24 * 60,
+        intent_min_ago=5,
+        gated_min_ago=None,
+    )
+    assert v.stalled is True
+
+
+def test_gate_release_grace_scales_with_interval():
+    """Grace tracks the cadence interval: the genesis ego (240m) gets a 240m
+    grace, so a release 3h ago is still within grace."""
+    v = _live(
+        success_min_ago=20 * 60,
+        intent_min_ago=5,
+        interval=240,
+        gated_min_ago=180,
+    )
+    assert v.stalled is False  # 180m since release < 240m grace
+
+
+def test_recent_gate_release_healthy_stays_healthy():
+    """Grace never FLIPS a healthy ego to stalled — a recently-gated ego that
+    also completed recently is simply not stalled (lag small)."""
+    v = _live(
+        success_min_ago=40,
+        intent_min_ago=50,
+        interval=90,
+        gated_min_ago=1,
+    )
+    assert v.stalled is False
+
+
+def test_future_last_gated_fails_toward_detection():
+    """A last_gated in the FUTURE (clock skew / corrupt row) must NOT grant
+    grace — a safety monitor fails toward detection, so a real stall fires."""
+    v = _live(
+        success_min_ago=3 * 24 * 60,
+        intent_min_ago=5,
+        interval=90,
+        gated_min_ago=-30,  # 30m in the FUTURE
+    )
+    assert v.stalled is True
+
+
+def test_grace_floor_protects_short_cadence():
+    """A 30m cadence would give a 30m grace — shorter than a cycle can take. The
+    floor (60m) protects it: a release 45m ago is still within grace, one 70m ago
+    (past the floor) is a genuine stall."""
+    within = _live(
+        success_min_ago=6 * 60 + 30,
+        intent_min_ago=5,
+        interval=30,
+        gated_min_ago=45,
+    )
+    assert within.stalled is False  # 45m < 60m floor
+    expired = _live(
+        success_min_ago=6 * 60 + 30,
+        intent_min_ago=5,
+        interval=30,
+        gated_min_ago=70,
+    )
+    assert expired.stalled is True  # 70m > 60m floor
+
+
+def test_degenerate_interval_with_gate_release_uses_floor():
+    """A degenerate (0) interval + last_gated collapses grace to the floor, not
+    zero — a recently-released ego is still excused, never false-fired."""
+    v = _live(
+        success_min_ago=6 * 60 + 30,
+        intent_min_ago=5,
+        interval=0,
+        gated_min_ago=30,
+    )
+    assert v.stalled is False  # 30m < 60m floor (interval 0 → floor)

--- a/tests/test_awareness/test_ego_liveness_check.py
+++ b/tests/test_awareness/test_ego_liveness_check.py
@@ -154,6 +154,44 @@ async def test_gated_ego_not_alerted(db, monkeypatch):
     assert await _open_count(db, USER_SRC) == 0
 
 
+async def _seed_last_gated(db, source, *, minutes_ago):
+    t = (NOW - timedelta(minutes=minutes_ago)).isoformat()
+    await db.execute(
+        "INSERT INTO ego_state (key, value, updated_at) VALUES (?, ?, ?)",
+        (f"last_gated:{source}", t, t),
+    )
+    await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_recent_gate_release_no_alert(db, monkeypatch):
+    """The gate-RELEASE race: a pending CLI approval was just granted, so the
+    ego is no longer `gated`, but `last_success` still trails until the
+    unblocked cycle completes. Recently gate-held (last_gated 1m ago) → within
+    the grace → no alert. WITHOUT the grace this stalled-shaped ego would
+    falsely alert."""
+    _wire(monkeypatch, user_mgr=_mgr(), genesis_mgr=None, gate_on=True)
+    await _seed(db, "user_ego_cycle", success_min_ago=6 * 60 + 30, intent_min_ago=5)
+    await _seed_last_gated(db, "user_ego_cycle", minutes_ago=1)
+
+    await loop._check_ego_liveness(db)
+
+    assert await _open_count(db, USER_SRC) == 0
+
+
+@pytest.mark.asyncio
+async def test_gate_release_grace_expired_still_alerts(db, monkeypatch):
+    """Grace does not mask indefinitely: long after the gate released (well past
+    one interval) a still-stale completion alerts as a genuine stall."""
+    _wire(monkeypatch, user_mgr=_mgr(interval=90), genesis_mgr=None, gate_on=False)
+    await _seed(db, "user_ego_cycle", success_min_ago=6 * 60 + 30, intent_min_ago=5)
+    await _seed_last_gated(db, "user_ego_cycle", minutes_ago=300)  # 5h > 90m grace
+
+    await loop._check_ego_liveness(db)
+
+    assert await _open_count(db, USER_SRC) == 1
+
+
 @pytest.mark.asyncio
 async def test_idempotent_then_resolves_on_recovery(db, monkeypatch):
     """Repeated ticks while stalled keep exactly one open alert; once a cycle


### PR DESCRIPTION
## What

The ego dashboard tile falsely read **"CEO stalled — no completed cycle in 6.0h"** while the ego was healthy. **DB-verified root cause:** a pending `autonomous_cli_fallback` approval held ego-cycle dispatches **12:32→18:47 UTC** (exactly the quiet window; `manual_approval_required=True`). The liveness `gated` exclusion correctly suppressed "stalled" **during** the hold. The false-positive fired only in the **~2–5 min race at gate RELEASE**: `gated` flips False the instant the approval resolves, but `job_health.last_success` can't advance until the now-unblocked cycle dispatches and completes. Intents advance during a hold (`_on_tick` pushes the signal *before* the consumer's approval gate), so in that gap: not-gated + stale-completion + old-intent → false "stalled".

## Fix (grace after gate-release)

Record `last_gated:<tag>` in the cadence consumer whenever `_process_signals` returns "gated" (covers CLI-approval **and** pause/global/circuit holds), and excuse the catch-up window in `compute_ego_liveness` for **one cadence interval** (floored at 60m = one gated-retry gap + one 2400s ego-cycle) after the last hold. A **never-gated real deadlock** (`last_gated` None/old) still fires — the no-masking guarantee rests on a wedged consumer being unable to refresh `last_gated` (it blocks in the cycle lock), documented in-code as a SAFETY INVARIANT. Both liveness consumers (dashboard `routes/ego.py` + awareness alert `loop.py`) updated identically. No schema (rides `ego_state` KV).

## Review + verification

**genesis-architect adversarial review: Ready, no BLOCKER** — the core masking risk is genuinely closed. All SHOULD-FIX/NOTE items landed in-PR: enumerated the new (bounded) blindness window in the coverage-boundary docstring; documented the load-bearing wedge-can't-refresh invariant; **deleted dead restore scaffolding** (`_last_gated_at`/`_restore_last_gated_at` were written-never-read); added a **grace floor** (architect corrected my 7200s premise — the ego-cycle timeout is 2400s/40m); added edge tests (clock-skew fails-toward-detection, grace-floor, degenerate interval).

**E2E replays the exact incident** (sub-second timestamps, lag 360.001m > 360m threshold): old code → `stalled=True` (false alarm reproduced), fix → `stalled=False`, never-gated deadlock → `stalled=True` (detection preserved). TDD verify-RED; **154 tests pass** (19 liveness incl. 3 new edge + 8 awareness incl. 2 new); ruff clean.

Part of the C5 ego-liveness signal-hygiene cluster (sibling of the modal-health-dot fix #1500).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved liveness monitoring to account for recently completed gated cycles.
  * Prevented false stall alerts while an ego completes its post-gate catch-up period.
  * Preserved deadlock detection for egos that have never completed a gated cycle.
  * Added bounded, cadence-aware grace periods with safeguards for unusual timing values.

* **Tests**
  * Expanded coverage for recent and expired gate releases, interval scaling, future timestamps, and healthy states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->