### PR TITLE
fix(routing): track Mistral Large as paid — free-tier entitlement was revoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Changed
+
+- **Mistral Large is now tracked as a paid provider.** Mistral removed the Large
+  model family from free-tier entitlement (unannounced; surfaces as
+  `403 tier_not_allowed`). The `mistral-large-free` provider is now flagged
+  `free: false`, so its spend is recorded at real rates ($0.5/$1.5 per MTok)
+  instead of $0, and call sites marked `never_pays` no longer route to it. The
+  provider name keeps its historical `-free` suffix to avoid churning the 30
+  chains that reference it. If your account tier still gets Large at $0,
+  override `free: true` in your local routing overlay.
+
 ### Added
 
 - **Telegram ping when someone replies to a marketing pitch.** When a real person

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -167,13 +167,18 @@ profiles:
     anti_sycophancy: B
     context_window: 131072
     cost_tier: moderate
-    cost_per_mtok_in: 2.00
-    cost_per_mtok_out: 6.00
+    # Paid-plan list price. Kept in step with the `free: false` flip on
+    # `mistral-large-free` in model_routing.yaml — that flip activates the
+    # profile-based cost fallback in litellm_delegate._cost_from_profile
+    # (used whenever litellm.completion_cost() raises), so a stale figure here
+    # is silently recorded as real spend. These were 2.00/6.00, which would
+    # have over-recorded every fallback-priced call by 4x.
+    cost_per_mtok_in: 0.50
+    cost_per_mtok_out: 1.50
     latency: moderate
     strengths:
       - JSON instruction following
       - multilingual mastery
-      - data privacy (free tier data NOT used for training)
     weaknesses:
       - creative output is boring
       - 128k context is small
@@ -181,11 +186,15 @@ profiles:
     best_for: [memory_consolidation, fact_extraction, triage, outreach_draft]
     avoid_for: [creative_writing, long_context_work]
     free_tier:
-      available: true
+      # Revoked 2026-08: Mistral removed Large from free-tier entitlement,
+      # surfacing as 403 tier_not_allowed. Consumers selecting on
+      # `require_free=True` must stop treating this as a $0 option — leaving it
+      # true is what makes a never-pays selector pick a paid model.
+      available: false
       provider: mistral
-      limits: "2 RPM, 4M tokens/month"
-    last_reviewed: "2026-04-01"
-    review_source: api_headers
+      note: "Large is paid-plan only since 2026-08; Small remains free-tier."
+    last_reviewed: "2026-09-03"
+    review_source: provider_pricing_page
 
   mistral-small:
     display_name: "Mistral Small (latest)"

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -20,7 +20,18 @@ providers:
     type: mistral
     model: mistral-large-latest
     profile: mistral-large-3
-    free: true
+    # `free` is account-tier semantics — what THIS account pays, not the model's
+    # list price (see _detect_mislabeled_free_openrouter's docstring in
+    # routing/config.py). Flipped to false 2026-09: Mistral removed Large from
+    # free-tier entitlement (403 tier_not_allowed measured on two independent
+    # free-tier accounts 2026-08-27, confirmed by Mistral support), and paid-plan
+    # pricing is $0.5/$1.5 per MTok — so cost is tracked at real rates and
+    # never_pays chains exclude it. If an install's account tier genuinely
+    # entitles Large at $0, override free: true in the local overlay. The
+    # provider NAME keeps its historical "-free" suffix deliberately: 30
+    # call-site chains reference it, and an in-place semantic fix beats a
+    # rename churn (same reasoning as the groq-free alias below).
+    free: false
     rpm_limit: 4
     open_duration_s: 120
   mistral-small-free:

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -232,9 +232,12 @@ def test_load_full_yaml(monkeypatch):
         "mistral-large-free",
     ]
 
-    # mistral-large-free provider (consolidated from mistral-free + mistral-large)
+    # mistral-large-free provider (consolidated from mistral-free + mistral-large).
+    # free: false since 2026-09: Mistral removed Large from free-tier entitlement
+    # (403 tier_not_allowed, measured on two independent free-tier accounts), so
+    # cost is tracked at paid rates and never_pays chains exclude it.
     ml = cfg.providers["mistral-large-free"]
-    assert ml.is_free is True
+    assert ml.is_free is False
     assert ml.model_id == "mistral-large-latest"
 
     # groq-free provider — MIGRATED 2026-08-06: Groq deprecated

--- a/tests/test_routing/test_model_profiles.py
+++ b/tests/test_routing/test_model_profiles.py
@@ -324,3 +324,74 @@ class TestStaleness:
         stale = reg.stale_profiles(days=30)
         assert len(stale) == 1
         assert stale[0].name == "no-date"
+
+
+# --- a paid provider's profile carries its FALLBACK PRICE ---------------------
+# `free: false` in model_routing.yaml activates the profile-based cost fallback
+# in litellm_delegate._cost_from_profile (used whenever litellm.completion_cost()
+# raises), so the profile's cost_per_mtok_* figures ARE the recorded spend on
+# that path. A stale figure there is not cosmetic — it is a wrong number in the
+# cost ledger. Found by review of PR #1619: flipping mistral-large-free to
+# free:false left its profile at 2.00/6.00 while the real paid rate is
+# 0.50/1.50, i.e. every fallback-priced call recorded at 4x.
+#
+# NOT tested here, deliberately: agreement between routing `free:` and profile
+# `free_tier.available`. They answer different questions and legitimately
+# differ. `free:` is ACCOUNT-tier semantics (does THIS account pay), while
+# `free_tier.available` is a fact about the model in the world. `glm51` is the
+# live proof: routing free=false because this install pays via zenmux, profile
+# free_tier.available=true because GLM really does offer "20M free tokens for
+# new users". An invariant forcing those to match would be false, and was
+# written and then withdrawn during this review. (`require_free`, the only
+# consumer of `free_tier.available`, has zero callers in src/ today.)
+
+
+def _repo_config_dir() -> Path:
+    return Path(__file__).resolve().parents[2] / "config"
+
+
+class TestPaidProviderProfilePricing:
+    """Invariant over the SHIPPED configs, not a fixture."""
+
+    @staticmethod
+    def _paid_providers_with_profiles():
+        import yaml
+
+        routing = yaml.safe_load((_repo_config_dir() / "model_routing.yaml").read_text())
+        return [
+            (name, spec["profile"])
+            for name, spec in (routing.get("providers") or {}).items()
+            if spec.get("profile") and not spec.get("free", False)
+        ]
+
+    def test_the_pairing_is_actually_discovered(self):
+        """Guard the guard — an empty list makes the test below vacuous."""
+        pairs = self._paid_providers_with_profiles()
+        assert len(pairs) >= 5, pairs
+        assert any(n == "mistral-large-free" for n, _ in pairs), pairs
+
+    def test_every_paid_provider_profile_has_a_nonzero_rate(self):
+        """A paid provider whose profile prices it at 0 records $0 spend on the
+        fallback path — silently, and forever."""
+        registry = ModelProfileRegistry(_repo_config_dir() / "model_profiles.yaml")
+        registry.load()
+
+        zero_rated = [
+            f"{provider} -> profile {profile_name!r} has "
+            f"in={p.cost_per_mtok_in} out={p.cost_per_mtok_out}"
+            for provider, profile_name in self._paid_providers_with_profiles()
+            if (p := registry.get(profile_name)) is not None
+            and not (p.cost_per_mtok_in > 0 and p.cost_per_mtok_out > 0)
+        ]
+        assert not zero_rated, zero_rated
+
+    def test_mistral_large_profile_matches_its_declared_paid_rate(self):
+        """The specific pair PR #1619 flipped, pinned so a later edit to either
+        file has to move both."""
+        registry = ModelProfileRegistry(_repo_config_dir() / "model_profiles.yaml")
+        registry.load()
+        p = registry.get("mistral-large-3")
+        assert p is not None
+        assert p.cost_per_mtok_in == 0.50
+        assert p.cost_per_mtok_out == 1.50
+        assert p.free_tier.get("available") is False


### PR DESCRIPTION
## What

Flip `free: true` → `false` on the `mistral-large-free` provider, with the
account-tier semantics documented at the provider block, the pinning test
updated, and a CHANGELOG entry.

## Why

Mistral removed the Large model family from free-tier entitlement (unannounced;
surfaces as `403 tier_not_allowed`, measured on two independent free-tier
accounts starting 2026-08-27 and confirmed by Mistral support). With paid access
now the realistic path, `free: true` had three wrong effects — enumerated from
every consumer of the flag:

| consumer | effect of the stale `free: true` |
|---|---|
| `litellm_delegate.py:246` | spend recorded as $0 (short-circuit) while list price is $0.5/$1.5 per MTok |
| `router.py:466` | `never_pays` call sites kept routing to a billable provider |
| `router.py:299` | the budget-exceeded gate never held it back |

## Measured outcomes (real loader, this diff)

- Exactly **3** `never_pays` sites drop the provider from their effective
  chains; each retains 2–4 free providers; **zero** sites are left without a
  free provider, so the `never_pays` config validation cannot raise.
- litellm prices `mistral/mistral-large-latest` at `5e-07/1.5e-06` per token,
  so cost tracking records real rates; the model_profiles fallback covers the
  exception path.
- Verify-RED: the updated test assertion failed against the pre-flip config
  (`assert True is False` at the `is_free` line), then 76 targeted routing
  tests green (`test_config`, `test_provider_criticality`,
  `test_litellm_delegate`, `test_integration`).

## Notes

- The provider NAME keeps its historical `-free` suffix: 30 call-site chains
  reference it, and an in-place semantic fix beats a rename churn (same
  reasoning as the `groq-free` alias).
- Known trade, disclosed in-code: an install whose account tier still entitles
  Large at $0 records phantom paid spend until it overrides `free: true` in its
  local routing overlay — the conservative direction versus invisible real
  spend on a paid account.
- Chain positions are unchanged: demoting the provider out of lead slots was
  considered and dropped — the provider currently answers, and chain order is a
  quality decision, not a cost-accounting one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Mistral Large is now treated as a paid provider rather than a free-tier option.
  - Usage tracking reflects the provider’s current input and output rates.
  - Requests restricted to free providers no longer route to Mistral Large.
  - Historical naming remains available for compatibility, with an explicit local override for free configurations.

- **Documentation**
  - The unreleased changelog now records Mistral Large’s paid status and pricing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->