### PR TITLE
fix(browser): stop screenshots overwriting one another in both writers

### DIFF
--- a/scripts/browser.py
+++ b/scripts/browser.py
@@ -16,12 +16,26 @@ Usage:
 
 import argparse
 import sys
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 from playwright.sync_api import sync_playwright
 
 USER_DATA_DIR = Path.home() / ".genesis" / "browser-profile"
-DEFAULT_SCREENSHOT = str(Path.home() / "tmp" / "browser_screenshot.png")
+
+
+def _default_screenshot_path() -> str:
+    """A unique path per capture, so consecutive screenshots don't overwrite.
+
+    A module-level constant cannot do this — it would bind one name for the
+    life of the process, which is the bug this replaces. Same scheme as the
+    MCP tool's `_impl_browser_screenshot` (genesis/mcp/health/browser.py):
+    sortable timestamp + full uuid4 hex. Deliberately duplicated rather than
+    imported — this CLI stays free of genesis imports so it can run standalone.
+    """
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+    return str(Path.home() / "tmp" / f"browser_screenshot_{stamp}_{uuid.uuid4().hex}.png")
 
 
 def _launch(pw):
@@ -83,7 +97,7 @@ def cmd_screenshot(args):
     with sync_playwright() as pw:
         context, page = _launch(pw)
         try:
-            path = args.path or DEFAULT_SCREENSHOT
+            path = args.path or _default_screenshot_path()
             page.screenshot(path=path)
             print(f"Screenshot saved: {path}")
         finally:

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -23,6 +23,8 @@ import random
 import re
 import signal
 import time
+import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 from genesis.mcp.health import mcp
@@ -51,6 +53,12 @@ _TS_LOG_PATH = Path.home() / "tmp" / "turnstile_debug.log"
 def _ts_log_write(msg: str) -> None:
     """Write a timestamped line directly to the Turnstile debug log."""
     try:
+        # Deliberate LOCAL import despite the module-level one: it keeps this
+        # writer out of reach of patch.object(browser, "datetime"), which the
+        # clock-controlled screenshot tests use. Deleting it as "redundant"
+        # would let this function consume an injected side_effect entry and
+        # write a MagicMock repr into the log — silently, since this block
+        # swallows exceptions.
         from datetime import UTC, datetime
 
         ts = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
@@ -2120,7 +2128,18 @@ async def _impl_browser_screenshot() -> dict:
         page = _active_page
     try:
         _SCREENSHOT_DIR.mkdir(parents=True, exist_ok=True)
-        screenshot_path = _SCREENSHOT_DIR / "genesis_browser_screenshot.png"
+        # Unique per call: consecutive captures must not overwrite one another
+        # (a session capturing 8 pages kept only the last one). The timestamp
+        # makes a capture SEQUENCE sortable at MICROSECOND resolution — a
+        # 1-second stamp ties an 8-capture burst (measured). The full uuid4 hex,
+        # not a truncation, keeps collisions negligible across the 7-day ~/tmp
+        # retention window. Sibling writer: scripts/browser.py — the stamp
+        # FORMAT is asserted on both sides, see the _STAMP regex in each test.
+        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+        screenshot_path = (
+            _SCREENSHOT_DIR
+            / f"genesis_browser_screenshot_{stamp}_{uuid.uuid4().hex}.png"
+        )
         await page.screenshot(path=str(screenshot_path))
         return {
             "path": str(screenshot_path),
@@ -2341,8 +2360,10 @@ async def browser_upload(selector: str, file_path: str) -> dict:
 async def browser_screenshot() -> dict:
     """Take a screenshot of the current page.
 
-    Saves to ~/tmp/genesis_browser_screenshot.png and returns the path.
-    Use the Read tool to view the image.
+    Saves to a uniquely-named, timestamp-prefixed file under ~/tmp/ (each
+    call gets its own file, so consecutive screenshots don't overwrite one
+    another and sort chronologically) and returns the path. Always read the
+    returned "path" — never reconstruct it. Use the Read tool to view it.
     """
     return await _with_tool_timeout(
         _impl_browser_screenshot(), 30.0, "browser_screenshot"

--- a/tests/test_mcp/test_browser_tools.py
+++ b/tests/test_mcp/test_browser_tools.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import re
 import signal
+from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1344,3 +1347,121 @@ class TestTurnstileShortGrace:
             result = await browser._wait_for_turnstile(page, response=resp)
         assert result == {"status": "blocked", "method": "timeout"}
         alert.assert_awaited()         # ladder ran to exhaustion
+
+
+# Must stay in step with scripts/browser.py's copy of the scheme
+# (tests/test_scripts/test_browser_cli_screenshot_path.py asserts the same
+# shape on that side). Format: %Y%m%dT%H%M%S%fZ -> 20260902T190142123456Z
+_MCP_STAMP = re.compile(r"^\d{8}T\d{12}Z$")
+
+
+class TestBrowserScreenshotUniquePath:
+    """Consecutive screenshots must not overwrite one another.
+
+    The tool previously wrote every capture to the single fixed path
+    ~/tmp/genesis_browser_screenshot.png, so a session that captured N pages
+    was left with only the last one — silently, since each call still returned
+    a valid-looking path.
+    """
+
+    @staticmethod
+    def _page():
+        page = MagicMock()
+        page.url = "https://example.com"
+        page.title = AsyncMock(return_value="Example")
+
+        async def _write(path: str) -> None:
+            # Mimic Playwright: actually create the file at the given path, so
+            # the test measures files-on-disk rather than returned strings.
+            with open(path, "wb") as fh:
+                fh.write(b"\x89PNG")
+
+        page.screenshot = AsyncMock(side_effect=_write)
+        return page
+
+    @pytest.mark.asyncio
+    async def test_consecutive_screenshots_do_not_overwrite(self, tmp_path):
+        browser._active_page = self._page()
+        with patch.object(browser, "_SCREENSHOT_DIR", tmp_path):
+            first = await browser._impl_browser_screenshot()
+            second = await browser._impl_browser_screenshot()
+
+        assert "error" not in first, first
+        assert "error" not in second, second
+        assert first["path"] != second["path"], (
+            "both captures wrote to the same path — the second overwrote the first"
+        )
+        # The property that actually matters: two files survive on disk.
+        written = sorted(p.name for p in tmp_path.glob("*.png"))
+        assert len(written) == 2, written
+        assert all(n.startswith("genesis_browser_screenshot_") for n in written), written
+
+    @pytest.mark.asyncio
+    async def test_returned_path_is_the_path_actually_written(self, tmp_path):
+        """The returned path must be the one Playwright wrote to.
+
+        Callers (and the tool's own docstring) treat the returned "path" as
+        authoritative, so a divergence here would hand out a path pointing at
+        nothing while the real capture sat elsewhere.
+        """
+        page = self._page()
+        browser._active_page = page
+        with patch.object(browser, "_SCREENSHOT_DIR", tmp_path):
+            result = await browser._impl_browser_screenshot()
+
+        assert "error" not in result, result
+        page.screenshot.assert_awaited_once_with(path=result["path"])
+        assert Path(result["path"]).is_file()
+
+    @pytest.mark.asyncio
+    async def test_capture_names_sort_chronologically(self, tmp_path):
+        """Names must sort into CAPTURE ORDER — the motivating incident was a
+        run of 8 captures with no way to tell which page was which.
+
+        The clock is CONTROLLED here on purpose. Two real back-to-back captures
+        land in the same wall-clock instant, which would make a
+        `stamps == sorted(stamps)` assertion a tautology over equal values —
+        i.e. green whatever the format string does. Distinct injected times make
+        the ordering claim the thing actually under test.
+        """
+        browser._active_page = self._page()
+        # These two instants STRADDLE MIDNIGHT on purpose: the earlier capture
+        # has the LATER clock time. Any format that does not lead with the date
+        # (e.g. a %H%M%S-first ordering) sorts them backwards, while two
+        # same-day times would sort correctly under such a format and let the
+        # bug through. The inputs are what make the ordering claim testable.
+        times = [
+            datetime(2026, 9, 2, 23, 59, 58, 900000, tzinfo=UTC),
+            datetime(2026, 9, 3, 0, 0, 1, 100000, tzinfo=UTC),
+        ]
+        with patch.object(browser, "_SCREENSHOT_DIR", tmp_path), \
+             patch.object(browser, "datetime") as fake_dt:
+            fake_dt.now.side_effect = times
+            first = await browser._impl_browser_screenshot()
+            second = await browser._impl_browser_screenshot()
+
+        stamps = [Path(r["path"]).name.split("_")[-2] for r in (first, second)]
+        # STRICT: an equal pair must not satisfy this.
+        assert stamps[0] < stamps[1], stamps
+        # SHAPE, not just order — ordering alone stays green if the T/Z are
+        # dropped, which is exactly how the two writers would drift apart.
+        assert all(_MCP_STAMP.match(x) for x in stamps), stamps
+
+    @pytest.mark.asyncio
+    async def test_stamp_resolves_below_one_second(self, tmp_path):
+        """A second-resolution stamp ties a rapid burst. Two captures 1ms apart
+        must still produce distinguishable, correctly-ordered stamps."""
+        browser._active_page = self._page()
+        times = [
+            datetime(2026, 9, 2, 19, 1, 42, 1000, tzinfo=UTC),
+            datetime(2026, 9, 2, 19, 1, 42, 2000, tzinfo=UTC),
+        ]
+        with patch.object(browser, "_SCREENSHOT_DIR", tmp_path), \
+             patch.object(browser, "datetime") as fake_dt:
+            fake_dt.now.side_effect = times
+            first = await browser._impl_browser_screenshot()
+            second = await browser._impl_browser_screenshot()
+
+        stamps = [Path(r["path"]).name.split("_")[-2] for r in (first, second)]
+        assert stamps[0] != stamps[1], stamps
+        assert stamps[0] < stamps[1], stamps

--- a/tests/test_scripts/test_browser_cli_screenshot_path.py
+++ b/tests/test_scripts/test_browser_cli_screenshot_path.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import sys
+import types
 from pathlib import Path
-
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CLI_PATH = REPO_ROOT / "scripts" / "browser.py"
@@ -27,16 +27,56 @@ _STAMP = re.compile(r"^\d{8}T\d{12}Z$")
 
 
 def _load_cli():
-    spec = importlib.util.spec_from_file_location("_genesis_browser_cli", CLI_PATH)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    """Import the standalone CLI WITHOUT requiring playwright.
+
+    `scripts/browser.py` imports `playwright.sync_api` at module scope, and CI
+    does not install playwright. Guarding this class with a `skipif` therefore
+    meant the CLI half of the fix had ZERO coverage on the one machine that
+    gates merges — it was only ever verified on a developer box that happened
+    to have playwright, while CI reported a green run that had asserted
+    nothing. Nothing under test here touches playwright (`_default_screenshot_path`
+    is pure stdlib), so stub the import instead of skipping the test.
+
+    The stub raises if anything actually calls it, so a future test that DOES
+    need a real browser fails loudly rather than passing against a mock.
+    """
+
+    def _stub_sync_playwright(*_args, **_kwargs):
+        raise RuntimeError(
+            "playwright is stubbed in this test module — it exists only to "
+            "satisfy the CLI's module-level import"
+        )
+
+    pw = types.ModuleType("playwright")
+    sync_api = types.ModuleType("playwright.sync_api")
+    sync_api.sync_playwright = _stub_sync_playwright
+    pw.sync_api = sync_api
+
+    # Stub UNCONDITIONALLY, even where playwright is installed. A
+    # `find_spec`-guarded stub would take one path on a developer box and the
+    # other in CI — so the path that matters would be the one never exercised
+    # here, which is the same shape of hole this fix exists to close.
+    _MISSING = object()
+    saved = {
+        name: sys.modules.get(name, _MISSING) for name in ("playwright", "playwright.sync_api")
+    }
+    sys.modules["playwright"] = pw
+    sys.modules["playwright.sync_api"] = sync_api
+    try:
+        spec = importlib.util.spec_from_file_location("_genesis_browser_cli", CLI_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        # Restore exactly what was there, so a real playwright installed by
+        # another test module survives and the stub never leaks.
+        for name, prior in saved.items():
+            if prior is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = prior
 
 
-@pytest.mark.skipif(
-    not importlib.util.find_spec("playwright"),
-    reason="playwright not installed",
-)
 class TestCliDefaultScreenshotPath:
     def test_each_call_returns_a_distinct_path(self):
         cli = _load_cli()

--- a/tests/test_scripts/test_browser_cli_screenshot_path.py
+++ b/tests/test_scripts/test_browser_cli_screenshot_path.py
@@ -1,0 +1,61 @@
+"""Drift guard for the CLI half of the unique-screenshot-path fix.
+
+`scripts/browser.py` deliberately imports no `genesis` modules — it is a
+standalone one-off CLI — so it carries its own copy of the naming scheme used by
+the MCP tool's `_impl_browser_screenshot`. Prose comments link the two copies;
+this test is what actually catches them drifting apart.
+
+The defect being guarded: a module-level `DEFAULT_SCREENSHOT` constant bound one
+filename for the life of the process, so every capture without an explicit path
+silently overwrote the previous one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CLI_PATH = REPO_ROOT / "scripts" / "browser.py"
+
+# Must stay in step with genesis/mcp/health/browser.py's stamp format:
+#   %Y%m%dT%H%M%S%fZ  ->  20260902T190142123456Z
+_STAMP = re.compile(r"^\d{8}T\d{12}Z$")
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_file_location("_genesis_browser_cli", CLI_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.skipif(
+    not importlib.util.find_spec("playwright"),
+    reason="playwright not installed",
+)
+class TestCliDefaultScreenshotPath:
+    def test_each_call_returns_a_distinct_path(self):
+        cli = _load_cli()
+        paths = [cli._default_screenshot_path() for _ in range(5)]
+        assert len(set(paths)) == 5, paths
+
+    def test_stamp_shape_matches_the_mcp_tool(self):
+        """Microsecond resolution + trailing Z — a second-resolution stamp ties
+        a rapid burst, which is the ordering half of the original bug."""
+        cli = _load_cli()
+        name = Path(cli._default_screenshot_path()).name
+        stamp = name.split("_")[-2]
+        assert _STAMP.match(stamp), name
+
+    def test_no_fixed_default_constant_remains(self):
+        """The module-level constant IS the bug — a name bound once per process
+        cannot be unique per call."""
+        cli = _load_cli()
+        assert not hasattr(cli, "DEFAULT_SCREENSHOT"), (
+            "a module-level default screenshot path reintroduces the "
+            "overwrite bug — it binds one name for the whole process"
+        )


### PR DESCRIPTION
## Problem

`browser_screenshot` wrote **every** capture to one fixed path,
`~/tmp/genesis_browser_screenshot.png`. A session that captured 8 pages kept only
the last one — silently, because each call still returned a valid-looking path.

`scripts/browser.py` had the identical defect through a module-level
`DEFAULT_SCREENSHOT` constant, which binds one filename for the life of the
process. Both writers are fixed here, so the **class** is closed rather than the
reported instance. Enumerated via `grep -rn "\.screenshot(" src/ scripts/` → 3
sites; the third takes a caller-supplied path with no default and is correctly
excluded.

## Fix

Filenames become `genesis_browser_screenshot_<stamp>_<uuid4hex>.png` with
`stamp = %Y%m%dT%H%M%S%fZ`.

- **Microsecond resolution**, not seconds — measured: 8 consecutive captures
  produced exactly **1** distinct second-resolution stamp, which would leave the
  motivating sequence unordered.
- **Untruncated uuid** — 32 bits would reintroduce silent overwrite by collision
  across the 7-day `~/tmp` window.
- **No new unbounded store**: `scripts/disk_hygiene.sh:59-66` already prunes
  direct children of `~/tmp` at `-mtime +7`; timer verified enabled + active.

The CLI keeps its own copy of the scheme so it stays free of `genesis` imports;
the stamp **shape is asserted on both sides** so the copies cannot drift apart
silently.

## Tests

First tests for a tool that had none, plus a CLI drift guard. **All 7 are
mutation-verified** — each dies under a mutation of the one property it names,
most of them length-preserving:

| mutation | result |
|---|---|
| ordering scrambled (same length) | RED |
| stamp shape drift (T and Z dropped) | RED |
| second-resolution only | RED |
| returned path diverges from written | RED |
| filename fixed again (the original bug) | RED |
| CLI stamp drifts from MCP | RED |
| CLI fixed constant returns | RED |

Zero survivors.

## End-to-end verification

Real Playwright, real captures, real files — the running MCP server still holds
pre-change code, so the runtime path was driven directly:

- **MCP path**: 8 sequential captures → 8 distinct paths, 8 non-empty files,
  stamps strictly increasing, **name-sort order == capture order**.
- **CLI path**: `cmd_screenshot()` ×3 with an isolated profile → 3 distinct
  names, 3 non-empty files.

106 tests pass; `ruff check src/ scripts/ tests/` clean.

## Review

3 adversarial `genesis-architect` rounds, sequential. Rounds 1–2 were
defect-bearing and both are documented in the evidence, including that round 1's
own replacement test was vacuous in the dimension it named — the round-1 mutation
changed filename *length*, so a co-located length assert masked a dead sort
assert. Round 3 was clean (5 NOTEs; 3 fixed, 2 doc-accepted as optional
hardening).

Also recorded rather than hidden: the mutation harness itself first keyed its
baseline copies on the file *basename* — and both files are named `browser.py`,
so the "restore" wrote CLI content into the MCP module. The same silent-overwrite
class this PR fixes, reproduced in the tooling built to verify it. Recovered from
the git index; the harness now keys on the full path with a collision assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser screenshots now use unique timestamped filenames by default.
  * Multiple screenshots are preserved instead of overwriting a fixed file.
  * Screenshot tools report the generated file path and document the updated naming behavior.

* **Bug Fixes**
  * Improved timestamp precision and ordering, including captures made across midnight.

* **Tests**
  * Added coverage verifying unique filenames, accurate returned paths, and retained screenshots.
  * Added reliable command-line screenshot path testing even when browser automation dependencies are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->