### PR TITLE
fix(tests): stop the earn-back fixture aging out of its own window

### DIFF
--- a/tests/test_mcp/test_calibration_status.py
+++ b/tests/test_mcp/test_calibration_status.py
@@ -7,7 +7,7 @@ phrasing, NEVER a bare percentage (design §3.4/§4.3).
 from __future__ import annotations
 
 import re
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import aiosqlite
@@ -196,18 +196,52 @@ async def _seed_autonomy(db, *, category="direct_session", current=2, earned=4):
     await db.commit()
 
 
-async def _seed_events(db, category, *, successes=0, corrections=0):
+def _ago(days: int) -> str:
+    """An ``occurred_at`` ``days`` before REAL now — never the frozen ``NOW``.
+
+    The earn-back surface reads its evidence through
+    ``crud.autonomy.windowed_counts``, which ages ``occurred_at`` against
+    ``datetime.now(UTC)``; ``calibration_status`` never injects a clock, so the
+    window always moves with the real calendar. Stamping events with the module's
+    frozen ``NOW`` therefore built a time bomb rather than a fixture: events dated
+    2026-07-19 sat inside the 45-day window when written and fell out of it on
+    2026-09-02, turning the suite red on every open PR at once.
+
+    The rest of this module may keep using ``NOW``, but for TWO different reasons,
+    and a new site is safe only if one of them holds:
+
+    * ``replace_cells`` / ``append_history`` take an explicit ``now=``, so their
+      timestamps are genuinely frozen rather than merely stamped.
+    * ``_seed_autonomy`` stamps ``autonomy_state.updated_at`` by raw INSERT with no
+      ``now=`` anywhere in the path — safe only because NOTHING AGES IT:
+      ``autonomy_crud.list_all`` is a bare SELECT with no time predicate, and
+      ``_earnback_evidence`` reads only category/current_level/earned_level/
+      ``last_regression_at`` off that row.
+
+    So "it takes a ``now=``" is NOT this file's invariant; "it is injected OR it is
+    never compared to a clock" is. ``autonomy_events.occurred_at`` is the one column
+    here that production does age against the live clock, and it is the only one this
+    helper stamps.
+
+    (A sibling ``_ago`` in ``tests/test_ledger/test_cells.py`` has the OPPOSITE
+    semantics — frozen-relative, ``NOW - delta``. Different module, but do not copy
+    one into the other.)
+    """
+    return (datetime.now(UTC) - timedelta(days=days)).isoformat()
+
+
+async def _seed_events(db, category, *, successes=0, corrections=0, age_days=0, tag="a"):
     for i in range(successes):
         await db.execute(
             "INSERT INTO autonomy_events (id, category, kind, occurred_at)"
             " VALUES (?, ?, 'success', ?)",
-            (f"ev-s-{category}-{i}", category, NOW.isoformat()),
+            (f"ev-s-{category}-{tag}-{i}", category, _ago(age_days)),
         )
     for i in range(corrections):
         await db.execute(
             "INSERT INTO autonomy_events (id, category, kind, occurred_at)"
             " VALUES (?, ?, 'correction', ?)",
-            (f"ev-c-{category}-{i}", category, NOW.isoformat()),
+            (f"ev-c-{category}-{tag}-{i}", category, _ago(age_days)),
         )
     await db.commit()
 
@@ -234,6 +268,36 @@ async def test_earnback_surfaces_demoted_category_with_windowed_evidence(db):
     assert entry["window_corrections"] == 1
     assert 0.0 < entry["posterior"] <= 1.0
     assert isinstance(entry["evidence_supports_earned"], bool)
+
+
+@pytest.mark.asyncio
+async def test_earnback_counts_only_events_inside_the_window(db):
+    """Events older than the 45-day earn-back window must NOT be counted.
+
+    This direction was untested, which is why the frozen-``NOW`` bomb above was
+    invisible: with every event seeded at one timestamp, a suite that counted the
+    window correctly and one that ignored the window entirely produced the same
+    number, right up until the calendar moved the fixture outside the window and
+    the count went to zero. Seeding BOTH sides is what makes the window itself the
+    thing under test.
+    """
+    await cc_crud.replace_cells(db, [_cell()], now=NOW)
+    await _seed_autonomy(db, current=2, earned=4)
+    await _seed_events(db, "direct_session", successes=3, corrections=1, age_days=1, tag="in")
+    await _seed_events(db, "direct_session", successes=5, corrections=2, age_days=60, tag="out")
+
+    result = await _run(db)
+    (entry,) = result["earnback"]["demoted_categories"]
+    assert entry["window_successes"] == 3, "events outside the window were counted"
+    assert entry["window_corrections"] == 1, "events outside the window were counted"
+
+    # The 1d/60d fixture only discriminates a LARGE window change, so pin the
+    # width too — nothing else in the suite asserts it, and _EARNBACK_WINDOW_DAYS
+    # is documented as mirroring autonomy.yaml `earnback.window_days`. This locks
+    # the CONSTANT (drift becomes a red), not the mirror itself; the true 44d/46d
+    # boundary is pinned in test_state_machine.py, where a clock CAN be injected
+    # and a tight-margin fixture is therefore safe.
+    assert entry["window_days"] == 45
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## This is currently red on every open PR

`tests/test_mcp/test_calibration_status.py::test_earnback_surfaces_demoted_category_with_windowed_evidence` started failing today with `assert 0 == 30`. It is not a flake and not caused by any recent change — it is a time bomb with a 45-day fuse, lit when the test was written.

The module freezes `NOW = datetime(2026, 7, 19, 12, 0, 0, tzinfo=UTC)` and stamped `autonomy_events.occurred_at` with it. Production reads that column through `crud.autonomy.windowed_counts`, which ages it against `datetime.now(UTC)` — `calibration_status` injects no clock — with `_EARNBACK_WINDOW_DAYS = 45`.

Measured at diagnosis:

| | |
|---|---|
| seeded events | `2026-07-19T12:00:00+00:00` |
| real now | `2026-09-02T13:45:44+00:00` |
| 45-day cutoff | `2026-07-19T13:45:44+00:00` |
| events inside window? | **False — they fell out 1h45m earlier** |

## The fix

Stamp the events relative to **real** now via an `_ago()` helper, mirroring the established precedent in `tests/test_memory_integrity/test_posture_and_jobs.py` (commit `95442438`). Margins become 44 days on one side and 15 on the other, rather than the minutes-wide margins behind the historical recurrences of this class.

Production is untouched; this is a test-only change.

## The coverage that was actually missing

Nothing asserted that the window **excludes** anything — and that absence is why the bomb was invisible rather than merely present. With every event stamped at a single instant, a correct window and no window at all produce the same count, right up until the calendar moves the fixture out and the number silently becomes zero.

The new `test_earnback_counts_only_events_inside_the_window` seeds **both** sides (1 day in, 60 days out) and asserts only the inside events count. Verified RED by widening the window `45 → 3650`, which is equivalent to deleting the window logic entirely.

It also pins the window width, which no test asserted either, so a change to `_EARNBACK_WINDOW_DAYS` becomes a red rather than a silent drift from the config default it is documented as mirroring.

The 45-day **boundary** is deliberately *not* pinned here. This surface injects no clock, so a 44d/46d fixture would be a tight-margin bomb of exactly the class being fixed. The boundary is already pinned in `tests/test_autonomy/test_state_machine.py`, where a clock can be injected.

## Why the CI guard did not catch it

`scripts/check_frozen_clock.py` names this shape in its own docstring as knowingly uncovered:

> an absolute date LITERAL near a production threshold. A real bomb, but not statically decidable — it depends on a threshold this guard cannot know. NOT covered here, and no claim is made that the literal population is clean.

That remains true; this PR does not change the guard.

## On the wider class — a floor, not a measurement

An attempt to size the population found 171 absolute datetime literals across 71 of 1,309 test files, and a cross-reference against production moving-window sites yielded 47 candidate files. **That scan failed its own acceptance replay**: it does not catch this very bomb, because the clock read and the subtraction sit on separate lines behind an intermediate variable and the pattern only matched them joined. So 47 is a floor from a demonstrably blind matcher.

A narrower sweep of the 12 files touching this table found no other instance, which bounds this table but not the repo. A real detector would be dynamic — run the suite against an advanced clock and diff the failures — and is left as a separate proposal.

## Verification

72 tests pass across `test_calibration_status.py`, `test_autonomy/test_state_machine.py` and `test_ledger/test_cells.py` (the sibling suites touching the same table). `ruff --no-cache` clean. `scripts/check_frozen_clock.py` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for calibration status calculations using event timestamps relative to the current UTC time.
  * Verified that only events within the 45-day earn-back window affect success and correction counts.
  * Added assertions for the reported earn-back window size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->