### PR TITLE
docs(review): take documentation out of automated review, and prose down to fact-checking

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -33,12 +33,31 @@ reviews:
 
   # Excluded from review, not from the repo. Each of these is either machine-
   # generated or binary, so a reviewer comment on it can never be actionable.
+  #
+  # DOCUMENTATION is excluded for a different reason, and it is a deliberate
+  # trade rather than an oversight: prose ships no behaviour, so a finding on it
+  # cannot prevent a defect, while it costs exactly what a finding on code costs
+  # — a review round, and a merge held. This reviewer's budget goes to the code.
+  #
+  # WHAT THIS GIVES UP, stated so it is a choice and not a discovery: this is the
+  # reviewer that actually READS prose, so nothing automated now reads the
+  # changelog or docs of a PUBLIC repo for an inadvertent disclosure. The CI leak
+  # detector still scans every diff for known private patterns, and the pre-push
+  # privacy review still runs, but those match PATTERNS — they do not read a
+  # sentence and notice it reveals something. Keep that in mind when a docs PR
+  # describes infrastructure.
   path_filters:
     - "!src/genesis/dashboard/webui/vendor/**"
     - "!**/*.min.js"
     - "!**/*.min.css"
     - "!docs/images/**"
     - "!**/package-lock.json"
+    # Documentation — see the note above.
+    - "!**/*.md"
+    - "!**/*.rst"
+    - "!**/*.adoc"
+    - "!**/*.asciidoc"
+    - "!docs/**"
 
   # The walkthrough is read at merge time; keep it to substance.
   poem: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -52,12 +52,25 @@ reviews:
     - "!**/*.min.css"
     - "!docs/images/**"
     - "!**/package-lock.json"
-    # Documentation — see the note above.
+    # Documentation — see the note above. Filtered by EXTENSION, deliberately not
+    # by directory: a blanket `!docs/**` would also hide anything under docs/ that
+    # is not prose, and there is exactly such a file —
+    # docs/genesis-architecture-interactive.html, a user-facing page linked from
+    # the README that carries its own interaction logic. Excluding executable code
+    # is not the trade that was made here; excluding prose is.
+    # BOTH forms on purpose. Glob implementations disagree about whether `**/`
+    # matches ZERO directories, so `**/*.md` alone may not cover a TOP-LEVEL file —
+    # which is precisely CHANGELOG.md and AGENTS.md, the ones this exclusion exists
+    # for. Betting on the matcher's semantics here would fail silently and look
+    # like the filter simply not working.
+    - "!*.md"
     - "!**/*.md"
+    - "!*.rst"
     - "!**/*.rst"
+    - "!*.adoc"
     - "!**/*.adoc"
+    - "!*.asciidoc"
     - "!**/*.asciidoc"
-    - "!docs/**"
 
   # The walkthrough is read at merge time; keep it to substance.
   poem: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,39 @@ not to confirm:
   itself a review failure.
 - **End with a verdict:** `Ready to merge: Yes | No | With fixes` + a one-line reason.
 
+### Documentation is out of scope for review
+
+Do not review CHANGELOG entries, release notes, README, or ordinary `docs/`
+prose, and do not raise findings on them. They ship no behaviour: an imprecise
+sentence in a changelog cannot break an install, while a review round spent on
+one costs the same as a round spent on the code that can. Skip them and put the
+whole budget on executable code.
+
+This does NOT relax factual accuracy where prose makes a CHECKABLE claim about
+behaviour — "restores the previous behaviour exactly", "defaults to off", a
+config key or a path. If such a statement contradicts the diff it describes, that
+is a code-adjacent defect and is still worth one line. The distinction is between
+*wrong* and merely *improvable*: report the first, ignore the second.
+
+<!-- BEGIN prose-review-scope (temporary; remove this block to restore full prose review) -->
+### Prompts, skills and other prose: basic factual accuracy only
+
+Markdown, agent and skill definitions, and other prose surfaces get a
+FACTUAL-ACCURACY pass, not the adversarial enumeration above. Check that what the
+text asserts matches the code it describes — a named file, function, flag,
+default or command that does not exist, or a claim the diff contradicts. Stop
+there.
+
+Do not enumerate wording, structure, tone, completeness, redundancy, or
+hypothetical misreadings by a future reader, and do not open a finding whose
+remedy is a rewrite for clarity. Prose in this repository is deliberately long
+and argumentative because it has to survive being read out of context by a fresh
+session; density there is a feature, and reviewing it as if it were code produces
+volume without defects.
+
+Executable code is unaffected by this section — review it in full.
+<!-- END prose-review-scope -->
+
 ## GitNexus — Code Intelligence (advisory)
 
 This repo is indexed by GitNexus. The MCP tools (`impact`, `query`,


### PR DESCRIPTION
## What

Takes documentation out of automated review, and drops prompt/skill prose to a factual-accuracy pass. Owner-directed.

Two files, two reviewers — and they are **not equally strong**, which is the main thing to know before merging.

## CodeRabbit — enforced

`.coderabbit.yaml` already declared `path_filters`; this extends the same list with `**/*.md`, `**/*.rst`, `**/*.adoc`, `**/*.asciidoc`, `docs/**`. This layer genuinely works — the reviewer will not read those paths.

**Timing caveat, from the file's own header:** *"Config on the DEFAULT branch governs every pull request. A copy on a feature branch does not take effect for that branch's own PR."* So this does **not** quiet CodeRabbit on this PR — it applies from the merge onward. A CodeRabbit comment on this PR's own markdown is not the change failing.

## AGENTS.md — advisory only

Codex has **no repository config file** (verified: no `.codex*`, no `codex.*` anywhere in the tree). Its documented lever is prose in `AGENTS.md`, so both entries below are a *request*, not enforcement.

**A sharper caveat:** OpenAI documents Codex Code Review as honouring a `## Code Review Rules` heading. This repo's heading is `## Code Review Mandate`. So it isn't established that *any* existing guidance in this file reaches Codex, and these entries inherit that uncertainty. Deliberately **not** renamed here — that's a separate change with its own blast radius, and bundling a heading rename into a scope change would confound both.

**Entry 1 — documentation out of scope.** Permanent. Excludes changelog, release notes, README and ordinary `docs/` prose.

**Entry 2 — prose to factual accuracy only.** Temporary, wrapped in a single removable block:

```
<!-- BEGIN prose-review-scope (temporary; remove this block to restore full prose review) -->
...
<!-- END prose-review-scope -->
```

Restoring full prose review is one deletion.

## The carve-out that stays

A prose statement making a **checkable claim about behaviour** — "restores the previous behaviour exactly", a default, a config key, a path — that **contradicts the diff** is still reportable.

That isn't hypothetical. Codex caught exactly such a false claim on #1689 today (`score` mode does *not* restore the previous behaviour), and a blanket exclusion would have suppressed it. The line drawn is between **wrong** and merely **improvable**.

## What this gives up

Written into the config rather than left to be discovered: CodeRabbit is the reviewer that actually *reads* prose. After this, nothing automated reads the changelog or docs of a **public** repo for an inadvertent disclosure. The CI leak detector and the pre-push privacy review still run — but they match **patterns**. They do not read a sentence and notice what it reveals.

Flagged before the change; the trade was accepted.

## Considered and rejected

Making the Codex side enforceable. There's no mechanism, and claiming otherwise would be the more dangerous outcome — an owner believing prose review is switched off when it is merely requested.

## Verification

`.coderabbit.yaml` parses as valid YAML with all ten filters reading back; `AGENTS.md` carries both block markers. Two files, +52/−0, no code. Privacy grep clean.

**Noted, not fixed:** `AGENTS.md` is itself doc-exempt at the merge gate after #1689, and the commit gate doesn't class it as a prompt surface — so this very file passes both gates with an unresolved finding. Already tracked as follow-up `0e9fbc61` with informed acceptance; recorded because this PR edits one of the five files that hole names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review filters to exclude Markdown, reStructuredText, and AsciiDoc documentation files at repository-root and nested paths.
  * Executable documentation files, such as interactive HTML pages, remain eligible for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->