### PR TITLE
fix(dashboard): ego modal surfaces a stale/failed refresh and an in-flight cue

### DIFF
--- a/src/genesis/dashboard/templates/partials/modals/ego.html
+++ b/src/genesis/dashboard/templates/partials/modals/ego.html
@@ -44,10 +44,13 @@
              so the 'loading' spinner below (gated on !egoStatus) stays hidden. Cover
              BOTH so a slow live fetch over shown data isn't invisible — the header
              dot shows last-known health, not refresh progress. Restores the progress
-             cue the semantic-verdict header replaced. aria-live announces it. -->
-        <div x-show="$store.genesisDashboard.egoModal.fetch.state === 'refreshing' || ($store.genesisDashboard.egoModal.fetch.state === 'loading' && $store.genesisDashboard.egoStatus)"
-             aria-live="polite"
-             style="text-align: right; font-size: 0.72rem; color: var(--color-text-secondary); margin-bottom: 0.5rem;">↻ Refreshing…</div>
+             cue the semantic-verdict header replaced. The aria-live region is
+             PERMANENT and its TEXT toggles (empty when idle → no visual footprint):
+             a live region must stay in the DOM to announce a change; toggling the
+             node's display via x-show would not announce reliably. -->
+        <div aria-live="polite"
+             x-text="($store.genesisDashboard.egoModal.fetch.state === 'refreshing' || ($store.genesisDashboard.egoModal.fetch.state === 'loading' && $store.genesisDashboard.egoStatus)) ? '↻ Refreshing…' : ''"
+             style="text-align: right; font-size: 0.72rem; color: var(--color-text-secondary);"></div>
         <!-- Loading -->
         <div x-show="$store.genesisDashboard.egoModal.fetch.state === 'loading' && !$store.genesisDashboard.egoStatus"
              style="text-align: center; padding: 2rem; color: var(--color-text-secondary);">Loading...</div>

--- a/src/genesis/dashboard/templates/partials/modals/ego.html
+++ b/src/genesis/dashboard/templates/partials/modals/ego.html
@@ -29,12 +29,25 @@
              the modal's own fetch fails AFTER egoStatus is already populated (the
              normal path — the overview card loads it before the modal opens), the
              body error placeholder below is suppressed by its !egoStatus guard, so
-             the refresh failure would otherwise be invisible. Surface it here. -->
-        <template x-if="$store.genesisDashboard.egoModal.fetch.state === 'error' && $store.genesisDashboard.egoStatus">
+             the refresh failure would otherwise be invisible. Surface it here.
+             A refresh failure AFTER a prior success sets fetch.state='stale' (only a
+             first-ever load failure is 'error'), so match BOTH — checking only
+             'error' let the common stale case slip through silently. -->
+        <template x-if="($store.genesisDashboard.egoModal.fetch.state === 'error' || $store.genesisDashboard.egoModal.fetch.state === 'stale') && $store.genesisDashboard.egoStatus">
           <div class="inline-warning" style="margin-bottom: 0.75rem;">
             ⚠ Live refresh failed — showing last known state.
           </div>
         </template>
+        <!-- In-flight cue over already-visible data: a re-open sets
+             fetch.state='refreshing' (a load with a prior success); a first open
+             sets 'loading' but egoStatus is already populated by the overview card,
+             so the 'loading' spinner below (gated on !egoStatus) stays hidden. Cover
+             BOTH so a slow live fetch over shown data isn't invisible — the header
+             dot shows last-known health, not refresh progress. Restores the progress
+             cue the semantic-verdict header replaced. aria-live announces it. -->
+        <div x-show="$store.genesisDashboard.egoModal.fetch.state === 'refreshing' || ($store.genesisDashboard.egoModal.fetch.state === 'loading' && $store.genesisDashboard.egoStatus)"
+             aria-live="polite"
+             style="text-align: right; font-size: 0.72rem; color: var(--color-text-secondary); margin-bottom: 0.5rem;">↻ Refreshing…</div>
         <!-- Loading -->
         <div x-show="$store.genesisDashboard.egoModal.fetch.state === 'loading' && !$store.genesisDashboard.egoStatus"
              style="text-align: center; padding: 2rem; color: var(--color-text-secondary);">Loading...</div>


### PR DESCRIPTION
Two #1500 follow-up fixes to the ego dashboard modal (`partials/modals/ego.html`), reusing existing store state (no new store member).

The modal header shows last-known health (`egoSemantic()`), not whether THIS open's live refresh succeeded — so a refresh failure or a slow refresh over already-shown data was invisible.

## Fixes

1. **Stale-refresh warning** — the "Live refresh failed" warning fired only on `fetch.state === 'error'`. But the fetch-state machine (`dashboard.js:3522`) sets `state = lastSuccess ? "stale" : "error"` on failure, so a refresh failure **after** a prior success is `'stale'` — the common case, which the old guard never caught. Broadened to `('error' || 'stale') && egoStatus`.

2. **In-flight cue** — added `↻ Refreshing…` for a fetch over already-visible data: `state === 'refreshing'` (re-open) or `'loading' && egoStatus` (first open — the overview card populates `egoStatus` before the modal opens, so the first-load spinner, gated on `!egoStatus`, stays hidden). `aria-live="polite"` announces it.

## Verification

State-machine mapping verified against `dashboard.js` (`startModalFetch`/`finishModalFetch`/`failModalFetch`, L3553-3573): full vocabulary `idle/loading/refreshing/healthy/stale/error`. Adversarial genesis-architect review walked all six states through every template branch — no state renders a conflicting or double UI; Ready to merge: Yes. JS-integrity guard green (11).

A browser E2E is owed post-deploy: open the modal twice (confirm `↻` on re-open), and force a refresh failure after a prior success (confirm the stale warning fires).

## Deploy

Template change — takes effect on `git pull` + server restart (no migration).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warnings when ego data cannot load initially or becomes stale during refresh.
  * Added accessible status announcements while data refreshes, keeping previously loaded data visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->