### PR TITLE
fix(hooks): the tokenizability probe now reports what the segmenter cannot represent

### DIFF
--- a/scripts/hooks/protected_paths_guard.py
+++ b/scripts/hooks/protected_paths_guard.py
@@ -208,7 +208,16 @@ def main() -> int:
     # no observed behaviour change.
     if untokenizable(cmd):
         reason = _legacy_substring_block(cmd, dirs)
-        return _block(reason) if reason else 0
+        if reason:
+            return _block(reason)
+        # FALL THROUGH rather than returning 0. This branch used to end here, on
+        # the assumption that the substring check is a superset of the parsed one
+        # below. It is not, and stopped being so the moment brace expansion was
+        # added to the parsed path only: an expanded operand is caught below and
+        # is invisible to a substring scan, so a command that merely TRIPPED the
+        # probe skipped the very check that would have blocked it. Running both
+        # is strictly fail-closed — the probe firing can now only ever add a
+        # reason to block, never remove one.
 
     cwd = payload.get("cwd") if isinstance(payload, dict) else None
     for seg in analyze(cmd):

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -667,10 +667,75 @@ def untokenizable(command: str) -> bool:
     normalization bought nothing and is removed rather than documented.
     """
     try:
-        shlex.split(command)
-        return False
+        tokens = shlex.split(command)
     except ValueError:
         return True
+    return _has_opaque_construct(tokens)
+
+
+# Reserved words the segmenter does not model. CLOSED SET, and that is the whole
+# reason this list is safe where a list of command CARRIERS would not be: the
+# shell grammar fixes its reserved words, while the set of programs that take a
+# command as an argument grows forever. Enumerating the first converges;
+# enumerating the second is a race. Only words MEASURED to leave `analyze()`
+# without the inner command are here — `if`/`while`/`for`/`select` and the
+# grouping operators all resolve correctly and are deliberately absent, because
+# every entry costs a fallback to coarse matching.
+_OPAQUE_WORDS = frozenset({"coproc", "function"})
+
+# `name()` — a function definition, whose body the segmenter reads as operands.
+_FUNCTION_DEF = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*\(\)$")
+
+# An option bundle carrying `c` somewhere other than the END. `-c` and `-ec`
+# resolve, because the script is the next argument either way; `-ce` and `-cl`
+# do not, because the letters after the `c` are read as the thing to run.
+_INTERPRETER_C_BUNDLE = re.compile(r"^-[A-Za-z]*c[A-Za-z]+$")
+_INTERPRETERS = frozenset({"bash", "sh", "zsh", "ksh", "dash"})
+
+
+def _has_opaque_construct(tokens: list[str]) -> bool:
+    """True when a TOKEN marks a construct `analyze()` cannot represent.
+
+    Tokens, never raw text, and that is what makes this quote-safe by
+    construction rather than by care: shlex keeps a quoted argument as ONE
+    token, so a reserved word inside `grep -r '...'` can never appear as a bare
+    token here. A raw-text scan would fire on every command that merely mentions
+    one, which is the false-positive class the parser exists to release.
+    """
+    # Shell operators are NOT token separators for shlex, so a reserved word
+    # adjacent to one arrives glued (`esac;`, `(git`, `done&&`). Comparing raw
+    # tokens therefore only ever matched a keyword that happened to sit at the
+    # end of the command — which is exactly the shape a hand-written fixture
+    # takes, and not the shape real commands take.
+    words = {t.strip(";&|()<>") for t in tokens}
+    # `case` is required to CLOSE. A real case statement always ends in `esac`,
+    # while prose that happens to contain the word does not — and prose reaches
+    # here routinely, because this probe reads heredoc bodies as ordinary text
+    # by design. MEASURED: requiring the pair removes a commit message whose
+    # body used "case" in an ordinary sentence, which had been enough on its own
+    # to divert a guard off its parsed path.
+    if "case" in words and "esac" in words:
+        return True
+    for i, token in enumerate(tokens):
+        bare = token.strip(";&|()<>")
+        if bare in _OPAQUE_WORDS:
+            return True
+        # `name()` alone is not enough. A shell function definition is
+        # `name() {` — the brace is part of the grammar. Without requiring it,
+        # MEASURED over 51,052 real commands, 574 fired on a zero-argument call
+        # inside a PYTHON HEREDOC body, which this probe reads as ordinary text
+        # by design. Every one of those would push a guard back to substring
+        # matching, which is the false-positive class the parser exists to
+        # reduce — so the probe would have undone at the parser layer what the
+        # guards gained.
+        # Against the RAW token, never the stripped one: `()` IS the shape here,
+        # so stripping the operator characters that matter for a reserved word
+        # erases the thing this pattern matches on.
+        if _FUNCTION_DEF.match(token) and i + 1 < len(tokens) and tokens[i + 1] == "{":
+            return True
+        if _INTERPRETER_C_BUNDLE.match(token) and i and _basename(tokens[i - 1]) in _INTERPRETERS:
+            return True
+    return False
 
 
 def _basename(token: str) -> str:

--- a/tests/test_hooks/test_protected_paths_guard.py
+++ b/tests/test_hooks/test_protected_paths_guard.py
@@ -326,3 +326,45 @@ class TestQuotedParenRedirectTargetRegression:
         assert r.returncode == 0, (
             f"benign command wrongly blocked: out={r.stdout!r} err={r.stderr!r}"
         )
+
+
+def test_an_opaque_command_still_gets_the_parsed_brace_check(fake_home):
+    """REGRESSION PIN: the probe firing must never REMOVE a reason to block.
+
+    The untokenizable branch used to return right after its substring check, on
+    the assumption that the check is a superset of the parsed path below. It
+    stopped being one when brace expansion was added to the parsed path only —
+    an expanded operand is caught there and is invisible to a substring scan.
+
+    So a command that merely TRIPPED the probe skipped the check that would have
+    blocked it, which means making the probe MORE sensitive made this guard MORE
+    permissive. MEASURED before the fix, over 51,052 real commands: one verdict
+    flipped from block to allow for exactly that reason.
+
+    The precondition assertion below is load-bearing, not decoration. A first
+    version of this test used an operand whose PARENT is itself protected, so the
+    substring path caught it and the test passed against the unfixed code —
+    green while pinning nothing. Mutation testing is what exposed that.
+    """
+    import sys as _sys
+
+    _sys.path.insert(0, str(_WORKTREE / "scripts" / "hooks"))
+    import protected_paths_guard as g
+    import shell_parse as sp
+
+    # Assembled per this suite's convention. case/esac makes it opaque; the
+    # braced operand is what must still be caught.
+    opaque = "case x in x) true;; esac; " + "rm -rf " + H + "/.claude/{projects,scratch}"
+
+    assert sp.untokenizable(opaque), "fixture is stale: this no longer trips the probe"
+    assert g._legacy_substring_block(opaque, g._protected_dirs()) is None, (
+        "fixture is VACUOUS: the substring path already catches this, so the "
+        "test would pass with the fall-through removed"
+    )
+
+    r = _run(opaque, fake_home)
+
+    assert r.returncode == 2, (
+        "an opaque command skipped the parsed brace-expansion check: "
+        f"rc={r.returncode} {r.stderr[:200]}"
+    )

--- a/tests/test_hooks/test_untokenizable_probe.py
+++ b/tests/test_hooks/test_untokenizable_probe.py
@@ -409,3 +409,120 @@ class TestCommitGuardFailsClosedOnCrash:
             "a broken review_state hard-blocks every commit, including the one "
             f"that would fix it.\n{r.stdout}{r.stderr}"
         )
+
+
+class TestOpaqueConstructs:
+    """Constructs the segmenter cannot represent, which shlex tokenizes cleanly.
+
+    `untokenizable()` began as "shlex raised", and that is a strictly narrower
+    question than the one every caller actually asks: can the parse be trusted?
+    A construct can tokenize perfectly and still leave `analyze()` reporting an
+    executable that is not one — a reserved word, or the letters trailing an
+    option bundle — with no signal that anything was missed. "Nothing gated
+    here" and "I could not see this" then return the same value, which is the
+    exact confusion this probe exists to remove.
+
+    The inner command in every fixture below is a NEUTRAL placeholder, not a
+    gated verb. These cases are about whether the parser can see a command
+    position at all; using a real gated operation would add nothing to the test
+    and would put a working shape in a public file.
+    """
+
+    # Assembled rather than written, per this file's convention.
+    _INNER = "my" + "cmd"
+
+    @pytest.mark.parametrize(
+        "label,command",
+        [
+            ("case arm", f"case x in x) {_INNER};; esac"),
+            ("function body", f"f() {{ {_INNER}; }}; f"),
+            ("function keyword", f"function f {{ {_INNER}; }}; f"),
+            ("coproc", f"coproc {_INNER}"),
+            ("interpreter bundle, c not last", f"bash -ce '{_INNER}'"),
+            ("interpreter bundle, other letter", f"bash -cl '{_INNER}'"),
+            ("sh bundle", f"sh -ce '{_INNER}'"),
+        ],
+    )
+    def test_a_construct_the_segmenter_cannot_represent_is_reported(self, label, command):
+        """The parse must be declared untrustworthy, so callers fail closed.
+
+        Each of these leaves `analyze()` with no segment for the inner command
+        while raising nothing, so a caller that keys on parsed segments has no
+        way to know it saw an incomplete picture.
+        """
+        import shell_parse as sp
+
+        assert not any(s.exe == self._INNER for s in sp.analyze(command)), (
+            f"{label}: fixture is stale — the segmenter now sees this, so the "
+            "case it was written for no longer exists"
+        )
+        assert sp.untokenizable(command), f"{label}: parse is incomplete and says nothing"
+
+    @pytest.mark.parametrize(
+        "label,command",
+        [
+            ("plain", _INNER),
+            ("if/then", f"if true; then {_INNER}; fi"),
+            ("while/do", f"while false; do {_INNER}; done"),
+            ("for/do", f"for i in 1; do {_INNER}; done"),
+            ("select/do", f"select i in a; do {_INNER}; done"),
+            ("subshell", f"( {_INNER} )"),
+            ("brace group", f"{{ {_INNER}; }}"),
+            ("negation", f"! {_INNER}"),
+            ("interpreter, plain -c", f"bash -c '{_INNER}'"),
+            ("interpreter bundle, c last", f"bash -ec '{_INNER}'"),
+        ],
+    )
+    def test_a_construct_the_segmenter_handles_is_not_reported(self, label, command):
+        """The other half of the measurement.
+
+        Over-reporting is the safe direction but it is not free: every caller
+        treats this signal as "fall back to the coarse path", so a probe that
+        fires on ordinary syntax quietly converts the whole guard layer back to
+        substring matching. These are the shapes the segmenter demonstrably
+        handles, and they must stay clean.
+        """
+        import shell_parse as sp
+
+        assert any(s.exe == self._INNER for s in sp.analyze(command)), (
+            f"{label}: fixture is stale — the segmenter no longer sees this"
+        )
+        assert not sp.untokenizable(command), f"{label}: false positive on ordinary syntax"
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "grep -r 'case x in x) something;; esac' .",
+            "echo 'define with f() { ... }'",
+            "git commit -m 'use coproc for the reader'",
+        ],
+    )
+    def test_a_reserved_word_inside_a_quoted_argument_is_not_a_construct(self, command):
+        """The discriminator is TOKENS, not raw text, and that is the whole
+        reason this is quote-safe: shlex keeps a quoted argument as ONE token,
+        so a reserved word inside it never appears as a bare token. A raw-text
+        scan would fire on every one of these and re-block the mention-only
+        commands the parser migration exists to release."""
+        import shell_parse as sp
+
+        assert not sp.untokenizable(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            # A zero-argument call in a heredoc body. This probe reads heredoc
+            # text as ordinary command text by design, so without the brace
+            # requirement these fired: MEASURED 574 of them in 51,052 real
+            # commands, every one of which would have pushed a guard back onto
+            # its coarse path.
+            "python3 - <<'PY' import x\nmain()\nPY",
+            "echo build; runner()",
+        ],
+    )
+    def test_a_call_without_a_body_brace_is_not_a_function_definition(self, command):
+        """`name()` alone is not the grammar. A shell function definition is
+        `name() {`, and requiring the brace is what separates it from a call
+        appearing in embedded code."""
+        import shell_parse as sp
+
+        assert not sp.untokenizable(command)


### PR DESCRIPTION
`untokenizable()` began as "shlex raised", and that is strictly narrower than the question every caller actually asks: **can this parse be trusted?**

A construct can tokenize perfectly and still leave `analyze()` with no segment for the command inside it, while the probe reports a clean parse. *"Nothing gated here"* and *"I could not see this"* then return the same value — the exact confusion the probe exists to remove.

## The class is seven, not the two that were reported

Two were raised in review. Rather than fix the named cases, every bash reserved word and grouping construct was run with a **neutral inner command** and checked for whether a segment survived:

| construct | segments | inner command |
|---|---|---|
| `case … esac` | `['case','esac']` | absent |
| `name() { … }` | `['f()','}','f']` | absent |
| `function name { … }` | `['function','}','f']` | absent |
| `coproc …` | `['coproc']` | absent |
| `bash -ce` / `-cl`, `sh -ce` | `['bash','e']` | absent |

`untokenizable()` returned `False` for all of them, so nothing reported the gap.

`if` / `while` / `until` / `for` / `select`, brace groups, subshells, negation and `time` all resolve correctly and are **deliberately absent** — every entry costs a fallback to coarse matching, so the set is only what was measured to fail. `bash -ec` resolves too, which is why the rule is *"c present and not last"* rather than *"contains c"*.

## Why a list is acceptable here, and is not for carriers

This repo has a recorded lesson that enumerating command **carriers** is a losing race, and it's right — the set of programs taking a command as an argument grows forever. Shell **reserved words are a closed set**, fixed by the grammar. So *"the parser reported a reserved word as an executable, therefore the parse is wrong"* converges, while *"the parser did not report a carrier"* never can.

That's the line, and it's why this belongs in the probe rather than in any guard's carrier list.

## A consumer whose fallback was not a superset

`protected_paths_guard.py:209` ran the legacy substring check and **returned**. Sound while that check was strictly broader; it stopped being sound when brace expansion was added to the parsed path only, because an expanded operand is caught there and is invisible to a substring scan.

The consequence inverts the intent of this change: **making the probe more sensitive made that guard more permissive.** Measured before the fix, three verdicts changed and one flipped from block to allow. The branch falls through now, so both checks run and the probe firing can only ever *add* a reason to block.

Pre-existing and independent of the probe — fixed here because the probe change is what makes it reachable often enough to matter.

## Measured rate, both directions — 51,052 real `(command, cwd)` pairs

Over-reporting is the safe direction but it is **not free**: every consumer treats this signal as "use the coarse path", so a probe that fires on ordinary syntax quietly converts the guard layer back to substring matching — the very false-positive class the parser migration exists to reduce.

| iteration | newly reported | verdict changes |
|---|---|---|
| as first written | 847 (1.66%) | 3, **one fail-open** |
| function definition requires `{` | 381 (0.75%) | — |
| `case` requires `esac`; consumer fixed | 269 (0.53%) | 2, both fail-closed |
| glued operators stripped | **320 (0.63%)** | **2, both fail-closed** |

The first tightening removed 466 hits that were a zero-argument call inside a **Python heredoc body**, which this probe reads as ordinary text by design. The second removed a commit message whose body used the word "case" in a sentence — that alone had been enough to divert a guard off its parsed path, and it is the command that produced the fail-open.

Of the final 320, only **2** change any verdict — both `ALLOW→BLOCK`, both carrying a real shell function definition the guard genuinely cannot see inside. `worktree_cwd_guard`: **0 changes out of 320**. Nothing that previously reported stopped reporting.

## Acceptance bar, through the real consumer

The reported constructs move from silent to a **native approval dialog** interactively, and to a **refusal** in a dispatched session where no human is present to answer. Controls unchanged in both directions — including a command that merely *mentions* the operation, which must stay allowed and does.

The consumer wiring for this already existed at `git_push_guard.py:5439`. It was simply never reached, because the signal it depends on never fired.

## Two things found by testing, not by review

**Reserved words arrive glued to shell operators.** `shlex` doesn't treat `;` `&` `|` `(` `)` as separators, so `esac;` is one token. Comparing raw tokens only ever matched a keyword that happened to sit at the *end* of a command — the shape a hand-written fixture takes, not the shape real commands take. Found by a test precondition failing. The keyword comparison strips those characters; the function-definition pattern deliberately does not, because `()` **is** its shape.

**Verify-RED: 7 mutations, 7 killed** — and one survived on the first sweep, which is the most useful result here. The consumer test passed against the unfixed code because its fixture used an operand whose *parent* is itself protected, so the substring path caught it and the parsed path was never needed: green while pinning nothing. The first draft had a precondition asserting the substring path does **not** catch the fixture; it was dropped during a rewrite, and dropping it is what made the test vacuous. It's back, with a comment saying it is load-bearing.

Also recorded: the first run of the acceptance bar read only the process exit code and reported that the fix did nothing. An `ask` decision is exit 0 with JSON on stdout — indistinguishable from an allow by return code alone.

## Disclosure

Test fixtures use a **neutral inner command** rather than a gated verb, so they carry no working shape at all. Comments describe what the segmenter cannot represent without pairing a construct with a claim about any specific gate. The repo's own prose-recipe test passes with them in place.

---

`ruff` clean · **501 passed** across eight guard suites · **183** on the parser and probe · **432** on the commit and merge gates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved protected-path safeguards for complex shell commands, including commands using brace expansion and unsupported shell constructs.
  - Prevented unsafe commands from bypassing protected-directory checks when command parsing is incomplete or ambiguous.
  - Reduced false positives for quoted text and function-like commands that do not define shell functions.

- **Tests**
  - Added regression coverage for complex command parsing and protected-path enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->