### PR TITLE
fix(memory): load the graph as a multigraph so parallel typed edges survive

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -117,7 +117,8 @@ Easy-to-forget mechanisms:
   — first-party memory vs knowledge-base is a load-bearing distinction.
 - **Entity layer (WS-H Pillar 2)** — typed entity nodes with identity:
   `entities`/`entity_mentions`/`entity_links` tables (migration 0051),
-  `db/crud/entities.py` (recursive-CTE traversal, bi-temporal edge validity,
+  `db/crud/entities.py` (Python frontier BFS — one flat `IN`-list query per
+  depth level, NOT a recursive CTE — bi-temporal edge validity,
   EXTRACTED/INFERRED/AMBIGUOUS provenance, `merge_entity` tombstone-with-
   redirect), `memory/entity_registry.py` (string→ID resolution tiering; fuzzy
   matches queue `entity_adjudication`), `memory/entity_seed.py` (curated spine

--- a/src/genesis/eval/graph_bakeoff/engines/nx_incremental.py
+++ b/src/genesis/eval/graph_bakeoff/engines/nx_incremental.py
@@ -1,17 +1,26 @@
 """NetworkX-incremental control engine (the baseline candidate).
 
 Represents "NetworkX done correctly as an engine": it REUSES production's exact
-BFS (``genesis.memory.graph._bfs_with_strength``) so we measure the shipped
-traversal logic, but builds an ``nx.MultiDiGraph`` (not production's lossy
-``DiGraph``) so all 115 parallel-typed edge-pairs are preserved and it matches the
-all-rows SQL oracle. Its cold-start IS a full rebuild from the snapshot — the
-honest architecture, and the number that quantifies today's price of every one of
-the 11 ``invalidate_graph_cache()`` sites.
+BFS (``genesis.memory.graph._bfs_with_strength``) and builds an
+``nx.MultiDiGraph`` — the same shape production's ``_ensure_graph`` now builds —
+so all parallel-typed edge-pairs are preserved and it matches the all-rows SQL
+oracle. Its cold-start IS a full rebuild from the snapshot — the honest
+architecture, and the number that quantifies today's price of every one of the
+11 ``invalidate_graph_cache()`` sites.
 
-FINDING (for the doc): production ``graph.py`` uses a plain ``DiGraph`` that
-silently collapses those parallel-typed edges (last-write-wins). Any adopted
-engine — including a productionized incremental-NX — must fix that to represent
-the true multigraph.
+HISTORY: production ``graph.py`` used a plain ``DiGraph`` that silently collapsed
+those parallel-typed edges (last-write-wins) until the MultiDiGraph fix. This
+engine predates that fix and was the finding that motivated it; any adopted
+engine must keep representing the true multigraph. (The pair count quoted here
+was 115 at the 2026-08-06 snapshot and is 139 as of 2026-09-02 — it tracks the
+graph, so re-derive it rather than citing this line.)
+
+One residual difference from production: ``load()`` below calls ``add_edge``
+without an explicit ``key=``, so networkx assigns auto-incrementing integer
+keys, whereas production passes ``key=link_type``. On a snapshot containing a
+duplicate ``(source, target, link_type)`` row the two would diverge (this keeps
+both, production keeps one). The production PK forbids that row, so it cannot
+occur in a snapshot exported from a real database.
 """
 
 from __future__ import annotations

--- a/src/genesis/eval/graph_bakeoff/engines/nx_incremental.py
+++ b/src/genesis/eval/graph_bakeoff/engines/nx_incremental.py
@@ -65,7 +65,14 @@ class NxIncrementalEngine:
             for s, t, lt, st in conn.execute(
                 "SELECT source_id, target_id, link_type, strength FROM memory_links"
             ):
-                G.add_edge(s, t, link_type=lt, strength=st if st is not None else 0.0)
+                # Coalesce BOTH: production's `strength < min_strength` guard
+                # already rejects a None strength before selection, but the
+                # shared `_bfs_with_strength` now tie-breaks on the
+                # (strength, link_type) tuple, so a NULL link_type here would
+                # raise rather than sort. The production CHECK constraint makes
+                # that unreachable from a real snapshot; this keeps the engine
+                # honest against a hand-built one.
+                G.add_edge(s, t, link_type=lt or "", strength=st if st is not None else 0.0)
 
             mentions: dict[str, set[str]] = defaultdict(set)
             for mid, eid in conn.execute("SELECT memory_id, entity_id FROM entity_mentions"):

--- a/src/genesis/memory/graph.py
+++ b/src/genesis/memory/graph.py
@@ -145,8 +145,43 @@ def _bfs_with_strength(
         # the only one that must also PICK a type, so strongest-wins is a
         # deliberate choice, not an inherited convention. Revisit if polarity
         # types start appearing on multi-type pairs (0 of 139 today carry
-        # `contradicts` as their max-strength edge), since graph_expansion
-        # deliberately excludes those from LLM-visible context.
+        # `contradicts` as their max-strength edge). Note the consumers of THIS
+        # path (mcp/memory/core.py:431,:704) put link_type in front of the model
+        # and do NOT exclude `contradicts` — graph_expansion, which does exclude
+        # it, reaches the graph through memory_links_crud.neighbors_of and never
+        # calls this function. So demoting the type here is a small real
+        # improvement on the one path that surfaces it, not consistency with a
+        # subsystem that already filters it elsewhere.
+        #
+        # The comparison is on the (strength, link_type) TUPLE, not on strength
+        # alone, because strength alone leaves ties to row order: 106 of the 139
+        # live multi-type pairs carry EQUAL strengths (MEASURED 2026-09-02), and
+        # the loader's SELECT has no ORDER BY, so a strength-only max would keep
+        # reporting an arbitrary type for those — the same defect as the DiGraph
+        # collapse, just narrowed. The secondary key is a DETERMINISTIC tie-break,
+        # not a semantic ranking; it happens to demote `contradicts` (which sorts
+        # early), the safe direction. 0 of the 106 tied pairs carries one.
+        #
+        # This makes the choice WITHIN one (source, target) pair well-defined. It
+        # does NOT make the traversal's reported labels row-order independent, and
+        # nothing here claims that: the `visited` check below means a node
+        # reachable from several parents is claimed by whichever parent the queue
+        # reaches first, and queue order follows row order. MEASURED 2026-09-02 on
+        # the live graph: ~15.8% of reported labels flip under a reversed row
+        # order. Attribution at 500 roots traced every flip to multi-parent claim
+        # order and none to ties — but that zero is a SUBSAMPLE BOUND, not an
+        # absolute: at 3000 roots the tie-break itself removes 16 of 21,486 flips
+        # (~0.07%). Ties are a rounding error on this surface, not nil.
+        #
+        # Pre-existing (~15.8% before the multigraph change too) and tracked as
+        # follow-up ab0d0c28 rather than changed here, since best-parent-wins is a
+        # traversal-semantics change needing its own blast-radius measurement.
+        # "Reach-set-neutral (0 delta)" holds for THIS function's full output, but
+        # not for what the model sees: core.py:437,:709 slice nodes[:5] after a
+        # stable sort on (depth, -strength), so on 3.5% of roots a different SET
+        # of five memories reaches the context depending on row order. Same root
+        # cause, same follow-up — stated here so the bound is not read as wider
+        # than it is.
         best: dict[str, tuple[float, str]] = {}
         for _, neighbor, data in G.out_edges(node, data=True):
             if neighbor in visited:
@@ -160,7 +195,7 @@ def _bfs_with_strength(
                 continue
 
             current = best.get(neighbor)
-            if current is None or strength > current[0]:
+            if current is None or (strength, edge_type) > current:
                 best[neighbor] = (strength, edge_type)
 
         for neighbor, (strength, edge_type) in best.items():

--- a/src/genesis/memory/graph.py
+++ b/src/genesis/memory/graph.py
@@ -1,6 +1,7 @@
 """Knowledge graph traversal with NetworkX caching.
 
-Primary path: in-memory NetworkX DiGraph loaded lazily from memory_links.
+Primary path: in-memory NetworkX MultiDiGraph loaded lazily from memory_links
+(a multigraph because one memory pair may carry several typed edges).
 Fallback: recursive CTE queries (if NetworkX import fails or cache is cold
 during the first query of a session).
 
@@ -49,7 +50,7 @@ class TraversalResult:
 
 # ─── NetworkX cache ───────────────────────────────────────────────────────────
 
-_nx_graph: object | None = None  # nx.DiGraph when _NX_AVAILABLE
+_nx_graph: object | None = None  # nx.MultiDiGraph when _NX_AVAILABLE
 _nx_dirty: bool = True
 
 
@@ -76,10 +77,17 @@ async def _ensure_graph(db: aiosqlite.Connection) -> object:
     )
     rows = await cursor.fetchall()
 
-    G = nx.DiGraph()
+    # MultiDiGraph, not DiGraph: memory_links' primary key is
+    # (source_id, target_id, link_type), so one pair may legitimately carry
+    # several typed edges. A DiGraph cannot hold parallel edges — the second
+    # add_edge for a pair overwrites the first's attributes — so the graph kept
+    # an arbitrary survivor and the strength/link_type filters below were
+    # evaluated against it.
+    G = nx.MultiDiGraph()
     for source_id, target_id, link_type, strength in rows:
         G.add_edge(
             source_id, target_id,
+            key=link_type,
             link_type=link_type, strength=strength,
         )
 
@@ -101,7 +109,7 @@ async def _ensure_graph(db: aiosqlite.Connection) -> object:
 
 
 def _bfs_with_strength(
-    G: object,  # nx.DiGraph
+    G: object,  # nx.MultiDiGraph
     root_id: str,
     *,
     max_depth: int,
@@ -125,6 +133,21 @@ def _bfs_with_strength(
         if depth >= max_depth:
             continue
 
+        # A pair may carry several typed edges (MultiDiGraph), so out_edges
+        # yields one tuple per parallel edge. Consider them all and keep the
+        # STRONGEST that passes the filters — otherwise the arbitrary survivor
+        # merely moves from load time to traversal time (the first parallel
+        # edge would win via the `visited` check) and a weak edge could still
+        # mask a strong one.
+        #
+        # Strength-max mirrors memory_links.neighbors_of's MAX(strength)
+        # collapse, but note neighbors_of returns no link_type — this path is
+        # the only one that must also PICK a type, so strongest-wins is a
+        # deliberate choice, not an inherited convention. Revisit if polarity
+        # types start appearing on multi-type pairs (0 of 139 today carry
+        # `contradicts` as their max-strength edge), since graph_expansion
+        # deliberately excludes those from LLM-visible context.
+        best: dict[str, tuple[float, str]] = {}
         for _, neighbor, data in G.out_edges(node, data=True):
             if neighbor in visited:
                 continue
@@ -136,6 +159,11 @@ def _bfs_with_strength(
             if link_type_filter and edge_type != link_type_filter:
                 continue
 
+            current = best.get(neighbor)
+            if current is None or strength > current[0]:
+                best[neighbor] = (strength, edge_type)
+
+        for neighbor, (strength, edge_type) in best.items():
             visited.add(neighbor)
             results.append(GraphNode(
                 memory_id=neighbor,

--- a/tests/test_memory/test_graph_parallel_edges.py
+++ b/tests/test_memory/test_graph_parallel_edges.py
@@ -12,11 +12,18 @@ what ``_bfs_with_strength``'s ``min_strength`` / ``link_type_filter`` checks
 were evaluated against — so a weak or wrong-typed survivor could hide a
 neighbour that a strong, matching parallel edge really does reach.
 
-MEASURED on the live database (2026-09-02): 252,525 link rows collapsed to
-252,383 distinct pairs — 142 edges lost across 139 multi-type pairs — and 0 of
-those pairs straddled a live ``min_strength`` threshold. So no recall result is
-known to be wrong today; these tests lock the correctness property before an
-engine migration builds on the loader, and they fail on the pre-fix code.
+MEASURED on the live database (2026-09-02): 142 edges lost across 139 multi-type
+pairs, and 0 of those pairs straddled a live ``min_strength`` threshold. So no
+recall result is known to be wrong today; these tests lock the correctness
+property before an engine migration builds on the loader, and they fail on the
+pre-fix code. (Row and pair counts track a growing table — 252,525 rows at the
+first measurement, 252,773 hours later — so re-derive them rather than quoting
+these numbers.)
+
+What these tests do NOT establish: that a traversal's reported labels are
+independent of row order. They are not, for a reason that predates this module —
+see ``test_tied_strength_resolves_independently_of_row_order``'s SCOPE note and
+follow-up ab0d0c28.
 
 Note the fixture below uses the PRODUCTION primary key. The pre-existing
 fixture in ``test_graph.py`` declares ``PRIMARY KEY (source_id, target_id)``,
@@ -34,23 +41,36 @@ from genesis.memory.graph import invalidate_graph_cache, traverse
 pytestmark = pytest.mark.asyncio
 
 
+# Single-sourced so the two builders below cannot drift apart.
+_SCHEMA = """
+    CREATE TABLE memory_links (
+        source_id   TEXT NOT NULL,
+        target_id   TEXT NOT NULL,
+        link_type   TEXT NOT NULL,
+        strength    REAL NOT NULL DEFAULT 0.5,
+        created_at  TEXT NOT NULL,
+        PRIMARY KEY (source_id, target_id, link_type)
+    )
+"""
+
+
+async def _make_db(links):
+    """Build an in-memory DB holding ``links`` in the given INSERTION order."""
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute(_SCHEMA)
+    for src, tgt, link_type, strength in links:
+        await db.execute(
+            "INSERT INTO memory_links VALUES (?, ?, ?, ?, '2026-09-02')",
+            (src, tgt, link_type, strength),
+        )
+    await db.commit()
+    return db
+
+
 @pytest.fixture
 async def parallel_db():
     """A DB whose memory_links PK matches production (pair + link_type)."""
-    db = await aiosqlite.connect(":memory:")
-    db.row_factory = aiosqlite.Row
-    await db.execute(
-        """
-        CREATE TABLE memory_links (
-            source_id   TEXT NOT NULL,
-            target_id   TEXT NOT NULL,
-            link_type   TEXT NOT NULL,
-            strength    REAL NOT NULL DEFAULT 0.5,
-            created_at  TEXT NOT NULL,
-            PRIMARY KEY (source_id, target_id, link_type)
-        )
-        """
-    )
     # Under a DiGraph the surviving edge is whichever row loads LAST, so which
     # edge survives depends on the SELECT's row order — and the loader's query
     # carries no ORDER BY. Insertion order is NOT enough to pin that: an index
@@ -73,12 +93,7 @@ async def parallel_db():
         ("A", "D", "extends", 0.9),
         ("A", "C", "extends", 0.8),
     ]
-    for src, tgt, link_type, strength in links:
-        await db.execute(
-            "INSERT INTO memory_links VALUES (?, ?, ?, ?, '2026-09-02')",
-            (src, tgt, link_type, strength),
-        )
-    await db.commit()
+    db = await _make_db(links)
 
     invalidate_graph_cache()
     yield db
@@ -121,3 +136,69 @@ async def test_reported_edge_is_the_strongest_passing_one(parallel_db):
     for pair in ("B", "D"):
         assert by_id[pair].strength == pytest.approx(0.9), pair
         assert by_id[pair].link_type == "extends", pair
+
+
+async def test_tied_strength_resolves_independently_of_row_order():
+    """Equal-strength parallel edges on ONE pair must not resolve by row order.
+
+    Selecting the strongest edge leaves the ties unresolved: 106 of the live
+    graph's 139 multi-type pairs (MEASURED 2026-09-02) carry EQUAL strengths, so
+    for those the reported ``link_type`` was still whichever row happened to load
+    first — the same arbitrary-survivor defect this module exists for, merely
+    narrowed from 139 pairs to 106. The loader's SELECT has no ORDER BY, so
+    "first" is a query-plan accident that can differ between rebuilds.
+
+    SCOPE — read this before trusting the name. The single root here has exactly
+    one neighbour, so the property under test is the WITHIN-PAIR choice and
+    nothing more. Traversal-wide label determinism is a DIFFERENT and much larger
+    property that this does not test and the code does not have: a node reachable
+    from several parents is claimed by whichever parent the queue reaches first
+    (15.84% of live labels flip under a reversed row order, 100% from that cause
+    and 0% from ties — follow-up ab0d0c28). A multi-parent fixture here would
+    measure that instead and pass or fail for the wrong reason.
+
+    This asserts the property that actually matters — the SAME answer from two
+    row orders — rather than a specific winner under one order, because an
+    order-specific assertion goes vacuously green the moment the planner picks a
+    different scan. The pinned value is asserted as well, so the test still fails
+    under an index scan (where both orders agree, but on the wrong edge).
+
+    Honest coverage limit, MEASURED against the real ``_bfs_with_strength`` in all
+    four orders rather than reasoned: only TWO discriminate. The pre-fix code kept
+    the first-loaded edge, so any order that loads the alphabetically-last edge
+    first already agreed with the fixed behaviour — that is BOTH descending orders
+    (rowid-reversed and PK-index DESC), where pre- and post-fix are behaviourally
+    identical for every tied pair and no fixture can be red. This test is red on
+    a rowid scan (today's plan) via the invariance assertion, and on an ascending
+    PK-index scan via the pinned value below. A tie-break policy cannot escape
+    this: ties resolve on link_type, and the PK index is ordered by link_type, so
+    one index direction always coincides with the policy.
+    """
+    tied = [
+        ("A", "E", "decided", 0.7),
+        ("A", "E", "supports", 0.7),
+    ]
+    reported = {}
+    for label, links in (("forward", tied), ("reversed", list(reversed(tied)))):
+        # The graph cache is module-global and this test takes no fixture that
+        # clears it, so without this the FIRST load could reuse a graph left
+        # behind by a preceding test. Iteration 2 is already covered by the
+        # `finally` below — measured: removing this line does NOT make the test
+        # pass on pre-fix code, so it guards the first load, nothing more.
+        invalidate_graph_cache()
+        db = await _make_db(links)
+        try:
+            result = await traverse(db, "A", max_depth=1, min_strength=0.0)
+            reported[label] = {n.memory_id: n for n in result.nodes}["E"].link_type
+        finally:
+            invalidate_graph_cache()
+            await db.close()
+
+    assert reported["forward"] == reported["reversed"], (
+        f"tied parallel edges resolved by row order: {reported}"
+    )
+    # Deterministic, not semantically ranked: max strength, then the highest
+    # link_type. Lexicographic-max happens to DEMOTE 'contradicts' (it sorts
+    # early), which is the safe direction — graph_expansion excludes that type
+    # from LLM-visible context. MEASURED: 0 of the 106 tied pairs carries one.
+    assert reported["forward"] == "supports"

--- a/tests/test_memory/test_graph_parallel_edges.py
+++ b/tests/test_memory/test_graph_parallel_edges.py
@@ -1,0 +1,123 @@
+"""Parallel typed edges must survive the graph load.
+
+`memory_links`' production primary key is ``(source_id, target_id, link_type)``
+(migration 0029: "distinct relationship types between the same pair … must
+coexist, not silently overwrite"), so ONE memory pair can legitimately carry
+several typed edges.
+
+`graph.py` loaded those rows into an ``nx.DiGraph``, which cannot hold parallel
+edges: the second ``add_edge`` for a pair OVERWRITES the first one's attributes.
+The graph therefore kept an ARBITRARY survivor per pair, and the survivor is
+what ``_bfs_with_strength``'s ``min_strength`` / ``link_type_filter`` checks
+were evaluated against — so a weak or wrong-typed survivor could hide a
+neighbour that a strong, matching parallel edge really does reach.
+
+MEASURED on the live database (2026-09-02): 252,525 link rows collapsed to
+252,383 distinct pairs — 142 edges lost across 139 multi-type pairs — and 0 of
+those pairs straddled a live ``min_strength`` threshold. So no recall result is
+known to be wrong today; these tests lock the correctness property before an
+engine migration builds on the loader, and they fail on the pre-fix code.
+
+Note the fixture below uses the PRODUCTION primary key. The pre-existing
+fixture in ``test_graph.py`` declares ``PRIMARY KEY (source_id, target_id)``,
+which structurally forbids the shape under test — which is precisely why the
+existing suite could never have caught this.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+
+from genesis.memory.graph import invalidate_graph_cache, traverse
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def parallel_db():
+    """A DB whose memory_links PK matches production (pair + link_type)."""
+    db = await aiosqlite.connect(":memory:")
+    db.row_factory = aiosqlite.Row
+    await db.execute(
+        """
+        CREATE TABLE memory_links (
+            source_id   TEXT NOT NULL,
+            target_id   TEXT NOT NULL,
+            link_type   TEXT NOT NULL,
+            strength    REAL NOT NULL DEFAULT 0.5,
+            created_at  TEXT NOT NULL,
+            PRIMARY KEY (source_id, target_id, link_type)
+        )
+        """
+    )
+    # Under a DiGraph the surviving edge is whichever row loads LAST, so which
+    # edge survives depends on the SELECT's row order — and the loader's query
+    # carries no ORDER BY. Insertion order is NOT enough to pin that: an index
+    # scan would resolve EVERY pair by the same alphabetical link_type rule, so
+    # "two pairs inserted in opposite orders" still leaves both keeping the same
+    # side. The link_types below are chosen so the WEAK edge sorts LAST for A→B
+    # and FIRST for A→D:
+    #   rowid / PK-index ASC  -> A→B keeps the weak 'supports' 0.2
+    #   reversed / PK DESC    -> A→D keeps the weak 'action_item_for' 0.2
+    # so at least one pair is broken under every plausible scan order, and the
+    # assertions below (which require BOTH pairs correct) fail on the old
+    # loader in all of them. VERIFIED across all four orders, not assumed.
+    # (Two earlier revisions of this fixture were vacuous — first by insertion
+    # order, then by index order — which is why the property is now pinned in
+    # the DATA rather than in a comment.)
+    links = [
+        ("A", "B", "extends", 0.9),
+        ("A", "B", "supports", 0.2),
+        ("A", "D", "action_item_for", 0.2),
+        ("A", "D", "extends", 0.9),
+        ("A", "C", "extends", 0.8),
+    ]
+    for src, tgt, link_type, strength in links:
+        await db.execute(
+            "INSERT INTO memory_links VALUES (?, ?, ?, ?, '2026-09-02')",
+            (src, tgt, link_type, strength),
+        )
+    await db.commit()
+
+    invalidate_graph_cache()
+    yield db
+    invalidate_graph_cache()
+    await db.close()
+
+
+async def test_parallel_edges_both_survive_the_load(parallel_db):
+    """Both typed A→B rows must exist in the loaded graph, not just one."""
+    from genesis.memory.graph import _ensure_graph
+
+    graph = await _ensure_graph(parallel_db)
+    # 5 rows in, 5 edges out. A DiGraph collapses each multi-type pair to one
+    # edge and yields 3.
+    assert graph.number_of_edges() == 5
+
+
+async def test_weak_parallel_edge_cannot_mask_a_strong_one(parallel_db):
+    """min_strength must consider EVERY parallel edge, not an arbitrary one.
+
+    A→B and A→D each carry a 0.2 and a 0.9 edge, so at min_strength=0.5 both
+    are reachable via their 0.9 'extends' edge. If the loader kept only a weak
+    survivor for a pair, that neighbour is wrongly filtered out entirely.
+    """
+    result = await traverse(parallel_db, "A", max_depth=1, min_strength=0.5)
+    ids = {n.memory_id for n in result.nodes}
+    assert {"B", "D"} <= ids, "a strong parallel edge was masked by a weak one"
+    assert "C" in ids
+
+
+async def test_reported_edge_is_the_strongest_passing_one(parallel_db):
+    """The surfaced link_type/strength must not be an arbitrary parallel edge.
+
+    Results are ordered by strength and sliced to the top 5 before reaching the
+    model (mcp/memory/core.py), so reporting 0.2/'supports' when a 0.9/'extends'
+    edge exists is wrong on both counts — and can reorder that slice.
+    """
+    result = await traverse(parallel_db, "A", max_depth=1, min_strength=0.0)
+    by_id = {n.memory_id: n for n in result.nodes}
+    for pair in ("B", "D"):
+        assert by_id[pair].strength == pytest.approx(0.9), pair
+        assert by_id[pair].link_type == "extends", pair


### PR DESCRIPTION
## The defect

`memory_links`' primary key is `(source_id, target_id, link_type)` — migration 0029 made distinct relationship types between the same pair coexist rather than overwrite. The loader then dropped them again: `_ensure_graph` built an `nx.DiGraph`, which cannot hold parallel edges, so the second `add_edge` for a pair overwrote the first's attributes and the graph kept an **arbitrary survivor** (whichever row loaded last).

That survivor is what `_bfs_with_strength`'s `min_strength` and `link_type_filter` were evaluated against — so a weak or wrong-typed survivor could hide a neighbour that a strong, matching parallel edge really does reach.

## The fix

Load into `nx.MultiDiGraph` keyed by `link_type` (mirroring the PK), and select the strongest passing edge per neighbour during traversal, **breaking ties on `link_type`**.

Max-strength selection is not optional: once the graph holds parallel edges, the old loop's `if neighbor in visited: continue` fires on the second parallel edge, so a bare graph-type swap would move the arbitrary survivor from load time to traversal time. The tie-break is not optional either — see below, only 33 of 139 multi-type pairs have a unique max.

## Measured (real database, ~252,700 link rows)

| | |
|---|---|
| Edges recovered | **142**, across 139 multi-type pairs |
| Pairs straddling `min_strength` 0.3 or 0.5 | **0 and 0** — exhaustive over the whole population |
| Multi-type pairs with a UNIQUE max strength | **33** |
| Multi-type pairs with a **TIED** max strength | **106** |
| Tied pairs containing a `contradicts` edge | **0** |
| Labels changed by the tie-break (same row order) | **10 / 140,286 (0.007%)** |
| Betweenness delta (DiGraph vs MultiDiGraph) | **~1e-17** |
| Rebuild time | 1508ms → 2394ms (**+59%**) |
| Additional peak RSS | **~+47MB** |

**Reach-set is provably unchanged.** 0.3 and 0.5 are the only thresholds any caller uses, and no multi-type pair straddles either — so no traversal *can* reach a different set of nodes. Exhaustive over all 139 pairs, not a sample. A 3,000-root replay agreed at both thresholds: 0 roots changed.

**Centrality is unaffected**, structurally rather than by luck: betweenness iterates neighbours, not edges, and the two graphs have identical adjacency. The dream-cycle importance shield therefore selects the same population.

## A correction to this PR's earlier claims

An earlier revision of this PR body and commit message said the reported `(link_type, strength)` "becomes deterministic-max instead of arbitrary." **That was wrong, and the tie-break does not make it true either.** Verifying the tie-break end-to-end surfaced a much larger effect:

Loading the same graph in **reversed row order** and running the same traversals flips **~15.8% of reported labels** (3,533 of 22,299 at 500 roots). At that sample every flip traced to a node claimable by more than one parent and none to a parallel-edge tie — but **that zero is a subsample bound, not an absolute**: at 3,000 roots the tie-break itself removes 16 of 21,486 flips (~0.07%). Ties are a rounding error on this surface, not nil. The dominant cause is the visited-set BFS letting whichever parent the queue reaches first claim the node, and queue order follows the loader's unordered `SELECT`.

That effect is **pre-existing and not introduced here** — the pre-PR `DiGraph` plus the original first-edge-wins BFS measures the same ~15.8% on the same roots.

"Reach-set unaffected (0 delta)" holds for `_bfs_with_strength`'s **full output**, but not for what the model actually sees: `mcp/memory/core.py:437` and `:709` slice `nodes[:5]` after a *stable* sort on `(depth, -strength)`, so ties in that key keep row order. Measured at the real call parameters (`max_depth=2, min_strength=0.3`, 3,000 roots): **102 of 2,904 roots (3.5%) get a different SET of five memories** into LLM context depending on row order, and 281 (9.7%) get the same five in a different order. That slice surface is the acceptance bar for the follow-up.

It is tracked as its own follow-up rather than fixed here: best-parent-wins is a traversal-semantics change affecting ~16% of reported labels and needs its own blast-radius measurement and review, and bundling it would make this diff two unrelated arguments at once.

**So what this PR claims, precisely:** parallel typed edges survive the load, `min_strength`/`link_type_filter` are evaluated against the real edge set rather than an arbitrary survivor, the choice *within* a pair is well-defined, and the loader represents the true multigraph an engine migration will build on. It does **not** claim row-order-independent labels.

## Cost

The rebuild is ~886ms slower and holds ~47MB more. It lands on a path that already exceeded its own traversal budget before this change, so this makes an existing problem more visible rather than introducing a new one. The synchronous rebuild's event-loop cost is tracked as a separate follow-up — a performance concern that should not be mixed into a correctness fix.

## Verification

Four tests, all watched RED before their fix and green after; both mutations re-confirmed RED (`MultiDiGraph`→`DiGraph` fails all four; tuple→strength-only fails exactly the tie test), applied with an anchor-count assertion and a `compile()` postcondition and restored by hash comparison.

Worth noting *how* the fixture got here, because three revisions were vacuous:

1. **Revision 1** — only 2 of 3 failed pre-fix; the strong edge happened to be the last-loaded survivor.
2. **Revision 2** — claimed order-independence via "two pairs inserted in opposite orders". That does not hold: under a PK-index scan every pair resolves by the same alphabetical rule, so both pairs keep the same side. Red in practice only because today's plan is a rowid scan — a planner accident, not a contract.
3. **Revision 3 (shipped)** — pins the property in the *data*, verified RED across insertion, PK-index ascending, reversed, and PK-index descending order.

The new tie test does not repeat that mistake: it asserts the answer is the **same from two row orders** rather than naming a winner under one, so it cannot go vacuously green when the planner changes. Its coverage limit is stated honestly in the docstring — measured, not reasoned: only 2 of the 4 scan orders can discriminate, because both descending orders already agree with the fixed behaviour.

Also fixed: the bake-off control engine's docstring described production's loader as lossy and flagged that as a finding staged for the engine write-up — this PR makes it false, and a stale claim there would propagate into an engine-adoption decision. And the subsystem map described `db/crud/entities.py` as recursive-CTE traversal; it is a Python frontier BFS issuing one query per depth level.

## Known residual (pre-existing, not introduced)

The CTE fallback used when NetworkX is unavailable emits one row per `(target, link_type, depth, strength)` while the NetworkX path emits one node per target, and it uses path-substring cycle avoidance rather than a visited set. This change narrows one axis — the NetworkX row is now the strongest — but does not close the divergence, and this PR does not claim parity between the two paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved multiple relationship types between the same memories during graph loading and traversal.
  - Traversal now evaluates parallel relationships and reports the strongest qualifying connection and its type.
  - Equal-strength relationships now produce deterministic results.
  - Strength filters correctly retain eligible parallel connections.
  - Improved consistency between production graph behavior and evaluation tooling.
- **Documentation**
  - Clarified graph traversal and relationship-handling behavior.
- **Tests**
  - Added coverage for parallel relationships and deterministic tie-breaking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->