### PR TITLE
feat(observability): monitor outreach cessation via a dedicated channel-independent heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Outreach total-cessation monitoring, without the old false-alarm trap.**
+  Outreach is now in the `subsystem_stale` alert set (WARNING) alongside
+  ego/inbox/dashboard. Previously it was excluded because its heartbeat was
+  *emergent* — a side-effect of an outreach job succeeding — and the outreach
+  scheduler only starts once a messaging channel (Telegram) registers, so a
+  Telegram-less install never pulsed and naively adding it would fire a permanent
+  unresolvable alert. Two pieces close that trap: (1) a dedicated,
+  channel-independent heartbeat daemon (`outreach/heartbeat.py`) that pulses **only
+  while the outreach scheduler is actually running** (`is_running`) — so a
+  never-started/stopped scheduler goes stale instead of reading a false `alive`; and
+  (2) an enable-gate (`_subsystem_enabled('outreach')` = Telegram configured, via the
+  same side-effect-free `build_bridge_config` loader onboarding-readiness uses) so a
+  dashboard-only install is benign. Documented boundary: a Telegram-configured install
+  whose scheduler *never once started* (registration failed) emits no pulse and stays
+  a benign `no_heartbeat` — outreach IS a bootstrap-manifest entry (`ok` = scheduler
+  *constructed*, not running), so it is explicitly exempted from the started-silent
+  `never_started` inference (a constructed-but-not-started scheduler is benign; a genuine
+  init *failure* still surfaces); a *wedged-but-alive* loop is job_health's domain. The
+  new `subsystem_stale:outreach` id is handled generically by the existing consumers
+  (morning-report dedup by prefix, the Sentinel `subsystem_stale:` disposition).
+
 - **Session-start surface for age-stale open PRs.** The repo-pulse worker now
   also caches the open-PR set each boundary, and a SessionStart hook lists the
   ones idle past a threshold (default 7 days) as one passive inline line —

--- a/src/genesis/hosting/standalone.py
+++ b/src/genesis/hosting/standalone.py
@@ -657,6 +657,19 @@ class StandaloneAdapter:
         except Exception:
             logger.exception("Failed to register dashboard blueprint")
 
+        # Outreach liveness heartbeat — a dedicated daemon (NOT gated on dashboard
+        # registration) so outreach is monitored independent of Telegram channel
+        # registration. It self-gates to pulse only while the outreach scheduler is
+        # running (see outreach/heartbeat.py), so it is a no-op until/unless outreach
+        # actually runs; the cessation alert is enable-gated on Telegram being
+        # configured, so a dashboard-only install stays benign.
+        try:
+            from genesis.outreach.heartbeat import OutreachHeartbeat
+
+            OutreachHeartbeat(interval_seconds=60).start()
+        except Exception:
+            logger.exception("Failed to start outreach heartbeat")
+
         # Terminal WebSocket
         try:
             from genesis.dashboard.routes.terminal import register_terminal_ws

--- a/src/genesis/mcp/health/errors.py
+++ b/src/genesis/mcp/health/errors.py
@@ -941,24 +941,32 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
 
     # ── Stopped-firing subsystems (total-cessation) ──────────────────
     # Each subsystem below pulses a durable ``heartbeat`` event whose emission is
-    # independent of pause (ego: dedicated ego_heartbeat job; dashboard: dedicated
-    # daemon thread) or is downgraded to "paused" while paused (inbox, whose pulse
-    # stops behind ``if paused: return`` — handled in compute_heartbeat_staleness).
+    # independent of pause (ego: dedicated ego_heartbeat job; dashboard + outreach:
+    # dedicated daemon threads) or is downgraded to "paused" while paused (inbox, whose
+    # pulse stops behind ``if paused: return`` — handled in compute_heartbeat_staleness).
     # When that pulse goes overdue past its per-subsystem threshold the
     # scheduler/loop has stopped — a SILENT death the failure-gap alarms above
     # cannot see (those need a RUNNING-but-failing job; a stopped job never
     # advances last_run either). Complements job_stale/job_never_succeeded.
     # SET = ego (CRITICAL — the dead-ego-scheduler failure this batch began with)
-    # + inbox + dashboard (WARNING). EXCLUDED: surplus — PR-B's shipped tile
-    # already flips red on a wedged/dead surplus via its finer job_health signal,
-    # and surplus's event-heartbeat is load-fragile (loop-END emit gaps under a
-    # 15-30min dispatch); outreach — its pulse is config-gated (never fires on a
-    # Telegram-less install; a once-Telegram-then-removed install would fire a
-    # permanent unresolvable alert), so it is a false-alarm trap (follow-up: give
-    # outreach a dedicated pause-independent heartbeat). reflection — its pulse is
-    # the awareness loop, not reflection-engine liveness; awareness — has the more
-    # precise ``awareness:tick_overdue`` above. Coverage cap: the ~90 non-pulse
-    # scheduled jobs get ONLY the failure-gap signals above. The shared
+    # + inbox + dashboard + outreach (WARNING). Outreach's dedicated heartbeat
+    # (``outreach/heartbeat.py``) pulses only while its scheduler is running and is
+    # enable-gated (``_subsystem_enabled('outreach')`` = Telegram configured), so a
+    # Telegram-less (dashboard-only) install is benign — closing the old false-alarm
+    # trap (its pulse used to be config-gated + emergent). EXCLUDED: surplus — PR-B's
+    # shipped tile already flips red on a wedged/dead surplus via its finer job_health
+    # signal, and surplus's event-heartbeat is load-fragile (loop-END emit gaps under a
+    # 15-30min dispatch); reflection — its pulse is the awareness loop, not
+    # reflection-engine liveness; awareness — has the more precise
+    # ``awareness:tick_overdue`` above. Coverage cap: the ~90 non-pulse scheduled jobs
+    # get ONLY the failure-gap signals above; and outreach's own boundary — a
+    # Telegram-configured install whose scheduler NEVER started (registration failed)
+    # emits no pulse ever → benign no_heartbeat. Outreach IS a bootstrap-manifest entry
+    # (records ``ok`` = scheduler CONSTRUCTED, not running), so it is explicitly exempted
+    # from the started-silent never_started inference (manifest ``_CONDITIONAL_PULSE_SUBSYSTEMS``)
+    # — a constructed-but-not-started scheduler is benign; only a genuine init FAILURE
+    # (``failed:``/``degraded``) fires never_started, and only ``subsystem_stale`` (a
+    # once-running scheduler that then died) fires on cessation. The shared
     # ``compute_heartbeat_staleness`` reads the same signal the ego dashboard tile
     # does, so alert and tile agree on the OVERDUE verdict. (They diverge by design
     # on ``no_heartbeat``: the tile applies a boot-grace and flips to error past it,
@@ -973,7 +981,7 @@ async def _compute_alerts() -> tuple[list[dict], set[str]]:
         )
 
         _stale_db = _service._db if _service else None
-        for _hb_name in ("ego", "inbox", "dashboard"):
+        for _hb_name in ("ego", "inbox", "dashboard", "outreach"):
             try:
                 # raise_on_error=True → a read failure fails LOUD (handled below by
                 # preserving any open alert), never a silent green that lets

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -169,7 +169,7 @@ HEARTBEAT_EXPECTED = {
     # A real reflection outage surfaces faster via the awareness heartbeat
     # (6 min), the cc resilience axis, and the deferred-work backlog.
     "reflection": (600, 14400),
-    "outreach": (86400, 172800),
+    "outreach": (120, 600),       # 60s daemon-thread pulse (outreach/heartbeat.py); overdue at 10×
     "dashboard": (120, 600),      # 60s daemon-thread pulse; overdue at 10× (was 4×)
     "ego": (300, 14400),          # 5-min liveness pulse (ego_heartbeat job), overdue at 4h
 }
@@ -182,6 +182,17 @@ HEARTBEAT_EXPECTED = {
 # pulse THROUGH pause, so they are NOT here — an overdue-while-paused for them is
 # a genuine scheduler death that must still surface. See compute_heartbeat_staleness.
 _PAUSE_GATED_HEARTBEATS = frozenset({"surplus", "inbox"})
+
+# Subsystems whose heartbeat only begins after a RUNTIME precondition (not just a
+# successful init), so a bootstrap-manifest ``"ok"`` (init constructed the object)
+# does NOT imply the subsystem should be pulsing yet. For these, an ``ok``-but-never-
+# pulsed state is a benign non-death — the started-silent never_started inference is
+# INVALID (their died-after-running case is caught by ``subsystem_stale`` via the
+# dedicated heartbeat instead). A genuine init FAILURE (``failed:``/``degraded``) still
+# surfaces as never_started. Currently: outreach — its scheduler is constructed at boot
+# but only ``.start()``s once a messaging channel registers, which may never happen even
+# on a Telegram-configured install (revoked token, Telegram unreachable at boot).
+_CONDITIONAL_PULSE_SUBSYSTEMS = frozenset({"outreach"})
 
 # The complete set of statuses ``compute_heartbeat_staleness`` can return. Every
 # consumer that switches on the status string (the alert loop in errors.py, the ego
@@ -251,14 +262,55 @@ def _inbox_enabled() -> bool:
     return bool(load_inbox_config(config_path).enabled)
 
 
+def _outreach_enabled() -> bool:
+    """Is a messaging channel (Telegram) configured — i.e. is outreach *supposed* to run?
+
+    The outreach scheduler only ``.start()``s once a messaging channel registers
+    (``runtime/_job_health.py`` → only Telegram registers), so a Telegram-less
+    (dashboard-only) install legitimately never runs outreach and must NOT alarm.
+    Uses the SAME side-effect-free loader the bridge + onboarding-readiness T2 signal
+    use (``channels.bridge_config.build_bridge_config`` over the parsed secrets), so
+    the "would Telegram start?" answer can't drift between them.
+
+    Fails CLOSED (→ False, benign) on any read/parse error — the conservative direction
+    for a false-alarm-prone subsystem (the OPPOSITE of ``_subsystem_enabled``'s default
+    True), so a missing/malformed secrets file never manufactures a permanent outreach
+    cessation alert on an install that isn't even running outreach."""
+    try:
+        import os
+
+        from genesis.channels.bridge_config import (
+            build_bridge_config,
+            parse_secrets_env_text,
+        )
+        from genesis.env import secrets_path
+
+        path = str(secrets_path())
+        if not os.path.exists(path):
+            return False
+        with open(path) as f:
+            return build_bridge_config(parse_secrets_env_text(f.read())) is not None
+    except Exception as exc:
+        # Log the exception TYPE only, never exc_info/message: a malformed non-token
+        # field in secrets.env (DAY_BOUNDARY_HOUR, or a TELEGRAM_ALLOWED_USERS entry
+        # that passes .isdigit() but not int()) can embed its raw value in the
+        # exception text — keep it out of the log. Broad catch is deliberate (fail
+        # CLOSED → False for EVERY error, so nothing bubbles to _subsystem_enabled's
+        # default-True). The token itself never reaches here (build_bridge_config
+        # returns None cleanly on a missing/placeholder token, no raise).
+        logger.debug("outreach-enabled read failed (%s); treating as not-enabled", type(exc).__name__)
+        return False
+
+
 def _subsystem_enabled(name: str) -> bool:
     """Best-effort: is this subsystem configured to run?
 
     A subsystem DISABLED (or unconfigured) must not raise a cessation/never-started
     alert: a disabled subsystem's stopped or absent pulse is intentional, not a death.
-    Covers ego (``ego`` config ``.enabled``) and inbox (``inbox_monitor.yaml`` present +
-    ``.enabled``); every other name defaults True (fail toward surfacing — only
-    subsystems with a real disable switch are checked)."""
+    Covers ego (``ego`` config ``.enabled``), inbox (``inbox_monitor.yaml`` present +
+    ``.enabled``), and outreach (a messaging channel / Telegram configured); every other
+    name defaults True (fail toward surfacing — only subsystems with a real disable
+    switch are checked)."""
     try:
         if name == "ego":
             from genesis.ego.config import load_ego_config
@@ -266,6 +318,8 @@ def _subsystem_enabled(name: str) -> bool:
             return bool(load_ego_config().enabled)
         if name == "inbox":
             return _inbox_enabled()
+        if name == "outreach":
+            return _outreach_enabled()
     except Exception:
         logger.debug("subsystem-enabled read failed for %s", name, exc_info=True)
     return True
@@ -393,6 +447,15 @@ def _never_started_verdict(
             is_paused = paused if paused is not None else _read_global_paused()
             if is_paused:
                 return benign
+        # Conditional-pulse subsystems (outreach): manifest "ok" means the object was
+        # constructed, NOT that it should be pulsing — its pulse only begins after a
+        # runtime precondition (channel registration) that may never occur. So an
+        # ok-but-never-pulsed state is benign, not a started-silent death (which would
+        # reintroduce a permanent unresolvable alert on a Telegram-configured install
+        # whose scheduler never starts). A genuine init FAILURE for it still alarms via
+        # the ``failed:``/``degraded`` branch above.
+        if name in _CONDITIONAL_PULSE_SUBSYSTEMS:
+            return benign
         persisted_at = parse_iso_utc(mf.get("persisted_at"))
         if persisted_at is None:
             return benign  # can't establish the grace clock → benign

--- a/src/genesis/outreach/heartbeat.py
+++ b/src/genesis/outreach/heartbeat.py
@@ -1,0 +1,109 @@
+"""Outreach heartbeat — a dedicated, channel-independent liveness pulse.
+
+Outreach's heartbeat used to be *emergent*: it only fired as a side-effect of an
+outreach job succeeding, and the outreach scheduler only ``.start()``s once a
+messaging channel (Telegram) registers. So a Telegram-less (dashboard-only) install
+never emitted an outreach pulse, and adding outreach to the cessation-alert set naively
+would fire a permanent unresolvable alert on exactly those installs — the false-alarm
+trap that kept outreach OUT of the alert set.
+
+This daemon breaks that coupling: it runs independently of channel registration and
+pulses ONLY while the outreach scheduler is actually running (``is_running``). Paired
+with the ``_subsystem_enabled('outreach')`` enable-gate (Telegram configured?), that
+gives honest coverage:
+  - Telegram-less install → not enabled → benign (no alert), and this daemon emits no
+    pulse anyway (scheduler never started).
+  - Telegram install, scheduler running → steady pulse → ``alive``.
+  - Telegram install, scheduler stopped/never-restarted → pulse ceases → the shared
+    ``compute_heartbeat_staleness`` goes ``overdue`` → ``subsystem_stale:outreach``.
+
+Boundary (documented, out of scope): a WEDGED-but-alive event loop keeps
+``is_running`` True and this thread pulsing — detecting a wedged (vs stopped) scheduler
+is job_health's domain, the same bar the dashboard/ego heartbeats hold.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+logger = logging.getLogger("genesis.outreach.heartbeat")
+
+
+class OutreachHeartbeat:
+    """Background daemon thread that emits heartbeat events for outreach."""
+
+    def __init__(self, interval_seconds: int = 60) -> None:
+        self._interval = interval_seconds
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+    def start(self) -> None:
+        """Start the heartbeat background thread."""
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name="outreach-heartbeat",
+        )
+        self._thread.start()
+        logger.info("Outreach heartbeat started (interval=%ds)", self._interval)
+
+    def stop(self) -> None:
+        """Signal the thread to stop and wait for it."""
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+
+    @staticmethod
+    def _should_emit(rt: object) -> bool:
+        """Emit a pulse only when outreach is genuinely running.
+
+        Gated on the scheduler's ``is_running`` (accurate across the start/stop
+        lifecycle: False before start and after ``stop()`` nulls it) so a
+        never-started / cleanly-stopped scheduler goes stale rather than reading a
+        false ``alive`` — while a Telegram-less install (scheduler never started)
+        simply never pulses.
+        """
+        scheduler = getattr(rt, "_outreach_scheduler", None)
+        return bool(
+            getattr(rt, "is_bootstrapped", False)
+            and getattr(rt, "event_bus", None)
+            and scheduler is not None
+            and getattr(scheduler, "is_running", False)
+        )
+
+    def _run(self) -> None:
+        from genesis.observability.types import Severity, Subsystem
+
+        while not self._stop_event.is_set():
+            try:
+                from genesis.runtime import GenesisRuntime
+
+                rt = GenesisRuntime.instance()
+                if self._should_emit(rt):
+                    loop = asyncio.new_event_loop()
+                    try:
+                        loop.run_until_complete(
+                            rt.event_bus.emit(
+                                Subsystem.OUTREACH,
+                                Severity.DEBUG,
+                                "heartbeat",
+                                "Outreach scheduler alive",
+                            )
+                        )
+                    finally:
+                        loop.close()
+                    rt.record_job_success("outreach_heartbeat")
+            except Exception as exc:
+                logger.error("Outreach heartbeat failed", exc_info=True)
+                try:
+                    from genesis.runtime import GenesisRuntime
+
+                    rt = GenesisRuntime.instance()
+                    rt.record_job_failure(
+                        "outreach_heartbeat", "heartbeat emission failed", exc=exc
+                    )
+                except Exception:
+                    pass
+            self._stop_event.wait(self._interval)

--- a/tests/test_mcp/test_subsystem_staleness.py
+++ b/tests/test_mcp/test_subsystem_staleness.py
@@ -5,12 +5,15 @@ Two surfaces, one shared signal (``compute_heartbeat_staleness``):
     heartbeat-emitting subsystem's last durable ``heartbeat`` event is older
     than its per-subsystem overdue threshold (its scheduler/loop stopped — a
     silent death the failure-gap job alarms cannot see). The alert set is
-    ``ego`` (CRITICAL) + ``inbox`` + ``dashboard`` (WARNING). **surplus** is
+    ``ego`` (CRITICAL) + ``inbox`` + ``dashboard`` + ``outreach`` (WARNING).
+    Outreach now has a DEDICATED, channel-independent heartbeat daemon
+    (``outreach/heartbeat.py``, pulses only while its scheduler is running) +
+    an enable-gate (``_outreach_enabled`` = Telegram configured), so it is
+    monitored without the old false-alarm trap (a Telegram-less install is
+    ``_subsystem_enabled('outreach') == False`` → benign). **surplus** stays
     dropped (PR-B's shipped tile already flips red on a wedged/dead surplus via
-    its job_health signal) and **outreach** is dropped (its pulse is
-    config-gated — never fires on a Telegram-less install). reflection/awareness
-    stay excluded (reflection's pulse tracks the awareness loop; awareness has
-    ``awareness:tick_overdue``).
+    its job_health signal). reflection/awareness stay excluded (reflection's
+    pulse tracks the awareness loop; awareness has ``awareness:tick_overdue``).
   - ``compute_heartbeat_staleness`` — the pure per-subsystem verdict the alert
     AND the ego dashboard tile both read, so the two can never disagree. It is
     pause-aware for the pause-gated subsystems ({surplus, inbox}, whose pulse
@@ -418,6 +421,99 @@ async def test_disabled_ego_suppresses_cessation_alert(db):
     assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:ego"]
 
 
+@pytest.mark.asyncio
+async def test_enabled_outreach_cessation_alerts_warning(db):
+    """An ENABLED outreach whose dedicated heartbeat stopped (pulse 50h old, past the
+    48h overdue threshold) → subsystem_stale:outreach WARNING. Proves outreach is now
+    in the alert set (previously excluded as a false-alarm trap)."""
+    await _seed_heartbeat(db, "outreach", age_seconds=50 * 3600)
+    with patch(
+        "genesis.mcp.health.manifest._subsystem_enabled",
+        side_effect=lambda n: n == "outreach",
+    ):
+        alerts = await _run_alerts_with_db(db)
+    stale = _stale(alerts)
+    assert any(a["id"] == "subsystem_stale:outreach" for a in stale), stale
+    o = next(a for a in stale if a["id"] == "subsystem_stale:outreach")
+    assert o["severity"] == "WARNING"
+    assert "outreach" in o["message"]
+
+
+@pytest.mark.asyncio
+async def test_disabled_outreach_suppresses_cessation_alert(db):
+    """A Telegram-less install (outreach not enabled) must NOT raise
+    subsystem_stale:outreach even with a stale retained pulse — the absent/stopped
+    scheduler is intentional, not a death. Mirrors the disabled-ego guard."""
+    await _seed_heartbeat(db, "outreach", age_seconds=50 * 3600)
+    with patch(
+        "genesis.mcp.health.manifest._subsystem_enabled",
+        side_effect=lambda n: n != "outreach",
+    ):
+        alerts = await _run_alerts_with_db(db)
+    assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:outreach"]
+
+
+def test_subsystem_enabled_reads_outreach_telegram_config(tmp_path):
+    """_subsystem_enabled('outreach') gates on whether Telegram is configured (the
+    same side-effect-free loader the bridge + onboarding-readiness use): no/placeholder
+    token → not enabled (dashboard-only install, benign); a valid token + numeric
+    allowed-user → enabled (outreach is supposed to run → monitor it)."""
+    from genesis.mcp.health import manifest as _m
+
+    not_configured = tmp_path / "secrets_none.env"
+    not_configured.write_text("TELEGRAM_BOT_TOKEN=\n")
+    with patch("genesis.env.secrets_path", return_value=not_configured):
+        assert _m._subsystem_enabled("outreach") is False
+
+    configured = tmp_path / "secrets_ok.env"
+    configured.write_text("TELEGRAM_BOT_TOKEN=123456:ABCDEF\nTELEGRAM_ALLOWED_USERS=42\n")
+    with patch("genesis.env.secrets_path", return_value=configured):
+        assert _m._subsystem_enabled("outreach") is True
+
+    # Fail CLOSED (→ benign) when the secrets file is absent — never manufacture a
+    # permanent outreach cessation alert from a read error.
+    missing = tmp_path / "does_not_exist.env"
+    with patch("genesis.env.secrets_path", return_value=missing):
+        assert _m._subsystem_enabled("outreach") is False
+
+
+@pytest.mark.asyncio
+async def test_enabled_outreach_no_pulse_is_benign_not_never_started(db):
+    """BLOCKER regression: outreach IS a bootstrap-manifest entry (records 'ok' =
+    scheduler CONSTRUCTED, not running). A Telegram-configured install whose scheduler
+    never .start()s (revoked token / Telegram unreachable at boot) has manifest 'ok' +
+    ZERO pulses past grace — that must be a BENIGN no_heartbeat, NOT a permanent
+    subsystem_never_started:outreach. Outreach's pulse only begins after channel
+    registration, so 'ok' ≠ 'should be pulsing' (the _CONDITIONAL_PULSE_SUBSYSTEMS
+    exemption). Without the exemption this returns never_started → RED."""
+    from genesis.mcp.health import manifest as _m
+
+    mf = _manifest({"outreach": "ok"}, persisted_age_s=3600)  # ≫ ~180s grace
+    with (
+        patch.object(_m, "_read_persisted_manifest", return_value=mf),
+        patch.object(_m, "_subsystem_enabled", side_effect=lambda n: n == "outreach"),
+    ):
+        verdict = await _m.compute_heartbeat_staleness("outreach", db=db, paused=False)
+    assert verdict["status"] == "no_heartbeat", verdict
+
+
+@pytest.mark.asyncio
+async def test_outreach_init_failure_still_never_started(db):
+    """The conditional-pulse exemption covers ONLY the ok-but-silent case: a genuine
+    outreach init FAILURE (manifest 'failed:'/'degraded' — the scheduler could not even
+    be constructed) still surfaces as never_started (init-failed)."""
+    from genesis.mcp.health import manifest as _m
+
+    mf = _manifest({"outreach": "failed: boom"}, persisted_age_s=3600)
+    with (
+        patch.object(_m, "_read_persisted_manifest", return_value=mf),
+        patch.object(_m, "_subsystem_enabled", side_effect=lambda n: n == "outreach"),
+    ):
+        verdict = await _m.compute_heartbeat_staleness("outreach", db=db, paused=False)
+    assert verdict["status"] == "never_started", verdict
+    assert verdict.get("reason") == "init-failed"
+
+
 # ── loosened thresholds (near-zero false-reds) ───────────────────────────────
 
 
@@ -483,6 +579,11 @@ async def _run_alerts_with_db(db, *, paused: bool = False):
         # subsystem_stale:inbox tests don't depend on the repo's inbox_monitor.yaml.
         # A test wanting a disabled inbox overrides this or patches _subsystem_enabled.
         patch("genesis.mcp.health.manifest._inbox_enabled", return_value=True),
+        # Hermetic default: treat outreach as NOT enabled (Telegram-less) so existing
+        # tests don't depend on this box's secrets.env / raise a spurious
+        # subsystem_stale:outreach. A test wanting outreach monitored overrides this
+        # or patches _subsystem_enabled.
+        patch("genesis.mcp.health.manifest._outreach_enabled", return_value=False),
     ):
         from genesis.mcp.health.errors import _impl_health_alerts
 
@@ -553,13 +654,9 @@ async def test_surplus_dropped_from_alert_set(db):
     assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:surplus"]
 
 
-@pytest.mark.asyncio
-async def test_outreach_dropped_from_alert_set(db):
-    """outreach is DROPPED (config-gated pulse → false-alarm trap) — even a
-    3-day-old outreach heartbeat emits NO subsystem_stale:outreach."""
-    await _seed_heartbeat(db, "outreach", age_seconds=3 * 86400)  # ≫ 172800 threshold
-    alerts = await _run_alerts_with_db(db)
-    assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:outreach"]
+# NOTE: outreach is no longer "dropped" — it is now in the alert set, enable-gated on
+# Telegram config. The enabled→WARNING and disabled→suppressed cases are covered by
+# test_enabled_outreach_cessation_alerts_warning + test_disabled_outreach_suppresses_cessation_alert.
 
 
 @pytest.mark.asyncio

--- a/tests/test_outreach/test_heartbeat.py
+++ b/tests/test_outreach/test_heartbeat.py
@@ -1,0 +1,44 @@
+"""OutreachHeartbeat gate — pulses ONLY while the outreach scheduler is running.
+
+The daemon exists to give outreach a channel-independent liveness pulse without the
+old false-alarm trap. Its emit condition is the load-bearing logic: a Telegram-less /
+never-started / cleanly-stopped scheduler must NOT pulse (so the subsystem reads stale
+or benign, never a false alive), while a running scheduler must.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from genesis.outreach.heartbeat import OutreachHeartbeat
+
+
+def _rt(*, bootstrapped=True, bus=True, scheduler=True, running=True):
+    sched = SimpleNamespace(is_running=running) if scheduler else None
+    return SimpleNamespace(
+        is_bootstrapped=bootstrapped,
+        event_bus=object() if bus else None,
+        _outreach_scheduler=sched,
+    )
+
+
+def test_emits_when_scheduler_running():
+    assert OutreachHeartbeat._should_emit(_rt()) is True
+
+
+def test_no_emit_when_scheduler_stopped():
+    # is_running False → never-started or cleanly-stopped → pulse ceases → goes stale.
+    assert OutreachHeartbeat._should_emit(_rt(running=False)) is False
+
+
+def test_no_emit_when_scheduler_absent():
+    # Telegram-less install: scheduler was never constructed/started.
+    assert OutreachHeartbeat._should_emit(_rt(scheduler=False)) is False
+
+
+def test_no_emit_before_bootstrap():
+    assert OutreachHeartbeat._should_emit(_rt(bootstrapped=False)) is False
+
+
+def test_no_emit_without_event_bus():
+    assert OutreachHeartbeat._should_emit(_rt(bus=False)) is False


### PR DESCRIPTION
## Problem

Outreach was excluded from the `subsystem_stale` cessation-alert set because its heartbeat was
**emergent** — emitted only as a side-effect of an outreach job succeeding — and the outreach scheduler
only `.start()`s once a messaging channel (Telegram) registers (`runtime/_job_health.py`, sole
`.start()` caller). So a Telegram-less (dashboard-only) install never pulsed, and naively adding outreach
to the alert set would fire a permanent unresolvable `subsystem_stale:outreach` on exactly those installs
(a documented false-alarm trap, `errors.py`).

## Fix

- **Dedicated daemon** (`outreach/heartbeat.py`, mirrors `dashboard/heartbeat.py`) that pulses **only
  while the outreach scheduler is running** (`is_running` — lifecycle-accurate: set at `start()`, nulled
  at `stop()`), independent of channel registration. Wired unconditionally at bootstrap in
  `standalone.py::_register_blueprints` (outside the dashboard-registration guard).
- **Enable-gate** `_outreach_enabled()` = Telegram configured, via the same side-effect-free
  `build_bridge_config` loader onboarding-readiness uses (no drift). Fails **closed** (benign) and logs
  only the exception *type*, never secrets content — so a dashboard-only install is benign.
- `outreach` added to the `subsystem_stale` set (WARNING); `HEARTBEAT_EXPECTED["outreach"]` retuned
  `86400/172800` → `120/600` to match the 60s daemon (overdue at 10×, like `dashboard`).

## never_started handling (the review BLOCKER)

Outreach **is** a bootstrap-manifest entry (`_INIT_CHECKS` → `"outreach": "_outreach_scheduler"`; records
`ok` = scheduler *constructed*, not running). So it is exempted from the **started-silent** `never_started`
inference (`_CONDITIONAL_PULSE_SUBSYSTEMS`) — a constructed-but-not-started scheduler is benign; only a
genuine init **failure** (`failed:`/`degraded`) fires `never_started`, and only `subsystem_stale` (a
once-running scheduler that died) fires on cessation. This avoids reintroducing the permanent-alert trap
on a Telegram-configured install whose scheduler never starts (revoked token / Telegram unreachable at
boot). Boundary (documented): a wedged-but-alive loop keeps `is_running` True → job_health's domain.

## Tests / review

77 tests green (RED→GREEN verified, incl. verify-RED on the never_started exemption). Reviewed by
`genesis-architect` (found + fixed the never_started BLOCKER + threshold) and `genesis-security-reviewer`
(secrets-read surface clean; one debug-log hardening applied). Consumers handle `subsystem_stale:outreach`
generically (morning-report dedup by prefix, Sentinel `subsystem_stale:` disposition). Live E2E (pulse +
alert fire/resolve on the running server) lands post-deploy.

Ledger: 12e9b797e466401b8e1f089fc44e974c
