### PR TITLE
docs(review): make a review state what it covered, not only what it found

### DIFF
--- a/.claude/commands/deep-review.md
+++ b/.claude/commands/deep-review.md
@@ -51,6 +51,20 @@ Prime each reviewer with the RIGHT SHAPE (what a lint scan misses). Paste this i
 > clear"; and **hand-rolled CLI / `gh` / bash / argv parsing** — flag that as an ARCHITECTURAL
 > defect and recommend atomic binding + fail-closed-on-unparseable, NOT case-by-case patches
 > (it is the root of the Codex review loop).
+>
+> ENUMERATE THE POPULATION BEFORE JUDGING IT. Name the call sites, consumers, states, branches
+> or axes the change touches, THEN say which you examined. Findings are a sample drawn from
+> that population; without it you cannot tell whether you sampled 3 of 3 or 3 of 9, and the
+> next round's "new" defect is usually the member nobody listed.
+>
+> REPORT WHERE YOU FOUND NOTHING, as explicitly as what you found. A bare findings list cannot
+> distinguish a CLEAN area from an UNEXAMINED one, so it silently reads as full coverage — and
+> the reader cannot audit a gap they cannot see. "I looked hard at X and found nothing" is a
+> first-class result; state it per area, not as a closing reassurance.
+>
+> Where a claim is load-bearing, RUN something rather than reasoning about it, and say what you
+> ran and observed. Prefer a reading over an argument — including about the review's own
+> instruments, whose output can be wrong in the flattering direction.
 
 ## 3. Triage → stage the class-level fix (don't commit yet)
 
@@ -59,6 +73,23 @@ When you fix, fix the mechanism/class — a per-instance patch is what spawns th
 round. `git add` the fix, but do NOT commit yet — the commit is the last step, after the marker.
 If you're on your 3rd EXTERNAL cross-model defect-bearing round, STOP at the escalation cap
 (see SKILL.md) — internal self/subagent audits like this one never count toward it.
+
+**A fix is not done until you have enumerated the CLASS'S OTHER MEMBERS and said what you
+found there.** The reviewer named the instance it happened to reach; the same defect usually
+sits at the sibling call sites nobody looked at, so patching only the named one leaves them
+for the next round and makes the loop look like bad luck rather than an unfinished fix. Write
+the enumeration down — "this shape appears at A, B and C; A was reported, B and C are fixed
+here / are not affected because …". A fix with no such list is a claim about one line.
+
+Two failure modes to watch for while fixing, both of which end the round *worse* than it
+started, and neither of which the findings list will tell you about:
+
+- **The fix that becomes the next finding.** When a round's defect was introduced by the
+  previous round's fix, stop patching and change the MECHANISM — the design is generating
+  them. Count findings by FILE across rounds; a file that keeps reappearing is the signal.
+- **Widening a check under cover of a regression fix.** Restoring what a change broke is not
+  the same as hardening a pre-existing case, and bundling them hides a new over-block inside
+  a "fix". Measure the pre-existing case's real rate before touching it, and say the number.
 
 ## 4. Record evidence, mark, THEN commit (satisfies the commit review-depth gate)
 
@@ -72,6 +103,14 @@ If you're on your 3rd EXTERNAL cross-model defect-bearing round, STOP at the esc
   (BLOCKER / SHOULD-FIX / CRITICAL / HIGH / MEDIUM / LOW / P1-P3 — a security-reviewer WARNING is
   NOT recognized by the validator, so render it as SHOULD-FIX in the text), at least one
   `file:line`, and ≥400 chars, or the gate rejects the evidence as non-adversarial.
+- **Carry the COVERAGE into the evidence, not just the findings.** The evidence is what a later
+  reader — a closing session, the next round, whoever inherits this branch — has instead of the
+  review. A findings-only file tells them what was wrong and NOTHING about what was checked, so
+  a gap and a clean bill look identical on disk. State the population §2 enumerated, which parts
+  were examined, and where you looked and found nothing. A `Scope Check:` heading is the
+  conventional place to put it — the validator recognises that phrase in place of a severity
+  ladder, though the `file:line` and length requirements above still apply on their own. It
+  costs one paragraph.
 - `python3 "$ROOT/scripts/review_state.py" mark --agent-output "$EVID"` — this is an INTERNAL
   (same-model) audit, so a plain `mark` is correct: it satisfies the commit review-depth gate and
   NEVER counts toward the cross-model escalation streak, whatever it found. No outcome flag is


### PR DESCRIPTION
A findings list cannot distinguish an area that was checked and clean from one nobody opened. Both render as silence, so the reader inherits a coverage claim nobody made — and the next round's "new" defect is usually the member of the population that no one listed.

Three additions to the reviewer prompt and triage step, each drawn from an actual review history rather than invented.

**Enumerate the population before judging it.** Name the call sites, consumers, states or axes the change touches, then say which were examined. The prompt already said to enumerate the whole class, but as an adjective on the hunt rather than an ordered step — which left findings looking like a to-do list instead of a sample with a denominator.

**Report where you found nothing**, per area rather than as a closing reassurance. This is the observation that motivated the change: the one audit that carried an explicit "areas I looked hard at and found nothing" section was materially more useful than its findings alone, because it made the unexamined regions visible instead of leaving a gap that reads as coverage.

**A fix is not done until the class's other members are enumerated** and the result written down. The reviewer names the instance it happened to reach; the same shape usually sits at sibling call sites nobody looked at, so patching only the named one leaves them for the next round and makes the loop look like bad luck rather than an unfinished fix. Two ways a round can end *worse* than it started are named alongside it — a fix that becomes the next round's finding (change the mechanism, stop patching), and widening a pre-existing check under cover of a regression fix, which hides a new over-block inside something that reads as a restoration.

The coverage also has to reach the **evidence file**, not just the reviewer's reply, since that file is what a later reader has instead of the review.

## What is deliberately *not* here

The fourth item this was queued for — re-review the fixed state — already exists: the evidence section opens with it. Adding a second, slightly different statement of the same rule to the same file is how two divergent rules get born.

## One claim verified rather than assumed

The new bullet says the evidence validator recognises a `Scope Check:` heading. The pattern was read at its definition and then executed against candidate strings, and the sentence was narrowed on the result — the phrase substitutes for a severity ladder *only*, and the `file:line` and length requirements still apply independently. The earlier draft would have implied such a line alone clears the gate.

## Scope

Prose only, one file, +39 lines. No code, no tests, and nothing in the tree asserts against this file, so there is no consumer to update. Hunks sit at §2, §3 and §4 and do not overlap the header region another open PR edits.

Ledger: 4cebfb535d6f484bb686ca00cbcdcb25
