### PR TITLE
feat(cc): running-binary sweep — which copy is RUNNING, not which is installed

### DIFF
--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -92,6 +92,62 @@ reinstalled forever.
 
 ---
 
+### Which copy is INSTALLED vs which copy is RUNNING
+
+Different questions, different checks, and a box can pass one while failing the
+other.
+
+`cc_shadow_scan` answers **installed**: it probes `command -v claude` plus
+`CC_PROBE_DIRS` for extra on-disk copies and removes the stale ones.
+
+`scripts/check_cc_running_versions.sh` answers **running**: for every live CC
+process it resolves `stat -L /proc/<pid>/exe` — procfs keeps that reference
+valid even after npm unlinks the file — and compares its **device + inode**
+against the binary on disk today. Device matters: an inode number is unique only
+within a filesystem, so copies on separate mounts can collide numerically.
+
+Measured on a live install: exactly one canonical binary, at the intended
+version, while **a majority of live CC sessions were still executing the
+replaced predecessor**. A long-running process keeps its original mapping until
+it restarts, and `claude --version` cannot reveal this — it spawns a *fresh
+child*, which reads the new on-disk binary and truthfully reports the new
+version while the session asking the question is not running it.
+
+This matters most during a local-first soak, whose whole premise is that real
+interactive use exercises the candidate. Run the sweep at soak start and again
+at soak end.
+
+**The rule it is built around**, because a check that produces release evidence
+has one failure that matters more than the others:
+
+> Any process the sweep cannot POSITIVELY PROVE is not-Claude-Code must not
+> contribute to a clean verdict.
+
+Positive proof is cheap: a readable executable whose basename is not a Claude
+Code name, or an unreadable executable whose command line's `argv[0]` is not
+one. Only when neither can be read is a process genuinely unclassifiable, and
+that refuses the clean verdict rather than being skipped. Measured on a live
+box, that bucket holds 0 of 109 processes — the rule costs nothing in practice
+and never launders a false all-clear.
+
+Classification is a **closed set of names**, never a path guess. An earlier
+design classified by whether the executable lived under an enumerated install
+root; it fails on the only case that matters, because npm's replace renames the
+old package aside and then deletes it, so a stale process's path points at a
+directory that no longer exists. A root set enumerated from the install cannot
+contain a directory the installer deleted, so exactly the stale processes would
+have been classified "not CC", ignored, and reported clean.
+
+Exit codes: **0** every live CC process runs the on-disk binary; **1** at least
+one runs a different binary — either a replaced one, or an installed copy that
+is not the PATH-canonical one (each named, so `cc_shadow_scan` can resolve it);
+**2** cannot determine, so no clean verdict is claimed. A node-wrapped install
+resolves `exe` to the interpreter, whose inode says nothing about which CC
+revision is loaded, so it reports undetermined rather than a false all-clear.
+The same is true under a `hidepid` procfs, where other users' processes are not
+enumerable at all and the denominator itself would be unverified.
+
+
 ## Integration Surface — Genesis Components That Use CC
 
 | Genesis Component | CC Feature Used | Files | Notes |

--- a/scripts/check_cc_running_versions.sh
+++ b/scripts/check_cc_running_versions.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Running-binary sweep — which LIVE Claude Code processes are executing the
+# binary that is on disk now, and which are still running one npm has replaced.
+#
+# WHY THIS EXISTS. On a live install a container was aligned to a candidate CC
+# version and a multi-day local-first soak was declared started. Measured at the
+# end of it, MOST interactive sessions were still executing the pre-align binary:
+# npm had replaced the package underneath them, and a long-lived process keeps
+# its original mapping until it restarts. `claude --version` did not reveal this
+# — it spawns a FRESH child, which reads the new on-disk binary and truthfully
+# reports the candidate while the session asking is not running it. The soak had
+# accumulated days of "real use" on the old release.
+#
+# NOT the same as `cc_shadow_scan`. That scans on-disk COPIES and removes stale
+# ones — "what is installed here?". This asks "what is actually RUNNING here?".
+# A box passes one and fails the other: exactly one canonical binary at the
+# intended version, while several live sessions execute a deleted predecessor.
+#
+# ── THE INVARIANT ────────────────────────────────────────────────────────────
+#
+#   Any process this sweep cannot POSITIVELY PROVE is not-Claude-Code must not
+#   contribute to a clean verdict.
+#
+# This is written down because its ABSENCE is what made the previous design
+# churn. Each round fixed the case a reviewer named and silently flipped the
+# fail direction, because there was nothing to check a fix against. Positive
+# proof of not-CC is cheap and available: the exe is readable and its basename
+# is not a CC name, or the exe is unreadable but the cmdline is readable and
+# argv[0] is not a CC name. Only when NEITHER can be read is a process
+# genuinely unclassifiable — and that must block a clean verdict, never be
+# skipped.
+#
+# SCOPE OF THAT COST, stated precisely because an earlier version of this
+# comment was not. Measured INSIDE A PID-NAMESPACED CONTAINER, 0 of 109
+# processes land in the unclassifiable bucket. That number does NOT generalise:
+# a container's PID namespace contains no kernel threads, and on a host kernel
+# they are a large fraction of all pids (measured ~170 of 320 on a comparable
+# host) with exactly the unclassifiable shape — no exe, empty cmdline. Left
+# unhandled they would make this script return 2 unconditionally off-container,
+# including on any CI runner. That is why kernel threads are identified
+# POSITIVELY as not-CC below rather than parked in the bucket.
+#
+# A rejected design, recorded so it is not re-proposed: classify by whether the
+# executable lives under an enumerated Claude Code INSTALL ROOT. It fails on the
+# only case that matters. npm's replace RENAMES the old package to
+# `@anthropic-ai/.claude-code-<random>` and then deletes it, so a stale
+# process's exe path points at a directory that no longer exists — measured live
+# here, with two sessions on `.claude-code-1devilah/bin/claude.exe (deleted)`
+# while `@anthropic-ai/` contained only `claude-code`. A root set enumerated
+# from the install cannot contain a directory the installer deleted, so those
+# processes classify as "not CC", are ignored, and the sweep exits 0. That
+# swapped a bounded NAME test whose mistakes shout (a false alarm) for a path
+# test whose mistakes whisper (ignored ⇒ all-clear).
+#
+# Method: `stat -L /proc/<pid>/exe` resolves the inode of the executable a
+# process is running, and procfs keeps that reference valid even after the file
+# is unlinked, so a replaced binary still resolves. NOTE the `-L` is
+# load-bearing: without it `stat` returns the procfs magic-link's own inode, not
+# the target's, and every process compares unequal.
+#
+# Identity is DEVICE + inode. An inode number is unique only within a
+# filesystem, so a binary on another mount can collide numerically and be
+# reported current while being an entirely different file.
+#
+# Exit codes:
+#     0 — every live CC process runs the on-disk binary (or none are running)
+#     1 — at least one runs a DIFFERENT (stale/replaced) binary
+#     2 — cannot determine, so no clean verdict is claimed
+#
+# Usage:  scripts/check_cc_running_versions.sh [--quiet] [--proc-root DIR]
+
+set -u
+set -o pipefail
+
+# Resolve HOME when unset: stripped-env/systemd/sandbox invocations can leave
+# HOME unset, which under `set -u` aborts at the first ${HOME} use — and would
+# abort with exit 1, the code that means "stale binaries found". Same
+# passwd-fallback form the rest of the script suite uses.
+if [ -z "${HOME:-}" ]; then
+    HOME="$(getent passwd "$(id -u)" 2>/dev/null | cut -d: -f6)"
+    if [ -z "${HOME:-}" ]; then
+        echo "cc-running-versions: UNDETERMINED — HOME is unset and unresolvable" >&2
+        exit 2
+    fi
+    export HOME
+fi
+
+QUIET=0
+PROC_ROOT="/proc"
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --quiet) QUIET=1 ;;
+        --proc-root)
+            shift
+            [ "$#" -gt 0 ] || { echo "--proc-root requires a path" >&2; exit 2; }
+            PROC_ROOT="$1"
+            ;;
+        -h|--help)
+            sed -n '3,80p' "$0"
+            echo
+            echo "Options: --quiet   suppress per-process lines (never the verdict)"
+            echo "         --proc-root DIR   scan an alternative procfs root"
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $1 (try --help)" >&2
+            exit 2
+            ;;
+    esac
+    shift
+done
+
+say() { [ "$QUIET" = "1" ] || echo "$@"; }
+
+# A typo'd --proc-root previously produced a confident "OK — all 0 live
+# processes": the unmatched-glob guard cannot tell an empty procfs from a wrong
+# path. Refuse instead.
+if [ ! -d "$PROC_ROOT" ]; then
+    echo "cc-running-versions: UNDETERMINED — proc root '$PROC_ROOT' is not a directory" >&2
+    exit 2
+fi
+# Existing-but-wrong is the likelier typo, and checking only for existence left
+# it open: MEASURED, `--proc-root /tmp` produced a confident "OK — all 0 live
+# Claude Code process(es)", exit 0. Require it to actually look like a procfs.
+if [ ! -d "$PROC_ROOT/1" ] && [ ! -e "$PROC_ROOT/self" ]; then
+    echo "cc-running-versions: UNDETERMINED — '$PROC_ROOT' does not look like a procfs" >&2
+    echo "  (no pid 1 and no self/ entry). Refusing rather than sweeping an empty directory." >&2
+    exit 2
+fi
+
+# ── the denominator ─────────────────────────────────────────────────────────
+# Under hidepid the sweep cannot verify its own DENOMINATOR. The two shapes
+# differ and both matter: hidepid=1 leaves other users' pid directories VISIBLE
+# but their contents unreadable, hidepid=2 and above hide them entirely. Either
+# way a clean verdict would describe only this user's processes while claiming
+# to describe every live one — the receipt's denominator would be unverified.
+# Match the OPTION, never an enumerated value list. `hidepid=[12]` missed
+# `hidepid=4` (HIDEPID_NOT_PTRACEABLE) and the symbolic spellings the 5.8+
+# multi-instance procfs work introduced — `noaccess`, `invisible`,
+# `ptraceable` — which is the same closed-set-of-values mistake this script
+# rejects elsewhere. Anything that is not explicitly "off"/"0" refuses.
+if [ "$PROC_ROOT" = "/proc" ] &&
+    grep -qE '(^| )/proc proc [^ ]*(^|,)hidepid=' /proc/mounts 2>/dev/null &&
+    ! grep -qE '(^| )/proc proc [^ ]*(^|,)hidepid=(0|off)(,| )' /proc/mounts 2>/dev/null; then
+    echo "cc-running-versions: UNDETERMINED — /proc is mounted with hidepid, so other" >&2
+    echo "  users' processes are hidden or unreadable and this run cannot claim to have" >&2
+    echo "  swept them. (hidepid=1 leaves the directories visible but unreadable;" >&2
+    echo "  hidepid=2 and above hide them entirely — under either, the DENOMINATOR is" >&2
+    echo "  unverified, which is the same lie as a wrong verdict.)" >&2
+    exit 2
+fi
+
+# ── the canonical binary, and every installed copy ──────────────────────────
+CC_PROBE_DIRS="${CC_PROBE_DIRS:-/usr/local/bin:/usr/bin:$HOME/.npm-global/bin:$HOME/.local/bin}"
+
+canonical_path=""
+canonical_path="$(command -v claude 2>/dev/null)" || canonical_path=""
+if [ -z "$canonical_path" ]; then
+    echo "cc-running-versions: UNDETERMINED — no 'claude' on PATH; nothing to compare against" >&2
+    exit 2
+fi
+
+canonical_real=""
+canonical_real="$(readlink -f "$canonical_path" 2>/dev/null)" || canonical_real=""
+[ -n "$canonical_real" ] || canonical_real="$canonical_path"
+
+canonical_id=""
+canonical_id="$(stat -c '%d:%i' "$canonical_real" 2>/dev/null)" || canonical_id=""
+if [ -z "$canonical_id" ]; then
+    echo "cc-running-versions: UNDETERMINED — cannot stat $canonical_real" >&2
+    exit 2
+fi
+
+# Map every INSTALLED copy by dev:inode. A process running a copy that is
+# installed-but-not-canonical is a different situation from one running a
+# deleted predecessor, and saying which is more useful than refusing outright.
+# The previous design refused the whole sweep whenever two copies disagreed on
+# --version, which (a) no-opped entirely when either probe failed, and (b) threw
+# away the per-process answer that resolves the question.
+installed_ids="$canonical_id"
+installed_desc="$canonical_id=$canonical_real"
+_oldIFS="$IFS"
+IFS=':'
+for _d in $CC_PROBE_DIRS; do
+    _cand="$_d/claude"
+    [ -x "$_cand" ] || continue
+    _cand_real="$(readlink -f "$_cand" 2>/dev/null)" || _cand_real="$_cand"
+    _cand_id="$(stat -c '%d:%i' "$_cand_real" 2>/dev/null)" || continue
+    case " $installed_ids " in *" $_cand_id "*) continue ;; esac
+    installed_ids="$installed_ids $_cand_id"
+    installed_desc="$installed_desc
+$_cand_id=$_cand_real"
+done
+IFS="$_oldIFS"
+
+say "on-disk canonical: $canonical_real"
+say "                  dev:inode=$canonical_id"
+say ""
+
+# ── classification: a CLOSED name set, never a path guess ───────────────────
+# `claude-code` is included defensively. The shipped package's bin map is
+# {claude: bin/claude.exe}, so no such executable exists on this install — it
+# costs one token and is not a demonstrated hole.
+is_cc_name() {
+    case "$1" in
+        claude|claude.exe|claude-code) return 0 ;;
+    esac
+    return 1
+}
+
+# Interpreters that can run the CC entry script. `bun`/`deno` are defensive —
+# not demonstrated on this install — but a reviewer measured the gap with a
+# bun-wrapped CLI, and the whole point of a CLOSED set is that widening it is a
+# token rather than an architecture. Missing one here is a false all-clear.
+is_interpreter_name() {
+    case "$1" in
+        node|nodejs|bun|deno) return 0 ;;
+    esac
+    return 1
+}
+
+# Does this command line run the CC entry script under an interpreter?
+#
+# The FIRST NON-FLAG token, not argv[1]. Testing argv[1] treated
+# `node --enable-source-maps /opt/cc/cli.js` as proof of NOT-CC, because the
+# flag occupied the slot — and node CLIs routinely carry --enable-source-maps,
+# --no-warnings or --max-old-space-size. Narrowing a detector that way trades a
+# loud false positive for a silent false negative, which is the wrong direction
+# for a check whose worst outcome is a false all-clear.
+cmdline_runs_cc() {
+    # shellcheck disable=SC2086 # deliberate word-split; globbing is off (set -f)
+    set -- $1
+    [ "$#" -ge 1 ] || return 1
+    shift
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            -*) shift ;;
+            *)
+                case "${1##*/}" in
+                    cli.js) return 0 ;;
+                esac
+                return 1
+                ;;
+        esac
+    done
+    return 1
+}
+
+# A kernel thread is POSITIVELY not Claude Code, and saying so is what keeps the
+# invariant affordable. Kernel threads have no mm, so no exe and an empty
+# cmdline — the same shape as an uninspectable process — and parking them in the
+# unclassifiable bucket makes the sweep return 2 on any host that has them.
+#
+# Two signals, either sufficient: this kernel exposes `Kthread:` in
+# /proc/<pid>/status (verified present on 6.8), and the mm-less signature
+# (no VmSize) is the portable fallback for kernels that do not.
+is_kernel_thread() {
+    _status="$1/status"
+    [ -r "$_status" ] || return 1
+    case "$(grep -m1 '^Kthread:' "$_status" 2>/dev/null)" in
+        *1) return 0 ;;
+        *0) return 1 ;;
+    esac
+    grep -q '^VmSize:' "$_status" 2>/dev/null && return 1
+    return 0
+}
+
+current=0
+stale=0
+other_install=0
+undetermined=0
+unclassifiable=0
+
+# Word-splitting a cmdline into positional parameters must NOT also glob against
+# the sweep's own working directory. MEASURED: an unrelated `node * --flag`, swept
+# from a directory containing cli.js, expanded into a CC-shaped argv and
+# manufactured a refusal purely from the operator's `cd`. The inverse hides a real
+# one. Nothing below needs pathname expansion; the pid glob already happened.
+for procdir in "$PROC_ROOT"/[0-9]*; do
+    # INSIDE the body, never before the `for`: the pid glob above must still
+    # expand. Setting it earlier disabled that glob too, so `procdir` stayed the
+    # literal pattern, the loop ran zero times, and the sweep reported
+    # "OK — all 0 live Claude Code process(es)" on a box with two stale ones.
+    # Total blindness presenting as a clean verdict — caught by running it live,
+    # not by any test, which is why the live run is part of the check.
+    set -f
+    [ -d "$procdir" ] || continue   # no match → the glob stays literal
+    pid="${procdir##*/}"
+
+    exe_target=""
+    exe_target="$(readlink "$procdir/exe" 2>/dev/null)" || exe_target=""
+
+    # `2>` precedes `<` deliberately: bash applies redirections left to right, so
+    # a stderr redirect written after the input redirect cannot suppress that
+    # redirect's own "No such file" — and a process exiting mid-sweep is routine.
+    cmdline=""
+    cmdline="$(tr '\0' ' ' 2>/dev/null < "$procdir/cmdline")" || cmdline=""
+
+    if [ -n "$exe_target" ]; then
+        # Strip procfs' " (deleted)" suffix BEFORE the name test. This one line
+        # carries the whole incident: npm renames-then-deletes, so a stale
+        # process's link reads `.../claude.exe (deleted)`, and without the strip
+        # `is_cc_name` sees "claude.exe (deleted)", fails, and the process is
+        # silently dropped — turning the exact case this exists to catch into a
+        # green verdict.
+        exe_base="${exe_target% (deleted)}"
+        exe_base="${exe_base##*/}"
+        if is_cc_name "$exe_base"; then
+            :   # CC, inode decides below
+        elif is_interpreter_name "$exe_base"; then
+            if cmdline_runs_cc "$cmdline"; then
+                undetermined=$((undetermined + 1))
+                say "  UNDETERMINED pid=$pid  interpreter-wrapped (exe=$exe_base) — the interpreter's inode says nothing about the CC revision"
+                continue
+            fi
+            continue    # an interpreter running something else: positively not CC
+        else
+            continue    # readable exe, not a CC name: POSITIVELY not CC
+        fi
+    elif is_kernel_thread "$procdir"; then
+        # POSITIVELY not CC, and this branch is why it must be checked: a kernel
+        # thread has no exe and an empty cmdline, so without it every kthread
+        # lands in the unclassifiable bucket and the sweep can never return 0 on
+        # a host that has them. This container's PID namespace shows none, which
+        # is exactly why the earlier "0 of 109" measurement did not reveal it.
+        continue
+    elif [ -n "${cmdline# }" ] && [ -n "$(printf '%s' "$cmdline" | tr -d '[:space:]')" ]; then
+        # Exe unreadable (another user, or a procfs restriction) but the cmdline
+        # is readable, so argv[0] still settles it. NO path/root-set clause here:
+        # requiring one would mean another user's CC install — under THEIR home —
+        # fails to match and is silently ignored, which is a false all-clear.
+        # shellcheck disable=SC2086 # deliberate word-split; globbing is off (set -f)
+        set -- $cmdline
+        if [ "$#" -lt 1 ]; then
+            # An all-NUL cmdline word-splits to nothing. Reading $1 here aborted
+            # the script under `set -u` with exit 1 — the code meaning "stale
+            # found". An environment shape must never read as a finding.
+            unclassifiable=$((unclassifiable + 1))
+            say "  UNDETERMINED pid=$pid  command line present but empty"
+            continue
+        fi
+        arg0_base="${1##*/}"
+        if is_cc_name "$arg0_base"; then
+            unclassifiable=$((unclassifiable + 1))
+            say "  UNDETERMINED pid=$pid  identified as CC by argv[0], but its executable could not be inspected"
+            continue
+        fi
+        if is_interpreter_name "$arg0_base" && cmdline_runs_cc "$cmdline"; then
+            unclassifiable=$((unclassifiable + 1))
+            say "  UNDETERMINED pid=$pid  interpreter-wrapped CC by cmdline, executable not inspectable"
+            continue
+        fi
+        continue        # readable cmdline, not a CC name: POSITIVELY not CC
+    else
+        # Nothing identifying could be read and it is not a kernel thread. It
+        # cannot be PROVEN not-CC, so per the invariant it must not contribute to
+        # a clean verdict. The count is unconditional — an earlier version put
+        # the increment inside a `[ -r stat ]` guard with `continue` OUTSIDE it,
+        # so a wholly unreadable pid dir (the hidepid=1 shape: visible, contents
+        # EACCES) incremented nothing and voted CLEAN, violating the invariant in
+        # the one branch written to enforce it.
+        unclassifiable=$((unclassifiable + 1))
+        if [ -r "$procdir/stat" ]; then
+            say "  UNDETERMINED pid=$pid  neither executable nor command line could be read"
+        else
+            say "  UNDETERMINED pid=$pid  process directory is entirely unreadable"
+        fi
+        continue
+    fi
+
+    started=""
+    started="$(stat -c %y "$procdir" 2>/dev/null | cut -c1-19)" || started=""
+
+    run_id=""
+    run_id="$(stat -L -c '%d:%i' "$procdir/exe" 2>/dev/null)" || run_id=""
+    if [ -z "$run_id" ]; then
+        # Realistically the process exited between the readlink and the stat.
+        # NOT treated as stale: manufacturing a stale verdict for a process that
+        # no longer exists is a false alarm on evidence quoted in a receipt.
+        undetermined=$((undetermined + 1))
+        say "  UNDETERMINED pid=$pid  running inode could not be resolved; started=$started"
+        continue
+    fi
+
+    if [ "$run_id" = "$canonical_id" ]; then
+        current=$((current + 1))
+        say "  current      pid=$pid  id=$run_id  started=$started"
+    elif case " $installed_ids " in *" $run_id "*) true ;; *) false ;; esac; then
+        other_install=$((other_install + 1))
+        say "  OTHER-COPY   pid=$pid  id=$run_id — an INSTALLED copy that is not the PATH-canonical one; started=$started"
+        say "               running: $exe_target"
+    else
+        stale=$((stale + 1))
+        say "  STALE        pid=$pid  id=$run_id (on-disk is $canonical_id)  started=$started"
+        say "               running: $exe_target"
+    fi
+done
+
+set +f
+
+say ""
+say "summary: current=$current stale=$stale other-copy=$other_install undetermined=$undetermined unclassifiable=$unclassifiable"
+
+if [ "$stale" -gt 0 ] || [ "$other_install" -gt 0 ]; then
+    if [ "$stale" -gt 0 ]; then
+        echo "cc-running-versions: $stale live Claude Code process(es) are running a REPLACED binary." >&2
+    fi
+    if [ "$other_install" -gt 0 ]; then
+        echo "cc-running-versions: $other_install live process(es) run an installed copy that is NOT the" >&2
+        echo "  PATH-canonical one. Installed copies seen:" >&2
+        printf '%s\n' "$installed_desc" | while IFS= read -r _line; do
+            echo "    $_line" >&2
+        done >&2
+        echo "  Run cc_shadow_scan to collapse to one copy." >&2
+    fi
+    echo "  They keep running it until each restarts. Any soak those sessions performed is" >&2
+    echo "  evidence about a different binary. Relaunch them, then re-run this." >&2
+    exit 1
+fi
+
+if [ "$undetermined" -gt 0 ] || [ "$unclassifiable" -gt 0 ]; then
+    echo "cc-running-versions: UNDETERMINED for $((undetermined + unclassifiable)) process(es) — refusing to" >&2
+    echo "  report all-clear. A verdict that skipped processes it could not inspect would be a" >&2
+    echo "  claim about sessions this run never saw." >&2
+    exit 2
+fi
+
+say "cc-running-versions: OK — all $current live Claude Code process(es) run the on-disk binary."
+exit 0

--- a/tests/test_scripts/test_cc_running_versions.py
+++ b/tests/test_scripts/test_cc_running_versions.py
@@ -1,0 +1,477 @@
+"""Running-binary sweep (scripts/check_cc_running_versions.sh).
+
+Reports which LIVE Claude Code processes execute the binary currently on disk
+and which still run one npm has replaced. Origin: on a live install, most CC
+processes were still executing the pre-align binary while `claude --version` —
+which spawns a fresh child — truthfully reported the new one, so a local-first
+soak had accumulated days of "real use" on the old release.
+
+THE INVARIANT UNDER TEST, and the reason this file is shaped the way it is:
+
+    Any process the sweep cannot POSITIVELY PROVE is not-Claude-Code must not
+    contribute to a clean verdict.
+
+The previous design had no such rule, so each review round fixed the case a
+reviewer named and silently flipped the fail direction. Tests here are grouped
+by which HALF of the invariant they pin — "must not report OK" and "must not
+false-alarm" — because a fix that satisfies one by breaking the other is the
+failure mode, and a test file organised by feature hides that.
+
+HERMETIC BY CONSTRUCTION. Every run sets `CC_PROBE_DIRS` and `HOME` to
+fixture-only paths. Without that the script reaches the REAL /usr/local/bin
+during the installed-copy scan, and the suite passes only while a fixture
+literal happens to equal the host's installed CC version — a time bomb whose
+fuse is the next pin bump, invisible on CI where no CC is installed.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "check_cc_running_versions.sh"
+
+EXIT_OK = 0
+EXIT_STALE = 1
+EXIT_UNDETERMINED = 2
+
+
+def _make_binary(path: Path, marker: str = "canonical") -> Path:
+    """A real, executable stand-in. Content differs per marker so two fixtures
+    are genuinely different files (different inodes), which is what the sweep
+    compares — never a version string."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f'#!/bin/sh\necho "{marker}"\n')
+    path.chmod(0o755)
+    return path
+
+
+def _make_proc(
+    proc_root: Path, pid: int, *, exe: Path | None = None, cmdline: str | None = "claude\x00"
+) -> Path:
+    d = proc_root / str(pid)
+    d.mkdir(parents=True, exist_ok=True)
+    if exe is not None:
+        (d / "exe").symlink_to(exe)
+    if cmdline is not None:
+        (d / "cmdline").write_bytes(cmdline.encode())
+    return d
+
+
+def _run(world, *args: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PATH"] = f"{world['bindir']}:{env['PATH']}"
+    # The two seams that keep this hermetic. Without them the installed-copy
+    # scan reads the real host install and the outcome depends on the host.
+    env["CC_PROBE_DIRS"] = str(world["bindir"])
+    env["HOME"] = str(world["tmp"])
+    return subprocess.run(
+        ["bash", str(_SCRIPT), "--proc-root", str(world["proc"]), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+
+
+@pytest.fixture
+def world(tmp_path: Path):
+    pkg = _make_binary(tmp_path / "pkg" / "claude.exe", "canonical")
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "claude").symlink_to(pkg)
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    # The sweep refuses a --proc-root that does not look like a procfs (an
+    # existing-but-wrong path used to produce a confident all-clear), so a
+    # fixture root must carry a pid 1. It is a plain userspace process that is
+    # positively not CC, so it never affects a verdict.
+    one = proc / "1"
+    one.mkdir()
+    (one / "exe").symlink_to(_make_binary(tmp_path / "sbin" / "init", "init"))
+    (one / "cmdline").write_bytes(b"/sbin/init\x00")
+    return {"tmp": tmp_path, "canonical": pkg, "bindir": bindir, "proc": proc}
+
+
+def test_the_suite_is_not_coupled_to_this_hosts_cc_version(world):
+    """Guards the hermeticity above, which is a property of the HARNESS.
+
+    The previous suite passed only because a fixture literal coincidentally
+    equalled the host's installed version; the next pin bump broke eight tests,
+    and CI could never catch it because no CC is installed there.
+    """
+    res = _run(world)
+
+    assert "/usr/local" not in res.stdout, "the sweep reached a real install path"
+    assert res.returncode == EXIT_OK
+
+
+# ── half one: must never report OK when it cannot see everything ──────────
+
+
+def test_a_replaced_binary_is_stale(world):
+    """The incident shape: npm replaced the package under a long-lived process,
+    which keeps executing the old inode until it restarts."""
+    old = _make_binary(world["tmp"] / "old" / "claude.exe", "replaced")
+    _make_proc(world["proc"], 101, exe=world["canonical"])
+    _make_proc(world["proc"], 102, exe=old)
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_STALE, res.stdout
+    assert "stale=1" in res.stdout
+    assert "current=1" in res.stdout
+
+
+def test_a_wrapper_named_process_is_not_silently_dropped(world):
+    """MEASURED false all-clear in the previous design.
+
+    A process whose exe basename matched no branch — reproduced with a
+    bun-wrapped CLI — incremented NO counter at all, so the sweep printed
+    "OK — all 0 live Claude Code process(es)" and exited 0 with a live CC
+    session running. Being ignored is a vote for a clean verdict.
+    """
+    bun = _make_binary(world["tmp"] / "rt" / "bun", "bun")
+    _make_proc(world["proc"], 201, exe=bun, cmdline="bun\x00/opt/claude-alt/cli.js\x00")
+
+    res = _run(world)
+
+    assert res.returncode != EXIT_OK, res.stdout
+    assert "UNDETERMINED" in res.stdout or "UNDETERMINED" in res.stderr
+
+
+def test_a_cc_process_whose_exe_cannot_be_read_blocks_a_clean_verdict(world):
+    """Identified as CC by argv[0], executable not inspectable (another user, or
+    a procfs restriction). Reporting OK would be a claim about a session this
+    run never saw, and a receipt quoting it would be false."""
+    _make_proc(world["proc"], 301, exe=None, cmdline="claude\x00")
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_UNDETERMINED, res.stdout
+
+
+def test_neither_exe_nor_cmdline_readable_blocks_a_clean_verdict(world):
+    """The one genuinely unclassifiable case. It cannot be proven not-CC, so by
+    the invariant it must not contribute to OK."""
+    d = world["proc"] / "401"
+    d.mkdir(parents=True)
+    (d / "stat").write_text("401 (x) S\n")  # enumerable, but nothing identifying
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_UNDETERMINED, res.stdout
+
+
+def test_a_node_wrapped_install_refuses_to_answer(world):
+    """/proc/<pid>/exe resolves to the interpreter, whose inode says nothing
+    about which CC revision is loaded. Refuse rather than answer wrongly."""
+    node = _make_binary(world["tmp"] / "rt" / "node", "node")
+    _make_proc(world["proc"], 501, exe=node, cmdline="node\x00/opt/cc/cli.js\x00")
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_UNDETERMINED, res.stdout
+
+
+def test_a_typod_proc_root_refuses_rather_than_reporting_all_clear(world):
+    """MEASURED: the unmatched-glob guard cannot tell an empty procfs from a
+    wrong path, so a typo produced a confident "OK — all 0"."""
+    res = subprocess.run(
+        ["bash", str(_SCRIPT), "--proc-root", "/nonexistent-typo"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert res.returncode == EXIT_UNDETERMINED
+    assert "not a directory" in res.stderr
+
+
+def test_no_claude_on_path_is_undetermined(tmp_path: Path):
+    """Without a canonical there is nothing to compare against. It must NOT
+    fall back to reporting everything current."""
+    proc = tmp_path / "proc"
+    (proc / "1").mkdir(parents=True)  # procfs-shaped, so the PATH check is what fires
+
+    res = subprocess.run(
+        ["bash", str(_SCRIPT), "--proc-root", str(proc)],
+        capture_output=True,
+        text=True,
+        # PATH must still resolve `bash` while excluding `claude`, which installs
+        # to /usr/local/bin — not /usr/bin or /bin, here or on a CI runner.
+        # Emptying PATH entirely fails on "no such file: bash" instead of
+        # exercising the branch.
+        env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
+        timeout=60,
+    )
+
+    assert res.returncode == EXIT_UNDETERMINED
+    assert "no 'claude' on PATH" in res.stderr
+
+
+def test_home_unset_exits_undetermined_not_stale(tmp_path: Path):
+    """MEASURED fail-direction inversion: `$HOME` under `set -u` aborted the
+    script with exit 1 — the code documented as "stale binaries found". An
+    environment error must never read as a finding. Regression against the
+    repo-wide HOME guard, which this file must satisfy."""
+    proc = tmp_path / "proc"
+    proc.mkdir()
+    env = {"PATH": "/usr/bin:/bin"}  # HOME deliberately absent
+
+    res = subprocess.run(
+        ["bash", str(_SCRIPT), "--proc-root", str(proc)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+
+    assert res.returncode != EXIT_STALE, "an environment error reported as a stale finding"
+    assert res.returncode == EXIT_UNDETERMINED
+
+
+# ── half two: must never false-alarm ──────────────────────────────────────
+
+
+def test_all_processes_on_canonical_is_ok(world):
+    _make_proc(world["proc"], 601, exe=world["canonical"])
+    _make_proc(world["proc"], 602, exe=world["canonical"])
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_OK, res.stderr
+    assert "current=2" in res.stdout
+    assert "stale=0" in res.stdout
+
+
+def test_an_unrelated_process_is_positively_not_cc(world):
+    """A readable exe whose basename is not a CC name is PROVEN not-CC. It must
+    be ignored silently — counting it would fail an otherwise clean soak."""
+    vim = _make_binary(world["tmp"] / "other" / "vim", "vim")
+    _make_proc(world["proc"], 701, exe=vim, cmdline="vim\x00")
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_OK, res.stdout
+
+
+def test_a_process_merely_MENTIONING_claude_is_not_counted(world):
+    """MEASURED false hard-fail in the previous design: another user's
+    `grep -r claude /var/log` had an unreadable exe, hit a `*claude*` cmdline
+    substring test, and wedged the whole sweep at exit 2. argv[0] is `grep`."""
+    _make_proc(world["proc"], 801, exe=None, cmdline="grep\x00-r\x00claude\x00/var/log\x00")
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_OK, res.stdout + res.stderr
+
+
+def test_a_vanished_process_does_not_leak_a_shell_error(world):
+    """A pid dir with nothing in it — the process exited mid-sweep. Routine.
+
+    Regression guard: written as `tr … < file 2>/dev/null` bash applies
+    redirections left to right, so the stderr redirect cannot suppress the INPUT
+    redirect's own "No such file". The `2>` must precede the `<`.
+    """
+    (world["proc"] / "901").mkdir()
+
+    res = _run(world)
+
+    assert "No such file" not in res.stderr
+    assert "cmdline" not in res.stderr
+
+
+def test_empty_proc_root_does_not_glob_literally(world):
+    res = _run(world)
+
+    assert res.returncode == EXIT_OK
+    assert "current=0" in res.stdout
+
+
+def test_rejects_an_unknown_argument(world):
+    res = subprocess.run(
+        ["bash", str(_SCRIPT), "--bogus"], capture_output=True, text=True, timeout=60
+    )
+
+    assert res.returncode == EXIT_UNDETERMINED
+    assert "unknown argument" in res.stderr
+
+
+def test_a_deleted_predecessor_is_still_recognised_as_cc(world):
+    """The single line the whole incident depends on.
+
+    npm renames-then-deletes, so a stale process's `readlink` yields
+    `.../claude.exe (deleted)`. Without stripping that suffix the name test
+    fails and the process is SILENTLY DROPPED — MEASURED: removing the strip
+    turned the live box from `stale=2, exit 1` into
+    `OK — all 8 live Claude Code process(es)`, exit 0, with the whole suite
+    still green. A one-character regression converting the exact incident into a
+    clean receipt, invisible to CI.
+    """
+    old = _make_binary(world["tmp"] / "old" / "claude.exe (deleted)", "replaced")
+    _make_proc(world["proc"], 1101, exe=old)
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_STALE, res.stdout
+    assert "stale=1" in res.stdout
+
+
+def test_a_wholly_unreadable_pid_dir_blocks_a_clean_verdict(world):
+    """MEASURED invariant violation: the count sat inside a `[ -r stat ]` guard
+    while `continue` sat outside it, so a pid dir with nothing readable at all
+    incremented nothing and voted CLEAN — in the one branch written to enforce
+    "cannot prove not-CC must not contribute to a clean verdict". That is the
+    hidepid=1 shape: directory visible, contents EACCES."""
+    (world["proc"] / "1201").mkdir(parents=True)
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_UNDETERMINED, res.stdout
+    assert "unclassifiable=1" in res.stdout
+
+
+@pytest.mark.parametrize(
+    "flags", [["--enable-source-maps"], ["--no-warnings"], ["--max-old-space-size=4096"]]
+)
+def test_interpreter_flags_do_not_hide_the_cc_script(world, flags):
+    """MEASURED: testing argv[1] treated `node --enable-source-maps .../cli.js`
+    as PROOF of not-CC, because the flag occupied the slot. Node CLIs routinely
+    carry these. Narrowing a detector that way trades a loud false positive for
+    a silent false negative — the wrong direction for a check whose worst
+    outcome is a false all-clear."""
+    node = _make_binary(world["tmp"] / "rt" / "node", "node")
+    argv = "\x00".join(["node", *flags, "/opt/cc/cli.js"]) + "\x00"
+    _make_proc(world["proc"], 1301, exe=node, cmdline=argv)
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_UNDETERMINED, res.stdout
+
+
+def test_a_kernel_thread_is_positively_not_cc(world):
+    """Kernel threads have no exe and an empty cmdline — the unclassifiable
+    shape. Parking them there makes the sweep return 2 on ANY host that has
+    them, which is every non-container host and every CI runner. This container
+    shows none, which is exactly why the earlier "0 of 109" measurement did not
+    reveal it: that number was namespace-scoped and stated as if general.
+    """
+    d = world["proc"] / "1401"
+    d.mkdir(parents=True)
+    (d / "stat").write_text("1401 (kworker/0:1) S 2 0 0\n")
+    (d / "cmdline").write_bytes(b"")
+    (d / "status").write_text("Name:\tkworker/0:1\nKthread:\t1\n")  # no VmSize: no mm
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_OK, res.stdout
+    assert "unclassifiable=0" in res.stdout
+
+
+def test_a_kernel_thread_is_detected_without_the_Kthread_field(world):
+    """Portable fallback for kernels predating `Kthread:` — no VmSize means no
+    mm, which means a kernel thread."""
+    d = world["proc"] / "1501"
+    d.mkdir(parents=True)
+    (d / "stat").write_text("1501 (ksoftirqd/0) S 2 0 0\n")
+    (d / "cmdline").write_bytes(b"")
+    (d / "status").write_text("Name:\tksoftirqd/0\nState:\tS (sleeping)\n")
+
+    res = _run(world)
+
+    assert res.returncode == EXIT_OK, res.stdout
+
+
+def test_an_all_nul_cmdline_does_not_abort_as_stale(world):
+    """MEASURED fail-direction inversion: an all-NUL cmdline word-splits to zero
+    tokens, so reading `$1` aborted under `set -u` with exit 1 — the code that
+    means "stale binaries found". Same class as the HOME guard, which this test
+    exists to generalise rather than leave pinned at one instance."""
+    d = world["proc"] / "1601"
+    d.mkdir(parents=True)
+    (d / "cmdline").write_bytes(b"\x00\x00")
+    (d / "stat").write_text("1601 (x) S 1 0 0\n")
+    (d / "status").write_text("Name:\tx\nVmSize:\t100 kB\n")  # userspace: has mm
+
+    res = _run(world)
+
+    assert res.returncode != EXIT_STALE, "a shell abort surfaced as a stale finding"
+    assert res.returncode == EXIT_UNDETERMINED
+
+
+def test_a_glob_in_an_unrelated_cmdline_does_not_manufacture_a_verdict(world, tmp_path):
+    """MEASURED false alarm: `set -- $cmdline` word-splits AND glob-expands, so
+    an unrelated `node * --flag` swept from a directory containing cli.js
+    expanded into a CC-shaped argv and produced a refusal purely from the
+    operator's working directory. The inverse hides a real one."""
+    node = _make_binary(world["tmp"] / "rt" / "node", "node")
+    _make_proc(world["proc"], 1701, exe=node, cmdline="node\x00*\x00--flag\x00")
+    cwd = tmp_path / "trap"
+    cwd.mkdir()
+    (cwd / "cli.js").write_text("//\n")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{world['bindir']}:{env['PATH']}"
+    env["CC_PROBE_DIRS"] = str(world["bindir"])
+    env["HOME"] = str(world["tmp"])
+    res = subprocess.run(
+        ["bash", str(_SCRIPT), "--proc-root", str(world["proc"])],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd,
+        timeout=120,
+    )
+
+    assert res.returncode == EXIT_OK, res.stdout
+
+
+def test_an_existing_but_wrong_proc_root_refuses(world):
+    """MEASURED: the existence check alone left the likelier typo open —
+    `--proc-root /tmp` produced a confident "OK — all 0", exit 0."""
+    res = subprocess.run(
+        ["bash", str(_SCRIPT), "--proc-root", "/tmp"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert res.returncode == EXIT_UNDETERMINED
+    assert "does not look like a procfs" in res.stderr
+
+
+# ── the third verdict: an installed-but-not-canonical copy ────────────────
+
+
+def test_a_process_on_another_INSTALLED_copy_is_named_not_refused(world):
+    """The previous design refused the WHOLE sweep when two installed copies
+    disagreed on `--version` — a refusal that (a) no-opped entirely whenever
+    either probe failed, and (b) discarded the per-process answer that actually
+    resolves the question. Reporting which copy each process runs is strictly
+    more evidence than refusing."""
+    other = _make_binary(world["tmp"] / "other-prefix" / "claude", "second-install")
+    probe2 = world["tmp"] / "probe2"
+    probe2.mkdir()
+    (probe2 / "claude").symlink_to(other)
+    _make_proc(world["proc"], 1001, exe=other)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{world['bindir']}:{env['PATH']}"
+    env["CC_PROBE_DIRS"] = f"{world['bindir']}:{probe2}"
+    env["HOME"] = str(world["tmp"])
+    res = subprocess.run(
+        ["bash", str(_SCRIPT), "--proc-root", str(world["proc"])],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120,
+    )
+
+    assert res.returncode == EXIT_STALE, res.stdout
+    assert "OTHER-COPY" in res.stdout
+    assert "cc_shadow_scan" in res.stderr, "point the operator at the fix"


### PR DESCRIPTION
## Problem

On a live install a container was aligned to a candidate Claude Code version and
a multi-day local-first soak was declared started. Measured at the end of it,
**most interactive sessions were still executing the pre-align binary.** npm had
replaced the package underneath them, and a long-lived process keeps its
original mapping until it restarts. `claude --version` could not reveal this —
it spawns a *fresh child*, which reads the new binary on disk and truthfully
reports the candidate while the session asking is not running it. The soak had
accumulated days of "real use" on the old release.

This answers the question `cc_shadow_scan` does not. That one asks what is
*installed*; this asks what is actually *running*. A box passes one and fails
the other: exactly one canonical binary at the intended version, while several
live sessions execute a deleted predecessor.

Split out of #1514, where it drew findings in three consecutive review rounds —
and two of the last round's were caused by the round before's fixes.

## One invariant, written down

That churn pattern is a missing invariant, not bad luck. Each round optimised
the case a reviewer named and silently flipped the fail direction, because there
was nothing to check a fix against. So the rule is now in the file and the doc:

> Any process the sweep cannot POSITIVELY PROVE is not-Claude-Code must not
> contribute to a clean verdict.

Positive proof is cheap: a readable executable whose basename is not a Claude
Code name, or an unreadable one whose command line's `argv[0]` is not. Only when
neither can be read is a process genuinely unclassifiable, and that refuses the
clean verdict rather than being skipped.

**A design refuted by measurement before implementation**, recorded in the file
so it is not proposed again: classify by whether the executable lives under an
enumerated install root. npm renames the old package aside and then deletes it,
so a stale process's path points at a directory that **no longer exists** —
measured here, two sessions on a deleted `.claude-code-<random>` path while the
scope directory contained only `claude-code`. A root set enumerated from the
install cannot contain a directory the installer deleted, so exactly the stale
processes would have been ignored and reported clean. That trades a bounded name
test whose mistakes *shout* for a path test whose mistakes *whisper*.

## Closed, each measured

- A process whose readable executable matched no branch incremented **no counter
  at all**, so the sweep printed "OK — all 0 live processes" with a live session
  running.
- Another user's `grep -r claude /var/log` had an unreadable executable, hit a
  cmdline substring test, and wedged the whole sweep. `argv[0]` is `grep`. The
  unreadable branch deliberately carries no path clause — requiring one would
  mean another user's install, under *their* home, is silently ignored.
- `$HOME` unset under `set -u` aborted with **exit 1**, the code meaning "stale
  binaries found". An environment error must never read as a finding.
- A typo'd `--proc-root` produced a confident all-clear. Both shapes now refuse.
- The ambiguity check compared `--version` strings, no-opped when either probe
  came back empty, and refused the whole sweep when they differed. It is now an
  installed-copy map keyed on device+inode with a third per-process verdict
  naming *which* copy each process runs — more evidence than a refusal, and it
  removes the only place that exec'd a discovered binary, so the unbounded probe
  cannot hang.
- The `(deleted)` ⇒ stale rule was dead code: `stat -L` **succeeds** on a deleted
  binary, which is precisely why the inode compare works at all.

## A second audit found four more

- **The invariant was violated in the one branch written to enforce it.** The
  unclassifiable count sat inside a readability guard while `continue` sat
  outside it, so a wholly unreadable pid directory incremented nothing and voted
  clean — the `hidepid=1` shape exactly.
- The interpreter branch tested `argv[1]` for the entry script, so
  `node --enable-source-maps .../cli.js` put a flag in the slot and the process
  was recorded as *proven not-CC*. It now takes the first non-flag token.
- The hidepid guard matched an enumerated value list, `hidepid=[12]`, missing
  `hidepid=4` and the symbolic spellings — the same closed-set-of-values mistake
  this script rejects elsewhere.
- **The `(deleted)` strip was untested.** Removing that one expression left the
  suite fully green while the live box flipped from two stale processes to
  "OK — all 8", exit 0. A one-character regression turning the exact incident
  into a green receipt, invisible to CI.

## A claim corrected, not just code

The header and doc said *"0 of 109 processes fall in that bucket, so the
invariant costs nothing in practice."* That was measured **inside a
PID-namespaced container**, which contains no kernel threads, and written as
though general. Kernel threads have exactly the unclassifiable shape — no exe,
empty cmdline — and are a large fraction of pids on a host, so off-container,
**including on any CI runner, the script would have returned 2 unconditionally**:
a 100%-rate false alarm, which is the outcome that teaches an operator to ignore
a tool. Kernel threads are now identified positively as not-CC, and both prose
claims name their namespace.

Worth flagging on its own: fixing the glob expansion introduced a worse bug that
**only the live run caught**. `set -f` placed before the loop also disabled the
pid glob, so the loop ran zero times and the sweep reported "OK — all 0" on a box
with two stale processes — total blindness presenting as a clean verdict. It
belongs inside the loop body, where the glob has already expanded.

## Testing

26 tests, shellcheck clean, ruff clean.

Tests are grouped by **which half of the invariant** each case pins — must never
report OK, and must never false-alarm — because a fix that satisfies one by
breaking the other is the failure mode here, and a feature-organised file hides
that.

Hermetic by construction: every run pins `CC_PROBE_DIRS` and `HOME` to
fixture-only paths, and a test asserts the sweep never reaches a real install
path. The previous suite passed only because a fixture literal coincidentally
equalled the host's installed version — the next pin bump broke eight tests,
invisibly on CI where no CC is installed.

Every fix is mutation-tested: dropping the deleted-strip, re-guarding the
unclassifiable count, breaking flag handling, disabling kernel-thread detection,
inverting `set -f`, or removing the procfs check each breaks the suite.

Verified live on a box carrying two genuinely stale sessions: `current=8
stale=2 undetermined=0`, exit 1, naming both.

## Known residual

The hidepid guard is **not** verified against a real hidepid mount —
`unshare --mount-proc` is not available in this container. The regex gap it
closes is measured; how a given kernel renders the option into `/proc/mounts` is
inferred from the documented option vocabulary.
