### PR TITLE
perf(memory): offload struggle-detector transcript parse off the event loop

### DIFF
--- a/src/genesis/memory/extraction_job.py
+++ b/src/genesis/memory/extraction_job.py
@@ -611,7 +611,13 @@ async def run_extraction_cycle(
                     score_struggle,
                 )
 
-                spine, haystack = build_spine_and_haystack(transcript_path)
+                # Offload the synchronous transcript read+parse to a thread —
+                # `build_spine_and_haystack` iterates a whole JSONL file
+                # (`for line in f`), which wedged the event loop ~1s at a time
+                # from this background extraction job (recall 503s correlated).
+                spine, haystack = await asyncio.to_thread(
+                    build_spine_and_haystack, transcript_path
+                )
                 struggle_score = score_struggle(spine)
                 struggle_triggered = struggle_score >= STRUGGLE_THRESHOLD
                 if (
@@ -788,7 +794,12 @@ async def _drain_procedure_rebuilds(
 
         await queue.mark_processing(item_id)  # increments attempts
         try:
-            spine, haystack = build_spine_and_haystack(transcript_path)
+            # Offload the synchronous transcript read+parse off the event loop
+            # (see the run_extraction_cycle call site) — a whole-file JSONL
+            # parse must not wedge the loop from this background job.
+            spine, haystack = await asyncio.to_thread(
+                build_spine_and_haystack, transcript_path
+            )
             score = score_struggle(spine)
             stored_ids = await asyncio.wait_for(
                 judge_multi_procedure(

--- a/tests/test_memory/test_extraction_offload.py
+++ b/tests/test_memory/test_extraction_offload.py
@@ -411,3 +411,43 @@ async def test_partial_read_failure_does_not_advance_or_extract(db, tmp_path, mo
     assert row["last_extracted_line"] == 2  # unchanged
     assert row["last_extracted_byte"] == 100  # NOT advanced to 150
     assert extract_calls == []  # partial set discarded, never extracted
+
+
+def test_build_spine_and_haystack_is_never_called_on_the_loop():
+    """`build_spine_and_haystack` reads+parses a whole JSONL transcript (a
+    synchronous `for line in f`) that wedged the event loop ~1s at a time from
+    this background job. Every call site in extraction_job.py must offload it to
+    a thread — i.e. it appears ONLY as an argument to `asyncio.to_thread`, never
+    as a direct call. Guards against a regression re-introducing the blocking
+    call."""
+    import ast
+    from pathlib import Path
+
+    from genesis.memory import extraction_job
+
+    src = Path(extraction_job.__file__).read_text()
+    tree = ast.parse(src)
+
+    direct_calls = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Name)
+        and n.func.id == "build_spine_and_haystack"
+    ]
+    assert direct_calls == [], (
+        f"{len(direct_calls)} direct (on-loop) call(s) to build_spine_and_haystack "
+        "in extraction_job.py — wrap each in `await asyncio.to_thread(...)`."
+    )
+
+    # ...and it IS still used (passed to to_thread), so the guard isn't vacuous.
+    to_thread_args = [
+        arg.id
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "to_thread"
+        for arg in n.args
+        if isinstance(arg, ast.Name)
+    ]
+    assert "build_spine_and_haystack" in to_thread_args


### PR DESCRIPTION
## What

A live loop-stall diagnostic (2026-08-26) named `struggle_detector.py build_spine_and_haystack → for line in f` — a **synchronous whole-file JSONL read+parse** — as wedging the event loop ~1s at a time from the async memory-extraction background job, correlating with the proactive-recall 503s. Both call sites in `run_extraction_cycle` now `await asyncio.to_thread(build_spine_and_haystack, ...)`, mirroring the transcript-delta reads already offloaded in the same function (470cec53).

## Safety

`build_spine_and_haystack` is a **pure function** — function-local state only, module-level reads are read-only constants, I/O is a plain `open()`+line-iterate on a distinct Path, no DB/router/async resource/contextvars. Thread-safe by construction; the DB/router stay on the loop at the call site. `score_struggle(spine)` is left on-loop (bounded in-memory work, not the wedge).

## Verification

genesis-architect adversarial review: **Ready, no BLOCKER / no SHOULD-FIX** — thread-safety verified by full read; exception/return/ordering semantics preserved; the one sync internal caller (`build_action_spine`) is test-only; regression guard sound + non-vacuous. Added an **AST regression guard** (the function may appear only as a `to_thread` arg, never a direct on-loop call) — **verify-RED proven** against origin/main (2 direct calls → guard fails). 83 extraction/procedure/offload tests pass unchanged; ruff clean.

Surfaced during the C5 ego-liveness investigation (the loop-stall that caused the recall 503s); shipped as its own PR since it's an unrelated subsystem. Sibling of #1500 (modal health dot) and #1501 (stall-detector grace).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved transcript processing by moving intensive parsing work off the main event loop.
  * Extraction workflows remain more responsive during whole-transcript processing.

* **Bug Fixes**
  * Prevented synchronous transcript parsing from blocking other asynchronous operations.

* **Tests**
  * Added regression coverage to ensure transcript parsing continues to run without blocking the event loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->