### PR TITLE
feat(observability): tell a session WHY its dispatched work was killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **When work is killed for running out of memory, Genesis now says so.** A
+  process the kernel reaps dies without a word, so a session that lost its work
+  that way reported a bare failure — indistinguishable from a crash or a timeout,
+  and typically followed by an immediate retry of the same memory-heavy work
+  under the same pressure. Genesis now checks whether the kernel actually reaped
+  anything while that work ran, and only then names the cause. It stays silent
+  whenever the evidence is short of that: a different kind of exit, a counter it
+  cannot read, or a process Genesis stopped itself. The attribution also stops
+  the retry — the failure was the machine running out of memory, so re-running
+  the same work, or handing it to a different model, only repeats it.
+
 - **Gated autonomous cold marketing outreach (inert by default).** Genesis can
   now stage cold marketing emails to an owner-curated prospect list via the new
   `marketing_send` tool. The recipient is resolved in code from a private

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -63,10 +63,14 @@ def _bg_notice(output) -> str:
 def _is_oom_death(exc: BaseException) -> bool:
     """Whether this failure was attributed to an out-of-memory reap.
 
-    Reads ``CCProcessError.oom_suspected`` — the machine-readable half of the
-    attribution — never the message prose, which is a human-facing string that will
-    be reworded. ``getattr`` rather than an isinstance check so every CCError type
-    can answer the question and none has to.
+    Reads ``CCError.oom_suspected`` — the machine-readable half of the attribution
+    — never the message prose, which is a human-facing string that will be
+    reworded. The flag lives on the BASE, so a reap that also produced recognisable
+    output (an MCP line, a session-expiry message, buffered quota text) is still
+    attributed: those exits classify as a typed error, and while the flag lived only
+    on ``CCProcessError`` they arrived here with nothing to read and took the
+    stale-resume branch anyway. ``getattr`` is kept for the non-CCError case, since
+    this is called on a bare ``BaseException``.
 
     An OOM death is a THIRD kind of failure alongside the rate/quota/timeout/offline
     family already fast-re-raised: not a stale resume. The resumed session is
@@ -1124,7 +1128,7 @@ class ConversationLoop:
             if not peers:
                 return None
             sticky = self._session_fallback_session(session)
-            for peer_name, peer_inv in peers:
+            for peer_idx, (peer_name, peer_inv) in enumerate(peers):
                 if streamed and streamed.get("text"):
                     break  # a prior peer already streamed answer text — can't fail
                     # over to another without double-output; degrade instead.
@@ -1135,7 +1139,27 @@ class ConversationLoop:
                     )
                 except (CCRateLimitError, CCQuotaExhaustedError):
                     continue  # this peer is also down → try the next one
-                except CCError:
+                except CCError as exc:
+                    if _is_oom_death(exc):
+                        # STOP, do not try the next peer. Every peer runs the same
+                        # memory-heavy prompt through a LOCAL subprocess, so "try
+                        # another model" re-arms the identical failure under the
+                        # identical pressure — the retry amplification this
+                        # attribution exists to end, once per peer. The peer is not
+                        # what failed; this box ran out of memory.
+                        #
+                        # Logged at ERROR, not warning: a peer being down is routine
+                        # and a reap is not, and if a later peer had succeeded the
+                        # cause would have vanished entirely from the record.
+                        logger.error(
+                            "failover peer %s was OOM-reaped locally — abandoning "
+                            "failover rather than re-arming the workload on the "
+                            "remaining %d peer(s): %s",
+                            peer_name,
+                            len(peers) - peer_idx - 1,
+                            exc,
+                        )
+                        break
                     logger.warning("failover peer %s failed", peer_name, exc_info=True)
                     continue
                 # Success on this peer. Record the account-wide flag + this session's

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -60,6 +60,25 @@ def _bg_notice(output) -> str:
     return _BG_TRUNCATION_NOTICE if getattr(output, "bg_truncated", False) else ""
 
 
+def _is_oom_death(exc: BaseException) -> bool:
+    """Whether this failure was attributed to an out-of-memory reap.
+
+    Reads ``CCProcessError.oom_suspected`` — the machine-readable half of the
+    attribution — never the message prose, which is a human-facing string that will
+    be reworded. ``getattr`` rather than an isinstance check so every CCError type
+    can answer the question and none has to.
+
+    An OOM death is a THIRD kind of failure alongside the rate/quota/timeout/offline
+    family already fast-re-raised: not a stale resume. The resumed session is
+    perfectly valid and the process was reaped, so ``_recover_stale_resume`` would
+    fail a live session for the wrong reason AND immediately re-run the identical
+    memory-heavy work under the same pressure — the retry amplification the
+    attribution exists to end. Worse, a retry that happens to succeed swallows the
+    cause entirely: the user learns nothing about why the first attempt died.
+    """
+    return bool(getattr(exc, "oom_suspected", False))
+
+
 # Nudge for dispatched, delivery-addressable (Telegram) channels: route long research/bg work
 # durable direct_session lane instead of an inline Workflow, which the CC bg-wait ceiling
 # kills after ~10min with nothing left to report back (the 2026-07-20 silent-death class).
@@ -842,8 +861,8 @@ class ConversationLoop:
             # retry fresh (which would also just re-raise offline). Let the
             # caller's terminal handler deal with it.
             raise
-        except CCError:
-            if not was_resume:
+        except CCError as exc:
+            if not was_resume or _is_oom_death(exc):
                 raise
             # Resume failed — recover and retry fresh
             session = await self._recover_stale_resume(
@@ -888,8 +907,8 @@ class ConversationLoop:
             # network-offline preflight (PR-3) likewise must NOT fail the live
             # session as a stale resume — the internet is down, not the session.
             raise
-        except CCError:
-            if not was_resume:
+        except CCError as exc:
+            if not was_resume or _is_oom_death(exc):
                 raise
             session = await self._recover_stale_resume(
                 session, user_id=user_id, channel=channel,
@@ -1052,10 +1071,17 @@ class ConversationLoop:
             # network is not a stale peer resume — retrying fresh won't help and
             # must not mark the sticky peer session stale.
             raise
-        except CCError:
+        except CCError as exc:
             # Don't re-stream: nothing to recover if already fresh, and never retry
-            # once answer text has reached the user (would double-output).
-            if inv.resume_session_id is None or (streamed and streamed.get("text")):
+            # once answer text has reached the user (would double-output). An
+            # attributed OOM joins those: the peer's sticky session is fine, the
+            # local subprocess was reaped, and re-running the identical workload
+            # under the same memory pressure re-arms the failure.
+            if (
+                inv.resume_session_id is None
+                or (streamed and streamed.get("text"))
+                or _is_oom_death(exc)
+            ):
                 raise
             logger.warning(
                 "failover peer %s sticky resume failed — retrying fresh", peer_name,

--- a/src/genesis/cc/exceptions.py
+++ b/src/genesis/cc/exceptions.py
@@ -8,7 +8,58 @@ from __future__ import annotations
 
 
 class CCError(Exception):
-    """Base for all CC invocation errors."""
+    """Base for all CC invocation errors.
+
+    ``oom_suspected`` is the MACHINE-READABLE half of an OOM attribution; the
+    human half is the note appended to the message, which no caller should have
+    to pattern-match to make a control-flow decision. It exists because an OOM
+    death must NOT be handled as a stale resume or as a reason to try the next
+    peer: the session is fine, the process was reaped, and re-running the
+    identical memory-heavy work re-arms the failure under the same pressure.
+
+    IT LIVES ON THE BASE, not on ``CCProcessError``, and the move is the fix for
+    a real hole rather than tidying. A reaped process usually writes nothing, so
+    it classified as a generic process error and the flag reached the callers.
+    But a process that emitted ANY recognised line before dying — an MCP startup
+    error, a session-expiry message, buffered quota text — classifies as
+    ``CCMCPError`` / ``CCSessionError`` / ``CCQuotaExhaustedError`` instead, and
+    when the flag existed only on ``CCProcessError`` those exits carried NO
+    attribution at all. They then took the worst possible branch: the MCP and
+    session ones entered stale-resume recovery and re-ran the workload, and the
+    quota one could park the turn for a capacity reset that was never the
+    problem. The class default is False, so every type answers the question and
+    none has to know about OOM.
+
+    A flag rather than a new exception TYPE, deliberately: the retry semantics of
+    the underlying failure stay intact everywhere that does not opt in — an OOM
+    that also hit a real rate limit is still a rate limit — and only the paths
+    that must not re-arm the work key off it.
+
+    See ``genesis.observability.oom`` for how the attribution is derived and for
+    the (deliberately narrow) conditions under which it is claimed at all.
+    """
+
+    oom_suspected: bool = False
+
+
+def annotate_oom(err: CCError, note: str) -> CCError:
+    """Attach an OOM attribution to an ALREADY-CLASSIFIED error, in place.
+
+    The single place the two halves are applied together, so a call site cannot
+    set one and forget the other. Applied AFTER classification rather than
+    instead of it: what killed the process and what the process managed to say
+    before dying are independent facts, and the old code could only report the
+    second.
+
+    ``args[0]`` is replaced rather than a new exception constructed: the typed
+    subclasses carry their own keyword state (``server_name``, ``raw_text``,
+    ``raw_event``) that a rebuild would have to enumerate and would silently
+    drop as new fields are added.
+    """
+    err.oom_suspected = True
+    base = str(err) or "killed with no output"
+    err.args = (f"{base} — {note}", *err.args[1:])
+    return err
 
 
 class CCTimeoutError(CCError):
@@ -18,19 +69,9 @@ class CCTimeoutError(CCError):
 class CCProcessError(CCError):
     """CC CLI exited with non-zero status.
 
-    ``oom_suspected`` is the MACHINE-READABLE half of an OOM attribution; the
-    human half is the note appended to the message, which no caller should have
-    to pattern-match to make a control-flow decision. It exists because an OOM
-    death must NOT be handled as a stale resume: the resumed session is fine, the
-    process was reaped, and re-running the identical memory-heavy work re-arms
-    the failure under the same pressure while discarding the live session for the
-    wrong reason. The flag rather than a new exception TYPE keeps the retry
-    semantics of a generic process failure everywhere that does not opt in —
-    only the stale-resume recovery in conversation.py keys off it, exactly as it
-    keys off ``CCNetworkOfflineError``.
-
-    See ``genesis.observability.oom`` for how the attribution is derived and for
-    the (deliberately narrow) conditions under which it is claimed at all.
+    The ``oom_suspected`` keyword is kept here (rather than moved to the base's
+    ``__init__``) because the base has none: adding one would force every
+    subclass with its own ``__init__`` to forward it.
     """
 
     def __init__(self, message: str = "", *, oom_suspected: bool = False):

--- a/src/genesis/cc/exceptions.py
+++ b/src/genesis/cc/exceptions.py
@@ -16,7 +16,26 @@ class CCTimeoutError(CCError):
 
 
 class CCProcessError(CCError):
-    """CC CLI exited with non-zero status."""
+    """CC CLI exited with non-zero status.
+
+    ``oom_suspected`` is the MACHINE-READABLE half of an OOM attribution; the
+    human half is the note appended to the message, which no caller should have
+    to pattern-match to make a control-flow decision. It exists because an OOM
+    death must NOT be handled as a stale resume: the resumed session is fine, the
+    process was reaped, and re-running the identical memory-heavy work re-arms
+    the failure under the same pressure while discarding the live session for the
+    wrong reason. The flag rather than a new exception TYPE keeps the retry
+    semantics of a generic process failure everywhere that does not opt in —
+    only the stale-resume recovery in conversation.py keys off it, exactly as it
+    keys off ``CCNetworkOfflineError``.
+
+    See ``genesis.observability.oom`` for how the attribution is derived and for
+    the (deliberately narrow) conditions under which it is claimed at all.
+    """
+
+    def __init__(self, message: str = "", *, oom_suspected: bool = False):
+        super().__init__(message)
+        self.oom_suspected = oom_suspected
 
 
 class CCParsingError(CCError):

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -34,6 +34,7 @@ from genesis.cc.types import (
     clamp_effort,
     model_supports_effort,
 )
+from genesis.observability.oom import OomProbe
 from genesis.observability.spans import SpanKind, start_span
 from genesis.util.proc_kill import (
     kill_process_group,
@@ -539,8 +540,19 @@ class CCInvoker:
             proc.send_signal(signal.SIGINT)
 
     @staticmethod
-    def _classify_error(stderr_text: str, stdout_text: str = "") -> CCError:
+    def _classify_error(
+        stderr_text: str, stdout_text: str = "", *, oom_note: str | None = None
+    ) -> CCError:
         """Classify CC output into a typed CC exception.
+
+        ``oom_note`` carries a cause this function cannot derive from text, because
+        the failure it describes produces none: a process reaped by the OOM killer
+        dies by SIGKILL with empty output, so every pattern below misses and it lands
+        on the generic error at the end. The note is appended to the message rather
+        than routed to a new exception type — the retry semantics of an OOM death are
+        the generic ones, and inventing a type would change control flow to deliver a
+        string. Callers that need to branch on it should key off the counter, not on
+        message text.
 
         Checks both stderr and stdout — when CC runs in streaming-JSON
         mode the rate-limit / quota signal often appears in stdout
@@ -611,7 +623,13 @@ class CCInvoker:
         # CCError on resumes, so this only improves classification fidelity.
         if "thinking" in lower and "cannot be modified" in lower:
             return CCSessionError(source)
-        # Generic process error
+        # Generic process error — and the one place an OOM note can land, because a
+        # reaped process matches none of the patterns above. `source` is typically
+        # EMPTY here (SIGKILL writes nothing), which is exactly the bare "[killed]"
+        # this note exists to replace; the fallback text keeps the message from being
+        # only the annotation with no statement of what happened.
+        if oom_note:
+            return CCProcessError(f"{source or 'killed with no output'} — {oom_note}")
         return CCProcessError(source)
 
     async def _notify_status_change(self, error: CCError | None) -> None:
@@ -797,6 +815,11 @@ class CCInvoker:
 
         proc = None
         reg_key: str | None = None
+        # Sample the OOM counter BEFORE the spawn, because attribution is a delta and
+        # there is no way to take a "before" reading after the fact. Cheap (one small
+        # read), never raises, and degrades to a probe that declines to attribute
+        # anything on a host where the counter is unreadable.
+        oom_probe = OomProbe.sample()
         try:
             scope_args = _get_scope_args()
             proc = await asyncio.create_subprocess_exec(
@@ -894,13 +917,23 @@ class CCInvoker:
         if proc.returncode != 0:
             stderr_text = stderr.decode(errors="replace").strip()
             stdout_text = stdout.decode(errors="replace").strip()
+            # An OOM reap is the one failure that arrives with NOTHING to classify:
+            # SIGKILL leaves no message, so stderr and stdout are typically empty and
+            # every text-matching branch below falls through to a generic error. The
+            # cause has to come from outside the process's own output, and the cgroup
+            # counter is the only source that does not depend on a log line the
+            # journal usually does not have. `self_killed` is False here by
+            # construction: this is the normal-completion path, and the timeout and
+            # reaper paths that DO send SIGKILL return before reaching it.
+            oom_note = oom_probe.describe(proc.returncode)
             logger.error(
-                "CC subprocess failed (exit=%s): stderr=%s stdout=%s",
+                "CC subprocess failed (exit=%s): stderr=%s stdout=%s%s",
                 proc.returncode,
                 stderr_text[:500] or "(no stderr)",
                 stdout_text[:500] or "(no stdout)",
+                f" [{oom_note}]" if oom_note else "",
             )
-            err = self._classify_error(stderr_text, stdout_text)
+            err = self._classify_error(stderr_text, stdout_text, oom_note=oom_note)
             await self._notify_status_change(err)
             raise err
 

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -45,19 +45,28 @@ from genesis.util.proc_kill import (
 logger = logging.getLogger(__name__)
 
 
-def set_oom_score_adj(pid: int, score: int = 500) -> None:
-    """Set OOM score adjustment for a process.
+def set_oom_score_adj(pid: int, score: int = 500) -> bool:
+    """Set OOM score adjustment for a process. Returns whether the write landed.
 
     Higher scores make the process more likely to be OOM-killed.
     CC subprocesses get +500 so the kernel kills them before genesis-server
     (-500) or qdrant. This is the container-side complement to the
     host VM's cgroup OOM scoring.
+
+    The return value is NOT decoration: the OOM attribution note cites this
+    preference as the reason the dispatched process was the likely victim, and
+    that premise is false on a host where procfs denied the write, is read-only,
+    or the process exited before it could be adjusted. Callers pass the result to
+    :meth:`genesis.observability.oom.OomProbe.describe` so an unestablished
+    premise is omitted from the diagnostic rather than asserted.
     """
     try:
         Path(f"/proc/{pid}/oom_score_adj").write_text(str(score))
         logger.debug("Set oom_score_adj=%d for PID %d", score, pid)
+        return True
     except OSError as exc:
         logger.warning("Could not set oom_score_adj for PID %d: %s", pid, exc)
+        return False
 
 
 def _build_scope_args() -> list[str]:
@@ -549,10 +558,10 @@ class CCInvoker:
         the failure it describes produces none: a process reaped by the OOM killer
         dies by SIGKILL with empty output, so every pattern below misses and it lands
         on the generic error at the end. The note is appended to the message rather
-        than routed to a new exception type — the retry semantics of an OOM death are
-        the generic ones, and inventing a type would change control flow to deliver a
-        string. Callers that need to branch on it should key off the counter, not on
-        message text.
+        than routed to a new exception type, because a new type would change the
+        retry semantics of every handler at once. Callers that must BRANCH on the
+        cause read ``CCProcessError.oom_suspected``, set here alongside the note —
+        never the message text, which is prose and will be reworded.
 
         Checks both stderr and stdout — when CC runs in streaming-JSON
         mode the rate-limit / quota signal often appears in stdout
@@ -629,7 +638,10 @@ class CCInvoker:
         # this note exists to replace; the fallback text keeps the message from being
         # only the annotation with no statement of what happened.
         if oom_note:
-            return CCProcessError(f"{source or 'killed with no output'} — {oom_note}")
+            return CCProcessError(
+                f"{source or 'killed with no output'} — {oom_note}",
+                oom_suspected=True,
+            )
         return CCProcessError(source)
 
     async def _notify_status_change(self, error: CCError | None) -> None:
@@ -820,6 +832,10 @@ class CCInvoker:
         # read), never raises, and degrades to a probe that declines to attribute
         # anything on a host where the counter is unreadable.
         oom_probe = OomProbe.sample()
+        # Whether the +500 preference was actually WRITTEN — the annotation cites it
+        # as the reason this process was the likely victim, and on a host where the
+        # write is denied that premise never held. False until the write succeeds.
+        oom_adjusted = False
         try:
             scope_args = _get_scope_args()
             proc = await asyncio.create_subprocess_exec(
@@ -838,7 +854,7 @@ class CCInvoker:
             reg_key = invocation.session_key or f"pid:{proc.pid}"
             self._register_proc(reg_key, proc)
             logger.info("CC subprocess spawned (PID %s)", proc.pid)
-            set_oom_score_adj(proc.pid, 500)
+            oom_adjusted = set_oom_score_adj(proc.pid, 500)
             if invocation.on_spawn is not None:
                 try:
                     await invocation.on_spawn(proc.pid)
@@ -925,7 +941,7 @@ class CCInvoker:
             # journal usually does not have. `self_killed` is False here by
             # construction: this is the normal-completion path, and the timeout and
             # reaper paths that DO send SIGKILL return before reaching it.
-            oom_note = oom_probe.describe(proc.returncode)
+            oom_note = oom_probe.describe(proc.returncode, score_adjusted=oom_adjusted)
             logger.error(
                 "CC subprocess failed (exit=%s): stderr=%s stdout=%s%s",
                 proc.returncode,
@@ -1026,6 +1042,11 @@ class CCInvoker:
             prompt_preview,
         )
 
+        # Same pre-spawn sample as _run_inner, for the same reason: attribution is a
+        # delta and the "before" reading cannot be taken after the fact. Streaming is
+        # NOT a lesser case — it is the path foreground conversations and
+        # DirectSessionRunner take, so a reap here is the one a human is waiting on.
+        oom_probe = OomProbe.sample()
         try:
             scope_args = _get_scope_args()
             proc = await asyncio.create_subprocess_exec(
@@ -1054,7 +1075,7 @@ class CCInvoker:
                 f"and ~/.npm-global/bin is on PATH."
             ) from None
         logger.info("CC streaming subprocess spawned (PID %s)", proc.pid)
-        set_oom_score_adj(proc.pid, 500)
+        oom_adjusted = set_oom_score_adj(proc.pid, 500)
         # cc-loop-01: register immediately (before the stdin feed) so the proc is
         # interruptible from spawn. If on_spawn or the stdin feed fails (broken
         # pipe, task cancellation), reap the proc and drop the registry entry —
@@ -1088,6 +1109,14 @@ class CCInvoker:
         timed_out = False
         terminated_after_result = False
         line_count = 0
+        # Did WE signal this process? Unlike _run_inner (where every self-kill path
+        # returns or raises before the exit is inspected), the streaming path can
+        # reach the post-stream branches after its own terminate/group-kill — and a
+        # group-kill sets returncode to -9, which is exactly what an OOM reap looks
+        # like. Without this flag a self-inflicted SIGKILL that happened to coincide
+        # with someone else's reap in the same cgroup would be reported as a probable
+        # OOM: a plausible wrong cause replacing a known true one.
+        self_killed = False
 
         try:
             async with asyncio.timeout(invocation.timeout_s):
@@ -1134,6 +1163,7 @@ class CCInvoker:
                         # overwrite the real answer with a throwaway response).
                         proc.terminate()
                         terminated_after_result = True
+                        self_killed = True
                         if on_event:
                             await on_event(event)
                         break
@@ -1147,6 +1177,7 @@ class CCInvoker:
                 time.monotonic() - start,
                 proc.pid,
             )
+            self_killed = True
             kill_process_group(proc)
         except asyncio.CancelledError:
             # Task cancellation (runtime shutdown cancelling an in-flight
@@ -1188,6 +1219,9 @@ class CCInvoker:
             # death); costs latency only when a survivor actually exists.
             await asyncio.sleep(_ESCALATION_GRACE_S)
         if proc.returncode is None or process_group_alive(proc):
+            # This SIGKILL is ours, and it lands on a process whose exit is inspected
+            # below — record it so the OOM probe cannot read our own -9 as a reap.
+            self_killed = True
             logger.warning(
                 "CC streaming group survived graceful stop/kill "
                 "(PID %s, rc=%s) — group-killing",
@@ -1288,7 +1322,36 @@ class CCInvoker:
                 await self._fire_empty_output_callback(invocation, output)
             return output
 
-        # No result event — treat collected text as response (success path)
+        # No result event. This branch is the streaming path's silent-loss hole: it
+        # builds a CCOutput with the default is_error=False regardless of
+        # proc.returncode, so a subprocess that was REAPED mid-stream is handed back
+        # as an ordinary (usually empty) answer — DirectSessionRunner then persists
+        # `success=not output.is_error` (direct_session.py:892) as True, and a
+        # foreground turn shows the user nothing at all about why their work
+        # vanished. Raise instead when, and only when, the counter actually
+        # attributed the death: SIGKILL, not our own, with a real delta. Everything
+        # short of that keeps the existing return-what-we-collected behaviour —
+        # a nonzero exit alone is ambiguous, and turning it into an exception would
+        # discard partial text that today reaches the user.
+        oom_note = oom_probe.describe(
+            proc.returncode, self_killed=self_killed, score_adjusted=oom_adjusted
+        )
+        if oom_note:
+            partial = "".join(collected_text)
+            logger.error(
+                "CC streaming subprocess reaped (exit=%s, partial=%d chars) [%s]",
+                proc.returncode,
+                len(partial),
+                oom_note,
+            )
+            # stderr only, never the collected assistant text: a partial answer that
+            # happens to discuss "usage limits" must not be classified as a quota
+            # failure and parked. A SIGKILL writes nothing, so this is normally "".
+            err = self._classify_error(stderr_str.strip(), oom_note=oom_note)
+            await self._notify_status_change(err)
+            raise err
+
+        # Treat collected text as the response (success path)
         if self._last_was_error:
             await self._notify_status_change(None)
         output = CCOutput(

--- a/src/genesis/cc/invoker.py
+++ b/src/genesis/cc/invoker.py
@@ -24,6 +24,7 @@ from genesis.cc.exceptions import (
     CCRateLimitError,
     CCSessionError,
     CCTimeoutError,
+    annotate_oom,
 )
 from genesis.cc.types import (
     CCInvocation,
@@ -552,16 +553,27 @@ class CCInvoker:
     def _classify_error(
         stderr_text: str, stdout_text: str = "", *, oom_note: str | None = None
     ) -> CCError:
-        """Classify CC output into a typed CC exception.
+        """Classify CC output into a typed CC exception, then annotate the cause.
 
-        ``oom_note`` carries a cause this function cannot derive from text, because
-        the failure it describes produces none: a process reaped by the OOM killer
-        dies by SIGKILL with empty output, so every pattern below misses and it lands
-        on the generic error at the end. The note is appended to the message rather
-        than routed to a new exception type, because a new type would change the
-        retry semantics of every handler at once. Callers that must BRANCH on the
-        cause read ``CCProcessError.oom_suspected``, set here alongside the note —
-        never the message text, which is prose and will be reworded.
+        TWO INDEPENDENT FACTS, applied in that order and never traded for each
+        other: what the process managed to SAY before it died (the text patterns
+        below), and what KILLED it (``oom_note``, which no amount of text can
+        reveal — a reaped process dies by SIGKILL writing nothing).
+
+        The annotation used to be applied only on the generic fallthrough, on the
+        reasoning that a reaped process matches no pattern. Usually true, and
+        wrong in exactly the case that matters: a process that emitted an MCP
+        startup error, a session-expiry line, or buffered quota text BEFORE the
+        kernel took it returns a typed exception from an earlier branch, and the
+        attribution was dropped on the floor. Those exits then took the worst
+        available branch — MCP and session errors entered stale-resume recovery
+        and re-ran the memory-heavy workload, and a quota match could park the
+        turn for a capacity reset that was never the problem. So the note is
+        applied at the ONE exit, to whatever was classified.
+
+        Callers that must BRANCH on the cause read ``CCError.oom_suspected``
+        (set by ``annotate_oom`` alongside the human note) — never the message
+        text, which is prose and will be reworded.
 
         Checks both stderr and stdout — when CC runs in streaming-JSON
         mode the rate-limit / quota signal often appears in stdout
@@ -569,6 +581,18 @@ class CCInvoker:
         Limiting classification to stderr would mis-categorize those as
         generic CCProcessError and skip downstream retry branches that
         key off the typed exception.
+        """
+        err = CCInvoker._classify_error_text(stderr_text, stdout_text)
+        return annotate_oom(err, oom_note) if oom_note else err
+
+    @staticmethod
+    def _classify_error_text(stderr_text: str, stdout_text: str = "") -> CCError:
+        """The TEXT half of ``_classify_error`` — what the process said, only.
+
+        Split out so the OOM annotation has exactly one place to attach. It is
+        deliberately ignorant of the kill cause: every ``return`` below answers
+        "what does this output look like", and none of them may decide whether an
+        attribution survives.
         """
         combined = f"{stderr_text}\n{stdout_text}"
         lower = combined.lower()
@@ -632,16 +656,11 @@ class CCInvoker:
         # CCError on resumes, so this only improves classification fidelity.
         if "thinking" in lower and "cannot be modified" in lower:
             return CCSessionError(source)
-        # Generic process error — and the one place an OOM note can land, because a
-        # reaped process matches none of the patterns above. `source` is typically
-        # EMPTY here (SIGKILL writes nothing), which is exactly the bare "[killed]"
-        # this note exists to replace; the fallback text keeps the message from being
-        # only the annotation with no statement of what happened.
-        if oom_note:
-            return CCProcessError(
-                f"{source or 'killed with no output'} — {oom_note}",
-                oom_suspected=True,
-            )
+        # Generic process error — where a reaped process lands, since SIGKILL
+        # writes nothing and none of the patterns above can match. The OOM note
+        # is NOT applied here: `_classify_error` attaches it to whatever this
+        # returns, so a process that DID say something on its way out keeps both
+        # its classification and its cause.
         return CCProcessError(source)
 
     async def _notify_status_change(self, error: CCError | None) -> None:
@@ -1218,10 +1237,22 @@ class CCInvoker:
             # short beat (stdio children normally exit sub-second on parent
             # death); costs latency only when a survivor actually exists.
             await asyncio.sleep(_ESCALATION_GRACE_S)
-        if proc.returncode is None or process_group_alive(proc):
-            # This SIGKILL is ours, and it lands on a process whose exit is inspected
-            # below — record it so the OOM probe cannot read our own -9 as a reap.
-            self_killed = True
+        leader_alive = proc.returncode is None
+        if leader_alive or process_group_alive(proc):
+            # `self_killed` answers ONE question: did WE produce the leader's exit
+            # code? Only a kill that lands on a LIVE leader can. When the leader is
+            # already dead and only an MCP/helper descendant survives, this branch is
+            # descendant CLEANUP — our signal cannot change an exit code that is
+            # already set, so claiming it here would discard someone else's news.
+            #
+            # And the news is precisely the case this file exists for: the OOM killer
+            # reaps the CC leader, a helper in its group outlives it, `returncode` is
+            # already -9, and marking that as self-inflicted made `describe` decline a
+            # VALID attribution — sending the no-result path back to an empty, and
+            # therefore SUCCESSFUL-looking, CCOutput. A common process-tree shape,
+            # silently recorded as work that completed.
+            if leader_alive:
+                self_killed = True
             logger.warning(
                 "CC streaming group survived graceful stop/kill "
                 "(PID %s, rc=%s) — group-killing",

--- a/src/genesis/observability/oom.py
+++ b/src/genesis/observability/oom.py
@@ -26,7 +26,11 @@ specifically, and both are recorded rather than assumed:
 * ``cc.invoker.set_oom_score_adj`` deliberately sets ``oom_score_adj=+500`` on CC
   subprocesses so the kernel prefers them over genesis-server and qdrant. The
   dispatched work is the INTENDED victim, so when a reap occurs in its cgroup while
-  it dies by SIGKILL, it is very likely the one that was chosen.
+  it dies by SIGKILL, it is very likely the one that was chosen. That write can
+  FAIL (denied procfs, read-only, or the process exited first), so it is not assumed
+  either: ``set_oom_score_adj`` returns whether it landed and the caller passes that
+  through as :meth:`OomProbe.describe`'s ``score_adjusted``, which omits the
+  preference sentence when the preference was never established.
 * A SIGKILL that Genesis itself sent (a timeout, a reaper) is distinguishable by the
   caller, which knows it sent one — see :meth:`OomProbe.describe` and its ``self_killed``
   argument. Attribution is skipped in that case rather than guessed at.
@@ -173,7 +177,13 @@ class OomProbe:
             return None
         return None
 
-    def describe(self, returncode: int | None, *, self_killed: bool = False) -> str | None:
+    def describe(
+        self,
+        returncode: int | None,
+        *,
+        self_killed: bool = False,
+        score_adjusted: bool = False,
+    ) -> str | None:
         """A cause annotation for an abnormal exit, or None to stay silent.
 
         Returns None — deliberately, and in every ambiguous case — unless all of:
@@ -186,6 +196,16 @@ class OomProbe:
         * the counter is readable AND increased. An unreadable counter is "unknown",
           which this reports as nothing rather than as absence.
 
+        ``score_adjusted`` is the caller's OBSERVED result of writing
+        ``oom_score_adj`` for this process (``cc.invoker.set_oom_score_adj`` returns
+        it), not an assumption that the write landed. The "the kernel prefers this
+        process" sentence strengthens the inference, so it is printed only when that
+        preference was actually established: on a host where procfs denied the write,
+        is read-only, or the process exited first, the sentence would present an
+        unverified premise as evidence — overstating what the counter and the SIGKILL
+        together prove. The default is False so a caller that does not know stays
+        silent about it rather than claiming it.
+
         Silence is the right default because this annotation exists to be trusted:
         a cause line that is sometimes invented is worse than a bare kill, which at
         least does not mislead.
@@ -195,10 +215,15 @@ class OomProbe:
         delta = self.kills_since()
         if not delta:
             return None
+        victim = (
+            " Dispatched work carries oom_score_adj=+500 so the kernel prefers it "
+            "over the server, which makes it the likely victim."
+            if score_adjusted
+            else ""
+        )
         return (
             f"probable cause: out-of-memory reap — the kernel OOM-killed {delta} "
             f"process(es) in {self.cgroup} while this ran, and this process died by "
-            "SIGKILL. Dispatched work carries oom_score_adj=+500 so the kernel "
-            "prefers it over the server, which makes it the likely victim. Reduce "
-            "the working set, or run fewer sessions concurrently."
+            f"SIGKILL.{victim} Reduce the working set, or run fewer sessions "
+            "concurrently."
         )

--- a/src/genesis/observability/oom.py
+++ b/src/genesis/observability/oom.py
@@ -1,0 +1,204 @@
+"""Attribute an abnormal process death to the kernel's OOM killer, from cgroup v2.
+
+A process reaped under memory pressure reaches its owner as a bare kill: a negative
+return code, usually empty stderr, and no cause. The owning session cannot tell a
+reap from a crash from a timeout, so it re-arms the identical work and loses it
+again — invisibility does not merely lose the result, it induces the retry.
+
+**Why the journal is not the answer.** The obvious source is the kernel log, and it
+is unreliable here. MEASURED on this install, cgroup ``user.slice`` reported
+``oom_kill 35`` against 14 matching lines in the user journal for the same boot —
+most reaps leave no log line a session can find, and reading the journal also needs
+permissions a subprocess may not have.
+
+The cgroup counter has neither problem. ``memory.events`` is readable by the owning
+user, it counts every reap in a cgroup and its descendants, and it never misses. So
+attribution here is a DELTA: sample the counter before the work starts, read it again
+once the process is dead, and compare.
+
+**What this can and cannot prove.** A delta says an OOM kill happened in this cgroup
+while the process was running — NOT that this process was the victim. Another process
+in the same cgroup could have been the one reaped. That is why nothing here reports a
+certainty: :func:`describe_oom_death` requires BOTH a delta AND death by SIGKILL, and
+still says "probable". Two facts make the inference strong on this deployment
+specifically, and both are recorded rather than assumed:
+
+* ``cc.invoker.set_oom_score_adj`` deliberately sets ``oom_score_adj=+500`` on CC
+  subprocesses so the kernel prefers them over genesis-server and qdrant. The
+  dispatched work is the INTENDED victim, so when a reap occurs in its cgroup while
+  it dies by SIGKILL, it is very likely the one that was chosen.
+* A SIGKILL that Genesis itself sent (a timeout, a reaper) is distinguishable by the
+  caller, which knows it sent one — see :meth:`OomProbe.describe` and its ``self_killed``
+  argument. Attribution is skipped in that case rather than guessed at.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CGROUP_ROOT = Path("/sys/fs/cgroup")
+_PROC_SELF_CGROUP = Path("/proc/self/cgroup")
+
+#: The field in ``memory.events`` counting processes reaped by the OOM killer in this
+#: cgroup and its descendants. Deliberately NOT ``oom``: that counts times the cgroup
+#: hit its limit, which includes pressure that killed nothing.
+_OOM_KILL_FIELD = "oom_kill"
+
+
+def _own_cgroup_relpath() -> str | None:
+    """This process's cgroup v2 path, relative to the hierarchy root.
+
+    ``/proc/self/cgroup`` on a v2-only host is a single ``0::<path>`` line. A v1 or
+    hybrid host has other lines, which this deliberately ignores rather than guessing
+    a v1 layout — an unsupported layout must degrade to "unknown", never to a wrong
+    attribution.
+    """
+    try:
+        for line in _PROC_SELF_CGROUP.read_text().splitlines():
+            hier, _, path = line.partition("::")
+            if hier == "0" and path.startswith("/"):
+                return path
+    except OSError:
+        return None
+    return None
+
+
+#: The cgroup level to watch by default: the whole per-user subtree.
+#:
+#: NOT the caller's own cgroup, and that distinction is the difference between this
+#: working and silently never firing. Genesis spawns CC through ``systemd-run
+#: --scope --user``, which puts the child in its OWN transient scope under
+#: ``user@<uid>.service`` — a SIBLING of the caller's cgroup, not a descendant. A
+#: counter read on the caller's own cgroup can therefore never see the child's reap,
+#: and the delta would be zero forever while dispatched work died invisibly.
+#:
+#: MEASURED on this install, which is what exposed it: all 35 reaps were counted at
+#: ``user-1000.slice`` and ``user@1000.service``, while every ``session-*.scope``
+#: read 0. Watching the user slice covers the caller, the systemd user units, and
+#: every transient scope, while still excluding ``system.slice`` — so an unrelated
+#: system daemon being reaped cannot be mistaken for our own.
+_USER_SLICE_RE = "user-"
+
+
+def read_oom_kills(cgroup_relpath: str | None = None) -> tuple[int, str] | None:
+    """``(count, cgroup_path)`` of OOM reaps in a cgroup subtree, or None if unknown.
+
+    Resolves to the enclosing per-user slice (``user-<uid>.slice``) when this process
+    sits under one — see :data:`_USER_SLICE_RE` for why the caller's OWN cgroup is
+    the wrong answer. Falls back to walking upward to the first readable
+    ``memory.events`` on a layout with no user slice (a container running as pid 1,
+    a v1 host), which is a narrower watch but still correct for a child that
+    inherits the cgroup.
+
+    The caller is told WHICH cgroup answered, because a delta from a broad cgroup is
+    weaker evidence than one from a narrow cgroup and the annotation says so.
+
+    Returns None — never 0 — when the counter cannot be read at all. Those are
+    different facts, and collapsing them would let "no OOM here" be reported for a
+    host where the question was never asked.
+    """
+    rel = cgroup_relpath if cgroup_relpath is not None else _own_cgroup_relpath()
+    if rel is None:
+        return None
+    node = _CGROUP_ROOT / rel.lstrip("/")
+
+    if cgroup_relpath is None:
+        # Prefer the per-user slice over anything nearer, so a sibling scope's reap
+        # is still counted. Explicit paths are honoured as given — a caller that
+        # names a cgroup means that one.
+        for ancestor in (node, *node.parents):
+            if ancestor.name.startswith(_USER_SLICE_RE) and ancestor.name.endswith(".slice"):
+                node = ancestor
+                break
+
+    while True:
+        try:
+            for line in (node / "memory.events").read_text().splitlines():
+                field, _, value = line.partition(" ")
+                if field == _OOM_KILL_FIELD:
+                    return int(value), str(node)
+        except (OSError, ValueError):
+            pass
+        if node == _CGROUP_ROOT or _CGROUP_ROOT not in node.parents:
+            return None
+        node = node.parent
+
+
+@dataclass(frozen=True)
+class OomProbe:
+    """A before-reading of the OOM counter, to be compared after a process dies.
+
+    Construct with :meth:`sample` before spawning the work; call :meth:`describe`
+    once the process is dead. Never raises: an unreadable counter yields a probe that
+    simply declines to attribute anything, because a monitoring helper that can break
+    the thing it monitors is worse than no monitoring.
+    """
+
+    baseline: int | None
+    cgroup: str | None
+
+    @classmethod
+    def sample(cls, cgroup_relpath: str | None = None) -> OomProbe:
+        reading = read_oom_kills(cgroup_relpath)
+        if reading is None:
+            return cls(baseline=None, cgroup=None)
+        count, path = reading
+        return cls(baseline=count, cgroup=path)
+
+    @property
+    def available(self) -> bool:
+        """Whether this host answered the question at all."""
+        return self.baseline is not None
+
+    def kills_since(self) -> int | None:
+        """Reaps in this cgroup since :meth:`sample`, or None if unknown.
+
+        Clamped at zero: a counter that appears to go backwards means the cgroup was
+        recreated under us (a restarted unit), which invalidates the comparison
+        rather than proving negative kills.
+        """
+        if self.baseline is None or self.cgroup is None:
+            return None
+        try:
+            for line in (Path(self.cgroup) / "memory.events").read_text().splitlines():
+                field, _, value = line.partition(" ")
+                if field == _OOM_KILL_FIELD:
+                    return max(0, int(value) - self.baseline)
+        except (OSError, ValueError):
+            return None
+        return None
+
+    def describe(self, returncode: int | None, *, self_killed: bool = False) -> str | None:
+        """A cause annotation for an abnormal exit, or None to stay silent.
+
+        Returns None — deliberately, and in every ambiguous case — unless all of:
+
+        * the process died by SIGKILL (``returncode == -9``). A non-SIGKILL exit was
+          not the OOM killer, whatever the counter says.
+        * ``self_killed`` is False. A timeout or reaper SIGKILL from Genesis itself
+          is a known cause already, and dressing it as a probable OOM would replace
+          one true statement with a plausible wrong one.
+        * the counter is readable AND increased. An unreadable counter is "unknown",
+          which this reports as nothing rather than as absence.
+
+        Silence is the right default because this annotation exists to be trusted:
+        a cause line that is sometimes invented is worse than a bare kill, which at
+        least does not mislead.
+        """
+        if self_killed or returncode != -signal.SIGKILL:
+            return None
+        delta = self.kills_since()
+        if not delta:
+            return None
+        return (
+            f"probable cause: out-of-memory reap — the kernel OOM-killed {delta} "
+            f"process(es) in {self.cgroup} while this ran, and this process died by "
+            "SIGKILL. Dispatched work carries oom_score_adj=+500 so the kernel "
+            "prefers it over the server, which makes it the likely victim. Reduce "
+            "the working set, or run fewer sessions concurrently."
+        )

--- a/tests/test_cc/test_conversation_failover.py
+++ b/tests/test_cc/test_conversation_failover.py
@@ -14,7 +14,12 @@ import pytest
 
 from genesis.cc import fallback_state, roster
 from genesis.cc.conversation import ConversationLoop
-from genesis.cc.exceptions import CCError, CCNetworkOfflineError, CCRateLimitError
+from genesis.cc.exceptions import (
+    CCError,
+    CCNetworkOfflineError,
+    CCProcessError,
+    CCRateLimitError,
+)
 from genesis.cc.invoker import CCInvoker
 from genesis.cc.system_prompt import SystemPromptAssembler
 from genesis.cc.types import (
@@ -285,3 +290,82 @@ async def test_run_failover_peer_offline_propagates_without_fresh_retry(loop, in
             on_event=None,
         )
     assert invoker.run.call_count == 1  # no fresh retry
+
+
+# ── An attributed OOM death is NOT a stale resume ──
+#
+# The reap kills the local subprocess; the CC session it was resuming is untouched.
+# Treating it as a stale resume does two wrong things at once: it fails a live
+# session for a cause that had nothing to do with it, and it immediately re-runs the
+# identical memory-heavy workload under the same pressure. If that retry happens to
+# succeed, the OOM fact is swallowed entirely and the user never learns why the first
+# attempt died — the exact retry amplification the attribution exists to end.
+
+
+def _oom_error(msg: str = "killed with no output — probable cause: out-of-memory reap"):
+    return CCProcessError(msg, oom_suspected=True)
+
+
+@pytest.mark.asyncio
+async def test_oom_death_on_resume_does_not_enter_stale_resume_recovery(loop, invoker):
+    invoker.run = AsyncMock(side_effect=_oom_error())
+    loop._recover_stale_resume = AsyncMock()
+    inv = CCInvocation(prompt="x", resume_session_id="cc-live")
+    with pytest.raises(CCProcessError) as caught:
+        await loop._try_invoke(
+            inv, session={"id": "cc-live"}, was_resume=True, prompt_text="x",
+            model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
+            user_id="u1", channel=ChannelType.TERMINAL, thread_id=None,
+        )
+    loop._recover_stale_resume.assert_not_awaited()
+    assert invoker.run.await_count == 1, "the identical workload must not be re-armed"
+    assert "out-of-memory" in str(caught.value), "the cause must survive to the caller"
+
+
+@pytest.mark.asyncio
+async def test_oom_death_on_streaming_resume_does_not_enter_stale_resume_recovery(
+    loop, invoker
+):
+    invoker.run_streaming = AsyncMock(side_effect=_oom_error())
+    loop._recover_stale_resume = AsyncMock()
+    inv = CCInvocation(prompt="x", resume_session_id="cc-live")
+    with pytest.raises(CCProcessError):
+        await loop._try_invoke_streaming(
+            inv, session={"id": "cc-live"}, was_resume=True, prompt_text="x",
+            model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
+            user_id="u1", channel=ChannelType.TERMINAL, thread_id=None, on_event=None,
+        )
+    loop._recover_stale_resume.assert_not_awaited()
+    assert invoker.run_streaming.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_oom_death_on_failover_peer_propagates_without_fresh_retry(loop, invoker):
+    # The third member of the retry class: a sticky PEER resume. Same reasoning —
+    # the peer's session is fine, our subprocess was reaped.
+    invoker.run = AsyncMock(side_effect=_oom_error())
+    with pytest.raises(CCProcessError):
+        await loop._run_failover_peer(
+            "glm-5.2", _PEER_INV,
+            sticky={"roster_model": "glm-5.2", "cc_session_id": "glm-prev"},
+            on_event=None,
+        )
+    assert invoker.run.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_an_unattributed_process_error_still_recovers_a_stale_resume(loop, invoker):
+    """The control. Only an ATTRIBUTED OOM opts out — an ordinary CCProcessError on a
+    resume must still go through stale-resume recovery, or this change would have
+    silently disabled the recovery path it was meant to leave alone."""
+    invoker.run = AsyncMock(side_effect=[CCProcessError("plain crash"), _output()])
+    loop._recover_stale_resume = AsyncMock(return_value={"id": "cc-fresh"})
+    inv = CCInvocation(prompt="x", resume_session_id="cc-live")
+    out, _sess = await loop._try_invoke(
+        inv, session={"id": "cc-live"}, was_resume=True, prompt_text="x",
+        model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
+        user_id="u1", channel=ChannelType.TERMINAL, thread_id=None,
+    )
+    loop._recover_stale_resume.assert_awaited_once()
+    assert invoker.run.await_count == 2
+    assert out.text == "reply"

--- a/tests/test_cc/test_conversation_failover.py
+++ b/tests/test_cc/test_conversation_failover.py
@@ -369,3 +369,79 @@ async def test_an_unattributed_process_error_still_recovers_a_stale_resume(loop,
     loop._recover_stale_resume.assert_awaited_once()
     assert invoker.run.await_count == 2
     assert out.text == "reply"
+
+
+@pytest.mark.asyncio
+async def test_an_oom_stops_the_peer_loop_instead_of_re_arming_the_workload(
+    loop, invoker, monkeypatch
+):
+    """Two peers, the first OOM-reaped: the second must NEVER be tried.
+
+    Every peer runs the same memory-heavy prompt through a LOCAL subprocess, so
+    "try another model" re-arms the identical failure under the identical
+    pressure — the retry amplification the attribution exists to end, once per
+    peer. The peer is not what failed; this box ran out of memory.
+
+    It also loses the cause: if peer two had happened to succeed, the reply would
+    have been returned and nothing would record that the first attempt was killed.
+    """
+    second = CCInvocation(
+        prompt="x", model_id_override="kimi-k3",
+        anthropic_base_url="https://kimi", anthropic_auth_token="sk",
+        roster_eligible=True,
+    )
+    monkeypatch.setattr(
+        roster, "failover_invocations",
+        lambda home, base, *a, **k: [("glm-5.2", _PEER_INV), ("kimi-k3", second)],
+    )
+    tried: list[str] = []
+
+    async def _peer(peer_name, peer_inv, **kw):
+        tried.append(peer_name)
+        raise _oom_error()
+
+    loop._run_failover_peer = AsyncMock(side_effect=_peer)
+    result = await loop._try_roster_failover(
+        CCInvocation(prompt="x"), session={"id": "cc-1"},
+        channel=ChannelType.TERMINAL, model=CCModel.SONNET,
+        effort=EffortLevel.MEDIUM, prompt_text="x",
+    )
+    assert tried == ["glm-5.2"], f"the loop re-armed the workload on {tried[1:]}"
+    # None, not a raise: the method's contract is that failover never breaks the
+    # turn. Contingency runs next, and it does not spawn a local CC subprocess, so
+    # falling through to it does not re-arm anything.
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_peer_failure_still_tries_the_next_peer(
+    loop, invoker, monkeypatch
+):
+    """The control on the other side. Only an ATTRIBUTED OOM stops the loop — a
+    peer that is merely broken must still fall through to the next one, or this
+    change would have quietly disabled failover itself."""
+    second = CCInvocation(
+        prompt="x", model_id_override="kimi-k3",
+        anthropic_base_url="https://kimi", anthropic_auth_token="sk",
+        roster_eligible=True,
+    )
+    monkeypatch.setattr(
+        roster, "failover_invocations",
+        lambda home, base, *a, **k: [("glm-5.2", _PEER_INV), ("kimi-k3", second)],
+    )
+    tried: list[str] = []
+
+    async def _peer(peer_name, peer_inv, **kw):
+        tried.append(peer_name)
+        if peer_name == "glm-5.2":
+            raise CCProcessError("plain crash")
+        return _output(text="second peer reply", session_id="kimi-1")
+
+    loop._run_failover_peer = AsyncMock(side_effect=_peer)
+    result = await loop._try_roster_failover(
+        CCInvocation(prompt="x"), session={"id": "cc-1"},
+        channel=ChannelType.TERMINAL, model=CCModel.SONNET,
+        effort=EffortLevel.MEDIUM, prompt_text="x",
+    )
+    assert tried == ["glm-5.2", "kimi-k3"]
+    assert result is not None and "second peer reply" in result

--- a/tests/test_cc/test_invoker.py
+++ b/tests/test_cc/test_invoker.py
@@ -2474,3 +2474,112 @@ def test_classify_error_marks_an_oom_death_machine_readably(invoker):
     err = invoker._classify_error("", "", oom_note="probable cause: out-of-memory reap")
     assert err.oom_suspected is True
     assert invoker._classify_error("boom").oom_suspected is False
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_type_name"),
+    [
+        ("MCP server 'memory' failed to start", "CCMCPError"),
+        ("session not found", "CCSessionError"),
+        ("usage limit reached", "CCQuotaExhaustedError"),
+        ("Rate limit exceeded, status 429", "CCRateLimitError"),
+        ("thinking blocks cannot be modified", "CCSessionError"),
+    ],
+)
+def test_an_oom_attribution_survives_every_typed_classification(
+    invoker, text, expected_type_name
+):
+    """A process that SAID something on its way out still died of the same cause.
+
+    The sibling test above asserts the typed classification wins — and passed even
+    while the attribution was being dropped, because it only checked the TYPE. This
+    is the other half, and it is the half with teeth: the note used to be applied
+    only on the generic fallthrough, so any pre-kill output at all erased it.
+
+    That erasure picked the worst branch available in each case. An MCP or session
+    match with no flag enters stale-resume recovery and re-runs the same
+    memory-heavy work; a quota match can park the turn for a capacity reset that
+    was never the problem.
+    """
+    note = "probable cause: out-of-memory reap"
+    err = invoker._classify_error(text, "", oom_note=note)
+    assert type(err).__name__ == expected_type_name, "classification must not change"
+    assert err.oom_suspected is True, (
+        f"{expected_type_name} dropped the OOM attribution — this exit re-runs the "
+        "workload or parks it for the wrong reason"
+    )
+    assert note in str(err), "the human half of the attribution is missing too"
+
+
+def test_the_typed_state_survives_the_oom_annotation(invoker):
+    """The other direction: annotating must not cost the keyword state the typed
+    exceptions carry. `annotate_oom` rewrites args[0] in place rather than
+    reconstructing, precisely so `server_name` / `raw_text` cannot be dropped —
+    a rebuild would have to enumerate them and would silently lose the next field
+    someone adds."""
+    note = "probable cause: out-of-memory reap"
+    mcp = invoker._classify_error("MCP server 'memory' failed", "", oom_note=note)
+    assert mcp.server_name == "memory"
+    quota = invoker._classify_error("usage limit reached", "", oom_note=note)
+    assert quota.raw_text is not None and "usage limit" in quota.raw_text
+
+
+@pytest.mark.asyncio
+async def test_cleaning_up_a_survivor_does_not_claim_the_leader_s_exit(
+    invoker, monkeypatch
+):
+    """The OOM killer takes the CC leader; an MCP helper in its group outlives it.
+
+    `self_killed` answers ONE question — did WE produce the leader's exit code?
+    Only a kill landing on a LIVE leader can. Here the leader is already dead at
+    -9 and the cleanup SIGKILL is aimed at a survivor, so claiming it made the
+    probe decline a VALID attribution and sent the no-result path back to an
+    empty, and therefore successful-looking, CCOutput.
+
+    A common process-tree shape, silently recorded as work that completed — which
+    is precisely what this whole file exists to stop.
+    """
+    probe = _RecordingProbe.install(monkeypatch, None)
+    mock_proc = _reaped_stream_proc(returncode=-9)  # leader ALREADY reaped
+    monkeypatch.setattr("genesis.cc.invoker.process_group_alive", lambda _p: True)
+    monkeypatch.setattr("genesis.cc.invoker.kill_process_group", lambda _p: None)
+    monkeypatch.setattr("genesis.cc.invoker._ESCALATION_GRACE_S", 0)
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        await invoker.run_streaming(CCInvocation(prompt="hello"))
+
+    assert probe.calls, "the probe was never consulted — the test proves nothing"
+    assert probe.calls[-1]["returncode"] == -9
+    assert probe.calls[-1]["self_killed"] is False, (
+        "descendant cleanup was recorded as killing the leader, so a real OOM "
+        "attribution is discarded"
+    )
+
+
+@pytest.mark.asyncio
+async def test_killing_a_live_leader_is_still_declared_self_killed(
+    invoker, monkeypatch
+):
+    """The control on the other side, and the reason the flag exists at all: when
+    the leader is STILL ALIVE our escalation SIGKILL is what sets -9, and reporting
+    that as a probable OOM would replace a known true cause with a plausible wrong
+    one. Narrowing the condition must not lose this."""
+    probe = _RecordingProbe.install(monkeypatch, None)
+    mock_proc = _reaped_stream_proc(returncode=None)  # leader still alive
+    monkeypatch.setattr("genesis.cc.invoker.process_group_alive", lambda _p: True)
+    monkeypatch.setattr("genesis.cc.invoker.kill_process_group", lambda _p: None)
+    monkeypatch.setattr("genesis.cc.invoker._ESCALATION_GRACE_S", 0)
+
+    waits = {"n": 0}
+
+    async def _wait():
+        waits["n"] += 1
+        if waits["n"] >= 2:
+            mock_proc.returncode = -9
+
+    mock_proc.wait = _wait
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        await invoker.run_streaming(CCInvocation(prompt="hello"))
+
+    assert probe.calls[-1]["self_killed"] is True

--- a/tests/test_cc/test_invoker.py
+++ b/tests/test_cc/test_invoker.py
@@ -2292,3 +2292,185 @@ async def test_streaming_escalates_when_leader_exits_but_group_survives(
     import signal as _signal
 
     assert (99992, _signal.SIGKILL) in calls
+
+
+# ── The STREAMING path: the one a human is waiting on ──
+#
+# run_streaming is what foreground conversations and DirectSessionRunner take. Its
+# no-result branch builds a CCOutput with the default is_error=False regardless of
+# proc.returncode, so a subprocess reaped mid-stream was handed back as an ordinary
+# (empty) answer and DirectSessionRunner persisted `success=not output.is_error` as
+# True. Attribution has to reach this path too, or killed work is recorded as done.
+
+
+class _RecordingProbe:
+    """Stands in for OomProbe: the WIRING is what these tests are about.
+
+    Whether the counter itself attributes correctly is settled hermetically in
+    test_observability/test_oom_attribution.py against a constructed cgroup tree.
+    What cannot be settled there is whether the streaming path SAMPLES at all, and
+    what it tells the probe about the exit — in particular whether a SIGKILL we sent
+    ourselves is declared as such, since our own group-kill produces the identical
+    -9 an OOM reap does.
+    """
+
+    def __init__(self, note: str | None):
+        self._note = note
+        self.calls: list[dict] = []
+
+    def describe(self, returncode, *, self_killed=False, score_adjusted=False):
+        self.calls.append(
+            {
+                "returncode": returncode,
+                "self_killed": self_killed,
+                "score_adjusted": score_adjusted,
+            }
+        )
+        return self._note
+
+    @classmethod
+    def install(cls, monkeypatch, note):
+        probe = cls(note)
+        monkeypatch.setattr(
+            "genesis.cc.invoker.OomProbe.sample",
+            classmethod(lambda _cls, *a, **kw: probe),
+        )
+        return probe
+
+
+def _reaped_stream_proc(returncode=-9):
+    """A stream that ends WITHOUT a result event, on a process that died by SIGKILL."""
+    data = _make_stream_lines(
+        {"type": "system", "subtype": "init", "session_id": "s1"},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "par"}]}},
+    )
+    proc = AsyncMock()
+    proc.stdout = _make_async_stdout(data)
+    proc.stdin = _make_mock_stdin()
+    proc.stderr = _make_mock_stderr()
+    proc.wait = AsyncMock()
+    proc.terminate = MagicMock()
+    proc.kill = MagicMock()
+    proc.returncode = returncode
+    # pid deliberately left a MagicMock: process_group_alive/kill_process_group both
+    # refuse a non-int pid, so no real signal is ever aimed at a live pid.
+    return proc
+
+
+@pytest.mark.asyncio
+async def test_run_streaming_reaped_without_a_result_raises_instead_of_reporting_success(
+    invoker, monkeypatch
+):
+    """THE regression for the streaming half. Before this, an OOM-reaped streaming
+    session returned a CCOutput with is_error=False and DirectSession stored it as
+    success=True — killed work recorded as finished work, with no cause anywhere."""
+    probe = _RecordingProbe.install(monkeypatch, "probable cause: out-of-memory reap")
+    mock_proc = _reaped_stream_proc()
+
+    with (
+        patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        pytest.raises(CCProcessError) as caught,
+    ):
+        await invoker.run_streaming(CCInvocation(prompt="hello"))
+
+    assert "out-of-memory" in str(caught.value)
+    assert caught.value.oom_suspected is True, (
+        "callers branch on the flag, never on the message prose"
+    )
+    assert probe.calls == [
+        {"returncode": -9, "self_killed": False, "score_adjusted": False}
+    ], "the exit must be reported to the probe verbatim, with no kill of our own"
+
+
+@pytest.mark.asyncio
+async def test_run_streaming_without_an_attribution_still_returns_collected_text(
+    invoker, monkeypatch
+):
+    """The control, and the deliberate limit of this change. A nonzero exit ALONE is
+    ambiguous — the process may have crashed after streaming a usable answer — so the
+    existing return-what-we-collected behaviour is untouched when the counter did not
+    attribute. Only a positive attribution turns the return into a raise."""
+    probe = _RecordingProbe.install(monkeypatch, None)
+    mock_proc = _reaped_stream_proc()
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        output = await invoker.run_streaming(CCInvocation(prompt="hello"))
+
+    assert output.text == "par"
+    assert output.is_error is False
+    assert probe.calls, "the probe must still be consulted"
+
+
+@pytest.mark.asyncio
+async def test_run_streaming_declares_our_own_group_kill_as_self_killed(
+    invoker, monkeypatch
+):
+    """Our escalation SIGKILL sets returncode to -9 — indistinguishable from a reap by
+    exit code alone. If the streaming path did not declare it, a self-inflicted kill
+    that merely coincided with someone else's reap in the same cgroup would be
+    reported as a probable OOM: a plausible wrong cause replacing a known true one."""
+    probe = _RecordingProbe.install(monkeypatch, None)
+    mock_proc = _reaped_stream_proc(returncode=None)
+
+    # Leader still unreaped after the first bounded wait → the escalation branch runs
+    # its own group-kill; the second wait sees it dead.
+    waits = {"n": 0}
+
+    async def _wait():
+        waits["n"] += 1
+        if waits["n"] >= 2:
+            mock_proc.returncode = -9
+
+    mock_proc.wait = _wait
+
+    with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        await invoker.run_streaming(CCInvocation(prompt="hello"))
+
+    assert waits["n"] >= 2, "the escalation path did not run — test proves nothing"
+    assert probe.calls[-1]["self_killed"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_streaming_reports_an_unwritable_oom_score_as_unadjusted(
+    invoker, monkeypatch
+):
+    """The +500 preference is cited as the reason THIS process was the likely victim.
+    On a host where the procfs write is denied it was never established, so the
+    caller must pass the observed result rather than the intent."""
+    probe = _RecordingProbe.install(monkeypatch, None)
+    monkeypatch.setattr("genesis.cc.invoker.set_oom_score_adj", lambda *a, **kw: True)
+    with patch("asyncio.create_subprocess_exec", return_value=_reaped_stream_proc()):
+        await invoker.run_streaming(CCInvocation(prompt="hello"))
+    assert probe.calls[-1]["score_adjusted"] is True
+
+    probe = _RecordingProbe.install(monkeypatch, None)
+    monkeypatch.setattr("genesis.cc.invoker.set_oom_score_adj", lambda *a, **kw: False)
+    with patch("asyncio.create_subprocess_exec", return_value=_reaped_stream_proc()):
+        await invoker.run_streaming(CCInvocation(prompt="hello"))
+    assert probe.calls[-1]["score_adjusted"] is False
+
+
+def test_set_oom_score_adj_reports_whether_the_write_landed(monkeypatch, tmp_path):
+    """It returns a fact, not a hope: the annotation's victim premise is built on it."""
+    from genesis.cc import invoker as invoker_mod
+
+    written = tmp_path / "oom_score_adj"
+    monkeypatch.setattr(invoker_mod, "Path", lambda _p: written)
+    assert invoker_mod.set_oom_score_adj(1234, 500) is True
+    assert written.read_text() == "500"
+
+    class _Denied:
+        def write_text(self, _s):
+            raise PermissionError("read-only procfs")
+
+    monkeypatch.setattr(invoker_mod, "Path", lambda _p: _Denied())
+    assert invoker_mod.set_oom_score_adj(1234, 500) is False
+
+
+def test_classify_error_marks_an_oom_death_machine_readably(invoker):
+    """The message is prose for a human; the flag is what control flow reads.
+    conversation.py keys its stale-resume opt-out off this — pattern-matching the
+    message would silently break the moment the wording changed."""
+    err = invoker._classify_error("", "", oom_note="probable cause: out-of-memory reap")
+    assert err.oom_suspected is True
+    assert invoker._classify_error("boom").oom_suspected is False

--- a/tests/test_cc/test_invoker.py
+++ b/tests/test_cc/test_invoker.py
@@ -906,6 +906,52 @@ def test_classify_error_generic(invoker):
     assert isinstance(err, CCProcessError)
 
 
+def test_classify_error_carries_an_oom_cause_when_there_is_no_output(invoker):
+    """The reap arrives with NOTHING to classify, which is the whole problem.
+
+    SIGKILL writes no message, so stderr and stdout are empty and every pattern in
+    the classifier misses — the death lands on the generic error carrying an empty
+    string. That is the bare "[killed]" a session cannot distinguish from a crash or
+    a timeout, and re-arms the identical work after. The cause has to be attached
+    from outside the process's own output.
+    """
+    err = invoker._classify_error("", "", oom_note="probable cause: out-of-memory reap")
+    assert isinstance(err, CCProcessError)
+    assert "out-of-memory" in str(err)
+    assert "killed with no output" in str(err), (
+        "an empty source must still state WHAT happened, not carry only the annotation"
+    )
+
+
+def test_classify_error_without_an_oom_note_is_unchanged(invoker):
+    """The control: the note is additive. Every existing classification path must
+    behave exactly as before when no cause was derivable, or this observability
+    change would be quietly altering failure handling."""
+    err = invoker._classify_error("Something unknown went wrong")
+    assert isinstance(err, CCProcessError)
+    assert "probable cause" not in str(err)
+
+
+def test_classify_error_oom_note_does_not_override_a_typed_failure(invoker):
+    """A rate-limit death that happens to coincide with a reap elsewhere in the
+    cgroup must still classify as a rate limit — the typed exceptions drive retry and
+    park/resume behaviour, and demoting one to a generic error to deliver a string
+    would change control flow for an annotation."""
+    from genesis.cc.exceptions import CCQuotaExhaustedError, CCRateLimitError
+
+    note = "probable cause: out-of-memory reap"
+    assert isinstance(
+        invoker._classify_error("Rate limit exceeded, status 429", "", oom_note=note),
+        CCRateLimitError,
+    )
+    # The quota family too — it drives the park/resume layer, so a demotion here
+    # would strand a background session instead of parking it.
+    assert isinstance(
+        invoker._classify_error("usage limit reached", "", oom_note=note),
+        CCQuotaExhaustedError,
+    )
+
+
 def test_classify_error_thinking_block(invoker):
     """Thinking-block corruption on resume classified as session error."""
     from genesis.cc.exceptions import CCSessionError

--- a/tests/test_observability/test_oom_attribution.py
+++ b/tests/test_observability/test_oom_attribution.py
@@ -1,0 +1,164 @@
+"""A process reaped for memory must say so, and must never guess when it cannot know.
+
+Hermetic: every test builds a fake cgroup tree under tmp_path rather than reading the
+live one. A test that asserted against this machine's real counter would pass or fail
+on whatever else happened to be running, and could not exercise the case that matters
+(a reap DURING the watched window) at all.
+"""
+
+from __future__ import annotations
+
+import signal
+from pathlib import Path
+
+import pytest
+
+from genesis.observability import oom
+
+
+def _tree(root: Path, rel: str, kills: int | None) -> Path:
+    """Create a cgroup dir at ``rel``; ``kills=None`` means no memory.events at all."""
+    node = root / rel.lstrip("/")
+    node.mkdir(parents=True, exist_ok=True)
+    if kills is not None:
+        (node / "memory.events").write_text(
+            f"low 0\nhigh 0\nmax 0\noom 0\noom_kill {kills}\noom_group_kill 0\n"
+        )
+    return node
+
+
+@pytest.fixture
+def fake_cgroup(tmp_path, monkeypatch):
+    """A realistic v2 layout: a user slice holding BOTH a login scope and a
+    systemd-user-manager subtree, which is the shape that matters here."""
+    root = tmp_path / "cgroup"
+    _tree(root, "/", 0)
+    _tree(root, "user.slice", 0)
+    _tree(root, "user.slice/user-1000.slice", 7)
+    _tree(root, "user.slice/user-1000.slice/session-abc.scope", 0)
+    _tree(root, "user.slice/user-1000.slice/user@1000.service", 7)
+    _tree(root, "user.slice/user-1000.slice/user@1000.service/genesis-server.service", 0)
+    monkeypatch.setattr(oom, "_CGROUP_ROOT", root)
+
+    def _set_own(rel: str) -> None:
+        proc = tmp_path / "self_cgroup"
+        proc.write_text(f"0::{rel}\n")
+        monkeypatch.setattr(oom, "_PROC_SELF_CGROUP", proc)
+
+    _set_own("/user.slice/user-1000.slice/session-abc.scope")
+    return root, _set_own
+
+
+def test_a_sibling_scopes_reap_is_still_counted(fake_cgroup):
+    """THE regression. Genesis spawns CC through `systemd-run --scope --user`, which
+    puts the child in its own transient scope — a SIBLING of the caller's cgroup, not
+    a descendant. Watching the caller's own cgroup therefore reads 0 forever while
+    dispatched work is reaped invisibly, which is the exact failure this module
+    exists to end.
+
+    Caught by a live smoke test, not by reasoning: the first implementation resolved
+    to the nearest readable cgroup, which on this box is the login scope reading 0
+    while all 35 real reaps sat one level up.
+    """
+    root, set_own = fake_cgroup
+    set_own("/user.slice/user-1000.slice/session-abc.scope")
+    reading = oom.read_oom_kills()
+    assert reading is not None
+    count, where = reading
+    assert count == 7, "resolved to a cgroup that cannot see a sibling scope's reap"
+    assert where.endswith("user-1000.slice")
+
+
+def test_a_systemd_user_unit_resolves_to_the_same_slice(fake_cgroup):
+    """The invoker runs inside genesis-server, a systemd USER unit — a different
+    starting point that must land on the same watch, or the caller and the child it
+    spawns would be watching different counters."""
+    _root, set_own = fake_cgroup
+    set_own("/user.slice/user-1000.slice/user@1000.service/genesis-server.service")
+    reading = oom.read_oom_kills()
+    assert reading is not None and reading[0] == 7
+    assert reading[1].endswith("user-1000.slice")
+
+
+def test_an_explicit_cgroup_is_honoured_not_widened(fake_cgroup):
+    """A caller that names a cgroup means that one — widening it would silently
+    answer a broader question than was asked."""
+    reading = oom.read_oom_kills("/user.slice/user-1000.slice/session-abc.scope")
+    assert reading is not None and reading[0] == 0
+    assert reading[1].endswith("session-abc.scope")
+
+
+def test_an_unreadable_counter_is_unknown_not_zero(tmp_path, monkeypatch):
+    """None and 0 are different facts. Collapsing them would report "no OOM here" on
+    a host where the question was never asked — a confident wrong all-clear, which is
+    the failure mode this whole module is built to avoid."""
+    monkeypatch.setattr(oom, "_CGROUP_ROOT", tmp_path / "cgroup")
+    missing = tmp_path / "no_such_proc_file"
+    monkeypatch.setattr(oom, "_PROC_SELF_CGROUP", missing)
+    assert oom.read_oom_kills() is None
+    probe = oom.OomProbe.sample()
+    assert probe.available is False
+    assert probe.kills_since() is None
+    assert probe.describe(-signal.SIGKILL) is None, "must not attribute without evidence"
+
+
+def test_the_delta_is_what_attributes_not_the_absolute_count(fake_cgroup):
+    """A cgroup with a long history of reaps must not make every later death look
+    like an OOM. Only a reap DURING the watched window counts."""
+    root, _set_own = fake_cgroup
+    probe = oom.OomProbe.sample()
+    assert probe.baseline == 7
+    assert probe.kills_since() == 0
+    assert probe.describe(-signal.SIGKILL) is None, "a pre-existing count is not evidence"
+
+    _tree(root, "user.slice/user-1000.slice", 9)  # two reaps during the window
+    assert probe.kills_since() == 2
+    note = probe.describe(-signal.SIGKILL)
+    assert note and "2 process(es)" in note
+
+
+def test_a_counter_that_moves_backwards_invalidates_rather_than_going_negative(fake_cgroup):
+    """A cgroup recreated under us (a restarted unit) resets the counter. That
+    invalidates the comparison; it does not prove negative kills."""
+    root, _ = fake_cgroup
+    probe = oom.OomProbe.sample()
+    _tree(root, "user.slice/user-1000.slice", 1)
+    assert probe.kills_since() == 0
+    assert probe.describe(-signal.SIGKILL) is None
+
+
+@pytest.mark.parametrize(
+    "returncode,self_killed,expected",
+    [
+        (-signal.SIGKILL, False, True),  # the only attributing case
+        (-signal.SIGKILL, True, False),  # our own timeout/reaper — cause already known
+        (-signal.SIGTERM, False, False),  # not the OOM killer, whatever the counter says
+        (1, False, False),  # ordinary failure
+        (0, False, False),
+        (None, False, False),  # still running
+    ],
+)
+def test_attribution_requires_sigkill_and_not_our_own_kill(
+    fake_cgroup, returncode, self_killed, expected
+):
+    """Silence is the default in every ambiguous case, because this annotation exists
+    to be TRUSTED. A cause line that is sometimes invented is worse than a bare kill,
+    which at least does not mislead."""
+    root, _ = fake_cgroup
+    probe = oom.OomProbe.sample()
+    _tree(root, "user.slice/user-1000.slice", 8)  # a real reap in the window
+    note = probe.describe(returncode, self_killed=self_killed)
+    assert (note is not None) is expected
+
+
+def test_the_note_names_the_cgroup_it_watched(fake_cgroup):
+    """A delta from a broad cgroup is weaker evidence than one from a narrow cgroup,
+    so the reader must be able to see which was watched rather than take the
+    conclusion on faith."""
+    root, _ = fake_cgroup
+    probe = oom.OomProbe.sample()
+    _tree(root, "user.slice/user-1000.slice", 8)
+    note = probe.describe(-signal.SIGKILL)
+    assert note is not None
+    assert "user-1000.slice" in note
+    assert "probable cause" in note, "must not claim certainty it cannot have"

--- a/tests/test_observability/test_oom_attribution.py
+++ b/tests/test_observability/test_oom_attribution.py
@@ -162,3 +162,40 @@ def test_the_note_names_the_cgroup_it_watched(fake_cgroup):
     assert note is not None
     assert "user-1000.slice" in note
     assert "probable cause" in note, "must not claim certainty it cannot have"
+
+
+def test_the_victim_premise_is_printed_only_when_it_was_established(fake_cgroup):
+    """The note cites oom_score_adj=+500 as the reason THIS process was the likely
+    victim. That write can fail — denied procfs, a read-only mount, a process that
+    exited first — and `set_oom_score_adj` swallows the OSError. Asserting the
+    preference anyway would present an unverified premise as evidence, overstating
+    what a counter delta and a SIGKILL actually prove between them.
+    """
+    root, _ = fake_cgroup
+    probe = oom.OomProbe.sample()
+    _tree(root, "user.slice/user-1000.slice", 8)
+
+    established = probe.describe(-signal.SIGKILL, score_adjusted=True)
+    assert established is not None
+    assert "oom_score_adj=+500" in established
+    assert "likely victim" in established
+
+    unestablished = probe.describe(-signal.SIGKILL, score_adjusted=False)
+    assert unestablished is not None, "the reap itself is still worth reporting"
+    assert "oom_score_adj" not in unestablished
+    assert "likely victim" not in unestablished
+    # What the counter and the signal DO prove stays, either way.
+    for note in (established, unestablished):
+        assert "probable cause" in note
+        assert "1 process(es)" in note
+        assert "Reduce the working set" in note
+
+
+def test_the_victim_premise_defaults_to_unclaimed(fake_cgroup):
+    """A caller that does not know whether the write landed must not have the claim
+    made on its behalf — the default is silence about it, not assertion of it."""
+    root, _ = fake_cgroup
+    probe = oom.OomProbe.sample()
+    _tree(root, "user.slice/user-1000.slice", 8)
+    note = probe.describe(-signal.SIGKILL)
+    assert note is not None and "oom_score_adj" not in note


### PR DESCRIPTION
A subprocess reaped under memory pressure reaches its owner as a bare kill: a negative return code, no output, no cause. The owner cannot tell a reap from a crash from a timeout, so it re-arms the identical work and loses it again — invisibility does not merely lose the result, it induces the retry that loses more.

Closes the **observability half** of #1593. The advisory-nudge half stays open.

## Why not the kernel log

Measured on one install, same boot:

| source | count |
| --- | --- |
| cgroup counter | 35 |
| matching journal lines | 14 |

Most reaps leave nothing a session can find, and reading the journal needs permissions a subprocess may not have. The cgroup counter has neither problem, so attribution is a delta — sample before the work starts, read again once the process is dead.

## The part that decides whether this works at all

Which cgroup gets sampled. Getting it wrong makes the feature silently inert rather than broken, which is worse.

Sampling the caller's own cgroup reads zero forever: dispatched work is spawned into its own transient scope — a **sibling** of the caller, not a descendant — and on this host every reap is accounted one level above the login scope the caller sits in. The watch is therefore the enclosing per-user slice, which covers the caller, the service units and every transient scope, while still excluding the system slice so an unrelated daemon's death cannot be mistaken for ours.

Found by a live smoke test, not by reasoning. It is pinned from two different starting cgroups.

## What it will not claim

A delta proves a reap happened in that cgroup during the window — not that this process was the one chosen. So a note is emitted only when the process died by SIGKILL, the kill did not come from the system itself, and a readable counter actually increased. An unreadable counter is reported as **nothing, never as absence**: collapsing those would print "no memory problem here" for a host where the question was never asked.

Silence is the default in every ambiguous case, because a cause line that is sometimes invented is worse than a bare kill, which at least does not mislead.

Two things make the inference worth printing, both recorded next to it rather than assumed: dispatched subprocesses are deliberately given an OOM score adjustment that makes the kernel prefer them, so they are the intended victim; and a self-sent kill is already a known cause, so attribution is skipped there instead of guessed at.

## Blast radius

The note lands only on the generic failure, because that is where a reap arrives — SIGKILL writes no message, so every pattern in the classifier misses and the death falls through carrying an empty string. Typed failures are untouched, verified by test: the quota family drives the park/resume layer, and demoting one to a generic error to deliver a string would change control flow for an annotation.

## Verification

`ruff` clean. 1,601 passed across the two affected suites. Six mutations verified to turn the suite red, with every file restored byte for byte.

Tests are hermetic against a constructed cgroup tree — one reading the live counter would pass or fail on whatever else happened to be running, and could never exercise a reap *during* the watched window at all.

**Disproven if:** a note appears on a process the system killed itself; a host with a readable counter never produces one across a real reap; or any existing error classification changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Genesis now detects and reports confirmed kernel out-of-memory terminations.
  - OOM-related failures include clearer diagnostic information.
  - Ambiguous exits and unavailable memory counters remain unreported.

- **Bug Fixes**
  - Confirmed OOM failures no longer trigger stale-session recovery, repeated retries, or failover to additional peers.
  - Streaming executions no longer appear successful when externally terminated by the OOM killer.
  - User-initiated process termination is not misclassified as an OOM event.

- **Tests**
  - Added coverage for OOM detection, attribution, streaming behavior, and failover handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->