### PR TITLE
fix(privacy): scrub the maintainer's name from a docstring and a test fixture

### DIFF
--- a/src/genesis/eval/graph_bakeoff/__init__.py
+++ b/src/genesis/eval/graph_bakeoff/__init__.py
@@ -2,8 +2,8 @@
 
 Collects DATA to inform the 2026-08-14 engine decision (NetworkX-incremental vs
 LadybugDB vs FalkorDB) for Genesis's memory graph. It does NOT compute a winner:
-the findings doc reports raw numbers; Jay + Genesis make the subjective call
-jointly (decision protocol, 2026-08-06).
+the findings doc reports raw numbers; the owner and Genesis make the subjective
+call jointly (decision protocol, 2026-08-06).
 
 Design invariants:
 - Read-only against a FROZEN snapshot (every number cites the snapshot sha256).

--- a/tests/test_scripts/test_inbox_sync.py
+++ b/tests/test_scripts/test_inbox_sync.py
@@ -162,12 +162,12 @@ def test_healthy_cycle_push_not_age_gated(tmp_path):
 
 
 def test_healthy_listing_cleans_user_deleted_file(tmp_path):
-    """Intent lock, with the live corpus's filename shapes (spaces/&/'):
-    a file absent from a HEALTHY listing and older than grace is a user
-    deletion → cleaned; a still-listed file stays."""
+    """Intent lock, with the filename shapes a real vault produces
+    (spaces / & / apostrophe): a file absent from a HEALTHY listing and older
+    than grace is a user deletion → cleaned; a still-listed file stays."""
     env, inbox, log, _ = _setup(tmp_path)
     gone = _old_response_file(inbox, "My todos & musings-1.genesis.md")
-    stays = _old_response_file(inbox, "Jay's Notes-2.genesis.md")
+    stays = _old_response_file(inbox, "Someone's Notes-2.genesis.md")
     _set_listing(env, [stays.name])  # user deleted the first in Obsidian
 
     r = _run(env)


### PR DESCRIPTION
## What

Removes the last two occurrences of the maintainer's real first name from this public repository.

A case-insensitive word-boundary `git grep` for that name on `main` returns 2. Both are fixed here; the count is now 0. The name itself is deliberately not written out in this description — see the note at the bottom.

## The two

**`src/genesis/eval/graph_bakeoff/__init__.py:5`** — a module docstring naming the maintainer in a sentence whose actual point is that a *human*, not the harness, makes the subjective call. Reworded to say that.

**`tests/test_scripts/test_inbox_sync.py:170`** — a fixture filename, and the worse of the two. The docstring directly above it said the fixtures use "the live corpus's filename shapes", so the file did not merely contain a name: it asserted these were real filenames from a real personal vault. That binds a name to a personal setup.

The fixture exists to exercise awkward filename **shapes** — space, `&`, apostrophe — through the listing and quoting path. `"Someone's Notes-2.genesis.md"` keeps every one of those. The sibling fixture `"My todos & musings-1.genesis.md"` is untouched: it carries the space-and-ampersand shape and discloses nothing.

## Why it is not just these two

The name was treated as a sample of the class, not the spec. The rest was swept and measured:

| checked | result |
|---|---|
| email addresses, excluding `example.com` / `test` / `noreply` | only doc placeholders, obviously-fake fixtures, a systemd unit path, and vendored editor bundles |
| the maintainer's account handle and personal mail domain | 0 |
| the deploy's container IP, host IP, and tailnet address | 0 each |

The `100.64.0.0/10` and `192.168.0.0/16` matches are CGNAT/RFC1918 **range constants** in `session_cap.py`, `netclass.py` and `SECURITY.md`, not anyone's address.

## Verification

- The word-boundary grep returns 0 across the whole tree.
- `pytest tests/test_scripts/test_inbox_sync.py` → 8 passed.
- No runtime path touched: one docstring and one test literal. The changed test asserts on file existence and on a log line quoting the *other* filename, so nothing references the renamed fixture by string.

## A correction to this description itself

An earlier version of this body spelled the name out three times while explaining that it was being removed — reproducing the disclosure on a public page in the course of fixing it. The review caught the class and it was right to: the tree-level `git grep` used as verification searches the tree only, so it cannot see the PR description, the commit message, or review comments. Those are public surfaces too, and the check has to cover them.

Scope of that slip, measured across every artifact authored for this work — PR bodies, issue comments, and review replies on all six PRs touched: two artifacts, this description and one comment on another PR. Both were editable in place and have been corrected. Commit metadata on this branch contains zero occurrences, verified against `%B` plus author fields rather than assumed, so nothing required a rewrite of history.
