### PR TITLE
chore(security): narrow GitHub secret-scanning ignore to scrubber test fixtures

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,16 @@
+# GitHub native secret-scanning configuration.
+#
+# `paths-ignore` excludes paths from GitHub's push-protection and alerting.
+# Scope is DELIBERATELY NARROW: only the secret-scrubber's own test suites,
+# which MUST embed realistic, credential-shaped strings as fixtures to prove
+# the scrubber redacts them. A realistic (high-entropy) example token in one
+# of these files will match a provider detector even though it is not a live
+# credential (e.g. the Telegram Bot API documented example token).
+#
+# This mirrors — and no wider than — the tests/ exclusion our own scanners
+# already apply (`.gitleaks.toml` allowlist, the detect-secrets scan scope in
+# ci.yml, and the pre-commit hook pathspec). It does NOT ignore all of tests/:
+# a real secret accidentally committed to any OTHER test file still alerts.
+paths-ignore:
+  - "tests/test_hooks/test_secret_scrub.py"
+  - "tests/test_hooks/test_session_observer_scrub.py"

--- a/config/protected_paths.yaml
+++ b/config/protected_paths.yaml
@@ -75,6 +75,8 @@ contribution_forbidden:
   # Security scanner config — a contribution must never weaken the gate that scans it
   - pattern: ".gitleaks.toml"
     reason: "The sanitizer's own secret-scan rules; a contribution that edits them could silently disable secret detection for every future contribution"
+  - pattern: ".github/secret_scanning.yml"
+    reason: "GitHub-native secret-scanning config; a contribution that widens its paths-ignore could silently disable GitHub's own secret detection for every future contribution"
   # User-specific configs
   - pattern: "config/research-profiles/**"
     reason: "Private research interests"

--- a/src/genesis/contribution/sanitize.py
+++ b/src/genesis/contribution/sanitize.py
@@ -61,6 +61,9 @@ DEFAULT_FORBIDDEN_GLOBS: tuple[str, ...] = (
     # Sanitizer's own secret-scan rules — a contribution must not weaken the gate
     # that scans it (else a merged edit silently disables detection downstream).
     ".gitleaks.toml",
+    # GitHub-native secret scanning config — a contribution must not widen its
+    # paths-ignore (e.g. to "**") and silently disable GitHub's own detection.
+    ".github/secret_scanning.yml",
     "config/research-profiles/*",
     "config/research-profiles/**",
     "config/external-modules/*",

--- a/tests/test_contribution/test_sanitize_real_scanners.py
+++ b/tests/test_contribution/test_sanitize_real_scanners.py
@@ -332,3 +332,25 @@ def test_gitleaks_toml_is_contribution_forbidden():
         f.kind == FindingKind.FORBIDDEN_PATH and ".gitleaks.toml" in (f.file or "")
         for f in result.blocking()
     ), "a .gitleaks.toml edit must raise a FORBIDDEN_PATH block"
+
+
+def test_secret_scanning_yml_is_contribution_forbidden():
+    """A contribution that edits .github/secret_scanning.yml must be BLOCKED — otherwise a
+    merged edit could widen paths-ignore to ["**"] and silently disable GitHub-native secret
+    detection for every future contribution. Mirrors the .gitleaks.toml self-protection; no
+    scanner binary needed — a path-policy check."""
+    diff = (
+        "diff --git a/.github/secret_scanning.yml b/.github/secret_scanning.yml\n"
+        "--- a/.github/secret_scanning.yml\n"
+        "+++ b/.github/secret_scanning.yml\n"
+        "@@ -1,2 +1,2 @@\n"
+        " paths-ignore:\n"
+        '-  - "tests/test_hooks/test_secret_scrub.py"\n'
+        '+  - "**"\n'
+    )
+    result = sanitize.scan_diff(diff)
+    assert result.ok is False, ".github/secret_scanning.yml edits must be blocked"
+    assert any(
+        f.kind == FindingKind.FORBIDDEN_PATH and ".github/secret_scanning.yml" in (f.file or "")
+        for f in result.blocking()
+    ), "a .github/secret_scanning.yml edit must raise a FORBIDDEN_PATH block"


### PR DESCRIPTION
## What

Adds `.github/secret_scanning.yml` with a **deliberately narrow** `paths-ignore` covering only the secret-scrubber's own two test suites:

```
paths-ignore:
  - tests/test_hooks/test_secret_scrub.py
  - tests/test_hooks/test_session_observer_scrub.py
```

## Why

These files must embed realistic, credential-shaped strings as fixtures to prove the scrubber redacts them. A high-entropy example token (a Telegram Bot API documented example) matches GitHub's provider detector and raises a `publicly_leaked` alert even though it is not a live credential.

Our three own scanners already exclude `tests/` wholesale (`.gitleaks.toml` allowlist; `detect-secrets` scan scope in `ci.yml` omits tests/; the `pre-commit` hook pathspec `:!tests/*`). GitHub-native scanning was the **only** path with no tests/ exclusion plus a Telegram detector, so it was the sole scanner that fired.

## Scope discipline

This does **not** ignore all of `tests/` — only these two fixture files. A real secret committed to any other test file still alerts via GitHub-native scanning. Strictly narrower than the whole-tree exclusion our own scanners already apply.

## Notes

- Effective only on the default branch, so it must land on `main`.
- The alerting fixture also appears on another open PR that touches the same test file; this config helps both.

## Review

genesis-security-reviewer: **CLEAN** — no CRITICAL/HIGH. Confirmed both files are fixture-only (no live credential), scope is minimal + wildcard-free (no glob-widening), valid `secret_scanning.yml` schema, and the only residual blind spot (a hand-pasted real secret in exactly these two files) matches the existing tests/ exclusion posture. Two LOW informational notes (merge-sequencing; an optional fixture comment) — neither blocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to avoid false positives from two credential-shaped test fixtures.
  * Secret scanning remains enabled for other test files.
  * Protected the security scanning configuration from being modified through contributions.

* **Tests**
  * Added coverage confirming that attempted changes to the protected scanning configuration are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->