### PR TITLE
fix(hooks): the wrong-repo check now says when it did not run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The wrong-repo commit check now says when it did not run.** It works out which
+  repository a `git add`/`commit` targets by reading the command text, and when that
+  text did not determine a directory — a shell variable, a command substitution, a
+  glob — it joined the unexpanded token onto the current path anyway. The result
+  cannot exist, so every lookup against it failed and the check was skipped through
+  the same branch that means "this repository is not covered". A command it could
+  not inspect was therefore indistinguishable from one it deliberately ignored.
+  It now reports that the check did not run, on **119 of 2,264 (5.3%)** real
+  `add`/`commit` commands. Deliberately an advisory and **not** a new refusal:
+  replaying those same 119 through the old behaviour, it blocked **0** of them —
+  it was failing open, so nobody has ever been wrongly stopped by this, and making
+  it refuse would newly stop 119 ordinary commands to fix a silence.
+
 - **The cold-marketing campaign no longer re-pitches the same person.** Once a
   marketing pitch is delivered to a prospect, that prospect is marked contacted and
   drops out of the campaign's target list — previously nothing recorded the contact,

--- a/scripts/hooks/repo_routing_guard.py
+++ b/scripts/hooks/repo_routing_guard.py
@@ -87,9 +87,74 @@ def _load_topology() -> dict | None:
 
 _SHELL_OPS = {"&&", "||", ";", "|", "&"}
 
+# Characters bash would ACT on, so reading the token literally would name a
+# DIFFERENT directory than the one bash enters: parameter expansion, command
+# substitution, and globs.
+#
+# DELIBERATELY NARROW, and the narrowness is the point. shlex has already erased
+# the quoting by the time a token reaches here, so a wider class cannot tell an
+# expansion from a quoted LITERAL that merely contains the same character. A
+# first version added `[{()<>` and MEASURED a real cost: `cd '/srv/a (wt)'`
+# names a directory that exists, is a git repo and held a wrong-repo hit, and
+# the guard stopped checking it. The class was over-covering as well as
+# under-covering — an open set in both directions.
+#
+# The positive validation in main() (`not os.path.isdir(git_dir)`) closes the
+# rest of the class without enumerating anything: a bracket-glob that expands to
+# nothing, a brace expression, a literal that does not exist — all fail the
+# is-it-a-real-directory test and are reported. Enumerating what bash expands
+# only ever catches the constructs somebody thought of; asking whether the
+# answer exists catches the ones nobody did.
+#
+# NOT a parity claim: the sibling resolvers (git_push_guard,
+# review_enforcement_commit, pre_push_privacy_review) each carry their OWN
+# class and they are NOT identical — review_enforcement_commit's is wider and
+# also handles `cd -`, a bare `cd` and CDPATH. An earlier comment here asserted
+# they matched; they do not. Canonicalizing the four copies is filed as a
+# follow-up rather than done here, because the shared module it belongs in is
+# being edited by another open branch.
+_UNRESOLVABLE_DIR_CHARS = "$`*?"
 
-def _parse_git_invocations(cmd: str) -> list[tuple[str, list[str], str]]:
+
+def _resolve_dir(base: str | None, token: str) -> str | None:
+    """Absolute directory a ``cd``/``-C`` lands in, or None if unknowable.
+
+    Returning None is the whole point. The previous code joined an unexpanded
+    token onto the base regardless, yielding a path like ``<cwd>/$W`` that
+    cannot exist — every git call against it failed, ``origin`` came back empty,
+    and the invocation was dropped at the ``if not origin`` guard. That reads
+    identically to "this repo is not in the topology", so a command the guard
+    could not scope was indistinguishable from one it deliberately ignored.
+
+    But None must be returned for the RIGHT tokens only. An absolute target is
+    knowable regardless of the base, and refusing it because an earlier ``cd``
+    was unresolvable converts a real block into an allow — measured, three of
+    them. Order matters here: resolve the token first, consult the base only for
+    a relative path.
+    """
+    d = os.path.expanduser(token)
+    if d.startswith("~"):
+        return None  # a ~user the passwd db cannot resolve
+    if any(c in d for c in _UNRESOLVABLE_DIR_CHARS):
+        return None
+    # An ABSOLUTE target recovers even from an unknown base: `cd $W && git -C
+    # /srv/repo add x` is fully determined by the `-C`, whatever the `cd` did.
+    # Testing the base FIRST is what made one unresolvable token blind every
+    # later leg of the command, turning three real wrong-repo blocks into
+    # allows. The sibling resolvers state this contract in their docstrings.
+    if os.path.isabs(d):
+        return os.path.normpath(d)
+    # A RELATIVE target genuinely cannot be placed without a base.
+    if base is None:
+        return None
+    return os.path.normpath(os.path.join(base, d))
+
+
+def _parse_git_invocations(cmd: str) -> list[tuple[str, list[str], str | None]]:
     """Return every git add|commit in the command as (subcommand, args, dir).
+
+    ``dir`` is None when the command text does not determine it — the caller
+    reports that rather than scanning a directory that was never entered.
 
     Tokenizes the WHOLE command once with shlex (quote-aware, so a ``;`` inside a
     ``-m`` message is not a separator, and newlines collapse to whitespace), then
@@ -101,7 +166,7 @@ def _parse_git_invocations(cmd: str) -> list[tuple[str, list[str], str]]:
         toks = shlex.split(cmd)
     except ValueError:
         return []
-    out: list[tuple[str, list[str], str]] = []
+    out: list[tuple[str, list[str], str | None]] = []
     cur_dir = os.getcwd()
     i, n = 0, len(toks)
     while i < n:
@@ -110,8 +175,7 @@ def _parse_git_invocations(cmd: str) -> list[tuple[str, list[str], str]]:
             i += 1
             continue
         if t == "cd" and i + 1 < n and toks[i + 1] not in _SHELL_OPS:
-            d = os.path.expanduser(toks[i + 1])
-            cur_dir = d if os.path.isabs(d) else os.path.normpath(os.path.join(cur_dir, d))
+            cur_dir = _resolve_dir(cur_dir, toks[i + 1])
             i += 2
             continue
         if t == "git":
@@ -119,8 +183,7 @@ def _parse_git_invocations(cmd: str) -> list[tuple[str, list[str], str]]:
             git_dir = cur_dir
             while i < n:
                 if toks[i] == "-C" and i + 1 < n:
-                    d = os.path.expanduser(toks[i + 1])
-                    git_dir = d if os.path.isabs(d) else os.path.normpath(os.path.join(cur_dir, d))
+                    git_dir = _resolve_dir(cur_dir, toks[i + 1])
                     i += 2
                     continue
                 if toks[i] == "-c" and i + 1 < n:
@@ -371,8 +434,16 @@ def main() -> int:
         # commands each get classified against their own effective repo).
         strong: list[tuple[str, str]] = []
         weak: list[tuple[str, str]] = []
+        unscoped = 0
         cur_key = None
         for sub, args, git_dir in invocations:
+            # Separated from the `if not origin` skip below ON PURPOSE. That one
+            # means "a real directory whose repo is not in the topology", which
+            # is documented as unguarded and stays silent. THIS one means the
+            # guard never got as far as looking, which is worth saying.
+            if git_dir is None or not os.path.isdir(git_dir):
+                unscoped += 1
+                continue
             origin = _normalize_remote(
                 _git(git_dir, ["config", "--get", "remote.origin.url"], timeout).strip()
             )
@@ -436,22 +507,53 @@ def main() -> int:
                 f"'# repo-routing-override' to proceed if this is intentional.",
                 file=sys.stderr,
             )
+            if unscoped:
+                print(
+                    f"(Also: {unscoped} further git invocation(s) in this command "
+                    f"could not be scoped and were NOT checked.)",
+                    file=sys.stderr,
+                )
             return 2
 
+        notes: list[str] = []
         if weak:
             belongs = sorted({name for _, name in weak})
             shown = ", ".join(p for p, _ in weak[:5])
+            notes.append(
+                f"NOTE: {len(weak)} file(s) look voice/edge-related "
+                f"({shown}) and may belong to {', '.join(belongs)} rather "
+                f"than {cur_key}. Proceed if this is legitimately internal "
+                f"channel code; otherwise commit it in the right repo."
+            )
+
+        if unscoped:
+            # Advisory, never a block. The bug this repairs fails OPEN, measured
+            # on the SAME population this notice fires for: of the 119 real
+            # commands (of 2,264 carrying a git add/commit) that reach this
+            # branch, the pre-change guard blocked 0 — it skipped the check
+            # silently every time. So nobody has ever been wrongly refused by
+            # it, the defect is the silence rather than the verdict, and turning
+            # it into a refusal would newly stop 119 ordinary commands to fix a
+            # problem nobody has.
+            notes.append(
+                f"NOTE: repo-routing check did NOT run for {unscoped} git "
+                f"add/commit invocation(s) — this guard reads the command text "
+                f"to work out which repository it targets, and could not "
+                f"(a shell variable, a substitution, a glob, or a directory "
+                f"that does not exist). Those files were NOT checked for "
+                f"wrong-repo content; nothing is claimed about them either way. "
+                f"The dominant cause is a variable holding the path, where "
+                f"there is often nothing to rewrite — if the check matters "
+                f"here, a literal `git -C <path>` makes it run."
+            )
+
+        if notes:
             print(
                 json.dumps(
                     {
                         "hookSpecificOutput": {
                             "hookEventName": "PreToolUse",
-                            "additionalContext": (
-                                f"NOTE: {len(weak)} file(s) look voice/edge-related "
-                                f"({shown}) and may belong to {', '.join(belongs)} rather "
-                                f"than {cur_key}. Proceed if this is legitimately internal "
-                                f"channel code; otherwise commit it in the right repo."
-                            ),
+                            "additionalContext": " ".join(notes),
                         }
                     }
                 )

--- a/scripts/hooks/repo_routing_guard.py
+++ b/scripts/hooks/repo_routing_guard.py
@@ -133,6 +133,28 @@ def _resolve_dir(base: str | None, token: str) -> str | None:
     a relative path.
     """
     d = os.path.expanduser(token)
+
+    # Where the token, read LITERALLY, names a real directory, that is the
+    # answer — and it outranks the character class below. shlex has already
+    # removed the quoting, so `cd '$repo'` and `cd $repo` arrive identical; if a
+    # directory named `$repo` exists, the first is what happened and refusing on
+    # the `$` skips the check on a real wrong-repo add. Same class as the
+    # `[{()<>` over-coverage found a round earlier, for the four characters that
+    # survived that narrowing.
+    #
+    # Positive validation, once more: asking whether the answer EXISTS settles
+    # what enumerating shell syntax cannot. The class below is now only the
+    # fallback for a token that names nothing, which is exactly what an
+    # unexpanded `$W` does.
+    literal: str | None = None
+    if not d.startswith("~"):
+        if os.path.isabs(d):
+            literal = os.path.normpath(d)
+        elif base is not None:
+            literal = os.path.normpath(os.path.join(base, d))
+    if literal is not None and os.path.isdir(literal):
+        return literal
+
     if d.startswith("~"):
         return None  # a ~user the passwd db cannot resolve
     if any(c in d for c in _UNRESOLVABLE_DIR_CHARS):

--- a/tests/test_hooks/test_repo_routing_guard.py
+++ b/tests/test_hooks/test_repo_routing_guard.py
@@ -364,3 +364,163 @@ def test_empty_tool_input_passes(agi_repo, topology):
         timeout=20,
     )
     assert r.returncode == 0
+
+
+# ── the check that did not run: audible, never blocking ─────────────────
+#
+# The guard joined an unexpanded `cd` token onto the current directory, so
+# `cd $W && git add .` produced a path like `<cwd>/$W`. That cannot exist, so
+# every git lookup failed, `origin` came back empty, and the invocation was
+# dropped at the `if not origin` guard — the SAME branch that means "this repo
+# is not in the topology". A command the guard could not scope was therefore
+# indistinguishable from one it deliberately ignored.
+#
+# MEASURED before fixing, on the SAME population the notice fires for: of the
+# 119 real commands (out of 2,264 carrying a `git add`/`commit`) whose directory
+# the guard cannot derive, the pre-change guard blocked 0 — the check was
+# skipped silently every time. It fails OPEN. That is why this is an ADVISORY
+# and not a new refusal: making it fail closed would newly stop 119 ordinary
+# commands, and nobody has ever been wrongly blocked by the bug.
+#
+# An earlier draft quoted "0 of 70" beside "119 of 2,264" as though they were
+# one measurement. They were two populations from two corpora. One population,
+# both numbers, or neither.
+
+
+def _advisory(result) -> str:
+    """The additionalContext string, or '' when the guard said nothing."""
+    if not result.stdout.strip():
+        return ""
+    return json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "cd $WORKTREE && git add .",
+        "cd ${W}/sub && git add .",
+        "cd $(pwd)/x && git add .",
+        "cd /nope/*/x && git add .",
+        "git -C $W add .",
+    ],
+)
+def test_an_unscopeable_directory_is_reported_not_swallowed(agi_repo, topology, cmd):
+    """REGRESSION PIN. Exit stays 0 — this must never become a block."""
+    r = _run(cmd, agi_repo, topology)
+
+    assert r.returncode == 0, r.stderr
+    assert "did NOT run" in _advisory(r)
+
+
+def test_a_directory_that_does_not_exist_is_reported(agi_repo, topology):
+    """Positive validation, not just metacharacter enumeration.
+
+    Listing the constructs bash expands only ever catches the ones somebody
+    thought of. Asking whether the answer is a real directory closes the class.
+    """
+    r = _run("cd /definitely/not/here && git add .", agi_repo, topology)
+
+    assert r.returncode == 0
+    assert "did NOT run" in _advisory(r)
+
+
+def test_a_scopeable_command_stays_silent(agi_repo, topology):
+    """TRUE-NEGATIVE CONTROL — the notice must not fire on ordinary work.
+
+    Without this, a guard that emitted the notice unconditionally would pass
+    every test above.
+    """
+    _write(agi_repo, "src/genesis/core.py")
+    r = _run("git add src/genesis/core.py", agi_repo, topology)
+
+    assert r.returncode == 0
+    assert _advisory(r) == ""
+
+
+def test_a_repo_with_no_origin_stays_silent(tmp_path, topology):
+    """The OTHER skip that shares the same `continue`, and it must stay quiet.
+
+    A real directory whose repo is not in the topology is documented as
+    unguarded. Only the could-not-scope case is new and reportable; conflating
+    them would make the notice fire on every unrelated repository on the box.
+    """
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(plain)], check=True)
+    _write(plain, "a.txt")
+
+    r = _run("git add a.txt", plain, topology)
+
+    assert r.returncode == 0
+    assert _advisory(r) == ""
+
+
+def test_a_strong_hit_before_an_unscopeable_leg_still_blocks(agi_repo, topology):
+    """A hit in the FIRST leg still blocks, and the unscoped leg is mentioned
+    rather than replacing it.
+
+    Pins one ORDERING only. The docstring used to claim the general property
+    ("the verdict is unchanged by the new bookkeeping") while asserting just
+    this safe direction — and the reversed order was exactly where an
+    allow-regression hid. The sibling test below pins that one.
+    """
+    _write(agi_repo, "firmware/boot.py")
+    r = _run("git add firmware/boot.py && cd $W && git add .", agi_repo, topology)
+
+    assert r.returncode == 2
+    assert "GENesis-Voice" in r.stderr
+    assert "could not be scoped" in r.stderr
+
+
+def test_an_absolute_leg_still_scopes_after_an_unresolvable_cd(agi_repo, topology):
+    """REGRESSION PIN for an allow-regression an adversarial audit found.
+
+    `_resolve_dir` consulted the base BEFORE testing whether the token was
+    absolute, so one unresolvable `cd` blinded every later leg — including legs
+    naming their directory absolutely. MEASURED old=BLOCK / broken=ALLOW /
+    fixed=BLOCK on three real wrong-repo shapes. An absolute path is knowable
+    whatever the earlier `cd` did.
+    """
+    _write(agi_repo, "firmware/boot.py")
+    r = _run(f"cd $W && git -C {agi_repo} add firmware/boot.py", agi_repo.parent, topology)
+
+    assert r.returncode == 2, r.stdout + r.stderr
+    assert "GENesis-Voice" in r.stderr
+
+
+def test_an_absolute_cd_also_recovers_from_an_unresolvable_one(agi_repo, topology):
+    """The `cd` form of the same recovery, not just the `-C` form."""
+    _write(agi_repo, "firmware/boot.py")
+    r = _run(f"cd $W && cd {agi_repo} && git add firmware/boot.py", agi_repo.parent, topology)
+
+    assert r.returncode == 2, r.stdout + r.stderr
+
+
+def test_a_quoted_literal_path_is_not_treated_as_an_expansion(tmp_path, topology):
+    """The metacharacter class must not reject a real directory.
+
+    shlex erases the quoting before the token arrives, so a wider class cannot
+    tell `cd '/srv/a (wt)'` — a directory that exists and holds a wrong-repo hit
+    — from a subshell. MEASURED: adding `[{()<>` to the class stopped the guard
+    checking this directory entirely. The narrow class plus the positive
+    is-it-a-real-directory validation covers both sides.
+    """
+    spaced = _make_repo(tmp_path / "agi (wt)", AGI)
+    _write(spaced, "firmware/boot.py")
+
+    r = _run(f"cd '{spaced}' && git add firmware/boot.py", tmp_path, topology)
+
+    assert r.returncode == 2, r.stdout + r.stderr
+
+
+def test_the_notice_composes_with_a_weak_hit(agi_repo, topology):
+    """Both advisories reach the caller. Only ONE JSON object may be printed,
+    so a second `print` would have produced two concatenated objects and the
+    harness would have parsed neither."""
+    _write(agi_repo, "satellite/config.py")
+    r = _run("git add satellite/config.py && cd $W && git add .", agi_repo, topology)
+
+    assert r.returncode == 0
+    note = _advisory(r)
+    assert "satellite/config.py" in note
+    assert "did NOT run" in note

--- a/tests/test_hooks/test_repo_routing_guard.py
+++ b/tests/test_hooks/test_repo_routing_guard.py
@@ -524,3 +524,37 @@ def test_the_notice_composes_with_a_weak_hit(agi_repo, topology):
     note = _advisory(r)
     assert "satellite/config.py" in note
     assert "did NOT run" in note
+
+
+def test_a_directory_literally_containing_expansion_syntax_is_checked(tmp_path, topology):
+    """REGRESSION PIN for a BLOCK -> ALLOW the character class caused.
+
+    A directory can literally be named `$repo`. shlex removes the quoting
+    before the token arrives, so `cd '$repo'` and `cd $repo` are
+    indistinguishable — and refusing on the `$` skipped the check entirely on
+    a real wrong-repo add inside a directory that exists.
+
+    Same class as the `[{()<>` over-coverage a round earlier, for the four
+    characters that survived that narrowing. Fixed the same way: ask whether
+    the answer EXISTS before consulting any character class.
+    """
+    odd = _make_repo(tmp_path / "$repo", AGI)
+    _write(odd, "firmware/boot.py")
+
+    r = _run(f"cd '{odd}' && git add firmware/boot.py", tmp_path, topology)
+
+    assert r.returncode == 2, r.stdout + r.stderr
+    assert "GENesis-Voice" in r.stderr
+
+
+def test_an_unexpanded_variable_naming_nothing_is_still_unresolvable(agi_repo, topology):
+    """TRUE-NEGATIVE CONTROL — the character class must still do its job.
+
+    Without this, "accept anything that exists" would degrade into "accept
+    everything": an unexpanded `$W` names no directory, so it must still be
+    reported as unscopeable rather than silently joined onto the cwd.
+    """
+    r = _run("cd $NOSUCHVAR_XYZ && git add .", agi_repo, topology)
+
+    assert r.returncode == 0
+    assert "did NOT run" in _advisory(r)


### PR DESCRIPTION
## What was wrong

`repo_routing_guard` catches a `git add`/`commit` that stages files belonging to a
*different* repository. It identifies the current repo by reading the command text to
work out which directory the command runs in.

When the text did not determine one — `cd $WORKTREE`, `cd $(…)`, a glob — it joined the
unexpanded token onto the current path anyway, producing something like `<cwd>/$W`. That
path cannot exist, so every `git` lookup against it failed and the invocation was dropped
at `if not origin: continue`.

**That is the same branch that means "this repository is not in the topology"** — a case
the module docstring documents as a deliberate non-guard. So a command the guard *could
not inspect* was indistinguishable from one it *chose to ignore*, and nothing said so.

## Why this is an advisory and not a refusal

This is the number that decided the shape of the fix, and it inverts the obvious one.

| | |
|---|---|
| real commands carrying a `git add`/`commit` | 2,264 |
| …whose directory the guard cannot derive | **119 (5.3%)** |
| …that the **pre-change** guard blocked | **0 / 119** |

The failure is **open**: the check is silently *skipped*, never mis-fired. Nobody has ever
been wrongly stopped by this. So the defect is the **silence**, not the verdict — and
making it fail closed would newly refuse 119 ordinary commands to fix a problem nobody
has. Exit codes are unchanged for every command in the corpus.

The two skips that shared one `continue` are now separated: a real directory whose repo
is not in the topology stays silent (documented as unguarded), and conflating them would
have fired the notice on every unrelated checkout on the machine.

## An adversarial audit found this PR turning refusals into allows

Recorded rather than quietly fixed, because it is the more useful half of the story.

The first version's resolver consulted its **base** directory before checking whether the
target was **absolute**. So one unresolvable `cd` blinded every later leg of the command —
including legs naming their directory absolutely. Measured with both binaries over real
scratch repositories holding a wrong-repo file:

| command | pre-PR | first version | fixed |
|---|---|---|---|
| `cd $W && git -C <repo> add firmware/boot.py` | BLOCK | **ALLOW** | BLOCK |
| `cd $W && cd <repo> && git add firmware/boot.py` | BLOCK | **ALLOW** | BLOCK |
| `cd '<repo (with parens)>' && git add firmware/boot.py` | BLOCK | **ALLOW** | BLOCK |
| plain wrong-repo add *(control)* | BLOCK | BLOCK | BLOCK |

Three real wrong-repo commits, waved through with a "check did not run" note.

The correct rule is written in the sibling resolvers' own docstrings — *an absolute target
is normalized and returned; it recovers even from a prior unknown*. **I had implemented it
correctly in `pre_push_privacy_review._resolve` earlier the same day, with this exact
`cd $W && git -C /wt` case spelled out in its docstring, and then wrote it the other way
here.** Two copies of one rule, drifting inside a day, which is the argument for the
follow-up below.

## The metacharacter set was over-broad, for the same underlying reason

`shlex` erases quoting before the token arrives, so a wide set cannot tell an expansion
from a quoted **literal** containing the same character. A directory whose name contains
parentheses exists, is a git repo, is in the topology and held a strong wrong-repo hit —
and was being skipped as unresolvable (row 3 above).

It is narrowed to `` "$`*?" `` (what `git_push_guard` actually uses), and the positive
check that the answer **is a real directory** closes the rest without enumerating
anything: a glob that expands to nothing, a brace expression, a literal that is not there
all fail that test and are reported. Enumerating what a shell expands only ever catches
the constructs somebody thought of.

The set was an open set in **both** directions — under-covering constructs nobody listed,
over-covering literals that merely look like them. Re-measured after narrowing: the notice
rate is unchanged at 119/2,264.

## A parity claim that was false

A comment asserted this set was "the same class the sibling cwd resolvers use". It is not,
and they differ from each other too: `git_push_guard` uses `` "$`*?" ``;
`review_enforcement_commit`'s copies are wider and additionally handle `cd -`, a bare `cd`
and `CDPATH`. The comment now states that, and states that this is a **fifth** copy sitting
outside the existing drift trip-wire (`test_value_flag_consistency.py` locks the
*value-flag* sets; `_UNRESOLVABLE` appears nowhere in it).

Unifying the copies belongs in `shell_parse.py`, which another open branch is editing in
the same session — doing it here would conflict two of my own PRs — so it is **filed as a
follow-up**, along with the bare `cd` / `cd -` cases this copy still handles silently.

## Two numbers that were presented as one

An earlier draft quoted "0 blocks across 70 real commands" beside "119 of 2,264" as though
they described one measurement. They were two populations from two corpora with different
predicates. Both are re-derived on a single population above, and all three sites (the
guard comment, the test header, the CHANGELOG) now quote that reconciled pair.

## Verification

**Verify-RED:** 8 of the 10 new tests fail against the pre-change guard. The 2 that pass
both ways are the true-negative controls and say so in their docstrings — an ordinary
scopeable command stays silent, and a repo with no origin stays silent. Without those two,
a guard that emitted the notice unconditionally would satisfy every other test.

Tests pin **both** orderings. The allow-regression hid behind a docstring that claimed the
general property ("the verdict is unchanged") while the body checked only the safe
direction — hit first, unscoped leg second. That docstring is narrowed to what it pins,
and the reversed order is now its own test.

Output contract re-checked: exactly one `json.dumps` site, always paired with `return 0`;
the block path writes stderr only; no `permissionDecision` anywhere; `main()` still wrapped
in `except Exception: return 0`. A second `print` would have emitted two concatenated JSON
objects and the harness would have parsed neither — silently destroying the pre-existing
weak-hit advisory as well.

**50 tests pass** (`test_repo_routing_guard`, `test_value_flag_consistency`,
`test_hook_versions_complete`). Lint and format clean.

Deploy path: hook changes take effect at the next Claude Code session start, not on merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The wrong-repository commit check now reports when it cannot determine the target directory for certain shell commands.
  - These cases remain advisory and fail open, so valid commands are not newly blocked.
  - Improved handling covers quoted directories, absolute paths, literal shell-like directory names, and commands that return to a resolvable directory.
  - Existing repository-routing checks continue to report strong and weak matches as before.

- **Documentation**
  - Added an Unreleased changelog entry describing the advisory reporting and its impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->