### PR TITLE
fix(ego): dispatch follow-through polish — obs isolation, caption fidelity, TTL on parse-fail

### DIFF
--- a/src/genesis/db/crud/ego_intentions.py
+++ b/src/genesis/db/crud/ego_intentions.py
@@ -35,7 +35,8 @@ async def create(
     ``origin='system'`` rows (mechanical dispatch follow-through) bypass the
     cap — it exists to stop the LLM hoarding slots, not to drop follow-through.
     ``proposal_id`` at creation is the system row's source dispatch proposal
-    (dedup key); ``fire()`` later overwrites it with the fired proposal.
+    (dedup key); ``fire()`` COALESCE-preserves it — a fire without a new
+    proposal_id keeps this creation-time value rather than nulling it.
     """
     if origin not in ("ego", "system"):
         origin = "ego"

--- a/src/genesis/ego/dispatch_followthrough.py
+++ b/src/genesis/ego/dispatch_followthrough.py
@@ -22,6 +22,14 @@ from genesis.db.crud import ego_intentions
 
 logger = logging.getLogger(__name__)
 
+# A proposal with NULL ego_source routes its follow-through to the GENESIS ego,
+# by the locked B2b design decision — deliberately NOT the user ego. This is an
+# ONGOING branch, not a legacy artifact: ego_source is a bare
+# `ALTER TABLE ego_proposals ADD COLUMN ego_source TEXT` (db/schema/_migrations.py,
+# no DEFAULT, no backfill), so proposals created without it are NULL by design
+# (see tests/ego/test_realist.py::test_ego_source_null_by_default). Routing this
+# operational bookkeeping onto the user ego's board would be a behavior change,
+# not a fix.
 _FALLBACK_EGO_SOURCE = "genesis_ego_cycle"
 
 _TRIGGER = "Next ego cycle — review this dispatch outcome and decide follow-through."
@@ -90,9 +98,16 @@ async def record_dispatch_followthrough(
     # status + the ego's own (first-party) proposal summary anchor the review;
     # the ego reads the full outcome via the execution_outcome observation + the
     # recallable dispatch memory.
+    # Status is authoritative EXCEPT the one misleading case: a session that
+    # reported "completed" but whose deliverables failed post-dispatch
+    # verification (failed=True + status="completed") — a bare [completed] would
+    # misreport it. Only override THAT case; keep every genuine terminal status
+    # (timeout/error/cancelled) intact, since the reviewing ego uses the specific
+    # outcome to choose step-2 vs retry vs close.
+    _state = "failed" if (failed and (status or "").lower() == "completed") else status
     content = (
         f"Review dispatch outcome for proposal {proposal_id[:8]} "
-        f"[{status}]: {prop_summary}"
+        f"[{_state}]: {prop_summary}"
         ". Decide follow-through: step-2, retry, or close."
     )
     if outcome:

--- a/src/genesis/ego/session.py
+++ b/src/genesis/ego/session.py
@@ -1223,6 +1223,11 @@ class EgoSession:
                 "Ego output could not be parsed — cycle %s stored with no proposals",
                 cycle.id,
             )
+            # Age intentions on a parse-failure cycle too: expiry and the
+            # implicit-keep sweep must run EVERY cycle so max_cycles is a
+            # mechanical TTL, not one dependent on the LLM emitting parseable
+            # output. (The parsed path runs this at step 10d above.)
+            await self._process_intentions({})
 
         logger.info(
             "Ego cycle %s completed (cost=$%.4f, proposals=%d, tokens=%d+%d)",

--- a/src/genesis/runtime/init/ego.py
+++ b/src/genesis/runtime/init/ego.py
@@ -303,24 +303,37 @@ async def init(rt: GenesisRuntime) -> None:
                         _meta = {}
                     caller_ctx = _meta.get("caller_context", "")
 
-                    await obs_crud.create(
-                        rt._db,
-                        id=str(uuid.uuid4()),
-                        source="ego_dispatch",
-                        type="execution_outcome",
-                        content=(
-                            f"Ego dispatch session {session_id[:8]} "
-                            f"completed: status={status}, cost=${cost:.4f}. "
-                            f"Context: {caller_ctx}"
-                        ),
-                        priority="medium",
-                        category="ego_dispatch",
-                        created_at=datetime.now(UTC).isoformat(),
-                    )
-                    logger.info(
-                        "Recorded ego dispatch outcome for session %s",
-                        session_id[:8],
-                    )
+                    # Own try/except: this observation is telemetry. A write
+                    # failure here must NOT skip the follow-through block below
+                    # (the "every terminal dispatch gets one forced review"
+                    # guarantee) — previously a bare create() inside the outer try
+                    # jumped straight to the outer except on failure.
+                    try:
+                        await obs_crud.create(
+                            rt._db,
+                            id=str(uuid.uuid4()),
+                            source="ego_dispatch",
+                            type="execution_outcome",
+                            content=(
+                                f"Ego dispatch session {session_id[:8]} "
+                                f"completed: status={status}, cost=${cost:.4f}. "
+                                f"Context: {caller_ctx}"
+                            ),
+                            priority="medium",
+                            category="ego_dispatch",
+                            created_at=datetime.now(UTC).isoformat(),
+                        )
+                        logger.info(
+                            "Recorded ego dispatch outcome for session %s",
+                            session_id[:8],
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to write ego dispatch execution_outcome "
+                            "observation for %s — continuing to follow-through",
+                            session_id[:8],
+                            exc_info=True,
+                        )
 
                     # Write goal progress if proposal is linked to a goal
                     if "ego_proposal:" in caller_ctx:

--- a/tests/ego/test_dispatch_followthrough.py
+++ b/tests/ego/test_dispatch_followthrough.py
@@ -217,6 +217,33 @@ class TestRecordDispatchFollowthrough:
         assert row["priority"] == "high"
 
     @pytest.mark.asyncio
+    async def test_caption_renders_derived_failed_not_raw_status(self, db):
+        """A verification-failed-but-session-completed dispatch must render the
+        DERIVED [failed] in the review caption, not the misleading raw
+        [completed] (#1496 P2 dispatch_followthrough.py:95)."""
+        from genesis.db.crud import ego_intentions
+        from genesis.ego.dispatch_followthrough import record_dispatch_followthrough
+
+        await db.execute(
+            """INSERT INTO ego_proposals
+               (id, action_type, content, status, created_at, ego_source)
+               VALUES (?, 'implement', 'Ship X', 'failed', ?, 'genesis_ego_cycle')""",
+            (PROPOSAL_ID, datetime.now(UTC).isoformat()),
+        )
+        await db.commit()
+        await record_dispatch_followthrough(
+            db,
+            proposal_id=PROPOSAL_ID,
+            session_id="sess1234abcd",
+            status="completed",  # session completed, but proposal verification-failed
+            outcome="",
+            failed=False,
+        )
+        row = (await ego_intentions.list_active(db, "genesis_ego_cycle"))[0]
+        assert "[failed]" in row["content"], row["content"]
+        assert "[completed]" not in row["content"], row["content"]
+
+    @pytest.mark.asyncio
     async def test_parked_dispatch_skips_followthrough(self, db):
         """A rate/quota-parked dispatch is NOT terminal — no follow-through now;
         the resumed session's on_end fires the real one (Codex #1496 P2)."""

--- a/tests/ego/test_session.py
+++ b/tests/ego/test_session.py
@@ -1533,3 +1533,20 @@ class TestReconcilePrompt:
         p = _build_reconcile_prompt([_draft()], board, {}, ego_source="user_ego_cycle")
         board_line = next(ln for ln in p.splitlines() if "NO_REVAL" in ln)
         assert "⚠due" not in board_line
+
+
+@pytest.mark.asyncio
+async def test_parse_failure_still_ages_intentions(ego_session, monkeypatch):
+    """On a parse-failure cycle the intention aging sweep must STILL run, so
+    max_cycles stays a mechanical TTL rather than one dependent on the LLM
+    emitting parseable output (#1496 CodeRabbit). Pins the else-branch wiring."""
+    from unittest.mock import AsyncMock as _AM
+
+    from genesis.cc.types import CCModel
+
+    spy = _AM()
+    monkeypatch.setattr(ego_session, "_process_intentions", spy)
+    # unparseable text -> _parse_output returns None -> the else branch
+    output = _cc_output(text="this is definitely not json")
+    await ego_session._process_cycle_output(output, CCModel.SONNET, None)
+    spy.assert_awaited_once_with({})


### PR DESCRIPTION
Five #1496 follow-through review-polish fixes (all verified OPEN against merged main before fixing; two sibling findings already handled in main — verification-propagation and provenance-by-exclusion — are left untouched).

## Fixes

1. **Observation-failure isolation** (`runtime/init/ego.py`) — the `execution_outcome` observation write in `_ego_dispatch_on_end` was bare inside the outer try, so a telemetry-write failure jumped to the outer `except` and **skipped the follow-through creation** below it. Wrapped in its own `try/except` (logs, continues), restoring the "every terminal dispatch gets one forced review" guarantee.

2. **Caption fidelity** (`ego/dispatch_followthrough.py`) — the review caption interpolated the raw session status, so a `completed` session whose deliverables failed post-dispatch verification read `[completed]`. Now renders `[failed]` **only** for that misleading case; `timeout`/`error`/`cancelled` keep their specific status (the reviewing ego uses it to choose step-2 vs retry vs close).

3. **Aging sweep on parse failure** (`ego/session.py`) — `_process_intentions` ran only inside `if parsed:`, so a parse-failure cycle skipped it; `max_cycles` wasn't a mechanical TTL on those cycles. Added the sweep to the `else` branch.

4. **NULL `ego_source` rationale** (`ego/dispatch_followthrough.py`) — documented the locked NULL→genesis-ego fallback as an ongoing by-design default (`ego_source` is a bare `ADD COLUMN`, no backfill; NULL is the live default), not a legacy artifact.

5. **Docstring** (`db/crud/ego_intentions.py`) — `create`'s docstring said `fire()` "overwrites" `proposal_id`; it actually `COALESCE`-preserves it. Corrected.

## Verification

Tests: caption-derives-failed; a parse-failure-still-ages-intentions wiring test (observed RED→GREEN). Suites green: follow-through 10, session 96, intentions 35. ruff clean. Adversarial genesis-architect review: 2 SHOULD-FIX (caption over-correction narrowed; rationale-comment facts corrected — both independently verified against the migrations) + the Fix-5 wiring test, all applied.

## Deploy

Runtime code — `git pull` + server restart. No migration. No CURRENT.md change (implementation polish, not a subsystem-map capability change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Follow-through updates now accurately report when deliverable verification fails.
  * Processing continues when outcome observations cannot be saved, preventing unrelated progress updates from being blocked.
  * Intention aging and expiry now continue even when cycle output cannot be parsed.
  * Proposals without a specified source are routed to the Genesis ego.
* **Documentation**
  * Clarified proposal ID behavior when firing existing intentions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->