### PR TITLE
fix(observability): surface subsystems that failed to start (never_started)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   outreach total-cessation is tracked separately, since its heartbeat only runs once
   a messaging channel is configured.)
 
+- **A subsystem that never started no longer reads "healthy" either.** The
+  total-cessation alert above catches a scheduler that ran and then *died*; a
+  subsystem that *failed to start* (its bootstrap init raised, or it registered but
+  never emitted a single pulse) has no heartbeat at all — which looked identical to
+  a fresh, never-run install, so it stayed silent. Now the health check cross-
+  references the persisted bootstrap manifest: an enabled ego (→ critical) or inbox
+  (→ warning) that the manifest shows failed to initialize, or that registered but
+  never pulsed past a boot grace, raises a distinct `subsystem_never_started:<name>`
+  alert and flips the Ego tile to error. It fails benign in every ambiguous case —
+  a fresh install, a deliberately disabled or unconfigured subsystem, or an
+  unreadable manifest never false-alarm — so the only new signal is a genuinely
+  broken start. (Covers ego + inbox; a never-started dashboard thread is out of
+  scope — it isn't a bootstrap-manifest entry.)
+
 - **Worktree sessions now run the main-tree hook scripts, not their branch-frozen
   copies.** The `genesis-hook` launcher resolved each hook from the *current*
   worktree, so a git-tracked hook (security gates included) ran whatever version

--- a/src/genesis/dashboard/routes/ego.py
+++ b/src/genesis/dashboard/routes/ego.py
@@ -176,7 +176,11 @@ async def ego_status():
         ego_heartbeat_stale = status == "overdue"
         ego_heartbeat_age_s = hb.get("age_seconds")
         # unknown (unparseable/future ts) can't confirm liveness → error, not healthy.
-        ego_heartbeat_error = status == "unknown"
+        # never_started (#10): compute_heartbeat_staleness now resolves the manifest-
+        # informed "failed to start / never pulsed" verdict itself → error, not healthy
+        # (this is the case the no_heartbeat boot-grace block below used to catch before
+        # compute owned it; keep flagging it so a dead-at-boot ego tile is never green).
+        ego_heartbeat_error = status in ("unknown", "never_started")
         # no_heartbeat = NO pulse on record. ego emits a "start" pulse at bootstrap
         # (cadence.py:302), so past a short boot-grace window this is a real absence
         # (never-started / lost), NOT a healthy tile. Within the grace window (just

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -1018,6 +1018,11 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 # has already gated this on _subsystem_enabled, so a disabled/
                 # unconfigured subsystem never reaches here. ego CRITICAL, else WARNING;
                 # auto-resolves when the subsystem finally pulses (verdict → alive).
+                # Coverage: only ego + inbox can reach this — both are bootstrap init
+                # steps recorded in the manifest. `dashboard` is in this loop for the
+                # stale/unknown paths only; it is a daemon thread, NOT a manifest entry,
+                # so its verdict is always benign here. A never-started dashboard needs
+                # its own signal (a manifest entry for the thread) — a separate follow-up.
                 _ns_failed = _hb.get("reason") == "init-failed"
                 _detail = (
                     "failed to initialize at bootstrap"

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -1010,6 +1010,34 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 )
                 current_ids.add(alert_id)
                 continue
+            if _status == "never_started":
+                # Registered/expected but failed to start or never pulsed once (#10) —
+                # a dead liveness signal that no_heartbeat (empty-state) would hide.
+                # Distinct id from subsystem_stale (a once-live scheduler that DIED)
+                # and heartbeat_unknown (corrupt pulse). compute_heartbeat_staleness
+                # has already gated this on _subsystem_enabled, so a disabled/
+                # unconfigured subsystem never reaches here. ego CRITICAL, else WARNING;
+                # auto-resolves when the subsystem finally pulses (verdict → alive).
+                _ns_failed = _hb.get("reason") == "init-failed"
+                _detail = (
+                    "failed to initialize at bootstrap"
+                    if _ns_failed
+                    else "started but has never emitted a heartbeat"
+                )
+                alert_id = f"subsystem_never_started:{_hb_name}"
+                alerts.append(
+                    {
+                        "id": alert_id,
+                        "severity": "CRITICAL" if _hb_name == "ego" else "WARNING",
+                        "message": (
+                            f"Subsystem '{_hb_name}' is not running — it {_detail} "
+                            f"(never started); a restart-safe config/code fault, not a "
+                            f"transient stall"
+                        ),
+                    }
+                )
+                current_ids.add(alert_id)
+                continue
             if _status != "overdue":
                 # alive / paused / resuming / no_heartbeat (empty-state) → no alert
                 continue
@@ -1046,12 +1074,18 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
                 from genesis.db.crud import alert_events as _ae
 
                 _open_rows = {r.get("alert_id", ""): r for r in await _ae.list_open(_service._db)}
-                # Preserve BOTH alert families this block can emit for the subsystem
-                # (subsystem_stale: overdue, subsystem_heartbeat_unknown: unreadable) —
-                # otherwise the omitted family flaps (auto-resolved by the reconciler
-                # on the failed tick, re-opened on the next successful one).
+                # Preserve EVERY alert family this per-subsystem block can emit
+                # (subsystem_stale: overdue, subsystem_heartbeat_unknown: unreadable,
+                # subsystem_never_started: failed/silent start) — otherwise the omitted
+                # family flaps (auto-resolved by the reconciler on the failed tick,
+                # re-opened on the next successful one). Keep in lockstep with the
+                # branches above that append to ``alerts``/``current_ids``.
                 for _n in _stale_read_failed:
-                    for _aid in (f"subsystem_stale:{_n}", f"subsystem_heartbeat_unknown:{_n}"):
+                    for _aid in (
+                        f"subsystem_stale:{_n}",
+                        f"subsystem_heartbeat_unknown:{_n}",
+                        f"subsystem_never_started:{_n}",
+                    ):
                         _row = _open_rows.get(_aid)
                         if _row is not None:
                             alerts.append(

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -183,6 +183,15 @@ HEARTBEAT_EXPECTED = {
 # a genuine scheduler death that must still surface. See compute_heartbeat_staleness.
 _PAUSE_GATED_HEARTBEATS = frozenset({"surplus", "inbox"})
 
+# The complete set of statuses ``compute_heartbeat_staleness`` can return. Every
+# consumer that switches on the status string (the alert loop in errors.py, the ego
+# dashboard tile/route, morning_report, the subsystem_heartbeats MCP tool) must handle
+# ALL of these. Locked by test_heartbeat_status_set_is_closed so a new status can't
+# ship while a consumer silently mis-renders it.
+_HEARTBEAT_STATUSES = frozenset(
+    {"alive", "overdue", "paused", "resuming", "no_heartbeat", "unknown", "never_started"}
+)
+
 # How many recent heartbeat rows to scan for the newest USABLE pulse. >1 so a few
 # unparseable / materially-future rows (which sort FIRST under the events table's
 # TEXT ``ORDER BY timestamp DESC`` — a "2099-.." or "not-a-date" value) can't hide
@@ -220,20 +229,41 @@ def _read_global_paused() -> bool:
         return False
 
 
+def _inbox_enabled() -> bool:
+    """Is the inbox monitor configured AND enabled? Mirrors ``runtime/init/inbox.py``:
+    no ``config/inbox_monitor.yaml`` → unconfigured → not enabled; else ``config.enabled``.
+
+    Load-bearing for the never_started verdict: inbox init SWALLOWS its own exceptions
+    (``runtime/init/inbox.py:68``) and returns early when disabled/unconfigured, so a
+    disabled, an unconfigured, AND a genuinely-crashed inbox ALL record the same
+    ``degraded`` manifest value. Gating the never_started alarm on this lets a
+    configured+enabled inbox that failed to start surface, while a deliberately-off or
+    unconfigured inbox (also ``degraded``) stays benign."""
+    from genesis.env import repo_root
+
+    config_path = repo_root() / "config" / "inbox_monitor.yaml"
+    if not config_path.exists():
+        return False
+    from genesis.inbox.config import load_inbox_config
+
+    return bool(load_inbox_config(config_path).enabled)
+
+
 def _subsystem_enabled(name: str) -> bool:
     """Best-effort: is this subsystem configured to run?
 
-    A subsystem DISABLED after it had already pulsed keeps a retained final heartbeat
-    that would otherwise age into a PERMANENT cessation alert (a disabled ego → a
-    permanent CRITICAL) — its stale pulse is intentional, not a death. Defaults True
-    (fail toward surfacing); only subsystems with a real disable switch are checked.
-    (Generalizing to inbox/dashboard + the never-started case is the bootstrap-manifest
-    follow-up.)"""
+    A subsystem DISABLED (or unconfigured) must not raise a cessation/never-started
+    alert: a disabled subsystem's stopped or absent pulse is intentional, not a death.
+    Covers ego (``ego`` config ``.enabled``) and inbox (``inbox_monitor.yaml`` present +
+    ``.enabled``); every other name defaults True (fail toward surfacing — only
+    subsystems with a real disable switch are checked)."""
     try:
         if name == "ego":
             from genesis.ego.config import load_ego_config
 
             return bool(load_ego_config().enabled)
+        if name == "inbox":
+            return _inbox_enabled()
     except Exception:
         logger.debug("subsystem-enabled read failed for %s", name, exc_info=True)
     return True
@@ -294,6 +324,80 @@ async def _post_resume_grace_active(db, *, name: str, now: datetime, interval_s:
     except (aiosqlite.Error, ImportError, AttributeError, TimeoutError):
         logger.debug("post-resume grace check failed for %s", name, exc_info=True)
         return False
+
+
+# Subsystems that emit NO bootstrap "start" pulse — their first heartbeat lands a
+# full check-interval after boot, so "manifest ok + no pulse yet" is the HONEST state
+# until then. Use the overdue threshold (not interval+60) as the never_started grace
+# for these to avoid a boot-time flap. ego/awareness/surplus emit a start pulse at
+# bootstrap, so the tighter interval+60 grace is safe for them.
+_NO_BOOT_PULSE_SUBSYSTEMS = frozenset({"inbox"})
+
+
+def _never_started_grace_s(name: str) -> float:
+    """Grace before a manifest-``ok`` but never-pulsed subsystem reads never_started.
+
+    Mirrors the ego dashboard tile (``interval_s + 60``) for start-pulse subsystems;
+    for a no-boot-pulse subsystem (inbox) uses the overdue threshold so a healthy one
+    that simply hasn't reached its first check interval is not falsely flagged."""
+    interval_s, overdue_s = HEARTBEAT_EXPECTED[name]
+    if name in _NO_BOOT_PULSE_SUBSYSTEMS:
+        return float(overdue_s)
+    return float(interval_s + 60)
+
+
+def _never_started_verdict(
+    name: str, *, now: datetime, paused: bool | None = None
+) -> dict:
+    """No usable pulse exists for *name*: decide fresh-install empty-state (benign
+    ``no_heartbeat``) vs a genuine failed / never-pulsed start (``never_started``),
+    using the persisted bootstrap manifest (``_read_persisted_manifest``).
+
+    Fails BENIGN (``no_heartbeat``) whenever never_started cannot be confidently
+    established — a deliberately-disabled/unconfigured subsystem, a globally-paused
+    pause-gated subsystem, an absent/unreadable manifest, a subsystem absent from the
+    manifest, an unparseable boot timestamp, or a still-within-grace ``ok`` — so a fresh
+    install is never spuriously alarmed. The boot manifest is written cross-process by
+    ``runtime/_capabilities.py`` (this MCP process does not bootstrap), so this is the
+    only liveness-independent signal that tells "failed to start" from "freshly
+    installed, never run"."""
+    benign = {"status": "no_heartbeat", "last_seen": None}
+    # Deliberately-off / unconfigured (ego config, or inbox with no yaml / disabled) —
+    # its absent pulse is intentional, not a death.
+    if not _subsystem_enabled(name):
+        return benign
+    # A pause-gated subsystem (surplus/inbox) emits its pulse only AFTER its loop's
+    # ``if paused: return`` guard, so a globally-paused Genesis legitimately has ZERO
+    # pulses for it — that silence is intentional, not a failed/never-started death.
+    # Mirrors the overdue-branch pause downgrade in compute_heartbeat_staleness.
+    # (ego/dashboard pulse THROUGH pause, so they are never suppressed here.)
+    if name in _PAUSE_GATED_HEARTBEATS:
+        is_paused = paused if paused is not None else _read_global_paused()
+        if is_paused:
+            return benign
+    mf = _read_persisted_manifest()
+    if not mf:
+        return benign  # no manifest at all (missing/unreadable) → protect fresh installs
+    st = (mf.get("manifest") or {}).get(name)
+    if not isinstance(st, str):
+        return benign  # subsystem absent from the manifest → fresh / unknown
+    # init raised or short-circuited: recorded as "failed: <msg>" (prefix) or "degraded".
+    # For an ENABLED subsystem (gated above) that is a genuine failed start → alarm now.
+    if st.startswith("failed") or st == "degraded":
+        return {"status": "never_started", "last_seen": None, "reason": "init-failed"}
+    # Registered ok but has never pulsed: a death only once past a boot grace (its
+    # first pulse may legitimately still be pending just after boot).
+    if st == "ok":
+        persisted_at = parse_iso_utc(mf.get("persisted_at"))
+        if persisted_at is None:
+            return benign  # can't establish the grace clock → benign
+        if (now - persisted_at).total_seconds() > _never_started_grace_s(name):
+            return {
+                "status": "never_started",
+                "last_seen": None,
+                "reason": "started-silent",
+            }
+    return benign  # within grace, or an unrecognized manifest status → benign
 
 
 async def compute_heartbeat_staleness(
@@ -407,9 +511,13 @@ async def compute_heartbeat_staleness(
 
     if last_ts is None or last_dt is None:
         # No usable pulse. A candidate WAS present but unusable → unknown (can't
-        # confirm liveness); nothing at all → no_heartbeat (fresh-install empty-state).
-        status = "unknown" if (saw_db or saw_ring) else "no_heartbeat"
-        return {"status": status, "last_seen": None}
+        # confirm liveness). Nothing at all → either a fresh-install empty-state
+        # (no_heartbeat, benign) OR a subsystem that failed to start / registered
+        # but never pulsed (never_started) — distinguished via the persisted boot
+        # manifest (#10). Fail benign whenever never_started can't be established.
+        if saw_db or saw_ring:
+            return {"status": "unknown", "last_seen": None}
+        return _never_started_verdict(name, now=_now, paused=paused)
 
     age_s = (_now - last_dt).total_seconds()
 

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -186,8 +186,10 @@ _PAUSE_GATED_HEARTBEATS = frozenset({"surplus", "inbox"})
 # The complete set of statuses ``compute_heartbeat_staleness`` can return. Every
 # consumer that switches on the status string (the alert loop in errors.py, the ego
 # dashboard tile/route, morning_report, the subsystem_heartbeats MCP tool) must handle
-# ALL of these. Locked by test_heartbeat_status_set_is_closed so a new status can't
-# ship while a consumer silently mis-renders it.
+# ALL of these. Locked by test_heartbeat_status_set_is_closed: the test pins this set to
+# a literal, so adding a status forces a deliberate edit here + in the test — a prompt to
+# audit the consumers. (It is a forcing function, not a proof that every consumer branches
+# on each member.)
 _HEARTBEAT_STATUSES = frozenset(
     {"alive", "overdue", "paused", "resuming", "no_heartbeat", "unknown", "never_started"}
 )
@@ -354,27 +356,19 @@ def _never_started_verdict(
     using the persisted bootstrap manifest (``_read_persisted_manifest``).
 
     Fails BENIGN (``no_heartbeat``) whenever never_started cannot be confidently
-    established — a deliberately-disabled/unconfigured subsystem, a globally-paused
-    pause-gated subsystem, an absent/unreadable manifest, a subsystem absent from the
-    manifest, an unparseable boot timestamp, or a still-within-grace ``ok`` — so a fresh
-    install is never spuriously alarmed. The boot manifest is written cross-process by
-    ``runtime/_capabilities.py`` (this MCP process does not bootstrap), so this is the
-    only liveness-independent signal that tells "failed to start" from "freshly
-    installed, never run"."""
+    established — a deliberately-disabled/unconfigured subsystem, an absent/unreadable
+    manifest, a subsystem absent from the manifest, an unparseable boot timestamp, a
+    still-within-grace ``ok``, or a paused pause-gated subsystem whose ONLY silence is a
+    stopped pulse (``ok``) — so a fresh install is never spuriously alarmed. A genuine
+    init fault (``failed:``/``degraded``) alarms even while paused, since pause cannot
+    cause it. The boot manifest is written cross-process by ``runtime/_capabilities.py``
+    (this MCP process does not bootstrap), so this is the only liveness-independent
+    signal that tells "failed to start" from "freshly installed, never run"."""
     benign = {"status": "no_heartbeat", "last_seen": None}
     # Deliberately-off / unconfigured (ego config, or inbox with no yaml / disabled) —
     # its absent pulse is intentional, not a death.
     if not _subsystem_enabled(name):
         return benign
-    # A pause-gated subsystem (surplus/inbox) emits its pulse only AFTER its loop's
-    # ``if paused: return`` guard, so a globally-paused Genesis legitimately has ZERO
-    # pulses for it — that silence is intentional, not a failed/never-started death.
-    # Mirrors the overdue-branch pause downgrade in compute_heartbeat_staleness.
-    # (ego/dashboard pulse THROUGH pause, so they are never suppressed here.)
-    if name in _PAUSE_GATED_HEARTBEATS:
-        is_paused = paused if paused is not None else _read_global_paused()
-        if is_paused:
-            return benign
     mf = _read_persisted_manifest()
     if not mf:
         return benign  # no manifest at all (missing/unreadable) → protect fresh installs
@@ -382,12 +376,23 @@ def _never_started_verdict(
     if not isinstance(st, str):
         return benign  # subsystem absent from the manifest → fresh / unknown
     # init raised or short-circuited: recorded as "failed: <msg>" (prefix) or "degraded".
-    # For an ENABLED subsystem (gated above) that is a genuine failed start → alarm now.
+    # A real init fault is INDEPENDENT of pause — pause is a runtime toggle applied AFTER
+    # bootstrap, so it cannot cause an init failure — so surface it even while paused
+    # (suppressing it would silence a genuinely-broken start behind an operator pause).
     if st.startswith("failed") or st == "degraded":
         return {"status": "never_started", "last_seen": None, "reason": "init-failed"}
-    # Registered ok but has never pulsed: a death only once past a boot grace (its
-    # first pulse may legitimately still be pending just after boot).
+    # Registered ok but has never pulsed: a death only once past a boot grace (its first
+    # pulse may legitimately still be pending just after boot).
     if st == "ok":
+        # ONLY the ok-but-silent pulse is excused by pause: a pause-gated subsystem
+        # (surplus/inbox) emits its pulse after its loop's ``if paused: return`` guard,
+        # so a globally-paused Genesis legitimately has zero pulses for it — intentional
+        # silence, not a never-started death. Mirrors the overdue-branch pause downgrade.
+        # (ego/dashboard pulse THROUGH pause, so they are never suppressed.)
+        if name in _PAUSE_GATED_HEARTBEATS:
+            is_paused = paused if paused is not None else _read_global_paused()
+            if is_paused:
+                return benign
         persisted_at = parse_iso_utc(mf.get("persisted_at"))
         if persisted_at is None:
             return benign  # can't establish the grace clock → benign

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -920,10 +920,11 @@ class MorningReportGenerator:
         section entirely. This is not a standing checklist.
         """
         lines: list[str] = []
-        # Subsystems already surfaced via a ``subsystem_stale:<name>`` alert in the
-        # health-alerts block below — the heartbeat-staleness block must not list
-        # them a SECOND time (P2-6 dedup). Populated from the alerts actually
-        # emitted, so it stays correct if the alert set changes.
+        # Subsystems already surfaced via a ``subsystem_stale:<name>`` or
+        # ``subsystem_never_started:<name>`` alert in the health-alerts block below —
+        # the heartbeat-staleness block must not list them a SECOND time (P2-6 dedup).
+        # Populated from the alerts actually emitted, so it stays correct if the alert
+        # set changes.
         stale_alert_names: set[str] = set()
 
         # Health alerts (call sites down, queue depth, resilience warnings)

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -946,7 +946,13 @@ class MorningReportGenerator:
                         f"- **{severity}**: {a.get('message', 'Unknown')} "
                         f"(id: {alert_id})"
                     )
-                    if alert_id.startswith("subsystem_stale:"):
+                    if alert_id.startswith(
+                        ("subsystem_stale:", "subsystem_never_started:")
+                    ):
+                        # never_started is rendered HERE (via the alert), and its
+                        # heartbeat status ("never_started") is not "overdue" so the
+                        # block below skips it anyway — capture the name regardless so
+                        # the dedup set stays complete if that block ever widens.
                         stale_alert_names.add(alert_id.split(":", 1)[1])
         except Exception:
             logger.warning("Failed to query health alerts for morning report", exc_info=True)

--- a/src/genesis/sentinel/remediation_map.py
+++ b/src/genesis/sentinel/remediation_map.py
@@ -294,6 +294,19 @@ UNMAPPED_BY_DESIGN: dict[str, str] = {
         "Distinct from subsystem_stale: (which asserts a probable DEATH) — this "
         "asserts only that we cannot tell."
     ),
+    "subsystem_never_started:": (
+        "A heartbeat-emitting subsystem (ego/inbox) that its persisted bootstrap "
+        "manifest shows FAILED TO INITIALIZE, or that registered ok but has never "
+        "emitted a single pulse past a boot grace (#10) — it is not running at all. "
+        "By construction NOT restart-remediable: a never-started subsystem is a "
+        "config/code defect (a raised init, a missing prerequisite), and a "
+        "container.services restart would either reproduce the same failure or "
+        "restart-loop (contrast job_stale:, a recoverable wedge). Gated on "
+        "_subsystem_enabled, so a deliberately-disabled/unconfigured subsystem never "
+        "raises it. Surface-only (ego CRITICAL, else WARNING) + a red ego tile for a "
+        "human to fix at the source; auto-resolves when the subsystem finally pulses. "
+        "Distinct from subsystem_stale: (a once-live scheduler that DIED)."
+    ),
 }
 
 

--- a/tests/test_dashboard/test_ego_routes.py
+++ b/tests/test_dashboard/test_ego_routes.py
@@ -453,6 +453,22 @@ class TestEgoStatusHeartbeat:
         assert data["ego_heartbeat_stale"] is False
         assert data["ego_heartbeat_error"] is True
 
+    def test_never_started_is_error(self, client):
+        """compute now owns the manifest-informed never_started verdict (#10); the
+        tile must flag it as error (not green) — the case the no_heartbeat boot-grace
+        block used to catch before compute owned it."""
+        resp = _status_response(
+            client,
+            hb_return={
+                "status": "never_started",
+                "last_seen": None,
+                "reason": "started-silent",
+            },
+        )
+        data = resp.get_json()
+        assert data["ego_heartbeat_stale"] is False
+        assert data["ego_heartbeat_error"] is True
+
     def test_no_heartbeat_degraded_boot_is_error(self, client):
         """No boot stamp (degraded boot) → no grace → fail-loud to error (P2-5)."""
         resp = _status_response(

--- a/tests/test_mcp/test_standalone_health.py
+++ b/tests/test_mcp/test_standalone_health.py
@@ -468,6 +468,17 @@ class TestStandaloneServiceDetection:
 class TestHeartbeatQueriesWithDB:
     """Test that heartbeat queries work when DB is connected."""
 
+    @pytest.fixture(autouse=True)
+    def _no_real_bootstrap_manifest(self):
+        """Hermetic: compute_heartbeat_staleness reads ~/.genesis/bootstrap_manifest.json
+        for the never_started verdict (#10). This box HAS that file; CI does not. Patch
+        it to None so a no-pulse subsystem reads the fresh-install empty state
+        (no_heartbeat), the behavior these DB-pulse tests assert — never the real file."""
+        from unittest.mock import patch
+
+        with patch("genesis.mcp.health.manifest._read_persisted_manifest", return_value=None):
+            yield
+
     async def test_heartbeats_find_events_in_db(self, db) -> None:
         """With a real DB containing heartbeat events, subsystem_heartbeats
         should return alive status."""

--- a/tests/test_mcp/test_subsystem_staleness.py
+++ b/tests/test_mcp/test_subsystem_staleness.py
@@ -49,15 +49,20 @@ async def _seed_heartbeat(db, subsystem: str, age_seconds: float) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _no_real_bootstrap_manifest():
+def _no_real_bootstrap_manifest(tmp_path):
     """Hermetic default: no persisted bootstrap manifest.
 
     ``compute_heartbeat_staleness`` reads ``~/.genesis/bootstrap_manifest.json``
-    (via ``_read_persisted_manifest``) to compute the never_started verdict. This
-    box HAS that file from its running server; CI does not. Patch it to None by
-    default so every test sees the fresh-install empty state (benign) unless it
-    explicitly injects a manifest — install-agnostic + no cross-test leakage."""
-    with patch("genesis.mcp.health.manifest._read_persisted_manifest", return_value=None):
+    (via ``_read_persisted_manifest`` → ``_MANIFEST_FILE``) to compute the
+    never_started verdict. This box HAS that file from its running server; CI does
+    not. Point ``_MANIFEST_FILE`` at an ABSENT path so the REAL reader returns None
+    (fresh-install empty state, benign) unless a test explicitly injects a manifest
+    — install-agnostic + no cross-test leakage. Patching the file path (not the
+    reader) keeps the real read+parse chain live for the integration test."""
+    from genesis.mcp.health import manifest as _m
+
+    absent = tmp_path / "no_such_bootstrap_manifest.json"  # intentionally does not exist
+    with patch.object(_m, "_MANIFEST_FILE", absent):
         yield
 
 
@@ -1006,6 +1011,22 @@ async def test_not_paused_inbox_ok_silent_still_never_started(db):
 
 
 @pytest.mark.asyncio
+async def test_paused_inbox_degraded_still_never_started(db):
+    """Pause excuses only a stopped PULSE, never a real init fault. A paused inbox whose
+    manifest shows 'degraded' (init failed/short-circuited) must STILL surface
+    never_started/init-failed — pause is applied after boot and cannot cause it."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    with (
+        _patch_manifest({"inbox": "degraded"}),
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
+    ):
+        hb = await compute_heartbeat_staleness("inbox", db=db, paused=True)
+    assert hb["status"] == "never_started"
+    assert hb.get("reason") == "init-failed"
+
+
+@pytest.mark.asyncio
 async def test_pulse_present_overrides_never_started(db):
     """never_started only fires with NO usable pulse — a recent pulse → alive even if
     the manifest says degraded."""
@@ -1016,6 +1037,48 @@ async def test_pulse_present_overrides_never_started(db):
     ):
         hb = await _compute("inbox", db)
     assert hb["status"] == "alive"
+
+
+@pytest.mark.asyncio
+async def test_never_started_integration_real_manifest_file(db, tmp_path):
+    """E2E through the REAL _read_persisted_manifest file read (NOT mocked): a real
+    bootstrap_manifest.json on disk with ego=ok + an old persisted_at and no pulse →
+    never_started/started-silent. Proves the file → JSON parse → verdict chain end to
+    end (the unit tests inject the manifest dict; this exercises the actual reader,
+    confirming the on-disk key shape {manifest, persisted_at} matches the verdict)."""
+    import json as _json
+
+    from genesis.mcp.health import manifest as _m
+
+    manifest_file = tmp_path / "bootstrap_manifest.json"
+    manifest_file.write_text(
+        _json.dumps({"manifest": {"ego": "ok"}, "persisted_at": _iso_ago(_GRACE_EGO_S + 120)})
+    )
+    with patch.object(_m, "_MANIFEST_FILE", manifest_file):  # real reader, real file
+        hb = await _m.compute_heartbeat_staleness("ego", db=db, paused=False)
+    assert hb["status"] == "never_started"
+    assert hb.get("reason") == "started-silent"
+
+
+@pytest.mark.asyncio
+async def test_never_started_integration_real_manifest_degraded_inbox(db, tmp_path):
+    """E2E real-file read: inbox recorded 'degraded' (the real failed/short-circuited
+    init shape) + enabled → never_started/init-failed, straight off disk."""
+    import json as _json
+
+    from genesis.mcp.health import manifest as _m
+
+    manifest_file = tmp_path / "bootstrap_manifest.json"
+    manifest_file.write_text(
+        _json.dumps({"manifest": {"inbox": "degraded"}, "persisted_at": _iso_ago(100)})
+    )
+    with (
+        patch.object(_m, "_MANIFEST_FILE", manifest_file),
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
+    ):
+        hb = await _m.compute_heartbeat_staleness("inbox", db=db, paused=False)
+    assert hb["status"] == "never_started"
+    assert hb.get("reason") == "init-failed"
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp/test_subsystem_staleness.py
+++ b/tests/test_mcp/test_subsystem_staleness.py
@@ -48,6 +48,29 @@ async def _seed_heartbeat(db, subsystem: str, age_seconds: float) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _no_real_bootstrap_manifest():
+    """Hermetic default: no persisted bootstrap manifest.
+
+    ``compute_heartbeat_staleness`` reads ``~/.genesis/bootstrap_manifest.json``
+    (via ``_read_persisted_manifest``) to compute the never_started verdict. This
+    box HAS that file from its running server; CI does not. Patch it to None by
+    default so every test sees the fresh-install empty state (benign) unless it
+    explicitly injects a manifest — install-agnostic + no cross-test leakage."""
+    with patch("genesis.mcp.health.manifest._read_persisted_manifest", return_value=None):
+        yield
+
+
+def _manifest(mapping: dict[str, str], *, persisted_age_s: float = 0.0) -> dict:
+    """A persisted-manifest dict as ``_read_persisted_manifest`` would return it."""
+    return {
+        "bootstrapped": False,
+        "manifest": mapping,
+        "source": "persisted_manifest",
+        "persisted_at": _iso_ago(persisted_age_s),
+    }
+
+
 # ── compute_heartbeat_staleness (the shared signal) ──────────────────────────
 
 
@@ -330,18 +353,51 @@ async def test_no_resume_event_no_grace(db):
 # ── #973 disabled-subsystem suppression ──────────────────────────────────────
 
 
-def test_subsystem_enabled_defaults_true_and_reads_ego_config():
-    """_subsystem_enabled defaults True (fail toward surfacing) and honors ego's
-    disable switch (#973)."""
+def test_subsystem_enabled_reads_ego_and_inbox_config():
+    """_subsystem_enabled defaults True (fail toward surfacing) but honors the ego AND
+    inbox disable switches — a disabled/unconfigured subsystem must not alarm (#973 +
+    never-started gating)."""
     from types import SimpleNamespace as _NS
 
     from genesis.mcp.health import manifest as _m
 
-    assert _m._subsystem_enabled("inbox") is True  # no disable switch → True
+    # A subsystem with no disable switch still defaults True.
+    assert _m._subsystem_enabled("dashboard") is True
+    # ego honors its config switch.
     with patch("genesis.ego.config.load_ego_config", return_value=_NS(enabled=False)):
         assert _m._subsystem_enabled("ego") is False
     with patch("genesis.ego.config.load_ego_config", return_value=_NS(enabled=True)):
         assert _m._subsystem_enabled("ego") is True
+    # inbox now honors config presence + .enabled (was unconditionally True before).
+    with patch("genesis.mcp.health.manifest._inbox_enabled", return_value=False):
+        assert _m._subsystem_enabled("inbox") is False
+    with patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True):
+        assert _m._subsystem_enabled("inbox") is True
+
+
+def test_inbox_enabled_reads_config(tmp_path):
+    """_inbox_enabled: no yaml → False (unconfigured); present + enabled honored."""
+    from types import SimpleNamespace as _NS
+
+    from genesis.mcp.health import manifest as _m
+
+    # No config/inbox_monitor.yaml under the (empty) repo root → not configured.
+    with patch("genesis.env.repo_root", return_value=tmp_path):
+        assert _m._inbox_enabled() is False
+    # Present + enabled=True → True; enabled=False → False.
+    cfg_dir = tmp_path / "config"
+    cfg_dir.mkdir()
+    (cfg_dir / "inbox_monitor.yaml").write_text("inbox:\n  enabled: true\n")
+    with (
+        patch("genesis.env.repo_root", return_value=tmp_path),
+        patch("genesis.inbox.config.load_inbox_config", return_value=_NS(enabled=True)),
+    ):
+        assert _m._inbox_enabled() is True
+    with (
+        patch("genesis.env.repo_root", return_value=tmp_path),
+        patch("genesis.inbox.config.load_inbox_config", return_value=_NS(enabled=False)),
+    ):
+        assert _m._inbox_enabled() is False
 
 
 @pytest.mark.asyncio
@@ -418,6 +474,10 @@ async def _run_alerts_with_db(db, *, paused: bool = False):
         patch("genesis.mcp.health_mcp._alert_history", {}),
         patch("genesis.mcp.health_mcp._event_bus", None),
         patch("genesis.mcp.health.manifest._read_global_paused", return_value=paused),
+        # Hermetic default: treat inbox as configured+enabled so existing
+        # subsystem_stale:inbox tests don't depend on the repo's inbox_monitor.yaml.
+        # A test wanting a disabled inbox overrides this or patches _subsystem_enabled.
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
     ):
         from genesis.mcp.health.errors import _impl_health_alerts
 
@@ -661,6 +721,37 @@ async def test_read_error_preserves_open_unknown_alert(db):
 
 
 @pytest.mark.asyncio
+async def test_read_error_preserves_open_never_started_alert(db):
+    """SF-2: the fail-open guard must preserve the subsystem_never_started family too —
+    an open never_started alert (CRITICAL ego) must not flap (auto-resolve then reopen)
+    on a transient staleness-read-failure tick."""
+    from genesis.db.crud import alert_events as ae_crud
+
+    await ae_crud.reconcile_open_set(
+        db,
+        active=[
+            {
+                "alert_id": "subsystem_never_started:ego",
+                "source": "health",
+                "severity": "CRITICAL",
+                "message": "ego never started",
+            }
+        ],
+        now=datetime.now(UTC).isoformat(),
+    )
+
+    async def _raise_for_ego(name, **kwargs):
+        if name == "ego":
+            raise aiosqlite.OperationalError("boom")
+        return {"status": "alive", "last_seen": _iso_ago(10), "age_seconds": 10.0}
+
+    alerts, current_ids = await _compute_alerts_with_hb_side_effect(db, _raise_for_ego)
+    alert_ids = {a["id"] for a in alerts}
+    assert "subsystem_never_started:ego" in alert_ids  # preserved, not flapped
+    assert "subsystem_never_started:ego" in current_ids
+
+
+@pytest.mark.asyncio
 async def test_freshest_ignores_corrupt_future_db_row(db):
     """N-2: a corrupt FUTURE db heartbeat must not mask a valid fresh ring pulse —
     the subsystem reads alive, not a false unknown."""
@@ -750,3 +841,232 @@ async def test_gc_keeps_only_newest_and_still_prunes_older(db):
     )
     assert len(ego_rows) == 1  # only the newest ego pulse kept
     assert len(surplus_rows) == 1  # the sole surplus pulse kept
+
+
+# ── never_started detection (failed-start / started-but-silent) #10 ───────────
+
+_GRACE_EGO_S = 300 + 60  # HEARTBEAT_EXPECTED["ego"][0] + 60
+
+
+async def _compute(name, db):
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    # paused=False keeps the never_started verdict deterministic without touching the
+    # real ~/.genesis/paused.json (a pause test calls compute directly with paused=True).
+    return await compute_heartbeat_staleness(name, db=db, paused=False)
+
+
+def _patch_manifest(mapping, *, persisted_age_s=0.0):
+    return patch(
+        "genesis.mcp.health.manifest._read_persisted_manifest",
+        return_value=_manifest(mapping, persisted_age_s=persisted_age_s),
+    )
+
+
+@pytest.mark.asyncio
+async def test_never_started_ego_ok_but_silent_past_grace(db):
+    """manifest ego=ok, no pulse, past interval+60 grace → never_started/started-silent."""
+    with _patch_manifest({"ego": "ok"}, persisted_age_s=_GRACE_EGO_S + 60):
+        hb = await _compute("ego", db)
+    assert hb["status"] == "never_started"
+    assert hb.get("reason") == "started-silent"
+
+
+@pytest.mark.asyncio
+async def test_never_started_ego_within_grace_is_benign(db):
+    """Just after boot (within grace), an unpulsed ego is benign, not never_started."""
+    with _patch_manifest({"ego": "ok"}, persisted_age_s=10):
+        hb = await _compute("ego", db)
+    assert hb["status"] == "no_heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_never_started_inbox_degraded_enabled(db):
+    """A configured+enabled inbox recorded 'degraded' (init failed/short-circuited) →
+    never_started/init-failed immediately (no grace)."""
+    with (
+        _patch_manifest({"inbox": "degraded"}),
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
+    ):
+        hb = await _compute("inbox", db)
+    assert hb["status"] == "never_started"
+    assert hb.get("reason") == "init-failed"
+
+
+@pytest.mark.asyncio
+async def test_never_started_inbox_failed_prefix_enabled(db):
+    """manifest stores 'failed: <msg>' with a prefix — matched via startswith."""
+    with (
+        _patch_manifest({"inbox": "failed: boom"}),
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
+    ):
+        hb = await _compute("inbox", db)
+    assert hb["status"] == "never_started"
+    assert hb.get("reason") == "init-failed"
+
+
+@pytest.mark.asyncio
+async def test_degraded_disabled_inbox_is_benign(db):
+    """A DISABLED/unconfigured inbox is ALSO 'degraded' — must stay benign, not alarm."""
+    with (
+        _patch_manifest({"inbox": "degraded"}),
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=False),
+    ):
+        hb = await _compute("inbox", db)
+    assert hb["status"] == "no_heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_never_started_absent_from_manifest_is_benign(db):
+    """A subsystem not present in the manifest → fresh-install empty state, benign."""
+    with _patch_manifest({}):  # no ego key
+        hb = await _compute("ego", db)
+    assert hb["status"] == "no_heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_never_started_manifest_none_is_benign(db):
+    """No persisted manifest at all (missing/unreadable) → benign (protect fresh installs)."""
+    with patch("genesis.mcp.health.manifest._read_persisted_manifest", return_value=None):
+        hb = await _compute("ego", db)
+    assert hb["status"] == "no_heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_never_started_persisted_at_none_is_benign_no_crash(db):
+    """manifest ok but persisted_at missing (older build/partial write) → benign, no crash."""
+    bad = {
+        "bootstrapped": False,
+        "manifest": {"ego": "ok"},
+        "source": "persisted_manifest",
+        "persisted_at": None,
+    }
+    with patch("genesis.mcp.health.manifest._read_persisted_manifest", return_value=bad):
+        hb = await _compute("ego", db)
+    assert hb["status"] == "no_heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_never_started_persisted_at_unparseable_is_benign(db):
+    bad = {"manifest": {"ego": "ok"}, "persisted_at": "not-a-date"}
+    with patch("genesis.mcp.health.manifest._read_persisted_manifest", return_value=bad):
+        hb = await _compute("ego", db)
+    assert hb["status"] == "no_heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_inbox_ok_silent_uses_overdue_grace_no_flap(db):
+    """inbox emits no boot pulse; its first real pulse is ~1800s in. A no-pulse read at
+    2000s (past interval+60=1860 but within overdue_s=7200) must stay benign — no flap."""
+    with (
+        _patch_manifest({"inbox": "ok"}, persisted_age_s=2000),
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
+    ):
+        hb = await _compute("inbox", db)
+    assert hb["status"] == "no_heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_inbox_ok_silent_past_overdue_grace_never_started(db):
+    with (
+        _patch_manifest({"inbox": "ok"}, persisted_age_s=8000),  # > overdue_s 7200
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
+    ):
+        hb = await _compute("inbox", db)
+    assert hb["status"] == "never_started"
+    assert hb.get("reason") == "started-silent"
+
+
+@pytest.mark.asyncio
+async def test_paused_inbox_ok_silent_is_benign(db):
+    """inbox is pause-gated (its pulse stops behind ``if paused: return``) and emits no
+    boot pulse — a globally-PAUSED Genesis legitimately has zero inbox pulses, so an
+    ok-but-silent inbox past its grace must NOT false-fire never_started while paused."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    with (
+        _patch_manifest({"inbox": "ok"}, persisted_age_s=8000),  # > overdue_s
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
+    ):
+        hb = await compute_heartbeat_staleness("inbox", db=db, paused=True)
+    assert hb["status"] == "no_heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_not_paused_inbox_ok_silent_still_never_started(db):
+    """The pause suppression is pause-specific — NOT paused, same shape → never_started."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    with (
+        _patch_manifest({"inbox": "ok"}, persisted_age_s=8000),
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
+    ):
+        hb = await compute_heartbeat_staleness("inbox", db=db, paused=False)
+    assert hb["status"] == "never_started"
+
+
+@pytest.mark.asyncio
+async def test_pulse_present_overrides_never_started(db):
+    """never_started only fires with NO usable pulse — a recent pulse → alive even if
+    the manifest says degraded."""
+    await _seed_heartbeat(db, "inbox", age_seconds=10)
+    with (
+        _patch_manifest({"inbox": "degraded"}),
+        patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
+    ):
+        hb = await _compute("inbox", db)
+    assert hb["status"] == "alive"
+
+
+@pytest.mark.asyncio
+async def test_alert_never_started_ego_critical(db):
+    with _patch_manifest({"ego": "ok"}, persisted_age_s=_GRACE_EGO_S + 60):
+        alerts = await _run_alerts_with_db(db)
+    a = next((a for a in alerts if a["id"] == "subsystem_never_started:ego"), None)
+    assert a is not None
+    assert a["severity"] == "CRITICAL"
+
+
+@pytest.mark.asyncio
+async def test_alert_never_started_inbox_warning(db):
+    # _run_alerts_with_db defaults _inbox_enabled True.
+    with _patch_manifest({"inbox": "degraded"}):
+        alerts = await _run_alerts_with_db(db)
+    a = next((a for a in alerts if a["id"] == "subsystem_never_started:inbox"), None)
+    assert a is not None
+    assert a["severity"] == "WARNING"
+
+
+@pytest.mark.asyncio
+async def test_never_started_alert_absent_when_healthy(db):
+    """No manifest (autouse None) + fresh pulses → zero never_started alerts."""
+    await _seed_heartbeat(db, "ego", age_seconds=10)
+    await _seed_heartbeat(db, "inbox", age_seconds=10)
+    alerts = await _run_alerts_with_db(db)
+    assert not [a for a in alerts if str(a["id"]).startswith("subsystem_never_started:")]
+
+
+@pytest.mark.asyncio
+async def test_never_started_resolves_on_pulse(db):
+    """Once the subsystem pulses, compute flips to alive → no never_started alert (the
+    reconcile writer then stamps resolved_at). Auto-resolve is by absence from the set."""
+    await _seed_heartbeat(db, "ego", age_seconds=10)  # ego has now pulsed
+    with _patch_manifest({"ego": "ok"}, persisted_age_s=_GRACE_EGO_S + 60):
+        alerts = await _run_alerts_with_db(db)
+    assert not [a for a in alerts if a["id"] == "subsystem_never_started:ego"]
+
+
+def test_heartbeat_status_set_is_closed():
+    """Lock the full status set so a new status can't ship while a consumer that
+    switches on status silently mis-renders it."""
+    from genesis.mcp.health.manifest import _HEARTBEAT_STATUSES
+
+    assert {
+        "alive",
+        "overdue",
+        "paused",
+        "resuming",
+        "no_heartbeat",
+        "unknown",
+        "never_started",
+    } == _HEARTBEAT_STATUSES

--- a/tests/test_outreach/test_morning_report.py
+++ b/tests/test_outreach/test_morning_report.py
@@ -109,6 +109,50 @@ async def test_critical_issues_dedupes_subsystem_stale(db, mock_health, mock_dra
 
 
 @pytest.mark.asyncio
+async def test_critical_issues_surfaces_and_dedupes_subsystem_never_started(
+    db, mock_health, mock_drafter
+):
+    """A subsystem_never_started:<name> alert (the new never-started liveness id) is
+    surfaced by the morning report (it passes the WARNING+ filter, it is not a
+    call_site: alert) and its name is captured into the dedup set so the
+    heartbeat-staleness block never lists it a SECOND time. A subsystem with a plain
+    overdue heartbeat but no alert is still surfaced once by the hb block."""
+    gen = MorningReportGenerator(mock_health, db, mock_drafter)
+    alerts = [
+        {
+            "id": "subsystem_never_started:inbox",
+            "severity": "WARNING",
+            "message": "Subsystem 'inbox' never started — enabled but no heartbeat since boot",
+        },
+    ]
+    # inbox's heartbeat verdict is "never_started" (mutually exclusive with overdue —
+    # never_started requires zero pulses). The hb block only renders "overdue", so the
+    # dedup capture is defensive here; assert inbox is NOT double-listed regardless.
+    heartbeats = {
+        "inbox": {"status": "never_started", "last_seen": None, "reason": "init-failed"},
+        "surplus": {"status": "overdue", "age_seconds": 5000, "last_seen": "y"},
+    }
+    with (
+        patch(
+            "genesis.mcp.health_mcp._impl_health_alerts",
+            new=AsyncMock(return_value=alerts),
+        ),
+        patch(
+            "genesis.mcp.health.manifest._impl_subsystem_heartbeats",
+            new=AsyncMock(return_value=heartbeats),
+        ),
+    ):
+        text = await gen._get_critical_issues()
+
+    assert text is not None
+    # inbox is surfaced exactly once — via its never_started alert line.
+    assert text.count("'inbox'") == 1
+    assert "subsystem_never_started:inbox" in text
+    # surplus has a heartbeat but no alert → still surfaced once by the hb block.
+    assert "'surplus'" in text
+
+
+@pytest.mark.asyncio
 async def test_generate_calls_health_snapshot(db, mock_health, mock_drafter):
     gen = MorningReportGenerator(mock_health, db, mock_drafter)
     await gen.generate()


### PR DESCRIPTION
## Problem

The total-cessation alert (surface a subsystem whose scheduler ran and then **died**) does not
cover a subsystem that **failed to start** — its init raised, or it registered but never emitted a
single heartbeat. With zero pulses on record it reads as benign `no_heartbeat`, indistinguishable
from a fresh, never-run install, so a dead-at-boot ego or inbox stays silent. This is the last hole
in the "a dead liveness signal must not read healthy" thesis.

## Change

`compute_heartbeat_staleness` now cross-references the persisted bootstrap manifest
(`~/.genesis/bootstrap_manifest.json`, written cross-process at boot) when a subsystem has no pulse,
to tell a genuine failed / never-pulsed start from an empty fresh install:

- manifest shows the subsystem **`failed:`/`degraded`** (init raised or left its attr unset) → new
  status `never_started` (reason `init-failed`) — immediately.
- manifest shows **`ok`** but no pulse past a boot grace → `never_started` (reason `started-silent`).
- absent / unreadable manifest, subsystem absent, unparseable boot timestamp, within grace, disabled
  or unconfigured, or (for a pause-gated subsystem) merely paused-and-silent → stays benign
  `no_heartbeat`.

A distinct `subsystem_never_started:<name>` alert is raised (ego **CRITICAL**, inbox **WARNING**) and
the ego dashboard tile flips to error. It auto-resolves when the subsystem finally pulses.

**Fail direction:** benign in every ambiguous case — a fresh install, a disabled/unconfigured
subsystem, or a paused pause-gated subsystem whose only silence is a stopped pulse never false-alarm.
A genuine init fault surfaces even while paused (pause is applied after boot and cannot cause it).

**Coverage:** ego + inbox (both are bootstrap init steps recorded in the manifest). Inbox is gated on
its config (yaml present + enabled) and uses its overdue threshold as the boot grace since it emits no
start pulse. A never-started **dashboard** thread is out of scope — it is a daemon thread, not a
manifest entry, and needs its own signal (tracked as a follow-up).

## Consumers updated

Alert loop (`errors.py`), ego tile route, morning-report dedup, and the Sentinel remediation map
(new alert id documented non-remediable — a never-started subsystem is a config/code fault, restart
won't help). The new id is preserved across transient staleness-read failures so it cannot flap. A
closed status-set constant + lock test guards future drift.

## Testing

- Unit + real-file **integration** tests (drive an actual on-disk `bootstrap_manifest.json` through
  the real reader → verdict), including the full manifest × enabled × paused × grace state space, the
  pause scoping (a real init fault is NOT hidden by pause), and the fail-open re-emit preservation.
- Read-only sanity check against live data confirmed healthy subsystems return `alive` with zero
  false positives.

## Deploy path

Runtime code — `git pull` + server restart. Post-deploy live E2E: seed the manifest with an enabled
subsystem + delete its pulses + backdate `persisted_at` past grace → confirm `subsystem_never_started`
appears and auto-resolves on a fresh pulse.

---

Reviewed adversarially over two rounds (fresh-context architect); three real defects found and fixed
(paused-inbox false positive, an alert-flap on read failure, and an over-scoped pause suppression that
would have hidden a real init fault). Independent-model Codex review is pending on its usage quota.

Ledger: 8cc9275d72e144e5a7905945cb24624a

Cross-reference: origin follow-up `00958eb5` (subsystem-liveness handoff, #10).
