### PR TITLE
fix(guardian): honor a self-expiring gateway pause file for deploys

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -821,7 +821,7 @@ radius) and the container-side Sentinel (CC-driven diagnosis/repair).
 ```yaml subsystem-map
 entry: guardian-sentinel
 modules: [guardian, sentinel]
-verified: 159698d4 2026-07-16
+verified: 84c7259d 2026-08-31
 ```
 
 - **guardian/** is bidirectional: host side (`python -m genesis.guardian`,
@@ -834,6 +834,15 @@ verified: 159698d4 2026-07-16
   `scripts/update.sh` / `guardian-gateway.sh` (the host-deploy gate in the dev
   skill). Known wart: the watchdog's stale-alert wording inverts when the
   deployed script is NEWER than the host checkout.
+- **Planned-maintenance stand-down** (`check.py::_gateway_pause_active`): reads a
+  self-expiring `<state_dir>/paused.json` — written by the gateway `pause [ttl]`
+  verb, bounded by `expires_at` and capped by `gateway_pause_max_ahead_s` — and
+  stands the whole check cycle down beside the indefinite `maintenance_file`. So a
+  `scripts/update.sh` deploy pauses the Guardian across the server restart instead
+  of escalating to `confirmed_dead` and firing a false down/recovered alert. The
+  TTL means a deploy killed before its `resume` self-heals rather than muting the
+  watchdog. Distinct from the container `~/.genesis/paused.json` runtime kill
+  switch (that pauses all of Genesis; this is host-side and Guardian-only).
 - Provisioning verbs are EXECUTE-ONLY — approval is the CALLER's
   responsibility (container obtains it via Telegram before invoking). Two
   families: Proxmox VM grows (`provision-grow-disk/-memory`, hypervisor API) and

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -837,12 +837,17 @@ verified: 84c7259d 2026-08-31
 - **Planned-maintenance stand-down** (`check.py::_gateway_pause_active`): reads a
   self-expiring `<state_dir>/paused.json` — written by the gateway `pause [ttl]`
   verb, bounded by `expires_at` and capped by `gateway_pause_max_ahead_s` — and
-  stands the whole check cycle down beside the indefinite `maintenance_file`. So a
-  `scripts/update.sh` deploy pauses the Guardian across the server restart instead
-  of escalating to `confirmed_dead` and firing a false down/recovered alert. The
-  TTL means a deploy killed before its `resume` self-heals rather than muting the
-  watchdog. Distinct from the container `~/.genesis/paused.json` runtime kill
-  switch (that pauses all of Genesis; this is host-side and Guardian-only).
+  stands the whole check cycle down beside the indefinite `maintenance_file`. This
+  is the *capability* a deploy uses to pause the Guardian across the server restart
+  — instead of escalating to `confirmed_dead` and firing a false down/recovered
+  alert — so that a paused restart is silent; the `scripts/update.sh` caller that
+  actually writes the pause across its stop/restart lands as a separate change (a
+  deploy on the old caller simply runs unpaused, as today). The TTL means a deploy
+  killed before its `resume` self-heals rather than muting the watchdog. During
+  stand-down the heartbeat carries a `standdown` marker so `probe_guardian` reports
+  DEGRADED (alive, not watching) rather than HEALTHY. Distinct from the container
+  `~/.genesis/paused.json` runtime kill switch (that pauses all of Genesis; this is
+  host-side and Guardian-only).
 - Provisioning verbs are EXECUTE-ONLY — approval is the CALLER's
   responsibility (container obtains it via Telegram before invoking). Two
   families: Proxmox VM grows (`provision-grow-disk/-memory`, hypervisor API) and

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -91,8 +91,13 @@ _write_gateway_pause() {
     expires_epoch=$((now_epoch + ttl))
     now_iso=$(date -u -d "@${now_epoch}" +%Y-%m-%dT%H:%M:%SZ)
     expires_iso=$(date -u -d "@${expires_epoch}" +%Y-%m-%dT%H:%M:%SZ)
+    # Atomic write (temp + mv): a guardian read racing the write must never see
+    # truncated JSON. The fail direction is already safe (ValueError -> not
+    # paused), but a torn read at deploy start could still cost one tick.
+    local tmp="$STATE_DIR/paused.json.tmp.$$"
     printf '{"paused": true, "reason": "deploy", "since": "%s", "expires_at": "%s"}' \
-        "$now_iso" "$expires_iso" > "$STATE_DIR/paused.json"
+        "$now_iso" "$expires_iso" > "$tmp"
+    mv -f "$tmp" "$STATE_DIR/paused.json"
     printf '{"ok": true, "action": "pause", "expires_at": "%s"}\n' "$expires_iso"
 }
 

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -119,6 +119,18 @@ case "${SSH_ORIGINAL_COMMAND:-}" in
                 exit 1
                 ;;
         esac
+        # Reject oversized magnitudes BEFORE base-10 conversion. Bash arithmetic
+        # uses fixed-width integers with NO overflow check, so a value beyond
+        # 64-bit (e.g. `pause 18446744073709551617`) silently WRAPS into the
+        # accepted range and reports success. Max valid is 3600 (4 digits): strip
+        # leading zeros, then reject anything longer than 4 digits — the numeric
+        # range check below catches 4-digit overshoot (e.g. 3601).
+        _TTL_MAG="${_PAUSE_TTL#"${_PAUSE_TTL%%[!0]*}"}"
+        [ -z "$_TTL_MAG" ] && _TTL_MAG=0
+        if [ "${#_TTL_MAG}" -gt 4 ]; then
+            echo '{"ok": false, "action": "pause", "error": "ttl out of range (1-3600)"}' >&2
+            exit 1
+        fi
         # Force base-10: a leading-zero value (e.g. 0888) would be read as octal
         # by bash arithmetic and abort under set -e.
         _PAUSE_TTL=$((10#$_PAUSE_TTL))

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -71,7 +71,11 @@ if [ -z "${HOME:-}" ]; then
     export HOME
 fi
 
-STATE_DIR="${HOME}/.local/state/genesis-guardian"
+# Honor the GUARDIAN_STATE_DIR override (the same env the guardian config reads,
+# config.py) so the pause file the gateway writes lands where _gateway_pause_active
+# looks. Default matches GuardianConfig.state_dir. (A guardian.yaml-only override
+# with no env is a pre-existing gateway limitation shared by the status verb.)
+STATE_DIR="${GUARDIAN_STATE_DIR:-${HOME}/.local/state/genesis-guardian}"
 
 # Write the gateway pause file with a bounded TTL (arg = seconds ahead). The
 # Guardian (check.py::_gateway_pause_active) stands down while this is present and

--- a/scripts/guardian-gateway.sh
+++ b/scripts/guardian-gateway.sh
@@ -73,15 +73,51 @@ fi
 
 STATE_DIR="${HOME}/.local/state/genesis-guardian"
 
+# Write the gateway pause file with a bounded TTL (arg = seconds ahead). The
+# Guardian (check.py::_gateway_pause_active) stands down while this is present and
+# unexpired, and IGNORES it once expires_at passes — so a deploy killed before
+# `resume` runs self-heals rather than muting the watchdog. The cap mirrors the
+# guardian's gateway_pause_max_ahead_s (3600). Distinct from the container-side
+# ~/.genesis/paused.json (the shared runtime kill switch).
+_write_gateway_pause() {
+    local ttl="$1"
+    mkdir -p "$STATE_DIR"
+    local now_epoch expires_epoch now_iso expires_iso
+    now_epoch=$(date -u +%s)
+    expires_epoch=$((now_epoch + ttl))
+    now_iso=$(date -u -d "@${now_epoch}" +%Y-%m-%dT%H:%M:%SZ)
+    expires_iso=$(date -u -d "@${expires_epoch}" +%Y-%m-%dT%H:%M:%SZ)
+    printf '{"paused": true, "reason": "deploy", "since": "%s", "expires_at": "%s"}' \
+        "$now_iso" "$expires_iso" > "$STATE_DIR/paused.json"
+    printf '{"ok": true, "action": "pause", "expires_at": "%s"}\n' "$expires_iso"
+}
+
 case "${SSH_ORIGINAL_COMMAND:-}" in
     restart-timer)
         systemctl --user restart genesis-guardian.timer
         echo '{"ok": true, "action": "restart-timer"}'
         ;;
     pause)
-        mkdir -p "$STATE_DIR"
-        printf '{"paused": true, "since": "%s"}' "$(date -Is)" > "$STATE_DIR/paused.json"
-        echo '{"ok": true, "action": "pause"}'
+        _write_gateway_pause 1800
+        ;;
+    pause\ *)
+        # pause <ttl_seconds> — deploy sets a generous TTL; EXIT-trap resume ends
+        # it early on success. Validate strictly (mirrors the redeploy arg guard).
+        _PAUSE_TTL="${SSH_ORIGINAL_COMMAND#pause }"
+        case "$_PAUSE_TTL" in
+            ''|*[!0-9]*)
+                echo '{"ok": false, "action": "pause", "error": "invalid ttl (want positive integer seconds)"}' >&2
+                exit 1
+                ;;
+        esac
+        # Force base-10: a leading-zero value (e.g. 0888) would be read as octal
+        # by bash arithmetic and abort under set -e.
+        _PAUSE_TTL=$((10#$_PAUSE_TTL))
+        if [ "$_PAUSE_TTL" -lt 1 ] || [ "$_PAUSE_TTL" -gt 3600 ]; then
+            echo '{"ok": false, "action": "pause", "error": "ttl out of range (1-3600)"}' >&2
+            exit 1
+        fi
+        _write_gateway_pause "$_PAUSE_TTL"
         ;;
     resume)
         rm -f "$STATE_DIR/paused.json"

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -311,6 +311,16 @@ async def _write_guardian_heartbeat(config: GuardianConfig) -> None:
             )
     except TimeoutError:
         logger.error("Guardian heartbeat write timed out", exc_info=True)
+        # wait_for cancelled communicate() but left the child running — kill and
+        # reap it, or a wedged incus/container orphans a process every tick (the
+        # stand-down paths call this each cycle during a long pause).
+        try:
+            proc.kill()
+            # Bound the reap: a D-state (uninterruptible) incus child could defer
+            # SIGKILL, so don't let the wait stall the tick indefinitely.
+            await asyncio.wait_for(proc.wait(), timeout=5.0)
+        except (TimeoutError, ProcessLookupError, OSError):
+            pass
     except OSError as exc:
         logger.error("Guardian heartbeat write failed: %s", exc)
 

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -278,17 +278,37 @@ async def _maybe_propose_provisioning(
         logger.warning("autonomous pool-grow proposal failed", exc_info=True)
 
 
-async def _write_guardian_heartbeat(config: GuardianConfig) -> None:
-    """Write heartbeat file into the container so Genesis knows Guardian is alive.
+def _heartbeat_payload(standdown: str | None = None) -> dict:
+    """Build the Guardian heartbeat payload.
 
-    Uses stdin pipe instead of heredoc to avoid shell injection.
+    ``standdown`` names the active stand-down (``"gateway_pause"`` /
+    ``"maintenance"``) so health surfaces can tell an intentional, alive-but-not-
+    watching Guardian (DEGRADED) from a fully-monitoring one (HEALTHY). The
+    process is alive either way — the container watchdog stays quiet — but
+    ``probe_guardian`` must not report HEALTHY while a check cycle is skipped.
+    Absent/None on the normal end-of-cycle heartbeat.
     """
     uptime_s = (datetime.now(UTC) - _STARTED_AT).total_seconds()
-    heartbeat = json.dumps({
+    payload: dict = {
         "guardian_alive": True,
         "timestamp": datetime.now(UTC).isoformat(),
         "uptime_s": round(uptime_s),
-    })
+    }
+    if standdown:
+        payload["standdown"] = standdown
+    return payload
+
+
+async def _write_guardian_heartbeat(
+    config: GuardianConfig, standdown: str | None = None
+) -> None:
+    """Write heartbeat file into the container so Genesis knows Guardian is alive.
+
+    ``standdown`` (when set) marks the heartbeat as an intentional stand-down so
+    ``probe_guardian`` reports DEGRADED rather than HEALTHY for the skipped cycle.
+    Uses stdin pipe instead of heredoc to avoid shell injection.
+    """
+    heartbeat = json.dumps(_heartbeat_payload(standdown))
 
     try:
         # Use stdin pipe — avoids heredoc injection risk
@@ -401,7 +421,7 @@ async def run_check(config: GuardianConfig | None = None) -> None:
             "Maintenance mode active — standing down (remove %s to resume)",
             maintenance_path,
         )
-        await _write_guardian_heartbeat(config)
+        await _write_guardian_heartbeat(config, standdown="maintenance")
         return
 
     # Gateway-driven, self-expiring stand-down (a deploy pauses us across the
@@ -409,7 +429,7 @@ async def run_check(config: GuardianConfig | None = None) -> None:
     # stand-down, but bounded by expires_at so a killed deploy can't mute us.
     if _gateway_pause_active(config):
         logger.info("Gateway pause active — standing down (deploy in progress)")
-        await _write_guardian_heartbeat(config)
+        await _write_guardian_heartbeat(config, standdown="gateway_pause")
         return
 
     state_path = config.state_path / "state.json"

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -23,7 +23,7 @@ import asyncio
 import json
 import logging
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from html import escape as html_escape
 from pathlib import Path
 
@@ -315,6 +315,59 @@ async def _write_guardian_heartbeat(config: GuardianConfig) -> None:
         logger.error("Guardian heartbeat write failed: %s", exc)
 
 
+def _gateway_pause_active(
+    config: GuardianConfig, now: datetime | None = None
+) -> bool:
+    """True if a live, unexpired gateway pause file is present — stand down.
+
+    The gateway ``pause`` verb writes ``<state_dir>/paused.json`` with an
+    ``expires_at`` (its built-in TTL) across a deploy's server restart. We honor
+    it only while unexpired AND only if ``expires_at`` is within
+    ``gateway_pause_max_ahead_s`` of now — a bad writer or clock skew must never
+    mute the watchdog for hours. A missing ``expires_at``, a malformed file, or
+    ``paused: false`` all read as NOT active: fail safe toward monitoring, since
+    indefinite stand-down is the ``maintenance_file``'s job, not this file's.
+    This is distinct from the container ``~/.genesis/paused.json`` (the shared
+    runtime kill switch) — this file is host-side and self-expiring.
+    """
+    now = now or datetime.now(UTC)
+    pause_file = config.state_path / "paused.json"
+    try:
+        if not pause_file.exists():
+            return False
+        data = json.loads(pause_file.read_text())
+        # Valid JSON can still be a non-object (e.g. `123`, `[..]`); `.get` on
+        # those raises AttributeError, which must NOT escape into run_check
+        # (it would abort the cycle, withhold the heartbeat, and read as DOWN).
+        if not isinstance(data, dict) or not data.get("paused"):
+            return False
+        expires_raw = data.get("expires_at")
+        if not expires_raw:
+            logger.warning(
+                "Gateway pause file has no expires_at — ignoring (use the "
+                "maintenance_file for indefinite stand-down): %s",
+                pause_file,
+            )
+            return False
+        expires_at = datetime.fromisoformat(expires_raw)
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        if expires_at <= now:
+            return False  # expired — the deploy pause self-healed
+        if expires_at > now + timedelta(seconds=config.gateway_pause_max_ahead_s):
+            logger.warning(
+                "Gateway pause expires_at too far ahead (>%ds) — ignoring as "
+                "suspect: %s",
+                config.gateway_pause_max_ahead_s,
+                expires_raw,
+            )
+            return False
+        return True
+    except (OSError, ValueError, TypeError) as exc:
+        logger.warning("Gateway pause file unreadable/malformed — ignoring: %s", exc)
+        return False
+
+
 async def run_check(config: GuardianConfig | None = None) -> None:
     """Run a single Guardian health check cycle.
 
@@ -325,12 +378,25 @@ async def run_check(config: GuardianConfig | None = None) -> None:
     if config is None:
         config = load_config()
 
+    # A stand-down still writes the heartbeat: the Guardian PROCESS is alive and
+    # deliberately not watching, so it must not read as DOWN to the container
+    # watchdog (watchdog.py, 300s stale threshold), which would otherwise SSH-
+    # restart it and page the mirror of the alert we suppress here.
     maintenance_path = Path(config.maintenance_file)
     if maintenance_path.exists():
         logger.info(
             "Maintenance mode active — standing down (remove %s to resume)",
             maintenance_path,
         )
+        await _write_guardian_heartbeat(config)
+        return
+
+    # Gateway-driven, self-expiring stand-down (a deploy pauses us across the
+    # server restart via the gateway `pause` verb) — beside the maintenance
+    # stand-down, but bounded by expires_at so a killed deploy can't mute us.
+    if _gateway_pause_active(config):
+        logger.info("Gateway pause active — standing down (deploy in progress)")
+        await _write_guardian_heartbeat(config)
         return
 
     state_path = config.state_path / "state.json"

--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -349,7 +349,10 @@ def _gateway_pause_active(
         # Valid JSON can still be a non-object (e.g. `123`, `[..]`); `.get` on
         # those raises AttributeError, which must NOT escape into run_check
         # (it would abort the cycle, withhold the heartbeat, and read as DOWN).
-        if not isinstance(data, dict) or not data.get("paused"):
+        # `paused` must be the literal boolean True — a truthy-but-non-bool value
+        # ("false", 1, "yes", {}) is malformed and must NEVER mute the watchdog
+        # (e.g. an operator hand-editing "paused":"false" to cancel a pause).
+        if not isinstance(data, dict) or data.get("paused") is not True:
             return False
         expires_raw = data.get("expires_at")
         if not expires_raw:

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -610,7 +610,7 @@ def load_config(path: Path | None = None) -> GuardianConfig:
         "container_name", "container_ip", "container_user",
         "health_api_port", "check_interval_s", "state_dir",
         "host_ip", "host_user", "maintenance_file",
-        "swap_reconcile_enabled",
+        "swap_reconcile_enabled", "gateway_pause_max_ahead_s",
     }
     top_kwargs = {k: v for k, v in raw.items() if k in top_fields}
 

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -334,6 +334,11 @@ class GuardianConfig:
     check_interval_s: int = 30
     state_dir: str = "~/.local/state/genesis-guardian"
     maintenance_file: str = "/var/lib/guardian-snapshots/.guardian-maintenance"
+    # Safety cap for the gateway pause file (`<state_dir>/paused.json`, written by
+    # the gateway `pause` verb across a deploy): the Guardian ignores a pause whose
+    # `expires_at` is more than this far in the future (a bad writer / clock skew
+    # must not mute the watchdog for hours). Keep >= the gateway's own ttl cap.
+    gateway_pause_max_ahead_s: int = 3600
     # Container-swap invariant reconciler (swap_watch): re-assert
     # limits.memory.swap=true + live cgroup activation each tick. Kill switch
     # for hosts where swap-off is a deliberate operator choice.

--- a/src/genesis/guardian/config.py
+++ b/src/genesis/guardian/config.py
@@ -336,8 +336,13 @@ class GuardianConfig:
     maintenance_file: str = "/var/lib/guardian-snapshots/.guardian-maintenance"
     # Safety cap for the gateway pause file (`<state_dir>/paused.json`, written by
     # the gateway `pause` verb across a deploy): the Guardian ignores a pause whose
-    # `expires_at` is more than this far in the future (a bad writer / clock skew
-    # must not mute the watchdog for hours). Keep >= the gateway's own ttl cap.
+    # `expires_at` is more than this far ahead (a bad writer / clock skew must not
+    # mute the watchdog for hours). Setting it below a pause's TTL does NOT tighten
+    # the pause — it makes that pause be rejected as too-far-ahead, silently
+    # disabling the stand-down. The automated deploy caller (update.sh) writes 1800,
+    # so load_config warns below 1800 (the deploy stand-down itself would break).
+    # A cap in [1800, 3600) still silently drops any MANUAL `pause >cap` (the gateway
+    # accepts up to 3600) — keep the 3600 default unless you accept that edge.
     gateway_pause_max_ahead_s: int = 3600
     # Container-swap invariant reconciler (swap_watch): re-assert
     # limits.memory.swap=true + live cgroup activation each tick. Kill switch
@@ -588,7 +593,22 @@ def _apply_provisioning_override(config: GuardianConfig) -> None:
 def _finalize(config: GuardianConfig) -> GuardianConfig:
     """Apply the provisioning override then env overrides (env wins)."""
     _apply_provisioning_override(config)
-    return _env_override(config)
+    config = _env_override(config)
+    # The gateway pause cap is an anti-absurdity guard (a bad writer/clock must
+    # never mute the watchdog for hours), NOT a policy knob to tighten below the
+    # caller TTLs. A cap under 1800 — the default TTL update.sh writes — makes
+    # even a bare `pause` file be rejected as too-far-ahead, so the gateway
+    # reports success while run_check keeps monitoring: the deploy stand-down
+    # silently never engages. Fail direction is safe (monitor, not mute), but the
+    # feature is disabled, so warn loudly rather than fail silently.
+    if config.gateway_pause_max_ahead_s < 1800:
+        logger.warning(
+            "gateway_pause_max_ahead_s=%ds is below the 1800s default deploy "
+            "pause TTL — pause files will be rejected as too-far-ahead and the "
+            "deploy stand-down will NOT engage. Set it >= the largest caller TTL.",
+            config.gateway_pause_max_ahead_s,
+        )
+    return config
 
 
 def load_config(path: Path | None = None) -> GuardianConfig:

--- a/src/genesis/observability/health.py
+++ b/src/genesis/observability/health.py
@@ -520,6 +520,21 @@ async def probe_guardian(
         staleness_s = (now - heartbeat_time).total_seconds()
 
         if staleness_s < degraded_threshold_s:
+            # A fresh heartbeat that carries a stand-down marker is an intentional,
+            # alive-but-not-watching Guardian (deploy pause / maintenance). The
+            # heartbeat is written each tick so the watchdog stays quiet, but the
+            # check cycle is skipped — so report DEGRADED, not HEALTHY, or health
+            # surfaces would claim full monitoring for the whole stand-down window.
+            standdown = data.get("standdown")
+            if standdown:
+                return ProbeResult(
+                    name="guardian",
+                    status=ProbeStatus.DEGRADED,
+                    latency_ms=round(latency, 2),
+                    message=f"Guardian standing down ({standdown}) — not monitoring",
+                    checked_at=now.isoformat(),
+                    details={"staleness_s": round(staleness_s, 1), "standdown": standdown},
+                )
             return ProbeResult(
                 name="guardian",
                 status=ProbeStatus.HEALTHY,

--- a/tests/test_guardian/test_container_side.py
+++ b/tests/test_guardian/test_container_side.py
@@ -35,6 +35,27 @@ class TestProbeGuardian:
         assert result.name == "guardian"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("reason", ["gateway_pause", "maintenance"])
+    async def test_fresh_standdown_heartbeat_is_degraded(self, tmp_path: Path, reason: str) -> None:
+        """F5: a FRESH heartbeat carrying a `standdown` marker means the Guardian
+        is alive but intentionally not watching (deploy pause / maintenance) — so
+        probe_guardian must report DEGRADED, not HEALTHY, even though the heartbeat
+        is current. Otherwise health surfaces claim full monitoring for the whole
+        stand-down window while check cycles are being skipped."""
+        now = datetime.now(UTC)
+        hb_file = tmp_path / "guardian_heartbeat.json"
+        hb_file.write_text(json.dumps({
+            "guardian_alive": True,
+            "timestamp": now.isoformat(),  # FRESH — not stale
+            "standdown": reason,
+        }))
+
+        result = await probe_guardian(hb_file, clock=lambda: now)
+        assert result.status == ProbeStatus.DEGRADED
+        assert reason in result.message
+        assert result.details.get("standdown") == reason
+
+    @pytest.mark.asyncio
     async def test_degraded_heartbeat(self, tmp_path: Path) -> None:
         now = datetime.now(UTC)
         old = now - timedelta(seconds=150)

--- a/tests/test_guardian/test_gateway_pause.py
+++ b/tests/test_guardian/test_gateway_pause.py
@@ -29,6 +29,10 @@ _GATEWAY = Path(__file__).resolve().parents[2] / "scripts" / "guardian-gateway.s
 
 def _run_gateway(cmd: str, home: Path) -> subprocess.CompletedProcess:
     env = {**os.environ, "HOME": str(home), "SSH_ORIGINAL_COMMAND": cmd}
+    # The gateway honors GUARDIAN_STATE_DIR; a dev running the guardian locally
+    # has it set, and inheriting it would make `pause` write to the REAL state
+    # dir (standing down a live guardian) instead of the test's HOME.
+    env.pop("GUARDIAN_STATE_DIR", None)
     return subprocess.run(
         ["bash", str(_GATEWAY)], env=env, capture_output=True, text=True, timeout=30
     )
@@ -36,7 +40,10 @@ def _run_gateway(cmd: str, home: Path) -> subprocess.CompletedProcess:
 
 def _cfg(tmp_path: Path) -> GuardianConfig:
     # state_dir drives config.state_path; the gateway writes paused.json there.
-    return GuardianConfig(state_dir=str(tmp_path))
+    # Point maintenance_file at an absent path so run_check can't take the
+    # maintenance stand-down branch on a box where the real flag exists (that
+    # would make the gateway-pause stand-down tests vacuous).
+    return GuardianConfig(state_dir=str(tmp_path), maintenance_file=str(tmp_path / "no-maint"))
 
 
 def _write_pause(
@@ -92,6 +99,26 @@ def test_paused_false_not_active(tmp_path: Path) -> None:
     assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is False
 
 
+@pytest.mark.parametrize("paused_val", ["false", "true", "0", 1, "yes"])
+def test_paused_truthy_non_bool_not_active(tmp_path: Path, paused_val) -> None:
+    """SF-1 regression: `paused` must be the literal boolean True. A truthy-but-
+    non-bool value (a string "false" an operator hand-edited to cancel a pause, or
+    a stringified "true") must NOT stand the guardian down — the old `not data.get
+    ("paused")` truthiness check treated "false"/1/"yes" as paused and MUTED the
+    watchdog. This REDs on that check and passes only under `is not True`."""
+    (tmp_path / "paused.json").write_text(
+        json.dumps(
+            {
+                "paused": paused_val,
+                "reason": "deploy",
+                "since": "2026-08-31T00:00:00Z",
+                "expires_at": (NOW + timedelta(minutes=10)).isoformat(),
+            }
+        )
+    )
+    assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is False
+
+
 def test_malformed_json_fails_safe(tmp_path: Path) -> None:
     (tmp_path / "paused.json").write_text("{not valid json")
     # Never crash the check cycle on a bad file; treat as not-paused.
@@ -133,10 +160,35 @@ def test_gateway_pause_verb_writes_file_guardian_honors(tmp_path: Path) -> None:
 
 
 def test_gateway_bare_pause_uses_default_ttl(tmp_path: Path) -> None:
+    # SF-7a: the bare `pause` must set a REAL 1800s window, not merely stamp
+    # *some* expires_at — a writer bug that collapsed the window to ~0 would
+    # pass a presence check yet leave the guardian effectively un-paused.
+    # since/expires_at derive from one `date +%s`, so the delta is exact.
     r = _run_gateway("pause", tmp_path)
     assert r.returncode == 0, r.stderr
     data = json.loads((_gateway_state_dir(tmp_path) / "paused.json").read_text())
-    assert data.get("expires_at")
+    since = datetime.fromisoformat(data["since"])
+    expires = datetime.fromisoformat(data["expires_at"])
+    assert (expires - since).total_seconds() == 1800
+
+
+def test_gateway_pause_ttl_cap_boundary(tmp_path: Path) -> None:
+    """SF-7b: the range guard is `1 <= ttl <= 3600` — 3600 is the INCLUSIVE cap
+    (accepted, writes a real 3600s window), 3601 is one past it (rejected), and 0
+    is below the floor (rejected). Locks the exact boundary so a `<`/`<=` slip in
+    the shell guard can't silently widen or narrow the accepted range."""
+    ok = _run_gateway("pause 3600", tmp_path)
+    assert ok.returncode == 0, ok.stderr
+    data = json.loads((_gateway_state_dir(tmp_path) / "paused.json").read_text())
+    since = datetime.fromisoformat(data["since"])
+    expires = datetime.fromisoformat(data["expires_at"])
+    assert (expires - since).total_seconds() == 3600
+    # one past the cap, and below the floor: both rejected, no file written
+    for bad in ("pause 3601", "pause 0"):
+        (_gateway_state_dir(tmp_path) / "paused.json").unlink(missing_ok=True)
+        r = _run_gateway(bad, tmp_path)
+        assert r.returncode == 1, f"{bad!r} should be rejected: {r.stdout} {r.stderr}"
+        assert not (_gateway_state_dir(tmp_path) / "paused.json").exists()
 
 
 def test_gateway_pause_rejects_non_integer_ttl(tmp_path: Path) -> None:
@@ -171,31 +223,35 @@ def test_non_object_json_fails_safe_no_crash(tmp_path: Path, body: str) -> None:
 
 
 @pytest.mark.asyncio
-async def test_stand_down_still_writes_heartbeat(tmp_path: Path, monkeypatch) -> None:
-    """SF-3: a stand-down must still heartbeat (Guardian is alive, just not
-    watching) so the container watchdog doesn't read it as DOWN and restart it.
+@pytest.mark.parametrize("trigger", ["gateway_pause", "maintenance"])
+async def test_stand_down_still_writes_heartbeat(tmp_path: Path, monkeypatch, trigger) -> None:
+    """BOTH stand-down branches (gateway pause AND maintenance) must still write
+    the heartbeat — the Guardian is alive, just not watching — so the container
+    watchdog doesn't read it as DOWN and restart it. Deleting the heartbeat from
+    EITHER branch must fail here (SF-4).
 
-    Fully isolated (P1): the heartbeat is spied and _check_cycle is tripwired, so
-    if the stand-down ever regressed, the test fails LOUDLY instead of running the
-    real production cycle (incus snapshot prune / swap reconcile / live alerts)
-    against the host it happens to run on.
+    Fully isolated: the heartbeat is spied and _check_cycle + the alert drain are
+    tripwired, so a regression fails LOUDLY instead of running the real production
+    cycle (incus snapshot prune / swap reconcile / live alerts) against the host.
     """
     calls: list[bool] = []
 
     async def _spy(config) -> None:  # real path uses incus; unavailable in CI
         calls.append(True)
 
-    async def _tripwire(*a, **k):  # first heavy production call after stand-down
+    async def _tripwire(*a, **k):  # first heavy production calls after stand-down
         raise AssertionError("run_check reached the production cycle — stand-down failed")
 
     monkeypatch.setattr("genesis.guardian.check._write_guardian_heartbeat", _spy)
-    # Tripwire the FIRST two production calls after the stand-down (the alert
-    # drain runs before _check_cycle), so a regression can't slip past either.
     monkeypatch.setattr("genesis.guardian.check._check_cycle", _tripwire)
     monkeypatch.setattr("genesis.guardian.check._drain_host_alert_queue", _tripwire)
-    _write_pause(tmp_path, expires_at=(datetime.now(UTC) + timedelta(minutes=10)).isoformat())
-    await run_check(_cfg(tmp_path))
-    assert calls == [True], "stand-down must write exactly one heartbeat"
+    cfg = _cfg(tmp_path)
+    if trigger == "gateway_pause":
+        _write_pause(tmp_path, expires_at=(datetime.now(UTC) + timedelta(minutes=10)).isoformat())
+    else:  # maintenance: create the (otherwise-absent) maintenance flag
+        Path(cfg.maintenance_file).write_text("")
+    await run_check(cfg)
+    assert calls == [True], f"{trigger} stand-down must write exactly one heartbeat"
     assert not (tmp_path / "state.json").exists(), "must still stand down"
 
 
@@ -213,6 +269,21 @@ def test_config_allowlist_honors_gateway_pause_cap(tmp_path: Path) -> None:
     cfg_yaml = tmp_path / "guardian.yaml"
     cfg_yaml.write_text("gateway_pause_max_ahead_s: 1200\n")
     assert load_config(cfg_yaml).gateway_pause_max_ahead_s == 1200
+
+
+def test_load_config_honors_state_dir_env(tmp_path: Path, monkeypatch) -> None:
+    """SF-6: the READER side of the env redirect. The gateway (writer) honors
+    GUARDIAN_STATE_DIR; load_config (the guardian's own config) must resolve the
+    SAME dir from that env, or writer and reader land on different paused.json
+    files and the stand-down silently never fires. Empty YAML so env is the only
+    source of state_dir; _finalize -> _env_override applies the override."""
+    cfg_yaml = tmp_path / "guardian.yaml"
+    cfg_yaml.write_text("")
+    custom = tmp_path / "reader-state"
+    monkeypatch.setenv("GUARDIAN_STATE_DIR", str(custom))
+    cfg = load_config(cfg_yaml)
+    assert cfg.state_dir == str(custom)
+    assert cfg.state_path == custom
 
 
 def test_gateway_honors_state_dir_env(tmp_path: Path) -> None:

--- a/tests/test_guardian/test_gateway_pause.py
+++ b/tests/test_guardian/test_gateway_pause.py
@@ -1,0 +1,207 @@
+"""Guardian honors an EXPIRING gateway pause file (deploy stand-down).
+
+The gateway `pause` verb writes `<state_dir>/paused.json` with an `expires_at`;
+`run_check` stands the whole cycle down while that pause is live and unexpired,
+so a planned deploy restart never escalates to confirmed_dead. The expiry is the
+built-in TTL: a deploy killed mid-run (EXIT-trap resume never fires) self-heals
+once `expires_at` passes, rather than leaving the Guardian blind forever.
+
+Distinct from the container `~/.genesis/paused.json` (the shared runtime kill
+switch) and from the indefinite `maintenance_file` — this is the host-side,
+bounded, gateway-driven stand-down.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from genesis.guardian.check import _gateway_pause_active, run_check
+from genesis.guardian.config import GuardianConfig
+
+_GATEWAY = Path(__file__).resolve().parents[2] / "scripts" / "guardian-gateway.sh"
+
+
+def _run_gateway(cmd: str, home: Path) -> subprocess.CompletedProcess:
+    env = {**os.environ, "HOME": str(home), "SSH_ORIGINAL_COMMAND": cmd}
+    return subprocess.run(
+        ["bash", str(_GATEWAY)], env=env, capture_output=True, text=True, timeout=30
+    )
+
+
+def _cfg(tmp_path: Path) -> GuardianConfig:
+    # state_dir drives config.state_path; the gateway writes paused.json there.
+    return GuardianConfig(state_dir=str(tmp_path))
+
+
+def _write_pause(
+    tmp_path: Path,
+    *,
+    expires_at: str | None,
+    paused: bool = True,
+    reason: str = "deploy",
+    since: str = "2026-08-31T00:00:00Z",
+) -> None:
+    data: dict = {"paused": paused, "reason": reason, "since": since}
+    if expires_at is not None:
+        data["expires_at"] = expires_at
+    (tmp_path / "paused.json").write_text(json.dumps(data))
+
+
+NOW = datetime(2026, 8, 31, 12, 0, 0, tzinfo=UTC)
+
+
+def test_no_file_not_active(tmp_path: Path) -> None:
+    assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is False
+
+
+def test_fresh_unexpired_is_active(tmp_path: Path) -> None:
+    _write_pause(tmp_path, expires_at=(NOW + timedelta(minutes=10)).isoformat())
+    assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is True
+
+
+def test_expired_not_active(tmp_path: Path) -> None:
+    # expires_at in the past -> the deploy pause self-healed; monitor normally.
+    _write_pause(tmp_path, expires_at=(NOW - timedelta(seconds=10)).isoformat())
+    assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is False
+
+
+def test_too_far_ahead_rejected_by_cap(tmp_path: Path) -> None:
+    # A pause whose expiry is absurdly far out is suspect (bad writer / clock) —
+    # ignore it rather than let the Guardian be muted for hours.
+    cfg = _cfg(tmp_path)
+    beyond = NOW + timedelta(seconds=cfg.gateway_pause_max_ahead_s + 60)
+    _write_pause(tmp_path, expires_at=beyond.isoformat())
+    assert _gateway_pause_active(cfg, now=NOW) is False
+
+
+def test_missing_expires_at_not_active(tmp_path: Path) -> None:
+    # No TTL -> fail safe toward monitoring; indefinite stand-down is the
+    # maintenance_file's job, not this file's.
+    _write_pause(tmp_path, expires_at=None)
+    assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is False
+
+
+def test_paused_false_not_active(tmp_path: Path) -> None:
+    _write_pause(tmp_path, expires_at=(NOW + timedelta(minutes=10)).isoformat(), paused=False)
+    assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is False
+
+
+def test_malformed_json_fails_safe(tmp_path: Path) -> None:
+    (tmp_path / "paused.json").write_text("{not valid json")
+    # Never crash the check cycle on a bad file; treat as not-paused.
+    assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is False
+
+
+def test_naive_expires_at_treated_as_utc(tmp_path: Path) -> None:
+    # A timestamp without tzinfo must not raise; interpret as UTC.
+    _write_pause(tmp_path, expires_at="2026-08-31T12:10:00")  # 10 min ahead of NOW
+    assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is True
+
+
+@pytest.mark.asyncio
+async def test_run_check_stands_down_when_pause_active(tmp_path: Path) -> None:
+    """Wiring: with a live gateway pause, run_check returns BEFORE it builds the
+    state machine, so no state.json is ever written (real side-effect, not a mock)."""
+    _write_pause(tmp_path, expires_at=(datetime.now(UTC) + timedelta(minutes=10)).isoformat())
+    await run_check(_cfg(tmp_path))
+    assert not (tmp_path / "state.json").exists(), "stand-down must skip the state machine"
+
+
+@pytest.mark.asyncio
+async def test_run_check_does_not_stand_down_when_expired(tmp_path: Path) -> None:
+    """Guard-the-guard: an EXPIRED pause must NOT stand the cycle down — otherwise
+    the stand-down test above could pass vacuously. run_check proceeds far enough
+    to create state.json (health probes fail against a dead endpoint, which is
+    fine — we only assert the cycle did NOT early-return)."""
+    _write_pause(tmp_path, expires_at=(datetime.now(UTC) - timedelta(minutes=10)).isoformat())
+    await run_check(_cfg(tmp_path))
+    assert (tmp_path / "state.json").exists(), "expired pause must not skip the cycle"
+
+
+# ── gateway verb round-trip: the writer + the reader must agree ──────────────
+
+
+def _gateway_state_dir(home: Path) -> Path:
+    return home / ".local" / "state" / "genesis-guardian"
+
+
+def test_gateway_pause_verb_writes_file_guardian_honors(tmp_path: Path) -> None:
+    """ACCEPTANCE: `pause <ttl>` writes a file the guardian's own reader accepts —
+    the whole point of the feature (writer and reader agree)."""
+    r = _run_gateway("pause 600", tmp_path)
+    assert r.returncode == 0, r.stderr
+    sd = _gateway_state_dir(tmp_path)
+    data = json.loads((sd / "paused.json").read_text())
+    assert data["paused"] is True
+    assert data["reason"] == "deploy"
+    assert "expires_at" in data and "since" in data
+    # The reader accepts exactly what the writer produced.
+    assert _gateway_pause_active(GuardianConfig(state_dir=str(sd))) is True
+
+
+def test_gateway_bare_pause_uses_default_ttl(tmp_path: Path) -> None:
+    r = _run_gateway("pause", tmp_path)
+    assert r.returncode == 0, r.stderr
+    data = json.loads((_gateway_state_dir(tmp_path) / "paused.json").read_text())
+    assert data.get("expires_at")
+
+
+def test_gateway_pause_rejects_non_integer_ttl(tmp_path: Path) -> None:
+    r = _run_gateway("pause abc", tmp_path)
+    assert r.returncode == 1
+    assert not (_gateway_state_dir(tmp_path) / "paused.json").exists()
+
+
+def test_gateway_pause_rejects_ttl_over_cap(tmp_path: Path) -> None:
+    r = _run_gateway("pause 99999", tmp_path)
+    assert r.returncode == 1
+    assert not (_gateway_state_dir(tmp_path) / "paused.json").exists()
+
+
+def test_gateway_resume_removes_pause_file(tmp_path: Path) -> None:
+    assert _run_gateway("pause 600", tmp_path).returncode == 0
+    assert (_gateway_state_dir(tmp_path) / "paused.json").exists()
+    r = _run_gateway("resume", tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert not (_gateway_state_dir(tmp_path) / "paused.json").exists()
+
+
+# ── regression guards (from the adversarial review) ─────────────────────────
+
+
+@pytest.mark.parametrize("body", ["123", "[1, 2]", '"a string"', "true", "null"])
+def test_non_object_json_fails_safe_no_crash(tmp_path: Path, body: str) -> None:
+    """SF-2: valid JSON that is not an object must NOT raise (AttributeError on
+    .get) — that would abort run_check, withhold the heartbeat, and read as DOWN."""
+    (tmp_path / "paused.json").write_text(body)
+    assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is False
+
+
+@pytest.mark.asyncio
+async def test_stand_down_still_writes_heartbeat(tmp_path: Path, monkeypatch) -> None:
+    """SF-3: a stand-down must still heartbeat (Guardian is alive, just not
+    watching) so the container watchdog doesn't read it as DOWN and restart it."""
+    calls: list[bool] = []
+
+    async def _spy(config) -> None:  # real path uses incus; unavailable in CI
+        calls.append(True)
+
+    monkeypatch.setattr("genesis.guardian.check._write_guardian_heartbeat", _spy)
+    _write_pause(tmp_path, expires_at=(datetime.now(UTC) + timedelta(minutes=10)).isoformat())
+    await run_check(_cfg(tmp_path))
+    assert calls == [True], "stand-down must write exactly one heartbeat"
+    assert not (tmp_path / "state.json").exists(), "must still stand down"
+
+
+def test_gateway_pause_leading_zero_ttl_is_base10(tmp_path: Path) -> None:
+    """NOTE-1: a leading-zero ttl must be read base-10 (not octal) — 0888 would
+    abort the arithmetic under set -e."""
+    r = _run_gateway("pause 0888", tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert (_gateway_state_dir(tmp_path) / "paused.json").exists()

--- a/tests/test_guardian/test_gateway_pause.py
+++ b/tests/test_guardian/test_gateway_pause.py
@@ -203,6 +203,18 @@ def test_gateway_pause_rejects_ttl_over_cap(tmp_path: Path) -> None:
     assert not (_gateway_state_dir(tmp_path) / "paused.json").exists()
 
 
+@pytest.mark.parametrize("overflow", ["18446744073709551617", "18446744073709555216"])
+def test_gateway_pause_rejects_overflow_ttl(tmp_path: Path, overflow: str) -> None:
+    """F6: a TTL beyond 64-bit must be rejected BEFORE `$((10#…))` wraps it into
+    the accepted range. Under fixed-width bash arithmetic `18446744073709551617`
+    wraps to 1 and `18446744073709555216` wraps to 3600 — both all-digit, both
+    passing the lexical guard, both silently accepted without the magnitude check.
+    The guard must reject them (rc 1, no file written)."""
+    r = _run_gateway(f"pause {overflow}", tmp_path)
+    assert r.returncode == 1, f"overflow ttl should be rejected: {r.stdout} {r.stderr}"
+    assert not (_gateway_state_dir(tmp_path) / "paused.json").exists()
+
+
 def test_gateway_resume_removes_pause_file(tmp_path: Path) -> None:
     assert _run_gateway("pause 600", tmp_path).returncode == 0
     assert (_gateway_state_dir(tmp_path) / "paused.json").exists()
@@ -234,10 +246,10 @@ async def test_stand_down_still_writes_heartbeat(tmp_path: Path, monkeypatch, tr
     tripwired, so a regression fails LOUDLY instead of running the real production
     cycle (incus snapshot prune / swap reconcile / live alerts) against the host.
     """
-    calls: list[bool] = []
+    calls: list[str | None] = []
 
-    async def _spy(config) -> None:  # real path uses incus; unavailable in CI
-        calls.append(True)
+    async def _spy(config, standdown=None) -> None:  # real path uses incus; CI-absent
+        calls.append(standdown)
 
     async def _tripwire(*a, **k):  # first heavy production calls after stand-down
         raise AssertionError("run_check reached the production cycle — stand-down failed")
@@ -251,8 +263,62 @@ async def test_stand_down_still_writes_heartbeat(tmp_path: Path, monkeypatch, tr
     else:  # maintenance: create the (otherwise-absent) maintenance flag
         Path(cfg.maintenance_file).write_text("")
     await run_check(cfg)
-    assert calls == [True], f"{trigger} stand-down must write exactly one heartbeat"
+    # Exactly one heartbeat, carrying the trigger's stand-down marker (F5) so
+    # probe_guardian reports DEGRADED, not HEALTHY, for the skipped cycle.
+    assert calls == [trigger], f"{trigger} stand-down must write one heartbeat marked '{trigger}'"
     assert not (tmp_path / "state.json").exists(), "must still stand down"
+
+
+def test_heartbeat_payload_marks_standdown() -> None:
+    """F5: the payload carries a `standdown` reason only when standing down; the
+    normal end-of-cycle heartbeat omits it (→ probe_guardian stays HEALTHY)."""
+    from genesis.guardian.check import _heartbeat_payload
+
+    assert _heartbeat_payload("gateway_pause")["standdown"] == "gateway_pause"
+    assert _heartbeat_payload("maintenance")["standdown"] == "maintenance"
+    assert "standdown" not in _heartbeat_payload()
+    assert "standdown" not in _heartbeat_payload(None)
+    # Always alive + timestamped regardless of stand-down.
+    assert _heartbeat_payload()["guardian_alive"] is True
+    assert "timestamp" in _heartbeat_payload("maintenance")
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_write_timeout_reaps_child(tmp_path: Path, monkeypatch) -> None:
+    """SF-5: when the incus heartbeat write times out, the child must be killed
+    AND reaped (proc.kill + awaited proc.wait) — else a wedged incus/container
+    orphans a process on every stand-down tick during a long pause. The function
+    must swallow the timeout (never raise into run_check, which would withhold the
+    heartbeat and read as DOWN)."""
+    from genesis.guardian import check as check_mod
+
+    class FakeProc:
+        def __init__(self) -> None:
+            self.killed = False
+            self.waited = False
+            self.returncode = None
+
+        async def communicate(self, input=None):  # noqa: A002 - matches asyncio API
+            raise TimeoutError  # simulate wait_for(communicate) timing out
+
+        def kill(self) -> None:
+            self.killed = True
+
+        async def wait(self) -> int:
+            self.waited = True
+            return 0
+
+    fake = FakeProc()
+
+    async def _fake_exec(*a, **k):
+        return fake
+
+    monkeypatch.setattr(check_mod.asyncio, "create_subprocess_exec", _fake_exec)
+
+    cfg = GuardianConfig(state_dir=str(tmp_path))
+    await check_mod._write_guardian_heartbeat(cfg)  # must NOT raise
+    assert fake.killed, "timed-out heartbeat child must be killed"
+    assert fake.waited, "killed child must be reaped (awaited), not left as a zombie"
 
 
 def test_gateway_pause_leading_zero_ttl_is_base10(tmp_path: Path) -> None:
@@ -284,6 +350,28 @@ def test_load_config_honors_state_dir_env(tmp_path: Path, monkeypatch) -> None:
     cfg = load_config(cfg_yaml)
     assert cfg.state_dir == str(custom)
     assert cfg.state_path == custom
+
+
+def test_load_config_warns_on_cap_below_caller_ttl(tmp_path: Path, caplog) -> None:
+    """F4: a gateway_pause_max_ahead_s below the 1800s default caller TTL silently
+    disables the deploy stand-down — the pause file is rejected as too-far-ahead,
+    so `pause` reports success while run_check keeps monitoring. load_config must
+    WARN on that misconfiguration; the default (3600) must stay silent."""
+    import logging
+
+    low_yaml = tmp_path / "low.yaml"
+    low_yaml.write_text("gateway_pause_max_ahead_s: 600\n")
+    with caplog.at_level(logging.WARNING, logger="genesis.guardian.config"):
+        cfg = load_config(low_yaml)
+    assert cfg.gateway_pause_max_ahead_s == 600  # value still applied (not clamped)
+    assert "below the 1800" in caplog.text
+
+    caplog.clear()
+    ok_yaml = tmp_path / "ok.yaml"
+    ok_yaml.write_text("gateway_pause_max_ahead_s: 3600\n")
+    with caplog.at_level(logging.WARNING, logger="genesis.guardian.config"):
+        load_config(ok_yaml)
+    assert "below the 1800" not in caplog.text
 
 
 def test_gateway_honors_state_dir_env(tmp_path: Path) -> None:

--- a/tests/test_guardian/test_gateway_pause.py
+++ b/tests/test_guardian/test_gateway_pause.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 
 from genesis.guardian.check import _gateway_pause_active, run_check
-from genesis.guardian.config import GuardianConfig
+from genesis.guardian.config import GuardianConfig, load_config
 
 _GATEWAY = Path(__file__).resolve().parents[2] / "scripts" / "guardian-gateway.sh"
 
@@ -104,24 +104,11 @@ def test_naive_expires_at_treated_as_utc(tmp_path: Path) -> None:
     assert _gateway_pause_active(_cfg(tmp_path), now=NOW) is True
 
 
-@pytest.mark.asyncio
-async def test_run_check_stands_down_when_pause_active(tmp_path: Path) -> None:
-    """Wiring: with a live gateway pause, run_check returns BEFORE it builds the
-    state machine, so no state.json is ever written (real side-effect, not a mock)."""
-    _write_pause(tmp_path, expires_at=(datetime.now(UTC) + timedelta(minutes=10)).isoformat())
-    await run_check(_cfg(tmp_path))
-    assert not (tmp_path / "state.json").exists(), "stand-down must skip the state machine"
-
-
-@pytest.mark.asyncio
-async def test_run_check_does_not_stand_down_when_expired(tmp_path: Path) -> None:
-    """Guard-the-guard: an EXPIRED pause must NOT stand the cycle down — otherwise
-    the stand-down test above could pass vacuously. run_check proceeds far enough
-    to create state.json (health probes fail against a dead endpoint, which is
-    fine — we only assert the cycle did NOT early-return)."""
-    _write_pause(tmp_path, expires_at=(datetime.now(UTC) - timedelta(minutes=10)).isoformat())
-    await run_check(_cfg(tmp_path))
-    assert (tmp_path / "state.json").exists(), "expired pause must not skip the cycle"
+# NOTE: run_check stand-down is tested via test_stand_down_still_writes_heartbeat
+# below (fully isolated: it tripwires _check_cycle so a regression can NEVER reach
+# the real production cycle — incus snapshot prune / swap reconcile / live alerts).
+# The "expired pause does not stand down" gate is covered by test_expired_not_active
+# at the unit level, without running run_check against the host.
 
 
 # ── gateway verb round-trip: the writer + the reader must agree ──────────────
@@ -186,13 +173,26 @@ def test_non_object_json_fails_safe_no_crash(tmp_path: Path, body: str) -> None:
 @pytest.mark.asyncio
 async def test_stand_down_still_writes_heartbeat(tmp_path: Path, monkeypatch) -> None:
     """SF-3: a stand-down must still heartbeat (Guardian is alive, just not
-    watching) so the container watchdog doesn't read it as DOWN and restart it."""
+    watching) so the container watchdog doesn't read it as DOWN and restart it.
+
+    Fully isolated (P1): the heartbeat is spied and _check_cycle is tripwired, so
+    if the stand-down ever regressed, the test fails LOUDLY instead of running the
+    real production cycle (incus snapshot prune / swap reconcile / live alerts)
+    against the host it happens to run on.
+    """
     calls: list[bool] = []
 
     async def _spy(config) -> None:  # real path uses incus; unavailable in CI
         calls.append(True)
 
+    async def _tripwire(*a, **k):  # first heavy production call after stand-down
+        raise AssertionError("run_check reached the production cycle — stand-down failed")
+
     monkeypatch.setattr("genesis.guardian.check._write_guardian_heartbeat", _spy)
+    # Tripwire the FIRST two production calls after the stand-down (the alert
+    # drain runs before _check_cycle), so a regression can't slip past either.
+    monkeypatch.setattr("genesis.guardian.check._check_cycle", _tripwire)
+    monkeypatch.setattr("genesis.guardian.check._drain_host_alert_queue", _tripwire)
     _write_pause(tmp_path, expires_at=(datetime.now(UTC) + timedelta(minutes=10)).isoformat())
     await run_check(_cfg(tmp_path))
     assert calls == [True], "stand-down must write exactly one heartbeat"
@@ -205,3 +205,27 @@ def test_gateway_pause_leading_zero_ttl_is_base10(tmp_path: Path) -> None:
     r = _run_gateway("pause 0888", tmp_path)
     assert r.returncode == 0, r.stderr
     assert (_gateway_state_dir(tmp_path) / "paused.json").exists()
+
+
+def test_config_allowlist_honors_gateway_pause_cap(tmp_path: Path) -> None:
+    """P2: a YAML-set gateway_pause_max_ahead_s must reach the config (be in the
+    load_config top-level allowlist), else the documented cap can't be tuned."""
+    cfg_yaml = tmp_path / "guardian.yaml"
+    cfg_yaml.write_text("gateway_pause_max_ahead_s: 1200\n")
+    assert load_config(cfg_yaml).gateway_pause_max_ahead_s == 1200
+
+
+def test_gateway_honors_state_dir_env(tmp_path: Path) -> None:
+    """P2: the gateway must write where the reader looks — GUARDIAN_STATE_DIR
+    redirects both (writer here, reader via GuardianConfig.state_dir)."""
+    custom = tmp_path / "custom-state"
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path),
+        "GUARDIAN_STATE_DIR": str(custom),
+        "SSH_ORIGINAL_COMMAND": "pause 300",
+    }
+    r = subprocess.run(["bash", str(_GATEWAY)], env=env, capture_output=True, text=True, timeout=30)
+    assert r.returncode == 0, r.stderr
+    assert (custom / "paused.json").exists()
+    assert _gateway_pause_active(GuardianConfig(state_dir=str(custom))) is True


### PR DESCRIPTION
## Problem

A `scripts/update.sh` deploy restarts genesis-server without standing the host-side Guardian down. The Guardian polls the container health endpoints, so during the ~4-min restart it escalates `confirming → surveying → confirmed_dead`, fires an alarming **critical + emergency + info** Telegram sequence, and spawns a **CC-powered diagnosis** — every deploy. (Verified live 2026-08-31: the guardian journal showed `State: confirmed_dead → healthy (auto-recovered)` at the restart window. The diagnosis correctly chose `ESCALATE`, not `RESTART_SERVICES`, so the real harm is alert noise + wasted diagnosis, not a restart race.)

## This PR — the capability half (guardian-only)

The Guardian now honors a **self-expiring** pause file that the gateway writes, beside the existing indefinite `maintenance_file` stand-down.

- **`guardian-gateway.sh`**: `pause [ttl]` writes `<state_dir>/paused.json` = `{paused, reason, since, expires_at}` with a bounded, validated TTL (1–3600s, base-10 to avoid octal). `resume` removes it.
- **`check.py::_gateway_pause_active`**: stands `run_check` down only while the pause is **unexpired** AND within `gateway_pause_max_ahead_s` (default 3600). Fail-safe toward monitoring on a missing / expired / malformed / **non-object** file. The `expires_at` TTL means a deploy killed before its `resume` self-heals rather than muting the watchdog forever.
- **Both stand-downs now still write the heartbeat** — the Guardian is ALIVE (just not watching), so the container watchdog (`watchdog.py`, 300s stale threshold) won't read it as DOWN and restart/alert the *mirror* of what we suppress.
- **`config.py`**: `gateway_pause_max_ahead_s` (safety cap).

Distinct from the container `~/.genesis/paused.json` (the shared runtime kill switch): this file is host-side, Guardian-only, and self-expiring.

## Scope — merging this alone changes no deploy behavior

By design (isolate the deploy-script change), the **`update.sh` caller** that invokes `gateway pause`/`resume` around the restart lands as a **separate follow-up PR**. This PR is the capability; until the caller ships, deploys behave exactly as today. Flagged by the architect review (SF-1) and intentional.

## Tests

22 new tests: gateway verb round-trip (writer + reader genuinely agree), the expiry/cap/timezone matrix, non-object-JSON fail-safe, heartbeat-on-stand-down (spy), and arg validation. 99 guardian tests green; ruff / subsystem-map / frozen-clock clean.

## Review

`genesis-architect` fresh-context adversarial audit ran; 3 findings applied in this PR — a non-object-JSON dict guard (was an `AttributeError` that aborted the cycle), heartbeat-on-stand-down (the container-watchdog mirror bug), and base-10 TTL parsing.

## Deploy

Host-deploy path (`guardian/`, `guardian-gateway.sh`): reaches the host via `scripts/update.sh` guardian-redeploy after merge.

Part of Ledger `05bb708ca22b488c96d04ea0918df82c` (completed by the update.sh caller PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-expiring gateway maintenance pauses lasting 1 second to 1 hour.
  * Guardian suspends checks during active pauses, continues heartbeats, and resumes automatically after expiration.
  * Added resume support and clear stand-down reasons for gateway and maintenance pauses.
  * Health monitoring now reports paused operation as degraded with relevant details.

* **Bug Fixes**
  * Improved validation safely rejects malformed, expired, or excessively long pause states.

* **Documentation**
  * Updated architecture documentation with gateway pause behavior and deployment considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->