### PR TITLE
fix(hooks): declare merge-to-main-override and full-suite-ok as sigils

### DIFF
--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -535,6 +535,21 @@ _KNOWN_SIGILS = (
     "stale-review-override",
     "scheduled-review-override",
     "discard-override",
+    # Both were passed to has_trailing_override from the day they shipped but never
+    # listed here, so the "kept in sync" claim above was false. The consequence is
+    # silent and asymmetric: the sigil queried FOR ITSELF still matches, so nothing
+    # looked broken, while an unlisted token written FIRST reads as prose and ends
+    # the leading run — disabling every sigil after it. NOTE this widens ACCEPTANCE
+    # as well as detection, in the fail-open direction, and the reach is wider than
+    # the merge gate; the PR that added them enumerates the combinations that flip.
+    # A test derives this set from the consumers themselves (an ast walk over
+    # scripts/, not just scripts/hooks/ — review_enforcement_commit.py lives
+    # outside that directory and is the only place two of the declared sigils are
+    # queried, and two guards pass their sigil as a module constant a literal scan
+    # cannot see), and asserts the set matches in BOTH directions, so neither a
+    # missing declaration nor an unwarranted one can ship unnoticed.
+    "merge-to-main-override",  # git_push_guard: local `git merge` onto main/master
+    "full-suite-ok",  # full_suite_guard: run the whole pytest suite locally
 )
 
 

--- a/tests/test_hooks/test_shell_parse.py
+++ b/tests/test_hooks/test_shell_parse.py
@@ -7,12 +7,15 @@ these lock in the wrapper/substitution/nesting cases two review passes found.
 
 from __future__ import annotations
 
+import ast
+import inspect
 import sys
 from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "hooks"))
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+sys.path.insert(0, str(_SCRIPTS / "hooks"))
 import shell_parse as sp  # noqa: E402
 
 NV = "--no" + "-verify"  # keep the literal out of this file's own text
@@ -739,3 +742,102 @@ def test_has_top_level_pipe_substitution_is_not_a_bg_pipe(cmd):
 )
 def test_has_top_level_pipe_real_pipe_around_substitution(cmd):
     assert sp.has_top_level_pipe(cmd) is True
+
+
+class TestSigilRunRegression:
+    """A sigil passed to has_trailing_override but absent from _KNOWN_SIGILS is
+    read as PROSE, so writing it FIRST silently ends the leading run and disables
+    every sigil after it. The sigil queried for ITSELF still matches, which is why
+    two such tokens shipped undetected."""
+
+    def test_an_unlisted_leading_sigil_no_longer_ends_the_run(self):
+        h = sp.has_trailing_override
+
+        assert h("git merge f  # merge-to-main-override audit-ack", "audit-ack")
+        assert h("git merge f  # audit-ack merge-to-main-override", "audit-ack")
+        assert h("git merge f  # merge-to-main-override", "merge-to-main-override")
+
+    def test_prose_still_ends_the_run(self):
+        h = sp.has_trailing_override
+
+        assert not h("git merge f  # see merge-to-main-override docs", "merge-to-main-override")
+
+    def test_every_sigil_any_guard_queries_is_declared(self):
+        """``_KNOWN_SIGILS`` claims to be kept in sync with the sigils actually
+        passed to has_trailing_override across the guards. Twice it was not, and
+        both times the consequence was silent.
+
+        Derived with ``ast`` over every CONSUMER, not a regex over one file. Two
+        guards pass their sigil as a module constant (``_OVERRIDE_SIGIL``,
+        ``_OVERRIDE``), so a literal-only scan cannot see them — which is how
+        ``full-suite-ok`` stayed undeclared while a regex test passed green.
+
+        The population is ``scripts/**.py``, NOT ``scripts/hooks/*.py``: a
+        hooks-only glob misses ``review_enforcement_commit.py``, where
+        ``audit-ack`` and ``depth-ack`` are queried — 2 of the declared sigils,
+        invisible to a scan that claimed to cover "every hook".
+        """
+        _DEFAULT_SIGIL = inspect.signature(sp._has_trailing_override).parameters["sigil"].default
+
+        queried: dict[str, str] = {}
+        for path in sorted(_SCRIPTS.rglob("*.py")):
+            tree = ast.parse(path.read_text())
+            consts = {}
+            for n in ast.walk(tree):
+                # Assign (`X = "s"`) AND AnnAssign (`X: str = "s"`) — a scan that
+                # handled only the first missed an annotated constant silently.
+                if isinstance(n, ast.Assign) and isinstance(n.value, ast.Constant):
+                    targets = [t for t in n.targets if isinstance(t, ast.Name)]
+                elif (
+                    isinstance(n, ast.AnnAssign)
+                    and isinstance(n.value, ast.Constant)
+                    and isinstance(n.target, ast.Name)
+                ):
+                    targets = [n.target]
+                else:
+                    continue
+                if isinstance(n.value.value, str):
+                    for t in targets:
+                        consts[t.id] = n.value.value
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                name = getattr(fn, "attr", None) or getattr(fn, "id", None)
+                if name not in ("has_trailing_override", "_has_trailing_override"):
+                    continue
+                arg = node.args[1] if len(node.args) > 1 else None
+                for kw in node.keywords:
+                    if kw.arg == "sigil":
+                        arg = kw.value
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    queried[arg.value] = path.name
+                elif isinstance(arg, ast.Name) and arg.id in consts:
+                    queried[consts[arg.id]] = path.name
+                elif arg is None:
+                    # A call with no sigil relies on the DEFAULT, which the walk
+                    # would otherwise never see — so a changed default could point
+                    # at an undeclared token from a call site invisible to this
+                    # test. Resolved from the live signature rather than restated
+                    # here, so the two cannot drift.
+                    queried[_DEFAULT_SIGIL] = path.name
+
+        # Guard the guard, against the CONSUMERS not a magic number: a floor of 5
+        # was satisfied by three files even when a fourth was silently dropped
+        # from the population, so it could not detect a lost consumer.
+        files = set(queried.values())
+        assert files >= {
+            "git_push_guard.py",
+            "git_discard_guard.py",
+            "full_suite_guard.py",
+            "review_enforcement_commit.py",
+        }, f"a known consumer produced no sigils — the walk went blind: {sorted(files)}"
+        undeclared = {s: f for s, f in queried.items() if s not in sp._KNOWN_SIGILS}
+        assert not undeclared, f"queried but not declared in _KNOWN_SIGILS: {undeclared}"
+        # The REVERSE direction, and it is the same defect class rather than an
+        # extra: an over-declared sigil no guard enforces widens acceptance for
+        # every OTHER sigil exactly as the two missing ones narrowed it, and a
+        # one-directional assertion ships it green. MEASURED: injecting an unqueried
+        # token into _KNOWN_SIGILS left all 146 tests in this file passing.
+        unqueried = sorted(set(sp._KNOWN_SIGILS) - set(queried))
+        assert not unqueried, f"declared in _KNOWN_SIGILS but no guard queries it: {unqueried}"


### PR DESCRIPTION
## What this changes

`merge-to-main-override` and `full-suite-ok` were passed to `has_trailing_override` from the day they shipped and never listed in `_KNOWN_SIGILS`, so that tuple's "kept in sync with the sigils actually passed across the guard hooks" claim was false.

The consequence is silent and asymmetric, which is why it survived: a sigil **queried for itself** matches before the membership test is reached, so nothing looked broken. But an undeclared token written **first** reads as prose, ends the leading run, and disables every sigil after it.

That broke a **documented** procedure, not a hypothetical one. The development skill instructs appending several sigils to one trailing comment when several waivers are genuinely intended — and any such comment led by one of these two silently lost the rest. The pre-fix behaviour failed **closed**: a waiver the operator typed was not honoured.

## This is a gate-loosening change

Stated plainly because it is riding as its own PR for exactly this reason — it was split out of a larger audit-logging PR so it gets its own merge decision.

Measured by exhaustive ordered-pair enumeration over the ten-token set, **eighteen** combinations flip from rejected to accepted, nine led by each new token. An earlier estimate of five was an undercount and is retracted.

Severity does not follow that count. Every one of the eighteen is a combination of two sigils that were **each already independently valid alone** — the change can never make one sigil satisfy a query for another. And nothing in the repo composes a multi-sigil comment programmatically (grepped): an operator types both, literally, or neither.

The sharpest single case, so it is not buried: `git clean -fdx  # full-suite-ok discard-override` now resolves `discard-override` where it previously did not.

## The test derives the set rather than restating it

Both previous divergences were invisible to the obvious check, so the test walks the consumers with `ast`:

- Population is `scripts/`, not `scripts/hooks/` — one consumer lives outside that directory and holds the only queries for two of the declared sigils.
- Two guards pass their sigil as a **module constant**, which a literal scan cannot see (this is how `full-suite-ok` stayed undeclared while a regex test passed green).
- One call site relies on the **default**, resolved from the live signature so the test and the function cannot drift.

The assertion runs in **both directions**. An adversarial pass showed the one-directional version green while an unqueried token sat in the tuple — over-declaration widens acceptance for every other sigil by exactly the mechanism these two additions repair, so it is the same defect reversed rather than a separate concern.

## Verification

- **Verify-RED ×3**: initial 2-fail/1-pass; the over-declaration mutation that previously passed 146/146 now fails; a mutated default sigil now fails and is attributed to the right file. Both mutations restored byte-identical, zero markers surviving.
- **306 passed** across the parser and every consumer suite the walk names.
- `ruff` clean. Private-data scan over the full diff: clean.
- **E2E acceptance replay** on the real hook: with `pytest tests/ # merge-to-main-override full-suite-ok`, the unfixed copy emits the BLOCKED message and the fixed copy allows it — while the no-sigil control still blocks, so the waiver is honoured without disabling the guard.

Adversarial security review found no CRITICAL. It did correct two things in the original diff — a comment that overstated the consumer count, and the flip-count estimate — both fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional acknowledgment tokens used by merge and full-suite checks.

* **Bug Fixes**
  * Improved recognition of override tokens regardless of their leading order.
  * Ensured ordinary prose correctly ends token scanning.

* **Tests**
  * Added regression coverage to validate supported tokens and their usage across guard checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->