### PR TITLE
fix(observability): persist job health from the heartbeat daemons' ticks

### DIFF
--- a/src/genesis/dashboard/heartbeat.py
+++ b/src/genesis/dashboard/heartbeat.py
@@ -52,6 +52,51 @@ class DashboardHeartbeat:
             self._thread.join(timeout=5)
 
 
+
+    def _submit(self, coro_factory) -> bool:
+        """Run a coroutine on the captured main loop. False if none is live.
+
+        Cancels the submission whenever the wait does not complete normally. A
+        timed-out ``Future.result()`` does NOT cancel the underlying task, so
+        without this a stalled loop would leave each tick pending while the next
+        one is submitted -- accumulating tasks that all fire at once on recovery,
+        emitting stale pulses and a burst of successes.
+        """
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return False
+        future = asyncio.run_coroutine_threadsafe(coro_factory(), loop)
+        try:
+            future.result(timeout=self._TICK_TIMEOUT_S)
+        except BaseException:
+            future.cancel()
+            raise
+        return True
+
+    def _record_failure(self, rt: object, exc: BaseException) -> None:
+        """Persist a failed tick, from the live loop when there is one.
+
+        ``record_job_failure`` persists through the SAME loop-dependent path as
+        ``record_job_success``: called from this worker thread it updates memory
+        and never the table. Recording success on the loop but failure off it
+        would leave exactly half the defect in place -- the failure direction,
+        which is the half an operator most needs to see.
+        """
+
+        async def _record() -> None:
+            rt.record_job_failure(
+                "dashboard_heartbeat", "heartbeat emission failed", exc=exc
+            )
+
+        try:
+            if self._submit(_record):
+                return
+        except BaseException:
+            # Already handling a failure; fall through to the degraded path
+            # rather than masking the original exception with this one.
+            pass
+        rt.record_job_failure("dashboard_heartbeat", "heartbeat emission failed", exc=exc)
+
     def _tick(self, rt: object, Subsystem: object, Severity: object) -> None:
         """Emit one pulse and record job health, on the runtime's main loop.
 
@@ -71,11 +116,7 @@ class DashboardHeartbeat:
             # its DB write onto a loop that keeps running afterwards.
             rt.record_job_success("dashboard_heartbeat")
 
-        loop = self._loop
-        if loop is not None and loop.is_running():
-            asyncio.run_coroutine_threadsafe(_emit_and_record(), loop).result(
-                timeout=self._TICK_TIMEOUT_S
-            )
+        if self._submit(_emit_and_record):
             return
 
         # No live main loop (start() ran outside one). Emit on a throwaway loop;
@@ -110,7 +151,7 @@ class DashboardHeartbeat:
                     from genesis.runtime import GenesisRuntime
 
                     rt = GenesisRuntime.instance()
-                    rt.record_job_failure("dashboard_heartbeat", "heartbeat emission failed", exc=exc)
+                    self._record_failure(rt, exc)
                 except Exception:
                     pass
             self._stop_event.wait(self._interval)

--- a/src/genesis/dashboard/heartbeat.py
+++ b/src/genesis/dashboard/heartbeat.py
@@ -19,13 +19,26 @@ logger = logging.getLogger("genesis.dashboard.heartbeat")
 class DashboardHeartbeat:
     """Background daemon thread that emits heartbeat events for the web UI."""
 
+    # Bounded so a wedged main loop cannot pin the worker thread or let ticks
+    # overlap; must stay BELOW the pulse interval (60s) for that to hold.
+    _TICK_TIMEOUT_S = 30
+
     def __init__(self, interval_seconds: int = 60) -> None:
         self._interval = interval_seconds
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
+        # The runtime's main event loop, captured in start(). See _tick: job
+        # health can only be persisted from a RUNNING loop that outlives the
+        # call, which a per-tick throwaway loop is not. None when start() runs
+        # outside a loop (tests) — _tick then falls back to the old behaviour.
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     def start(self) -> None:
         """Start the heartbeat background thread."""
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None
         self._thread = threading.Thread(
             target=self._run, daemon=True, name="dashboard-heartbeat",
         )
@@ -38,6 +51,49 @@ class DashboardHeartbeat:
         if self._thread:
             self._thread.join(timeout=5)
 
+
+    def _tick(self, rt: object, Subsystem: object, Severity: object) -> None:
+        """Emit one pulse and record job health, on the runtime's main loop.
+
+        Blocks on the scheduled coroutine so a failure still raises into _run's
+        handler (which records the job FAILURE) rather than being swallowed by a
+        discarded future.
+        """
+
+        async def _emit_and_record() -> None:
+            await rt.event_bus.emit(
+                Subsystem.DASHBOARD,
+                Severity.DEBUG,
+                "heartbeat",
+                "Dashboard web UI alive",
+            )
+            # Runs INSIDE the live main loop, so persist_job_health can schedule
+            # its DB write onto a loop that keeps running afterwards.
+            rt.record_job_success("dashboard_heartbeat")
+
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            asyncio.run_coroutine_threadsafe(_emit_and_record(), loop).result(
+                timeout=self._TICK_TIMEOUT_S
+            )
+            return
+
+        # No live main loop (start() ran outside one). Emit on a throwaway loop;
+        # job health stays in-memory only, exactly as before this fix.
+        fallback = asyncio.new_event_loop()
+        try:
+            fallback.run_until_complete(
+                rt.event_bus.emit(
+                    Subsystem.DASHBOARD,
+                    Severity.DEBUG,
+                    "heartbeat",
+                    "Dashboard web UI alive",
+                )
+            )
+        finally:
+            fallback.close()
+        rt.record_job_success("dashboard_heartbeat")
+
     def _run(self) -> None:
         from genesis.observability.types import Severity, Subsystem
 
@@ -47,19 +103,7 @@ class DashboardHeartbeat:
 
                 rt = GenesisRuntime.instance()
                 if rt.is_bootstrapped and rt.event_bus:
-                    loop = asyncio.new_event_loop()
-                    try:
-                        loop.run_until_complete(
-                            rt.event_bus.emit(
-                                Subsystem.DASHBOARD,
-                                Severity.DEBUG,
-                                "heartbeat",
-                                "Dashboard web UI alive",
-                            )
-                        )
-                    finally:
-                        loop.close()
-                    rt.record_job_success("dashboard_heartbeat")
+                    self._tick(rt, Subsystem, Severity)
             except Exception as exc:
                 logger.error("Dashboard heartbeat failed", exc_info=True)
                 try:

--- a/src/genesis/dashboard/heartbeat.py
+++ b/src/genesis/dashboard/heartbeat.py
@@ -1,166 +1,24 @@
 """Dashboard heartbeat — emits periodic heartbeats to the event bus.
 
-The web UI runs in the same process as all Genesis subsystems. If the Flask
-app degrades (routes broken, event loop stalled) this heartbeat will stop,
-allowing subsystem_heartbeats() to detect the issue.  If the entire process
-dies, external monitoring (status.json file age, systemd watchdog) covers
-the gap — this heartbeat handles the *degraded-but-alive* case.
+The web UI runs in the same process as all Genesis subsystems. If the Flask app
+degrades (routes broken, event loop stalled) this heartbeat stops, allowing
+``subsystem_heartbeats()`` to detect the issue. If the entire process dies,
+external monitoring (status.json file age, systemd watchdog) covers the gap —
+this heartbeat handles the *degraded-but-alive* case.
+
+The threading, loop capture and health recording live in
+``observability.heartbeat_daemon``; only the identity is here.
 """
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import threading
-
-logger = logging.getLogger("genesis.dashboard.heartbeat")
+from genesis.observability.heartbeat_daemon import HeartbeatDaemon
 
 
-class DashboardHeartbeat:
-    """Background daemon thread that emits heartbeat events for the web UI."""
+class DashboardHeartbeat(HeartbeatDaemon):
+    """Emits the dashboard liveness pulse while the runtime is bootstrapped."""
 
-    # Bounded so a wedged main loop cannot pin the worker thread or let ticks
-    # overlap; must stay BELOW the pulse interval (60s) for that to hold.
-    _TICK_TIMEOUT_S = 30
-
-    def __init__(self, interval_seconds: int = 60) -> None:
-        self._interval = interval_seconds
-        self._thread: threading.Thread | None = None
-        self._stop_event = threading.Event()
-        # The runtime's main event loop, captured in start(). See _tick: job
-        # health can only be persisted from a RUNNING loop that outlives the
-        # call, which a per-tick throwaway loop is not. None when start() runs
-        # outside a loop (tests) — _tick then falls back to the old behaviour.
-        self._loop: asyncio.AbstractEventLoop | None = None
-
-    def start(self) -> None:
-        """Start the heartbeat background thread."""
-        try:
-            self._loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self._loop = None
-        self._thread = threading.Thread(
-            target=self._run, daemon=True, name="dashboard-heartbeat",
-        )
-        self._thread.start()
-        logger.info("Dashboard heartbeat started (interval=%ds)", self._interval)
-
-    def stop(self) -> None:
-        """Signal the thread to stop and wait for it."""
-        self._stop_event.set()
-        if self._thread:
-            self._thread.join(timeout=5)
-
-
-
-    def _submit(self, coro_factory) -> bool:
-        """Run a coroutine on the captured main loop. False if none is live.
-
-        Cancels the submission whenever the wait does not complete normally. A
-        timed-out ``Future.result()`` does NOT cancel the underlying task, so
-        without this a stalled loop would leave each tick pending while the next
-        one is submitted -- accumulating tasks that all fire at once on recovery,
-        emitting stale pulses and a burst of successes.
-        """
-        loop = self._loop
-        if loop is None or not loop.is_running():
-            return False
-        future = asyncio.run_coroutine_threadsafe(coro_factory(), loop)
-        try:
-            future.result(timeout=self._TICK_TIMEOUT_S)
-        except BaseException:
-            future.cancel()
-            raise
-        return True
-
-    def _record_failure(self, rt: object, exc: BaseException) -> None:
-        """Persist a failed tick, from the live loop when there is one.
-
-        ``record_job_failure`` persists through the SAME loop-dependent path as
-        ``record_job_success``: called from this worker thread it updates memory
-        and never the table. Recording success on the loop but failure off it
-        would leave exactly half the defect in place -- the failure direction,
-        which is the half an operator most needs to see.
-        """
-
-        async def _record() -> None:
-            rt.record_job_failure(
-                "dashboard_heartbeat", "heartbeat emission failed", exc=exc
-            )
-
-        loop = self._loop
-        if loop is not None and loop.is_running():
-            try:
-                # Submitted WITHOUT _submit's bounded wait, deliberately. A tick is
-                # periodic and a stale one is actively misleading, so it is cancelled
-                # on timeout; a failure record is a one-off that stays true however
-                # late it lands. Bounding it would drop the record in precisely the
-                # scenario it describes — a loop wedged past the timeout is exactly
-                # when the wait would expire — leaving the persisted row showing the
-                # previous SUCCESS across the whole stall. Pending records are bounded
-                # by one per interval and settle when the loop recovers.
-                asyncio.run_coroutine_threadsafe(_record(), loop)
-                return
-            except RuntimeError:
-                # The loop stopped between the check and the submit; fall through.
-                pass
-        rt.record_job_failure("dashboard_heartbeat", "heartbeat emission failed", exc=exc)
-
-    def _tick(self, rt: object, Subsystem: object, Severity: object) -> None:
-        """Emit one pulse and record job health, on the runtime's main loop.
-
-        Blocks on the scheduled coroutine so a failure still raises into _run's
-        handler (which records the job FAILURE) rather than being swallowed by a
-        discarded future.
-        """
-
-        async def _emit_and_record() -> None:
-            await rt.event_bus.emit(
-                Subsystem.DASHBOARD,
-                Severity.DEBUG,
-                "heartbeat",
-                "Dashboard web UI alive",
-            )
-            # Runs INSIDE the live main loop, so persist_job_health can schedule
-            # its DB write onto a loop that keeps running afterwards.
-            rt.record_job_success("dashboard_heartbeat")
-
-        if self._submit(_emit_and_record):
-            return
-
-        # No live main loop (start() ran outside one). Emit on a throwaway loop;
-        # job health stays in-memory only, exactly as before this fix.
-        fallback = asyncio.new_event_loop()
-        try:
-            fallback.run_until_complete(
-                rt.event_bus.emit(
-                    Subsystem.DASHBOARD,
-                    Severity.DEBUG,
-                    "heartbeat",
-                    "Dashboard web UI alive",
-                )
-            )
-        finally:
-            fallback.close()
-        rt.record_job_success("dashboard_heartbeat")
-
-    def _run(self) -> None:
-        from genesis.observability.types import Severity, Subsystem
-
-        while not self._stop_event.is_set():
-            try:
-                from genesis.runtime import GenesisRuntime
-
-                rt = GenesisRuntime.instance()
-                if rt.is_bootstrapped and rt.event_bus:
-                    self._tick(rt, Subsystem, Severity)
-            except Exception as exc:
-                logger.error("Dashboard heartbeat failed", exc_info=True)
-                try:
-                    from genesis.runtime import GenesisRuntime
-
-                    rt = GenesisRuntime.instance()
-                    self._record_failure(rt, exc)
-                except Exception:
-                    pass
-            self._stop_event.wait(self._interval)
+    subsystem_name = "DASHBOARD"
+    job_name = "dashboard_heartbeat"
+    message = "Dashboard web UI alive"
+    thread_name = "dashboard-heartbeat"

--- a/src/genesis/dashboard/heartbeat.py
+++ b/src/genesis/dashboard/heartbeat.py
@@ -88,13 +88,22 @@ class DashboardHeartbeat:
                 "dashboard_heartbeat", "heartbeat emission failed", exc=exc
             )
 
-        try:
-            if self._submit(_record):
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            try:
+                # Submitted WITHOUT _submit's bounded wait, deliberately. A tick is
+                # periodic and a stale one is actively misleading, so it is cancelled
+                # on timeout; a failure record is a one-off that stays true however
+                # late it lands. Bounding it would drop the record in precisely the
+                # scenario it describes — a loop wedged past the timeout is exactly
+                # when the wait would expire — leaving the persisted row showing the
+                # previous SUCCESS across the whole stall. Pending records are bounded
+                # by one per interval and settle when the loop recovers.
+                asyncio.run_coroutine_threadsafe(_record(), loop)
                 return
-        except BaseException:
-            # Already handling a failure; fall through to the degraded path
-            # rather than masking the original exception with this one.
-            pass
+            except RuntimeError:
+                # The loop stopped between the check and the submit; fall through.
+                pass
         rt.record_job_failure("dashboard_heartbeat", "heartbeat emission failed", exc=exc)
 
     def _tick(self, rt: object, Subsystem: object, Severity: object) -> None:

--- a/src/genesis/observability/heartbeat_daemon.py
+++ b/src/genesis/observability/heartbeat_daemon.py
@@ -66,14 +66,35 @@ class HeartbeatDaemon:
         # a throwaway loop and pulses without recording health, which is the
         # pre-existing behaviour rather than a new failure.
         self._loop: asyncio.AbstractEventLoop | None = None
+        # The in-flight failure record, if any. See _record_failure: at most one.
+        self._pending_failure = None
 
     # --- lifecycle ---------------------------------------------------------
     def start(self) -> None:
-        """Start the heartbeat thread, capturing the loop it was started from."""
+        """Start the heartbeat thread, capturing the loop it was started from.
+
+        MUST be called from the runtime's loop thread. That is the fix's entire
+        activation condition, and it used to be silent: an embedder calling this
+        from a sync context gets ``_loop = None``, every tick takes the fallback,
+        and job health is never persisted — the exact defect this class exists to
+        remove. So the miss is now LOUD rather than inferred from missing rows.
+        """
+        if self._thread is not None and self._thread.is_alive():
+            logger.warning(
+                "%s heartbeat already running — ignoring duplicate start()",
+                self.job_name,
+            )
+            return
         try:
             self._loop = asyncio.get_running_loop()
         except RuntimeError:
             self._loop = None
+            logger.warning(
+                "%s heartbeat started with NO running event loop: it will pulse, but "
+                "job health will not be persisted. Start it from the runtime's loop "
+                "thread to restore persistence.",
+                self.job_name,
+            )
         self._thread = threading.Thread(
             target=self._run, daemon=True, name=self.thread_name or "heartbeat",
         )
@@ -106,7 +127,12 @@ class HeartbeatDaemon:
         loop = self._loop
         if loop is None or not loop.is_running():
             return False
-        future = asyncio.run_coroutine_threadsafe(coro_factory(), loop)
+        coro = coro_factory()
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
+        except RuntimeError:
+            coro.close()  # never scheduled -> close it rather than leak a warning
+            raise
         try:
             future.result(timeout=self._TICK_TIMEOUT_S)
         except BaseException:
@@ -155,13 +181,40 @@ class HeartbeatDaemon:
 
         loop = self._loop
         if loop is not None and loop.is_running():
-            try:
-                asyncio.run_coroutine_threadsafe(_record(), loop)
+            # COALESCE: at most ONE failure record may be in flight. Unbounded
+            # submission was the previous shape and it is wrong for the case it was
+            # written for — during a wedge every tick times out and queues another
+            # record, so a three-hour stall lands ~120 of them at once on recovery,
+            # driving consecutive_failures to ~120, permanently inflating
+            # total_failures, and firing a retry per record where a retry registry
+            # is wired. "The daemon is failing" is ONE fact however long the stall
+            # lasts; the pending record already carries it.
+            pending = self._pending_failure
+            if pending is not None and not pending.done():
                 return
+            coro = _record()
+            try:
+                self._pending_failure = asyncio.run_coroutine_threadsafe(coro, loop)
             except RuntimeError:
-                # The loop stopped between the check and the submit; fall through.
-                pass
+                # The loop stopped between the check and the submit. Close the
+                # coroutine explicitly: it was created as an argument and never
+                # scheduled, so without this it warns "never awaited" every tick
+                # through the shutdown window.
+                coro.close()
+            else:
+                # A concurrent.futures.Future does not warn on an unretrieved
+                # exception the way an asyncio task does, so an error inside the
+                # record would vanish silently.
+                self._pending_failure.add_done_callback(self._log_record_error)
+                return
         rt.record_job_failure(self.job_name, "heartbeat emission failed", exc=exc)
+
+    def _log_record_error(self, future) -> None:
+        """Surface an exception raised by a submitted failure record."""
+        try:
+            future.result()
+        except Exception:
+            logger.error("%s heartbeat failure-record failed", self.job_name, exc_info=True)
 
     def _run(self) -> None:
         from genesis.observability.types import Severity, Subsystem

--- a/src/genesis/observability/heartbeat_daemon.py
+++ b/src/genesis/observability/heartbeat_daemon.py
@@ -1,0 +1,185 @@
+"""Shared mechanism for the threaded subsystem heartbeat daemons.
+
+Subclasses supply IDENTITY — which subsystem, which job name, which message,
+which thread name — and, where they need one, an emit GATE. The mechanism lives
+here exactly once: capture the runtime's main event loop, run each tick ON it,
+cancel a tick that outlives its budget, and record BOTH success and failure from
+that loop.
+
+WHY THIS MODULE EXISTS, since a new module needs a reason. It did not exist, and
+the cost was measured: the outreach daemon was copied from the dashboard one and
+inherited, verbatim, a silent job-health persistence bug (both recorded health
+AFTER closing the throwaway loop they emitted on, so ``persist_job_health``
+returned early and the row was never written — neither subsystem appeared among
+89 persisted job rows while both pulsed normally). Three successive review rounds
+then had to apply the same fix twice, and each round's fix created the next
+round's defect. Duplication was the generator, so removing it is the fix rather
+than a tidy-up.
+
+WHY THE TICK RUNS ON THE RUNTIME'S LOOP. Recording job health needs a RUNNING
+loop that OUTLIVES the call: ``persist_job_health`` schedules the DB write as a
+task and returns early when no loop is running, so a per-tick throwaway loop
+loses the write either way — it is closed before the scheduled write can run.
+
+WHY SUCCESS AND FAILURE ARE BOUNDED DIFFERENTLY. A tick is PERIODIC and a stale
+pulse is actively misleading, so an overdue tick is cancelled. A failure record
+is a ONE-OFF that stays true however late it lands, and the condition it reports
+— a wedged loop — is exactly what makes a bounded wait expire; bounding it would
+drop the record across the whole stall, leaving the persisted row showing the
+previous SUCCESS. Do not "make these consistent": the asymmetry is the point, and
+collapsing it is the defect a review round already caught here once.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+logger = logging.getLogger("genesis.observability.heartbeat_daemon")
+
+
+class HeartbeatDaemon:
+    """Background daemon thread emitting a subsystem's liveness pulse."""
+
+    # Bounded so a wedged main loop cannot pin the worker thread or let ticks
+    # overlap; must stay BELOW the pulse interval for that to hold.
+    _TICK_TIMEOUT_S = 30
+
+    # --- subclass identity -------------------------------------------------
+    #: Attribute name on ``observability.types.Subsystem`` (resolved lazily so
+    #: this module stays import-cheap for a foundational path).
+    subsystem_name: str = ""
+    #: job_health key recorded for each tick.
+    job_name: str = ""
+    #: Human-facing event message.
+    message: str = ""
+    #: OS thread name, for ps/py-spy.
+    thread_name: str = ""
+
+    def __init__(self, interval_seconds: int = 60) -> None:
+        self._interval = interval_seconds
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        # The runtime's main event loop, captured in start(). None when start()
+        # runs outside a loop (tests, sync embedders) — _tick then falls back to
+        # a throwaway loop and pulses without recording health, which is the
+        # pre-existing behaviour rather than a new failure.
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    # --- lifecycle ---------------------------------------------------------
+    def start(self) -> None:
+        """Start the heartbeat thread, capturing the loop it was started from."""
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None
+        self._thread = threading.Thread(
+            target=self._run, daemon=True, name=self.thread_name or "heartbeat",
+        )
+        self._thread.start()
+        logger.info(
+            "%s heartbeat started (interval=%ds)", self.job_name, self._interval
+        )
+
+    def stop(self) -> None:
+        """Signal the thread to stop and wait briefly for it."""
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+
+    # --- overridable gate --------------------------------------------------
+    def _should_emit(self, rt: object) -> bool:
+        """Whether to pulse this cycle. Default: the runtime is usable."""
+        return bool(getattr(rt, "is_bootstrapped", False) and getattr(rt, "event_bus", None))
+
+    # --- mechanism ---------------------------------------------------------
+    def _submit(self, coro_factory) -> bool:
+        """Run a coroutine on the captured main loop. False if none is live.
+
+        Cancels the submission whenever the wait does not complete normally. A
+        timed-out ``Future.result()`` does NOT cancel the underlying task, so
+        without this a stalled loop would leave each tick pending while the next
+        is submitted — accumulating tasks that all fire at once on recovery,
+        emitting stale pulses and a burst of successes.
+        """
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return False
+        future = asyncio.run_coroutine_threadsafe(coro_factory(), loop)
+        try:
+            future.result(timeout=self._TICK_TIMEOUT_S)
+        except BaseException:
+            future.cancel()
+            raise
+        return True
+
+    def _tick(self, rt: object, Subsystem: object, Severity: object) -> None:
+        """Emit one pulse and record success, on the runtime's main loop.
+
+        Blocks on the scheduled coroutine so a failure still raises into _run's
+        handler (which records the job FAILURE) instead of being swallowed by a
+        discarded future.
+        """
+        subsystem = getattr(Subsystem, self.subsystem_name)
+
+        async def _emit_and_record() -> None:
+            await rt.event_bus.emit(subsystem, Severity.DEBUG, "heartbeat", self.message)
+            # Runs INSIDE the live main loop, so persist_job_health can schedule
+            # its DB write onto a loop that keeps running afterwards.
+            rt.record_job_success(self.job_name)
+
+        if self._submit(_emit_and_record):
+            return
+
+        # No live main loop. Emit on a throwaway loop; job health stays in-memory
+        # only, exactly as before this mechanism existed.
+        fallback = asyncio.new_event_loop()
+        try:
+            fallback.run_until_complete(
+                rt.event_bus.emit(subsystem, Severity.DEBUG, "heartbeat", self.message)
+            )
+        finally:
+            fallback.close()
+        rt.record_job_success(self.job_name)
+
+    def _record_failure(self, rt: object, exc: BaseException) -> None:
+        """Persist a failed tick, from the live loop when there is one.
+
+        Submitted WITHOUT _submit's bounded wait — see the module docstring for
+        why the two directions are bounded differently.
+        """
+
+        async def _record() -> None:
+            rt.record_job_failure(self.job_name, "heartbeat emission failed", exc=exc)
+
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            try:
+                asyncio.run_coroutine_threadsafe(_record(), loop)
+                return
+            except RuntimeError:
+                # The loop stopped between the check and the submit; fall through.
+                pass
+        rt.record_job_failure(self.job_name, "heartbeat emission failed", exc=exc)
+
+    def _run(self) -> None:
+        from genesis.observability.types import Severity, Subsystem
+
+        while not self._stop_event.is_set():
+            try:
+                from genesis.runtime import GenesisRuntime
+
+                rt = GenesisRuntime.instance()
+                if self._should_emit(rt):
+                    self._tick(rt, Subsystem, Severity)
+            except Exception as exc:
+                logger.error("%s heartbeat failed", self.job_name, exc_info=True)
+                try:
+                    from genesis.runtime import GenesisRuntime
+
+                    rt = GenesisRuntime.instance()
+                    self._record_failure(rt, exc)
+                except Exception:
+                    pass
+            self._stop_event.wait(self._interval)

--- a/src/genesis/outreach/heartbeat.py
+++ b/src/genesis/outreach/heartbeat.py
@@ -18,9 +18,13 @@ that gives honest coverage:
     shared ``compute_heartbeat_staleness`` goes ``overdue`` →
     ``subsystem_stale:outreach``.
 
-Boundary (documented, out of scope): a WEDGED-but-alive event loop keeps
-``is_running`` True and this thread pulsing — detecting a wedged (vs stopped)
-scheduler is job_health's domain, the same bar the dashboard/ego heartbeats hold.
+Wedge behaviour (CHANGED, and this docstring used to say the opposite): the
+scheduler is an ``AsyncIOScheduler`` running on the runtime's main loop, and the
+pulse is now emitted ON that loop. So a WEDGED-but-alive loop no longer keeps this
+thread pulsing — the tick times out, the pulse ceases, and the stall surfaces as
+BOTH ``subsystem_stale:outreach`` and a job-health failure. Wedge detection is
+therefore no longer "job_health's domain, out of scope here"; it falls out of the
+mechanism. Recorded because the previous wording described the old contract.
 
 The threading, loop capture and health recording live in
 ``observability.heartbeat_daemon``; only the identity and the gate are here.

--- a/src/genesis/outreach/heartbeat.py
+++ b/src/genesis/outreach/heartbeat.py
@@ -92,6 +92,51 @@ class OutreachHeartbeat:
         )
 
 
+
+    def _submit(self, coro_factory) -> bool:
+        """Run a coroutine on the captured main loop. False if none is live.
+
+        Cancels the submission whenever the wait does not complete normally. A
+        timed-out ``Future.result()`` does NOT cancel the underlying task, so
+        without this a stalled loop would leave each tick pending while the next
+        one is submitted -- accumulating tasks that all fire at once on recovery,
+        emitting stale pulses and a burst of successes.
+        """
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            return False
+        future = asyncio.run_coroutine_threadsafe(coro_factory(), loop)
+        try:
+            future.result(timeout=self._TICK_TIMEOUT_S)
+        except BaseException:
+            future.cancel()
+            raise
+        return True
+
+    def _record_failure(self, rt: object, exc: BaseException) -> None:
+        """Persist a failed tick, from the live loop when there is one.
+
+        ``record_job_failure`` persists through the SAME loop-dependent path as
+        ``record_job_success``: called from this worker thread it updates memory
+        and never the table. Recording success on the loop but failure off it
+        would leave exactly half the defect in place -- the failure direction,
+        which is the half an operator most needs to see.
+        """
+
+        async def _record() -> None:
+            rt.record_job_failure(
+                "outreach_heartbeat", "heartbeat emission failed", exc=exc
+            )
+
+        try:
+            if self._submit(_record):
+                return
+        except BaseException:
+            # Already handling a failure; fall through to the degraded path
+            # rather than masking the original exception with this one.
+            pass
+        rt.record_job_failure("outreach_heartbeat", "heartbeat emission failed", exc=exc)
+
     def _tick(self, rt: object, Subsystem: object, Severity: object) -> None:
         """Emit one pulse and record job health, on the runtime's main loop.
 
@@ -112,11 +157,7 @@ class OutreachHeartbeat:
             # its DB write onto a loop that keeps running afterwards.
             rt.record_job_success("outreach_heartbeat")
 
-        loop = self._loop
-        if loop is not None and loop.is_running():
-            asyncio.run_coroutine_threadsafe(_emit_and_record(), loop).result(
-                timeout=self._TICK_TIMEOUT_S
-            )
+        if self._submit(_emit_and_record):
             return
 
         # No live main loop (start() ran outside one). Emit on a throwaway loop;
@@ -151,9 +192,7 @@ class OutreachHeartbeat:
                     from genesis.runtime import GenesisRuntime
 
                     rt = GenesisRuntime.instance()
-                    rt.record_job_failure(
-                        "outreach_heartbeat", "heartbeat emission failed", exc=exc
-                    )
+                    self._record_failure(rt, exc)
                 except Exception:
                     pass
             self._stop_event.wait(self._interval)

--- a/src/genesis/outreach/heartbeat.py
+++ b/src/genesis/outreach/heartbeat.py
@@ -34,13 +34,31 @@ logger = logging.getLogger("genesis.outreach.heartbeat")
 class OutreachHeartbeat:
     """Background daemon thread that emits heartbeat events for outreach."""
 
+    # Bounded so a wedged main loop cannot pin the worker thread or let ticks
+    # overlap; must stay BELOW the pulse interval (60s) for that to hold.
+    _TICK_TIMEOUT_S = 30
+
     def __init__(self, interval_seconds: int = 60) -> None:
         self._interval = interval_seconds
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
+        # The runtime's main event loop, captured in start(). Each tick runs ON
+        # it rather than on a per-tick throwaway loop, because recording job
+        # health needs a RUNNING loop that OUTLIVES the call: persist_job_health
+        # schedules the DB write as a task and returns early when no loop is
+        # running, so a throwaway loop that is closed straight after the emit
+        # loses the write either way. None when start() is called outside a loop
+        # (tests, sync embedders) — the worker then falls back to the previous
+        # throwaway-loop behaviour.
+        self._loop: asyncio.AbstractEventLoop | None = None
 
     def start(self) -> None:
         """Start the heartbeat background thread."""
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Started outside a running loop; _tick falls back (see _tick).
+            self._loop = None
         self._thread = threading.Thread(
             target=self._run,
             daemon=True,
@@ -73,6 +91,50 @@ class OutreachHeartbeat:
             and getattr(scheduler, "is_running", False)
         )
 
+
+    def _tick(self, rt: object, Subsystem: object, Severity: object) -> None:
+        """Emit one pulse and record job health, on the runtime's main loop.
+
+        Blocks on the scheduled coroutine so a failure still raises into _run's
+        handler (which records the job FAILURE) instead of being swallowed by a
+        discarded future. The wait is bounded below the pulse interval so a
+        wedged loop cannot stack overlapping ticks or pin this thread forever.
+        """
+
+        async def _emit_and_record() -> None:
+            await rt.event_bus.emit(
+                Subsystem.OUTREACH,
+                Severity.DEBUG,
+                "heartbeat",
+                "Outreach scheduler alive",
+            )
+            # Runs INSIDE the live main loop, so persist_job_health can schedule
+            # its DB write onto a loop that keeps running afterwards.
+            rt.record_job_success("outreach_heartbeat")
+
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            asyncio.run_coroutine_threadsafe(_emit_and_record(), loop).result(
+                timeout=self._TICK_TIMEOUT_S
+            )
+            return
+
+        # No live main loop (start() ran outside one). Emit on a throwaway loop;
+        # job health stays in-memory only, exactly as before this fix.
+        fallback = asyncio.new_event_loop()
+        try:
+            fallback.run_until_complete(
+                rt.event_bus.emit(
+                    Subsystem.OUTREACH,
+                    Severity.DEBUG,
+                    "heartbeat",
+                    "Outreach scheduler alive",
+                )
+            )
+        finally:
+            fallback.close()
+        rt.record_job_success("outreach_heartbeat")
+
     def _run(self) -> None:
         from genesis.observability.types import Severity, Subsystem
 
@@ -82,19 +144,7 @@ class OutreachHeartbeat:
 
                 rt = GenesisRuntime.instance()
                 if self._should_emit(rt):
-                    loop = asyncio.new_event_loop()
-                    try:
-                        loop.run_until_complete(
-                            rt.event_bus.emit(
-                                Subsystem.OUTREACH,
-                                Severity.DEBUG,
-                                "heartbeat",
-                                "Outreach scheduler alive",
-                            )
-                        )
-                    finally:
-                        loop.close()
-                    rt.record_job_success("outreach_heartbeat")
+                    self._tick(rt, Subsystem, Severity)
             except Exception as exc:
                 logger.error("Outreach heartbeat failed", exc_info=True)
                 try:

--- a/src/genesis/outreach/heartbeat.py
+++ b/src/genesis/outreach/heartbeat.py
@@ -128,13 +128,22 @@ class OutreachHeartbeat:
                 "outreach_heartbeat", "heartbeat emission failed", exc=exc
             )
 
-        try:
-            if self._submit(_record):
+        loop = self._loop
+        if loop is not None and loop.is_running():
+            try:
+                # Submitted WITHOUT _submit's bounded wait, deliberately. A tick is
+                # periodic and a stale one is actively misleading, so it is cancelled
+                # on timeout; a failure record is a one-off that stays true however
+                # late it lands. Bounding it would drop the record in precisely the
+                # scenario it describes — a loop wedged past the timeout is exactly
+                # when the wait would expire — leaving the persisted row showing the
+                # previous SUCCESS across the whole stall. Pending records are bounded
+                # by one per interval and settle when the loop recovers.
+                asyncio.run_coroutine_threadsafe(_record(), loop)
                 return
-        except BaseException:
-            # Already handling a failure; fall through to the degraded path
-            # rather than masking the original exception with this one.
-            pass
+            except RuntimeError:
+                # The loop stopped between the check and the submit; fall through.
+                pass
         rt.record_job_failure("outreach_heartbeat", "heartbeat emission failed", exc=exc)
 
     def _tick(self, rt: object, Subsystem: object, Severity: object) -> None:

--- a/src/genesis/outreach/heartbeat.py
+++ b/src/genesis/outreach/heartbeat.py
@@ -2,206 +2,54 @@
 
 Outreach's heartbeat used to be *emergent*: it only fired as a side-effect of an
 outreach job succeeding, and the outreach scheduler only ``.start()``s once a
-messaging channel (Telegram) registers. So a Telegram-less (dashboard-only) install
-never emitted an outreach pulse, and adding outreach to the cessation-alert set naively
-would fire a permanent unresolvable alert on exactly those installs — the false-alarm
-trap that kept outreach OUT of the alert set.
+messaging channel registers. So a channel-less (dashboard-only) install never
+emitted an outreach pulse, and adding outreach to the cessation-alert set naively
+would fire a permanent unresolvable alert on exactly those installs — the
+false-alarm trap that kept outreach OUT of the alert set.
 
-This daemon breaks that coupling: it runs independently of channel registration and
-pulses ONLY while the outreach scheduler is actually running (``is_running``). Paired
-with the ``_subsystem_enabled('outreach')`` enable-gate (Telegram configured?), that
-gives honest coverage:
-  - Telegram-less install → not enabled → benign (no alert), and this daemon emits no
-    pulse anyway (scheduler never started).
-  - Telegram install, scheduler running → steady pulse → ``alive``.
-  - Telegram install, scheduler stopped/never-restarted → pulse ceases → the shared
-    ``compute_heartbeat_staleness`` goes ``overdue`` → ``subsystem_stale:outreach``.
+This daemon breaks that coupling: it runs independently of channel registration
+and pulses ONLY while the outreach scheduler is actually running
+(``is_running``). Paired with the ``_subsystem_enabled('outreach')`` enable-gate,
+that gives honest coverage:
+  - channel-less install → not enabled → benign (no alert), and this daemon emits
+    no pulse anyway (the scheduler never started).
+  - channel configured, scheduler running → steady pulse → ``alive``.
+  - channel configured, scheduler stopped/never-restarted → pulse ceases → the
+    shared ``compute_heartbeat_staleness`` goes ``overdue`` →
+    ``subsystem_stale:outreach``.
 
 Boundary (documented, out of scope): a WEDGED-but-alive event loop keeps
-``is_running`` True and this thread pulsing — detecting a wedged (vs stopped) scheduler
-is job_health's domain, the same bar the dashboard/ego heartbeats hold.
+``is_running`` True and this thread pulsing — detecting a wedged (vs stopped)
+scheduler is job_health's domain, the same bar the dashboard/ego heartbeats hold.
+
+The threading, loop capture and health recording live in
+``observability.heartbeat_daemon``; only the identity and the gate are here.
 """
 
 from __future__ import annotations
 
-import asyncio
-import logging
-import threading
-
-logger = logging.getLogger("genesis.outreach.heartbeat")
+from genesis.observability.heartbeat_daemon import HeartbeatDaemon
 
 
-class OutreachHeartbeat:
-    """Background daemon thread that emits heartbeat events for outreach."""
+class OutreachHeartbeat(HeartbeatDaemon):
+    """Emits the outreach liveness pulse while its scheduler is running."""
 
-    # Bounded so a wedged main loop cannot pin the worker thread or let ticks
-    # overlap; must stay BELOW the pulse interval (60s) for that to hold.
-    _TICK_TIMEOUT_S = 30
+    subsystem_name = "OUTREACH"
+    job_name = "outreach_heartbeat"
+    message = "Outreach scheduler alive"
+    thread_name = "outreach-heartbeat"
 
-    def __init__(self, interval_seconds: int = 60) -> None:
-        self._interval = interval_seconds
-        self._thread: threading.Thread | None = None
-        self._stop_event = threading.Event()
-        # The runtime's main event loop, captured in start(). Each tick runs ON
-        # it rather than on a per-tick throwaway loop, because recording job
-        # health needs a RUNNING loop that OUTLIVES the call: persist_job_health
-        # schedules the DB write as a task and returns early when no loop is
-        # running, so a throwaway loop that is closed straight after the emit
-        # loses the write either way. None when start() is called outside a loop
-        # (tests, sync embedders) — the worker then falls back to the previous
-        # throwaway-loop behaviour.
-        self._loop: asyncio.AbstractEventLoop | None = None
-
-    def start(self) -> None:
-        """Start the heartbeat background thread."""
-        try:
-            self._loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # Started outside a running loop; _tick falls back (see _tick).
-            self._loop = None
-        self._thread = threading.Thread(
-            target=self._run,
-            daemon=True,
-            name="outreach-heartbeat",
-        )
-        self._thread.start()
-        logger.info("Outreach heartbeat started (interval=%ds)", self._interval)
-
-    def stop(self) -> None:
-        """Signal the thread to stop and wait for it."""
-        self._stop_event.set()
-        if self._thread:
-            self._thread.join(timeout=5)
-
-    @staticmethod
-    def _should_emit(rt: object) -> bool:
+    def _should_emit(self, rt: object) -> bool:
         """Emit a pulse only when outreach is genuinely running.
 
         Gated on the scheduler's ``is_running`` (accurate across the start/stop
         lifecycle: False before start and after ``stop()`` nulls it) so a
         never-started / cleanly-stopped scheduler goes stale rather than reading a
-        false ``alive`` — while a Telegram-less install (scheduler never started)
-        simply never pulses.
+        false ``alive`` — while a channel-less install simply never pulses.
         """
         scheduler = getattr(rt, "_outreach_scheduler", None)
         return bool(
-            getattr(rt, "is_bootstrapped", False)
-            and getattr(rt, "event_bus", None)
+            super()._should_emit(rt)
             and scheduler is not None
             and getattr(scheduler, "is_running", False)
         )
-
-
-
-    def _submit(self, coro_factory) -> bool:
-        """Run a coroutine on the captured main loop. False if none is live.
-
-        Cancels the submission whenever the wait does not complete normally. A
-        timed-out ``Future.result()`` does NOT cancel the underlying task, so
-        without this a stalled loop would leave each tick pending while the next
-        one is submitted -- accumulating tasks that all fire at once on recovery,
-        emitting stale pulses and a burst of successes.
-        """
-        loop = self._loop
-        if loop is None or not loop.is_running():
-            return False
-        future = asyncio.run_coroutine_threadsafe(coro_factory(), loop)
-        try:
-            future.result(timeout=self._TICK_TIMEOUT_S)
-        except BaseException:
-            future.cancel()
-            raise
-        return True
-
-    def _record_failure(self, rt: object, exc: BaseException) -> None:
-        """Persist a failed tick, from the live loop when there is one.
-
-        ``record_job_failure`` persists through the SAME loop-dependent path as
-        ``record_job_success``: called from this worker thread it updates memory
-        and never the table. Recording success on the loop but failure off it
-        would leave exactly half the defect in place -- the failure direction,
-        which is the half an operator most needs to see.
-        """
-
-        async def _record() -> None:
-            rt.record_job_failure(
-                "outreach_heartbeat", "heartbeat emission failed", exc=exc
-            )
-
-        loop = self._loop
-        if loop is not None and loop.is_running():
-            try:
-                # Submitted WITHOUT _submit's bounded wait, deliberately. A tick is
-                # periodic and a stale one is actively misleading, so it is cancelled
-                # on timeout; a failure record is a one-off that stays true however
-                # late it lands. Bounding it would drop the record in precisely the
-                # scenario it describes — a loop wedged past the timeout is exactly
-                # when the wait would expire — leaving the persisted row showing the
-                # previous SUCCESS across the whole stall. Pending records are bounded
-                # by one per interval and settle when the loop recovers.
-                asyncio.run_coroutine_threadsafe(_record(), loop)
-                return
-            except RuntimeError:
-                # The loop stopped between the check and the submit; fall through.
-                pass
-        rt.record_job_failure("outreach_heartbeat", "heartbeat emission failed", exc=exc)
-
-    def _tick(self, rt: object, Subsystem: object, Severity: object) -> None:
-        """Emit one pulse and record job health, on the runtime's main loop.
-
-        Blocks on the scheduled coroutine so a failure still raises into _run's
-        handler (which records the job FAILURE) instead of being swallowed by a
-        discarded future. The wait is bounded below the pulse interval so a
-        wedged loop cannot stack overlapping ticks or pin this thread forever.
-        """
-
-        async def _emit_and_record() -> None:
-            await rt.event_bus.emit(
-                Subsystem.OUTREACH,
-                Severity.DEBUG,
-                "heartbeat",
-                "Outreach scheduler alive",
-            )
-            # Runs INSIDE the live main loop, so persist_job_health can schedule
-            # its DB write onto a loop that keeps running afterwards.
-            rt.record_job_success("outreach_heartbeat")
-
-        if self._submit(_emit_and_record):
-            return
-
-        # No live main loop (start() ran outside one). Emit on a throwaway loop;
-        # job health stays in-memory only, exactly as before this fix.
-        fallback = asyncio.new_event_loop()
-        try:
-            fallback.run_until_complete(
-                rt.event_bus.emit(
-                    Subsystem.OUTREACH,
-                    Severity.DEBUG,
-                    "heartbeat",
-                    "Outreach scheduler alive",
-                )
-            )
-        finally:
-            fallback.close()
-        rt.record_job_success("outreach_heartbeat")
-
-    def _run(self) -> None:
-        from genesis.observability.types import Severity, Subsystem
-
-        while not self._stop_event.is_set():
-            try:
-                from genesis.runtime import GenesisRuntime
-
-                rt = GenesisRuntime.instance()
-                if self._should_emit(rt):
-                    self._tick(rt, Subsystem, Severity)
-            except Exception as exc:
-                logger.error("Outreach heartbeat failed", exc_info=True)
-                try:
-                    from genesis.runtime import GenesisRuntime
-
-                    rt = GenesisRuntime.instance()
-                    self._record_failure(rt, exc)
-                except Exception:
-                    pass
-            self._stop_event.wait(self._interval)

--- a/src/genesis/runtime/_job_health.py
+++ b/src/genesis/runtime/_job_health.py
@@ -195,7 +195,18 @@ def persist_job_health(rt: GenesisRuntime, job_name: str, entry: dict, now: str)
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        logger.debug("No event loop — job health for %s persisted in-memory only", job_name)
+        # WARNING, not debug: this is a SILENT data-loss path — the in-memory
+        # entry is updated and the DB row never is, so job_health (which reads
+        # sqlite) shows the job as if it had never run. A threaded caller that
+        # records health without a running loop hit exactly this and went
+        # unnoticed until an unrelated E2E check missed the row. If this fires,
+        # the caller must record from a live loop (see the heartbeat daemons'
+        # _tick), not lower this log level.
+        logger.warning(
+            "job health for %s NOT persisted (no running event loop) — "
+            "in-memory only; the job_health table will not reflect this run",
+            job_name,
+        )
         return
 
     from genesis.util.tasks import tracked_task

--- a/tests/test_outreach/test_heartbeat.py
+++ b/tests/test_outreach/test_heartbeat.py
@@ -23,22 +23,22 @@ def _rt(*, bootstrapped=True, bus=True, scheduler=True, running=True):
 
 
 def test_emits_when_scheduler_running():
-    assert OutreachHeartbeat._should_emit(_rt()) is True
+    assert OutreachHeartbeat()._should_emit(_rt()) is True
 
 
 def test_no_emit_when_scheduler_stopped():
     # is_running False → never-started or cleanly-stopped → pulse ceases → goes stale.
-    assert OutreachHeartbeat._should_emit(_rt(running=False)) is False
+    assert OutreachHeartbeat()._should_emit(_rt(running=False)) is False
 
 
 def test_no_emit_when_scheduler_absent():
     # Telegram-less install: scheduler was never constructed/started.
-    assert OutreachHeartbeat._should_emit(_rt(scheduler=False)) is False
+    assert OutreachHeartbeat()._should_emit(_rt(scheduler=False)) is False
 
 
 def test_no_emit_before_bootstrap():
-    assert OutreachHeartbeat._should_emit(_rt(bootstrapped=False)) is False
+    assert OutreachHeartbeat()._should_emit(_rt(bootstrapped=False)) is False
 
 
 def test_no_emit_without_event_bus():
-    assert OutreachHeartbeat._should_emit(_rt(bus=False)) is False
+    assert OutreachHeartbeat()._should_emit(_rt(bus=False)) is False

--- a/tests/test_runtime/test_threaded_daemon_job_health.py
+++ b/tests/test_runtime/test_threaded_daemon_job_health.py
@@ -149,3 +149,108 @@ async def test_tick_without_a_captured_loop_still_emits(factory, job_name):
         await _run_tick_from_worker_thread(daemon, rt)
 
         assert bus.emitted, f"{job_name} fallback path lost the pulse"
+
+
+async def _drive(fn) -> BaseException | None:
+    """Run fn() on a worker thread while this loop keeps turning.
+
+    Returns the exception fn raised, or None. Deadline-bounded so a regression
+    fails the test instead of hanging the suite.
+    """
+    captured: list[BaseException] = []
+
+    def _worker() -> None:
+        try:
+            fn()
+        except BaseException as exc:  # noqa: BLE001 - returned to the caller
+            captured.append(exc)
+
+    thread = threading.Thread(target=_worker, name="drive-worker")
+    thread.start()
+    deadline = asyncio.get_running_loop().time() + 15
+    while thread.is_alive():
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError("worker thread did not finish within 15s")
+        await asyncio.sleep(0.01)
+    thread.join(timeout=5)
+    return captured[0] if captured else None
+
+
+@pytest.mark.parametrize(
+    ("factory", "job_name"),
+    [(OutreachHeartbeat, "outreach_heartbeat"), (DashboardHeartbeat, "dashboard_heartbeat")],
+    ids=["outreach", "dashboard"],
+)
+async def test_failed_tick_persists_a_failure_row(factory, job_name):
+    """The FAILURE direction must persist too, not only the success direction.
+
+    record_job_failure goes through the same loop-dependent persistence path as
+    record_job_success. Fixing only the success path would leave half the defect
+    in place -- and the failure half is the one an operator most needs to see.
+    """
+    async with aiosqlite.connect(":memory:") as db:
+        await create_all_tables(db)
+        await db.commit()
+        rt = _make_runtime(db, _FakeBus())
+
+        daemon = factory(interval_seconds=60)
+        daemon._loop = asyncio.get_running_loop()
+
+        raised = await _drive(lambda: daemon._record_failure(rt, RuntimeError("emit exploded")))
+        assert raised is None, f"recording the failure itself raised: {raised!r}"
+        await _drain_pending()
+
+        async with db.execute(
+            "SELECT last_failure, last_error FROM job_health WHERE job_name = ?",
+            (job_name,),
+        ) as cur:
+            row = await cur.fetchone()
+
+        assert row is not None, (
+            f"{job_name} left NO job_health row for a FAILED tick -- "
+            "record_job_failure ran without a live event loop"
+        )
+        assert row[0] is not None, f"{job_name} row has no last_failure timestamp"
+
+
+@pytest.mark.parametrize(
+    ("factory",),
+    [(OutreachHeartbeat,), (DashboardHeartbeat,)],
+    ids=["outreach", "dashboard"],
+)
+async def test_timed_out_tick_cancels_its_submission(factory):
+    """A tick that outlives its timeout must be CANCELLED, not left pending.
+
+    Future.result(timeout=...) does not cancel the underlying task. Without an
+    explicit cancel, a stalled loop accumulates one pending tick per interval
+    and they all complete in a burst on recovery -- emitting stale pulses.
+    """
+    cancelled = asyncio.Event()
+
+    class _StallingBus:
+        emitted: list = []
+
+        async def emit(self, *args, **kwargs):
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+    async with aiosqlite.connect(":memory:") as db:
+        await create_all_tables(db)
+        await db.commit()
+        rt = _make_runtime(db, _StallingBus())
+
+        daemon = factory(interval_seconds=60)
+        daemon._loop = asyncio.get_running_loop()
+        daemon._TICK_TIMEOUT_S = 0.2  # instance attr shadows the class default
+
+        raised = await _drive(lambda: daemon._tick(rt, Subsystem, Severity))
+        assert isinstance(raised, TimeoutError), (
+            f"expected the tick to time out, got {raised!r}"
+        )
+
+        # The cancellation is delivered on this loop; give it a bounded chance.
+        await asyncio.wait_for(cancelled.wait(), timeout=5)
+        assert cancelled.is_set(), "the timed-out submission was never cancelled"

--- a/tests/test_runtime/test_threaded_daemon_job_health.py
+++ b/tests/test_runtime/test_threaded_daemon_job_health.py
@@ -1,0 +1,151 @@
+"""Threaded heartbeat daemons must PERSIST job health, not only record it in memory.
+
+Regression coverage for a silent data-loss path found live on 2026-08-29: both
+heartbeat daemons called ``rt.record_job_success()`` AFTER closing the throwaway
+event loop they had created for the emit. ``persist_job_health`` returns early
+when no loop is running, so the ``job_health`` ROW was never written and the
+``job_health`` tool -- which reads sqlite -- reported the job as if it had never
+run. Measured: neither ``outreach_heartbeat`` nor ``dashboard_heartbeat``
+appeared among 89 persisted job rows while both daemons were pulsing normally.
+
+The assertion is deliberately on the ROW, never on the call. ``record_job_success``
+was ALREADY being called before the fix, so a test asserting the call passes just
+as happily on the broken code -- the vacuous version of this test.
+
+Both daemons are covered because the population is exactly two: they were the only
+files in ``src/genesis/`` that both call ``record_job_success`` and use
+``threading.Thread``, and the outreach daemon was modelled on the dashboard one,
+inheriting the defect verbatim.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import aiosqlite
+import pytest
+
+from genesis.dashboard.heartbeat import DashboardHeartbeat
+from genesis.db.schema import create_all_tables
+from genesis.observability.types import Severity, Subsystem
+from genesis.outreach.heartbeat import OutreachHeartbeat
+from genesis.runtime import GenesisRuntime
+
+
+class _FakeBus:
+    """Minimal event bus: records emits, and is awaitable like the real one."""
+
+    def __init__(self) -> None:
+        self.emitted: list[tuple] = []
+
+    async def emit(self, subsystem, severity, event_type, message, **kwargs):
+        self.emitted.append((subsystem, event_type, message))
+
+
+def _make_runtime(db: aiosqlite.Connection, bus: _FakeBus) -> GenesisRuntime:
+    rt = GenesisRuntime.__new__(GenesisRuntime)
+    rt._job_health = {}
+    rt._db = db
+    rt._job_retry_registry = None
+    rt._event_bus = bus  # event_bus is a read-only property over this
+    return rt
+
+
+async def _drain_pending() -> None:
+    """Await the tracked_task background writes so the DB is settled."""
+    pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+async def _run_tick_from_worker_thread(daemon, rt) -> None:
+    """Drive one tick from a WORKER THREAD, as in production.
+
+    The main loop must keep running while the worker schedules onto it, so this
+    yields until the thread finishes -- bounded, so a regression that never
+    completes fails the test instead of hanging the suite forever.
+    """
+    errors: list[BaseException] = []
+
+    def _worker() -> None:
+        try:
+            daemon._tick(rt, Subsystem, Severity)
+        except BaseException as exc:  # noqa: BLE001 - surfaced below
+            errors.append(exc)
+
+    thread = threading.Thread(target=_worker, name="tick-worker")
+    thread.start()
+    deadline = asyncio.get_running_loop().time() + 10
+    while thread.is_alive():
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError("daemon tick did not complete within 10s")
+        await asyncio.sleep(0.01)
+    thread.join(timeout=5)
+    if errors:
+        raise errors[0]
+
+
+@pytest.mark.parametrize(
+    ("factory", "job_name", "subsystem"),
+    [
+        (OutreachHeartbeat, "outreach_heartbeat", Subsystem.OUTREACH),
+        (DashboardHeartbeat, "dashboard_heartbeat", Subsystem.DASHBOARD),
+    ],
+    ids=["outreach", "dashboard"],
+)
+async def test_tick_persists_a_job_health_row(factory, job_name, subsystem):
+    """One tick on the runtime's main loop must leave a job_health ROW behind."""
+    async with aiosqlite.connect(":memory:") as db:
+        await create_all_tables(db)
+        await db.commit()
+        bus = _FakeBus()
+        rt = _make_runtime(db, bus)
+
+        daemon = factory(interval_seconds=60)
+        daemon._loop = asyncio.get_running_loop()  # what start() captures
+
+        await _run_tick_from_worker_thread(daemon, rt)
+        await _drain_pending()
+
+        # Guard the guard: the tick must actually have emitted, or a missing row
+        # below would prove nothing about persistence.
+        assert bus.emitted, "daemon did not emit -- test proves nothing"
+        assert bus.emitted[0][0] is subsystem
+
+        async with db.execute(
+            "SELECT last_success FROM job_health WHERE job_name = ?", (job_name,)
+        ) as cur:
+            row = await cur.fetchone()
+
+        assert row is not None, (
+            f"{job_name} left NO job_health row -- record_job_success ran without a "
+            "live event loop, so persist_job_health dropped the write silently"
+        )
+        assert row[0] is not None, f"{job_name} row has no last_success timestamp"
+
+
+@pytest.mark.parametrize(
+    ("factory", "job_name"),
+    [(OutreachHeartbeat, "outreach_heartbeat"), (DashboardHeartbeat, "dashboard_heartbeat")],
+    ids=["outreach", "dashboard"],
+)
+async def test_tick_without_a_captured_loop_still_emits(factory, job_name):
+    """The no-live-loop fallback must still pulse rather than raise.
+
+    Liveness detection reads heartbeat EVENTS, so the fallback losing only the
+    job_health row is a documented degradation -- but it must never cost the
+    pulse itself, which is the daemon's whole purpose.
+    """
+    async with aiosqlite.connect(":memory:") as db:
+        await create_all_tables(db)
+        await db.commit()
+        bus = _FakeBus()
+        rt = _make_runtime(db, bus)
+
+        daemon = factory(interval_seconds=60)
+        daemon._loop = None  # start() ran outside a loop
+
+        await _run_tick_from_worker_thread(daemon, rt)
+
+        assert bus.emitted, f"{job_name} fallback path lost the pulse"

--- a/tests/test_runtime/test_threaded_daemon_job_health.py
+++ b/tests/test_runtime/test_threaded_daemon_job_health.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 
 import aiosqlite
 import pytest
@@ -198,13 +199,23 @@ async def test_failed_tick_persists_a_failure_row(factory, job_name):
 
         raised = await _drive(lambda: daemon._record_failure(rt, RuntimeError("emit exploded")))
         assert raised is None, f"recording the failure itself raised: {raised!r}"
-        await _drain_pending()
 
-        async with db.execute(
-            "SELECT last_failure, last_error FROM job_health WHERE job_name = ?",
-            (job_name,),
-        ) as cur:
-            row = await cur.fetchone()
+        # The record is submitted to the loop and NOT waited on (deliberately -- see
+        # test_failure_record_is_not_bounded_by_the_tick_timeout), so poll for the row
+        # rather than assuming it has landed. Bounded: if it never lands the assertion
+        # below still fires, so this cannot mask the defect it guards.
+        row = None
+        deadline = asyncio.get_running_loop().time() + 10
+        while asyncio.get_running_loop().time() < deadline:
+            await _drain_pending()
+            async with db.execute(
+                "SELECT last_failure, last_error FROM job_health WHERE job_name = ?",
+                (job_name,),
+            ) as cur:
+                row = await cur.fetchone()
+            if row is not None:
+                break
+            await asyncio.sleep(0.02)
 
         assert row is not None, (
             f"{job_name} left NO job_health row for a FAILED tick -- "
@@ -254,3 +265,53 @@ async def test_timed_out_tick_cancels_its_submission(factory):
         # The cancellation is delivered on this loop; give it a bounded chance.
         await asyncio.wait_for(cancelled.wait(), timeout=5)
         assert cancelled.is_set(), "the timed-out submission was never cancelled"
+
+
+@pytest.mark.parametrize(
+    ("factory",),
+    [(OutreachHeartbeat,), (DashboardHeartbeat,)],
+    ids=["outreach", "dashboard"],
+)
+async def test_failure_record_is_not_bounded_by_the_tick_timeout(factory):
+    """A slow failure record must NOT be abandoned and re-done off the loop.
+
+    A tick is cancelled when it outlives its timeout, because a stale pulse is
+    actively misleading. A failure record is the opposite: it stays true however
+    late it lands, and the situation it reports -- a wedged loop -- is exactly
+    when a bounded wait would expire. Bounding it would drop the record during
+    the whole stall, leaving the persisted row showing the previous SUCCESS.
+
+    Counting calls makes this timing-tolerant rather than racy: with a bounded
+    wait the on-loop attempt runs AND the degraded fallback runs too (two calls),
+    because the wait expires while the first is still in flight. Unbounded, the
+    record is made exactly once.
+    """
+    calls: list[str] = []
+
+    class _SlowRuntime:
+        """Records on the loop, slowly enough to outlive a tiny timeout."""
+
+        def record_job_failure(self, job_name, *args, **kwargs):
+            calls.append(job_name)
+            time.sleep(0.25)  # blocks the loop; a cancel cannot interrupt it
+
+    daemon = factory(interval_seconds=60)
+    daemon._loop = asyncio.get_running_loop()
+    daemon._TICK_TIMEOUT_S = 0.05  # far below the work, so a bounded wait WOULD expire
+
+    rt = _SlowRuntime()
+    raised = await _drive(lambda: daemon._record_failure(rt, RuntimeError("boom")))
+    assert raised is None, f"_record_failure raised: {raised!r}"
+
+    # Let the submitted coroutine finish on this loop.
+    for _ in range(200):
+        if calls:
+            break
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.35)
+
+    assert len(calls) == 1, (
+        f"expected exactly ONE failure record, got {len(calls)} -- a second call "
+        "means the submission was abandoned on a timeout and re-done off the loop, "
+        "where it does not persist"
+    )

--- a/tests/test_runtime/test_threaded_daemon_job_health.py
+++ b/tests/test_runtime/test_threaded_daemon_job_health.py
@@ -315,3 +315,98 @@ async def test_failure_record_is_not_bounded_by_the_tick_timeout(factory):
         "means the submission was abandoned on a timeout and re-done off the loop, "
         "where it does not persist"
     )
+
+
+@pytest.mark.parametrize(
+    ("factory",),
+    [(OutreachHeartbeat,), (DashboardHeartbeat,)],
+    ids=["outreach", "dashboard"],
+)
+async def test_start_captures_the_running_loop(factory):
+    """start() must capture the loop, and every test until now assigned _loop by hand.
+
+    That left the fix's ENTIRE activation condition uncovered: deleting the
+    get_running_loop() capture would have left the whole suite green while
+    production silently lost every job-health row again.
+    """
+    daemon = factory(interval_seconds=3600)
+    daemon._stop_event.set()  # the worker exits immediately; we only inspect capture
+    daemon.start()
+    try:
+        assert daemon._loop is asyncio.get_running_loop()
+    finally:
+        daemon.stop()
+
+
+@pytest.mark.parametrize(
+    ("factory",),
+    [(OutreachHeartbeat,), (DashboardHeartbeat,)],
+    ids=["outreach", "dashboard"],
+)
+async def test_repeated_failures_coalesce_into_one_pending_record(factory):
+    """A stalled loop must not queue one failure record per tick.
+
+    Unbounded submission was the previous shape. During a wedge every tick times
+    out and queues another record, so a long stall lands them all at once on
+    recovery -- spiking consecutive_failures, permanently inflating total_failures,
+    and firing a retry per record where a retry registry is wired. "The daemon is
+    failing" is ONE fact however long the stall lasts.
+
+    The repeats are submitted from a single worker pass WITHOUT yielding to the
+    loop, which is what a wedge looks like from the daemon's side: the first record
+    is scheduled and cannot run, so the rest must be absorbed rather than queued.
+    Driving them through separate loop yields would let the first complete and prove
+    nothing.
+    """
+    calls: list[str] = []
+
+    class _CountingRuntime:
+        def record_job_failure(self, job_name, *args, **kwargs):
+            calls.append(job_name)
+
+    daemon = factory(interval_seconds=60)
+    daemon._loop = asyncio.get_running_loop()
+    rt = _CountingRuntime()
+
+    def _five_failures() -> None:
+        for n in range(5):
+            daemon._record_failure(rt, RuntimeError(str(n)))
+
+    assert await _drive(_five_failures) is None
+    for _ in range(200):
+        if calls:
+            break
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.1)
+    await _drain_pending()
+
+    assert len(calls) == 1, (
+        f"expected the pending record to absorb the repeats, got {len(calls)} "
+        "-- a wedge would queue one per tick and burst on recovery"
+    )
+
+
+@pytest.mark.parametrize(
+    ("factory",),
+    [(OutreachHeartbeat,), (DashboardHeartbeat,)],
+    ids=["outreach", "dashboard"],
+)
+async def test_double_start_is_refused_while_running(factory):
+    """A second start() must not spawn a second pulsing thread.
+
+    The guard keys on the existing thread being ALIVE, so this stands in a live
+    one rather than starting a real worker: setting _stop_event first would let the
+    worker exit immediately, and restarting a DEAD daemon is correct behaviour, not
+    the case under test.
+    """
+    daemon = factory(interval_seconds=3600)
+    release = threading.Event()
+    sentinel = threading.Thread(target=lambda: release.wait(timeout=10), daemon=True)
+    sentinel.start()
+    daemon._thread = sentinel
+    try:
+        daemon.start()
+        assert daemon._thread is sentinel, "double start() replaced a live thread"
+    finally:
+        release.set()
+        sentinel.join(timeout=5)


### PR DESCRIPTION
## What

Both threaded heartbeat daemons record job health, and neither one's row ever reached the database.

`persist_job_health` schedules its write as a task and returns early when no event loop is running. Both daemons called `record_job_success(...)` **after** the `finally: loop.close()` of the throwaway loop they built for the emit — so no loop was running, the write was dropped, and only the in-memory entry updated. Nothing looked broken from the outside.

Measured on a live install: both daemons pulsing normally on their 60s interval, and the job-health view (reading sqlite, 89 rows) contained neither `outreach_heartbeat` nor `dashboard_heartbeat`.

## Why the obvious fix does not work

Moving the call inside the throwaway loop is not enough. The write is *scheduled*, and the loop is closed as soon as the emit returns — taking the pending task with it. The write has to land on a loop that keeps running afterwards.

So each tick now runs on the runtime's main loop, captured when the daemon starts, via `run_coroutine_threadsafe`. The tick blocks on the result deliberately: a discarded future would swallow exceptions and the existing failure-reporting path would never fire.

## Scope

Both daemons change, not just the one that surfaced the problem. They are the only two modules that both record job health and run on a thread, and the newer was modelled on the older, inheriting the defect verbatim. Fixing one would have left the parent in place.

`persist_job_health`'s early return now logs a warning rather than a debug line. It is a silent data-loss path, and the silence is exactly why this went unnoticed.

## Fail direction

Where no main loop is available (a caller that starts the daemon outside one), the daemon falls back to the previous behaviour rather than losing its pulse. Liveness detection reads the heartbeat *events*, so the fallback degrades only the secondary job-health signal — never the thing the daemon exists for.

## Verification

- **Verify-RED**: both daemons mutated back to the original shape; each mutation asserted to have applied (anchor matched once, sha256 changed, parses). Both parametrisations of the new test failed with the intended message; the fallback cases correctly stayed green. Byte-exact restore confirmed by sha256.
- The RED run also captured the new warning firing, so the log change is verified behaviourally rather than only written.
- The new test asserts the **row**, never the call — `record_job_success` was already being called before this change, so a test asserting the call passes just as happily on the broken code. A guard-the-guard assert confirms the tick really emitted, and the wait loop is deadline-bounded.
- 15 passed, including both pre-existing daemon suites, unregressed. `ruff` clean.

## Known residual

After this change a tick depends on the main loop, so if that loop stops mid-tick the daemon logs one error where previously it could not. Deliberately not guarded: `persist_job_health`'s own docstring records that creating the coroutine eagerly and then catching `RuntimeError` leaks an unawaited coroutine and warns every 60s, and separating "failed to schedule" from "the coroutine raised" is subtle enough to risk a worse bug than the shutdown noise it would prevent. Flagged for review rather than silently accepted.

## Deliberately not done

The two daemons are near-identical, and that duplication is what propagated this bug. Extracting a shared base is the durable class fix, but it is a wider refactor of live daemons than this defect warrants and would obscure the diff. Called out here rather than silently skipped.

## Deploy path

Runtime code: `git pull` plus a server restart. No schema change, no new dependency, no operator step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard and outreach heartbeat reliability through shared runtime handling.
  * Heartbeat updates now use the active event loop when available, with fallback behavior preserved.
  * Timed-out heartbeat submissions are cancelled, while failure recording completes reliably.
  * Failed heartbeat checks now persist job-health details more consistently.
  * Missing event-loop conditions now issue a warning when updates cannot be persisted.
  * Duplicate heartbeat starts are prevented, and repeated failures are consolidated.

* **Tests**
  * Added coverage for failure persistence, timeout cancellation, fallback behavior, and daemon lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Follow-up: f2e513bc4e1841f28f94e812c45e9497
