### PR TITLE
docs(cc): hook output has two channels, capped differently

### DIFF
--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -506,6 +506,45 @@ Genesis hooks read input through `scripts/hooks/hook_input.py`
 stdin, extracts the `tool_input`-nested fields, and warns on a malformed payload
 so a broken contract can't silently fail open again.
 
+#### Hook OUTPUT: a decision channel and a context channel, capped differently
+
+These are separate, and conflating them produces a plausible-but-wrong safety
+worry. CC **files** a hook's stdout above a per-hook-entry size cap (10,000
+characters on 2.1.246 — version-volatile; it sat near the high-20s K on 2.1.218)
+and shows the model a ~2 KB preview. That cap governs stdout as **model-visible
+context**.
+
+It does **not** gate the control-plane parse of `hookSpecificOutput`. A
+PreToolUse `deny` is parsed and honoured however long its
+`permissionDecisionReason` is — so an oversized reason does **not** cause the
+gate to fail open.
+
+MEASURED 2026-09-03 on CC 2.1.246, via `claude -p --settings <probe>` with a
+PreToolUse hook emitting a `deny` whose reason length was varied, discriminating
+on a **disk side effect** (the denied command writes a marker file) rather than
+on wording:
+
+| reason chars | hook stdout bytes | marker written | verdict |
+|---|---|---|---|
+| 500 | 617 | no | BLOCKED (control) |
+| 15,000 | 15,117 | no | BLOCKED |
+| 200,000 | 200,117 | no | BLOCKED |
+
+The small-reason control arm is load-bearing: without it, "not blocked" at the
+large size is indistinguishable from a probe that never worked. In all three
+arms the reason also reached the model, so it is not silently discarded.
+
+Two cautions. **Re-measure both numbers after a CC pin bump** — the stdout cap
+has already moved once across a version bump, and this one could too. And do not
+transfer either result to the other channel, or to a tool result: per-tool
+`maxResultSizeChars` is a third budget again.
+
+Genesis's own gates are unaffected either way: every blocking hook uses **exit
+code 2 with the reason on stderr**, whose verdict comes from the exit status and
+therefore cannot be weakened by a long reason. `permissionDecision` appears in
+the tree only as `allow` and `ask`. The measurement matters for any future hook
+that denies via JSON.
+
 `session_id` is a special case: a dozen hooks interpolate it into a filesystem
 path (`~/.genesis/sessions/<id>/`), and several `mkdir(parents=True)` — so an id
 carrying `/` or `..` would not merely read the wrong file, it would CREATE


### PR DESCRIPTION
## What this settles

Claude Code **files** a hook's stdout above a per-hook-entry cap (10,000 chars on
2.1.246) and shows the model a ~2 KB preview. That raised a reasonable safety worry:
if a PreToolUse `deny` carries a long `permissionDecisionReason`, is the stdout filed
*before* the JSON is parsed — so the decision is never read and **the gate silently
fails open**?

**No.** This was first established at n=1 / 11,000 chars, in a measurement whose own
write-up flagged the limit: *"says nothing about far larger payloads."* This PR is an
independent replication that **extends the range 18x, to 200,117 bytes**, and writes
the result into the reference doc where the next person will actually look for it.

The cap governs stdout as *model-visible context*. It does not gate the control-plane
parse of `hookSpecificOutput`.

## Measured

`claude -p --settings <probe>` on CC 2.1.246, with a PreToolUse hook emitting a `deny`
whose reason length was varied. The discriminator is a **disk side effect** — the
denied command writes a marker file — not the wording of any message:

| reason chars | hook stdout bytes | marker written | verdict |
|---|---|---|---|
| 500 | 617 | no | BLOCKED (control) |
| 15,000 | 15,117 | no | BLOCKED |
| 200,000 | 200,117 | no | BLOCKED |

The small-reason **control arm is load-bearing**: without a run that is known to
block, "not blocked" at the large size is indistinguishable from a probe that never
worked at all. In all three arms the reason also reached the model (it quoted the
probe's marker token), so it is not silently discarded either.

## Why it's worth writing down rather than just knowing

Two cautions ship with the number, because the failure mode here is confident
over-generalisation:

- **Version-volatile.** The sibling stdout cap already moved once across a bump
  (~high-20s K on 2.1.218 → 10 K on 2.1.246). Re-measure both after a pin bump.
- **Don't transfer the result between channels.** Hook stdout, the
  `hookSpecificOutput` parse, and a tool result's `maxResultSizeChars` are three
  separate budgets. A probe on one says nothing about the others — which is precisely
  the mistake this measurement exists to close.

## Genesis impact: none today, relevant tomorrow

Every blocking gate in the tree uses **exit code 2 with the reason on stderr**, whose
verdict comes from the exit status and so cannot be weakened by a long reason.
`permissionDecision` appears only as `allow` and `ask` — there is no JSON `deny` in
the tree at all, so the failure mode had no live instance either way.

It becomes relevant for any future hook that denies via JSON: this is the evidence
that such a path needs no reason-length cap for *correctness* (it may still want one
for readability).

## Why the doc, given the result already existed

It existed in a local design doc, not in `cc-compatibility.md` — which is the file the
CC-update checklist actually sends you to, and the one that already carries the sibling
stdout-cap number. A measurement recorded only beside the design that prompted it gets
re-derived by the next person who needs it; this PR is that re-derivation, so the fix
is to put it where the question gets asked.

Docs-only, single file.
