### PR TITLE
fix(memory): enforce the wing vocabulary on the write path and at its source

### DIFF
--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -732,6 +732,31 @@ async def memory_expand(
     return results
 
 
+def _validate_wing(wing: str | None) -> None:
+    """Reject an out-of-vocabulary wing at the AGENT-FACING boundary.
+
+    Every MCP tool that accepts a `wing` must call this. A caller that can be
+    told the valid set should be told it: a silent coercion here teaches
+    nothing, and this parameter has been reported as "not exposed" by an agent
+    that never tried it. `MemoryStore.store()` coerces instead — see the
+    comment there for why the two tiers differ.
+
+    Measured 2026-09-02 on the live store: 18 of ~81k rows carry an
+    out-of-vocabulary wing, and 17 of those 18 have `dream_cycle_run_id IS
+    NULL` — they came through THIS boundary, not the LLM-internal synthesis
+    path. Guarding one tool and not its sibling just moves the door.
+    """
+    if wing is None or not wing.strip():
+        return
+    from genesis.memory.taxonomy import WINGS
+
+    if wing.strip() not in WINGS:
+        raise ValueError(
+            f"invalid wing {wing!r}; expected one of {sorted(WINGS)}. "
+            "Omit `wing` to let it be classified automatically."
+        )
+
+
 @mcp.tool()
 async def memory_store(
     content: str,
@@ -761,6 +786,7 @@ async def memory_store(
     memory_mod = _memory_mod()
     memory_mod._require_init()
     assert memory_mod._store is not None
+    _validate_wing(wing)
     # WS-3: dispatched sessions carry a session-level origin via env
     # (GENESIS_SESSION_ORIGIN, stamped by CCInvoker). Forward it so an
     # external-influenced session's writes stop landing first_party via the
@@ -1379,6 +1405,7 @@ async def memory_synthesize(
     memory_mod = _memory_mod()
     memory_mod._require_init()
     assert memory_mod._store is not None
+    _validate_wing(wing)
 
     resolved_tags = list(tags or [])
     if "synthesis" not in resolved_tags:

--- a/src/genesis/mcp/memory/core.py
+++ b/src/genesis/mcp/memory/core.py
@@ -95,7 +95,13 @@ async def memory_recall(
         compact: If True, return lightweight previews only (memory_id, preview,
             score, wing, room, memory_class, source). Use memory_expand to
             fetch full content for specific IDs. Saves tokens and ~500ms.
-        wing: Filter results to this structural domain (e.g., "infrastructure").
+        wing: Filter results to this structural domain. Controlled vocabulary —
+            one of: autonomy, career, channels, dev_workflow, employment,
+            general, infrastructure, integrations, learning, memory, research,
+            routing. Enumerated here, as `life_domain` below is, because this
+            docstring IS the schema the caller sees: an unlisted value is
+            refused, and a caller that can be told the valid set should not
+            have to learn it by failing a call.
         room: Filter results to this topic within a wing.
         life_domain: Filter by life domain: "personal", "employment", or "genesis".
         include_graph: If False, skip graph traversal (saves ~500ms per call).
@@ -138,6 +144,34 @@ async def memory_recall(
             return [
                 {"error": f"life_domain must be one of {sorted(LIFE_DOMAINS)}, got {life_domain!r}"}
             ]
+
+    # Same treatment for `wing`, the sibling filter parameter. Both Qdrant
+    # (`collections.py` applies wing as a hard `must` condition) and the FTS5
+    # post-filter drop every row on an out-of-vocabulary value, so a typo
+    # returns an empty list that reads as "no such memories exist" rather than
+    # "no such wing". Validity comes from `_validate_wing` so there is ONE
+    # definition of the vocabulary; only the failure SHAPE differs by
+    # direction — the write path raises, this read path reports.
+    if wing is not None:
+        try:
+            _validate_wing(wing)
+        except ValueError as exc:
+            note = ""
+            if mode == "drift":
+                # Drift mode discovers clusters dynamically and ignores
+                # wing/room entirely, so this call would have succeeded before
+                # the guard. Erroring is still right — the caller asked for a
+                # filter that does not exist — but say why it was ignorable.
+                note = " (note: drift mode ignores wing/room filters)"
+            return [{"error": f"{exc}{note}"}]
+        # Use the value we CHECKED, not the one we were handed. `_validate_wing`
+        # tests `wing.strip()`, but every downstream consumer compares the raw
+        # string verbatim — Qdrant as a `MatchValue` FieldCondition and the FTS5
+        # path as a post-filter. Forwarding the unstripped value would let
+        # `wing=" memory "` pass validation and still match zero rows, which is
+        # precisely the silent-empty-result this guard exists to eliminate.
+        # A blank/whitespace-only wing means "no filter", not "filter on empty".
+        wing = wing.strip() or None
 
     _t0 = _time.monotonic()
     memory_mod = _memory_mod()
@@ -735,16 +769,37 @@ async def memory_expand(
 def _validate_wing(wing: str | None) -> None:
     """Reject an out-of-vocabulary wing at the AGENT-FACING boundary.
 
-    Every MCP tool that accepts a `wing` must call this. A caller that can be
-    told the valid set should be told it: a silent coercion here teaches
+    Every MCP tool that accepts a `wing` must call this — all three of
+    `memory_recall`, `memory_store` and `memory_synthesize` do. A caller that
+    can be told the valid set should be told it: a silent coercion here teaches
     nothing, and this parameter has been reported as "not exposed" by an agent
     that never tried it. `MemoryStore.store()` coerces instead — see the
     comment there for why the two tiers differ.
 
-    Measured 2026-09-02 on the live store: 18 of ~81k rows carry an
-    out-of-vocabulary wing, and 17 of those 18 have `dream_cycle_run_id IS
-    NULL` — they came through THIS boundary, not the LLM-internal synthesis
-    path. Guarding one tool and not its sibling just moves the door.
+    One definition of validity, two failure SHAPES, chosen by direction. The
+    WRITE tools let this ValueError propagate: a rejected write must not look
+    like a completed one. The READ tool (`memory_recall`) catches it and
+    returns `[{"error": ...}]`, matching how its sibling `life_domain` filter
+    already reports a bad value in the same function. Raising there would be
+    the louder choice but not the better one — recall returns a list, and an
+    exception is a harsher failure mode than the empty-looking list it exists
+    to explain.
+
+    Guarding one tool and not its sibling just moves the door: all three
+    agent-facing tools write or filter on the same `memory_metadata.wing`
+    column, and `classify_life_domain()` returns "personal" for an unknown
+    wing, so one bad value corrupts a DERIVED field too. That holds regardless
+    of how many bad rows exist at any moment.
+
+    An earlier revision justified this with a row count ("18 of ~81k rows …,
+    17 of those 18 have `dream_cycle_run_id IS NULL`, so they came through
+    THIS boundary"). Retracted, not merely restated: re-measured 2026-09-03,
+    no wing-bearing table holds ANY out-of-vocabulary row, no store is ~81k,
+    and `dream_cycle_run_id` is NULL for every row in `memory_metadata` — so
+    that column discriminates nothing and the provenance inference never
+    followed from it, whatever the counts had been. The mechanism argument
+    above needs no corpus, which is why it replaces rather than supplements
+    the number.
     """
     if wing is None or not wing.strip():
         return

--- a/src/genesis/memory/dream_cycle.py
+++ b/src/genesis/memory/dream_cycle.py
@@ -1577,7 +1577,7 @@ Output JSON (no markdown fences, just raw JSON):
   "tags": ["<merged relevant tags — deduplicated>"],
   "confidence": <float 0-1, max of inputs as baseline>,
   "memory_class": "<fact|reference|procedure|insight>",
-  "wing": "<wing>",
+  "wing": "<one of: {wing_choices}>",
   "room": "<room>",
   "synthesis_notes": "<why these were merged, what was dropped>"
 }}
@@ -1606,12 +1606,33 @@ def _build_synthesis_prompt(
             f"--- Memory {i} (confidence {confidence}, source {source}, "
             f"created {created}) ---\n{content}"
         )
+    from genesis.memory.taxonomy import WINGS
+
     return _SYNTHESIS_PROMPT.format(
         wing=wing,
         room=room,
         n=len(cluster),
+        # Enumerate the controlled vocabulary rather than asking for free text.
+        # The write-path guard is a backstop; the prompt is the root cause, and
+        # a schema that says "<wing>" invites a plausible invention.
+        wing_choices="|".join(sorted(WINGS)),
         memories="\n\n".join(memory_blocks),
     )
+
+
+def _valid_wing_or(candidate: object, fallback: str) -> str:
+    """The candidate wing if it is in the controlled vocabulary, else fallback.
+
+    `dict.get(key, default)` only falls back on a MISSING key, so a model that
+    emits an invalid wing beats the caller's known-good default. Here the
+    fallback is the cluster's own wing — derived from the memories being
+    merged — which is better information than re-classifying from content.
+    """
+    from genesis.memory.taxonomy import WINGS
+
+    if isinstance(candidate, str) and candidate.strip() in WINGS:
+        return candidate.strip()
+    return fallback
 
 
 def _parse_synthesis_response(
@@ -1643,7 +1664,12 @@ def _parse_synthesis_response(
             "tags": data.get("tags", []),
             "confidence": data.get("confidence", 0.8),
             "memory_class": data.get("memory_class", "fact"),
-            "wing": data.get("wing", default_wing),
+            # Fall back on an INVALID wing too, not only a missing one. The
+            # cluster's own wing is known-valid and derived from the very
+            # memories being merged — strictly better than letting store()
+            # discard a bad value and re-guess from content, whose terminal
+            # fallback is general/uncategorized.
+            "wing": _valid_wing_or(data.get("wing"), default_wing),
             "room": data.get("room", default_room),
             "synthesis_notes": data.get("synthesis_notes", ""),
         }

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -16,6 +16,7 @@ from genesis.memory._locks import memory_id_lock
 from genesis.memory.classification import classify_memory
 from genesis.memory.embeddings import EmbeddingProvider, EmbeddingUnavailableError
 from genesis.memory.linker import MemoryLinker
+from genesis.memory.taxonomy import WINGS
 from genesis.memory.taxonomy import classify as classify_taxonomy
 from genesis.observability.call_site_recorder import record_last_run
 from genesis.observability.events import GenesisEventBus
@@ -232,6 +233,37 @@ class MemoryStore:
         # fans out to the FTS5 tag, the Qdrant payload, and memory_metadata.
         wing = _strip_kv_prefix(wing, "wing")
         room = _strip_kv_prefix(room, "room")
+
+        # An explicit wing outside the controlled vocabulary is DROPPED, not
+        # stored. Until now this branch only tested falsiness, so any string
+        # sailed through into the FTS5 `wing:` tag, the Qdrant payload and
+        # memory_metadata.wing — and classify_life_domain() silently returns
+        # "personal" for an unknown wing, so one bad value corrupted the life
+        # domain too. essential_knowledge.py filters junk wings on READ; that
+        # hid the problem instead of preventing it.
+        #
+        # COERCE rather than raise. NB the two sibling controlled-vocabulary
+        # fields in this same function RAISE — life_domain just above, and
+        # origin_class via derive_origin_class(). The divergence is deliberate:
+        # those two are effectively never passed by live callers (life_domain is
+        # DERIVED from wing; almost nothing sets it explicitly), whereas `wing`
+        # genuinely arrives from model output on live paths (dream_cycle), where
+        # raising would abort a whole synthesis run over one bad token. Falling
+        # back to auto-classification yields a VALID wing instead of a poisoned
+        # one. The agent-facing MCP tools raise instead — a caller that can be
+        # told the valid set should be. `room` is deliberately NOT enforced:
+        # measured, 18% of live rows have a room outside ROOMS[wing] and the
+        # shipped ego prompts instruct room="ego", so enforcing it symmetrically
+        # would coerce a fifth of writes and break the ego. It is descriptive,
+        # has no read-side filter, and gets no FTS tag — unlike wing, whose bad
+        # value also corrupts the derived life_domain.
+        if wing and wing not in WINGS:
+            logger.warning(
+                "Ignoring unknown wing %r (not in the controlled vocabulary); "
+                "falling back to auto-classification. Valid wings: %s",
+                wing, sorted(WINGS),
+            )
+            wing = None
 
         # Taxonomy classification — auto-classify if not explicitly provided
         if not wing or not room:

--- a/src/genesis/surplus/executor.py
+++ b/src/genesis/surplus/executor.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from genesis.db.crud import observations
+from genesis.memory.taxonomy import WINGS
 from genesis.surplus.intake import FENCE_RE
 from genesis.surplus.types import ExecutorResult, SurplusTask, TaskType
 
@@ -270,6 +271,28 @@ _CALL_SITES: dict[TaskType, str] = {
 _DEFAULT_CALL_SITE = "12_surplus_brainstorm"
 
 
+# The wing vocabulary is closed (`taxonomy.WINGS`). A prompt that RESTATES the
+# list can only teach the model names the system will not honour: the three
+# agent-facing MCP doors REJECT an out-of-vocabulary wing outright, and
+# `MemoryStore.store()` COERCES it back to auto-classification (see the comment
+# there — the two tiers differ deliberately). Either way the model's answer is
+# discarded, so deriving the list is the only spelling that stays true as
+# `WINGS` changes. This prompt shipped a hand-copied list naming `architecture`
+# and `identity`, neither of which is a wing.
+#
+# `general` is excluded because this audit exists to move memories OUT of it;
+# offering it back as a destination defeats the task.
+_WING_VOCABULARY = ", ".join(sorted(WINGS - {"general"}))
+
+# NB: the template is `.format(context=...)`-ed at dispatch, which is why every
+# other brace in it is doubled. A wing name containing a brace would raise
+# inside _build_prompt and kill the surplus task. WINGS members are
+# identifier-shaped today; the guard against a future one that is not lives in
+# test_wing_audit_prompt_offers_only_real_wings, not here — an import-time
+# assert would take the whole module down on a bad wing, and asserts vanish
+# under `python -O` anyway.
+
+
 # ── Task-specific prompt templates ──────────────────────────────────
 
 _TASK_PROMPTS: dict[TaskType, str] = {
@@ -476,9 +499,7 @@ _TASK_PROMPTS: dict[TaskType, str] = {
         "memories that should be reclassified into a more specific wing/room.\n\n"
         "Rules:\n"
         "- Only propose a new wing/room if 3+ memories clearly belong together\n"
-        "- Use existing wings when possible: learning, infrastructure, channels, "
-        "routing, memory, autonomy, dev_workflow, career, integrations, research, "
-        "architecture, identity\n"
+        "- Use existing wings when possible: " + _WING_VOCABULARY + "\n"
         "- Propose new rooms within existing wings before proposing new wings\n"
         "- Be conservative — uncategorized is fine if nothing clearly clusters\n\n"
         "Respond with ONLY a JSON object in this exact format:\n"

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -15,6 +15,7 @@ async def test_all_tools_registered():
     tools = await _get_tools()
     expected = [
         "memory_recall", "memory_store", "memory_extract", "memory_proactive",
+        "memory_synthesize",
         "memory_core_facts", "memory_stats",
         "observation_write", "observation_query", "observation_resolve",
         "conversation_history",
@@ -2028,3 +2029,95 @@ async def test_conversation_history_search_honors_scoping_and_cursor():
             )
         finally:
             mod._store, mod._db, mod._retriever = old_store, old_db, old_retriever
+
+
+# --- memory_store: `wing` is a controlled vocabulary at the agent boundary ---
+# The tool takes a `wing` parameter (it has since 2026-04-14), but nothing
+# validated it: any string was accepted and written through to the FTS5 tag,
+# the Qdrant payload and memory_metadata.wing. A background session once
+# reported that no memory tool exposed `wing` at all and encoded its intent as
+# a free-text tag instead — a caller that can be told the valid set should be.
+
+
+@pytest.mark.asyncio
+async def test_memory_store_rejects_unknown_wing():
+    from genesis.mcp.memory import core
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(return_value="mem-id")
+        with pytest.raises(ValueError) as exc:
+            await tools["memory_store"].fn("content", "src", wing="portfolio")
+
+    msg = str(exc.value)
+    assert "portfolio" in msg
+    # The error must TEACH the vocabulary, not merely refuse.
+    assert "career" in msg and "infrastructure" in msg, msg
+    # And it must refuse BEFORE writing anything.
+    mod.return_value._store.store.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_memory_store_accepts_a_valid_wing():
+    from genesis.mcp.memory import core
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(return_value="mem-id")
+        result = await tools["memory_store"].fn("content", "src", wing="career")
+
+    assert result == "mem-id"
+    assert mod.return_value._store.store.await_args.kwargs["wing"] == "career"
+
+
+@pytest.mark.asyncio
+async def test_memory_store_without_wing_is_unaffected():
+    """Omitting `wing` must still reach the store for auto-classification."""
+    from genesis.mcp.memory import core
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(return_value="mem-id")
+        result = await tools["memory_store"].fn("content", "src")
+
+    assert result == "mem-id"
+    assert mod.return_value._store.store.await_args.kwargs["wing"] is None
+
+
+@pytest.mark.asyncio
+async def test_memory_synthesize_rejects_unknown_wing():
+    """The SECOND agent-facing door into the same boundary.
+
+    Provenance on the 18 out-of-vocabulary rows in the live store: 17 have
+    dream_cycle_run_id IS NULL, i.e. they came through the MCP boundary rather
+    than the LLM-internal synthesis path. Guarding memory_store while leaving
+    memory_synthesize open just moves the door.
+    """
+    from genesis.mcp.memory import core
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(return_value="mem-id")
+        with pytest.raises(ValueError) as exc:
+            await tools["memory_synthesize"].fn("content", wing="portfolio")
+
+    assert "portfolio" in str(exc.value)
+    assert "career" in str(exc.value), str(exc.value)
+    mod.return_value._store.store.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_memory_synthesize_accepts_a_valid_wing():
+    from genesis.mcp.memory import core
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        mod.return_value._store = MagicMock()
+        mod.return_value._store.store = AsyncMock(return_value="mem-id")
+        result = await tools["memory_synthesize"].fn("content", wing="memory")
+
+    assert result == "mem-id"

--- a/tests/test_mcp/test_memory_mcp.py
+++ b/tests/test_mcp/test_memory_mcp.py
@@ -1,5 +1,6 @@
 """Tests for memory-mcp server — verify all tools are registered with correct signatures."""
 
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2121,3 +2122,118 @@ async def test_memory_synthesize_accepts_a_valid_wing():
         result = await tools["memory_synthesize"].fn("content", wing="memory")
 
     assert result == "mem-id"
+
+
+# --- memory_recall: the THIRD door, and the only one that READS ---
+# Enumerated rather than spot-checked: exactly three MCP tools take a `wing`
+# (memory_recall, memory_store, memory_synthesize). The two writers above
+# validate; the reader did not. Qdrant applies wing as a hard `must` condition
+# and the FTS5 path post-filters on it, so a typo returns [] — which an agent
+# reads as "no such memories exist" rather than "no such wing".
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_reports_an_unknown_wing_instead_of_returning_empty():
+    """A bad wing must be DISTINGUISHABLE from an honest empty result."""
+    from genesis.mcp.memory import core
+
+    tools = await _get_tools()
+    with patch.object(core, "_memory_mod") as mod:
+        result = await tools["memory_recall"].fn(query="anything", wing="architecture")
+
+    assert len(result) == 1 and "error" in result[0], result
+    msg = result[0]["error"]
+    assert "architecture" in msg
+    # Must TEACH the vocabulary, exactly as the write path does.
+    assert "career" in msg and "infrastructure" in msg, msg
+    # And it must refuse BEFORE the expensive search, not filter afterwards.
+    mod.assert_not_called()
+
+
+def test_memory_recall_docstring_lists_exactly_the_wing_vocabulary():
+    """The docstring IS the agent-facing schema, so it must not rot.
+
+    This PR's thesis is "stop hand-copying a closed vocabulary" — and its own
+    fix to `memory_recall`'s docstring introduced a fresh hand-copied copy, in
+    the one place with the highest blast radius: the MCP tool schema every
+    agent reads to decide what to pass. The prompt copy 200 lines away is
+    derived AND locked; this one was neither.
+
+    Deriving it is not available here (the docstring is the schema, extracted
+    statically), so it gets the lock instead. `WINGS` has changed membership
+    twice in this repo's history, so "correct today" is not a guarantee.
+    """
+    import re
+
+    from genesis.mcp.memory import core
+    from genesis.memory.taxonomy import WINGS
+
+    doc = core.memory_recall.fn.__doc__
+    m = re.search(r"one of: (.*?)\. Enumerated", doc, re.S)
+    assert m, "the `wing` docstring entry no longer enumerates the vocabulary"
+    listed = {w.strip() for w in m.group(1).replace("\n", " ").split(",")}
+    assert listed == WINGS, f"docstring drifted from WINGS: {listed ^ WINGS}"
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_forwards_the_wing_it_validated_not_the_raw_one():
+    """A padded wing must not pass validation and then match zero rows.
+
+    `_validate_wing` tests `wing.strip()`, but Qdrant applies `wing` as a hard
+    `must` FieldCondition and the FTS5 path compares it verbatim. Forwarding the
+    RAW value would let `" memory "` clear the guard and still return [] — the
+    exact silent-empty-result this guard exists to eliminate, surviving on a
+    whitespace edge. Blank means "no filter", not "filter on empty".
+    """
+    from genesis.mcp.memory import core
+
+    tools = await _get_tools()
+    seen = {}
+
+    with patch.object(core, "_memory_mod") as mod:
+
+        async def _capture(*args, **kwargs):
+            seen["wing"] = kwargs.get("wing")
+            raise RuntimeError("stop after the filter is decided")
+
+        mod.return_value._retriever.recall = _capture
+        with contextlib.suppress(RuntimeError):
+            await tools["memory_recall"].fn(query="q", wing="  memory  ")
+    assert seen.get("wing") == "memory", seen
+
+    seen.clear()
+    with patch.object(core, "_memory_mod") as mod:
+
+        async def _capture2(*args, **kwargs):
+            seen["wing"] = kwargs.get("wing")
+            raise RuntimeError("stop after the filter is decided")
+
+        mod.return_value._retriever.recall = _capture2
+        with contextlib.suppress(RuntimeError):
+            await tools["memory_recall"].fn(query="q", wing="   ")
+    assert seen.get("wing") is None, seen
+
+
+@pytest.mark.asyncio
+async def test_memory_recall_wing_validation_shares_one_definition_with_the_writers():
+    """No second vocabulary. Every WINGS member is accepted by the reader.
+
+    A per-tool copy of the list is the defect this whole PR is about — the
+    WING_AUDIT prompt carried one and put `architecture` into 11 live rows.
+
+    Scope, stated because this test's green is narrower than its name: it
+    catches a NARROWED vocabulary (verified RED by validating against
+    ``WINGS - {"employment"}``), which is the copy-the-list defect. It does NOT
+    catch validation being deleted outright — with no check at all every wing
+    is trivially "accepted" and this still passes. The sibling test above is
+    the deletion guard; verify both when either changes.
+    """
+    from genesis.mcp.memory import core
+    from genesis.memory.taxonomy import WINGS
+
+    tools = await _get_tools()
+    for wing in sorted(WINGS):
+        with patch.object(core, "_memory_mod") as mod:
+            mod.side_effect = RuntimeError("reached the search path")
+            with pytest.raises(RuntimeError):
+                await tools["memory_recall"].fn(query="q", wing=wing)

--- a/tests/test_memory/test_dream_cycle.py
+++ b/tests/test_memory/test_dream_cycle.py
@@ -1336,3 +1336,51 @@ class TestShieldDrainRecheck:
         )
         assert report["shield_members_skipped"] == 0
         assert report["would_merge"] == 1
+
+
+class TestSynthesisWingVocabulary:
+    """An invalid wing from the model must not beat the cluster's own wing.
+
+    `dict.get(key, default)` falls back only when the key is ABSENT, so a model
+    emitting `"wing": "architecture"` won over `default_wing`. MemoryStore then
+    drops the invalid value and re-classifies from CONTENT, whose terminal
+    fallback is ("general", "uncategorized") — the exact pile the WING_AUDIT
+    surplus task exists to drain. The write-path guard would have fed the
+    backlog it was added to protect.
+    """
+
+    def test_invalid_wing_falls_back_to_the_cluster_wing(self):
+        from genesis.memory.dream_cycle import _parse_synthesis_response
+
+        response = json.dumps(
+            {"content": "merged", "wing": "architecture", "room": "whatever"}
+        )
+        result = _parse_synthesis_response(response, "memory", "retrieval")
+        assert result["wing"] == "memory", result["wing"]
+
+    def test_valid_wing_from_the_model_is_kept(self):
+        from genesis.memory.dream_cycle import _parse_synthesis_response
+
+        response = json.dumps({"content": "merged", "wing": "learning"})
+        result = _parse_synthesis_response(response, "memory", "retrieval")
+        assert result["wing"] == "learning"
+
+    def test_missing_wing_still_falls_back(self):
+        from genesis.memory.dream_cycle import _parse_synthesis_response
+
+        result = _parse_synthesis_response(
+            json.dumps({"content": "merged"}), "memory", "retrieval"
+        )
+        assert result["wing"] == "memory"
+
+    def test_prompt_enumerates_the_controlled_vocabulary(self):
+        """LLM-first: the guard is a backstop, the prompt is the root cause.
+        A schema line reading "<wing>" invites a plausible invention."""
+        from genesis.memory.dream_cycle import _build_synthesis_prompt
+        from genesis.memory.taxonomy import WINGS
+
+        cluster = [{"id": "m1", "payload": {"content": "a"}}]
+        prompt = _build_synthesis_prompt(cluster, "memory", "retrieval")
+        for wing in sorted(WINGS):
+            assert wing in prompt, f"{wing} missing from the synthesis prompt"
+        assert '"<wing>"' not in prompt

--- a/tests/test_memory/test_store_tagging.py
+++ b/tests/test_memory/test_store_tagging.py
@@ -162,3 +162,67 @@ def test_extraction_kwargs_include_source_pipeline():
     )
     kwargs = extractions_to_store_kwargs(extraction)
     assert kwargs["source_pipeline"] == "harvest"
+
+
+# --- Controlled-vocabulary enforcement for `wing` ---------------------------
+# Before this, the wing branch only tested falsiness, so ANY explicit string
+# reached the FTS5 `wing:` tag, the Qdrant payload and memory_metadata.wing —
+# and classify_life_domain() returns "personal" for an unknown wing, so one bad
+# value corrupted the life domain too. essential_knowledge.py filtered junk
+# wings on READ, which hid the problem rather than preventing it.
+
+
+@pytest.mark.asyncio()
+async def test_store_drops_unknown_wing_and_auto_classifies(store, caplog):
+    """An out-of-vocabulary wing must never be persisted. The store COERCES
+    (rather than raising) because internal callers pass LLM-derived values."""
+    with patch("genesis.memory.store.upsert_point") as mock_upsert, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        with caplog.at_level("WARNING"):
+            await store.store("test content", "src", wing="portfolio")
+
+    from genesis.memory.taxonomy import WINGS
+
+    payload = mock_upsert.call_args.kwargs["payload"]
+    assert payload["wing"] != "portfolio"
+    assert payload["wing"] in WINGS, payload["wing"]
+    assert "wing:portfolio" not in payload["tags"], payload["tags"]
+    # The companion metadata write must not carry it either.
+    assert mock_mem.create_metadata.call_args.kwargs["wing"] != "portfolio"
+    assert mock_mem.create_metadata.call_args.kwargs["wing"] in WINGS
+    # The second half of the defect: classify_life_domain() returns "personal"
+    # for an unknown wing, so a bad value corrupts a DERIVED field too. There is
+    # no life_domain column on memory_metadata — the payload is the only place
+    # this is observable.
+    from genesis.memory.taxonomy import LIFE_DOMAINS
+
+    assert payload["life_domain"] in LIFE_DOMAINS, payload["life_domain"]
+    # Silent coercion would be its own trap — the drop is logged, by THIS
+    # logger at WARNING (any WARNING anywhere mentioning the value would
+    # otherwise satisfy this).
+    assert any(
+        r.name == "genesis.memory.store"
+        and r.levelname == "WARNING"
+        and "portfolio" in r.getMessage()
+        for r in caplog.records
+    ), caplog.text
+
+
+@pytest.mark.asyncio()
+async def test_store_preserves_a_valid_explicit_wing(store):
+    """The guard must not disturb the supported case — an explicit, valid wing
+    still wins outright over auto-classification."""
+    with patch("genesis.memory.store.upsert_point") as mock_upsert, \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        await store.store("test content", "src", wing="career", room="applications")
+
+    payload = mock_upsert.call_args.kwargs["payload"]
+    assert payload["wing"] == "career"
+    assert "wing:career" in payload["tags"]
+    assert mock_mem.create_metadata.call_args.kwargs["wing"] == "career"

--- a/tests/test_surplus/test_executor.py
+++ b/tests/test_surplus/test_executor.py
@@ -615,3 +615,54 @@ async def test_gather_context_excludes_infrastructure_alerts():
     typed_calls = [c for c in q.call_args_list if "type" in c.kwargs]
     for c in typed_calls:
         assert "exclude_types" not in c.kwargs
+
+
+# --- The WING_AUDIT prompt teaches a vocabulary the system will not honour ---
+# It asks a model to propose wing reclassifications, and it shipped a
+# hand-copied list naming `architecture` and `identity`, neither of which is in
+# `taxonomy.WINGS`. That is a defect on the mechanism alone: the agent-facing
+# MCP doors reject an out-of-vocabulary wing and `MemoryStore.store()` coerces
+# it away, so any name here that is not a wing can only produce work the system
+# discards.
+#
+# Deliberately NOT claimed: that this prompt caused specific corrupt rows.
+# `executor.py` states 11 lines above the prompt that wing-audit findings are
+# observational-only (posted for review, not auto-applied), and the traced path
+# — intake -> _route_to_knowledge -> MemoryStore.store() — passes no explicit
+# wing at all. It is a plausible contributor (it teaches an agent a word the
+# agent may later hand to `memory_store`), not a demonstrated cause. Row counts
+# quoted from an earlier revision of this branch did not reproduce against a
+# live store — re-measured, no wing-bearing table held any out-of-vocabulary
+# row — so they are omitted rather than restated. The mechanism argument above
+# needs no corpus, and a public repo is no place to state the size of an
+# install's private memory store.
+
+
+def test_wing_audit_prompt_offers_only_real_wings():
+    """Every wing the prompt names must be one the write path will accept."""
+    import re
+
+    from genesis.memory.taxonomy import WINGS
+    from genesis.surplus.executor import _TASK_PROMPTS
+
+    prompt = _TASK_PROMPTS[TaskType.WING_AUDIT]
+    line = next(ln for ln in prompt.split("\n") if "existing wings" in ln)
+    offered = {w.strip() for w in line.split(":", 1)[1].split(",")}
+
+    assert offered, "the prompt names no wings at all"
+    assert not (offered - WINGS), f"prompt offers non-wings: {sorted(offered - WINGS)}"
+    # The two the hand-copied list actually shipped, named so a regression reads
+    # as the specific defect rather than a generic set mismatch.
+    assert "architecture" not in offered and "identity" not in offered
+
+    # The template is `.format(context=...)`-ed at dispatch (executor.py), so a
+    # wing name carrying a format brace would raise inside _build_prompt and
+    # kill the surplus task. Guarded here rather than at import — see the note
+    # beside _WING_VOCABULARY.
+    assert "{" not in line and "}" not in line, line
+
+    # Derived, not restated: the prompt must carry the WHOLE vocabulary, or the
+    # next wing added to WINGS is one this audit can never propose. `general`
+    # is the sole exclusion — this task exists to move memories OUT of it.
+    assert offered == WINGS - {"general"}
+    assert not re.search(r"\bgeneral\b", line)


### PR DESCRIPTION
## Problem

`wing` is a controlled vocabulary (`taxonomy.py` `WINGS`, 12 members) but the
write path only ever tested falsiness — `if not wing or not room:` is an or-fill,
never a membership check. Any string reached the FTS5 `wing:` tag, the Qdrant
payload and `memory_metadata.wing`. And `classify_life_domain()` returns
`"personal"` for an unknown wing, so one bad value also corrupts a **derived**
field.

The read side had already been patched to filter junk wings out of the L1 view.
The write side never was — the symptom was hidden rather than prevented.

**Measured on the live store (read-only): 18 rows already carry an
out-of-vocabulary wing** — `architecture` ×11, plus `wing=channels`,
`technology`, `strategy`, `outreach`, `identity`, `genesis`, `cooperation`.

## Fix — three levels, because the first attempt closed only one

**Both agent-facing MCP doors.** `memory_synthesize` takes the same `wing` into
the same store and was initially left unguarded. That turned out to matter more
than it looked: pulling provenance on the 18 corrupt rows, **17 have
`dream_cycle_run_id IS NULL`** — they came through the MCP boundary, *not* the
synthesis path the coercion tier had been justified by. Guarding one tool and not
its sibling would only have moved the door.

**`MemoryStore.store()` coerces** rather than raising, because live callers pass
model output and one bad token must not abort a synthesis run. The two sibling
controlled-vocabulary fields in that same function (`life_domain`,
`origin_class`) *do* raise, so the divergence is now stated in the code instead
of left for a maintainer to "fix" in one direction.

**`dream_cycle` at the source.** `.get("wing", default)` falls back only on a
*missing* key, so an invalid wing beat the cluster's own known-valid one,
survived to the store, got dropped, and was re-classified from content — whose
terminal fallback is `general/uncategorized`, the exact backlog the `WING_AUDIT`
surplus task exists to drain. The guard could have **fed the pile it was added to
protect**. The synthesis prompt now enumerates the legal values instead of asking
for `"<wing>"`; the guard is a backstop, the prompt was the cause.

## What is deliberately *not* enforced

`room`. Measured: **14,667 of 81,343 rows (18%)** have a room outside
`ROOMS[wing]`, and the shipped ego prompts instruct `room="ego"`. Enforcing
symmetry would coerce a fifth of all writes and break the ego. `room` is
descriptive — one consumer, no read filter, no FTS tag, corrupts no derived
field. That reasoning is now a comment beside the guard so the next reviewer
doesn't "complete" the symmetry.

## Verification

**7 mutations RED, zero survivors**, covering both directions — guard absent
*and* guard over-broad (a guard that also drops *valid* wings), with the
`memory_synthesize` guard mutated on its own call site after the first sweep's
anchor was found to have matched `memory_store`'s.

| mutation | result |
|---|---|
| store guard removed / over-broad | RED / RED |
| MCP raise removed / over-broad | RED / RED |
| synthesize guard removed | RED |
| dream_cycle invalid-wing-wins-again | RED |
| dream_cycle prompt unenumerated | RED |

164 tests pass; `ruff check src/ tests/` clean. The acceptance replay is the
original defect: `memory_store(wing="portfolio")` — the exact value a background
session tried — now raises with the valid set.

## Not in scope

The 18 existing rows are **data repair**, not part of a write-path fix. Tracked
as a follow-up for a numbered migration that reconciles `memory_metadata`, the
Qdrant payload and the FTS tag together and re-derives `life_domain`. Note the
dashboard Memory tab does not filter to `WINGS`, so those values stay visible
until that lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added controlled validation for memory “wing” values across storage, recall, and synthesis workflows.
  * Added clearer errors for invalid recall inputs and automatic fallback behavior for unrecognized values.
  * Prompts now list the supported wing vocabulary to improve consistent classification.

* **Bug Fixes**
  * Prevented invalid wing values from being stored or propagated.
  * Preserved valid explicit wings during automatic classification.
  * Ensured invalid synthesis results fall back to the appropriate cluster wing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->