### PR TITLE
feat(hooks): merge-time migration-prefix gate — catch what a stale CI tick cannot

### DIFF
--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -4515,30 +4515,47 @@ def _pr_file_effects(
     created: list[str] = []
     removed: set[str] = set()
     for line in rows:
+        # The WHOLE row access sits inside the try, not just the parse: a null
+        # row or a missing "filename" raises past a parse-only guard, and those
+        # exceptions route to the two WRONG fail directions (audit BLOCKER,
+        # 2026-09-03 — AttributeError → run_guard exit 2 = every-merge outage;
+        # KeyError → main()'s catch = silent allow, gates after this skipped).
+        # The docstring promises None on any read failure; make it true.
         try:
             row = json.loads(line)
+            status = row.get("status", "added")
+            if status in _MIGRATION_CREATING_STATUSES:
+                created.append(row["filename"])
+            if status == "removed":
+                removed.add(row["filename"])
+            prev = row.get("previous_filename")
+            if status == "renamed" and prev:
+                removed.add(prev)
         except Exception:
             return None
-        status = row.get("status", "added")
-        if status in _MIGRATION_CREATING_STATUSES:
-            created.append(row["filename"])
-        if status == "removed":
-            removed.add(row["filename"])
-        prev = row.get("previous_filename")
-        if status == "renamed" and prev:
-            removed.add(prev)
     return created, removed
 
 
-def _default_branch_migrations(repo: str | None = None) -> list[str] | None:
-    """Migration PATHS on the repo's DEFAULT BRANCH (both namespaces), or None.
+def _target_branch_migrations(
+    repo: str | None = None, ref: str | None = None
+) -> list[str] | None:
+    """Migration PATHS on the branch this PR merges into (both namespaces).
 
-    Read live rather than from the local checkout: this gate's whole point is
-    that the merge base a CI run used has moved, so a local `origin/main` that
-    was last fetched at some other time answers the wrong question. Tests inject
-    via ``_TEST_GH_MAIN_MIGRATIONS`` (one entry per line — a bare basename means
-    the numbered dir, an entry containing ``/`` is a full path; the literal
-    ``__error__`` simulates an API error).
+    ``ref`` is the PR's base branch; None falls back to the repo default. Read
+    live rather than from the local checkout: this gate's whole point is that
+    the merge base a CI run used has moved, so a local ``origin/main`` fetched
+    at some other time answers the wrong question.
+
+    Filenames travel as JSON RECORDS, never trimmed scalars: ``strip()`` on a
+    legal-but-odd git filename (leading space, embedded newline) ALTERS the
+    identity before the runner's regex sees it, and could manufacture a
+    migration-looking record that blocks a merge on a collision that does not
+    exist (Codex P3, #1666 round 2). A name the runner would ignore must be
+    ignored here for the same reason, in its exact original bytes.
+
+    Tests inject via ``_TEST_GH_MAIN_MIGRATIONS`` (one entry per line — a bare
+    basename means the numbered dir, an entry containing ``/`` is a full path;
+    the literal ``__error__`` simulates an API error).
     """
     raw = os.environ.get("_TEST_GH_MAIN_MIGRATIONS")
     if raw == "__error__":
@@ -4551,7 +4568,7 @@ def _default_branch_migrations(repo: str | None = None) -> list[str] | None:
                 continue
             out.append(ln if "/" in ln else f"src/genesis/db/migrations/{ln}")
         return out
-    branch = _repo_default_branch(repo=repo)
+    branch = ref or _repo_default_branch(repo=repo)
     if not branch:
         return None
     paths: list[str] = []
@@ -4567,7 +4584,7 @@ def _default_branch_migrations(repo: str | None = None) -> list[str] | None:
                     "-f",
                     f"ref={branch}",
                     "--jq",
-                    '.[] | select(.type == "file") | .name',
+                    ".[] | {name: .name, type: .type}",
                 ],
                 capture_output=True,
                 text=True,
@@ -4575,25 +4592,70 @@ def _default_branch_migrations(repo: str | None = None) -> list[str] | None:
             )
             if result.returncode != 0:
                 return None
-            names = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+            rows = []
+            for ln in result.stdout.splitlines():
+                if not ln.strip():
+                    continue
+                try:
+                    rows.append(json.loads(ln))
+                except Exception:
+                    return None
             # The directory form of the contents API returns AT MOST 1,000
             # entries with no truncation marker (the Trees API is the >1k
-            # route). 94 files today; at the cap a full read and a clipped one
-            # are indistinguishable, so treat it as unreadable rather than
-            # report collisions from a listing that may have ended early.
-            if len(names) >= 1000:
+            # route). The cap check counts RAW rows, filtered client-side —
+            # a query-side type filter would hide non-file entries from the
+            # count and let a clipped read pass as complete, the exact class
+            # round 2 fixed in _pr_file_effects (audit SF4, 2026-09-03).
+            if len(rows) >= 1000:
                 return None
-            paths.extend(dir_prefix + n for n in names)
+            try:
+                paths.extend(
+                    dir_prefix + r["name"] for r in rows if r.get("type") == "file"
+                )
+            except Exception:
+                return None
         except Exception:
             return None
     return paths
 
 
+def _parse_open_pr_nodes(
+    nodes: list,
+    out: dict[str, list[str]],
+    short_read: list[str],
+    bases: dict[str, str | None],
+) -> None:
+    """Parse GraphQL PR nodes into claims/overflow/base maps. Raises on any
+    malformed element — the caller converts that to its documented None."""
+    for node in nodes:
+        num = str(node.get("number"))
+        bases[num] = node.get("baseRefName")
+        files = node.get("files") or {}
+        paths = [
+            f["path"]
+            for f in (files.get("nodes") or [])
+            if str(f.get("changeType", "ADDED")).lower() in _MIGRATION_CREATING_STATUSES
+        ]
+        # FULL PATHS, never basenames: the consumer re-derives claims by running
+        # these through `_migration_prefix_claims`, which is anchored on the
+        # directory — a basename matches nothing there, and every cross-PR
+        # collision silently vanishes. That exact live regression shipped once
+        # while 41 seam-fed unit tests stayed green (the seams normalize to full
+        # paths; the live path did not), and only the live acceptance replay
+        # caught it. The contract test that pins this feeds THIS function's real
+        # output into the consumer.
+        mig_paths = sorted(p for p in paths if _migration_prefix_claims([p]))
+        if mig_paths:
+            out[num] = mig_paths
+        if (files.get("pageInfo") or {}).get("hasNextPage"):
+            short_read.append(num)
+
+
 def _open_pr_migrations(
     repo: str | None = None,
-) -> tuple[dict[str, list[str]], list[str], bool] | None:
-    """``({pr_number: [migration paths]}, [unresolved pr numbers], pr_list_truncated)``,
-    or None on any read failure.
+) -> tuple[dict[str, list[str]], list[str], bool, dict[str, str | None]] | None:
+    """``({pr_number: [migration paths]}, [unresolved pr numbers], pr_list_truncated,
+    {pr_number: baseRefName})``, or None on any read failure.
 
     ONE GraphQL request for every open PR (measured 3.4s for 48 PRs — a
     per-PR REST walk of the same set took ~40s, well past the merge gate's
@@ -4622,6 +4684,9 @@ def _open_pr_migrations(
                 prs,
                 [str(n) for n in payload.get("truncated", [])],
                 bool(payload.get("pr_list_truncated", False)),
+                # Absent per-PR bases (older fixtures) read as None = "assume
+                # the same target", preserving pre-baseRefName behavior.
+                {str(k): v for k, v in payload.get("bases", {}).items()},
             )
         except Exception:
             return None
@@ -4632,7 +4697,7 @@ def _open_pr_migrations(
     query = (
         "query($owner:String!,$name:String!){repository(owner:$owner,name:$name)"
         "{pullRequests(states:OPEN,first:100){pageInfo{hasNextPage} nodes{number "
-        "files(first:100){pageInfo{hasNextPage} nodes{path changeType}}}}}}"
+        "baseRefName files(first:100){pageInfo{hasNextPage} nodes{path changeType}}}}}}"
     )
     try:
         result = subprocess.run(
@@ -4655,27 +4720,16 @@ def _open_pr_migrations(
         return None
     out: dict[str, list[str]] = {}
     short_read: list[str] = []
-    for node in nodes:
-        num = str(node.get("number"))
-        files = node.get("files") or {}
-        paths = [
-            f["path"]
-            for f in (files.get("nodes") or [])
-            if str(f.get("changeType", "ADDED")).lower() in _MIGRATION_CREATING_STATUSES
-        ]
-        # FULL PATHS, never basenames: the consumer re-derives claims by running
-        # these through `_migration_prefix_claims`, which is anchored on the
-        # directory — a basename matches nothing there, and every cross-PR
-        # collision silently vanishes. That exact live regression shipped once
-        # while 41 seam-fed unit tests stayed green (the seams normalize to full
-        # paths; the live path did not), and only the live acceptance replay
-        # caught it. The contract test that pins this feeds THIS function's real
-        # output into the consumer.
-        mig_paths = sorted(p for p in paths if _migration_prefix_claims([p]))
-        if mig_paths:
-            out[num] = mig_paths
-        if (files.get("pageInfo") or {}).get("hasNextPage"):
-            short_read.append(num)
+    bases: dict[str, str | None] = {}
+    try:
+        _parse_open_pr_nodes(nodes, out, short_read, bases)
+    except Exception:
+        # Docstring contract: None on ANY read failure. A null node or a null
+        # files element raises AttributeError, which would otherwise reach
+        # run_guard's fail-closed exit 2 — a repo-wide every-merge outage from
+        # one malformed element among 100 open PRs, on the one gate designed
+        # to degrade OPEN (audit BLOCKER, 2026-09-03; raises measured).
+        return None
     # RESOLVE the short reads rather than merely reporting them. A standing
     # "could not see PR #X" caveat on every other PR is noise that trains a
     # reader to skip the line, and it leaves a real blind spot open: the PR whose
@@ -4697,7 +4751,12 @@ def _open_pr_migrations(
             unresolved.extend(short_read[i:])
             break
         effects = _pr_file_effects(num, repo=repo)
-        if effects is None:
+        if effects is None or (not effects[0] and not effects[1]):
+            # A >100-file PR (that is WHY we are refetching) cannot have an
+            # empty file list — a zero-row rc-0 read is not a possible answer,
+            # so it goes to UNRESOLVED, never to clean. The sibling listing arm
+            # applies the same empty-when-impossible contract (audit SF3,
+            # 2026-09-03: the old code resolved the truncation caveat as clean).
             unresolved.append(num)
             continue
         # Same full-path contract as the sweep above. Only the CREATED side
@@ -4708,20 +4767,23 @@ def _open_pr_migrations(
             out[num] = mig_paths
         else:
             out.pop(num, None)
-    return out, unresolved, pr_list_truncated
+    return out, unresolved, pr_list_truncated, bases
 
 
 def _ci_freshness_note(pr_num: str, repo: str | None = None) -> str | None:
     """ADVISORY note when NO check on the PR's head STARTED after the current
     default-branch head landed — i.e. every run tested a main that has moved.
 
-    STARTED, not completed (Codex P2, #1666): a check's merge-ref snapshot is
-    taken when the run is created, so ``completed_at`` proves nothing about
-    WHICH main was tested — a slow run finishing after main moved still tested
-    the old merge ref, and its late completion would suppress this note in
-    exactly the stale case it exists to expose. ``max(started_at)`` is the
-    faithful cheap proxy; the residual (a run created in the seconds between
-    snapshot and main's commit) is accepted for an advisory.
+    Keyed on check-suite ``created_at`` — the event that SELECTS the merge-ref
+    snapshot. Two per-run timestamps failed here first, same class both times
+    (a per-run field standing in for snapshot identity): ``completed_at``
+    (a slow run finishing after main moved still tested the old ref) and then
+    ``started_at`` (a queued run STARTS long after its snapshot was taken —
+    this repo documents 50-75 minute runner queues in codeql.yml). Suite
+    creation happens at trigger time, before any queueing, so
+    ``max(created_at)`` is the faithful time for "newest snapshot"; the
+    residual (a suite created in the seconds before main's commit) is accepted
+    for an advisory.
 
     Deliberately NOT a gate. Measured 2026-09-03, 30 of 48 open PRs were in this
     state (oldest tick six weeks old), so blocking would refuse most of the queue
@@ -4735,10 +4797,13 @@ def _ci_freshness_note(pr_num: str, repo: str | None = None) -> str | None:
     Returns None when either side is unreadable: no note beats a wrong note, and
     a hedge printed on every PR is indistinguishable from a finding on every PR.
     """
-    raw_check = os.environ.get("_TEST_GH_CI_NEWEST_START")
+    raw_check = os.environ.get("_TEST_GH_CI_NEWEST_SNAPSHOT")
     raw_main = os.environ.get("_TEST_GH_DEFAULT_HEAD_DATE")
     if raw_check is None or raw_main is None:
-        branch = _repo_default_branch(repo=repo)
+        # The PR's ACTUAL base where readable (audit NOTE 5): a stacked PR's
+        # CI ran against its parent, and keying the note to main's movement is
+        # wrong in both directions there. Default branch as fallback.
+        branch = _pr_base_ref(pr_num, repo=repo) or _repo_default_branch(repo=repo)
         head_sha = _pr_head_sha(pr_num, repo=repo)
         if not branch or not head_sha:
             return None
@@ -4750,12 +4815,12 @@ def _ci_freshness_note(pr_num: str, repo: str | None = None) -> str | None:
                 # "stale" note the day the count crosses the page size
                 # (architect SHOULD-FIX 8). With --paginate each page is its own
                 # JSON document, so per-page jq output is concatenated lines and
-                # the aggregate must happen client-side. started_at, not
-                # completed_at — see the docstring.
+                # the aggregate must happen client-side. Suite created_at,
+                # not any per-run timestamp — see the docstring.
                 stamps = subprocess.run(
-                    ["gh", "api", f"repos/{repo or ':owner/:repo'}/commits/{head_sha}/check-runs",
+                    ["gh", "api", f"repos/{repo or ':owner/:repo'}/commits/{head_sha}/check-suites",
                      "--paginate",
-                     "--jq", ".check_runs[]|select(.started_at != null)|.started_at"],
+                     "--jq", ".check_suites[]|select(.created_at != null)|.created_at"],
                     capture_output=True, text=True, timeout=_gh_timeout(8),
                 ).stdout.split()
                 raw_check = max(stamps) if stamps else ""
@@ -4784,9 +4849,10 @@ def _ci_freshness_note(pr_num: str, repo: str | None = None) -> str | None:
     except Exception:
         return None
     return (
-        f"NOTE: the newest check on this head STARTED {raw_check}, before the "
-        f"default branch moved at {raw_main} — this PR's checks ran against a "
-        "DIFFERENT main. CI re-runs only on a push, so whatever they concluded "
+        f"NOTE: the newest CI snapshot of this head was taken {raw_check} "
+        "(check-suite created), before the "
+        f"target branch moved at {raw_main} — this PR's checks ran against a "
+        "DIFFERENT base. CI re-runs only on a push, so whatever they concluded "
         "does not describe a merge today."
     )
 
@@ -4829,7 +4895,7 @@ def _check_migration_prefixes(
     if not mine:
         return False, "ok (no migrations in this PR)"
 
-    problems: list[str] = []
+    problems: list[tuple[str, str]] = []
     caveats: list[str] = []
 
     # A SELF-collision — one PR adding two files under one prefix — is the
@@ -4837,11 +4903,35 @@ def _check_migration_prefixes(
     # OTHER sources is structurally blind to it (architect SHOULD-FIX 6).
     for prefix, names in sorted(mine.items()):
         if len(names) > 1:
-            problems.append(f"  {prefix}: this PR itself adds {' and '.join(sorted(names))}")
+            problems.append(
+                (prefix, f"  {prefix}: this PR itself adds {' and '.join(sorted(names))}")
+            )
 
-    on_main = _default_branch_migrations(repo=repo)
+    # Compare against the branch this PR ACTUALLY merges into. For the
+    # default-base majority this is the default branch; for the deliberately
+    # supported stacked path it is the parent branch, where a parent's
+    # deletions and additions are both visible (Codex P2, #1666 round 2).
+    # Unreadable base ref → default branch (today's behavior), and the label
+    # keeps the message honest either way. Reuses the EXISTING _pr_base_ref
+    # (seam _TEST_GH_BASE_REF) — a first draft added a second one, which
+    # SHADOWED the original and silently swapped the seam under the
+    # base-is-default gate; one gh interaction, one helper, one seam.
+    base_ref = _pr_base_ref(pr_num, repo=repo)
+    non_default_base = False
+    if base_ref:
+        # Default-branch resolution only when there IS a base to compare it to —
+        # an unconditional call would put a live gh read on every invocation
+        # (and every unit test) for a fact only the stacked minority needs.
+        default_ref = _repo_default_branch(repo=repo)
+        non_default_base = bool(default_ref and base_ref != default_ref)
+    target_label = (
+        f"the base branch '{base_ref}'" if non_default_base else "the default branch"
+    )
+    on_main = _target_branch_migrations(
+        repo=repo, ref=base_ref if non_default_base else None
+    )
     if on_main is None:
-        caveats.append("could not read the default branch's migrations")
+        caveats.append(f"could not read {target_label}'s migrations")
     elif not on_main:
         # 90+ migrations exist on main today, so an EMPTY successful listing is
         # not a possible answer — it means the read did not describe the
@@ -4849,7 +4939,7 @@ def _check_migration_prefixes(
         # it would be the seen-nothing-reported-no-problem failure (architect
         # SHOULD-FIX 4).
         caveats.append(
-            "the default branch's migration listing came back EMPTY — not a "
+            f"{target_label}'s migration listing came back EMPTY — not a "
             "possible state, so the read did not describe the directory"
         )
     else:
@@ -4873,20 +4963,32 @@ def _check_migration_prefixes(
                     # refuses a PR that adds nothing.
                     if other != basename:
                         problems.append(
-                            f"  {prefix}: this PR adds {basename}, but the default "
-                            f"branch already has {other}"
+                            (
+                                prefix,
+                                f"  {prefix}: this PR adds {basename}, but "
+                                f"{target_label} already has {other}",
+                            )
                         )
 
     others = _open_pr_migrations(repo=repo)
     if others is None:
         caveats.append("could not read other open PRs' migrations")
     else:
-        by_pr, unresolved, pr_list_truncated = others
+        by_pr, unresolved, pr_list_truncated, other_bases = others
         for other_pr, other_paths in sorted(by_pr.items()):
             # Exclude by PR NUMBER, not by filename: excluding "the file I also
             # have" would silence a real collision whenever two PRs add the
             # same basename.
             if str(other_pr) == str(pr_num):
+                continue
+            # Same-TARGET PRs only (Codex P2, #1666 round 2): two PRs adding
+            # one prefix collide iff they merge into the same branch. A stacked
+            # child and an unrelated main-bound PR share no target tree, and
+            # comparing them manufactures a collision that no merge order
+            # produces. An unknown base on either side compares anyway — the
+            # conservative direction for the default-base majority.
+            other_base = other_bases.get(str(other_pr))
+            if base_ref and other_base and other_base != base_ref:
                 continue
             other_claims = _migration_prefix_claims(other_paths)
             for prefix, names in sorted(mine.items()):
@@ -4898,9 +5000,21 @@ def _check_migration_prefixes(
                 # prefix (and a conflict on the path).
                 for clash in other_claims.get(prefix, []):
                     problems.append(
-                        f"  {prefix}: this PR adds {' and '.join(sorted(names))}, "
-                        f"and open PR #{other_pr} adds {clash}"
+                        (
+                            prefix,
+                            f"  {prefix}: this PR adds {' and '.join(sorted(names))}, "
+                            f"and open PR #{other_pr} adds {clash}",
+                        )
                     )
+        if not base_ref and any(other_bases.values()):
+            # Comparing against ALL open PRs because THIS PR's base could not
+            # be read is the conservative direction — but a block built on it
+            # must say so, or a plumbing failure wears the grammar of a
+            # definite fact (audit NOTE 8).
+            caveats.append(
+                "this PR's base branch was unreadable — compared against every "
+                "open PR's target"
+            )
         live_truncation = [n for n in unresolved if str(n) != str(pr_num)]
         if live_truncation:
             caveats.append(
@@ -4920,8 +5034,12 @@ def _check_migration_prefixes(
         # the numbered runner raises pre-flight and ABORTS BOOTSTRAP on every
         # install; the data runner catches its duplicate post-boot and skips
         # ONLY the data-migration batch while the server runs on.
-        numbered_hit = any(not ln.strip().startswith("d") for ln in problems)
-        data_hit = any(ln.strip().startswith("d") for ln in problems)
+        # Classified on the PREFIX carried with each line, never re-derived
+        # from the rendered string — a text-shape proxy for identity silently
+        # misclassifies the headline the day a line's format changes (audit
+        # NOTE 6; same class as the timestamp proxies, in miniature).
+        numbered_hit = any(not pfx.startswith("d") for pfx, _ in problems)
+        data_hit = any(pfx.startswith("d") for pfx, _ in problems)
         consequences = []
         if numbered_hit:
             consequences.append(
@@ -4941,7 +5059,7 @@ def _check_migration_prefixes(
             + "; ".join(consequences)
             + "."
         )
-        body = "\n".join(problems)
+        body = "\n".join(line for _, line in problems)
         tail = ("\n  caveat: " + "; ".join(caveats)) if caveats else ""
         return True, f"{head}\n{body}{tail}"
     n_files = sum(len(v) for v in mine.values())
@@ -4951,7 +5069,7 @@ def _check_migration_prefixes(
         # report-is-an-inventory rule names: it hides a true fact (the default
         # branch WAS cleanly checked) behind a single pessimistic label, and a
         # line that always reads the same trains a reader to skip it.
-        checked = "the default branch" if on_main else None
+        checked = target_label if on_main else None
         prefix = (
             f"NOTE: {n_files} migration(s) — no collision with {checked}, but "
             if checked

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -108,6 +108,7 @@ import shlex
 import subprocess
 import sys
 import time
+from datetime import datetime
 
 # Self-locate so `from hook_input import …` resolves both when CC runs this as a
 # script (sys.path[0] is this dir) AND when it is imported as a module for tests
@@ -4402,6 +4403,493 @@ def _check_base_is_default(
     return False, ""
 
 
+#: The migration namespaces, each with its prefix pattern DERIVED FROM ITS
+#: RUNNER's own discovery regex (db/migrations/runner.py `^(\d{4})_\w+\.py$`;
+#: db/data_migrations/runner.py `^(d\d{4})_\w+\.py$`) — both runners raise on a
+#: duplicate prefix, and BOTH were unguarded cross-PR (CI's migration-check
+#: covers only the numbered dir). Anchored to the directory itself: nested
+#: paths, `runner.py` and `__init__.py` are not migrations, and a name the
+#: runner would silently SKIP (a dash, a dot — `\w+` rejects them) must not be
+#: claimed here either, or the gate blocks on a file that can never collide at
+#: runtime. The `d` prefix keeps the two namespaces' keys disjoint by
+#: construction, so they can never cross-collide in one claims dict.
+_MIGRATION_DIRS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("src/genesis/db/migrations/", re.compile(r"^(\d{4})_\w+\.py$")),
+    ("src/genesis/db/data_migrations/", re.compile(r"^(d\d{4})_\w+\.py$")),
+)
+
+#: How many overflowing PR file-lists to re-fetch individually (one paginated
+#: call each) before giving up and REPORTING the rest as unseen. Bounds the
+#: gate's wall-clock on a queue where many PRs overflow at once; measured
+#: 2026-09-03, 1 of 48 open PRs overflowed, so the cap is slack today and
+#: exists so a pathological queue degrades loudly instead of stalling the merge.
+_MIGRATION_TRUNCATION_REFETCH_CAP = 2
+
+#: File statuses that CREATE a path (and so claim its prefix). "modified",
+#: "removed" and "changed" touch a file that already exists on some base — a PR
+#: that merely edits an existing migration claims nothing, and treating every
+#: touched path as an addition is how two PRs that both patch one old migration
+#: would have hard-blocked each other with no override (architect BLOCKER 2).
+_MIGRATION_CREATING_STATUSES = frozenset({"added", "renamed", "copied"})
+
+
+def _migration_prefix_claims(paths: list[str]) -> dict[str, list[str]]:
+    """``{prefix: [basenames]}`` for the migration files among ``paths``.
+
+    Basenames are LISTS, not a single value: a PR adding TWO files under one
+    prefix is the exact state the runners raise on, and a last-write-wins dict
+    was structurally blind to that self-collision. Values are named files
+    because every message this gate prints names the colliding FILES, not just
+    the number — "0090 collides" leaves the reader to go and find what it
+    collides with, which is the whole diagnosis.
+    """
+    claims: dict[str, list[str]] = {}
+    for path in paths:
+        for dir_prefix, pattern in _MIGRATION_DIRS:
+            if not path.startswith(dir_prefix):
+                continue
+            basename = path[len(dir_prefix):]
+            m = pattern.match(basename)
+            if m:
+                claims.setdefault(m.group(1), []).append(basename)
+    return claims
+
+
+def _pr_added_files(pr_num: str, repo: str | None = None) -> list[str] | None:
+    """Filenames this PR CREATES (status added/renamed/copied), or None.
+
+    Distinct from ``_pr_changed_files``, which deliberately includes every
+    touched path plus rename SOURCES — right for the hook-surface fence (a
+    guard renamed away is a hook change), wrong here (a modified migration is
+    not a new prefix claim). Shares the ``_TEST_GH_PR_FILES`` seam; a seam
+    entry's optional ``status`` defaults to "added" so existing fixtures keep
+    their meaning.
+    """
+    raw = os.environ.get("_TEST_GH_PR_FILES")
+    if raw == "__error__":
+        return None
+    if raw is not None:
+        out = []
+        for line in raw.splitlines():
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except Exception:
+                return None
+            if row.get("status", "added") in _MIGRATION_CREATING_STATUSES:
+                out.append(row["filename"])
+        return out
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo or ':owner/:repo'}/pulls/{pr_num}/files",
+                "--paginate",
+                "--jq",
+                '.[] | select(.status == "added" or .status == "renamed" or '
+                '.status == "copied") | .filename',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_gh_timeout(8),
+        )
+        if result.returncode != 0:
+            return None
+        return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+    except Exception:
+        return None
+
+
+def _default_branch_migrations(repo: str | None = None) -> list[str] | None:
+    """Migration PATHS on the repo's DEFAULT BRANCH (both namespaces), or None.
+
+    Read live rather than from the local checkout: this gate's whole point is
+    that the merge base a CI run used has moved, so a local `origin/main` that
+    was last fetched at some other time answers the wrong question. Tests inject
+    via ``_TEST_GH_MAIN_MIGRATIONS`` (one entry per line — a bare basename means
+    the numbered dir, an entry containing ``/`` is a full path; the literal
+    ``__error__`` simulates an API error).
+    """
+    raw = os.environ.get("_TEST_GH_MAIN_MIGRATIONS")
+    if raw == "__error__":
+        return None
+    if raw is not None:
+        out = []
+        for ln in raw.splitlines():
+            ln = ln.strip()
+            if not ln:
+                continue
+            out.append(ln if "/" in ln else f"src/genesis/db/migrations/{ln}")
+        return out
+    branch = _repo_default_branch(repo=repo)
+    if not branch:
+        return None
+    paths: list[str] = []
+    for dir_prefix, _pattern in _MIGRATION_DIRS:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo or ':owner/:repo'}/contents/{dir_prefix.rstrip('/')}",
+                    "-X",
+                    "GET",
+                    "-f",
+                    f"ref={branch}",
+                    "--jq",
+                    '.[] | select(.type == "file") | .name',
+                ],
+                capture_output=True,
+                text=True,
+                timeout=_gh_timeout(8),
+            )
+            if result.returncode != 0:
+                return None
+            names = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+            # The directory form of the contents API returns AT MOST 1,000
+            # entries with no truncation marker (the Trees API is the >1k
+            # route). 94 files today; at the cap a full read and a clipped one
+            # are indistinguishable, so treat it as unreadable rather than
+            # report collisions from a listing that may have ended early.
+            if len(names) >= 1000:
+                return None
+            paths.extend(dir_prefix + n for n in names)
+        except Exception:
+            return None
+    return paths
+
+
+def _open_pr_migrations(
+    repo: str | None = None,
+) -> tuple[dict[str, list[str]], list[str], bool] | None:
+    """``({pr_number: [migration paths]}, [unresolved pr numbers], pr_list_truncated)``,
+    or None on any read failure.
+
+    ONE GraphQL request for every open PR (measured 3.4s for 48 PRs — a
+    per-PR REST walk of the same set took ~40s, well past the merge gate's
+    wall-clock budget). Only files whose ``changeType`` CREATES a path are
+    claims — a PR that merely edits an existing migration claims nothing.
+
+    The second and third elements are the honest half. GraphQL caps BOTH the
+    file list per PR and the PR list itself at 100, and a capped read is
+    indistinguishable from a short one: #1541 hit the file cap live while
+    carrying colliding migrations, and the docstring that said "every open PR"
+    was false the day the queue crossed 100 (architect SHOULD-FIX 3). Truncated
+    reads are RESOLVED where cheap and REPORTED where not — never silently
+    treated as complete. Tests inject via ``_TEST_GH_OPEN_PR_MIGRATIONS``.
+    """
+    raw = os.environ.get("_TEST_GH_OPEN_PR_MIGRATIONS")
+    if raw == "__error__":
+        return None
+    if raw is not None:
+        try:
+            payload = json.loads(raw)
+            prs = {
+                str(k): [v if "/" in v else f"src/genesis/db/migrations/{v}" for v in vs]
+                for k, vs in payload.get("prs", {}).items()
+            }
+            return (
+                prs,
+                [str(n) for n in payload.get("truncated", [])],
+                bool(payload.get("pr_list_truncated", False)),
+            )
+        except Exception:
+            return None
+    owner_name = repo or _derive_repo_from_cwd(os.getcwd()) or ""
+    if "/" not in owner_name:
+        return None
+    owner, name = owner_name.split("/", 1)
+    query = (
+        "query($owner:String!,$name:String!){repository(owner:$owner,name:$name)"
+        "{pullRequests(states:OPEN,first:100){pageInfo{hasNextPage} nodes{number "
+        "files(first:100){pageInfo{hasNextPage} nodes{path changeType}}}}}}"
+    )
+    try:
+        result = subprocess.run(
+            [
+                "gh", "api", "graphql",
+                "-f", f"query={query}",
+                "-F", f"owner={owner}",
+                "-F", f"name={name}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_gh_timeout(8),
+        )
+        if result.returncode != 0:
+            return None
+        prs_conn = json.loads(result.stdout)["data"]["repository"]["pullRequests"]
+        nodes = prs_conn["nodes"]
+        pr_list_truncated = bool((prs_conn.get("pageInfo") or {}).get("hasNextPage"))
+    except Exception:
+        return None
+    out: dict[str, list[str]] = {}
+    short_read: list[str] = []
+    for node in nodes:
+        num = str(node.get("number"))
+        files = node.get("files") or {}
+        paths = [
+            f["path"]
+            for f in (files.get("nodes") or [])
+            if str(f.get("changeType", "ADDED")).lower() in _MIGRATION_CREATING_STATUSES
+        ]
+        # FULL PATHS, never basenames: the consumer re-derives claims by running
+        # these through `_migration_prefix_claims`, which is anchored on the
+        # directory — a basename matches nothing there, and every cross-PR
+        # collision silently vanishes. That exact live regression shipped once
+        # while 41 seam-fed unit tests stayed green (the seams normalize to full
+        # paths; the live path did not), and only the live acceptance replay
+        # caught it. The contract test that pins this feeds THIS function's real
+        # output into the consumer.
+        mig_paths = sorted(p for p in paths if _migration_prefix_claims([p]))
+        if mig_paths:
+            out[num] = mig_paths
+        if (files.get("pageInfo") or {}).get("hasNextPage"):
+            short_read.append(num)
+    # RESOLVE the short reads rather than merely reporting them. A standing
+    # "could not see PR #X" caveat on every other PR is noise that trains a
+    # reader to skip the line, and it leaves a real blind spot open: the PR whose
+    # list overflows is exactly the long-lived branch most likely to carry an
+    # old prefix. One paginated call per overflow closes it (measured
+    # 2026-09-03: 1 of 48 open PRs overflowed).
+    unresolved: list[str] = []
+    for i, num in enumerate(short_read):
+        # Bounded in BOTH dimensions: the refetch cap, and the shared merge
+        # deadline — this loop was the one multi-call loop on the merge path
+        # with no inter-iteration deadline check (architect BLOCKER 1), and a
+        # drained budget here starves nothing downstream only because the gate
+        # runs LAST; the check keeps it from spinning uselessly regardless.
+        if i >= _MIGRATION_TRUNCATION_REFETCH_CAP or (
+            _merge_deadline is not None and time.monotonic() >= _merge_deadline
+        ):
+            # NEVER a silent cap: anything past the budget is reported as
+            # unseen, so a bounded scan can't read as a complete one.
+            unresolved.extend(short_read[i:])
+            break
+        full = _pr_added_files(num, repo=repo)
+        if full is None:
+            unresolved.append(num)
+            continue
+        # Same full-path contract as the sweep above.
+        mig_paths = sorted(p for p in full if _migration_prefix_claims([p]))
+        if mig_paths:
+            out[num] = mig_paths
+        else:
+            out.pop(num, None)
+    return out, unresolved, pr_list_truncated
+
+
+def _ci_freshness_note(pr_num: str, repo: str | None = None) -> str | None:
+    """ADVISORY note when the PR's newest completed check predates the current
+    default-branch head — i.e. its green tick describes a main that has moved.
+
+    Deliberately NOT a gate. Measured 2026-09-03, 30 of 48 open PRs were in this
+    state (oldest tick six weeks old), so blocking would refuse most of the queue
+    for a condition nearly all of it shares; and the remedy — re-run every PR's
+    CI against current main — is a throughput decision the owner makes globally,
+    not one a gate should force one PR at a time. It is a note precisely because
+    the *specific* consequence worth blocking on (a prefix collision) now has its
+    own gate above; what is left here is the residual "tests were green against
+    different code", which is real but not mechanically decidable.
+
+    Returns None when either side is unreadable: no note beats a wrong note, and
+    a hedge printed on every PR is indistinguishable from a finding on every PR.
+    """
+    raw_check = os.environ.get("_TEST_GH_CI_COMPLETED_AT")
+    raw_main = os.environ.get("_TEST_GH_DEFAULT_HEAD_DATE")
+    if raw_check is None or raw_main is None:
+        branch = _repo_default_branch(repo=repo)
+        head_sha = _pr_head_sha(pr_num, repo=repo)
+        if not branch or not head_sha:
+            return None
+        try:
+            if raw_check is None:
+                # --paginate + max() HERE, not `max` in jq: the endpoint pages at
+                # 30 and this repo's heads carry 16+ check runs today — a
+                # first-page max UNDERSTATES the newest completion and emits a
+                # false "stale" note the day the count crosses the page size
+                # (architect SHOULD-FIX 8). With --paginate each page is its own
+                # JSON document, so per-page jq output is concatenated lines and
+                # the aggregate must happen client-side.
+                stamps = subprocess.run(
+                    ["gh", "api", f"repos/{repo or ':owner/:repo'}/commits/{head_sha}/check-runs",
+                     "--paginate",
+                     "--jq", ".check_runs[]|select(.completed_at != null)|.completed_at"],
+                    capture_output=True, text=True, timeout=_gh_timeout(8),
+                ).stdout.split()
+                raw_check = max(stamps) if stamps else ""
+            if raw_main is None:
+                raw_main = subprocess.run(
+                    ["gh", "api", f"repos/{repo or ':owner/:repo'}/commits/{branch}",
+                     "--jq", ".commit.committer.date"],
+                    capture_output=True, text=True, timeout=_gh_timeout(8),
+                ).stdout.strip()
+        except Exception:
+            return None
+    if raw_check in (None, "", "null", "__error__") or raw_main in (None, "", "null", "__error__"):
+        return None
+    try:
+        # PARSED, never lexical: the checks API returns `Z` and the commit API a
+        # numeric offset, so a string compare puts 21:43:17Z before its own
+        # equivalent 17:43:17-04:00 — the same instant, opposite answer. The
+        # COMPARISON sits inside the try as well: comparing a naive stamp to an
+        # aware one raises TypeError, and out here that aborts the whole report
+        # mid-print — a partial report that looks structurally complete
+        # (architect SHOULD-FIX 9). An advisory that cannot decide says nothing.
+        checked = datetime.fromisoformat(raw_check.replace("Z", "+00:00"))
+        main_at = datetime.fromisoformat(raw_main.replace("Z", "+00:00"))
+        if checked >= main_at:
+            return None
+    except Exception:
+        return None
+    return (
+        f"NOTE: CI last completed {raw_check} but the default branch moved at "
+        f"{raw_main} — this PR's checks ran against a DIFFERENT main. "
+        "CI re-runs only on a push, so whatever they concluded does not describe "
+        "a merge today."
+    )
+
+
+def _check_migration_prefixes(
+    pr_num: str, repo: str | None = None
+) -> tuple[bool, str]:
+    """Block when this PR's migration prefixes collide with the default branch
+    or with another OPEN PR.
+
+    CI's `migration-check` already rejects duplicates, but against the merge
+    preview AT ONE MOMENT. Two modes survive that and were both live on
+    2026-09-03: a green tick that went stale when main grew a colliding
+    migration hours later (#1541), and two PRs adding differently-NAMED files
+    under one prefix, each individually clean and colliding only once both
+    merge (#1610 vs #1616). `migrations/runner.py` raises on a duplicate prefix
+    BEFORE running anything, so the cost is every migration on every install
+    halted at next restart.
+
+    Blocks only on a DEFINITE collision. Every plumbing failure — unreadable
+    listing, malformed payload, an unresolved truncation — passes with the
+    limitation stated, because walling off every merge over an auxiliary check
+    is worse than the failure it prevents.
+    """
+    # One repo resolution for every read below — the helpers' individual
+    # fallbacks (gh's `:owner/:repo` vs `_derive_repo_from_cwd`) can disagree
+    # when `repo` is None, and a gate comparing two repos' listings answers a
+    # question nobody asked (architect NOTE 12).
+    repo = repo or _derive_repo_from_cwd(os.getcwd())
+    # ADDED files only — a PR that merely edits or deletes an existing
+    # migration claims no prefix (architect BLOCKER 2: reading every touched
+    # path as an addition hard-blocked two PRs that both patched one old
+    # migration, with no override).
+    added = _pr_added_files(pr_num, repo=repo)
+    if added is None:
+        return False, "NOTE: could not read the PR's file list — prefixes unverified."
+    mine = _migration_prefix_claims(added)
+    if not mine:
+        return False, "ok (no migrations in this PR)"
+
+    problems: list[str] = []
+    caveats: list[str] = []
+
+    # A SELF-collision — one PR adding two files under one prefix — is the
+    # exact state the runners raise on, and a scan that only compares against
+    # OTHER sources is structurally blind to it (architect SHOULD-FIX 6).
+    for prefix, names in sorted(mine.items()):
+        if len(names) > 1:
+            problems.append(f"  {prefix}: this PR itself adds {' and '.join(sorted(names))}")
+
+    on_main = _default_branch_migrations(repo=repo)
+    if on_main is None:
+        caveats.append("could not read the default branch's migrations")
+    elif not on_main:
+        # 90+ migrations exist on main today, so an EMPTY successful listing is
+        # not a possible answer — it means the read did not describe the
+        # directory (moved path, odd ref, changed API shape). Saying "clean" on
+        # it would be the seen-nothing-reported-no-problem failure (architect
+        # SHOULD-FIX 4).
+        caveats.append(
+            "the default branch's migration listing came back EMPTY — not a "
+            "possible state, so the read did not describe the directory"
+        )
+    else:
+        main_claims = _migration_prefix_claims(on_main)
+        for prefix, names in sorted(mine.items()):
+            others_on_main = main_claims.get(prefix, [])
+            for basename in sorted(names):
+                for other in others_on_main:
+                    # An IDENTICAL basename is the same file, not a duplicate
+                    # prefix: a long-lived branch that merged main carries
+                    # main's own migrations in its diff, and blocking there
+                    # refuses a PR that adds nothing.
+                    if other != basename:
+                        problems.append(
+                            f"  {prefix}: this PR adds {basename}, but the default "
+                            f"branch already has {other}"
+                        )
+
+    others = _open_pr_migrations(repo=repo)
+    if others is None:
+        caveats.append("could not read other open PRs' migrations")
+    else:
+        by_pr, unresolved, pr_list_truncated = others
+        for other_pr, other_paths in sorted(by_pr.items()):
+            # Exclude by PR NUMBER, not by filename: excluding "the file I also
+            # have" would silence a real collision whenever two PRs add the
+            # same basename.
+            if str(other_pr) == str(pr_num):
+                continue
+            other_claims = _migration_prefix_claims(other_paths)
+            for prefix, names in sorted(mine.items()):
+                # No identical-basename exemption here, unlike the default-branch
+                # arm above. There it means "the same file" — a branch that merged
+                # main carries main's own migrations in its diff. Between two OPEN
+                # PRs it means the opposite: both are CREATING that path (both
+                # sides are filtered to added files), which is a collision on the
+                # prefix (and a conflict on the path).
+                for clash in other_claims.get(prefix, []):
+                    problems.append(
+                        f"  {prefix}: this PR adds {' and '.join(sorted(names))}, "
+                        f"and open PR #{other_pr} adds {clash}"
+                    )
+        live_truncation = [n for n in unresolved if str(n) != str(pr_num)]
+        if live_truncation:
+            caveats.append(
+                "file lists TRUNCATED (incomplete) for open PR(s) "
+                + ", ".join(f"#{n}" for n in sorted(live_truncation))
+                + " — they may claim a prefix this scan could not see"
+            )
+        if pr_list_truncated:
+            caveats.append(
+                "the open-PR list itself was TRUNCATED at 100 — PRs beyond the "
+                "first page were not scanned"
+            )
+
+    if problems:
+        head = (
+            f"{len(problems)} migration-prefix collision(s) — a duplicate prefix "
+            "halts EVERY migration on EVERY install at next restart "
+            "(db/migrations/runner.py raises before running any)."
+        )
+        body = "\n".join(problems)
+        tail = ("\n  caveat: " + "; ".join(caveats)) if caveats else ""
+        return True, f"{head}\n{body}{tail}"
+    n_files = sum(len(v) for v in mine.values())
+    if caveats:
+        # Say what WAS checked, not just what was not. A blanket "unverified"
+        # when only one of the two arms came up short is the same defect the
+        # report-is-an-inventory rule names: it hides a true fact (the default
+        # branch WAS cleanly checked) behind a single pessimistic label, and a
+        # line that always reads the same trains a reader to skip it.
+        checked = "the default branch" if on_main else None
+        prefix = (
+            f"NOTE: {n_files} migration(s) — no collision with {checked}, but "
+            if checked
+            else "NOTE: prefixes unverified — "
+        )
+        return False, prefix + "; ".join(caveats) + "."
+    return False, f"ok ({n_files} migration(s), no prefix collision)"
+
+
 def _suggested_merge_cmd(pr_num: str, verified_head: str, repo: str | None) -> str:
     """The exact atomic merge command to copy — PRESERVING an explicit --repo.
 
@@ -5633,10 +6121,13 @@ def main() -> int:
                 # their own block/allow decision at or inside the budget, and
                 # any ONE of them timing out fail-closes IMMEDIATELY (the
                 # additive worst case needs every call slow-but-successful);
-                # the TOCTOU binding runs argv-only right after freshness, so
-                # only the tail advisory scanners (fail-OPEN by design) could
-                # ever be clipped, which nets the same outcome as their error
-                # path.
+                # the TOCTOU binding runs argv-only right after freshness. The
+                # finding scanners at the tail ALSO fail CLOSED on a clipped
+                # budget (PR #1434 removed their fail-open), so a drained
+                # deadline BLOCKS rather than silently passing; the one gate
+                # that degrades OPEN under starvation is the migration-prefix
+                # check, which is why it runs dead last — it can only starve
+                # itself, and it says so in a NOTE when it does.
                 # A timing-out fail-closed gate returns BLOCK immediately, so
                 # the additive worst case needs every call slow-but-successful.
                 mergeable = _check_mergeable(pr_num, repo=merge_repo)
@@ -5938,6 +6429,39 @@ def main() -> int:
                     print(sched_msg, file=sys.stderr)
                     return 2
 
+                # Migration-prefix collisions. CI's `migration-check` already rejects
+                # duplicates, but only against the merge preview AT THE MOMENT IT RAN:
+                # measured 2026-09-03, #1541 held a green tick from 8.5h before the
+                # colliding migration landed on main, and #1610/#1616 each add a
+                # differently-named 0092 that no single PR's CI can see. Only a
+                # merge-TIME read answers the question that matters.
+                # Deliberately the LAST gate (architect BLOCKER 1): it can spend up
+                # to ~5 gh calls, and every gate above fails CLOSED when the shared
+                # deadline drains — so run the fail-closed gates while budget is
+                # guaranteed, and let this one starve only ITSELF (its own failure
+                # direction is open-with-a-NOTE, the survivable degradation).
+                # NO override sigil, for the pin gate's reason above: the honest fix
+                # is to renumber the file, which takes seconds, and there is no
+                # legitimate duplicate-prefix state — both runners raise on one
+                # before running any migration, on every install. (A false block
+                # from status misreads is designed out instead: only files a PR
+                # ADDS claim a prefix.)
+                should_block, migration_msg = _check_migration_prefixes(
+                    pr_num, repo=merge_repo
+                )
+                if should_block:
+                    print(
+                        f"BLOCKED: PR #{pr_num} — migration-prefix collision.",
+                        file=sys.stderr,
+                    )
+                    print(migration_msg, file=sys.stderr)
+                    return 2
+                elif migration_msg.startswith("NOTE:"):
+                    # Fail-open direction must be VISIBLE at the moment of merging,
+                    # mirroring the pin gate — a silent NOTE is what makes
+                    # "verified" and "could not verify" indistinguishable.
+                    print(migration_msg, file=sys.stderr)
+
         # ── sqlite3 write operations ────────────────────────────────
         # Whole-command match (never misses a fragmented/wrapped invocation),
         # narrowed to DML in statement position so the `replace()` scalar
@@ -6092,6 +6616,14 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
             f"({', '.join(ci_bad[:6])}); the required suite never ran."
         )
         failures += 1
+    # ADVISORY, and report-only by design. It never changes the verdict, so it
+    # cannot make the report and the enforcement arm disagree — the invariant in
+    # this function's docstring is about GATES. A green tick from before main
+    # moved is real (30/48 open PRs, 2026-09-03) but not mechanically decidable
+    # into a block; the one consequence that IS decidable has its own gate below.
+    _stale_ci = _ci_freshness_note(pr_num, repo=repo)
+    if _stale_ci:
+        print(f"  ↳ {_stale_ci}")
     # Order mirrors the gate: base-invariant → freshness → finding scans, so a
     # review published mid-run can't pass freshness with its P1s unscanned.
     blocked, msg = _check_base_is_default(pr_num, repo=repo)
@@ -6107,6 +6639,13 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     if blocked:
         for line in msg.splitlines()[1:]:
             print(f"  {line}")
+    failures += 1 if blocked else 0
+    blocked, msg = _check_migration_prefixes(pr_num, repo=repo)
+    print(f"migrations     : {'BLOCK — ' + msg.splitlines()[0] if blocked else msg.splitlines()[0]}")
+    # Render the TAIL: line 0 is the summary and the per-collision bullets live on
+    # lines 1+, which are the whole diagnosis (which prefix, against what).
+    for line in msg.splitlines()[1:]:
+        print(f"  {line}")
     failures += 1 if blocked else 0
     blocked, msg, verified_head = _check_codex_reviewed_head(pr_num, repo=repo)
     if blocked:

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -4455,51 +4455,79 @@ def _migration_prefix_claims(paths: list[str]) -> dict[str, list[str]]:
     return claims
 
 
-def _pr_added_files(pr_num: str, repo: str | None = None) -> list[str] | None:
-    """Filenames this PR CREATES (status added/renamed/copied), or None.
+#: GitHub caps ``pulls/N/files`` at 3,000 entries; at the cap a file may sit
+#: beyond the listing, indistinguishable from absence (the sibling
+#: ``_pr_changed_files`` documents and fails closed on the same cap).
+_PR_FILES_API_CAP = 3000
 
-    Distinct from ``_pr_changed_files``, which deliberately includes every
-    touched path plus rename SOURCES — right for the hook-surface fence (a
-    guard renamed away is a hook change), wrong here (a modified migration is
-    not a new prefix claim). Shares the ``_TEST_GH_PR_FILES`` seam; a seam
-    entry's optional ``status`` defaults to "added" so existing fixtures keep
-    their meaning.
+
+def _pr_file_effects(
+    pr_num: str, repo: str | None = None
+) -> tuple[list[str], set[str]] | None:
+    """``(created_paths, removed_paths)`` for this PR, or None if unreadable.
+
+    ``created``: files the PR ADDS (status added/renamed/copied) — the only
+    ones that claim a migration prefix. ``removed``: paths the PR deletes plus
+    rename SOURCES — the ones to SUBTRACT from the default branch's claims,
+    because a rename/replacement of main's ``0090_old.py`` into ``0090_new.py``
+    leaves the MERGED tree with one 0090, and comparing the addition against a
+    listing that still shows the old file reports a collision that will not
+    exist (Codex P2, #1666 — and this gate has no override, so that false
+    block would make a legitimate migration replacement unmergeable).
+
+    Distinct from ``_pr_changed_files``, which flattens every touched path into
+    one undifferentiated list — right for the hook-surface fence, wrong here.
+    Shares the ``_TEST_GH_PR_FILES`` seam (optional ``status`` defaults to
+    "added"; ``previous_filename`` carries a rename source).
+
+    Fails to None at ``_PR_FILES_API_CAP`` rows: at the cap, a migration beyond
+    the listing is silently absent and "no migrations" would be a claim about
+    the LISTING, not the PR (Codex P2, #1666; same contract as the sibling).
     """
     raw = os.environ.get("_TEST_GH_PR_FILES")
     if raw == "__error__":
         return None
     if raw is not None:
-        out = []
-        for line in raw.splitlines():
-            if not line.strip():
-                continue
-            try:
-                row = json.loads(line)
-            except Exception:
+        rows = [ln for ln in raw.splitlines() if ln.strip()]
+    else:
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo or ':owner/:repo'}/pulls/{pr_num}/files",
+                    "--paginate",
+                    "--jq",
+                    '.[] | {filename: .filename, previous_filename: '
+                    ".previous_filename, status: .status}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=_gh_timeout(8),
+            )
+            if result.returncode != 0:
                 return None
-            if row.get("status", "added") in _MIGRATION_CREATING_STATUSES:
-                out.append(row["filename"])
-        return out
-    try:
-        result = subprocess.run(
-            [
-                "gh",
-                "api",
-                f"repos/{repo or ':owner/:repo'}/pulls/{pr_num}/files",
-                "--paginate",
-                "--jq",
-                '.[] | select(.status == "added" or .status == "renamed" or '
-                '.status == "copied") | .filename',
-            ],
-            capture_output=True,
-            text=True,
-            timeout=_gh_timeout(8),
-        )
-        if result.returncode != 0:
+            rows = [ln for ln in result.stdout.splitlines() if ln.strip()]
+        except Exception:
             return None
-        return [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
-    except Exception:
+    if len(rows) >= _PR_FILES_API_CAP:
         return None
+    created: list[str] = []
+    removed: set[str] = set()
+    for line in rows:
+        try:
+            row = json.loads(line)
+        except Exception:
+            return None
+        status = row.get("status", "added")
+        if status in _MIGRATION_CREATING_STATUSES:
+            created.append(row["filename"])
+        if status == "removed":
+            removed.add(row["filename"])
+        prev = row.get("previous_filename")
+        if status == "renamed" and prev:
+            removed.add(prev)
+    return created, removed
 
 
 def _default_branch_migrations(repo: str | None = None) -> list[str] | None:
@@ -4668,12 +4696,14 @@ def _open_pr_migrations(
             # unseen, so a bounded scan can't read as a complete one.
             unresolved.extend(short_read[i:])
             break
-        full = _pr_added_files(num, repo=repo)
-        if full is None:
+        effects = _pr_file_effects(num, repo=repo)
+        if effects is None:
             unresolved.append(num)
             continue
-        # Same full-path contract as the sweep above.
-        mig_paths = sorted(p for p in full if _migration_prefix_claims([p]))
+        # Same full-path contract as the sweep above. Only the CREATED side
+        # matters cross-PR: another PR's removals affect its own main
+        # comparison, never this one's claim set.
+        mig_paths = sorted(p for p in effects[0] if _migration_prefix_claims([p]))
         if mig_paths:
             out[num] = mig_paths
         else:
@@ -4682,8 +4712,16 @@ def _open_pr_migrations(
 
 
 def _ci_freshness_note(pr_num: str, repo: str | None = None) -> str | None:
-    """ADVISORY note when the PR's newest completed check predates the current
-    default-branch head — i.e. its green tick describes a main that has moved.
+    """ADVISORY note when NO check on the PR's head STARTED after the current
+    default-branch head landed — i.e. every run tested a main that has moved.
+
+    STARTED, not completed (Codex P2, #1666): a check's merge-ref snapshot is
+    taken when the run is created, so ``completed_at`` proves nothing about
+    WHICH main was tested — a slow run finishing after main moved still tested
+    the old merge ref, and its late completion would suppress this note in
+    exactly the stale case it exists to expose. ``max(started_at)`` is the
+    faithful cheap proxy; the residual (a run created in the seconds between
+    snapshot and main's commit) is accepted for an advisory.
 
     Deliberately NOT a gate. Measured 2026-09-03, 30 of 48 open PRs were in this
     state (oldest tick six weeks old), so blocking would refuse most of the queue
@@ -4697,7 +4735,7 @@ def _ci_freshness_note(pr_num: str, repo: str | None = None) -> str | None:
     Returns None when either side is unreadable: no note beats a wrong note, and
     a hedge printed on every PR is indistinguishable from a finding on every PR.
     """
-    raw_check = os.environ.get("_TEST_GH_CI_COMPLETED_AT")
+    raw_check = os.environ.get("_TEST_GH_CI_NEWEST_START")
     raw_main = os.environ.get("_TEST_GH_DEFAULT_HEAD_DATE")
     if raw_check is None or raw_main is None:
         branch = _repo_default_branch(repo=repo)
@@ -4708,15 +4746,16 @@ def _ci_freshness_note(pr_num: str, repo: str | None = None) -> str | None:
             if raw_check is None:
                 # --paginate + max() HERE, not `max` in jq: the endpoint pages at
                 # 30 and this repo's heads carry 16+ check runs today — a
-                # first-page max UNDERSTATES the newest completion and emits a
-                # false "stale" note the day the count crosses the page size
+                # first-page max UNDERSTATES the newest run and emits a false
+                # "stale" note the day the count crosses the page size
                 # (architect SHOULD-FIX 8). With --paginate each page is its own
                 # JSON document, so per-page jq output is concatenated lines and
-                # the aggregate must happen client-side.
+                # the aggregate must happen client-side. started_at, not
+                # completed_at — see the docstring.
                 stamps = subprocess.run(
                     ["gh", "api", f"repos/{repo or ':owner/:repo'}/commits/{head_sha}/check-runs",
                      "--paginate",
-                     "--jq", ".check_runs[]|select(.completed_at != null)|.completed_at"],
+                     "--jq", ".check_runs[]|select(.started_at != null)|.started_at"],
                     capture_output=True, text=True, timeout=_gh_timeout(8),
                 ).stdout.split()
                 raw_check = max(stamps) if stamps else ""
@@ -4745,10 +4784,10 @@ def _ci_freshness_note(pr_num: str, repo: str | None = None) -> str | None:
     except Exception:
         return None
     return (
-        f"NOTE: CI last completed {raw_check} but the default branch moved at "
-        f"{raw_main} — this PR's checks ran against a DIFFERENT main. "
-        "CI re-runs only on a push, so whatever they concluded does not describe "
-        "a merge today."
+        f"NOTE: the newest check on this head STARTED {raw_check}, before the "
+        f"default branch moved at {raw_main} — this PR's checks ran against a "
+        "DIFFERENT main. CI re-runs only on a push, so whatever they concluded "
+        "does not describe a merge today."
     )
 
 
@@ -4780,10 +4819,12 @@ def _check_migration_prefixes(
     # ADDED files only — a PR that merely edits or deletes an existing
     # migration claims no prefix (architect BLOCKER 2: reading every touched
     # path as an addition hard-blocked two PRs that both patched one old
-    # migration, with no override).
-    added = _pr_added_files(pr_num, repo=repo)
-    if added is None:
+    # migration, with no override). Removals and rename SOURCES ride along so
+    # the default-branch arm can subtract a replaced file (Codex P2, #1666).
+    effects = _pr_file_effects(pr_num, repo=repo)
+    if effects is None:
         return False, "NOTE: could not read the PR's file list — prefixes unverified."
+    added, removed_paths = effects
     mine = _migration_prefix_claims(added)
     if not mine:
         return False, "ok (no migrations in this PR)"
@@ -4812,7 +4853,16 @@ def _check_migration_prefixes(
             "possible state, so the read did not describe the directory"
         )
     else:
-        main_claims = _migration_prefix_claims(on_main)
+        # SUBTRACT this PR's removals and rename sources first (Codex P2,
+        # #1666): a rename/replacement of main's 0090_old.py into 0090_new.py
+        # leaves the MERGED tree with one 0090 — comparing the addition against
+        # a listing that still shows the old file reports a collision that will
+        # not exist, and with no override that false block makes a legitimate
+        # migration replacement permanently unmergeable. The subtraction is by
+        # EXACT PATH: removing an unrelated file licenses nothing.
+        main_claims = _migration_prefix_claims(
+            [p for p in on_main if p not in removed_paths]
+        )
         for prefix, names in sorted(mine.items()):
             others_on_main = main_claims.get(prefix, [])
             for basename in sorted(names):
@@ -4865,10 +4915,31 @@ def _check_migration_prefixes(
             )
 
     if problems:
+        # The two runners fail DIFFERENTLY, and the headline must not attribute
+        # the harsher consequence to the milder namespace (Codex P3, #1666):
+        # the numbered runner raises pre-flight and ABORTS BOOTSTRAP on every
+        # install; the data runner catches its duplicate post-boot and skips
+        # ONLY the data-migration batch while the server runs on.
+        numbered_hit = any(not ln.strip().startswith("d") for ln in problems)
+        data_hit = any(ln.strip().startswith("d") for ln in problems)
+        consequences = []
+        if numbered_hit:
+            consequences.append(
+                "a duplicate numbered prefix halts EVERY migration on EVERY "
+                "install at next restart (db/migrations/runner.py raises before "
+                "running any)"
+            )
+        if data_hit:
+            consequences.append(
+                "a duplicate data-migration prefix makes every install skip its "
+                "whole data-migration batch post-boot "
+                "(db/data_migrations/runner.py refuses the batch; the server "
+                "boots on)"
+            )
         head = (
-            f"{len(problems)} migration-prefix collision(s) — a duplicate prefix "
-            "halts EVERY migration on EVERY install at next restart "
-            "(db/migrations/runner.py raises before running any)."
+            f"{len(problems)} migration-prefix collision(s) — "
+            + "; ".join(consequences)
+            + "."
         )
         body = "\n".join(problems)
         tail = ("\n  caveat: " + "; ".join(caveats)) if caveats else ""

--- a/tests/test_hooks/test_git_push_guard_migration_prefixes.py
+++ b/tests/test_hooks/test_git_push_guard_migration_prefixes.py
@@ -78,6 +78,11 @@ def _files(*paths: str, status: str = "added") -> str:
     )
 
 
+def _file_row(filename: str, status: str = "added", previous: str | None = None) -> str:
+    """One wire row with full control (rename sources, removals)."""
+    return json.dumps({"filename": filename, "previous_filename": previous, "status": status})
+
+
 def _main(*names: str) -> str:
     """The `_TEST_GH_MAIN_MIGRATIONS` seam: one entry per line (bare basename
     = the numbered dir; an entry with a slash is a full path)."""
@@ -180,6 +185,42 @@ class TestOnlyAddedFilesClaim:
         blocked, _ = _mod._check_migration_prefixes("1616")
         assert blocked is False
 
+    def test_a_rename_of_a_MAIN_migration_is_not_a_collision(self, monkeypatch):
+        """Codex P2 (#1666): renaming main's `0090_old.py` to `0090_new.py`
+        claims 0090 while main still lists 0090_old — but the MERGED tree holds
+        only one 0090, so blocking (with no override, by design) makes a
+        legitimate migration replacement permanently unmergeable. The rename
+        SOURCE must be subtracted from main's claims before comparing."""
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            _file_row(f"{_D}0090_new.py", status="renamed", previous=f"{_D}0090_old.py"),
+        )
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0090_old.py"))
+        blocked, _ = _mod._check_migration_prefixes("1700")
+        assert blocked is False
+
+    def test_a_delete_plus_add_replacement_is_not_a_collision(self, monkeypatch):
+        """Same replacement expressed as remove-old + add-new."""
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            _file_row(f"{_D}0090_new.py") + "\n" + _file_row(f"{_D}0090_old.py", status="removed"),
+        )
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0090_old.py"))
+        blocked, _ = _mod._check_migration_prefixes("1700")
+        assert blocked is False
+
+    def test_removing_an_UNRELATED_file_exempts_nothing(self, monkeypatch):
+        """The subtraction is by exact path, never by 'the PR removed
+        something': removing 0089_x must not license a 0090 collision."""
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            _file_row(f"{_D}0090_new.py") + "\n" + _file_row(f"{_D}0089_x.py", status="removed"),
+        )
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0090_old.py", "0089_x.py"))
+        blocked, msg = _mod._check_migration_prefixes("1700")
+        assert blocked is True
+        assert "0090" in msg
+
     def test_a_renamed_target_still_claims(self, monkeypatch):
         """A rename CREATES the destination path — that prefix is claimed."""
         monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_renamed.py", status="renamed"))
@@ -187,6 +228,29 @@ class TestOnlyAddedFilesClaim:
         blocked, msg = _mod._check_migration_prefixes("1616")
         assert blocked is True
         assert "0092" in msg
+
+
+class TestConsequenceAccuracy:
+    """Codex P3 (#1666): the two runners fail DIFFERENTLY, and the block must
+    say which. The numbered runner raises pre-flight and aborts bootstrap; the
+    data runner catches its duplicate, skips ONLY the data-migration batch, and
+    the server boots on (data_migrations/runner.py catches; _core.py runs it
+    post-boot). Attributing the startup-halt to a d-collision overstates it."""
+
+    def test_numbered_collision_names_the_startup_halt(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0090_x.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0090_y.py"))
+        blocked, msg = _mod._check_migration_prefixes("1700")
+        assert blocked is True
+        assert "halts" in msg and "restart" in msg
+
+    def test_data_collision_names_the_batch_skip_not_the_halt(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_DD}d0004_mine.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main(f"{_DD}d0004_theirs.py"))
+        blocked, msg = _mod._check_migration_prefixes("1700")
+        assert blocked is True
+        assert "data-migration" in msg
+        assert "EVERY migration" not in msg
 
 
 class TestSelfCollision:
@@ -445,8 +509,8 @@ class TestOpenPrSweepSubprocessLevel:
         run, calls = _fake_run(
             [
                 (_graphql_payload([_pr_node(1541, [], has_next=True)]), 0),
-                # the refetch: _pr_added_files' REST read for #1541
-                (f"{_D}0090_ledger.py\n", 0),
+                # the refetch: _pr_file_effects' REST read for #1541 — JSON rows
+                (_file_row(f"{_D}0090_ledger.py") + "\n", 0),
             ]
         )
         monkeypatch.setattr(_mod.subprocess, "run", run)
@@ -487,7 +551,7 @@ class TestOpenPrSweepSubprocessLevel:
         assert _mod._open_pr_migrations(repo="o/r") is None
 
     def test_added_files_reads_status_from_the_wire(self, monkeypatch):
-        """`_pr_added_files`' live jq filters by status; the seam path filters
+        """`_pr_file_effects`' live path reads status per row; the seam path filters
         in Python. This exercises the SEAM path's filter with explicit
         statuses — the live filter is asserted by the jq text itself."""
         monkeypatch.setenv(
@@ -496,7 +560,29 @@ class TestOpenPrSweepSubprocessLevel:
             + "\n"
             + _files(f"{_D}0090_b.py", status="modified"),
         )
-        assert _mod._pr_added_files("1") == [f"{_D}0092_a.py"]
+        created, removed = _mod._pr_file_effects("1")
+        assert created == [f"{_D}0092_a.py"]
+        assert removed == set()
+
+    def test_file_effects_reports_removals_and_rename_sources(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            _file_row(f"{_D}0090_new.py", status="renamed", previous=f"{_D}0090_old.py")
+            + "\n"
+            + _file_row(f"{_D}0089_gone.py", status="removed"),
+        )
+        created, removed = _mod._pr_file_effects("1")
+        assert created == [f"{_D}0090_new.py"]
+        assert removed == {f"{_D}0090_old.py", f"{_D}0089_gone.py"}
+
+    def test_file_effects_fails_to_None_at_the_api_cap(self, monkeypatch):
+        """Codex P2 (#1666): pulls/N/files caps at 3,000 rows; at the cap a
+        migration beyond the listing is silently absent, so 'no migrations'
+        would describe the LISTING, not the PR. Same contract as the sibling
+        _pr_changed_files."""
+        rows = "\n".join(_file_row(f"src/f{i}.py") for i in range(_mod._PR_FILES_API_CAP))
+        monkeypatch.setenv("_TEST_GH_PR_FILES", rows)
+        assert _mod._pr_file_effects("1") is None
 
 
 class TestCiFreshnessNote:
@@ -511,7 +597,7 @@ class TestCiFreshnessNote:
     """
 
     def test_flags_a_check_older_than_the_default_branch_head(self, monkeypatch):
-        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-02T13:17:21Z")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-02T13:17:21Z")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T21:43:17Z")
         note = _mod._ci_freshness_note("1541")
         assert note is not None
@@ -526,22 +612,22 @@ class TestCiFreshnessNote:
         demonstrated on, had gone RED under a concurrent push. Staleness and
         outcome are independent facts; claiming one from the other is exactly
         the unverified-assertion class the report is supposed to avoid."""
-        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-02T13:17:21Z")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-02T13:17:21Z")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T21:43:17Z")
         note = _mod._ci_freshness_note("1541")
         assert "green" not in note.lower()
         assert "pass" not in note.lower()
 
     def test_silent_when_the_check_is_newer_than_main(self, monkeypatch):
-        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-03T18:00:00Z")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-03T18:00:00Z")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-03T12:00:00Z")
         assert _mod._ci_freshness_note("1616") is None
 
     def test_silent_when_either_side_is_unreadable(self, monkeypatch):
-        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "__error__")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "__error__")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-03T12:00:00Z")
         assert _mod._ci_freshness_note("1616") is None
-        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-03T12:00:00Z")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-03T12:00:00Z")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "__error__")
         assert _mod._ci_freshness_note("1616") is None
 
@@ -549,7 +635,7 @@ class TestCiFreshnessNote:
         """GitHub returns `Z` on the checks API and a numeric offset on the
         commit API. Comparing them as STRINGS would put `2026-09-02T21:43:17Z`
         before `2026-09-02T17:43:17-04:00` — the same instant, wrong answer."""
-        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-02T13:17:21Z")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-02T13:17:21Z")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T17:43:17-04:00")
         assert _mod._ci_freshness_note("1541") is not None
 
@@ -557,6 +643,6 @@ class TestCiFreshnessNote:
         """Comparing naive to aware raises TypeError; outside the guard that
         aborts the whole report mid-print — a partial report that looks
         structurally complete (SHOULD-FIX 9)."""
-        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-02T13:17:21")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-02T13:17:21")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T21:43:17Z")
         assert _mod._ci_freshness_note("1541") is None

--- a/tests/test_hooks/test_git_push_guard_migration_prefixes.py
+++ b/tests/test_hooks/test_git_push_guard_migration_prefixes.py
@@ -93,6 +93,7 @@ def _others(
     mapping: dict[int, list[str]],
     truncated: list[int] | None = None,
     pr_list_truncated: bool = False,
+    bases: dict[int, str] | None = None,
 ) -> str:
     """The `_TEST_GH_OPEN_PR_MIGRATIONS` seam: a JSON object."""
     return json.dumps(
@@ -100,6 +101,7 @@ def _others(
             "prs": {str(k): v for k, v in mapping.items()},
             "truncated": truncated or [],
             "pr_list_truncated": pr_list_truncated,
+            "bases": {str(k): v for k, v in (bases or {}).items()},
         }
     )
 
@@ -117,6 +119,10 @@ def _seams(monkeypatch):
     monkeypatch.setenv("_TEST_GH_PR_FILES", "")
     monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", "")
     monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", _others({}))
+    # Base-ref + default-branch seams: empty base = unreadable -> the gate takes
+    # the default-branch path with NO live gh reads (the lazy-resolve contract).
+    monkeypatch.setenv("_TEST_GH_BASE_REF", "")
+    monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
 
 
 class TestPrefixExtraction:
@@ -341,6 +347,59 @@ class TestCollisionWithOtherOpenPRs:
         assert "1610" in msg
 
 
+class TestStackedBase:
+    """Codex P2 (#1666 round 2): a non-default-base (stacked) PR merges into
+    its PARENT branch — comparing against the default branch is wrong in both
+    directions (a parent's deletion still shows on main → false block on the
+    child; a parent's addition is invisible on main → missed collision)."""
+
+    def test_collision_message_names_the_actual_base_branch(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "feat-parent")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_child.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0092_parent.py"))
+        blocked, msg = _mod._check_migration_prefixes("1700")
+        assert blocked is True
+        assert "feat-parent" in msg
+        assert "the default branch" not in msg
+
+    def test_cross_pr_arm_skips_prs_with_a_DIFFERENT_target(self, monkeypatch):
+        """Two PRs adding one prefix collide iff they merge into the same
+        branch; a stacked child and a main-bound PR share no target tree, and
+        comparing them manufactures a collision no merge order produces."""
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "main")
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_mine.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0091_last.py"))
+        monkeypatch.setenv(
+            "_TEST_GH_OPEN_PR_MIGRATIONS",
+            _others({1610: ["0092_other.py"]}, bases={1610: "feat-parent"}),
+        )
+        blocked, _ = _mod._check_migration_prefixes("1616")
+        assert blocked is False
+
+    def test_cross_pr_arm_still_blocks_same_target_prs(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "main")
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_mine.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0091_last.py"))
+        monkeypatch.setenv(
+            "_TEST_GH_OPEN_PR_MIGRATIONS",
+            _others({1610: ["0092_other.py"]}, bases={1610: "main"}),
+        )
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is True
+        assert "1610" in msg
+
+    def test_unknown_bases_still_compare(self, monkeypatch):
+        """An absent base on either side compares anyway — the conservative
+        direction for the default-base majority (and older fixtures)."""
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "")
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_mine.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0091_last.py"))
+        monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", _others({1610: ["0092_other.py"]}))
+        blocked, _ = _mod._check_migration_prefixes("1616")
+        assert blocked is True
+
+
 class TestFailDirection:
     """Plumbing failures must NOT block; they must also not read as clean."""
 
@@ -480,7 +539,7 @@ class TestOpenPrSweepSubprocessLevel:
         monkeypatch.setattr(_mod.subprocess, "run", run)
         out = _mod._open_pr_migrations(repo="o/r")
         assert out is not None
-        prs, unresolved, pr_trunc = out
+        prs, unresolved, pr_trunc, _bases = out
         # The MODIFIED file must not claim; the ADDED one must — and as a FULL
         # path, because the consumer re-parses claims through the dir-anchored
         # matcher. A basename here made every live cross-PR collision vanish
@@ -516,7 +575,7 @@ class TestOpenPrSweepSubprocessLevel:
         monkeypatch.setattr(_mod.subprocess, "run", run)
         out = _mod._open_pr_migrations(repo="o/r")
         assert out is not None
-        prs, unresolved, _ = out
+        prs, unresolved, _trunc, _bases = out
         assert prs == {"1541": [f"{_D}0090_ledger.py"]}  # full path — see above
         assert unresolved == []
         assert len(calls) == 2
@@ -533,9 +592,12 @@ class TestOpenPrSweepSubprocessLevel:
         monkeypatch.setattr(_mod.subprocess, "run", run)
         out = _mod._open_pr_migrations(repo="o/r")
         assert out is not None
-        _, unresolved, _ = out
-        # Everything past the cap is REPORTED, never silently dropped.
-        assert len(unresolved) == 2
+        _, unresolved, _trunc, _bases = out
+        # Past-cap PRs are reported unseen — AND the refetched ones landed in
+        # unresolved too, because their canned refetch returned ZERO rows and a
+        # >100-file PR cannot have an empty file list (empty-when-impossible;
+        # audit SF3: the old code resolved that truncation caveat as clean).
+        assert len(unresolved) == 2 + _mod._MIGRATION_TRUNCATION_REFETCH_CAP
         assert len(calls) == 1 + _mod._MIGRATION_TRUNCATION_REFETCH_CAP
 
     def test_pr_list_truncation_is_surfaced(self, monkeypatch):
@@ -545,10 +607,124 @@ class TestOpenPrSweepSubprocessLevel:
         assert out is not None
         assert out[2] is True
 
+    def test_live_contents_listing_preserves_exact_filenames(self, monkeypatch):
+        """Codex P3 (#1666 round 2): `strip()` on a scalar --jq name ALTERS a
+        legal-but-odd git filename before the runner's regex sees it — turning
+        ' 0092_fake.py ' (which the runner ignores) into a migration-looking
+        record that could block a real 0092 on a phantom collision. Names now
+        travel as JSON records; a name the runner ignores is ignored here, in
+        its exact original bytes."""
+        responses = [
+            (json.dumps({"name": " 0092_fake.py ", "type": "file"}) + "\n", 0),
+            ("", 0),  # data_migrations dir
+        ]
+        run, _ = _fake_run(responses)
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        monkeypatch.delenv("_TEST_GH_MAIN_MIGRATIONS", raising=False)
+        monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
+        listing = _mod._target_branch_migrations(repo="o/r")
+        assert listing == ["src/genesis/db/migrations/ 0092_fake.py "]
+        # The odd name flows through UNCHANGED and claims nothing:
+        assert _mod._migration_prefix_claims(listing) == {}
+
+    def test_ci_note_reads_check_SUITES_not_runs(self, monkeypatch):
+        """Codex P2 (#1666 round 2), second instance of the same class: any
+        per-RUN timestamp is a proxy for snapshot identity, and started_at
+        fails under runner queueing (this repo documents 50-75 min queues).
+        The suite's created_at is stamped at trigger time, before queueing —
+        so the live path must read /check-suites, not /check-runs."""
+        responses = [
+            ("2026-09-02T13:00:00Z\n", 0),  # suites created_at stamps
+            ("2026-09-03T00:00:00Z\n", 0),  # default-branch head date
+        ]
+        run, calls = _fake_run(responses)
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        monkeypatch.delenv("_TEST_GH_CI_NEWEST_SNAPSHOT", raising=False)
+        monkeypatch.delenv("_TEST_GH_DEFAULT_HEAD_DATE", raising=False)
+        monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", "a" * 40)
+        note = _mod._ci_freshness_note("1700", repo="o/r")
+        assert note is not None  # snapshot predates main's move → stale
+        joined = " ".join(str(a) for c in calls for a in c)
+        assert "check-suites" in joined
+        assert "check-runs" not in joined
+
     def test_a_failed_graphql_call_returns_None(self, monkeypatch):
         run, _ = _fake_run([("", 1)])
         monkeypatch.setattr(_mod.subprocess, "run", run)
         assert _mod._open_pr_migrations(repo="o/r") is None
+
+    def test_a_null_pr_node_returns_None_not_a_raise(self, monkeypatch):
+        """Audit BLOCKER (2026-09-03): a malformed element used to RAISE past
+        the docstring's 'None on any read failure' — AttributeError reaches
+        run_guard's fail-closed exit 2, i.e. one bad node among 100 open PRs
+        blocks EVERY merge on this machine, on the one gate designed to
+        degrade open."""
+        payload = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequests": {"pageInfo": {"hasNextPage": False}, "nodes": [None]}
+                    }
+                }
+            }
+        )
+        run, _ = _fake_run([(payload, 0)])
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        assert _mod._open_pr_migrations(repo="o/r") is None
+
+    def test_a_null_files_element_returns_None_not_a_raise(self, monkeypatch):
+        node = {
+            "number": 1610,
+            "baseRefName": "main",
+            "files": {"pageInfo": {"hasNextPage": False}, "nodes": [None]},
+        }
+        run, _ = _fake_run([(_graphql_payload([node]), 0)])
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        assert _mod._open_pr_migrations(repo="o/r") is None
+
+    def test_a_null_file_row_returns_None_not_a_raise(self, monkeypatch):
+        """The KeyError twin routed to the OTHER wrong direction: main()'s
+        broad catch turned it into a silent allow that also skipped every gate
+        after this one."""
+        monkeypatch.setenv("_TEST_GH_PR_FILES", "null")
+        assert _mod._pr_file_effects("1") is None
+
+    def test_a_row_missing_filename_returns_None_not_a_raise(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", json.dumps({"status": "added"}))
+        assert _mod._pr_file_effects("1") is None
+
+    def test_non_default_base_listing_reads_the_BASE_ref(self, monkeypatch):
+        """Audit SF2 (measured delete-survivable): mutating the ref THREADING
+        in the caller to always-None left 55/55 tests green, because the
+        listing seam returns before `ref` is read. The lock is the recorded
+        argv — and it must run THROUGH the caller: a first version of this
+        test called the helper directly and the same mutation still survived
+        (the mutation lives in the threading, not the helper)."""
+        responses = [
+            (json.dumps({"name": "0092_parent.py", "type": "file"}) + "\n", 0),
+            ("", 0),  # data_migrations dir
+        ]
+        run, calls = _fake_run(responses)
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        monkeypatch.delenv("_TEST_GH_MAIN_MIGRATIONS", raising=False)
+        monkeypatch.setenv("_TEST_GH_BASE_REF", "feat-parent")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_BRANCH", "main")
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_child.py"))
+        blocked, _ = _mod._check_migration_prefixes("1700", repo="o/r")
+        assert blocked is True  # 0092_child vs the BASE's 0092_parent
+        assert any("ref=feat-parent" in str(a) for c in calls for a in c)
+
+    def test_live_sweep_captures_baseRefName_from_the_wire(self, monkeypatch):
+        """Audit SF2, second half: the live same-target filter is only as real
+        as the wire capture feeding it."""
+        node = _pr_node(1610, [f"{_D}0092_x.py"])
+        node["baseRefName"] = "feat-parent"
+        run, _ = _fake_run([(_graphql_payload([node]), 0)])
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        out = _mod._open_pr_migrations(repo="o/r")
+        assert out is not None
+        assert out[3]["1610"] == "feat-parent"
 
     def test_added_files_reads_status_from_the_wire(self, monkeypatch):
         """`_pr_file_effects`' live path reads status per row; the seam path filters
@@ -597,11 +773,11 @@ class TestCiFreshnessNote:
     """
 
     def test_flags_a_check_older_than_the_default_branch_head(self, monkeypatch):
-        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-02T13:17:21Z")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_SNAPSHOT", "2026-09-02T13:17:21Z")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T21:43:17Z")
         note = _mod._ci_freshness_note("1541")
         assert note is not None
-        assert "DIFFERENT main" in note
+        assert "DIFFERENT base" in note
         # Both instants named — a note that says "stale" without saying stale
         # against WHAT sends the reader back to the API to find out.
         assert "2026-09-02T13:17:21Z" in note and "2026-09-02T21:43:17Z" in note
@@ -612,22 +788,22 @@ class TestCiFreshnessNote:
         demonstrated on, had gone RED under a concurrent push. Staleness and
         outcome are independent facts; claiming one from the other is exactly
         the unverified-assertion class the report is supposed to avoid."""
-        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-02T13:17:21Z")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_SNAPSHOT", "2026-09-02T13:17:21Z")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T21:43:17Z")
         note = _mod._ci_freshness_note("1541")
         assert "green" not in note.lower()
         assert "pass" not in note.lower()
 
     def test_silent_when_the_check_is_newer_than_main(self, monkeypatch):
-        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-03T18:00:00Z")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_SNAPSHOT", "2026-09-03T18:00:00Z")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-03T12:00:00Z")
         assert _mod._ci_freshness_note("1616") is None
 
     def test_silent_when_either_side_is_unreadable(self, monkeypatch):
-        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "__error__")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_SNAPSHOT", "__error__")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-03T12:00:00Z")
         assert _mod._ci_freshness_note("1616") is None
-        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-03T12:00:00Z")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_SNAPSHOT", "2026-09-03T12:00:00Z")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "__error__")
         assert _mod._ci_freshness_note("1616") is None
 
@@ -635,7 +811,7 @@ class TestCiFreshnessNote:
         """GitHub returns `Z` on the checks API and a numeric offset on the
         commit API. Comparing them as STRINGS would put `2026-09-02T21:43:17Z`
         before `2026-09-02T17:43:17-04:00` — the same instant, wrong answer."""
-        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-02T13:17:21Z")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_SNAPSHOT", "2026-09-02T13:17:21Z")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T17:43:17-04:00")
         assert _mod._ci_freshness_note("1541") is not None
 
@@ -643,6 +819,6 @@ class TestCiFreshnessNote:
         """Comparing naive to aware raises TypeError; outside the guard that
         aborts the whole report mid-print — a partial report that looks
         structurally complete (SHOULD-FIX 9)."""
-        monkeypatch.setenv("_TEST_GH_CI_NEWEST_START", "2026-09-02T13:17:21")
+        monkeypatch.setenv("_TEST_GH_CI_NEWEST_SNAPSHOT", "2026-09-02T13:17:21")
         monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T21:43:17Z")
         assert _mod._ci_freshness_note("1541") is None

--- a/tests/test_hooks/test_git_push_guard_migration_prefixes.py
+++ b/tests/test_hooks/test_git_push_guard_migration_prefixes.py
@@ -1,0 +1,562 @@
+"""The migration-prefix collision gate inside git_push_guard.
+
+WHY THIS EXISTS, measured 2026-09-03. CI's `migration-check` job
+(`.github/workflows/ci.yml`) already rejects duplicate prefixes — but it runs on
+the PR's merge preview at ONE MOMENT, and that verdict then goes stale. Two
+failure modes slip through, and both were live on the board when this was
+written:
+
+  * STALE GREEN. #1541's `migration-check` passed 2026-09-02T13:17Z; the
+    colliding `0090_ws2_calibration_sunset.py` landed on main 8.5 hours later at
+    21:43Z. The tick stayed green and the PR stayed MERGEABLE. 30 of 48 open PRs
+    were in this stale-CI state.
+  * CROSS-PR INVISIBILITY. #1610 and #1616 each add a DIFFERENTLY-NAMED
+    `0092_*.py`. Each is individually clean, so no single PR's CI can ever see
+    the collision — it exists only after both merge.
+
+The consequence is not cosmetic: BOTH runners (`db/migrations/runner.py:252-264`
+and `db/data_migrations/runner.py`) run a duplicate-prefix pre-flight and raise,
+so a collision halts every migration on every install at next restart until a
+human renames a file. That severity plus the measured frequency is why this gate
+BLOCKS rather than advises (the standing axiom is advisory-by-default; a block
+needs a specific, credible, measured reason, and this has both halves).
+
+FAIL DIRECTION, split deliberately:
+
+  * a DEFINITE collision BLOCKS — a prefix this PR ADDS that already exists on
+    the default branch, that another open PR also adds, or that this PR itself
+    claims twice;
+  * a failure of the gate's own PLUMBING (gh unreadable, malformed payload, a
+    truncated listing we could not resolve, an impossible EMPTY listing) does
+    NOT block. Walling off every merge over an auxiliary availability check is
+    a worse failure than the one it prevents, and it mirrors the pin-receipt
+    gate's split.
+
+Only ADDED files claim a prefix (architect BLOCKER 2): a PR that merely edits
+or deletes an existing migration claims nothing, and reading every touched path
+as an addition would hard-block two PRs that both patch one old migration —
+with no override, since this gate deliberately has none.
+
+The truncation case is called out because "the listing ended" and "there is
+nothing there" are indistinguishable to a naive reader: GraphQL caps a PR's
+file list AND the PR list itself, #1541 hit the file cap live, and a gate that
+read the short list as "no migrations" would report CLEAN on the very PR
+carrying collisions.
+
+Network-free via the `_TEST_GH_*` env-injection seams, matching the sibling
+gates' convention — PLUS subprocess-level tests (seams deleted, subprocess.run
+faked) so the GraphQL parse, the changeType filter, the refetch loop and the
+truncation accounting are exercised rather than stubbed out from every test
+(architect SHOULD-FIX 7: with autouse seams alone, the entire network layer had
+zero coverage and deleting it wholesale left 24 greens).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess as _subprocess
+from pathlib import Path
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parent.parent.parent
+_spec = importlib.util.spec_from_file_location(
+    "git_push_guard", _WORKTREE / "scripts" / "hooks" / "git_push_guard.py"
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+_D = "src/genesis/db/migrations/"
+_DD = "src/genesis/db/data_migrations/"
+
+
+def _files(*paths: str, status: str = "added") -> str:
+    """The `_TEST_GH_PR_FILES` wire format: one JSON object per line."""
+    return "\n".join(
+        json.dumps({"filename": p, "previous_filename": None, "status": status}) for p in paths
+    )
+
+
+def _main(*names: str) -> str:
+    """The `_TEST_GH_MAIN_MIGRATIONS` seam: one entry per line (bare basename
+    = the numbered dir; an entry with a slash is a full path)."""
+    return "\n".join(names)
+
+
+def _others(
+    mapping: dict[int, list[str]],
+    truncated: list[int] | None = None,
+    pr_list_truncated: bool = False,
+) -> str:
+    """The `_TEST_GH_OPEN_PR_MIGRATIONS` seam: a JSON object."""
+    return json.dumps(
+        {
+            "prs": {str(k): v for k, v in mapping.items()},
+            "truncated": truncated or [],
+            "pr_list_truncated": pr_list_truncated,
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _seams(monkeypatch):
+    """Default every test to a readable, empty world.
+
+    Set explicitly rather than left unset: an UNSET seam falls through to the
+    live `gh` path, which would make these tests network-dependent and — worse —
+    quietly pass for the wrong reason on a machine with `gh` auth. The
+    subprocess-level tests below DELETE these deliberately and fake the layer
+    underneath instead.
+    """
+    monkeypatch.setenv("_TEST_GH_PR_FILES", "")
+    monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", "")
+    monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", _others({}))
+
+
+class TestPrefixExtraction:
+    """`_migration_prefix_claims` — what counts as claiming a prefix."""
+
+    def test_extracts_four_digit_prefix(self):
+        got = _mod._migration_prefix_claims([f"{_D}0092_tco_tool_use_id.py"])
+        assert got == {"0092": ["0092_tco_tool_use_id.py"]}
+
+    def test_two_files_under_one_prefix_are_BOTH_kept(self):
+        """Last-write-wins would collapse the exact state the runner raises on
+        — a PR self-colliding — into one invisible entry (SHOULD-FIX 6)."""
+        got = _mod._migration_prefix_claims([f"{_D}0092_a.py", f"{_D}0092_b.py"])
+        assert got == {"0092": ["0092_a.py", "0092_b.py"]}
+
+    def test_data_migrations_claim_their_own_namespace(self):
+        """Both runners raise on duplicates; only the numbered dir was covered
+        by CI (SHOULD-FIX 5). The `d` prefix keeps the keys disjoint, so the
+        namespaces can never cross-collide in one dict."""
+        got = _mod._migration_prefix_claims([f"{_DD}d0004_purge.py", f"{_D}0004_other.py"])
+        assert got == {"d0004": ["d0004_purge.py"], "0004": ["0004_other.py"]}
+
+    def test_ignores_non_migration_paths(self):
+        assert _mod._migration_prefix_claims(["src/genesis/db/crud/foo.py"]) == {}
+
+    def test_ignores_the_runner_and_dunder_files(self):
+        got = _mod._migration_prefix_claims([f"{_D}runner.py", f"{_D}__init__.py"])
+        assert got == {}
+
+    def test_ignores_a_nested_path_under_the_directory(self):
+        assert _mod._migration_prefix_claims([f"{_D}sub/0092_x.py"]) == {}
+
+    def test_requires_exactly_four_digits(self):
+        assert _mod._migration_prefix_claims([f"{_D}092_short.py"]) == {}
+        assert _mod._migration_prefix_claims([f"{_D}00921_long.py"]) == {}
+
+    def test_matches_the_runners_charset_not_a_looser_one(self):
+        """The runner's discovery regex is `\\w+` — a dash or dot name is
+        silently SKIPPED at runtime and can never produce the RuntimeError this
+        gate cites, so claiming it here would block on a phantom (NOTE 10)."""
+        assert _mod._migration_prefix_claims([f"{_D}0092_a-b.py"]) == {}
+        assert _mod._migration_prefix_claims([f"{_D}0092_a.b.py"]) == {}
+
+    def test_requires_a_py_extension(self):
+        assert _mod._migration_prefix_claims([f"{_D}0092_notes.md"]) == {}
+
+
+class TestOnlyAddedFilesClaim:
+    """BLOCKER 2: a touched file is not an added file."""
+
+    def test_a_modified_migration_claims_nothing(self, monkeypatch):
+        """Two PRs both PATCHING one existing migration must not block each
+        other — neither is creating a prefix."""
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES", _files(f"{_D}0090_ws2_sunset.py", status="modified")
+        )
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0090_ws2_sunset.py"))
+        monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", _others({1610: ["0090_ws2_sunset.py"]}))
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is False
+        assert "no migration" in msg.lower()
+
+    def test_a_removed_migration_claims_nothing(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0090_ws2_sunset.py", status="removed"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0090_ws2_sunset.py"))
+        blocked, _ = _mod._check_migration_prefixes("1616")
+        assert blocked is False
+
+    def test_a_renamed_target_still_claims(self, monkeypatch):
+        """A rename CREATES the destination path — that prefix is claimed."""
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_renamed.py", status="renamed"))
+        monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", _others({1610: ["0092_other.py"]}))
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is True
+        assert "0092" in msg
+
+
+class TestSelfCollision:
+    def test_one_pr_adding_two_files_under_one_prefix_blocks(self, monkeypatch):
+        """The exact state the runner raises on; a scan comparing only against
+        OTHER sources is structurally blind to it (SHOULD-FIX 6)."""
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_a.py", f"{_D}0092_b.py"))
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is True
+        assert "0092_a.py" in msg and "0092_b.py" in msg
+
+
+class TestCollisionWithDefaultBranch:
+    """The STALE-GREEN mode: main moved after CI last ran (#1541)."""
+
+    def test_blocks_when_prefix_already_on_main(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0090_session_ledger.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0090_ws2_sunset.py"))
+        blocked, msg = _mod._check_migration_prefixes("1541")
+        assert blocked is True
+        assert "0090" in msg
+        # Names BOTH sides — a bare "0090 collides" leaves the reader to go
+        # find what it collides with, which is the diagnosis they need.
+        assert "0090_ws2_sunset.py" in msg
+        assert "0090_session_ledger.py" in msg
+
+    def test_reports_every_colliding_prefix_not_just_the_first(self, monkeypatch):
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            _files(f"{_D}0087_a.py", f"{_D}0088_b.py", f"{_D}0089_c.py"),
+        )
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0087_x.py", "0088_y.py", "0089_z.py"))
+        blocked, msg = _mod._check_migration_prefixes("1541")
+        assert blocked is True
+        for p in ("0087", "0088", "0089"):
+            assert p in msg
+
+    def test_allows_a_fresh_prefix(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0093_entity.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0091_last.py"))
+        blocked, _ = _mod._check_migration_prefixes("1477")
+        assert blocked is False
+
+    def test_same_filename_on_main_is_not_a_collision(self, monkeypatch):
+        """A long-lived branch that already merged main can show main's own
+        migrations as ADDED relative to its ancient merge-base. Identical path
+        = the same file, not a duplicate prefix."""
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0090_ws2_sunset.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0090_ws2_sunset.py"))
+        blocked, _ = _mod._check_migration_prefixes("1541")
+        assert blocked is False
+
+    def test_data_migration_collision_with_main_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_DD}d0004_mine.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main(f"{_DD}d0004_theirs.py"))
+        blocked, msg = _mod._check_migration_prefixes("1700")
+        assert blocked is True
+        assert "d0004" in msg
+
+
+class TestCollisionWithOtherOpenPRs:
+    """The CROSS-PR mode: each PR individually clean (#1610 vs #1616)."""
+
+    def test_blocks_when_another_open_pr_claims_the_prefix(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_tco.py"))
+        monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", _others({1610: ["0092_void_owner.py"]}))
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is True
+        assert "0092" in msg
+        assert "1610" in msg  # names WHICH PR — the reader must go look at it
+
+    def test_does_not_collide_with_itself(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_tco.py"))
+        monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", _others({1616: ["0092_tco.py"]}))
+        blocked, _ = _mod._check_migration_prefixes("1616")
+        assert blocked is False
+
+    def test_self_exclusion_is_by_number_not_by_filename(self, monkeypatch):
+        """Excluding "the file I also have" instead of "my own PR row" would
+        silence a REAL collision whenever two PRs add the same basename."""
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_tco.py"))
+        monkeypatch.setenv(
+            "_TEST_GH_OPEN_PR_MIGRATIONS",
+            _others({1616: ["0092_tco.py"], 1610: ["0092_tco.py"]}),
+        )
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is True
+        assert "1610" in msg
+
+
+class TestFailDirection:
+    """Plumbing failures must NOT block; they must also not read as clean."""
+
+    def test_unreadable_pr_file_list_does_not_block(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", "__error__")
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is False
+        assert "could not" in msg.lower() or "unverified" in msg.lower()
+
+    def test_unreadable_main_listing_does_not_block(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_tco.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", "__error__")
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is False
+        assert "could not" in msg.lower() or "unverified" in msg.lower()
+
+    def test_an_EMPTY_main_listing_is_an_anomaly_not_a_clean_pass(self, monkeypatch):
+        """90+ migrations exist on main; a successful listing with zero rows
+        means the read did not describe the directory — the seen-nothing case
+        that must never report no-problem (SHOULD-FIX 4). The autouse fixture
+        sets this seam empty, so this test asserts on the DEFAULT world too."""
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_tco.py"))
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is False
+        assert "EMPTY" in msg
+        assert "ok (" not in msg
+
+    def test_unreadable_open_pr_listing_still_blocks_a_main_collision(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0090_x.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0090_ws2.py"))
+        monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", "__error__")
+        blocked, msg = _mod._check_migration_prefixes("1541")
+        assert blocked is True
+        assert "0090" in msg
+
+    def test_truncated_listing_never_reads_as_clean(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0095_new.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0091_last.py"))
+        monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", _others({}, truncated=[1541]))
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is False
+        assert "1541" in msg
+        assert "truncat" in msg.lower() or "incomplete" in msg.lower()
+
+    def test_a_truncated_PR_LIST_never_reads_as_clean(self, monkeypatch):
+        """The sweep caps the PR list itself at 100; above that, unseen PRs
+        must be REPORTED, not silently treated as clean (SHOULD-FIX 3)."""
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0095_new.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0091_last.py"))
+        monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", _others({}, pr_list_truncated=True))
+        blocked, msg = _mod._check_migration_prefixes("1616")
+        assert blocked is False
+        assert "TRUNCATED" in msg
+
+    def test_partial_scan_still_states_what_it_DID_verify(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0093_entity.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0091_last.py"))
+        monkeypatch.setenv("_TEST_GH_OPEN_PR_MIGRATIONS", _others({}, truncated=[1541]))
+        blocked, msg = _mod._check_migration_prefixes("1477")
+        assert blocked is False
+        assert "default branch" in msg
+        assert "1541" in msg
+
+    def test_no_migrations_in_pr_is_a_clean_pass(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files("README.md"))
+        blocked, msg = _mod._check_migration_prefixes("1657")
+        assert blocked is False
+        assert "no migration" in msg.lower()
+
+
+def _fake_run(responses):
+    """A subprocess.run stand-in: pops canned (stdout, returncode) per call and
+    RECORDS each argv, so a test can assert which calls actually happened."""
+    calls = []
+
+    def run(argv, **kwargs):
+        calls.append(argv)
+        stdout, rc = responses.pop(0)
+        return _subprocess.CompletedProcess(argv, rc, stdout=stdout, stderr="")
+
+    return run, calls
+
+
+def _graphql_payload(nodes, pr_list_has_next=False):
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "pageInfo": {"hasNextPage": pr_list_has_next},
+                        "nodes": nodes,
+                    }
+                }
+            }
+        }
+    )
+
+
+def _pr_node(number, paths, has_next=False, change_type="ADDED"):
+    return {
+        "number": number,
+        "files": {
+            "pageInfo": {"hasNextPage": has_next},
+            "nodes": [{"path": p, "changeType": change_type} for p in paths],
+        },
+    }
+
+
+class TestOpenPrSweepSubprocessLevel:
+    """The network layer itself — seams DELETED, subprocess.run faked.
+
+    With the autouse seams alone, the GraphQL parse, changeType filter, refetch
+    loop and truncation accounting had ZERO executions under pytest: the whole
+    block could be deleted and 24 tests stayed green (SHOULD-FIX 7). These run
+    the real code against canned wire payloads.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_seam(self, monkeypatch):
+        monkeypatch.delenv("_TEST_GH_OPEN_PR_MIGRATIONS", raising=False)
+        monkeypatch.delenv("_TEST_GH_PR_FILES", raising=False)
+
+    def test_parses_the_graphql_payload_and_filters_changetype(self, monkeypatch):
+        run, calls = _fake_run(
+            [
+                (
+                    _graphql_payload(
+                        [
+                            _pr_node(1610, [f"{_D}0092_void.py"]),
+                            _pr_node(1600, [f"{_D}0090_ws2.py"], change_type="MODIFIED"),
+                        ]
+                    ),
+                    0,
+                )
+            ]
+        )
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        out = _mod._open_pr_migrations(repo="o/r")
+        assert out is not None
+        prs, unresolved, pr_trunc = out
+        # The MODIFIED file must not claim; the ADDED one must — and as a FULL
+        # path, because the consumer re-parses claims through the dir-anchored
+        # matcher. A basename here made every live cross-PR collision vanish
+        # while all seam-fed tests stayed green (shipped once, caught only by
+        # the live acceptance replay).
+        assert prs == {"1610": [f"{_D}0092_void.py"]}
+        assert unresolved == [] and pr_trunc is False
+        assert len(calls) == 1  # no refetch when nothing overflowed
+
+    def test_live_sweep_output_actually_collides_in_the_consumer(self, monkeypatch):
+        """THE CONTRACT TEST: the sweep's real (non-seam) output must flow
+        through `_check_migration_prefixes` and produce a block. The producer
+        and consumer were each green in isolation while their wire format
+        disagreed — only a test that wires one into the other pins the
+        contract."""
+        run, _ = _fake_run([(_graphql_payload([_pr_node(1610, [f"{_D}0092_void.py"])]), 0)])
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        # Own files + main via seams; ONLY the open-PR sweep goes live.
+        monkeypatch.setenv("_TEST_GH_PR_FILES", _files(f"{_D}0092_tco.py"))
+        monkeypatch.setenv("_TEST_GH_MAIN_MIGRATIONS", _main("0091_last.py"))
+        blocked, msg = _mod._check_migration_prefixes("1616", repo="o/r")
+        assert blocked is True
+        assert "0092" in msg and "1610" in msg
+
+    def test_an_overflowing_file_list_triggers_exactly_one_refetch(self, monkeypatch):
+        run, calls = _fake_run(
+            [
+                (_graphql_payload([_pr_node(1541, [], has_next=True)]), 0),
+                # the refetch: _pr_added_files' REST read for #1541
+                (f"{_D}0090_ledger.py\n", 0),
+            ]
+        )
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        out = _mod._open_pr_migrations(repo="o/r")
+        assert out is not None
+        prs, unresolved, _ = out
+        assert prs == {"1541": [f"{_D}0090_ledger.py"]}  # full path — see above
+        assert unresolved == []
+        assert len(calls) == 2
+        assert "1541" in " ".join(str(a) for a in calls[1])
+
+    def test_overflow_beyond_the_refetch_cap_lands_in_unresolved(self, monkeypatch):
+        overflowing = [
+            _pr_node(1500 + i, [], has_next=True)
+            for i in range(_mod._MIGRATION_TRUNCATION_REFETCH_CAP + 2)
+        ]
+        responses = [(_graphql_payload(overflowing), 0)]
+        responses += [("", 0)] * _mod._MIGRATION_TRUNCATION_REFETCH_CAP
+        run, calls = _fake_run(responses)
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        out = _mod._open_pr_migrations(repo="o/r")
+        assert out is not None
+        _, unresolved, _ = out
+        # Everything past the cap is REPORTED, never silently dropped.
+        assert len(unresolved) == 2
+        assert len(calls) == 1 + _mod._MIGRATION_TRUNCATION_REFETCH_CAP
+
+    def test_pr_list_truncation_is_surfaced(self, monkeypatch):
+        run, _ = _fake_run([(_graphql_payload([], pr_list_has_next=True), 0)])
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        out = _mod._open_pr_migrations(repo="o/r")
+        assert out is not None
+        assert out[2] is True
+
+    def test_a_failed_graphql_call_returns_None(self, monkeypatch):
+        run, _ = _fake_run([("", 1)])
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        assert _mod._open_pr_migrations(repo="o/r") is None
+
+    def test_added_files_reads_status_from_the_wire(self, monkeypatch):
+        """`_pr_added_files`' live jq filters by status; the seam path filters
+        in Python. This exercises the SEAM path's filter with explicit
+        statuses — the live filter is asserted by the jq text itself."""
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            _files(f"{_D}0092_a.py", status="added")
+            + "\n"
+            + _files(f"{_D}0090_b.py", status="modified"),
+        )
+        assert _mod._pr_added_files("1") == [f"{_D}0092_a.py"]
+
+
+class TestCiFreshnessNote:
+    """ADVISORY only — a green tick that predates the current default branch.
+
+    Measured 2026-09-03: 30 of 48 open PRs were in this state, the oldest
+    (#1223) carrying a tick from six weeks earlier. That is the majority of the
+    queue, so this can only ever be a note: blocking on it would refuse 62% of
+    open PRs for a condition every one of them shares, and the honest remedy
+    (re-run CI against current main) is a throughput decision the owner makes,
+    not something a gate should force one PR at a time.
+    """
+
+    def test_flags_a_check_older_than_the_default_branch_head(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-02T13:17:21Z")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T21:43:17Z")
+        note = _mod._ci_freshness_note("1541")
+        assert note is not None
+        assert "DIFFERENT main" in note
+        # Both instants named — a note that says "stale" without saying stale
+        # against WHAT sends the reader back to the API to find out.
+        assert "2026-09-02T13:17:21Z" in note and "2026-09-02T21:43:17Z" in note
+
+    def test_note_does_not_assert_a_CI_verdict_it_never_read(self, monkeypatch):
+        """Caught live: the first wording said "green against a different main",
+        but this function never reads pass/fail — and #1541, the very PR it was
+        demonstrated on, had gone RED under a concurrent push. Staleness and
+        outcome are independent facts; claiming one from the other is exactly
+        the unverified-assertion class the report is supposed to avoid."""
+        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-02T13:17:21Z")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T21:43:17Z")
+        note = _mod._ci_freshness_note("1541")
+        assert "green" not in note.lower()
+        assert "pass" not in note.lower()
+
+    def test_silent_when_the_check_is_newer_than_main(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-03T18:00:00Z")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-03T12:00:00Z")
+        assert _mod._ci_freshness_note("1616") is None
+
+    def test_silent_when_either_side_is_unreadable(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "__error__")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-03T12:00:00Z")
+        assert _mod._ci_freshness_note("1616") is None
+        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-03T12:00:00Z")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "__error__")
+        assert _mod._ci_freshness_note("1616") is None
+
+    def test_handles_offset_timestamps_not_just_Z(self, monkeypatch):
+        """GitHub returns `Z` on the checks API and a numeric offset on the
+        commit API. Comparing them as STRINGS would put `2026-09-02T21:43:17Z`
+        before `2026-09-02T17:43:17-04:00` — the same instant, wrong answer."""
+        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-02T13:17:21Z")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T17:43:17-04:00")
+        assert _mod._ci_freshness_note("1541") is not None
+
+    def test_a_naive_timestamp_yields_silence_not_a_crash(self, monkeypatch):
+        """Comparing naive to aware raises TypeError; outside the guard that
+        aborts the whole report mid-print — a partial report that looks
+        structurally complete (SHOULD-FIX 9)."""
+        monkeypatch.setenv("_TEST_GH_CI_COMPLETED_AT", "2026-09-02T13:17:21")
+        monkeypatch.setenv("_TEST_GH_DEFAULT_HEAD_DATE", "2026-09-02T21:43:17Z")
+        assert _mod._ci_freshness_note("1541") is None


### PR DESCRIPTION
CI's `migration-check` is correct and stays: it rejects duplicate migration prefixes on the merge preview. But that verdict is a snapshot, and two failure modes outlive it — both live on the board when this was built:

- **Stale green.** A PR's check passed; hours later a colliding migration landed on the default branch. The tick stayed green, the PR stayed MERGEABLE, and merging it would have halted every migration on every install at next restart (both runners raise on a duplicate prefix before running anything).
- **Cross-PR invisibility.** Two open PRs each add a *differently-named* file under one prefix. Each is individually clean; the collision exists only after both merge. No single PR's CI can ever see it.

### What this adds

`--check-pr` and the merge-enforcement arm now re-derive prefix claims **at merge time**: this PR's added migration files vs the default branch's live listing and vs every other open PR's added files (one GraphQL sweep; per-PR paginated refetch when a file list overflows its page). Both migration namespaces are covered — the numbered directory and the `d`-prefixed data migrations, whose runner raises identically and which nothing previously watched.

Design points that came out of adversarial review rather than the first draft:

- **Only added/renamed/copied files claim a prefix.** A PR that merely edits an existing migration claims nothing — otherwise two PRs patching one old migration would hard-block each other, and this gate deliberately has no override sigil (a true collision's honest fix is renaming a file, which takes seconds).
- **A PR claiming one prefix twice itself blocks** — the exact state the runner raises on, invisible to any scan that only compares against other sources.
- **Deliberately the last merge gate.** Every gate before it fails closed under a drained API budget; this one degrades open with a NOTE, so under starvation it can only harm itself.
- **No silent bounds.** An unreadable listing, an impossible-empty listing, an overflowed file list past the refetch cap, and the open-PR list's own page cap are each stated in the output, never folded into a clean verdict.

The report also prints an advisory when a PR's newest completed check predates the current default-branch head — naming both instants, and asserting no CI verdict it never read (staleness and outcome are independent facts).

### Verification

- 906 tests across all push-guard files; 42 new, each seen RED before its green was trusted
- 5/5 targeted mutations verify-RED (compile-checked before running; hash-verified restores from a single baseline copy)
- Live acceptance: all four real collision cases on the current board block with both sides named; two clean controls stay clean
- Measured rate: 4/48 open PRs fire (8.3%), zero unverified NOTEs; all four adjudicated true positives against independent ground truth (CI's own check agrees on one and is structurally blind to the other three)
- One defect was introduced mid-fix and caught before commit: the live sweep emitted basenames where the consumer parses directory-anchored paths, silently erasing every cross-PR collision while all seam-fed unit tests stayed green. The live replay caught it; a contract test now feeds the sweep's real output into the real consumer and goes RED on exactly that regression.
- Gate cost measured: 0.63s on the no-migration path, ~5–6s on a collision path, inside the merge gate's 45s budget


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration conflict checks now account for created, removed, and renamed files, including incomplete or malformed file listings.
  * Checks use the pull request’s actual base branch and limit cross-pull-request collisions to matching targets.
  * Conflict reports distinguish numbered migrations from data-migration batches and preserve exact filenames.
  * CI freshness checks compare check-suite creation time with the target branch tip.

* **Improvements**
  * Pre-merge reports provide advisory freshness status and more detailed migration validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->