### PR TITLE
fix(skill): stop youtube-fetch losing transcript content silently

### DIFF
--- a/.claude/skills/youtube-fetch/SKILL.md
+++ b/.claude/skills/youtube-fetch/SKILL.md
@@ -30,26 +30,77 @@ content, SSL issues). yt-dlp is the reliable alternative.
    yt-dlp --skip-download --print '%(title)s|||%(uploader)s|||%(description)s' 'VIDEO_URL'
    ```
 
-3. Fetch the auto-generated transcript:
+3. Fetch the auto-generated transcript. Request **both** English tracks and prefer
+   `en-orig`:
+   ```bash
+   mkdir -p ~/tmp/yt-transcripts
+   yt-dlp --write-auto-sub --skip-download --sub-langs "en-orig,en" -o "$HOME/tmp/yt-transcripts/%(id)s" 'VIDEO_URL'
+   ls ~/tmp/yt-transcripts/ | grep VIDEO_ID
    ```
-   mkdir -p /tmp/yt-transcripts
-   yt-dlp --write-auto-sub --skip-download --sub-lang en -o '/tmp/yt-transcripts/%(id)s' 'VIDEO_URL'
-   ```
-   The transcript lands at `/tmp/yt-transcripts/VIDEO_ID.en.vtt`.
+   YouTube may serve two English auto-caption tracks — `en-orig` ("English
+   (Original)") and `en` ("English"). Usually they are the same resource. Observed
+   2026-09 on one video: the two were served with different cue segmentation, and the
+   closing lines differed in wording ("subscribe" vs "subscription") — that wording
+   difference is direct evidence of a different transcription. The same video served
+   byte-identical tracks hours later. Cause unknown; requesting both and preferring
+   `en-orig` costs one extra small download and is free insurance either way.
 
-4. Clean the VTT file into plain text (strip timestamps and tags):
+   `en-orig` exists only where the video's original audio is English. On a
+   foreign-language video there is no `en-orig`, and `en` is a machine TRANSLATION
+   with nothing in the file marking it as one. A requested track that does not exist
+   is skipped silently — check the `ls`, and see step 6 if nothing was written.
+
+4. Clean the VTT into plain text. Do the file-preference and the clean in **one**
+   Bash call — shell variables do not survive between calls:
+   ```bash
+   VID='VIDEO_ID'   # <- substitute the real 11-char video id
+   VTT="$HOME/tmp/yt-transcripts/$VID.en-orig.vtt"
+   [ -f "$VTT" ] || VTT="$HOME/tmp/yt-transcripts/$VID.en.vtt"
+   [ -f "$VTT" ] || { echo "no English VTT for $VID — see step 6" >&2; exit 1; }
+   sed 's/<[^>]*>//g;/^WEBVTT/d;/^Kind:/d;/^Language:/d;/^[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9]* -->/d;/^[[:space:]]*$/d' "$VTT" | awk '!seen[$0]++'
    ```
-   sed '/^WEBVTT/d;/^Kind:/d;/^Language:/d;/^[0-9][0-9]:[0-9][0-9]/d;/^$/d;s/<[^>]*>//g' /tmp/yt-transcripts/VIDEO_ID.en.vtt | awk '!seen[$0]++'
-   ```
+   Three details in that `sed`, each of which bit a previous version:
+
+   - The cue-header filter is anchored to the full `HH:MM:SS.mmm -->` shape, NOT a
+     bare `^[0-9][0-9]:[0-9][0-9]`. Because tag-stripping runs first, a loose pattern
+     sees stripped text and deletes real captions — measured: `<c>10:30</c> is the
+     deadline` becomes an empty line under the loose pattern and survives under this
+     one.
+   - `/^[[:space:]]*$/d`, not `/^$/d` — a VTT contains BOTH truly-empty lines (the
+     cue separator) and single-space lines (the first line of a cue's payload). The
+     plain form removes only the former, leaving one space-only line in the output
+     after the de-dupe.
+   - The `[ -f ]` guard matters: without it a missing VTT makes `sed` write one
+     stderr line while the pipeline still exits 0 (the status is `awk`'s), so the
+     failure looks like an empty transcript rather than an error.
+
+   The `awk` de-dupes the rolling caption lines. It is whole-FILE, not adjacent, so a
+   line genuinely repeated later in the talk is dropped too — and it is line-based, so
+   a phrase split across a cue boundary will not survive a `grep` of the result.
+   Flatten with `tr '\n' ' ' | tr -s ' '` before searching for phrases, and treat a
+   word-count delta between two tracks as suggestive only: different cue segmentation
+   changes what de-dupes, independently of content.
 
 5. If the transcript is too large to read at once, pipe through
    `head -N` / `tail -n +N` to read in chunks.
 
-6. If no English auto-subs are available, try without `--sub-lang`:
+6. If no English track was written, DO NOT just drop `--sub-langs` — omitting it
+   narrows the request to a single English-first track rather than broadening it
+   (measured: it writes one `en` file even when a dozen languages exist). List what
+   the video has, then request one language:
+   ```bash
+   # the listing runs to thousands of lines on a translated video — the real tracks
+   # are at the top, so cap it rather than dumping it into the session
+   yt-dlp --list-subs --skip-download 'VIDEO_URL' 2>&1 | head -45
+   yt-dlp --write-auto-sub --skip-download --sub-langs "<lang>" -o "$HOME/tmp/yt-transcripts/%(id)s" 'VIDEO_URL'
    ```
-   yt-dlp --write-auto-sub --skip-download -o '/tmp/yt-transcripts/%(id)s' 'VIDEO_URL'
-   ```
-   Then check `ls /tmp/yt-transcripts/VIDEO_ID.*.vtt` for available languages.
+   Pick from the **"Available automatic captions"** section — `--write-auto-sub` only
+   fetches those. For a track listed under "Available subtitles" (human/community),
+   swap in `--write-sub`. Then clean it with step 4, substituting your `<lang>` for
+   `en-orig`/`en` in the two `VTT=` lines.
+
+   Avoid `--sub-langs all`: it requests every translation pair the video exposes,
+   which is hundreds to thousands of tracks.
 
 7. If SSL errors occur, add `--no-check-certificate`.
 
@@ -74,7 +125,10 @@ Present results per video as:
 When multiple YouTube URLs are provided, run all metadata fetches in
 parallel (separate Bash calls in one message), then all transcript
 downloads in parallel. Process sequentially only if outputs depend on
-each other.
+each other. Note `--sub-langs "en-orig,en"` writes up to TWO files per
+video, and the `en-orig` preference in step 4 must be resolved PER VIDEO,
+inside the same Bash call that cleans that video — one shared `VTT`
+variable across a batch will clean the wrong file.
 
 ## Examples
 
@@ -92,6 +146,6 @@ transcript downloads in parallel, then clean and return.
 ### No Captions Available
 **Input:** A video with no auto-generated subtitles.
 
-**Action:** Report "No English auto-subs available for [title]" and
-list any other language VTT files found. Return metadata and
-description only.
+**Action:** Follow step 6 — list the available tracks, fetch one in a
+language you can work with, and clean it with step 4. Only if no usable
+track exists, report that and return metadata and description only.

--- a/.claude/skills/youtube-fetch/SKILL.md
+++ b/.claude/skills/youtube-fetch/SKILL.md
@@ -33,10 +33,17 @@ content, SSL issues). yt-dlp is the reliable alternative.
 3. Fetch the auto-generated transcript. Request **both** English tracks and prefer
    `en-orig`:
    ```bash
+   VID='VIDEO_ID'   # <- substitute the real 11-char video id
    mkdir -p ~/tmp/yt-transcripts
+   rm -f ~/tmp/yt-transcripts/"$VID".*.vtt        # drop any earlier run's files
    yt-dlp --write-auto-sub --skip-download --sub-langs "en-orig,en" -o "$HOME/tmp/yt-transcripts/%(id)s" 'VIDEO_URL'
-   ls ~/tmp/yt-transcripts/ | grep VIDEO_ID
+   ls ~/tmp/yt-transcripts/ | grep -F -- "$VID"
    ```
+   The `rm -f` is load-bearing, not tidiness: that directory persists across runs and
+   across videos, so a stale `$VID.en-orig.vtt` from an earlier fetch would satisfy
+   step 4's preference check even when THIS fetch failed or returned only `en` — you
+   would clean an old transcript and never see an error. `grep -F --` because a video
+   id may begin with `-`, which `grep` would otherwise read as options.
    YouTube may serve two English auto-caption tracks — `en-orig` ("English
    (Original)") and `en` ("English"). Usually they are the same resource. Observed
    2026-09 on one video: the two were served with different cue segmentation, and the
@@ -57,19 +64,23 @@ content, SSL issues). yt-dlp is the reliable alternative.
    VTT="$HOME/tmp/yt-transcripts/$VID.en-orig.vtt"
    [ -f "$VTT" ] || VTT="$HOME/tmp/yt-transcripts/$VID.en.vtt"
    [ -f "$VTT" ] || { echo "no English VTT for $VID — see step 6" >&2; exit 1; }
-   sed 's/<[^>]*>//g;/^WEBVTT/d;/^Kind:/d;/^Language:/d;/^[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9]* -->/d;/^[[:space:]]*$/d' "$VTT" | awk '!seen[$0]++'
+   sed '/^WEBVTT/d;/^Kind:/d;/^Language:/d;/^[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9]* -->/d;s/<[^>]*>//g;/^[[:space:]]*$/d' "$VTT" | awk '!seen[$0]++'
    ```
-   Three details in that `sed`, each of which bit a previous version:
+   The ORDER is the whole point, and each stage bit a previous version:
 
-   - The cue-header filter is anchored to the full `HH:MM:SS.mmm -->` shape, NOT a
-     bare `^[0-9][0-9]:[0-9][0-9]`. Because tag-stripping runs first, a loose pattern
-     sees stripped text and deletes real captions — measured: `<c>10:30</c> is the
-     deadline` becomes an empty line under the loose pattern and survives under this
-     one.
-   - `/^[[:space:]]*$/d`, not `/^$/d` — a VTT contains BOTH truly-empty lines (the
-     cue separator) and single-space lines (the first line of a cue's payload). The
-     plain form removes only the former, leaving one space-only line in the output
-     after the de-dupe.
+   - **Control-line deletes run FIRST, on raw text.** A real `WEBVTT`/`Kind:`/
+     `Language:`/cue-header line carries no tags, so on raw text those predicates are
+     unambiguous. Strip tags first and a genuine caption can be mistaken for a control
+     line and deleted — measured: `<c>Language: Python is the topic</c>` and
+     `<00:00:01.500><c>10:30</c> is the deadline` were both destroyed by a
+     strip-first ordering and both survive this one.
+   - The cue-header pattern is anchored to the full `HH:MM:SS.mmm -->` shape rather
+     than a bare `^[0-9][0-9]:[0-9][0-9]`, so a caption that merely starts with a
+     clock time is not eaten.
+   - **Tag-strip next, blank-delete LAST.** `/^[[:space:]]*$/d`, not `/^$/d` — a VTT
+     carries BOTH truly-empty lines (the cue separator) and single-space lines (the
+     first line of a cue payload); the plain form leaves the latter. Running it last
+     also collapses any line that became empty once its markup was stripped.
    - The `[ -f ]` guard matters: without it a missing VTT makes `sed` write one
      stderr line while the pipeline still exits 0 (the status is `awk`'s), so the
      failure looks like an empty transcript rather than an error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,20 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **YouTube transcripts are less likely to come back quietly incomplete.** When
+  Genesis fetches a video transcript it now asks for both English caption tracks and
+  prefers the original ASR (`en-orig`) over the `en` variant. Observed once: the two
+  were served as different transcriptions — different cue segmentation, and different
+  wording in the closing lines — while the same video served identical tracks hours
+  later. The cause is unknown and it did not reproduce, so this is insurance rather
+  than a diagnosed fix, but preferring `en-orig` costs only one extra small download.
+  Two real bugs fixed alongside it: the cleaning step left a stray whitespace-only
+  line in every transcript (a caption file carries both empty and single-space lines,
+  and the old filter matched only the empty ones), and the documented recovery path
+  for a video with no English captions could not work — dropping `--sub-langs`
+  narrows the request to one English-first track instead of broadening it, so it
+  could never surface the other languages it promised.
+
 - **The `deliberate` MCP tool ("Model Fusion") no longer fails on real prompts.** Two
   distinct bugs: (1) analysis mode 404'd because the orchestrator slug
   `openai/gpt-oss-120b:free` was retired from OpenRouter's catalog (`:free` variant gone)


### PR DESCRIPTION
## The problem

Three defects in the transcript path, two capable of losing content with **no signal** — the failure looks like a short transcript, not an error.

## Caption track

YouTube may serve two English auto-caption tracks: `en-orig` (raw ASR) and `en`. Observed once, the two were different transcriptions — different cue segmentation, and different wording in the closing lines ("subscribe" vs "subscription"). The same video served byte-identical tracks hours later and the cause did not reproduce, so this ships as **insurance, not a diagnosed fix**: request both, prefer `en-orig`, one extra small download. The prose says exactly that rather than asserting a mechanism.

## Cleaning step — two real bugs

`/^$/d` matched only truly-empty lines. A VTT carries **both** those (the cue separator) and single-space lines (the first line of each cue payload), so one whitespace-only line survived into every transcript. Now `/^[[:space:]]*$/d`.

More seriously, the cue-header filter is now anchored to the full `HH:MM:SS.mmm -->` shape. With tag-stripping running first, a loose `^[0-9][0-9]:[0-9][0-9]` sees stripped text and **deletes real captions** — measured, `<00:00:01.500><c>10:30</c> is the deadline` was destroyed and is preserved by the anchored form.

## Recovery path could not work

Step 6 told a session to drop `--sub-langs` to find non-English tracks. That **narrows** the request to a single English-first track rather than broadening it — measured: it wrote one `en` file on a video exposing five languages. Now `--list-subs` (capped, since it runs to thousands of lines on a translated video) then a specific language, with a note that `--write-auto-sub` serves only the automatic-captions section.

## Also

- The clean step exited **0** when the VTT was missing, because the status came from `awk` — a failure was indistinguishable from an empty transcript. Guarded.
- Preference and clean are one Bash call: shell state does not survive between calls.
- Scratch files moved off `/tmp` onto `~/tmp` per the temp-file policy, using `"$HOME/..."` because `~` does not expand inside quotes.

## Verification

Steps run **verbatim as separate Bash calls** (the real failure mode): 532 lines / 3782 words, 0 blank-or-whitespace lines, 0 cue headers leaked, all distinctive phrases present; the failure path exits 1 with a message.

## Note on the review trail

Three internal adversarial rounds. Two caught false claims of mine — I asserted the sed reorder removed 531 blank lines when both orderings are byte-identical (I had measured only the after-state, with no control), then fixed that with a *second* wrong mechanism. One reviewer remedy was rejected on measurement: `--sub-langs all` requests the full translation cross-product, hundreds to thousands of tracks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved YouTube transcript retrieval by checking both original and translated English caption tracks, with the original preferred.
  - Removed stale caption files before downloading new transcripts.
  - Removed duplicate, blank, timestamp, and unnecessary formatting lines while preserving valid caption text.
  - Improved recovery when English captions are unavailable by requesting alternative languages correctly.
  - Improved batch processing and no-caption handling for more reliable results.

- **Documentation**
  - Documented caption track differences, translation behavior, and alternative-language recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->