### PR TITLE
fix(ci): read the CC pin the way bash reads it — one comment line defeated the guard

### DIFF
--- a/scripts/check_cc_node_lockstep.py
+++ b/scripts/check_cc_node_lockstep.py
@@ -48,12 +48,14 @@ _REGISTRY_URL = "https://registry.npmjs.org/@anthropic-ai/claude-code/{version}"
 _HTTP_TIMEOUT = 15  # seconds — a single registry GET; generous for a slow runner.
 _RETRIES = 1  # one retry on a transient network error before failing open.
 
-# Matches `CC_VERSION="${CC_VERSION:-2.1.201}"` / `NODE_MAJOR="${NODE_MAJOR:-22}"`.
-# Captures the default value after `:-`. Tolerant of surrounding quoting/spacing.
-_PIN_RE = {
-    "CC_VERSION": re.compile(r'CC_VERSION="?\$\{CC_VERSION:-([0-9]+\.[0-9]+\.[0-9]+)\}"?'),
-    "NODE_MAJOR": re.compile(r'NODE_MAJOR="?\$\{NODE_MAJOR:-([0-9]+)\}"?'),
-}
+# Pin reading lives in scripts/ci/cc_pin_parse.py, shared with the pin-receipt
+# guard. It replaced a local first-match regex that disagreed with bash: a
+# COMMENTED-OUT decoy above the real assignment made this guard read a pin the
+# machine never installs (measured: 2.1.100/Node 18 from a file bash resolves as
+# 2.1.246/Node 22), so a CC bump could clear the Node floor against the wrong
+# version entirely.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "ci"))
+from cc_pin_parse import parse_cc_version, parse_node_major  # noqa: E402
 
 
 class LockstepViolation(Exception):
@@ -75,19 +77,22 @@ def parse_pins(pin_file: Path) -> tuple[str, int]:
     except OSError as exc:
         raise LockstepViolation(f"cannot read pin file {pin_file}: {exc}") from exc
 
-    cc_match = _PIN_RE["CC_VERSION"].search(text)
-    node_match = _PIN_RE["NODE_MAJOR"].search(text)
-    if not cc_match or not node_match:
+    cc_version = parse_cc_version(text)
+    node_major = parse_node_major(text)
+    if cc_version is None or node_major is None:
         missing = []
-        if not cc_match:
+        if cc_version is None:
             missing.append("CC_VERSION")
-        if not node_match:
+        if node_major is None:
             missing.append("NODE_MAJOR")
         raise LockstepViolation(
-            f"could not parse {', '.join(missing)} default(s) from {pin_file} "
-            "(expected `VAR=\"${VAR:-value}\"` form)"
+            f"could not unambiguously determine {', '.join(missing)} from {pin_file} "
+            "(expected exactly ONE `VAR=\"${VAR:-value}\"` assignment at the start "
+            "of a line, outside comments). A duplicate assignment reports as "
+            "unparseable ON PURPOSE: this gate must not guess which one the "
+            "runtime uses."
         )
-    return cc_match.group(1), int(node_match.group(1))
+    return cc_version, node_major
 
 
 def fetch_engines_node(cc_version: str, *, opener=urllib.request.urlopen) -> str:

--- a/scripts/ci/cc_pin_parse.py
+++ b/scripts/ci/cc_pin_parse.py
@@ -93,10 +93,30 @@ _ASSIGNMENT = r'^[^\S\n]*{var}=[^\S\n]*"?\$\{{{var}:-{value}\}}"?'
 #: the file); under-detection costs a bypass. This is a DETECTOR, not a shell
 #: parser — it never has to decide which assignment wins, only whether more
 #: than one exists.
+#:
+#: NOT ANCHORED, and that is the whole point. An anchored version of this check
+#: shipped first and closed exactly one shape — the one it had a test for. Bash
+#: executes assignments after ``;``, ``||`` and ``&&``, and inside one-line
+#: ``if``/``case`` bodies, none of which start a line. MEASURED, every one of
+#: these left the guard reporting the untouched pin line while bash resolved
+#: 2.1.999::
+#:
+#:     [ -n "${X:-}" ] || CC_VERSION="2.1.999"
+#:     if true; then CC_VERSION="2.1.999"; fi
+#:     true && CC_VERSION=2.1.999
+#:     printf -v CC_VERSION "2.1.999"
+#:     read -r CC_VERSION <<< "2.1.999"
+#:     eval CC_VERSION=2.1.999
+#:
+#: The lookbehind keeps ``MY_CC_VERSION=`` and ``OLD_CC_VERSION=`` from counting.
+#: ``"${CC_VERSION:-…}"`` is not miscounted either: that text is ``CC_VERSION:-``,
+#: not ``CC_VERSION=``. The last three alternatives cover the builtins that
+#: assign without an ``=`` at all.
 _ANY_ASSIGNMENT = (
-    r"^[^\S\n]*"
-    r"(?:(?:export|readonly|local|declare|typeset)[^\S\n]+(?:-\w+[^\S\n]+)*)?"
-    r"{var}="
+    r"(?<![\w.-]){var}="
+    r"|printf[^\n]*-v[^\S\n]+{var}\b"
+    r"|read[^\n]*[^\S\n]{var}\b"
+    r"|eval\b[^\n]*{var}"
 )
 
 _SEMVER = r"([0-9]+\.[0-9]+\.[0-9]+)"

--- a/scripts/ci/cc_pin_parse.py
+++ b/scripts/ci/cc_pin_parse.py
@@ -1,0 +1,97 @@
+"""Read a pin out of ``scripts/lib/cc_version.sh`` the way bash reads it.
+
+Every CI guard over the Claude Code pin has to answer one question first: what
+value does the runtime actually use? Getting that wrong makes the guard check a
+number nobody runs, which is worse than having no guard — it reports green over
+the thing it was built to catch.
+
+THE BUG THIS EXISTS TO FIX. The guards each carried a copy of
+
+    re.compile(r'CC_VERSION="?\\$\\{CC_VERSION:-([0-9]+\\.[0-9]+\\.[0-9]+)\\}"?')
+
+and called ``.search()`` on the whole file. Two divergences from bash follow:
+
+  * ``search`` returns the FIRST match anywhere in the file. Bash executes
+    assignments in order, so the value that survives is the LAST one.
+  * The pattern is unanchored, so it matches inside a ``#`` comment — a line
+    bash never executes at all.
+
+Together those let one comment line above the real pin decide what a guard
+believes. Measured against ``bash -c '. cc_version.sh; echo $CC_VERSION'``:
+
+    # was: CC_VERSION="${CC_VERSION:-2.1.218}"     <- a comment
+    CC_VERSION="${CC_VERSION:-2.1.246}"            <- what bash uses
+
+  check_cc_node_lockstep.parse_pins  ->  2.1.218   (and Node 18 from a decoy)
+  bash                               ->  2.1.246
+
+so the Node-floor guard could be pointed at a pin the machine never installs,
+and the pin-receipt guard could be told "unchanged" for a PR that bumps it.
+
+WHAT THIS DOES INSTEAD. Comment lines are dropped, assignments must start their
+line, and every match is collected rather than the first. Then:
+
+  * exactly one  -> that value
+  * none         -> ``None``
+  * more than one-> ``None``
+
+Returning ``None`` for a duplicate is deliberate, and it is NOT what bash does
+(bash takes the last). A second effective assignment in a one-line pin file is
+not a thing anyone does by accident, so the honest report is "I cannot tell you
+what this file means", and the caller fails closed. Silently taking the last
+would let a PR hide a pin change behind a plausible-looking earlier assignment.
+
+DELIBERATELY NOT SOURCING THE FILE. ``bash -c '. cc_version.sh; echo …'`` would
+be exact, and is exactly the wrong instrument: on a pull_request the file is
+attacker-controlled, so sourcing it executes a contributor's shell in CI. A
+parser that under-claims is the correct trade.
+
+Callers must treat ``None`` as a BLOCK, never as a skip. It means the file did
+not parse — not that there is nothing to check.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: ``CC_VERSION="${CC_VERSION:-2.1.201}"`` at the start of a line. Quoting and
+#: spacing around the assignment are tolerated; a leading ``#`` is not, because
+#: ``_strip_comments`` has already removed those lines.
+_ASSIGNMENT = r'^[^\S\n]*{var}=[^\S\n]*"?\$\{{{var}:-{value}\}}"?'
+
+_SEMVER = r"([0-9]+\.[0-9]+\.[0-9]+)"
+_INTEGER = r"([0-9]+)"
+
+
+def _strip_comments(text: str) -> str:
+    """Drop whole-line ``#`` comments.
+
+    Only whole-line comments: a trailing ``# note`` after a real assignment
+    leaves the assignment intact, and the anchored pattern reads it correctly.
+    Trying to strip trailing comments properly would mean tracking shell
+    quoting, which is the hand-rolled-shell-parsing trap — and it buys nothing
+    here, because the value is captured before any ``#`` could appear.
+    """
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _parse(text: str, var: str, value_pattern: str) -> str | None:
+    pattern = re.compile(
+        _ASSIGNMENT.format(var=re.escape(var), value=value_pattern),
+        re.MULTILINE,
+    )
+    matches = pattern.findall(_strip_comments(text))
+    if len(matches) != 1:
+        return None  # 0 = not found; >1 = ambiguous. Both are "cannot tell".
+    return matches[0]
+
+
+def parse_cc_version(text: str) -> str | None:
+    """The pinned Claude Code version, or ``None`` if it cannot be determined."""
+    return _parse(text, "CC_VERSION", _SEMVER)
+
+
+def parse_node_major(text: str) -> int | None:
+    """The pinned Node major, or ``None`` if it cannot be determined."""
+    raw = _parse(text, "NODE_MAJOR", _INTEGER)
+    return int(raw) if raw is not None else None

--- a/scripts/ci/cc_pin_parse.py
+++ b/scripts/ci/cc_pin_parse.py
@@ -35,6 +35,21 @@ line, and every match is collected rather than the first. Then:
   * none         -> ``None``
   * more than one-> ``None``
 
+RECOGNISING THE PIN FORM IS NOT KNOWING WHAT THE FILE MEANS. ``cc_version.sh``
+is sourced, not read, so a line the pin pattern does not recognise can still
+change the value. A file may leave the pin untouched and reassign below it::
+
+    CC_VERSION="${CC_VERSION:-2.1.218}"
+    if [ -z "${CC_ALIGN_LEGACY:-}" ]; then
+      CC_VERSION="2.1.999"
+    fi
+
+Reading only the pin form gives 2.1.218 for a file bash resolves as 2.1.999 —
+a forward move to an un-vetted version that reads as "unchanged" and is asked
+for no receipts. So the count that decides is over EVERY assignment to the
+variable (``_ANY_ASSIGNMENT``), in any shape, taken before any value is read.
+More than one means the file's value is not something this parser can state.
+
 Returning ``None`` for a duplicate is deliberate, and it is NOT what bash does
 (bash takes the last). A second effective assignment in a one-line pin file is
 not a thing anyone does by accident, so the honest report is "I cannot tell you
@@ -59,6 +74,31 @@ import re
 #: ``_strip_comments`` has already removed those lines.
 _ASSIGNMENT = r'^[^\S\n]*{var}=[^\S\n]*"?\$\{{{var}:-{value}\}}"?'
 
+#: ANY assignment to the variable, in any shape — not just the pin form above.
+#: This exists because recognising only the pin form is not the same as knowing
+#: what the file MEANS. A file can leave the pin line untouched and reassign the
+#: variable further down::
+#:
+#:     CC_VERSION="${CC_VERSION:-2.1.218}"     <- the only line _ASSIGNMENT sees
+#:     if [ -z "${CC_ALIGN_LEGACY:-}" ]; then
+#:       CC_VERSION="2.1.999"                  <- what bash actually resolves
+#:     fi
+#:
+#: Matching only the pin form reports 2.1.218 for a file bash resolves as
+#: 2.1.999 — a forward move to an un-vetted version that reads as "unchanged"
+#: and is asked for no receipts. Counting EVERY assignment closes that: two
+#: means the file's value is not a thing this parser can state.
+#:
+#: Deliberately over-broad. Over-detection costs a block (safe: a human reads
+#: the file); under-detection costs a bypass. This is a DETECTOR, not a shell
+#: parser — it never has to decide which assignment wins, only whether more
+#: than one exists.
+_ANY_ASSIGNMENT = (
+    r"^[^\S\n]*"
+    r"(?:(?:export|readonly|local|declare|typeset)[^\S\n]+(?:-\w+[^\S\n]+)*)?"
+    r"{var}="
+)
+
 _SEMVER = r"([0-9]+\.[0-9]+\.[0-9]+)"
 _INTEGER = r"([0-9]+)"
 
@@ -76,11 +116,19 @@ def _strip_comments(text: str) -> str:
 
 
 def _parse(text: str, var: str, value_pattern: str) -> str | None:
+    body = _strip_comments(text)
+
+    # Refuse BEFORE reading a value: if the variable is assigned more than once
+    # in any shape, the pin line is not the file's answer and extracting it
+    # would state a version bash does not resolve to.
+    if len(re.findall(_ANY_ASSIGNMENT.format(var=re.escape(var)), body, re.MULTILINE)) != 1:
+        return None
+
     pattern = re.compile(
         _ASSIGNMENT.format(var=re.escape(var), value=value_pattern),
         re.MULTILINE,
     )
-    matches = pattern.findall(_strip_comments(text))
+    matches = pattern.findall(body)
     if len(matches) != 1:
         return None  # 0 = not found; >1 = ambiguous. Both are "cannot tell".
     return matches[0]

--- a/tests/test_scripts/test_cc_pin_parse.py
+++ b/tests/test_scripts/test_cc_pin_parse.py
@@ -130,6 +130,64 @@ def test_duplicate_assignment_is_unparseable_not_last_wins() -> None:
     assert pin.parse_cc_version(text) is None
 
 
+_REASSIGN = (
+    "#!/usr/bin/env bash\n"
+    'CC_VERSION="${CC_VERSION:-2.1.218}"\n'
+    'NODE_MAJOR="${NODE_MAJOR:-22}"\n'
+    "\n"
+    'if [ -z "${CC_ALIGN_LEGACY:-}" ]; then\n'
+    '  CC_VERSION="2.1.999"\n'
+    "fi\n"
+)
+
+
+def test_a_later_plain_reassignment_is_unparseable(tmp_path: Path) -> None:
+    """The pin line is untouched; a plain assignment below it changes the value.
+
+    Recognising the pin form is not the same as knowing what the file MEANS —
+    cc_version.sh is SOURCED, so a line the pin pattern does not match still
+    decides the result. Reading only the pin form reported 2.1.218 for a file
+    bash resolves as 2.1.999: a forward move to an un-vetted version that reads
+    as "unchanged" and is asked for no receipts.
+
+    Asserted against real bash, so this pins the DIVERGENCE, not a typed-in
+    expectation.
+    """
+    bash_answer = _bash_resolves(_REASSIGN, "CC_VERSION", tmp_path)
+
+    assert bash_answer == "2.1.999", "fixture no longer reproduces the reassignment"
+    assert pin.parse_cc_version(_REASSIGN) is None, (
+        "the parser must refuse, not report the pin line — reporting 2.1.218 here "
+        "is a forward bump that reads as unchanged"
+    )
+
+
+def test_reassignment_refusal_does_not_fire_on_the_real_pin_file() -> None:
+    """Over-detection costs a block, so prove it does not block the shipped file.
+
+    `_ANY_ASSIGNMENT` is deliberately broad (export/readonly/local/declare/
+    typeset prefixes). The live cc_version.sh dereferences CC_VERSION in several
+    helpers (`local pin="${CC_VERSION:-}"`), which must NOT count as assignments
+    to it.
+    """
+    text = _PIN_FILE.read_text()
+
+    assert pin.parse_cc_version(text) is not None
+    assert pin.parse_node_major(text) is not None
+
+
+def test_export_prefixed_reassignment_is_also_counted() -> None:
+    """The shape of the second assignment must not be the way around the check."""
+    for second in (
+        'export CC_VERSION="2.1.999"',
+        'readonly CC_VERSION="2.1.999"',
+        'declare -g CC_VERSION="2.1.999"',
+    ):
+        text = f'CC_VERSION="${{CC_VERSION:-2.1.218}}"\n{second}\n'
+
+        assert pin.parse_cc_version(text) is None, f"{second!r} evaded the check"
+
+
 def test_absent_is_none() -> None:
     assert pin.parse_cc_version('NODE_MAJOR="${NODE_MAJOR:-22}"\n') is None
     assert pin.parse_node_major('CC_VERSION="${CC_VERSION:-2.1.1}"\n') is None

--- a/tests/test_scripts/test_cc_pin_parse.py
+++ b/tests/test_scripts/test_cc_pin_parse.py
@@ -1,0 +1,186 @@
+"""Pin reading must agree with bash (scripts/ci/cc_pin_parse.py).
+
+A CI guard over the Claude Code pin is only as good as its answer to "what does
+the runtime actually use?". The guards previously used an unanchored
+``re.search`` for ``CC_VERSION="${CC_VERSION:-…}"``, which diverges from bash
+twice: ``search`` returns the FIRST match while bash keeps the LAST assignment,
+and an unanchored pattern matches inside a ``#`` comment that bash never
+executes.
+
+The consequence was live on main: one commented-out decoy line above the real
+pin made ``check_cc_node_lockstep.py`` read a version the machine never
+installs, so a CC bump could be checked against the wrong Node floor entirely.
+
+The load-bearing test here is ``test_parser_agrees_with_bash``: rather than
+asserting the parser matches a value someone typed into a fixture, it sources
+each fixture with real bash and asserts the parser reports what bash reports.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PIN_FILE = _REPO_ROOT / "scripts" / "lib" / "cc_version.sh"
+
+
+def _load(name: str, rel: str):
+    spec = importlib.util.spec_from_file_location(name, _REPO_ROOT / rel)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+pin = _load("cc_pin_parse", "scripts/ci/cc_pin_parse.py")
+lockstep = _load("check_cc_node_lockstep", "scripts/check_cc_node_lockstep.py")
+
+
+def _bash_resolves(text: str, var: str, tmp_path: Path) -> str:
+    """What bash ACTUALLY sets `var` to after sourcing `text`.
+
+    Ground truth for the parser. Safe here because every fixture is written by
+    this test file — the parser itself must never source a real pin file, which
+    on a pull_request is attacker-controlled.
+    """
+    f = tmp_path / "pin.sh"
+    f.write_text(text)
+    r = subprocess.run(
+        ["bash", "-c", f'unset {var}; . "{f}"; printf "%s" "${{{var}:-}}"'],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert r.returncode == 0, r.stderr
+    return r.stdout
+
+
+# ── the property that matters ─────────────────────────────────────────────
+
+_FIXTURES = {
+    "plain": '#!/usr/bin/env bash\nCC_VERSION="${CC_VERSION:-2.1.246}"\n',
+    "commented decoy above": (
+        "#!/usr/bin/env bash\n"
+        '# was: CC_VERSION="${CC_VERSION:-2.1.218}"\n'
+        'CC_VERSION="${CC_VERSION:-2.1.246}"\n'
+    ),
+    "commented decoy below": (
+        'CC_VERSION="${CC_VERSION:-2.1.246}"\n#   old: CC_VERSION="${CC_VERSION:-2.1.100}"\n'
+    ),
+    "indented comment decoy": (
+        '    # CC_VERSION="${CC_VERSION:-1.0.0}"\nCC_VERSION="${CC_VERSION:-2.1.246}"\n'
+    ),
+    "trailing comment on the real line": (
+        'CC_VERSION="${CC_VERSION:-2.1.246}"   # bumped 2026-08\n'
+    ),
+    "prose mentioning a version": (
+        "# See the 2.1.90 -> 2.1.87 rollback for why there is no floor.\n"
+        'CC_VERSION="${CC_VERSION:-2.1.246}"\n'
+    ),
+}
+
+
+@pytest.mark.parametrize("name", list(_FIXTURES))
+def test_parser_agrees_with_bash(name, tmp_path: Path) -> None:
+    """The parser's answer must equal the shell's answer, fixture by fixture."""
+    text = _FIXTURES[name]
+    expected = _bash_resolves(text, "CC_VERSION", tmp_path)
+
+    assert pin.parse_cc_version(text) == expected, (
+        f"{name}: parser and bash disagree — the guard would check a version "
+        f"the machine never installs"
+    )
+
+
+def test_the_old_first_match_regex_would_have_failed_these(tmp_path: Path) -> None:
+    """Pins the REGRESSION, not just the fix.
+
+    Reproduces the exact pattern the guards used to carry. If someone reverts to
+    an unanchored first-match search, this test says so in the same terms the
+    incident did.
+    """
+    import re
+
+    old = re.compile(r'CC_VERSION="?\$\{CC_VERSION:-([0-9]+\.[0-9]+\.[0-9]+)\}"?')
+    text = _FIXTURES["commented decoy above"]
+
+    old_answer = old.search(text).group(1)
+    bash_answer = _bash_resolves(text, "CC_VERSION", tmp_path)
+
+    assert old_answer != bash_answer, "fixture no longer reproduces the bug"
+    assert pin.parse_cc_version(text) == bash_answer
+
+
+# ── refusing to guess ─────────────────────────────────────────────────────
+
+
+def test_duplicate_assignment_is_unparseable_not_last_wins() -> None:
+    """Bash takes the last; this deliberately refuses instead.
+
+    Nobody writes two effective pin assignments by accident, so "the last one
+    wins" would be the guard quietly picking a winner in a file engineered to
+    have two. `None` forces the caller to fail closed.
+    """
+    text = 'CC_VERSION="${CC_VERSION:-2.1.218}"\nCC_VERSION="${CC_VERSION:-2.1.246}"\n'
+
+    assert pin.parse_cc_version(text) is None
+
+
+def test_absent_is_none() -> None:
+    assert pin.parse_cc_version('NODE_MAJOR="${NODE_MAJOR:-22}"\n') is None
+    assert pin.parse_node_major('CC_VERSION="${CC_VERSION:-2.1.1}"\n') is None
+
+
+def test_node_major_parses_and_is_an_int() -> None:
+    got = pin.parse_node_major('NODE_MAJOR="${NODE_MAJOR:-22}"\n')
+
+    assert got == 22
+    assert isinstance(got, int)
+
+
+# ── the real file, and the guard that consumes it ─────────────────────────
+
+
+def test_the_live_pin_file_parses() -> None:
+    """Smoke: the shipped cc_version.sh must be readable by this parser."""
+    text = _PIN_FILE.read_text()
+
+    assert pin.parse_cc_version(text) is not None
+    assert pin.parse_node_major(text) is not None
+
+
+def test_lockstep_guard_reads_past_a_comment_decoy(tmp_path: Path) -> None:
+    """End-to-end through the guard that ships today.
+
+    Before the fix this returned ('2.1.100', 18) for a file bash resolves as
+    ('2.1.246', 22) — the Node floor would have been checked against a version
+    that is not installed anywhere.
+    """
+    f = tmp_path / "cc_version.sh"
+    f.write_text(
+        "#!/usr/bin/env bash\n"
+        '# example: CC_VERSION="${CC_VERSION:-2.1.100}" NODE_MAJOR="${NODE_MAJOR:-18}"\n'
+        'CC_VERSION="${CC_VERSION:-2.1.246}"\n'
+        'NODE_MAJOR="${NODE_MAJOR:-22}"\n'
+    )
+
+    assert lockstep.parse_pins(f) == ("2.1.246", 22)
+
+
+def test_lockstep_guard_fails_closed_on_an_ambiguous_pin(tmp_path: Path) -> None:
+    """A file it cannot read must BLOCK, never resolve to something plausible."""
+    f = tmp_path / "cc_version.sh"
+    f.write_text(
+        'CC_VERSION="${CC_VERSION:-2.1.218}"\n'
+        'CC_VERSION="${CC_VERSION:-2.1.246}"\n'
+        'NODE_MAJOR="${NODE_MAJOR:-22}"\n'
+    )
+
+    with pytest.raises(lockstep.LockstepViolation) as exc:
+        lockstep.parse_pins(f)
+
+    assert "CC_VERSION" in str(exc.value)

--- a/tests/test_scripts/test_cc_pin_parse.py
+++ b/tests/test_scripts/test_cc_pin_parse.py
@@ -176,16 +176,53 @@ def test_reassignment_refusal_does_not_fire_on_the_real_pin_file() -> None:
     assert pin.parse_node_major(text) is not None
 
 
-def test_export_prefixed_reassignment_is_also_counted() -> None:
-    """The shape of the second assignment must not be the way around the check."""
-    for second in (
-        'export CC_VERSION="2.1.999"',
-        'readonly CC_VERSION="2.1.999"',
-        'declare -g CC_VERSION="2.1.999"',
-    ):
-        text = f'CC_VERSION="${{CC_VERSION:-2.1.218}}"\n{second}\n'
+#: Every shape MEASURED as resolving to 2.1.999 under bash while the pin line
+#: still reads 2.1.218. The anchored first attempt closed only the first one —
+#: the one it had a test for. That is why this list is a parametrization and not
+#: a single case.
+_REASSIGNMENT_SHAPES = [
+    'CC_VERSION="2.1.999"',
+    'export CC_VERSION="2.1.999"',
+    'readonly CC_VERSION="2.1.999"',
+    'declare -g CC_VERSION="2.1.999"',
+    '[ -n "${X:-}" ] || CC_VERSION="2.1.999"',
+    'if true; then CC_VERSION="2.1.999"; fi',
+    "true && CC_VERSION=2.1.999",
+    'printf -v CC_VERSION "2.1.999"',
+    'read -r CC_VERSION <<< "2.1.999"',
+    "eval CC_VERSION=2.1.999",
+]
 
-        assert pin.parse_cc_version(text) is None, f"{second!r} evaded the check"
+
+@pytest.mark.parametrize("second", _REASSIGNMENT_SHAPES)
+def test_every_reassignment_shape_is_counted(second: str, tmp_path: Path) -> None:
+    """The SHAPE of the second assignment must not be the way around the check.
+
+    Each case is checked against real bash first, so the test cannot quietly
+    degrade into asserting that the parser refuses files bash does not actually
+    change. If bash stops resolving 2.1.999 for a shape, that case fails loudly
+    rather than passing for the wrong reason.
+    """
+    text = f'CC_VERSION="${{CC_VERSION:-2.1.218}}"\n{second}\n'
+
+    assert _bash_resolves(text, "CC_VERSION", tmp_path) == "2.1.999", (
+        f"fixture no longer reproduces a reassignment for {second!r}"
+    )
+    assert pin.parse_cc_version(text) is None, f"{second!r} evaded the check"
+
+
+def test_similar_variable_names_are_not_miscounted() -> None:
+    """The other failure direction: over-detection costs a BLOCK.
+
+    `MY_CC_VERSION=` / `OLD_CC_VERSION=` must not read as a second assignment to
+    CC_VERSION, and `"${CC_VERSION:-…}"` is `CC_VERSION:-`, not `CC_VERSION=`.
+    """
+    pinline = 'CC_VERSION="${CC_VERSION:-2.1.218}"\n'
+
+    for decoy in ("MY_CC_VERSION=1", "OLD_CC_VERSION=1", 'NOTE_CC_VERSION="x"'):
+        assert pin.parse_cc_version(pinline + decoy + "\n") == "2.1.218", (
+            f"{decoy!r} was miscounted as an assignment to CC_VERSION"
+        )
 
 
 def test_absent_is_none() -> None:


### PR DESCRIPTION
## Problem

The CC↔Node lockstep gate exists so a Claude Code bump cannot outrun the Node
floor it requires. It read the pin with an unanchored first-match regex, which
disagrees with bash twice: `re.search` returns the FIRST match in the file while
bash keeps the LAST assignment, and an unanchored pattern matches inside a `#`
comment bash never executes.

So a single commented-out line above the real pin decided what the guard
believed. Measured on one file:

```
# example: CC_VERSION="${CC_VERSION:-2.1.100}" NODE_MAJOR="${NODE_MAJOR:-18}"
CC_VERSION="${CC_VERSION:-2.1.246}"
NODE_MAJOR="${NODE_MAJOR:-22}"

parse_pins()                       -> ('2.1.100', 18)
bash -c '. f; echo $CC_VERSION'    -> 2.1.246
```

The gate then checked a Node floor against a version the machine never installs,
and reported green. Nothing else noticed, because the whole point of the job is
that a human does not have to.

**This was live on `main`,** not a defect in unmerged work.

## The fix

Pin reading moves into `scripts/ci/cc_pin_parse.py`, shared rather than copied —
the same regex had been pasted into a second guard, so the defect propagated by
copy-paste and a local fix would have left the other one wrong.

The parser drops comment lines, anchors assignments to the start of a line, and
collects every match rather than the first. One match wins; zero or more than one
returns `None`, and callers fail closed on it.

### Recognising the pin form is not knowing what the file means

`cc_version.sh` is **sourced**, not read, so a line the pin pattern does not
recognise still decides the value. A change can leave the pin untouched and
reassign below it:

```bash
CC_VERSION="${CC_VERSION:-2.1.218}"
if [ -z "${CC_ALIGN_LEGACY:-}" ]; then
  CC_VERSION="2.1.999"
fi
```

Reading only the pin form reports `2.1.218` for a file bash resolves as
`2.1.999` — a forward move to an un-vetted version that reads as "unchanged".

The deciding count is therefore taken over **every** assignment to the variable,
in any shape, before any value is read. More than one means the file's value is
not something this parser can state.

**That check shipped anchored first, and closed one shape of six.** Bash executes
assignments after `;`, `||` and `&&`, and inside one-line `if`/`case` bodies, none
of which start a line. Measured — each row is the untouched pin line plus one
appended line:

| appended | parser | bash |
|---|---|---|
| `CC_VERSION="2.1.999"` | refused | 2.1.999 |
| `[ -n "${X:-}" ] \|\| CC_VERSION="2.1.999"` | **2.1.218** | 2.1.999 |
| `if true; then CC_VERSION="2.1.999"; fi` | **2.1.218** | 2.1.999 |
| `true && CC_VERSION=2.1.999` | **2.1.218** | 2.1.999 |
| `printf -v CC_VERSION "2.1.999"` | **2.1.218** | 2.1.999 |
| `eval CC_VERSION=2.1.999` | **2.1.218** | 2.1.999 |

The axis was wrong: assignments were enumerated by *variable prefix* (`export`,
`readonly`, `local`, …) while the defect varies by *syntactic position*. The
pattern is unanchored now, with a negative lookbehind so `MY_CC_VERSION` and
`OLD_CC_VERSION` do not count, plus alternatives for the builtins that assign
without an `=` at all.

## Deliberate decisions, recorded in the module so they are not "fixed" back

**Returning `None` for a duplicate is NOT what bash does** — bash takes the last.
But a second effective pin assignment is not something anyone writes by accident,
and a guard that silently picks a winner in a file engineered to have two is
choosing on the reader's behalf. The honest answer is "I cannot tell what this
file means."

**Sourcing the file would be exact, and is the wrong instrument.** On a
`pull_request` that file is attacker-controlled, so sourcing it runs a
contributor's shell inside CI. A parser that occasionally under-claims beats one
that can be made to execute code.

**The assignment detector is deliberately over-broad.** Over-detection costs a
block, which a human resolves by reading the file; under-detection costs a
bypass. It is a detector, not a shell parser — it never decides which assignment
wins, only whether more than one exists, so widening it carries no correctness
burden.

## Testing

47 tests, including the 21 existing lockstep tests unmodified.

The load-bearing tests do not assert against a value typed into a fixture: for
each one they source the file with **real bash** and assert the parser reports
what bash reports. The six reassignment shapes are a parametrization, and each
asserts what bash resolves *before* asserting the parser refuses — so a fixture
that stops reproducing the bug fails loudly instead of passing for the wrong
reason.

Over-rejection is guarded too: the shipped `cc_version.sh` must still parse (its
helpers dereference `CC_VERSION` in `local pin="${CC_VERSION:-}"`, which are
assignments to `pin`, not to `CC_VERSION`), and `MY_`/`OLD_`/`NOTE_`-prefixed
decoys must not count.

Verify-RED: reverting to first-match fails six tests; neutering the
any-assignment counter restores the `2.1.218` answer for a file bash resolves as
`2.1.999`.
