### PR TITLE
fix(surplus): flag heavy_workload across a long dispatch so the watchdog does not restart-loop

### DIFF
--- a/src/genesis/surplus/dispatch.py
+++ b/src/genesis/surplus/dispatch.py
@@ -426,40 +426,70 @@ def _filter_tiers_for_network(tiers: list[ComputeTier]) -> list[ComputeTier]:
 
 async def dispatch_once(sched: DispatchContext) -> bool:
     """Single dispatch cycle. Returns True if a task was processed."""
-    # Flag the WHOLE dispatch cycle — setup phases (recover/drain/reap/select) AND the
-    # executor — as a heavy workload so the 900s zombie-scheduler watchdog FORGIVES a
-    # stall ANYWHERE in dispatch_once, not just inside a long executor. The dispatch
-    # loop refreshes the surplus heartbeat only BETWEEN dispatches (scheduler.py), so a
-    # single dispatch_once that blocks — whether in a 25-min executor (j9) OR in a setup
-    # phase (the 2026-09-01 incident: 3 of 4 zombie restarts had NO task running) —
-    # gaps the heartbeat past 900s and triggers a restart. Setting the flag at ENTRY,
-    # before recover_stuck, closes the setup-phase half that #1588 left open (its flag
-    # was set only AFTER task selection). Covers ALL long surplus executors (j9,
-    # model_eval, wing_audit, code_audit) too. The runtime flag auto-expires after 2h
-    # (runtime/_core.py), so a genuinely HUNG cycle is still caught — forgives long, not
-    # dead. Propagates to the watchdog via status.json (status_writer runs on its own
-    # 60s loop, decoupled from this one — verified), so the flag is seen as long as the
-    # event loop stays responsive (a truly-blocked loop is a real hang, correctly NOT
-    # masked). (Mirrors the dream jobs; direct-attr writes match dream.py.)
+    # Setup phases (recover/drain/reap/select) are TIMED but NOT heavy_workload-covered.
+    # `_timed_phase` logs a WARNING if any phase runs abnormally long — the diagnostic
+    # for the 2026-09-01 incident's still-unidentified "zombie restart with NO task
+    # running" mechanism (localizes a stalling setup phase). We deliberately do NOT
+    # forgive a setup-phase stall: (1) a genuine stall here is a real hang the 900s
+    # watchdog SHOULD catch, and (2) the heavy_workload flag cannot be reliably published
+    # while a setup phase holds the shared DB connection anyway — status_writer awaits
+    # DB-backed counts before reading the flag (Codex #1588 P1). heavy_workload is scoped
+    # to the EXECUTOR below, the one case it reliably covers (a long j9 executor that does
+    # not hold the DB lock). Robust setup-phase coverage waits on the instrumentation
+    # identifying the real mechanism (heavy_workload-hardening follow-up).
+    with _timed_phase("recover_stuck"):
+        await sched._queue.recover_stuck()
+
+    with _timed_phase("drain_expired"):
+        await sched._queue.drain_expired(max_age_hours=sched._task_expiry_hours)
+
+    # Age-cap terminal rows (completed/failed/cancelled) so they don't accumulate
+    # forever — drain_expired only touches pending.
+    with _timed_phase("reap_terminal"):
+        await sched._queue.reap_terminal(older_than_days=sched._terminal_retention_days)
+
+    # Check idle
+    if not sched._idle_detector.is_idle():
+        return False
+
+    with _timed_phase("get_available_tiers"):
+        available_tiers = await sched._compute.get_available_tiers()
+
+    # Outage awareness (PR-3): when the network is hard-OFFLINE, strip cloud tiers so
+    # internet-dependent tasks stay `pending` instead of churning into a dead network.
+    available_tiers = _filter_tiers_for_network(available_tiers)
+
+    with _timed_phase("next_task"):
+        task = await sched._queue.next_task(available_tiers)
+    if task is None:
+        return False
+
+    # Execute
+    logger.info("Dispatching surplus task %s (%s)", task.id, task.task_type)
+    await sched._queue.mark_running(task.id)
+
+    executor = _select_executor(sched, task)
+
+    # Flag the EXECUTOR (+ intake routing + completion) as a heavy workload so the 900s
+    # zombie-scheduler watchdog FORGIVES a single long-running task (e.g. j9_eval_batch
+    # ~25 min) that would otherwise gap the dispatch-loop heartbeat and trigger a restart.
+    # Covers ALL long surplus executors (j9, model_eval, wing_audit, code_audit). The
+    # runtime flag auto-expires after 2h (runtime/_core.py), so a genuinely HUNG task is
+    # still caught — forgives long, not dead. (Mirrors the dream jobs; direct-attr writes
+    # match dream.py.) CLAIM ONLY A FREE SLOT (a single process-wide slot the dream jobs
+    # also use) and clear only what WE set.
     #
-    # CLAIM ONLY A FREE SLOT: the flag is a single process-wide slot the dream jobs
-    # also use. Overwriting it would clear a concurrent dream's protection when THIS
-    # (short) dispatch finishes, leaving the dream unprotected mid-cycle. So we set
-    # only when the slot is free, and clear only what WE set. Any truthy label already
-    # forgives the watchdog, so declining to claim still leaves us covered. A GENERIC
-    # label (not the task-type) is used because the flag is now claimed before a task
-    # is selected — and any truthy label forgives identically.
-    #
-    # NOTE: while set, this also defers the sentinel's restart remediation
-    # (sentinel/dispatcher.py Gate 2.5 reads heavy_workload). That now applies to every
-    # dispatch cycle (incl. brief idle no-ops), not just long tasks — intended (a
-    # running dispatch is genuine work), low harm (the sentinel retries), and the window
-    # is milliseconds for an idle cycle.
+    # KNOWN LIMITATIONS (pre-existing to the single-slot flag; tracked in the
+    # heavy_workload-hardening follow-up, NOT fixed here): the slot is not ref-counted, so
+    # a concurrent dream that stomps+clears it can drop this dispatch's protection mid-run
+    # (rare: dream overlap + long dispatch + dream finishes first); and the flag reaches
+    # the watchdog only via status.json, which the status writer builds AFTER DB-backed
+    # counts, so a DB stall can hide it. Both need a ref-counted + DB-independent publish.
     from datetime import UTC, datetime
 
     from genesis.runtime import GenesisRuntime
 
-    _hw_label = "surplus:dispatch"
+    _hw_label = f"surplus:{task.task_type}"
     _hw_rt = None
     _hw_did_set = False
     with contextlib.suppress(Exception):
@@ -470,46 +500,6 @@ async def dispatch_once(sched: DispatchContext) -> bool:
             _hw_rt, _hw_did_set = _rt, True
 
     try:
-        # 0. Recover tasks stuck in 'running' state (crashed mid-execution)
-        with _timed_phase("recover_stuck"):
-            await sched._queue.recover_stuck()
-
-        # 1. Drain expired pending tasks
-        with _timed_phase("drain_expired"):
-            await sched._queue.drain_expired(max_age_hours=sched._task_expiry_hours)
-
-        # 1b. Age-cap terminal rows (completed/failed/cancelled) so they don't
-        # accumulate forever — drain_expired only touches pending.
-        with _timed_phase("reap_terminal"):
-            await sched._queue.reap_terminal(
-                older_than_days=sched._terminal_retention_days
-            )
-
-        # 2. Check idle
-        if not sched._idle_detector.is_idle():
-            return False
-
-        # 3. Check compute availability
-        with _timed_phase("get_available_tiers"):
-            available_tiers = await sched._compute.get_available_tiers()
-
-        # 3b. Outage awareness (PR-3): when the network is hard-OFFLINE, strip cloud
-        # tiers so internet-dependent tasks stay `pending` instead of churning into a
-        # dead network. LAN-local compute still runs; fail-safe leaves tiers intact.
-        available_tiers = _filter_tiers_for_network(available_tiers)
-
-        # 4. Get next task
-        with _timed_phase("next_task"):
-            task = await sched._queue.next_task(available_tiers)
-        if task is None:
-            return False
-
-        # 5. Execute
-        logger.info("Dispatching surplus task %s (%s)", task.id, task.task_type)
-        await sched._queue.mark_running(task.id)
-
-        executor = _select_executor(sched, task)
-
         try:
             result = await executor.execute(task)
         except Exception:
@@ -523,7 +513,7 @@ async def dispatch_once(sched: DispatchContext) -> bool:
             )
             return False
 
-        # 6. Route through intake pipeline (atomize → score → route to knowledge)
+        # Route through intake pipeline (atomize → score → route to knowledge)
         staging_id, outcome_quality, judge_score, judge_detail = await _route_insights(
             sched, task, result,
         )
@@ -541,8 +531,7 @@ async def dispatch_once(sched: DispatchContext) -> bool:
         logger.info("Surplus task %s completed (staging=%s)", task.id, staging_id)
         return True
     finally:
-        # Clear only what WE claimed, and only if still ours (label-guarded) —
-        # brackets the WHOLE cycle so the heartbeat gap is covered end-to-end.
+        # Clear only what WE claimed, and only if still ours (label-guarded).
         if _hw_did_set and _hw_rt is not None:
             with contextlib.suppress(Exception):
                 if _hw_rt._heavy_workload == _hw_label:

--- a/src/genesis/surplus/dispatch.py
+++ b/src/genesis/surplus/dispatch.py
@@ -19,8 +19,10 @@ seam and the import-cycle breaker; do not hoist them to module top.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import logging
+import time
 from datetime import timedelta
 from typing import TYPE_CHECKING, Protocol
 
@@ -47,6 +49,32 @@ if TYPE_CHECKING:
     from genesis.surplus.types import SurplusExecutor
 
 logger = logging.getLogger(__name__)
+
+# A single dispatch_once phase (queue maintenance or task selection) is normally
+# sub-second. One this slow is abnormal and is the diagnostic surface for the
+# 2026-09-01 heartbeat-stall class (a phase blocking with NO task running). Observe
+# only — never a timeout: a legitimately long task lives inside `execute`, not these
+# phases, so this only LOGS to localize a stall the heavy_workload flag already forgives.
+_SLOW_PHASE_WARN_S = 120.0
+
+
+@contextlib.contextmanager
+def _timed_phase(name: str):
+    """Time a dispatch_once phase; WARN (never kill) if it runs abnormally long."""
+    t0 = time.monotonic()
+    try:
+        yield
+    finally:
+        dt = time.monotonic() - t0
+        if dt > _SLOW_PHASE_WARN_S:
+            logger.warning(
+                "surplus dispatch phase '%s' took %.0fs (>%ds) — possible "
+                "heartbeat-stall source; heavy_workload forgives the watchdog, this "
+                "log localizes the stalling phase",
+                name,
+                dt,
+                int(_SLOW_PHASE_WARN_S),
+            )
 
 
 class DispatchContext(Protocol):
@@ -398,66 +426,40 @@ def _filter_tiers_for_network(tiers: list[ComputeTier]) -> list[ComputeTier]:
 
 async def dispatch_once(sched: DispatchContext) -> bool:
     """Single dispatch cycle. Returns True if a task was processed."""
-    # 0. Recover tasks stuck in 'running' state (crashed mid-execution)
-    await sched._queue.recover_stuck()
-
-    # 1. Drain expired pending tasks
-    await sched._queue.drain_expired(max_age_hours=sched._task_expiry_hours)
-
-    # 1b. Age-cap terminal rows (completed/failed/cancelled) so they don't
-    # accumulate forever — drain_expired only touches pending.
-    await sched._queue.reap_terminal(older_than_days=sched._terminal_retention_days)
-
-    # 2. Check idle
-    if not sched._idle_detector.is_idle():
-        return False
-
-    # 3. Check compute availability
-    available_tiers = await sched._compute.get_available_tiers()
-
-    # 3b. Outage awareness (PR-3): when the network is hard-OFFLINE, strip cloud
-    # tiers so internet-dependent tasks stay `pending` instead of churning into a
-    # dead network. LAN-local compute still runs; fail-safe leaves tiers intact.
-    available_tiers = _filter_tiers_for_network(available_tiers)
-
-    # 4. Get next task
-    task = await sched._queue.next_task(available_tiers)
-    if task is None:
-        return False
-
-    # 5. Execute
-    logger.info("Dispatching surplus task %s (%s)", task.id, task.task_type)
-    await sched._queue.mark_running(task.id)
-
-    executor = _select_executor(sched, task)
-
-    # Flag this dispatch as a heavy workload for the WHOLE dispatch body (execute
-    # + intake routing + completion) so the 900s zombie-scheduler watchdog FORGIVES
-    # a single long-running task (e.g. j9_eval_batch ~25 min) that would otherwise
-    # gap the dispatch-loop heartbeat and trigger a server restart. Closes the KNOWN
-    # GAP flagged at scheduler.py: the loop refreshes liveness only BETWEEN
-    # dispatches, never DURING one that itself blocks 15-30 min. Covers ALL long
-    # surplus executors (j9, model_eval, wing_audit, code_audit), not just the one
-    # that surfaced it. The runtime flag auto-expires after 2h (runtime/_core.py),
-    # so a genuinely HUNG task is still caught by the watchdog — forgives long, not
-    # dead. (Mirrors the dream jobs; direct-attr writes match dream.py.)
+    # Flag the WHOLE dispatch cycle — setup phases (recover/drain/reap/select) AND the
+    # executor — as a heavy workload so the 900s zombie-scheduler watchdog FORGIVES a
+    # stall ANYWHERE in dispatch_once, not just inside a long executor. The dispatch
+    # loop refreshes the surplus heartbeat only BETWEEN dispatches (scheduler.py), so a
+    # single dispatch_once that blocks — whether in a 25-min executor (j9) OR in a setup
+    # phase (the 2026-09-01 incident: 3 of 4 zombie restarts had NO task running) —
+    # gaps the heartbeat past 900s and triggers a restart. Setting the flag at ENTRY,
+    # before recover_stuck, closes the setup-phase half that #1588 left open (its flag
+    # was set only AFTER task selection). Covers ALL long surplus executors (j9,
+    # model_eval, wing_audit, code_audit) too. The runtime flag auto-expires after 2h
+    # (runtime/_core.py), so a genuinely HUNG cycle is still caught — forgives long, not
+    # dead. Propagates to the watchdog via status.json (status_writer runs on its own
+    # 60s loop, decoupled from this one — verified), so the flag is seen as long as the
+    # event loop stays responsive (a truly-blocked loop is a real hang, correctly NOT
+    # masked). (Mirrors the dream jobs; direct-attr writes match dream.py.)
     #
     # CLAIM ONLY A FREE SLOT: the flag is a single process-wide slot the dream jobs
     # also use. Overwriting it would clear a concurrent dream's protection when THIS
     # (short) dispatch finishes, leaving the dream unprotected mid-cycle. So we set
-    # only when the slot is free, and clear only what WE set. Any truthy label
-    # already forgives the watchdog, so declining to claim still leaves us covered.
+    # only when the slot is free, and clear only what WE set. Any truthy label already
+    # forgives the watchdog, so declining to claim still leaves us covered. A GENERIC
+    # label (not the task-type) is used because the flag is now claimed before a task
+    # is selected — and any truthy label forgives identically.
     #
     # NOTE: while set, this also defers the sentinel's restart remediation
-    # (sentinel/dispatcher.py Gate 2.5 reads heavy_workload). That now applies to
-    # every surplus dispatch, not just dream cycles — intended (a running dispatch
-    # is genuine work), low harm (the sentinel retries).
-    import contextlib
+    # (sentinel/dispatcher.py Gate 2.5 reads heavy_workload). That now applies to every
+    # dispatch cycle (incl. brief idle no-ops), not just long tasks — intended (a
+    # running dispatch is genuine work), low harm (the sentinel retries), and the window
+    # is milliseconds for an idle cycle.
     from datetime import UTC, datetime
 
     from genesis.runtime import GenesisRuntime
 
-    _hw_label = f"surplus:{task.task_type}"
+    _hw_label = "surplus:dispatch"
     _hw_rt = None
     _hw_did_set = False
     with contextlib.suppress(Exception):
@@ -468,6 +470,46 @@ async def dispatch_once(sched: DispatchContext) -> bool:
             _hw_rt, _hw_did_set = _rt, True
 
     try:
+        # 0. Recover tasks stuck in 'running' state (crashed mid-execution)
+        with _timed_phase("recover_stuck"):
+            await sched._queue.recover_stuck()
+
+        # 1. Drain expired pending tasks
+        with _timed_phase("drain_expired"):
+            await sched._queue.drain_expired(max_age_hours=sched._task_expiry_hours)
+
+        # 1b. Age-cap terminal rows (completed/failed/cancelled) so they don't
+        # accumulate forever — drain_expired only touches pending.
+        with _timed_phase("reap_terminal"):
+            await sched._queue.reap_terminal(
+                older_than_days=sched._terminal_retention_days
+            )
+
+        # 2. Check idle
+        if not sched._idle_detector.is_idle():
+            return False
+
+        # 3. Check compute availability
+        with _timed_phase("get_available_tiers"):
+            available_tiers = await sched._compute.get_available_tiers()
+
+        # 3b. Outage awareness (PR-3): when the network is hard-OFFLINE, strip cloud
+        # tiers so internet-dependent tasks stay `pending` instead of churning into a
+        # dead network. LAN-local compute still runs; fail-safe leaves tiers intact.
+        available_tiers = _filter_tiers_for_network(available_tiers)
+
+        # 4. Get next task
+        with _timed_phase("next_task"):
+            task = await sched._queue.next_task(available_tiers)
+        if task is None:
+            return False
+
+        # 5. Execute
+        logger.info("Dispatching surplus task %s (%s)", task.id, task.task_type)
+        await sched._queue.mark_running(task.id)
+
+        executor = _select_executor(sched, task)
+
         try:
             result = await executor.execute(task)
         except Exception:
@@ -500,7 +542,7 @@ async def dispatch_once(sched: DispatchContext) -> bool:
         return True
     finally:
         # Clear only what WE claimed, and only if still ours (label-guarded) —
-        # brackets the WHOLE body so the heartbeat gap is covered end-to-end.
+        # brackets the WHOLE cycle so the heartbeat gap is covered end-to-end.
         if _hw_did_set and _hw_rt is not None:
             with contextlib.suppress(Exception):
                 if _hw_rt._heavy_workload == _hw_label:

--- a/src/genesis/surplus/dispatch.py
+++ b/src/genesis/surplus/dispatch.py
@@ -431,34 +431,81 @@ async def dispatch_once(sched: DispatchContext) -> bool:
 
     executor = _select_executor(sched, task)
 
+    # Flag this dispatch as a heavy workload for the WHOLE dispatch body (execute
+    # + intake routing + completion) so the 900s zombie-scheduler watchdog FORGIVES
+    # a single long-running task (e.g. j9_eval_batch ~25 min) that would otherwise
+    # gap the dispatch-loop heartbeat and trigger a server restart. Closes the KNOWN
+    # GAP flagged at scheduler.py: the loop refreshes liveness only BETWEEN
+    # dispatches, never DURING one that itself blocks 15-30 min. Covers ALL long
+    # surplus executors (j9, model_eval, wing_audit, code_audit), not just the one
+    # that surfaced it. The runtime flag auto-expires after 2h (runtime/_core.py),
+    # so a genuinely HUNG task is still caught by the watchdog — forgives long, not
+    # dead. (Mirrors the dream jobs; direct-attr writes match dream.py.)
+    #
+    # CLAIM ONLY A FREE SLOT: the flag is a single process-wide slot the dream jobs
+    # also use. Overwriting it would clear a concurrent dream's protection when THIS
+    # (short) dispatch finishes, leaving the dream unprotected mid-cycle. So we set
+    # only when the slot is free, and clear only what WE set. Any truthy label
+    # already forgives the watchdog, so declining to claim still leaves us covered.
+    #
+    # NOTE: while set, this also defers the sentinel's restart remediation
+    # (sentinel/dispatcher.py Gate 2.5 reads heavy_workload). That now applies to
+    # every surplus dispatch, not just dream cycles — intended (a running dispatch
+    # is genuine work), low harm (the sentinel retries).
+    import contextlib
+    from datetime import UTC, datetime
+
+    from genesis.runtime import GenesisRuntime
+
+    _hw_label = f"surplus:{task.task_type}"
+    _hw_rt = None
+    _hw_did_set = False
+    with contextlib.suppress(Exception):
+        _rt = GenesisRuntime.instance()
+        if _rt._heavy_workload is None:  # free slot only — never stomp dream's flag
+            _rt._heavy_workload = _hw_label
+            _rt._heavy_workload_since = datetime.now(UTC)
+            _hw_rt, _hw_did_set = _rt, True
+
     try:
-        result = await executor.execute(task)
-    except Exception:
-        logger.exception("Surplus task %s failed with exception", task.id)
-        await _handle_failure(sched, task, "executor_exception", emit_event=True)
-        return False
+        try:
+            result = await executor.execute(task)
+        except Exception:
+            logger.exception("Surplus task %s failed with exception", task.id)
+            await _handle_failure(sched, task, "executor_exception", emit_event=True)
+            return False
 
-    if not result.success:
-        await _handle_failure(sched, task, result.error or "unknown", emit_event=False)
-        return False
+        if not result.success:
+            await _handle_failure(
+                sched, task, result.error or "unknown", emit_event=False
+            )
+            return False
 
-    # 6. Route through intake pipeline (atomize → score → route to knowledge)
-    staging_id, outcome_quality, judge_score, judge_detail = await _route_insights(
-        sched, task, result,
-    )
+        # 6. Route through intake pipeline (atomize → score → route to knowledge)
+        staging_id, outcome_quality, judge_score, judge_detail = await _route_insights(
+            sched, task, result,
+        )
 
-    await sched._queue.mark_completed(
-        task.id, staging_id=staging_id, outcome_quality=outcome_quality,
-        judge_score=judge_score, judge_detail=judge_detail,
-    )
+        await sched._queue.mark_completed(
+            task.id, staging_id=staging_id, outcome_quality=outcome_quality,
+            judge_score=judge_score, judge_detail=judge_detail,
+        )
 
-    await _chain_pipeline(sched, task, result)
-    await _bridge_code_audit_findings(task, result)
-    await _log_brainstorm(sched, task, result, staging_id)
-    await _signal_autonomy_success()
+        await _chain_pipeline(sched, task, result)
+        await _bridge_code_audit_findings(task, result)
+        await _log_brainstorm(sched, task, result, staging_id)
+        await _signal_autonomy_success()
 
-    logger.info("Surplus task %s completed (staging=%s)", task.id, staging_id)
-    return True
+        logger.info("Surplus task %s completed (staging=%s)", task.id, staging_id)
+        return True
+    finally:
+        # Clear only what WE claimed, and only if still ours (label-guarded) —
+        # brackets the WHOLE body so the heartbeat gap is covered end-to-end.
+        if _hw_did_set and _hw_rt is not None:
+            with contextlib.suppress(Exception):
+                if _hw_rt._heavy_workload == _hw_label:
+                    _hw_rt._heavy_workload = None
+                    _hw_rt._heavy_workload_since = None
 
 
 async def maybe_observe_failure(sched: DispatchContext, task, reason: str) -> None:

--- a/src/genesis/surplus/scheduler.py
+++ b/src/genesis/surplus/scheduler.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -40,6 +39,30 @@ if TYPE_CHECKING:
     from genesis.routing.router import Router
 
 logger = logging.getLogger(__name__)
+
+
+def _pump_surplus_heartbeat(where: str) -> None:
+    """Refresh the surplus job-health heartbeat; LOG (never swallow) on failure.
+
+    The 900s zombie-scheduler watchdog reads ``job_health['surplus_dispatch'].last_run``
+    (via status.json). This is the ONLY producer of that timestamp. A silently-failing
+    ``record_job_success`` would starve the watchdog while the loop runs fine — a
+    candidate cause of the 2026-09-01 no-task-running restarts. Logging the failure
+    makes that (previously invisible) mode diagnosable.
+    """
+    try:
+        from genesis.runtime import GenesisRuntime
+
+        GenesisRuntime.instance().record_job_success("surplus_dispatch")
+    except Exception as exc:
+        # No exc_info: record_job_success does a DB persist, so a sustained outage
+        # would emit up to ~4 tracebacks/loop. The exception repr names the cause
+        # (e.g. 'database is locked') without flooding the log during that incident.
+        logger.warning(
+            "surplus heartbeat write failed (%s): %r — the 900s zombie watchdog may see a false stall",
+            where,
+            exc,
+        )
 
 
 def _restart_safe_hourly(hours: int, *, minute: int = 0):
@@ -828,23 +851,19 @@ class SurplusScheduler:
         try:
             # Refresh job_health at loop entry (and before each dispatch, below) so the
             # 900s zombie-scheduler watchdog sees liveness across a SEQUENCE of moderate
-            # dispatches. KNOWN GAP: this does NOT refresh DURING one dispatch_once that
-            # itself blocks 15-30 min — last_run then gaps, and unless heavy_workload is set
-            # (only the dream jobs set it) the watchdog could restart a healthy-but-slow
-            # surplus. Latent — no such restart observed to date; tracked as a follow-up.
-            try:
-                from genesis.runtime import GenesisRuntime
-
-                GenesisRuntime.instance().record_job_success("surplus_dispatch")
-            except Exception:
-                pass
+            # dispatches. The single-long-dispatch gap (a dispatch_once that itself blocks
+            # 15-30 min — INCLUDING a setup-phase stall with NO task running, the
+            # 2026-09-01 incident) is now covered by the heavy_workload flag set at
+            # dispatch_once ENTRY (see dispatch.py). This heartbeat write is the OTHER
+            # liveness signal; its failures are LOGGED (not swallowed) because a silent
+            # failure here would starve the watchdog while the loop runs fine.
+            _pump_surplus_heartbeat("loop-entry")
 
             for _ in range(3):
                 # Refresh before each dispatch so a SEQUENCE of slow/failing tasks
-                # doesn't trip the 900s watchdog (does NOT cover the single-long-dispatch
-                # gap noted at loop entry).
-                with contextlib.suppress(Exception):
-                    GenesisRuntime.instance().record_job_success("surplus_dispatch")
+                # doesn't trip the 900s watchdog (the single-long-dispatch gap is covered
+                # by dispatch_once's entry-set heavy_workload flag).
+                _pump_surplus_heartbeat("pre-dispatch")
                 if not await self.dispatch_once():
                     break
 

--- a/tests/test_surplus/test_dispatch.py
+++ b/tests/test_surplus/test_dispatch.py
@@ -178,8 +178,8 @@ async def test_heavy_workload_flag_set_during_execute_and_cleared_after(monkeypa
     result = await dispatch.dispatch_once(ctx)
 
     assert result is True
-    # DURING execute the flag was set to the generic cycle label (set at entry).
-    assert captured["hw"] == "surplus:dispatch"
+    # DURING execute the flag was set to the task-type label.
+    assert captured["hw"] == f"surplus:{task.task_type}"
     assert captured["since"] is not None
     # AFTER the dispatch the flag is cleared (label-guarded) — no leak.
     assert fake_rt._heavy_workload is None
@@ -197,7 +197,7 @@ async def test_heavy_workload_flag_cleared_even_when_executor_raises(monkeypatch
     seen = {}
 
     async def _boom(_t):
-        seen["hw"] = fake_rt._heavy_workload  # set at entry, before execute
+        seen["hw"] = fake_rt._heavy_workload  # set before execute
         raise RuntimeError("hang→boom")
 
     task = _Task(TaskType.J9_EVAL_BATCH)
@@ -207,8 +207,8 @@ async def test_heavy_workload_flag_cleared_even_when_executor_raises(monkeypatch
     result = await dispatch.dispatch_once(ctx)
 
     assert result is False
-    # Flag was set at ENTRY, before the executor ran.
-    assert seen["hw"] == "surplus:dispatch"
+    # Flag was set before the executor ran.
+    assert seen["hw"] == f"surplus:{task.task_type}"
     # The finally clears it even on the exception path — no stuck heavy flag.
     assert fake_rt._heavy_workload is None
     assert fake_rt._heavy_workload_since is None
@@ -266,41 +266,6 @@ async def test_heavy_workload_not_claimed_when_slot_already_held(monkeypatch):
     assert captured["hw"] == "dream_cycle"
     # ...and NOT cleared afterward (we never owned it).
     assert fake_rt._heavy_workload == "dream_cycle"
-
-
-async def test_heavy_workload_flag_set_during_setup_phase(monkeypatch):
-    # 2026-09-01 incident: the surplus heartbeat can stall in a SETUP step
-    # (recover_stuck / drain_expired / next_task) with NO task running. #1588 set the
-    # flag only AFTER task selection, so a setup-phase stall was NOT forgiven by the
-    # 900s zombie watchdog. The flag must now cover the WHOLE dispatch_once cycle —
-    # set at entry, before recover_stuck — even on a no-task cycle.
-    import genesis.runtime as runtime_mod
-
-    fake_rt = types.SimpleNamespace(_heavy_workload=None, _heavy_workload_since=None)
-    monkeypatch.setattr(
-        runtime_mod.GenesisRuntime, "instance", staticmethod(lambda: fake_rt)
-    )
-
-    seen = {}
-
-    async def _capture_during_setup():
-        # The flag must ALREADY be set when the first setup phase runs.
-        seen["hw"] = fake_rt._heavy_workload
-        seen["since"] = fake_rt._heavy_workload_since
-
-    ctx = _make_ctx()
-    ctx._queue.recover_stuck = AsyncMock(side_effect=_capture_during_setup)
-    ctx._queue.next_task = AsyncMock(return_value=None)  # no-task early return
-
-    result = await dispatch.dispatch_once(ctx)
-
-    assert result is False
-    # Flag was set at ENTRY, before recover_stuck (RED on #1588 → None here).
-    assert seen["hw"] == "surplus:dispatch"
-    assert seen["since"] is not None
-    # Cleared after the no-task early return — no leak.
-    assert fake_rt._heavy_workload is None
-    assert fake_rt._heavy_workload_since is None
 
 
 # ── _timed_phase: diagnostic warning on an abnormally slow setup phase ──

--- a/tests/test_surplus/test_dispatch.py
+++ b/tests/test_surplus/test_dispatch.py
@@ -8,6 +8,7 @@ task.failed), executor-selection fallback semantics, the maintenance→idle→
 task ordering, and the consecutive-failure observation threshold.
 """
 
+import logging
 import types
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
@@ -177,8 +178,8 @@ async def test_heavy_workload_flag_set_during_execute_and_cleared_after(monkeypa
     result = await dispatch.dispatch_once(ctx)
 
     assert result is True
-    # DURING execute the flag was set to the task-type label (this is the fix).
-    assert captured["hw"] == f"surplus:{task.task_type}"
+    # DURING execute the flag was set to the generic cycle label (set at entry).
+    assert captured["hw"] == "surplus:dispatch"
     assert captured["since"] is not None
     # AFTER the dispatch the flag is cleared (label-guarded) — no leak.
     assert fake_rt._heavy_workload is None
@@ -196,7 +197,7 @@ async def test_heavy_workload_flag_cleared_even_when_executor_raises(monkeypatch
     seen = {}
 
     async def _boom(_t):
-        seen["hw"] = fake_rt._heavy_workload  # set before execute (the fix)
+        seen["hw"] = fake_rt._heavy_workload  # set at entry, before execute
         raise RuntimeError("hang→boom")
 
     task = _Task(TaskType.J9_EVAL_BATCH)
@@ -206,8 +207,8 @@ async def test_heavy_workload_flag_cleared_even_when_executor_raises(monkeypatch
     result = await dispatch.dispatch_once(ctx)
 
     assert result is False
-    # Flag was set BEFORE the executor ran (RED without the fix).
-    assert seen["hw"] == f"surplus:{task.task_type}"
+    # Flag was set at ENTRY, before the executor ran.
+    assert seen["hw"] == "surplus:dispatch"
     # The finally clears it even on the exception path — no stuck heavy flag.
     assert fake_rt._heavy_workload is None
     assert fake_rt._heavy_workload_since is None
@@ -265,6 +266,63 @@ async def test_heavy_workload_not_claimed_when_slot_already_held(monkeypatch):
     assert captured["hw"] == "dream_cycle"
     # ...and NOT cleared afterward (we never owned it).
     assert fake_rt._heavy_workload == "dream_cycle"
+
+
+async def test_heavy_workload_flag_set_during_setup_phase(monkeypatch):
+    # 2026-09-01 incident: the surplus heartbeat can stall in a SETUP step
+    # (recover_stuck / drain_expired / next_task) with NO task running. #1588 set the
+    # flag only AFTER task selection, so a setup-phase stall was NOT forgiven by the
+    # 900s zombie watchdog. The flag must now cover the WHOLE dispatch_once cycle —
+    # set at entry, before recover_stuck — even on a no-task cycle.
+    import genesis.runtime as runtime_mod
+
+    fake_rt = types.SimpleNamespace(_heavy_workload=None, _heavy_workload_since=None)
+    monkeypatch.setattr(
+        runtime_mod.GenesisRuntime, "instance", staticmethod(lambda: fake_rt)
+    )
+
+    seen = {}
+
+    async def _capture_during_setup():
+        # The flag must ALREADY be set when the first setup phase runs.
+        seen["hw"] = fake_rt._heavy_workload
+        seen["since"] = fake_rt._heavy_workload_since
+
+    ctx = _make_ctx()
+    ctx._queue.recover_stuck = AsyncMock(side_effect=_capture_during_setup)
+    ctx._queue.next_task = AsyncMock(return_value=None)  # no-task early return
+
+    result = await dispatch.dispatch_once(ctx)
+
+    assert result is False
+    # Flag was set at ENTRY, before recover_stuck (RED on #1588 → None here).
+    assert seen["hw"] == "surplus:dispatch"
+    assert seen["since"] is not None
+    # Cleared after the no-task early return — no leak.
+    assert fake_rt._heavy_workload is None
+    assert fake_rt._heavy_workload_since is None
+
+
+# ── _timed_phase: diagnostic warning on an abnormally slow setup phase ──
+
+
+def test_timed_phase_warns_when_slow(monkeypatch, caplog):
+    # A setup phase exceeding the threshold logs a diagnostic WARNING (the surface
+    # that would have localized the 2026-09-01 no-task-running stall).
+    monkeypatch.setattr(dispatch, "_SLOW_PHASE_WARN_S", -1.0)  # any duration exceeds
+    with caplog.at_level(logging.WARNING), dispatch._timed_phase("recover_stuck"):
+        pass
+    assert any(
+        "recover_stuck" in r.getMessage() and "heartbeat-stall" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_timed_phase_silent_when_fast(monkeypatch, caplog):
+    monkeypatch.setattr(dispatch, "_SLOW_PHASE_WARN_S", 1e9)  # nothing exceeds
+    with caplog.at_level(logging.WARNING), dispatch._timed_phase("recover_stuck"):
+        pass
+    assert not any("heartbeat-stall" in r.getMessage() for r in caplog.records)
 
 
 # ── maybe_observe_failure: the 3-strike threshold ───────────────────

--- a/tests/test_surplus/test_dispatch.py
+++ b/tests/test_surplus/test_dispatch.py
@@ -149,6 +149,124 @@ async def test_success_path_marks_completed_and_returns_true():
     ctx._event_bus.emit.assert_not_awaited()
 
 
+# ── dispatch_once: heavy_workload flag guards the zombie watchdog ────
+# A single long dispatch (e.g. j9_eval_batch ~25 min) must set the runtime
+# heavy_workload flag for the DURATION of executor.execute so the 900s
+# zombie-scheduler watchdog forgives it instead of restarting the server.
+
+async def test_heavy_workload_flag_set_during_execute_and_cleared_after(monkeypatch):
+    import genesis.runtime as runtime_mod
+
+    fake_rt = types.SimpleNamespace(_heavy_workload=None, _heavy_workload_since=None)
+    monkeypatch.setattr(
+        runtime_mod.GenesisRuntime, "instance", staticmethod(lambda: fake_rt)
+    )
+
+    task = _Task(TaskType.J9_EVAL_BATCH)
+    captured = {}
+
+    async def _capture_execute(t):
+        # Observe the flag AT execute time — this is the window the watchdog sees.
+        captured["hw"] = fake_rt._heavy_workload
+        captured["since"] = fake_rt._heavy_workload_since
+        return _Result(success=True)
+
+    ctx = _make_ctx(executor=types.SimpleNamespace(execute=_capture_execute))
+    ctx._queue.next_task = AsyncMock(return_value=task)
+
+    result = await dispatch.dispatch_once(ctx)
+
+    assert result is True
+    # DURING execute the flag was set to the task-type label (this is the fix).
+    assert captured["hw"] == f"surplus:{task.task_type}"
+    assert captured["since"] is not None
+    # AFTER the dispatch the flag is cleared (label-guarded) — no leak.
+    assert fake_rt._heavy_workload is None
+    assert fake_rt._heavy_workload_since is None
+
+
+async def test_heavy_workload_flag_cleared_even_when_executor_raises(monkeypatch):
+    import genesis.runtime as runtime_mod
+
+    fake_rt = types.SimpleNamespace(_heavy_workload=None, _heavy_workload_since=None)
+    monkeypatch.setattr(
+        runtime_mod.GenesisRuntime, "instance", staticmethod(lambda: fake_rt)
+    )
+
+    seen = {}
+
+    async def _boom(_t):
+        seen["hw"] = fake_rt._heavy_workload  # set before execute (the fix)
+        raise RuntimeError("hang→boom")
+
+    task = _Task(TaskType.J9_EVAL_BATCH)
+    ctx = _make_ctx(executor=types.SimpleNamespace(execute=_boom))
+    ctx._queue.next_task = AsyncMock(return_value=task)
+
+    result = await dispatch.dispatch_once(ctx)
+
+    assert result is False
+    # Flag was set BEFORE the executor ran (RED without the fix).
+    assert seen["hw"] == f"surplus:{task.task_type}"
+    # The finally clears it even on the exception path — no stuck heavy flag.
+    assert fake_rt._heavy_workload is None
+    assert fake_rt._heavy_workload_since is None
+
+
+async def test_heavy_workload_clear_does_not_stomp_another_jobs_flag(monkeypatch):
+    import genesis.runtime as runtime_mod
+
+    # A concurrent job (e.g. dream_cycle) owns the flag; our clear must not touch it
+    # if, mid-dispatch, the label no longer matches ours.
+    fake_rt = types.SimpleNamespace(_heavy_workload=None, _heavy_workload_since=None)
+    monkeypatch.setattr(
+        runtime_mod.GenesisRuntime, "instance", staticmethod(lambda: fake_rt)
+    )
+
+    async def _steal(_t):
+        # Simulate another job taking ownership during our execute.
+        fake_rt._heavy_workload = "dream_cycle"
+        return _Result(success=True)
+
+    ctx = _make_ctx(executor=types.SimpleNamespace(execute=_steal))
+    ctx._queue.next_task = AsyncMock(return_value=_Task(TaskType.J9_EVAL_BATCH))
+
+    await dispatch.dispatch_once(ctx)
+
+    # Label no longer ours → we must leave the other job's flag intact.
+    assert fake_rt._heavy_workload == "dream_cycle"
+
+
+async def test_heavy_workload_not_claimed_when_slot_already_held(monkeypatch):
+    # A concurrent dream job already owns the single-slot flag BEFORE this dispatch
+    # starts. We must NOT overwrite it (free-slot claim only) — otherwise our clear
+    # would leave the dream unprotected mid-cycle. (RED against an unconditional set.)
+    import genesis.runtime as runtime_mod
+
+    fake_rt = types.SimpleNamespace(
+        _heavy_workload="dream_cycle", _heavy_workload_since=datetime.now(UTC)
+    )
+    monkeypatch.setattr(
+        runtime_mod.GenesisRuntime, "instance", staticmethod(lambda: fake_rt)
+    )
+
+    captured = {}
+
+    async def _capture_execute(_t):
+        captured["hw"] = fake_rt._heavy_workload
+        return _Result(success=True)
+
+    ctx = _make_ctx(executor=types.SimpleNamespace(execute=_capture_execute))
+    ctx._queue.next_task = AsyncMock(return_value=_Task(TaskType.J9_EVAL_BATCH))
+
+    await dispatch.dispatch_once(ctx)
+
+    # Dream's flag untouched DURING our dispatch (we declined to claim)...
+    assert captured["hw"] == "dream_cycle"
+    # ...and NOT cleared afterward (we never owned it).
+    assert fake_rt._heavy_workload == "dream_cycle"
+
+
 # ── maybe_observe_failure: the 3-strike threshold ───────────────────
 
 async def test_maybe_observe_failure_upserts_at_threshold(monkeypatch):

--- a/tests/test_surplus/test_scheduler.py
+++ b/tests/test_surplus/test_scheduler.py
@@ -14,10 +14,54 @@ from genesis.surplus.compute_availability import ComputeAvailability
 from genesis.surplus.executor import StubExecutor
 from genesis.surplus.idle_detector import IdleDetector
 from genesis.surplus.queue import SurplusQueue
-from genesis.surplus.scheduler import SurplusScheduler, _restart_safe_hourly
+from genesis.surplus.scheduler import (
+    SurplusScheduler,
+    _pump_surplus_heartbeat,
+    _restart_safe_hourly,
+)
 from genesis.surplus.types import ComputeTier, TaskType
 
 pytestmark = pytest.mark.asyncio
+
+
+async def test_pump_surplus_heartbeat_logs_on_failure(monkeypatch, caplog):
+    # A silently-failing heartbeat write would starve the 900s zombie watchdog while
+    # the loop runs fine (2026-09-01 incident candidate). It must LOG, not swallow.
+    import logging
+
+    import genesis.runtime as runtime_mod
+
+    class _BoomRt:
+        def record_job_success(self, name):
+            raise RuntimeError("db down")
+
+    monkeypatch.setattr(runtime_mod.GenesisRuntime, "instance", staticmethod(lambda: _BoomRt()))
+    with caplog.at_level(logging.WARNING):
+        _pump_surplus_heartbeat("loop-entry")
+
+    assert any(
+        "surplus heartbeat write failed" in r.getMessage() and "loop-entry" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+async def test_pump_surplus_heartbeat_silent_on_success(monkeypatch, caplog):
+    import logging
+
+    import genesis.runtime as runtime_mod
+
+    calls = []
+
+    class _OkRt:
+        def record_job_success(self, name):
+            calls.append(name)
+
+    monkeypatch.setattr(runtime_mod.GenesisRuntime, "instance", staticmethod(lambda: _OkRt()))
+    with caplog.at_level(logging.WARNING):
+        _pump_surplus_heartbeat("pre-dispatch")
+
+    assert calls == ["surplus_dispatch"]  # the write actually happened
+    assert not any("surplus heartbeat write failed" in r.getMessage() for r in caplog.records)
 
 
 def _make_scheduler(db, *, idle=True, lmstudio_up=False):


### PR DESCRIPTION
## Incident

genesis-server entered a ~30-min watchdog restart loop. A single `j9_eval_batch` surplus dispatch runs ~25 min, but the dispatch loop refreshes its liveness heartbeat only **between** dispatches, never **during** one long `dispatch_once`. So the 900s zombie-scheduler watchdog declared surplus a zombie and restarted the server mid-run; the re-queued task hung again → loop. This is the **KNOWN GAP** documented at `scheduler.py:826-833` ("latent — no such restart observed to date"), now triggered — the deploy's restart kicked off a j9 task and current provider outages (403/529) made it slower/stuck. **Not a code regression** — `git log 975d3944..0d27905a` shows surplus/dispatch/scheduler/j9_batch unchanged.

## Fix

Flag the runtime `heavy_workload` for the **whole dispatch body** (execute + intake routing + completion) so the watchdog forgives the heartbeat gap of a long dispatch. The flag **auto-expires after 2h** (`runtime/_core.py`), so a genuinely **hung** task is still caught — this forgives *long*, not *dead*. Only the zombie-scheduler check is affected; server-**down** detection is untouched. Covers **all** long surplus executors routed through `dispatch_once` (j9, model_eval, wing_audit, code_audit), not just the one that surfaced it. Mirrors how the dream jobs already set the flag.

**Claim only a free slot:** `heavy_workload` is a single process-wide slot the dream jobs also use. An unconditional set would overwrite a concurrent dream's flag and clear it when this (short) dispatch finished, leaving the dream unprotected mid-cycle. So we set only when the slot is free and clear only what we set.

## Review

genesis-architect adversarial pass found 2 SHOULD-FIX (both **fixed + verify-RED'd** here):
1. unconditional set stomped a concurrent dream's flag → now claims a free slot only;
2. clear ran after `execute` but the post-processing tail still gapped the heartbeat → now brackets the whole body.

Plus a NOTE: the flag now defers sentinel Gate 2.5 restart remediation on every dispatch (was dream-only) — intended, low harm, documented in-code.

## Tests

`tests/test_surplus/test_dispatch.py`: flag set-during-execute + cleared-after (incl. on exception), free-slot-claim does not stomp a concurrent dream flag. Verify-RED'd (the flag-set: 2 RED; the free-slot guard: 1 RED). 26 pass, ruff clean.

## Note

The live install has `j9_eval_batch` temporarily disabled via an install-local overlay to stop the active loop; re-enabled once this deploys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heavy-workload tracking during task execution and post-processing.
  * Prevented overlapping dispatch cycles from overwriting workload status.
  * Ensured workload indicators are cleared only by the cycle that owns them.
  * Added warnings when dispatch setup phases exceed two minutes.
  * Improved heartbeat reporting and visibility when heartbeat updates fail.

* **Tests**
  * Expanded coverage for workload ownership, timing warnings, and heartbeat success or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->