### PR TITLE
feat(outreach): marketing_prospects_list — read-only prospect enumeration for the campaign

### DIFF
--- a/src/genesis/cc/direct_session.py
+++ b/src/genesis/cc/direct_session.py
@@ -223,15 +223,20 @@ _NO_OUTREACH_EXTRAS = [
     "mcp__genesis-outreach__outreach_digest",
 ]
 
-# Cold-marketing actuator. marketing_send resolves its recipient in-code from the
-# owner-curated marketing_prospects store and enqueues a BULK cold send — it must be
-# reachable ONLY from the `campaign` profile (the intended autonomous marketing
-# caller). Deny it in every other profile: mandatorily for the untrusted-inbound
-# perimeter profiles (mail, community-responder), where an injected inbound message
-# could otherwise reach the actuator, and belt-and-suspenders on profiles that don't
-# mount genesis-outreach today (guards an MCP-config fallback-to-full).
+# Cold-marketing tools. marketing_send resolves its recipient in-code from the
+# owner-curated marketing_prospects store and enqueues a BULK cold send;
+# marketing_prospects_list ENUMERATES that same private store (names + addresses).
+# Both must be reachable ONLY from the `campaign` profile (the intended autonomous
+# marketing caller). Deny them in every other profile: mandatorily for the
+# untrusted-inbound perimeter profiles (mail, community-responder), where an injected
+# inbound message could otherwise reach the actuator OR exfiltrate the prospect list
+# by echoing it back through the profile's reply tool, and belt-and-suspenders on
+# profiles that don't mount genesis-outreach today (guards an MCP-config
+# fallback-to-full). NOTE: the tool code-gates on effective_mode()==off (returns
+# empty), so this denial is what protects the store once marketing mode is ARMED.
 _NO_MARKETING_SEND = [
     "mcp__genesis-outreach__marketing_send",
+    "mcp__genesis-outreach__marketing_prospects_list",
 ]
 
 # The venv Python interpreter running genesis-server. Exposed to profile

--- a/src/genesis/mcp/outreach_mcp.py
+++ b/src/genesis/mcp/outreach_mcp.py
@@ -286,6 +286,62 @@ async def marketing_send(prospect_id: str, subject: str, body: str) -> str:
 
 
 @mcp.tool()
+async def marketing_prospects_list(limit: int = 100) -> str:
+    """List the ACTIVE, non-opted-out marketing prospects — the cold-outreach targets
+    the campaign may pitch — so it can enumerate → personalise a pitch → call
+    ``marketing_send(prospect_id, subject, body)``.
+
+    READ-ONLY (never sends). Returns ``id``/``email``/``name``/``company`` per row.
+    Excludes any prospect that is opted-out OR already ``contacted``/``replied``
+    (``list_active`` semantics), so a target that has been delivered a pitch never
+    reappears here — this is what stops the campaign re-pitching the same person.
+    Also returns the live ``mode`` of the ``marketing_outreach`` lever so the campaign
+    can do nothing when it is ``off``. On a fresh clone the store is empty and this
+    returns an empty list.
+
+    Args:
+        limit: max prospects to return (default 100). ``truncated`` flags a longer store.
+    """
+    from genesis.outreach.marketing_config import effective_mode
+
+    mode = effective_mode()
+    if _db is None:
+        return json.dumps({"status": "error", "reason": "no_database", "mode": mode, "prospects": []})
+    if mode == "off":
+        # Mirror marketing_send's OUTER off-switch: when the marketing lever is off the
+        # cold-send substrate surfaces NOTHING — don't hand the target inventory to a
+        # campaign session that shouldn't be running. Code-gated (not LLM-trusted to
+        # read the `mode` field), so the off posture holds even for a misbehaving caller.
+        return json.dumps({
+            "status": "ok", "mode": mode, "count": 0, "total": 0, "truncated": False,
+            "prospects": [],
+        })
+
+    from genesis.db.crud import marketing_prospects as mp
+
+    n = limit if isinstance(limit, int) and limit > 0 else 100
+    rows = await mp.list_active(_db)
+    truncated = len(rows) > n
+    prospects = [
+        {
+            "id": r["id"],
+            "email": r["email"],
+            "name": r.get("name"),
+            "company": r.get("company"),
+        }
+        for r in rows[:n]
+    ]
+    return json.dumps({
+        "status": "ok",
+        "mode": mode,
+        "count": len(prospects),
+        "total": len(rows),  # denominator for `truncated` (no silent cap)
+        "truncated": truncated,
+        "prospects": prospects,
+    })
+
+
+@mcp.tool()
 async def outreach_poll(
     channel: str,
     question: str,

--- a/tests/test_cc/test_direct_session_profiles.py
+++ b/tests/test_cc/test_direct_session_profiles.py
@@ -470,6 +470,46 @@ def test_marketing_send_cannot_be_re_enabled_via_tool_exceptions(profile):
     assert _MARKETING_SEND in inv.disallowed_tools
 
 
+_MARKETING_LIST = "mcp__genesis-outreach__marketing_prospects_list"
+
+
+@pytest.mark.parametrize(
+    "profile",
+    [p for p in PROFILES if p != "campaign"],
+)
+def test_marketing_prospects_list_denied_outside_campaign(profile):
+    """The prospect ENUMERATION tool exposes private names+addresses from the
+    marketing_prospects store. Like the actuator, it must be reachable ONLY from
+    `campaign`; every other profile — crucially the untrusted-inbound perimeter
+    (mail + community-responder) — must deny it, so an injected inbound message can
+    never enumerate the list and echo it back through the reply tool."""
+    assert _MARKETING_LIST in PROFILES[profile], f"{profile} must deny {_MARKETING_LIST}"
+
+
+def test_marketing_prospects_list_allowed_in_campaign():
+    """campaign is the intended marketing caller — it must NOT deny the enumeration."""
+    assert _MARKETING_LIST not in PROFILES["campaign"]
+
+
+@pytest.mark.parametrize(
+    "profile",
+    [p for p in PROFILES if p != "campaign"],
+)
+def test_marketing_prospects_list_cannot_be_re_enabled_via_tool_exceptions(profile):
+    """A per-request tool_exception must NOT unblock the enumeration on a non-campaign
+    profile — otherwise the exception mechanism is a prospect-PII exfil hole from the
+    untrusted-inbound perimeter."""
+    runner = _make_runner()
+    req = DirectSessionRequest(
+        prompt="t",
+        profile=profile,
+        model=CCModel.SONNET,
+        tool_exceptions=(_MARKETING_LIST,),
+    )
+    inv = runner._build_invocation(req, "test-session")
+    assert _MARKETING_LIST in inv.disallowed_tools
+
+
 def test_mail_blocks_outreach_extras():
     assert "mcp__genesis-outreach__outreach_send_and_wait" in PROFILES["mail"]
     assert "mcp__genesis-outreach__outreach_poll" in PROFILES["mail"]

--- a/tests/test_outreach/test_marketing_prospects_list.py
+++ b/tests/test_outreach/test_marketing_prospects_list.py
@@ -1,0 +1,111 @@
+"""Tests for the ``marketing_prospects_list`` MCP tool — the read-only enumeration
+the campaign uses to discover which curated prospects to pitch (→ marketing_send).
+
+Install-agnostic: tmp DB, no network, synthetic prospects only.
+"""
+
+from __future__ import annotations
+
+import json
+
+import aiosqlite
+import pytest
+
+import genesis.mcp.outreach_mcp as om
+from genesis.db.crud import marketing_prospects as mp
+from genesis.db.schema import create_all_tables
+
+_TS = "2026-09-03T00:00:00"
+
+
+@pytest.fixture
+async def db(tmp_path):
+    conn = await aiosqlite.connect(str(tmp_path / "t.db"))
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    await conn.commit()
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture(autouse=True)
+def _wire(db, monkeypatch):
+    monkeypatch.setattr(om, "_db", db, raising=False)
+    monkeypatch.setattr("genesis.outreach.marketing_config.effective_mode", lambda: "observe")
+    yield
+
+
+async def _list(limit=100):
+    tools = await om.mcp.get_tools()
+    return json.loads(await tools["marketing_prospects_list"].fn(limit=limit))
+
+
+@pytest.mark.asyncio
+async def test_empty_store_returns_empty_list_with_mode(db):
+    out = await _list()
+    assert out["status"] == "ok"
+    assert out["mode"] == "observe"  # campaign can short-circuit when off
+    assert out["count"] == 0
+    assert out["prospects"] == []
+    assert out["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_lists_active_prospects_with_fields(db):
+    await mp.create(
+        db,
+        id="p1",
+        email="Dev@Example.com",
+        name="Dev One",
+        company="Acme",
+        created_at=_TS,
+        updated_at=_TS,
+    )
+    out = await _list()
+    assert out["count"] == 1
+    row = out["prospects"][0]
+    assert row == {"id": "p1", "email": "dev@example.com", "name": "Dev One", "company": "Acme"}
+
+
+@pytest.mark.asyncio
+async def test_excludes_opted_out_and_non_active(db):
+    await mp.create(db, id="active", email="a@example.com", created_at=_TS, updated_at=_TS)
+    await mp.create(db, id="contacted", email="c@example.com", created_at=_TS, updated_at=_TS)
+    await mp.mark_contacted(db, "contacted", contacted_at=_TS)  # delivered → excluded
+    await mp.create(db, id="opted", email="o@example.com", created_at=_TS, updated_at=_TS)
+    await mp.mark_opted_out(db, "opted", opted_out_at=_TS)  # opted-out → excluded
+    out = await _list()
+    assert [p["id"] for p in out["prospects"]] == ["active"]  # only the active one
+
+
+@pytest.mark.asyncio
+async def test_limit_truncates_and_flags(db):
+    for i in range(3):
+        await mp.create(db, id=f"p{i}", email=f"p{i}@example.com", created_at=_TS, updated_at=_TS)
+    out = await _list(limit=2)
+    assert out["count"] == 2
+    assert out["total"] == 3  # denominator reported alongside truncated (no silent cap)
+    assert out["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_off_mode_surfaces_nothing(db, monkeypatch):
+    """The outer off-switch: when the marketing lever is off the tool surfaces NO
+    prospects (code-gated, mirroring marketing_send's off refusal) — even with a
+    populated store, a campaign session that shouldn't be running gets nothing."""
+    monkeypatch.setattr("genesis.outreach.marketing_config.effective_mode", lambda: "off")
+    await mp.create(db, id="p1", email="a@example.com", created_at=_TS, updated_at=_TS)
+    out = await _list()
+    assert out["status"] == "ok"
+    assert out["mode"] == "off"
+    assert out["count"] == 0
+    assert out["prospects"] == []
+
+
+@pytest.mark.asyncio
+async def test_no_database_is_clean_error(db, monkeypatch):
+    monkeypatch.setattr(om, "_db", None, raising=False)
+    out = await _list()
+    assert out["status"] == "error"
+    assert out["reason"] == "no_database"
+    assert out["prospects"] == []


### PR DESCRIPTION
## What

The campaign can call `marketing_send(prospect_id, …)` but had no way to discover WHICH curated prospects to pitch. This adds a read-only `marketing_prospects_list` MCP tool (genesis-outreach) returning the ACTIVE, non-opted-out prospects (`id`/`email`/`name`/`company`), so the campaign can enumerate → personalize → `marketing_send`. Companion to #1647 (the send-side loop-fix + approval-flood cap).

## Behavior

- Excludes opted-out + already-`contacted`/`replied` prospects (via `list_active`) — a delivered target never reappears (the loop-fix's enumeration guarantee).
- **Code-gates on the marketing lever `off`**: returns nothing, mirroring `marketing_send`'s outer off-switch — not LLM-trusted to read the reported `mode`.
- Reports `total` alongside `truncated` (no silent cap). Read-only, no egress.

## Review

genesis-architect (DONE_WITH_CONCERNS → all folded: the off-switch code-gate, the off-mode test, the `total` denominator). 6 tests, verify-RED on the off-gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a read-only tool for listing eligible marketing prospects.
  * Results include basic prospect details, total counts, and truncation status.
  * Supports configurable result limits and respects the marketing mode.

* **Bug Fixes**
  * Handles missing databases and invalid limits without errors.
  * Excludes contacted or opted-out prospects from results.
  * Restricts prospect-list access to the campaign profile, including when request-level overrides are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->