### PR TITLE
docs(process): the zero-drop rule — finish before you stop, and review as you build

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -929,22 +929,36 @@ interactive one does). What this paragraph adds is the named DEFAULT below the
 substantial line: for an ordinary code commit, run the built-in `/code-review`
 at **low** effort and let its findings feed the evidence you mark. Cheap,
 catches drift while the fix is one edit instead of a review round, and it is
-NOT a clearance — the marker flow is unchanged. (Commits the table below rates
-"None" — docs, mechanical renames — stay exempt as ever.) Every defect that
+NOT a clearance — the marker flow is unchanged. (The gate auto-allows a
+docs/config-only commit; any code change goes through the marker flow, and the
+gate itself sets the depth — an ordinary edit takes a plain marker, a
+substantial or prompt-surface one takes the adversarial pass.)
+Every defect that
 survives to the end-of-build review costs an adversarial cycle there, and
 every one that survives THAT costs an external Codex round against the
 escalation cap.
 
-**For a SUBSTANTIAL change, the end-of-build review is canonical, not the
-builder's choice: run `/deep-review`.** Substantial is the commit gate's own
-definition — ≥50 reviewable lines, more than one code file, or any auth /
-API / migration / prompt / agent / skill surface. `/deep-review` dispatches
-the adversarial pass in the required shape (genesis-architect, plus
-genesis-security-reviewer when the diff touches a security surface) and
-writes the evidence marker the gate reads. Below substantial, the table
-governs: a small focused fix ends with code-reviewer inline. `/audit-changes`
-stays what it is — a light self-check that writes no marker — and is a
-terminus for nothing beyond the table's "None" rows.
+**For a SUBSTANTIAL change, the end-of-build adversarial review is canonical,
+not the builder's choice: run `/deep-review`.** Judge substantial at end of
+build over the WHOLE branch — the `merge-base(HEAD, origin/main)..working-tree`
+range `/deep-review` and the CI check examine — not the last staged commit: the
+commit gate classifies each commit's own staged diff, so continuous commits
+leave the index empty and a branch split into individually-small commits would
+otherwise slip the bar it clears in aggregate. The threshold VALUES are the
+commit gate's — ≥50 reviewable lines, more than one code file, or any auth /
+API / migration / prompt / agent / skill surface (the prompt-surface trigger
+excludes the user-sovereign top-level CAPS docs, CLAUDE.md / SOUL.md / USER.md)
+— applied here to the branch range rather than one staged commit. `/deep-review`
+dispatches the adversarial pass in the required shape (genesis-architect, plus
+genesis-security-reviewer when the diff touches a security surface) and writes
+the evidence marker the gate reads; it is the end-of-build terminus, riding on
+TOP of the during-build `/code-review` inline passes — which is exactly the
+table's "Code-reviewer inline + `/deep-review`" for a substantial row, the two
+playing different positions rather than a choice between them. Below
+substantial, the table governs: a small focused fix ends with code-reviewer
+inline. `/audit-changes` stays what it is — a light self-check that writes no
+marker — and is a terminus only where the gate needs no marker at all: a
+docs/config-only commit it auto-allows.
 
 Choose the review level proportional to the change:
 

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -920,15 +920,20 @@ For "does Genesis already have X", consult the subsystem map
 
 ## Adaptive Review Protocol
 
-**Review early and often DURING the build, not only at the end.** After each
-meaningful chunk of CODE — a function wired, a guard changed, a test file
-written — run the built-in `/code-review` at **low** effort. It is cheap, it
-is not a gate, and it clears nothing; its value is catching drift while the
-fix is one edit instead of a review round. (Chunks the table below rates
-"None" — docs, mechanical renames — need no in-build pass either.) Every
-defect that survives to the end-of-build review costs an adversarial cycle
-there, and every one that survives THAT costs an external Codex round against
-the escalation cap.
+**Review rides the commit, because the commit is the only mechanical
+trigger.** "After each meaningful chunk" is unenforceable — nobody can gate a
+vibe — but this repo commits continuously, so the commit IS the chunk, and the
+commit gate already refuses unreviewed code commits in every session type
+(hooks are session-agnostic; a dispatched builder hits the same gate an
+interactive one does). What this paragraph adds is the named DEFAULT below the
+substantial line: for an ordinary code commit, run the built-in `/code-review`
+at **low** effort and let its findings feed the evidence you mark. Cheap,
+catches drift while the fix is one edit instead of a review round, and it is
+NOT a clearance — the marker flow is unchanged. (Commits the table below rates
+"None" — docs, mechanical renames — stay exempt as ever.) Every defect that
+survives to the end-of-build review costs an adversarial cycle there, and
+every one that survives THAT costs an external Codex round against the
+escalation cap.
 
 **For a SUBSTANTIAL change, the end-of-build review is canonical, not the
 builder's choice: run `/deep-review`.** Substantial is the commit gate's own

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -920,6 +920,27 @@ For "does Genesis already have X", consult the subsystem map
 
 ## Adaptive Review Protocol
 
+**Review early and often DURING the build, not only at the end.** After each
+meaningful chunk of CODE — a function wired, a guard changed, a test file
+written — run the built-in `/code-review` at **low** effort. It is cheap, it
+is not a gate, and it clears nothing; its value is catching drift while the
+fix is one edit instead of a review round. (Chunks the table below rates
+"None" — docs, mechanical renames — need no in-build pass either.) Every
+defect that survives to the end-of-build review costs an adversarial cycle
+there, and every one that survives THAT costs an external Codex round against
+the escalation cap.
+
+**For a SUBSTANTIAL change, the end-of-build review is canonical, not the
+builder's choice: run `/deep-review`.** Substantial is the commit gate's own
+definition — ≥50 reviewable lines, more than one code file, or any auth /
+API / migration / prompt / agent / skill surface. `/deep-review` dispatches
+the adversarial pass in the required shape (genesis-architect, plus
+genesis-security-reviewer when the diff touches a security surface) and
+writes the evidence marker the gate reads. Below substantial, the table
+governs: a small focused fix ends with code-reviewer inline. `/audit-changes`
+stays what it is — a light self-check that writes no marker — and is a
+terminus for nothing beyond the table's "None" rows.
+
 Choose the review level proportional to the change:
 
 | Change type | Review level | Examples |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,7 +460,11 @@ When a user shares a file path or URL in conversation:
   work. When something genuinely cannot finish this turn, every unfinished
   piece becomes a tracked row BEFORE stopping: ledger or follow-up — or an
   issue, which keeps its per-instance approval gate from "Where deferred
-  work goes" below, this rule waives nothing. An untracked remainder is a
+  work goes" below, this rule waives nothing. Where none of those trackers
+  is reachable — a non-Genesis client (Codex, Cursor) reads this file with no
+  ledger or follow-up tool — the fallback is a structured handoff that NAMES
+  every unfinished piece in your final message; a named remainder is tracked,
+  an unnamed one is dropped. An untracked remainder is a
   drop, not a deferral, and a plan-file bullet is not a row. On the next
   prompt, reconcile your own stranded artifacts early — ordered behind
   anything the user's prompt makes urgent — before taking on discretionary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -453,6 +453,21 @@ When a user shares a file path or URL in conversation:
   decision or durable record.
 - **NEVER `rm -rf` the working directory.** Never run destructive commands
   without explicit user confirmation.
+- **Finish before you stop — the zero-drop rule.** A turn may run as long as
+  the work requires; never yield with steps you could still complete AND are
+  cleared to complete — stopping for an approval, a blocking question, plan
+  approval, or a designed hard stop is finishing correctly, not dropping
+  work. When something genuinely cannot finish this turn, every unfinished
+  piece becomes a tracked row BEFORE stopping: ledger or follow-up — or an
+  issue, which keeps its per-instance approval gate from "Where deferred
+  work goes" below, this rule waives nothing. An untracked remainder is a
+  drop, not a deferral, and a plan-file bullet is not a row. On the next
+  prompt, reconcile your own stranded artifacts early — ordered behind
+  anything the user's prompt makes urgent — before taking on discretionary
+  new work. The answer to "what has fallen through the cracks?" is MADE
+  zero: enumerate, then fix or file what the enumeration finds. (Origin
+  2026-09-04: finished, tested code sat unpushed on a local branch for 1.5
+  days because it was recorded only in a plan file nothing reads back.)
 - **Session wrap-up**: structured handoff — what changed, what's pending,
   what was learned. If it's not committed, it doesn't exist.
 - **Where deferred work goes.** Bias = FIX NOW; defer only if the work is (1) blocked


### PR DESCRIPTION
## What

Two instruction-surface additions from a measured failure: finished, tested code sat unpushed on a local branch for **1.5 days**, invisible to every session, because it was recorded only in a plan file nothing reads back.

**CLAUDE.md — the zero-drop rule.** A turn runs as long as the work requires; never yield with steps you could still complete *and are cleared to complete* — stopping for an approval, a blocking question, plan approval, or a designed hard stop is finishing correctly, not dropping work. What genuinely can't finish becomes a tracked row before stopping (and an issue keeps its per-instance approval gate — the rule waives nothing). Next prompt: reconcile your own stranded artifacts early, ordered behind whatever the user made urgent. "What fell through the cracks?" is *made* zero — enumerate, then fix or file what the enumeration finds.

**genesis-development — review as you build.** The built-in `/code-review` at **low** effort after each meaningful chunk of code: cheap, not a gate, catches drift while the fix is one edit instead of a review round. For a **substantial** change (the commit gate's own definition), the end-of-build review is canonical, not the builder's choice: `/deep-review`. Below substantial, the existing table governs unchanged.

## Reviewed as instructions, and the review earned its keep

An adversarial pass hunted for readings where a literal agent obeys the text into the wrong behavior. It found a **blocker in the rule itself**: the first draft listed "issue" among the row types to create *before stopping*, with no approval caveat — thirty lines above the same file's rule that a public post needs explicit approval every time and that a channel-driven session cannot confirm anything. A gate bypass written in the grammar of hygiene, inside the rule built to prevent drops.

Also fixed before commit: "never yield with steps you could still complete" tested *capability* where the legitimate stops are *permission* (the carve-out now names them); "reconcile FIRST" hardened the deliberately-soft ≈51/49 close-bias and inverted priority for urgent prompts (now "early, ordered behind the user's ask"); the canonical-review claim overclaimed below the gate's substantiality line (verified against the gate source — it now uses the gate's definition verbatim); a citation pointed at a table that didn't contain the claim; and "the answer is always zero" pre-committed a conclusion a lazy agent could satisfy by asserting — it is now a process.

The mechanical half of this rule — the stranded-work detector and session-exit gate that *enforce* what this prose asks — is specced separately (session-roles design §8.11) and handed off for build; this PR is the floor, not the mechanism.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that continuously committed code changes are the standard unit for routine reviews.
  - Established lightweight reviews as the default for ordinary code commits, with deeper review required for substantial branch changes.
  - Documented exemptions for documentation-only and configuration-only commits.
  - Added a requirement to complete cleared work before stopping or explicitly identify every unfinished item in the final handoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->