### PR TITLE
feat(hooks): weighted inline-findings score in the merge gate (P1=1.0, P2=0.5)

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1636,7 +1636,10 @@ The review-findings gate specifically:
    for automated review findings (ERROR, [P1], HARD BLOCK).
 2. If review present with **blocking findings** → merge is **BLOCKED**
    by the hook (exit code 2). Fix the findings first.
-3. If review present with only WARNINGs/NOTEs → merge allowed.
+3. Inline findings are SCORED — P1 = 1.0, P2 = 0.5 — and the gate blocks at
+   score >= 1.0 (any P1, OR >= 2 P2s). A lone P2 is advisory (0.5, allowed); a
+   P2 is excluded from the score if a MAINTAINER reply engages it or it is on a
+   documentation path. Pure WARNINGs/NOTEs (non-P1/P2) → merge allowed.
 4. If no review comments at all (quota exhausted) → merge allowed
    on CI alone. Note in PR that review was quota-limited.
 5. **Override**: Append `# review-override` to the merge command to
@@ -1656,9 +1659,11 @@ The review-findings gate specifically:
    `gh repo view --json nameWithOwner --jq .nameWithOwner` — NEVER hardcode
    it (configs name several repos; the working repo is not the org default).
    A **404 from that endpoint means WRONG SLUG or PR number, never "no
-   findings"** — a clean PR returns `[]`. The merge-gate hook only blocks
-   ERROR/[P1]/HARD BLOCK, so unread P2s pass silently (2026-07-10: 8 real
-   P2s on the entity-layer PRs were merged past this exact way). And the two
+   findings"** — a clean PR returns `[]`. The merge-gate hook blocks on the
+   weighted inline SCORE (P1=1.0, P2=0.5; block at >= 1.0), so a lone P2 is
+   advisory but TWO unresolved P2s block — unread P2s no longer slip through in
+   pairs (2026-07-10: 8 real P2s on the entity-layer PRs merged past the OLD
+   P1-only gate, the exact gap this score closes). And the two
    channels are INDEPENDENT: Codex can post a quota/usage-limit message as an
    ISSUE comment while a later `@codex review` trigger delivers real inline
    findings anyway — a quota message is evidence about that channel at that

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1241,8 +1241,13 @@ def _check_inline_review_findings(
     score — P1 = 1.0, P2 = 0.5 — and the gate blocks when the score >= 1.0 (any P1, OR
     >= 2 P2s). A finding is EXCLUDED from the score when its thread has a MAINTAINER
     reply (engagement = consciously accepted) or its path is documentation
-    (``_is_doc_path``). Exclusion is from the SCORE only, never from VISIBILITY: every P2
-    is surfaced on stderr — scored P2s as a WARNING, doc-path P2s as a NOTE. An UNREADABLE or
+    (``_is_doc_path``). The two exclusions differ in VISIBILITY by design: a doc-path
+    finding was auto-excluded by PATH (not engaged), so it is still SURFACED as a NOTE —
+    scored P2s print as a WARNING, doc-path P1s/P2s as a NOTE — nothing unaddressed is
+    dropped. A maintainer-replied finding was CONSCIOUSLY ENGAGED (the reply IS the
+    acknowledgement), so it is excluded from the report too: the pre-merge report shows
+    what still needs attention, not what a maintainer already handled (re-listing every
+    replied finding on each check would bury the live ones). An UNREADABLE or
     INCOMPLETE scan (gh error/timeout/malformed/clipped budget) ALWAYS blocks
     (fail-closed — see ``_scan_unreadable``); '# review-override' waives the whole scan.
     """

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1241,7 +1241,8 @@ def _check_inline_review_findings(
     score — P1 = 1.0, P2 = 0.5 — and the gate blocks when the score >= 1.0 (any P1, OR
     >= 2 P2s). A finding is EXCLUDED from the score when its thread has a MAINTAINER
     reply (engagement = consciously accepted) or its path is documentation
-    (``_is_doc_path``). P2s are always printed to stderr one per line. An UNREADABLE or
+    (``_is_doc_path``). Exclusion is from the SCORE only, never from VISIBILITY: every P2
+    is surfaced on stderr — scored P2s as a WARNING, doc-path P2s as a NOTE. An UNREADABLE or
     INCOMPLETE scan (gh error/timeout/malformed/clipped budget) ALWAYS blocks
     (fail-closed — see ``_scan_unreadable``); '# review-override' waives the whole scan.
     """
@@ -1277,6 +1278,7 @@ def _check_inline_review_findings(
     p1: list[str] = []
     p2: list[str] = []
     doc_skipped: list[str] = []  # P1s on doc paths — surfaced, never blocking
+    doc_skipped_p2: list[str] = []  # P2s on doc paths — surfaced, excluded from score
     for c in raw:
         login, utype = c.get("login") or "", c.get("type") or ""
         body = c.get("body") or ""
@@ -1297,9 +1299,12 @@ def _check_inline_review_findings(
             if c.get("id") in replied_to:
                 continue  # thread engaged — maintainer consciously accepted the P2
             if _is_doc_path(c.get("path") or ""):
-                # A P2 on a doc path is not a code defect — excluded from the score.
-                # Dropped silently (unlike a doc-path P1, surfaced as a NOTE): a
-                # doc-file P2 nitpick is negligible; the asymmetry is deliberate.
+                # A P2 on a doc path is not a code defect — excluded from the SCORE, but
+                # still SURFACED as a NOTE (mirroring doc-path P1s). A documentation-
+                # correctness P2 can be substantive, so it must stay visible in the
+                # canonical pre-merge report to be consciously accepted, never silently
+                # dropped (Codex #1589 P2).
+                doc_skipped_p2.append(_inline_title(body))
                 continue
             p2.append(_inline_title(body))
 
@@ -1312,6 +1317,15 @@ def _check_inline_review_findings(
         )
         for title in doc_skipped[:5]:
             print(f"  [doc P1] {title}", file=sys.stderr)
+    if doc_skipped_p2:
+        print(
+            f"NOTE: PR #{pr_num} — {len(doc_skipped_p2)} inline [P2] finding(s) on "
+            f"documentation paths — surfaced for conscious acceptance, NOT counted "
+            f"toward the review score:",
+            file=sys.stderr,
+        )
+        for title in doc_skipped_p2[:5]:
+            print(f"  [doc P2] {title}", file=sys.stderr)
     # Weighted review score: P1 = 1.0 (full blocker), P2 = 0.5. Blocks at
     # score >= threshold — any unresolved P1, OR >= 2 unresolved P2s. Doc-path
     # and maintainer-replied findings were already excluded from p1/p2 above.

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -971,6 +971,13 @@ _REVIEW_BOTS = {"chatgpt-codex-connector[bot]", "github-actions[bot]"}
 # 118 merged PRs passed unseen, 64 of them P1).
 _INLINE_P1_RE = re.compile(r"!\[P1 Badge\]")
 _INLINE_P2_RE = re.compile(r"!\[P2 Badge\]")
+# Weighted review score for inline findings: a P1 is a full blocker (1.0), a P2
+# is half (0.5), so the gate blocks at any unresolved P1 OR >= 2 unresolved P2s.
+# Doc-path and maintainer-replied (consciously-accepted) findings are excluded
+# from the score, exactly as for P1s. Fixed policy value that works on any clone —
+# deliberately not per-install configurable.
+_INLINE_P2_SCORE_WEIGHT = 0.5
+_INLINE_SCORE_BLOCK_THRESHOLD = 1.0
 _INLINE_REVIEW_BOTS = {
     "chatgpt-codex-connector[bot]",
     "github-advanced-security[bot]",
@@ -1228,14 +1235,15 @@ def _check_inline_review_findings(
     force: bool = False,
     repo: str | None = None,
 ) -> tuple[bool, str]:
-    """Scan INLINE review comments for P1/P2 badge findings.
+    """Scan INLINE review comments for P1/P2 badge findings and apply a weighted score.
 
-    Returns (should_block, message). P1 findings block unless their thread has a
-    MAINTAINER reply (engagement = a reviewer read it) or the merge carries
-    '# review-override'. P2 findings never block but are printed to stderr one per
-    line — the session must consciously accept them. An UNREADABLE or INCOMPLETE scan
-    (gh error/timeout/malformed/clipped budget) ALWAYS blocks (fail-closed — see
-    ``_scan_unreadable``); '# review-override' is the conscious escape hatch.
+    Returns (should_block, message). Each unresolved finding contributes to a review
+    score — P1 = 1.0, P2 = 0.5 — and the gate blocks when the score >= 1.0 (any P1, OR
+    >= 2 P2s). A finding is EXCLUDED from the score when its thread has a MAINTAINER
+    reply (engagement = consciously accepted) or its path is documentation
+    (``_is_doc_path``). P2s are always printed to stderr one per line. An UNREADABLE or
+    INCOMPLETE scan (gh error/timeout/malformed/clipped budget) ALWAYS blocks
+    (fail-closed — see ``_scan_unreadable``); '# review-override' waives the whole scan.
     """
     if force:
         return False, ""  # override NOTE already printed by the body gate
@@ -1286,6 +1294,13 @@ def _check_inline_review_findings(
                 continue
             p1.append(_inline_title(body))
         elif _INLINE_P2_RE.search(body):
+            if c.get("id") in replied_to:
+                continue  # thread engaged — maintainer consciously accepted the P2
+            if _is_doc_path(c.get("path") or ""):
+                # A P2 on a doc path is not a code defect — excluded from the score.
+                # Dropped silently (unlike a doc-path P1, surfaced as a NOTE): a
+                # doc-file P2 nitpick is negligible; the asymmetry is deliberate.
+                continue
             p2.append(_inline_title(body))
 
     if doc_skipped:
@@ -1297,18 +1312,28 @@ def _check_inline_review_findings(
         )
         for title in doc_skipped[:5]:
             print(f"  [doc P1] {title}", file=sys.stderr)
+    # Weighted review score: P1 = 1.0 (full blocker), P2 = 0.5. Blocks at
+    # score >= threshold — any unresolved P1, OR >= 2 unresolved P2s. Doc-path
+    # and maintainer-replied findings were already excluded from p1/p2 above.
+    score = len(p1) + _INLINE_P2_SCORE_WEIGHT * len(p2)
     if p2:
         print(
-            f"WARNING: PR #{pr_num} has {len(p2)} inline [P2] review "
-            f"finding(s) (not blocking — address or consciously accept):",
+            f"WARNING: PR #{pr_num} has {len(p2)} inline [P2] review finding(s) "
+            f"(each adds {_INLINE_P2_SCORE_WEIGHT} to the review score; the gate "
+            f"blocks at score >= {_INLINE_SCORE_BLOCK_THRESHOLD:.0f}, i.e. any P1 "
+            f"or {int(_INLINE_SCORE_BLOCK_THRESHOLD / _INLINE_P2_SCORE_WEIGHT)}+ P2s):",
             file=sys.stderr,
         )
         for title in p2[:8]:
             print(f"  [P2] {title}", file=sys.stderr)
-    if p1:
-        listing = "\n".join(f"  [P1] {t}" for t in p1[:5])
+    if score >= _INLINE_SCORE_BLOCK_THRESHOLD:
+        listing = "\n".join(
+            [f"  [P1] {t}" for t in p1[:5]] + [f"  [P2] {t}" for t in p2[:5]]
+        )
         return True, (
-            f"{len(p1)} inline [P1] finding(s) with no reply:\n{listing}\n"
+            f"review score {score:.1f} >= {_INLINE_SCORE_BLOCK_THRESHOLD:.1f} blocks "
+            f"(P1=1.0, P2={_INLINE_P2_SCORE_WEIGHT} each): {len(p1)} unresolved [P1] + "
+            f"{len(p2)} unresolved [P2] finding(s), none maintainer-replied:\n{listing}\n"
             f"Fix and reply in-thread, or append '# review-override' "
             f"to the merge command to acknowledge and proceed."
         )
@@ -5842,7 +5867,8 @@ def main() -> int:
                     return 2
 
                 # Inline review comments (Codex P1/P2 badges) — separate
-                # endpoint, separate check. P1 blocks; P2 warns.
+                # endpoint, separate check. Weighted score: P1=1.0, P2=0.5;
+                # blocks at >= 1.0 (any P1, or 2+ unresolved P2s).
                 should_block, inline_msg = _check_inline_review_findings(
                     pr_num,
                     force=force_override,

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1223,6 +1223,56 @@ class TestCheckInlineReviewFindings:
         err = capsys.readouterr().err
         assert "[P2] Preserve multi-word ledger keys" in err
 
+    # ── weighted review score: P1 = 1.0, P2 = 0.5, block at >= 1.0 ──
+    def test_inline_two_p2_block(self, guard_module):
+        """Two unresolved P2s score 1.0 >= threshold → BLOCK (a single P2 stays
+        advisory; see test_inline_p2_warns_but_allows)."""
+        with self._mock(
+            guard_module, [self._codex(1, _P2_BODY), self._codex(2, _P2_BODY)]
+        ):
+            block, msg = guard_module._check_inline_review_findings("100")
+        assert block
+        assert "score" in msg.lower()
+
+    def test_inline_p1_plus_p2_block_lists_both(self, guard_module):
+        """1 P1 (1.0) + 1 P2 (0.5) = 1.5 → BLOCK; the P1 title is listed."""
+        with self._mock(
+            guard_module, [self._codex(1, _P1_BODY), self._codex(2, _P2_BODY)]
+        ):
+            block, msg = guard_module._check_inline_review_findings("100")
+        assert block
+        assert "Make queue claim atomic" in msg
+
+    def test_inline_replied_p2_excluded_from_score(self, guard_module):
+        """A MAINTAINER reply acks a P2 (consciously accepted) — it drops from the
+        score, so two P2s where one is replied = 0.5 < 1.0 → no block."""
+        comments = [
+            self._codex(1, _P2_BODY),
+            self._codex(2, _P2_BODY),
+            {
+                "id": 3,
+                "reply_to": 2,
+                "login": "WingedGuardian",
+                "type": "User",
+                "assoc": "OWNER",
+                "body": "Accepted; tracked in a follow-up.",
+            },
+        ]
+        with self._mock(guard_module, comments):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert not block
+
+    def test_inline_doc_path_p2_excluded_from_score(self, guard_module):
+        """A P2 on a documentation path is not a code defect — excluded from the
+        score, so two P2s where one is on CHANGELOG.md = 0.5 < 1.0 → no block."""
+        comments = [
+            self._codex(1, _P2_BODY, path="src/genesis/foo.py"),
+            self._codex(2, _P2_BODY, path="CHANGELOG.md"),
+        ]
+        with self._mock(guard_module, comments):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert not block
+
     def test_replied_p1_is_acknowledged_by_maintainer(self, guard_module):
         """A MAINTAINER reply (author_association OWNER/MEMBER/COLLABORATOR) acks a P1."""
         comments = [

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1262,9 +1262,10 @@ class TestCheckInlineReviewFindings:
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
 
-    def test_inline_doc_path_p2_excluded_from_score(self, guard_module):
+    def test_inline_doc_path_p2_excluded_from_score(self, guard_module, capsys):
         """A P2 on a documentation path is not a code defect — excluded from the
-        score, so two P2s where one is on CHANGELOG.md = 0.5 < 1.0 → no block."""
+        score, so two P2s where one is on CHANGELOG.md = 0.5 < 1.0 → no block. But it is
+        still SURFACED as a NOTE (never silently dropped — Codex #1589 P2)."""
         comments = [
             self._codex(1, _P2_BODY, path="src/genesis/foo.py"),
             self._codex(2, _P2_BODY, path="CHANGELOG.md"),
@@ -1272,6 +1273,8 @@ class TestCheckInlineReviewFindings:
         with self._mock(guard_module, comments):
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
+        # The doc-path P2 must remain VISIBLE in the pre-merge report, not dropped.
+        assert "[doc P2]" in capsys.readouterr().err
 
     def test_replied_p1_is_acknowledged_by_maintainer(self, guard_module):
         """A MAINTAINER reply (author_association OWNER/MEMBER/COLLABORATOR) acks a P1."""


### PR DESCRIPTION
## Problem

The merge gate (`git_push_guard.py::_check_inline_review_findings`) blocked only on unresolved **P1** findings; **P2s were purely advisory** and never counted. So a PR with several P2s reported `MERGEABLE` against the intended design — e.g. **#1567 with 5 P2s** passed the gate. This is the gap behind the 2026-07-10 miss where 8 real P2s merged past the P1-only gate.

## Change

Compute a **weighted score** — P1 = 1.0, P2 = 0.5 — and block at **score ≥ 1.0**: any unresolved P1, **or ≥ 2 unresolved P2s**.

- The P2 branch gains the **same exclusions the P1 branch already had**: a **maintainer reply** engages/accepts the finding (drops it from the score), and a **documentation-path** finding is not a code defect. Mirrors P1 exactly.
- Block message lists both P1s and P2s and names the score.
- Threshold is a fixed policy value (works on any clone), not per-install configurable.

## Safety

Purely **additive strictness**: the P1 branch is byte-for-byte unchanged; fail-closed paths (unreadable/incomplete scan) and the `# review-override` escape hatch are preserved; a genuinely down/absent review still blocks. A both-badge comment is treated as P1 (stricter).

## Verification

- **Acceptance bar:** the real **#1567** (5 P2s) now reports `inline-findings: BLOCK — review score 2.5 >= 1.0` where the old gate said MERGEABLE.
- **Tests:** 617 merge-gate tests green (test_merge_review_gate 299 + characterization/repo/freshness 318); 5 new score tests **verify-RED'd both directions** (2-P2 boundary RED against P1-only code; the reply/doc exclusions RED with exclusions disabled).
- genesis-architect: **Ready to merge: Yes**, no BLOCKER/SHOULD-FIX (verified full state space, IEEE754 boundary, fail-closed, both callers, no weakening). 2 NOTE comment-fixes applied, 1 accepted.
- Docstring + genesis-development SKILL.md updated to the weighted-score contract.

Hook-surface change → current Codex review at head required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Merge checks now use weighted scoring for unresolved inline review findings.
  - A single P1 finding or at least two P2 findings blocks merging.
  - Maintainer-engaged findings and documentation-path P1/P2 findings do not contribute to the blocking score.
  - Documentation-path findings are surfaced as notes.
  - Warnings and notes remain non-blocking.

- **Documentation**
  - Updated merge guidance to explain weighted scoring and blocking criteria.

- **Tests**
  - Added coverage for scoring, exclusions, combined findings, and surfaced documentation notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->