### PR TITLE
fix(observability): heartbeat GC deletes clock-skewed future rows instead of starving liveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,27 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Heartbeat GC no longer lets a clock-skewed future row starve a subsystem's
+  liveness signal.** The `keep_latest_per_subsystem` heartbeat GC
+  (`db/crud/events.py::prune`) kept the row equal to the per-subsystem
+  `MAX(timestamp)`. Because `timestamp` is ISO **text**, a corrupt/clock-skewed
+  future row (e.g. `2099-…`) sorts as that MAX and survived the retention window
+  forever, while genuine pulses aged out and were deleted — leaving
+  `compute_heartbeat_staleness` with only the future row, which it rejects as
+  materially-future, degrading the verdict to a permanent `unknown` (a false
+  "can't tell" for a subsystem that may be perfectly healthy or truthfully
+  stale). The GC now uses two distinct future bounds: (a) it deletes only
+  *implausibly*-far-future rows (> 1 day ahead — corrupt beyond any clock-skew
+  recovery), and (b) it anchors the "keep newest" on the newest row within the
+  read-side display tolerance (`observability.liveness.FUTURE_SKEW_TOLERANCE_MINUTES`),
+  so the preserved pulse is one the staleness read accepts (`alive`/`overdue`). The
+  wide destructive horizon is deliberate: a *modestly*-future row ages into validity
+  instead of being destroyed, and a **backward** clock skew at GC time cannot delete
+  genuinely-recent pulses. A write-time clamp was considered and rejected: the only
+  production trigger is host clock skew, against which a clamp is ineffective (at
+  write time `now()` *is* the skewed value), so the retention layer — re-evaluated at
+  GC time — is the layer that actually closes the hole.
+
 - **The run_in_background pipe guard no longer false-blocks a `|` inside a quoted
   argument.** The old inline check (`${CMD//||/ }` then `grep -qF "|"`) blocked any
   literal `|`, so backgrounding `gh api … --jq '.[] | .x'` or `grep -F '|' file`

--- a/src/genesis/db/crud/events.py
+++ b/src/genesis/db/crud/events.py
@@ -5,9 +5,18 @@ from __future__ import annotations
 import contextlib
 import json
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import aiosqlite
+
+# A heartbeat is always stamped at emit with ``now()``; a timestamp more than this
+# far in the FUTURE cannot arise from legitimate clock skew and is treated as
+# corrupt-beyond-recovery by the keep-latest GC (deleted outright). Kept far wider
+# than the read-side display tolerance (``FUTURE_SKEW_TOLERANCE_MINUTES``) so a
+# modestly skewed-but-recoverable pulse ages into validity instead of being
+# destroyed — and so a BACKWARD clock skew at GC time can't delete genuinely-recent
+# pulses.
+_HEARTBEAT_FUTURE_CORRUPT_DAYS = 1
 
 
 def _safe_details_json(details: dict | None) -> str | None:
@@ -172,12 +181,42 @@ async def prune(
     if event_type is not None and keep_latest_per_subsystem:
         # Delete old rows EXCEPT the newest per subsystem (a row is kept when its
         # timestamp equals the per-subsystem max — strict ``<`` so ties are kept).
+        #
+        # Future-row hardening: ``timestamp`` is ISO TEXT and every heartbeat is
+        # stamped ``datetime.now(UTC).isoformat()`` at emit (uniform ``+00:00``, so
+        # lexical order == chronological order FOR THIS event_type; a future producer
+        # emitting ``Z``/naive/non-UTC would break that invariant — flag on change).
+        # A clock-skewed/corrupt future row (e.g. ``2099-…``) would otherwise be the
+        # lexical MAX and survive forever as the keep-anchor while genuine pulses age
+        # out — degrading ``compute_heartbeat_staleness`` to a permanent ``unknown``.
+        # TWO DISTINCT future bounds (destructive vs. non-destructive):
+        #  (a) delete only rows IMPLAUSIBLY far future (> corrupt horizon) — corrupt
+        #      beyond any clock-skew recovery. A modestly-future row is left to age
+        #      into validity, and this wide bound also protects genuinely-recent
+        #      pulses from a BACKWARD clock skew at GC time.
+        #  (b) anchor the keep on the newest row within the read-side display
+        #      tolerance, so the pulse we preserve is one the staleness read accepts.
+        # ``FUTURE_SKEW_TOLERANCE_MINUTES`` mirrors observability.liveness (single
+        # source of truth; imported locally — this infrequent GC path shouldn't couple
+        # a foundational CRUD module to observability at import time).
+        from genesis.observability.liveness import FUTURE_SKEW_TOLERANCE_MINUTES
+
+        now_dt = datetime.now(UTC)
+        future_delete_bound = (
+            now_dt + timedelta(days=_HEARTBEAT_FUTURE_CORRUPT_DAYS)
+        ).isoformat()
+        future_anchor_bound = (
+            now_dt + timedelta(minutes=FUTURE_SKEW_TOLERANCE_MINUTES)
+        ).isoformat()
         cursor = await db.execute(
-            "DELETE FROM events WHERE event_type = ? AND timestamp < ? "
+            "DELETE FROM events WHERE event_type = ? AND ("
+            "timestamp > ? "  # (a) implausibly-future rows: corrupt → delete outright
+            "OR (timestamp < ? "  # (b) below-cutoff AND below the newest valid anchor
             "AND timestamp < (SELECT MAX(e2.timestamp) FROM events e2 "
             "WHERE e2.event_type = events.event_type "
-            "AND e2.subsystem = events.subsystem)",
-            (event_type, older_than),
+            "AND e2.subsystem = events.subsystem "
+            "AND e2.timestamp <= ?)))",
+            (event_type, future_delete_bound, older_than, future_anchor_bound),
         )
     elif event_type is not None:
         cursor = await db.execute(

--- a/src/genesis/surplus/jobs/gates.py
+++ b/src/genesis/surplus/jobs/gates.py
@@ -285,7 +285,9 @@ async def _run_maintenance_gc(db: aiosqlite.Connection) -> None:
             keep_latest_per_subsystem=True,
         )
         if hb_purged:
-            logger.info("Pruned %d heartbeat events older than 7d", hb_purged)
+            # Count spans both retention (>7d, below the per-subsystem anchor) and
+            # implausibly-future corrupt rows the keep-latest GC also removes.
+            logger.info("Pruned %d stale/corrupt heartbeat events", hb_purged)
     except Exception:
         logger.warning("GC: heartbeat event rotation failed", exc_info=True)
 

--- a/tests/test_db/test_events_prune.py
+++ b/tests/test_db/test_events_prune.py
@@ -15,6 +15,7 @@ import pytest
 
 from genesis.db.crud import events
 from genesis.db.schema import create_all_tables
+from genesis.mcp.health.manifest import compute_heartbeat_staleness
 
 pytestmark = pytest.mark.asyncio
 
@@ -27,6 +28,7 @@ async def _db() -> aiosqlite.Connection:
 
 
 def _iso(days_ago: float) -> str:
+    # Negative days_ago → a FUTURE timestamp (used to simulate clock-skew rows).
     return (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
 
 
@@ -37,6 +39,18 @@ async def _insert(db, *, days_ago: float, event_type: str = "test.event") -> str
         severity="error",
         event_type=event_type,
         message=f"event {days_ago}d ago",
+        timestamp=_iso(days_ago),
+    )
+
+
+async def _insert_hb(db, *, subsystem: str, days_ago: float) -> str:
+    """Insert a durable ``heartbeat`` event for a subsystem at a now-relative age."""
+    return await events.insert(
+        db,
+        subsystem=subsystem,
+        severity="debug",
+        event_type="heartbeat",
+        message=f"{subsystem} pulse {days_ago}d ago",
         timestamp=_iso(days_ago),
     )
 
@@ -96,5 +110,165 @@ async def test_prune_scoped_to_event_type():
         assert removed == 1
         remaining = {r["event_type"] for r in await events.query(db)}
         assert remaining == {"keep.me"}
+    finally:
+        await db.close()
+
+
+# ── keep_latest_per_subsystem: future-row (clock-skew) hardening ──────────────
+# A corrupt/clock-skewed FUTURE heartbeat row is the lexical MAX(timestamp), so
+# the keep-latest anchor pins ON IT — genuine pulses age past the window and are
+# deleted, leaving only the future row → compute_heartbeat_staleness degrades to
+# a permanent ``unknown``. The GC must anchor on the newest VALID row and delete
+# materially-future rows outright.
+
+
+async def test_keep_latest_deletes_future_row_and_retains_newest_valid():
+    """The bug: a 'future' heartbeat must not survive as the keep-latest anchor.
+
+    Seed a far-future row + two genuine pulses both older than the 7d cutoff.
+    After GC: the future row is gone and the NEWEST VALID pulse survives (so the
+    liveness read can still say 'dead since X' rather than 'unknown').
+    """
+    db = await _db()
+    try:
+        future = await _insert_hb(db, subsystem="ego", days_ago=-1000)  # ~2099
+        valid_old = await _insert_hb(db, subsystem="ego", days_ago=100)
+        valid_newest = await _insert_hb(db, subsystem="ego", days_ago=90)
+        cutoff = _iso(7)
+
+        await events.prune(
+            db, older_than=cutoff, event_type="heartbeat", keep_latest_per_subsystem=True
+        )
+
+        ids = {r["id"] for r in await events.query(db)}
+        assert future not in ids, "materially-future row must be deleted"
+        assert valid_newest in ids, "newest VALID pulse must be retained as the anchor"
+        assert valid_old not in ids, "older valid pulse below the anchor is pruned"
+    finally:
+        await db.close()
+
+
+async def test_keep_latest_only_far_future_rows_all_deleted():
+    """A subsystem whose ONLY rows are IMPLAUSIBLY-far future → all deleted.
+
+    Far-future (> the corrupt horizon) rows are corrupt beyond recovery; with no
+    valid pulse to preserve, keeping nothing (→ no_heartbeat) is the truthful
+    outcome, not a retained corrupt row.
+    """
+    db = await _db()
+    try:
+        await _insert_hb(db, subsystem="inbox", days_ago=-500)  # ~2027+, > 1d horizon
+        await _insert_hb(db, subsystem="inbox", days_ago=-400)
+        cutoff = _iso(7)
+
+        await events.prune(
+            db, older_than=cutoff, event_type="heartbeat", keep_latest_per_subsystem=True
+        )
+
+        rows = [r for r in await events.query(db) if r["subsystem"] == "inbox"]
+        assert rows == [], "only-future rows must all be deleted (no valid pulse to keep)"
+    finally:
+        await db.close()
+
+
+async def test_keep_latest_normal_case_retains_newest_valid_below_cutoff():
+    """No future rows: keep_latest still retains the newest pulse even when it is
+    older than the cutoff (the whole point of keep_latest_per_subsystem)."""
+    db = await _db()
+    try:
+        oldest = await _insert_hb(db, subsystem="dashboard", days_ago=100)
+        newest = await _insert_hb(db, subsystem="dashboard", days_ago=30)
+        cutoff = _iso(7)
+
+        await events.prune(
+            db, older_than=cutoff, event_type="heartbeat", keep_latest_per_subsystem=True
+        )
+
+        ids = {r["id"] for r in await events.query(db)}
+        assert newest in ids and oldest not in ids
+    finally:
+        await db.close()
+
+
+async def test_keep_latest_future_row_no_longer_poisons_staleness_read():
+    """Integration: after GC, compute_heartbeat_staleness reads the truthful
+    verdict (a stale-but-real pulse → 'overdue') instead of the future-row
+    induced permanent 'unknown'."""
+    db = await _db()
+    try:
+        await _insert_hb(db, subsystem="ego", days_ago=-1000)  # skewed-future
+        await _insert_hb(db, subsystem="ego", days_ago=30)  # real, long stale
+        cutoff = _iso(7)
+
+        await events.prune(
+            db, older_than=cutoff, event_type="heartbeat", keep_latest_per_subsystem=True
+        )
+
+        verdict = await compute_heartbeat_staleness("ego", db=db, paused=False)
+        assert verdict["status"] == "overdue", verdict
+    finally:
+        await db.close()
+
+
+async def test_keep_latest_modestly_future_retained_only_far_future_deleted():
+    """A modestly-future (recoverable) row must NOT be destroyed — it ages into
+    validity. Only implausibly-far-future (corrupt) rows are deleted outright.
+
+    Guards the split-bound design: the destructive horizon (>1d) is deliberately
+    far wider than the read-side display tolerance (5min), so a row a few minutes
+    ahead of a skewed clock survives instead of reverting the subsystem to a false
+    no_heartbeat.
+    """
+    db = await _db()
+    try:
+        far_future = await _insert_hb(db, subsystem="ego", days_ago=-1000)  # ~2099
+        mod_future = await _insert_hb(db, subsystem="ego", days_ago=-(30 / 1440))  # +30min
+        valid = await _insert_hb(db, subsystem="ego", days_ago=30)
+        cutoff = _iso(7)
+
+        await events.prune(
+            db, older_than=cutoff, event_type="heartbeat", keep_latest_per_subsystem=True
+        )
+
+        ids = {r["id"] for r in await events.query(db)}
+        assert far_future not in ids, "implausibly-far-future row is corrupt → deleted"
+        assert mod_future in ids, "modestly-future row is recoverable → retained"
+        assert valid in ids, "genuine valid pulse retained (anchor within display tolerance)"
+    finally:
+        await db.close()
+
+
+async def test_keep_latest_ties_at_valid_anchor_both_retained():
+    """Two rows sharing the newest-valid timestamp are BOTH kept (strict ``<``);
+    an older valid row below them is pruned."""
+    db = await _db()
+    try:
+        tie_ts = _iso(30)
+        a = await events.insert(
+            db,
+            subsystem="ego",
+            severity="debug",
+            event_type="heartbeat",
+            message="tie a",
+            timestamp=tie_ts,
+        )
+        b = await events.insert(
+            db,
+            subsystem="ego",
+            severity="debug",
+            event_type="heartbeat",
+            message="tie b",
+            timestamp=tie_ts,
+        )
+        older = await _insert_hb(db, subsystem="ego", days_ago=100)
+        cutoff = _iso(7)
+
+        await events.prune(
+            db, older_than=cutoff, event_type="heartbeat", keep_latest_per_subsystem=True
+        )
+
+        ids = {r["id"] for r in await events.query(db)}
+        assert a in ids and b in ids, "tied newest-valid rows are both kept (strict <)"
+        assert older not in ids, "older valid row below the anchor is pruned"
     finally:
         await db.close()


### PR DESCRIPTION
## Problem

The `keep_latest_per_subsystem` heartbeat GC (`db/crud/events.py::prune`, sole caller
`surplus/jobs/gates.py`) retains the row equal to the per-subsystem `MAX(timestamp)`. Because
`timestamp` is ISO **text**, a clock-skewed/corrupt future row (e.g. `2099-…`) is the lexical MAX and
survives the 7-day retention window forever, while genuine pulses age out and are deleted. Downstream,
`compute_heartbeat_staleness` rejects the lone materially-future row and returns a permanent
`unknown` — a false "can't tell" for a subsystem that may be healthy or truthfully stale, and a break
of the invariant that a once-run subsystem always retains its last pulse.

Only reachable via host clock skew (every heartbeat is stamped `datetime.now(UTC).isoformat()` at emit —
no code path passes an explicit future timestamp), so it surfaces LOUD (`unknown`), not as a silent
green. Low probability, but it defeats the purpose of `keep_latest`.

## Fix

Retention-layer, in the `keep_latest` branch only. Two distinct future bounds:

- **(a) delete** only *implausibly*-far-future rows (`timestamp > now + 1 day` — corrupt beyond any
  clock-skew recovery). The wide horizon leaves a *modestly*-future row to age into validity instead of
  destroying it, and prevents a **backward** clock skew at GC time from deleting genuinely-recent pulses.
- **(b) anchor** the "keep newest" on the newest row within the read-side display tolerance
  (`observability.liveness.FUTURE_SKEW_TOLERANCE_MINUTES`), so the preserved pulse is one the staleness
  read will accept (`alive`/`overdue`).

A write-time clamp was considered and rejected: the only production trigger is host clock skew, against
which a clamp is ineffective (at write time `now()` *is* the skewed value). The retention layer —
re-evaluated at GC time — is the layer that actually closes the hole.

## Tests

Adds 6 `keep_latest` GC tests (the branch was previously untested): future-row delete, only-far-future
all-deleted, **modestly-future retained** (the split-bound guard — fails under a single 5-min bound),
ties-at-anchor both-kept, normal-case regression guard, and an integration test proving
`compute_heartbeat_staleness` returns a truthful `overdue` instead of permanent `unknown`. RED→GREEN
verified. Consumer regression (`test_subsystem_staleness`) green (78 passed total).

Also: pins the "heartbeat timestamps are uniform UTC `+00:00`, so lexical order == chronological *for
this event_type*" invariant with a comment (a future producer emitting `Z`/naive/non-UTC would need a
review flag), and corrects the caller's log string (the count now spans retention + corrupt-future
deletes).

Ledger: 12e9b797e466401b8e1f089fc44e974c
