### PR TITLE
chore(review): declare the CodeRabbit config in the repo

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# CodeRabbit review configuration.
+#
+# This file exists so the review behaviour is declared IN THE REPOSITORY rather
+# than living only in a dashboard nobody can read from a checkout. Several of the
+# values below match CodeRabbit's own defaults; they are written out anyway,
+# because "the default happens to be what we want" and "we decided this" are
+# different states, and only the second survives someone changing a default.
+#
+# Config on the DEFAULT branch governs every pull request. A copy on a feature
+# branch does not take effect for that branch's own PR.
+
+language: en-US
+
+reviews:
+  # chill = balanced. `assertive` produces more findings, most of them nitpicks;
+  # this repo already runs a separate cross-model review, so the value here is
+  # a second independent perspective, not volume.
+  profile: chill
+
+  auto_review:
+    # Declared explicitly. CodeRabbit's default is already true, but the point of
+    # this file is that the answer does not depend on a dashboard toggle.
+    enabled: true
+    # Re-review on each push. Without it, a review describes the first commit of
+    # a PR and silently stops describing the branch after that — the same
+    # stale-evidence failure the merge gate guards against elsewhere.
+    auto_incremental_review: true
+    # Drafts are work in progress by definition; reviewing them trains people to
+    # ignore the reviewer.
+    drafts: false
+
+  # Excluded from review, not from the repo. Each of these is either machine-
+  # generated or binary, so a reviewer comment on it can never be actionable.
+  path_filters:
+    - "!src/genesis/dashboard/webui/vendor/**"
+    - "!**/*.min.js"
+    - "!**/*.min.css"
+    - "!docs/images/**"
+    - "!**/package-lock.json"
+
+  # The walkthrough is read at merge time; keep it to substance.
+  poem: false
+  high_level_summary: true
+
+  # Do NOT auto-approve when comments are resolved. Merges in this repo require a
+  # human approval by policy, and a bot approval that satisfies a required-review
+  # rule would quietly remove that.
+  request_changes_workflow: false


### PR DESCRIPTION
Puts the CodeRabbit review configuration in the default branch, where it governs every pull request, instead of leaving it in a dashboard that cannot be read from a checkout or reviewed as a change.

## Why write out values that are already the default

Several settings here match CodeRabbit's own defaults. They are declared anyway: *"the default happens to be what we want"* and *"we decided this"* are different states, and only the second survives someone changing a default upstream.

## What is set, and why

| setting | reason |
|---|---|
| `auto_review.enabled: true` | Declared rather than inherited. The answer must not depend on a toggle nobody can see from the repo. |
| `auto_review.auto_incremental_review: true` | Re-review on each push. Without it a review describes a PR's *first* commit and then silently stops describing the branch — the same stale-evidence failure the merge gate refuses elsewhere. |
| `auto_review.drafts: false` | Reviewing work-in-progress trains people to ignore the reviewer. |
| `profile: chill` | This repo already runs a separate cross-model review, so the value here is an independent second perspective, not volume. `assertive` mostly adds nitpicks. |
| `path_filters` | Excludes vendored bundles, minified assets, images and lockfiles. A review comment on generated output can never be actionable. |
| `request_changes_workflow: false` | Explicitly **off**. Merges here require a human approval by policy, and a bot approval that satisfied a required-review rule would quietly remove that. |

## Verification

Validated against the published `schema.v2.json` rather than written from memory — every key and nesting level was checked against the real schema before commit, not inferred from documentation prose.

## Note on scope

Config on a feature branch does not govern that branch's own pull request, so this takes effect once it is on the default branch. It also does not retroactively review pull requests opened before CodeRabbit was installed; those are picked up on their next push, or on request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository review and automation settings to provide more consistent, focused feedback.
  * Improved handling of draft changes and generated or binary files during automated reviews.
  * Standardized review language and summary formatting.
  * No end-user functionality or public-facing behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->