### PR TITLE
fix(hooks): make the merge gate's "(logged)" promise true

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1474,7 +1474,17 @@ The review-findings gate specifically:
    on CI alone. Note in PR that review was quota-limited.
 5. **Override**: Append `# review-override` to the merge command to
    bypass the gate (e.g., `gh pr merge 123 --squash --admin  # review-override`).
-   The override is logged. Use only when findings are intentionally accepted.
+   The override is logged — one metadata row per sigil in
+   `~/.genesis/merge_override_log.jsonl` (sigil, PR, bound head, which gate it
+   waived, and what the command actually got: `allowed` / `asked` / `blocked` /
+   `error`), so "was this escape reached for?" is a query rather than a survey.
+   `blocked` matters: a sigil can be appended to a command that some OTHER gate
+   then stops, which is a real signal but not an override that took effect, and
+   `asked` means the decision went to a human who may still have denied it.
+   Never any command text — the row is metadata only, because a trailing comment
+   rides a Bash command that can carry a credential. Every merge-path sigil is
+   covered, including `# escalation-ack`. Use only when findings are
+   intentionally accepted.
 6. **Read the PR's warning comments before merging — not just the hard gate.**
    Beyond Codex, a structural-review bot posts under the repo-owner account
    (`WingedGuardian`, review state COMMENTED) and emits **SOFT WARNINGs** (PII /

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1482,8 +1482,15 @@ The review-findings gate specifically:
    then stops, which is a real signal but not an override that took effect, and
    `asked` means the decision went to a human who may still have denied it.
    Never any command text — the row is metadata only, because a trailing comment
-   rides a Bash command that can carry a credential. Every merge-path sigil is
-   covered, including `# escalation-ack`. Use only when findings are
+   rides a Bash command that can carry a credential.
+   **Scope, stated so the log is not read as more complete than it is:** the four
+   PR-merge sigils are covered (`# review-override`, `# ci-override`,
+   `# stale-review-override`, `# scheduled-review-override`), from the point the
+   PR is resolved onward. A merge rejected before that — no `--admin`, or an
+   unresolvable repo/PR — writes nothing. The command-scoped acks
+   (`# escalation-ack`, `# merge-to-main-override`) are deliberately NOT logged:
+   their gate is not evaluated where the sigil is seen, so a row could only say
+   the ack was typed, never that it waived anything. Use only when findings are
    intentionally accepted.
 6. **Read the PR's warning comments before merging — not just the hard gate.**
    Beyond Codex, a structural-review bot posts under the repo-owner account

--- a/scripts/hooks/audit_jsonl.py
+++ b/scripts/hooks/audit_jsonl.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Secure append-only JSONL for hook audit/recovery logs.
+
+Extracted from ``git_discard_guard.py`` (2026-08-30) when a SECOND hook log —
+the merge gate's override record — needed the same properties. The mechanics
+below are security properties, not conveniences, and a partial adoption is the
+failure this module exists to prevent: the override log's first cut took the
+credential rule from the discard guard and left the 0600 modes, the umask-free
+create and the sidecar lock behind. The log it produced was mode 644.
+
+WHAT THIS GUARANTEES
+====================
+* **Own-user-only files, with no umask window.** ``os.open`` applies the mode AT
+  create time; ``open()`` + ``chmod`` is briefly group/world-readable per the
+  process umask. These logs sit in ``~/.genesis`` beside secrets.
+* **Serialized appends.** The exclusive ``flock`` rides a SIDECAR lock file, not
+  the log fh: a maintainer that calls :func:`rewrite` replaces the log inode, so
+  a lock held on the log itself would ride the ORPHAN inode and a waiter would
+  append to a file nobody reads. The sidecar is never replaced.
+* **Bounded waiting.** Acquisition gives up after :data:`LOCK_TIMEOUT_S`. For a
+  caller whose return value is a security verdict, an unbounded wait is a
+  fail-open bug rather than a latency one — see that constant.
+* **A broken maintainer cannot cost the caller its row.** Each maintainer runs in
+  its own ``try`` — MEASURED as the load-bearing part: removing the isolation
+  loses the write, while merely reordering append and maintenance does not.
+  Retention still runs AFTER the append, so a maintainer's own read sees the row
+  just written and a size trim measures the real size; but ordering is the
+  secondary safeguard, not the guarantee. The unisolated version is what made the
+  override log's first cut a silent, permanent no-op: one row it could not parse
+  raised, the write was abandoned, and every later write hit the same row.
+* **Failures are reported, never fatal.** Callers on a hook path must not break
+  the user's command over a log write, so :func:`append_row` returns ``None``
+  instead of raising — but it says so on stderr rather than swallowing in
+  silence. A logger that fails quietly is indistinguishable from one that was
+  never wired. CAVEAT, so the guarantee is not overstated: the harness discards a
+  PreToolUse hook's stderr when that hook exits 0, so on an ALLOWED command the
+  notice reaches the hook log rather than the user; on a block it is visible.
+
+WHAT THIS DELIBERATELY DOES NOT DO
+==================================
+No schema, no field validation, no free-text policy. Those belong to each log's
+own writer, which knows its row shape; this module only gets rows to disk safely.
+
+KNOWN RESIDUALS, stated rather than implied
+===========================================
+* No ``O_NOFOLLOW``: a symlink at the log path is followed. That also keeps a
+  deliberately relocated log working, and the threat requires write access to a
+  directory inside the user's own home — at which point the attacker has the home.
+* No ``fsync``: a crash immediately after a write can lose recent rows.
+* :data:`LOG_DIR_MODE` applies only to a directory this module CREATES.
+  ``os.makedirs(exist_ok=True)`` does not tighten an existing one, and the real
+  ``~/.genesis`` is 0755 on a normal install — so the effective protection for
+  contents is the 0600 FILE mode, not the directory. Filenames and sizes in that
+  directory are readable by other local users.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime
+import fcntl
+import json
+import os
+import sys
+import time
+from collections.abc import Callable, Sequence
+
+#: Own-user-only. These logs can carry local repo paths, branch names and PR
+#: numbers, and they live beside secrets in ``~/.genesis``. See the residual note
+#: above: the directory mode binds only when this module creates the directory.
+LOG_DIR_MODE = 0o700
+LOG_FILE_MODE = 0o600
+
+#: How long to wait for the sidecar lock before giving up on the row.
+#:
+#: This bound is load-bearing, not tidiness. A caller may be a hook that BLOCKS a
+#: command, and its block is delivered by RETURNING in time — a hook killed by the
+#: harness wall-clock does not return 2, and a non-2 exit lets the guarded command
+#: RUN. An unbounded wait here therefore converts a fail-CLOSED gate into a
+#: fail-OPEN one for as long as anything holds the lock. MEASURED before this
+#: bound existed: another process holding the sidecar hung the merge gate with no
+#: verdict until it was killed at 20s, against a 0.00s baseline.
+#:
+#: Audit logging must never outlive the verdict it describes. A lost row is a gap
+#: in a log; a lost verdict is an unguarded merge.
+LOCK_TIMEOUT_S = 0.5
+_LOCK_POLL_S = 0.02
+
+
+def open_own(path: str, *, append: bool):
+    """Open ``path`` for writing, creating it 0600 with NO umask window.
+
+    ``os.open`` applies the mode at create time, unlike ``open()`` then
+    ``chmod`` (briefly world/group-readable per the process umask). A
+    PRE-EXISTING looser file is a separate problem — :func:`restrict` tightens
+    that.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | (os.O_APPEND if append else os.O_TRUNC)
+    fd = os.open(path, flags, LOG_FILE_MODE)
+    return os.fdopen(fd, "a" if append else "w", encoding="utf-8")
+
+
+def restrict(path: str) -> None:
+    """Best-effort chmod to own-user-only; a chmod failure never aborts logging."""
+    with contextlib.suppress(OSError):
+        os.chmod(path, LOG_FILE_MODE)
+
+
+def warn(message: str) -> None:
+    """One-line stderr notice. Audit paths report failure — see the module docstring."""
+    with contextlib.suppress(Exception):
+        print(f"[audit-log] {message}", file=sys.stderr)
+
+
+def rewrite(log_path: str, lines: Sequence[str]) -> None:
+    """Atomically replace ``log_path`` with ``lines`` (one trailing newline each).
+
+    For maintainers only, and only while holding the sidecar lock — see
+    :func:`append_row`. The temp file is restricted BEFORE the replace, because
+    it becomes the log's inode and so its mode becomes the log's mode.
+    """
+    tmp = log_path + ".tmp"
+    with open_own(tmp, append=False) as wr:
+        wr.write("".join(line.rstrip("\n") + "\n" for line in lines))
+    restrict(tmp)
+    os.replace(tmp, log_path)
+
+
+def new_deadline() -> float:
+    """A single lock deadline to share across a batch of :func:`append_row` calls.
+
+    A caller writing N rows must not pay N × :data:`LOCK_TIMEOUT_S`: the bound
+    that matters is on the CALLER's total delay before it can return its verdict,
+    not on each row. Without this, 4 rows under contention cost 2s and an
+    unbounded compound could cost far more — MEASURED at 60 pending rows.
+    """
+    return time.monotonic() + LOCK_TIMEOUT_S
+
+
+def _take_lock(lock_fh, log_path: str, deadline: float | None = None) -> bool:
+    """Take the exclusive sidecar lock, or give up by ``deadline``.
+
+    Non-blocking with a short poll rather than a blocking ``flock``; see
+    LOCK_TIMEOUT_S for why an unbounded wait here is a security bug.
+    """
+    if deadline is None:
+        deadline = new_deadline()
+    while True:
+        try:
+            fcntl.flock(lock_fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            if time.monotonic() >= deadline:
+                warn(f"{log_path}: lock busy for {LOCK_TIMEOUT_S}s — row dropped")
+                return False
+            time.sleep(_LOCK_POLL_S)
+
+
+def append_row(
+    log_path: str,
+    row: dict,
+    *,
+    maintain: Sequence[Callable[[str], None]] = (),
+    sort_keys: bool = False,
+    deadline: float | None = None,
+) -> str | None:
+    """Append ``row`` as one JSON line, then run ``maintain`` under the same lock.
+
+    Returns the log path on success, ``None`` if the row could not be written —
+    an OS error, or the lock still busy at ``deadline``. Both are reported on
+    stderr; neither raises, because a caller's return value may be a security
+    verdict.
+
+    ``deadline`` (from :func:`new_deadline`) lets a caller writing several rows
+    share ONE budget across all of them, so its total delay stays bounded by
+    :data:`LOCK_TIMEOUT_S` rather than N × it. Omit it for a single row.
+    """
+    try:
+        # A relative override has an empty dirname — makedirs("") raises.
+        os.makedirs(os.path.dirname(log_path) or ".", mode=LOG_DIR_MODE, exist_ok=True)
+        lock_path = log_path + ".lock"
+        with open_own(lock_path, append=True) as lock_fh:
+            restrict(lock_path)  # tighten a pre-existing loose sidecar
+            if not _take_lock(lock_fh, log_path, deadline):
+                return None
+            with open_own(log_path, append=True) as fh:
+                restrict(log_path)
+                fh.write(json.dumps(row, sort_keys=sort_keys) + "\n")
+            for maintainer in maintain:
+                try:
+                    maintainer(log_path)
+                except Exception as exc:  # noqa: BLE001 — one bad maintainer
+                    warn(f"{log_path}: maintenance failed ({exc!r})")
+    except OSError as exc:
+        warn(f"{log_path}: write failed ({exc!r})")
+        return None
+    return log_path
+
+
+def trim_by_size(max_bytes: int) -> Callable[[str], None]:
+    """Maintainer: when the log exceeds ``max_bytes``, keep the most recent half.
+
+    The size backstop every one of these logs needs regardless of any
+    content-based retention, because retention can legitimately keep rows it
+    cannot interpret (see :func:`prune_by_age`).
+    """
+
+    def _trim(log_path: str) -> None:
+        if os.path.getsize(log_path) <= max_bytes:
+            return
+        with open(log_path, encoding="utf-8") as rd:
+            lines = rd.readlines()
+        rewrite(log_path, lines[len(lines) // 2 :])
+
+    return _trim
+
+
+def prune_by_age(days: int, *, ts_key: str = "ts") -> Callable[[str], None]:
+    """Maintainer: drop rows whose ``ts_key`` is older than ``days``.
+
+    A row this cannot interpret — unparseable JSON, a missing key, a
+    timezone-NAIVE timestamp that cannot be compared against an aware cutoff —
+    is **KEPT**, and the fact is reported once per sweep. Dropping it would let
+    a log silently destroy the rows it exists to preserve, and raising on it
+    (the first cut's behaviour, with the comparison outside the per-row ``try``)
+    made ONE bad row permanently disable all future writes while the gate kept
+    telling the operator the override was "(logged)". Keeping is the only
+    failure direction that loses nothing; :func:`trim_by_size` bounds the file
+    if such rows accumulate.
+
+    Rewrites only when a row actually aged out — otherwise every append would pay
+    a full read, rewrite and inode replace to change nothing.
+    """
+
+    def _prune(log_path: str) -> None:
+        cutoff = datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=days)
+        kept: list[str] = []
+        total = 0
+        unreadable = 0
+        with open(log_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                total += 1
+                try:
+                    ts = datetime.datetime.fromisoformat(json.loads(line)[ts_key])
+                    stale = ts < cutoff  # raises on a naive ts — caught below
+                except Exception:  # noqa: BLE001 — see docstring: KEEP, never drop
+                    unreadable += 1
+                    kept.append(line)
+                    continue
+                if not stale:
+                    kept.append(line)
+        if unreadable:
+            warn(f"{log_path}: kept {unreadable} row(s) with an unreadable {ts_key}")
+        if len(kept) != total:
+            rewrite(log_path, kept)
+
+    return _prune

--- a/scripts/hooks/audit_jsonl.py
+++ b/scripts/hooks/audit_jsonl.py
@@ -21,8 +21,10 @@ WHAT THIS GUARANTEES
   caller whose return value is a security verdict, an unbounded wait is a
   fail-open bug rather than a latency one — see that constant.
 * **A broken maintainer cannot cost the caller its row.** Each maintainer runs in
-  its own ``try`` — MEASURED as the load-bearing part: removing the isolation
-  loses the write, while merely reordering append and maintenance does not.
+  its own ``try``. Precisely: the row is already on disk before any maintainer
+  runs, so an unisolated raise costs the caller its RETURN VALUE and any
+  SUBSEQUENT rows in the same batch — not the row just written. Reordering append
+  and maintenance changes nothing observable; the isolation is what matters.
   Retention still runs AFTER the append, so a maintainer's own read sees the row
   just written and a size trim measures the real size; but ordering is the
   secondary safeguard, not the guarantee. The unisolated version is what made the
@@ -191,7 +193,12 @@ def append_row(
                     maintainer(log_path)
                 except Exception as exc:  # noqa: BLE001 — one bad maintainer
                     warn(f"{log_path}: maintenance failed ({exc!r})")
-    except OSError as exc:
+    except Exception as exc:  # noqa: BLE001 — the contract is "never raises".
+        # NOT just OSError. A caller's return value may be a security verdict, so
+        # anything escaping here can convert an allow into a block via a
+        # fail-closed wrapper. MEASURED before this widened: a row containing a
+        # non-serialisable value raised TypeError straight through a docstring
+        # that promised the function returns None instead of raising.
         warn(f"{log_path}: write failed ({exc!r})")
         return None
     return log_path

--- a/scripts/hooks/git_discard_guard.py
+++ b/scripts/hooks/git_discard_guard.py
@@ -103,7 +103,6 @@ from __future__ import annotations
 
 import contextlib
 import datetime
-import fcntl
 import json
 import os
 import subprocess
@@ -112,6 +111,16 @@ import time
 
 # Self-locate so sibling hook modules resolve whether run as a script or imported.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# SOFT dependency: this guard BLOCKS `git clean` (exit 2), and a module-load
+# exception exits 1, which the harness treats as non-blocking — so an unimportable
+# brand-new logging module would let an unrecoverable `git clean -fdx` through.
+# Snapshot logging degrades to a no-op instead. Mirrors git_push_guard's guard on
+# the same import, for the same reason.
+try:
+    import audit_jsonl  # noqa: E402
+except Exception:  # noqa: BLE001 — logging must never disarm the clean block.
+    audit_jsonl = None
+
 from hook_input import field, read_payload  # noqa: E402
 from shell_parse import analyze, has_trailing_override  # noqa: E402
 
@@ -189,9 +198,9 @@ _TOTAL_SNAPSHOT_BUDGET_S = 8.0
 # Self-trim the snapshot JSONL when it grows past this (no external consumer /
 # rotation exists); keep the most recent half.
 _SNAPSHOT_LOG_MAX_BYTES = 1_000_000
-# Recovery logs may sit in ~/.genesis alongside secrets — own-user only.
-_LOG_DIR_MODE = 0o700
-_LOG_FILE_MODE = 0o600
+# Own-user-only modes for logs that sit in ~/.genesis beside secrets now live in
+# audit_jsonl (LOG_DIR_MODE / LOG_FILE_MODE), shared with the merge-gate override
+# log so the two cannot diverge.
 
 
 def _snapshot_log_path() -> str:
@@ -238,48 +247,24 @@ def _snapshot_worktree(cwd: str, timeout: float = _GIT_TIMEOUT_S) -> str | None:
     return sha or None
 
 
-def _open_own(path: str, *, append: bool):
-    """Open ``path`` for writing, creating it own-user-only (0600) with NO
-    umask window — ``os.open`` applies the mode AT create time, unlike
-    ``open()`` then ``chmod`` (which is briefly world/group-readable per the
-    process umask). A pre-existing looser file is separately tightened by
-    ``_restrict``; the 0700 log dir already gates access regardless."""
-    flags = os.O_WRONLY | os.O_CREAT | (os.O_APPEND if append else os.O_TRUNC)
-    fd = os.open(path, flags, _LOG_FILE_MODE)
-    return os.fdopen(fd, "a" if append else "w", encoding="utf-8")
-
-
 def _write_log_row(row: dict) -> str | None:
-    """Append ``row`` to the recovery JSONL under an exclusive flock on a SIDECAR
-    lock file (locking the log fh itself is defeated by the trim's os.replace —
-    the lock rides the OLD inode and a waiter appends to the orphan). The
-    sidecar is never replaced, so every writer serializes on one inode. Returns
-    the log path on success, None on any OS error. Files are created own-user
-    only (the log can carry local repo paths and sits beside secrets)."""
+    """Append ``row`` to the recovery JSONL, then self-trim past the size cap.
+
+    The locking, own-user create modes and atomic rewrite live in
+    ``audit_jsonl`` — extracted from HERE when the merge gate's override log
+    needed the same properties, so the two cannot drift apart. Returns the log
+    path, or None if the write failed (reported on stderr, never raised: a
+    logging failure must not break the user's command).
+
+    ``_SNAPSHOT_LOG_MAX_BYTES`` is read at CALL time so a test can lower it.
+    Returns None when the writer is unavailable (see the guarded import).
+    """
+    if audit_jsonl is None:
+        return None
     log_path = _snapshot_log_path()
-    # A relative override has an empty dirname — makedirs("") raises.
-    os.makedirs(os.path.dirname(log_path) or ".", mode=_LOG_DIR_MODE, exist_ok=True)
-    lock_path = log_path + ".lock"
-    with _open_own(lock_path, append=True) as lk:
-        _restrict(lock_path)  # tighten a pre-existing loose sidecar
-        fcntl.flock(lk, fcntl.LOCK_EX)
-        with _open_own(log_path, append=True) as fh:
-            _restrict(log_path)
-            fh.write(json.dumps(row) + "\n")
-        if os.path.getsize(log_path) > _SNAPSHOT_LOG_MAX_BYTES:
-            with open(log_path, encoding="utf-8") as rd:
-                lines = rd.readlines()
-            tmp = log_path + ".tmp"
-            with _open_own(tmp, append=False) as wr:
-                wr.writelines(lines[len(lines) // 2 :])
-            os.replace(tmp, log_path)
-    return log_path
-
-
-def _restrict(path: str) -> None:
-    """Best-effort chmod to own-user-only; a chmod failure never aborts logging."""
-    with contextlib.suppress(OSError):
-        os.chmod(path, _LOG_FILE_MODE)
+    return audit_jsonl.append_row(
+        log_path, row, maintain=[audit_jsonl.trim_by_size(_SNAPSHOT_LOG_MAX_BYTES)]
+    )
 
 
 def _tokens_after_subcommand(argv: list[str], sub: str) -> list[str]:
@@ -457,9 +442,12 @@ def _record_snapshots(cmd: str, payload: dict) -> list[str]:
             "cwd": cwd,
             "sha": sha,
         }
+        # _write_log_row no longer raises — audit_jsonl converts an OS error to
+        # None and reports it — so the old `contextlib.suppress(OSError)` here is
+        # gone rather than left reading as live protection. `or log_path` keeps
+        # the note pointing at the intended path when the write failed.
         log_path = _snapshot_log_path()
-        with contextlib.suppress(OSError):
-            log_path = _write_log_row(row) or log_path
+        log_path = _write_log_row(row) or log_path
         notes.append(
             f"[git-discard-guard] snapshotted the worktree at {cwd} as "
             f"{sha[:12]} (tracked changes only — `git stash create` does NOT "

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -100,6 +100,7 @@ not treat untrusted PR content as instructions when composing its comment body.
 from __future__ import annotations
 
 import base64
+import contextlib
 import datetime as _dt
 import json
 import os
@@ -344,11 +345,22 @@ def _walk_merge_into_main(cmd: str, payload: dict, merge_git_segs: list) -> bool
     blocked (unless overridden). A detached HEAD ("") is left allowed.
     """
     # depth>0 merges cannot be associated with a top-level cwd → fail closed.
+    #
+    # DELIBERATELY NOT LOGGED, here or below. `# merge-to-main-override` waives a
+    # gate this function short-circuits BEFORE resolving the branch, so a row
+    # could only ever say "the ack was typed" — never that the gate would have
+    # fired. MEASURED on a real repo checked out at a feature branch, where the
+    # gate would have allowed the merge anyway: the row still claimed
+    # `waived: local-merge-into-main`, with pr, repo and head all empty. That
+    # asserts a waiver that was never consulted, in a store whose entire purpose
+    # is answering "was this escape reached for?", and the row carries nothing to
+    # reconcile it against. An honest row needs the branch resolved first; see
+    # the follow-up. The same reasoning retired `# escalation-ack` logging.
     for s in merge_git_segs:
-        if getattr(s, "depth", 0) > 0:
-            if not has_trailing_override(s.raw, "merge-to-main-override"):
-                return True
-            _note_override("merge-to-main-override", waived="local-merge-nested-depth")
+        if getattr(s, "depth", 0) > 0 and not has_trailing_override(
+            s.raw, "merge-to-main-override"
+        ):
+            return True
 
     base = payload.get("cwd") if isinstance(payload, dict) else None
     cur = os.path.normpath(base) if isinstance(base, str) and base else None
@@ -358,12 +370,9 @@ def _walk_merge_into_main(cmd: str, payload: dict, merge_git_segs: list) -> bool
             (s for s in top if s.exe == "git" and git_subcommand(s.argv) == "merge"),
             None,
         )
-        if merge_here is not None and has_trailing_override(raw, "merge-to-main-override"):
-            # Noted, not evaluated: the ack short-circuits BEFORE the branch is
-            # resolved, so this records that the ack was invoked on a merge
-            # segment — never a claim that the segment targeted main.
-            _note_override("merge-to-main-override", waived="local-merge-into-main")
-        elif merge_here is not None:
+        if merge_here is not None and not has_trailing_override(
+            raw, "merge-to-main-override"
+        ):
             dash_c = _seg_dash_C(merge_here.argv)
             mcwd = _resolve_against(cur, dash_c) if dash_c is not None else cur
             if mcwd is _CWD_UNKNOWN:
@@ -1771,31 +1780,21 @@ def _check_codex_round_escalation(segs) -> tuple[bool, str]:
     """
     try:
         if any(has_trailing_override(s.raw, "escalation-ack") for s in segs):
-            # Record it ONLY when this gate would actually have counted the
-            # command — i.e. a `gh pr comment … @codex review` segment is
-            # present. `escalation-ack` is a SHARED sigil: it is also the
-            # documented ack for the commit gate (review_enforcement_commit.py
+            # DELIBERATELY NOT LOGGED. `escalation-ack` is a SHARED, COMMAND-scoped
+            # sigil: it is also the commit gate's ack (review_enforcement_commit.py
             # prints `git commit -m "…"  # escalation-ack` in its own block
-            # message). Noting on the bare short-circuit fabricated a row for
-            # EVERY Bash command carrying the ack — MEASURED on `git commit`,
-            # `git status` and `pytest` — each claiming the round cap was waived
-            # when it was never consulted, with no PR to reconcile against. That
-            # would have made this sigil's dominant population fiction.
-            acked = next(
-                (
-                    s
-                    for s in segs
-                    if gh_pr_subcommand(s.argv) == "comment"
-                    and any("@codex review" in tok.lower() for tok in s.argv)
-                ),
-                None,
-            )
-            if acked is not None:
-                _note_override(
-                    "escalation-ack",
-                    waived="codex-round-escalation-cap",
-                    pr=_comment_target(acked.argv)[0] or "",
-                )
+            # message), and this check accepts it on ANY segment. Two attempts to
+            # attribute it honestly both failed, MEASURED:
+            #   1. noting on the bare short-circuit wrote a row for every Bash
+            #      command carrying the ack — `git commit`, `git status`, `pytest`
+            #      each claimed this cap was waived when it was never consulted;
+            #   2. narrowing to "a `@codex review` comment is somewhere in the
+            #      command" still misattributes, because the ack may ride a
+            #      DIFFERENT segment: `git commit … # escalation-ack && gh pr
+            #      comment 5 …` recorded the commit gate's ack against PR 5.
+            # An honest row needs the ack bound to the segment it rides and that
+            # segment's own PR, which this function's shape does not give. Logging
+            # it is deferred rather than approximated — see the follow-up.
             return False, ""
         # Bound this scan's gh (_codex_reviews) calls by the SHARED hook deadline,
         # so a slow API + a compound command can't push the aggregate past the
@@ -2031,6 +2030,14 @@ _OVERRIDE_LOG_FIELDS = ("ts", "sigil", "outcome", "waived", "pr", "repo", "head"
 #: merge that may never have happened — the same conflation this field exists to
 #: prevent, one level down. "error" is the fail-closed wrapper's path.
 #:
+#: HONESTY NOTE: no CURRENTLY-logged sigil can reach "asked". Every logged sigil
+#: is noted inside the `gh pr merge` arm, which returns allow/block and never
+#: asks, and a compound that pairs a merge with a push is refused outright
+#: ("multiple publish/merge operations in one command"). The mapping is kept and
+#: unit-tested because it is three lines and it is the CORRECT answer the moment
+#: a sigil is logged on a path that does ask — at which point silence here would
+#: mean a false "allowed". It is not an observed state today.
+#:
 #: ENFORCED, not just documented: ``_flush_overrides`` drops a row whose outcome
 #: is outside this tuple, the way ``sigil`` is checked against ``_KNOWN_SIGILS``.
 _OVERRIDE_OUTCOMES = ("allowed", "asked", "blocked", "error")
@@ -2041,6 +2048,12 @@ _OVERRIDE_OUTCOMES = ("allowed", "asked", "blocked", "error")
 #: which is arbitrary text, which makes the no-free-text guarantee false.
 _SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
 _REPO_RE = re.compile(r"^[\w.-]{1,100}/[\w.-]{1,100}$")
+#: ``waived`` names the gate CLASS a sigil targets. Every producer is a literal in
+#: this file (plus ``ci-status`` refined to ``ci:<state>``), so it is a closed set
+#: — enforced, because "the field set is closed" was only ever true of NAMES:
+#: MEASURED, a 311-character ``waived`` carrying quotes and a token-shaped string
+#: was written to the row while the docstring claimed every field was shape-checked.
+_WAIVED_RE = re.compile(r"^[a-z][a-z0-9:+-]{0,63}$")
 
 #: Rows noted during this invocation, flushed once the gate's verdict is known.
 #: Module-level because detection is spread across the merge gate while the
@@ -2054,17 +2067,22 @@ _ASK_EMITTED = False
 
 
 def _actor() -> str:
-    """Who ran the command, from the passwd database rather than ``$USER``.
+    """Who ran the command, from the passwd database — NOT from the environment.
 
-    ``$USER`` is unset under some launchers, which would silently empty the one
-    field whose only job is attribution. Falls back to the env var, then "".
+    ``getpass.getuser()`` is the obvious choice and is WRONG here: it consults
+    ``$LOGNAME``/``$USER``/``$LNAME``/``$USERNAME`` FIRST and only falls back to
+    passwd. MEASURED: with ``LOGNAME`` set, ``getpass.getuser()`` returned that
+    value — so an audited command could forge its own attribution
+    (``LOGNAME=someone-else gh pr merge … # ci-override``) in the one field whose
+    entire job is saying who did it. ``os.getuid()`` cannot be set by the command
+    being guarded.
     """
     try:
-        import getpass
+        import pwd
 
-        return getpass.getuser()
+        return pwd.getpwuid(os.getuid()).pw_name
     except Exception:  # noqa: BLE001 — attribution is best-effort, never fatal.
-        return os.environ.get("USER", "")
+        return str(os.getuid())
 
 
 def _override_log_path() -> str:
@@ -2143,7 +2161,7 @@ def _note_override(
     _PENDING_OVERRIDES.append(
         {
             "sigil": sigil,
-            "waived": waived,
+            "waived": waived if _WAIVED_RE.match(waived or "") else "",
             # Digits-only by construction at every current producer, but checked
             # anyway — the docstring above claims EVERY field is shape-checked,
             # and `pr` is the field a future caller is most likely to feed from a
@@ -2195,10 +2213,16 @@ def _flush_overrides(outcome: str) -> None:
         # operator, and a quiet no-op here is indistinguishable from the
         # never-wired state this whole change exists to end. Cannot use
         # audit_jsonl.warn — that is the module we do not have.
-        print(
-            f"[audit-log] audit_jsonl unavailable — {len(rows)} override row(s) NOT recorded",
-            file=sys.stderr,
-        )
+        #
+        # SUPPRESSED, and that matters: this runs in main()'s `finally`, so an
+        # unwritable stderr raising here escapes into run_guard, which fails
+        # CLOSED and converts it to exit 2 — turning an ALLOW into a BLOCK. The
+        # sibling guard wraps its own block print for exactly this reason.
+        with contextlib.suppress(Exception):
+            print(
+                f"[audit-log] audit_jsonl unavailable — {len(rows)} row(s) NOT recorded",
+                file=sys.stderr,
+            )
         return
     if outcome not in _OVERRIDE_OUTCOMES:
         # The tuple is a contract, not a comment. A row whose verdict is outside

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -100,6 +100,7 @@ not treat untrusted PR content as instructions when composing its comment body.
 from __future__ import annotations
 
 import base64
+import datetime as _dt
 import json
 import os
 import re
@@ -131,7 +132,17 @@ except Exception:  # noqa: BLE001 — ANY failure (absent OR broken: SyntaxError
     # and silently disables every fail-closed gate in this file (round-6 P1).
     ESCALATION_ROUND_CAP = 3  # the genesis-development SKILL.md prose cap
 
+# SOFT dependency, for the reason spelled out directly above: this module is
+# NEW, and audit LOGGING must never be able to disarm the gates it audits. If it
+# cannot be imported, logging degrades to a no-op (guarded in _flush_overrides)
+# rather than taking every fail-closed gate in this file down with it.
+try:
+    import audit_jsonl  # noqa: E402
+except Exception:  # noqa: BLE001 — see above: a load failure exits 1 = non-blocking.
+    audit_jsonl = None
+
 from shell_parse import (  # noqa: E402
+    _KNOWN_SIGILS,
     analyze,
     commit_skips_hooks,
     gh_pr_subcommand,
@@ -334,10 +345,10 @@ def _walk_merge_into_main(cmd: str, payload: dict, merge_git_segs: list) -> bool
     """
     # depth>0 merges cannot be associated with a top-level cwd → fail closed.
     for s in merge_git_segs:
-        if getattr(s, "depth", 0) > 0 and not has_trailing_override(
-            s.raw, "merge-to-main-override"
-        ):
-            return True
+        if getattr(s, "depth", 0) > 0:
+            if not has_trailing_override(s.raw, "merge-to-main-override"):
+                return True
+            _note_override("merge-to-main-override", waived="local-merge-nested-depth")
 
     base = payload.get("cwd") if isinstance(payload, dict) else None
     cur = os.path.normpath(base) if isinstance(base, str) and base else None
@@ -347,7 +358,12 @@ def _walk_merge_into_main(cmd: str, payload: dict, merge_git_segs: list) -> bool
             (s for s in top if s.exe == "git" and git_subcommand(s.argv) == "merge"),
             None,
         )
-        if merge_here is not None and not has_trailing_override(raw, "merge-to-main-override"):
+        if merge_here is not None and has_trailing_override(raw, "merge-to-main-override"):
+            # Noted, not evaluated: the ack short-circuits BEFORE the branch is
+            # resolved, so this records that the ack was invoked on a merge
+            # segment — never a claim that the segment targeted main.
+            _note_override("merge-to-main-override", waived="local-merge-into-main")
+        elif merge_here is not None:
             dash_c = _seg_dash_C(merge_here.argv)
             mcwd = _resolve_against(cur, dash_c) if dash_c is not None else cur
             if mcwd is _CWD_UNKNOWN:
@@ -1755,6 +1771,31 @@ def _check_codex_round_escalation(segs) -> tuple[bool, str]:
     """
     try:
         if any(has_trailing_override(s.raw, "escalation-ack") for s in segs):
+            # Record it ONLY when this gate would actually have counted the
+            # command — i.e. a `gh pr comment … @codex review` segment is
+            # present. `escalation-ack` is a SHARED sigil: it is also the
+            # documented ack for the commit gate (review_enforcement_commit.py
+            # prints `git commit -m "…"  # escalation-ack` in its own block
+            # message). Noting on the bare short-circuit fabricated a row for
+            # EVERY Bash command carrying the ack — MEASURED on `git commit`,
+            # `git status` and `pytest` — each claiming the round cap was waived
+            # when it was never consulted, with no PR to reconcile against. That
+            # would have made this sigil's dominant population fiction.
+            acked = next(
+                (
+                    s
+                    for s in segs
+                    if gh_pr_subcommand(s.argv) == "comment"
+                    and any("@codex review" in tok.lower() for tok in s.argv)
+                ),
+                None,
+            )
+            if acked is not None:
+                _note_override(
+                    "escalation-ack",
+                    waived="codex-round-escalation-cap",
+                    pr=_comment_target(acked.argv)[0] or "",
+                )
             return False, ""
         # Bound this scan's gh (_codex_reviews) calls by the SHARED hook deadline,
         # so a slow API + a compound command can't push the aggregate past the
@@ -1964,6 +2005,233 @@ _MIN_OVERRIDE_EVIDENCE_CHARS = 200
 # Bound the read on the merge-gate hot path (the floor is 200 chars; any real review
 # fits easily) so an oversized file in the evidence dir can't be slurped into memory.
 _MAX_OVERRIDE_EVIDENCE_READ = 65536
+
+
+#: Retention for the override log. Long enough to answer "has this escape decayed
+#: into the routine path?" over a meaningful sample, short enough to stay small.
+_OVERRIDE_LOG_RETENTION_DAYS = 90
+#: Size backstop, mirroring the discard log's. Retention KEEPS rows whose ts it
+#: cannot read (audit_jsonl.prune_by_age), so age alone does not bound the file.
+_OVERRIDE_LOG_MAX_BYTES = 1_000_000
+#: The row's field set is CLOSED, and the writer builds rows from THIS tuple — a
+#: caller cannot add a field by passing one. See the no-free-text constraint on
+#: ``_note_override``. ``base`` is deliberately absent: no gate on this path
+#: returns the base ref without a second API read, and a field that is empty on
+#: every real call is worse than no field (pr + repo resolve it after the fact).
+_OVERRIDE_LOG_FIELDS = ("ts", "sigil", "outcome", "waived", "pr", "repo", "head", "actor")
+#: Outcomes a row can carry. The log records override ATTEMPTS, tagged with what
+#: the command actually did — a sigil appended to a command that was then blocked
+#: by a DIFFERENT gate is a real signal (it says the escape was reached for), but
+#: it is not an override that took effect, and conflating the two would inflate
+#: every count drawn from this file.
+#:
+#: "asked" is NOT a spelling of "allowed". ``_ask`` returns 0 while emitting a
+#: permissionDecision the HUMAN may still deny, so the exit code alone cannot say
+#: whether the command ran; recording it as "allowed" would have the log assert a
+#: merge that may never have happened — the same conflation this field exists to
+#: prevent, one level down. "error" is the fail-closed wrapper's path.
+#:
+#: ENFORCED, not just documented: ``_flush_overrides`` drops a row whose outcome
+#: is outside this tuple, the way ``sigil`` is checked against ``_KNOWN_SIGILS``.
+_OVERRIDE_OUTCOMES = ("allowed", "asked", "blocked", "error")
+
+#: Shapes a stored value may take. A row is metadata, so every field is either a
+#: closed set or matches one of these — see ``_note_override``. Without them
+#: ``head`` is whatever followed ``--match-head-commit`` on the command line,
+#: which is arbitrary text, which makes the no-free-text guarantee false.
+_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+_REPO_RE = re.compile(r"^[\w.-]{1,100}/[\w.-]{1,100}$")
+
+#: Rows noted during this invocation, flushed once the gate's verdict is known.
+#: Module-level because detection is spread across the merge gate while the
+#: outcome is only known at the end; ``main`` clears it on entry, so a second
+#: call in the same process (the tests, and only the tests) cannot inherit rows.
+_PENDING_OVERRIDES: list[dict] = []
+
+#: Set by :func:`_ask` when the guard hands the decision to the user. Read by the
+#: flush to tell an ask from an allow — both exit 0. Cleared by ``main`` on entry.
+_ASK_EMITTED = False
+
+
+def _actor() -> str:
+    """Who ran the command, from the passwd database rather than ``$USER``.
+
+    ``$USER`` is unset under some launchers, which would silently empty the one
+    field whose only job is attribution. Falls back to the env var, then "".
+    """
+    try:
+        import getpass
+
+        return getpass.getuser()
+    except Exception:  # noqa: BLE001 — attribution is best-effort, never fatal.
+        return os.environ.get("USER", "")
+
+
+def _override_log_path() -> str:
+    """Path of the merge-gate override record.
+
+    Deliberately NOT inside ``_override_evidence_dir()``: that directory is a store
+    the gate READS AND VALIDATES (>=200 chars, must cite the head), so an audit row
+    living there could satisfy an evidence check, and a retention sweep there would
+    delete evidence the gate still needs. Kept separate, beside
+    ``git_discard_snapshots.jsonl``, with which it shares its writer.
+
+    A RELATIVE override is refused in favour of the default: it would resolve
+    against the hook's cwd — the repo — putting a durable audit file inside the
+    working tree, where it can be committed. The repo rule is that output lives
+    outside the tree, and ``test_the_live_default_path_is_outside_any_repo``
+    exists to keep the default honest; an env var must not be able to undo it."""
+    override = os.environ.get("GENESIS_MERGE_OVERRIDE_LOG")
+    if override and os.path.isabs(override):
+        return override
+    if override:
+        print(
+            "[audit-log] GENESIS_MERGE_OVERRIDE_LOG must be an absolute path; "
+            f"ignoring {override!r}",
+            file=sys.stderr,
+        )
+    return os.path.expanduser("~/.genesis/merge_override_log.jsonl")
+
+
+def _note_override(
+    sigil: str,
+    *,
+    waived: str,
+    pr: str = "",
+    repo: str | None = None,
+    head: str | None = None,
+    **_ignored: object,
+) -> None:
+    """Note that an override sigil was invoked. METADATA ONLY; never raises.
+
+    The gate's own messages promise the operator that an override is "(logged)".
+    Until this existed that claim was false on every surface — no writer anywhere
+    under ``scripts/`` or ``src/genesis/``, and nothing on disk. A gate promising an
+    audit trail it does not keep is worse than one promising nothing: it invites use
+    of the escape on the belief that it is recorded.
+
+    The row is HELD until :func:`_flush_overrides` learns the gate's verdict, because
+    "the sigil was appended" and "the sigil let a merge through" are different facts
+    and only the second one is an override. Both are kept, distinguished by
+    ``outcome`` — see ``_OVERRIDE_OUTCOMES``.
+
+    NO COMMAND OR COMMENT TEXT EVER REACHES THIS ROW, and there is no "reason" field
+    to add. The constraint is inherited, not invented — ``git_discard_guard.py``'s
+    ``_record_snapshots`` refuses to persist the command because "the Bash payload can
+    carry credentials (``curl -H 'Authorization: …' && git checkout``) and this log is
+    durable". An override sigil IS a trailing comment on a Bash command, so the only
+    free text available here is command-line text, from a segment that may carry a
+    token. ``**_ignored`` exists so a caller cannot smuggle text in by passing an extra
+    keyword: the row is built from ``_OVERRIDE_LOG_FIELDS`` and nothing else.
+
+    ``sigil`` is validated against ``shell_parse._KNOWN_SIGILS`` — a closed set, never
+    free text. An unrecognised sigil notes nothing rather than persisting the caller's
+    string.
+
+    EVERY OTHER FIELD IS SHAPE-CHECKED for the same reason, because "the closed field
+    tuple stops free text" was only true of the field NAMES. ``head`` arrives as
+    whatever token followed ``--match-head-commit`` on the command line — arbitrary
+    text, of arbitrary length, which the operator typed — so it is stored only if it
+    looks like a sha, and ``repo`` only if it looks like ``owner/name``. Anything else
+    becomes empty: an unattributed row is a small loss, an arbitrary string written
+    durably to a file beside secrets is not.
+    """
+    if sigil not in _KNOWN_SIGILS:
+        return
+    head = (head or "").strip().lower()
+    repo = (repo or "").strip()
+    _PENDING_OVERRIDES.append(
+        {
+            "sigil": sigil,
+            "waived": waived,
+            # Digits-only by construction at every current producer, but checked
+            # anyway — the docstring above claims EVERY field is shape-checked,
+            # and `pr` is the field a future caller is most likely to feed from a
+            # branch name.
+            "pr": pr_s if (pr_s := str(pr or "")).isdigit() else "",
+            "repo": repo if _REPO_RE.match(repo) else "",
+            "head": head if _SHA_RE.match(head) else "",
+            "actor": _actor(),
+        }
+    )
+
+
+def _amend_note(sigil: str, *, waived: str) -> None:
+    """Refine a noted row's ``waived`` once the gate knows more than the sigil did.
+
+    Sigils are noted BEFORE the gates run, so their ``waived`` starts as the gate
+    CLASS. A gate that then learns something specific (CI was red rather than
+    merely pending) says so here. If the command blocked before that gate ran,
+    the row simply keeps the class — which is the honest record, since the
+    specific fact was never established.
+    """
+    for row in _PENDING_OVERRIDES:
+        if row["sigil"] == sigil:
+            row["waived"] = waived
+
+
+def _flush_overrides(outcome: str) -> None:
+    """Write the noted rows with the verdict the command actually got.
+
+    Best-effort by contract: this runs on the merge path and a logging failure must
+    never break a merge, so nothing here propagates. It is NOT silent, though — the
+    shared writer reports failures on stderr. A logger that fails quietly is
+    indistinguishable from one that was never wired, which is the state this whole
+    change found the gate in.
+
+    Retention ships WITH the store (New-Store Gate) rather than as a follow-up —
+    which is how the existing unpruned stores under ``~/.genesis/`` got that way.
+    KNOWN LIMIT, stated rather than implied: pruning happens only ON A WRITE, so if
+    overrides stop entirely the rows on disk age past the window and stay. That
+    bounds the file without guaranteeing freshness. A periodic sweep would close it;
+    this deliberately does not add one, because a second implementation of the
+    retention rule is the drift hazard that keeping ONE writer exists to avoid.
+    """
+    rows, _PENDING_OVERRIDES[:] = list(_PENDING_OVERRIDES), []
+    if not rows:
+        return
+    if audit_jsonl is None:
+        # Degraded, but NOT silent: the gate is still printing "(logged)" to the
+        # operator, and a quiet no-op here is indistinguishable from the
+        # never-wired state this whole change exists to end. Cannot use
+        # audit_jsonl.warn — that is the module we do not have.
+        print(
+            f"[audit-log] audit_jsonl unavailable — {len(rows)} override row(s) NOT recorded",
+            file=sys.stderr,
+        )
+        return
+    if outcome not in _OVERRIDE_OUTCOMES:
+        # The tuple is a contract, not a comment. A row whose verdict is outside
+        # it would be uncountable, and silently so.
+        audit_jsonl.warn(f"refusing {len(rows)} row(s) with unknown outcome {outcome!r}")
+        return
+    try:
+        ts = _dt.datetime.now(_dt.UTC).isoformat()
+        path = _override_log_path()
+        maintain = [
+            audit_jsonl.prune_by_age(_OVERRIDE_LOG_RETENTION_DAYS),
+            audit_jsonl.trim_by_size(_OVERRIDE_LOG_MAX_BYTES),
+        ]
+        # ONE deadline for the whole flush. Per-row deadlines would make the
+        # delay before this hook can return its verdict N × LOCK_TIMEOUT_S, and N
+        # is not bounded (a compound command notes one row per merge segment).
+        deadline = audit_jsonl.new_deadline()
+        for noted in rows:
+            full = {"ts": ts, "outcome": outcome, **noted}
+            # Built from the CLOSED field tuple, so an extra key on a noted row
+            # (or a future caller's stray kwarg) cannot reach disk.
+            audit_jsonl.append_row(
+                path,
+                {k: full.get(k, "") for k in _OVERRIDE_LOG_FIELDS},
+                maintain=maintain,
+                sort_keys=True,
+                deadline=deadline,
+            )
+    except Exception as exc:  # noqa: BLE001 — logging must never break a merge.
+        # Reported, not swallowed: audit_jsonl converts OSError, so anything
+        # reaching here is a bug in THIS function, and a silent one would look
+        # exactly like the no-writer state this change exists to end.
+        audit_jsonl.warn(f"override rows not written ({exc!r})")
 
 
 def _override_evidence_dir() -> str:
@@ -4348,7 +4616,12 @@ def _ask(reason: str) -> int:
     permission prompt and runs the tool only on explicit approval — a gate the
     agent cannot self-satisfy. Verified to render in a wrapped child session
     2026-07-27.
+
+    Records that the decision was DEFERRED, so the override log does not report a
+    still-undecided command as allowed — see ``_OVERRIDE_OUTCOMES``.
     """
+    global _ASK_EMITTED
+    _ASK_EMITTED = True
     print(
         json.dumps(
             {
@@ -4483,6 +4756,29 @@ def _pr_create_would_publish(argv: list[str]) -> bool:
 
 
 def main() -> int:
+    """Run the guard, then record any override sigils with the verdict they got.
+
+    The override log's rows are written HERE rather than where each sigil is
+    detected, because "the sigil was appended" is known early and "what the
+    command actually did" is only known at the end. One flush point covers every
+    return above — including the fail-closed conversion in ``run_guard``, which
+    reaches this wrapper as an exception.
+    """
+    global _ASK_EMITTED
+    _PENDING_OVERRIDES.clear()  # a second call in-process must not inherit rows
+    _ASK_EMITTED = False
+    outcome = "error"
+    try:
+        rc = _run_merge_and_push_gates()
+        # rc == 0 is THREE states, not two: allowed outright, or handed to the
+        # user as a permission prompt they may yet deny.
+        outcome = "blocked" if rc == 2 else ("asked" if _ASK_EMITTED else "allowed")
+        return rc
+    finally:
+        _flush_overrides(outcome)
+
+
+def _run_merge_and_push_gates() -> int:
     try:
         payload = read_payload()
         cmd = field(payload, "command")
@@ -4883,6 +5179,49 @@ def main() -> int:
                 )
                 return 2
             if pr_num:
+                # The head an override row is ABOUT. Read from the command's own
+                # `--match-head-commit` (the cluster-safe parser the TOCTOU binding
+                # uses) rather than an extra API call on a budgeted path: GitHub
+                # enforces that value server-side, so when the merge succeeds it IS
+                # the merged sha. Empty when the merge is unbound — which the gates
+                # below then refuse anyway, except under a sigil that waives the
+                # binding, and "unbound" is itself the honest record for that row.
+                merge_head = _merge_match_head(merge_seg.argv) or ""
+                # Note every sigil on the merge segment HERE — before the first
+                # gate that can `return 2`. Noting at each gate's own site
+                # recorded nothing when an EARLIER gate blocked, which silently
+                # dropped exactly the attempts the log exists to count (MEASURED:
+                # a CONFLICTING mergeable with three sigils appended wrote zero
+                # rows). The verdict is attached later, by the flush.
+                #
+                # The three `return 2`s ABOVE this point are deliberately not
+                # covered: they fire when the command has no --admin, or when the
+                # repo or PR cannot be resolved at all. Those are malformed
+                # commands rather than override events, and a row could not name
+                # which PR it was about.
+                ci_override = has_trailing_override(merge_seg.raw, "ci-override")
+                stale_override = has_trailing_override(merge_seg.raw, "stale-review-override")
+                sched_override = has_trailing_override(
+                    merge_seg.raw, "scheduled-review-override"
+                )
+                # The FINDINGS waiver, read off the parsed segment rather than via
+                # has_trailing_override — which is why enumerating that helper's
+                # call sites missed the one sigil SKILL.md documents as logged.
+                force_override = merge_seg.override
+                for _sigil, _present, _waives in (
+                    ("ci-override", ci_override, "ci-status"),
+                    ("stale-review-override", stale_override, "codex-freshness+base-invariant"),
+                    ("review-override", force_override, "review-body+inline-findings"),
+                    ("scheduled-review-override", sched_override, "scheduled-claude-review"),
+                ):
+                    if _present:
+                        _note_override(
+                            _sigil,
+                            waived=_waives,
+                            pr=pr_num,
+                            repo=merge_repo,
+                            head=merge_head,
+                        )
                 # ── Merge-path gh TIMEOUT BUDGET ──────────────────────────
                 # This hook runs under a 60s CC wall-clock (settings.json). A
                 # wall-clock overrun SIGKILLs the hook MID-GATE, which "fails
@@ -4953,7 +5292,11 @@ def main() -> int:
                 # or dropped pull_request trigger can't slip an un-CI'd merge through
                 # (handled just below).
                 ci_state, ci_bad = _pr_ci_status(pr_num, repo=merge_repo)
-                ci_override = has_trailing_override(merge_seg.raw, "ci-override")
+                # ci_override was detected and noted above, before any gate could
+                # return — see the note block after merge_head. Now that the CI
+                # verdict is known, record WHICH state was waived.
+                if ci_override:
+                    _amend_note("ci-override", waived=f"ci:{ci_state}")
                 if ci_state in ("red", "pending") and not ci_override:
                     print(
                         f"BLOCKED: PR #{pr_num} CI is {ci_state.upper()} "
@@ -5027,15 +5370,15 @@ def main() -> int:
                         file=sys.stderr,
                     )
 
-                force_override = merge_seg.override
-                # The review-CONTEXT waiver (freshness + base gates) is a SEPARATE
-                # sigil from # review-override: the freshness gate is the
-                # high-traffic one (Codex never auto-re-reviews a push), and if its
-                # escape also waived the P1 finding scans, the path of least
-                # resistance would systematically disarm P1 enforcement (Codex P1 +
-                # architect SHOULD-FIX on #1366). One trailing comment may carry
-                # both sigils when both waivers are genuinely intended.
-                stale_override = has_trailing_override(merge_seg.raw, "stale-review-override")
+                # force_override / stale_override were detected and noted above,
+                # before any gate could return. The review-CONTEXT waiver
+                # (freshness + base gates) is a SEPARATE sigil from
+                # # review-override: the freshness gate is the high-traffic one
+                # (Codex never auto-re-reviews a push), and if its escape also
+                # waived the P1 finding scans, the path of least resistance would
+                # systematically disarm P1 enforcement (Codex P1 + architect
+                # SHOULD-FIX on #1366). One trailing comment may carry both
+                # sigils when both waivers are genuinely intended.
 
                 # Base-branch invariant: a PR retargeted AFTER Codex reviewed it
                 # keeps the SAME head oid, so head-freshness alone can't see the
@@ -5163,7 +5506,8 @@ def main() -> int:
                 # merge-gate deadline BLOCKS at whichever gate hits its 1s floor first —
                 # never a silent pass. Uses verified_head from the Codex gate (None under
                 # # stale-review-override → re-read).
-                sched_override = has_trailing_override(merge_seg.raw, "scheduled-review-override")
+                # sched_override was detected and noted above, before any gate
+                # could return.
                 # Provision-or-surface: the scheduled gate no-ops off the configured
                 # public repo (by design). A SILENT no-op would hide a drifted
                 # genesis.yaml (canonical != the real public repo) disarming the gate

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -543,10 +543,18 @@ _KNOWN_SIGILS = (
     # sigil queried first still matched, which is why it went unnoticed.
     #
     # NOTE this widens acceptance as well as detection, in the fail-OPEN
-    # direction: `# merge-to-main-override review-override` now waives the
-    # findings gate where the unlisted token previously ended the run and it did
-    # not. That is the intended contract — the operator typed both sigils
-    # literally — but it is a gate-loosening change and is named as one.
+    # direction, and the reach is wider than the merge gate. MEASURED against the
+    # previous parser, every one of these flipped False -> True:
+    #   `git clean -fdx  # full-suite-ok discard-override`         -> the
+    #   `git clean -fdx  # merge-to-main-override discard-override`   UNRECOVERABLE
+    #                                                                 clean block
+    #   `gh pr merge …   # full-suite-ok review-override`          -> findings gate
+    #   `gh pr merge …   # merge-to-main-override ci-override`     -> CI gate
+    #   `git commit      # full-suite-ok audit-ack | depth-ack`    -> commit gates
+    # That is the intended contract — the operator typed both sigils literally,
+    # and nothing in the repo auto-composes a multi-sigil comment — but it is a
+    # gate-loosening change, the sharpest case is the one that deletes untracked
+    # files, and both are named here rather than left to be discovered.
     #
     # A test derives this set from the guards themselves (an ast walk over
     # scripts/hooks/), so the next divergence fails a test rather than waiting to

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -535,6 +535,24 @@ _KNOWN_SIGILS = (
     "stale-review-override",
     "scheduled-review-override",
     "discard-override",
+    # Both of these were passed to has_trailing_override from the day they
+    # shipped but never listed here, which made the "kept in sync" claim above
+    # false and had a MEASURED effect: the leading-run scan treats an unlisted
+    # token as PROSE, so an unlisted sigil written FIRST silently disables every
+    # sigil after it (`# full-suite-ok audit-ack` → audit-ack undetected). The
+    # sigil queried first still matched, which is why it went unnoticed.
+    #
+    # NOTE this widens acceptance as well as detection, in the fail-OPEN
+    # direction: `# merge-to-main-override review-override` now waives the
+    # findings gate where the unlisted token previously ended the run and it did
+    # not. That is the intended contract — the operator typed both sigils
+    # literally — but it is a gate-loosening change and is named as one.
+    #
+    # A test derives this set from the guards themselves (an ast walk over
+    # scripts/hooks/), so the next divergence fails a test rather than waiting to
+    # be noticed.
+    "merge-to-main-override",  # git_push_guard: local `git merge` onto main/master
+    "full-suite-ok",  # full_suite_guard: run the whole pytest suite locally
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,6 +251,34 @@ def _isolate_alert_queue(tmp_path):
     mp.undo()
 
 
+# ── Safety: prevent tests from writing REAL merge-override audit rows ───────
+@pytest.fixture(autouse=True)
+def _isolate_override_log(tmp_path):
+    """Redirect the merge gate's override log to tmp for ALL tests.
+
+    Any test that drives ``git_push_guard`` with an override sigil in the command
+    now produces a durable audit row, and the default path is the live log the
+    operator reads. MEASURED before this existed: four rows describing a PR that
+    does not exist — one blocked command retried during development — reached the
+    real file and had to be removed by hand. A store nobody isolated records
+    fiction before it records anything true.
+
+    Repo-wide rather than under ``tests/test_hooks/``: ``tests/test_scripts/``
+    also drives these hooks (some as subprocesses), and a bare local
+    ``git merge x  # merge-to-main-override`` is enough to write a row — no PR,
+    no network. Set on the environment so subprocess-launched hooks inherit it.
+
+    Uses a fixture-OWNED ``MonkeyPatch`` (not the shared ``monkeypatch``
+    fixture) so a test that calls ``monkeypatch.undo()`` mid-body cannot revert
+    this suite-isolation patch and re-expose the real log — mirrors
+    ``_isolate_alert_queue``.
+    """
+    mp = pytest.MonkeyPatch()
+    mp.setenv("GENESIS_MERGE_OVERRIDE_LOG", str(tmp_path / "merge_override_log.jsonl"))
+    yield
+    mp.undo()
+
+
 # ── Safety: prevent tests from writing to the REAL genesis.db ────────────────
 @pytest.fixture(autouse=True)
 def _isolate_genesis_db_path(tmp_path):

--- a/tests/test_hooks/test_merge_override_log.py
+++ b/tests/test_hooks/test_merge_override_log.py
@@ -1,0 +1,648 @@
+"""The merge gate's override sigils are advertised as "(logged)" — make that true.
+
+Before this module, the gate told the operator that appending `# ci-override` was
+"(logged)" and nothing anywhere wrote a record. The claim was false on every
+surface: no writer under scripts/ or src/genesis/, and nothing on disk but the
+hook-surface evidence directory.
+
+Two constraints are inherited rather than invented, both from
+``git_discard_guard.py`` (which is now the same writer — ``audit_jsonl``):
+
+* The row is METADATA ONLY. ``_record_snapshots``' docstring refuses to persist
+  the command because "the Bash payload can carry credentials … and this log is
+  durable". An override sigil IS a trailing comment on a Bash command, so the
+  only free text available here is command-line text. It never reaches the log.
+* The file is own-user-only, created without a umask window, appended under a
+  sidecar lock.
+"""
+
+import ast
+import importlib.util
+import json
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+_HOOKS = Path(__file__).resolve().parents[2] / "scripts" / "hooks"
+_spec = importlib.util.spec_from_file_location("git_push_guard_ovl", _HOOKS / "git_push_guard.py")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+HEAD = "a" * 40
+OTHER = "c" * 40
+
+
+@pytest.fixture
+def log_path(tmp_path, monkeypatch):
+    p = tmp_path / "sub" / "merge_override_log.jsonl"  # parent does NOT exist
+    monkeypatch.setenv("GENESIS_MERGE_OVERRIDE_LOG", str(p))
+    return p
+
+
+def _rows(path):
+    if not path.exists():
+        return []
+    return [json.loads(x) for x in path.read_text().splitlines() if x.strip()]
+
+
+def _note_and_flush(outcome="allowed", **kw):
+    _mod._PENDING_OVERRIDES.clear()
+    _mod._note_override(kw.pop("sigil", "ci-override"), **kw)
+    _mod._flush_overrides(outcome)
+
+
+class TestWriter:
+    def test_records_a_row(self, log_path):
+        _note_and_flush(waived="ci:red", pr="1525", repo="o/r", head=HEAD)
+        (row,) = _rows(log_path)
+        assert row["sigil"] == "ci-override"
+        assert row["pr"] == "1525"
+        assert row["head"] == HEAD
+        assert row["waived"] == "ci:red"
+        assert row["outcome"] == "allowed"
+        assert row["ts"]
+
+    def test_creates_a_missing_parent_directory(self, log_path):
+        """A missing parent silently made the whole feature a no-op in the first cut."""
+        assert not log_path.parent.exists()
+        _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        assert len(_rows(log_path)) == 1
+
+    def test_appends_rather_than_truncates(self, log_path):
+        _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        _note_and_flush(sigil="stale-review-override", waived="codex", pr="2", repo="o/r")
+        assert [r["pr"] for r in _rows(log_path)] == ["1", "2"]
+
+    def test_one_row_per_sigil_on_a_multi_sigil_merge(self, log_path):
+        """A merge routinely carries several sigils; per-sigil rates must stay countable."""
+        _mod._PENDING_OVERRIDES.clear()
+        _mod._note_override("stale-review-override", waived="codex", pr="9", repo="o/r")
+        _mod._note_override("scheduled-review-override", waived="sched", pr="9", repo="o/r")
+        _mod._flush_overrides("allowed")
+        assert sorted(r["sigil"] for r in _rows(log_path)) == [
+            "scheduled-review-override",
+            "stale-review-override",
+        ]
+
+    def test_rejects_a_sigil_outside_the_closed_set(self, log_path):
+        """The sigil field is a closed set (shell_parse._KNOWN_SIGILS), never free text."""
+        _note_and_flush(sigil="not-a-sigil", waived="ci")
+        assert _rows(log_path) == []
+
+    def test_never_raises_on_an_unwritable_path(self, tmp_path, monkeypatch, capsys):
+        """Best-effort: a logging failure must never break a merge — but it is LOUD."""
+        blocker = tmp_path / "not-a-dir"
+        blocker.write_text("")
+        monkeypatch.setenv("GENESIS_MERGE_OVERRIDE_LOG", str(blocker / "x.jsonl"))
+        _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        assert "[audit-log]" in capsys.readouterr().err
+
+    def test_file_and_directory_are_own_user_only(self, log_path):
+        _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        assert stat.S_IMODE(log_path.stat().st_mode) == 0o600
+        assert stat.S_IMODE(log_path.parent.stat().st_mode) == 0o700
+
+    def test_the_file_is_CREATED_restrictive_not_chmodded_afterwards(self, log_path):
+        """Pins the umask WINDOW, which a mode check structurally cannot see.
+
+        ``restrict()`` chmods to 0600 immediately after the open, so the final
+        mode is 0600 whether or not ``os.open`` was given a restrictive mode —
+        the two differ only for the instants between create and chmod, which is
+        exactly the exposure ``open()``+``chmod`` has and ``os.open`` does not.
+        Asserting the observable end state therefore passes on the insecure
+        version (MEASURED: mutating the mode to 0o644 left every mode assertion
+        green). So assert the CREATE mode itself.
+        """
+        import audit_jsonl
+
+        seen = {}
+        real_open = audit_jsonl.os.open
+
+        def spy(path, flags, mode=0o777):
+            seen[str(path)] = mode  # PATH too: append_row opens the sidecar AND
+            return real_open(path, flags, mode)  # the log; only the log matters
+
+        audit_jsonl.os.open = spy
+        try:
+            _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        finally:
+            audit_jsonl.os.open = real_open
+        # Recording only the mode let the .lock file satisfy the assertion while
+        # the LOG was opened insecurely — measured vacuous before this keyed on path.
+        assert str(log_path) in seen, f"the log itself was never os.open'd: {sorted(seen)}"
+        assert seen[str(log_path)] == 0o600, oct(seen[str(log_path)])
+
+    def test_pending_rows_do_not_leak_between_flushes(self, log_path):
+        _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        _mod._flush_overrides("allowed")  # nothing pending
+        assert len(_rows(log_path)) == 1
+
+
+class TestOutcomeTagging:
+    """A sigil that was typed and a sigil that let a merge through are different facts."""
+
+    @pytest.mark.parametrize("outcome", ["allowed", "asked", "blocked", "error"])
+    def test_outcome_is_recorded(self, log_path, outcome):
+        _note_and_flush(outcome, waived="ci:red", pr="1", repo="o/r")
+        assert _rows(log_path)[0]["outcome"] == outcome
+
+    def test_an_outcome_outside_the_closed_set_is_refused(self, log_path):
+        """The tuple is enforcement, not documentation — same as ``sigil``."""
+        _note_and_flush("probably-fine", waived="ci:red", pr="1", repo="o/r")
+        assert _rows(log_path) == []
+
+
+class TestNoCredentialLeak:
+    """The load-bearing test. A durable log must not persist command text."""
+
+    def test_row_carries_no_command_or_comment_text(self, log_path):
+        secret = "ghp_EXAMPLETOKENVALUE1234567890"
+        _note_and_flush(
+            waived="ci:red",
+            pr="1",
+            repo="o/r",
+            # A caller passing command text must not get it persisted, even by
+            # accident — the writer builds the row from a fixed field set.
+            **{"raw": f"gh pr merge 1 -H 'Authorization: {secret}'  # ci-override"},
+        )
+        text = log_path.read_text()
+        assert secret not in text
+        assert "Authorization" not in text
+        assert "gh pr merge" not in text
+
+    def test_field_set_is_closed(self, log_path):
+        """The expected names are LITERAL here, deliberately.
+
+        Comparing the row against ``_OVERRIDE_LOG_FIELDS`` compares production to
+        production: adding ``reason`` to the tuple and populating it — the
+        realistic way command text would ever reach this log — keeps that version
+        green. Widening the row must fail a test and be a conscious edit here.
+        """
+        _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        assert set(_rows(log_path)[0]) == {
+            "ts",
+            "sigil",
+            "outcome",
+            "waived",
+            "pr",
+            "repo",
+            "head",
+            "actor",
+        }
+
+    def test_head_and_repo_are_shape_checked(self, log_path):
+        """`head` is whatever followed --match-head-commit — arbitrary typed text."""
+        _note_and_flush(
+            waived="ci:red",
+            pr="1",
+            repo='own\nrep/x"}{',
+            head="ghp_notAShaButATokenShapedString12345",
+        )
+        row = _rows(log_path)[0]
+        assert row["head"] == ""
+        assert row["repo"] == ""
+
+    def test_a_valid_head_and_repo_survive(self, log_path):
+        """Positive control: the shape check must not reject real values."""
+        _note_and_flush(waived="ci:red", pr="1", repo="owner/repo-name.x", head=HEAD)
+        row = _rows(log_path)[0]
+        assert row["head"] == HEAD
+        assert row["repo"] == "owner/repo-name.x"
+
+
+class TestRetention:
+    """New store ships with its own prune — the New-Store Gate, same PR."""
+
+    def test_prunes_rows_older_than_the_window(self, log_path):
+        log_path.parent.mkdir(parents=True)
+        log_path.write_text('{"ts": "2020-01-01T00:00:00+00:00", "pr": "old"}\n')
+        _note_and_flush(waived="ci:red", pr="2", repo="o/r")
+        assert [r["pr"] for r in _rows(log_path)] == ["2"]
+
+    def test_keeps_rows_inside_the_window(self, log_path):
+        _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        _note_and_flush(waived="ci:red", pr="2", repo="o/r")
+        assert len(_rows(log_path)) == 2, "positive control: prune must not eat live rows"
+
+    def test_a_naive_timestamp_neither_kills_the_write_nor_the_row(self, log_path, capsys):
+        """THE ACCEPTANCE REPLAY for the blocker this rework exists to fix.
+
+        In the first cut the aware/naive comparison sat OUTSIDE the per-row try, so
+        ONE row with a timezone-naive ts raised, aborted the write, and did so on
+        every subsequent write forever — while the gate kept printing "(logged)".
+        The row is now appended BEFORE retention runs, and an unreadable ts is KEPT.
+        """
+        log_path.parent.mkdir(parents=True)
+        log_path.write_text('{"ts": "2026-08-30T00:00:00", "pr": "111"}\n')  # no tz
+        _note_and_flush(waived="ci:red", pr="222", repo="o/r")
+        assert [r["pr"] for r in _rows(log_path)] == ["111", "222"]
+        assert "[audit-log]" in capsys.readouterr().err
+
+        _note_and_flush(waived="ci:red", pr="333", repo="o/r")
+        assert "333" in [r["pr"] for r in _rows(log_path)], "writes must not stop"
+
+    def test_the_row_survives_a_maintainer_that_explodes(self, log_path, capsys):
+        """The structural fix behind the blocker: a maintainer that raises cannot
+        cost the caller the row it is writing.
+
+        MEASURED, and worth stating because the intuitive answer is wrong: removing
+        the per-maintainer ``try`` makes this test RED, while merely reordering the
+        append and the maintenance does NOT. Isolation is the guarantee; ordering is
+        a secondary safeguard.
+        """
+        import audit_jsonl
+
+        def _boom(_path):
+            raise RuntimeError("retention is broken")
+
+        _mod._PENDING_OVERRIDES.clear()
+        _mod._note_override("ci-override", waived="ci:red", pr="1", repo="o/r")
+        row = {k: "" for k in _mod._OVERRIDE_LOG_FIELDS}
+        assert audit_jsonl.append_row(str(log_path), row, maintain=[_boom])
+        assert len(_rows(log_path)) == 1
+        assert "maintenance failed" in capsys.readouterr().err
+
+    def test_unparseable_rows_are_kept_not_dropped(self, log_path):
+        log_path.parent.mkdir(parents=True)
+        log_path.write_text("not json at all\n")
+        _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        assert "not json at all" in log_path.read_text()
+
+    def test_size_backstop_bounds_a_file_of_unprunable_rows(self, log_path, monkeypatch):
+        """Age retention KEEPS what it cannot read, so size is the real bound.
+
+        The bound must be measured against the SEEDED size, not a round number: an
+        earlier version asserted ``< 2000`` on a 1600-byte seed plus a 166-byte
+        row, which is 1766 — i.e. it passed with the trim entirely inert, and was
+        the only test of the property the module calls the real bound.
+        """
+        monkeypatch.setattr(_mod, "_OVERRIDE_LOG_MAX_BYTES", 200)
+        log_path.parent.mkdir(parents=True)
+        seeded = "garbage\n" * 200
+        log_path.write_text(seeded)
+        _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        after = log_path.stat().st_size
+        assert after < len(seeded), f"trim did not shrink the file ({after} >= {len(seeded)})"
+        # ...and it keeps the RECENT half: the new row must survive its own trim.
+        assert '"pr": "1"' in log_path.read_text()
+
+
+class TestWiredIntoTheMergePath:
+    """E2E: the CALL SITES fire, not just the helper.
+
+    A helper that works and is never called is indistinguishable from no helper at
+    all — and that is exactly the state this change found the gate in. These drive
+    the real ``main()`` with a real merge command.
+    """
+
+    def _drive(self, monkeypatch, command, *, ci="SUCCESS", mergeable="MERGEABLE"):
+        monkeypatch.delenv("CLAUDE_TOOL_INPUT", raising=False)
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "main")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
+        # NETWORK-FREE BY CONSTRUCTION. Without these three seams the Codex
+        # freshness and scheduled-review gates issue live `gh api` reads against
+        # the real repo, so these tests were both flaky and MEASURING SOMETHING
+        # ELSE: four of them blocked on a real PR's review state while their
+        # docstrings claimed to exercise "a real merge". Mirrors the seam set in
+        # test_merge_gate_characterization.py, which is network-free by design.
+        monkeypatch.setenv(
+            "_TEST_GH_CODEX_REVIEWS",
+            json.dumps({"login": "chatgpt-codex-connector[bot]", "commit_id": HEAD}),
+        )
+        monkeypatch.setenv("_TEST_GH_CODEX_COMMENTS", "")
+        monkeypatch.setenv(
+            "_TEST_GH_SCHEDULED_COMMENTS",
+            json.dumps(
+                {
+                    "login": "owner",
+                    "author_association": "OWNER",
+                    "body": f"<!-- genesis-scheduled-review: head={HEAD} kind=code-review -->\n"
+                    f"<!-- genesis-scheduled-review: head={HEAD} kind=leaks -->",
+                }
+            ),
+        )
+        monkeypatch.setenv(
+            "_TEST_GH_CI_ROLLUP",
+            json.dumps([{"name": "t", "workflowName": "CI", "conclusion": ci}]),
+        )
+        monkeypatch.setattr(_mod, "_check_mergeable", lambda n, repo=None: mergeable)
+        monkeypatch.setattr(
+            _mod, "_check_pr_review_findings", lambda n, force=False, repo=None: (False, "")
+        )
+        monkeypatch.setattr(
+            _mod, "_check_inline_review_findings", lambda n, force=False, repo=None: (False, "")
+        )
+        monkeypatch.setattr(
+            _mod,
+            "read_payload",
+            lambda: {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            },
+        )
+        return _mod.main()
+
+    def test_ci_override_on_a_real_merge_is_recorded(self, monkeypatch, log_path):
+        self._drive(
+            monkeypatch,
+            f"gh pr merge 77 --squash --admin --match-head-commit {HEAD}  # ci-override",
+            ci="FAILURE",
+        )
+        (row,) = _rows(log_path)
+        assert row["sigil"] == "ci-override"
+        assert row["pr"] == "77"
+        assert row["waived"].startswith("ci:")
+
+    def test_the_row_carries_the_head_the_merge_is_bound_to(self, monkeypatch, log_path):
+        """Production passed no head at all in the first cut, so the store could not
+        answer the first question anyone would ask it: which commit merged?"""
+        self._drive(
+            monkeypatch,
+            f"gh pr merge 77 --squash --admin --match-head-commit {HEAD}  # ci-override",
+            ci="FAILURE",
+        )
+        assert _rows(log_path)[0]["head"] == HEAD
+
+    def test_review_override_on_a_real_merge_is_recorded(self, monkeypatch, log_path):
+        """The sigil the genesis-development skill documents as logged. It is read
+        off merge_seg.override, so enumerating has_trailing_override's call sites —
+        how the first cut chose its population — missed it entirely."""
+        self._drive(
+            monkeypatch,
+            f"gh pr merge 77 --squash --admin --match-head-commit {HEAD}  # review-override",
+        )
+        assert "review-override" in [r["sigil"] for r in _rows(log_path)]
+
+    def test_a_blocked_command_is_tagged_blocked(self, monkeypatch, log_path):
+        """The distortion that made the live file useless: rows fired on ATTEMPTS
+        with no way to tell them from overrides that took effect. Here the sigil
+        waives CI, but the merge is still blocked by the head-binding gate."""
+        rc = self._drive(
+            monkeypatch,
+            f"gh pr merge 77 --squash --admin --match-head-commit {OTHER}  # ci-override",
+            ci="FAILURE",
+        )
+        assert rc == 2
+        assert [r["outcome"] for r in _rows(log_path)] == ["blocked"]
+
+    def test_a_sigil_is_recorded_even_when_an_EARLIER_gate_blocks(self, monkeypatch, log_path):
+        """Noting at each gate's own site recorded NOTHING when a gate upstream of
+        it blocked — dropping exactly the attempts this log exists to count.
+        MEASURED then: a CONFLICTING mergeable with three sigils wrote zero rows.
+        """
+        rc = self._drive(
+            monkeypatch,
+            f"gh pr merge 77 --squash --admin --match-head-commit {HEAD}"
+            "  # ci-override stale-review-override scheduled-review-override",
+            mergeable="CONFLICTING",
+        )
+        assert rc == 2
+        rows = _rows(log_path)
+        assert sorted(r["sigil"] for r in rows) == [
+            "ci-override",
+            "scheduled-review-override",
+            "stale-review-override",
+        ]
+        assert {r["outcome"] for r in rows} == {"blocked"}
+        # The CI gate never ran, so the row keeps the gate CLASS, not a verdict.
+        ci = next(r for r in rows if r["sigil"] == "ci-override")
+        assert ci["waived"] == "ci-status"
+
+    def test_an_override_that_TAKES_EFFECT_is_recorded_as_allowed(self, monkeypatch, log_path):
+        """The distinction the whole outcome field exists for, asserted E2E.
+
+        Every other wired test asserted `blocked` or `asked`, or asserted no
+        outcome at all — so mislabelling every EFFECTIVE override as "asked"
+        (i.e. as still-undecided) left the whole suite green.
+        """
+        rc = self._drive(
+            monkeypatch,
+            f"gh pr merge 77 --squash --admin --match-head-commit {HEAD}  # ci-override",
+            ci="FAILURE",
+        )
+        assert rc == 0, "the sigil should have let this through"
+        assert [r["outcome"] for r in _rows(log_path)] == ["allowed"]
+
+    def test_escalation_ack_on_an_unrelated_command_records_nothing(self, monkeypatch, log_path):
+        """`escalation-ack` is a SHARED sigil — it is also the commit gate's ack,
+        printed by review_enforcement_commit.py as `git commit -m "…"  # escalation-ack`.
+
+        MEASURED before this control existed: `git commit`, `git status` and even
+        `pytest` each wrote a row claiming the codex-round-escalation cap had been
+        waived, for a gate that was never consulted and with no PR to reconcile
+        against. That would have made this sigil's dominant population fiction.
+        """
+        for cmd in (
+            'git commit -m "wip"  # escalation-ack',
+            "git status  # escalation-ack",
+            "pytest tests/test_x.py -q  # escalation-ack",
+        ):
+            self._drive(monkeypatch, cmd)
+            assert _rows(log_path) == [], f"{cmd!r} fabricated a row"
+
+    def test_escalation_ack_is_recorded(self, monkeypatch, log_path):
+        """The cap-BYPASS sigil — the escape from the anti-whack-a-mole gate, and
+        the highest-signal one. It IS a has_trailing_override call site, and was
+        still missed by enumerating that helper's call sites."""
+        self._drive(monkeypatch, 'gh pr comment 5 --body "@codex review"  # escalation-ack')
+        (row,) = _rows(log_path)
+        assert row["sigil"] == "escalation-ack"
+        assert row["pr"] == "5"
+        assert row["waived"] == "codex-round-escalation-cap"
+
+    def test_an_ask_decision_is_not_recorded_as_allowed(self, monkeypatch, log_path, capsys):
+        """`_ask` returns 0 while emitting a prompt the human may still DENY, so
+        rc==0 is three states. Recording it as allowed would have the log assert a
+        merge that never happened."""
+        monkeypatch.setattr(
+            _mod,
+            "read_payload",
+            lambda: {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": "git merge feat  # merge-to-main-override && git push origin feat",
+                    "cwd": "/home/ubuntu/tmp",
+                },
+            },
+        )
+        rc = _mod.main()
+        assert rc == 0
+        assert '"ask"' in capsys.readouterr().out
+        assert [r["outcome"] for r in _rows(log_path)] == ["asked"]
+
+    def test_no_sigil_writes_nothing(self, monkeypatch, log_path):
+        """Positive control's twin: an ordinary merge must not log."""
+        self._drive(monkeypatch, f"gh pr merge 77 --squash --admin --match-head-commit {HEAD}")
+        assert _rows(log_path) == []
+
+    def test_merge_command_text_never_reaches_the_log(self, monkeypatch, log_path):
+        """The credential guard, exercised through the real path rather than the helper."""
+        secret = "ghp_EXAMPLETOKENVALUE1234567890"
+        self._drive(
+            monkeypatch,
+            f"GH_TOKEN={secret} gh pr merge 77 --squash --admin "
+            f"--match-head-commit {HEAD}  # ci-override",
+            ci="FAILURE",
+        )
+        text = log_path.read_text() if log_path.exists() else ""
+        assert secret not in text
+        assert "GH_TOKEN" not in text
+
+    def test_merge_to_main_override_is_recorded(self, monkeypatch, tmp_path, log_path):
+        """The fifth merge-path sigil, and the second one the first cut missed."""
+        monkeypatch.setattr(
+            _mod,
+            "read_payload",
+            lambda: {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {
+                    "command": "git merge feature  # merge-to-main-override",
+                    "cwd": str(tmp_path),
+                },
+            },
+        )
+        _mod.main()
+        assert [r["sigil"] for r in _rows(log_path)] == ["merge-to-main-override"]
+
+
+class TestLoggingCannotCostTheVerdict:
+    """A hook's block is delivered by RETURNING in time. Anything the audit path
+    can do to delay that return is a security bug, not a latency one."""
+
+    def test_a_held_lock_drops_the_row_not_the_verdict(self, log_path, capsys):
+        """MEASURED before the bound existed: a second process holding the sidecar
+        hung the merge gate with no verdict until it was killed at 20s. Past the
+        harness wall-clock that is a SIGKILL, which is not exit 2, which lets the
+        guarded command run — a fail-CLOSED gate turned fail-OPEN."""
+        log_path.parent.mkdir(parents=True)
+        lock = str(log_path) + ".lock"
+        holder = subprocess.Popen(["flock", lock, "-c", "sleep 10"])
+        try:
+            time.sleep(0.4)  # let flock actually take it
+            started = time.monotonic()
+            _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+            elapsed = time.monotonic() - started
+        finally:
+            holder.terminate()
+            holder.wait(timeout=5)
+        # HARD number, not LOCK_TIMEOUT_S + slack: deriving the bound from the
+        # constant under test detects the bound's REMOVAL but not its loosening —
+        # raising LOCK_TIMEOUT_S to 8.0 (a 16x regression on a hook with a 60s
+        # wall clock) kept that version green.
+        assert elapsed < 2.0, (
+            f"the audit write blocked for {elapsed:.1f}s — a hook that cannot "
+            "return in time cannot deliver a block"
+        )
+        assert _mod.audit_jsonl.LOCK_TIMEOUT_S <= 1.0, "the bound itself has drifted"
+        assert _rows(log_path) == [], "the row is what gets dropped, not the verdict"
+        assert "lock busy" in capsys.readouterr().err
+
+    def test_the_row_lands_when_the_lock_is_free(self, log_path):
+        """Positive control: without it, the test above passes on a broken writer."""
+        _note_and_flush(waived="ci:red", pr="1", repo="o/r")
+        assert len(_rows(log_path)) == 1
+
+
+class TestSigilRunRegression:
+    """``merge-to-main-override`` was passed to has_trailing_override from the day it
+    shipped but never listed in _KNOWN_SIGILS, so the leading-run scan treated it as
+    PROSE and silently ended the run — disabling every sigil written after it."""
+
+    def test_an_unlisted_leading_sigil_no_longer_ends_the_run(self):
+        from shell_parse import has_trailing_override as h
+
+        assert h("git merge f  # merge-to-main-override audit-ack", "audit-ack")
+        assert h("git merge f  # audit-ack merge-to-main-override", "audit-ack")
+        assert h("git merge f  # merge-to-main-override", "merge-to-main-override")
+
+    def test_prose_still_ends_the_run(self):
+        from shell_parse import has_trailing_override as h
+
+        assert not h("git merge f  # see merge-to-main-override docs", "merge-to-main-override")
+
+    def test_every_sigil_any_guard_queries_is_declared(self):
+        """``_KNOWN_SIGILS`` claims to be kept in sync with the sigils actually
+        passed to has_trailing_override "across the guard hooks". Twice now it
+        was not, and both times the consequence was silent: an undeclared token
+        ends the leading run, disabling every sigil written after it.
+
+        Derived with ``ast`` over every CONSUMER, not a regex over one file. Two
+        guards pass their sigil as a module constant (``_OVERRIDE_SIGIL``,
+        ``_OVERRIDE``), so a literal-only scan cannot see them — which is how
+        ``full-suite-ok`` stayed undeclared while a regex test passed green.
+
+        The population is `scripts/**.py`, NOT `scripts/hooks/*.py`: a
+        hooks-only glob misses ``review_enforcement_commit.py``, which is where
+        ``audit-ack`` and ``depth-ack`` are queried — 2 of the declared sigils,
+        invisible to a scan that claimed to cover "every hook".
+        """
+        from shell_parse import _KNOWN_SIGILS
+
+        queried: dict[str, str] = {}
+        for path in sorted(_HOOKS.parent.rglob("*.py")):
+            tree = ast.parse(path.read_text())
+            consts = {}
+            for n in ast.walk(tree):
+                # Assign (`X = "s"`) AND AnnAssign (`X: str = "s"`) — a scan that
+                # handled only the first missed an annotated constant silently.
+                if isinstance(n, ast.Assign) and isinstance(n.value, ast.Constant):
+                    targets = [t for t in n.targets if isinstance(t, ast.Name)]
+                elif (
+                    isinstance(n, ast.AnnAssign)
+                    and isinstance(n.value, ast.Constant)
+                    and isinstance(n.target, ast.Name)
+                ):
+                    targets = [n.target]
+                else:
+                    continue
+                if isinstance(n.value.value, str):
+                    for t in targets:
+                        consts[t.id] = n.value.value
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                name = getattr(fn, "attr", None) or getattr(fn, "id", None)
+                if name not in ("has_trailing_override", "_has_trailing_override"):
+                    continue
+                arg = node.args[1] if len(node.args) > 1 else None
+                for kw in node.keywords:
+                    if kw.arg == "sigil":
+                        arg = kw.value
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    queried[arg.value] = path.name
+                elif isinstance(arg, ast.Name) and arg.id in consts:
+                    queried[consts[arg.id]] = path.name
+
+        # Guard the guard, against the CONSUMERS not a magic number: a floor of 5
+        # was satisfied by three files even when a fourth was silently dropped
+        # from the population, so it could not detect a lost consumer.
+        files = set(queried.values())
+        assert files >= {
+            "git_push_guard.py",
+            "git_discard_guard.py",
+            "full_suite_guard.py",
+            "review_enforcement_commit.py",
+        }, f"a known consumer produced no sigils — the walk went blind: {sorted(files)}"
+        undeclared = {s: f for s, f in queried.items() if s not in _KNOWN_SIGILS}
+        assert not undeclared, f"queried but not declared in _KNOWN_SIGILS: {undeclared}"
+
+
+def test_the_live_default_path_is_outside_any_repo(monkeypatch):
+    """The log must survive worktree removal and never be committed."""
+    monkeypatch.delenv("GENESIS_MERGE_OVERRIDE_LOG", raising=False)
+    assert _mod._override_log_path().endswith("/.genesis/merge_override_log.jsonl")
+
+
+def test_a_relative_env_override_is_refused(monkeypatch):
+    """A relative path resolves against the hook's cwd — the repo — putting a
+    durable audit file inside the working tree where it can be committed."""
+    monkeypatch.setenv("GENESIS_MERGE_OVERRIDE_LOG", "merge_override_log.jsonl")
+    assert _mod._override_log_path().endswith("/.genesis/merge_override_log.jsonl")

--- a/tests/test_hooks/test_merge_override_log.py
+++ b/tests/test_hooks/test_merge_override_log.py
@@ -19,6 +19,7 @@ Two constraints are inherited rather than invented, both from
 import ast
 import importlib.util
 import json
+import os
 import stat
 import subprocess
 import time
@@ -172,6 +173,36 @@ class TestNoCredentialLeak:
         assert secret not in text
         assert "Authorization" not in text
         assert "gh pr merge" not in text
+
+    def test_actor_cannot_be_forged_by_the_audited_command(self, log_path, monkeypatch):
+        """`actor` is the one field whose entire job is saying who did it.
+
+        `getpass.getuser()` looks right and is wrong: it reads $LOGNAME/$USER
+        FIRST and only then passwd. MEASURED with that version — `LOGNAME=...`
+        set by the very command being audited was written into the row, so a
+        merge could forge its own attribution.
+        """
+        monkeypatch.setenv("LOGNAME", "someone-else")
+        monkeypatch.setenv("USER", "someone-else")
+        _note_and_flush(waived="ci-status", pr="1", repo="o/r")
+        assert _rows(log_path)[0]["actor"] != "someone-else"
+
+    def test_waived_is_a_closed_shape(self, log_path):
+        """MEASURED before the check: a 311-char `waived` carrying quotes and a
+        token-shaped string was written to the row, while the docstring claimed
+        every field was shape-checked. It names a gate class, so it is closed."""
+        _note_and_flush(waived="X" * 300 + " ghp_secret", pr="1", repo="o/r")
+        assert _rows(log_path)[0]["waived"] == ""
+
+    def test_a_real_gate_class_survives(self, log_path):
+        """Positive control: the shape must not reject the values production sends."""
+        for w in ("ci-status", "ci:red", "codex-freshness+base-invariant"):
+            _note_and_flush(waived=w, pr="1", repo="o/r")
+        assert [r["waived"] for r in _rows(log_path)] == [
+            "ci-status",
+            "ci:red",
+            "codex-freshness+base-invariant",
+        ]
 
     def test_field_set_is_closed(self, log_path):
         """The expected names are LITERAL here, deliberately.
@@ -428,53 +459,28 @@ class TestWiredIntoTheMergePath:
         assert rc == 0, "the sigil should have let this through"
         assert [r["outcome"] for r in _rows(log_path)] == ["allowed"]
 
-    def test_escalation_ack_on_an_unrelated_command_records_nothing(self, monkeypatch, log_path):
-        """`escalation-ack` is a SHARED sigil — it is also the commit gate's ack,
-        printed by review_enforcement_commit.py as `git commit -m "…"  # escalation-ack`.
+    def test_command_scoped_acks_are_not_logged_at_all(self, monkeypatch, log_path):
+        """`escalation-ack` and `merge-to-main-override` are deliberately OUT of
+        scope — the pin for a decision, not an oversight.
 
-        MEASURED before this control existed: `git commit`, `git status` and even
-        `pytest` each wrote a row claiming the codex-round-escalation cap had been
-        waived, for a gate that was never consulted and with no PR to reconcile
-        against. That would have made this sigil's dominant population fiction.
+        Both are COMMAND-scoped acks whose gate is not evaluated where the sigil
+        is seen, so any row would assert a waiver that was never consulted, with
+        every identifying field empty. Two attempts to attribute them honestly
+        both produced fiction, MEASURED: `escalation-ack` on `git commit`,
+        `git status` and `pytest` each claimed the round cap was waived; after
+        narrowing, `git commit … # escalation-ack && gh pr comment 5 …` recorded
+        the COMMIT gate's ack against PR 5; and `merge-to-main-override` on a repo
+        checked out at a feature branch — where the gate would have allowed the
+        merge anyway — still claimed a local-merge-into-main waiver.
         """
         for cmd in (
             'git commit -m "wip"  # escalation-ack',
             "git status  # escalation-ack",
-            "pytest tests/test_x.py -q  # escalation-ack",
+            'gh pr comment 5 --body "@codex review"  # escalation-ack',
+            'git commit -m "x"  # escalation-ack && gh pr comment 5 --body "@codex review"',
         ):
             self._drive(monkeypatch, cmd)
-            assert _rows(log_path) == [], f"{cmd!r} fabricated a row"
-
-    def test_escalation_ack_is_recorded(self, monkeypatch, log_path):
-        """The cap-BYPASS sigil — the escape from the anti-whack-a-mole gate, and
-        the highest-signal one. It IS a has_trailing_override call site, and was
-        still missed by enumerating that helper's call sites."""
-        self._drive(monkeypatch, 'gh pr comment 5 --body "@codex review"  # escalation-ack')
-        (row,) = _rows(log_path)
-        assert row["sigil"] == "escalation-ack"
-        assert row["pr"] == "5"
-        assert row["waived"] == "codex-round-escalation-cap"
-
-    def test_an_ask_decision_is_not_recorded_as_allowed(self, monkeypatch, log_path, capsys):
-        """`_ask` returns 0 while emitting a prompt the human may still DENY, so
-        rc==0 is three states. Recording it as allowed would have the log assert a
-        merge that never happened."""
-        monkeypatch.setattr(
-            _mod,
-            "read_payload",
-            lambda: {
-                "hook_event_name": "PreToolUse",
-                "tool_name": "Bash",
-                "tool_input": {
-                    "command": "git merge feat  # merge-to-main-override && git push origin feat",
-                    "cwd": "/home/ubuntu/tmp",
-                },
-            },
-        )
-        rc = _mod.main()
-        assert rc == 0
-        assert '"ask"' in capsys.readouterr().out
-        assert [r["outcome"] for r in _rows(log_path)] == ["asked"]
+            assert _rows(log_path) == [], f"{cmd!r} produced a row"
 
     def test_no_sigil_writes_nothing(self, monkeypatch, log_path):
         """Positive control's twin: an ordinary merge must not log."""
@@ -494,8 +500,12 @@ class TestWiredIntoTheMergePath:
         assert secret not in text
         assert "GH_TOKEN" not in text
 
-    def test_merge_to_main_override_is_recorded(self, monkeypatch, tmp_path, log_path):
-        """The fifth merge-path sigil, and the second one the first cut missed."""
+    def test_a_local_merge_ack_writes_nothing(self, monkeypatch, tmp_path, log_path):
+        """`merge-to-main-override` is out of scope — see the class-scoped test
+        above. Pinned here too because this is the path that produced the fiction:
+        the ack short-circuits before the branch is resolved, so on a feature
+        branch (where the gate would have allowed the merge anyway) the row still
+        claimed a waiver, with pr, repo and head all empty."""
         monkeypatch.setattr(
             _mod,
             "read_payload",
@@ -509,7 +519,7 @@ class TestWiredIntoTheMergePath:
             },
         )
         _mod.main()
-        assert [r["sigil"] for r in _rows(log_path)] == ["merge-to-main-override"]
+        assert _rows(log_path) == []
 
 
 class TestLoggingCannotCostTheVerdict:
@@ -542,6 +552,35 @@ class TestLoggingCannotCostTheVerdict:
         )
         assert _mod.audit_jsonl.LOCK_TIMEOUT_S <= 1.0, "the bound itself has drifted"
         assert _rows(log_path) == [], "the row is what gets dropped, not the verdict"
+        assert "lock busy" in capsys.readouterr().err
+
+    def test_many_rows_share_ONE_deadline(self, log_path, capsys):
+        """The bound is on the CALLER's total delay, not on each row.
+
+        Per-row deadlines make the wait before the hook can return N x
+        LOCK_TIMEOUT_S, and N is not bounded — a compound command notes a row per
+        merge segment. Deleting the shared `deadline=` argument restores that and
+        was caught by NO test until this one: the only other timing test writes a
+        single row, where per-row and shared deadlines are indistinguishable.
+        """
+        log_path.parent.mkdir(parents=True)
+        lock = str(log_path) + ".lock"
+        holder = subprocess.Popen(["flock", lock, "-c", "sleep 10"])
+        try:
+            time.sleep(0.4)
+            _mod._PENDING_OVERRIDES.clear()
+            for n in range(6):
+                _mod._note_override("ci-override", waived="ci-status", pr=str(n), repo="o/r")
+            started = time.monotonic()
+            _mod._flush_overrides("allowed")
+            elapsed = time.monotonic() - started
+        finally:
+            holder.terminate()
+            holder.wait(timeout=5)
+        assert elapsed < 2.0, (
+            f"6 rows took {elapsed:.1f}s under contention — the deadline is being "
+            "applied per row, so the delay scales with the row count"
+        )
         assert "lock busy" in capsys.readouterr().err
 
     def test_the_row_lands_when_the_lock_is_free(self, log_path):
@@ -635,14 +674,21 @@ class TestSigilRunRegression:
         assert not undeclared, f"queried but not declared in _KNOWN_SIGILS: {undeclared}"
 
 
+#: The default, spelled out ONCE. Asserting only the SUFFIX was measured vacuous
+#: for the property these tests claim: a mutant returning
+#: `os.path.abspath(".genesis/merge_override_log.jsonl")` puts the log INSIDE the
+#: repo worktree — exactly "committed" — and still ends with that suffix.
+_EXPECTED_DEFAULT = os.path.expanduser("~/.genesis/merge_override_log.jsonl")
+
+
 def test_the_live_default_path_is_outside_any_repo(monkeypatch):
     """The log must survive worktree removal and never be committed."""
     monkeypatch.delenv("GENESIS_MERGE_OVERRIDE_LOG", raising=False)
-    assert _mod._override_log_path().endswith("/.genesis/merge_override_log.jsonl")
+    assert _mod._override_log_path() == _EXPECTED_DEFAULT
 
 
 def test_a_relative_env_override_is_refused(monkeypatch):
     """A relative path resolves against the hook's cwd — the repo — putting a
     durable audit file inside the working tree where it can be committed."""
     monkeypatch.setenv("GENESIS_MERGE_OVERRIDE_LOG", "merge_override_log.jsonl")
-    assert _mod._override_log_path().endswith("/.genesis/merge_override_log.jsonl")
+    assert _mod._override_log_path() == _EXPECTED_DEFAULT


### PR DESCRIPTION
The merge gate told the operator that appending `# ci-override` was "(logged)", and
the development skill said "The override is logged." Nothing wrote a record. Every
writer under `scripts/` and `src/` was enumerated: there was none. A gate that
promises an audit trail it does not keep is worse than one promising nothing — it
invites the escape on the belief that it is recorded.

## What is recorded

One metadata row per (merge, sigil) in `~/.genesis/merge_override_log.jsonl`:
`{ts, sigil, outcome, waived, pr, repo, head, actor}`.

`head` is the `--match-head-commit` value, which GitHub enforces server-side, so a
successful merge's row names the sha that merged. `outcome` is resolved at the gate's
verdict, not at detection: a sigil appended to a command that some **other** gate then
blocks is real signal — the escape was reached for — but it is not an override that
took effect, and counting the two together would inflate every figure drawn from the
file.

Metadata only. An override sigil is a trailing comment on a Bash command that can
carry a credential, so no command or comment text reaches the row and there is no
reason field to add. That constraint is inherited from `git_discard_guard`, whose
recovery log refuses command text for the same reason. Every value is shape-checked,
not just the field names.

## Scope, and what is deliberately outside it

The four **PR-merge** sigils are covered: `# review-override`, `# ci-override`,
`# stale-review-override`, `# scheduled-review-override` — from the point the PR
resolves onward. A merge rejected before that (no `--admin`, unresolvable repo or PR)
writes nothing; those are malformed commands, not override events.

The two **command-scoped acks** — `# escalation-ack` and `# merge-to-main-override` —
are deliberately **not** logged. Their gate is not evaluated where the sigil is seen,
so a row could only say the ack was typed, never that it waived anything. Two attempts
to attribute them honestly both produced fiction, measured: `escalation-ack` on
`git commit`, `git status` and `pytest` each claimed the round cap was waived; after
narrowing, `git commit … # escalation-ack && gh pr comment 5 …` recorded the commit
gate's ack against PR 5; and `merge-to-main-override` on a repo at a feature branch,
where the gate would have allowed the merge anyway, still claimed a waiver with every
identifying field empty. A test pins the exclusion as a decision. Logging them needs
the ack bound to the segment it rides — filed as a follow-up.

## Shared writer, whole precedent

The locking and create modes move out of `git_discard_guard` into a new
`scripts/hooks/audit_jsonl.py` used by both: 0600/0700, `os.open` applying the mode at
create time (no umask window), an exclusive flock on a sidecar that atomic rewrites
cannot orphan, and retention/trim as maintainer callables. An earlier cut cited that
precedent and adopted only its credential rule; the live log it produced was mode
**644**.

Retention keeps rows it cannot interpret. An earlier cut compared an aware cutoff
against a row timestamp outside the per-row `try`, so one timezone-naive row raised,
abandoned the write, and did so on every later write forever — while the gate kept
printing "(logged)". Each maintainer is now isolated, and a size cap bounds a file of
rows retention cannot read.

## Two things this had to fix in itself

**A fail-open.** The flush took the sidecar lock with a blocking `flock`, from `main`'s
`finally` — the path that delivers a block. Measured: with another process holding the
lock the guard produced no verdict and was killed at 20s, against a 0.00s baseline.
Past the hook wall clock that is a SIGKILL, which is not exit 2, which lets the guarded
command run. Acquisition is now bounded and non-blocking with one deadline shared
across the whole flush; a contended write drops the **row**, never the verdict.
Re-measured at 0.51s.

**Forgeable attribution.** `actor` used `getpass.getuser()`, which reads
`$LOGNAME`/`$USER` before the passwd database — so the command being audited could set
the one field whose job is saying who ran it. It now reads the uid.

## Sigil declaration

`# merge-to-main-override` and `# full-suite-ok` were passed to
`has_trailing_override` since they shipped but never listed in `_KNOWN_SIGILS`, which
made that tuple's "kept in sync" comment false and had a measured effect: the
leading-run scan treats an unlisted token as prose, so an unlisted sigil written first
silently disabled every sigil after it (`# full-suite-ok audit-ack` → `audit-ack`
undetected). Both are declared now, and an `ast` walk over every consumer pins the set.

Declaring them **widens acceptance as well as detection**, in the fail-open direction.
Every newly-accepted combination is enumerated in the code comment; the sharpest is
`# full-suite-ok discard-override`, which reaches the untracked-file deletion block.
All require the operator to type both tokens literally, and nothing in the repo
auto-composes a multi-sigil comment.

## Verification

45 tests in the new module. Every new assertion was verified RED against a mutation of
the specific behaviour it pins — 14/14, verdicts read from the pytest summary line
rather than the exit code (this repo's wrapper exits 200 under lock contention, which
an exit-code rule scores as a false "caught"), with restore checked against
pre-mutation hashes. One mutation is skipped with its reason recorded rather than
silently omitted.

Four tests were found vacuous during review and fixed rather than kept, including a
size backstop that passed with the trim entirely inert and two path assertions that
checked only a suffix, so a mutant putting the log inside the repo worktree passed the
very tests written to prevent that. The E2E harness was also making live GitHub API
calls, and four tests claiming to exercise "a real merge" were silently blocking; it
is now network-free by construction.

1512 tests across 21 affected suites pass. `ruff` clean. Differential against `main` on
four payloads (push arm, local merge, ask, multi-sigil): decisions byte-identical.

An autouse fixture isolates the log for the whole test suite. Without it, any test
driving the gate with a sigil writes a durable row to the real store — which is how
four rows describing a nonexistent PR reached the live file during development.

No change to any block/allow decision beyond the sigil widening named above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merge override actions are now recorded with the relevant pull request, commit, waived gate, and final outcome.
  * Added support for recognizing additional merge approval sigils.
  * Audit records exclude command text and sensitive credentials.

* **Bug Fixes**
  * Logging failures no longer interrupt merge or discard protections.
  * Audit logs are secured, size-limited, and automatically maintained.

* **Documentation**
  * Updated development guidance to describe merge override logging behavior and scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->