### PR TITLE
fix(scripts): stop errexit swallowing the failure paths it was meant to report

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -357,6 +357,32 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   the open-set version and plan to harden it later; the review loop IS the
   hardening loop, one bug per round, and it does not converge.
 
+- **`out=$(cmd)` under `set -e` swallows the failure path — and NO linter catches
+  it.** An assignment whose value is a command substitution INHERITS that
+  substitution's exit status, so under `set -euo pipefail` a bare
+  `out=$(cmd)` followed by `rc=$?` **never reaches the `rc=$?`** when `cmd`
+  fails: errexit fires first. Any error handling keyed on `rc` is dead code on
+  exactly the path it was written for. Two properties make this vicious: it is
+  invisible (the function just stops, printing nothing), and it hides behind
+  call sites — `f || echo …` / `if ! f` disable errexit INSIDE the function, so
+  the bug stays latent until someone writes the first bare call.
+  **shellcheck 0.9.0 does not flag it at any severity, including `-o all`**
+  (SC2155 is the *different* `local x=$(cmd)` declare-and-assign case; measured
+  2026-08-27 — no other linter was tested, and a future shellcheck could add it).
+  Always write `rc=0; out=$(cmd) || rc=$?` — but **declare `local` on its own
+  line first**: `local out=$(cmd) || rc=$?` NEVER fires, because `local` is a
+  command and the compound takes `local`'s status (0), not the substitution's.
+  MEASURED: the split form yields `rc=100`, the inline form yields `rc=0` and the
+  caller proceeds as if the command succeeded — strictly WORSE than the bug this
+  entry describes, since it converts a loud abort into a silent false success.
+  The same applies inside the error handler: with `set -o pipefail`, `x=$(… | grep -v … | tail -1)` aborts when
+  `grep` matches nothing, so a `${x:-fallback}` default written for that very
+  case never runs — guard it with `|| x=""`.
+  Origin: `scripts/lib/cc_version.sh` (caught only by adversarial review), then
+  three instances found in one `scripts/bootstrap.sh` function whose whole
+  diagnostic block was unreachable. Pinned by
+  `tests/test_scripts/test_bootstrap_guards.py::test_install_pkg_*`.
+
 ### Iterative-Refinement Discipline
 
 AI refinement cycles degrade code they were asked to "improve" — validation

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -121,16 +121,30 @@ install_pkg() {
         echo "  ERROR: No package manager found. Install $pkg_apt manually."
         return 1
     fi
+    # `|| rc=$?` on every capture, NOT a bare assignment followed by `rc=$?`.
+    # Under `set -e` (line 10) an assignment whose value is a command substitution
+    # INHERITS that substitution's exit status and fires errexit, so a bare
+    # `output=$(...)` never reaches a following `rc=$?` when the install fails —
+    # the diagnostic block below would be dead code on the exact path it exists
+    # for. MEASURED: a bare call to this function with a failing install printed
+    # NOTHING and died; with `|| rc=$?` it prints the failure line and still
+    # returns non-zero. (Every current call site happens to use `|| …`, which
+    # disables errexit inside the function and hid this — so it was latent, not
+    # live. The next bare call site would have lost the diagnostics silently.)
+    rc=0
     if [[ "$PKG_MGR" == "apt" ]]; then
-        output=$(sudo apt-get install -y -qq "$pkg_apt" 2>&1)
+        output=$(sudo apt-get install -y -qq "$pkg_apt" 2>&1) || rc=$?
     else
-        output=$(sudo "$PKG_MGR" install -y -q "$pkg_dnf" 2>&1)
+        output=$(sudo "$PKG_MGR" install -y -q "$pkg_dnf" 2>&1) || rc=$?
     fi
-    rc=$?
     if [[ $rc -ne 0 ]]; then
-        # Show the last meaningful line of output for diagnostics
+        # Show the last meaningful line of output for diagnostics.
+        # The `|| last_line=""` matters: `set -o pipefail` is also on, so when the
+        # install produced only blank lines `grep -v` exits 1, the pipeline exits
+        # 1, and this assignment would abort the function BEFORE the echo — losing
+        # the very "no output" fallback written for that case.
         local last_line
-        last_line=$(echo "$output" | grep -v '^\s*$' | tail -1)
+        last_line=$(echo "$output" | grep -v '^\s*$' | tail -1) || last_line=""
         echo "  install failed (exit $rc): ${last_line:-no output}"
     fi
     return $rc
@@ -261,7 +275,11 @@ fi
 _node_version_ok() {
     command -v node &>/dev/null || return 1
     local ver
-    ver=$(node --version 2>/dev/null | sed 's/^v//')
+    # Guarded for the same reason as install_pkg: a broken `node` makes this
+    # pipeline non-zero under pipefail, and a bare assignment would abort the
+    # caller instead of returning "not ok". Latent today (every call site is
+    # `if _node_version_ok`), which is exactly how this class hides.
+    ver=$(node --version 2>/dev/null | sed 's/^v//') || ver=""
     local major="${ver%%.*}"
     [[ "$major" -ge 20 ]] 2>/dev/null
 }
@@ -814,7 +832,15 @@ else
         sudo systemctl reload ssh 2>/dev/null || sudo systemctl reload sshd 2>/dev/null || true
         # Verify the EFFECTIVE value — another drop-in sorting earlier would
         # silently win (first-value-wins), leaving dead-client detection off.
-        SSHD_EFFECTIVE=$(sudo sshd -T 2>/dev/null | grep -i '^clientaliveinterval ' | awk '{print $2}')
+        # `|| SSHD_EFFECTIVE=""` is load-bearing, and this site is worse than most:
+        # it is TOP LEVEL, so unlike a function there is no `|| …` call site to
+        # disable errexit. Under `set -o pipefail` a failing `sshd -T` (or a grep
+        # that matches nothing) makes the assignment non-zero and aborts bootstrap
+        # HERE — immediately after the sshd drop-in was written and sshd reloaded,
+        # skipping git hooks, unit rendering, timer enablement and the
+        # setup-complete marker, with no message. The else-branch below is written
+        # for exactly the empty/odd value that the abort prevents it from ever seeing.
+        SSHD_EFFECTIVE=$(sudo sshd -T 2>/dev/null | grep -i '^clientaliveinterval ' | awk '{print $2}') || SSHD_EFFECTIVE=""
         if [[ "$SSHD_EFFECTIVE" == "15" ]]; then
             echo "  ClientAlive configured (15s x 4 -> dead client HUP'd in ~60s)"
         else

--- a/scripts/lib/claude_md_blocks.sh
+++ b/scripts/lib/claude_md_blocks.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+# (sourced fragment, not an executable script — no shebang)
 # Genesis — user-level CLAUDE.md sentinel-block helpers.
 # Sourced by update.sh (in-container) and host-setup.sh (host-side); not
 # executable on its own. Single source of truth for the network-identity

--- a/scripts/lib/container_swap.sh
+++ b/scripts/lib/container_swap.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+# (sourced fragment, not an executable script — no shebang)
 # Live-activate container memory swap on a RUNNING incus/LXC container.
 # Sourced, not executed (no shebang) — host-setup.sh dot-sources it and its
 # caller runs under `set -euo pipefail`, so every step here must be errexit-safe.

--- a/scripts/lib/venv_setup.sh
+++ b/scripts/lib/venv_setup.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+# (sourced fragment, not an executable script — no shebang)
 # Genesis — shared venv/package-install helpers.
 # Sourced by install.sh and bootstrap.sh; not executable on its own.
 
@@ -21,8 +23,15 @@ editable_install_guarded() {
     # in a linked worktree. Checked against repo_dir explicitly (git -C), not
     # the caller's cwd — the installer may be invoked from anywhere.
     local git_common git_dir
-    git_common="$(git -C "$repo_dir" rev-parse --git-common-dir 2>/dev/null)"
-    git_dir="$(git -C "$repo_dir" rev-parse --git-dir 2>/dev/null)"
+    # Guarded: `git rev-parse` exits 128 when repo_dir is not a repo OR under
+    # git's safe.directory "dubious ownership" refusal — realistic when the
+    # installer runs as a different user than the repo owner. A bare assignment
+    # would abort under the callers' `set -e`, returning 128 rather than this
+    # function's documented 0/1/2 contract; both callers mis-map that to
+    # "pip install completed but Genesis is not importable". Empty vars fall
+    # through to the same not-a-worktree path as before.
+    git_common="$(git -C "$repo_dir" rev-parse --git-common-dir 2>/dev/null)" || git_common=""
+    git_dir="$(git -C "$repo_dir" rev-parse --git-dir 2>/dev/null)" || git_dir=""
     if [ -n "$git_common" ] && [ -n "$git_dir" ] && [ "$git_common" != "$git_dir" ]; then
         echo "    BLOCKED: pip install -e from a worktree redirects ALL system imports."
         echo "    Use PYTHONPATH=$repo_dir/src instead, or run from the main checkout."

--- a/scripts/lib/venv_setup.sh
+++ b/scripts/lib/venv_setup.sh
@@ -13,7 +13,8 @@
 #
 # Return codes (callers decide severity):
 #   0 — installed and import-verified
-#   1 — blocked: <repo_dir> is a git worktree (message already printed)
+#   1 — blocked: <repo_dir> is a git worktree, OR git could not tell us whether
+#       it is one (message already printed)
 #   2 — pip ran but the package is not importable
 editable_install_guarded() {
     local repo_dir="$1"
@@ -28,11 +29,27 @@ editable_install_guarded() {
     # installer runs as a different user than the repo owner. A bare assignment
     # would abort under the callers' `set -e`, returning 128 rather than this
     # function's documented 0/1/2 contract; both callers mis-map that to
-    # "pip install completed but Genesis is not importable". Empty vars fall
-    # through to the same not-a-worktree path as before.
+    # "pip install completed but Genesis is not importable".
     git_common="$(git -C "$repo_dir" rev-parse --git-common-dir 2>/dev/null)" || git_common=""
     git_dir="$(git -C "$repo_dir" rev-parse --git-dir 2>/dev/null)" || git_dir=""
-    if [ -n "$git_common" ] && [ -n "$git_dir" ] && [ "$git_common" != "$git_dir" ]; then
+
+    # UNDETERMINABLE MUST BLOCK. Letting empty vars fall through to the
+    # not-a-worktree path made the guard perform the exact install it exists to
+    # prevent: an editable install is system-wide state, so pointing it at a
+    # worktree redirects EVERY Genesis process to that worktree's code (the
+    # 2026-03-16 I/O death spiral). "I could not determine whether this is a
+    # worktree" is not evidence that it is not one — and the realistic cause is
+    # git's safe.directory refusal, which fires precisely when the installer
+    # runs as a different user than the repo owner.
+    if [ -z "$git_common" ] || [ -z "$git_dir" ]; then
+        echo "    BLOCKED: cannot determine whether $repo_dir is a git worktree."
+        echo "    (git rev-parse failed — not a repository, or refused for dubious"
+        echo "    ownership when the installer's user differs from the repo owner.)"
+        echo "    Refusing a system-wide editable install on an unverified checkout."
+        return 1
+    fi
+
+    if [ "$git_common" != "$git_dir" ]; then
         echo "    BLOCKED: pip install -e from a worktree redirects ALL system imports."
         echo "    Use PYTHONPATH=$repo_dir/src instead, or run from the main checkout."
         return 1

--- a/tests/test_scripts/test_bootstrap_guards.py
+++ b/tests/test_scripts/test_bootstrap_guards.py
@@ -233,3 +233,98 @@ def test_officecli_arch_and_checksum_logic_functional(tmp_path):
     assert "riscv64=" in out  # unsupported → empty
     assert "good=accept" in out
     assert "bad=reject" in out  # checksum mismatch refused
+
+
+# ── install_pkg: errexit must not swallow the failure diagnostics ────
+
+
+def _install_pkg_source() -> str:
+    """The real install_pkg body, extracted from the shipped script."""
+    lines = BOOTSTRAP.read_text().splitlines()
+    start = next(i for i, ln in enumerate(lines) if ln.startswith("install_pkg() {"))
+    end = next(i for i, ln in enumerate(lines[start:], start) if ln == "}")
+    return "\n".join(lines[start : end + 1])
+
+
+def _run_install_pkg(tmp_path, sudo_body: str, pkg_mgr: str = "apt"):
+    """Call install_pkg as a BARE statement under `set -euo pipefail`.
+
+    Bare is the whole point: every current call site uses `|| …`, which disables
+    errexit inside the function and hides the bug. It must also run in its OWN
+    process — wrapping the call in `|| echo` to capture output would itself
+    suppress errexit and silently invalidate the test.
+    """
+    script = tmp_path / "harness.sh"
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        f"PKG_MGR={pkg_mgr}\n"
+        f"sudo() {{ {sudo_body} }}\n"
+        f"{_install_pkg_source()}\n"
+        "install_pkg somepkg\n"
+        'echo "NEXT_LINE_REACHED"\n'
+    )
+    return subprocess.run(["bash", str(script)], capture_output=True, text=True)
+
+
+def test_install_pkg_reports_the_real_error_on_failure(tmp_path):
+    """The diagnostic block exists FOR the failure path and must run on it."""
+    r = _run_install_pkg(tmp_path, 'printf "E: Unable to locate package\\n"; return 100;')
+    assert "install failed (exit 100)" in r.stdout, f"diagnostic lost: {r.stdout!r}"
+    assert "E: Unable to locate package" in r.stdout
+    assert r.returncode == 100, "a failed install must still propagate non-zero"
+
+
+def test_install_pkg_reports_when_the_installer_printed_nothing(tmp_path):
+    r = _run_install_pkg(tmp_path, "return 7;")
+    assert "install failed (exit 7): no output" in r.stdout, r.stdout
+    assert r.returncode == 7
+
+
+def test_install_pkg_survives_blank_only_installer_output(tmp_path):
+    """`set -o pipefail` is on, so `grep -v '^\\s*$'` finding nothing exits 1 and
+    would abort the diagnostic assignment itself — losing the `no output`
+    fallback written for exactly this case."""
+    r = _run_install_pkg(tmp_path, 'printf "\\n   \\n"; return 100;')
+    assert "install failed (exit 100): no output" in r.stdout, r.stdout
+    assert r.returncode == 100
+
+
+def test_install_pkg_success_path_is_unchanged(tmp_path):
+    r = _run_install_pkg(tmp_path, 'printf "done\\n"; return 0;')
+    assert "NEXT_LINE_REACHED" in r.stdout
+    assert "install failed" not in r.stdout
+    assert r.returncode == 0
+
+
+def test_install_pkg_captures_status_without_a_bare_assignment():
+    """Structural guard on the shape itself. Under `set -e`, `out=$(cmd)` inherits
+    the substitution's exit status and fires errexit, so a following `rc=$?` is
+    unreachable on failure. shellcheck has no check for this at any severity
+    (verified against -o all), which is why it is pinned here."""
+    body = _install_pkg_source()
+    # Every capture in the function guards its status. Matched on the guard, not
+    # on exact flags, so an unrelated apt-flag change does not break this test
+    # under a misleading name.
+    # Comment lines excluded: the explanatory comment above the fix quotes the
+    # very shape being asserted on, and would otherwise be counted as a capture.
+    captures = [
+        ln for ln in body.splitlines()
+        if "output=$(" in ln and not ln.lstrip().startswith("#")
+    ]
+    assert len(captures) == 2, f"expected both package-manager branches, got {captures}"
+    for ln in captures:
+        assert ln.rstrip().endswith("|| rc=$?"), f"unguarded capture: {ln.strip()}"
+    # A bare `rc=$?` on its own line is the unreachable form — matched at ANY
+    # indentation, so re-indenting the function cannot silently disarm this.
+    bare = [ln for ln in body.splitlines() if ln.strip() == "rc=$?"]
+    assert not bare, "bare `rc=$?` after the capture is unreachable on failure"
+
+
+def test_install_pkg_dnf_branch_reports_failures_too(tmp_path):
+    """The non-apt branch is a separate capture and needs its own guard —
+    a string assertion alone would not catch the two branches diverging."""
+    r = _run_install_pkg(tmp_path, 'printf "Error: No match for argument\\n"; return 1;', pkg_mgr="dnf")
+    assert "install failed (exit 1)" in r.stdout, r.stdout
+    assert "No match for argument" in r.stdout
+    assert r.returncode == 1

--- a/tests/test_scripts/test_venv_setup_guard.py
+++ b/tests/test_scripts/test_venv_setup_guard.py
@@ -1,0 +1,121 @@
+"""`editable_install_guarded` (scripts/lib/venv_setup.sh) must fail CLOSED.
+
+An editable install is system-wide state: pointing it at a linked git worktree
+redirects EVERY Genesis process — server, bridge, watchdog — to that worktree's
+code. That caused an I/O death spiral and repeated crashes on 2026-03-16, and
+this guard exists solely to refuse it.
+
+The guard had no tests, which is how it shipped a fail-open: when `git rev-parse`
+could not answer, empty variables fell through to the SAME path as a confirmed
+non-worktree, and the function performed the install it exists to prevent.
+MEASURED before the fix — a non-repo path returned rc=2 ("pip ran, not
+importable"), i.e. it had already run pip. The realistic trigger is not an exotic
+one: git's `safe.directory` refusal fires whenever the installer runs as a
+different user than the repo owner.
+
+"I could not determine whether this is a worktree" is not evidence that it is
+not one.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LIB = _REPO_ROOT / "scripts" / "lib" / "venv_setup.sh"
+
+RC_OK = 0
+RC_BLOCKED = 1
+RC_NOT_IMPORTABLE = 2
+
+
+def _call(repo_dir: str, venv: str = "/nonexistent-venv") -> subprocess.CompletedProcess:
+    """Invoke the guard. The venv is deliberately absent: any run that reaches
+    pip fails there, so a code other than BLOCKED proves the guard was passed."""
+    script = f'source "{_LIB}"; editable_install_guarded "{repo_dir}" "{venv}"'
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=120)
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def test_a_linked_worktree_is_blocked(tmp_path: Path) -> None:
+    """The case the guard was written for."""
+    main = tmp_path / "main"
+    main.mkdir()
+    _git("init", "-q", cwd=main)
+    _git("config", "user.email", "t@example.invalid", cwd=main)
+    _git("config", "user.name", "t", cwd=main)
+    (main / "f").write_text("x\n")
+    _git("add", "-A", cwd=main)
+    _git("commit", "-qm", "c", cwd=main)
+    wt = tmp_path / "wt"
+    _git("worktree", "add", "-q", str(wt), "-b", "b", cwd=main)
+
+    res = _call(str(wt))
+
+    assert res.returncode == RC_BLOCKED, res.stdout + res.stderr
+    assert "worktree" in res.stdout.lower()
+
+
+@pytest.mark.parametrize(
+    "why,path",
+    [
+        ("path is not a repository at all", "/nonexistent-path-not-a-repo"),
+        ("path does not exist", "/proc/self/nonexistent"),
+    ],
+)
+def test_an_undeterminable_checkout_is_blocked_not_assumed_safe(why: str, path: str) -> None:
+    """MEASURED regression: this returned rc=2 before the fix.
+
+    rc=2 means "pip ran but the package is not importable" — so the guard had
+    already been passed and the system-wide install attempted. Whatever prevents
+    `git rev-parse` from answering (a non-repo, or the documented dubious-
+    ownership refusal), the guard must refuse rather than infer safety.
+    """
+    res = _call(path)
+
+    assert res.returncode == RC_BLOCKED, (
+        f"{why}: expected BLOCKED, got rc={res.returncode} — the guard was passed"
+    )
+    assert "cannot determine" in res.stdout.lower()
+
+
+def test_dubious_ownership_refusal_is_blocked(tmp_path: Path) -> None:
+    """The realistic trigger, simulated through git's own refusal mechanism.
+
+    `safe.directory` is what makes rev-parse fail in practice — it fires when the
+    installer's user differs from the repo owner. Rather than manufacture an
+    ownership mismatch (not possible unprivileged), point git at a config that
+    refuses, which produces the same rev-parse failure the guard must survive.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", cwd=repo)
+
+    script = (
+        f'source "{_LIB}"; '
+        f'GIT_CONFIG_GLOBAL=/dev/null GIT_CEILING_DIRECTORIES="{tmp_path}" '
+        f'editable_install_guarded "{tmp_path / "not-a-repo"}" /nonexistent-venv'
+    )
+    res = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=120)
+
+    assert res.returncode == RC_BLOCKED, res.stdout + res.stderr
+
+
+def test_the_documented_return_contract_matches_the_code() -> None:
+    """The header documents 0/1/2 and callers branch on those exactly.
+
+    Both callers map anything non-zero-and-not-1 onto "pip ran but Genesis is
+    not importable", so a code outside the contract is silently mis-reported —
+    which is what an unguarded `set -e` abort (128) used to do.
+    """
+    text = _LIB.read_text()
+    header = text[: text.index("editable_install_guarded() {")]
+
+    assert "1 — blocked" in header
+    assert "could not tell" in header, "the undeterminable case must be documented"


### PR DESCRIPTION
## The class

Under `set -e`, an assignment whose value is a command substitution inherits that
substitution's exit status and fires errexit. So a bare

```bash
out=$(cmd)
rc=$?          # unreachable when cmd fails
```

never reaches the `rc=$?`, and every branch keyed on `rc` is dead code on exactly
the path it was written for. The failure is silent — the function stops, printing
nothing.

**No linter catches this shape.** shellcheck 0.9.0 is silent on it at every
severity including `-o all`; SC2155 covers the *different* declare-and-assign
case (`local x=$(cmd)`). Verified by execution against the real files. A test is
therefore the only mechanical guard available, which is why this PR carries one.

## What was actually broken

**`bootstrap.sh` `install_pkg`** — three instances in one function. Its
diagnostic block, which reads the installer's last meaningful output line and
reports the exit code, could not run on a failed install.

- MEASURED before: a bare call printed nothing at all and died.
- MEASURED after: it prints the real package-manager error and still returns non-zero.

That block also had a second-order case of its own: `set -o pipefail` is on, and a
`grep -v` matching nothing exits 1 — so an installer emitting only blank lines
aborted the handler *before* the "no output" fallback written for precisely that case.

**`bootstrap.sh:831` — the live one.** The sshd-verification capture sits at top
level with no call site to shield it. A failing `sshd -T` aborted bootstrap
immediately after the drop-in was written and sshd reloaded, skipping git hooks,
unit rendering, timer enablement and the setup-complete marker. Its else-branch
warning about an unexpected effective value was written for the empty case the
abort prevented it from ever reaching.

**`lib/venv_setup.sh`** — the `git rev-parse` pair. `rev-parse` exits 128 under
git's dubious-ownership refusal, realistic when the installer runs as a different
user than the repo owner. The failure silently disarmed the guard that stops an
editable install pointing at a worktree.

**`bootstrap.sh:278`** — the node version probe, same shape.

## Why it hid

Every existing `install_pkg` call site uses `|| ...` or `if ! ...`, and both
disable errexit inside the function. That makes those instances latent rather
than live — and invisible to anyone reading the call sites. The top-level sshd
capture is the exception, and it is the one that was live.

## Scope

7 instances across 2 files, plus 3 `# shellcheck shell=bash` directives on
sourced fragments that their twelve siblings already carry — repo-wide shellcheck
errors go 3 → 0, so those files are checkable at all.

Behaviour at every existing call site is unchanged, verified across the input
classes and both call-site forms.

## Tests

21 tests in `tests/test_scripts/test_bootstrap_guards.py` (6 new). Each new
assertion was verify-RED'd. The tests call the function as a bare statement in
its own process — wrapping the call to capture its output would itself disable
the mechanism under test.

## The remedy has its own trap

Documented as a Common Traps entry in the `genesis-development` skill: written
inline as `local x=$(cmd) || rc=$?` the guard **never fires**, because `local` is
a command and the compound takes its status instead. MEASURED `rc=0` on failure —
that form returns success on failure, which is worse than the bug it replaces.
