### PR TITLE
fix(cc): stabilize the SSH slot cap on total RAM + operator emergency reclaim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,8 +86,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   misreporting "3/2 active") while other apps' memory use silently ate slots too.
   The cap is now a stable function of the box's TOTAL RAM (a new pure, unit-tested
   `genesis.cc.session_cap` helper), so it scales per install, does not shrink as
-  sessions run, and ignores unrelated apps. Live free RAM is used only as an OOM
-  circuit-breaker. A direct LAN/Tailscale SSH login (the operator) gets an
+  sessions run, and ignores unrelated apps. It is **container-aware** — it uses the
+  cgroup memory limit and CPU affinity, not host `/proc` values, so a container that
+  sees host RAM is sized for its real limit (not the host). Live free RAM is used
+  only as an OOM circuit-breaker, and a new session only starts when there is room
+  for a full session (never over-committing a swapless box). A direct LAN/Tailscale SSH login (the operator) gets an
   emergency slot above the safe cap and is never hard-denied — when the box is
   full or memory is tight it offers to reattach or end a chosen session to make
   room (the ended session's transcript persists, resume with `claude --resume`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,11 +90,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   cgroup memory limit and CPU affinity, not host `/proc` values, so a container that
   sees host RAM is sized for its real limit (not the host). Live free RAM is used
   only as an OOM circuit-breaker, and a new session only starts when there is room
-  for a full session (never over-committing a swapless box). A direct LAN/Tailscale SSH login (the operator) gets an
-  emergency slot above the safe cap and is never hard-denied — when the box is
-  full or memory is tight it offers to reattach or end a chosen session to make
-  room (the ended session's transcript persists, resume with `claude --resume`).
-  Reattaching always works. Tunable via `~/.genesis/cc-slot.env`
+  for a full session (never over-committing a swapless box). Any interactive SSH
+  login (a slot hostname or a plain shell running `claude`, from a LAN/Tailscale IP)
+  is the operator and gets an emergency slot above the safe cap; the cap itself
+  never turns it away — when the box is full or memory is tight it offers to reattach
+  or end a chosen session to make room (the ended session's transcript persists,
+  resume with `claude --resume`), and an ATTACHED session needs an explicit confirm
+  before it's ended. Two honest corners still decline: a non-interactive login
+  (no terminal to prompt on) is guided to reattach, and a genuine OOM-floor breach
+  with no slot to trade is refused rather than risking an OOM. The dashboard web
+  terminal / local console (no `SSH_CONNECTION`) is held to the safe cap. Reattaching
+  always works. Tunable via `~/.genesis/cc-slot.env`
   (`GENESIS_CC_SYSTEM_RESERVE_MB` / `_PER_SESSION_MB` / `_OOM_FLOOR_MB` /
   `_EMERGENCY_SLOTS`); the gate fails open so it can never strand you. See
   `docs/reference/tailscale-ssh-access.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,23 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **SSH slot cap no longer collapses below the running session count.** The
+  interactive-slot launcher (`scripts/cc-slot.sh`) sized its cap from
+  *instantaneous free RAM* (`(MemAvailable − reserve) / per_session`), so each
+  running session lowered free RAM and thus lowered the cap *below* the number
+  already running — locking the operator out of a new session (and even
+  misreporting "3/2 active") while other apps' memory use silently ate slots too.
+  The cap is now a stable function of the box's TOTAL RAM (a new pure, unit-tested
+  `genesis.cc.session_cap` helper), so it scales per install, does not shrink as
+  sessions run, and ignores unrelated apps. Live free RAM is used only as an OOM
+  circuit-breaker. A direct LAN/Tailscale SSH login (the operator) gets an
+  emergency slot above the safe cap and is never hard-denied — when the box is
+  full or memory is tight it offers to reattach or end a chosen session to make
+  room (the ended session's transcript persists, resume with `claude --resume`).
+  Reattaching always works. Tunable via `~/.genesis/cc-slot.env`
+  (`GENESIS_CC_SYSTEM_RESERVE_MB` / `_PER_SESSION_MB` / `_OOM_FLOOR_MB` /
+  `_EMERGENCY_SLOTS`); the gate fails open so it can never strand you. See
+  `docs/reference/tailscale-ssh-access.md`.
 - **Heartbeat GC no longer lets a clock-skewed future row starve a subsystem's
   liveness signal.** The `keep_latest_per_subsystem` heartbeat GC
   (`db/crud/events.py::prune`) kept the row equal to the per-subsystem

--- a/docs/reference/tailscale-ssh-access.md
+++ b/docs/reference/tailscale-ssh-access.md
@@ -33,6 +33,31 @@ ssh <host>-lobby    # the session picker → pick any live slot
 Windows one-click: make a shortcut whose target is `wt.exe ssh <host>-lobby`
 (or `ssh.exe <host>-lobby`) and pin it to the taskbar.
 
+## The session cap and the operator emergency slot
+
+New slots are capped by the box's **capacity**, derived from its TOTAL RAM —
+`SAFE_CAP = (MemTotal − reserve) / per_session`, clamped to the CPU count. The cap
+is stable: it does NOT shrink as sessions run, and background apps (other coding
+tools, daemons) don't consume it. It scales per install — a bigger box allows more
+slots, a small box fewer (never below 1). Live free RAM is used only as an
+OOM circuit-breaker, never as the cap.
+
+- **Reattaching** to an existing slot (`ssh <host>-N` to a slot that already
+  exists, or the lobby picker) is ALWAYS allowed — it starts nothing new.
+- **A direct LAN/Tailscale SSH login is treated as the operator** and gets an
+  emergency slot **above** the safe cap, and is **never hard-denied**: when the
+  box is at the limit or RAM is genuinely tight, the login drops to an interactive
+  prompt — reattach an existing slot, or pick one to END (freeing its slot/memory;
+  its transcript persists, resume later with `claude --resume`). You choose what to
+  reclaim; the OOM-killer never does.
+- Other doors (the dashboard web terminal / "normal method") are held to the safe
+  cap.
+
+Tune the model per box in `~/.genesis/cc-slot.env` (all optional):
+`GENESIS_CC_SYSTEM_RESERVE_MB`, `GENESIS_CC_PER_SESSION_MB`,
+`GENESIS_CC_OOM_FLOOR_MB`, `GENESIS_CC_EMERGENCY_SLOTS`. The gate fails **open** —
+if it can't run, a static MemTotal-based fallback still lets you in.
+
 ## Why the aliases are keyed on the Tailscale IP, not the MagicDNS name
 
 `generate-ssh-config.sh` writes each `HostName` as the host's **stable Tailscale

--- a/docs/reference/tailscale-ssh-access.md
+++ b/docs/reference/tailscale-ssh-access.md
@@ -44,14 +44,20 @@ OOM circuit-breaker, never as the cap.
 
 - **Reattaching** to an existing slot (`ssh <host>-N` to a slot that already
   exists, or the lobby picker) is ALWAYS allowed — it starts nothing new.
-- **A direct LAN/Tailscale SSH login is treated as the operator** and gets an
-  emergency slot **above** the safe cap, and is **never hard-denied**: when the
-  box is at the limit or RAM is genuinely tight, the login drops to an interactive
-  prompt — reattach an existing slot, or pick one to END (freeing its slot/memory;
-  its transcript persists, resume later with `claude --resume`). You choose what to
-  reclaim; the OOM-killer never does.
-- Other doors (the dashboard web terminal / "normal method") are held to the safe
-  cap.
+- **Any interactive SSH login is treated as the operator** — a slot hostname OR a
+  plain shell you then run `claude` in, from a LAN/Tailscale IP. It gets an
+  emergency slot **above** the safe cap and is **never turned away by the cap
+  itself**: when the box is at the limit or RAM is genuinely tight, the login drops
+  to an interactive prompt — reattach an existing slot, or pick one to END (freeing
+  its slot/memory; its transcript persists, resume later with `claude --resume`).
+  You choose what to reclaim; the OOM-killer never does. (Two honest corners still
+  decline: a **non-interactive** login with no terminal can't show the prompt, so
+  it's guided to reattach; and if RAM is below the OOM floor with **no slot to
+  trade**, the login is refused rather than risk an OOM on the swapless box. A
+  fully ungated way in always remains — a plain `ssh <box>` shell that doesn't run
+  the slot launcher.)
+- Other doors (the dashboard web terminal / local console — the "normal method",
+  no `SSH_CONNECTION`) are held to the safe cap with a plain refusal over it.
 
 Tune the model per box in `~/.genesis/cc-slot.env` (all optional):
 `GENESIS_CC_SYSTEM_RESERVE_MB`, `GENESIS_CC_PER_SESSION_MB`,

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -292,7 +292,9 @@ else
     esac
 fi
 
-echo "→ Slot ${SLOT} (session: ${SESSION_NAME})" >&2
+# `live: N` = current numeric cc-N count (excludes retired cc-manual-* strays);
+# the gate/fallback message above carries the cap itself.
+echo "→ Slot ${SLOT} (session: ${SESSION_NAME}, live: ${existing})" >&2
 
 # Redirect CC temp to dedicated directory (keeps /tmp clean)
 export TMPDIR="$HOME/.genesis/cc-tmp"

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -109,10 +109,12 @@ unset _lever
 # unit-tested Python gate decides (SAFE_CAP from MemTotal — stable, does NOT
 # collapse as sessions run, unlike the old MemAvailable/900 formula that locked
 # the operator out at "3/2"). Reattach to an existing slot bypasses this entirely.
-# The gate NEVER hard-locks the operator out: ALLOW → proceed; DENY → message+exit
-# (dashboard/"normal method" over cap); RECLAIM → interactive pick-a-session-to-end
-# (LAN/tailscale operator). It fails OPEN — a Python error falls back to a
-# MemTotal-based STATIC cap (never the collapsing free-RAM formula), so a broken
+# The gate never turns an operator away by the CAP: ALLOW → proceed; DENY →
+# message+exit (dashboard/"normal method" — no SSH_CONNECTION — over cap); RECLAIM →
+# interactive pick-a-session-to-end (any SSH login). RECLAIM can still decline in two
+# honest corners (no controlling TTY, or an OOM-floor breach with nothing to trade) —
+# both guide to reattach, never risk an OOM. It fails OPEN — a Python error falls back
+# to a MemTotal-based STATIC cap (never the collapsing free-RAM formula), so a broken
 # venv can never strand the operator. Config levers (~/.genesis/cc-slot.env):
 # GENESIS_CC_SYSTEM_RESERVE_MB / _PER_SESSION_MB / _OOM_FLOOR_MB / _EMERGENCY_SLOTS.
 
@@ -128,11 +130,23 @@ _cap_list_slots() {
 # to END a session to make room, or cancel and reattach. Returns 0 to proceed
 # with the launch; exits on cancel / invalid / no-TTY.
 _cap_reclaim() {
-    local msg="$1" reason="${2:-}" choice victim row nm att act state i=1
-    local -a rows
-    mapfile -t rows < <(tmux list-sessions \
-        -F '#{session_name}|#{session_attached}|#{t:session_activity}' 2>/dev/null \
-        | grep -E "^${SESSION_PREFIX}-[0-9]+\|" || true)
+    local msg="$1" reason="${2:-}" choice victim victim_att _confirm row nm att act state meta i=1
+    local -a names rows
+    # Build the reclaim list from FULLY-anchored bare cc-N names (`grep -xE`, the
+    # same full-line match the `existing` count uses), then query each session's
+    # attach/activity BY EXACT NAME. Never split a single combined
+    # `name|attached|activity` line: a session whose NAME embeds `|` (e.g. one an
+    # attacker crafts as `cc-9|0|x`) would desync the field split and forge the
+    # attach flag, defeating the attached-victim confirm and redirecting the kill.
+    # A crafted `|`-name can't equal a real cc-N and is excluded by the anchor here;
+    # the per-name `=`-exact query then can't shift field boundaries.
+    mapfile -t names < <(tmux list-sessions -F '#{session_name}' 2>/dev/null \
+        | grep -xE "${SESSION_PREFIX}-[0-9]+" || true)
+    rows=()
+    for nm in "${names[@]}"; do
+        meta=$(tmux display-message -p -t "=${nm}" '#{session_attached}|#{t:session_activity}' 2>/dev/null || true)
+        rows+=("${nm}|${meta}")
+    done
     echo "" >&2
     echo "!  ${msg}" >&2
     if [ "${#rows[@]}" -eq 0 ]; then
@@ -182,7 +196,20 @@ _cap_reclaim() {
         echo "Invalid selection — cancelled." >&2
         exit 1
     fi
-    IFS='|' read -r victim _ _ <<<"${rows[$((10#$choice - 1))]}"
+    IFS='|' read -r victim victim_att _ <<<"${rows[$((10#$choice - 1))]}"
+    # An ATTACHED session may have someone actively working in it — require an
+    # explicit y/N before killing it (a detached slot needs no second prompt).
+    if [ "${victim_att:-0}" -ge 1 ]; then
+        echo "!  ${victim} is ATTACHED — someone may be using it. End it anyway? [y/N]" >&2
+        IFS= read -r -p "> " _confirm </dev/tty || _confirm=""
+        case "$_confirm" in
+            y | Y | yes | YES) ;;
+            *)
+                echo "Cancelled — no session ended (reattach: tmux attach -t ${victim})." >&2
+                exit 1
+                ;;
+        esac
+    fi
     echo "Ending ${victim} to free room for ${SESSION_NAME}…" >&2
     # If the kill fails, NO memory was freed — do not spawn a new session on top
     # (that would over-commit the box, the very thing reclaim exists to prevent).
@@ -198,70 +225,124 @@ _cap_reclaim() {
 # STATIC MemTotal cap — NEVER the collapsing free-RAM formula — + a hard OOM
 # floor. Leans permissive so a Python outage never locks the operator out.
 _cap_fail_open() {
-    local total_mb avail_mb reserve per floor cpus safe reason cg_max cg_cur cg_file head_mb need
-    total_mb=$(( $(awk '/^MemTotal:/{print $2}' /proc/meminfo) / 1024 ))
-    avail_mb=$(( $(awk '/^MemAvailable:/{print $2}' /proc/meminfo) / 1024 ))
-    # Cap by the container's cgroup memory limit — procfs can expose HOST values
-    # inside a container, which would size the cap for the host and trigger a
-    # cgroup OOM (mirrors the Python gate's effective_memory()). cgroup v2 only in
-    # this fail-open path (Python handles v1); a v1 host with the gate down falls
-    # back to procfs — the rare degraded case.
+    local mt ma total_mb avail_mb avail_known reserve per floor emerg cpus safe need
+    local cg_max cg_cur cg_if cg_af cg_file head_mb is_op limit reason
+
+    # Validate the operator levers BEFORE any arithmetic, with the SAME grammar as
+    # the Python gate's CapConfig.from_env (so one ~/.genesis/cc-slot.env yields the
+    # same cap on both paths). Positive levers: no leading zero (bash reads that as
+    # OCTAL), 1-7 digits — an oversized value like 2^64 would otherwise WRAP to 0 in
+    # $(( )) and divide-by-zero, aborting the login. Emergency: 0-99 (0 disables).
+    # Anything malformed/oversized → the default.
+    # `read -r <<<` strips surrounding whitespace exactly like Python's str.strip()
+    # in CapConfig.from_env — so a padded value (e.g. "8192 ") is honored IDENTICALLY
+    # on both paths, not accepted by the gate and silently defaulted here.
+    read -r reserve <<<"${GENESIS_CC_SYSTEM_RESERVE_MB:-4096}"; [[ "$reserve" =~ ^[1-9][0-9]{0,6}$ ]] || reserve=4096
+    read -r per     <<<"${GENESIS_CC_PER_SESSION_MB:-3072}";    [[ "$per"     =~ ^[1-9][0-9]{0,6}$ ]] || per=3072
+    read -r floor   <<<"${GENESIS_CC_OOM_FLOOR_MB:-1536}";      [[ "$floor"   =~ ^[1-9][0-9]{0,6}$ ]] || floor=1536
+    read -r emerg   <<<"${GENESIS_CC_EMERGENCY_SLOTS:-1}";      [[ "$emerg"   =~ ^(0|[1-9][0-9]?)$ ]] || emerg=1
+    cpus=$(nproc 2>/dev/null || echo 1);                        [[ "$cpus"    =~ ^[1-9][0-9]{0,3}$ ]] || cpus=1
+
+    # MemTotal / MemAvailable — validate each INDEPENDENTLY (an empty awk result
+    # would break $(( )) under set -e, and an unreadable field must degrade only its
+    # OWN gate, never both). MemTotal is required to size the cap; MemAvailable only
+    # feeds the OOM floor, so a missing MemAvailable → skip the RAM gate, keep count.
+    mt=$(awk '/^MemTotal:/{print $2; exit}' /proc/meminfo 2>/dev/null)
+    if ! [[ "$mt" =~ ^[0-9]+$ ]]; then
+        echo "cc-slot: cannot read MemTotal — capacity gate unavailable, allowing this slot." >&2
+        return 0
+    fi
+    total_mb=$(( mt / 1024 ))
+    ma=$(awk '/^MemAvailable:/{print $2; exit}' /proc/meminfo 2>/dev/null)
+    if [[ "$ma" =~ ^[0-9]+$ ]]; then avail_mb=$(( ma / 1024 )); avail_known=1; else avail_mb=0; avail_known=0; fi
+
+    # Cap by the container's cgroup v2 memory limit — procfs can expose HOST values
+    # inside a container, which would size the cap for the host and trigger a cgroup
+    # OOM (mirrors effective_memory()). v2 only here (Python handles v1); a v1 host
+    # with the gate down uses procfs — the rare degraded case.
     if [ -r /sys/fs/cgroup/memory.max ]; then
         cg_max=$(cat /sys/fs/cgroup/memory.max 2>/dev/null)
         if [[ "$cg_max" =~ ^[0-9]+$ ]]; then
             [ $(( cg_max / 1048576 )) -lt "$total_mb" ] && total_mb=$(( cg_max / 1048576 ))
             cg_cur=$(cat /sys/fs/cgroup/memory.current 2>/dev/null)
             if [[ "$cg_cur" =~ ^[0-9]+$ ]]; then
-                # Add back reclaimable page cache (memory.stat `file`) — current
-                # counts cache as used, so max-current alone understates available
-                # and would wrongly DENY. Matches effective_memory()'s add-back.
-                cg_file=$(awk '/^file /{print $2; exit}' /sys/fs/cgroup/memory.stat 2>/dev/null)
-                [[ "$cg_file" =~ ^[0-9]+$ ]] || cg_file=0
+                # Reclaimable = file LRU (inactive_file + active_file), NOT the `file`
+                # counter — `file` also counts tmpfs/shmem, which live on the ANON LRU
+                # and are NOT reclaimable for a new session (would over-state available
+                # → wrongly ALLOW). Mirrors read_container_memory_reclaimable().
+                cg_if=$(awk '/^inactive_file /{print $2; exit}' /sys/fs/cgroup/memory.stat 2>/dev/null); [[ "$cg_if" =~ ^[0-9]+$ ]] || cg_if=0
+                cg_af=$(awk '/^active_file /{print $2; exit}' /sys/fs/cgroup/memory.stat 2>/dev/null);   [[ "$cg_af" =~ ^[0-9]+$ ]] || cg_af=0
+                cg_file=$(( cg_if + cg_af ))
                 head_mb=$(( (cg_max - cg_cur + cg_file) / 1048576 )); [ "$head_mb" -lt 0 ] && head_mb=0
-                [ "$head_mb" -lt "$avail_mb" ] && avail_mb=$head_mb
+                if [ "$avail_known" = 1 ]; then
+                    [ "$head_mb" -lt "$avail_mb" ] && avail_mb=$head_mb
+                else
+                    avail_mb=$head_mb; avail_known=1
+                fi
+            else
+                # cgroup limit known but usage unreadable → procfs MemAvailable may be
+                # HOST headroom (over-allow on a swapless container). Estimate free from
+                # the capacity model instead (mirror the Python degrade): total − reserve
+                # − existing×per. Never trust host free RAM here. (User decision 2026-08-27.)
+                avail_mb=$(( total_mb - reserve - existing * per )); [ "$avail_mb" -lt 0 ] && avail_mb=0
+                avail_known=1
             fi
         fi
     fi
-    # Validate the operator-set levers BEFORE using them in $(( )): a non-numeric
-    # override (e.g. "3072mb", a leading-zero octal, or a zero floor that disables
-    # the guard) would break the arithmetic or the OOM floor. Mirror
-    # CapConfig.from_env's guard: bad/zero → default.
-    reserve=${GENESIS_CC_SYSTEM_RESERVE_MB:-4096}; [[ "$reserve" =~ ^[1-9][0-9]*$ ]] || reserve=4096
-    per=${GENESIS_CC_PER_SESSION_MB:-3072};        [[ "$per"     =~ ^[1-9][0-9]*$ ]] || per=3072
-    floor=${GENESIS_CC_OOM_FLOOR_MB:-1536};        [[ "$floor"   =~ ^[1-9][0-9]*$ ]] || floor=1536
-    cpus=$(nproc 2>/dev/null || echo 1); [[ "$cpus" =~ ^[1-9][0-9]*$ ]] || cpus=1
+
     safe=$(( (total_mb - reserve) / per )); [ "$safe" -lt 1 ] && safe=1
     [ "$safe" -gt "$cpus" ] && safe=$cpus   # nproc clamp (process-aware; thrash guard)
     # Room to START one more session must cover a FULL per-session footprint (a
     # session grows toward `per`), plus the absolute floor — whichever is larger.
     need=$per; [ "$floor" -gt "$need" ] && need=$floor
-    # Leans permissive on COUNT (allows up to safe+1 for any origin — the fallback
-    # can't classify SSH origin, and never-lock-the-operator-out wins) but the OOM
-    # guard below is strict. Looser than the real gate BY DESIGN; only reachable
-    # when the Python gate is down (broken venv).
-    if [ "$existing" -lt $((safe + 1)) ] && [ "$avail_mb" -ge "$need" ]; then
-        echo "cc-slot: capacity gate unavailable — static fallback allows this slot (${existing}/${safe})." >&2
+
+    # Origin: ANY SSH login ($SSH_CONNECTION set) is the OPERATOR — emergency slot +
+    # interactive reclaim, never a hard deny (user policy 2026-08-27: SSH = operator).
+    # No SSH_CONNECTION is the "normal method" (dashboard web terminal / local
+    # console) — held to `safe`, plain deny. This static path can't classify the
+    # client IP without a hand-rolled parser (the Codex tar-pit), so it keys on SSH
+    # PRESENCE; documented fail-open-only divergence: a public-IP SSH gets the
+    # operator affordance here, whereas the Python gate would DENY it.
+    if [ -n "${SSH_CONNECTION:-}" ]; then is_op=1; limit=$(( safe + emerg )); else is_op=0; limit=$safe; fi
+
+    # ALLOW iff under the origin's limit AND (RAM unknown OR enough headroom).
+    if [ "$existing" -lt "$limit" ] && { [ "$avail_known" = 0 ] || [ "$avail_mb" -ge "$need" ]; }; then
+        if [ "$avail_known" = 0 ]; then
+            echo "cc-slot: capacity gate unavailable, MemAvailable unreadable — count-cap only ($(( existing + 1 ))/${safe})." >&2
+        else
+            echo "cc-slot: capacity gate unavailable — static fallback allows this slot ($(( existing + 1 ))/${safe})." >&2
+        fi
         return 0
     fi
-    if [ "$avail_mb" -lt "$need" ]; then reason="oom_floor"; else reason="cap_full"; fi
-    # The interactive reclaim (which can kill a session) is an OPERATOR affordance.
-    # The dashboard/"manual" door is the "normal method" held to the cap — do NOT
-    # widen the session-kill flow to it, even in fail-open. It gets a plain DENY.
-    # (This gates on the door, not SSH origin — so a rare public-IP SSH slot login
-    # under fail-open still reaches reclaim; the Python gate would DENY it. No
-    # escalation: the caller is already SSH-authenticated, and it's fail-open-only.)
-    if [ "$MODE_ARG" = "manual" ]; then
-        echo "ERROR: Session cap reached (${existing}/${safe}) [capacity gate unavailable]." >&2
-        _cap_list_slots
-        exit 1
+
+    # Not allowed → classify reason (RAM tight vs at-limit).
+    if [ "$avail_known" = 1 ] && [ "$avail_mb" -lt "$need" ]; then reason="oom_floor"; else reason="cap_full"; fi
+
+    if [ "$is_op" = 1 ]; then
+        # Operator (SSH): never a hard no — interactive reclaim (pick a session to end).
+        if [ "$reason" = "oom_floor" ]; then
+            _cap_reclaim "Capacity gate unavailable; RAM low (${avail_mb}MB free, need >= ${need}MB)." "$reason"
+        else
+            _cap_reclaim "Capacity gate unavailable; at the limit (${existing}/${safe}+${emerg})." "$reason"
+        fi
+        return 0
     fi
-    _cap_reclaim "Capacity gate unavailable; static limit ${existing}/${safe}, ${avail_mb}MB free." "$reason"
-    return 0
+    # Normal method (dashboard/local console): plain deny, message matches the reason.
+    if [ "$reason" = "oom_floor" ]; then
+        echo "ERROR: RAM low (${avail_mb}MB free, need >= ${need}MB) [capacity gate unavailable]." >&2
+    else
+        echo "ERROR: Session cap reached (${existing}/${safe}) [capacity gate unavailable]." >&2
+    fi
+    _cap_list_slots
+    exit 1
 }
 
 # Numeric slots only: retired cc-manual-<ts>-<pid> sessions from the old wrapper
 # (and any other cc-* stray) must not consume cap headroom — manual allocation
-# can only ever probe/create cc-<N>.
+# can only ever probe/create cc-<N>. This count is a point-in-time snapshot: two
+# logins racing at the same instant can both read the same `existing` and both
+# spawn (a benign, pre-existing over-count of at most the concurrency — the cap is
+# a resource governor, not a lock; the OOM floor still guards actual exhaustion).
 existing=$(tmux list-sessions -F '#{session_name}' 2>/dev/null \
            | grep -cE "^${SESSION_PREFIX}-[0-9]+$" || true)
 

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -170,11 +170,15 @@ _cap_reclaim() {
         echo "Cancelled — reattach an existing session (tmux attach -t ${SESSION_PREFIX}-<N>)." >&2
         exit 1
     fi
-    # Reject leading zeros (^[1-9][0-9]*$, same as SLOT above): bash reads a
-    # leading-zero numeral as OCTAL, so "08"/"09" would raise a "value too great
-    # for base" arithmetic error that silently unwinds past this gate and spawns
-    # anyway — defeating the cap. 10# forces base-10 defensively in the index.
-    if ! [[ "$choice" =~ ^[1-9][0-9]*$ ]] || [ "$choice" -gt "${#rows[@]}" ]; then
+    # Validate the choice fully BEFORE any arithmetic. Reject: leading zeros
+    # (^[1-9][0-9]*$ — bash reads a leading-zero numeral as OCTAL → "08" errors),
+    # AND an over-long digit string (the `-le 3` bound short-circuits before the
+    # `-gt` comparison, so an oversized value like 2^64 can't raise an arithmetic
+    # error that unwinds past the check and then WRAP the index to a valid slot,
+    # killing the wrong session). The row list is always << 1000, so ≤3 digits
+    # covers every real selection. 10# forces base-10 in the index defensively.
+    if ! [[ "$choice" =~ ^[1-9][0-9]*$ ]] || [ "${#choice}" -gt 3 ] \
+       || [ "$choice" -gt "${#rows[@]}" ]; then
         echo "Invalid selection — cancelled." >&2
         exit 1
     fi

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -85,23 +85,146 @@ SESSION_NAME="${SESSION_PREFIX}-${SLOT}"
 # Handle nested tmux
 unset TMUX
 
-# --- Dynamic session cap (RAM + CPU aware) ---
-RESERVED_MB=4096        # OS + Genesis runtime + background work headroom
-PER_SESSION_MB=900      # Measured: ~800MB (claude + 4 MCP servers) + buffer
-CPU_CAP=$(nproc)        # Never exceed core count (thrashing)
+# Load operator config levers (~/.genesis/cc-slot.env) BEFORE the capacity gate,
+# so its GENESIS_CC_* tunables actually take effect there (an SSH RemoteCommand
+# does NOT source .bashrc). This file is also home to the permission-mode lever
+# (GENESIS_CC_PERMISSION_MODE) and the OAuth-durability lever
+# (GENESIS_CC_SLOT_OAUTH), both consumed later. `|| echo` keeps a malformed file
+# from aborting the login under `set -e`.
+if [ -f "${HOME}/.genesis/cc-slot.env" ]; then
+    . "${HOME}/.genesis/cc-slot.env" \
+        || echo "cc-slot: warning: ~/.genesis/cc-slot.env sourced with errors (continuing)" >&2
+fi
+# A sourced var is a shell var, NOT exported — EXPORT the cap levers so the Python
+# gate subprocess inherits them. Only export those actually set (an empty export
+# would still read as unset → default, but keep the env clean).
+for _lever in GENESIS_CC_SYSTEM_RESERVE_MB GENESIS_CC_PER_SESSION_MB \
+              GENESIS_CC_OOM_FLOOR_MB GENESIS_CC_EMERGENCY_SLOTS; do
+    [ -n "${!_lever:-}" ] && export "$_lever"
+done
+unset _lever
 
-avail_kb=$(awk '/^MemAvailable:/ {print $2}' /proc/meminfo)
-avail_mb=$((avail_kb / 1024))
-ram_cap=$(( (avail_mb - RESERVED_MB) / PER_SESSION_MB ))
+# --- Session cap (capacity model; decision delegated to genesis.cc.session_cap) ---
+# The launcher only GATHERS inputs and EXECUTES the returned action; the pure,
+# unit-tested Python gate decides (SAFE_CAP from MemTotal — stable, does NOT
+# collapse as sessions run, unlike the old MemAvailable/900 formula that locked
+# the operator out at "3/2"). Reattach to an existing slot bypasses this entirely.
+# The gate NEVER hard-locks the operator out: ALLOW → proceed; DENY → message+exit
+# (dashboard/"normal method" over cap); RECLAIM → interactive pick-a-session-to-end
+# (LAN/tailscale operator). It fails OPEN — a Python error falls back to a
+# MemTotal-based STATIC cap (never the collapsing free-RAM formula), so a broken
+# venv can never strand the operator. Config levers (~/.genesis/cc-slot.env):
+# GENESIS_CC_SYSTEM_RESERVE_MB / _PER_SESSION_MB / _OOM_FLOOR_MB / _EMERGENCY_SLOTS.
 
-# Floor: 1 (never lock out); Ceiling: nproc
-max_sessions=$ram_cap
-[[ $max_sessions -lt 1 ]] && max_sessions=1
-[[ $max_sessions -gt $CPU_CAP ]] && max_sessions=$CPU_CAP
+# List live numeric cc-N slots to stderr (shared by DENY + fail-open paths).
+_cap_list_slots() {
+    echo "Active sessions (reattach: tmux attach -t <name>):" >&2
+    tmux list-sessions \
+        -F '  #{session_name}  (#{?session_attached,ATTACHED,detached}, idle since #{t:session_activity})' \
+        2>/dev/null | grep -E "^  ${SESSION_PREFIX}-[0-9]+ " >&2 || true
+}
 
-# Numeric slots only: retired cc-manual-<ts>-<pid> sessions from the old
-# wrapper (and any other cc-* stray) must not consume cap headroom — manual
-# allocation can only ever probe/create cc-<N>.
+# Interactive reclaim (operator origin, or the fail-open path with a TTY): offer
+# to END a session to make room, or cancel and reattach. Returns 0 to proceed
+# with the launch; exits on cancel / invalid / no-TTY.
+_cap_reclaim() {
+    local msg="$1" reason="${2:-}" choice victim row nm att act state i=1
+    local -a rows
+    mapfile -t rows < <(tmux list-sessions \
+        -F '#{session_name}|#{session_attached}|#{t:session_activity}' 2>/dev/null \
+        | grep -E "^${SESSION_PREFIX}-[0-9]+\|" || true)
+    echo "" >&2
+    echo "!  ${msg}" >&2
+    if [ "${#rows[@]}" -eq 0 ]; then
+        # No cc-N session to trade. Under a genuine OOM-floor breach, REFUSE the
+        # new session — the swapless box is already below the safety floor from
+        # NON-cc memory pressure, and spawning a ~3GB session risks an OOM that
+        # takes down every session. This is the OOM circuit-breaker doing its
+        # job, NOT the old collapse bug (which denied while sessions ran fine).
+        # For a soft cap with nothing to reclaim, proceeding is harmless.
+        if [ "$reason" = "oom_floor" ]; then
+            echo "RAM is below the safety floor and no cc session exists to reclaim —" >&2
+            echo "free non-cc memory and retry, or reattach an existing session." >&2
+            exit 1
+        fi
+        echo "(no cc-N session to reclaim; proceeding.)" >&2
+        return 0
+    fi
+    echo "" >&2
+    for row in "${rows[@]}"; do
+        IFS='|' read -r nm att act <<<"$row"
+        state="detached"; [ "${att:-0}" -ge 1 ] && state="ATTACHED"
+        echo "  [$i] ${nm}  ${state}  (idle since ${act})" >&2
+        i=$((i + 1))
+    done
+    echo "" >&2
+    if [ ! -t 0 ]; then
+        echo "No interactive terminal here — reattach a session" >&2
+        echo "(tmux attach -t ${SESSION_PREFIX}-<N>), or re-run 'ssh <host>-<N>' with a TTY to end one." >&2
+        exit 1
+    fi
+    echo "Enter a number to END that session (frees memory + its slot; the transcript" >&2
+    echo "persists — resume later with 'claude --resume'). Press Enter to cancel:" >&2
+    IFS= read -r -p "> " choice </dev/tty || choice=""
+    if [ -z "$choice" ]; then
+        echo "Cancelled — reattach an existing session (tmux attach -t ${SESSION_PREFIX}-<N>)." >&2
+        exit 1
+    fi
+    # Reject leading zeros (^[1-9][0-9]*$, same as SLOT above): bash reads a
+    # leading-zero numeral as OCTAL, so "08"/"09" would raise a "value too great
+    # for base" arithmetic error that silently unwinds past this gate and spawns
+    # anyway — defeating the cap. 10# forces base-10 defensively in the index.
+    if ! [[ "$choice" =~ ^[1-9][0-9]*$ ]] || [ "$choice" -gt "${#rows[@]}" ]; then
+        echo "Invalid selection — cancelled." >&2
+        exit 1
+    fi
+    IFS='|' read -r victim _ _ <<<"${rows[$((10#$choice - 1))]}"
+    echo "Ending ${victim} to free room for ${SESSION_NAME}…" >&2
+    tmux kill-session -t "=${victim}" 2>/dev/null || true
+    return 0
+}
+
+# Pure-bash fallback when the Python gate cannot run (broken venv / timeout).
+# STATIC MemTotal cap — NEVER the collapsing free-RAM formula — + a hard OOM
+# floor. Leans permissive so a Python outage never locks the operator out.
+_cap_fail_open() {
+    local total_mb avail_mb reserve per floor cpus safe reason
+    total_mb=$(( $(awk '/^MemTotal:/{print $2}' /proc/meminfo) / 1024 ))
+    avail_mb=$(( $(awk '/^MemAvailable:/{print $2}' /proc/meminfo) / 1024 ))
+    # Validate the operator-set levers BEFORE using them in $(( )): a non-numeric
+    # override (e.g. "3072mb", or a leading-zero octal) would raise an arithmetic
+    # error that silently unwinds this function → the fallback becomes a no-op and
+    # the session spawns with NO cap. Mirror CapConfig.from_env's guard: bad → default.
+    reserve=${GENESIS_CC_SYSTEM_RESERVE_MB:-4096}; [[ "$reserve" =~ ^[1-9][0-9]*$ ]] || reserve=4096
+    per=${GENESIS_CC_PER_SESSION_MB:-3072};        [[ "$per"     =~ ^[1-9][0-9]*$ ]] || per=3072
+    floor=${GENESIS_CC_OOM_FLOOR_MB:-1536};        [[ "$floor"   =~ ^[0-9]+$ ]]      || floor=1536
+    cpus=$(nproc 2>/dev/null || echo 1); [[ "$cpus" =~ ^[1-9][0-9]*$ ]] || cpus=1
+    safe=$(( (total_mb - reserve) / per )); [ "$safe" -lt 1 ] && safe=1
+    [ "$safe" -gt "$cpus" ] && safe=$cpus   # mirror the Python gate's nproc clamp (thrash guard)
+    # Leans permissive: allows up to safe+1 (the fallback can't call the Python
+    # origin classifier, and never-lock-the-operator-out wins here) — the OOM floor
+    # below still guards the box. Looser than the real gate BY DESIGN, and only
+    # reachable when the Python gate is down (broken venv).
+    if [ "$existing" -lt $((safe + 1)) ] && [ "$avail_mb" -ge "$floor" ]; then
+        echo "cc-slot: capacity gate unavailable — static fallback allows this slot (${existing}/${safe})." >&2
+        return 0
+    fi
+    if [ "$avail_mb" -lt "$floor" ]; then reason="oom_floor"; else reason="cap_full"; fi
+    # The interactive reclaim (which can kill a session) is an OPERATOR affordance.
+    # The dashboard/"manual" door is the "normal method" held to the cap — do NOT
+    # widen the session-kill flow to it, even in fail-open. It gets a plain DENY.
+    if [ "$MODE_ARG" = "manual" ]; then
+        echo "ERROR: Session cap reached (${existing}/${safe}) [capacity gate unavailable]." >&2
+        _cap_list_slots
+        exit 1
+    fi
+    _cap_reclaim "Capacity gate unavailable; static limit ${existing}/${safe}, ${avail_mb}MB free." "$reason"
+    return 0
+}
+
+# Numeric slots only: retired cc-manual-<ts>-<pid> sessions from the old wrapper
+# (and any other cc-* stray) must not consume cap headroom — manual allocation
+# can only ever probe/create cc-<N>.
 existing=$(tmux list-sessions -F '#{session_name}' 2>/dev/null \
            | grep -cE "^${SESSION_PREFIX}-[0-9]+$" || true)
 
@@ -111,19 +234,28 @@ if tmux has-session -t "=$SESSION_NAME" 2>/dev/null; then
     _SESSION_EXISTS=1  # bypass cap check; also skips the OAuth gate below —
                        # attach does NOT re-run the pane command, so any token
                        # injection would be moot (and would waste a probe).
-elif [[ $existing -ge $max_sessions ]]; then
-    echo "ERROR: Session cap reached (${existing}/${max_sessions} active)." >&2
-    echo "RAM: ${avail_mb}MB available, ${RESERVED_MB}MB reserved, ${PER_SESSION_MB}MB/session" >&2
-    echo "" >&2
-    echo "Active sessions:" >&2
-    tmux list-sessions -F '  #{session_name}  (last activity: #{t:session_activity})' \
-        2>/dev/null | grep "^  ${SESSION_PREFIX}-" >&2
-    echo "" >&2
-    echo "Kill an idle session: tmux kill-session -t ${SESSION_PREFIX}-<N>" >&2
-    exit 1
+else
+    # New session → consult the capacity gate (SSH_CONNECTION classifies origin
+    # inside the Python helper). `timeout` bounds a hung import; trailing
+    # `|| true` keeps a non-zero exit from aborting under `set -e`.
+    _cap_py="${GENESIS_ROOT}/.venv/bin/python"
+    _cap_out=""
+    if [ -x "$_cap_py" ]; then
+        _cap_out=$(timeout 15 "$_cap_py" -m genesis.cc.session_cap --existing "$existing" 2>/dev/null || true)
+    fi
+    # Protocol: line 1 = action, line 2 = human message, line 3 = machine reason.
+    _cap_action=$(printf '%s\n' "$_cap_out" | sed -n '1p')
+    _cap_msg=$(printf '%s\n' "$_cap_out" | sed -n '2p')
+    _cap_reason=$(printf '%s\n' "$_cap_out" | sed -n '3p')
+    case "$_cap_action" in
+        ALLOW)   [ -n "$_cap_msg" ] && echo "cc-slot: ${_cap_msg}" >&2 || true ;;
+        DENY)    echo "ERROR: ${_cap_msg}" >&2; _cap_list_slots; exit 1 ;;
+        RECLAIM) _cap_reclaim "$_cap_msg" "$_cap_reason" ;;
+        *)       _cap_fail_open ;;   # empty/unexpected → Python gate unavailable
+    esac
 fi
 
-echo "→ Slot ${SLOT} (session: ${SESSION_NAME}, cap: ${existing}/${max_sessions})" >&2
+echo "→ Slot ${SLOT} (session: ${SESSION_NAME})" >&2
 
 # Redirect CC temp to dedicated directory (keeps /tmp clean)
 export TMPDIR="$HOME/.genesis/cc-tmp"
@@ -147,13 +279,8 @@ export CLAUDE_CODE_TMPDIR="$HOME/.genesis/cc-tmp"
 # dies (see the OAuth block below).
 # Headless/autonomous CC sessions (CCInvoker -p) keep bypass separately — no
 # human is present to answer a prompt.
-if [ -f "${HOME}/.genesis/cc-slot.env" ]; then
-    # Don't let a malformed override file kill the session under `set -e` (the
-    # sourced file is the final command of an && chain, so a non-zero exit would
-    # abort the script and drop the SSH session with no diagnostic).
-    . "${HOME}/.genesis/cc-slot.env" \
-        || echo "cc-slot: warning: ~/.genesis/cc-slot.env sourced with errors (continuing)" >&2
-fi
+# (~/.genesis/cc-slot.env is already sourced near the top, before the capacity
+# gate, so these levers are populated here.)
 case "${GENESIS_CC_PERMISSION_MODE:-auto}" in
     bypass|dangerous|skip) CC_PERM_FLAG="--dangerously-skip-permissions" ;;
     *)                     CC_PERM_FLAG="--permission-mode auto" ;;

--- a/scripts/cc-slot.sh
+++ b/scripts/cc-slot.sh
@@ -180,7 +180,13 @@ _cap_reclaim() {
     fi
     IFS='|' read -r victim _ _ <<<"${rows[$((10#$choice - 1))]}"
     echo "Ending ${victim} to free room for ${SESSION_NAME}…" >&2
-    tmux kill-session -t "=${victim}" 2>/dev/null || true
+    # If the kill fails, NO memory was freed — do not spawn a new session on top
+    # (that would over-commit the box, the very thing reclaim exists to prevent).
+    if ! tmux kill-session -t "=${victim}" 2>/dev/null; then
+        echo "Failed to end ${victim} — not starting a new session (no memory freed)." >&2
+        echo "Reattach an existing session instead (tmux attach -t ${SESSION_PREFIX}-<N>)." >&2
+        exit 1
+    fi
     return 0
 }
 
@@ -188,31 +194,58 @@ _cap_reclaim() {
 # STATIC MemTotal cap — NEVER the collapsing free-RAM formula — + a hard OOM
 # floor. Leans permissive so a Python outage never locks the operator out.
 _cap_fail_open() {
-    local total_mb avail_mb reserve per floor cpus safe reason
+    local total_mb avail_mb reserve per floor cpus safe reason cg_max cg_cur cg_file head_mb need
     total_mb=$(( $(awk '/^MemTotal:/{print $2}' /proc/meminfo) / 1024 ))
     avail_mb=$(( $(awk '/^MemAvailable:/{print $2}' /proc/meminfo) / 1024 ))
+    # Cap by the container's cgroup memory limit — procfs can expose HOST values
+    # inside a container, which would size the cap for the host and trigger a
+    # cgroup OOM (mirrors the Python gate's effective_memory()). cgroup v2 only in
+    # this fail-open path (Python handles v1); a v1 host with the gate down falls
+    # back to procfs — the rare degraded case.
+    if [ -r /sys/fs/cgroup/memory.max ]; then
+        cg_max=$(cat /sys/fs/cgroup/memory.max 2>/dev/null)
+        if [[ "$cg_max" =~ ^[0-9]+$ ]]; then
+            [ $(( cg_max / 1048576 )) -lt "$total_mb" ] && total_mb=$(( cg_max / 1048576 ))
+            cg_cur=$(cat /sys/fs/cgroup/memory.current 2>/dev/null)
+            if [[ "$cg_cur" =~ ^[0-9]+$ ]]; then
+                # Add back reclaimable page cache (memory.stat `file`) — current
+                # counts cache as used, so max-current alone understates available
+                # and would wrongly DENY. Matches effective_memory()'s add-back.
+                cg_file=$(awk '/^file /{print $2; exit}' /sys/fs/cgroup/memory.stat 2>/dev/null)
+                [[ "$cg_file" =~ ^[0-9]+$ ]] || cg_file=0
+                head_mb=$(( (cg_max - cg_cur + cg_file) / 1048576 )); [ "$head_mb" -lt 0 ] && head_mb=0
+                [ "$head_mb" -lt "$avail_mb" ] && avail_mb=$head_mb
+            fi
+        fi
+    fi
     # Validate the operator-set levers BEFORE using them in $(( )): a non-numeric
-    # override (e.g. "3072mb", or a leading-zero octal) would raise an arithmetic
-    # error that silently unwinds this function → the fallback becomes a no-op and
-    # the session spawns with NO cap. Mirror CapConfig.from_env's guard: bad → default.
+    # override (e.g. "3072mb", a leading-zero octal, or a zero floor that disables
+    # the guard) would break the arithmetic or the OOM floor. Mirror
+    # CapConfig.from_env's guard: bad/zero → default.
     reserve=${GENESIS_CC_SYSTEM_RESERVE_MB:-4096}; [[ "$reserve" =~ ^[1-9][0-9]*$ ]] || reserve=4096
     per=${GENESIS_CC_PER_SESSION_MB:-3072};        [[ "$per"     =~ ^[1-9][0-9]*$ ]] || per=3072
-    floor=${GENESIS_CC_OOM_FLOOR_MB:-1536};        [[ "$floor"   =~ ^[0-9]+$ ]]      || floor=1536
+    floor=${GENESIS_CC_OOM_FLOOR_MB:-1536};        [[ "$floor"   =~ ^[1-9][0-9]*$ ]] || floor=1536
     cpus=$(nproc 2>/dev/null || echo 1); [[ "$cpus" =~ ^[1-9][0-9]*$ ]] || cpus=1
     safe=$(( (total_mb - reserve) / per )); [ "$safe" -lt 1 ] && safe=1
-    [ "$safe" -gt "$cpus" ] && safe=$cpus   # mirror the Python gate's nproc clamp (thrash guard)
-    # Leans permissive: allows up to safe+1 (the fallback can't call the Python
-    # origin classifier, and never-lock-the-operator-out wins here) — the OOM floor
-    # below still guards the box. Looser than the real gate BY DESIGN, and only
-    # reachable when the Python gate is down (broken venv).
-    if [ "$existing" -lt $((safe + 1)) ] && [ "$avail_mb" -ge "$floor" ]; then
+    [ "$safe" -gt "$cpus" ] && safe=$cpus   # nproc clamp (process-aware; thrash guard)
+    # Room to START one more session must cover a FULL per-session footprint (a
+    # session grows toward `per`), plus the absolute floor — whichever is larger.
+    need=$per; [ "$floor" -gt "$need" ] && need=$floor
+    # Leans permissive on COUNT (allows up to safe+1 for any origin — the fallback
+    # can't classify SSH origin, and never-lock-the-operator-out wins) but the OOM
+    # guard below is strict. Looser than the real gate BY DESIGN; only reachable
+    # when the Python gate is down (broken venv).
+    if [ "$existing" -lt $((safe + 1)) ] && [ "$avail_mb" -ge "$need" ]; then
         echo "cc-slot: capacity gate unavailable — static fallback allows this slot (${existing}/${safe})." >&2
         return 0
     fi
-    if [ "$avail_mb" -lt "$floor" ]; then reason="oom_floor"; else reason="cap_full"; fi
+    if [ "$avail_mb" -lt "$need" ]; then reason="oom_floor"; else reason="cap_full"; fi
     # The interactive reclaim (which can kill a session) is an OPERATOR affordance.
     # The dashboard/"manual" door is the "normal method" held to the cap — do NOT
     # widen the session-kill flow to it, even in fail-open. It gets a plain DENY.
+    # (This gates on the door, not SSH origin — so a rare public-IP SSH slot login
+    # under fail-open still reaches reclaim; the Python gate would DENY it. No
+    # escalation: the caller is already SSH-authenticated, and it's fail-open-only.)
     if [ "$MODE_ARG" = "manual" ]; then
         echo "ERROR: Session cap reached (${existing}/${safe}) [capacity gate unavailable]." >&2
         _cap_list_slots

--- a/src/genesis/cc/session_cap.py
+++ b/src/genesis/cc/session_cap.py
@@ -16,11 +16,15 @@ The model here is CAPACITY, not free-RAM:
 - Live free RAM (MemAvailable) is consulted ONLY as a low OOM circuit-breaker —
   a floor to refuse a NEW session when the swapless box is genuinely near
   exhaustion — never as the cap.
-- Origin-aware: a direct LAN/tailscale SSH login (the operator "let me in" path,
-  distinct from the dashboard/magic-link "normal method") gets an emergency slot
-  ABOVE the safe cap and is NEVER hard-denied — when the box is full/tight it is
-  offered an interactive RECLAIM (pick a session to end, or reattach), so the
-  operator always has a path in without the OOM-killer choosing the casualty.
+- Origin-aware: ANY interactive SSH login (the operator "let me in" path — a slot
+  hostname OR a plain shell that runs `claude`, keyed on SSH_CONNECTION, distinct
+  from the dashboard/local-console "normal method") gets an emergency slot ABOVE
+  the safe cap. `decide()` NEVER returns DENY for an operator — when the box is
+  full/tight it returns RECLAIM (pick a session to end, or reattach), so the
+  operator always has a path in without the OOM-killer choosing the casualty. (The
+  interactive reclaim in cc-slot.sh can still decline in two honest corners the
+  pure gate can't see: no controlling TTY to prompt on, or an OOM-floor breach with
+  no slot to trade — both guide the user to reattach rather than risk an OOM.)
 
 Contract (mirrors `genesis.cc.login_gate`): `main()` reads /proc/meminfo, cpu
 count, `SSH_CONNECTION`, and the `GENESIS_CC_*` config levers, takes the current
@@ -40,7 +44,16 @@ from __future__ import annotations
 import argparse
 import ipaddress
 import os
+import re
 from dataclasses import dataclass
+
+# Lever grammars — kept BYTE-IDENTICAL to the bash fallback's validation in
+# scripts/cc-slot.sh so the same ~/.genesis/cc-slot.env yields the same cap on
+# the Python path and the degraded static path. Positive levers: no leading zero
+# (bash reads that as octal), 1–7 digits (bash arithmetic can't overflow a
+# ≤9,999,999 value). Emergency: 0–99 (0 disables the emergency slot).
+_LEVER_POSITIVE = re.compile(r"[1-9][0-9]{0,6}")
+_LEVER_EMERGENCY = re.compile(r"0|[1-9][0-9]?")
 
 # --- Config levers (documented, tunable via ~/.genesis/cc-slot.env) -----------
 # Explicit, honest defaults measured on the reference 18GB swapless box
@@ -76,36 +89,31 @@ class CapConfig:
     def from_env(cls, environ: dict | None = None) -> CapConfig:
         env = os.environ if environ is None else environ
 
-        def _int(name: str, default: int) -> int:
+        def _lever(name: str, default: int, pattern: re.Pattern) -> int:
+            # Accept ONLY the exact bash grammar (fullmatch) — a value the bash
+            # fallback would reject (e.g. "3072mb", "+3072", "2_000", a leading
+            # zero, or an oversized string) falls back to the default here too,
+            # so the two paths never disagree on a config file.
             raw = env.get(name)
-            if raw is None or str(raw).strip() == "":
+            if raw is None:
                 return default
-            try:
-                val = int(str(raw).strip())
-            except ValueError:
-                return default
-            # Guard against a nonsensical override that would break the model
-            # (e.g. per_session 0 → division error). Fall back to the default.
-            return val if val > 0 else default
+            s = str(raw).strip()
+            return int(s) if pattern.fullmatch(s) else default
 
         return cls(
-            system_reserve_mb=_int("GENESIS_CC_SYSTEM_RESERVE_MB", _DEF_SYSTEM_RESERVE_MB),
-            per_session_mb=_int("GENESIS_CC_PER_SESSION_MB", _DEF_PER_SESSION_MB),
-            oom_floor_mb=_int("GENESIS_CC_OOM_FLOOR_MB", _DEF_OOM_FLOOR_MB),
-            # emergency_slots may legitimately be 0 (disable the emergency lever),
-            # so it uses a >=0 guard rather than the >0 guard above.
-            emergency_slots=max(0, _emergency_from_env(env)),
+            system_reserve_mb=_lever(
+                "GENESIS_CC_SYSTEM_RESERVE_MB", _DEF_SYSTEM_RESERVE_MB, _LEVER_POSITIVE
+            ),
+            per_session_mb=_lever(
+                "GENESIS_CC_PER_SESSION_MB", _DEF_PER_SESSION_MB, _LEVER_POSITIVE
+            ),
+            oom_floor_mb=_lever("GENESIS_CC_OOM_FLOOR_MB", _DEF_OOM_FLOOR_MB, _LEVER_POSITIVE),
+            # emergency_slots may legitimately be 0 (disable the emergency lever) —
+            # the emergency grammar admits 0; anything malformed → the default.
+            emergency_slots=_lever(
+                "GENESIS_CC_EMERGENCY_SLOTS", _DEF_EMERGENCY_SLOTS, _LEVER_EMERGENCY
+            ),
         )
-
-
-def _emergency_from_env(env: dict) -> int:
-    raw = env.get("GENESIS_CC_EMERGENCY_SLOTS")
-    if raw is None or str(raw).strip() == "":
-        return _DEF_EMERGENCY_SLOTS
-    try:
-        return int(str(raw).strip())
-    except ValueError:
-        return _DEF_EMERGENCY_SLOTS
 
 
 @dataclass(frozen=True)
@@ -121,10 +129,12 @@ class Decision:
 def classify_origin(ssh_connection: str | None) -> str:
     """Classify the SSH client origin from $SSH_CONNECTION.
 
-    Returns tailscale/lan for the OPERATOR-at-console (emergency-eligible),
-    public for a non-private remote, and none for no SSH (dashboard/manual/local
-    "normal method"). Unparseable → public (safe: no emergency, still reattachable
-    and still fail-open in the bash caller).
+    Returns tailscale/lan for the OPERATOR (any interactive SSH login from a
+    private/tailscale IP — a slot hostname OR a plain shell that then runs
+    `claude`), public for a non-private remote, and none when there is no
+    SSH_CONNECTION at all (the dashboard web terminal / local console — the
+    "normal method" held to the plain cap). Unparseable → public (safe: no
+    emergency, still reattachable and still fail-open in the bash caller).
     """
     if not ssh_connection or not ssh_connection.strip():
         return "none"
@@ -133,6 +143,11 @@ def classify_origin(ssh_connection: str | None) -> str:
         ip = ipaddress.ip_address(client)
     except ValueError:
         return "public"
+    # A dual-stack sshd can report an IPv4-mapped v6 client (::ffff:a.b.c.d);
+    # unwrap it so a mapped tailscale/LAN operator is not misread as "public"
+    # (ip.is_private is False on the mapped v6 form, and it misses _TAILSCALE_V4).
+    if getattr(ip, "ipv4_mapped", None) is not None:
+        ip = ip.ipv4_mapped
     if ip in _TAILSCALE_V4:
         return "tailscale"
     # ULA (fc00::/7, incl. tailscale's v6 range) + RFC1918 + loopback → operator.
@@ -165,7 +180,8 @@ def decide(
     # The threshold must cover a FULL per-session footprint (a fresh session
     # grows toward per_session_mb; starting one with less free than that can OOM
     # a swapless box), plus the operator's absolute floor — whichever is larger.
-    ram_ok = mem_available_mb >= max(config.per_session_mb, config.oom_floor_mb)
+    need_mb = max(config.per_session_mb, config.oom_floor_mb)
+    ram_ok = mem_available_mb >= need_mb
 
     if not is_operator:
         # Normal method (dashboard/magic-link/public): held to SAFE_CAP.
@@ -186,7 +202,7 @@ def decide(
                 effective_cap,
                 origin,
                 "oom_floor",
-                f"RAM low ({mem_available_mb}MB free, need >= {config.oom_floor_mb}MB "
+                f"RAM low ({mem_available_mb}MB free, need >= {need_mb}MB "
                 f"to start safely). Reattach an existing session or free memory.",
             )
         return Decision(
@@ -228,7 +244,7 @@ def decide(
             effective_cap,
             origin,
             "oom_floor",
-            f"RAM tight ({mem_available_mb}MB free, need >= {config.oom_floor_mb}MB). "
+            f"RAM tight ({mem_available_mb}MB free, need >= {need_mb}MB). "
             f"Reattach a session, or reclaim one to free memory and start fresh.",
         )
     return Decision(
@@ -270,12 +286,21 @@ def _cpu_count() -> int:
         return os.cpu_count() or 1
 
 
-def effective_memory() -> tuple[int, int]:
-    """(total_mb, available_mb), each capped by the container's cgroup memory
-    limit. procfs can expose HOST values inside a container — a 16GiB container
-    on a 32GiB host would otherwise be sized for 32GiB and trigger a cgroup OOM.
-    Reuses genesis.runtime.cgroup; degrades to procfs-only if cgroup is absent."""
+def effective_memory() -> tuple[int, int, bool]:
+    """(total_mb, available_mb, available_known), each capped by the container's
+    cgroup memory limit. procfs can expose HOST values inside a container — a
+    16GiB container on a 32GiB host would otherwise be sized for 32GiB and trigger
+    a cgroup OOM. Reuses genesis.runtime.cgroup; degrades to procfs-only if cgroup
+    is absent.
+
+    ``available_known`` is False in exactly one case: a FINITE cgroup limit was
+    found but current usage could not be read. procfs MemAvailable is then
+    untrustworthy (it may describe HOST headroom, not the container's), so the
+    caller must substitute a conservative estimate rather than trust it — otherwise
+    a partial cgroup read would let the gate ALLOW a session the container cannot
+    hold. total is still clamped to the limit; only availability is unknown."""
     total_mb, avail_mb = read_meminfo()
+    available_known = True
     try:
         from genesis.runtime import cgroup
 
@@ -291,7 +316,10 @@ def effective_memory() -> tuple[int, int]:
             # cache as used; add it back so this matches MemAvailable's meaning).
             cg_avail = max(0, cg_max - cg_cur + (cg_file or 0))
             avail_mb = min(avail_mb, cg_avail // (1024 * 1024))
-    return total_mb, avail_mb
+        else:
+            # Finite limit but usage unreadable → procfs avail cannot be trusted.
+            available_known = False
+    return total_mb, avail_mb, available_known
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -304,14 +332,25 @@ def main(argv: list[str] | None = None) -> int:
     )
     try:
         args = parser.parse_args(argv)
-        mem_total, mem_available = effective_memory()
+        config = CapConfig.from_env()
+        mem_total, mem_available, available_known = effective_memory()
+        if not available_known:
+            # cgroup limit known but usage unreadable (see effective_memory):
+            # estimate free RAM from the capacity model itself rather than trust
+            # host procfs — free ≈ total − reserve − (running sessions × per).
+            # Conservative (leans toward RECLAIM when loaded), never a hard lockout
+            # at 0 sessions. User decision 2026-08-27.
+            mem_available = max(
+                0,
+                mem_total - config.system_reserve_mb - args.existing * config.per_session_mb,
+            )
         decision = decide(
             mem_total_mb=mem_total,
             mem_available_mb=mem_available,
             existing=args.existing,
             cpu_count=_cpu_count(),
             ssh_connection=os.environ.get("SSH_CONNECTION"),
-            config=CapConfig.from_env(),
+            config=config,
         )
     except Exception:  # noqa: BLE001 — fail-OPEN: any error → cc-slot.sh static fallback
         return 1

--- a/src/genesis/cc/session_cap.py
+++ b/src/genesis/cc/session_cap.py
@@ -162,7 +162,10 @@ def decide(
     effective_cap = safe_cap + emergency
 
     # OOM circuit-breaker: enough live RAM to safely START one more session?
-    ram_ok = mem_available_mb >= config.oom_floor_mb
+    # The threshold must cover a FULL per-session footprint (a fresh session
+    # grows toward per_session_mb; starting one with less free than that can OOM
+    # a swapless box), plus the operator's absolute floor — whichever is larger.
+    ram_ok = mem_available_mb >= max(config.per_session_mb, config.oom_floor_mb)
 
     if not is_operator:
         # Normal method (dashboard/magic-link/public): held to SAFE_CAP.
@@ -256,6 +259,41 @@ def read_meminfo(path: str = "/proc/meminfo") -> tuple[int, int]:
     return total, avail
 
 
+def _cpu_count() -> int:
+    """Process-aware CPU count — respects the cpuset/CPU affinity (like `nproc`),
+    NOT os.cpu_count() which returns HOST cores inside a container and would
+    inflate the clamp. (It does not read a cpu.max bandwidth quota, but memory is
+    the binding constraint here, and this only ever CLAMPS the RAM-derived cap.)"""
+    try:
+        return len(os.sched_getaffinity(0)) or 1
+    except (AttributeError, OSError):
+        return os.cpu_count() or 1
+
+
+def effective_memory() -> tuple[int, int]:
+    """(total_mb, available_mb), each capped by the container's cgroup memory
+    limit. procfs can expose HOST values inside a container — a 16GiB container
+    on a 32GiB host would otherwise be sized for 32GiB and trigger a cgroup OOM.
+    Reuses genesis.runtime.cgroup; degrades to procfs-only if cgroup is absent."""
+    total_mb, avail_mb = read_meminfo()
+    try:
+        from genesis.runtime import cgroup
+
+        cg_max = cgroup.read_container_memory_max()  # bytes, or None if unlimited
+        cg_cur = cgroup.read_container_memory_current() if cg_max else None
+        cg_file = cgroup.read_container_memory_reclaimable() if cg_max else None
+    except Exception:  # noqa: BLE001 — cgroup unreadable → procfs values stand
+        cg_max = cg_cur = cg_file = None
+    if cg_max:
+        total_mb = min(total_mb, cg_max // (1024 * 1024))
+        if cg_cur is not None:
+            # Available = limit − usage + reclaimable page cache (current counts
+            # cache as used; add it back so this matches MemAvailable's meaning).
+            cg_avail = max(0, cg_max - cg_cur + (cg_file or 0))
+            avail_mb = min(avail_mb, cg_avail // (1024 * 1024))
+    return total_mb, avail_mb
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="session_cap")
     parser.add_argument(
@@ -266,12 +304,12 @@ def main(argv: list[str] | None = None) -> int:
     )
     try:
         args = parser.parse_args(argv)
-        mem_total, mem_available = read_meminfo()
+        mem_total, mem_available = effective_memory()
         decision = decide(
             mem_total_mb=mem_total,
             mem_available_mb=mem_available,
             existing=args.existing,
-            cpu_count=os.cpu_count() or 1,
+            cpu_count=_cpu_count(),
             ssh_connection=os.environ.get("SSH_CONNECTION"),
             config=CapConfig.from_env(),
         )

--- a/src/genesis/cc/session_cap.py
+++ b/src/genesis/cc/session_cap.py
@@ -1,0 +1,294 @@
+"""Interactive-slot capacity decision — `python -m genesis.cc.session_cap`.
+
+`scripts/cc-slot.sh` runs this on slot CREATE (never on reattach) to decide
+whether a NEW `cc-N` session may start. It replaces the old free-RAM formula
+(`(MemAvailable - reserve) / per_session`) that *collapsed*: because it sampled
+instantaneous FREE RAM after sessions were already running, each running session
+lowered MemAvailable and thus lowered the cap BELOW the running count (3 running →
+computed cap 2 → the operator locked out of a 4th, sometimes the 3rd).
+
+The model here is CAPACITY, not free-RAM:
+
+- The cap is a function of the box's own TOTAL resources (MemTotal) → stable, does
+  NOT shrink as sessions run, and portable to any install (a bigger box yields a
+  bigger cap with no hardcoded per-install number). Background apps (Kimi/codex,
+  bg daemons) no longer shrink the foreground cap.
+- Live free RAM (MemAvailable) is consulted ONLY as a low OOM circuit-breaker —
+  a floor to refuse a NEW session when the swapless box is genuinely near
+  exhaustion — never as the cap.
+- Origin-aware: a direct LAN/tailscale SSH login (the operator "let me in" path,
+  distinct from the dashboard/magic-link "normal method") gets an emergency slot
+  ABOVE the safe cap and is NEVER hard-denied — when the box is full/tight it is
+  offered an interactive RECLAIM (pick a session to end, or reattach), so the
+  operator always has a path in without the OOM-killer choosing the casualty.
+
+Contract (mirrors `genesis.cc.login_gate`): `main()` reads /proc/meminfo, cpu
+count, `SSH_CONNECTION`, and the `GENESIS_CC_*` config levers, takes the current
+`cc-N` count via `--existing N`, then prints a two-part protocol to STDOUT:
+
+    line 1: ``ALLOW`` | ``RECLAIM`` | ``DENY``   (the action)
+    line 2+: a human-facing explanation (cc-slot.sh echoes it to the operator)
+
+Exit 0 whenever a decision was produced (even DENY). Exit non-zero ONLY on an
+internal error — cc-slot.sh treats that as fail-OPEN (its own MemTotal-based
+static fallback), because the one thing this gate must never do is lock the
+operator out. It is a resource governor, not a security gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import os
+from dataclasses import dataclass
+
+# --- Config levers (documented, tunable via ~/.genesis/cc-slot.env) -----------
+# Explicit, honest defaults measured on the reference 18GB swapless box
+# (2026-08-27): a fully-loaded cc session (claude + serena + memory/health/
+# outreach/recon MCPs + gitnexus + pyright) measured ~2.9GB RSS, so PER_SESSION
+# is sized NEAR that max (conservative — a swapless box OOM-KILLS a resident
+# spike, it cannot page). On this box these yield SAFE_CAP = (18432-4096)//3072
+# = 4 (matching the 3-4 comfortably run); a bigger MemTotal scales the cap up,
+# a smaller one down (clamped to >=1 so a small box is never locked out).
+_DEF_SYSTEM_RESERVE_MB = 4096  # OS + genesis-server + qdrant + bg-spares + swapless margin
+_DEF_PER_SESSION_MB = 3072  # measured loaded-session RSS ceiling, conservative
+_DEF_OOM_FLOOR_MB = 1536  # min free RAM to START a new session (circuit-breaker)
+_DEF_EMERGENCY_SLOTS = 1  # extra slots an operator-origin login may claim above SAFE_CAP
+
+# Tailscale's v4 space is RFC 6598 CGNAT (100.64/10) — checked explicitly so
+# classification does not depend on `is_private`'s version-dependent treatment of
+# 100.64/10. Tailscale's v6 space is a ULA (fc00::/7), which `ip.is_private`
+# ALREADY classifies as operator ("lan") — so no explicit v6 tailnet range is
+# needed (and hardcoding one would embed an install-adjacent literal).
+_TAILSCALE_V4 = ipaddress.ip_network("100.64.0.0/10")
+
+_ACTIONS = ("ALLOW", "RECLAIM", "DENY")
+
+
+@dataclass(frozen=True)
+class CapConfig:
+    system_reserve_mb: int = _DEF_SYSTEM_RESERVE_MB
+    per_session_mb: int = _DEF_PER_SESSION_MB
+    oom_floor_mb: int = _DEF_OOM_FLOOR_MB
+    emergency_slots: int = _DEF_EMERGENCY_SLOTS
+
+    @classmethod
+    def from_env(cls, environ: dict | None = None) -> CapConfig:
+        env = os.environ if environ is None else environ
+
+        def _int(name: str, default: int) -> int:
+            raw = env.get(name)
+            if raw is None or str(raw).strip() == "":
+                return default
+            try:
+                val = int(str(raw).strip())
+            except ValueError:
+                return default
+            # Guard against a nonsensical override that would break the model
+            # (e.g. per_session 0 → division error). Fall back to the default.
+            return val if val > 0 else default
+
+        return cls(
+            system_reserve_mb=_int("GENESIS_CC_SYSTEM_RESERVE_MB", _DEF_SYSTEM_RESERVE_MB),
+            per_session_mb=_int("GENESIS_CC_PER_SESSION_MB", _DEF_PER_SESSION_MB),
+            oom_floor_mb=_int("GENESIS_CC_OOM_FLOOR_MB", _DEF_OOM_FLOOR_MB),
+            # emergency_slots may legitimately be 0 (disable the emergency lever),
+            # so it uses a >=0 guard rather than the >0 guard above.
+            emergency_slots=max(0, _emergency_from_env(env)),
+        )
+
+
+def _emergency_from_env(env: dict) -> int:
+    raw = env.get("GENESIS_CC_EMERGENCY_SLOTS")
+    if raw is None or str(raw).strip() == "":
+        return _DEF_EMERGENCY_SLOTS
+    try:
+        return int(str(raw).strip())
+    except ValueError:
+        return _DEF_EMERGENCY_SLOTS
+
+
+@dataclass(frozen=True)
+class Decision:
+    action: str  # ALLOW | RECLAIM | DENY
+    safe_cap: int  # the resource-derived normal limit
+    effective_cap: int  # safe_cap (+ emergency for operator origin)
+    origin: str  # tailscale | lan | public | none
+    reason: str  # machine tag: ok | emergency_slot | cap_reached | cap_full | oom_floor
+    message: str  # human-facing explanation
+
+
+def classify_origin(ssh_connection: str | None) -> str:
+    """Classify the SSH client origin from $SSH_CONNECTION.
+
+    Returns tailscale/lan for the OPERATOR-at-console (emergency-eligible),
+    public for a non-private remote, and none for no SSH (dashboard/manual/local
+    "normal method"). Unparseable → public (safe: no emergency, still reattachable
+    and still fail-open in the bash caller).
+    """
+    if not ssh_connection or not ssh_connection.strip():
+        return "none"
+    client = ssh_connection.split()[0]
+    try:
+        ip = ipaddress.ip_address(client)
+    except ValueError:
+        return "public"
+    if ip in _TAILSCALE_V4:
+        return "tailscale"
+    # ULA (fc00::/7, incl. tailscale's v6 range) + RFC1918 + loopback → operator.
+    if ip.is_loopback or ip.is_private:
+        return "lan"
+    return "public"
+
+
+def decide(
+    *,
+    mem_total_mb: int,
+    mem_available_mb: int,
+    existing: int,
+    cpu_count: int,
+    ssh_connection: str | None,
+    config: CapConfig,
+) -> Decision:
+    """Pure decision: may a NEW cc-N session start? (reattach is handled upstream)."""
+    origin = classify_origin(ssh_connection)
+    is_operator = origin in ("lan", "tailscale")
+
+    # SAFE_CAP from TOTAL memory — stable, does NOT collapse as sessions run.
+    raw = (mem_total_mb - config.system_reserve_mb) // config.per_session_mb
+    cpu = cpu_count if cpu_count and cpu_count > 0 else 1
+    safe_cap = max(1, min(raw, cpu))
+    emergency = config.emergency_slots if is_operator else 0
+    effective_cap = safe_cap + emergency
+
+    # OOM circuit-breaker: enough live RAM to safely START one more session?
+    ram_ok = mem_available_mb >= config.oom_floor_mb
+
+    if not is_operator:
+        # Normal method (dashboard/magic-link/public): held to SAFE_CAP.
+        if existing >= safe_cap:
+            return Decision(
+                "DENY",
+                safe_cap,
+                effective_cap,
+                origin,
+                "cap_reached",
+                f"Session cap reached ({existing}/{safe_cap}). Reattach an existing "
+                f"session, or SSH in over LAN/tailscale for an emergency slot.",
+            )
+        if not ram_ok:
+            return Decision(
+                "DENY",
+                safe_cap,
+                effective_cap,
+                origin,
+                "oom_floor",
+                f"RAM low ({mem_available_mb}MB free, need >= {config.oom_floor_mb}MB "
+                f"to start safely). Reattach an existing session or free memory.",
+            )
+        return Decision(
+            "ALLOW",
+            safe_cap,
+            effective_cap,
+            origin,
+            "ok",
+            f"Slot available ({existing + 1}/{safe_cap}).",
+        )
+
+    # Operator origin (LAN/tailscale): NEVER hard-denied.
+    if existing < effective_cap and ram_ok:
+        if existing >= safe_cap:
+            return Decision(
+                "ALLOW",
+                safe_cap,
+                effective_cap,
+                origin,
+                "emergency_slot",
+                f"Emergency slot granted (operator origin: {origin}) — "
+                f"{existing + 1}/{safe_cap}+{emergency}.",
+            )
+        return Decision(
+            "ALLOW",
+            safe_cap,
+            effective_cap,
+            origin,
+            "ok",
+            f"Slot available ({existing + 1}/{safe_cap}).",
+        )
+
+    # Full (past the emergency slot) OR RAM genuinely tight → offer RECLAIM,
+    # never a hard "no". cc-slot.sh runs the interactive pick-a-session-to-end UI.
+    if not ram_ok:
+        return Decision(
+            "RECLAIM",
+            safe_cap,
+            effective_cap,
+            origin,
+            "oom_floor",
+            f"RAM tight ({mem_available_mb}MB free, need >= {config.oom_floor_mb}MB). "
+            f"Reattach a session, or reclaim one to free memory and start fresh.",
+        )
+    return Decision(
+        "RECLAIM",
+        safe_cap,
+        effective_cap,
+        origin,
+        "cap_full",
+        f"At the emergency limit ({existing}/{safe_cap}+{emergency}). "
+        f"Reattach a session, or reclaim one to start fresh.",
+    )
+
+
+def read_meminfo(path: str = "/proc/meminfo") -> tuple[int, int]:
+    """Return (MemTotal, MemAvailable) in MB. Raises on unreadable/absent fields
+    so main() can fail-OPEN (cc-slot.sh falls back to its bash static cap)."""
+    total = avail = None
+    with open(path, encoding="ascii") as fh:
+        for line in fh:
+            if line.startswith("MemTotal:"):
+                total = int(line.split()[1]) // 1024
+            elif line.startswith("MemAvailable:"):
+                avail = int(line.split()[1]) // 1024
+            if total is not None and avail is not None:
+                break
+    if total is None or avail is None:
+        raise ValueError("MemTotal/MemAvailable not found in meminfo")
+    return total, avail
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="session_cap")
+    parser.add_argument(
+        "--existing",
+        type=int,
+        required=True,
+        help="Current count of live cc-N tmux sessions (from cc-slot.sh).",
+    )
+    try:
+        args = parser.parse_args(argv)
+        mem_total, mem_available = read_meminfo()
+        decision = decide(
+            mem_total_mb=mem_total,
+            mem_available_mb=mem_available,
+            existing=args.existing,
+            cpu_count=os.cpu_count() or 1,
+            ssh_connection=os.environ.get("SSH_CONNECTION"),
+            config=CapConfig.from_env(),
+        )
+    except Exception:  # noqa: BLE001 — fail-OPEN: any error → cc-slot.sh static fallback
+        return 1
+
+    # STDOUT protocol (cc-slot.sh parses by line):
+    #   line 1: action  (ALLOW | RECLAIM | DENY)
+    #   line 2: human-facing message (echoed to the operator)
+    #   line 3: machine reason tag (ok|emergency_slot|cap_reached|cap_full|oom_floor)
+    #           — lets the shell distinguish "trade a slot" (cap_full) from
+    #           "genuine RAM exhaustion, nothing to trade" (oom_floor) on RECLAIM.
+    print(decision.action)
+    print(decision.message)
+    print(decision.reason)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/genesis/runtime/cgroup.py
+++ b/src/genesis/runtime/cgroup.py
@@ -51,15 +51,80 @@ def detect_root_device() -> str | None:
         return None
 
 
-def read_container_memory_max() -> int | None:
-    """Read the container's memory.max from the root cgroup."""
+# cgroup v1 "unlimited" sentinel (PAGE_COUNTER_MAX, page-aligned). memory.
+# limit_in_bytes reports a value at/above this when no limit is set.
+_CGROUP_V1_UNLIMITED = 0x7FFFFFFFFFFFF000
+
+
+def _read_text(path: str) -> str | None:
+    """Read a cgroup file (seam so the v1/v2 fallbacks are unit-testable)."""
     try:
-        raw = Path("/sys/fs/cgroup/memory.max").read_text().strip()
+        return Path(path).read_text().strip()
+    except OSError:
+        return None
+
+
+def _read_int(path: str) -> int | None:
+    raw = _read_text(path)
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+def _read_stat(path: str) -> dict[str, int]:
+    raw = _read_text(path)
+    stats: dict[str, int] = {}
+    if raw:
+        for line in raw.splitlines():
+            parts = line.split()
+            if len(parts) == 2 and parts[1].lstrip("-").isdigit():
+                stats[parts[0]] = int(parts[1])
+    return stats
+
+
+def read_container_memory_max() -> int | None:
+    """Container memory limit in bytes (cgroup v2, then v1). None = unlimited/unknown."""
+    raw = _read_text("/sys/fs/cgroup/memory.max")  # v2 unified
+    if raw is not None:
         if raw == "max":
             return None
-        return int(raw)
-    except (OSError, ValueError):
-        return None
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+    v1 = _read_int("/sys/fs/cgroup/memory/memory.limit_in_bytes")  # v1 fallback
+    if v1 is not None and 0 < v1 < _CGROUP_V1_UNLIMITED:
+        return v1
+    return None
+
+
+def read_container_memory_current() -> int | None:
+    """Container current memory usage (bytes) — cgroup v2, then v1."""
+    cur = _read_int("/sys/fs/cgroup/memory.current")  # v2
+    if cur is not None:
+        return cur
+    return _read_int("/sys/fs/cgroup/memory/memory.usage_in_bytes")  # v1
+
+
+def read_container_memory_reclaimable() -> int | None:
+    """Reclaimable page cache (bytes) from cgroup memory.stat — v2 then v1.
+
+    memory.current counts page cache as "used", so max-current UNDER-states
+    available. Adding back the reclaimable file cache mirrors what /proc
+    MemAvailable means (usable without swapping). `file` slightly over-states
+    strictly-reclaimable memory (it includes dirty/mlocked file pages), but the
+    caller clamps the result with `min(procfs_MemAvailable, …)`, so it can only
+    make the estimate MORE conservative, never dangerously optimistic."""
+    v2 = _read_stat("/sys/fs/cgroup/memory.stat")  # v2: `file` = total page cache
+    if "file" in v2:
+        return v2["file"]
+    v1 = _read_stat("/sys/fs/cgroup/memory/memory.stat")  # v1: active+inactive file
+    if "total_inactive_file" in v1 or "total_active_file" in v1:
+        return v1.get("total_inactive_file", 0) + v1.get("total_active_file", 0)
+    return None
 
 
 def cgroup_status() -> dict:

--- a/src/genesis/runtime/cgroup.py
+++ b/src/genesis/runtime/cgroup.py
@@ -110,17 +110,23 @@ def read_container_memory_current() -> int | None:
 
 
 def read_container_memory_reclaimable() -> int | None:
-    """Reclaimable page cache (bytes) from cgroup memory.stat — v2 then v1.
+    """Reclaimable file-backed page cache (bytes) from cgroup memory.stat — v2 then v1.
 
     memory.current counts page cache as "used", so max-current UNDER-states
     available. Adding back the reclaimable file cache mirrors what /proc
-    MemAvailable means (usable without swapping). `file` slightly over-states
-    strictly-reclaimable memory (it includes dirty/mlocked file pages), but the
-    caller clamps the result with `min(procfs_MemAvailable, …)`, so it can only
-    make the estimate MORE conservative, never dangerously optimistic."""
-    v2 = _read_stat("/sys/fs/cgroup/memory.stat")  # v2: `file` = total page cache
-    if "file" in v2:
-        return v2["file"]
+    MemAvailable means (usable without swapping). We sum the file LRU lists
+    (`inactive_file` + `active_file`) rather than the type-based `file` counter:
+    on cgroup v2, `file` also includes tmpfs/shmem pages, which sit on the ANON
+    LRU and are NOT reclaimable for a new anonymous allocation — counting them
+    would over-state available and could let the gate ALLOW a session the
+    container cannot actually hold (kernel cgroup-v2 memory.stat semantics:
+    inactive_file + active_file == page cache minus tmpfs). The file LRU still
+    contains dirty pages (writeback-then-reclaim, not instant), but the caller
+    additionally clamps with `min(procfs_MemAvailable, …)`, so the estimate stays
+    conservative. v1's `total_*_file` counters are already list-based."""
+    v2 = _read_stat("/sys/fs/cgroup/memory.stat")  # v2: file LRU lists (exclude shmem)
+    if "inactive_file" in v2 or "active_file" in v2:
+        return v2.get("inactive_file", 0) + v2.get("active_file", 0)
     v1 = _read_stat("/sys/fs/cgroup/memory/memory.stat")  # v1: active+inactive file
     if "total_inactive_file" in v1 or "total_active_file" in v1:
         return v1.get("total_inactive_file", 0) + v1.get("total_active_file", 0)

--- a/tests/test_cc/test_session_cap.py
+++ b/tests/test_cc/test_session_cap.py
@@ -174,3 +174,88 @@ def test_config_from_env_reads_overrides():
         1000,
         2,
     )
+
+
+# ── OOM floor must cover a full per-session footprint (Codex P1) ──────────────
+def test_operator_below_one_full_session_reclaims_not_allows():
+    # avail (2000) is above the old 1536 floor but BELOW one session (3072) → a
+    # started session could grow past all free RAM → RECLAIM, never ALLOW.
+    d = _d(1, TS, avail=2000)
+    assert d.action == "RECLAIM"
+    assert d.reason == "oom_floor"
+
+
+def test_normal_below_one_full_session_denies():
+    d = _d(1, None, avail=2000)
+    assert d.action == "DENY"
+    assert d.reason == "oom_floor"
+
+
+def test_allow_needs_room_for_a_full_session():
+    # Exactly one session's worth free (3072) → ALLOW; one MB less → not ram_ok.
+    assert _d(1, TS, avail=3072).action == "ALLOW"
+    assert _d(1, TS, avail=3071).action == "RECLAIM"
+
+
+# ── Container/cgroup-aware memory (Codex P1: procfs may show HOST values) ─────
+def test_effective_memory_caps_by_cgroup(monkeypatch):
+    import genesis.cc.session_cap as m
+    from genesis.runtime import cgroup
+
+    monkeypatch.setattr(m, "read_meminfo", lambda *a, **k: (32768, 30000))  # host-inflated
+    monkeypatch.setattr(cgroup, "read_container_memory_max", lambda: 16 * 1024**3)  # 16 GiB
+    monkeypatch.setattr(
+        cgroup, "read_container_memory_current", lambda: 10 * 1024**3
+    )  # 10 GiB used
+    monkeypatch.setattr(
+        cgroup, "read_container_memory_reclaimable", lambda: 2 * 1024**3
+    )  # 2 GiB cache
+    total, avail = m.effective_memory()
+    assert total == 16384  # capped to the cgroup limit, not host 32768
+    # available = limit(16) - usage(10) + reclaimable cache(2) = 8 GiB, not host 30000
+    assert avail == 8 * 1024
+
+
+def test_effective_memory_procfs_only_when_no_cgroup(monkeypatch):
+    import genesis.cc.session_cap as m
+    from genesis.runtime import cgroup
+
+    monkeypatch.setattr(m, "read_meminfo", lambda *a, **k: (8192, 4000))
+    monkeypatch.setattr(cgroup, "read_container_memory_max", lambda: None)  # unlimited/unreadable
+    assert m.effective_memory() == (8192, 4000)
+
+
+# ── cgroup v1 fallback (older hosts lack the v2 unified paths) ────────────────
+def test_cgroup_v1_memory_max_fallback(monkeypatch):
+    from genesis.runtime import cgroup
+
+    # v2 memory.max absent → read v1 memory.limit_in_bytes.
+    monkeypatch.setattr(
+        cgroup,
+        "_read_text",
+        lambda p: "16000000000" if p.endswith("memory/memory.limit_in_bytes") else None,
+    )
+    assert cgroup.read_container_memory_max() == 16000000000
+
+
+def test_cgroup_v1_unlimited_sentinel_is_none(monkeypatch):
+    from genesis.runtime import cgroup
+
+    monkeypatch.setattr(
+        cgroup,
+        "_read_text",
+        lambda p: "9223372036854771712" if "limit_in_bytes" in p else None,
+    )
+    assert cgroup.read_container_memory_max() is None  # sentinel → unlimited
+
+
+def test_cgroup_v1_reclaimable_fallback(monkeypatch):
+    from genesis.runtime import cgroup
+
+    def fake(path):
+        if path.endswith("memory/memory.stat"):  # v1 stat
+            return "total_inactive_file 1000\ntotal_active_file 500\nrss 200"
+        return None  # no v2 stat
+
+    monkeypatch.setattr(cgroup, "_read_text", fake)
+    assert cgroup.read_container_memory_reclaimable() == 1500

--- a/tests/test_cc/test_session_cap.py
+++ b/tests/test_cc/test_session_cap.py
@@ -1,0 +1,176 @@
+"""Unit tests for the capacity-based cc session cap (genesis.cc.session_cap).
+
+The load-bearing test is `test_collapse_case_now_allows` — the exact live scenario
+that locked the operator out (3 running, 6566MB free → old formula computed cap 2).
+Under the capacity model it must ALLOW.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.cc.session_cap import CapConfig, Decision, classify_origin, decide
+
+# Reference box: 18GB, 6 cores. Defaults → SAFE_CAP = (18432-4096)//3072 = 4.
+CFG = CapConfig()
+TS = "100.100.100.100 56002 100.100.0.1 22"  # tailscale operator
+LAN = "192.0.2.10 51000 192.0.2.1 22"  # LAN operator (RFC 5737 TEST-NET, synthetic)
+PUB = "8.8.8.8 40000 203.0.113.1 22"  # public remote
+
+
+def _d(existing, ssh, *, total=18432, avail=6566, cpu=6, cfg=CFG) -> Decision:
+    return decide(
+        mem_total_mb=total,
+        mem_available_mb=avail,
+        existing=existing,
+        cpu_count=cpu,
+        ssh_connection=ssh,
+        config=cfg,
+    )
+
+
+# ── SAFE_CAP shape ────────────────────────────────────────────────────────────
+def test_safe_cap_is_four_on_reference_box():
+    assert _d(0, TS).safe_cap == 4
+
+
+def test_safe_cap_scales_up_on_a_bigger_box():
+    # 32GB, 16 cores → (32768-4096)//3072 = 9 (cpu clamp does not bind at 16).
+    assert _d(0, TS, total=32768, cpu=16).safe_cap == 9
+
+
+def test_safe_cap_clamped_by_cpu_count():
+    # RAM would allow 9 but only 6 cores → clamp to 6 (thrash guard).
+    assert _d(0, TS, total=32768, cpu=6).safe_cap == 6
+
+
+def test_tiny_box_never_locks_out_floor_of_one():
+    # 4GB: (4096-4096)//3072 = 0 → floored to 1.
+    assert _d(0, TS, total=4096, avail=3000).safe_cap == 1
+
+
+# ── THE BUG: collapse case must now ALLOW ─────────────────────────────────────
+def test_collapse_case_now_allows():
+    # 3 running, 6566MB free, tailscale operator — the exact lockout scenario.
+    d = _d(3, TS)
+    assert d.action == "ALLOW"
+    assert d.safe_cap == 4
+
+
+def test_safe_cap_is_stable_as_free_ram_drops():
+    # Free RAM varying from 6566 down to 2000 does NOT change SAFE_CAP (no collapse).
+    caps = {_d(3, TS, avail=a).safe_cap for a in (6566, 5000, 3000, 2000)}
+    assert caps == {4}
+
+
+# ── Emergency slot (operator origin, +1 above SAFE_CAP) ───────────────────────
+def test_operator_gets_emergency_slot_at_cap():
+    d = _d(4, TS)  # existing == safe_cap → the +1 emergency slot
+    assert d.action == "ALLOW"
+    assert d.reason == "emergency_slot"
+    assert d.effective_cap == 5
+
+
+@pytest.mark.parametrize("ssh", [TS, LAN])
+def test_both_lan_and_tailscale_are_operator(ssh):
+    assert _d(4, ssh).action == "ALLOW"
+
+
+# ── Normal method (dashboard/public) is held to SAFE_CAP ──────────────────────
+def test_normal_origin_denied_over_cap():
+    assert _d(4, None).action == "DENY"  # dashboard/manual (no SSH_CONNECTION)
+
+
+def test_public_ssh_is_not_operator():
+    assert _d(4, PUB).action == "DENY"
+
+
+def test_normal_origin_allowed_under_cap():
+    assert _d(2, None).action == "ALLOW"
+
+
+def test_normal_origin_denied_when_ram_tight_under_cap():
+    d = _d(2, None, avail=800)  # under cap but below OOM floor
+    assert d.action == "DENY"
+    assert d.reason == "oom_floor"
+
+
+# ── Operator is NEVER hard-denied → RECLAIM instead ───────────────────────────
+def test_operator_over_emergency_cap_reclaims_not_denies():
+    d = _d(5, TS)  # past safe_cap(4) + emergency(1)
+    assert d.action == "RECLAIM"
+    assert d.reason == "cap_full"
+
+
+def test_operator_ram_tight_reclaims_not_denies():
+    d = _d(2, TS, avail=800)  # under cap but RAM below floor
+    assert d.action == "RECLAIM"
+    assert d.reason == "oom_floor"
+
+
+def test_operator_never_returns_deny_across_the_grid():
+    # Exhaustive: no (existing, avail) combination yields DENY for an operator.
+    actions = {_d(e, TS, avail=a).action for e in range(0, 8) for a in (400, 800, 1536, 3000, 6566)}
+    assert "DENY" not in actions
+
+
+# ── Emergency lever can be disabled via config ────────────────────────────────
+def test_emergency_slots_zero_still_reclaims_never_denies_operator():
+    cfg = CapConfig(emergency_slots=0)
+    d = _d(4, TS, cfg=cfg)  # at cap, no emergency slot → reclaim (still not deny)
+    assert d.action == "RECLAIM"
+    assert d.effective_cap == 4
+
+
+# ── Origin classification ─────────────────────────────────────────────────────
+@pytest.mark.parametrize(
+    "client,expected",
+    [
+        ("100.100.100.100", "tailscale"),  # CGNAT
+        ("100.64.0.1", "tailscale"),  # CGNAT low boundary
+        ("100.127.255.254", "tailscale"),  # CGNAT high boundary
+        ("100.63.0.1", "public"),  # just below CGNAT
+        ("100.128.0.1", "public"),  # just above CGNAT
+        ("198.51.100.5", "lan"),  # RFC 5737 TEST-NET-2 → is_private
+        ("10.0.0.5", "lan"),  # RFC1918 10/8
+        ("172.16.0.5", "lan"),  # RFC1918 172.16/12
+        ("127.0.0.1", "lan"),  # loopback = local operator
+        ("8.8.8.8", "public"),
+        # Tailscale's v6 is a ULA (fc00::/7) → classified operator via is_private
+        # ("lan"), no explicit tailnet range hardcoded. A generic ULA proves it:
+        ("fd00:1:2:3::1", "lan"),  # ULA (fc00::/7) → operator
+        ("garbage", "public"),  # unparseable → non-operator (safe)
+    ],
+)
+def test_classify_origin(client, expected):
+    ssh = f"{client} 51000 100.100.0.1 22"
+    assert classify_origin(ssh) == expected
+
+
+def test_classify_origin_none_when_no_ssh():
+    assert classify_origin(None) == "none"
+    assert classify_origin("") == "none"
+    assert classify_origin("   ") == "none"
+
+
+# ── Config env parsing (guards against nonsensical overrides) ─────────────────
+def test_config_from_env_guards_zero_per_session():
+    cfg = CapConfig.from_env({"GENESIS_CC_PER_SESSION_MB": "0"})
+    assert cfg.per_session_mb == 3072  # zero rejected → default (no ZeroDivision)
+
+
+def test_config_from_env_reads_overrides():
+    cfg = CapConfig.from_env(
+        {
+            "GENESIS_CC_SYSTEM_RESERVE_MB": "6000",
+            "GENESIS_CC_PER_SESSION_MB": "2000",
+            "GENESIS_CC_OOM_FLOOR_MB": "1000",
+            "GENESIS_CC_EMERGENCY_SLOTS": "2",
+        }
+    )
+    assert (cfg.system_reserve_mb, cfg.per_session_mb, cfg.oom_floor_mb, cfg.emergency_slots) == (
+        6000,
+        2000,
+        1000,
+        2,
+    )

--- a/tests/test_cc/test_session_cap.py
+++ b/tests/test_cc/test_session_cap.py
@@ -153,10 +153,59 @@ def test_classify_origin_none_when_no_ssh():
     assert classify_origin("   ") == "none"
 
 
+@pytest.mark.parametrize(
+    "client,expected",
+    [
+        ("::ffff:100.100.100.100", "tailscale"),  # IPv4-mapped CGNAT → operator
+        ("::ffff:192.0.2.10", "lan"),  # IPv4-mapped RFC5737 (is_private) → operator
+        ("::ffff:8.8.8.8", "public"),  # IPv4-mapped public → non-operator
+    ],
+)
+def test_classify_origin_unwraps_ipv4_mapped(client, expected):
+    # A dual-stack sshd can report ::ffff:a.b.c.d; without unwrapping, is_private
+    # is False on the mapped v6 form and a tailscale/LAN operator is misread public.
+    assert classify_origin(f"{client} 51000 100.100.0.1 22") == expected
+
+
 # ── Config env parsing (guards against nonsensical overrides) ─────────────────
 def test_config_from_env_guards_zero_per_session():
     cfg = CapConfig.from_env({"GENESIS_CC_PER_SESSION_MB": "0"})
     assert cfg.per_session_mb == 3072  # zero rejected → default (no ZeroDivision)
+
+
+# Reserve's default (4096) differs from every override below, so a reject is
+# unambiguous (no false pass from a default that happens to equal the input).
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("6000", 6000),  # plain digits → accepted
+        (" 6000 ", 6000),  # surrounding whitespace stripped → accepted
+        ("+6000", 4096),  # sign rejected → default
+        ("6000mb", 4096),  # unit suffix rejected → default
+        ("6_000", 4096),  # python int() underscore rejected → default
+        ("06000", 4096),  # leading zero (bash octal hazard) rejected → default
+        ("0x10", 4096),  # hex rejected → default
+        ("-5", 4096),  # negative rejected → default
+        ("99999999", 4096),  # 8 digits (bash-overflow guard, >7) rejected → default
+    ],
+)
+def test_config_from_env_matches_bash_grammar(raw, expected):
+    # F8: python accepts ONLY the bash fallback's grammar so the same cc-slot.env
+    # yields the same cap on the primary and the degraded static path.
+    assert CapConfig.from_env({"GENESIS_CC_SYSTEM_RESERVE_MB": raw}).system_reserve_mb == expected
+
+
+def test_config_from_env_emergency_grammar():
+    # 0 explicitly disables; malformed/oversized → default (1), matching bash.
+    assert CapConfig.from_env({"GENESIS_CC_EMERGENCY_SLOTS": "0"}).emergency_slots == 0
+    assert CapConfig.from_env({"GENESIS_CC_EMERGENCY_SLOTS": "2"}).emergency_slots == 2
+    assert CapConfig.from_env({"GENESIS_CC_EMERGENCY_SLOTS": "-1"}).emergency_slots == 1  # default
+    assert (
+        CapConfig.from_env({"GENESIS_CC_EMERGENCY_SLOTS": "100"}).emergency_slots == 1
+    )  # >99 → default
+    assert (
+        CapConfig.from_env({"GENESIS_CC_EMERGENCY_SLOTS": "07"}).emergency_slots == 1
+    )  # leading zero → default
 
 
 def test_config_from_env_reads_overrides():
@@ -191,6 +240,18 @@ def test_normal_below_one_full_session_denies():
     assert d.reason == "oom_floor"
 
 
+def test_oom_message_reports_the_real_threshold_not_just_floor():
+    # F6: with defaults the effective threshold is max(per=3072, floor=1536)=3072;
+    # the message must print 3072, not the bare oom_floor (1536) — 2000MB free is
+    # denied precisely because it's under 3072, so the number the operator reads
+    # has to match the gate that fired.
+    d_norm = _d(1, None, avail=2000)  # normal → DENY
+    d_op = _d(1, TS, avail=2000)  # operator → RECLAIM
+    assert "need >= 3072MB" in d_norm.message
+    assert "need >= 3072MB" in d_op.message
+    assert "1536" not in d_norm.message and "1536" not in d_op.message
+
+
 def test_allow_needs_room_for_a_full_session():
     # Exactly one session's worth free (3072) → ALLOW; one MB less → not ram_ok.
     assert _d(1, TS, avail=3072).action == "ALLOW"
@@ -210,10 +271,11 @@ def test_effective_memory_caps_by_cgroup(monkeypatch):
     monkeypatch.setattr(
         cgroup, "read_container_memory_reclaimable", lambda: 2 * 1024**3
     )  # 2 GiB cache
-    total, avail = m.effective_memory()
+    total, avail, known = m.effective_memory()
     assert total == 16384  # capped to the cgroup limit, not host 32768
     # available = limit(16) - usage(10) + reclaimable cache(2) = 8 GiB, not host 30000
     assert avail == 8 * 1024
+    assert known is True
 
 
 def test_effective_memory_procfs_only_when_no_cgroup(monkeypatch):
@@ -222,7 +284,56 @@ def test_effective_memory_procfs_only_when_no_cgroup(monkeypatch):
 
     monkeypatch.setattr(m, "read_meminfo", lambda *a, **k: (8192, 4000))
     monkeypatch.setattr(cgroup, "read_container_memory_max", lambda: None)  # unlimited/unreadable
-    assert m.effective_memory() == (8192, 4000)
+    assert m.effective_memory() == (8192, 4000, True)
+
+
+def test_effective_memory_unknown_when_usage_unreadable(monkeypatch):
+    # Codex P2: a FINITE cgroup limit but unreadable memory.current must NOT leave
+    # host procfs MemAvailable standing (it may describe host headroom → over-allow).
+    # total is still clamped to the limit; availability is flagged unknown so main()
+    # substitutes the conservative model estimate.
+    import genesis.cc.session_cap as m
+    from genesis.runtime import cgroup
+
+    monkeypatch.setattr(m, "read_meminfo", lambda *a, **k: (32768, 30000))  # host-inflated
+    monkeypatch.setattr(cgroup, "read_container_memory_max", lambda: 16 * 1024**3)
+    monkeypatch.setattr(cgroup, "read_container_memory_current", lambda: None)  # unreadable
+    monkeypatch.setattr(cgroup, "read_container_memory_reclaimable", lambda: None)
+    total, avail, known = m.effective_memory()
+    assert total == 16384  # limit still applied
+    assert avail == 30000  # raw value passes through …
+    assert known is False  # … but flagged untrustworthy (main() will not use it)
+
+
+def test_main_degrades_available_to_model_estimate_when_usage_unknown(monkeypatch, capsys):
+    # End-to-end: usage-unknown → main() computes free from the capacity model
+    # (total − reserve − existing×per), not host procfs, and the gate acts on THAT.
+    # 16384 − 4096 − 3×3072 = 3072 → exactly one session's room → operator ALLOW.
+    import genesis.cc.session_cap as m
+
+    monkeypatch.setattr(m, "effective_memory", lambda: (16384, 30000, False))
+    monkeypatch.setattr(m, "_cpu_count", lambda: 6)
+    monkeypatch.setenv("SSH_CONNECTION", TS)
+    rc = m.main(["--existing", "3"])
+    assert rc == 0
+    assert capsys.readouterr().out.splitlines()[0] == "ALLOW"
+
+
+def test_effective_memory_v2_reclaimable_excludes_shmem(monkeypatch):
+    # F5: v2 reclaimable = inactive_file + active_file (file LRU), NOT the `file`
+    # type-counter (which also counts tmpfs/shmem on the anon LRU → over-states).
+    from genesis.runtime import cgroup
+
+    monkeypatch.setattr(
+        cgroup,
+        "_read_text",
+        lambda p: (
+            "file 5000\ninactive_file 2000\nactive_file 1800\nshmem 1200"
+            if p == "/sys/fs/cgroup/memory.stat"
+            else None
+        ),
+    )
+    assert cgroup.read_container_memory_reclaimable() == 3800  # 2000+1800, not 5000
 
 
 # ── cgroup v1 fallback (older hosts lack the v2 unified paths) ────────────────

--- a/tests/test_scripts/test_cc_slot_cap.py
+++ b/tests/test_scripts/test_cc_slot_cap.py
@@ -1,0 +1,299 @@
+"""End-to-end guards for the cc-slot.sh capacity gate (session-cap redesign).
+
+Static asserts that the gate is wired the safe way (delegates to
+genesis.cc.session_cap, old collapsing free-RAM formula gone, reattach bypass +
+_SESSION_EXISTS preserved, fail-open present, levers sourced before the gate),
+PLUS a hermetic dynamic harness that runs the ACTUAL cc-slot.sh against fake
+`tmux`/`python` — including a pty-driven pass over the interactive reclaim choice
+(valid pick kills the right session and spawns; a leading-zero/octal input is
+rejected, not silently spawned past the cap). No real sessions are created.
+"""
+
+from __future__ import annotations
+
+import os
+import select
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_CC_SLOT = _REPO / "scripts" / "cc-slot.sh"
+
+
+# ── Static wiring guards ──────────────────────────────────────────────────────
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return _CC_SLOT.read_text()
+
+
+def test_delegates_to_session_cap(script_text):
+    assert "-m genesis.cc.session_cap --existing" in script_text
+
+
+def test_old_collapsing_formula_is_gone(script_text):
+    assert "ram_cap" not in script_text
+    assert "PER_SESSION_MB=900" not in script_text
+    assert "(avail_mb - RESERVED_MB)" not in script_text
+
+
+def test_reattach_bypass_and_session_exists_preserved(script_text):
+    assert 'tmux has-session -t "=$SESSION_NAME"' in script_text
+    assert "_SESSION_EXISTS=1" in script_text
+
+
+def test_fail_open_and_reclaim_present(script_text):
+    assert "_cap_fail_open" in script_text
+    assert "_cap_reclaim" in script_text
+    assert "timeout 15" in script_text
+
+
+def test_levers_sourced_and_exported_before_the_gate(script_text):
+    # cc-slot.env must be sourced (and the cap levers exported) BEFORE the Python
+    # gate call, or the documented tunables never take effect / never reach the
+    # subprocess. Assert the source precedes the session_cap invocation.
+    src_i = script_text.index('. "${HOME}/.genesis/cc-slot.env"')
+    gate_i = script_text.index("-m genesis.cc.session_cap --existing")
+    assert src_i < gate_i
+    assert 'export "$_lever"' in script_text
+
+
+# ── Hermetic end-to-end harness ───────────────────────────────────────────────
+def _write(path: Path, text: str) -> None:
+    path.write_text(text)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _setup(tmp_path, *, action, exists, session_names, rc):
+    """Build a fake HOME + fake tmux + fake venv python. Returns (env, spawn_marker, kill_file).
+
+    The fake tmux is FORMAT-AWARE: a names-only `-F` (the `existing` count) prints
+    bare names; a pipe `-F` (the reclaim list) prints `name|0|t0`. session_names is
+    a list of live cc-N names.
+    """
+    home = tmp_path / "home"
+    fakebin = tmp_path / "fakebin"
+    venvbin = home / "genesis" / ".venv" / "bin"
+    for d in (fakebin, venvbin, home / "genesis" / "scripts"):
+        d.mkdir(parents=True, exist_ok=True)
+    spawn_marker = tmp_path / "spawned"
+    kill_file = tmp_path / "killed"
+    names = "".join(f"{n}\n" for n in session_names)
+
+    _write(
+        fakebin / "tmux",
+        f"""#!/bin/bash
+sub=""; fmt=""; target=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    has-session|list-sessions|kill-session|new-session) sub="$1" ;;
+    -F) shift; fmt="${{1:-}}" ;;
+    -t) shift; target="${{1:-}}" ;;
+  esac
+  shift
+done
+case "$sub" in
+  has-session) exit {0 if exists else 1} ;;
+  list-sessions)
+    while IFS= read -r n; do
+      [ -z "$n" ] && continue
+      case "$fmt" in
+        *"|"*) printf '%s|0|t0\\n' "$n" ;;
+        *)     printf '%s\\n' "$n" ;;
+      esac
+    done <<< "$FAKE_NAMES"
+    exit 0 ;;
+  kill-session) printf '%s\\n' "$target" >> "{kill_file}"; exit 0 ;;
+  new-session) touch "{spawn_marker}"; exit 0 ;;
+esac
+exit 0
+""",
+    )
+    _write(fakebin / "nproc", "#!/bin/bash\necho 6\n")
+    _write(fakebin / "claude", "#!/bin/bash\nexit 0\n")
+    _write(
+        venvbin / "python",
+        f"""#!/bin/bash
+for a in "$@"; do
+  case "$a" in
+    *session_cap*) printf '%s\\n' "{action}"; exit {rc} ;;
+    *login_gate*)  exit 1 ;;
+  esac
+done
+exit 0
+""",
+    )
+    env = {
+        "HOME": str(home),
+        "PATH": f"{fakebin}:/usr/bin:/bin",
+        "SSH_CONNECTION": "100.100.100.100 1 2 22",
+        "FAKE_NAMES": names,
+    }
+    return env, spawn_marker, kill_file
+
+
+def _run(
+    tmp_path, *, action, exists=False, session_names=(), rc=0, mode="genesis-3-4", extra_env=None
+):
+    env, spawn_marker, kill_file = _setup(
+        tmp_path, action=action, exists=exists, session_names=session_names, rc=rc
+    )
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.run(
+        ["bash", str(_CC_SLOT), mode], env=env, capture_output=True, text=True, timeout=30
+    )
+    killed = kill_file.read_text() if kill_file.exists() else ""
+    return proc, spawn_marker.exists(), killed
+
+
+def _run_pty(tmp_path, *, action, session_names, feed, exists=False, rc=0, mode="genesis-3-4"):
+    """Run cc-slot.sh under a pty so the interactive reclaim `read </dev/tty` works."""
+    import pty
+
+    env, spawn_marker, kill_file = _setup(
+        tmp_path, action=action, exists=exists, session_names=session_names, rc=rc
+    )
+    pid, fd = pty.fork()
+    if pid == 0:  # child: becomes the pty session leader
+        try:
+            os.execve("/bin/bash", ["bash", str(_CC_SLOT), mode], env)  # noqa: S606 — pty child, fixed argv
+        except Exception:  # noqa: BLE001
+            os._exit(127)
+    os.write(fd, feed)
+    out = b""
+    while True:
+        try:
+            r, _, _ = select.select([fd], [], [], 8)
+        except OSError:
+            break
+        if not r:
+            break
+        try:
+            chunk = os.read(fd, 4096)
+        except OSError:
+            break
+        if not chunk:
+            break
+        out += chunk
+    _, status = os.waitpid(pid, 0)
+    code = os.waitstatus_to_exitcode(status)
+    killed = kill_file.read_text() if kill_file.exists() else ""
+    return code, out.decode(errors="replace"), spawn_marker.exists(), killed
+
+
+_THREE = ["cc-1", "cc-2", "cc-3"]
+
+
+def test_allow_spawns(tmp_path):
+    proc, spawned, _ = _run(tmp_path, action="ALLOW\nSlot available (4/4).", session_names=_THREE)
+    assert spawned, proc.stderr
+    assert proc.returncode == 0
+
+
+def test_deny_exits_without_spawning(tmp_path):
+    proc, spawned, _ = _run(
+        tmp_path,
+        action="DENY\nSession cap reached (4/4).",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-4"],
+    )
+    assert not spawned
+    assert proc.returncode == 1
+    assert "Session cap reached" in proc.stderr
+
+
+def test_reattach_bypasses_gate_and_spawns(tmp_path):
+    proc, spawned, _ = _run(
+        tmp_path, action="DENY\nshould not be consulted", exists=True, session_names=_THREE
+    )
+    assert spawned, proc.stderr
+    assert proc.returncode == 0
+    assert "should not be consulted" not in proc.stderr
+
+
+def test_python_unavailable_fails_open_and_spawns(tmp_path):
+    proc, spawned, _ = _run(tmp_path, action="", rc=1, session_names=[])
+    assert spawned, proc.stderr
+    assert proc.returncode == 0
+    assert "static fallback" in proc.stderr
+
+
+def test_reclaim_without_tty_fails_safe_no_spawn(tmp_path):
+    # RECLAIM with no interactive terminal (subprocess pipes) cannot prompt → fail
+    # SAFE (guide to reattach, exit 1, spawn nothing), never silently over-spawn.
+    proc, spawned, _ = _run(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit (5/4+1).\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6"],
+    )
+    assert not spawned
+    assert proc.returncode == 1
+    assert "reattach" in proc.stderr.lower()
+
+
+def test_reclaim_empty_oom_floor_refuses_no_spawn(tmp_path):
+    # RECLAIM for reason oom_floor with NO cc session to reclaim → REFUSE (OOM
+    # circuit-breaker), not a silent spawn on a swapless box.
+    proc, spawned, _ = _run(
+        tmp_path, action="RECLAIM\nRAM tight (900MB free).\noom_floor", session_names=[]
+    )
+    assert not spawned
+    assert proc.returncode == 1
+    assert "safety floor" in proc.stderr.lower()
+
+
+def test_reclaim_empty_cap_full_proceeds(tmp_path):
+    proc, spawned, _ = _run(tmp_path, action="RECLAIM\nAt the limit.\ncap_full", session_names=[])
+    assert spawned, proc.stderr
+    assert proc.returncode == 0
+    assert "no cc-N session to reclaim" in proc.stderr
+
+
+def test_reclaim_valid_choice_kills_selected_and_spawns(tmp_path):
+    # pty-driven: pick "2" → ends the 2nd listed session (cc-2), then spawns.
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit (5/4+1).\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6"],
+        feed=b"2\n",
+    )
+    assert spawned, out
+    assert code == 0
+    assert "cc-2" in killed  # exactly the chosen row's session
+    assert "cc-1" not in killed
+
+
+def test_reclaim_leading_zero_choice_rejected_no_spawn(tmp_path):
+    # The security-review HIGH: "08" is octal in bash arithmetic. It must be
+    # REJECTED (invalid selection, exit 1, nothing killed/spawned), never silently
+    # unwind past the gate and spawn.
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit.\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6", "cc-7", "cc-8", "cc-9"],
+        feed=b"08\n",
+    )
+    assert not spawned
+    assert code == 1
+    assert "invalid selection" in out.lower()
+    assert killed == ""
+
+
+def test_manual_door_failopen_over_cap_denies_no_reclaim(tmp_path):
+    # Dashboard/"manual" door is the normal method held to the cap: even in
+    # fail-open it must NOT get the destructive reclaim flow — a plain DENY.
+    # A huge per-session lever forces SAFE_CAP to 1 deterministically.
+    proc, spawned, killed = _run(
+        tmp_path,
+        action="",
+        rc=1,
+        mode="manual",
+        session_names=["cc-1", "cc-2", "cc-3"],
+        extra_env={"GENESIS_CC_PER_SESSION_MB": "1000000"},
+    )
+    assert not spawned
+    assert proc.returncode == 1
+    assert killed == ""
+    assert "cap reached" in proc.stderr.lower()

--- a/tests/test_scripts/test_cc_slot_cap.py
+++ b/tests/test_scripts/test_cc_slot_cap.py
@@ -301,6 +301,22 @@ def test_reclaim_leading_zero_choice_rejected_no_spawn(tmp_path):
     assert killed == ""
 
 
+def test_reclaim_oversized_choice_rejected_no_wrong_kill(tmp_path):
+    # Codex P2: an oversized decimal (2^64) slipped the regex, errored the bounds
+    # check, and WRAPPED $((10#choice-1)) to -1 → killed the LAST session. Must be
+    # rejected outright (invalid, exit 1, nothing killed/spawned).
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit.\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6"],
+        feed=b"18446744073709551616\n",
+    )
+    assert not spawned
+    assert code == 1
+    assert "invalid selection" in out.lower()
+    assert killed == ""  # crucially: did NOT wrap-index and kill cc-6
+
+
 def test_manual_door_failopen_over_cap_denies_no_reclaim(tmp_path):
     # Dashboard/"manual" door is the normal method held to the cap: even in
     # fail-open it must NOT get the destructive reclaim flow — a plain DENY.

--- a/tests/test_scripts/test_cc_slot_cap.py
+++ b/tests/test_scripts/test_cc_slot_cap.py
@@ -66,7 +66,7 @@ def _write(path: Path, text: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
 
 
-def _setup(tmp_path, *, action, exists, session_names, rc):
+def _setup(tmp_path, *, action, exists, session_names, rc, attached=""):
     """Build a fake HOME + fake tmux + fake venv python. Returns (env, spawn_marker, kill_file).
 
     The fake tmux is FORMAT-AWARE: a names-only `-F` (the `existing` count) prints
@@ -85,22 +85,34 @@ def _setup(tmp_path, *, action, exists, session_names, rc):
     _write(
         fakebin / "tmux",
         f"""#!/bin/bash
-sub=""; fmt=""; target=""
+sub=""; fmt=""; target=""; posfmt=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    has-session|list-sessions|kill-session|new-session) sub="$1" ;;
+    has-session|list-sessions|kill-session|new-session|display-message) sub="$1" ;;
     -F) shift; fmt="${{1:-}}" ;;
     -t) shift; target="${{1:-}}" ;;
+    -p) : ;;
+    -*) : ;;
+    *) posfmt="$1" ;;
   esac
   shift
 done
 case "$sub" in
   has-session) exit {0 if exists else 1} ;;
+  display-message)
+    # Per-name attach/activity query (display-message -p -t =cc-N of att|activity).
+    nm="${{target#=}}"; att=0
+    case " ${{FAKE_ATTACHED:-}} " in *" $nm "*) att=1 ;; esac
+    printf '%s|t0\\n' "$att"
+    exit 0 ;;
   list-sessions)
     while IFS= read -r n; do
       [ -z "$n" ] && continue
       case "$fmt" in
-        *"|"*) printf '%s|0|t0\\n' "$n" ;;
+        *"|"*)
+          att=0
+          case " ${{FAKE_ATTACHED:-}} " in *" $n "*) att=1 ;; esac
+          printf '%s|%s|t0\\n' "$n" "$att" ;;
         *)     printf '%s\\n' "$n" ;;
       esac
     done <<< "$FAKE_NAMES"
@@ -130,6 +142,7 @@ exit 0
         "PATH": f"{fakebin}:/usr/bin:/bin",
         "SSH_CONNECTION": "100.100.100.100 1 2 22",
         "FAKE_NAMES": names,
+        "FAKE_ATTACHED": attached,
     }
     return env, spawn_marker, kill_file
 
@@ -159,15 +172,24 @@ def _run_pty(
     rc=0,
     mode="genesis-3-4",
     kill_fails=False,
+    attached="",
+    extra_env=None,
 ):
     """Run cc-slot.sh under a pty so the interactive reclaim `read </dev/tty` works."""
     import pty
 
     env, spawn_marker, kill_file = _setup(
-        tmp_path, action=action, exists=exists, session_names=session_names, rc=rc
+        tmp_path,
+        action=action,
+        exists=exists,
+        session_names=session_names,
+        rc=rc,
+        attached=attached,
     )
     if kill_fails:
         env["KILL_RC"] = "1"
+    if extra_env:
+        env.update(extra_env)
     pid, fd = pty.fork()
     if pid == 0:  # child: becomes the pty session leader
         try:
@@ -317,22 +339,156 @@ def test_reclaim_oversized_choice_rejected_no_wrong_kill(tmp_path):
     assert killed == ""  # crucially: did NOT wrap-index and kill cc-6
 
 
-def test_manual_door_failopen_over_cap_denies_no_reclaim(tmp_path):
-    # Dashboard/"manual" door is the normal method held to the cap: even in
-    # fail-open it must NOT get the destructive reclaim flow — a plain DENY.
-    # A huge per-session lever forces SAFE_CAP to 1 deterministically.
+def test_normal_method_no_ssh_failopen_over_cap_denies_not_reclaim(tmp_path):
+    # F1: the "normal method" — no SSH_CONNECTION (dashboard web terminal / local
+    # console) — is held to SAFE_CAP with a PLAIN DENY in fail-open, never the
+    # destructive reclaim flow. safe = min((total-128)/128, nproc=6) = 6; 6 live
+    # sessions → over cap. Small per/floor so `need` passes on any CI free RAM →
+    # the reason is cap_full and the message is the count-cap one.
     proc, spawned, killed = _run(
         tmp_path,
         action="",
         rc=1,
         mode="manual",
-        session_names=["cc-1", "cc-2", "cc-3"],
-        extra_env={"GENESIS_CC_PER_SESSION_MB": "1000000"},
+        session_names=["cc-1", "cc-2", "cc-3", "cc-4", "cc-5", "cc-6"],
+        extra_env={
+            "SSH_CONNECTION": "",  # ← normal method: no SSH origin
+            "GENESIS_CC_PER_SESSION_MB": "128",
+            "GENESIS_CC_OOM_FLOOR_MB": "128",
+        },
     )
     assert not spawned
     assert proc.returncode == 1
     assert killed == ""
-    assert "cap reached" in proc.stderr.lower()
+    assert "session cap reached" in proc.stderr.lower()
+    assert "capacity gate unavailable" in proc.stderr.lower()
+
+
+def test_operator_ssh_failopen_over_cap_reclaims_not_denies(tmp_path):
+    # F1 (the other half): an SSH login IS the operator regardless of door — over
+    # the emergency limit in fail-open it gets the interactive RECLAIM, never a hard
+    # deny. safe=6, emergency=1 → limit 7; 7 live sessions → over. pty feed "1" ends
+    # cc-1 and spawns. Proves SSH presence (not the mode label) drives the affordance.
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="",
+        rc=1,
+        mode="manual",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-4", "cc-5", "cc-6", "cc-7"],
+        feed=b"1\n",
+        extra_env={"GENESIS_CC_PER_SESSION_MB": "128", "GENESIS_CC_OOM_FLOOR_MB": "128"},
+    )
+    assert spawned, out
+    assert code == 0
+    assert "cc-1" in killed
+
+
+def test_failopen_oversized_lever_no_divzero_abort(tmp_path):
+    # F2: an oversized PER_SESSION lever (2^64) passed the old `^[1-9][0-9]*$` regex,
+    # wrapped to 0 in bash $(( )), and div-by-zero ABORTED the login under set -e
+    # (a silent lockout — the opposite of fail-open). It must now fall back to the
+    # default and still produce a decision, never a bash arithmetic crash. Both the
+    # allow and the reclaim paths carry "capacity gate unavailable"; only the crash
+    # would emit "division by 0" with no decision.
+    proc, spawned, killed = _run(
+        tmp_path,
+        action="",
+        rc=1,
+        session_names=[],
+        extra_env={"GENESIS_CC_PER_SESSION_MB": "18446744073709551616"},
+    )
+    assert "division by 0" not in proc.stderr
+    assert "capacity gate unavailable" in proc.stderr.lower()
+
+
+def test_failopen_padded_lever_honored_matches_python(tmp_path):
+    # Architect SHOULD-FIX: a whitespace-padded lever must be honored on the bash
+    # fallback IDENTICALLY to the Python gate (which str.strip()s). A padded, huge
+    # reserve forces SAFE_CAP=1; with 1 live session (no SSH → normal method) that
+    # DENIES. If bash didn't strip, the padded value would be rejected → default
+    # reserve (4096) → SAFE_CAP≈6 → the session would spawn. per/floor kept tiny so
+    # the RAM gate passes on any CI free RAM, isolating the count axis.
+    proc, spawned, killed = _run(
+        tmp_path,
+        action="",
+        rc=1,
+        mode="manual",
+        session_names=["cc-1"],
+        extra_env={
+            "SSH_CONNECTION": "",  # normal method
+            "GENESIS_CC_SYSTEM_RESERVE_MB": "  9999999  ",  # padded → strip → honored → SAFE_CAP=1
+            "GENESIS_CC_PER_SESSION_MB": "128",
+            "GENESIS_CC_OOM_FLOOR_MB": "128",
+        },
+    )
+    assert not spawned  # padded reserve honored → cap 1 → over cap → deny
+    assert proc.returncode == 1
+    assert killed == ""
+    assert "session cap reached" in proc.stderr.lower()
+
+
+def test_reclaim_attached_victim_confirm_no_cancels(tmp_path):
+    # F9: ending an ATTACHED session (someone may be using it) requires an explicit
+    # y/N. Feeding the slot number then 'n' cancels — nothing killed, nothing spawned.
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit.\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6"],
+        feed=b"1\nn\n",
+        attached="cc-1",
+    )
+    assert not spawned
+    assert code == 1
+    assert killed == ""
+    assert "attached" in out.lower()
+
+
+def test_reclaim_attached_victim_confirm_yes_kills(tmp_path):
+    # F9: the same attached victim, confirmed with 'y' → killed and spawned.
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit.\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6"],
+        feed=b"1\ny\n",
+        attached="cc-1",
+    )
+    assert spawned, out
+    assert code == 0
+    assert "cc-1" in killed
+
+
+def test_reclaim_detached_victim_needs_no_confirm(tmp_path):
+    # F9 boundary: a DETACHED victim is killed on the single number keystroke — no
+    # second prompt. Feeding only "2\n" (no y/N) must still end cc-2 and spawn.
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit.\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6"],
+        feed=b"2\n",
+        attached="cc-1",  # cc-1 attached, but we pick cc-2 (detached)
+    )
+    assert spawned, out
+    assert code == 0
+    assert "cc-2" in killed
+
+
+def test_reclaim_crafted_pipe_name_not_a_selectable_row(tmp_path):
+    # Security HIGH (confused deputy): a crafted session whose NAME embeds '|'
+    # (e.g. "cc-1|0|fake") must NOT enter the reclaim list. The old combined-line
+    # split + prefix grep admitted it as a SECOND "cc-1" row with a forged att=0,
+    # so picking it bypassed the attached-victim confirm and killed the REAL cc-1.
+    # With the full-anchored name grep + per-name metadata query, only the real
+    # cc-1 is listed, so selecting "2" is out of range — nothing killed or spawned.
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit.\ncap_full",
+        session_names=["cc-1", "cc-1|0|fake"],
+        feed=b"2\n",
+        attached="cc-1",
+    )
+    assert "invalid selection" in out.lower()  # crafted row is not selectable
+    assert killed == ""  # the real cc-1 was NOT killed
+    assert not spawned
 
 
 def test_reclaim_kill_failure_aborts_no_spawn(tmp_path):

--- a/tests/test_scripts/test_cc_slot_cap.py
+++ b/tests/test_scripts/test_cc_slot_cap.py
@@ -105,7 +105,7 @@ case "$sub" in
       esac
     done <<< "$FAKE_NAMES"
     exit 0 ;;
-  kill-session) printf '%s\\n' "$target" >> "{kill_file}"; exit 0 ;;
+  kill-session) if [ "${{KILL_RC:-0}}" = "0" ]; then printf '%s\\n' "$target" >> "{kill_file}"; fi; exit "${{KILL_RC:-0}}" ;;
   new-session) touch "{spawn_marker}"; exit 0 ;;
 esac
 exit 0
@@ -149,13 +149,25 @@ def _run(
     return proc, spawn_marker.exists(), killed
 
 
-def _run_pty(tmp_path, *, action, session_names, feed, exists=False, rc=0, mode="genesis-3-4"):
+def _run_pty(
+    tmp_path,
+    *,
+    action,
+    session_names,
+    feed,
+    exists=False,
+    rc=0,
+    mode="genesis-3-4",
+    kill_fails=False,
+):
     """Run cc-slot.sh under a pty so the interactive reclaim `read </dev/tty` works."""
     import pty
 
     env, spawn_marker, kill_file = _setup(
         tmp_path, action=action, exists=exists, session_names=session_names, rc=rc
     )
+    if kill_fails:
+        env["KILL_RC"] = "1"
     pid, fd = pty.fork()
     if pid == 0:  # child: becomes the pty session leader
         try:
@@ -214,7 +226,15 @@ def test_reattach_bypasses_gate_and_spawns(tmp_path):
 
 
 def test_python_unavailable_fails_open_and_spawns(tmp_path):
-    proc, spawned, _ = _run(tmp_path, action="", rc=1, session_names=[])
+    # Low per/floor so the "room for a full session" check passes regardless of
+    # the CI runner's free RAM — we're testing the fail-open dispatch, not sizing.
+    proc, spawned, _ = _run(
+        tmp_path,
+        action="",
+        rc=1,
+        session_names=[],
+        extra_env={"GENESIS_CC_PER_SESSION_MB": "128", "GENESIS_CC_OOM_FLOOR_MB": "128"},
+    )
     assert spawned, proc.stderr
     assert proc.returncode == 0
     assert "static fallback" in proc.stderr
@@ -297,3 +317,19 @@ def test_manual_door_failopen_over_cap_denies_no_reclaim(tmp_path):
     assert proc.returncode == 1
     assert killed == ""
     assert "cap reached" in proc.stderr.lower()
+
+
+def test_reclaim_kill_failure_aborts_no_spawn(tmp_path):
+    # Codex P2: if `tmux kill-session` fails, NO memory was freed — must NOT spawn
+    # a new session on top (that over-commits the box). pty-driven with kill_fails.
+    code, out, spawned, killed = _run_pty(
+        tmp_path,
+        action="RECLAIM\nAt the emergency limit (5/4+1).\ncap_full",
+        session_names=["cc-1", "cc-2", "cc-3", "cc-5", "cc-6"],
+        feed=b"1\n",
+        kill_fails=True,
+    )
+    assert not spawned
+    assert code == 1
+    assert killed == ""  # nothing recorded — the kill failed
+    assert "failed to end" in out.lower()

--- a/tests/test_scripts/test_session_doors.py
+++ b/tests/test_scripts/test_session_doors.py
@@ -168,8 +168,9 @@ class TestManualMode:
         result = run("manual")
         assert result.returncode == 0, result.stderr
         assert "-s cc-2" in _new_session_line(log)
-        # Only the numeric slot counts: cap line reads 1/<max>, not 2/<max>.
-        assert "cap: 1/" in result.stderr
+        # Only the numeric slot counts: the header reads `live: 1`, not `live: 2`
+        # (the retired cc-manual-* stray is excluded from the count).
+        assert "live: 1" in result.stderr
 
     def test_exotic_arg_survives_quoting(self, door):
         run, log, _sessions, _listing = door


### PR DESCRIPTION
## Problem

`scripts/cc-slot.sh` sized its concurrent-session cap from **instantaneous free RAM** — `(MemAvailable − reserve) / per_session`, floored 1, clamped to nproc. Because that samples free RAM *after* sessions are running, each running session lowered `MemAvailable` and thus lowered the cap **below the number already running** — the operator got locked out of a new session (a nonsensical "cap reached (3/2 active)") while three ran fine, and unrelated apps' memory silently ate slots too.

## Fix

The cap is now a stable function of **total** RAM, decided by a new pure, unit-tested module `genesis.cc.session_cap` (mirrors the existing `login_gate` pattern):

- **Capacity model, not free-RAM:** `SAFE_CAP = clamp((MemTotal − reserve) / per_session, 1, nproc)`. Stable (does not shrink as sessions run), portable (scales per install — bigger box → bigger cap, small box → down to 1), unaffected by unrelated apps. Live free RAM is consulted **only** as an OOM circuit-breaker.
- **Operator emergency + reclaim:** a direct LAN/tailscale SSH login (origin from `SSH_CONNECTION`) gets an emergency slot above the safe cap and is **never hard-denied** — when full or tight it drops to an interactive prompt: reattach, or pick a session to end (its transcript persists → `claude --resume`). The dashboard/"normal method" is held to the safe cap.
- **Never lock out:** reattach always bypasses the gate; the gate **fails open** to a MemTotal-based static fallback so a broken venv can't strand the operator. The one refusal is a genuine OOM-floor breach with no session to reclaim (protecting a swapless box from a crash that would kill every session).

Tunable per box via `~/.genesis/cc-slot.env`: `GENESIS_CC_SYSTEM_RESERVE_MB` / `_PER_SESSION_MB` / `_OOM_FLOOR_MB` / `_EMERGENCY_SLOTS`.

## Tests

47: pure-function unit matrix (incl. verify-RED on the collapse case) + hermetic end-to-end runs of the real cc-slot.sh against fake tmux/python + **pty-driven** coverage of the interactive choice (valid pick kills the right session and spawns; a leading-zero/octal input is rejected, not silently spawned).

## Review

`genesis-architect` (logic) then `genesis-security-reviewer` (security), sequentially, on the fixed code. Fixed: a silent OOM-floor bypass on empty reclaim, a leading-zero-octal arithmetic gate bypass, unvalidated arithmetic env in the fallback, a lever-ordering bug (config sourced after the gate), a fail-open capability widening, and a public-repo privacy scrub of test fixtures.

## Notes

- Replaces #1516 (rebuilt on a clean history to drop an install-specific literal from the diff).
- Part of the SSH session-cap program; the background-session governor is a separate follow-up.
- Deploy: `git pull` (cc-slot.sh re-read per SSH login, module re-imported per invocation — no server restart). Live-login E2E lands post-deploy.
