### PR TITLE
fix(deliberation): repair the deliberate tool — analysis 404 + real-prompt timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The `deliberate` MCP tool ("Model Fusion") no longer fails on real prompts.** Two
+  distinct bugs: (1) analysis mode 404'd because the orchestrator slug
+  `openai/gpt-oss-120b:free` was retired from OpenRouter's catalog (`:free` variant gone)
+  — switched to the live base slug `openai/gpt-oss-120b`; (2) real multi-paragraph prompts
+  false-timed-out at 240s (a 6-model frontier panel + judge legitimately runs several
+  minutes, while a trivial ping finished in ~33s) — the budget is now a single env-driven
+  knob (`GENESIS_DELIBERATE_TIMEOUT_S`, default 1000s) read per-call and threaded through
+  `core.deliberate()` (which previously hard-pinned 240s, silently overriding the backend
+  default). Also hardened the panels' one remaining concrete `x-ai/grok-4.3` slug to the
+  drift-resistant `~x-ai/grok-latest`.
 - **The morning report no longer cries "surplus heartbeat overdue" during a long
   healthy dispatch.** Surplus emits its subsystem heartbeat only at the end of a
   dispatch cycle, and a single healthy dispatch can run 15-30 minutes — longer than

--- a/scripts/genesis_mcp_server.py
+++ b/scripts/genesis_mcp_server.py
@@ -545,6 +545,11 @@ def main(argv: list[str] | None = None) -> None:
         # switch + size as the server runtime, so a secrets.env-configured
         # value must reach the child too (Codex P2 on #1302)
         "GENESIS_RECALL_READ_POOL_OFF", "GENESIS_RECALL_READ_POOL_SIZE",
+        # deliberate() (Model Fusion) timeout budget — the health MCP server hosts the
+        # `deliberate` tool, so a secrets.env-set override must reach this child or the
+        # documented knob is inert and every call silently stays at the 1000s default
+        # (Codex P2 on #1587).
+        "GENESIS_DELIBERATE_TIMEOUT_S",
     }
     import os
 

--- a/src/genesis/deliberation/backends/fusion.py
+++ b/src/genesis/deliberation/backends/fusion.py
@@ -10,7 +10,7 @@ Two modes × two presets, all probe-confirmed live (2026-06-24; orchestrator slu
 - **synthesis** (default, fast): the `openrouter/fusion` model-slug → a synthesized prose verdict in
   ``message.content`` (the meta-model IGNORES output-format prompts, so we take its markdown as the
   ``answer``; consensus/dissent stay empty). Default preset: **budget**.
-- **analysis** (deep): a free, tool-capable orchestrator + the Fusion *server-tool*
+- **analysis** (deep): a tool-capable orchestrator + the Fusion *server-tool*
   (`tools:[{"type":"openrouter:fusion"}]`, `tool_choice:"required"`, via extra_body) → the orchestrator
   (a normal instruct model that honors a JSON system prompt) returns machine-structured
   {answer, consensus, dissent[], blind_spots[], confidence}. Default preset: **strong**.
@@ -37,6 +37,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 import time
@@ -144,7 +145,8 @@ def _default_timeout_s() -> float:
     """The deliberation timeout budget (seconds), overridable via ``GENESIS_DELIBERATE_TIMEOUT_S``.
 
     Read per-CALL (not at import) so a runtime env change / test takes effect without a reload.
-    A non-positive or unparseable value falls back to ``_DEFAULT_TIMEOUT_S``.
+    A non-positive, non-FINITE (``inf``/``nan``), or unparseable value falls back to
+    ``_DEFAULT_TIMEOUT_S`` — an infinite budget would let a hung panel wait forever.
     """
     raw = os.environ.get("GENESIS_DELIBERATE_TIMEOUT_S")
     if raw:
@@ -152,7 +154,7 @@ def _default_timeout_s() -> float:
             v = float(raw)
         except (TypeError, ValueError):
             return _DEFAULT_TIMEOUT_S
-        if v > 0:
+        if math.isfinite(v) and v > 0:
             return v
     return _DEFAULT_TIMEOUT_S
 
@@ -215,9 +217,22 @@ async def _call(model, system, user, key, timeout_s, extra_body, mode, preset) -
     t0 = time.perf_counter()
     last_exc: Exception | None = None
     for attempt in range(_MAX_ATTEMPTS):
+        # The budget is a TOTAL wall-clock bound, not per-attempt: a retry gets only the
+        # REMAINING budget (prior attempts + backoff sleeps are already counted via t0), so
+        # N retries can't multiply the user's max wait by N. Once exhausted, stop rather than
+        # start another full-timeout attempt.
+        remaining = timeout_s - (time.perf_counter() - t0)
+        if remaining <= 0:
+            return DeliberationResult(
+                answer=None,
+                backend_used=f"fusion/{mode}",
+                preset_used=preset,
+                latency_s=time.perf_counter() - t0,
+                error=f"fusion ({mode}) timed out after ~{timeout_s:.0f}s",
+            )
         try:
             content, cost, stream_err = await asyncio.wait_for(
-                _consume_stream(body, key, timeout_s), timeout=timeout_s + 10
+                _consume_stream(body, key, remaining), timeout=remaining + 10
             )
         except (TimeoutError, httpx.TimeoutException):
             return DeliberationResult(

--- a/src/genesis/deliberation/backends/fusion.py
+++ b/src/genesis/deliberation/backends/fusion.py
@@ -204,6 +204,15 @@ class FusionBackend:
         return await _call(_MODEL, _SYNTHESIS_SYSTEM + high, user, key, timeout_s, extra, "synthesis", preset_name)
 
 
+async def _bounded_backoff(attempt: int, t0: float, timeout_s: float) -> None:
+    """Sleep the retry backoff, but never past the total deadline — so the backoff itself
+    can't blow the budget (e.g. a 3s backoff on a 1s budget). Sleeps nothing if exhausted."""
+    remaining = timeout_s - (time.perf_counter() - t0)
+    if remaining <= 0:
+        return
+    await asyncio.sleep(min(_BACKOFF_S * (attempt + 1), remaining))
+
+
 async def _call(model, system, user, key, timeout_s, extra_body, mode, preset) -> DeliberationResult:
     body = {
         "model": model,
@@ -231,8 +240,10 @@ async def _call(model, system, user, key, timeout_s, extra_body, mode, preset) -
                 error=f"fusion ({mode}) timed out after ~{timeout_s:.0f}s",
             )
         try:
+            # wait_for bounded by `remaining` (NOT remaining+10): it is the hard total-budget
+            # deadline, so a stalled/keep-alive-chatty stream can't run past the advertised budget.
             content, cost, stream_err = await asyncio.wait_for(
-                _consume_stream(body, key, remaining), timeout=remaining + 10
+                _consume_stream(body, key, remaining), timeout=remaining
             )
         except (TimeoutError, httpx.TimeoutException):
             return DeliberationResult(
@@ -245,14 +256,14 @@ async def _call(model, system, user, key, timeout_s, extra_body, mode, preset) -
         except httpx.HTTPStatusError as exc:
             last_exc = exc
             if exc.response.status_code in _RETRYABLE_STATUS and attempt + 1 < _MAX_ATTEMPTS:
-                await asyncio.sleep(_BACKOFF_S * (attempt + 1))
+                await _bounded_backoff(attempt, t0, timeout_s)
                 continue
             return _error_result(exc, time.perf_counter() - t0, mode, preset)
         except httpx.TransportError as exc:
             # connection reset / read error mid-panel — transient, retry
             last_exc = exc
             if attempt + 1 < _MAX_ATTEMPTS:
-                await asyncio.sleep(_BACKOFF_S * (attempt + 1))
+                await _bounded_backoff(attempt, t0, timeout_s)
                 continue
             return _error_result(exc, time.perf_counter() - t0, mode, preset)
         except Exception as exc:  # noqa: BLE001 — any other error → graceful result, never raise
@@ -261,7 +272,7 @@ async def _call(model, system, user, key, timeout_s, extra_body, mode, preset) -
             if not content and attempt + 1 < _MAX_ATTEMPTS:
                 # transient empty / in-stream panel error from a flaky panel — one more shot
                 last_exc = RuntimeError(stream_err or "empty stream")
-                await asyncio.sleep(_BACKOFF_S * (attempt + 1))
+                await _bounded_backoff(attempt, t0, timeout_s)
                 continue
             return _normalize(content, cost, stream_err, time.perf_counter() - t0, mode, preset)
     return _error_result(last_exc or RuntimeError("retries exhausted"), time.perf_counter() - t0, mode, preset)

--- a/src/genesis/deliberation/backends/fusion.py
+++ b/src/genesis/deliberation/backends/fusion.py
@@ -1,6 +1,11 @@
 """Fusion backend — OpenRouter Fusion (a server-side panel-of-models + judge).
 
-Two modes × two presets, all probe-confirmed live (2026-06-24):
+Latency scales with prompt size: a trivial ping finishes in tens of seconds, but a real
+(multi-paragraph) prompt on a 6-model frontier panel + judge runs several MINUTES. The budget is
+therefore generous (``_DEFAULT_TIMEOUT_S``, env-overridable via ``GENESIS_DELIBERATE_TIMEOUT_S``);
+the old 240s false-timed-out real prompts.
+
+Two modes × two presets, all probe-confirmed live (2026-06-24; orchestrator slug refreshed 2026-09-01):
 
 - **synthesis** (default, fast): the `openrouter/fusion` model-slug → a synthesized prose verdict in
   ``message.content`` (the meta-model IGNORES output-format prompts, so we take its markdown as the
@@ -45,8 +50,11 @@ logger = logging.getLogger(__name__)
 _OR_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
 # synthesis: the `openrouter/fusion` model-slug — the meta-model itself (raw OpenRouter id, probe-confirmed).
 _MODEL = "openrouter/fusion"
-# analysis: a free, tool-capable orchestrator that calls the fusion server-tool and returns structured JSON.
-_ANALYSIS_ORCHESTRATOR = "openai/gpt-oss-120b:free"
+# analysis: a tool-capable orchestrator that calls the fusion server-tool and returns structured JSON.
+# NB: the `:free` variant was retired from OpenRouter's catalog (base + `:batch` remain) → the old
+# `openai/gpt-oss-120b:free` 404'd the analysis-mode call. Base slug; the orchestrator is a thin caller
+# so its small paid cost is negligible next to the fusion panel.
+_ANALYSIS_ORCHESTRATOR = "openai/gpt-oss-120b"
 
 # Explicit chorus panels (`analysis_models`) + judge (`model`) per preset. EDIT THESE to change the
 # chorus. `~…-latest` ids float to the newest version. Panel/judge models need NOT support tools.
@@ -56,7 +64,7 @@ _PRESET_PANELS: dict[str, dict] = {
             "~anthropic/claude-opus-latest",
             "~openai/gpt-latest",
             "~google/gemini-pro-latest",
-            "x-ai/grok-4.3",
+            "~x-ai/grok-latest",
             "deepseek/deepseek-v4-pro",
             "~moonshotai/kimi-latest",
         ],
@@ -66,7 +74,7 @@ _PRESET_PANELS: dict[str, dict] = {
         "analysis_models": [
             "deepseek/deepseek-v4-pro",
             "~openai/gpt-mini-latest",
-            "x-ai/grok-4.3",
+            "~x-ai/grok-latest",
             "qwen/qwen3-235b-a22b-thinking-2507",
             "~moonshotai/kimi-latest",
             "~google/gemini-flash-latest",
@@ -78,7 +86,10 @@ _PRESET_PANELS: dict[str, dict] = {
 _DEFAULT_PRESET = {"synthesis": "budget", "analysis": "strong"}
 
 _MAX_TOKENS = 2000  # explicit — the 65536 default trips OpenRouter's "fewer max_tokens" 402.
-_DEFAULT_TIMEOUT_S = 240.0  # analysis (panel + judge + orchestrator) runs ~120-170s; synthesis ~47-110s.
+# Deliberation budget. A real 6-model frontier panel + judge on a real (multi-paragraph) prompt
+# legitimately runs several MINUTES — the old 240s false-timed-out real prompts while a trivial ping
+# finished in ~33s. Generous by default; env-overridable at runtime (GENESIS_DELIBERATE_TIMEOUT_S).
+_DEFAULT_TIMEOUT_S = 1000.0
 _ANSWER_CAP = 6000
 # deliberate() owns its own retry on TRANSIENT errors (frontier panels 429 under load — observed on the
 # strong preset). Retried: 429/5xx + transport errors. NOT retried: other 4xx and timeouts.
@@ -129,6 +140,23 @@ def _resolve_stakes(stakes: str | None, mode: str, preset_name: str) -> str:
     return "high" if (mode == "analysis" or preset_name == "strong") else "normal"
 
 
+def _default_timeout_s() -> float:
+    """The deliberation timeout budget (seconds), overridable via ``GENESIS_DELIBERATE_TIMEOUT_S``.
+
+    Read per-CALL (not at import) so a runtime env change / test takes effect without a reload.
+    A non-positive or unparseable value falls back to ``_DEFAULT_TIMEOUT_S``.
+    """
+    raw = os.environ.get("GENESIS_DELIBERATE_TIMEOUT_S")
+    if raw:
+        try:
+            v = float(raw)
+        except (TypeError, ValueError):
+            return _DEFAULT_TIMEOUT_S
+        if v > 0:
+            return v
+    return _DEFAULT_TIMEOUT_S
+
+
 class FusionBackend:
     """OpenRouter Fusion backend — `synthesis` (model-slug) and `analysis` (server-tool) modes."""
 
@@ -142,15 +170,21 @@ class FusionBackend:
         stakes: str | None = None,
         mode: str = "synthesis",
         preset: str | None = None,
-        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        timeout_s: float | None = None,
         models: list[str] | None = None,  # noqa: ARG002 — panel is set via preset, not a client list
     ) -> DeliberationResult:
-        """Deliberate via Fusion in the given mode/preset. Returns a DeliberationResult; never raises."""
+        """Deliberate via Fusion in the given mode/preset. Returns a DeliberationResult; never raises.
+
+        ``timeout_s`` ``None`` (the default, used by the MCP tool) resolves to
+        ``_default_timeout_s()`` (env ``GENESIS_DELIBERATE_TIMEOUT_S``, else ``_DEFAULT_TIMEOUT_S``).
+        An explicit value overrides.
+        """
         key = _openrouter_key()
         if not key:
             return DeliberationResult(
                 answer=None, error="OpenRouter API key not configured (API_KEY_OPENROUTER)"
             )
+        timeout_s = timeout_s if timeout_s is not None else _default_timeout_s()
         user = question if not context else f"{question}\n\nContext:\n{context}"
         preset_name, panel = _resolve_preset(preset, mode)
         high = _HIGH_SUFFIX if _resolve_stakes(stakes, mode, preset_name) == "high" else ""

--- a/src/genesis/deliberation/core.py
+++ b/src/genesis/deliberation/core.py
@@ -28,7 +28,7 @@ async def deliberate(
     backend: str = "fusion",
     mode: str = "synthesis",
     preset: str | None = None,
-    timeout_s: float = 240.0,
+    timeout_s: float | None = None,
     models: list[str] | None = None,
 ) -> DeliberationResult:
     """Run a question through a chorus of models and return verdict + dissent.

--- a/src/genesis/mcp/health/deliberation_tools.py
+++ b/src/genesis/mcp/health/deliberation_tools.py
@@ -80,8 +80,10 @@ async def deliberate(
       context:  optional background to ground the panel.
       stakes:   "" (default) auto-couples — high for analysis or the strong preset, else normal.
                 Pass "normal"/"high" to override (high weights dissent more heavily).
-      mode:     "synthesis" (default) = fast prose verdict; "analysis" = deeper (~2-3min)
-                machine-structured consensus + dissent[] + blind_spots[] (always the strong panel).
+      mode:     "synthesis" (default) = fast prose verdict; "analysis" = deeper, machine-structured
+                consensus + dissent[] + blind_spots[] (always the strong panel). Latency scales with
+                prompt size — a real multi-paragraph prompt on the frontier panel runs several minutes
+                (budget: env GENESIS_DELIBERATE_TIMEOUT_S, default 1000s).
       preset:   "" = mode default (synthesis→budget, analysis→strong); "strong" = frontier panel
                 (opus/gpt/gemini/grok/deepseek/kimi, gpt judge); "budget" = mid-tier panel
                 (deepseek/gpt-mini/grok/qwen/kimi/gemini-flash, sonnet judge — cheaper/faster).

--- a/tests/test_deliberation/test_deliberate.py
+++ b/tests/test_deliberation/test_deliberate.py
@@ -331,19 +331,20 @@ def test_default_timeout_env_overridable(monkeypatch):
 
 
 async def test_timeout_is_total_budget_across_retries(monkeypatch):
-    # The budget bounds TOTAL wall time, not each attempt: a retry gets only the REMAINING
-    # budget, and once it's spent the loop STOPS instead of launching another full-timeout
-    # attempt (so 3 retries can't multiply the user's max wait by 3). Deterministic fake clock
-    # (perf_counter monkeypatched — NOT wall-clock): t0=0; attempt 1 runs with the full 100s;
-    # by attempt 2 the clock reads 60 → remaining 40; then it jumps past the budget so a 3rd
-    # attempt is refused.
+    # The budget bounds TOTAL wall time, not each attempt: each retry gets only the REMAINING
+    # budget (monotonically shrinking as time passes), never exceeds the total, and the loop
+    # terminates rather than launching N full-timeout attempts. Deterministic MONOTONIC fake
+    # clock (perf_counter monkeypatched — NOT wall-clock): every read advances 15 "seconds".
     monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
     monkeypatch.setattr("genesis.deliberation.backends.fusion._BACKOFF_S", 0.0)
-    times = [0.0, 0.0, 60.0, 200.0, 200.0, 200.0]
-    monkeypatch.setattr(
-        "genesis.deliberation.backends.fusion.time.perf_counter",
-        lambda: times.pop(0) if times else 200.0,
-    )
+    ticks = {"n": 0}
+
+    def fake_perf() -> float:
+        v = ticks["n"] * 15.0
+        ticks["n"] += 1
+        return v
+
+    monkeypatch.setattr("genesis.deliberation.backends.fusion.time.perf_counter", fake_perf)
     seen: list[float] = []
 
     async def fake_stream(body, key, t):
@@ -352,10 +353,33 @@ async def test_timeout_is_total_budget_across_retries(monkeypatch):
 
     monkeypatch.setattr("genesis.deliberation.backends.fusion._consume_stream", fake_stream)
     r = await FusionBackend().run("q", timeout_s=100.0)
-    # attempt 1 got the full 100s remaining; attempt 2 got only 40s (100 - 60 elapsed), NOT 100;
-    # attempt 3 was refused because the budget was exhausted (only 2 stream calls total).
-    assert seen == [100.0, 40.0]
-    assert not r.ok
+    assert len(seen) >= 2, seen  # it retried at least once
+    assert all(t <= 100.0 for t in seen), seen  # no attempt exceeds the TOTAL budget
+    assert seen == sorted(seen, reverse=True) and len(set(seen)) == len(seen), seen  # strictly shrinking
+    assert not r.ok  # exhausting the budget yields a graceful failure, never a hang
+
+
+async def test_bounded_backoff_never_exceeds_remaining(monkeypatch):
+    # A retry backoff must never blow the total budget: it is capped by the remaining deadline
+    # (a 3s backoff on a budget with 0.1s left sleeps 0.1s), and sleeps nothing once exhausted.
+    from genesis.deliberation.backends import fusion as fmod
+
+    monkeypatch.setattr(fmod, "_BACKOFF_S", 3.0)
+    slept: list[float] = []
+
+    async def fake_sleep(s):
+        slept.append(s)
+
+    monkeypatch.setattr(fmod.asyncio, "sleep", fake_sleep)
+    # 0.9s already elapsed of a 1.0s budget → raw backoff 3.0 capped to 0.1
+    monkeypatch.setattr(fmod.time, "perf_counter", lambda: 0.9)
+    await fmod._bounded_backoff(0, 0.0, 1.0)
+    assert slept == [pytest.approx(0.1)]
+    # budget exhausted → no sleep at all
+    slept.clear()
+    monkeypatch.setattr(fmod.time, "perf_counter", lambda: 2.0)
+    await fmod._bounded_backoff(0, 0.0, 1.0)
+    assert slept == []
 
 
 async def test_timeout_threads_env_to_http_layer(monkeypatch):

--- a/tests/test_deliberation/test_deliberate.py
+++ b/tests/test_deliberation/test_deliberate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import httpx
+import pytest
 
 from genesis.deliberation import DeliberationResult, deliberate
 from genesis.deliberation.backends.fusion import (
@@ -323,6 +324,38 @@ def test_default_timeout_env_overridable(monkeypatch):
     assert _default_timeout_s() == _DEFAULT_TIMEOUT_S
     monkeypatch.setenv("GENESIS_DELIBERATE_TIMEOUT_S", "not-a-number")
     assert _default_timeout_s() == _DEFAULT_TIMEOUT_S
+    # non-FINITE values are rejected too — an infinite budget would let a hung panel wait forever
+    for bad in ("inf", "Infinity", "-inf", "nan"):
+        monkeypatch.setenv("GENESIS_DELIBERATE_TIMEOUT_S", bad)
+        assert _default_timeout_s() == _DEFAULT_TIMEOUT_S, bad
+
+
+async def test_timeout_is_total_budget_across_retries(monkeypatch):
+    # The budget bounds TOTAL wall time, not each attempt: a retry gets only the REMAINING
+    # budget, and once it's spent the loop STOPS instead of launching another full-timeout
+    # attempt (so 3 retries can't multiply the user's max wait by 3). Deterministic fake clock
+    # (perf_counter monkeypatched — NOT wall-clock): t0=0; attempt 1 runs with the full 100s;
+    # by attempt 2 the clock reads 60 → remaining 40; then it jumps past the budget so a 3rd
+    # attempt is refused.
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    monkeypatch.setattr("genesis.deliberation.backends.fusion._BACKOFF_S", 0.0)
+    times = [0.0, 0.0, 60.0, 200.0, 200.0, 200.0]
+    monkeypatch.setattr(
+        "genesis.deliberation.backends.fusion.time.perf_counter",
+        lambda: times.pop(0) if times else 200.0,
+    )
+    seen: list[float] = []
+
+    async def fake_stream(body, key, t):
+        seen.append(t)
+        raise httpx.ConnectError("reset")  # retryable → the loop continues
+
+    monkeypatch.setattr("genesis.deliberation.backends.fusion._consume_stream", fake_stream)
+    r = await FusionBackend().run("q", timeout_s=100.0)
+    # attempt 1 got the full 100s remaining; attempt 2 got only 40s (100 - 60 elapsed), NOT 100;
+    # attempt 3 was refused because the budget was exhausted (only 2 stream calls total).
+    assert seen == [100.0, 40.0]
+    assert not r.ok
 
 
 async def test_timeout_threads_env_to_http_layer(monkeypatch):
@@ -333,10 +366,12 @@ async def test_timeout_threads_env_to_http_layer(monkeypatch):
     monkeypatch.setenv("GENESIS_DELIBERATE_TIMEOUT_S", "777")
     with patch(_STREAM, new=AsyncMock(return_value=(JSON_OK, 0.05, None))) as m:
         await FusionBackend().run("q")  # timeout_s omitted → None → env default
-    assert m.call_args.args[2] == 777.0  # _consume_stream(body, key, timeout_s)
+    # _consume_stream(body, key, remaining) — remaining ≈ full budget on the first attempt
+    # (a tiny elapsed is subtracted now that the budget is a total-wall-clock bound).
+    assert m.call_args.args[2] == pytest.approx(777.0, abs=1.0)
     with patch(_STREAM, new=AsyncMock(return_value=(JSON_OK, 0.05, None))) as m2:
         await FusionBackend().run("q", timeout_s=99.0)  # explicit wins
-    assert m2.call_args.args[2] == 99.0
+    assert m2.call_args.args[2] == pytest.approx(99.0, abs=1.0)
 
 
 async def test_deliberate_core_threads_env_timeout(monkeypatch):
@@ -346,7 +381,7 @@ async def test_deliberate_core_threads_env_timeout(monkeypatch):
     monkeypatch.setenv("GENESIS_DELIBERATE_TIMEOUT_S", "633")
     with patch(_STREAM, new=AsyncMock(return_value=(JSON_OK, 0.05, None))) as m:
         await deliberate("q", backend="fusion")
-    assert m.call_args.args[2] == 633.0
+    assert m.call_args.args[2] == pytest.approx(633.0, abs=1.0)
 
 
 async def test_fusion_http_400_no_retry(monkeypatch):

--- a/tests/test_deliberation/test_deliberate.py
+++ b/tests/test_deliberation/test_deliberate.py
@@ -8,8 +8,10 @@ import httpx
 
 from genesis.deliberation import DeliberationResult, deliberate
 from genesis.deliberation.backends.fusion import (
+    _DEFAULT_TIMEOUT_S,
     _PRESET_PANELS,
     FusionBackend,
+    _default_timeout_s,
     _normalize,
     _parse_content,
     _parse_sse,
@@ -238,7 +240,10 @@ async def test_fusion_analysis_mode_request(monkeypatch):
     assert r.ok and len(r.dissent) == 3 and r.backend_used == "fusion/analysis"
     assert r.preset_used == "strong"  # analysis default preset
     body = m.call_args.args[0]
-    assert body["model"] == "openai/gpt-oss-120b:free"
+    # Bug-1 lock: the analysis orchestrator must be a LIVE slug. The `:free` variant was retired
+    # from OpenRouter (404'd the whole analysis call); the base slug is current.
+    assert body["model"] == "openai/gpt-oss-120b"
+    assert not body["model"].endswith(":free")
     assert body["tools"][0]["type"] == "openrouter:fusion"
     params = body["tools"][0]["parameters"]  # analysis default preset → strong panel
     assert params["analysis_models"] == _PRESET_PANELS["strong"]["analysis_models"]
@@ -303,6 +308,45 @@ async def test_fusion_timeout_graceful(monkeypatch):
     with patch(_STREAM, new=AsyncMock(side_effect=httpx.ReadTimeout("slow"))):
         r = await FusionBackend().run("q", timeout_s=1.0)
     assert not r.ok and "timed out" in r.error
+
+
+# ── Bug 2: the timeout budget is env-configurable and threads through to the HTTP layer ──
+
+
+def test_default_timeout_env_overridable(monkeypatch):
+    monkeypatch.delenv("GENESIS_DELIBERATE_TIMEOUT_S", raising=False)
+    assert _default_timeout_s() == _DEFAULT_TIMEOUT_S  # default when unset
+    monkeypatch.setenv("GENESIS_DELIBERATE_TIMEOUT_S", "512")
+    assert _default_timeout_s() == 512.0
+    # a non-positive / unparseable value falls back to the default (fail-safe, not a 0s timeout)
+    monkeypatch.setenv("GENESIS_DELIBERATE_TIMEOUT_S", "-5")
+    assert _default_timeout_s() == _DEFAULT_TIMEOUT_S
+    monkeypatch.setenv("GENESIS_DELIBERATE_TIMEOUT_S", "not-a-number")
+    assert _default_timeout_s() == _DEFAULT_TIMEOUT_S
+
+
+async def test_timeout_threads_env_to_http_layer(monkeypatch):
+    # timeout_s=None (the MCP-tool default) resolves to the env budget and reaches _consume_stream
+    # (its 3rd positional arg). An explicit timeout_s overrides. This is what makes the raised
+    # budget actually apply to real calls — the old 240s was hard-pinned in core.deliberate().
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    monkeypatch.setenv("GENESIS_DELIBERATE_TIMEOUT_S", "777")
+    with patch(_STREAM, new=AsyncMock(return_value=(JSON_OK, 0.05, None))) as m:
+        await FusionBackend().run("q")  # timeout_s omitted → None → env default
+    assert m.call_args.args[2] == 777.0  # _consume_stream(body, key, timeout_s)
+    with patch(_STREAM, new=AsyncMock(return_value=(JSON_OK, 0.05, None))) as m2:
+        await FusionBackend().run("q", timeout_s=99.0)  # explicit wins
+    assert m2.call_args.args[2] == 99.0
+
+
+async def test_deliberate_core_threads_env_timeout(monkeypatch):
+    # core.deliberate() no longer hard-pins 240s: with no explicit timeout_s it defers to the
+    # backend's env-driven default all the way to the HTTP layer.
+    monkeypatch.setenv("API_KEY_OPENROUTER", "test-key")
+    monkeypatch.setenv("GENESIS_DELIBERATE_TIMEOUT_S", "633")
+    with patch(_STREAM, new=AsyncMock(return_value=(JSON_OK, 0.05, None))) as m:
+        await deliberate("q", backend="fusion")
+    assert m.call_args.args[2] == 633.0
 
 
 async def test_fusion_http_400_no_retry(monkeypatch):


### PR DESCRIPTION
## Problem

The `deliberate` MCP tool ("Model Fusion" — OpenRouter Fusion panel+judge) failed on every
real-content prompt; only a trivial ping worked (tracked: tabled follow-up `7d786274`). Two
distinct, verified bugs.

## Fixes

**1. Analysis-mode 404.** The orchestrator slug `openai/gpt-oss-120b:free` was retired from
OpenRouter's catalog (base + `:batch` remain; `:free` is gone), so the top-level model of every
analysis call 404'd. Root cause differs from the follow-up's guess ("bad slug in the strong
panel"): the **live catalog** confirms all panel `~vendor/family-latest` variants are alive, and
synthesis (same panel via `plugins`) *timed out* rather than 404'd — the 404 is orchestrator-specific.
→ `openai/gpt-oss-120b` (base, live).

**2. Real-prompt timeout.** The *effective* budget was `core.deliberate()`'s hard-pinned **240s**
(the MCP wrapper never passes `timeout_s`, so core's default silently overrode the backend). A real
6-model-panel prompt legitimately runs minutes. → a single env-driven knob
`GENESIS_DELIBERATE_TIMEOUT_S` (default **1000s**), read per-call and threaded core→backend→HTTP;
core no longer hard-pins a value.

**Bonus:** hardened the panels' one remaining concrete `x-ai/grok-4.3` → `~x-ai/grok-latest`
(the existing `~…-latest` drift-resistant design).

## Verification

Unit (mocked HTTP): lock the analysis orchestrator against a `:free`/dead slug; lock env-timeout
threading core→backend→`_consume_stream` (+ explicit-override + fail-safe parse). **Verify-RED**
confirmed by reproducing both original bugs. 51 tests pass; ruff clean.

**Live paid verification** (real multi-paragraph prompt, worktree code):
| call | error | latency | cost |
|---|---|---|---|
| analysis+strong | **null (404 gone)** | 122.8s | $0.18 |
| synthesis+budget | null | **271.1s** | $0.32 |

The synthesis run's **271s > the old 240s budget** — that exact prompt would have timed out before;
it completes under 1000s. Direct measured proof of fix #2.

## Newly-exposed issue (tracked separately, NOT bundled)

The live runs revealed that analysis mode returns content but **not** the structured
`{consensus, dissent[], blind_spots[]}` it promises — the orchestrator echoes the fusion tool's raw
panel dump instead of synthesizing JSON. This is **pre-existing** (masked by the 404; the old `:free`
was the same model family), not a regression. The tool is **no longer "down"** (it returns rich,
usable verdicts — every frontier model's full reasoning). Fix candidate = a stronger
instruction-following orchestrator, needs its own paid live test → follow-up `ef91648b`.

Resolves the 404 + timeout scope of follow-up `7d786274`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the deliberation tool by replacing retired model configurations.
  * Updated Grok analysis to use the latest available model identifier.

* **Improvements**
  * Increased the default deliberation timeout to 1,000 seconds.
  * Added environment-based timeout configuration with validation for invalid values.
  * Ensured retries share a single overall timeout budget.
  * Improved guidance about expected analysis duration and timeout settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->