### PR TITLE
fix(cc): tell a conversation session it can change its own model

### DIFF
--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -81,6 +81,71 @@ _BG_RESEARCH_ROUTING = (
 )
 
 
+def _session_control_block(
+    channel: ChannelType | str | None,
+    model,
+    effort,
+    session_id: str | None,
+) -> str:
+    """Tell a conversation session what it currently IS, and that it can change it.
+
+    Two failures this closes, both MEASURED on a Telegram DM session 2026-09-02.
+
+    1. The session was asked to "switch to Opus, medium effort" and replied that
+       it could not change its own model. It could: `session_config` has existed
+       on the health MCP since long before, its docstring literally says "Call
+       when the user asks to switch models ('use opus', 'switch to haiku')", and
+       `GENESIS_SESSION_ID` — the id that tool needs — was in its environment.
+       It had even run `env` and seen that variable 31 seconds earlier. No
+       capability was missing; the session simply held a false belief about
+       itself. A tool the model does not know it has is not a capability.
+
+    2. The model/effort a session believes it is running are stated ONLY in the
+       fresh-session system prompt. A resumed turn sends no system prompt, so
+       after any /model or /effort switch the session's self-description goes
+       stale and stays stale for the life of the conversation.
+
+    Both are fixed by re-stating the CURRENT values every turn, which is why this
+    rides `--append-system-prompt` alongside `--resume` (the same delivery the
+    topic-context block uses) rather than living in the assembler — an assembler
+    change would reach fresh sessions only, i.e. it would have missed the very
+    turn that failed.
+
+    Deliberately NOT a natural-language intent matcher. The failure was
+    self-knowledge, not parsing: no pattern over the USER's words would have
+    corrected a model that believed the capability did not exist.
+
+    Scoped to OWNER-ATTENDED channels via ``origin_delivery_supported`` — i.e.
+    Telegram today. That predicate was written for a different purpose (can a
+    background result be delivered back here) but it is the correct one here for
+    an independent reason: it is the same "the owner is on the other end" test.
+
+    Withheld everywhere else, deliberately:
+    - TERMINAL: the human already has Claude Code's own /model and /effort, and
+      a terminal resume carries NO system prompt at all (an invariant
+      test_second_message_resumes pins).
+    - WEB (OpenClaw): `/v1/chat/completions` is registered with NO auth gate and
+      the invocation is stamped supervised=False, origin=external_untrusted.
+      Telling THAT session it can switch its own model — and never to refuse —
+      hands an anonymous caller a lever the user is supposed to own. Quality
+      over cost is the USER's tradeoff to make.
+    - VOICE / WHATSAPP: no ConversationLoop call sites exist for them today.
+    """
+    if not origin_delivery_supported(channel):
+        return ""
+    return (
+        "\n\n## Changing your own model / effort\n"
+        f"You are currently running model={model}, effort={effort}. "
+        "These are NOT fixed for the conversation. When the user asks you to "
+        "switch (\"use opus\", \"switch to haiku\", \"think harder\", \"low effort\"), "
+        f'call `mcp__genesis-health__session_config` with session_id="{session_id}" '
+        "(not the shorter id in the [Clock | Session: x] tag). The change takes "
+        "effect on your next response, so say what you switched to and continue. "
+        "You DO have this capability — never claim otherwise; if the tool returns "
+        "an error, report that error verbatim rather than hiding it."
+    )
+
+
 def _apply_research_routing(system_prompt: str | None, channel) -> str | None:
     """Append the long-research routing nudge for channels the delivery model can
     actually report back to.
@@ -284,6 +349,13 @@ class ConversationLoop:
                 )
                 resume_id = None
 
+            # Self-knowledge on BOTH new and resumed turns — see
+            # _session_control_block. Same slot as the routing nudge below and
+            # for the same reason: a resumed turn carries no system prompt.
+            _ctl = _session_control_block(channel, model, effort, session["id"])
+            if _ctl:
+                system_prompt = (system_prompt + _ctl) if system_prompt else _ctl
+
             # Non-terminal (dispatched) channels end the turn after replying, so long
             # inline work is killed at the CC bg-wait ceiling with nothing left to report
             # back — nudge routing to the durable background lane (delivers back via
@@ -357,6 +429,7 @@ class ConversationLoop:
                 fallback = await self._try_contingency(
                     prompt_text, system_prompt, channel,
                     session_id=session["id"],
+                    was_resume=resume_id is not None,
                 )
                 if fallback is not None:
                     return fallback
@@ -629,6 +702,14 @@ class ConversationLoop:
                     else:
                         system_prompt = topic_ctx
 
+            # Self-knowledge, injected for BOTH new and resumed sessions for the
+            # same reason as the topic context above: a resumed turn carries no
+            # system prompt, so anything stated only at session start is both
+            # absent from every later turn AND stale after a /model switch.
+            _ctl = _session_control_block(channel, model, effort, session["id"])
+            if _ctl:
+                system_prompt = (system_prompt + _ctl) if system_prompt else _ctl
+
             # Route long research off this turn to the durable background lane
             # (dispatched channels end the turn). See _apply_research_routing.
             system_prompt = _apply_research_routing(system_prompt, channel)
@@ -715,6 +796,7 @@ class ConversationLoop:
                 fallback = await self._try_contingency(
                     prompt_text, system_prompt, channel,
                     session_id=session["id"],
+                    was_resume=resume_id is not None,
                 )
                 if fallback is not None:
                     return fallback
@@ -919,8 +1001,14 @@ class ConversationLoop:
             session_id=session_id,
         )
         system_prompt = await self._enrich_with_context(system_prompt, prompt_text)
-        # A stale-resume retry rebuilds the prompt from scratch — re-apply the
-        # dispatched-channel research routing so the nudge isn't lost on recovery.
+        # A stale-resume retry rebuilds the prompt from scratch — re-apply both
+        # the dispatched-channel research routing and the session-control block,
+        # so neither is lost on recovery.
+        # This path always has a freshly assembled prompt, so a plain append is
+        # enough; the block is "" on TERMINAL and appends nothing.
+        system_prompt += _session_control_block(
+            channel, model, effort, session_id,
+        )
         system_prompt = _apply_research_routing(system_prompt, channel)
         return CCInvocation(
             prompt=prompt_text,
@@ -1085,7 +1173,12 @@ class ConversationLoop:
             # session being resumed). The peer runs a FRESH session, so re-assemble
             # the identity/context — otherwise the peer answers with no Genesis
             # persona/instructions.
-            if base_inv.system_prompt is None:
+            # Keyed on the RESUME FACT, not on `system_prompt is None`. The
+            # latter is a proxy that silently breaks the moment anything is
+            # appended to a resumed turn's prompt (the research-routing nudge
+            # already does this on Telegram), leaving the peer with only that
+            # fragment as its whole identity.
+            if base_inv.resume_session_id is not None:
                 system_prompt = await self._assembler.assemble(
                     db=self._db, model=str(model), effort=str(effort),
                     session_id=session["id"],
@@ -1540,6 +1633,7 @@ class ConversationLoop:
         system_prompt: str | None,
         channel: ChannelType,
         session_id: str | None = None,
+        was_resume: bool = False,
     ) -> str | None:
         """Attempt to route through API contingency dispatcher.
 
@@ -1548,8 +1642,11 @@ class ConversationLoop:
         if self._contingency is None:
             return None
 
-        # Rebuild system prompt if it was None (resume case)
-        if system_prompt is None:
+        # Rebuild the system prompt for the resume case. Keyed on the resume
+        # FACT: a resumed turn's prompt may be a non-empty fragment (an appended
+        # nudge) rather than None, and shipping that fragment alone to a raw
+        # router LLM would answer as Genesis with no Genesis identity at all.
+        if was_resume or system_prompt is None:
             try:
                 system_prompt = await self._assembler.assemble(
                     db=self._db, model="sonnet", effort="medium",

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -1202,15 +1202,27 @@ class ConversationLoop:
             # appended to a resumed turn's prompt (the research-routing nudge
             # already does this on Telegram), leaving the peer with only that
             # fragment as its whole identity.
+            # The re-assembled identity COMPOSES with whatever fragments the
+            # turn already assembled (topic context with the live proposal
+            # board, session-control block, research-routing nudge) — it never
+            # replaces them. Those fragments are the only place that per-turn
+            # context exists on a resume; dropping them made "approve this
+            # proposal" arrive at the peer with no referent.
             if base_inv.resume_session_id is not None:
-                system_prompt = await self._assembler.assemble(
+                identity = await self._assembler.assemble(
                     db=self._db, model=str(model), effort=str(effort),
                     session_id=session["id"],
                 )
-                system_prompt = await self._enrich_with_context(
-                    system_prompt, prompt_text,
+                identity = await self._enrich_with_context(
+                    identity, prompt_text,
                 )
-                base_inv = replace(base_inv, system_prompt=system_prompt)
+                fragments = base_inv.system_prompt
+                base_inv = replace(
+                    base_inv,
+                    system_prompt=(
+                        f"{identity}\n\n{fragments}" if fragments else identity
+                    ),
+                )
             peers = roster.failover_invocations(home, base_inv)
             if not peers:
                 return None
@@ -1670,15 +1682,22 @@ class ConversationLoop:
         # FACT: a resumed turn's prompt may be a non-empty fragment (an appended
         # nudge) rather than None, and shipping that fragment alone to a raw
         # router LLM would answer as Genesis with no Genesis identity at all.
+        # The rebuilt identity COMPOSES with the incoming fragments (same rule
+        # as _try_roster_failover): the tool-less router has no other referent
+        # for "this one" / "the older ones" than the topic context the turn
+        # already assembled — replacing it strips exactly that.
         if was_resume or system_prompt is None:
             try:
-                system_prompt = await self._assembler.assemble(
+                identity = await self._assembler.assemble(
                     db=self._db, model="sonnet", effort="medium",
                     session_id=session_id,
                 )
             except Exception:
                 logger.error("Failed to assemble system prompt for contingency", exc_info=True)
                 return None
+            system_prompt = (
+                f"{identity}\n\n{system_prompt}" if system_prompt else identity
+            )
 
         messages = [{"role": "user", "content": prompt_text}]
 

--- a/src/genesis/cc/conversation.py
+++ b/src/genesis/cc/conversation.py
@@ -31,6 +31,7 @@ from genesis.cc.types import (
     EffortLevel,
     StreamEvent,
     is_owner_attended_channel,
+    model_name_supports_effort,
     origin_delivery_supported,
     session_origin_for_channel,
     task_detected_origin,
@@ -133,16 +134,39 @@ def _session_control_block(
     """
     if not origin_delivery_supported(channel):
         return ""
+    # Haiku does not use --effort at all: `invoker._build_args` gates the flag on
+    # `model_supports_effort`, so a stored effort never reaches dispatch there —
+    # while `session_config` still writes the row and returns success. Stating an
+    # ACTIVE effort on Haiku would have the session confirm a change dispatch
+    # never saw, which is the same false self-belief this block exists to remove.
+    # An unrecognised (roster/provider) id resolves to effort-capable, so nothing
+    # is silently stripped of effort on a model we cannot classify.
+    if model_name_supports_effort(str(model)):
+        current = (
+            f"You are currently running model={model}, effort={effort}. "
+            "Neither is fixed for the conversation. "
+        )
+        asks = '("use opus", "switch to haiku", "think harder", "low effort")'
+    else:
+        current = (
+            f"You are currently running model={model}, which has no effort "
+            f"setting — a stored effort ({effort}) is inert until you switch "
+            "models. Your model is not fixed. "
+        )
+        # No effort examples here: on a model with no effort setting, "think
+        # harder" is not a switch this session can make.
+        asks = '("use opus", "switch to sonnet")'
     return (
         "\n\n## Changing your own model / effort\n"
-        f"You are currently running model={model}, effort={effort}. "
-        "These are NOT fixed for the conversation. When the user asks you to "
-        "switch (\"use opus\", \"switch to haiku\", \"think harder\", \"low effort\"), "
+        + current
+        + f"When the user asks you to switch {asks}, "
         f'call `mcp__genesis-health__session_config` with session_id="{session_id}" '
         "(not the shorter id in the [Clock | Session: x] tag). The change takes "
         "effect on your next response, so say what you switched to and continue. "
-        "You DO have this capability — never claim otherwise; if the tool returns "
-        "an error, report that error verbatim rather than hiding it."
+        "You DO have this capability when that tool is listed — do not refuse on "
+        "the belief that you cannot. If it is absent from this session, or "
+        "returns an error, report that verbatim rather than a change that did "
+        "not happen."
     )
 
 

--- a/tests/test_cc/test_conversation.py
+++ b/tests/test_cc/test_conversation.py
@@ -726,3 +726,145 @@ async def test_should_reset_uses_local_midnight_not_utc(loop, monkeypatch):
     assert loop._should_reset({"started_at": "2026-08-24T02:00:00+00:00"}, now=now) is True
     # Started 06:00 UTC — after local midnight → not stale yet today.
     assert loop._should_reset({"started_at": "2026-08-24T06:00:00+00:00"}, now=now) is False
+
+
+# --- Session self-knowledge on RESUMED turns (measured 2026-09-02) ----------
+# A Telegram DM session refused "switch to Opus, medium effort", claiming it
+# could not change its own model. session_config existed and GENESIS_SESSION_ID
+# was in its env. The gap was self-knowledge, and it had to survive RESUME:
+# a resumed turn sends no system prompt, so anything stated only at session
+# start is absent from every later turn — including the turn that failed.
+
+
+@pytest.mark.asyncio
+async def test_streaming_carries_session_control_on_a_FRESH_turn(loop):
+    sp = await _capture_streaming_system_prompt(
+        loop, channel=ChannelType.TELEGRAM, user_id="tg-ctl-1"
+    )
+    assert sp is not None
+    assert "session_config" in sp
+    # The id is interpolated, not read from the (stale-prone) env var.
+    assert "GENESIS_SESSION_ID" not in sp
+
+
+@pytest.mark.asyncio
+async def test_streaming_carries_session_control_on_a_RESUMED_turn(loop, db):
+    """THE case that matters. On resume the system prompt is None, so the block
+    must arrive via --append-system-prompt or it is absent exactly when needed."""
+    captured = {}
+
+    async def _fake_try(invocation, *, session, **kw):
+        captured["sp"] = invocation.system_prompt
+        captured["resume"] = invocation.resume_session_id
+        return _make_output(), session
+
+    loop._try_invoke_streaming = _fake_try
+    # First turn establishes the session and its cc_session_id.
+    await loop.handle_message_streaming(
+        "hello", user_id="tg-ctl-2", channel=ChannelType.TELEGRAM, thread_id=None,
+    )
+    # Second turn resumes it.
+    await loop.handle_message_streaming(
+        "switch to opus", user_id="tg-ctl-2", channel=ChannelType.TELEGRAM,
+        thread_id=None,
+    )
+    sp = captured["sp"]
+    # PIN the resume branch. Without this the test passes even if the second
+    # turn silently took the fresh path, since that path gets the block too.
+    assert captured["resume"] == "cc-sess-1", captured["resume"]
+    assert "You are Genesis." not in (sp or ""), "took the fresh path, not resume"
+    assert sp is not None, "resumed turn carried NO system prompt at all"
+    assert "session_config" in sp, sp[:400]
+
+
+@pytest.mark.asyncio
+async def test_session_control_reports_the_CURRENT_model_not_the_original(loop, db):
+    """After a /model switch the session's own description must follow. Values
+    stated only in the fresh-session prompt go stale for the conversation's life."""
+    captured = {}
+
+    async def _fake_try(invocation, *, session, **kw):
+        captured["sp"] = invocation.system_prompt
+        return _make_output(), session
+
+    loop._try_invoke_streaming = _fake_try
+    await loop.handle_message_streaming(
+        "hi", user_id="tg-ctl-3", channel=ChannelType.TELEGRAM, thread_id=None,
+    )
+    session = await cc_sessions.get_active_foreground(
+        db, user_id="tg-ctl-3", channel=str(ChannelType.TELEGRAM), thread_id=None,
+    )
+    await cc_sessions.update_model_effort(db, session["id"], model="opus", effort="low")
+    await loop.handle_message_streaming(
+        "and now?", user_id="tg-ctl-3", channel=ChannelType.TELEGRAM, thread_id=None,
+    )
+    assert "model=opus" in captured["sp"], captured["sp"][:400]
+    assert "effort=low" in captured["sp"], captured["sp"][:400]
+
+
+@pytest.mark.asyncio
+async def test_session_control_withheld_on_terminal(loop, mock_invoker, db):
+    """TERMINAL has Claude Code's own /model and /effort, and its resumed turns
+    deliberately carry NO system prompt (test_second_message_resumes pins that)."""
+    await loop.handle_message("hello", user_id="u-term", channel=ChannelType.TERMINAL)
+    first = mock_invoker.run.call_args[0][0]
+    assert "session_config" not in (first.system_prompt or "")
+
+    await loop.handle_message("again", user_id="u-term", channel=ChannelType.TERMINAL)
+    second = mock_invoker.run.call_args[0][0]
+    assert second.resume_session_id is not None
+    assert second.system_prompt is None
+
+
+@pytest.mark.asyncio
+async def test_handle_message_carries_session_control_for_telegram(loop, mock_invoker):
+    """The non-streaming path had NO positive coverage: deleting its injection
+    left every test green. It is also the OpenClaw production path."""
+    await loop.handle_message("hi", user_id="tg-ctl-4", channel=ChannelType.TELEGRAM)
+    sp = mock_invoker.run.call_args[0][0].system_prompt
+    assert "session_config" in (sp or ""), (sp or "")[:300]
+
+
+@pytest.mark.asyncio
+async def test_session_control_withheld_on_web(loop, mock_invoker):
+    """WEB is OpenClaw's /v1/chat/completions — registered with NO auth gate and
+    stamped supervised=False / origin=external_untrusted. Telling THAT session it
+    can switch its own model, and never to refuse, hands an anonymous caller a
+    lever the user is supposed to own."""
+    await loop.handle_message("hi", user_id="web-ctl-1", channel=ChannelType.WEB)
+    sp = mock_invoker.run.call_args[0][0].system_prompt
+    assert "session_config" not in (sp or ""), (sp or "")[:300]
+
+
+@pytest.mark.asyncio
+async def test_contingency_reassembles_identity_on_a_RESUMED_turn(
+    loop_with_contingency, mock_invoker
+):
+    """`system_prompt is None` was a RESUME SENTINEL, not a null guard.
+
+    Two degraded paths used it to decide whether to re-assemble Genesis identity
+    for a fresh peer. A resumed turn's prompt is NOT None once anything is
+    appended to it — the research-routing nudge already does this on Telegram —
+    so the sentinel silently failed and the contingency shipped that fragment
+    alone to a tool-less router LLM: an assistant answering as Genesis with no
+    SOUL.md, no persona, during the outage contingency exists to survive.
+
+    The guard is now keyed on the resume FACT, so an appended fragment cannot
+    disable it.
+    """
+    from genesis.cc.exceptions import CCQuotaExhaustedError
+
+    loop, contingency = loop_with_contingency
+    # Turn 1 establishes the session so that turn 2 RESUMES it.
+    await loop.handle_message("hello", user_id="tg-cx", channel=ChannelType.TELEGRAM)
+    mock_invoker.run.side_effect = CCQuotaExhaustedError("usage limit reached")
+
+    await loop.handle_message("follow up", user_id="tg-cx", channel=ChannelType.TELEGRAM)
+
+    contingency.dispatch_conversation.assert_awaited()
+    kwargs = contingency.dispatch_conversation.await_args.kwargs
+    args = contingency.dispatch_conversation.await_args.args
+    system_prompt = kwargs.get("system_prompt") or (args[1] if len(args) > 1 else "")
+    # The distinguishing fact: FULL identity, not just the appended fragment
+    # that a resumed turn's prompt had been reduced to.
+    assert "You are Genesis." in (system_prompt or ""), (system_prompt or "")[:300]

--- a/tests/test_cc/test_conversation.py
+++ b/tests/test_cc/test_conversation.py
@@ -802,6 +802,48 @@ async def test_session_control_reports_the_CURRENT_model_not_the_original(loop, 
     assert "effort=low" in captured["sp"], captured["sp"][:400]
 
 
+def test_session_control_states_no_active_effort_on_haiku():
+    """Haiku does not use --effort: `invoker._build_args` gates the flag on
+    `model_supports_effort`, so a stored effort never reaches dispatch. But
+    `session_config` writes the row and returns success anyway — so a block that
+    printed `effort=high` would have the session confirm a change dispatch never
+    saw, the exact false self-belief this block exists to remove."""
+    from genesis.cc.conversation import _session_control_block
+
+    block = _session_control_block(
+        ChannelType.TELEGRAM, CCModel.HAIKU, EffortLevel.HIGH, "sess-haiku",
+    )
+    assert "effort=high" not in block, block
+    assert "has no effort setting" in block, block
+    # "think harder" is not a switch this session can make, so it is not offered
+    # as an example on this branch.
+    assert "think harder" not in block, block
+    # The capability itself is still advertised — this narrows the claim, it
+    # does not withhold the tool.
+    assert "session_config" in block, block
+
+    # Control: an effort-capable tier still states its ACTIVE effort, so the
+    # assertion above is about Haiku and not about the sentence disappearing.
+    opus = _session_control_block(
+        ChannelType.TELEGRAM, CCModel.OPUS, EffortLevel.HIGH, "sess-opus",
+    )
+    assert "effort=high" in opus, opus
+
+
+def test_session_control_permits_reporting_an_absent_tool():
+    """An absent tool is not "the tool returned an error". When genesis-health
+    fails to start, `session_config` is simply not registered, and an absolute
+    "never claim otherwise" would compel a fabricated success in exactly the
+    session that can least deliver one."""
+    from genesis.cc.conversation import _session_control_block
+
+    block = _session_control_block(
+        ChannelType.TELEGRAM, CCModel.SONNET, EffortLevel.MEDIUM, "sess-abs",
+    )
+    assert "never claim otherwise" not in block, block
+    assert "absent from this session" in block, block
+
+
 @pytest.mark.asyncio
 async def test_session_control_withheld_on_terminal(loop, mock_invoker, db):
     """TERMINAL has Claude Code's own /model and /effort, and its resumed turns

--- a/tests/test_cc/test_conversation_failover.py
+++ b/tests/test_cc/test_conversation_failover.py
@@ -285,3 +285,67 @@ async def test_run_failover_peer_offline_propagates_without_fresh_retry(loop, in
             on_event=None,
         )
     assert invoker.run.call_count == 1  # no fresh retry
+
+
+# ── Resumed-turn fragments must SURVIVE failover/contingency rebuilds ────────
+# A resumed turn's system_prompt is not empty on Telegram: it carries the
+# per-turn fragments assembled by the caller (topic context with the live
+# proposal board, the session-control block, the research-routing nudge). Both
+# degraded paths re-assemble the identity for a fresh/tool-less session — that
+# part is right — but they must COMPOSE it with those fragments, not replace
+# them: "approve this proposal" needs the board, and "the older ones" needs the
+# thread context, on the peer exactly as much as on the home model.
+
+
+@pytest.mark.asyncio
+async def test_failover_preserves_resume_fragments_beside_identity(loop, invoker, monkeypatch):
+    captured: dict = {}
+
+    def _spy(home, base, *a, **k):
+        captured["system_prompt"] = base.system_prompt
+        return [("glm-5.2", _PEER_INV)]
+
+    inv = CCInvocation(
+        prompt="approve this proposal", resume_session_id="cc-1",
+        system_prompt="## Pending proposals\n- P1: adopt-first demo",
+    )
+    monkeypatch.setattr(roster, "failover_invocations", _spy)
+    invoker.run = AsyncMock(return_value=_output(text="peer reply", session_id="glm-1"))
+
+    out = await loop._try_roster_failover(
+        inv, session={"id": "cc-live"}, channel=ChannelType.TELEGRAM,
+        model=CCModel.SONNET, effort=EffortLevel.MEDIUM,
+        prompt_text="approve this proposal",
+    )
+
+    assert out and "peer reply" in out
+    # Identity re-assembled for the fresh peer session…
+    assert "You are Genesis." in captured["system_prompt"]
+    # …AND the turn's own context preserved, not discarded by the rebuild.
+    assert "P1: adopt-first demo" in captured["system_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_contingency_preserves_resume_fragments_beside_identity(loop):
+    # The tool-less contingency dispatcher gets referents for "this one"/"the
+    # older ones" the same way: assembled identity + the turn's fragments.
+    captured: dict = {}
+
+    class _Dispatch:
+        async def dispatch_conversation(self, messages, system_prompt):
+            captured["system_prompt"] = system_prompt
+            result = MagicMock()
+            result.success, result.content, result.model = True, "ok", "router-x"
+            return result
+
+    loop._contingency = _Dispatch()
+
+    out = await loop._try_contingency(
+        "approve this proposal",
+        "## Pending proposals\n- P1: adopt-first demo",
+        ChannelType.TELEGRAM, session_id="cc-live", was_resume=True,
+    )
+
+    assert "ok" in out  # reply text (contingency preamble is prefixed by the caller)
+    assert "You are Genesis." in captured["system_prompt"]
+    assert "P1: adopt-first demo" in captured["system_prompt"]

--- a/tests/test_cc/test_recovery_context.py
+++ b/tests/test_cc/test_recovery_context.py
@@ -178,3 +178,57 @@ def test_conversation_identity_block_thread_scoped_suggestion():
         "555000111", "telegram", None,
     )
     assert "chat_id=555000111, limit=50" in dm_block
+
+
+# --- Session self-knowledge: model/effort + how to change them --------------
+# MEASURED 2026-09-02: a Telegram DM session was asked to "switch to Opus,
+# medium effort" and replied it could not change its own model. It could —
+# session_config existed, its docstring names that exact request, and
+# GENESIS_SESSION_ID was in its env (it had run `env` and seen the variable 31
+# seconds earlier). Nothing was missing but the session's belief about itself.
+
+
+class TestSessionControlBlock:
+    @staticmethod
+    def _block(model="sonnet", effort="high", session_id="sess-abc123"):
+        from genesis.cc.conversation import _session_control_block
+        from genesis.cc.types import ChannelType
+
+        return _session_control_block(ChannelType.TELEGRAM, model, effort, session_id)
+
+    def test_states_the_current_model_and_effort(self):
+        """A resumed turn sends no system prompt, so values stated only at
+        session start go stale the moment /model or /effort is used."""
+        block = self._block(model="opus", effort="medium")
+        assert "model=opus" in block
+        assert "effort=medium" in block
+
+    def test_names_the_tool_and_embeds_the_REAL_id(self):
+        """The id is interpolated, not sourced from GENESIS_SESSION_ID. That env
+        var is STALE on the stale-resume rebuild path — _recover_stale_resume
+        creates a new session row and never updates the ContextVar — so a switch
+        would write to the FAILED row, succeed, and report a change that did not
+        happen."""
+        block = self._block(session_id="sess-real-42")
+        assert "session_config" in block
+        assert 'session_id="sess-real-42"' in block
+        assert "GENESIS_SESSION_ID" not in block
+
+    def test_warns_off_the_visible_but_wrong_id(self):
+        """The [Clock | Session: x] tag holds the CC transcript id, truncated to
+        8 chars — a different id that could never match."""
+        block = self._block()
+        assert "Clock" in block
+
+    def test_asserts_the_capability_without_forbidding_honest_errors(self):
+        """The measured failure was a FALSE BELIEF, so the block corrects that —
+        but an absolute "never say you cannot" is itself false on the contingency
+        path (a tool-less router LLM) and on a tool error, where it would compel
+        a fabricated success."""
+        block = self._block()
+        assert "You DO have this capability" in block
+        assert "report that error verbatim" in block
+
+    def test_block_is_bounded(self):
+        """It rides every turn, so it must not crowd out real context."""
+        assert len(self._block()) < 700, len(self._block())

--- a/tests/test_cc/test_recovery_context.py
+++ b/tests/test_cc/test_recovery_context.py
@@ -227,8 +227,12 @@ class TestSessionControlBlock:
         a fabricated success."""
         block = self._block()
         assert "You DO have this capability" in block
-        assert "report that error verbatim" in block
+        assert "report that verbatim" in block
 
     def test_block_is_bounded(self):
-        """It rides every turn, so it must not crowd out real context."""
-        assert len(self._block()) < 700, len(self._block())
+        """It rides every turn, so it must not crowd out real context. Bounded on
+        EVERY branch: the no-effort (Haiku) wording is the longest one, so a bound
+        checked only on the default would not bind the branch most likely to grow."""
+        for model in ("sonnet", "opus", "haiku"):
+            block = self._block(model=model)
+            assert len(block) < 700, (model, len(block))


### PR DESCRIPTION
## Problem

A Telegram DM session was asked to *"switch to Opus, medium effort"* and replied
it **could not change its own model**. It could:

- `session_config` was registered, and its docstring literally says *"Call when
  the user asks to switch models ('use opus', 'switch to haiku')"*;
- the id it needs was in the session's environment — the transcript shows it ran
  `env` and **saw that variable 31 seconds before refusing**.

Nothing was missing but the session's belief about itself. Deliberately **not** a
natural-language intent matcher: the failure was self-knowledge, not parsing, so
no pattern over the *user's* words would have corrected it.

The block rides `--append-system-prompt` alongside `--resume`, because a resumed
turn carries **no system prompt at all** — anything stated only at session start
is absent from every later turn, which is exactly where this failed. That also
fixes a second defect found while building: model/effort were stated only in the
fresh-session prompt, so after any switch a session's self-description went
**stale for the life of the conversation**.

## Three things this got wrong first, all caught in review

**It broke a resume sentinel.** `system_prompt is None` is not a null guard —
two degraded paths use it to decide whether to re-assemble Genesis identity for a
*fresh* peer. An unconditional append made it never-None, which would have run a
failover peer with this note as its **entire** system prompt: no SOUL.md, no
persona, during exactly the outage failover exists to survive. Both consumers are
now keyed on the resume *fact*. That also closes a **pre-existing** instance —
the research-routing nudge already did this to Telegram, so Telegram contingency
replies already carried no Genesis identity before this PR.

**The boundary was wrong.** Excluding only TERMINAL left **WEB** — OpenClaw's
`/v1/chat/completions`, registered with **no auth gate** and stamped
`supervised=False, origin=external_untrusted`. Telling that session it can switch
its own model, and never to refuse, hands an anonymous caller a lever a prior
commit deliberately closed. Now scoped to owner-attended channels.

**The id was wrong on one path.** `GENESIS_SESSION_ID` is stale after a
stale-resume recovery — that path creates a new session row and never updates the
context var — so a switch would write to the **failed** row, succeed, and report
a change that did not happen. The real id is interpolated instead, which also
drops a `Bash` env read from the flow and shortens the block.

Also softened an absolute "never say you cannot", which is false on the
tool-less contingency path and on any tool error, where it would compel a
fabricated success.

## Verification

**5 mutations RED, zero survivors** — including the one that survived the first
sweep (the non-streaming injection site, which is the OpenClaw production path
and had no positive test at all), and the sentinel guard itself.

184 tests pass; ruff clean.

## What is NOT verified

**The behaviour.** That a session seeing this block will now call the tool rather
than refuse is *not* proven and cannot be from here — the original failure was a
model asserting a false belief while holding the capability. What is proven is
that the text reaches a resumed turn's invocation carrying the correct id.

The real test is a live Telegram DM saying "switch to opus" after this deploys.
**Regression marker:** if a channel session still refuses with the block present
in its prompt, the salience hypothesis is wrong and the answer is a mechanical
intercept.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Conversation session details now clearly identify the active model, effort settings, and session.
  - Session context is preserved across fresh, resumed, recovery, and failover interactions.
  - Tool guidance now distinguishes unavailable tools from tool errors and accurately reflects model capabilities.
  - Recovery paths better retain conversation identity and existing turn context after errors.

- **Tests**
  - Added coverage for session reporting, capability messaging, context propagation, recovery, and failover scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->