### PR TITLE
fix(contribution): resolve detect-secrets PATH-independently in the secret-scan floor

### DIFF
--- a/src/genesis/contribution/sanitize.py
+++ b/src/genesis/contribution/sanitize.py
@@ -532,11 +532,21 @@ def _run_detect_secrets(parsed: _ParsedDiff) -> tuple[bool, list[Finding]]:
                 timeout=5,
                 check=False,
             )
-        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        except Exception as exc:  # noqa: BLE001 — REQUIRED fail-closed floor: ANY scan failure BLOCKs
             # Fail CLOSED: the REQUIRED secret-scan floor could not run on this
-            # line, so we cannot assert it is secret-free — BLOCK rather than
-            # let an unscanned line pass (the old `continue` was a fail-OPEN hole
-            # through a fail-CLOSED component).
+            # line, so we cannot assert it is secret-free — BLOCK rather than let
+            # an unscanned line pass (the old `continue` was a fail-OPEN hole
+            # through a fail-CLOSED component). Deliberately broad, NOT an
+            # enumerated subtype list — the floor's contract is "any inability to
+            # scan == BLOCK", so timeouts, E2BIG/resource errors (OSError, e.g. a
+            # >128 KB line over MAX_ARG_STRLEN), a NUL byte in the line (ValueError
+            # from execve/text-decode), permission errors, etc. ALL fail closed.
+            # Enumerating subtypes one at a time is whack-a-mole (this is the 2nd
+            # such miss). KeyboardInterrupt/SystemExit are not Exception subclasses
+            # → still propagate; the Finding message carries type(exc).__name__ for
+            # operator triage. (STDIN-feeding to remove the 128 KB argv blind spot
+            # entirely — so oversized lines get scanned rather than BLOCKed — is a
+            # separate hardening follow-up.)
             hits.append(
                 Finding(
                     kind=FindingKind.SECRET,

--- a/src/genesis/contribution/sanitize.py
+++ b/src/genesis/contribution/sanitize.py
@@ -35,6 +35,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from fnmatch import fnmatch
@@ -464,6 +465,23 @@ def _check_fingerprints(
     return hits
 
 
+def _resolve_detect_secrets() -> str | None:
+    """Resolve the detect-secrets executable regardless of the process PATH.
+
+    detect-secrets is a declared CORE dependency, installed into the SAME venv as the
+    running interpreter. But the sanitizer can run in a process whose PATH lacks that
+    venv's bin — e.g. a Claude-Code-spawned MCP child inherits CC's PATH, not the
+    server unit's ``PATH=<venv>/bin:...`` — so a bare ``shutil.which`` returns None
+    and the floor fail-closed BLOCKS every contribution even though the binary IS
+    installed. Prefer the interpreter-relative path (``sys.executable``'s bin dir),
+    then fall back to PATH.
+    """
+    candidate = Path(sys.executable).parent / "detect-secrets"
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return shutil.which("detect-secrets")
+
+
 def _run_detect_secrets(parsed: _ParsedDiff) -> tuple[bool, list[Finding]]:
     """Run `detect-secrets scan --string` on every added line.
 
@@ -473,8 +491,13 @@ def _run_detect_secrets(parsed: _ParsedDiff) -> tuple[bool, list[Finding]]:
     without secret-scanning. bootstrap.sh installs detect-secrets as
     part of the Genesis venv; a missing binary means the install is
     broken and the user must repair it before contributing.
+
+    Resolution is PATH-independent (see ``_resolve_detect_secrets``): the tool can
+    run in a process whose PATH lacks the venv bin, and a bare PATH lookup there
+    would fail-closed-BLOCK every contribution despite the binary being installed.
     """
-    if shutil.which("detect-secrets") is None:
+    ds_bin = _resolve_detect_secrets()
+    if ds_bin is None:
         return True, [
             Finding(
                 kind=FindingKind.SECRET,
@@ -503,7 +526,7 @@ def _run_detect_secrets(parsed: _ParsedDiff) -> tuple[bool, list[Finding]]:
             continue
         try:
             proc = subprocess.run(
-                ["detect-secrets", "scan", "--string", text],
+                [ds_bin, "scan", "--string", text],
                 capture_output=True,
                 text=True,
                 timeout=5,

--- a/tests/test_contribution/test_cli.py
+++ b/tests/test_contribution/test_cli.py
@@ -348,6 +348,9 @@ def test_true_end_to_end_dry_run_happy_path(tmp_path, monkeypatch, capsys):
         return original_run(cmd, *a, **k)
 
     monkeypatch.setattr(sanitize.subprocess, "run", sanitize_fake_run)
+    # Floor now resolves the binary PATH-independently (absolute venv path), which
+    # would bypass the sanitize_fake_run guard — pin it to the bare name.
+    monkeypatch.setattr(sanitize, "_resolve_detect_secrets", lambda: "detect-secrets")
 
     # Mock the version-gate LLM path so no real network call is made.
     monkeypatch.setenv("GROQ_API_KEY", "fake-for-selection")

--- a/tests/test_contribution/test_fingerprints.py
+++ b/tests/test_contribution/test_fingerprints.py
@@ -72,6 +72,9 @@ def _no_external_scanners(monkeypatch):
 
     monkeypatch.setattr(sanitize.shutil, "which", mock_which)
     monkeypatch.setattr(sanitize.subprocess, "run", mock_run)
+    # Floor now resolves the binary PATH-independently (absolute venv path), which
+    # would bypass the mock_run guard — pin it to the bare name so the stub holds.
+    monkeypatch.setattr(sanitize, "_resolve_detect_secrets", lambda: "detect-secrets")
 
 
 def _harvest(home, **kw):

--- a/tests/test_contribution/test_sanitize.py
+++ b/tests/test_contribution/test_sanitize.py
@@ -46,6 +46,10 @@ def no_external_scanners(monkeypatch):
 
     monkeypatch.setattr(sanitize.shutil, "which", mock_which)
     monkeypatch.setattr(sanitize.subprocess, "run", mock_run)
+    # The floor now resolves the binary PATH-independently (venv-relative), so
+    # cmd[0] would be an absolute path and bypass the mock_run guard above. Pin
+    # the resolver to the bare name so the stub keeps intercepting.
+    monkeypatch.setattr(sanitize, "_resolve_detect_secrets", lambda: "detect-secrets")
 
 
 @pytest.fixture
@@ -335,7 +339,8 @@ def test_detect_secrets_runs_when_available(clean_diff, monkeypatch):
 def test_detect_secrets_missing_is_blocking_p1_1(clean_diff, monkeypatch):
     """P1-1 regression: missing detect-secrets binary must fail CLOSED,
     not silently skip. This is the sanitizer's required floor."""
-    monkeypatch.setattr(sanitize.shutil, "which", lambda name: None)
+    # Resolution is now PATH-independent, so drive the resolver, not shutil.which.
+    monkeypatch.setattr(sanitize, "_resolve_detect_secrets", lambda: None)
     r = sanitize.scan_diff(clean_diff)
     assert r.ok is False
     blocking = r.blocking()
@@ -343,6 +348,47 @@ def test_detect_secrets_missing_is_blocking_p1_1(clean_diff, monkeypatch):
         f.scanner == "detect-secrets" and f.detail == "missing_binary"
         for f in blocking
     ), f"expected missing_binary block, got: {blocking}"
+
+
+def test_detect_secrets_oversized_line_fails_closed(clean_diff, monkeypatch):
+    """E2BIG regression: a single added line over Linux MAX_ARG_STRLEN (~128 KB)
+    makes `detect-secrets scan --string <text>` raise OSError from execve. The
+    required floor must fail CLOSED (scan_error BLOCK), not propagate an uncaught
+    OSError that would let the line pass unscanned. (Verify-RED: reverting the
+    OSError addition to the except tuple makes this raise instead of BLOCK.)"""
+
+    def raise_e2big(cmd, *a, **k):
+        if cmd and cmd[0] == "detect-secrets":
+            raise OSError(7, "Argument list too long")
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    # autouse fixture pins _resolve_detect_secrets -> "detect-secrets", so
+    # cmd[0] == "detect-secrets" here.
+    monkeypatch.setattr(sanitize.subprocess, "run", raise_e2big)
+    r = sanitize.scan_diff(clean_diff)
+    assert r.ok is False
+    assert any(
+        f.scanner == "detect-secrets" and f.detail == "scan_error" for f in r.blocking()
+    ), f"expected scan_error BLOCK on OSError, got: {r.blocking()}"
+
+
+def test_detect_secrets_nul_byte_line_fails_closed(clean_diff, monkeypatch):
+    """A NUL byte in an added line makes `subprocess.run(..., text=True)` raise
+    ValueError('embedded null byte') from execve — NOT an OSError. The required
+    floor must still fail CLOSED (scan_error BLOCK). (Verify-RED: an enumerated
+    OSError-only except tuple lets this ValueError propagate uncaught.)"""
+
+    def raise_nul(cmd, *a, **k):
+        if cmd and cmd[0] == "detect-secrets":
+            raise ValueError("embedded null byte")
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    monkeypatch.setattr(sanitize.subprocess, "run", raise_nul)
+    r = sanitize.scan_diff(clean_diff)
+    assert r.ok is False
+    assert any(
+        f.scanner == "detect-secrets" and f.detail == "scan_error" for f in r.blocking()
+    ), f"expected scan_error BLOCK on ValueError, got: {r.blocking()}"
 
 
 def test_rename_only_forbidden_path_blocks_codex_p1():
@@ -719,7 +765,9 @@ def test_scan_prose_scans_all_lines_not_just_first(tmp_path):
 def test_scan_prose_detect_secrets_missing_fails_closed(tmp_path):
     """detect-secrets is the required floor — if the binary is absent, the
     prose scan fails CLOSED (ok=False), never open."""
-    with patch.object(sanitize.shutil, "which", return_value=None):
+    # Resolution is PATH-independent now; force the resolver (not shutil.which) to
+    # None to simulate the absent binary, overriding the autouse fixture's pin.
+    with patch.object(sanitize, "_resolve_detect_secrets", return_value=None):
         r = sanitize.scan_prose(
             "totally benign text", fingerprint_file=tmp_path / "no-fp.txt"
         )

--- a/tests/test_contribution/test_sanitize_real_scanners.py
+++ b/tests/test_contribution/test_sanitize_real_scanners.py
@@ -18,6 +18,7 @@ optional external binary → skipif-guarded.
 
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
@@ -50,6 +51,44 @@ def test_detect_secrets_real_binary_flags_suffixed_true():
     assert any(h.kind == FindingKind.SECRET and h.severity == Severity.BLOCK for h in hits), (
         "detect-secrets must BLOCK on the github token (real output is 'True  (unverified)')"
     )
+
+
+@pytest.mark.skipif(
+    shutil.which("detect-secrets") is None,
+    reason="detect-secrets not installed in the test env",
+)
+def test_detect_secrets_floor_survives_path_without_venv_bin(monkeypatch):
+    """Regression (2026-08-27): the required secret-scan floor fail-closed BLOCKED
+    with detail='missing_binary' whenever the running process's PATH lacked the venv
+    bin — e.g. a CC-spawned MCP child inherits CC's PATH, not the server unit's
+    ``PATH=<venv>/bin:...`` — even though detect-secrets is a declared core dependency
+    installed next to ``sys.executable``. A bare ``shutil.which('detect-secrets')``
+    returned None and blocked EVERY contribution proposal on every install.
+
+    With PATH stripped so bare resolution fails, the floor must STILL resolve
+    detect-secrets (via the interpreter's bin dir) and actually scan — blocking the
+    token, never emitting ``missing_binary``.
+    """
+    monkeypatch.setenv("PATH", "/nonexistent-dir")
+    assert shutil.which("detect-secrets") is None  # precondition: bare PATH now fails
+
+    ran, hits = sanitize._run_detect_secrets(sanitize.parse_diff(_SECRET_DIFF))
+    assert ran
+    assert not any((h.detail or "") == "missing_binary" for h in hits), (
+        "floor must resolve detect-secrets via the venv, not bare PATH"
+    )
+    assert any(h.kind == FindingKind.SECRET and h.severity == Severity.BLOCK for h in hits), (
+        "the floor must still catch the github token with the venv-relative resolve"
+    )
+
+
+def test_resolve_detect_secrets_prefers_interpreter_bin(monkeypatch):
+    """The resolver returns an executable even when PATH is empty (installed as a
+    core dep next to sys.executable)."""
+    monkeypatch.setenv("PATH", "")
+    resolved = sanitize._resolve_detect_secrets()
+    assert resolved is not None
+    assert Path(resolved).is_file() and os.access(resolved, os.X_OK)
 
 
 @pytest.mark.skipif(
@@ -214,7 +253,6 @@ def test_gitleaks_config_error_warns_not_silent_clean(monkeypatch):
     deliberately broken pinned config."""
     if shutil.which("gitleaks") is None:
         pytest.skip("gitleaks not installed")
-    import os
     import tempfile
 
     fd, bad = tempfile.mkstemp(suffix=".gitleaks.toml")

--- a/tests/test_contribution/test_sanitize_real_scanners.py
+++ b/tests/test_contribution/test_sanitize_real_scanners.py
@@ -39,7 +39,9 @@ _SECRET_DIFF = (
 )
 
 
-@pytest.mark.skipif(shutil.which("detect-secrets") is None, reason="detect-secrets not installed")
+@pytest.mark.skipif(
+    sanitize._resolve_detect_secrets() is None, reason="detect-secrets not installed"
+)
 def test_detect_secrets_real_binary_flags_suffixed_true():
     """The REAL detect-secrets '<plugin> : True  (suffix)' output must parse as a hit.
 
@@ -54,7 +56,7 @@ def test_detect_secrets_real_binary_flags_suffixed_true():
 
 
 @pytest.mark.skipif(
-    shutil.which("detect-secrets") is None,
+    sanitize._resolve_detect_secrets() is None,
     reason="detect-secrets not installed in the test env",
 )
 def test_detect_secrets_floor_survives_path_without_venv_bin(monkeypatch):
@@ -120,7 +122,9 @@ def test_gitleaks_loads_repo_config_for_genesis_rules():
     ), "the genesis-aws-account-id rule (only in .gitleaks.toml) must fire with -c"
 
 
-@pytest.mark.skipif(shutil.which("detect-secrets") is None, reason="detect-secrets not installed")
+@pytest.mark.skipif(
+    sanitize._resolve_detect_secrets() is None, reason="detect-secrets not installed"
+)
 def test_scan_diff_end_to_end_blocks_secret():
     """Full scan_diff over a secret-bearing diff must NOT be ok (the floor blocks it)."""
     result = sanitize.scan_diff(_SECRET_DIFF)
@@ -289,7 +293,9 @@ def test_gitleaks_allowlist_path_cannot_hide_secret():
     )
 
 
-@pytest.mark.skipif(shutil.which("detect-secrets") is None, reason="detect-secrets not installed")
+@pytest.mark.skipif(
+    sanitize._resolve_detect_secrets() is None, reason="detect-secrets not installed"
+)
 def test_detect_secrets_output_format_canary():
     """Canary against detect-secrets output-format DRIFT — the exact failure mode
     this PR fixed (a suffix on the verdict token silently voided the parser). If a


### PR DESCRIPTION
## Problem

The required secret-scan floor for community contributions
(`contribution/sanitize.py::_run_detect_secrets`) resolved `detect-secrets` via a
**bare** `shutil.which("detect-secrets")` + `["detect-secrets", ...]` subprocess.

That fails whenever the running process's PATH lacks the venv bin — which is the case
for the foreground `contributor_issue_propose` tool: it runs in a **Claude-Code-spawned
MCP child** that inherits CC's PATH, **not** the `genesis-server` unit's
`PATH=<venv>/bin:...`. So the floor **fail-closed BLOCKED every contribution** with
`detail="missing_binary"` — even though `detect-secrets` is a declared **core dependency**
(`pyproject.toml`) installed in that same venv.

- **Shipped:** 2026-04-11 (v3.0a3) — ~4.5 months.
- **Blast radius:** the foreground contributor tool on **every install** (fails **closed** —
  it blocks proposals, never posts anything unscanned — so a feature-availability bug, not
  a security hole).

## Fix

`_resolve_detect_secrets()` prefers the **interpreter-relative** path
(`Path(sys.executable).parent / "detect-secrets"`, `is_file` + `X_OK`) — PATH-independent —
with `shutil.which` as fallback. Both call sites use the resolved path. This **narrows** the
attacker-influenceable surface (`sys.executable` is fixed at process start and is not
env-mutable like PATH).

## Review / tests

`genesis-security-reviewer`: **no CRITICAL / SHOULD-FIX** — fail-closed preserved on every
branch (missing_binary / timeout / nonzero-exit / parse-failure), no trust-boundary expansion,
no TOCTOU/injection, tests non-vacuous (ran live). TDD verify-RED → GREEN; real-scanner suite
**14/14** (2 new + 12 existing, no regression); ruff clean.

> **Deploy note:** takes effect on the next CC/MCP session start (the foreground contributor
> tool runs in the CC-spawned MCP child; a running session's MCP won't pick it up until restart).
