### PR TITLE
docs(skill): record three review lessons in genesis-development

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -205,10 +205,16 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   passed may be testing nothing; a whole suite passing every review round
   while a reviewer keeps finding real spec bugs is the tell that the tests
   encode the same wrong spec as the code.
-- **A RED that comes back GREEN is TWO hypotheses, not one.** Either the test is
-  vacuous, or the MUTATION silently failed to apply — and the second is common,
-  because the auto-formatter reflows lines and a `str.replace()` anchor written
-  from memory then matches nothing. The PRINCIPLE, which is what to remember:
+- **A RED that comes back GREEN is THREE hypotheses, not one.** The test is
+  vacuous; or the MUTATION silently failed to apply — common, because the
+  auto-formatter reflows lines and a `str.replace()` anchor written from memory
+  then matches nothing; or the mutation applied to a mechanism that a SIBLING
+  LAYER still enforces, so the invariant holds and the green is correct. The
+  third is the one that gets a sound test rewritten: when two layers produce the
+  same behaviour (see the duplicated-layer entry below), mutate the WHOLE
+  mechanism, not one of its halves. Rule out the second before suspecting the
+  first, and the third before touching the test at all. The PRINCIPLE, which is
+  what to remember:
   **every injection must prove it applied, by its own postcondition, before any
   result is read as RED.** Two corollaries follow, and both have bitten:
   prove it against the value THAT injection was handed, never against the
@@ -219,7 +225,15 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   `ast.parse` for Python, `bash -n` for shell — since an invalid mutation breaks
   collection and reads as a successful RED, while the wrong language's parser
   rejects a valid mutation and hides a real survivor. Restore from a file copy
-  taken beforehand, never `git checkout` — the work is uncommitted.
+  taken beforehand, never `git checkout` — the work is uncommitted — and make
+  that restore UNCONDITIONAL (`trap restore EXIT`, a `finally:`), never the tail
+  of an `&&` chain. The expected outcome here is a NONZERO exit, and under
+  `set -e` a trailing restore is exactly the statement that never runs (the
+  `out=$(cmd)` entry in Common Traps is the same mechanism), so the shape that
+  reads as careful leaves a deliberately-broken file in an uncommitted worktree
+  on the ordinary path — as well as on interruption or a tool timeout. Refuse to
+  start if the file already differs from the snapshot, and verify the restore by
+  hash rather than assuming it.
 - **Vacuous-test shapes to check for by name.** A test is vacuous when: its
   assertion is ALSO true on the success path (`assert x.blocked is False` where
   a successful call also returns False — assert the fact that DISTINGUISHES
@@ -675,8 +689,12 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
      construction redesign, narrow scope, or shelve.
   **Tabulate findings by CLASS before fixing — but never let that change what
   COUNTS.**
-  Before fixing anything in a second round, tabulate the findings with a CLASS
-  column. Findings that look unrelated one at a time routinely share one
+  Tabulate the findings with a CLASS column before fixing ANY round's findings,
+  including round ONE. Deferring the tabulation to the second round is what
+  spends a round discovering a shared cause that was visible in the first: if the
+  opening review returns several instances of one generator, an instance-level
+  first pass fixes the ones named and ships the rest as the next round's
+  findings. The tabulation is cheap and the round it saves is not. Findings that look unrelated one at a time routinely share one
   generator — five across three rounds once reduced to a single defect (two
   layers that had to agree about every lever and could not), and patching
   instances twice changed nothing while deleting the second layer removed all

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -205,6 +205,22 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   passed may be testing nothing; a whole suite passing every review round
   while a reviewer keeps finding real spec bugs is the tell that the tests
   encode the same wrong spec as the code.
+- **A RED that comes back GREEN is TWO hypotheses, not one.** Either the test is
+  vacuous, or the MUTATION silently failed to apply — and the second is common,
+  because the auto-formatter reflows lines and a `str.replace()` anchor written
+  from memory then matches nothing. So: `assert mutated != original` after every
+  injection, and `ast.parse()` it before writing (an invalid mutation breaks
+  collection, and that failure reads as a successful RED). Restore from a file
+  copy taken beforehand, never `git checkout` — the work is uncommitted.
+- **Vacuous-test shapes to check for by name.** A test is vacuous when: its
+  assertion is ALSO true on the success path (`assert x.blocked is False` where
+  a successful call also returns False — assert the fact that DISTINGUISHES
+  them); its setup short-circuits the path it names (passing an explicit
+  argument the code prefers over the env var under test); or its fixture never
+  creates the shape it claims (a `bash -c 'sleep 30 # marker'` decoy
+  exec-replaces itself and loses the marker from its argv — add a
+  guard-the-guard assert that the fixture really has the property). Ask of every
+  new test: *would this still pass if the mechanism it names were deleted?*
 - **Contested/subtle specs: write the expectations first.** When what-should-
   happen is itself under discussion (which keys count, which states clear an
   alarm), enumerate the expectation table as failing tests BEFORE implementing
@@ -649,6 +665,24 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
      cost), name the cap explicitly ("we've hit the 3-round escalation cap"),
      and get a FRESH decision: keep hardening, switch to a robust-by-
      construction redesign, narrow scope, or shelve.
+  **Count CLASSES, not findings, when judging whether the cap has fired.**
+  Before fixing anything in a second round, tabulate the findings with a CLASS
+  column. Findings that look unrelated one at a time routinely share one
+  generator — five across three rounds once reduced to a single defect (two
+  layers that had to agree about every lever and could not), and patching
+  instances twice changed nothing while deleting the second layer removed all
+  five at once. If one class has ≥2 entries, the fix is architectural. The count
+  that matters is "consecutive rounds surfacing a NEW class", not the finding
+  total.
+
+  A corollary that costs a round if missed: when you delete a duplicated layer,
+  verify the class is closed by enumerating the registry for the BEHAVIOUR, not
+  for the deleted file's NAME. A name-scoped guard beneath a class-scoped claim
+  passes happily while a sibling oracle sits on the same event and matcher.
+  (And if the invariant turns out not to be statically checkable, say so and
+  narrow the test to what it can prove — a guard that cries wolf gets deleted by
+  whoever hits it next.)
+
   These three are backstopped by a **machine layer** with **two tiers, not one**.
   The tier you hit FIRST is the one most sessions do not know exists:
 

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -209,8 +209,11 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   vacuous, or the MUTATION silently failed to apply — and the second is common,
   because the auto-formatter reflows lines and a `str.replace()` anchor written
   from memory then matches nothing. So: `assert mutated != original` after every
-  injection, and `ast.parse()` it before writing (an invalid mutation breaks
-  collection, and that failure reads as a successful RED). Restore from a file
+  injection, and syntax-check it with the MUTATED FILE'S OWN parser before
+  writing — `ast.parse()` for Python, `bash -n` for shell, the equivalent for
+  anything else (an invalid mutation breaks collection, and that failure reads
+  as a successful RED; conversely, running Python's parser over a shell hook
+  rejects a valid mutation and hides a real survivor). Restore from a file
   copy taken beforehand, never `git checkout` — the work is uncommitted.
 - **Vacuous-test shapes to check for by name.** A test is vacuous when: its
   assertion is ALSO true on the success path (`assert x.blocked is False` where
@@ -665,15 +668,22 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
      cost), name the cap explicitly ("we've hit the 3-round escalation cap"),
      and get a FRESH decision: keep hardening, switch to a robust-by-
      construction redesign, narrow scope, or shelve.
-  **Count CLASSES, not findings, when judging whether the cap has fired.**
+  **Tabulate findings by CLASS before fixing — but never let that change what
+  COUNTS.**
   Before fixing anything in a second round, tabulate the findings with a CLASS
   column. Findings that look unrelated one at a time routinely share one
   generator — five across three rounds once reduced to a single defect (two
   layers that had to agree about every lever and could not), and patching
   instances twice changed nothing while deleting the second layer removed all
-  five at once. If one class has ≥2 entries, the fix is architectural. The count
-  that matters is "consecutive rounds surfacing a NEW class", not the finding
-  total.
+  five at once. If one class has ≥2 entries, the fix is architectural.
+  **Class grouping decides HOW you fix — never whether the round counts.** The
+  counter is deliberately class-blind: `bump_review_round` increments on a
+  distinct staged diff and records no class (or reviewer) identity, and the
+  marking rule below is finding-based — ANY new BLOCKER/SHOULD-FIX/P1/P2 makes
+  the round defect-bearing, including the second instance of a class you have
+  already named. Passing `--clean` to keep a repeat-class round off the counter
+  is a falsification, and worse than miscounting: `--clean` RESETS the streak to
+  zero, so it disarms the cap outright rather than merely under-counting it.
 
   A corollary that costs a round if missed: when you delete a duplicated layer,
   verify the class is closed by enumerating the registry for the BEHAVIOUR, not

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -208,13 +208,18 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
 - **A RED that comes back GREEN is TWO hypotheses, not one.** Either the test is
   vacuous, or the MUTATION silently failed to apply — and the second is common,
   because the auto-formatter reflows lines and a `str.replace()` anchor written
-  from memory then matches nothing. So: `assert mutated != original` after every
-  injection, and syntax-check it with the MUTATED FILE'S OWN parser before
-  writing — `ast.parse()` for Python, `bash -n` for shell, the equivalent for
-  anything else (an invalid mutation breaks collection, and that failure reads
-  as a successful RED; conversely, running Python's parser over a shell hook
-  rejects a valid mutation and hides a real survivor). Restore from a file
-  copy taken beforehand, never `git checkout` — the work is uncommitted.
+  from memory then matches nothing. The PRINCIPLE, which is what to remember:
+  **every injection must prove it applied, by its own postcondition, before any
+  result is read as RED.** Two corollaries follow, and both have bitten:
+  prove it against the value THAT injection was handed, never against the
+  pristine original — with two or more edits, the first edit keeps a whole-file
+  `mutated != original` true while a later one silently misses its anchor, so
+  the partial mutation reads as complete (assert the anchor matched the expected
+  number of times); and prove it with the mutated file's OWN parser —
+  `ast.parse` for Python, `bash -n` for shell — since an invalid mutation breaks
+  collection and reads as a successful RED, while the wrong language's parser
+  rejects a valid mutation and hides a real survivor. Restore from a file copy
+  taken beforehand, never `git checkout` — the work is uncommitted.
 - **Vacuous-test shapes to check for by name.** A test is vacuous when: its
   assertion is ALSO true on the success path (`assert x.blocked is False` where
   a successful call also returns False — assert the fact that DISTINGUISHES

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -205,16 +205,20 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   passed may be testing nothing; a whole suite passing every review round
   while a reviewer keeps finding real spec bugs is the tell that the tests
   encode the same wrong spec as the code.
-- **A RED that comes back GREEN is THREE hypotheses, not one.** The test is
-  vacuous; or the MUTATION silently failed to apply — common, because the
-  auto-formatter reflows lines and a `str.replace()` anchor written from memory
-  then matches nothing; or the mutation applied to a mechanism that a SIBLING
-  LAYER still enforces, so the invariant holds and the green is correct. The
-  third is the one that gets a sound test rewritten: when two layers produce the
-  same behaviour (see the duplicated-layer entry below), mutate the WHOLE
-  mechanism, not one of its halves. Rule out the second before suspecting the
-  first, and the third before touching the test at all. The PRINCIPLE, which is
-  what to remember:
+- **A RED that comes back GREEN is FOUR hypotheses, not one.** The run never
+  EXECUTED (a guard refused it, a lock held it, the tool timed out) and there is
+  no result at all; or the MUTATION silently failed to apply — common, because
+  the auto-formatter reflows lines and a `str.replace()` anchor written from
+  memory then matches nothing; or the mutation applied to a mechanism a SIBLING
+  LAYER still enforces, so the invariant holds and the green is correct; or the
+  test is vacuous. Check them in that order — cheapest and most common first —
+  and touch the test only when the other three are excluded. The first is the
+  one that produces a CONFIDENT FALSE NEGATIVE: a sweep reporting "all mutations
+  survived" is far more often a sweep that never ran, so make the runner ABORT
+  when the test command emits no result line rather than recording a survivor.
+  The third is the one that gets a SOUND test rewritten: when two layers produce
+  the same behaviour (see the duplicated-layer entry below), mutate the WHOLE
+  mechanism, not one of its halves. The PRINCIPLE, which is what to remember:
   **every injection must prove it applied, by its own postcondition, before any
   result is read as RED.** Two corollaries follow, and both have bitten:
   prove it against the value THAT injection was handed, never against the
@@ -233,7 +237,14 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   reads as careful leaves a deliberately-broken file in an uncommitted worktree
   on the ordinary path — as well as on interruption or a tool timeout. Refuse to
   start if the file already differs from the snapshot, and verify the restore by
-  hash rather than assuming it.
+  hash rather than assuming it. And restore ONLY what you broke: compare against
+  the hash the MUTATION wrote before overwriting, because between the mutation
+  and the handler another session, agent or formatter may have edited that file,
+  and a blind snapshot restore silently destroys their uncommitted work — a
+  final hash check does not catch this, it only confirms the overwrite
+  succeeded. If the file no longer matches what the mutation wrote, PRESERVE it
+  and report the conflict instead. The cleanest way to avoid the window entirely
+  is to mutate inside an isolated worktree nobody else is editing.
 - **Vacuous-test shapes to check for by name.** A test is vacuous when: its
   assertion is ALSO true on the success path (`assert x.blocked is False` where
   a successful call also returns False — assert the fact that DISTINGUISHES

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -205,20 +205,35 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   passed may be testing nothing; a whole suite passing every review round
   while a reviewer keeps finding real spec bugs is the tell that the tests
   encode the same wrong spec as the code.
-- **A RED that comes back GREEN is FOUR hypotheses, not one.** The run never
-  EXECUTED (a guard refused it, a lock held it, the tool timed out) and there is
-  no result at all; or the MUTATION silently failed to apply — common, because
-  the auto-formatter reflows lines and a `str.replace()` anchor written from
-  memory then matches nothing; or the mutation applied to a mechanism a SIBLING
-  LAYER still enforces, so the invariant holds and the green is correct; or the
-  test is vacuous. Check them in that order — cheapest and most common first —
-  and touch the test only when the other three are excluded. The first is the
-  one that produces a CONFIDENT FALSE NEGATIVE: a sweep reporting "all mutations
-  survived" is far more often a sweep that never ran, so make the runner ABORT
-  when the test command emits no result line rather than recording a survivor.
-  The third is the one that gets a SOUND test rewritten: when two layers produce
-  the same behaviour (see the duplicated-layer entry below), mutate the WHOLE
-  mechanism, not one of its halves. The PRINCIPLE, which is what to remember:
+- **A RED that comes back GREEN has AT LEAST five causes, and "the test is
+  vacuous" is the LAST one to reach for.** In rough order of how often they
+  actually occur:
+  1. **The run never EXECUTED** — a guard refused it, a lock held it, the tool
+     timed out — so there is no result at all. This is the CONFIDENT FALSE
+     NEGATIVE: a sweep reporting "all mutations survived" is far more often a
+     sweep that never ran. Make the runner ABORT when the test command emits no
+     result line, and treat a SKIPPED/deselected line the same way — it is a
+     result line, and it still means nothing ran.
+  2. **The MUTATION silently failed to apply** — the auto-formatter reflows
+     lines and a `str.replace()` anchor written from memory then matches nothing.
+  3. **The test ran against a DIFFERENT COPY of the code** — an installed
+     package shadowing the source tree, a stale `.pyc`, the wrong virtualenv, or
+     (measured, this session) a path relative to a process whose cwd had moved to
+     another worktree. The mutation applied, the run happened, the test is sound,
+     and none of the other causes fits.
+  4. **The mutation was BEHAVIOURALLY NULL** — it applied and parses, so every
+     postcondition below passes, but it changed no behaviour: swapped operands
+     that commute, an edit inside a dead branch, a type annotation Python does
+     not enforce (also measured this session). The remedy is a different
+     MUTATION, not a different test.
+  5. **A SIBLING LAYER still enforces the invariant**, so the green is correct.
+     When two layers produce the same behaviour, mutate the WHOLE mechanism, not
+     one of its halves. (The duplicated-layer anecdote in the review-loop section
+     is the worked example.)
+  Only after all five: the test is vacuous. The list is ordered, not closed —
+  if none of them fits, look for a sixth before rewriting a test that may be
+  sound, because rewriting a sound test is the expensive mistake here.
+  The PRINCIPLE, which is what to remember:
   **every injection must prove it applied, by its own postcondition, before any
   result is read as RED.** Two corollaries follow, and both have bitten:
   prove it against the value THAT injection was handed, never against the
@@ -230,8 +245,11 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   collection and reads as a successful RED, while the wrong language's parser
   rejects a valid mutation and hides a real survivor. Restore from a file copy
   taken beforehand, never `git checkout` — the work is uncommitted — and make
-  that restore UNCONDITIONAL (`trap restore EXIT`, a `finally:`), never the tail
-  of an `&&` chain. The expected outcome here is a NONZERO exit, and under
+  the restore ATTEMPT unconditional ON THE RUN'S OUTCOME (`trap restore EXIT`, a
+  `finally:`), never the tail of an `&&` chain. Unconditional means it always
+  RUNS, not that it always OVERWRITES: what it writes is still gated on the hash
+  check below. A `trap` that restores blindly is the very thing that destroys a
+  concurrent edit. The expected outcome here is a NONZERO exit, and under
   `set -e` a trailing restore is exactly the statement that never runs (the
   `out=$(cmd)` entry in Common Traps is the same mechanism), so the shape that
   reads as careful leaves a deliberately-broken file in an uncommitted worktree
@@ -245,7 +263,11 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   succeeded. If the file no longer matches what the mutation wrote, PRESERVE it
   and report the conflict instead. The cleanest way to avoid the window entirely
   is to mutate inside an isolated worktree nobody else is editing.
-- **Vacuous-test shapes to check for by name.** A test is vacuous when: its
+- **Vacuous-test shapes to check for by name** (a list of the common ones, not a
+  definition). The most frequent in practice is the one that never ran at all: a
+  test SKIPPED by a marker, or deselected by a `-k` filter or a wrong path, which
+  reports SKIPPED or "no tests ran" and never goes red — check the count, not just
+  the absence of failures. Beyond that, a test is vacuous when: its
   assertion is ALSO true on the success path (`assert x.blocked is False` where
   a successful call also returns False — assert the fact that DISTINGUISHES
   them); its setup short-circuits the path it names (passing an explicit
@@ -709,7 +731,9 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   generator — five across three rounds once reduced to a single defect (two
   layers that had to agree about every lever and could not), and patching
   instances twice changed nothing while deleting the second layer removed all
-  five at once. If one class has ≥2 entries, the fix is architectural.
+  five at once. If one class has ≥2 entries, look for the shared GENERATOR and fix
+  that; two findings can land in one superficial class without sharing a cause, so
+  the count is the prompt to look, not the verdict.
   **Class grouping decides HOW you fix — never whether the round counts.** The
   counter is deliberately class-blind: `bump_review_round` increments on a
   distinct staged diff and records no class (or reviewer) identity, and the

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -241,7 +241,11 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   `mutated != original` true while a later one silently misses its anchor, so
   the partial mutation reads as complete (assert the anchor matched the expected
   number of times); and prove it with the mutated file's OWN parser —
-  `ast.parse` for Python, `bash -n` for shell — since an invalid mutation breaks
+  `compile(src, path, "exec")` for Python (NOT `ast.parse`: that only builds a
+  tree, so it accepts context-invalid constructs like a `return` moved outside a
+  function or a `break` outside a loop, and the `SyntaxError` then surfaces at
+  COLLECTION, where a nonzero exit reads as a successful RED), `bash -n` for
+  shell — since an invalid mutation breaks
   collection and reads as a successful RED, while the wrong language's parser
   rejects a valid mutation and hides a real survivor. Restore from a file copy
   taken beforehand, never `git checkout` — the work is uncommitted — and make

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -205,15 +205,19 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   passed may be testing nothing; a whole suite passing every review round
   while a reviewer keeps finding real spec bugs is the tell that the tests
   encode the same wrong spec as the code.
-- **A RED that comes back GREEN has AT LEAST five causes, and "the test is
+- **A RED that comes back GREEN has AT LEAST six causes, and "the test is
   vacuous" is the LAST one to reach for.** In rough order of how often they
   actually occur:
   1. **The run never EXECUTED** — a guard refused it, a lock held it, the tool
      timed out — so there is no result at all. This is the CONFIDENT FALSE
      NEGATIVE: a sweep reporting "all mutations survived" is far more often a
      sweep that never ran. Make the runner ABORT when the test command emits no
-     result line, and treat a SKIPPED/deselected line the same way — it is a
-     result line, and it still means nothing ran.
+     result line, and treat a SKIPPED/deselected line FOR THE TEST UNDER
+     VERIFICATION the same way — it is a result line, and it still means
+     nothing ran. Scope that check to the target: a suite carrying legitimate
+     `skipif` tests emits SKIPPED lines on every healthy run, so a runner that
+     aborts on ANY of them refuses every run — and the agent then either sits
+     blocked or starts stripping skip markers to unblock itself.
   2. **The MUTATION silently failed to apply** — the auto-formatter reflows
      lines and a `str.replace()` anchor written from memory then matches nothing.
   3. **The test ran against a DIFFERENT COPY of the code** — an installed
@@ -230,9 +234,21 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
      When two layers produce the same behaviour, mutate the WHOLE mechanism, not
      one of its halves. (The duplicated-layer anecdote in the review-loop section
      is the worked example.)
-  Only after all five: the test is vacuous. The list is ordered, not closed —
-  if none of them fits, look for a sixth before rewriting a test that may be
-  sound, because rewriting a sound test is the expensive mistake here.
+  6. **A SIBLING TEST LEAKED STATE that masks the mutation** — an undone
+     `monkeypatch`, a stray `os.environ` entry, a mutated singleton or a
+     module-level cache — so the mutated path is never reached in THIS run.
+     It matches none of the five above: the run executed, the mutation applied
+     and is not behaviourally null, the code is the right copy, and no
+     production layer is enforcing anything. MEASURED in this repo: a leaked
+     disable lever made the very lock under test a no-op, and five real
+     failures read as a story about the mechanism instead. The remedy is test
+     ISOLATION (an autouse fixture that clears the lever) — NOT a different
+     mutation, and NOT a different test.
+  Only after all six: the test is vacuous. The list is ordered and still not
+  closed — if none of them fits, the vacuous conclusion is UNPROVEN rather than
+  established: look for the cause you have not modelled before rewriting a test
+  that may be sound, because rewriting a sound test is the expensive mistake
+  here.
   The PRINCIPLE, which is what to remember:
   **every injection must prove it applied, by its own postcondition, before any
   result is read as RED.** Two corollaries follow, and both have bitten:
@@ -245,8 +261,8 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   tree, so it accepts context-invalid constructs like a `return` moved outside a
   function or a `break` outside a loop, and the `SyntaxError` then surfaces at
   COLLECTION, where a nonzero exit reads as a successful RED), `bash -n` for
-  shell — since an invalid mutation breaks
-  collection and reads as a successful RED, while the wrong language's parser
+  shell — since an invalid mutation breaks collection and reads as a successful
+  RED, while the wrong language's parser
   rejects a valid mutation and hides a real survivor. Restore from a file copy
   taken beforehand, never `git checkout` — the work is uncommitted — and make
   the restore ATTEMPT unconditional ON THE RUN'S OUTCOME (`trap restore EXIT`, a
@@ -257,9 +273,13 @@ Adapted from superpowers `test-driven-development`, scoped to where it pays:
   `set -e` a trailing restore is exactly the statement that never runs (the
   `out=$(cmd)` entry in Common Traps is the same mechanism), so the shape that
   reads as careful leaves a deliberately-broken file in an uncommitted worktree
-  on the ordinary path — as well as on interruption or a tool timeout. Refuse to
-  start if the file already differs from the snapshot, and verify the restore by
-  hash rather than assuming it. And restore ONLY what you broke: compare against
+  on the ordinary path — as well as on interruption or a tool timeout. Take
+  that copy ONCE for the whole sweep and refuse to start EACH cycle if the file
+  already differs from it — a copy re-taken immediately before each mutation
+  makes the check vacuous, since the file trivially matches a copy a moment
+  old; the baseline exists to catch a PREVIOUS cycle that failed to restore, or
+  a concurrent edit. Verify the restore by hash rather than assuming it. And
+  restore ONLY what you broke: compare against
   the hash the MUTATION wrote before overwriting, because between the mutation
   and the handler another session, agent or formatter may have edited that file,
   and a blind snapshot restore silently destroys their uncommitted work — a


### PR DESCRIPTION
Three lessons that each cost a real review round, recorded in the section that already owns the topic. Prose only — no code, no runtime surface.

## A verify-RED that comes back green is two hypotheses, not one

Either the test is vacuous, or the **mutation silently failed to apply** — and the second is common, because the auto-formatter reflows lines and an anchor written from memory then matches nothing. The resulting green reads as *"this test proves nothing"*, which is how a correct test gets rewritten.

So: assert the mutation actually changed the file, and parse it before writing. An invalid mutation breaks collection, and that failure looks like a successful RED.

## Three vacuous-test shapes, named

"Watch it fail once" doesn't say *what* failure to look for. The three that recur:

- the assertion is **also true on the success path** (`assert x.blocked is False`, where a successful call returns that too — assert the fact that *distinguishes* them);
- the setup **short-circuits the path it names** (passing an explicit argument the code prefers over the env var under test);
- the fixture **never creates the shape it claims** — a shell decoy can exec-replace itself with the last simple command and lose the very argv the test asserts on, so add a guard-the-guard assert that the fixture really has the property.

The operational question: *would this still pass if the mechanism it names were deleted?*

## The escalation cap is about the generator, not the count

Findings that look unrelated one at a time routinely share one cause, and patching instances leaves it producing. Tabulating by **class** before fixing anything is what makes the architectural fix visible — and the count that matters is "consecutive rounds surfacing a *new* class", not the finding total.

With a corollary: after deleting a duplicated layer, confirm the class is closed by enumerating **behaviour**, not the deleted file's **name** — a sibling on the same event and matcher passes a name-scoped guard unnoticed. And where the invariant turns out not to be statically checkable, narrow the test to what it can prove and say so, because a guard that cries wolf gets deleted by whoever hits it next.

---

Written install-generic: no incident specifics, so it reads as standing practice rather than one postmortem. Each addition extends an existing bullet rather than adding a section. No hooks proposed — detecting a vacuous assertion statically needs semantic understanding of the code under test, and the one lesson with an enforcement surface already has one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified RED-test validation to distinguish non-execution, mutation failures, sibling-layer enforcement, and vacuous tests.
  * Added requirements for mutation postcondition checks and stopping validation when no result is emitted.
  * Refined restoration guidance to cover only executed cleanup paths, verify hashes, and preserve concurrent edits.
  * Updated review escalation guidance to require class tabulation before each round while retaining class-blind counting and registry enumeration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->