### PR TITLE
fix(cc): ship roster infrastructure, not an unprovisionable peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,18 +146,22 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
       failover_order: 1
   ```
 
-  This matters because the failure is quiet: an overlay setting `default: glm-5.2`
-  with no matching entry does not error — it falls back to native Claude, so a
+  This matters because the failure is quiet FOR THE USER: an overlay setting
+  `default: glm-5.2` with no matching entry falls back to native Claude, so a
   subscription-cap fallback you believed was configured would simply not engage.
+  It is not silent in the logs (`apply_active` logs an error with a traceback),
+  and the `cc_roster` settings domain rejects such a write outright — the quiet
+  path is a hand-edited overlay.
 
-  `secrets.env.example` now documents both Z.AI keys and which endpoint each one
-  serves: a Coding Plan key (`ZAI_CODING_API_KEY`) is required for a roster peer
+  `secrets.env.example` now documents all three GLM key slots and which endpoint
+  each one serves: a Coding Plan key (`ZAI_CODING_API_KEY`) is required for a roster peer
   because Claude Code speaks the Anthropic protocol, while a general/prepaid key
   (`ZHIPU_API_KEY`) works only on `/api/paas/v4`. Using the general key on a coding
   endpoint returns `1113 Insufficient balance` even when the account is funded.
 
-  The `validated:` field is unchanged but now documented as advisory only — no code
-  reads it. Stale stamps were dropped rather than carried forward unverified.
+  The `validated:` field is unchanged but now documented as advisory only: it is
+  parsed into `RosterEntry.validated` and then acted on by nothing, so it gates
+  nothing. Stale stamps were dropped rather than carried forward unverified.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,42 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   session and fail-open: a fresh session stays silent, and any read/parse miss emits
   nothing.
 
+### Changed
+
+- **The Claude Code model roster now ships infrastructure, not a preconfigured
+  provider.** `config/cc_roster.yaml` previously shipped a `glm-5.2` peer pointed at
+  `open.bigmodel.cn`, which requires Chinese real-name identity verification (实名认证)
+  to buy a Coding Plan — so on any install outside China the documented rate-limit
+  fallback could not be provisioned at all. The base config now ships only the native `claude` entry
+  plus commented examples for both Z.AI platforms (`api.z.ai` international,
+  `open.bigmodel.cn` China) and several other Anthropic-compatible providers.
+
+  **If you were using the shipped peer, you must now declare it yourself** in
+  `~/.genesis/config/cc_roster.local.yaml`, which is deep-merged over the base file
+  and is where the `cc_roster` settings domain already writes:
+
+  ```yaml
+  models:
+    glm-5.3:
+      anthropic_base_url: "https://api.z.ai/api/anthropic"
+      auth_env: ZAI_CODING_API_KEY
+      model_id: glm-5.3
+      failover_order: 1
+  ```
+
+  This matters because the failure is quiet: an overlay setting `default: glm-5.2`
+  with no matching entry does not error — it falls back to native Claude, so a
+  subscription-cap fallback you believed was configured would simply not engage.
+
+  `secrets.env.example` now documents both Z.AI keys and which endpoint each one
+  serves: a Coding Plan key (`ZAI_CODING_API_KEY`) is required for a roster peer
+  because Claude Code speaks the Anthropic protocol, while a general/prepaid key
+  (`ZHIPU_API_KEY`) works only on `/api/paas/v4`. Using the general key on a coding
+  endpoint returns `1113 Insufficient balance` even when the account is funded.
+
+  The `validated:` field is unchanged but now documented as advisory only — no code
+  reads it. Stale stamps were dropped rather than carried forward unverified.
+
 ### Fixed
 
 - **The morning report no longer cries "surplus heartbeat overdue" during a long

--- a/config/cc_roster.yaml
+++ b/config/cc_roster.yaml
@@ -41,9 +41,11 @@
 #   failover_order     — lower = tried first when the active model exhausts
 #                        (0 = primary; `claude` is a valid failover peer)
 #   validated          — ADVISORY ONLY. A human note recording when someone last
-#                        confirmed this peer actually worked. No code reads it;
-#                        it gates nothing. Do not carry a stamp forward without
-#                        re-testing — an unverified date is worse than none.
+#                        confirmed this peer actually worked. It is PARSED into
+#                        `RosterEntry.validated` and then acted on by nothing:
+#                        it gates nothing, anywhere. Do not carry a stamp
+#                        forward without re-testing — an unverified date is
+#                        worse than none.
 #
 # Selection + failover live in genesis.cc.roster; the invoker only honors the
 # resolved fields. Interactive use: `gmodel <name>` launches a foreground
@@ -85,7 +87,10 @@ models:
 #       auth_env: ZAI_CODING_API_KEY
 #       # ...or China (BigModel) — swap BOTH of the two lines above for:
 #       #   anthropic_base_url: "https://open.bigmodel.cn/api/anthropic"
-#       #   auth_env: ZHIPU_API_KEY
+#       #   auth_env: BIGMODEL_CODING_API_KEY
+#       # NOT ZHIPU_API_KEY: that is the general/prepaid slot for /api/paas/v4,
+#       # and pointing it at /api/anthropic is exactly the 1113 failure below.
+#       # A Coding Plan is bought PER PLATFORM, so the key is not portable.
 #       model_id: glm-5.3
 #       failover_order: 1
 #

--- a/config/cc_roster.yaml
+++ b/config/cc_roster.yaml
@@ -53,7 +53,7 @@
 # `gmodel --print-env <name>` previews the env without launching.
 default: claude
 # Agentic gauntlet (genesis.eval.gauntlet) — validates that a roster member can
-# still drive Claude Code through a coding fix-loop. `genesis eval gauntlet run
+# still drive Claude Code through a coding fix-loop. `genesis eval gauntlet -m
 # <model>` runs on demand anytime. The WEEKLY auto-run is OFF by default because
 # it spends inference on paid peers; flip `scheduled: true` (here or via the
 # cc_roster settings domain) to enable it for all runnable roster models.
@@ -117,6 +117,6 @@ models:
 #     deepseek:      anthropic_base_url: "https://api.deepseek.com/anthropic"
 #
 # Prove a peer before you depend on it: `gmodel --print-env <name>` to check the
-# env resolves, then `genesis eval gauntlet run <name>` to confirm it can
+# env resolves, then `genesis eval gauntlet -m <name>` to confirm it can
 # actually drive a coding fix-loop. Record the date in `validated:` yourself.
 # ─────────────────────────────────────────────────────────────────────────────

--- a/config/cc_roster.yaml
+++ b/config/cc_roster.yaml
@@ -1,37 +1,117 @@
 # CC model roster — first-class model diversification (run non-Anthropic models
-# behind Claude Code). Managed via the `cc_roster` settings domain.
+# behind Claude Code), and the fallback used when the Anthropic subscription hits
+# its usage cap.
 #
-# `default` is the active model when none is chosen. `models` defines each
-# roster member. Claude = the native Anthropic Max subscription (no overrides).
-# Other members are reached via their NATIVE Anthropic-compatible endpoint:
+# THIS FILE SHIPS INFRASTRUCTURE, NOT PEERS — and the reason is VERSION CHURN,
+# not "peers are user data". Be clear about which argument is load-bearing,
+# because the weaker one does not survive contact with this repo:
+# `config/model_routing.yaml` ships ~28 named vendor providers, every one of
+# them inert without its key, and `routing/config.py` states that intent
+# outright ("Partial API-key configuration is the normal install state").
+# `roster.py`'s failover chain gates each peer on its `auth_env` being present,
+# so a shipped peer with no key is PROVABLY inert here too. By that standard a
+# shipped peer would cost an unprovisioned install nothing, and "it is user
+# data" would be the wrong reason to omit it.
+#
+# The reason that DOES hold: a roster peer pins a `model_id`, and model ids go
+# EOL. This file already shipped `glm-5.2` past its replacement by `glm-5.3`.
+# A stale pinned id fails at exactly one moment — when the subscription caps and
+# the fallback is finally needed — and it fails while LOOKING configured, which
+# is worse than an empty roster that fails honestly. A routing provider degrades
+# to "one model of ~28 is down"; a stale roster peer degrades to "the fallback
+# you were relying on does not exist". Different blast radius, different answer.
+#
+# So: declare your peer yourself, against a model id you have actually tested.
+# The overlay is deep-merged over this file and is where the `cc_roster`
+# settings domain writes:
+#
+#     ~/.genesis/config/cc_roster.local.yaml
+#
+# An overlay ADDS to `models` (keys union), and can shadow a key but never
+# delete one — so `claude` below survives any overlay whose `models:` is a
+# mapping. (A hand-edited overlay with a non-mapping `models:` — bare `models:`,
+# which parses as null, or a list — REPLACES the block instead of merging, and
+# would take `claude` with it. `models: {}` is safe.)
+#
+# Peer fields:
 #   anthropic_base_url — the provider's Anthropic-compatible base URL
-#   auth_env           — name of the secrets.env var holding the API key
-#                        (the token VALUE is never stored here)
+#   auth_env           — NAME of the secrets.env var holding the key
+#                        (the token VALUE is never stored in config)
 #   model_id           — the provider's model id (sent via ANTHROPIC_MODEL)
-# Selection + failover happen in genesis.cc.roster (policy layer); the invoker
-# only honors the resolved fields. failover_order: lower = tried first when the
-# active model rate-limits/exhausts (0 = primary; skipped as a failover peer is
-# not done — claude IS a valid peer when something else is active).
+#   failover_order     — lower = tried first when the active model exhausts
+#                        (0 = primary; `claude` is a valid failover peer)
+#   validated          — ADVISORY ONLY. A human note recording when someone last
+#                        confirmed this peer actually worked. No code reads it;
+#                        it gates nothing. Do not carry a stamp forward without
+#                        re-testing — an unverified date is worse than none.
 #
-# Interactive use: `gmodel` (scripts/gmodel) launches a foreground `claude`
-# session on any model here — `gmodel glm-5.2` (peer), `gmodel opus` (native Max
-# tier), `gmodel` alone lists them. `gmodel --print-env <name>` previews the env.
+# Selection + failover live in genesis.cc.roster; the invoker only honors the
+# resolved fields. Interactive use: `gmodel <name>` launches a foreground
+# `claude` on any roster member, `gmodel` alone lists them, and
+# `gmodel --print-env <name>` previews the env without launching.
 default: claude
 # Agentic gauntlet (genesis.eval.gauntlet) — validates that a roster member can
 # still drive Claude Code through a coding fix-loop. `genesis eval gauntlet run
 # <model>` runs on demand anytime. The WEEKLY auto-run is OFF by default because
-# it spends inference on paid peers (e.g. GLM); flip `scheduled: true` (here or
-# via the cc_roster settings domain) to enable it for all runnable roster models.
+# it spends inference on paid peers; flip `scheduled: true` (here or via the
+# cc_roster settings domain) to enable it for all runnable roster models.
 gauntlet:
   scheduled: false
 models:
   claude:
     native_subscription: true
     failover_order: 0
-    validated: "2026-06-29"
-  glm-5.2:
-    anthropic_base_url: "https://open.bigmodel.cn/api/anthropic"
-    auth_env: ZHIPU_API_KEY
-    model_id: glm-5.2
-    failover_order: 1
-    validated: "2026-06-29"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EXAMPLE PEERS — copy one into ~/.genesis/config/cc_roster.local.yaml and fill
+# in your own key name. Nothing below is active.
+#
+# NAME YOUR PEER EXACTLY WHAT ITS `model_id` IS. This is a real constraint, not
+# a style preference: `roster.apply_active` returns the model_id where its
+# callers expect the roster NAME, so a peer whose key differs from its model_id
+# breaks two things downstream — the account-wide fallback flag never clears
+# (`direct_session.py`, which compares against a roster name), and the resume
+# endpoint is never persisted (`endpoint_payload` looks the name up and misses).
+# Keeping key == model_id sidesteps it entirely. Tracked as a follow-up.
+#
+# GLM / Z.AI ships on TWO platforms with DIFFERENT provisioning requirements and
+# DIFFERENT endpoints, but the SAME model id — so pick the one you can actually
+# sign up for and use ONE entry, changing only the URL and the key name:
+#
+#   models:
+#     glm-5.3:
+#       # international (z.ai):
+#       anthropic_base_url: "https://api.z.ai/api/anthropic"
+#       auth_env: ZAI_CODING_API_KEY
+#       # ...or China (BigModel) — swap BOTH of the two lines above for:
+#       #   anthropic_base_url: "https://open.bigmodel.cn/api/anthropic"
+#       #   auth_env: ZHIPU_API_KEY
+#       model_id: glm-5.3
+#       failover_order: 1
+#
+# WHICH KEY GOES WHERE — using the wrong one returns `1113 Insufficient balance`
+# even when the account is funded, because the two endpoints draw on different
+# products:
+#   * a GLM Coding Plan key  -> the CODING endpoints (/api/anthropic, and the
+#     OpenAI-protocol /api/coding/paas/v4). This is what Claude Code needs.
+#   * a general/prepaid key  -> the GENERAL endpoint (/api/paas/v4) only.
+# Per Z.AI's published GLM Coding Plan terms (read 2026-09-02): Coding-Plan
+# endpoints may only be used from provider-approved tools, and Claude Code is
+# named on that list. Third-party terms change — re-check before relying on it.
+# Genesis's ROUTER must never use a Coding-Plan key — give routing its own
+# general-endpoint key.
+# The China platform additionally requires real-name identity verification
+# (实名认证) to buy a Coding Plan, which an international account cannot satisfy.
+#
+# OTHER ANTHROPIC-COMPATIBLE PROVIDERS. The endpoints below are published by
+# their vendors; they are NOT verified in this repo. Treat them as starting
+# points and confirm against current provider docs before relying on one:
+#
+#     moonshot:      anthropic_base_url: "https://api.moonshot.cn/anthropic"
+#     minimax:       anthropic_base_url: "https://api.minimaxi.com/anthropic"
+#     deepseek:      anthropic_base_url: "https://api.deepseek.com/anthropic"
+#
+# Prove a peer before you depend on it: `gmodel --print-env <name>` to check the
+# env resolves, then `genesis eval gauntlet run <name>` to confirm it can
+# actually drive a coding fix-loop. Record the date in `validated:` yourself.
+# ─────────────────────────────────────────────────────────────────────────────

--- a/scripts/gmodel
+++ b/scripts/gmodel
@@ -37,7 +37,7 @@ if _VENV_PYTHON.is_file() and Path(sys.executable).resolve() != _VENV_PYTHON.res
 sys.path.insert(0, str(_REPO_ROOT / "src"))
 
 # Load secrets.env into THIS process only so peer auth_env tokens (e.g.
-# ZHIPU_API_KEY) resolve for roster.overrides_for. The child's env is built
+# ZAI_CODING_API_KEY) resolve for roster.overrides_for. The child's env is built
 # explicitly below — we never blanket-forward every secret, and ANTHROPIC_API_KEY
 # is always dropped from the child.
 _SECRETS = _REPO_ROOT / "secrets.env"
@@ -61,9 +61,11 @@ def _list_models() -> int:
     models = r.get("models") or {}
     if not models:
         print(
-            "No roster models configured. Declare peers in "
-            "~/.genesis/config/cc_roster.local.yaml "
-            "(config/cc_roster.yaml ships none by design).",
+            "No roster models resolved — the base config ships `claude`, so "
+            "this means config/cc_roster.yaml failed to load, or a "
+            "non-mapping `models:` in ~/.genesis/config/cc_roster.local.yaml "
+            "REPLACED the shipped block instead of merging into it. "
+            "(Peers are declared in that overlay; the base ships no PEERS.)",
             file=sys.stderr,
         )
         return 1

--- a/scripts/gmodel
+++ b/scripts/gmodel
@@ -9,8 +9,10 @@
 <name> is either:
   • a Claude tier — opus / sonnet / haiku — → native `claude --model <tier>` on
     your Max subscription (OAuth); or
-  • a roster model from config/cc_roster.yaml — `claude` (a peer runs on that
-    provider's native Anthropic endpoint + its API key).
+  • a roster model — `claude`, plus any peer you declared in
+    ~/.genesis/config/cc_roster.local.yaml (a peer runs on that provider's
+    native Anthropic endpoint + its API key). The shipped
+    config/cc_roster.yaml declares no peers; it documents the fields.
 
 Anthropic always runs on Max (native OAuth — `ANTHROPIC_API_KEY` is dropped so a
 stray key can't silently switch you to per-token billing). A session is pinned to
@@ -58,7 +60,12 @@ def _list_models() -> int:
     default = roster.active_model(r)
     models = r.get("models") or {}
     if not models:
-        print("No roster models configured (config/cc_roster.yaml).", file=sys.stderr)
+        print(
+            "No roster models configured. Declare peers in "
+            "~/.genesis/config/cc_roster.local.yaml "
+            "(config/cc_roster.yaml ships none by design).",
+            file=sys.stderr,
+        )
         return 1
     print("Models (gmodel <name> to launch):\n")
     print("  claude tiers:  opus  sonnet  haiku   (native Max, via --model)\n")

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -318,8 +318,23 @@ GENESIS_CDP_URL=
 
 # ─── LLM Providers (extra) ───────────────────────────────────────────────
 # --- Zhipu / Z.ai (GLM) ---
-# Used by: CC roster peer glm model (failover). Signup: bigmodel.cn / z.ai
+# TWO keys, TWO endpoints — using the wrong one returns "1113 Insufficient
+# balance" even on a funded account, because they bill different products.
+#
+# ZHIPU_API_KEY: a general / prepaid-balance key. Endpoint: /api/paas/v4.
+#   NOT read by anything in this repo today — the router has no zhipu/z.ai
+#   provider (its `glm51` entry is a z-ai model served via ZenMux, billed to
+#   that provider's own key). Kept as a labelled slot for a general-endpoint
+#   peer you wire yourself, and to document the two-key split below.
+#   Signup: bigmodel.cn (China) or z.ai (global).
 ZHIPU_API_KEY=
+# ZAI_CODING_API_KEY: a GLM Coding Plan key. Endpoints: /api/anthropic and
+#   /api/coding/paas/v4 — this is what a CC roster peer needs, since Claude Code
+#   speaks the Anthropic protocol. Coding endpoints may only be used from
+#   provider-approved tools (Claude Code is one). Never give this key to the
+#   router. Configure the peer itself in ~/.genesis/config/cc_roster.local.yaml;
+#   see config/cc_roster.yaml for the fields and examples.
+ZAI_CODING_API_KEY=
 
 # ─── AWS (EC2 install-test runner) ───────────────────────────────────────
 # Used by: scheduler/install_test.py — provisions ephemeral VMs for weekly

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -318,23 +318,44 @@ GENESIS_CDP_URL=
 
 # ─── LLM Providers (extra) ───────────────────────────────────────────────
 # --- Zhipu / Z.ai (GLM) ---
-# TWO keys, TWO endpoints — using the wrong one returns "1113 Insufficient
-# balance" even on a funded account, because they bill different products.
+# NOTE FOR EDITORS: this file is a PARSED REGISTRY, not prose. The dashboard's
+# Provider Keys panel builds itself from it (dashboard/routes/secrets.py
+# `_parse_example_file`). `# Used by:` becomes the description and `# Signup:`
+# becomes a link the template renders as "https://" + the value, so that field
+# must be a BARE HOST — free text there ships a dead hyperlink. Both fields reset
+# after every KEY=, so each key needs its own pair. Verify edits by running the
+# parser, not by reading.
 #
-# ZHIPU_API_KEY: a general / prepaid-balance key. Endpoint: /api/paas/v4.
-#   NOT read by anything in this repo today — the router has no zhipu/z.ai
-#   provider (its `glm51` entry is a z-ai model served via ZenMux, billed to
-#   that provider's own key). Kept as a labelled slot for a general-endpoint
-#   peer you wire yourself, and to document the two-key split below.
-#   Signup: bigmodel.cn (China) or z.ai (global).
+# The split that matters: a CODING-PLAN key for the Anthropic-protocol coding
+# endpoints, and a GENERAL/prepaid key for the general endpoint. Using the wrong
+# one returns "1113 Insufficient balance" even on a funded account, because they
+# bill different products. GLM ships on TWO PLATFORMS (z.ai international,
+# bigmodel.cn China) and a Coding Plan is bought PER PLATFORM, so a coding key is
+# NOT portable between them — hence a separate slot for each.
+#
+# Used by: nothing in this repo today — a general-endpoint (/api/paas/v4) peer
+#   you wire yourself. The router has no zhipu/z.ai provider (its `glm51` entry
+#   is a z-ai model served via ZenMux, billed to that provider's own key). Kept
+#   as a labelled slot, and to document the coding-vs-general split above.
+# Signup: z.ai
 ZHIPU_API_KEY=
-# ZAI_CODING_API_KEY: a GLM Coding Plan key. Endpoints: /api/anthropic and
-#   /api/coding/paas/v4 — this is what a CC roster peer needs, since Claude Code
-#   speaks the Anthropic protocol. Coding endpoints may only be used from
-#   provider-approved tools (Claude Code is one). Never give this key to the
-#   router. Configure the peer itself in ~/.genesis/config/cc_roster.local.yaml;
-#   see config/cc_roster.yaml for the fields and examples.
+# Used by: a CC roster peer you declare in ~/.genesis/config/cc_roster.local.yaml
+#   — a GLM Coding Plan key for the INTERNATIONAL platform. Endpoints:
+#   /api/anthropic and /api/coding/paas/v4; Claude Code speaks the Anthropic
+#   protocol, so this is the one a roster peer needs. Coding endpoints may only
+#   be used from provider-approved tools (Claude Code is one). Never give this
+#   key to the router.
+# Signup: z.ai
 ZAI_CODING_API_KEY=
+# Used by: a CC roster peer on the CHINA platform
+#   (https://open.bigmodel.cn/api/anthropic) — the same thing as
+#   ZAI_CODING_API_KEY but bought on bigmodel.cn, since a Coding Plan is not
+#   portable between platforms. Distinct from ZHIPU_API_KEY on purpose: that is
+#   the general/prepaid slot, and pointing it at /api/anthropic is precisely the
+#   1113 failure above. The China platform requires real-name identity
+#   verification (实名认证) to buy a Coding Plan.
+# Signup: open.bigmodel.cn
+BIGMODEL_CODING_API_KEY=
 
 # ─── AWS (EC2 install-test runner) ───────────────────────────────────────
 # Used by: scheduler/install_test.py — provisions ephemeral VMs for weekly

--- a/src/genesis/_config_overlay.py
+++ b/src/genesis/_config_overlay.py
@@ -11,9 +11,12 @@ to avoid circular imports from any config loader.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 
 def _user_config_dir() -> Path:
@@ -57,6 +60,20 @@ def merge_local_overlay(base: dict, base_path: Path) -> dict:
     try:
         local = yaml.safe_load(local_path.read_text()) or {}
     except Exception:
+        # NEVER silent. Returning `base` is the right FALLBACK, but an unlogged
+        # one is indistinguishable from a clean load — the caller sees a valid
+        # config and cannot tell that every override in this file was dropped.
+        # That is load-bearing for configs whose overlay is the SOLE home of a
+        # setting (cc_roster peers, for one): a single YAML typo silently
+        # yields "no peers configured", and the discovery moment is the
+        # subscription cap. The base-file loader in genesis.cc.roster already
+        # warns on the same failure; this is the matching half.
+        logger.warning(
+            "Failed to parse config overlay %s — IGNORING it; every setting in "
+            "this file is NOT in effect. Fix the YAML and reload.",
+            local_path,
+            exc_info=True,
+        )
         return base
     return _deep_merge(base, local)
 

--- a/src/genesis/_config_overlay.py
+++ b/src/genesis/_config_overlay.py
@@ -44,6 +44,30 @@ def _resolve_overlay_path(base_path: Path) -> Path:
     return base_path.with_suffix(".local.yaml")
 
 
+#: Last-warned mtime per overlay path. A broken overlay MUST warn — but several
+#: loaders re-read on every call (the immunity gate reloads per check), so an
+#: undeduped warning turns one YAML typo into a multiline traceback on every
+#: memory or approval operation, flooding the journal until an operator notices.
+#: Warn once per bad file VERSION: any mtime CHANGE warns again, so a failed
+#: repair stays visible — including a backwards move, which an mtime-preserving
+#: restore produces. Keyed by path (not path+mtime) so the map is bounded by the
+#: number of overlay files rather than growing once per edit forever.
+_WARNED_OVERLAYS: dict[str, float] = {}
+
+
+def _warn_overlay_once(local_path: Path, msg: str, *args, exc_info: bool = False) -> None:
+    """Log an overlay problem once per (path, mtime). Never raises."""
+    path_key = str(local_path)
+    try:
+        mtime = local_path.stat().st_mtime
+    except OSError:
+        mtime = 0.0
+    if _WARNED_OVERLAYS.get(path_key) == mtime:
+        return
+    _WARNED_OVERLAYS[path_key] = mtime
+    logger.warning(msg, *args, exc_info=exc_info)
+
+
 def merge_local_overlay(base: dict, base_path: Path) -> dict:
     """Deep-merge a ``.local.yaml`` overlay into *base* if it exists.
 
@@ -52,13 +76,38 @@ def merge_local_overlay(base: dict, base_path: Path) -> dict:
     (``~/.genesis/config/{stem}.local.yaml``), falling back to the repo-relative
     sibling.
 
-    Returns *base* unchanged when no overlay file exists.
+    Returns *base* unchanged when no overlay file exists, is unparseable, or is
+    valid YAML of the wrong SHAPE.
     """
     local_path = _resolve_overlay_path(base_path)
     if not local_path.exists():
         return base
     try:
-        local = yaml.safe_load(local_path.read_text()) or {}
+        local = yaml.safe_load(local_path.read_text())
+        if local is None:
+            # Empty file or an explicit `null` — legitimately nothing to merge,
+            # and NOT a malformed overlay. Distinguished from the falsy
+            # non-mappings below, which an `or {}` default used to swallow
+            # without a word: `[]`, `false`, `0` and `""` all became "no
+            # overrides" silently, and an empty-list root is precisely the shape
+            # this guard advertises catching.
+            return base
+        if not isinstance(local, dict):
+            # Valid YAML, wrong ROOT SHAPE — a list or a bare scalar. This is the
+            # one malformed case the except below does NOT catch: parsing
+            # succeeds, and the AttributeError from `.items()` would be raised by
+            # _deep_merge OUTSIDE this function, propagating to every caller of
+            # the config loader instead of degrading to base. Validate here so a
+            # wrong-shape overlay fails the same safe way an unparseable one does.
+            _warn_overlay_once(
+                local_path,
+                "Config overlay %s has a %s at its root, not a mapping — "
+                "IGNORING it; every setting in this file is NOT in effect. "
+                "Fix the YAML and reload.",
+                local_path,
+                type(local).__name__,
+            )
+            return base
     except Exception:
         # NEVER silent. Returning `base` is the right FALLBACK, but an unlogged
         # one is indistinguishable from a clean load — the caller sees a valid
@@ -68,7 +117,8 @@ def merge_local_overlay(base: dict, base_path: Path) -> dict:
         # yields "no peers configured", and the discovery moment is the
         # subscription cap. The base-file loader in genesis.cc.roster already
         # warns on the same failure; this is the matching half.
-        logger.warning(
+        _warn_overlay_once(
+            local_path,
             "Failed to parse config overlay %s — IGNORING it; every setting in "
             "this file is NOT in effect. Fix the YAML and reload.",
             local_path,

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -1096,6 +1096,21 @@ class ConversationLoop:
                 base_inv = replace(base_inv, system_prompt=system_prompt)
             peers = roster.failover_invocations(home, base_inv)
             if not peers:
+                # Say so. This is the one branch that degrades SILENTLY at the
+                # exact moment the fallback exists for — the subscription has
+                # capped and there is nothing to fail over to. The turn goes on
+                # to contingency and rate_limit_park, which do surface something
+                # to the user, but nothing anywhere names the actual cause: no
+                # usable peer is configured. `failover_chain` also drops any
+                # peer whose auth_env is unset, so "declared but keyless" lands
+                # here too and looks identical to "none declared".
+                logger.warning(
+                    "CC failover: no usable roster peer for home=%r — degrading "
+                    "to contingency. Declare one in "
+                    "~/.genesis/config/cc_roster.local.yaml (a peer whose "
+                    "auth_env key is unset is skipped).",
+                    home,
+                )
                 return None
             sticky = self._session_fallback_session(session)
             for peer_name, peer_inv in peers:

--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -630,9 +630,10 @@ class DirectSessionRequest:
     planning_instruction: str | None = None  # opt-in: prepended to prompt
     skills: list[str] | None = None  # explicit skill injection (overrides auto-detect)
     tool_exceptions: tuple[str, ...] = ()  # tools to UN-block from the profile disallow list
-    # Intentional per-dispatch model SELECTION (not failover): a roster name
-    # (e.g. "glm-5.2") to run this background session on instead of the global
-    # default. None → the chokepoint applies the active default as usual.
+    # Intentional per-dispatch model SELECTION (not failover): a roster name —
+    # a peer from the cc_roster overlay — to run this background session on
+    # instead of the global default. None → the chokepoint applies the active
+    # default as usual.
     roster_model: str | None = None
     # Delivery of the terminal outcome. None → derived from the legacy
     # notify/notify_on_failure_only bools in __post_init__ (SILENT/FAILURE_ONLY),
@@ -676,7 +677,7 @@ class DirectSessionResult:
     duration_s: float = 0.0
     tools_called: list[dict] = field(default_factory=list)
     model_used: str = ""
-    roster_model: str = ""  # roster NAME the chokepoint selected ("glm-5.2"/"claude")
+    roster_model: str = ""  # roster NAME the chokepoint selected (peer name or "claude")
 
 
 # ---------------------------------------------------------------------------

--- a/src/genesis/cc/fallback_state.py
+++ b/src/genesis/cc/fallback_state.py
@@ -43,7 +43,7 @@ class FallbackState:
 
     is_fallback: bool = False
     original: str = ""  # home model name (e.g. "claude")
-    fallback: str = ""  # active peer name (e.g. "glm-5.2")
+    fallback: str = ""  # active peer name, from the roster overlay
     reason: str = ""  # short cause (e.g. "rate_limit")
     since: str = ""  # ISO8601 UTC when the fallback began
 

--- a/src/genesis/cc/roster.py
+++ b/src/genesis/cc/roster.py
@@ -1,6 +1,6 @@
 """Model roster — first-class model-diversification policy layer.
 
-Maps roster names (e.g. "glm-5.2") to the CCInvocation overrides that point a
+Maps roster names ("claude", or a peer from the local overlay) to the
 Claude Code subprocess at a non-Anthropic provider's native Anthropic-compatible
 endpoint. This is the POLICY layer.
 

--- a/src/genesis/cc/roster.py
+++ b/src/genesis/cc/roster.py
@@ -194,6 +194,34 @@ def overrides_for(name: str, roster: dict | None = None) -> dict:
     }
 
 
+#: Defaults already reported as unresolvable. apply_active sits on the universal
+#: CC path, so without dedupe this logs on EVERY routed invocation; the point is
+#: one actionable line per process, not a flood.
+_WARNED_UNRESOLVABLE_DEFAULTS: set[str] = set()
+
+
+def _warn_unresolvable_default_once(name: str) -> None:
+    """Report a configured default that no longer resolves. Once per name."""
+    if name in _WARNED_UNRESOLVABLE_DEFAULTS:
+        return
+    _WARNED_UNRESOLVABLE_DEFAULTS.add(name)
+    logger.error(
+        "cc_roster default %r cannot be resolved — there is no model by that "
+        "name in config/cc_roster.yaml, nor in the cc_roster overlay under "
+        "~/.genesis/config/. "
+        "Falling back to native Claude, so every roster-eligible call now runs on "
+        "a DIFFERENT model than the one configured. The usual cause is an upgrade: "
+        "the default was chosen through the cc_roster settings domain, which "
+        "persists only `default: %s` because the model DEFINITION came from the "
+        "shipped base file — and that base entry has since been removed, leaving "
+        "the selection without an endpoint. Fix by re-selecting a model, or by "
+        "adding its definition (anthropic_base_url, auth_env, model_id) to the "
+        "local overlay.",
+        name,
+        name,
+    )
+
+
 def apply_active(
     inv: CCInvocation, roster: dict | None = None,
 ) -> tuple[CCInvocation, str]:
@@ -222,8 +250,32 @@ def apply_active(
             return inv, (inv.model_id_override or "routed")
         if inv.resume_session_id is not None:
             return inv, CLAUDE
-        active = active_model(roster)
-        overrides = overrides_for(active, roster)
+        # Load ONCE and thread it through. active_model/resolve/overrides_for each
+        # fall back to load_roster() when passed None, and production call sites
+        # pass None — so reading per-helper meant three independent YAML loads per
+        # invocation on the universal CC path, which can also disagree with each
+        # other while the server rewrites the overlay live.
+        r = roster if roster is not None else load_roster()
+        active = active_model(r)
+        if active != CLAUDE and resolve(active, r) is None:
+            # UNDEFINED default — deliberately narrow on two axes.
+            # (1) Not CLAUDE: `resolve` returns None for EVERY name when the
+            #     models mapping is missing or nulled (a bare `models:` in an
+            #     overlay merges as None), and claiming the native default "has
+            #     been removed" would be flatly false.
+            # (2) Absent definition only: a model that exists but has no auth
+            #     token, or is missing routing fields, is a DIFFERENT fault with
+            #     a different repair and must fall through to the generic handler.
+            _warn_unresolvable_default_once(active)
+            return inv, CLAUDE
+        overrides = overrides_for(active, r)
+        # Resolved cleanly — drop EVERY prior complaint, not just this name's. A
+        # successful resolve proves the roster is currently coherent, so any
+        # earlier grievance is stale by definition; discarding only `active`
+        # leaves an entry behind when the default is repaired by pointing
+        # SOMEWHERE ELSE, and the original name then re-breaks in silence. Only
+        # one default is active at a time, so the set stays tiny either way.
+        _WARNED_UNRESOLVABLE_DEFAULTS.clear()
         if not overrides:
             return inv, active
         return replace(inv, **overrides), active

--- a/src/genesis/cc/types.py
+++ b/src/genesis/cc/types.py
@@ -508,7 +508,7 @@ class CCOutput:
     downgraded: bool = False
     via_proxy: bool = False
     # The roster model NAME selected at the chokepoint (genesis.cc.roster) — e.g.
-    # "claude" (native) or "glm-5.2". Ground truth for what we ROUTED to (set from
+    # "claude" (native) or a configured peer. Ground truth for what we ROUTED to (set from
     # apply_active), independent of the provider's self-reported model_used, which
     # may be a variant string or empty. Used for resume-endpoint persistence.
     roster_model: str = ""

--- a/src/genesis/eval/cli.py
+++ b/src/genesis/eval/cli.py
@@ -128,7 +128,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         "--model",
         "-m",
         required=True,
-        help="Roster model name (e.g. claude, glm-5.2)",
+        help="Roster model name (claude, or a peer from your cc_roster overlay)",
     )
     gauntlet_cmd.add_argument(
         "--no-db",

--- a/src/genesis/mcp/health/direct_session_tools.py
+++ b/src/genesis/mcp/health/direct_session_tools.py
@@ -348,10 +348,11 @@ async def direct_session_run(
         deliver_to_origin: Deliver the terminal outcome (success and failure)
             back to the conversation this tool was called from. Requires a
             foreground channel session as the caller.
-        roster_model: Optionally run this session on a specific roster model
-            (e.g. "glm-5.2") instead of the default — intentional model
-            selection. Omit/None to use the active default. Fails the session
-            if the named model is unknown or its API key is not configured.
+        roster_model: Optionally run this session on a specific roster model —
+            a peer from the cc_roster overlay — instead of the default,
+            i.e. intentional model selection. Omit/None to use the active
+            default. Fails the session if the named model is unknown or its
+            API key is not configured.
     """
     return await _impl_direct_session_run(
         prompt,

--- a/tests/test_cc/test_gmodel.py
+++ b/tests/test_cc/test_gmodel.py
@@ -1,8 +1,15 @@
 """Smoke tests for the foreground `gmodel` launcher (scripts/gmodel).
 
 Exercised via subprocess with `--print-env` (a no-launch diagnostic) so the tests
-never spawn a real `claude`. Uses the repo's real config/cc_roster.yaml; the peer
-key is supplied via env so no secrets.env is required (CI-safe).
+never spawn a real `claude`.
+
+HERMETIC BY CONSTRUCTION. These tests subprocess, so conftest's
+`_isolate_user_config_dir` fixture does NOT reach the child — it would read a
+real `$HOME` and therefore the developer's real `~/.genesis/config/` overlay.
+`_run` takes a REQUIRED `home`, with no `Path.home()` default, so a new test
+cannot silently reintroduce that leak; every test passes the `hermetic_home`
+fixture. The shipped `config/cc_roster.yaml` declares no peers (they are
+install-local), so any peer a test needs, it writes into its own overlay.
 """
 from __future__ import annotations
 
@@ -16,8 +23,19 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _GMODEL = _REPO_ROOT / "scripts" / "gmodel"
 
 
-def _run(args, extra_env=None):
-    env = {"PATH": "/usr/bin:/bin", "HOME": str(Path.home())}
+@pytest.fixture
+def hermetic_home(tmp_path):
+    """An empty HOME with a config dir, so the child reads no real overlay."""
+    (tmp_path / ".genesis" / "config").mkdir(parents=True)
+    return tmp_path
+
+
+def _run(args, home, extra_env=None):
+    """Run the launcher against an explicit HOME.
+
+    `home` is REQUIRED and has no default on purpose — see the module docstring.
+    """
+    env = {"PATH": "/usr/bin:/bin", "HOME": str(home)}
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -27,24 +45,24 @@ def _run(args, extra_env=None):
 
 
 @pytest.mark.skipif(not _GMODEL.is_file(), reason="gmodel launcher not present")
-def test_list_runs_and_shows_claude():
-    r = _run(["--list"])
+def test_list_runs_and_shows_claude(hermetic_home):
+    r = _run(["--list"], hermetic_home)
     assert r.returncode == 0, r.stderr
     assert "claude" in r.stdout
     assert "native Max" in r.stdout
 
 
 @pytest.mark.skipif(not _GMODEL.is_file(), reason="gmodel launcher not present")
-def test_unknown_model_errors():
-    r = _run(["--print-env", "no-such-model"])
+def test_unknown_model_errors(hermetic_home):
+    r = _run(["--print-env", "no-such-model"], hermetic_home)
     assert r.returncode == 1
     assert "unknown roster model" in r.stderr
 
 
 @pytest.mark.skipif(not _GMODEL.is_file(), reason="gmodel launcher not present")
-def test_native_claude_has_no_routing_and_drops_api_key():
+def test_native_claude_has_no_routing_and_drops_api_key(hermetic_home):
     # A stray ANTHROPIC_API_KEY must be dropped so native runs on Max, not API.
-    r = _run(["--print-env", "claude"], {"ANTHROPIC_API_KEY": "sk-stray"})
+    r = _run(["--print-env", "claude"], hermetic_home, {"ANTHROPIC_API_KEY": "sk-stray"})
     assert r.returncode == 0, r.stderr
     assert "ANTHROPIC_API_KEY=<unset>" in r.stdout
     assert "ANTHROPIC_BASE_URL=<unset>" in r.stdout
@@ -52,23 +70,33 @@ def test_native_claude_has_no_routing_and_drops_api_key():
 
 
 @pytest.mark.skipif(not _GMODEL.is_file(), reason="gmodel launcher not present")
-def test_opus_tier_is_native_with_model_flag():
-    r = _run(["--print-env", "opus"], {"ANTHROPIC_API_KEY": "sk-stray"})
+def test_opus_tier_is_native_with_model_flag(hermetic_home):
+    r = _run(["--print-env", "opus"], hermetic_home, {"ANTHROPIC_API_KEY": "sk-stray"})
     assert r.returncode == 0, r.stderr
     assert "ANTHROPIC_API_KEY=<unset>" in r.stdout
     assert "claude --model opus" in r.stdout
 
 
 @pytest.mark.skipif(not _GMODEL.is_file(), reason="gmodel launcher not present")
-def test_peer_routes_and_drops_api_key():
-    # Peer key via env (no secrets.env needed). Uses the repo roster's glm-5.2.
+def test_peer_routes_and_drops_api_key(hermetic_home):
+    """A peer declared in the overlay resolves end-to-end; the stray key is dropped."""
+    overlay = hermetic_home / ".genesis" / "config" / "cc_roster.local.yaml"
+    overlay.write_text(
+        "models:\n"
+        "  test-peer:\n"
+        '    anthropic_base_url: "https://example.invalid/api/anthropic"\n'
+        "    auth_env: GENESIS_TEST_ROSTER_KEY\n"
+        "    model_id: test-peer\n"
+        "    failover_order: 1\n"
+    )
     r = _run(
-        ["--print-env", "glm-5.2"],
-        {"ANTHROPIC_API_KEY": "sk-stray", "ZHIPU_API_KEY": "zk-test"},
+        ["--print-env", "test-peer"],
+        hermetic_home,
+        {"ANTHROPIC_API_KEY": "sk-stray", "GENESIS_TEST_ROSTER_KEY": "zk-test"},
     )
     assert r.returncode == 0, r.stderr
-    assert "ANTHROPIC_BASE_URL=https://open.bigmodel.cn/api/anthropic" in r.stdout
+    assert "ANTHROPIC_BASE_URL=https://example.invalid/api/anthropic" in r.stdout
     assert "ANTHROPIC_AUTH_TOKEN=<set>" in r.stdout
-    assert "ANTHROPIC_MODEL=glm-5.2" in r.stdout
+    assert "ANTHROPIC_MODEL=test-peer" in r.stdout
     assert "ANTHROPIC_API_KEY=<unset>" in r.stdout  # isolation
-    assert "GENESIS_ROSTER_MODEL=glm-5.2" in r.stdout
+    assert "GENESIS_ROSTER_MODEL=test-peer" in r.stdout

--- a/tests/test_cc/test_roster.py
+++ b/tests/test_cc/test_roster.py
@@ -267,3 +267,57 @@ def test_shipped_config_ships_no_peers():
         "(version churn: a stale pinned model_id fails exactly when needed)."
     )
     assert base["models"]["claude"].get("native_subscription") is True
+
+
+def test_every_documented_auth_env_has_a_secrets_slot():
+    """CROSS-FILE GUARD: a peer example may not name a key the template lacks.
+
+    Round-2 defect on PR #1606: the shipped China example told users to set
+    `auth_env: ZHIPU_API_KEY` against `/api/anthropic`, while
+    `secrets.env.example` — edited in the SAME change — declared that variable
+    to be the general/prepaid key for a different endpoint. Two files, each
+    internally consistent, contradicting each other. Nothing checked the pair,
+    so a human reviewer had to notice.
+
+    Scans COMMENTED examples too, on purpose: the shipped roster declares no
+    active peers (see test_shipped_config_ships_no_peers), so every auth_env in
+    it lives in a comment — which is exactly where the defect was.
+    """
+    import re
+
+    from genesis.cc.roster import _CONFIG_DIR, _ROSTER_FILE
+
+    roster_text = (_CONFIG_DIR / _ROSTER_FILE).read_text()
+    # Prose mentions a key to warn AGAINST it ("NOT ZHIPU_API_KEY"), so match
+    # only the field form `auth_env: NAME`, commented or not.
+    named = set(re.findall(r"auth_env:\s*([A-Z][A-Z0-9_]+)", roster_text))
+    assert named, "no auth_env examples found — has the example block moved?"
+
+    example = _CONFIG_DIR.parent / "secrets.env.example"
+    declared = set(re.findall(r"^([A-Z][A-Z0-9_]+)=", example.read_text(), re.MULTILINE))
+
+    missing = named - declared
+    assert not missing, (
+        f"config/cc_roster.yaml names auth_env {sorted(missing)}, which "
+        "secrets.env.example does not declare. A user following the example "
+        "would set a variable nothing reads. Add the slot (with its own "
+        "`# Used by:` and `# Signup:` lines) or fix the example."
+    )
+
+    # "Is it declared?" is NOT enough, and verifying-RED proved it: the round-2
+    # defect named ZHIPU_API_KEY, which IS a declared slot — it is simply the
+    # WRONG KIND of key. The real invariant is about the endpoint: every roster
+    # peer reaches its provider over the Anthropic protocol (that is what
+    # `anthropic_base_url` means), and those coding endpoints require a
+    # CODING-PLAN key, never the general/prepaid one. The naming convention
+    # `*_CODING_API_KEY` is what makes that mechanically checkable, and
+    # secrets.env.example documents it.
+    wrong_class = {n for n in named if not n.endswith("_CODING_API_KEY")}
+    assert not wrong_class, (
+        f"config/cc_roster.yaml names auth_env {sorted(wrong_class)} for a peer. "
+        "A roster peer talks to an Anthropic-protocol coding endpoint, which "
+        "needs a CODING-PLAN key (`*_CODING_API_KEY`) — a general/prepaid key "
+        "there returns `1113 Insufficient balance` on a funded account. If a "
+        "provider genuinely uses one key for both, rename the slot so the "
+        "convention still reads true."
+    )

--- a/tests/test_cc/test_roster.py
+++ b/tests/test_cc/test_roster.py
@@ -239,3 +239,31 @@ def test_apply_routing_env_auth_token_only_still_drops_api_key():
     R.apply_routing_env(env, base_url=None, auth_token="zk-secret", model_id=None)
     assert "ANTHROPIC_API_KEY" not in env
     assert env["ANTHROPIC_AUTH_TOKEN"] == "zk-secret"
+
+
+def test_shipped_config_ships_no_peers():
+    """DELIVERABLE LOCK: config/cc_roster.yaml ships INFRASTRUCTURE, not peers.
+
+    A peer pins a `model_id`, and model ids go EOL — this file shipped
+    `glm-5.2` past its replacement by `glm-5.3`. A stale pinned peer fails at
+    the one moment it is needed (when the subscription caps) and fails while
+    LOOKING configured, which is worse than an empty roster failing honestly.
+    So peers are declared per-install in ~/.genesis/config/cc_roster.local.yaml.
+
+    Asserts on the SHIPPED FILE directly rather than the merged roster, so
+    neither a developer's real overlay nor the repo-relative fallback can mask
+    a regression. Without this, re-adding a peer to the shipped config would
+    break nothing — every other roster test writes its own synthetic yaml.
+    """
+    import yaml
+
+    from genesis.cc.roster import _CONFIG_DIR, _ROSTER_FILE
+
+    base = yaml.safe_load((_CONFIG_DIR / _ROSTER_FILE).read_text())
+    assert base["default"] == "claude"
+    assert set(base["models"]) == {"claude"}, (
+        "config/cc_roster.yaml must ship no peers — declare them in "
+        "~/.genesis/config/cc_roster.local.yaml. See the file header for why "
+        "(version churn: a stale pinned model_id fails exactly when needed)."
+    )
+    assert base["models"]["claude"].get("native_subscription") is True

--- a/tests/test_cc/test_roster_apply.py
+++ b/tests/test_cc/test_roster_apply.py
@@ -20,6 +20,14 @@ def _hermetic_user_overlay(tmp_path, monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_unresolvable_warn_cache():
+    """Isolate the module-global warn-dedupe set for unresolvable defaults."""
+    R._WARNED_UNRESOLVABLE_DEFAULTS.clear()
+    yield
+    R._WARNED_UNRESOLVABLE_DEFAULTS.clear()
+
+
 @pytest.fixture
 def roster_dir(tmp_path):
     (tmp_path / "cc_roster.yaml").write_text(textwrap.dedent(
@@ -140,3 +148,133 @@ def test_overrides_from_persisted_missing_token_raises(roster_dir, monkeypatch):
 def test_overrides_from_persisted_incomplete_raises():
     with pytest.raises(R.RosterError):
         R.overrides_from_persisted({"base_url": "u"})  # missing auth_env/model_id
+
+
+# ── a configured default that no longer resolves ─────────────────────────────
+# Codex P1 on the roster-portability PR: `settings_update` persists ONLY
+# `default: <name>` into the local overlay, because the model DEFINITION came
+# from the shipped base. Remove that base entry and the selection is left
+# without an endpoint — apply_active then falls back to native Claude, so an
+# install silently runs a different provider than the one it chose. The fallback
+# itself is correct (breaking every call would be worse); being ANONYMOUS about
+# it is not.
+
+
+def _dangling_default_roster(tmp_path):
+    (tmp_path / "cc_roster.yaml").write_text(textwrap.dedent(
+        """
+        default: claude
+        models:
+          claude:
+            native_subscription: true
+            failover_order: 0
+        """
+    ))
+    user_dir = tmp_path / "user-config"
+    user_dir.mkdir(exist_ok=True)
+    # What a settings-selected default looks like after its base entry is gone.
+    (user_dir / "cc_roster.local.yaml").write_text("default: removed-peer\n")
+    return tmp_path
+
+
+def test_unresolvable_default_falls_back_to_claude_loudly(tmp_path, monkeypatch, caplog):
+    cfg = _dangling_default_roster(tmp_path)
+    monkeypatch.setattr(R, "_CONFIG_DIR", cfg)
+
+    inv = CCInvocation(prompt="hi", roster_eligible=True)
+    with caplog.at_level(logging.ERROR, logger="genesis.cc.roster"):
+        out, name = R.apply_active(inv)
+
+    assert name == R.CLAUDE  # fell back rather than breaking the call
+    assert out is inv  # no routing stamped
+    assert caplog.records, "a silent provider change must not be silent"
+    msg = caplog.records[0].getMessage()
+    assert "removed-peer" in msg  # names the unresolvable selection
+    assert "cc_roster" in msg  # points at where to fix it
+    # and it must not read as a generic crash
+    assert "apply_active failed" not in msg
+
+
+def test_unresolvable_default_warns_once_not_per_invocation(tmp_path, monkeypatch, caplog):
+    """apply_active runs on the UNIVERSAL CC path — an undeduped error here logs
+    a traceback on every routed call and buries the one line that matters."""
+    cfg = _dangling_default_roster(tmp_path)
+    monkeypatch.setattr(R, "_CONFIG_DIR", cfg)
+
+    inv = CCInvocation(prompt="hi", roster_eligible=True)
+    with caplog.at_level(logging.ERROR, logger="genesis.cc.roster"):
+        for _ in range(6):
+            assert R.apply_active(inv)[1] == R.CLAUDE
+    assert len(caplog.records) == 1
+
+
+def test_native_default_is_never_blamed_when_models_is_nulled(tmp_path, monkeypatch, caplog):
+    """A bare `models:` in an overlay merges as None, so `resolve` returns None
+    for EVERY name — including the native default. Announcing that `claude`
+    "cannot be resolved" and that "its base entry has been removed" would be
+    flatly false, and would fire on the most common configuration there is."""
+    (tmp_path / "cc_roster.yaml").write_text(textwrap.dedent(
+        """
+        default: claude
+        models:
+          claude:
+            native_subscription: true
+        """
+    ))
+    user_dir = tmp_path / "user-config"
+    user_dir.mkdir(exist_ok=True)
+    (user_dir / "cc_roster.local.yaml").write_text("models:\n")  # nulls the mapping
+    monkeypatch.setattr(R, "_CONFIG_DIR", tmp_path)
+
+    inv = CCInvocation(prompt="hi", roster_eligible=True)
+    with caplog.at_level(logging.ERROR, logger="genesis.cc.roster"):
+        out, name = R.apply_active(inv)
+
+    assert name == R.CLAUDE and out is inv  # native, as configured
+    assert not [r for r in caplog.records if "cannot be resolved" in r.getMessage()], (
+        "claimed the native default was orphaned"
+    )
+
+
+def test_repaired_then_rebroken_default_warns_again(tmp_path, monkeypatch, caplog):
+    """Three-state probe. A name-keyed cache that never clears makes the SECOND
+    breakage silent — which is the exact silent provider substitution this
+    branch exists to remove."""
+    cfg = _dangling_default_roster(tmp_path)
+    monkeypatch.setattr(R, "_CONFIG_DIR", cfg)
+    inv = CCInvocation(prompt="hi", roster_eligible=True)
+    local = cfg / "user-config" / "cc_roster.local.yaml"
+
+    # 1. broken -> warns
+    with caplog.at_level(logging.ERROR, logger="genesis.cc.roster"):
+        assert R.apply_active(inv)[1] == R.CLAUDE
+    assert len(caplog.records) == 1
+
+    # 2. repaired -> resolves, no complaint
+    caplog.clear()
+    local.write_text("default: claude\n")
+    with caplog.at_level(logging.ERROR, logger="genesis.cc.roster"):
+        assert R.apply_active(inv)[1] == R.CLAUDE
+    assert not caplog.records
+
+    # 3. broken AGAIN -> must warn again, not be swallowed by the dedupe
+    caplog.clear()
+    local.write_text("default: removed-peer\n")
+    with caplog.at_level(logging.ERROR, logger="genesis.cc.roster"):
+        assert R.apply_active(inv)[1] == R.CLAUDE
+    assert len(caplog.records) == 1, "a re-break was silent"
+
+
+def test_defined_but_tokenless_default_uses_the_generic_handler(roster_dir, monkeypatch, caplog):
+    """Locks the load-bearing narrowing: a model that EXISTS but has no auth
+    token must not be reported as undefined — different fault, different repair.
+    Verified by hand during review; nothing asserted it."""
+    monkeypatch.delenv("ZHIPU_TEST_KEY", raising=False)
+    (roster_dir / "cc_roster.local.yaml").write_text("default: glm-5.2\n")
+    inv = CCInvocation(prompt="x", roster_eligible=True)
+    with caplog.at_level(logging.ERROR, logger="genesis.cc.roster"):
+        out, name = R.apply_active(inv, _load(roster_dir))
+    assert out is inv and name == R.CLAUDE
+    msgs = " ".join(r.getMessage() for r in caplog.records)
+    assert "apply_active failed" in msgs  # generic path
+    assert "cannot be resolved" not in msgs  # NOT the undefined-model message

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -24,6 +24,20 @@ _SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / "genesis"
 _HOME_CONFIG_RE = re.compile(r'Path\.home\(\)\s*/\s*["\']\.genesis["\']\s*/\s*["\']config["\']')
 
 
+@pytest.fixture(autouse=True)
+def _reset_overlay_warn_cache():
+    """Isolate the module-global warn-dedupe map.
+
+    ``_WARNED_OVERLAYS`` persists for the process, so without this one test's
+    warning suppresses another's and the suite passes for the wrong reason.
+    """
+    from genesis import _config_overlay as ov
+
+    ov._WARNED_OVERLAYS.clear()
+    yield
+    ov._WARNED_OVERLAYS.clear()
+
+
 def test_merge_reads_user_dir_overlay_first(tmp_path, monkeypatch):
     user_dir = tmp_path / "user_config"
     user_dir.mkdir()
@@ -334,3 +348,121 @@ def test_broken_overlay_warns_and_falls_back(tmp_path, monkeypatch, caplog):
     msg = caplog.records[0].getMessage()
     assert "cc_roster.local.yaml" in msg  # names the offending file
     assert "NOT in effect" in msg  # states the consequence
+
+
+# ── wrong ROOT SHAPE: valid YAML, not a mapping ──────────────────────────────
+# Codex/CodeRabbit review of the roster-portability PR: `_deep_merge` calls
+# `overlay.items()`, so a list or scalar root raised AttributeError from OUTSIDE
+# merge_local_overlay — propagating to every caller of the config loader instead
+# of degrading to base like every other malformed case.
+
+
+@pytest.mark.parametrize(
+    ("body", "shape"),
+    [("- one\n- two\n", "list"), ("just-a-string\n", "str"), ("42\n", "int")],
+)
+def test_non_mapping_overlay_root_falls_back_and_warns(tmp_path, monkeypatch, caplog, body, shape):
+    import logging
+
+    from genesis import _config_overlay as ov
+
+    base_path = tmp_path / "cc_roster.yaml"
+    base_path.write_text("default: claude\n")
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    (user_dir / "cc_roster.local.yaml").write_text(body)
+    monkeypatch.setattr(ov, "_user_config_dir", lambda: user_dir)
+
+    base = {"default": "claude", "models": {"claude": {"native_subscription": True}}}
+    with caplog.at_level(logging.WARNING, logger="genesis._config_overlay"):
+        out = ov.merge_local_overlay(base, base_path)  # must not raise
+
+    assert out == base  # fell back rather than exploding
+    assert caplog.records, "a wrong-shape overlay must not fail silently"
+    msg = caplog.records[0].getMessage()
+    assert "cc_roster.local.yaml" in msg
+    assert shape in msg  # names the offending shape
+    assert "NOT in effect" in msg
+
+
+def test_overlay_warning_is_deduped_per_file_version(tmp_path, monkeypatch, caplog):
+    """Some loaders re-read the overlay on EVERY call (the immunity gate reloads
+    per gate check), so an undeduped warning turns one YAML typo into a traceback
+    on every memory or approval operation. Warn once per file VERSION — and warn
+    again once the file changes, so a failed repair is still visible."""
+    import logging
+    import os
+
+    from genesis import _config_overlay as ov
+
+    base_path = tmp_path / "cc_roster.yaml"
+    base_path.write_text("default: claude\n")
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    local = user_dir / "cc_roster.local.yaml"
+    local.write_text("models:\n  bad: [unclosed\n")
+    monkeypatch.setattr(ov, "_user_config_dir", lambda: user_dir)
+
+    base = {"default": "claude"}
+    with caplog.at_level(logging.WARNING, logger="genesis._config_overlay"):
+        for _ in range(5):
+            assert ov.merge_local_overlay(base, base_path) == base
+    assert len(caplog.records) == 1, "flooded the journal on a hot-path loader"
+
+    # A NEW bad version must warn again — a silent second failure would hide a
+    # botched repair.
+    caplog.clear()
+    local.write_text("models:\n  worse: {also-unclosed\n")
+    os.utime(local, (0, 0))  # force a distinct mtime
+    with caplog.at_level(logging.WARNING, logger="genesis._config_overlay"):
+        assert ov.merge_local_overlay(base, base_path) == base
+    assert len(caplog.records) == 1, "a changed bad file must warn again"
+
+
+@pytest.mark.parametrize(
+    ("body", "shape"),
+    [("[]\n", "list"), ("false\n", "bool"), ("0\n", "int"), ('""\n', "str")],
+)
+def test_falsy_non_mapping_root_still_warns(tmp_path, monkeypatch, caplog, body, shape):
+    """A FALSY non-mapping root used to be swallowed by an `or {}` default — no
+    warning, every override silently dropped. An empty-list root is exactly the
+    shape this guard advertises catching, so the non-empty cases above were not
+    enough to prove it."""
+    import logging
+
+    from genesis import _config_overlay as ov
+
+    base_path = tmp_path / "cc_roster.yaml"
+    base_path.write_text("default: claude\n")
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    (user_dir / "cc_roster.local.yaml").write_text(body)
+    monkeypatch.setattr(ov, "_user_config_dir", lambda: user_dir)
+
+    base = {"default": "claude"}
+    with caplog.at_level(logging.WARNING, logger="genesis._config_overlay"):
+        assert ov.merge_local_overlay(base, base_path) == base
+    assert caplog.records, f"a {shape} root was dropped silently"
+    assert shape in caplog.records[0].getMessage()
+
+
+@pytest.mark.parametrize("body", ["", "\n", "null\n"])
+def test_empty_or_null_overlay_is_not_an_error(tmp_path, monkeypatch, caplog, body):
+    """An empty file or explicit `null` legitimately has nothing to merge, and
+    must NOT be reported as malformed — otherwise a freshly-created overlay
+    warns on every read."""
+    import logging
+
+    from genesis import _config_overlay as ov
+
+    base_path = tmp_path / "cc_roster.yaml"
+    base_path.write_text("default: claude\n")
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    (user_dir / "cc_roster.local.yaml").write_text(body)
+    monkeypatch.setattr(ov, "_user_config_dir", lambda: user_dir)
+
+    base = {"default": "claude"}
+    with caplog.at_level(logging.WARNING, logger="genesis._config_overlay"):
+        assert ov.merge_local_overlay(base, base_path) == base
+    assert not caplog.records, "an empty overlay is not a malformed one"

--- a/tests/test_config_overlay.py
+++ b/tests/test_config_overlay.py
@@ -214,7 +214,11 @@ def test_no_unisolated_local_yaml_resolver():
         "ledger/learned_knobs.py",  # _user_config_dir()/<stem>.local.yaml (user-dir-always)
     }
     # Files that merely MENTION ".local.yaml" in a message/help string.
-    prose_mentions = {"mcp/health/reflex_status.py"}
+    # cc/conversation.py: a WARNING emitted when CC failover finds no usable
+    # roster peer, telling the operator where to declare one. It reads the
+    # roster through genesis.cc.roster (which routes via merge_local_overlay);
+    # the path appears only in the human-facing message text.
+    prose_mentions = {"mcp/health/reflex_status.py", "cc/conversation.py"}
     accounted = independent_resolvers | shared_seam_users | prose_mentions
 
     found: set[str] = set()
@@ -298,3 +302,35 @@ def test_repo_sibling_overlay_is_neutralized_on_real_tree():
         f"repo-relative overlay {sib.name} leaked into a test merge — the "
         "_sandboxed_resolve neutralizer in conftest is not covering it"
     )
+
+
+def test_broken_overlay_warns_and_falls_back(tmp_path, monkeypatch, caplog):
+    """A malformed overlay must FALL BACK LOUDLY, never silently.
+
+    Regression guard for a silent-degradation path: `merge_local_overlay`
+    swallowed every parse error and returned `base` with no log line, so a
+    broken overlay was indistinguishable from a clean load. That is
+    load-bearing wherever the overlay is the SOLE home of a setting —
+    cc_roster peers, for one, where a single YAML typo yields "no fallback
+    peer configured" and the discovery moment is the subscription cap.
+    """
+    import logging
+
+    from genesis import _config_overlay as ov
+
+    base_path = tmp_path / "cc_roster.yaml"
+    base_path.write_text("default: claude\n")
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    (user_dir / "cc_roster.local.yaml").write_text("models:\n  bad: [unclosed\n")
+    monkeypatch.setattr(ov, "_user_config_dir", lambda: user_dir)
+
+    base = {"default": "claude", "models": {"claude": {"native_subscription": True}}}
+    with caplog.at_level(logging.WARNING, logger="genesis._config_overlay"):
+        out = ov.merge_local_overlay(base, base_path)
+
+    assert out == base  # fell back
+    assert caplog.records, "a broken overlay must not fail silently"
+    msg = caplog.records[0].getMessage()
+    assert "cc_roster.local.yaml" in msg  # names the offending file
+    assert "NOT in effect" in msg  # states the consequence

--- a/tests/test_dashboard/test_secrets_registry.py
+++ b/tests/test_dashboard/test_secrets_registry.py
@@ -1,0 +1,114 @@
+"""`secrets.env.example` is a PARSED REGISTRY, not prose — guard its contract.
+
+`dashboard/routes/secrets.py::_parse_example_file` builds the dashboard's
+Provider Keys panel from this file. Four comment shapes are load-bearing, and
+two of them are rendered to users:
+
+* ``# Used by: …`` becomes the key's description
+* ``# Signup: …``  becomes ``signup_url``, which
+  ``templates/partials/tabs/config.html`` renders as ``https://`` + the value
+
+So a ``# Signup:`` line containing free text ships a DEAD CLICKABLE LINK to
+every install. There was no test for any of this, which is why three
+consecutive review rounds on PR #1606 read the file as prose and only the third
+noticed — after measuring the parser's output rather than reading the file.
+These tests exist so the next editor is told by CI instead.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from genesis.dashboard.routes.secrets import _parse_example_file
+
+# Pre-existing malformed values, enumerated rather than silently tolerated.
+# Each renders a dead link in the Provider Keys panel today (e.g.
+# "https://console.cloud.google.com -> APIs & Services -> Credentials").
+# They predate the guard and are tracked separately; the point of listing them
+# is that the set may only ever SHRINK. A new key cannot join it — adding one
+# here should feel like the deliberate act it is.
+_KNOWN_MALFORMED_SIGNUP = frozenset(
+    {
+        "GOOGLE_API_KEY",
+        "API_KEY_ZENMUX",
+        "API_KEY_MINIMAX",
+        "API_KEY_NVIDIA_NIM",
+        "API_KEY_GITHUB",
+        "API_KEY_AZURE",
+        "API_KEY_BEDROCK",
+        "API_KEY_TAVILY",
+        "API_KEY_EXA",
+        "API_KEY_CLOUDFLARE",
+        "API_KEY_ELEVENLABS",
+        "API_KEY_CARTESIA",
+        "API_KEY_FISH_AUDIO",
+        "API_KEY_DEEPINFRA",
+        "API_KEY_PAGEINDEX",
+        "TESTSPRITE_API_KEY",
+    }
+)
+
+# A bare host: labels separated by dots, optionally followed by a /path.
+# Deliberately strict — no spaces, no arrows, no trailing prose.
+_BARE_HOST_RE = re.compile(
+    r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+(/\S*)?$"
+)
+
+
+def test_signup_urls_are_bare_hosts():
+    """Every ``# Signup:`` value must be href-able, because it becomes an href.
+
+    The template does ``:href="'https://' + k.signup_url"`` with no validation,
+    so anything with a space in it is a broken link shipped to every install.
+    """
+    offenders = {
+        d.key: d.signup_url
+        for d in _parse_example_file()
+        if d.signup_url
+        and d.key not in _KNOWN_MALFORMED_SIGNUP
+        and not _BARE_HOST_RE.match(d.signup_url)
+    }
+    assert not offenders, (
+        "`# Signup:` becomes an href (https:// + value) in the dashboard's "
+        f"Provider Keys panel, so these ship dead links: {offenders}. Use a bare "
+        "host (e.g. `# Signup: console.cloud.google.com`) and put any "
+        "navigation steps on the `# Used by:` line instead."
+    )
+
+
+def test_known_malformed_set_only_shrinks():
+    """The pre-existing-debt allow-list must not contain keys that are now fine.
+
+    Without this, a fixed key would linger in the list forever and the guard
+    would quietly stop covering it.
+    """
+    parsed = {d.key: d.signup_url for d in _parse_example_file()}
+    stale = {
+        key
+        for key in _KNOWN_MALFORMED_SIGNUP
+        if key not in parsed or not parsed[key] or _BARE_HOST_RE.match(parsed[key])
+    }
+    assert not stale, (
+        f"These keys are no longer malformed (or no longer exist): {sorted(stale)}. "
+        "Remove them from _KNOWN_MALFORMED_SIGNUP — the list may only shrink."
+    )
+
+
+@pytest.mark.parametrize("key", ["ZHIPU_API_KEY", "ZAI_CODING_API_KEY", "BIGMODEL_CODING_API_KEY"])
+def test_glm_keys_carry_both_parsed_fields(key):
+    """The GLM slots specifically — the ones PR #1606 broke and then fixed.
+
+    Both fields RESET after every ``KEY=`` line (secrets.py), so a single shared
+    prose block above three keys leaves two of them empty. That is exactly what
+    happened, and it was invisible to reading.
+    """
+    by_key = {d.key: d for d in _parse_example_file()}
+    assert key in by_key, f"{key} is not declared in secrets.env.example"
+    entry = by_key[key]
+    assert entry.description, f"{key} lost its `# Used by:` line"
+    assert entry.signup_url, f"{key} lost its `# Signup:` line"
+    assert _BARE_HOST_RE.match(entry.signup_url), (
+        f"{key} signup_url is not a bare host: {entry.signup_url!r}"
+    )

--- a/tests/test_db/test_cc_sessions.py
+++ b/tests/test_db/test_cc_sessions.py
@@ -72,9 +72,23 @@ async def test_roster_persist_reconstruct_loop(db, sess_fields, monkeypatch):
     from genesis.cc import roster
     from genesis.cc.types import CCInvocation
 
-    monkeypatch.setenv("ZHIPU_API_KEY", "sk-live")
+    monkeypatch.setenv("GENESIS_TEST_ROSTER_KEY", "sk-live")
+    # Hermetic roster: the shipped config ships NO peers (install-specific, they
+    # live in ~/.genesis/config/cc_roster.local.yaml), so inject one rather than
+    # depend on whatever this machine happens to have configured.
+    test_roster = {
+        "default": "claude",
+        "models": {
+            "claude": {"native_subscription": True},
+            "test-peer": {
+                "anthropic_base_url": "https://example.invalid/api/anthropic",
+                "model_id": "test-peer",
+                "auth_env": "GENESIS_TEST_ROSTER_KEY",
+            },
+        },
+    }
     # (persist) what conversation/direct_session compute from output.roster_model:
-    payload = roster.endpoint_payload("glm-5.2")  # real config ships glm-5.2
+    payload = roster.endpoint_payload("test-peer", test_roster)
     assert payload and "token" not in payload  # NAME only, no secret
     await cc_sessions.create(db, **sess_fields)
     assert await cc_sessions.merge_metadata(db, "sess-1", {"roster_endpoint": payload})
@@ -83,7 +97,7 @@ async def test_roster_persist_reconstruct_loop(db, sess_fields, monkeypatch):
     row = await cc_sessions.get_by_id(db, "sess-1")
     ep = json.loads(row["metadata"])["roster_endpoint"]
     overrides = roster.overrides_from_persisted(ep)  # token re-read from env
-    assert overrides["model_id_override"] == "glm-5.2"
+    assert overrides["model_id_override"] == "test-peer"
     assert overrides["anthropic_auth_token"] == "sk-live"
 
     # (chokepoint) a pre-stamped routed resume is respected, never rerouted:
@@ -94,7 +108,7 @@ async def test_roster_persist_reconstruct_loop(db, sess_fields, monkeypatch):
         **overrides,
     )
     out_inv, name = roster.apply_active(inv)
-    assert out_inv is inv and name == "glm-5.2"
+    assert out_inv is inv and name == "test-peer"
 
 
 async def test_merge_metadata_round_trip(db, sess_fields):

--- a/tests/test_mcp/test_settings_cc_roster.py
+++ b/tests/test_mcp/test_settings_cc_roster.py
@@ -22,17 +22,30 @@ def test_validate_accepts_native_default():
     assert _validate_cc_roster({"default": "claude"}) == []
 
 
+# Hermetic peer. The shipped config deliberately contains NO peers (they are
+# install-specific, configured in ~/.genesis/config/cc_roster.local.yaml), so a
+# test must supply its own. `_validate_cc_roster` merges `changes["models"]` over
+# the loaded roster before validating, which is exactly the "add a peer and make
+# it default in one call" path — so this exercises more than the old version did.
+_TEST_PEER = {
+    "test-peer": {
+        "anthropic_base_url": "https://example.invalid/api/anthropic",
+        "model_id": "test-model",
+        "auth_env": "GENESIS_TEST_ROSTER_KEY",
+    }
+}
+
+
 def test_validate_accepts_routed_default_when_auth_present(monkeypatch):
-    # config/cc_roster.yaml ships glm-5.2 with auth_env ZHIPU_API_KEY.
-    monkeypatch.setenv("ZHIPU_API_KEY", "sk-test")
-    assert _validate_cc_roster({"default": "glm-5.2"}) == []
+    monkeypatch.setenv("GENESIS_TEST_ROSTER_KEY", "sk-test")
+    assert _validate_cc_roster({"default": "test-peer", "models": _TEST_PEER}) == []
 
 
 def test_validate_rejects_routed_default_when_auth_missing(monkeypatch):
     # no-silent-degrade: setting a routed default with no key must be loud.
-    monkeypatch.delenv("ZHIPU_API_KEY", raising=False)
-    errs = _validate_cc_roster({"default": "glm-5.2"})
-    assert errs and "ZHIPU_API_KEY" in errs[0]
+    monkeypatch.delenv("GENESIS_TEST_ROSTER_KEY", raising=False)
+    errs = _validate_cc_roster({"default": "test-peer", "models": _TEST_PEER})
+    assert errs and "GENESIS_TEST_ROSTER_KEY" in errs[0]
 
 
 def test_validate_rejects_unknown_default():


### PR DESCRIPTION
## The bug

`config/cc_roster.yaml` shipped a hardcoded `glm-5.2` peer pointed at `open.bigmodel.cn`. That platform requires Chinese real-name identity verification (实名认证) to buy a Coding Plan — so **on any install outside China, the documented CC rate-limit fallback could not be provisioned at all.**

The base config now ships only the native `claude` entry plus commented examples. Peers are declared per-install in `~/.genesis/config/cc_roster.local.yaml`, which is already where the `cc_roster` settings domain writes (verified: `settings.py` `_atomic_yaml_write` targets the user config dir, and `_config_overlay._resolve_overlay_path` reads user-dir-first, so writer and loader agree).

## Why version churn, not "peers are user data"

The weaker argument doesn't survive this repo, and the PR says so in the file rather than hiding it. `config/model_routing.yaml` ships **28** named vendor providers, `routing/config.py:287` states *"Partial API-key configuration is the normal install state"*, and `roster.py:293` gates every peer on its `auth_env` being present — so a shipped peer with no key is **provably inert** and would cost an unprovisioned install nothing.

The reason that does hold: a roster peer pins a `model_id`, and model ids go EOL. This file already shipped `glm-5.2` past its replacement by `glm-5.3`. A stale pinned id fails **while looking configured**, at exactly the moment the subscription caps and the fallback is finally needed. A routing provider degrades to "1 of 28 models down"; a stale roster peer degrades to "the fallback you were relying on does not exist."

## Migration

**Blast radius is smaller than it looks.** `failover_chain` already dropped any peer whose `auth_env` was unset, so an install without `ZHIPU_API_KEY` had zero fallback peers before this change too. Only installs that had *both* the key and a BigModel Coding Plan lose a peer — the population this fixes.

All 13 roster-peer call sites were enumerated. **Nothing fails open.** Removal is loud at `apply_active` (logs + falls back to native), `overrides_for` (`RosterError`), `_reconstruct_resume` (refuses native resume of a routed session), `gmodel` (exit 1), `eval gauntlet`, `direct_session_run`, and `_validate_cc_roster` (blocks at write time). The resume path is unaffected: `overrides_from_persisted` reads the persisted payload and re-reads the token from env, with no config lookup.

## Also fixed, from the adversarial review of the above

- **`_config_overlay` no longer swallows a malformed overlay silently.** It returned `base` with no log line, so a broken overlay was indistinguishable from a clean load. That's load-bearing now the overlay is the sole home of every peer: one YAML typo means "no fallback", discovered at the cap. Verified end-to-end and locked by a regression test.
- **CC failover logs when no usable peer exists** instead of returning `None` silently — and names the keyless-peer case, which otherwise looks identical to "none declared".
- **`secrets.env.example` no longer claims `ZHIPU_API_KEY` is read by the router.** Nothing in this repo reads it (the router's `glm51` entry is a z-ai model served via ZenMux on that provider's key). An earlier revision of this branch introduced that false attribution; this corrects it.
- **`test_gmodel.py` is hermetic at the helper, not at one caller.** `_run` now takes a required `home` with no `Path.home()` default, so a new test cannot reintroduce the leak of a developer's real overlay into a subprocess.
- **A test pins the deliverable.** Every other roster test writes synthetic yaml or monkeypatches `load_roster`, so re-adding a peer to the shipped config previously broke nothing.
- **The example keeps roster key == `model_id`.** `apply_active` returns the model_id where callers expect the roster name, which would strand the account-wide fallback flag and skip resume-endpoint persistence. Documented here; mechanism fix tracked separately.
- Doc accuracy: `claude` survives an overlay only when `models:` is a mapping (a non-mapping `models:` replaces the block); `gmodel` points at the overlay; the third-party ToS note is attributed and date-stamped; the CHANGELOG drops a fleet claim the repo can't measure.

## Verification

- `ruff check .` clean
- **200 passed, 1 skipped** across `test_config_overlay`, `test_roster`, `test_gmodel`, `test_fallback_state`, `test_fallback_recovery`, `test_conversation_failover`, `test_conversation`, `test_invoker_roster_env`, `test_direct_session`, `test_settings_cc_roster`, `test_cc_sessions`, `test_health_mcp`
- The overlay-warning fix was verified outside pytest as well, not only unit-tested

Note `scripts/check_portability.sh` exits 1 locally on `src/genesis/cc/session_cap.py:73,76,153` — pre-existing (that file is untouched here) and not CI-gating: `ci.yml:173` invokes it with `--warn`, which the script documents as a non-gating advisory sweep that always exits 0.

Follow-up: 69fb6f2ec9214ec9b043f632e67b73b3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changed**
  - The shipped Claude Code roster now includes only native Claude.
  - Additional peers can be configured through a local roster overlay.
  - Credential and endpoint guidance distinguishes general/prepaid access from GLM Coding Plan usage, including China and international options.
  - Validation status is documented as advisory.

- **Bug Fixes**
  - Invalid or empty local overlays now preserve the base configuration with clear warnings.
  - Unresolved or unauthenticated failover peers now fall back to contingency handling with clearer diagnostics.

- **Documentation**
  - Updated roster setup, model selection, and credential guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->