### PR TITLE
fix(hooks): fold only real line continuations, not escaped backslashes

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -615,10 +615,50 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   `scripts/hooks/destructive_command_guard.py:101-120`: its replacements delete a
   line continuation — which is what the shell does with it — or insert
   whitespace and separators; none introduces a quote or an escape, so none can
-  corrupt the quote balance shlex decides on. (The deletion removes a backslash,
-  but a backslash-newline is a continuation, not an escape the shell keeps; the
-  one place the shell does keep it, inside single quotes, is an over-block the
-  guard states rather than hides.) That is a `cannot`; a
+  corrupt the quote balance shlex decides on. (The one place the shell keeps a
+  backslash-newline literally, inside single quotes, is an over-block the guard
+  states rather than hides.) That is a `cannot` — but read the next paragraph
+  before reusing it, because the version of this argument that stood here for
+  weeks was WRONG in a way that shipped a live bypass.
+
+  **What that earlier version got wrong, and why it is the sharpest example on
+  this page.** It added: *"a backslash-newline is a continuation, not an escape
+  the shell keeps."* That is true only when the backslash is itself unescaped —
+  an ODD-length run. In an EVEN-length run every backslash is escaped by its
+  neighbour, so the last one is a literal character and the newline after it is
+  a REAL command separator. The guard folded it anyway, deleting the separator
+  and gluing the next command's first word onto the previous token, so no `rm`
+  token existed and a destructive command was ALLOWED — measured end-to-end
+  through the live hook, exit 0 where the plain-newline control gave exit 2. The
+  legacy regex net did not save it either: that fires only when tokenizing
+  FAILED, and this tokenized fine, just wrongly. Fixed 2026-09-02 by folding
+  only odd-length runs.
+
+  Note precisely what was and was not at fault, because the first attempt at
+  this correction got it wrong in an instructive way: it said the quote-balance
+  reasoning "was CORRECT and is not what broke", and exonerated it. Quote
+  corruption is indeed not the *mechanism* of the token-glue bypass — but the
+  quote-balance `cannot` **was not sound either, and it failed in the very same
+  cell**. Deleting one backslash from an even-length run leaves an ODD run whose
+  survivor escapes the next character; when that character is a quote, the fold
+  DOES introduce an escape and shlex's balance shifts. Measured: it turned
+  parseable commands UNPARSEABLE (11 of 20,000 random parseable commands under
+  the old fold, 0 under the fix), which dropped them into the legacy-regex net —
+  a net that matches neither `-Rf` nor `-r -f` nor `--recursive --force` nor a
+  quoted `'rm'`, so they failed OPEN. One quiet universal quantifier (*every*
+  backslash-newline is a continuation) falsified BOTH claims at once, and the
+  old code therefore had two bypass families rather than one. The fold now
+  always leaves an even-length run, which is what finally makes the `cannot`
+  true.
+
+  A structural `cannot` is only as good as the case-split it rests on, so state
+  the split explicitly and enumerate it — the same trap as the direction-claim
+  two paragraphs down, which was true of the operand and false of the option
+  token. That both the wrong premise AND the first correction of it were written
+  in a document teaching this exact discipline is the point: the danger is not
+  knowing the rule, it is believing you already applied it.
+
+  A corpus run only ever yields `did not, here`, and by the rule above it is
   corpus run only ever yields `did not, here`, and by the rule above it is
   structurally blind to the shape nobody typed. Run the corpus as
   corroboration, never as the proof, and pair it with a control that DOES flip

--- a/scripts/hooks/destructive_command_guard.py
+++ b/scripts/hooks/destructive_command_guard.py
@@ -74,6 +74,15 @@ _REDIR_TOKEN = re.compile(r"\d*[<>]|&>")
 # (`2>&1`, `>&2`) or followed by `>` (`&>`). (`&&` is matched as a unit first.)
 _SEPARATOR_SPACING = re.compile(r"(\|\||&&|[|;]|(?<![<>])&(?!>))")
 
+# A line continuation: a backslash-newline whose backslash is NOT itself escaped.
+# `(?<!\\)` anchors the match at the START of a backslash run; `((?:\\\\)*)`
+# consumes the escaped PAIRS (kept via the backreference); the trailing `\\\n` is
+# the odd one out — the real continuation — and is dropped with its newline.
+# An even-length run therefore matches nothing: its last backslash is a literal
+# character and the newline after it stays a command separator. Getting this
+# wrong is a guard bypass, not a cosmetic issue — see _rm_violations.
+_CONTINUATION = re.compile(r"(?<!\\)((?:\\\\)*)\\\n")
+
 
 def _check_target(target: str) -> str | None:
     """Reason string if *target* is too broad to rm recursively."""
@@ -112,12 +121,24 @@ def _rm_violations(cmd: str) -> list[str] | None:
     # the shell keeps the sequence literally; folding it there only changes the
     # spelling of one operand, never its depth or its flags.)
     #
+    # ONLY AN ODD-LENGTH BACKSLASH RUN IS A CONTINUATION. In an even-length run
+    # every backslash is escaped by its neighbour, so the last one is a literal
+    # character and the newline after it is a REAL command separator. Folding it
+    # anyway deleted that separator and glued the next command's first word onto
+    # the previous token (`printf x` + `rm` -> `xrm`), so no `rm` token existed
+    # and the guard allowed a destructive command the shell then ran. It returned
+    # "no violations" rather than "unparseable", so main()'s legacy-regex fallback
+    # — which only fires when tokenizing FAILED — never fired either.
+    # `_CONTINUATION` therefore matches a backslash-newline only when the run
+    # length is odd: the captured even pairs are kept, the final backslash and its
+    # newline are dropped.
+    #
     # These replacements delete a continuation or insert whitespace/`;`, never
     # quote or escape characters, so they cannot corrupt shlex's quote balance.
     # Redirections are NOT stripped here — they are recognized at the token
     # level after shlex (see _REDIR_TOKEN), so shlex stays the sole authority on
     # quoting/escaping.
-    cmd = cmd.replace("\\\n", "").replace("\n", " ; ")
+    cmd = _CONTINUATION.sub(r"\1", cmd).replace("\n", " ; ")
     # Space glued command separators (`x;y`, `a&&b`) into standalone tokens so
     # the operand loop stops at them; a redirection `&` is preserved.
     spaced = _SEPARATOR_SPACING.sub(r" \1 ", cmd)

--- a/tests/test_hooks/test_destructive_command_guard.py
+++ b/tests/test_hooks/test_destructive_command_guard.py
@@ -117,3 +117,75 @@ class TestLineContinuationFoldsAsTheShellFolds:
         """Without this, an implementation that returned None for everything
         would satisfy the equality above."""
         assert _blocks("rm -rf ~/genesis")
+
+
+class TestEscapedBackslashIsNotAContinuation:
+    """An ESCAPED backslash before a newline does NOT continue the line.
+
+    The class above folds `\\<newline>` because the shell deletes it. That is
+    true only when the backslash is ITSELF unescaped — i.e. an ODD-length run.
+    In an EVEN-length run every backslash is already escaped by its neighbour,
+    so the final one is a literal character and the newline that follows is a
+    real command separator: the shell runs TWO commands.
+
+    Folding it anyway deletes that separator, glues the next command's first
+    word onto the previous token (`printf x` + `rm` -> `xrm`), and the guard
+    then never sees an `rm` token at all. It returns "no violations" — not
+    "unparseable" — so `main()`'s legacy-regex fallback, which only runs when
+    tokenizing FAILED, never fires either. The command is allowed and the shell
+    runs it.
+
+    Same property as the class above, asserted on the other side of the parity:
+    the verdict for the escaped form must equal the verdict for the form the
+    shell actually executes.
+    """
+
+    @pytest.mark.parametrize("run_len", [2, 4])
+    def test_even_run_preserves_the_separator(self, run_len):
+        backslashes = "\\" * run_len
+        escaped = f"printf x{backslashes}\nrm -rf /"
+        # What the shell really runs: two commands. `;` is the separator form.
+        as_shell_runs = f"printf x{backslashes} ; rm -rf /"
+
+        # Guard-the-guard: this fixture must actually carry an EVEN-length
+        # backslash run immediately before the newline, or it tests nothing.
+        head = escaped.split("\n", 1)[0]
+        trailing = len(head) - len(head.rstrip("\\"))
+        assert trailing == run_len and run_len % 2 == 0, (
+            f"fixture lost its property: trailing run {trailing}, expected even {run_len}"
+        )
+
+        assert dg._rm_violations(escaped) == dg._rm_violations(as_shell_runs), (
+            f"{escaped!r} -> {dg._rm_violations(escaped)!r}; "
+            f"shell runs {as_shell_runs!r} -> {dg._rm_violations(as_shell_runs)!r}"
+        )
+        assert _blocks(escaped), "an escaped backslash hid a destructive command"
+
+    def test_odd_run_still_folds(self):
+        """Cheap equivalence lock on the odd run — NOT an over-correction constraint.
+
+        Measured against a never-fold implementation, BOTH sides return ``[]``,
+        so this passes and constrains nothing in that direction. The
+        over-correction guarantee is carried entirely by
+        ``TestLineContinuationFoldsAsTheShellFolds`` above, which does fail
+        (4 cases) under never-fold. Do not read this as proof the fix cannot
+        over-correct; the docstring said exactly that once and was wrong.
+        """
+        assert dg._rm_violations("rm -rf /a/b/c/d\\\n/e") == dg._rm_violations("rm -rf /a/b/c/d/e")
+
+    def test_boundary_one_backslash_folds_two_does_not(self):
+        """The odd/even boundary is the whole fix, asserted directly.
+
+        The odd-run target is ``/`` — depth 1 — deliberately. An earlier
+        revision used a depth-5 target, which is ALLOWED whether or not the
+        fold happens, so the assertion passed under a never-fold implementation
+        too: vacuous in precisely the direction it claims to test. At ``/`` the
+        two implementations disagree — folding joins ``x``+``rm`` so no rm token
+        exists (allow), never-folding leaves a real ``rm -rf /`` (block).
+        """
+        assert not _blocks("printf x\\\nrm -rf /"), (
+            "odd run is a continuation: the words join, no second command exists"
+        )
+        assert _blocks("printf x\\\\\nrm -rf /"), (
+            "even run is a literal backslash + a real separator: rm must be seen"
+        )


### PR DESCRIPTION
## A live fail-open in a wired PreToolUse guard

`_rm_violations` normalized with `cmd.replace("\\\n", "")`, treating **every** backslash-newline as a line continuation. That holds only when the backslash is itself unescaped — an **odd**-length run. In an **even**-length run each backslash is escaped by its neighbour, so the last one is a literal character and the newline after it is a real command separator.

Folding it anyway deleted that separator, glued the next command's first word onto the previous token, and left no `rm` token for the guard to see. Measured end-to-end through the real hook entry:

| input | shell runs | guard tokens | hook exit |
|---|---|---|---|
| `printf x` ⏎ `rm -rf /` (control) | 2 commands | `['printf','x',';','rm','-rf','/']` | **2 — block** |
| `printf x\\` ⏎ `rm -rf /` | 2 commands | `['printf','xrm','-rf','/']` | **0 — allow** |

The legacy `_RM_RF_PATTERN` net does not catch it either: `main()` consults that net only when `_rm_violations` returned `None` (tokenizing **failed**). Here it returned `[]` — tokenizing succeeded and produced the wrong tokens. The stated contract, *an unparseable command is a block*, says nothing about a **mis-parsed** one.

`protected_paths_guard` independently blocks protected targets, but shallow non-protected targets (`/`, `/usr`, `/etc`) are caught by nothing else in the chain.

## The fix

```python
_CONTINUATION = re.compile(r"(?<!\\)((?:\\\\)*)\\\n")
cmd = _CONTINUATION.sub(r"\1", cmd).replace("\n", " ; ")
```

`(?<!\\)` can only succeed at a run's **start**, so a match is attempted once per run; from there the pattern succeeds iff the run is odd. Even runs match nothing.

## Measured

Corpus replay is structurally blind to shapes nobody typed, so the coverage check is a **generated matrix**, with the corpus-style fuzz as corroboration:

| probe | result |
|---|---|
| 5 contexts × run lengths 0–6 (mine) | run 0 and **every odd run byte-identical** to the previous implementation; only even runs ≥2 change |
| Truth table, run lengths 0–8 × 14 positions (reviewer, against a logging `rm` shim) | **new 0 misses, old 20 misses** |
| Exhaustive insertion sweep, every index of 5 destructive bases, ~700 executed cases | **new 0 misses, old 20 misses** |
| Random differential fuzz, 4,000 executed commands | 292 genuinely destructive per bash; **0 new misses** |
| Quote-balance, 20,000 random parseable commands | **old corrupted 11, new 0** |
| ReDoS: 50k-backslash inputs | 3.4–6.2 ms |

Acceptance replay through the real hook, 7/7: the attack blocks at 2 and 4 backslashes; genuine continuations still fold; a continuation inside an option token still blocks; deep paths and ordinary commands unaffected.

## The same error had a second consequence

The review found the parity bug also broke a claim the file makes about itself. Deleting one backslash from an even run leaves an **odd** run whose survivor escapes the next character — and when that character is a quote, the fold **introduces an escape**, shifting shlex's balance. Parseable commands became unparseable and fell into the legacy net, which matches neither `-Rf` nor `-r -f` nor `--recursive --force` nor a quoted `'rm'`, so they failed **open**. Four such old-code bypasses were measured directly, e.g. `printf x\\` ⏎ `'rm' -Rf /usr` → old allow, new block.

One faulty premise produced two bypass families. The fold now always leaves an even-length run, which is what finally makes the file's stated `cannot` true.

## Documentation corrected

`.claude/skills/genesis-development/SKILL.md` cited this exact function as the model of a sound structural argument, on the premise that "a backslash-newline is a continuation, not an escape the shell keeps". That premise is the bug. The correction states the odd/even case-split, records that the quote-balance argument was *also* unsound in the same cell, and keeps the part that was right — in a passage whose own thesis is that the danger is believing you already applied the rule.

## Verification

Four new tests, RED witnessed before the fix. Two of them were initially **vacuous in the direction their docstrings claimed** — measured against a never-fold control, both passed — which the review caught. The boundary test's target moved from a depth-5 path to `/` so the two implementations actually disagree, re-verified by mutation; the other keeps a corrected docstring naming it an equivalence lock rather than an over-correction constraint, since the pre-existing `TestLineContinuationFoldsAsTheShellFolds` class is what genuinely carries that guarantee.

217 tests pass across the guard, `shell_parse` and `protected_paths` suites. `ruff` clean.

## Not bundled here

Two sibling findings from the same review are tracked separately, since a gate-parser change belongs in its own isolated PR:

- **`shell_parse.split_segments` has no backslash handling outside quotes** and splits unconditionally on `\n`, so a *genuine* continuation splits a word bash joins and the protected-paths guard never sees the real target. Verified: `rm -rf ~/.claude/proj\`⏎`ects` and `rm -rf ~/genesis/da`⏎`ta` return exit 0 from every hook, while their unsplit controls are blocked. More severe than the defect fixed here.
- The protected-paths ancestor test builds a doubled separator for filesystem root, the one ancestor it therefore misses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved destructive-command detection for shell commands containing escaped backslashes before newlines.
  - Command separators are now preserved when appropriate, preventing separate commands from being incorrectly combined.
  - Destructive `rm` commands following escaped line breaks are detected more reliably.
  - Shell line continuations continue to work correctly for odd-length backslash sequences.

- **Documentation**
  - Expanded guidance on shell normalization, backslash handling, quote balancing, and validation limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->