### PR TITLE
docs: route Genesis-repo work to the public tracker, not a local row

### DIFF
--- a/.claude/docs/mcp-tools-guide.md
+++ b/.claude/docs/mcp-tools-guide.md
@@ -69,9 +69,17 @@ live in code with `tests/test_scripts/test_file_tracker_issue.py` pinning each o
   not exist; a nonexistent mandatory label makes `gh issue create` fail. Use
   `area:other` when nothing fits.
 
-Exit codes: `0` filed (or dry-run clean) · `2` refused, nothing posted · `3` an
-identical title already exists · `1` unexpected error. **Run `--dry-run` first** —
-it performs every check and posts nothing.
+Exit codes: `0` filed (or dry-run clean) · `2` refused — **nothing was posted**, that
+is a hard guarantee · `3` an identical title already exists · `4` **INDETERMINATE** ·
+`1` unexpected error. **Run `--dry-run` first** — it performs every check and posts
+nothing.
+
+Exit `4` is the one that needs a human. It means `gh` failed but GitHub may already
+have committed the issue and lost the response — so the post may exist. Check the
+tracker for that title BEFORE retrying or writing a local row; a retry on a successful
+post creates a duplicate, and a local row records a falsehood. `2` and `4` are
+deliberately distinct: conflating them would tell you nothing was posted when
+something may have been.
 
 Use a fresh `mktemp -d` per invocation, and clean it WITHOUT `rm -rf` — this
 repo's own destructive-command guard refuses a recursive-force delete on a path it

--- a/.claude/docs/mcp-tools-guide.md
+++ b/.claude/docs/mcp-tools-guide.md
@@ -31,96 +31,77 @@ user-owned + purely-local operational work → a follow-up; consciously-not-doin
 `tabled`) and its two hard limits (explicit approval every time; never publish a
 security defect before it is fixed). This section is the operational detail.
 
-### Who may file at all
-
-Only a session whose operator has **write access to the shared tracker**. Identity is
-not enough — a direct clone of the shared repo reports the right slug while the
-authenticated user still lacks push access, and GitHub then silently DROPS the
-mandatory labels. Check the PERMISSION, fail closed, and CAPTURE the slug:
+### Filing it — use the script, not a hand-typed command
 
 ```bash
-REPO="$(gh repo view --json nameWithOwner,viewerPermission \
-        --jq 'select(.viewerPermission|IN("WRITE","MAINTAIN","ADMIN")) | .nameWithOwner')"
-[ -n "$REPO" ] || { echo "no write access to this tracker — keep it local" >&2; exit 1; }
+DRAFT="$(mktemp -d)"                       # per-invocation, never a shared path
+# write the title and body with an EDITOR TOOL, not by echoing through a shell
+#   $DRAFT/title.txt   $DRAFT/body.md
+
+python3 scripts/file_tracker_issue.py \
+  --title-file "$DRAFT/title.txt" --body-file "$DRAFT/body.md" \
+  --area area:memory --difficulty "help wanted" --dry-run   # drop --dry-run to post
+rm -f "$DRAFT"/*.txt "$DRAFT"/*.md && rmdir "$DRAFT"
 ```
 
-Keep `$REPO` and pass it explicitly to every later command (below). A bare `gh issue
-…` re-resolves its target from the CURRENT directory each time, so a `cd` between the
-check and the post sends an irreversible write to a repository nobody verified — and
-on a fork-cloned install the bare form targets the operator's own fork, where nobody
-can pick the issue up.
+The script exists because three cross-model review rounds each found a different
+way for a hand-typed version of this to target the wrong repository or execute its
+own input. Those are not things prose can enforce and nothing tests, so they now
+live in code with `tests/test_scripts/test_file_tracker_issue.py` pinning each one:
 
-If the check fails, Genesis-repo work stays a local `follow_up_create` row until a
-maintainer carries it across. That is a known gap, not a workaround.
+- **Resolves the UPSTREAM tracker.** `gh repo view` with no argument reports the
+  CURRENT directory's repo, so on a fork-cloned install it returns the operator's
+  own fork — where they are ADMIN, so a permission check on it passes and the issue
+  lands where nobody reads it. The script follows `parent` when `isFork`, and
+  refuses outright if a fork's parent cannot be resolved.
+- **Checks `viewerPermission` on that explicit slug.** Identity is not permission:
+  a direct clone reports the right slug while the user still lacks push access, and
+  GitHub then silently DROPS the mandatory labels.
+- **Never lets issue text reach a shell.** Title and body travel as argv. A title
+  containing backticks or `$(...)` — ordinary in a technical title — would execute
+  if interpolated into a command line, after your privacy scan, with its output in
+  the public title.
+- **Exact-title dedup, failing closed.** `gh issue list --search` parses `repo:` /
+  `is:` / `label:` inside a title as query syntax. The script compares normalized
+  titles over structured output, and REFUSES if the lookup fails — a failed lookup
+  is not evidence of no duplicate.
+- **Validates both labels against the real sets.** `area:docs` and `area:infra` do
+  not exist; a nonexistent mandatory label makes `gh issue create` fail. Use
+  `area:other` when nothing fits.
 
-On a non-owning install, Genesis-repo work stays a local `follow_up_create` row until
+Exit codes: `0` filed (or dry-run clean) · `2` refused, nothing posted · `3` an
+identical title already exists · `1` unexpected error. **Run `--dry-run` first** —
+it performs every check and posts nothing.
+
+Use a fresh `mktemp -d` per invocation, and clean it WITHOUT `rm -rf` — this
+repo's own destructive-command guard refuses a recursive-force delete on a path it
+cannot prove is deep enough, so `rm -rf "$DRAFT"` is blocked for every session. Foreground and background sessions run
+concurrently here, and a shared draft path lets one session overwrite the body
+another has already scanned and approved, between the scan and the post.
+
+### What the script does NOT decide
+
+Two things stay with you, because they are judgment, not mechanism:
+
+**Approval, every time.** A public post is irreversible;
+`contributor_issue.py` classifies it exactly that way. Channel-driven sessions run
+with `skip_permissions=True`, so no tool confirmation appears — ASK, in words, and
+get a yes, for each issue. A prior "go ahead" does not carry.
+
+**Privacy-scan the title AND the body.** Both egress. Technical detail only: no
+IPs, hostnames, absolute home paths, identifiers, or raw install metrics (row
+counts and spend leak usage scale — state proportions instead). Nothing gates this
+path; `gh issue create` appears nowhere in `scripts/hooks/git_push_guard.py`.
+
+**Security defects never go public first.** An unpatched authentication bypass,
+credential exposure, injection path, or anything otherwise exploitable is not filed
+publicly while unfixed — publishing hands a working lead to anyone reading, against
+installs running the vulnerable code right now. Keep it local, fix it, then file.
+The privacy scan does not catch this: it looks for install-specific data, not for
+dangerous technical disclosure.
+
+If the script refuses (exit 2), the work stays a local `follow_up_create` row until
 a maintainer carries it across. That is a known gap, not a workaround.
-
-### Approval — every time
-
-A public post is irreversible; `contributor_issue.py` classifies it exactly that way
-(`action_class="irreversible"`, owner approval, never auto-approved). CLAUDE.md's
-standing rule already covers it: irreversible actions need explicit approval first.
-
-**Human presence is not approval.** Channel-driven sessions run with
-`skip_permissions=True` (`src/genesis/cc/conversation.py`), so no tool confirmation
-appears — the session must ASK, in words, and get a yes, for each issue. A prior
-"go ahead" does not carry to the next one.
-
-### Filing the issue
-
-Write the title and body to FILES first, then read them into quoted variables. Never
-paste issue text straight into the command line: a title containing backticks or
-`$(...)` — ordinary in a technical title — is executed by the shell AFTER your privacy
-scan, and its output lands in the public title.
-
-```bash
-# title and body already written to files by an editor tool, not echoed through a shell
-TITLE="$(cat ~/tmp/issue-title.txt)"
-BODY=~/tmp/issue-body.md
-
-# 1. preflight against the VERIFIED repo — do not create a duplicate
-gh issue list --repo "$REPO" --search "$TITLE" --state all --limit 10
-
-# 2. file, non-interactively, every expansion quoted
-gh issue create --repo "$REPO" \
-  --title "$TITLE" --body-file "$BODY" \
-  --label "area:<domain>" --label "good first issue"
-```
-
-Quote every label: `good first issue` and `help wanted` contain spaces and word-split
-into invalid arguments unquoted. Quote `"$BODY"` too.
-
-`--title` and `--body`/`--body-file` are REQUIRED, not optional: `gh` prompts for a
-missing body, and Genesis runs the CLI with piped stdin, so the prompt can never be
-answered — the command hangs or fails and neither an issue nor a local row results.
-
-The preflight matters because the hand path has no dedup. The gated path checks open
-titles and fails closed; nothing protects a direct `gh issue create`, and two sessions
-finding the same defect (or one retrying after losing the first command's output)
-otherwise produce duplicates — against the one-record-per-item rule.
-
-**Both label classes are mandatory**, matching the policy the propose path enforces
-fail-closed (`src/genesis/mcp/health/contributor_issue.py`): an `area:*` domain label
-AND one of `good first issue`, `first-timers-only`, `help wanted`,
-`needs-genesis-instance`.
-
-**Privacy-scan the TITLE and the BODY, and the labels.** All three egress; the gated
-path scans all three for exactly that reason, and a title is the easiest place to leak
-a hostname, a path, or a metric. Technical detail only — no IPs, hostnames, absolute
-home paths, identifiers, or raw install metrics (row counts and spend leak usage
-scale; state proportions or shapes instead). Nothing gates this path — `gh issue
-create` appears nowhere in `scripts/hooks/git_push_guard.py`, which gates push /
-`gh pr merge` / `gh pr create` — so the scan is manual and there is no backstop.
-
-### Security defects never go public first
-
-An unpatched authentication bypass, credential exposure, injection path, or anything
-otherwise exploitable is NOT filed on the public tracker while it is unfixed —
-publishing it hands a working lead to anyone reading, against installs that are
-running the vulnerable code right now. Keep it local, fix it, then file (or file a
-post-fix note). The privacy scan does not catch this: it looks for install-specific
-data, not for dangerous technical disclosure.
 
 ### Why not `contributor_issue_propose`
 
@@ -140,11 +121,13 @@ line, not a locked door.) It records locally instead — but check the profile f
 denylist rather than trusting a list here; three tiers exist today:
 
 - HAS `follow_up_create` (`interact`, `research`, `campaign`, `steward`; and
-  `sentinel` when NOT degraded) → file there, and say in `reason` that it is repo work
-  awaiting a foreground session. The row is FORCED onto the cold `tabled` lane by
-  sacred-board authorization whatever `work_state` you pass, and tabled rows are
-  excluded from every default listing — retrieve with
-  `follow_up_list(include_tabled=True)`.
+  `sentinel` when NOT degraded) → file there AND state the finding in the session's
+  returned output. Both, not either: the row is FORCED onto the cold `tabled` lane by
+  sacred-board authorization whatever `work_state` you pass, tabled rows are excluded
+  from every default listing, and there is no promoter — so a row alone is a handoff
+  nobody receives unless someone independently guesses to run
+  `follow_up_list(include_tabled=True)`. The returned output is what the dispatching
+  foreground session actually reads.
 - HAS `observation_write` but NOT `follow_up_create` (reflection sessions) → use
   `observation_write` or the parsed `observations` output field.
 - Has NEITHER (`observe`, `community-responder`, `mail`; and sentinel-DEGRADED, which

--- a/.claude/docs/mcp-tools-guide.md
+++ b/.claude/docs/mcp-tools-guide.md
@@ -12,13 +12,104 @@ trees to pick the right one.
 | `knowledge_ingest` | Authoritative external sources (docs, articles) | Knowledge base | "Ingest this API reference" |
 | `reference_store` | Credentials, URLs, IPs, identifiers | Reference ledger | "API key for service X" |
 | `procedure_store` | Reusable multi-step workflows with confidence | Procedural memory | "Deploy pattern: steps 1-5" |
-| `follow_up_create` | Deferred work that needs tracking + completion | Follow-up ledger | "Benchmark new model next week" |
+| `follow_up_create` | Deferred USER-OWNED work needing tracking + completion | Follow-up ledger | "Finish the deck I asked for" |
+| `gh issue create` | Deferred GENESIS-REPO work (code, tests, docs, infra) | Public GitHub tracker | "Adapter for provider X is hardcoded" |
 
 **Quick rule:** If it's about the user → `memory_store`. If it's a finding
 during work → `observation_write`. If it's an external source to learn
 from → `knowledge_ingest`. If it's a credential or URL → `reference_store`.
-If it's a repeatable process → `procedure_store`. If it's deferred work →
-`follow_up_create`.
+If it's a repeatable process → `procedure_store`. If it's deferred work, route by
+owner: Genesis-repo work → a **GitHub issue**; user-owned work → `follow_up_create`;
+consciously not pursuing → `follow_up_create` with `work_state="deferred_cold"`.
+
+
+## Where Deferred Work Goes — mechanics
+
+`CLAUDE.md` carries the routing principle (Genesis-repo work → a GitHub issue;
+user-owned + purely-local operational work → a follow-up; consciously-not-doing →
+`tabled`). This section is the operational detail behind it.
+
+### Filing the issue
+
+```bash
+gh issue create --repo <owner>/<public-repo> \
+  --label area:<domain> --label <difficulty-or-environment>
+```
+
+**Always pass `--repo`.** `gh` resolves the target from the git remote, and the
+documented install is a fork clone (`.claude/docs/your-genesis.md`) — so on most
+installs a bare `gh issue create` files to the user's PRIVATE fork, where nobody can
+pick it up, silently and with no error. The target is `github.user` + `github.public_repo` in
+`~/.genesis/config/genesis.yaml` (resolvers: `genesis.env.github_user()` /
+`github_public_repo()` — the latter returns the bare name, without the owner).
+
+**Both label classes are mandatory**, matching the policy the propose path enforces
+fail-closed (`src/genesis/mcp/health/contributor_issue.py`): an `area:*` domain label
+AND a difficulty/environment label (`good first issue`, `first-timers-only`,
+`help wanted`, `needs-genesis-instance`). The hand path has no validator, so this is on you — an
+unlabelled issue silently breaks an invariant the codebase enforces elsewhere.
+
+**Privacy-scan the body first.** Technical detail only: no IPs, hostnames, absolute
+home paths, identifiers, or raw install metrics (row counts and spend leak usage
+scale — state proportions or shapes instead). Nothing gates this path — `gh issue
+create` appears nowhere in `scripts/hooks/git_push_guard.py`, which gates push /
+`gh pr merge` / `gh pr create` — so a public post here is irreversible and unguarded,
+and must be a conscious, human-present act.
+
+### Why not `contributor_issue_propose`
+
+That MCP tool is the *gated* door: fail-closed prose sanitizer, owner approval hold,
+label validation, dedup and rate backpressure, and a `source_follow_up_id` close-loop
+link. It is the better path when it applies — but it ships `propose_only` by default,
+where an approved hold still dry-runs and never posts, and a `dry_run` mark is
+terminal (flipping the lever to `live` later does NOT retro-post). So it cannot serve
+"file this now". Use it for curated contributor-facing work; use the hand path above
+for engineering issues you need on the tracker today.
+
+### Dispatched / background sessions
+
+A dispatched session must NOT file issues — no gate covers the path and no human is
+present. (`steward` gets `gh`-restricted Bash, so for that profile this is a policy
+line, not a locked door.) It records locally instead, but check the profile first
+(`.claude/docs/background-sessions.md`): **naming a route a session cannot take is
+worse than naming none.**
+
+Check your OWN denylist rather than trusting a list here — profiles change. Three
+tiers exist today:
+
+- HAS `follow_up_create` (`interact`, `research`, `campaign`, `steward`; and
+  `sentinel` when NOT degraded — `_DEGRADED_DISALLOWED_TOOLS` denies no MCP tools)
+  → file there, and say in `reason` that it is repo work awaiting a foreground
+  session. Note the row is FORCED onto the cold `tabled` lane by sacred-board
+  authorization whatever `work_state` you pass, and tabled rows are excluded from
+  every default listing — retrieve with `follow_up_list(include_tabled=True)`.
+- HAS `observation_write` but NOT `follow_up_create` (reflection sessions, whose
+  denylist derives as `live registry − read-allowlist − observation_write`) → use
+  `observation_write` or the parsed `observations` output field.
+- Has NEITHER (`observe`, `community-responder`, `mail` — all carry
+  `_NO_MEMORY_WRITES` + no follow-ups; and sentinel-DEGRADED, which mounts no MCP at
+  all) → there is no local record to write. Return it in the session's output text
+  and let the dispatching foreground session file it.
+
+There is no automated promoter from a `tabled` row to an issue today. A foreground
+session has to carry it across.
+
+### The time-gated exception
+
+A GitHub issue has no revisit mechanism — the trigger machinery (`blocked_on_trigger`,
+`revisit_condition`, `scheduled_at`, the 5-minute dispatcher) is ledger-only. So repo
+work that is ALSO gated on a time or event keeps **both**: the issue, plus a local
+`blocked_on_trigger` row carrying the trigger. That row REQUIRES a `revisit_condition`
+(the tool hard-errors without one) and cannot use `strategy="surplus_task"`.
+
+This is the one case where two records for one item is correct. Otherwise: one record.
+
+### Closing the loop
+
+Citing the issue when closing a local row is MANUAL. The automated reconciliation in
+`session_awareness/repo_pulse.py` maps issue → follow-up only via
+`pending_issue_posts.source_ref`, which a hand-filed `gh issue create` never creates —
+so unlike the `Ledger:` / `Follow-up:` PR-body conventions, nothing absorbs it for you.
 
 ## Recall — Where to Search
 
@@ -72,7 +163,7 @@ See `.claude/docs/background-sessions.md` for the full guide. Quick rule:
 
 | Use | When |
 |-----|------|
-| `follow_up_create` | Deferred work with a verifiable outcome — needs tracking through completion |
+| `follow_up_create` | Deferred USER-OWNED work with a verifiable outcome (Genesis-repo work → GitHub issue) |
 | `observation_write` | A finding, insight, or detection — informational, feeds the perception pipeline |
 
 Follow-ups are accountability. Observations are awareness.

--- a/.claude/docs/mcp-tools-guide.md
+++ b/.claude/docs/mcp-tools-guide.md
@@ -41,7 +41,8 @@ DRAFT="$(mktemp -d)"                       # per-invocation, never a shared path
 python3 scripts/file_tracker_issue.py \
   --title-file "$DRAFT/title.txt" --body-file "$DRAFT/body.md" \
   --area area:memory --difficulty "help wanted" --dry-run   # drop --dry-run to post
-rm -f "$DRAFT"/*.txt "$DRAFT"/*.md && rmdir "$DRAFT"
+# KEEP $DRAFT until the real filing reaches a known outcome — see below
+# rm -f "$DRAFT"/*.txt "$DRAFT"/*.md && rmdir "$DRAFT"
 ```
 
 The script exists because three cross-model review rounds each found a different
@@ -86,9 +87,19 @@ nonzero exit, timeout, a broken pipe while printing the URL — is another way t
 wrong about whether the post happened. Asking the tracker answers all of them from
 ground truth instead of patching each one as it is found.
 
-Use a fresh `mktemp -d` per invocation, and clean it WITHOUT `rm -rf` — this
-repo's own destructive-command guard refuses a recursive-force delete on a path it
-cannot prove is deep enough, so `rm -rf "$DRAFT"` is blocked for every session. Foreground and background sessions run
+**Do not delete the drafts after the dry run.** The dry run validates the exact files
+the real invocation will use; deleting them means the real post either fails for want
+of files or uses drafts that were never validated. Keep `$DRAFT` until the real filing
+returns a KNOWN outcome — and on exit 4 keep it longer, because the title and body are
+what you need to reconcile against the tracker. Clean up only after 0, 2 or 3:
+
+```bash
+rm -f "$DRAFT"/*.txt "$DRAFT"/*.md && rmdir "$DRAFT"
+```
+
+Use a fresh `mktemp -d` per invocation, and clean it WITHOUT `rm -rf` — this repo's own
+destructive-command guard refuses a recursive-force delete on a path it cannot prove is
+deep enough, so `rm -rf "$DRAFT"` is blocked for every session. Foreground and background sessions run
 concurrently here, and a shared draft path lets one session overwrite the body
 another has already scanned and approved, between the scan and the post.
 

--- a/.claude/docs/mcp-tools-guide.md
+++ b/.claude/docs/mcp-tools-guide.md
@@ -74,12 +74,17 @@ is a hard guarantee · `3` an identical title already exists · `4` **INDETERMIN
 `1` unexpected error. **Run `--dry-run` first** — it performs every check and posts
 nothing.
 
-Exit `4` is the one that needs a human. It means `gh` failed but GitHub may already
-have committed the issue and lost the response — so the post may exist. Check the
-tracker for that title BEFORE retrying or writing a local row; a retry on a successful
-post creates a duplicate, and a local row records a falsehood. `2` and `4` are
-deliberately distinct: conflating them would tell you nothing was posted when
-something may have been.
+Exit `4` is the one that needs a human, and it is now RARE. When a create fails or
+times out, the script does not guess — it re-queries the tracker for that exact title
+and tells you what actually happened: the issue exists (success, reported as
+reconciled) or it does not (a clean `2`, safe to retry). `4` survives only when that
+reconciling lookup ALSO fails, which is the one genuinely unknowable case; check the
+tracker by hand before retrying or writing a local row.
+
+That design is deliberate. Every route by which a create's outcome can be lost —
+nonzero exit, timeout, a broken pipe while printing the URL — is another way to be
+wrong about whether the post happened. Asking the tracker answers all of them from
+ground truth instead of patching each one as it is found.
 
 Use a fresh `mktemp -d` per invocation, and clean it WITHOUT `rm -rf` — this
 repo's own destructive-command guard refuses a recursive-force delete on a path it

--- a/.claude/docs/mcp-tools-guide.md
+++ b/.claude/docs/mcp-tools-guide.md
@@ -33,18 +33,25 @@ security defect before it is fixed). This section is the operational detail.
 
 ### Who may file at all
 
-Only a session on an install whose operator **owns the tracker** — i.e. `origin` IS
-the public repo and the operator has push access. Check before filing:
+Only a session whose operator has **write access to the shared tracker**. Identity is
+not enough — a direct clone of the shared repo reports the right slug while the
+authenticated user still lacks push access, and GitHub then silently DROPS the
+mandatory labels. Check the PERMISSION, fail closed, and CAPTURE the slug:
 
 ```bash
-gh repo view --json nameWithOwner --jq .nameWithOwner
+REPO="$(gh repo view --json nameWithOwner,viewerPermission \
+        --jq 'select(.viewerPermission|IN("WRITE","MAINTAIN","ADMIN")) | .nameWithOwner')"
+[ -n "$REPO" ] || { echo "no write access to this tracker — keep it local" >&2; exit 1; }
 ```
 
-If that is not the shared tracker, DO NOT file. `gh` resolves the target from the git
-remote, and the documented install is a fork clone, so an issue would land in the
-operator's own fork where nobody can pick it up — silently, with no error. Note also
-that GitHub silently DROPS labels supplied by a user without push access, so a
-non-owner cannot satisfy the label rule below even if the target were right.
+Keep `$REPO` and pass it explicitly to every later command (below). A bare `gh issue
+…` re-resolves its target from the CURRENT directory each time, so a `cd` between the
+check and the post sends an irreversible write to a repository nobody verified — and
+on a fork-cloned install the bare form targets the operator's own fork, where nobody
+can pick the issue up.
+
+If the check fails, Genesis-repo work stays a local `follow_up_create` row until a
+maintainer carries it across. That is a known gap, not a workaround.
 
 On a non-owning install, Genesis-repo work stays a local `follow_up_create` row until
 a maintainer carries it across. That is a known gap, not a workaround.
@@ -62,15 +69,27 @@ appears — the session must ASK, in words, and get a yes, for each issue. A pri
 
 ### Filing the issue
 
-```bash
-# 1. preflight — do not create a duplicate
-gh issue list --search "<distinctive phrase> in:title" --state all --limit 10
+Write the title and body to FILES first, then read them into quoted variables. Never
+paste issue text straight into the command line: a title containing backticks or
+`$(...)` — ordinary in a technical title — is executed by the shell AFTER your privacy
+scan, and its output lands in the public title.
 
-# 2. file, non-interactively
-gh issue create \
-  --title "<title>" --body-file <path> \
-  --label area:<domain> --label <difficulty-or-environment>
+```bash
+# title and body already written to files by an editor tool, not echoed through a shell
+TITLE="$(cat ~/tmp/issue-title.txt)"
+BODY=~/tmp/issue-body.md
+
+# 1. preflight against the VERIFIED repo — do not create a duplicate
+gh issue list --repo "$REPO" --search "$TITLE" --state all --limit 10
+
+# 2. file, non-interactively, every expansion quoted
+gh issue create --repo "$REPO" \
+  --title "$TITLE" --body-file "$BODY" \
+  --label "area:<domain>" --label "good first issue"
 ```
+
+Quote every label: `good first issue` and `help wanted` contain spaces and word-split
+into invalid arguments unquoted. Quote `"$BODY"` too.
 
 `--title` and `--body`/`--body-file` are REQUIRED, not optional: `gh` prompts for a
 missing body, and Genesis runs the CLI with piped stdin, so the prompt can never be
@@ -141,12 +160,22 @@ a local `blocked_on_trigger` row carrying the trigger, which REQUIRES a
 `revisit_condition` (the tool hard-errors without one) and cannot use
 `strategy="surplus_task"`.
 
-Be clear about what that row does: `revisit_condition` is **stored and displayed, not
-evaluated**. The dispatcher dispatches due `scheduled_task` rows and immediate
-`surplus_task` rows; nothing watches for your event and nothing transitions the row
-when it happens. It is a passive reminder that surfaces in listings — for a TIME
-trigger use `strategy="scheduled_task"` with `scheduled_at`, which the dispatcher does
-act on.
+Be clear about what that row does, because none of the strategies gives repo work a
+real trigger — read what the dispatcher does with each before choosing:
+
+- `revisit_condition` is **stored and displayed, never evaluated**. Nothing watches for
+  your event and nothing transitions the row. It is a passive reminder that surfaces in
+  listings for a foreground session to act on. That is the right choice here.
+- Do NOT reach for `strategy="scheduled_task"` to get a time trigger. The dispatcher
+  hands every due scheduled row to SURPLUS (`follow_ups/dispatcher.py` `run_cycle`),
+  where a keyword fallback turns arbitrary repo work into a free-model
+  `BRAINSTORM_SELF` task, and output from that task marks the follow-up COMPLETED. The
+  reminder deletes itself while the GitHub issue is still unimplemented — strictly
+  worse than no trigger.
+- `surplus_task` is rejected outright for `blocked_on_trigger` (it dispatches
+  immediately, ignoring the trigger).
+
+So: a passive row a human reads, not an automated revisit.
 
 This is the one case where two records for one item is correct.
 

--- a/.claude/docs/mcp-tools-guide.md
+++ b/.claude/docs/mcp-tools-guide.md
@@ -23,86 +23,132 @@ owner: Genesis-repo work → a **GitHub issue**; user-owned work → `follow_up_
 consciously not pursuing → `follow_up_create` with `work_state="deferred_cold"`.
 
 
+
 ## Where Deferred Work Goes — mechanics
 
 `CLAUDE.md` carries the routing principle (Genesis-repo work → a GitHub issue;
 user-owned + purely-local operational work → a follow-up; consciously-not-doing →
-`tabled`). This section is the operational detail behind it.
+`tabled`) and its two hard limits (explicit approval every time; never publish a
+security defect before it is fixed). This section is the operational detail.
+
+### Who may file at all
+
+Only a session on an install whose operator **owns the tracker** — i.e. `origin` IS
+the public repo and the operator has push access. Check before filing:
+
+```bash
+gh repo view --json nameWithOwner --jq .nameWithOwner
+```
+
+If that is not the shared tracker, DO NOT file. `gh` resolves the target from the git
+remote, and the documented install is a fork clone, so an issue would land in the
+operator's own fork where nobody can pick it up — silently, with no error. Note also
+that GitHub silently DROPS labels supplied by a user without push access, so a
+non-owner cannot satisfy the label rule below even if the target were right.
+
+On a non-owning install, Genesis-repo work stays a local `follow_up_create` row until
+a maintainer carries it across. That is a known gap, not a workaround.
+
+### Approval — every time
+
+A public post is irreversible; `contributor_issue.py` classifies it exactly that way
+(`action_class="irreversible"`, owner approval, never auto-approved). CLAUDE.md's
+standing rule already covers it: irreversible actions need explicit approval first.
+
+**Human presence is not approval.** Channel-driven sessions run with
+`skip_permissions=True` (`src/genesis/cc/conversation.py`), so no tool confirmation
+appears — the session must ASK, in words, and get a yes, for each issue. A prior
+"go ahead" does not carry to the next one.
 
 ### Filing the issue
 
 ```bash
-gh issue create --repo <owner>/<public-repo> \
+# 1. preflight — do not create a duplicate
+gh issue list --search "<distinctive phrase> in:title" --state all --limit 10
+
+# 2. file, non-interactively
+gh issue create \
+  --title "<title>" --body-file <path> \
   --label area:<domain> --label <difficulty-or-environment>
 ```
 
-**Always pass `--repo`.** `gh` resolves the target from the git remote, and the
-documented install is a fork clone (`.claude/docs/your-genesis.md`) — so on most
-installs a bare `gh issue create` files to the user's PRIVATE fork, where nobody can
-pick it up, silently and with no error. The target is `github.user` + `github.public_repo` in
-`~/.genesis/config/genesis.yaml` (resolvers: `genesis.env.github_user()` /
-`github_public_repo()` — the latter returns the bare name, without the owner).
+`--title` and `--body`/`--body-file` are REQUIRED, not optional: `gh` prompts for a
+missing body, and Genesis runs the CLI with piped stdin, so the prompt can never be
+answered — the command hangs or fails and neither an issue nor a local row results.
+
+The preflight matters because the hand path has no dedup. The gated path checks open
+titles and fails closed; nothing protects a direct `gh issue create`, and two sessions
+finding the same defect (or one retrying after losing the first command's output)
+otherwise produce duplicates — against the one-record-per-item rule.
 
 **Both label classes are mandatory**, matching the policy the propose path enforces
 fail-closed (`src/genesis/mcp/health/contributor_issue.py`): an `area:*` domain label
-AND a difficulty/environment label (`good first issue`, `first-timers-only`,
-`help wanted`, `needs-genesis-instance`). The hand path has no validator, so this is on you — an
-unlabelled issue silently breaks an invariant the codebase enforces elsewhere.
+AND one of `good first issue`, `first-timers-only`, `help wanted`,
+`needs-genesis-instance`.
 
-**Privacy-scan the body first.** Technical detail only: no IPs, hostnames, absolute
+**Privacy-scan the TITLE and the BODY, and the labels.** All three egress; the gated
+path scans all three for exactly that reason, and a title is the easiest place to leak
+a hostname, a path, or a metric. Technical detail only — no IPs, hostnames, absolute
 home paths, identifiers, or raw install metrics (row counts and spend leak usage
-scale — state proportions or shapes instead). Nothing gates this path — `gh issue
+scale; state proportions or shapes instead). Nothing gates this path — `gh issue
 create` appears nowhere in `scripts/hooks/git_push_guard.py`, which gates push /
-`gh pr merge` / `gh pr create` — so a public post here is irreversible and unguarded,
-and must be a conscious, human-present act.
+`gh pr merge` / `gh pr create` — so the scan is manual and there is no backstop.
+
+### Security defects never go public first
+
+An unpatched authentication bypass, credential exposure, injection path, or anything
+otherwise exploitable is NOT filed on the public tracker while it is unfixed —
+publishing it hands a working lead to anyone reading, against installs that are
+running the vulnerable code right now. Keep it local, fix it, then file (or file a
+post-fix note). The privacy scan does not catch this: it looks for install-specific
+data, not for dangerous technical disclosure.
 
 ### Why not `contributor_issue_propose`
 
-That MCP tool is the *gated* door: fail-closed prose sanitizer, owner approval hold,
-label validation, dedup and rate backpressure, and a `source_follow_up_id` close-loop
-link. It is the better path when it applies — but it ships `propose_only` by default,
-where an approved hold still dry-runs and never posts, and a `dry_run` mark is
-terminal (flipping the lever to `live` later does NOT retro-post). So it cannot serve
-"file this now". Use it for curated contributor-facing work; use the hand path above
-for engineering issues you need on the tracker today.
+That MCP tool is the *gated* door: fail-closed sanitizer over title/body/labels, owner
+approval hold, label validation, dedup and rate backpressure, and a
+`source_follow_up_id` close-loop link. It is the better path when it applies — but it
+ships `propose_only` by default, where an approved hold still dry-runs and never
+posts, and a `dry_run` mark is terminal (flipping the lever to `live` later does NOT
+retro-post). So it cannot serve "file this now".
 
 ### Dispatched / background sessions
 
-A dispatched session must NOT file issues — no gate covers the path and no human is
-present. (`steward` gets `gh`-restricted Bash, so for that profile this is a policy
-line, not a locked door.) It records locally instead, but check the profile first
-(`.claude/docs/background-sessions.md`): **naming a route a session cannot take is
-worse than naming none.**
-
-Check your OWN denylist rather than trusting a list here — profiles change. Three
-tiers exist today:
+A dispatched session must NOT file issues — nothing gates the path and there is no one
+to approve. (`steward` gets `gh`-restricted Bash, so for that profile this is a policy
+line, not a locked door.) It records locally instead — but check the profile first:
+**naming a route a session cannot take is worse than naming none.** Check your OWN
+denylist rather than trusting a list here; three tiers exist today:
 
 - HAS `follow_up_create` (`interact`, `research`, `campaign`, `steward`; and
-  `sentinel` when NOT degraded — `_DEGRADED_DISALLOWED_TOOLS` denies no MCP tools)
-  → file there, and say in `reason` that it is repo work awaiting a foreground
-  session. Note the row is FORCED onto the cold `tabled` lane by sacred-board
-  authorization whatever `work_state` you pass, and tabled rows are excluded from
-  every default listing — retrieve with `follow_up_list(include_tabled=True)`.
-- HAS `observation_write` but NOT `follow_up_create` (reflection sessions, whose
-  denylist derives as `live registry − read-allowlist − observation_write`) → use
+  `sentinel` when NOT degraded) → file there, and say in `reason` that it is repo work
+  awaiting a foreground session. The row is FORCED onto the cold `tabled` lane by
+  sacred-board authorization whatever `work_state` you pass, and tabled rows are
+  excluded from every default listing — retrieve with
+  `follow_up_list(include_tabled=True)`.
+- HAS `observation_write` but NOT `follow_up_create` (reflection sessions) → use
   `observation_write` or the parsed `observations` output field.
-- Has NEITHER (`observe`, `community-responder`, `mail` — all carry
-  `_NO_MEMORY_WRITES` + no follow-ups; and sentinel-DEGRADED, which mounts no MCP at
-  all) → there is no local record to write. Return it in the session's output text
-  and let the dispatching foreground session file it.
+- Has NEITHER (`observe`, `community-responder`, `mail`; and sentinel-DEGRADED, which
+  mounts no MCP at all) → there is no local record to write. Return it in the
+  session's output text and let the dispatching foreground session file it.
 
-There is no automated promoter from a `tabled` row to an issue today. A foreground
-session has to carry it across.
+There is no automated promoter from a `tabled` row to an issue today.
 
-### The time-gated exception
+### The time-gated case
 
-A GitHub issue has no revisit mechanism — the trigger machinery (`blocked_on_trigger`,
-`revisit_condition`, `scheduled_at`, the 5-minute dispatcher) is ledger-only. So repo
-work that is ALSO gated on a time or event keeps **both**: the issue, plus a local
-`blocked_on_trigger` row carrying the trigger. That row REQUIRES a `revisit_condition`
-(the tool hard-errors without one) and cannot use `strategy="surplus_task"`.
+A GitHub issue has no revisit mechanism. Repo work ALSO gated on a time or event keeps
+a local `blocked_on_trigger` row carrying the trigger, which REQUIRES a
+`revisit_condition` (the tool hard-errors without one) and cannot use
+`strategy="surplus_task"`.
 
-This is the one case where two records for one item is correct. Otherwise: one record.
+Be clear about what that row does: `revisit_condition` is **stored and displayed, not
+evaluated**. The dispatcher dispatches due `scheduled_task` rows and immediate
+`surplus_task` rows; nothing watches for your event and nothing transitions the row
+when it happens. It is a passive reminder that surfaces in listings — for a TIME
+trigger use `strategy="scheduled_task"` with `scheduled_at`, which the dispatcher does
+act on.
+
+This is the one case where two records for one item is correct.
 
 ### Closing the loop
 

--- a/.claude/skills/cc-update/SKILL.md
+++ b/.claude/skills/cc-update/SKILL.md
@@ -401,7 +401,7 @@ existing Genesis workflow, replaces a hand-rolled mechanism, or covers a known
 gap), do BOTH:
 
 1. File the informational KB entry as usual (no alert — calibration unchanged).
-2. File a GitHub ISSUE (`gh issue create --repo <owner>/<public-repo>`) naming
+2. File a GitHub ISSUE (see the mechanics in `.claude/docs/mcp-tools-guide.md`) naming
    the SPECIFIC instruction change — editing a skill or CLAUDE.md is repo work,
    so it belongs on the public tracker. Because it is ALSO time-gated on the
    pin, keep a local `blocked_on_trigger` row alongside it, with a

--- a/.claude/skills/cc-update/SKILL.md
+++ b/.claude/skills/cc-update/SKILL.md
@@ -403,10 +403,12 @@ gap), do BOTH:
 1. File the informational KB entry as usual (no alert — calibration unchanged).
 2. File a GitHub ISSUE (see the mechanics in `.claude/docs/mcp-tools-guide.md`) naming
    the SPECIFIC instruction change — editing a skill or CLAUDE.md is repo work,
-   so it belongs on the public tracker. Because it is ALSO time-gated on the
-   pin, keep a local `blocked_on_trigger` row alongside it, with a
-   `revisit_condition` (the tool hard-errors without one; the tracker has no
-   revisit mechanism). E.g. "once CC >= vX.Y.Z is pinned: prefer
+   so it belongs on the public tracker. At THIS step the selected pin is already
+   deployed and validated (steps 8-9), so the issue alone is enough — do NOT add a
+   `blocked_on_trigger` row here; it would record a blocker already satisfied and,
+   since the condition is never evaluated, sit there indefinitely. Add one only for
+   a pin genuinely not yet reached, with a `revisit_condition` (the tool
+   hard-errors without one). E.g. "once CC >= vX.Y.Z is pinned: prefer
    native `/design` over the gstack `design-*` skills for UI drafting; decide
    precedence and update the relevant skill/CLAUDE.md instruction". A
    capability nobody wires into an instruction is a capability Genesis never

--- a/.claude/skills/cc-update/SKILL.md
+++ b/.claude/skills/cc-update/SKILL.md
@@ -388,7 +388,7 @@ the delta touches:
   backstop).
 - **`--flags` Genesis passes** (`--model`, `--mcp-config`, `--bare`, `-p`, `--append-system-prompt`).
 
-Capture any such change as a follow-up + a doc entry — that is how the next update stays
+Capture any such change as a GitHub issue + a doc entry — that is how the next update stays
 execute-not-rediscover.
 
 ## Detection → behavior (new-capability adoption path)
@@ -401,8 +401,12 @@ existing Genesis workflow, replaces a hand-rolled mechanism, or covers a known
 gap), do BOTH:
 
 1. File the informational KB entry as usual (no alert — calibration unchanged).
-2. Create a `follow_up_create` row (`work_state="ready"`, low priority) naming
-   the SPECIFIC instruction change, e.g. "once CC >= vX.Y.Z is pinned: prefer
+2. File a GitHub ISSUE (`gh issue create --repo <owner>/<public-repo>`) naming
+   the SPECIFIC instruction change — editing a skill or CLAUDE.md is repo work,
+   so it belongs on the public tracker. Because it is ALSO time-gated on the
+   pin, keep a local `blocked_on_trigger` row alongside it, with a
+   `revisit_condition` (the tool hard-errors without one; the tracker has no
+   revisit mechanism). E.g. "once CC >= vX.Y.Z is pinned: prefer
    native `/design` over the gstack `design-*` skills for UI drafting; decide
    precedence and update the relevant skill/CLAUDE.md instruction". A
    capability nobody wires into an instruction is a capability Genesis never

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -240,8 +240,9 @@ classify it:
 
 - **Data repair** — you wrote the artifact the mechanism should have
   written. Label it "data repair" explicitly, and in the same session
-  either fix the mechanism or get the user's explicit deferral
-  (recorded as a follow-up). Never report a data repair as "fixed".
+  either fix the mechanism or get the user's explicit deferral (the mechanism
+  fix recorded as an ISSUE; a local row only if the deferral itself needs
+  tracking). Never report a data repair as "fixed".
 - **Class fix** — you changed the mechanism so the artifact is written
   correctly on every install, going forward, with a test proving it.
 
@@ -865,13 +866,13 @@ thinking any of these, STOP — you are rationalizing a shortcut.
 | "This is just a simple fix, no tests needed" | Simple fixes break complex systems. The Qdrant regression was a "simple fix." Write the test. |
 | "I already know what this function does" | You haven't read the implementation. Docstrings lie. Read the actual code. |
 | "Tests pass, so we're done" | Tests verify what they cover, not the outcome. Verify actual end-to-end behavior. |
-| "I'll clean this up in the next commit" | Next commit never comes in autonomous sessions. Do it now or create a follow-up. |
+| "I'll clean this up in the next commit" | Next commit never comes in autonomous sessions. Do it now, or file it — Genesis-repo work is a GitHub issue, not a local row. |
 | "This file is too large to read fully" | Read the relevant section. Partial reads lead to partial understanding and wrong fixes. |
 | "The linter is happy, ship it" | Linters catch syntax, not logic. Clean lint with broken behavior is worse than a warning with correct behavior. |
 | "This change is low-risk, no impact analysis needed" | Your confidence is based on what you know; checking callers reveals what you don't. Serena `find_referencing_symbols` is live — run it. For multi-hop blast radius, `gitnexus analyze` then `impact`. |
 | "I can skip the worktree, I'll be quick" | Concurrent session safety exists because "quick" commits have destroyed work before. Always worktree. |
 | "The error is transient, retry will fix it" | Diagnose first. Retrying a misdiagnosed error wastes tokens and masks root causes. |
-| "I'll add the follow-up later" | Follow-ups not created in-session are lost. Create it now while context is fresh. |
+| "I'll add the follow-up later" | Records not created in-session are lost. File it now while context is fresh — Genesis-repo work as a GitHub issue, user-owned work as a follow-up. |
 | "I don't need a skill for this" | If a skill exists, use it. The using-superpowers Red Flags table exists for this exact rationalization. |
 | "This review round is the same class, it doesn't really count" | For an EXTERNAL cross-model round, the counter decides, not you — a repeat-class external round still counts; update it every external cycle and STOP at the cap. (Internal same-model reviews are never rounds.) |
 | "The user already said proceed, so I can keep looping" | The escalation/fix-attempt caps CONSUME standing approval. Round 4+ (or fix #4) on an old instruction is a violation, not obedience. |
@@ -1571,8 +1572,10 @@ session assumed deploy "happens somehow").
 2. Verify the deploy landed: gateway `version` op reports the expected
    `deployed_commit` / CC version; guardian tick healthy in its journal.
 3. State the deploy + verification result explicitly in the wrap-up. If the
-   deploy cannot happen this session (host unreachable), create a follow-up
-   via `follow_up_create` — never leave deploy as an implicit assumption.
+   deploy cannot happen this session, record it — never leave deploy as an
+   implicit assumption. Route it: a purely LOCAL blocker (host unreachable
+   tonight) is a `follow_up_create` row; a blocker that exposes a REPO-level gap
+   (a missing reconcile mechanism, no self-heal path) is a GitHub issue.
 
 **The reverse direction is equally binding**: host VMs are deploy targets,
 never edit-in-place dev environments. An emergency hand-edit on a host gets a

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1573,9 +1573,12 @@ session assumed deploy "happens somehow").
    `deployed_commit` / CC version; guardian tick healthy in its journal.
 3. State the deploy + verification result explicitly in the wrap-up. If the
    deploy cannot happen this session, record it — never leave deploy as an
-   implicit assumption. Route it: a purely LOCAL blocker (host unreachable
-   tonight) is a `follow_up_create` row; a blocker that exposes a REPO-level gap
-   (a missing reconcile mechanism, no self-heal path) is a GitHub issue.
+   implicit assumption. A purely LOCAL blocker (host unreachable tonight) is a
+   `follow_up_create` row. A blocker exposing a REPO-level gap (a missing reconcile
+   mechanism, no self-heal path) needs BOTH: an issue for the mechanism fix, AND a
+   local row for the fact that THIS install is still undeployed — another
+   contributor can close the issue without ever touching this host, which is
+   exactly the stale-host failure above.
 
 **The reverse direction is equally binding**: host VMs are deploy targets,
 never edit-in-place dev environments. An emergency hand-edit on a host gets a

--- a/.claude/skills/genesis-development/references/observability.md
+++ b/.claude/skills/genesis-development/references/observability.md
@@ -55,5 +55,6 @@ Write/Edit containing hide-problem patterns in code, plans, or comments.
 **Bugs you see get fixed or tracked — never ignored.** Every bug you
 encounter during any work (even unrelated work, pre-existing bugs, things
 mentioned in passing) must be either fixed inline (if small and low-risk)
-or filed as a follow-up (observation, task, TODO) AND raised in your next
+or filed — a Genesis-repo bug as a GitHub issue, a someday one as `tabled`
+(see CLAUDE.md "Where deferred work goes") — AND raised in your next
 user-facing report. "Out of scope" is not an option.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,10 +474,14 @@ When a user shares a file path or URL in conversation:
   far-off direction) → **tabled** (`work_state="deferred_cold"`) — a private record,
   never dispatched, surfaced, or filed as an issue, because we don't want it picked
   up. `work_state` DERIVES the lane, so priority never picks it. ONE record per item.
-  Mechanics — the exact `gh` command and its mandatory labels, what a DISPATCHED
-  session does instead, and the time-gated exception — are in
-  `.claude/docs/mcp-tools-guide.md` ("Where Deferred Work Goes"). Read it before
-  filing your first; a bare `gh issue create` files to the wrong repo on most installs.
+  Two hard limits on the issue route, both non-negotiable: a public post is
+  IRREVERSIBLE, so it needs the user's **explicit approval every time** (no standing
+  approval carries forward, and a channel-driven session has no confirmation step of
+  its own); and a **security** defect — an unpatched bypass, a credential exposure,
+  anything exploitable — is NEVER filed publicly before it is fixed, no matter who
+  owns it. Everything else — who may file, the command, labels, dispatched sessions,
+  the time-gated case — is in `.claude/docs/mcp-tools-guide.md` ("Where Deferred Work
+  Goes"). Read it before filing your first.
 - **No laziness.** Find root causes. No temporary fixes. No shortcuts.
   Don't EVER mute the symptom — fix the problem.
 - **Read before writing.** Never modify code you haven't fully read.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,26 +463,21 @@ When a user shares a file path or URL in conversation:
   without explicit user confirmation.
 - **Session wrap-up**: structured handoff — what changed, what's pending,
   what was learned. If it's not committed, it doesn't exist.
-- **Follow-up discipline**: bias = FIX NOW, not defer. A follow-up is valid
-  ONLY if the work is (1) blocked on a precondition unmet this session (incl.
-  an unmade design decision), (2) gated on time/data, or (3) big enough to
-  derail this session — or the user directs it as separate. Otherwise do it
-  now, even if unrelated/unasked; "already noted in a PR/comment" is not a
-  reason to also create a row. Valid ones: create via `follow_up_create` MCP,
-  never leave as just text. **`follow_up_create` takes a `work_state`, not a raw
-  lane** — declare the item's state and the tool DERIVES the lane, so priority
-  never decides it. It is an INTENT/tractability axis, NOT priority (a low-priority
-  item you still intend to do is `ready`, never `deferred_cold`):
-  `ready` (actionable now, just needs doing) and `blocked_on_trigger` (intended,
-  waiting on a specific time/event — REQUIRES a `revisit_condition`) → the HOT
-  `follow_up` lane (committed, actionable, dispatched/surfaced — the
-  FIX-NOW-or-valid-defer cases above); `deferred_cold` (consciously NOT pursuing
-  near-term — vague/hard/someday) → the COLD `tabled` lane (an awareness record,
-  bug-tracker semantics, never dispatched or surfaced). Genuine someday/maybe and
-  deferred known bugs are `deferred_cold`, not the hot lane. (`follow_up_update`
-  moves lanes via the same `work_state` — there is no raw-`kind` lane override on
-  either surface, so priority can't pick the lane on update either. Inbox
-  WATCH/BOOKMARK markers auto-route to `tabled` and soft-decay after 60d.)
+- **Where deferred work goes.** Bias = FIX NOW; defer only if the work is (1) blocked
+  on an unmet precondition (incl. an unmade design decision), (2) gated on time/data,
+  or (3) big enough to derail the session — or the user directs it. Route by OWNER:
+  **Genesis-repo work** (code, tests, docs, infra — anything that would live in the
+  public repo, even when hit locally) → a **GitHub issue**, so anyone can pick it up.
+  **User-owned work** (a deliverable, an errand, anything asked for and unfinished),
+  and operational state purely local to this box → a local **follow-up** via
+  `follow_up_create`, never plain text. **Consciously not doing** (nitpick, someday, a
+  far-off direction) → **tabled** (`work_state="deferred_cold"`) — a private record,
+  never dispatched, surfaced, or filed as an issue, because we don't want it picked
+  up. `work_state` DERIVES the lane, so priority never picks it. ONE record per item.
+  Mechanics — the exact `gh` command and its mandatory labels, what a DISPATCHED
+  session does instead, and the time-gated exception — are in
+  `.claude/docs/mcp-tools-guide.md` ("Where Deferred Work Goes"). Read it before
+  filing your first; a bare `gh issue create` files to the wrong repo on most installs.
 - **No laziness.** Find root causes. No temporary fixes. No shortcuts.
   Don't EVER mute the symptom — fix the problem.
 - **Read before writing.** Never modify code you haven't fully read.
@@ -492,8 +487,8 @@ When a user shares a file path or URL in conversation:
 - **NEVER hide broken things — FIX THEM.** Fix the root cause, not the
   symptom. This is a thinking rule, not just a code rule.
 - **Bugs you see get fixed or tracked — never ignored.** Fix now by default; a
-  bug you consciously defer becomes a `tabled` record (`work_state="deferred_cold"`,
-  bug-tracker lane above), never a silent drop.
+  deferred bug follows the routing above — a Genesis-repo bug becomes an ISSUE, a
+  someday/not-pursuing one becomes `tabled` — never a silent drop.
 - **Data repair is not a fix.** If a mechanism failed to write or propagate
   something, hand-writing the missing artifact (memory, directive, row, flag)
   repairs ONE instance on ONE install. Label it "data repair", and fix the

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -644,6 +644,10 @@ verified: 50b79ffb 2026-09-01
   `surplus/scheduler.py`.
 - `follow_ups/` = accountability ledger + dispatcher (every 5 min) that turns
   follow-ups into surplus tasks; retention sweep on the learning scheduler. The
+  `follow_up_create` MCP tool routes USER-OWNED and purely-local operational work
+  here; Genesis-repo work goes to the public GitHub tracker as an issue (CLAUDE.md
+  "Where deferred work goes"). Templated pipelines write via `crud.follow_ups.create()`
+  directly and are governed at their own call sites. The
   `follow_up_create`/`update` MCP tools take a `work_state`
   (ready/blocked_on_trigger/deferred_cold) and DERIVE the hot(`follow_up`)/
   cold(`tabled`) lane, so priority never picks the lane; `blocked_on_trigger`

--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -644,10 +644,14 @@ When a new CC version is released, run through this:
    **Detection → behavior:** for each new skill/command/flag Genesis would
    plausibly WANT (overlaps an existing workflow, replaces a hand-rolled
    mechanism, covers a known gap), do not stop at the informational KB note —
-   create a `follow_up_create` row (`work_state="ready"`, low priority) naming
+   file a GitHub ISSUE (`gh issue create --repo <owner>/<public-repo>`) naming
    the SPECIFIC instruction change that would make Genesis actually reach for
    it (which skill/CLAUDE.md line to edit, and any precedence decision vs
-   existing skills). A detected-but-unwired capability is never used.
+   existing skills) — that edit is repo work, so it belongs on the public
+   tracker. Keep a local `blocked_on_trigger` row alongside it when the
+   change waits on a version pin, with a `revisit_condition` naming the pin (the
+   tool hard-errors without one); the tracker has no revisit mechanism.
+   A detected-but-unwired capability is never used.
    (Origin: the 2026-08 `/design` research-preview announcement.)
 5. **Obsolescence check:** Does this make something we built unnecessary?
 6. **Interactive UX check:** Does this change the foreground session experience?

--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -644,7 +644,7 @@ When a new CC version is released, run through this:
    **Detection → behavior:** for each new skill/command/flag Genesis would
    plausibly WANT (overlaps an existing workflow, replaces a hand-rolled
    mechanism, covers a known gap), do not stop at the informational KB note —
-   file a GitHub ISSUE (`gh issue create --repo <owner>/<public-repo>`) naming
+   file a GitHub ISSUE (mechanics: `.claude/docs/mcp-tools-guide.md`) naming
    the SPECIFIC instruction change that would make Genesis actually reach for
    it (which skill/CLAUDE.md line to edit, and any precedence decision vs
    existing skills) — that edit is repo work, so it belongs on the public

--- a/scripts/file_tracker_issue.py
+++ b/scripts/file_tracker_issue.py
@@ -64,7 +64,7 @@ import signal
 import subprocess
 import sys
 import unicodedata
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -482,7 +482,41 @@ def _sigterm_as_interrupt(signum, frame):  # noqa: ARG001 - signal handler signa
     raise KeyboardInterrupt
 
 
+@contextmanager
+def _sigterm_reconciles() -> Iterator[None]:
+    """Route SIGTERM through the reconciling path, then put the old handler back.
+
+    Installing this globally and LEAVING it there is a bug, not a detail. main()
+    is importable and is called in-process (the tests do exactly that), and a
+    leaked SIGTERM handler is inherited by every process forked afterwards. An
+    unrelated test's multiprocessing children then raised KeyboardInterrupt
+    instead of dying on terminate(), so the parent's join() never returned --
+    MEASURED in CI as two tests hanging for the full 1800s timeout, in a file
+    this change does not touch.
+
+    Restoring is therefore part of the contract: the handler is a property of
+    THIS call, not of the interpreter.
+    """
+    try:
+        prior = signal.signal(signal.SIGTERM, _sigterm_as_interrupt)
+    except (ValueError, OSError):
+        # not the main thread, or no signals here -- best-effort, nothing to undo
+        yield
+        return
+    try:
+        yield
+    finally:
+        with contextlib.suppress(ValueError, OSError):
+            signal.signal(signal.SIGTERM, prior)
+
+
 def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
+    """Thin wrapper so the signal scope covers every return path in _run_main."""
+    with _sigterm_reconciles():
+        return _run_main(argv, run)
+
+
+def _run_main(argv: Sequence[str] | None, run: Runner) -> int:
     ap = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -496,10 +530,6 @@ def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
     )
     ap.add_argument("--dry-run", action="store_true", help="run every check, post nothing")
     args = ap.parse_args(argv)
-
-    # not the main thread, or no signals here — best-effort only
-    with contextlib.suppress(ValueError, OSError):
-        signal.signal(signal.SIGTERM, _sigterm_as_interrupt)
 
     posted: str | None = None
     # Set the instant before the create is attempted. An interrupt between

--- a/scripts/file_tracker_issue.py
+++ b/scripts/file_tracker_issue.py
@@ -131,23 +131,39 @@ def _run(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
 def _finish(code: int) -> int:
     """Return `code` and make sure the interpreter cannot override it.
 
-    CPython flushes stdout during shutdown, AFTER main() returns. If stdout is
-    closed or full that flush fails and the process exits 120 — silently
-    replacing whatever we returned. MEASURED: a run whose issue was created
-    successfully exited 120 under `> /dev/full`, i.e. a confirmed post reported
-    as an undocumented failure, sending the operator to retry into a duplicate.
+    CPython flushes stdout during shutdown, AFTER main() returns. If that flush
+    fails the process exits 120, silently replacing whatever we returned —
+    MEASURED: a run whose issue was created successfully exited 120 under
+    `> /dev/full`, i.e. a confirmed post reported as an undocumented failure.
 
-    So: flush here, where we can still react, and if that fails put a usable fd
-    under stdout so the shutdown flush has nothing to fail on.
+    This function is deliberately TOTAL: it is the guarantee, so it must not be
+    able to raise. Every stdout shape is handled —
+
+      * `sys.stdout is None`      (launched with fd 1 closed, e.g. `>&-`).
+        Nothing to flush and nothing for shutdown to flush either.
+      * a closed stream           (`flush()` raises ValueError, and so does the
+        `fileno()` we would use to recover — the recovery path needs its own
+        guard, which an earlier version of this function did not have).
+      * a full or broken pipe     (flush raises OSError; put a usable fd under
+        it so shutdown has nothing to fail on).
     """
+    stream = getattr(sys, "stdout", None)
+    if stream is None:
+        return code
     try:
-        sys.stdout.flush()
+        stream.flush()
+        return code
     except (OSError, ValueError):
-        try:
-            devnull = os.open(os.devnull, os.O_WRONLY)
-            os.dup2(devnull, sys.stdout.fileno())
-        except OSError:
-            pass  # nothing further to try; the exit code is still ours
+        pass
+    except Exception:  # noqa: BLE001 - a guarantee must never raise
+        return code
+    try:
+        fd = stream.fileno()
+    except (OSError, ValueError, AttributeError):
+        return code  # no fd to repair; shutdown has nothing usable to flush
+    with contextlib.suppress(OSError):
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, fd)
     return code
 
 
@@ -364,7 +380,12 @@ def _reconcile_uncertain_create(slug: str, title: str, cause: str, run: Runner) 
     # necessarily the one this invocation created — not a pre-existing one.
     try:
         found = find_duplicate(slug, title, run)
-    except Refused as exc:
+    except (Refused, OSError, ValueError) as exc:
+        # Not just Refused: the reconciling `gh` may fail to START at all
+        # (FileNotFoundError during an executable swap, ENOMEM, a decode error).
+        # Those are OSError/ValueError, which main()'s generic handler turns into
+        # exit 1 — "unexpected error" — when the truth is that the issue MAY
+        # exist. Everything that leaves the outcome unknown must land on exit 4.
         raise Indeterminate(
             f"{cause}, and the reconciling lookup then failed ({exc}). The issue MAY "
             f"exist on {slug}. Check the tracker for this exact title BEFORE retrying "
@@ -425,6 +446,18 @@ def create_issue(
     return url
 
 
+def _report_posted(posted: str, why: str) -> int:
+    """A confirmed post stays confirmed, whatever failed afterwards.
+
+    Once `gh issue create` has returned a URL the issue is durable. Any later
+    failure — a lock release, a print, a flush, an interrupt — is a REPORTING
+    problem, and reporting it as a failure is what sends an operator to retry
+    into a duplicate.
+    """
+    _warn(f"POSTED ({why}): {posted}")
+    return _finish(0)
+
+
 def _warn(message: str) -> None:
     """stderr write that cannot itself become the failure being reported."""
     with contextlib.suppress(OSError):
@@ -459,6 +492,8 @@ def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
     with contextlib.suppress(ValueError, OSError):
         signal.signal(signal.SIGTERM, _sigterm_as_interrupt)
 
+    posted: str | None = None
+
     try:
         try:
             with open(args.title_file, encoding="utf-8") as fh:
@@ -491,19 +526,18 @@ def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
         with tracker_lock(slug):
             dup = find_duplicate(slug, title, run)
             if dup is not None:
-                print(
-                    f"DUPLICATE: {slug}#{dup} already has this exact title. Nothing filed.",
-                    file=sys.stderr,
-                )
-                return 3
+                _warn(f"DUPLICATE: {slug}#{dup} already has this exact title. Nothing filed.")
+                return _finish(3)
             if args.dry_run:
                 print(f"DRY RUN ok — would file to {slug} (perm={perm}) with labels {labels}")
-                return 0
+                return _finish(0)
             # Create FIRST, report second. If stdout is closed or full, the post
             # has already happened — letting the print's OSError fall through to
             # the generic handler would report exit 1 for a CONFIRMED issue and
             # send the operator to retry into a duplicate.
             posted = create_issue(slug, title, args.body_file, labels, run)
+        # From here the issue EXISTS. Nothing below may report otherwise — see
+        # the handlers, which all check `posted` first.
         try:
             print(posted)
         except OSError:
@@ -514,16 +548,26 @@ def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
                 print(f"POSTED (could not write the URL to stdout): {posted}", file=sys.stderr)
         return _finish(0)
     except Indeterminate as exc:
+        if posted:
+            return _report_posted(posted, f"after creation: {exc}")
         _warn(f"INDETERMINATE: {exc}")
         return _finish(4)
     except Refused as exc:
+        if posted:
+            return _report_posted(posted, f"after creation: {exc}")
         _warn(f"REFUSED: {exc}")
         return _finish(2)
     except KeyboardInterrupt:
-        # Outside the create window, so nothing was posted.
+        # An interrupt arriving while the lock is released, the URL printed, or
+        # stdout flushed is AFTER the post. Reporting "nothing was created" there
+        # would send the operator to retry into a duplicate.
+        if posted:
+            return _report_posted(posted, "interrupted after creation")
         _warn("REFUSED: interrupted before the issue was created.")
         return _finish(2)
     except (OSError, subprocess.SubprocessError, ValueError) as exc:
+        if posted:
+            return _report_posted(posted, f"after creation: {exc}")
         _warn(f"ERROR: {exc}")
         return _finish(1)
 

--- a/scripts/file_tracker_issue.py
+++ b/scripts/file_tracker_issue.py
@@ -147,24 +147,33 @@ def _finish(code: int) -> int:
       * a full or broken pipe     (flush raises OSError; put a usable fd under
         it so shutdown has nothing to fail on).
     """
-    stream = getattr(sys, "stdout", None)
+    # BOTH streams: CPython flushes stderr at shutdown too, so a diagnostic
+    # written to a failing stderr replaces the exit code with 120 exactly as a
+    # failing stdout does. MEASURED: the missing-title path returned 120 instead
+    # of 2 with stderr on /dev/full.
+    for name in ("stdout", "stderr"):
+        _repair_stream(getattr(sys, name, None))
+    return code
+
+
+def _repair_stream(stream) -> None:
+    """Flush one stream, or put a usable fd under it. Never raises."""
     if stream is None:
-        return code
+        return
     try:
         stream.flush()
-        return code
+        return
     except (OSError, ValueError):
         pass
     except Exception:  # noqa: BLE001 - a guarantee must never raise
-        return code
+        return
     try:
         fd = stream.fileno()
     except (OSError, ValueError, AttributeError):
-        return code  # no fd to repair; shutdown has nothing usable to flush
+        return  # no fd to repair; shutdown has nothing usable to flush
     with contextlib.suppress(OSError):
         devnull = os.open(os.devnull, os.O_WRONLY)
         os.dup2(devnull, fd)
-    return code
 
 
 def _gh_json(run: Runner, argv: Sequence[str]) -> dict:
@@ -493,6 +502,10 @@ def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
         signal.signal(signal.SIGTERM, _sigterm_as_interrupt)
 
     posted: str | None = None
+    # Set the instant before the create is attempted. An interrupt between
+    # that point and create_issue() returning leaves the outcome UNKNOWN, not
+    # refused — the request may already have reached GitHub.
+    create_attempted = False
 
     try:
         try:
@@ -535,6 +548,7 @@ def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
             # has already happened — letting the print's OSError fall through to
             # the generic handler would report exit 1 for a CONFIRMED issue and
             # send the operator to retry into a duplicate.
+            create_attempted = True
             posted = create_issue(slug, title, args.body_file, labels, run)
         # From here the issue EXISTS. Nothing below may report otherwise — see
         # the handlers, which all check `posted` first.
@@ -563,11 +577,21 @@ def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
         # would send the operator to retry into a duplicate.
         if posted:
             return _report_posted(posted, "interrupted after creation")
+        if create_attempted:
+            _warn(
+                "INDETERMINATE: interrupted while creating the issue on "
+                f"{slug}. The request MAY have reached GitHub. Check the tracker "
+                "for this exact title BEFORE retrying."
+            )
+            return _finish(4)
         _warn("REFUSED: interrupted before the issue was created.")
         return _finish(2)
     except (OSError, subprocess.SubprocessError, ValueError) as exc:
         if posted:
             return _report_posted(posted, f"after creation: {exc}")
+        if create_attempted:
+            _warn(f"INDETERMINATE: {exc} — raised while creating on {slug}; the post MAY exist.")
+            return _finish(4)
         _warn(f"ERROR: {exc}")
         return _finish(1)
 

--- a/scripts/file_tracker_issue.py
+++ b/scripts/file_tracker_issue.py
@@ -1,50 +1,65 @@
 #!/usr/bin/env python3
 """File a Genesis-repo issue on the SHARED public tracker, safely.
 
-Three consecutive cross-model review rounds on the prose version of this
-procedure each found a different way for it to target the wrong repository or
-execute its own inputs. The failures were not independent bugs — they were the
-same class, and prose cannot enforce any of the five properties that matter:
+Four cross-model review rounds on this procedure — three while it was prose, one
+after it became this script — found the same shape of defect each time: a step
+CLAIMING MORE CERTAINTY THAN IT HAD. Every guarantee below exists because a
+reviewer showed the previous version asserting something it could not know.
 
-1. Resolve the UPSTREAM tracker, not whatever repo the cwd happens to be in.
-   `gh repo view` with no argument reports the CURRENT directory's repo, so on a
-   fork-cloned install it returns the operator's own fork — where they are ADMIN,
-   so a permission check on it passes and the issue lands somewhere nobody reads.
-2. Check `viewerPermission` on THAT EXPLICIT SLUG. Identity is not permission:
-   a direct clone reports the right slug while the user still lacks push access,
-   and GitHub then silently DROPS the mandatory labels.
-3. Never let issue text reach a shell. A title containing backticks or `$(...)` —
-   ordinary in a technical title — is executed if it is interpolated into a
-   command line, and its output lands in the public title. Everything here goes
-   through argv lists; no shell is ever involved.
-4. Per-invocation temp files. Two concurrent sessions sharing a fixed draft path
-   can overwrite each other between the privacy scan and the post.
-5. Exact-title dedup. `gh issue list --search` interprets `repo:` / `is:` /
-   `label:` inside a title as query syntax, so a raw-title search both misses
-   duplicates and can match unrelated issues.
+Targeting (rounds 1-3, prose):
+  * `--repo <install-user>/<repo>` resolved to the operator's OWN FORK.
+  * Bare `gh` commands re-resolve their target from the current directory, so a
+    `cd` between check and post redirects an irreversible write.
+  * `gh repo view` with no argument reports the CURRENT repo — on a fork clone
+    that is the fork, where the operator IS ADMIN, so a permission check on it
+    PASSES and the issue lands where nobody reads it.
 
-Everything fails CLOSED: any check that cannot complete refuses to file.
+Certainty at boundaries (round 4, this script):
+  * A capped listing is not proof of absence. The duplicate check paginates to
+    exhaustion; it never infers "no duplicate" from a truncated window.
+  * One `parent` hop is not the fork-network root. A fork of a fork needs the
+    chain walked. (This `gh` exposes `parent` but NOT `source`, so walking is
+    the available mechanism, not a stylistic preference.)
+  * Check-then-act is not atomic. Lookup and creation are serialised under a
+    per-tracker lock, so two concurrent sessions cannot both pass the duplicate
+    check and both post.
+  * A failed `gh issue create` does NOT prove nothing was posted. If the server
+    committed the issue and the response was lost, the issue EXISTS. That case
+    is reported as INDETERMINATE, never as "refused" — telling an operator that
+    nothing was posted when something may have been is the worst outcome here,
+    because they then file a duplicate or a false local record.
 
-This does NOT decide whether the issue *should* be public. The caller is
-responsible for the two hard limits in CLAUDE.md — explicit user approval for an
-irreversible post, and never publishing an unfixed security defect.
+Shell safety: everything runs through argv lists with `shell=False`. A title
+containing backticks or `$(...)` — ordinary in a technical title — would execute
+if interpolated into a command line, after the privacy scan, with its output in
+the public title. The absence of a shell is the mechanism, not a precaution.
+
+This does NOT decide whether the issue SHOULD be public. The caller owns the two
+hard limits in CLAUDE.md — explicit user approval for an irreversible post, and
+never publishing an unfixed security defect.
 
 Usage:
     file_tracker_issue.py --title-file T --body-file B --area area:memory \\
         --difficulty "help wanted" [--dry-run]
 
-Exit codes: 0 filed (or dry-run OK) · 2 refused (a precondition failed) ·
-3 duplicate found · 1 unexpected error.
+Exit codes: 0 filed (or dry-run OK) · 2 refused, nothing posted · 3 duplicate
+found · 4 INDETERMINATE — a post may or may not exist, reconcile before retrying
+· 1 unexpected error.
 """
 
 from __future__ import annotations
 
 import argparse
+import fcntl
+import hashlib
 import json
 import subprocess
 import sys
+import tempfile
 import unicodedata
 from collections.abc import Callable, Sequence
+from contextlib import contextmanager
+from pathlib import Path
 
 # Mirrors of the fail-closed sets enforced server-side by
 # ``src/genesis/mcp/health/contributor_issue.py``. Duplicated deliberately —
@@ -74,11 +89,23 @@ DIFFICULTY_LABELS = frozenset(
 )
 WRITE_PERMISSIONS = frozenset({"WRITE", "MAINTAIN", "ADMIN"})
 
+# A fork chain deeper than this is pathological; bound the walk so a cycle or a
+# misbehaving API can never spin.
+MAX_FORK_DEPTH = 10
+
 Runner = Callable[[Sequence[str]], "subprocess.CompletedProcess[str]"]
 
 
 class Refused(Exception):
-    """A precondition failed. Nothing was posted."""
+    """A precondition failed. NOTHING was posted — this is a hard guarantee."""
+
+
+class Indeterminate(Exception):
+    """The post may or may not exist. Reconcile against the tracker.
+
+    Deliberately NOT a subclass of Refused: the entire point is that a caller
+    must not treat it as "nothing happened".
+    """
 
 
 def _run(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
@@ -98,25 +125,43 @@ def _gh_json(run: Runner, argv: Sequence[str]) -> dict:
         raise Refused(f"`{' '.join(argv)}` returned unparseable JSON: {exc}") from exc
 
 
-def resolve_tracker(run: Runner = _run) -> str:
-    """The SHARED tracker slug — the fork's parent when this is a fork.
+def _parent_slug(data: dict) -> str | None:
+    parent = data.get("parent") or {}
+    owner = (parent.get("owner") or {}).get("login")
+    name = parent.get("name")
+    return f"{owner}/{name}" if owner and name else None
 
-    Never returns the current repo blindly: that is the round-3 defect.
+
+def resolve_tracker(run: Runner = _run) -> str:
+    """The SHARED tracker slug — the ROOT of the fork network.
+
+    Walks the parent chain rather than taking a single hop: a fork of a fork
+    would otherwise resolve to the intermediate fork, where the operator may
+    well have write access, so the permission check passes and the post lands on
+    the wrong tracker. This `gh` exposes ``parent`` but not ``source``, so the
+    walk is the available mechanism.
     """
     data = _gh_json(run, ["gh", "repo", "view", "--json", "isFork,parent,nameWithOwner"])
-    if data.get("isFork"):
-        parent = data.get("parent") or {}
-        owner = (parent.get("owner") or {}).get("login")
-        name = parent.get("name")
-        if not owner or not name:
-            raise Refused(
-                "this clone is a fork but its parent could not be resolved — "
-                "refusing to file into the fork"
-            )
-        return f"{owner}/{name}"
     slug = data.get("nameWithOwner")
     if not slug:
         raise Refused("could not resolve a repository from this directory")
+
+    depth = 0
+    while data.get("isFork"):
+        depth += 1
+        if depth > MAX_FORK_DEPTH:
+            raise Refused(
+                f"fork chain deeper than {MAX_FORK_DEPTH} from {slug} — refusing rather "
+                "than guessing which repository is the shared tracker"
+            )
+        parent = _parent_slug(data)
+        if not parent:
+            raise Refused(
+                f"{slug} is a fork but its parent could not be resolved — refusing to "
+                "file into the fork"
+            )
+        slug = parent
+        data = _gh_json(run, ["gh", "repo", "view", slug, "--json", "isFork,parent,nameWithOwner"])
     return str(slug)
 
 
@@ -137,25 +182,26 @@ def _normalize(title: str) -> str:
     return " ".join(unicodedata.normalize("NFKC", title).casefold().split())
 
 
-def find_duplicate(slug: str, title: str, run: Runner = _run, limit: int = 200) -> int | None:
-    """Exact normalized-title match over structured output.
+def find_duplicate(slug: str, title: str, run: Runner = _run) -> int | None:
+    """Exact normalized-title match over an EXHAUSTIVE listing.
 
-    Deliberately does NOT use `--search`: a title containing `repo:` or `is:`
-    would be parsed as query syntax rather than searched literally.
+    Two things this deliberately does not do:
+
+    * It does not use ``--search``. A title containing ``repo:`` / ``is:`` /
+      ``label:`` would be parsed as query syntax rather than searched literally.
+    * It does not cap. A capped window that happens to exclude the match is
+      indistinguishable from no match — absence from a truncated read is not
+      absence. ``--paginate`` walks every page; the ``pull_request`` filter is
+      required because GitHub's issues endpoint returns PRs too.
     """
     proc = run(
         [
             "gh",
-            "issue",
-            "list",
-            "--repo",
-            slug,
-            "--state",
-            "all",
-            "--limit",
-            str(limit),
-            "--json",
-            "number,title",
+            "api",
+            "--paginate",
+            f"repos/{slug}/issues?state=all&per_page=100",
+            "--jq",
+            '.[] | select(has("pull_request")|not) | {number,title}',
         ]
     )
     if proc.returncode != 0:
@@ -163,12 +209,18 @@ def find_duplicate(slug: str, title: str, run: Runner = _run, limit: int = 200) 
             f"duplicate check failed on {slug}: {proc.stderr.strip() or proc.returncode}. "
             "Refusing to file — a failed lookup is not 'no duplicate'."
         )
-    try:
-        issues = json.loads(proc.stdout or "[]")
-    except json.JSONDecodeError as exc:
-        raise Refused(f"duplicate check returned unparseable JSON: {exc}") from exc
     target = _normalize(title)
-    for issue in issues:
+    for raw in (proc.stdout or "").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            issue = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise Refused(
+                f"duplicate check returned unparseable JSON: {exc}. Refusing — a partial "
+                "read cannot prove absence."
+            ) from exc
         if _normalize(str(issue.get("title", ""))) == target:
             return int(issue["number"])
     return None
@@ -189,16 +241,55 @@ def validate_labels(area: str, difficulty: str) -> list[str]:
     return [area, difficulty]
 
 
+def _lock_path(slug: str) -> Path:
+    """Per-tracker lock file. Home-based so a tmp cleaner cannot drop it."""
+    digest = hashlib.sha256(slug.encode()).hexdigest()[:16]
+    base = Path.home() / ".genesis" / "locks"
+    try:
+        base.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        base = Path(tempfile.gettempdir())
+    return base / f"tracker-issue-{digest}.lock"
+
+
+@contextmanager
+def tracker_lock(slug: str):
+    """Serialise duplicate-check + create for one tracker on this install.
+
+    Without it, two concurrent foreground sessions can both pass the duplicate
+    check before either posts, and both then post — defeating the check that
+    exists precisely for that case. Cross-INSTALL races remain possible; that is
+    inherent to client-side dedup and is stated here rather than hidden.
+    """
+    path = _lock_path(slug)
+    with open(path, "w", encoding="utf-8") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
 def create_issue(
     slug: str, title: str, body_path: str, labels: Sequence[str], run: Runner = _run
 ) -> str:
-    """Post it. Title and body travel as argv, never through a shell."""
+    """Post it. Title and body travel as argv, never through a shell.
+
+    A nonzero exit raises Indeterminate, NOT Refused: GitHub may have committed
+    the issue before the response was lost, in which case the post exists. The
+    caller must reconcile rather than assume nothing happened.
+    """
     argv = ["gh", "issue", "create", "--repo", slug, "--title", title, "--body-file", body_path]
     for label in labels:
         argv += ["--label", label]
     proc = run(argv)
     if proc.returncode != 0:
-        raise Refused(f"gh issue create failed: {proc.stderr.strip() or proc.returncode}")
+        raise Indeterminate(
+            f"gh issue create on {slug} exited {proc.returncode}: "
+            f"{proc.stderr.strip() or '(no stderr)'}. The issue MAY have been created — "
+            "GitHub can commit the post and still lose the response. Check the tracker "
+            "for this title BEFORE retrying or recording a local row."
+        )
     return proc.stdout.strip()
 
 
@@ -229,18 +320,24 @@ def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
         labels = validate_labels(args.area, args.difficulty)
         slug = resolve_tracker(run)
         perm = check_permission(slug, run)
-        dup = find_duplicate(slug, title, run)
-        if dup is not None:
-            print(
-                f"DUPLICATE: {slug}#{dup} already has this exact title. Nothing filed.",
-                file=sys.stderr,
-            )
-            return 3
-        if args.dry_run:
-            print(f"DRY RUN ok — would file to {slug} (perm={perm}) with labels {labels}")
-            return 0
-        print(create_issue(slug, title, args.body_file, labels, run))
+
+        # Lookup and creation are ONE critical section — see tracker_lock().
+        with tracker_lock(slug):
+            dup = find_duplicate(slug, title, run)
+            if dup is not None:
+                print(
+                    f"DUPLICATE: {slug}#{dup} already has this exact title. Nothing filed.",
+                    file=sys.stderr,
+                )
+                return 3
+            if args.dry_run:
+                print(f"DRY RUN ok — would file to {slug} (perm={perm}) with labels {labels}")
+                return 0
+            print(create_issue(slug, title, args.body_file, labels, run))
         return 0
+    except Indeterminate as exc:
+        print(f"INDETERMINATE: {exc}", file=sys.stderr)
+        return 4
     except Refused as exc:
         print(f"REFUSED: {exc}", file=sys.stderr)
         return 2

--- a/scripts/file_tracker_issue.py
+++ b/scripts/file_tracker_issue.py
@@ -23,11 +23,16 @@ Certainty at boundaries (round 4, this script):
   * Check-then-act is not atomic. Lookup and creation are serialised under a
     per-tracker lock, so two concurrent sessions cannot both pass the duplicate
     check and both post.
-  * A failed `gh issue create` does NOT prove nothing was posted. If the server
-    committed the issue and the response was lost, the issue EXISTS. That case
-    is reported as INDETERMINATE, never as "refused" — telling an operator that
-    nothing was posted when something may have been is the worst outcome here,
-    because they then file a duplicate or a false local record.
+  * A failed `gh issue create` does NOT prove nothing was posted. Every route
+    the process SURVIVES — nonzero exit, timeout, SIGINT/SIGTERM, an rc=0 with
+    no URL — is resolved against the tracker rather than inferred from the exit
+    status. INDETERMINATE survives only when that reconciling lookup ALSO
+    fails. A SIGKILL cannot be caught by anything, so it remains the one route
+    that can leave an unreported issue; that is a property of SIGKILL, not a
+    gap this script can close.
+  * The exit code itself is guaranteed. CPython flushes stdout during shutdown
+    AFTER main() returns, and a failed flush exits 120 — silently replacing a
+    successful result. `_finish()` flushes while we can still react.
 
 Shell safety: everything runs through argv lists with `shell=False`. A title
 containing backticks or `$(...)` — ordinary in a technical title — would execute
@@ -50,12 +55,14 @@ found · 4 INDETERMINATE — a post may or may not exist, reconcile before retry
 from __future__ import annotations
 
 import argparse
+import contextlib
 import fcntl
 import hashlib
 import json
+import os
+import signal
 import subprocess
 import sys
-import tempfile
 import unicodedata
 from collections.abc import Callable, Sequence
 from contextlib import contextmanager
@@ -108,11 +115,40 @@ class Indeterminate(Exception):
     """
 
 
+#: Every `gh` call is bounded. A tracker large enough to exceed this on the
+#: paginated listing (order 10k+ issues) will time out rather than hang — that
+#: surfaces as a Refused, never as a silent partial read.
+GH_TIMEOUT_S = 120
+
+
 def _run(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
     """Execute argv with NO shell. The absence of a shell is the point."""
     return subprocess.run(  # noqa: S603 - argv list, shell=False, no interpolation
-        list(argv), capture_output=True, text=True, timeout=120, check=False
+        list(argv), capture_output=True, text=True, timeout=GH_TIMEOUT_S, check=False
     )
+
+
+def _finish(code: int) -> int:
+    """Return `code` and make sure the interpreter cannot override it.
+
+    CPython flushes stdout during shutdown, AFTER main() returns. If stdout is
+    closed or full that flush fails and the process exits 120 — silently
+    replacing whatever we returned. MEASURED: a run whose issue was created
+    successfully exited 120 under `> /dev/full`, i.e. a confirmed post reported
+    as an undocumented failure, sending the operator to retry into a duplicate.
+
+    So: flush here, where we can still react, and if that fails put a usable fd
+    under stdout so the shutdown flush has nothing to fail on.
+    """
+    try:
+        sys.stdout.flush()
+    except (OSError, ValueError):
+        try:
+            devnull = os.open(os.devnull, os.O_WRONLY)
+            os.dup2(devnull, sys.stdout.fileno())
+        except OSError:
+            pass  # nothing further to try; the exit code is still ours
+    return code
 
 
 def _gh_json(run: Runner, argv: Sequence[str]) -> dict:
@@ -120,9 +156,16 @@ def _gh_json(run: Runner, argv: Sequence[str]) -> dict:
     if proc.returncode != 0:
         raise Refused(f"`{' '.join(argv)}` failed: {proc.stderr.strip() or proc.returncode}")
     try:
-        return json.loads(proc.stdout or "{}")
+        data = json.loads(proc.stdout or "{}")
     except json.JSONDecodeError as exc:
         raise Refused(f"`{' '.join(argv)}` returned unparseable JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        # `gh` returning a list or null here would surface as an AttributeError
+        # from the caller's .get(), which is not in any handler's except clause.
+        raise Refused(
+            f"`{' '.join(argv)}` returned {type(data).__name__}, expected an object"
+        )
+    return data
 
 
 def _parent_slug(data: dict) -> str | None:
@@ -194,16 +237,28 @@ def find_duplicate(slug: str, title: str, run: Runner = _run) -> int | None:
       absence. ``--paginate`` walks every page; the ``pull_request`` filter is
       required because GitHub's issues endpoint returns PRs too.
     """
-    proc = run(
-        [
-            "gh",
-            "api",
-            "--paginate",
-            f"repos/{slug}/issues?state=all&per_page=100",
-            "--jq",
-            '.[] | select(has("pull_request")|not) | {number,title}',
-        ]
-    )
+    try:
+        proc = run(
+            [
+                "gh",
+                "api",
+                "--paginate",
+                f"repos/{slug}/issues?state=all&per_page=100",
+                "--jq",
+                '.[] | select(has("pull_request")|not) | {number,title}',
+            ]
+        )
+    except subprocess.SubprocessError as exc:
+        # TimeoutExpired is NOT an OSError and is caught by no handler upstream.
+        raise Refused(
+            f"duplicate check on {slug} did not complete ({exc}). Refusing to file — "
+            "a lookup that never finished is not 'no duplicate'."
+        ) from exc
+    # returncode is checked BEFORE stdout is parsed, deliberately: `gh api
+    # --paginate` writes each page as it arrives and only then reports a later
+    # page's failure, so parsing first would read a PARTIAL listing as an
+    # exhaustive one — the exact defect this function's docstring promises
+    # against. Do not reorder.
     if proc.returncode != 0:
         raise Refused(
             f"duplicate check failed on {slug}: {proc.stderr.strip() or proc.returncode}. "
@@ -242,13 +297,29 @@ def validate_labels(area: str, difficulty: str) -> list[str]:
 
 
 def _lock_path(slug: str) -> Path:
-    """Per-tracker lock file. Home-based so a tmp cleaner cannot drop it."""
+    """Per-tracker lock file, at a path that is STABLE across sessions.
+
+    No tempdir fallback, deliberately. ``tempfile.gettempdir()`` follows
+    ``TMPDIR``, and on this project a Claude Code session has ``TMPDIR`` pointed
+    at its own cc-tmp BY DESIGN while a manual shell has ``/tmp`` — so a
+    fallback would hand two concurrent sessions DIFFERENT lock files for the
+    same tracker, both would pass duplicate detection, and both would post. A
+    lock whose identity varies by caller is not a lock; refuse instead.
+    """
+    # NOTE: unlinking this file while a peer holds it destroys mutual
+    # exclusion — flock is on the inode, so the next caller creates a fresh
+    # one and locks nothing. `scripts/disk_hygiene.sh` does not currently reap
+    # ~/.genesis/locks; if a broad sweep is ever added, exclude this path.
     digest = hashlib.sha256(slug.encode()).hexdigest()[:16]
     base = Path.home() / ".genesis" / "locks"
     try:
         base.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        base = Path(tempfile.gettempdir())
+    except OSError as exc:
+        raise Refused(
+            f"cannot establish the per-install lock directory ({base}): {exc}. "
+            "Refusing rather than using a TMPDIR-dependent fallback, which would "
+            "let two sessions lock different files and both post."
+        ) from exc
     return base / f"tracker-issue-{digest}.lock"
 
 
@@ -263,11 +334,48 @@ def tracker_lock(slug: str):
     """
     path = _lock_path(slug)
     with open(path, "w", encoding="utf-8") as handle:
-        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            # Blocking silently for a peer's full paginated listing looks like a
+            # hang. Say so, then wait.
+            print(f"waiting for the {slug} tracker lock…", file=sys.stderr)
+            fcntl.flock(handle, fcntl.LOCK_EX)
         try:
             yield
         finally:
             fcntl.flock(handle, fcntl.LOCK_UN)
+
+
+def _reconcile_uncertain_create(slug: str, title: str, cause: str, run: Runner) -> str:
+    """Resolve an uncertain create by asking the TRACKER, not the exit status.
+
+    Every way a create's outcome can be lost — a nonzero exit, a timeout, a
+    killed process — is another path where the issue may exist anyway. Inferring
+    the answer from the call means patching each path as it is discovered.
+    Asking the tracker answers all of them the same way, from ground truth.
+
+    Raises Indeterminate ONLY when the reconciling lookup itself fails, which is
+    the one case where the outcome is genuinely unknowable here.
+    """
+    # PRECONDITION, asserted by the caller's flow rather than assumed: main()
+    # ran the duplicate check under the SAME tracker lock immediately before the
+    # create, and it found nothing. So an issue carrying this exact title now is
+    # necessarily the one this invocation created — not a pre-existing one.
+    try:
+        found = find_duplicate(slug, title, run)
+    except Refused as exc:
+        raise Indeterminate(
+            f"{cause}, and the reconciling lookup then failed ({exc}). The issue MAY "
+            f"exist on {slug}. Check the tracker for this exact title BEFORE retrying "
+            "or recording a local row."
+        ) from exc
+    if found is not None:
+        return f"{slug}#{found} (reconciled: {cause}, but the issue EXISTS)"
+    raise Refused(
+        f"{cause}. Reconciled against {slug}: no issue with this title exists, so "
+        "nothing was posted. Safe to retry."
+    )
 
 
 def create_issue(
@@ -275,22 +383,61 @@ def create_issue(
 ) -> str:
     """Post it. Title and body travel as argv, never through a shell.
 
-    A nonzero exit raises Indeterminate, NOT Refused: GitHub may have committed
-    the issue before the response was lost, in which case the post exists. The
-    caller must reconcile rather than assume nothing happened.
+    An uncertain outcome is RESOLVED, not reported: a nonzero exit or a timeout
+    both mean "the post may exist", so the tracker is queried and the real answer
+    returned. Indeterminate survives only for the case where that query also
+    fails.
     """
     argv = ["gh", "issue", "create", "--repo", slug, "--title", title, "--body-file", body_path]
     for label in labels:
         argv += ["--label", label]
-    proc = run(argv)
-    if proc.returncode != 0:
-        raise Indeterminate(
-            f"gh issue create on {slug} exited {proc.returncode}: "
-            f"{proc.stderr.strip() or '(no stderr)'}. The issue MAY have been created — "
-            "GitHub can commit the post and still lose the response. Check the tracker "
-            "for this title BEFORE retrying or recording a local row."
+    try:
+        proc = run(argv)
+    except subprocess.SubprocessError as exc:
+        # TimeoutExpired is the common case and is EXACTLY when the server may
+        # have committed the issue. Catch the whole SubprocessError family: none
+        # of it is an OSError, so none of it is caught anywhere upstream.
+        return _reconcile_uncertain_create(
+            slug, title, f"gh issue create on {slug} did not complete ({exc})", run
         )
-    return proc.stdout.strip()
+    except KeyboardInterrupt:
+        # SIGINT/SIGTERM after the request went out. KeyboardInterrupt is a
+        # BaseException, so it escapes every `except Exception` handler — and it
+        # arrives precisely when the post may already exist.
+        return _reconcile_uncertain_create(
+            slug, title, f"gh issue create on {slug} was interrupted", run
+        )
+    if proc.returncode != 0:
+        return _reconcile_uncertain_create(
+            slug,
+            title,
+            f"gh issue create on {slug} exited {proc.returncode} "
+            f"({proc.stderr.strip() or 'no stderr'})",
+            run,
+        )
+    url = proc.stdout.strip()
+    if not url:
+        # rc=0 with no URL: reporting success with nothing to cite would be the
+        # same false certainty in the opposite direction.
+        return _reconcile_uncertain_create(
+            slug, title, f"gh issue create on {slug} exited 0 but printed no URL", run
+        )
+    return url
+
+
+def _warn(message: str) -> None:
+    """stderr write that cannot itself become the failure being reported."""
+    with contextlib.suppress(OSError):
+        print(message, file=sys.stderr)
+
+
+def _sigterm_as_interrupt(signum, frame):  # noqa: ARG001 - signal handler signature
+    """Make SIGTERM take the same reconciling path as SIGINT.
+
+    Default SIGTERM kills the process outright, so a create that had already
+    reached GitHub would leave an issue nobody knows about.
+    """
+    raise KeyboardInterrupt
 
 
 def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
@@ -308,14 +455,33 @@ def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
     ap.add_argument("--dry-run", action="store_true", help="run every check, post nothing")
     args = ap.parse_args(argv)
 
+    # not the main thread, or no signals here — best-effort only
+    with contextlib.suppress(ValueError, OSError):
+        signal.signal(signal.SIGTERM, _sigterm_as_interrupt)
+
     try:
-        with open(args.title_file, encoding="utf-8") as fh:
-            title = fh.read().strip()
+        try:
+            with open(args.title_file, encoding="utf-8") as fh:
+                title = fh.read().strip()
+            with open(args.body_file, encoding="utf-8") as fh:
+                body = fh.read().strip()
+        except (OSError, UnicodeDecodeError) as exc:
+            # Unreadable or non-UTF-8 drafts are a "nothing was posted" outcome,
+            # so they belong on exit 2 with everything else that refused — not on
+            # the generic exit 1. UnicodeDecodeError is a ValueError, which no
+            # handler here caught before.
+            raise Refused(f"cannot read the draft files: {exc}") from exc
         if not title:
             raise Refused("title file is empty")
-        with open(args.body_file, encoding="utf-8") as fh:
-            if not fh.read().strip():
-                raise Refused("body file is empty")
+        if not body:
+            raise Refused("body file is empty")
+        if len(title) > 256:
+            raise Refused(
+                f"title is {len(title)} chars; GitHub rejects titles beyond ~256, so "
+                "this would fail every retry"
+            )
+        if "\n" in title or "\r" in title:
+            raise Refused("title contains a newline — GitHub's handling of that is unverified")
 
         labels = validate_labels(args.area, args.difficulty)
         slug = resolve_tracker(run)
@@ -333,17 +499,33 @@ def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
             if args.dry_run:
                 print(f"DRY RUN ok — would file to {slug} (perm={perm}) with labels {labels}")
                 return 0
-            print(create_issue(slug, title, args.body_file, labels, run))
-        return 0
+            # Create FIRST, report second. If stdout is closed or full, the post
+            # has already happened — letting the print's OSError fall through to
+            # the generic handler would report exit 1 for a CONFIRMED issue and
+            # send the operator to retry into a duplicate.
+            posted = create_issue(slug, title, args.body_file, labels, run)
+        try:
+            print(posted)
+        except OSError:
+            # The post is already durable; a reporting failure must not
+            # reclassify it. The stderr fallback is itself guarded, because it
+            # can fail for the same reason.
+            with contextlib.suppress(OSError):
+                print(f"POSTED (could not write the URL to stdout): {posted}", file=sys.stderr)
+        return _finish(0)
     except Indeterminate as exc:
-        print(f"INDETERMINATE: {exc}", file=sys.stderr)
-        return 4
+        _warn(f"INDETERMINATE: {exc}")
+        return _finish(4)
     except Refused as exc:
-        print(f"REFUSED: {exc}", file=sys.stderr)
-        return 2
-    except OSError as exc:
-        print(f"ERROR: {exc}", file=sys.stderr)
-        return 1
+        _warn(f"REFUSED: {exc}")
+        return _finish(2)
+    except KeyboardInterrupt:
+        # Outside the create window, so nothing was posted.
+        _warn("REFUSED: interrupted before the issue was created.")
+        return _finish(2)
+    except (OSError, subprocess.SubprocessError, ValueError) as exc:
+        _warn(f"ERROR: {exc}")
+        return _finish(1)
 
 
 if __name__ == "__main__":

--- a/scripts/file_tracker_issue.py
+++ b/scripts/file_tracker_issue.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""File a Genesis-repo issue on the SHARED public tracker, safely.
+
+Three consecutive cross-model review rounds on the prose version of this
+procedure each found a different way for it to target the wrong repository or
+execute its own inputs. The failures were not independent bugs — they were the
+same class, and prose cannot enforce any of the five properties that matter:
+
+1. Resolve the UPSTREAM tracker, not whatever repo the cwd happens to be in.
+   `gh repo view` with no argument reports the CURRENT directory's repo, so on a
+   fork-cloned install it returns the operator's own fork — where they are ADMIN,
+   so a permission check on it passes and the issue lands somewhere nobody reads.
+2. Check `viewerPermission` on THAT EXPLICIT SLUG. Identity is not permission:
+   a direct clone reports the right slug while the user still lacks push access,
+   and GitHub then silently DROPS the mandatory labels.
+3. Never let issue text reach a shell. A title containing backticks or `$(...)` —
+   ordinary in a technical title — is executed if it is interpolated into a
+   command line, and its output lands in the public title. Everything here goes
+   through argv lists; no shell is ever involved.
+4. Per-invocation temp files. Two concurrent sessions sharing a fixed draft path
+   can overwrite each other between the privacy scan and the post.
+5. Exact-title dedup. `gh issue list --search` interprets `repo:` / `is:` /
+   `label:` inside a title as query syntax, so a raw-title search both misses
+   duplicates and can match unrelated issues.
+
+Everything fails CLOSED: any check that cannot complete refuses to file.
+
+This does NOT decide whether the issue *should* be public. The caller is
+responsible for the two hard limits in CLAUDE.md — explicit user approval for an
+irreversible post, and never publishing an unfixed security defect.
+
+Usage:
+    file_tracker_issue.py --title-file T --body-file B --area area:memory \\
+        --difficulty "help wanted" [--dry-run]
+
+Exit codes: 0 filed (or dry-run OK) · 2 refused (a precondition failed) ·
+3 duplicate found · 1 unexpected error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import unicodedata
+from collections.abc import Callable, Sequence
+
+# Mirrors of the fail-closed sets enforced server-side by
+# ``src/genesis/mcp/health/contributor_issue.py``. Duplicated deliberately —
+# importing that module pulls the whole MCP stack into a standalone script — and
+# pinned against drift by tests/test_scripts/test_file_tracker_issue.py, which
+# asserts these equal the canonical sets exactly.
+AREA_LABELS = frozenset(
+    {
+        "area:memory",
+        "area:dashboard",
+        "area:runtime",
+        "area:guardian",
+        "area:autonomy",
+        "area:channels",
+        "area:knowledge",
+        "area:eval",
+        "area:other",
+    }
+)
+DIFFICULTY_LABELS = frozenset(
+    {
+        "good first issue",
+        "first-timers-only",
+        "needs-genesis-instance",
+        "help wanted",
+    }
+)
+WRITE_PERMISSIONS = frozenset({"WRITE", "MAINTAIN", "ADMIN"})
+
+Runner = Callable[[Sequence[str]], "subprocess.CompletedProcess[str]"]
+
+
+class Refused(Exception):
+    """A precondition failed. Nothing was posted."""
+
+
+def _run(argv: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Execute argv with NO shell. The absence of a shell is the point."""
+    return subprocess.run(  # noqa: S603 - argv list, shell=False, no interpolation
+        list(argv), capture_output=True, text=True, timeout=120, check=False
+    )
+
+
+def _gh_json(run: Runner, argv: Sequence[str]) -> dict:
+    proc = run(argv)
+    if proc.returncode != 0:
+        raise Refused(f"`{' '.join(argv)}` failed: {proc.stderr.strip() or proc.returncode}")
+    try:
+        return json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise Refused(f"`{' '.join(argv)}` returned unparseable JSON: {exc}") from exc
+
+
+def resolve_tracker(run: Runner = _run) -> str:
+    """The SHARED tracker slug — the fork's parent when this is a fork.
+
+    Never returns the current repo blindly: that is the round-3 defect.
+    """
+    data = _gh_json(run, ["gh", "repo", "view", "--json", "isFork,parent,nameWithOwner"])
+    if data.get("isFork"):
+        parent = data.get("parent") or {}
+        owner = (parent.get("owner") or {}).get("login")
+        name = parent.get("name")
+        if not owner or not name:
+            raise Refused(
+                "this clone is a fork but its parent could not be resolved — "
+                "refusing to file into the fork"
+            )
+        return f"{owner}/{name}"
+    slug = data.get("nameWithOwner")
+    if not slug:
+        raise Refused("could not resolve a repository from this directory")
+    return str(slug)
+
+
+def check_permission(slug: str, run: Runner = _run) -> str:
+    """Verify write access ON THE RESOLVED SLUG. Identity is not permission."""
+    data = _gh_json(run, ["gh", "repo", "view", slug, "--json", "viewerPermission"])
+    perm = data.get("viewerPermission")
+    if perm not in WRITE_PERMISSIONS:
+        raise Refused(
+            f"no write access to {slug} (viewerPermission={perm!r}). "
+            "Keep this as a local follow-up until a maintainer carries it across."
+        )
+    return str(perm)
+
+
+def _normalize(title: str) -> str:
+    """Fold case/whitespace/unicode so trivially-different titles compare equal."""
+    return " ".join(unicodedata.normalize("NFKC", title).casefold().split())
+
+
+def find_duplicate(slug: str, title: str, run: Runner = _run, limit: int = 200) -> int | None:
+    """Exact normalized-title match over structured output.
+
+    Deliberately does NOT use `--search`: a title containing `repo:` or `is:`
+    would be parsed as query syntax rather than searched literally.
+    """
+    proc = run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            slug,
+            "--state",
+            "all",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title",
+        ]
+    )
+    if proc.returncode != 0:
+        raise Refused(
+            f"duplicate check failed on {slug}: {proc.stderr.strip() or proc.returncode}. "
+            "Refusing to file — a failed lookup is not 'no duplicate'."
+        )
+    try:
+        issues = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise Refused(f"duplicate check returned unparseable JSON: {exc}") from exc
+    target = _normalize(title)
+    for issue in issues:
+        if _normalize(str(issue.get("title", ""))) == target:
+            return int(issue["number"])
+    return None
+
+
+def validate_labels(area: str, difficulty: str) -> list[str]:
+    """Both classes are mandatory, and a nonexistent label makes `gh` fail."""
+    if area not in AREA_LABELS:
+        raise Refused(
+            f"{area!r} is not a real area label. Allowed: "
+            f"{', '.join(sorted(AREA_LABELS))}. Use area:other if none fits."
+        )
+    if difficulty not in DIFFICULTY_LABELS:
+        raise Refused(
+            f"{difficulty!r} is not a real difficulty/environment label. Allowed: "
+            f"{', '.join(sorted(DIFFICULTY_LABELS))}."
+        )
+    return [area, difficulty]
+
+
+def create_issue(
+    slug: str, title: str, body_path: str, labels: Sequence[str], run: Runner = _run
+) -> str:
+    """Post it. Title and body travel as argv, never through a shell."""
+    argv = ["gh", "issue", "create", "--repo", slug, "--title", title, "--body-file", body_path]
+    for label in labels:
+        argv += ["--label", label]
+    proc = run(argv)
+    if proc.returncode != 0:
+        raise Refused(f"gh issue create failed: {proc.stderr.strip() or proc.returncode}")
+    return proc.stdout.strip()
+
+
+def main(argv: Sequence[str] | None = None, run: Runner = _run) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument(
+        "--title-file", required=True, help="file holding the title (never a shell arg)"
+    )
+    ap.add_argument("--body-file", required=True)
+    ap.add_argument("--area", required=True, help=f"one of: {', '.join(sorted(AREA_LABELS))}")
+    ap.add_argument(
+        "--difficulty", required=True, help=f"one of: {', '.join(sorted(DIFFICULTY_LABELS))}"
+    )
+    ap.add_argument("--dry-run", action="store_true", help="run every check, post nothing")
+    args = ap.parse_args(argv)
+
+    try:
+        with open(args.title_file, encoding="utf-8") as fh:
+            title = fh.read().strip()
+        if not title:
+            raise Refused("title file is empty")
+        with open(args.body_file, encoding="utf-8") as fh:
+            if not fh.read().strip():
+                raise Refused("body file is empty")
+
+        labels = validate_labels(args.area, args.difficulty)
+        slug = resolve_tracker(run)
+        perm = check_permission(slug, run)
+        dup = find_duplicate(slug, title, run)
+        if dup is not None:
+            print(
+                f"DUPLICATE: {slug}#{dup} already has this exact title. Nothing filed.",
+                file=sys.stderr,
+            )
+            return 3
+        if args.dry_run:
+            print(f"DRY RUN ok — would file to {slug} (perm={perm}) with labels {labels}")
+            return 0
+        print(create_issue(slug, title, args.body_file, labels, run))
+        return 0
+    except Refused as exc:
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -495,11 +495,15 @@ async def follow_up_create(
 
     FIRST — is this the right home? Genesis-repo work (code, tests, docs, infra —
     anything that would live in the public repo, even when hit locally) belongs on
-    the PUBLIC TRACKER as a GitHub issue, not here. This ledger is for USER-OWNED
-    work (a deliverable, an errand, something asked for and unfinished) and for
-    operational state purely LOCAL to this box; something a fresh clone would hit
-    too is a repo gap, so an issue. Something you are consciously NOT pursuing is
-    `deferred_cold` (tabled) — never an issue, because we don't want it picked up.
+    the PUBLIC TRACKER as a GitHub issue, not here — but ONLY from an install that
+    owns the tracker, and only with the user's explicit approval each time (a public
+    post is irreversible). A security defect is never filed publicly before it is
+    fixed. Where those do not hold, it stays HERE until a maintainer carries it over.
+
+    This ledger is otherwise for USER-OWNED work (a deliverable, an errand, something
+    asked for and unfinished) and operational state purely LOCAL to this box.
+    Something you are consciously NOT pursuing is `deferred_cold` (tabled) — never an
+    issue, because we don't want it picked up.
 
     A DISPATCHED session records here rather than filing publicly — but the row is
     FORCED onto the COLD `tabled` lane by sacred-board authorization, whatever
@@ -507,9 +511,7 @@ async def follow_up_create(
     Say in `reason` that it is repo work awaiting a foreground session, and expect
     to need `follow_up_list(include_tabled=True)` to find it again.
 
-    Mechanics (the exact `gh` command and its mandatory labels, the fork-install
-    trap, the time-gated exception): `.claude/docs/mcp-tools-guide.md`,
-    section "Where Deferred Work Goes".
+    Mechanics: `.claude/docs/mcp-tools-guide.md`, "Where Deferred Work Goes".
 
     Declare the item's WORK_STATE — the tool DERIVES the lane from it, so priority
     never decides the lane. Two lists:

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -493,6 +493,24 @@ async def follow_up_create(
 ) -> dict:
     """Create a follow-up in the accountability ledger.
 
+    FIRST — is this the right home? Genesis-repo work (code, tests, docs, infra —
+    anything that would live in the public repo, even when hit locally) belongs on
+    the PUBLIC TRACKER as a GitHub issue, not here. This ledger is for USER-OWNED
+    work (a deliverable, an errand, something asked for and unfinished) and for
+    operational state purely LOCAL to this box; something a fresh clone would hit
+    too is a repo gap, so an issue. Something you are consciously NOT pursuing is
+    `deferred_cold` (tabled) — never an issue, because we don't want it picked up.
+
+    A DISPATCHED session records here rather than filing publicly — but the row is
+    FORCED onto the COLD `tabled` lane by sacred-board authorization, whatever
+    work_state you pass, and tabled rows are excluded from every default listing.
+    Say in `reason` that it is repo work awaiting a foreground session, and expect
+    to need `follow_up_list(include_tabled=True)` to find it again.
+
+    Mechanics (the exact `gh` command and its mandatory labels, the fork-install
+    trap, the time-gated exception): `.claude/docs/mcp-tools-guide.md`,
+    section "Where Deferred Work Goes".
+
     Declare the item's WORK_STATE — the tool DERIVES the lane from it, so priority
     never decides the lane. Two lists:
     - HOT (follow_up): work you INTEND to do near-term. May be blocked on time, an
@@ -528,8 +546,11 @@ async def follow_up_create(
         scheduled_at: ISO datetime (required when strategy is scheduled_task).
         priority: low | medium | high | critical. Does NOT affect the lane.
         pinned: If true, ego can see but cannot auto-resolve; only the user closes it.
-        domain: "internal" (Genesis's own system work) or "user_world" (the user's
-            life/career/content). Leave empty to let Genesis classify (internal-only).
+        domain: "internal" (operational Genesis work that stays LOCAL — repo work
+            belongs on the public tracker, not here) or "user_world" (the user's
+            life/career/content). Leave empty to let Genesis classify (internal-only);
+            note the classifier keyword-matches repo-ish terms, so an empty domain on
+            a misrouted repo item will still look correctly filed.
     """
     return await _impl_follow_up_create(
         content,

--- a/tests/test_scripts/test_file_tracker_issue.py
+++ b/tests/test_scripts/test_file_tracker_issue.py
@@ -852,3 +852,160 @@ def test_confirmed_post_does_not_exit_120_when_stdout_is_full(tmp_path):
         "a CONFIRMED post exited 120 — CPython's shutdown flush overrode the exit code"
     )
     assert proc.returncode == 0, f"expected 0 for a successful post, got {proc.returncode}"
+
+
+# ===========================================================================
+# round 6 — the guarantee's own edges. Each of these is a hole IN the fix that
+# was written to close the previous hole.
+# ===========================================================================
+
+
+def test_finish_survives_stdout_being_none():
+    """`>&-` makes sys.stdout None; the guard itself raised AttributeError."""
+    real = sys.stdout
+    try:
+        sys.stdout = None
+        assert fti._finish(0) == 0
+        assert fti._finish(4) == 4
+    finally:
+        sys.stdout = real
+
+
+def test_finish_survives_an_already_closed_stream():
+    """flush() raises ValueError, and so does the fileno() used to recover."""
+
+    class Closed:
+        closed = True
+
+        def flush(self):
+            raise ValueError("I/O operation on closed file")
+
+        def fileno(self):
+            raise ValueError("I/O operation on closed file")
+
+    real = sys.stdout
+    try:
+        sys.stdout = Closed()
+        assert fti._finish(0) == 0
+    finally:
+        sys.stdout = real
+
+
+def test_finish_never_raises_for_any_stdout_shape():
+    """It IS the exit-code guarantee, so it must be total."""
+
+    class Hostile:
+        def flush(self):
+            raise RuntimeError("unexpected")
+
+        def fileno(self):
+            raise RuntimeError("unexpected")
+
+    real = sys.stdout
+    try:
+        for stream in (None, Hostile()):
+            sys.stdout = stream
+            assert fti._finish(7) == 7
+    finally:
+        sys.stdout = real
+
+
+def test_a_late_interrupt_after_creation_reports_the_post_not_a_refusal(tmp_path, capsys):
+    """SIGINT while releasing the lock is AFTER the post — exit 0, not 2."""
+
+    class InterruptingLock:
+        def __init__(self, slug):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            raise KeyboardInterrupt
+
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+            ),
+            "viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"})),
+            "gh api": _proc(""),
+            "issue create": _proc("https://example/9"),
+        }
+    )
+    import unittest.mock
+
+    with unittest.mock.patch.object(fti, "tracker_lock", InterruptingLock):
+        tf, bf = _drafts(tmp_path)
+        rc = fti.main(
+            ["--title-file", tf, "--body-file", bf, "--area", "area:memory",
+             "--difficulty", "help wanted"],
+            run,
+        )
+    assert rc == 0, "the issue exists; reporting a refusal invites a duplicate retry"
+    err = capsys.readouterr().err
+    assert "POSTED" in err and "https://example/9" in err
+
+
+def test_reconcile_failing_to_start_gh_is_indeterminate_not_exit_1():
+    """FileNotFoundError is an OSError — it bypassed the Refused-only clause."""
+
+    def run(argv):
+        if "issue create" in " ".join(argv):
+            return _proc(returncode=1, stderr="connection reset")
+        raise FileNotFoundError("gh: no such file")
+
+    with pytest.raises(fti.Indeterminate):
+        fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "help wanted"], run)
+
+
+def test_dry_run_is_finalized_through_finish(tmp_path, monkeypatch):
+    """Every return path must be finalized, or it exits 120 on a bad stdout."""
+    seen = {}
+    real_finish = fti._finish
+
+    def spy(code):
+        seen["code"] = code
+        return real_finish(code)
+
+    monkeypatch.setattr(fti, "_finish", spy)
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+            ),
+            "viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"})),
+            "gh api": _proc(""),
+        }
+    )
+    tf, bf = _drafts(tmp_path)
+    rc = fti.main(
+        ["--title-file", tf, "--body-file", bf, "--area", "area:memory",
+         "--difficulty", "help wanted", "--dry-run"],
+        run,
+    )
+    assert rc == 0
+    assert seen.get("code") == 0, "the dry-run path bypassed the exit-code guarantee"
+
+
+def test_duplicate_path_is_finalized_through_finish(tmp_path, monkeypatch):
+    seen = {}
+    real_finish = fti._finish
+    monkeypatch.setattr(fti, "_finish", lambda c: (seen.setdefault("code", c), real_finish(c))[1])
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+            ),
+            "viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"})),
+            "gh api": _proc(json.dumps({"number": 3, "title": "A real title"})),
+        }
+    )
+    tf, bf = _drafts(tmp_path)
+    rc = fti.main(
+        ["--title-file", tf, "--body-file", bf, "--area", "area:memory",
+         "--difficulty", "help wanted"],
+        run,
+    )
+    assert rc == 3
+    assert seen.get("code") == 3

--- a/tests/test_scripts/test_file_tracker_issue.py
+++ b/tests/test_scripts/test_file_tracker_issue.py
@@ -1,0 +1,341 @@
+"""Tests for scripts/file_tracker_issue.py.
+
+Every test here corresponds to a defect a cross-model reviewer found in the
+PROSE version of this procedure across three rounds. The point of moving it into
+a script was that these become checkable; the point of these tests is that the
+class cannot come back silently.
+
+No network, no `gh`, no live repo — the runner is injected.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "file_tracker_issue.py"
+_spec = importlib.util.spec_from_file_location("file_tracker_issue", _SCRIPT)
+assert _spec and _spec.loader
+fti = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fti)
+
+
+def _proc(
+    stdout: str = "", returncode: int = 0, stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _runner(responses: dict[str, subprocess.CompletedProcess[str]], calls: list | None = None):
+    """Dispatch on a distinctive substring of the argv, recording every call."""
+
+    def run(argv):
+        if calls is not None:
+            calls.append(list(argv))
+        joined = " ".join(argv)
+        for key, resp in responses.items():
+            if key in joined:
+                return resp
+        raise AssertionError(f"unexpected command: {joined}")
+
+    return run
+
+
+# --- round 3: the permission check resolved the FORK and reported ADMIN -------
+
+
+def test_fork_resolves_to_parent_not_the_fork():
+    """A fork clone must target the upstream tracker, never the operator's fork."""
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps(
+                    {
+                        "isFork": True,
+                        "nameWithOwner": "downstream/Proj",
+                        "parent": {"owner": {"login": "Upstream"}, "name": "Proj"},
+                    }
+                )
+            )
+        }
+    )
+    assert fti.resolve_tracker(run) == "Upstream/Proj"
+
+
+def test_fork_without_resolvable_parent_refuses():
+    run = _runner(
+        {"isFork": _proc(json.dumps({"isFork": True, "nameWithOwner": "alice/x", "parent": None}))}
+    )
+    with pytest.raises(fti.Refused, match="parent could not be resolved"):
+        fti.resolve_tracker(run)
+
+
+def test_non_fork_uses_current_repo():
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+            )
+        }
+    )
+    assert fti.resolve_tracker(run) == "Org/Repo"
+
+
+# --- round 2: identity was checked instead of PERMISSION ---------------------
+
+
+@pytest.mark.parametrize("perm", ["WRITE", "MAINTAIN", "ADMIN"])
+def test_write_permissions_accepted(perm):
+    run = _runner({"viewerPermission": _proc(json.dumps({"viewerPermission": perm}))})
+    assert fti.check_permission("Org/Repo", run) == perm
+
+
+@pytest.mark.parametrize("perm", ["READ", "TRIAGE", None])
+def test_insufficient_permission_refuses(perm):
+    """GitHub silently DROPS labels without push access — so this must fail closed."""
+    run = _runner({"viewerPermission": _proc(json.dumps({"viewerPermission": perm}))})
+    with pytest.raises(fti.Refused, match="no write access"):
+        fti.check_permission("Org/Repo", run)
+
+
+def test_permission_is_checked_on_the_resolved_slug_not_the_cwd():
+    """The slug must be passed EXPLICITLY — a bare `gh repo view` reads the cwd."""
+    calls: list = []
+    run = _runner({"viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"}))}, calls)
+    fti.check_permission("Upstream/Proj", run)
+    assert "Upstream/Proj" in calls[0]
+
+
+# --- round 3: `--search` parsed query syntax inside a title ------------------
+
+
+def test_duplicate_check_does_not_use_search():
+    """A title containing `repo:`/`is:` must be compared, not interpreted."""
+    calls: list = []
+    run = _runner({"issue list": _proc(json.dumps([{"number": 5, "title": "unrelated"}]))}, calls)
+    fti.find_duplicate("Org/Repo", "fix repo: parsing in is: handler", run)
+    assert "--search" not in " ".join(calls[0])
+
+
+def test_exact_title_match_is_found_and_near_miss_is_not():
+    listing = json.dumps(
+        [
+            {"number": 11, "title": "Fix   the   PARSER  "},
+            {"number": 12, "title": "Fix the parser eventually"},
+        ]
+    )
+    run = _runner({"issue list": _proc(listing)})
+    assert fti.find_duplicate("Org/Repo", "fix the parser", run) == 11
+    assert fti.find_duplicate("Org/Repo", "totally different title", run) is None
+
+
+def test_failed_duplicate_lookup_refuses_rather_than_assuming_none():
+    """A failed lookup is not evidence of no duplicate."""
+    run = _runner({"issue list": _proc(returncode=1, stderr="network down")})
+    with pytest.raises(fti.Refused, match="Refusing to file"):
+        fti.find_duplicate("Org/Repo", "anything", run)
+
+
+# --- round 3: area:docs / area:infra do not exist and make `gh` fail ---------
+
+
+def test_plausible_but_nonexistent_area_labels_are_rejected():
+    """The routing rule says 'docs, infra' — so these are what an agent reaches for."""
+    for bogus in ("area:docs", "area:infra", "area:tooling"):
+        with pytest.raises(fti.Refused, match="not a real area label"):
+            fti.validate_labels(bogus, "help wanted")
+
+
+def test_bad_difficulty_label_rejected_and_good_pair_accepted():
+    with pytest.raises(fti.Refused, match="not a real difficulty"):
+        fti.validate_labels("area:memory", "easy")
+    assert fti.validate_labels("area:memory", "help wanted") == ["area:memory", "help wanted"]
+
+
+def test_label_sets_match_the_canonical_server_side_sets():
+    """Drift-lock: these mirror contributor_issue.py, which enforces them fail-closed.
+
+    A mirror that silently drifts is worse than no mirror — this asserts the WHOLE
+    set both ways, not membership of the few labels we happened to think of.
+    """
+    src = (
+        Path(__file__).resolve().parents[2] / "src/genesis/mcp/health/contributor_issue.py"
+    ).read_text()
+    ns: dict = {"frozenset": frozenset}
+    for name in ("_AREA_LABELS", "_ENV_DIFFICULTY_LABELS"):
+        start = src.index(f"{name} = frozenset")
+        end = src.index(")", src.index("}", start)) + 1
+        exec(compile(src[start:end], "<canonical>", "exec"), ns)  # noqa: S102
+    assert ns["_AREA_LABELS"] == fti.AREA_LABELS
+    assert ns["_ENV_DIFFICULTY_LABELS"] == fti.DIFFICULTY_LABELS
+
+
+# --- round 2: issue text was interpolated into a shell command line ----------
+
+
+def test_title_with_shell_metacharacters_is_passed_as_argv_verbatim():
+    """The whole reason this is a script: no shell, so nothing can execute."""
+    calls: list = []
+    run = _runner({"issue create": _proc("https://example/1")}, calls)
+    nasty = "Fix `$(id -un)` and $(rm -rf /) parsing; use \"quotes\" & 'apostrophes'"
+    fti.create_issue("Org/Repo", nasty, "/tmp/b.md", ["area:memory", "help wanted"], run)
+    argv = calls[0]
+    assert nasty in argv, "title must reach gh as a single unmangled argv element"
+    assert argv[argv.index("--title") + 1] == nasty
+
+
+def test_multiword_labels_are_separate_argv_elements():
+    """`good first issue` word-splits if it ever touches a shell."""
+    calls: list = []
+    run = _runner({"issue create": _proc("https://example/1")}, calls)
+    fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "good first issue"], run)
+    assert "good first issue" in calls[0]
+
+
+def test_repo_is_pinned_on_every_gh_invocation():
+    """A bare gh command re-resolves its target from the cwd."""
+    calls: list = []
+    run = _runner(
+        {
+            "issue list": _proc("[]"),
+            "issue create": _proc("https://example/1"),
+        },
+        calls,
+    )
+    fti.find_duplicate("Org/Repo", "t", run)
+    fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "help wanted"], run)
+    for argv in calls:
+        assert "--repo" in argv and argv[argv.index("--repo") + 1] == "Org/Repo"
+
+
+# --- end to end through main() ----------------------------------------------
+
+
+def _drafts(tmp_path: Path, title: str = "A real title") -> tuple[str, str]:
+    t = tmp_path / "title.txt"
+    b = tmp_path / "body.md"
+    t.write_text(title, encoding="utf-8")
+    b.write_text("body text", encoding="utf-8")
+    return str(t), str(b)
+
+
+def test_main_dry_run_passes_every_check_without_posting(tmp_path, capsys):
+    calls: list = []
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+            ),
+            "viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"})),
+            "issue list": _proc("[]"),
+        },
+        calls,
+    )
+    t, b = _drafts(tmp_path)
+    rc = fti.main(
+        [
+            "--title-file",
+            t,
+            "--body-file",
+            b,
+            "--area",
+            "area:memory",
+            "--difficulty",
+            "help wanted",
+            "--dry-run",
+        ],
+        run,
+    )
+    assert rc == 0
+    assert "DRY RUN ok" in capsys.readouterr().out
+    assert not any("issue create" in " ".join(c) for c in calls), "dry run must not post"
+
+
+def test_main_refuses_on_a_fork_without_write_access(tmp_path, capsys):
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps(
+                    {
+                        "isFork": True,
+                        "nameWithOwner": "downstream/Proj",
+                        "parent": {"owner": {"login": "Upstream"}, "name": "Proj"},
+                    }
+                )
+            ),
+            "viewerPermission": _proc(json.dumps({"viewerPermission": "READ"})),
+        }
+    )
+    t, b = _drafts(tmp_path)
+    rc = fti.main(
+        [
+            "--title-file",
+            t,
+            "--body-file",
+            b,
+            "--area",
+            "area:memory",
+            "--difficulty",
+            "help wanted",
+        ],
+        run,
+    )
+    assert rc == 2
+    assert "no write access" in capsys.readouterr().err
+
+
+def test_main_reports_duplicate_and_files_nothing(tmp_path, capsys):
+    calls: list = []
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+            ),
+            "viewerPermission": _proc(json.dumps({"viewerPermission": "WRITE"})),
+            "issue list": _proc(json.dumps([{"number": 9, "title": "A real title"}])),
+        },
+        calls,
+    )
+    t, b = _drafts(tmp_path)
+    rc = fti.main(
+        [
+            "--title-file",
+            t,
+            "--body-file",
+            b,
+            "--area",
+            "area:other",
+            "--difficulty",
+            "help wanted",
+        ],
+        run,
+    )
+    assert rc == 3
+    assert "DUPLICATE: Org/Repo#9" in capsys.readouterr().err
+    assert not any("issue create" in " ".join(c) for c in calls)
+
+
+def test_main_refuses_an_empty_title(tmp_path, capsys):
+    t = tmp_path / "title.txt"
+    t.write_text("   \n", encoding="utf-8")
+    b = tmp_path / "body.md"
+    b.write_text("body", encoding="utf-8")
+    rc = fti.main(
+        [
+            "--title-file",
+            str(t),
+            "--body-file",
+            str(b),
+            "--area",
+            "area:memory",
+            "--difficulty",
+            "help wanted",
+        ],
+        _runner({}),
+    )
+    assert rc == 2
+    assert "title file is empty" in capsys.readouterr().err

--- a/tests/test_scripts/test_file_tracker_issue.py
+++ b/tests/test_scripts/test_file_tracker_issue.py
@@ -50,19 +50,24 @@ def _runner(responses: dict[str, subprocess.CompletedProcess[str]], calls: list 
 
 def test_fork_resolves_to_parent_not_the_fork():
     """A fork clone must target the upstream tracker, never the operator's fork."""
-    run = _runner(
-        {
-            "isFork": _proc(
+
+    def run(argv):
+        if "Upstream/Proj" in " ".join(argv):
+            return _proc(
                 json.dumps(
-                    {
-                        "isFork": True,
-                        "nameWithOwner": "downstream/Proj",
-                        "parent": {"owner": {"login": "Upstream"}, "name": "Proj"},
-                    }
+                    {"isFork": False, "nameWithOwner": "Upstream/Proj", "parent": None}
                 )
             )
-        }
-    )
+        return _proc(
+            json.dumps(
+                {
+                    "isFork": True,
+                    "nameWithOwner": "downstream/Proj",
+                    "parent": {"owner": {"login": "Upstream"}, "name": "Proj"},
+                }
+            )
+        )
+
     assert fti.resolve_tracker(run) == "Upstream/Proj"
 
 
@@ -116,26 +121,25 @@ def test_permission_is_checked_on_the_resolved_slug_not_the_cwd():
 def test_duplicate_check_does_not_use_search():
     """A title containing `repo:`/`is:` must be compared, not interpreted."""
     calls: list = []
-    run = _runner({"issue list": _proc(json.dumps([{"number": 5, "title": "unrelated"}]))}, calls)
+    run = _runner({"gh api": _proc('{"number":5,"title":"unrelated"}')}, calls)
     fti.find_duplicate("Org/Repo", "fix repo: parsing in is: handler", run)
     assert "--search" not in " ".join(calls[0])
 
 
 def test_exact_title_match_is_found_and_near_miss_is_not():
-    listing = json.dumps(
-        [
-            {"number": 11, "title": "Fix   the   PARSER  "},
-            {"number": 12, "title": "Fix the parser eventually"},
-        ]
+    listing = (
+        json.dumps({"number": 11, "title": "Fix   the   PARSER  "})
+        + "\n"
+        + json.dumps({"number": 12, "title": "Fix the parser eventually"})
     )
-    run = _runner({"issue list": _proc(listing)})
+    run = _runner({"gh api": _proc(listing)})
     assert fti.find_duplicate("Org/Repo", "fix the parser", run) == 11
     assert fti.find_duplicate("Org/Repo", "totally different title", run) is None
 
 
 def test_failed_duplicate_lookup_refuses_rather_than_assuming_none():
     """A failed lookup is not evidence of no duplicate."""
-    run = _runner({"issue list": _proc(returncode=1, stderr="network down")})
+    run = _runner({"gh api": _proc(returncode=1, stderr="network down")})
     with pytest.raises(fti.Refused, match="Refusing to file"):
         fti.find_duplicate("Org/Repo", "anything", run)
 
@@ -201,7 +205,7 @@ def test_repo_is_pinned_on_every_gh_invocation():
     calls: list = []
     run = _runner(
         {
-            "issue list": _proc("[]"),
+            "gh api": _proc(""),
             "issue create": _proc("https://example/1"),
         },
         calls,
@@ -209,7 +213,11 @@ def test_repo_is_pinned_on_every_gh_invocation():
     fti.find_duplicate("Org/Repo", "t", run)
     fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "help wanted"], run)
     for argv in calls:
-        assert "--repo" in argv and argv[argv.index("--repo") + 1] == "Org/Repo"
+        joined = " ".join(argv)
+        if "--repo" in argv:
+            assert argv[argv.index("--repo") + 1] == "Org/Repo"
+        else:
+            assert "repos/Org/Repo/" in joined, "the slug must be pinned in the API path"
 
 
 # --- end to end through main() ----------------------------------------------
@@ -231,7 +239,7 @@ def test_main_dry_run_passes_every_check_without_posting(tmp_path, capsys):
                 json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
             ),
             "viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"})),
-            "issue list": _proc("[]"),
+            "gh api": _proc(""),
         },
         calls,
     )
@@ -256,20 +264,26 @@ def test_main_dry_run_passes_every_check_without_posting(tmp_path, capsys):
 
 
 def test_main_refuses_on_a_fork_without_write_access(tmp_path, capsys):
-    run = _runner(
-        {
-            "isFork": _proc(
+    def run(argv):
+        joined = " ".join(argv)
+        if "viewerPermission" in joined:
+            return _proc(json.dumps({"viewerPermission": "READ"}))
+        if "Upstream/Proj" in joined:
+            return _proc(
                 json.dumps(
-                    {
-                        "isFork": True,
-                        "nameWithOwner": "downstream/Proj",
-                        "parent": {"owner": {"login": "Upstream"}, "name": "Proj"},
-                    }
+                    {"isFork": False, "nameWithOwner": "Upstream/Proj", "parent": None}
                 )
-            ),
-            "viewerPermission": _proc(json.dumps({"viewerPermission": "READ"})),
-        }
-    )
+            )
+        return _proc(
+            json.dumps(
+                {
+                    "isFork": True,
+                    "nameWithOwner": "downstream/Proj",
+                    "parent": {"owner": {"login": "Upstream"}, "name": "Proj"},
+                }
+            )
+        )
+
     t, b = _drafts(tmp_path)
     rc = fti.main(
         [
@@ -296,7 +310,7 @@ def test_main_reports_duplicate_and_files_nothing(tmp_path, capsys):
                 json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
             ),
             "viewerPermission": _proc(json.dumps({"viewerPermission": "WRITE"})),
-            "issue list": _proc(json.dumps([{"number": 9, "title": "A real title"}])),
+            "gh api": _proc(json.dumps({"number": 9, "title": "A real title"})),
         },
         calls,
     )
@@ -339,3 +353,187 @@ def test_main_refuses_an_empty_title(tmp_path, capsys):
     )
     assert rc == 2
     assert "title file is empty" in capsys.readouterr().err
+
+
+# ===========================================================================
+# round 4 (Codex, on the script itself) — one class: CLAIMING MORE CERTAINTY
+# THAN THE STEP ACTUALLY HAS.
+# ===========================================================================
+
+
+def test_fork_of_a_fork_walks_to_the_network_root():
+    """One `parent` hop is not the root — the intermediate fork may be writable."""
+    seen = []
+
+    def run(argv):
+        seen.append(list(argv))
+        joined = " ".join(argv)
+        if "mid/Proj" in joined:
+            return _proc(
+                json.dumps(
+                    {
+                        "isFork": True,
+                        "nameWithOwner": "mid/Proj",
+                        "parent": {"owner": {"login": "Root"}, "name": "Proj"},
+                    }
+                )
+            )
+        if "Root/Proj" in joined:
+            return _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Root/Proj", "parent": None})
+            )
+        return _proc(
+            json.dumps(
+                {
+                    "isFork": True,
+                    "nameWithOwner": "leaf/Proj",
+                    "parent": {"owner": {"login": "mid"}, "name": "Proj"},
+                }
+            )
+        )
+
+    assert fti.resolve_tracker(run) == "Root/Proj"
+    assert len(seen) == 3, "must keep walking while isFork, not stop at the first parent"
+
+
+def test_fork_chain_deeper_than_the_bound_refuses():
+    """A cycle or a misbehaving API must not spin."""
+
+    def run(argv):
+        return _proc(
+            json.dumps(
+                {
+                    "isFork": True,
+                    "nameWithOwner": "a/Proj",
+                    "parent": {"owner": {"login": "b"}, "name": "Proj"},
+                }
+            )
+        )
+
+    with pytest.raises(fti.Refused, match="fork chain deeper"):
+        fti.resolve_tracker(run)
+
+
+def test_duplicate_lookup_paginates_and_is_not_capped():
+    """A capped window that excludes the match is indistinguishable from no match."""
+    calls: list = []
+    run = _runner({"gh api": _proc('{"number":1,"title":"other"}\n')}, calls)
+    fti.find_duplicate("Org/Repo", "anything", run)
+    argv = " ".join(calls[0])
+    assert "--paginate" in argv, "must walk every page, not a first window"
+    assert "--limit" not in argv, "no cap — absence from a truncated read is not absence"
+    assert "pull_request" in argv, "GitHub's issues endpoint returns PRs too"
+
+
+def test_duplicate_found_on_a_later_page():
+    """The match is the LAST record — a capped read would have missed it."""
+    lines = "\n".join(
+        json.dumps({"number": n, "title": f"filler {n}"}) for n in range(1, 300)
+    )
+    lines += "\n" + json.dumps({"number": 999, "title": "The Real Title"})
+    run = _runner({"gh api": _proc(lines)})
+    assert fti.find_duplicate("Org/Repo", "the real title", run) == 999
+
+
+def test_partial_json_in_the_listing_refuses_rather_than_reporting_absence():
+    run = _runner({"gh api": _proc('{"number":1,"title":"ok"}\n{"number":2,"tit')})
+    with pytest.raises(fti.Refused, match="cannot prove absence"):
+        fti.find_duplicate("Org/Repo", "anything", run)
+
+
+def test_create_failure_is_indeterminate_not_refused():
+    """A lost response after the server committed means the issue EXISTS."""
+    run = _runner({"issue create": _proc(returncode=1, stderr="connection reset")})
+    with pytest.raises(fti.Indeterminate, match="MAY have been created"):
+        fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "help wanted"], run)
+
+
+def test_indeterminate_is_not_a_refused_subclass():
+    """Refused's contract is 'nothing was posted'. Conflating them is the bug."""
+    assert not issubclass(fti.Indeterminate, fti.Refused)
+    assert not issubclass(fti.Refused, fti.Indeterminate)
+
+
+def test_main_reports_exit_4_for_an_indeterminate_post(tmp_path, capsys):
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+            ),
+            "viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"})),
+            "gh api": _proc(""),
+            "issue create": _proc(returncode=1, stderr="connection reset"),
+        }
+    )
+    t, b = _drafts(tmp_path)
+    rc = fti.main(
+        ["--title-file", t, "--body-file", b, "--area", "area:memory",
+         "--difficulty", "help wanted"],
+        run,
+    )
+    assert rc == 4, "exit 2 would tell the operator nothing was posted — it may have been"
+    err = capsys.readouterr().err
+    assert "INDETERMINATE" in err
+    assert "BEFORE retrying" in err
+
+
+def test_lookup_and_create_run_inside_the_tracker_lock(tmp_path, monkeypatch):
+    """Check-then-act must be one critical section, or both sessions post."""
+    events: list = []
+
+    class _Recorder:
+        def __init__(self, slug):
+            self.slug = slug
+
+        def __enter__(self):
+            events.append("lock")
+            return self
+
+        def __exit__(self, *a):
+            events.append("unlock")
+            return False
+
+    monkeypatch.setattr(fti, "tracker_lock", _Recorder)
+
+    def run(argv):
+        joined = " ".join(argv)
+        if "isFork" in joined:
+            return _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+            )
+        if "viewerPermission" in joined:
+            return _proc(json.dumps({"viewerPermission": "ADMIN"}))
+        if "gh api" in joined:
+            events.append("lookup")
+            return _proc("")
+        if "issue create" in joined:
+            events.append("create")
+            return _proc("https://example/1")
+        raise AssertionError(joined)
+
+    t, b = _drafts(tmp_path)
+    rc = fti.main(
+        ["--title-file", t, "--body-file", b, "--area", "area:memory",
+         "--difficulty", "help wanted"],
+        run,
+    )
+    assert rc == 0
+    assert events == ["lock", "lookup", "create", "unlock"], events
+
+
+def test_tracker_lock_is_per_tracker_and_actually_excludes(tmp_path, monkeypatch):
+    """Different trackers get different locks; the same tracker serialises."""
+    monkeypatch.setattr(fti.Path, "home", staticmethod(lambda: tmp_path))
+    a1 = fti._lock_path("Org/Repo")
+    a2 = fti._lock_path("Org/Repo")
+    b1 = fti._lock_path("Other/Repo")
+    assert a1 == a2 and a1 != b1
+
+    import fcntl as _f
+
+    with (
+        fti.tracker_lock("Org/Repo"),
+        open(a1, "w", encoding="utf-8") as second,
+        pytest.raises(BlockingIOError),
+    ):
+        _f.flock(second, _f.LOCK_EX | _f.LOCK_NB)

--- a/tests/test_scripts/test_file_tracker_issue.py
+++ b/tests/test_scripts/test_file_tracker_issue.py
@@ -14,6 +14,7 @@ import ast
 import importlib.util
 import json
 import os
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -1060,3 +1061,87 @@ def test_interrupt_while_creating_is_indeterminate_not_refused(tmp_path, capsys)
         )
     assert rc == 4, "the request may have reached GitHub — refusing would invite a duplicate"
     assert "INDETERMINATE" in capsys.readouterr().err
+
+
+class TestSigtermHandlerIsScoped:
+    """main() must not leave the SIGTERM handler installed process-wide.
+
+    REGRESSION (MEASURED in CI): main() installed `_sigterm_as_interrupt`
+    globally and never restored it. These tests call main() in-process, so the
+    handler outlived them and was inherited by every process forked later in the
+    same pytest run. tests/test_scripts/test_session_heartbeat_throttle.py forks
+    multiprocessing children and terminate()s them; the inherited handler turned
+    that SIGTERM into a KeyboardInterrupt instead of death, join() never
+    returned, and TWO tests in a file this PR does not touch hung for the full
+    1800s pytest-timeout. Test files run alphabetically, so this one poisoned it.
+    """
+
+    @staticmethod
+    def _ok_runner(calls=None):
+        return _runner(
+            {
+                "isFork": _proc(
+                    json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+                ),
+                "viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"})),
+                "gh api": _proc(""),
+            },
+            calls,
+        )
+
+    @staticmethod
+    def _argv(tmp_path):
+        t_, b_ = _drafts(tmp_path)
+        return [
+            "--title-file", t_,
+            "--body-file", b_,
+            "--area", "area:memory",
+            "--difficulty", "help wanted",
+            "--dry-run",
+        ]
+
+    def test_main_restores_the_previous_sigterm_handler(self, tmp_path, capsys):
+        """The leak itself: after main() returns, the handler is what it was.
+
+        A DISTINCTIVE sentinel is installed first rather than reading whatever
+        happens to be current. Reading the current handler makes this test
+        order-dependent and nearly vacuous: any earlier test in this file that
+        calls main() would already have leaked the handler, so `before` and
+        `after` would both be the leaked one and compare equal. MEASURED — that
+        weaker form passed against the unfixed script.
+        """
+
+        def _sentinel(signum, frame):  # pragma: no cover - never delivered
+            raise AssertionError("sentinel handler should not run")
+
+        prior = signal.signal(signal.SIGTERM, _sentinel)
+        try:
+            rc = fti.main(self._argv(tmp_path), self._ok_runner())
+            capsys.readouterr()
+
+            assert rc == 0
+            assert signal.getsignal(signal.SIGTERM) is _sentinel
+        finally:
+            signal.signal(signal.SIGTERM, prior)
+
+    def test_the_handler_is_active_while_main_runs(self, tmp_path, capsys):
+        """The guarantee the scope must not cost us — untested until now.
+
+        Restoring is only correct if the handler is genuinely installed FOR the
+        duration. A "fix" that simply stopped installing it would pass the leak
+        test above while silently dropping the reconcile-on-SIGTERM property the
+        handler exists for, so both halves are pinned.
+        """
+        seen = []
+        inner = self._ok_runner()
+
+        def watching_run(argv):
+            seen.append(signal.getsignal(signal.SIGTERM))
+            return inner(argv)
+
+        rc = fti.main(self._argv(tmp_path), watching_run)
+        capsys.readouterr()
+
+        assert rc == 0
+        assert seen, "the runner was never called, so nothing was observed"
+        assert all(h is fti._sigterm_as_interrupt for h in seen)

--- a/tests/test_scripts/test_file_tracker_issue.py
+++ b/tests/test_scripts/test_file_tracker_issue.py
@@ -1009,3 +1009,54 @@ def test_duplicate_path_is_finalized_through_finish(tmp_path, monkeypatch):
     )
     assert rc == 3
     assert seen.get("code") == 3
+
+
+# --- round 7: the last three -------------------------------------------------
+
+
+def test_stderr_is_finalized_too(monkeypatch):
+    """CPython flushes stderr at shutdown as well — it can also force exit 120."""
+    flushed = []
+
+    class S:
+        def __init__(self, name):
+            self.name = name
+
+        def flush(self):
+            flushed.append(self.name)
+
+        def fileno(self):
+            return 1
+
+    monkeypatch.setattr(sys, "stdout", S("out"))
+    monkeypatch.setattr(sys, "stderr", S("err"))
+    assert fti._finish(2) == 2
+    assert flushed == ["out", "err"], f"both streams must be finalized, got {flushed}"
+
+
+def test_interrupt_while_creating_is_indeterminate_not_refused(tmp_path, capsys):
+    """Between attempting the create and it returning, the outcome is UNKNOWN."""
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+            ),
+            "viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"})),
+            "gh api": _proc(""),
+        }
+    )
+
+    def interrupting(*a, **k):
+        raise KeyboardInterrupt
+
+    import unittest.mock
+
+    with unittest.mock.patch.object(fti, "create_issue", interrupting):
+        tf, bf = _drafts(tmp_path)
+        rc = fti.main(
+            ["--title-file", tf, "--body-file", bf, "--area", "area:memory",
+             "--difficulty", "help wanted"],
+            run,
+        )
+    assert rc == 4, "the request may have reached GitHub — refusing would invite a duplicate"
+    assert "INDETERMINATE" in capsys.readouterr().err

--- a/tests/test_scripts/test_file_tracker_issue.py
+++ b/tests/test_scripts/test_file_tracker_issue.py
@@ -10,9 +10,12 @@ No network, no `gh`, no live repo — the runner is injected.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -22,6 +25,14 @@ _spec = importlib.util.spec_from_file_location("file_tracker_issue", _SCRIPT)
 assert _spec and _spec.loader
 fti = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(fti)
+
+
+
+class _PathWithFailingMkdir(Path):
+    """Scoped stand-in: only THIS class fails, not pathlib.Path process-wide."""
+
+    def mkdir(self, *a, **k):
+        raise OSError("read-only file system")
 
 
 def _proc(
@@ -441,10 +452,20 @@ def test_partial_json_in_the_listing_refuses_rather_than_reporting_absence():
         fti.find_duplicate("Org/Repo", "anything", run)
 
 
-def test_create_failure_is_indeterminate_not_refused():
-    """A lost response after the server committed means the issue EXISTS."""
-    run = _runner({"issue create": _proc(returncode=1, stderr="connection reset")})
-    with pytest.raises(fti.Indeterminate, match="MAY have been created"):
+def test_create_failure_reconciles_against_the_tracker():
+    """Superseded round-4 behaviour: the outcome is RESOLVED, not reported.
+
+    Kept as a test because the guarantee still matters — a lost response after
+    the server committed means the issue EXISTS — but the script now answers the
+    question instead of handing it to the operator.
+    """
+
+    def run(argv):
+        if "issue create" in " ".join(argv):
+            return _proc(returncode=1, stderr="connection reset")
+        return _proc("")
+
+    with pytest.raises(fti.Refused, match="Reconciled against"):
         fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "help wanted"], run)
 
 
@@ -455,16 +476,25 @@ def test_indeterminate_is_not_a_refused_subclass():
 
 
 def test_main_reports_exit_4_for_an_indeterminate_post(tmp_path, capsys):
-    run = _runner(
-        {
-            "isFork": _proc(
+    """Exit 4 now means only one thing: the reconciling lookup ALSO failed."""
+    calls = {"api": 0}
+
+    def run(argv):
+        joined = " ".join(argv)
+        if "isFork" in joined:
+            return _proc(
                 json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
-            ),
-            "viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"})),
-            "gh api": _proc(""),
-            "issue create": _proc(returncode=1, stderr="connection reset"),
-        }
-    )
+            )
+        if "viewerPermission" in joined:
+            return _proc(json.dumps({"viewerPermission": "ADMIN"}))
+        if "gh api" in joined:
+            calls["api"] += 1
+            # first call = the pre-flight dup check; second = the reconcile
+            return _proc("") if calls["api"] == 1 else _proc(returncode=1, stderr="network down")
+        if "issue create" in joined:
+            return _proc(returncode=1, stderr="connection reset")
+        raise AssertionError(joined)
+
     t, b = _drafts(tmp_path)
     rc = fti.main(
         ["--title-file", t, "--body-file", b, "--area", "area:memory",
@@ -475,6 +505,7 @@ def test_main_reports_exit_4_for_an_indeterminate_post(tmp_path, capsys):
     err = capsys.readouterr().err
     assert "INDETERMINATE" in err
     assert "BEFORE retrying" in err
+    assert calls["api"] == 2, "must have attempted a reconcile"
 
 
 def test_lookup_and_create_run_inside_the_tracker_lock(tmp_path, monkeypatch):
@@ -523,7 +554,9 @@ def test_lookup_and_create_run_inside_the_tracker_lock(tmp_path, monkeypatch):
 
 def test_tracker_lock_is_per_tracker_and_actually_excludes(tmp_path, monkeypatch):
     """Different trackers get different locks; the same tracker serialises."""
-    monkeypatch.setattr(fti.Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.setattr(fti, "Path", type("P", (fti.Path.__class__ if False else Path,), {}))
+    monkeypatch.setattr(fti, "_lock_base_override", tmp_path, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
     a1 = fti._lock_path("Org/Repo")
     a2 = fti._lock_path("Org/Repo")
     b1 = fti._lock_path("Other/Repo")
@@ -537,3 +570,285 @@ def test_tracker_lock_is_per_tracker_and_actually_excludes(tmp_path, monkeypatch
         pytest.raises(BlockingIOError),
     ):
         _f.flock(second, _f.LOCK_EX | _f.LOCK_NB)
+
+
+# ===========================================================================
+# round 5 — same class again, at the outer edges: the script inferring whether
+# it posted. Resolved by asking the TRACKER instead of the exit status.
+# ===========================================================================
+
+
+def test_create_timeout_is_reconciled_not_an_uncaught_exception():
+    """A timeout is EXACTLY when the post may exist — it must not escape."""
+    calls: list = []
+
+    def run(argv):
+        calls.append(list(argv))
+        if "issue create" in " ".join(argv):
+            raise subprocess.TimeoutExpired(cmd=list(argv), timeout=120)
+        return _proc(json.dumps({"number": 77, "title": "A real title"}))
+
+    out = fti.create_issue(
+        "Org/Repo", "A real title", "/tmp/b.md", ["area:eval", "help wanted"], run
+    )
+    assert "Org/Repo#77" in out
+    assert "EXISTS" in out
+    assert any("gh api" in " ".join(c) for c in calls), "must reconcile against the tracker"
+
+
+def test_timeout_with_no_issue_on_the_tracker_is_a_clean_refusal():
+    """Reconciling can also prove the post did NOT happen — say so definitively."""
+
+    def run(argv):
+        if "issue create" in " ".join(argv):
+            raise subprocess.TimeoutExpired(cmd=list(argv), timeout=120)
+        return _proc("")
+
+    with pytest.raises(fti.Refused, match="nothing was posted"):
+        fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "help wanted"], run)
+
+
+def test_nonzero_exit_with_the_issue_present_reports_success():
+    """The old code called this 'indeterminate'; the tracker knows the answer."""
+
+    def run(argv):
+        if "issue create" in " ".join(argv):
+            return _proc(returncode=1, stderr="connection reset")
+        return _proc(json.dumps({"number": 42, "title": "A real title"}))
+
+    out = fti.create_issue(
+        "Org/Repo", "A real title", "/tmp/b.md", ["area:eval", "help wanted"], run
+    )
+    assert "Org/Repo#42" in out
+
+
+def test_indeterminate_only_when_the_reconciling_lookup_also_fails():
+    """The one genuinely unknowable case — and the only one left."""
+
+    def run(argv):
+        if "issue create" in " ".join(argv):
+            return _proc(returncode=1, stderr="connection reset")
+        return _proc(returncode=1, stderr="network down")
+
+    with pytest.raises(fti.Indeterminate, match="MAY exist"):
+        fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "help wanted"], run)
+
+
+def test_lock_directory_failure_refuses_rather_than_using_a_tmpdir_fallback(monkeypatch):
+    """A TMPDIR-dependent fallback is not a lock: CC sets TMPDIR, a shell does not."""
+
+
+    monkeypatch.setattr(fti, "Path", _PathWithFailingMkdir)
+    with pytest.raises(fti.Refused, match="TMPDIR-dependent fallback"):
+        fti._lock_path("Org/Repo")
+
+
+def test_no_tempfile_fallback_remains_in_the_source():
+    """Guard the guard: the fallback must be gone, not merely unreachable.
+
+    Asserts on the IMPORT, not on the word — the docstring deliberately names
+    `tempfile.gettempdir()` to explain why the fallback was removed, and a guard
+    that fires on its own rationale is one the next reader deletes.
+    """
+    src = (
+        Path(__file__).resolve().parents[2] / "scripts" / "file_tracker_issue.py"
+    ).read_text()
+    tree = ast.parse(src)
+    imported = {
+        alias.name.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module.split(".")[0]
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert "tempfile" not in imported, "cannot call gettempdir() without importing it"
+
+
+def test_a_reporting_failure_does_not_reclassify_a_posted_issue(tmp_path, capsys, monkeypatch):
+    """In-process half of the guarantee; the exit-code half is the subprocess test below.
+
+    Kept deliberately narrow: this proves main() RETURNS 0 when the URL cannot be
+    written. It cannot prove the PROCESS exits 0 — the shutdown flush happens
+    after main() returns — which is why the subprocess test exists and why the
+    version of this test that only did the former was false assurance.
+    """
+    run = _runner(
+        {
+            "isFork": _proc(
+                json.dumps({"isFork": False, "nameWithOwner": "Org/Repo", "parent": None})
+            ),
+            "viewerPermission": _proc(json.dumps({"viewerPermission": "ADMIN"})),
+            "gh api": _proc(""),
+            "issue create": _proc("https://example/1"),
+        }
+    )
+    real_print = print
+    state = {"failed": False}
+
+    def flaky(*a, **k):
+        if not state["failed"] and a and str(a[0]).startswith("https://"):
+            state["failed"] = True
+            raise BrokenPipeError("stdout closed")
+        return real_print(*a, **k)
+
+    monkeypatch.setattr("builtins.print", flaky)
+    tf, bf = _drafts(tmp_path)
+    rc = fti.main(
+        ["--title-file", tf, "--body-file", bf, "--area", "area:memory",
+         "--difficulty", "help wanted"],
+        run,
+    )
+    assert rc == 0, "a confirmed post must not be reported as failure"
+    assert state["failed"], "the print failure must actually have been exercised"
+    assert "POSTED" in capsys.readouterr().err
+
+
+# ===========================================================================
+# fresh-context audit — the exception surface. Each of these is a type that
+# escaped EVERY handler, so the documented exit-code contract was not real.
+# ===========================================================================
+
+
+def test_reconcile_timeout_does_not_escape_as_exit_1():
+    """TimeoutExpired is not an OSError — it was caught nowhere on this path."""
+
+    def run(argv):
+        if "issue create" in " ".join(argv):
+            return _proc(returncode=1, stderr="connection reset")
+        raise subprocess.TimeoutExpired(cmd=list(argv), timeout=120)
+
+    # the reconcile's own lookup timing out is Refused (nothing proven posted),
+    # never an uncaught exception
+    with pytest.raises(fti.Indeterminate):
+        fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "help wanted"], run)
+
+
+def test_preflight_duplicate_timeout_is_refused_not_uncaught():
+    def run(argv):
+        raise subprocess.TimeoutExpired(cmd=list(argv), timeout=120)
+
+    with pytest.raises(fti.Refused, match="did not complete"):
+        fti.find_duplicate("Org/Repo", "t", run)
+
+
+def test_interrupt_during_create_reconciles():
+    """KeyboardInterrupt is a BaseException — it escapes `except Exception`."""
+
+    def run(argv):
+        if "issue create" in " ".join(argv):
+            raise KeyboardInterrupt
+        return _proc(json.dumps({"number": 5, "title": "t"}))
+
+    out = fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "help wanted"], run)
+    assert "Org/Repo#5" in out
+
+
+def test_gh_returning_a_non_object_is_refused_not_attributeerror():
+    run = _runner({"isFork": _proc("[]")})
+    with pytest.raises(fti.Refused, match="expected an object"):
+        fti.resolve_tracker(run)
+
+
+def test_rc_zero_with_no_url_is_reconciled_not_reported_as_filed():
+    """Success with nothing to cite is the same false certainty, inverted."""
+
+    def run(argv):
+        if "issue create" in " ".join(argv):
+            return _proc("")
+        return _proc("")
+
+    with pytest.raises(fti.Refused, match="printed no URL"):
+        fti.create_issue("Org/Repo", "t", "/tmp/b.md", ["area:eval", "help wanted"], run)
+
+
+def test_unreadable_or_non_utf8_draft_is_exit_2_not_1(tmp_path, capsys):
+    """UnicodeDecodeError is a ValueError — no handler caught it."""
+    t = tmp_path / "title.txt"
+    t.write_bytes(b"\xff\xfe not utf-8")
+    b = tmp_path / "body.md"
+    b.write_text("body", encoding="utf-8")
+    rc = fti.main(
+        ["--title-file", str(t), "--body-file", str(b), "--area", "area:memory",
+         "--difficulty", "help wanted"],
+        _runner({}),
+    )
+    assert rc == 2, "a draft we cannot read means nothing was posted"
+    assert "cannot read the draft files" in capsys.readouterr().err
+
+
+def test_missing_title_file_is_exit_2(tmp_path, capsys):
+    b = tmp_path / "body.md"
+    b.write_text("body", encoding="utf-8")
+    rc = fti.main(
+        ["--title-file", str(tmp_path / "nope.txt"), "--body-file", str(b),
+         "--area", "area:memory", "--difficulty", "help wanted"],
+        _runner({}),
+    )
+    assert rc == 2
+    assert "cannot read the draft files" in capsys.readouterr().err
+
+
+def test_over_long_and_multiline_titles_refuse_before_any_network_call(tmp_path):
+    """A title GitHub will reject would otherwise loop forever on 'safe to retry'."""
+    b = tmp_path / "body.md"
+    b.write_text("body", encoding="utf-8")
+
+    def run(argv):
+        raise AssertionError("must refuse before touching the network")
+
+    for bad in ("x" * 257, "line one\nline two"):
+        t = tmp_path / "title.txt"
+        t.write_text(bad, encoding="utf-8")
+        rc = fti.main(
+            ["--title-file", str(t), "--body-file", str(b), "--area", "area:memory",
+             "--difficulty", "help wanted"],
+            run,
+        )
+        assert rc == 2
+
+
+# --- the exit code must survive interpreter shutdown ------------------------
+
+
+def test_confirmed_post_does_not_exit_120_when_stdout_is_full(tmp_path):
+    """The real defect: CPython's shutdown flush overrides the return code.
+
+    Runs the script as a SUBPROCESS with stdout on /dev/full, because the
+    previous version of this test injected a `print` that raises — which the
+    real `print` does not — and passed green while the script exited 120.
+    Asserting on the process's actual exit status is the only way to see it.
+    """
+    stub = tmp_path / "gh"
+    stub.write_text(
+        "#!/bin/sh\n"
+        'case "$*" in\n'
+        '  *"--json isFork"*) echo \'{"isFork":false,"nameWithOwner":"Org/Repo","parent":null}\' ;;\n'
+        '  *viewerPermission*) echo \'{"viewerPermission":"ADMIN"}\' ;;\n'
+        '  *"api"*) : ;;\n'
+        '  *"issue create"*) echo "https://example/1" ;;\n'
+        "esac\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    title = tmp_path / "title.txt"
+    title.write_text("A real title", encoding="utf-8")
+    body = tmp_path / "body.md"
+    body.write_text("body", encoding="utf-8")
+    home = tmp_path / "home"
+    home.mkdir()
+
+    env = dict(os.environ, PATH=f"{tmp_path}:{os.environ['PATH']}", HOME=str(home))
+    with open("/dev/full", "w", encoding="utf-8") as full:
+        proc = subprocess.run(
+            [sys.executable, str(_SCRIPT), "--title-file", str(title), "--body-file",
+             str(body), "--area", "area:memory", "--difficulty", "help wanted"],
+            stdout=full, stderr=subprocess.PIPE, text=True, timeout=60, check=False,
+            env=env,
+        )
+    assert proc.returncode != 120, (
+        "a CONFIRMED post exited 120 — CPython's shutdown flush overrode the exit code"
+    )
+    assert proc.returncode == 0, f"expected 0 for a successful post, got {proc.returncode}"


### PR DESCRIPTION
## The problem

Deferred work had two destinations, both local: the hot `follow_up` lane and the cold `tabled` lane. Nothing said when something belongs on the **public issue tracker** instead — so the default for every session was a local row nobody outside the install can see, including bugs in the public codebase itself.

## Three destinations, routed by owner

- **Genesis-repo work** (code, tests, docs, infra — anything that would live in the public repo, even when hit locally) → a **GitHub issue**, so anyone can pick it up.
- **User-owned work** (a deliverable, an errand) and operational state purely local to this box → a local **follow-up**.
- **Consciously not pursuing** → `tabled`, and deliberately *never* an issue — an issue invites someone to pick it up, which is exactly wrong for a someday item.

## Split by altitude

`CLAUDE.md` carries the principle only and lands at **194 words — shorter than the 226-word rule it replaces**, despite covering a third destination. Every mechanic moved to `.claude/docs/mcp-tools-guide.md` ("Where Deferred Work Goes"), where it has room to be complete.

That split was not the original plan. Two adversarial review rounds each surfaced new defects in the same prose while it inflated toward 320+ words — the instance-fixing signature. The generator was writing routing detail into the file that loads into *every* session, where there is no room to be correct. Splitting by altitude dissolved it; the third round confirms the split holds.

## What the reviews caught

Four of these would have shipped as real defects:

- **A bare `gh issue create` files to the wrong repo on most installs.** `gh` resolves from the git remote, and the documented install is a fork clone — so issues would land on the user's *private* fork, silently, with no error, defeating the entire rationale. Now `--repo`, with both resolvers named (`github_user()` + `github_public_repo()`, the latter returning the bare name).
- **The original justification was false.** It claimed a public post is "gated, irreversible egress". `gh issue create` appears nowhere in `git_push_guard.py`, which gates push / `gh pr merge` / `gh pr create`. Irreversible yes, gated no — so the guide now says the path is unguarded and the privacy scan is manual.
- **The docstring misled about what actually happens.** A dispatched session's row is FORCED onto the cold `tabled` lane by sacred-board authorization whatever `work_state` is passed, and tabled rows are excluded from every default listing. The docstring implied a live parking spot.
- **The dispatched-session fallback named routes those sessions cannot take** — twice. The first attempt pointed `observe` at `observation_write`, which `_NO_MEMORY_WRITES` denies it; it also listed `sentinel` as lacking `follow_up_create` (only the *degraded* case does) and omitted `community-responder` entirely. Now three tiers, each member verified from `_PROFILE_DISALLOW`, with a real terminal route for sessions that can write neither.

Also: both label classes (`area:*` AND difficulty/environment) are now mandatory on the hand path, matching what `contributor_issue_propose` enforces fail-closed — the hand path has no validator, so an unlabelled issue silently breaks an invariant the codebase holds elsewhere.

## Reconciled surfaces

Every other file that still taught the old behaviour: `cc-update/SKILL.md`, `cc-compatibility.md`, `genesis-development/SKILL.md` and its `observability.md` reference, and the `CURRENT.md` subsystem-map entry (rescoped — templated pipelines write via `crud.follow_ups.create()` and are governed at their own call sites).

The first enumeration missed two sites because it grepped for `follow_up_create` and they said "filed as a follow-up". Redone with concept-level patterns.

## Verification

`ruff` clean · `tests/test_mcp/test_follow_up_tools.py` 39 passed · `check_external_io` / `check_subsystem_map` / `check_shared_artifact_consumers` / `check_frozen_clock` all pass · privacy scan clean on the diff and the commit message (placeholders only).

The Python change is **docstring-only** — no behaviour change.

Ledger: bf057f3bfc9543bc939d2cdf78968f62


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a safe command-line workflow for filing tracker issues with permission checks, label validation, duplicate detection, draft validation, and clear failure statuses.
  * Improved issue filing with fork-chain tracking, exhaustive duplicate checks, serialized creation, timeout handling, and reconciliation of uncertain outcomes.

* **Documentation**
  * Clarified routing for deferred work, capability adoption, bugs, deployment blockers, scheduling, dispatched sessions, approvals, and security-sensitive disclosures.
  * Documented when to use tracker issues, local follow-ups, or tabled records.

* **Tests**
  * Expanded coverage for pagination, fork resolution, malformed data, locking, validation, interruptions, and indeterminate filing outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->