### PR TITLE
fix(observability): MCP tool-call boundary rolls back on any non-clean exit, not just Exception

### DIFF
--- a/src/genesis/observability/mcp_middleware.py
+++ b/src/genesis/observability/mcp_middleware.py
@@ -92,29 +92,48 @@ class InstrumentationMiddleware(Middleware):
             success = True
             return result
         finally:
-            if self._db is not None:
+            # Nested try/finally so a BaseException raised by the DB step cannot
+            # skip the tracker record below it. Cancellation is the reachable
+            # case: `except Exception` does not catch `asyncio.CancelledError`,
+            # so before this nesting a cancellation landing in the commit await
+            # left the call unrecorded — the tool ran, and the activity tracker
+            # never heard about it.
+            #
+            # What that cancellation does NOT do is lose the write, which is
+            # worth stating because the obvious remedy (roll back on cancel) is
+            # built on the opposite assumption. aiosqlite QUEUES the operation
+            # to its worker thread BEFORE awaiting — `_execute` does
+            # `self._tx.put_nowait((future, function))` and only then
+            # `await future` — so cancelling the await cancels the WAIT, not the
+            # commit. MEASURED against aiosqlite 0.21: a row inserted before a
+            # cancelled `commit()` is durable afterwards. Issuing a rollback
+            # here would either be a no-op behind the commit already in the
+            # queue, or would discard a successful tool call's writes.
+            try:
+                if self._db is not None:
+                    try:
+                        if success:
+                            await self._db.commit()
+                        else:
+                            await self._db.rollback()
+                    except Exception:
+                        logger.warning(
+                            "DB %s after %s failed",
+                            "commit" if success else "rollback",
+                            provider, exc_info=True,
+                        )
+            finally:
                 try:
-                    if success:
-                        await self._db.commit()
-                    else:
-                        await self._db.rollback()
+                    self._tracker.record(
+                        provider,
+                        latency_ms=(time.monotonic() - t0) * 1000,
+                        success=success,
+                    )
                 except Exception:
                     logger.warning(
-                        "DB %s after %s failed",
-                        "commit" if success else "rollback",
+                        "Activity tracker record failed for %s",
                         provider, exc_info=True,
                     )
-            try:
-                self._tracker.record(
-                    provider,
-                    latency_ms=(time.monotonic() - t0) * 1000,
-                    success=success,
-                )
-            except Exception:
-                logger.warning(
-                    "Activity tracker record failed for %s",
-                    provider, exc_info=True,
-                )
 
     async def _enforce_freshness(self, tool_name: str) -> None:
         """Block a guarded tool when this subprocess is running stale code.

--- a/src/genesis/observability/mcp_middleware.py
+++ b/src/genesis/observability/mcp_middleware.py
@@ -40,14 +40,17 @@ class InstrumentationMiddleware(Middleware):
     the MCP tool handler.
 
     Per-call transaction boundary (WS-15 follow-up): when constructed with the
-    server's long-lived ``db`` connection, each tool call ends with a
-    commit-on-success / rollback-on-error. This releases the read snapshot that
-    a read-only tool would otherwise leave open in deferred-isolation mode —
-    which pins the SQLite WAL checkpoint and makes later writes fail
-    "database is locked". Writes already commit at the CRUD layer before the
-    tool returns, so the commit here only closes a *trailing* read txn (it can
-    never discard a tool's own write); rollback-on-error discards a partial.
-    DB errors in this boundary never propagate to the tool handler.
+    server's long-lived ``db`` connection, each tool call commits only after a
+    clean return and rolls back otherwise. This releases the read snapshot that a
+    read-only tool would otherwise leave open in deferred-isolation mode — which
+    pins the SQLite WAL checkpoint and makes later writes fail "database is locked".
+    Writes already commit at the CRUD layer before the tool returns, so the commit
+    here only closes a *trailing* read txn (it can never discard a tool's own
+    write); any non-clean exit — a raised ``Exception``, or a ``BaseException`` no
+    clause catches (``asyncio.CancelledError``, ``SystemExit``, …) — rolls back the
+    possibly-partial write instead of committing it. The boundary catches nothing;
+    every exception propagates unchanged. DB errors in this boundary never
+    propagate to the tool handler.
     """
 
     def __init__(
@@ -70,7 +73,15 @@ class InstrumentationMiddleware(Middleware):
         tool_name = context.message.name
         provider = f"mcp.{self._server}.{tool_name}"
         t0 = time.monotonic()
-        success = True
+        # Default False so the finally COMMITS only after a clean return. Any exit
+        # that is NOT a normal return leaves this False and rolls back the
+        # possibly-partial write instead of committing it: a raised ``Exception``,
+        # or a ``BaseException`` no clause catches — ``asyncio.CancelledError``,
+        # ``SystemExit``, ``KeyboardInterrupt``, ``GeneratorExit`` (follow-up
+        # 3183405d — the old ``except Exception`` let all of those keep success=True
+        # and commit a partial). Nothing is caught here, so every exception,
+        # cancellation included, propagates unchanged.
+        success = False
         try:
             if tool_name in GUARDED_MCP_TOOLS:
                 # Raises ToolError (block mode) if this subprocess is running
@@ -78,10 +89,8 @@ class InstrumentationMiddleware(Middleware):
                 # the read snapshot the staleness check opened on self._db.
                 await self._enforce_freshness(tool_name)
             result = await call_next(context)
+            success = True
             return result
-        except Exception:
-            success = False
-            raise
         finally:
             if self._db is not None:
                 try:

--- a/tests/test_observability/test_mcp_middleware.py
+++ b/tests/test_observability/test_mcp_middleware.py
@@ -197,3 +197,42 @@ class TestMiddlewareUnitOfWork:
 
         db.rollback.assert_awaited_once()
         db.commit.assert_not_awaited()
+
+    async def test_cancellation_inside_commit_still_records_the_call(self):
+        """A cancellation landing IN the commit await must not swallow the record.
+
+        `except Exception` does not catch `asyncio.CancelledError`, so before the
+        DB step and the tracker record were nested in their own try/finally, a
+        cancellation here left this finally early: the tool had run and the
+        activity tracker never heard about it.
+
+        Deliberately NOT asserting a rollback. CodeRabbit's finding proposed one,
+        and the premise it rests on does not hold for this driver: aiosqlite
+        queues the operation to its worker thread BEFORE awaiting
+        (`_tx.put_nowait(...)` then `await future`), so cancelling the await
+        cancels the WAIT, not the commit. MEASURED against aiosqlite 0.21 — a row
+        inserted before a cancelled `commit()` is durable afterwards. A rollback
+        issued here would either sit behind the queued commit as a no-op, or
+        discard a successful tool call's writes.
+        """
+        tracker = ProviderActivityTracker()
+        db = AsyncMock()
+
+        async def _commit_that_gets_cancelled():
+            raise asyncio.CancelledError()
+
+        db.commit = AsyncMock(side_effect=_commit_that_gets_cancelled)
+        mw = InstrumentationMiddleware(tracker, "memory", db=db)
+        context = MagicMock()
+        context.message.name = "memory_store"
+        call_next = AsyncMock(return_value={"result": "ok"})
+
+        with pytest.raises(asyncio.CancelledError):
+            await mw.on_call_tool(context, call_next)
+
+        # The cancellation propagated (above) AND the call was still recorded.
+        summary = tracker.summary("mcp.memory.memory_store")
+        assert summary["calls"] == 1, (
+            "a cancellation inside commit() must not cost the tracker record"
+        )
+        assert summary["errors"] == 0, "the TOOL succeeded; only the commit wait was cut"

--- a/tests/test_observability/test_mcp_middleware.py
+++ b/tests/test_observability/test_mcp_middleware.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -145,3 +146,54 @@ class TestMiddlewareUnitOfWork:
 
         with pytest.raises(ValueError, match="original tool error"):
             await mw.on_call_tool(context, call_next)
+
+    async def test_rolls_back_on_cancelled_tool_call(self):
+        """A CANCELLED tool call rolls back its partial, exactly like an errored one.
+
+        ``asyncio.CancelledError`` is a ``BaseException``, not an ``Exception``, so
+        a bare ``except Exception`` never catches it: ``success`` stays ``True`` and
+        the ``finally`` COMMITS a possibly-partial write (follow-up 3183405d). The
+        boundary must roll it back instead (the flip pattern defaults ``success=False``,
+        so only a clean return commits).
+        """
+        tracker = ProviderActivityTracker()
+        db = AsyncMock()
+        mw = InstrumentationMiddleware(tracker, "memory", db=db)
+        context = MagicMock()
+        context.message.name = "memory_store"
+        call_next = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await mw.on_call_tool(context, call_next)
+
+        db.rollback.assert_awaited_once()
+        db.commit.assert_not_awaited()
+
+    async def test_real_cancellation_mid_call_rolls_back(self):
+        """A GENUINE task cancellation mid-tool-call rolls back, never commits.
+
+        Unlike the synthetic ``side_effect=CancelledError`` above, this cancels a
+        real task while it is suspended INSIDE ``call_next`` — exercising the
+        finally's cleanup on the actual cancellation path, not just the routing.
+        """
+        tracker = ProviderActivityTracker()
+        db = AsyncMock()
+        mw = InstrumentationMiddleware(tracker, "memory", db=db)
+        context = MagicMock()
+        context.message.name = "memory_store"
+
+        inside_call = asyncio.Event()
+
+        async def _blocks_until_cancelled(_ctx):
+            inside_call.set()
+            await asyncio.Event().wait()  # never set — only cancellation ends this
+            return {"unreachable": True}
+
+        task = asyncio.create_task(mw.on_call_tool(context, _blocks_until_cancelled))
+        await inside_call.wait()  # ensure we are suspended inside call_next
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        db.rollback.assert_awaited_once()
+        db.commit.assert_not_awaited()


### PR DESCRIPTION
## Problem

`InstrumentationMiddleware.on_call_tool` wraps every MCP tool call with a per-call
commit-on-success / rollback-on-error boundary on the server's shared DB connection.
It initialised `success = True` and only flipped it to `False` inside `except Exception`.
Because `asyncio.CancelledError` (and `SystemExit` / `KeyboardInterrupt` / `GeneratorExit`)
are `BaseException`s, not `Exception`s, they bypassed that clause: `success` stayed `True`
and the `finally` **committed** a possibly-partial write instead of discarding it.

## Fix

Flip the default — `success = False`, set it `True` only immediately before `return`.
Any exit that is not a clean return now rolls back the partial; the boundary catches
nothing, so every exception (cancellation included) propagates unchanged. Both `except`
clauses are deleted. This closes the whole `BaseException` class, not just `CancelledError`.

## Scope / severity

Defense-in-depth on a boundary WS-15 documented as imperfect under concurrency (true
multi-statement atomicity was deferred to an unbuilt Phase 2). The clear win is the serial
case: a cancelled tool call's own uncommitted partial is discarded, not committed. Under
concurrency it only aligns cancel with the pre-existing error→rollback path — it neither
closes nor worsens that Phase-2 gap.

## Tests

- `test_rolls_back_on_cancelled_tool_call` — synthetic `CancelledError` routing.
- `test_real_cancellation_mid_call_rolls_back` — cancels a **real** task suspended inside
  `call_next`, exercising the finally's cleanup on the genuine cancellation path.

Both verify-RED against the prior behavior (rollback awaited 0×; the pristine boundary
commits on cancel); the error-path control test still passes on pristine, so the tests
target cancel precisely. Full boundary suite green, ruff clean.

Follow-up: 3183405dd69848329a7cf91916798489


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database transactions now roll back when tool calls are cancelled or exit unexpectedly.
  * Cancellation signals and other errors continue propagating correctly instead of being treated as successful calls.
  * Activity tracking continues during database cleanup failures.
  * Successfully completed calls are recorded without errors, including when cancellation occurs during commit processing.

* **Tests**
  * Added coverage for cancellation scenarios, rollback, non-commit behavior, propagation, and successful completion tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->