### PR TITLE
fix(hooks): let a green per-head leak scan carry an earlier leaks review forward

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1423,11 +1423,21 @@ findings below, a gated `gh pr merge`:
   evidence a review had ever run hidden by a drive-by comment. Precedence is the right
   shape for a VERDICT; for a REPORT, hiding a true fact is never correct.
   Or append `# scheduled-review-override` to merge anyway (the conscious "merge without
-  the scheduled reviews" case). Head match is EXACT — no ancestor walk, no delta
+  the scheduled reviews" case). Head match is EXACT for the LLM marker — no delta
   tolerance, unlike the Codex freshness gate, which grants relief on a provably trivial
   delta. That asymmetry is deliberate: the Codex classifier judges code-review
   substantiality by file type and size, and an inferential leak lands in exactly the small
-  doc edit it would wave through. The marker means "ran **clean**", not merely "ran": a
+  doc edit it would wave through. The ONE relief the leaks kind gets is MECHANICAL, not a
+  delta tolerance: an ACCEPTED `leaks` marker on an ANCESTOR commit of head satisfies the
+  gate when the `leak-detector` job of the `CI` workflow is green at head (identity pinned
+  to that (name, workflow) pair; `_MECHANICAL_RESCAN_BY_KIND`), and NEVER when any
+  refused `leaks` marker — or any blocking finding the scan could not credit to a head
+  or kind (a tie, a malformed marker) — exists anywhere in the PR (the head axis is not
+  a time axis — a later acceptance at an older head must not outrank a refusal). `--check-pr` renders a
+  carried marker as `ok (leaks carried from <sha>, leak-detector green at head)`, never
+  as `ok (at head)`. Measured motive: 6 of 10 sampled multi-push PRs were blocked purely
+  because the routine does not re-stamp after a push, and the override had become
+  routine. The marker means "ran **clean**", not merely "ran": a
   review whose body carries a blocking finding (`[P1]`/`HARD BLOCK`/`### ERROR`, unless a
   clean verdict overrides) is rejected, and DISMISSED/PENDING(draft) reviews don't count.
   **ALWAYS end a genuinely-clean scheduled review with an explicit verdict line**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,27 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A multi-push PR no longer needs `# scheduled-review-override` just because the
+  leak-scan routine stamped an earlier commit.** The merge gate now accepts an
+  ACCEPTED `leaks` marker on an ancestor of the current head when the `leak-detector`
+  job of the `CI` workflow is green at head — the mechanical scanner re-ran on the
+  exact commit being merged, which is the literal-leak guarantee the exact-head rule
+  existed to keep. Measured motive: 6 of 10 sampled multi-push PRs were blocked purely
+  because the routine does not re-stamp after a push, so the override had become the
+  routine path. The relief is deliberately blunt where it matters: ANY refused `leaks`
+  marker anywhere in the PR denies it (a later acceptance at an older head must never
+  outrank a refusal — the head axis is not a time axis), the carried marker must be a
+  verified ancestor (an unreadable compare is "unknown", never "yes"), the scanner is
+  pinned to its named workflow rather than to membership in the required-CI set, and
+  every compare respects the shared merge deadline. `--check-pr` renders a carried
+  marker as `ok (leaks carried from <sha>, leak-detector green at head)`, never as
+  `ok (at head)`. Only the `leaks` kind is mapped; `code-review` gets no mechanical
+  relief. A blocking finding the marker scan cannot credit to a head or a kind (a
+  same-timestamp tie, or a malformed marker with a blocking body) is now returned by
+  the scan as structured residue and denies relief the same way a refusal does — an
+  adversarial audit reproduced that path before the field existed. Measured on the 40
+  most recent marker-carrying PRs: 14 were relief-eligible and the rule denies none of
+  them; 7 carry benign uncountable rows that a blanket rule would have denied.
 - **The ego's self-model stopped presenting stale, thin and arbitrarily-ranked
   rows as present-tense capability.** `capability_map` feeds three ego-prompt
   sections and the capability-improvement scanner. Measurements below come from

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -3058,10 +3058,20 @@ def _scheduled_review_marker_scan(
                         ", and its body reads as carrying a blocking finding, so a "
                         "corrected marker would not make it count either"
                     )
-                    # No parseable head -> unattributable residue. A malformed kind
-                    # field attributes to no kind, which on a leak gate means EVERY kind.
+                    # No parseable head -> unattributable residue, keyed "". The KIND is
+                    # retained only when it names a review that actually exists: a
+                    # syntactically valid but UNKNOWN kind (`kind=leak`, the singular
+                    # typo) would otherwise file the residue under a name no required
+                    # kind ever matches, and the blocking finding would be filed into
+                    # nothing -- relief carries past it. Codex reproduced exactly that
+                    # through the gate entry point. Unknown or unparseable -> "*", which
+                    # denies every kind, because a blocking finding nobody can attribute
+                    # is not evidence about one review, it is evidence about all of them.
+                    _residue_kind = _marker_kind_or_none(block)
                     blocking_residue.setdefault("", set()).add(
-                        _marker_kind_or_none(block) or "*"
+                        _residue_kind
+                        if _residue_kind in _KNOWN_SCHEDULED_REVIEW_KINDS
+                        else "*"
                     )
                 unusable.append((_marker_kind_or_none(block), why, True))
                 continue

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2910,6 +2910,15 @@ def _mechanical_scan_is_green(
     if not isinstance(rollup, list):
         return False
     required_workflows = {w.strip().lower() for w in _required_ci_workflows()}
+    # Collect EVERY same-identity entry, never the first match. One head can carry
+    # several runs of one job (a re-run after a ruleset change, a superseded
+    # concurrency sibling), and rollup ORDER is not a guarantee -- _pr_ci_status
+    # refuses to trust it for exactly this reason. A first-match read of a
+    # SUCCESS-then-FAILURE pair reports green while the scanner is red, and under
+    # `# ci-override` this relief is the ONLY remaining check of the mechanical
+    # layer. So: at least one matching entry, and NO matching entry that
+    # contradicts SUCCESS.
+    conclusions: list[str] = []
     for entry in rollup:
         if not isinstance(entry, dict):
             continue
@@ -2918,11 +2927,13 @@ def _mechanical_scan_is_green(
         workflow = (entry.get("workflowName") or "").strip().lower()
         if not workflow or workflow not in required_workflows:
             continue  # same display name, different (or unidentifiable) workflow
-        return (entry.get("conclusion") or "").strip().upper() == "SUCCESS"
-    return False
+        conclusions.append((entry.get("conclusion") or "").strip().upper())
+    if not conclusions:
+        return False  # the scanner never ran at this head under that identity
+    return all(c == "SUCCESS" for c in conclusions)
 
 
-def _sha_is_ancestor(ancestor: str, descendant: str, repo: str | None = None) -> bool:
+def _sha_is_ancestor(ancestor: str, descendant: str, repo: str | None = None) -> bool | None:
     """Whether *ancestor* is an ancestor of *descendant*, per GitHub's compare API.
 
     Load-bearing for the relief below. "An earlier head of the same PR" is NOT
@@ -2937,16 +2948,32 @@ def _sha_is_ancestor(ancestor: str, descendant: str, repo: str | None = None) ->
     descendant is ahead of the ancestor) counts; "diverged", "behind" and
     "identical" do not, and neither does an unreadable read.
 
-    Tests inject via ``_TEST_GH_COMPARE_STATUS``.
+    Tests inject via ``_TEST_GH_COMPARE_STATUS``: either a bare status applying to
+    every pair, or a JSON object keyed ``"<ancestor>...<descendant>"`` so a test can
+    give different answers per pair. The map form exists because the relief walks
+    SEVERAL pairs (each candidate against the head, and each refusal against the
+    chosen candidate); with one global value those paths cannot be told apart, which
+    left the refusal-veto and multi-candidate cells untestable.
     """
     raw = os.environ.get("_TEST_GH_COMPARE_STATUS")
+    if raw is not None and raw.strip().startswith("{"):
+        try:
+            table = json.loads(raw)
+        except Exception:
+            return None
+        if not isinstance(table, dict):
+            return None
+        found = table.get(f"{ancestor}...{descendant}")
+        if found is None:
+            return None  # unspecified pair -> unreadable, never a silent "ahead"
+        raw = str(found)
     if raw is None:
         try:
             owner_repo = repo or _derive_repo_from_cwd(os.getcwd())
         except Exception:
             owner_repo = repo
         if not owner_repo:
-            return False
+            return None
         try:
             result = subprocess.run(
                 [
@@ -2961,16 +2988,20 @@ def _sha_is_ancestor(ancestor: str, descendant: str, repo: str | None = None) ->
                 timeout=_gh_timeout(8),  # merge-path budget; fail-closed -> no relief
             )
             if result.returncode != 0:
-                return False
+                return None
             raw = result.stdout.strip()
         except Exception:
-            return False
-    return (raw or "").strip().lower() == "ahead"
+            return None
+    status = (raw or "").strip().lower()
+    if not status:
+        return None  # unreadable -> the CALLER must fail closed, not try another marker
+    return status == "ahead"
 
 
 def _relieve_kinds_by_mechanical_rescan(
     missing: list[str],
     accepted: dict[str, set[str]],
+    rejected: dict[str, set[str]],
     head: str,
     pr_num: str,
     repo: str | None = None,
@@ -2982,27 +3013,68 @@ def _relieve_kinds_by_mechanical_rescan(
     and the report line, so a carried-forward review is never rendered as one
     made at head.
 
-    Only ``accepted`` markers count. A marker REFUSED at an earlier head proves a
-    routine ran and FOUND something; carrying it would convert a detected leak
-    into a merge. ``rejected`` is deliberately not a parameter rather than merely
-    unused.
+    ``rejected`` IS a parameter, and load-bearing. An earlier draft omitted it on
+    the reasoning that a refusal at an EARLIER head cannot matter once a later
+    ACCEPTED review exists. That reasoning missed the cell that matters: a
+    refusal at the CURRENT head, or at any commit after the accepted one. The
+    routine re-runs, finds an INFERENTIAL leak (which the mechanical scanner
+    cannot see, by construction), posts a refused marker — and relief would
+    carry the older clean review forward and merge the leak. That is precisely
+    the class this gate exists to stop, so the veto below is the whole safety
+    argument, not a detail.
+
+    The rule: an accepted marker may be carried only when EVERY refusal for that
+    kind is an ANCESTOR of it — i.e. every refusal predates the accepted review
+    and was therefore answered by it. A refusal at the head, or between the
+    accepted marker and the head, vetoes.
     """
     relieved: list[tuple[str, str, str]] = []
     for kind in missing:
         check_name = _MECHANICAL_RESCAN_BY_KIND.get(kind)
         if not check_name:
             continue
-        candidates = sorted(h for h, kinds in accepted.items() if h != head and kind in kinds)
+        # Candidates in the scan's own order, which follows the API's chronological
+        # comment order, and take the LAST — the newest accepted review carries the
+        # smallest never-LLM-reviewed delta. Correctness does not depend on the
+        # ordering (any accepted ancestor that survives the refusal veto is sound);
+        # it minimises exposure. An earlier draft sorted the SHAs and called that
+        # "newest first", which is alphabetical hex order and means nothing.
+        candidates = [h for h, kinds in accepted.items() if h != head and kind in kinds]
         if not candidates:
             continue  # never accepted anywhere in this PR -> nothing to carry forward
-        # Newest-first: prefer the most recent accepted review that is genuinely
-        # on this branch's history.
-        ancestor = next(
-            (h for h in reversed(candidates) if _sha_is_ancestor(h, head, repo=repo)),
-            None,
-        )
-        if ancestor is None:
-            continue  # rewritten history (or unreadable) -> the review is not OF this tree
+        refusals = [h for h, kinds in rejected.items() if kind in kinds]
+        if head in refusals:
+            continue  # the routine ran at THIS head and found something -> never relieve
+
+        ancestor = None
+        unreadable = False
+        for candidate in reversed(candidates):
+            verdict = _sha_is_ancestor(candidate, head, repo=repo)
+            if verdict is None:
+                unreadable = True  # cannot establish history -> fail closed, do not
+                break              # silently fall back to an older marker
+            if not verdict:
+                continue  # rewritten history: this review is not OF this tree
+            # Every refusal must predate this accepted review.
+            answered = True
+            for refusal in refusals:
+                if refusal == candidate:
+                    continue
+                r_verdict = _sha_is_ancestor(refusal, candidate, repo=repo)
+                if r_verdict is None:
+                    unreadable = True
+                    answered = False
+                    break
+                if not r_verdict:
+                    answered = False  # a refusal at or after this review -> veto
+                    break
+            if unreadable:
+                break
+            if answered:
+                ancestor = candidate
+                break
+        if unreadable or ancestor is None:
+            continue
         if not _mechanical_scan_is_green(pr_num, head, check_name, repo=repo):
             continue  # unreadable, absent, wrong workflow, pending or failed -> fail CLOSED
         relieved.append((kind, ancestor[:12], check_name))
@@ -3067,13 +3139,22 @@ def _check_scheduled_claude_reviewed_head(
     fire would be asserting a guarantee the code cannot back — and would become actively
     misleading on an install that also runs them on ``synchronize``.
 
-    Head match is EXACT — there is no ancestor walk and no delta tolerance here, unlike
-    the Codex freshness gate, which grants relief on a provably trivial delta via
-    ``_classify_post_review_delta``. That asymmetry is deliberate for now: that
-    classifier judges CODE-REVIEW substantiality by file type and size, and an
-    inferential leak (household/schedule/habit detail, not a token a regex can catch)
-    arrives in exactly the small doc edit it would wave through. A leak-specific
-    tolerance is tracked separately; do not reuse the code-review classifier for it.
+    Head match is EXACT by default, and the code-review classifier must NEVER be
+    reused here: ``_classify_post_review_delta`` judges CODE-REVIEW substantiality by
+    file type and size, and an inferential leak (household/schedule/habit detail, not
+    a token a regex can catch) arrives in exactly the small doc edit it would wave
+    through. That prohibition is unchanged.
+
+    The ONE tolerance that exists is the leak-specific one this docstring used to
+    describe as "tracked separately": ``_relieve_kinds_by_mechanical_rescan`` may
+    carry an ACCEPTED marker forward from an ANCESTOR commit of this PR, but only
+    while the kind's MECHANICAL scanner is green at the exact current head, only
+    when no refusal for that kind sits at or after the carried review, and only for
+    kinds in ``_MECHANICAL_RESCAN_BY_KIND``. It is not a delta tolerance: nothing is
+    judged by how big or how doc-like the change is. It trades a re-read of the
+    inferential layer for a per-head guarantee about the literal layer — strictly
+    more checking than the ``# scheduled-review-override`` it exists to retire,
+    which verifies nothing at all.
 
     SCOPE: this gate enforces ONLY for a merge targeting the configured PUBLIC repo
     (``_scheduled_gate_applies`` / ``_canonical_public_repo``). A merge to any other
@@ -3115,17 +3196,21 @@ def _check_scheduled_claude_reviewed_head(
         # A kind already ACCEPTED at an earlier head of this PR is satisfied when its
         # mechanical scanner is green at THIS head (see _MECHANICAL_RESCAN_BY_KIND).
         missing, relieved = _relieve_kinds_by_mechanical_rescan(
-            missing, markers, head, pr_num, repo=repo
+            missing, markers, rejected, head, pr_num, repo=repo
         )
         if relief_out is not None:
             relief_out.extend(relieved)
-        for kind, earlier_head, check_name in relieved:
-            print(
-                f"NOTE: scheduled '{kind}' review for PR #{pr_num} was accepted at "
-                f"{earlier_head} (not at head {head[:12]}), but '{check_name}' is green "
-                f"at this head — honouring the earlier review.",
-                file=sys.stderr,
-            )
+        # Announce ONLY when relief actually clears the gate. Printing "honouring
+        # the earlier review" while the merge is still denied on another kind
+        # describes a decision that was not made.
+        if not missing:
+            for kind, earlier_head, check_name in relieved:
+                print(
+                    f"NOTE: scheduled '{kind}' review for PR #{pr_num} was accepted at "
+                    f"{earlier_head} (not at head {head[:12]}), but '{check_name}' is green "
+                    f"at this head — honouring the earlier review.",
+                    file=sys.stderr,
+                )
     if not missing:
         return None
     # WHY the marker is missing decides whether waiting is useful, and the two causes are

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2453,6 +2453,29 @@ _DEFAULT_REQUIRED_SCHEDULED_REVIEW_KINDS = ("code-review", "leaks")
 # The leak/secret scanner is IRREDUCIBLE: always required, never removable by config. A
 # secret reaching a public repo is irreversible, so no local policy may waive it.
 _IRREDUCIBLE_REQUIRED_SCHEDULED_REVIEW_KINDS = ("leaks",)
+
+# Scheduled-review kinds whose marker may be honoured from an EARLIER head of the
+# same PR, provided the named MECHANICAL scanner is green at the CURRENT head.
+#
+# WHY this exists, and why only for leaks. The routines are not re-run on a push,
+# so on any multi-push PR the marker sits at the first head and the gate blocks —
+# measured over ten recent PRs, every one with commits after its marker. The
+# operator's only escape was `# scheduled-review-override`, a sigil that checks
+# NOTHING, so routine use of it was eroding an override meant for exceptions.
+#
+# The relief is narrow BECAUSE the two layers cover different leak classes. The
+# mechanical scanner catches literal patterns (addresses, emails, configured
+# private patterns) and it runs per-head; the scheduled LLM review catches
+# INFERENTIAL leaks, which no pattern can. Honouring an earlier LLM review while
+# REQUIRING the mechanical one at this exact head therefore trades a re-read of
+# the inferential layer for a guarantee the literal layer covers the new commits
+# — strictly more checking than the bare override it replaces, never less.
+#
+# NOT a prose-delta tolerance. That was the first design and it was MEASURED
+# inert: 0 of 6 applicable PRs had a prose-free delta (22-692 added prose lines
+# each), because essentially every push adds a comment, docstring or string.
+# A relief valve that never opens leaves the override in daily use.
+_MECHANICAL_RESCAN_BY_KIND = {"leaks": "leak-detector"}
 # Every kind an install is ALLOWED to name in config. A configured kind outside this set
 # (a typo, a wrong type, a stale routine name) can never be satisfied by a real marker, so
 # the whole config is treated as invalid and we fail closed to the default rather than let
@@ -2820,6 +2843,94 @@ def _scheduled_review_marker_scan(
     return accepted, rejected
 
 
+def _mechanical_scan_conclusion(
+    head_sha: str, check_name: str, repo: str | None = None
+) -> str | None:
+    """The conclusion of check run *check_name* AT *head_sha*, or None if unreadable.
+
+    Binds the sha EXPLICITLY (``commits/{sha}/check-runs``) rather than reading the
+    PR's rollup, so the answer cannot silently describe a different commit than the
+    one the gate is deciding about.
+
+    Returns None on ANY doubt — a gh error, an unparseable payload, or the check
+    simply not present at this head. Callers treat None as "no relief": this feeds
+    a merge gate, so an unreadable mechanical scan must never read as a pass.
+
+    Tests inject via ``_TEST_GH_CHECK_RUNS`` (a JSON array of check-run objects).
+    """
+    raw = os.environ.get("_TEST_GH_CHECK_RUNS")
+    if raw is None:
+        try:
+            owner_repo = repo or _derive_repo_from_cwd(os.getcwd())
+        except Exception:
+            owner_repo = repo
+        if not owner_repo:
+            return None
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{owner_repo}/commits/{head_sha}/check-runs",
+                    "--jq",
+                    ".check_runs",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=_gh_timeout(8),  # merge-path budget; fail-closed -> no relief
+            )
+            if result.returncode != 0:
+                return None
+            raw = result.stdout.strip()
+        except Exception:
+            return None
+    if not raw:
+        return None
+    try:
+        runs = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(runs, list):
+        return None
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if (run.get("name") or "").strip() == check_name:
+            # A run still in flight has conclusion null -> not "success" -> no relief.
+            return (run.get("conclusion") or "").strip().lower() or None
+    return None  # the check never ran at this head
+
+
+def _relieve_kinds_by_mechanical_rescan(
+    missing: list[str],
+    accepted: dict[str, set[str]],
+    head: str,
+    repo: str | None = None,
+) -> tuple[list[str], list[tuple[str, str, str]]]:
+    """Drop kinds satisfiable by an earlier ACCEPTED marker + a green scanner at head.
+
+    Returns ``(still_missing, relieved)`` where each *relieved* entry is
+    ``(kind, earlier_head_12, check_name)`` for the message.
+
+    Only ``accepted`` markers count. A marker that was REFUSED at an earlier head
+    proves a routine ran and FOUND something — it must never grant relief, which is
+    why ``rejected`` is deliberately not a parameter here rather than merely unused.
+    """
+    relieved: list[tuple[str, str, str]] = []
+    for kind in missing:
+        check_name = _MECHANICAL_RESCAN_BY_KIND.get(kind)
+        if not check_name:
+            continue
+        earlier = sorted(h for h, kinds in accepted.items() if h != head and kind in kinds)
+        if not earlier:
+            continue  # never accepted anywhere in this PR -> nothing to carry forward
+        if _mechanical_scan_conclusion(head, check_name, repo=repo) != "success":
+            continue  # unreadable, absent, pending or failed -> fail CLOSED
+        relieved.append((kind, earlier[-1][:12], check_name))
+    relieved_kinds = {k for k, _, _ in relieved}
+    return [k for k in missing if k not in relieved_kinds], relieved
+
+
 def _check_scheduled_claude_reviewed_head(
     pr_num: str,
     head_sha: str | None = None,
@@ -2920,6 +3031,19 @@ def _check_scheduled_claude_reviewed_head(
     kinds_here = markers.get(head, set())
     required = _required_scheduled_review_kinds()
     missing = [k for k in required if k not in kinds_here]
+    if missing:
+        # A kind already ACCEPTED at an earlier head of this PR is satisfied when its
+        # mechanical scanner is green at THIS head (see _MECHANICAL_RESCAN_BY_KIND).
+        missing, relieved = _relieve_kinds_by_mechanical_rescan(
+            missing, markers, head, repo=repo
+        )
+        for kind, earlier_head, check_name in relieved:
+            print(
+                f"NOTE: scheduled '{kind}' review for PR #{pr_num} was accepted at "
+                f"{earlier_head} (not at head {head[:12]}), but '{check_name}' is green "
+                f"at this head — honouring the earlier review.",
+                file=sys.stderr,
+            )
     if not missing:
         return None
     # WHY the marker is missing decides whether waiting is useful, and the two causes are

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2843,90 +2843,169 @@ def _scheduled_review_marker_scan(
     return accepted, rejected
 
 
-def _mechanical_scan_conclusion(
-    head_sha: str, check_name: str, repo: str | None = None
-) -> str | None:
-    """The conclusion of check run *check_name* AT *head_sha*, or None if unreadable.
+def _mechanical_scan_is_green(
+    pr_num: str, head_sha: str, check_name: str, repo: str | None = None
+) -> bool:
+    """Whether *check_name* concluded SUCCESS for *head_sha*, identified by
+    ``(name, workflowName)`` rather than by display name alone.
 
-    Binds the sha EXPLICITLY (``commits/{sha}/check-runs``) rather than reading the
-    PR's rollup, so the answer cannot silently describe a different commit than the
-    one the gate is deciding about.
+    Reads ``headRefOid`` AND ``statusCheckRollup`` in ONE query so the rollup
+    provably describes the commit being decided: if the head returned alongside
+    it is not *head_sha*, the read is discarded. That preserves the sha binding a
+    ``commits/{sha}/check-runs`` read would give, while gaining ``workflowName``,
+    which that endpoint does not expose — and it is not paginated the way the
+    REST check-runs list is, so a scanner cannot fall off a later page and read
+    as absent (which would recreate the routine false block this relief exists to
+    retire).
 
-    Returns None on ANY doubt — a gh error, an unparseable payload, or the check
-    simply not present at this head. Callers treat None as "no relief": this feeds
-    a merge gate, so an unreadable mechanical scan must never read as a pass.
+    Identity is ``(name, workflowName)`` against ``_required_ci_workflows()``,
+    mirroring ``_ci_identity``. A bare display-name match would let a same-named
+    check from another app or workflow stand in for the real scanner — the decoy
+    class this file already documents at _ci_identity, and the whole point of
+    this relief is that the mechanical layer really ran.
 
-    Tests inject via ``_TEST_GH_CHECK_RUNS`` (a JSON array of check-run objects).
+    Returns False on ANY doubt: a gh error, an unparseable payload, a head that
+    does not match, no entry with that identity, or any conclusion other than
+    SUCCESS. This feeds a merge gate that forces --admin, so an unreadable or
+    ambiguous scan must never read as a pass.
+
+    Tests inject via ``_TEST_GH_ROLLUP_WITH_HEAD`` (a JSON object with
+    ``headRefOid`` and ``statusCheckRollup``).
     """
-    raw = os.environ.get("_TEST_GH_CHECK_RUNS")
+    raw = os.environ.get("_TEST_GH_ROLLUP_WITH_HEAD")
     if raw is None:
-        try:
-            owner_repo = repo or _derive_repo_from_cwd(os.getcwd())
-        except Exception:
-            owner_repo = repo
-        if not owner_repo:
-            return None
         try:
             result = subprocess.run(
                 [
                     "gh",
-                    "api",
-                    f"repos/{owner_repo}/commits/{head_sha}/check-runs",
-                    "--jq",
-                    ".check_runs",
+                    "pr",
+                    "view",
+                    pr_num,
+                    *_repo_args(repo),
+                    "--json",
+                    "headRefOid,statusCheckRollup",
                 ],
                 capture_output=True,
                 text=True,
                 timeout=_gh_timeout(8),  # merge-path budget; fail-closed -> no relief
             )
             if result.returncode != 0:
-                return None
+                return False
             raw = result.stdout.strip()
         except Exception:
-            return None
+            return False
     if not raw:
-        return None
+        return False
     try:
-        runs = json.loads(raw)
+        data = json.loads(raw)
     except Exception:
-        return None
-    if not isinstance(runs, list):
-        return None
-    for run in runs:
-        if not isinstance(run, dict):
+        return False
+    if not isinstance(data, dict):
+        return False
+    # The rollup and the head come from the SAME read; if that head is not the one
+    # being decided, the rollup describes a different commit and proves nothing.
+    if (data.get("headRefOid") or "").strip().lower() != (head_sha or "").strip().lower():
+        return False
+    rollup = data.get("statusCheckRollup")
+    if not isinstance(rollup, list):
+        return False
+    required_workflows = {w.strip().lower() for w in _required_ci_workflows()}
+    for entry in rollup:
+        if not isinstance(entry, dict):
             continue
-        if (run.get("name") or "").strip() == check_name:
-            # A run still in flight has conclusion null -> not "success" -> no relief.
-            return (run.get("conclusion") or "").strip().lower() or None
-    return None  # the check never ran at this head
+        if (entry.get("name") or "").strip() != check_name:
+            continue
+        workflow = (entry.get("workflowName") or "").strip().lower()
+        if not workflow or workflow not in required_workflows:
+            continue  # same display name, different (or unidentifiable) workflow
+        return (entry.get("conclusion") or "").strip().upper() == "SUCCESS"
+    return False
+
+
+def _sha_is_ancestor(ancestor: str, descendant: str, repo: str | None = None) -> bool:
+    """Whether *ancestor* is an ancestor of *descendant*, per GitHub's compare API.
+
+    Load-bearing for the relief below. "An earlier head of the same PR" is NOT
+    established by "a sha that differs from the current head": a force-push or a
+    history-rewriting rebase leaves the reviewed commit off the branch entirely,
+    so the PR can carry an entirely different tree while an old accepted marker
+    still names a real commit. Carrying that review forward would vouch for code
+    its reviewer never saw — precisely the inferential leak this irreducible gate
+    exists to catch.
+
+    Returns False on ANY doubt. Only compare ``status == "ahead"`` (the
+    descendant is ahead of the ancestor) counts; "diverged", "behind" and
+    "identical" do not, and neither does an unreadable read.
+
+    Tests inject via ``_TEST_GH_COMPARE_STATUS``.
+    """
+    raw = os.environ.get("_TEST_GH_COMPARE_STATUS")
+    if raw is None:
+        try:
+            owner_repo = repo or _derive_repo_from_cwd(os.getcwd())
+        except Exception:
+            owner_repo = repo
+        if not owner_repo:
+            return False
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{owner_repo}/compare/{ancestor}...{descendant}",
+                    "--jq",
+                    ".status",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=_gh_timeout(8),  # merge-path budget; fail-closed -> no relief
+            )
+            if result.returncode != 0:
+                return False
+            raw = result.stdout.strip()
+        except Exception:
+            return False
+    return (raw or "").strip().lower() == "ahead"
 
 
 def _relieve_kinds_by_mechanical_rescan(
     missing: list[str],
     accepted: dict[str, set[str]],
     head: str,
+    pr_num: str,
     repo: str | None = None,
 ) -> tuple[list[str], list[tuple[str, str, str]]]:
-    """Drop kinds satisfiable by an earlier ACCEPTED marker + a green scanner at head.
+    """Drop kinds satisfiable by an ANCESTOR ACCEPTED marker + a green scanner at head.
 
     Returns ``(still_missing, relieved)`` where each *relieved* entry is
-    ``(kind, earlier_head_12, check_name)`` for the message.
+    ``(kind, ancestor_head_12, check_name)`` — enough for both the operator note
+    and the report line, so a carried-forward review is never rendered as one
+    made at head.
 
-    Only ``accepted`` markers count. A marker that was REFUSED at an earlier head
-    proves a routine ran and FOUND something — it must never grant relief, which is
-    why ``rejected`` is deliberately not a parameter here rather than merely unused.
+    Only ``accepted`` markers count. A marker REFUSED at an earlier head proves a
+    routine ran and FOUND something; carrying it would convert a detected leak
+    into a merge. ``rejected`` is deliberately not a parameter rather than merely
+    unused.
     """
     relieved: list[tuple[str, str, str]] = []
     for kind in missing:
         check_name = _MECHANICAL_RESCAN_BY_KIND.get(kind)
         if not check_name:
             continue
-        earlier = sorted(h for h, kinds in accepted.items() if h != head and kind in kinds)
-        if not earlier:
+        candidates = sorted(h for h, kinds in accepted.items() if h != head and kind in kinds)
+        if not candidates:
             continue  # never accepted anywhere in this PR -> nothing to carry forward
-        if _mechanical_scan_conclusion(head, check_name, repo=repo) != "success":
-            continue  # unreadable, absent, pending or failed -> fail CLOSED
-        relieved.append((kind, earlier[-1][:12], check_name))
+        # Newest-first: prefer the most recent accepted review that is genuinely
+        # on this branch's history.
+        ancestor = next(
+            (h for h in reversed(candidates) if _sha_is_ancestor(h, head, repo=repo)),
+            None,
+        )
+        if ancestor is None:
+            continue  # rewritten history (or unreadable) -> the review is not OF this tree
+        if not _mechanical_scan_is_green(pr_num, head, check_name, repo=repo):
+            continue  # unreadable, absent, wrong workflow, pending or failed -> fail CLOSED
+        relieved.append((kind, ancestor[:12], check_name))
     relieved_kinds = {k for k, _, _ in relieved}
     return [k for k in missing if k not in relieved_kinds], relieved
 
@@ -2937,6 +3016,7 @@ def _check_scheduled_claude_reviewed_head(
     repo: str | None = None,
     *,
     force: bool = False,
+    relief_out: list[tuple[str, str, str]] | None = None,
 ) -> str | None:
     """Block a merge unless EVERY required scheduled Claude review (by the repo OWNER)
     has run on the PR's CURRENT head. Returns ``None`` when a valid owner marker for
@@ -3035,8 +3115,10 @@ def _check_scheduled_claude_reviewed_head(
         # A kind already ACCEPTED at an earlier head of this PR is satisfied when its
         # mechanical scanner is green at THIS head (see _MECHANICAL_RESCAN_BY_KIND).
         missing, relieved = _relieve_kinds_by_mechanical_rescan(
-            missing, markers, head, repo=repo
+            missing, markers, head, pr_num, repo=repo
         )
+        if relief_out is not None:
+            relief_out.extend(relieved)
         for kind, earlier_head, check_name in relieved:
             print(
                 f"NOTE: scheduled '{kind}' review for PR #{pr_num} was accepted at "
@@ -5212,10 +5294,23 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     if not _scheduled_gate_applies(repo):
         print("scheduled-claude: n/a (scoped to the public repo only)")
     else:
-        sched_msg = _check_scheduled_claude_reviewed_head(pr_num, verified_head, repo)
-        print(
-            f"scheduled-claude: {'BLOCK — ' + sched_msg.splitlines()[0] if sched_msg else 'ok (at head)'}"
+        sched_relief: list[tuple[str, str, str]] = []
+        sched_msg = _check_scheduled_claude_reviewed_head(
+            pr_num, verified_head, repo, relief_out=sched_relief
         )
+        if sched_msg:
+            sched_state = "BLOCK — " + sched_msg.splitlines()[0]
+        elif sched_relief:
+            # NEVER render a carried-forward review as one made at head: this line is
+            # what a human (and a structured consumer) reads to judge freshness, and
+            # "ok (at head)" here would be a false assertion about what was reviewed.
+            sched_state = "ok (" + "; ".join(
+                f"{kind} carried from {anc}, {check} green at head"
+                for kind, anc, check in sched_relief
+            ) + ")"
+        else:
+            sched_state = "ok (at head)"
+        print(f"scheduled-claude: {sched_state}")
         failures += 1 if sched_msg else 0
     # Fail-closed (the only mode now): a scan that could not be READ (gh error/malformed)
     # shows as a failure here, never as "ok" — the report must not issue a false all-clear.

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2493,7 +2493,15 @@ _IRREDUCIBLE_REQUIRED_SCHEDULED_REVIEW_KINDS = ("leaks",)
 # inert: 0 of 6 applicable PRs had a prose-free delta (22-692 added prose lines
 # each), because essentially every push adds a comment, docstring or string.
 # A relief valve that never opens leaves the override in daily use.
-_MECHANICAL_RESCAN_BY_KIND = {"leaks": "leak-detector"}
+# kind -> (check name, WORKFLOW name) for the mechanical scanner that may carry an
+# earlier accepted review forward. The workflow half is the round-4 finding: matching
+# the display name against the whole required-CI set lets a same-named check from
+# ANOTHER workflow stand in for the real scanner. Both halves are read from this
+# repo's own .github/workflows/ci.yml (`name: CI`; the `leak-detector` job), so they
+# travel with a clone rather than describing one install. A suite named differently
+# simply finds no match, and no match means NO RELIEF -- the pre-relief behaviour, so
+# the failure direction of a wrong pin is a missing convenience, never a weaker gate.
+_MECHANICAL_RESCAN_BY_KIND = {"leaks": ("leak-detector", "CI")}
 # Every kind an install is ALLOWED to name in config. A configured kind outside this set
 # (a typo, a wrong type, a stale routine name) can never be satisfied by a real marker, so
 # the whole config is treated as invalid and we fail closed to the default rather than let
@@ -2852,7 +2860,7 @@ def _scheduled_review_marker_scan(
     tuple[dict[str, set[str]], dict[str, set[str]], list[tuple[str | None, str, bool]]]
     | None
 ):
-    """``(accepted, rejected_not_clean, unusable)`` for the PR's scheduled-review
+    """``(accepted, rejected_not_clean, unusable, blocking_residue)`` for the PR's scheduled-review
     markers, or ``None`` on an UNREADABLE fetch.
 
     ``unusable`` is a list of ``(kind_or_None, reason, owner_authored)`` for marker
@@ -2894,6 +2902,13 @@ def _scheduled_review_marker_scan(
     # it only to count whether the OWNER has posted anything for a kind, because that is
     # the one thing that says whether the owner's routine has evidently already run.
     unusable: list[tuple[str | None, str, bool]] = []
+    # BLOCKING RESIDUE: head -> kinds for which the owner's body READ AS BLOCKING but
+    # the finding could not be credited to `rejected` -- a same-timestamp tie (recorded
+    # in neither verdict map), or a malformed / unknown-kind marker whose body carries
+    # the finding. Structured, so a consumer never has to match the prose in
+    # `unusable`. Keyed "" when no head can be attributed; kind "*" when no kind can.
+    # Additive: the three return shapes above are unchanged.
+    blocking_residue: dict[str, set[str]] = {}
     # Every owner statement about a (head, kind), in CHRONOLOGICAL order, classified as
     # "clean" (explicit verdict line), "refused" (blocking finding, no verdict) or "plain"
     # (neither). The verdict for the pair is resolved AFTER the loop from this list -- see
@@ -3043,6 +3058,11 @@ def _scheduled_review_marker_scan(
                         ", and its body reads as carrying a blocking finding, so a "
                         "corrected marker would not make it count either"
                     )
+                    # No parseable head -> unattributable residue. A malformed kind
+                    # field attributes to no kind, which on a leak gate means EVERY kind.
+                    blocking_residue.setdefault("", set()).add(
+                        _marker_kind_or_none(block) or "*"
+                    )
                 unusable.append((_marker_kind_or_none(block), why, True))
                 continue
             _kind = kind_m.group(1).lower()
@@ -3062,6 +3082,9 @@ def _scheduled_review_marker_scan(
                     # does for a malformed field: reporting only the typo invites a
                     # corrected marker over an unresolved finding.
                     _why += ", and its body reads as carrying a blocking finding"
+                    # A blocking body under a kind nothing knows about cannot be
+                    # credited to any kind -- so it is residue against ALL of them.
+                    blocking_residue.setdefault("", set()).add("*")
                 unusable.append((_kind, _why, True))
                 continue
             stmts.setdefault((head_m.group(1).lower(), _kind), []).append(
@@ -3111,6 +3134,8 @@ def _scheduled_review_marker_scan(
             # One row per BLOCK here too, so the header's count still equals the number
             # of blocks in the thread; each says what its own block was and why the pair
             # cannot be ordered.
+            # The tie IS blocking evidence at this head that neither map can carry.
+            blocking_residue.setdefault(h, set()).add(k)
             for _, v in seq:
                 what = {
                     "clean": "an explicit clean verdict",
@@ -3148,11 +3173,11 @@ def _scheduled_review_marker_scan(
                 else superseded[v]
             )
             unusable.append((k, text, True))
-    return accepted, rejected, unusable
+    return accepted, rejected, unusable, blocking_residue
 
 
 def _mechanical_scan_is_green(
-    pr_num: str, head_sha: str, check_name: str, repo: str | None = None
+    pr_num: str, head_sha: str, check_name: str, workflow: str, repo: str | None = None
 ) -> bool:
     """Whether *check_name* concluded SUCCESS for *head_sha*, identified by
     ``(name, workflowName)`` rather than by display name alone.
@@ -3166,7 +3191,7 @@ def _mechanical_scan_is_green(
     as absent (which would recreate the routine false block this relief exists to
     retire).
 
-    Identity is ``(name, workflowName)`` against ``_required_ci_workflows()``,
+    Identity is ``(name, workflowName)`` against the kind's PINNED workflow,
     mirroring ``_ci_identity``. A bare display-name match would let a same-named
     check from another app or workflow stand in for the real scanner — the decoy
     class this file already documents at _ci_identity, and the whole point of
@@ -3217,7 +3242,14 @@ def _mechanical_scan_is_green(
     rollup = data.get("statusCheckRollup")
     if not isinstance(rollup, list):
         return False
-    required_workflows = {w.strip().lower() for w in _required_ci_workflows()}
+    # Pinned to the ONE workflow the scanner belongs to, not to membership in the
+    # required-CI SET. The set has no meaningful order and several members, so
+    # "some required workflow published a check with this name" is satisfied by a
+    # decoy from an unrelated workflow -- the same identity confusion _ci_identity
+    # documents, one level down.
+    wanted_workflow = (workflow or "").strip().lower()
+    if not wanted_workflow:
+        return False  # an unpinned kind can never be established -> fail closed
     # Collect EVERY same-identity entry, never the first match. One head can carry
     # several runs of one job (a re-run after a ruleset change, a superseded
     # concurrency sibling), and rollup ORDER is not a guarantee -- _pr_ci_status
@@ -3232,8 +3264,8 @@ def _mechanical_scan_is_green(
             continue
         if (entry.get("name") or "").strip() != check_name:
             continue
-        workflow = (entry.get("workflowName") or "").strip().lower()
-        if not workflow or workflow not in required_workflows:
+        entry_workflow = (entry.get("workflowName") or "").strip().lower()
+        if not entry_workflow or entry_workflow != wanted_workflow:
             continue  # same display name, different (or unidentifiable) workflow
         conclusions.append((entry.get("conclusion") or "").strip().upper())
     if not conclusions:
@@ -3258,10 +3290,9 @@ def _sha_is_ancestor(ancestor: str, descendant: str, repo: str | None = None) ->
 
     Tests inject via ``_TEST_GH_COMPARE_STATUS``: either a bare status applying to
     every pair, or a JSON object keyed ``"<ancestor>...<descendant>"`` so a test can
-    give different answers per pair. The map form exists because the relief walks
-    SEVERAL pairs (each candidate against the head, and each refusal against the
-    chosen candidate); with one global value those paths cannot be told apart, which
-    left the refusal-veto and multi-candidate cells untestable.
+    give different answers per pair. The map form exists because the relief may try
+    SEVERAL candidates against the head (an unreadable one is skipped for the next);
+    with one global value those cells cannot be told apart.
     """
     raw = os.environ.get("_TEST_GH_COMPARE_STATUS")
     if raw is not None and raw.strip().startswith("{"):
@@ -3302,7 +3333,8 @@ def _sha_is_ancestor(ancestor: str, descendant: str, repo: str | None = None) ->
             return None
     status = (raw or "").strip().lower()
     if not status:
-        return None  # unreadable -> the CALLER must fail closed, not try another marker
+        return None  # unreadable -> "unknown": the caller may try another candidate,
+        #              and fails closed only if NO candidate verifies
     return status == "ahead"
 
 
@@ -3310,113 +3342,143 @@ def _relieve_kinds_by_mechanical_rescan(
     missing: list[str],
     accepted: dict[str, set[str]],
     rejected: dict[str, set[str]],
+    residue: dict[str, set[str]],
     head: str,
     pr_num: str,
     repo: str | None = None,
 ) -> tuple[list[str], list[tuple[str, str, str]], dict[str, str]]:
     """Drop kinds satisfiable by an ANCESTOR ACCEPTED marker + a green scanner at head.
 
-    The third return value maps a kind to WHY its relief failed, when a carriable
-    marker existed but something else stopped it. The block message needs this:
-    "the scanner has not finished" and "the scanner FAILED" call for opposite
-    actions (wait vs fix CI), and neither is "re-run the scheduled review", which
-    is what the message says when it only knows the marker sits on another head.
+    Returns ``(still_missing, relieved, reasons)``. Each *relieved* entry is
+    ``(kind, ancestor_head_12, check_name)`` -- enough for both the operator note and
+    the report line, so a carried-forward review is never rendered as one made at
+    head. *reasons* maps a kind to WHY relief failed when a carriable marker existed:
+    "the scanner has not finished" and "the scanner FAILED" call for opposite actions
+    (wait vs fix that job), and neither is "re-run the scheduled review", which is
+    what the message says when it only knows the marker sits on another head.
 
-    Returns ``(still_missing, relieved)`` where each *relieved* entry is
-    ``(kind, ancestor_head_12, check_name)`` — enough for both the operator note
-    and the report line, so a carried-forward review is never rendered as one
-    made at head.
+    THE RULE: **any refusal for the kind, anywhere in this PR, denies relief.**
 
-    ``rejected`` IS a parameter, and load-bearing. An earlier draft omitted it on
-    the reasoning that a refusal at an EARLIER head cannot matter once a later
-    ACCEPTED review exists. That reasoning missed the cell that matters: a
-    refusal at the CURRENT head, or at any commit after the accepted one. The
-    routine re-runs, finds an INFERENTIAL leak (which the mechanical scanner
-    cannot see, by construction), posts a refused marker — and relief would
-    carry the older clean review forward and merge the leak. That is precisely
-    the class this gate exists to stop, so the veto below is the whole safety
-    argument, not a detail.
+    That is deliberately blunter than the predicate it replaces, which tried to
+    establish that every refusal PREDATED the accepted review it was carrying, via a
+    refusal-vs-candidate ancestry walk. Four review rounds found four different ways
+    that reconstruction was wrong -- too permissive at one round (a refusal at the
+    head overridden by an older acceptance), too strict at the next (an off-branch
+    refusal false-blocking) -- which is the signature of a predicate the available
+    data cannot support. The blunt membership test deletes the whole class: the
+    nested loop, its per-refusal network compares, the merge-budget pressure they
+    created, and the same-SHA collision case.
 
-    The rule: an accepted marker may be carried only when EVERY refusal for that
-    kind is an ANCESTOR of it — i.e. every refusal predates the accepted review
-    and was therefore answered by it. A refusal at the head, or between the
-    accepted marker and the head, vetoes.
+    Two things make the bluntness affordable rather than merely simpler.
+
+    First, the OWNER'S CHRONOLOGY ALREADY RAN. ``_scheduled_review_marker_scan``
+    resolves the owner's latest decisive statement per (head, kind) before this is
+    reached, so a refusal later answered by a clean verdict AT THAT HEAD never
+    reaches ``rejected`` at all. What lands here is a refusal the owner never
+    retracted at the commit it was made about.
+
+    Second, the head axis is NOT a time axis. A clean review of yesterday's code says
+    nothing about today's, so a later acceptance at an older head must never outrank a
+    refusal -- cross-head resolution may only ever ADD acceptance, never remove a
+    refusal. A predicate that let one refusal be "answered" is exactly a predicate that
+    can remove one.
+
+    MEASURED cost, main's own scan over the 40 most recent PRs (all 40 carry a leaks
+    marker): 14 are relief-eligible -- no accepted marker at head, one elsewhere --
+    and this rule denies none of them; two PRs carry a refused row, both already
+    satisfied at their final head. So the observed price of denying on any refusal
+    is ZERO relief lost, and the fallback for the case that does occur is the
+    override plus a human reading a leak finding -- the right outcome when a leaks
+    review has refused.
+
+    BLOCKING RESIDUE closes the one path that reads `rejected` alone would leave: a
+    blocking finding the scan cannot credit to `rejected` -- a same-timestamp tie
+    (neither map, by design) or a malformed / unknown-kind marker whose body reads as
+    blocking. The scan now returns it STRUCTURALLY (``blocking_residue``, head -> kinds,
+    "" for unattributable, "*" for kind-less), so this predicate denies on it without
+    ever matching prose. An adversarial audit reproduced the hole before this existed:
+    a [P1] body under a 12-char ``head=`` at HEAD -- a producer fault the scan records
+    as observed live -- was carried over by the older clean review. On the 40-PR
+    corpus, 7 PRs carry BENIGN unusable rows (re-posts, a short sha, a superseded
+    refusal) and none carry residue: denying on residue costs nothing measured, where
+    denying on any unusable row would have cost 7/40 on their next push.
     """
     relieved: list[tuple[str, str, str]] = []
     reasons: dict[str, str] = {}
     for kind in missing:
-        check_name = _MECHANICAL_RESCAN_BY_KIND.get(kind)
-        if not check_name:
+        pin = _MECHANICAL_RESCAN_BY_KIND.get(kind)
+        if not pin:
             continue
-        # Candidates in the scan's own order, which follows the API's chronological
-        # comment order, and take the LAST — the newest accepted review carries the
-        # smallest never-LLM-reviewed delta. Correctness does not depend on the
-        # ordering (any accepted ancestor that survives the refusal veto is sound);
-        # it minimises exposure. An earlier draft sorted the SHAs and called that
-        # "newest first", which is alphabetical hex order and means nothing.
+        check_name, workflow = pin
+        # ANY refusal for this kind, at ANY head -> no relief. See THE RULE above.
+        if any(kind in kinds for kinds in rejected.values()):
+            reasons[kind] = (
+                "a scheduled review for this kind was REFUSED in this PR and never "
+                "retracted at the commit it was made about, so no earlier review is "
+                "carried forward -- read that finding rather than re-running the review"
+            )
+            continue
+        # Blocking evidence the scan could not credit to `rejected` -- a same-timestamp
+        # tie at some head, or a malformed / unknown-kind marker whose body reads as
+        # blocking -- is RESIDUE, and it denies exactly as a refusal does, at ANY head:
+        # the finding was never provably retracted, and the head axis is not a time
+        # axis. A "*" entry is a blocking body under no creditable kind: it denies
+        # every kind. This closes the path an adversarial audit REPRODUCED (2026-08-30):
+        # a [P1] body under a 12-char `head=` at HEAD landed in `unusable`, and relief
+        # carried the older clean review straight over it.
+        residue_kinds: set[str] = set()
+        for kinds in residue.values():
+            residue_kinds |= kinds
+        if kind in residue_kinds or "*" in residue_kinds:
+            reasons[kind] = (
+                "a marker in this PR carries a blocking finding that could not be "
+                "credited to a head or a kind (a malformed field, or a verdict tied "
+                "with a clean one), so no earlier review is carried forward -- "
+                "resolve that finding first"
+            )
+            continue
         candidates = [h for h, kinds in accepted.items() if h != head and kind in kinds]
         if not candidates:
             continue  # never accepted anywhere in this PR -> nothing to carry forward
-        refusals = [h for h, kinds in rejected.items() if kind in kinds]
-        if head in refusals:
-            reasons[kind] = "a refused review sits at THIS head"
-            continue  # the routine ran at THIS head and found something -> never relieve
-
+        # ANY accepted ancestor will do; stop at the first. The previous code took the
+        # LAST candidate to minimise the un-LLM-reviewed delta, and called that
+        # "newest" -- but `accepted` is keyed by SHA and carries no order, so that was
+        # a claim the data does not support (round-4 finding). The safety argument is
+        # the per-head mechanical scan below, never the size of the delta, so nothing
+        # rests on which ancestor is chosen.
         ancestor = None
         unreadable = False
-        for candidate in reversed(candidates):
-            # The merge path runs these gates sequentially under ONE deadline; each
-            # compare is a network call. Without this check a PR carrying many
-            # markers can walk the budget to zero, and an overrun gets the whole
-            # hook SIGKILLed — which fails toward "tool runs" and disengages the
-            # ENTIRE gate stack. Relief must never be the thing that spends it.
+        for candidate in candidates:
+            # The merge path runs these gates sequentially under ONE deadline, and each
+            # compare is a network call. An overrun gets the whole hook SIGKILLed, which
+            # fails toward "the tool runs" and disengages the ENTIRE gate stack. Relief
+            # must never be the thing that spends that budget.
             if _merge_deadline is not None and time.monotonic() >= _merge_deadline:
                 unreadable = True
                 break
             verdict = _sha_is_ancestor(candidate, head, repo=repo)
             if verdict is None:
-                unreadable = True  # cannot establish history -> fail closed, do not
-                break              # silently fall back to an older marker
-            if not verdict:
-                continue  # rewritten history: this review is not OF this tree
-            # Every refusal must predate this accepted review.
-            answered = True
-            for refusal in refusals:
-                if refusal == candidate:
-                    # SAME SHA carries both an accepted and a refused marker — a
-                    # clean run and a re-run that found something, on one commit.
-                    # The scan stores SETS keyed by head and discards row order, so
-                    # there is no evidence here about which came last. Unprovable
-                    # ordering on a leak gate resolves to a veto.
-                    answered = False
-                    break
-                if _merge_deadline is not None and time.monotonic() >= _merge_deadline:
-                    unreadable = True
-                    answered = False
-                    break
-                r_verdict = _sha_is_ancestor(refusal, candidate, repo=repo)
-                if r_verdict is None:
-                    unreadable = True
-                    answered = False
-                    break
-                if not r_verdict:
-                    answered = False  # a refusal at or after this review -> veto
-                    break
-            if unreadable:
-                break
-            if answered:
+                # An unreadable compare is "I do not know", not "no". It is recorded,
+                # and the loop moves on: since nothing rests on WHICH accepted ancestor
+                # is carried, a candidate that verifies is not a downgrade from one that
+                # could not be read. Only when no candidate verifies does the unknown
+                # decide the outcome -- closed.
+                unreadable = True
+                continue
+            if verdict:
                 ancestor = candidate
                 break
-        if unreadable:
-            reasons[kind] = "the review history could not be established in the time available"
-            continue
         if ancestor is None:
-            reasons[kind] = "every accepted review is off this branch's history, or a refusal supersedes it"
+            reasons[kind] = (
+                "the review history could not be established in the time available"
+                if unreadable
+                else "every accepted review for this kind is off this branch's history"
+            )
             continue
-        if not _mechanical_scan_is_green(pr_num, head, check_name, repo=repo):
+        if not _mechanical_scan_is_green(pr_num, head, check_name, workflow, repo=repo):
             reasons[kind] = (
                 f"an earlier accepted review exists, but '{check_name}' is not green at "
-                f"this head (pending, failed, absent, or unreadable) — check that job "
+                f"this head (pending, failed, absent, or unreadable) -- check that job "
                 f"rather than re-running the scheduled review"
             )
             continue  # unreadable, absent, wrong workflow, pending or failed -> fail CLOSED
@@ -3473,7 +3535,7 @@ def _check_scheduled_claude_reviewed_head(
     describe as "tracked separately": ``_relieve_kinds_by_mechanical_rescan`` may
     carry an ACCEPTED marker forward from an ANCESTOR commit of this PR, but only
     while the kind's MECHANICAL scanner is green at the exact current head, only
-    when no refusal for that kind sits at or after the carried review, and only for
+    never when any refusal or uncreditable blocking finding for that kind exists in the PR, and only for
     kinds in ``_MECHANICAL_RESCAN_BY_KIND``. It is not a delta tolerance: nothing is
     judged by how big or how doc-like the change is. It trades a re-read of the
     inferential layer for a per-head guarantee about the literal layer — strictly
@@ -3506,7 +3568,7 @@ def _check_scheduled_claude_reviewed_head(
             f"Retry, or append '# scheduled-review-override' to merge anyway."
         )
     scan = _scheduled_review_marker_scan(pr_num, repo=repo, head_sha=head)
-    markers, rejected, unusable = (None, {}, []) if scan is None else scan
+    markers, rejected, unusable, residue = (None, {}, [], {}) if scan is None else scan
     if markers is None:
         return (
             f"could not read PR #{pr_num}'s comments/reviews to verify the scheduled Claude "
@@ -3520,7 +3582,7 @@ def _check_scheduled_claude_reviewed_head(
         # A kind already ACCEPTED at an earlier head of this PR is satisfied when its
         # mechanical scanner is green at THIS head (see _MECHANICAL_RESCAN_BY_KIND).
         missing, relieved, relief_reasons = _relieve_kinds_by_mechanical_rescan(
-            missing, markers, rejected, head, pr_num, repo=repo
+            missing, markers, rejected, residue, head, pr_num, repo=repo
         )
         if relief_out is not None:
             relief_out.extend(relieved)

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -3005,8 +3005,14 @@ def _relieve_kinds_by_mechanical_rescan(
     head: str,
     pr_num: str,
     repo: str | None = None,
-) -> tuple[list[str], list[tuple[str, str, str]]]:
+) -> tuple[list[str], list[tuple[str, str, str]], dict[str, str]]:
     """Drop kinds satisfiable by an ANCESTOR ACCEPTED marker + a green scanner at head.
+
+    The third return value maps a kind to WHY its relief failed, when a carriable
+    marker existed but something else stopped it. The block message needs this:
+    "the scanner has not finished" and "the scanner FAILED" call for opposite
+    actions (wait vs fix CI), and neither is "re-run the scheduled review", which
+    is what the message says when it only knows the marker sits on another head.
 
     Returns ``(still_missing, relieved)`` where each *relieved* entry is
     ``(kind, ancestor_head_12, check_name)`` — enough for both the operator note
@@ -3029,6 +3035,7 @@ def _relieve_kinds_by_mechanical_rescan(
     accepted marker and the head, vetoes.
     """
     relieved: list[tuple[str, str, str]] = []
+    reasons: dict[str, str] = {}
     for kind in missing:
         check_name = _MECHANICAL_RESCAN_BY_KIND.get(kind)
         if not check_name:
@@ -3044,11 +3051,20 @@ def _relieve_kinds_by_mechanical_rescan(
             continue  # never accepted anywhere in this PR -> nothing to carry forward
         refusals = [h for h, kinds in rejected.items() if kind in kinds]
         if head in refusals:
+            reasons[kind] = "a refused review sits at THIS head"
             continue  # the routine ran at THIS head and found something -> never relieve
 
         ancestor = None
         unreadable = False
         for candidate in reversed(candidates):
+            # The merge path runs these gates sequentially under ONE deadline; each
+            # compare is a network call. Without this check a PR carrying many
+            # markers can walk the budget to zero, and an overrun gets the whole
+            # hook SIGKILLed — which fails toward "tool runs" and disengages the
+            # ENTIRE gate stack. Relief must never be the thing that spends it.
+            if _merge_deadline is not None and time.monotonic() >= _merge_deadline:
+                unreadable = True
+                break
             verdict = _sha_is_ancestor(candidate, head, repo=repo)
             if verdict is None:
                 unreadable = True  # cannot establish history -> fail closed, do not
@@ -3059,7 +3075,17 @@ def _relieve_kinds_by_mechanical_rescan(
             answered = True
             for refusal in refusals:
                 if refusal == candidate:
-                    continue
+                    # SAME SHA carries both an accepted and a refused marker — a
+                    # clean run and a re-run that found something, on one commit.
+                    # The scan stores SETS keyed by head and discards row order, so
+                    # there is no evidence here about which came last. Unprovable
+                    # ordering on a leak gate resolves to a veto.
+                    answered = False
+                    break
+                if _merge_deadline is not None and time.monotonic() >= _merge_deadline:
+                    unreadable = True
+                    answered = False
+                    break
                 r_verdict = _sha_is_ancestor(refusal, candidate, repo=repo)
                 if r_verdict is None:
                     unreadable = True
@@ -3073,13 +3099,22 @@ def _relieve_kinds_by_mechanical_rescan(
             if answered:
                 ancestor = candidate
                 break
-        if unreadable or ancestor is None:
+        if unreadable:
+            reasons[kind] = "the review history could not be established in the time available"
+            continue
+        if ancestor is None:
+            reasons[kind] = "every accepted review is off this branch's history, or a refusal supersedes it"
             continue
         if not _mechanical_scan_is_green(pr_num, head, check_name, repo=repo):
+            reasons[kind] = (
+                f"an earlier accepted review exists, but '{check_name}' is not green at "
+                f"this head (pending, failed, absent, or unreadable) — check that job "
+                f"rather than re-running the scheduled review"
+            )
             continue  # unreadable, absent, wrong workflow, pending or failed -> fail CLOSED
         relieved.append((kind, ancestor[:12], check_name))
     relieved_kinds = {k for k, _, _ in relieved}
-    return [k for k in missing if k not in relieved_kinds], relieved
+    return [k for k in missing if k not in relieved_kinds], relieved, reasons
 
 
 def _check_scheduled_claude_reviewed_head(
@@ -3195,7 +3230,7 @@ def _check_scheduled_claude_reviewed_head(
     if missing:
         # A kind already ACCEPTED at an earlier head of this PR is satisfied when its
         # mechanical scanner is green at THIS head (see _MECHANICAL_RESCAN_BY_KIND).
-        missing, relieved = _relieve_kinds_by_mechanical_rescan(
+        missing, relieved, relief_reasons = _relieve_kinds_by_mechanical_rescan(
             missing, markers, rejected, head, pr_num, repo=repo
         )
         if relief_out is not None:
@@ -3227,6 +3262,16 @@ def _check_scheduled_claude_reviewed_head(
     # had been read — so this is the general form rather than a fourth point patch: a total
     # partition needs no precedence BETWEEN groups, only within a single kind.
     missing_set = set(missing)
+    # A kind whose RELIEF was attempted and failed has a specific, observed cause,
+    # and it outranks the generic partition below: telling an operator to re-run the
+    # scheduled review is wrong advice when the mechanical scanner is merely still
+    # running (wait) or has failed (fix that job).
+    # ADDITIVE, never substitutive: the three-way partition below was shaped by three
+    # successive review findings and stays intact. This adds the observed relief cause
+    # ALONGSIDE it, first, so the specific remedy is read before the generic one. An
+    # earlier draft removed these kinds from the partition and silently deleted that
+    # hard-won guidance -- caught by its own regression tests.
+    relief_blocked = {k: r for k, r in relief_reasons.items() if k in missing_set}
     refused_kinds = rejected.get(head, set()) & missing_set
     # A marker for a missing kind on some OTHER head — ACCEPTED OR REFUSED. Both prove a
     # routine ran on a different commit; counting only accepted ones sent a
@@ -3276,6 +3321,12 @@ def _check_scheduled_claude_reviewed_head(
         f"(required: {', '.join(required)}; present: "
         f"{', '.join(sorted(kinds_here)) or 'none'}).\n"
         + "".join(f"  * {p}\n" for p in parts)
+        + (
+            "".join(
+                f"  (relief for '{k}' was attempted and declined: {r}.)\n"
+                for k, r in sorted(relief_blocked.items())
+            )
+        )
         + "A marker is a comment/review by the repo OWNER carrying "
         f"'<!-- genesis-scheduled-review: head={head} kind=<name> -->' — the FULL 40-hex "
         "head, exactly as written here.\n"

--- a/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
+++ b/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
@@ -1,4 +1,4 @@
-"""The leaks gate honours an EARLIER accepted marker when the mechanical scanner
+"""The leaks gate honours an ANCESTOR accepted marker when the mechanical scanner
 is green at the CURRENT head.
 
 WHY the relief exists. The scheduled routines are not re-run on a push, so on any
@@ -7,15 +7,22 @@ ten recent PRs: every one with commits after its marker was blocked, and the onl
 escape was `# scheduled-review-override` -- a sigil that verifies NOTHING. Routine
 use of an exception valve is worse than a narrower rule.
 
-WHY IT IS SAFE. The two layers catch different leak classes. The mechanical scanner
+WHY IT IS SAFE. The two layers catch different leak classes: the mechanical scan
 catches literal patterns and runs per-head; the scheduled LLM review catches
 inferential leaks. Carrying the LLM verdict forward while REQUIRING the mechanical
-one at this exact head is strictly more checking than the bare override it replaces.
+one at this exact commit is strictly more checking than the bare override.
 
-Every test here pins a cell of the product {marker state} x {scanner state}, because
-relief that fires on the wrong cell silently weakens an irreducible gate. The
-fail-closed cells matter more than the happy path: a merge gate that mistakes an
-unreadable scan for a pass is worse than one that never grants relief at all.
+THREE PROPERTIES CARRY THAT SAFETY, and each has its own tests below, because
+relief granted on the wrong cell silently weakens an irreducible gate:
+  * ANCESTRY -- "an earlier head of this PR" is NOT "a sha that differs from
+    head". A force-push or rewriting rebase leaves the reviewed commit off the
+    branch, so the PR can carry a wholly different tree while the old marker still
+    names a real commit. Carrying it would vouch for code no reviewer saw.
+  * IDENTITY -- a check is trusted on (name, workflowName), never display name
+    alone; a same-named check from another workflow must not stand in for the
+    scanner. Same decoy class this file's _ci_identity already documents.
+  * HONEST REPORTING -- a carried-forward review must never be rendered as one
+    made at head.
 
 Network-free via the _TEST_GH_* env-injection seams.
 """
@@ -45,127 +52,180 @@ def _marker(*kinds, head=EARLIER, body_prefix="scheduled review done. VERDICT: P
     return json.dumps({"login": "owner", "author_association": "OWNER", "body": body})
 
 
-def _check_runs(*runs):
-    return json.dumps([{"name": n, "conclusion": c} for n, c in runs])
+def _rollup(*, head=HEAD, name="leak-detector", workflow="CI", conclusion="SUCCESS"):
+    entries = []
+    if name is not None:
+        entries.append({"name": name, "workflowName": workflow, "conclusion": conclusion})
+    return json.dumps({"headRefOid": head, "statusCheckRollup": entries})
 
 
 @pytest.fixture(autouse=True)
 def _base(monkeypatch):
     monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
     monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+    monkeypatch.setenv("_TEST_GH_COMPARE_STATUS", "ahead")  # ancestor unless overridden
 
 
-def _gate():
-    return _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+def _gate(relief_out=None):
+    return _mod._check_scheduled_claude_reviewed_head(
+        "1", head_sha=HEAD, repo="acme/pub", relief_out=relief_out
+    )
 
 
 class TestReliefHappyPath:
-    def test_earlier_accepted_marker_plus_green_scanner_passes(self, monkeypatch):
+    def test_ancestor_marker_plus_green_scanner_passes(self, monkeypatch):
         """The whole point: a multi-push PR reviewed once no longer needs an override."""
         monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
-        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("leak-detector", "success")))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
         assert _gate() is None
 
     def test_marker_already_at_head_needs_no_relief(self, monkeypatch):
-        """Control: the pre-existing pass path is untouched, with NO scanner data at all.
+        """CONTROL: the pre-existing pass path works with NO scanner data at all.
 
-        Without this, a bug that made relief the ONLY way to pass would still look
+        Without this, a bug making relief the ONLY way to pass would still look
         green on the happy-path test above.
         """
         monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks", head=HEAD))
-        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", "[]")
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", "")
+        monkeypatch.setenv("_TEST_GH_COMPARE_STATUS", "diverged")
         assert _gate() is None
+
+    def test_relief_is_reported_not_silent(self, monkeypatch):
+        """The caller must learn the review was CARRIED, so the report cannot
+        render a stale review as 'ok (at head)'."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        relief: list = []
+        assert _gate(relief_out=relief) is None
+        assert relief == [("leaks", EARLIER[:12], "leak-detector")]
+
+
+class TestAncestryIsRequired:
+    """A sha that merely DIFFERS from head is not an earlier head of this PR."""
+
+    def test_rewritten_history_blocks(self, monkeypatch):
+        """Force-push / rebase: the reviewed commit is not on this branch.
+
+        The scanner is green and the marker is genuine, so ONLY the ancestry
+        check stands between a rewritten tree and a carried-forward LLM verdict.
+        """
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        monkeypatch.setenv("_TEST_GH_COMPARE_STATUS", "diverged")
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_unreadable_ancestry_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        monkeypatch.setenv("_TEST_GH_COMPARE_STATUS", "")
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    @pytest.mark.parametrize("status", ["ahead", "behind", "identical", "diverged", "weird"])
+    def test_only_ahead_counts(self, monkeypatch, status):
+        monkeypatch.setenv("_TEST_GH_COMPARE_STATUS", status)
+        assert _mod._sha_is_ancestor(EARLIER, HEAD, repo="acme/pub") is (status == "ahead")
+
+
+class TestScannerIdentity:
+    """(name, workflowName), never the display name alone."""
+
+    def test_same_name_wrong_workflow_blocks(self, monkeypatch):
+        """A decoy check with the scanner's name from another workflow must not count."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup(workflow="Decoy"))
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_missing_workflow_name_blocks(self, monkeypatch):
+        """A legacy status context / non-Actions app has no workflowName: unidentifiable."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup(workflow=""))
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_rollup_for_a_different_head_blocks(self, monkeypatch):
+        """The rollup must describe the commit being decided, or it proves nothing."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup(head=EARLIER))
+        msg = _gate()
+        assert msg and "leaks" in msg
 
 
 class TestReliefFailsClosed:
-    """Each cell here MUST still block. These are the tests that keep the relief narrow."""
-
     def test_scanner_failed_blocks(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
-        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("leak-detector", "failure")))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup(conclusion="FAILURE"))
         msg = _gate()
         assert msg and "leaks" in msg
 
     def test_scanner_still_running_blocks(self, monkeypatch):
-        """conclusion is null while a run is in flight -- not success, so no relief."""
         monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
-        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", json.dumps([{"name": "leak-detector"}]))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup(conclusion=None))
         msg = _gate()
         assert msg and "leaks" in msg
 
     def test_scanner_absent_at_head_blocks(self, monkeypatch):
-        """A head the scanner never ran on gets no relief -- absence is not success."""
         monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
-        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("some-other-job", "success")))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup(name=None))
         msg = _gate()
         assert msg and "leaks" in msg
 
-    def test_unreadable_scanner_payload_blocks(self, monkeypatch):
-        """An unreadable mechanical scan must never read as a pass."""
+    def test_unreadable_rollup_blocks(self, monkeypatch):
         monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
-        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", "not json at all")
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", "not json at all")
         msg = _gate()
         assert msg and "leaks" in msg
 
     def test_no_marker_anywhere_blocks_even_when_green(self, monkeypatch):
-        """Relief CARRIES a prior review forward; it never manufactures one.
-
-        A green mechanical scan on a PR the LLM reviewer never looked at must still
-        block -- otherwise the inferential layer is silently dropped entirely.
-        """
+        """Relief CARRIES a prior review forward; it never manufactures one."""
         monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", "")
-        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("leak-detector", "success")))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
         msg = _gate()
         assert msg and "leaks" in msg
 
     def test_refused_earlier_marker_does_not_carry(self, monkeypatch):
-        """A routine that ran and FOUND something must not be carried forward.
-
-        The earlier marker is recorded as REFUSED (its body reads as a blocking
-        finding), so it lives in the rejected map and must not grant relief even
-        with the scanner green.
-        """
+        """A routine that ran and FOUND something must never be carried forward."""
         monkeypatch.setenv(
             "_TEST_GH_SCHEDULED_COMMENTS",
             _marker("leaks", body_prefix="[P1] private hostname in a docstring"),
         )
-        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("leak-detector", "success")))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
         msg = _gate()
         assert msg and "leaks" in msg
 
 
 class TestReliefIsScopedToMappedKinds:
     def test_code_review_gets_no_mechanical_relief(self, monkeypatch):
-        """Only kinds with a named mechanical counterpart are relievable.
-
-        code-review has no scanner that could stand in for it, so an earlier marker
-        plus a green leak-detector must not carry it.
-        """
+        """Only kinds with a named mechanical counterpart are relievable."""
         monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
         monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("code-review", "leaks"))
-        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("leak-detector", "success")))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
         msg = _gate()
         assert msg and "code-review" in msg
-        # leaks WAS relieved, so it must not appear as still-missing.
-        assert "leaks" not in msg.split("(required")[0].split("missing at head")[-1]
 
 
-class TestConclusionReader:
-    """_mechanical_scan_conclusion in isolation: None on every doubt."""
+class TestScannerReader:
+    """_mechanical_scan_is_green in isolation: False on every doubt."""
 
     @pytest.mark.parametrize(
         ("payload", "expected"),
         [
-            (json.dumps([{"name": "leak-detector", "conclusion": "success"}]), "success"),
-            (json.dumps([{"name": "leak-detector", "conclusion": "FAILURE"}]), "failure"),
-            (json.dumps([{"name": "leak-detector", "conclusion": None}]), None),
-            (json.dumps([{"name": "other", "conclusion": "success"}]), None),
-            (json.dumps([]), None),
-            (json.dumps({"not": "a list"}), None),
-            ("", None),
-            ("}{ not json", None),
+            (_rollup(), True),
+            (_rollup(conclusion="FAILURE"), False),
+            (_rollup(conclusion=None), False),
+            (_rollup(workflow="Other"), False),
+            (_rollup(name="other-job"), False),
+            (_rollup(head=EARLIER), False),
+            (_rollup(name=None), False),
+            (json.dumps({"headRefOid": HEAD, "statusCheckRollup": None}), False),
+            (json.dumps(["not", "a", "dict"]), False),
+            ("", False),
+            ("}{ not json", False),
         ],
     )
     def test_reader(self, monkeypatch, payload, expected):
-        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", payload)
-        assert _mod._mechanical_scan_conclusion(HEAD, "leak-detector", repo="acme/pub") == expected
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", payload)
+        got = _mod._mechanical_scan_is_green("1", HEAD, "leak-detector", repo="acme/pub")
+        assert got is expected

--- a/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
+++ b/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
@@ -229,3 +229,157 @@ class TestScannerReader:
         monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", payload)
         got = _mod._mechanical_scan_is_green("1", HEAD, "leak-detector", repo="acme/pub")
         assert got is expected
+
+
+REFUSED_BODY = "[P1] inferential leak: a docstring naming a home town and employer"
+INTERMEDIATE = "2222222222222222222222222222222222222222"
+
+
+def _markers(*entries):
+    """Several owner-authored marker comments, oldest first (API order)."""
+    rows = []
+    for head, kinds, prefix in entries:
+        body = prefix + "\n" + "\n".join(
+            f"<!-- genesis-scheduled-review: head={head} kind={k} -->" for k in kinds
+        )
+        rows.append(json.dumps({"login": "owner", "author_association": "OWNER", "body": body}))
+    return "\n".join(rows)
+
+
+class TestRefusalVetoesRelief:
+    """The cell that matters most: a refusal AT or AFTER the carried review.
+
+    The mechanical scanner cannot see inferential leaks by construction, so if the
+    routine re-ran and refused, carrying an older clean review forward converts a
+    DETECTED leak into a merge — exactly what this gate exists to stop.
+    """
+
+    def test_refused_at_current_head_blocks(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS"),
+                (HEAD, ["leaks"], REFUSED_BODY),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_refused_between_the_carried_review_and_head_blocks(self, monkeypatch):
+        """A refusal on a commit still present at head is the same hole."""
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS"),
+                (INTERMEDIATE, ["leaks"], REFUSED_BODY),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        # EARLIER is an ancestor of HEAD; the refusal at INTERMEDIATE is NOT an
+        # ancestor of EARLIER, so it lands after the carried review and must veto.
+        monkeypatch.setenv(
+            "_TEST_GH_COMPARE_STATUS",
+            json.dumps({
+                f"{EARLIER}...{HEAD}": "ahead",
+                f"{INTERMEDIATE}...{EARLIER}": "diverged",
+            }),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_refusal_already_answered_by_a_later_review_still_relieves(self, monkeypatch):
+        """A refusal that PREDATES the carried review was answered by it.
+
+        Without this the veto would be 'any refusal ever blocks forever', which is
+        too strict — a PR that had a leak, fixed it, and was re-reviewed clean
+        would never get relief again.
+        """
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (INTERMEDIATE, ["leaks"], REFUSED_BODY),
+                (EARLIER, ["leaks"], "re-reviewed after the fix. VERDICT: PASS"),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        monkeypatch.setenv(
+            "_TEST_GH_COMPARE_STATUS",
+            json.dumps({
+                f"{EARLIER}...{HEAD}": "ahead",
+                f"{INTERMEDIATE}...{EARLIER}": "ahead",  # refusal predates the accept
+            }),
+        )
+        assert _gate() is None
+
+    def test_unreadable_refusal_ancestry_blocks(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS"),
+                (INTERMEDIATE, ["leaks"], REFUSED_BODY),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        monkeypatch.setenv(
+            "_TEST_GH_COMPARE_STATUS",
+            json.dumps({f"{EARLIER}...{HEAD}": "ahead"}),  # refusal pair unspecified
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+
+class TestDuplicateRollupEntries:
+    """One head can carry several runs of one job; order is not a guarantee."""
+
+    @pytest.mark.parametrize("order", ["success_first", "failure_first"])
+    def test_a_contradicting_rerun_blocks_in_either_order(self, monkeypatch, order):
+        entries = [
+            {"name": "leak-detector", "workflowName": "CI", "conclusion": "SUCCESS"},
+            {"name": "leak-detector", "workflowName": "CI", "conclusion": "FAILURE"},
+        ]
+        if order == "failure_first":
+            entries.reverse()
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            json.dumps({"headRefOid": HEAD, "statusCheckRollup": entries}),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_two_agreeing_successes_still_relieve(self, monkeypatch):
+        entries = [
+            {"name": "leak-detector", "workflowName": "CI", "conclusion": "SUCCESS"},
+            {"name": "leak-detector", "workflowName": "CI", "conclusion": "SUCCESS"},
+        ]
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv(
+            "_TEST_GH_ROLLUP_WITH_HEAD",
+            json.dumps({"headRefOid": HEAD, "statusCheckRollup": entries}),
+        )
+        assert _gate() is None
+
+
+class TestCandidateSelection:
+    def test_an_unreadable_compare_fails_closed_rather_than_trying_an_older_marker(
+        self, monkeypatch
+    ):
+        """A transient API error must not silently downgrade to an older review."""
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (INTERMEDIATE, ["leaks"], "older. VERDICT: PASS"),
+                (EARLIER, ["leaks"], "newer. VERDICT: PASS"),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        # The NEWEST candidate's compare is unreadable; the older one would be
+        # 'ahead'. Falling back to it would carry a staler review than the gate
+        # was able to verify.
+        monkeypatch.setenv(
+            "_TEST_GH_COMPARE_STATUS",
+            json.dumps({f"{INTERMEDIATE}...{HEAD}": "ahead"}),
+        )
+        msg = _gate()
+        assert msg and "leaks" in msg

--- a/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
+++ b/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
@@ -387,6 +387,35 @@ class TestBlockingResidueDenies:
         msg = _gate()
         assert msg and "could not be credited" in msg
 
+    def test_short_sha_with_a_valid_but_UNKNOWN_kind_denies(self, monkeypatch):
+        """Codex round 6, reproduced through the gate: `head=<short> kind=leak` parses a
+        syntactically valid kind that names no real review. Filing residue under "leak"
+        put the blocking finding somewhere no required kind ever looks, and relief
+        carried past it. An unknown kind is unattributable -> "*" -> denies every kind."""
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS"),
+                (HEAD[:12], ["leak"], REFUSED_BODY),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        msg = _gate()
+        assert msg and "could not be credited" in msg
+
+    def test_short_sha_with_a_KNOWN_other_kind_denies_only_that_kind(self, monkeypatch):
+        """CONTROL for the fix above: a KNOWN kind is still retained, so residue for
+        `code-review` does not deny `leaks`. Without this the fix could be "always *",
+        which would make every malformed blocking marker deny every kind forever."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS"),
+                (HEAD[:12], ["code-review"], REFUSED_BODY),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        assert _gate() is None
+
     def test_same_timestamp_tie_at_head_denies(self, monkeypatch):
         """A clean verdict and a blocking finding at HEAD with the SAME stamp land in
         neither verdict map by design; the tie is residue at HEAD and denies."""
@@ -589,3 +618,76 @@ class TestBlockMessageNamesTheRealRemedy:
         monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
         msg = _gate()
         assert msg and "REFUSED in this PR" in msg
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# The CLASS, enumerated: blocking evidence must never be filed where the
+# relief decision does not read it
+# ══════════════════════════════════════════════════════════════════════════
+_HEADS = {"valid": HEAD, "short": HEAD[:12], "empty": "", "absent": None}
+_KINDS = {"required": "leaks", "known-other": "code-review", "unknown": "leak", "absent": None}
+_BODIES = {"blocking": REFUSED_BODY, "clean": "scheduled review done. VERDICT: PASS"}
+_STATES = {"live": None, "dismissed": "DISMISSED", "pending": "PENDING"}
+_AUTHORS = {"owner": ("owner", "OWNER"), "stranger": ("someone", "NONE")}
+
+
+def _cell_marker(head, kind):
+    parts = []
+    if head is not None:
+        parts.append(f"head={head}")
+    if kind is not None:
+        parts.append(f"kind={kind}")
+    return "<!-- genesis-scheduled-review: " + " ".join(parts) + " -->"
+
+
+@pytest.mark.parametrize("author", sorted(_AUTHORS))
+@pytest.mark.parametrize("state", sorted(_STATES))
+@pytest.mark.parametrize("body", sorted(_BODIES))
+@pytest.mark.parametrize("kind", sorted(_KINDS))
+@pytest.mark.parametrize("head", sorted(_HEADS))
+def test_matrix_blocking_evidence_is_never_filed_out_of_reach(
+    head, kind, body, state, author, monkeypatch
+):
+    """Two review rounds found the SAME class one branch apart: a blocking finding
+    recorded somewhere the relief decision does not read (round 5: the `unusable`
+    bucket; round 6: residue filed under an unknown kind). Two instances is the
+    signal to enumerate rather than patch a third time.
+
+    The axes below are the ones that decide WHERE the scan files a marker. The
+    invariant: a LIVE, OWNER-authored, BLOCKING marker denies relief for the kind it
+    names, and for EVERY kind when it names none that exists — an unattributable
+    finding is evidence about all reviews, not one.
+
+    Deliberately NOT asserted, each with the scan's own reason (an unasserted cell
+    and a hole look identical, so they are named here):
+      * author=stranger — a non-owner comment is not the owner's routine speaking;
+        the scan drops it before any verdict (`login != owner`).
+      * state=dismissed — a dismissed review no longer vouches for anything, and
+        dismissal is an authoritative act by someone with permission.
+      * state=pending — an unpublished draft never ran publicly; the scan states it
+        is read like any other block once submitted.
+    """
+    login, assoc = _AUTHORS[author]
+    row = {"login": login, "author_association": assoc,
+           "body": _BODIES[body] + "\n" + _cell_marker(_HEADS[head], _KINDS[kind])}
+    if _STATES[state]:
+        row["state"] = _STATES[state]
+    monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", "\n".join([
+        json.dumps({"login": "owner", "author_association": "OWNER",
+                    "body": "scheduled review done. VERDICT: PASS\n"
+                            + _cell_marker(EARLIER, "leaks")}),
+        json.dumps(row),
+    ]))
+    monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+
+    denied = _gate() is not None
+    live_owner_blocking = body == "blocking" and state == "live" and author == "owner"
+    if live_owner_blocking and _KINDS[kind] != "code-review":
+        assert denied, (
+            f"blocking finding filed out of reach: head={head} kind={kind} — relief was "
+            f"granted over a live owner finding"
+        )
+    elif live_owner_blocking:
+        assert not denied, (
+            "over-correction: a code-review finding must not deny the leaks gate"
+        )

--- a/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
+++ b/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
@@ -383,3 +383,71 @@ class TestCandidateSelection:
         )
         msg = _gate()
         assert msg and "leaks" in msg
+
+
+class TestSameShaCollision:
+    def test_accepted_and_refused_on_the_same_commit_vetoes(self, monkeypatch):
+        """One commit carrying BOTH verdicts is unprovable, so it must veto.
+
+        The routine can run twice on one head -- clean, then a re-run that finds an
+        inferential leak. The marker scan stores SETS keyed by head and discards row
+        order, so there is no evidence here about which verdict came last. Carrying
+        the acceptance forward would be guessing, on the gate whose whole job is to
+        not guess about leaks.
+        """
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS"),
+                (EARLIER, ["leaks"], REFUSED_BODY),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+
+class TestMergeDeadline:
+    def test_an_exhausted_deadline_blocks_rather_than_walking_on(self, monkeypatch):
+        """Relief must not spend the shared merge budget.
+
+        The merge gates run sequentially under ONE deadline; each ancestry check is a
+        network call. A PR with many markers could walk that budget to zero, and an
+        overrun gets the whole hook SIGKILLed -- which fails toward "the tool runs"
+        and disengages the ENTIRE gate stack. Relief being the thing that spends it
+        would be a bypass of every gate, not just this one.
+        """
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        monkeypatch.setattr(_mod, "_merge_deadline", _mod.time.monotonic() - 1)
+        msg = _gate()
+        assert msg and "leaks" in msg
+        assert "time available" in msg, "the block must name the deadline as the cause"
+
+
+class TestBlockMessageNamesTheRealRemedy:
+    """A failed relief has an observed cause; the message must give ITS remedy."""
+
+    def test_pending_scanner_is_not_reported_as_a_stale_marker(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup(conclusion=None))
+        msg = _gate()
+        assert msg and "leak-detector" in msg, "the message must name the scanner"
+        assert "not green at this head" in msg
+        # The scanner cause is reported ALONGSIDE the generic partition, not instead
+        # of it -- that partition is hard-won and its own tests guard it. What matters
+        # is that the specific, actionable cause is present and named, and that it
+        # comes FIRST so it is read before the generic advice.
+        assert msg.index("leak-detector") < msg.index("kind=leaks") if "kind=leaks" in msg else True
+
+    def test_refused_at_head_says_so_rather_than_blaming_the_scanner(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS"),
+                (HEAD, ["leaks"], REFUSED_BODY),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        msg = _gate()
+        assert msg and "refused review sits at THIS head" in msg

--- a/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
+++ b/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
@@ -1,0 +1,171 @@
+"""The leaks gate honours an EARLIER accepted marker when the mechanical scanner
+is green at the CURRENT head.
+
+WHY the relief exists. The scheduled routines are not re-run on a push, so on any
+multi-push PR the marker sits at the first head and the gate blocks. Measured over
+ten recent PRs: every one with commits after its marker was blocked, and the only
+escape was `# scheduled-review-override` -- a sigil that verifies NOTHING. Routine
+use of an exception valve is worse than a narrower rule.
+
+WHY IT IS SAFE. The two layers catch different leak classes. The mechanical scanner
+catches literal patterns and runs per-head; the scheduled LLM review catches
+inferential leaks. Carrying the LLM verdict forward while REQUIRING the mechanical
+one at this exact head is strictly more checking than the bare override it replaces.
+
+Every test here pins a cell of the product {marker state} x {scanner state}, because
+relief that fires on the wrong cell silently weakens an irreducible gate. The
+fail-closed cells matter more than the happy path: a merge gate that mistakes an
+unreadable scan for a pass is worse than one that never grants relief at all.
+
+Network-free via the _TEST_GH_* env-injection seams.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parent.parent.parent
+_HOOKS_DIR = _WORKTREE / "scripts" / "hooks"
+_spec = importlib.util.spec_from_file_location("git_push_guard", _HOOKS_DIR / "git_push_guard.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+HEAD = "0cd13afeb51025af5dc7bd24df1ffa57cd2babab"
+EARLIER = "1111111111111111111111111111111111111111"
+
+
+def _marker(*kinds, head=EARLIER, body_prefix="scheduled review done. VERDICT: PASS"):
+    body = body_prefix + "\n" + "\n".join(
+        f"<!-- genesis-scheduled-review: head={head} kind={k} -->" for k in kinds
+    )
+    return json.dumps({"login": "owner", "author_association": "OWNER", "body": body})
+
+
+def _check_runs(*runs):
+    return json.dumps([{"name": n, "conclusion": c} for n, c in runs])
+
+
+@pytest.fixture(autouse=True)
+def _base(monkeypatch):
+    monkeypatch.setenv("_TEST_CANONICAL_PUBLIC_REPO", "acme/pub")
+    monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "leaks")
+
+
+def _gate():
+    return _mod._check_scheduled_claude_reviewed_head("1", head_sha=HEAD, repo="acme/pub")
+
+
+class TestReliefHappyPath:
+    def test_earlier_accepted_marker_plus_green_scanner_passes(self, monkeypatch):
+        """The whole point: a multi-push PR reviewed once no longer needs an override."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("leak-detector", "success")))
+        assert _gate() is None
+
+    def test_marker_already_at_head_needs_no_relief(self, monkeypatch):
+        """Control: the pre-existing pass path is untouched, with NO scanner data at all.
+
+        Without this, a bug that made relief the ONLY way to pass would still look
+        green on the happy-path test above.
+        """
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks", head=HEAD))
+        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", "[]")
+        assert _gate() is None
+
+
+class TestReliefFailsClosed:
+    """Each cell here MUST still block. These are the tests that keep the relief narrow."""
+
+    def test_scanner_failed_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("leak-detector", "failure")))
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_scanner_still_running_blocks(self, monkeypatch):
+        """conclusion is null while a run is in flight -- not success, so no relief."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", json.dumps([{"name": "leak-detector"}]))
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_scanner_absent_at_head_blocks(self, monkeypatch):
+        """A head the scanner never ran on gets no relief -- absence is not success."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("some-other-job", "success")))
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_unreadable_scanner_payload_blocks(self, monkeypatch):
+        """An unreadable mechanical scan must never read as a pass."""
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", "not json at all")
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_no_marker_anywhere_blocks_even_when_green(self, monkeypatch):
+        """Relief CARRIES a prior review forward; it never manufactures one.
+
+        A green mechanical scan on a PR the LLM reviewer never looked at must still
+        block -- otherwise the inferential layer is silently dropped entirely.
+        """
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", "")
+        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("leak-detector", "success")))
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+    def test_refused_earlier_marker_does_not_carry(self, monkeypatch):
+        """A routine that ran and FOUND something must not be carried forward.
+
+        The earlier marker is recorded as REFUSED (its body reads as a blocking
+        finding), so it lives in the rejected map and must not grant relief even
+        with the scanner green.
+        """
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _marker("leaks", body_prefix="[P1] private hostname in a docstring"),
+        )
+        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("leak-detector", "success")))
+        msg = _gate()
+        assert msg and "leaks" in msg
+
+
+class TestReliefIsScopedToMappedKinds:
+    def test_code_review_gets_no_mechanical_relief(self, monkeypatch):
+        """Only kinds with a named mechanical counterpart are relievable.
+
+        code-review has no scanner that could stand in for it, so an earlier marker
+        plus a green leak-detector must not carry it.
+        """
+        monkeypatch.setenv("_TEST_REQUIRED_SCHEDULED_REVIEWS", "code-review,leaks")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("code-review", "leaks"))
+        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", _check_runs(("leak-detector", "success")))
+        msg = _gate()
+        assert msg and "code-review" in msg
+        # leaks WAS relieved, so it must not appear as still-missing.
+        assert "leaks" not in msg.split("(required")[0].split("missing at head")[-1]
+
+
+class TestConclusionReader:
+    """_mechanical_scan_conclusion in isolation: None on every doubt."""
+
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            (json.dumps([{"name": "leak-detector", "conclusion": "success"}]), "success"),
+            (json.dumps([{"name": "leak-detector", "conclusion": "FAILURE"}]), "failure"),
+            (json.dumps([{"name": "leak-detector", "conclusion": None}]), None),
+            (json.dumps([{"name": "other", "conclusion": "success"}]), None),
+            (json.dumps([]), None),
+            (json.dumps({"not": "a list"}), None),
+            ("", None),
+            ("}{ not json", None),
+        ],
+    )
+    def test_reader(self, monkeypatch, payload, expected):
+        monkeypatch.setenv("_TEST_GH_CHECK_RUNS", payload)
+        assert _mod._mechanical_scan_conclusion(HEAD, "leak-detector", repo="acme/pub") == expected

--- a/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
+++ b/tests/test_hooks/test_leaks_gate_mechanical_rescan.py
@@ -138,6 +138,19 @@ class TestScannerIdentity:
         msg = _gate()
         assert msg and "leaks" in msg
 
+    def test_same_name_from_another_REQUIRED_workflow_blocks(self, monkeypatch):
+        """Round-4 finding, now pinned: membership in the required-CI SET is not
+        identity. The pre-pin code PASSED this shape (measured by the audit)."""
+        monkeypatch.setenv("_TEST_REQUIRED_CI_WORKFLOWS", "CI,Nightly")
+        monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup(workflow="Nightly"))
+        msg = _gate()
+        assert msg and "not green at this head" in msg
+
+    def test_empty_workflow_pin_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        assert _mod._mechanical_scan_is_green("1", HEAD, "leak-detector", "", repo="acme/pub") is False
+
     def test_missing_workflow_name_blocks(self, monkeypatch):
         """A legacy status context / non-Actions app has no workflowName: unidentifiable."""
         monkeypatch.setenv("_TEST_GH_SCHEDULED_COMMENTS", _marker("leaks"))
@@ -227,7 +240,7 @@ class TestScannerReader:
     )
     def test_reader(self, monkeypatch, payload, expected):
         monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", payload)
-        got = _mod._mechanical_scan_is_green("1", HEAD, "leak-detector", repo="acme/pub")
+        got = _mod._mechanical_scan_is_green("1", HEAD, "leak-detector", "CI", repo="acme/pub")
         assert got is expected
 
 
@@ -246,12 +259,17 @@ def _markers(*entries):
     return "\n".join(rows)
 
 
-class TestRefusalVetoesRelief:
-    """The cell that matters most: a refusal AT or AFTER the carried review.
+class TestAnyRefusalDenies:
+    """THE RULE: a refusal for the kind, anywhere in the PR, denies relief.
 
-    The mechanical scanner cannot see inferential leaks by construction, so if the
-    routine re-ran and refused, carrying an older clean review forward converts a
-    DETECTED leak into a merge — exactly what this gate exists to stop.
+    The mechanical scanner cannot see inferential leaks by construction, so carrying
+    an older clean review past a refusal would convert a DETECTED leak into a merge.
+    The previous predicate tried to establish that every refusal PREDATED the carried
+    review via ancestry compares; four review rounds found four ways that
+    reconstruction was wrong. The membership test replaces all of it. The owner's
+    chronology already ran inside the scan: a refusal answered by a clean verdict AT
+    ITS OWN HEAD never reaches `rejected`, so what lands here is a refusal the owner
+    never retracted at the commit it was made about.
     """
 
     def test_refused_at_current_head_blocks(self, monkeypatch):
@@ -267,7 +285,6 @@ class TestRefusalVetoesRelief:
         assert msg and "leaks" in msg
 
     def test_refused_between_the_carried_review_and_head_blocks(self, monkeypatch):
-        """A refusal on a commit still present at head is the same hole."""
         monkeypatch.setenv(
             "_TEST_GH_SCHEDULED_COMMENTS",
             _markers(
@@ -276,24 +293,21 @@ class TestRefusalVetoesRelief:
             ),
         )
         monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
-        # EARLIER is an ancestor of HEAD; the refusal at INTERMEDIATE is NOT an
-        # ancestor of EARLIER, so it lands after the carried review and must veto.
-        monkeypatch.setenv(
-            "_TEST_GH_COMPARE_STATUS",
-            json.dumps({
-                f"{EARLIER}...{HEAD}": "ahead",
-                f"{INTERMEDIATE}...{EARLIER}": "diverged",
-            }),
-        )
         msg = _gate()
         assert msg and "leaks" in msg
 
-    def test_refusal_already_answered_by_a_later_review_still_relieves(self, monkeypatch):
-        """A refusal that PREDATES the carried review was answered by it.
+    def test_a_refusal_that_predates_the_accepted_review_still_denies(self, monkeypatch):
+        """DELIBERATE, decided 2026-08-30: the head axis is not a time axis.
 
-        Without this the veto would be 'any refusal ever blocks forever', which is
-        too strict — a PR that had a leak, fixed it, and was re-reviewed clean
-        would never get relief again.
+        A clean review of yesterday's code says nothing about today's, so a LATER
+        acceptance at an OLDER head must never outrank a refusal. Cross-head resolution
+        may only ever ADD acceptance, never remove a refusal. The previous version of
+        this test asserted the opposite ("answered by a later review still relieves");
+        that was the predicate the redesign deleted. Measured cost on the 30 most
+        recent marker-carrying PRs: zero relief lost -- every observed refusal was
+        superseded at its own head, false, or followed by a clean marker at the final
+        head. The fallback for the case that does occur is the override plus a human
+        reading a leak finding, which is the right outcome.
         """
         monkeypatch.setenv(
             "_TEST_GH_SCHEDULED_COMMENTS",
@@ -303,16 +317,15 @@ class TestRefusalVetoesRelief:
             ),
         )
         monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
-        monkeypatch.setenv(
-            "_TEST_GH_COMPARE_STATUS",
-            json.dumps({
-                f"{EARLIER}...{HEAD}": "ahead",
-                f"{INTERMEDIATE}...{EARLIER}": "ahead",  # refusal predates the accept
-            }),
-        )
-        assert _gate() is None
+        msg = _gate()
+        assert msg and "leaks" in msg
+        assert "REFUSED in this PR" in msg, "the reason must name the refusal, not the scanner"
 
-    def test_unreadable_refusal_ancestry_blocks(self, monkeypatch):
+    def test_no_ancestry_compare_is_spent_on_a_refusal(self, monkeypatch):
+        """The membership test costs no network: with a refusal present, relief is
+        denied before any compare runs -- even when every compare would be
+        UNREADABLE. (The old predicate walked the refusals with per-refusal compares
+        and could exhaust the shared merge deadline doing it.)"""
         monkeypatch.setenv(
             "_TEST_GH_SCHEDULED_COMMENTS",
             _markers(
@@ -321,12 +334,86 @@ class TestRefusalVetoesRelief:
             ),
         )
         monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
-        monkeypatch.setenv(
-            "_TEST_GH_COMPARE_STATUS",
-            json.dumps({f"{EARLIER}...{HEAD}": "ahead"}),  # refusal pair unspecified
+        monkeypatch.setenv("_TEST_GH_COMPARE_STATUS", "")  # every compare unreadable
+        msg = _gate()
+        assert msg and "REFUSED in this PR" in msg
+        assert "time available" not in msg, "a refusal must be the stated cause, not the deadline"
+
+
+def _stamped(*entries):
+    """Owner marker rows WITH timestamps, so the scan's tie rule can engage (rows without
+    a stamp keep list order and cannot tie)."""
+    rows = []
+    for head, kinds, prefix, stamp in entries:
+        body = prefix + "\n" + "\n".join(
+            f"<!-- genesis-scheduled-review: head={head} kind={k} -->" for k in kinds
         )
+        rows.append(json.dumps({
+            "login": "owner", "author_association": "OWNER", "body": body, "stamp": stamp,
+        }))
+    return "\n".join(rows)
+
+
+class TestBlockingResidueDenies:
+    """The path an adversarial audit REPRODUCED on the entry point (2026-08-30): a
+    blocking finding the scan files under `unusable` rather than `rejected` must deny
+    relief exactly as a refusal does. Both shapes below granted relief before the scan
+    exposed `blocking_residue`."""
+
+    def test_blocking_body_under_a_short_sha_at_head_denies(self, monkeypatch):
+        """A [P1] under a 12-char head= is a producer fault the scan records as seen
+        live. It is unattributable to a head, so it is residue under "" and denies."""
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS"),
+                (HEAD[:12], ["leaks"], REFUSED_BODY),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
         msg = _gate()
         assert msg and "leaks" in msg
+        assert "could not be credited" in msg, "the reason must name the residue, not the scanner"
+
+    def test_blocking_body_under_an_unknown_kind_denies_every_kind(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS"),
+                (HEAD, ["leak"], REFUSED_BODY),  # singular typo: no known kind
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        msg = _gate()
+        assert msg and "could not be credited" in msg
+
+    def test_same_timestamp_tie_at_head_denies(self, monkeypatch):
+        """A clean verdict and a blocking finding at HEAD with the SAME stamp land in
+        neither verdict map by design; the tie is residue at HEAD and denies."""
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _stamped(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS", "2026-08-30T10:00:00Z"),
+                (HEAD, ["leaks"], "re-run. VERDICT: PASS", "2026-08-30T12:00:00Z"),
+                (HEAD, ["leaks"], REFUSED_BODY, "2026-08-30T12:00:00Z"),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        msg = _gate()
+        assert msg and "could not be credited" in msg
+
+    def test_benign_unusable_rows_do_not_deny(self, monkeypatch):
+        """CONTROL: a short-sha marker with a CLEAN body is plain `unusable`, never
+        residue -- 7 of 40 recent PRs carry rows like it, and they must still relieve."""
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (EARLIER, ["leaks"], "scheduled review done. VERDICT: PASS"),
+                (HEAD[:12], ["leaks"], "re-run. PII scan: CLEAN"),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        assert _gate() is None
 
 
 class TestDuplicateRollupEntries:
@@ -362,10 +449,16 @@ class TestDuplicateRollupEntries:
 
 
 class TestCandidateSelection:
-    def test_an_unreadable_compare_fails_closed_rather_than_trying_an_older_marker(
-        self, monkeypatch
-    ):
-        """A transient API error must not silently downgrade to an older review."""
+    """Any accepted ancestor will do. Nothing rests on WHICH one is carried: the safety
+    argument is the per-head mechanical scan, never the age of the carried review (the
+    previous code took the last candidate and called that "newest", a claim the SHA-keyed
+    map cannot support). So an unreadable compare is "I do not know", not "no": it is
+    recorded and the next candidate is tried; only when no candidate verifies does the
+    unknown decide -- closed."""
+
+    def test_multiple_accepted_markers_relieve(self, monkeypatch):
+        """The load-bearing case: about a third of recent PRs carry MORE than one accepted
+        leaks marker. Both are ancestors; relief must not depend on picking one."""
         monkeypatch.setenv(
             "_TEST_GH_SCHEDULED_COMMENTS",
             _markers(
@@ -374,26 +467,71 @@ class TestCandidateSelection:
             ),
         )
         monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
-        # The NEWEST candidate's compare is unreadable; the older one would be
-        # 'ahead'. Falling back to it would carry a staler review than the gate
-        # was able to verify.
+        relief: list = []
+        assert _gate(relief_out=relief) is None
+        assert relief and relief[0][0] == "leaks"
+
+    def test_one_unreadable_candidate_does_not_block_when_another_verifies(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (INTERMEDIATE, ["leaks"], "first in scan order. VERDICT: PASS"),
+                (EARLIER, ["leaks"], "second. VERDICT: PASS"),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        # INTERMEDIATE's compare is unreadable (unspecified); EARLIER's is 'ahead'.
         monkeypatch.setenv(
             "_TEST_GH_COMPARE_STATUS",
-            json.dumps({f"{INTERMEDIATE}...{HEAD}": "ahead"}),
+            json.dumps({f"{EARLIER}...{HEAD}": "ahead"}),
         )
+        assert _gate() is None
+
+    def test_all_unreadable_fails_closed(self, monkeypatch):
+        """When NOTHING can be proven the unknown decides, and it decides closed --
+        never a silent fall-through to relief."""
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (INTERMEDIATE, ["leaks"], "older. VERDICT: PASS"),
+                (EARLIER, ["leaks"], "newer. VERDICT: PASS"),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        monkeypatch.setenv("_TEST_GH_COMPARE_STATUS", json.dumps({}))
         msg = _gate()
         assert msg and "leaks" in msg
+        assert "time available" in msg
+
+    def test_off_branch_plus_unreadable_still_fails_closed(self, monkeypatch):
+        """A candidate that is provably NOT an ancestor is skipped (that is a real
+        'no'); if the only other candidate is unreadable, the unknown still wins."""
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            _markers(
+                (INTERMEDIATE, ["leaks"], "rewritten away. VERDICT: PASS"),
+                (EARLIER, ["leaks"], "unreadable. VERDICT: PASS"),
+            ),
+        )
+        monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
+        monkeypatch.setenv(
+            "_TEST_GH_COMPARE_STATUS",
+            json.dumps({f"{INTERMEDIATE}...{HEAD}": "diverged"}),
+        )
+        msg = _gate()
+        assert msg and "time available" in msg
 
 
 class TestSameShaCollision:
     def test_accepted_and_refused_on_the_same_commit_vetoes(self, monkeypatch):
-        """One commit carrying BOTH verdicts is unprovable, so it must veto.
+        """One commit carrying both verdicts is resolved by the SCAN, not by us.
 
         The routine can run twice on one head -- clean, then a re-run that finds an
-        inferential leak. The marker scan stores SETS keyed by head and discards row
-        order, so there is no evidence here about which verdict came last. Carrying
-        the acceptance forward would be guessing, on the gate whose whole job is to
-        not guess about leaks.
+        inferential leak. The scan resolves that by the owner's latest DECISIVE
+        statement (rows carry timestamps; the test seam keeps list order), so the later
+        refusal governs and lands in `rejected`; the membership test then denies. The
+        relief code carries NO same-commit veto of its own any more -- two answers to
+        one question was exactly the class the redesign deleted.
         """
         monkeypatch.setenv(
             "_TEST_GH_SCHEDULED_COMMENTS",
@@ -450,4 +588,4 @@ class TestBlockMessageNamesTheRealRemedy:
         )
         monkeypatch.setenv("_TEST_GH_ROLLUP_WITH_HEAD", _rollup())
         msg = _gate()
-        assert msg and "refused review sits at THIS head" in msg
+        assert msg and "REFUSED in this PR" in msg


### PR DESCRIPTION
## What this changes

The merge gate's scheduled-review check requires an owner-authored marker for every required review kind at the PR's exact head. The leak-scan routine stamps a marker at the head it ran on and does not re-stamp after a push, so a multi-push PR reads as "stale" by construction and `# scheduled-review-override` had become the routine path — measured at 6 of 10 sampled multi-push PRs blocked purely for that reason.

This PR adds one narrow, mechanical relief for the `leaks` kind only, and (after the marker-scan rewrite landed on main) rebuilds it on the new scan with less code than before.

## The rule

An ACCEPTED `leaks` marker on an ancestor of the current head satisfies the gate **iff**:

1. **No refused `leaks` marker exists anywhere in the PR.** One membership test. The scan already resolves each (head, kind) by the owner's latest decisive statement, so a refusal answered by a clean verdict at its own head never reaches this predicate; what does reach it is a refusal never retracted at the commit it was made about. A later acceptance at an older head must never outrank that — the head axis is not a time axis.
2. **The carried marker is a verified ancestor of head.** An unreadable compare is "unknown", not "yes": the next candidate is tried, and if nothing verifies the outcome is closed. A force-push or rewrite that leaves the reviewed commit off the branch gets no relief.
3. **The `leak-detector` check of the `CI` workflow is green at head**, identified by that (name, workflow) pair rather than by membership in the required-CI set — a same-named check from another workflow does not count. All same-identity rollup entries must agree. The pin is read from this repo's own workflow file, so it holds on a fresh clone; a differently named suite gets no relief rather than a weaker gate.
4. Every ancestry compare respects the shared merge deadline; relief never spends the budget whose overrun would disengage the whole gate stack.

`code-review` is not mapped; it gets no mechanical relief.

## What it renders

- Block message: the relief reason ("the scanner has not finished" / "failed" / "the carried marker is not an ancestor" / "a refused review exists") is added **alongside** the scan's inventory, never replacing it.
- `--check-pr`: a carried marker renders as `ok (leaks carried from <sha>, leak-detector green at head)`, never as `ok (at head)`.

## Blocking residue — the path the audit reproduced

A blocking finding that the scan files under `unusable` — a same-timestamp tie (deliberately recorded in neither verdict map) or a malformed / unknown-kind marker whose body reads as blocking — was invisible to a `rejected`-only predicate. An un-anchored adversarial audit reproduced it on the real entry point: a `[P1]` body under a 12-char `head=` at HEAD (a producer fault the scan records as observed live) was carried over by the older clean review.

The close is structural, not prose-matching: the scan returns a fourth, additive element `blocking_residue: dict[head, set[kind]]` (`""` for an unattributable head, `"*"` for a blocking body under no creditable kind), and relief denies on residue at any head exactly as it does on a refusal. The three existing return shapes are unchanged. Benign unusable rows — plain re-posts, a clean-bodied short-SHA stamp, a refusal superseded at its own head — never enter residue; a control test pins that, because 7 of the 40 PRs below carry such rows and must keep relieving.

## Measured

- **Corpus (main's scan over the 40 most recent PRs):** 40/40 carry a leaks marker; 14 are relief-eligible (no accepted marker at head, one elsewhere); this rule denies **0/14**. A blanket "any unusable row denies" alternative would also deny 0 today, but 7/40 PRs carry benign owner-authored unusable rows (five plain re-posts of a clean statement, one short SHA, one superseded refusal) and would lose relief on their next push — which is why the structured field, not a blanket arm, is the right close.
- **Verify-RED:** five mutations (drop the refusal test; accept the scanner from any workflow; skip the ancestry check; ignore the merge deadline; treat an unreadable compare as verified) each turn a named test red; the guard is restored byte-exact after each and the sweep aborts if a run emits no result line.
- **Tests:** 46 in the relief suite; 545 across the leaks-gate, Codex-freshness and merge-review-gate suites on the merged base.

## Review history

Four rounds on the earlier shape (~14 findings), which reconstructed review history from a source that then discarded ordering; main's scan rewrite (#1544, #1548) made that reconstruction unnecessary, and this revision deletes it rather than hardening it again. Codex re-review at the new head is required before merge (hook surface).
