### PR TITLE
chore(git): let two branches add a changelog entry without colliding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,51 +1,48 @@
-# CHANGELOG.md is an append-only list of independent bullets. Two branches that
-# each add an entry under the same heading are not disagreeing about anything —
-# they are inserting at the same position, which git's default driver reports as
-# a conflict. `union` keeps both sides' lines instead of leaving markers.
+# CHANGELOG.md is an append-only list of independent bullets, so two branches
+# adding an entry under the same heading are inserting at the same position
+# rather than disagreeing — which git's default driver calls a conflict. `union`
+# takes lines from both sides instead of leaving markers.
 #
-# It does NOT promise an ordering. gitattributes(5) on the union driver: "This
-# tends to leave the added lines in the resulting file in random order and the
-# user should verify the result." For a list of independent bullets that is a
-# proofreading matter, not a correctness one — but it is why nothing here claims
-# the entries come out in the order they were written.
+# WHAT THIS DOES NOT DO, because the measurement that motivated it is easy to
+# over-read: it does NOT make a conflicting PR mergeable on github.com. GitHub
+# ignores repository .gitattributes in its server-side merge. MEASURED against
+# GitHub's own merge engine (POST /repos/:owner/:repo/merges) on two branch
+# pairs built to collide on this file: 409 Conflict WITH the union attribute
+# present in both commits, and 409 for the no-attribute control. So a PR that
+# collides here still shows CONFLICTING, and scripts/hooks/git_push_guard.py
+# still blocks `gh pr merge` on GitHub's `mergeable` field — which this rule
+# provably cannot move. Clearing that block means merging the base branch into
+# the PR branch LOCALLY, which is what the gate itself instructs. THAT is what
+# this rule changes: the local merge resolves the changelog with no hand-editing.
+# Measured on the 18 open PRs that collided only on this file: 18/18 merge clean
+# locally, every bullet from both sides intact.
 #
-# Measured 2026-09-04 against origin/main 2d5ea3dd: of 49 open PRs, 21 could not
-# merge, and 18 of those 21 conflicted on CHANGELOG.md and nothing else — every
-# other file in them merged cleanly. That is 37% of the open queue blocked by
-# one file's merge semantics.
+# The pattern is ANCHORED. A gitattributes pattern with no slash matches the
+# basename at every depth, like .gitignore (gitattributes(5)) — unanchored, this
+# would silently arm every future vendored or subproject CHANGELOG.md with a
+# driver nobody reviewed for it.
 #
-# The pattern is ANCHORED with a leading slash on purpose. A gitattributes
-# pattern containing no slash matches the basename at EVERY depth, exactly like
-# .gitignore (gitattributes(5), "the same as in .gitignore files"). Unanchored,
-# this rule would silently pre-arm every future vendored, subproject or plugin
-# CHANGELOG.md with a driver nobody reviewed for it. Measured: `CHANGELOG.md`
-# resolves to union either way, but `vendor/dep/CHANGELOG.md` resolves to union
-# ONLY without the slash. Scope is one path, and the tests grade that over the
-# whole tracked file list rather than a hand-picked sample.
+# TWO WAYS UNION GETS IT WRONG, both at exit 0, both documented in the release
+# runbook (docs/reference/recovery-and-portability-workflow.md), which is where
+# the person who can act on them actually reads:
+#   1. It cannot express a REMOVAL. If one side deletes lines while the other
+#      edits the same hunk, the deleted lines come back. Pruning an entry and
+#      cutting a release (which MOVES entries under a version heading) both hit
+#      this. `git revert` of an older commit is absorbed the same way — git then
+#      reports "nothing to commit", so an exit-code check still catches it, and
+#      guardian/recovery.py's `git revert HEAD` on a clean tree is unaffected
+#      (MEASURED: reverts correctly, because ours == base so union never runs).
+#   2. It merges LINES, not records, so two entries sharing an aligned identical
+#      line collapse into one and the other loses its continuation. This reaches
+#      insertion-only merges, so "just adding a bullet" is not automatically
+#      safe. MEASURED rate on real work: 0 of those same 18 PRs — it needs
+#      identical aligned lines, and these entries are long distinctive prose.
+# Union also promises no ordering ("tends to leave the added lines in the
+# resulting file in random order and the user should verify the result" —
+# gitattributes(5)).
 #
-# `union` resolves SILENTLY, so it must only ever apply where a silent
-# resolution cannot be wrong: an unordered list of independent entries that no
-# code reads. It must NOT be extended to source, config, or prose that two
-# branches might legitimately rewrite in the same place — there, a conflict is
-# the correct and desirable outcome.
-#
-# WHAT UNION CANNOT DO IS EXPRESS A REMOVAL, and this is the sharp edge. If one
-# side deletes lines and the other edits the same hunk, union keeps the deleted
-# lines and exits 0 — the deletion is discarded, silently, with a success code
-# and no duplicated prose to catch the eye. MEASURED with a no-attribute
-# control: pruning an entry on one branch while another branch adds a bullet
-# merges rc=0 with the pruned entry restored; without this rule the same merge
-# conflicts and a human decides. So anyone PRUNING, REVERTING, or CUTTING A
-# RELEASE on this file must read the merged result rather than trust the exit
-# code. Cutting a release is the routine case, because it MOVES entries under a
-# version heading rather than adding them, and another branch's new bullet can
-# land under the wrong heading. Ordinary "add a bullet" merges — which is what
-# nearly every PR does — cannot hit any of this.
-#
-# The attribute also governs cherry-pick, revert, rebase and merge-tree, not
-# just merge (gitattributes(5)). In this repo that reaches
-# contribution/divergence.py (merge-tree conflict probe),
-# contribution/pr_opener.py (cherry-pick into an auto-opened PR) and
-# guardian/recovery.py (autonomous `git revert`): every path where a CHANGELOG
-# conflict used to stop for a human now resolves on its own.
+# Scope is deliberately this one path, and tests/test_changelog_merge_attribute.py
+# enforces that two ways, both of which are load-bearing: an equality over every
+# TRACKED file, and a list of paths that do NOT exist yet (a vendored changelog,
+# a shell script) which the population check structurally cannot reach.
 /CHANGELOG.md merge=union

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,13 @@
 # CHANGELOG.md is an append-only list of independent bullets. Two branches that
 # each add an entry under the same heading are not disagreeing about anything —
 # they are inserting at the same position, which git's default driver reports as
-# a conflict. `union` keeps both sides' lines, in order.
+# a conflict. `union` keeps both sides' lines instead of leaving markers.
+#
+# It does NOT promise an ordering. gitattributes(5) on the union driver: "This
+# tends to leave the added lines in the resulting file in random order and the
+# user should verify the result." For a list of independent bullets that is a
+# proofreading matter, not a correctness one — but it is why nothing here claims
+# the entries come out in the order they were written.
 #
 # Measured 2026-09-04 against origin/main 2d5ea3dd: of 49 open PRs, 21 could not
 # merge, and 18 of those 21 conflicted on CHANGELOG.md and nothing else — every

--- a/.gitattributes
+++ b/.gitattributes
@@ -10,12 +10,27 @@
 # pairs built to collide on this file: 409 Conflict WITH the union attribute
 # present in both commits, and 409 for the no-attribute control. So a PR that
 # collides here still shows CONFLICTING, and scripts/hooks/git_push_guard.py
-# still blocks `gh pr merge` on GitHub's `mergeable` field — which this rule
-# provably cannot move. Clearing that block means merging the base branch into
-# the PR branch LOCALLY, which is what the gate itself instructs. THAT is what
-# this rule changes: the local merge resolves the changelog with no hand-editing.
-# Measured on the 18 open PRs that collided only on this file: 18/18 merge clean
-# locally, every bullet from both sides intact.
+# still blocks the merge on GitHub's `mergeable` field — which this rule
+# provably cannot move.
+#
+# AND IT DOES NOT HELP A BRANCH'S FIRST MERGE EITHER, which is the one that
+# matters for a PR that is already open. Attributes resolve from the CHECKOUT,
+# not from the commits being merged, so on a branch created before this file
+# existed, `git merge origin/main` still conflicts — the rule arrives IN that
+# merge and is not in effect during it. MEASURED on a real open PR: checked out
+# at its head and merging in the branch carrying this rule, CHANGELOG.md
+# conflicts. An earlier measurement here claimed "18/18 merge clean locally";
+# that replayed the OPPOSITE direction (merging each PR into a checkout that
+# already had the rule) and did not describe the workflow anyone performs. It
+# has been withdrawn.
+#
+# So what this actually buys is narrow and worth stating plainly: once a branch
+# CONTAINS this file — every branch cut after it lands, and any older branch
+# after its first merge — subsequent merges of the base branch resolve the
+# changelog with no hand-editing. Measured in that direction: 18/18 clean with
+# every bullet from both sides intact. The structural fix for the collision
+# itself is one changelog fragment per change (see changelog.d/), which this
+# rule does not replace.
 #
 # The pattern is ANCHORED. A gitattributes pattern with no slash matches the
 # basename at every depth, like .gitignore (gitattributes(5)) — unanchored, this

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,45 @@
+# CHANGELOG.md is an append-only list of independent bullets. Two branches that
+# each add an entry under the same heading are not disagreeing about anything —
+# they are inserting at the same position, which git's default driver reports as
+# a conflict. `union` keeps both sides' lines, in order.
+#
+# Measured 2026-09-04 against origin/main 2d5ea3dd: of 49 open PRs, 21 could not
+# merge, and 18 of those 21 conflicted on CHANGELOG.md and nothing else — every
+# other file in them merged cleanly. That is 37% of the open queue blocked by
+# one file's merge semantics.
+#
+# The pattern is ANCHORED with a leading slash on purpose. A gitattributes
+# pattern containing no slash matches the basename at EVERY depth, exactly like
+# .gitignore (gitattributes(5), "the same as in .gitignore files"). Unanchored,
+# this rule would silently pre-arm every future vendored, subproject or plugin
+# CHANGELOG.md with a driver nobody reviewed for it. Measured: `CHANGELOG.md`
+# resolves to union either way, but `vendor/dep/CHANGELOG.md` resolves to union
+# ONLY without the slash. Scope is one path, and the tests grade that over the
+# whole tracked file list rather than a hand-picked sample.
+#
+# `union` resolves SILENTLY, so it must only ever apply where a silent
+# resolution cannot be wrong: an unordered list of independent entries that no
+# code reads. It must NOT be extended to source, config, or prose that two
+# branches might legitimately rewrite in the same place — there, a conflict is
+# the correct and desirable outcome.
+#
+# WHAT UNION CANNOT DO IS EXPRESS A REMOVAL, and this is the sharp edge. If one
+# side deletes lines and the other edits the same hunk, union keeps the deleted
+# lines and exits 0 — the deletion is discarded, silently, with a success code
+# and no duplicated prose to catch the eye. MEASURED with a no-attribute
+# control: pruning an entry on one branch while another branch adds a bullet
+# merges rc=0 with the pruned entry restored; without this rule the same merge
+# conflicts and a human decides. So anyone PRUNING, REVERTING, or CUTTING A
+# RELEASE on this file must read the merged result rather than trust the exit
+# code. Cutting a release is the routine case, because it MOVES entries under a
+# version heading rather than adding them, and another branch's new bullet can
+# land under the wrong heading. Ordinary "add a bullet" merges — which is what
+# nearly every PR does — cannot hit any of this.
+#
+# The attribute also governs cherry-pick, revert, rebase and merge-tree, not
+# just merge (gitattributes(5)). In this repo that reaches
+# contribution/divergence.py (merge-tree conflict probe),
+# contribution/pr_opener.py (cherry-pick into an auto-opened PR) and
+# guardian/recovery.py (autonomous `git revert`): every path where a CHANGELOG
+# conflict used to stop for a human now resolves on its own.
+/CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   without conflict, while the three genuine conflicts (in source, a shell
   script and an architecture document) still conflict exactly as before.
 
+  **What this does not do, since that measurement is easy to over-read: it does
+  not make a conflicting pull request mergeable on GitHub.** GitHub ignores a
+  repository's `.gitattributes` in its server-side merge — measured directly
+  against GitHub's own merge engine on two branch pairs built to collide on this
+  file, which returned a conflict both with the union attribute present and
+  without it. Such a pull request still shows as conflicting, and the merge gate
+  still refuses it. Clearing that requires merging the base branch into the
+  branch locally, which is what the gate already instructs. What changes is the
+  cost of that step: the changelog now resolves itself instead of being
+  hand-edited every time.
+
   The rule is scoped to the one file at the repository root, and the tests
   enforce that scope over the complete tracked-file list rather than a sample.
   The leading slash matters: a pattern without one matches the basename at
@@ -41,9 +52,24 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   a release (which moves entries under a version heading rather than adding
   them) can quietly come out wrong, with a zero exit code and nothing visibly
   duplicated to catch the eye. Read the merged file in those three cases.
-  Ordinary "add a bullet" merges, which is what nearly every change does,
-  cannot hit it. The attribute also governs cherry-pick, revert and rebase, so
-  the same caveat reaches the automated contribution and recovery paths.
+
+  Union merges lines, not records, and that reaches insertion-only merges too:
+  two entries sharing an identical aligned line — the same closing sentence, the
+  same title — can collapse into one, again at exit 0. Measured across the 18
+  real colliding pull requests, every bullet from both sides survived intact in
+  all 18; the failure needs identical lines and these entries are long
+  distinctive prose. So it is a real edge with a measured rate of zero, worth
+  knowing when writing a terse or templated entry.
+
+  The attribute also governs `git revert` and `git cherry-pick`
+  (`gitattributes(5)`) and, measured here, `git merge-tree` — but only when the
+  checkout running them already carries this rule, since attributes resolve from
+  the current checkout rather than from the commits being compared. Two
+  consequences were measured rather than assumed: reverting an *older* commit
+  that added an entry is absorbed, and git then reports "nothing to commit" with
+  a non-zero exit, so a caller checking exit status still notices; and the
+  guardian's automated `git revert HEAD` on a clean tree is unaffected, because
+  there both sides equal the base and the driver never runs.
 
 - **Two branches can no longer pick the same database-migration number.** Each
   new migration is now named by the UTC time it was written rather than by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,20 +25,23 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   Measured before the change, against the repository's own open work: of 49
   open pull requests, 21 could not merge, and **18 of those 21 conflicted on
   this file and nothing else** — every other file in them merged cleanly.
-  Replaying all 18 locally with the rule in place, every one of them merges
-  without conflict, while the three genuine conflicts (in source, a shell
-  script and an architecture document) still conflict exactly as before.
+  **Two things it deliberately does not do**, because the measurement above is
+  easy to over-read. It does not make a conflicting pull request mergeable on
+  GitHub: GitHub ignores a repository's `.gitattributes` in its server-side
+  merge, measured against GitHub's own merge engine on two branch pairs built to
+  collide on this file, which conflicted both with the attribute present and
+  without it. And it does not help a branch's *first* merge, which is the one an
+  already-open pull request needs — attributes resolve from the checkout rather
+  than from the commits being merged, so on a branch created before this file
+  existed the merge that introduces the rule is not governed by it. Measured on
+  a real open pull request: the changelog still conflicts.
 
-  **What this does not do, since that measurement is easy to over-read: it does
-  not make a conflicting pull request mergeable on GitHub.** GitHub ignores a
-  repository's `.gitattributes` in its server-side merge — measured directly
-  against GitHub's own merge engine on two branch pairs built to collide on this
-  file, which returned a conflict both with the union attribute present and
-  without it. Such a pull request still shows as conflicting, and the merge gate
-  still refuses it. Clearing that requires merging the base branch into the
-  branch locally, which is what the gate already instructs. What changes is the
-  cost of that step: the changelog now resolves itself instead of being
-  hand-edited every time.
+  What it does buy, stated narrowly: once a branch contains the file — every
+  branch cut after this lands, and any older branch after its first merge —
+  later merges of the base branch resolve the changelog with no hand-editing.
+  Measured in that direction across the same 18: all of them clean, with every
+  bullet from both sides intact. The structural fix is one fragment per change
+  under `changelog.d/`; this rule does not replace it.
 
   The rule is scoped to the one file at the repository root, and the tests
   enforce that scope over the complete tracked-file list rather than a sample.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   adding an entry under the same heading are not disagreeing about anything —
   they are inserting at the same position, which git's default merge reports as
   a conflict a human has to resolve by hand. It now merges with git's `union`
-  driver, which keeps both sides' lines, in order, and drops neither.
+  driver, which keeps both sides' lines instead of leaving markers. It makes no
+  promise about their ORDER — git's own documentation says union "tends to leave
+  the added lines in the resulting file in random order and the user should
+  verify the result" — so a merged section may need its entries re-sorted by
+  hand. For a list of independent bullets that is proofreading, not breakage.
 
   Measured before the change, against the repository's own open work: of 49
   open pull requests, 21 could not merge, and **18 of those 21 conflicted on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **Two branches that each add a changelog entry no longer collide over it.**
+  This file is an append-only list of independent bullets, so two branches
+  adding an entry under the same heading are not disagreeing about anything —
+  they are inserting at the same position, which git's default merge reports as
+  a conflict a human has to resolve by hand. It now merges with git's `union`
+  driver, which keeps both sides' lines, in order, and drops neither.
+
+  Measured before the change, against the repository's own open work: of 49
+  open pull requests, 21 could not merge, and **18 of those 21 conflicted on
+  this file and nothing else** — every other file in them merged cleanly.
+  Replaying all 18 locally with the rule in place, every one of them merges
+  without conflict, while the three genuine conflicts (in source, a shell
+  script and an architecture document) still conflict exactly as before.
+
+  The rule is scoped to the one file at the repository root, and the tests
+  enforce that scope over the complete tracked-file list rather than a sample.
+  The leading slash matters: a pattern without one matches the basename at
+  every depth, which would silently hand the same driver to any future
+  vendored or subproject changelog.
+
+  What `union` cannot express is a **removal**. If one side deletes lines while
+  the other edits the same place, it keeps the deleted lines and reports
+  success — so pruning an entry, reverting a commit that added one, or cutting
+  a release (which moves entries under a version heading rather than adding
+  them) can quietly come out wrong, with a zero exit code and nothing visibly
+  duplicated to catch the eye. Read the merged file in those three cases.
+  Ordinary "add a bullet" merges, which is what nearly every change does,
+  cannot hit it. The attribute also governs cherry-pick, revert and rebase, so
+  the same caveat reaches the automated contribution and recovery paths.
+
 - **Two branches can no longer pick the same database-migration number.** Each
   new migration is now named by the UTC time it was written rather than by the
   next free number, so nobody has to check what anyone else took — and two

--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -30,6 +30,20 @@ with the repo's `.gitleaks.toml` PII/infrastructure rules + portability
 + email scans). Releases are cut by tagging `vX.Y` on `main` and publishing a
 GitHub Release from the matching `CHANGELOG.md` section.
 
+**Read the section before you publish it.** `CHANGELOG.md` merges with git's
+`union` driver (see `.gitattributes`), which resolves same-position insertions
+without a conflict — that is what keeps ordinary PRs from colliding over it.
+The tradeoff lands here and nowhere else: union cannot express a *move* or a
+*removal*, so a release cut, which moves entries beneath a new version heading,
+can absorb another branch's later bullet into the section you are about to
+publish, and can restore an entry someone pruned. It does this with a zero exit
+code and no conflict to stop you. Union also makes no promise about ordering
+("tends to leave the added lines in the resulting file in random order" —
+`gitattributes(5)`), so entries may need re-sorting. Diff the version section
+against the tag's commit range and confirm every bullet belongs to it. Ordinary
+"add a bullet" merges cannot hit any of this; the release cut is the one
+operation that can.
+
 ## Current Recovery Anchors
 
 - Genesis repo state is preserved by git plus captured diffs/untracked-file

--- a/docs/reference/recovery-and-portability-workflow.md
+++ b/docs/reference/recovery-and-portability-workflow.md
@@ -32,17 +32,24 @@ GitHub Release from the matching `CHANGELOG.md` section.
 
 **Read the section before you publish it.** `CHANGELOG.md` merges with git's
 `union` driver (see `.gitattributes`), which resolves same-position insertions
-without a conflict — that is what keeps ordinary PRs from colliding over it.
-The tradeoff lands here and nowhere else: union cannot express a *move* or a
-*removal*, so a release cut, which moves entries beneath a new version heading,
-can absorb another branch's later bullet into the section you are about to
-publish, and can restore an entry someone pruned. It does this with a zero exit
-code and no conflict to stop you. Union also makes no promise about ordering
-("tends to leave the added lines in the resulting file in random order" —
-`gitattributes(5)`), so entries may need re-sorting. Diff the version section
-against the tag's commit range and confirm every bullet belongs to it. Ordinary
-"add a bullet" merges cannot hit any of this; the release cut is the one
-operation that can.
+without a conflict when merging **locally**. GitHub ignores repository
+`.gitattributes` server-side, so a PR colliding on this file still shows as
+conflicting there and still has to have the base branch merged in locally.
+The tradeoff lands hardest here: union cannot express a *move* or a *removal*,
+so a release cut, which moves entries beneath a new version heading, can absorb
+another branch's later bullet into the section you are about to publish, and can
+restore an entry someone pruned. It does this with a zero exit code and no
+conflict to stop you. Union also makes no promise about ordering ("tends to
+leave the added lines in the resulting file in random order" —
+`gitattributes(5)`), so entries may need re-sorting.
+
+The release cut is the most exposed operation but not the only one: union merges
+lines, not records, so two entries sharing an identical aligned line can collapse
+into one even when both branches only added. Measured at 0 of the 18 real
+colliding PRs — it needs identical lines, and entries here are long distinctive
+prose — but it is why the check is **confirm every bullet is intact**, not merely
+"confirm nothing is missing". Diff the version section against the tag's commit
+range and read it.
 
 ## Current Recovery Anchors
 

--- a/tests/test_changelog_merge_attribute.py
+++ b/tests/test_changelog_merge_attribute.py
@@ -59,35 +59,62 @@ MUST_NOT_BE_UNION = (
 )
 
 
-# Ambient git configuration can decide the outcome of these tests, and
-# neutralising settings one at a time is whack-a-mole: `merge.default` routes
-# unspecified paths to a driver, `core.attributesFile` injects attributes from
-# outside the repo, `init.templateDir` can plant a `.git/info/attributes` (the
-# HIGHEST-precedence attribute source), `core.autocrlf` rewrites content before
-# a merge ever sees it. Rather than keep a list of them current, every git
-# subprocess here runs with global and system configuration switched off
-# outright, plus the system attributes file. One control instead of a checklist.
-_HERMETIC_ENV = {
+# Ambient git state can decide the outcome of these tests, and naming the
+# offending settings one at a time has already failed twice here: first
+# `commit.gpgsign`/`core.hooksPath`, then `merge.default`/`core.attributesFile`,
+# and each time the NEXT source was the finding. The sources are not a list one
+# can keep current — config comes from system, global, XDG, the environment and
+# command-scoped `GIT_CONFIG_COUNT` pairs, while ATTRIBUTES come from the system
+# file, `core.attributesFile`, its `$XDG_CONFIG_HOME/git/attributes` default,
+# `$GIT_DIR/info/attributes` (highest precedence) and a template dir that can
+# plant one.
+#
+# So this is subtractive, not a denylist: drop EVERY `GIT_*` variable inherited
+# from the caller, point HOME and XDG_CONFIG_HOME at an empty directory so the
+# per-user config and attributes files resolve to nothing, and disable the
+# system sources explicitly. Anything new git grows is covered by construction
+# unless it is reachable without a `GIT_*` variable and without HOME.
+_HERMETIC_ENV: dict[str, str] = {
     "GIT_CONFIG_GLOBAL": os.devnull,
     "GIT_CONFIG_SYSTEM": os.devnull,
     "GIT_ATTR_NOSYSTEM": "1",
 }
 
 
-def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+@pytest.fixture(scope="session", autouse=True)
+def _empty_home(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Point HOME/XDG_CONFIG_HOME at an empty dir for every git call here.
+
+    Without this, `$XDG_CONFIG_HOME/git/attributes` — which is where
+    `core.attributesFile` DEFAULTS to, and needs no config entry to take effect
+    — still reaches these subprocesses even with global config disabled.
+    """
+    empty = tmp_path_factory.mktemp("hermetic-home")
+    _HERMETIC_ENV["HOME"] = str(empty)
+    _HERMETIC_ENV["XDG_CONFIG_HOME"] = str(empty)
+
+
+def _hermetic_env() -> dict[str, str]:
+    """The caller's environment with every git-controlling variable removed."""
+    base = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+    return {**base, **_HERMETIC_ENV}
+
+
+def _git(*args: str, cwd: Path, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
         cwd=cwd,
         capture_output=True,
         text=True,
         check=False,
-        env={**os.environ, **_HERMETIC_ENV},
+        input=stdin,
+        env=_hermetic_env(),
     )
 
 
-def _git_ok(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+def _git_ok(*args: str, cwd: Path, stdin: str | None = None) -> subprocess.CompletedProcess[str]:
     """Run git and fail the test on a non-zero exit rather than sailing on."""
-    proc = _git(*args, cwd=cwd)
+    proc = _git(*args, cwd=cwd, stdin=stdin)
     assert proc.returncode == 0, (
         f"git {' '.join(args)} failed ({proc.returncode}): {proc.stderr.strip()}"
     )
@@ -204,20 +231,23 @@ def test_union_applies_to_exactly_one_tracked_path() -> None:
     the invariant has to be an equality over every tracked file.
 
     Scope of the guarantee, stated so it is not read as more than it is: this
-    grades the repository's own attribute surface. A developer who sets
-    ``merge.default`` locally routes every *unspecified* path to that driver,
-    and no committed file can prevent it — that is a per-machine choice, not
-    something this repo controls.
+    grades the repository's own attribute surface, under a git environment
+    stripped of the caller's config and attribute sources. It says nothing about
+    what a merge does on a machine whose own ``merge.default`` routes unspecified
+    paths to a driver — that is a per-machine choice no committed file can pin.
     """
     assert GITATTRIBUTES.is_file(), "repo-root .gitattributes is missing"
     files = _git_ok("ls-files", "-z", cwd=REPO_ROOT)
-    proc = subprocess.run(
-        ["git", "check-attr", "--stdin", "-z", "merge"],
+    # Through the same helper as everything else: a second subprocess spelled by
+    # hand is how this call silently kept the caller's git environment while the
+    # module claimed to have none.
+    proc = _git_ok(
+        "check-attr",
+        "--stdin",
+        "-z",
+        "merge",
         cwd=REPO_ROOT,
-        input=files.stdout,
-        capture_output=True,
-        text=True,
-        check=True,
+        stdin=files.stdout,
     )
     # -z output is a flat NUL-separated stream of (path, attribute, value).
     fields = proc.stdout.split("\0")

--- a/tests/test_changelog_merge_attribute.py
+++ b/tests/test_changelog_merge_attribute.py
@@ -1,0 +1,196 @@
+"""The CHANGELOG merge driver, pinned by behaviour rather than by its text.
+
+Two branches that each add a bullet under the same ``[Unreleased]`` heading are
+not disagreeing — they are inserting at the same position. Git's default driver
+calls that a conflict. Measured 2026-09-04 against ``origin/main`` 2d5ea3dd: of
+49 open PRs, 21 could not merge, and 18 of those 21 conflicted on CHANGELOG.md
+and nothing else.
+
+``.gitattributes`` fixes that with ``/CHANGELOG.md merge=union``. The guarantee
+is carried by :func:`test_two_branches_appending_at_the_same_position_merge_without_conflict`,
+which copies the real artifact into a fresh repo and runs a real merge, paired
+with its negative control — the ``check-attr`` tests below are cheap
+corroboration and could pass on a repo-local override alone.
+
+Scope is graded over the complete tracked-file population rather than a list of
+paths someone thought to name. ``union`` resolves *silently*, and an unanchored
+pattern captures precisely the paths nobody enumerated, so a negative allowlist
+is structurally unable to catch the failure it exists for.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GITATTRIBUTES = REPO_ROOT / ".gitattributes"
+
+# Paths that must NOT inherit a silent union merge. The population check below
+# covers every TRACKED file; these are the cases it structurally cannot reach —
+# paths that do not exist in the tree but that a widened or unanchored pattern
+# would capture the moment someone added them.
+MUST_NOT_BE_UNION = (
+    "CHANGELOG.md.bak",  # catches a rule widened to a glob such as CHANGELOG*
+    "vendor/dep/CHANGELOG.md",  # catches an UNANCHORED pattern (no leading slash)
+    "docs/CHANGELOG.md",  # same, one level down
+    "scripts/release.sh",  # catches a rule widened to shell scripts
+    "src/genesis/new_module.py",
+)
+
+
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=False)
+
+
+def _git_ok(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run git and fail the test on a non-zero exit rather than sailing on."""
+    proc = _git(*args, cwd=cwd)
+    assert proc.returncode == 0, (
+        f"git {' '.join(args)} failed ({proc.returncode}): {proc.stderr.strip()}"
+    )
+    return proc
+
+
+def _merge_attr(path: str, cwd: Path) -> str:
+    """The merge attribute git resolves for ``path`` ("unspecified" if none).
+
+    Fails loudly on a git error or on output it does not recognise. Folding
+    either into ``"unspecified"`` would be fail-OPEN: that string is the PASS
+    value for every scope assertion here, so a broken helper — a typo'd
+    attribute name, a run outside a repo — would leave the whole scope suite
+    green while checking nothing.
+    """
+    proc = _git_ok("check-attr", "merge", "--", path, cwd=cwd)
+    line = proc.stdout.strip()
+    prefix = f"{path}: merge: "
+    assert line.startswith(prefix), f"unexpected check-attr output for {path!r}: {line!r}"
+    return line[len(prefix) :]
+
+
+def _make_repo(tmp_path: Path, *, with_attributes: bool) -> Path:
+    """A repo whose trunk holds a CHANGELOG with an [Unreleased] heading.
+
+    Deliberately hermetic: the ambient environment supplies an identity, a hooks
+    path and a signing setting, and a contributor whose global config turns on
+    ``commit.gpgsign`` without a key would otherwise get a silent no-commit that
+    surfaces later as a baffling merge failure in a test about merge drivers.
+    """
+    repo = tmp_path / ("with_attrs" if with_attributes else "without_attrs")
+    repo.mkdir()
+    _git_ok("init", "--quiet", "-b", "trunk", cwd=repo)
+    _git_ok("config", "user.email", "test@example.invalid", cwd=repo)
+    _git_ok("config", "user.name", "Test", cwd=repo)
+    _git_ok("config", "commit.gpgsign", "false", cwd=repo)
+    _git_ok("config", "core.hooksPath", str(repo / "no-such-hooks"), cwd=repo)
+
+    (repo / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- a pre-existing entry\n"
+    )
+    if with_attributes:
+        # Grade the REAL artifact, not a reconstruction of it. If the union line
+        # is deleted, misspelled, or its pattern stops matching CHANGELOG.md,
+        # this copy stops carrying the driver and the merge below conflicts.
+        shutil.copyfile(GITATTRIBUTES, repo / ".gitattributes")
+    _git_ok("add", "-A", cwd=repo)
+    _git_ok("commit", "--quiet", "-m", "base", cwd=repo)
+    return repo
+
+
+def _branch_adding_bullet(repo: Path, branch: str, bullet: str) -> None:
+    """Insert ``bullet`` at the top of the Fixed list — the collision shape."""
+    _git_ok("checkout", "--quiet", "-b", branch, "trunk", cwd=repo)
+    changelog = repo / "CHANGELOG.md"
+    changelog.write_text(
+        changelog.read_text().replace("### Fixed\n\n", f"### Fixed\n\n- {bullet}\n", 1)
+    )
+    _git_ok("add", "CHANGELOG.md", cwd=repo)
+    _git_ok("commit", "--quiet", "-m", f"add {bullet}", cwd=repo)
+
+
+def test_two_branches_appending_at_the_same_position_merge_without_conflict(
+    tmp_path: Path,
+) -> None:
+    """The acceptance case: the real collision shape resolves, keeping BOTH."""
+    repo = _make_repo(tmp_path, with_attributes=True)
+    _branch_adding_bullet(repo, "feature-a", "entry from branch A")
+    _branch_adding_bullet(repo, "feature-b", "entry from branch B")
+
+    _git_ok("checkout", "--quiet", "trunk", cwd=repo)
+    _git_ok("merge", "--quiet", "--no-edit", "feature-a", cwd=repo)
+    second = _git("merge", "--no-edit", "feature-b", cwd=repo)
+
+    assert second.returncode == 0, (
+        "the second branch conflicted on CHANGELOG.md — the union merge driver "
+        f"is not in effect.\nstdout: {second.stdout}\nstderr: {second.stderr}"
+    )
+    merged = (repo / "CHANGELOG.md").read_text()
+    # Union keeps both sides. Neither entry may be dropped, and no conflict
+    # markers may survive into the merged file.
+    assert "entry from branch A" in merged
+    assert "entry from branch B" in merged
+    assert "a pre-existing entry" in merged
+    assert "<<<<<<<" not in merged and ">>>>>>>" not in merged
+
+
+def test_without_the_attribute_the_same_merge_conflicts(tmp_path: Path) -> None:
+    """Negative control: the driver is what resolves it, not the content shape.
+
+    Without this, the test above could pass for reasons having nothing to do
+    with ``.gitattributes`` and would keep passing after the rule was deleted.
+    """
+    repo = _make_repo(tmp_path, with_attributes=False)
+    _branch_adding_bullet(repo, "feature-a", "entry from branch A")
+    _branch_adding_bullet(repo, "feature-b", "entry from branch B")
+
+    _git_ok("checkout", "--quiet", "trunk", cwd=repo)
+    _git_ok("merge", "--quiet", "--no-edit", "feature-a", cwd=repo)
+    second = _git("merge", "--no-edit", "feature-b", cwd=repo)
+
+    assert second.returncode != 0, (
+        "expected a CHANGELOG conflict with no .gitattributes present; if this "
+        "passes, the acceptance test above proves nothing about the driver"
+    )
+
+
+def test_union_applies_to_exactly_one_tracked_path() -> None:
+    """Grade the whole population, not a hand-picked sample.
+
+    A negative list can only fail on paths a reviewer thought to enumerate, and
+    the paths a widened or unanchored pattern actually captures are, by
+    definition, the ones nobody thought of. Since ``union`` resolves silently,
+    the invariant has to be an equality over every tracked file.
+    """
+    assert GITATTRIBUTES.is_file(), "repo-root .gitattributes is missing"
+    files = _git_ok("ls-files", "-z", cwd=REPO_ROOT)
+    proc = subprocess.run(
+        ["git", "check-attr", "--stdin", "-z", "merge"],
+        cwd=REPO_ROOT,
+        input=files.stdout,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # -z output is a flat NUL-separated stream of (path, attribute, value).
+    fields = proc.stdout.split("\0")
+    union_paths = {fields[i] for i in range(0, len(fields) - 2, 3) if fields[i + 2] == "union"}
+    assert union_paths == {"CHANGELOG.md"}, (
+        f"merge=union must apply to CHANGELOG.md and nothing else; got {sorted(union_paths)}"
+    )
+
+
+@pytest.mark.parametrize("path", MUST_NOT_BE_UNION)
+def test_union_does_not_reach_paths_that_do_not_exist_yet(path: str) -> None:
+    """``check-attr`` is pure pattern matching and never stats the path.
+
+    That is what makes these assertions meaningful: they describe files nobody
+    has added yet, which is exactly when an over-broad pattern does its damage —
+    the rule is already in place and inherited silently.
+    """
+    assert _merge_attr(path, cwd=REPO_ROOT) != "union", (
+        f"{path} inherited merge=union; union resolves silently and must apply "
+        "only to the repo-root CHANGELOG.md"
+    )

--- a/tests/test_changelog_merge_attribute.py
+++ b/tests/test_changelog_merge_attribute.py
@@ -163,6 +163,12 @@ def test_union_applies_to_exactly_one_tracked_path() -> None:
     the paths a widened or unanchored pattern actually captures are, by
     definition, the ones nobody thought of. Since ``union`` resolves silently,
     the invariant has to be an equality over every tracked file.
+
+    Scope of the guarantee, stated so it is not read as more than it is: this
+    grades the repository's own attribute surface. A developer who sets
+    ``merge.default`` locally routes every *unspecified* path to that driver,
+    and no committed file can prevent it — that is a per-machine choice, not
+    something this repo controls.
     """
     assert GITATTRIBUTES.is_file(), "repo-root .gitattributes is missing"
     files = _git_ok("ls-files", "-z", cwd=REPO_ROOT)

--- a/tests/test_changelog_merge_attribute.py
+++ b/tests/test_changelog_merge_attribute.py
@@ -6,20 +6,37 @@ calls that a conflict. Measured 2026-09-04 against ``origin/main`` 2d5ea3dd: of
 49 open PRs, 21 could not merge, and 18 of those 21 conflicted on CHANGELOG.md
 and nothing else.
 
-``.gitattributes`` fixes that with ``/CHANGELOG.md merge=union``. The guarantee
-is carried by :func:`test_two_branches_appending_at_the_same_position_merge_without_conflict`,
-which copies the real artifact into a fresh repo and runs a real merge, paired
-with its negative control — the ``check-attr`` tests below are cheap
-corroboration and could pass on a repo-local override alone.
+``.gitattributes`` fixes that with ``/CHANGELOG.md merge=union``. Note the
+leading slash: an unanchored pattern matches the basename at every depth, and
+that near-miss is the reason the scope tests exist at all.
 
-Scope is graded over the complete tracked-file population rather than a list of
-paths someone thought to name. ``union`` resolves *silently*, and an unanchored
-pattern captures precisely the paths nobody enumerated, so a negative allowlist
-is structurally unable to catch the failure it exists for.
+Four tests, and NONE of them is redundant — read this before deleting one:
+
+* :func:`test_two_branches_appending_at_the_same_position_merge_without_conflict`
+  carries the BEHAVIOURAL guarantee. It copies the real artifact into a fresh
+  repo and runs a real merge.
+* :func:`test_without_the_attribute_the_same_merge_conflicts` is its negative
+  control. Without it the test above could pass for reasons having nothing to do
+  with the attribute, and would keep passing after the rule was deleted.
+* :func:`test_union_applies_to_exactly_one_tracked_path` grades SCOPE as an
+  equality over every tracked file, because a widened pattern captures precisely
+  the paths nobody would have thought to enumerate.
+* :func:`test_union_does_not_reach_paths_that_do_not_exist_yet` covers what that
+  population check structurally CANNOT: paths absent from the tree. It is not a
+  weaker duplicate of the population check — it is the only test that fails on
+  an unanchored pattern today, since the one tracked ``CHANGELOG.md`` sits at
+  the root and satisfies both spellings. That is exactly the bug this rule
+  shipped with in review, and this is the test that would have caught it.
+
+The tests grade this repository's own attribute surface. A developer's local
+``merge.default`` routes unspecified paths to a driver regardless; no committed
+file can pin that, which is why every git subprocess here disables ambient
+config rather than trying to enumerate it.
 """
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -42,8 +59,30 @@ MUST_NOT_BE_UNION = (
 )
 
 
+# Ambient git configuration can decide the outcome of these tests, and
+# neutralising settings one at a time is whack-a-mole: `merge.default` routes
+# unspecified paths to a driver, `core.attributesFile` injects attributes from
+# outside the repo, `init.templateDir` can plant a `.git/info/attributes` (the
+# HIGHEST-precedence attribute source), `core.autocrlf` rewrites content before
+# a merge ever sees it. Rather than keep a list of them current, every git
+# subprocess here runs with global and system configuration switched off
+# outright, plus the system attributes file. One control instead of a checklist.
+_HERMETIC_ENV = {
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+    "GIT_ATTR_NOSYSTEM": "1",
+}
+
+
 def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=False)
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, **_HERMETIC_ENV},
+    )
 
 
 def _git_ok(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -74,18 +113,18 @@ def _merge_attr(path: str, cwd: Path) -> str:
 def _make_repo(tmp_path: Path, *, with_attributes: bool) -> Path:
     """A repo whose trunk holds a CHANGELOG with an [Unreleased] heading.
 
-    Deliberately hermetic: the ambient environment supplies an identity, a hooks
-    path and a signing setting, and a contributor whose global config turns on
-    ``commit.gpgsign`` without a key would otherwise get a silent no-commit that
-    surfaces later as a baffling merge failure in a test about merge drivers.
+    ``_git`` already disables global and system config, so nothing ambient
+    reaches this repo — including the setting that actually decides the negative
+    control's outcome (a global ``merge.default=union`` would resolve the merge
+    in the WITHOUT-attributes repo and turn that control green, voiding the only
+    proof that the attribute resolves anything). An identity is set here because
+    with global config off there is no longer one to inherit.
     """
     repo = tmp_path / ("with_attrs" if with_attributes else "without_attrs")
     repo.mkdir()
     _git_ok("init", "--quiet", "-b", "trunk", cwd=repo)
     _git_ok("config", "user.email", "test@example.invalid", cwd=repo)
     _git_ok("config", "user.name", "Test", cwd=repo)
-    _git_ok("config", "commit.gpgsign", "false", cwd=repo)
-    _git_ok("config", "core.hooksPath", str(repo / "no-such-hooks"), cwd=repo)
 
     (repo / "CHANGELOG.md").write_text(
         "# Changelog\n\n## [Unreleased]\n\n### Fixed\n\n- a pre-existing entry\n"


### PR DESCRIPTION
## What

`CHANGELOG.md` is an append-only list of independent bullets. Two branches that each add an entry under the same heading are not disagreeing — they are inserting at the same position, which git's default merge driver reports as a conflict a human resolves by hand. One line in a new `.gitattributes` gives that file git's built-in `union` driver.

## Read this first — two things it does NOT do

Both measured during review, and both narrowed this PR from what it originally claimed.

**1. It does not make a conflicting PR mergeable on GitHub.** GitHub ignores a repository's `.gitattributes` in its server-side merge. Measured against GitHub's own merge engine on two purpose-built branch pairs:

| `POST /repos/:owner/:repo/merges` | result |
|---|---|
| union attribute present in **both** commits | **409 Conflict** |
| control, no `.gitattributes` | 409 Conflict |

So a colliding PR still shows `CONFLICTING`, and `scripts/hooks/git_push_guard.py:5642` still refuses it — the gate reads GitHub's `mergeable` field, which this rule cannot move.

**2. It does not help a branch's *first* reconciliation with the base — the only one an already-open PR needs.** Attributes resolve from the **checkout**, not from the commits being combined, so on a branch created before this file existed the rule arrives *in* that operation and is not in effect during it. Measured on a real open PR: checked out at its head, pulling in the branch carrying the rule, `CHANGELOG.md` conflicts.

An earlier version of this PR claimed "18/18 clean locally". That measurement went the other way round — folding each PR *into* a checkout that already had the attribute — which is neither the workflow anyone performs nor the remedy the gate prints. **The claim is withdrawn**, not softened. Recording it here because the failure was in the acceptance bar, which exists to prevent exactly that.

## What it actually buys

Once a branch **contains** the file — every branch cut after this lands, and any older branch after its first reconciliation — later reconciliations resolve the changelog with no hand-editing. Measured in that direction across the same 18 PRs: all clean, with every bullet from both sides intact, while the three genuine conflicts (source, a shell script, an architecture doc) still conflict. Those three are the control proving the harness ran — an earlier run of this replay reported 18/18 while every merge was actually being refused by a dirty worktree, and only the controls exposed it.

The structural fix for the collision is one changelog fragment per change, so nothing shares a file at all. This does not replace that.

## Why it was worth measuring

Against `origin/main` 2d5ea3dd, via `git merge-tree --write-tree --name-only` over every conflicting PR: **49** open, **21** could not merge, **18** conflicted *only* on `CHANGELOG.md`.

## The sharp edges, all measured

**Anchored on purpose** (`/CHANGELOG.md`). A pattern with no slash matches the basename at every depth, like `.gitignore`, and would silently arm any future vendored changelog. This PR shipped with that bug in review; the negative-path test is the *only* test that catches it, because the sole tracked `CHANGELOG.md` sits at the root and satisfies both spellings.

**Union cannot express a removal.** One side deletes lines, the other edits the same hunk → the deleted lines come back at exit 0. Measured: the guardian's automated `git revert HEAD` on a clean tree is unaffected (both sides equal the base, so the driver never runs); reverting an older commit is absorbed but exits non-zero, which its caller checks.

**Union merges lines, not records.** Two entries sharing an aligned identical line collapse into one and the other loses its continuation — this reaches insertion-only merges, so "just adding a bullet" is not automatically safe. Measured rate on real work: **0 of 18**; it needs identical aligned lines and these entries are long distinctive prose.

**No ordering guarantee** — `gitattributes(5)`: "tends to leave the added lines in the resulting file in random order and the user should verify the result."

Caveats aimed at a person cutting a release live in the release runbook, where that person actually reads.

## Tests

Four, none redundant, and the docstring says which is which with the measurement behind it: a real merge in a temp repo built from the **real** artifact; its negative control; a scope check as an equality over the complete `git ls-files` population; and a negative-path check for paths that do not exist yet, which the population check structurally cannot reach. Every git subprocess drops inherited `GIT_*` variables and points `HOME`/`XDG_CONFIG_HOME` at an empty directory, because pinning ambient settings one at a time produced three findings in a row.

## Known open, dispositioned in-thread rather than fixed

Two reviewer findings are accepted as real and deliberately not fixed here, both in the test module and both failing in the safe direction: `$GIT_DIR/info/attributes` and a repo-local `core.attributesFile` are still readable by the scope queries (a false alarm on a contributor's machine, not a false pass in CI); and `ls-files -z` with `text=True` raises on a tracked non-UTF-8 pathname (fails loud, never vacuous).
