### PR TITLE
fix(awareness): say which tick a resumed reflection actually runs against

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1024,7 +1024,7 @@ The loops that make Genesis think between conversations.
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness,
           session_charter.py]
-verified: 50b79ffb 2026-09-01
+verified: 29a382e7 2026-09-03
 ```
 
 - **PR-watch inline surface (2026-07-21)**: a SessionStart hook
@@ -1151,6 +1151,21 @@ verified: 50b79ffb 2026-09-01
   `job.failed` is in the ego's `_REFLEX_OWNED_EVENT_TYPES` so it never spins a
   reactive ego cycle. Ingested by the reflex arc as of PR-2b (`ingest.py`
   consumes `job.failed`, guarded on `error_type` presence).
+- **A resumed reflection runs against a DIFFERENT tick than the one that asked.**
+  When a user approves a reflection's gated CC fallback, `_resume_approved_reflections`
+  dispatches it with `self._last_tick_result` — the CURRENT tick — because the
+  loop's own scoring may never reach that depth again. So what a person approved
+  and what runs are about different moments — and per that method's docstring
+  the reason is availability, not a preference for fresher state: the current
+  tick is the only one it has. The ORIGINATING tick is genuinely unrecoverable: the approval context is
+  built from a fixed key set with no tick field, and `_approval_key` excludes
+  per-invocation identity on purpose so recurring dispatches reuse one pending
+  row rather than minting a new approval every tick. The resume log therefore
+  names the approval, its age, and the tick being run against, and says outright
+  that this is not the requesting tick — rather than implying a lineage that
+  does not exist. Giving it one would mean a key-neutral carrier that does not
+  currently exist; do not smuggle a tick id into `action_label` or
+  `extra_context`, both of which feed the approval key.
 - **perception/**: the real-time reflection engine — MICRO (and LIGHT without
   a CC bridge) run in-process via the router; DEEP/STRATEGIC go to the CC
   reflection bridge. GROUNDWORK: user-model-synthesis, pre-execution-gate

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -2713,6 +2713,29 @@ async def perform_tick(
     return result
 
 
+def _approval_age(resolved_at: str | None) -> str:
+    """How long ago an approval was granted, for a log line — never a raise.
+
+    `resolved_at` is a DB column reached through a resume path that dispatches
+    real work; a log line must not be what breaks it. Anything unparseable or
+    absent degrades to "age unknown", which is also the honest rendering.
+    """
+    if not resolved_at:
+        return "age unknown"
+    try:
+        resolved = datetime.fromisoformat(str(resolved_at))
+    except (TypeError, ValueError):
+        return "age unknown"
+    if resolved.tzinfo is None:
+        resolved = resolved.replace(tzinfo=UTC)
+    minutes = int((datetime.now(UTC) - resolved).total_seconds() // 60)
+    if minutes < 0:
+        return "age unknown"
+    if minutes < 60:
+        return f"{minutes}m ago"
+    return f"{minutes // 60}h{minutes % 60:02d}m ago"
+
+
 class AwarenessLoop:
     """The metronome — drives the 5-minute awareness tick via APScheduler."""
 
@@ -3616,10 +3639,28 @@ class AwarenessLoop:
                 consumed = await gate.mark_consumed(approved["id"])
                 if not consumed:
                     continue  # Another tick already consumed it
+                # Name the tick this actually runs against, and say plainly
+                # that it is not the tick that asked. A resumed reflection is
+                # dispatched with `self._last_tick_result` — the CURRENT tick —
+                # so what a person approved and what runs are about different
+                # moments. Per this method's own docstring the current tick is
+                # the only one available (the loop's scoring may never reach
+                # that depth again), NOT a freshness preference; either way the
+                # gap was invisible, because the line named only the approval.
+                #
+                # The ORIGINATING tick is not recoverable. Nothing records it:
+                # the approval context is built from a fixed key set with no
+                # tick field, and the approval key deliberately excludes
+                # per-invocation identity so recurring dispatches reuse one
+                # pending row. So this states what is known, and what is not.
                 logger.info(
-                    "Resuming %s reflection from approved request %s",
+                    "Resuming %s reflection from approval %s (approved %s) — "
+                    "running against the current tick %s, NOT the tick that "
+                    "requested it, which is not recorded",
                     depth_name,
                     approved["id"][:8],
+                    _approval_age(approved.get("resolved_at")),
+                    tick.tick_id[:8],
                 )
                 await self._cc_reflection_bridge.reflect(
                     depth,

--- a/tests/test_awareness/test_loop_resilience.py
+++ b/tests/test_awareness/test_loop_resilience.py
@@ -252,7 +252,7 @@ async def test_retry_deferred_reflection_failure_resets_to_pending(db):
 
 # ── _resume_approved_reflections tests ───────────────────────────────────
 
-def _approval_loop(db, cc_bridge, approved_for):
+def _approval_loop(db, cc_bridge, approved_for, resolved_at="2026-03-24T03:00:00+00:00"):
     """Build an AwarenessLoop wired to a mock bridge whose approval gate
     reports the given ``policy_id`` → approval-request-id pairs as
     approved-but-unconsumed.
@@ -261,7 +261,12 @@ def _approval_loop(db, cc_bridge, approved_for):
 
     async def _find(*, subsystem, policy_id):
         rid = approved_for.get(policy_id)
-        return {"id": rid} if rid else None
+        if not rid:
+            return None
+        # The real query is `SELECT *`, so the row carries resolved_at. The
+        # fake used to return the id alone, which let the resume path read a
+        # column the production row always has.
+        return {"id": rid, "resolved_at": resolved_at}
 
     gate.find_recently_approved = AsyncMock(side_effect=_find)
     gate.mark_consumed = AsyncMock(return_value=True)
@@ -371,3 +376,140 @@ async def test_reflection_light_approval_resume_data_path(db):
     assert await ar_crud.find_approved_unconsumed(
         db, subsystem="reflection", policy_id="reflection_light",
     ) is None
+
+
+async def test_resume_log_names_the_tick_it_actually_runs_against(db, caplog):
+    """A resumed reflection runs against `self._last_tick_result` — the CURRENT
+    tick — not the one that raised the approval. That is a real gap between
+    what a person approved and what runs, and the log said neither, naming only
+    the approval id.
+
+    The originating tick is NOT recoverable: nothing writes it. The approval
+    context is built from a fixed key set and `_approval_key` has no tick input,
+    so the honest line names what IS known and says what is not.
+    """
+    import logging
+
+    cc_bridge = AsyncMock()
+    cc_bridge.reflect = AsyncMock(return_value=_MockReflectionResult(success=True))
+    from datetime import UTC, datetime, timedelta
+
+    two_hours_ago = (datetime.now(UTC) - timedelta(hours=2, seconds=1)).isoformat()
+    loop, _gate = _approval_loop(
+        db, cc_bridge, {"reflection_deep": "appr-deep-123456"},
+        resolved_at=two_hours_ago,
+    )
+
+    with caplog.at_level(logging.INFO, logger="genesis.awareness.loop"):
+        await loop._resume_approved_reflections()
+
+    line = next(
+        (r.getMessage() for r in caplog.records if "Resuming" in r.getMessage()), None
+    )
+    assert line is not None, [r.getMessage() for r in caplog.records]
+    assert "appr-dee" in line, line          # the approval, as before
+    assert "t-resume" in line, line          # the tick it RUNS against
+    # The FULL clause, not a prefix: asserting "requested it" alone still
+    # matched when the "which is not recorded" half was deleted, so the
+    # sentence could lose the thing it exists to say and stay green.
+    assert "NOT the tick that requested it, which is not recorded" in line, line
+    # The VALUE, not the literal: `"approved "` is part of the format string
+    # `"(approved %s)"`, so it matched even with the whole age computation
+    # replaced by a constant. The fixture pins resolved_at 2h before the frozen
+    # "now" this test sets, so the rendered age is checkable.
+    assert "(approved 2h00m ago)" in line, line
+
+
+async def test_resume_log_survives_a_row_without_a_resolved_timestamp(db, caplog):
+    """Never let a log line be the thing that breaks a resume. `resolved_at`
+    comes from the DB row; an unparseable or absent value degrades the age to
+    unknown rather than raising inside the dispatch path."""
+    import logging
+
+    cc_bridge = AsyncMock()
+    cc_bridge.reflect = AsyncMock(return_value=_MockReflectionResult(success=True))
+    loop, _gate = _approval_loop(
+        db, cc_bridge, {"reflection_light": "appr-light"}, resolved_at="not-a-timestamp"
+    )
+
+    with caplog.at_level(logging.INFO, logger="genesis.awareness.loop"):
+        await loop._resume_approved_reflections()
+
+    cc_bridge.reflect.assert_awaited_once()
+    assert any("Resuming" in r.getMessage() for r in caplog.records)
+
+
+async def test_resume_log_survives_a_row_with_no_resolved_column(db, caplog):
+    """The ABSENT case, not just the unparseable one.
+
+    A truthy-but-garbage timestamp exercises the parse branch; it never
+    reaches `if not resolved_at`. Making that branch raise left the suite
+    green, so the two inputs need separate tests.
+    """
+    import logging
+
+    cc_bridge = AsyncMock()
+    cc_bridge.reflect = AsyncMock(return_value=_MockReflectionResult(success=True))
+    loop, _gate = _approval_loop(
+        db, cc_bridge, {"reflection_light": "appr-light"}, resolved_at=None
+    )
+
+    with caplog.at_level(logging.INFO, logger="genesis.awareness.loop"):
+        await loop._resume_approved_reflections()
+
+    # NOT `assert_awaited_once(), "msg"` — that is a tuple expression and can
+    # never fail, which is how it read here until review caught it.
+    cc_bridge.reflect.assert_awaited_once()
+    line = next(r.getMessage() for r in caplog.records if "Resuming" in r.getMessage())
+    assert "age unknown" in line, line
+
+
+class TestApprovalAge:
+    """`_approval_age` sits between `mark_consumed` and `reflect()`.
+
+    By that point the approval is already consumed, so anything that raises
+    here loses a user-approved reflection and leaves only an error log. It must
+    therefore be TOTAL over every value the DB column can hold — and that
+    totality has to be tested directly, because reaching it through the log
+    line exercises almost none of it.
+    """
+
+    @staticmethod
+    def _ago(**kw):
+        from datetime import UTC, datetime, timedelta
+
+        return (datetime.now(UTC) - timedelta(**kw)).isoformat()
+
+    def test_minutes_under_an_hour(self):
+        from genesis.awareness.loop import _approval_age
+
+        assert _approval_age(self._ago(minutes=5, seconds=1)) == "5m ago"
+
+    def test_hours_and_minutes_are_zero_padded(self):
+        from genesis.awareness.loop import _approval_age
+
+        assert _approval_age(self._ago(hours=3, minutes=7, seconds=1)) == "3h07m ago"
+
+    def test_a_naive_timestamp_is_read_as_utc_and_does_not_raise(self):
+        """The branch that would actually RAISE. SQLite columns are text and
+        nothing guarantees an offset; subtracting a naive datetime from an
+        aware one is a TypeError, swallowed AFTER the approval was consumed."""
+        from datetime import UTC, datetime, timedelta
+
+        from genesis.awareness.loop import _approval_age
+
+        naive = (datetime.now(UTC) - timedelta(hours=1, seconds=1)).replace(tzinfo=None)
+        assert _approval_age(naive.isoformat()) == "1h00m ago"
+
+    def test_every_unusable_value_degrades_rather_than_raising(self):
+        from genesis.awareness.loop import _approval_age
+
+        for value in (None, "", "not-a-timestamp", 12345, [], {}):
+            assert _approval_age(value) == "age unknown", value
+
+    def test_a_future_timestamp_is_not_rendered_as_an_age(self):
+        """Clock skew between writer and reader is real; a negative age would
+        render as nonsense minutes."""
+        from genesis.awareness.loop import _approval_age
+
+        assert _approval_age(self._ago(hours=-1)) == "age unknown"


### PR DESCRIPTION
## The gap

When a user approves a reflection's gated CC fallback, the resume path dispatches it on a **later** tick, using `self._last_tick_result` — the current one. So what a person approved and what runs concern different moments.

The log said neither. It named only the approval id.

## What it says now

The approval, how long ago it was granted, the tick being run against, and — explicitly — that this is **not** the tick that requested it.

That last clause is the honest part rather than a hedge. The originating tick is genuinely unrecoverable: nothing writes it. The approval context is built from a fixed key set with no tick field, and the approval key deliberately excludes per-invocation identity so recurring dispatches reuse one pending row instead of minting a new approval every tick. Giving the line a real lineage would mean building a key-neutral carrier that does not exist today — so it states what is known, and what is not.

`CURRENT.md` records the same thing, including a warning against smuggling a tick id into `action_label` or `extra_context`, since both feed the approval key.

## Nothing under `autonomy/` is touched

`git diff origin/main -- src/genesis/autonomy/` is empty. Key derivation, the existing-approval lookup, both freshness checks and the consume are all unchanged. The new code only **reads** a column off an already-consumed row.

## Why a log line got this much care

It runs **after** `mark_consumed` and **before** `reflect()`, inside a broad `except Exception`. Anything raising there would consume a user-approved reflection, dispatch nothing, and leave only an error log. So the age helper is total over every value that column can hold — verified directly, not just through the log line.

## Review found two surviving mutants

Both now killed:

- **the entire age computation could be replaced by a constant** and the suite stayed green — the assertion matched the format literal `"(approved %s)"` rather than the value it renders
- **the tz-naive branch — the one that can actually raise** — was unreachable from every fixture, since all of them were aware, unparseable, or `None`

Seven mutants now, all killed. Also fixed: an `assert_awaited_once(), "msg"` that was a tuple expression and could never fail.

## Filed, not fixed here

- **The resume path's freshness filter admits approvals older than the 24 hours it documents.** It compares timestamp text whose two sides use different separators, so anything sharing the cutoff's calendar date compares greater regardless of time. Measured: 23h admitted (correct), 47h rejected (correct), **25h and 30h admitted** (not). Pre-existing, and this PR does not cause it — but it now *displays* the age, so the first operator to see `31h00m ago` would reasonably blame the log line. Bounded honestly: it widens a freshness window, it never admits an unapproved or already-consumed request.
- **This is the eleventh copy of the same relative-age helper**, and they disagree on timezone handling, fallback wording, and negative guarding — one would raise where the others degrade.

Neither belongs in a logging change.
