### PR TITLE
fix(privacy): dated docs are private in every opt-in dir, not just reference/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,10 +130,21 @@ docs/reference/backup-history-migration.md
 # inherits public-by-default, so an allowed dir doubles as a scratch pad and
 # `git add -A` publishes it. MEASURED 2026-09-02: 8 such files had accumulated
 # under docs/decisions/ (none ever pushed — caught first), while 0 of 92
-# tracked docs files carry a date prefix. So this excludes nothing currently
+# tracked docs files carry a year prefix. So this excludes nothing currently
 # public and no legitimate naming convention.
+#
+# The prefix is a YEAR, not a full date, because that is what the rule above
+# actually is — an earlier draft required YYYY-MM-DD- and so did NOT generalise
+# it: docs/decisions/2026-private-strategy.md stayed publishable while the
+# identically-named file under reference/ was ignored (Codex P1, #1611).
+# Written 20[0-9][0-9] rather than [0-9][0-9][0-9][0-9] to avoid colliding with
+# sequentially-numbered ADRs — docs/decisions/ uses 001-…007- today, but a
+# 4-digit ADR scheme would otherwise be silently swallowed.
+# No extension suffix, deliberately: the fail-safe direction for a PRIVACY rule
+# is to ignore too much (visible, recoverable with `git add -f`) rather than too
+# little (a silent leak). A dated .svg or .txt is a working artifact too.
 # A genuinely-public dated doc is still possible with an explicit `git add -f`.
-docs/**/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*
+docs/**/20[0-9][0-9]-*
 
 # Career-ops interop (private — lives at ~/.genesis/interop/)
 config/interop_system_prompt.md

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,17 @@ docs/*
 # Private files within allowed dirs
 docs/reference/2026-*.md
 docs/reference/backup-history-migration.md
+# Dated docs are WORKING ARTIFACTS — design notes, decision drafts, migration
+# plans — and belong in ~/.genesis/output/specs/, never in the public tree.
+# Generalises the docs/reference/2026-*.md rule above to every opt-in dir,
+# because the opt-in above is per-DIRECTORY: anything dropped into one of them
+# inherits public-by-default, so an allowed dir doubles as a scratch pad and
+# `git add -A` publishes it. MEASURED 2026-09-02: 8 such files had accumulated
+# under docs/decisions/ (none ever pushed — caught first), while 0 of 92
+# tracked docs files carry a date prefix. So this excludes nothing currently
+# public and no legitimate naming convention.
+# A genuinely-public dated doc is still possible with an explicit `git add -f`.
+docs/**/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*
 
 # Career-ops interop (private — lives at ~/.genesis/interop/)
 config/interop_system_prompt.md


### PR DESCRIPTION
## What

`.gitignore` already makes docs private by default (`docs/*`) with a
per-**directory** opt-in allowlist (`!docs/architecture/`, `!docs/decisions/`, …).
Because the opt-in is per-directory, anything dropped into one of those
directories inherits public-by-default — so an allowed directory doubles as a
scratch pad and `git add -A` publishes it.

This generalises the file's **own existing convention** — `docs/reference/2026-*.md`,
which has sat under the comment *"Private files within allowed dirs"* all along —
from one directory to all of them. It is not a new mechanism.

## Why now

Eight dated design docs had accumulated under `docs/decisions/`, including a
strategy note.

**Exposure: zero, verified.** Every one was checked against every ref before this
change. Seven were never committed anywhere; the eighth has three commits but
only on local branches (`backup/main-pre-*`, `models-merge`) —
`git log --remotes -- <path>` returns 0. Nothing was ever pushed. The hazard was
real and had not fired.

The eight have been relocated to `~/.genesis/output/specs/`, where the standing
"design docs stay local" rule puts them.

## Measured, both directions

| Check | Result |
|---|---|
| Tracked docs files this would exclude | **0 of 92** |
| `**` matches at depth 1 as well as deeper | verified (a rule that only worked below level 1 would silently miss `docs/2026-*.md`) |
| Numbered ADRs / undated architecture docs / README still addable | yes |
| **Acceptance bar** — two real leaked files present, `git add -A` | stages only `.gitignore` |
| **Control** — same command, rule reverted | stages **both** leaked docs |

Already-tracked files are unaffected (gitignore never applies to them), so the
eight ADRs and README under `docs/decisions/` are untouched.

## Rejected alternatives, on evidence

**Suffix rules.** `*-design.md` and `*-plan.md` would have wrongly excluded four
legitimately-public architecture documents
(`genesis-v3-self-healing-design.md` and three siblings). Rejected on that
measurement.

**A `chmod a-w` belt.** Dropped after testing the real operation rather than the
primitives: on a directory holding tracked files it corrupts branch switching —
git fails to unlink, **switches the branch anyway**, and leaves the working tree
holding another branch's file content plus a file that should not exist there;
the return checkout then fails outright. Silent tree/branch inconsistency is
worse than the hazard it was guarding.

## Known gap, stated not hidden

An **undated** design doc in an opt-in directory is still exposed. The only rules
that would close it cost the four false positives above, which is the worse
trade. A genuinely-public dated doc remains possible with an explicit
`git add -f`.

## Deploy

None. `.gitignore` is tracked, so this reaches every install and every worktree
on pull. The sibling install was checked and carries a byte-identical docs block —
no cross-machine action needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated version-control exclusions for supported documentation subdirectories to omit files beginning with a four-digit year followed by a hyphen, regardless of file extension. Explicit overrides remain available when a file must be added manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->