### PR TITLE
feat(outreach): Telegram-ping the owner on a genuine marketing reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **Telegram ping when someone replies to a marketing pitch.** When a real person
+  replies to one of Genesis's cold marketing emails, you now get one brief
+  Telegram notification — the sender and the first line of their reply.
+  Auto-responders (out-of-office / bounces) and spoofed senders are filtered out,
+  so you're pinged only for genuine human replies, and never for sends. The reply
+  is still recorded on the dashboard exactly as before; this just surfaces it to
+  you immediately instead of waiting for you to go look.
+
 - **Gated autonomous cold marketing outreach (inert by default).** Genesis can
   now stage cold marketing emails to an owner-curated prospect list via the new
   `marketing_send` tool. The recipient is resolved in code from a private

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -432,7 +432,7 @@ gated — that contract is one-directional.
 ```yaml subsystem-map
 entry: autonomy-egress
 modules: [autonomy, outreach, distribution, content, campaigns]
-verified: 84c7259d 2026-08-31
+verified: 85f91765 2026-09-01
 ```
 
 - **The chokepoint is `outreach/pipeline.py _deliver`** — ~12 send paths
@@ -497,6 +497,19 @@ verified: 84c7259d 2026-08-31
   stamping, AND a hard per-window cap on hold-creation (the ASK-state
   approval-flood guard) alongside the batch-approval card — `marketing_send` has
   no autonomous caller until then.
+- **Marketing reply → owner Telegram ping (notify-only).** When a GENUINE human
+  reply lands (auto-responders + foreign senders already gated out by the
+  reply→engagement bridge, `outreach/engagement.py`) AND the reply's recipient is
+  a curated `marketing_prospects` row (`get_by_email` — NOT the thread
+  `signal_type`, which the owner-approval resume path overwrites to
+  `email_gate_resume`, so it never survives a held→approved cold send), the owner
+  gets ONE brief `submit_raw` Telegram ping (`make_marketing_reply_notifier`,
+  wired in `runtime/init/outreach.py`). Owner-facing, so never gated; best-effort
+  (a non-DELIVERED ping is logged, not retried — the reply is already durably
+  recorded in `outreach_history`/`email_threads`). Attacker-controlled reply
+  fields are HTML-escaped + control-char-stripped (`_sanitize_ping_field`) because
+  the outreach telegram path delivers with `parse_mode="HTML"` unescaped. The
+  autonomous `ReplyHandler` auto-reply path is unchanged by this.
 - **`content/egress.py gate()` is LIVE** in the pipeline: anti-slop scrub +
   PII scan for EXTERNAL channels and `content`-category drafts only. Never
   applied to owner channels — don't add them.

--- a/src/genesis/outreach/engagement.py
+++ b/src/genesis/outreach/engagement.py
@@ -126,10 +126,11 @@ def make_marketing_reply_notifier(pipeline):
     owner that a real human reply landed on a cold marketing pitch.
 
     Owner-facing delivery is never gated: ``submit_raw`` skips governance,
-    quiet-hours, and the LLM drafter. A non-DELIVERED result is logged, not
-    retried — the reply itself is already durably recorded in
-    ``outreach_history`` / ``email_threads``, so a transient miss is an
-    un-pushed row, not lost data.
+    quiet-hours, and the LLM drafter. Sent ``best_effort=True`` so a
+    non-DELIVERED result is logged and dropped, never deferred into the recovery
+    queue (no retries, no delivery-exhausted observation) — the reply itself is
+    already durably recorded in ``outreach_history`` / ``email_threads``, so a
+    transient miss is an un-pushed row, not lost data.
     """
 
     async def _notify(thread: dict, reply) -> None:
@@ -157,23 +158,33 @@ def make_marketing_reply_notifier(pipeline):
         # Per-reply uniqueness so a genuine reply is never suppressed as a
         # duplicate of an earlier, differently-worded one. submit_raw dedups on
         # BOTH (signal_type, topic) AND a topic-independent content_hash(context)
-        # (outreach/governance.py::_is_duplicate) — so message_id keys BOTH the
-        # topic and the (non-delivered) context. Effect: each distinct reply
-        # pings once; only the exact same reply re-processed is deduped. The
+        # (outreach/governance.py::_is_duplicate). content_hash only hashes the
+        # FIRST 200 chars (governance.py::content_hash), so message_id must lead
+        # the context — a long rendered ping (sender+subject+preview can exceed
+        # 200 chars) would otherwise push the discriminator out of the hashed
+        # prefix and two distinct replies would collide. Effect: each distinct
+        # reply pings once; only the exact same reply re-processed is deduped. The
         # delivered message is the `text` arg (submit_raw ignores request.context,
         # which feeds only the dedup hash), so context can carry the discriminator
         # without changing what the owner sees.
-        message_id = getattr(reply, "message_id", "") or thread.get("id") or ""
+        # Cap the attacker-influenceable Message-ID for storage hygiene (metadata
+        # only — never rendered to the owner; feeds the dedup topic/hash), matching
+        # the 200-char cap on the other reply fields.
+        message_id = (getattr(reply, "message_id", "") or thread.get("id") or "")[:200]
         request = OutreachRequest(
             category=OutreachCategory.NOTIFICATION,
             channel="telegram",
             topic=f"Marketing reply {message_id}",
-            context=f"{text}\n{message_id}",
+            context=f"{message_id}\n{text}",
             signal_type="marketing_reply",
             salience_score=0.9,
             verbatim=True,
         )
-        result = await pipeline.submit_raw(text, request)
+        # best_effort: this ping is fire-and-forget. A missing Telegram adapter
+        # (email-only install) or a transient outage must NOT defer into the
+        # recovery queue (5 retries + a delivery-exhausted observation) — the
+        # reply is already durably recorded in outreach_history/email_threads.
+        result = await pipeline.submit_raw(text, request, best_effort=True)
         if result is not None and result.status == OutreachStatus.DELIVERED:
             logger.info("Pinged owner of marketing reply on thread %s", thread.get("id"))
         else:

--- a/src/genesis/outreach/engagement.py
+++ b/src/genesis/outreach/engagement.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import html
 import logging
+import unicodedata
 from email.utils import parseaddr
 
 import aiosqlite
@@ -12,7 +14,25 @@ from genesis.db.crud import outreach as outreach_crud
 logger = logging.getLogger(__name__)
 
 
-def make_reply_engagement_bridge(tracker: EngagementTracker):
+def _sanitize_ping_field(value: str) -> str:
+    """Make an attacker-controlled email field safe for the owner's Telegram ping.
+
+    The outreach delivery path sends with ``parse_mode="HTML"`` and does NOT
+    escape (verified 2026-09-01: ``pipeline._deliver`` → ``adapter.send_message``
+    with no parse_mode → ``adapter_v2`` defaults to HTML → ``safe_send_message``
+    sends the text raw — ``md_to_telegram_html``/``html.escape`` runs only on the
+    interactive chat-reply path, never here). So a reply's ``sender``/``subject``/
+    ``body`` would otherwise render as live HTML (clickable links, formatting) in
+    the owner's trusted chat. Strip Unicode control/format chars (categories
+    ``Cc``/``Cf`` — bidi overrides, zero-width) so a display string can't be
+    visually disguised, then HTML-escape. Truncate BEFORE calling this so a cut
+    never lands mid-entity.
+    """
+    cleaned = "".join(ch for ch in value if unicodedata.category(ch) not in ("Cc", "Cf"))
+    return html.escape(cleaned)
+
+
+def make_reply_engagement_bridge(tracker: EngagementTracker, notify_owner=None):
     """Build the mail→outreach reply bridge for ``ReplyPoller.set_engagement_bridge``.
 
     The poller calls it with the matched ``thread`` dict (whose ``context`` was
@@ -21,6 +41,16 @@ def make_reply_engagement_bridge(tracker: EngagementTracker):
     engagement NULL-guarded. Every miss degrades to a logged no-op — reply
     tracking must never depend on this bridge. Injected from
     ``runtime/init/outreach.py`` so ``genesis.mail`` stays outreach-agnostic.
+
+    ``notify_owner`` (optional): an async ``(thread, reply) -> None`` callable
+    fired AFTER the genuine-reply gates, but ONLY when the thread recipient is a
+    curated marketing prospect (``marketing_prospects.get_by_email``), so the
+    owner gets a Telegram ping when a real human replies to a cold pitch.
+    Recipient-membership (not the thread's ``signal_type``, which the
+    owner-approval resume path overwrites) is what makes this fire on the default
+    held→approved send path. Best-effort and self-contained: a ping failure is
+    logged and swallowed here, so it never breaks reply tracking and never counts
+    as a bridge error.
     """
 
     async def _bridge(thread: dict, reply) -> None:
@@ -61,7 +91,98 @@ def make_reply_engagement_bridge(tracker: EngagementTracker):
         reply_text = getattr(reply, "body_preview", "") or ""
         await tracker.record_reply_if_pending(str(outreach_id), reply_text)
 
+        # Owner ping on a genuine reply to a cold marketing pitch (notify-only).
+        # The reply has already cleared the auto-responder + foreign-sender gates
+        # above, so it's a real human reply. Marketing-ness is keyed on the
+        # RECIPIENT being a curated marketing prospect — NOT the thread's
+        # signal_type: the owner-approval resume path (pipeline.deliver_approved)
+        # rebuilds the send with signal_type="email_gate_resume", so
+        # "marketing_cold" never survives a held→approved cold send (the DEFAULT
+        # gated path). Every marketing_send resolves its address in code from
+        # marketing_prospects, so recipient-membership fires for exactly the
+        # marketing replies and is send-path-independent. Membership (not
+        # is_active_recipient) is intentional: a contacted / opted-out prospect
+        # who replies is still a real human reply worth surfacing. Best-effort:
+        # any failure is logged and swallowed so reply tracking never depends on
+        # it (and it never counts as a bridge error).
+        if notify_owner is not None and recipient:
+            try:
+                from genesis.db.crud import marketing_prospects as _marketing_prospects
+
+                if await _marketing_prospects.get_by_email(tracker._db, recipient) is not None:
+                    await notify_owner(thread, reply)
+            except Exception:
+                logger.warning(
+                    "Marketing reply owner-ping failed for thread %s",
+                    thread.get("id"), exc_info=True,
+                )
+
     return _bridge
+
+
+def make_marketing_reply_notifier(pipeline):
+    """Build the owner-ping callable for ``make_reply_engagement_bridge``'s
+    ``notify_owner``. Fires ONE brief, verbatim Telegram notification to the
+    owner that a real human reply landed on a cold marketing pitch.
+
+    Owner-facing delivery is never gated: ``submit_raw`` skips governance,
+    quiet-hours, and the LLM drafter. A non-DELIVERED result is logged, not
+    retried — the reply itself is already durably recorded in
+    ``outreach_history`` / ``email_threads``, so a transient miss is an
+    un-pushed row, not lost data.
+    """
+
+    async def _notify(thread: dict, reply) -> None:
+        from genesis.outreach.types import (
+            OutreachCategory,
+            OutreachRequest,
+            OutreachStatus,
+        )
+
+        # Attacker-controlled fields (anyone who can email the marketing inbox
+        # controls their own From display name / Subject / body). Truncate RAW
+        # (char count), then sanitize — see _sanitize_ping_field: the owner's
+        # Telegram receives this with parse_mode="HTML" and no escaping.
+        sender = _sanitize_ping_field((getattr(reply, "sender", "") or "someone")[:200])
+        subject = _sanitize_ping_field((getattr(reply, "subject", "") or "").strip()[:150])
+        preview = (getattr(reply, "body_preview", "") or "").strip()
+        first_line = _sanitize_ping_field(
+            (preview.splitlines()[0].strip() if preview else "")[:200]
+        )
+        text = f"📨 Reply to your pitch from {sender}"
+        if subject:
+            text += f"\n{subject}"
+        if first_line:
+            text += f'\n"{first_line}"'
+        # Per-reply uniqueness so a genuine reply is never suppressed as a
+        # duplicate of an earlier, differently-worded one. submit_raw dedups on
+        # BOTH (signal_type, topic) AND a topic-independent content_hash(context)
+        # (outreach/governance.py::_is_duplicate) — so message_id keys BOTH the
+        # topic and the (non-delivered) context. Effect: each distinct reply
+        # pings once; only the exact same reply re-processed is deduped. The
+        # delivered message is the `text` arg (submit_raw ignores request.context,
+        # which feeds only the dedup hash), so context can carry the discriminator
+        # without changing what the owner sees.
+        message_id = getattr(reply, "message_id", "") or thread.get("id") or ""
+        request = OutreachRequest(
+            category=OutreachCategory.NOTIFICATION,
+            channel="telegram",
+            topic=f"Marketing reply {message_id}",
+            context=f"{text}\n{message_id}",
+            signal_type="marketing_reply",
+            salience_score=0.9,
+            verbatim=True,
+        )
+        result = await pipeline.submit_raw(text, request)
+        if result is not None and result.status == OutreachStatus.DELIVERED:
+            logger.info("Pinged owner of marketing reply on thread %s", thread.get("id"))
+        else:
+            logger.warning(
+                "Marketing reply owner-ping not delivered (status=%s) for thread %s",
+                getattr(result, "status", None), thread.get("id"),
+            )
+
+    return _notify
 
 
 class EngagementTracker:

--- a/src/genesis/outreach/engagement.py
+++ b/src/genesis/outreach/engagement.py
@@ -105,7 +105,18 @@ def make_reply_engagement_bridge(tracker: EngagementTracker, notify_owner=None):
         # who replies is still a real human reply worth surfacing. Best-effort:
         # any failure is logged and swallowed so reply tracking never depends on
         # it (and it never counts as a bridge error).
-        if notify_owner is not None and recipient:
+        #
+        # Require a NON-EMPTY parsed sender: the foreign-sender guard above
+        # (`recipient and sender_addr and sender_addr != recipient`) only rejects
+        # when BOTH addresses are truthy, so a reply with a missing/unparsable
+        # `From` (empty sender_addr) slips past it. Gating the ping on `sender_addr`
+        # means we only surface a reply whose sender we positively verified equals
+        # the prospect recipient (a truthy sender that reached here must == recipient,
+        # or the guard would have returned) — never an unverified "reply from someone".
+        # record_reply_if_pending above is intentionally NOT gated on this (internal
+        # engagement tracking keeps its pre-existing permissiveness); only the
+        # owner-facing ping requires the stronger sender proof.
+        if notify_owner is not None and recipient and sender_addr:
             try:
                 from genesis.db.crud import marketing_prospects as _marketing_prospects
 

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -271,13 +271,22 @@ class OutreachPipeline:
 
     async def submit_raw(
         self, text: str, request: OutreachRequest,
-        *, reply_markup: object | None = None,
+        *, reply_markup: object | None = None, best_effort: bool = False,
     ) -> OutreachResult:
         """Deliver pre-formatted text. Skips governance and LLM drafter.
 
         For urgent infrastructure alerts where speed matters more than prose.
         Still applies dedup to prevent alert spam (e.g. sentinel approvals).
         ``reply_markup`` is forwarded to the adapter for inline keyboard buttons.
+
+        ``best_effort=True`` makes delivery fire-and-forget: a missing adapter/
+        recipient or a send failure returns a non-DELIVERED result WITHOUT
+        deferring to the recovery queue (no retries, no delivery-exhausted
+        observation). For notifications whose source data is already durably
+        recorded elsewhere, so a transient miss is acceptable — e.g. the
+        marketing reply-ping, where the reply lives in outreach_history/
+        email_threads regardless. Prevents an email-only install or a Telegram
+        outage from turning each such ping into hours of retry work + health noise.
         """
         outreach_id = str(uuid.uuid4())
 
@@ -303,7 +312,7 @@ class OutreachPipeline:
         format_target = _CHANNEL_FORMAT.get(channel, FormatTarget.GENERIC)
         formatted = self._formatter.format(text, format_target)
         return await self._deliver(outreach_id, channel, formatted, request, None,
-                                   reply_markup=reply_markup)
+                                   reply_markup=reply_markup, best_effort=best_effort)
 
     async def submit_urgent(self, request: OutreachRequest) -> OutreachResult:
         outreach_id = str(uuid.uuid4())
@@ -499,6 +508,7 @@ class OutreachPipeline:
         *,
         reply_markup: object | None = None,
         gate_cleared: bool = False,
+        best_effort: bool = False,
     ) -> OutreachResult:
         adapter = self._channels.get(channel)
         recipient = (
@@ -538,11 +548,16 @@ class OutreachPipeline:
                 )
 
         if not adapter or not recipient:
-            logger.warning("No adapter/recipient for channel %s — deferring", channel)
-            await self._defer(
-                outreach_id, channel, formatted.text, request,
-                f"No adapter or recipient for {channel}",
-            )
+            if best_effort:
+                logger.warning(
+                    "No adapter/recipient for channel %s — dropping (best-effort)", channel,
+                )
+            else:
+                logger.warning("No adapter/recipient for channel %s — deferring", channel)
+                await self._defer(
+                    outreach_id, channel, formatted.text, request,
+                    f"No adapter or recipient for {channel}",
+                )
             return OutreachResult(
                 outreach_id=outreach_id,
                 status=OutreachStatus.FAILED,
@@ -686,11 +701,13 @@ class OutreachPipeline:
                     logger.warning("DM copy failed for 'both' routing", exc_info=True)
         except Exception as exc:
             logger.error("Delivery failed on %s: %s", channel, exc, exc_info=True)
-            if not gate_cleared:
+            if not gate_cleared and not best_effort:
                 # Gate-cleared (resume) sends are retried by the WS-8 email-gate
                 # drain, NOT the deferred-work queue: deferring here would route
                 # the retry back through _deliver and re-gate it. The drain owns
                 # resume retries (it leaves the hold 'held' on failure).
+                # best_effort sends (e.g. the marketing reply-ping) intentionally
+                # drop on failure — no retry, no delivery-exhausted observation.
                 await self._defer(outreach_id, channel, formatted.text, request, str(exc))
             return OutreachResult(
                 outreach_id=outreach_id,

--- a/src/genesis/runtime/init/outreach.py
+++ b/src/genesis/runtime/init/outreach.py
@@ -28,6 +28,7 @@ async def init(rt: GenesisRuntime) -> None:
         from genesis.outreach.config import load_outreach_config
         from genesis.outreach.engagement import (
             EngagementTracker,
+            make_marketing_reply_notifier,
             make_reply_engagement_bridge,
         )
         from genesis.outreach.fresh_eyes import FreshEyesReview
@@ -139,7 +140,12 @@ async def init(rt: GenesisRuntime) -> None:
         # exists; the mail layer stays outreach-agnostic via injection).
         reply_poller = getattr(rt, "_reply_poller", None)
         if reply_poller is not None:
-            reply_poller.set_engagement_bridge(make_reply_engagement_bridge(engagement))
+            reply_poller.set_engagement_bridge(
+                make_reply_engagement_bridge(
+                    engagement,
+                    notify_owner=make_marketing_reply_notifier(rt._outreach_pipeline),
+                )
+            )
             logger.info("Reply→engagement bridge wired into reply poller")
 
         morning = MorningReportGenerator(

--- a/tests/test_mail/test_reply_poller_engagement.py
+++ b/tests/test_mail/test_reply_poller_engagement.py
@@ -360,3 +360,350 @@ async def test_e2e_reply_prediction_resolves_after_bridge(db):
     assert value_a == 1, f"bridged reply must grade 1, got {value_a} ({status_a})"
     status_b, value_b = await _reply_pred(other_id)
     assert value_b == 0, f"silent send must grade 0 at deadline, got {value_b} ({status_b})"
+
+
+# ---------------------------------------------------------------------------
+# B — marketing reply owner-ping (notify-only). A GENUINE reply from a curated
+# marketing prospect pings the owner exactly once; nothing else does, and the
+# best-effort ping never affects engagement recording. The discriminator is
+# RECIPIENT-in-marketing_prospects (NOT the thread signal_type, which the
+# owner-approval resume path overwrites to "email_gate_resume"). The auto-reply
+# path is untouched by this feature.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_prospect(db, *, email: str = "target@example.com", opted_out: bool = False) -> None:
+    """Seed a curated marketing prospect (the recipient of a cold pitch)."""
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id=f"prospect-{email}", email=email, name="Target", source="test")
+    if opted_out:
+        await mp.mark_opted_out(db, f"prospect-{email}", opted_out_at="2026-09-01T00:00:00Z")
+
+
+async def _run_poll_with_notify(db, *, thread_context, notify_owner, raws=None):
+    tracker = ThreadTracker(db)
+    await _register_thread(tracker, context=thread_context)
+    poller = ReplyPoller(imap_client=_FakeImap(raws or [_reply()]), thread_tracker=tracker)
+    from genesis.outreach.engagement import make_reply_engagement_bridge
+
+    poller.set_engagement_bridge(
+        make_reply_engagement_bridge(EngagementTracker(db), notify_owner=notify_owner)
+    )
+    return await poller.poll()
+
+
+async def test_reply_from_marketing_prospect_pings_owner(db):
+    await _seed_outreach(db)
+    await _seed_prospect(db)  # recipient target@example.com is a curated prospect
+    calls = []
+
+    async def _notify(thread, reply):
+        calls.append((thread, reply))
+
+    stats = await _run_poll_with_notify(
+        db,
+        thread_context={"outreach_id": OUTREACH_ID},
+        notify_owner=_notify,
+    )
+    assert stats["errors"] == 0
+    assert len(calls) == 1  # genuine reply from a prospect → owner pinged exactly once
+    # Engagement is still recorded — the ping is additive, not a replacement.
+    outcome, signal, _ = await _engagement(db)
+    assert (outcome, signal) == ("useful", "user_reply")
+
+
+async def test_reply_from_non_prospect_does_not_ping(db):
+    """A genuine reply whose recipient is NOT a curated marketing prospect records
+    engagement but must NOT fire the marketing owner-ping."""
+    await _seed_outreach(db)
+    # No prospect seeded → recipient is not in marketing_prospects.
+    calls = []
+
+    async def _notify(thread, reply):
+        calls.append(1)
+
+    await _run_poll_with_notify(
+        db,
+        thread_context={"outreach_id": OUTREACH_ID},
+        notify_owner=_notify,
+    )
+    assert calls == []  # recipient not a prospect → no ping
+    outcome, _s, _r = await _engagement(db)
+    assert outcome == "useful"  # ...engagement still recorded
+
+
+async def test_reply_from_opted_out_prospect_still_pings(db):
+    """Membership (get_by_email), NOT is_active_recipient: a contacted / opted-out
+    prospect who replies is still a real human reply worth surfacing to the owner.
+    Locks the inclusive discriminator against a future narrowing to active-only."""
+    await _seed_outreach(db)
+    await _seed_prospect(db, opted_out=True)
+    calls = []
+
+    async def _notify(thread, reply):
+        calls.append(1)
+
+    await _run_poll_with_notify(
+        db,
+        thread_context={"outreach_id": OUTREACH_ID},
+        notify_owner=_notify,
+    )
+    assert calls == [1]  # opted-out prospect's genuine reply still pings
+
+
+async def test_auto_responder_from_prospect_does_not_ping(db):
+    """An OOO/auto-reply from a prospect is gated BEFORE the ping — the owner is
+    not pinged for a bounce, and it is not counted as engagement."""
+    await _seed_outreach(db)
+    await _seed_prospect(db)
+    calls = []
+
+    async def _notify(thread, reply):
+        calls.append(1)
+
+    auto = _reply(extra_headers="Auto-Submitted: auto-replied\r\n", body="I am away.")
+    await _run_poll_with_notify(
+        db,
+        thread_context={"outreach_id": OUTREACH_ID},
+        notify_owner=_notify,
+        raws=[auto],
+    )
+    assert calls == []  # auto-responder gated before the ping
+    outcome, _s, _r = await _engagement(db)
+    assert outcome is None  # and not counted as engagement
+
+
+async def test_foreign_sender_does_not_ping(db):
+    """Recipient is a prospect, but the reply comes from a foreign/spoofed sender.
+    The sender!=recipient gate returns early, before the prospect lookup + ping."""
+    await _seed_outreach(db)
+    await _seed_prospect(db)
+    calls = []
+
+    async def _notify(thread, reply):
+        calls.append(1)
+
+    foreign = _reply(from_addr="stranger@elsewhere.com")
+    await _run_poll_with_notify(
+        db,
+        thread_context={"outreach_id": OUTREACH_ID},
+        notify_owner=_notify,
+        raws=[foreign],
+    )
+    assert calls == []
+
+
+async def test_ping_failure_does_not_break_engagement_or_count_error(db):
+    """The owner-ping is best-effort: if notify_owner raises, engagement is still
+    recorded and the bridge does NOT report an error — reply tracking must never
+    depend on the ping (the bridge's fail-safe contract)."""
+    await _seed_outreach(db)
+    await _seed_prospect(db)
+
+    async def _notify(thread, reply):
+        raise RuntimeError("telegram down")
+
+    stats = await _run_poll_with_notify(
+        db,
+        thread_context={"outreach_id": OUTREACH_ID},
+        notify_owner=_notify,
+    )
+    assert stats["errors"] == 0  # ping failure isolated from bridge error accounting
+    outcome, signal, _ = await _engagement(db)
+    assert (outcome, signal) == ("useful", "user_reply")  # engagement survived
+
+
+async def test_bridge_without_notify_owner_is_unchanged(db):
+    # Backward-compat: the factory's original 1-arg form still works (no ping).
+    await _seed_outreach(db)
+    await _seed_prospect(db)  # even with a prospect, no notify_owner → no ping path
+    stats = await _run_poll(db, thread_context={"outreach_id": OUTREACH_ID}, with_bridge=True)
+    assert stats["errors"] == 0
+    outcome, _s, _r = await _engagement(db)
+    assert outcome == "useful"
+
+
+# --- the notifier factory: the actual ping construction --------------------
+
+
+class _FakePipeline:
+    """Records submit_raw calls, returns a canned OutreachResult status."""
+
+    def __init__(self, status):
+        self._status = status
+        self.calls = []
+
+    async def submit_raw(self, text, request):
+        self.calls.append((text, request))
+        from genesis.outreach.types import OutreachResult
+
+        return OutreachResult(
+            outreach_id="x",
+            status=self._status,
+            channel="telegram",
+            message_content=text,
+        )
+
+
+class _ReplyStub:
+    sender = "Cole <cole@example.com>"
+    subject = "Re: your pitch"
+    body_preview = "Interesting -- tell me more.\nSecond line should be dropped."
+    message_id = "<r-1@example.com>"
+
+
+async def test_marketing_reply_notifier_builds_brief_telegram_ping():
+    from genesis.outreach.engagement import make_marketing_reply_notifier
+    from genesis.outreach.types import OutreachCategory, OutreachStatus
+
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+    notifier = make_marketing_reply_notifier(pipe)
+
+    await notifier({"id": "th-1", "recipient": "cole@example.com"}, _ReplyStub())
+
+    assert len(pipe.calls) == 1
+    text, request = pipe.calls[0]
+    assert request.channel == "telegram"
+    assert request.category == OutreachCategory.NOTIFICATION
+    assert request.verbatim is True
+    assert request.salience_score == 0.9
+    assert "Cole &lt;cole@example.com&gt;" in text  # angle brackets HTML-escaped
+    assert "Re: your pitch" in text
+    assert "Interesting" in text
+    assert "Second line should be dropped" not in text  # only the FIRST preview line
+
+
+async def test_marketing_reply_notifier_escapes_attacker_html():
+    """CRITICAL security regression: the outreach telegram send path delivers
+    with parse_mode='HTML' and does NOT escape, so attacker-controlled reply
+    fields (sender/subject/body — anyone who can email the inbox controls them)
+    must be HTML-escaped here or they render as live HTML (clickable links,
+    formatting) in the owner's trusted chat. Reddens if the escape is removed."""
+    from genesis.outreach.engagement import make_marketing_reply_notifier
+    from genesis.outreach.types import OutreachStatus
+
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+    notifier = make_marketing_reply_notifier(pipe)
+
+    class _Evil:
+        sender = '<a href="https://evil.example">Genesis Security</a>'
+        subject = '<b>urgent</b> <a href="https://evil">verify</a>'
+        body_preview = '<code>x</code> click <a href="https://evil">here</a>'
+        message_id = "<r-evil@example.com>"
+
+    await notifier({"id": "th", "recipient": "p@example.com"}, _Evil())
+    text, _req = pipe.calls[0]
+    # No raw HTML tags survive anywhere in the delivered text.
+    assert "<a href" not in text
+    assert "<b>" not in text
+    assert "<code>" not in text
+    assert "&lt;a href" in text  # escaped form present, so content is preserved
+
+
+async def test_marketing_reply_notifier_strips_control_chars():
+    """Bidi-override / zero-width chars in a display string could visually
+    disguise the sender/subject the owner reads -- strip Cc/Cf categories."""
+    from genesis.outreach.engagement import make_marketing_reply_notifier
+    from genesis.outreach.types import OutreachStatus
+
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+    notifier = make_marketing_reply_notifier(pipe)
+
+    class _R:
+        sender = "ev\u202eil@example.com"  # U+202E RTL override (Cf)
+        subject = "hi\u200bthere\x07"  # U+200B zero-width (Cf) + BEL (Cc)
+        body_preview = "ok"
+        message_id = "<r@example.com>"
+
+    await notifier({"id": "th", "recipient": "p@example.com"}, _R())
+    text, _req = pipe.calls[0]
+    assert "\u202e" not in text  # bidi override stripped
+    assert "\u200b" not in text  # zero-width space stripped
+    assert "\x07" not in text  # control char stripped
+    assert "evil@example.com" in text  # legible content preserved
+
+
+async def test_marketing_reply_notifier_survives_non_delivered():
+    from genesis.outreach.engagement import make_marketing_reply_notifier
+    from genesis.outreach.types import OutreachStatus
+
+    pipe = _FakePipeline(OutreachStatus.FAILED)
+    notifier = make_marketing_reply_notifier(pipe)
+
+    class _R:
+        sender = "x@example.com"
+        subject = ""
+        body_preview = ""
+        message_id = "<r-2@example.com>"
+
+    # A non-DELIVERED result must NOT raise (best-effort ping).
+    await notifier({"id": "th-2", "recipient": "x@example.com"}, _R())
+    assert len(pipe.calls) == 1
+
+
+async def test_end_to_end_genuine_marketing_reply_through_real_notifier(db):
+    """Integration: a genuine marketing_cold reply drives the WHOLE chain —
+    bridge gate → REAL make_marketing_reply_notifier → submit_raw — as one unit
+    (stub-free notifier, so it guards the notifier↔submit_raw seam that a fake
+    _notify can't)."""
+    from genesis.outreach.engagement import (
+        make_marketing_reply_notifier,
+        make_reply_engagement_bridge,
+    )
+    from genesis.outreach.types import OutreachStatus
+
+    await _seed_outreach(db)
+    await _seed_prospect(db)  # recipient target@example.com is a curated prospect
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+    tracker = ThreadTracker(db)
+    await _register_thread(tracker, context={"outreach_id": OUTREACH_ID})
+    poller = ReplyPoller(imap_client=_FakeImap([_reply()]), thread_tracker=tracker)
+    poller.set_engagement_bridge(
+        make_reply_engagement_bridge(
+            EngagementTracker(db), notify_owner=make_marketing_reply_notifier(pipe)
+        )
+    )
+    stats = await poller.poll()
+
+    assert stats["errors"] == 0
+    assert len(pipe.calls) == 1  # genuine reply → real notifier → exactly one submit_raw
+    text, request = pipe.calls[0]
+    assert request.channel == "telegram"
+    assert "target@example.com" in text  # the reply's sender, in the brief ping
+    # Per-reply dedup discriminator is carried in the (non-delivered) context.
+    assert request.topic != request.context
+    # Engagement is still recorded alongside the ping.
+    outcome, signal, _ = await _engagement(db)
+    assert (outcome, signal) == ("useful", "user_reply")
+
+
+async def test_marketing_reply_notifier_dedup_is_per_reply():
+    """Two DISTINCT replies with identical rendered text but different
+    Message-IDs must produce different dedup keys, so submit_raw's
+    content-hash secondary key (outreach/governance.py::_is_duplicate) cannot
+    collapse two genuine replies into a single owner ping. Locks the SHOULD-FIX:
+    reddens if `context` reverts to the delivered text."""
+    from genesis.outreach.engagement import make_marketing_reply_notifier
+    from genesis.outreach.types import OutreachStatus
+
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+    notifier = make_marketing_reply_notifier(pipe)
+
+    class _R1:
+        sender = "same@example.com"
+        subject = "Re: pitch"
+        body_preview = "ok"
+        message_id = "<r-A@example.com>"
+
+    class _R2(_R1):
+        message_id = "<r-B@example.com>"
+
+    thread = {"id": "th", "recipient": "same@example.com"}
+    await notifier(thread, _R1())
+    await notifier(thread, _R2())
+
+    (text1, req1), (text2, req2) = pipe.calls
+    assert text1 == text2  # identical DELIVERED text...
+    assert req1.context != req2.context  # ...but distinct dedup context (per-reply)
+    assert req1.topic != req2.topic

--- a/tests/test_mail/test_reply_poller_engagement.py
+++ b/tests/test_mail/test_reply_poller_engagement.py
@@ -494,6 +494,36 @@ async def test_foreign_sender_does_not_ping(db):
     assert calls == []
 
 
+async def test_unverified_empty_sender_does_not_ping(db):
+    """A reply matched to a prospect thread but with a malformed/unparsable ``From``
+    (a display name with no address → empty parsed sender) slips PAST the
+    sender!=recipient guard, which only rejects when BOTH addresses are truthy.
+    The owner-ping must still NOT fire — we surface only a reply whose sender we
+    positively verified equals the prospect recipient, never an unverified
+    "reply from someone". Engagement recording keeps its pre-existing
+    permissiveness (this test does not assert on it)."""
+    await _seed_outreach(db)
+    await _seed_prospect(db)
+    calls = []
+
+    async def _notify(thread, reply):
+        calls.append(1)
+
+    # From header present (so the reply matches + reaches the bridge) but with an
+    # empty angle-address → parseaddr("Anonymous <>")[1] == "" → the mismatch guard
+    # (needs BOTH addrs truthy) can't reject it, so only the ping's own sender_addr
+    # check stops it. (NB: a bare quoted string like '"X"' parses AS the address, so
+    # it would trip the mismatch guard instead — not the path under test.)
+    no_addr = _reply(from_addr="Anonymous <>")
+    await _run_poll_with_notify(
+        db,
+        thread_context={"outreach_id": OUTREACH_ID},
+        notify_owner=_notify,
+        raws=[no_addr],
+    )
+    assert calls == []  # unverified/empty sender → no owner ping
+
+
 async def test_ping_failure_does_not_break_engagement_or_count_error(db):
     """The owner-ping is best-effort: if notify_owner raises, engagement is still
     recorded and the bridge does NOT report an error — reply tracking must never

--- a/tests/test_mail/test_reply_poller_engagement.py
+++ b/tests/test_mail/test_reply_poller_engagement.py
@@ -533,9 +533,11 @@ class _FakePipeline:
     def __init__(self, status):
         self._status = status
         self.calls = []
+        self.best_effort_flags = []
 
-    async def submit_raw(self, text, request):
+    async def submit_raw(self, text, request, *, best_effort=False):
         self.calls.append((text, request))
+        self.best_effort_flags.append(best_effort)
         from genesis.outreach.types import OutreachResult
 
         return OutreachResult(
@@ -572,6 +574,7 @@ async def test_marketing_reply_notifier_builds_brief_telegram_ping():
     assert "Re: your pitch" in text
     assert "Interesting" in text
     assert "Second line should be dropped" not in text  # only the FIRST preview line
+    assert pipe.best_effort_flags == [True]  # fire-and-forget: never deferred/retried
 
 
 async def test_marketing_reply_notifier_escapes_attacker_html():
@@ -682,9 +685,15 @@ async def test_marketing_reply_notifier_dedup_is_per_reply():
     """Two DISTINCT replies with identical rendered text but different
     Message-IDs must produce different dedup keys, so submit_raw's
     content-hash secondary key (outreach/governance.py::_is_duplicate) cannot
-    collapse two genuine replies into a single owner ping. Locks the SHOULD-FIX:
-    reddens if `context` reverts to the delivered text."""
+    collapse two genuine replies into a single owner ping.
+
+    The rendered text here is LONG (>200 chars) on purpose: content_hash only
+    hashes context[:200] (governance.py::content_hash), so the per-reply
+    discriminator (message_id) must LEAD the context to stay inside the hashed
+    prefix. Reddens if `context` appends message_id after the text (the pre-fix
+    order), where both long replies share an identical first-200-char prefix."""
     from genesis.outreach.engagement import make_marketing_reply_notifier
+    from genesis.outreach.governance import content_hash
     from genesis.outreach.types import OutreachStatus
 
     pipe = _FakePipeline(OutreachStatus.DELIVERED)
@@ -693,7 +702,7 @@ async def test_marketing_reply_notifier_dedup_is_per_reply():
     class _R1:
         sender = "same@example.com"
         subject = "Re: pitch"
-        body_preview = "ok"
+        body_preview = "x" * 300  # long → any trailing discriminator falls past char 200
         message_id = "<r-A@example.com>"
 
     class _R2(_R1):
@@ -707,3 +716,6 @@ async def test_marketing_reply_notifier_dedup_is_per_reply():
     assert text1 == text2  # identical DELIVERED text...
     assert req1.context != req2.context  # ...but distinct dedup context (per-reply)
     assert req1.topic != req2.topic
+    # The load-bearing lock: the discriminator participates in the hashed prefix,
+    # so the secondary content-hash dedup key differs for the two replies.
+    assert content_hash(req1.context) != content_hash(req2.context)


### PR DESCRIPTION
## What

Notify the owner via Telegram when a **genuine human reply** lands on a cold marketing pitch. Notify-only — no change to any send path.

## How

- `make_reply_engagement_bridge(tracker, notify_owner=None)` — after the existing genuine-reply gates (auto-responder + foreign-sender), fire `notify_owner` **iff the thread recipient is a curated marketing prospect** (`marketing_prospects.get_by_email`).
- Recipient-membership is the discriminator, deliberately **not** the thread `signal_type`: the owner-approval resume path (`pipeline.deliver_approved`) rebuilds a held→approved cold send with `signal_type="email_gate_resume"`, so `"marketing_cold"` never survives the default gated path — but the recipient is always a curated prospect (every marketing send resolves its address in-code from `marketing_prospects`). This makes the gate correct and send-path-independent. Membership (not `is_active_recipient`) is intentional: an opted-out prospect who replies is still a real human reply worth surfacing.
- `make_marketing_reply_notifier(pipeline)` — builds ONE brief, verbatim Telegram ping via `submit_raw` (owner-facing, never gated). Per-reply-unique dedup context (keyed on `message_id`) so distinct replies each ping once and only the exact same reply re-processed is deduped.
- `_sanitize_ping_field` — the reply's attacker-controlled `sender`/`subject`/`body` are HTML-escaped (and Unicode `Cc`/`Cf` control/format chars stripped) before delivery: the outreach Telegram delivery path sends with `parse_mode="HTML"` and does not escape, so without this an attacker-controlled field would render as live HTML in the owner's trusted chat.
- Best-effort: a ping failure is logged and swallowed — reply tracking never depends on it and it never counts as a bridge error (`record_reply_if_pending` runs first).

## Tests

26 targeted tests (`tests/test_mail/test_reply_poller_engagement.py`): the gate matrix (prospect / non-prospect / opted-out / auto-responder / foreign-sender), fail-safe isolation on ping failure, HTML-escape of attacker markup, `Cc`/`Cf` control-char stripping, per-reply dedup, and a stub-free real-notifier end-to-end.

## Review

Adversarial architect + security review, both clean for this diff (no BLOCKER / SHOULD-FIX / CRITICAL / HIGH). The `parse_mode="HTML"` unescaped delivery sink and the recipient-membership discriminator were re-derived from source. A follow-up is tracked for an **inherited** gap this diff does not introduce: reply authenticity currently rests on forgeable `In-Reply-To` / `From` matching (no SPF/DKIM/DMARC at mail ingestion) — worth hardening in the mail-ingestion layer before scaling send volume.

Part of the campaign notification layer (session ledger `2591d40317e24cd39a926007b3f47c64`; this PR is the B / marketing-reply half — the C / career-ops half remains).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Telegram notifications when genuine replies arrive from curated marketing prospects.
  * Notifications include the sender and first line of the reply.
  * Duplicate alerts are prevented, and unsafe content is sanitized.

* **Bug Fixes**
  * Automated responses, bounced messages, spoofed senders, and outbound messages no longer trigger alerts.
  * Notification failures do not interrupt dashboard reply tracking or engagement processing.
  * Failed notifications are handled without unnecessary retries.

* **Documentation**
  * Documented notification behavior, deduplication, sanitization, and delivery handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->