### PR TITLE
fix(hooks): stop reporting an unusable scheduled-review marker as an absent one

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1186,33 +1186,35 @@ findings below, a gated `gh pr merge`:
   names the PR's current head — so if any required routine never ran, ran on a stale
   commit, or was rate-limited, the merge blocks (naming the missing kinds). An ADVISORY
   routine still posts its review on the PR to be read/addressed, but its absence does not
-  block. A missing marker has **five causes needing different actions**, and the block
-  message names which one you are in — do not guess. Run
-  `git_push_guard.py --check-pr <N>`, which renders the per-cause bullets, not just its
-  summary line (that line's `present: none` clause is a SUMMARY and reads like "nothing
-  was posted" in every one of these cases):
-  (1) *no marker at any head* — nothing has run; on a freshly-opened PR a routine may
-  still be in flight, so **waiting is correct**;
-  (2) *a marker at an EARLIER head* — a routine ran, then a push moved the head. Routines
-  are generally not re-run on a push, so waiting is unlikely to help: re-review the
-  current head and post the marker by hand;
-  (3) *a marker AT this head that was REFUSED* — see the clean-verdict rule below;
-  (4) *a marker block that is PRESENT but cannot be credited* — a head that is not full
-  40-lowercase-hex, a `kind` the grammar refuses, an author who is not the repo owner, a
-  dismissed review, a stale unpublished draft. It is reported with its raw text quoted, so
-  "you posted one that does not count" is distinguishable from "nobody posted anything";
-  (5) *a block naming no REQUIRED kind* — reported as unscoped, and deliberately credited
-  to no review: guessing which kind a block meant would steer the reader into attesting
-  for a review that never ran.
-  A block in (4) or (5) SUPERSEDES a kind's own state — replacing (1)'s or (2)'s advice —
-  only when it says something specific about that kind's status (a marker only the owner
-  need correct, an unknown kind, a stale draft that cannot help). Another author's block
-  and a dismissed review say nothing about whether anything ran, so they are reported
-  ALONGSIDE the kind's true state, never instead of it. On a public repository the
-  alternative lets one comment from any account delete the guidance a fresh PR needs.
-  A value carrying a `/status` suffix (`kind=leaks/failed`) is refused AND flagged as a
-  run that reported its own failure — naming only the grammar problem would read as an
-  instruction to strip the suffix and produce a marker vouching for a failed run.
+  block. The block message is an **inventory**, not a diagnosis: under each missing
+  kind it lists EVERY marker block the scan found that names that kind, with its
+  status, and hides nothing. Run `git_push_guard.py --check-pr <N>` — it renders those
+  rows, not just the summary line (whose `present: none` clause reads like "nothing was
+  posted" in every case below, and is the exact wording an operator was once measured
+  acting wrongly on). Row statuses you will see:
+  * *accepted at a DIFFERENT head* — a routine ran, then a push moved the head. Routines
+  are generally not re-run on a push; re-review the current head and post the marker;
+  * *REFUSED* (at this head or another) — the body reads as carrying a blocking finding
+  and no clean-verdict line overrides it; see the clean-verdict rule below. The message
+  deliberately does NOT print the verdict string, because a gate that prints the line
+  that makes it pass is explaining how to get past itself;
+  * *could not be counted: <reason>* — a head that is not full 40-lowercase-hex, an
+  empty or refused field value (quoted back verbatim), an author who is not the repo
+  owner, a dismissed review, a stale unpublished draft;
+  * *unscoped* — blocks naming no REQUIRED kind, listed and credited to nothing:
+  guessing which review a block "meant" would steer you into attesting for one that
+  never ran. A value carrying a `/status` suffix (`kind=leaks/failed`) lands here and
+  is flagged as a run that reported its own failure.
+  The one conditional is a COUNT, keyed on a fact: a kind with no OWNER-authored block at
+  any head gets "a routine may still be in flight — waiting is the right move", because
+  that is the only state where patience can help. A stranger's comment is not evidence
+  about the owner's routine and never silences that note; an owner's block in ANY state
+  (accepted elsewhere, refused, dismissed, stale draft, malformed) is, and does.
+  Why an inventory and not a diagnosis: the previous shape picked one cause per kind and
+  hid the rest, and every one of nine review findings across six rounds was a hidden fact
+  — a refused `[P1]` on an older commit hidden behind a typo at the current one, the only
+  evidence a review had ever run hidden by a drive-by comment. Precedence is the right
+  shape for a VERDICT; for a REPORT, hiding a true fact is never correct.
   Or append `# scheduled-review-override` to merge anyway (the conscious "merge without
   the scheduled reviews" case). Head match is EXACT — no ancestor walk, no delta
   tolerance, unlike the Codex freshness gate, which grants relief on a provably trivial

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1188,7 +1188,8 @@ findings below, a gated `gh pr merge`:
   routine still posts its review on the PR to be read/addressed, but its absence does not
   block. The block message is an **inventory**, not a diagnosis: under each missing
   kind it lists EVERY marker block the scan found that names that kind, with its
-  status, and hides nothing. Run `git_push_guard.py --check-pr <N>` — it renders those
+  status, and hides nothing. Run `python3 scripts/hooks/git_push_guard.py --check-pr <N>`
+  — it renders those
   rows, not just the summary line (whose `present: none` clause reads like "nothing was
   posted" in every case below, and is the exact wording an operator was once measured
   acting wrongly on). Row statuses you will see:

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1057,14 +1057,33 @@ findings below, a gated `gh pr merge`:
   names the PR's current head — so if any required routine never ran, ran on a stale
   commit, or was rate-limited, the merge blocks (naming the missing kinds). An ADVISORY
   routine still posts its review on the PR to be read/addressed, but its absence does not
-  block. A missing marker has **three causes needing different actions**, and the block
-  message now names which one you are in — do not guess:
+  block. A missing marker has **five causes needing different actions**, and the block
+  message names which one you are in — do not guess. Run
+  `git_push_guard.py --check-pr <N>`, which renders the per-cause bullets, not just its
+  summary line (that line's `present: none` clause is a SUMMARY and reads like "nothing
+  was posted" in every one of these cases):
   (1) *no marker at any head* — nothing has run; on a freshly-opened PR a routine may
   still be in flight, so **waiting is correct**;
   (2) *a marker at an EARLIER head* — a routine ran, then a push moved the head. Routines
   are generally not re-run on a push, so waiting is unlikely to help: re-review the
   current head and post the marker by hand;
-  (3) *a marker AT this head that was REFUSED* — see the clean-verdict rule below.
+  (3) *a marker AT this head that was REFUSED* — see the clean-verdict rule below;
+  (4) *a marker block that is PRESENT but cannot be credited* — a head that is not full
+  40-lowercase-hex, a `kind` the grammar refuses, an author who is not the repo owner, a
+  dismissed review, a stale unpublished draft. It is reported with its raw text quoted, so
+  "you posted one that does not count" is distinguishable from "nobody posted anything";
+  (5) *a block naming no REQUIRED kind* — reported as unscoped, and deliberately credited
+  to no review: guessing which kind a block meant would steer the reader into attesting
+  for a review that never ran.
+  A block in (4) or (5) SUPERSEDES a kind's own state — replacing (1)'s or (2)'s advice —
+  only when it says something specific about that kind's status (a marker only the owner
+  need correct, an unknown kind, a stale draft that cannot help). Another author's block
+  and a dismissed review say nothing about whether anything ran, so they are reported
+  ALONGSIDE the kind's true state, never instead of it. On a public repository the
+  alternative lets one comment from any account delete the guidance a fresh PR needs.
+  A value carrying a `/status` suffix (`kind=leaks/failed`) is refused AND flagged as a
+  run that reported its own failure — naming only the grammar problem would read as an
+  instruction to strip the suffix and produce a marker vouching for a failed run.
   Or append `# scheduled-review-override` to merge anyway (the conscious "merge without
   the scheduled reviews" case). Head match is EXACT — no ancestor walk, no delta
   tolerance, unlike the Codex freshness gate, which grants relief on a provably trivial

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2787,7 +2787,7 @@ def emit_scheduled_review_marker(pr_num: str, *, kind: str, repo: str | None = N
 
 
 def _scheduled_review_marker_scan(
-    pr_num: str, repo: str | None = None
+    pr_num: str, repo: str | None = None, head_sha: str | None = None
 ) -> (
     tuple[dict[str, set[str]], dict[str, set[str]], list[tuple[str | None, str, bool]]]
     | None
@@ -2866,16 +2866,26 @@ def _scheduled_review_marker_scan(
             # unusable would attach "waiting cannot clear this" to the one state
             # where waiting IS the answer. Dropped silently on purpose; it falls
             # through to the absent/in-flight guidance.
-            if _state == "DISMISSED":
-                for block in blocks:
-                    unusable.append(
-                        (
-                            _marker_kind_or_none(block),
-                            "it is carried by a DISMISSED review, which no longer "
-                            "vouches for anything",
-                            False,
-                        )
+            for block in blocks:
+                if _state == "PENDING":
+                    # Submitting the draft can only help if the marker already names
+                    # the CURRENT head. A pending review whose marker names an older
+                    # commit is stale no matter when it is submitted, and dropping it
+                    # silently sent the reader to wait for something that could never
+                    # count.
+                    _hm = _SCHEDULED_REVIEW_HEAD_RE.search(block)
+                    if head_sha and _hm and _hm.group(1).lower() == head_sha.lower():
+                        continue
+                    why = (
+                        "it is carried by a PENDING review and does not name the "
+                        "current head, so submitting that draft would not make it count"
                     )
+                else:
+                    why = (
+                        "it is carried by a DISMISSED review, which no longer vouches "
+                        "for anything"
+                    )
+                unusable.append((_marker_kind_or_none(block), why, False))
             continue
         # The marker must mean "ran CLEAN", not merely "ran": a scheduled review whose body
         # CONTAINS a blocking finding ([P1]/HARD BLOCK/### ERROR, unless a clean marker
@@ -2924,7 +2934,24 @@ def _scheduled_review_marker_scan(
                     )
                 unusable.append((_marker_kind_or_none(block), why, not not_clean))
                 continue
-            target.setdefault(head_m.group(1).lower(), set()).add(kind_m.group(1).lower())
+            _kind = kind_m.group(1).lower()
+            if _kind not in _KNOWN_SCHEDULED_REVIEW_KINDS:
+                # Parses cleanly and names a review nothing knows about -- a terminal
+                # typo such as a singular form. Recording it in `accepted` hid it
+                # completely: it can never match a required kind, so the message went
+                # back to "no marker at ANY head" and advised waiting, while the block
+                # sat visibly in the thread. Verdict-neutral either way (an unknown
+                # kind satisfies nothing), so this is purely so the reader can SEE it.
+                unusable.append(
+                    (
+                        _kind,
+                        f"it names kind={_kind!r}, which is not a known scheduled "
+                        f"review, so it can never satisfy one",
+                        True,
+                    )
+                )
+                continue
+            target.setdefault(head_m.group(1).lower(), set()).add(_kind)
     return accepted, rejected, unusable
 
 
@@ -3017,7 +3044,7 @@ def _check_scheduled_claude_reviewed_head(
             f"reviews (GitHub query failed).\n"
             f"Retry, or append '# scheduled-review-override' to merge anyway."
         )
-    scan = _scheduled_review_marker_scan(pr_num, repo=repo)
+    scan = _scheduled_review_marker_scan(pr_num, repo=repo, head_sha=head)
     markers, rejected, unusable = (None, {}, []) if scan is None else scan
     if markers is None:
         return (
@@ -3085,7 +3112,11 @@ def _check_scheduled_claude_reviewed_head(
     # case is the point: narrowing to named kinds without it made a block reading
     # `kind=<near-miss>` vanish from every group, and the message went back to claiming
     # nothing had been posted -- the exact misdiagnosis this whole change exists to end.
-    unscoped = [(k, r) for k, r, _ in unusable if k is None or k not in missing_set]
+    # REQUIRED, not MISSING. Keying on missing_set called a duplicate for an
+    # already-SATISFIED kind unscoped, so the bullet said it named no required kind
+    # directly beneath a summary line listing that kind as present.
+    _required_set = set(required)
+    unscoped = [(k, r) for k, r, _ in unusable if k is None or k not in _required_set]
 
     parts: list[str] = []
     if refused_kinds:

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2754,13 +2754,7 @@ def _scheduled_review_rows(pr_num: str, repo: str | None = None) -> list[dict] |
                     "--paginate",
                     "--jq",
                     ".[] | {login: .user.login, author_association: .author_association, "
-                    "body: .body, state: .state, "
-                    "stamp: (.updated_at // .submitted_at // .created_at)}",
-                    # .state present on reviews, null on issue comments. `stamp` is the LAST
-                    # MODIFICATION: issue comments are editable and an edit that adds a
-                    # finding must sort by when it was written, not when the comment was
-                    # created. Review bodies expose only submitted_at (an edited review body
-                    # keeps its original stamp -- documented residue in the scan).
+                    "body: .body, state: .state}",  # .state present on reviews, null on issue comments
                 ],
                 capture_output=True,
                 text=True,
@@ -2871,20 +2865,6 @@ def _scheduled_review_marker_scan(
     # it only to count whether the OWNER has posted anything for a kind, because that is
     # the one thing that says whether the owner's routine has evidently already run.
     unusable: list[tuple[str | None, str, bool]] = []
-    # Every owner statement about a (head, kind), in CHRONOLOGICAL order, classified as
-    # "clean" (explicit verdict line), "refused" (blocking finding, no verdict) or "plain"
-    # (neither). The verdict for the pair is resolved AFTER the loop from this list -- see
-    # there for the rule and why the order matters.
-    stmts: dict[tuple[str, str], list[str]] = {}
-    # Chronology: rows carry `stamp` = last modification (updated_at for issue comments,
-    # which are editable; submitted_at for reviews). The two endpoints are fetched
-    # separately, so without sorting a review could sort before a comment posted after
-    # it; and sorting by CREATION would let a finding edited into an old comment lose
-    # to a verdict posted before the edit. Rows without a stamp (the test seam) keep list
-    # order -- the sort is stable. Residue, stated: an edited REVIEW body has no edit
-    # timestamp in the API, so a finding added by editing a review keeps the review's
-    # original position.
-    rows = sorted(rows, key=lambda r: (r.get("stamp") or r.get("created_at") or ""))
     for row in rows:
         body = row.get("body") or ""
         # Blocks are parsed BEFORE the trust checks, so a row about to be dropped can
@@ -2952,9 +2932,10 @@ def _scheduled_review_marker_scan(
         # measured 2026-08-28: those two produced the identical `present: none` line, and
         # the only signal distinguishing an accepted marker from a rejected one was
         # whether its prose happened to contain a _CLEAN_PATTERNS phrase.
-        has_clean = any(c.search(body) for c in _CLEAN_PATTERNS)
-        not_clean = any(p.search(body) for p in _BLOCKING_PATTERNS) and not has_clean
-        verdict = "refused" if not_clean else ("clean" if has_clean else "plain")
+        not_clean = any(p.search(body) for p in _BLOCKING_PATTERNS) and not any(
+            c.search(body) for c in _CLEAN_PATTERNS
+        )
+        target = rejected if not_clean else accepted
         # Defense-in-depth follow-up: for rows from /pulls/N/reviews we could ALSO
         # cross-check GitHub's authoritative `commit_id` vs the marker sha (issue comments
         # carry none). Deferred (LOW): the marker sha is matched EXACTLY vs the authoritative
@@ -3041,62 +3022,7 @@ def _scheduled_review_marker_scan(
                     _why += ", and its body reads as carrying a blocking finding"
                 unusable.append((_kind, _why, True))
                 continue
-            stmts.setdefault((head_m.group(1).lower(), _kind), []).append(verdict)
-    # RESOLUTION. Each row used to choose its own map, so a second owner comment at the
-    # same head -- same marker, ordinary prose -- was accepted while the first row's [P1]
-    # sat refused, and the gate passed with the finding unchanged. The first fix let any
-    # explicit clean verdict win regardless of order, which passed a LATER [P1] posted
-    # after an earlier verdict. Order is the whole question, so the rule is stated in it:
-    #
-    #   THE OWNER'S LATEST DECISIVE STATEMENT ABOUT (head, kind) GOVERNS.
-    #
-    # Decisive = an explicit clean-verdict line, or a blocking finding. Plain rows (neither)
-    # are not decisive in either direction: they count only when nothing decisive was ever
-    # said. So a plain re-post never overrides a refusal, the documented remedy (re-post
-    # WITH a verdict) still clears a prose-tripped refusal, and a re-run that finds
-    # something after a verdict is heard. Scoped to the head -- a finding on an older
-    # commit is what a new commit fixes. Every superseded row is still LISTED, so the
-    # report never says one block where two exist.
-    for (h, k), seq in stmts.items():
-        decisive = [v for v in seq if v != "plain"]
-        final = decisive[-1] if decisive else "plain"
-        (rejected if final == "refused" else accepted).setdefault(h, set()).add(k)
-        # The verdict maps are SETS, so repeated statements collapsed to one rendered row
-        # and the report said one block where several were observed. Every repeat is a row.
-        same = seq.count(final) - 1 if final != "plain" else seq.count("plain") - 1
-        if same > 0:
-            unusable.append(
-                (k, f"{same} further block(s) at this head repeating the same statement", True)
-            )
-        if final == "refused":
-            n_plain = seq.count("plain")
-            if n_plain:
-                unusable.append(
-                    (
-                        k,
-                        f"a plain re-post at this head ({n_plain} block(s), no verdict "
-                        f"line) does not override the refusal for this kind",
-                        True,
-                    )
-                )
-            if "clean" in seq:
-                unusable.append(
-                    (
-                        k,
-                        "an explicit clean verdict at this head, superseded by a LATER "
-                        "blocking finding for this kind",
-                        True,
-                    )
-                )
-        elif "refused" in seq:
-            unusable.append(
-                (
-                    k,
-                    "a refusal at this head, superseded by a LATER explicit clean "
-                    "verdict for this kind",
-                    True,
-                )
-            )
+            target.setdefault(head_m.group(1).lower(), set()).add(_kind)
     return accepted, rejected, unusable
 
 

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2456,8 +2456,8 @@ _SCHEDULED_REVIEW_KIND_RE = re.compile(r"\bkind=([a-z0-9][a-z0-9._-]*)(?=\s|\Z)"
 #
 # These must never feed the gate. Matching loosely here is how the operator learns
 # their head= was abbreviated -- never a second way to satisfy anything.
-_SCHEDULED_REVIEW_LOOSE_HEAD_RE = re.compile(r"\bhead=(\S+)")
-_SCHEDULED_REVIEW_LOOSE_KIND_RE = re.compile(r"\bkind=(\S+)")
+_SCHEDULED_REVIEW_LOOSE_HEAD_RE = re.compile(r"\bhead=(\S*)")
+_SCHEDULED_REVIEW_LOOSE_KIND_RE = re.compile(r"\bkind=(\S*)")
 # A 40-hex head in the WRONG CASE is full-length and well-formed apart from case.
 # Telling that operator their head "is not a full 40-hex commit sha" sends them to
 # recount 40 characters and find nothing wrong, so the two causes are separated.
@@ -2826,7 +2826,7 @@ def _scheduled_review_marker_scan(
     """``(accepted, rejected_not_clean, unusable)`` for the PR's scheduled-review
     markers, or ``None`` on an UNREADABLE fetch.
 
-    ``unusable`` is a list of ``(kind_or_None, reason, supersedes_state)`` for marker
+    ``unusable`` is a list of ``(kind_or_None, reason, owner_authored)`` for marker
     BLOCKS that were
     seen and could not be counted — a head that is not a full 40-hex sha, a missing
     ``kind``, an author who is not the owner, a dismissed review. Every one of those
@@ -2858,19 +2858,12 @@ def _scheduled_review_marker_scan(
     owner = (owner_repo.split("/")[0] if owner_repo else "").lower() or None
     accepted: dict[str, set[str]] = {}
     rejected: dict[str, set[str]] = {}
-    # (kind_or_None, reason, supersedes_state). The third field decides ONE thing, and
-    # naming it for anything else is how it drifted: whether this block SUPERSEDES the
-    # kind's generic state in the message, or is reported alongside it.
-    #
-    # True where the block says something specific about THAT kind's status — a marker
-    # only the owner needs to correct, a kind nothing knows, a stale draft that cannot
-    # help. False where it says nothing about status: another author's block, or a
-    # dismissed review, both of which leave "has anything actually run?" untouched.
-    #
-    # It was once documented as "a TRUSTED, CLEAN review really happened", which it never
-    # computed and could not: the value is derived from whether the BODY tripped the
-    # blocking patterns, and a run that reports its own failure trips none of them. Under
-    # that reading a failed run counted as a clean one and outranked genuine history.
+    # (kind_or_None, reason, owner_authored). The third field is a FACT, not a
+    # judgement. It once carried one -- "trusted and clean", later "supersedes the
+    # kind's state" -- and every consumer of that judgement was a place the message
+    # could hide something true. Authorship is observed, not decided: the message uses
+    # it only to count whether the OWNER has posted anything for a kind, because that is
+    # the one thing that says whether the owner's routine has evidently already run.
     unusable: list[tuple[str | None, str, bool]] = []
     for row in rows:
         body = row.get("body") or ""
@@ -2923,15 +2916,7 @@ def _scheduled_review_marker_scan(
                         "it is carried by a DISMISSED review, which no longer vouches "
                         "for anything"
                     )
-                # A stale PENDING draft SUPERSEDES the kind's generic state; a DISMISSED
-                # review does not. The difference is whether the block says anything about
-                # THIS kind's status. "A draft exists and naming an older commit means it
-                # cannot help you" is a specific, visible fact that the generic "something
-                # may still be in flight, waiting is right" would actively contradict. A
-                # dismissed review says only that IT no longer vouches — it leaves the
-                # question of whether anything has run untouched, so the kind keeps its own
-                # true state and its own advice.
-                unusable.append((_marker_kind_or_none(block), why, _state == "PENDING"))
+                unusable.append((_marker_kind_or_none(block), why, True))
             continue
         # The marker must mean "ran CLEAN", not merely "ran": a scheduled review whose body
         # CONTAINS a blocking finding ([P1]/HARD BLOCK/### ERROR, unless a clean marker
@@ -2964,6 +2949,11 @@ def _scheduled_review_marker_scan(
                     loose = _SCHEDULED_REVIEW_LOOSE_HEAD_RE.search(block)
                     if not loose:
                         why = "it carries no head= field"
+                    elif not loose.group(1):
+                        # `\S*` so an EMPTY value is seen. `\S+` reported it as no field
+                        # at all -- the most likely producer fault (an uninterpolated
+                        # variable) described as the operator having omitted the field.
+                        why = "its head= field is present but EMPTY"
                     elif _SCHEDULED_REVIEW_ANYCASE_HEAD_RE.fullmatch(loose.group(1)):
                         why = (
                             f"its head={loose.group(1)!r} is full length but not "
@@ -2982,6 +2972,8 @@ def _scheduled_review_marker_scan(
                     loose = _SCHEDULED_REVIEW_LOOSE_KIND_RE.search(block)
                     if not loose:
                         why = "it carries no kind= field"
+                    elif not loose.group(1):
+                        why = "its kind= field is present but EMPTY"
                     else:
                         why = f"its kind={loose.group(1)!r} is not a bare review name"
                         why += _status_suffix_warning(loose.group(1))
@@ -2994,7 +2986,7 @@ def _scheduled_review_marker_scan(
                         ", and its body reads as carrying a blocking finding, so a "
                         "corrected marker would not make it count either"
                     )
-                unusable.append((_marker_kind_or_none(block), why, not not_clean))
+                unusable.append((_marker_kind_or_none(block), why, True))
                 continue
             _kind = kind_m.group(1).lower()
             if _kind not in _KNOWN_SCHEDULED_REVIEW_KINDS:
@@ -3036,36 +3028,17 @@ def _check_scheduled_claude_reviewed_head(
     blocks. The merge path and the report path share this single fail-closed decision,
     so the report can never issue a false all-clear here.
 
-    WHY THE BLOCK MESSAGE PARTITIONS. A missing marker has THREE causes calling for
-    DIFFERENT operator actions, all distinguishable from what was already read. The
-    missing kinds are PARTITIONED across those causes and EVERY non-empty group is
-    reported — this is not a precedence chain that picks one winner:
-      * REFUSED at this head — a marker is present on the current commit but read as
-        carrying a blocking finding. Neither waiting nor re-reviewing helps; the body's
-        wording (or a real finding) is the cause. It is also the cause most easily
-        mistaken for "nobody posted anything", since the gate's `present:` line shows
-        the same `none` either way.
-      * ELSEWHERE — a marker for that kind sits on some OTHER head, ACCEPTED OR REFUSED.
-        A routine ran, then a push moved the head. Routines are not generally re-run on a
-        push, so waiting is unlikely to help; re-review the current head and post it.
-      * ABSENT — no marker for that kind at any head. Nothing has run for it, so on a
-        freshly-opened PR a routine may still be in flight and waiting IS the right move.
-
-    Two design rules earned by successive review rounds, both of the SAME shape — a
-    decision made from only part of what had been read. Keep them:
-      1. Scope every group to ``missing``. A marker for an already-satisfied kind explains
-         nothing about this block, and prescribing a remedy for it sends the operator to
-         fix something that is not broken (it also let the message contradict its own
-         ``present:`` line one row above).
-      2. PARTITION rather than prioritise. Different kinds routinely fail for different
-         reasons — a refused ``code-review`` beside an absent ``leaks`` — and choosing a
-         single winning cause explained one kind while the other silently got no guidance
-         at all. Precedence exists only WITHIN a kind (refused-here beats elsewhere).
-
-    An earlier draft collapsed everything into an unconditional "waiting will not clear
-    this", which was wrong for the ABSENT case and pushed the operator toward
-    ``# scheduled-review-override`` — i.e. toward waiving the IRREDUCIBLE leak gate — in
-    the one situation where patience was the correct answer.
+    WHY THE BLOCK MESSAGE IS AN INVENTORY. Every marker block the scan found is listed
+    under the kind it names with its status — accepted at another head, refused (here or
+    elsewhere), or uncreditable with the reason — and nothing is subtracted from anything.
+    The previous shape partitioned the missing kinds by cause and let one cause per kind
+    win. Across six review rounds every finding on it was the same defect: the winning
+    cause hid a fact the operator needed (a refused [P1] on an older commit, the only
+    evidence a review had ever run, a field that was present but refused). Precedence is
+    the right shape for the VERDICT, which needs one answer; it is the wrong shape for a
+    REPORT, where hiding a true fact is never correct. The one conditional left is a
+    count: a kind with zero rows gets the in-flight note, since "nothing found at all" is
+    the only state where waiting can help.
 
     The message deliberately reports only what it OBSERVED (which heads carry markers)
     and hedges the schedule ("generally not re-run"). The routines live OUTSIDE this repo
@@ -3119,162 +3092,92 @@ def _check_scheduled_claude_reviewed_head(
     missing = [k for k in required if k not in kinds_here]
     if not missing:
         return None
-    # WHY the marker is missing decides whether waiting is useful, and the two causes are
-    # DISTINGUISHABLE from what was actually read — so report the observed state instead
-    # of asserting a routine schedule this repo cannot see (the routines live outside it).
-    # Every branch below is scoped to the MISSING kinds. A marker for a kind that is
-    # already satisfied says nothing about why this merge is blocked, and prescribing a
-    # remedy for it sends the operator to fix something that is not broken.
-    # PARTITION the missing kinds by cause and report EVERY group — never pick one cause
-    # for the whole block. Different kinds routinely fail for different reasons (a refused
-    # code-review alongside an absent leaks), and collapsing to a single winner explains
-    # one kind while the other silently gets no guidance at all. THREE successive review
-    # findings on this function were that same shape — a branch deciding from part of what
-    # had been read — so this is the general form rather than a fourth point patch: a total
-    # partition needs no precedence BETWEEN groups, only within a single kind.
-    missing_set = set(missing)
-    refused_kinds = rejected.get(head, set()) & missing_set
-    # A marker for a missing kind on some OTHER head — ACCEPTED OR REFUSED. Both prove a
-    # routine ran on a different commit; counting only accepted ones sent a
-    # refused-at-a-stale-head PR down the "nothing has run, wait for it" path.
-    heads_by_kind: dict[str, set[str]] = {}
-    for by_head in (markers, rejected):
-        for other_head, kinds in by_head.items():
-            if other_head == head:
-                continue
-            for kind in kinds & missing_set:
-                heads_by_kind.setdefault(kind, set()).add(other_head[:12])
-    # Within a KIND, refused-at-this-head wins: it is the most specific cause, and the only
-    # one whose remedy is neither waiting nor re-reviewing.
-    # A marker BLOCK that was seen but could not be counted. This group exists because
-    # the ones above partition only the markers that PARSE — a block discarded during
-    # the scan reached none of them and fell through to ABSENT, whose advice is to
-    # wait. An unusable marker is the one cause where waiting is guaranteed useless.
+    # The message is an INVENTORY, not a verdict. Every marker block the scan found is
+    # listed under the kind it names, with its status, and NOTHING is subtracted from
+    # anything. The verdict above (block) is the only decision this function makes.
     #
-    # It is scoped ONLY to kinds a block actually NAMED. An earlier version let a block
-    # with no kind= claim every remaining kind, reasoning that over-reporting is the
-    # safe direction. It is not, once the group carries a remedy: the guidance would
-    # tell the owner to post a `leaks` marker on the strength of a block that never
-    # mentioned leaks, and a hand-written marker satisfies the one gate this repository
-    # calls irreducible. An unscoped block is reported as unscoped, and every kind it
-    # cannot account for keeps its true state.
-    # Scoped to kinds a block actually NAMED, and named as a REQUIRED kind. A block
-    # naming no kind, or naming one nothing requires (a typo such as a singular form),
-    # cannot be credited to any review -- it is reported separately and claims nothing.
-    _named = {k for k, _, _ in unusable if k is not None} & missing_set
-    # ONE rule governs what follows, stated once because splitting it is what went wrong
-    # twice: A BLOCK SUPERSEDES A KIND'S GENERIC STATE ONLY IF IT SAYS SOMETHING SPECIFIC
-    # ABOUT THAT KIND'S STATUS. Anything else is reported ALONGSIDE the kind's true state,
-    # never instead of it.
+    # Six review rounds and nine findings on the previous shape of this message shared
+    # one anatomy: a rule decided which true fact "won" for a kind and the losing fact was
+    # hidden -- a refused [P1] at an older commit hidden by a typo at the current one; the
+    # only evidence that a review had ever run hidden by a stranger's comment; a present
+    # field reported as absent. Each fix moved the rule and the next reviewer found the
+    # next hidden fact. A report has no winners. An operator can read three lines; they
+    # cannot read a line that was deleted for them.
     #
-    # Reporting and superseding are separate jobs. ``_named`` is deliberately UNgated, so
-    # every named block is still reported; gating that too made blocks vanish from the
-    # message altogether -- silently dropping a marker is the defect this change exists to
-    # end, and six existing tests caught it immediately.
-    #
-    # The third field decides superseding, and it is NOT "can the owner repair this". That
-    # reading is close enough to survive casual inspection and wrong at one cell: a stale
-    # PENDING draft cannot be repaired by editing text, yet it must supersede, because
-    # "a draft exists and cannot help you" is precisely what the generic "something may
-    # still be in flight, waiting is right" would contradict. Superseding is true for a
-    # repairable marker, an unknown kind, and a stale draft; false for another author's
-    # block and a dismissed review, which say nothing about whether anything has run.
-    #
-    # Applying it to only ONE of the two consuming branches was the defect underneath all
-    # of this: an untrusted block stopped hiding "a routine ran on an older commit" but
-    # went on hiding "nothing has run yet, waiting is right" -- so on a public repository
-    # one comment from any account still deleted the guidance a fresh PR needs. The verdict
-    # never moved (no such block satisfies anything); the report an operator acts on did.
-    _superseding_named = {
-        k for k, _, supersedes in unusable if k is not None and supersedes
-    } & missing_set
-    unusable_kinds = (missing_set - refused_kinds) & _named
-    # Both consuming branches subtract the SAME set, so a kind can appear in two bullets:
-    # "an uncreditable block sits at head" AND its own true state. That overlap is the
-    # point -- they are independent facts and the operator needs both. Only a repairable
-    # marker earns the right to stand alone, because only then is "fix this one" the whole
-    # of the advice.
-    elsewhere_kinds = {
-        k for k in missing_set - refused_kinds - _superseding_named if k in heads_by_kind
-    }
-    absent_kinds = missing_set - refused_kinds - _superseding_named - elsewhere_kinds
-    # Everything this cannot attribute to a required kind. Including the wrong-kind
-    # case is the point: narrowing to named kinds without it made a block reading
-    # `kind=<near-miss>` vanish from every group, and the message went back to claiming
-    # nothing had been posted -- the exact misdiagnosis this whole change exists to end.
-    # REQUIRED, not MISSING. Keying on missing_set called a duplicate for an
-    # already-SATISFIED kind unscoped, so the bullet said it named no required kind
-    # directly beneath a summary line listing that kind as present.
-    _required_set = set(required)
-    unscoped = [(k, r) for k, r, _ in unusable if k is None or k not in _required_set]
-
+    # What follows therefore contains no precedence, no superseding, no attribution
+    # beyond the strict grammar, and no remedy text. The one conditional is a COUNT: a
+    # kind with zero rows gets the in-flight note, because "nothing at all was found" is
+    # the single state where waiting can help; a kind with rows gets a line saying none
+    # of them counts at the current head. Both are facts about the list above them.
+    required_set = set(required)
+    refused_here = rejected.get(head, set())
     parts: list[str] = []
-    if refused_kinds:
-        parts.append(
-            f"{', '.join(sorted(refused_kinds))} — a marker IS present at THIS head, but it "
-            f"was REFUSED because its body reads as carrying a blocking finding (matching "
-            f"one of [P1] / HARD BLOCK / an '### ERROR' heading) with no explicit clean "
-            f"verdict to override it. A marker must mean it ran CLEAN, not merely that it "
-            f"ran. If the review really was clean, its prose tripped the check — re-post it "
-            f"ending with an explicit verdict line, exactly 'VERDICT: PASS' or "
-            f"'PII/Secrets/Wording: CLEAN'. If the finding is real, fix it first."
-        )
-    if elsewhere_kinds:
-        seen = sorted({h for k in elsewhere_kinds for h in heads_by_kind[k]})
-        shown = ", ".join(seen[:3]) + (f" (+{len(seen) - 3} more)" if len(seen) > 3 else "")
-        parts.append(
-            f"{', '.join(sorted(elsewhere_kinds))} — a marker is present for a DIFFERENT "
-            f"head ({shown}), so a routine HAS run on this PR, just not on the current "
-            f"commit. Routines are generally not re-run when a later push moves the head, "
-            f"so waiting is unlikely to clear this on its own: re-run against the current "
-            f"head and post the marker yourself."
-        )
-    def _detail(kinds: set[str]) -> str:
-        # Filter to THIS group before truncating. Truncating the global list first
-        # showed four unrelated reasons and hid the one that caused this bullet.
-        rows = [f"[{k}] {r}" for k, r, _ in unusable if k in kinds]
-        return "; ".join(rows[:4]) + (f" (+{len(rows) - 4} more)" if len(rows) > 4 else "")
-
-    # These bullets REPORT. They deliberately prescribe nothing.
-    #
-    # Six of six blocker-class review findings on the first version of this feature
-    # were in its advice, and none in its observations. The cause was structural: the
-    # advice had to know whether a trusted clean review existed, so each branch decided
-    # that for itself and each got it wrong differently -- offering to mint a marker for
-    # a review posted by someone else, for one that was dismissed, for one that came
-    # back BLOCKING. A marker is an attestation, and a gate that tells you how to write
-    # one is a gate explaining how to get past itself.
-    #
-    # What the reader needs from a GATE is what it found. What to do about it depends on
-    # facts this code cannot see -- whether the review actually ran, whether a finding
-    # was real -- and every attempt to guess ended up advising a way around the check.
-    # So: no remedy text here, and nothing offering to produce a marker. A command that
-    # emitted one was written and then removed: it was wired to nothing (the routines that
-    # actually post markers live outside this repository and were untouched), and the
-    # closing line of this very message already prints the complete marker with the full
-    # head filled in, so it duplicated output that already existed while adding a second
-    # place to reason about attestation.
-    if unusable_kinds:
-        parts.append(
-            f"{', '.join(sorted(unusable_kinds))} — a marker block IS present on this "
-            f"PR but could not be counted, so it stands for nothing: "
-            f"{_detail(unusable_kinds)}. This is NOT 'nobody posted anything'."
-        )
+    for kind in missing:
+        # (row text, owner-authored). Accepted/refused rows are owner-authored by
+        # construction -- the scan admits nothing else to those maps.
+        rows: list[tuple[str, bool]] = []
+        # Accepted markers at OTHER heads -- a routine ran, then the head moved.
+        for other_head, kinds in sorted(markers.items()):
+            if other_head != head and kind in kinds:
+                rows.append((f"accepted at a DIFFERENT head ({other_head[:12]})", True))
+        # Refused markers, here and elsewhere. Stated as the fact the scan observed;
+        # the clean-verdict rule that decides "refused" lives in the dev skill, and the
+        # exact verdict string is deliberately NOT quoted here -- a gate that prints the
+        # incantation that makes it pass is explaining how to get past itself.
+        if kind in refused_here:
+            rows.append(
+                (
+                    "a marker IS present at THIS head but was REFUSED: its body reads as "
+                    "carrying a blocking finding ([P1] / HARD BLOCK / an '### ERROR' "
+                    "heading) and no clean-verdict line overrides it",
+                    True,
+                )
+            )
+        for other_head, kinds in sorted(rejected.items()):
+            if other_head != head and kind in kinds:
+                rows.append((f"REFUSED at a DIFFERENT head ({other_head[:12]}), same reason", True))
+        # Blocks that named this kind but could not be counted, each with its reason.
+        for named, reason, owner_authored in unusable:
+            if named == kind:
+                rows.append((f"could not be counted: {reason}", owner_authored))
+        listing = "".join(f"\n      - {r}" for r, _ in rows)
+        # The in-flight note is the ONE conditional, and it is a count over a fact: has
+        # the OWNER posted anything for this kind, at any head, in any state? If so, the
+        # owner's routine has evidently already run and waiting for it cannot help. If
+        # not, nothing the gate can see rules it out -- and a stranger's comment is not
+        # evidence about the owner's routine, so it must not silence the note. On a
+        # public repository that would let any account delete the one line telling a
+        # fresh PR's operator that patience, not an override, is the answer.
+        owner_evidence = any(owner for _, owner in rows)
+        if rows and owner_evidence:
+            parts.append(
+                f"{kind} — {len(rows)} marker block(s) found for this kind, none of which "
+                f"counts at the current head:{listing}"
+            )
+        elif rows:
+            parts.append(
+                f"{kind} — {len(rows)} marker block(s) found for this kind, none of which "
+                f"counts at the current head, and none posted by the repo owner:{listing}"
+                f"\n      No owner marker for this kind at any head. If the PR was just "
+                f"opened, a routine may still be in flight, and waiting is the right move."
+            )
+        else:
+            parts.append(
+                f"{kind} — no marker block found for this kind at any head. If the PR was "
+                f"just opened, a routine may still be in flight, and waiting is the right "
+                f"move."
+            )
+    # Blocks that named no REQUIRED kind. Listed so they are visible, credited to
+    # nothing: deciding which review a block "meant" is a guess, and a guessed kind
+    # steers the reader toward attesting for a review that never ran.
+    unscoped = [(k, r) for k, r, _ in unusable if k is None or k not in required_set]
     if unscoped:
-        shown = "; ".join(
-            f"[{k or 'no kind named'}] {r}" for k, r in unscoped[:3]
-        ) + (f" (+{len(unscoped) - 3} more)" if len(unscoped) > 3 else "")
+        listing = "".join(
+            f"\n      - [{k or 'no kind named'}] {r}" for k, r in unscoped[:6]
+        ) + (f"\n      - (+{len(unscoped) - 6} more)" if len(unscoped) > 6 else "")
         parts.append(
-            f"unscoped — {len(unscoped)} marker block(s) on this PR name no required "
-            f"kind, so they are credited to nothing and counted against nothing: "
-            f"{shown}. Every required kind above is reported by its own state."
-        )
-    if absent_kinds:
-        parts.append(
-            f"{', '.join(sorted(absent_kinds))} — no marker at ANY head on this PR yet. If "
-            f"it was just opened, a routine may still be in flight, and waiting IS the right "
-            f"move. If it has been open a while, re-run against the current head and post "
-            f"the marker yourself."
+            f"unscoped — {len(unscoped)} marker block(s) name no required kind and count "
+            f"toward nothing:{listing}"
         )
     return (
         f"scheduled Claude review(s) missing at head {head[:12]}: {', '.join(missing)} "

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2732,6 +2732,29 @@ def _scheduled_review_rows(pr_num: str, repo: str | None = None) -> list[dict] |
     return rows
 
 
+def _status_suffix_warning(raw: str) -> str:
+    """Extra clause for a refused field value carrying a ``/status`` suffix, else "".
+
+    Naming ONLY the grammar problem is an instruction to strip the suffix, and a reader
+    who follows it produces a well-formed marker attesting to a run that reported its own
+    failure -- on the gate this repository calls irreducible. The strict expressions above
+    exist to refuse exactly that shape, so a message that coaches the reader past them
+    undoes the guard in prose. Saying what the suffix MEANS costs one clause and removes
+    the invitation, without the message having to guess which review was intended.
+
+    Applies to both fields: `head=<sha>/failed` and `kind=<name>/failed` reach the same
+    branch by different routes, and fixing only the one a review happened to name is how
+    this class keeps coming back.
+    """
+    return (
+        ", and the status suffix reports that the run did NOT complete cleanly -- "
+        "re-posting it without the suffix would attest to a review that declared its "
+        "own failure, so the run itself needs repeating"
+        if "/" in raw
+        else ""
+    )
+
+
 def _marker_kind_or_none(block: str) -> str | None:
     """The ``kind`` a marker block names, or None when it names none.
 
@@ -2739,82 +2762,22 @@ def _marker_kind_or_none(block: str) -> str | None:
     meant to satisfy, so the block message can scope its guidance instead of
     reporting an unattached complaint.
 
-    A STATUS-SUFFIXED value (``kind=leaks/failed``) is refused by the gate grammar
-    -- correctly, since a failed run must never satisfy anything -- but it NAMES
-    its review unambiguously, and reading it here is not the attribution guess this
-    module deliberately refuses to make. The line is exact-match, not resemblance:
-    the segment before the suffix must BE a known kind. A near-miss like
-    ``kind=leak`` still returns None, because deciding it meant ``leaks`` would be
-    guessing at intent, and a guessed kind steers the reader toward vouching for a
-    review that never ran. Attribution is reporting-only either way -- the caller
-    records this on the UNUSABLE path, which never reaches ``accepted``.
+    Reads the STRICT grammar only, and deliberately so. An earlier revision also read a
+    status-suffixed value (``kind=leaks/failed``) by taking the segment before the suffix,
+    on the reasoning that it names its review unambiguously. That was wrong in a way worth
+    recording, because the argument for it sounded sober. A suffixed value denotes a run
+    that reported itself FAILED; crediting it to ``leaks`` made a failed run occupy the
+    kind, and — through the state rule below — SUPPRESS the bullet saying a real review had
+    run on an earlier commit. A failed run thereby outranked trusted history that an
+    untrusted stranger's marker was not permitted to outrank. The trust ordering came out
+    backwards, on the gate this repository calls irreducible.
+
+    A value the strict grammar refuses therefore names nothing here. It is still REPORTED,
+    with its raw text quoted, by the caller's unusable path — the operator sees it; it just
+    does not get to speak for a review.
     """
     m = _SCHEDULED_REVIEW_KIND_RE.search(block)
-    if m:
-        return m.group(1)
-    loose = _SCHEDULED_REVIEW_LOOSE_KIND_RE.search(block)
-    if loose:
-        stem = loose.group(1).split("/", 1)[0].lower()
-        if stem in _KNOWN_SCHEDULED_REVIEW_KINDS:
-            return stem
-    return None
-
-
-def emit_scheduled_review_marker(pr_num: str, *, kind: str, repo: str | None = None) -> int:
-    """Print the scheduled-review marker for ``pr_num``'s CURRENT head. 0 on success.
-
-    The PREVENT half of the marker contract. Nothing in this repository emitted a
-    marker: the 40-hex requirement lived in a regex on the CONSUMER side and in a
-    sentence asking a person to copy a commit sha by hand. A marker whose head was
-    abbreviated then matched no head at all, was discarded during the scan, and was
-    reported as "nobody posted anything" — advice to wait, for a review that had
-    already run.
-
-    Two properties make that unrepeatable here. The head is READ from GitHub rather
-    than typed. And the finished line is parsed back through the gate's OWN regexes,
-    with the captured values compared to what went in, before anything is printed —
-    so a marker this command emits is by construction a marker the gate counts, and a
-    change to either regex that breaks the pairing fails loudly rather than shipping a
-    producer that quietly disagrees with its consumer.
-
-    Refusals are silent on stdout: nothing that looks like a marker is ever printed on
-    a failure path, because a half-formed marker pasted into a PR is the defect.
-    """
-    if kind not in _KNOWN_SCHEDULED_REVIEW_KINDS:
-        print(
-            f"ERROR: kind={kind!r} is not a known scheduled-review kind, so a marker "
-            f"naming it could never satisfy the gate. Known kinds: "
-            f"{', '.join(_KNOWN_SCHEDULED_REVIEW_KINDS)}.",
-            file=sys.stderr,
-        )
-        return 2
-    head = (_pr_head_sha(pr_num, repo=repo) or "").strip().lower()
-    if not head:
-        print(
-            f"ERROR: could not read PR #{pr_num}'s head commit from GitHub. Refusing to "
-            f"emit a marker at all rather than emit one carrying a missing or partial "
-            f"head — that is the exact defect this command exists to prevent.",
-            file=sys.stderr,
-        )
-        return 1
-    marker = f"<!-- genesis-scheduled-review: head={head} kind={kind} -->"
-    # Round-trip through the CONSUMER's regexes. Not a formality: this is the only
-    # thing binding producer and consumer together, and it compares the CAPTURED
-    # values rather than merely checking that something matched.
-    blocks = _SCHEDULED_REVIEW_BLOCK_RE.findall(marker)
-    head_m = _SCHEDULED_REVIEW_HEAD_RE.search(blocks[0]) if len(blocks) == 1 else None
-    kind_m = _SCHEDULED_REVIEW_KIND_RE.search(blocks[0]) if len(blocks) == 1 else None
-    if not (head_m and kind_m and head_m.group(1) == head and kind_m.group(1) == kind):
-        print(
-            "ERROR: the marker just built does not parse back under this gate's own "
-            "marker grammar, so the producer and the consumer have drifted apart. "
-            "Nothing was emitted. Fix the grammar or this builder before posting "
-            "anything by hand.",
-            file=sys.stderr,
-        )
-        return 3
-    print(marker)
-    return 0
+    return m.group(1) if m else None
 
 
 def _scheduled_review_marker_scan(
@@ -2826,7 +2789,7 @@ def _scheduled_review_marker_scan(
     """``(accepted, rejected_not_clean, unusable)`` for the PR's scheduled-review
     markers, or ``None`` on an UNREADABLE fetch.
 
-    ``unusable`` is a list of ``(kind_or_None, reason, grammar_only)`` for marker
+    ``unusable`` is a list of ``(kind_or_None, reason, supersedes_state)`` for marker
     BLOCKS that were
     seen and could not be counted — a head that is not a full 40-hex sha, a missing
     ``kind``, an author who is not the owner, a dismissed review. Every one of those
@@ -2858,12 +2821,19 @@ def _scheduled_review_marker_scan(
     owner = (owner_repo.split("/")[0] if owner_repo else "").lower() or None
     accepted: dict[str, set[str]] = {}
     rejected: dict[str, set[str]] = {}
-    # (kind_or_None, reason, grammar_only). The third field is the whole point:
-    # True means a TRUSTED, CLEAN review really happened and only the marker text
-    # is malformed, so re-posting it is honest. False means no such review exists
-    # at this head -- another author's, a dismissed one, or one whose body carries
-    # a blocking finding -- and telling the owner to re-post there would be telling
-    # them to attest to something that did not happen.
+    # (kind_or_None, reason, supersedes_state). The third field decides ONE thing, and
+    # naming it for anything else is how it drifted: whether this block SUPERSEDES the
+    # kind's generic state in the message, or is reported alongside it.
+    #
+    # True where the block says something specific about THAT kind's status — a marker
+    # only the owner needs to correct, a kind nothing knows, a stale draft that cannot
+    # help. False where it says nothing about status: another author's block, or a
+    # dismissed review, both of which leave "has anything actually run?" untouched.
+    #
+    # It was once documented as "a TRUSTED, CLEAN review really happened", which it never
+    # computed and could not: the value is derived from whether the BODY tripped the
+    # blocking patterns, and a run that reports its own failure trips none of them. Under
+    # that reading a failed run counted as a clean one and outranked genuine history.
     unusable: list[tuple[str | None, str, bool]] = []
     for row in rows:
         body = row.get("body") or ""
@@ -2916,7 +2886,15 @@ def _scheduled_review_marker_scan(
                         "it is carried by a DISMISSED review, which no longer vouches "
                         "for anything"
                     )
-                unusable.append((_marker_kind_or_none(block), why, False))
+                # A stale PENDING draft SUPERSEDES the kind's generic state; a DISMISSED
+                # review does not. The difference is whether the block says anything about
+                # THIS kind's status. "A draft exists and naming an older commit means it
+                # cannot help you" is a specific, visible fact that the generic "something
+                # may still be in flight, waiting is right" would actively contradict. A
+                # dismissed review says only that IT no longer vouches — it leaves the
+                # question of whether anything has run untouched, so the kind keeps its own
+                # true state and its own advice.
+                unusable.append((_marker_kind_or_none(block), why, _state == "PENDING"))
             continue
         # The marker must mean "ran CLEAN", not merely "ran": a scheduled review whose body
         # CONTAINS a blocking finding ([P1]/HARD BLOCK/### ERROR, unless a clean marker
@@ -2958,17 +2936,18 @@ def _scheduled_review_marker_scan(
                         why = (
                             f"its head={loose.group(1)!r} is not a full 40-hex commit sha"
                         )
+                        why += _status_suffix_warning(loose.group(1))
                 else:
                     # Read PERMISSIVELY to say what is actually there. The strict
                     # expression refuses a status-suffixed `kind=leaks/failed`, and
                     # reporting that refusal as an absent field told the operator a
                     # field they had written did not exist.
                     loose = _SCHEDULED_REVIEW_LOOSE_KIND_RE.search(block)
-                    why = (
-                        f"its kind={loose.group(1)!r} is not a bare review name"
-                        if loose
-                        else "it carries no kind= field"
-                    )
+                    if not loose:
+                        why = "it carries no kind= field"
+                    else:
+                        why = f"its kind={loose.group(1)!r} is not a bare review name"
+                        why += _status_suffix_warning(loose.group(1))
                 # A malformed marker on a body that reads as BLOCKING is not a typo
                 # to be re-posted. The verdict survives the malformed field, because
                 # pasting a clean marker over an unresolved finding would make the
@@ -3146,33 +3125,42 @@ def _check_scheduled_claude_reviewed_head(
     # naming no kind, or naming one nothing requires (a typo such as a singular form),
     # cannot be credited to any review -- it is reported separately and claims nothing.
     _named = {k for k, _, _ in unusable if k is not None} & missing_set
-    # Being REPORTED and OUTRANKING history are two different jobs, and only the second
-    # may be gated on trust. Gating the first as well makes the block vanish from the
-    # message altogether -- silently dropping an untrusted marker is the very defect
-    # this change exists to end, and a test here catches it.
+    # ONE rule governs what follows, stated once because splitting it is what went wrong
+    # twice: A BLOCK SUPERSEDES A KIND'S GENERIC STATE ONLY IF IT SAYS SOMETHING SPECIFIC
+    # ABOUT THAT KIND'S STATUS. Anything else is reported ALONGSIDE the kind's true state,
+    # never instead of it.
     #
-    # So: every named kind is still reported (``_named``), while only a cause the OWNER
-    # can repair by fixing the marker (the third field) suppresses the history bullet.
-    # Letting EVERY unusable cause suppress it meant an untrusted block hid trusted
-    # evidence: on a public repository any account can post a marker naming the current
-    # head, and that erased "a routine ran on an older commit" -- the one fact telling
-    # the operator a review had ever happened. A dismissed review did the same. The
-    # verdict never moved (neither block satisfies anything); the report did.
-    _fixable_named = {
-        k for k, _, fixable in unusable if k is not None and fixable
+    # Reporting and superseding are separate jobs. ``_named`` is deliberately UNgated, so
+    # every named block is still reported; gating that too made blocks vanish from the
+    # message altogether -- silently dropping a marker is the defect this change exists to
+    # end, and six existing tests caught it immediately.
+    #
+    # The third field decides superseding, and it is NOT "can the owner repair this". That
+    # reading is close enough to survive casual inspection and wrong at one cell: a stale
+    # PENDING draft cannot be repaired by editing text, yet it must supersede, because
+    # "a draft exists and cannot help you" is precisely what the generic "something may
+    # still be in flight, waiting is right" would contradict. Superseding is true for a
+    # repairable marker, an unknown kind, and a stale draft; false for another author's
+    # block and a dismissed review, which say nothing about whether anything has run.
+    #
+    # Applying it to only ONE of the two consuming branches was the defect underneath all
+    # of this: an untrusted block stopped hiding "a routine ran on an older commit" but
+    # went on hiding "nothing has run yet, waiting is right" -- so on a public repository
+    # one comment from any account still deleted the guidance a fresh PR needs. The verdict
+    # never moved (no such block satisfies anything); the report an operator acts on did.
+    _superseding_named = {
+        k for k, _, supersedes in unusable if k is not None and supersedes
     } & missing_set
-    # A CURRENT malformed marker outranks marker history for the same kind: "you posted
-    # one and it needs one character fixed" is more actionable than "a routine ran on an
-    # older commit", and the latter used to hide the former on any PR with history.
     unusable_kinds = (missing_set - refused_kinds) & _named
-    # Subtracts the FIXABLE set, not every unusable kind, so a kind can now appear in
-    # BOTH bullets: "an untrusted block sits at head" AND "your own review ran on an
-    # older commit". That overlap is the point -- those are two independent facts and
-    # the operator needs both. Only a repairable typo earns the right to stand alone.
+    # Both consuming branches subtract the SAME set, so a kind can appear in two bullets:
+    # "an uncreditable block sits at head" AND its own true state. That overlap is the
+    # point -- they are independent facts and the operator needs both. Only a repairable
+    # marker earns the right to stand alone, because only then is "fix this one" the whole
+    # of the advice.
     elsewhere_kinds = {
-        k for k in missing_set - refused_kinds - _fixable_named if k in heads_by_kind
+        k for k in missing_set - refused_kinds - _superseding_named if k in heads_by_kind
     }
-    absent_kinds = missing_set - refused_kinds - unusable_kinds - elsewhere_kinds
+    absent_kinds = missing_set - refused_kinds - _superseding_named - elsewhere_kinds
     # Everything this cannot attribute to a required kind. Including the wrong-kind
     # case is the point: narrowing to named kinds without it made a block reading
     # `kind=<near-miss>` vanish from every group, and the message went back to claiming
@@ -3223,9 +3211,12 @@ def _check_scheduled_claude_reviewed_head(
     # What the reader needs from a GATE is what it found. What to do about it depends on
     # facts this code cannot see -- whether the review actually ran, whether a finding
     # was real -- and every attempt to guess ended up advising a way around the check.
-    # So: no remedy text, and no emitter suggestion, here. `--emit-marker` remains a
-    # command someone runs deliberately after a review, which is the only context in
-    # which it is honest.
+    # So: no remedy text here, and nothing offering to produce a marker. A command that
+    # emitted one was written and then removed: it was wired to nothing (the routines that
+    # actually post markers live outside this repository and were untouched), and the
+    # closing line of this very message already prints the complete marker with the full
+    # head filled in, so it duplicated output that already existed while adding a second
+    # place to reason about attestation.
     if unusable_kinds:
         parts.append(
             f"{', '.join(sorted(unusable_kinds))} — a marker block IS present on this "
@@ -5279,6 +5270,16 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
         print(
             f"scheduled-claude: {'BLOCK — ' + sched_msg.splitlines()[0] if sched_msg else 'ok (at head)'}"
         )
+        # Render the TAIL, following the pin-receipts idiom above. Without this the whole
+        # per-cause diagnosis is discarded on the canonical pre-merge surface: line 0 is
+        # the summary, and its `present: none` clause is the exact string an operator was
+        # measured acting wrongly on -- they read "nothing was posted", waited, and the
+        # marker was sitting in the thread the whole time. The bullets that say WHICH
+        # cause it was live on lines 1+. Printing only line 0 means every improvement to
+        # them is invisible here, which is where the mistake was actually made.
+        if sched_msg:
+            for line in sched_msg.splitlines()[1:]:
+                print(f"  {line}")
         failures += 1 if sched_msg else 0
     # Fail-closed (the only mode now): a scan that could not be READ (gh error/malformed)
     # shows as a failure here, never as "ok" — the report must not issue a false all-clear.
@@ -5316,31 +5317,4 @@ if __name__ == "__main__":
             )
             sys.exit(2)
         sys.exit(check_pr_report(sys.argv[2], repo=_repo))
-    # Producer mode: `git_push_guard.py --emit-marker <N> --kind <name> [--repo O/R]`
-    # prints the scheduled-review marker for that PR's CURRENT head, so the 40-hex
-    # sha is read rather than retyped. See emit_scheduled_review_marker.
-    if len(sys.argv) >= 3 and sys.argv[1] == "--emit-marker":
-        _rest = sys.argv[3:]
-        _repo = _parse_check_pr_repo(_rest)
-        if _repo is _CHECK_PR_REPO_EMPTY:
-            print(
-                "ERROR: --repo/-R was given an empty value. Specify OWNER/REPO, or "
-                "omit the option to use the current repository.",
-                file=sys.stderr,
-            )
-            sys.exit(2)
-        _kind = None
-        for _i, _a in enumerate(_rest):
-            if _a == "--kind" and _i + 1 < len(_rest):
-                _kind = _rest[_i + 1]
-            elif _a.startswith("--kind="):
-                _kind = _a.split("=", 1)[1]
-        if not _kind:
-            print(
-                "ERROR: --emit-marker needs --kind <name>. Known kinds: "
-                f"{', '.join(_KNOWN_SCHEDULED_REVIEW_KINDS)}.",
-                file=sys.stderr,
-            )
-            sys.exit(2)
-        sys.exit(emit_scheduled_review_marker(sys.argv[2], kind=_kind, repo=_repo))
     run_guard(main, "git_push_guard")

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2407,10 +2407,24 @@ _SCHEDULED_REVIEW_BLOCK_RE = re.compile(
 # violating fail-closed (a failed/corrupt routine run must NOT satisfy the gate).
 _SCHEDULED_REVIEW_HEAD_RE = re.compile(r"\bhead=([0-9a-f]{40})(?=\s|\Z)")
 _SCHEDULED_REVIEW_KIND_RE = re.compile(r"\bkind=([a-z0-9][a-z0-9._-]*)(?=\s|\Z)")
-# Deliberately permissive, and used ONLY to quote back what a malformed marker
-# actually said. It must never feed the gate: matching loosely here is how the
-# operator learns their head= was abbreviated, not a second way to satisfy it.
+# THE REPORTING GRAMMAR -- deliberately a SECOND, permissive read of the same text.
+#
+# The strict expressions above answer "does this count?" and must stay narrow. A
+# MESSAGE answers a different question -- "what did the operator actually write?"
+# -- and answering it with the strict expression produces confident falsehoods,
+# because a REFUSED value and an ABSENT one become indistinguishable. That is the
+# exact defect this whole change exists to end, so it must not be reintroduced one
+# field at a time: EVERY field the block message describes needs a permissive
+# counterpart here, and a new strict field is not finished until it has one.
+#
+# These must never feed the gate. Matching loosely here is how the operator learns
+# their head= was abbreviated -- never a second way to satisfy anything.
 _SCHEDULED_REVIEW_LOOSE_HEAD_RE = re.compile(r"\bhead=(\S+)")
+_SCHEDULED_REVIEW_LOOSE_KIND_RE = re.compile(r"\bkind=(\S+)")
+# A 40-hex head in the WRONG CASE is full-length and well-formed apart from case.
+# Telling that operator their head "is not a full 40-hex commit sha" sends them to
+# recount 40 characters and find nothing wrong, so the two causes are separated.
+_SCHEDULED_REVIEW_ANYCASE_HEAD_RE = re.compile(r"[0-9a-fA-F]{40}\Z")
 
 # Default scheduled-review kinds the merge gate REQUIRES at head. A PR merges only when
 # a valid owner-authored marker for EACH effective required kind names the current head.
@@ -2724,9 +2738,26 @@ def _marker_kind_or_none(block: str) -> str | None:
     Lets a block that is being REJECTED still be attributed to the kind it was
     meant to satisfy, so the block message can scope its guidance instead of
     reporting an unattached complaint.
+
+    A STATUS-SUFFIXED value (``kind=leaks/failed``) is refused by the gate grammar
+    -- correctly, since a failed run must never satisfy anything -- but it NAMES
+    its review unambiguously, and reading it here is not the attribution guess this
+    module deliberately refuses to make. The line is exact-match, not resemblance:
+    the segment before the suffix must BE a known kind. A near-miss like
+    ``kind=leak`` still returns None, because deciding it meant ``leaks`` would be
+    guessing at intent, and a guessed kind steers the reader toward vouching for a
+    review that never ran. Attribution is reporting-only either way -- the caller
+    records this on the UNUSABLE path, which never reaches ``accepted``.
     """
     m = _SCHEDULED_REVIEW_KIND_RE.search(block)
-    return m.group(1) if m else None
+    if m:
+        return m.group(1)
+    loose = _SCHEDULED_REVIEW_LOOSE_KIND_RE.search(block)
+    if loose:
+        stem = loose.group(1).split("/", 1)[0].lower()
+        if stem in _KNOWN_SCHEDULED_REVIEW_KINDS:
+            return stem
+    return None
 
 
 def emit_scheduled_review_marker(pr_num: str, *, kind: str, repo: str | None = None) -> int:
@@ -2916,13 +2947,28 @@ def _scheduled_review_marker_scan(
                 # otherwise cannot tell which of several markers is the broken one.
                 if not head_m:
                     loose = _SCHEDULED_REVIEW_LOOSE_HEAD_RE.search(block)
-                    why = (
-                        f"its head={loose.group(1)!r} is not a full 40-hex commit sha"
-                        if loose
-                        else "it carries no head= field"
-                    )
+                    if not loose:
+                        why = "it carries no head= field"
+                    elif _SCHEDULED_REVIEW_ANYCASE_HEAD_RE.fullmatch(loose.group(1)):
+                        why = (
+                            f"its head={loose.group(1)!r} is full length but not "
+                            f"lowercase, and the grammar is lowercase hex"
+                        )
+                    else:
+                        why = (
+                            f"its head={loose.group(1)!r} is not a full 40-hex commit sha"
+                        )
                 else:
-                    why = "it carries no kind= field"
+                    # Read PERMISSIVELY to say what is actually there. The strict
+                    # expression refuses a status-suffixed `kind=leaks/failed`, and
+                    # reporting that refusal as an absent field told the operator a
+                    # field they had written did not exist.
+                    loose = _SCHEDULED_REVIEW_LOOSE_KIND_RE.search(block)
+                    why = (
+                        f"its kind={loose.group(1)!r} is not a bare review name"
+                        if loose
+                        else "it carries no kind= field"
+                    )
                 # A malformed marker on a body that reads as BLOCKING is not a typo
                 # to be re-posted. The verdict survives the malformed field, because
                 # pasting a clean marker over an unresolved finding would make the
@@ -3100,12 +3146,31 @@ def _check_scheduled_claude_reviewed_head(
     # naming no kind, or naming one nothing requires (a typo such as a singular form),
     # cannot be credited to any review -- it is reported separately and claims nothing.
     _named = {k for k, _, _ in unusable if k is not None} & missing_set
+    # Being REPORTED and OUTRANKING history are two different jobs, and only the second
+    # may be gated on trust. Gating the first as well makes the block vanish from the
+    # message altogether -- silently dropping an untrusted marker is the very defect
+    # this change exists to end, and a test here catches it.
+    #
+    # So: every named kind is still reported (``_named``), while only a cause the OWNER
+    # can repair by fixing the marker (the third field) suppresses the history bullet.
+    # Letting EVERY unusable cause suppress it meant an untrusted block hid trusted
+    # evidence: on a public repository any account can post a marker naming the current
+    # head, and that erased "a routine ran on an older commit" -- the one fact telling
+    # the operator a review had ever happened. A dismissed review did the same. The
+    # verdict never moved (neither block satisfies anything); the report did.
+    _fixable_named = {
+        k for k, _, fixable in unusable if k is not None and fixable
+    } & missing_set
     # A CURRENT malformed marker outranks marker history for the same kind: "you posted
     # one and it needs one character fixed" is more actionable than "a routine ran on an
     # older commit", and the latter used to hide the former on any PR with history.
     unusable_kinds = (missing_set - refused_kinds) & _named
+    # Subtracts the FIXABLE set, not every unusable kind, so a kind can now appear in
+    # BOTH bullets: "an untrusted block sits at head" AND "your own review ran on an
+    # older commit". That overlap is the point -- those are two independent facts and
+    # the operator needs both. Only a repairable typo earns the right to stand alone.
     elsewhere_kinds = {
-        k for k in missing_set - refused_kinds - unusable_kinds if k in heads_by_kind
+        k for k in missing_set - refused_kinds - _fixable_named if k in heads_by_kind
     }
     absent_kinds = missing_set - refused_kinds - unusable_kinds - elsewhere_kinds
     # Everything this cannot attribute to a required kind. Including the wrong-kind

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2788,11 +2788,15 @@ def emit_scheduled_review_marker(pr_num: str, *, kind: str, repo: str | None = N
 
 def _scheduled_review_marker_scan(
     pr_num: str, repo: str | None = None
-) -> tuple[dict[str, set[str]], dict[str, set[str]], list[tuple[str | None, str]]] | None:
+) -> (
+    tuple[dict[str, set[str]], dict[str, set[str]], list[tuple[str | None, str, bool]]]
+    | None
+):
     """``(accepted, rejected_not_clean, unusable)`` for the PR's scheduled-review
     markers, or ``None`` on an UNREADABLE fetch.
 
-    ``unusable`` is a list of ``(kind_or_None, reason)`` for marker BLOCKS that were
+    ``unusable`` is a list of ``(kind_or_None, reason, grammar_only)`` for marker
+    BLOCKS that were
     seen and could not be counted — a head that is not a full 40-hex sha, a missing
     ``kind``, an author who is not the owner, a dismissed review. Every one of those
     was previously dropped in silence, which made 'you posted a marker that does not
@@ -2823,7 +2827,13 @@ def _scheduled_review_marker_scan(
     owner = (owner_repo.split("/")[0] if owner_repo else "").lower() or None
     accepted: dict[str, set[str]] = {}
     rejected: dict[str, set[str]] = {}
-    unusable: list[tuple[str | None, str]] = []
+    # (kind_or_None, reason, grammar_only). The third field is the whole point:
+    # True means a TRUSTED, CLEAN review really happened and only the marker text
+    # is malformed, so re-posting it is honest. False means no such review exists
+    # at this head -- another author's, a dismissed one, or one whose body carries
+    # a blocking finding -- and telling the owner to re-post there would be telling
+    # them to attest to something that did not happen.
+    unusable: list[tuple[str | None, str, bool]] = []
     for row in rows:
         body = row.get("body") or ""
         # Blocks are parsed BEFORE the trust checks, so a row about to be dropped can
@@ -2839,7 +2849,8 @@ def _scheduled_review_marker_scan(
                     (
                         _marker_kind_or_none(block),
                         f"it was posted by '{login or 'an unidentified account'}', who "
-                        f"is not the repo owner, so it is not trusted",
+                        f"is not the repo owner, so nothing here vouches for a review",
+                        False,
                     )
                 )
             continue
@@ -2849,14 +2860,22 @@ def _scheduled_review_marker_scan(
         # issue comments, so this only drops review rows; issue comments remain state-less.
         _state = (row.get("state") or "").upper()
         if _state in ("DISMISSED", "PENDING"):
-            for block in blocks:
-                unusable.append(
-                    (
-                        _marker_kind_or_none(block),
-                        f"it is carried by a {_state} review, which no longer vouches "
-                        f"for anything",
+            # Only DISMISSED is terminal. A PENDING review is an unpublished draft
+            # that can still be submitted, so it is precisely the IN-FLIGHT case
+            # where waiting can make this same review count -- recording it as
+            # unusable would attach "waiting cannot clear this" to the one state
+            # where waiting IS the answer. Dropped silently on purpose; it falls
+            # through to the absent/in-flight guidance.
+            if _state == "DISMISSED":
+                for block in blocks:
+                    unusable.append(
+                        (
+                            _marker_kind_or_none(block),
+                            "it is carried by a DISMISSED review, which no longer "
+                            "vouches for anything",
+                            False,
+                        )
                     )
-                )
             continue
         # The marker must mean "ran CLEAN", not merely "ran": a scheduled review whose body
         # CONTAINS a blocking finding ([P1]/HARD BLOCK/### ERROR, unless a clean marker
@@ -2894,7 +2913,16 @@ def _scheduled_review_marker_scan(
                     )
                 else:
                     why = "it carries no kind= field"
-                unusable.append((_marker_kind_or_none(block), why))
+                # A malformed marker on a body that reads as BLOCKING is not a typo
+                # to be re-posted. The verdict survives the malformed field, because
+                # pasting a clean marker over an unresolved finding would make the
+                # gate pass while the finding still stands.
+                if not_clean:
+                    why += (
+                        ", and its body reads as carrying a blocking finding, so a "
+                        "corrected marker would not make it count either"
+                    )
+                unusable.append((_marker_kind_or_none(block), why, not not_clean))
                 continue
             target.setdefault(head_m.group(1).lower(), set()).add(kind_m.group(1).lower())
     return accepted, rejected, unusable
@@ -3029,20 +3057,34 @@ def _check_scheduled_claude_reviewed_head(
                 heads_by_kind.setdefault(kind, set()).add(other_head[:12])
     # Within a KIND, refused-at-this-head wins: it is the most specific cause, and the only
     # one whose remedy is neither waiting nor re-reviewing.
-    elsewhere_kinds = {k for k in missing_set - refused_kinds if k in heads_by_kind}
     # A marker BLOCK that was seen but could not be counted. This group exists because
-    # the three above partition only the markers that PARSE — a block discarded during
+    # the ones above partition only the markers that PARSE — a block discarded during
     # the scan reached none of them and fell through to ABSENT, whose advice is to
     # wait. An unusable marker is the one cause where waiting is guaranteed useless.
-    # When a discarded block names no kind we cannot say WHICH kind it was for, so it
-    # claims all remaining ones: an operator re-posting a marker they did not need to
-    # is harmless, while being told to wait on a marker that will never count is the
-    # failure this group was added for.
-    _rest = missing_set - refused_kinds - elsewhere_kinds
-    _named = {k for k, _ in unusable if k is not None}
-    _unnamed = any(k is None for k, _ in unusable)
-    unusable_kinds = _rest if _unnamed and unusable else (_rest & _named)
-    absent_kinds = _rest - unusable_kinds
+    #
+    # It is scoped ONLY to kinds a block actually NAMED. An earlier version let a block
+    # with no kind= claim every remaining kind, reasoning that over-reporting is the
+    # safe direction. It is not, once the group carries a remedy: the guidance would
+    # tell the owner to post a `leaks` marker on the strength of a block that never
+    # mentioned leaks, and a hand-written marker satisfies the one gate this repository
+    # calls irreducible. An unscoped block is reported as unscoped, and every kind it
+    # cannot account for keeps its true state.
+    _named = {k for k, _, _ in unusable if k is not None}
+    # A CURRENT malformed marker outranks marker history for the same kind: "you posted
+    # one and it needs one character fixed" is more actionable than "a routine ran on an
+    # older commit", and the latter used to hide the former on any PR with history.
+    unusable_kinds = (missing_set - refused_kinds) & _named
+    elsewhere_kinds = {
+        k for k in missing_set - refused_kinds - unusable_kinds if k in heads_by_kind
+    }
+    absent_kinds = missing_set - refused_kinds - unusable_kinds - elsewhere_kinds
+    # Split by what the cause MEANS. Only a trusted, clean review with a malformed
+    # marker may be answered with "re-post it"; everything else has to be answered with
+    # "run the review", because minting the marker is exactly what must not happen.
+    _grammar = {k for k, _, ok in unusable if ok and k in unusable_kinds}
+    grammar_kinds = _grammar
+    untrusted_kinds = unusable_kinds - grammar_kinds
+    unscoped = [(r, ok) for k, r, ok in unusable if k is None]
 
     parts: list[str] = []
     if refused_kinds:
@@ -3065,17 +3107,44 @@ def _check_scheduled_claude_reviewed_head(
             f"so waiting is unlikely to clear this on its own: re-run against the current "
             f"head and post the marker yourself."
         )
-    if unusable_kinds:
-        detail = "; ".join(
-            f"[{k or 'no kind named'}] {r}" for k, r in unusable[:4]
-        ) + (f" (+{len(unusable) - 4} more)" if len(unusable) > 4 else "")
+    def _detail(kinds: set[str]) -> str:
+        # Filter to THIS group before truncating. Truncating the global list first
+        # showed four unrelated reasons and hid the one that caused this bullet.
+        rows = [f"[{k}] {r}" for k, r, _ in unusable if k in kinds]
+        return "; ".join(rows[:4]) + (f" (+{len(rows) - 4} more)" if len(rows) > 4 else "")
+
+    # The runnable form, and carrying --repo when one was given: run from another
+    # checkout, an emitter without it resolves this PR number in the wrong repository
+    # and prints a marker for the wrong head. The file is tracked non-executable and is
+    # not on PATH, so a bare invocation is command-not-found.
+    _repo_arg = f" --repo {repo}" if repo else ""
+    _emit = f"python3 scripts/hooks/git_push_guard.py --emit-marker {pr_num} --kind <name>{_repo_arg}"
+
+    if grammar_kinds:
         parts.append(
-            f"{', '.join(sorted(unusable_kinds))} — a marker block IS present on this "
-            f"PR but is UNUSABLE, so it counts for nothing: {detail}. This is NOT "
-            f"'nobody posted anything', and waiting cannot clear it — re-post the "
-            f"marker in the exact form below. "
-            f"`git_push_guard.py --emit-marker {pr_num} --kind <name>` prints one with "
-            f"the head read from GitHub, so the sha is never retyped."
+            f"{', '.join(sorted(grammar_kinds))} — a marker block IS present at this "
+            f"head from the owner and its body reads clean, but the block itself is "
+            f"UNUSABLE so it counts for nothing: {_detail(grammar_kinds)}. This is NOT "
+            f"'nobody posted anything', and waiting cannot clear it. The review really "
+            f"ran; only the marker text is wrong, so re-post it — `{_emit}` prints one "
+            f"with the head read from GitHub, so the sha is never retyped."
+        )
+    if untrusted_kinds:
+        parts.append(
+            f"{', '.join(sorted(untrusted_kinds))} — a marker block is present but "
+            f"nothing here vouches for a clean review at this head: "
+            f"{_detail(untrusted_kinds)}. Do NOT hand-write a marker to clear this. A "
+            f"marker is an attestation that the review RAN and came back clean, and on "
+            f"this path it did not — run the review against the current head (and "
+            f"resolve any finding it reports) before posting anything."
+        )
+    if unscoped:
+        _shown = "; ".join(r for r, _ in unscoped[:3])
+        parts.append(
+            f"unscoped — {len(unscoped)} marker block(s) on this PR name no kind, so "
+            f"they cannot be credited to any required review and are NOT counted "
+            f"against the kinds above: {_shown}. Re-post each naming its kind. Until "
+            f"then every required kind is reported by its own true state."
         )
     if absent_kinds:
         parts.append(

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2754,7 +2754,9 @@ def _scheduled_review_rows(pr_num: str, repo: str | None = None) -> list[dict] |
                     "--paginate",
                     "--jq",
                     ".[] | {login: .user.login, author_association: .author_association, "
-                    "body: .body, state: .state}",  # .state present on reviews, null on issue comments
+                    "body: .body, state: .state, created_at: (.created_at // .submitted_at)}",
+                    # .state present on reviews, null on issue comments; the timestamp field
+                    # differs per endpoint and is what lets the scan order rows ACROSS them
                 ],
                 capture_output=True,
                 text=True,
@@ -2865,9 +2867,15 @@ def _scheduled_review_marker_scan(
     # it only to count whether the OWNER has posted anything for a kind, because that is
     # the one thing that says whether the owner's routine has evidently already run.
     unusable: list[tuple[str | None, str, bool]] = []
-    # (head -> kinds) whose accepting row carried an EXPLICIT clean verdict. Consulted
-    # only where the same (head, kind) was also REFUSED by another row -- see below.
-    explicit_clean: dict[str, set[str]] = {}
+    # Every owner statement about a (head, kind), in CHRONOLOGICAL order, classified as
+    # "clean" (explicit verdict line), "refused" (blocking finding, no verdict) or "plain"
+    # (neither). The verdict for the pair is resolved AFTER the loop from this list -- see
+    # there for the rule and why the order matters.
+    stmts: dict[tuple[str, str], list[str]] = {}
+    # Chronology: the API rows carry created_at/submitted_at; the two endpoints are fetched
+    # separately, so without sorting a review could sort before a comment posted after it.
+    # Rows without a timestamp (the test seam) keep list order -- the sort is stable.
+    rows = sorted(rows, key=lambda r: (r.get("created_at") or ""))
     for row in rows:
         body = row.get("body") or ""
         # Blocks are parsed BEFORE the trust checks, so a row about to be dropped can
@@ -2908,8 +2916,8 @@ def _scheduled_review_marker_scan(
                     if head_sha and _hm and _hm.group(1).lower() == head_sha.lower():
                         why = (
                             "it is carried by a PENDING (unpublished) review naming the "
-                            "current head, so it is not yet visible to the gate and "
-                            "counts only once that draft is submitted"
+                            "current head, so it is not yet visible to the gate; once "
+                            "submitted it is read like any other block"
                         )
                     else:
                         why = (
@@ -2937,7 +2945,7 @@ def _scheduled_review_marker_scan(
         # whether its prose happened to contain a _CLEAN_PATTERNS phrase.
         has_clean = any(c.search(body) for c in _CLEAN_PATTERNS)
         not_clean = any(p.search(body) for p in _BLOCKING_PATTERNS) and not has_clean
-        target = rejected if not_clean else accepted
+        verdict = "refused" if not_clean else ("clean" if has_clean else "plain")
         # Defense-in-depth follow-up: for rows from /pulls/N/reviews we could ALSO
         # cross-check GitHub's authoritative `commit_id` vs the marker sha (issue comments
         # carry none). Deferred (LOW): the marker sha is matched EXACTLY vs the authoritative
@@ -2983,6 +2991,11 @@ def _scheduled_review_marker_scan(
                         reasons.append("it carries no kind= field")
                     elif not loose.group(1):
                         reasons.append("its kind= field is present but EMPTY")
+                    elif loose.group(1).lower() in _KNOWN_SCHEDULED_REVIEW_KINDS:
+                        reasons.append(
+                            f"its kind={loose.group(1)!r} is a known review but not "
+                            f"lowercase, and the grammar is lowercase"
+                        )
                     else:
                         reasons.append(
                             f"its kind={loose.group(1)!r} is not a bare review name"
@@ -3008,32 +3021,66 @@ def _scheduled_review_marker_scan(
                 # back to "no marker at ANY head" and advised waiting, while the block
                 # sat visibly in the thread. Verdict-neutral either way (an unknown
                 # kind satisfies nothing), so this is purely so the reader can SEE it.
+                _why = (
+                    f"it names kind={_kind!r}, which is not a known scheduled "
+                    f"review, so it can never satisfy one"
+                )
+                if not_clean:
+                    # The body's verdict survives the naming problem, exactly as it
+                    # does for a malformed field: reporting only the typo invites a
+                    # corrected marker over an unresolved finding.
+                    _why += ", and its body reads as carrying a blocking finding"
+                unusable.append((_kind, _why, True))
+                continue
+            stmts.setdefault((head_m.group(1).lower(), _kind), []).append(verdict)
+    # RESOLUTION. Each row used to choose its own map, so a second owner comment at the
+    # same head -- same marker, ordinary prose -- was accepted while the first row's [P1]
+    # sat refused, and the gate passed with the finding unchanged. The first fix let any
+    # explicit clean verdict win regardless of order, which passed a LATER [P1] posted
+    # after an earlier verdict. Order is the whole question, so the rule is stated in it:
+    #
+    #   THE OWNER'S LATEST DECISIVE STATEMENT ABOUT (head, kind) GOVERNS.
+    #
+    # Decisive = an explicit clean-verdict line, or a blocking finding. Plain rows (neither)
+    # are not decisive in either direction: they count only when nothing decisive was ever
+    # said. So a plain re-post never overrides a refusal, the documented remedy (re-post
+    # WITH a verdict) still clears a prose-tripped refusal, and a re-run that finds
+    # something after a verdict is heard. Scoped to the head -- a finding on an older
+    # commit is what a new commit fixes. Every superseded row is still LISTED, so the
+    # report never says one block where two exist.
+    for (h, k), seq in stmts.items():
+        decisive = [v for v in seq if v != "plain"]
+        final = decisive[-1] if decisive else "plain"
+        (rejected if final == "refused" else accepted).setdefault(h, set()).add(k)
+        if final == "refused":
+            n_plain = seq.count("plain")
+            if n_plain:
                 unusable.append(
                     (
-                        _kind,
-                        f"it names kind={_kind!r}, which is not a known scheduled "
-                        f"review, so it can never satisfy one",
+                        k,
+                        f"a plain re-post at this head ({n_plain} block(s), no verdict "
+                        f"line) does not override the refusal for this kind",
                         True,
                     )
                 )
-                continue
-            target.setdefault(head_m.group(1).lower(), set()).add(_kind)
-            if target is accepted and has_clean:
-                explicit_clean.setdefault(head_m.group(1).lower(), set()).add(_kind)
-    # `not_clean` is decided PER ROW, and each row chose its own map. So a second owner
-    # comment at the SAME head -- same marker, ordinary prose, no verdict -- landed in
-    # `accepted` while the first row's [P1] sat in `rejected`, and the gate PASSED with
-    # nothing about the finding changed. A refusal and an acceptance for one (head, kind)
-    # are a contradiction the scan must resolve, and it resolves it the way the documented
-    # remedy already says: a prose-tripped refusal is cleared by re-posting WITH an explicit
-    # clean-verdict line. That stays. A plain re-post is not an override; a stated verdict
-    # is. Scoped to the same head -- a refusal on an OLDER commit is exactly what a new
-    # commit exists to fix, and must not taint a clean marker at the new head.
-    for h, refused in rejected.items():
-        if h in accepted:
-            accepted[h] -= refused - explicit_clean.get(h, set())
-            if not accepted[h]:
-                del accepted[h]
+            if "clean" in seq:
+                unusable.append(
+                    (
+                        k,
+                        "an explicit clean verdict at this head, superseded by a LATER "
+                        "blocking finding for this kind",
+                        True,
+                    )
+                )
+        elif "refused" in seq:
+            unusable.append(
+                (
+                    k,
+                    "a refusal at this head, superseded by a LATER explicit clean "
+                    "verdict for this kind",
+                    True,
+                )
+            )
     return accepted, rejected, unusable
 
 

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2865,6 +2865,9 @@ def _scheduled_review_marker_scan(
     # it only to count whether the OWNER has posted anything for a kind, because that is
     # the one thing that says whether the owner's routine has evidently already run.
     unusable: list[tuple[str | None, str, bool]] = []
+    # (head -> kinds) whose accepting row carried an EXPLICIT clean verdict. Consulted
+    # only where the same (head, kind) was also REFUSED by another row -- see below.
+    explicit_clean: dict[str, set[str]] = {}
     for row in rows:
         body = row.get("body") or ""
         # Blocks are parsed BEFORE the trust checks, so a row about to be dropped can
@@ -2892,25 +2895,27 @@ def _scheduled_review_marker_scan(
         _state = (row.get("state") or "").upper()
         if _state in ("DISMISSED", "PENDING"):
             # Only DISMISSED is terminal. A PENDING review is an unpublished draft
-            # that can still be submitted, so it is precisely the IN-FLIGHT case
-            # where waiting can make this same review count -- recording it as
-            # unusable would attach "waiting cannot clear this" to the one state
-            # where waiting IS the answer. Dropped silently on purpose; it falls
-            # through to the absent/in-flight guidance.
+            # that can still be submitted. Both are RECORDED: an earlier version dropped
+            # a current-head draft silently so the generic in-flight note would cover
+            # it, which was the one remaining silent drop in a message that promises to
+            # list every block it saw. The row is the precise form of that note.
             for block in blocks:
                 if _state == "PENDING":
-                    # Submitting the draft can only help if the marker already names
-                    # the CURRENT head. A pending review whose marker names an older
-                    # commit is stale no matter when it is submitted, and dropping it
-                    # silently sent the reader to wait for something that could never
-                    # count.
+                    # Whether submitting the draft can help depends on the head it
+                    # names: the current one counts once published; an older one is
+                    # stale no matter when it is submitted.
                     _hm = _SCHEDULED_REVIEW_HEAD_RE.search(block)
                     if head_sha and _hm and _hm.group(1).lower() == head_sha.lower():
-                        continue
-                    why = (
-                        "it is carried by a PENDING review and does not name the "
-                        "current head, so submitting that draft would not make it count"
-                    )
+                        why = (
+                            "it is carried by a PENDING (unpublished) review naming the "
+                            "current head, so it is not yet visible to the gate and "
+                            "counts only once that draft is submitted"
+                        )
+                    else:
+                        why = (
+                            "it is carried by a PENDING review and does not name the "
+                            "current head, so submitting that draft would not make it count"
+                        )
                 else:
                     why = (
                         "it is carried by a DISMISSED review, which no longer vouches "
@@ -2930,9 +2935,8 @@ def _scheduled_review_marker_scan(
         # measured 2026-08-28: those two produced the identical `present: none` line, and
         # the only signal distinguishing an accepted marker from a rejected one was
         # whether its prose happened to contain a _CLEAN_PATTERNS phrase.
-        not_clean = any(p.search(body) for p in _BLOCKING_PATTERNS) and not any(
-            c.search(body) for c in _CLEAN_PATTERNS
-        )
+        has_clean = any(c.search(body) for c in _CLEAN_PATTERNS)
+        not_clean = any(p.search(body) for p in _BLOCKING_PATTERNS) and not has_clean
         target = rejected if not_clean else accepted
         # Defense-in-depth follow-up: for rows from /pulls/N/reviews we could ALSO
         # cross-check GitHub's authoritative `commit_id` vs the marker sha (issue comments
@@ -2945,38 +2949,46 @@ def _scheduled_review_marker_scan(
                 # A marker must name both a head AND a kind to count. Say WHICH is
                 # wrong and quote the offending value: on a long thread the operator
                 # otherwise cannot tell which of several markers is the broken one.
+                # EVERY bad field is reported, not the first one found. An if/else here
+                # reported only the head, so `head=abc kind=leaks/failed` read as a short
+                # sha and the suffix saying the run FAILED was never shown -- one repair
+                # cycle per hidden field, on a message that promises to hide nothing.
+                reasons: list[str] = []
                 if not head_m:
                     loose = _SCHEDULED_REVIEW_LOOSE_HEAD_RE.search(block)
                     if not loose:
-                        why = "it carries no head= field"
+                        reasons.append("it carries no head= field")
                     elif not loose.group(1):
                         # `\S*` so an EMPTY value is seen. `\S+` reported it as no field
                         # at all -- the most likely producer fault (an uninterpolated
                         # variable) described as the operator having omitted the field.
-                        why = "its head= field is present but EMPTY"
+                        reasons.append("its head= field is present but EMPTY")
                     elif _SCHEDULED_REVIEW_ANYCASE_HEAD_RE.fullmatch(loose.group(1)):
-                        why = (
+                        reasons.append(
                             f"its head={loose.group(1)!r} is full length but not "
                             f"lowercase, and the grammar is lowercase hex"
                         )
                     else:
-                        why = (
+                        reasons.append(
                             f"its head={loose.group(1)!r} is not a full 40-hex commit sha"
+                            + _status_suffix_warning(loose.group(1))
                         )
-                        why += _status_suffix_warning(loose.group(1))
-                else:
+                if not kind_m:
                     # Read PERMISSIVELY to say what is actually there. The strict
                     # expression refuses a status-suffixed `kind=leaks/failed`, and
                     # reporting that refusal as an absent field told the operator a
                     # field they had written did not exist.
                     loose = _SCHEDULED_REVIEW_LOOSE_KIND_RE.search(block)
                     if not loose:
-                        why = "it carries no kind= field"
+                        reasons.append("it carries no kind= field")
                     elif not loose.group(1):
-                        why = "its kind= field is present but EMPTY"
+                        reasons.append("its kind= field is present but EMPTY")
                     else:
-                        why = f"its kind={loose.group(1)!r} is not a bare review name"
-                        why += _status_suffix_warning(loose.group(1))
+                        reasons.append(
+                            f"its kind={loose.group(1)!r} is not a bare review name"
+                            + _status_suffix_warning(loose.group(1))
+                        )
+                why = ", and ".join(reasons)
                 # A malformed marker on a body that reads as BLOCKING is not a typo
                 # to be re-posted. The verdict survives the malformed field, because
                 # pasting a clean marker over an unresolved finding would make the
@@ -3006,6 +3018,22 @@ def _scheduled_review_marker_scan(
                 )
                 continue
             target.setdefault(head_m.group(1).lower(), set()).add(_kind)
+            if target is accepted and has_clean:
+                explicit_clean.setdefault(head_m.group(1).lower(), set()).add(_kind)
+    # `not_clean` is decided PER ROW, and each row chose its own map. So a second owner
+    # comment at the SAME head -- same marker, ordinary prose, no verdict -- landed in
+    # `accepted` while the first row's [P1] sat in `rejected`, and the gate PASSED with
+    # nothing about the finding changed. A refusal and an acceptance for one (head, kind)
+    # are a contradiction the scan must resolve, and it resolves it the way the documented
+    # remedy already says: a prose-tripped refusal is cleared by re-posting WITH an explicit
+    # clean-verdict line. That stays. A plain re-post is not an override; a stated verdict
+    # is. Scoped to the same head -- a refusal on an OLDER commit is exactly what a new
+    # commit exists to fix, and must not taint a clean marker at the new head.
+    for h, refused in rejected.items():
+        if h in accepted:
+            accepted[h] -= refused - explicit_clean.get(h, set())
+            if not accepted[h]:
+                del accepted[h]
     return accepted, rejected, unusable
 
 

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -3069,7 +3069,10 @@ def _check_scheduled_claude_reviewed_head(
     # mentioned leaks, and a hand-written marker satisfies the one gate this repository
     # calls irreducible. An unscoped block is reported as unscoped, and every kind it
     # cannot account for keeps its true state.
-    _named = {k for k, _, _ in unusable if k is not None}
+    # Scoped to kinds a block actually NAMED, and named as a REQUIRED kind. A block
+    # naming no kind, or naming one nothing requires (a typo such as a singular form),
+    # cannot be credited to any review -- it is reported separately and claims nothing.
+    _named = {k for k, _, _ in unusable if k is not None} & missing_set
     # A CURRENT malformed marker outranks marker history for the same kind: "you posted
     # one and it needs one character fixed" is more actionable than "a routine ran on an
     # older commit", and the latter used to hide the former on any PR with history.
@@ -3078,13 +3081,11 @@ def _check_scheduled_claude_reviewed_head(
         k for k in missing_set - refused_kinds - unusable_kinds if k in heads_by_kind
     }
     absent_kinds = missing_set - refused_kinds - unusable_kinds - elsewhere_kinds
-    # Split by what the cause MEANS. Only a trusted, clean review with a malformed
-    # marker may be answered with "re-post it"; everything else has to be answered with
-    # "run the review", because minting the marker is exactly what must not happen.
-    _grammar = {k for k, _, ok in unusable if ok and k in unusable_kinds}
-    grammar_kinds = _grammar
-    untrusted_kinds = unusable_kinds - grammar_kinds
-    unscoped = [(r, ok) for k, r, ok in unusable if k is None]
+    # Everything this cannot attribute to a required kind. Including the wrong-kind
+    # case is the point: narrowing to named kinds without it made a block reading
+    # `kind=<near-miss>` vanish from every group, and the message went back to claiming
+    # nothing had been posted -- the exact misdiagnosis this whole change exists to end.
+    unscoped = [(k, r) for k, r, _ in unusable if k is None or k not in missing_set]
 
     parts: list[str] = []
     if refused_kinds:
@@ -3113,38 +3114,36 @@ def _check_scheduled_claude_reviewed_head(
         rows = [f"[{k}] {r}" for k, r, _ in unusable if k in kinds]
         return "; ".join(rows[:4]) + (f" (+{len(rows) - 4} more)" if len(rows) > 4 else "")
 
-    # The runnable form, and carrying --repo when one was given: run from another
-    # checkout, an emitter without it resolves this PR number in the wrong repository
-    # and prints a marker for the wrong head. The file is tracked non-executable and is
-    # not on PATH, so a bare invocation is command-not-found.
-    _repo_arg = f" --repo {repo}" if repo else ""
-    _emit = f"python3 scripts/hooks/git_push_guard.py --emit-marker {pr_num} --kind <name>{_repo_arg}"
-
-    if grammar_kinds:
+    # These bullets REPORT. They deliberately prescribe nothing.
+    #
+    # Six of six blocker-class review findings on the first version of this feature
+    # were in its advice, and none in its observations. The cause was structural: the
+    # advice had to know whether a trusted clean review existed, so each branch decided
+    # that for itself and each got it wrong differently -- offering to mint a marker for
+    # a review posted by someone else, for one that was dismissed, for one that came
+    # back BLOCKING. A marker is an attestation, and a gate that tells you how to write
+    # one is a gate explaining how to get past itself.
+    #
+    # What the reader needs from a GATE is what it found. What to do about it depends on
+    # facts this code cannot see -- whether the review actually ran, whether a finding
+    # was real -- and every attempt to guess ended up advising a way around the check.
+    # So: no remedy text, and no emitter suggestion, here. `--emit-marker` remains a
+    # command someone runs deliberately after a review, which is the only context in
+    # which it is honest.
+    if unusable_kinds:
         parts.append(
-            f"{', '.join(sorted(grammar_kinds))} — a marker block IS present at this "
-            f"head from the owner and its body reads clean, but the block itself is "
-            f"UNUSABLE so it counts for nothing: {_detail(grammar_kinds)}. This is NOT "
-            f"'nobody posted anything', and waiting cannot clear it. The review really "
-            f"ran; only the marker text is wrong, so re-post it — `{_emit}` prints one "
-            f"with the head read from GitHub, so the sha is never retyped."
-        )
-    if untrusted_kinds:
-        parts.append(
-            f"{', '.join(sorted(untrusted_kinds))} — a marker block is present but "
-            f"nothing here vouches for a clean review at this head: "
-            f"{_detail(untrusted_kinds)}. Do NOT hand-write a marker to clear this. A "
-            f"marker is an attestation that the review RAN and came back clean, and on "
-            f"this path it did not — run the review against the current head (and "
-            f"resolve any finding it reports) before posting anything."
+            f"{', '.join(sorted(unusable_kinds))} — a marker block IS present on this "
+            f"PR but could not be counted, so it stands for nothing: "
+            f"{_detail(unusable_kinds)}. This is NOT 'nobody posted anything'."
         )
     if unscoped:
-        _shown = "; ".join(r for r, _ in unscoped[:3])
+        shown = "; ".join(
+            f"[{k or 'no kind named'}] {r}" for k, r in unscoped[:3]
+        ) + (f" (+{len(unscoped) - 3} more)" if len(unscoped) > 3 else "")
         parts.append(
-            f"unscoped — {len(unscoped)} marker block(s) on this PR name no kind, so "
-            f"they cannot be credited to any required review and are NOT counted "
-            f"against the kinds above: {_shown}. Re-post each naming its kind. Until "
-            f"then every required kind is reported by its own true state."
+            f"unscoped — {len(unscoped)} marker block(s) on this PR name no required "
+            f"kind, so they are credited to nothing and counted against nothing: "
+            f"{shown}. Every required kind above is reported by its own state."
         )
     if absent_kinds:
         parts.append(

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2407,6 +2407,10 @@ _SCHEDULED_REVIEW_BLOCK_RE = re.compile(
 # violating fail-closed (a failed/corrupt routine run must NOT satisfy the gate).
 _SCHEDULED_REVIEW_HEAD_RE = re.compile(r"\bhead=([0-9a-f]{40})(?=\s|\Z)")
 _SCHEDULED_REVIEW_KIND_RE = re.compile(r"\bkind=([a-z0-9][a-z0-9._-]*)(?=\s|\Z)")
+# Deliberately permissive, and used ONLY to quote back what a malformed marker
+# actually said. It must never feed the gate: matching loosely here is how the
+# operator learns their head= was abbreviated, not a second way to satisfy it.
+_SCHEDULED_REVIEW_LOOSE_HEAD_RE = re.compile(r"\bhead=(\S+)")
 
 # Default scheduled-review kinds the merge gate REQUIRES at head. A PR merges only when
 # a valid owner-authored marker for EACH effective required kind names the current head.
@@ -2714,11 +2718,88 @@ def _scheduled_review_rows(pr_num: str, repo: str | None = None) -> list[dict] |
     return rows
 
 
+def _marker_kind_or_none(block: str) -> str | None:
+    """The ``kind`` a marker block names, or None when it names none.
+
+    Lets a block that is being REJECTED still be attributed to the kind it was
+    meant to satisfy, so the block message can scope its guidance instead of
+    reporting an unattached complaint.
+    """
+    m = _SCHEDULED_REVIEW_KIND_RE.search(block)
+    return m.group(1) if m else None
+
+
+def emit_scheduled_review_marker(pr_num: str, *, kind: str, repo: str | None = None) -> int:
+    """Print the scheduled-review marker for ``pr_num``'s CURRENT head. 0 on success.
+
+    The PREVENT half of the marker contract. Nothing in this repository emitted a
+    marker: the 40-hex requirement lived in a regex on the CONSUMER side and in a
+    sentence asking a person to copy a commit sha by hand. A marker whose head was
+    abbreviated then matched no head at all, was discarded during the scan, and was
+    reported as "nobody posted anything" — advice to wait, for a review that had
+    already run.
+
+    Two properties make that unrepeatable here. The head is READ from GitHub rather
+    than typed. And the finished line is parsed back through the gate's OWN regexes,
+    with the captured values compared to what went in, before anything is printed —
+    so a marker this command emits is by construction a marker the gate counts, and a
+    change to either regex that breaks the pairing fails loudly rather than shipping a
+    producer that quietly disagrees with its consumer.
+
+    Refusals are silent on stdout: nothing that looks like a marker is ever printed on
+    a failure path, because a half-formed marker pasted into a PR is the defect.
+    """
+    if kind not in _KNOWN_SCHEDULED_REVIEW_KINDS:
+        print(
+            f"ERROR: kind={kind!r} is not a known scheduled-review kind, so a marker "
+            f"naming it could never satisfy the gate. Known kinds: "
+            f"{', '.join(_KNOWN_SCHEDULED_REVIEW_KINDS)}.",
+            file=sys.stderr,
+        )
+        return 2
+    head = (_pr_head_sha(pr_num, repo=repo) or "").strip().lower()
+    if not head:
+        print(
+            f"ERROR: could not read PR #{pr_num}'s head commit from GitHub. Refusing to "
+            f"emit a marker at all rather than emit one carrying a missing or partial "
+            f"head — that is the exact defect this command exists to prevent.",
+            file=sys.stderr,
+        )
+        return 1
+    marker = f"<!-- genesis-scheduled-review: head={head} kind={kind} -->"
+    # Round-trip through the CONSUMER's regexes. Not a formality: this is the only
+    # thing binding producer and consumer together, and it compares the CAPTURED
+    # values rather than merely checking that something matched.
+    blocks = _SCHEDULED_REVIEW_BLOCK_RE.findall(marker)
+    head_m = _SCHEDULED_REVIEW_HEAD_RE.search(blocks[0]) if len(blocks) == 1 else None
+    kind_m = _SCHEDULED_REVIEW_KIND_RE.search(blocks[0]) if len(blocks) == 1 else None
+    if not (head_m and kind_m and head_m.group(1) == head and kind_m.group(1) == kind):
+        print(
+            "ERROR: the marker just built does not parse back under this gate's own "
+            "marker grammar, so the producer and the consumer have drifted apart. "
+            "Nothing was emitted. Fix the grammar or this builder before posting "
+            "anything by hand.",
+            file=sys.stderr,
+        )
+        return 3
+    print(marker)
+    return 0
+
+
 def _scheduled_review_marker_scan(
     pr_num: str, repo: str | None = None
-) -> tuple[dict[str, set[str]], dict[str, set[str]]] | None:
-    """``(accepted, rejected_not_clean)`` maps of ``head-sha -> {kinds}`` for the PR's
-    owner-authored scheduled-review markers, or ``None`` on an UNREADABLE fetch.
+) -> tuple[dict[str, set[str]], dict[str, set[str]], list[tuple[str | None, str]]] | None:
+    """``(accepted, rejected_not_clean, unusable)`` for the PR's scheduled-review
+    markers, or ``None`` on an UNREADABLE fetch.
+
+    ``unusable`` is a list of ``(kind_or_None, reason)`` for marker BLOCKS that were
+    seen and could not be counted — a head that is not a full 40-hex sha, a missing
+    ``kind``, an author who is not the owner, a dismissed review. Every one of those
+    was previously dropped in silence, which made 'you posted a marker that does not
+    count' indistinguishable from 'nobody posted anything' — and the gate answers the
+    latter with 'a routine may still be in flight, waiting IS the right move'. MEASURED
+    on a live PR: an abbreviated head produced exactly that, and waiting could never
+    have cleared it.
 
     Both maps come from ONE pass so they cannot drift apart. ``accepted`` is what the
     gate honours; ``rejected_not_clean`` is markers that parsed fine and named a head,
@@ -2742,18 +2823,41 @@ def _scheduled_review_marker_scan(
     owner = (owner_repo.split("/")[0] if owner_repo else "").lower() or None
     accepted: dict[str, set[str]] = {}
     rejected: dict[str, set[str]] = {}
+    unusable: list[tuple[str | None, str]] = []
     for row in rows:
+        body = row.get("body") or ""
+        # Blocks are parsed BEFORE the trust checks, so a row about to be dropped can
+        # still report that it carried a marker. Refusing is right; refusing in
+        # silence is what sent an operator to wait for a routine that had already run.
+        blocks = _SCHEDULED_REVIEW_BLOCK_RE.findall(body)
         login = (row.get("login") or "").lower()
         assoc = (row.get("author_association") or "").upper()
         if login != owner and assoc != "OWNER":
-            continue  # not the repo owner — not a trusted scheduled review
+            # not the repo owner — not a trusted scheduled review
+            for block in blocks:
+                unusable.append(
+                    (
+                        _marker_kind_or_none(block),
+                        f"it was posted by '{login or 'an unidentified account'}', who "
+                        f"is not the repo owner, so it is not trusted",
+                    )
+                )
+            continue
         # A DISMISSED review no longer vouches, and a PENDING review is an UNPUBLISHED
         # draft that never ran publicly — neither should satisfy the gate (mirrors the
         # Codex-freshness path). `state` is present on /pulls/N/reviews rows and null on
         # issue comments, so this only drops review rows; issue comments remain state-less.
-        if (row.get("state") or "").upper() in ("DISMISSED", "PENDING"):
+        _state = (row.get("state") or "").upper()
+        if _state in ("DISMISSED", "PENDING"):
+            for block in blocks:
+                unusable.append(
+                    (
+                        _marker_kind_or_none(block),
+                        f"it is carried by a {_state} review, which no longer vouches "
+                        f"for anything",
+                    )
+                )
             continue
-        body = row.get("body") or ""
         # The marker must mean "ran CLEAN", not merely "ran": a scheduled review whose body
         # CONTAINS a blocking finding ([P1]/HARD BLOCK/### ERROR, unless a clean marker
         # overrides — same "clean wins" rule the finding scanners use) does NOT satisfy the
@@ -2774,13 +2878,26 @@ def _scheduled_review_marker_scan(
         # cross-check GitHub's authoritative `commit_id` vs the marker sha (issue comments
         # carry none). Deferred (LOW): the marker sha is matched EXACTLY vs the authoritative
         # HEAD by the caller, so a stale marker can't pass; this only catches a buggy reviewer.
-        for block in _SCHEDULED_REVIEW_BLOCK_RE.findall(body):
+        for block in blocks:
             head_m = _SCHEDULED_REVIEW_HEAD_RE.search(block)
             kind_m = _SCHEDULED_REVIEW_KIND_RE.search(block)
             if not head_m or not kind_m:
-                continue  # a marker must name both a head AND a kind to count
+                # A marker must name both a head AND a kind to count. Say WHICH is
+                # wrong and quote the offending value: on a long thread the operator
+                # otherwise cannot tell which of several markers is the broken one.
+                if not head_m:
+                    loose = _SCHEDULED_REVIEW_LOOSE_HEAD_RE.search(block)
+                    why = (
+                        f"its head={loose.group(1)!r} is not a full 40-hex commit sha"
+                        if loose
+                        else "it carries no head= field"
+                    )
+                else:
+                    why = "it carries no kind= field"
+                unusable.append((_marker_kind_or_none(block), why))
+                continue
             target.setdefault(head_m.group(1).lower(), set()).add(kind_m.group(1).lower())
-    return accepted, rejected
+    return accepted, rejected, unusable
 
 
 def _check_scheduled_claude_reviewed_head(
@@ -2873,7 +2990,7 @@ def _check_scheduled_claude_reviewed_head(
             f"Retry, or append '# scheduled-review-override' to merge anyway."
         )
     scan = _scheduled_review_marker_scan(pr_num, repo=repo)
-    markers, rejected = (None, {}) if scan is None else scan
+    markers, rejected, unusable = (None, {}, []) if scan is None else scan
     if markers is None:
         return (
             f"could not read PR #{pr_num}'s comments/reviews to verify the scheduled Claude "
@@ -2913,7 +3030,19 @@ def _check_scheduled_claude_reviewed_head(
     # Within a KIND, refused-at-this-head wins: it is the most specific cause, and the only
     # one whose remedy is neither waiting nor re-reviewing.
     elsewhere_kinds = {k for k in missing_set - refused_kinds if k in heads_by_kind}
-    absent_kinds = missing_set - refused_kinds - elsewhere_kinds
+    # A marker BLOCK that was seen but could not be counted. This group exists because
+    # the three above partition only the markers that PARSE — a block discarded during
+    # the scan reached none of them and fell through to ABSENT, whose advice is to
+    # wait. An unusable marker is the one cause where waiting is guaranteed useless.
+    # When a discarded block names no kind we cannot say WHICH kind it was for, so it
+    # claims all remaining ones: an operator re-posting a marker they did not need to
+    # is harmless, while being told to wait on a marker that will never count is the
+    # failure this group was added for.
+    _rest = missing_set - refused_kinds - elsewhere_kinds
+    _named = {k for k, _ in unusable if k is not None}
+    _unnamed = any(k is None for k, _ in unusable)
+    unusable_kinds = _rest if _unnamed and unusable else (_rest & _named)
+    absent_kinds = _rest - unusable_kinds
 
     parts: list[str] = []
     if refused_kinds:
@@ -2935,6 +3064,18 @@ def _check_scheduled_claude_reviewed_head(
             f"commit. Routines are generally not re-run when a later push moves the head, "
             f"so waiting is unlikely to clear this on its own: re-run against the current "
             f"head and post the marker yourself."
+        )
+    if unusable_kinds:
+        detail = "; ".join(
+            f"[{k or 'no kind named'}] {r}" for k, r in unusable[:4]
+        ) + (f" (+{len(unusable) - 4} more)" if len(unusable) > 4 else "")
+        parts.append(
+            f"{', '.join(sorted(unusable_kinds))} — a marker block IS present on this "
+            f"PR but is UNUSABLE, so it counts for nothing: {detail}. This is NOT "
+            f"'nobody posted anything', and waiting cannot clear it — re-post the "
+            f"marker in the exact form below. "
+            f"`git_push_guard.py --emit-marker {pr_num} --kind <name>` prints one with "
+            f"the head read from GitHub, so the sha is never retyped."
         )
     if absent_kinds:
         parts.append(
@@ -5011,4 +5152,31 @@ if __name__ == "__main__":
             )
             sys.exit(2)
         sys.exit(check_pr_report(sys.argv[2], repo=_repo))
+    # Producer mode: `git_push_guard.py --emit-marker <N> --kind <name> [--repo O/R]`
+    # prints the scheduled-review marker for that PR's CURRENT head, so the 40-hex
+    # sha is read rather than retyped. See emit_scheduled_review_marker.
+    if len(sys.argv) >= 3 and sys.argv[1] == "--emit-marker":
+        _rest = sys.argv[3:]
+        _repo = _parse_check_pr_repo(_rest)
+        if _repo is _CHECK_PR_REPO_EMPTY:
+            print(
+                "ERROR: --repo/-R was given an empty value. Specify OWNER/REPO, or "
+                "omit the option to use the current repository.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        _kind = None
+        for _i, _a in enumerate(_rest):
+            if _a == "--kind" and _i + 1 < len(_rest):
+                _kind = _rest[_i + 1]
+            elif _a.startswith("--kind="):
+                _kind = _a.split("=", 1)[1]
+        if not _kind:
+            print(
+                "ERROR: --emit-marker needs --kind <name>. Known kinds: "
+                f"{', '.join(_KNOWN_SCHEDULED_REVIEW_KINDS)}.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        sys.exit(emit_scheduled_review_marker(sys.argv[2], kind=_kind, repo=_repo))
     run_guard(main, "git_push_guard")

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2754,9 +2754,13 @@ def _scheduled_review_rows(pr_num: str, repo: str | None = None) -> list[dict] |
                     "--paginate",
                     "--jq",
                     ".[] | {login: .user.login, author_association: .author_association, "
-                    "body: .body, state: .state, created_at: (.created_at // .submitted_at)}",
-                    # .state present on reviews, null on issue comments; the timestamp field
-                    # differs per endpoint and is what lets the scan order rows ACROSS them
+                    "body: .body, state: .state, "
+                    "stamp: (.updated_at // .submitted_at // .created_at)}",
+                    # .state present on reviews, null on issue comments. `stamp` is the LAST
+                    # MODIFICATION: issue comments are editable and an edit that adds a
+                    # finding must sort by when it was written, not when the comment was
+                    # created. Review bodies expose only submitted_at (an edited review body
+                    # keeps its original stamp -- documented residue in the scan).
                 ],
                 capture_output=True,
                 text=True,
@@ -2872,10 +2876,15 @@ def _scheduled_review_marker_scan(
     # (neither). The verdict for the pair is resolved AFTER the loop from this list -- see
     # there for the rule and why the order matters.
     stmts: dict[tuple[str, str], list[str]] = {}
-    # Chronology: the API rows carry created_at/submitted_at; the two endpoints are fetched
-    # separately, so without sorting a review could sort before a comment posted after it.
-    # Rows without a timestamp (the test seam) keep list order -- the sort is stable.
-    rows = sorted(rows, key=lambda r: (r.get("created_at") or ""))
+    # Chronology: rows carry `stamp` = last modification (updated_at for issue comments,
+    # which are editable; submitted_at for reviews). The two endpoints are fetched
+    # separately, so without sorting a review could sort before a comment posted after
+    # it; and sorting by CREATION would let a finding edited into an old comment lose
+    # to a verdict posted before the edit. Rows without a stamp (the test seam) keep list
+    # order -- the sort is stable. Residue, stated: an edited REVIEW body has no edit
+    # timestamp in the API, so a finding added by editing a review keeps the review's
+    # original position.
+    rows = sorted(rows, key=lambda r: (r.get("stamp") or r.get("created_at") or ""))
     for row in rows:
         body = row.get("body") or ""
         # Blocks are parsed BEFORE the trust checks, so a row about to be dropped can
@@ -3052,6 +3061,13 @@ def _scheduled_review_marker_scan(
         decisive = [v for v in seq if v != "plain"]
         final = decisive[-1] if decisive else "plain"
         (rejected if final == "refused" else accepted).setdefault(h, set()).add(k)
+        # The verdict maps are SETS, so repeated statements collapsed to one rendered row
+        # and the report said one block where several were observed. Every repeat is a row.
+        same = seq.count(final) - 1 if final != "plain" else seq.count("plain") - 1
+        if same > 0:
+            unusable.append(
+                (k, f"{same} further block(s) at this head repeating the same statement", True)
+            )
         if final == "refused":
             n_plain = seq.count("plain")
             if n_plain:

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1457,11 +1457,30 @@ class TestAnUnusableMarkerIsNotReportedAsAbsent:
             f"full head this message also prints: {msg}"
         )
 
-    def test_a_marker_with_no_kind_is_reported_as_unusable(self, monkeypatch):
+    def test_a_marker_with_no_kind_is_reported_but_claims_no_kind(self, monkeypatch):
+        """Reported, yes. Attributed to a required review, no.
+
+        REWRITTEN, and worth saying why rather than quietly relaxing it. The first
+        version asserted this block produced an "unusable" bullet AND suppressed the
+        waiting guidance. Both were wrong, and review caught it: a block naming no
+        kind cannot be credited to any particular review, so attaching it to `leaks`
+        would have told the owner to post a leak marker on the strength of a block
+        that never mentioned leaks -- and a hand-written marker satisfies the one
+        gate this repository calls irreducible.
+
+        The corrected behaviour reports the block as UNSCOPED and leaves every
+        unidentified kind in its own true state. Here nothing else has been posted
+        for `leaks`, so its true state is absent, and absent legitimately carries the
+        in-flight guidance. The assertion that used to forbid that wording was
+        encoding the bug.
+        """
         body = f"scan done.\n<!-- genesis-scheduled-review: head={HEAD} -->"
         msg = self._block_msg(monkeypatch, self._row(body)).lower()
-        assert "unusable" in msg or "could not be parsed" in msg
-        assert "may still be in flight" not in msg
+        assert "unscoped" in msg, "a block that names no kind must still be reported"
+        assert "leaks — a marker block is present" not in msg, (
+            "the kindless block was credited to leaks; following that guidance would "
+            "satisfy the irreducible gate with no leak review behind it"
+        )
 
     def test_a_marker_from_a_non_owner_is_reported_not_silently_dropped(self, monkeypatch):
         """Untrusted is the CORRECT verdict; silent is not. Someone posted a marker.
@@ -1555,3 +1574,144 @@ class TestTheGateCanEmitAMarkerItWillItselfAccept:
         rc, cap = self._emit(monkeypatch, capsys, kind="Not A Kind")
         assert rc != 0
         assert "genesis-scheduled-review" not in cap.out
+
+
+class TestAnUnusableMarkerRemedyMatchesItsCause:
+    """Naming a marker unusable is only half the job; the REMEDY has to match WHY.
+
+    The first version of this feature had one remedy -- "re-post the marker" -- and
+    applied it to every cause. That is right for exactly one of them. For the rest it
+    tells the owner to hand-write an attestation for a review that never ran, never
+    finished, or ran and BLOCKED. Following it would satisfy the gate the repository
+    calls irreducible without the scan behind it ever happening. A diagnostic that
+    makes the message more informative and the outcome less safe is a bad trade, and
+    that is what review found here.
+
+    So the causes split in two:
+      GRAMMAR ONLY -- the owner posted it, the body is clean, only the marker text is
+        malformed. A trusted clean review really did happen. Re-post it.
+      NO TRUSTED CLEAN REVIEW -- posted by someone else, carried by a dismissed
+        review, or carrying a blocking finding. Minting a marker here would be a lie.
+        Run the review; resolve the finding.
+    """
+
+    BLOCKING = "[P1] a real finding that has not been resolved"
+
+    @staticmethod
+    def _row(body, *, login="owner", author_association="OWNER", state=None):
+        row = {"login": login, "author_association": author_association, "body": body}
+        if state is not None:
+            row["state"] = state
+        return json.dumps(row)
+
+    @staticmethod
+    def _marker(head=HEAD, kind="leaks"):
+        parts = [f"head={head}"] if head else []
+        if kind:
+            parts.append(f"kind={kind}")
+        return "<!-- genesis-scheduled-review: " + " ".join(parts) + " -->"
+
+    def _msg(self, monkeypatch, comments, required="leaks", repo="acme/pub"):
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", comments)
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", required)
+        msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo=repo)
+        assert msg, "a head without an ACCEPTED marker must still block"
+        return msg
+
+    # ---- P1: a block naming no kind must not claim a required one ----------
+    def test_a_kindless_block_does_not_claim_the_irreducible_kind(self, monkeypatch):
+        """Otherwise the guidance invites minting a leak attestation that nothing ran."""
+        body = "scan done.\n" + self._marker(kind=None)
+        msg = self._msg(monkeypatch, self._row(body), required="code-review,leaks")
+        assert "unscoped" in msg.lower() or "does not say which" in msg.lower(), msg
+        assert "leaks — a marker block IS present" not in msg, (
+            "a block naming no kind was attributed to leaks; following that guidance "
+            "would satisfy the irreducible gate with no leak review"
+        )
+
+    # ---- P1: untrusted causes must not be answered with "re-post it" -------
+    def test_a_non_owner_marker_is_not_answered_by_minting_one(self, monkeypatch):
+        body = "scan done.\n" + self._marker()
+        msg = self._msg(
+            monkeypatch, self._row(body, login="drive-by", author_association="CONTRIBUTOR")
+        )
+        assert "drive-by" in msg
+        assert "run" in msg.lower() and "review" in msg.lower()
+        assert "--emit-marker" not in msg, (
+            "the emitter mints an attestation and performs no review; offering it here "
+            "turns an untrusted marker into a passing gate"
+        )
+
+    def test_a_dismissed_review_is_not_answered_by_minting_one(self, monkeypatch):
+        body = "scan done.\n" + self._marker()
+        msg = self._msg(monkeypatch, self._row(body, state="DISMISSED"))
+        assert "dismissed" in msg.lower()
+        assert "--emit-marker" not in msg
+
+    def test_a_blocking_body_with_a_malformed_marker_keeps_its_verdict(self, monkeypatch):
+        """The sharpest case: a real finding, plus a typo, must not become a typo."""
+        body = f"{self.BLOCKING}\n" + self._marker(head=HEAD[:8])
+        msg = self._msg(monkeypatch, self._row(body))
+        assert "blocking" in msg.lower(), msg
+        assert "--emit-marker" not in msg, (
+            "re-posting a clean marker over an unresolved blocking finding makes the "
+            "gate pass while the finding stands"
+        )
+
+    # ---- CONTROL: the one cause the original remedy WAS right for ---------
+    def test_a_grammar_only_marker_still_gets_the_re_post_remedy(self, monkeypatch):
+        """Without this, an implementation that refused to help anyone would pass
+        every assertion above while making the feature useless."""
+        body = "scan done, all clean.\n" + self._marker(head=HEAD[:8])
+        msg = self._msg(monkeypatch, self._row(body))
+        assert f"'{HEAD[:8]}'" in msg, "the malformed value must still be quoted"
+        assert "--emit-marker" in msg, "the grammar-only case is exactly what it is for"
+
+    # ---- P2: a pending review is in-flight, not unusable -------------------
+    def test_a_pending_review_keeps_the_waiting_guidance(self, monkeypatch):
+        """A pending review is an unpublished draft that can still be submitted, so
+        waiting CAN make it count -- the one thing the unusable wording denies."""
+        body = "scan done.\n" + self._marker()
+        msg = self._msg(monkeypatch, self._row(body, state="PENDING")).lower()
+        assert "may still be in flight" in msg
+
+    # ---- P2: a current malformed marker beats stale marker history --------
+    def test_a_current_unusable_marker_outranks_a_stale_valid_one(self, monkeypatch):
+        rows = "\n".join(
+            [
+                self._row("older run.\n" + self._marker(head=OTHER_HEAD)),
+                self._row("current run.\n" + self._marker(head=HEAD[:8])),
+            ]
+        )
+        msg = self._msg(monkeypatch, rows)
+        assert f"'{HEAD[:8]}'" in msg, (
+            "the malformed CURRENT marker is the actionable one and was hidden behind "
+            "the stale-head explanation"
+        )
+
+    # ---- P2: the suggested command must actually run -----------------------
+    def test_the_suggested_command_is_runnable_and_keeps_the_repo(self, monkeypatch):
+        body = "scan done, all clean.\n" + self._marker(head=HEAD[:8])
+        msg = self._msg(monkeypatch, self._row(body))
+        assert "python3 scripts/hooks/git_push_guard.py --emit-marker" in msg, (
+            "the file is tracked non-executable and is not on PATH, so a bare "
+            "invocation is command-not-found"
+        )
+        assert "--repo acme/pub" in msg, (
+            "run from another checkout, an emitter without --repo resolves the PR "
+            "number in the wrong repository"
+        )
+
+    # ---- P2: show the detail that belongs to THIS group -------------------
+    def test_the_detail_shown_belongs_to_the_kind_being_explained(self, monkeypatch):
+        """Truncating the global list first hid the one value that mattered."""
+        noise = [
+            self._row(f"run {i}.\n" + self._marker(head=HEAD[:8], kind="code-review"))
+            for i in range(4)
+        ]
+        rows = "\n".join([*noise, self._row("leaks run.\n" + self._marker(head=HEAD[:6]))])
+        msg = self._msg(monkeypatch, rows, required="leaks")
+        assert f"'{HEAD[:6]}'" in msg, (
+            "the leaks bullet showed four unrelated code-review reasons and hid its own"
+        )

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -2299,3 +2299,29 @@ class TestChronologyComesFromTimestampsNotFetchOrder:
     def test_the_reverse_order_passes(self, monkeypatch):
         """CONTROL: same rows, timestamps swapped -> the verdict is later and clears it."""
         assert self._gate(monkeypatch, self._rows("2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z")) is None
+
+    def test_an_EDITED_older_comment_is_ordered_by_its_edit(self, monkeypatch):
+        """Issue comments are editable. An owner can add a [P1] to an OLD comment after
+        posting a later verdict; ordering by creation would let the verdict win over a
+        finding that was in fact written after it. Rows carry `stamp` = last modification."""
+        m = f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
+        rows = "\n".join(
+            [
+                json.dumps({"login": "owner", "author_association": "OWNER",
+                            "body": "[P1] added on edit\n" + m,
+                            "created_at": "2026-01-01T00:00:00Z", "stamp": "2026-01-03T00:00:00Z"}),
+                json.dumps({"login": "owner", "author_association": "OWNER",
+                            "body": "VERDICT: PASS\n" + m,
+                            "created_at": "2026-01-02T00:00:00Z", "stamp": "2026-01-02T00:00:00Z"}),
+            ]
+        )
+        assert self._gate(monkeypatch, rows), "an edited-in finding was ordered by creation and lost"
+
+    def test_duplicate_statements_each_get_a_row(self, monkeypatch):
+        """Two accepted owner markers for the same stale (head, kind) are two blocks;
+        the verdict maps are sets and collapsed them into one row."""
+        m = f"<!-- genesis-scheduled-review: head={OTHER_HEAD} kind=leaks -->"
+        rows = "\n".join([json.dumps({"login": "owner", "author_association": "OWNER", "body": f"run {i}.\n" + m}) for i in range(2)])
+        msg = self._gate(monkeypatch, rows)
+        assert msg
+        assert "leaks — 2 marker block(s) found" in msg, msg

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -815,6 +815,40 @@ class TestCheckPrReportFreshnessLabel:
         )
         assert "ok (current)" in out
 
+    def test_the_scheduled_row_renders_its_per_cause_tail(self, monkeypatch, capsys):
+        """The canonical report printed only line 0 of the scheduled-review message.
+
+        Line 0 is the summary, and its `present: none` clause is the exact string an
+        operator was measured acting wrongly on — read as "nothing was posted", waited,
+        while the marker sat in the thread. Every per-cause bullet lives on lines 1+, so
+        printing line 0 alone made the entire diagnosis invisible on the one surface
+        where the mistake is actually made. The sibling `pin-receipts` row already
+        rendered its tail; this asserts the scheduled row does too.
+        """
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            json.dumps(
+                {
+                    "login": "drive-by",
+                    "author_association": "CONTRIBUTOR",
+                    "body": f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->",
+                }
+            ),
+        )
+        out = self._run_report(
+            monkeypatch,
+            capsys,
+            reviews=_reviews_jsonl(HEAD),
+            compare=_compare_json("identical"),
+        )
+        assert "scheduled-claude: BLOCK" in out
+        assert "drive-by" in out, (
+            "the per-cause bullet never reached the canonical report, so the whole "
+            f"diagnosis is invisible where the operator reads it:\n{out}"
+        )
+
 
 class TestMergeDeadline:
     """Codex P1 #1373: _gh_timeout bounds the AGGREGATE merge-path gh time under the
@@ -1501,19 +1535,45 @@ class TestAnUnusableMarkerIsNotReportedAsAbsent:
         path, so `"owner" in msg` is true whether or not this branch exists. That is
         the assertion-also-true-on-the-success-path shape, and it was the first draft
         of this very test.
+
+        REWRITTEN, and the reason is recorded rather than the line quietly relaxed.
+        This test used to ALSO assert the waiting guidance was suppressed. That is the
+        same defect a sibling test on this class had already been rewritten to remove:
+        `test_a_marker_with_no_kind_is_reported_but_claims_no_kind` records that a block
+        which cannot be credited "leaves every unidentified kind in its own true state",
+        and that "absent legitimately carries the in-flight guidance. The assertion that
+        used to forbid that wording was encoding the bug." An untrusted block is that
+        same shape reached by a different route — it says who posted it, and nothing
+        whatever about whether a review has run. On a PUBLIC repository the old
+        behaviour meant one comment from any account deleted the guidance a freshly
+        opened PR needs, which is the branch that exists to stop an operator reaching
+        for an override on the irreducible gate.
         """
         body = f"scan done.\n<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
         msg = self._block_msg(
             monkeypatch, self._row(body, login="drive-by", author_association="CONTRIBUTOR")
         )
         assert "drive-by" in msg, "the untrusted author must be named"
-        assert "may still be in flight" not in msg.lower()
+        assert "may still be in flight" in msg.lower(), (
+            "an untrusted block consumed the kind's true state; nothing trustworthy has "
+            f"run for leaks, so the waiting guidance must survive:\n{msg}"
+        )
 
     def test_a_marker_in_a_dismissed_review_is_reported(self, monkeypatch):
+        """Same rewrite, same precedent, reached by review STATE rather than authorship.
+
+        A dismissed review says only that IT no longer vouches. Whether anything has run
+        for this kind is a separate question it does not answer, so the kind keeps its
+        own state and its own advice. Contrast the stale-PENDING case below, which DOES
+        supersede: there the block genuinely reports on this kind's status.
+        """
         body = f"scan done.\n<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
         msg = self._block_msg(monkeypatch, self._row(body, state="DISMISSED")).lower()
         assert "dismissed" in msg
-        assert "may still be in flight" not in msg
+        assert "may still be in flight" in msg, (
+            "a dismissed review consumed the kind's true state, deleting the guidance "
+            f"for a review that has not run:\n{msg}"
+        )
 
     def test_a_GENUINELY_absent_marker_still_advises_waiting(self, monkeypatch):
         """CONTROL. Without this, an implementation that called EVERYTHING unusable
@@ -1531,60 +1591,6 @@ class TestAnUnusableMarkerIsNotReportedAsAbsent:
             monkeypatch, self._row("I will post the genesis-scheduled-review marker shortly.")
         ).lower()
         assert "may still be in flight" in msg
-
-
-class TestTheGateCanEmitAMarkerItWillItselfAccept:
-    """PREVENT, not just diagnose.
-
-    Every marker is hand-authored: nothing in this repository emitted one, so the
-    40-hex contract lived only in a regex on the consumer side and in prose asking a
-    human to copy a sha correctly. That is the shape that produced the abbreviated
-    head above.
-
-    These tests pin the ROUND TRIP -- what the emitter prints is fed back through the
-    real scan and must be ACCEPTED. Producer and consumer therefore cannot drift:
-    a change to either regex that the emitter does not satisfy fails here.
-    """
-
-    def _emit(self, monkeypatch, capsys, head=HEAD, kind="leaks"):
-        monkeypatch.setenv("_TEST_GH_HEAD_SHA", head)
-        rc = _mod.emit_scheduled_review_marker("1", kind=kind, repo="acme/pub")
-        return rc, capsys.readouterr()
-
-    def test_the_emitted_marker_round_trips_through_the_real_scan(self, monkeypatch, capsys):
-        rc, cap = self._emit(monkeypatch, capsys)
-        assert rc == 0
-        marker = cap.out.strip()
-        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
-        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
-        monkeypatch.setenv(
-            "_TEST_GH_SCHEDULED_COMMENTS",
-            json.dumps({"login": "owner", "author_association": "OWNER", "body": marker}),
-        )
-        assert (
-            _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub") is None
-        ), f"the gate rejected its own emitter's output: {marker!r}"
-
-    def test_it_emits_the_full_forty_hex_head(self, monkeypatch, capsys):
-        _, cap = self._emit(monkeypatch, capsys)
-        assert f"head={HEAD}" in cap.out
-        assert f"head={HEAD[:8]} " not in cap.out
-
-    def test_it_refuses_rather_than_emitting_an_unusable_marker(self, monkeypatch, capsys):
-        """If the head cannot be read, printing a marker with a blank or partial head
-        would manufacture exactly the defect this change exists to remove."""
-        monkeypatch.setenv("_TEST_GH_HEAD_SHA", "")
-        rc = _mod.emit_scheduled_review_marker("1", kind="leaks", repo="acme/pub")
-        cap = capsys.readouterr()
-        assert rc != 0
-        assert "genesis-scheduled-review" not in cap.out
-
-    def test_it_refuses_a_kind_the_gate_could_never_accept(self, monkeypatch, capsys):
-        """A kind outside the marker grammar can never satisfy the gate, so emitting
-        it would hand the operator a marker that silently does nothing."""
-        rc, cap = self._emit(monkeypatch, capsys, kind="Not A Kind")
-        assert rc != 0
-        assert "genesis-scheduled-review" not in cap.out
 
 
 BLOCKING_PROSE = "[P1] a real finding that has not been resolved"
@@ -1917,39 +1923,49 @@ class TestTheReportReadsEveryFieldPermissively:
             f"the block DOES carry a kind= field; the gate merely refused it:\n{msg}"
         )
 
-    def test_a_status_suffixed_kind_does_not_advise_waiting(self, monkeypatch):
-        """The second false statement, and the more expensive one.
+    def test_a_status_suffixed_value_says_what_the_suffix_MEANS(self, monkeypatch):
+        """Naming only the grammar problem is an instruction to strip the suffix.
 
-        A failed run is the state where the operator most needs to hear "it ran and
-        failed" -- and instead heard "no marker at ANY head yet, waiting IS the right
-        move", which is the precise misdiagnosis this whole change exists to end.
+        A reader who follows "its kind is not a bare review name" produces a
+        well-formed marker attesting to a run that reported its own FAILURE, on the
+        gate this repository calls irreducible. The message must therefore say what
+        the suffix means, not merely that the grammar refused it.
+
+        Both fields reach this branch by different routes and both are asserted here:
+        fixing only the one a review happened to name is how this class recurs.
+        """
+        for value, mk in (
+            ("leaks/failed", lambda: self._marker(kind="leaks/failed")),
+            (f"{HEAD}/failed", lambda: self._marker(head=f"{HEAD}/failed")),
+        ):
+            msg = self._msg(monkeypatch, self._row("run failed.\n" + mk()))
+            assert msg, value
+            assert f"'{value}'" in msg, f"{value}: the operator's own text must be quoted:\n{msg}"
+            assert "did NOT complete cleanly" in msg, (
+                f"{value}: the message named the grammar problem only, which reads as "
+                f"'strip the suffix' and yields a marker vouching for a failed run:\n{msg}"
+            )
+
+    def test_a_refused_value_is_credited_to_no_review(self, monkeypatch):
+        """CONTROL for the reverted attribution, and it is the load-bearing one.
+
+        An earlier revision read `leaks/failed` as naming `leaks`, on the reasoning
+        that it says so unambiguously. That let a FAILED run occupy the kind and, via
+        the state rule, suppress the bullet reporting a real review on an earlier
+        commit — so a failed run outranked history that an untrusted stranger's marker
+        was not allowed to outrank. A value the strict grammar refuses now names
+        nothing, and `leaks` keeps its own true state.
+
+        Asserted for a value whose stem IS a real kind (`leaks/failed`), because that
+        is the one an attributing implementation would credit; a near-miss stem would
+        pass on both implementations and prove nothing.
         """
         msg = self._msg(monkeypatch, self._row("run failed.\n" + self._marker(kind="leaks/failed")))
         assert msg
-        assert "may still be in flight" not in msg.lower(), (
-            f"a routine that RAN was reported as never having been posted:\n{msg}"
-        )
-
-    def test_a_near_miss_kind_is_still_NOT_attributed(self, monkeypatch):
-        """CONTROL, and it guards a deliberate earlier refusal rather than a wording.
-
-        Reading `leaks/failed` as `leaks` is an exact match on the segment before the
-        suffix, not a resemblance judgement. `leak` is a resemblance judgement, and
-        attributing it was declined in review because a guessed kind steers the reader
-        toward vouching for a review that never ran. Without this control the permissive
-        read above could quietly widen into exactly that.
-
-        The value is `leak/failed`, NOT a bare `leak`, and the difference is the whole
-        point: a bare `leak` is matched by the STRICT expression and never reaches the
-        permissive branch at all, so a control written that way passes identically on
-        an implementation that guesses. This one drives the branch under test.
-        """
-        msg = self._msg(monkeypatch, self._row("bad run.\n" + self._marker(kind="leak/failed")))
-        assert msg
-        assert "'leak/failed'" in msg, f"the value the operator wrote must be quoted:\n{msg}"
+        assert "'leaks/failed'" in msg, f"the block must still be REPORTED:\n{msg}"
         assert "may still be in flight" in msg.lower(), (
-            "an unrecognisable kind was CREDITED to the required review it merely "
-            f"resembles; leaks has no marker and must still read as absent:\n{msg}"
+            "a refused value was credited to the review it names; leaks has no usable "
+            f"marker and must keep its own state:\n{msg}"
         )
 
     def test_an_uppercase_head_is_reported_as_case_not_as_length(self, monkeypatch):
@@ -2001,4 +2017,49 @@ class TestTheReportReadsEveryFieldPermissively:
         assert "dismissed" in msg.lower(), f"the dismissed block must be reported:\n{msg}"
         assert OTHER_HEAD[:12] in msg, (
             f"a dismissed review erased the trusted older-head evidence:\n{msg}"
+        )
+
+    def test_an_untrusted_block_does_not_erase_the_ABSENT_guidance(self, monkeypatch):
+        """The same rule on its OTHER consuming branch, and the reason it is one rule.
+
+        Gating only the history branch left this one open: on a freshly-opened PR where
+        the routine genuinely has not run, a single comment from any account deleted
+        "nothing has run yet, waiting is right" — the branch whose whole purpose is to
+        stop an operator reaching for an override on the irreducible gate. On a public
+        repository the trigger is one comment from anybody.
+        """
+        msg = self._msg(
+            monkeypatch,
+            self._row(
+                self._marker(head=HEAD), login="drive-by", author_association="CONTRIBUTOR"
+            ),
+        )
+        assert msg
+        assert "drive-by" in msg, f"the untrusted block must still be reported:\n{msg}"
+        assert "may still be in flight" in msg.lower(), (
+            "an untrusted comment consumed the kind's true state and deleted the "
+            f"waiting guidance a fresh PR needs:\n{msg}"
+        )
+
+    def test_an_owner_repairable_marker_DOES_still_outrank_history(self, monkeypatch):
+        """POSITIVE CONTROL for the rule above, without which it could be inert.
+
+        "Only a repairable block consumes a kind's state" is satisfied just as well by
+        an implementation where NOTHING consumes it — every test above would still pass
+        while the outranking this rule exists to preserve was silently gone. Here the
+        owner's own one-character typo sits at head, and the history bullet must yield
+        to it, because "fix this one" is then the whole of the advice.
+        """
+        rows = "\n".join(
+            [
+                self._row("older run.\n" + self._marker(head=OTHER_HEAD)),
+                self._row("scan done.\n" + self._marker(head=HEAD[:8])),
+            ]
+        )
+        msg = self._msg(monkeypatch, rows)
+        assert msg
+        assert f"'{HEAD[:8]}'" in msg, f"the repairable typo must be reported:\n{msg}"
+        assert OTHER_HEAD[:12] not in msg, (
+            "an owner-repairable marker at head no longer outranks stale history, so "
+            f"the trust rule has become inert rather than selective:\n{msg}"
         )

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1383,3 +1383,175 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         assert "kind=" in msg
         assert "# scheduled-review-override" in msg
         assert "leaks" in msg
+
+
+SHORT_HEAD = HEAD[:8]
+
+
+class TestAnUnusableMarkerIsNotReportedAsAbsent:
+    """A marker BLOCK that is present but does not parse must not read as "nobody
+    posted anything".
+
+    MEASURED on a live PR, 2026-08-29. A leaks marker was posted whose machine
+    field carried an ABBREVIATED head (8 hex, not 40). ``_SCHEDULED_REVIEW_HEAD_RE``
+    requires the full 40, so the block matched, the head did not, and the marker was
+    dropped before it reached EITHER map. The gate then printed ``present: none`` and
+    routed the kind into ABSENT -- whose advice is that a routine "may still be in
+    flight, and waiting IS the right move". No amount of waiting could clear it; the
+    marker needed re-posting. The advice was not merely unhelpful, it was the exact
+    opposite of the remedy.
+
+    The partition this extends already documents THREE causes and calls itself total.
+    It is total over markers that PARSE. The parse discards a block before the
+    partition can see it, which is the same "decided from part of what had been read"
+    shape the function's own comment says three prior findings had -- one level up,
+    in the scan rather than in the branching.
+
+    Every test here asserts what its branch advises AND that it does not carry the
+    absent-branch advice, matching the convention above: a reworded regression that
+    flips the guidance fails instead of sliding through on surviving substrings.
+    """
+
+    @staticmethod
+    def _row(body, *, login="owner", author_association="OWNER", state=None):
+        row = {"login": login, "author_association": author_association, "body": body}
+        if state is not None:
+            row["state"] = state
+        return json.dumps(row)
+
+    def _block_msg(self, monkeypatch, comments):
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", comments)
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+        msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+        assert msg, "a head without an ACCEPTED marker must still block"
+        return msg
+
+    def test_an_abbreviated_head_is_reported_as_unusable(self, monkeypatch):
+        """The measured case: the operator did post one, and needs to know."""
+        body = f"scan done.\n<!-- genesis-scheduled-review: head={SHORT_HEAD} kind=leaks -->"
+        msg = self._block_msg(monkeypatch, self._row(body))
+        assert "unusable" in msg.lower() or "could not be parsed" in msg.lower(), msg
+
+    def test_an_abbreviated_head_does_not_advise_waiting(self, monkeypatch):
+        """The failure this exists to prevent -- and the one that actually happened."""
+        body = f"scan done.\n<!-- genesis-scheduled-review: head={SHORT_HEAD} kind=leaks -->"
+        msg = self._block_msg(monkeypatch, self._row(body)).lower()
+        assert "may still be in flight" not in msg
+        assert "waiting is the right move" not in msg
+
+    def test_the_offending_value_is_quoted_so_the_typo_is_visible(self, monkeypatch):
+        """Naming the cause without showing the value leaves the operator guessing
+        which of several markers on a long thread is the broken one.
+
+        Asserts the QUOTED form. A bare `SHORT_HEAD in msg` passes on the unfixed
+        code, because the abbreviated head is by construction a PREFIX of the full
+        head the closing grammar line already prints — so the substring is present
+        whether or not this branch exists. Verify-RED caught it: this test went green
+        before the fix was written.
+        """
+        body = f"scan done.\n<!-- genesis-scheduled-review: head={SHORT_HEAD} kind=leaks -->"
+        msg = self._block_msg(monkeypatch, self._row(body))
+        assert f"'{SHORT_HEAD}'" in msg, (
+            "the malformed head must be quoted, so it is distinguishable from the "
+            f"full head this message also prints: {msg}"
+        )
+
+    def test_a_marker_with_no_kind_is_reported_as_unusable(self, monkeypatch):
+        body = f"scan done.\n<!-- genesis-scheduled-review: head={HEAD} -->"
+        msg = self._block_msg(monkeypatch, self._row(body)).lower()
+        assert "unusable" in msg or "could not be parsed" in msg
+        assert "may still be in flight" not in msg
+
+    def test_a_marker_from_a_non_owner_is_reported_not_silently_dropped(self, monkeypatch):
+        """Untrusted is the CORRECT verdict; silent is not. Someone posted a marker.
+
+        Asserts the AUTHOR is named, not merely that the word "owner" appears: the
+        block message's closing grammar line already says "by the repo OWNER" on every
+        path, so `"owner" in msg` is true whether or not this branch exists. That is
+        the assertion-also-true-on-the-success-path shape, and it was the first draft
+        of this very test.
+        """
+        body = f"scan done.\n<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
+        msg = self._block_msg(
+            monkeypatch, self._row(body, login="drive-by", author_association="CONTRIBUTOR")
+        )
+        assert "drive-by" in msg, "the untrusted author must be named"
+        assert "may still be in flight" not in msg.lower()
+
+    def test_a_marker_in_a_dismissed_review_is_reported(self, monkeypatch):
+        body = f"scan done.\n<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
+        msg = self._block_msg(monkeypatch, self._row(body, state="DISMISSED")).lower()
+        assert "dismissed" in msg
+        assert "may still be in flight" not in msg
+
+    def test_a_GENUINELY_absent_marker_still_advises_waiting(self, monkeypatch):
+        """CONTROL. Without this, an implementation that called EVERYTHING unusable
+        would pass every assertion above while destroying the one case where patience
+        is the correct answer -- the exact regression the three-way partition was
+        built to prevent."""
+        msg = self._block_msg(monkeypatch, "").lower()
+        assert "may still be in flight" in msg
+        assert "waiting is the right move" in msg
+
+    def test_prose_mentioning_the_marker_without_one_is_still_absent(self, monkeypatch):
+        """CONTROL. A comment that TALKS about markers is not a marker; only a real
+        block counts, or every review conversation would read as an unusable marker."""
+        msg = self._block_msg(
+            monkeypatch, self._row("I will post the genesis-scheduled-review marker shortly.")
+        ).lower()
+        assert "may still be in flight" in msg
+
+
+class TestTheGateCanEmitAMarkerItWillItselfAccept:
+    """PREVENT, not just diagnose.
+
+    Every marker is hand-authored: nothing in this repository emitted one, so the
+    40-hex contract lived only in a regex on the consumer side and in prose asking a
+    human to copy a sha correctly. That is the shape that produced the abbreviated
+    head above.
+
+    These tests pin the ROUND TRIP -- what the emitter prints is fed back through the
+    real scan and must be ACCEPTED. Producer and consumer therefore cannot drift:
+    a change to either regex that the emitter does not satisfy fails here.
+    """
+
+    def _emit(self, monkeypatch, capsys, head=HEAD, kind="leaks"):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", head)
+        rc = _mod.emit_scheduled_review_marker("1", kind=kind, repo="acme/pub")
+        return rc, capsys.readouterr()
+
+    def test_the_emitted_marker_round_trips_through_the_real_scan(self, monkeypatch, capsys):
+        rc, cap = self._emit(monkeypatch, capsys)
+        assert rc == 0
+        marker = cap.out.strip()
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            json.dumps({"login": "owner", "author_association": "OWNER", "body": marker}),
+        )
+        assert (
+            _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub") is None
+        ), f"the gate rejected its own emitter's output: {marker!r}"
+
+    def test_it_emits_the_full_forty_hex_head(self, monkeypatch, capsys):
+        _, cap = self._emit(monkeypatch, capsys)
+        assert f"head={HEAD}" in cap.out
+        assert f"head={HEAD[:8]} " not in cap.out
+
+    def test_it_refuses_rather_than_emitting_an_unusable_marker(self, monkeypatch, capsys):
+        """If the head cannot be read, printing a marker with a blank or partial head
+        would manufacture exactly the defect this change exists to remove."""
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", "")
+        rc = _mod.emit_scheduled_review_marker("1", kind="leaks", repo="acme/pub")
+        cap = capsys.readouterr()
+        assert rc != 0
+        assert "genesis-scheduled-review" not in cap.out
+
+    def test_it_refuses_a_kind_the_gate_could_never_accept(self, monkeypatch, capsys):
+        """A kind outside the marker grammar can never satisfy the gate, so emitting
+        it would hand the operator a marker that silently does nothing."""
+        rc, cap = self._emit(monkeypatch, capsys, kind="Not A Kind")
+        assert rc != 0
+        assert "genesis-scheduled-review" not in cap.out

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1758,3 +1758,106 @@ class TestAnUnusableMarkerRemedyMatchesItsCause:
         assert f"'{HEAD[:6]}'" in msg, (
             "the leaks bullet showed four unrelated code-review reasons and hid its own"
         )
+
+
+class TestEveryMarkerFormIsAccountedFor:
+    """The remaining shape of this feature's defects: a marker form the
+    classification does not cover falls back to "nothing was posted".
+
+    That fallback is the original bug. Each case below is a form that reached it
+    by a different route -- one parsed too well to be called malformed, one was
+    dropped for its review state, one was filtered against the wrong set. They are
+    fixed together because they are one class; fixing the reported subset would
+    leave the unreported one for the next round.
+    """
+
+    @staticmethod
+    def _row(body, **kw):
+        row = {"login": "owner", "author_association": "OWNER", "body": body}
+        row.update(kw)
+        return json.dumps(row)
+
+    @staticmethod
+    def _marker(head=HEAD, kind="leaks"):
+        parts = ([f"head={head}"] if head else []) + ([f"kind={kind}"] if kind else [])
+        return "<!-- genesis-scheduled-review: " + " ".join(parts) + " -->"
+
+    def _msg(self, monkeypatch, comments, required="leaks"):
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", comments)
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", required)
+        return _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+
+    def test_a_wellformed_marker_naming_an_unknown_kind_is_visible(self, monkeypatch):
+        """Parses perfectly, names a review nothing knows about (a singular typo).
+
+        It went into the accepted map under its own key, matched no required kind,
+        and so vanished -- the message said no marker existed at any head while the
+        block sat plainly in the thread. Being well-formed was exactly why it hid.
+        """
+        msg = self._msg(monkeypatch, self._row("scan done.\n" + self._marker(kind="leak")))
+        assert msg, "an unknown kind satisfies nothing, so this must still block"
+        assert "leak" in msg and "not a known scheduled" in msg, msg
+
+    def test_an_unknown_kind_is_NOT_attributed_to_the_kind_it_resembles(self, monkeypatch):
+        """DELIBERATELY not taken from review, and the reason is a prior finding.
+
+        Review asked that a near-miss kind also stop the required review from
+        advising that waiting may help. Doing that means deciding the block was
+        MEANT for that review -- and an earlier finding on this same PR was that an
+        unattributable block must never claim a required kind, precisely because a
+        claimed kind steers the reader toward posting a marker for a review nothing
+        vouches for. The two cannot both be satisfied without guessing intent.
+
+        Resolved toward the side with the security consequence: report both facts
+        and let the reader join them. The message says a block naming an unknown
+        review exists, and separately that the required review has no marker. Both
+        are true; neither asserts what the author meant.
+        """
+        msg = self._msg(monkeypatch, self._row("scan done.\n" + self._marker(kind="leak")))
+        assert "not a known scheduled" in msg, "the block must be visible"
+        assert "no marker at ANY head" in msg, (
+            "attributing the near-miss to the required kind is the guess a prior "
+            "finding forbade; the required kind's own state is that none was posted"
+        )
+
+    def test_a_duplicate_for_an_ALREADY_SATISFIED_kind_is_not_called_unscoped(
+        self, monkeypatch
+    ):
+        """The bullet contradicted the summary line two rows above it."""
+        rows = "\n".join(
+            [
+                self._row("clean run.\n" + self._marker(kind="leaks")),
+                self._row("dup.\n" + self._marker(head=HEAD[:8], kind="leaks")),
+            ]
+        )
+        msg = self._msg(monkeypatch, rows, required="code-review,leaks")
+        assert msg, "code-review is still missing, so this blocks"
+        assert "present: leaks" in msg, "leaks IS satisfied and the summary says so"
+        assert "unscoped" not in msg.lower(), (
+            "a duplicate for a SATISFIED required kind was reported as naming no "
+            f"required kind, contradicting the summary line above it:\n{msg}"
+        )
+
+    def test_a_pending_review_with_a_STALE_marker_does_not_advise_waiting(
+        self, monkeypatch
+    ):
+        """Submitting a draft cannot help when its marker names an older commit."""
+        msg = self._msg(
+            monkeypatch,
+            self._row("draft.\n" + self._marker(head=OTHER_HEAD), state="PENDING"),
+        )
+        assert msg
+        assert "may still be in flight" not in msg.lower(), (
+            "waiting was advised for a draft that is stale whenever it is submitted"
+        )
+
+    def test_a_pending_review_at_the_CURRENT_head_still_advises_waiting(self, monkeypatch):
+        """CONTROL. Without it, an implementation that reported every pending review
+        as unusable would pass the test above while destroying the one case where
+        submitting the draft genuinely does clear the gate."""
+        msg = self._msg(
+            monkeypatch, self._row("draft.\n" + self._marker(head=HEAD), state="PENDING")
+        )
+        assert msg
+        assert "may still be in flight" in msg.lower()

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1427,11 +1427,22 @@ class TestAnUnusableMarkerIsNotReportedAsAbsent:
         assert msg, "a head without an ACCEPTED marker must still block"
         return msg
 
-    def test_an_abbreviated_head_is_reported_as_unusable(self, monkeypatch):
-        """The measured case: the operator did post one, and needs to know."""
+    def test_an_abbreviated_head_is_reported_rather_than_treated_as_absent(self, monkeypatch):
+        """The measured case: the operator did post one, and needs to know.
+
+        Asserts the SUBSTANCE rather than a keyword. The first version matched on the
+        word "unusable" and broke when the wording changed, even though the behaviour
+        it cared about was intact -- a test that fails on a synonym is measuring the
+        sentence, not the property. What has to hold is that the malformed value is
+        shown and that the message actively denies the reading it used to give.
+        """
         body = f"scan done.\n<!-- genesis-scheduled-review: head={SHORT_HEAD} kind=leaks -->"
         msg = self._block_msg(monkeypatch, self._row(body))
-        assert "unusable" in msg.lower() or "could not be parsed" in msg.lower(), msg
+        assert f"'{SHORT_HEAD}'" in msg, "the offending value must be quoted back"
+        assert "not 'nobody posted anything'" in msg.lower(), (
+            "the report must contradict the absent reading, which is the one that "
+            "sent an operator away to wait"
+        )
 
     def test_an_abbreviated_head_does_not_advise_waiting(self, monkeypatch):
         """The failure this exists to prevent -- and the one that actually happened."""
@@ -1576,6 +1587,9 @@ class TestTheGateCanEmitAMarkerItWillItselfAccept:
         assert "genesis-scheduled-review" not in cap.out
 
 
+BLOCKING_PROSE = "[P1] a real finding that has not been resolved"
+
+
 class TestAnUnusableMarkerRemedyMatchesItsCause:
     """Naming a marker unusable is only half the job; the REMEDY has to match WHY.
 
@@ -1595,7 +1609,7 @@ class TestAnUnusableMarkerRemedyMatchesItsCause:
         Run the review; resolve the finding.
     """
 
-    BLOCKING = "[P1] a real finding that has not been resolved"
+    BLOCKING = BLOCKING_PROSE
 
     @staticmethod
     def _row(body, *, login="owner", author_association="OWNER", state=None):
@@ -1636,8 +1650,7 @@ class TestAnUnusableMarkerRemedyMatchesItsCause:
         msg = self._msg(
             monkeypatch, self._row(body, login="drive-by", author_association="CONTRIBUTOR")
         )
-        assert "drive-by" in msg
-        assert "run" in msg.lower() and "review" in msg.lower()
+        assert "drive-by" in msg, "the untrusted author must be named"
         assert "--emit-marker" not in msg, (
             "the emitter mints an attestation and performs no review; offering it here "
             "turns an untrusted marker into a passing gate"
@@ -1659,14 +1672,57 @@ class TestAnUnusableMarkerRemedyMatchesItsCause:
             "gate pass while the finding stands"
         )
 
-    # ---- CONTROL: the one cause the original remedy WAS right for ---------
-    def test_a_grammar_only_marker_still_gets_the_re_post_remedy(self, monkeypatch):
-        """Without this, an implementation that refused to help anyone would pass
-        every assertion above while making the feature useless."""
+    # ---- THE INVARIANT that makes this whole class impossible --------------
+    @pytest.mark.parametrize(
+        "label,row_kwargs,body_prefix,marker_kwargs",
+        [
+            ("grammar only", {}, "scan done, all clean.", {"head": HEAD[:8]}),
+            ("non-owner", {"login": "drive-by", "author_association": "CONTRIBUTOR"}, "x.", {}),
+            ("dismissed", {"state": "DISMISSED"}, "x.", {}),
+            ("blocking body", {}, BLOCKING_PROSE, {"head": HEAD[:8]}),
+            ("no kind", {}, "x.", {"kind": None}),
+            ("wrong kind", {}, "x.", {"head": HEAD[:8], "kind": "code-review"}),
+        ],
+    )
+    def test_no_cause_is_ever_answered_with_a_way_to_mint_a_marker(
+        self, monkeypatch, label, row_kwargs, body_prefix, marker_kwargs
+    ):
+        """The structural guarantee, replacing a remedy that kept being wrong.
+
+        Six of six blocker-class findings on the first version of this feature were
+        in its ADVICE and none in its observations, because the advice had to know
+        whether a trusted clean review existed and each branch decided that for
+        itself. A gate that explains how to write its own attestation is a gate
+        explaining how to get past itself.
+
+        So the message reports and prescribes nothing, and this asserts it for EVERY
+        cause rather than for the ones review happened to reach. A future branch that
+        reintroduces advice fails here instead of shipping and being found later.
+        """
+        body = body_prefix + "\n" + self._marker(**marker_kwargs)
+        msg = self._msg(monkeypatch, self._row(body, **row_kwargs))
+        assert "--emit-marker" not in msg, f"{label}: offered a way to mint a marker"
+        assert "re-post" not in msg.lower(), f"{label}: prescribed a remedy"
+
+    def test_the_report_still_names_the_cause(self, monkeypatch):
+        """CONTROL. Removing the advice must not remove the diagnosis -- an
+        implementation that said nothing at all would satisfy every assertion above
+        while restoring the exact silence this change was written to end."""
         body = "scan done, all clean.\n" + self._marker(head=HEAD[:8])
         msg = self._msg(monkeypatch, self._row(body))
         assert f"'{HEAD[:8]}'" in msg, "the malformed value must still be quoted"
-        assert "--emit-marker" in msg, "the grammar-only case is exactly what it is for"
+        assert "could not be counted" in msg
+        assert "not 'nobody posted anything'" in msg.lower()
+
+    def test_a_block_naming_an_unrequired_kind_is_still_reported(self, monkeypatch):
+        """A near-miss kind is the case that narrowing to named kinds broke: it
+        matched the grammar, so it was not malformed-by-field, but it belonged to no
+        required review, so it fell out of every group and the message went back to
+        claiming nothing had been posted."""
+        body = "scan done.\n" + self._marker(head=HEAD[:8], kind="code-review")
+        msg = self._msg(monkeypatch, self._row(body), required="leaks")
+        assert "unscoped" in msg.lower(), msg
+        assert f"'{HEAD[:8]}'" in msg
 
     # ---- P2: a pending review is in-flight, not unusable -------------------
     def test_a_pending_review_keeps_the_waiting_guidance(self, monkeypatch):
@@ -1688,19 +1744,6 @@ class TestAnUnusableMarkerRemedyMatchesItsCause:
         assert f"'{HEAD[:8]}'" in msg, (
             "the malformed CURRENT marker is the actionable one and was hidden behind "
             "the stale-head explanation"
-        )
-
-    # ---- P2: the suggested command must actually run -----------------------
-    def test_the_suggested_command_is_runnable_and_keeps_the_repo(self, monkeypatch):
-        body = "scan done, all clean.\n" + self._marker(head=HEAD[:8])
-        msg = self._msg(monkeypatch, self._row(body))
-        assert "python3 scripts/hooks/git_push_guard.py --emit-marker" in msg, (
-            "the file is tracked non-executable and is not on PATH, so a bare "
-            "invocation is command-not-found"
-        )
-        assert "--repo acme/pub" in msg, (
-            "run from another checkout, an emitter without --repo resolves the PR "
-            "number in the wrong repository"
         )
 
     # ---- P2: show the detail that belongs to THIS group -------------------

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1362,12 +1362,10 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         to be clean; with the verdict present, leaks is genuinely satisfied and the
         original intent of this test (no hijack by a satisfied kind) is preserved.
         """
-        # Order matters now: the owner's LATEST decisive statement governs, so the
-        # refused prose comes first and the explicit verdict clears it.
         comments = "\n".join(
             [
-                self._marker_kind(HEAD, "leaks", self.REFUSED_PROSE),
                 self._marker_kind(HEAD, "leaks", "scheduled review done.\nVERDICT: PASS"),
+                self._marker_kind(HEAD, "leaks", self.REFUSED_PROSE),
             ]
         )
         monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
@@ -2126,125 +2124,6 @@ class TestTheReportReadsEveryFieldPermissively:
             assert msg, block
             assert needle in msg, f"{block}\n{msg}"
             assert "carries no" not in msg, f"the field IS present:\n{msg}"
-class TestARefusalAtHeadIsNotLaunderedByAPlainRepost:
-    """PRE-EXISTING gate defect on the irreducible review, surfaced by adversarial review.
-
-    `not_clean` was computed PER ROW and each row chose its own map. So a second
-    owner comment at the same head — same marker, ordinary prose, no verdict line —
-    landed in `accepted` while the first row's [P1] sat in `rejected`, and the gate
-    PASSED. Nothing about the finding had changed; the head was identical.
-
-    The documented remedy for a refusal caused by prose is to re-post ending with an
-    EXPLICIT clean-verdict line, and that must keep working (control below). So the
-    rule is: at a head where this kind was refused, a later marker counts only if its
-    body carries an explicit clean verdict. A plain re-post is not an override; a
-    stated verdict is.
-    """
-
-    @staticmethod
-    def _row(body):
-        return json.dumps({"login": "owner", "author_association": "OWNER", "body": body})
-
-    @staticmethod
-    def _marker(head=HEAD):
-        return f"<!-- genesis-scheduled-review: head={head} kind=leaks -->"
-
-    def _gate(self, monkeypatch, rows):
-        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
-        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", "\n".join(rows))
-        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
-        return _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
-
-    def test_a_plain_repost_does_not_override_a_refusal_at_the_same_head(self, monkeypatch):
-        msg = self._gate(
-            monkeypatch,
-            [
-                self._row("[P1] a real leak finding\n" + self._marker()),
-                self._row("scan done.\n" + self._marker()),
-            ],
-        )
-        assert msg, "a [P1] at this head was laundered by a plain re-post of the marker"
-        assert "IS present at THIS head but was REFUSED" in msg, msg
-
-    def test_order_does_not_matter(self, monkeypatch):
-        """The refusal may arrive AFTER the plain marker (a routine posting its finding
-        late); the outcome must be the same."""
-        msg = self._gate(
-            monkeypatch,
-            [
-                self._row("scan done.\n" + self._marker()),
-                self._row("[P1] a real leak finding\n" + self._marker()),
-            ],
-        )
-        assert msg, "a later [P1] at this head was ignored because a plain marker came first"
-
-    def test_an_explicit_clean_verdict_still_overrides(self, monkeypatch):
-        """CONTROL: the documented remedy. Without it, an implementation that made every
-        refusal permanent would pass the tests above while breaking the one documented
-        way to clear a prose-tripped refusal."""
-        msg = self._gate(
-            monkeypatch,
-            [
-                self._row("The config value is not a hard block.\n" + self._marker()),
-                self._row("Re-reviewed.\nVERDICT: PASS\n" + self._marker()),
-            ],
-        )
-        assert msg is None, f"an explicit verdict line must still clear a refusal:\n{msg}"
-
-    def test_a_refusal_at_another_head_does_not_taint_this_one(self, monkeypatch):
-        """CONTROL: scoping. A [P1] on an OLDER commit is exactly what a new commit
-        fixes; a plain clean marker at the NEW head must count."""
-        msg = self._gate(
-            monkeypatch,
-            [
-                self._row("[P1] finding on the old commit\n" + self._marker(head=OTHER_HEAD)),
-                self._row("scan done.\n" + self._marker()),
-            ],
-        )
-        assert msg is None, f"a refusal at a different head must not block this one:\n{msg}"
-
-    # ---- the rule is CHRONOLOGICAL: the owner's latest decisive statement governs ----
-    def test_a_LATER_refusal_overrides_an_earlier_clean_verdict(self, monkeypatch):
-        """A clean verdict, then a re-run that posts a [P1] at the same head. The
-        newer finding is unresolved; a set-based reconcile that let any explicit
-        clean verdict win regardless of order passed the gate here."""
-        msg = self._gate(
-            monkeypatch,
-            [
-                self._row("Re-reviewed.\nVERDICT: PASS\n" + self._marker()),
-                self._row("[P1] a finding the re-run found\n" + self._marker()),
-            ],
-        )
-        assert msg, "a later [P1] at this head was overridden by an EARLIER clean verdict"
-        assert "IS present at THIS head but was REFUSED" in msg, msg
-
-    def test_a_plain_repost_after_a_clean_verdict_is_still_accepted(self, monkeypatch):
-        """CONTROL for chronology: plain rows are not decisive in either direction."""
-        msg = self._gate(
-            monkeypatch,
-            [
-                self._row("VERDICT: PASS\n" + self._marker()),
-                self._row("scan done.\n" + self._marker()),
-            ],
-        )
-        assert msg is None, msg
-
-    def test_every_row_for_the_pair_stays_in_the_inventory(self, monkeypatch):
-        """The verdict picks one statement; the report still lists all of them. A
-        plain re-post that lost to a refusal, and a refusal that lost to a later
-        verdict, must both be visible -- or the operator thinks a post never arrived."""
-        msg = self._gate(
-            monkeypatch,
-            [
-                self._row("[P1] a real leak finding\n" + self._marker()),
-                self._row("scan done.\n" + self._marker()),
-            ],
-        )
-        assert msg
-        assert "leaks — 2 marker block(s) found" in msg, msg
-        assert "plain re-post" in msg, msg
-
-
 class TestNamingProblemsKeepTheBodyVerdict:
     @staticmethod
     def _row(body):
@@ -2267,61 +2146,3 @@ class TestNamingProblemsKeepTheBodyVerdict:
         msg = self._msg(monkeypatch, f"scan.\n<!-- genesis-scheduled-review: head={HEAD} kind=LEAKS -->")
         assert "'LEAKS'" in msg and "not lowercase" in msg, msg
         assert "not a bare review name" not in msg, msg
-
-
-class TestChronologyComesFromTimestampsNotFetchOrder:
-    """Issue comments and review bodies are fetched from two endpoints and concatenated,
-    so fetch order is not time order. With timestamps present, a review posted AFTER a
-    comment must be read after it even though it arrives first in the list."""
-
-    @staticmethod
-    def _rows(p1_at, pass_at):
-        m = f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
-        return "\n".join(
-            [
-                json.dumps({"login": "owner", "author_association": "OWNER",
-                            "body": "[P1] found on re-run\n" + m, "created_at": p1_at}),
-                json.dumps({"login": "owner", "author_association": "OWNER",
-                            "body": "VERDICT: PASS\n" + m, "created_at": pass_at}),
-            ]
-        )
-
-    def _gate(self, monkeypatch, rows):
-        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
-        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", rows)
-        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
-        return _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
-
-    def test_a_later_refusal_wins_even_when_it_is_listed_first(self, monkeypatch):
-        msg = self._gate(monkeypatch, self._rows("2026-01-02T00:00:00Z", "2026-01-01T00:00:00Z"))
-        assert msg, "the refusal is the later statement by timestamp and must govern"
-
-    def test_the_reverse_order_passes(self, monkeypatch):
-        """CONTROL: same rows, timestamps swapped -> the verdict is later and clears it."""
-        assert self._gate(monkeypatch, self._rows("2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z")) is None
-
-    def test_an_EDITED_older_comment_is_ordered_by_its_edit(self, monkeypatch):
-        """Issue comments are editable. An owner can add a [P1] to an OLD comment after
-        posting a later verdict; ordering by creation would let the verdict win over a
-        finding that was in fact written after it. Rows carry `stamp` = last modification."""
-        m = f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
-        rows = "\n".join(
-            [
-                json.dumps({"login": "owner", "author_association": "OWNER",
-                            "body": "[P1] added on edit\n" + m,
-                            "created_at": "2026-01-01T00:00:00Z", "stamp": "2026-01-03T00:00:00Z"}),
-                json.dumps({"login": "owner", "author_association": "OWNER",
-                            "body": "VERDICT: PASS\n" + m,
-                            "created_at": "2026-01-02T00:00:00Z", "stamp": "2026-01-02T00:00:00Z"}),
-            ]
-        )
-        assert self._gate(monkeypatch, rows), "an edited-in finding was ordered by creation and lost"
-
-    def test_duplicate_statements_each_get_a_row(self, monkeypatch):
-        """Two accepted owner markers for the same stale (head, kind) are two blocks;
-        the verdict maps are sets and collapsed them into one row."""
-        m = f"<!-- genesis-scheduled-review: head={OTHER_HEAD} kind=leaks -->"
-        rows = "\n".join([json.dumps({"login": "owner", "author_association": "OWNER", "body": f"run {i}.\n" + m}) for i in range(2)])
-        msg = self._gate(monkeypatch, rows)
-        assert msg
-        assert "leaks — 2 marker block(s) found" in msg, msg

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1362,10 +1362,12 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         to be clean; with the verdict present, leaks is genuinely satisfied and the
         original intent of this test (no hijack by a satisfied kind) is preserved.
         """
+        # Order matters now: the owner's LATEST decisive statement governs, so the
+        # refused prose comes first and the explicit verdict clears it.
         comments = "\n".join(
             [
-                self._marker_kind(HEAD, "leaks", "scheduled review done.\nVERDICT: PASS"),
                 self._marker_kind(HEAD, "leaks", self.REFUSED_PROSE),
+                self._marker_kind(HEAD, "leaks", "scheduled review done.\nVERDICT: PASS"),
             ]
         )
         monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
@@ -1901,7 +1903,7 @@ class TestEveryMarkerFormIsAccountedFor:
         )
         assert msg
         assert "PENDING (unpublished) review naming the current head" in msg, msg
-        assert "counts only once that draft is submitted" in msg, msg
+        assert "once submitted it is read like any other block" in msg, msg
         assert "may still be in flight" not in msg.lower(), (
             "the generic note beside the specific row would say the same thing twice"
         )
@@ -2200,3 +2202,100 @@ class TestARefusalAtHeadIsNotLaunderedByAPlainRepost:
             ],
         )
         assert msg is None, f"a refusal at a different head must not block this one:\n{msg}"
+
+    # ---- the rule is CHRONOLOGICAL: the owner's latest decisive statement governs ----
+    def test_a_LATER_refusal_overrides_an_earlier_clean_verdict(self, monkeypatch):
+        """A clean verdict, then a re-run that posts a [P1] at the same head. The
+        newer finding is unresolved; a set-based reconcile that let any explicit
+        clean verdict win regardless of order passed the gate here."""
+        msg = self._gate(
+            monkeypatch,
+            [
+                self._row("Re-reviewed.\nVERDICT: PASS\n" + self._marker()),
+                self._row("[P1] a finding the re-run found\n" + self._marker()),
+            ],
+        )
+        assert msg, "a later [P1] at this head was overridden by an EARLIER clean verdict"
+        assert "IS present at THIS head but was REFUSED" in msg, msg
+
+    def test_a_plain_repost_after_a_clean_verdict_is_still_accepted(self, monkeypatch):
+        """CONTROL for chronology: plain rows are not decisive in either direction."""
+        msg = self._gate(
+            monkeypatch,
+            [
+                self._row("VERDICT: PASS\n" + self._marker()),
+                self._row("scan done.\n" + self._marker()),
+            ],
+        )
+        assert msg is None, msg
+
+    def test_every_row_for_the_pair_stays_in_the_inventory(self, monkeypatch):
+        """The verdict picks one statement; the report still lists all of them. A
+        plain re-post that lost to a refusal, and a refusal that lost to a later
+        verdict, must both be visible -- or the operator thinks a post never arrived."""
+        msg = self._gate(
+            monkeypatch,
+            [
+                self._row("[P1] a real leak finding\n" + self._marker()),
+                self._row("scan done.\n" + self._marker()),
+            ],
+        )
+        assert msg
+        assert "leaks — 2 marker block(s) found" in msg, msg
+        assert "plain re-post" in msg, msg
+
+
+class TestNamingProblemsKeepTheBodyVerdict:
+    @staticmethod
+    def _row(body):
+        return json.dumps({"login": "owner", "author_association": "OWNER", "body": body})
+
+    def _msg(self, monkeypatch, body):
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", self._row(body))
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+        return _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub") or ""
+
+    def test_an_unknown_kind_with_a_blocking_body_says_so(self, monkeypatch):
+        """Reporting only the typo invites a corrected marker over an unresolved finding
+        -- the malformed-field branch already keeps the verdict; this branch did not."""
+        msg = self._msg(monkeypatch, f"[P1] a finding\n<!-- genesis-scheduled-review: head={HEAD} kind=leak -->")
+        assert "not a known scheduled" in msg, msg
+        assert "carrying a blocking finding" in msg, msg
+
+    def test_an_uppercase_kind_is_diagnosed_as_case(self, monkeypatch):
+        msg = self._msg(monkeypatch, f"scan.\n<!-- genesis-scheduled-review: head={HEAD} kind=LEAKS -->")
+        assert "'LEAKS'" in msg and "not lowercase" in msg, msg
+        assert "not a bare review name" not in msg, msg
+
+
+class TestChronologyComesFromTimestampsNotFetchOrder:
+    """Issue comments and review bodies are fetched from two endpoints and concatenated,
+    so fetch order is not time order. With timestamps present, a review posted AFTER a
+    comment must be read after it even though it arrives first in the list."""
+
+    @staticmethod
+    def _rows(p1_at, pass_at):
+        m = f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
+        return "\n".join(
+            [
+                json.dumps({"login": "owner", "author_association": "OWNER",
+                            "body": "[P1] found on re-run\n" + m, "created_at": p1_at}),
+                json.dumps({"login": "owner", "author_association": "OWNER",
+                            "body": "VERDICT: PASS\n" + m, "created_at": pass_at}),
+            ]
+        )
+
+    def _gate(self, monkeypatch, rows):
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", rows)
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+        return _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+
+    def test_a_later_refusal_wins_even_when_it_is_listed_first(self, monkeypatch):
+        msg = self._gate(monkeypatch, self._rows("2026-01-02T00:00:00Z", "2026-01-01T00:00:00Z"))
+        assert msg, "the refusal is the later statement by timestamp and must govern"
+
+    def test_the_reverse_order_passes(self, monkeypatch):
+        """CONTROL: same rows, timestamps swapped -> the verdict is later and clears it."""
+        assert self._gate(monkeypatch, self._rows("2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z")) is None

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1349,15 +1349,22 @@ class TestScheduledGateBlockMessageBranchesOnCause:
     def test_refused_marker_for_an_already_satisfied_kind_does_not_hijack_the_message(
         self, monkeypatch
     ):
-        """A refused marker whose kind is NOT missing must not drive the remedy.
+        """A refused marker whose kind is NOT missing must not drive the message.
 
-        leaks is satisfied by a clean marker at HEAD; a second, refused leaks marker also
-        sits at HEAD; code-review is what is actually missing. Prescribing "re-post the
-        leaks marker with a verdict line" fixes nothing and leaves the real gap unguided.
+        leaks is satisfied at HEAD; a second, refused leaks marker also sits at HEAD;
+        code-review is what is actually missing. The message must be about code-review.
+
+        REWRITTEN: the satisfying marker now carries an explicit verdict line. As first
+        written it was a PLAIN clean marker beside a refused one at the same head, and
+        the test asserted the plain one won -- which is the laundering defect
+        `TestARefusalAtHeadIsNotLaunderedByAPlainRepost` closes, in the other order. A
+        refusal at a head is cleared by a stated verdict, not by whichever row happens
+        to be clean; with the verdict present, leaks is genuinely satisfied and the
+        original intent of this test (no hijack by a satisfied kind) is preserved.
         """
         comments = "\n".join(
             [
-                self._marker_kind(HEAD, "leaks"),
+                self._marker_kind(HEAD, "leaks", "scheduled review done.\nVERDICT: PASS"),
                 self._marker_kind(HEAD, "leaks", self.REFUSED_PROSE),
             ]
         )
@@ -1752,15 +1759,20 @@ class TestAnUnusableMarkerRemedyMatchesItsCause:
         assert f"'{HEAD[:8]}'" in msg
 
     # ---- P2: a pending review is in-flight, not unusable -------------------
-    def test_a_pending_review_keeps_the_waiting_guidance(self, monkeypatch):
-        """A pending review is an unpublished draft that can still be submitted, so
-        waiting CAN make it count -- the one thing the unusable wording denies."""
+    def test_a_pending_review_at_head_is_listed_as_unpublished(self, monkeypatch):
+        """REWRITTEN from "keeps the waiting guidance". A draft naming the current
+        head used to be dropped so the generic in-flight note would stand in for it;
+        the inventory lists it as its own row, which says the same thing precisely:
+        unpublished, current head, counts once submitted."""
         body = "scan done.\n" + self._marker()
-        msg = self._msg(monkeypatch, self._row(body, state="PENDING")).lower()
-        assert "may still be in flight" in msg
+        msg = self._msg(monkeypatch, self._row(body, state="PENDING"))
+        assert "PENDING (unpublished) review naming the current head" in msg, msg
 
-    # ---- P2: a current malformed marker beats stale marker history --------
-    def test_a_current_unusable_marker_outranks_a_stale_valid_one(self, monkeypatch):
+    # ---- a current malformed marker is shown BESIDE stale history ----------
+    def test_a_current_unusable_marker_is_shown_beside_stale_history(self, monkeypatch):
+        """RENAMED from "...outranks a stale valid one". It never asserted the stale
+        row was hidden, only that the current typo was shown -- and under the inventory
+        both are shown. The name said precedence; the assertion never did."""
         rows = "\n".join(
             [
                 self._row("older run.\n" + self._marker(head=OTHER_HEAD)),
@@ -1768,10 +1780,8 @@ class TestAnUnusableMarkerRemedyMatchesItsCause:
             ]
         )
         msg = self._msg(monkeypatch, rows)
-        assert f"'{HEAD[:8]}'" in msg, (
-            "the malformed CURRENT marker is the actionable one and was hidden behind "
-            "the stale-head explanation"
-        )
+        assert f"'{HEAD[:8]}'" in msg, "the malformed CURRENT marker must be shown"
+        assert OTHER_HEAD[:12] in msg, "and so must the stale history -- nothing outranks"
 
     # ---- P2: show the detail that belongs to THIS group -------------------
     def test_the_detail_shown_belongs_to_the_kind_being_explained(self, monkeypatch):
@@ -1879,15 +1889,33 @@ class TestEveryMarkerFormIsAccountedFor:
             "waiting was advised for a draft that is stale whenever it is submitted"
         )
 
-    def test_a_pending_review_at_the_CURRENT_head_still_advises_waiting(self, monkeypatch):
-        """CONTROL. Without it, an implementation that reported every pending review
-        as unusable would pass the test above while destroying the one case where
-        submitting the draft genuinely does clear the gate."""
+    def test_a_pending_review_at_the_CURRENT_head_is_listed_as_unpublished(self, monkeypatch):
+        """Was the CONTROL asserting the generic in-flight note. REWRITTEN: this was
+        the last silent drop in the scan -- a current-head draft was `continue`d so the
+        generic note would cover it, which contradicts an inventory that promises to
+        list every block. The row is the precise form of "in flight": it names the
+        draft, the head, and that submission is what makes it count. The stale-draft
+        test above still discriminates: its row says submission would NOT help."""
         msg = self._msg(
             monkeypatch, self._row("draft.\n" + self._marker(head=HEAD), state="PENDING")
         )
         assert msg
-        assert "may still be in flight" in msg.lower()
+        assert "PENDING (unpublished) review naming the current head" in msg, msg
+        assert "counts only once that draft is submitted" in msg, msg
+        assert "may still be in flight" not in msg.lower(), (
+            "the generic note beside the specific row would say the same thing twice"
+        )
+
+    def test_a_block_with_BOTH_fields_malformed_reports_both(self, monkeypatch):
+        """`head=abc kind=leaks/failed`: the old if/else reported the short sha only and
+        hid the suffix saying the run FAILED -- one repair cycle per hidden field."""
+        msg = self._msg(
+            monkeypatch,
+            self._row("run failed.\n<!-- genesis-scheduled-review: head=abc kind=leaks/failed -->"),
+        )
+        assert msg
+        assert "'abc'" in msg and "'leaks/failed'" in msg, msg
+        assert "did NOT complete cleanly" in msg, msg
 
 
 class TestTheReportReadsEveryFieldPermissively:
@@ -2096,3 +2124,79 @@ class TestTheReportReadsEveryFieldPermissively:
             assert msg, block
             assert needle in msg, f"{block}\n{msg}"
             assert "carries no" not in msg, f"the field IS present:\n{msg}"
+class TestARefusalAtHeadIsNotLaunderedByAPlainRepost:
+    """PRE-EXISTING gate defect on the irreducible review, surfaced by adversarial review.
+
+    `not_clean` was computed PER ROW and each row chose its own map. So a second
+    owner comment at the same head — same marker, ordinary prose, no verdict line —
+    landed in `accepted` while the first row's [P1] sat in `rejected`, and the gate
+    PASSED. Nothing about the finding had changed; the head was identical.
+
+    The documented remedy for a refusal caused by prose is to re-post ending with an
+    EXPLICIT clean-verdict line, and that must keep working (control below). So the
+    rule is: at a head where this kind was refused, a later marker counts only if its
+    body carries an explicit clean verdict. A plain re-post is not an override; a
+    stated verdict is.
+    """
+
+    @staticmethod
+    def _row(body):
+        return json.dumps({"login": "owner", "author_association": "OWNER", "body": body})
+
+    @staticmethod
+    def _marker(head=HEAD):
+        return f"<!-- genesis-scheduled-review: head={head} kind=leaks -->"
+
+    def _gate(self, monkeypatch, rows):
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", "\n".join(rows))
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+        return _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+
+    def test_a_plain_repost_does_not_override_a_refusal_at_the_same_head(self, monkeypatch):
+        msg = self._gate(
+            monkeypatch,
+            [
+                self._row("[P1] a real leak finding\n" + self._marker()),
+                self._row("scan done.\n" + self._marker()),
+            ],
+        )
+        assert msg, "a [P1] at this head was laundered by a plain re-post of the marker"
+        assert "IS present at THIS head but was REFUSED" in msg, msg
+
+    def test_order_does_not_matter(self, monkeypatch):
+        """The refusal may arrive AFTER the plain marker (a routine posting its finding
+        late); the outcome must be the same."""
+        msg = self._gate(
+            monkeypatch,
+            [
+                self._row("scan done.\n" + self._marker()),
+                self._row("[P1] a real leak finding\n" + self._marker()),
+            ],
+        )
+        assert msg, "a later [P1] at this head was ignored because a plain marker came first"
+
+    def test_an_explicit_clean_verdict_still_overrides(self, monkeypatch):
+        """CONTROL: the documented remedy. Without it, an implementation that made every
+        refusal permanent would pass the tests above while breaking the one documented
+        way to clear a prose-tripped refusal."""
+        msg = self._gate(
+            monkeypatch,
+            [
+                self._row("The config value is not a hard block.\n" + self._marker()),
+                self._row("Re-reviewed.\nVERDICT: PASS\n" + self._marker()),
+            ],
+        )
+        assert msg is None, f"an explicit verdict line must still clear a refusal:\n{msg}"
+
+    def test_a_refusal_at_another_head_does_not_taint_this_one(self, monkeypatch):
+        """CONTROL: scoping. A [P1] on an OLDER commit is exactly what a new commit
+        fixes; a plain clean marker at the NEW head must count."""
+        msg = self._gate(
+            monkeypatch,
+            [
+                self._row("[P1] finding on the old commit\n" + self._marker(head=OTHER_HEAD)),
+                self._row("scan done.\n" + self._marker()),
+            ],
+        )
+        assert msg is None, f"a refusal at a different head must not block this one:\n{msg}"

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1861,3 +1861,144 @@ class TestEveryMarkerFormIsAccountedFor:
         )
         assert msg
         assert "may still be in flight" in msg.lower()
+
+
+class TestTheReportReadsEveryFieldPermissively:
+    """One class behind several defects: the GATE's strict grammar was reused to answer
+    a REPORTING question, so a REFUSED value became indistinguishable from an ABSENT
+    one and the message asserted things that were false.
+
+    This change had already solved that once -- on the head axis, with a permissive
+    second read used only for the message. It did not generalise, and every remaining
+    field reproduced the defect on its own axis:
+
+      * head  -- had the permissive read, but still called a wrong-CASE 40-hex head
+                 "not a full 40-hex commit sha", sending the operator to recount 40
+                 characters and find nothing wrong
+      * kind  -- had no permissive read, so `kind=leaks/failed` (a form the strict
+                 grammar's own comment anticipates) was reported as carrying no kind
+                 field at all, and the kind then fell to "waiting IS the right move"
+                 for a routine that had run AND FAILED
+      * trust -- the fixable/not-fixable flag was computed at every call site and then
+                 discarded, so an UNTRUSTED block could suppress trusted evidence
+
+    Each test asserts the honest statement AND denies the false one, so a regression
+    that drops the permissive read fails instead of sliding through on a substring.
+    """
+
+    @staticmethod
+    def _row(body, *, login="owner", author_association="OWNER", **kw):
+        row = {"login": login, "author_association": author_association, "body": body}
+        row.update(kw)
+        return json.dumps(row)
+
+    @staticmethod
+    def _marker(head=HEAD, kind="leaks"):
+        parts = ([f"head={head}"] if head else []) + ([f"kind={kind}"] if kind else [])
+        return "<!-- genesis-scheduled-review: " + " ".join(parts) + " -->"
+
+    def _msg(self, monkeypatch, comments, required="leaks"):
+        monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", comments)
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", required)
+        return _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+
+    def test_a_status_suffixed_kind_is_not_reported_as_a_missing_field(self, monkeypatch):
+        """`kind=leaks/failed` is refused by the gate -- correctly -- but it IS there.
+
+        The strict expression's own comment names this exact form as the thing the
+        whitespace terminator exists to reject, so it is an anticipated shape rather
+        than a hypothetical. Reporting it as "carries no kind= field" is simply false.
+        """
+        msg = self._msg(monkeypatch, self._row("run failed.\n" + self._marker(kind="leaks/failed")))
+        assert msg, "a failed run satisfies nothing, so this must still block"
+        assert "'leaks/failed'" in msg, f"the value the operator wrote must be quoted:\n{msg}"
+        assert "carries no kind= field" not in msg, (
+            f"the block DOES carry a kind= field; the gate merely refused it:\n{msg}"
+        )
+
+    def test_a_status_suffixed_kind_does_not_advise_waiting(self, monkeypatch):
+        """The second false statement, and the more expensive one.
+
+        A failed run is the state where the operator most needs to hear "it ran and
+        failed" -- and instead heard "no marker at ANY head yet, waiting IS the right
+        move", which is the precise misdiagnosis this whole change exists to end.
+        """
+        msg = self._msg(monkeypatch, self._row("run failed.\n" + self._marker(kind="leaks/failed")))
+        assert msg
+        assert "may still be in flight" not in msg.lower(), (
+            f"a routine that RAN was reported as never having been posted:\n{msg}"
+        )
+
+    def test_a_near_miss_kind_is_still_NOT_attributed(self, monkeypatch):
+        """CONTROL, and it guards a deliberate earlier refusal rather than a wording.
+
+        Reading `leaks/failed` as `leaks` is an exact match on the segment before the
+        suffix, not a resemblance judgement. `leak` is a resemblance judgement, and
+        attributing it was declined in review because a guessed kind steers the reader
+        toward vouching for a review that never ran. Without this control the permissive
+        read above could quietly widen into exactly that.
+
+        The value is `leak/failed`, NOT a bare `leak`, and the difference is the whole
+        point: a bare `leak` is matched by the STRICT expression and never reaches the
+        permissive branch at all, so a control written that way passes identically on
+        an implementation that guesses. This one drives the branch under test.
+        """
+        msg = self._msg(monkeypatch, self._row("bad run.\n" + self._marker(kind="leak/failed")))
+        assert msg
+        assert "'leak/failed'" in msg, f"the value the operator wrote must be quoted:\n{msg}"
+        assert "may still be in flight" in msg.lower(), (
+            "an unrecognisable kind was CREDITED to the required review it merely "
+            f"resembles; leaks has no marker and must still read as absent:\n{msg}"
+        )
+
+    def test_an_uppercase_head_is_reported_as_case_not_as_length(self, monkeypatch):
+        """40 uppercase hex IS full length. Telling that operator it is not sends them
+        to count characters, find 40, and learn nothing about the real cause."""
+        msg = self._msg(monkeypatch, self._row("scan done.\n" + self._marker(head=HEAD.upper())))
+        assert msg
+        assert "lowercase" in msg, f"the real cause is case, and must be named:\n{msg}"
+        assert "is not a full 40-hex commit sha" not in msg, (
+            f"the head IS full length; only its case is wrong:\n{msg}"
+        )
+
+    def test_an_untrusted_block_does_not_erase_the_older_head_evidence(self, monkeypatch):
+        """On a PUBLIC repo any account can post a marker naming the current head.
+
+        Doing so used to delete the "a routine ran on an older commit" bullet -- the
+        one fact telling the operator a review had ever happened. The verdict never
+        moved (an untrusted marker satisfies nothing); the report an operator acts on
+        did, and it lost the actionable half.
+        """
+        rows = "\n".join(
+            [
+                self._row("older run.\n" + self._marker(head=OTHER_HEAD)),
+                self._row(
+                    "scan done.\n" + self._marker(head=HEAD),
+                    login="drive-by",
+                    author_association="CONTRIBUTOR",
+                ),
+            ]
+        )
+        msg = self._msg(monkeypatch, rows)
+        assert msg
+        assert "drive-by" in msg, f"the untrusted block must still be reported:\n{msg}"
+        assert OTHER_HEAD[:12] in msg, (
+            f"an untrusted commenter erased the trusted older-head evidence:\n{msg}"
+        )
+
+    def test_a_dismissed_review_does_not_erase_the_older_head_evidence(self, monkeypatch):
+        """Same mechanism, reached by review STATE rather than by authorship -- which
+        is why it is fixed on the flag both share rather than at either site."""
+        rows = "\n".join(
+            [
+                self._row("older run.\n" + self._marker(head=OTHER_HEAD)),
+                self._row("scan done.\n" + self._marker(head=HEAD), state="DISMISSED"),
+            ]
+        )
+        msg = self._msg(monkeypatch, rows)
+        assert msg
+        assert "dismissed" in msg.lower(), f"the dismissed block must be reported:\n{msg}"
+        assert OTHER_HEAD[:12] in msg, (
+            f"a dismissed review erased the trusted older-head evidence:\n{msg}"
+        )

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -1191,7 +1191,19 @@ OTHER_HEAD = "1111111111111111111111111111111111111111"
 
 
 class TestScheduledGateBlockMessageBranchesOnCause:
-    """A missing marker has two causes needing OPPOSITE actions; the message must branch.
+    """The block message is an INVENTORY: every marker block found is listed under the
+    kind it names, with its status, and nothing is subtracted from anything.
+
+    HISTORY. This class was written when the message PARTITIONED the missing kinds by
+    cause and let one cause per kind win. Across six review rounds every finding on
+    that shape was the same defect: the winning cause hid a fact the operator needed.
+    The tests below were rewritten from "the winning branch says X and not Y" to "the
+    row for X is present"; the reasoning is kept where a test's meaning changed. The
+    one conditional that survives is a count: a kind with no OWNER-authored block at
+    any head gets the in-flight note, because that is the only state in which waiting
+    can help.
+
+    Original framing, still true of the facts even though nothing "branches" now:
 
     * markers exist for OTHER heads -> a routine ran, then a push moved the head. Waiting
       is unlikely to help; re-review the current head and post the marker by hand.
@@ -1222,10 +1234,12 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         return msg
 
     # -- branch 1: a marker exists, but for an earlier head ---------------------
-    def test_stale_marker_says_waiting_is_unlikely_to_help(self, monkeypatch):
-        msg = self._block_msg(monkeypatch, self._marker_at(OTHER_HEAD)).lower()
-        assert "unlikely to clear this" in msg
-        assert "re-run against the current head" in msg
+    def test_stale_marker_lists_the_older_head_as_a_row(self, monkeypatch):
+        """Was: asserts the advice "unlikely to clear this / re-run". The inventory
+        carries no advice; the fact it replaces it with is the accepted-elsewhere row."""
+        msg = self._block_msg(monkeypatch, self._marker_at(OTHER_HEAD))
+        assert f"accepted at a DIFFERENT head ({OTHER_HEAD[:12]})" in msg
+        assert "none of which counts at the current head" in msg
 
     def test_stale_marker_does_not_tell_the_operator_to_wait(self, monkeypatch):
         """The failure this branch exists to prevent: advice-to-wait on a pushed head."""
@@ -1262,17 +1276,18 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         assert "IS present at THIS head" in msg
         assert "REFUSED" in msg
 
-    def test_refused_marker_gives_the_remedy_a_clean_verdict_line(self, monkeypatch):
-        """The remedy is neither waiting nor re-reviewing — it is the verdict line.
+    def test_refused_marker_states_the_cause_without_the_verdict_incantation(self, monkeypatch):
+        """INVERTED from its previous form, which asserted the two verdict strings VERBATIM.
 
-        Asserts the two remedy strings VERBATIM and conjunctively. An earlier version
-        used `"VERDICT: PASS" in msg or "CLEAN" in msg`, which could never fail inside
-        this branch: the branch's own fixed prose contains the word CLEAN, so the second
-        disjunct held even with the remedy sentence deleted entirely.
+        A gate that prints the exact line that makes it pass is explaining how to get
+        past itself: the refused body may carry a REAL finding, and "append this string"
+        launders it. The rule that decides "refused" is documented in the dev skill; the
+        message states the cause and stops.
         """
         msg = self._block_msg(monkeypatch, self._marker_at(HEAD, self.REFUSED_PROSE))
-        assert "VERDICT: PASS" in msg
-        assert "PII/Secrets/Wording: CLEAN" in msg
+        assert "no clean-verdict line overrides it" in msg
+        assert "VERDICT: PASS" not in msg
+        assert "PII/Secrets/Wording: CLEAN" not in msg
 
     def test_refused_marker_does_not_give_the_other_branches_advice(self, monkeypatch):
         """The failure this branch exists to prevent: being told to wait, or to re-post
@@ -1280,7 +1295,7 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         msg = self._block_msg(monkeypatch, self._marker_at(HEAD, self.REFUSED_PROSE)).lower()
         assert "may still be in flight" not in msg
         assert "waiting is the right move" not in msg
-        assert "present for a different head" not in msg
+        assert "different head" not in msg
 
     def test_a_clean_verdict_line_makes_the_same_marker_pass(self, monkeypatch):
         """The remedy the message prescribes must actually work — end to end."""
@@ -1314,8 +1329,7 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         the "nothing has run — wait for it" path: wrong claim AND wrong advice.
         """
         msg = self._block_msg(monkeypatch, self._marker_at(OTHER_HEAD, self.REFUSED_PROSE))
-        assert OTHER_HEAD[:12] in msg
-        assert "a marker is present for a DIFFERENT head" in msg
+        assert f"REFUSED at a DIFFERENT head ({OTHER_HEAD[:12]})" in msg
         assert "may still be in flight" not in msg.lower()
 
     def test_partial_acceptance_does_not_contradict_the_present_line(self, monkeypatch):
@@ -1329,8 +1343,8 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
         msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
         assert msg and "present: code-review" in msg
-        assert "at ANY head" in msg, "the no-marker branch is still the right one here"
-        assert "leaks — no marker at ANY head" in msg, "must be scoped to the MISSING kind"
+        assert "leaks — no marker block found" in msg, "must be scoped to the MISSING kind"
+        assert "code-review —" not in msg, "a satisfied kind gets no row at all"
 
     def test_refused_marker_for_an_already_satisfied_kind_does_not_hijack_the_message(
         self, monkeypatch
@@ -1353,7 +1367,7 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
         assert msg and "code-review" in msg
         assert "REFUSED" not in msg, "the refused kind is already satisfied — not the cause"
-        assert "code-review — no marker at ANY head" in msg
+        assert "code-review — no marker block found" in msg
 
     def test_mixed_causes_report_every_missing_kind_not_just_one(self, monkeypatch):
         """Two missing kinds failing for DIFFERENT reasons must BOTH get guidance.
@@ -1375,14 +1389,14 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
         msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
         assert msg
-        # code-review: refused AT this head -> the verdict-line remedy.
-        assert "code-review — a marker IS present at THIS head" in msg
-        assert "VERDICT: PASS" in msg
-        # leaks: present at an EARLIER head -> the re-review remedy, naming that head.
-        assert "leaks — a marker is present for a DIFFERENT head" in msg
-        assert OTHER_HEAD[:12] in msg
-        # Neither kind may be silently dropped.
-        assert msg.count("  * ") == 2, "one bullet per cause group, both present"
+        # code-review: refused AT this head. The row states the cause; no incantation.
+        assert "code-review — 1 marker block(s) found" in msg
+        assert "IS present at THIS head but was REFUSED" in msg
+        # leaks: accepted at an EARLIER head, named.
+        assert "leaks — 1 marker block(s) found" in msg
+        assert f"accepted at a DIFFERENT head ({OTHER_HEAD[:12]})" in msg
+        # Neither kind may be silently dropped: one bullet per MISSING kind.
+        assert msg.count("  * ") == 2, "one bullet per missing kind, both present"
 
     def test_three_way_split_reports_all_three_causes(self, monkeypatch):
         """The full partition: refused here, present elsewhere, and absent — at once."""
@@ -1399,8 +1413,9 @@ class TestScheduledGateBlockMessageBranchesOnCause:
         monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
         msg = _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
         assert msg and msg.count("  * ") == 2
-        assert "code-review — a marker IS present at THIS head" in msg
-        assert "leaks — a marker is present for a DIFFERENT head" in msg
+        assert "code-review — 1 marker block(s) found" in msg
+        assert "IS present at THIS head but was REFUSED" in msg
+        assert f"accepted at a DIFFERENT head ({third[:12]})" in msg
 
     # -- shared: what ALL branches must still carry -----------------------------
     @pytest.mark.parametrize("which", ["stale", "empty", "refused"])
@@ -1473,9 +1488,12 @@ class TestAnUnusableMarkerIsNotReportedAsAbsent:
         body = f"scan done.\n<!-- genesis-scheduled-review: head={SHORT_HEAD} kind=leaks -->"
         msg = self._block_msg(monkeypatch, self._row(body))
         assert f"'{SHORT_HEAD}'" in msg, "the offending value must be quoted back"
-        assert "not 'nobody posted anything'" in msg.lower(), (
-            "the report must contradict the absent reading, which is the one that "
-            "sent an operator away to wait"
+        assert "none of which counts at the current head" in msg, (
+            "the report must state that a block was FOUND, which is the reading that "
+            "used to be replaced by 'nothing was posted, wait'"
+        )
+        assert "may still be in flight" not in msg.lower(), (
+            "an owner block exists, so the routine has evidently run; waiting cannot help"
         )
 
     def test_an_abbreviated_head_does_not_advise_waiting(self, monkeypatch):
@@ -1560,19 +1578,22 @@ class TestAnUnusableMarkerIsNotReportedAsAbsent:
         )
 
     def test_a_marker_in_a_dismissed_review_is_reported(self, monkeypatch):
-        """Same rewrite, same precedent, reached by review STATE rather than authorship.
+        """Corrected twice, and the second correction is the honest one.
 
-        A dismissed review says only that IT no longer vouches. Whether anything has run
-        for this kind is a separate question it does not answer, so the kind keeps its
-        own state and its own advice. Contrast the stale-PENDING case below, which DOES
-        supersede: there the block genuinely reports on this kind's status.
+        First form: waiting guidance suppressed (the dismissed block "won"). Then
+        rewritten to keep the guidance, on the argument that a dismissed review says
+        nothing about whether anything ran. That argument was wrong: it is an OWNER-
+        authored review at this head, which is direct evidence the owner's routine ran.
+        The inventory lists the dismissed block; the in-flight note is keyed on owner
+        evidence, so it is correctly absent here and correctly present for a stranger's
+        block (test below).
         """
         body = f"scan done.\n<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->"
         msg = self._block_msg(monkeypatch, self._row(body, state="DISMISSED")).lower()
         assert "dismissed" in msg
-        assert "may still be in flight" in msg, (
-            "a dismissed review consumed the kind's true state, deleting the guidance "
-            f"for a review that has not run:\n{msg}"
+        assert "may still be in flight" not in msg, (
+            "an OWNER's dismissed review is evidence the owner's routine already ran at "
+            f"this head; waiting for it cannot help:\n{msg}"
         )
 
     def test_a_GENUINELY_absent_marker_still_advises_waiting(self, monkeypatch):
@@ -1718,7 +1739,7 @@ class TestAnUnusableMarkerRemedyMatchesItsCause:
         msg = self._msg(monkeypatch, self._row(body))
         assert f"'{HEAD[:8]}'" in msg, "the malformed value must still be quoted"
         assert "could not be counted" in msg
-        assert "not 'nobody posted anything'" in msg.lower()
+        assert "none of which counts at the current head" in msg
 
     def test_a_block_naming_an_unrequired_kind_is_still_reported(self, monkeypatch):
         """A near-miss kind is the case that narrowing to named kinds broke: it
@@ -1822,7 +1843,7 @@ class TestEveryMarkerFormIsAccountedFor:
         """
         msg = self._msg(monkeypatch, self._row("scan done.\n" + self._marker(kind="leak")))
         assert "not a known scheduled" in msg, "the block must be visible"
-        assert "no marker at ANY head" in msg, (
+        assert "leaks — no marker block found" in msg, (
             "attributing the near-miss to the required kind is the guess a prior "
             "finding forbade; the required kind's own state is that none was posted"
         )
@@ -2041,25 +2062,37 @@ class TestTheReportReadsEveryFieldPermissively:
             f"waiting guidance a fresh PR needs:\n{msg}"
         )
 
-    def test_an_owner_repairable_marker_DOES_still_outrank_history(self, monkeypatch):
-        """POSITIVE CONTROL for the rule above, without which it could be inert.
+    def test_every_block_for_a_kind_is_listed_and_nothing_outranks_anything(self, monkeypatch):
+        """The inventory invariant, on the scenario that ended the previous design.
 
-        "Only a repairable block consumes a kind's state" is satisfied just as well by
-        an implementation where NOTHING consumes it — every test above would still pass
-        while the outranking this rule exists to preserve was silently gone. Here the
-        owner's own one-character typo sits at head, and the history bullet must yield
-        to it, because "fix this one" is then the whole of the advice.
+        A REFUSED marker at an older head — its body carries a real [P1] — and the
+        owner's truncated marker at the current head. Under the partition, the typo
+        "won" and the [P1] vanished; the message then told the operator their sha was
+        short, and the layout handed them the full current head to fix it with. Doing
+        so mints a clean attestation at head while a leak finding stands unresolved on
+        the older commit. Both rows must be present; the count must say two.
         """
         rows = "\n".join(
             [
-                self._row("older run.\n" + self._marker(head=OTHER_HEAD)),
+                self._row("[P1] a real leak finding\n" + self._marker(head=OTHER_HEAD)),
                 self._row("scan done.\n" + self._marker(head=HEAD[:8])),
             ]
         )
         msg = self._msg(monkeypatch, rows)
         assert msg
-        assert f"'{HEAD[:8]}'" in msg, f"the repairable typo must be reported:\n{msg}"
-        assert OTHER_HEAD[:12] not in msg, (
-            "an owner-repairable marker at head no longer outranks stale history, so "
-            f"the trust rule has become inert rather than selective:\n{msg}"
-        )
+        assert "leaks — 2 marker block(s) found" in msg, msg
+        assert f"REFUSED at a DIFFERENT head ({OTHER_HEAD[:12]})" in msg, msg
+        assert f"'{HEAD[:8]}'" in msg, msg
+
+    def test_an_empty_field_value_is_not_reported_as_a_missing_field(self, monkeypatch):
+        """`head=` with no value is the single most likely producer fault (an
+        uninterpolated variable). It was reported as "carries no head= field", which
+        is the REFUSED-vs-ABSENT confusion this file forbids, at the empty-value cell."""
+        for block, needle in (
+            ("<!-- genesis-scheduled-review: head= kind=leaks -->", "head= field is present but EMPTY"),
+            (f"<!-- genesis-scheduled-review: head={HEAD} kind= -->", "kind= field is present but EMPTY"),
+        ):
+            msg = self._msg(monkeypatch, self._row("scan.\n" + block))
+            assert msg, block
+            assert needle in msg, f"{block}\n{msg}"
+            assert "carries no" not in msg, f"the field IS present:\n{msg}"


### PR DESCRIPTION
## Summary

A scheduled-review marker was posted whose machine-readable field carried an abbreviated commit id instead of the full forty characters the grammar requires. The block matched, the head did not, and the marker was discarded during the scan before it reached the message. The gate then reported that no marker existed at any head, and the guidance attached to that case is that a routine may still be in flight and **waiting is the right move**. Waiting could never have cleared it.

## What this does

**The scan reports every marker block it finds.** Malformed head, empty or refused field value, non-owner author, dismissed review, stale draft, unknown kind — each was previously dropped in silence, which made "you posted one that does not count" indistinguishable from "nobody posted anything". Each is now recorded with its reason and the offending value quoted.

**The block message is an inventory, not a verdict.** Under each missing kind it lists every block that names that kind — accepted at another head, refused (here or elsewhere), or could-not-be-counted with the reason — and subtracts nothing. There is no precedence between rows, no rule about which fact outranks which, and no attribution of a refused value to the review it resembles.

**The pre-merge report shows it.** `--check-pr` printed only the first line of this message, whose `present: none` clause reads as "nothing was posted" in every case above — the wording the original incident turned on. Every row lived on the lines below and was discarded. It now renders the tail. Live differential on an unrelated open PR:

```
before   scheduled-claude: BLOCK — ... (required: leaks; present: none).

after    scheduled-claude: BLOCK — ... (required: leaks; present: none).
           * leaks — 2 marker block(s) found for this kind, none of which counts at the current head:
               - accepted at a DIFFERENT head (d018e5682df5)
               - accepted at a DIFFERENT head (f45ae5f6788e)
```

## Why an inventory

Earlier revisions of this branch kept the existing partition — one winning cause per kind — and elaborated it. Six review rounds found nine defects in that layer, every one with the same anatomy: the winning cause hid a fact the operator needed. A refused `[P1]` on an older commit, hidden behind a truncated marker on the current one, where following the message would have minted a clean attestation over the unresolved finding. The only evidence a review had ever run, hidden by a comment from any account on a public repository. Each fix moved the rule; the next round found the next hidden fact. Precedence is the right shape for a decision, which needs one answer; it is the wrong shape for a report, where hiding a true fact is never correct. With no winner-picking there is no losing fact.

The one conditional that survives is a count over a fact: "a routine may still be in flight" appears only when the repo owner has posted nothing for that kind at any head in any state. Keying it on "any block exists" would let a stranger's comment silence it; making it unconditional would contradict a listed stale draft.

The refused row deliberately does not print the verdict string that would make the marker pass — a gate that prints the line that gets past it is explaining how to get past itself. The rule lives in the dev skill.

## It cannot make the gate pass where it blocked

The accepted map is written at exactly one site, only when both fields parse under the strict grammar and the kind is known; every branch added here ends without touching it. A valid marker at head still passes (asserted). Refused still blocks (asserted).

## Review

Seven rounds. The scan's reporting has never drawn a finding. Everything built around it did, until it was removed. Every behavioural cell is asserted; each new or rewritten test was watched failing against a mutated production line with the injection confirmed on disk; both directions of the one surviving conditional are mutation-tested.

## A pre-existing gate defect, fixed here

Whether a marker counted was decided one comment at a time, each choosing its own outcome. A second owner comment at the same head — same marker, ordinary prose — was accepted while the first comment's blocking finding stayed refused, and the gate passed. This predates the branch; the adversarial pass surfaced it. Every owner statement about a commit and review is classified as an explicit clean verdict, a blocking finding, or neither, and **the latest decisive statement governs**. Plain statements are not decisive in either direction — they count only when nothing decisive was ever said — so a plain re-post cannot clear a refusal, the documented remedy of re-posting with a stated verdict can, and a finding posted after a verdict is heard. Order comes from the timestamps of both endpoints, fetched and sorted, since list order is not time order. Scoped to the same commit, so a finding on an older commit does not taint a clean marker at the new one. Every ordering is asserted, each written first and watched failing; superseded statements stay in the report.

Also taken from the Codex review of the inventory head: an unpublished draft naming the current head is now a row rather than a silent drop; a block with both fields malformed reports both; the skill's example command is runnable as written.

Ledger: 8275414d33624ec0b5ce2f391b22a9a4
