### PR TITLE
feat(outreach): complete cold-marketing substrate — contact-stamping + approval-flood cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   swallows ALTER errors (a transient lock is retried, a real failure fails loud); and an
   already-approved cold send is halted at delivery if the lever is flipped to `off` / the
   kill switch is set before it goes out (the outer off-switch is now honored deliver-side,
-  not only at enqueue — the held send is paused and resumes if you re-enable).
+  not only at enqueue — the held send is paused and resumes if you re-enable). A
+  delivered (or owner-rejected) cold send marks its prospect `contacted` so the
+  campaign never re-pitches the same person, while a send that never reaches a
+  decision (dropped/expired) leaves the prospect eligible; and Genesis refuses to
+  stage a new send once a configurable number of cold sends (`max_pending_holds`,
+  default 20) already await your approval — so a run can't flood your approval queue.
 - **Contributor-issue close loop.** When an external contributor's merged PR
   closes a GitHub issue Genesis posted from the Contributor Work-Log (via a
   `Closes #N` keyword), the repo-pulse worker now auto-resolves the originating

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   not only at enqueue — the held send is paused and resumes if you re-enable). A
   delivered (or owner-rejected) cold send marks its prospect `contacted` so the
   campaign never re-pitches the same person, while a send that never reaches a
-  decision (dropped/expired) leaves the prospect eligible; and Genesis refuses to
-  stage a new send once a configurable number of cold sends (`max_pending_holds`,
-  default 20) already await your approval — so a run can't flood your approval queue.
+  decision (dropped/expired) leaves the prospect eligible; Genesis won't stage a
+  second cold send to someone who already has one in flight (no duplicate pitches);
+  and it refuses to stage a new send once a configurable number of cold sends
+  (`max_pending_holds`, default 20) already await your approval — so a run can't
+  flood your approval queue.
 - **Contributor-issue close loop.** When an external contributor's merged PR
   closes a GitHub issue Genesis posted from the Contributor Work-Log (via a
   `Closes #N` keyword), the repo-pulse worker now auto-resolves the originating

--- a/config/marketing_outreach.yaml
+++ b/config/marketing_outreach.yaml
@@ -24,3 +24,9 @@
 # tool cleanly refuses.
 enabled: true
 mode: "off"
+
+# Max BULK (cold-marketing) sends that may sit HELD awaiting owner approval
+# before `marketing_send` refuses to stage new ones (the ASK-state approval-flood
+# guard). Bounds the owner's approval queue regardless of how many prospects are
+# curated. A non-positive / non-int / corrupt value degrades to the safe default.
+max_pending_holds: 20

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -562,14 +562,18 @@ verified: a2f2be52 2026-09-03
   lifecycle is stamped on a CONFIRMED outcome, not at stage time, via ONE
   active-guarded CRUD (`marketing_prospects.mark_contacted_by_email`) called from
   BOTH delivery paths: the email-gate drain (`email_gate_watcher`) on delivery or
-  owner-rejection of a HELD BULK send, AND `pipeline._deliver` on a GRANTED-cell
-  autonomous BULK delivery (which delivers inline and never touches the drain — so
-  the loop-fix survives graduation). A send dropped/expired before any decision
-  leaves the prospect `active` (no silent burn). `marketing_send` refuses
-  a non-`active` prospect (dedup) and refuses when `>= max_pending_holds` BULK
-  sends are in flight — counting BOTH the pending_outreach queue and the held
-  `pending_email_sends` so the cap bounds a single run (the ASK-state approval-flood
-  guard, `marketing_config.max_pending_holds`). A batch approval card (approve N
+  owner-rejection, AND `pipeline._deliver` on a GRANTED-cell autonomous delivery
+  (which delivers inline and never touches the drain — so the loop-fix survives
+  graduation). The stamp is keyed on the RECIPIENT being a curated prospect, NOT on
+  `cell_risk_class`, so a cold pitch that misclassified FINANCIAL (money-term body)
+  is still stamped and never re-pitched. A send dropped/expired before any decision
+  leaves the prospect `active` (no silent burn). `marketing_send` refuses a
+  non-`active` prospect, refuses a recipient that already has an in-flight send
+  (per-prospect dedup across both queues — no duplicate pitch to one person), and
+  refuses when `>= max_pending_holds` BULK sends are in flight — counting BOTH the
+  `pending_outreach` queue and the held `pending_email_sends` so the cap bounds a
+  single run (`marketing_config.max_pending_holds`; a non-int / non-positive value
+  degrades to the default, never coerced). A batch approval card (approve N
   holds at once) remains deferred — per-item dashboard approval is the surface today.
 - **Marketing reply → owner Telegram ping (notify-only).** When a GENUINE human
   reply lands (auto-responders + foreign senders already gated out by the

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -494,7 +494,7 @@ gated — that contract is one-directional.
 ```yaml subsystem-map
 entry: autonomy-egress
 modules: [autonomy, outreach, distribution, content, campaigns]
-verified: 85f91765 2026-09-01
+verified: a2f2be52 2026-09-03
 ```
 
 - **The chokepoint is `outreach/pipeline.py _deliver`** — ~12 send paths
@@ -555,10 +555,22 @@ verified: 85f91765 2026-09-01
   MUST be a curated, non-opted-out `marketing_prospects` row (authorization is
   DECOUPLED from send-lifecycle status, so a `contacted` follow-up still sends) —
   an unknown / opted-out recipient trips (`recipient_not_curated` / `opted_out`)
-  → demote + hold (fail-closed). PR2 will wire graduation, send-time contact
-  stamping, AND a hard per-window cap on hold-creation (the ASK-state
-  approval-flood guard) alongside the batch-approval card — `marketing_send` has
-  no autonomous caller until then.
+  → demote + hold (fail-closed). Graduation for the BULK cell rides the generic
+  capability-promotion path (`capability_grants.detect_promotable_cells` — no
+  risk-class filter → `email:send:bulk` qualifies once it has ≥5 owner-approved
+  successes + posterior ≥0.70 → `ego/cadence` proposes → owner grants). The prospect
+  lifecycle is stamped on a CONFIRMED outcome, not at stage time, via ONE
+  active-guarded CRUD (`marketing_prospects.mark_contacted_by_email`) called from
+  BOTH delivery paths: the email-gate drain (`email_gate_watcher`) on delivery or
+  owner-rejection of a HELD BULK send, AND `pipeline._deliver` on a GRANTED-cell
+  autonomous BULK delivery (which delivers inline and never touches the drain — so
+  the loop-fix survives graduation). A send dropped/expired before any decision
+  leaves the prospect `active` (no silent burn). `marketing_send` refuses
+  a non-`active` prospect (dedup) and refuses when `>= max_pending_holds` BULK
+  sends are in flight — counting BOTH the pending_outreach queue and the held
+  `pending_email_sends` so the cap bounds a single run (the ASK-state approval-flood
+  guard, `marketing_config.max_pending_holds`). A batch approval card (approve N
+  holds at once) remains deferred — per-item dashboard approval is the surface today.
 - **Marketing reply → owner Telegram ping (notify-only).** When a GENUINE human
   reply lands (auto-responders + foreign senders already gated out by the
   reply→engagement bridge, `outreach/engagement.py`) AND the reply's recipient is

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -213,10 +213,12 @@ async def drain_pending_email_sends(rt: object) -> int:
                     # WS-3 gate-3: the OWNER approved this send — owner evidence.
                     origin_class="owner",
                 )
-                if row["cell_risk_class"] == "bulk":
-                    # Confirmed delivery of a cold-marketing send → advance the
-                    # prospect active → contacted so list_active stops re-pitching it.
-                    await _stamp_prospect_contacted(db, row["validated_recipient"], now)
+                # Confirmed delivery → advance a matching curated prospect
+                # active → contacted (a no-op for a non-prospect recipient) so
+                # list_active stops re-pitching it. Keyed on the RECIPIENT being a
+                # curated prospect, NOT cell_risk_class, so a cold pitch that
+                # misclassified FINANCIAL (a money-term body) is still stamped.
+                await _stamp_prospect_contacted(db, row["validated_recipient"], now)
                 resolved += 1
                 logger.info(
                     "Resolved held email %s → sent to %s",
@@ -257,12 +259,12 @@ async def drain_pending_email_sends(rt: object) -> int:
                     # WS-3 gate-3: the OWNER rejected/cancelled — owner decision.
                     origin_class="owner",
                 )
-                if row["cell_risk_class"] == "bulk":
-                    # Owner explicitly declined this cold-marketing draft → advance
-                    # the prospect to contacted so it is not auto re-proposed next
-                    # tick. (A rejection is a decision; opt-out is the "never
-                    # contact" signal — a system-drop, e.g. expiry, leaves it active.)
-                    await _stamp_prospect_contacted(db, row["validated_recipient"], now)
+                # Owner explicitly declined this draft → advance a matching curated
+                # prospect to contacted so it is not auto re-proposed next tick (a
+                # rejection is a decision; opt-out is the "never contact" signal; a
+                # system-drop/expiry leaves it active). Recipient-keyed, risk-class-
+                # agnostic (a FINANCIAL-misclassified pitch is handled too).
+                await _stamp_prospect_contacted(db, row["validated_recipient"], now)
                 resolved += 1
         elif status == "expired":
             # No-decision (the owner never answered) — expire the hold but do

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -70,6 +70,21 @@ async def _recipient_opted_out(db: object, recipient: str | None) -> bool:
     return bool(row.get("opted_out"))
 
 
+async def _stamp_prospect_contacted(db: object, recipient: str | None, now: str) -> None:
+    """After a CONFIRMED marketing outcome (delivered / owner-rejected), advance the
+    matching prospect active → contacted so the campaign's ``list_active`` never
+    re-pitches it. Stamped on a confirmed outcome, NOT at stage time, so a send
+    dropped before it reaches a decision never burns the prospect (it stays
+    'active', re-eligible). Delegates to the shared, active-guarded CRUD (the same
+    entry point ``pipeline._deliver`` uses for the GRANTED autonomous path), so the
+    stamp semantics live in one place."""
+    if not recipient:
+        return
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.mark_contacted_by_email(db, recipient, contacted_at=now)
+
+
 def _subject(context: str | None) -> str:
     if not context:
         return ""
@@ -198,6 +213,10 @@ async def drain_pending_email_sends(rt: object) -> int:
                     # WS-3 gate-3: the OWNER approved this send — owner evidence.
                     origin_class="owner",
                 )
+                if row["cell_risk_class"] == "bulk":
+                    # Confirmed delivery of a cold-marketing send → advance the
+                    # prospect active → contacted so list_active stops re-pitching it.
+                    await _stamp_prospect_contacted(db, row["validated_recipient"], now)
                 resolved += 1
                 logger.info(
                     "Resolved held email %s → sent to %s",
@@ -238,6 +257,12 @@ async def drain_pending_email_sends(rt: object) -> int:
                     # WS-3 gate-3: the OWNER rejected/cancelled — owner decision.
                     origin_class="owner",
                 )
+                if row["cell_risk_class"] == "bulk":
+                    # Owner explicitly declined this cold-marketing draft → advance
+                    # the prospect to contacted so it is not auto re-proposed next
+                    # tick. (A rejection is a decision; opt-out is the "never
+                    # contact" signal — a system-drop, e.g. expiry, leaves it active.)
+                    await _stamp_prospect_contacted(db, row["validated_recipient"], now)
                 resolved += 1
         elif status == "expired":
             # No-decision (the owner never answered) — expire the hold but do

--- a/src/genesis/db/crud/marketing_prospects.py
+++ b/src/genesis/db/crud/marketing_prospects.py
@@ -109,6 +109,24 @@ async def mark_contacted(
     return cursor.rowcount > 0
 
 
+async def mark_contacted_by_email(
+    db: aiosqlite.Connection, email: str, *, contacted_at: str
+) -> bool:
+    """Advance the ACTIVE prospect matching ``email`` → contacted. The by-email
+    entry point for the delivery paths (which know the resolved recipient, not the
+    id) — used on a CONFIRMED marketing outcome (delivery / owner-rejection) so
+    ``list_active`` stops re-pitching the prospect.
+
+    No-op returning False when there is no matching prospect, or the row is not
+    'active' (an already-'contacted'/'replied' row is never downgraded, and a
+    non-marketing recipient is never touched). Only ``opted_out`` — NOT this
+    status — gates authorization, so this write can never weaken a send gate."""
+    row = await get_by_email(db, email)
+    if row is None or row.get("status") != "active":
+        return False
+    return await mark_contacted(db, row["id"], contacted_at=contacted_at)
+
+
 async def mark_opted_out(db: aiosqlite.Connection, id: str, *, opted_out_at: str) -> bool:
     """PERMANENT suppression — set opted_out=1. Returns False if id is unknown.
     The row is never pruned, so the address can never be silently re-enabled."""

--- a/src/genesis/db/crud/pending_email_sends.py
+++ b/src/genesis/db/crud/pending_email_sends.py
@@ -64,6 +64,19 @@ async def list_held(db: aiosqlite.Connection) -> list[dict]:
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def count_held_by_risk_class(db: aiosqlite.Connection, risk_class: str) -> int:
+    """Count rows still HELD (awaiting owner approval) for a given capability
+    risk class. Used by the marketing approval-flood guard to bound the owner's
+    BULK approval queue (``risk_class='bulk'``)."""
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM pending_email_sends "
+        "WHERE status = 'held' AND cell_risk_class = ?",
+        (risk_class,),
+    )
+    row = await cursor.fetchone()
+    return int(row[0]) if row else 0
+
+
 async def mark_sent(db: aiosqlite.Connection, id: str, *, sent_at: str) -> bool:
     """Transition held → sent. Returns False if the row already left 'held'
     (double-send guard: only one caller can flip a given hold)."""

--- a/src/genesis/db/crud/pending_email_sends.py
+++ b/src/genesis/db/crud/pending_email_sends.py
@@ -64,6 +64,20 @@ async def list_held(db: aiosqlite.Connection) -> list[dict]:
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def has_held_for_recipient(db: aiosqlite.Connection, recipient: str) -> bool:
+    """True iff a send to ``recipient`` is still HELD (awaiting owner approval).
+    Recipient-keyed (case-insensitive) + risk-class-AGNOSTIC so a marketing send is
+    caught whatever it classified (BULK, or FINANCIAL if the body tripped the money
+    pattern) — the per-prospect in-flight dedup that stops a second cold pitch to
+    someone already in flight."""
+    cursor = await db.execute(
+        "SELECT 1 FROM pending_email_sends "
+        "WHERE status = 'held' AND validated_recipient = ? COLLATE NOCASE LIMIT 1",
+        (recipient,),
+    )
+    return await cursor.fetchone() is not None
+
+
 async def count_held_by_risk_class(db: aiosqlite.Connection, risk_class: str) -> int:
     """Count rows still HELD (awaiting owner approval) for a given capability
     risk class. Used by the marketing approval-flood guard to bound the owner's

--- a/src/genesis/db/crud/pending_outreach.py
+++ b/src/genesis/db/crud/pending_outreach.py
@@ -85,6 +85,22 @@ async def drain(
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def count_undelivered_labeled_surplus(
+    db: aiosqlite.Connection, *, channel: str = "email"
+) -> int:
+    """Count undelivered BULK/campaign (``labeled_surplus``) rows still queued for
+    the drain. Used with ``pending_email_sends.count_held_by_risk_class`` so the
+    marketing approval-flood guard bounds a single campaign RUN — this is the
+    pre-drain half (rows enqueued this run, not yet converted into HELD sends)."""
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM pending_outreach "
+        "WHERE delivered = 0 AND labeled_surplus = 1 AND channel = ?",
+        (channel,),
+    )
+    row = await cursor.fetchone()
+    return int(row[0]) if row else 0
+
+
 async def mark_delivered(
     db: aiosqlite.Connection,
     pending_id: str,

--- a/src/genesis/db/crud/pending_outreach.py
+++ b/src/genesis/db/crud/pending_outreach.py
@@ -85,6 +85,22 @@ async def drain(
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def has_undelivered_labeled_surplus_for_recipient(
+    db: aiosqlite.Connection, recipient: str, *, channel: str = "email"
+) -> bool:
+    """True iff ``recipient`` already has an undelivered BULK/campaign
+    (``labeled_surplus``) row queued for the drain — the pre-drain half of the
+    per-prospect in-flight dedup (a send enqueued this run, not yet converted into a
+    HELD row). Case-insensitive recipient match."""
+    cursor = await db.execute(
+        "SELECT 1 FROM pending_outreach "
+        "WHERE delivered = 0 AND labeled_surplus = 1 AND channel = ? "
+        "AND validated_recipient = ? COLLATE NOCASE LIMIT 1",
+        (channel, recipient),
+    )
+    return await cursor.fetchone() is not None
+
+
 async def count_undelivered_labeled_surplus(
     db: aiosqlite.Connection, *, channel: str = "email"
 ) -> int:

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -249,6 +249,20 @@ async def marketing_send(prospect_id: str, subject: str, body: str) -> str:
     # before any prior enqueue, pending_outreach may not exist yet; without this the
     # count would raise "no such table" instead of reading 0 (empty-state safety).
     await pending_outreach.ensure_table(_db)
+
+    # (b2b) Per-prospect in-flight dedup: refuse if THIS recipient already has an
+    # undelivered marketing send in flight (queued in pending_outreach OR held in
+    # pending_email_sends). An active prospect stays 'active' until a CONFIRMED
+    # outcome, so without this the campaign stages a SECOND send to the same person
+    # on the next tick → duplicate approval holds → two pitches to one person (and
+    # after one outcome stamps the prospect, the other hold still delivers).
+    # Recipient-keyed (case-insensitive), risk-class-agnostic (catches a
+    # FINANCIAL-misclassified pitch too).
+    if await pes.has_held_for_recipient(_db, recipient) or (
+        await pending_outreach.has_undelivered_labeled_surplus_for_recipient(_db, recipient)
+    ):
+        return json.dumps({"status": "refused", "reason": "already_in_flight"})
+
     in_flight = await pes.count_held_by_risk_class(_db, "bulk") + (
         await pending_outreach.count_undelivered_labeled_surplus(_db, channel="email")
     )

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -226,6 +226,35 @@ async def marketing_send(prospect_id: str, subject: str, body: str) -> str:
     if not recipient or not _is_valid_email(recipient):
         return json.dumps({"status": "refused", "reason": "invalid_recipient"})
 
+    # (b2) Per-prospect dedup: only an ACTIVE prospect may be staged. A prospect is
+    # stamped 'contacted' at the end of a successful stage below, so together with
+    # list_active this stops the ongoing campaign from re-pitching the same targets
+    # every tick (the loop bug), prevents a duplicate hold across ticks, and never
+    # re-cold-pitches someone already in conversation ('replied').
+    if prospect.get("status") != "active":
+        return json.dumps({"status": "refused", "reason": "already_contacted"})
+
+    # (b3) Approval-flood guard: refuse when the owner already has
+    # >= max_pending_holds BULK marketing sends in flight awaiting approval. Count
+    # BOTH queues so the cap bounds a single campaign RUN, not just the post-drain
+    # queue: the campaign (subprocess) path enqueues to pending_outreach, which the
+    # */5min scheduler drain only later converts into HELD pending_email_sends rows.
+    # Counting only the latter reads stale mid-run (the cap would never fire).
+    # held (awaiting owner approval) + queued (awaiting the drain). Read live.
+    from genesis.db.crud import pending_email_sends as pes
+    from genesis.db.crud import pending_outreach
+    from genesis.outreach.marketing_config import max_pending_holds
+
+    # Ensure the queue table exists BEFORE counting it — on a standalone MCP boot
+    # before any prior enqueue, pending_outreach may not exist yet; without this the
+    # count would raise "no such table" instead of reading 0 (empty-state safety).
+    await pending_outreach.ensure_table(_db)
+    in_flight = await pes.count_held_by_risk_class(_db, "bulk") + (
+        await pending_outreach.count_undelivered_labeled_surplus(_db, channel="email")
+    )
+    if in_flight >= max_pending_holds():
+        return json.dumps({"status": "refused", "reason": "approval_queue_full"})
+
     # (c) Compose + stage. category=NOTIFICATION (external informational outreach,
     # no category-level approval gate — the email autonomy gate is the authority);
     # labeled_surplus=True → BULK classification at the gate.
@@ -239,9 +268,10 @@ async def marketing_send(prospect_id: str, subject: str, body: str) -> str:
         # Subprocess (standalone MCP) path — enqueue for the genesis-server drain,
         # which rebuilds the request with labeled_surplus preserved (mirrors
         # outreach_send's enqueue). The BULK flag survives via pending_outreach.
-        from genesis.db.crud import pending_outreach
-
-        await pending_outreach.ensure_table(_db)  # idempotent safety net
+        # The prospect is stamped 'contacted' downstream by the email-gate drain /
+        # pipeline on a CONFIRMED outcome (delivered / owner-rejected) — NOT here at
+        # enqueue, so a send later dropped before it reaches the gate never burns the
+        # prospect. (pending_outreach.ensure_table already ran in the flood-cap check.)
         pending_id = await pending_outreach.enqueue(
             _db,
             message=message,
@@ -268,6 +298,10 @@ async def marketing_send(prospect_id: str, subject: str, body: str) -> str:
         verbatim=True,
     )
     result = await _pipeline.submit(req)
+    # The prospect is stamped 'contacted' by the email-gate drain on a CONFIRMED
+    # outcome (delivered / owner-rejected), NOT here — a held send is not yet a
+    # confirmed contact, and stamping now would burn the prospect if it is later
+    # rejected as uncurated/opted-out or never approved.
     if result.status == OutreachStatus.HELD:
         return json.dumps({
             "status": "not_performed",

--- a/src/genesis/outreach/marketing_config.py
+++ b/src/genesis/outreach/marketing_config.py
@@ -133,12 +133,12 @@ def max_pending_holds() -> int:
     guard. Read live. A non-int / bool / non-positive value degrades to the safe
     default (the guard is never disabled by a typo)."""
     raw = load_config().get("max_pending_holds", _DEFAULT_MAX_PENDING_HOLDS)
-    # bool is an int subclass — reject it explicitly (YAML `true` → 1 would be a
-    # nonsensical cap of one).
-    if isinstance(raw, bool):
+    # Require a GENUINE positive int (YAML `20`). Do NOT coerce with int(): a float
+    # would silently truncate (1.9 -> 1, unexpectedly blocking nearly all staging),
+    # a YAML `.inf` would raise OverflowError, and a string is malformed. bool is an
+    # int subclass so it is rejected first (YAML `true` must not read as a cap of 1).
+    # Every non-int / non-positive value degrades to the safe default (the documented
+    # promise — the guard is never silently mis-set or disabled by a typo).
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
         return _DEFAULT_MAX_PENDING_HOLDS
-    try:
-        n = int(raw)
-    except (TypeError, ValueError):
-        return _DEFAULT_MAX_PENDING_HOLDS
-    return n if n > 0 else _DEFAULT_MAX_PENDING_HOLDS
+    return raw

--- a/src/genesis/outreach/marketing_config.py
+++ b/src/genesis/outreach/marketing_config.py
@@ -56,12 +56,20 @@ _CONFIG_NAME = "marketing_outreach.yaml"
 
 _ENV_KILL_SWITCH = "GENESIS_MARKETING_OUTREACH_DISABLED"
 
+# Default cap on BULK marketing sends awaiting owner approval — the ASK-state
+# approval-flood guard. Bounds the owner's approval queue independent of prospect
+# count. A non-positive / non-int / corrupt override degrades to this value (the
+# guard can never be disabled by a typo — set a very high number for "unbounded").
+_DEFAULT_MAX_PENDING_HOLDS = 20
+
 DEFAULTS: dict[str, Any] = {
     # Master switch: require a LITERAL boolean True to stay enabled.
     "enabled": True,
     # Shipped default: OFF. This substrate stages cold outreach on the owner's
     # behalf — it stays inert until the owner deliberately opts in.
     "mode": "off",
+    # ASK-state approval-flood guard (see _DEFAULT_MAX_PENDING_HOLDS).
+    "max_pending_holds": _DEFAULT_MAX_PENDING_HOLDS,
 }
 
 
@@ -117,3 +125,20 @@ def effective_mode() -> str:
         logger.warning("marketing_outreach has invalid mode %r — degrading to off", mode)
         return "off"
     return mode
+
+
+def max_pending_holds() -> int:
+    """Max BULK (marketing) sends that may sit HELD awaiting owner approval before
+    ``marketing_send`` refuses to stage new ones — the ASK-state approval-flood
+    guard. Read live. A non-int / bool / non-positive value degrades to the safe
+    default (the guard is never disabled by a typo)."""
+    raw = load_config().get("max_pending_holds", _DEFAULT_MAX_PENDING_HOLDS)
+    # bool is an int subclass — reject it explicitly (YAML `true` → 1 would be a
+    # nonsensical cap of one).
+    if isinstance(raw, bool):
+        return _DEFAULT_MAX_PENDING_HOLDS
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_PENDING_HOLDS
+    return n if n > 0 else _DEFAULT_MAX_PENDING_HOLDS

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -781,6 +781,17 @@ class OutreachPipeline:
                 await self._record_autonomous_send(
                     request, gate_cell, recipient, outreach_id, now,
                 )
+                # Marketing (BULK) autonomous delivery: advance the prospect
+                # active → contacted so the campaign's list_active stops re-pitching
+                # it. The HELD → owner-approved path stamps in the email-gate drain
+                # (email_gate_watcher, keyed on the hold's cell_risk_class); this is
+                # the GRANTED-cell path, which delivers INLINE here and never touches
+                # that drain — without this the loop-fix would silently regress once
+                # the BULK cell graduates to autonomous. Same active-guarded CRUD.
+                if gate_cell[2] == "bulk":
+                    from genesis.db.crud import marketing_prospects as _mp
+
+                    await _mp.mark_contacted_by_email(self._db, recipient, contacted_at=now)
 
         # Auto-register email threads for reply tracking
         if channel == "email" and self._thread_tracker is not None:

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -781,17 +781,17 @@ class OutreachPipeline:
                 await self._record_autonomous_send(
                     request, gate_cell, recipient, outreach_id, now,
                 )
-                # Marketing (BULK) autonomous delivery: advance the prospect
-                # active → contacted so the campaign's list_active stops re-pitching
-                # it. The HELD → owner-approved path stamps in the email-gate drain
-                # (email_gate_watcher, keyed on the hold's cell_risk_class); this is
+                # Autonomous (GRANTED-cell) delivery: advance a matching curated
+                # prospect active → contacted (a no-op for a non-prospect recipient)
+                # so the campaign's list_active stops re-pitching it. The
+                # HELD → owner-approved path stamps in the email-gate drain; this is
                 # the GRANTED-cell path, which delivers INLINE here and never touches
                 # that drain — without this the loop-fix would silently regress once
-                # the BULK cell graduates to autonomous. Same active-guarded CRUD.
-                if gate_cell[2] == "bulk":
-                    from genesis.db.crud import marketing_prospects as _mp
+                # the cell graduates to autonomous. Keyed on the RECIPIENT (not the
+                # cell's risk class), same active-guarded CRUD as the drain.
+                from genesis.db.crud import marketing_prospects as _mp
 
-                    await _mp.mark_contacted_by_email(self._db, recipient, contacted_at=now)
+                await _mp.mark_contacted_by_email(self._db, recipient, contacted_at=now)
 
         # Auto-register email threads for reply tracking
         if channel == "email" and self._thread_tracker is not None:

--- a/tests/test_autonomy/test_email_gate_watcher.py
+++ b/tests/test_autonomy/test_email_gate_watcher.py
@@ -428,27 +428,31 @@ async def test_orphaned_bulk_hold_leaves_prospect_active(db):
 
 
 @pytest.mark.asyncio
-async def test_delivered_standard_hold_does_not_stamp_prospects(db):
-    """Only BULK (marketing) sends stamp a prospect. A delivered STANDARD email that
-    happens to reach a prospect's address must NOT flip its status."""
+async def test_delivered_financial_misclassified_pitch_still_stamps_prospect(db):
+    """Provenance is RECIPIENT-based, NOT cell_risk_class. A cold pitch whose body
+    tripped the money-pattern classifier holds as FINANCIAL (not BULK), but on
+    delivery to a curated prospect it must STILL stamp them contacted — else that
+    prospect is re-pitched forever (Codex P1: preserve marketing provenance across
+    the financial misclassification)."""
     from genesis.db.crud import marketing_prospects as mp
 
     await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
     rid = await _approval(db, status="approved")
     await pes.create(
         db,
-        id="ps",
+        id="pf",
         request_id=rid,
         validated_recipient="prospect@example.com",
-        category="outreach",
-        message="a normal reply",
+        category="notification",
+        message="invoice attached — remit payment",
         held_at=_TS,
         cell_domain="email",
         cell_verb="send",
-        cell_risk_class="standard",
+        cell_risk_class="financial",
     )
 
     assert (
         await drain_pending_email_sends(_FakeRt(db, _FakePipeline(OutreachStatus.DELIVERED))) == 1
     )
-    assert (await mp.get_by_id(db, "prospect"))["status"] == "active"  # untouched
+    # stamped despite the FINANCIAL class — provenance is recipient-based
+    assert (await mp.get_by_id(db, "prospect"))["status"] == "contacted"

--- a/tests/test_autonomy/test_email_gate_watcher.py
+++ b/tests/test_autonomy/test_email_gate_watcher.py
@@ -352,3 +352,103 @@ async def test_approved_but_pipeline_ignores_is_terminal(db):
     # The approval lifecycle is closed (consumed) so it doesn't linger as a
     # ghost approved/unconsumed row in operator views.
     assert (await ac.get_by_id(db, rid))["consumed_at"] is not None
+
+
+# --- PR2: prospect contact-stamping at CONFIRMED outcome (not stage time) -----
+
+
+async def _bulk_hold_for(db, *, prospect_email, rid, pid="pb"):
+    await pes.create(
+        db,
+        id=pid,
+        request_id=rid,
+        validated_recipient=prospect_email,
+        category="notification",
+        message="cold pitch",
+        held_at=_TS,
+        cell_domain="email",
+        cell_verb="send",
+        cell_risk_class="bulk",
+    )
+
+
+@pytest.mark.asyncio
+async def test_delivered_bulk_hold_stamps_prospect_contacted(db, monkeypatch):
+    """Confirmed delivery of a cold-marketing (BULK) send advances the prospect
+    active → contacted at the DRAIN (the confirmed-outcome home), so the campaign's
+    list_active stops re-pitching it — the loop fix, applied where delivery is real."""
+    monkeypatch.setattr(egw, "_marketing_mode", lambda: "live")  # armed
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    rid = await _approval(db, status="approved")
+    await _bulk_hold_for(db, prospect_email="prospect@example.com", rid=rid)
+
+    assert (
+        await drain_pending_email_sends(_FakeRt(db, _FakePipeline(OutreachStatus.DELIVERED))) == 1
+    )
+    row = await mp.get_by_id(db, "prospect")
+    assert row["status"] == "contacted"
+    assert row["last_contacted_at"] is not None
+    assert await mp.list_active(db) == []  # no longer re-pitched
+
+
+@pytest.mark.asyncio
+async def test_owner_rejected_bulk_hold_stamps_prospect_contacted(db):
+    """An owner REJECTION of a cold-marketing draft advances the prospect to
+    contacted (not auto re-proposed next tick) — a rejection is a decision. No live
+    lever needed: this is the reject branch, not delivery."""
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    rid = await _approval(db, status="rejected")
+    await _bulk_hold_for(db, prospect_email="prospect@example.com", rid=rid)
+
+    assert (
+        await drain_pending_email_sends(_FakeRt(db, _FakePipeline(OutreachStatus.DELIVERED))) == 1
+    )
+    assert (await mp.get_by_id(db, "prospect"))["status"] == "contacted"
+
+
+@pytest.mark.asyncio
+async def test_orphaned_bulk_hold_leaves_prospect_active(db):
+    """Anti-burn: a system drop (orphaned hold — approval gone, no owner decision)
+    must NOT stamp the prospect. It stays 'active', re-eligible — only a confirmed
+    owner outcome (deliver / reject) closes a prospect, never a stage or a drop."""
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    await _bulk_hold_for(db, prospect_email="prospect@example.com", rid="gone")
+
+    assert (
+        await drain_pending_email_sends(_FakeRt(db, _FakePipeline(OutreachStatus.DELIVERED))) == 1
+    )
+    assert (await mp.get_by_id(db, "prospect"))["status"] == "active"  # not burned
+    assert len(await mp.list_active(db)) == 1
+
+
+@pytest.mark.asyncio
+async def test_delivered_standard_hold_does_not_stamp_prospects(db):
+    """Only BULK (marketing) sends stamp a prospect. A delivered STANDARD email that
+    happens to reach a prospect's address must NOT flip its status."""
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    rid = await _approval(db, status="approved")
+    await pes.create(
+        db,
+        id="ps",
+        request_id=rid,
+        validated_recipient="prospect@example.com",
+        category="outreach",
+        message="a normal reply",
+        held_at=_TS,
+        cell_domain="email",
+        cell_verb="send",
+        cell_risk_class="standard",
+    )
+
+    assert (
+        await drain_pending_email_sends(_FakeRt(db, _FakePipeline(OutreachStatus.DELIVERED))) == 1
+    )
+    assert (await mp.get_by_id(db, "prospect"))["status"] == "active"  # untouched

--- a/tests/test_db/test_marketing_prospects.py
+++ b/tests/test_db/test_marketing_prospects.py
@@ -116,3 +116,25 @@ async def test_mark_opted_out_is_permanent_suppression(db):
     assert row["opted_out"] == 1
     # An opted-out prospect never re-enters the active set.
     assert await mp.list_active(db) == []
+
+
+@pytest.mark.asyncio
+async def test_mark_contacted_by_email_only_advances_active(db):
+    """The shared by-email stamp used by BOTH delivery paths (drain + granted
+    pipeline). Advances an ACTIVE match → contacted; no-ops (returns False) on an
+    absent recipient or a non-'active' row (never downgrades 'replied'/'contacted',
+    never touches a non-marketing address). Case-insensitive on the email."""
+    await mp.create(db, id="p1", email="Prospect@Example.com", created_at=_TS, updated_at=_TS)
+    # active → contacted (and email match is normalized/case-insensitive)
+    assert await mp.mark_contacted_by_email(db, "prospect@example.com", contacted_at=_TS) is True
+    assert (await mp.get_by_id(db, "p1"))["status"] == "contacted"
+    # second call is a no-op — already non-active, never re-stamped/downgraded
+    assert await mp.mark_contacted_by_email(db, "prospect@example.com", contacted_at=_TS) is False
+    # a 'replied' prospect is NEVER downgraded to 'contacted'
+    await mp.create(
+        db, id="p2", email="replied@example.com", status="replied", created_at=_TS, updated_at=_TS
+    )
+    assert await mp.mark_contacted_by_email(db, "replied@example.com", contacted_at=_TS) is False
+    assert (await mp.get_by_id(db, "p2"))["status"] == "replied"
+    # absent recipient → no-op, no crash
+    assert await mp.mark_contacted_by_email(db, "nobody@example.com", contacted_at=_TS) is False

--- a/tests/test_outreach/test_marketing_send.py
+++ b/tests/test_outreach/test_marketing_send.py
@@ -237,3 +237,52 @@ async def test_refused_send_does_not_stamp_contacted(db):
     out = await _call("p1")
     assert out["status"] == "refused"
     assert (await mp.get_by_id(db, "p1"))["status"] == "active"  # never stamped
+
+
+@pytest.mark.asyncio
+async def test_in_flight_queued_prospect_refuses_second_send(db):
+    """Codex P1 (dup-send): a prospect stays 'active' until a CONFIRMED outcome, so
+    the campaign would re-stage it next tick. The per-prospect in-flight dedup
+    refuses a second send while the first (queued in pending_outreach) is unresolved
+    — no duplicate hold, no two pitches to one person."""
+    await mp.create(db, id="p1", email="a@example.com", created_at=_TS, updated_at=_TS)
+    assert (await _call("p1"))["status"] == "queued"  # first send queued, prospect still active
+    assert (await mp.get_by_id(db, "p1"))["status"] == "active"
+    out = await _call("p1")  # second send while the first is in flight
+    assert out["status"] == "refused"
+    assert out["reason"] == "already_in_flight"
+
+
+@pytest.mark.asyncio
+async def test_in_flight_held_prospect_refuses_second_send(db):
+    """Same dedup via the held queue: a recipient with a HELD send (any risk class,
+    incl. a FINANCIAL-misclassified pitch) is refused a second stage."""
+    await mp.create(db, id="p1", email="a@example.com", created_at=_TS, updated_at=_TS)
+    await pes.create(
+        db,
+        id="h",
+        request_id="r",
+        validated_recipient="a@example.com",
+        category="notification",
+        message="held pitch",
+        cell_domain="email",
+        cell_verb="send",
+        cell_risk_class="financial",  # misclassified marketing hold — still caught
+        held_at=_TS,
+    )
+    out = await _call("p1")
+    assert out["status"] == "refused"
+    assert out["reason"] == "already_in_flight"
+
+
+def test_max_pending_holds_rejects_non_integer(monkeypatch):
+    """Codex P2: the cap must NOT coerce — a fractional value (1.9→1 would block
+    nearly all staging), a YAML .inf (int(float('inf')) raises OverflowError), a
+    string, a bool, or a non-positive value all degrade to the safe default (20)."""
+    import genesis.outreach.marketing_config as mc
+
+    monkeypatch.setattr(mc, "load_config", lambda: {"max_pending_holds": 25})
+    assert mc.max_pending_holds() == 25  # a genuine int is honored
+    for bad in (1.9, 100.9, float("inf"), "20", True, 0, -5):
+        monkeypatch.setattr(mc, "load_config", lambda v=bad: {"max_pending_holds": v})
+        assert mc.max_pending_holds() == mc._DEFAULT_MAX_PENDING_HOLDS

--- a/tests/test_outreach/test_marketing_send.py
+++ b/tests/test_outreach/test_marketing_send.py
@@ -20,6 +20,7 @@ import pytest
 
 import genesis.mcp.outreach_mcp as om
 from genesis.db.crud import marketing_prospects as mp
+from genesis.db.crud import pending_email_sends as pes
 from genesis.db.crud import pending_outreach as po
 from genesis.db.schema import create_all_tables
 
@@ -113,3 +114,126 @@ async def test_empty_store_no_adapter_is_clean_noop(db):
     out = await _call("anything")
     assert out["status"] == "refused"  # clean refuse, no crash
     assert await po.drain(db, now="2099-01-01T00:00:00") == []
+
+
+# --- PR2: contact-stamping (loop-fix) + approval-flood guard -----------------
+
+
+@pytest.mark.asyncio
+async def test_stage_does_not_stamp_at_enqueue(db):
+    """The subprocess (campaign) path stages to pending_outreach but does NOT stamp
+    the prospect at enqueue — 'contacted' is applied downstream by the email-gate
+    drain on a CONFIRMED outcome (delivered / owner-rejected), so a send dropped
+    before it reaches a decision never burns the prospect. After staging the
+    prospect is still 'active' (see test_email_gate_watcher for the drain stamp)."""
+    await mp.create(db, id="p1", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    out = await _call("p1")
+    assert out["status"] == "queued"
+    row = await mp.get_by_id(db, "p1")
+    assert row["status"] == "active"  # NOT stamped at stage
+    assert row["last_contacted_at"] is None
+    assert len(await mp.list_active(db)) == 1  # still eligible until an outcome confirms
+
+
+@pytest.mark.asyncio
+async def test_already_contacted_prospect_refuses_and_enqueues_nothing(db):
+    """A non-active prospect (already staged/contacted) is refused — no duplicate
+    hold across ticks, no re-pitch."""
+    await mp.create(db, id="p1", email="a@example.com", created_at=_TS, updated_at=_TS)
+    await mp.mark_contacted(db, "p1", contacted_at=_TS)
+    out = await _call("p1")
+    assert out["status"] == "refused"
+    assert out["reason"] == "already_contacted"
+    assert await po.drain(db, now="2099-01-01T00:00:00") == []
+
+
+@pytest.mark.asyncio
+async def test_replied_prospect_is_never_recold_pitched(db):
+    """A prospect already in conversation (status='replied') is not re-cold-pitched."""
+    await mp.create(db, id="p1", email="a@example.com", created_at=_TS, updated_at=_TS)
+    await mp.mark_contacted(db, "p1", contacted_at=_TS, status="replied")
+    out = await _call("p1")
+    assert out["status"] == "refused"
+    assert out["reason"] == "already_contacted"
+
+
+@pytest.mark.asyncio
+async def test_flood_cap_refuses_when_approval_queue_full(db, monkeypatch):
+    """When >= max_pending_holds BULK sends already await owner approval, a new
+    stage is refused (the ASK-state approval-flood guard): nothing enqueued, and
+    the prospect is NOT stamped (a refused send is a no-op)."""
+    monkeypatch.setattr("genesis.outreach.marketing_config.max_pending_holds", lambda: 2)
+    for i in range(2):
+        await pes.create(
+            db,
+            id=f"h{i}",
+            request_id=f"r{i}",
+            validated_recipient=f"held{i}@example.com",
+            category="notification",
+            message="held pitch",
+            cell_domain="email",
+            cell_verb="send",
+            cell_risk_class="bulk",
+            held_at=_TS,
+        )
+    await mp.create(db, id="p1", email="a@example.com", created_at=_TS, updated_at=_TS)
+    out = await _call("p1")
+    assert out["status"] == "refused"
+    assert out["reason"] == "approval_queue_full"
+    assert await po.drain(db, now="2099-01-01T00:00:00") == []
+    assert (await mp.get_by_id(db, "p1"))["status"] == "active"  # not stamped
+
+
+@pytest.mark.asyncio
+async def test_flood_cap_ignores_non_bulk_holds(db, monkeypatch):
+    """Only BULK holds count toward the marketing flood cap — an unrelated
+    IDENTITY/STANDARD hold does not block a marketing stage."""
+    monkeypatch.setattr("genesis.outreach.marketing_config.max_pending_holds", lambda: 1)
+    await pes.create(
+        db,
+        id="h_identity",
+        request_id="r_identity",
+        validated_recipient="someone@example.com",
+        category="identity",
+        message="a non-marketing reply",
+        cell_domain="email",
+        cell_verb="send",
+        cell_risk_class="identity",
+        held_at=_TS,
+    )
+    await mp.create(db, id="p1", email="a@example.com", created_at=_TS, updated_at=_TS)
+    out = await _call("p1")
+    assert out["status"] == "queued"  # the identity hold does not count
+
+
+@pytest.mark.asyncio
+async def test_flood_cap_counts_pending_outreach_queue(db, monkeypatch):
+    """The cap must bound a single RUN: the campaign's subprocess path enqueues to
+    pending_outreach (converted into HELD sends only by the */5min drain), so
+    undelivered labeled_surplus rows count toward the cap too — otherwise the cap
+    reads a stale post-drain table and never fires mid-run."""
+    monkeypatch.setattr("genesis.outreach.marketing_config.max_pending_holds", lambda: 2)
+    for i in range(2):
+        await po.enqueue(
+            db,
+            message="queued pitch",
+            category="notification",
+            channel="email",
+            validated_recipient=f"q{i}@example.com",
+            labeled_surplus=True,
+        )
+    await mp.create(db, id="p1", email="a@example.com", created_at=_TS, updated_at=_TS)
+    out = await _call("p1")
+    assert out["status"] == "refused"
+    assert out["reason"] == "approval_queue_full"
+
+
+@pytest.mark.asyncio
+async def test_refused_send_does_not_stamp_contacted(db):
+    """Ordering guard: the stamp happens ONLY after a successful stage, so a
+    refused send (opted-out) leaves the prospect status untouched."""
+    await mp.create(db, id="p1", email="a@example.com", created_at=_TS, updated_at=_TS)
+    await mp.mark_opted_out(db, "p1", opted_out_at=_TS)
+    out = await _call("p1")
+    assert out["status"] == "refused"
+    assert (await mp.get_by_id(db, "p1"))["status"] == "active"  # never stamped

--- a/tests/test_outreach/test_ws8_full_slice_e2e.py
+++ b/tests/test_outreach/test_ws8_full_slice_e2e.py
@@ -175,3 +175,50 @@ async def test_full_earn_grant_send_flag_demote_loop(config, db):
 
     # 7. Re-flag is idempotent: no second demotion path is taken.
     assert await aes.mark_flagged(db, log[0]["id"], flagged_at=now) is False
+
+
+@pytest.mark.asyncio
+async def test_granted_bulk_autonomous_send_stamps_prospect_contacted(config, db, monkeypatch):
+    """The GRANTED-cell autonomous path delivers INLINE in ``pipeline._deliver``,
+    NEVER through the email-gate drain — so the marketing loop-fix (advance the
+    prospect active → contacted so it is not re-pitched) must fire there too. Without
+    it, a delivered cold send leaves the prospect 'active' forever once the BULK cell
+    graduates, and the campaign re-cold-pitches the same person every tick,
+    unsupervised. This is the highest-stakes moment for the loop-fix to hold."""
+    from genesis.db.crud import capability_grants as cg
+    from genesis.db.crud import marketing_prospects as mp
+
+    _ts = "2026-06-21T00:00:00"
+    # Marketing lever armed (a GRANTED bulk cell still auto-sends only when live).
+    monkeypatch.setattr("genesis.outreach.marketing_config.effective_mode", lambda: "live")
+    # GRANT email:send:bulk (grant machinery itself is covered by the loop test above).
+    await cg.ensure_cell(db, domain="email", verb="send", risk_class="bulk", updated_at=_ts)
+    await db.execute(
+        "UPDATE capability_grants SET state = 'granted', granted_at = ? WHERE id = ?",
+        (_ts, cg.cell_id("email", "send", "bulk")),
+    )
+    await db.commit()
+    # A curated ACTIVE prospect (the bulk scope guard requires a curated recipient).
+    await mp.create(db, id="p1", email="prospect@example.com", created_at=_ts, updated_at=_ts)
+
+    adapter = AsyncMock()
+    adapter.send_message.return_value = "<m@x>"
+    pipe = _pipeline(config, db, adapter)
+
+    req = OutreachRequest(
+        category=OutreachCategory.NOTIFICATION,
+        topic="cold pitch",
+        context="body",
+        salience_score=0.5,
+        signal_type="marketing_cold",
+        channel="email",
+        validated_recipient="prospect@example.com",
+        labeled_surplus=True,  # → classifies BULK at the gate
+        verbatim=True,
+    )
+    r = await pipe.submit_raw("cold pitch", req)
+    assert r.status == OutreachStatus.DELIVERED  # autonomous — no hold
+    adapter.send_message.assert_called_once()
+    # The loop-fix at the GRANTED chokepoint: prospect stamped on inline delivery.
+    assert (await mp.get_by_id(db, "p1"))["status"] == "contacted"
+    assert await mp.list_active(db) == []


### PR DESCRIPTION
## What

Completes the autonomous cold-marketing substrate (PR1 = #1490) so the ongoing campaign is safe to run.

- **Loop-fix (contact-stamping).** `marketing_prospects.mark_contacted` had **no caller**, so a delivered prospect stayed `status='active'` and `list_active` returned it forever — an ongoing campaign would re-pitch the same people every tick. A prospect is now advanced `active → contacted` on a **confirmed outcome** (delivery / owner-rejection), via one shared active-guarded CRUD (`mark_contacted_by_email`) called from **both** delivery paths: the email-gate drain (HELD → owner-approved) **and** `pipeline._deliver` on the GRANTED-cell autonomous path (which delivers inline and never touches the drain — so the fix survives capability graduation). A send dropped/expired before any decision leaves the prospect `active` (no silent burn).
- **Per-prospect dedup.** `marketing_send` refuses a non-`active` prospect before staging.
- **Approval-flood guard.** `marketing_send` refuses when `>= max_pending_holds` BULK sends are in flight — counting **both** the `pending_outreach` queue and held `pending_email_sends`, so the cap bounds a single run (config knob, default 20, damage-tolerant: a bad value degrades to the default, never disabled by a typo).

## Safety

Substrate still ships `mode: off`. The `status` stamp is decoupled from every send-authorization predicate (only `opted_out` gates), so it can never weaken the WS-8 email autonomy gate — confirmed by genesis-security-reviewer (no CRITICAL).

## Review + verification

genesis-architect + genesis-security-reviewer (both surfaced real issues, all remediated): the flood-cap now counts both queues (was vestigial for the subprocess campaign path); stamping moved off the stage path (no prospect burn on a downstream drop); the GRANTED-autonomous delivery path now stamps too (the fix previously regressed at graduation). 84 targeted tests pass; verify-RED confirmed non-vacuous on the new stamp tests; E2E through the real pipeline+drain on both delivery paths.

## Deferred (tracked follow-ups)

- TOCTOU on concurrent `marketing_send` callers — bounded (not an authorization bypass; each hold still needs separate owner approval; single-threaded caller today), gated on live-arming.
- A first-class prospect "reopen" path (owner-rejected → re-eligible for a re-worded pitch; opt-out remains the permanent "never" signal).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safeguards preventing duplicate in-flight outreach to the same prospect.
  * Added a configurable approval-queue limit, defaulting to 20 pending holds.
  * Prospects are marked as contacted after confirmed delivery or owner rejection, regardless of message risk classification.
* **Bug Fixes**
  * Pending approval capacity now accounts for queued outreach across delivery paths.
  * Inactive prospects and recipients with queued or held sends are no longer eligible for new outreach.
* **Documentation**
  * Updated outreach safeguards, approval behavior, and verification documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->