### PR TITLE
fix(hooks): fold a line continuation the way the shell does

### DIFF
--- a/scripts/hooks/destructive_command_guard.py
+++ b/scripts/hooks/destructive_command_guard.py
@@ -100,12 +100,24 @@ def _rm_violations(cmd: str) -> list[str] | None:
     """Reasons to block, or None when the command cannot be tokenized."""
     # Line-continuations and bare newlines must be handled BEFORE shlex, which
     # drops a bare newline as whitespace (so a following command would fold into
-    # the first rm's operands). These replacements only ever insert spaces/`;`,
-    # never quote or escape characters, so they cannot corrupt shlex's quote
-    # balance. Redirections are NOT stripped here — they are recognized at the
-    # token level after shlex (see _REDIR_TOKEN), so shlex stays the sole
-    # authority on quoting/escaping.
-    cmd = cmd.replace("\\\n", " ").replace("\n", " ; ")
+    # the first rm's operands) and keeps an escaped newline INSIDE the token.
+    #
+    # A backslash-newline is folded to NOTHING, because that is what the shell
+    # does: it is deleted, and the characters either side of it become one word.
+    # An earlier version folded it to a space, which SPLITS a word the shell
+    # joins. Measured: that let a continuation placed inside an option token turn
+    # a recursive-force removal of a protected path into two tokens the guard
+    # recognized as neither, and the command was allowed. The guard must read
+    # the command the shell will run, not a nearby one. (Inside single quotes
+    # the shell keeps the sequence literally; folding it there only changes the
+    # spelling of one operand, never its depth or its flags.)
+    #
+    # These replacements delete a continuation or insert whitespace/`;`, never
+    # quote or escape characters, so they cannot corrupt shlex's quote balance.
+    # Redirections are NOT stripped here — they are recognized at the token
+    # level after shlex (see _REDIR_TOKEN), so shlex stays the sole authority on
+    # quoting/escaping.
+    cmd = cmd.replace("\\\n", "").replace("\n", " ; ")
     # Space glued command separators (`x;y`, `a&&b`) into standalone tokens so
     # the operand loop stops at them; a redirection `&` is preserved.
     spaced = _SEPARATOR_SPACING.sub(r" \1 ", cmd)

--- a/tests/test_hooks/test_destructive_command_guard.py
+++ b/tests/test_hooks/test_destructive_command_guard.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "hooks"))
 import destructive_command_guard as dg  # noqa: E402
 
@@ -83,3 +85,35 @@ class TestSafetyNoOverBlock:
 
     def test_no_rm_at_all(self):
         assert not _blocks("git status")
+
+
+class TestLineContinuationFoldsAsTheShellFolds:
+    """A backslash-newline is DELETED by the shell, not replaced by whitespace.
+
+    The guard's pre-tokenizer must fold it the same way, or a token the shell
+    reads as one is read here as two — and a verdict taken on the two-token
+    reading is a verdict on a command the shell never runs. Asserted as a
+    PROPERTY over pairs: the guard's answer for the continued form must equal
+    its answer for the form the shell actually executes, in both directions.
+    """
+
+    @pytest.mark.parametrize(
+        ("continued", "joined"),
+        [
+            ("rm -\\\nrf ~/genesis", "rm -rf ~/genesis"),
+            ("rm -r\\\nf /home/u/genesis", "rm -rf /home/u/genesis"),
+            ("rm -rf /home/u/gen\\\nesis", "rm -rf /home/u/genesis"),
+            ("rm -rf /home/u/a/b/c/d\\\n/e", "rm -rf /home/u/a/b/c/d/e"),
+            ("rm -rf /a/b/c/d/e \\\n/f/g", "rm -rf /a/b/c/d/e /f/g"),
+        ],
+    )
+    def test_continued_and_joined_forms_get_the_same_verdict(self, continued, joined):
+        assert dg._rm_violations(continued) == dg._rm_violations(joined), (
+            f"{continued!r} -> {dg._rm_violations(continued)!r}; "
+            f"shell runs {joined!r} -> {dg._rm_violations(joined)!r}"
+        )
+
+    def test_positive_control_the_joined_form_is_refused(self):
+        """Without this, an implementation that returned None for everything
+        would satisfy the equality above."""
+        assert _blocks("rm -rf ~/genesis")


### PR DESCRIPTION
## Summary

The destructive-command guard normalizes a command before tokenizing it, and one step replaced a backslash-newline with a space. The shell deletes that sequence: the characters either side of it become one word. So the guard could read one word as two and take its verdict on a command the shell never runs.

Measured against the real hook entry: a continuation placed inside an option token made a recursive-force removal of a protected path read as two tokens the guard recognized as neither, and the command was **allowed**; the plain spelling of the same command is refused. Both spellings are now refused.

## The fix

One line: the fold deletes the sequence instead of replacing it with whitespace, which is what the shell does. The surrounding rationale is rewritten to say why, including the one place the shell and the guard still differ (inside single quotes the shell keeps the sequence literally) and why that difference can only change the spelling of an operand, never its depth or its flags.

## What was wrong before, and why it was believed

An audit of this guard earlier this month concluded its fold could only ever move a verdict toward refusing. That audit split path operands at every position and never split the option token — the examples were treated as the specification — and its zero-flips result was taken over benign recorded commands with no true-positive control, which is the measurement this repository's own notes warn yields a confident wrong answer. The claim is withdrawn where it appears.

## Verification

- Property test, written first and watched failing on 4 of 5 pairs: the guard's answer for the continued form must equal its answer for the form the shell executes. A positive control asserts the joined form is refused, so an implementation that returned nothing for everything cannot satisfy the equality. The test's docstring states the mechanism, not the outcome.
- Verify-RED after the fix: reverting the fold on disk fails the same 4.
- Differential over every distinct Bash command recorded on this install (22,392; 259 contain a continuation): **0 verdict flips** on real traffic. The constructed shape is the only flip, allowed → refused.
- End-to-end through the real PreToolUse entry on the fixed tree: both spellings of the shallow target refused; two spellings of a deep target allowed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of potentially destructive shell commands that use backslash-newline continuations.
  * Prevented incorrectly split command arguments, flags, paths, and operands from bypassing safety checks.

* **Tests**
  * Added regression coverage for continued commands and recursive home-directory deletion safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->