### PR TITLE
fix(hooks): ANSI-C/comment/line-continuation-aware quote scanning in shell_parse

### DIFF
--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -22,6 +22,26 @@ This module centralizes that parsing so ``git_push_guard``,
 ``review_enforcement_commit``, and the destructive/path guards agree. Stdlib
 only; fail-open (a segment that won't tokenize degrades to a naive split rather
 than raising) — a guard must never crash the tool.
+
+Quote scanning is CENTRALIZED in one primitive (``_quote_span_end``): every
+hand-rolled walker below calls it, so all four bash quote openers — ``'…'``,
+``"…"``, ANSI-C ``$'…'`` (``\\'`` does NOT close), locale ``$"…"`` — are modelled
+once, and the ANSI-C form can no longer hide a gated action from segmentation.
+
+SCOPE IS CONSCIOUSLY BOUNDED — this is an ACCIDENT-PREVENTION parser, not an
+adversarial sandbox (a Bash-STRING guard can never be one: a deliberate evader
+already has ``python -c 'subprocess…'`` and ``eval``, which no such guard sees).
+So it closes the ACCIDENT-PLAUSIBLE lexical forms (the quote openers above,
+backslash line-continuation, ``\\'`` outside quotes) and treats the rest as
+ACCEPTED RESIDUE, per the standing 2026-08-12 decision (``review_enforcement_commit``
+~lines 686-697): DELIBERATE / dynamic construction — ``eval``, shell aliases,
+``python -c``, ``$(printf …)`` dynamic strings — and the LARGER structural gap of
+heredoc bodies (``<<``/``<<-``) and escaped-backtick nesting. A future review
+finding of one of THOSE is a ``tabled`` residue record, NOT another one-off patch
+here (that is the non-converging hand-rolled-lexer tail —
+``feedback_no_handrolled_shell_parsing_for_guards``). Do NOT re-open the class by
+symptom-patching a residue form; the fix for the residue is architectural
+(canonical parser) or a conscious threat-model change, not an incremental scanner.
 """
 
 from __future__ import annotations
@@ -174,6 +194,51 @@ class _ParsedSegment(NamedTuple):
     redirects: tuple[str, ...]
 
 
+def _quote_span_end(command: str, i: int, n: int) -> int:
+    """Index just PAST the closing quote of the span that OPENS at ``command[i]``.
+
+    The single shared quote-scanner for every hand-rolled walker in this module, so
+    the four bash quote openers live in ONE place (this logic was duplicated across
+    seven scanners, each blind to ANSI-C ``$'…'``):
+
+    - ``'…'``   POSIX single quote — NOTHING escapes; closes on the next ``'``.
+    - ``"…"``   double quote — ``\\`` escapes the next char; closes on an unescaped ``"``.
+    - ``$'…'``  ANSI-C quote — ``\\`` escapes (so ``\\'`` does NOT close); closes on ``'``.
+    - ``$"…"``  locale quote — parses exactly like ``"…"``.
+
+    ``command[i]`` MUST be ``'``/``"`` or begin ``$'``/``$"`` — callers gate on that.
+
+    Two load-bearing contract points: it NEVER raises — an UNTERMINATED span fails
+    open to ``n`` (consume to EOL), matching the module's no-crash guarantee; and it
+    ALWAYS returns an index STRICTLY greater than ``i``. analyze()'s substitution /
+    ``bash -c`` recursion is unbounded, so a non-advancing return would HANG the tool
+    — a worse failure than the mis-parse this closes.
+    """
+    if command[i] == "$":  # two-char opener: $' (ANSI-C) or $" (locale)
+        qchar = command[i + 1]
+        escapes = True  # both $'…' and $"…" honor backslash escaping
+        j = i + 2
+    else:
+        qchar = command[i]
+        escapes = qchar == '"'  # \ is active only inside "…" (inert inside '…')
+        j = i + 1
+    while j < n:
+        c = command[j]
+        if escapes and c == "\\" and j + 1 < n:
+            j += 2
+            continue
+        if c == qchar:
+            return j + 1
+        j += 1
+    return n  # unterminated → fail-open to EOL, never raise
+
+
+def _is_quote_opener(command: str, i: int, n: int) -> bool:
+    """True when ``command[i]`` opens a quote span: bare ``'``/``"`` or ``$'``/``$"``."""
+    c = command[i]
+    return c in ("'", '"') or (c == "$" and i + 1 < n and command[i + 1] in ("'", '"'))
+
+
 def _command_sub_end(command: str, i: int, n: int) -> int:
     """Index just past the matching ``)`` of a ``$(…)`` command substitution that
     opens at ``command[i:i+2] == "$("``.
@@ -191,23 +256,13 @@ def _command_sub_end(command: str, i: int, n: int) -> int:
     two divergent paren-counters.
     """
     depth, j = 1, i + 2
-    q: str | None = None  # in-body quote state
     while j < n:
         ch = command[j]
-        if q is not None:
-            if q == '"' and ch == "\\" and j + 1 < n:  # \ escapes only inside "…"
-                j += 2
-                continue
-            if ch == q:
-                q = None
-            j += 1
-            continue
         if ch == "\\" and j + 1 < n:  # unquoted backslash escapes the next char
             j += 2
             continue
-        if ch in ("'", '"'):  # a quoted span begins — its inner ) is data
-            q = ch
-            j += 1
+        if _is_quote_opener(command, j, n):  # ', ", $', $" span — its inner ) is data
+            j = _quote_span_end(command, j, n)
             continue
         if ch == "`":  # nested backtick span — skip to its close (or EOL)
             close = command.find("`", j + 1)
@@ -239,26 +294,16 @@ def _redirect_target_end(command: str, j0: int, n: int) -> int:
     as one word and excised from argv whole, not just its leading ``$``.
     """
     j = j0
-    wq: str | None = None  # in-word quote state
     while j < n:
         ch = command[j]
-        if wq is not None:
-            if wq == '"' and ch == "\\" and j + 1 < n:
-                j += 2
-                continue
-            if ch == wq:
-                wq = None
-            j += 1
-            continue
         if ch == "\\" and j + 1 < n:  # unquoted backslash escapes the next char
             j += 2
             continue
-        if ch in ("'", '"'):  # a quote span begins (or concatenates)
-            wq = ch
-            j += 1
-            continue
         if ch == "$" and j + 1 < n and command[j + 1] == "(":  # $(…) command sub
             j = _command_sub_end(command, j, n)  # quote/escape/nesting-aware close
+            continue
+        if _is_quote_opener(command, j, n):  # ', ", $', $" span suppresses metachars
+            j = _quote_span_end(command, j, n)
             continue
         if ch == "`":  # `…` backtick sub — to the matching backtick (or EOL)
             close = command.find("`", j + 1)
@@ -268,6 +313,12 @@ def _redirect_target_end(command: str, j0: int, n: int) -> int:
             break
         j += 1
     return j
+
+
+# A ``#`` starts a bash comment ONLY at the start of a word — preceded by nothing
+# (start of input) or by an unquoted whitespace / command-separator / subshell-open.
+# A ``#`` glued into a word (``foo#bar``, ``--format=%h#``) is literal, NOT a comment.
+_COMMENT_PRECEDERS = frozenset(" \t\n;|&(")
 
 
 def parse_segments(command: str) -> list[_ParsedSegment]:
@@ -288,41 +339,79 @@ def parse_segments(command: str) -> list[_ParsedSegment]:
     split closes). Process substitution ``<(…)``/``>(…)`` stays in BOTH (documented gap).
     ``raw`` stays byte-identical to the historical ``split_segments`` output for every
     ordinary command (the cwd/occurrence consumers match ``Segment.raw`` against a fresh
-    re-split; locked by a golden test over a broad corpus). ONE intentional difference
-    from the pre-#1455 scanner: a ``$(…)``/backtick target that contains an UNQUOTED
-    control operator (``;`` ``&&`` ``||`` ``|``) is now paren-balanced into ONE segment
-    instead of mis-split on that operator — which CLOSES an additional fail-open (HEAD
-    mis-split ``git 2>$(a; b) push`` into ``git  $(a`` + ``b) push`` so ``git_subcommand``
-    never saw the ``push``); the nested ``a``/``b`` still surface via ``_substitutions``.
-    So ``raw`` is byte-identical EXCEPT it is strictly SAFER on this class — never the
-    other direction (locked by the ``$(;)``/``$(&&)``/``$(|)`` cases in the redirect-argv
-    test's EXPLOITS).
+    re-split — self-consistent regardless — locked by a golden test over a broad corpus).
+    The intentional differences are ALL correctness fixes in the SAFE direction (a segment
+    that used to mis-split now stays whole so a following gated token can't hide):
+
+      1. A ``$(…)``/backtick target with an UNQUOTED control operator (``;`` ``&&`` ``||``
+         ``|``) is paren-balanced into ONE segment (pre-#1455 mis-split ``git 2>$(a; b)
+         push`` so ``git_subcommand`` never saw ``push``); the nested ``a``/``b`` still
+         surface via ``_substitutions``.
+      2. ANSI-C ``$'…'`` spans are honored (``\\'`` no longer mis-closes and re-exposes an
+         in-string ``;``/``&&``/``#`` as a real separator/comment).
+      3. A ``\\<newline>`` line-continuation is DROPPED (bash joins the lines); other
+         unquoted-``\\`` escapes (``\\;`` ``\\&`` ``\\'``) are kept as one inert unit so an
+         escaped separator/quote no longer splits or opens a span.
+      4. A word-start ``#`` comment runs to end-of-line: a quote char or separator INSIDE
+         the comment (a contraction ``# don't``, a ``# a ; b``) is inert, so it can no
+         longer swallow the newline / mis-split and hide the next command.
+
+    Never the other (fail-open) direction — locked by the redirect-argv EXPLOITS corpus
+    and ``test_shell_parse_quote_class`` (ANSI-C, line-continuation, comment-swallow).
     """
     pairs: list[tuple[str, str, list[str]]] = []
     raw_buf: list[str] = []
     argv_buf: list[str] = []
     redirs: list[str] = []
     i, n = 0, len(command)
-    quote: str | None = None
+    # Paren-type stack: True = a `$(` EXPANSION-open, False = a bare `(` GROUP-open.
+    # A `)` closing a bare GROUP is a comment word-boundary (`(cmd)#comment` IS a real
+    # bash comment); a `)` closing an EXPANSION is word-continuation (`$(cmd)#note` is
+    # literal). The single-char lookback below can't tell the two apart — both end in
+    # `)` — so we track which the most recent `)` closed in ``last_close_was_group``.
+    pstack: list[bool] = []
+    last_close_was_group = False
     while i < n:
         c = command[i]
-        if quote:
-            raw_buf.append(c)
-            argv_buf.append(c)
-            if quote == '"' and c == "\\" and i + 1 < n:
-                raw_buf.append(command[i + 1])
-                argv_buf.append(command[i + 1])
+        if c == "\\" and i + 1 < n:
+            if command[i + 1] == "\n":
+                # Line-continuation: bash REMOVES `\<newline>` entirely (the two lines
+                # join), so drop both chars — otherwise a real `git \<newline>push`
+                # keeps a stray newline and shlex fails to see the subcommand.
                 i += 2
                 continue
-            if c == quote:
-                quote = None
-            i += 1
+            # Any other unquoted backslash escapes the next char: an escaped separator
+            # (\; \& \|) or an escaped quote (\' \") is INERT — kept verbatim so it
+            # neither splits the segment nor opens a quote span.
+            raw_buf.append(command[i : i + 2])
+            argv_buf.append(command[i : i + 2])
+            i += 2
             continue
-        if c in ("'", '"'):
-            quote = c
-            raw_buf.append(c)
-            argv_buf.append(c)
-            i += 1
+        if _is_quote_opener(command, i, n):
+            # ', ", $' (ANSI-C), $" (locale) — copy the whole span verbatim (its inner
+            # operators/#/quotes are data). One shared scanner: no naive `'`-only model.
+            end = _quote_span_end(command, i, n)
+            raw_buf.append(command[i:end])
+            argv_buf.append(command[i:end])
+            i = end
+            continue
+        if c == "#" and (
+            i == 0
+            or command[i - 1] in _COMMENT_PRECEDERS
+            # a `)` that closed a bare subshell GROUP is a word boundary → comment;
+            # a `)` that closed a `$(` EXPANSION is word-continuation → NOT a comment.
+            or (command[i - 1] == ")" and last_close_was_group)
+        ):
+            # An unquoted, word-start `#` is a comment to END OF LINE (bash). Copy it
+            # verbatim but WITHOUT quote-scanning it — a quote char inside the comment
+            # (a contraction: `# don't`) is INERT and must not open a span that swallows
+            # the newline separator and hides the next command. The `\n` still splits
+            # (handled below); an EOF-terminated comment ends the final segment.
+            nl = command.find("\n", i)
+            end = nl if nl != -1 else n
+            raw_buf.append(command[i:end])
+            argv_buf.append(command[i:end])
+            i = end
             continue
         two = command[i : i + 2]
         if two in ("&&", "||"):
@@ -380,6 +469,10 @@ def parse_segments(command: str) -> list[_ParsedSegment]:
             continue
         raw_buf.append(c)
         argv_buf.append(c)
+        if c == "(":  # bare `(` = group-open; `$(` = expansion-open (prev char is `$`)
+            pstack.append(i > 0 and command[i - 1] == "$")
+        elif c == ")":
+            last_close_was_group = bool(pstack) and not pstack.pop()
         i += 1
     pairs.append(("".join(raw_buf), "".join(argv_buf), list(redirs)))
     return [
@@ -417,27 +510,20 @@ def has_top_level_pipe(command: str) -> bool:
     these fully is the unbounded quote-parsing tail shared with ``split_segments``.
     """
     i, n = 0, len(command)
-    quote: str | None = None
     subst_depth = 0  # inside $( … ): its output is CAPTURED, not streamed to bg stdout
     in_backtick = False
     while i < n:
         c = command[i]
-        if quote:
-            if quote == '"' and c == "\\" and i + 1 < n:
-                i += 2
-                continue
-            if c == quote:
-                quote = None
-            i += 1
-            continue
         if in_backtick:  # `…` substitution — output captured, so any `|` inside is not a bg pipe
             if c == "`":
                 in_backtick = False
             i += 1
             continue
-        if c in ("'", '"'):
-            quote = c
-            i += 1
+        if c == "\\" and i + 1 < n:  # unquoted backslash escapes the next char
+            i += 2
+            continue
+        if _is_quote_opener(command, i, n):  # ', ", $', $" — any `|` inside is data
+            i = _quote_span_end(command, i, n)
             continue
         if c == "`":
             in_backtick = True
@@ -471,27 +557,20 @@ def has_top_level_pipe(command: str) -> bool:
 def _strip_trailing_comment(seg: str) -> str:
     """Remove an unquoted ``#`` comment (whitespace-preceded or at start) to EOL."""
     out: list[str] = []
-    quote: str | None = None
     prev_ws = True  # start-of-string counts as preceding whitespace
     i, n = 0, len(seg)
     while i < n:
         c = seg[i]
-        if quote:
-            out.append(c)
-            if quote == '"' and c == "\\" and i + 1 < n:
-                out.append(seg[i + 1])
-                i += 2
-                continue
-            if c == quote:
-                quote = None
+        if c == "\\" and i + 1 < n:  # unquoted backslash escapes the next char (incl. #)
+            out.append(seg[i : i + 2])
             prev_ws = False
-            i += 1
+            i += 2
             continue
-        if c in ("'", '"'):
-            quote = c
-            out.append(c)
+        if _is_quote_opener(seg, i, n):  # ', ", $', $" — copy verbatim; a # inside is data
+            end = _quote_span_end(seg, i, n)
+            out.append(seg[i:end])
             prev_ws = False
-            i += 1
+            i = end
             continue
         if c == "#" and prev_ws:
             break  # comment to end of segment
@@ -540,24 +619,17 @@ def _has_trailing_override(seg: str, sigil: str = "review-override") -> bool:
     able to coexist without letting an incidental or negated prose mention waive
     the gate.
     """
-    quote: str | None = None
     prev_ws = True
     i, n = 0, len(seg)
     while i < n:
         c = seg[i]
-        if quote:
-            if quote == '"' and c == "\\" and i + 1 < n:
-                i += 2
-                continue
-            if c == quote:
-                quote = None
+        if c == "\\" and i + 1 < n:  # unquoted backslash escapes the next char
             prev_ws = False
-            i += 1
+            i += 2
             continue
-        if c in ("'", '"'):
-            quote = c
+        if _is_quote_opener(seg, i, n):  # ', ", $', $" — a # inside is data, not a comment
+            i = _quote_span_end(seg, i, n)
             prev_ws = False
-            i += 1
             continue
         if c == "#" and prev_ws:
             for tok in seg[i + 1 :].split():
@@ -783,30 +855,27 @@ def command_runs_pytest(command: str) -> bool:
 def _substitutions(text: str) -> list[str]:
     """Command-substitution bodies — ``$(…)`` and ``` `…` ``` — which also run.
 
-    Only single-quoted spans block substitution (``$()`` still expands inside
-    double quotes). A ``$()`` body is bounded QUOTE/ESCAPE/NESTING-aware via the
-    shared ``_command_sub_end`` — a ``)`` inside a quoted operand of the body is
-    DATA, so the body is extracted to its TRUE close (the same scanner the redirect-
-    target boundary uses, so the two never disagree on where a ``$()`` ends).
-    Best-effort: exotic forms (process substitution ``<(…)``, ANSI-C ``$'…'``
-    scripts, ``env -S`` string-splitting, shell aliases/functions) are NOT parsed —
-    this guard is an approval/friction layer, not a sandbox, and fails toward
-    over-matching on the common forms rather than pretending to cover every shell
-    construct.
+    Single-quoted AND ANSI-C ``$'…'`` spans block substitution (both are skipped
+    whole via the shared ``_quote_span_end``, so a ``\\'`` inside ``$'…'`` no longer
+    mis-closes and re-exposes a following ``$()``); ``$()`` still expands inside
+    double / locale (``$"…"``) quotes, which stay transparent. A ``$()`` body is
+    bounded QUOTE/ESCAPE/NESTING-aware via the shared ``_command_sub_end`` — a ``)``
+    inside a quoted operand of the body is DATA, so the body is extracted to its TRUE
+    close (the same scanner the redirect-target boundary uses, so the two never
+    disagree on where a ``$()`` ends). Best-effort residue (accepted, see module
+    docstring): process substitution ``<(…)``, ``env -S`` string-splitting, shell
+    aliases/functions, and ANSI-C escape DECODING (span boundaries are honored, but
+    the escapes inside are not decoded) — this is an approval/friction layer, not a
+    sandbox, and fails toward over-matching on the common forms.
     """
     subs: list[str] = []
     i, n = 0, len(text)
-    in_sq = False
     while i < n:
         c = text[i]
-        if in_sq:
-            if c == "'":
-                in_sq = False
-            i += 1
-            continue
-        if c == "'":
-            in_sq = True
-            i += 1
+        # A single-quoted or ANSI-C ($'…') span SUPPRESSES substitution — skip it whole.
+        # Double / locale quotes ("…", $"…") stay TRANSPARENT: $() still expands inside.
+        if c == "'" or (c == "$" and i + 1 < n and text[i + 1] == "'"):
+            i = _quote_span_end(text, i, n)
             continue
         if c == "$" and i + 1 < n and text[i + 1] == "(":
             end = _command_sub_end(text, i, n)  # index past matching ')'

--- a/tests/test_hooks/test_shell_parse_quote_class.py
+++ b/tests/test_hooks/test_shell_parse_quote_class.py
@@ -1,0 +1,196 @@
+"""Class fix: shell_parse's hand-rolled quote scanners must be ANSI-C ($'…') /
+locale ($"…") aware and honor unquoted-backslash escaping (line-continuation,
+\\' outside quotes), so a gated git action cannot hide from analyze()-based
+guards behind an ACCIDENT-PLAUSIBLE lexical form.
+
+Ground truth (verified against real bash 5.x): each obfuscated command below
+runs a real `git push --force` / `git commit --no-verify`; the heredoc-body form
+runs git as DATA (never executed) and is DOCUMENTED ACCEPTED RESIDUE.
+
+Scope boundary (consciously bounded — see shell_parse module docstring): DELIBERATE
+evasion and dynamic construction (eval / python -c / $(printf…) / aliases / heredoc
+bodies) are accepted residue per the 2026-08-12 decision (review_enforcement_commit
+lines ~686-697); those are NOT expected to be caught and are locked as residue below.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_WT = Path(__file__).resolve().parents[2]
+_HOOKS = _WT / "scripts" / "hooks"
+_SCRIPTS = _WT / "scripts"
+_PY = sys.executable
+if str(_HOOKS) not in sys.path:
+    sys.path.insert(0, str(_HOOKS))
+
+_spec = importlib.util.spec_from_file_location("shell_parse", _HOOKS / "shell_parse.py")
+sp = importlib.util.module_from_spec(_spec)
+sys.modules["shell_parse"] = sp
+_spec.loader.exec_module(sp)
+
+P = "pu" + "sh"
+NV = "--no" + "-verify"
+F = "--" + "force"
+
+# ANSI-C obfuscation: x=$'a\'b'  (the \' must NOT close the span; bash runs the
+# tail as a real command). Assembled so the literal stays intact.
+_ANSI = "x=$'a\\'b'"
+_LC = "\\\n"  # backslash-newline line continuation (bash removes it)
+
+
+def _sees_git(cmd: str, sub: str) -> bool:
+    segs = sp.analyze(cmd)
+    return any(s.exe == "git" and sp.git_subcommand(s.argv) == sub for s in segs)
+
+
+def _run_hook(
+    script_rel: str, command: str, script_dir: Path = _HOOKS
+) -> subprocess.CompletedProcess:
+    payload = json.dumps({"tool_input": {"command": command}, "tool_name": "Bash"})
+    return subprocess.run(
+        [_PY, str(script_dir / script_rel)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+class TestAnalyzeSeesGatedActionThroughLexicalForms:
+    """RED before the fix: analyze() mis-segments these and the git action vanishes."""
+
+    def test_ansi_c_then_push(self):
+        assert _sees_git(f"{_ANSI} && git {P} {F}", P)
+
+    def test_line_continuation_push(self):
+        assert _sees_git(f"git {_LC}{P} {F}", P)
+
+    def test_ansi_c_then_commit_no_verify(self):
+        cmd = f"{_ANSI} && git commit {NV} -m x"
+        assert any(sp.commit_skips_hooks(s.argv) for s in sp.analyze(cmd))
+
+    def test_control_plain_push_still_seen(self):
+        assert _sees_git(f"git {P} {F}", P)
+
+
+class TestPushGuardBlocksThroughLexicalForms:
+    """E2E through the real hook (stdin payload, as CC invokes it)."""
+
+    def test_ansi_c_force_push_blocks(self):
+        r = _run_hook("git_push_guard.py", f"{_ANSI} && git {P} origin main {F}")
+        assert r.returncode == 2, f"expected BLOCK, got {r.returncode}: {r.stderr}"
+
+    def test_line_continuation_force_push_blocks(self):
+        r = _run_hook("git_push_guard.py", f"git {_LC}{P} origin main {F}")
+        assert r.returncode == 2, f"expected BLOCK, got {r.returncode}: {r.stderr}"
+
+    def test_ansi_c_commit_no_verify_blocks(self):
+        r = _run_hook("git_push_guard.py", f"{_ANSI} && git commit {NV} -m x")
+        assert r.returncode == 2, f"expected BLOCK, got {r.returncode}: {r.stderr}"
+
+    def test_control_no_verify_still_blocks(self):
+        r = _run_hook("git_push_guard.py", f"git commit {NV} -m x")
+        assert r.returncode == 2
+
+
+class TestTwinCommitGateInheritsFix:
+    """review_enforcement_commit.py shares the analyze()-based commit gate."""
+
+    def test_ansi_c_commit_no_verify_blocks_at_commit_hook(self):
+        r = _run_hook("review_enforcement_commit.py", f"{_ANSI} && git commit {NV} -m x", _SCRIPTS)
+        assert r.returncode == 2, f"expected BLOCK, got {r.returncode}: {r.stderr}"
+
+
+class TestNoFalseFireOnLegitForms:
+    """Monotonic: the fix must not start blocking legit commands."""
+
+    def test_legit_ansi_c_commit_message_not_blocked(self):
+        # $'l1\nl2' as a legit multi-line message, no gated flag → allow.
+        r = _run_hook("git_push_guard.py", "git commit -m $'l1\\nl2'")
+        assert r.returncode == 0, r.stderr
+
+    def test_apostrophe_in_trailing_comment_not_blocked(self):
+        # The false-fire that killed the rejected shlex-probe approach.
+        r = _run_hook("git_push_guard.py", f"git {P} {F} # don't")
+        # push present → the push gate applies (ask/deny), but this must NOT be a
+        # crash/parse-block. In a non-interactive test env the push path returns
+        # its own code; we only assert the parser didn't corrupt into an error exit.
+        assert r.returncode in (0, 2)
+
+
+class TestDocumentedAcceptedResidue:
+    """LOCK the boundary: these DELIBERATE/dynamic forms are accepted residue
+    (not caught). A future change that 'fixes' one is a CONSCIOUS choice, not an
+    incremental patch — this test failing means the boundary moved on purpose."""
+
+    def test_eval_wrapped_push_is_accepted_residue(self):
+        # eval executes its string arg; no Bash-string guard can see it. RESIDUE.
+        assert not _sees_git(f"eval 'git {P} {F}'", P)
+
+    def test_python_c_push_is_accepted_residue(self):
+        cmd = 'python3 -c \'import subprocess; subprocess.run(["git","' + P + "\"])'"
+        assert not _sees_git(cmd, P)
+
+
+class TestCommentAwarenessNoSwallow:
+    """A ``#`` comment runs to end-of-line (bash). A quote char inside it (any English
+    contraction — don't / it's / can't) must NOT open a span that swallows the newline
+    and hides a following gated command. This is the accident-plausible bypass the
+    security review reproduced live (pre-existing; folded into this PR as same-class)."""
+
+    def test_comment_apostrophe_then_push_blocks(self):
+        r = _run_hook("git_push_guard.py", f"git status # don't worry\ngit {P} origin main {F}")
+        assert r.returncode == 2, f"comment-apostrophe swallowed the push: {r.stderr}"
+
+    def test_comment_apostrophe_then_commit_nv_blocks(self):
+        r = _run_hook("git_push_guard.py", f"git status # don't\ngit commit {NV} -m x")
+        assert r.returncode == 2, r.stderr
+
+    def test_comment_apostrophe_at_review_enforcement_commit(self):
+        r = _run_hook(
+            "review_enforcement_commit.py", f"git status # don't\ngit commit {NV} -m x", _SCRIPTS
+        )
+        assert r.returncode == 2, r.stderr
+
+    def test_control_plain_comment_then_commit_nv_blocks(self):
+        r = _run_hook("git_push_guard.py", f"git status # note\ngit commit {NV} -m x")
+        assert r.returncode == 2
+
+    def test_analyze_splits_across_comment_apostrophe(self):
+        assert _sees_git(f"git status # don't\ngit {P} {F}", P)
+
+    def test_multiline_double_quote_still_one_span(self):
+        # A real newline INSIDE a double-quoted string must still be ONE segment —
+        # comment-awareness must not break legit multi-line quotes.
+        segs = sp.analyze('git commit -m "line1\nline2"')
+        assert len(segs) == 1 and sp.git_subcommand(segs[0].argv) == "commit"
+
+    def test_hash_glued_to_word_not_a_comment(self):
+        # `#` NOT preceded by a boundary is not a comment; treating it as one would
+        # strip trailing content and could hide a following gated token (safe-direction
+        # guardrail — the push after && must stay visible).
+        assert _sees_git(f"echo a#b && git {P} {F}", P)
+
+    def test_subshell_group_close_glued_comment_apostrophe_blocks(self):
+        # A bare subshell-group close `)` glued to a comment is a REAL bash comment;
+        # an apostrophe in it must not swallow the following gated command.
+        r = _run_hook(
+            "review_enforcement_commit.py", f"(git status)#don't\ngit commit {NV} -m x", _SCRIPTS
+        )
+        assert r.returncode == 2, r.stderr
+
+    def test_expansion_close_glued_hash_not_a_comment(self):
+        # `$(cmd)#...` is word-continuation, NOT a comment — the following SAME-LINE
+        # gated command must stay visible. (Naively treating any `)` as a comment
+        # preceder would fail-open here — this locks the distinction.)
+        segs = sp.analyze(f"foo=$(date)#c; git commit {NV} -m x")
+        assert any(sp.commit_skips_hooks(s.argv) for s in segs)
+
+    def test_backtick_close_glued_hash_not_a_comment(self):
+        segs = sp.analyze(f"foo=`date`#c; git commit {NV} -m x")
+        assert any(sp.commit_skips_hooks(s.argv) for s in segs)


### PR DESCRIPTION
## Summary

Centralize `shell_parse`'s quote scanning into one ANSI-C/locale-aware primitive and close a family of accident-plausible lexical blind spots that could let a gated git action (push / commit `--no-verify` / force / clean) slip an `analyze()`-based guard.

## Problem

`shell_parse` had seven separate hand-rolled quote scanners, each modelling only `'…'`/`"…"` and blind to:

- ANSI-C `$'…'` (where `\'` does not close the span)
- backslash line-continuation and `\'`-outside-quotes
- end-of-line `#` comments — an apostrophe in a comment (any contraction, `# don't`) opened an unterminated span that swallowed the newline and hid the next command

Each gap could mis-segment a command so a following gated subcommand was mis-attributed and never seen by the guards.

## Fix

- One shared `_quote_span_end` (+ `_is_quote_opener`) modelling all four bash quote openers (`'…'`, `"…"`, `$'…'`, `$"…"`) once; all seven scanners refactored to it (removes the duplicated naive model).
- Unquoted-backslash handling (line-continuation drop; escaped separator/quote kept inert).
- `parse_segments` comment-awareness with paren-type tracking: a bare `(cmd)` group-close is a comment word-boundary, but a `$(cmd)` expansion-close is not (the single-char lookback can't distinguish them otherwise, and a naive rule would itself be a fail-open).
- Consciously-bounded scope documented in-module: deliberate/dynamic evasion (`eval`, aliases, `python -c`, `$(printf…)`) and heredoc bodies are accepted residue, locked by a test so they can't silently reopen.

All changes are correctness fixes in the safe direction — a segment that used to mis-split now stays whole so a following gated token can't hide; never a new fail-open.

## Verification

- verify-RED→GREEN for every fixed form.
- Targeted regression green (592 tests): golden-`raw` corpus, `git_push_guard`, `review_enforcement_commit`, `git_discard`, destructive/protected-path guards, sqlite, `run_guard`.
- Differential fuzz vs real bash: 0 unsafe misses across ANSI-C / line-continuation / comment / subshell-comment forms.

## Deploy

Hooks/parser take effect at next Claude Code session start.
