### PR TITLE
fix(observability): stop surplus's loop-END heartbeat false-firing 'overdue'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The morning report no longer cries "surplus heartbeat overdue" during a long
+  healthy dispatch.** Surplus emits its subsystem heartbeat only at the end of a
+  dispatch cycle, and a single healthy dispatch can run 15-30 minutes — longer than
+  the old 10-minute overdue threshold — so a busy-but-healthy surplus was flagged
+  "heartbeat overdue" in the morning report and the subsystem-heartbeats view. The
+  threshold is loosened to 3 hours, matching the surplus dashboard tile's own
+  liveness bound; a genuinely dead surplus is still caught within ~15 minutes by the
+  scheduler watchdog, which reads a separate, per-dispatch signal.
+
 - **The Queues card could report "healthy — queues are clear" for counters it
   never collected.** When the queues section of the health snapshot fails, it is
   replaced wholesale by an error marker carrying no per-counter detail. The

--- a/src/genesis/mcp/health/manifest.py
+++ b/src/genesis/mcp/health/manifest.py
@@ -157,7 +157,14 @@ async def _impl_bootstrap_manifest() -> dict:
 # verdict.
 HEARTBEAT_EXPECTED = {
     "awareness": (300, 360),      # 5 min tick, error at 6 min
-    "surplus": (300, 600),
+    # surplus's event-HB emits at loop-END (surplus/scheduler.py), so a healthy single
+    # dispatch_once (15-30 min) legitimately gaps it — a tight 600s overdue false-fired
+    # "surplus heartbeat overdue" in the morning report / subsystem_heartbeats display.
+    # overdue=3h matches the surplus TILE's job_health stall bound
+    # (observability/liveness.stall_threshold_minutes(5) = 180 min), so display and tile
+    # agree; genuine total cessation is caught far sooner (900s) by the zombie-scheduler
+    # watchdog, which reads job_health (refreshed every dispatch), not this event-HB.
+    "surplus": (300, 10800),      # 5-min loop; overdue at 3h (loop-END HB is load-fragile)
     # inbox checks every 30 min (inbox/types.py check_interval_seconds=1800).
     # overdue=4× (7200s) so one slow/skipped check doesn't false-fire; a 2×
     # (3600s) threshold was too tight. (Assumes the default interval; a custom

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -826,9 +826,12 @@ class SurplusScheduler:
         except Exception:
             pass
         try:
-            # Record heartbeat at loop entry so the watchdog sees liveness
-            # even when a single dispatch_once() blocks for 15-30 minutes
-            # (sequential task execution + intake pipeline overhead).
+            # Refresh job_health at loop entry (and before each dispatch, below) so the
+            # 900s zombie-scheduler watchdog sees liveness across a SEQUENCE of moderate
+            # dispatches. KNOWN GAP: this does NOT refresh DURING one dispatch_once that
+            # itself blocks 15-30 min — last_run then gaps, and unless heavy_workload is set
+            # (only the dream jobs set it) the watchdog could restart a healthy-but-slow
+            # surplus. Latent — no such restart observed to date; tracked as a follow-up.
             try:
                 from genesis.runtime import GenesisRuntime
 
@@ -837,8 +840,9 @@ class SurplusScheduler:
                 pass
 
             for _ in range(3):
-                # Refresh heartbeat before each dispatch so slow or
-                # failing tasks don't trip the 900s watchdog threshold.
+                # Refresh before each dispatch so a SEQUENCE of slow/failing tasks
+                # doesn't trip the 900s watchdog (does NOT cover the single-long-dispatch
+                # gap noted at loop entry).
                 with contextlib.suppress(Exception):
                     GenesisRuntime.instance().record_job_success("surplus_dispatch")
                 if not await self.dispatch_once():

--- a/tests/test_mcp/test_subsystem_staleness.py
+++ b/tests/test_mcp/test_subsystem_staleness.py
@@ -105,6 +105,34 @@ async def test_staleness_alive(db):
 
 
 @pytest.mark.asyncio
+async def test_staleness_surplus_long_dispatch_not_false_overdue(db):
+    """A busy-but-healthy surplus refreshes no event-HB mid-dispatch: its loop-END
+    ``Subsystem.SURPLUS`` pulse gaps for the length of a single long ``dispatch_once``
+    (15-30 min, per ``surplus/scheduler.py``). At the old 600s overdue threshold that
+    false-read 'overdue' — crying wolf in the morning report + ``subsystem_heartbeats``
+    display. The threshold is now aligned to the tile's 3h job_health stall bound, so a
+    ~25-min gap reads 'alive'."""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    # 1500s: well past the old 600s, comfortably under the 3h (10800s) threshold.
+    await _seed_heartbeat(db, "surplus", age_seconds=25 * 60)
+    hb = await compute_heartbeat_staleness("surplus", db=db, paused=False)
+    assert hb["status"] == "alive"
+
+
+@pytest.mark.asyncio
+async def test_staleness_surplus_overdue_past_3h(db):
+    """The loosening must NOT blind genuine total cessation: a surplus silent past the
+    3h threshold still reads 'overdue'. (In production the 900s watchdog restarts a real
+    death long before this display bound; this is the honest display backstop.)"""
+    from genesis.mcp.health.manifest import compute_heartbeat_staleness
+
+    await _seed_heartbeat(db, "surplus", age_seconds=4 * 3600)  # 14400s > 10800 (3h)
+    hb = await compute_heartbeat_staleness("surplus", db=db, paused=False)
+    assert hb["status"] == "overdue"
+
+
+@pytest.mark.asyncio
 async def test_staleness_no_heartbeat_empty_state(db):
     """No pulse ever (fresh install) → no_heartbeat, never 'stalled'."""
     from genesis.mcp.health.manifest import compute_heartbeat_staleness
@@ -255,7 +283,7 @@ async def test_staleness_paused_downgrades_surplus(db):
     while globally paused is NOT dead → downgraded to 'paused', not 'overdue'."""
     from genesis.mcp.health.manifest import compute_heartbeat_staleness
 
-    await _seed_heartbeat(db, "surplus", age_seconds=2 * 3600)  # > 600 threshold
+    await _seed_heartbeat(db, "surplus", age_seconds=4 * 3600)  # > 10800 (3h) threshold
     hb = await compute_heartbeat_staleness("surplus", db=db, paused=True)
     assert hb["status"] == "paused"
 
@@ -649,7 +677,7 @@ async def test_dashboard_cessation_alerts_warning(db):
 async def test_surplus_dropped_from_alert_set(db):
     """surplus is DROPPED from the alert set (PR-B's tile already covers it) —
     even a badly-overdue surplus emits NO subsystem_stale:surplus."""
-    await _seed_heartbeat(db, "surplus", age_seconds=3 * 3600)  # ≫ 600 threshold
+    await _seed_heartbeat(db, "surplus", age_seconds=4 * 3600)  # ≫ 10800 (3h) threshold
     alerts = await _run_alerts_with_db(db)
     assert not [a for a in _stale(alerts) if a["id"] == "subsystem_stale:surplus"]
 


### PR DESCRIPTION
## Problem
Surplus emits its `Subsystem.SURPLUS` event heartbeat only at the END of `_dispatch_loop`, so a healthy single `dispatch_once` (15-30 min) legitimately gaps it. The `HEARTBEAT_EXPECTED["surplus"]` overdue threshold was 600s — tighter than that gap — so a busy-but-healthy surplus false-fired "surplus heartbeat overdue" in the morning report and the `subsystem_heartbeats` display (crying wolf).

## Fix
- Loosen surplus overdue **600s → 3h (10800s)** = the surplus dashboard tile's job_health stall bound (`stall_threshold_minutes(5)`), so the event-HB display and the tile agree. Genuine total cessation is still caught far sooner (900s) by the zombie-scheduler watchdog, which reads job_health (refreshed every dispatch), not this event-HB. ~2× margin over the ~90 min worst-case healthy loop.
- Correct two misleading `_dispatch_loop` comments: the before-each-dispatch `record_job_success` refresh protects a *sequence* of moderate dispatches but does NOT refresh during one long `dispatch_once`, so `last_run` can still gap past the 900s watchdog with no `heavy_workload` deferral (dream-only). That latent watchdog-restart gap is tracked as a follow-up (no such restart observed to date).

## Tests
RED-first: a 25-min surplus read "overdue" at 600s, "alive" at 3h. +2 tests (long-dispatch-not-false-overdue; overdue-past-3h); 2 existing seeds bumped above the new threshold. 74/74 in the file green.

## Review
genesis-architect adversarial pass — CLEAN (Ready: Yes). Blast radius contained to `compute_heartbeat_staleness` (only reader of surplus's overdue value); value tile-aligned; tests non-vacuous.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false surplus scheduler staleness alerts by extending the heartbeat overdue threshold from 10 minutes to 3 hours.
  * Preserved earlier detection of genuinely stalled schedulers through the existing watchdog checks.

* **Documentation**
  * Clarified heartbeat behavior during long-running dispatches and documented the updated monitoring thresholds.

* **Tests**
  * Added coverage confirming moderate dispatch gaps remain healthy while multi-hour gaps are correctly reported as overdue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->