### PR TITLE
fix(cc): stabilize the SSH slot cap on total RAM + operator emergency reclaim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,23 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **SSH slot cap no longer collapses below the running session count.** The
+  interactive-slot launcher (`scripts/cc-slot.sh`) sized its cap from
+  *instantaneous free RAM* (`(MemAvailable − reserve) / per_session`), so each
+  running session lowered free RAM and thus lowered the cap *below* the number
+  already running — locking the operator out of a new session (and even
+  misreporting "3/2 active") while other apps' memory use silently ate slots too.
+  The cap is now a stable function of the box's TOTAL RAM (a new pure, unit-tested
+  `genesis.cc.session_cap` helper), so it scales per install, does not shrink as
+  sessions run, and ignores unrelated apps. Live free RAM is used only as an OOM
+  circuit-breaker. A direct LAN/Tailscale SSH login (the operator) gets an
+  emergency slot above the safe cap and is never hard-denied — when the box is
+  full or memory is tight it offers to reattach or end a chosen session to make
+  room (the ended session's transcript persists, resume with `claude --resume`).
+  Reattaching always works. Tunable via `~/.genesis/cc-slot.env`
+  (`GENESIS_CC_SYSTEM_RESERVE_MB` / `_PER_SESSION_MB` / `_OOM_FLOOR_MB` /
+  `_EMERGENCY_SLOTS`); the gate fails open so it can never strand you. See
+  `docs/reference/tailscale-ssh-access.md`.
 - **Heartbeat GC no longer lets a clock-skewed future row starve a subsystem's
   liveness signal.** The `keep_latest_per_subsystem` heartbeat GC
   (`db/crud/events.py::prune`) kept the row equal to the per-subsystem

--- a/docs/reference/tailscale-ssh-access.md
+++ b/docs/reference/tailscale-ssh-access.md
@@ -33,6 +33,31 @@ ssh <host>-lobby    # the session picker → pick any live slot
 Windows one-click: make a shortcut whose target is `wt.exe ssh <host>-lobby`
 (or `ssh.exe <host>-lobby`) and pin it to the taskbar.
 
+## The session cap and the operator emergency slot
+
+New slots are capped by the box's **capacity**, derived from its TOTAL RAM —
+`SAFE_CAP = (MemTotal − reserve) / per_session`, clamped to the CPU count. The cap
+is stable: it does NOT shrink as sessions run, and background apps (other coding
+tools, daemons) don't consume it. It scales per install — a bigger box allows more
+slots, a small box fewer (never below 1). Live free RAM is used only as an
+OOM circuit-breaker, never as the cap.
+
+- **Reattaching** to an existing slot (`ssh <host>-N` to a slot that already
+  exists, or the lobby picker) is ALWAYS allowed — it starts nothing new.
+- **A direct LAN/Tailscale SSH login is treated as the operator** and gets an
+  emergency slot **above** the safe cap, and is **never hard-denied**: when the
+  box is at the limit or RAM is genuinely tight, the login drops to an interactive
+  prompt — reattach an existing slot, or pick one to END (freeing its slot/memory;
+  its transcript persists, resume later with `claude --resume`). You choose what to
+  reclaim; the OOM-killer never does.
+- Other doors (the dashboard web terminal / "normal method") are held to the safe
+  cap.
+
+Tune the model per box in `~/.genesis/cc-slot.env` (all optional):
+`GENESIS_CC_SYSTEM_RESERVE_MB`, `GENESIS_CC_PER_SESSION_MB`,
+`GENESIS_CC_OOM_FLOOR_MB`, `GENESIS_CC_EMERGENCY_SLOTS`. The gate fails **open** —
+if it can't run, a static MemTotal-based fallback still lets you in.
+
 ## Why the aliases are keyed on the Tailscale IP, not the MagicDNS name
 
 `generate-ssh-config.sh` writes each `HostName` as the host's **stable Tailscale

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -85,23 +85,146 @@ SESSION_NAME="${SESSION_PREFIX}-${SLOT}"
 # Handle nested tmux
 unset TMUX
 
-# --- Dynamic session cap (RAM + CPU aware) ---
-RESERVED_MB=4096        # OS + Genesis runtime + background work headroom
-PER_SESSION_MB=900      # Measured: ~800MB (claude + 4 MCP servers) + buffer
-CPU_CAP=$(nproc)        # Never exceed core count (thrashing)
+# Load operator config levers (~/.genesis/cc-slot.env) BEFORE the capacity gate,
+# so its GENESIS_CC_* tunables actually take effect there (an SSH RemoteCommand
+# does NOT source .bashrc). This file is also home to the permission-mode lever
+# (GENESIS_CC_PERMISSION_MODE) and the OAuth-durability lever
+# (GENESIS_CC_SLOT_OAUTH), both consumed later. `|| echo` keeps a malformed file
+# from aborting the login under `set -e`.
+if [ -f "${HOME}/.genesis/cc-slot.env" ]; then
+    . "${HOME}/.genesis/cc-slot.env" \
+        || echo "cc-slot: warning: ~/.genesis/cc-slot.env sourced with errors (continuing)" >&2
+fi
+# A sourced var is a shell var, NOT exported — EXPORT the cap levers so the Python
+# gate subprocess inherits them. Only export those actually set (an empty export
+# would still read as unset → default, but keep the env clean).
+for _lever in GENESIS_CC_SYSTEM_RESERVE_MB GENESIS_CC_PER_SESSION_MB \
+              GENESIS_CC_OOM_FLOOR_MB GENESIS_CC_EMERGENCY_SLOTS; do
+    [ -n "${!_lever:-}" ] && export "$_lever"
+done
+unset _lever
 
-avail_kb=$(awk '/^MemAvailable:/ {print $2}' /proc/meminfo)
-avail_mb=$((avail_kb / 1024))
-ram_cap=$(( (avail_mb - RESERVED_MB) / PER_SESSION_MB ))
+# --- Session cap (capacity model; decision delegated to genesis.cc.session_cap) ---
+# The launcher only GATHERS inputs and EXECUTES the returned action; the pure,
+# unit-tested Python gate decides (SAFE_CAP from MemTotal — stable, does NOT
+# collapse as sessions run, unlike the old MemAvailable/900 formula that locked
+# the operator out at "3/2"). Reattach to an existing slot bypasses this entirely.
+# The gate NEVER hard-locks the operator out: ALLOW → proceed; DENY → message+exit
+# (dashboard/"normal method" over cap); RECLAIM → interactive pick-a-session-to-end
+# (LAN/tailscale operator). It fails OPEN — a Python error falls back to a
+# MemTotal-based STATIC cap (never the collapsing free-RAM formula), so a broken
+# venv can never strand the operator. Config levers (~/.genesis/cc-slot.env):
+# GENESIS_CC_SYSTEM_RESERVE_MB / _PER_SESSION_MB / _OOM_FLOOR_MB / _EMERGENCY_SLOTS.
 
-# Floor: 1 (never lock out); Ceiling: nproc
-max_sessions=$ram_cap
-[[ $max_sessions -lt 1 ]] && max_sessions=1
-[[ $max_sessions -gt $CPU_CAP ]] && max_sessions=$CPU_CAP
+# List live numeric cc-N slots to stderr (shared by DENY + fail-open paths).
+_cap_list_slots() {
+    echo "Active sessions (reattach: tmux attach -t <name>):" >&2
+    tmux list-sessions \
+        -F '  #{session_name}  (#{?session_attached,ATTACHED,detached}, idle since #{t:session_activity})' \
+        2>/dev/null | grep -E "^  ${SESSION_PREFIX}-[0-9]+ " >&2 || true
+}
 
-# Numeric slots only: retired cc-manual-<ts>-<pid> sessions from the old
-# wrapper (and any other cc-* stray) must not consume cap headroom — manual
-# allocation can only ever probe/create cc-<N>.
+# Interactive reclaim (operator origin, or the fail-open path with a TTY): offer
+# to END a session to make room, or cancel and reattach. Returns 0 to proceed
+# with the launch; exits on cancel / invalid / no-TTY.
+_cap_reclaim() {
+    local msg="$1" reason="${2:-}" choice victim row nm att act state i=1
+    local -a rows
+    mapfile -t rows < <(tmux list-sessions \
+        -F '#{session_name}|#{session_attached}|#{t:session_activity}' 2>/dev/null \
+        | grep -E "^${SESSION_PREFIX}-[0-9]+\|" || true)
+    echo "" >&2
+    echo "!  ${msg}" >&2
+    if [ "${#rows[@]}" -eq 0 ]; then
+        # No cc-N session to trade. Under a genuine OOM-floor breach, REFUSE the
+        # new session — the swapless box is already below the safety floor from
+        # NON-cc memory pressure, and spawning a ~3GB session risks an OOM that
+        # takes down every session. This is the OOM circuit-breaker doing its
+        # job, NOT the old collapse bug (which denied while sessions ran fine).
+        # For a soft cap with nothing to reclaim, proceeding is harmless.
+        if [ "$reason" = "oom_floor" ]; then
+            echo "RAM is below the safety floor and no cc session exists to reclaim —" >&2
+            echo "free non-cc memory and retry, or reattach an existing session." >&2
+            exit 1
+        fi
+        echo "(no cc-N session to reclaim; proceeding.)" >&2
+        return 0
+    fi
+    echo "" >&2
+    for row in "${rows[@]}"; do
+        IFS='|' read -r nm att act <<<"$row"
+        state="detached"; [ "${att:-0}" -ge 1 ] && state="ATTACHED"
+        echo "  [$i] ${nm}  ${state}  (idle since ${act})" >&2
+        i=$((i + 1))
+    done
+    echo "" >&2
+    if [ ! -t 0 ]; then
+        echo "No interactive terminal here — reattach a session" >&2
+        echo "(tmux attach -t ${SESSION_PREFIX}-<N>), or re-run 'ssh <host>-<N>' with a TTY to end one." >&2
+        exit 1
+    fi
+    echo "Enter a number to END that session (frees memory + its slot; the transcript" >&2
+    echo "persists — resume later with 'claude --resume'). Press Enter to cancel:" >&2
+    IFS= read -r -p "> " choice </dev/tty || choice=""
+    if [ -z "$choice" ]; then
+        echo "Cancelled — reattach an existing session (tmux attach -t ${SESSION_PREFIX}-<N>)." >&2
+        exit 1
+    fi
+    # Reject leading zeros (^[1-9][0-9]*$, same as SLOT above): bash reads a
+    # leading-zero numeral as OCTAL, so "08"/"09" would raise a "value too great
+    # for base" arithmetic error that silently unwinds past this gate and spawns
+    # anyway — defeating the cap. 10# forces base-10 defensively in the index.
+    if ! [[ "$choice" =~ ^[1-9][0-9]*$ ]] || [ "$choice" -gt "${#rows[@]}" ]; then
+        echo "Invalid selection — cancelled." >&2
+        exit 1
+    fi
+    IFS='|' read -r victim _ _ <<<"${rows[$((10#$choice - 1))]}"
+    echo "Ending ${victim} to free room for ${SESSION_NAME}…" >&2
+    tmux kill-session -t "=${victim}" 2>/dev/null || true
+    return 0
+}
+
+# Pure-bash fallback when the Python gate cannot run (broken venv / timeout).
+# STATIC MemTotal cap — NEVER the collapsing free-RAM formula — + a hard OOM
+# floor. Leans permissive so a Python outage never locks the operator out.
+_cap_fail_open() {
+    local total_mb avail_mb reserve per floor cpus safe reason
+    total_mb=$(( $(awk '/^MemTotal:/{print $2}' /proc/meminfo) / 1024 ))
+    avail_mb=$(( $(awk '/^MemAvailable:/{print $2}' /proc/meminfo) / 1024 ))
+    # Validate the operator-set levers BEFORE using them in $(( )): a non-numeric
+    # override (e.g. "3072mb", or a leading-zero octal) would raise an arithmetic
+    # error that silently unwinds this function → the fallback becomes a no-op and
+    # the session spawns with NO cap. Mirror CapConfig.from_env's guard: bad → default.
+    reserve=${GENESIS_CC_SYSTEM_RESERVE_MB:-4096}; [[ "$reserve" =~ ^[1-9][0-9]*$ ]] || reserve=4096
+    per=${GENESIS_CC_PER_SESSION_MB:-3072};        [[ "$per"     =~ ^[1-9][0-9]*$ ]] || per=3072
+    floor=${GENESIS_CC_OOM_FLOOR_MB:-1536};        [[ "$floor"   =~ ^[0-9]+$ ]]      || floor=1536
+    cpus=$(nproc 2>/dev/null || echo 1); [[ "$cpus" =~ ^[1-9][0-9]*$ ]] || cpus=1
+    safe=$(( (total_mb - reserve) / per )); [ "$safe" -lt 1 ] && safe=1
+    [ "$safe" -gt "$cpus" ] && safe=$cpus   # mirror the Python gate's nproc clamp (thrash guard)
+    # Leans permissive: allows up to safe+1 (the fallback can't call the Python
+    # origin classifier, and never-lock-the-operator-out wins here) — the OOM floor
+    # below still guards the box. Looser than the real gate BY DESIGN, and only
+    # reachable when the Python gate is down (broken venv).
+    if [ "$existing" -lt $((safe + 1)) ] && [ "$avail_mb" -ge "$floor" ]; then
+        echo "cc-slot: capacity gate unavailable — static fallback allows this slot (${existing}/${safe})." >&2
+        return 0
+    fi
+    if [ "$avail_mb" -lt "$floor" ]; then reason="oom_floor"; else reason="cap_full"; fi
+    # The interactive reclaim (which can kill a session) is an OPERATOR affordance.
+    # The dashboard/"manual" door is the "normal method" held to the cap — do NOT
+    # widen the session-kill flow to it, even in fail-open. It gets a plain DENY.
+    if [ "$MODE_ARG" = "manual" ]; then
+        echo "ERROR: Session cap reached (${existing}/${safe}) [capacity gate unavailable]." >&2
+        _cap_list_slots
+        exit 1
+    fi
+    _cap_reclaim "Capacity gate unavailable; static limit ${existing}/${safe}, ${avail_mb}MB free." "$reason"
+    return 0
+}
+
+# Numeric slots only: retired cc-manual-<ts>-<pid> sessions from the old wrapper
+# (and any other cc-* stray) must not consume cap headroom — manual allocation
+# can only ever probe/create cc-<N>.
 existing=$(tmux list-sessions -F '#{session_name}' 2>/dev/null \
            | grep -cE "^${SESSION_PREFIX}-[0-9]+$" || true)
 
@@ -111,19 +234,28 @@ if tmux has-session -t "=$SESSION_NAME" 2>/dev/null; then
     _SESSION_EXISTS=1  # bypass cap check; also skips the OAuth gate below —
                        # attach does NOT re-run the pane command, so any token
                        # injection would be moot (and would waste a probe).
-elif [[ $existing -ge $max_sessions ]]; then
-    echo "ERROR: Session cap reached (${existing}/${max_sessions} active)." >&2
-    echo "RAM: ${avail_mb}MB available, ${RESERVED_MB}MB reserved, ${PER_SESSION_MB}MB/session" >&2
-    echo "" >&2
-    echo "Active sessions:" >&2
-    tmux list-sessions -F '  #{session_name}  (last activity: #{t:session_activity})' \
-        2>/dev/null | grep "^  ${SESSION_PREFIX}-" >&2
-    echo "" >&2
-    echo "Kill an idle session: tmux kill-session -t ${SESSION_PREFIX}-<N>" >&2
-    exit 1
+else
+    # New session → consult the capacity gate (SSH_CONNECTION classifies origin
+    # inside the Python helper). `timeout` bounds a hung import; trailing
+    # `|| true` keeps a non-zero exit from aborting under `set -e`.
+    _cap_py="${GENESIS_ROOT}/.venv/bin/python"
+    _cap_out=""
+    if [ -x "$_cap_py" ]; then
+        _cap_out=$(timeout 15 "$_cap_py" -m genesis.cc.session_cap --existing "$existing" 2>/dev/null || true)
+    fi
+    # Protocol: line 1 = action, line 2 = human message, line 3 = machine reason.
+    _cap_action=$(printf '%s\n' "$_cap_out" | sed -n '1p')
+    _cap_msg=$(printf '%s\n' "$_cap_out" | sed -n '2p')
+    _cap_reason=$(printf '%s\n' "$_cap_out" | sed -n '3p')
+    case "$_cap_action" in
+        ALLOW)   [ -n "$_cap_msg" ] && echo "cc-slot: ${_cap_msg}" >&2 || true ;;
+        DENY)    echo "ERROR: ${_cap_msg}" >&2; _cap_list_slots; exit 1 ;;
+        RECLAIM) _cap_reclaim "$_cap_msg" "$_cap_reason" ;;
+        *)       _cap_fail_open ;;   # empty/unexpected → Python gate unavailable
+    esac
 fi
 
-echo "→ Slot ${SLOT} (session: ${SESSION_NAME}, cap: ${existing}/${max_sessions})" >&2
+echo "→ Slot ${SLOT} (session: ${SESSION_NAME})" >&2
 
 # Redirect CC temp to dedicated directory (keeps /tmp clean)
 export TMPDIR="$HOME/.genesis/cc-tmp"
@@ -147,13 +279,8 @@ export CLAUDE_CODE_TMPDIR="$HOME/.genesis/cc-tmp"
 # dies (see the OAuth block below).
 # Headless/autonomous CC sessions (CCInvoker -p) keep bypass separately — no
 # human is present to answer a prompt.
-if [ -f "${HOME}/.genesis/cc-slot.env" ]; then
-    # Don't let a malformed override file kill the session under `set -e` (the
-    # sourced file is the final command of an && chain, so a non-zero exit would
-    # abort the script and drop the SSH session with no diagnostic).
-    . "${HOME}/.genesis/cc-slot.env" \
-        || echo "cc-slot: warning: ~/.genesis/cc-slot.env sourced with errors (continuing)" >&2
-fi
+# (~/.genesis/cc-slot.env is already sourced near the top, before the capacity
+# gate, so these levers are populated here.)
 case "${GENESIS_CC_PERMISSION_MODE:-auto}" in
     bypass|dangerous|skip) CC_PERM_FLAG="--dangerously-skip-permissions" ;;
     *)                     CC_PERM_FLAG="--permission-mode auto" ;;

--- a/src/genesis/cc/session_cap.py
+++ b/src/genesis/cc/session_cap.py
@@ -1,0 +1,292 @@
+"""Interactive-slot capacity decision — `python -m genesis.cc.session_cap`.
+
+`scripts/cc-slot.sh` runs this on slot CREATE (never on reattach) to decide
+whether a NEW `cc-N` session may start. It replaces the old free-RAM formula
+(`(MemAvailable - reserve) / per_session`) that *collapsed*: because it sampled
+instantaneous FREE RAM after sessions were already running, each running session
+lowered MemAvailable and thus lowered the cap BELOW the running count (3 running →
+computed cap 2 → the operator locked out of a 4th, sometimes the 3rd).
+
+The model here is CAPACITY, not free-RAM:
+
+- The cap is a function of the box's own TOTAL resources (MemTotal) → stable, does
+  NOT shrink as sessions run, and portable to any install (a bigger box yields a
+  bigger cap with no hardcoded per-install number). Background apps (Kimi/codex,
+  bg daemons) no longer shrink the foreground cap.
+- Live free RAM (MemAvailable) is consulted ONLY as a low OOM circuit-breaker —
+  a floor to refuse a NEW session when the swapless box is genuinely near
+  exhaustion — never as the cap.
+- Origin-aware: a direct LAN/tailscale SSH login (the operator "let me in" path,
+  distinct from the dashboard/magic-link "normal method") gets an emergency slot
+  ABOVE the safe cap and is NEVER hard-denied — when the box is full/tight it is
+  offered an interactive RECLAIM (pick a session to end, or reattach), so the
+  operator always has a path in without the OOM-killer choosing the casualty.
+
+Contract (mirrors `genesis.cc.login_gate`): `main()` reads /proc/meminfo, cpu
+count, `SSH_CONNECTION`, and the `GENESIS_CC_*` config levers, takes the current
+`cc-N` count via `--existing N`, then prints a two-part protocol to STDOUT:
+
+    line 1: ``ALLOW`` | ``RECLAIM`` | ``DENY``   (the action)
+    line 2+: a human-facing explanation (cc-slot.sh echoes it to the operator)
+
+Exit 0 whenever a decision was produced (even DENY). Exit non-zero ONLY on an
+internal error — cc-slot.sh treats that as fail-OPEN (its own MemTotal-based
+static fallback), because the one thing this gate must never do is lock the
+operator out. It is a resource governor, not a security gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import os
+from dataclasses import dataclass
+
+# --- Config levers (documented, tunable via ~/.genesis/cc-slot.env) -----------
+# Explicit, honest defaults measured on the reference 18GB swapless box
+# (2026-08-27): a fully-loaded cc session (claude + serena + memory/health/
+# outreach/recon MCPs + gitnexus + pyright) measured ~2.9GB RSS, so PER_SESSION
+# is sized NEAR that max (conservative — a swapless box OOM-KILLS a resident
+# spike, it cannot page). On this box these yield SAFE_CAP = (18432-4096)//3072
+# = 4 (matching the 3-4 comfortably run); a bigger MemTotal scales the cap up,
+# a smaller one down (clamped to >=1 so a small box is never locked out).
+_DEF_SYSTEM_RESERVE_MB = 4096  # OS + genesis-server + qdrant + bg-spares + swapless margin
+_DEF_PER_SESSION_MB = 3072  # measured loaded-session RSS ceiling, conservative
+_DEF_OOM_FLOOR_MB = 1536  # min free RAM to START a new session (circuit-breaker)
+_DEF_EMERGENCY_SLOTS = 1  # extra slots an operator-origin login may claim above SAFE_CAP
+
+# Tailscale address space (RFC 6598 CGNAT for v4; the fixed tailnet ULA for v6).
+# Checked explicitly so classification does not depend on `is_private`'s
+# version-dependent treatment of 100.64/10.
+_TAILSCALE_V4 = ipaddress.ip_network("100.64.0.0/10")
+_TAILSCALE_V6 = ipaddress.ip_network("fd7a:115c:a1e0::/48")
+
+_ACTIONS = ("ALLOW", "RECLAIM", "DENY")
+
+
+@dataclass(frozen=True)
+class CapConfig:
+    system_reserve_mb: int = _DEF_SYSTEM_RESERVE_MB
+    per_session_mb: int = _DEF_PER_SESSION_MB
+    oom_floor_mb: int = _DEF_OOM_FLOOR_MB
+    emergency_slots: int = _DEF_EMERGENCY_SLOTS
+
+    @classmethod
+    def from_env(cls, environ: dict | None = None) -> CapConfig:
+        env = os.environ if environ is None else environ
+
+        def _int(name: str, default: int) -> int:
+            raw = env.get(name)
+            if raw is None or str(raw).strip() == "":
+                return default
+            try:
+                val = int(str(raw).strip())
+            except ValueError:
+                return default
+            # Guard against a nonsensical override that would break the model
+            # (e.g. per_session 0 → division error). Fall back to the default.
+            return val if val > 0 else default
+
+        return cls(
+            system_reserve_mb=_int("GENESIS_CC_SYSTEM_RESERVE_MB", _DEF_SYSTEM_RESERVE_MB),
+            per_session_mb=_int("GENESIS_CC_PER_SESSION_MB", _DEF_PER_SESSION_MB),
+            oom_floor_mb=_int("GENESIS_CC_OOM_FLOOR_MB", _DEF_OOM_FLOOR_MB),
+            # emergency_slots may legitimately be 0 (disable the emergency lever),
+            # so it uses a >=0 guard rather than the >0 guard above.
+            emergency_slots=max(0, _emergency_from_env(env)),
+        )
+
+
+def _emergency_from_env(env: dict) -> int:
+    raw = env.get("GENESIS_CC_EMERGENCY_SLOTS")
+    if raw is None or str(raw).strip() == "":
+        return _DEF_EMERGENCY_SLOTS
+    try:
+        return int(str(raw).strip())
+    except ValueError:
+        return _DEF_EMERGENCY_SLOTS
+
+
+@dataclass(frozen=True)
+class Decision:
+    action: str  # ALLOW | RECLAIM | DENY
+    safe_cap: int  # the resource-derived normal limit
+    effective_cap: int  # safe_cap (+ emergency for operator origin)
+    origin: str  # tailscale | lan | public | none
+    reason: str  # machine tag: ok | emergency_slot | cap_reached | cap_full | oom_floor
+    message: str  # human-facing explanation
+
+
+def classify_origin(ssh_connection: str | None) -> str:
+    """Classify the SSH client origin from $SSH_CONNECTION.
+
+    Returns tailscale/lan for the OPERATOR-at-console (emergency-eligible),
+    public for a non-private remote, and none for no SSH (dashboard/manual/local
+    "normal method"). Unparseable → public (safe: no emergency, still reattachable
+    and still fail-open in the bash caller).
+    """
+    if not ssh_connection or not ssh_connection.strip():
+        return "none"
+    client = ssh_connection.split()[0]
+    try:
+        ip = ipaddress.ip_address(client)
+    except ValueError:
+        return "public"
+    if ip in _TAILSCALE_V4 or ip in _TAILSCALE_V6:
+        return "tailscale"
+    if ip.is_loopback or ip.is_private:
+        return "lan"
+    return "public"
+
+
+def decide(
+    *,
+    mem_total_mb: int,
+    mem_available_mb: int,
+    existing: int,
+    cpu_count: int,
+    ssh_connection: str | None,
+    config: CapConfig,
+) -> Decision:
+    """Pure decision: may a NEW cc-N session start? (reattach is handled upstream)."""
+    origin = classify_origin(ssh_connection)
+    is_operator = origin in ("lan", "tailscale")
+
+    # SAFE_CAP from TOTAL memory — stable, does NOT collapse as sessions run.
+    raw = (mem_total_mb - config.system_reserve_mb) // config.per_session_mb
+    cpu = cpu_count if cpu_count and cpu_count > 0 else 1
+    safe_cap = max(1, min(raw, cpu))
+    emergency = config.emergency_slots if is_operator else 0
+    effective_cap = safe_cap + emergency
+
+    # OOM circuit-breaker: enough live RAM to safely START one more session?
+    ram_ok = mem_available_mb >= config.oom_floor_mb
+
+    if not is_operator:
+        # Normal method (dashboard/magic-link/public): held to SAFE_CAP.
+        if existing >= safe_cap:
+            return Decision(
+                "DENY",
+                safe_cap,
+                effective_cap,
+                origin,
+                "cap_reached",
+                f"Session cap reached ({existing}/{safe_cap}). Reattach an existing "
+                f"session, or SSH in over LAN/tailscale for an emergency slot.",
+            )
+        if not ram_ok:
+            return Decision(
+                "DENY",
+                safe_cap,
+                effective_cap,
+                origin,
+                "oom_floor",
+                f"RAM low ({mem_available_mb}MB free, need >= {config.oom_floor_mb}MB "
+                f"to start safely). Reattach an existing session or free memory.",
+            )
+        return Decision(
+            "ALLOW",
+            safe_cap,
+            effective_cap,
+            origin,
+            "ok",
+            f"Slot available ({existing + 1}/{safe_cap}).",
+        )
+
+    # Operator origin (LAN/tailscale): NEVER hard-denied.
+    if existing < effective_cap and ram_ok:
+        if existing >= safe_cap:
+            return Decision(
+                "ALLOW",
+                safe_cap,
+                effective_cap,
+                origin,
+                "emergency_slot",
+                f"Emergency slot granted (operator origin: {origin}) — "
+                f"{existing + 1}/{safe_cap}+{emergency}.",
+            )
+        return Decision(
+            "ALLOW",
+            safe_cap,
+            effective_cap,
+            origin,
+            "ok",
+            f"Slot available ({existing + 1}/{safe_cap}).",
+        )
+
+    # Full (past the emergency slot) OR RAM genuinely tight → offer RECLAIM,
+    # never a hard "no". cc-slot.sh runs the interactive pick-a-session-to-end UI.
+    if not ram_ok:
+        return Decision(
+            "RECLAIM",
+            safe_cap,
+            effective_cap,
+            origin,
+            "oom_floor",
+            f"RAM tight ({mem_available_mb}MB free, need >= {config.oom_floor_mb}MB). "
+            f"Reattach a session, or reclaim one to free memory and start fresh.",
+        )
+    return Decision(
+        "RECLAIM",
+        safe_cap,
+        effective_cap,
+        origin,
+        "cap_full",
+        f"At the emergency limit ({existing}/{safe_cap}+{emergency}). "
+        f"Reattach a session, or reclaim one to start fresh.",
+    )
+
+
+def read_meminfo(path: str = "/proc/meminfo") -> tuple[int, int]:
+    """Return (MemTotal, MemAvailable) in MB. Raises on unreadable/absent fields
+    so main() can fail-OPEN (cc-slot.sh falls back to its bash static cap)."""
+    total = avail = None
+    with open(path, encoding="ascii") as fh:
+        for line in fh:
+            if line.startswith("MemTotal:"):
+                total = int(line.split()[1]) // 1024
+            elif line.startswith("MemAvailable:"):
+                avail = int(line.split()[1]) // 1024
+            if total is not None and avail is not None:
+                break
+    if total is None or avail is None:
+        raise ValueError("MemTotal/MemAvailable not found in meminfo")
+    return total, avail
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="session_cap")
+    parser.add_argument(
+        "--existing",
+        type=int,
+        required=True,
+        help="Current count of live cc-N tmux sessions (from cc-slot.sh).",
+    )
+    try:
+        args = parser.parse_args(argv)
+        mem_total, mem_available = read_meminfo()
+        decision = decide(
+            mem_total_mb=mem_total,
+            mem_available_mb=mem_available,
+            existing=args.existing,
+            cpu_count=os.cpu_count() or 1,
+            ssh_connection=os.environ.get("SSH_CONNECTION"),
+            config=CapConfig.from_env(),
+        )
+    except Exception:  # noqa: BLE001 — fail-OPEN: any error → cc-slot.sh static fallback
+        return 1
+
+    # STDOUT protocol (cc-slot.sh parses by line):
+    #   line 1: action  (ALLOW | RECLAIM | DENY)
+    #   line 2: human-facing message (echoed to the operator)
+    #   line 3: machine reason tag (ok|emergency_slot|cap_reached|cap_full|oom_floor)
+    #           — lets the shell distinguish "trade a slot" (cap_full) from
+    #           "genuine RAM exhaustion, nothing to trade" (oom_floor) on RECLAIM.
+    print(decision.action)
+    print(decision.message)
+    print(decision.reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cc/test_session_cap.py
+++ b/tests/test_cc/test_session_cap.py
@@ -1,0 +1,175 @@
+"""Unit tests for the capacity-based cc session cap (genesis.cc.session_cap).
+
+The load-bearing test is `test_collapse_case_now_allows` — the exact live scenario
+that locked the operator out (3 running, 6566MB free → old formula computed cap 2).
+Under the capacity model it must ALLOW.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.cc.session_cap import CapConfig, Decision, classify_origin, decide
+
+# Reference box: 18GB, 6 cores. Defaults → SAFE_CAP = (18432-4096)//3072 = 4.
+CFG = CapConfig()
+TS = "100.100.100.100 56002 100.100.0.1 22"  # tailscale operator
+LAN = "192.0.2.10 51000 192.0.2.1 22"  # LAN operator (RFC 5737 TEST-NET, synthetic)
+PUB = "8.8.8.8 40000 203.0.113.1 22"  # public remote
+
+
+def _d(existing, ssh, *, total=18432, avail=6566, cpu=6, cfg=CFG) -> Decision:
+    return decide(
+        mem_total_mb=total,
+        mem_available_mb=avail,
+        existing=existing,
+        cpu_count=cpu,
+        ssh_connection=ssh,
+        config=cfg,
+    )
+
+
+# ── SAFE_CAP shape ────────────────────────────────────────────────────────────
+def test_safe_cap_is_four_on_reference_box():
+    assert _d(0, TS).safe_cap == 4
+
+
+def test_safe_cap_scales_up_on_a_bigger_box():
+    # 32GB, 16 cores → (32768-4096)//3072 = 9 (cpu clamp does not bind at 16).
+    assert _d(0, TS, total=32768, cpu=16).safe_cap == 9
+
+
+def test_safe_cap_clamped_by_cpu_count():
+    # RAM would allow 9 but only 6 cores → clamp to 6 (thrash guard).
+    assert _d(0, TS, total=32768, cpu=6).safe_cap == 6
+
+
+def test_tiny_box_never_locks_out_floor_of_one():
+    # 4GB: (4096-4096)//3072 = 0 → floored to 1.
+    assert _d(0, TS, total=4096, avail=3000).safe_cap == 1
+
+
+# ── THE BUG: collapse case must now ALLOW ─────────────────────────────────────
+def test_collapse_case_now_allows():
+    # 3 running, 6566MB free, tailscale operator — the exact lockout scenario.
+    d = _d(3, TS)
+    assert d.action == "ALLOW"
+    assert d.safe_cap == 4
+
+
+def test_safe_cap_is_stable_as_free_ram_drops():
+    # Free RAM varying from 6566 down to 2000 does NOT change SAFE_CAP (no collapse).
+    caps = {_d(3, TS, avail=a).safe_cap for a in (6566, 5000, 3000, 2000)}
+    assert caps == {4}
+
+
+# ── Emergency slot (operator origin, +1 above SAFE_CAP) ───────────────────────
+def test_operator_gets_emergency_slot_at_cap():
+    d = _d(4, TS)  # existing == safe_cap → the +1 emergency slot
+    assert d.action == "ALLOW"
+    assert d.reason == "emergency_slot"
+    assert d.effective_cap == 5
+
+
+@pytest.mark.parametrize("ssh", [TS, LAN])
+def test_both_lan_and_tailscale_are_operator(ssh):
+    assert _d(4, ssh).action == "ALLOW"
+
+
+# ── Normal method (dashboard/public) is held to SAFE_CAP ──────────────────────
+def test_normal_origin_denied_over_cap():
+    assert _d(4, None).action == "DENY"  # dashboard/manual (no SSH_CONNECTION)
+
+
+def test_public_ssh_is_not_operator():
+    assert _d(4, PUB).action == "DENY"
+
+
+def test_normal_origin_allowed_under_cap():
+    assert _d(2, None).action == "ALLOW"
+
+
+def test_normal_origin_denied_when_ram_tight_under_cap():
+    d = _d(2, None, avail=800)  # under cap but below OOM floor
+    assert d.action == "DENY"
+    assert d.reason == "oom_floor"
+
+
+# ── Operator is NEVER hard-denied → RECLAIM instead ───────────────────────────
+def test_operator_over_emergency_cap_reclaims_not_denies():
+    d = _d(5, TS)  # past safe_cap(4) + emergency(1)
+    assert d.action == "RECLAIM"
+    assert d.reason == "cap_full"
+
+
+def test_operator_ram_tight_reclaims_not_denies():
+    d = _d(2, TS, avail=800)  # under cap but RAM below floor
+    assert d.action == "RECLAIM"
+    assert d.reason == "oom_floor"
+
+
+def test_operator_never_returns_deny_across_the_grid():
+    # Exhaustive: no (existing, avail) combination yields DENY for an operator.
+    actions = {_d(e, TS, avail=a).action for e in range(0, 8) for a in (400, 800, 1536, 3000, 6566)}
+    assert "DENY" not in actions
+
+
+# ── Emergency lever can be disabled via config ────────────────────────────────
+def test_emergency_slots_zero_still_reclaims_never_denies_operator():
+    cfg = CapConfig(emergency_slots=0)
+    d = _d(4, TS, cfg=cfg)  # at cap, no emergency slot → reclaim (still not deny)
+    assert d.action == "RECLAIM"
+    assert d.effective_cap == 4
+
+
+# ── Origin classification ─────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "client,expected",
+    [
+        ("100.100.100.100", "tailscale"),  # CGNAT
+        ("100.64.0.1", "tailscale"),  # CGNAT low boundary
+        ("100.127.255.254", "tailscale"),  # CGNAT high boundary
+        ("100.63.0.1", "public"),  # just below CGNAT
+        ("100.128.0.1", "public"),  # just above CGNAT
+        ("198.51.100.5", "lan"),  # RFC 5737 TEST-NET-2 → is_private
+        ("10.0.0.5", "lan"),  # RFC1918 10/8
+        ("172.16.0.5", "lan"),  # RFC1918 172.16/12
+        ("127.0.0.1", "lan"),  # loopback = local operator
+        ("8.8.8.8", "public"),
+        ("fd7a:115c:a1e0::1234", "tailscale"),  # tailscale's fixed tailnet ULA prefix
+        ("fd00:1:2:3::1", "lan"),  # generic ULA (fc00::/7)
+        ("garbage", "public"),  # unparseable → non-operator (safe)
+    ],
+)
+def test_classify_origin(client, expected):
+    ssh = f"{client} 51000 100.100.0.1 22"
+    assert classify_origin(ssh) == expected
+
+
+def test_classify_origin_none_when_no_ssh():
+    assert classify_origin(None) == "none"
+    assert classify_origin("") == "none"
+    assert classify_origin("   ") == "none"
+
+
+# ── Config env parsing (guards against nonsensical overrides) ─────────────────
+def test_config_from_env_guards_zero_per_session():
+    cfg = CapConfig.from_env({"GENESIS_CC_PER_SESSION_MB": "0"})
+    assert cfg.per_session_mb == 3072  # zero rejected → default (no ZeroDivision)
+
+
+def test_config_from_env_reads_overrides():
+    cfg = CapConfig.from_env(
+        {
+            "GENESIS_CC_SYSTEM_RESERVE_MB": "6000",
+            "GENESIS_CC_PER_SESSION_MB": "2000",
+            "GENESIS_CC_OOM_FLOOR_MB": "1000",
+            "GENESIS_CC_EMERGENCY_SLOTS": "2",
+        }
+    )
+    assert (cfg.system_reserve_mb, cfg.per_session_mb, cfg.oom_floor_mb, cfg.emergency_slots) == (
+        6000,
+        2000,
+        1000,
+        2,
+    )

--- a/tests/test_scripts/test_cc_slot_cap.py
+++ b/tests/test_scripts/test_cc_slot_cap.py
@@ -1,0 +1,299 @@
+"""End-to-end guards for the cc-slot.sh capacity gate (session-cap redesign).
+
+Static asserts that the gate is wired the safe way (delegates to
+genesis.cc.session_cap, old collapsing free-RAM formula gone, reattach bypass +
+_SESSION_EXISTS preserved, fail-open present, levers sourced before the gate),
+PLUS a hermetic dynamic harness that runs the ACTUAL cc-slot.sh against fake
+`tmux`/`python` — including a pty-driven pass over the interactive reclaim choice
+(valid pick kills the right session and spawns; a leading-zero/octal input is
+rejected, not silently spawned past the cap). No real sessions are created.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_CC_SLOT = _REPO / "scripts" / "cc-slot.sh"
+
+
+# ── Static wiring guards ──────────────────────────────────────────────────────
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return _CC_SLOT.read_text()
+
+
+def test_delegates_to_session_cap(script_text):
+    assert "-m genesis.cc.session_cap --existing" in script_text
+
+
+def test_old_collapsing_formula_is_gone(script_text):
+    assert "ram_cap" not in script_text
+    assert "PER_SESSION_MB=900" not in script_text
+    assert "(avail_mb - RESERVED_MB)" not in script_text
+
+
+def test_reattach_bypass_and_session_exists_preserved(script_text):
+    assert 'tmux has-session -t "=$SESSION_NAME"' in script_text
+    assert "_SESSION_EXISTS=1" in script_text
+
+
+def test_fail_open_and_reclaim_present(script_text):
+    assert "_cap_fail_open" in script_text
+    assert "_cap_reclaim" in script_text
+    assert "timeout 15" in script_text
+
+
+def test_levers_sourced_and_exported_before_the_gate(script_text):
+    # cc-slot.env must be sourced (and the cap levers exported) BEFORE the Python
+    # gate call, or the documented tunables never take effect / never reach the
+    # subprocess. Assert the source precedes the session_cap invocation.
+    src_i = script_text.index('. "${HOME}/.genesis/cc-slot.env"')
+    gate_i = script_text.index("-m genesis.cc.session_cap --existing")
+    assert src_i < gate_i
+    assert 'export "$_lever"' in script_text
+
+
+# ── Hermetic end-to-end harness ───────────────────────────────────────────────
+def _write(path: Path, text: str) -> None:
+    path.write_text(text)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _setup(tmp_path, *, action, exists, session_names, rc):
+    """Build a fake HOME + fake tmux + fake venv python. Returns (env, spawn_marker, kill_file).
+
+    The fake tmux is FORMAT-AWARE: a names-only `-F` (the `existing` count) prints
+    bare names; a pipe `-F` (the reclaim list) prints `name|0|t0`. session_names is
+    a list of live cc-N names.
+    """
+    home = tmp_path / "home"
+    fakebin = tmp_path / "fakebin"
+    venvbin = home / "genesis" / ".venv" / "bin"
+    for d in (fakebin, venvbin, home / "genesis" / "scripts"):
+        d.mkdir(parents=True, exist_ok=True)
+    spawn_marker = tmp_path / "spawned"
+    kill_file = tmp_path / "killed"
+    names = "".join(f"{n}\n" for n in session_names)
+
+    _write(
+        fakebin / "tmux",
+        f"""#!/bin/bash
+sub=""; fmt=""; target=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    has-session|list-sessions|kill-session|new-session) sub="$1" ;;
+    -F) shift; fmt="${{1:-}}" ;;
+    -t) shift; target="${{1:-}}" ;;
+  esac
+  shift
+done
+case "$sub" in
+  has-session) exit {0 if exists else 1} ;;
+  list-sessions)
+    while IFS= read -r n; do
+      [ -z "$n" ] && continue
+      case "$fmt" in
+        *"|"*) printf '%s|0|t0\\n' "$n" ;;
+        *)     printf '%s\\n' "$n" ;;
+      esac
+    done <<< "$FAKE_NAMES"
+    exit 0 ;;
+  kill-session) printf '%s\\n' "$target" >> "{kill_file}"; exit 0 ;;
+  new-session) touch "{spawn_marker}"; exit 0 ;;
+esac
+exit 0
+""",
+    )
+    _write(fakebin / "nproc", "#!/bin/bash\necho 6\n")
+    _write(fakebin / "claude", "#!/bin/bash\nexit 0\n")
+    _write(
+        venvbin / "python",
+        f"""#!/bin/bash
+for a in "$@"; do
+  case "$a" in
+    *session_cap*) printf '%s\\n' "{action}"; exit {rc} ;;
+    *login_gate*)  exit 1 ;;
+  esac
+done
+exit 0
+""",
+    )
+    env = {
+        "HOME": str(home),
+        "PATH": f"{fakebin}:/usr/bin:/bin",
+        "SSH_CONNECTION": "100.100.100.100 1 2 22",
+        "FAKE_NAMES": names,
+    }
+    return env, spawn_marker, kill_file
+
+
+def _run(
+    tmp_path, *, action, exists=False, session_names=(), rc=0, mode="genesis-3-4", extra_env=None
+):
+    env, spawn_marker, kill_file = _setup(
+        tmp_path, action=action, exists=exists, session_names=session_names, rc=rc
+    )
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.run(
+        ["bash", str(_CC_SLOT), mode], env=env, capture_output=True, text=True, timeout=30
+    )
+    killed = kill_file.read_text() if kill_file.exists() else ""
+    return proc, spawn_marker.exists(), killed
+
+
+def _run_pty(tmp_path, *, action, session_names, feed, exists=False, rc=0, mode="genesis-3-4"):
+    """Run cc-slot.sh under a pty so the interactive reclaim `read </dev/tty` works."""
+    import pty
+
+    env, spawn_marker, kill_file = _setup(
+        tmp_path, action=action, exists=exists, session_names=session_names, rc=rc
+    )
+    pid, fd = pty.fork()
+    if pid == 0:  # child: becomes the pty session leader
+        try:
+            os.execve("/bin/bash", ["bash", str(_CC_SLOT), mode], env)  # noqa: S606 — pty child, fixed argv
+        except Exception:  # noqa: BLE001
+            os._exit(127)
+    os.write(fd, feed)
+    out = b""
+    while True:
+        try:
+            r, _, _ = select.select([fd], [], [], 8)
+        except OSError:
+            break
+        if not r:
+            break
+        try:
+            chunk = os.read(fd, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        out += chunk
+    _, status = os.waitpid(pid, 0)
+    code = os.waitstatus_to_exitcode(status)
+    killed = kill_file.read_text() if kill_file.exists() else ""
+    return code, out.decode(errors="replace"), spawn_marker.exists(), killed
+
+
+_THREE = ["cc-1", "cc-2", "cc-3"]
+
+
+def test_allow_spawns(tmp_path):
+    proc, spawned, _ = _run(tmp_path, action="ALLOW\nSlot available (4/4).", session_names=_THREE)
+    assert spawned, proc.stderr
+    assert proc.returncode == 0
+
+
+def test_deny_exits_without_spawning(tmp_path):
+    proc, spawned, _ = _run(
+        tmp_path,
+        action="DENY\nSession cap reached (4/4).",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-4"],
+    )
+    assert not spawned
+    assert proc.returncode == 1
+    assert "Session cap reached" in proc.stderr
+
+
+def test_reattach_bypasses_gate_and_spawns(tmp_path):
+    proc, spawned, _ = _run(
+        tmp_path, action="DENY\nshould not be consulted", exists=True, session_names=_THREE
+    )
+    assert spawned, proc.stderr
+    assert proc.returncode == 0
+    assert "should not be consulted" not in proc.stderr
+
+
+def test_python_unavailable_fails_open_and_spawns(tmp_path):
+    proc, spawned, _ = _run(tmp_path, action="", rc=1, session_names=[])
+    assert spawned, proc.stderr
+    assert proc.returncode == 0
+    assert "static fallback" in proc.stderr
+
+
+def test_reclaim_without_tty_fails_safe_no_spawn(tmp_path):
+    # RECLAIM with no interactive terminal (subprocess pipes) cannot prompt → fail
+    # SAFE (guide to reattach, exit 1, spawn nothing), never silently over-spawn.
+    proc, spawned, _ = _run(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit (5/4+1).\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6"],
+    )
+    assert not spawned
+    assert proc.returncode == 1
+    assert "reattach" in proc.stderr.lower()
+
+
+def test_reclaim_empty_oom_floor_refuses_no_spawn(tmp_path):
+    # RECLAIM for reason oom_floor with NO cc session to reclaim → REFUSE (OOM
+    # circuit-breaker), not a silent spawn on a swapless box.
+    proc, spawned, _ = _run(
+        tmp_path, action="RECLAIM\nRAM tight (900MB free).\noom_floor", session_names=[]
+    )
+    assert not spawned
+    assert proc.returncode == 1
+    assert "safety floor" in proc.stderr.lower()
+
+
+def test_reclaim_empty_cap_full_proceeds(tmp_path):
+    proc, spawned, _ = _run(tmp_path, action="RECLAIM\nAt the limit.\ncap_full", session_names=[])
+    assert spawned, proc.stderr
+    assert proc.returncode == 0
+    assert "no cc-N session to reclaim" in proc.stderr
+
+
+def test_reclaim_valid_choice_kills_selected_and_spawns(tmp_path):
+    # pty-driven: pick "2" → ends the 2nd listed session (cc-2), then spawns.
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit (5/4+1).\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6"],
+        feed=b"2\n",
+    )
+    assert spawned, out
+    assert code == 0
+    assert "cc-2" in killed  # exactly the chosen row's session
+    assert "cc-1" not in killed
+
+
+def test_reclaim_leading_zero_choice_rejected_no_spawn(tmp_path):
+    # The security-review HIGH: "08" is octal in bash arithmetic. It must be
+    # REJECTED (invalid selection, exit 1, nothing killed/spawned), never silently
+    # unwind past the gate and spawn.
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit.\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6", "cc-7", "cc-8", "cc-9"],
+        feed=b"08\n",
+    )
+    assert not spawned
+    assert code == 1
+    assert "invalid selection" in out.lower()
+    assert killed == ""
+
+
+def test_manual_door_failopen_over_cap_denies_no_reclaim(tmp_path):
+    # Dashboard/"manual" door is the normal method held to the cap: even in
+    # fail-open it must NOT get the destructive reclaim flow — a plain DENY.
+    # A huge per-session lever forces SAFE_CAP to 1 deterministically.
+    proc, spawned, killed = _run(
+        tmp_path,
+        action="",
+        rc=1,
+        mode="manual",
+        session_names=["cc-1", "cc-2", "cc-3"],
+        extra_env={"GENESIS_CC_PER_SESSION_MB": "1000000"},
+    )
+    assert not spawned
+    assert proc.returncode == 1
+    assert killed == ""
+    assert "cap reached" in proc.stderr.lower()


### PR DESCRIPTION
## Problem

The interactive Claude Code slot launcher (`scripts/cc-slot.sh`) sized its concurrent-session cap from **instantaneous free RAM** — `(MemAvailable − reserve) / per_session`, floored 1, clamped to nproc. Because that samples free RAM *after* sessions are already running, each running session lowered `MemAvailable` and thus lowered the cap **below the number already running** — so the operator got locked out of a new session (observed as a nonsensical "cap reached (3/2 active)") while three ran fine, and unrelated apps' memory silently ate slots too.

## Fix

The cap is now a stable function of **total** RAM, decided by a new pure, unit-tested module `genesis.cc.session_cap` (mirrors the existing `login_gate` pattern — `decide()` + `main()` CLI that cc-slot.sh shells out to):

- **Capacity model, not free-RAM:** `SAFE_CAP = clamp((MemTotal − reserve) / per_session, 1, nproc)`. Stable (does not shrink as sessions run), portable (scales per install — a bigger box gets a bigger cap, a small box down to 1), and unaffected by unrelated apps. Live free RAM is consulted **only** as an OOM circuit-breaker.
- **Operator emergency + reclaim:** a direct LAN/tailscale SSH login (origin classified from `SSH_CONNECTION`) gets an emergency slot above the safe cap and is **never hard-denied** — when the box is full or memory is tight it drops to an interactive prompt: reattach an existing slot, or pick one to end (the ended session's transcript persists → `claude --resume`). The dashboard/"normal method" is held to the safe cap.
- **Never lock out:** reattach always bypasses the gate; the gate **fails open** to a MemTotal-based static fallback (never the old collapsing formula) so a broken venv can't strand the operator. The one refusal is a genuine OOM-floor breach with no cc session to reclaim (protecting a swapless box from a crash that would kill every session).

Tunable per box via `~/.genesis/cc-slot.env`: `GENESIS_CC_SYSTEM_RESERVE_MB` / `_PER_SESSION_MB` / `_OOM_FLOOR_MB` / `_EMERGENCY_SLOTS`.

## Tests

48 tests: pure-function unit matrix (incl. verify-RED on the collapse case) + hermetic end-to-end runs of the real cc-slot.sh against fake tmux/python (ALLOW/DENY/reattach/fail-open/reason-aware reclaim) + **pty-driven** coverage of the interactive choice (valid pick kills the right session and spawns; a leading-zero/octal input is rejected, not silently spawned).

## Review

Reviewed by `genesis-architect` (logic) then `genesis-security-reviewer` (security), sequentially, on the fixed code. Findings fixed: a public-repo privacy leak in test fixtures (scrubbed to synthetic RFC-5737/CGNAT), a silent OOM-floor bypass on empty reclaim, a leading-zero-octal arithmetic gate bypass, unvalidated arithmetic env in the fallback, a lever-ordering bug (config sourced after the gate → tunables never took effect), and a capability-widening in fail-open. All covered by new tests.

## Notes

- Part of the SSH session-cap program; the background-session governor is tracked separately as a follow-up.
- Deploy: `git pull` (cc-slot.sh is re-read per SSH login, the module re-imported per invocation — no server restart). Live-login E2E lands post-deploy.
