### PR TITLE
fix(ci): subsystem-map staleness — one dead stamp no longer skips the whole check

### DIFF
--- a/scripts/check_subsystem_map.py
+++ b/scripts/check_subsystem_map.py
@@ -175,8 +175,21 @@ def check_staleness(entries: list[Entry], threshold: int) -> list[str] | None:
         return None
     warnings: list[str] = []
     for entry in entries:
-        if _git(["cat-file", "-e", f"{entry.verified_sha}^{{commit}}"]) is None:
-            return None  # stamped sha not in local history — can't count honestly
+        if _git(["merge-base", "--is-ancestor", entry.verified_sha, "HEAD"]) is None:
+            # Stamp is not an ancestor of HEAD (git merge-base --is-ancestor exits
+            # non-zero) — almost always a pre-squash feature-branch HEAD that squash-merge
+            # discarded. This is the ancestry check the stamp actually needs: a bare
+            # `cat-file -e` would PASS an orphan that still exists locally and then miscount
+            # `<sha>..HEAD`, so local and CI would disagree. Warn and keep policing the
+            # OTHER entries — a single dead stamp must NOT return None here, because that
+            # returns None for the WHOLE file, silently drops every entry's freshness
+            # check, and the caller then misreports it as a shallow clone.
+            warnings.append(
+                f"entry '{entry.name}': verified stamp {entry.verified_sha} "
+                f"({entry.verified_date}) is unresolvable (not an ancestor of HEAD) — "
+                f"likely a pre-squash orphan; re-verify and re-stamp to a default-branch commit"
+            )
+            continue
         paths = [f"src/genesis/{m}" for m in entry.modules]
         count_out = _git(["rev-list", "--count", f"{entry.verified_sha}..HEAD", "--", *paths])
         if count_out is None:
@@ -222,8 +235,9 @@ def main() -> int:
     stale = check_staleness(entries, STALE_COMMIT_THRESHOLD)
     if stale is None:
         print(
-            "subsystem-map guard: staleness check SKIPPED (shallow or incomplete git "
-            "history — CI needs fetch-depth: 0)"
+            "subsystem-map guard: staleness check SKIPPED (shallow clone, or a git "
+            "call failed/timed out). A full clone (fetch-depth: 0) fixes the shallow case; "
+            "an unresolvable stamp no longer skips the whole check (it warns per-entry)."
         )
     else:
         for warning in stale:

--- a/tests/test_scripts/test_check_subsystem_map.py
+++ b/tests/test_scripts/test_check_subsystem_map.py
@@ -204,7 +204,7 @@ def test_staleness_warns_past_threshold(monkeypatch):
     def fake_git(args: list[str]) -> str | None:
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:
             return "false"
-        if args[0] == "cat-file":
+        if args[0] == "merge-base":
             return ""
         if args[0] == "rev-list":
             return "999"
@@ -222,7 +222,7 @@ def test_staleness_quiet_under_threshold(monkeypatch):
     def fake_git(args: list[str]) -> str | None:
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:
             return "false"
-        if args[0] == "cat-file":
+        if args[0] == "merge-base":
             return ""
         if args[0] == "rev-list":
             return "3"
@@ -230,6 +230,37 @@ def test_staleness_quiet_under_threshold(monkeypatch):
 
     monkeypatch.setattr(csm, "_git", fake_git)
     assert csm.check_staleness(entries, threshold=20) == []
+
+
+def test_staleness_unresolvable_stamp_warns_and_keeps_checking(monkeypatch):
+    # One entry's stamp is unresolvable (a pre-squash orphan); the other is stale.
+    # The unresolvable stamp must NOT disable policing for the rest — it warns and
+    # continues, so the stale entry is still caught. (Regression: a single dead stamp
+    # used to `return None` and skip the whole staleness check for every entry.)
+    # Two entries with DISTINCT stamps so one can be singled out as unresolvable.
+    map_text = (
+        "# Genesis\n\n## Memory\n\n```yaml subsystem-map\n"
+        "entry: memory\nmodules: [memory]\nverified: aaaaaaaa 2026-07-07\n```\n\n"
+        "## Platform\n\n```yaml subsystem-map\n"
+        "entry: platform\nmodules: [db]\nverified: bbbbbbbb 2026-07-07\n```\n"
+    )
+    entries, _ = csm.parse_map(map_text)
+    bad = entries[0].verified_sha  # "aaaaaaaa" — distinct from entry[1]'s stamp
+
+    def fake_git(args: list[str]) -> str | None:
+        if args[:2] == ["rev-parse", "--is-shallow-repository"]:
+            return "false"
+        if args[0] == "merge-base":
+            return None if bad in args else ""  # sha is a distinct element of the git args
+        if args[0] == "rev-list":
+            return "999"
+        raise AssertionError(f"unexpected git call: {args}")
+
+    monkeypatch.setattr(csm, "_git", fake_git)
+    warnings = csm.check_staleness(entries, threshold=20)
+    assert warnings is not None
+    assert any("unresolvable" in w and bad in w for w in warnings)  # the orphan is surfaced
+    assert any(entries[1].name in w and "commits touched" in w for w in warnings)  # stale still caught
 
 
 def test_staleness_degrades_on_shallow_history(monkeypatch):
@@ -244,18 +275,24 @@ def test_staleness_degrades_on_shallow_history(monkeypatch):
     assert csm.check_staleness(entries, threshold=20) is None
 
 
-def test_staleness_degrades_on_unknown_sha(monkeypatch):
+def test_staleness_all_stamps_unresolvable_warns_never_blanket_none(monkeypatch):
+    # Every stamp unresolvable → one warning per entry, never a blanket None that
+    # would mask real staleness for the whole file. (A shallow clone is the only
+    # genuine None case — see test_staleness_degrades_on_shallow_history.)
     entries, _ = csm.parse_map(MAP_TWO_ENTRIES)
 
     def fake_git(args: list[str]) -> str | None:
         if args[:2] == ["rev-parse", "--is-shallow-repository"]:
             return "false"
-        if args[0] == "cat-file":
+        if args[0] == "merge-base":
             return None  # sha not present locally
         raise AssertionError(f"unexpected git call: {args}")
 
     monkeypatch.setattr(csm, "_git", fake_git)
-    assert csm.check_staleness(entries, threshold=20) is None
+    warnings = csm.check_staleness(entries, threshold=20)
+    assert warnings is not None
+    assert len(warnings) == 2
+    assert all("unresolvable" in w for w in warnings)
 
 
 # --- main (integration over a synthetic repo) ---


### PR DESCRIPTION
## Problem
`check_subsystem_map.py::check_staleness` did `return None` for the **whole file** on the first unresolvable `verified:` stamp — inside the per-entry loop. So a single dead stamp silently disabled the freshness check for **all 14 entries**, and the caller misreported it as a shallow clone ("CI needs fetch-depth: 0"). The dead stamps are **pre-squash feature-branch HEADs** that squash-merge discards, so they're permanently unresolvable in CI.

## Fix
- **Per-entry warn + continue** instead of `return None` — one dead stamp no longer disables policing for the other 13.
- **Detect by ANCESTRY, not existence:** `merge-base --is-ancestor <sha> HEAD`, not `cat-file -e`. A pre-squash orphan that still *exists locally* passes `cat-file` and then miscounts `<sha>..HEAD`, so local and CI disagreed. Ancestry is the invariant a stamp actually needs, and it's consistent local↔CI.
- **Broaden the SKIP diagnostic** — it now only fires on a genuine shallow clone or a git failure, not on a dead stamp.

Unchanged: the genuine shallow-repo skip and the fail-fast-on-`rev-list`-failure path. Warnings emit as `::warning::` (**exit 0 — CI stays green**).

## Real-data acceptance
The fixed guard surfaces **3 pre-squash orphans** (`0e65071c`, `ca875c4b`, `fbcf8ee4`) + **3 genuinely-stale** entries that were hidden. (The scheduled-review comment that surfaced this named only 2 orphans; the ancestry check found the 3rd.) Re-stamping those 6 is tracked as a follow-up (data-repair, per-entry re-verification).

## Tests
RED-first: the new mixed test + rewritten all-unresolvable test fail (`assert None is not None`) against the unfixed guard, pass after. 21/21 in the file green.

## Review
genesis-architect adversarial pass — CLEAN (Ready: Yes). All 3 NOTEs addressed: NOTE 2 (ancestry switch) applied, NOTE 1 (diagnostic wording) applied, NOTE 3 (follow-up filed).