### PR TITLE
fix(hooks): make the scheduled-review block name its own cause instead of guessing

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -889,11 +889,29 @@ findings below, a gated `gh pr merge`:
   names the PR's current head — so if any required routine never ran, ran on a stale
   commit, or was rate-limited, the merge blocks (naming the missing kinds). An ADVISORY
   routine still posts its review on the PR to be read/addressed, but its absence does not
-  block. If a required routine is pending or rate-limited, wait for it, or
-  append `# scheduled-review-override` to merge anyway (the conscious "merge without the
-  scheduled reviews" case). The marker means "ran **clean**", not merely "ran": a
+  block. A missing marker has **three causes needing different actions**, and the block
+  message now names which one you are in — do not guess:
+  (1) *no marker at any head* — nothing has run; on a freshly-opened PR a routine may
+  still be in flight, so **waiting is correct**;
+  (2) *a marker at an EARLIER head* — a routine ran, then a push moved the head. Routines
+  are generally not re-run on a push, so waiting is unlikely to help: re-review the
+  current head and post the marker by hand;
+  (3) *a marker AT this head that was REFUSED* — see the clean-verdict rule below.
+  Or append `# scheduled-review-override` to merge anyway (the conscious "merge without
+  the scheduled reviews" case). Head match is EXACT — no ancestor walk, no delta
+  tolerance, unlike the Codex freshness gate, which grants relief on a provably trivial
+  delta. That asymmetry is deliberate: the Codex classifier judges code-review
+  substantiality by file type and size, and an inferential leak lands in exactly the small
+  doc edit it would wave through. The marker means "ran **clean**", not merely "ran": a
   review whose body carries a blocking finding (`[P1]`/`HARD BLOCK`/`### ERROR`, unless a
   clean verdict overrides) is rejected, and DISMISSED/PENDING(draft) reviews don't count.
+  **ALWAYS end a genuinely-clean scheduled review with an explicit verdict line**
+  (`VERDICT: PASS`, or `PII/Secrets/Wording: CLEAN`). The blocking patterns are plain
+  substrings with no negation awareness, so prose like "not a hard block" or "no hard
+  blocks found" TRIPS them — measured on two 2026-08-28 PRs whose markers both contained
+  that phrase in negated prose; the one that also carried a clean-verdict line was
+  accepted and the one without it was silently refused. Without the verdict line a clean
+  review can be rejected on wording alone;
   Fail-closed: an unreadable comments/reviews fetch BLOCKS (never a false all-clear);
 - requires the PR base to equal the repo's default branch (retarget guard);
 - blocks unless mergeability is a definite `MERGEABLE` (a failed/unknown read

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2784,25 +2784,36 @@ def _check_scheduled_claude_reviewed_head(
     blocks. The merge path and the report path share this single fail-closed decision,
     so the report can never issue a false all-clear here.
 
-    WHY THE BLOCK MESSAGE BRANCHES. A missing marker has THREE causes calling for
-    DIFFERENT operator actions, all distinguishable from what was already read. Every
-    branch is scoped to the MISSING kinds — a marker for an already-satisfied kind
-    explains nothing about this block, and prescribing a remedy for it sends the operator
-    to fix something that is not broken:
-      * a marker for a missing kind AT THIS head that was REFUSED as not-clean → neither
-        waiting nor re-reviewing helps; the body's wording (or a real finding) is the
-        cause. Reported FIRST: its remedy is unique, and it is the cause most easily
-        mistaken for "nobody posted anything".
-      * a marker for a missing kind at some OTHER head, ACCEPTED OR REFUSED → a routine
-        ran, then a push moved the head. Routines are not generally re-run on a push, so
-        waiting is unlikely to help; re-review the current head and post the marker.
-      * no marker for the missing kind(s) at any head → nothing has run for them. On a
-        freshly-opened PR a routine may still be in flight, and waiting IS the right move.
+    WHY THE BLOCK MESSAGE PARTITIONS. A missing marker has THREE causes calling for
+    DIFFERENT operator actions, all distinguishable from what was already read. The
+    missing kinds are PARTITIONED across those causes and EVERY non-empty group is
+    reported — this is not a precedence chain that picks one winner:
+      * REFUSED at this head — a marker is present on the current commit but read as
+        carrying a blocking finding. Neither waiting nor re-reviewing helps; the body's
+        wording (or a real finding) is the cause. It is also the cause most easily
+        mistaken for "nobody posted anything", since the gate's `present:` line shows
+        the same `none` either way.
+      * ELSEWHERE — a marker for that kind sits on some OTHER head, ACCEPTED OR REFUSED.
+        A routine ran, then a push moved the head. Routines are not generally re-run on a
+        push, so waiting is unlikely to help; re-review the current head and post it.
+      * ABSENT — no marker for that kind at any head. Nothing has run for it, so on a
+        freshly-opened PR a routine may still be in flight and waiting IS the right move.
+
+    Two design rules earned by successive review rounds, both of the SAME shape — a
+    decision made from only part of what had been read. Keep them:
+      1. Scope every group to ``missing``. A marker for an already-satisfied kind explains
+         nothing about this block, and prescribing a remedy for it sends the operator to
+         fix something that is not broken (it also let the message contradict its own
+         ``present:`` line one row above).
+      2. PARTITION rather than prioritise. Different kinds routinely fail for different
+         reasons — a refused ``code-review`` beside an absent ``leaks`` — and choosing a
+         single winning cause explained one kind while the other silently got no guidance
+         at all. Precedence exists only WITHIN a kind (refused-here beats elsewhere).
+
     An earlier draft collapsed everything into an unconditional "waiting will not clear
-    this", which was wrong for the third case and pushed the operator toward
+    this", which was wrong for the ABSENT case and pushed the operator toward
     ``# scheduled-review-override`` — i.e. toward waiving the IRREDUCIBLE leak gate — in
-    the one situation where patience was the correct answer. Keep the branches, and keep
-    them scoped to ``missing``.
+    the one situation where patience was the correct answer.
 
     The message deliberately reports only what it OBSERVED (which heads carry markers)
     and hedges the schedule ("generally not re-run"). The routines live OUTSIDE this repo
@@ -2862,64 +2873,67 @@ def _check_scheduled_claude_reviewed_head(
     # Every branch below is scoped to the MISSING kinds. A marker for a kind that is
     # already satisfied says nothing about why this merge is blocked, and prescribing a
     # remedy for it sends the operator to fix something that is not broken.
+    # PARTITION the missing kinds by cause and report EVERY group — never pick one cause
+    # for the whole block. Different kinds routinely fail for different reasons (a refused
+    # code-review alongside an absent leaks), and collapsing to a single winner explains
+    # one kind while the other silently gets no guidance at all. THREE successive review
+    # findings on this function were that same shape — a branch deciding from part of what
+    # had been read — so this is the general form rather than a fourth point patch: a total
+    # partition needs no precedence BETWEEN groups, only within a single kind.
     missing_set = set(missing)
-    refused_here = sorted(rejected.get(head, set()) & missing_set)
-    # Any marker for a missing kind on some OTHER head — ACCEPTED OR REFUSED. Both prove a
-    # routine ran on a different commit, which is the whole content of this branch; only
-    # counting accepted ones sent a refused-at-a-stale-head PR down the "nothing has run,
-    # wait for it" path, i.e. straight back into the wrong-advice bug.
-    other_heads = sorted(
-        {
-            h[:12]
-            for by_head in (markers, rejected)
-            for h, kinds in by_head.items()
-            if h != head and (kinds & missing_set)
-        }
-    )
-    shown = ", ".join(other_heads[:3]) + (
-        f" (+{len(other_heads) - 3} more)" if len(other_heads) > 3 else ""
-    )
-    if refused_here:
-        # A marker IS present on this exact head — it was refused for reading as not-clean.
-        # Reported first: it is the only cause whose remedy is neither waiting nor
-        # re-reviewing, and the one most easily mistaken for "nobody posted anything".
-        cause = (
-            f"A marker for {', '.join(refused_here)} IS present at THIS head, but it was "
-            f"REFUSED because its body reads as carrying a blocking finding "
-            f"(matches one of [P1] / HARD BLOCK / an '### ERROR' heading) without an "
-            f"explicit clean verdict to override it. A marker must mean it ran clean, not "
-            f"merely that it ran. If the review really was clean, the prose tripped the "
-            f"check — re-post it ending with an explicit verdict line, exactly "
-            f"'VERDICT: PASS' or 'PII/Secrets/Wording: CLEAN'. If the finding is real, fix "
-            f"it first."
+    refused_kinds = rejected.get(head, set()) & missing_set
+    # A marker for a missing kind on some OTHER head — ACCEPTED OR REFUSED. Both prove a
+    # routine ran on a different commit; counting only accepted ones sent a
+    # refused-at-a-stale-head PR down the "nothing has run, wait for it" path.
+    heads_by_kind: dict[str, set[str]] = {}
+    for by_head in (markers, rejected):
+        for other_head, kinds in by_head.items():
+            if other_head == head:
+                continue
+            for kind in kinds & missing_set:
+                heads_by_kind.setdefault(kind, set()).add(other_head[:12])
+    # Within a KIND, refused-at-this-head wins: it is the most specific cause, and the only
+    # one whose remedy is neither waiting nor re-reviewing.
+    elsewhere_kinds = {k for k in missing_set - refused_kinds if k in heads_by_kind}
+    absent_kinds = missing_set - refused_kinds - elsewhere_kinds
+
+    parts: list[str] = []
+    if refused_kinds:
+        parts.append(
+            f"{', '.join(sorted(refused_kinds))} — a marker IS present at THIS head, but it "
+            f"was REFUSED because its body reads as carrying a blocking finding (matching "
+            f"one of [P1] / HARD BLOCK / an '### ERROR' heading) with no explicit clean "
+            f"verdict to override it. A marker must mean it ran CLEAN, not merely that it "
+            f"ran. If the review really was clean, its prose tripped the check — re-post it "
+            f"ending with an explicit verdict line, exactly 'VERDICT: PASS' or "
+            f"'PII/Secrets/Wording: CLEAN'. If the finding is real, fix it first."
         )
-    elif other_heads:
-        cause = (
-            f"A marker for the missing kind(s) is present for a DIFFERENT head ({shown}), "
-            f"so a routine HAS run on this PR — just not on the current commit. Routines "
-            f"are generally not re-run when a later push moves the head, so waiting is "
-            f"unlikely to clear this on its own: re-run the missing review(s) against the "
-            f"current head and post the marker yourself."
+    if elsewhere_kinds:
+        seen = sorted({h for k in elsewhere_kinds for h in heads_by_kind[k]})
+        shown = ", ".join(seen[:3]) + (f" (+{len(seen) - 3} more)" if len(seen) > 3 else "")
+        parts.append(
+            f"{', '.join(sorted(elsewhere_kinds))} — a marker is present for a DIFFERENT "
+            f"head ({shown}), so a routine HAS run on this PR, just not on the current "
+            f"commit. Routines are generally not re-run when a later push moves the head, "
+            f"so waiting is unlikely to clear this on its own: re-run against the current "
+            f"head and post the marker yourself."
         )
-    else:
-        # Scoped to the missing kinds on purpose: with more than one required kind, a
-        # blanket "no marker at ANY head" contradicts the `present:` list on the line above
-        # whenever another kind is already satisfied.
-        cause = (
-            f"No marker for {', '.join(missing)} is present at ANY head on this PR yet. If "
-            f"it was just opened, a routine may still be in flight — wait for it. If it "
-            f"has been open a while, re-run the missing review(s) against the current head "
-            f"and post the marker yourself."
+    if absent_kinds:
+        parts.append(
+            f"{', '.join(sorted(absent_kinds))} — no marker at ANY head on this PR yet. If "
+            f"it was just opened, a routine may still be in flight, and waiting IS the right "
+            f"move. If it has been open a while, re-run against the current head and post "
+            f"the marker yourself."
         )
     return (
         f"scheduled Claude review(s) missing at head {head[:12]}: {', '.join(missing)} "
         f"(required: {', '.join(required)}; present: "
         f"{', '.join(sorted(kinds_here)) or 'none'}).\n"
-        f"{cause}\n"
-        f"A marker is a comment/review by the repo OWNER carrying "
+        + "".join(f"  * {p}\n" for p in parts)
+        + "A marker is a comment/review by the repo OWNER carrying "
         f"'<!-- genesis-scheduled-review: head={head} kind=<name> -->' — the FULL 40-hex "
-        f"head, exactly as written here.\n"
-        f"Or append '# scheduled-review-override' to merge without the missing review(s)."
+        "head, exactly as written here.\n"
+        "Or append '# scheduled-review-override' to merge without the missing review(s)."
     )
 
 

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2696,10 +2696,16 @@ def _scheduled_review_rows(pr_num: str, repo: str | None = None) -> list[dict] |
     return rows
 
 
-def _scheduled_review_markers(pr_num: str, repo: str | None = None) -> dict[str, set[str]] | None:
-    """Map of ``head-sha -> {kinds}`` from valid owner-authored scheduled-review markers
-    on the PR, or ``None`` on an UNREADABLE fetch (the caller fail-closes on both None
-    and an empty map — None only distinguishes "could not read" from "read, no marker").
+def _scheduled_review_marker_scan(
+    pr_num: str, repo: str | None = None
+) -> tuple[dict[str, set[str]], dict[str, set[str]]] | None:
+    """``(accepted, rejected_not_clean)`` maps of ``head-sha -> {kinds}`` for the PR's
+    owner-authored scheduled-review markers, or ``None`` on an UNREADABLE fetch.
+
+    Both maps come from ONE pass so they cannot drift apart. ``accepted`` is what the
+    gate honours; ``rejected_not_clean`` is markers that parsed fine and named a head,
+    but whose body read as carrying a blocking finding. Only the DIAGNOSTIC message
+    consumes the second map — it never widens what satisfies the gate.
 
     A marker is trusted only when its author is the repo OWNER: ``login == owner`` OR
     ``author_association == "OWNER"`` (belt-and-suspenders — the marker itself is the
@@ -2716,7 +2722,8 @@ def _scheduled_review_markers(pr_num: str, repo: str | None = None) -> dict[str,
     except Exception:
         owner_repo = repo
     owner = (owner_repo.split("/")[0] if owner_repo else "").lower() or None
-    by_head: dict[str, set[str]] = {}
+    accepted: dict[str, set[str]] = {}
+    rejected: dict[str, set[str]] = {}
     for row in rows:
         login = (row.get("login") or "").lower()
         assoc = (row.get("author_association") or "").upper()
@@ -2735,10 +2742,16 @@ def _scheduled_review_markers(pr_num: str, repo: str | None = None) -> dict[str,
         # gate. Owner-authored review bodies are never seen by _check_pr_review_findings
         # (bots only), so without this a scheduled reviewer that explicitly BLOCKED would
         # still stamp its marker and slip the merge through.
-        if any(p.search(body) for p in _BLOCKING_PATTERNS) and not any(
+        #
+        # Such a marker is RECORDED (not dropped on the floor) so the block message can
+        # tell "you posted one and it was rejected" apart from "nobody posted anything" —
+        # measured 2026-08-28: those two produced the identical `present: none` line, and
+        # the only signal distinguishing an accepted marker from a rejected one was
+        # whether its prose happened to contain a _CLEAN_PATTERNS phrase.
+        not_clean = any(p.search(body) for p in _BLOCKING_PATTERNS) and not any(
             c.search(body) for c in _CLEAN_PATTERNS
-        ):
-            continue
+        )
+        target = rejected if not_clean else accepted
         # Defense-in-depth follow-up: for rows from /pulls/N/reviews we could ALSO
         # cross-check GitHub's authoritative `commit_id` vs the marker sha (issue comments
         # carry none). Deferred (LOW): the marker sha is matched EXACTLY vs the authoritative
@@ -2748,8 +2761,8 @@ def _scheduled_review_markers(pr_num: str, repo: str | None = None) -> dict[str,
             kind_m = _SCHEDULED_REVIEW_KIND_RE.search(block)
             if not head_m or not kind_m:
                 continue  # a marker must name both a head AND a kind to count
-            by_head.setdefault(head_m.group(1).lower(), set()).add(kind_m.group(1).lower())
-    return by_head
+            target.setdefault(head_m.group(1).lower(), set()).add(kind_m.group(1).lower())
+    return accepted, rejected
 
 
 def _check_scheduled_claude_reviewed_head(
@@ -2765,11 +2778,45 @@ def _check_scheduled_claude_reviewed_head(
     40-char), else a BLOCK MESSAGE naming the MISSING kinds.
 
     Fail-CLOSED — this gate never passes on absence of positive evidence: if the head
-    cannot be read, or the comment/review fetch errors (``_scheduled_review_markers`` →
+    cannot be read, or the comment/review fetch errors (``_scheduled_review_marker_scan`` →
     None), the merge is BLOCKED. A read that simply does not carry every required kind
     at this head (a routine didn't run, ran on a stale commit, or was rate-limited) also
     blocks. The merge path and the report path share this single fail-closed decision,
     so the report can never issue a false all-clear here.
+
+    WHY THE BLOCK MESSAGE BRANCHES. A missing marker has THREE causes calling for
+    DIFFERENT operator actions, all distinguishable from what was already read. Every
+    branch is scoped to the MISSING kinds — a marker for an already-satisfied kind
+    explains nothing about this block, and prescribing a remedy for it sends the operator
+    to fix something that is not broken:
+      * a marker for a missing kind AT THIS head that was REFUSED as not-clean → neither
+        waiting nor re-reviewing helps; the body's wording (or a real finding) is the
+        cause. Reported FIRST: its remedy is unique, and it is the cause most easily
+        mistaken for "nobody posted anything".
+      * a marker for a missing kind at some OTHER head, ACCEPTED OR REFUSED → a routine
+        ran, then a push moved the head. Routines are not generally re-run on a push, so
+        waiting is unlikely to help; re-review the current head and post the marker.
+      * no marker for the missing kind(s) at any head → nothing has run for them. On a
+        freshly-opened PR a routine may still be in flight, and waiting IS the right move.
+    An earlier draft collapsed everything into an unconditional "waiting will not clear
+    this", which was wrong for the third case and pushed the operator toward
+    ``# scheduled-review-override`` — i.e. toward waiving the IRREDUCIBLE leak gate — in
+    the one situation where patience was the correct answer. Keep the branches, and keep
+    them scoped to ``missing``.
+
+    The message deliberately reports only what it OBSERVED (which heads carry markers)
+    and hedges the schedule ("generally not re-run"). The routines live OUTSIDE this repo
+    and this gate cannot see their triggers, so an unconditional claim about when they
+    fire would be asserting a guarantee the code cannot back — and would become actively
+    misleading on an install that also runs them on ``synchronize``.
+
+    Head match is EXACT — there is no ancestor walk and no delta tolerance here, unlike
+    the Codex freshness gate, which grants relief on a provably trivial delta via
+    ``_classify_post_review_delta``. That asymmetry is deliberate for now: that
+    classifier judges CODE-REVIEW substantiality by file type and size, and an
+    inferential leak (household/schedule/habit detail, not a token a regex can catch)
+    arrives in exactly the small doc edit it would wave through. A leak-specific
+    tolerance is tracked separately; do not reuse the code-review classifier for it.
 
     SCOPE: this gate enforces ONLY for a merge targeting the configured PUBLIC repo
     (``_scheduled_gate_applies`` / ``_canonical_public_repo``). A merge to any other
@@ -2796,7 +2843,8 @@ def _check_scheduled_claude_reviewed_head(
             f"reviews (GitHub query failed).\n"
             f"Retry, or append '# scheduled-review-override' to merge anyway."
         )
-    markers = _scheduled_review_markers(pr_num, repo=repo)
+    scan = _scheduled_review_marker_scan(pr_num, repo=repo)
+    markers, rejected = (None, {}) if scan is None else scan
     if markers is None:
         return (
             f"could not read PR #{pr_num}'s comments/reviews to verify the scheduled Claude "
@@ -2808,14 +2856,70 @@ def _check_scheduled_claude_reviewed_head(
     missing = [k for k in required if k not in kinds_here]
     if not missing:
         return None
+    # WHY the marker is missing decides whether waiting is useful, and the two causes are
+    # DISTINGUISHABLE from what was actually read — so report the observed state instead
+    # of asserting a routine schedule this repo cannot see (the routines live outside it).
+    # Every branch below is scoped to the MISSING kinds. A marker for a kind that is
+    # already satisfied says nothing about why this merge is blocked, and prescribing a
+    # remedy for it sends the operator to fix something that is not broken.
+    missing_set = set(missing)
+    refused_here = sorted(rejected.get(head, set()) & missing_set)
+    # Any marker for a missing kind on some OTHER head — ACCEPTED OR REFUSED. Both prove a
+    # routine ran on a different commit, which is the whole content of this branch; only
+    # counting accepted ones sent a refused-at-a-stale-head PR down the "nothing has run,
+    # wait for it" path, i.e. straight back into the wrong-advice bug.
+    other_heads = sorted(
+        {
+            h[:12]
+            for by_head in (markers, rejected)
+            for h, kinds in by_head.items()
+            if h != head and (kinds & missing_set)
+        }
+    )
+    shown = ", ".join(other_heads[:3]) + (
+        f" (+{len(other_heads) - 3} more)" if len(other_heads) > 3 else ""
+    )
+    if refused_here:
+        # A marker IS present on this exact head — it was refused for reading as not-clean.
+        # Reported first: it is the only cause whose remedy is neither waiting nor
+        # re-reviewing, and the one most easily mistaken for "nobody posted anything".
+        cause = (
+            f"A marker for {', '.join(refused_here)} IS present at THIS head, but it was "
+            f"REFUSED because its body reads as carrying a blocking finding "
+            f"(matches one of [P1] / HARD BLOCK / an '### ERROR' heading) without an "
+            f"explicit clean verdict to override it. A marker must mean it ran clean, not "
+            f"merely that it ran. If the review really was clean, the prose tripped the "
+            f"check — re-post it ending with an explicit verdict line, exactly "
+            f"'VERDICT: PASS' or 'PII/Secrets/Wording: CLEAN'. If the finding is real, fix "
+            f"it first."
+        )
+    elif other_heads:
+        cause = (
+            f"A marker for the missing kind(s) is present for a DIFFERENT head ({shown}), "
+            f"so a routine HAS run on this PR — just not on the current commit. Routines "
+            f"are generally not re-run when a later push moves the head, so waiting is "
+            f"unlikely to clear this on its own: re-run the missing review(s) against the "
+            f"current head and post the marker yourself."
+        )
+    else:
+        # Scoped to the missing kinds on purpose: with more than one required kind, a
+        # blanket "no marker at ANY head" contradicts the `present:` list on the line above
+        # whenever another kind is already satisfied.
+        cause = (
+            f"No marker for {', '.join(missing)} is present at ANY head on this PR yet. If "
+            f"it was just opened, a routine may still be in flight — wait for it. If it "
+            f"has been open a while, re-run the missing review(s) against the current head "
+            f"and post the marker yourself."
+        )
     return (
         f"scheduled Claude review(s) missing at head {head[:12]}: {', '.join(missing)} "
         f"(required: {', '.join(required)}; present: "
         f"{', '.join(sorted(kinds_here)) or 'none'}).\n"
-        f"Each routine posts a comment/review carrying "
-        f"'<!-- genesis-scheduled-review: head=<sha> kind=<name> -->' once it runs on THIS "
-        f"exact commit — wait for the missing routine(s) to run on the current head, or "
-        f"append '# scheduled-review-override' to merge without them."
+        f"{cause}\n"
+        f"A marker is a comment/review by the repo OWNER carrying "
+        f"'<!-- genesis-scheduled-review: head={head} kind=<name> -->' — the FULL 40-hex "
+        f"head, exactly as written here.\n"
+        f"Or append '# scheduled-review-override' to merge without the missing review(s)."
     )
 
 

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1191,13 +1191,13 @@ class TestScheduledGateBlockMessageBranchesOnCause:
     def test_stale_marker_says_waiting_is_unlikely_to_help(self, monkeypatch):
         msg = self._block_msg(monkeypatch, self._marker_at(OTHER_HEAD)).lower()
         assert "unlikely to clear this" in msg
-        assert "re-run the missing review" in msg
+        assert "re-run against the current head" in msg
 
     def test_stale_marker_does_not_tell_the_operator_to_wait(self, monkeypatch):
         """The failure this branch exists to prevent: advice-to-wait on a pushed head."""
         msg = self._block_msg(monkeypatch, self._marker_at(OTHER_HEAD)).lower()
         assert "may still be in flight" not in msg
-        assert "wait for it" not in msg
+        assert "waiting is the right move" not in msg
 
     def test_stale_marker_names_the_head_that_was_actually_reviewed(self, monkeypatch):
         """Evidence, not assertion — the operator sees which commit DID get reviewed."""
@@ -1208,7 +1208,7 @@ class TestScheduledGateBlockMessageBranchesOnCause:
     def test_no_marker_anywhere_says_waiting_may_be_correct(self, monkeypatch):
         msg = self._block_msg(monkeypatch, "").lower()
         assert "may still be in flight" in msg
-        assert "wait for it" in msg
+        assert "waiting is the right move" in msg
 
     def test_no_marker_anywhere_does_not_claim_waiting_is_futile(self, monkeypatch):
         """Regression guard for the overcorrection this class documents."""
@@ -1245,8 +1245,8 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         the identical comment, when the body's WORDING is what refused it."""
         msg = self._block_msg(monkeypatch, self._marker_at(HEAD, self.REFUSED_PROSE)).lower()
         assert "may still be in flight" not in msg
-        assert "wait for it" not in msg
-        assert "already present for a different head" not in msg
+        assert "waiting is the right move" not in msg
+        assert "present for a different head" not in msg
 
     def test_a_clean_verdict_line_makes_the_same_marker_pass(self, monkeypatch):
         """The remedy the message prescribes must actually work — end to end."""
@@ -1281,7 +1281,7 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         """
         msg = self._block_msg(monkeypatch, self._marker_at(OTHER_HEAD, self.REFUSED_PROSE))
         assert OTHER_HEAD[:12] in msg
-        assert "DIFFERENT head" in msg
+        assert "a marker is present for a DIFFERENT head" in msg
         assert "may still be in flight" not in msg.lower()
 
     def test_partial_acceptance_does_not_contradict_the_present_line(self, monkeypatch):
@@ -1296,7 +1296,7 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
         assert msg and "present: code-review" in msg
         assert "at ANY head" in msg, "the no-marker branch is still the right one here"
-        assert "No marker for leaks" in msg, "must be scoped to the MISSING kind"
+        assert "leaks — no marker at ANY head" in msg, "must be scoped to the MISSING kind"
 
     def test_refused_marker_for_an_already_satisfied_kind_does_not_hijack_the_message(
         self, monkeypatch
@@ -1319,7 +1319,54 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
         assert msg and "code-review" in msg
         assert "REFUSED" not in msg, "the refused kind is already satisfied — not the cause"
-        assert "No marker for code-review" in msg
+        assert "code-review — no marker at ANY head" in msg
+
+    def test_mixed_causes_report_every_missing_kind_not_just_one(self, monkeypatch):
+        """Two missing kinds failing for DIFFERENT reasons must BOTH get guidance.
+
+        The regression this guards: picking a single winning cause for the whole block
+        explained one kind and left the other with no guidance at all. Three successive
+        review findings on this function were that same shape (a decision made from part
+        of what had been read), which is why the causes are now a total PARTITION over
+        the missing kinds rather than a precedence chain.
+        """
+        comments = "\n".join(
+            [
+                self._marker_kind(HEAD, "code-review", self.REFUSED_PROSE),
+                self._marker_kind(OTHER_HEAD, "leaks"),
+            ]
+        )
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", comments)
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
+        msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+        assert msg
+        # code-review: refused AT this head -> the verdict-line remedy.
+        assert "code-review — a marker IS present at THIS head" in msg
+        assert "VERDICT: PASS" in msg
+        # leaks: present at an EARLIER head -> the re-review remedy, naming that head.
+        assert "leaks — a marker is present for a DIFFERENT head" in msg
+        assert OTHER_HEAD[:12] in msg
+        # Neither kind may be silently dropped.
+        assert msg.count("  * ") == 2, "one bullet per cause group, both present"
+
+    def test_three_way_split_reports_all_three_causes(self, monkeypatch):
+        """The full partition: refused here, present elsewhere, and absent — at once."""
+        third = "2" * 40
+        comments = "\n".join(
+            [
+                self._marker_kind(HEAD, "code-review", self.REFUSED_PROSE),
+                self._marker_kind(third, "leaks"),
+            ]
+        )
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", comments)
+        # A third required kind nothing has ever posted for.
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
+        msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+        assert msg and msg.count("  * ") == 2
+        assert "code-review — a marker IS present at THIS head" in msg
+        assert "leaks — a marker is present for a DIFFERENT head" in msg
 
     # -- shared: what ALL branches must still carry -----------------------------
     @pytest.mark.parametrize("which", ["stale", "empty", "refused"])

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1151,3 +1151,188 @@ class TestScheduledGateUsesRequiredKinds:
         self._setup(monkeypatch, ["code-review"], "code-review")  # config omits leaks
         msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
         assert msg and "leaks" in msg
+
+
+OTHER_HEAD = "1111111111111111111111111111111111111111"
+
+
+class TestScheduledGateBlockMessageBranchesOnCause:
+    """A missing marker has two causes needing OPPOSITE actions; the message must branch.
+
+    * markers exist for OTHER heads -> a routine ran, then a push moved the head. Waiting
+      is unlikely to help; re-review the current head and post the marker by hand.
+    * no marker at ANY head -> nothing has run. On a freshly-opened PR a routine may
+      still be in flight, and WAITING IS THE CORRECT ACTION.
+
+    An earlier draft asserted an unconditional "waiting will not clear this". That was
+    false in the second case and steered the operator toward the override sigil — i.e.
+    toward waiving the IRREDUCIBLE leak gate — in the one situation where patience was
+    the right answer.
+
+    Each test asserts what its branch ADVISES *and* that it does not carry the other
+    branch's advice, so a reworded regression that flips the guidance fails instead of
+    sliding through on surviving substrings.
+    """
+
+    @staticmethod
+    def _marker_at(head, prose="scheduled review done."):
+        body = f"{prose}\n<!-- genesis-scheduled-review: head={head} kind=leaks -->"
+        return json.dumps({"login": "owner", "author_association": "OWNER", "body": body})
+
+    def _block_msg(self, monkeypatch, comments):
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", comments)
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+        msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+        assert msg, "a head without the required marker must block"
+        return msg
+
+    # -- branch 1: a marker exists, but for an earlier head ---------------------
+    def test_stale_marker_says_waiting_is_unlikely_to_help(self, monkeypatch):
+        msg = self._block_msg(monkeypatch, self._marker_at(OTHER_HEAD)).lower()
+        assert "unlikely to clear this" in msg
+        assert "re-run the missing review" in msg
+
+    def test_stale_marker_does_not_tell_the_operator_to_wait(self, monkeypatch):
+        """The failure this branch exists to prevent: advice-to-wait on a pushed head."""
+        msg = self._block_msg(monkeypatch, self._marker_at(OTHER_HEAD)).lower()
+        assert "may still be in flight" not in msg
+        assert "wait for it" not in msg
+
+    def test_stale_marker_names_the_head_that_was_actually_reviewed(self, monkeypatch):
+        """Evidence, not assertion — the operator sees which commit DID get reviewed."""
+        msg = self._block_msg(monkeypatch, self._marker_at(OTHER_HEAD))
+        assert OTHER_HEAD[:12] in msg
+
+    # -- branch 2: nothing has ever posted --------------------------------------
+    def test_no_marker_anywhere_says_waiting_may_be_correct(self, monkeypatch):
+        msg = self._block_msg(monkeypatch, "").lower()
+        assert "may still be in flight" in msg
+        assert "wait for it" in msg
+
+    def test_no_marker_anywhere_does_not_claim_waiting_is_futile(self, monkeypatch):
+        """Regression guard for the overcorrection this class documents."""
+        msg = self._block_msg(monkeypatch, "").lower()
+        assert "unlikely to clear this" not in msg
+        assert "will not clear" not in msg
+
+    # -- branch 3: a marker IS at this head, but was refused as not-clean -------
+    # MEASURED on PR #1521 (2026-08-28): an owner marker at the exact head, body
+    # "...not a hard block.", was refused by the HARD\\s+BLOCK pattern (which is
+    # negation-blind) with no clean phrase to override — and the gate reported
+    # "present: none", identical to nobody having posted anything.
+    REFUSED_PROSE = "Reviewed the diff. The config value is not a hard block."
+
+    def test_refused_marker_says_a_marker_is_present_at_this_head(self, monkeypatch):
+        msg = self._block_msg(monkeypatch, self._marker_at(HEAD, self.REFUSED_PROSE))
+        assert "IS present at THIS head" in msg
+        assert "REFUSED" in msg
+
+    def test_refused_marker_gives_the_remedy_a_clean_verdict_line(self, monkeypatch):
+        """The remedy is neither waiting nor re-reviewing — it is the verdict line.
+
+        Asserts the two remedy strings VERBATIM and conjunctively. An earlier version
+        used `"VERDICT: PASS" in msg or "CLEAN" in msg`, which could never fail inside
+        this branch: the branch's own fixed prose contains the word CLEAN, so the second
+        disjunct held even with the remedy sentence deleted entirely.
+        """
+        msg = self._block_msg(monkeypatch, self._marker_at(HEAD, self.REFUSED_PROSE))
+        assert "VERDICT: PASS" in msg
+        assert "PII/Secrets/Wording: CLEAN" in msg
+
+    def test_refused_marker_does_not_give_the_other_branches_advice(self, monkeypatch):
+        """The failure this branch exists to prevent: being told to wait, or to re-post
+        the identical comment, when the body's WORDING is what refused it."""
+        msg = self._block_msg(monkeypatch, self._marker_at(HEAD, self.REFUSED_PROSE)).lower()
+        assert "may still be in flight" not in msg
+        assert "wait for it" not in msg
+        assert "already present for a different head" not in msg
+
+    def test_a_clean_verdict_line_makes_the_same_marker_pass(self, monkeypatch):
+        """The remedy the message prescribes must actually work — end to end."""
+        prose = self.REFUSED_PROSE + "\n\nVERDICT: PASS"
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", self._marker_at(HEAD, prose))
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+        assert (
+            _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub") is None
+        )
+
+    def test_a_refused_marker_never_satisfies_the_gate(self, monkeypatch):
+        """The diagnostic must not have widened what passes: refused still blocks."""
+        msg = self._block_msg(monkeypatch, self._marker_at(HEAD, self.REFUSED_PROSE))
+        assert msg, "a refused marker must still BLOCK, not merely warn"
+
+    # -- misroutes: states that fell into the WRONG branch ----------------------
+    # Each of these reproduced a real misdiagnosis: the branch logic consulted only part
+    # of what had been read, so the operator got another branch's advice. That is the
+    # exact defect class this change exists to remove, one hop away from where it started.
+
+    @staticmethod
+    def _marker_kind(head, kind, prose="scheduled review done."):
+        body = f"{prose}\n<!-- genesis-scheduled-review: head={head} kind={kind} -->"
+        return json.dumps({"login": "owner", "author_association": "OWNER", "body": body})
+
+    def test_refused_marker_at_a_stale_head_is_not_reported_as_nothing_ran(self, monkeypatch):
+        """A REFUSED marker at an earlier head still proves a routine ran on this PR.
+
+        Counting only ACCEPTED markers when looking for other heads sent this state down
+        the "nothing has run — wait for it" path: wrong claim AND wrong advice.
+        """
+        msg = self._block_msg(monkeypatch, self._marker_at(OTHER_HEAD, self.REFUSED_PROSE))
+        assert OTHER_HEAD[:12] in msg
+        assert "DIFFERENT head" in msg
+        assert "may still be in flight" not in msg.lower()
+
+    def test_partial_acceptance_does_not_contradict_the_present_line(self, monkeypatch):
+        """With >1 required kind, one satisfied kind must not yield 'no marker at ANY head'.
+
+        The header lists `present: code-review` — a blanket "no marker at ANY head" on the
+        next line contradicts it. Fires on the SHIPPED DEFAULT required set, not an edge.
+        """
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", self._marker_kind(HEAD, "code-review"))
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
+        msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+        assert msg and "present: code-review" in msg
+        assert "at ANY head" in msg, "the no-marker branch is still the right one here"
+        assert "No marker for leaks" in msg, "must be scoped to the MISSING kind"
+
+    def test_refused_marker_for_an_already_satisfied_kind_does_not_hijack_the_message(
+        self, monkeypatch
+    ):
+        """A refused marker whose kind is NOT missing must not drive the remedy.
+
+        leaks is satisfied by a clean marker at HEAD; a second, refused leaks marker also
+        sits at HEAD; code-review is what is actually missing. Prescribing "re-post the
+        leaks marker with a verdict line" fixes nothing and leaves the real gap unguided.
+        """
+        comments = "\n".join(
+            [
+                self._marker_kind(HEAD, "leaks"),
+                self._marker_kind(HEAD, "leaks", self.REFUSED_PROSE),
+            ]
+        )
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", comments)
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
+        msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+        assert msg and "code-review" in msg
+        assert "REFUSED" not in msg, "the refused kind is already satisfied — not the cause"
+        assert "No marker for code-review" in msg
+
+    # -- shared: what ALL branches must still carry -----------------------------
+    @pytest.mark.parametrize("which", ["stale", "empty", "refused"])
+    def test_every_branch_gives_the_full_head_and_marker_grammar(self, monkeypatch, which):
+        """Route 1 is unusable without the FULL 40-hex head; the summary line shows 12."""
+        comments = {
+            "stale": self._marker_at(OTHER_HEAD),
+            "empty": "",
+            "refused": self._marker_at(HEAD, self.REFUSED_PROSE),
+        }[which]
+        msg = self._block_msg(monkeypatch, comments)
+        assert f"head={HEAD}" in msg, "the full 40-hex head must be quoted verbatim"
+        assert "genesis-scheduled-review" in msg
+        assert "kind=" in msg
+        assert "# scheduled-review-override" in msg
+        assert "leaks" in msg


### PR DESCRIPTION
## The problem

A merge blocked by the scheduled-review gate told the operator to *"wait for the missing routine(s) to run on the current head"*. The routine runs when the PR is **opened**; a later push moves the head and invalidates the marker it stamped. Waiting could never clear the block, and the message left the two routes that could — re-review the current head and post the marker, or `# scheduled-review-override` — undiscoverable from the block itself.

At the time of writing, 21 of 26 open PRs were sitting on this gate.

## Why the obvious fix is also wrong

Replacing it with an unconditional *"waiting will not clear this"* is the same mistake pointed the other way. On a freshly-opened PR a routine really is still in flight, and telling the operator otherwise steers them toward the override sigil — that is, toward waiving the **irreducible leak gate** — in the one case where patience is correct.

## What this does

The message now branches on what was actually read, and every branch is scoped to the kinds that are **missing**:

| observed state | advice |
|---|---|
| a marker for a missing kind **at this head, refused as not-clean** | neither waiting nor re-reviewing helps — the body's wording, or a real finding, is the cause |
| a marker for a missing kind **at some other head** (accepted or refused) | a routine ran, then a push moved the head — re-review and re-post |
| **no marker for the missing kinds anywhere** | nothing has run yet; on a new PR, wait |

The refused case was previously invisible. Such a marker was dropped on the floor, and the gate then reported `present: none` — the identical line it prints when nobody posted anything at all. An owner marker sitting at the exact head read as absent, and the remedy the message prescribed (post a marker at this head) was already done.

`_scheduled_review_marker_scan` now records refused markers alongside accepted ones in a single pass, so the message can tell the two apart. One pass rather than two readers, so the maps cannot drift.

## What is deliberately unchanged

**What satisfies the gate.** Same owner check, same DISMISSED/PENDING drop, same clean-verdict rule, same exact-head match, same fail-closed on an unreadable fetch. The `rejected` map is consumed only to choose the message and never reaches the verdict — pinned by a test asserting a refused marker still blocks.

## Why every branch is scoped to `missing`

Unscoped, two states misroute. Under the default required set, a satisfied kind's marker made the no-marker branch contradict the `present:` list one line above it. And a refused marker for an already-satisfied kind hijacked the remedy, sending the operator to fix something that was not broken while the actually-missing kind got no guidance.

## On asserting what the code cannot see

The message reports only what it observed and hedges the schedule ("generally not re-run"). The routines live outside this repo and the gate cannot see their triggers, so an unconditional claim about when they fire would assert a guarantee the code cannot back, and would go stale on an install that also runs them on `synchronize`.

## Two root causes tracked rather than fixed here

- **The blocking patterns are negation-blind.** `HARD\s+BLOCK` has no word boundary and no anchor, so prose reporting the *absence* of a finding trips it — "not a hard block", "no hard blocks found". That set is shared with the bot-review finding scanner, which makes changing it a security-adjacent edit deserving its own review. Mitigated meanwhile by this message plus a documented convention: always end a genuinely-clean scheduled review with an explicit verdict line.
- **The gate has no ancestor tolerance**, unlike the Codex freshness gate. That classifier judges code-review substantiality by file type and size, and an inferential leak arrives in exactly the small doc edit it would wave through — so it must not simply be reused here.

## Verification

- 516 tests pass across the three gate suites; `ruff` clean repo-wide.
- **Verify-RED, each fix defended individually rather than as a batch**: restoring the old message fails 4 of 5 tests; collapsing the branch fails exactly the 2 branch-2 tests; disabling the refused diagnostic fails exactly the 3 refused tests while the two asserting gate *behaviour* still pass; reverting the three scoping fixes fails exactly those three, one-to-one.
- **E2E against real PRs with live reads and no test seams** — all three states produce distinct, correct messages, and a passing control PR still reports no block.
- `_scheduled_review_markers` is removed rather than kept as a shim: the scan replaced its only caller and grep confirms none remain.
