### PR TITLE
feat(routing): wire Zhipu GLM-4 Flash as a free provider ahead of paid fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **GLM-4 Flash as a free routing provider (Zhipu direct).** A new
+  `zhipu-glm-flash` provider reaches Zhipu's published free model on the
+  general OpenAI-compatible endpoint using the standard `ZHIPU_API_KEY`. It
+  sits immediately ahead of the paid DeepSeek fallbacks in 12 chains — never
+  ahead of a deliberately-paid lead, and not promoted above the free
+  providers that precede the paid fallback — so overflow that previously
+  went straight to paid models now tries a free, vendor-independent lane
+  first. Installs without the key are unaffected (the provider
+  auto-disables, as always); installs that set `ZHIPU_API_KEY` for the CC
+  roster's glm failover share that key here, so it must be valid on the
+  general endpoint (a coding-plan-only key just 401s this lane —
+  the chain continues past it).
+
 - **Telegram ping when someone replies to a marketing pitch.** When a real person
   replies to one of Genesis's cold marketing emails, you now get one brief
   Telegram notification — the sender and the first line of their reply.

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -65,6 +65,34 @@ profiles:
     last_reviewed: "2026-08-19"
     review_source: nvidia_nim_live_probe
 
+  glm-4-flash:
+    display_name: "GLM-4 Flash"
+    provider: zhipu
+    api_id: "glm-4-flash"
+    intelligence_tier: B
+    reasoning: C
+    instruction_following: B
+    anti_sycophancy: C
+    context_window: 128000
+    cost_tier: free
+    cost_per_mtok_in: 0.0
+    cost_per_mtok_out: 0.0
+    latency: low
+    strengths:
+      - fast responses (~3s on live probe)
+      - clean bare JSON without fencing (live probe)
+      - free-tier daily capacity independent of every other vendor
+    weaknesses:
+      - small-model reasoning depth
+      - quality beyond smoke-probe UNMEASURED on real Genesis workloads
+    best_for: [fact_extraction, outcome_classification]
+    avoid_for: [deep_reflection, code_work, math_heavy]
+    free_tier:
+      available: true
+      limits: "published ~1K req/day (unverified against account)"
+    last_reviewed: "2026-09-03"
+    review_source: zai_general_endpoint_live_probe
+
   glm-5.1:
     display_name: "GLM-5.1"
     provider: zenmux

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -242,6 +242,23 @@ providers:
     # Not promoted above the free providers that precede the paid fallback,
     # and never ahead of a deliberately-paid lead, until a real success rate
     # is measured on live fallback traffic.
+    # AND NOT IN A CHALLENGE CHAIN AT ALL, at any position. The placement rule
+    # above is about COST ORDER; a challenge site has a second requirement the
+    # cost rule cannot see. Its entire job is to DISAGREE with a verdict another
+    # model already produced — `dream_cycle_entity_challenge` deprecates a
+    # memory on agreement, `entity_adjudication_challenge` irreversibly merges
+    # two entities, and `20_adversarial_counterargument` is the executor's
+    # devil's advocate. Anti-sycophancy is the load-bearing capability at all
+    # three, and this profile rates it C with quality UNMEASURED on real
+    # workloads (config/model_profiles.yaml: glm-4-flash). A challenger that
+    # agrees is not a challenger: it silently turns a two-model gate into a
+    # one-model gate while still looking like two.
+    # The profile already said so — `avoid_for` names deep reflection and
+    # `best_for` is fact_extraction / outcome_classification — so this is the
+    # model's own stated fit, not a new policy invented here. Codex named the
+    # two entity sites (P1, PR #1626); the executor's devil's advocate is the
+    # same class and was not named. `TestChallengeChainsRejectWeakChallengers`
+    # pins the rule for whatever provider is added next.
     # rpd_limit is the published free-tier daily cap (~1K req/day, not yet
     # verified against this account). No consumer exists in THIS tree — it
     # is a forward declaration for the daily-budget ledger (built on a
@@ -411,7 +428,6 @@ call_sites:
     chain:
     - openrouter-gpt55
     - nvidia-nim-deepseek
-    - zhipu-glm-flash
     - openrouter-deepseek-v4
     - openrouter-qwen36plus
     default_paid: true
@@ -484,7 +500,6 @@ call_sites:
   dream_cycle_entity_challenge:
     chain:
     - nvidia-nim-deepseek
-    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     retry_profile: background
   # Entity-NODE merge-vs-distinct adjudication (entity_adjudication drainer).
@@ -504,7 +519,6 @@ call_sites:
   entity_adjudication_challenge:
     chain:
     - nvidia-nim-deepseek
-    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     retry_profile: background
   # One-shot supervised wing backfill (scripts/wing_backfill.py) — batch

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -220,6 +220,43 @@ providers:
     base_url: https://zenmux.ai/api/v1
     free: false
     open_duration_s: 120
+  zhipu-glm-flash:
+    # Zhipu/Z.AI direct, GENERAL endpoint (api/paas/v4) with the standard
+    # ZHIPU_API_KEY — the type's env resolution finds it by convention.
+    # NEVER point this at a coding-plan endpoint or key: Z.AI's coding-plan
+    # surface is restricted to approved tools and misuse risks the account.
+    # glm-4-flash is Zhipu's published free model (live probe at this
+    # endpoint: 200, clean bare JSON, ~3s; glm-4.5-flash was rejected for
+    # this lane — reasoning-by-default, 10-18s, fence-wrapped JSON even with
+    # thinking disabled). Billing-vs-free unverified against an account
+    # statement — measure alongside the success-rate acceptance below.
+    # NOTE: ZHIPU_API_KEY is SHARED with the CC roster's glm failover
+    # (cc_roster.yaml auth_env) — it must be a key valid on the GENERAL
+    # endpoint. A coding-plan-only key would 401 this lane on every fallback
+    # pass (graceful — the chain continues — but it is a dead hop and log
+    # noise; and never point such a key at coding endpoints from here).
+    # Placement: inserted immediately BEFORE the first paid DeepSeek member,
+    # only where that member is not the chain lead. Pre-existing free
+    # last-resort tails that already sat below the paid members keep their
+    # positions (so in a few chains this provider ranks above those tails).
+    # Not promoted above the free providers that precede the paid fallback,
+    # and never ahead of a deliberately-paid lead, until a real success rate
+    # is measured on live fallback traffic.
+    # rpd_limit is the published free-tier daily cap (~1K req/day, not yet
+    # verified against this account). No consumer exists in THIS tree — it
+    # is a forward declaration for the daily-budget ledger (built on a
+    # sibling branch, PR #1624) and is silently ignored until that lands.
+    # rpm_limit 20 is a conservative self-throttle, PROVISIONAL — Zhipu's
+    # real free-tier RPM is unmeasured; revisit with the success-rate
+    # measurement.
+    type: zhipu
+    model: glm-4-flash
+    profile: glm-4-flash
+    base_url: https://api.z.ai/api/paas/v4
+    free: true
+    rpm_limit: 20
+    rpd_limit: 1000
+    open_duration_s: 120
   minimax-m25:
     type: minimax
     model: MiniMax-M2.7
@@ -309,6 +346,7 @@ call_sites:
     - gemini-free
     - nvidia-nim-deepseek
     - mistral-large-free
+    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
   # V4 placeholder: cognitive state IS actively maintained today, but via direct
   # DB writes (awareness/loop.py, cc/reflection_bridge*.py), NOT this call site.
@@ -373,6 +411,7 @@ call_sites:
     chain:
     - openrouter-gpt55
     - nvidia-nim-deepseek
+    - zhipu-glm-flash
     - openrouter-deepseek-v4
     - openrouter-qwen36plus
     default_paid: true
@@ -396,6 +435,7 @@ call_sites:
   dream_cycle_synthesis:
     chain:
     - nvidia-nim-deepseek
+    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     - groq-free
     retry_profile: background
@@ -444,6 +484,7 @@ call_sites:
   dream_cycle_entity_challenge:
     chain:
     - nvidia-nim-deepseek
+    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     retry_profile: background
   # Entity-NODE merge-vs-distinct adjudication (entity_adjudication drainer).
@@ -463,6 +504,7 @@ call_sites:
   entity_adjudication_challenge:
     chain:
     - nvidia-nim-deepseek
+    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     retry_profile: background
   # One-shot supervised wing backfill (scripts/wing_backfill.py) — batch
@@ -472,11 +514,13 @@ call_sites:
     chain:
     - nvidia-nim-deepseek
     - groq-free
+    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     retry_profile: background
   27_pre_execution_assessment:
     chain:
     - glm51
+    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     default_paid: true
     retry_profile: user_facing
@@ -531,6 +575,7 @@ call_sites:
   38_procedure_extraction:
     chain:
     - nvidia-nim-deepseek
+    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
     - groq-free
@@ -550,6 +595,7 @@ call_sites:
     chain:
     - mistral-large-free
     - gemini-free
+    - zhipu-glm-flash
     - openrouter-deepseek-v4
     default_paid: true
     description: Salvage a deep-reflection CC session that ended in prose (no
@@ -565,6 +611,7 @@ call_sites:
   43_task_retrospective:
     chain:
     - nvidia-nim-deepseek
+    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
     - mistral-large-free
@@ -574,6 +621,7 @@ call_sites:
   44_task_premortem:
     chain:
     - nvidia-nim-deepseek
+    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
     - mistral-large-free
@@ -644,6 +692,7 @@ call_sites:
     - gemini-free
     - mistral-large-free
     - openrouter-free
+    - zhipu-glm-flash
     - openrouter-deepseek-v4-flash
     default_paid: true
     retry_profile: background

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -222,6 +222,26 @@ Optimized for specific tasks: speed, video reasoning, and massive memory ingesti
   critical analysis or design review.
 - Software Design: Great at reading code, but bad at writing it from scratch.
 
+### GLM-4 Flash (Zhipu direct)
+
+- **API ID:** `glm-4-flash` (Zhipu/Z.AI GENERAL endpoint `api/paas/v4`)
+- **Role:** Free structured-output fallback, vendor-independent of every other free lane
+- **Context:** 128k tokens
+- **Intelligence Tier:** B
+- **Cost:** Free (Zhipu's published free model)
+- **Free Tier:** see Free Tier Terms below
+
+**Best At (live-probed 2026-09):**
+1. Speed: ~3s round trip on a live probe from a Genesis install.
+2. Clean structured output: returned bare unfenced JSON on the probe —
+   unlike glm-4.5-flash, which reasons by default (10–18s) and fences its
+   JSON even with thinking disabled.
+
+**Worst For:**
+- Deep reasoning / code / math — small-model depth; quality beyond the smoke
+  probe is UNMEASURED on real Genesis workloads (it rides ahead of the paid
+  DeepSeek fallbacks only, until a real success rate is measured).
+
 ### Llama 4 Scout
 
 - **API ID:** `meta-llama/llama-4-scout` (OpenRouter)
@@ -425,6 +445,19 @@ Loose guidance — not prescriptive. Use your judgment based on the task require
 - EU/EEA/UK/Switzerland restricted on free tier
 - Full 1M token context window available on free tier
 - Free tier limits can change without warning (Google cut limits 50-80% in Dec 2025)
+
+### Zhipu / Z.AI (GLM direct)
+- **Endpoint:** `api.z.ai/api/paas/v4` (the GENERAL OpenAI-compatible endpoint;
+  `open.bigmodel.cn/api/paas/v4` is the mainland twin — both measured accepting
+  the same general key on a live completion probe, 2026-09)
+- **Setup:** `ZHIPU_API_KEY` in secrets.env — NOTE this var is shared with the
+  CC roster's glm failover (`cc_roster.yaml`), so it must be a GENERAL-endpoint
+  key, not a coding-plan-only key
+- **Limits:** published ~1K requests/day on flash models — NOT yet verified
+  against a live account; treat as provisional
+- **NEVER** point tooling at the coding-plan endpoints (`api/coding/…`) or use a
+  coding-plan key here: that surface is restricted to officially approved apps
+  and misuse risks the account.
 
 ### Nvidia NIM
 - **Endpoint:** build.nvidia.com

--- a/src/genesis/dashboard/webui/js/dashboard.js
+++ b/src/genesis/dashboard/webui/js/dashboard.js
@@ -2619,7 +2619,21 @@
         },
 
         // Map env var names → provider_type values from model_routing.yaml.
-        // MAINTENANCE: update when adding new providers to config/model_routing.yaml.
+        //
+        // A MISSING entry fails silently and in the worse direction: with no
+        // mapping, secretHealthStatus() returns the raw PERSISTED status, so the
+        // Settings row keeps reporting the key as configured while that
+        // provider's circuit breaker is open and its chains are falling through
+        // to paid fallbacks. Nothing on screen says so.
+        //
+        // "MAINTENANCE: update when adding a provider" was the whole mechanism,
+        // and a convention that must be REMEMBERED is a convention that gets
+        // missed — measured 2026-09-04, TWO of the thirteen key-bearing provider
+        // types were absent: zhipu (added in this PR, Codex P2 #1626) and
+        // nvidia_nim, which had been missing since it was added and which the
+        // review did not name. `test_every_keyed_provider_type_is_mapped` now
+        // fails CI on the next omission instead of leaving it to be noticed.
+        // (ollama and lmstudio are deliberately absent — local, no key.)
         _KEY_TO_PROVIDER_TYPES: {
           API_KEY_GROQ: ['groq'],
           API_KEY_MISTRAL: ['mistral'],
@@ -2635,6 +2649,8 @@
           API_KEY_CEREBRAS: ['cerebras'],
           API_KEY_GITHUB: ['github'],
           API_KEY_SAMBANOVA: ['sambanova'],
+          API_KEY_NVIDIA_NIM: ['nvidia_nim'],
+          ZHIPU_API_KEY: ['zhipu'],
         },
         secretHealthStatus(keyEntry) {
           if (keyEntry.status === 'not_set') return 'not_set';

--- a/src/genesis/routing/litellm_delegate.py
+++ b/src/genesis/routing/litellm_delegate.py
@@ -55,7 +55,7 @@ _TYPE_TO_PREFIX: dict[str, str] = {
     "ollama": "ollama",
     "lmstudio": "openai",  # OpenAI-compatible with base_url
     "qwen": "openai",  # Alibaba — use OpenAI-compatible endpoint
-    "glm": "openai",  # Zhipu — use OpenAI-compatible endpoint
+    "zhipu": "openai",  # Zhipu GLM — OpenAI-compatible endpoint (api/paas/v4)
     "zenmux": "openai",  # ZenMux — OpenAI-compatible aggregator
     "minimax": "openai",  # MiniMax — OpenAI-compatible with base_url
     "deepseek": "deepseek",  # DeepSeek — native LiteLLM support

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -133,7 +133,8 @@ def test_load_full_yaml(monkeypatch):
     # unwired openrouter-qwen3coder (delisted qwen/qwen3-coder:free slug).
     # 2026-08-19: 26 → 25 after removing dead nvidia-nim-kimi (moonshotai/kimi-k2.6
     # 404-for-account on NIM); nvidia-nim-deepseek repointed v4-pro → v4-flash-0731.
-    assert len(cfg.providers) == 25
+    # 2026-09-03: 25 → 26 adding zhipu-glm-flash (Zhipu direct, general endpoint).
+    assert len(cfg.providers) == 26
     assert "lmstudio-30b" not in cfg.providers
     assert "github-o3mini" not in cfg.providers
     assert "openrouter-deepseek-r1" not in cfg.providers  # removed from config
@@ -236,6 +237,23 @@ def test_load_full_yaml(monkeypatch):
     ml = cfg.providers["mistral-large-free"]
     assert ml.is_free is True
     assert ml.model_id == "mistral-large-latest"
+
+    # zhipu-glm-flash (2026-09): Zhipu direct on the GENERAL endpoint with the
+    # published free flash model. Inserted immediately before the first paid
+    # DeepSeek member, only where that member is not the chain lead; free
+    # last-resort tails already below the paid members keep their positions
+    # (success rate unmeasured beyond a live smoke probe — no promotion).
+    zp = cfg.providers["zhipu-glm-flash"]
+    assert zp.provider_type == "zhipu"
+    assert zp.model_id == "glm-4-flash"
+    assert zp.is_free is True
+    assert zp.base_url == "https://api.z.ai/api/paas/v4"
+    chain_38 = cfg.call_sites["38_procedure_extraction"].chain
+    pos = chain_38.index("zhipu-glm-flash")
+    assert chain_38[pos + 1] in (
+        "openrouter-deepseek-v4-flash", "openrouter-deepseek-v4",
+    ), "zhipu-glm-flash must sit immediately ahead of the paid fallback"
+    assert pos > 0, "zhipu-glm-flash must not lead a chain yet (unmeasured)"
 
     # groq-free provider — MIGRATED 2026-08-06: Groq deprecated
     # llama-3.3-70b-versatile (shutdown 2026-08-16) → openai/gpt-oss-120b, its

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from genesis.routing.config import load_config, load_config_from_string
 
@@ -735,3 +737,155 @@ def test_detect_mislabeled_free_openrouter_flags_paid_slug_marked_free():
     # (substring checks collide: "or-paid" is inside "or-paid-as-free").
     flagged_names = {f.split(":", 1)[0] for f in flagged}
     assert flagged_names == {"or-paid-as-free", "or-curated-bad"}, flagged
+
+
+_CONFIG_DIR = Path(__file__).resolve().parents[2] / "config"
+
+
+@pytest.fixture(scope="module")
+def routing_config() -> dict:
+    """The SHIPPED routing config, parsed as data.
+
+    Read straight from the file rather than through load_config(): these two
+    classes assert properties of what the repo ships — which chains exist and
+    which providers sit in them — and a loader that merged a local overlay would
+    make the assertions describe this install instead.
+    """
+    return yaml.safe_load((_CONFIG_DIR / "model_routing.yaml").read_text())
+
+
+@pytest.fixture(scope="module")
+def profiles_config() -> dict:
+    return yaml.safe_load((_CONFIG_DIR / "model_profiles.yaml").read_text())
+
+
+# ─── a challenge chain has a second requirement the cost rule cannot see ──────
+
+
+_CHALLENGE_ROLE = re.compile(r"challenge|adversarial|devil", re.IGNORECASE)
+#: Anti-sycophancy grades that disqualify a model from a challenge chain.
+_WEAK_ANTI_SYCOPHANCY = {"C", "D", "F"}
+
+
+def _iter_call_sites(routing: dict):
+    """Every (name, site) with a chain, wherever it sits in the file."""
+
+    def walk(node, name=""):
+        if isinstance(node, dict):
+            if isinstance(node.get("chain"), list):
+                yield name, node
+            else:
+                for k, v in node.items():
+                    yield from walk(v, k)
+
+    yield from walk(routing)
+
+
+class TestChallengeChainsRejectWeakChallengers:
+    """A challenge site's entire job is to DISAGREE with a verdict another model
+    already produced, so anti-sycophancy is its load-bearing capability — and a
+    challenger that agrees is not a challenger. It silently turns a two-model
+    gate into a one-model gate while still looking like two.
+
+    The consequences are not symmetric with an ordinary chain's:
+    `dream_cycle_entity_challenge` deprecates a memory on agreement,
+    `entity_adjudication_challenge` irreversibly merges two entities, and
+    `20_adversarial_counterargument` is the executor's devil's advocate. Codex
+    named the first two (P1, PR #1626); the third is the same class and was not
+    named, which is why this is a rule over the whole role rather than a fix to
+    two chains.
+
+    The role is derived from the site's name and description rather than a
+    hand-kept list, so a challenge site added tomorrow is covered without anyone
+    remembering to add it here.
+    """
+
+    def _sites(self, routing):
+        return [
+            (name, site)
+            for name, site in _iter_call_sites(routing)
+            if _CHALLENGE_ROLE.search(f"{name} {site.get('description', '')}")
+        ]
+
+    def test_the_role_predicate_actually_matches_something(self, routing_config):
+        """Guard the guard: a predicate that matched nothing would make every
+        assertion below vacuously true."""
+        assert len(self._sites(routing_config)) >= 3
+
+    def test_no_challenge_chain_contains_a_weak_challenger(
+        self, routing_config, profiles_config
+    ):
+        providers = routing_config.get("providers") or {}
+        profiles = profiles_config.get("profiles") or profiles_config
+        offenders = []
+        for name, site in self._sites(routing_config):
+            for member in site["chain"]:
+                key = (providers.get(member) or {}).get("profile")
+                grade = (profiles.get(key) or {}).get("anti_sycophancy")
+                if grade in _WEAK_ANTI_SYCOPHANCY:
+                    offenders.append(f"{name}: {member} (anti_sycophancy={grade})")
+        assert not offenders, (
+            "a model rated C or worse on anti-sycophancy sits in a chain whose "
+            "job is to disagree — the gate looks like two models and behaves "
+            "like one: " + "; ".join(offenders)
+        )
+
+
+class TestEveryKeyedProviderTypeIsMappedInTheDashboard:
+    """A provider type absent from `_KEY_TO_PROVIDER_TYPES` fails silently and in
+    the worse direction: `secretHealthStatus()` falls back to the raw persisted
+    status, so Settings reports the key as configured while that provider's
+    breaker is open and its chains fall through to paid fallbacks.
+
+    The old mechanism was a comment saying "MAINTENANCE: update when adding new
+    providers". Measured 2026-09-04, two of thirteen key-bearing types were
+    missing — the one this PR adds, and one that had been absent since it landed.
+    A convention that must be remembered is the thing being replaced here.
+    """
+
+    _LOCAL_BASE_URL = re.compile(
+        r"localhost|127\.0\.0\.1|\$\{(?:OLLAMA_URL|LM_STUDIO_URL)"
+    )
+
+    def _keyed_types(self, routing: dict) -> set[str]:
+        """Provider types that need an API key.
+
+        Derived from the config — a type whose every provider points at a local
+        base_url needs no key — rather than an exemption list that would drift
+        the same way the mapping did.
+        """
+        by_type: dict[str, list[str]] = {}
+        for provider in (routing.get("providers") or {}).values():
+            ptype = provider.get("type")
+            if ptype:
+                by_type.setdefault(ptype, []).append(str(provider.get("base_url") or ""))
+        return {
+            t
+            for t, urls in by_type.items()
+            if not (urls and all(self._LOCAL_BASE_URL.search(u) for u in urls))
+        }
+
+    def _mapped_types(self) -> set[str]:
+        js = (
+            Path(__file__).resolve().parents[2]
+            / "src/genesis/dashboard/webui/js/dashboard.js"
+        ).read_text()
+        block = re.search(r"_KEY_TO_PROVIDER_TYPES:\s*\{(.*?)\n\s*\},", js, re.S)
+        assert block, "the mapping moved — retarget this test rather than deleting it"
+        return set(re.findall(r"'([a-z0-9_]+)'", block.group(1)))
+
+    def test_the_local_predicate_leaves_real_providers_in_scope(self, routing_config):
+        """Guard the guard: if the 'needs no key' predicate ever widened to
+        everything, the assertion below would pass while checking nothing."""
+        keyed = self._keyed_types(routing_config)
+        assert "openrouter" in keyed and "groq" in keyed
+        assert "ollama" not in keyed and "lmstudio" not in keyed
+
+    def test_every_keyed_provider_type_is_mapped(self, routing_config):
+        missing = sorted(self._keyed_types(routing_config) - self._mapped_types())
+        assert not missing, (
+            "provider type(s) with no key mapping in dashboard.js: "
+            f"{missing}. Settings will report their keys as configured even "
+            "while the breaker is open and chains fall through to paid "
+            "fallbacks. Add KEY_NAME: ['<type>'] to _KEY_TO_PROVIDER_TYPES."
+        )

--- a/tests/test_routing/test_litellm_delegate.py
+++ b/tests/test_routing/test_litellm_delegate.py
@@ -74,6 +74,10 @@ def _install_litellm_exceptions(mock_litellm):
         ("lmstudio", "TBD", "openai/TBD"),
         ("openrouter", "best-free", "openrouter/best-free"),
         ("mistral", "mistral-large-latest", "mistral/mistral-large-latest"),
+        # Zhipu GLM — OpenAI-compatible via base_url; the type name matches
+        # the shipped ZHIPU_API_KEY convention so key resolution needs no
+        # install-local env aliases.
+        ("zhipu", "glm-4-flash", "openai/glm-4-flash"),
     ],
 )
 def test_build_model_string(provider_type, model_id, expected):


### PR DESCRIPTION
## What

Wire Zhipu GLM as a free routing provider: a new `zhipu-glm-flash` provider on
Zhipu's **general** OpenAI-compatible endpoint (`api/paas/v4`) serving the
published free `glm-4-flash` model, inserted into 12 call-site chains
immediately ahead of the paid DeepSeek fallbacks. Plus: the unused `"glm"` key
in the delegate's `_TYPE_TO_PREFIX` renamed to `"zhipu"` (so standard
`{TYPE}_API_KEY` env resolution finds the shipped `ZHIPU_API_KEY` convention
with no install-local aliases), a `model_profiles` entry, config/delegate test
pins, models.md + CHANGELOG.

## Why (measured)

Paid DeepSeek absorbs ~2,000 calls/day of free-tier overflow. Zhipu is a free,
vendor-independent lane that was already reachable: live probes from this
branch measured **200 in ~3.2s with clean bare JSON** on `glm-4-flash` at both
general endpoints. `glm-4.5-flash` was rejected for this lane on the same
probes — reasoning-by-default (10–18s) and fence-wrapped JSON even with
thinking explicitly disabled.

## Placement rule (exact, and deliberately conservative)

Inserted **immediately before the first paid DeepSeek member, only where that
member is not the chain lead** (12 of 17 candidate chains; the other 5 lead
with paid DeepSeek deliberately — quality choices, untouched, including the
invariant-locked `judge`). Not promoted above the free providers that precede
the paid fallback; pre-existing free last-resort tails below the paid members
keep their positions. Promotion beyond this waits on a **measured success rate
over real fallback traffic** — the acceptance measurement is tracked and
includes verifying the published ~1K req/day cap and billing against the
account.

## Notes

- `ZHIPU_API_KEY` is shared with the CC roster's glm failover, so it must be a
  general-endpoint key. A coding-plan-only key 401s this lane gracefully (the
  chain continues past it). Documented at the provider block, models.md, and
  the CHANGELOG. A per-provider `api_key_env` override was considered and
  deferred — the graceful 401 bounds the cost, and the override is new surface
  this PR does not need.
- `rpd_limit: 1000` is a forward declaration for the daily-budget ledger
  (sibling PR #1624) — verified silently ignored by this tree's parser until
  that lands. `rpm_limit: 20` is a provisional self-throttle, marked as such.
- Installs without the key are unaffected: the provider auto-disables
  (`has_api_key=False`), chains intact.

## Review + verification

Adversarial pre-push review (fresh-context architect) applied in-branch:
shared-key documentation, overclaim rewording at three sites ("never above
other free providers" was false in 4 chains — the true rule is now stated),
provenance added to every measured claim. One reviewer finding was refuted by
source and recorded as such. Verify-RED on both new test groups (config pins
RED against the pre-change yaml; the delegate `zhipu` row RED against a
`glm`-keyed map), restores hash-verified. 106 targeted tests green; 12/12
chain insertions verified by re-parse with no other chain touched; rename
blast radius enumerated (zero `type: glm` users repo-wide); ruff +
subsystem-map guards clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Zhipu GLM-4 Flash as a free, low-latency model option for structured-output workflows.
  * Added GLM-4 Flash as a fallback across multiple routing workflows, before paid DeepSeek alternatives.
  * Routing automatically skips the provider when no compatible API key is configured.

* **Documentation**
  * Documented GLM-4 Flash capabilities, limitations, availability, endpoint requirements, and free-tier usage terms.

* **Bug Fixes**
  * Improved compatibility with Zhipu’s OpenAI-compatible API format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->