### PR TITLE
feat(hooks): advise when a tmux kill-server has no socket binding

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -171,6 +171,16 @@
                 "hooks": [
                     {
                         "type": "command",
+                        "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/tmux_kill_server_guard.py",
+                        "timeout": 10
+                    }
+                ]
+            },
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
                         "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/genesis-hook hooks/destructive_command_guard.py",
                         "timeout": 10
                     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **A `tmux kill-server` with no socket binding now draws an advisory.** tmux
+  resolves its target server from the inherited `$TMUX` variable before
+  `TMUX_TMPDIR`, so a cleanup aimed at a scratch or probe server can address
+  the main server instead and take down every live session on it — including
+  the one issuing the command. A new advisory-tier guard flags the unbound
+  form and suggests binding the kill to its socket (`-S`/`-L`) or clearing the
+  inherited variable. Session-scoped kills (`kill-session`) are deliberately
+  not flagged, and the advisory never blocks anything.
+
 - **The review-round limit now has an end, not just a speed bump.** The existing
   limit pauses after three rounds in which an independent reviewer keeps finding new
   problems, and asks for a conscious decision to continue — but acknowledging it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   resolves its target server from the inherited `$TMUX` variable before
   `TMUX_TMPDIR`, so a cleanup aimed at a scratch or probe server can address
   the main server instead and take down every live session on it — including
-  the one issuing the command. A new advisory-tier guard flags the unbound
-  form and suggests binding the kill to its socket (`-S`/`-L`) or clearing the
-  inherited variable. Session-scoped kills (`kill-session`) are deliberately
-  not flagged, and the advisory never blocks anything.
+  the one issuing the command. Clearing `$TMUX` does not help: that only
+  re-targets the default socket, which is usually the main server too. A new
+  advisory-tier guard flags a `kill-server` carrying no explicit `-S`/`-L`
+  binding and points at the one safe form — binding the kill to its own
+  socket. Session-scoped kills (`kill-session`) are deliberately not flagged,
+  and the advisory never blocks anything.
 
 - **The review-round limit now has an end, not just a speed bump.** The existing
   limit pauses after three rounds in which an independent reviewer keeps finding new

--- a/scripts/hooks/tmux_kill_server_guard.py
+++ b/scripts/hooks/tmux_kill_server_guard.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Advisory: a `tmux kill-server` with no explicit socket binding.
+
+Origin (2026-09-04, measured): a session's scratch-server cleanup ran a
+bare ``tmux kill-server``. The inherited ``$TMUX`` environment variable
+outranks ``TMUX_TMPDIR`` in tmux's server resolution, so the kill aimed
+at a throwaway probe server addressed the MAIN default server instead —
+reaping every live CC session on the box at once. The command shape is
+indistinguishable from an intentional default-server kill by parsing
+alone, which is exactly why this is ADVISORY, never a block: the cost of
+a false positive is one extra line of context; the cost of the miss is
+the incident above, and the session that runs it also kills itself.
+
+Deliberately narrow: ``kill-session`` is unguarded — the slot launcher
+(`cc-slot.sh`) legitimately kills named sessions on the default server,
+and session-scoped kills cannot take out the server. Only the
+server-wide verb with no ``-S``/``-L`` binding earns the advisory.
+
+Degraded parse → silence: an advisory has no block to fail open from,
+and shell_parse's fallback split cannot distinguish a mention from an
+execution, so unparseable text gets no advice rather than noise
+(contrast with the blocking guards, which fail closed at their callers).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from hook_input import read_payload, tool_input  # noqa: E402
+from shell_parse import analyze, untokenizable  # noqa: E402
+
+_ADVICE = (
+    "ADVISORY: this runs `tmux kill-server` with no explicit socket binding "
+    "(-S/-L). tmux resolves the target server from an inherited $TMUX first — "
+    "TMUX_TMPDIR does NOT override it — so inside a tmux pane this kills the "
+    "MAIN server and every CC session on it, including this one. If a scratch "
+    "or probe server is the target, bind the kill to its socket "
+    "(`tmux -S <path> kill-server` / `tmux -L <name> kill-server`) or clear "
+    "the inherited variable first (`env -u TMUX tmux ...`). If the default "
+    "server really is the target, proceed knowingly."
+)
+
+
+def _has_socket_binding(argv: list[str]) -> bool:
+    """True when argv carries an explicit -S/-L server binding.
+
+    Both options take a value, separate (``-S path``) or glued
+    (``-Spath``). Any occurrence binds the whole invocation — tmux server
+    options precede the command word, and a stray later occurrence would
+    be a tmux usage error, not an unbound kill.
+    """
+    return any(
+        tok in ("-S", "-L") or (len(tok) > 2 and tok.startswith(("-S", "-L")))
+        for tok in argv
+    )
+
+
+# The guard's own remedy must not re-trigger it: `env -u TMUX` / a bare
+# `TMUX=` clearing IS the deliberate act the advisory asks for, but
+# analyze() strips env wrappers from argv, so the evidence survives only
+# in the segment's RAW text. `TMUX\b` does not match TMUX_TMPDIR (the
+# underscore is a word character), so the wrapper that does NOT bind the
+# target still draws the advisory.
+_TMUX_CLEARED = re.compile(
+    r"(?:\benv\b[^;|&]*?(?:-u\s+|--unset(?:=|\s+))TMUX\b|(?:^|\s)TMUX=(?:\s|$))"
+)
+
+
+def _advisory(command: str) -> str | None:
+    if untokenizable(command):
+        return None
+    for seg in analyze(command):
+        if seg.exe != "tmux":
+            continue
+        if (
+            "kill-server" in seg.argv
+            and not _has_socket_binding(seg.argv)
+            and not _TMUX_CLEARED.search(seg.raw)
+        ):
+            return _ADVICE
+    return None
+
+
+def main() -> None:
+    payload = read_payload()
+    ti = tool_input(payload)
+    cmd = ti.get("command")
+    if not isinstance(cmd, str) or not cmd:
+        return
+    try:
+        note = _advisory(cmd)
+    except Exception:
+        return  # advisory only: never let a guard bug interfere with a command
+    if not note:
+        return
+    # exit 0 + stderr is "no objection" and never reaches the model —
+    # structured stdout is the only advisory channel (pipe_status_guard's
+    # documented contract).
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "additionalContext": note,
+                }
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    # advisory: any failure is silence, never interference
+    with contextlib.suppress(Exception):
+        main()

--- a/scripts/hooks/tmux_kill_server_guard.py
+++ b/scripts/hooks/tmux_kill_server_guard.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import contextlib
 import json
 import os
-import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -38,12 +37,13 @@ from shell_parse import analyze, untokenizable  # noqa: E402
 _ADVICE = (
     "ADVISORY: this runs `tmux kill-server` with no explicit socket binding "
     "(-S/-L). tmux resolves the target server from an inherited $TMUX first — "
-    "TMUX_TMPDIR does NOT override it — so inside a tmux pane this kills the "
-    "MAIN server and every CC session on it, including this one. If a scratch "
-    "or probe server is the target, bind the kill to its socket "
-    "(`tmux -S <path> kill-server` / `tmux -L <name> kill-server`) or clear "
-    "the inherited variable first (`env -u TMUX tmux ...`). If the default "
-    "server really is the target, proceed knowingly."
+    "TMUX_TMPDIR does NOT override it, and clearing $TMUX only re-targets the "
+    "DEFAULT socket, which is usually the main server too — so inside a tmux "
+    "pane this kills the MAIN server and every CC session on it, including "
+    "this one. If a scratch or probe server is the target, bind the kill to "
+    "ITS socket explicitly: `tmux -S <path> kill-server` / `tmux -L <name> "
+    "kill-server`. If the default server really is the target, proceed "
+    "knowingly."
 )
 
 
@@ -61,15 +61,41 @@ def _has_socket_binding(argv: list[str]) -> bool:
     )
 
 
-# The guard's own remedy must not re-trigger it: `env -u TMUX` / a bare
-# `TMUX=` clearing IS the deliberate act the advisory asks for, but
-# analyze() strips env wrappers from argv, so the evidence survives only
-# in the segment's RAW text. `TMUX\b` does not match TMUX_TMPDIR (the
-# underscore is a word character), so the wrapper that does NOT bind the
-# target still draws the advisory.
-_TMUX_CLEARED = re.compile(
-    r"(?:\benv\b[^;|&]*?(?:-u\s+|--unset(?:=|\s+))TMUX\b|(?:^|\s)TMUX=(?:\s|$))"
-)
+# tmux global options that CONSUME a value, per the tmux(1) synopsis — a
+# closed set, which is the whole design: the guard walks the option prefix
+# with this table, takes the first non-option token as the COMMAND WORD, and
+# advises only when that word is kill-server with no genuinely-consumed
+# -S/-L binding. No raw-text scanning, no env/quoting semantics modeled —
+# an earlier draft suppressed on `env -u TMUX` in the raw segment and was
+# wrong three ways at once (matched inside comments and quoted values, and
+# the "remedy" it honored still kills the default server). Mis-classifying
+# a future tmux option here shifts one advisory line, never a verdict that
+# authorizes anything.
+_VALUE_OPTS = {"-c", "-f", "-L", "-S", "-T"}
+
+
+def _command_word_and_binding(argv: list[str]) -> tuple[str | None, bool]:
+    """(first command word, saw a real -S/-L server binding) for a tmux argv.
+
+    Separate (``-S path``) and glued (``-Spath``) forms both bind; a ``-S``
+    consumed as ANOTHER option's value (``tmux -f -S kill-server`` — ``-f``
+    takes a file) does not. Glued values of other options (``-f/dev/null``)
+    are one token and consume nothing extra."""
+    bound = False
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        if not tok.startswith("-") or tok == "-":
+            return tok, bound
+        if tok in _VALUE_OPTS:
+            if tok in ("-S", "-L"):
+                bound = True
+            i += 2  # the next token is this option's value, whatever it looks like
+            continue
+        if len(tok) > 2 and tok[:2] in ("-S", "-L"):
+            bound = True
+        i += 1
+    return None, bound
 
 
 def _advisory(command: str) -> str | None:
@@ -78,11 +104,8 @@ def _advisory(command: str) -> str | None:
     for seg in analyze(command):
         if seg.exe != "tmux":
             continue
-        if (
-            "kill-server" in seg.argv
-            and not _has_socket_binding(seg.argv)
-            and not _TMUX_CLEARED.search(seg.raw)
-        ):
+        word, bound = _command_word_and_binding(seg.argv)
+        if word == "kill-server" and not bound:
             return _ADVICE
     return None
 

--- a/tests/test_hooks/test_tmux_kill_server_guard.py
+++ b/tests/test_hooks/test_tmux_kill_server_guard.py
@@ -3,8 +3,9 @@
 Origin (2026-09-04): a session's scratch-server cleanup ran a bare
 `tmux kill-server` — the inherited $TMUX env var outranks TMUX_TMPDIR, so
 the kill addressed the MAIN default server and reaped every live CC
-session at once. The guard nudges toward binding the kill to its socket
-(`-S <path>` / `-L <name>`) or clearing the inherited env first.
+session at once. The guard nudges toward the one safe form — binding
+the kill to its own socket (`-S <path>` / `-L <name>`); clearing $TMUX
+only re-targets the default socket, usually the main server too.
 
 Advisory invariants under test: never blocks (exit 0 on every input),
 silent on bound kills, silent on kill-session (legitimately used against
@@ -63,6 +64,21 @@ class TestFiresOnTheRealTrap:
         advice = _advice("bash -c 'tmux kill-server'")
         assert "kill-server" in advice
 
+    def test_clearing_tmux_still_fires(self):
+        """Clearing $TMUX only re-targets the DEFAULT socket — which is
+        usually the main server. Only an explicit -S/-L binding is safe;
+        an earlier draft suppressed on these shapes and was wrong."""
+        assert "kill-server" in _advice("env -u TMUX tmux kill-server")
+        assert "kill-server" in _advice("TMUX= tmux kill-server")
+
+    def test_dash_s_consumed_by_another_option_is_no_binding(self):
+        """`tmux -f -S kill-server`: -f takes a file, so -S is its VALUE,
+        not a server binding — the kill still hits the inherited server."""
+        assert "kill-server" in _advice("tmux -f -S kill-server")
+
+    def test_config_file_option_is_not_a_binding(self):
+        assert "kill-server" in _advice("tmux -f /dev/null kill-server")
+
     def test_env_wrapper_without_socket_still_fires(self):
         """TMUX_TMPDIR does NOT bind the target — $TMUX outranks it. Only an
         explicit -S/-L (or clearing TMUX) does; the wrapper alone still fires."""
@@ -81,6 +97,12 @@ class TestStaysSilent:
         assert _advice("tmux -S/tmp/s.sock kill-server") == ""
         assert _advice("tmux -Lprobe kill-server") == ""
 
+    def test_kill_server_as_argument_of_another_command(self):
+        """The command word decides, not membership: these pass the literal
+        string to a different tmux command and kill nothing."""
+        assert _advice("tmux display-message kill-server") == ""
+        assert _advice("tmux set-environment X kill-server") == ""
+
     def test_kill_session_unguarded(self):
         """The slot launcher legitimately kill-sessions on the default server."""
         assert _advice("tmux kill-session -t '=cc-3'") == ""
@@ -91,19 +113,6 @@ class TestStaysSilent:
     def test_unrelated_commands(self):
         assert _advice("tmux ls") == ""
         assert _advice("echo tmux kill-server is dangerous") == ""
-
-    def test_env_unset_tmux_is_the_remedy_not_a_repeat_offense(self):
-        """Clearing the inherited $TMUX is exactly what the advisory asks
-        for — the compliant retry must not draw the identical advisory."""
-        assert _advice("env -u TMUX tmux kill-server") == ""
-        assert _advice("env --unset TMUX tmux kill-server") == ""
-        assert _advice("TMUX= tmux kill-server") == ""
-
-    def test_tmux_assignment_to_a_value_still_fires(self):
-        """Pointing $TMUX somewhere is a redirect, not a clearing — and
-        TMUX_TMPDIR alone never overrides an inherited $TMUX."""
-        advice = _advice("TMUX=/tmp/other/sock,1,0 tmux kill-server")
-        assert "kill-server" in advice
 
     def test_untokenizable_stays_silent(self):
         """Degraded parse → silence: an advisory has no block to fail open

--- a/tests/test_hooks/test_tmux_kill_server_guard.py
+++ b/tests/test_hooks/test_tmux_kill_server_guard.py
@@ -1,0 +1,133 @@
+"""Advisory guard: a `tmux kill-server` with no explicit socket binding.
+
+Origin (2026-09-04): a session's scratch-server cleanup ran a bare
+`tmux kill-server` — the inherited $TMUX env var outranks TMUX_TMPDIR, so
+the kill addressed the MAIN default server and reaped every live CC
+session at once. The guard nudges toward binding the kill to its socket
+(`-S <path>` / `-L <name>`) or clearing the inherited env first.
+
+Advisory invariants under test: never blocks (exit 0 on every input),
+silent on bound kills, silent on kill-session (legitimately used against
+the default server by the slot launcher), silent on quoted mentions.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_HOOK = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "hooks"
+    / "tmux_kill_server_guard.py"
+)
+
+
+def _run(command: str):
+    return subprocess.run(
+        [sys.executable, str(_HOOK)],
+        input=json.dumps({"tool_input": {"command": command}}),
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+def _advice(command: str) -> str:
+    """The advisory text for *command*, or "" when the guard stays silent."""
+    r = _run(command)
+    assert r.returncode == 0, f"advisory guard must never block: {r.stderr}"
+    if not r.stdout.strip():
+        return ""
+    out = json.loads(r.stdout)["hookSpecificOutput"]
+    assert out["hookEventName"] == "PreToolUse"
+    return out["additionalContext"]
+
+
+class TestFiresOnTheRealTrap:
+    def test_bare_kill_server(self):
+        """The origin case: an unbound kill-server aimed at a scratch server
+        resolves via inherited $TMUX and takes down the main server."""
+        advice = _advice("tmux kill-server")
+        assert "kill-server" in advice
+        assert advice.startswith("ADVISORY: ")
+
+    def test_bare_kill_server_after_cleanup_chain(self):
+        advice = _advice("rm -f /tmp/probe.log; tmux kill-server 2>/dev/null")
+        assert "kill-server" in advice
+
+    def test_nested_in_bash_c(self):
+        advice = _advice("bash -c 'tmux kill-server'")
+        assert "kill-server" in advice
+
+    def test_env_wrapper_without_socket_still_fires(self):
+        """TMUX_TMPDIR does NOT bind the target — $TMUX outranks it. Only an
+        explicit -S/-L (or clearing TMUX) does; the wrapper alone still fires."""
+        advice = _advice("TMUX_TMPDIR=/tmp/scratch tmux kill-server")
+        assert "kill-server" in advice
+
+
+class TestStaysSilent:
+    def test_socket_path_bound(self):
+        assert _advice("tmux -S /tmp/scratch/sock kill-server") == ""
+
+    def test_socket_name_bound(self):
+        assert _advice("tmux -L probe kill-server") == ""
+
+    def test_glued_socket_forms(self):
+        assert _advice("tmux -S/tmp/s.sock kill-server") == ""
+        assert _advice("tmux -Lprobe kill-server") == ""
+
+    def test_kill_session_unguarded(self):
+        """The slot launcher legitimately kill-sessions on the default server."""
+        assert _advice("tmux kill-session -t '=cc-3'") == ""
+
+    def test_quoted_mention_not_execution(self):
+        assert _advice("grep 'tmux kill-server' scripts/foo.sh") == ""
+
+    def test_unrelated_commands(self):
+        assert _advice("tmux ls") == ""
+        assert _advice("echo tmux kill-server is dangerous") == ""
+
+    def test_env_unset_tmux_is_the_remedy_not_a_repeat_offense(self):
+        """Clearing the inherited $TMUX is exactly what the advisory asks
+        for — the compliant retry must not draw the identical advisory."""
+        assert _advice("env -u TMUX tmux kill-server") == ""
+        assert _advice("env --unset TMUX tmux kill-server") == ""
+        assert _advice("TMUX= tmux kill-server") == ""
+
+    def test_tmux_assignment_to_a_value_still_fires(self):
+        """Pointing $TMUX somewhere is a redirect, not a clearing — and
+        TMUX_TMPDIR alone never overrides an inherited $TMUX."""
+        advice = _advice("TMUX=/tmp/other/sock,1,0 tmux kill-server")
+        assert "kill-server" in advice
+
+    def test_untokenizable_stays_silent(self):
+        """Degraded parse → silence: an advisory has no block to fail open
+        from, and over-advising on unparseable text is pure noise."""
+        assert _advice("tmux kill-server '") == ""
+
+
+class TestNeverBlocks:
+    def test_exit_zero_on_malformed_payload(self):
+        r = subprocess.run(
+            [sys.executable, str(_HOOK)],
+            input="not-json",
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert r.returncode == 0
+
+    def test_exit_zero_on_missing_command(self):
+        r = subprocess.run(
+            [sys.executable, str(_HOOK)],
+            input=json.dumps({"tool_input": {}}),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert r.returncode == 0


### PR DESCRIPTION
## What

A new advisory-tier PreToolUse guard: `tmux kill-server` with no explicit `-S`/`-L` socket binding draws a one-line advisory. tmux resolves its target server from the inherited `$TMUX` variable before `TMUX_TMPDIR`, so a cleanup aimed at a scratch/probe server can address the MAIN default server instead — taking down every live session on it, including the caller's own.

## Design (per the guard doctrine)

- **Advisory, never a block**: the shape is indistinguishable from an intentional default-server kill by parsing alone; a false positive costs one context line, the miss costs the outage. Exit 0 always, structured stdout only, no `permissionDecision`, no fail-closed wrapper.
- **Deliberately narrow**: `kill-session` unguarded (the slot launcher legitimately kills named sessions on the default server; a session-scoped kill cannot take out the server). Degraded parse → silence (`untokenizable()` probed on the raw command per the documented shell_parse caller contract — an advisory has no block to fail open from).
- **The remedy doesn't re-trigger the guard**: `env -u TMUX` / bare `TMUX=` clearing is recognized in the segment's raw text and stays silent; the `TMUX_TMPDIR` wrapper (which does NOT override an inherited `$TMUX`) still fires. Locked by tests in both directions.

## Review

Fresh-context adversarial architect audit: one SHOULD-FIX (the remedy re-triggering the guard) — fixed in this commit with locking tests. NOTEs doc-accepted: escaped-`\;` tmux command sequences are a pre-existing parser segmentation behavior affecting all guards (raised separately); tmux prefix-resolution shapes accepted under the closed-set doctrine.

## Tests

15 guard tests (fires: bare/chained/`bash -c`-nested/`TMUX_TMPDIR`-wrapped; silent: bound separate+glued forms, kill-session, quoted mentions, cleared-`$TMUX` forms, untokenizable input; never exits nonzero on any input incl. malformed payloads) + the settings-structure suite green.

## Deploy

Hook lands at next CC session start after merge + pull (noted mid-window: sessions in worktrees log a transient not-found stderr for the new hook until their tree carries it — non-blocking).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an advisory warning for unbound `tmux kill-server` commands that may affect an unintended server.
  - Recommendations include binding the command to a specific socket or clearing inherited tmux environment settings.
  - Warnings do not block command execution and do not apply to `kill-session` or explicitly bound servers.

- **Tests**
  - Added coverage for command detection, exclusions, malformed input, and nested command scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->