### PR TITLE
fix(tests): read the clock when the helper is called, not at module import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A test no longer reads the wall clock once at import and races the suite.**
+  `test_surplus_liveness.py` captured `datetime.now(UTC)` at module import and
+  seeded a heartbeat 30 minutes ahead of it; production ages that seed against
+  the *live* clock with a 5-minute future-skew tolerance, so the assertion only
+  held while under 25 minutes had elapsed since import — the whole suite's
+  runtime, not the test's. Past that edge it failed, and a re-run went green,
+  so it read as a flake; a 31-run survey put it at roughly 3% of runs. The seed
+  is now computed when the helper is called, shrinking the margin from the
+  suite's runtime to one test's. Measured on both sides of the boundary against
+  real production code: the case passes with 16 minutes of simulated elapsed
+  time and fails at 26.
 - **SSH slot cap no longer collapses below the running session count.** The
   interactive-slot launcher (`scripts/cc-slot.sh`) sized its cap from
   *instantaneous free RAM* (`(MemAvailable − reserve) / per_session`), so each

--- a/tests/test_observability/test_surplus_liveness.py
+++ b/tests/test_observability/test_surplus_liveness.py
@@ -24,7 +24,6 @@ from genesis.db.schema import create_all_tables
 from genesis.observability.snapshots.surplus import surplus_status
 from genesis.runtime._core import GenesisRuntime
 
-NOW = datetime.now(UTC)
 _UNSET = object()
 
 
@@ -49,7 +48,10 @@ def _install_runtime(
 ):
     """Inject a stub runtime whose in-memory _job_health holds the surplus pulse.
 
-    pulse_min_ago: seed last_success that many minutes before NOW.
+    pulse_min_ago: seed last_success that many minutes before the CALL-TIME clock
+        (negative seeds the future). Read `now` HERE, never at import: production
+        ages this seed against the live clock, so a module-level capture makes the
+        margin the whole suite's runtime instead of this one test's.
     pulse_raw: seed a literal last_success value (e.g. a garbage string).
     neither set: no surplus_dispatch entry at all (never pulsed).
     """
@@ -60,7 +62,7 @@ def _install_runtime(
     if pulse_raw is not _UNSET:
         entry = {"surplus_dispatch": {"last_success": pulse_raw}}
     elif pulse_min_ago is not _UNSET:
-        ts = (NOW - timedelta(minutes=pulse_min_ago)).isoformat()
+        ts = (datetime.now(UTC) - timedelta(minutes=pulse_min_ago)).isoformat()
         entry = {"surplus_dispatch": {"last_success": ts}}
     GenesisRuntime._instance = SimpleNamespace(
         is_bootstrapped=bootstrapped,


### PR DESCRIPTION
## The defect

`test_surplus_liveness.py` read the wall clock **once, at module import**, and seeded a heartbeat 30 minutes ahead of it. Production ages that seed against the **live** clock with a 5-minute future-skew tolerance, so the assertion only held while under **25 minutes** had elapsed since import — the whole suite's runtime, not the test's.

Past that edge it failed; a re-run went green; it read as a flake. A 31-run survey put it at roughly **3% of runs**. Nothing is wrong with the production code, and nothing is wrong on a fast run.

## Evidence

Measured on both sides of the boundary against real production code. Elapsed time was simulated by moving the module's captured value *backwards*, which is exactly equivalent to the import having happened N minutes ago and leaves production on the real clock:

| simulated elapsed | result |
|---|---|
| 16 min | passes |
| 26 min | **fails** |

That matches what CI observed in the wild — a pass 16m02s into a run, a failure at 27m12s.

## The fix

The seed is computed when the helper is called, shrinking the margin from the suite's runtime to one test's duration.

The other four seeds in this file are unaffected, and each was re-derived individually against production rather than assumed: a 300-minute seed against a 180-minute stall threshold (which only grows), a 2-minute seed with 178 minutes of headroom, a paused case that short-circuits before the pulse math, and an unbootstrapped case that raises before the clock is read.

## Scope

Deliberately just the live defect. A CI guard for this whole class — this is its third recurrence, because both earlier sweeps enumerated absolute date *literals* and a clock frozen at import is not one — is in flight separately and is still settling under review. Splitting it out so the flake stops now rather than waiting on that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved heartbeat timing validation to avoid results varying with test-suite runtime.
  - Added boundary checks for simulated elapsed times of 16 and 26 minutes.

- **Documentation**
  - Documented the updated call-time timing behavior for heartbeat checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->