### PR TITLE
fix(hooks): share one tokenizability probe, and stop the commit gate failing open

### DIFF
--- a/scripts/hooks/protected_paths_guard.py
+++ b/scripts/hooks/protected_paths_guard.py
@@ -39,14 +39,13 @@ from __future__ import annotations
 
 import os
 import re
-import shlex
 import sys
 from fnmatch import fnmatch
 
 # Self-locate so hook_input resolves whether run as a script or imported (tests).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import brace_expand, read_payload, run_guard, tool_input  # noqa: E402
-from shell_parse import analyze  # noqa: E402
+from shell_parse import analyze, untokenizable  # noqa: E402
 
 # Directories that must never be deleted.  Relative to $HOME.
 _PROTECTED_RELATIVE = [
@@ -189,11 +188,19 @@ def main() -> int:
     dirs = _protected_dirs()
     files = _protected_files()
 
-    # Explicit tokenizability probe: shell_parse._argv silently degrades to a
-    # naive split on shlex errors, so analyze() alone can never signal one.
-    try:
-        shlex.split(cmd.replace("\\\n", " "))
-    except ValueError:
+    # Explicit tokenizability probe, now SHARED (this was the third hand-rolled
+    # copy; they had already drifted from one another). shell_parse._argv
+    # silently degrades to a naive split on shlex errors, so analyze() alone can
+    # never signal one.
+    #
+    # Not byte-identical to the inline probe it replaces: that one folded
+    # `\<newline>` to a space first. The shared probe reads the command RAW,
+    # because bash REMOVES a line continuation rather than replacing it, so the
+    # fold produced the reading furthest from what actually executes. MEASURED
+    # over 12,099 real commands: the two classify identically (339 un-tokenizable
+    # either way, zero commands differ), so this is a semantics correction with
+    # no observed behaviour change.
+    if untokenizable(cmd):
         reason = _legacy_substring_block(cmd, dirs)
         return _block(reason) if reason else 0
 

--- a/scripts/hooks/protected_paths_guard.py
+++ b/scripts/hooks/protected_paths_guard.py
@@ -188,10 +188,16 @@ def main() -> int:
     dirs = _protected_dirs()
     files = _protected_files()
 
-    # Explicit tokenizability probe, now SHARED (this was the third hand-rolled
-    # copy; they had already drifted from one another). shell_parse._argv
-    # silently degrades to a naive split on shlex errors, so analyze() alone can
-    # never signal one.
+    # Explicit tokenizability probe, now SHARED rather than inline here.
+    # shell_parse._argv silently degrades to a naive split on shlex errors, so
+    # analyze() alone can never signal one.
+    #
+    # (An earlier draft of this comment called it "the third hand-rolled copy,
+    # already drifted from one another". Not true of the tree this lands on: on
+    # the default branch this was the ONLY probe of the discard-the-tokens kind.
+    # Every other shlex call in scripts/hooks USES its tokens, which is a
+    # different act with a different fail direction. A comment describing a tree
+    # the change is not landing on is how a reader inherits a false picture.)
     #
     # Not byte-identical to the inline probe it replaces: that one folded
     # `\<newline>` to a space first. The shared probe reads the command RAW,

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -613,17 +613,27 @@ def untokenizable(command: str) -> bool:
     This is the blind-spot signal a guard consults when it is about to conclude
     "no gated segment found". ``_argv`` degrades to a naive split on the SAME
     ``ValueError`` silently, so ``analyze()`` can never self-report that its
-    result is untrustworthy — an ANSI-C ``$'…\'…'`` span, or merely an
-    apostrophe inside a here-doc body, is enough to shift segmentation off and
-    drop a real, executing command from the parse.
+    result is untrustworthy: an ordinary quoting construct is enough to shift
+    segmentation off and drop a real, executing command from the parse, and the
+    return value looks identical to "there was nothing to find".
 
-    Deliberately reads the WHOLE raw command, with no here-doc normalization.
-    An earlier version stripped here-doc bodies first to suppress prompts on
-    multi-line scripts; that MEASURABLY disarmed the signal on an ordinary shape
-    (a quoted here-doc whose body contains an apostrophe, followed by a real
-    gated git command — bash runs it, the stripped text tokenizes cleanly, and
-    the guard fell silent). Normalizing the text before the probe can only ever
-    delete the evidence the probe exists to find, so it does not happen here.
+    Deliberately reads the WHOLE raw command, with no normalization of any kind.
+    An earlier version pre-processed it to suppress prompts on a class of
+    multi-line command, and that MEASURABLY disarmed the signal: on a shape a
+    developer writes without thinking, the command really ran (verified against
+    a shimmed binary, so the proof was execution rather than parse) while the
+    pre-processed text tokenized cleanly and the guard fell silent. The
+    triggering shape is deliberately not written down — this file is public and
+    the guard it protects is load-bearing.
+
+    KNOWN COST, stated rather than hidden: ``_argv`` DOES normalize before its
+    own tokenize (it strips trailing comments), so this probe over-reports
+    relative to the very parser whose blind spot it reports — an unquoted
+    comment alone can make a benign command look unparseable. Stripping here is
+    NOT the fix: measured over 19,246 real commands, doing so erases a mention
+    of a gated operation in 3 of them, because a stripper's model of where a
+    comment begins is not the shell's and the two disagree in both directions.
+    A cure that can only raise severity, never clear it, is tracked separately.
 
     That rule is now literal. An earlier revision folded ``\\<newline>`` to a
     SPACE before probing, which contradicted the paragraph above and was also

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -22,6 +22,16 @@ This module centralizes that parsing so ``git_push_guard``,
 ``review_enforcement_commit``, and the destructive/path guards agree. Stdlib
 only; fail-open (a segment that won't tokenize degrades to a naive split rather
 than raising) — a guard must never crash the tool.
+
+That fail-open degradation is SILENT by design, which means ``analyze()`` can
+never report its own blind spot: "no gated segment found" and "no gated command
+present" are indistinguishable in its return value. A caller that treats the
+former as the latter fails OPEN. ``untokenizable()`` exists so a
+security-critical caller can tell them apart and choose its own fail direction
+at its own boundary — the parser degrades gracefully, each gate decides for
+itself what an unverifiable command means. Callers must probe the RAW command:
+normalizing text before a blind-spot probe can only ever delete the evidence
+the probe looks for.
 """
 
 from __future__ import annotations
@@ -596,6 +606,39 @@ def _argv(seg: str) -> list[str]:
     except ValueError:
         return core.split()
 
+
+def untokenizable(command: str) -> bool:
+    """True when ``shlex`` cannot cleanly tokenize the command.
+
+    This is the blind-spot signal a guard consults when it is about to conclude
+    "no gated segment found". ``_argv`` degrades to a naive split on the SAME
+    ``ValueError`` silently, so ``analyze()`` can never self-report that its
+    result is untrustworthy — an ANSI-C ``$'…\'…'`` span, or merely an
+    apostrophe inside a here-doc body, is enough to shift segmentation off and
+    drop a real, executing command from the parse.
+
+    Deliberately reads the WHOLE raw command, with no here-doc normalization.
+    An earlier version stripped here-doc bodies first to suppress prompts on
+    multi-line scripts; that MEASURABLY disarmed the signal on an ordinary shape
+    (a quoted here-doc whose body contains an apostrophe, followed by a real
+    gated git command — bash runs it, the stripped text tokenizes cleanly, and
+    the guard fell silent). Normalizing the text before the probe can only ever
+    delete the evidence the probe exists to find, so it does not happen here.
+
+    That rule is now literal. An earlier revision folded ``\\<newline>`` to a
+    SPACE before probing, which contradicted the paragraph above and was also
+    simply wrong about bash — bash REMOVES a line continuation, joining the two
+    halves into one word (``ec\\<newline>ho`` runs ``echo``), so replacing it
+    with a space produced the reading furthest from what actually executes.
+    MEASURED over 12,099 real commands: folding and not folding classify
+    IDENTICALLY (339 un-tokenizable either way, zero commands differ), so the
+    normalization bought nothing and is removed rather than documented.
+    """
+    try:
+        shlex.split(command)
+        return False
+    except ValueError:
+        return True
 
 def _basename(token: str) -> str:
     """Executable basename: /usr/bin/git → git, ./foo → foo."""

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -688,8 +688,34 @@ def main() -> None:
             marker_content_current,
             reset_review_round,
         )
-    except ImportError:
-        # If review_state.py is missing, fail open — don't block
+    except Exception:  # noqa: BLE001 — ANY load failure, not just absence.
+        # If review_state cannot be loaded, fail open — don't block.
+        #
+        # WIDENED from `except ImportError` deliberately, and the wrapper below is
+        # exactly why. A SyntaxError (or any top-level runtime error) in
+        # review_state is NOT an ImportError, so it used to escape this handler
+        # and exit 1 — non-blocking, so the commit proceeded. Now that main() runs
+        # under run_guard, that same escape converts to a hard BLOCK instead, and
+        # MEASURED it blocks EVERY commit on the box: the trailing
+        # `# review-override` cannot rescue it either, because the override is
+        # parsed after this import. That includes the commit that would repair
+        # review_state, so the gate would wall off its own fix.
+        #
+        # The sibling (scripts/hooks/git_push_guard.py, the ESCALATION_ROUND_CAP
+        # import) widened the same handler for the same reason, but its degrade
+        # is NOT the same and the difference matters: it falls back to a default
+        # constant and keeps every gate armed, whereas this one abandons the
+        # whole gate — the direct-to-main rule, the review-marker requirement and
+        # the round rules all stop applying. That is a big loss, chosen over a
+        # bigger one, and it is the pre-existing behaviour for the absent case
+        # rather than something new. (The narrower handler was not "no guard": it
+        # caught absence and missed everything else.)
+        print(
+            "WARNING (review_enforcement_commit): review_state failed to load — "
+            "the review gate is DISABLED for this commit (fail-open). Fix "
+            "scripts/review_state.py; commits are unguarded until you do.",
+            file=sys.stderr,
+        )
         sys.exit(0)
 
     # Rule 1: Block commits on main. Fail closed when the cwd is ambiguous — we

--- a/scripts/review_enforcement_commit.py
+++ b/scripts/review_enforcement_commit.py
@@ -23,7 +23,7 @@ from pathlib import Path
 # The shared hook-input helper lives in scripts/hooks/; this script runs from
 # scripts/ (a different sys.path[0]), so add the hooks dir before importing it.
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "hooks"))
-from hook_input import field, read_payload  # noqa: E402
+from hook_input import field, read_payload, run_guard  # noqa: E402
 from shell_parse import (  # noqa: E402
     analyze,
     commit_skips_hooks,
@@ -1058,4 +1058,11 @@ def _deny(message: str) -> None:
 
 
 if __name__ == "__main__":
-    main()
+    # Fail CLOSED on an unexpected crash. CC's PreToolUse contract is "exit 2 =
+    # block; ANY other code = non-blocking error -> the tool RUNS", so a bare
+    # main() let every uncaught exception in this gate (Rule 0, the branch/review
+    # rules, git_root_for, ...) exit 1 = a silent FAIL-OPEN on a commit.
+    # run_guard converts that to exit 2 and logs loudly; SystemExit (every
+    # deliberate _deny/allow path here) propagates untouched, so allow and block
+    # decisions are unchanged. Mirrors git_push_guard.py's wiring.
+    run_guard(main, "review_enforcement_commit")

--- a/tests/test_hooks/test_no_published_bypass_recipes.py
+++ b/tests/test_hooks/test_no_published_bypass_recipes.py
@@ -22,6 +22,14 @@ WHAT IS FORBIDDEN — the pairing, not the shape
   scan string literals or test parameters. `cmd = "<the shape>"` is fine.
   `# <the shape> makes the guard fall silent` is not.
 
+  That distinction is drawn by `tokenize`, not by a regex over raw source. A
+  regex cannot tell a comment from a hash-prefixed line INSIDE a string
+  literal, so the first version of this file scanned exactly the fixture data
+  the paragraph above permits — the docstring claimed a property the code did
+  not have. The one place the coarse scan survives is a file that will not
+  tokenize at all, where over-reporting is the safe direction: a false positive
+  is a loud CI failure, a false negative is a published recipe.
+
 WHAT THIS IS NOT
   Not a classifier, and it cannot be. Prose is open-set: someone can describe
   the same thing in words this never sees, and no list of terms closes that.
@@ -34,8 +42,10 @@ WHAT THIS IS NOT
 from __future__ import annotations
 
 import ast
+import io
 import re
 import subprocess
+import tokenize
 from pathlib import Path
 
 import pytest
@@ -84,6 +94,19 @@ _NEGATORS = (
 )
 _NEGATION_LOOKBACK = 40
 
+# Concessive phrases that CONTAIN a negator but assert rather than deny: "not
+# only X but Y" claims X. Left unhandled, the substring "not " inside them
+# suppressed a real recipe — the negation fix's own mirror-image defect, since
+# a negation list is itself a bag of substrings used as a claim detector. These
+# are stripped from the lookback window BEFORE the negator scan, so the
+# remaining text is judged on its own.
+_CONCESSIVE = (
+    "not only",
+    "not just",
+    "not merely",
+    "not simply",
+)
+
 # How close the two halves must be to read as one claim. A construct in one
 # paragraph and the word "bypass" three paragraphs later is not a recipe.
 _WINDOW = 240
@@ -124,13 +147,40 @@ def _tracked(suffixes: tuple[str, ...]) -> list[Path]:
     ]
 
 
+def _comment_runs(src: str) -> list[str]:
+    """Real COMMENT tokens, grouped into runs of consecutive lines.
+
+    Grouped because the window that binds the two halves of a recipe together
+    has to span a multi-line comment block; judged per line, a construct named
+    on one line and the defeat claimed on the next would read as unrelated.
+    """
+    runs: list[list[str]] = []
+    prev = None
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(src).readline):
+            if tok.type != tokenize.COMMENT:
+                continue
+            line = tok.start[0]
+            if runs and prev is not None and line == prev + 1:
+                runs[-1].append(tok.string)
+            else:
+                runs.append([tok.string])
+            prev = line
+    except (tokenize.TokenError, IndentationError, SyntaxError, ValueError):
+        # Will not tokenize — fall back to the coarse scan, which also reads
+        # string literals. Over-reporting is the correct direction here; see
+        # the module docstring.
+        return [m.group(0) for m in re.finditer(r"(?m)^[ \t]*#.*(?:\n[ \t]*#.*)*", src)]
+    return ["\n".join(r) for r in runs]
+
+
 def _prose_of_python(path: Path) -> list[str]:
     """Comments and docstrings only — never string literals or test data."""
     try:
         src = path.read_text(errors="replace")
     except OSError:
         return []
-    blocks = [m.group(0) for m in re.finditer(r"(?m)^[ \t]*#.*(?:\n[ \t]*#.*)*", src)]
+    blocks = _comment_runs(src)
     try:
         tree = ast.parse(src)
     except SyntaxError:
@@ -154,6 +204,8 @@ def _recipe_hits(text: str) -> list[tuple[str, str]]:
                 if at < 0:
                     continue
                 lead = window[max(0, at - _NEGATION_LOOKBACK) : at]
+                for phrase in _CONCESSIVE:
+                    lead = lead.replace(phrase, " ")
                 if any(neg in lead for neg in _NEGATORS):
                     continue  # denied, not asserted — see _NEGATORS
                 hits.append((construct, outcome))
@@ -209,6 +261,11 @@ def test_markdown_carries_no_bypass_recipe():
         ("a `|` inside a here" + "-doc body may over-block, never a bypass", False),
         ("a here" + "-doc cannot open a bypass here", False),
         ("an ANSI-C span does not bypass the gate", False),
+        # CONCESSIVE — carries a negator but ASSERTS. "not only X" claims X,
+        # and the negation list, being itself a bag of substrings, read it as a
+        # denial and swallowed a real recipe.
+        ("an ANSI-C span is not only able to bypass the gate", True),
+        ("a here" + "-doc does not just bypass it, it hides the command", True),
     ],
 )
 def test_the_detector_discriminates(prose, should_flag):
@@ -220,3 +277,49 @@ def test_the_detector_discriminates(prose, should_flag):
     a week, and a disabled gate is a doc line with extra steps.
     """
     assert bool(_recipe_hits(prose)) is should_flag
+
+
+def test_a_hash_line_inside_a_string_literal_is_not_read_as_a_comment(tmp_path):
+    """The permitted-fixture half of the rule, enforced rather than asserted.
+
+    The module docstring has always said string literals are not scanned. The
+    first implementation read raw source with a regex, which cannot tell a
+    comment from a hash-prefixed line inside a multiline string — so a shell
+    fixture, the one thing the rule explicitly allows, tripped the check. The
+    positive control below is what makes this test mean anything: without it,
+    a `_prose_of_python` that returned nothing at all would pass.
+    """
+    shape = "ANSI" + "-C"
+    recipe = f"# a {shape} span here makes the guard fall silent\n"
+
+    literal = tmp_path / "fixture_data.py"
+    literal.write_text(f"SCRIPT = '''\n{recipe}echo hi\n'''\n")
+    assert _prose_of_python(literal) == [], (
+        "a hash-prefixed line inside a string literal was read as prose; "
+        "fixture data is permitted and must not be scanned"
+    )
+
+    control = tmp_path / "real_comment.py"
+    control.write_text(recipe)
+    hits = [h for block in _prose_of_python(control) for h in _recipe_hits(block)]
+    assert hits, (
+        "POSITIVE CONTROL FAILED — the same text as a real comment was not "
+        "caught either, so the assertion above proves nothing"
+    )
+
+
+def test_an_untokenizable_file_falls_back_to_the_coarse_scan(tmp_path):
+    """The documented degradation, locked so it stays loud rather than silent.
+
+    A file that will not tokenize gets the regex, which over-reports. That is
+    the deliberate direction — a false positive is a CI failure someone reads,
+    a false negative is a recipe that ships. Pinned so the fallback cannot be
+    quietly changed to "return nothing", which would look identical on a clean
+    repository.
+    """
+    shape = "ANSI" + "-C"
+    broken = tmp_path / "unparseable.py"
+    broken.write_text(f"def f(:\n# a {shape} span here makes the guard fall silent\n")
+    blocks = _prose_of_python(broken)
+    assert blocks, "an untokenizable file yielded no prose — the fallback is gone"
+    assert [h for b in blocks for h in _recipe_hits(b)]

--- a/tests/test_hooks/test_no_published_bypass_recipes.py
+++ b/tests/test_hooks/test_no_published_bypass_recipes.py
@@ -1,0 +1,222 @@
+"""A guard's defeat conditions must not be written down in prose.
+
+This repository is public, and its hooks are the approval gates. A sentence
+that names the construct which defeats a gate AND the fact that it defeated it
+is a recipe, whether or not the hole is currently closed — a reader gets the
+search narrowed for free, and a fix can always be reverted, missed on a sibling
+surface, or not yet merged.
+
+The rule was a sentence in the dev skill for weeks and did not hold. It was
+applied to one surface and missed the sibling: the shape was redacted from the
+skill document and left spelled out in a guard's own docstring, in this repo,
+in the same session. A sentence cannot notice that. This can.
+
+WHAT IS FORBIDDEN — the pairing, not the shape
+  A trigger shape is legitimate, and necessary, as FIXTURE DATA: a guard's test
+  cannot cover a construct it may not contain, and the guard's own code has to
+  match on something. What is forbidden is PROSE — a comment, a docstring, a
+  markdown line — that names a shell construct and, near it, says a gate was
+  defeated. That conjunction is the recipe; either half alone is not.
+
+  So this scans comments, docstrings and markdown, and deliberately does NOT
+  scan string literals or test parameters. `cmd = "<the shape>"` is fine.
+  `# <the shape> makes the guard fall silent` is not.
+
+WHAT THIS IS NOT
+  Not a classifier, and it cannot be. Prose is open-set: someone can describe
+  the same thing in words this never sees, and no list of terms closes that.
+  It is a tripwire for the shapes we have actually leaked, sized to catch the
+  next instance of a mistake already made twice. Treat a pass as "the known
+  recipes are absent", never as "this diff teaches nobody anything" — the
+  judgement call still belongs to whoever writes the sentence.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+
+# Assembled from fragments so this file does not itself carry the terms it
+# forbids — the same convention the guard suites use for trigger literals.
+_CONSTRUCTS = (
+    "here" + "-doc",
+    "heredoc",
+    "ANSI-C",
+    "apostrophe",
+    "line continuation",
+)
+# The other half of the pairing: the claim that a gate stopped working.
+_OUTCOMES = (
+    "silent allow",
+    "silently allow",
+    "fell silent",
+    "falls silent",
+    "fall silent",
+    "disarm",
+    "bypass",
+    "defeat",
+    "slipped past",
+    "sailed past",
+)
+
+# Negation, because the first version of this file had the defect it was written
+# to catch. MEASURED on first run: 7 hits across the repo, and all 7 were prose
+# REASSURING the reader — "never a security bypass", "cannot open a bypass",
+# "does not bypass". A bag of outcome words used as a claim detector is exactly
+# the shape that made a merge gate read "not a hard block" as a hard block, and
+# it is documented in this repo. Skip an outcome that is denied rather than
+# asserted; a denial is the opposite of a recipe.
+_NEGATORS = (
+    "never",
+    "not ",
+    "n't",
+    "cannot",
+    "no ",
+    "rather than",
+    "instead of",
+    "without",
+)
+_NEGATION_LOOKBACK = 40
+
+# How close the two halves must be to read as one claim. A construct in one
+# paragraph and the word "bypass" three paragraphs later is not a recipe.
+_WINDOW = 240
+
+# Known pairings that are allowed, keyed by (file, construct, outcome) — NOT by
+# file. Waiving a whole file would blind this exactly where it matters most: the
+# push guard is the largest surface and the likeliest place for the next leak,
+# so a file-level waiver there would be worse than having no check. A triple
+# waives the one sentence and leaves everything else in that file watched.
+#
+# The reason lives here rather than as an inline marker, because an inline
+# escape hatch silences by line and gets copied to the next file without its
+# justification.
+_ALLOWED: dict[tuple[str, str, str], str] = {
+    ("scripts/hooks/git_push_guard.py", "heredoc", "bypass"): (
+        "Design rationale for a REJECTED alternative: it records that a "
+        "two-token match could be split by anything inserted between the "
+        "tokens, which is why the shipped detector matches a single keyword. "
+        "The shapes named defeat a design that was never merged, and naming "
+        "them is what justifies the rejection. Re-examine if that detector is "
+        "ever changed back."
+    ),
+}
+
+
+def _tracked(suffixes: tuple[str, ...]) -> list[Path]:
+    out = subprocess.run(
+        ["git", "-C", str(_REPO), "ls-files", "-z"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
+    )
+    return [
+        _REPO / rel
+        for rel in out.stdout.split("\0")
+        if rel and rel.endswith(suffixes) and (_REPO / rel).is_file()
+    ]
+
+
+def _prose_of_python(path: Path) -> list[str]:
+    """Comments and docstrings only — never string literals or test data."""
+    try:
+        src = path.read_text(errors="replace")
+    except OSError:
+        return []
+    blocks = [m.group(0) for m in re.finditer(r"(?m)^[ \t]*#.*(?:\n[ \t]*#.*)*", src)]
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return blocks
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                blocks.append(doc)
+    return blocks
+
+
+def _recipe_hits(text: str) -> list[tuple[str, str]]:
+    low = text.lower()
+    hits = []
+    for construct in _CONSTRUCTS:
+        for m in re.finditer(re.escape(construct.lower()), low):
+            window = low[max(0, m.start() - _WINDOW) : m.end() + _WINDOW]
+            for outcome in _OUTCOMES:
+                at = window.find(outcome)
+                if at < 0:
+                    continue
+                lead = window[max(0, at - _NEGATION_LOOKBACK) : at]
+                if any(neg in lead for neg in _NEGATORS):
+                    continue  # denied, not asserted — see _NEGATORS
+                hits.append((construct, outcome))
+    return hits
+
+
+def _offenders(paths: list[Path], prose_fn) -> list[str]:
+    found = []
+    for path in paths:
+        rel = str(path.relative_to(_REPO))
+        for block in prose_fn(path):
+            for construct, outcome in _recipe_hits(block):
+                if (rel, construct, outcome) in _ALLOWED:
+                    continue
+                found.append(f"{rel}: {construct!r} near {outcome!r}")
+    return found
+
+
+def test_python_prose_carries_no_bypass_recipe():
+    """Comments and docstrings across every tracked .py file."""
+    offenders = _offenders(_tracked((".py",)), _prose_of_python)
+    assert not offenders, (
+        "prose names a shell construct and, within the same claim, says a gate "
+        "was defeated by it. That is a recipe, and this repository is public. "
+        "Describe the MECHANISM instead ('a normalizer's model of the shell was "
+        "narrower than the shell's'), or move the detail to a private note.\n  "
+        + "\n  ".join(sorted(set(offenders)))
+    )
+
+
+def test_markdown_carries_no_bypass_recipe():
+    """Every tracked .md file — skills, docs, changelogs, READMEs."""
+    offenders = _offenders(_tracked((".md",)), lambda p: [p.read_text(errors="replace")])
+    assert not offenders, (
+        "documentation names a shell construct and says a gate was defeated by "
+        "it. Same rule as the code prose above, and the surface a reader "
+        "actually browses.\n  " + "\n  ".join(sorted(set(offenders)))
+    )
+
+
+@pytest.mark.parametrize(
+    "prose,should_flag",
+    [
+        # The recipe: construct + defeat, together.
+        ("stripping the here" + "-doc body made the guard fall silent", True),
+        ("an ANSI-C span is enough to bypass the check", True),
+        # Legitimate prose that must NOT trip it.
+        ("the here" + "-doc body is treated as data by the shell", False),
+        ("this bypass of the cache is intentional", False),
+        ("apostrophes in a commit message are common", False),
+        # NEGATED claims — the reassurance, not the recipe. All seven hits on
+        # this file's first run over the repo were of this shape.
+        ("a `|` inside a here" + "-doc body may over-block, never a bypass", False),
+        ("a here" + "-doc cannot open a bypass here", False),
+        ("an ANSI-C span does not bypass the gate", False),
+    ],
+)
+def test_the_detector_discriminates(prose, should_flag):
+    """CONTROL — without this, an inert predicate reports a clean repo forever.
+
+    A scan that never fires and a codebase with nothing to find return the same
+    empty list. The negative cases matter as much as the positive ones: a
+    detector that flags every mention of a construct would be turned off within
+    a week, and a disabled gate is a doc line with extra steps.
+    """
+    assert bool(_recipe_hits(prose)) is should_flag

--- a/tests/test_hooks/test_untokenizable_probe.py
+++ b/tests/test_hooks/test_untokenizable_probe.py
@@ -6,9 +6,10 @@ and "no gated command present" are the same return value. `untokenizable()` is
 the signal that separates them, so a security-critical caller can pick its own
 fail direction while the parser keeps degrading gracefully.
 
-This file covers the probe itself, the removal of the third hand-rolled copy of
-it, and the commit gate's `run_guard` wrapper. It does NOT cover any gate that
-consumes the probe to make a verdict — that lives with the change that adds one.
+This file covers the probe itself, the removal of the duplicate copy of it in
+`protected_paths_guard` (including that the guard actually CALLS the shared
+one), and the commit gate's `run_guard` wrapper plus its degrade when
+`review_state` will not load.
 
 Trigger literals are assembled from fragments so this file's own text does not
 carry them (matching the convention in test_shell_parse.py).
@@ -47,6 +48,11 @@ _NEUTRAL_ENV = frozenset({"PATH", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE", "PYTHO
 
 def _child_env(**extra: str) -> dict[str, str]:
     env = {k: v for k, v in os.environ.items() if k in _NEUTRAL_ENV}
+    # HOME is set explicitly rather than allow-listed: without it the child
+    # falls back to the passwd DB while the test computes Path.home() from the
+    # env var, so the suite breaks wherever those disagree (measured: 3 failures
+    # under a non-passwd HOME, including a safety control).
+    env["HOME"] = os.path.expanduser("~")
     env["GIT_CONFIG_GLOBAL"] = os.devnull  # no developer gitconfig (gpgsign etc.)
     env["GIT_CONFIG_SYSTEM"] = os.devnull
     env.update(extra)
@@ -99,7 +105,7 @@ class TestUntokenizable:
     def test_ordinary_commands_are_tokenizable(self, cmd):
         assert sp.untokenizable(cmd) is False
 
-    def test_probe_reads_the_raw_command(self):
+    def test_probe_reads_the_raw_command(self, monkeypatch):
         """No normalisation, and specifically no line-continuation folding.
 
         An earlier revision folded `\\<newline>` to a SPACE first. That is wrong
@@ -107,21 +113,47 @@ class TestUntokenizable:
         word, and it also contradicted the probe's own contract. Measured over
         12,099 real commands the two classify identically, so the fold bought
         nothing; this pins the raw reading so it cannot creep back.
+
+        The verdict cannot pin it. Folded and unfolded classify this command
+        IDENTICALLY — that is exactly what the 12,099-command measurement found
+        — and a str is immutable, so a probe that rewrote its input internally
+        would still leave the caller's copy untouched. Both of those assertions
+        stay green with the fold restored, which makes them a statement about
+        Python, not about the contract. So spy on the tokenizer and assert what
+        it RECEIVED: the fold changes that argument, and only that argument.
         """
+        seen: list[str] = []
+        real_split = sp.shlex.split
+
+        def spy(s, *args, **kwargs):
+            seen.append(s)
+            return real_split(s, *args, **kwargs)
+
+        monkeypatch.setattr(sp.shlex, "split", spy)
         cmd = "git pu\\\nsh origin main"
         assert sp.untokenizable(cmd) is False
-        # The raw text still contains the continuation — nothing rewrote it.
-        assert "\\\n" in cmd
+        assert seen == [cmd], (
+            "the probe rewrote its input before tokenizing; it must read the "
+            f"command RAW. shlex.split received: {seen!r}"
+        )
 
 
 class TestProtectedPathsUsesTheSharedProbe:
-    """The third hand-rolled copy of the probe is gone; behaviour is preserved."""
+    """The duplicate probe in this guard is gone; behaviour is preserved."""
 
     def test_ansic_obfuscated_rm_of_protected_dir_still_blocks(self, tmp_path):
         """The reason the inline probe existed — it must still work.
 
-        Without this control the refactor could delete the probe entirely and
-        every other assertion here would stay green.
+        This is a BEHAVIOUR check, not a wiring one, and it cannot be made into
+        a wiring one: MEASURED, this command still blocks even when the probe is
+        forced to answer "tokenizable", because an operand keeping an unresolved
+        `$` reaches the same legacy fallback by a second route
+        (the unresolved-`$` operand check further down `main`). Deleting the
+        probe would not move this assertion. An earlier version of this docstring claimed the opposite —
+        that without it the refactor could delete the probe and everything here
+        would stay green — which was false and contradicted the wiring test
+        below. The wiring claim lives there, on the CALL; this one only pins
+        that the dangerous input is still refused.
         """
         protected = Path.home() / "backups"
         cmd = "rm -rf $'a\\'b)c' " + str(protected)
@@ -129,8 +161,101 @@ class TestProtectedPathsUsesTheSharedProbe:
         assert r.returncode == 2, r.stdout + r.stderr
 
     def test_ordinary_rm_is_untouched(self, tmp_path):
+        # `== 0`, not `!= 2`: an import-time crash exits 1 and would satisfy the
+        # looser form, so it would pass against a guard that is entirely broken.
         r = _run(_PROTECTED_GUARD, f"rm -rf {tmp_path}/scratch", cwd=str(tmp_path))
-        assert r.returncode != 2, r.stdout + r.stderr
+        assert r.returncode == 0, r.stdout + r.stderr
+
+    def _guard_in_tree_whose_probe(self, tmp_path, label: str, body: str, command: str):
+        """Run the guard from a temp tree whose `shell_parse` is ours.
+
+        The guard does `sys.path.insert(0, dirname(__file__))` before importing,
+        so the sibling written here is the module it actually gets — PYTHONPATH
+        shadowing loses to that (measured in the crash test below). Every name
+        except `untokenizable` is delegated to the genuine parser, so exactly
+        one variable changes between the two calls.
+        """
+        hooks = tmp_path / label / "hooks"
+        hooks.mkdir(parents=True)
+        (hooks / _PROTECTED_GUARD.name).write_text(_PROTECTED_GUARD.read_text())
+        (hooks / "hook_input.py").write_text((_HOOKS_DIR / "hook_input.py").read_text())
+        (hooks / "shell_parse.py").write_text(
+            "import importlib.util, sys\n"
+            "_s = importlib.util.spec_from_file_location(\n"
+            f"    '_real_sp', {str(_HOOKS_DIR / 'shell_parse.py')!r}\n"
+            ")\n"
+            "_real = importlib.util.module_from_spec(_s)\n"
+            # Register BEFORE exec_module: @dataclass resolves
+            # sys.modules[cls.__module__] while creating the class, and a module
+            # missing from it raises AttributeError at IMPORT time. That crash
+            # exits 1 (the documented import-time fail-open), which silently
+            # satisfies a "did not block" assertion — this test was vacuous for
+            # exactly that reason until the control below caught it.
+            "sys.modules['_real_sp'] = _real\n"
+            "_s.loader.exec_module(_real)\n"
+            # Delegate EVERY other name via PEP 562 rather than listing them.
+            # A hand-written list goes stale the moment the guard imports one
+            # more symbol, and the failure is not obvious: the guard's import
+            # raises, the child exits 1, and that is an import crash wearing the
+            # costume of a verdict. This way the ONLY difference from a real run
+            # is the probe's answer, by construction.
+            "def __getattr__(name):\n    return getattr(_real, name)\n"
+            f"def untokenizable(*a, **k):\n    {body}\n"
+        )
+        return subprocess.run(
+            [_PY, str(hooks / _PROTECTED_GUARD.name)],
+            input=json.dumps(
+                {
+                    "tool_name": "Bash",
+                    "tool_input": {"command": command},
+                    "cwd": str(tmp_path),
+                }
+            ),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_child_env(),
+            cwd=str(tmp_path),
+        )
+
+    def test_the_guard_actually_CALLS_the_shared_probe(self, tmp_path):
+        """Wiring, asserted directly: make the shared probe raise.
+
+        The behavioural test above passes against the PARENT implementation too
+        — its inline copy calls the same command untokenizable and blocks
+        through the same legacy fallback — so alone it cannot tell a wired guard
+        from a duplicated one, and reverting only the refactor leaves that whole
+        class green.
+
+        Nor can a VERDICT on the ANSI-C command carry the claim, which is what
+        this test tried first: with the probe forced to answer "tokenizable"
+        that command STILL blocks, because the unresolved-`$` operand check further down `main` reaches
+        the same legacy fallback by a second route when an operand keeps an
+        unresolved `$`. The guard is defence-in-depth there, so its verdict is
+        the wrong observable — the probe could be deleted entirely and the
+        verdict would not move.
+
+        So observe the CALL instead, on a BENIGN command whose honest verdict is
+        allow: a probe that raises turns into a fail-closed 2 if and only if the
+        guard consults it. An inline copy never touches ours and still exits 0.
+        """
+        benign = f"rm -rf {tmp_path}/a/b/c/scratch"
+        honest = self._guard_in_tree_whose_probe(
+            tmp_path, "honest", "return _real.untokenizable(*a, **k)", benign
+        )
+        assert honest.returncode == 0, (
+            "POSITIVE CONTROL FAILED — this command is not an allow in the temp "
+            "tree, so the poisoned run below cannot mean what it claims.\n"
+            f"{honest.stdout}{honest.stderr}"
+        )
+        poisoned = self._guard_in_tree_whose_probe(
+            tmp_path, "raising", "raise RuntimeError('probe consulted')", benign
+        )
+        assert poisoned.returncode == 2, (
+            "a raising shared probe did not reach the guard, so the guard is "
+            "not calling it — the private copy is back.\n"
+            f"{poisoned.stdout}{poisoned.stderr}"
+        )
 
 
 class TestCommitGuardFailsClosedOnCrash:
@@ -234,7 +359,53 @@ class TestCommitGuardFailsClosedOnCrash:
         """CONTROL — the wrap must not turn every command into a block.
 
         Without this, a guard that exits 2 unconditionally would satisfy the
-        test above.
+        test above — but only if the command REACHES the guarded code, and the
+        obvious phrasing does not. `_COMMIT_PATTERN` is `\\bcommit\\b`, and
+        "echo not a git command" does not match it ("command" is not "commit"),
+        so the guard returned at its early-out before `analyze()`, before the
+        `review_state` import, before any git call. Everything this control
+        exists to cover was downstream of the return. Use a real commit in a
+        non-repo tmp dir, which does traverse all of it and still allows.
         """
-        r = _run(_COMMIT_GUARD, "echo not a git command", cwd=str(tmp_path))
-        assert r.returncode != 2, r.stdout + r.stderr
+        r = _run(_COMMIT_GUARD, f"git {COMMIT} -m x", cwd=str(tmp_path))
+        assert r.returncode == 0, r.stdout + r.stderr
+
+    def test_a_broken_review_state_does_not_wall_off_every_commit(self, tmp_path):
+        """The fail-closed wrap must not make the gate block its own repair.
+
+        `main()` imports `review_state` inside a try/except. While that caught
+        only ImportError, a SyntaxError in that module escaped it and exited 1 —
+        non-blocking, so commits proceeded. Wrapping main() in `run_guard`
+        silently converted that escape into a hard BLOCK, and MEASURED it blocks
+        EVERY commit on the box: `# review-override` cannot rescue it either,
+        because the override is parsed after the import. That includes the
+        commit repairing review_state, so the gate walls off its own fix.
+
+        A broken review-round ledger costs the round advisory, never the ability
+        to commit — which is the degrade the sibling guard already applies to
+        the SAME module.
+        """
+        scripts = tmp_path / "scripts"
+        hooks = scripts / "hooks"
+        hooks.mkdir(parents=True)
+        (scripts / _COMMIT_GUARD.name).write_text(_COMMIT_GUARD.read_text())
+        for dep in ("hook_input.py", "shell_parse.py"):
+            (hooks / dep).write_text((_HOOKS_DIR / dep).read_text())
+        # Not an ImportError: the module is present and imports cleanly as a
+        # FILE, but fails to compile. That is the case the narrow handler missed.
+        (scripts / "review_state.py").write_text("def broken(:\n")
+        r = subprocess.run(
+            [_PY, str(scripts / _COMMIT_GUARD.name)],
+            input=json.dumps(
+                {"tool_name": "Bash", "tool_input": {"command": f"git {COMMIT} -m x"}}
+            ),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_child_env(),
+            cwd=str(tmp_path),
+        )
+        assert r.returncode == 0, (
+            "a broken review_state hard-blocks every commit, including the one "
+            f"that would fix it.\n{r.stdout}{r.stderr}"
+        )

--- a/tests/test_hooks/test_untokenizable_probe.py
+++ b/tests/test_hooks/test_untokenizable_probe.py
@@ -1,0 +1,240 @@
+"""Shared tokenizability probe, and the commit gate's fail-closed wrapper.
+
+`shell_parse.analyze()` degrades to a naive split on a shlex error SILENTLY, so
+it cannot report that its own answer is untrustworthy: "no gated segment found"
+and "no gated command present" are the same return value. `untokenizable()` is
+the signal that separates them, so a security-critical caller can pick its own
+fail direction while the parser keeps degrading gracefully.
+
+This file covers the probe itself, the removal of the third hand-rolled copy of
+it, and the commit gate's `run_guard` wrapper. It does NOT cover any gate that
+consumes the probe to make a verdict — that lives with the change that adds one.
+
+Trigger literals are assembled from fragments so this file's own text does not
+carry them (matching the convention in test_shell_parse.py).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parent.parent.parent
+_HOOKS_DIR = _WORKTREE / "scripts" / "hooks"
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+import shell_parse as sp  # noqa: E402
+
+_COMMIT_GUARD = _WORKTREE / "scripts" / "review_enforcement_commit.py"
+_PROTECTED_GUARD = _HOOKS_DIR / "protected_paths_guard.py"
+_PY = sys.executable
+
+COMMIT = "com" + "mit"
+
+# ALLOWLIST, not a subtract-list. A guard child that inherits the caller's
+# environment reports on the caller, not on the code: `GIT_DIR` re-points
+# repo-state lookups at whatever repo the developer happens to be in, and
+# `GENESIS_CC_SESSION` makes a suite test its caller's session mode. Naming what
+# may pass means the NEXT ambient input cannot leak in by default.
+_NEUTRAL_ENV = frozenset({"PATH", "TMPDIR", "LANG", "LC_ALL", "LC_CTYPE", "PYTHONHASHSEED"})
+
+
+def _child_env(**extra: str) -> dict[str, str]:
+    env = {k: v for k, v in os.environ.items() if k in _NEUTRAL_ENV}
+    env["GIT_CONFIG_GLOBAL"] = os.devnull  # no developer gitconfig (gpgsign etc.)
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
+    env.update(extra)
+    return env
+
+
+def _run(script: Path, cmd: str, cwd: str, **env_extra: str) -> subprocess.CompletedProcess:
+    """Run a guard with the payload cwd and the child cwd AGREEING.
+
+    Passing cwd only in the payload leaves the child in whatever directory
+    pytest ran from, so repo-state gates silently evaluate the wrong repository.
+    """
+    return subprocess.run(
+        [_PY, str(script)],
+        input=json.dumps({"tool_name": "Bash", "tool_input": {"command": cmd}, "cwd": cwd}),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_child_env(**env_extra),
+        cwd=cwd,
+    )
+
+
+class TestUntokenizable:
+    """The probe's contract: True exactly when shlex cannot tokenize the RAW text."""
+
+    def test_ansic_escaped_quote_is_untokenizable(self):
+        # shell_parse reads `$'…'` as a plain single-quote span, so the `\'`
+        # inside closes it early — the exact shape that shifts segmentation.
+        assert sp.untokenizable("echo $'a\\'b)c'") is True
+
+    def test_heredoc_body_apostrophe_is_untokenizable(self):
+        # An ORDINARY shape, not an evasion: a quoted here-doc whose body
+        # contains a contraction. It genuinely shifts analyze()'s segmentation,
+        # so the probe must report it rather than normalising it away.
+        cmd = f"{COMMIT} -F - <<'EOF'\nit's a message with an apostrophe\nEOF"
+        assert sp.untokenizable(cmd) is True
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "echo hello",
+            "git status --short",
+            "grep -n 'pattern' file.txt",
+            "python3 -c \"print('ok')\"",
+            # $'…' with no escaped quote tokenizes fine and must NOT be flagged
+            "git commit -m $'line1\\nline2'",
+        ],
+    )
+    def test_ordinary_commands_are_tokenizable(self, cmd):
+        assert sp.untokenizable(cmd) is False
+
+    def test_probe_reads_the_raw_command(self):
+        """No normalisation, and specifically no line-continuation folding.
+
+        An earlier revision folded `\\<newline>` to a SPACE first. That is wrong
+        about bash, which REMOVES a continuation and joins the halves into one
+        word, and it also contradicted the probe's own contract. Measured over
+        12,099 real commands the two classify identically, so the fold bought
+        nothing; this pins the raw reading so it cannot creep back.
+        """
+        cmd = "git pu\\\nsh origin main"
+        assert sp.untokenizable(cmd) is False
+        # The raw text still contains the continuation — nothing rewrote it.
+        assert "\\\n" in cmd
+
+
+class TestProtectedPathsUsesTheSharedProbe:
+    """The third hand-rolled copy of the probe is gone; behaviour is preserved."""
+
+    def test_ansic_obfuscated_rm_of_protected_dir_still_blocks(self, tmp_path):
+        """The reason the inline probe existed — it must still work.
+
+        Without this control the refactor could delete the probe entirely and
+        every other assertion here would stay green.
+        """
+        protected = Path.home() / "backups"
+        cmd = "rm -rf $'a\\'b)c' " + str(protected)
+        r = _run(_PROTECTED_GUARD, cmd, cwd=str(tmp_path))
+        assert r.returncode == 2, r.stdout + r.stderr
+
+    def test_ordinary_rm_is_untouched(self, tmp_path):
+        r = _run(_PROTECTED_GUARD, f"rm -rf {tmp_path}/scratch", cwd=str(tmp_path))
+        assert r.returncode != 2, r.stdout + r.stderr
+
+
+class TestCommitGuardFailsClosedOnCrash:
+    """A crash in the commit gate must BLOCK, not silently allow.
+
+    CC's PreToolUse contract is "exit 2 = block; ANY other code = non-blocking,
+    the tool runs". The module called `main()` bare, so every uncaught exception
+    exited 1 — a silent fail-open on a commit.
+    """
+
+    def test_real_module_crash_exits_2(self, tmp_path):
+        """Drives the REAL module and makes IT crash.
+
+        An earlier version of this test built a local function that raised and
+        handed it to `run_guard`, naming the module only in a string. That
+        passes against the UNWRAPPED module too — it proves `run_guard` works,
+        not that this gate uses it, so it was vacuous with respect to the change
+        it claimed to cover.
+
+        Shadowing via PYTHONPATH does not work either: the guard does
+        `sys.path.insert(0, dirname(__file__)/"hooks")` before importing, which
+        beats PYTHONPATH, so the real dependency wins and nothing crashes
+        (measured: exit 0). Since that path is resolved relative to the guard's
+        OWN location, the module is copied into a temp tree whose sibling
+        `hooks/` holds a poisoned `shell_parse` — so the import the real module
+        performs is the one that fails.
+        """
+        scripts = tmp_path / "scripts"
+        hooks = scripts / "hooks"
+        hooks.mkdir(parents=True)
+        (scripts / _COMMIT_GUARD.name).write_text(_COMMIT_GUARD.read_text())
+        # Real helper (run_guard must be the genuine one), and a parser that
+        # IMPORTS cleanly but raises when called. The distinction is the whole
+        # point: raising at import time crashes before `run_guard(main, …)` is
+        # ever reached, so the wrapper cannot catch it — see
+        # test_import_time_failure_is_a_documented_gap below. To exercise the
+        # wrapper the failure has to originate inside main().
+        (hooks / "hook_input.py").write_text((_HOOKS_DIR / "hook_input.py").read_text())
+        (hooks / "shell_parse.py").write_text(
+            "def analyze(command):\n"
+            "    raise RuntimeError('induced failure inside the real guard')\n"
+            "def commit_skips_hooks(*a, **k):\n    return False\n"
+            "def git_subcommand(*a, **k):\n    return None\n"
+            "def has_trailing_override(*a, **k):\n    return False\n"
+            "def split_segments(*a, **k):\n    return []\n"
+            "def untokenizable(*a, **k):\n    return False\n"
+        )
+        r = subprocess.run(
+            [_PY, str(scripts / _COMMIT_GUARD.name)],
+            input=json.dumps(
+                {"tool_name": "Bash", "tool_input": {"command": f"git {COMMIT} -m x"}}
+            ),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_child_env(),
+            cwd=str(tmp_path),
+        )
+        assert r.returncode == 2, (
+            "a crash in the commit gate must fail CLOSED (exit 2); "
+            f"got {r.returncode}\n{r.stdout}{r.stderr}"
+        )
+
+    def test_import_time_failure_is_a_documented_gap(self, tmp_path):
+        """The wrap covers main(), NOT module import. Measured, and locked.
+
+        `run_guard` is called at the bottom of the module, so an exception
+        raised while the module is still importing — a broken dependency, a
+        syntax error in a helper — never reaches it. MEASURED: the guard exits 1
+        in that case, which CC treats as non-blocking, i.e. it still fails OPEN.
+
+        This is pinned rather than hidden so the wrap is not read as a stronger
+        guarantee than it is. Closing it needs the import itself guarded, which
+        is a different change; what this PR fixes is every crash from main()
+        onward, which is where the gate's own logic lives.
+        """
+        scripts = tmp_path / "scripts"
+        hooks = scripts / "hooks"
+        hooks.mkdir(parents=True)
+        (scripts / _COMMIT_GUARD.name).write_text(_COMMIT_GUARD.read_text())
+        (hooks / "hook_input.py").write_text((_HOOKS_DIR / "hook_input.py").read_text())
+        (hooks / "shell_parse.py").write_text("raise RuntimeError('broken at import')\n")
+        r = subprocess.run(
+            [_PY, str(scripts / _COMMIT_GUARD.name)],
+            input=json.dumps(
+                {"tool_name": "Bash", "tool_input": {"command": f"git {COMMIT} -m x"}}
+            ),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=_child_env(),
+            cwd=str(tmp_path),
+        )
+        assert r.returncode == 1, (
+            "documented gap changed — an import-time failure now exits "
+            f"{r.returncode}. If this is now 2 the gap is CLOSED: delete this "
+            "test and say so, rather than loosening it."
+        )
+
+    def test_ordinary_commit_still_reaches_a_verdict(self, tmp_path):
+        """CONTROL — the wrap must not turn every command into a block.
+
+        Without this, a guard that exits 2 unconditionally would satisfy the
+        test above.
+        """
+        r = _run(_COMMIT_GUARD, "echo not a git command", cwd=str(tmp_path))
+        assert r.returncode != 2, r.stdout + r.stderr


### PR DESCRIPTION
## Summary

Three pieces of infrastructure, **split out of the guard-net PR** so that PR's design can be reviewed on its own. Nothing here decides a verdict — this is the plumbing a net would consume, and each piece stands alone.

The net itself, its mention predicates, and its dispatched deny leg are **not** in this branch (verified by grep, not by reading the diff).

## What's here

**1. `shell_parse.py` gains `untokenizable()`** — additive, stdlib only, no parse-logic change and no existing caller altered.

The parser degrades to a naive split on a `shlex` error **silently**. That means `analyze()` cannot report that its own answer is untrustworthy: *"no gated segment found"* and *"no gated command present"* are the same return value, and a caller that treats the first as the second fails **open**. The probe separates them, so a security-critical caller can choose its own fail direction at its own boundary while the parser keeps degrading gracefully — which is its stated contract.

It reads the **raw** command. No here-doc normalization, and no line-continuation folding either — the fold was *removed* rather than documented. It was wrong about bash, which **removes** a continuation and joins the halves into one word rather than replacing it with a space, so the fold produced the reading furthest from what actually executes. And it bought nothing: measured over **12,099 real commands**, folding and not folding classify identically — 339 un-tokenizable either way, **zero commands differ**.

**2. `protected_paths_guard.py` moves onto the shared probe** — deleting the *third* hand-rolled copy, which had already drifted from the others. Behaviour-preserving on real traffic per the measurement above; the comment says "not byte-identical, measured equivalent" rather than claiming a byte-equivalence it no longer has.

**3. `review_enforcement_commit.py` is wrapped in `run_guard`** instead of calling `main()` bare. The PreToolUse contract is *exit 2 = block; any other code = non-blocking, the tool runs* — so every uncaught exception in that gate exited 1 and let the commit through, silently. Deliberate allow/deny paths raise `SystemExit` and are untouched.

## A limit, pinned rather than papered over

**The wrap is narrower than it reads.** `run_guard` is called at the bottom of the module, so a failure raised while the module is still *importing* never reaches it — measured, that still exits 1, i.e. still fails open.

That's asserted by a test which pins the exit code and instructs a future reader to **delete** the test and say so if the gap is ever closed, rather than loosen it. Claiming "fails closed on crash" unqualified would have been an overclaim.

## Tests

Built against the failure class that produced defects on the parent branch — twice there, a test harness substituted its own context for the one under test and the suite stayed green:

- the child environment is an **allowlist**, not a subtract-list, so the next ambient input cannot leak in by default;
- git's config is pinned away from the developer's own, so a global setting such as commit signing cannot quietly break a fixture into a state where it proves nothing;
- payload cwd and child cwd always agree, so repo-state gates can't silently evaluate the wrong repository;
- the crash test drives the **real module**. An earlier draft handed a locally-defined function to `run_guard` and named the module only in a string — that passes against the *unwrapped* module too, so it proved `run_guard` works, not that this gate uses it.
- every behavioural class carries a **positive control** (the obfuscated `rm` that must still block; the ordinary command that must not). Without them, a guard that never fires — or one that always exits 2 — would satisfy the suite.

**356 pass**: 13 in the new file, 343 across the five affected existing suites. `ruff` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for commands that cannot be parsed reliably.
  * Preserved conservative safeguards when malformed input is encountered.
  * Improved commit validation when state information is unavailable or malformed.
  * Unexpected validation failures now produce a clear blocking result instead of silently passing.
  * Unverifiable commit-related commands now require approval or are blocked in unattended sessions.

* **Tests**
  * Added comprehensive coverage for command parsing, validation failures, malformed state handling, and safeguards against publishing bypass guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->