### PR TITLE
fix(hooks): superseded by #1580

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **Captured session output no longer persists API keys in plaintext.** When an
+  interactive session exits, Genesis records a tail of the terminal scrollback to
+  `~/.genesis/logs/cc_exit_<slot>.log` so a crash can be diagnosed afterwards.
+  That tail is raw terminal output, so anything the session printed — including a
+  credential a CLI echoed to the screen — was written verbatim. The tail is now
+  scrubbed before it is stored, and if the scrubber cannot run the tail is
+  withheld entirely rather than written raw; the exit status and crash diagnosis
+  are always recorded either way.
+- **Credential detection now recognises modern key formats.** The shared
+  secret-detection patterns required an unbroken run of letters and digits after a
+  vendor prefix, so any key that namespaces itself with internal separators —
+  which most current formats do — stopped matching a few characters in and were
+  treated as ordinary text, so they were never redacted from captured telemetry.
+  Redaction now handles them, along with several provider prefixes, JWTs, webhook
+  URLs and bot tokens that had no coverage at all. Coverage is by shape, so it is
+  not complete: keys that are a bare run of letters and digits with no vendor
+  prefix stay indistinguishable from an ordinary hash and are still only caught
+  in their labelled or ``KEY=VALUE`` forms. The reference-capture path keeps a
+  deliberately narrower rule, so that an ordinary hyphenated name is never stored
+  as though it were a credential.
+- **Secret scrubbing no longer stalls on long machine output.** Two detection
+  patterns backtracked quadratically against a long unbroken alphanumeric run
+  (a base64 blob or a minified bundle in captured output), taking tens of seconds
+  on input a session produces routinely. The repeats with real-world ceilings are
+  now bounded, which removes the stall while leaving long secret *values* fully
+  covered.
+
 ### Added
 
 - **Gated autonomous cold marketing outreach (inert by default).** Genesis can

--- a/scripts/cc_exit_capture.sh
+++ b/scripts/cc_exit_capture.sh
@@ -32,6 +32,27 @@ if [ -z "${HOME:-}" ]; then
 fi
 [ -n "${HOME:-}" ] || exit 0
 
+# Scrub filter for the pane tail. secret_scrub is stdlib-only by design, so ANY
+# python3 can run it — deliberately NOT the venv interpreter, which may be
+# absent or broken on the path a dying session takes. Resolved relative to this
+# script so a worktree checkout scrubs with its own copy.
+#
+# Returns non-zero (emitting nothing) when it cannot scrub, which the caller
+# turns into a withheld-tail marker. It must NEVER pass input through on error.
+_CC_HOOKS_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/hooks"
+
+_cc_scrub_stdin() {
+    [ -r "${_CC_HOOKS_DIR}/secret_scrub.py" ] || return 1
+    command -v python3 >/dev/null 2>&1 || return 1
+    # Read BYTES and decode leniently: the tail exists to capture a CRASHING
+    # session, which is exactly the kind that emits a stray non-UTF-8 byte, and
+    # a strict decode would discard the entire diagnostic over one of them.
+    python3 -c 'import sys
+sys.path.insert(0, sys.argv[1])
+from secret_scrub import scrub
+sys.stdout.write(scrub(sys.stdin.buffer.read().decode("utf-8", "replace")))' "$_CC_HOOKS_DIR"
+}
+
 log_dir="${HOME}/.genesis/logs"
 log="${log_dir}/cc_exit_${slot}.log"
 mkdir -p "$log_dir" 2>/dev/null || exit 0
@@ -54,7 +75,27 @@ mkdir -p "$log_dir" 2>/dev/null || exit 0
     # Guarded on TMUX_PANE so the script is harmless when run outside tmux.
     if [ -n "${TMUX_PANE:-}" ] && command -v tmux >/dev/null 2>&1; then
         echo "  --- pane tail (last 200 lines) ---"
-        tmux capture-pane -p -t "$TMUX_PANE" -S -200 2>/dev/null | sed 's/^/  | /'
+        # The tail is RAW terminal output: whatever the session printed, a
+        # freshly-minted credential included. Scrub it through the same
+        # stdlib-only helper the capture hooks use (no venv needed — it imports
+        # nothing outside the standard library, so a broken venv cannot break
+        # this path). FAIL CLOSED: if the scrubber cannot run, WITHHOLD the tail
+        # rather than write it raw. secret_scrub.scrub() already withholds its
+        # own content on an internal error; this mirrors that choice one level
+        # up, for the case where python itself is unavailable. The exit-status
+        # lines above are always written either way, so the primary diagnostic
+        # (why did the session die) survives even with no tail at all.
+        if _tail=$(tmux capture-pane -p -t "$TMUX_PANE" -S -200 2>/dev/null) \
+           && [ -n "$_tail" ]; then
+            # Deliberately if/else, not `A && B || C`: in the chain form a
+            # failure in the PRINT step (disk full, SIGPIPE) also fires C and
+            # appends a "withheld" marker after a half-written tail.
+            if _scrubbed=$(printf '%s\n' "$_tail" | _cc_scrub_stdin 2>/dev/null); then
+                printf '%s\n' "$_scrubbed" | sed 's/^/  | /'
+            else
+                echo "  | [tail withheld: scrubber unavailable]"
+            fi
+        fi
     fi
     echo
 } >> "$log" 2>/dev/null || exit 0

--- a/scripts/hooks/secret_scrub.py
+++ b/scripts/hooks/secret_scrub.py
@@ -36,20 +36,69 @@ import re
 
 _REDACTED = "[REDACTED]"
 
-# ── Detection patterns (mirror of reference_extraction.py) ───────────────────
+# ── Detection patterns ───────────────────────────────────────────────────────
+#
+# THREE files carry credential-detection patterns, and they are NOT all the
+# same by design. Enumerated, with what each does on a match:
+#   * this file                              — REDACTS captured telemetry
+#   * ``src/genesis/security/output_scanner.py``  — FLAGS outbound content
+#   * ``src/genesis/memory/reference_extraction.py`` — WRITES a stored reference
+# The first two favour recall: over-matching costs a redaction or a flag. The
+# third acts on a match by creating a record the user sees, so it favours
+# precision and deliberately keeps a NARROWER class (its own comment explains
+# the split). Duplicated rather than imported so this hook stays stdlib-only.
+# Change a shape here, decide explicitly for the other two — do not paste.
+#
+# The STRUCTURED class is redaction-only and has no twin: it exists because a
+# captured terminal stream carries credentials with no label and no vendor
+# prefix, which is not a shape the capture-side classifier needs to recognise.
 
 # Known key prefixes — format-only, near-certain real credentials. The whole
 # match is the secret, so it is redacted wholesale.
+# The character class after a prefix MUST admit ``-`` and ``_``: modern keys
+# namespace themselves with interior separators (``sk-ant-…``, ``sk-or-v1-…``,
+# ``sk-proj-…``), so an [A-Za-z0-9]-only class stops at the first hyphen — only
+# a few characters in — and never reaches the length floor. The token then
+# passes through whole. Prefixes are anchored on the left (?<![A-Za-z0-9_-]) so
+# a longer surrounding word cannot part-match into one.
 _KNOWN_KEY_PREFIX_PATTERN = re.compile(
-    r"(?:"
-    r"ghp_[A-Za-z0-9]{30,}"  # GitHub personal access token
-    r"|gho_[A-Za-z0-9]{30,}"  # GitHub OAuth token
-    r"|sk-[A-Za-z0-9]{20,}"  # OpenAI / Anthropic
+    r"(?<![A-Za-z0-9_-])(?:"
+    r"gh[pousr]_[A-Za-z0-9]{30,}"  # GitHub PAT / OAuth / user / server / refresh
+    r"|github_pat_[A-Za-z0-9_]{30,}"  # GitHub fine-grained PAT
+    r"|glpat-[A-Za-z0-9_\-]{15,}"  # GitLab PAT
+    r"|sk-[A-Za-z0-9_\-]{20,}"  # OpenAI / Anthropic / OpenRouter / compatible
+    r"|gsk_[A-Za-z0-9]{20,}"  # Groq
+    r"|nvapi-[A-Za-z0-9_\-]{20,}"  # NVIDIA NIM
+    r"|tvly-[A-Za-z0-9_\-]{20,}"  # Tavily
+    r"|fc-[A-Za-z0-9]{24,}"  # Firecrawl (longer floor: short prefix)
+    r"|hf_[A-Za-z0-9]{20,}"  # HuggingFace
+    r"|xai-[A-Za-z0-9]{20,}"  # xAI
     r"|xoxb-[A-Za-z0-9\-]{20,}"  # Slack bot token
     r"|xoxp-[A-Za-z0-9\-]{20,}"  # Slack user token
     r"|AKIA[A-Z0-9]{12,}"  # AWS access key id
     r"|AIza[A-Za-z0-9_\-]{30,}"  # Google API key
     r"|di-[A-Za-z0-9]{20,}"  # DeepInfra
+    r"|eyJ[A-Za-z0-9_\-]{8,}\.eyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}"  # JWT
+    r")",
+)
+
+# Structured credentials — identified by SHAPE, not by a vendor prefix. Both
+# carry their secret as a positional path/field component, so no label pattern
+# ever sees them and no prefix class can match them.
+_STRUCTURED_CREDENTIAL_PATTERN = re.compile(
+    r"(?:"
+    # Discord webhook: the trailing path segment IS the credential.
+    r"https://(?:canary\.|ptb\.)?discord(?:app)?\.com/api/(?:v\d+/)?webhooks/"
+    r"\d{15,}/[A-Za-z0-9_\-]{40,}"
+    # Telegram bot token: <bot-id>:<secret>. The anchor rejects only a preceding
+    # DIGIT — enough to stop a match starting mid-way through a longer digit
+    # run, which is all it needs to do. It must NOT reject a preceding letter:
+    # the form Genesis itself builds is ``…/bot<id>:<secret>``, where the id is
+    # preceded by "bot", and a word-boundary-style anchor silently passes the
+    # whole token through. The floor is set from the vendor's DOCUMENTED
+    # example (34 chars), not from one locally observed token, so a shorter
+    # legitimate token cannot slip under it.
+    r"|(?<!\d)\d{6,}:[A-Za-z0-9_\-]{30,}"
     r")",
 )
 
@@ -81,8 +130,15 @@ _SINGLE_CREDENTIAL_PATTERN = re.compile(
 # Credentials embedded in a URL's userinfo section (the user/password pair that
 # can precede an "@" host separator). Only fires when an "@" follows, so a plain
 # host-and-port URL never matches.
+# The SCHEME and HOST repeats are bounded; the PASSWORD repeat deliberately is
+# not. A greedy unbounded repeat followed by a required literal backtracks
+# quadratically over a long unbroken run — ordinary machine output (base64
+# blobs, minified bundles) hits this, and the scrubber runs on captured tool
+# output. Bounding only the parts with real-world ceilings (RFC 1035 caps a
+# hostname at 253 chars; a URL scheme is a handful) removes the blowup WITHOUT
+# introducing a fail-open: a long password still matches and is still redacted.
 _URL_CREDENTIAL_PATTERN = re.compile(
-    r"(?P<pre>[a-zA-Z][a-zA-Z0-9+.\-]*://[^:/@\s]+:)(?P<pw>[^@/\s]+)(?P<at>@)",
+    r"(?P<pre>[a-zA-Z][a-zA-Z0-9+.\-]{0,32}://[^:/@\s]{1,253}:)(?P<pw>[^@/\s]+)(?P<at>@)",
 )
 
 # .env-style UPPER_SNAKE=value. The bare pattern over-redacts (PYTHONPATH=…,
@@ -90,8 +146,11 @@ _URL_CREDENTIAL_PATTERN = re.compile(
 # is captured whole (so a multi-word secret like KEY='a b c' is not left with
 # its tail exposed after the first space); an unquoted value is a 6+ run of
 # non-space so short non-secret values aren't touched.
+# The KEY repeat is bounded for the same reason as the URL host above (see that
+# comment): an environment-variable NAME has a small real ceiling, while the
+# VALUE repeat stays unbounded so no long secret escapes redaction.
 _ENV_ASSIGNMENT_PATTERN = re.compile(
-    r"(?P<key>[A-Z][A-Z0-9_]{2,})"
+    r"(?P<key>[A-Z][A-Z0-9_]{2,64})"
     r"(?P<sep>\s*=\s*)"
     r"(?P<val>\"[^\"]*\"|'[^']*'|[^\s]{6,})",
 )
@@ -151,6 +210,7 @@ def scrub(text: str) -> str:
         return text
     try:
         text = _KNOWN_KEY_PREFIX_PATTERN.sub(_REDACTED, text)
+        text = _STRUCTURED_CREDENTIAL_PATTERN.sub(_REDACTED, text)
         text = _redact_value_group(_CREDENTIAL_TOKEN_PATTERN, text, "token")
         text = _redact_value_group(_SINGLE_CREDENTIAL_PATTERN, text, "value")
         text = _redact_value_group(_URL_CREDENTIAL_PATTERN, text, "pw")

--- a/src/genesis/memory/reference_extraction.py
+++ b/src/genesis/memory/reference_extraction.py
@@ -92,6 +92,22 @@ _EMAIL_PASSWORD_PATTERN = re.compile(
 
 # B. Known key prefixes — format-only, no keyword needed.
 # These prefixes are near-certain indicators of real credentials.
+# DELIBERATELY NARROWER than the prefix classes in
+# ``scripts/hooks/secret_scrub.py`` and ``src/genesis/security/output_scanner.py``.
+# All three detect credentials; only this one ACTS on a match by writing a
+# reference the user sees. The other two redact or flag, where over-matching is
+# nearly free — here a false positive fabricates a credential entry in the
+# reference store and the dashboard, which is the exact junk-capture this
+# module's precision tests exist to prevent.
+#
+# Concretely: admitting ``-``/``_`` into the tail (correct for redaction, since
+# modern keys namespace themselves) makes ordinary hyphenated slugs clear the
+# length floor — "sk-learn-pipeline-preprocessing" and "glpat-staging-eu-west1"
+# were both captured as credentials while that class was shared. An unlabelled
+# modern key is therefore NOT auto-captured here; the labelled path
+# (_CREDENTIAL_TOKEN_PATTERN, "the API key is <value>") covers the ordinary
+# conversational phrasing, and real-time ``reference_store`` calls remain the
+# primary capture path — this module is only the safety net.
 _KNOWN_KEY_PREFIX_PATTERN = re.compile(
     r"(?P<token>"
     r"ghp_[A-Za-z0-9]{30,}"       # GitHub personal access token

--- a/tests/test_hooks/test_secret_scrub.py
+++ b/tests/test_hooks/test_secret_scrub.py
@@ -213,3 +213,153 @@ class TestReviewFixes:
         # The secret-key-name gate still applies: a quoted value under a benign
         # key (no KEY/SECRET/TOKEN/… in the name) must NOT be redacted.
         assert s.scrub("MESSAGE='hello world foo'") == "MESSAGE='hello world foo'"
+
+
+# ── scrub: bare-value credential shapes (the captured-output case) ────────
+
+
+class TestScrubRedactsBareProviderTokens:
+    """Credential shapes that arrive with NO label.
+
+    Captured terminal output is the motivating case: a token printed by a CLI
+    lands in the capture as a naked value, so only its SHAPE can save it. The
+    labeled/assignment patterns never see it. Values here are synthetic.
+    """
+
+    def test_anthropic_setup_token(self):
+        # ``sk-`` keys carry interior hyphens; an [A-Za-z0-9]-only class stops
+        # at the first one, far short of any length floor, and passes it through.
+        assert R in s.scrub("sk-ant-oat01-" + "A" * 40)
+
+    def test_openrouter_key(self):
+        assert R in s.scrub("sk-or-v1-" + "b" * 48)
+
+    def test_openai_project_key(self):
+        assert R in s.scrub("sk-proj-" + "c" * 40)
+
+    def test_groq_key(self):
+        assert R in s.scrub("gsk_" + "d" * 40)
+
+    def test_nvidia_nim_key(self):
+        assert R in s.scrub("nvapi-" + "e" * 40)
+
+    def test_tavily_key(self):
+        assert R in s.scrub("tvly-" + "f" * 32)
+
+    def test_github_fine_grained_pat(self):
+        assert R in s.scrub("github_pat_" + "g" * 40)
+
+    def test_jwt(self):
+        assert R in s.scrub("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhIn0." + "h" * 40)
+
+    def test_bare_token_alone_on_its_own_line(self):
+        # The captured-output shape: no label, no assignment, just the value
+        # surrounded by prose the tool printed around it.
+        out = s.scrub("Your token (valid for 1 year):\n\nsk-ant-oat01-" + "Z" * 40 + "\n")
+        assert R in out
+        assert "Z" * 40 not in out
+
+
+class TestScrubRedactsStructuredCredentials:
+    """Credentials identified by STRUCTURE rather than a vendor prefix."""
+
+    def test_discord_webhook_url(self):
+        out = s.scrub("https://discord.com/api/webhooks/123456789012345678/" + "A" * 60)
+        assert R in out
+        assert "A" * 60 not in out
+
+    def test_discord_webhook_url_alt_host(self):
+        out = s.scrub("https://discordapp.com/api/webhooks/987654321098765432/" + "B" * 60)
+        assert R in out
+
+    def test_telegram_bot_token_bare(self):
+        out = s.scrub("1234567890:AA" + "C" * 33)
+        assert R in out
+        assert "C" * 33 not in out
+
+    def test_telegram_bot_token_in_api_url(self):
+        # The form Genesis itself constructs (guardian alert, backup.sh,
+        # install.sh) and therefore the form most likely to reach a pane tail.
+        # A left anchor that rejects any preceding word character kills this,
+        # because the id is preceded by the literal "bot".
+        url = "https://api.telegram.org/bot7891234567:AAG1a2b3c4d5" + "e" * 24 + "/sendMessage"
+        out = s.scrub(url)
+        assert R in out, "token unredacted in the vendor's own URL form"
+        assert "AAG1a2b3c4d5" not in out
+
+    def test_telegram_bot_token_at_vendor_documented_length(self):
+        # Telegram's public Bot API example carries a 34-char secret half. A
+        # floor derived from one locally-observed token has no margin and
+        # silently passes anything shorter.
+        doc_shape = "110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw"
+        assert len(doc_shape.split(":")[1]) == 34
+        assert R in s.scrub(doc_shape)
+
+
+class TestScrubKeepsHyphenatedLookalikes:
+    """The widened classes must not eat ordinary hyphenated text."""
+
+    def test_short_sk_fragment(self):
+        assert R not in s.scrub("sk-1")
+
+    def test_hyphenated_prose(self):
+        text = "a well-documented self-healing check-and-repair reconciliation pass"
+        assert R not in s.scrub(text)
+
+    def test_branch_name(self):
+        assert R not in s.scrub("fix/scrub-capture-hygiene-and-more-words-here")
+
+    def test_timestamps_and_ports_are_not_telegram_tokens(self):
+        # Discriminating negatives for the digits:secret shape — these carry the
+        # colon-separated form and must still survive.
+        for benign in (
+            "elapsed 18:13",
+            "2026-09-01T12:34:56Z",
+            "port 8080:8080 mapped",
+            "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+        ):
+            assert R not in s.scrub(benign), benign
+
+    def test_uuid_is_not_a_provider_token(self):
+        assert R not in s.scrub("bed2f4dd-4224-4fe3-94b2-e18c9f99e0e3")
+
+    def test_git_sha_is_not_a_token(self):
+        assert R not in s.scrub("0400c706186786ccc92e8a8d7904773e7ed5f8b1")
+
+    def test_timestamp_pair_is_not_a_telegram_token(self):
+        assert R not in s.scrub("elapsed 18:13")
+
+    def test_plain_discord_url_without_token(self):
+        assert R not in s.scrub("https://discord.com/channels/123/456")
+
+
+# ── scrub: bounded work on hostile input ─────────────────────────────────
+
+
+class TestScrubDoesNotBacktrackCatastrophically:
+    """``scrub`` runs inside a PostToolUse hook and on captured terminal tails,
+    so its input is arbitrary machine output — long unbroken alphanumeric runs
+    (base64 blobs, minified bundles, hex dumps) are ordinary, not adversarial.
+
+    Greedy unbounded quantifiers followed by a required literal backtrack
+    quadratically on exactly that shape. The threshold is deliberately loose:
+    the unfixed patterns take ~30s on this input, so a multi-second ceiling
+    separates linear from quadratic without being sensitive to machine speed.
+    """
+
+    def test_long_alphanumeric_run_completes_promptly(self):
+        import time
+
+        blob = "eyJ" + "A" * 40000
+        start = time.perf_counter()
+        s.scrub(blob)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 5.0, f"scrub took {elapsed:.1f}s — quadratic backtracking"
+
+    def test_long_value_still_redacted_after_bounding(self):
+        # Guard the fix did not over-correct into a fail-open: bounding the KEY
+        # must not stop a long VALUE from being redacted.
+        assert R in s.scrub("API_SECRET=" + "y" * 9000)
+
+    def test_long_url_password_still_redacted_after_bounding(self):
+        assert R in s.scrub("https://user:" + "p" * 900 + "@host.example/path")

--- a/tests/test_memory/test_reference_extraction_precision.py
+++ b/tests/test_memory/test_reference_extraction_precision.py
@@ -105,6 +105,28 @@ class TestRejectsProseFalsePositives:
         assert classify_as_reference(ext) is None
 
 
+class TestHyphenatedSlugsAreNotCredentials:
+    """Regression guard for the capture/redaction split.
+
+    The redaction-side prefix class admits ``-``/``_`` so that namespaced keys
+    match. Sharing that class with this module made ordinary hyphenated slugs
+    clear the length floor and land in the reference store as credentials.
+    These are the measured false captures from that attempt.
+    """
+
+    @pytest.mark.parametrize(
+        "prose",
+        [
+            "We should use sk-learn-pipeline-preprocessing for the feature step",
+            "Renamed the branch to sk-refactor-memory-graph-phase2 yesterday",
+            "The kube namespace glpat-staging-eu-west1 is the one we scaled",
+            "The CSS class fc-timegrid0123456789abcdef0 broke the calendar",
+        ],
+    )
+    def test_slug_is_not_captured_as_a_credential(self, prose):
+        assert classify_as_reference(_ext(prose, entities=["x"]), user_text=prose) is None
+
+
 # ─── Must STILL classify (guards the fix didn't over-correct) ─────────────────
 
 
@@ -129,6 +151,18 @@ class TestStillClassifiesGenuine:
         assert ref is not None
         assert ref["kind"] == "credentials"
         assert "verysecretword" in ref["value"]
+
+    def test_labelled_modern_key_still_captured(self):
+        # Unlabelled modern keys are deliberately NOT matched here (see the
+        # divergence note on _KNOWN_KEY_PREFIX_PATTERN); the labelled phrasing
+        # is the one that actually occurs in conversation, and it must work.
+        ext = _ext(
+            "The OpenRouter API key is sk-or-v1-" + "a" * 48 + " for the router",
+            entities=["OpenRouter"],
+        )
+        ref = classify_as_reference(ext)
+        assert ref is not None
+        assert ref["kind"] == "credentials"
 
     def test_ip_with_adjacent_context_still_network(self):
         ext = _ext(

--- a/tests/test_scripts/test_cc_exit_capture.py
+++ b/tests/test_scripts/test_cc_exit_capture.py
@@ -13,9 +13,11 @@ private ``-L`` socket, so the real cc-* sessions are never touched.
 """
 
 import os
+import re
 import shutil
 import stat
 import subprocess
+import sys
 import time
 import uuid
 from pathlib import Path
@@ -169,3 +171,126 @@ def test_full_flow_captures_crash_in_scratch_tmux(tmp_path):
     assert "cc-7 claude exited status=134" in body, body
     assert "SIGABRT" in body, body
     assert marker in body, f"pane dying words not captured:\n{body}"
+
+
+@pytest.mark.skipif(not shutil.which("tmux"), reason="tmux not available")
+def test_scrollback_credentials_are_redacted(tmp_path):
+    """A credential printed into the pane must not reach the log verbatim.
+
+    The motivating shape: a CLI that prints a freshly-minted long-lived token
+    to stdout. The capture takes 200 lines of raw scrollback, so without
+    redaction the token is persisted in plaintext. Benign output in the same
+    scrollback must survive, or the log stops being useful for diagnosis.
+    """
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    benign = f"BENIGN_MARKER_{uuid.uuid4().hex[:8]}"
+    secret = "sk-ant-oat01-" + "T" * 60  # synthetic, never a real credential
+    fake_claude = tmp_path / "fakeclaude.sh"
+    fake_claude.write_text(
+        f"#!/usr/bin/env bash\necho '{benign}'\necho 'Your token:'\necho '{secret}'\nexit 0\n"
+    )
+    fake_claude.chmod(0o755)
+
+    sock = f"ccexit-red-{os.getpid()}-{uuid.uuid4().hex[:6]}"
+    inner = (
+        f"HOME={home} '{fake_claude}'; __ec=$?; "
+        f"HOME={home} '{_CAPTURE}' 8 $__ec >/dev/null 2>&1; exit $__ec"
+    )
+    try:
+        subprocess.run(
+            ["tmux", "-L", sock, "new-session", "-d", "-s", "t", inner],
+            check=True, capture_output=True, text=True,
+        )
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            r = subprocess.run(["tmux", "-L", sock, "has-session", "-t", "t"], capture_output=True)
+            if r.returncode != 0:
+                break
+            time.sleep(0.2)
+    finally:
+        subprocess.run(["tmux", "-L", sock, "kill-server"], capture_output=True)
+
+    body = _log_for(home, "8").read_text()
+    assert secret not in body, "credential persisted verbatim into the exit log"
+    assert "T" * 60 not in body, "credential body persisted into the exit log"
+    assert "cc-8 claude exited status=0" in body, body
+    assert benign in body, f"redaction ate benign scrollback:\n{body}"
+
+
+@pytest.mark.skipif(not shutil.which("tmux"), reason="tmux not available")
+def test_tail_is_withheld_when_scrubber_is_unavailable(tmp_path):
+    """Fail CLOSED: with no usable scrubber the tail is WITHHELD, never raw.
+
+    Verified by running a copy of the script whose sibling ``hooks/`` directory
+    does not exist — the same state a partial checkout would produce. The
+    exit-status diagnosis must still be written, since that is the primary
+    reason the log exists.
+    """
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    # A copy with NO hooks/ sibling -> secret_scrub.py unreadable -> scrub fails.
+    isolated = tmp_path / "nohooks"
+    isolated.mkdir()
+    capture_copy = isolated / "cc_exit_capture.sh"
+    capture_copy.write_text(Path(_CAPTURE).read_text())
+    capture_copy.chmod(0o755)
+
+    secret = "sk-ant-oat01-" + "W" * 60  # synthetic
+    fake_claude = tmp_path / "fakeclaude2.sh"
+    fake_claude.write_text(f"#!/usr/bin/env bash\necho '{secret}'\nexit 0\n")
+    fake_claude.chmod(0o755)
+
+    sock = f"ccexit-fc-{os.getpid()}-{uuid.uuid4().hex[:6]}"
+    inner = (
+        f"HOME={home} '{fake_claude}'; __ec=$?; "
+        f"HOME={home} '{capture_copy}' 9 $__ec >/dev/null 2>&1; exit $__ec"
+    )
+    try:
+        subprocess.run(
+            ["tmux", "-L", sock, "new-session", "-d", "-s", "t", inner],
+            check=True, capture_output=True, text=True,
+        )
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            r = subprocess.run(["tmux", "-L", sock, "has-session", "-t", "t"], capture_output=True)
+            if r.returncode != 0:
+                break
+            time.sleep(0.2)
+    finally:
+        subprocess.run(["tmux", "-L", sock, "kill-server"], capture_output=True)
+
+    body = _log_for(home, "9").read_text()
+    assert secret not in body, "raw tail written when the scrubber was unavailable"
+    assert "withheld" in body, f"no withheld-tail marker:\n{body}"
+    assert "cc-9 claude exited status=0" in body, body
+
+
+def test_scrub_filter_decodes_bytes_leniently():
+    """The scrub filter must not abort on an undecodable byte.
+
+    Scope, honestly: ``tmux capture-pane -p`` normalises stray bytes out, so
+    this is NOT reachable through the tmux path today (measured — a raw 0xff
+    never survives capture). It guards the FILTER itself, which is a plain
+    stdin->stdout stage: a strict decode there turns one bad byte into a
+    discarded 200-line diagnostic, in exactly the crash case the tail exists
+    for. The snippet is extracted from the script rather than restated, so this
+    fails if the real decode ever regresses.
+    """
+    src = Path(_CAPTURE).read_text()
+    m = re.search(r"python3 -c '(.*?)' \"\$_CC_HOOKS_DIR\"", src, re.S)
+    assert m, "could not locate the scrub filter snippet in the script"
+    snippet = m.group(1)
+
+    hooks_dir = str(Path(_CAPTURE).resolve().parent / "hooks")
+    secret = "sk-ant-oat01-" + "R" * 60  # synthetic
+    payload = b"bad \xff byte KEEPME\n" + secret.encode() + b"\n"
+    r = subprocess.run(
+        [sys.executable, "-c", snippet, hooks_dir], input=payload, capture_output=True
+    )
+    assert r.returncode == 0, f"filter aborted on a non-UTF-8 byte: {r.stderr.decode()}"
+    out = r.stdout.decode()
+    assert "KEEPME" in out, "surrounding diagnostic text was lost"
+    assert secret not in out, "credential survived the lenient decode path"
+
+


### PR DESCRIPTION
Superseded by #1580.

Closed and reopened so the branch carries a single commit with corrected wording. Squash merges take their message from the branch commits, so the wording had to be corrected at the commit; the push guard does not permit force-pushing a public branch, so a fresh branch was the route.

Same code, same tests, same measurements. See #1580.