### PR TITLE
test(observability): wedge the loop instead of racing it, and cover the re-arm

### DIFF
--- a/tests/test_runtime/test_threaded_daemon_job_health.py
+++ b/tests/test_runtime/test_threaded_daemon_job_health.py
@@ -177,6 +177,73 @@ async def _drive(fn) -> BaseException | None:
     return captured[0] if captured else None
 
 
+async def _drive_wedged(fn) -> BaseException | None:
+    """Run fn() on a worker thread while the event loop is genuinely BLOCKED.
+
+    This is the difference between modelling a stall and merely running beside
+    one. ``_drive`` keeps the loop turning (it polls with a 10 ms sleep), so a
+    record submitted by the worker CAN complete mid-burst -- and coalescing is
+    still satisfied there, because it is a CONCURRENCY bound; what does not hold
+    in that case is a cumulative count of one. A test that asserts the count must
+    create the "submitted and unable to run" state, not hope for it.
+
+    Sequencing, and every step of it is load-bearing:
+      * the worker waits on ``entered`` so it cannot submit before the wedge;
+      * ``call_soon`` enqueues ``_blocker`` BEFORE this task's own resume handle
+        and the ready queue is FIFO (it appends to the TAIL, so this is an
+        ordering guarantee relative to the resume, never "runs first overall"),
+        so the single ``sleep(0)`` below is enough for the loop to enter it;
+      * while ``_blocker`` sits in ``released.wait()`` the loop runs NOTHING --
+        ``run_coroutine_threadsafe`` still enqueues, but nothing drains it;
+      * the worker sets ``released`` when it is done, and only then does the
+        loop resume and run whatever was queued.
+    Both waits are deadline-bounded so a regression fails the test instead of
+    hanging the suite.
+    """
+    entered = threading.Event()
+    released = threading.Event()
+    captured: list[BaseException] = []
+    # Guard the guard: records whether the wedge was still held when the worker
+    # released it. Without this, an ordering regression (a sleep(0) that becomes
+    # sleep(0.01), a call_soon moved after the await, a different loop policy)
+    # degrades this test silently back into the ~50% flake it was written to
+    # remove -- and the failures would read as a coalescing regression, sending
+    # the next session to debug production code that is fine.
+    wedge_held: list[bool] = []
+
+    def _blocker() -> None:
+        entered.set()
+        wedge_held.append(released.wait(timeout=15))
+
+    def _worker() -> None:
+        try:
+            # STRICTLY smaller than the join bound below, or this message can
+            # never print: the loop only reaches the join before _blocker runs
+            # or after it returns, so a 15s wait here would always lose the race
+            # to a 5s join and report the wrong cause.
+            if not entered.wait(timeout=2):
+                raise AssertionError("event loop never entered the wedge")
+            fn()
+        except BaseException as exc:  # noqa: BLE001 - returned to the caller
+            captured.append(exc)
+        finally:
+            released.set()
+
+    thread = threading.Thread(target=_worker, name="wedge-worker", daemon=True)
+    thread.start()
+    asyncio.get_running_loop().call_soon(_blocker)
+    await asyncio.sleep(0)  # yield: the loop enters _blocker and stays there
+    thread.join(timeout=5)
+    if thread.is_alive():
+        raise AssertionError("worker thread did not finish within 5s")
+    if not wedge_held or not wedge_held[0]:
+        raise AssertionError(
+            "the wedge broke before the worker finished -- this test's "
+            "precondition did not hold, so its result proves nothing"
+        )
+    return captured[0] if captured else None
+
+
 @pytest.mark.parametrize(
     ("factory", "job_name"),
     [(OutreachHeartbeat, "outreach_heartbeat"), (DashboardHeartbeat, "dashboard_heartbeat")],
@@ -352,11 +419,19 @@ async def test_repeated_failures_coalesce_into_one_pending_record(factory):
     and firing a retry per record where a retry registry is wired. "The daemon is
     failing" is ONE fact however long the stall lasts.
 
-    The repeats are submitted from a single worker pass WITHOUT yielding to the
-    loop, which is what a wedge looks like from the daemon's side: the first record
-    is scheduled and cannot run, so the rest must be absorbed rather than queued.
-    Driving them through separate loop yields would let the first complete and prove
-    nothing.
+    The repeats are submitted while the event loop is genuinely WEDGED, which is
+    what a stall looks like from the daemon's side: the first record is scheduled
+    and CANNOT run, so the rest must be absorbed rather than queued.
+
+    That wedge is the whole point, and an earlier version of this test only
+    described it. It used ``_drive``, which keeps the loop turning, so the first
+    record could complete mid-burst -- at which point ``_record_failure`` is
+    SUPPOSED to submit another, and the assertion below failed. MEASURED at the
+    time: ~50% locally (6 of 12 runs), on either parametrization, and twice on
+    main's own CI. The mechanism guarantees a CONCURRENCY bound -- at most one
+    record IN FLIGHT -- and the cumulative count asserted here is only equivalent
+    to it while nothing can drain. ``_drive_wedged`` establishes that precondition
+    instead of hoping for it.
     """
     calls: list[str] = []
 
@@ -372,7 +447,11 @@ async def test_repeated_failures_coalesce_into_one_pending_record(factory):
         for n in range(5):
             daemon._record_failure(rt, RuntimeError(str(n)))
 
-    assert await _drive(_five_failures) is None
+    assert await _drive_wedged(_five_failures) is None
+    assert not calls, (
+        f"the loop drained {len(calls)} record(s) DURING the supposed wedge -- "
+        "the precondition broke, so the count below measures nothing"
+    )
     for _ in range(200):
         if calls:
             break
@@ -383,6 +462,67 @@ async def test_repeated_failures_coalesce_into_one_pending_record(factory):
     assert len(calls) == 1, (
         f"expected the pending record to absorb the repeats, got {len(calls)} "
         "-- a wedge would queue one per tick and burst on recovery"
+    )
+
+
+@pytest.mark.parametrize(
+    ("factory",),
+    [(OutreachHeartbeat,), (DashboardHeartbeat,)],
+    ids=["outreach", "dashboard"],
+)
+async def test_a_completed_record_re_arms_for_the_next_failure(factory):
+    """Coalescing is a CONCURRENCY bound, NOT a one-record-per-process latch.
+
+    The wedged test above pins ``pending.done()`` to False for its whole burst,
+    which is what makes its count assertion meaningful -- and which also makes it
+    structurally blind to the other half of the same predicate. MEASURED: with
+    only that test, weakening the guard to ``if pending is not None: return``
+    leaves the entire file green, while production stops recording after its
+    FIRST failure for the lifetime of the process -- consecutive_failures frozen
+    at 1, last_failure frozen at the first stall, and a wired retry registry
+    never firing again.
+
+    That is also the ORDINARY case, not the exotic one: ``_run`` calls
+    ``_record_failure`` once per interval (60s default), so a healthy loop with a
+    throwing emit completes each record long before the next tick and depends on
+    the re-arm entirely.
+
+    This test is deliberately NOT racy -- it drives the first record to
+    COMPLETION before submitting the second, so it asserts a state rather than a
+    timing window.
+    """
+    calls: list[str] = []
+
+    class _CountingRuntime:
+        def record_job_failure(self, job_name, *args, **kwargs):
+            calls.append(job_name)
+
+    daemon = factory(interval_seconds=60)
+    daemon._loop = asyncio.get_running_loop()
+    rt = _CountingRuntime()
+
+    assert await _drive(lambda: daemon._record_failure(rt, RuntimeError("a"))) is None
+    for _ in range(200):
+        if calls:
+            break
+        await asyncio.sleep(0.01)
+    await _drain_pending()
+    # Guard the guard: if the first record never landed, the re-arm assertion
+    # below would pass for the wrong reason.
+    assert len(calls) == 1, "the first record never landed -- this test proves nothing"
+    assert daemon._pending_failure is not None and daemon._pending_failure.done()
+
+    assert await _drive(lambda: daemon._record_failure(rt, RuntimeError("b"))) is None
+    for _ in range(200):
+        if len(calls) == 2:
+            break
+        await asyncio.sleep(0.01)
+    await _drain_pending()
+
+    assert len(calls) == 2, (
+        f"the COMPLETED pending record was never re-armed, got {len(calls)} -- a "
+        "daemon that keeps failing would record only its first failure, freezing "
+        "consecutive_failures and never re-firing the retry registry"
     )
 
 

--- a/tests/test_runtime/test_threaded_daemon_job_health.py
+++ b/tests/test_runtime/test_threaded_daemon_job_health.py
@@ -510,7 +510,18 @@ async def test_a_completed_record_re_arms_for_the_next_failure(factory):
     # Guard the guard: if the first record never landed, the re-arm assertion
     # below would pass for the wrong reason.
     assert len(calls) == 1, "the first record never landed -- this test proves nothing"
-    assert daemon._pending_failure is not None and daemon._pending_failure.done()
+    # The first record must not still be IN FLIGHT, or the second submission
+    # would be absorbed and this would test coalescing again rather than re-arm.
+    # Deliberately permissive about HOW: retaining the completed future and
+    # clearing it in a done-callback are both valid re-arms, and the callback
+    # form is arguably better since it stops holding the exception. Asserting
+    # `is not None and .done()` would have failed a correct implementation --
+    # over-constraining the mechanism instead of pinning the behaviour.
+    pending = daemon._pending_failure
+    assert pending is None or pending.done(), (
+        "the first failure record is still in flight, so the second submission "
+        "below would exercise coalescing rather than the re-arm branch"
+    )
 
     assert await _drive(lambda: daemon._record_failure(rt, RuntimeError("b"))) is None
     for _ in range(200):


### PR DESCRIPTION
## The problem

`test_repeated_failures_coalesce_into_one_pending_record` fails intermittently **on `main` itself**, not just on branches — main's own CI at 12:43 today, and a PR run at 14:40. Measured before touching anything: **6 failures in 12 local runs**, on either parametrization. A probe outside pytest entirely reproduced it 1/10, which rules out ordering and test pollution.

## Root cause

The mechanism guarantees a **concurrency bound** — at most one failure record *in flight*. The test asserted a **cumulative count** — at most one *ever*. Those coincide only while nothing can drain, and the `_drive` helper it used polls with a 10 ms sleep and keeps the loop turning. So the first record could complete mid-burst, at which point `_record_failure` is *supposed* to submit another, and the assertion failed.

The test's docstring claimed "the first record is scheduled and cannot run". `_drive`'s docstring says it keeps the loop turning. They contradicted each other, and the helper was right.

Captured with values rather than argued — an instrumented probe printing the pending-future state at each of the five submits, on a failing trial:

```
['None', 'DONE', 'pend', 'pend', 'pend'] -> calls=2
```

**Production is correct and is unchanged by this PR.** During a real stall the loop is blocked, `done()` stays `False`, and repeats genuinely absorb.

## The fix

`_drive_wedged` establishes the precondition instead of hoping for it: the worker cannot submit until the loop has entered the blocker, and the loop runs nothing until the worker releases it. Every synchronisation point is **event-gated rather than timing-gated**, which is what makes it hold on a loaded single-core runner.

## The hole that opened, and why it is closed here

Wedging pins `pending.done()` to `False`, so the *other* half of the same predicate became unreachable in the only test that submits more than once.

Measured: collapsing the guard to `if pending is not None: return` left **the entire file green**. That mutation is a real production bug — the daemon would record its first failure and never another for the life of the process, `consecutive_failures` frozen at 1, a wired retry registry never firing again. It is also the *ordinary* path: `_run` records once per interval, so a healthy loop completes each record long before the next tick and depends entirely on the re-arm.

The gap pre-dates this change. But this change is the moment it stops being intermittently loud and becomes invisible, so it gets a test rather than a follow-up. The new sibling drives the first record to completion before submitting the second — asserting a state, not a timing window.

The wedge also now proves its own precondition. If it breaks, the test says so in its own words rather than degrading back into a flake whose failures would read as a coalescing regression and send the next reader to debug production code that is fine.

## Verification

**Mutation matrix** (snapshot + trap-restore + sha256 verify + abort-on-no-result-line):

| mutation | before this PR | after |
|---|---|---|
| baseline | 16 passed | 18 passed |
| delete the coalesce guard | RED | RED |
| **never re-arm** | **SURVIVED (16 passed)** | **RED** |
| drop the future store | RED | RED |
| invert `done()` | RED | RED |

Zero survivors. Final restore byte-exact by sha256.

**Determinism**, A/B in the same window on the same box, counting only runs that produced a result line:

| | passed | failed | discarded |
|---|---|---|---|
| old (`_drive`) | 7 | 3 | 0 |
| new (`_drive_wedged`) | 20 | 0 | 0 |
| whole file, 18 runs | 18 | 0 | 0 |

With the earlier 6/12, that is **9 failures in 22 old runs against 0 in 38 new**.

An earlier measurement of mine reported this working fix as broken, because the box-wide pytest lock was refusing runs and the harness scored a non-zero exit as a test failure. Every number above therefore discards no-result runs explicitly and reports the discard count.

**Blast radius:** all four test files touching the daemons — 48 passed. `_drive` unchanged and still used by its three other callers. Ruff clean, frozen-clock guard clean, privacy scan clean. `git status` shows exactly one file.

## Review

`genesis-architect`, dispatched un-anchored: 0 BLOCKER / 2 SHOULD-FIX / 4 NOTE, all actioned. The load-bearing finding — the surviving mutation — was independently re-derived before being acted on. One NOTE consciously deferred: extracting the three hand-rolled thread-drive helpers into one shared helper, which would modify `_drive` and widen the blast radius of a de-flake. Tracked as 7d11b114409b4ae18d8d93fd88998871.

Note `migration-check` is currently failing on every open PR because `main` carries two migrations claiming prefix `0086`; that is unrelated to this change, which adds no migration and touches no production file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for failure handling during event-loop execution and worker-thread submissions.
  * Verified that concurrent failures are coalesced into a single persisted failure record.
  * Confirmed completed failure-record tasks can be re-armed for subsequent failures.
  * Added bounded waiting and cleanup safeguards to make asynchronous test scenarios more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->