### PR TITLE
fix(hooks): tell the author a merge is in progress — do not let one silence the gate

### DIFF
--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -18,6 +18,7 @@ import os
 import re
 import subprocess
 import sys
+from pathlib import Path
 
 # The shared hook-input helper lives in scripts/hooks/; this script runs from
 # scripts/ (a different sys.path[0]), so add the hooks dir before importing it.
@@ -593,6 +594,44 @@ def _worktree_root(cwd: str) -> str:
     return os.path.realpath(cwd)
 
 
+def _merge_note(cwd: str | None) -> str:
+    """A hint appended to a cap/mode-switch denial when a merge is mid-flight.
+
+    ADVISORY TEXT ONLY. Deliberately NOT wired into the verdict or the round
+    counter: those sentinels are unauthenticated files that any actor with shell
+    access can create (``echo x > .git/MERGE_HEAD``), and `git merge --no-commit`
+    leaves one indefinitely without any forgery at all. Keying an EXEMPTION off
+    them would let the actor this gate exists to constrain silence it
+    permanently with one write — measured: a forged sentinel froze the counter
+    across three further distinct defect rounds. Telling the author what the
+    gate can see is safe; letting that state decide the verdict is not.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            cwd=cwd, capture_output=True, text=True, timeout=5,
+        )
+        if out.returncode != 0 or not out.stdout.strip():
+            return ""
+        raw = out.stdout.strip()
+        git_dir = Path(raw) if Path(raw).is_absolute() else Path(cwd or ".") / raw
+        merging = any(
+            (git_dir / n).exists()
+            for n in ("MERGE_HEAD", "CHERRY_PICK_HEAD", "REVERT_HEAD")
+        ) or (git_dir / "rebase-merge").exists() or (git_dir / "rebase-apply").exists()
+    except (subprocess.SubprocessError, OSError, ValueError):
+        return ""
+    if not merging:
+        return ""
+    return (
+        "\n\nNOTE: a merge/rebase appears to be in progress. The round counter "
+        "keys on the staged diff, so pulling upstream in to resolve a conflict "
+        "reads as another round even though it adds no authored code. If this "
+        "commit IS only that merge, say so in the ack rather than treating it "
+        "as a real round."
+    )
+
+
 def main() -> None:
     # Parse tool input
     payload = read_payload()
@@ -822,6 +861,7 @@ def main() -> None:
                 "acknowledge that decision with a trailing shell comment (outside any "
                 "quotes):\n"
                 '  git commit -m "your message"  # escalation-ack'
+                + _merge_note(cwd)
             )
             return
         # Acked = a fresh decision to continue → reset the round budget so the next
@@ -865,6 +905,7 @@ def main() -> None:
                 "Then acknowledge you did the audit (not another blind patch) with a "
                 "trailing shell comment (outside any quotes):\n"
                 '  git commit -m "your message"  # audit-ack'
+                + _merge_note(cwd)
             )
             return
 

--- a/tests/test_hooks/test_escalation_cap.py
+++ b/tests/test_hooks/test_escalation_cap.py
@@ -492,3 +492,65 @@ def test_gate_fails_open_on_infinity_round(repo, home):
     rf.write_text('{"branch": "' + branch + '", "round": 1e999, "last_hash": "x"}')
     res = _run_hook('git commit -m "wip"', repo, home)
     assert res.returncode == 0, res.stdout + res.stderr
+
+
+# ── A merge must NOT be able to silence the counter ───────────────────────
+
+
+def _fabricate_merge_sentinel(repo: Path) -> None:
+    """One file write. No git command, no real merge."""
+    (repo / ".git" / "MERGE_HEAD").write_text("garbage-not-a-sha\n")
+
+
+def test_a_forged_merge_sentinel_cannot_freeze_the_counter(repo, _isolate_rounds):
+    """The counter must not trust unauthenticated on-disk state.
+
+    An earlier attempt at this exempted rounds whenever a merge sentinel was
+    present. Those sentinels are plain files: `echo x > .git/MERGE_HEAD` needs
+    no git command, and `git merge --no-commit` leaves one indefinitely with no
+    forgery at all. Measured against that version, a single write froze the
+    counter across three further distinct defect rounds — letting the exact
+    actor this gate constrains disable the anti-runaway cap permanently.
+
+    The exemption was abandoned for that reason. The gate now only MENTIONS a
+    merge in its denial text; it never lets one decide the verdict.
+    """
+    _stage(repo, "base = 1\nfix_one = True\n")
+    assert review_state.bump_review_round(str(repo)) == 1
+
+    _fabricate_merge_sentinel(repo)
+
+    _stage(repo, "base = 1\nfix_two = True\n")
+    assert review_state.bump_review_round(str(repo)) == 2, (
+        "a forged merge sentinel suppressed a real defect-bearing round"
+    )
+    _stage(repo, "base = 1\nfix_three = True\n")
+    assert review_state.bump_review_round(str(repo)) == 3, (
+        "the escalation cap can be silenced by writing a file"
+    )
+
+
+def test_a_real_merge_also_does_not_suppress_rounds(repo, _isolate_rounds):
+    """Not even a genuine merge exempts a round — by design.
+
+    A real conflicted merge is indistinguishable from a forged sentinel to any
+    check cheap enough to run in a hook, so the counter treats neither as
+    special. The cost is one ack on a merge commit; the alternative was a gate
+    that could be turned off silently.
+    """
+    _stage(repo, "base = 1\nfix_one = True\n")
+    assert review_state.bump_review_round(str(repo)) == 1
+
+    _git(repo, "checkout", "-q", "main")
+    (repo / "f.py").write_text("base = 1\nupstream = True\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "upstream")
+    _git(repo, "checkout", "-q", "feature/x")
+    (repo / "f.py").write_text("base = 1\nmine = True\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "mine")
+    subprocess.run(["git", "merge", "main"], cwd=repo, capture_output=True, text=True)
+    (repo / "f.py").write_text("base = 1\nmine = True\nupstream = True\n")
+    _git(repo, "add", "-A")
+
+    assert review_state.bump_review_round(str(repo)) == 2


### PR DESCRIPTION
## The problem

The review round counter keys on the staged diff, so pulling upstream changes
into a PR branch to resolve a conflict reads as another **defect-bearing review
round**. Seen live: a branch that had already completed its adversarial audit
went 1 → 2 purely from a CHANGELOG resolution that added no authored code, which
tripped the mode-switch gate and demanded an ack for a commit containing nothing
to audit.

That weakens the gate twice over — it burns the round budget on non-events, and
it trains the reflex of acking past the mode-switch and escalation blocks in
situations that don't warrant it, which is precisely the habit those gates exist
to prevent.

## What I tried first, and why it is not in this PR

The obvious fix is to exempt the round when git reports an in-flight merge.
That was written, reviewed, and **abandoned** — it makes the gate forgeable.

Those sentinels are plain files:

- `echo garbage > .git/MERGE_HEAD` — no git command at all — makes the exemption
  fire. Measured against that version, the counter stayed **frozen across three
  further genuinely distinct defect rounds**.
- No forgery is even required. `--no-commit --no-ff` leaves `MERGE_HEAD` until an
  explicit commit or abort, and a killed session leaves stale `MERGE_HEAD` /
  `rebase-merge` / `rebase-apply` that ordinary work never clears.

The actor this gate constrains is an agent with shell access to the same repo.
An anti-runaway cap that such an actor can disable with one write is worse than
the annoyance it removes — especially when an auditable escape already exists in
the ack comment, which leaves a trace in the command.

`scripts/review_state.py` is therefore **byte-identical to `origin/main`**.

## What ships

Advisory text only. When the mode-switch or escalation denial fires *and* a
merge appears to be in flight, the message says so and asks the author to note it
in the ack. The sentinel is read to **phrase** a denial, never to **decide** one:
the verdict, the counter and the ack requirement are unchanged.

Telling the author what the gate can see is safe. Letting that state pick the
verdict is not.

## Tests

They assert the property that matters, not the convenience:

- a **forged** sentinel does not suppress a round
- a **real** conflicted resolution does not either

Both would have failed against the abandoned design. 146 tests green across
`test_escalation_cap.py` and `test_review_enforcement_commit.py` — every
pre-existing gate test unchanged (direct-to-main, `--no-verify` in all bundled
forms, the cap, the mode-switch, chained cross-worktree commits, unresolvable
cwd).
