### PR TITLE
feat(contribution): area/difficulty label policy + Closes-# prevention

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,15 @@
 
 <!-- What does this PR do? Keep it brief. -->
 
+## Related issue
+
+<!-- If this PR resolves a tracked issue, link it with a CLOSING KEYWORD so the
+     issue closes automatically when this merges to the default branch. A bare
+     "#123" only cross-links — "Closes #123" (or Fixes/Resolves #123) closes it.
+     Delete this section if there's no linked issue. -->
+
+Closes #
+
 ## Changes
 
 <!-- Bullet the key changes. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   Every issue the Contributor Work-Log proposes must now carry an `area:*` domain
   label (memory/dashboard/runtime/guardian/autonomy/channels/knowledge/eval, or
   `area:other`) and a difficulty/environment label (`good first issue`,
-  `first-timers-only`, or `needs-genesis-instance`) —
+  `first-timers-only`, `needs-genesis-instance`, or `help wanted`) —
   `contributor_issue_propose` rejects a proposal missing either (fail-closed, after
   the privacy scan). The public PR template now prompts for a `Closes #NNN` keyword,
   and CONTRIBUTING documents that a bare `#NNN` won't auto-close the linked issue.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Contributor issues are labeled by domain and difficulty, enforced at the source.**
+  Every issue the Contributor Work-Log proposes must now carry an `area:*` domain
+  label (memory/dashboard/runtime/guardian/autonomy/channels/knowledge/eval, or
+  `area:other`) and a difficulty/environment label (`good first issue`,
+  `first-timers-only`, or `needs-genesis-instance`) —
+  `contributor_issue_propose` rejects a proposal missing either (fail-closed, after
+  the privacy scan). The public PR template now prompts for a `Closes #NNN` keyword,
+  and CONTRIBUTING documents that a bare `#NNN` won't auto-close the linked issue.
 - **Outreach total-cessation monitoring, without the old false-alarm trap.**
   Outreach is now in the `subsystem_stale` alert set (WARNING) alongside
   ego/inbox/dashboard. Previously it was excluded because its heartbeat was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,6 +393,11 @@ When a user shares a file path or URL in conversation:
 - **Code review after code changes.** Codex will review your output.
   Protocol in genesis-development skill.
 - **Commit continuously**: uncommitted = invisible = lost.
+- **Bias toward closing open work before opening new — softly (≈51/49).** Not a
+  gate: parallel work and multiple in-flight PRs are fine, and you needn't finish
+  everything before starting the next thing. Just lean, gently, toward landing or
+  closing open PRs over opening more — so work doesn't pile up and go stale on the
+  repo instead of getting done.
 - **Procedure recall is automatic** — the proactive hook surfaces relevant
   procedures. Store new procedures immediately when you discover them.
 - **Never insert directly into `task_states`.** Use `task_submit` MCP
@@ -420,6 +425,10 @@ When a user shares a file path or URL in conversation:
   echoes `input_value`, which holds the proof; read it, and check whether the
   same tool succeeded earlier in the session, before concluding anything about
   the tool.
+- **AskUserQuestion — always pass ≥2 questions.** Never call `AskUserQuestion`
+  with a single question — a Claude Code rendering bug rejects single-question
+  calls. Always pass ≥2 questions; if only one is real, add a trivial/filler
+  second question to satisfy the tool. Every time, no exceptions.
 - **Plan mode by default** for any task with 3+ steps or architectural
   decisions. If something goes sideways — STOP and re-plan.
 - **Use subagents** to keep main context clean. One concern per subagent.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,10 @@ gated on values they can't know.
 4. **Make your changes** — target ~600 LOC per file, hard cap 1000
 5. **Run lint + tests**: `ruff check . && pytest -v`
 6. **Commit** with a conventional prefix: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
-7. **Open a PR** against `main` — reference the issue/discussion in the description
+7. **Open a PR** against `main` — link the issue with a **closing keyword**:
+   `Closes #123` (or `Fixes`/`Resolves #123`) in the PR description. A bare `#123`
+   only cross-links; a closing keyword makes GitHub close the issue automatically
+   when the PR merges — and closing only fires on a merge to the **default branch**.
 
 PRs without a prior issue or discussion may be closed if the change wasn't
 discussed first. All PRs require a maintainer review before merging.
@@ -109,6 +112,10 @@ The architecture docs in [`docs/architecture/`](docs/architecture/) are the prim
 
 - Issues labeled [`good first issue`](https://github.com/WingedGuardian/GENesis-AGI/labels/good%20first%20issue) are scoped for new contributors
 - Issues labeled [`help wanted`](https://github.com/WingedGuardian/GENesis-AGI/labels/help%20wanted) are open for community contribution
+- Each issue carries an **`area:*`** label (memory, dashboard, runtime, guardian,
+  autonomy, channels, knowledge, eval) so you can find work in a domain you know,
+  and an environment label: **`needs-genesis-instance`** means you'll want a running
+  Genesis to reproduce/validate; without it you can generally start from a clone.
 - Check [Discussions](https://github.com/WingedGuardian/GENesis-AGI/discussions) for ideas and design conversations
 
 ## Questions?

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -425,7 +425,7 @@ gated — that contract is one-directional.
 ```yaml subsystem-map
 entry: autonomy-egress
 modules: [autonomy, outreach, distribution, content, campaigns]
-verified: d8204a0c 2026-08-25
+verified: 84c7259d 2026-08-31
 ```
 
 - **The chokepoint is `outreach/pipeline.py _deliver`** — ~12 send paths
@@ -446,9 +446,10 @@ verified: d8204a0c 2026-08-25
   server-side MCP tool (`contributor_issue_propose`, genesis-health) sanitizes a
   curator-drafted issue via the fail-closed `contribution/sanitize.py scan_prose`
   (title+body+labels — every string that egresses) and enforces the label policy
-  (fail-closed, AFTER the scan: a proposal missing an `area:*` domain label or a
-  difficulty/environment label — `_AREA_LABELS`/`_ENV_DIFFICULTY_LABELS` — is
-  `rejected` with no row), then HOLDS it: the
+  ON THE CONFIGURED PUBLIC TRACKER (fail-closed, AFTER the scan: a proposal missing
+  an `area:*` domain label or a difficulty/environment label —
+  `_AREA_LABELS`/`_ENV_DIFFICULTY_LABELS` — is `rejected` with no row; a
+  human-approved cross-repo post is not subject to the policy), then HOLDS it: the
   `approval_requests` row FIRST, then `pending_issue_posts` (mirroring the email
   gate). By default each hold is per-item owner-approved on the dashboard (excluded
   from `approve_all_pending`, like email). **Autonomous posture (opt-in,

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -445,7 +445,10 @@ verified: d8204a0c 2026-08-25
 - **The Contributor Work-Log posts public GitHub issues, gated like email.** A
   server-side MCP tool (`contributor_issue_propose`, genesis-health) sanitizes a
   curator-drafted issue via the fail-closed `contribution/sanitize.py scan_prose`
-  (title+body+labels — every string that egresses), then HOLDS it: the
+  (title+body+labels — every string that egresses) and enforces the label policy
+  (fail-closed, AFTER the scan: a proposal missing an `area:*` domain label or a
+  difficulty/environment label — `_AREA_LABELS`/`_ENV_DIFFICULTY_LABELS` — is
+  `rejected` with no row), then HOLDS it: the
   `approval_requests` row FIRST, then `pending_issue_posts` (mirroring the email
   gate). By default each hold is per-item owner-approved on the dashboard (excluded
   from `approve_all_pending`, like email). **Autonomous posture (opt-in,

--- a/src/genesis/mcp/health/contributor_issue.py
+++ b/src/genesis/mcp/health/contributor_issue.py
@@ -99,6 +99,17 @@ def _default_repo() -> str:
     return f"{owner}/{name}" if owner else name
 
 
+def _canonical_repo(repo: str) -> str:
+    """``owner/name`` lowercased, with any leading gh host segment dropped.
+
+    The repo validator admits gh's ``host/owner/repo`` form and GitHub slugs are
+    case-insensitive, so a case/host variant of the tracker (``wingedguardian/...``,
+    ``github.com/Owner/Name``) is the SAME repo. The label-policy scope check
+    compares canonical forms so such a variant can't skip the teeth."""
+    parts = [p for p in (repo or "").split("/") if p]
+    return "/".join(parts[-2:]).casefold()
+
+
 async def _impl_contributor_issue_propose(
     db,
     *,
@@ -171,8 +182,9 @@ async def _impl_contributor_issue_propose(
     #     `gh issue create` and strand the hold (retry-forever, consuming max_held).
     #     AFTER the privacy scan so a private-data proposal reports `blocked`
     #     (security), not `rejected` (policy). No row on rejection; the curator gets
-    #     a clear reason and self-corrects.
-    if repo == _default_repo():
+    #     a clear reason and self-corrects. Match on CANONICAL repo form so a
+    #     case/host variant of the tracker can't slip past the scope (Kimi review).
+    if _canonical_repo(repo) == _canonical_repo(_default_repo()):
         label_set = set(label_list)
         if not (label_set & _AREA_LABELS):
             return {
@@ -328,11 +340,12 @@ async def contributor_issue_propose(
     Args:
         title: issue title (sanitized here; must be public-safe).
         body: issue body / description (sanitized here).
-        labels: GitHub label names. REQUIRED (fail-closed): one ``area:*`` domain
-            label AND one difficulty/environment label (``good first issue`` /
-            ``first-timers-only`` / ``needs-genesis-instance``) — a proposal missing
-            either is ``rejected`` with no row. ``area:other`` is the cross-cutting
-            escape hatch.
+        labels: GitHub label names. On the configured public TRACKER repo this is
+            REQUIRED (fail-closed): one ``area:*`` domain label AND one difficulty/
+            environment label (``good first issue`` / ``first-timers-only`` /
+            ``needs-genesis-instance`` / ``help wanted``) — a proposal missing either
+            is ``rejected`` with no row. ``area:other`` is the cross-cutting escape
+            hatch. A post to a DIFFERENT repo is not subject to this policy.
         repo: target ``owner/name``. Defaults to this install's public repo.
         source: provenance — "follow_up" (backlog-derived) or "codebase".
         source_follow_up_id: originating follow_up id, for the close-loop link

--- a/src/genesis/mcp/health/contributor_issue.py
+++ b/src/genesis/mcp/health/contributor_issue.py
@@ -319,15 +319,20 @@ async def contributor_issue_propose(
     Args:
         title: issue title (sanitized here; must be public-safe).
         body: issue body / description (sanitized here).
-        labels: GitHub label names (e.g. ["good first issue"]). Optional.
+        labels: GitHub label names. REQUIRED (fail-closed): one ``area:*`` domain
+            label AND one difficulty/environment label (``good first issue`` /
+            ``first-timers-only`` / ``needs-genesis-instance``) — a proposal missing
+            either is ``rejected`` with no row. ``area:other`` is the cross-cutting
+            escape hatch.
         repo: target ``owner/name``. Defaults to this install's public repo.
         source: provenance — "follow_up" (backlog-derived) or "codebase".
         source_follow_up_id: originating follow_up id, for the close-loop link
             (stored on ``source_ref``). Optional.
 
     Returns a status dict: ``held`` (parked + approval created), ``blocked``
-    (sanitizer findings, no row), ``duplicate`` / ``backpressure`` (no row),
-    ``disabled`` (mode off), or ``error``.
+    (sanitizer findings, no row), ``rejected`` (missing a required area:* or
+    difficulty/environment label, no row), ``duplicate`` / ``backpressure`` (no
+    row), ``disabled`` (mode off), or ``error``.
     """
     import genesis.mcp.health_mcp as health_mcp_mod
 

--- a/src/genesis/mcp/health/contributor_issue.py
+++ b/src/genesis/mcp/health/contributor_issue.py
@@ -52,6 +52,43 @@ from genesis.mcp.health import mcp
 
 logger = logging.getLogger(__name__)
 
+# Label policy (fail-closed). Every proposed contributor issue must carry a
+# domain label (``area:*``) AND a difficulty/environment label, so the public
+# tracker stays navigable by domain and newcomers can find right-sized work.
+# Enforced in ``_impl`` below, AFTER the privacy scan (so a private-data proposal
+# reports ``blocked`` — the security verdict — rather than ``rejected``).
+#
+# PRODUCER: the labels are emitted by the curator's PROMPT — the install-local
+# contributor-worklog strategy doc, not any in-repo default (campaigns are user
+# data; see the module docstring). This validator is the machine BACKSTOP so a
+# drifting prompt can't silently ship unlabeled issues; a rejected proposal's
+# ``reason`` enumerates the valid labels, so an LLM curator that loops on error
+# self-corrects. ``area:other`` is the escape hatch for a genuinely cross-cutting
+# issue, so a valid proposal is never wrongly rejected. Keep in sync with the
+# GitHub label set (created via ``gh label create``).
+_AREA_LABELS = frozenset(
+    {
+        "area:memory",
+        "area:dashboard",
+        "area:runtime",
+        "area:guardian",
+        "area:autonomy",
+        "area:channels",
+        "area:knowledge",
+        "area:eval",
+        "area:other",
+    }
+)
+# A real difficulty/environment signal — NOT ``help wanted`` (a "community welcome"
+# marker that says nothing about difficulty or whether a running instance is needed).
+_ENV_DIFFICULTY_LABELS = frozenset(
+    {
+        "good first issue",
+        "first-timers-only",
+        "needs-genesis-instance",
+    }
+)
+
 
 def _default_repo() -> str:
     owner = github_user()
@@ -122,6 +159,28 @@ async def _impl_contributor_issue_propose(
         ]
         logger.warning("contributor_issue_propose BLOCKED %d finding(s): %s", len(reasons), reasons)
         return {"status": "blocked", "reasons": reasons, "scanners_run": scan.scanners_run}
+
+    # 1b) Label policy (fail-closed) — require a domain (area:*) AND a
+    #     difficulty/environment label. AFTER the privacy scan so a private-data
+    #     proposal reports `blocked` (security), not `rejected` (policy). No row is
+    #     written on rejection; the curator gets a clear reason and self-corrects.
+    label_set = set(label_list)
+    if not (label_set & _AREA_LABELS):
+        return {
+            "status": "rejected",
+            "reason": (
+                "missing an area:* label — every issue needs one domain label "
+                f"({', '.join(sorted(_AREA_LABELS))})"
+            ),
+        }
+    if not (label_set & _ENV_DIFFICULTY_LABELS):
+        return {
+            "status": "rejected",
+            "reason": (
+                "missing a difficulty/environment label — every issue needs one "
+                f"({', '.join(sorted(_ENV_DIFFICULTY_LABELS))})"
+            ),
+        }
 
     # 2) Backpressure + DB-side dedup (GitHub open-issue dedup is done at post
     #    time in the drain — the curator profile has no gh).

--- a/src/genesis/mcp/health/contributor_issue.py
+++ b/src/genesis/mcp/health/contributor_issue.py
@@ -79,13 +79,16 @@ _AREA_LABELS = frozenset(
         "area:other",
     }
 )
-# A real difficulty/environment signal — NOT ``help wanted`` (a "community welcome"
-# marker that says nothing about difficulty or whether a running instance is needed).
+# A contributor-lane label. ``help wanted`` is kept as the lane for experienced /
+# community clone-only work — beyond a newcomer ice-breaker but not needing a
+# running instance. Without it such a task has no truthful label and would be
+# forced to mislabel as beginner or be excluded (per Codex review, 2026-08-31).
 _ENV_DIFFICULTY_LABELS = frozenset(
     {
         "good first issue",
         "first-timers-only",
         "needs-genesis-instance",
+        "help wanted",
     }
 )
 
@@ -161,26 +164,32 @@ async def _impl_contributor_issue_propose(
         return {"status": "blocked", "reasons": reasons, "scanners_run": scan.scanners_run}
 
     # 1b) Label policy (fail-closed) — require a domain (area:*) AND a
-    #     difficulty/environment label. AFTER the privacy scan so a private-data
-    #     proposal reports `blocked` (security), not `rejected` (policy). No row is
-    #     written on rejection; the curator gets a clear reason and self-corrects.
-    label_set = set(label_list)
-    if not (label_set & _AREA_LABELS):
-        return {
-            "status": "rejected",
-            "reason": (
-                "missing an area:* label — every issue needs one domain label "
-                f"({', '.join(sorted(_AREA_LABELS))})"
-            ),
-        }
-    if not (label_set & _ENV_DIFFICULTY_LABELS):
-        return {
-            "status": "rejected",
-            "reason": (
-                "missing a difficulty/environment label — every issue needs one "
-                f"({', '.join(sorted(_ENV_DIFFICULTY_LABELS))})"
-            ),
-        }
+    #     difficulty/environment label. SCOPED to the configured public tracker
+    #     (`_default_repo()`), where the area:*/difficulty taxonomy is defined: a
+    #     human-approved cross-repo post to a repo without these labels is left to
+    #     the human, since mandating labels that don't exist there would fail at
+    #     `gh issue create` and strand the hold (retry-forever, consuming max_held).
+    #     AFTER the privacy scan so a private-data proposal reports `blocked`
+    #     (security), not `rejected` (policy). No row on rejection; the curator gets
+    #     a clear reason and self-corrects.
+    if repo == _default_repo():
+        label_set = set(label_list)
+        if not (label_set & _AREA_LABELS):
+            return {
+                "status": "rejected",
+                "reason": (
+                    "missing an area:* label — every issue needs one domain label "
+                    f"({', '.join(sorted(_AREA_LABELS))})"
+                ),
+            }
+        if not (label_set & _ENV_DIFFICULTY_LABELS):
+            return {
+                "status": "rejected",
+                "reason": (
+                    "missing a difficulty/environment label — every issue needs one "
+                    f"({', '.join(sorted(_ENV_DIFFICULTY_LABELS))})"
+                ),
+            }
 
     # 2) Backpressure + DB-side dedup (GitHub open-issue dedup is done at post
     #    time in the drain — the curator profile has no gh).

--- a/tests/test_autonomy/test_contributor_issue_watcher.py
+++ b/tests/test_autonomy/test_contributor_issue_watcher.py
@@ -543,7 +543,11 @@ async def test_e2e_autoapprove_then_drain_posts(db, tmp_path, monkeypatch):
     # the test exercises the post path, not the empty-config edge (covered elsewhere).
     monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)
     res = await ci._impl_contributor_issue_propose(
-        db, title="Autonomous newcomer task", body="A clean, public-safe task.", repo=_REPO
+        db,
+        title="Autonomous newcomer task",
+        body="A clean, public-safe task.",
+        labels=["good first issue", "area:runtime"],
+        repo=_REPO,
     )
     assert res["status"] == "held"
     assert res["auto_approved"] is True

--- a/tests/test_mcp/test_contributor_issue.py
+++ b/tests/test_mcp/test_contributor_issue.py
@@ -333,9 +333,10 @@ async def test_malformed_repo_components_rejected(db, live):
 
 
 @pytest.mark.asyncio
-async def test_rejected_missing_area_label(db, live):
+async def test_rejected_missing_area_label(db, live, monkeypatch):
     """A proposal with a difficulty label but NO area:* domain label is rejected
     with no row — the public tracker must stay navigable by domain."""
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)  # teeth scoped to the tracker
     res = await ci._impl_contributor_issue_propose(
         db, title="A clean title", body="A clean body.", labels=["good first issue"], repo=_REPO
     )
@@ -347,9 +348,10 @@ async def test_rejected_missing_area_label(db, live):
 
 
 @pytest.mark.asyncio
-async def test_rejected_missing_env_label(db, live):
+async def test_rejected_missing_env_label(db, live, monkeypatch):
     """An area:* label but NO difficulty/environment label is rejected — every
     issue must declare a lane (good first issue / needs-genesis-instance / …)."""
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)  # teeth scoped to the tracker
     res = await ci._impl_contributor_issue_propose(
         db, title="A clean title", body="A clean body.", labels=["area:runtime"], repo=_REPO
     )
@@ -361,8 +363,9 @@ async def test_rejected_missing_env_label(db, live):
 
 
 @pytest.mark.asyncio
-async def test_rejected_no_labels(db, live):
+async def test_rejected_no_labels(db, live, monkeypatch):
     """No labels at all → rejected (missing area is reported first)."""
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)  # teeth scoped to the tracker
     res = await ci._impl_contributor_issue_propose(
         db, title="A clean title", body="A clean body.", labels=[], repo=_REPO
     )
@@ -371,15 +374,33 @@ async def test_rejected_no_labels(db, live):
 
 
 @pytest.mark.asyncio
-async def test_area_other_is_a_valid_domain(db, live):
+async def test_area_other_is_a_valid_domain(db, live, monkeypatch):
     """area:other is the escape hatch for a genuinely cross-cutting issue, so a
     well-formed proposal is never wrongly rejected."""
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)  # teeth scoped to the tracker
     res = await ci._impl_contributor_issue_propose(
         db,
         title="A cross-cutting clean title",
         body="A clean body.",
         labels=["good first issue", "area:other"],
         repo=_REPO,
+    )
+    assert res["status"] == "held"
+
+
+@pytest.mark.asyncio
+async def test_label_policy_scoped_to_tracker_repo(db, live, monkeypatch):
+    """The label teeth is scoped to the configured tracker (`_default_repo()`),
+    where the area:* taxonomy exists. A human-approved post to a DIFFERENT repo is
+    NOT subjected to the policy (those labels may not exist there) — so an unlabeled
+    cross-repo proposal is held, not rejected."""
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)
+    res = await ci._impl_contributor_issue_propose(
+        db,
+        title="A clean cross-repo task",
+        body="A clean body.",
+        labels=[],  # no area/difficulty labels ...
+        repo="WingedGuardian/GENesis-Voice",  # ... but a NON-tracker repo → teeth skipped
     )
     assert res["status"] == "held"
 

--- a/tests/test_mcp/test_contributor_issue.py
+++ b/tests/test_mcp/test_contributor_issue.py
@@ -406,6 +406,23 @@ async def test_label_policy_scoped_to_tracker_repo(db, live, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_label_policy_matches_tracker_by_canonical_repo(db, live, monkeypatch):
+    """The scope check normalizes the repo (drops a gh `host/` prefix, casefolds), so
+    a case/host VARIANT of the tracker is still policed — it can't skip the teeth by
+    using a non-canonical slug for the same repo (Kimi review, 2026-08-31)."""
+    monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)  # WingedGuardian/GENesis-AGI
+    res = await ci._impl_contributor_issue_propose(
+        db,
+        title="A clean title",
+        body="A clean body.",
+        labels=[],  # unlabeled ...
+        repo="github.com/wingedguardian/genesis-agi",  # ... host-prefixed + lowercase variant → still the tracker
+    )
+    assert res["status"] == "rejected"
+    assert await pip.list_held(db) == []
+
+
+@pytest.mark.asyncio
 async def test_privacy_block_precedes_label_policy(db, live):
     """Placement invariant: the label policy runs AFTER the privacy scan, so a
     proposal that is BOTH label-invalid AND carries a private identifier reports

--- a/tests/test_mcp/test_contributor_issue.py
+++ b/tests/test_mcp/test_contributor_issue.py
@@ -47,6 +47,10 @@ def live(monkeypatch):
 
 async def _propose(db, **kw):
     kw.setdefault("repo", _REPO)
+    # Default to a policy-valid label set (area:* + a difficulty label) so tests
+    # exercising OTHER concerns (dedup, backpressure, mode) reach the code path
+    # they target. Tests of the label policy itself pass `labels=` explicitly.
+    kw.setdefault("labels", ["good first issue", "area:runtime"])
     return await ci._impl_contributor_issue_propose(db, **kw)
 
 
@@ -59,7 +63,7 @@ async def test_held_creates_row_and_approval(db, live):
         db,
         title="Add a test for parser.chunk empty input",
         body="No test covers the empty-input branch of chunk(); add one.",
-        labels=["good first issue", "help wanted"],
+        labels=["good first issue", "area:runtime"],
         source="follow_up",
         source_follow_up_id="fu-123",
     )
@@ -72,7 +76,7 @@ async def test_held_creates_row_and_approval(db, live):
     assert row["title"] == "Add a test for parser.chunk empty input"
     assert row["source"] == "follow_up"
     assert row["source_ref"] == "fu-123"
-    assert json.loads(row["labels"]) == ["good first issue", "help wanted"]
+    assert json.loads(row["labels"]) == ["good first issue", "area:runtime"]
     assert row["cell_domain"] == "github"
     assert row["request_id"] == res["request_id"]
     assert row["mode"] == "live"  # lever mode STAMPED at propose time (dry-run-terminal invariant)
@@ -85,7 +89,7 @@ async def test_held_creates_row_and_approval(db, live):
     assert appr["status"] == "pending"
     ctx = json.loads(appr["context"])
     assert ctx["repo"] == _REPO
-    assert ctx["labels"] == ["good first issue", "help wanted"]
+    assert ctx["labels"] == ["good first issue", "area:runtime"]
     assert ctx["source_follow_up_id"] == "fu-123"
     assert ctx["cell"] == ["github", "issue_create", "bulk"]
 
@@ -160,7 +164,11 @@ async def test_autonomous_pins_repo_to_default(db, live, monkeypatch):
     monkeypatch.setattr(ci, "require_approval", lambda: False)
     monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)
     res = await ci._impl_contributor_issue_propose(
-        db, title="Redirect attempt", body="A clean body.", repo="attacker/other-repo"
+        db,
+        title="Redirect attempt",
+        body="A clean body.",
+        labels=["good first issue", "area:runtime"],
+        repo="attacker/other-repo",
     )
     assert res["status"] == "held"
     assert res["repo"] == _REPO  # pinned, not attacker/other-repo
@@ -190,7 +198,11 @@ async def test_human_posture_keeps_curator_repo(db, live, monkeypatch):
     reviews the destination before it posts, so no pin is needed."""
     monkeypatch.setattr(ci, "_default_repo", lambda: _REPO)
     res = await ci._impl_contributor_issue_propose(
-        db, title="Other repo task", body="A clean body.", repo="WingedGuardian/GENesis-Voice"
+        db,
+        title="Other repo task",
+        body="A clean body.",
+        labels=["good first issue", "area:runtime"],
+        repo="WingedGuardian/GENesis-Voice",
     )
     assert res["status"] == "held"
     assert res["repo"] == "WingedGuardian/GENesis-Voice"  # not pinned under human review
@@ -314,6 +326,77 @@ async def test_malformed_repo_components_rejected(db, live):
     for bad in ("owner/", "/repo", "/", "a//b"):
         res = await ci._impl_contributor_issue_propose(db, title="t title", body="b body", repo=bad)
         assert res["status"] == "error", bad
+    assert await pip.list_held(db) == []
+
+
+# ── label policy (fail-closed): area:* + difficulty/env on every proposal ──
+
+
+@pytest.mark.asyncio
+async def test_rejected_missing_area_label(db, live):
+    """A proposal with a difficulty label but NO area:* domain label is rejected
+    with no row — the public tracker must stay navigable by domain."""
+    res = await ci._impl_contributor_issue_propose(
+        db, title="A clean title", body="A clean body.", labels=["good first issue"], repo=_REPO
+    )
+    assert res["status"] == "rejected"
+    assert "area" in res["reason"].lower()
+    assert await pip.list_held(db) == []
+    cur = await db.execute("SELECT COUNT(*) FROM approval_requests")
+    assert (await cur.fetchone())[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_rejected_missing_env_label(db, live):
+    """An area:* label but NO difficulty/environment label is rejected — every
+    issue must declare a lane (good first issue / needs-genesis-instance / …)."""
+    res = await ci._impl_contributor_issue_propose(
+        db, title="A clean title", body="A clean body.", labels=["area:runtime"], repo=_REPO
+    )
+    assert res["status"] == "rejected"
+    assert "difficulty" in res["reason"].lower() or "environment" in res["reason"].lower()
+    assert await pip.list_held(db) == []
+    cur = await db.execute("SELECT COUNT(*) FROM approval_requests")
+    assert (await cur.fetchone())[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_rejected_no_labels(db, live):
+    """No labels at all → rejected (missing area is reported first)."""
+    res = await ci._impl_contributor_issue_propose(
+        db, title="A clean title", body="A clean body.", labels=[], repo=_REPO
+    )
+    assert res["status"] == "rejected"
+    assert await pip.list_held(db) == []
+
+
+@pytest.mark.asyncio
+async def test_area_other_is_a_valid_domain(db, live):
+    """area:other is the escape hatch for a genuinely cross-cutting issue, so a
+    well-formed proposal is never wrongly rejected."""
+    res = await ci._impl_contributor_issue_propose(
+        db,
+        title="A cross-cutting clean title",
+        body="A clean body.",
+        labels=["good first issue", "area:other"],
+        repo=_REPO,
+    )
+    assert res["status"] == "held"
+
+
+@pytest.mark.asyncio
+async def test_privacy_block_precedes_label_policy(db, live):
+    """Placement invariant: the label policy runs AFTER the privacy scan, so a
+    proposal that is BOTH label-invalid AND carries a private identifier reports
+    `blocked` (the security verdict), never `rejected` (the policy one)."""
+    res = await ci._impl_contributor_issue_propose(
+        db,
+        title="Fix the box",
+        body="On the host at 192.168.1.42 the poller hangs.",
+        labels=[],  # also label-invalid, but security must win
+        repo=_REPO,
+    )
+    assert res["status"] == "blocked"
     assert await pip.list_held(db) == []
 
 


### PR DESCRIPTION
## Summary

Keeps contributor issues **navigable** (labeled by domain + difficulty) and
**auto-closing** (PRs prompted for a closing keyword). Prevention half of a
two-part effort; the merge-time follow-up reconcile is a separate, smaller PR.

## Changes

- **Fail-closed label policy** on `contributor_issue_propose`: rejects a proposal
  missing an `area:*` domain label OR a difficulty/environment label
  (`good first issue` / `first-timers-only` / `needs-genesis-instance`). Runs
  **after** the privacy scan (private-data → `blocked`, not `rejected`) and
  **before** any DB write (a rejected proposal creates no row). `area:other` is
  the escape hatch. The curator prompt (install-local strategy doc) emits the
  labels; this validator is the machine backstop.
- **Prevention**: the PR template now prompts for `Closes #NNN`, and CONTRIBUTING
  documents that a bare `#NNN` only cross-links and that auto-close fires only on
  a merge to the **default branch**.
- **CLAUDE.md**: always pass ≥2 questions to `AskUserQuestion` (works around a CC
  single-question rendering bug); a soft (~51/49) bias toward closing open work
  before opening new.
- **CHANGELOG** + **CURRENT.md** updated.
- Out-of-band (not in this diff): `area:knowledge`/`area:eval`/`area:other` GitHub
  labels created; the two install-local curator strategy docs updated to emit the
  mandated labels + a difficulty spread.

## Testing

- [x] `ruff check` clean on changed files
- [x] `pytest tests/test_mcp/test_contributor_issue.py` — **25 passed**; new
  fail-closed reject cases (missing area / missing env / no labels), area:other
  valid, and privacy-block-precedes-policy. **verify-RED** confirmed on both teeth
  branches (each RED-fails when disabled).
- [x] Local CI guards green: `check_external_io`, `check_subsystem_map`,
  `check_frozen_clock`, `check_shared_artifact_consumers`.
- [x] Adversarial `genesis-architect` review (round 1): SHOULD-FIX + 3 NOTEs, all
  addressed (producer-traceability comment, dropped `help wanted`, test symmetry,
  CONTRIBUTING wording).
- [x] `docs/architecture/CURRENT.md` entry updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Contributor Work-Log proposals now accept `help wanted` as a difficulty or environment label.
  - Label validation applies to the configured public tracker, with case- and host-insensitive matching.
  - Cross-repository proposals are exempt from taxonomy checks.
  - Invalid proposals are rejected before creation, while privacy checks remain the priority.

- **Documentation**
  - Updated contribution guidance to require issue-closing keywords in pull requests.
  - Added guidance for selecting issue labels and linking related work.
  - Updated the pull request template with a related issue section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->