### PR TITLE
feat(db): migration ids are timestamps, so two branches cannot pick the same one

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1495,6 +1495,7 @@ Merged-but-undeployable-elsewhere is a bug. The standard paths:
 | DB schema | additive idempotent migration — applies at restart |
 | One-off data fix / backfill | data-migration framework (post-boot, idempotent) — NEVER a hand-run script only this install executed |
 | **Naming either migration** | **UTC timestamp id: `` `date -u +%Y%m%d%H%M%S` ``_description.py** (data migrations prefix a `d`). NEVER hand-pick the next number — the legacy 4-digit namespace is FROZEN and CI refuses a new one. An id you have to CHOOSE is an id two branches choose identically: measured 2026-09-03, one PR was renumbered twice in a day and four open PRs held live collisions, while a duplicate prefix aborts bootstrap on every install. Nobody allocates a timestamp. |
+| **Changing an EXISTING migration** | **Don't — add a new one.** The legacy 4-digit set is frozen by ENUMERATED FILENAME, so renaming or deleting one fails CI. Installs that already applied `0050` will never run a renamed `0050_*`, while fresh installs will — two schemas diverging with nothing to notice. Discovery also REFUSES to run anything from a directory holding a file it cannot classify (a mistyped 13-digit id used to be skipped in silence, so the migration never ran at all). |
 | Config default | repo config file (+ optional local overlay); works with no overlay |
 | systemd unit / timer | registered in bootstrap.sh AND the update path — never hand-`systemctl enable`d only here |
 | Hooks / MCP servers | land at next CC session start (note the mid-window in the PR) |

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -1494,6 +1494,7 @@ Merged-but-undeployable-elsewhere is a bug. The standard paths:
 | Runtime code | `git pull` + server restart (update.sh does both) |
 | DB schema | additive idempotent migration — applies at restart |
 | One-off data fix / backfill | data-migration framework (post-boot, idempotent) — NEVER a hand-run script only this install executed |
+| **Naming either migration** | **UTC timestamp id: `` `date -u +%Y%m%d%H%M%S` ``_description.py** (data migrations prefix a `d`). NEVER hand-pick the next number — the legacy 4-digit namespace is FROZEN and CI refuses a new one. An id you have to CHOOSE is an id two branches choose identically: measured 2026-09-03, one PR was renumbered twice in a day and four open PRs held live collisions, while a duplicate prefix aborts bootstrap on every install. Nobody allocates a timestamp. |
 | Config default | repo config file (+ optional local overlay); works with no overlay |
 | systemd unit / timer | registered in bootstrap.sh AND the update path — never hand-`systemctl enable`d only here |
 | Hooks / MCP servers | land at next CC session start (note the mid-window in the PR) |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,10 +305,17 @@ jobs:
           printf '%s\n%s\n' "$added" "$body" | python3 scripts/ci/private_pattern_scan.py --patterns "$pf"
 
   migration-check:
-    # Migration ids: no duplicate prefix in either namespace, and no NEW
-    # hand-allocated 4-digit id (that namespace is frozen — new migrations use
-    # a UTC timestamp, which nobody has to allocate and two branches therefore
-    # cannot both claim).
+    # Migration ids, three rules: every file in a migrations directory is a
+    # legal migration (the residue is a violation, because a name that matches
+    # nothing is discovered by nothing and NEVER RUNS), no duplicate id in
+    # either namespace, and every frozen legacy file is still present under its
+    # own name (deleting or renaming one leaves the id set identical while
+    # existing installs skip the replacement forever).
+    #
+    # The legacy namespace is frozen as an ENUMERATED set, not a range: 0092
+    # lies between the endpoints and does not exist, so a range check admitted
+    # a brand-new hand-allocated 0092_*.py. New migrations use a UTC timestamp,
+    # which nobody has to allocate and two branches therefore cannot both claim.
     #
     # The check moved out of shell deliberately. The old glob+grep restated the
     # runners' filename semantics in a second language and could not survive

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,14 +339,38 @@ jobs:
           # Passed via env, not interpolated into `run` — same handling the
           # leak-detector job uses for PR_BASE_SHA.
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          # For `push: main` builds. origin/main is USELESS there — it IS the
+          # just-pushed checkout, so `--base origin/main` compares the tree with
+          # itself and the immutability rule silently checks nothing. The push
+          # event's `before` SHA is the pre-push state, which is the base that
+          # makes the post-merge run able to see a deletion that reached main
+          # outside the PR check. All-zero on branch creation, hence the guards
+          # below.
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: |
           set -euo pipefail
-          # On a push build there is no PR base; fall back to the default branch,
-          # which the full-depth fetch above has. `--base` is passed only when a
-          # ref was resolved, so the guard never fails a build for a base that
-          # does not exist in that context.
+          # Base resolution, most-specific first:
+          #   PR build        -> the PR base (what "already merged" means there);
+          #   push build      -> the pre-push SHA (see PUSH_BEFORE_SHA above);
+          #   schedule/manual -> origin/main IF it differs from the checkout.
+          # `--base` is passed only when a ref was resolved, exists, AND is not
+          # the checkout itself. A base equal to HEAD is a self-comparison: the
+          # rule would examine nothing while the log claimed "immutable against
+          # origin/main" — a verified-grammar claim that is false, and the exact
+          # silent pass the guard's own doctrine forbids. So schedule/dispatch
+          # runs on main (and any degraded push case whose `before` is
+          # unreachable) drop --base and honestly print best-effort scope; the
+          # PR and push runs are the enforcement points for immutability.
+          # Known fail-NOISY edge, accepted: a re-run of an OLD build compares
+          # its old checkout against origin/main fetched NOW and can go red on
+          # migrations that merged since — loud and explainable, never silent.
           base="${PR_BASE_SHA:-}"
-          if [[ -z "$base" ]] && git rev-parse --verify -q origin/main >/dev/null; then
+          if [[ -z "$base" && -n "${PUSH_BEFORE_SHA:-}" && "${PUSH_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]] \
+             && git cat-file -e "${PUSH_BEFORE_SHA}^{commit}" 2>/dev/null; then
+            base="$PUSH_BEFORE_SHA"
+          fi
+          if [[ -z "$base" ]] && git rev-parse --verify -q origin/main >/dev/null \
+             && [[ "$(git rev-parse origin/main)" != "$(git rev-parse HEAD)" ]]; then
             base="origin/main"
           fi
           if [[ -n "$base" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,27 +305,24 @@ jobs:
           printf '%s\n%s\n' "$added" "$body" | python3 scripts/ci/private_pattern_scan.py --patterns "$pf"
 
   migration-check:
-    # Catch duplicate migration prefixes before merge — two PRs creating
-    # the same NNNN_*.py prefix will collide at runtime.
+    # Migration ids: no duplicate prefix in either namespace, and no NEW
+    # hand-allocated 4-digit id (that namespace is frozen — new migrations use
+    # a UTC timestamp, which nobody has to allocate and two branches therefore
+    # cannot both claim).
+    #
+    # The check moved out of shell deliberately. The old glob+grep restated the
+    # runners' filename semantics in a second language and could not survive
+    # mixed-width ids in EITHER direction (both measured 2026-09-03): its
+    # 4-digit glob made timestamp migrations invisible to the guard, and
+    # widening the glob while keeping `grep -oP '^\d{4}'` truncated every
+    # 20260903… id to "2026", reporting two distinct migrations as duplicates.
+    # scripts/check_migration_prefixes.py imports the runners' own patterns, so
+    # the guard cannot drift from what actually runs.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Check migration prefix uniqueness
-        run: |
-          set -euo pipefail
-          dir="src/genesis/db/migrations"
-          dupes=$(ls "$dir"/[0-9][0-9][0-9][0-9]_*.py 2>/dev/null \
-            | xargs -I{} basename {} \
-            | grep -oP '^\d{4}' \
-            | sort | uniq -d || true)
-          if [[ -n "$dupes" ]]; then
-            echo "::error::Duplicate migration prefixes found: $dupes"
-            for p in $dupes; do
-              echo "  Files: $(ls "$dir"/${p}_*.py)"
-            done
-            exit 1
-          fi
-          echo "Migration prefix check: CLEAN"
+      - name: Check migration ids (uniqueness + legacy freeze)
+        run: python3 scripts/check_migration_prefixes.py
 
   external-io-check:
     # WS5 regression guard: no NEW ungated autonomous external-world egress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,8 +328,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - name: Check migration ids (uniqueness + legacy freeze)
-        run: python3 scripts/check_migration_prefixes.py
+        with:
+          # The immutability rule asks git what was ALREADY MERGED — the one
+          # question a list in the repo cannot answer for an unbounded id space.
+          # A shallow clone has no base commit to compare against, and the guard
+          # treats an unreadable --base as a violation rather than a pass.
+          fetch-depth: 0
+      - name: Check migration ids (uniqueness + immutability)
+        env:
+          # Passed via env, not interpolated into `run` — same handling the
+          # leak-detector job uses for PR_BASE_SHA.
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          # On a push build there is no PR base; fall back to the default branch,
+          # which the full-depth fetch above has. `--base` is passed only when a
+          # ref was resolved, so the guard never fails a build for a base that
+          # does not exist in that context.
+          base="${PR_BASE_SHA:-}"
+          if [[ -z "$base" ]] && git rev-parse --verify -q origin/main >/dev/null; then
+            base="origin/main"
+          fi
+          if [[ -n "$base" ]]; then
+            python3 scripts/check_migration_prefixes.py --base "$base"
+          else
+            python3 scripts/check_migration_prefixes.py
+          fi
 
   external-io-check:
     # WS5 regression guard: no NEW ungated autonomous external-world egress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Two branches can no longer pick the same database-migration number.** Each
+  new migration is now named by the UTC time it was written rather than by the
+  next free number, so nobody has to check what anyone else took — and two
+  people working at once cannot both claim the same one. The numbers already in
+  use are frozen exactly as they are; an existing install is unaffected and runs
+  nothing again. A migration that has already shipped can no longer be renamed
+  or removed either: installs that already ran it would never run its
+  replacement, so the two would drift apart with nothing to notice. And a
+  migration whose name is subtly wrong — a digit too few, filed in the wrong
+  folder — is now reported instead of being quietly skipped, which is what used
+  to happen: the file simply never ran, and the change that needed it shipped
+  without it.
+
 - **The cold-marketing campaign no longer re-pitches the same person.** Once a
   marketing pitch is delivered to a prospect, that prospect is marked contacted and
   drops out of the campaign's target list — previously nothing recorded the contact,

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1663,7 +1663,7 @@ verified: 50b79ffb 2026-09-01
   non-schema backfills (Qdrant payloads, entity graphs) that run POST-boot as a
   background `tracked_task` (kicked from `runtime/_core`), never abort boot, are
   idempotent, and are claimed atomically via the `data_migrations` ledger (so
-  server + bridge-fallback can't double-run). `dNNNN_*.py` modules expose sync
+  server + bridge-fallback can't double-run). `d`-prefixed modules expose sync
   `migrate()`+`verify()` (runner offloads via `to_thread`); `requires_operator`
   ones sit `operator_pending` and never auto-run. Shared file-discovery with the
   schema runner (`db/_migration_discovery.py`), deliberately NOT the atomic-txn

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1674,7 +1674,7 @@ verified: 50b79ffb 2026-09-01
   non-schema backfills (Qdrant payloads, entity graphs) that run POST-boot as a
   background `tracked_task` (kicked from `runtime/_core`), never abort boot, are
   idempotent, and are claimed atomically via the `data_migrations` ledger (so
-  server + bridge-fallback can't double-run). `dNNNN_*.py` modules expose sync
+  server + bridge-fallback can't double-run). `d`-prefixed modules expose sync
   `migrate()`+`verify()` (runner offloads via `to_thread`); `requires_operator`
   ones sit `operator_pending` and never auto-run. Shared file-discovery with the
   schema runner (`db/_migration_discovery.py`), deliberately NOT the atomic-txn

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1656,8 +1656,17 @@ verified: 50b79ffb 2026-09-01
 - **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
   without it interleaved commits pin `in_transaction` until restart). Two
   schema paths coexist: base DDL (`schema/_tables.py`, 118 CREATE TABLE; docs
-  still say "60+") plus versioned `migrations/` 0001..0089 run ONCE at startup
-  before any other init step touches data; a failed migration ABORTS bootstrap.
+  still say "60+") plus versioned `migrations/` run ONCE at startup before any
+  other init step touches data; a failed migration ABORTS bootstrap. Ids are
+  92 FROZEN legacy 4-digit ones (`0001`..`0093`, with a GAP at `0092` from a
+  rename) plus new `YYYYMMDDHHMMSS_*.py` UTC timestamps — nobody allocates an
+  id any more, which is what removed the cross-branch collisions. The legacy
+  set is ENUMERATED in `db/_migration_ids.FROZEN_LEGACY_FILES` (a range cannot
+  express the `0092` gap), and discovery REFUSES a directory holding any file
+  it cannot classify, because a name matching nothing is discovered by nothing
+  and would never run. Discovery enforces RUNNABLE; CI
+  (`scripts/check_migration_prefixes.py`) additionally enforces this repo's
+  freeze, so a fork's own 4-digit migration runs rather than bricking its boot.
   EVERY table must be in BOTH paths (fresh-install DDL + its numbered
   migration) — a design CONVENTION whose TABLE-set parity is NOT test-enforced:
   `test_db/test_schema.py`'s `EXPECTED_TABLES` allow-list only pins the DDL

--- a/scripts/check_migration_prefixes.py
+++ b/scripts/check_migration_prefixes.py
@@ -63,6 +63,17 @@ Rules, all fail-closed:
 5. **No migration in a SUBDIRECTORY.** Discovery is flat because importlib
    resolves a flat package, so a nested file is discovered by nothing: the same
    never-runs silence as rule 1, in the one shape a flat scan cannot see.
+6. **Nothing already MERGED disappears.** Rule 3 is an enumerated list, and a
+   list can only hold a closed set: the legacy ids. Timestamp ids are unbounded,
+   so the moment the first one merges, deleting or renaming it passes every rule
+   above — existing installs keep its id in their ledger and skip the
+   replacement forever. "Already merged" is a fact only git holds, so this rule
+   asks git (``--base``) instead of transcribing it into a list that goes stale.
+   A rename is a delete plus an add, so no rename detection is needed. An
+   explicitly-passed base that cannot be READ is a violation, because a guard
+   told to compare that then compares nothing is the silent pass this file
+   exists to remove; with no base given at all the rule is skipped, so a fork
+   running from a tarball is not failed for lacking history.
 
 Read-only. Exit 0 clean, 1 on any violation, 2 on a usage/plumbing error
 (never a silent pass).
@@ -72,11 +83,12 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import subprocess
 import sys
 import traceback
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -101,16 +113,60 @@ def _load_id_contract(repo_root: Path):
     return module
 
 
-def check(repo_root: Path) -> list[str]:
-    """Return a list of human-readable violations (empty == clean)."""
+#: Where the "already merged" question is answered when nobody says otherwise.
+_DEFAULT_BASE_REF = "origin/main"
+
+
+def _runnable_names_at(repo_root: Path, ref: str, rel_dir: str, ids) -> set[str] | None:
+    """Runnable migration filenames present in *rel_dir* at git *ref*.
+
+    ``None`` means the question could not be ASKED — no git, no such ref, a
+    tarball checkout. That is not the same answer as "nothing was deleted", and
+    the caller keeps the two apart.
+
+    Filtered through the SAME :func:`classify` the on-disk scan uses, so a name
+    that never ran (malformed on the base) is not defended: removing it is a
+    fix, not a regression. A rename is a delete plus an add, so it needs no
+    rename detection to be caught — the old name is simply gone.
+    """
+    try:
+        out = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["git", "-C", str(repo_root), "ls-tree", "-r", "--name-only", ref, "--", rel_dir],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    names = {PurePosixPath(line).name for line in out.stdout.splitlines() if line.strip()}
+    label = ids.SCHEMA if rel_dir.endswith("/migrations") else ids.DATA
+    return {n for n in names if ids.classify(label, n) in ids.RUNNABLE}
+
+
+def check(repo_root: Path, *, base_ref: str | None = None) -> list[str]:
+    """Return a list of human-readable violations (empty == clean).
+
+    ``base_ref`` names the commit that answers "what was already merged". Pass
+    it explicitly (CI does) and an unreadable ref becomes a VIOLATION: a guard
+    that was configured to compare and then quietly compared nothing is the
+    silent-pass this whole file exists to remove. Left unset, the check falls
+    back to ``origin/main`` and DEGRADES to a printed note if that is not
+    resolvable — a fork running this from a tarball has no base to compare
+    against and should not be failed for it.
+    """
     ids = _load_id_contract(repo_root)
     surfaces = [
-        (ids.SCHEMA, repo_root / "src/genesis/db/migrations"),
-        (ids.DATA, repo_root / "src/genesis/db/data_migrations"),
+        (ids.SCHEMA, "src/genesis/db/migrations"),
+        (ids.DATA, "src/genesis/db/data_migrations"),
     ]
+    ref = base_ref or _DEFAULT_BASE_REF
 
     violations: list[str] = []
-    for label, directory in surfaces:
+    for label, rel_dir in surfaces:
+        directory = repo_root / rel_dir
         if not directory.is_dir():
             # Fail CLOSED: the id contract now lives OUTSIDE these directories,
             # so a missing one no longer fails at load — and a scan that never
@@ -199,6 +255,46 @@ def check(repo_root: Path) -> list[str]:
                 "timestamp id."
             )
 
+        # ...and the SAME rule for everything the enumerated list cannot hold.
+        #
+        # FROZEN_LEGACY_FILES is a hand-maintained snapshot of one closed set. It
+        # cannot grow to cover timestamp migrations — those are unbounded and
+        # nobody would remember to add them — so the moment the first timestamp
+        # migration merges, a later PR can delete it or rename it to another
+        # perfectly valid timestamp and every rule above still reports CLEAN.
+        # Existing installs keep the old id in their ledger and skip the
+        # replacement forever; fresh installs never run the deleted one. Same
+        # divergence the legacy freeze exists to prevent, one namespace over.
+        #
+        # "Already merged" is a fact only git holds, so it is asked of git rather
+        # than transcribed into a list that goes stale. This subsumes the check
+        # above for anything on the base branch; the enumeration is kept because
+        # it answers a different question — it asserts what main itself should
+        # contain, and so still fires if the base branch is the thing that lost a
+        # file.
+        base_names = _runnable_names_at(repo_root, ref, rel_dir, ids)
+        if base_names is None:
+            if base_ref is not None:
+                violations.append(
+                    f"{label}s: base ref {ref!r} could not be read, so nothing "
+                    "was compared against what is already merged. A guard that "
+                    "was told to compare and then compared nothing is a silent "
+                    "pass — fetch the base (actions/checkout needs "
+                    "`fetch-depth: 0`) or drop --base to run without this rule."
+                )
+        else:
+            gone = sorted(base_names - seen)
+            if gone:
+                violations.append(
+                    f"{label}s: {len(gone)} migration(s) present at {ref} are "
+                    f"missing here: {', '.join(gone)}. An already-merged "
+                    "migration may not be deleted or renamed at any id — installs "
+                    "that ran it keep its id in their ledger and will never run "
+                    "the replacement, while a fresh install runs only the new "
+                    "one. To change what a migration does, add a NEW one with a "
+                    "UTC timestamp id."
+                )
+
     return violations
 
 
@@ -210,10 +306,19 @@ def main() -> int:
         default=_REPO_ROOT,
         help="repository root (default: this script's parent repo)",
     )
+    parser.add_argument(
+        "--base",
+        default=None,
+        help=(
+            "git ref answering 'what is already merged' (CI passes the PR base "
+            f"sha). Unset: try {_DEFAULT_BASE_REF} and skip the rule if it is "
+            "not resolvable. Set: an unreadable ref is a violation."
+        ),
+    )
     args = parser.parse_args()
 
     try:
-        violations = check(args.repo_root)
+        violations = check(args.repo_root, base_ref=args.base)
     except Exception as exc:  # plumbing failure must never read as clean
         print(f"::error::migration-prefix guard could not run: {exc}", file=sys.stderr)
         # The annotation names the cause; the traceback is what a maintainer
@@ -225,9 +330,10 @@ def main() -> int:
         for v in violations:
             print(f"::error::{v}")
         return 1
+    scope = f"immutable against {args.base}" if args.base else "no base compared"
     print(
         "Migration id check: CLEAN (every file classified; no duplicates; "
-        "frozen legacy set intact)"
+        f"frozen legacy set intact; {scope})"
     )
     return 0
 

--- a/scripts/check_migration_prefixes.py
+++ b/scripts/check_migration_prefixes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Migration-id guard: no duplicate prefixes, and the legacy namespace stays frozen.
+"""Migration-id guard: every file in a migrations directory is a legal migration.
 
 Replaces the shell glob+grep that lived in ci.yml. That version could not
 survive the move to timestamp ids in either direction, both measured
@@ -12,9 +12,9 @@ survive the move to timestamp ids in either direction, both measured
     duplicate of each other — CI red on the second one ever written.
 
 Both failures come from re-implementing the runners' filename semantics in a
-second language. This script instead IMPORTS the authoritative patterns from
+second language. This script instead IMPORTS the authoritative contract from
 ``src/genesis/db/_migration_ids.py``, so the guard cannot drift from what
-actually runs (the same reason the tree-wide test imports them rather than
+actually runs (the same reason the tree-wide test imports it rather than
 copying).
 
 It imports that module and NOT the runners, which was the first attempt: the
@@ -26,20 +26,43 @@ stdlib-only precisely so this path import is safe under a bare ``python3``;
 ``test_ci_command_line_*`` runs this script the way CI does so that premise
 stays true.
 
-Two rules, both fail-closed:
+THIS GUARD IS STRICTER THAN THE RUNTIME, ON PURPOSE. Discovery refuses only
+files that CANNOT RUN; a well-formed 4-digit id outside this repo's frozen set
+runs there with a warning, because refusing it on the boot-abort path would
+leave a downstream fork carrying its own ``0094_*.py`` with no database after a
+pull — over a policy of ours, not an invariant of theirs. CI is the layer that
+may enforce this repo's namespace, so the freeze is refused HERE.
 
-1. **No duplicate prefix** in either namespace. Both runners raise on one —
-   the schema runner aborts bootstrap on every install, the data runner skips
-   its whole batch post-boot — so this stays enforced for timestamp ids too
-   (two authors can hit the same second, however unlikely).
-2. **The legacy namespace is FROZEN.** New migrations use a UTC timestamp id;
-   a new 4-digit (or ``d`` + 4-digit) prefix is refused. Freezing is what
-   removes prefix contention at the root: nobody allocates an id any more, so
-   two branches cannot claim the same one. Enforced against the frozen
-   window's BOTH ENDS — an earlier one-sided "above the mark" rule let
-   ``0000`` through, which is legacy-width, duplicates nothing, and is the
-   worst possible id for it (fresh install: runs before ``0001``; existing
-   install: runs last).
+Rules, all fail-closed:
+
+1. **Every file is classified, and the residue is a violation.** A name that
+   presents as a migration but does not parse as one — a mistyped width, a
+   ``d`` prefix in the wrong directory, a non-ASCII digit, a legacy-width id
+   outside the frozen set — is reported. Its predecessor matched a regex and
+   skipped whatever failed, which is the same silence the runtime had: the file
+   is discovered by nothing and NEVER RUNS, so the code that needs it deploys
+   against a schema that never got the change.
+2. **No duplicate id** in either namespace. Both runners raise on one — the
+   schema runner aborts bootstrap on every install, the data runner skips its
+   whole batch post-boot — so this stays enforced for timestamp ids too (two
+   authors can hit the same second, however unlikely).
+3. **Every frozen legacy file is still present, under its own name.** The
+   frozen set is enumerated, not a range, so this catches a DELETED legacy
+   migration and a RENAMED one (``0050_old.py`` -> ``0050_new.py`` leaves the
+   id set identical while existing installs skip the file forever and fresh
+   installs run it). It is a statement about the default branch, which is why
+   it lives here and not in the runtime: CI checks out the merge ref, so main's
+   files are present, but an individual install legitimately sits on an older
+   commit with fewer of them.
+4. **No FUTURE timestamp id.** The ordering invariant's floor is guarded in the
+   contract (a year >= the epoch forces a leading '2', so timestamps sort after
+   legacy ids); the ceiling is guarded here, where "future" can be measured
+   against the present instead of a static cap that would age badly. One wrong
+   digit — 2926 for 2026 — is a valid id that sorts after everything anyone
+   writes for centuries, and is a likelier typo than the widths already caught.
+5. **No migration in a SUBDIRECTORY.** Discovery is flat because importlib
+   resolves a flat package, so a nested file is discovered by nothing: the same
+   never-runs silence as rule 1, in the one shape a flat scan cannot see.
 
 Read-only. Exit 0 clean, 1 on any violation, 2 on a usage/plumbing error
 (never a silent pass).
@@ -52,6 +75,7 @@ import importlib.util
 import sys
 import traceback
 from collections import defaultdict
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -81,20 +105,12 @@ def check(repo_root: Path) -> list[str]:
     """Return a list of human-readable violations (empty == clean)."""
     ids = _load_id_contract(repo_root)
     surfaces = [
-        (
-            "schema migration",
-            repo_root / "src/genesis/db/migrations",
-            ids.SCHEMA_MIGRATION_PATTERN,
-        ),
-        (
-            "data migration",
-            repo_root / "src/genesis/db/data_migrations",
-            ids.DATA_MIGRATION_PATTERN,
-        ),
+        (ids.SCHEMA, repo_root / "src/genesis/db/migrations"),
+        (ids.DATA, repo_root / "src/genesis/db/data_migrations"),
     ]
 
     violations: list[str] = []
-    for label, directory, pattern in surfaces:
+    for label, directory in surfaces:
         if not directory.is_dir():
             # Fail CLOSED: the id contract now lives OUTSIDE these directories,
             # so a missing one no longer fails at load — and a scan that never
@@ -104,15 +120,58 @@ def check(repo_root: Path) -> list[str]:
             )
             continue
 
+        # ONE scan, shared with the runtime, so the guard cannot classify a file
+        # differently from the runner that will execute it.
+        runnable, unrunnable, disallowed = ids.scan_directory(label, directory)
+
+        # The runtime RUNS a disallowed-but-runnable id and only warns, because
+        # refusing it there would brick a downstream fork over a rule of ours.
+        # CI is the layer that may enforce this repo's namespace policy.
+        for reason in unrunnable + disallowed:
+            violations.append(f"{label}s: {reason}")
+
         by_prefix: dict[str, list[str]] = defaultdict(list)
-        for path in sorted(directory.iterdir()):
-            m = pattern.match(path.name)
-            if m:
-                by_prefix[m.group(1)].append(path.name)
+        seen: set[str] = set()
+        for migration_id, _stem, path in runnable:
+            seen.add(path.name)
+            by_prefix[migration_id].append(path.name)
+            # The ordering invariant is guarded at its floor by
+            # is_valid_timestamp_id (year >= epoch, so a timestamp sorts after
+            # every legacy id). Nothing bounded the other end, and the typo that
+            # hits it is far likelier than the ones that were caught: one wrong
+            # digit turns 2026 into 2926, which is a perfectly valid id that
+            # sorts after everything anyone writes for the next 900 years.
+            #
+            # The ceiling lives HERE and not in the contract because it is
+            # relative to now: a static cap would become a time bomb for an
+            # install running years from now, while CI always runs in the
+            # present.
+            core = migration_id.lstrip("d")
+            if len(core) == 14:
+                stamp = datetime.strptime(core, "%Y%m%d%H%M%S").replace(tzinfo=UTC)
+                if stamp > datetime.now(UTC) + timedelta(days=1):
+                    violations.append(
+                        f"{label}s: {path.name!r} carries a FUTURE timestamp id "
+                        f"{core!r}. It would sort after every migration written "
+                        f"between now and then, so it runs last on a fresh "
+                        f"install and in sequence on an existing one. "
+                        f"Regenerate it with `date -u +%Y%m%d%H%M%S`."
+                    )
+
+        # Discovery is FLAT (importlib resolves a flat package), so a migration
+        # one directory down is discovered by nothing — the same never-runs
+        # silence this guard exists to close, left open for one shape.
+        for nested in sorted(directory.rglob("*.py")):
+            if nested.parent != directory and ids.CANDIDATE_PATTERN.match(nested.name):
+                violations.append(
+                    f"{label}s: {nested.relative_to(directory)} sits in a "
+                    "subdirectory of the migrations package. Discovery is flat, "
+                    "so it would never run. Move it up one level."
+                )
 
         if not by_prefix:
             violations.append(
-                f"{label}s: no files matched {pattern.pattern} in {directory} — "
+                f"{label}s: no runnable migration found in {directory} — "
                 "not a possible state, so the scan did not describe the directory"
             )
             continue
@@ -120,27 +179,25 @@ def check(repo_root: Path) -> list[str]:
         for prefix, names in sorted(by_prefix.items()):
             if len(names) > 1:
                 violations.append(
-                    f"{label}s: duplicate prefix '{prefix}' — {', '.join(sorted(names))}. "
+                    f"{label}s: duplicate id '{prefix}' — {', '.join(sorted(names))}. "
                     "Rename one to a fresh UTC timestamp id "
                     "(`date -u +%Y%m%d%H%M%S`)."
                 )
 
-        lo, hi = ids.FROZEN_LEGACY_WINDOW[label]
-        suffix = " with a leading 'd'." if label == "data migration" else "."
-        for prefix in sorted(p for p in by_prefix if ids.is_legacy_id(p)):
-            # BOTH ends: below `lo` is as much a hand-allocated id as above
-            # `hi`, and `0000` — which a one-sided rule let through — is the id
-            # whose fresh-vs-existing ordering diverges maximally.
-            if not (lo <= prefix <= hi):
-                violations.append(
-                    f"{label}s: '{prefix}' ({', '.join(sorted(by_prefix[prefix]))}) "
-                    f"allocates a NEW legacy-width id, but that namespace is frozen "
-                    f"at {lo}..{hi}. New migrations use a UTC timestamp id: "
-                    "`date -u +%Y%m%d%H%M%S`_description.py" + suffix
-                    + " (If a legacy migration legitimately landed on the default "
-                    "branch above the window while this was in flight, bump the "
-                    "window in src/genesis/db/_migration_ids.py.)"
-                )
+        # An id-set check cannot see this: deleting or renaming a frozen file
+        # leaves min/max/count untouched, while existing installs — which have
+        # the id in `schema_migrations` — skip it forever and fresh installs
+        # run it. The two schemas then diverge with nothing to notice.
+        missing = sorted(ids.FROZEN_LEGACY_FILES[label] - seen)
+        if missing:
+            violations.append(
+                f"{label}s: {len(missing)} frozen legacy file(s) missing from "
+                f"{directory}: {', '.join(missing)}. That namespace is frozen — "
+                "an applied migration may not be deleted or renamed, because "
+                "installs that already ran it will never run the replacement. "
+                "To change what one does, add a NEW migration with a UTC "
+                "timestamp id."
+            )
 
     return violations
 
@@ -168,7 +225,10 @@ def main() -> int:
         for v in violations:
             print(f"::error::{v}")
         return 1
-    print("Migration prefix check: CLEAN (no duplicates; legacy namespace frozen)")
+    print(
+        "Migration id check: CLEAN (every file classified; no duplicates; "
+        "frozen legacy set intact)"
+    )
     return 0
 
 

--- a/scripts/check_migration_prefixes.py
+++ b/scripts/check_migration_prefixes.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Migration-id guard: no duplicate prefixes, and the legacy namespace stays frozen.
+
+Replaces the shell glob+grep that lived in ci.yml. That version could not
+survive the move to timestamp ids in either direction, both measured
+2026-09-03 against a mixed directory:
+
+  * its glob ``[0-9][0-9][0-9][0-9]_*.py`` made every timestamp migration
+    INVISIBLE to the duplicate check — the guard silently stopped guarding;
+  * widening the glob while keeping ``grep -oP '^\\d{4}'`` truncated
+    ``20260903200000`` to ``2026``, so any two same-year migrations read as a
+    duplicate of each other — CI red on the second one ever written.
+
+Both failures come from re-implementing the runners' filename semantics in a
+second language. This script instead IMPORTS the authoritative patterns from
+``src/genesis/db/_migration_ids.py``, so the guard cannot drift from what
+actually runs (the same reason the tree-wide test imports them rather than
+copying).
+
+It imports that module and NOT the runners, which was the first attempt: the
+runners carry module-scope ``import aiosqlite`` / ``from genesis.db.crud …``,
+so binding to them pulled 117 modules into a CI job that installs nothing and
+exited 2 on every PR — a guard that enforced neither rule while every test
+passed, because pytest runs inside the project venv. ``_migration_ids`` is
+stdlib-only precisely so this path import is safe under a bare ``python3``;
+``test_ci_command_line_*`` runs this script the way CI does so that premise
+stays true.
+
+Two rules, both fail-closed:
+
+1. **No duplicate prefix** in either namespace. Both runners raise on one —
+   the schema runner aborts bootstrap on every install, the data runner skips
+   its whole batch post-boot — so this stays enforced for timestamp ids too
+   (two authors can hit the same second, however unlikely).
+2. **The legacy namespace is FROZEN.** New migrations use a UTC timestamp id;
+   a new 4-digit (or ``d`` + 4-digit) prefix is refused. Freezing is what
+   removes prefix contention at the root: nobody allocates an id any more, so
+   two branches cannot claim the same one. Enforced against the frozen
+   window's BOTH ENDS plus its size — an earlier one-sided "above the mark"
+   rule let ``0000`` through, which is legacy-width, duplicates nothing, and
+   is the worst possible id for it (fresh install: runs before ``0001``;
+   existing install: runs after ``0091``).
+
+Read-only. Exit 0 clean, 1 on any violation, 2 on a usage/plumbing error
+(never a silent pass).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import traceback
+from collections import defaultdict
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_id_contract(repo_root: Path):
+    """Path-import ``db/_migration_ids`` and return it.
+
+    By path, not by package import: CI installs nothing, so
+    ``import genesis.db…`` is unavailable. That module is stdlib-only by
+    contract (its own docstring says so and this is why), which is what makes
+    a bare-interpreter path import safe here. Not registered in ``sys.modules``
+    — it defines no dataclasses, so nothing needs the self-reference, and
+    leaving the process clean avoids the cross-test contamination a previous
+    runner-importing version created.
+    """
+    path = repo_root / "src/genesis/db/_migration_ids.py"
+    spec = importlib.util.spec_from_file_location("_migration_ids", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - plumbing
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def check(repo_root: Path) -> list[str]:
+    """Return a list of human-readable violations (empty == clean)."""
+    ids = _load_id_contract(repo_root)
+    surfaces = [
+        (
+            "schema migration",
+            repo_root / "src/genesis/db/migrations",
+            ids.SCHEMA_MIGRATION_PATTERN,
+        ),
+        (
+            "data migration",
+            repo_root / "src/genesis/db/data_migrations",
+            ids.DATA_MIGRATION_PATTERN,
+        ),
+    ]
+
+    violations: list[str] = []
+    for label, directory, pattern in surfaces:
+        if not directory.is_dir():
+            # Fail CLOSED: the id contract now lives OUTSIDE these directories,
+            # so a missing one no longer fails at load — and a scan that never
+            # read a directory must never read as clean.
+            violations.append(
+                f"{label}s: directory not found at {directory} — nothing was scanned"
+            )
+            continue
+
+        by_prefix: dict[str, list[str]] = defaultdict(list)
+        for path in sorted(directory.iterdir()):
+            m = pattern.match(path.name)
+            if m:
+                by_prefix[m.group(1)].append(path.name)
+
+        if not by_prefix:
+            violations.append(
+                f"{label}s: no files matched {pattern.pattern} in {directory} — "
+                "not a possible state, so the scan did not describe the directory"
+            )
+            continue
+
+        for prefix, names in sorted(by_prefix.items()):
+            if len(names) > 1:
+                violations.append(
+                    f"{label}s: duplicate prefix '{prefix}' — {', '.join(sorted(names))}. "
+                    "Rename one to a fresh UTC timestamp id "
+                    "(`date -u +%Y%m%d%H%M%S`)."
+                )
+
+        lo, hi, expected = ids.FROZEN_LEGACY_WINDOW[label]
+        suffix = " with a leading 'd'." if label == "data migration" else "."
+        legacy = sorted(p for p in by_prefix if ids.is_legacy_id(p))
+
+        for prefix in legacy:
+            # BOTH ends: below `lo` is as much a hand-allocated id as above
+            # `hi`, and `0000` — which a one-sided rule let through — is the
+            # id whose fresh-vs-existing ordering diverges maximally.
+            if not (lo <= prefix <= hi):
+                violations.append(
+                    f"{label}s: '{prefix}' ({', '.join(sorted(by_prefix[prefix]))}) "
+                    f"allocates a NEW legacy-width id, but that namespace is frozen "
+                    f"at {lo}..{hi}. New migrations use a UTC timestamp id: "
+                    "`date -u +%Y%m%d%H%M%S`_description.py" + suffix
+                )
+
+        # Contiguity: for a contiguous range, (lo, hi, count) characterises the
+        # set exactly — so a DELETED legacy migration, which would otherwise
+        # free its id for silent re-allocation, surfaces here instead.
+        if legacy and (legacy[0], legacy[-1], len(legacy)) != (lo, hi, expected):
+            violations.append(
+                f"{label}s: the frozen legacy window {lo}..{hi} should hold exactly "
+                f"{expected} ids; found {len(legacy)} spanning "
+                f"{legacy[0]}..{legacy[-1]}. A deleted legacy migration frees its id "
+                "for re-allocation — restore it, or move the window deliberately in "
+                "src/genesis/db/_migration_ids.py."
+            )
+
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=_REPO_ROOT,
+        help="repository root (default: this script's parent repo)",
+    )
+    args = parser.parse_args()
+
+    try:
+        violations = check(args.repo_root)
+    except Exception as exc:  # plumbing failure must never read as clean
+        print(f"::error::migration-prefix guard could not run: {exc}", file=sys.stderr)
+        # The annotation names the cause; the traceback is what a maintainer
+        # needs when the cause is not self-describing.
+        traceback.print_exc(file=sys.stderr)
+        return 2
+
+    if violations:
+        for v in violations:
+            print(f"::error::{v}")
+        return 1
+    print("Migration prefix check: CLEAN (no duplicates; legacy namespace frozen)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_migration_prefixes.py
+++ b/scripts/check_migration_prefixes.py
@@ -130,8 +130,14 @@ def _runnable_names_at(repo_root: Path, ref: str, rel_dir: str, ids) -> set[str]
     rename detection to be caught — the old name is simply gone.
     """
     try:
+        # -z: NUL-delimited RAW paths. Without it git C-quotes any non-ASCII
+        # path ("…caf\303\251.py", quotes included), the quoted form matches no
+        # classify() verdict, and the file silently drops out of base_names —
+        # so a Unicode-named migration could be deleted or renamed undetected,
+        # the exact divergence this rule exists to catch. MEASURED 2026-09-04
+        # against a real tree (default output quoted; -z byte-exact).
         out = subprocess.run(  # noqa: S603 - fixed argv, no shell
-            ["git", "-C", str(repo_root), "ls-tree", "-r", "--name-only", ref, "--", rel_dir],
+            ["git", "-C", str(repo_root), "ls-tree", "-r", "--name-only", "-z", ref, "--", rel_dir],
             capture_output=True,
             text=True,
             timeout=30,
@@ -141,7 +147,7 @@ def _runnable_names_at(repo_root: Path, ref: str, rel_dir: str, ids) -> set[str]
         return None
     if out.returncode != 0:
         return None
-    names = {PurePosixPath(line).name for line in out.stdout.splitlines() if line.strip()}
+    names = {PurePosixPath(line).name for line in out.stdout.split("\0") if line.strip()}
     label = ids.SCHEMA if rel_dir.endswith("/migrations") else ids.DATA
     return {n for n in names if ids.classify(label, n) in ids.RUNNABLE}
 
@@ -330,7 +336,15 @@ def main() -> int:
         for v in violations:
             print(f"::error::{v}")
         return 1
-    scope = f"immutable against {args.base}" if args.base else "no base compared"
+    # Two honest labels, neither overclaiming: with --base the comparison is
+    # ENFORCED (an unreadable ref was a violation above); without it check()
+    # still tried the default ref best-effort, silently skipping the rule if
+    # that ref is absent — which is a weaker statement and must read as one.
+    scope = (
+        f"immutable against {args.base}"
+        if args.base
+        else f"immutability vs {_DEFAULT_BASE_REF} best-effort (pass --base to enforce)"
+    )
     print(
         "Migration id check: CLEAN (every file classified; no duplicates; "
         f"frozen legacy set intact; {scope})"

--- a/scripts/check_migration_prefixes.py
+++ b/scripts/check_migration_prefixes.py
@@ -36,10 +36,10 @@ Two rules, both fail-closed:
    a new 4-digit (or ``d`` + 4-digit) prefix is refused. Freezing is what
    removes prefix contention at the root: nobody allocates an id any more, so
    two branches cannot claim the same one. Enforced against the frozen
-   window's BOTH ENDS plus its size — an earlier one-sided "above the mark"
-   rule let ``0000`` through, which is legacy-width, duplicates nothing, and
-   is the worst possible id for it (fresh install: runs before ``0001``;
-   existing install: runs after ``0091``).
+   window's BOTH ENDS — an earlier one-sided "above the mark" rule let
+   ``0000`` through, which is legacy-width, duplicates nothing, and is the
+   worst possible id for it (fresh install: runs before ``0001``; existing
+   install: runs last).
 
 Read-only. Exit 0 clean, 1 on any violation, 2 on a usage/plumbing error
 (never a silent pass).
@@ -125,33 +125,22 @@ def check(repo_root: Path) -> list[str]:
                     "(`date -u +%Y%m%d%H%M%S`)."
                 )
 
-        lo, hi, expected = ids.FROZEN_LEGACY_WINDOW[label]
+        lo, hi = ids.FROZEN_LEGACY_WINDOW[label]
         suffix = " with a leading 'd'." if label == "data migration" else "."
-        legacy = sorted(p for p in by_prefix if ids.is_legacy_id(p))
-
-        for prefix in legacy:
+        for prefix in sorted(p for p in by_prefix if ids.is_legacy_id(p)):
             # BOTH ends: below `lo` is as much a hand-allocated id as above
-            # `hi`, and `0000` — which a one-sided rule let through — is the
-            # id whose fresh-vs-existing ordering diverges maximally.
+            # `hi`, and `0000` — which a one-sided rule let through — is the id
+            # whose fresh-vs-existing ordering diverges maximally.
             if not (lo <= prefix <= hi):
                 violations.append(
                     f"{label}s: '{prefix}' ({', '.join(sorted(by_prefix[prefix]))}) "
                     f"allocates a NEW legacy-width id, but that namespace is frozen "
                     f"at {lo}..{hi}. New migrations use a UTC timestamp id: "
                     "`date -u +%Y%m%d%H%M%S`_description.py" + suffix
+                    + " (If a legacy migration legitimately landed on the default "
+                    "branch above the window while this was in flight, bump the "
+                    "window in src/genesis/db/_migration_ids.py.)"
                 )
-
-        # Contiguity: for a contiguous range, (lo, hi, count) characterises the
-        # set exactly — so a DELETED legacy migration, which would otherwise
-        # free its id for silent re-allocation, surfaces here instead.
-        if legacy and (legacy[0], legacy[-1], len(legacy)) != (lo, hi, expected):
-            violations.append(
-                f"{label}s: the frozen legacy window {lo}..{hi} should hold exactly "
-                f"{expected} ids; found {len(legacy)} spanning "
-                f"{legacy[0]}..{legacy[-1]}. A deleted legacy migration frees its id "
-                "for re-allocation — restore it, or move the window deliberately in "
-                "src/genesis/db/_migration_ids.py."
-            )
 
     return violations
 

--- a/src/genesis/db/_migration_discovery.py
+++ b/src/genesis/db/_migration_discovery.py
@@ -2,39 +2,79 @@
 
 Both the schema-migration runner (``db/migrations/runner.py``) and the
 data-migration runner (``db/data_migrations/runner.py``, ``d``-prefixed)
-discover numbered module files the same way: sorted directory listing, regex
-match, ``group(1)`` is the stable id, ``path.stem`` is the display name. Only
-the filename PATTERN differs — the two runners' EXECUTION semantics (atomic
-schema txn vs long-running idempotent data backfill) are deliberately NOT
-shared.
+discover numbered module files the same way: sorted directory listing,
+classification against the id contract, ``group(1)`` is the stable id,
+``path.stem`` is the display name. Only the NAMESPACE differs — the two
+runners' EXECUTION semantics (atomic schema txn vs long-running idempotent data
+backfill) are deliberately NOT shared.
 
-New migrations carry a UTC timestamp id (``YYYYMMDDHHMMSS``); the legacy
-hand-allocated 4-digit ids are frozen. See ``db/migrations/runner.py`` for why.
+New migrations carry a UTC timestamp id (``YYYYMMDDHHMMSS``); this repo's
+legacy hand-allocated 4-digit ids are frozen. See ``db/migrations/runner.py``.
+
+This function takes a NAMESPACE, not a pattern. It used to take the pattern,
+which let a caller pass one that disagreed with the directory it was scanning —
+and, more importantly, made the pattern the whole contract, so a filename it did
+not match was skipped in silence.
+
+WHAT THE RUNTIME ENFORCES, AND WHAT IT DELIBERATELY DOES NOT
+------------------------------------------------------------
+The runtime refuses on files that CANNOT RUN, and only those. A file that is
+merely disallowed by this repo's freeze — a fork's own ``0094_fork_custom.py``,
+say — is well-formed, has a unique id, sorts correctly, and applies cleanly. It
+breaks a policy of ours, not an invariant of theirs.
+
+That distinction is load-bearing because this discovery sits on the boot-abort
+path: ``runtime/init/db.py`` re-raises, and ``runtime/_core.py`` stops bootstrap
+when the DB step fails. Enforcing OUR namespace policy there would leave any
+downstream fork with no database after a pull, over a 4-digit id that was the
+only convention available before this scheme existed. So the runtime logs a
+warning and runs it; ``scripts/check_migration_prefixes.py`` refuses it in CI,
+which is where a rule about this repo's namespace belongs.
 """
 
 from __future__ import annotations
 
-import re
+import logging
 from pathlib import Path
 
+from genesis.db._migration_ids import scan_directory
 
-def discover_numbered_modules(
-    directory: Path, pattern: re.Pattern[str]
-) -> list[tuple[str, str, Path]]:
-    """Return ``[(id, stem, path)]`` for files matching ``pattern``, id-ordered.
+logger = logging.getLogger(__name__)
 
-    ``pattern`` must capture the id in group 1 (the runners' own patterns
-    accept a frozen 4-digit legacy id OR a 14-digit UTC timestamp).
+
+def discover_numbered_modules(directory: Path, namespace: str) -> list[tuple[str, str, Path]]:
+    """Return ``[(id, stem, path)]`` for the migrations in ``directory``, id-ordered.
+
+    ``namespace`` is ``_migration_ids.SCHEMA`` or ``.DATA``.
+
+    Raises ``RuntimeError`` if any entry PRESENTS as a migration but CANNOT run
+    — a mistyped width (``2026090320000_x.py``), a ``d`` prefix in the wrong
+    directory, a non-ASCII digit. Refusing is the whole point: the previous
+    version matched a regex and skipped whatever failed, so a mistyped migration
+    was discovered by nothing and NEVER RAN, and the code that needed it
+    deployed against a schema that never got the change. A duplicate id already
+    aborts here for a strictly smaller reason (``migrations/runner.py``
+    pre-flight), and a duplicate is at least loud; this one was silent.
 
     Sorted filename order == id order, and that holds ACROSS the two widths:
-    every legacy id begins with ``0`` (the namespace froze at 0091) and every
-    timestamp with ``2``, so lexicographic order puts the frozen history ahead
-    of all new work. Pinned by
+    every frozen legacy id begins with ``0`` and every timestamp id is a real
+    calendar year >= ``TIMESTAMP_EPOCH_YEAR`` and so begins with ``2``, which is
+    what makes lexicographic order put the frozen history ahead of all new work.
+    Pinned by
     ``tests/test_db/test_migration_discovery.py::test_frozen_legacy_ids_always_precede_timestamp_ids``.
     """
-    out: list[tuple[str, str, Path]] = []
-    for path in sorted(directory.iterdir()):
-        m = pattern.match(path.name)
-        if m:
-            out.append((m.group(1), path.stem, path))
-    return out
+    runnable, unrunnable, disallowed = scan_directory(namespace, directory)
+
+    if unrunnable:
+        raise RuntimeError(
+            f"{directory} contains {len(unrunnable)} unrunnable {namespace} "
+            f"file(s); refusing to run any migration from this directory "
+            f"because a file that is discovered by nothing fails SILENTLY:\n  "
+            + "\n  ".join(unrunnable)
+        )
+
+    for note in disallowed:
+        # Runs anyway — see the module docstring. CI is where this is refused.
+        logger.warning("%s outside this repo's frozen set: %s", namespace, note)
+
+    return runnable

--- a/src/genesis/db/_migration_discovery.py
+++ b/src/genesis/db/_migration_discovery.py
@@ -1,12 +1,15 @@
 """Shared file-discovery for the two migration runners.
 
-Both the schema-migration runner (``db/migrations/runner.py``, files
-``NNNN_desc.py``) and the data-migration runner (``db/data_migrations/
-runner.py``, files ``dNNNN_desc.py``) discover numbered module files the same
-way: sorted directory listing, regex match, ``group(1)`` is the stable id,
-``path.stem`` is the display name. Only the filename PATTERN differs — the two
-runners' EXECUTION semantics (atomic schema txn vs long-running idempotent
-data backfill) are deliberately NOT shared.
+Both the schema-migration runner (``db/migrations/runner.py``) and the
+data-migration runner (``db/data_migrations/runner.py``, ``d``-prefixed)
+discover numbered module files the same way: sorted directory listing, regex
+match, ``group(1)`` is the stable id, ``path.stem`` is the display name. Only
+the filename PATTERN differs — the two runners' EXECUTION semantics (atomic
+schema txn vs long-running idempotent data backfill) are deliberately NOT
+shared.
+
+New migrations carry a UTC timestamp id (``YYYYMMDDHHMMSS``); the legacy
+hand-allocated 4-digit ids are frozen. See ``db/migrations/runner.py`` for why.
 """
 
 from __future__ import annotations
@@ -20,9 +23,14 @@ def discover_numbered_modules(
 ) -> list[tuple[str, str, Path]]:
     """Return ``[(id, stem, path)]`` for files matching ``pattern``, id-ordered.
 
-    ``pattern`` must capture the id in group 1 (e.g. ``r"^(\\d{4})_\\w+\\.py$"``
-    or ``r"^(d\\d{4})_\\w+\\.py$"``). Sorted filename order == id order because
-    the zero-padded numeric prefix sorts lexicographically.
+    ``pattern`` must capture the id in group 1 (the runners' own patterns
+    accept a frozen 4-digit legacy id OR a 14-digit UTC timestamp).
+
+    Sorted filename order == id order, and that holds ACROSS the two widths:
+    every legacy id begins with ``0`` (the namespace froze at 0091) and every
+    timestamp with ``2``, so lexicographic order puts the frozen history ahead
+    of all new work. Pinned by
+    ``tests/test_db/test_migration_discovery.py::test_frozen_legacy_ids_always_precede_timestamp_ids``.
     """
     out: list[tuple[str, str, Path]] = []
     for path in sorted(directory.iterdir()):

--- a/src/genesis/db/_migration_ids.py
+++ b/src/genesis/db/_migration_ids.py
@@ -55,11 +55,20 @@ DATA = "data migration"
 #: ``[0-9]`` and not ``\d``: ``\d`` also matches non-ASCII decimal digits, so
 #: ``\d{14}`` accepts full-width and Arabic-Indic numerals whose codepoints sort
 #: nowhere near the ASCII ids the ordering invariant is stated over.
-SCHEMA_MIGRATION_PATTERN = re.compile(r"^([0-9]{4}|[0-9]{14})_[A-Za-z0-9_]+\.py$")
+#:
+#: The ID is ASCII; the DESCRIPTION after the underscore is ``\w+``, and the
+#: asymmetry is the whole point. Only the id participates in ordering and
+#: uniqueness, so only the id needs a codepoint guarantee. Restricting the
+#: description too was collateral, and it broke names that already work:
+#: ``0094_café.py`` and ``d0012_修復.py`` import fine today (a Python module name
+#: may be any identifier), and a downstream fork carrying one would have had
+#: discovery start raising — aborting database init on the schema side, and
+#: skipping the whole batch on the data side — over a naming preference of ours.
+SCHEMA_MIGRATION_PATTERN = re.compile(r"^([0-9]{4}|[0-9]{14})_\w+\.py$")
 
 #: Data migrations: the same, ``d``-prefixed. The prefix keeps the two
 #: namespaces disjoint, so they can never cross-collide in one claims map.
-DATA_MIGRATION_PATTERN = re.compile(r"^(d(?:[0-9]{4}|[0-9]{14}))_[A-Za-z0-9_]+\.py$")
+DATA_MIGRATION_PATTERN = re.compile(r"^(d(?:[0-9]{4}|[0-9]{14}))_\w+\.py$")
 
 MIGRATION_PATTERNS: dict[str, re.Pattern[str]] = {
     SCHEMA: SCHEMA_MIGRATION_PATTERN,

--- a/src/genesis/db/_migration_ids.py
+++ b/src/genesis/db/_migration_ids.py
@@ -1,0 +1,55 @@
+"""The migration-id contract: what ids are legal, in one place.
+
+**STDLIB-ONLY, ON PURPOSE — do not add an import to this module.**
+``scripts/check_migration_prefixes.py`` path-imports it from a CI job that runs
+a bare ``python3`` with no ``setup-python`` and no ``pip install``. An earlier
+version of that guard imported the two RUNNER modules instead, to bind to their
+real patterns; the intent was right but the runners carry module-scope
+``import aiosqlite`` / ``from genesis.db.crud import …``, so the guard pulled in
+117 modules and exited 2 on every PR — enforcing nothing, while every test
+passed because pytest runs inside the project venv. Two regexes have no reason
+to drag the package in; this module is what both sides can safely share.
+
+New migrations use a UTC timestamp id (``date -u +%Y%m%d%H%M%S``). The legacy
+hand-allocated 4-digit ids are FROZEN — see ``migrations/runner.py`` for why
+allocation was the thing worth removing.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Schema migrations: a frozen 4-digit legacy id OR a 14-digit UTC timestamp.
+#: Width-anchored alternation (``{4}|{14}``, never ``{4,14}``) so a mistyped
+#: 13- or 15-digit id is REFUSED at discovery rather than quietly founding a
+#: third id namespace with its own ordering semantics.
+SCHEMA_MIGRATION_PATTERN = re.compile(r"^(\d{4}|\d{14})_\w+\.py$")
+
+#: Data migrations: the same, ``d``-prefixed. The prefix keeps the two
+#: namespaces disjoint, so they can never cross-collide in one claims map.
+DATA_MIGRATION_PATTERN = re.compile(r"^(d(?:\d{4}|\d{14}))_\w+\.py$")
+
+#: The frozen legacy window per namespace, as ``(lo, hi, count)`` — the exact
+#: set that existed when the namespace froze (2026-09-03).
+#:
+#: BOTH ENDS are enforced, and the count with them. Below ``lo`` is as much a
+#: hand-allocated id as above ``hi``: ``0000`` is legacy-width, duplicates
+#: nothing, and slipped through an earlier one-sided ``prefix > hi`` rule — and
+#: it is the WORST id for it, because on a fresh install it sorts first and runs
+#: before ``0001``, while on an existing install every legacy id is already
+#: applied so it runs last. Same tree, opposite order, nothing detecting it.
+#:
+#: ``count`` pins contiguity: for a contiguous range, ``(lo, hi, count)``
+#: characterises the set exactly, so a DELETED legacy migration (which would
+#: otherwise free its id for silent re-allocation) shows up as a violation
+#: rather than as a gap. Moving the window is then a deliberate edit here.
+FROZEN_LEGACY_WINDOW: dict[str, tuple[str, str, int]] = {
+    "schema migration": ("0001", "0091", 91),
+    "data migration": ("d0001", "d0011", 11),
+}
+
+
+def is_legacy_id(prefix: str) -> bool:
+    """True for a hand-allocated 4-digit id (``0091``/``d0011``), not a timestamp."""
+    digits = prefix[1:] if prefix.startswith("d") else prefix
+    return len(digits) == 4

--- a/src/genesis/db/_migration_ids.py
+++ b/src/genesis/db/_migration_ids.py
@@ -1,64 +1,405 @@
-"""The migration-id contract: what ids are legal, in one place.
+"""The migration-id contract: what filenames are legal, in one place.
 
-**STDLIB-ONLY, ON PURPOSE — do not add an import to this module.**
+**STDLIB-ONLY, ON PURPOSE — do not add a third-party import to this module.**
 ``scripts/check_migration_prefixes.py`` path-imports it from a CI job that runs
 a bare ``python3`` with no ``setup-python`` and no ``pip install``. An earlier
 version of that guard imported the two RUNNER modules instead, to bind to their
 real patterns; the intent was right but the runners carry module-scope
 ``import aiosqlite`` / ``from genesis.db.crud import …``, so the guard pulled in
 117 modules and exited 2 on every PR — enforcing nothing, while every test
-passed because pytest runs inside the project venv. Two regexes have no reason
-to drag the package in; this module is what both sides can safely share.
+passed because pytest runs inside the project venv.
 
 New migrations use a UTC timestamp id (``date -u +%Y%m%d%H%M%S``). The legacy
 hand-allocated 4-digit ids are FROZEN — see ``migrations/runner.py`` for why
 allocation was the thing worth removing.
+
+Every file in a migrations directory is CLASSIFIED, and the residue is a
+violation
+-----------------------------------------------------------------------------
+The first version of this contract checked properties of the id SET — no
+duplicates, and min/max inside a frozen window. Four independent review findings
+came out of that one choice, because a set-property is blind in two directions:
+
+* it never sees a file the pattern did not match (a mistyped
+  ``2026090320000_x.py`` is 13 digits, so ``if m:`` skipped it — in the guard AND
+  in ``_migration_discovery``, meaning the migration silently NEVER RAN and the
+  code deployed without its schema change); and
+* it is invariant under mutations that keep the endpoints (``0092`` sits inside
+  ``0001..0093`` but does not exist on the default branch, so a hand-allocated
+  ``0092_new.py`` passed; renaming ``0050_old.py`` to ``0050_new.py`` left the
+  id set identical; and deleting every legacy file left the legacy loop empty,
+  which read as clean).
+
+So the contract is now stated the other way round, as a total function over
+filenames: a name either IS a frozen legacy migration, or IS a well-formed
+timestamp migration, or is NOT a migration at all — and anything left over is a
+violation. Adding a new way to be wrong no longer requires a new rule.
 """
 
 from __future__ import annotations
 
 import re
+from datetime import datetime
+from pathlib import Path
+
+#: Namespace labels. These are the dict keys below and the human-readable
+#: nouns in every message the guard prints, deliberately the same string.
+SCHEMA = "schema migration"
+DATA = "data migration"
 
 #: Schema migrations: a frozen 4-digit legacy id OR a 14-digit UTC timestamp.
 #: Width-anchored alternation (``{4}|{14}``, never ``{4,14}``) so a mistyped
-#: 13- or 15-digit id is REFUSED at discovery rather than quietly founding a
-#: third id namespace with its own ordering semantics.
-SCHEMA_MIGRATION_PATTERN = re.compile(r"^(\d{4}|\d{14})_\w+\.py$")
+#: 13- or 15-digit id cannot quietly found a third id namespace with its own
+#: ordering semantics — it fails to match and is caught as MALFORMED below.
+#:
+#: ``[0-9]`` and not ``\d``: ``\d`` also matches non-ASCII decimal digits, so
+#: ``\d{14}`` accepts full-width and Arabic-Indic numerals whose codepoints sort
+#: nowhere near the ASCII ids the ordering invariant is stated over.
+SCHEMA_MIGRATION_PATTERN = re.compile(r"^([0-9]{4}|[0-9]{14})_[A-Za-z0-9_]+\.py$")
 
 #: Data migrations: the same, ``d``-prefixed. The prefix keeps the two
 #: namespaces disjoint, so they can never cross-collide in one claims map.
-DATA_MIGRATION_PATTERN = re.compile(r"^(d(?:\d{4}|\d{14}))_\w+\.py$")
+DATA_MIGRATION_PATTERN = re.compile(r"^(d(?:[0-9]{4}|[0-9]{14}))_[A-Za-z0-9_]+\.py$")
 
-#: The frozen legacy window per namespace, as ``(lo, hi)`` — the range of
-#: hand-allocated ids that already exist. A legacy-width id OUTSIDE it is a new
-#: allocation and is refused.
-#:
-#: BOTH ENDS matter. Below ``lo`` is as much a hand-allocated id as above
-#: ``hi``: ``0000`` is legacy-width, duplicates nothing, and slipped an earlier
-#: one-sided ``prefix > hi`` rule — and it is the worst id to miss, because on
-#: a fresh install it sorts first and runs before ``0001`` while on an existing
-#: install every legacy id is already applied, so it runs last. Same tree,
-#: opposite order, nothing detecting it.
-#:
-#: TRANSITION CONSTANT: ``hi`` tracks the highest legacy id on the default
-#: branch, which still moves while migrations authored under the old
-#: convention are in flight (``0093`` landed 2026-09-04, leaving a gap at
-#: ``0092`` from a rename). If one merges above ``hi`` before this scheme does,
-#: bump it here — the guard will say exactly that. Once the in-flight set is
-#: drained the window is fixed forever, because nothing allocates a legacy id
-#: any more.
-#:
-#: Deliberately NOT pinned by count. A size check would catch a DELETED legacy
-#: migration freeing its id — but the freeze already makes that unreachable
-#: (every new migration is a timestamp, so no id is ever re-allocated), and the
-#: range is not contiguous anyway.
-FROZEN_LEGACY_WINDOW: dict[str, tuple[str, str]] = {
-    "schema migration": ("0001", "0093"),
-    "data migration": ("d0001", "d0011"),
+MIGRATION_PATTERNS: dict[str, re.Pattern[str]] = {
+    SCHEMA: SCHEMA_MIGRATION_PATTERN,
+    DATA: DATA_MIGRATION_PATTERN,
 }
 
+#: "This file PRESENTS as a migration." Deliberately far looser than the real
+#: patterns: it is what makes the residue detectable at all. A name that looks
+#: like a migration but does not parse as one is an ERROR, whereas a name that
+#: never looked like one (``runner.py``, ``__init__.py``, ``_util.py``,
+#: ``stale_embedding_repair.py`` — the only non-migration files in either
+#: directory, measured 2026-09-04) is simply not our business.
+#:
+#: ``d?`` on BOTH namespaces on purpose: a ``d0001_x.py`` misfiled into
+#: ``migrations/``, or a bare ``0001_x.py`` misfiled into ``data_migrations/``,
+#: is exactly the silent no-op this class of check exists to catch.
+#:
+#: ``\d`` here and ``[0-9]`` in the strict patterns above, and the asymmetry is
+#: load-bearing. This net must be WIDER than what is legal, or a name that is
+#: illegal *because* of its digits escapes classification and is skipped in
+#: silence — the very outcome the ASCII restriction exists to prevent. Measured
+#: 2026-09-04: with ``[0-9]`` here, ``２０２６０９０４００００００_bad.py``
+#: (full-width digits) classified NOT_A_MIGRATION and the guard reported CLEAN.
+CANDIDATE_PATTERN = re.compile(r"^d?\d")
 
-def is_legacy_id(prefix: str) -> bool:
-    """True for a hand-allocated 4-digit id (``0091``/``d0011``), not a timestamp."""
+#: Timestamps must be at or after this year. This is the ORDERING INVARIANT
+#: made checkable, not a taste: every frozen legacy id begins with ``0``, so
+#: requiring a real calendar year >= 2020 forces a leading ``2`` and therefore
+#: guarantees every timestamp id sorts after every legacy id, on a fresh
+#: install and an existing one alike.
+#:
+#: Without it, ``00000000000000`` is 14 ASCII digits, duplicates nothing, and is
+#: NOT legacy-width — so the earlier window check never even looked at it. On a
+#: fresh install it sorts before ``0001`` and runs first; on an existing install
+#: every legacy id is already applied, so it runs last. Same tree, opposite
+#: order, nothing detecting it. (Its 4-digit twin ``0000`` was found and fixed
+#: one review round earlier in this same change; the 14-digit sibling was not
+#: swept at the same time.)
+TIMESTAMP_EPOCH_YEAR = 2020
+
+#: The EXACT frozen legacy filenames per namespace — not a range, and not a set
+#: of ids. Filenames, because the id alone cannot tell ``0050_old.py`` from
+#: ``0050_new.py``: existing installs have ``0050`` in ``schema_migrations`` and
+#: skip the renamed file forever, while fresh installs execute it, and the two
+#: schemas diverge with nothing to notice.
+#:
+#: A range cannot express this set. ``0092`` is INSIDE ``0001..0093`` yet absent
+#: here — the id was consumed by a rename and never landed — so an endpoint
+#: check admitted a brand-new hand-allocated ``0092_*.py``. Enumeration is what
+#: makes the gap representable.
+#:
+#: NOT a content pin. An edit to an applied migration still passes: measured
+#: 2026-09-04, 2 of 92 legacy files were edited well after they merged
+#: (``0051_entity_layer.py`` +8 days, ``0015_rename_confusable_call_sites.py``
+#: +2 months), which is the same fresh-vs-existing divergence one level down.
+#: Pinning content is tracked separately — it is a new repo-wide rule (every
+#: future edit becomes a CI failure needing a hash bump) and wants its own
+#: decision, not a side effect of this one.
+#:
+#: This set is CLOSED. Nothing is ever added: every new migration is a
+#: timestamp, so no id is ever allocated by hand again. If a legacy-id migration
+#: authored before this scheme lands merges to the default branch while this is
+#: in flight, add its filename here in that same PR — the guard's message says
+#: so by name.
+FROZEN_LEGACY_FILES: dict[str, frozenset[str]] = {
+    SCHEMA: frozenset(
+        {
+            "0001_add_update_history.py",
+            "0002_add_eval_tables.py",
+            "0003_eval_results_skipped.py",
+            "0004_follow_ups.py",
+            "0005_surplus_not_before.py",
+            "0006_follow_up_verification.py",
+            "0007_ego_proposal_board.py",
+            "0008_follow_up_pinned.py",
+            "0009_intake_token_enforcement.py",
+            "0010_bitemporal_memory.py",
+            "0011_j9_eval_tables.py",
+            "0012_ego_proposals_status_check.py",
+            "0013_migrate_refs_to_episodic.py",
+            "0014_eval_results_metadata.py",
+            "0015_rename_confusable_call_sites.py",
+            "0016_memory_subsystem_tag.py",
+            "0017_deep_floor_24h.py",
+            "0018_dream_cycle.py",
+            "0019_cache_and_errors.py",
+            "0020_proposal_goal_id.py",
+            "0021_ego_integrity_tracking.py",
+            "0022_reflection_corpus.py",
+            "0023_procedural_scenario.py",
+            "0024_update_history_conflicts_status.py",
+            "0025_outcome_events.py",
+            "0026_ego_calibration_snapshots.py",
+            "0027_cognitive_file_modifications.py",
+            "0028_otel_spans.py",
+            "0029_memory_links_link_type_pk.py",
+            "0030_capability_grants.py",
+            "0031_pending_email_sends.py",
+            "0032_seed_email_standard_grant.py",
+            "0033_autonomy_earn_lose.py",
+            "0034_follow_up_kind_domain_goal.py",
+            "0035_backfill_procedure_invocation_count.py",
+            "0036_rename_procedure_tiers.py",
+            "0037_rename_procedure_speculative_to_draft.py",
+            "0038_pending_outreach_thread_recipient.py",
+            "0039_procedural_surfaced_count.py",
+            "0040_inbox_drop_batching.py",
+            "0041_surplus_outcome_quality.py",
+            "0042_attention_events.py",
+            "0043_surplus_judge_score.py",
+            "0044_capability_shadow_events.py",
+            "0045_attention_acceptance_note.py",
+            "0046_attention_events_source.py",
+            "0047_build_candidates.py",
+            "0048_task_states_source.py",
+            "0049_dead_letter_created_index.py",
+            "0050_canonicalize_bitemporal_ts.py",
+            "0051_entity_layer.py",
+            "0052_drop_stale_code_audit_job_health.py",
+            "0053_table_inbox_watch_markers.py",
+            "0054_origin_class.py",
+            "0055_immunity_shadow_events.py",
+            "0056_pending_outreach_null_id_backfill.py",
+            "0057_origin_class_sessions_observations.py",
+            "0058_session_charters.py",
+            "0059_session_ledger_shadow.py",
+            "0060_data_migrations_ledger.py",
+            "0061_job_run_events_alert_events.py",
+            "0062_repo_pulse.py",
+            "0063_user_goals_origin.py",
+            "0064_ledger_predictions.py",
+            "0065_entity_adjudications.py",
+            "0066_ego_directive_decisions.py",
+            "0067_autonomy_events.py",
+            "0068_voice_graduation.py",
+            "0069_calibration_cells.py",
+            "0070_reflex_arc.py",
+            "0071_ego_proposal_revisions.py",
+            "0072_job_health_error_type.py",
+            "0073_memory_integrity.py",
+            "0074_memory_reconcile_runs.py",
+            "0075_follow_up_revisit_condition.py",
+            "0076_follow_ups_idea_kind.py",
+            "0077_backfill_revalidate_at.py",
+            "0078_ego_proposal_scope.py",
+            "0079_pending_issue_posts.py",
+            "0080_cc_sessions_extracted_byte.py",
+            "0081_mw1_extraction_judgment.py",
+            "0082_mw2_link_metadata.py",
+            "0083_mw3_entity_types_cards.py",
+            "0084_repo_pulse_target_kind.py",
+            "0085_backfill_observation_origin.py",
+            "0086_seed_timezone_config.py",
+            "0087_pending_issue_posts_adopted.py",
+            "0088_ego_intentions_origin.py",
+            "0089_marketing_prospects.py",
+            "0090_ws2_calibration_sunset.py",
+            "0091_topic_recency_stamps.py",
+            "0093_entity_adjudication_approval.py",
+        }
+    ),
+    DATA: frozenset(
+        {
+            "d0001_origin_class_qdrant.py",
+            "d0002_resolve_duplicate_session_alerts.py",
+            "d0003_purge_extraction_goals.py",
+            "d0004_purge_retired_job_health.py",
+            "d0005_reverify_false_dispatch_failures.py",
+            "d0006_purge_surplus_ops_telemetry.py",
+            "d0007_clear_orphaned_completed_at.py",
+            "d0008_reconcile_memory_cross_store.py",
+            "d0009_resync_memory_class_qdrant.py",
+            "d0010_backfill_skill_proposal_dampening.py",
+            "d0011_reembed_stale_procedure_embeddings.py",
+        }
+    ),
+}
+
+# --- classification outcomes -------------------------------------------------
+#: Not a migration and never looked like one — ``runner.py``, ``__init__.py``.
+NOT_A_MIGRATION = "not-a-migration"
+#: A frozen legacy migration, present under its original filename.
+FROZEN_LEGACY = "frozen-legacy"
+#: A well-formed new-scheme migration: 14 ASCII digits, a real UTC timestamp.
+TIMESTAMP = "timestamp"
+#: Well-formed and perfectly RUNNABLE, but not one of THIS repo's frozen legacy
+#: files: a new hand-allocated 4-digit id, or a renamed frozen one.
+#:
+#: Its own verdict because runnable-ness and allowed-ness are different
+#: questions and only one of them belongs at boot. This id has a unique
+#: prefix, sorts correctly, and would apply cleanly; it violates a repo POLICY,
+#: not a runtime invariant. Genesis ships to forks, and a fork's own
+#: ``0094_fork_custom.py`` is the ONLY convention that existed before this
+#: change — refusing it at runtime would leave that fork with no database after
+#: a pull, for a rule that is ours and not theirs. So the runtime RUNS it and
+#: warns; CI refuses it, which is where a policy about this repo's namespace
+#: can be enforced without reaching into anyone else's install.
+DISALLOWED_LEGACY = "disallowed-legacy"
+#: Presents as a migration and CANNOT run: no runner discovers it, so it would
+#: be skipped in silence. Always a violation, everywhere.
+MALFORMED = "malformed"
+
+#: The verdicts a runner may execute. Consumers switch on THIS, never on the
+#: negative verdicts — see :func:`scan_directory`.
+RUNNABLE = (FROZEN_LEGACY, TIMESTAMP, DISALLOWED_LEGACY)
+
+
+def is_legacy_width(prefix: str) -> bool:
+    """True for a 4-digit-width id (``0091``/``d0011``), not a 14-digit one.
+
+    WIDTH only — it says nothing about whether the id is an ALLOWED legacy id.
+    Membership of the frozen set is ``FROZEN_LEGACY_FILES``, and conflating the
+    two is what let a fresh ``0092_new.py`` through an endpoint check.
+    """
     digits = prefix[1:] if prefix.startswith("d") else prefix
     return len(digits) == 4
+
+
+def is_valid_timestamp_id(prefix: str) -> bool:
+    """True if ``prefix`` is a real UTC ``YYYYMMDDHHMMSS`` at/after the epoch year.
+
+    Rejects impossible calendar values (month 13, day 32, hour 25), non-ASCII
+    digits, and every id that would sort before the frozen legacy namespace.
+    """
+    core = prefix[1:] if prefix.startswith("d") else prefix
+    if re.fullmatch(r"[0-9]{14}", core) is None:
+        return False
+    try:
+        stamp = datetime.strptime(core, "%Y%m%d%H%M%S")
+    except ValueError:
+        return False
+    return stamp.year >= TIMESTAMP_EPOCH_YEAR
+
+
+def classify(namespace: str, filename: str) -> str:
+    """Classify one directory entry. Total: every name gets exactly one answer.
+
+    ``namespace`` is :data:`SCHEMA` or :data:`DATA`. Returns one of
+    :data:`NOT_A_MIGRATION`, :data:`FROZEN_LEGACY`, :data:`TIMESTAMP`,
+    :data:`DISALLOWED_LEGACY`, :data:`MALFORMED`.
+    """
+    if CANDIDATE_PATTERN.match(filename) is None or not filename.endswith(".py"):
+        return NOT_A_MIGRATION
+
+    match = MIGRATION_PATTERNS[namespace].match(filename)
+    if match is None:
+        # Presents as a migration, does not parse as one: a mistyped width, a
+        # misfiled ``d`` prefix, a non-ASCII digit. Never silently skipped.
+        return MALFORMED
+
+    if filename in FROZEN_LEGACY_FILES[namespace]:
+        return FROZEN_LEGACY
+    if is_legacy_width(match.group(1)):
+        return DISALLOWED_LEGACY
+    return TIMESTAMP if is_valid_timestamp_id(match.group(1)) else MALFORMED
+
+
+def rejection_reason(namespace: str, filename: str) -> str:
+    """A one-line, actionable explanation for a rejected filename.
+
+    Covers both :data:`MALFORMED` and :data:`DISALLOWED_LEGACY`. Separate from
+    :func:`classify` so the runtime and the CI guard print the same sentence;
+    a caller that only needs the verdict pays nothing for it.
+    """
+    match = MIGRATION_PATTERNS[namespace].match(filename)
+    new_id = "`date -u +%Y%m%d%H%M%S`_description.py" + (
+        " with a leading 'd'." if namespace == DATA else "."
+    )
+    if match is None:
+        return (
+            f"{filename!r} looks like a {namespace} but does not match "
+            f"{MIGRATION_PATTERNS[namespace].pattern} — so it is discovered by "
+            f"nothing and would never run. Name it {new_id}"
+        )
+    prefix = match.group(1)
+    if is_legacy_width(prefix):
+        # NOTE: the frozen set is NOT offered here as a remedy. It is editable
+        # by the very PR that violates it, so advertising it at the moment of
+        # violation is an invitation to grow a set whose entire value is that it
+        # never grows. Adding to it is a deliberate, reviewed act with its own
+        # failing test to answer to (test_the_frozen_legacy_set_is_closed).
+        return (
+            f"{filename!r} allocates the legacy-width id {prefix!r}. That "
+            f"namespace is FROZEN to an enumerated set of "
+            f"{len(FROZEN_LEGACY_FILES[namespace])} files and {prefix!r} is not "
+            f"one of them, so this is either a new hand-allocated id or a "
+            f"renamed frozen file. Hand-allocating is precisely what made two "
+            f"branches claim the same id; use {new_id}"
+        )
+    return (
+        f"{filename!r} has a 14-digit id {prefix!r} that is not a real UTC "
+        f"timestamp at or after {TIMESTAMP_EPOCH_YEAR} — so its position in the "
+        f"run order is undefined relative to the frozen ids. Use "
+        f"`date -u +%Y%m%d%H%M%S`."
+    )
+
+
+def scan_directory(
+    namespace: str, directory: Path
+) -> tuple[list[tuple[str, str, Path]], list[str], list[str]]:
+    """Classify every entry in ``directory``. Returns ``(runnable, unrunnable, disallowed)``.
+
+    ``runnable`` is ``[(id, stem, path)]`` in id order. ``unrunnable`` and
+    ``disallowed`` are human-readable reasons.
+
+    ONE implementation, shared by the runtime and the CI guard, because the two
+    previously carried the same hand-copied loop — so a fail-open in it was a
+    fail-open twice, needing to be found twice.
+
+    It switches on the POSITIVE verdicts and raises on an unrecognised one. The
+    earlier loops switched on the two NEGATIVE verdicts and accepted everything
+    else, which is not a total switch at all: it is an accept-by-default whose
+    residue grows silently every time a verdict is added. That is not
+    hypothetical — adding :data:`DISALLOWED_LEGACY` to fix the boot-refusal
+    scope would have been silently accepted as runnable by both callers.
+    """
+    runnable: list[tuple[str, str, Path]] = []
+    unrunnable: list[str] = []
+    disallowed: list[str] = []
+
+    for path in sorted(directory.iterdir()):
+        verdict = classify(namespace, path.name)
+        if verdict == NOT_A_MIGRATION:
+            continue
+        if verdict == MALFORMED:
+            unrunnable.append(rejection_reason(namespace, path.name))
+            continue
+        if verdict not in RUNNABLE:
+            raise RuntimeError(
+                f"unhandled migration classification {verdict!r} for "
+                f"{path.name!r} — refusing to guess whether it should run"
+            )
+        if verdict == DISALLOWED_LEGACY:
+            disallowed.append(rejection_reason(namespace, path.name))
+        match = MIGRATION_PATTERNS[namespace].match(path.name)
+        if match is None:  # pragma: no cover - classify() already proved this
+            raise RuntimeError(
+                f"internal inconsistency: {path.name!r} classified {verdict!r} "
+                f"but does not match {MIGRATION_PATTERNS[namespace].pattern}"
+            )
+        runnable.append((match.group(1), path.stem, path))
+
+    return runnable, unrunnable, disallowed

--- a/src/genesis/db/_migration_ids.py
+++ b/src/genesis/db/_migration_ids.py
@@ -430,4 +430,16 @@ def scan_directory(
             )
         runnable.append((match.group(1), path.stem, path))
 
+    # ORDER: every legacy-width id before every timestamp id, then by id within
+    # each band. A raw filename sort ALMOST does this — every frozen legacy id
+    # begins with '0' and every timestamp with '2' — but "begins with 0" holds
+    # only for the frozen 0001..0093 set, NOT for a downstream FORK's own
+    # legacy-width id. A fork's ``3000_custom.py`` (or ``d3000_…``) sorts AFTER a
+    # ``2026…`` timestamp by leading character, so a fresh clone would run it
+    # after the timestamp while the fork that authored it ran it before the
+    # timestamp existed — divergent order across installs, exactly what the
+    # ordering invariant exists to prevent. The band key makes the invariant
+    # true by construction instead of by a leading-digit coincidence, and it
+    # is a no-op for this repo (its legacy ids all begin with 0 already).
+    runnable.sort(key=lambda r: (is_valid_timestamp_id(r[0]), r[0]))
     return runnable, unrunnable, disallowed

--- a/src/genesis/db/_migration_ids.py
+++ b/src/genesis/db/_migration_ids.py
@@ -92,7 +92,19 @@ MIGRATION_PATTERNS: dict[str, re.Pattern[str]] = {
 #: silence — the very outcome the ASCII restriction exists to prevent. Measured
 #: 2026-09-04: with ``[0-9]`` here, ``２０２６０９０４００００００_bad.py``
 #: (full-width digits) classified NOT_A_MIGRATION and the guard reported CLEAN.
-CANDIDATE_PATTERN = re.compile(r"^d?\d")
+#: ``[dDｄＤ]*`` and not ``d?``, for the same reason as ``\d``: the net must
+#: cover the MISTAKE space, not the legal space — and the mistake space is
+#: found by asking what the mistake GENERATORS produce, not by patching named
+#: instances. This net has been too narrow three times, each a different
+#: generator: ASCII ``[0-9]`` waved through an IME's full-width digits; ``d?``
+#: waved through a doubled keystroke (``dd2026…``) and a case habit
+#: (``D2026…``); and the review of THAT fix found the first generator still
+#: alive in the prefix position (full-width ``ｄ２０２６…``) — the same IME that
+#: produces full-width digits produces the full-width letter in the same
+#: keystroke. Every one of these presented as a migration to a human and to no
+#: code, so the file was skipped in silence, in runtime discovery AND in CI —
+#: the never-runs outcome this whole contract exists to refuse.
+CANDIDATE_PATTERN = re.compile(r"^[dDｄＤ]*\d")
 
 #: Timestamps must be at or after this year. This is the ORDERING INVARIANT
 #: made checkable, not a taste: every frozen legacy id begins with ``0``, so
@@ -310,8 +322,15 @@ def classify(namespace: str, filename: str) -> str:
     :data:`NOT_A_MIGRATION`, :data:`FROZEN_LEGACY`, :data:`TIMESTAMP`,
     :data:`DISALLOWED_LEGACY`, :data:`MALFORMED`.
     """
-    if CANDIDATE_PATTERN.match(filename) is None or not filename.endswith(".py"):
+    if CANDIDATE_PATTERN.match(filename) is None:
         return NOT_A_MIGRATION
+    if not filename.endswith(".py"):
+        # ``20260904000000_x.PY`` is a migration-shaped name Python will never
+        # import — the same never-runs silence, entering through the extension
+        # test instead of the digit test. A candidate with a case-mangled .py
+        # is refused; a candidate that is genuinely another filetype
+        # (``0094_notes.txt``, ``.pyc``) is not our business.
+        return MALFORMED if filename.lower().endswith(".py") else NOT_A_MIGRATION
 
     match = MIGRATION_PATTERNS[namespace].match(filename)
     if match is None:

--- a/src/genesis/db/_migration_ids.py
+++ b/src/genesis/db/_migration_ids.py
@@ -29,23 +29,32 @@ SCHEMA_MIGRATION_PATTERN = re.compile(r"^(\d{4}|\d{14})_\w+\.py$")
 #: namespaces disjoint, so they can never cross-collide in one claims map.
 DATA_MIGRATION_PATTERN = re.compile(r"^(d(?:\d{4}|\d{14}))_\w+\.py$")
 
-#: The frozen legacy window per namespace, as ``(lo, hi, count)`` — the exact
-#: set that existed when the namespace froze (2026-09-03).
+#: The frozen legacy window per namespace, as ``(lo, hi)`` — the range of
+#: hand-allocated ids that already exist. A legacy-width id OUTSIDE it is a new
+#: allocation and is refused.
 #:
-#: BOTH ENDS are enforced, and the count with them. Below ``lo`` is as much a
-#: hand-allocated id as above ``hi``: ``0000`` is legacy-width, duplicates
-#: nothing, and slipped through an earlier one-sided ``prefix > hi`` rule — and
-#: it is the WORST id for it, because on a fresh install it sorts first and runs
-#: before ``0001``, while on an existing install every legacy id is already
-#: applied so it runs last. Same tree, opposite order, nothing detecting it.
+#: BOTH ENDS matter. Below ``lo`` is as much a hand-allocated id as above
+#: ``hi``: ``0000`` is legacy-width, duplicates nothing, and slipped an earlier
+#: one-sided ``prefix > hi`` rule — and it is the worst id to miss, because on
+#: a fresh install it sorts first and runs before ``0001`` while on an existing
+#: install every legacy id is already applied, so it runs last. Same tree,
+#: opposite order, nothing detecting it.
 #:
-#: ``count`` pins contiguity: for a contiguous range, ``(lo, hi, count)``
-#: characterises the set exactly, so a DELETED legacy migration (which would
-#: otherwise free its id for silent re-allocation) shows up as a violation
-#: rather than as a gap. Moving the window is then a deliberate edit here.
-FROZEN_LEGACY_WINDOW: dict[str, tuple[str, str, int]] = {
-    "schema migration": ("0001", "0091", 91),
-    "data migration": ("d0001", "d0011", 11),
+#: TRANSITION CONSTANT: ``hi`` tracks the highest legacy id on the default
+#: branch, which still moves while migrations authored under the old
+#: convention are in flight (``0093`` landed 2026-09-04, leaving a gap at
+#: ``0092`` from a rename). If one merges above ``hi`` before this scheme does,
+#: bump it here — the guard will say exactly that. Once the in-flight set is
+#: drained the window is fixed forever, because nothing allocates a legacy id
+#: any more.
+#:
+#: Deliberately NOT pinned by count. A size check would catch a DELETED legacy
+#: migration freeing its id — but the freeze already makes that unreachable
+#: (every new migration is a timestamp, so no id is ever re-allocated), and the
+#: range is not contiguous anyway.
+FROZEN_LEGACY_WINDOW: dict[str, tuple[str, str]] = {
+    "schema migration": ("0001", "0093"),
+    "data migration": ("d0001", "d0011"),
 }
 
 

--- a/src/genesis/db/data_migrations/__init__.py
+++ b/src/genesis/db/data_migrations/__init__.py
@@ -2,7 +2,9 @@
 
 Once-per-install backfills/transforms of NON-schema state — Qdrant payloads,
 entity graphs — that schema migrations (``db/migrations/``) can't express.
-Each ``dNNNN_*.py`` module exposes:
+Each module is named ``d`` + a UTC timestamp — ``dYYYYMMDDHHMMSS_desc.py``,
+from ``date -u +%Y%m%d%H%M%S`` (the legacy ``d0001``-``d0011`` ids are frozen;
+see ``db/migrations/runner.py`` for why new ids are timestamps). Each exposes:
 
     requires_operator: bool = False   # optional; True => auto-runner skips it
     def migrate() -> dict:  ...        # sync, idempotent; returns a summary

--- a/src/genesis/db/data_migrations/runner.py
+++ b/src/genesis/db/data_migrations/runner.py
@@ -21,16 +21,21 @@ from pathlib import Path
 import aiosqlite
 
 from genesis.db._migration_discovery import discover_numbered_modules
-from genesis.db._migration_ids import DATA_MIGRATION_PATTERN
+from genesis.db._migration_ids import DATA, DATA_MIGRATION_PATTERN
 from genesis.db.crud import data_migrations as crud
 from genesis.db.data_migrations._util import MigrationDependencyUnavailable
 
 logger = logging.getLogger(__name__)
 
 _DATA_MIGRATIONS_DIR = Path(__file__).parent
-#: Frozen legacy ids (``d0001``-``d0011``) OR ``d`` + a UTC timestamp. Defined
-#: in ``db/_migration_ids`` (stdlib-only, shared with CI's guard); see the
-#: schema runner's module docstring for why new ids are timestamps.
+#: A ``d`` + 4-digit legacy id OR ``d`` + a 14-digit UTC timestamp. Defined in
+#: ``db/_migration_ids`` (stdlib-only, shared with CI's guard); see the schema
+#: runner's module docstring for why new ids are timestamps.
+#:
+#: MATCHING IS NOT SUFFICIENT — the pattern says well-FORMED, not ALLOWED; the
+#: legacy set is enumerated, and ``classify`` is the verdict. Discovery raises
+#: on anything that presents as a data migration and cannot run, because a
+#: silently-skipped backfill is indistinguishable from one that ran.
 _DATA_MIGRATION_PATTERN = DATA_MIGRATION_PATTERN
 
 # The ledger bookkeeping (mark_completed / mark_failed) writes through the shared
@@ -113,7 +118,9 @@ class DataMigrationRunner:
         self._db = db
 
     def _discover(self) -> list[tuple[str, str, Path]]:
-        return discover_numbered_modules(_DATA_MIGRATIONS_DIR, _DATA_MIGRATION_PATTERN)
+        # Raises if any file presents as a data migration but cannot run — a
+        # silently-skipped backfill is indistinguishable from one that ran.
+        return discover_numbered_modules(_DATA_MIGRATIONS_DIR, DATA)
 
     async def run_pending(self) -> list[dict]:
         """Run every claimable data migration once. Returns per-migration outcomes.

--- a/src/genesis/db/data_migrations/runner.py
+++ b/src/genesis/db/data_migrations/runner.py
@@ -14,7 +14,6 @@ import importlib
 import logging
 import math
 import os
-import re
 import sqlite3
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -22,13 +21,17 @@ from pathlib import Path
 import aiosqlite
 
 from genesis.db._migration_discovery import discover_numbered_modules
+from genesis.db._migration_ids import DATA_MIGRATION_PATTERN
 from genesis.db.crud import data_migrations as crud
 from genesis.db.data_migrations._util import MigrationDependencyUnavailable
 
 logger = logging.getLogger(__name__)
 
 _DATA_MIGRATIONS_DIR = Path(__file__).parent
-_DATA_MIGRATION_PATTERN = re.compile(r"^(d\d{4})_\w+\.py$")
+#: Frozen legacy ids (``d0001``-``d0011``) OR ``d`` + a UTC timestamp. Defined
+#: in ``db/_migration_ids`` (stdlib-only, shared with CI's guard); see the
+#: schema runner's module docstring for why new ids are timestamps.
+_DATA_MIGRATION_PATTERN = DATA_MIGRATION_PATTERN
 
 # The ledger bookkeeping (mark_completed / mark_failed) writes through the shared
 # server connection, which waits only BUSY_TIMEOUT_MS (5s) for the write lock. A
@@ -120,7 +123,7 @@ class DataMigrationRunner:
         task) and never blocks the others."""
         available = self._discover()
 
-        # Pre-flight: two files sharing a dNNNN prefix would collide on the
+        # Pre-flight: two files sharing a d-prefix would collide on the
         # ledger PRIMARY KEY. Unlike the schema runner (whose plain INSERT
         # surfaces the clash as a UNIQUE error mid-run), our ensure_row uses
         # INSERT OR IGNORE, so a collision would SILENTLY drop the second
@@ -131,7 +134,8 @@ class DataMigrationRunner:
             if mid in seen:
                 raise RuntimeError(
                     f"Duplicate data-migration prefix '{mid}': '{seen[mid]}' and "
-                    f"'{name}'. Rename one to the next free prefix."
+                    f"'{name}'. Rename one to a fresh UTC timestamp id "
+                    f"(`d$(date -u +%Y%m%d%H%M%S)`)."
                 )
             seen[mid] = name
 

--- a/src/genesis/db/migrations/runner.py
+++ b/src/genesis/db/migrations/runner.py
@@ -3,10 +3,20 @@
 Each migration is a Python file in this directory. **New migrations use a UTC
 timestamp id** — ``YYYYMMDDHHMMSS_description.py``, e.g.
 ``20260903200000_add_widget_table.py``; generate it with
-``date -u +%Y%m%d%H%M%S``. The legacy hand-allocated 4-digit ids
-(``0001``-``0091``) are FROZEN: they still run, and nothing renames them, but
-no new one may be added (enforced by ``scripts/check_migration_prefixes.py``
-in CI).
+``date -u +%Y%m%d%H%M%S``. The legacy hand-allocated 4-digit ids are FROZEN as
+an ENUMERATED set (``_migration_ids.FROZEN_LEGACY_FILES``): they still run, and
+nothing adds to, deletes from, or renames within that set. A range could not
+express it — ``0092`` lies between the endpoints and does not exist, so an
+endpoint check admitted a brand-new hand-allocated ``0092_*.py``.
+
+Discovery is a TOTAL function over filenames: a name is a frozen legacy
+migration, a well-formed timestamp migration, or not a migration at all — and
+anything left over raises rather than being skipped. The skip is what made this
+dangerous: a mistyped ``2026090320000_x.py`` (13 digits) matched nothing, so it
+was discovered by nothing and NEVER RAN, and the code needing it deployed
+against a schema that never got the change. CI enforces the same contract via
+``scripts/check_migration_prefixes.py``, plus one rule that is only true of the
+default branch: every frozen file is still present under its own name.
 
 Why: a hand-allocated id has to be CHOSEN, so two branches routinely choose
 the same one — measured 2026-09-03, one PR was renumbered twice in a single
@@ -64,17 +74,23 @@ from pathlib import Path
 
 import aiosqlite
 
-from genesis.db._migration_ids import SCHEMA_MIGRATION_PATTERN
+from genesis.db._migration_ids import SCHEMA, SCHEMA_MIGRATION_PATTERN
 
 logger = logging.getLogger(__name__)
 
 _MIGRATIONS_DIR = Path(__file__).parent
-#: Frozen legacy ids (``0001``-``0091``) OR a UTC timestamp id
-#: (``YYYYMMDDHHMMSS``). Both widths are all-digits, so they sort together and
-#: '0' < '2' keeps every legacy id ahead of every timestamp one. Defined in
-#: ``db/_migration_ids`` (stdlib-only) so CI's guard can bind to the REAL
-#: pattern without importing this module's aiosqlite dependency; aliased here
-#: because the name is part of this module's established surface.
+#: A 4-digit legacy id OR a 14-digit UTC timestamp id. Both widths are ASCII
+#: digits, so they sort together, and '0' < '2' keeps every legacy id ahead of
+#: every timestamp one — which is why a timestamp must validate as a real
+#: calendar date at/after ``TIMESTAMP_EPOCH_YEAR`` and not merely be 14 digits.
+#: Defined in ``db/_migration_ids`` (stdlib-only) so CI's guard can bind to the
+#: REAL contract without importing this module's aiosqlite dependency; aliased
+#: here because the name is part of this module's established surface.
+#:
+#: MATCHING IS NOT SUFFICIENT: the pattern says a name is well-FORMED, never
+#: that it is ALLOWED. A legacy-width id must also be in the frozen set. Use
+#: ``_migration_ids.classify`` for the verdict; conflating the two is what let
+#: a fresh ``0092_new.py`` past an endpoint check.
 _MIGRATION_PATTERN = SCHEMA_MIGRATION_PATTERN
 
 # SQL statements that would escape the runner's outer BEGIN IMMEDIATE /
@@ -265,10 +281,12 @@ class MigrationRunner:
     async def get_available(self) -> list[tuple[str, str, Path]]:
         """Return ordered list of (id, name, path) for all migration files."""
         # Shared file-discovery with the data-migration runner (only the
-        # filename pattern differs; execution semantics are deliberately not).
+        # namespace differs; execution semantics are deliberately not). Raises
+        # if any file presents as a migration but cannot run — see the note on
+        # _MIGRATION_PATTERN for why silence there was the dangerous case.
         from genesis.db._migration_discovery import discover_numbered_modules
 
-        return discover_numbered_modules(_MIGRATIONS_DIR, _MIGRATION_PATTERN)
+        return discover_numbered_modules(_MIGRATIONS_DIR, SCHEMA)
 
     async def get_pending(self) -> list[tuple[str, str, Path]]:
         """Return ordered list of migrations not yet applied."""

--- a/src/genesis/db/migrations/runner.py
+++ b/src/genesis/db/migrations/runner.py
@@ -1,7 +1,34 @@
 """Migration runner — discovers and applies versioned schema migrations.
 
-Each migration is a Python file in this directory named NNNN_description.py
-(e.g., 0001_add_update_history.py). Files must define:
+Each migration is a Python file in this directory. **New migrations use a UTC
+timestamp id** — ``YYYYMMDDHHMMSS_description.py``, e.g.
+``20260903200000_add_widget_table.py``; generate it with
+``date -u +%Y%m%d%H%M%S``. The legacy hand-allocated 4-digit ids
+(``0001``-``0091``) are FROZEN: they still run, and nothing renames them, but
+no new one may be added (enforced by ``scripts/check_migration_prefixes.py``
+in CI).
+
+Why: a hand-allocated id has to be CHOSEN, so two branches routinely choose
+the same one — measured 2026-09-03, one PR was renumbered twice in a single
+day and four open PRs held live collisions. A duplicate prefix is not cosmetic
+(see the pre-flight below), so the contention was worth removing at the root
+rather than detecting later. Nobody allocates a timestamp; the clock does.
+
+Ordering is unchanged in practice: ids sort lexicographically, every legacy id
+begins with ``0`` and every timestamp with ``2``, so the frozen history always
+precedes new work.
+
+The one property to know: the id encodes CREATION time, not merge time. A
+fresh install replays creation order; an existing install only runs what is
+still pending, i.e. merge order. They agree unless a migration is authored
+before, but merged after, one it depends on — so if that happens, RENAME IT AT
+MERGE TIME to a later id rather than at creation. CI replays the full sequence
+against an empty database on every PR (``tests/test_db/test_migrations_runner``
+and the security suites), so an ordering that breaks at the SQL level fails
+loudly there; a purely semantic dependency (A backfills what B adds) would
+not, which is why the rename rule is stated rather than left to the tests.
+
+Files must define:
 
     async def up(db: aiosqlite.Connection) -> None:
         '''Apply the migration. MUST NOT call db.commit() or db.rollback()
@@ -29,7 +56,6 @@ from __future__ import annotations
 import asyncio
 import importlib
 import logging
-import re
 import sqlite3
 import time
 from dataclasses import dataclass
@@ -38,10 +64,18 @@ from pathlib import Path
 
 import aiosqlite
 
+from genesis.db._migration_ids import SCHEMA_MIGRATION_PATTERN
+
 logger = logging.getLogger(__name__)
 
 _MIGRATIONS_DIR = Path(__file__).parent
-_MIGRATION_PATTERN = re.compile(r"^(\d{4})_\w+\.py$")
+#: Frozen legacy ids (``0001``-``0091``) OR a UTC timestamp id
+#: (``YYYYMMDDHHMMSS``). Both widths are all-digits, so they sort together and
+#: '0' < '2' keeps every legacy id ahead of every timestamp one. Defined in
+#: ``db/_migration_ids`` (stdlib-only) so CI's guard can bind to the REAL
+#: pattern without importing this module's aiosqlite dependency; aliased here
+#: because the name is part of this module's established surface.
+_MIGRATION_PATTERN = SCHEMA_MIGRATION_PATTERN
 
 # SQL statements that would escape the runner's outer BEGIN IMMEDIATE /
 # COMMIT / ROLLBACK envelope. Matched case-insensitively against the
@@ -260,7 +294,8 @@ class MigrationRunner:
                 raise RuntimeError(
                     f"Duplicate migration prefix '{mid}': "
                     f"'{seen[mid]}' and '{name}'. "
-                    f"Rename one file to use the next available prefix."
+                    f"Rename one file to a fresh UTC timestamp id "
+                    f"(`date -u +%Y%m%d%H%M%S`)."
                 )
             seen[mid] = name
 

--- a/tests/test_db/test_data_migrations.py
+++ b/tests/test_db/test_data_migrations.py
@@ -15,7 +15,6 @@ import pytest
 from genesis.db.crud import data_migrations as crud
 from genesis.db.data_migrations import runner as runner_mod
 from genesis.db.data_migrations.runner import DataMigrationRunner
-from genesis.db.migrations import runner as _schema_runner
 from genesis.db.schema import create_all_tables
 
 
@@ -249,25 +248,18 @@ def test_no_duplicate_migration_prefixes_in_tree():
     from collections import Counter
 
     from genesis.db._migration_discovery import discover_numbered_modules
+    from genesis.db._migration_ids import DATA, SCHEMA
 
+    # The NAMESPACE, not a pattern: discovery resolves the pattern from the
+    # contract itself, so this test cannot bind to a regex that disagrees with
+    # the directory it is scanning. (A copied regex here silently stopped
+    # covering timestamp-id migrations the moment the runner's pattern widened.)
     surfaces = [
-        (
-            runner_mod._DATA_MIGRATIONS_DIR,
-            runner_mod._DATA_MIGRATION_PATTERN,
-            "data migration",
-        ),
-        (
-            runner_mod._DATA_MIGRATIONS_DIR.parent / "migrations",
-            # IMPORTED, not restated: a copied regex here silently stopped
-            # covering timestamp-id migrations the moment the runner's pattern
-            # widened, while the data half (which imports its constant, just
-            # above) self-healed. Same asymmetry, same fix.
-            _schema_runner._MIGRATION_PATTERN,
-            "schema migration",
-        ),
+        (runner_mod._DATA_MIGRATIONS_DIR, DATA, "data migration"),
+        (runner_mod._DATA_MIGRATIONS_DIR.parent / "migrations", SCHEMA, "schema migration"),
     ]
-    for directory, pattern, label in surfaces:
-        ids = [mid for mid, _, _ in discover_numbered_modules(directory, pattern)]
+    for directory, namespace, label in surfaces:
+        ids = [mid for mid, _, _ in discover_numbered_modules(directory, namespace)]
         dupes = {mid: n for mid, n in Counter(ids).items() if n > 1}
         assert not dupes, (
             f"duplicate {label} prefix(es) {dupes} in {directory} — "

--- a/tests/test_db/test_data_migrations.py
+++ b/tests/test_db/test_data_migrations.py
@@ -15,6 +15,7 @@ import pytest
 from genesis.db.crud import data_migrations as crud
 from genesis.db.data_migrations import runner as runner_mod
 from genesis.db.data_migrations.runner import DataMigrationRunner
+from genesis.db.migrations import runner as _schema_runner
 from genesis.db.schema import create_all_tables
 
 
@@ -130,7 +131,14 @@ def _patch_migrations(monkeypatch, mods: dict):
     """Wire discovery + import to a dict of {stem: fake module}."""
     from pathlib import Path
 
-    available = [(stem[:5], stem, Path(f"/fake/{stem}.py")) for stem in mods]
+    # Derive the id with the RUNNER's pattern rather than a fixed slice:
+    # `stem[:5]` silently yields "d2026" for a timestamp-shaped fake, so a
+    # future timestamp fixture would test a nonsense id and still pass.
+    available = []
+    for stem in mods:
+        m = runner_mod._DATA_MIGRATION_PATTERN.match(f"{stem}.py")
+        assert m, f"fake migration stem {stem!r} does not match the runner pattern"
+        available.append((m.group(1), stem, Path(f"/fake/{stem}.py")))
     monkeypatch.setattr(DataMigrationRunner, "_discover", lambda self: available)
     monkeypatch.setattr(
         runner_mod.importlib, "import_module", lambda name: mods[name.rsplit(".", 1)[-1]]
@@ -238,7 +246,6 @@ def test_no_duplicate_migration_prefixes_in_tree():
     test fires at CI time on the offending PR's merge ref, where the collision
     is cheap to fix.
     """
-    import re
     from collections import Counter
 
     from genesis.db._migration_discovery import discover_numbered_modules
@@ -251,7 +258,11 @@ def test_no_duplicate_migration_prefixes_in_tree():
         ),
         (
             runner_mod._DATA_MIGRATIONS_DIR.parent / "migrations",
-            re.compile(r"^(\d{4})_\w+\.py$"),
+            # IMPORTED, not restated: a copied regex here silently stopped
+            # covering timestamp-id migrations the moment the runner's pattern
+            # widened, while the data half (which imports its constant, just
+            # above) self-healed. Same asymmetry, same fix.
+            _schema_runner._MIGRATION_PATTERN,
             "schema migration",
         ),
     ]
@@ -260,7 +271,8 @@ def test_no_duplicate_migration_prefixes_in_tree():
         dupes = {mid: n for mid, n in Counter(ids).items() if n > 1}
         assert not dupes, (
             f"duplicate {label} prefix(es) {dupes} in {directory} — "
-            "rename the newer file to the next free prefix"
+            "rename the newer file to a fresh UTC timestamp id "
+            "(`date -u +%Y%m%d%H%M%S`; data migrations prefix a 'd')"
         )
 
 

--- a/tests/test_db/test_migration_discovery.py
+++ b/tests/test_db/test_migration_discovery.py
@@ -2,16 +2,35 @@
 
 Extracted from the two migration runners; this exercises it directly (the
 structural reviewer flagged it had only transitive coverage).
+
+Fixtures here use REAL frozen legacy filenames rather than invented ones
+(``0001_add_update_history.py``, not ``0001_a.py``). That is not incidental
+tidiness: discovery now consults the enumerated frozen set, so an invented
+legacy name is — correctly — a violation, and a test that used one would be
+asserting against a fixture the production contract rejects.
 """
 
 from __future__ import annotations
 
-import re
+import logging
 import sqlite3
 
+import pytest
+
 from genesis.db._migration_discovery import discover_numbered_modules
-from genesis.db.data_migrations.runner import _DATA_MIGRATION_PATTERN
-from genesis.db.migrations.runner import _MIGRATION_PATTERN
+from genesis.db._migration_ids import (
+    DATA,
+    DATA_MIGRATION_PATTERN,
+    SCHEMA,
+    SCHEMA_MIGRATION_PATTERN,
+)
+
+# Real members of the frozen set, used wherever a test needs a legacy file.
+FIRST_LEGACY = "0001_add_update_history.py"
+SECOND_LEGACY = "0002_add_eval_tables.py"
+TENTH_LEGACY = "0010_bitemporal_memory.py"
+LAST_LEGACY = "0093_entity_adjudication_approval.py"
+FIRST_DATA = "d0001_origin_class_qdrant.py"
 
 
 def _make(dir_, *names):
@@ -20,32 +39,35 @@ def _make(dir_, *names):
 
 
 def test_matches_pattern_and_orders_by_id(tmp_path):
-    _make(tmp_path, "0002_b.py", "0001_a.py", "0010_c.py")
-    pat = re.compile(r"^(\d{4})_\w+\.py$")
-    out = discover_numbered_modules(tmp_path, pat)
+    _make(tmp_path, SECOND_LEGACY, FIRST_LEGACY, TENTH_LEGACY)
+    out = discover_numbered_modules(tmp_path, SCHEMA)
     assert [mid for mid, _, _ in out] == ["0001", "0002", "0010"]  # zero-pad sort
-    assert [stem for _, stem, _ in out] == ["0001_a", "0002_b", "0010_c"]
+    assert [stem for _, stem, _ in out] == [
+        FIRST_LEGACY[:-3],
+        SECOND_LEGACY[:-3],
+        TENTH_LEGACY[:-3],
+    ]
 
 
 def test_frozen_legacy_ids_always_precede_timestamp_ids(tmp_path):
     """THE ordering invariant the whole mixed-width scheme rests on.
 
-    Every legacy id starts with '0' (the namespace froze at 0091) and every
-    timestamp with '2', so a plain lexicographic sort keeps the frozen history
-    ahead of all new work — in Python's `sorted()` here AND in SQLite's TEXT
-    collation on the ledger. If this ever fails, a fresh install would replay
-    history in the wrong order.
+    Every legacy id starts with '0' and every timestamp id is a real calendar
+    year >= TIMESTAMP_EPOCH_YEAR and so starts with '2', which is what a plain
+    lexicographic sort needs to keep the frozen history ahead of all new work —
+    in Python's `sorted()` here AND in SQLite's TEXT collation on the ledger.
+    If this ever fails, a fresh install would replay history in the wrong order.
     """
     _make(
         tmp_path,
         "20260903200000_new.py",
-        "0091_last_legacy.py",
+        LAST_LEGACY,
         "20260101000000_earlier.py",
-        "0001_first_legacy.py",
+        FIRST_LEGACY,
     )
-    out = discover_numbered_modules(tmp_path, _MIGRATION_PATTERN)
+    out = discover_numbered_modules(tmp_path, SCHEMA)
     ids = [mid for mid, _, _ in out]
-    assert ids == ["0001", "0091", "20260101000000", "20260903200000"]
+    assert ids == ["0001", "0093", "20260101000000", "20260903200000"]
 
     # The SQLite half, EXERCISED rather than asserted in prose (the docstring
     # used to claim it while the body never touched a database): both ledgers
@@ -64,54 +86,183 @@ def test_frozen_legacy_ids_always_precede_timestamp_ids(tmp_path):
 def test_timestamp_ids_are_discovered_in_both_namespaces(tmp_path):
     """The runners' real patterns must accept the new width — a pattern that
     silently skipped it would mean the migration never runs, with no error."""
-    _make(tmp_path, "20260903200000_schema.py", "d20260903200000_data.py")
-    assert [m for m, _, _ in discover_numbered_modules(tmp_path, _MIGRATION_PATTERN)] == [
-        "20260903200000"
-    ]
-    assert [m for m, _, _ in discover_numbered_modules(tmp_path, _DATA_MIGRATION_PATTERN)] == [
-        "d20260903200000"
+    schema_dir = tmp_path / "schema"
+    data_dir = tmp_path / "data"
+    schema_dir.mkdir()
+    data_dir.mkdir()
+    _make(schema_dir, "20260903200000_schema.py")
+    _make(data_dir, "d20260903200000_data.py")
+    assert [m for m, _, _ in discover_numbered_modules(schema_dir, SCHEMA)] == ["20260903200000"]
+    assert [m for m, _, _ in discover_numbered_modules(data_dir, DATA)] == ["d20260903200000"]
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "2026090320000_short.py",  # 13 digits
+        "202609032000000_long.py",  # 15 digits
+        "00000000000000_zero.py",  # 14 digits, not a calendar timestamp
+        "20261301000000_month13.py",  # impossible month
+        "20260932000000_day32.py",  # impossible day
+        "19990101000000_preepoch.py",  # sorts before the frozen namespace
+        "２０２６０９０４００００００_fullwidth.py",
+        "d0001_misfiled_data_in_schema_dir.py",
+    ],
+)
+def test_unrunnable_files_raise_instead_of_being_skipped(tmp_path, bad_name):
+    """A file that presents as a migration but cannot run must ABORT discovery.
+
+    The previous version matched a regex and skipped whatever failed, so each
+    of these was discovered by nothing and NEVER RAN — and the code that needed
+    it deployed against a schema that never got the change. A duplicate id
+    already aborts for a strictly smaller reason; a duplicate is at least loud.
+
+    The full-width case is here because it regressed once already: the
+    candidate net was written with ASCII ``[0-9]`` "for consistency" with the
+    strict pattern, which made a full-width id fail to even PRESENT as a
+    migration, so it was classified not-a-migration and the guard reported
+    CLEAN — reproducing the exact silence the ASCII restriction was added to
+    remove.
+    """
+    _make(tmp_path, FIRST_LEGACY, bad_name)
+    with pytest.raises(RuntimeError) as excinfo:
+        discover_numbered_modules(tmp_path, SCHEMA)
+    message = str(excinfo.value)
+    assert bad_name in message
+    # The message has to be actionable, not merely present.
+    assert "date -u +%Y%m%d%H%M%S" in message or "FROZEN_LEGACY_FILES" in message
+
+
+@pytest.mark.parametrize("name", ["0094_fork_custom.py", "0092_gap.py"])
+def test_a_disallowed_but_RUNNABLE_legacy_id_still_runs(tmp_path, caplog, name):
+    """The runtime enforces RUNNABLE, never this repo's namespace POLICY.
+
+    A 4-digit id outside our frozen set is well-formed, uniquely numbered, sorts
+    correctly and applies cleanly — it breaks a rule of ours, not an invariant
+    of the installation running it. Discovery sits on the boot-abort path
+    (``runtime/init/db.py`` re-raises and ``_core`` stops bootstrap), so
+    refusing here would leave a downstream fork carrying its own 4-digit
+    migration with NO DATABASE after a pull, over a convention that was the only
+    one available before this scheme existed. It runs, and warns; CI refuses it,
+    which is where a policy about our namespace can be enforced without reaching
+    into anyone else's install.
+    """
+    _make(tmp_path, FIRST_LEGACY, name)
+    with caplog.at_level(logging.WARNING):
+        out = discover_numbered_modules(tmp_path, SCHEMA)
+    assert [stem for _, stem, _ in out] == [FIRST_LEGACY[:-3], name[:-3]]
+    # Runs, but never silently: the warning names the file.
+    assert any(name in r.getMessage() for r in caplog.records), caplog.records
+
+
+def test_the_ci_guard_refuses_what_the_runtime_merely_warns_about(tmp_path):
+    """The two layers must DISAGREE in exactly one direction, or the split is
+    decorative. Pinned here so a future change cannot quietly align them by
+    making the runtime strict again."""
+    from genesis.db._migration_ids import DISALLOWED_LEGACY, RUNNABLE, classify
+
+    assert classify(SCHEMA, "0094_fork_custom.py") == DISALLOWED_LEGACY
+    assert DISALLOWED_LEGACY in RUNNABLE  # the runtime may execute it
+    assert classify(SCHEMA, "2026090320000_short.py") not in RUNNABLE  # it may not
+
+
+def test_an_unhandled_verdict_is_a_hard_error_not_an_accept(tmp_path, monkeypatch):
+    """The residue of the residue.
+
+    Both consumers used to switch on the two NEGATIVE verdicts and accept
+    everything else, which is an accept-by-DEFAULT wearing a total-function
+    docstring: every verdict added later is silently runnable. Adding
+    DISALLOWED_LEGACY would have been accepted by both, in exactly the place the
+    module claims that cannot happen.
+    """
+    import genesis.db._migration_ids as ids_mod
+
+    _make(tmp_path, FIRST_LEGACY)
+    monkeypatch.setattr(ids_mod, "classify", lambda ns, name: "a-verdict-from-the-future")
+    with pytest.raises(RuntimeError, match="unhandled migration classification"):
+        discover_numbered_modules(tmp_path, SCHEMA)
+
+
+def test_a_valid_directory_does_not_raise(tmp_path):
+    """The control for the test above: the same shape, all names legal."""
+    _make(tmp_path, FIRST_LEGACY, "20260904120000_new.py")
+    assert [m for m, _, _ in discover_numbered_modules(tmp_path, SCHEMA)] == [
+        "0001",
+        "20260904120000",
     ]
 
 
-def test_off_width_ids_are_refused_by_both_patterns(tmp_path):
-    """Anchored alternation ({4}|{14}), never {4,14}: a mistyped 13- or
-    15-digit id is REFUSED at discovery rather than quietly founding a third
-    id namespace with its own ordering semantics."""
+def test_ignores_files_that_never_looked_like_migrations(tmp_path):
+    """Non-candidates stay ignored — the residue rule must not swallow the
+    runner's own modules, which live in the same directory."""
     _make(
         tmp_path,
-        "2026090320000_short.py",
-        "202609032000000_long.py",
-        "d2026090320000_short.py",
+        FIRST_LEGACY,
+        "README.md",
+        "notes.txt",
+        "_helper.py",
+        "__init__.py",
+        "runner.py",
+        "stale_embedding_repair.py",
     )
-    assert discover_numbered_modules(tmp_path, _MIGRATION_PATTERN) == []
-    assert discover_numbered_modules(tmp_path, _DATA_MIGRATION_PATTERN) == []
+    out = discover_numbered_modules(tmp_path, SCHEMA)
+    assert [stem for _, stem, _ in out] == [FIRST_LEGACY[:-3]]
 
 
-def test_ignores_non_matching_files(tmp_path):
-    _make(tmp_path, "0001_ok.py", "README.md", "0001_ok.pyc", "notes.txt", "_helper.py")
-    pat = re.compile(r"^(\d{4})_\w+\.py$")
-    out = discover_numbered_modules(tmp_path, pat)
-    assert [stem for _, stem, _ in out] == ["0001_ok"]
+def test_a_migration_named_file_that_is_not_python_is_not_a_migration(tmp_path):
+    """``0094_notes.txt`` is not a migration anyone expected to run."""
+    _make(tmp_path, FIRST_LEGACY, "0094_notes.txt", "0094_compiled.pyc")
+    out = discover_numbered_modules(tmp_path, SCHEMA)
+    assert [stem for _, stem, _ in out] == [FIRST_LEGACY[:-3]]
 
 
-def test_data_migration_pattern_is_distinct(tmp_path):
-    # The d-prefixed pattern must NOT pick up schema-style files and vice versa.
-    _make(
-        tmp_path,
-        "0001_schema.py",
-        "d0001_data.py",
-        "20260903200000_schema_ts.py",
-        "d20260903200000_data_ts.py",
-    )
-    assert [s for _, s, _ in discover_numbered_modules(tmp_path, _MIGRATION_PATTERN)] == [
-        "0001_schema",
-        "20260903200000_schema_ts",
-    ]
-    assert [s for _, s, _ in discover_numbered_modules(tmp_path, _DATA_MIGRATION_PATTERN)] == [
-        "d0001_data",
-        "d20260903200000_data_ts",
-    ]
+def test_data_migration_pattern_is_distinct():
+    """The d-prefixed pattern must NOT accept schema-style names, or vice versa.
+
+    A pattern-level assertion: putting both kinds in one directory is now a
+    violation (see the misfiled case above), so this can no longer be shown by
+    discovering a mixed directory.
+    """
+    assert SCHEMA_MIGRATION_PATTERN.match("0001_schema.py")
+    assert not SCHEMA_MIGRATION_PATTERN.match("d0001_data.py")
+    assert DATA_MIGRATION_PATTERN.match("d0001_data.py")
+    assert not DATA_MIGRATION_PATTERN.match("0001_schema.py")
+    assert SCHEMA_MIGRATION_PATTERN.match("20260903200000_schema_ts.py")
+    assert DATA_MIGRATION_PATTERN.match("d20260903200000_data_ts.py")
+
+
+def test_the_strict_patterns_accept_only_ASCII_digits():
+    """``[0-9]`` rather than ``\\d`` in the id field, asserted where it is claimed.
+
+    ``\\d`` also matches non-ASCII decimal digits, whose codepoints sort nowhere
+    near the ASCII ids the ordering invariant is stated over. Reverting the
+    patterns to ``\\d`` leaves the whole suite green because
+    ``is_valid_timestamp_id`` independently rejects non-ASCII — a correct green
+    from a sibling layer, but it means nothing pinned the PATTERN's own
+    contract, which is what the runners' discovery reads.
+    """
+    assert not SCHEMA_MIGRATION_PATTERN.match("２０２６０９０４００００００_x.py")
+    assert not DATA_MIGRATION_PATTERN.match("d２０２６０９０４００００００_x.py")
+    assert not SCHEMA_MIGRATION_PATTERN.match("２０２６_x.py")
+    assert SCHEMA_MIGRATION_PATTERN.match("20260904000000_x.py")
 
 
 def test_empty_dir_returns_empty(tmp_path):
-    assert discover_numbered_modules(tmp_path, re.compile(r"^(\d{4})_\w+\.py$")) == []
+    assert discover_numbered_modules(tmp_path, SCHEMA) == []
+
+
+def test_the_real_migrations_directories_are_discoverable():
+    """The acceptance case: the SHIPPING tree must survive its own contract.
+
+    A guard that is clean only on fixtures is the failure this whole change
+    exists to remove, so discovery runs against the real directories here.
+    """
+    from genesis.db.data_migrations import runner as data_runner
+    from genesis.db.migrations import runner as schema_runner
+
+    schema = discover_numbered_modules(schema_runner._MIGRATIONS_DIR, SCHEMA)
+    data = discover_numbered_modules(data_runner._DATA_MIGRATIONS_DIR, DATA)
+    assert len(schema) >= 92
+    assert len(data) >= 11
+    assert [m for m, _, _ in schema] == sorted(m for m, _, _ in schema)
+    assert [m for m, _, _ in data] == sorted(m for m, _, _ in data)

--- a/tests/test_db/test_migration_discovery.py
+++ b/tests/test_db/test_migration_discovery.py
@@ -107,6 +107,10 @@ def test_timestamp_ids_are_discovered_in_both_namespaces(tmp_path):
         "19990101000000_preepoch.py",  # sorts before the frozen namespace
         "２０２６０９０４００００００_fullwidth.py",
         "d0001_misfiled_data_in_schema_dir.py",
+        "dd20260904000000_doubled_prefix.py",  # ^d?\d never saw it — silent skip
+        "D20260904000000_capitalised.py",  # same class, capitalised d
+        "ｄ２０２６０９０４００００００_fullwidth_prefix.py",  # same IME generator, prefix position
+        "20260904000000_case_mangled.PY",  # perfect id, Python never imports it
     ],
 )
 def test_unrunnable_files_raise_instead_of_being_skipped(tmp_path, bad_name):

--- a/tests/test_db/test_migration_discovery.py
+++ b/tests/test_db/test_migration_discovery.py
@@ -7,8 +7,11 @@ structural reviewer flagged it had only transitive coverage).
 from __future__ import annotations
 
 import re
+import sqlite3
 
 from genesis.db._migration_discovery import discover_numbered_modules
+from genesis.db.data_migrations.runner import _DATA_MIGRATION_PATTERN
+from genesis.db.migrations.runner import _MIGRATION_PATTERN
 
 
 def _make(dir_, *names):
@@ -24,6 +27,66 @@ def test_matches_pattern_and_orders_by_id(tmp_path):
     assert [stem for _, stem, _ in out] == ["0001_a", "0002_b", "0010_c"]
 
 
+def test_frozen_legacy_ids_always_precede_timestamp_ids(tmp_path):
+    """THE ordering invariant the whole mixed-width scheme rests on.
+
+    Every legacy id starts with '0' (the namespace froze at 0091) and every
+    timestamp with '2', so a plain lexicographic sort keeps the frozen history
+    ahead of all new work — in Python's `sorted()` here AND in SQLite's TEXT
+    collation on the ledger. If this ever fails, a fresh install would replay
+    history in the wrong order.
+    """
+    _make(
+        tmp_path,
+        "20260903200000_new.py",
+        "0091_last_legacy.py",
+        "20260101000000_earlier.py",
+        "0001_first_legacy.py",
+    )
+    out = discover_numbered_modules(tmp_path, _MIGRATION_PATTERN)
+    ids = [mid for mid, _, _ in out]
+    assert ids == ["0001", "0091", "20260101000000", "20260903200000"]
+
+    # The SQLite half, EXERCISED rather than asserted in prose (the docstring
+    # used to claim it while the body never touched a database): both ledgers
+    # key on TEXT PRIMARY KEY, whose default BINARY collation must agree with
+    # Python's codepoint order. Rows go in reversed so a table that happened to
+    # return insertion order would fail this.
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE TABLE m (id TEXT PRIMARY KEY)")
+        conn.executemany("INSERT INTO m VALUES (?)", [(i,) for i in reversed(ids)])
+        assert [r[0] for r in conn.execute("SELECT id FROM m ORDER BY id")] == ids
+    finally:
+        conn.close()
+
+
+def test_timestamp_ids_are_discovered_in_both_namespaces(tmp_path):
+    """The runners' real patterns must accept the new width — a pattern that
+    silently skipped it would mean the migration never runs, with no error."""
+    _make(tmp_path, "20260903200000_schema.py", "d20260903200000_data.py")
+    assert [m for m, _, _ in discover_numbered_modules(tmp_path, _MIGRATION_PATTERN)] == [
+        "20260903200000"
+    ]
+    assert [m for m, _, _ in discover_numbered_modules(tmp_path, _DATA_MIGRATION_PATTERN)] == [
+        "d20260903200000"
+    ]
+
+
+def test_off_width_ids_are_refused_by_both_patterns(tmp_path):
+    """Anchored alternation ({4}|{14}), never {4,14}: a mistyped 13- or
+    15-digit id is REFUSED at discovery rather than quietly founding a third
+    id namespace with its own ordering semantics."""
+    _make(
+        tmp_path,
+        "2026090320000_short.py",
+        "202609032000000_long.py",
+        "d2026090320000_short.py",
+    )
+    assert discover_numbered_modules(tmp_path, _MIGRATION_PATTERN) == []
+    assert discover_numbered_modules(tmp_path, _DATA_MIGRATION_PATTERN) == []
+
+
 def test_ignores_non_matching_files(tmp_path):
     _make(tmp_path, "0001_ok.py", "README.md", "0001_ok.pyc", "notes.txt", "_helper.py")
     pat = re.compile(r"^(\d{4})_\w+\.py$")
@@ -33,11 +96,21 @@ def test_ignores_non_matching_files(tmp_path):
 
 def test_data_migration_pattern_is_distinct(tmp_path):
     # The d-prefixed pattern must NOT pick up schema-style files and vice versa.
-    _make(tmp_path, "0001_schema.py", "d0001_data.py")
-    schema_pat = re.compile(r"^(\d{4})_\w+\.py$")
-    data_pat = re.compile(r"^(d\d{4})_\w+\.py$")
-    assert [s for _, s, _ in discover_numbered_modules(tmp_path, schema_pat)] == ["0001_schema"]
-    assert [s for _, s, _ in discover_numbered_modules(tmp_path, data_pat)] == ["d0001_data"]
+    _make(
+        tmp_path,
+        "0001_schema.py",
+        "d0001_data.py",
+        "20260903200000_schema_ts.py",
+        "d20260903200000_data_ts.py",
+    )
+    assert [s for _, s, _ in discover_numbered_modules(tmp_path, _MIGRATION_PATTERN)] == [
+        "0001_schema",
+        "20260903200000_schema_ts",
+    ]
+    assert [s for _, s, _ in discover_numbered_modules(tmp_path, _DATA_MIGRATION_PATTERN)] == [
+        "d0001_data",
+        "d20260903200000_data_ts",
+    ]
 
 
 def test_empty_dir_returns_empty(tmp_path):

--- a/tests/test_db/test_migration_discovery.py
+++ b/tests/test_db/test_migration_discovery.py
@@ -83,6 +83,28 @@ def test_frozen_legacy_ids_always_precede_timestamp_ids(tmp_path):
         conn.close()
 
 
+def test_a_fork_legacy_id_above_2xxx_still_precedes_timestamps(tmp_path):
+    """The ordering invariant must hold by CONSTRUCTION, not by leading digit.
+
+    A raw filename sort keeps legacy ahead of timestamps only because the frozen
+    set all begins with '0' and timestamps with '2'. A downstream FORK's own
+    legacy-width id is runnable (DISALLOWED_LEGACY) and need not begin with '0':
+    ``3000_fork_custom.py`` sorts AFTER a ``2026…`` timestamp by leading char, so
+    a fresh clone would run it after the timestamp while the fork that authored
+    it ran it before — divergent order across installs. discovery bands
+    legacy-before-timestamp explicitly so a fork id in the 2xxx–9xxx range is
+    ordered with the other legacy history, not scattered into new work.
+    """
+    _make(tmp_path, FIRST_LEGACY, "3000_fork_custom.py", "20260904120000_upstream.py")
+    ids = [mid for mid, _, _ in discover_numbered_modules(tmp_path, SCHEMA)]
+    assert ids == ["0001", "3000", "20260904120000"], ids
+    # No legacy-width id may appear after any timestamp id.
+    from genesis.db._migration_ids import is_valid_timestamp_id
+
+    first_ts = next((i for i, x in enumerate(ids) if is_valid_timestamp_id(x)), len(ids))
+    assert not [x for x in ids[first_ts:] if not is_valid_timestamp_id(x)], ids
+
+
 def test_timestamp_ids_are_discovered_in_both_namespaces(tmp_path):
     """The runners' real patterns must accept the new width — a pattern that
     silently skipped it would mean the migration never runs, with no error."""

--- a/tests/test_db/test_migrations_runner.py
+++ b/tests/test_db/test_migrations_runner.py
@@ -392,16 +392,24 @@ class TestConnectionProxy:
 
 
 class TestDuplicatePrefixDetection:
-    """Pre-flight check must catch duplicate migration prefixes before running."""
+    """Pre-flight check must catch duplicate migration ids before running.
+
+    These use TIMESTAMP ids because that is the only collision still reachable.
+    A duplicate LEGACY id cannot occur any more: the frozen set holds exactly
+    one filename per legacy id, so a second file claiming ``0001`` is refused
+    by discovery as an illegal legacy id before the duplicate pre-flight is
+    consulted. Two authors CAN still stamp the same second, which is what this
+    pre-flight exists for.
+    """
 
     @pytest.mark.asyncio
     async def test_duplicate_prefix_raises_before_any_migration_runs(
         self, db, tmp_path, monkeypatch,
     ) -> None:
-        # Create two migration files with the same prefix in a temp dir
+        # Two migration files claiming the same timestamp id in a temp dir
         migrations_dir = tmp_path / "migrations"
         migrations_dir.mkdir()
-        for name in ("0001_alpha.py", "0001_beta.py"):
+        for name in ("20260904120000_alpha.py", "20260904120000_beta.py"):
             (migrations_dir / name).write_text(
                 "async def up(db): pass\n"
             )
@@ -410,7 +418,9 @@ class TestDuplicatePrefixDetection:
         )
 
         runner = MigrationRunner(db)
-        with pytest.raises(RuntimeError, match=r"Duplicate migration prefix '0001'"):
+        with pytest.raises(
+            RuntimeError, match=r"Duplicate migration prefix '20260904120000'"
+        ):
             await runner.run_pending()
 
         # No migrations applied — check was pre-flight
@@ -421,13 +431,13 @@ class TestDuplicatePrefixDetection:
     async def test_no_false_positive_on_unique_prefixes(
         self, db, tmp_path, monkeypatch,
     ) -> None:
-        """Unique prefixes pass the pre-flight check (verified via get_pending)."""
+        """Unique ids pass the pre-flight check (verified via get_pending)."""
         migrations_dir = tmp_path / "migrations"
         migrations_dir.mkdir()
-        (migrations_dir / "0001_alpha.py").write_text(
+        (migrations_dir / "20260904120000_alpha.py").write_text(
             "async def up(db): pass\n"
         )
-        (migrations_dir / "0002_beta.py").write_text(
+        (migrations_dir / "20260904120001_beta.py").write_text(
             "async def up(db): pass\n"
         )
         monkeypatch.setattr(

--- a/tests/test_db/test_schema_base_path_parity.py
+++ b/tests/test_db/test_schema_base_path_parity.py
@@ -41,6 +41,7 @@ import textwrap
 from pathlib import Path
 
 from genesis.db import migrations as _migrations_pkg
+from genesis.db.migrations import runner as _migrations_runner
 from genesis.db.schema import INDEXES, TABLES
 from genesis.db.schema import _migrations as _schema_migrations
 
@@ -152,8 +153,14 @@ def _migration_added() -> set[tuple[str, str]]:
     """(table, column) pairs any numbered migration adds via ALTER ... ADD COLUMN."""
     mig_dir = Path(_migrations_pkg.__file__).parent
     pairs: set[tuple[str, str]] = set()
-    for path in sorted(mig_dir.glob("[0-9][0-9][0-9][0-9]_*.py")):
-        pairs |= _alter_pairs_in_source(path.read_text())
+    # Match on the RUNNER's own pattern, not a hand-written glob. The previous
+    # `[0-9][0-9][0-9][0-9]_*.py` glob silently excluded timestamp-id
+    # migrations, so this guard would have stopped seeing every NEW migration
+    # while still reporting green — a fail-open on the bootstrap-crash class
+    # (#1123/#1127) it exists to catch.
+    for path in sorted(mig_dir.iterdir()):
+        if _migrations_runner._MIGRATION_PATTERN.match(path.name):
+            pairs |= _alter_pairs_in_source(path.read_text())
     return pairs
 
 

--- a/tests/test_scripts/test_check_migration_prefixes.py
+++ b/tests/test_scripts/test_check_migration_prefixes.py
@@ -1,23 +1,24 @@
 """The migration-id CI guard (scripts/check_migration_prefixes.py).
 
-Two rules: no duplicate prefix in either namespace, and no NEW hand-allocated
-4-digit id — that namespace is frozen to the exact set that existed on
-2026-09-04 (0001..0093 with a gap at 0092, d0001..d0011), enforced at BOTH ends.
+Three rules: every file in a migrations directory classifies as a legal
+migration (the residue is a violation), no duplicate id in either namespace,
+and every frozen legacy file is still present under its own name.
 
-The both-ends part is load-bearing and was learned the hard way: a one-sided
-"above the freeze mark" rule let ``0000`` through, and ``0000`` is the worst
-possible id to miss — legacy-width, duplicating nothing, and ordering-divergent
-in the maximal way (on a fresh install it sorts first and runs before ``0001``;
-on an existing install every legacy id is already applied, so it runs last).
-Deliberately no size/contiguity check: it would only catch a deleted legacy id
-being re-allocated, which the freeze already makes unreachable — and the range
-is not contiguous anyway.
+The guard used to check properties of the id SET — no duplicates, min/max inside
+a window — and four independent review findings came out of that one choice,
+because a set-property is blind in two directions. It could not see a file the
+pattern failed to match (a 13-digit id was skipped in silence, in the guard AND
+in discovery, so the migration NEVER RAN), and it was invariant under mutations
+that preserve the endpoints (``0092`` sits inside ``0001..0093`` yet does not
+exist, so a hand-allocated ``0092_new.py`` passed; renaming a frozen file left
+the id set identical; deleting every legacy file left the legacy loop empty,
+which read as clean). Stating the contract as a total function over filenames is
+what closes all four, and closes the ones nobody has thought of yet.
 
-The guard replaced a shell glob+grep that could not survive mixed-width ids in
-either direction — MEASURED 2026-09-03: the 4-digit glob made timestamp
-migrations invisible to the guard, and widening the glob while keeping
-``grep -oP '^\\d{4}'`` truncated every ``20260903…`` id to ``2026``, so two
-distinct migrations reported as duplicates of each other.
+Fixtures bind to the REAL frozen set via the contract module rather than
+generating plausible names, because a generated ``0001_legacy.py`` is not a
+frozen filename and the guard is right to reject it — a fixture that hand-wrote
+the set would be testing the fixture.
 
 TWO LEVELS OF TEST HERE, and the second exists because the first cannot see
 CI's environment. Most cases call ``check()`` directly against a fake tree.
@@ -41,6 +42,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 _REPO = Path(__file__).resolve().parent.parent.parent
 _SCRIPT = _REPO / "scripts" / "check_migration_prefixes.py"
 _spec = importlib.util.spec_from_file_location("check_migration_prefixes", _SCRIPT)
@@ -48,12 +51,14 @@ _mod = importlib.util.module_from_spec(_spec)
 sys.modules["check_migration_prefixes"] = _mod
 _spec.loader.exec_module(_mod)
 
+_IDS = _mod._load_id_contract(_REPO)
+
 
 def _fake_repo(schema: list[str], data: list[str], *, tmp_path: Path) -> Path:
     """A minimal tree with both migration dirs and the REAL id-contract module.
 
     The contract is copied verbatim from the repo so the guard binds to the
-    genuine patterns AND the genuine freeze window — a fixture that hand-wrote
+    genuine patterns AND the genuine frozen set — a fixture that hand-wrote
     either would be testing the fixture, which is the exact defect this script
     exists to remove.
     """
@@ -72,14 +77,15 @@ def _fake_repo(schema: list[str], data: list[str], *, tmp_path: Path) -> Path:
 def _full_legacy(
     schema_extra: list[str] | None = None, data_extra: list[str] | None = None
 ) -> tuple[list[str], list[str]]:
-    """The legacy ids as they actually exist, plus extras.
+    """The frozen legacy files as they ACTUALLY exist, plus extras.
 
-    Mirrors the real shape rather than an idealised one: the schema range runs
-    0001..0091 and then 0093, with a GAP at 0092 left by a rename — which is
-    why the freeze window pins endpoints and NOT a count.
+    Read from the contract, not generated: the real schema set runs 0001..0091
+    and then 0093 — a GAP at 0092, left by a rename — and it was exactly that
+    gap that a range check could not express, admitting a brand-new
+    hand-allocated ``0092_new.py``.
     """
-    schema = [f"{i:04d}_legacy.py" for i in list(range(1, 92)) + [93]]
-    data = [f"d{i:04d}_legacy.py" for i in range(1, 12)]
+    schema = sorted(_IDS.FROZEN_LEGACY_FILES[_IDS.SCHEMA])
+    data = sorted(_IDS.FROZEN_LEGACY_FILES[_IDS.DATA])
     return schema + (schema_extra or []), data + (data_extra or [])
 
 
@@ -97,57 +103,198 @@ def test_clean_mixed_tree_passes(tmp_path):
     assert _mod.check(repo) == []
 
 
-def test_duplicate_timestamp_prefix_is_caught(tmp_path):
+def test_duplicate_timestamp_id_is_caught(tmp_path):
     """The residual the freeze cannot remove: two authors CAN hit the same
     second. Rare, but both runners still raise on it, so the guard still checks."""
     repo = _fake_repo(
-        *_full_legacy(["20260903200000_a.py", "20260903200000_b.py"]), tmp_path=tmp_path
+        *_full_legacy(["20260903200000_a.py", "20260903200000_b.py"]),
+        tmp_path=tmp_path,
     )
     out = _mod.check(repo)
-    assert any("duplicate prefix '20260903200000'" in v for v in out)
+    assert any("duplicate id '20260903200000'" in v for v in out)
 
 
-def test_duplicate_legacy_prefix_still_caught(tmp_path):
+def test_a_second_file_claiming_a_frozen_id_is_caught(tmp_path):
+    """The legacy half of "duplicate id", which the freeze now subsumes.
+
+    Two files can no longer share a LEGACY id without one of them being outside
+    the frozen set — the set holds one filename per id — so this is reported as
+    an illegal legacy id rather than reaching the duplicate arm. The duplicate
+    arm still matters for TIMESTAMP ids, where two authors really can collide
+    (covered above); this test pins that the file is refused either way, which
+    is the property that actually protects the tree.
+    """
     schema, data = _full_legacy()
     repo = _fake_repo(schema + ["0001_duplicate.py"], data, tmp_path=tmp_path)
     out = _mod.check(repo)
-    assert any("duplicate prefix '0001'" in v for v in out)
+    assert any("0001_duplicate.py" in v for v in out), out
 
 
-def test_a_NEW_legacy_prefix_ABOVE_the_window_is_refused(tmp_path):
-    """The freeze rule — the whole point. 0094 is the id a human would
-    hand-allocate next, and allocating is what made two branches collide."""
-    repo = _fake_repo(*_full_legacy(["0094_hand_allocated.py"]), tmp_path=tmp_path)
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "0094_hand_allocated.py",  # the id a human would allocate next
+        "0000_hand_allocated.py",  # below the old window; maximally order-divergent
+        "0092_gap.py",  # INSIDE the old lo..hi range, absent from the set
+    ],
+)
+def test_a_new_hand_allocated_legacy_id_is_refused(tmp_path, bad):
+    """The freeze rule — the whole point. Allocating is what made two branches
+    collide, so no new legacy-width id is admissible in any position.
+
+    ``0092`` is the case a range check structurally could not catch: it lies
+    between the endpoints, so only the enumerated set can tell it is not real.
+    """
+    repo = _fake_repo(*_full_legacy([bad]), tmp_path=tmp_path)
     out = _mod.check(repo)
-    freeze = [v for v in out if "allocates a NEW legacy-width id" in v]
-    assert any("0094" in v for v in freeze)
+    freeze = [v for v in out if "allocates the legacy-width id" in v]
+    assert any(bad in v for v in freeze), out
     assert any("date -u +%Y%m%d%H%M%S" in v for v in freeze)  # names the remedy
 
 
-def test_a_NEW_legacy_prefix_BELOW_the_window_is_refused(tmp_path):
-    """0000 is legacy-width, duplicates nothing, and slipped a one-sided
-    `prefix > mark` rule. It is also the maximally order-divergent id: first on
-    a fresh install, last on an existing one."""
-    repo = _fake_repo(*_full_legacy(["0000_hand_allocated.py"]), tmp_path=tmp_path)
+@pytest.mark.parametrize("bad", ["d0012_new.py", "d0000_hand.py"])
+def test_a_new_hand_allocated_legacy_data_id_is_refused(tmp_path, bad):
+    repo = _fake_repo(*_full_legacy(data_extra=[bad]), tmp_path=tmp_path)
     out = _mod.check(repo)
-    # The FREEZE-WINDOW arm specifically. Asserting on "0000" + "frozen" alone
-    # passed under a one-sided mutation, because the contiguity message names
-    # both too — a test that fires for the wrong reason is not a lock.
-    assert any(
-        "0000" in v and "allocates a NEW legacy-width id" in v for v in out
-    )
+    assert any(bad in v and "allocates the legacy-width id" in v for v in out)
 
 
-def test_a_NEW_legacy_data_prefix_is_refused(tmp_path):
-    repo = _fake_repo(*_full_legacy(data_extra=["d0012_new.py"]), tmp_path=tmp_path)
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "2026090320000_short.py",  # 13 digits
+        "202609032000000_long.py",  # 15 digits
+        "00000000000000_zero.py",  # 14 digits, not a calendar timestamp
+        "20261301000000_month13.py",
+        "20260932000000_day32.py",
+        "19990101000000_preepoch.py",  # would sort before the frozen namespace
+        "２０２６０９０４００００００_fullwidth.py",
+        "d0001_misfiled_data_in_schema_dir.py",
+    ],
+)
+def test_a_file_that_cannot_run_is_a_violation_not_a_skip(tmp_path, bad):
+    """The finding the set-shaped guard could not see at all.
+
+    Each of these was previously skipped by ``if m:`` — in the guard AND in
+    discovery — so the migration was found by nothing, never ran, and the code
+    needing it deployed against a schema that never got the change. Silent, and
+    indistinguishable from a clean tree.
+    """
+    repo = _fake_repo(*_full_legacy([bad]), tmp_path=tmp_path)
     out = _mod.check(repo)
-    assert any("d0012" in v and "allocates a NEW legacy-width id" in v for v in out)
+    assert any(bad in v for v in out), out
 
 
-def test_a_NEW_legacy_data_prefix_below_the_window_is_refused(tmp_path):
-    repo = _fake_repo(*_full_legacy(data_extra=["d0000_hand.py"]), tmp_path=tmp_path)
+def test_deleting_a_frozen_migration_is_caught(tmp_path):
+    """An id-set check cannot see this: min, max and count are all unchanged.
+
+    The COUNT is asserted, not just the victim's presence in the message.
+    Mutating the guard so it never records what it saw makes it report all 92
+    frozen files as missing — which still contains the victim's name, so an
+    ``assert victim in message`` passes while the guard has gone completely
+    blind. A test that cannot tell one missing file from ninety-two is not
+    locking the behaviour it claims to.
+    """
+    schema, data = _full_legacy()
+    victim = "0051_entity_layer.py"
+    repo = _fake_repo([s for s in schema if s != victim], data, tmp_path=tmp_path)
     out = _mod.check(repo)
-    assert any("d0000" in v and "allocates a NEW legacy-width id" in v for v in out)
+    missing = [v for v in out if "frozen legacy file(s) missing" in v]
+    assert len(missing) == 1, out
+    assert "1 frozen legacy file(s) missing" in missing[0], missing
+    assert victim in missing[0], missing
+    # A file that is still present must not be named.
+    assert "0050_canonicalize_bitemporal_ts.py" not in missing[0], missing
+
+
+def test_renaming_a_frozen_migration_is_caught(tmp_path):
+    """``0050_old.py`` -> ``0050_new.py`` leaves the id set IDENTICAL, while
+    installs that already applied ``0050`` skip the replacement forever and
+    fresh installs run it — two schemas, diverging, with nothing to notice."""
+    schema, data = _full_legacy()
+    victim = "0050_canonicalize_bitemporal_ts.py"
+    renamed = [s for s in schema if s != victim] + ["0050_renamed.py"]
+    repo = _fake_repo(renamed, data, tmp_path=tmp_path)
+    out = _mod.check(repo)
+    assert any(victim in v and "missing" in v for v in out), out
+    assert any("0050_renamed.py" in v for v in out), out
+
+
+def test_deleting_every_legacy_migration_is_caught(tmp_path):
+    """The empty-legacy hole: with one timestamp migration present the id map is
+    non-empty, so the legacy loop simply had nothing to iterate and reported
+    clean."""
+    _, data = _full_legacy()
+    repo = _fake_repo(["20260904120000_only.py"], data, tmp_path=tmp_path)
+    out = _mod.check(repo)
+    assert any("frozen legacy file(s) missing" in v for v in out), out
+
+
+def test_the_frozen_legacy_set_is_closed(tmp_path):
+    """The set's SIZE is pinned, so growing it cannot be a quiet side effect.
+
+    This is a speed bump, not enforcement, and the distinction is worth stating.
+    The guard reads FROZEN_LEGACY_FILES from the commit under test — it takes no
+    base ref and shells out to no git — so a single PR can add ``0094_x.py`` AND
+    add ``"0094_x.py"`` to the set, and every rule passes. Only an out-of-repo
+    reference (a merge-base diff, or a required human review) could actually
+    close it.
+
+    A merge-base diff was considered and declined: it needs the base ref in CI
+    (``fetch-depth: 0``) and would mean exec'ing a source file from another ref.
+    An unmet CI dependency is the exact bug that already bit this guard once —
+    it path-imported aiosqlite-bearing modules and exited 2 on every PR while
+    every test passed inside the venv — so buying enforcement with a new CI
+    dependency is a poor trade here.
+
+    What this DOES buy: the addition can no longer be silent. Anyone growing the
+    set must also change a number in a test whose name says the set is closed,
+    which is a deliberate act with a message attached at the moment it matters.
+    The error text deliberately does not advertise the set as a remedy either.
+
+    If you are here because this test failed: you are hand-allocating a
+    migration id, which is the thing this whole scheme removed. Use
+    ``date -u +%Y%m%d%H%M%S`` instead. The only legitimate reason to proceed is
+    a legacy-id migration that was authored before this scheme and has already
+    merged to the default branch.
+    """
+    assert len(_IDS.FROZEN_LEGACY_FILES[_IDS.SCHEMA]) == 92
+    assert len(_IDS.FROZEN_LEGACY_FILES[_IDS.DATA]) == 11
+
+
+def test_a_future_timestamp_id_is_refused(tmp_path):
+    """The ordering invariant's ceiling — the side nobody looked at.
+
+    The floor is guarded in the contract because a year >= the epoch forces a
+    leading '2'. Nothing bounded the top, and the typo that reaches it is more
+    likely than the widths that WERE caught: one wrong digit turns 2026 into
+    2926, a perfectly valid id that sorts after every migration anyone writes
+    for the next nine centuries — silent in discovery, in the guard, and in the
+    runner.
+    """
+    repo = _fake_repo(*_full_legacy(["29260903200000_typo_year.py"]), tmp_path=tmp_path)
+    out = _mod.check(repo)
+    assert any("FUTURE timestamp id" in v and "29260903200000" in v for v in out), out
+
+
+def test_a_recent_past_timestamp_is_not_flagged_as_future(tmp_path):
+    """The control: the ceiling must not redden ordinary work. A guard that
+    fires on a normal migration gets disabled by whoever hits it next."""
+    repo = _fake_repo(*_full_legacy(["20200101000000_old_but_fine.py"]), tmp_path=tmp_path)
+    assert _mod.check(repo) == []
+
+
+def test_a_migration_in_a_subdirectory_is_caught(tmp_path):
+    """Discovery is flat (importlib resolves a flat package), so a nested file
+    is discovered by nothing — the same never-runs silence as a mistyped width,
+    in the one shape a flat scan structurally cannot see."""
+    schema, data = _full_legacy()
+    repo = _fake_repo(schema, data, tmp_path=tmp_path)
+    nested = repo / "src/genesis/db/migrations/helpers"
+    nested.mkdir()
+    (nested / "20260904120000_buried.py").write_text("")
+    out = _mod.check(repo)
+    assert any("subdirectory" in v and "20260904120000_buried.py" in v for v in out), out
 
 
 def test_existing_legacy_ids_are_not_flagged(tmp_path):
@@ -157,13 +304,25 @@ def test_existing_legacy_ids_are_not_flagged(tmp_path):
     assert _mod.check(repo) == []
 
 
+def test_the_runners_own_modules_are_not_migrations(tmp_path):
+    """The residue rule must not swallow files that never presented as
+    migrations — they share the directory with every migration."""
+    schema, data = _full_legacy()
+    repo = _fake_repo(
+        schema + ["__init__.py", "runner.py", "__main__.py"],
+        data + ["__init__.py", "runner.py", "_util.py", "stale_embedding_repair.py"],
+        tmp_path=tmp_path,
+    )
+    assert _mod.check(repo) == []
+
+
 def test_an_empty_directory_is_an_anomaly_not_a_pass(tmp_path):
-    """91 migrations exist; a scan finding none did not describe the directory.
+    """92 migrations exist; a scan finding none did not describe the directory.
     Reporting CLEAN there is the seen-nothing-so-no-problem failure."""
     _, data = _full_legacy()
     repo = _fake_repo([], data, tmp_path=tmp_path)
     out = _mod.check(repo)
-    assert any("no files matched" in v for v in out)
+    assert any("no runnable migration found" in v for v in out), out
 
 
 def test_a_missing_directory_fails_closed_not_clean(tmp_path):
@@ -209,7 +368,8 @@ def test_ci_command_line_runs_at_all_on_the_real_tree():
     """BLOCKER regression: the first version of this guard bound to the runner
     modules, which import aiosqlite at module scope, so it exited 2 on every PR
     in a job that installs nothing — while every check()-level test passed
-    inside the venv. The id contract is stdlib-only so this stays true."""
+    inside the venv. The id contract is stdlib-only so this stays true, and
+    ``datetime`` (added for timestamp validation) keeps it true."""
     proc = _run_as_ci(_REPO)
     assert proc.returncode == 0, f"exit {proc.returncode}\n{proc.stdout}\n{proc.stderr}"
     assert "CLEAN" in proc.stdout

--- a/tests/test_scripts/test_check_migration_prefixes.py
+++ b/tests/test_scripts/test_check_migration_prefixes.py
@@ -1,0 +1,237 @@
+"""The migration-id CI guard (scripts/check_migration_prefixes.py).
+
+Two rules: no duplicate prefix in either namespace, and no NEW hand-allocated
+4-digit id — that namespace is frozen to the exact set that existed on
+2026-09-03 (0001..0091, d0001..d0011), enforced at BOTH ends plus its size.
+
+The both-ends part is load-bearing and was learned the hard way: a one-sided
+"above the freeze mark" rule let ``0000`` through, and ``0000`` is the worst
+possible id to miss — legacy-width, duplicating nothing, and ordering-divergent
+in the maximal way (on a fresh install it sorts first and runs before ``0001``;
+on an existing install every legacy id is already applied, so it runs last).
+The size check pins contiguity, so a DELETED legacy migration cannot silently
+free its id for re-allocation.
+
+The guard replaced a shell glob+grep that could not survive mixed-width ids in
+either direction — MEASURED 2026-09-03: the 4-digit glob made timestamp
+migrations invisible to the guard, and widening the glob while keeping
+``grep -oP '^\\d{4}'`` truncated every ``20260903…`` id to ``2026``, so two
+distinct migrations reported as duplicates of each other.
+
+TWO LEVELS OF TEST HERE, and the second exists because the first cannot see
+CI's environment. Most cases call ``check()`` directly against a fake tree.
+``test_ci_command_line_*`` instead runs the script the way ci.yml runs it —
+bare interpreter, no venv, no PYTHONPATH — because the first version of this
+guard path-imported the RUNNER modules (which carry module-scope
+``import aiosqlite``) and therefore exited 2 on every PR, enforcing nothing,
+while every check()-level test passed inside the project venv. That test is
+also the only thing asserting violations reach a NONZERO EXIT: mutating
+``return 1`` to ``return 0`` in ``main()`` left the whole suite green, printing
+red annotations on a passing job.
+
+Filesystem-only: no network, no DB, no gh.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+_SCRIPT = _REPO / "scripts" / "check_migration_prefixes.py"
+_spec = importlib.util.spec_from_file_location("check_migration_prefixes", _SCRIPT)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["check_migration_prefixes"] = _mod
+_spec.loader.exec_module(_mod)
+
+
+def _fake_repo(schema: list[str], data: list[str], *, tmp_path: Path) -> Path:
+    """A minimal tree with both migration dirs and the REAL id-contract module.
+
+    The contract is copied verbatim from the repo so the guard binds to the
+    genuine patterns AND the genuine freeze window — a fixture that hand-wrote
+    either would be testing the fixture, which is the exact defect this script
+    exists to remove.
+    """
+    for rel in ("src/genesis/db/migrations", "src/genesis/db/data_migrations"):
+        (tmp_path / rel).mkdir(parents=True)
+    (tmp_path / "src/genesis/db/_migration_ids.py").write_text(
+        (_REPO / "src/genesis/db/_migration_ids.py").read_text()
+    )
+    for name in schema:
+        (tmp_path / "src/genesis/db/migrations" / name).write_text("")
+    for name in data:
+        (tmp_path / "src/genesis/db/data_migrations" / name).write_text("")
+    return tmp_path
+
+
+def _full_legacy(
+    schema_extra: list[str] | None = None, data_extra: list[str] | None = None
+) -> tuple[list[str], list[str]]:
+    """The complete frozen window (0001..0091 / d0001..d0011), plus extras.
+
+    Contiguity is enforced, so a fixture laying down only a couple of legacy
+    files is itself a violation — every freeze/duplicate case must start from
+    the real window or it would trip the contiguity rule by accident and pass
+    for the wrong reason.
+    """
+    schema = [f"{i:04d}_legacy.py" for i in range(1, 92)] + (schema_extra or [])
+    data = [f"d{i:04d}_legacy.py" for i in range(1, 12)] + (data_extra or [])
+    return schema, data
+
+
+def test_real_repo_is_clean():
+    """The acceptance baseline: the guard must pass on the ACTUAL tree, or it
+    is measuring something other than what ships."""
+    assert _mod.check(_REPO) == []
+
+
+def test_clean_mixed_tree_passes(tmp_path):
+    repo = _fake_repo(
+        *_full_legacy(["20260903200000_new.py"], ["d20260903200000_new.py"]),
+        tmp_path=tmp_path,
+    )
+    assert _mod.check(repo) == []
+
+
+def test_duplicate_timestamp_prefix_is_caught(tmp_path):
+    """The residual the freeze cannot remove: two authors CAN hit the same
+    second. Rare, but both runners still raise on it, so the guard still checks."""
+    repo = _fake_repo(
+        *_full_legacy(["20260903200000_a.py", "20260903200000_b.py"]), tmp_path=tmp_path
+    )
+    out = _mod.check(repo)
+    assert any("duplicate prefix '20260903200000'" in v for v in out)
+
+
+def test_duplicate_legacy_prefix_still_caught(tmp_path):
+    schema, data = _full_legacy()
+    repo = _fake_repo(schema + ["0001_duplicate.py"], data, tmp_path=tmp_path)
+    out = _mod.check(repo)
+    assert any("duplicate prefix '0001'" in v for v in out)
+
+
+def test_a_NEW_legacy_prefix_ABOVE_the_window_is_refused(tmp_path):
+    """The freeze rule — the whole point. 0092 is the id a human would
+    hand-allocate next, and allocating is what made two branches collide."""
+    repo = _fake_repo(*_full_legacy(["0092_hand_allocated.py"]), tmp_path=tmp_path)
+    out = _mod.check(repo)
+    freeze = [v for v in out if "allocates a NEW legacy-width id" in v]
+    assert any("0092" in v for v in freeze)
+    assert any("date -u +%Y%m%d%H%M%S" in v for v in freeze)  # names the remedy
+
+
+def test_a_NEW_legacy_prefix_BELOW_the_window_is_refused(tmp_path):
+    """0000 is legacy-width, duplicates nothing, and slipped a one-sided
+    `prefix > mark` rule. It is also the maximally order-divergent id: first on
+    a fresh install, last on an existing one."""
+    repo = _fake_repo(*_full_legacy(["0000_hand_allocated.py"]), tmp_path=tmp_path)
+    out = _mod.check(repo)
+    # The FREEZE-WINDOW arm specifically. Asserting on "0000" + "frozen" alone
+    # passed under a one-sided mutation, because the contiguity message names
+    # both too — a test that fires for the wrong reason is not a lock.
+    assert any(
+        "0000" in v and "allocates a NEW legacy-width id" in v for v in out
+    )
+
+
+def test_a_NEW_legacy_data_prefix_is_refused(tmp_path):
+    repo = _fake_repo(*_full_legacy(data_extra=["d0012_new.py"]), tmp_path=tmp_path)
+    out = _mod.check(repo)
+    assert any("d0012" in v and "allocates a NEW legacy-width id" in v for v in out)
+
+
+def test_a_NEW_legacy_data_prefix_below_the_window_is_refused(tmp_path):
+    repo = _fake_repo(*_full_legacy(data_extra=["d0000_hand.py"]), tmp_path=tmp_path)
+    out = _mod.check(repo)
+    assert any("d0000" in v and "allocates a NEW legacy-width id" in v for v in out)
+
+
+def test_a_DELETED_legacy_migration_is_caught(tmp_path):
+    """Deleting a legacy file frees its id for silent re-allocation — the one
+    way the frozen set can change without anyone deciding to change it."""
+    schema, data = _full_legacy()
+    repo = _fake_repo([s for s in schema if not s.startswith("0050")], data, tmp_path=tmp_path)
+    out = _mod.check(repo)
+    # The CONTIGUITY arm specifically — the mirror of the freeze-window tests.
+    assert any("should hold exactly 91" in v for v in out)
+    assert not any("allocates a NEW legacy-width id" in v for v in out)
+
+
+def test_existing_legacy_ids_are_not_flagged(tmp_path):
+    """The freeze must not fire on the ids that already exist — a guard that
+    reddens the untouched tree gets disabled by whoever hits it next."""
+    repo = _fake_repo(*_full_legacy(), tmp_path=tmp_path)
+    assert _mod.check(repo) == []
+
+
+def test_an_empty_directory_is_an_anomaly_not_a_pass(tmp_path):
+    """91 migrations exist; a scan finding none did not describe the directory.
+    Reporting CLEAN there is the seen-nothing-so-no-problem failure."""
+    _, data = _full_legacy()
+    repo = _fake_repo([], data, tmp_path=tmp_path)
+    out = _mod.check(repo)
+    assert any("no files matched" in v for v in out)
+
+
+def test_a_missing_directory_fails_closed_not_clean(tmp_path):
+    """The id contract lives OUTSIDE the migration dirs now, so a missing
+    directory no longer fails at load — it must be a violation, never a scan
+    that quietly examined nothing and reported clean."""
+    schema, data = _full_legacy()
+    repo = _fake_repo(schema, data, tmp_path=tmp_path)
+    for f in (repo / "src/genesis/db/data_migrations").iterdir():
+        f.unlink()
+    (repo / "src/genesis/db/data_migrations").rmdir()
+    out = _mod.check(repo)
+    assert any("directory not found" in v and "nothing was scanned" in v for v in out)
+
+
+def test_plumbing_failure_exits_2_never_0(tmp_path, monkeypatch, capsys):
+    """A guard that cannot run must not report clean. Exit 2 is distinct from
+    exit 1 (real violations) so CI can tell them apart."""
+    monkeypatch.setattr(sys, "argv", ["check", "--repo-root", str(tmp_path / "nope")])
+    assert _mod.main() == 2
+    assert "could not run" in capsys.readouterr().err
+
+
+def test_clean_run_exits_0_and_says_so(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["check", "--repo-root", str(_REPO)])
+    assert _mod.main() == 0
+    assert "CLEAN" in capsys.readouterr().out
+
+
+def _run_as_ci(repo_root: Path) -> subprocess.CompletedProcess:
+    """Run the script EXACTLY as ci.yml does: a bare interpreter with no venv,
+    no PYTHONPATH, and nothing pip-installed."""
+    return subprocess.run(
+        [sys.executable, "-E", "-S", str(_SCRIPT), "--repo-root", str(repo_root)],
+        capture_output=True,
+        text=True,
+        cwd=str(_REPO),
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "HOME": str(repo_root)},
+    )
+
+
+def test_ci_command_line_runs_at_all_on_the_real_tree():
+    """BLOCKER regression: the first version of this guard bound to the runner
+    modules, which import aiosqlite at module scope, so it exited 2 on every PR
+    in a job that installs nothing — while every check()-level test passed
+    inside the venv. The id contract is stdlib-only so this stays true."""
+    proc = _run_as_ci(_REPO)
+    assert proc.returncode == 0, f"exit {proc.returncode}\n{proc.stdout}\n{proc.stderr}"
+    assert "CLEAN" in proc.stdout
+
+
+def test_ci_command_line_exits_NONZERO_on_a_violation(tmp_path):
+    """The block/pass wiring, which no check()-level test can reach: mutating
+    main()'s `return 1` to `return 0` printed every ::error:: annotation and
+    still exited 0 — red annotations on a green job, the most convincing form
+    of reporting clean when it is not."""
+    repo = _fake_repo(*_full_legacy(["0092_hand_allocated.py"]), tmp_path=tmp_path)
+    proc = _run_as_ci(repo)
+    assert proc.returncode == 1, f"exit {proc.returncode}\n{proc.stdout}\n{proc.stderr}"
+    assert "0092" in proc.stdout and "frozen" in proc.stdout

--- a/tests/test_scripts/test_check_migration_prefixes.py
+++ b/tests/test_scripts/test_check_migration_prefixes.py
@@ -384,3 +384,150 @@ def test_ci_command_line_exits_NONZERO_on_a_violation(tmp_path):
     proc = _run_as_ci(repo)
     assert proc.returncode == 1, f"exit {proc.returncode}\n{proc.stdout}\n{proc.stderr}"
     assert "0094" in proc.stdout and "frozen" in proc.stdout
+
+
+# --- Immutability against what is ALREADY MERGED (Codex P1, PR #1678) -------
+# FROZEN_LEGACY_FILES is a hand-maintained snapshot of one closed set. It cannot
+# grow to cover timestamp migrations — they are unbounded — so the moment the
+# first one merges, a later PR can delete it or rename it to another perfectly
+# valid timestamp and every other rule still reports CLEAN. "Already merged" is
+# a fact only git holds, so the guard asks git.
+
+
+def _git(repo: Path, *args: str) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+    return out.stdout
+
+
+def _committed_repo(tmp_path: Path, *, extra_schema: list[str] | None = None) -> tuple[Path, str]:
+    """A fake repo whose CURRENT tree is committed. Returns (repo, base_sha)."""
+    schema, data = _full_legacy(extra_schema or [])
+    repo = _fake_repo(schema, data, tmp_path=tmp_path)
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+    return repo, _git(repo, "rev-parse", "HEAD").strip()
+
+
+# A real, well-formed timestamp id — the namespace the enumerated list can
+# never cover, which is the whole point of the finding.
+_MERGED_TS = "20260101000000_add_a_column.py"
+
+
+def test_deleting_an_already_merged_timestamp_migration_is_caught(tmp_path):
+    """THE acceptance replay, and it shows the hole and the fix in one run.
+
+    Nothing in the enumerated frozen set mentions this file — the set is closed
+    and covers only legacy ids — so EVERY other rule reports clean while existing
+    installs keep its id in their ledger and skip the replacement forever. The
+    first assertion pins that: without a base there is nothing to notice with,
+    which is the state the finding describes rather than a bug in this test. The
+    second is what the base buys.
+    """
+    repo, base = _committed_repo(tmp_path, extra_schema=[_MERGED_TS])
+    (repo / "src/genesis/db/migrations" / _MERGED_TS).unlink()
+
+    assert _mod.check(repo) == [], (
+        "the deletion is invisible without a base — if this ever fails, some "
+        "other rule now covers it and this test is no longer measuring the base"
+    )
+    violations = _mod.check(repo, base_ref=base)
+    assert any(_MERGED_TS in v and "already-merged" in v for v in violations), violations
+
+
+def test_renaming_an_already_merged_timestamp_migration_is_caught(tmp_path):
+    """A rename is a delete plus an add, so it needs no rename detection to be
+    caught — and it is the more dangerous shape, because the id set still has
+    the same size and the body still exists to read."""
+    repo, base = _committed_repo(tmp_path, extra_schema=[_MERGED_TS])
+    d = repo / "src/genesis/db/migrations"
+    (d / _MERGED_TS).rename(d / "20260101000000_add_a_column_v2.py")
+
+    violations = _mod.check(repo, base_ref=base)
+    assert any(_MERGED_TS in v for v in violations), violations
+
+
+def test_an_unchanged_tree_is_clean_against_its_own_base(tmp_path):
+    """CONTROL. The rule must not fire on the ordinary case, or it fails every
+    PR and gets switched off."""
+    repo, base = _committed_repo(tmp_path, extra_schema=[_MERGED_TS])
+    assert _mod.check(repo, base_ref=base) == []
+
+
+def test_adding_a_new_timestamp_migration_is_clean(tmp_path):
+    """CONTROL, and the one that matters most: the rule freezes what exists, it
+    does not freeze the directory."""
+    repo, base = _committed_repo(tmp_path, extra_schema=[_MERGED_TS])
+    (repo / "src/genesis/db/migrations" / "20260202000000_new_work.py").write_text("")
+    assert _mod.check(repo, base_ref=base) == []
+
+
+def test_a_malformed_file_on_the_base_may_be_removed(tmp_path):
+    """Deleting a file that never RAN is a fix, not a regression — a 13-digit id
+    is discovered by nothing, so no install has it in a ledger. Filtering the
+    base list through the same classify() keeps the rule from defending files it
+    should be reporting."""
+    repo, base = _committed_repo(tmp_path)
+    d = repo / "src/genesis/db/migrations"
+    (d / "2026010100000_short.py").write_text("")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "add a malformed file")
+    base2 = _git(repo, "rev-parse", "HEAD").strip()
+    (d / "2026010100000_short.py").unlink()
+
+    assert _mod.check(repo, base_ref=base2) == []
+
+
+def test_an_unreadable_explicit_base_is_a_violation_not_a_pass(tmp_path):
+    """A guard TOLD to compare, that then compares nothing, is the silent pass
+    this whole script exists to remove — a shallow CI checkout would produce
+    exactly this and read as clean."""
+    repo, _ = _committed_repo(tmp_path)
+    violations = _mod.check(repo, base_ref="no-such-ref-ffffffff")
+    assert violations and all("could not be read" in v for v in violations), violations
+
+
+def test_no_base_at_all_degrades_instead_of_failing(tmp_path):
+    """CONTROL on the fail direction. A fork running this from a tarball has no
+    base to compare against and must not be failed for it — the rule is skipped,
+    every other rule still applies."""
+    schema, data = _full_legacy()
+    repo = _fake_repo(schema, data, tmp_path=tmp_path)  # never git-init'ed
+    assert _mod.check(repo) == []
+
+
+# --- The ID is ASCII; the DESCRIPTION is not (Codex P2, PR #1678) -----------
+
+
+@pytest.mark.parametrize("name", ["0094_café.py", "20260101000000_修復.py"])
+def test_a_unicode_description_is_a_legal_migration(tmp_path, name):
+    """Only the id participates in ordering and uniqueness, so only the id needs
+    a codepoint guarantee. Restricting the description too was collateral, and
+    it broke names that import fine today: a fork carrying one would have had
+    discovery start RAISING — aborting database init on the schema side — over a
+    naming preference of ours.
+
+    `0094_café.py` is a hand-allocated legacy id, so the guard still refuses it
+    as a POLICY violation; what must not happen is MALFORMED, which means "no
+    runner will ever discover this".
+    """
+    assert _IDS.classify(_IDS.SCHEMA, name) != _IDS.MALFORMED
+
+
+def test_a_unicode_digit_in_the_ID_is_still_malformed(tmp_path):
+    """The control on the other side, and the reason the two halves differ: a
+    full-width digit sorts nowhere near the ASCII ids the ordering invariant is
+    stated over, so it must stay a violation."""
+    assert _IDS.classify(_IDS.SCHEMA, "２０２６０１０１０００００_x.py") == _IDS.MALFORMED

--- a/tests/test_scripts/test_check_migration_prefixes.py
+++ b/tests/test_scripts/test_check_migration_prefixes.py
@@ -170,6 +170,10 @@ def test_a_new_hand_allocated_legacy_data_id_is_refused(tmp_path, bad):
         "19990101000000_preepoch.py",  # would sort before the frozen namespace
         "２０２６０９０４００００００_fullwidth.py",
         "d0001_misfiled_data_in_schema_dir.py",
+        "dd20260904000000_doubled_prefix.py",  # candidate net was ^d?\d — skipped
+        "D20260904000000_capitalised.py",  # same class, capitalised d
+        "ｄ２０２６０９０４００００００_fullwidth_prefix.py",  # same IME generator, prefix position
+        "20260904000000_case_mangled.PY",  # perfect id, Python never imports it
     ],
 )
 def test_a_file_that_cannot_run_is_a_violation_not_a_skip(tmp_path, bad):
@@ -457,6 +461,35 @@ def test_renaming_an_already_merged_timestamp_migration_is_caught(tmp_path):
 
     violations = _mod.check(repo, base_ref=base)
     assert any(_MERGED_TS in v for v in violations), violations
+
+
+def test_a_unicode_named_merged_migration_deletion_is_still_caught(tmp_path):
+    """The immutability rule must survive git's own quoting layer.
+
+    ``git ls-tree --name-only`` C-quotes non-ASCII paths by default
+    (``"…caf\\303\\251.py"``, quotes included — MEASURED 2026-09-04), and the
+    quoted form matches no classify() verdict, so without ``-z`` a
+    Unicode-named migration silently drops out of base_names and its deletion
+    reads as CLEAN. This composes two earlier findings: Unicode descriptions
+    are legal (round 2), and already-merged migrations are immutable (round 2)
+    — legal name + immutability rule must not cancel each other at the
+    encoding boundary.
+    """
+    unicode_ts = "20260101000000_café.py"
+    repo, base = _committed_repo(tmp_path, extra_schema=[unicode_ts])
+    (repo / "src/genesis/db/migrations" / unicode_ts).unlink()
+
+    violations = _mod.check(repo, base_ref=base)
+    assert any(unicode_ts in v and "already-merged" in v for v in violations), violations
+
+
+def test_a_unicode_named_migration_present_on_both_sides_is_clean(tmp_path):
+    """CONTROL for the quoting fix: the raw-bytes name must round-trip through
+    ls-tree and match the on-disk scan, or every Unicode migration would fire
+    the missing-file arm on every build."""
+    unicode_ts = "20260101000000_café.py"
+    repo, base = _committed_repo(tmp_path, extra_schema=[unicode_ts])
+    assert _mod.check(repo, base_ref=base) == []
 
 
 def test_an_unchanged_tree_is_clean_against_its_own_base(tmp_path):

--- a/tests/test_scripts/test_check_migration_prefixes.py
+++ b/tests/test_scripts/test_check_migration_prefixes.py
@@ -2,15 +2,16 @@
 
 Two rules: no duplicate prefix in either namespace, and no NEW hand-allocated
 4-digit id — that namespace is frozen to the exact set that existed on
-2026-09-03 (0001..0091, d0001..d0011), enforced at BOTH ends plus its size.
+2026-09-04 (0001..0093 with a gap at 0092, d0001..d0011), enforced at BOTH ends.
 
 The both-ends part is load-bearing and was learned the hard way: a one-sided
 "above the freeze mark" rule let ``0000`` through, and ``0000`` is the worst
 possible id to miss — legacy-width, duplicating nothing, and ordering-divergent
 in the maximal way (on a fresh install it sorts first and runs before ``0001``;
 on an existing install every legacy id is already applied, so it runs last).
-The size check pins contiguity, so a DELETED legacy migration cannot silently
-free its id for re-allocation.
+Deliberately no size/contiguity check: it would only catch a deleted legacy id
+being re-allocated, which the freeze already makes unreachable — and the range
+is not contiguous anyway.
 
 The guard replaced a shell glob+grep that could not survive mixed-width ids in
 either direction — MEASURED 2026-09-03: the 4-digit glob made timestamp
@@ -71,16 +72,15 @@ def _fake_repo(schema: list[str], data: list[str], *, tmp_path: Path) -> Path:
 def _full_legacy(
     schema_extra: list[str] | None = None, data_extra: list[str] | None = None
 ) -> tuple[list[str], list[str]]:
-    """The complete frozen window (0001..0091 / d0001..d0011), plus extras.
+    """The legacy ids as they actually exist, plus extras.
 
-    Contiguity is enforced, so a fixture laying down only a couple of legacy
-    files is itself a violation — every freeze/duplicate case must start from
-    the real window or it would trip the contiguity rule by accident and pass
-    for the wrong reason.
+    Mirrors the real shape rather than an idealised one: the schema range runs
+    0001..0091 and then 0093, with a GAP at 0092 left by a rename — which is
+    why the freeze window pins endpoints and NOT a count.
     """
-    schema = [f"{i:04d}_legacy.py" for i in range(1, 92)] + (schema_extra or [])
-    data = [f"d{i:04d}_legacy.py" for i in range(1, 12)] + (data_extra or [])
-    return schema, data
+    schema = [f"{i:04d}_legacy.py" for i in list(range(1, 92)) + [93]]
+    data = [f"d{i:04d}_legacy.py" for i in range(1, 12)]
+    return schema + (schema_extra or []), data + (data_extra or [])
 
 
 def test_real_repo_is_clean():
@@ -115,12 +115,12 @@ def test_duplicate_legacy_prefix_still_caught(tmp_path):
 
 
 def test_a_NEW_legacy_prefix_ABOVE_the_window_is_refused(tmp_path):
-    """The freeze rule — the whole point. 0092 is the id a human would
+    """The freeze rule — the whole point. 0094 is the id a human would
     hand-allocate next, and allocating is what made two branches collide."""
-    repo = _fake_repo(*_full_legacy(["0092_hand_allocated.py"]), tmp_path=tmp_path)
+    repo = _fake_repo(*_full_legacy(["0094_hand_allocated.py"]), tmp_path=tmp_path)
     out = _mod.check(repo)
     freeze = [v for v in out if "allocates a NEW legacy-width id" in v]
-    assert any("0092" in v for v in freeze)
+    assert any("0094" in v for v in freeze)
     assert any("date -u +%Y%m%d%H%M%S" in v for v in freeze)  # names the remedy
 
 
@@ -148,17 +148,6 @@ def test_a_NEW_legacy_data_prefix_below_the_window_is_refused(tmp_path):
     repo = _fake_repo(*_full_legacy(data_extra=["d0000_hand.py"]), tmp_path=tmp_path)
     out = _mod.check(repo)
     assert any("d0000" in v and "allocates a NEW legacy-width id" in v for v in out)
-
-
-def test_a_DELETED_legacy_migration_is_caught(tmp_path):
-    """Deleting a legacy file frees its id for silent re-allocation — the one
-    way the frozen set can change without anyone deciding to change it."""
-    schema, data = _full_legacy()
-    repo = _fake_repo([s for s in schema if not s.startswith("0050")], data, tmp_path=tmp_path)
-    out = _mod.check(repo)
-    # The CONTIGUITY arm specifically — the mirror of the freeze-window tests.
-    assert any("should hold exactly 91" in v for v in out)
-    assert not any("allocates a NEW legacy-width id" in v for v in out)
 
 
 def test_existing_legacy_ids_are_not_flagged(tmp_path):
@@ -231,7 +220,7 @@ def test_ci_command_line_exits_NONZERO_on_a_violation(tmp_path):
     main()'s `return 1` to `return 0` printed every ::error:: annotation and
     still exited 0 — red annotations on a green job, the most convincing form
     of reporting clean when it is not."""
-    repo = _fake_repo(*_full_legacy(["0092_hand_allocated.py"]), tmp_path=tmp_path)
+    repo = _fake_repo(*_full_legacy(["0094_hand_allocated.py"]), tmp_path=tmp_path)
     proc = _run_as_ci(repo)
     assert proc.returncode == 1, f"exit {proc.returncode}\n{proc.stdout}\n{proc.stderr}"
-    assert "0092" in proc.stdout and "frozen" in proc.stdout
+    assert "0094" in proc.stdout and "frozen" in proc.stdout


### PR DESCRIPTION
## The problem

A migration id had to be **chosen**, so two branches routinely chose the same one.
Measured 2026-09-03: one PR was renumbered twice in a single day, and four open PRs
held live collisions. A duplicate is not cosmetic — `migrations/runner.py`'s pre-flight
raises before `get_pending()`, so a duplicate prefix halts **every** migration on
**every** install at the next restart.

Detecting collisions at merge time was tried first (#1666) and hit the review escalation
cap: the detector had to model an open set — a five-endpoint GitHub read with per-site
field trust — and no finite audit bounds that. Prevention is smaller than detection here.

## The change

New migrations carry a UTC timestamp id, `date -u +%Y%m%d%H%M%S`. **Nobody allocates a
timestamp; the clock does**, so two branches cannot claim the same one. The legacy
hand-allocated 4-digit ids are frozen.

Ordering is unchanged in practice: every frozen legacy id begins with `0` and every
timestamp id is a real calendar year ≥ 2020 and so begins with `2`, so lexicographic
order keeps the frozen history ahead of all new work — in Python's `sorted()` and in
SQLite's `TEXT` collation on the ledger, both exercised by a test rather than asserted
in prose.

## The contract is a total function over filenames

The first version of this PR checked properties of the id **set** — no duplicates,
min/max inside a frozen window. Review found four independent defects from that one
choice, because a set-property is blind in two directions: it never sees a file the
pattern failed to match, and it is invariant under mutations that preserve the endpoints.

- A mistyped `2026090320000_x.py` (13 digits) matched nothing, so `if m:` skipped it — in
  the guard **and** in `_migration_discovery`. The migration was discovered by nothing,
  never ran, and the code needing it deployed against a schema that never got the change.
- `00000000000000` is 14 digits, so the width test called it not-legacy and the freeze
  check never looked at it. It sorts before `0001` on a fresh install and last on an
  existing one.
- `0092` lies **inside** `0001..0093` and does not exist — the id was consumed by a
  rename — so an endpoint check admitted a brand-new hand-allocated `0092_new.py`.
- Renaming `0050_old.py` to `0050_new.py`, or deleting a frozen file, leaves the id set
  identical while existing installs skip the replacement forever and fresh installs run
  it.

So the contract is stated the other way round. Every filename is classified: it **is** a
frozen legacy migration, **is** a well-formed timestamp migration, or **is not** a
migration at all — and anything left over is a violation. Adding a new way to be wrong no
longer requires a new rule. The legacy set is **enumerated**, not bounded, because a
range cannot express the `0092` gap.

## The runtime and CI differ in strictness, deliberately

Discovery refuses only files that **cannot run**. A well-formed 4-digit id outside this
repo's frozen set is uniquely numbered, sorts correctly and applies cleanly — it breaks a
policy of ours, not an invariant of the install running it. Discovery sits on the
boot-abort path (`runtime/init/db.py` re-raises; `_core` stops bootstrap when the DB step
fails), so enforcing our namespace there would leave a downstream fork carrying its own
`0094_*.py` with **no database** after a pull, over the only convention that existed
before this change. The runtime runs it and warns; CI refuses it.

## The CI check moved out of shell

The old glob+grep restated the runners' filename semantics in a second language and could
not survive mixed-width ids in **either** direction (both measured 2026-09-03): the
4-digit glob made timestamp migrations invisible to the guard, and widening the glob while
keeping `grep -oP '^\d{4}'` truncated every `20260903…` id to `2026`, reporting two
distinct migrations as duplicates of each other.

`scripts/check_migration_prefixes.py` imports the authoritative contract instead. It binds
to `src/genesis/db/_migration_ids.py` and **not** to the runners — that was the first
attempt, and the runners carry module-scope `import aiosqlite`, so the guard pulled 117
modules into a job that installs nothing and exited 2 on every PR, enforcing neither rule
while every test passed inside the venv. The contract module is stdlib-only precisely so
the path import is safe under a bare `python3`, and a subprocess test runs the script the
way CI runs it so that premise cannot rot.

CI enforces five rules, all fail-closed: every file classifies as a legal migration; no
duplicate id; every frozen legacy file still present under its own name; no future-dated
timestamp (one wrong digit makes `2926`, a valid id that sorts after everything for nine
centuries); and no migration buried in a subdirectory, which flat discovery structurally
cannot see.

## What is deliberately not here

**Content-pinning of the frozen migrations.** Freezing filenames stops renames and
deletions but not edits, and edits happen: measured across the 92 legacy schema
migrations, `0051_entity_layer.py` was edited 8 days after it merged and
`0015_rename_confusable_call_sites.py` about two months after. That is the same
fresh-vs-existing divergence one level down. It needs a repo-wide decision — every future
edit to an applied migration becomes a CI failure requiring a hash bump — so it is tracked
separately rather than smuggled in here.

**True closure of the frozen set.** The guard reads the set from the commit under test, so
one PR can add a legacy migration *and* add it to the set. Closing that needs an
out-of-repo reference (a merge-base diff), which would mean requiring `fetch-depth: 0` and
executing a source file from another ref — buying enforcement with exactly the kind of CI
dependency that already broke this guard once. Instead the set's size is pinned by a test
that names the rule, and the error text no longer advertises the set as a remedy, so
growing it cannot be a quiet side effect.

## Verification

- `ruff` clean; 175 targeted tests.
- **Acceptance replay, 22/22**: every review finding reproduced against the guard —
  13- and 15-digit widths, all-zero and impossible-calendar timestamps, pre-epoch ids,
  full-width Unicode digits, a new legacy id above/below/inside the window, a renamed
  frozen file, a deleted one, deleting the entire legacy set, duplicate timestamps, and
  misfiled `d`-prefixes in both directions.
- **Mutation sweep, 21/21 RED**, each anchor-unique and compile-checked, with
  hash-verified restore and an abort on any run that produced no result.
- **E2E on a fresh database**: 92/92 migrations applied, 48 tables, 0 pending.
- The guard verified under a bare CI interpreter (`env -i`, no venv, nothing installed).

## Consequence for in-flight PRs

Three open PRs carry legacy-id migrations and will need renaming to timestamps once this
lands: #1576 (`0090_federation.py`, which duplicates `0090_ws2_calibration_sunset.py`
already on main), #1610 and #1616 (two different `0092_*.py`, which also collide with each
other). Git merges those two cleanly because the paths differ, and nothing on main detects
it until the next boot.

Closes #1666's problem by prevention; that PR closes unmerged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New schema and data migrations use UTC timestamp-based IDs, while existing legacy IDs remain supported.
  * Migration validation detects duplicate, malformed, future, and unauthorized legacy identifiers.

* **Bug Fixes**
  * Migration discovery consistently recognizes and orders legacy and timestamp-based migrations.
  * Invalid migration filenames are reported instead of silently skipped.
  * CI checks prevent naming violations and deletion or renaming of frozen migrations.

* **Documentation**
  * Updated migration naming, validation, preservation, and ordering guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->