### PR TITLE
fix(outreach): stamp a delivered marketing prospect contacted (loop-fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **The cold-marketing campaign no longer re-pitches the same person.** Once a
+  marketing pitch is delivered to a prospect, that prospect is marked contacted and
+  drops out of the campaign's target list — previously nothing recorded the contact,
+  so the campaign would have re-pitched every delivered target on each run. Works on
+  both the owner-approved and (future) autonomous send paths; a pitch that never
+  delivers (dropped, expired, or rejected) leaves the prospect eligible for a later,
+  re-worked pitch. (The substrate still ships off by default.)
+
 ### Changed
 
 - **Mistral Large is now tracked as a paid provider.** Mistral removed the Large

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -494,7 +494,7 @@ gated — that contract is one-directional.
 ```yaml subsystem-map
 entry: autonomy-egress
 modules: [autonomy, outreach, distribution, content, campaigns]
-verified: 85f91765 2026-09-01
+verified: 5808e7cd 2026-09-03
 ```
 
 - **The chokepoint is `outreach/pipeline.py _deliver`** — ~12 send paths
@@ -555,10 +555,22 @@ verified: 85f91765 2026-09-01
   MUST be a curated, non-opted-out `marketing_prospects` row (authorization is
   DECOUPLED from send-lifecycle status, so a `contacted` follow-up still sends) —
   an unknown / opted-out recipient trips (`recipient_not_curated` / `opted_out`)
-  → demote + hold (fail-closed). PR2 will wire graduation, send-time contact
-  stamping, AND a hard per-window cap on hold-creation (the ASK-state
-  approval-flood guard) alongside the batch-approval card — `marketing_send` has
-  no autonomous caller until then.
+  → demote + hold (fail-closed). Graduation for the BULK cell rides the generic
+  capability-promotion path (`capability_grants.detect_promotable_cells` — no
+  risk-class filter → `email:send:bulk` qualifies once it has ≥5 owner-approved
+  successes + posterior ≥0.70). **Contact-stamping (loop-fix):** on a CONFIRMED
+  delivery a matching prospect is advanced active → `contacted` via one
+  active-guarded CRUD (`marketing_prospects.mark_contacted_by_email`) called from
+  BOTH delivery paths — the email-gate drain (`email_gate_watcher`) for a HELD →
+  owner-approved send, AND `pipeline._deliver` for a GRANTED-cell autonomous send
+  (which delivers inline and never touches the drain, so the fix survives
+  graduation). Keyed on the RECIPIENT being a curated prospect, NOT `cell_risk_class`
+  (a FINANCIAL-misclassified pitch is still stamped); a send that never delivers
+  (dropped/expired/rejected) leaves the prospect `active`, re-eligible. Without this,
+  `mark_contacted` had no caller and `list_active` re-returned a delivered prospect
+  every tick. **DEFERRED (hot follow-up, before arming at volume):** an atomic
+  per-prospect in-flight dedup + a per-window approval-flood cap + the batch-approval
+  card — `marketing_send` has no autonomous caller until the campaign is armed.
 - **Marketing reply → owner Telegram ping (notify-only).** When a GENUINE human
   reply lands (auto-responders + foreign senders already gated out by the
   reply→engagement bridge, `outreach/engagement.py`) AND the reply's recipient is

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -121,12 +121,15 @@ async def drain_pending_email_sends(rt: object) -> int:
                 # but crashed before marking the hold 'sent'. Reconcile WITHOUT
                 # re-sending: this narrows the at-least-once window to the gap
                 # between adapter.send and mark_consumed.
-                await pes.mark_sent(db, row["id"], sent_at=now)
                 # LOOP-FIX: this row was genuinely DELIVERED by the prior (crashed)
-                # cycle, which never reached the stamp below — advance the prospect
-                # here too so a crash between delivery and the stamp can't leave it
-                # 'active' and re-pitched.
+                # cycle, which never reached the DELIVERED-branch stamp — advance the
+                # prospect here too. Stamp BEFORE terminalizing (mark_sent), mirroring
+                # the DELIVERED branch: if this recovery itself crashes/DB-errors in the
+                # window, the hold stays 'held' (re-drained → this branch re-runs, the
+                # stamp being idempotent) rather than going 'sent' with the prospect
+                # left 'active' and re-pitched.
                 await _stamp_prospect_contacted(db, row["validated_recipient"], now)
+                await pes.mark_sent(db, row["id"], sent_at=now)
                 resolved += 1
                 logger.info(
                     "Reconciled held email %s (approval already consumed) — not re-sent",

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -70,6 +70,20 @@ async def _recipient_opted_out(db: object, recipient: str | None) -> bool:
     return bool(row.get("opted_out"))
 
 
+async def _stamp_prospect_contacted(db: object, recipient: str | None, now: str) -> None:
+    """LOOP-FIX helper: on a CONFIRMED delivery, advance the matching prospect
+    active → contacted so the campaign's ``list_active`` never re-pitches it.
+    Delegates to the shared, active-guarded CRUD (the same entry point
+    ``pipeline._deliver`` uses for the GRANTED autonomous path), so the stamp
+    semantics live in one place. A non-marketing / non-active / absent recipient is
+    a no-op."""
+    if not recipient:
+        return
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.mark_contacted_by_email(db, recipient, contacted_at=now)
+
+
 def _subject(context: str | None) -> str:
     if not context:
         return ""
@@ -108,6 +122,11 @@ async def drain_pending_email_sends(rt: object) -> int:
                 # re-sending: this narrows the at-least-once window to the gap
                 # between adapter.send and mark_consumed.
                 await pes.mark_sent(db, row["id"], sent_at=now)
+                # LOOP-FIX: this row was genuinely DELIVERED by the prior (crashed)
+                # cycle, which never reached the stamp below — advance the prospect
+                # here too so a crash between delivery and the stamp can't leave it
+                # 'active' and re-pitched.
+                await _stamp_prospect_contacted(db, row["validated_recipient"], now)
                 resolved += 1
                 logger.info(
                     "Reconciled held email %s (approval already consumed) — not re-sent",
@@ -198,6 +217,12 @@ async def drain_pending_email_sends(rt: object) -> int:
                     # WS-3 gate-3: the OWNER approved this send — owner evidence.
                     origin_class="owner",
                 )
+                # LOOP-FIX: confirmed delivery → advance a matching curated prospect
+                # active → contacted (a no-op for a non-prospect recipient) so
+                # list_active stops re-pitching it. Keyed on the RECIPIENT being a
+                # curated prospect, NOT cell_risk_class, so a cold pitch that
+                # misclassified FINANCIAL (money-term body) is still stamped.
+                await _stamp_prospect_contacted(db, row["validated_recipient"], now)
                 resolved += 1
                 logger.info(
                     "Resolved held email %s → sent to %s",

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -207,6 +207,16 @@ async def drain_pending_email_sends(rt: object) -> int:
             )
             if result.status == OutreachStatus.DELIVERED:
                 await approval_crud.mark_consumed(db, row["request_id"], consumed_at=now)
+                # LOOP-FIX: stamp the prospect BEFORE the hold goes terminal
+                # (`mark_sent`), so a crash in this window leaves the hold 'held' —
+                # re-drained via the consumed-approval reconcile branch above, which
+                # re-stamps — rather than 'sent' with the prospect never advanced.
+                # `mark_consumed` already ran, so a re-drain can never double-send.
+                # Advance a matching curated prospect active → contacted (a no-op for
+                # a non-prospect recipient) so list_active stops re-pitching it. Keyed
+                # on the RECIPIENT being a curated prospect, NOT cell_risk_class, so a
+                # cold pitch that misclassified FINANCIAL (money-term body) is stamped.
+                await _stamp_prospect_contacted(db, row["validated_recipient"], now)
                 await pes.mark_sent(db, row["id"], sent_at=now)
                 await cg.record_success(
                     db,
@@ -217,12 +227,6 @@ async def drain_pending_email_sends(rt: object) -> int:
                     # WS-3 gate-3: the OWNER approved this send — owner evidence.
                     origin_class="owner",
                 )
-                # LOOP-FIX: confirmed delivery → advance a matching curated prospect
-                # active → contacted (a no-op for a non-prospect recipient) so
-                # list_active stops re-pitching it. Keyed on the RECIPIENT being a
-                # curated prospect, NOT cell_risk_class, so a cold pitch that
-                # misclassified FINANCIAL (money-term body) is still stamped.
-                await _stamp_prospect_contacted(db, row["validated_recipient"], now)
                 resolved += 1
                 logger.info(
                     "Resolved held email %s → sent to %s",

--- a/src/genesis/autonomy/email_gate_watcher.py
+++ b/src/genesis/autonomy/email_gate_watcher.py
@@ -84,6 +84,32 @@ async def _stamp_prospect_contacted(db: object, recipient: str | None, now: str)
     await mp.mark_contacted_by_email(db, recipient, contacted_at=now)
 
 
+async def _terminalize_delivered_hold(db: object, row: dict, now: str) -> None:
+    """Terminalize an owner-approved DELIVERED hold (held → sent) AND record its
+    capability success EXACTLY ONCE, shared by the DELIVERED branch and the
+    consumed-approval reconcile branch so both do the identical terminal accounting.
+
+    ``pes.mark_sent`` is the single-flip claim (``WHERE status='held'``): only the
+    ONE drain cycle that wins the flip records the success, so record_success is
+    called AT MOST once per hold (no double-count), and a reconcile replay of a hold
+    the prior cycle delivered-but-never-terminalized records it — closing the window
+    where a stamp/DB failure in the DELIVERED branch (before mark_sent) permanently
+    dropped an owner-approved delivery from promotion evidence. Residual (fail-safe,
+    tracked in follow-up 6a518adc): a crash in the microsecond between mark_sent
+    committing and record_success leaves the hold 'sent' (unrecoverable) → the success
+    is under-counted, delaying cell promotion but NEVER over-granting."""
+    if await pes.mark_sent(db, row["id"], sent_at=now):
+        await cg.record_success(
+            db,
+            domain=row["cell_domain"],
+            verb=row["cell_verb"],
+            risk_class=row["cell_risk_class"],
+            updated_at=now,
+            # WS-3 gate-3: the OWNER approved this send — owner evidence.
+            origin_class="owner",
+        )
+
+
 def _subject(context: str | None) -> str:
     if not context:
         return ""
@@ -122,14 +148,16 @@ async def drain_pending_email_sends(rt: object) -> int:
                 # re-sending: this narrows the at-least-once window to the gap
                 # between adapter.send and mark_consumed.
                 # LOOP-FIX: this row was genuinely DELIVERED by the prior (crashed)
-                # cycle, which never reached the DELIVERED-branch stamp — advance the
-                # prospect here too. Stamp BEFORE terminalizing (mark_sent), mirroring
-                # the DELIVERED branch: if this recovery itself crashes/DB-errors in the
-                # window, the hold stays 'held' (re-drained → this branch re-runs, the
-                # stamp being idempotent) rather than going 'sent' with the prospect
-                # left 'active' and re-pitched.
+                # cycle, which never reached the DELIVERED-branch terminal accounting —
+                # complete it here too, identically. Stamp BEFORE terminalizing, then
+                # _terminalize_delivered_hold (mark_sent single-flip claim → gated
+                # record_success): if this recovery itself crashes/DB-errors before the
+                # claim, the hold stays 'held' (re-drained → this branch re-runs, the
+                # stamp being idempotent and record_success gated on the flip) rather
+                # than going 'sent' with the prospect left 'active' or the owner-approved
+                # success dropped from promotion evidence.
                 await _stamp_prospect_contacted(db, row["validated_recipient"], now)
-                await pes.mark_sent(db, row["id"], sent_at=now)
+                await _terminalize_delivered_hold(db, row, now)
                 resolved += 1
                 logger.info(
                     "Reconciled held email %s (approval already consumed) — not re-sent",
@@ -220,16 +248,10 @@ async def drain_pending_email_sends(rt: object) -> int:
                 # on the RECIPIENT being a curated prospect, NOT cell_risk_class, so a
                 # cold pitch that misclassified FINANCIAL (money-term body) is stamped.
                 await _stamp_prospect_contacted(db, row["validated_recipient"], now)
-                await pes.mark_sent(db, row["id"], sent_at=now)
-                await cg.record_success(
-                    db,
-                    domain=row["cell_domain"],
-                    verb=row["cell_verb"],
-                    risk_class=row["cell_risk_class"],
-                    updated_at=now,
-                    # WS-3 gate-3: the OWNER approved this send — owner evidence.
-                    origin_class="owner",
-                )
+                # Terminalize + record the owner-approved success exactly once (the
+                # mark_sent single-flip gates record_success; identical to the reconcile
+                # branch, so a crash-recovery replay accounts for it the same way).
+                await _terminalize_delivered_hold(db, row, now)
                 resolved += 1
                 logger.info(
                     "Resolved held email %s → sent to %s",

--- a/src/genesis/db/crud/marketing_prospects.py
+++ b/src/genesis/db/crud/marketing_prospects.py
@@ -69,7 +69,8 @@ async def get_by_id(db: aiosqlite.Connection, id: str) -> dict | None:
 
 async def get_by_email(db: aiosqlite.Connection, email: str) -> dict | None:
     cursor = await db.execute(
-        "SELECT * FROM marketing_prospects WHERE email = ?", (_normalize_email(email),)
+        "SELECT * FROM marketing_prospects WHERE email = ? COLLATE NOCASE",
+        (_normalize_email(email),),
     )
     row = await cursor.fetchone()
     return dict(row) if row else None

--- a/src/genesis/db/crud/marketing_prospects.py
+++ b/src/genesis/db/crud/marketing_prospects.py
@@ -124,11 +124,21 @@ async def mark_contacted_by_email(
     non-marketing recipient is never touched). Keyed on the RECIPIENT being a curated
     prospect — NOT on cell_risk_class — so a cold pitch that misclassified FINANCIAL
     (money-term body) is still stamped. Only ``opted_out`` — NOT this status — gates
-    authorization, so this write can never weaken a send gate."""
-    row = await get_by_email(db, email)
-    if row is None or row.get("status") != "active":
-        return False
-    return await mark_contacted(db, row["id"], contacted_at=contacted_at)
+    authorization, so this write can never weaken a send gate.
+
+    ATOMIC: a single conditional UPDATE (``WHERE email = ? COLLATE NOCASE AND
+    status = 'active'``), NOT a read-then-write. A concurrent writer flipping the row
+    (e.g. active → replied) between a lookup and an update can't be clobbered back to
+    'contacted' — the never-downgrade guarantee holds under concurrency. ``rowcount``
+    is the stamped/not-stamped signal."""
+    cursor = await db.execute(
+        "UPDATE marketing_prospects "
+        "SET last_contacted_at = ?, status = 'contacted', updated_at = ? "
+        "WHERE email = ? COLLATE NOCASE AND status = 'active'",
+        (contacted_at, contacted_at, _normalize_email(email)),
+    )
+    await db.commit()
+    return cursor.rowcount > 0
 
 
 async def mark_opted_out(db: aiosqlite.Connection, id: str, *, opted_out_at: str) -> bool:

--- a/src/genesis/db/crud/marketing_prospects.py
+++ b/src/genesis/db/crud/marketing_prospects.py
@@ -109,6 +109,27 @@ async def mark_contacted(
     return cursor.rowcount > 0
 
 
+async def mark_contacted_by_email(
+    db: aiosqlite.Connection, email: str, *, contacted_at: str
+) -> bool:
+    """Advance the ACTIVE prospect matching ``email`` → contacted. The by-email entry
+    point for the delivery paths (which know the resolved recipient, not the id) —
+    called on a CONFIRMED delivery so ``list_active`` stops re-pitching the prospect
+    (the loop-fix: ``mark_contacted`` had no caller, so a delivered prospect stayed
+    'active' and got re-pitched every tick).
+
+    No-op returning False when there is no matching prospect, or the row is not
+    'active' (an already-'contacted'/'replied' row is never downgraded, and a
+    non-marketing recipient is never touched). Keyed on the RECIPIENT being a curated
+    prospect — NOT on cell_risk_class — so a cold pitch that misclassified FINANCIAL
+    (money-term body) is still stamped. Only ``opted_out`` — NOT this status — gates
+    authorization, so this write can never weaken a send gate."""
+    row = await get_by_email(db, email)
+    if row is None or row.get("status") != "active":
+        return False
+    return await mark_contacted(db, row["id"], contacted_at=contacted_at)
+
+
 async def mark_opted_out(db: aiosqlite.Connection, id: str, *, opted_out_at: str) -> bool:
     """PERMANENT suppression — set opted_out=1. Returns False if id is unknown.
     The row is never pruned, so the address can never be silently re-enabled."""

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -788,9 +788,26 @@ class OutreachPipeline:
                 # the GRANTED-cell path, which delivers INLINE here and never touches
                 # that drain — without this the loop-fix would silently regress once
                 # the cell graduates to autonomous. Same active-guarded CRUD.
-                from genesis.db.crud import marketing_prospects as _mp
+                #
+                # Wrapped best-effort (uniform with the ledger/shadow hooks above):
+                # this runs AFTER the irreversible adapter.send, so a transient DB/WAL
+                # error must NOT raise out of _deliver — that would strand the thread
+                # registration below (reply-tracking lost) and surface a post-send
+                # exception for an already-delivered message (re-attempt → dup risk).
+                # Unlike the drain-branch stamps (whose CronTrigger re-run + held-state
+                # owns retry, so fail-loud is correct there), this inline path has no
+                # retry owner; a logged miss is strictly safer than a post-send raise.
+                # A missed stamp here degrades to at most one re-pitch, not a re-send.
+                try:
+                    from genesis.db.crud import marketing_prospects as _mp
 
-                await _mp.mark_contacted_by_email(self._db, recipient, contacted_at=now)
+                    await _mp.mark_contacted_by_email(self._db, recipient, contacted_at=now)
+                except Exception:  # noqa: BLE001 — stamp is best-effort post-send; never break the send
+                    logger.warning(
+                        "granted-cell prospect contact-stamp failed (post-send); "
+                        "list_active may re-pitch until next stamp",
+                        exc_info=True,
+                    )
 
         # Auto-register email threads for reply tracking
         if channel == "email" and self._thread_tracker is not None:

--- a/src/genesis/outreach/pipeline.py
+++ b/src/genesis/outreach/pipeline.py
@@ -781,6 +781,16 @@ class OutreachPipeline:
                 await self._record_autonomous_send(
                     request, gate_cell, recipient, outreach_id, now,
                 )
+                # LOOP-FIX: autonomous (GRANTED-cell) delivery advances a matching
+                # curated prospect active → contacted (a no-op for a non-prospect
+                # recipient) so the campaign's list_active stops re-pitching it. The
+                # HELD → owner-approved path stamps in the email-gate drain; this is
+                # the GRANTED-cell path, which delivers INLINE here and never touches
+                # that drain — without this the loop-fix would silently regress once
+                # the cell graduates to autonomous. Same active-guarded CRUD.
+                from genesis.db.crud import marketing_prospects as _mp
+
+                await _mp.mark_contacted_by_email(self._db, recipient, contacted_at=now)
 
         # Auto-register email threads for reply tracking
         if channel == "email" and self._thread_tracker is not None:

--- a/tests/test_autonomy/test_email_gate_watcher.py
+++ b/tests/test_autonomy/test_email_gate_watcher.py
@@ -451,3 +451,33 @@ async def test_reconciled_consumed_hold_stamps_prospect(db):
     assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 1
     assert pipe.calls == []  # NOT re-sent
     assert (await mp.get_by_id(db, "prospect"))["status"] == "contacted"
+
+
+@pytest.mark.asyncio
+async def test_reconciled_hold_stamps_prospect_before_terminalizing(db, monkeypatch):
+    """Crash-safety of the reconcile branch: the prospect stamp must be durable
+    BEFORE the hold goes terminal (mark_sent). If the terminal write fails (DB
+    error) — or the process stops right after mark_sent commits — the hold leaves
+    list_held forever while the prospect is still 'active' → re-pitched. Simulate
+    the terminal write raising at exactly that point and assert the prospect was
+    ALREADY advanced to 'contacted' (i.e. stamp precedes mark_sent, matching the
+    DELIVERED branch). RED on the old mark_sent-first order."""
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    rid = await _approval(db, status="approved")
+    await ac.mark_consumed(db, rid, consumed_at=_TS)
+    await _bulk_hold_for(db, prospect_email="prospect@example.com", rid=rid)
+
+    async def _boom(*a, **k):
+        raise aiosqlite.OperationalError("simulated crash terminalizing the hold")
+
+    monkeypatch.setattr(pes, "mark_sent", _boom)
+
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+    with pytest.raises(aiosqlite.OperationalError):
+        await drain_pending_email_sends(_FakeRt(db, pipe))
+
+    assert pipe.calls == []  # reconcile never re-sends
+    # The stamp must have committed before the failed terminal write.
+    assert (await mp.get_by_id(db, "prospect"))["status"] == "contacted"

--- a/tests/test_autonomy/test_email_gate_watcher.py
+++ b/tests/test_autonomy/test_email_gate_watcher.py
@@ -481,3 +481,51 @@ async def test_reconciled_hold_stamps_prospect_before_terminalizing(db, monkeypa
     assert pipe.calls == []  # reconcile never re-sends
     # The stamp must have committed before the failed terminal write.
     assert (await mp.get_by_id(db, "prospect"))["status"] == "contacted"
+
+
+@pytest.mark.asyncio
+async def test_reconciled_consumed_hold_records_owner_success(db):
+    """Crash-recovery must complete capability success accounting: a consumed-approval
+    reconcile (delivered by a prior crashed cycle that never terminalized) records the
+    owner-approved cg success exactly once — so a transient DELIVERED-branch failure
+    before mark_sent doesn't permanently drop the delivery from promotion evidence.
+    RED: the reconcile branch previously never called record_success."""
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    await cg.ensure_cell(db, domain="email", verb="send", risk_class="bulk", updated_at=_TS)
+    rid = await _approval(db, status="approved")
+    await ac.mark_consumed(db, rid, consumed_at=_TS)
+    await _bulk_hold_for(db, prospect_email="prospect@example.com", rid=rid)
+
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+    assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 1
+    assert pipe.calls == []  # reconcile never re-sends
+    assert (await pes.get_by_id(db, "pb"))["status"] == "sent"
+    cell = await cg.get_cell(db, "email", "send", "bulk")
+    assert cell["successes"] == 1  # owner-approved success accounted once via recovery
+
+
+@pytest.mark.asyncio
+async def test_owner_success_gated_on_mark_sent_claim(db, monkeypatch):
+    """record_success is gated on the mark_sent single-flip claim: if the hold was
+    already flipped out of 'held' (a lost race / double-drain), record_success is NOT
+    called, so an owner-approved success is counted AT MOST once (no double-count).
+    RED: the old code called record_success unconditionally after mark_sent."""
+    monkeypatch.setattr(egw, "_marketing_mode", lambda: "live")
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    await cg.ensure_cell(db, domain="email", verb="send", risk_class="bulk", updated_at=_TS)
+    rid = await _approval(db, status="approved")
+    await _bulk_hold_for(db, prospect_email="prospect@example.com", rid=rid)
+
+    async def _not_claimed(*a, **k):  # hold already left 'held' → this cycle didn't win the flip
+        return False
+
+    monkeypatch.setattr(pes, "mark_sent", _not_claimed)
+
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+    assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 1
+    cell = await cg.get_cell(db, "email", "send", "bulk")
+    assert cell["successes"] == 0  # not claimed → success not recorded (no double-count)

--- a/tests/test_autonomy/test_email_gate_watcher.py
+++ b/tests/test_autonomy/test_email_gate_watcher.py
@@ -352,3 +352,102 @@ async def test_approved_but_pipeline_ignores_is_terminal(db):
     # The approval lifecycle is closed (consumed) so it doesn't linger as a
     # ghost approved/unconsumed row in operator views.
     assert (await ac.get_by_id(db, rid))["consumed_at"] is not None
+
+
+# --- loop-fix: prospect contact-stamping on CONFIRMED delivery -----------------
+
+
+async def _bulk_hold_for(db, *, prospect_email, rid, cell_risk_class="bulk", pid="pb"):
+    await pes.create(
+        db,
+        id=pid,
+        request_id=rid,
+        validated_recipient=prospect_email,
+        category="notification",
+        message="cold pitch",
+        held_at=_TS,
+        cell_domain="email",
+        cell_verb="send",
+        cell_risk_class=cell_risk_class,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delivered_bulk_hold_stamps_prospect_contacted(db, monkeypatch):
+    """Confirmed delivery of a cold-marketing (BULK) send advances the prospect
+    active → contacted at the DRAIN, so list_active stops re-pitching it — the
+    loop-fix (mark_contacted previously had no caller)."""
+    monkeypatch.setattr(egw, "_marketing_mode", lambda: "live")
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    rid = await _approval(db, status="approved")
+    await _bulk_hold_for(db, prospect_email="prospect@example.com", rid=rid)
+
+    assert (
+        await drain_pending_email_sends(_FakeRt(db, _FakePipeline(OutreachStatus.DELIVERED))) == 1
+    )
+    row = await mp.get_by_id(db, "prospect")
+    assert row["status"] == "contacted"
+    assert row["last_contacted_at"] is not None
+    assert await mp.list_active(db) == []
+
+
+@pytest.mark.asyncio
+async def test_delivered_financial_misclassified_pitch_still_stamps(db):
+    """Provenance is RECIPIENT-based, NOT cell_risk_class: a cold pitch whose body
+    tripped the money-pattern classifier holds as FINANCIAL (not BULK), but on
+    delivery to a curated prospect it must STILL stamp them — else re-pitched."""
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    rid = await _approval(db, status="approved")
+    await _bulk_hold_for(
+        db,
+        prospect_email="prospect@example.com",
+        rid=rid,
+        cell_risk_class="financial",
+        pid="pf",
+    )
+
+    assert (
+        await drain_pending_email_sends(_FakeRt(db, _FakePipeline(OutreachStatus.DELIVERED))) == 1
+    )
+    assert (await mp.get_by_id(db, "prospect"))["status"] == "contacted"
+
+
+@pytest.mark.asyncio
+async def test_non_delivery_outcome_leaves_prospect_active(db):
+    """Anti-burn: the stamp fires ONLY on confirmed delivery. An orphaned hold
+    (approval gone → expired, no delivery) leaves the prospect 'active', re-eligible
+    — a send that never delivers never closes a prospect. Owner-rejection likewise
+    leaves it active (re-eligible for a re-worded pitch; opt-out is the 'never')."""
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    await _bulk_hold_for(db, prospect_email="prospect@example.com", rid="gone")  # no approval
+
+    assert (
+        await drain_pending_email_sends(_FakeRt(db, _FakePipeline(OutreachStatus.DELIVERED))) == 1
+    )
+    assert (await mp.get_by_id(db, "prospect"))["status"] == "active"  # not burned
+    assert len(await mp.list_active(db)) == 1
+
+
+@pytest.mark.asyncio
+async def test_reconciled_consumed_hold_stamps_prospect(db):
+    """Crash-recovery: a hold whose approval was ALREADY consumed (delivered by a
+    prior cycle that crashed before marking 'sent') reconciles to sent AND stamps the
+    prospect — a crash between delivery and the stamp must not leave a delivered
+    prospect 'active' and re-pitchable. Not re-sent (pipe.calls stays empty)."""
+    from genesis.db.crud import marketing_prospects as mp
+
+    await mp.create(db, id="prospect", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    rid = await _approval(db, status="approved")
+    await ac.mark_consumed(db, rid, consumed_at=_TS)
+    await _bulk_hold_for(db, prospect_email="prospect@example.com", rid=rid)
+
+    pipe = _FakePipeline(OutreachStatus.DELIVERED)
+    assert await drain_pending_email_sends(_FakeRt(db, pipe)) == 1
+    assert pipe.calls == []  # NOT re-sent
+    assert (await mp.get_by_id(db, "prospect"))["status"] == "contacted"

--- a/tests/test_db/test_marketing_prospects.py
+++ b/tests/test_db/test_marketing_prospects.py
@@ -154,3 +154,26 @@ async def test_mark_contacted_by_email_matches_mixed_case_seeded_row(db):
     await db.commit()
     assert await mp.mark_contacted_by_email(db, "mixed@example.com", contacted_at=_TS) is True
     assert (await mp.get_by_id(db, "mc"))["status"] == "contacted"
+
+
+@pytest.mark.asyncio
+async def test_mark_contacted_by_email_is_atomic_no_read_then_write(db, monkeypatch):
+    """The stamp is a single conditional UPDATE (`WHERE ... AND status = 'active'`),
+    NOT a read-then-write — so a concurrent active→replied flip between a lookup and an
+    update can't clobber the newer state back to 'contacted' (the never-downgrade
+    guarantee holds under concurrency). Proven structurally: it performs NO get_by_email
+    read before its write. RED on the old read-then-write (get_by_email → unconditional
+    mark_contacted)."""
+    calls: list[str] = []
+    orig = mp.get_by_email
+
+    async def spy_get_by_email(conn, email):
+        calls.append(email)
+        return await orig(conn, email)
+
+    monkeypatch.setattr(mp, "get_by_email", spy_get_by_email)
+
+    await mp.create(db, id="p1", email="prospect@example.com", created_at=_TS, updated_at=_TS)
+    assert await mp.mark_contacted_by_email(db, "prospect@example.com", contacted_at=_TS) is True
+    assert (await mp.get_by_id(db, "p1"))["status"] == "contacted"
+    assert calls == []  # atomic: no read-before-write window a concurrent flip could exploit

--- a/tests/test_db/test_marketing_prospects.py
+++ b/tests/test_db/test_marketing_prospects.py
@@ -138,3 +138,19 @@ async def test_mark_contacted_by_email_only_advances_active(db):
     assert (await mp.get_by_id(db, "p2"))["status"] == "replied"
     # absent recipient → no-op, no crash
     assert await mp.mark_contacted_by_email(db, "nobody@example.com", contacted_at=_TS) is False
+
+
+@pytest.mark.asyncio
+async def test_mark_contacted_by_email_matches_mixed_case_seeded_row(db):
+    """A directly-seeded row with a mixed-case email (bypassing create()'s
+    normalization — e.g. a future bulk-import path) is still matched
+    case-insensitively (get_by_email COLLATE NOCASE), so the delivery stamp never
+    misses it and re-pitches a delivered prospect."""
+    await db.execute(
+        "INSERT INTO marketing_prospects (id, email, status, opted_out, created_at, updated_at) "
+        "VALUES ('mc', 'Mixed@Example.com', 'active', 0, ?, ?)",
+        (_TS, _TS),
+    )
+    await db.commit()
+    assert await mp.mark_contacted_by_email(db, "mixed@example.com", contacted_at=_TS) is True
+    assert (await mp.get_by_id(db, "mc"))["status"] == "contacted"

--- a/tests/test_db/test_marketing_prospects.py
+++ b/tests/test_db/test_marketing_prospects.py
@@ -116,3 +116,25 @@ async def test_mark_opted_out_is_permanent_suppression(db):
     assert row["opted_out"] == 1
     # An opted-out prospect never re-enters the active set.
     assert await mp.list_active(db) == []
+
+
+@pytest.mark.asyncio
+async def test_mark_contacted_by_email_only_advances_active(db):
+    """The shared by-email stamp used by BOTH delivery paths (drain + granted
+    pipeline). Advances an ACTIVE match → contacted; no-ops (returns False) on an
+    absent recipient or a non-'active' row (never downgrades 'replied'/'contacted',
+    never touches a non-marketing address). Case-insensitive on the email."""
+    await mp.create(db, id="p1", email="Prospect@Example.com", created_at=_TS, updated_at=_TS)
+    # active → contacted (email match is normalized/case-insensitive)
+    assert await mp.mark_contacted_by_email(db, "prospect@example.com", contacted_at=_TS) is True
+    assert (await mp.get_by_id(db, "p1"))["status"] == "contacted"
+    # second call is a no-op — already non-active, never re-stamped/downgraded
+    assert await mp.mark_contacted_by_email(db, "prospect@example.com", contacted_at=_TS) is False
+    # a 'replied' prospect is NEVER downgraded to 'contacted'
+    await mp.create(
+        db, id="p2", email="replied@example.com", status="replied", created_at=_TS, updated_at=_TS
+    )
+    assert await mp.mark_contacted_by_email(db, "replied@example.com", contacted_at=_TS) is False
+    assert (await mp.get_by_id(db, "p2"))["status"] == "replied"
+    # absent recipient → no-op, no crash
+    assert await mp.mark_contacted_by_email(db, "nobody@example.com", contacted_at=_TS) is False

--- a/tests/test_outreach/test_ws8_full_slice_e2e.py
+++ b/tests/test_outreach/test_ws8_full_slice_e2e.py
@@ -175,3 +175,47 @@ async def test_full_earn_grant_send_flag_demote_loop(config, db):
 
     # 7. Re-flag is idempotent: no second demotion path is taken.
     assert await aes.mark_flagged(db, log[0]["id"], flagged_at=now) is False
+
+
+@pytest.mark.asyncio
+async def test_granted_bulk_autonomous_send_stamps_prospect_contacted(config, db, monkeypatch):
+    """The GRANTED-cell autonomous path delivers INLINE in pipeline._deliver, NEVER
+    through the email-gate drain — so the loop-fix (advance the prospect
+    active → contacted) must fire there too. Without it, a delivered cold send leaves
+    the prospect 'active' forever once BULK graduates, and the campaign re-pitches it
+    every tick, unsupervised — the highest-stakes moment for the loop-fix to hold."""
+    from genesis.db.crud import capability_grants as cg
+    from genesis.db.crud import marketing_prospects as mp
+
+    _ts = "2026-06-21T00:00:00"
+    monkeypatch.setattr("genesis.outreach.marketing_config.effective_mode", lambda: "live")
+    await cg.ensure_cell(db, domain="email", verb="send", risk_class="bulk", updated_at=_ts)
+    await db.execute(
+        "UPDATE capability_grants SET state = 'granted', granted_at = ? WHERE id = ?",
+        (_ts, cg.cell_id("email", "send", "bulk")),
+    )
+    await db.commit()
+    await mp.create(db, id="p1", email="prospect@example.com", created_at=_ts, updated_at=_ts)
+
+    adapter = AsyncMock()
+    adapter.send_message.return_value = "<m@x>"
+    pipe = _pipeline(config, db, adapter)
+
+    req = OutreachRequest(
+        category=OutreachCategory.NOTIFICATION,
+        topic="cold pitch",
+        context="body",
+        salience_score=0.5,
+        signal_type="marketing_cold",
+        channel="email",
+        validated_recipient="prospect@example.com",
+        labeled_surplus=True,  # → classifies BULK at the gate
+        verbatim=True,
+    )
+    r = await pipe.submit_raw("cold pitch", req)
+    assert r.status == OutreachStatus.DELIVERED  # autonomous — no hold
+    adapter.send_message.assert_called_once()
+    assert (await mp.get_by_id(db, "p1"))[
+        "status"
+    ] == "contacted"  # loop-fix at the granted chokepoint
+    assert await mp.list_active(db) == []

--- a/tests/test_outreach/test_ws8_full_slice_e2e.py
+++ b/tests/test_outreach/test_ws8_full_slice_e2e.py
@@ -219,3 +219,49 @@ async def test_granted_bulk_autonomous_send_stamps_prospect_contacted(config, db
         "status"
     ] == "contacted"  # loop-fix at the granted chokepoint
     assert await mp.list_active(db) == []
+
+
+@pytest.mark.asyncio
+async def test_granted_bulk_send_survives_stamp_failure(config, db, monkeypatch):
+    """The granted-path contact-stamp runs AFTER the irreversible adapter.send, so a
+    transient DB error in the stamp must NOT raise out of _deliver: the message is
+    already out, and a post-send raise would report FAILED (re-attempt → dup) and
+    strand thread registration. Assert the send still reports DELIVERED and the
+    adapter was called exactly once despite the stamp blowing up (best-effort wrap).
+    RED on the pre-wrap bare-await code."""
+    from genesis.db.crud import capability_grants as cg
+    from genesis.db.crud import marketing_prospects as mp
+
+    _ts = "2026-06-21T00:00:00"
+    monkeypatch.setattr("genesis.outreach.marketing_config.effective_mode", lambda: "live")
+    await cg.ensure_cell(db, domain="email", verb="send", risk_class="bulk", updated_at=_ts)
+    await db.execute(
+        "UPDATE capability_grants SET state = 'granted', granted_at = ? WHERE id = ?",
+        (_ts, cg.cell_id("email", "send", "bulk")),
+    )
+    await db.commit()
+    await mp.create(db, id="p1", email="prospect@example.com", created_at=_ts, updated_at=_ts)
+
+    async def _boom(*a, **k):
+        raise RuntimeError("simulated DB error stamping the prospect post-send")
+
+    monkeypatch.setattr(mp, "mark_contacted_by_email", _boom)
+
+    adapter = AsyncMock()
+    adapter.send_message.return_value = "<m@x>"
+    pipe = _pipeline(config, db, adapter)
+
+    req = OutreachRequest(
+        category=OutreachCategory.NOTIFICATION,
+        topic="cold pitch",
+        context="body",
+        salience_score=0.5,
+        signal_type="marketing_cold",
+        channel="email",
+        validated_recipient="prospect@example.com",
+        labeled_surplus=True,  # → classifies BULK at the gate
+        verbatim=True,
+    )
+    r = await pipe.submit_raw("cold pitch", req)
+    assert r.status == OutreachStatus.DELIVERED  # completed send NOT broken by the stamp failure
+    adapter.send_message.assert_called_once()  # sent exactly once — no re-attempt

--- a/tests/test_security/test_identity_autonomy_gate_coverage.py
+++ b/tests/test_security/test_identity_autonomy_gate_coverage.py
@@ -219,8 +219,15 @@ AUTONOMY_GATE_SITES: dict[str, tuple[str, str]] = {
     ),
     "autonomy/email_gate_watcher.py::drain_pending_email_sends": (
         "gated-via",
-        "owner approve -> record_success / owner reject -> record_correction; "
-        "threads origin_class='owner' (owner decisions are the evidence)",
+        "owner reject/cancel -> record_correction; threads origin_class='owner' "
+        "(owner decisions are the evidence). The owner-approve record_success path "
+        "moved to _terminalize_delivered_hold (identical origin_class threading)",
+    ),
+    "autonomy/email_gate_watcher.py::_terminalize_delivered_hold": (
+        "gated-via",
+        "owner approve -> record_success, gated on the pes.mark_sent single-flip "
+        "claim (at-most-once); threads origin_class='owner' (owner decisions are the "
+        "evidence). Shared by the DELIVERED + consumed-approval reconcile branches",
     ),
     "dashboard/routes/autonomy.py::autonomy_flag_send": (
         "gated-via",


### PR DESCRIPTION
## What

`marketing_prospects.mark_contacted` had **no caller**, so a delivered prospect stayed `status='active'` and `list_active` re-returned it every campaign tick — the campaign would re-pitch the same person forever. This stamps a prospect `contacted` on **confirmed delivery**, from both delivery paths (the owner-approved drain, incl. the crash-recovery reconcile branch, and the granted-cell autonomous inline path in `pipeline._deliver`). Keyed on the **recipient** being a curated prospect (not `cell_risk_class`), so a FINANCIAL-misclassified pitch still stamps. A send that never delivers (dropped/expired/rejected) leaves the prospect eligible.

## Safety

The `status` stamp is **decoupled from every send-authorization predicate** (only `opted_out` gates) — verified by enumeration (g2 scope guard, the drain re-checks, and the opt-out check all key on `opted_out`; the one status-coupled predicate is dead on gate paths). So it can never weaken the WS-8 email gate. Substrate still ships off by default.

## Scope (deliberate)

This is the scoped-down replacement for #1647, which bundled a per-prospect in-flight dedup + approval-flood cap that Codex review did not converge on (they need an atomic reservation — disproportionate for an off-by-default, single-threaded-today substrate). Those are **deferred to a hot follow-up**, required before arming the campaign at volume. This PR ships **only** the confirmed loop-fix.

## Review

genesis-architect: **Ready to merge: Yes** (one crash-recovery NOTE folded in). 26 tests, verify-RED on the delivery stamp, E2E through the real drain + real pipeline+gate+grant on both delivery paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cold-marketing prospects are now marked as contacted after confirmed email delivery and excluded from future targeting.
  - Applies to owner-approved and autonomous delivery paths, including recovery after interruptions.
  - Undelivered emails remain eligible for retry.
  - Email matching is case-insensitive for more reliable contact tracking.
  - Delivery remains successful if contact-status recording encounters an error.

- **Documentation**
  - Updated outreach documentation to clarify delivery tracking and recipient-handling rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->