### PR TITLE
docs(dev-skill): select, don't amputate — a rule against truncation

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -221,9 +221,17 @@ Three rules when a bound really is needed:
 
 - **Bound by MEANING, not by one blanket number.** A closed set is validated
   against that set — a value outside it is INVALID, not "too long". A timestamp
-  is a shape; half a timestamp is not a shorter timestamp. Only genuinely free
-  text gets a length bound. A blanket cap turns 100,000 characters of foreign
-  data into 300 characters of foreign data and calls it bounded.
+  is a shape; half a timestamp is not a shorter timestamp. A blanket cap turns
+  100,000 characters of foreign data into 300 characters of foreign data and
+  calls it bounded.
+  **This governs HOW you bound, never WHETHER you may.** Rejecting a structured
+  value or a collection by size is correct and stays correct: an over-long id, an
+  over-large batch or an implausibly large file is simply not a value we accept,
+  and refusing it is a resource guard, not an amputation
+  (`channels/voice/transcript_writer.py` rejects a `session_id` over 128 chars;
+  `dashboard/routes/follow_ups.py` rejects a batch over 200 ids). What is
+  forbidden is silently CUTTING them to fit. Only free text gets a bound it is
+  expected to sit under; everything else gets one it must not cross.
 - **Derive the number, and record how.** Measure the real population and report
   `k/N` per the Acceptance Bar — then name the corpus, the query and the date, so
   the next reader can re-derive it rather than take it on faith. Re-derivable
@@ -242,22 +250,39 @@ Three rules when a bound really is needed:
   -consequence model in `memory/integrity_repair.py:27` ("Truncation asymmetry").
 
 One trap worth naming: a cap can manufacture a correctness bug in the data it was
-added to protect. Bounding an IDENTIFIER by truncation merges two distinct
-identities onto one key, and downstream code then attributes one subject's state
-to another.
+added to protect. Truncating an identifier used as a KEY merges two distinct
+identities into one, and downstream code then attributes one subject's state to
+another. A short DISPLAY handle is a different thing and is the house pattern —
+`memory_expand` resolves an 8-char prefix and reports `ambiguous` rather than
+guessing. The rule is about the stored key, not the rendered one.
 
 **A real need to truncate is a CONVERSATION to have, not a magic number to pick
 alone.** If you catch yourself choosing 300 or 200 or 1000, stop and raise it —
 and if there is nobody to raise it with (an unattended background session), the
-default is: emit the value WHOLE and record a follow-up naming the value, the
-population you could not measure, and the decision owed. Never pick the number
-just because no one was there to stop you.
+default is: emit the value WHOLE and record the decision owed — the value, the
+population you could not measure, and what you could not decide. Never pick the
+number just because no one was there to stop you.
+
+Record it somewhere that session can actually reach AND that PRESERVES it —
+availability is not preservation, and checking only the first is how this very
+paragraph came out wrong the first time. An autonomy executor CODE or VERIFICATION
+step is tool-scoped (`step_dispatcher.py` hands those two the reflection denylist,
+whose allowed set in `cc/session_config.py` carries `follow_up_list` but not
+`follow_up_create`), so there "file a follow-up" is not an instruction it can
+execute. Its `result` field is no answer either: the contract calls it a "brief
+description" and every consumer cuts it — `[:200]` into the next step's prompt and
+into the trace, `[:2000]` on the write path — so a decision placed there is
+amputated by the machinery, which is the failure this section exists to name. Use
+`TASK_NOTEPAD.md`'s `## Decisions` section, which steps are already instructed to
+append to and which `engine._promote_notepad` stores WHOLE. Other unattended
+profiles differ — `interact` and `research` keep `follow_up_create` — so check the
+surface you are actually on instead of assuming the strictest case.
 
 That default is about SIZE, never about secrecy, and the two must not be
 confused. If a value may carry a credential, token, or personal data, the
 unbounded default does NOT apply: fail closed and omit it wholesale with a
-marker, exactly as the "omit explicitly" rule says, and keep only non-sensitive
-metadata in the follow-up. Losing diagnostic prose is recoverable; leaking a
+marker, exactly as the "omit explicitly" rule says, and record only
+non-sensitive metadata. Losing diagnostic prose is recoverable; leaking a
 token is not. Emitting whole and omitting wholesale are the same discipline —
 both refuse to hand on a fragment that looks complete.
 

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -192,17 +192,25 @@ only replaying a known-positive tells them apart.
 
 ### Select, don't amputate — truncation is the absence of a decision
 
-**Scope first, because bounding is often correct.** A bounded PREVIEW whose full
-value stays retrievable from its store is a selection with a pointer, not an
-amputation — `memory/proactive.py:418` renders `principle[:200]` into the
-injection block on purpose, and the whole record comes back from
-`procedure_recall`. Name the RIGHT retrieval path when you claim one: procedures
-live in SQLite `procedural_memory`, so `memory_expand` — which retrieves from the
-Qdrant collections only — cannot recover them, and a preview whose pointer does
-not resolve is an amputation wearing a citation. Bounding is likewise correct
-against a hard external budget (a hook stdout cap, a DB column, a context
-window). This section is about the other case: a value that is the ONLY copy,
-where cutting it destroys the information for good.
+**Scope first, because bounding is often correct.** A bounded PREVIEW is a
+selection with a pointer, not an amputation — but ONLY if the pointer actually
+resolves. The proactive memory hook is the worked example: it renders a snippet
+plus `id:xxxxxxxx`, and `memory_expand` takes exactly that handle (it resolves
+short prefixes and reports `ambiguous` rather than guessing) and returns the full
+record. Bounding is likewise correct against a hard external budget — a hook
+stdout cap, a DB column, a context window — and a log line or diagnostic
+rendering of something stored intact elsewhere is a preview like any other. This
+section is about the other case: a value that is the ONLY copy, where cutting it
+destroys the information.
+
+**Test the pointer before you call something a preview.** The same hook renders
+`principle[:200]` for procedures with an id beside it, and that one does NOT
+resolve: procedures live in SQLite `procedural_memory`, `memory_expand` retrieves
+only the Qdrant collections, and `procedure_recall` takes a task description and
+tags with no id lookup at all. So it looks exactly like the memory case and is an
+amputation — and successive drafts of this very section cited it as the carve-out,
+each naming a different wrong tool. A pointer you have not followed is not a
+pointer.
 
 **There, do not truncate.** Not strings, not lists, not context, not output.
 Reaching for a character cap is a signal that a question was skipped, not
@@ -241,8 +249,13 @@ Three rules when a bound really is needed:
   error_message IS NOT NULL AND error_message != '';` On one install on
   2026-09-03 that gave **270/318 (84.9%)** cut by a 300-char cap — and since JSON
   error bodies put the machine-readable cause last, the cap discards exactly the
-  part worth keeping. Your install will differ; the denominator is itself already
-  truncated at 1024, so treat it as a floor.
+  part worth keeping. Your install will differ.
+  This rule failed on itself once, which is why the correction stays: an earlier
+  draft hedged that rate as "a floor" because the corpus is capped at 1024
+  upstream. Wrong — a 1024-cap cannot change whether a length exceeds 300, and
+  `COUNT(*)` counts rows, so the rate is EXACT and only the CONTENT LOST is a
+  lower bound. Hedging a number you have not thought through is the same failure
+  as asserting one.
 - **Omit explicitly, with a constant-bounded marker** (`<omitted: 104,823
   chars>`), never a mid-value cut. An honest gap beats a plausible-looking
   fragment. Already the house pattern: repo-pulse's loud `limit_hit`
@@ -263,20 +276,39 @@ default is: emit the value WHOLE and record the decision owed — the value, the
 population you could not measure, and what you could not decide. Never pick the
 number just because no one was there to stop you.
 
-Record it somewhere that session can actually reach AND that PRESERVES it —
-availability is not preservation, and checking only the first is how this very
-paragraph came out wrong the first time. An autonomy executor CODE or VERIFICATION
-step is tool-scoped (`step_dispatcher.py` hands those two the reflection denylist,
-whose allowed set in `cc/session_config.py` carries `follow_up_list` but not
-`follow_up_create`), so there "file a follow-up" is not an instruction it can
-execute. Its `result` field is no answer either: the contract calls it a "brief
-description" and every consumer cuts it — `[:200]` into the next step's prompt and
-into the trace, `[:2000]` on the write path — so a decision placed there is
-amputated by the machinery, which is the failure this section exists to name. Use
-`TASK_NOTEPAD.md`'s `## Decisions` section, which steps are already instructed to
-append to and which `engine._promote_notepad` stores WHOLE. Other unattended
-profiles differ — `interact` and `research` keep `follow_up_create` — so check the
-surface you are actually on instead of assuming the strictest case.
+Record it somewhere that session can actually REACH and that PRESERVES it whole.
+Both halves, checked against the surface you are on. This instruction names no
+channel on purpose: every earlier draft prescribed one, and each was wrong for
+some surface. Three worked examples of getting it wrong, because the failures
+teach the check better than a rule does:
+
+- **Reachable, preserves nothing.** An executor step's `result` field exists
+  everywhere and its contract calls it a "brief description"; every consumer cuts
+  it — `[:200]` into the next step's prompt and into the trace, `[:2000]` on the
+  write path. Availability said yes; preservation said no.
+- **Preserves whole, not reachable.** `TASK_NOTEPAD.md` is promoted to memory
+  uncut — but it is seeded in a CODE task's worktree, and a VERIFICATION step runs
+  in the background-session directory, so for that step it is a file in the wrong
+  place. Preservation said yes; reachability said no.
+- **A ranking assumed instead of read.** A draft called CODE/VERIFICATION the
+  strictest executor scope because `follow_up_create` is denied there. Backwards:
+  the MCP setup is gated on `is_code_or_verify`, so RESEARCH/ANALYSIS/SYNTHESIS
+  get *zero* MCP tools — the denied-list surface is the most permissive one.
+  Membership facts were right; the ordering derived from them was never checked.
+
+The rule is the property, not the mechanism: **availability is not preservation,
+neither is portable between surfaces, and a ranking is a separate claim from the
+facts it sorts.** Verify each for the surface you are on. If nothing obvious
+qualifies, look harder before declaring a dead end — grep the sibling fields of
+whatever you were about to give up on. (The same `result` write that slices to
+`[:2000]` stores `blocker_description` and `artifacts` UNSLICED, and the step
+contract defines the first as "what decision is needed from the user", which is
+close to exactly this. It costs a `blocked` status, which is a real price worth
+naming — but it is an answer, and the earlier draft asserted there was none.)
+This is the one carve-out from "never leave a follow-up as just text": that rule
+assumes a surface where `follow_up_create` exists. Where it does not, an
+unrecorded debt is worse than a differently-recorded one — but say which surface
+forced it, so the exception cannot quietly become the habit.
 
 That default is about SIZE, never about secrecy, and the two must not be
 confused. If a value may carry a credential, token, or personal data, the

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -196,13 +196,18 @@ only replaying a known-positive tells them apart.
 amputation is LOSS — the value cut here was the only copy. Nothing else. A
 bounded PREVIEW of something stored intact elsewhere is a selection, and stays
 one even if its handle is useless. Bounding against a hard external budget is
-likewise correct: a hook's stdout cap, a database column, a context window. So is
-refusing an oversized value outright.
+likewise correct: a hook's stdout cap, a context window, a column whose limit is
+actually ENFORCED. That last qualifier is load-bearing here — this repo's SQLite
+`TEXT` columns enforce no length at all, so "the database column" does not
+excuse a cut; a self-imposed storage assumption is a decision to justify, not a
+budget to obey. So is refusing an oversized value outright.
 
 **And a SAFETY cap may be lossy — that is the one place cutting the only copy is
 right.** An unbounded stream has no other copy by definition, and reading it to
 the end to avoid "truncating" is how a runaway command exhausts memory; this repo
-bounds subprocess output at a few MiB for exactly that reason. Losing the tail of
+bounds subprocess output at a few MiB for exactly that reason
+(`autonomy/executor/deterministic.py` `_read_limited`, whose own comment names
+the `yes`-command threat; verified 2026-09-04). Losing the tail of
 a log beats losing the process. The obligation there is not to keep the bytes, it
 is to be LOUD about the cut — say the output was bounded and roughly by how much,
 so nobody reads a clipped log as a complete one. A silent lossy cap is still the
@@ -262,15 +267,18 @@ Three rules when a bound really is needed:
   plausible-looking fragment. The bound-plus-loud-flag half of this is already
   the house pattern; the character-count marker is a proposal, so do not go
   looking for a precedent that is not there.
-  **The line is DECLARED versus SILENT, not omit versus cut.** That is the
-  distinction this whole section is really about, and stating it as "never cut"
-  overshoots: this repo cuts mid-value in several places on purpose and is right
-  to — a resource guard on an unbounded stream, a preview rendered next to the
-  full record, a display string trimmed before escaping so the cut cannot land
-  mid-entity. Every one of those is a decision someone made and can defend. What
-  is forbidden is the cut nobody decided and nothing announces, because that is
-  the one that reaches a reader looking complete. Prefer the marker; when you cut
-  instead, say so where the value is read.
+  **Declaration is a requirement on top of the loss rules, never a substitute
+  for them.** Stating the rule as "never cut" overshoots: this repo cuts
+  mid-value in several places on purpose and is right to — a resource guard on
+  an unbounded stream, a preview rendered next to the full record, a display
+  string trimmed before escaping so the cut cannot land mid-entity. Each of
+  those is a cut the loss rules PERMIT (a safety cap, a pointer-backed
+  selection, third-party display text), and each is declared or bounded where
+  it is read. The order matters: first the loss rules decide whether a cut may
+  happen at all — announcing a sliced KEY does not un-merge the two identities
+  it collapsed — and only then does declaration decide whether the permitted
+  cut is honest. A silent permitted cut is still a defect; a loud forbidden cut
+  is still forbidden.
   **When the total is not already known, say that instead of computing it.**
   Bounding a stream is the case: learning the exact discarded length means
   reading the whole source, which is the cost the bound existed to avoid. So
@@ -307,25 +315,34 @@ unbounded default does NOT apply: fail closed, omit wholesale with a marker as
 the "omit explicitly" rule says, and keep only non-sensitive metadata. Losing
 diagnostic prose is recoverable; leaking a token is not.
 
-**Then ask WHO WROTE IT, before you ask where it is going.** Authorship is the
-axis that decides, and it beats destination outright. Third-party-authored
-content stays bounded and sanitized no matter how trusted the destination is —
+**Then ask WHO WROTE IT as well as where it is going — two independent axes,
+and each governs a different decision.** Destination governs DISCLOSURE: what
+may cross a trust boundary is decided by where it lands, whoever wrote it — a
+user-authored secret bound for an external channel still gets scanned and
+quarantined. Authorship governs SANITIZATION: third-party-authored content
+stays bounded and escaped no matter how trusted the destination is —
 this repo truncates and HTML-escapes a stranger's email fields on the way to the
-OWNER'S OWN chat, because that channel renders HTML unescaped, so a display name
-someone else chose would otherwise arrive as live markup in the one place the
-user trusts absolutely. Maximally authorized destination, maximally defensive
-treatment. Any rule that reads "it's going somewhere trusted, so pass it whole"
-deletes that defence.
+OWNER'S OWN chat (`outreach/engagement.py` `_sanitize_ping_field`, whose
+docstring names both the threat and the destination; verified 2026-09-04),
+because that channel renders HTML unescaped, so a display name someone else
+chose would otherwise arrive as live markup in the one place the user trusts
+absolutely. Maximally authorized destination, maximally defensive treatment.
+Any rule that reads "it's going somewhere trusted, so pass it whole" deletes
+that defence.
 
 **And an authorized destination does not mean untreated.** The rule is narrow:
 do not strip the USER'S OWN content on its way to the user. It is not a licence
-to stop scrubbing on owner-facing surfaces, and this repo does not — it rewrites
-username-bearing paths out of what the owner's own dashboard renders, gates
-credential values behind an explicit reveal rather than showing them, scrubs the
-draft the user reviews so the copy they approve is already clean, and in at least
-one subsystem deliberately keeps captured text out of its own private store
-entirely. "Into a private store" is emphatically not a blanket exemption; some
-stores are built specifically to never receive the value.
+to stop scrubbing on owner-facing surfaces, and this repo does not (each
+verified 2026-09-04): it rewrites username-bearing paths out of what the owner's
+own dashboard renders (`dashboard/routes/backup.py` `_scrub_reason`), gates
+credential values behind an explicit reveal rather than showing them (the
+References tab), scrubs the draft the user reviews so the copy they approve is
+already clean (`content/egress.py` `should_gate`, `category == "content"`), and
+in at least one subsystem deliberately keeps captured text out of its own
+private store entirely (`attention/types.py`: "never stored";
+`db/crud/attention.py`: "value-free … NO text"). "Into a private store" is
+emphatically not a blanket exemption; some stores are built specifically to
+never receive the value.
 
 **One last thing, learned the hard way from this section itself.** Four review
 rounds found defects in it, and every single one had the same shape: the cited

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -240,22 +240,34 @@ Three rules when a bound really is needed:
   `dashboard/routes/follow_ups.py` rejects a batch over 200 ids). What is
   forbidden is silently CUTTING them to fit. Only free text gets a bound it is
   expected to sit under; everything else gets one it must not cross.
-- **Derive the number, and record how.** Measure the real population and report
-  `k/N` per the Acceptance Bar — then name the corpus, the query and the date, so
-  the next reader can re-derive it rather than take it on faith. Re-derivable
-  example: provider error prose lands in `activity_log.error_message` (written by
-  `routing/router.py`, already capped there at 1024), so
-  `SELECT SUM(LENGTH(error_message) > 300), COUNT(*) FROM activity_log WHERE
-  error_message IS NOT NULL AND error_message != '';` On one install on
-  2026-09-03 that gave **270/318 (84.9%)** cut by a 300-char cap — and since JSON
-  error bodies put the machine-readable cause last, the cap discards exactly the
-  part worth keeping. Your install will differ.
-  This rule failed on itself once, which is why the correction stays: an earlier
-  draft hedged that rate as "a floor" because the corpus is capped at 1024
-  upstream. Wrong — a 1024-cap cannot change whether a length exceeds 300, and
-  `COUNT(*)` counts rows, so the rate is EXACT and only the CONTENT LOST is a
+- **Derive the number, and record how — against a corpus that OUTLIVES the
+  claim.** Measure the real population and report `k/N` per the Acceptance Bar,
+  then name the corpus, the query and the date. Naming them is necessary and not
+  sufficient: a query is only re-derivable if the rows are still there when the
+  next reader runs it.
+  Worked example, and it fails that second test — deliberately, because the
+  failure is the lesson. Provider error prose lands in
+  `activity_log.error_message` (written by `routing/router.py`, already capped
+  there at 1024), so `SELECT SUM(LENGTH(error_message) > 300), COUNT(*) FROM
+  activity_log WHERE error_message IS NOT NULL AND error_message != '';` On one
+  install on 2026-09-03 that gave **270/318 (84.9%)** cut by a 300-char cap —
+  and since JSON error bodies put the machine-readable cause last, the cap
+  discards exactly the part worth keeping.
+  That is an EPHEMERAL OBSERVATION, not a re-derivable one. `activity_log` is
+  reaped at 24 hours (`observability/provider_activity.py` `reap_old_records`,
+  scheduled four times daily by `runtime/init/learning.py`), and the query carries
+  no `created_at` predicate or snapshot id — so re-running it later measures a
+  different rolling window on the same install, and nobody can reproduce the
+  original. To make a number like this re-derivable you must pin the window in
+  the query AND export the rows, or measure something durable (git history, a
+  committed fixture) instead. Label it honestly when you cannot.
+  This rule has now failed on itself twice, which is why both corrections stay.
+  An earlier draft hedged that rate as "a floor" because the corpus is capped at
+  1024 upstream. Wrong — a 1024-cap cannot change whether a length exceeds 300,
+  and `COUNT(*)` counts rows, so the rate is EXACT and only the CONTENT LOST is a
   lower bound. Hedging a number you have not thought through is the same failure
-  as asserting one.
+  as asserting one; and calling a number re-derivable without checking that its
+  corpus survives is the same failure wearing the opposite face.
 - **Omit explicitly, with a constant-bounded marker** (`<omitted: 104,823
   chars>`), never a mid-value cut. An honest gap beats a plausible-looking
   fragment. Already the house pattern: repo-pulse's loud `limit_hit`
@@ -282,10 +294,18 @@ channel on purpose: every earlier draft prescribed one, and each was wrong for
 some surface. Three worked examples of getting it wrong, because the failures
 teach the check better than a rule does:
 
-- **Reachable, preserves nothing.** An executor step's `result` field exists
-  everywhere and its contract calls it a "brief description"; every consumer cuts
-  it — `[:200]` into the next step's prompt and into the trace, `[:2000]` on the
-  write path. Availability said yes; preservation said no.
+- **Reachable everywhere, preserving on only SOME paths.** An executor step's
+  `result` field exists everywhere and its contract calls it a "brief
+  description". The carry-forward paths cut it — `[:200]` into the next step's
+  prompt and into the trace, `[:2000]` on the write path — so a value left there
+  for a LATER step to read is not preserved. But a step that COMPLETES has its
+  result carried whole into the synthesized deliverable
+  (`autonomy/executor/dispatch.py` `synthesize_deliverable`, which interpolates
+  `r.result` unsliced) and persisted from there. An earlier draft of this bullet
+  said "every consumer cuts it" and was wrong: that ruled out a channel that
+  works, which would push a step toward halting on `blocker_description` when it
+  did not need to. Preservation is a property of the PATH, not of the field —
+  which is the whole point of checking rather than assuming.
 - **Preserves whole, not reachable.** `TASK_NOTEPAD.md` is promoted to memory
   uncut — but it is seeded in a CODE task's worktree, and a VERIFICATION step runs
   in the background-session directory, so for that step it is a file in the wrong

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -193,33 +193,12 @@ only replaying a known-positive tells them apart.
 ### Select, don't amputate — truncation is the absence of a decision
 
 **Scope first, because bounding is often correct.** A bounded PREVIEW is a
-selection with a pointer, not an amputation — but ONLY if the pointer actually
-resolves. The proactive memory hook is the worked example: it renders a snippet
-plus `id:xxxxxxxx` (for most rows — code-sourced ones render no handle at all,
-which is the same defect as the procedure case below), and `memory_expand` takes
-exactly that handle (it resolves
-short prefixes and reports `ambiguous` rather than guessing) and returns the full
-record. Bounding is likewise correct against a hard external budget — a hook
-stdout cap, a DB column, a context window — and a log line or diagnostic
-rendering of something stored intact elsewhere is a preview like any other. This
-section is about the other case: a value that is the ONLY copy, where cutting it
-destroys the information.
-
-**Test the pointer before you call something a preview.** The same hook renders
-`principle[:200]` for procedures with an id beside it, and that HANDLE does not
-resolve: procedures live in SQLite `procedural_memory`, `memory_expand` retrieves
-only the Qdrant collections, and `procedure_recall` takes a task description and
-tags with no id lookup at all. It is still not an amputation — the principle
-survives whole in SQLite and `procedure_recall` returns it unsliced, and the cap
-is a cache-width decision the code states outright. So this is a preview whose
-handle is DECORATIVE: a defect of its own, because it teaches a retrieval path
-that does not exist, but not the defect this section is about. Getting that
-distinction wrong is not academic — a reader who reads "amputation" here goes and
-removes the cap, and the proactive hook's output is bounded against CC's
-10,000-char hook-stdout limit, above which it is silently filed. Successive
-drafts of this very section cited this case as the carve-out, each naming a
-different wrong tool, and one called it an amputation. A pointer you have not
-followed is not a pointer.
+selection with a pointer, not an amputation — but only if the pointer actually
+resolves, and that is a claim to CHECK for the case in hand, never one to inherit
+from the mechanism. Bounding against a hard external budget is likewise correct:
+a hook's stdout cap, a database column, a context window. So is refusing an
+oversized value outright. This section is about the other case: a value that is
+the ONLY copy, where cutting it destroys the information.
 
 **There, do not truncate.** Not strings, not lists, not context, not output.
 Reaching for a character cap is a signal that a question was skipped, not
@@ -244,145 +223,63 @@ Three rules when a bound really is needed:
   **This governs HOW you bound, never WHETHER you may.** Rejecting a structured
   value or a collection by size is correct and stays correct: an over-long id, an
   over-large batch or an implausibly large file is simply not a value we accept,
-  and refusing it is a resource guard, not an amputation
-  (`channels/voice/transcript_writer.py` rejects a `session_id` over 128 chars;
-  `dashboard/routes/follow_ups.py` rejects a batch over 200 ids). What is
-  forbidden is silently CUTTING them to fit. Only free text gets a bound it is
-  expected to sit under; everything else gets one it must not cross.
+  and refusing it is a resource guard, not an amputation. What is forbidden is
+  silently CUTTING them to fit. Only free text gets a bound it is expected to sit
+  under; everything else gets one it must not cross.
 - **Derive the number, and record how — against a corpus that OUTLIVES the
   claim.** Measure the real population and report `k/N` per the Acceptance Bar,
   then name the corpus, the query and the date. Naming them is necessary and not
-  sufficient: a query is only re-derivable if the rows are still there when the
-  next reader runs it.
-  Worked example, and it fails that second test — deliberately, because the
-  failure is the lesson. Provider error prose lands in
-  `activity_log.error_message` (written by `routing/router.py`, already capped
-  there at 1024), so `SELECT SUM(LENGTH(error_message) > 300), COUNT(*) FROM
-  activity_log WHERE error_message IS NOT NULL AND error_message != '';` On one
-  install on 2026-09-03 that gave **270/318 (84.9%)** cut by a 300-char cap.
-  What the cap COSTS is a second claim needing its own denominator, and an
-  earlier draft asserted it without one — "JSON error bodies put the
-  machine-readable cause last, so the cap discards exactly the part worth
-  keeping." Measured against the same table: 251 of 600 cut rows (41.8%) carry
-  `code` inside the first 300 characters, and every row leads with the litellm
-  exception class. Some providers do put a `"code":"rate_limit_exceeded"` in the
-  tail a 300-char cut discards; others put it in the first sixty characters. So
-  the cap destroys a provider-specific remainder, unevenly — not "exactly the
-  part worth keeping". Note also that this corpus is ITSELF already cut at 1024
-  upstream, so the population being measured is one the rule would forbid
-  creating. Both of those are worth saying out loud, because a measurement
-  followed by an unmeasured generalisation is how a number launders an opinion.
-  That is an EPHEMERAL OBSERVATION, not a re-derivable one. `activity_log` is
-  reaped at 24 hours (`observability/provider_activity.py` `reap_old_records`,
-  scheduled four times daily by `runtime/init/learning.py`), and the query carries
-  no `created_at` predicate or snapshot id — so re-running it later measures a
-  different rolling window on the same install, and nobody can reproduce the
-  original. To make a number like this re-derivable you must pin the window in
-  the query AND export the rows, or measure something durable (git history, a
-  committed fixture) instead. Label it honestly when you cannot.
-  This rule has now failed on itself twice, which is why both corrections stay.
-  An earlier draft hedged that rate as "a floor" because the corpus is capped at
-  1024 upstream. Wrong — a 1024-cap cannot change whether a length exceeds 300,
-  and `COUNT(*)` counts rows, so the rate is EXACT and only the CONTENT LOST is a
-  lower bound. Hedging a number you have not thought through is the same failure
-  as asserting one; and calling a number re-derivable without checking that its
-  corpus survives is the same failure wearing the opposite face.
+  sufficient: the query is only re-derivable if the rows are still there when the
+  next reader runs it, so a table with a retention window yields an EPHEMERAL
+  observation. Say which one you have. And what the bound COSTS is a SECOND claim
+  needing its own denominator — "the cap discards the part worth keeping" is
+  exactly the sentence that sounds measured because it followed a measurement.
 - **Omit explicitly, with a constant-bounded marker** (`<omitted: 104,823
   chars>`), never a mid-value cut. An honest gap beats a plausible-looking
-  fragment. The FLAG half is already the house pattern — the character-count
-  marker is new, and no call site in the tree emits one today (grep for it and
-  you get nothing; do not go looking for a precedent that is not there):
-  repo-pulse's loud `limit_hit`
-  (`session_awareness/repo_pulse_gh.py` returns `limit_hit` alongside the rows),
-  and the bound-plus-flag-plus-stated-consequence model in
-  `memory/integrity_repair.py` ("Truncation asymmetry": ghost repair proceeds on
-  a partial scroll because every scanned point is genuinely present AND it holds
-  the complete id set from a full SQLite read; mirror repair is SKIPPED because
-  it proves absence, which a partial set cannot). Cited by SYMBOL, not by line — a line number in an
-  always-loaded file rots silently, and every claim here is one a reader should
-  be able to re-check with a grep.
+  fragment. The bound-plus-loud-flag half of this is already the house pattern;
+  the character-count marker is a proposal, so do not go looking for a precedent
+  that is not there.
 
-One trap worth naming: a cap can manufacture a correctness bug in the data it was
-added to protect. Truncating an identifier used as a KEY merges two distinct
-identities into one, and downstream code then attributes one subject's state to
-another. A short DISPLAY handle is a different thing and is the house pattern —
-`memory_expand` resolves an 8-char prefix and reports `ambiguous` rather than
-guessing. The rule is about the stored key, not the rendered one.
+One trap deserves naming, because it is what produced this rule: **a cap can
+manufacture a correctness bug in the very data it was added to protect.**
+Truncating an identifier used as a KEY merges two distinct identities into one,
+and downstream code then attributes one subject's state to another. That is not
+hypothetical — it shipped here. Two roster peers whose names shared a prefix
+collapsed onto a single key, so one peer's success cleared the other peer's
+recorded failure. A short DISPLAY handle is a different thing and is fine; the
+rule is about the stored key, not the rendered one.
 
 **A real need to truncate is a CONVERSATION to have, not a magic number to pick
-alone.** If you catch yourself choosing 300 or 200 or 1000, stop and raise it —
-and if there is nobody to raise it with (an unattended background session), the
-default is: emit the value WHOLE and record the decision owed — the value, the
-population you could not measure, and what you could not decide. Never pick the
-number just because no one was there to stop you.
+alone.** If you catch yourself choosing 300 or 200 or 1000, stop and raise it.
 
-Record it somewhere that session can actually REACH and that PRESERVES it whole.
-Both halves, checked against the surface you are on. This instruction names no
-channel on purpose: every earlier draft prescribed one, and each was wrong for
-some surface. Three worked examples of getting it wrong, because the failures
-teach the check better than a rule does:
-
-- **Reachable everywhere, preserving on only SOME paths.** An executor step's
-  `result` field exists everywhere and its contract calls it a "brief
-  description". The carry-forward paths cut it — `[:200]` into the next step's
-  prompt and into the trace, `[:2000]` on the write path — so a value left there
-  for a LATER step to read is not preserved. But a step that COMPLETES has its
-  result carried whole into the synthesized deliverable
-  (`autonomy/executor/dispatch.py` `synthesize_deliverable`, which interpolates
-  `r.result` unsliced) and persisted from there. An earlier draft of this bullet
-  said "every consumer cuts it" and was wrong: that ruled out a channel that
-  works, which would push a step toward halting on `blocker_description` when it
-  did not need to. Preservation is a property of the PATH, not of the field —
-  which is the whole point of checking rather than assuming.
-- **Preserves whole, not reachable.** `TASK_NOTEPAD.md` is promoted to memory
-  uncut — but it is seeded in a CODE task's worktree, and a VERIFICATION step runs
-  in the background-session directory, so for that step it is a file in the wrong
-  place. Preservation said yes; reachability said no.
-- **A ranking assumed instead of read.** A draft called CODE/VERIFICATION the
-  strictest executor scope because `follow_up_create` is denied there. Backwards:
-  the MCP setup is gated on `is_code_or_verify`, so RESEARCH/ANALYSIS/SYNTHESIS
-  get *zero* MCP tools — the denied-list surface is the most permissive one.
-  Membership facts were right; the ordering derived from them was never checked.
-
-The rule is the property, not the mechanism: **availability is not preservation,
-neither is portable between surfaces, and a ranking is a separate claim from the
-facts it sorts.** Verify each for the surface you are on.
-
-**And one pattern above all, because this section kept committing it while
-describing it.** Across four review rounds every single defect found here had the
-same shape: the membership facts were RIGHT and the CONCLUSION drawn from them
-was wrong. `procedure_recall` really has no id lookup — and "therefore it is an
-amputation" was false, because the principle is stored whole elsewhere. Some
-providers really do put the error code in the tail — and "therefore JSON bodies
-put the cause last" was false for 42% of the corpus. `follow_up_create` really is
-denied for CODE steps — and "therefore that scope is the strictest" was backwards.
-`blocker_description` really is stored unsliced — and "therefore it costs a
-status" understated a price that is the whole run. Checking that each cited fact
-is true is the easy half and it is not the half that fails. **Say the inference
-out loud as its own claim, and check THAT.** If nothing obvious
-qualifies, look harder before declaring a dead end — grep the sibling fields of
-whatever you were about to give up on. (The same `result` write that slices to
-`[:2000]` stores `blocker_description` and `artifacts` UNSLICED, and the step
-contract defines the first as "What specific information, credential, or
-decision is needed from the user" — scoped to blockers, so the fit is close but
-not exact. And price it honestly: it costs the whole RUN, not a status field.
-`engine.py` returns False on a blocked step, so no deliverable is synthesized,
-the notepad is never promoted, and the user is paged. That is far too high for a
-note; it is the answer only when the step was going to block anyway. An earlier
-draft said "it costs a `blocked` status", which named a price several times too
-small — worse than naming none, because it was written to encourage taking the
-route.) Where no channel qualifies at all, that is a conflict with "never leave a
-follow-up as just text" to RAISE, not to resolve unilaterally: that rule lives in
-CLAUDE.md and states no exception, and a skill file granting itself one is
-exactly the precedence problem CLAUDE.md tells you to name out loud.
+**When there is nobody to raise it with** — an unattended background session —
+the rule is NOT "never pick a number". It is **never pick one silently.** Bound
+if you must, and put the reasoning beside the number, where a reader of the value
+will see it. That includes the question that comes BEFORE the number — whether
+this value needed bounding at all — because "is this big enough to matter?" is
+the same judgement drawing on the same missing information, and skipping it is
+precisely how the number gets invented. State both. A number with its reasoning
+next to it can be argued with and corrected, which is all anyone needed from you.
+What made the original defect dangerous was never that 300 existed — it was that
+300 arrived silent, looking deliberate, and was then defended.
 
 That default is about SIZE, never about secrecy, and the two must not be
 confused. If a value may carry a credential, token, or personal data, the
 unbounded default does NOT apply: fail closed and omit it wholesale with a
 marker, exactly as the "omit explicitly" rule says, and record only
-non-sensitive metadata. Losing diagnostic prose is recoverable; leaking a
-token is not. Emitting whole and omitting wholesale are the same discipline —
-both refuse to hand on a fragment that looks complete.
+non-sensitive metadata. Losing diagnostic prose is recoverable; leaking a token
+is not. Emitting whole and omitting wholesale are the same discipline — both
+refuse to hand on a fragment that looks complete.
+
+**One last thing, learned the hard way from this section itself.** Four review
+rounds found defects in it, and every single one had the same shape: the cited
+FACT was true, and the CONCLUSION drawn from it was false. A retrieval tool
+really did lack an id lookup — and "therefore this is an amputation" was wrong,
+because the value was stored whole elsewhere. A field really was written
+unsliced — and "therefore it is a cheap place to record something" was wrong,
+because reaching it aborted the whole run. Verifying that each cited fact is true
+is the easy half, and it is not the half that fails. **State the inference as its
+own claim, and check THAT.**
 
 ### A blocked compound command loses EVERYTHING in it
 

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -203,23 +203,34 @@ excuse a cut; a self-imposed storage assumption is a decision to justify, not a
 budget to obey. So is refusing an oversized value outright.
 
 **And a SAFETY cap may be lossy — that is the one place cutting the only copy is
-right.** An unbounded stream has no other copy by definition, and reading it to
-the end to avoid "truncating" is how a runaway command exhausts memory; this repo
-bounds subprocess output at a few MiB for exactly that reason
-(`autonomy/executor/deterministic.py` `_read_limited`, whose own comment names
-the `yes`-command threat; verified 2026-09-04). Losing the tail of
-a log beats losing the process. The obligation there is not to keep the bytes, it
-is to be LOUD about the cut — say the output was bounded and roughly by how much,
-so nobody reads a clipped log as a complete one. A silent lossy cap is still the
-defect; a declared one is a resource guard doing its job. This section is about
-the remaining case.
+right.** Streaming is a TRANSPORT property and only-copy is a DURABILITY one;
+check them separately, because a chunked read is often backed by a retained
+source you could go back to. The case that earns the lossy cap is the source
+that genuinely has no retained copy — a live subprocess pipe — where reading to
+the end to avoid "truncating" is how a runaway command exhausts memory; this
+repo bounds exactly that at a few MiB (`autonomy/executor/deterministic.py`
+`_read_limited`, whose own comment names the `yes`-command threat; verified
+2026-09-04). Losing the tail of a log beats losing the process. The obligation
+there is not to keep the bytes, it is to be LOUD about the cut — say the output
+was bounded and roughly by how much, so nobody reads a clipped log as a
+complete one. That cited cap does NOT yet meet this bar: `_read_limited`
+returns only the retained bytes with no truncation flag, and its caller reports
+the retained length as the total — a 3 MiB stream reads as "2097152 bytes
+total". The cap is right; its silence is the improvable half, cited here as a
+counterexample to "never cut", not as a model of declaring. A silent lossy cap
+is still the defect; a declared one is a resource guard doing its job. This
+section is about the remaining case.
 
 **A handle that does not resolve is a separate defect, and do not conflate the
 two** — that conflation is the mistake this section made about itself, twice.
 Check the pointer, because a preview advertising a retrieval path that does not
 exist teaches a lie; but when the full value survives somewhere, the fix is to
-mend or drop the handle, never to remove the cap. Removing a cap to prevent a
-loss that never happened is how this rule causes the damage it exists to stop.
+mend or drop the handle — removing the cap TO PREVENT DATA LOSS is fixing a
+loss that never happened, and that misdiagnosis is how this rule causes the
+damage it exists to stop. Whether the cap should exist at all is the separate
+question the "what breaks if it is unbounded" test answers: a cap with no
+external, safety, or measured compatibility justification may be removed once
+that is established — for being unjustified, never for being an amputation.
 
 **There, do not truncate.** Not strings, not lists, not context, not output.
 Reaching for a character cap is a signal that a question was skipped, not
@@ -273,8 +284,9 @@ Three rules when a bound really is needed:
   an unbounded stream, a preview rendered next to the full record, a display
   string trimmed before escaping so the cut cannot land mid-entity. Each of
   those is a cut the loss rules PERMIT (a safety cap, a pointer-backed
-  selection, third-party display text), and each is declared or bounded where
-  it is read. The order matters: first the loss rules decide whether a cut may
+  selection, third-party display text) — which does not certify how each is
+  reported today: the safety cap above still cuts silently, and PERMITTED is
+  not DECLARED. The order matters: first the loss rules decide whether a cut may
   happen at all — announcing a sliced KEY does not un-merge the two identities
   it collapsed — and only then does declaration decide whether the permitted
   cut is honest. A silent permitted cut is still a defect; a loud forbidden cut

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -317,10 +317,14 @@ explicitly" rule says, and keep only non-sensitive metadata. Losing diagnostic
 prose is recoverable; leaking a token is not. The scope qualifier is
 load-bearing and an earlier revision dropped it while restructuring — read
 unconditionally, "omit wholesale" would delete values existing features exist
-to hold: the References store deliberately RETAINS credentials and exposes
-plaintext only through its explicit reveal flow
-(`dashboard/routes/references.py`; verified 2026-09-04). An authorized, gated
-store holding a secret is the feature working, not a leak.
+to hold: the References store deliberately RETAINS credentials, and its own
+dashboard tab masks the value behind an explicit reveal
+(`dashboard/routes/references.py`; verified 2026-09-04). That is a statement
+about ONE surface, not a security guarantee — other readers of the same store
+return raw bodies (`reference_lookup`, the knowledge routes), which is worth
+knowing precisely because a rule reader might otherwise lean on the reveal
+gate as if it covered them. An authorized, gated store holding a secret is the
+feature working, not a leak.
 
 **Then ask WHO WROTE IT as well as where it is going — two independent axes,
 and each governs a different decision.** Destination governs DISCLOSURE: what
@@ -330,10 +334,16 @@ quarantined. Authorship is a RISK INPUT to sanitization, and the treatment
 itself is chosen by the CONSUMING SINK: the same stranger-authored email
 fields are HTML-escaped and truncated where the sink renders raw HTML
 (`outreach/engagement.py` `_sanitize_ping_field`, whose docstring names both
-the threat and the destination; verified 2026-09-04) and stored CANONICAL —
-unescaped, unbounded — where the sink is a parameterised database column
-(`db/crud/email_threads.py` `record_reply`; verified 2026-09-04). Escaping at
-ingestion would corrupt the canonical copy; passing raw markup to a live
+the threat and the destination; verified 2026-09-04) and stored UNESCAPED
+where the sink is a parameterised database column (`db/crud/email_threads.py`
+`record_reply`; verified 2026-09-04). Unescaped is not unbounded, and an
+earlier draft conflated them: what reaches that column is `body_preview`,
+already cut to 500 characters upstream (`mail/reply_poller.py`,
+`parsed.body[:500]`) — a silent mid-value cut of exactly the kind this section
+exists to surface, sitting inside the example chosen to demonstrate the
+opposite. The escaping point stands; the "canonical, unbounded" flourish did
+not survive following its own pointer. Escaping at
+ingestion would corrupt the stored copy; passing raw markup to a live
 renderer hands a stranger the user's most trusted channel. Maximally
 authorized destination, maximally defensive treatment AT THE RENDERER — any
 rule that reads "it's going somewhere trusted, so pass it whole" deletes that
@@ -346,8 +356,10 @@ to stop scrubbing on owner-facing surfaces, and this repo does not (each
 verified 2026-09-04): it rewrites username-bearing paths out of what the owner's
 own dashboard renders (`dashboard/routes/backup.py` `_scrub_reason`), gates
 credential values behind an explicit reveal rather than showing them (the
-References tab), scrubs the draft the user reviews so the copy they approve is
-already clean (`content/egress.py` `should_gate`, `category == "content"`), and
+References tab — that one surface, per the caveat above), applies the safe
+mechanical rewrite to the draft the user reviews (`content/egress.py`
+`should_gate`, `category == "content"` — non-fixable tells are FLAGGED, not
+removed, so the copy they approve has been treated, not certified clean), and
 in at least one subsystem deliberately keeps captured text out of its own
 private store entirely (`attention/types.py`: "never stored";
 `db/crud/attention.py`: "value-free … NO text"). "Into a private store" is

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -197,7 +197,17 @@ amputation is LOSS — the value cut here was the only copy. Nothing else. A
 bounded PREVIEW of something stored intact elsewhere is a selection, and stays
 one even if its handle is useless. Bounding against a hard external budget is
 likewise correct: a hook's stdout cap, a database column, a context window. So is
-refusing an oversized value outright. This section is about the loss case.
+refusing an oversized value outright.
+
+**And a SAFETY cap may be lossy — that is the one place cutting the only copy is
+right.** An unbounded stream has no other copy by definition, and reading it to
+the end to avoid "truncating" is how a runaway command exhausts memory; this repo
+bounds subprocess output at a few MiB for exactly that reason. Losing the tail of
+a log beats losing the process. The obligation there is not to keep the bytes, it
+is to be LOUD about the cut — say the output was bounded and roughly by how much,
+so nobody reads a clipped log as a complete one. A silent lossy cap is still the
+defect; a declared one is a resource guard doing its job. This section is about
+the remaining case.
 
 **A handle that does not resolve is a separate defect, and do not conflate the
 two** — that conflation is the mistake this section made about itself, twice.
@@ -248,10 +258,19 @@ Three rules when a bound really is needed:
   needing its own denominator — "the cap discards the part worth keeping" is
   exactly the sentence that sounds measured because it followed a measurement.
 - **Omit explicitly, with a constant-bounded marker** (`<omitted: 104,823
-  chars>`), never a mid-value cut. An honest gap beats a plausible-looking
-  fragment. The bound-plus-loud-flag half of this is already the house pattern;
-  the character-count marker is a proposal, so do not go looking for a precedent
-  that is not there.
+  chars>`) in preference to a mid-value cut. An honest gap beats a
+  plausible-looking fragment. The bound-plus-loud-flag half of this is already
+  the house pattern; the character-count marker is a proposal, so do not go
+  looking for a precedent that is not there.
+  **The line is DECLARED versus SILENT, not omit versus cut.** That is the
+  distinction this whole section is really about, and stating it as "never cut"
+  overshoots: this repo cuts mid-value in several places on purpose and is right
+  to — a resource guard on an unbounded stream, a preview rendered next to the
+  full record, a display string trimmed before escaping so the cut cannot land
+  mid-entity. Every one of those is a decision someone made and can defend. What
+  is forbidden is the cut nobody decided and nothing announces, because that is
+  the one that reaches a reader looking complete. Prefer the marker; when you cut
+  instead, say so where the value is read.
   **When the total is not already known, say that instead of computing it.**
   Bounding a stream is the case: learning the exact discarded length means
   reading the whole source, which is the cost the bound existed to avoid. So
@@ -284,20 +303,29 @@ What made the original defect dangerous was never that 300 existed — it was th
 
 That default is about SIZE, never about secrecy, and the two must not be
 confused. If a value may carry a credential, token, or personal data, the
-unbounded default does NOT apply — but what replaces it depends on WHERE the
-value is going, not on what it contains. Bound for unauthorized egress and for
-storage you cannot vouch for: fail closed, omit wholesale with a marker as the
-"omit explicitly" rule says, and keep only non-sensitive metadata. Losing
+unbounded default does NOT apply: fail closed, omit wholesale with a marker as
+the "omit explicitly" rule says, and keep only non-sensitive metadata. Losing
 diagnostic prose is recoverable; leaking a token is not.
 
-**Do not apply that to an authorized destination.** The user's own messages,
-memories and diagnostics flowing to the user, or into a private store, are
-personal data arriving exactly where it belongs; stripping them there is not a
-safeguard, it is data loss dressed as one — and this repo already draws that
-line, scanning and quarantining on the OUTBOUND path while leaving owner-facing
-content untouched. Ask which boundary the value is crossing before deciding.
-Where it is crossing one, emitting whole and omitting wholesale are the same
-discipline: both refuse to hand on a fragment that looks complete.
+**Then ask WHO WROTE IT, before you ask where it is going.** Authorship is the
+axis that decides, and it beats destination outright. Third-party-authored
+content stays bounded and sanitized no matter how trusted the destination is —
+this repo truncates and HTML-escapes a stranger's email fields on the way to the
+OWNER'S OWN chat, because that channel renders HTML unescaped, so a display name
+someone else chose would otherwise arrive as live markup in the one place the
+user trusts absolutely. Maximally authorized destination, maximally defensive
+treatment. Any rule that reads "it's going somewhere trusted, so pass it whole"
+deletes that defence.
+
+**And an authorized destination does not mean untreated.** The rule is narrow:
+do not strip the USER'S OWN content on its way to the user. It is not a licence
+to stop scrubbing on owner-facing surfaces, and this repo does not — it rewrites
+username-bearing paths out of what the owner's own dashboard renders, gates
+credential values behind an explicit reveal rather than showing them, scrubs the
+draft the user reviews so the copy they approve is already clean, and in at least
+one subsystem deliberately keeps captured text out of its own private store
+entirely. "Into a private store" is emphatically not a blanket exemption; some
+stores are built specifically to never receive the value.
 
 **One last thing, learned the hard way from this section itself.** Four review
 rounds found defects in it, and every single one had the same shape: the cited
@@ -308,6 +336,15 @@ unsliced — and "therefore it is a cheap place to record something" was wrong,
 because reaching it aborted the whole run. Verifying that each cited fact is true
 is the easy half, and it is not the half that fails. **State the inference as its
 own claim, and check THAT.**
+
+The sharpest instance is this section committing that error in the sentence next
+to the one warning against it. A draft of the paragraph above cited a real file
+that says, correctly, that a particular scrub applies to external audiences and
+not to replies going to the user — and generalised it into "this repo leaves
+owner-facing content untouched", which four other paths contradict. True fact,
+false inference, two paragraphs from the rule forbidding exactly that. The
+generalisation is the step to distrust, and it is seductive precisely when the
+evidence under it is solid.
 
 ### A blocked compound command loses EVERYTHING in it
 

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -195,7 +195,9 @@ only replaying a known-positive tells them apart.
 **Scope first, because bounding is often correct.** A bounded PREVIEW is a
 selection with a pointer, not an amputation — but ONLY if the pointer actually
 resolves. The proactive memory hook is the worked example: it renders a snippet
-plus `id:xxxxxxxx`, and `memory_expand` takes exactly that handle (it resolves
+plus `id:xxxxxxxx` (for most rows — code-sourced ones render no handle at all,
+which is the same defect as the procedure case below), and `memory_expand` takes
+exactly that handle (it resolves
 short prefixes and reports `ambiguous` rather than guessing) and returns the full
 record. Bounding is likewise correct against a hard external budget — a hook
 stdout cap, a DB column, a context window — and a log line or diagnostic
@@ -204,13 +206,20 @@ section is about the other case: a value that is the ONLY copy, where cutting it
 destroys the information.
 
 **Test the pointer before you call something a preview.** The same hook renders
-`principle[:200]` for procedures with an id beside it, and that one does NOT
+`principle[:200]` for procedures with an id beside it, and that HANDLE does not
 resolve: procedures live in SQLite `procedural_memory`, `memory_expand` retrieves
 only the Qdrant collections, and `procedure_recall` takes a task description and
-tags with no id lookup at all. So it looks exactly like the memory case and is an
-amputation — and successive drafts of this very section cited it as the carve-out,
-each naming a different wrong tool. A pointer you have not followed is not a
-pointer.
+tags with no id lookup at all. It is still not an amputation — the principle
+survives whole in SQLite and `procedure_recall` returns it unsliced, and the cap
+is a cache-width decision the code states outright. So this is a preview whose
+handle is DECORATIVE: a defect of its own, because it teaches a retrieval path
+that does not exist, but not the defect this section is about. Getting that
+distinction wrong is not academic — a reader who reads "amputation" here goes and
+removes the cap, and the proactive hook's output is bounded against CC's
+10,000-char hook-stdout limit, above which it is silently filed. Successive
+drafts of this very section cited this case as the carve-out, each naming a
+different wrong tool, and one called it an amputation. A pointer you have not
+followed is not a pointer.
 
 **There, do not truncate.** Not strings, not lists, not context, not output.
 Reaching for a character cap is a signal that a question was skipped, not
@@ -250,9 +259,19 @@ Three rules when a bound really is needed:
   `activity_log.error_message` (written by `routing/router.py`, already capped
   there at 1024), so `SELECT SUM(LENGTH(error_message) > 300), COUNT(*) FROM
   activity_log WHERE error_message IS NOT NULL AND error_message != '';` On one
-  install on 2026-09-03 that gave **270/318 (84.9%)** cut by a 300-char cap —
-  and since JSON error bodies put the machine-readable cause last, the cap
-  discards exactly the part worth keeping.
+  install on 2026-09-03 that gave **270/318 (84.9%)** cut by a 300-char cap.
+  What the cap COSTS is a second claim needing its own denominator, and an
+  earlier draft asserted it without one — "JSON error bodies put the
+  machine-readable cause last, so the cap discards exactly the part worth
+  keeping." Measured against the same table: 251 of 600 cut rows (41.8%) carry
+  `code` inside the first 300 characters, and every row leads with the litellm
+  exception class. Some providers do put a `"code":"rate_limit_exceeded"` in the
+  tail a 300-char cut discards; others put it in the first sixty characters. So
+  the cap destroys a provider-specific remainder, unevenly — not "exactly the
+  part worth keeping". Note also that this corpus is ITSELF already cut at 1024
+  upstream, so the population being measured is one the rule would forbid
+  creating. Both of those are worth saying out loud, because a measurement
+  followed by an unmeasured generalisation is how a number launders an opinion.
   That is an EPHEMERAL OBSERVATION, not a re-derivable one. `activity_log` is
   reaped at 24 hours (`observability/provider_activity.py` `reap_old_records`,
   scheduled four times daily by `runtime/init/learning.py`), and the query carries
@@ -270,9 +289,18 @@ Three rules when a bound really is needed:
   corpus survives is the same failure wearing the opposite face.
 - **Omit explicitly, with a constant-bounded marker** (`<omitted: 104,823
   chars>`), never a mid-value cut. An honest gap beats a plausible-looking
-  fragment. Already the house pattern: repo-pulse's loud `limit_hit`
-  (`session_awareness/repo_pulse_gh.py:170`), and the bound-plus-flag-plus-stated
-  -consequence model in `memory/integrity_repair.py:27` ("Truncation asymmetry").
+  fragment. The FLAG half is already the house pattern — the character-count
+  marker is new, and no call site in the tree emits one today (grep for it and
+  you get nothing; do not go looking for a precedent that is not there):
+  repo-pulse's loud `limit_hit`
+  (`session_awareness/repo_pulse_gh.py` returns `limit_hit` alongside the rows),
+  and the bound-plus-flag-plus-stated-consequence model in
+  `memory/integrity_repair.py` ("Truncation asymmetry": ghost repair proceeds on
+  a partial scroll because every scanned point is genuinely present AND it holds
+  the complete id set from a full SQLite read; mirror repair is SKIPPED because
+  it proves absence, which a partial set cannot). Cited by SYMBOL, not by line — a line number in an
+  always-loaded file rots silently, and every claim here is one a reader should
+  be able to re-check with a grep.
 
 One trap worth naming: a cap can manufacture a correctness bug in the data it was
 added to protect. Truncating an identifier used as a KEY merges two distinct
@@ -318,17 +346,35 @@ teach the check better than a rule does:
 
 The rule is the property, not the mechanism: **availability is not preservation,
 neither is portable between surfaces, and a ranking is a separate claim from the
-facts it sorts.** Verify each for the surface you are on. If nothing obvious
+facts it sorts.** Verify each for the surface you are on.
+
+**And one pattern above all, because this section kept committing it while
+describing it.** Across four review rounds every single defect found here had the
+same shape: the membership facts were RIGHT and the CONCLUSION drawn from them
+was wrong. `procedure_recall` really has no id lookup — and "therefore it is an
+amputation" was false, because the principle is stored whole elsewhere. Some
+providers really do put the error code in the tail — and "therefore JSON bodies
+put the cause last" was false for 42% of the corpus. `follow_up_create` really is
+denied for CODE steps — and "therefore that scope is the strictest" was backwards.
+`blocker_description` really is stored unsliced — and "therefore it costs a
+status" understated a price that is the whole run. Checking that each cited fact
+is true is the easy half and it is not the half that fails. **Say the inference
+out loud as its own claim, and check THAT.** If nothing obvious
 qualifies, look harder before declaring a dead end — grep the sibling fields of
 whatever you were about to give up on. (The same `result` write that slices to
 `[:2000]` stores `blocker_description` and `artifacts` UNSLICED, and the step
-contract defines the first as "what decision is needed from the user", which is
-close to exactly this. It costs a `blocked` status, which is a real price worth
-naming — but it is an answer, and the earlier draft asserted there was none.)
-This is the one carve-out from "never leave a follow-up as just text": that rule
-assumes a surface where `follow_up_create` exists. Where it does not, an
-unrecorded debt is worse than a differently-recorded one — but say which surface
-forced it, so the exception cannot quietly become the habit.
+contract defines the first as "What specific information, credential, or
+decision is needed from the user" — scoped to blockers, so the fit is close but
+not exact. And price it honestly: it costs the whole RUN, not a status field.
+`engine.py` returns False on a blocked step, so no deliverable is synthesized,
+the notepad is never promoted, and the user is paged. That is far too high for a
+note; it is the answer only when the step was going to block anyway. An earlier
+draft said "it costs a `blocked` status", which named a price several times too
+small — worse than naming none, because it was written to encourage taking the
+route.) Where no channel qualifies at all, that is a conflict with "never leave a
+follow-up as just text" to RAISE, not to resolve unilaterally: that rule lives in
+CLAUDE.md and states no exception, and a skill file granting itself one is
+exactly the precedence problem CLAUDE.md tells you to name out loud.
 
 That default is about SIZE, never about secrecy, and the two must not be
 confused. If a value may carry a credential, token, or personal data, the

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -311,24 +311,34 @@ What made the original defect dangerous was never that 300 existed — it was th
 
 That default is about SIZE, never about secrecy, and the two must not be
 confused. If a value may carry a credential, token, or personal data, the
-unbounded default does NOT apply: fail closed, omit wholesale with a marker as
-the "omit explicitly" rule says, and keep only non-sensitive metadata. Losing
-diagnostic prose is recoverable; leaking a token is not.
+unbounded default does NOT apply — for UNAUTHORIZED egress and for storage you
+cannot vouch for: there, fail closed, omit wholesale with a marker as the "omit
+explicitly" rule says, and keep only non-sensitive metadata. Losing diagnostic
+prose is recoverable; leaking a token is not. The scope qualifier is
+load-bearing and an earlier revision dropped it while restructuring — read
+unconditionally, "omit wholesale" would delete values existing features exist
+to hold: the References store deliberately RETAINS credentials and exposes
+plaintext only through its explicit reveal flow
+(`dashboard/routes/references.py`; verified 2026-09-04). An authorized, gated
+store holding a secret is the feature working, not a leak.
 
 **Then ask WHO WROTE IT as well as where it is going — two independent axes,
 and each governs a different decision.** Destination governs DISCLOSURE: what
 may cross a trust boundary is decided by where it lands, whoever wrote it — a
 user-authored secret bound for an external channel still gets scanned and
-quarantined. Authorship governs SANITIZATION: third-party-authored content
-stays bounded and escaped no matter how trusted the destination is —
-this repo truncates and HTML-escapes a stranger's email fields on the way to the
-OWNER'S OWN chat (`outreach/engagement.py` `_sanitize_ping_field`, whose
-docstring names both the threat and the destination; verified 2026-09-04),
-because that channel renders HTML unescaped, so a display name someone else
-chose would otherwise arrive as live markup in the one place the user trusts
-absolutely. Maximally authorized destination, maximally defensive treatment.
-Any rule that reads "it's going somewhere trusted, so pass it whole" deletes
-that defence.
+quarantined. Authorship is a RISK INPUT to sanitization, and the treatment
+itself is chosen by the CONSUMING SINK: the same stranger-authored email
+fields are HTML-escaped and truncated where the sink renders raw HTML
+(`outreach/engagement.py` `_sanitize_ping_field`, whose docstring names both
+the threat and the destination; verified 2026-09-04) and stored CANONICAL —
+unescaped, unbounded — where the sink is a parameterised database column
+(`db/crud/email_threads.py` `record_reply`; verified 2026-09-04). Escaping at
+ingestion would corrupt the canonical copy; passing raw markup to a live
+renderer hands a stranger the user's most trusted channel. Maximally
+authorized destination, maximally defensive treatment AT THE RENDERER — any
+rule that reads "it's going somewhere trusted, so pass it whole" deletes that
+defence, and any rule that reads "a stranger wrote it, so escape it
+everywhere" corrupts the stored original.
 
 **And an authorized destination does not mean untreated.** The rule is narrow:
 do not strip the USER'S OWN content on its way to the user. It is not a licence

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -297,9 +297,13 @@ Three rules when a bound really is needed:
   cut is honest. A silent permitted cut is still a defect; a loud forbidden cut
   is still forbidden.
   **When the total is not already known, say that instead of computing it.**
-  Bounding a stream is the case: learning the exact discarded length means
-  reading the whole source, which is the cost the bound existed to avoid. State
-  the quantity you KNOW — the cap — and mark the tail unknown:
+  Bounding a stream is the case — but first ask which KIND of bounded reader
+  you have, because the bound is on RETENTION, not necessarily on reading. A
+  drain-and-discard reader consumes to EOF anyway (a subprocess pipe must be
+  drained or the child blocks) and can count what it discards in constant
+  space, so it KNOWS the exact total and should say it. Only a stop-at-limit
+  reader, which truly stops consuming, cannot know. There, state the quantity
+  you KNOW — the cap — and mark the tail unknown:
   `<kept first 40,000 chars; rest of stream omitted>`. Do not write
   `<omitted: ≥40,000 chars>`: under this rule's own grammar that number
   describes the OMITTED content, and one character over the cap makes it a

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -257,7 +257,12 @@ Three rules when a bound really is needed:
   over-large batch or an implausibly large file is simply not a value we accept,
   and refusing it is a resource guard, not an amputation. What is forbidden is
   silently CUTTING them to fit. Only free text gets a bound it is expected to sit
-  under; everything else gets one it must not cross.
+  under; every other INBOUND value gets one it must not cross. Scope that to
+  inbound on purpose: a READ that pages a large collection — the first n WHOLE
+  elements plus a total and a truncation flag — is a selection with a
+  denominator, this section's own preferred shape, and the source collection is
+  valid precisely because it exceeds the page. Reject the oversized value you
+  are asked to ACCEPT; paginate the oversized collection you are asked to LIST.
 - **Derive the number from the right thing, and record how.** A SAFETY bound —
   memory exhaustion, an abuse ceiling, untrusted input — does not come from the
   corpus at all: historical traffic says nothing about adversarial input,

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -298,10 +298,13 @@ Three rules when a bound really is needed:
   is still forbidden.
   **When the total is not already known, say that instead of computing it.**
   Bounding a stream is the case: learning the exact discarded length means
-  reading the whole source, which is the cost the bound existed to avoid. So
-  `<omitted: ≥40,000 chars>` or `<omitted: rest of stream>` is the correct
-  marker there, and demanding an exact figure would force either an unbounded
-  read or an invented number — the two things this whole section is against.
+  reading the whole source, which is the cost the bound existed to avoid. State
+  the quantity you KNOW — the cap — and mark the tail unknown:
+  `<kept first 40,000 chars; rest of stream omitted>`. Do not write
+  `<omitted: ≥40,000 chars>`: under this rule's own grammar that number
+  describes the OMITTED content, and one character over the cap makes it a
+  fabricated tail length — an invented number wearing the honest marker's
+  clothes, which is the exact thing the marker exists to prevent.
 
 One trap deserves naming, because it is what produced this rule: **a cap can
 manufacture a correctness bug in the very data it was added to protect.**
@@ -346,8 +349,12 @@ feature working, not a leak.
 **Then ask WHO WROTE IT as well as where it is going — two independent axes,
 and each governs a different decision.** Destination governs DISCLOSURE: what
 may cross a trust boundary is decided by where it lands, whoever wrote it — a
-user-authored secret bound for an external channel still gets scanned and
-quarantined. Authorship is a RISK INPUT to sanitization, and the treatment
+user-authored secret bound for an external channel still gets scanned — and
+quarantined when a SUPPORTED pattern matches. Say that precisely, because the
+scanner is a high-confidence pattern gate by its own declaration, not a general
+secret filter: content carrying a secret outside its pattern set passes as
+safe, so nothing downstream may lean on that gate as proof of cleanliness
+(`security/output_scanner.py`; verified 2026-09-05). Authorship is a RISK INPUT to sanitization, and the treatment
 itself is chosen by the CONSUMING SINK: the same stranger-authored email
 fields are HTML-escaped and truncated where the sink renders raw HTML
 (`outreach/engagement.py` `_sanitize_ping_field`, whose docstring names both

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -195,10 +195,14 @@ only replaying a known-positive tells them apart.
 **Scope first, because bounding is often correct.** A bounded PREVIEW whose full
 value stays retrievable from its store is a selection with a pointer, not an
 amputation — `memory/proactive.py:418` renders `principle[:200]` into the
-injection block on purpose, and the whole record is one `memory_expand` away.
-Bounding is likewise correct against a hard external budget (a hook stdout cap, a
-DB column, a context window). This section is about the other case: a value that
-is the ONLY copy, where cutting it destroys the information for good.
+injection block on purpose, and the whole record comes back from
+`procedure_recall`. Name the RIGHT retrieval path when you claim one: procedures
+live in SQLite `procedural_memory`, so `memory_expand` — which retrieves from the
+Qdrant collections only — cannot recover them, and a preview whose pointer does
+not resolve is an amputation wearing a citation. Bounding is likewise correct
+against a hard external budget (a hook stdout cap, a DB column, a context
+window). This section is about the other case: a value that is the ONLY copy,
+where cutting it destroys the information for good.
 
 **There, do not truncate.** Not strings, not lists, not context, not output.
 Reaching for a character cap is a signal that a question was skipped, not
@@ -248,6 +252,14 @@ and if there is nobody to raise it with (an unattended background session), the
 default is: emit the value WHOLE and record a follow-up naming the value, the
 population you could not measure, and the decision owed. Never pick the number
 just because no one was there to stop you.
+
+That default is about SIZE, never about secrecy, and the two must not be
+confused. If a value may carry a credential, token, or personal data, the
+unbounded default does NOT apply: fail closed and omit it wholesale with a
+marker, exactly as the "omit explicitly" rule says, and keep only non-sensitive
+metadata in the follow-up. Losing diagnostic prose is recoverable; leaking a
+token is not. Emitting whole and omitting wholesale are the same discipline —
+both refuse to hand on a fragment that looks complete.
 
 ### A blocked compound command loses EVERYTHING in it
 

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -192,13 +192,19 @@ only replaying a known-positive tells them apart.
 
 ### Select, don't amputate — truncation is the absence of a decision
 
-**Scope first, because bounding is often correct.** A bounded PREVIEW is a
-selection with a pointer, not an amputation — but only if the pointer actually
-resolves, and that is a claim to CHECK for the case in hand, never one to inherit
-from the mechanism. Bounding against a hard external budget is likewise correct:
-a hook's stdout cap, a database column, a context window. So is refusing an
-oversized value outright. This section is about the other case: a value that is
-the ONLY copy, where cutting it destroys the information.
+**Scope first, because bounding is often correct.** What makes something an
+amputation is LOSS — the value cut here was the only copy. Nothing else. A
+bounded PREVIEW of something stored intact elsewhere is a selection, and stays
+one even if its handle is useless. Bounding against a hard external budget is
+likewise correct: a hook's stdout cap, a database column, a context window. So is
+refusing an oversized value outright. This section is about the loss case.
+
+**A handle that does not resolve is a separate defect, and do not conflate the
+two** — that conflation is the mistake this section made about itself, twice.
+Check the pointer, because a preview advertising a retrieval path that does not
+exist teaches a lie; but when the full value survives somewhere, the fix is to
+mend or drop the handle, never to remove the cap. Removing a cap to prevent a
+loss that never happened is how this rule causes the damage it exists to stop.
 
 **There, do not truncate.** Not strings, not lists, not context, not output.
 Reaching for a character cap is a signal that a question was skipped, not
@@ -226,8 +232,15 @@ Three rules when a bound really is needed:
   and refusing it is a resource guard, not an amputation. What is forbidden is
   silently CUTTING them to fit. Only free text gets a bound it is expected to sit
   under; everything else gets one it must not cross.
-- **Derive the number, and record how — against a corpus that OUTLIVES the
-  claim.** Measure the real population and report `k/N` per the Acceptance Bar,
+- **Derive the number from the right thing, and record how.** A SAFETY bound —
+  memory exhaustion, an abuse ceiling, untrusted input — does not come from the
+  corpus at all: historical traffic says nothing about adversarial input,
+  concurrency, or the memory you actually have, and a cap chosen from observed
+  values will be exactly the wrong size when it matters. Derive those from the
+  protocol, the capacity and the threat model FIRST, then use `k/N` only to price
+  what the bound rejects. It is the COMPATIBILITY bounds — how long is this field
+  in practice, what does this cap cost real readers — that a corpus answers, and
+  for those: measure the real population and report `k/N` per the Acceptance Bar,
   then name the corpus, the query and the date. Naming them is necessary and not
   sufficient: the query is only re-derivable if the rows are still there when the
   next reader runs it, so a table with a retention window yields an EPHEMERAL
@@ -239,6 +252,12 @@ Three rules when a bound really is needed:
   fragment. The bound-plus-loud-flag half of this is already the house pattern;
   the character-count marker is a proposal, so do not go looking for a precedent
   that is not there.
+  **When the total is not already known, say that instead of computing it.**
+  Bounding a stream is the case: learning the exact discarded length means
+  reading the whole source, which is the cost the bound existed to avoid. So
+  `<omitted: ≥40,000 chars>` or `<omitted: rest of stream>` is the correct
+  marker there, and demanding an exact figure would force either an unbounded
+  read or an invented number — the two things this whole section is against.
 
 One trap deserves naming, because it is what produced this rule: **a cap can
 manufacture a correctness bug in the very data it was added to protect.**
@@ -265,11 +284,20 @@ What made the original defect dangerous was never that 300 existed — it was th
 
 That default is about SIZE, never about secrecy, and the two must not be
 confused. If a value may carry a credential, token, or personal data, the
-unbounded default does NOT apply: fail closed and omit it wholesale with a
-marker, exactly as the "omit explicitly" rule says, and record only
-non-sensitive metadata. Losing diagnostic prose is recoverable; leaking a token
-is not. Emitting whole and omitting wholesale are the same discipline — both
-refuse to hand on a fragment that looks complete.
+unbounded default does NOT apply — but what replaces it depends on WHERE the
+value is going, not on what it contains. Bound for unauthorized egress and for
+storage you cannot vouch for: fail closed, omit wholesale with a marker as the
+"omit explicitly" rule says, and keep only non-sensitive metadata. Losing
+diagnostic prose is recoverable; leaking a token is not.
+
+**Do not apply that to an authorized destination.** The user's own messages,
+memories and diagnostics flowing to the user, or into a private store, are
+personal data arriving exactly where it belongs; stripping them there is not a
+safeguard, it is data loss dressed as one — and this repo already draws that
+line, scanning and quarantining on the OUTBOUND path while leaving owner-facing
+content untouched. Ask which boundary the value is crossing before deciding.
+Where it is crossing one, emitting whole and omitting wholesale are the same
+discipline: both refuse to hand on a fragment that looks complete.
 
 **One last thing, learned the hard way from this section itself.** Four review
 rounds found defects in it, and every single one had the same shape: the cited

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -190,6 +190,65 @@ string ends in `\n`). The acceptance replay is what exposed it. A matcher that
 finds nothing is indistinguishable from a matcher that looks at nothing —
 only replaying a known-positive tells them apart.
 
+### Select, don't amputate — truncation is the absence of a decision
+
+**Scope first, because bounding is often correct.** A bounded PREVIEW whose full
+value stays retrievable from its store is a selection with a pointer, not an
+amputation — `memory/proactive.py:418` renders `principle[:200]` into the
+injection block on purpose, and the whole record is one `memory_expand` away.
+Bounding is likewise correct against a hard external budget (a hook stdout cap, a
+DB column, a context window). This section is about the other case: a value that
+is the ONLY copy, where cutting it destroys the information for good.
+
+**There, do not truncate.** Not strings, not lists, not context, not output.
+Reaching for a character cap is a signal that a question was skipped, not
+answered. Omitting is legitimate — it is a judgement about relevance. Truncating
+is not: it is what happens when that judgement was never made, so the value gets
+cut at a point that has nothing to do with meaning. A truncated value is
+frequently worse than either alternative, because it still LOOKS complete, so
+nobody checks it — at which point you may as well not have passed it at all.
+
+Before bounding anything, answer: what is this value FOR, who reads it, why does
+it need budgeting at all, and what actually breaks if it is unbounded? Solve
+THAT. Usually the answer is "select less, whole" rather than "cut", and often the
+bound turns out not to be load-bearing.
+
+Three rules when a bound really is needed:
+
+- **Bound by MEANING, not by one blanket number.** A closed set is validated
+  against that set — a value outside it is INVALID, not "too long". A timestamp
+  is a shape; half a timestamp is not a shorter timestamp. Only genuinely free
+  text gets a length bound. A blanket cap turns 100,000 characters of foreign
+  data into 300 characters of foreign data and calls it bounded.
+- **Derive the number, and record how.** Measure the real population and report
+  `k/N` per the Acceptance Bar — then name the corpus, the query and the date, so
+  the next reader can re-derive it rather than take it on faith. Re-derivable
+  example: provider error prose lands in `activity_log.error_message` (written by
+  `routing/router.py`, already capped there at 1024), so
+  `SELECT SUM(LENGTH(error_message) > 300), COUNT(*) FROM activity_log WHERE
+  error_message IS NOT NULL AND error_message != '';` On one install on
+  2026-09-03 that gave **270/318 (84.9%)** cut by a 300-char cap — and since JSON
+  error bodies put the machine-readable cause last, the cap discards exactly the
+  part worth keeping. Your install will differ; the denominator is itself already
+  truncated at 1024, so treat it as a floor.
+- **Omit explicitly, with a constant-bounded marker** (`<omitted: 104,823
+  chars>`), never a mid-value cut. An honest gap beats a plausible-looking
+  fragment. Already the house pattern: repo-pulse's loud `limit_hit`
+  (`session_awareness/repo_pulse_gh.py:170`), and the bound-plus-flag-plus-stated
+  -consequence model in `memory/integrity_repair.py:27` ("Truncation asymmetry").
+
+One trap worth naming: a cap can manufacture a correctness bug in the data it was
+added to protect. Bounding an IDENTIFIER by truncation merges two distinct
+identities onto one key, and downstream code then attributes one subject's state
+to another.
+
+**A real need to truncate is a CONVERSATION to have, not a magic number to pick
+alone.** If you catch yourself choosing 300 or 200 or 1000, stop and raise it —
+and if there is nobody to raise it with (an unattended background session), the
+default is: emit the value WHOLE and record a follow-up naming the value, the
+population you could not measure, and the decision owed. Never pick the number
+just because no one was there to stop you.
+
 ### A blocked compound command loses EVERYTHING in it
 
 A PreToolUse block kills the **whole** Bash call, not the offending part — so a


### PR DESCRIPTION
## Why

A cap invented during #1646 bounded peer *names* by truncation. Two peers whose names shared a prefix collapsed onto one state key, so **one peer's success cleared another peer's recorded quota failure** — the cap manufactured a correctness bug in the data it was added to protect.

That is the general shape, so the rule goes in the dev skill rather than staying a note on one PR.

## The rule

**Truncation is the absence of a decision.** Omitting is legitimate — it is a judgement about relevance. Truncating is what happens when that judgement was never made, so the value gets cut at a point that has nothing to do with meaning. And it still *looks* complete, so nobody checks it — at which point you may as well not have passed it at all.

## Scoped deliberately, because bounding is often correct

The first draft said "do not truncate" flat, which contradicts **904** shipped call sites — including `memory/proactive.py:418`, on the injection path that renders this very skill's context.

So the section now opens with the carve-out, *before* the absolute, so reading order works for the reader: a bounded **preview** whose full value stays retrievable is a selection with a pointer, not an amputation; so is bounding against a hard external budget (hook stdout cap, DB column, context window). What remains in scope is a value that is the **only copy**.

## Three rules where a bound is genuinely needed

- **Bound by MEANING, not one blanket number.** A closed set is validated against that set — a value outside it is *invalid*, not "too long". A timestamp is a shape; half a timestamp is not a shorter timestamp. A blanket cap turns 100,000 characters of foreign data into 300 characters of foreign data and calls it bounded.
- **Derive the number, and record how** — corpus, query, date — so the next reader can re-derive rather than take it on faith.
- **Omit with a constant-bounded marker**, never a mid-value cut. Already the house pattern: repo-pulse's loud `limit_hit` (`repo_pulse_gh.py:170`) and the bound-plus-flag-plus-stated-consequence model in `memory/integrity_repair.py:27`.

It ends with an **executable default**, not only "ask a human", so it is followable in an unattended background session: emit the value whole and record a follow-up naming the decision owed. This mirrors the Timeout Policy, which pairs the same terminus with a 7200s floor.

## The audit caught this section committing its own sin

The first draft cited a measured statistic — `183/670 (27.3%)` — that **no reader could re-derive**. It came from journalctl log lines on one install. The caveat was stated while measuring and then dropped when writing to permanent record, inside the very section that legislates against exactly that.

Replaced with a re-derivable measurement, verified by running it:

```sql
SELECT SUM(LENGTH(error_message) > 300), COUNT(*) FROM activity_log
 WHERE error_message IS NOT NULL AND error_message != '';
```

`270/318 (84.9%)` on one install — with the caveat that the corpus is itself already capped at 1024 by `routing/router.py:325`, so that figure is a **floor**, and that any other install will differ. The correction also strengthens the case: a 300-char cap is far more destructive than the original number claimed.

## Review

Docs-only, but a skill surface is always "substantial" to the depth gate, so it had a full adversarial pass: 1 BLOCKER, 2 SHOULD-FIX, 3 NOTEs — all addressed, dispositions recorded in the review evidence. Every cited `file:line` re-checked at the exact line; the published SQL executed as written; privacy scan of the added lines clean.

Placed at a point with ~35 lines of clearance from all seven in-flight PRs that touch this file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded guidance for presenting bounded previews without cutting through complete structured values.
  - Clarified that preview pointers must resolve, distinguishing resolvable memory handles from unresolved procedure references.
  - Corrected the documented truncation rate to exactly 270/318; content-loss estimates remain lower bounds.
  - Added surface-specific checks for reachability and whole-value preservation, including executor results, worktree-local notes, tool-scope rankings, and blocker fields.
  - Identified activity-log measurements as ephemeral unless their source corpus is preserved.
  - Required sensitive values to be omitted wholesale while retaining only non-sensitive metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->