### PR TITLE
fix(tests): read the clock where it is used, and guard the class in CI

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -801,6 +801,7 @@ ruff check src/ tests/ scripts/
 python scripts/check_external_io.py
 python scripts/check_subsystem_map.py
 python scripts/check_shared_artifact_consumers.py
+python scripts/check_frozen_clock.py
 ```
 
 Do NOT run the full pytest suite locally (it is banned, and the concurrent-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,24 @@ jobs:
       - name: External-I/O egress guard
         run: python scripts/check_external_io.py
 
+  frozen-clock-check:
+    # A test that captures a wall clock at IMPORT time gives the whole suite's
+    # runtime to burn its safety margin, then fails on slow runners as an
+    # unreproducible "flake". Measured instance: a 25-minute margin that passed
+    # at 16m into a run and failed at 27m (~3% of runs). Runs as its own fast
+    # job so the finding reads as a lint error in seconds rather than surfacing
+    # 16 minutes into the suite. Escape hatch is
+    # '# frozen-clock-ok: <why, with the measured margin>'.
+    # See scripts/check_frozen_clock.py.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Frozen-clock guard
+        run: python scripts/check_frozen_clock.py
+
   subsystem-map-check:
     # Judgment-layer map guard: docs/architecture/CURRENT.md must claim every
     # top-level src/genesis module (an unmapped or vanished module = the map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,31 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A test no longer reads the wall clock once at import and races the suite.**
+  `test_surplus_liveness.py` captured `datetime.now(UTC)` at module import and
+  seeded a heartbeat 30 minutes ahead of it; production ages that seed against
+  the *live* clock with a 5-minute future-skew tolerance, so the assertion only
+  held while under 25 minutes had elapsed since import — the whole suite's
+  runtime, not the test's. Measured on both sides of that boundary: the test
+  passed 16m02s into a run and failed at 27m12s, roughly 3% of runs. The seed is
+  now computed when the helper is called, shrinking the margin from the suite's
+  runtime to one test's. (An earlier draft of this entry claimed the old test
+  silently stopped exercising the branch it names; that is not what happens and
+  the claim is withdrawn — past the edge it fails loudly, because the
+  past-pulse path cannot satisfy the assertion either way.)
+- **New `frozen-clock-check` CI guard for the whole class.** This was the third
+  recurrence; the two earlier sweeps each enumerated absolute date *literals* and
+  declared the class closed, so a clock frozen at import walked through both.
+  `scripts/check_frozen_clock.py` keys on *when the clock is read* rather than
+  how a date is spelled, and fails in seconds as its own job instead of surfacing
+  deep inside the suite. It flags wall-clock calls evaluated in a module body,
+  class body, default argument, decorator argument, or a
+  session/module/package-scoped fixture, and ignores the call-time forms that are
+  the fix. Escape hatch `# frozen-clock-ok: <why, with the measured margin>` on
+  the line or the comment block above it; a reason is required. This closes the
+  mechanically-decidable sub-shape only — an absolute date literal is a bomb only
+  relative to a production threshold, which is not statically decidable, and no
+  claim is made that the literal population is clean.
 - **SSH slot cap no longer collapses below the running session count.** The
   interactive-slot launcher (`scripts/cc-slot.sh`) sized its cap from
   *instantaneous free RAM* (`(MemAvailable − reserve) / per_session`), so each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,10 +96,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   `scripts/check_frozen_clock.py` keys on *when the clock is read* rather than
   how a date is spelled, and fails in seconds as its own job instead of surfacing
   deep inside the suite. It flags wall-clock calls evaluated in a module body,
-  class body, default argument, decorator argument, or a
-  session/module/package-scoped fixture, and ignores the call-time forms that are
-  the fix. Escape hatch `# frozen-clock-ok: <why, with the measured margin>` on
-  the line or the comment block above it; a reason is required. This closes the
+  class body, default argument, decorator argument, or any fixture whose scope is
+  broader than `function` — including inside module-level `if`/`try`/`with`/`for`/
+  `while` bodies, comprehensions, and a generator expression's leftmost iterable,
+  which is evaluated at creation. It ignores the call-time forms that are the fix:
+  function and lambda bodies, the defaults and decorators of a `def` nested in one,
+  a generator expression's element, `skipif`/`xfail` conditions (import-time by
+  contract), and `if __name__ == "__main__":` blocks. Escape hatch
+  `# frozen-clock-ok: <why, with the measured margin>` on the flagged statement or
+  the comment block above it; the reason must state a magnitude, and a span needs
+  as many waivers as it has flagged calls, so one waiver cannot cover two sites. This closes the
   mechanically-decidable sub-shape only — an absolute date literal is a bomb only
   relative to a production threshold, which is not statically decidable, and no
   claim is made that the literal population is clean.

--- a/scripts/check_frozen_clock.py
+++ b/scripts/check_frozen_clock.py
@@ -111,11 +111,15 @@ CLOCK_SUFFIXES: tuple[str, ...] = (
     "time.clock_gettime_ns",
 )
 
+# ``localtime(secs)``/``gmtime(secs)`` CONVERT a supplied epoch value; only their
+# zero-argument forms read the current clock.
+ARG_SENSITIVE: frozenset[str] = frozenset({"time.localtime", "time.gmtime"})
+
 # Fixture scopes whose body is evaluated once, well before the tests that use it.
 BROAD_SCOPES = frozenset({"session", "module", "package", "class"})
 
 # Decorators whose arguments are import-time BY CONTRACT — flagging them is noise.
-IMPORT_TIME_BY_DESIGN = ("skipif", "xfail")
+IMPORT_TIME_BY_DESIGN = frozenset({"skipif", "xfail"})
 
 OPT_OUT = re.compile(r"#\s*frozen-clock-ok:\s*(?P<reason>\S.*)")
 # A margin is a magnitude. "unbounded" is the honest form for a site nothing ages.
@@ -142,36 +146,68 @@ def _is_clock(dotted: str) -> bool:
     return any(dotted == s or dotted.endswith("." + s) for s in CLOCK_SUFFIXES)
 
 
-def _clock_calls(node: ast.AST) -> list[tuple[int, int, str, int]]:
-    """Clock calls in ``node``, NOT descending into anything evaluated later.
+def _terminal(dotted: str) -> str:
+    """Last dotted component — ``pytest.mark.skipif`` -> ``skipif``.
+
+    Matched exactly rather than by suffix: ``endswith("skipif")`` also accepts
+    ``custom_skipif``, which would let an arbitrary decorator disarm the guard, and
+    ``endswith("fixture")`` accepts ``not_a_fixture``, which would flag its body.
+    """
+    return dotted.rsplit(".", 1)[-1]
+
+
+def _reads_the_clock(call: ast.Call) -> bool:
+    """True if this call actually reads the current time."""
+    dotted = _dotted(call.func)
+    if not _is_clock(dotted):
+        return False
+    if any(dotted == s or dotted.endswith("." + s) for s in ARG_SENSITIVE):
+        # gmtime(0) converts a supplied epoch; gmtime() reads the clock.
+        return not (call.args or call.keywords)
+    return True
+
+
+def _eager_children(node: ast.AST) -> list[ast.AST]:
+    """Children of ``node`` evaluated NOW, with the deferred parts pruned.
+
+    Three constructs are part-eager and part-deferred, and treating any of them as
+    wholly deferred loses a real import-time read:
+      * a ``def``/``lambda`` BODY runs when called, but its DEFAULTS are evaluated
+        where the definition appears;
+      * a generator expression's element and inner ``for`` clauses are lazy, but its
+        LEFTMOST iterable is consumed when the generator is created.
+    """
+    out: list[ast.AST] = []
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.Lambda):
+            out.extend(child.args.defaults)
+            out.extend(d for d in child.args.kw_defaults if d)
+            continue
+        if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue  # its defaults/decorators are visited with the function itself
+        if isinstance(child, ast.GeneratorExp):
+            if child.generators:
+                out.append(child.generators[0].iter)
+            continue
+        out.append(child)
+    return out
+
+
+def _clock_calls(node: ast.AST) -> list[ast.Call]:
+    """Clock-reading calls in ``node`` that are evaluated when ``node`` is.
 
     The ROOT is checked as well as the children: a scoped fixture may hold a nested
-    ``def`` whose body only runs when the returned callable is invoked. Such a node's
-    own defaults and decorators are not lost — every function in the tree is visited
-    separately for those.
+    ``def`` whose body only runs when the returned callable is invoked.
     """
     if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
         return []
-    found: list[tuple[int, int, str, int]] = []
+    found: list[ast.Call] = []
     stack: list[ast.AST] = [node]
     while stack:
         cur = stack.pop()
-        if isinstance(cur, ast.Call):
-            dotted = _dotted(cur.func)
-            if _is_clock(dotted):
-                found.append((cur.lineno, cur.col_offset, dotted, id(cur)))
-        for child in ast.iter_child_nodes(cur):
-            # Deferred: a function/lambda body runs when called.
-            if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
-                continue
-            # A generator expression is lazy EXCEPT its leftmost iterable, which is
-            # evaluated the moment the genexp is created. Comprehensions are eager
-            # throughout and stay in scope.
-            if isinstance(child, ast.GeneratorExp):
-                if child.generators:
-                    stack.append(child.generators[0].iter)
-                continue
-            stack.append(child)
+        if isinstance(cur, ast.Call) and _reads_the_clock(cur):
+            found.append(cur)
+        stack.extend(_eager_children(cur))
     return found
 
 
@@ -184,7 +220,7 @@ def _fixture_scope(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
     """
     for dec in fn.decorator_list:
         target = dec.func if isinstance(dec, ast.Call) else dec
-        if not _dotted(target).endswith("fixture"):
+        if _terminal(_dotted(target)) != "fixture":
             continue
         if not isinstance(dec, ast.Call):
             return "function"
@@ -249,6 +285,20 @@ def _top_level_functions(tree: ast.AST):
     return out
 
 
+def _fixture_setup(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.stmt]:
+    """The statements of a fixture that run during SETUP.
+
+    A generator fixture's statements after ``yield`` run at TEARDOWN — after every
+    consumer has finished — so a clock read there cannot age before it is used.
+    """
+    setup: list[ast.stmt] = []
+    for stmt in fn.body:
+        setup.append(stmt)
+        if any(isinstance(n, ast.Yield | ast.YieldFrom) for n in ast.walk(stmt)):
+            break
+    return setup
+
+
 def _is_dunder_main(node: ast.stmt) -> bool:
     """``if __name__ == "__main__":`` — never executed under pytest."""
     if not isinstance(node, ast.If):
@@ -272,11 +322,32 @@ def _under_import_time_contract(node: ast.AST) -> set[int]:
         if not isinstance(sub_node, ast.Call):
             continue
         target = sub_node.func
-        if _dotted(target).endswith(IMPORT_TIME_BY_DESIGN):
+        if _terminal(_dotted(target)) in IMPORT_TIME_BY_DESIGN:
             for inner in ast.walk(sub_node):
-                if isinstance(inner, ast.Call) and _is_clock(_dotted(inner.func)):
+                if isinstance(inner, ast.Call) and _reads_the_clock(inner):
                     exempt.add(id(inner))
     return exempt
+
+
+def _enclosing_statements(tree: ast.AST) -> dict[int, ast.stmt]:
+    """id(node) -> the INNERMOST statement containing it.
+
+    A waiver binds to the statement its clock actually sits in. Keying to an outer
+    compound statement instead would pool every clock in an ``if``/``try`` block into
+    one span, where a stale marker left beside a deleted clock would silently exempt a
+    different clock added elsewhere in the same block.
+    """
+    owner: dict[int, ast.stmt] = {}
+
+    def walk(node: ast.AST, current: ast.stmt | None) -> None:
+        for child in ast.iter_child_nodes(node):
+            inner = child if isinstance(child, ast.stmt) else current
+            if inner is not None:
+                owner[id(child)] = inner
+            walk(child, inner)
+
+    walk(tree, None)
+    return owner
 
 
 def scan_source(source: str, rel: str) -> list[Violation]:
@@ -284,18 +355,22 @@ def scan_source(source: str, rel: str) -> list[Violation]:
     tree = ast.parse(source)
     lines = source.splitlines()
     comments = _comment_lines(source)
-    hits: dict[tuple[int, int, str], Hit] = {}
-
+    owner = _enclosing_statements(tree)
     exempt_calls = _under_import_time_contract(tree)
-
-    def record(node: ast.AST, shape: str, span: tuple[int, int]) -> None:
-        for lineno, col, dotted, node_id in _clock_calls(node):
-            if node_id in exempt_calls:
-                continue
-            hits.setdefault((lineno, col, dotted), (lineno, col, dotted, shape, *span))
+    hits: dict[tuple[int, int, str], Hit] = {}
 
     def span_of(node: ast.AST) -> tuple[int, int]:
         return (node.lineno, getattr(node, "end_lineno", None) or node.lineno)
+
+    def record(node: ast.AST, shape: str, span: tuple[int, int] | None = None) -> None:
+        for call in _clock_calls(node):
+            if id(call) in exempt_calls:
+                continue
+            # Bind to the innermost statement holding THIS call, not to the outer
+            # construct we happened to start the walk from.
+            here = span if span is not None else span_of(owner.get(id(call), call))
+            key = (call.lineno, call.col_offset, _dotted(call.func))
+            hits.setdefault(key, (*key, shape, *here))
 
     def walk_import_time(body: list[ast.stmt], shape: str) -> None:
         """Statements evaluated when the module is imported."""
@@ -306,13 +381,10 @@ def scan_source(source: str, rel: str) -> list[Violation]:
                 continue  # only runs when the file is executed directly, never in a suite
             if isinstance(st, ast.ClassDef):
                 for extra in [*st.decorator_list, *st.bases, *st.keywords]:
-                    # span_of(extra), NOT span_of(st): keying these to the whole class
-                    # body would let one waiver inside the class silence a base-class
-                    # clock, and let that same waiver be counted twice.
                     record(extra, shape, span_of(extra))
                 walk_import_time(st.body, "class-body")
                 continue
-            record(st, shape, span_of(st))
+            record(st, shape)
 
     walk_import_time(tree.body, "module-body")
 
@@ -325,17 +397,17 @@ def scan_source(source: str, rel: str) -> list[Violation]:
         for dec in node.decorator_list:
             record(dec, "decorator-arg", span_of(dec))
         if (_fixture_scope(node) or "function") in BROAD_SCOPES:
-            for st in node.body:
-                record(st, "scoped-fixture", span_of(st))
+            for st in _fixture_setup(node):
+                record(st, "scoped-fixture")
 
     by_span: dict[tuple[int, int], list[Hit]] = {}
     for hit in hits.values():
         by_span.setdefault((hit[4], hit[5]), []).append(hit)
 
     out: list[Violation] = []
-    for (start, end), group in by_span.items():
+    for (start_line, end_line), group in by_span.items():
         # One recorded measurement per site: N calls in a span need N waivers.
-        waived = _markers_for_span(comments, lines, start, end)
+        waived = _markers_for_span(comments, lines, start_line, end_line)
         for hit in sorted(group)[waived:]:
             out.append((rel, hit[0], hit[3], hit[2]))
     return sorted(out, key=lambda v: (v[0], v[1]))

--- a/scripts/check_frozen_clock.py
+++ b/scripts/check_frozen_clock.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Frozen-clock guard — no test may capture a wall clock at IMPORT time.
+
+THE BUG CLASS THIS CLOSES (three recurrences: #978, #1441, and again in 2026-08).
+A test materialises a timestamp into state under test; production then AGES that
+timestamp against the LIVE clock with no injectable ``now``. The assertion holds only
+while (elapsed since the capture) stays under (seed offset - production threshold). A
+whole test suite takes many minutes to run, so a capture evaluated ONCE at import gives
+the whole suite's runtime to burn that margin — and the failure surfaces on slow
+runners only, which is how it survived twice.
+
+Measured instance that motivated this guard: a pulse seeded 30 minutes in the future,
+checked against a 5-minute future-skew tolerance, i.e. a 25-minute margin. It passed at
+16m02s into a CI run and FAILED at 27m12s. Roughly 3% of runs (1 of 31 surveyed).
+
+Syntax is NOT the key. Both earlier sweeps enumerated absolute ISO-date LITERALS and
+each declared the class closed; a ``datetime.now()`` frozen at import walked straight
+through both. So this guard keys on WHEN THE CLOCK IS READ, not on how a date is spelled.
+
+WHAT IT FLAGS — a wall-clock call in a position evaluated ONCE, early:
+  * module body          — the classic; one read for the entire session
+  * class body           — same, at class-definition time
+  * default argument     — evaluated at ``def`` time, not per call
+  * decorator argument   — evaluated at import (e.g. inside ``@parametrize(...)``)
+  * session/module/package-scoped fixture body — one read per session/module/package
+
+WHAT IT DOES NOT FLAG (deliberately — these read the clock at use time):
+  * any call inside an ordinary function/method/lambda body, including function-scoped
+    fixtures. That is the FIX this guard steers you toward.
+  * a generator expression's body, which is lazy. List/set/dict comprehensions ARE
+    eager and so ARE flagged.
+  * ``@pytest.mark.skipif(...)``, whose whole contract is import-time evaluation.
+
+SCOPE IS ``tests/`` DELIBERATELY, and the reason is not that production is exempt: a
+module-level clock in a long-running daemon is the worse version of this bug. It is
+that in production such a capture is usually a legitimate process-start baseline
+(``guardian/check.py`` holds one, correctly, for uptime), so the shape carries no
+signal there, while under ``tests/`` it is nearly always the bug. A ``src/`` sweep run
+when this guard was written found exactly that one site and nothing else.
+
+KNOWN BLIND SPOTS, stated rather than implied:
+  * an ALIASED import — ``from datetime import datetime as dt`` then ``dt.now()``, or
+    ``from time import time`` then ``time()``. Matching is on the dotted call, so an
+    alias is invisible. This is the blind spot a contributor is most likely to hit by
+    accident; widening the match to any bare ``now()``/``time()`` would fire on
+    unrelated APIs, which costs more than it buys.
+  * a clock read inside a helper the module body then CALLS (``SEED = _make_seed()``).
+    The value is still frozen at import, but proving it needs interprocedural analysis.
+  * an absolute date LITERAL near a production threshold. A real bomb, but not
+    statically decidable — it depends on a threshold this guard cannot know. NOT
+    covered here, and no claim is made that the literal population is clean.
+
+ESCAPE HATCH — ``# frozen-clock-ok: <why, WITH the measured margin>``, in a real
+comment either inside the flagged statement's line span or in the contiguous comment
+block directly above it. Both positions are accepted because a justification names a
+margin AND the production threshold it is measured against, which does not fit in the
+trailing columns of an already-long line under a 100-column limit. Three rules make the
+hatch mean something:
+  * the reason must be non-empty AND state a magnitude — a number, or the word
+    "unbounded" for a site nothing ages;
+  * only REAL comment tokens count, so a marker inside a string literal does not
+    silence anything;
+  * a span needs as many markers as it has distinct flagged calls, so one waiver cannot
+    cover two sites — each site records its own measurement.
+Of the five sites that existed when this guard was written, four were legitimate and
+carry such a waiver; the fifth was the bug that motivated it.
+
+Usage:  python scripts/check_frozen_clock.py   (exit 0 = clean, 1 = violation)
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import re
+import sys
+import tokenize
+from pathlib import Path
+
+SCAN_ROOT = Path("tests")
+
+# Dotted call suffixes that read a wall clock. Monotonic clocks are included: a
+# module-level perf_counter/monotonic baseline drifts by the same mechanism.
+CLOCK_SUFFIXES: tuple[str, ...] = (
+    "datetime.now",
+    "datetime.utcnow",
+    "datetime.today",
+    "date.today",
+    "time.time",
+    "time.time_ns",
+    "time.monotonic",
+    "time.monotonic_ns",
+    "time.perf_counter",
+    "time.perf_counter_ns",
+    "time.localtime",
+    "time.gmtime",
+    "time.clock_gettime",
+    "time.clock_gettime_ns",
+)
+
+# Fixture scopes whose body is evaluated once, well before the tests that use it.
+BROAD_SCOPES = frozenset({"session", "module", "package"})
+
+# Decorators whose arguments are import-time BY CONTRACT — flagging them is noise.
+IMPORT_TIME_BY_DESIGN = ("skipif",)
+
+OPT_OUT = re.compile(r"#\s*frozen-clock-ok:\s*(?P<reason>\S.*)")
+# A margin is a magnitude. "unbounded" is the honest form for a site nothing ages.
+_STATES_A_MARGIN = re.compile(r"\d|unbounded", re.IGNORECASE)
+
+# (lineno, col, dotted, shape, span_start, span_end)
+Hit = tuple[int, int, str, str, int, int]
+# (relpath, lineno, shape, dotted)
+Violation = tuple[str, int, str, str]
+
+
+def _dotted(node: ast.expr) -> str:
+    """Best-effort dotted name for a call target (``datetime.datetime.now``)."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def _is_clock(dotted: str) -> bool:
+    return any(dotted == s or dotted.endswith("." + s) for s in CLOCK_SUFFIXES)
+
+
+def _clock_calls(node: ast.AST) -> list[tuple[int, int, str]]:
+    """Clock calls in ``node``, NOT descending into anything evaluated later.
+
+    The ROOT is checked as well as the children: a scoped fixture may hold a nested
+    ``def`` whose body only runs when the returned callable is invoked. Such a node's
+    own defaults and decorators are not lost — every function in the tree is visited
+    separately for those.
+    """
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+        return []
+    found: list[tuple[int, int, str]] = []
+    stack: list[ast.AST] = [node]
+    while stack:
+        cur = stack.pop()
+        if isinstance(cur, ast.Call):
+            dotted = _dotted(cur.func)
+            if _is_clock(dotted):
+                found.append((cur.lineno, cur.col_offset, dotted))
+        for child in ast.iter_child_nodes(cur):
+            # Deferred: a function/lambda body, and a generator expression's element,
+            # run when called/consumed. Comprehensions are eager and stay in scope.
+            if isinstance(
+                child, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda | ast.GeneratorExp
+            ):
+                continue
+            stack.append(child)
+    return found
+
+
+def _fixture_scope(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    """The declared scope if ``fn`` is a pytest fixture, else None.
+
+    A ``scope=`` that is not a literal (a name, an enum, ``**kwargs``) is treated as
+    BROAD: the guard cannot prove it is narrow, and guessing "function" would fail open
+    on exactly the shape it exists to catch.
+    """
+    for dec in fn.decorator_list:
+        target = dec.func if isinstance(dec, ast.Call) else dec
+        if not _dotted(target).endswith("fixture"):
+            continue
+        if not isinstance(dec, ast.Call):
+            return "function"
+        for kw in dec.keywords:
+            if kw.arg is None:  # **kwargs — scope unknowable
+                return "session"
+            if kw.arg == "scope":
+                if isinstance(kw.value, ast.Constant):
+                    return str(kw.value.value)
+                return "session"  # fail closed
+        return "function"
+    return None
+
+
+def _comment_lines(source: str) -> dict[int, str]:
+    """{lineno: text} for REAL comment tokens — a '#' inside a string is not one."""
+    out: dict[int, str] = {}
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            if tok.type == tokenize.COMMENT:
+                out[tok.start[0]] = tok.string
+    except (tokenize.TokenError, IndentationError, SyntaxError, ValueError):
+        pass  # a file we cannot tokenize simply has no usable waivers
+    return out
+
+
+def _markers_for_span(
+    comments: dict[int, str], lines: list[str], start: int, end: int
+) -> int:
+    """How many well-formed waivers apply to the statement spanning start..end."""
+    count = 0
+    for lineno in range(start, end + 1):
+        text = comments.get(lineno)
+        if text and (m := OPT_OUT.search(text)) and _STATES_A_MARGIN.search(m.group("reason")):
+            count += 1
+    idx = start - 1  # contiguous comment-only block directly above the statement
+    while idx >= 1 and idx <= len(lines) and lines[idx - 1].lstrip().startswith("#"):
+        text = comments.get(idx)
+        if text and (m := OPT_OUT.search(text)) and _STATES_A_MARGIN.search(m.group("reason")):
+            count += 1
+        idx -= 1
+    return count
+
+
+def scan_source(source: str, rel: str) -> list[Violation]:
+    """Return [(relpath, lineno, shape, dotted)] for un-waived frozen clocks."""
+    tree = ast.parse(source)
+    lines = source.splitlines()
+    comments = _comment_lines(source)
+    hits: dict[tuple[int, int, str], Hit] = {}
+
+    def record(node: ast.AST, shape: str, span: tuple[int, int]) -> None:
+        for lineno, col, dotted in _clock_calls(node):
+            hits.setdefault((lineno, col, dotted), (lineno, col, dotted, shape, *span))
+
+    def span_of(node: ast.AST) -> tuple[int, int]:
+        return (node.lineno, getattr(node, "end_lineno", None) or node.lineno)
+
+    def walk_import_time(body: list[ast.stmt], shape: str) -> None:
+        """Statements evaluated when the module is imported."""
+        for st in body:
+            if isinstance(st, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue  # handled below; only its defaults/decorators run now
+            if isinstance(st, ast.ClassDef):
+                for extra in [*st.decorator_list, *st.bases, *st.keywords]:
+                    record(extra, shape, span_of(st))
+                walk_import_time(st.body, "class-body")
+                continue
+            record(st, shape, span_of(st))
+
+    walk_import_time(tree.body, "module-body")
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        # The signature region only — a waiver in the body must not cover a default.
+        sig_end = node.body[0].lineno - 1 if node.body else node.lineno
+        sig_span = (node.lineno, max(node.lineno, sig_end))
+        for default in [*node.args.defaults, *[k for k in node.args.kw_defaults if k]]:
+            record(default, "default-arg", sig_span)
+        for dec in node.decorator_list:
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            if _dotted(target).endswith(IMPORT_TIME_BY_DESIGN):
+                continue  # import-time by contract; no seed can age here
+            record(dec, "decorator-arg", span_of(dec))
+        if (_fixture_scope(node) or "function") in BROAD_SCOPES:
+            for st in node.body:
+                record(st, "scoped-fixture", span_of(st))
+
+    by_span: dict[tuple[int, int], list[Hit]] = {}
+    for hit in hits.values():
+        by_span.setdefault((hit[4], hit[5]), []).append(hit)
+
+    out: list[Violation] = []
+    for (start, end), group in by_span.items():
+        # One recorded measurement per site: N calls in a span need N waivers.
+        waived = _markers_for_span(comments, lines, start, end)
+        for hit in sorted(group)[waived:]:
+            out.append((rel, hit[0], hit[3], hit[2]))
+    return sorted(out, key=lambda v: (v[0], v[1]))
+
+
+def scan(root: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            # A file the guard cannot READ is exactly as much of a gap as one it
+            # cannot PARSE. Never a silent pass — that would print CLEAN over a bomb.
+            print(f"::error::frozen-clock guard could not read {path}: {exc}")
+            violations.append((path.as_posix(), 0, "unreadable", "-"))
+            continue
+        try:
+            violations.extend(scan_source(source, path.as_posix()))
+        except SyntaxError as exc:
+            print(f"::error::frozen-clock guard could not parse {path}: {exc}")
+            violations.append((path.as_posix(), exc.lineno or 0, "unparseable", "-"))
+    return violations
+
+
+def main() -> int:
+    if not SCAN_ROOT.is_dir():
+        print(f"frozen-clock guard: scan root {SCAN_ROOT} not found (run from repo root)")
+        return 1
+    violations = scan(SCAN_ROOT)
+    if not violations:
+        print("Frozen-clock guard: CLEAN (no import-time wall-clock captures under tests/)")
+        return 0
+    print("::error::A test captures the wall clock at import time (frozen-clock bomb).")
+    print("Read the clock where it is USED (inside the test or its helper), so the")
+    print("margin is one test's duration instead of the whole suite's runtime.")
+    print("If the site is genuinely safe, put this in a comment on the statement or")
+    print("directly above it (one per flagged call):")
+    print("    # frozen-clock-ok: <why, with the measured margin>")
+    print("A session-scoped fixture that IS a start-time baseline is legitimate — its")
+    print("waiver is `unbounded — nothing ages this seed`, not a made-up number.")
+    for rel, lineno, shape, dotted in violations:
+        print(f"  {rel}:{lineno}: [{shape}] {dotted}()")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_frozen_clock.py
+++ b/scripts/check_frozen_clock.py
@@ -105,6 +105,10 @@ CLOCK_SUFFIXES: tuple[str, ...] = (
     "time.monotonic_ns",
     "time.perf_counter",
     "time.perf_counter_ns",
+    "time.process_time",
+    "time.process_time_ns",
+    "time.thread_time",
+    "time.thread_time_ns",
     "time.localtime",
     "time.gmtime",
     "time.clock_gettime",
@@ -167,6 +171,17 @@ def _reads_the_clock(call: ast.Call) -> bool:
     return True
 
 
+def _eager_parts(node: ast.AST) -> list[ast.AST]:
+    """The parts of a part-eager construct that are evaluated where it appears."""
+    if isinstance(node, ast.Lambda):
+        return [*node.args.defaults, *[d for d in node.args.kw_defaults if d]]
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+        return []  # its defaults/decorators are visited with the function itself
+    if isinstance(node, ast.GeneratorExp):
+        return [node.generators[0].iter] if node.generators else []
+    return [node]
+
+
 def _eager_children(node: ast.AST) -> list[ast.AST]:
     """Children of ``node`` evaluated NOW, with the deferred parts pruned.
 
@@ -179,17 +194,7 @@ def _eager_children(node: ast.AST) -> list[ast.AST]:
     """
     out: list[ast.AST] = []
     for child in ast.iter_child_nodes(node):
-        if isinstance(child, ast.Lambda):
-            out.extend(child.args.defaults)
-            out.extend(d for d in child.args.kw_defaults if d)
-            continue
-        if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
-            continue  # its defaults/decorators are visited with the function itself
-        if isinstance(child, ast.GeneratorExp):
-            if child.generators:
-                out.append(child.generators[0].iter)
-            continue
-        out.append(child)
+        out.extend(_eager_parts(child))
     return out
 
 
@@ -199,10 +204,15 @@ def _clock_calls(node: ast.AST) -> list[ast.Call]:
     The ROOT is checked as well as the children: a scoped fixture may hold a nested
     ``def`` whose body only runs when the returned callable is invoked.
     """
-    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
-        return []
     found: list[ast.Call] = []
-    stack: list[ast.AST] = [node]
+    # The ROOT obeys the same rules as any child — it can itself be a part-eager
+    # construct (a lambda passed directly as a default, a bare generator
+    # expression), and treating it specially is what made those cases wrong in
+    # both directions.
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda | ast.GeneratorExp):
+        stack: list[ast.AST] = _eager_parts(node)
+    else:
+        stack = [node]
     while stack:
         cur = stack.pop()
         if isinstance(cur, ast.Call) and _reads_the_clock(cur):
@@ -285,22 +295,74 @@ def _top_level_functions(tree: ast.AST):
     return out
 
 
+def _own_yields(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.expr]:
+    """Yield expressions belonging to ``fn`` ITSELF, not to a nested function.
+
+    A ``yield`` inside a helper defined in the fixture says nothing about where the
+    fixture's own setup ends.
+    """
+    found: list[ast.expr] = []
+
+    def walk(node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+                continue
+            if isinstance(child, ast.Yield | ast.YieldFrom):
+                found.append(child)
+            walk(child)
+
+    walk(fn)
+    return found
+
+
 def _fixture_setup(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.stmt]:
     """The statements of a fixture that run during SETUP.
 
-    A generator fixture's statements after ``yield`` run at TEARDOWN — after every
-    consumer has finished — so a clock read there cannot age before it is used.
+    A generator fixture's statements after its own ``yield`` run at TEARDOWN, once
+    every consumer has finished, so a clock read there cannot age before use. This
+    follows the fixture's execution FLOW rather than stopping at whichever statement
+    happens to contain a yield: a ``yield`` wrapped in ``try`` must not drag the
+    ``finally`` cleanup into setup, and a yield inside a nested helper must not cut
+    setup short and let a genuinely shared clock through.
     """
+    yields = _own_yields(fn)
+    if not yields:
+        return list(fn.body)  # a return-style fixture: the whole body is setup
+    first = min(y.lineno for y in yields)
     setup: list[ast.stmt] = []
-    for stmt in fn.body:
-        setup.append(stmt)
-        if any(isinstance(n, ast.Yield | ast.YieldFrom) for n in ast.walk(stmt)):
-            break
+
+    def collect(body: list[ast.stmt]) -> None:
+        for st in body:
+            if st.lineno > first:
+                return  # everything from here on runs after the yield
+            if (getattr(st, "end_lineno", None) or st.lineno) < first:
+                setup.append(st)
+                continue
+            # This statement SPANS the yield. Descend, so that a `finally` (which
+            # runs at teardown) is not swept in with the setup blocks.
+            blocks = [getattr(st, "body", None), getattr(st, "orelse", None)]
+            handlers = getattr(st, "handlers", None) or []
+            if not any(blocks) and not handlers:
+                setup.append(st)  # e.g. `yield expr` — the operand IS setup
+                continue
+            for block in blocks:
+                if block:
+                    collect(block)
+            for handler in handlers:
+                collect(handler.body)
+            # `finalbody` is deliberately NOT collected — it runs at teardown.
+
+    collect(fn.body)
     return setup
 
 
 def _is_dunder_main(node: ast.stmt) -> bool:
-    """``if __name__ == "__main__":`` — never executed under pytest."""
+    """Exactly ``if __name__ == "__main__":`` — never executed under pytest.
+
+    The comparison operator and the literal both matter: ``if __name__ !=
+    "__main__":`` and ``if __name__ == "some_module":`` DO run on import, so a
+    looser predicate would wave a real frozen clock straight through.
+    """
     if not isinstance(node, ast.If):
         return False
     test = node.test
@@ -308,6 +370,11 @@ def _is_dunder_main(node: ast.stmt) -> bool:
         isinstance(test, ast.Compare)
         and isinstance(test.left, ast.Name)
         and test.left.id == "__name__"
+        and len(test.ops) == 1
+        and isinstance(test.ops[0], ast.Eq)
+        and len(test.comparators) == 1
+        and isinstance(test.comparators[0], ast.Constant)
+        and test.comparators[0].value == "__main__"
     )
 
 
@@ -350,10 +417,43 @@ def _enclosing_statements(tree: ast.AST) -> dict[int, ast.stmt]:
     return owner
 
 
+def _annotations_are_deferred(tree: ast.Module) -> bool:
+    """True if ``from __future__ import annotations`` is active in this module.
+
+    With it, every annotation is stored as a STRING and never evaluated, so a clock
+    written in one cannot freeze anything. Without it (the language default on 3.12),
+    a ``def`` annotation is evaluated when the ``def`` executes.
+    """
+    for stmt in tree.body:
+        if isinstance(stmt, ast.ImportFrom) and stmt.module == "__future__" and any(
+            alias.name == "annotations" for alias in stmt.names
+        ):
+            return True
+    return False
+
+
+def _strip_annotations(node: ast.AST) -> None:
+    """Blank every annotation in ``node`` — they are strings, not evaluated code."""
+    for sub_node in ast.walk(node):
+        if isinstance(sub_node, ast.AnnAssign | ast.arg):
+            sub_node.annotation = None
+        elif isinstance(sub_node, ast.FunctionDef | ast.AsyncFunctionDef):
+            sub_node.returns = None
+
+
 def scan_source(source: str, rel: str) -> list[Violation]:
     """Return [(relpath, lineno, shape, dotted)] for un-waived frozen clocks."""
     tree = ast.parse(source)
-    lines = source.splitlines()
+    deferred_annotations = _annotations_are_deferred(tree)
+    if deferred_annotations:
+        # Under future-annotations they are never evaluated, so reporting a clock
+        # inside one would be a false positive on most of this repo's test files.
+        _strip_annotations(tree)
+    # split("\n"), NOT splitlines(): the latter also breaks on NEL, VT, FF and the
+    # Unicode line separators, which Python's tokenizer does not count as physical
+    # lines — one such character inside a string literal would shift every waiver
+    # lookup after it and drop a valid waiver.
+    lines = source.split("\n")
     comments = _comment_lines(source)
     owner = _enclosing_statements(tree)
     exempt_calls = _under_import_time_contract(tree)
@@ -396,6 +496,17 @@ def scan_source(source: str, rel: str) -> list[Violation]:
             record(default, "default-arg", sig_span)
         for dec in node.decorator_list:
             record(dec, "decorator-arg", span_of(dec))
+        if not deferred_annotations:
+            # Without future-annotations, a signature annotation is evaluated when the
+            # `def` executes — the same import-time moment as a default.
+            args = node.args
+            every = [*args.posonlyargs, *args.args, *args.kwonlyargs,
+                     args.vararg, args.kwarg]
+            for arg in every:
+                if arg is not None and arg.annotation is not None:
+                    record(arg.annotation, "annotation", sig_span)
+            if node.returns is not None:
+                record(node.returns, "annotation", sig_span)
         if (_fixture_scope(node) or "function") in BROAD_SCOPES:
             for st in _fixture_setup(node):
                 record(st, "scoped-fixture")

--- a/scripts/check_frozen_clock.py
+++ b/scripts/check_frozen_clock.py
@@ -22,14 +22,19 @@ WHAT IT FLAGS — a wall-clock call in a position evaluated ONCE, early:
   * class body           — same, at class-definition time
   * default argument     — evaluated at ``def`` time, not per call
   * decorator argument   — evaluated at import (e.g. inside ``@parametrize(...)``)
-  * session/module/package-scoped fixture body — one read per session/module/package
+  * class/module/package/session-scoped fixture body — any scope broader than
+    ``function`` shares ONE read across many tests
 
 WHAT IT DOES NOT FLAG (deliberately — these read the clock at use time):
   * any call inside an ordinary function/method/lambda body, including function-scoped
-    fixtures. That is the FIX this guard steers you toward.
-  * a generator expression's body, which is lazy. List/set/dict comprehensions ARE
-    eager and so ARE flagged.
-  * ``@pytest.mark.skipif(...)``, whose whole contract is import-time evaluation.
+    fixtures — that is the FIX this guard steers you toward — and the defaults and
+    decorators of a ``def`` NESTED in one, which re-bind on every call.
+  * a generator expression's element and its inner ``for`` clauses, which are lazy. Its
+    LEFTMOST iterable is evaluated at creation and IS flagged. List/set/dict
+    comprehensions are eager throughout and are flagged.
+  * a ``skipif``/``xfail`` condition, whose contract IS import-time evaluation — in
+    decorator position and equally in a module-level ``pytestmark`` assignment.
+  * ``if __name__ == "__main__":`` blocks, which no suite run executes.
 
 SCOPE IS ``tests/`` DELIBERATELY, and the reason is not that production is exempt: a
 module-level clock in a long-running daemon is the worse version of this bug. It is
@@ -57,13 +62,21 @@ margin AND the production threshold it is measured against, which does not fit i
 trailing columns of an already-long line under a 100-column limit. Three rules make the
 hatch mean something:
   * the reason must be non-empty AND state a magnitude — a number, or the word
-    "unbounded" for a site nothing ages;
+    "unbounded" for a site nothing ages. This is a SOCIAL guard, not a mechanical
+    one: it forces the shape of a measurement, and cannot tell a real margin from a
+    digit that happens to be in an issue number. It raises the cost of waving the
+    guard off; it does not make that impossible;
   * only REAL comment tokens count, so a marker inside a string literal does not
     silence anything;
   * a span needs as many markers as it has distinct flagged calls, so one waiver cannot
     cover two sites — each site records its own measurement.
 Of the five sites that existed when this guard was written, four were legitimate and
 carry such a waiver; the fifth was the bug that motivated it.
+
+A waiver attaches to the STATEMENT the clock is in. A marker above a fixture's
+decorator therefore does not waive a clock in that fixture's BODY, and a marker above
+a decorator does not waive a clock in a default argument — put it on the statement the
+guard names in its output. That direction is fail-safe: the guard still fires.
 
 Usage:  python scripts/check_frozen_clock.py   (exit 0 = clean, 1 = violation)
 """
@@ -99,10 +112,10 @@ CLOCK_SUFFIXES: tuple[str, ...] = (
 )
 
 # Fixture scopes whose body is evaluated once, well before the tests that use it.
-BROAD_SCOPES = frozenset({"session", "module", "package"})
+BROAD_SCOPES = frozenset({"session", "module", "package", "class"})
 
 # Decorators whose arguments are import-time BY CONTRACT — flagging them is noise.
-IMPORT_TIME_BY_DESIGN = ("skipif",)
+IMPORT_TIME_BY_DESIGN = ("skipif", "xfail")
 
 OPT_OUT = re.compile(r"#\s*frozen-clock-ok:\s*(?P<reason>\S.*)")
 # A margin is a magnitude. "unbounded" is the honest form for a site nothing ages.
@@ -129,7 +142,7 @@ def _is_clock(dotted: str) -> bool:
     return any(dotted == s or dotted.endswith("." + s) for s in CLOCK_SUFFIXES)
 
 
-def _clock_calls(node: ast.AST) -> list[tuple[int, int, str]]:
+def _clock_calls(node: ast.AST) -> list[tuple[int, int, str, int]]:
     """Clock calls in ``node``, NOT descending into anything evaluated later.
 
     The ROOT is checked as well as the children: a scoped fixture may hold a nested
@@ -139,20 +152,24 @@ def _clock_calls(node: ast.AST) -> list[tuple[int, int, str]]:
     """
     if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
         return []
-    found: list[tuple[int, int, str]] = []
+    found: list[tuple[int, int, str, int]] = []
     stack: list[ast.AST] = [node]
     while stack:
         cur = stack.pop()
         if isinstance(cur, ast.Call):
             dotted = _dotted(cur.func)
             if _is_clock(dotted):
-                found.append((cur.lineno, cur.col_offset, dotted))
+                found.append((cur.lineno, cur.col_offset, dotted, id(cur)))
         for child in ast.iter_child_nodes(cur):
-            # Deferred: a function/lambda body, and a generator expression's element,
-            # run when called/consumed. Comprehensions are eager and stay in scope.
-            if isinstance(
-                child, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda | ast.GeneratorExp
-            ):
+            # Deferred: a function/lambda body runs when called.
+            if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+                continue
+            # A generator expression is lazy EXCEPT its leftmost iterable, which is
+            # evaluated the moment the genexp is created. Comprehensions are eager
+            # throughout and stay in scope.
+            if isinstance(child, ast.GeneratorExp):
+                if child.generators:
+                    stack.append(child.generators[0].iter)
                 continue
             stack.append(child)
     return found
@@ -212,6 +229,56 @@ def _markers_for_span(
     return count
 
 
+def _top_level_functions(tree: ast.AST):
+    """Every function NOT nested inside another function.
+
+    A `def` inside a test body re-executes on each call, so its defaults and
+    decorators bind at call time — that is the very shape this guard steers people
+    toward, and flagging it would charge a waiver for the fix.
+    """
+    out: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+
+    def walk(node: ast.AST, inside_function: bool) -> None:
+        for child in ast.iter_child_nodes(node):
+            is_fn = isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef)
+            if is_fn and not inside_function:
+                out.append(child)
+            walk(child, inside_function or is_fn or isinstance(child, ast.Lambda))
+
+    walk(tree, False)
+    return out
+
+
+def _is_dunder_main(node: ast.stmt) -> bool:
+    """``if __name__ == "__main__":`` — never executed under pytest."""
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    return (
+        isinstance(test, ast.Compare)
+        and isinstance(test.left, ast.Name)
+        and test.left.id == "__name__"
+    )
+
+
+def _under_import_time_contract(node: ast.AST) -> set[int]:
+    """Column-tagged clock calls inside a skipif/xfail condition.
+
+    Both evaluate their condition at import BY CONTRACT, in decorator position and
+    equally in a module-level ``pytestmark`` assignment, so no seed can age there.
+    """
+    exempt: set[int] = set()
+    for sub_node in ast.walk(node):
+        if not isinstance(sub_node, ast.Call):
+            continue
+        target = sub_node.func
+        if _dotted(target).endswith(IMPORT_TIME_BY_DESIGN):
+            for inner in ast.walk(sub_node):
+                if isinstance(inner, ast.Call) and _is_clock(_dotted(inner.func)):
+                    exempt.add(id(inner))
+    return exempt
+
+
 def scan_source(source: str, rel: str) -> list[Violation]:
     """Return [(relpath, lineno, shape, dotted)] for un-waived frozen clocks."""
     tree = ast.parse(source)
@@ -219,8 +286,12 @@ def scan_source(source: str, rel: str) -> list[Violation]:
     comments = _comment_lines(source)
     hits: dict[tuple[int, int, str], Hit] = {}
 
+    exempt_calls = _under_import_time_contract(tree)
+
     def record(node: ast.AST, shape: str, span: tuple[int, int]) -> None:
-        for lineno, col, dotted in _clock_calls(node):
+        for lineno, col, dotted, node_id in _clock_calls(node):
+            if node_id in exempt_calls:
+                continue
             hits.setdefault((lineno, col, dotted), (lineno, col, dotted, shape, *span))
 
     def span_of(node: ast.AST) -> tuple[int, int]:
@@ -231,27 +302,27 @@ def scan_source(source: str, rel: str) -> list[Violation]:
         for st in body:
             if isinstance(st, ast.FunctionDef | ast.AsyncFunctionDef):
                 continue  # handled below; only its defaults/decorators run now
+            if _is_dunder_main(st):
+                continue  # only runs when the file is executed directly, never in a suite
             if isinstance(st, ast.ClassDef):
                 for extra in [*st.decorator_list, *st.bases, *st.keywords]:
-                    record(extra, shape, span_of(st))
+                    # span_of(extra), NOT span_of(st): keying these to the whole class
+                    # body would let one waiver inside the class silence a base-class
+                    # clock, and let that same waiver be counted twice.
+                    record(extra, shape, span_of(extra))
                 walk_import_time(st.body, "class-body")
                 continue
             record(st, shape, span_of(st))
 
     walk_import_time(tree.body, "module-body")
 
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-            continue
+    for node in _top_level_functions(tree):
         # The signature region only — a waiver in the body must not cover a default.
         sig_end = node.body[0].lineno - 1 if node.body else node.lineno
         sig_span = (node.lineno, max(node.lineno, sig_end))
         for default in [*node.args.defaults, *[k for k in node.args.kw_defaults if k]]:
             record(default, "default-arg", sig_span)
         for dec in node.decorator_list:
-            target = dec.func if isinstance(dec, ast.Call) else dec
-            if _dotted(target).endswith(IMPORT_TIME_BY_DESIGN):
-                continue  # import-time by contract; no seed can age here
             record(dec, "decorator-arg", span_of(dec))
         if (_fixture_scope(node) or "function") in BROAD_SCOPES:
             for st in node.body:
@@ -270,9 +341,37 @@ def scan_source(source: str, rel: str) -> list[Violation]:
     return sorted(out, key=lambda v: (v[0], v[1]))
 
 
+def _walk_py(root: Path) -> tuple[list[Path], list[tuple[Path, OSError]]]:
+    """Every .py under root, plus the directories that could not be listed.
+
+    ``Path.rglob`` swallows an unlistable directory, which would hide every file
+    beneath it — the same silent pass the read/parse branches refuse.
+    """
+    files: list[Path] = []
+    bad: list[tuple[Path, OSError]] = []
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(current.iterdir())
+        except OSError as exc:
+            bad.append((current, exc))
+            continue
+        for entry in entries:
+            if entry.is_dir() and not entry.is_symlink():
+                stack.append(entry)
+            elif entry.suffix == ".py":
+                files.append(entry)
+    return sorted(files), bad
+
+
 def scan(root: Path) -> list[Violation]:
     violations: list[Violation] = []
-    for path in sorted(root.rglob("*.py")):
+    files, unlistable = _walk_py(root)
+    for directory, exc in unlistable:
+        print(f"::error::frozen-clock guard could not list {directory}: {exc}")
+        violations.append((directory.as_posix(), 0, "unreadable-dir", "-"))
+    for path in files:
         try:
             source = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError) as exc:

--- a/tests/test_awareness/test_ego_liveness_check.py
+++ b/tests/test_awareness/test_ego_liveness_check.py
@@ -18,6 +18,11 @@ import pytest
 from genesis.awareness import loop
 from genesis.db.schema import create_all_tables
 
+# frozen-clock-ok: unbounded margin. `compute_ego_liveness` scores `intent - success`, a
+# difference of two SEEDS (its `now` parameter is assigned and then never referenced).
+# `loop._check_ego_liveness`, which these tests actually drive, does read the live clock,
+# but only to stamp `resolved_at`; the assertions here count rows with resolved=0, so no
+# assertion ages. Elapsed time cannot move any of them.
 NOW = datetime.now(UTC)
 USER_SRC = "ego_liveness:user_ego_cycle"
 GEN_SRC = "ego_liveness:genesis_ego_cycle"

--- a/tests/test_dashboard/test_directives_goals_routes.py
+++ b/tests/test_dashboard/test_directives_goals_routes.py
@@ -17,7 +17,11 @@ from genesis.dashboard.api import blueprint
 
 # Dates relative to now so the resolved-history recency window (14 days) is
 # pinned on BOTH sides without a fixed calendar date that rots after 14 days.
+# frozen-clock-ok: 11-day margin — seeded 3d back, must stay INSIDE the 14-day
+# resolved-history window (the `_cutoff` in the ego-directives route).
 _RECENT_RESOLVED = (datetime.now(UTC) - timedelta(days=3)).isoformat()
+# frozen-clock-ok: unbounded margin — seeded 30d back and must stay OUTSIDE that same
+# 14-day window; elapsed time only deepens the staleness it asserts.
 _STALE_RESOLVED = (datetime.now(UTC) - timedelta(days=30)).isoformat()
 
 

--- a/tests/test_mcp/test_job_staleness.py
+++ b/tests/test_mcp/test_job_staleness.py
@@ -25,6 +25,8 @@ _OK_RECENT = "2026-06-25T00:00:00+00:00"  # 3.0 days before _RUN   → below thr
 _OK_HEALTHY = _RUN                          # 0.0 days               → healthy
 # A recent last_run (well within the never-succeeded alarm's 35d recency window),
 # computed once at import — always inside the window, so no wall-clock flakiness.
+# frozen-clock-ok: ~35-day margin — seeded 1h back, must stay INSIDE the 35-day
+# never-succeeded recency window (`recent_since` in the health-alerts impl).
 _RECENT = (datetime.now(UTC) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 

--- a/tests/test_mcp/test_job_staleness.py
+++ b/tests/test_mcp/test_job_staleness.py
@@ -25,8 +25,10 @@ _OK_RECENT = "2026-06-25T00:00:00+00:00"  # 3.0 days before _RUN   → below thr
 _OK_HEALTHY = _RUN                          # 0.0 days               → healthy
 # A recent last_run (well within the never-succeeded alarm's 35d recency window),
 # computed once at import — always inside the window, so no wall-clock flakiness.
-# frozen-clock-ok: ~35-day margin — seeded 1h back, must stay INSIDE the 35-day
-# never-succeeded recency window (`recent_since` in the health-alerts impl).
+# frozen-clock-ok: ~7-day margin — seeded 1h back. The BINDING constraint is the
+# now-7d cutoff built in test_get_never_succeeded_jobs_recency_bound below, not the
+# wider 35-day `recent_since` window in the health-alerts impl; both are eternity
+# next to a suite run, but 7d is the one that would break first.
 _RECENT = (datetime.now(UTC) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 

--- a/tests/test_observability/test_surplus_liveness.py
+++ b/tests/test_observability/test_surplus_liveness.py
@@ -24,7 +24,6 @@ from genesis.db.schema import create_all_tables
 from genesis.observability.snapshots.surplus import surplus_status
 from genesis.runtime._core import GenesisRuntime
 
-NOW = datetime.now(UTC)
 _UNSET = object()
 
 
@@ -49,7 +48,10 @@ def _install_runtime(
 ):
     """Inject a stub runtime whose in-memory _job_health holds the surplus pulse.
 
-    pulse_min_ago: seed last_success that many minutes before NOW.
+    pulse_min_ago: seed last_success that many minutes before the CALL-TIME clock
+        (negative seeds the future). Read `now` HERE, never at import: production
+        ages this seed against the live clock, so a module-level capture makes the
+        margin the whole suite's runtime instead of this one test's.
     pulse_raw: seed a literal last_success value (e.g. a garbage string).
     neither set: no surplus_dispatch entry at all (never pulsed).
     """
@@ -60,7 +62,7 @@ def _install_runtime(
     if pulse_raw is not _UNSET:
         entry = {"surplus_dispatch": {"last_success": pulse_raw}}
     elif pulse_min_ago is not _UNSET:
-        ts = (NOW - timedelta(minutes=pulse_min_ago)).isoformat()
+        ts = (datetime.now(UTC) - timedelta(minutes=pulse_min_ago)).isoformat()
         entry = {"surplus_dispatch": {"last_success": ts}}
     GenesisRuntime._instance = SimpleNamespace(
         is_bootstrapped=bootstrapped,

--- a/tests/test_scripts/test_check_frozen_clock.py
+++ b/tests/test_scripts/test_check_frozen_clock.py
@@ -87,6 +87,31 @@ COMPOUND_FROZEN = [
     # A lambda BODY is deferred, but its DEFAULTS bind where the lambda appears.
     ("lambda default", "F = lambda seed=datetime.now(UTC): seed\n"),
     (
+        "lambda default used AS a def default",
+        "def f(cb=lambda seed=datetime.now(UTC): seed):\n    return cb\n",
+    ),
+    ("annotation without future import", "def f(t: datetime.now(UTC)):\n    return t\n"),
+    (
+        "dunder-main with a NON-eq comparison still runs",
+        'if __name__ != "__main__":\n    NOW = datetime.now(UTC)\n',
+    ),
+    (
+        "dunder-main compared to another module name still runs",
+        'if __name__ == "other":\n    NOW = datetime.now(UTC)\n',
+    ),
+    (
+        "fixture setup before a try/yield",
+        '@pytest.fixture(scope="session")\ndef r():\n'
+        "    t = datetime.now(UTC)\n    try:\n        yield t\n"
+        "    finally:\n        pass\n",
+    ),
+    (
+        "a yield in a NESTED helper must not cut setup short",
+        '@pytest.fixture(scope="session")\ndef r():\n'
+        "    def gen():\n        yield 1\n"
+        "    t = datetime.now(UTC)\n    return t\n",
+    ),
+    (
         "broad-fixture setup before yield",
         '@pytest.fixture(scope="session")\ndef r():\n'
         "    t = datetime.now(UTC)\n    yield t\n",
@@ -153,6 +178,16 @@ DEFERRED_SAFE = [
         "    yield 1\n    done = datetime.now(UTC)\n    return done\n",
     ),
     ("gmtime with an epoch argument converts", "EPOCH = time.gmtime(0)\n"),
+    (
+        "genexp used AS a def default is still lazy",
+        "def f(g=(datetime.now(UTC) for _ in range(3))):\n    return g\n",
+    ),
+    (
+        "a fixture's finally block runs at teardown",
+        '@pytest.fixture(scope="session")\ndef r():\n'
+        "    try:\n        yield 1\n    finally:\n"
+        "        done = datetime.now(UTC)\n",
+    ),
     ("localtime with an argument converts", "T = time.localtime(0)\n"),
     (
         "decorator merely ENDING in fixture is not a fixture",
@@ -279,6 +314,10 @@ def test_two_clocks_on_one_line_are_two_violations(tmp_path):
         "time.localtime()",
         "time.gmtime()",
         "time.clock_gettime(0)",
+        "time.process_time()",
+        "time.process_time_ns()",
+        "time.thread_time()",
+        "time.thread_time_ns()",
     ],
 )
 def test_recognises_dotted_clock_variants(tmp_path, expr):
@@ -377,6 +416,47 @@ def test_waiver_binds_to_its_own_statement_not_the_enclosing_block(tmp_path):
         "    A = 1\n"
         "    # frozen-clock-ok: 5d vs a 35d window\n"
         "    B = datetime.now(UTC)\n",
+    )
+    assert check.scan(tmp_path) == []
+
+
+def test_annotations_are_skipped_under_future_annotations(tmp_path):
+    """With `from __future__ import annotations` every annotation is a STRING.
+
+    Reporting a clock inside one would be a false positive on most files in this
+    repo, which use that import. Without it, an annotation IS evaluated at def
+    time and must still be caught — both directions are asserted here.
+    """
+    header = "from __future__ import annotations\n\n"
+    header += "import time\n\nimport pytest\n"
+    header += "from datetime import UTC, datetime\n\n"
+    f = tmp_path / "test_planted.py"
+    f.write_text(header + "def f(t: datetime.now(UTC)):\n    return t\n")
+    assert check.scan(tmp_path) == []
+    f.write_text(header + "X: datetime.now(UTC) = 1\n")
+    assert check.scan(tmp_path) == []
+    # ...and the same annotation without that import IS evaluated at def time.
+    _write(tmp_path, "def f(t: datetime.now(UTC)):\n    return t\n")
+    assert len(check.scan(tmp_path)) == 1
+
+
+@pytest.mark.parametrize(
+    "oddity",
+    ["\x0c", "\x85", "\x0b"],
+    ids=["form-feed", "next-line", "vertical-tab"],
+)
+def test_waiver_lookup_uses_pythons_own_line_model(tmp_path, oddity):
+    """`str.splitlines()` breaks on characters Python's tokenizer does not.
+
+    One of them inside an earlier string literal shifts every subsequent index, so
+    a valid waiver directly above a frozen clock is looked up on the wrong line and
+    missed — turning a documented site into a CI failure on an unrelated PR.
+    """
+    _write(
+        tmp_path,
+        f'MSG = "a{oddity}b"\n'
+        "# frozen-clock-ok: 5d vs a 35d window\n"
+        "NOW = datetime.now(UTC)\n",
     )
     assert check.scan(tmp_path) == []
 

--- a/tests/test_scripts/test_check_frozen_clock.py
+++ b/tests/test_scripts/test_check_frozen_clock.py
@@ -79,6 +79,15 @@ COMPOUND_FROZEN = [
     ("walrus", "if (n := datetime.now(UTC)):\n    NOW = n\n"),
     ("nested-class", "class A:\n    class B:\n        NOW = datetime.now(UTC)\n"),
     ("kwonly-default", "def f(*, t=datetime.now(UTC)):\n    return t\n"),
+    # A genexp is lazy EXCEPT its leftmost iterable, which runs at creation.
+    (
+        "genexp leftmost iterable",
+        "S = list(str(t) for t in [datetime.now(UTC)])\n",
+    ),
+    (
+        "class-scoped fixture",
+        '@pytest.fixture(scope="class")\ndef s():\n    return datetime.now(UTC)\n',
+    ),
     (
         "metaclass-keyword",
         "def mk(x):\n    return type\n\n\nclass C(metaclass=mk(datetime.now(UTC))):\n    pass\n",
@@ -107,6 +116,28 @@ DEFERRED_SAFE = [
         "skipif is import-time by contract",
         '@pytest.mark.skipif(datetime.now(UTC).year > 3000, reason="never")\n'
         "def test_x():\n    pass\n",
+    ),
+    (
+        "xfail is import-time by contract",
+        '@pytest.mark.xfail(datetime.now(UTC).year < 2027, reason="never")\n'
+        "def test_x():\n    pass\n",
+    ),
+    (
+        "module-level pytestmark skipif",
+        'pytestmark = pytest.mark.skipif(datetime.now(UTC).year > 3000, reason="x")\n',
+    ),
+    (
+        "genexp inner-clause iterable is lazy",
+        "G = (x for y in [1] for x in [datetime.now(UTC)])\n",
+    ),
+    (
+        "default of a def nested in a test",
+        "def test_x():\n    def helper(t=datetime.now(UTC)):\n"
+        "        return t\n    return helper\n",
+    ),
+    (
+        "dunder-main block never runs in a suite",
+        'if __name__ == "__main__":\n    NOW = datetime.now(UTC)\n',
     ),
 ]
 
@@ -237,7 +268,11 @@ def test_recognises_dotted_clock_variants(tmp_path, expr):
 )
 def test_unprovable_fixture_scope_fails_closed(tmp_path, decorator):
     """The guard cannot prove the scope is narrow, so it must not assume it is."""
-    _write(tmp_path, f'_S = "session"\n_KW = {{}}\n{decorator}\ndef f():\n    return datetime.now(UTC)\n')
+    body = (
+        f'_S = "session"\n_KW = {{}}\n{decorator}\n'
+        f'def f():\n    return datetime.now(UTC)\n'
+    )
+    _write(tmp_path, body)
     assert len(check.scan(tmp_path)) == 1
 
 
@@ -249,6 +284,7 @@ def test_unparseable_file_is_reported_not_silently_skipped(tmp_path):
     assert violations[0][2] == "unparseable"
 
 
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores these permission bits")
 @pytest.mark.parametrize("mode", ["non-utf8", "unreadable"])
 def test_file_that_cannot_be_read_is_reported_not_silently_skipped(tmp_path, mode):
     """The same fail-closed rule for READ errors — this branch printed CLEAN over a bomb."""
@@ -264,6 +300,35 @@ def test_file_that_cannot_be_read_is_reported_not_silently_skipped(tmp_path, mod
         assert violations[0][2] == "unreadable"
     finally:
         os.chmod(f, 0o644)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores these permission bits")
+def test_unlistable_directory_is_reported_not_silently_skipped(tmp_path):
+    """rglob swallows an unlistable dir, hiding every file beneath it."""
+    sub = tmp_path / "locked"
+    sub.mkdir()
+    (sub / "test_bomb.py").write_text("NOW = datetime.now(UTC)\n")
+    os.chmod(sub, 0o000)
+    try:
+        violations = check.scan(tmp_path)
+        assert len(violations) == 1
+        assert violations[0][2] == "unreadable-dir"
+    finally:
+        os.chmod(sub, 0o755)
+
+
+def test_one_waiver_never_covers_a_nested_span(tmp_path):
+    """A marker inside a class body must not also waive the class's OWN base clock."""
+    base = "class TestT(type(datetime.now())):\n"
+    inner = "    SEED = time.time()\n"
+    waiver = "    # frozen-clock-ok: 5d vs a 35d window\n"
+    _write(tmp_path, base + inner)
+    assert len(check.scan(tmp_path)) == 2
+    _write(tmp_path, base + waiver + inner)
+    assert len(check.scan(tmp_path)) == 1  # the base clock is still its own site
+    top = "# frozen-clock-ok: unbounded, base class only\n"
+    _write(tmp_path, top + base + waiver + inner)
+    assert check.scan(tmp_path) == []
 
 
 def test_repo_tests_tree_is_clean():

--- a/tests/test_scripts/test_check_frozen_clock.py
+++ b/tests/test_scripts/test_check_frozen_clock.py
@@ -84,6 +84,18 @@ COMPOUND_FROZEN = [
         "genexp leftmost iterable",
         "S = list(str(t) for t in [datetime.now(UTC)])\n",
     ),
+    # A lambda BODY is deferred, but its DEFAULTS bind where the lambda appears.
+    ("lambda default", "F = lambda seed=datetime.now(UTC): seed\n"),
+    (
+        "broad-fixture setup before yield",
+        '@pytest.fixture(scope="session")\ndef r():\n'
+        "    t = datetime.now(UTC)\n    yield t\n",
+    ),
+    (
+        "decorator merely ENDING in skipif is not the pytest mark",
+        "def custom_skipif(*a, **k):\n    return lambda f: f\n\n\n"
+        "@custom_skipif(time.time())\ndef test_a():\n    pass\n",
+    ),
     (
         "class-scoped fixture",
         '@pytest.fixture(scope="class")\ndef s():\n    return datetime.now(UTC)\n',
@@ -134,6 +146,19 @@ DEFERRED_SAFE = [
         "default of a def nested in a test",
         "def test_x():\n    def helper(t=datetime.now(UTC)):\n"
         "        return t\n    return helper\n",
+    ),
+    (
+        "broad-fixture teardown after yield",
+        '@pytest.fixture(scope="session")\ndef r():\n'
+        "    yield 1\n    done = datetime.now(UTC)\n    return done\n",
+    ),
+    ("gmtime with an epoch argument converts", "EPOCH = time.gmtime(0)\n"),
+    ("localtime with an argument converts", "T = time.localtime(0)\n"),
+    (
+        "decorator merely ENDING in fixture is not a fixture",
+        "def not_a_fixture(**k):\n    return lambda f: f\n\n\n"
+        '@not_a_fixture(scope="session")\ndef g():\n'
+        "    return datetime.now(UTC)\n",
     ),
     (
         "dunder-main block never runs in a suite",
@@ -328,6 +353,31 @@ def test_one_waiver_never_covers_a_nested_span(tmp_path):
     assert len(check.scan(tmp_path)) == 1  # the base clock is still its own site
     top = "# frozen-clock-ok: unbounded, base class only\n"
     _write(tmp_path, top + base + waiver + inner)
+    assert check.scan(tmp_path) == []
+
+
+def test_waiver_binds_to_its_own_statement_not_the_enclosing_block(tmp_path):
+    """A stale marker in an `if`/`try` must not exempt a clock added elsewhere in it.
+
+    Pooling every clock in a compound statement into one span and counting waivers
+    across it lets a marker left beside a deleted clock silently cover a new one.
+    """
+    _write(
+        tmp_path,
+        "if True:\n"
+        "    # frozen-clock-ok: 5d, belongs to a line that no longer exists\n"
+        "    A = 1\n"
+        "    B = datetime.now(UTC)\n",
+    )
+    assert len(check.scan(tmp_path)) == 1
+    # ...and a marker on the clock's OWN statement still works.
+    _write(
+        tmp_path,
+        "if True:\n"
+        "    A = 1\n"
+        "    # frozen-clock-ok: 5d vs a 35d window\n"
+        "    B = datetime.now(UTC)\n",
+    )
     assert check.scan(tmp_path) == []
 
 

--- a/tests/test_scripts/test_check_frozen_clock.py
+++ b/tests/test_scripts/test_check_frozen_clock.py
@@ -1,0 +1,287 @@
+"""Frozen-clock guard (scripts/check_frozen_clock.py).
+
+The guard exists because a test that captures a wall clock at IMPORT time gives the
+whole suite's runtime to burn its safety margin, and the resulting failure only shows
+up on slow runners. Two prior sweeps declared this class closed and were wrong, so
+this suite IS the thing keeping it closed — it is written to be mutation-hostile:
+
+  * every shape the guard must catch is paired with the safe shape it must NOT catch,
+    because a detection-only suite and an inert guard produce the same "no false
+    positives" number;
+  * the compound module-level statements (if/try/with/for/while/comprehension) are
+    covered as POSITIVES, not only as negatives — a negative passes trivially on a
+    scanner that never descends, so negatives alone let that whole branch be deleted
+    while the suite stays green;
+  * both fail-closed paths (a file that cannot be parsed, and one that cannot be READ)
+    are asserted, because the failure mode there is printing CLEAN over a live bomb.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "check_frozen_clock", _REPO_ROOT / "scripts" / "check_frozen_clock.py",
+)
+check = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check)
+
+_HEADER = "import time\n\nimport pytest\nfrom datetime import UTC, datetime\n\n"
+
+# (shape label, frozen source, the SAFE counterpart that must stay silent)
+SHAPES = [
+    (
+        "module-body",
+        "NOW = datetime.now(UTC)\n",
+        "def test_x():\n    now = datetime.now(UTC)\n    assert now\n",
+    ),
+    (
+        "class-body",
+        "class TestThing:\n    NOW = datetime.now(UTC)\n",
+        "class TestThing:\n    def test_x(self):\n        assert datetime.now(UTC)\n",
+    ),
+    (
+        "default-arg",
+        "def helper(seed=datetime.now(UTC)):\n    return seed\n",
+        "def helper(seed=None):\n    return seed or datetime.now(UTC)\n",
+    ),
+    (
+        "decorator-arg",
+        '@pytest.mark.parametrize("t", [datetime.now(UTC)])\ndef test_x(t):\n    assert t\n',
+        '@pytest.mark.parametrize("d", [1])\ndef test_x(d):\n    assert datetime.now(UTC)\n',
+    ),
+    (
+        "scoped-fixture",
+        '@pytest.fixture(scope="session")\ndef seed():\n    return datetime.now(UTC)\n',
+        "@pytest.fixture\ndef seed():\n    return datetime.now(UTC)\n",
+    ),
+]
+
+# Module-level COMPOUND statements. These reach the scanner's catch-all descent, which
+# nothing else here exercises as a positive — verify-RED showed that branch could be
+# deleted outright with the rest of the suite still green.
+COMPOUND_FROZEN = [
+    ("if-body", "if True:\n    NOW = datetime.now(UTC)\n"),
+    ("try-body", "try:\n    NOW = datetime.now(UTC)\nexcept Exception:\n    NOW = None\n"),
+    (
+        "with-body",
+        "import contextlib\nwith contextlib.suppress(Exception):\n"
+        "    NOW = datetime.now(UTC)\n",
+    ),
+    ("for-body", "S = []\nfor _ in range(3):\n    S.append(datetime.now(UTC))\n"),
+    ("while-body", "NOW = None\nwhile NOW is None:\n    NOW = datetime.now(UTC)\n"),
+    ("list-comprehension", "S = [datetime.now(UTC) for _ in range(3)]\n"),
+    ("walrus", "if (n := datetime.now(UTC)):\n    NOW = n\n"),
+    ("nested-class", "class A:\n    class B:\n        NOW = datetime.now(UTC)\n"),
+    ("kwonly-default", "def f(*, t=datetime.now(UTC)):\n    return t\n"),
+    (
+        "metaclass-keyword",
+        "def mk(x):\n    return type\n\n\nclass C(metaclass=mk(datetime.now(UTC))):\n    pass\n",
+    ),
+]
+
+# Deferred bodies that sit INSIDE an import-time statement. The top-level `def` cases
+# in SHAPES never reach the scanner at all, so only these exercise the rule that a
+# function/lambda/generator body is skipped — verify-RED proved the others could not.
+DEFERRED_SAFE = [
+    ("module-level lambda", "SEED = lambda: datetime.now(UTC)\n"),
+    ("def nested in an if", "if True:\n    def helper():\n        return datetime.now(UTC)\n"),
+    (
+        "def nested in a try",
+        "try:\n    def helper():\n        return datetime.now(UTC)\n"
+        "except Exception:\n    helper = None\n",
+    ),
+    ("lambda in a class body", "class TestThing:\n    seed = lambda self: datetime.now(UTC)\n"),
+    (
+        "nested def in a scoped fixture",
+        '@pytest.fixture(scope="session")\ndef seed():\n'
+        "    def _later():\n        return datetime.now(UTC)\n    return _later\n",
+    ),
+    ("generator expression is lazy", "G = (datetime.now(UTC) for _ in range(3))\n"),
+    (
+        "skipif is import-time by contract",
+        '@pytest.mark.skipif(datetime.now(UTC).year > 3000, reason="never")\n'
+        "def test_x():\n    pass\n",
+    ),
+]
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    f = tmp_path / "test_planted.py"
+    f.write_text(_HEADER + body)
+    return f
+
+
+@pytest.mark.parametrize("shape,frozen,_safe", SHAPES, ids=[s[0] for s in SHAPES])
+def test_flags_each_frozen_shape(tmp_path, shape, frozen, _safe):
+    """POSITIVE control: every import-time position the guard claims to cover."""
+    _write(tmp_path, frozen)
+    violations = check.scan(tmp_path)
+    assert len(violations) == 1, f"{shape} not flagged: {violations}"
+    assert violations[0][2] == shape
+
+
+@pytest.mark.parametrize("shape,_frozen,safe", SHAPES, ids=[s[0] for s in SHAPES])
+def test_ignores_the_safe_counterpart(tmp_path, shape, _frozen, safe):
+    """NEGATIVE control: the call-time form is the FIX, and must never be flagged."""
+    _write(tmp_path, safe)
+    assert check.scan(tmp_path) == [], f"{shape} safe form wrongly flagged"
+
+
+@pytest.mark.parametrize("label,body", COMPOUND_FROZEN, ids=[c[0] for c in COMPOUND_FROZEN])
+def test_descends_into_import_time_compound_statements(tmp_path, label, body):
+    """A clock does not stop being frozen because it sits inside an `if` or a `try`."""
+    _write(tmp_path, body)
+    assert len(check.scan(tmp_path)) == 1, f"{label} not flagged"
+
+
+@pytest.mark.parametrize("label,body", DEFERRED_SAFE, ids=[d[0] for d in DEFERRED_SAFE])
+def test_deferred_body_inside_an_import_time_statement_is_safe(tmp_path, label, body):
+    """A callable's BODY runs when called, however early the statement holding it runs."""
+    _write(tmp_path, body)
+    assert check.scan(tmp_path) == [], f"{label} wrongly flagged"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "NOW = datetime.now(UTC)  # frozen-clock-ok: 34d margin vs a 35d window\n",
+        "# frozen-clock-ok: 34d margin vs a 35d window\nNOW = datetime.now(UTC)\n",
+        "# unbounded: two seeds only\n# frozen-clock-ok: 11d margin vs a 14d window\n"
+        "NOW = datetime.now(UTC)\n",
+        "# frozen-clock-ok: 11d margin vs a 14d window\n_X = (\n    datetime.now(UTC)\n)\n",
+        "NOW = datetime.now(UTC)  # frozen-clock-ok: unbounded, nothing ages this seed\n",
+    ],
+    ids=["same-line", "directly-above", "in-a-comment-block", "wrapped-statement", "unbounded"],
+)
+def test_opt_out_is_honoured(tmp_path, body):
+    _write(tmp_path, body)
+    assert check.scan(tmp_path) == []
+
+
+@pytest.mark.parametrize(
+    "marker",
+    ["# frozen-clock-ok:", "# frozen-clock-ok:   ", "# frozen-clock-ok"],
+    ids=["empty-reason", "whitespace-reason", "no-colon"],
+)
+def test_opt_out_without_a_stated_reason_does_not_count(tmp_path, marker):
+    """The margin is the point — a bare wave-off must not silence the guard."""
+    _write(tmp_path, f"NOW = datetime.now(UTC)  {marker}\n")
+    assert len(check.scan(tmp_path)) == 1
+
+
+def test_opt_out_reason_must_state_a_magnitude(tmp_path):
+    """A reason with no number and no 'unbounded' records no measurement."""
+    _write(tmp_path, "NOW = datetime.now(UTC)  # frozen-clock-ok: it is fine, honest\n")
+    assert len(check.scan(tmp_path)) == 1
+
+
+def test_marker_inside_a_string_literal_does_not_waive(tmp_path):
+    """Only real comment tokens count, so prose about the guard cannot disarm it."""
+    _write(tmp_path, 'NOW = datetime.now(UTC); MSG = "# frozen-clock-ok: 5d bogus"\n')
+    assert len(check.scan(tmp_path)) == 1
+
+
+def test_one_marker_cannot_waive_two_sites(tmp_path):
+    """One recorded measurement per site: two clocks in a span need two waivers."""
+    _write(tmp_path, "A = datetime.now(UTC); B = time.time()  # frozen-clock-ok: 5d one reason\n")
+    assert len(check.scan(tmp_path)) == 1
+    _write(
+        tmp_path,
+        "# frozen-clock-ok: 5d for A\n# frozen-clock-ok: 5d for B\n"
+        "A = datetime.now(UTC); B = time.time()\n",
+    )
+    assert check.scan(tmp_path) == []
+
+
+def test_opt_out_does_not_reach_across_a_blank_line(tmp_path):
+    """Only the CONTIGUOUS comment block counts, so a stray marker cannot drift down."""
+    _write(tmp_path, "# frozen-clock-ok: 9d elsewhere\n\nNOW = datetime.now(UTC)\n")
+    assert len(check.scan(tmp_path)) == 1
+
+
+def test_two_clocks_on_one_line_are_two_violations(tmp_path):
+    """Deduping by name alone would under-report and under-charge the waiver rule."""
+    _write(tmp_path, "A, B = datetime.now(UTC), datetime.now(UTC)\n")
+    assert len(check.scan(tmp_path)) == 2
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "datetime.datetime.now(UTC)",
+        "datetime.utcnow()",
+        "datetime.today()",
+        "time.monotonic()",
+        "time.perf_counter()",
+        "time.time()",
+        "time.localtime()",
+        "time.gmtime()",
+        "time.clock_gettime(0)",
+    ],
+)
+def test_recognises_dotted_clock_variants(tmp_path, expr):
+    _write(tmp_path, f"SEED = {expr}\n")
+    assert len(check.scan(tmp_path)) == 1, f"{expr} not recognised"
+
+
+@pytest.mark.parametrize(
+    "decorator",
+    ['@pytest.fixture(scope=_S)', '@pytest.fixture(**_KW)'],
+    ids=["scope-is-a-variable", "scope-via-kwargs"],
+)
+def test_unprovable_fixture_scope_fails_closed(tmp_path, decorator):
+    """The guard cannot prove the scope is narrow, so it must not assume it is."""
+    _write(tmp_path, f'_S = "session"\n_KW = {{}}\n{decorator}\ndef f():\n    return datetime.now(UTC)\n')
+    assert len(check.scan(tmp_path)) == 1
+
+
+def test_unparseable_file_is_reported_not_silently_skipped(tmp_path):
+    """Fail CLOSED: a file the guard cannot parse is a gap, never a silent pass."""
+    (tmp_path / "test_broken.py").write_text("def oops(:\n")
+    violations = check.scan(tmp_path)
+    assert len(violations) == 1
+    assert violations[0][2] == "unparseable"
+
+
+@pytest.mark.parametrize("mode", ["non-utf8", "unreadable"])
+def test_file_that_cannot_be_read_is_reported_not_silently_skipped(tmp_path, mode):
+    """The same fail-closed rule for READ errors — this branch printed CLEAN over a bomb."""
+    f = tmp_path / "test_unreadable.py"
+    if mode == "non-utf8":
+        f.write_bytes("NOW = datetime.now(UTC)  # caf\xe9\n".encode("latin-1"))
+    else:
+        f.write_text("NOW = datetime.now(UTC)\n")
+        os.chmod(f, 0o000)
+    try:
+        violations = check.scan(tmp_path)
+        assert len(violations) == 1
+        assert violations[0][2] == "unreadable"
+    finally:
+        os.chmod(f, 0o644)
+
+
+def test_repo_tests_tree_is_clean():
+    """The real tree must stay clean — this is what actually blocks a regression."""
+    violations = check.scan(_REPO_ROOT / "tests")
+    assert violations == [], f"frozen clocks reintroduced: {violations}"
+
+
+def test_main_returns_nonzero_on_a_violation(tmp_path, monkeypatch, capsys):
+    _write(tmp_path, "NOW = datetime.now(UTC)\n")
+    monkeypatch.setattr(check, "SCAN_ROOT", tmp_path)
+    assert check.main() == 1
+    assert "frozen-clock" in capsys.readouterr().out
+
+
+def test_main_returns_zero_on_a_clean_tree(tmp_path, monkeypatch, capsys):
+    """Negative control: a main() hardwired to 1 would pass the test above alone."""
+    _write(tmp_path, "def test_x():\n    assert datetime.now(UTC)\n")
+    monkeypatch.setattr(check, "SCAN_ROOT", tmp_path)
+    assert check.main() == 0
+    assert "CLEAN" in capsys.readouterr().out


### PR DESCRIPTION
## What

A test read a wall clock **once at module import** and seeded a heartbeat 30 minutes ahead of it. Production ages that seed against the **live** clock with a 5-minute future-skew tolerance, so the assertion only held while under 25 minutes had elapsed since import — the whole suite's runtime, not the test's. The seed now reads the clock when the helper is called.

A new `frozen-clock-check` CI job closes the class.

## Why it kept coming back

This is the third recurrence. The two earlier sweeps each enumerated absolute date **literals** and each declared the class closed; a clock frozen at import walked through both. Syntax was never the key, so this guard keys on **when the clock is read**.

## Evidence

Measured on both sides of the boundary against real production code — the elapsed time was simulated by moving the module's captured value backwards, which is exactly equivalent to the import having happened N minutes ago and leaves production on the real clock:

| simulated elapsed | result |
|---|---|
| 16 min | passes |
| 26 min | **fails** |

That matches what CI observed in the wild (a pass at 16m02s into a run, a failure at 27m12s). A 31-run survey put it at roughly 3% of runs — rare enough to read as a flake, which is how it survived.

## The guard

Flags a wall-clock call evaluated in a module body, class body, default argument, decorator argument, or a session/module/package-scoped fixture — including inside module-level `if`/`try`/`with`/`for`/`while` bodies and comprehensions.

Does **not** flag the forms that read the clock at use time: function and lambda bodies, generator expressions, function-scoped fixtures, and `skipif`, whose contract *is* import-time evaluation.

Escape hatch `# frozen-clock-ok: <why, with the measured margin>`, in a real comment inside the flagged statement's span or the contiguous block above it. Three rules keep it meaningful:

- the reason must state a magnitude — a number, or `unbounded` for a site nothing ages;
- only real comment tokens count, so a marker inside a string cannot disarm it;
- a span needs as many waivers as it has flagged calls, so one waiver cannot cover two sites.

Both positions are accepted because a justification naming a margin *and* its production threshold does not fit in the trailing columns of a line under a 100-column limit. A guard whose escape hatch forces a lint violation gets deleted by whoever hits it next.

## The four opt-outs

Of the five sites that existed before this change, four were legitimate. Each margin was verified individually against the production threshold it names, rather than copied: unbounded where the verdict is a difference of two seeds, 11 days against a 14-day window, unbounded where elapsed time only deepens the staleness asserted, and ~35 days against a 35-day window.

## Scope, stated plainly

This closes the **mechanically-decidable sub-shape only**. An absolute date literal is a bomb only relative to a production threshold, which is not statically decidable. No claim is made that the literal population is clean, and the guard's docstring records its own blind spots — aliased imports, a clock read in a helper the module body calls, and those literals. The production half of the class (sites that age a stored timestamp against the live clock) is filed separately for enumeration.

## Verification

- 95 targeted tests across the five affected files; ruff clean; the guard is clean on the tree.
- **Thirteen mutations**, one per guard mechanism, each verified to actually apply, each killed by the specific test named for it, each restored byte-exact.
- Both fail-closed paths are asserted, not assumed: a file the guard cannot **parse** and one it cannot **read** are each reported, because the failure mode there is printing `CLEAN` over a live bomb.

Mutation testing surfaced three defects before review: a suite that stayed green when the skip-deferred-bodies rule was deleted; a real bug where a nested `def` inside a scoped fixture was flagged although its body only runs when called; and a suite that stayed green when descent into module-level compound statements was removed — the branch where most real instances of this bug live.

An adversarial architect audit then found two more blocking issues, both confirmed by direct measurement before being fixed: the guard silently skipped files it could not read (printing `CLEAN` over two planted bombs), and its largest coverage branch survived deletion with the suite green. It also caught a factual error in this PR's own prose, which is corrected in the changelog rather than quietly dropped.

---

Related open work, filed by this change and **not** completed by it (bare ids, context only):
`d64831761dbb460d95c21a70f3e211b0` — enumerate the production half of this class.
`465261f53b29425183d5b7c45eca42e8` — a liveness helper takes a `now` parameter it never reads.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automated safeguards to detect unsafe wall-clock usage in tests.
  * Improved reliability of time-sensitive test scenarios through documented timing boundaries and validated clock behavior.

* **CI**
  * Added a frozen-clock validation check to continuous integration and local verification workflows.

* **Documentation**
  * Updated changelog details covering the wall-clock race fix, validation results, and production-code boundary measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->