### PR TITLE
fix(charter): refuse ledger writes a dispatched session can never read back

### DIFF
--- a/src/genesis/mcp/health/session_charter_tools.py
+++ b/src/genesis/mcp/health/session_charter_tools.py
@@ -59,6 +59,74 @@ def _default_added_by() -> str:
     return "ambient" if os.environ.get("GENESIS_CC_SESSION") == "1" else "foreground"
 
 
+def _self_write_unreadable_error(sid: str) -> dict | None:
+    """Refuse a charter/ledger write a DISPATCHED session makes to ITS OWN charter.
+
+    The charter system is foreground-only: the reader
+    (``scripts/genesis_session_context.py`` — the emission block sits in the
+    ``not is_genesis_session`` branch) and the maintainer
+    (``scripts/genesis_precompact.py``, which returns early on the same
+    discriminator so ``origin_prompt`` is never filled) both skip dispatched
+    sessions. A dispatched session writing to its OWN charter therefore
+    produces a row that is inert BY CONSTRUCTION — stored, never re-injected.
+
+    Measured 2026-09-02: a Telegram DM session (``claude -p`` via CCInvoker)
+    wrote a ledger row and told the user it would "survive to Friday". It could
+    not — the emission block returned 0 chars for that session on startup,
+    resume AND compact.
+
+    Deliberately NARROW. A dispatched session writing to a FOREGROUND session's
+    charter is legitimate and readable — that is what ``added_by='ambient'``
+    exists for — so only the self-write is refused.
+
+    Residual known gap: a dispatched session writing to a DIFFERENT dispatched
+    session's charter is equally inert and is NOT caught here. The obvious
+    alternative — classify the TARGET via ``cc_sessions`` — would be WRONG, not
+    merely expensive: the incident session's own row records
+    ``session_type='foreground', source_tag='foreground', channel='telegram'``,
+    so a DB-based gate would have waved the actual defect through, and another
+    ambient charter has no ``cc_sessions`` row at all. There is no DB signal for
+    "will this session's charter ever be read"; the writer's own env is the only
+    sound one.
+
+    Fails OPEN when the session id is unavailable OR STALE. The MCP child's env
+    is a SNAPSHOT taken when CC spawned it: CC sets ``CLAUDE_CODE_SESSION_ID``
+    at stdio-MCP spawn and, on a conversation reset, updates only its OWN
+    ``process.env`` — the child keeps the pre-reset id (MEASURED 2026-09-02: the
+    health MCP held ``837dfb4b…`` while the live session was ``d3d02163…``).
+    Unreachable for this gate, because staleness needs a reset and a
+    ``GENESIS_CC_SESSION=1`` session is a single-shot ``claude -p`` that never
+    resets — but a future dispatched shape that DID reset would silently disarm
+    this. A truthfulness gate, not a security boundary.
+
+    Two things this deliberately does NOT do. ``_impl_session_ledger_update`` is
+    ungated: it can only edit an existing row, never mint a new promise. And a
+    refused session could route around this by passing a fabricated 32-char id
+    (``upsert_stub`` is a bare INSERT OR IGNORE), producing an orphan charter —
+    pre-existing and equally reachable from a foreground session, but newly
+    incentivised by this refusal, so it is named here rather than discovered.
+    """
+    if os.environ.get("GENESIS_CC_SESSION") != "1":
+        return None
+    own = (os.environ.get("CLAUDE_CODE_SESSION_ID") or "").strip()
+    if not own or own != sid:
+        return None
+    return {
+        "error": "Refusing the write: this is a dispatched/channel session "
+        "writing to its OWN charter, and the charter/ledger is foreground-only. "
+        "The row would be stored but NEVER re-injected into any future window, "
+        "so recording it here would promise a persistence that does not exist. "
+        "Durable alternatives, IF this session's profile allows them: "
+        "`memory_store` for a fact/decision/plan — denied on every "
+        "direct-session profile (cc/direct_session.py _UNIVERSAL_DISALLOW), "
+        "reachable from a conversation channel; or `follow_up_create` for "
+        "actionable work — a dispatched session's item is routed to the COLD "
+        "`tabled` lane, tracked but never auto-dispatched. If both are denied, "
+        "put it in your final output: that transcript IS this session's "
+        "deliverable."
+    }
+
+
 def _unresolved_short_id_error(sid: str) -> dict | None:
     """Refuse WRITES under a truncated id that did not resolve.
 
@@ -99,6 +167,13 @@ async def _impl_session_charter(session_id: str) -> dict:
                 "error": f"No charter for session '{session_id}'. A charter row "
                 "appears at the session's first compaction, or on the first "
                 "session_charter_update / session_ledger_add call."
+                + (
+                    " NOTE: for a dispatched/channel session neither route"
+                    " fires — compaction skips it and both writes are refused"
+                    " — so no charter will ever appear. task_states is the"
+                    " continuity spine for that session class."
+                    if os.environ.get("GENESIS_CC_SESSION") == "1" else ""
+                )
             }
         ledger = await crud.ledger_list(db, sid)
         counts = await crud.ledger_counts(db, sid)
@@ -147,6 +222,8 @@ async def _impl_session_charter_update(
 
         sid = await crud.resolve_session_id(db, session_id)
         if err := _unresolved_short_id_error(sid):
+            return err
+        if err := _self_write_unreadable_error(sid):
             return err
         # A stub row lets mission/pointers precede the first compaction; the
         # PreCompact hook fills origin later (WHERE origin_prompt IS NULL).
@@ -197,6 +274,8 @@ async def _impl_session_ledger_add(
         sid = await crud.resolve_session_id(db, session_id)
         if err := _unresolved_short_id_error(sid):
             return err
+        if err := _self_write_unreadable_error(sid):
+            return err
         await crud.upsert_stub(db, sid)
         item_id = await crud.ledger_add(
             db,
@@ -208,13 +287,43 @@ async def _impl_session_ledger_add(
         await _refresh_mirror(db, sid)
         counts = await crud.ledger_counts(db, sid)
         open_n = counts.get("open", 0) + counts.get("in_progress", 0)
+        # The message must mirror the GATE's predicate exactly. The gate needs
+        # BOTH dispatched AND own-id-known-and-equal; a message keyed on only
+        # the first is FALSE on the fail-open path, where a dispatched
+        # SELF-write gets through and would be told the row lands on "THAT
+        # session" — which is this one. Three states, not two.
+        _own = (os.environ.get("CLAUDE_CODE_SESSION_ID") or "").strip()
+        _dispatched = os.environ.get("GENESIS_CC_SESSION") == "1"
+        if _dispatched and _own:
+            # Own id known and != sid (equal was refused by the gate above), so
+            # this is the supported cross-session write. Name the beneficiary:
+            # the row re-injects into the TARGET's windows, never this session's.
+            message = (
+                f"Ledger item recorded on session {sid[:8]}'s charter — it will "
+                "re-inject into THAT session's post-compaction windows, NOT "
+                "this one (dispatched sessions get no charter injection). "
+                "Close via session_ledger_update."
+            )
+        elif _dispatched:
+            # Fail-open: own id unknown, so sid may be THIS session. Claim
+            # nothing about persistence rather than claim it confidently wrong.
+            message = (
+                f"Ledger item recorded on session {sid[:8]}'s charter. This "
+                "session's own id is unknown, so whether that charter is ever "
+                "re-injected could NOT be verified — do not tell the user it "
+                "persists. Close via session_ledger_update."
+            )
+        else:
+            message = (
+                "Ledger item recorded — it will re-inject into every "
+                "post-compaction window until closed via session_ledger_update."
+            )
         return {
             "id": item_id,
             "session_id": sid,
             "status": "open",
             "open_items": open_n,
-            "message": "Ledger item recorded — it will re-inject into every "
-            "post-compaction window until closed via session_ledger_update.",
+            "message": message,
         }
     except ValueError as exc:
         return {"error": str(exc)}
@@ -274,6 +383,8 @@ async def session_charter(session_id: str) -> dict:
     what the session is FOR. Use it to reconnect with the origin after heavy
     compaction, or to fetch ledger item ids before session_ledger_update.
 
+    FOREGROUND SESSIONS ONLY: a dispatched/channel session's own charter is never re-injected (the SessionStart reader, the PreCompact maintainer and the per-turn drift tag all skip GENESIS_CC_SESSION=1), so a self-write is refused; writing to a FOREGROUND session's charter is supported.
+
     Args:
         session_id: CC session id (shown in the per-turn [Clock | Session: x]
             tag). A truncated prefix resolves when unambiguous.
@@ -294,6 +405,8 @@ async def session_charter_update(
     an approved plan) so post-compaction windows inherit it. Pointers are
     paths/refs to the session's governing artifacts (spec docs, plan files).
     The immutable origin cannot be changed by this tool.
+
+    FOREGROUND SESSIONS ONLY: a dispatched/channel session's own charter is never re-injected (the SessionStart reader, the PreCompact maintainer and the per-turn drift tag all skip GENESIS_CC_SESSION=1), so a self-write is refused; writing to a FOREGROUND session's charter is supported.
 
     Args:
         session_id: CC session id (per-turn [Clock | Session: x] tag; unique
@@ -323,6 +436,8 @@ async def session_ledger_add(
     plan item, or work is promised — the row re-injects into every
     post-compaction window until closed, so no summary can erase it. This is
     the first line of defense; ambient extraction is only the safety net.
+
+    FOREGROUND SESSIONS ONLY: a dispatched/channel session's own charter is never re-injected (the SessionStart reader, the PreCompact maintainer and the per-turn drift tag all skip GENESIS_CC_SESSION=1), so a self-write is refused; writing to a FOREGROUND session's charter is supported.
 
     Args:
         session_id: CC session id (per-turn [Clock | Session: x] tag; unique

--- a/src/genesis/mcp/health/session_charter_tools.py
+++ b/src/genesis/mcp/health/session_charter_tools.py
@@ -108,6 +108,47 @@ def _own_session_ids() -> set[str]:
     return ids
 
 
+# The advertised SHORT form of a session id: the per-turn `[Clock | Session: x]`
+# tag prints the first 8 characters, and `_unresolved_short_id_error` names that
+# tag when it asks for the full id — so 8 is the shortest prefix a caller is ever
+# told exists. Below it, a "prefix" is a guess.
+_ADVERTISED_PREFIX_CHARS = 8
+
+
+def _resolves_to_own(sid: str) -> bool:
+    """Is *sid* this session's own id — including the advertised short prefix?
+
+    ONE predicate, shared by the write gate and the read path's guidance,
+    because a disagreement between them is not a cosmetic inconsistency. With an
+    exact comparison, a caller passing the 8-char prefix it was SHOWN slipped
+    past this classification: the read path then said "update/add can create the
+    charter" while the write tools rejected that same prefix as unresolved. Two
+    calls, two incompatible answers, both from Genesis.
+
+    Resolved against OUR OWN ids rather than through
+    ``crud.resolve_session_id``, which cannot answer this question: it searches
+    ``session_charters.session_id`` and ``cc_sessions.cc_session_id``, while a
+    channel session is advertised its ``cc_sessions.id`` — a different namespace
+    — and may have no charter row yet. The prefix therefore comes back
+    unchanged, which is exactly how it reached the failing comparison. Matching
+    against the at-most-two ids we hold needs no query and cannot be made
+    ambiguous by another session's rows.
+
+    Uniqueness is required, not assumed: if a prefix matched BOTH own ids they
+    would have to differ later on, so the caller has still named us — but a
+    prefix that matches neither is not ours, and one shorter than the advertised
+    form is not a prefix we ever handed out.
+    """
+    own = _own_session_ids()
+    if not own:
+        return False
+    if sid in own:
+        return True
+    if len(sid) < _ADVERTISED_PREFIX_CHARS:
+        return False
+    return any(o.startswith(sid) for o in own)
+
+
 def _self_write_unreadable_error(sid: str) -> dict | None:
     """Refuse a charter/ledger write a DISPATCHED session makes to ITS OWN charter.
 
@@ -166,7 +207,7 @@ def _self_write_unreadable_error(sid: str) -> dict | None:
     """
     if not _is_dispatched():
         return None
-    if sid not in _own_session_ids():
+    if not _resolves_to_own(sid):
         return None
     return {
         "error": "Refusing the write: this is a dispatched/channel session "
@@ -203,10 +244,11 @@ def _missing_charter_suffix(sid: str) -> str:
     if not _is_dispatched():
         return ""
     own = _own_session_ids()
-    if sid in own:
-        # The caller's own charter. Both write routes are refused and the
-        # PreCompact maintainer returns early on GENESIS_CC_SESSION=1, so
-        # nothing can ever create it.
+    if _resolves_to_own(sid):
+        # The caller's own charter — by the SAME predicate the write gate uses,
+        # short prefix included, so the two calls cannot contradict each other.
+        # Both write routes are refused and the PreCompact maintainer returns
+        # early on GENESIS_CC_SESSION=1, so nothing can ever create it.
         return (
             " NOTE: that is THIS dispatched/channel session's own id — neither"
             " route fires for it (compaction skips this session class and both"
@@ -319,9 +361,14 @@ async def _impl_session_charter_update(
         from genesis.db.crud import session_charters as crud
 
         sid = await crud.resolve_session_id(db, session_id)
-        if err := _unresolved_short_id_error(sid):
-            return err
+        # SELF first, then the id FORM. Both refuse, so the order only decides
+        # which reason the caller is given — and "pass the full id" implies the
+        # write would then land, which for this session's own charter it never
+        # will. Answering the id form first costs the caller a round trip to
+        # fetch an id that is about to be refused anyway.
         if err := _self_write_unreadable_error(sid):
+            return err
+        if err := _unresolved_short_id_error(sid):
             return err
         # A stub row lets mission/pointers precede the first compaction; the
         # PreCompact hook fills origin later (WHERE origin_prompt IS NULL).
@@ -370,9 +417,14 @@ async def _impl_session_ledger_add(
         from genesis.db.crud import session_charters as crud
 
         sid = await crud.resolve_session_id(db, session_id)
-        if err := _unresolved_short_id_error(sid):
-            return err
+        # SELF first, then the id FORM. Both refuse, so the order only decides
+        # which reason the caller is given — and "pass the full id" implies the
+        # write would then land, which for this session's own charter it never
+        # will. Answering the id form first costs the caller a round trip to
+        # fetch an id that is about to be refused anyway.
         if err := _self_write_unreadable_error(sid):
+            return err
+        if err := _unresolved_short_id_error(sid):
             return err
         await crud.upsert_stub(db, sid)
         item_id = await crud.ledger_add(

--- a/src/genesis/mcp/health/session_charter_tools.py
+++ b/src/genesis/mcp/health/session_charter_tools.py
@@ -25,6 +25,13 @@ logger = logging.getLogger(__name__)
 
 _SESSIONS_DIR = Path.home() / ".genesis" / "sessions"
 
+# Ledger statuses that CLOSE a row. Everything else in the crud allow-list
+# leaves it a live commitment — see _impl_session_ledger_update, which derives
+# the promise-creating set as the complement of this one so a status added to
+# db/crud/session_charters.VALID_LEDGER_STATUSES is gated by default. A test
+# pins this against that allow-list.
+_TERMINAL_LEDGER_STATUSES = frozenset({"done", "absorbed", "dropped"})
+
 
 def _get_db():
     """Late-import DB from the health MCP module state."""
@@ -59,6 +66,48 @@ def _default_added_by() -> str:
     return "ambient" if os.environ.get("GENESIS_CC_SESSION") == "1" else "foreground"
 
 
+def _is_dispatched() -> bool:
+    """True in a Genesis-dispatched session (cc/invoker.py stamps this on every
+    ``claude -p`` it spawns — channel conversations included)."""
+    return os.environ.get("GENESIS_CC_SESSION") == "1"
+
+
+def _own_session_ids() -> set[str]:
+    """Every id a dispatched session may be asked to call "itself".
+
+    TWO ids, in two different namespaces, and the caller usually knows only the
+    second:
+
+    - ``CLAUDE_CODE_SESSION_ID`` — the CC transcript id. This is the charter key
+      namespace (``session_charters.session_id`` matches
+      ``cc_sessions.cc_session_id``, see db/crud/session_charters.py module
+      docstring). Set by CC on every stdio-MCP spawn.
+    - ``GENESIS_SESSION_ID`` — the Genesis ``cc_sessions.id`` row id, stamped by
+      cc/invoker.py:403 from the dispatch-time session context and inherited by
+      this MCP child (the same read direct_session_tools.py:109 relies on).
+
+    The gap this closes (Codex P1 on PR #1617): a channel session is TOLD its
+    "Session ID" is the Genesis row id — ``ConversationManager`` passes
+    ``session["id"]`` to the prompt assembler (cc/conversation.py:259,280 →
+    cc/system_prompt.py:97) — and it never sees the CC transcript id at all,
+    because the per-turn ``[Clock | Session: x]`` tag is suppressed for
+    dispatched sessions (scripts/genesis_urgent_alerts.py:433-435). So the id
+    the model actually passes is the Genesis row id, and comparing only against
+    ``CLAUDE_CODE_SESSION_ID`` let the real production shape straight through.
+    MEASURED on this install's ``cc_sessions``: for the 10 channel rows
+    ``id != cc_session_id`` in 10/10, and for the 183 background rows
+    ``id == cc_session_id`` in 0/183 — the two namespaces never collide, so
+    treating the Genesis row id as "self" cannot mis-flag a legitimate
+    cross-session write.
+    """
+    ids: set[str] = set()
+    for var in ("CLAUDE_CODE_SESSION_ID", "GENESIS_SESSION_ID"):
+        value = (os.environ.get(var) or "").strip()
+        if value:
+            ids.add(value)
+    return ids
+
+
 def _self_write_unreadable_error(sid: str) -> dict | None:
     """Refuse a charter/ledger write a DISPATCHED session makes to ITS OWN charter.
 
@@ -89,7 +138,8 @@ def _self_write_unreadable_error(sid: str) -> dict | None:
     "will this session's charter ever be read"; the writer's own env is the only
     sound one.
 
-    Fails OPEN when the session id is unavailable OR STALE. The MCP child's env
+    Fails OPEN when NEITHER own-id is available (see ``_own_session_ids``), or
+    when one is STALE. The MCP child's env
     is a SNAPSHOT taken when CC spawned it: CC sets ``CLAUDE_CODE_SESSION_ID``
     at stdio-MCP spawn and, on a conversation reset, updates only its OWN
     ``process.env`` — the child keeps the pre-reset id (MEASURED 2026-09-02: the
@@ -99,17 +149,24 @@ def _self_write_unreadable_error(sid: str) -> dict | None:
     resets — but a future dispatched shape that DID reset would silently disarm
     this. A truthfulness gate, not a security boundary.
 
-    Two things this deliberately does NOT do. ``_impl_session_ledger_update`` is
-    ungated: it can only edit an existing row, never mint a new promise. And a
-    refused session could route around this by passing a fabricated 32-char id
-    (``upsert_stub`` is a bare INSERT OR IGNORE), producing an orphan charter —
-    pre-existing and equally reachable from a foreground session, but newly
-    incentivised by this refusal, so it is named here rather than discovered.
+    ``_impl_session_ledger_update`` applies this same predicate, but only to the
+    PROMISE-CREATING mutations (a ``text`` replacement, or a status back to
+    open/in_progress): those rewrite an existing row into a new live-looking
+    commitment just as effectively as an insert (db/crud/session_charters.py
+    ledger_update takes arbitrary text and any VALID_LEDGER_STATUS, Codex P2 on
+    PR #1617). Closing a legacy inert row — done/absorbed/dropped, or an
+    evidence write — stays allowed, so this never traps a session with rows it
+    cannot clean up.
+
+    One thing this deliberately does NOT do: a refused session could route
+    around it by passing a fabricated 32-char id (``upsert_stub`` is a bare
+    INSERT OR IGNORE), producing an orphan charter — pre-existing and equally
+    reachable from a foreground session, but newly incentivised by this refusal,
+    so it is named here rather than discovered.
     """
-    if os.environ.get("GENESIS_CC_SESSION") != "1":
+    if not _is_dispatched():
         return None
-    own = (os.environ.get("CLAUDE_CODE_SESSION_ID") or "").strip()
-    if not own or own != sid:
+    if sid not in _own_session_ids():
         return None
     return {
         "error": "Refusing the write: this is a dispatched/channel session "
@@ -125,6 +182,53 @@ def _self_write_unreadable_error(sid: str) -> dict | None:
         "put it in your final output: that transcript IS this session's "
         "deliverable."
     }
+
+
+def _missing_charter_suffix(sid: str) -> str:
+    """Extra guidance appended to the read path's "no charter" error.
+
+    Keyed on the SAME predicate as the write gate, not on "am I dispatched"
+    (Codex P2 on PR #1617). A dispatched session routinely reads a FOREGROUND
+    session's charter — the ambient/cross-session path this gate deliberately
+    leaves open — and that charter is NOT permanently absent: the target's own
+    next compaction creates it (scripts/genesis_precompact.py), as does any
+    foreground write. Telling an ambient caller to abandon a valid target is a
+    false claim of absence, so the "will never appear" wording is confined to
+    the caller's OWN charter.
+
+    Three states, mirroring the write gate: own charter (permanently absent),
+    own id unknown (uncertain — say so), everything else (no suffix; the base
+    message is already correct).
+    """
+    if not _is_dispatched():
+        return ""
+    own = _own_session_ids()
+    if sid in own:
+        # The caller's own charter. Both write routes are refused and the
+        # PreCompact maintainer returns early on GENESIS_CC_SESSION=1, so
+        # nothing can ever create it.
+        return (
+            " NOTE: that is THIS dispatched/channel session's own id — neither"
+            " route fires for it (compaction skips this session class and both"
+            " writes are refused), so no charter will ever appear here."
+            " Continuity for a dispatched session depends on which kind it is:"
+            " an autonomous task session has its task_states row (created by"
+            " the task dispatcher / task_submit, autonomy/dispatcher.py:188 and"
+            " mcp/health/task_tools.py:200); a CHANNEL conversation has NO"
+            " task_states row at all — its continuity is the conversation"
+            " itself plus, profile permitting, memory_store / follow_up_create,"
+            " and otherwise this session's final output."
+        )
+    if not own:
+        # Fail-open: with no id of our own, we cannot tell whether sid is us.
+        return (
+            " NOTE: this is a dispatched/channel session and its own id is"
+            " unknown here, so whether that charter can ever appear could NOT"
+            " be determined — if it is this session's own id, it never will"
+            " (compaction skips this session class and both writes are"
+            " refused)."
+        )
+    return ""
 
 
 def _unresolved_short_id_error(sid: str) -> dict | None:
@@ -167,13 +271,7 @@ async def _impl_session_charter(session_id: str) -> dict:
                 "error": f"No charter for session '{session_id}'. A charter row "
                 "appears at the session's first compaction, or on the first "
                 "session_charter_update / session_ledger_add call."
-                + (
-                    " NOTE: for a dispatched/channel session neither route"
-                    " fires — compaction skips it and both writes are refused"
-                    " — so no charter will ever appear. task_states is the"
-                    " continuity spine for that session class."
-                    if os.environ.get("GENESIS_CC_SESSION") == "1" else ""
-                )
+                + _missing_charter_suffix(sid)
             }
         ledger = await crud.ledger_list(db, sid)
         counts = await crud.ledger_counts(db, sid)
@@ -292,9 +390,15 @@ async def _impl_session_ledger_add(
         # the first is FALSE on the fail-open path, where a dispatched
         # SELF-write gets through and would be told the row lands on "THAT
         # session" — which is this one. Three states, not two.
-        _own = (os.environ.get("CLAUDE_CODE_SESSION_ID") or "").strip()
-        _dispatched = os.environ.get("GENESIS_CC_SESSION") == "1"
-        if _dispatched and _own:
+        #
+        # The confident branch is keyed on the TRANSCRIPT id specifically, not
+        # on _own_session_ids() being non-empty: sid lives in the transcript-id
+        # namespace (it is a session_charters key), so knowing only the Genesis
+        # row id still leaves "sid might be my own transcript id" open, and the
+        # beneficiary claim would be unsound.
+        _own_transcript = (os.environ.get("CLAUDE_CODE_SESSION_ID") or "").strip()
+        _dispatched = _is_dispatched()
+        if _dispatched and _own_transcript:
             # Own id known and != sid (equal was refused by the gate above), so
             # this is the supported cross-session write. Name the beneficiary:
             # the row re-injects into the TARGET's windows, never this session's.
@@ -339,7 +443,16 @@ async def _impl_session_ledger_update(
     text: str | None = None,
     evidence: str | None = None,
 ) -> dict:
-    """Update a ledger item: close it (done), mark absorbed/dropped, or edit."""
+    """Update a ledger item: close it (done), mark absorbed/dropped, or edit.
+
+    A dispatched session's PROMISE-CREATING edits to its OWN charter are refused
+    on the same predicate as the insert path. ``crud.ledger_update`` accepts an
+    arbitrary replacement ``text`` and any VALID_LEDGER_STATUS including a
+    reopen, so on an install that already carries a legacy inert row — exactly
+    the population this gate protects — rewrite-plus-reopen mints a live-looking
+    promise just as effectively as an insert would. Closure (done / absorbed /
+    dropped) and evidence writes stay open so legacy rows remain cleanable.
+    """
     db = _get_db()
     if db is None:
         return {"error": "Database not available"}
@@ -350,6 +463,29 @@ async def _impl_session_ledger_update(
     try:
         from genesis.db.crud import session_charters as crud
 
+        # Read BEFORE writing: the gate needs the row's owning session, and the
+        # refusal must land before any mutation (same ordering the insert path
+        # uses relative to upsert_stub).
+        existing = await crud.get_ledger_item(db, item_id)
+        if existing is None:
+            return {"error": f"No ledger item with id '{item_id}'"}
+        # Promise-creating = a text replacement, or a status that leaves the row
+        # LIVE. Derived as the complement of the terminal set against the crud
+        # allow-list rather than a positive literal, so a status added upstream
+        # is gated by default instead of silently slipping past — and so an
+        # INVALID status still falls through to crud.ledger_update's ValueError
+        # rather than being answered with a confusing refusal.
+        live_statuses = crud.VALID_LEDGER_STATUSES - _TERMINAL_LEDGER_STATUSES
+        creates_a_promise = text is not None or status in live_statuses
+        if creates_a_promise and (err := _self_write_unreadable_error(existing["session_id"])):
+            err["error"] = (
+                "Refusing this edit: rewriting the text of, or reopening, a "
+                "row on this dispatched session's OWN charter creates a new "
+                "live-looking promise on a charter nothing re-injects. "
+                "Closing it (status=done/absorbed/dropped) or attaching "
+                "evidence is still allowed. " + err["error"]
+            )
+            return err
         ok = await crud.ledger_update(db, item_id, status=status, text=text, evidence=evidence)
         if not ok:
             return {"error": f"No ledger item with id '{item_id}'"}
@@ -467,6 +603,8 @@ async def session_ledger_update(
     Statuses: open | in_progress | done | absorbed (shipped elsewhere — cite
     evidence, e.g. the PR) | dropped (consciously abandoned). Get item ids
     from session_charter or the SessionStart injection block.
+
+    FOREGROUND SESSIONS ONLY: a dispatched/channel session's own charter is never re-injected (the SessionStart reader, the PreCompact maintainer and the per-turn drift tag all skip GENESIS_CC_SESSION=1), so a self-write is refused; writing to a FOREGROUND session's charter is supported. On a row of its own charter a dispatched session may still close it (done/absorbed/dropped) or attach evidence — only a text replacement or a reopen is refused.
 
     Args:
         item_id: the ledger row id.

--- a/src/genesis/mcp/health/session_charter_tools.py
+++ b/src/genesis/mcp/health/session_charter_tools.py
@@ -149,7 +149,31 @@ def _resolves_to_own(sid: str) -> bool:
     return any(o.startswith(sid) for o in own)
 
 
-def _self_write_unreadable_error(sid: str) -> dict | None:
+def _names_own_session(sid: str, raw_id: str | None = None) -> bool:
+    """Does the caller's request name THIS session — BEFORE or AFTER resolution?
+
+    ``crud.resolve_session_id`` (db/crud/session_charters.py:126-155) rewrites a
+    short id to whichever single ``session_charters.session_id`` or
+    ``cc_sessions.cc_session_id`` row it happens to LIKE-match. Our own
+    ``GENESIS_SESSION_ID`` is a ``cc_sessions.id``, which is in NEITHER of those
+    columns, so a prefix of our own id that collides with one unrelated row
+    comes back as somebody ELSE's full transcript id. An identity check that
+    sees only the resolved value then reads the caller's own id as a
+    cross-session target and lets the write through (Codex P2, PR #1617).
+
+    So classify the RAW input too, and let self-ness WIN when the two answers
+    disagree — they can only disagree when resolution silently changed who the
+    caller named, and in that state the honest answer is "this may be you",
+    which on a truthfulness gate means refuse rather than promise. Rare (an
+    8-hex-char collision against ~200 rows), but the cost of checking is a
+    string comparison against at most two ids and no query at all.
+    """
+    if _resolves_to_own(sid):
+        return True
+    return raw_id is not None and _resolves_to_own(raw_id.strip())
+
+
+def _self_write_unreadable_error(sid: str, raw_id: str | None = None) -> dict | None:
     """Refuse a charter/ledger write a DISPATCHED session makes to ITS OWN charter.
 
     The charter system is foreground-only: the reader
@@ -191,13 +215,15 @@ def _self_write_unreadable_error(sid: str) -> dict | None:
     this. A truthfulness gate, not a security boundary.
 
     ``_impl_session_ledger_update`` applies this same predicate, but only to the
-    PROMISE-CREATING mutations (a ``text`` replacement, or a status back to
-    open/in_progress): those rewrite an existing row into a new live-looking
-    commitment just as effectively as an insert (db/crud/session_charters.py
-    ledger_update takes arbitrary text and any VALID_LEDGER_STATUS, Codex P2 on
-    PR #1617). Closing a legacy inert row — done/absorbed/dropped, or an
-    evidence write — stays allowed, so this never traps a session with rows it
-    cannot clean up.
+    PROMISE-CREATING mutations — those that leave the row LIVE and either
+    replace its ``text`` or move its status back to open/in_progress. Those
+    rewrite an existing row into a new live-looking commitment just as
+    effectively as an insert (db/crud/session_charters.py ledger_update takes
+    arbitrary text and any VALID_LEDGER_STATUS, Codex P2 on PR #1617). Anything
+    that leaves the row TERMINAL — closing it done/absorbed/dropped, correcting
+    the text of an already-closed row, or refining text and closing in one call
+    — stays allowed, so this never traps a session with rows it cannot clean up
+    or correct.
 
     One thing this deliberately does NOT do: a refused session could route
     around it by passing a fabricated 32-char id (``upsert_stub`` is a bare
@@ -207,7 +233,7 @@ def _self_write_unreadable_error(sid: str) -> dict | None:
     """
     if not _is_dispatched():
         return None
-    if not _resolves_to_own(sid):
+    if not _names_own_session(sid, raw_id):
         return None
     return {
         "error": "Refusing the write: this is a dispatched/channel session "
@@ -225,7 +251,7 @@ def _self_write_unreadable_error(sid: str) -> dict | None:
     }
 
 
-def _missing_charter_suffix(sid: str) -> str:
+def _missing_charter_suffix(sid: str, raw_id: str | None = None) -> str:
     """Extra guidance appended to the read path's "no charter" error.
 
     Keyed on the SAME predicate as the write gate, not on "am I dispatched"
@@ -237,22 +263,35 @@ def _missing_charter_suffix(sid: str) -> str:
     false claim of absence, so the "will never appear" wording is confined to
     the caller's OWN charter.
 
-    Three states, mirroring the write gate: own charter (permanently absent),
-    own id unknown (uncertain — say so), everything else (no suffix; the base
-    message is already correct).
+    Three states, mirroring the write gate: own charter (nothing will ever
+    re-inject it HERE), own id unknown (uncertain — say so), everything else
+    (no suffix; the base message is already correct).
+
+    What the own-charter branch may NOT say is that the charter can never
+    APPEAR (Codex P2, PR #1617). The claim is caller-relative, and this PR's
+    own premise is that a cross-session write is legitimate and supported —
+    so any foreground session, and any OTHER dispatched session (the residual
+    gap named in ``_self_write_unreadable_error``), can create this very row
+    through ``session_charter_update`` / ``session_ledger_add``. The claim that
+    IS sound, and the one the caller actually needs, is about re-injection into
+    THIS session: the SessionStart reader, the PreCompact maintainer and the
+    per-turn drift tag all skip ``GENESIS_CC_SESSION=1``, so no charter — this
+    one or one somebody else creates later — ever reaches this session's
+    windows.
     """
     if not _is_dispatched():
         return ""
     own = _own_session_ids()
-    if _resolves_to_own(sid):
+    if _names_own_session(sid, raw_id):
         # The caller's own charter — by the SAME predicate the write gate uses,
-        # short prefix included, so the two calls cannot contradict each other.
-        # Both write routes are refused and the PreCompact maintainer returns
-        # early on GENESIS_CC_SESSION=1, so nothing can ever create it.
+        # short prefix and pre-resolution spelling included, so the two calls
+        # cannot contradict each other.
         return (
-            " NOTE: that is THIS dispatched/channel session's own id — neither"
-            " route fires for it (compaction skips this session class and both"
-            " writes are refused), so no charter will ever appear here."
+            " NOTE: that is THIS dispatched/channel session's own id — nothing"
+            " THIS session can do will create it (compaction skips this session"
+            " class and both write routes are refused here), and even if another"
+            " session creates it through the supported cross-session write path,"
+            " it will never be re-injected into THIS session's windows."
             " Continuity for a dispatched session depends on which kind it is:"
             " an autonomous task session has its task_states row (created by"
             " the task dispatcher / task_submit, autonomy/dispatcher.py:188 and"
@@ -262,13 +301,18 @@ def _missing_charter_suffix(sid: str) -> str:
             " and otherwise this session's final output."
         )
     if not own:
-        # Fail-open: with no id of our own, we cannot tell whether sid is us.
+        # Fail-open: with no id of our own we cannot tell whether sid is us —
+        # and in that state the write gate does NOT fire either, so this branch
+        # must not repeat the own-charter branch's "both writes are refused".
+        # Saying so was self-contradictory: the same missing id that makes the
+        # target unknowable is what lets the write through (Codex P2, #1617).
         return (
             " NOTE: this is a dispatched/channel session and its own id is"
-            " unknown here, so whether that charter can ever appear could NOT"
-            " be determined — if it is this session's own id, it never will"
-            " (compaction skips this session class and both writes are"
-            " refused)."
+            " unknown here, so whether that is this session's OWN charter could"
+            " NOT be determined. Writes are not refused in this state — they"
+            " fail OPEN and would land — but if it IS this session's own id,"
+            " nothing written there is ever re-injected into this session"
+            " (compaction skips this session class)."
         )
     return ""
 
@@ -313,7 +357,7 @@ async def _impl_session_charter(session_id: str) -> dict:
                 "error": f"No charter for session '{session_id}'. A charter row "
                 "appears at the session's first compaction, or on the first "
                 "session_charter_update / session_ledger_add call."
-                + _missing_charter_suffix(sid)
+                + _missing_charter_suffix(sid, session_id)
             }
         ledger = await crud.ledger_list(db, sid)
         counts = await crud.ledger_counts(db, sid)
@@ -366,7 +410,7 @@ async def _impl_session_charter_update(
         # write would then land, which for this session's own charter it never
         # will. Answering the id form first costs the caller a round trip to
         # fetch an id that is about to be refused anyway.
-        if err := _self_write_unreadable_error(sid):
+        if err := _self_write_unreadable_error(sid, session_id):
             return err
         if err := _unresolved_short_id_error(sid):
             return err
@@ -422,7 +466,7 @@ async def _impl_session_ledger_add(
         # write would then land, which for this session's own charter it never
         # will. Answering the id form first costs the caller a round trip to
         # fetch an id that is about to be refused anyway.
-        if err := _self_write_unreadable_error(sid):
+        if err := _self_write_unreadable_error(sid, session_id):
             return err
         if err := _unresolved_short_id_error(sid):
             return err
@@ -502,8 +546,13 @@ async def _impl_session_ledger_update(
     arbitrary replacement ``text`` and any VALID_LEDGER_STATUS including a
     reopen, so on an install that already carries a legacy inert row — exactly
     the population this gate protects — rewrite-plus-reopen mints a live-looking
-    promise just as effectively as an insert would. Closure (done / absorbed /
-    dropped) and evidence writes stay open so legacy rows remain cleanable.
+    promise just as effectively as an insert would.
+
+    "Promise-creating" is judged on the RESULTING row, not on which fields the
+    call names: an edit that leaves the row terminal (done / absorbed /
+    dropped) creates no promise, so closure, evidence writes, correcting the
+    text of an already-closed row, and text-plus-closure in one call all stay
+    open — legacy rows stay both cleanable and correctable.
     """
     db = _get_db()
     if db is None:
@@ -521,21 +570,35 @@ async def _impl_session_ledger_update(
         existing = await crud.get_ledger_item(db, item_id)
         if existing is None:
             return {"error": f"No ledger item with id '{item_id}'"}
-        # Promise-creating = a text replacement, or a status that leaves the row
-        # LIVE. Derived as the complement of the terminal set against the crud
-        # allow-list rather than a positive literal, so a status added upstream
-        # is gated by default instead of silently slipping past — and so an
-        # INVALID status still falls through to crud.ledger_update's ValueError
-        # rather than being answered with a confusing refusal.
+        # Promise-creating is a property of the row this edit LEAVES BEHIND, not
+        # of the fields it touches (Codex P2, PR #1617). Judging `text is not
+        # None` on its own refused two edits that create no promise at all: a
+        # correction to the text of an already done/absorbed/dropped row, and a
+        # text refinement applied atomically WITH status="done". Both leave a
+        # terminal row, which the charter injection excludes and which nobody can
+        # read as a live commitment — and refusing them contradicts the tool's
+        # own promise that closure stays available.
+        #
+        # So: resolve the RESULTING status first (an omitted status leaves the
+        # existing one), and only then ask whether the edit mints a live
+        # promise. The live set is still derived as the complement of the
+        # terminal set against the crud allow-list rather than a positive
+        # literal, so a status added upstream is gated by default instead of
+        # silently slipping past — and an INVALID status still falls through to
+        # crud.ledger_update's ValueError rather than a confusing refusal.
         live_statuses = crud.VALID_LEDGER_STATUSES - _TERMINAL_LEDGER_STATUSES
-        creates_a_promise = text is not None or status in live_statuses
+        resulting_status = status if status is not None else existing["status"]
+        leaves_the_row_live = resulting_status not in _TERMINAL_LEDGER_STATUSES
+        creates_a_promise = leaves_the_row_live and (text is not None or status in live_statuses)
         if creates_a_promise and (err := _self_write_unreadable_error(existing["session_id"])):
             err["error"] = (
-                "Refusing this edit: rewriting the text of, or reopening, a "
-                "row on this dispatched session's OWN charter creates a new "
-                "live-looking promise on a charter nothing re-injects. "
-                "Closing it (status=done/absorbed/dropped) or attaching "
-                "evidence is still allowed. " + err["error"]
+                "Refusing this edit: it would leave a LIVE row on this "
+                "dispatched session's OWN charter with new text or a reopened "
+                "status — a new live-looking promise on a charter nothing "
+                "re-injects. Anything that leaves the row terminal is still "
+                "allowed: close it (status=done/absorbed/dropped), attach "
+                "evidence, correct the text of an already-closed row, or pass "
+                "text together with status=done. " + err["error"]
             )
             return err
         ok = await crud.ledger_update(db, item_id, status=status, text=text, evidence=evidence)
@@ -656,7 +719,7 @@ async def session_ledger_update(
     evidence, e.g. the PR) | dropped (consciously abandoned). Get item ids
     from session_charter or the SessionStart injection block.
 
-    FOREGROUND SESSIONS ONLY: a dispatched/channel session's own charter is never re-injected (the SessionStart reader, the PreCompact maintainer and the per-turn drift tag all skip GENESIS_CC_SESSION=1), so a self-write is refused; writing to a FOREGROUND session's charter is supported. On a row of its own charter a dispatched session may still close it (done/absorbed/dropped) or attach evidence — only a text replacement or a reopen is refused.
+    FOREGROUND SESSIONS ONLY: a dispatched/channel session's own charter is never re-injected (the SessionStart reader, the PreCompact maintainer and the per-turn drift tag all skip GENESIS_CC_SESSION=1), so a self-write is refused; writing to a FOREGROUND session's charter is supported. On a row of its own charter a dispatched session may still close it (done/absorbed/dropped), attach evidence, edit the text of an already-closed row, or pass text together with status=done — only an edit that leaves the row LIVE with new text or a reopened status is refused.
 
     Args:
         item_id: the ledger row id.

--- a/tests/test_mcp/test_session_charter_tools.py
+++ b/tests/test_mcp/test_session_charter_tools.py
@@ -527,3 +527,79 @@ async def test_terminal_status_set_is_a_subset_of_the_crud_allow_list():
         "open",
         "in_progress",
     } == crud.VALID_LEDGER_STATUSES - tools._TERMINAL_LEDGER_STATUSES
+
+
+# --- The SHORT form the caller was shown (Codex P2, PR #1617) ---------------
+# `_unresolved_short_id_error` tells a caller the [Clock | Session: x] tag shows
+# the first 8 characters — so 8 chars is a prefix Genesis itself hands out. An
+# exact self-comparison missed it, and the two tools then disagreed: the read
+# path said update/add could create the charter while the write path rejected
+# the same prefix as unresolved.
+
+
+async def test_self_write_under_the_advertised_short_prefix_is_refused(
+    db, sessions_dir, monkeypatch
+):
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_add(SID[:8], "survives to Friday")
+    assert "never re-injected" in res["error"].lower(), res
+    assert await crud.ledger_counts(db, SID) == {}
+
+
+async def test_the_read_path_agrees_with_the_write_path_on_a_short_prefix(
+    db, sessions_dir, monkeypatch
+):
+    """The contradiction itself, through the PUBLIC tools rather than the helper.
+
+    Before this, reading a missing charter under an 8-char prefix omitted the
+    self warning — leaving the base message's "or on the first
+    session_charter_update / session_ledger_add call", i.e. telling the caller a
+    write would create it — while the very next write call refused that prefix.
+    Two tools, two incompatible answers, both from Genesis.
+
+    Asserted end-to-end deliberately: a direct `_resolves_to_own` call would fail
+    on the old code with AttributeError, which proves the helper is new and
+    nothing about behaviour.
+    """
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        read = await tools._impl_session_charter(SID[:8])
+        write = await tools._impl_session_ledger_add(SID[:8], "a promise")
+    assert "no charter will ever appear here" in read["error"], read
+    assert "never re-injected" in write["error"].lower(), write
+
+
+async def test_a_prefix_shorter_than_the_advertised_form_is_not_claimed(
+    monkeypatch,
+):
+    """CONTROL (passes on both sides by design — the helper is new).
+
+    A 'prefix' shorter than anything Genesis advertises is a guess, and claiming
+    it as self would refuse a legitimate cross-session write under an id that
+    merely happens to share a first character."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    assert tools._resolves_to_own(SID[:7]) is False
+
+
+async def test_another_session_s_prefix_is_still_not_self(monkeypatch):
+    """CONTROL. Widening to prefixes must not swallow the ambient path — a
+    dispatched session writing to a FOREGROUND charter is the legitimate case
+    this gate deliberately leaves open."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", OTHER_SID)
+    assert tools._resolves_to_own(SID[:8]) is False
+    assert tools._resolves_to_own(SID) is False
+
+
+async def test_with_no_own_id_nothing_is_claimed_as_self(monkeypatch):
+    """CONTROL. Fail-open is the documented direction for an unknown own id — a
+    prefix must not become the exception that fails closed."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.delenv("GENESIS_SESSION_ID", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    assert tools._resolves_to_own(SID[:8]) is False
+    assert tools._resolves_to_own(SID) is False

--- a/tests/test_mcp/test_session_charter_tools.py
+++ b/tests/test_mcp/test_session_charter_tools.py
@@ -61,6 +61,10 @@ async def test_ledger_add_auto_added_by(db, sessions_dir, monkeypatch):
     assert res["open_items"] == 1
 
     monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    # Explicit, not accidental: this asserts the CROSS-session ambient write, so
+    # the caller's own id must differ from the target. Left to the ambient
+    # environment it passes only by luck.
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "99998888-7777-6666-5555-444433332222")
     with patch.object(tools, "_get_db", return_value=db):
         res2 = await tools._impl_session_ledger_add(SID, "dispatched item")
     item2 = await crud.get_ledger_item(db, res2["id"])
@@ -171,3 +175,140 @@ async def test_prefix_resolves_via_cc_sessions_before_first_compaction(db, sessi
     assert res["session_id"] == SID
     assert await crud.get(db, SID) is not None
     assert await crud.get(db, SID[:8]) is None
+
+
+# --- Dispatched self-write refusal (foreground-only charter) ----------------
+# A dispatched session (GENESIS_CC_SESSION=1) writing to its OWN charter
+# produces a row nothing will ever re-inject: the SessionStart emission block
+# and the PreCompact maintainer both skip that session class. Measured
+# 2026-09-02 — a Telegram DM session wrote a ledger row and promised the user
+# it would survive to Friday.
+
+OTHER_SID = "11112222-3333-4444-5555-666677778888"
+
+
+async def test_dispatched_self_write_refused_and_creates_nothing(
+    db, sessions_dir, monkeypatch
+):
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res1 = await tools._impl_session_ledger_add(SID, "survives to Friday")
+        res2 = await tools._impl_session_charter_update(SID, mission="m")
+    assert "never re-injected" in res1["error"].lower(), res1
+    assert "never re-injected" in res2["error"].lower(), res2
+    # The refusal must precede every write — no stub, no ledger row, no mirror.
+    assert await crud.get(db, SID) is None
+    assert await crud.ledger_counts(db, SID) == {}
+    assert not (sessions_dir / SID).exists()
+
+
+async def test_dispatched_write_to_another_session_still_allowed(
+    db, sessions_dir, monkeypatch
+):
+    """The gate is NARROW on purpose: `added_by='ambient'` exists so a
+    dispatched session can contribute to a FOREGROUND session's charter, and
+    that row IS re-injected for its owner. Only the self-write is inert."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", OTHER_SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_add(SID, "ambient contribution")
+    assert "error" not in res, res
+    item = await crud.get_ledger_item(db, res["id"])
+    assert item["added_by"] == "ambient"
+
+
+async def test_foreground_self_write_allowed(db, sessions_dir, monkeypatch):
+    """Both conditions are required — an interactive session writing to its own
+    charter is the primary supported case and must never be refused."""
+    monkeypatch.delenv("GENESIS_CC_SESSION", raising=False)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_add(SID, "foreground item")
+    assert "error" not in res, res
+    # The row must actually LAND — absence of an error is also true of a tool
+    # that silently did nothing.
+    assert await crud.get_ledger_item(db, res["id"]) is not None
+    assert "every post-compaction window" in res["message"], res
+
+
+async def test_dispatched_self_write_refused_via_short_prefix(
+    db, sessions_dir, monkeypatch
+):
+    """The guard runs AFTER id resolution, so the 8-char prefix form the
+    session sees in its own [Session: xxxxxxxx] tag is refused too."""
+    await db.execute(
+        "INSERT INTO cc_sessions (id, session_type, model, started_at,"
+        " last_activity_at, cc_session_id)"
+        " VALUES ('g-tg', 'foreground', 'sonnet',"
+        " '2026-09-02T00:00:00+00:00', '2026-09-02T00:00:00+00:00', ?)",
+        (SID,),
+    )
+    await db.commit()
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_add(SID[:8], "prefix form")
+    assert "never re-injected" in res["error"].lower(), res
+    assert await crud.get(db, SID) is None
+
+
+async def test_gate_fails_open_without_a_known_session_id(
+    db, sessions_dir, monkeypatch
+):
+    """Truthfulness gate, not a security boundary: with no id to compare, it
+    degrades to the previous behaviour rather than refusing legitimate work.
+
+    NOTE this test cannot fail if the gate is deleted — it is an INTENT PIN
+    against a future fail-CLOSED rewrite, not a guard on the mechanism. The
+    branch is near-dead in production (CC sets CLAUDE_CODE_SESSION_ID on every
+    stdio-MCP spawn), which is precisely why the intent needs pinning in a test
+    rather than left to be re-derived."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_add(SID, "unknown own id")
+    assert "error" not in res, res
+    # Failing open must not UPGRADE to a confidently false claim. With no own
+    # id, sid may be this very session, so the cross-session wording would be
+    # unsound — the message must claim nothing about persistence.
+    assert "THAT session's" not in res["message"], res["message"]
+    assert "could NOT be verified" in res["message"], res["message"]
+
+
+async def test_dispatched_cross_session_message_names_the_beneficiary(
+    db, sessions_dir, monkeypatch
+):
+    """The success message is the sentence that produced "survives to Friday".
+    On the path this gate deliberately leaves open — dispatched writing to a
+    FOREGROUND charter — it must say WHOSE windows the row re-injects into, or
+    the natural reading is "mine", and it is not."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", OTHER_SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_add(SID, "ambient contribution")
+    assert "error" not in res, res
+    msg = res["message"]
+    assert SID[:8] in msg, msg
+    assert "NOT" in msg and "this one" in msg, msg
+    # The unqualified promise must NOT appear on this path.
+    assert "re-inject into every post-compaction window" not in msg, msg
+
+
+async def test_every_charter_tool_description_states_the_foreground_limit():
+    """The @mcp.tool descriptions are injected into the system prompt of every
+    session holding genesis-health — including dispatched ones. They are what
+    INDUCED the bad call: the ledger description promised the row "re-injects
+    into every post-compaction window ... no summary can erase it".
+
+    Gating the write while leaving the inducement unqualified just converts a
+    silent false promise into refusal + friction, so every description that
+    makes a persistence claim must carry the limit.
+    """
+    from genesis.mcp.health import mcp
+
+    tools_by_name = await mcp.get_tools()
+    for name in ("session_charter", "session_charter_update", "session_ledger_add"):
+        desc = (tools_by_name[name].description or "")
+        assert "FOREGROUND SESSIONS ONLY" in desc, f"{name} description: {desc[:200]}"
+        assert "GENESIS_CC_SESSION=1" in desc, name

--- a/tests/test_mcp/test_session_charter_tools.py
+++ b/tests/test_mcp/test_session_charter_tools.py
@@ -25,6 +25,20 @@ def sessions_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
+@pytest.fixture(autouse=True)
+def _no_ambient_session_identity(monkeypatch):
+    """Neutralise the RUNNER's own session identity for every test in this file.
+
+    The dispatched-session gate reads three env vars, and CC sets two of them in
+    any session that runs pytest. A test that only sets the vars it cares about
+    would then pass or fail on the runner's identity — the same "passes only by
+    luck" hazard already called out on the cross-session case below. Tests that
+    exercise a dispatched shape set what they need explicitly.
+    """
+    for var in ("GENESIS_CC_SESSION", "CLAUDE_CODE_SESSION_ID", "GENESIS_SESSION_ID"):
+        monkeypatch.delenv(var, raising=False)
+
+
 async def test_charter_update_creates_stub_and_sets_mission(db, sessions_dir):
     with patch.object(tools, "_get_db", return_value=db):
         res = await tools._impl_session_charter_update(SID, mission="Ship PR-2a")
@@ -308,7 +322,208 @@ async def test_every_charter_tool_description_states_the_foreground_limit():
     from genesis.mcp.health import mcp
 
     tools_by_name = await mcp.get_tools()
-    for name in ("session_charter", "session_charter_update", "session_ledger_add"):
+    for name in (
+        "session_charter",
+        "session_charter_update",
+        "session_ledger_add",
+        "session_ledger_update",
+    ):
         desc = (tools_by_name[name].description or "")
         assert "FOREGROUND SESSIONS ONLY" in desc, f"{name} description: {desc[:200]}"
         assert "GENESIS_CC_SESSION=1" in desc, name
+
+
+# --- The id the caller actually HAS (Codex P1, PR #1617) -------------------
+# A channel session is told its "Session ID" is the Genesis cc_sessions.id
+# (cc/conversation.py:259,280 -> cc/system_prompt.py:97) and never sees the CC
+# transcript id, because the per-turn [Clock | Session: x] tag is suppressed for
+# dispatched sessions (scripts/genesis_urgent_alerts.py:433-435). So the
+# production self-write arrives under GENESIS_SESSION_ID, not
+# CLAUDE_CODE_SESSION_ID.
+
+TRANSCRIPT_SID = "22223333-4444-5555-6666-777788889999"
+
+
+async def test_channel_self_write_under_the_genesis_row_id_is_refused(
+    db, sessions_dir, monkeypatch
+):
+    """The exact production shape: the two ids differ, and the caller passes the
+    only one it was ever shown."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", TRANSCRIPT_SID)
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res1 = await tools._impl_session_ledger_add(SID, "survives to Friday")
+        res2 = await tools._impl_session_charter_update(SID, mission="m")
+    assert "never re-injected" in res1["error"].lower(), res1
+    assert "never re-injected" in res2["error"].lower(), res2
+    assert await crud.get(db, SID) is None
+    assert await crud.ledger_counts(db, SID) == {}
+    assert not (sessions_dir / SID).exists()
+
+
+async def test_cross_session_write_still_allowed_with_both_ids_known(
+    db, sessions_dir, monkeypatch
+):
+    """Widening self-identity must not swallow the ambient path: neither of the
+    caller's two ids is the target, so the write stands."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", TRANSCRIPT_SID)
+    monkeypatch.setenv("GENESIS_SESSION_ID", OTHER_SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_add(SID, "ambient contribution")
+    assert "error" not in res, res
+    assert (await crud.get_ledger_item(db, res["id"]))["added_by"] == "ambient"
+
+
+async def test_beneficiary_claim_requires_the_transcript_id_not_just_the_row_id(
+    db, sessions_dir, monkeypatch
+):
+    """sid lives in the transcript-id namespace (it is a session_charters key).
+    Knowing only the Genesis row id leaves "sid might be my own transcript id"
+    open, so the confident beneficiary sentence must not fire."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
+    monkeypatch.setenv("GENESIS_SESSION_ID", OTHER_SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_add(SID, "own transcript id unknown")
+    assert "error" not in res, res
+    assert "THAT session's" not in res["message"], res["message"]
+    assert "could NOT be verified" in res["message"], res["message"]
+
+
+# --- Read path: absence is only permanent for the caller's OWN charter ------
+
+
+async def test_missing_charter_of_ANOTHER_session_is_not_called_permanent(
+    db, sessions_dir, monkeypatch
+):
+    """Codex P2: keyed on "am I dispatched" the suffix told an ambient caller to
+    abandon a FOREGROUND target whose charter its own next compaction creates."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", TRANSCRIPT_SID)
+    monkeypatch.setenv("GENESIS_SESSION_ID", OTHER_SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_charter(SID)
+    assert "No charter for session" in res["error"], res
+    assert "never" not in res["error"].lower(), res["error"]
+    assert "task_states" not in res["error"], res["error"]
+
+
+async def test_missing_own_charter_is_permanent_and_names_the_right_spine(
+    db, sessions_dir, monkeypatch
+):
+    """Codex P2: task_states rows are created only by the autonomous task
+    dispatcher (autonomy/dispatcher.py:188) and task_submit
+    (mcp/health/task_tools.py:200) — never by ConversationManager — so a channel
+    conversation has none, and naming it as "the continuity spine" is false
+    assurance for exactly the session class that hit this."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", TRANSCRIPT_SID)
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_charter(SID)
+    err = res["error"]
+    assert "no charter will ever appear here" in err, err
+    # It may still point an AUTONOMOUS session at task_states, but never
+    # unconditionally: a channel conversation must be told it has no such row.
+    assert "task_states" in err, err
+    assert "CHANNEL conversation has NO" in err, err
+
+
+async def test_missing_charter_uncertain_when_the_caller_has_no_id(
+    db, sessions_dir, monkeypatch
+):
+    """Fail-open on the read path too: with no id of its own the tool cannot
+    know whether the target is the caller, so it must not assert either way."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_charter(SID)
+    err = res["error"]
+    assert "could NOT be determined" in err, err
+    assert "no charter will ever appear here" not in err, err
+
+
+# --- Rewrite/reopen of a legacy inert row (Codex P2, PR #1617) --------------
+
+
+async def _seed_legacy_inert_row(db) -> str:
+    """A row already on the caller's own charter, as an install that predates
+    the insert gate would have. Written through crud, below the tool gate."""
+    await crud.upsert_stub(db, SID)
+    return await crud.ledger_add(
+        db, session_id=SID, text="legacy inert row", added_by="ambient"
+    )
+
+
+async def test_dispatched_self_rewrite_and_reopen_refused(
+    db, sessions_dir, monkeypatch
+):
+    item_id = await _seed_legacy_inert_row(db)
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        rewritten = await tools._impl_session_ledger_update(
+            item_id, text="a brand new promise"
+        )
+        reopened = await tools._impl_session_ledger_update(item_id, status="open")
+        in_progress = await tools._impl_session_ledger_update(
+            item_id, status="in_progress"
+        )
+    for res in (rewritten, reopened, in_progress):
+        assert "Refusing this edit" in res.get("error", ""), res
+    # The refusal must precede the mutation — the row is untouched.
+    row = await crud.get_ledger_item(db, item_id)
+    assert row["text"] == "legacy inert row", row
+    assert row["status"] == "open", row
+
+
+async def test_dispatched_self_closure_and_evidence_still_allowed(
+    db, sessions_dir, monkeypatch
+):
+    """Never trap a session with rows it cannot clean up: terminal statuses and
+    evidence writes stay open on the caller's own charter."""
+    item_id = await _seed_legacy_inert_row(db)
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        evidenced = await tools._impl_session_ledger_update(item_id, evidence="PR #1617")
+        closed = await tools._impl_session_ledger_update(item_id, status="done")
+    assert "error" not in evidenced, evidenced
+    assert "error" not in closed, closed
+    assert (await crud.get_ledger_item(db, item_id))["status"] == "done"
+
+
+async def test_foreground_rewrite_and_reopen_untouched(db, sessions_dir):
+    """The gate is dispatched-only — the primary interactive path must not
+    acquire a new refusal."""
+    item_id = await _seed_legacy_inert_row(db)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_update(
+            item_id, text="refined wording", status="open"
+        )
+    assert "error" not in res, res
+    assert res["text"] == "refined wording", res
+
+
+async def test_unknown_item_id_still_reports_unknown_not_refused(
+    db, sessions_dir, monkeypatch
+):
+    """Pre-fetching the row for the gate must not change the unknown-id error."""
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_update("deadbeef" * 4, text="x")
+    assert "No ledger item with id" in res["error"], res
+
+
+async def test_terminal_status_set_is_a_subset_of_the_crud_allow_list():
+    """The promise-creating set is the COMPLEMENT of _TERMINAL_LEDGER_STATUSES
+    against crud.VALID_LEDGER_STATUSES, so a terminal name that drifts out of
+    the allow-list would silently widen what counts as "live" — or, worse, a
+    typo'd terminal name would leave a real closure gated."""
+    assert tools._TERMINAL_LEDGER_STATUSES <= crud.VALID_LEDGER_STATUSES
+    assert {
+        "open",
+        "in_progress",
+    } == crud.VALID_LEDGER_STATUSES - tools._TERMINAL_LEDGER_STATUSES

--- a/tests/test_mcp/test_session_charter_tools.py
+++ b/tests/test_mcp/test_session_charter_tools.py
@@ -424,7 +424,7 @@ async def test_missing_own_charter_is_permanent_and_names_the_right_spine(
     with patch.object(tools, "_get_db", return_value=db):
         res = await tools._impl_session_charter(SID)
     err = res["error"]
-    assert "no charter will ever appear here" in err, err
+    assert "never be re-injected into THIS session" in err, err
     # It may still point an AUTONOMOUS session at task_states, but never
     # unconditionally: a channel conversation must be told it has no such row.
     assert "task_states" in err, err
@@ -441,7 +441,7 @@ async def test_missing_charter_uncertain_when_the_caller_has_no_id(
         res = await tools._impl_session_charter(SID)
     err = res["error"]
     assert "could NOT be determined" in err, err
-    assert "no charter will ever appear here" not in err, err
+    assert "THIS dispatched/channel session's own id" not in err, err
 
 
 # --- Rewrite/reopen of a legacy inert row (Codex P2, PR #1617) --------------
@@ -568,7 +568,7 @@ async def test_the_read_path_agrees_with_the_write_path_on_a_short_prefix(
     with patch.object(tools, "_get_db", return_value=db):
         read = await tools._impl_session_charter(SID[:8])
         write = await tools._impl_session_ledger_add(SID[:8], "a promise")
-    assert "no charter will ever appear here" in read["error"], read
+    assert "THIS dispatched/channel session's own id" in read["error"], read
     assert "never re-injected" in write["error"].lower(), write
 
 
@@ -603,3 +603,185 @@ async def test_with_no_own_id_nothing_is_claimed_as_self(monkeypatch):
     monkeypatch.delenv("CLAUDE_CODE_SESSION_ID", raising=False)
     assert tools._resolves_to_own(SID[:8]) is False
     assert tools._resolves_to_own(SID) is False
+
+
+# --- Round-3 Codex P2s ------------------------------------------------------
+# Three findings against 14ce4e64c, all on the same theme: the gate's CLAIMS
+# were wider than the mechanism behind them.
+
+
+async def test_own_missing_charter_promises_no_reinjection_not_absolute_absence(
+    db, sessions_dir, monkeypatch
+):
+    """The claim is caller-relative, so it may not be stated as absolute.
+
+    "no charter will ever appear here" was false: the cross-session write path
+    this PR deliberately preserves lets ANY foreground session — and, per the
+    residual gap named in `_self_write_unreadable_error`, any OTHER dispatched
+    session — create this very charter through session_charter_update /
+    session_ledger_add. What is actually guaranteed is that it never reaches
+    THIS session's windows, because the SessionStart reader, the PreCompact
+    maintainer and the drift tag all skip GENESIS_CC_SESSION=1.
+    """
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_charter(SID)
+    err = res["error"]
+    assert "never be re-injected into THIS session" in err, err
+    # The overreaching absolute claim must be gone.
+    assert "no charter will ever appear here" not in err, err
+    # ...and the reason it is gone must be stated, not merely omitted: the
+    # supported cross-session path is why absence cannot be promised.
+    assert "another" in err.lower() and "cross-session" in err.lower(), err
+
+
+async def test_unknown_own_id_suffix_does_not_claim_writes_are_refused(
+    db, sessions_dir, monkeypatch
+):
+    """The fail-open branch contradicted itself.
+
+    With no own id, `_resolves_to_own` returns False, so
+    `_self_write_unreadable_error` returns None and the write LANDS — yet the
+    suffix told the caller "both writes are refused". The same missing id that
+    makes the target unknowable is what disarms the gate.
+    """
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_charter(SID)
+        # Ground truth for the claim: the write really is allowed here.
+        wrote = await tools._impl_session_ledger_add(SID, "fail-open write")
+    err = res["error"]
+    assert "error" not in wrote, wrote
+    assert "could NOT be determined" in err, err
+    assert "fail OPEN" in err, err
+    assert "writes are refused" not in err, err
+
+
+async def test_terminal_row_text_correction_allowed_on_own_charter(
+    db, sessions_dir, monkeypatch
+):
+    """A text edit that leaves the row DONE creates no promise (Codex P2).
+
+    Promise-creating is a property of the resulting row, not of which fields the
+    call names — refusing a correction to an already-closed row contradicted the
+    tool's own guarantee that closure and cleanup stay available.
+    """
+    item_id = await _seed_legacy_inert_row(db)
+    await crud.ledger_update(db, item_id, status="done")
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_update(item_id, text="closed: shipped in #1617")
+    assert "error" not in res, res
+    row = await crud.get_ledger_item(db, item_id)
+    assert row["text"] == "closed: shipped in #1617", row
+    assert row["status"] == "done", row
+
+
+async def test_text_plus_closure_in_one_call_allowed_on_own_charter(
+    db, sessions_dir, monkeypatch
+):
+    """Atomically refining text WHILE closing leaves a terminal row — allowed."""
+    item_id = await _seed_legacy_inert_row(db)
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_update(
+            item_id, text="what it actually was", status="absorbed"
+        )
+    assert "error" not in res, res
+    row = await crud.get_ledger_item(db, item_id)
+    assert row["status"] == "absorbed", row
+    assert row["text"] == "what it actually was", row
+
+
+async def test_text_edit_that_leaves_a_row_live_is_still_refused(
+    db, sessions_dir, monkeypatch
+):
+    """CONTROL for the widening above: relaxing to "resulting row" must not
+    reopen the hole. A text swap on an OPEN row still mints a live promise, and
+    so does text + an explicit reopen of a closed row."""
+    item_id = await _seed_legacy_inert_row(db)  # status 'open'
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        live_swap = await tools._impl_session_ledger_update(item_id, text="a brand new promise")
+        await crud.ledger_update(db, item_id, status="done")
+        reopen_with_text = await tools._impl_session_ledger_update(
+            item_id, text="back from the dead", status="open"
+        )
+    for res in (live_swap, reopen_with_text):
+        assert "Refusing this edit" in res.get("error", ""), res
+    assert (await crud.get_ledger_item(db, item_id))["text"] == "legacy inert row"
+
+
+async def test_own_prefix_that_resolves_to_a_FOREIGN_id_is_still_self(
+    db, sessions_dir, monkeypatch
+):
+    """The guard saw only the RESOLVED id, so resolution could rename the caller.
+
+    `crud.resolve_session_id` LIKE-matches a short id against
+    session_charters.session_id / cc_sessions.cc_session_id. Our own
+    GENESIS_SESSION_ID is a cc_sessions.id — in NEITHER column — so a prefix of
+    it that uniquely matches one unrelated row is rewritten to that row's full
+    transcript id. `_resolves_to_own` then answered False and the self-write was
+    accepted as cross-session, landing on a stranger's charter.
+    """
+    foreign = SID[:8] + "-9999-8888-7777-666655554444"
+    assert foreign != SID and foreign.startswith(SID[:8])
+    await crud.upsert_stub(db, foreign)
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        # Sanity: resolution really does rename the caller's own prefix.
+        assert await crud.resolve_session_id(db, SID[:8]) == foreign
+        write = await tools._impl_session_ledger_add(SID[:8], "survives to Friday")
+        update = await tools._impl_session_charter_update(SID[:8], mission="m")
+    assert "never re-injected" in write["error"].lower(), write
+    assert "never re-injected" in update["error"].lower(), update
+    # Nothing landed on the stranger's charter.
+    assert await crud.ledger_counts(db, foreign) == {}
+    assert (await crud.get(db, foreign)).get("mission") is None
+
+
+async def test_read_path_agrees_when_an_own_prefix_resolves_to_a_FOREIGN_id(
+    db, sessions_dir, monkeypatch
+):
+    """Same rename, on the read path (session_charter_tools.py:309 in the finding).
+
+    Seeded through cc_sessions rather than a charter row so the target is
+    charterless and the suffix branch is reached: the resolved id is a
+    stranger's, but the caller named ITSELF, so the response must not tell it a
+    write would create the charter.
+    """
+    foreign = SID[:8] + "-9999-8888-7777-666655554444"
+    await db.execute(
+        "INSERT INTO cc_sessions (id, session_type, model, started_at,"
+        " last_activity_at, cc_session_id)"
+        " VALUES ('g-foreign', 'foreground', 'test-model',"
+        " '2026-07-13T00:00:00+00:00', '2026-07-13T00:00:00+00:00', ?)",
+        (foreign,),
+    )
+    await db.commit()
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        assert await crud.resolve_session_id(db, SID[:8]) == foreign
+        read = await tools._impl_session_charter(SID[:8])
+    assert "THIS dispatched/channel session's own id" in read["error"], read
+
+
+async def test_a_foreign_prefix_is_not_made_self_by_the_raw_check(
+    db, sessions_dir, monkeypatch
+):
+    """CONTROL. Checking the raw input must not swallow the ambient path: a
+    prefix of ANOTHER session is still a legitimate cross-session write."""
+    await crud.upsert_stub(db, OTHER_SID)
+    monkeypatch.setenv("GENESIS_CC_SESSION", "1")
+    monkeypatch.setenv("GENESIS_SESSION_ID", SID)
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", TRANSCRIPT_SID)
+    with patch.object(tools, "_get_db", return_value=db):
+        res = await tools._impl_session_ledger_add(OTHER_SID[:8], "for the foreground session")
+    assert "error" not in res, res
+    assert res["session_id"] == OTHER_SID, res


### PR DESCRIPTION
## Problem

The session charter/ledger is **foreground-only by construction** — the
SessionStart reader, the PreCompact maintainer and the per-turn drift tag all
skip `GENESIS_CC_SESSION=1`. Only the **writer** lacked that gate.

So a Telegram `claude -p` session wrote a ledger row to its own charter and told
the user it would *"survive to Friday"*. It could not: `_charter_emission_block()`
returns **0 chars** for that session on startup, resume *and* compact. The row is
inert by construction — stored, never re-injected.

## The gate is deliberately narrow

Refuses only when the session is dispatched **AND** the resolved target is its
**own** id.

A broader caller-based gate was tried and rejected: a dispatched session writing
to a *foreground* session's charter is legitimate and readable — that is what
`added_by='ambient'` exists for — and the broad gate broke the pre-existing test
asserting exactly that path.

Classifying the **target** via `cc_sessions` would be *wrong*, not merely
expensive: the incident session's own row records `session_type='foreground'`, so
a DB-based gate would have waved the actual defect through. The writer's own env
is the only sound signal. The one residual gap (dispatched → *another*
dispatched charter) is documented rather than hidden.

## Gating the write was only half the problem

Two adversarial rounds established that the real class is *"messages that assert
a persistence the caller cannot rely on"*, and round 1's sweep stopped at
response strings without reaching the layer that **induces** the call. The
population was then re-derived by an AST walk rather than by eye:

- **Refusal message** — previously pointed at `memory_store` (in
  `_UNIVERSAL_DISALLOW`, denied on every direct-session profile) and
  `follow_up_create` (dispatched items are demoted to the cold `tabled` lane).
  Now states the profile split and offers the fallback that always works.
- **Success message** — was unconditional, so the path this gate *deliberately
  leaves open* still emitted the "survives to Friday" sentence. Now names the
  beneficiary, and claims **nothing** when this session's own id is unknown.
- **All three `@mcp.tool` descriptions** now carry the foreground-only limit.
  These are injected into the system prompt and are what induced the original
  call; gating the write while leaving the inducement unqualified merely trades
  a silent false promise for refusal + friction. A test pins the qualifier in
  each so they cannot drift.
- **Read path** — the "no charter" error no longer hands a dispatched session a
  two-step recipe in which neither step can fire.

## Verification

End-to-end against a **real schema** (`create_all_tables`), not mocks:

| case | outcome |
|---|---|
| dispatched **self**-write | refused — no row, no stub, no mirror |
| dispatched, own id **unknown** (fail-open) | allowed, message claims nothing |
| dispatched **cross-session** | allowed, `added_by='ambient'`, beneficiary named |
| interactive self-write | allowed, row verified present |
| 8-char **prefix** self-write | refused — proves the guard runs after id resolution |
| dispatched read of a charterless session | warns the recipe never fires |

**4 mutations RED, zero survivors** — including both failure directions: gate
absent, and gate over-broad (reproducing the rejected caller-based design).
22 tests pass; ruff clean.

## Incidental finding, recorded

The MCP child's `CLAUDE_CODE_SESSION_ID` is a **spawn-time snapshot**: CC updates
only its own `process.env` on a conversation reset and never respawns MCP
children. Measured 3h stale on one box. Not reachable for this gate (staleness
needs a reset; `-p` sessions never reset), but it is documented in the helper so
a future dispatched shape that *does* reset cannot silently disarm it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards preventing dispatched sessions from writing to their own charter.
  * Added clearer guidance when a dispatched session cannot access its own charter.
  * Ledger updates now allow closure and evidence changes while restricting promise creation and reopening.
  * Added clearer documentation of foreground-only behavior and dispatched-session restrictions.

* **Bug Fixes**
  * Improved session identity handling across transcript and Genesis session IDs.
  * Added safeguards for ambiguous or missing session identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->