### PR TITLE
fix(guardian): stop a failed stash from reverting over unsaved work

### DIFF
--- a/src/genesis/guardian/recovery.py
+++ b/src/genesis/guardian/recovery.py
@@ -4,8 +4,7 @@ Recovery actions in escalation order:
 1. RESTART_SERVICES  — systemctl restart genesis-server
 2. IO_TRIAGE         — kill top I/O consumer (one per cycle)
 3. RESOURCE_CLEAR    — clear /tmp, reclaim page cache, restart
-4. REVERT_CODE       — git stash && git revert <pinned sha>, restart (aborts if
-                       the stash failed; never reverts an unvetted HEAD)
+4. REVERT_CODE       — git stash && git revert HEAD, restart
 5. RESTART_CONTAINER — incus restart genesis
 6. SNAPSHOT_ROLLBACK — incus snapshot restore genesis {last_healthy}
 7. ESCALATE          — alert user, stop automated recovery
@@ -17,7 +16,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -31,11 +29,6 @@ from genesis.guardian.snapshots import SnapshotManager
 from genesis.guardian.state_machine import ConfirmationStateMachine
 
 logger = logging.getLogger(__name__)
-
-# A resolved commit sha, used to validate the value before it is interpolated
-# into a shell command run inside the container. Shape-checking it is what keeps
-# a contaminated or error-path `git rev-parse` result from reaching the shell.
-_FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
 
 
 @dataclass(frozen=True)
@@ -300,170 +293,66 @@ class RecoveryEngine:
         # Restart services
         return await self._restart_services(container)
 
-    async def _git_probe(
-        self, container: str, git_cmd: str,
-    ) -> tuple[int, str, str]:
-        """Run a read-only git command in the checkout. Returns (rc, value, stderr).
-
-        ``value`` is the LAST non-empty stdout line. `su -` starts a LOGIN shell,
-        whose startup files (nvm / direnv / ~/.profile) write to the same stdout
-        BEFORE the ``-c`` command runs — so a pipe inside that command cannot
-        filter them, the banner never being its input. Taking the last line here
-        also keeps the exit status meaningful, which a pipe would otherwise
-        replace with the filter's, and avoids depending on the account's login
-        shell supporting any particular option.
-        """
-        rc, stdout, stderr = await _run_subprocess(
-            "incus", "exec", container, "--",
-            "su", "-", "ubuntu", "-c",
-            f"cd ~/genesis && {git_cmd}",
-            timeout=15.0,
-        )
-        lines = [ln.strip() for ln in stdout.splitlines() if ln.strip()]
-        return rc, (lines[-1] if lines else ""), stderr
-
-    async def _clean_up_failed_revert(
-        self, container: str, sha: str, revert_err: str,
-    ) -> str:
-        """Undo OUR failed revert, and describe what the checkout was left as.
-
-        A failed revert leaves the tree mid-revert — unmerged paths, conflict
-        markers. Left there it poisons every later attempt, because `git stash`
-        refuses an unmerged index and the stash guard would then decline this
-        rung forever.
-
-        The abort is CONDITIONAL: it fires only when the in-flight revert is the
-        one this invocation started. If another session began a revert in the
-        race window, aborting would reset ITS state and destroy a conflict
-        resolution that our stash never captured.
-
-        Returns the detail string for the recovery result — the original revert
-        error ALWAYS survives, with any cleanup problem appended, so an alert
-        never reports a tidy failure over a poisoned checkout.
-        """
-        base = f"git revert failed: {revert_err}"
-
-        rc, in_flight, probe_err = await self._git_probe(
-            container, "git rev-parse --verify --quiet REVERT_HEAD || true",
-        )
-        if rc != 0:
-            logger.error("post-revert state probe failed: %s", probe_err)
-            return (
-                f"{base} — could not determine whether a revert was left in "
-                f"progress ({probe_err}); the checkout may need manual repair"
-            )
-        if not in_flight:
-            return base  # nothing was left behind; nothing to clean up
-        if in_flight != sha:
-            logger.warning(
-                "a revert of %s is in progress and is not ours (%s) — not aborting",
-                in_flight, sha,
-            )
-            return (
-                f"{base} — left alone: a revert of {in_flight[:12]} is in "
-                "progress that this did not start"
-            )
-
-        rc, _, abort_err = await _run_subprocess(
-            "incus", "exec", container, "--",
-            "su", "-", "ubuntu", "-c",
-            "cd ~/genesis && git revert --abort",
-            timeout=15.0,
-        )
-        if rc != 0:
-            logger.error(
-                "git revert --abort failed — the checkout is left mid-revert "
-                "with an unmerged index: %s", abort_err,
-            )
-            return (
-                f"{base} — AND `git revert --abort` failed ({abort_err}); the "
-                "checkout is left mid-revert with an unmerged index and needs "
-                "manual repair before this rung can run again"
-            )
-        return f"{base} (revert aborted; checkout restored)"
-
     async def _revert_code(self, container: str) -> tuple[bool, str]:
-        """Stash uncommitted changes and revert the last commit, then restart.
+        """Stash uncommitted changes and revert last commit, then restart.
 
-        This runs against the container's LIVE development checkout, not a
-        pristine deploy tree, so two things are guarded:
+        The stash must SUCCEED before anything is reverted. This runs against the
+        container's LIVE development checkout — the tree sessions hold
+        uncommitted work in — and the stash's exit code used to be discarded, so
+        a FAILED stash still went on to revert on top of TRACKED changes that
+        were never saved. `git stash` exits 0 with "No local changes to save" on
+        a clean tree, so rc is the success test, not whether anything was stashed.
 
-        - **The stash must SUCCEED.** Its exit code used to be discarded, so a
-          FAILED stash still went on to revert — on top of uncommitted work that
-          was never saved. Note `git stash` exits 0 with "No local changes to
-          save" on a clean tree, so rc is the success test, not whether anything
-          was actually stashed.
-        - **The commit is PINNED by sha.** HEAD is resolved in one `incus exec`
-          and the revert runs in another, with the stash round-trip in between;
-          a deploy landing in that window would otherwise revert a commit this
-          never looked at. Reverting the pinned sha stays correct if HEAD moved.
+        "tracked" is exact, not hedging: plain `git stash` does not take
+        UNTRACKED files, so rc == 0 does not mean the whole working tree is
+        safe — the same residual `scripts/hooks/git_discard_guard.py` documents
+        for `git stash create`. Switching to `-u` would remove those files from a
+        running checkout, which is a behaviour change this guard should not make
+        on its own.
 
-        A failed revert is ABORTED rather than left in place — but only when the
-        in-flight revert is the one this started. Without the cleanup the two
-        guards deadlock each other: a conflicted revert leaves an unmerged index,
-        `git stash` refuses an unmerged index, and the stash guard would then
-        refuse this rung on every future attempt. Without the ownership check the
-        cleanup would reset a revert another session began, destroying a conflict
-        resolution the stash never captured.
-
-        The stash is deliberately NOT popped — a revert that restored the same
-        uncommitted changes could reintroduce the fault. The outcome string says
-        where the work went so the recovery alert carries it. Note plain
-        `git stash` takes TRACKED files only; untracked files stay in the tree.
-
-        Caveat inherited from the rung's design: when HEAD arrived by
-        fast-forward, reverting it undoes ONE commit of the batch that landed,
-        not the whole deploy.
+        The stash is never popped, so the outcome string below is the only place
+        the recovery alert can tell the owner where their work went.
         """
-        rc, sha, stderr = await self._git_probe(container, "git rev-parse HEAD")
-        if rc != 0 or not _FULL_SHA_RE.fullmatch(sha):
-            return False, (
-                f"could not resolve HEAD to a commit sha: {stderr or sha or 'no output'}"
-            )
-
-        # Refuse if a revert is ALREADY in flight — it is not ours to touch, and
-        # proceeding would make our own revert fail and our cleanup abort someone
-        # else's operation (destroying a staged conflict resolution that our stash
-        # never captured). Safe to read "" as "none in flight": HEAD just resolved,
-        # so the repo is readable and an empty answer is a real answer.
-        rc, in_flight, stderr = await self._git_probe(
-            container, "git rev-parse --verify --quiet REVERT_HEAD || true",
-        )
-        if rc != 0:
-            return False, f"could not check for an in-flight revert: {stderr}"
-        if in_flight:
-            return False, (
-                f"a revert of {in_flight[:12]} is already in progress in the "
-                "checkout — refusing to disturb another operation"
-            )
-
-        # Stash any TRACKED uncommitted work. Plain `git stash` does not take
-        # untracked files, which is why the outcome string below says "tracked".
+        # Stash any uncommitted work. The timeout matches the revert and the
+        # service restart (30s): `su -` starts a LOGIN shell before git even
+        # runs, inside a container that is by definition unhealthy — this ladder
+        # has an IO_TRIAGE rung precisely because I/O pressure is a routine cause
+        # — and a spurious abort here now retires the rung AND burns one of
+        # max_escalations. The cheapest precondition should not have the tightest
+        # budget in the file.
         rc, _, stderr = await _run_subprocess(
             "incus", "exec", container, "--",
             "su", "-", "ubuntu", "-c",
             "cd ~/genesis && git stash",
-            timeout=15.0,
-        )
-        if rc != 0:
-            return False, f"git stash failed, refusing to revert: {stderr}"
-
-        # Revert the PINNED commit, not symbolic HEAD.
-        logger.info("REVERT_CODE reverting pinned commit %s", sha)
-        rc, stdout, stderr = await _run_subprocess(
-            "incus", "exec", container, "--",
-            "su", "-", "ubuntu", "-c",
-            f"cd ~/genesis && git revert --no-edit {sha}",
             timeout=30.0,
         )
         if rc != 0:
-            return False, await self._clean_up_failed_revert(container, sha, stderr)
+            # `_run_subprocess` returns rc=-1 with stderr "timeout" for a timeout
+            # and rc=-1 with the exception text for an exec failure — neither is
+            # "the stash failed", it is "we do not know whether it ran". Say so:
+            # refusing is still right (this gates a destructive action), but an
+            # alert that calls an unknown a failure sends the reader after the
+            # wrong thing.
+            what = "timed out — state unknown" if stderr == "timeout" else "failed"
+            return False, (
+                f"git stash {what}, refusing to revert: {stderr}"
+            )
+
+        # Revert the last commit
+        rc, stdout, stderr = await _run_subprocess(
+            "incus", "exec", container, "--",
+            "su", "-", "ubuntu", "-c",
+            "cd ~/genesis && git revert --no-edit HEAD",
+            timeout=30.0,
+        )
+        if rc != 0:
+            return False, f"git revert failed: {stderr}"
 
         # Restart services after code change
         svc_ok, svc_detail = await self._restart_services(container)
         return svc_ok, (
-            f"Code reverted ({sha[:12]}; tracked uncommitted work is in "
-            f"`git stash list`), {svc_detail}"
+            f"Code reverted, {svc_detail} — tracked uncommitted work was moved to "
+            "a git stash and NOT popped (recover: git stash list / git stash pop)"
         )
 
     async def _restart_container(self, container: str) -> tuple[bool, str]:

--- a/src/genesis/guardian/recovery.py
+++ b/src/genesis/guardian/recovery.py
@@ -300,6 +300,88 @@ class RecoveryEngine:
         # Restart services
         return await self._restart_services(container)
 
+    async def _git_probe(
+        self, container: str, git_cmd: str,
+    ) -> tuple[int, str, str]:
+        """Run a read-only git command in the checkout. Returns (rc, value, stderr).
+
+        ``value`` is the LAST non-empty stdout line. `su -` starts a LOGIN shell,
+        whose startup files (nvm / direnv / ~/.profile) write to the same stdout
+        BEFORE the ``-c`` command runs — so a pipe inside that command cannot
+        filter them, the banner never being its input. Taking the last line here
+        also keeps the exit status meaningful, which a pipe would otherwise
+        replace with the filter's, and avoids depending on the account's login
+        shell supporting any particular option.
+        """
+        rc, stdout, stderr = await _run_subprocess(
+            "incus", "exec", container, "--",
+            "su", "-", "ubuntu", "-c",
+            f"cd ~/genesis && {git_cmd}",
+            timeout=15.0,
+        )
+        lines = [ln.strip() for ln in stdout.splitlines() if ln.strip()]
+        return rc, (lines[-1] if lines else ""), stderr
+
+    async def _clean_up_failed_revert(
+        self, container: str, sha: str, revert_err: str,
+    ) -> str:
+        """Undo OUR failed revert, and describe what the checkout was left as.
+
+        A failed revert leaves the tree mid-revert — unmerged paths, conflict
+        markers. Left there it poisons every later attempt, because `git stash`
+        refuses an unmerged index and the stash guard would then decline this
+        rung forever.
+
+        The abort is CONDITIONAL: it fires only when the in-flight revert is the
+        one this invocation started. If another session began a revert in the
+        race window, aborting would reset ITS state and destroy a conflict
+        resolution that our stash never captured.
+
+        Returns the detail string for the recovery result — the original revert
+        error ALWAYS survives, with any cleanup problem appended, so an alert
+        never reports a tidy failure over a poisoned checkout.
+        """
+        base = f"git revert failed: {revert_err}"
+
+        rc, in_flight, probe_err = await self._git_probe(
+            container, "git rev-parse --verify --quiet REVERT_HEAD || true",
+        )
+        if rc != 0:
+            logger.error("post-revert state probe failed: %s", probe_err)
+            return (
+                f"{base} — could not determine whether a revert was left in "
+                f"progress ({probe_err}); the checkout may need manual repair"
+            )
+        if not in_flight:
+            return base  # nothing was left behind; nothing to clean up
+        if in_flight != sha:
+            logger.warning(
+                "a revert of %s is in progress and is not ours (%s) — not aborting",
+                in_flight, sha,
+            )
+            return (
+                f"{base} — left alone: a revert of {in_flight[:12]} is in "
+                "progress that this did not start"
+            )
+
+        rc, _, abort_err = await _run_subprocess(
+            "incus", "exec", container, "--",
+            "su", "-", "ubuntu", "-c",
+            "cd ~/genesis && git revert --abort",
+            timeout=15.0,
+        )
+        if rc != 0:
+            logger.error(
+                "git revert --abort failed — the checkout is left mid-revert "
+                "with an unmerged index: %s", abort_err,
+            )
+            return (
+                f"{base} — AND `git revert --abort` failed ({abort_err}); the "
+                "checkout is left mid-revert with an unmerged index and needs "
+                "manual repair before this rung can run again"
+            )
+        return f"{base} (revert aborted; checkout restored)"
+
     async def _revert_code(self, container: str) -> tuple[bool, str]:
         """Stash uncommitted changes and revert the last commit, then restart.
 
@@ -316,10 +398,13 @@ class RecoveryEngine:
           a deploy landing in that window would otherwise revert a commit this
           never looked at. Reverting the pinned sha stays correct if HEAD moved.
 
-        A failed revert is ABORTED rather than left in place. Together those two
-        guards would otherwise deadlock each other: a conflicted revert leaves an
-        unmerged index, `git stash` refuses an unmerged index, and the stash
-        guard would then refuse this rung on every future attempt.
+        A failed revert is ABORTED rather than left in place — but only when the
+        in-flight revert is the one this started. Without the cleanup the two
+        guards deadlock each other: a conflicted revert leaves an unmerged index,
+        `git stash` refuses an unmerged index, and the stash guard would then
+        refuse this rung on every future attempt. Without the ownership check the
+        cleanup would reset a revert another session began, destroying a conflict
+        resolution the stash never captured.
 
         The stash is deliberately NOT popped — a revert that restored the same
         uncommitted changes could reintroduce the fault. The outcome string says
@@ -330,21 +415,26 @@ class RecoveryEngine:
         fast-forward, reverting it undoes ONE commit of the batch that landed,
         not the whole deploy.
         """
-        rc, stdout, stderr = await _run_subprocess(
-            "incus", "exec", container, "--",
-            "su", "-", "ubuntu", "-c",
-            # `pipefail` because the pipe would otherwise report tail's status:
-            # `git rev-parse HEAD` exits 128 on a broken repo AND prints the
-            # literal "HEAD" to stdout, so without it a failure reads as rc=0.
-            # `| tail -n1` drops a login-shell banner (nvm/direnv/~/.profile).
-            # The shape check below is still the real gate.
-            "set -o pipefail; cd ~/genesis && git rev-parse HEAD | tail -n1",
-            timeout=15.0,
-        )
-        sha = stdout.strip()
+        rc, sha, stderr = await self._git_probe(container, "git rev-parse HEAD")
         if rc != 0 or not _FULL_SHA_RE.fullmatch(sha):
             return False, (
-                f"could not resolve HEAD to a commit sha: {stderr or stdout or 'no output'}"
+                f"could not resolve HEAD to a commit sha: {stderr or sha or 'no output'}"
+            )
+
+        # Refuse if a revert is ALREADY in flight — it is not ours to touch, and
+        # proceeding would make our own revert fail and our cleanup abort someone
+        # else's operation (destroying a staged conflict resolution that our stash
+        # never captured). Safe to read "" as "none in flight": HEAD just resolved,
+        # so the repo is readable and an empty answer is a real answer.
+        rc, in_flight, stderr = await self._git_probe(
+            container, "git rev-parse --verify --quiet REVERT_HEAD || true",
+        )
+        if rc != 0:
+            return False, f"could not check for an in-flight revert: {stderr}"
+        if in_flight:
+            return False, (
+                f"a revert of {in_flight[:12]} is already in progress in the "
+                "checkout — refusing to disturb another operation"
             )
 
         # Stash any TRACKED uncommitted work. Plain `git stash` does not take
@@ -367,25 +457,7 @@ class RecoveryEngine:
             timeout=30.0,
         )
         if rc != 0:
-            # A failed revert leaves the checkout MID-REVERT — unmerged paths and
-            # conflict markers in tracked files. Left behind, that state poisons
-            # every later attempt: `git stash` refuses an unmerged index, so the
-            # stash guard above would then refuse this rung forever. Abort so the
-            # tree returns to the sha we pinned. Best-effort: if the abort itself
-            # fails there is nothing further this can safely do, and the recovery
-            # is already being reported as failed.
-            _abort_rc, _, abort_err = await _run_subprocess(
-                "incus", "exec", container, "--",
-                "su", "-", "ubuntu", "-c",
-                "cd ~/genesis && git revert --abort",
-                timeout=15.0,
-            )
-            if _abort_rc != 0:
-                logger.error(
-                    "git revert --abort failed after a failed revert — the "
-                    "checkout may be left mid-revert: %s", abort_err,
-                )
-            return False, f"git revert failed: {stderr}"
+            return False, await self._clean_up_failed_revert(container, sha, stderr)
 
         # Restart services after code change
         svc_ok, svc_detail = await self._restart_services(container)

--- a/src/genesis/guardian/recovery.py
+++ b/src/genesis/guardian/recovery.py
@@ -4,7 +4,8 @@ Recovery actions in escalation order:
 1. RESTART_SERVICES  — systemctl restart genesis-server
 2. IO_TRIAGE         — kill top I/O consumer (one per cycle)
 3. RESOURCE_CLEAR    — clear /tmp, reclaim page cache, restart
-4. REVERT_CODE       — git stash && git revert HEAD, restart
+4. REVERT_CODE       — git stash && git revert <pinned sha>, restart (aborts if
+                       the stash failed; never reverts an unvetted HEAD)
 5. RESTART_CONTAINER — incus restart genesis
 6. SNAPSHOT_ROLLBACK — incus snapshot restore genesis {last_healthy}
 7. ESCALATE          — alert user, stop automated recovery
@@ -16,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -29,6 +31,11 @@ from genesis.guardian.snapshots import SnapshotManager
 from genesis.guardian.state_machine import ConfirmationStateMachine
 
 logger = logging.getLogger(__name__)
+
+# A resolved commit sha, used to validate the value before it is interpolated
+# into a shell command run inside the container. Shape-checking it is what keeps
+# a contaminated or error-path `git rev-parse` result from reaching the shell.
+_FULL_SHA_RE = re.compile(r"[0-9a-f]{40}")
 
 
 @dataclass(frozen=True)
@@ -294,28 +301,98 @@ class RecoveryEngine:
         return await self._restart_services(container)
 
     async def _revert_code(self, container: str) -> tuple[bool, str]:
-        """Stash uncommitted changes and revert last commit, then restart."""
-        # Stash any uncommitted work
-        rc, _, _ = await _run_subprocess(
+        """Stash uncommitted changes and revert the last commit, then restart.
+
+        This runs against the container's LIVE development checkout, not a
+        pristine deploy tree, so two things are guarded:
+
+        - **The stash must SUCCEED.** Its exit code used to be discarded, so a
+          FAILED stash still went on to revert — on top of uncommitted work that
+          was never saved. Note `git stash` exits 0 with "No local changes to
+          save" on a clean tree, so rc is the success test, not whether anything
+          was actually stashed.
+        - **The commit is PINNED by sha.** HEAD is resolved in one `incus exec`
+          and the revert runs in another, with the stash round-trip in between;
+          a deploy landing in that window would otherwise revert a commit this
+          never looked at. Reverting the pinned sha stays correct if HEAD moved.
+
+        A failed revert is ABORTED rather than left in place. Together those two
+        guards would otherwise deadlock each other: a conflicted revert leaves an
+        unmerged index, `git stash` refuses an unmerged index, and the stash
+        guard would then refuse this rung on every future attempt.
+
+        The stash is deliberately NOT popped — a revert that restored the same
+        uncommitted changes could reintroduce the fault. The outcome string says
+        where the work went so the recovery alert carries it. Note plain
+        `git stash` takes TRACKED files only; untracked files stay in the tree.
+
+        Caveat inherited from the rung's design: when HEAD arrived by
+        fast-forward, reverting it undoes ONE commit of the batch that landed,
+        not the whole deploy.
+        """
+        rc, stdout, stderr = await _run_subprocess(
+            "incus", "exec", container, "--",
+            "su", "-", "ubuntu", "-c",
+            # `pipefail` because the pipe would otherwise report tail's status:
+            # `git rev-parse HEAD` exits 128 on a broken repo AND prints the
+            # literal "HEAD" to stdout, so without it a failure reads as rc=0.
+            # `| tail -n1` drops a login-shell banner (nvm/direnv/~/.profile).
+            # The shape check below is still the real gate.
+            "set -o pipefail; cd ~/genesis && git rev-parse HEAD | tail -n1",
+            timeout=15.0,
+        )
+        sha = stdout.strip()
+        if rc != 0 or not _FULL_SHA_RE.fullmatch(sha):
+            return False, (
+                f"could not resolve HEAD to a commit sha: {stderr or stdout or 'no output'}"
+            )
+
+        # Stash any TRACKED uncommitted work. Plain `git stash` does not take
+        # untracked files, which is why the outcome string below says "tracked".
+        rc, _, stderr = await _run_subprocess(
             "incus", "exec", container, "--",
             "su", "-", "ubuntu", "-c",
             "cd ~/genesis && git stash",
             timeout=15.0,
         )
+        if rc != 0:
+            return False, f"git stash failed, refusing to revert: {stderr}"
 
-        # Revert the last commit
+        # Revert the PINNED commit, not symbolic HEAD.
+        logger.info("REVERT_CODE reverting pinned commit %s", sha)
         rc, stdout, stderr = await _run_subprocess(
             "incus", "exec", container, "--",
             "su", "-", "ubuntu", "-c",
-            "cd ~/genesis && git revert --no-edit HEAD",
+            f"cd ~/genesis && git revert --no-edit {sha}",
             timeout=30.0,
         )
         if rc != 0:
+            # A failed revert leaves the checkout MID-REVERT — unmerged paths and
+            # conflict markers in tracked files. Left behind, that state poisons
+            # every later attempt: `git stash` refuses an unmerged index, so the
+            # stash guard above would then refuse this rung forever. Abort so the
+            # tree returns to the sha we pinned. Best-effort: if the abort itself
+            # fails there is nothing further this can safely do, and the recovery
+            # is already being reported as failed.
+            _abort_rc, _, abort_err = await _run_subprocess(
+                "incus", "exec", container, "--",
+                "su", "-", "ubuntu", "-c",
+                "cd ~/genesis && git revert --abort",
+                timeout=15.0,
+            )
+            if _abort_rc != 0:
+                logger.error(
+                    "git revert --abort failed after a failed revert — the "
+                    "checkout may be left mid-revert: %s", abort_err,
+                )
             return False, f"git revert failed: {stderr}"
 
         # Restart services after code change
         svc_ok, svc_detail = await self._restart_services(container)
-        return svc_ok, f"Code reverted, {svc_detail}"
+        return svc_ok, (
+            f"Code reverted ({sha[:12]}; tracked uncommitted work is in "
+            f"`git stash list`), {svc_detail}"
+        )
 
     async def _restart_container(self, container: str) -> tuple[bool, str]:
         """Restart the entire container (or start it, if stopped).

--- a/tests/test_guardian/test_recovery.py
+++ b/tests/test_guardian/test_recovery.py
@@ -12,7 +12,7 @@ from genesis.guardian.diagnosis import DiagnosisResult, RecoveryAction
 from genesis.guardian.health_signals import HealthSnapshot, PauseState, SignalResult
 from genesis.guardian.recovery import RecoveryEngine
 from genesis.guardian.snapshots import SnapshotManager
-from genesis.guardian.state_machine import ConfirmationStateMachine
+from genesis.guardian.state_machine import ConfirmationStateMachine, GuardianState
 
 
 @pytest.fixture
@@ -231,83 +231,41 @@ class TestRecoveryIOTriage:
         assert engine._sm.state.recovery_attempts == 1
 
 
-_SHA_A = "a" * 40
-_SHA_B = "b" * 40
-_SHA_OTHER = "c" * 40
-
-
 def _revert_mock(
-    *, head: tuple[int, str] = (0, _SHA_A), in_flight: str = "",
-    left_behind: str | None = None, stash: tuple[int, str] = (0, ""),
-    revert: tuple[int, str] = (0, ""), abort: tuple[int, str] = (0, ""),
-    calls: list[str] | None = None,
+    *, stash: tuple[int, str] = (0, ""),
+    calls: list[str] | None = None, kwargs_seen: list[dict] | None = None,
 ):
     """Mock `_run_subprocess` for the revert path, dispatching on the shell command.
 
-    ``head``        (rc, stdout) of the `git rev-parse HEAD` probe. stdout may
-                    carry a login-shell banner ahead of the sha.
-    ``in_flight``   REVERT_HEAD BEFORE we start ("" = no revert in progress).
-    ``left_behind`` REVERT_HEAD AFTER our revert ran; defaults to the sha we
-                    pinned when the revert failed, "" when it succeeded.
-    ``stash`` / ``revert`` / ``abort``  (rc, stderr) of those calls.
+    ``stash`` is the (rc, stderr) the `git stash` call returns; everything else
+    succeeds. ``kwargs_seen`` captures per-call kwargs so a test can assert the
+    timeout, which the dispatch itself ignores.
 
-    Dispatch order matters: REVERT_HEAD is matched before the bare `rev-parse
-    HEAD`, and `revert --abort` before the bare `git revert` — each pair shares
-    a substring.
+    The dispatch keys on ``args[-1]`` being the shell-command string. That holds
+    for every call reachable from `_revert_code` today, but NOT for
+    `_restart_container`, whose last arg is a number — so a future routing change
+    would need this revisited.
     """
-    state = {"revert_ran": False}
-
     async def mock(*args, **kwargs):
         cmd = args[-1]
         if calls is not None:
             calls.append(cmd)
-        if "REVERT_HEAD" in cmd:
-            if not state["revert_ran"]:
-                return (0, in_flight, "")
-            if left_behind is not None:
-                return (0, left_behind, "")
-            return (0, (head[1] if revert[0] != 0 else ""), "")
-        if "rev-parse HEAD" in cmd:
-            return (head[0], head[1], "")
+        if kwargs_seen is not None:
+            kwargs_seen.append({"cmd": cmd, **kwargs})
         if "git stash" in cmd:
             return (stash[0], "", stash[1])
-        if "revert --abort" in cmd:
-            return (abort[0], "", abort[1])
-        if "git revert" in cmd:
-            state["revert_ran"] = True
-            return (revert[0], "", revert[1])
         return (0, "", "")
     return mock
 
 
-class TestRecoveryRevertCode:
-
-    @pytest.mark.asyncio
-    async def test_revert_code(self, engine: RecoveryEngine) -> None:
-        with (
-            patch("genesis.guardian.recovery._run_subprocess", _revert_mock()),
-            patch("genesis.guardian.recovery.collect_all_signals", return_value=_healthy_snapshot()),
-            patch.object(engine._snapshots, "take", return_value="pre-recovery"),
-            patch("asyncio.sleep", new_callable=AsyncMock),
-        ):
-            result = await engine.execute(_diagnosis(RecoveryAction.REVERT_CODE))
-        assert result.success is True
-        assert "reverted" in result.detail.lower()
-
-
-class TestRevertCodeGuards:
+class TestRevertCodeStashGuard:
     """REVERT_CODE runs `git stash` then `git revert` against the container's
-    LIVE dev checkout. Ways that destroyed work it should not touch:
+    LIVE development checkout — the tree sessions hold uncommitted work in.
 
-    1. The stash's exit code was DISCARDED, so a failed stash still reverted on
-       top of uncommitted work that was never saved.
-    2. HEAD was resolved implicitly by the revert itself, so a commit landing
-       during the stash round-trip redirected the revert onto a commit nothing
-       had inspected.
-    3. A failed revert left the tree mid-revert; `git stash` refuses an unmerged
-       index, so the new stash guard would then decline this rung forever.
-    4. Cleaning that up unconditionally would reset a revert ANOTHER session
-       started, destroying a conflict resolution our stash never captured.
+    The stash's exit code was DISCARDED (`rc, _, _ = ...`), so a FAILED stash
+    still went on to revert, on top of changes that were never saved. `git stash`
+    exits 0 with "No local changes to save" on a clean tree, so rc is the success
+    test — not whether anything was actually stashed.
     """
 
     @pytest.mark.asyncio
@@ -330,7 +288,8 @@ class TestRevertCodeGuards:
     async def test_stash_timeout_aborts_before_reverting(
         self, engine: RecoveryEngine,
     ) -> None:
-        # _run_subprocess returns (-1, "", "timeout") on timeout — rc != 0.
+        # _run_subprocess never raises: it returns (-1, "", "timeout") on timeout
+        # and (-1, "", str(exc)) on exec failure, so rc != 0 is the correct test.
         calls: list[str] = []
         with patch(
             "genesis.guardian.recovery._run_subprocess",
@@ -341,183 +300,108 @@ class TestRevertCodeGuards:
         assert not any("git revert" in c for c in calls)
 
     @pytest.mark.asyncio
-    async def test_reverts_the_pinned_sha_not_symbolic_head(
+    async def test_stash_runs_plain_with_a_budget_matching_its_siblings(
         self, engine: RecoveryEngine,
     ) -> None:
-        calls: list[str] = []
-        with patch(
-            "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(head=(0, _SHA_B), calls=calls),
-        ):
-            ok, _ = await engine._revert_code("genesis")
-        assert ok is True
-        revert_cmds = [c for c in calls if "git revert" in c and "--abort" not in c]
-        assert len(revert_cmds) == 1
-        assert _SHA_B in revert_cmds[0], "the resolved sha must be what gets reverted"
-        assert "HEAD" not in revert_cmds[0], (
-            "reverting symbolic HEAD re-resolves it — a commit landing after the "
-            "probe would then revert something that was never vetted"
-        )
+        """Two unlocked constants the guard's behaviour depends on.
 
-    @pytest.mark.asyncio
-    async def test_login_shell_banner_does_not_disable_the_rung(
-        self, engine: RecoveryEngine,
-    ) -> None:
-        # `su -` runs a LOGIN shell: its startup files write to the same stdout
-        # BEFORE the -c command runs, so a pipe inside that command cannot filter
-        # them — the banner was never its input. Parsing the last line in Python
-        # is what stops a supported shell config failing this rung closed on
-        # every attempt.
-        banner = "Found '.nvmrc' with version <22>\ndirenv: loading ~/.envrc\n"
-        calls: list[str] = []
-        with patch(
-            "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(head=(0, banner + _SHA_B), calls=calls),
-        ):
-            ok, _ = await engine._revert_code("genesis")
-        assert ok is True, "a login-shell banner must not be read as a bad sha"
-        revert_cmds = [c for c in calls if "git revert" in c and "--abort" not in c]
-        assert _SHA_B in revert_cmds[0]
+        The COMMAND: `"git stash" in cmd` would equally match `git stash -u` or
+        `git stash push --keep-index`, which save different things — `-u` also
+        REMOVES untracked files from a running checkout. Assert what actually runs.
 
-    @pytest.mark.asyncio
-    async def test_probe_does_not_pipe_away_its_exit_status(
-        self, engine: RecoveryEngine,
-    ) -> None:
-        # The mock cannot execute a shell, so assert on the command TEXT. A pipe
-        # makes the probe report the filter's status instead of git's, and
-        # `git rev-parse HEAD` exits 128 while printing the literal "HEAD".
-        calls: list[str] = []
-        with patch("genesis.guardian.recovery._run_subprocess", _revert_mock(calls=calls)):
+        The TIMEOUT: it decides how often this guard aborts the rung spuriously.
+        `su -` starts a login shell before git runs, in a container that is by
+        definition unhealthy, and a spurious abort now also burns one of
+        max_escalations. It must not be tighter than the revert it gates.
+        """
+        seen: list[dict] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess", _revert_mock(kwargs_seen=seen),
+        ):
             await engine._revert_code("genesis")
-        probe = next(c for c in calls if "rev-parse HEAD" in c)
-        assert "|" not in probe, (
-            "piping the probe replaces git's exit status with the filter's; the "
-            "last-line parse belongs in Python, where rc stays meaningful"
+        stash = next(c for c in seen if "git stash" in c["cmd"])
+        revert = next(c for c in seen if "git revert" in c["cmd"])
+        assert stash["cmd"] == "cd ~/genesis && git stash", (
+            "plain stash only — `-u` would delete untracked files from a live checkout"
+        )
+        assert stash["timeout"] >= revert["timeout"], (
+            "the cheapest precondition must not have a tighter budget than the "
+            "destructive step it guards"
         )
 
     @pytest.mark.asyncio
-    async def test_nonzero_probe_rc_refuses_even_when_stdout_looks_valid(
+    async def test_timeout_is_reported_as_unknown_not_as_failure(
         self, engine: RecoveryEngine,
     ) -> None:
-        # Isolates the `rc != 0` half of the probe guard: a test that ALSO passed
-        # empty stdout would pass on the regex alone and leave this clause dead.
-        calls: list[str] = []
+        # _run_subprocess returns rc=-1/"timeout" when it does not KNOW whether
+        # the stash ran. Refusing is still right, but the alert must not assert a
+        # failure it cannot establish.
         with patch(
             "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(head=(128, _SHA_A), calls=calls),
-        ):
-            ok, _ = await engine._revert_code("genesis")
-        assert ok is False
-        assert not any("git stash" in c for c in calls)
-
-    @pytest.mark.parametrize("contaminated", ["$(id)", "`id`", _SHA_A + "; echo INJECTED", "HEAD", "", "a" * 7, "a" * 39, "a" * 41])
-    @pytest.mark.asyncio
-    async def test_refuses_any_head_value_that_is_not_a_bare_sha(
-        self, engine: RecoveryEngine, contaminated: str,
-    ) -> None:
-        # The sha is interpolated into a shell command inside the container, so
-        # the shape check is a boundary, not a formality. The length cases pin
-        # the exact-40 requirement: an abbreviated sha is still hex.
-        calls: list[str] = []
-        with patch(
-            "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(head=(0, contaminated), calls=calls),
-        ):
-            ok, _ = await engine._revert_code("genesis")
-        assert ok is False
-        assert not any("git revert" in c for c in calls)
-
-    @pytest.mark.asyncio
-    async def test_refuses_when_another_revert_is_already_in_progress(
-        self, engine: RecoveryEngine,
-    ) -> None:
-        calls: list[str] = []
-        with patch(
-            "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(in_flight=_SHA_OTHER, calls=calls),
+            _revert_mock(stash=(-1, "timeout")),
         ):
             ok, detail = await engine._revert_code("genesis")
         assert ok is False
-        assert "already in progress" in detail.lower()
-        assert not any("git stash" in c for c in calls), (
-            "refuse BEFORE stashing — our own revert would fail against another "
-            "session's sequencer state, and cleanup would then abort THEIRS"
-        )
+        assert "unknown" in detail.lower()
 
     @pytest.mark.asyncio
-    async def test_failed_revert_aborts_only_our_own(
+    async def test_failed_stash_surfaces_through_execute_as_a_critical_alert(
         self, engine: RecoveryEngine,
     ) -> None:
-        calls: list[str] = []
-        with patch(
-            "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(revert=(1, "conflict"), calls=calls),
+        """The guard makes a NEW False path reachable from execute(). Its blast
+        radius — the attempt is recorded, the machine goes confirmed-dead, and
+        the operator gets the reason — is what the direct-call tests cannot see."""
+        with (
+            patch(
+                "genesis.guardian.recovery._run_subprocess",
+                _revert_mock(stash=(1, "fatal: unable to write new index file")),
+            ),
+            patch.object(engine._snapshots, "take", return_value="pre-recovery"),
+            patch("asyncio.sleep", new_callable=AsyncMock),
         ):
-            ok, detail = await engine._revert_code("genesis")
-        assert ok is False
-        assert "revert failed" in detail.lower()
-        assert any("revert --abort" in c for c in calls), (
-            "our own failed revert must be aborted, or the conflicted tree "
-            "disables this rung permanently"
-        )
+            result = await engine.execute(_diagnosis(RecoveryAction.REVERT_CODE))
+        assert result.success is False
+        assert "stash" in result.detail.lower()
+        assert engine._sm.state.current_state is GuardianState.CONFIRMED_DEAD
+        assert engine._sm.state.recovery_attempts == 1
 
     @pytest.mark.asyncio
-    async def test_does_not_abort_a_revert_this_did_not_start(
+    async def test_success_detail_says_where_the_displaced_work_went(
         self, engine: RecoveryEngine,
     ) -> None:
-        # Race window: another session began a revert between our pre-check and
-        # our own revert. Aborting it would reset their state and destroy a
-        # staged conflict resolution our stash never captured.
-        calls: list[str] = []
-        with patch(
-            "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(revert=(1, "conflict"), left_behind=_SHA_OTHER, calls=calls),
-        ):
-            ok, detail = await engine._revert_code("genesis")
-        assert ok is False
-        assert not any("revert --abort" in c for c in calls)
-        assert "did not start" in detail.lower()
-
-    @pytest.mark.asyncio
-    async def test_no_abort_when_the_failed_revert_left_nothing_behind(
-        self, engine: RecoveryEngine,
-    ) -> None:
-        calls: list[str] = []
-        with patch(
-            "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(revert=(1, "bad object"), left_behind="", calls=calls),
-        ):
-            ok, detail = await engine._revert_code("genesis")
-        assert ok is False
-        assert not any("revert --abort" in c for c in calls)
-        assert "revert failed" in detail.lower()
-
-    @pytest.mark.asyncio
-    async def test_abort_failure_is_surfaced_in_the_result_not_only_logged(
-        self, engine: RecoveryEngine,
-    ) -> None:
-        # The recovery ALERT is built from this string. If cleanup failed, the
-        # checkout is left with an unmerged index that makes every later stash
-        # fail — reporting only the original revert error hides that.
-        with patch(
-            "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(revert=(1, "conflict"), abort=(1, "no revert in progress")),
-        ):
-            ok, detail = await engine._revert_code("genesis")
-        assert ok is False
-        assert "revert failed" in detail.lower(), "the original cause must survive"
-        assert "manual repair" in detail.lower(), "the poisoned checkout must be named"
-
-    @pytest.mark.asyncio
-    async def test_success_detail_says_where_uncommitted_work_went(
-        self, engine: RecoveryEngine,
-    ) -> None:
-        # The stash is never popped, so the outcome string is the only place the
-        # recovery alert can tell the owner their work is recoverable.
+        # The stash is never popped and the next rung (SNAPSHOT_ROLLBACK) would
+        # destroy it, so this string is the owner's only notice.
         with patch("genesis.guardian.recovery._run_subprocess", _revert_mock()):
             ok, detail = await engine._revert_code("genesis")
         assert ok is True
         assert "stash" in detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_clean_tree_still_reverts(self, engine: RecoveryEngine) -> None:
+        # "No local changes to save" exits 0 — a clean tree is not a failure, and
+        # the rung must still do its job.
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess", _revert_mock(calls=calls),
+        ):
+            ok, _ = await engine._revert_code("genesis")
+        assert ok is True
+        assert any("git revert" in c for c in calls)
+
+
+class TestRecoveryRevertCode:
+
+    @pytest.mark.asyncio
+    async def test_revert_code(self, engine: RecoveryEngine) -> None:
+        with (
+            patch("genesis.guardian.recovery._run_subprocess", _mock_subprocess(0, "")),
+            patch("genesis.guardian.recovery.collect_all_signals", return_value=_healthy_snapshot()),
+            patch.object(engine._snapshots, "take", return_value="pre-recovery"),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await engine.execute(_diagnosis(RecoveryAction.REVERT_CODE))
+        assert result.success is True
+        assert "reverted" in result.detail.lower()
 
 
 class TestRestartContainerStopped:

--- a/tests/test_guardian/test_recovery.py
+++ b/tests/test_guardian/test_recovery.py
@@ -233,31 +233,48 @@ class TestRecoveryIOTriage:
 
 _SHA_A = "a" * 40
 _SHA_B = "b" * 40
+_SHA_OTHER = "c" * 40
 
 
 def _revert_mock(
-    *, head: tuple[int, str] = (0, _SHA_A), stash: tuple[int, str] = (0, ""),
+    *, head: tuple[int, str] = (0, _SHA_A), in_flight: str = "",
+    left_behind: str | None = None, stash: tuple[int, str] = (0, ""),
     revert: tuple[int, str] = (0, ""), abort: tuple[int, str] = (0, ""),
     calls: list[str] | None = None,
 ):
     """Mock `_run_subprocess` for the revert path, dispatching on the shell command.
 
-    ``head`` is the (rc, stdout) of the `git rev-parse HEAD` probe; ``stash``,
-    ``revert`` and ``abort`` are the (rc, stderr) of their respective calls.
-    Order matters: `--abort` is checked before the bare revert, since its
-    command string also contains "git revert".
+    ``head``        (rc, stdout) of the `git rev-parse HEAD` probe. stdout may
+                    carry a login-shell banner ahead of the sha.
+    ``in_flight``   REVERT_HEAD BEFORE we start ("" = no revert in progress).
+    ``left_behind`` REVERT_HEAD AFTER our revert ran; defaults to the sha we
+                    pinned when the revert failed, "" when it succeeded.
+    ``stash`` / ``revert`` / ``abort``  (rc, stderr) of those calls.
+
+    Dispatch order matters: REVERT_HEAD is matched before the bare `rev-parse
+    HEAD`, and `revert --abort` before the bare `git revert` — each pair shares
+    a substring.
     """
+    state = {"revert_ran": False}
+
     async def mock(*args, **kwargs):
         cmd = args[-1]
         if calls is not None:
             calls.append(cmd)
-        if "rev-parse" in cmd:
+        if "REVERT_HEAD" in cmd:
+            if not state["revert_ran"]:
+                return (0, in_flight, "")
+            if left_behind is not None:
+                return (0, left_behind, "")
+            return (0, (head[1] if revert[0] != 0 else ""), "")
+        if "rev-parse HEAD" in cmd:
             return (head[0], head[1], "")
         if "git stash" in cmd:
             return (stash[0], "", stash[1])
         if "revert --abort" in cmd:
             return (abort[0], "", abort[1])
         if "git revert" in cmd:
+            state["revert_ran"] = True
             return (revert[0], "", revert[1])
         return (0, "", "")
     return mock
@@ -280,13 +297,17 @@ class TestRecoveryRevertCode:
 
 class TestRevertCodeGuards:
     """REVERT_CODE runs `git stash` then `git revert` against the container's
-    LIVE dev checkout. Two ways that destroyed work it should not touch:
+    LIVE dev checkout. Ways that destroyed work it should not touch:
 
-    1. The stash's exit code was DISCARDED (`rc, _, _ = ...`), so a failed stash
-       still went on to revert — on top of uncommitted work never saved.
-    2. HEAD was resolved implicitly by the revert itself. With a stash round-trip
-       in between, a deploy landing in that window meant reverting a commit the
-       action never looked at.
+    1. The stash's exit code was DISCARDED, so a failed stash still reverted on
+       top of uncommitted work that was never saved.
+    2. HEAD was resolved implicitly by the revert itself, so a commit landing
+       during the stash round-trip redirected the revert onto a commit nothing
+       had inspected.
+    3. A failed revert left the tree mid-revert; `git stash` refuses an unmerged
+       index, so the new stash guard would then decline this rung forever.
+    4. Cleaning that up unconditionally would reset a revert ANOTHER session
+       started, destroying a conflict resolution our stash never captured.
     """
 
     @pytest.mark.asyncio
@@ -315,7 +336,7 @@ class TestRevertCodeGuards:
             "genesis.guardian.recovery._run_subprocess",
             _revert_mock(stash=(-1, "timeout"), calls=calls),
         ):
-            ok, detail = await engine._revert_code("genesis")
+            ok, _ = await engine._revert_code("genesis")
         assert ok is False
         assert not any("git revert" in c for c in calls)
 
@@ -330,48 +351,73 @@ class TestRevertCodeGuards:
         ):
             ok, _ = await engine._revert_code("genesis")
         assert ok is True
-        revert_cmds = [c for c in calls if "git revert" in c]
+        revert_cmds = [c for c in calls if "git revert" in c and "--abort" not in c]
         assert len(revert_cmds) == 1
         assert _SHA_B in revert_cmds[0], "the resolved sha must be what gets reverted"
         assert "HEAD" not in revert_cmds[0], (
-            "reverting symbolic HEAD re-resolves it — a deploy landing after the "
-            "probe would then revert a commit that was never vetted"
+            "reverting symbolic HEAD re-resolves it — a commit landing after the "
+            "probe would then revert something that was never vetted"
         )
 
     @pytest.mark.asyncio
-    async def test_refuses_when_head_cannot_be_resolved(
+    async def test_login_shell_banner_does_not_disable_the_rung(
         self, engine: RecoveryEngine,
     ) -> None:
+        # `su -` runs a LOGIN shell: its startup files write to the same stdout
+        # BEFORE the -c command runs, so a pipe inside that command cannot filter
+        # them — the banner was never its input. Parsing the last line in Python
+        # is what stops a supported shell config failing this rung closed on
+        # every attempt.
+        banner = "Found '.nvmrc' with version <22>\ndirenv: loading ~/.envrc\n"
         calls: list[str] = []
         with patch(
             "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(head=(128, ""), calls=calls),
+            _revert_mock(head=(0, banner + _SHA_B), calls=calls),
         ):
-            ok, detail = await engine._revert_code("genesis")
-        assert ok is False
-        assert "resolve" in detail.lower()
-        assert not any("git stash" in c for c in calls), (
-            "refuse BEFORE stashing — a refusal that stashes still displaces the work"
-        )
-        assert not any("git revert" in c for c in calls)
+            ok, _ = await engine._revert_code("genesis")
+        assert ok is True, "a login-shell banner must not be read as a bad sha"
+        revert_cmds = [c for c in calls if "git revert" in c and "--abort" not in c]
+        assert _SHA_B in revert_cmds[0]
 
-    @pytest.mark.parametrize(
-        "contaminated",
-        [
-            "nvm: loaded\n" + _SHA_A,          # login-shell banner ahead of the value
-            "$(rm -rf /)",                      # not sha-shaped at all
-            _SHA_A + "; rm -rf /",              # sha-shaped prefix, shell suffix
-            "HEAD",
-            "",
-        ],
-    )
+    @pytest.mark.asyncio
+    async def test_probe_does_not_pipe_away_its_exit_status(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        # The mock cannot execute a shell, so assert on the command TEXT. A pipe
+        # makes the probe report the filter's status instead of git's, and
+        # `git rev-parse HEAD` exits 128 while printing the literal "HEAD".
+        calls: list[str] = []
+        with patch("genesis.guardian.recovery._run_subprocess", _revert_mock(calls=calls)):
+            await engine._revert_code("genesis")
+        probe = next(c for c in calls if "rev-parse HEAD" in c)
+        assert "|" not in probe, (
+            "piping the probe replaces git's exit status with the filter's; the "
+            "last-line parse belongs in Python, where rc stays meaningful"
+        )
+
+    @pytest.mark.asyncio
+    async def test_nonzero_probe_rc_refuses_even_when_stdout_looks_valid(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        # Isolates the `rc != 0` half of the probe guard: a test that ALSO passed
+        # empty stdout would pass on the regex alone and leave this clause dead.
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(head=(128, _SHA_A), calls=calls),
+        ):
+            ok, _ = await engine._revert_code("genesis")
+        assert ok is False
+        assert not any("git stash" in c for c in calls)
+
+    @pytest.mark.parametrize("contaminated", ["$(id)", "`id`", _SHA_A + "; echo INJECTED", "HEAD", "", "a" * 7, "a" * 39, "a" * 41])
     @pytest.mark.asyncio
     async def test_refuses_any_head_value_that_is_not_a_bare_sha(
         self, engine: RecoveryEngine, contaminated: str,
     ) -> None:
         # The sha is interpolated into a shell command inside the container, so
-        # the shape check is a boundary, not a formality. `| tail -n1` strips a
-        # banner; this refuses whatever still is not a bare 40-hex sha.
+        # the shape check is a boundary, not a formality. The length cases pin
+        # the exact-40 requirement: an abbreviated sha is still hex.
         calls: list[str] = []
         with patch(
             "genesis.guardian.recovery._run_subprocess",
@@ -382,86 +428,85 @@ class TestRevertCodeGuards:
         assert not any("git revert" in c for c in calls)
 
     @pytest.mark.asyncio
-    async def test_failed_revert_aborts_so_the_tree_is_not_left_mid_revert(
+    async def test_refuses_when_another_revert_is_already_in_progress(
         self, engine: RecoveryEngine,
     ) -> None:
-        # Without the abort the two guards deadlock: a conflicted revert leaves
-        # an unmerged index, `git stash` refuses an unmerged index, and the stash
-        # guard then refuses this rung on EVERY later attempt.
         calls: list[str] = []
         with patch(
             "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(revert=(1, "error: could not revert... conflict"), calls=calls),
+            _revert_mock(in_flight=_SHA_OTHER, calls=calls),
+        ):
+            ok, detail = await engine._revert_code("genesis")
+        assert ok is False
+        assert "already in progress" in detail.lower()
+        assert not any("git stash" in c for c in calls), (
+            "refuse BEFORE stashing — our own revert would fail against another "
+            "session's sequencer state, and cleanup would then abort THEIRS"
+        )
+
+    @pytest.mark.asyncio
+    async def test_failed_revert_aborts_only_our_own(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(revert=(1, "conflict"), calls=calls),
         ):
             ok, detail = await engine._revert_code("genesis")
         assert ok is False
         assert "revert failed" in detail.lower()
         assert any("revert --abort" in c for c in calls), (
-            "a failed revert must be aborted, or the conflicted tree disables the rung"
+            "our own failed revert must be aborted, or the conflicted tree "
+            "disables this rung permanently"
         )
 
     @pytest.mark.asyncio
-    async def test_abort_failure_is_reported_but_does_not_mask_the_revert_failure(
+    async def test_does_not_abort_a_revert_this_did_not_start(
         self, engine: RecoveryEngine,
     ) -> None:
+        # Race window: another session began a revert between our pre-check and
+        # our own revert. Aborting it would reset their state and destroy a
+        # staged conflict resolution our stash never captured.
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(revert=(1, "conflict"), left_behind=_SHA_OTHER, calls=calls),
+        ):
+            ok, detail = await engine._revert_code("genesis")
+        assert ok is False
+        assert not any("revert --abort" in c for c in calls)
+        assert "did not start" in detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_abort_when_the_failed_revert_left_nothing_behind(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(revert=(1, "bad object"), left_behind="", calls=calls),
+        ):
+            ok, detail = await engine._revert_code("genesis")
+        assert ok is False
+        assert not any("revert --abort" in c for c in calls)
+        assert "revert failed" in detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_abort_failure_is_surfaced_in_the_result_not_only_logged(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        # The recovery ALERT is built from this string. If cleanup failed, the
+        # checkout is left with an unmerged index that makes every later stash
+        # fail — reporting only the original revert error hides that.
         with patch(
             "genesis.guardian.recovery._run_subprocess",
             _revert_mock(revert=(1, "conflict"), abort=(1, "no revert in progress")),
         ):
             ok, detail = await engine._revert_code("genesis")
         assert ok is False
-        # The caller still learns why the RECOVERY failed, not why cleanup did.
-        assert "revert failed" in detail.lower()
-
-    @pytest.mark.asyncio
-    async def test_nonzero_probe_rc_refuses_even_when_stdout_looks_valid(
-        self, engine: RecoveryEngine,
-    ) -> None:
-        # Isolates the `rc != 0` half of the probe guard. Without pipefail the
-        # pipe reports tail's status, so a failing `git rev-parse` reads as rc=0;
-        # a test that also supplies empty stdout would pass on the regex alone
-        # and leave this clause unverified.
-        calls: list[str] = []
-        with patch(
-            "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(head=(128, _SHA_A), calls=calls),
-        ):
-            ok, _ = await engine._revert_code("genesis")
-        assert ok is False
-        assert not any("git stash" in c for c in calls)
-
-    @pytest.mark.asyncio
-    async def test_probe_command_restores_pipeline_exit_status(
-        self, engine: RecoveryEngine,
-    ) -> None:
-        # The mock cannot execute a shell, so assert on the command TEXT: the
-        # pipe must not be allowed to mask a failing `git rev-parse`.
-        calls: list[str] = []
-        with patch("genesis.guardian.recovery._run_subprocess", _revert_mock(calls=calls)):
-            await engine._revert_code("genesis")
-        probe = next(c for c in calls if "rev-parse" in c)
-        assert "pipefail" in probe, (
-            "`git rev-parse HEAD | tail -n1` reports tail's status; rev-parse "
-            "exits 128 AND prints 'HEAD' on a broken repo, so the rc check is "
-            "dead without pipefail"
-        )
-
-    @pytest.mark.parametrize("short_sha", ["a" * 7, "a" * 39, "a" * 41])
-    @pytest.mark.asyncio
-    async def test_refuses_a_sha_of_the_wrong_length(
-        self, engine: RecoveryEngine, short_sha: str,
-    ) -> None:
-        # Isolates the regex's exact-40 requirement: an abbreviated sha is hex
-        # and would satisfy a length-relaxed pattern, but is not what the probe
-        # is contracted to return.
-        calls: list[str] = []
-        with patch(
-            "genesis.guardian.recovery._run_subprocess",
-            _revert_mock(head=(0, short_sha), calls=calls),
-        ):
-            ok, _ = await engine._revert_code("genesis")
-        assert ok is False
-        assert not any("git revert" in c for c in calls)
+        assert "revert failed" in detail.lower(), "the original cause must survive"
+        assert "manual repair" in detail.lower(), "the poisoned checkout must be named"
 
     @pytest.mark.asyncio
     async def test_success_detail_says_where_uncommitted_work_went(

--- a/tests/test_guardian/test_recovery.py
+++ b/tests/test_guardian/test_recovery.py
@@ -231,12 +231,44 @@ class TestRecoveryIOTriage:
         assert engine._sm.state.recovery_attempts == 1
 
 
+_SHA_A = "a" * 40
+_SHA_B = "b" * 40
+
+
+def _revert_mock(
+    *, head: tuple[int, str] = (0, _SHA_A), stash: tuple[int, str] = (0, ""),
+    revert: tuple[int, str] = (0, ""), abort: tuple[int, str] = (0, ""),
+    calls: list[str] | None = None,
+):
+    """Mock `_run_subprocess` for the revert path, dispatching on the shell command.
+
+    ``head`` is the (rc, stdout) of the `git rev-parse HEAD` probe; ``stash``,
+    ``revert`` and ``abort`` are the (rc, stderr) of their respective calls.
+    Order matters: `--abort` is checked before the bare revert, since its
+    command string also contains "git revert".
+    """
+    async def mock(*args, **kwargs):
+        cmd = args[-1]
+        if calls is not None:
+            calls.append(cmd)
+        if "rev-parse" in cmd:
+            return (head[0], head[1], "")
+        if "git stash" in cmd:
+            return (stash[0], "", stash[1])
+        if "revert --abort" in cmd:
+            return (abort[0], "", abort[1])
+        if "git revert" in cmd:
+            return (revert[0], "", revert[1])
+        return (0, "", "")
+    return mock
+
+
 class TestRecoveryRevertCode:
 
     @pytest.mark.asyncio
     async def test_revert_code(self, engine: RecoveryEngine) -> None:
         with (
-            patch("genesis.guardian.recovery._run_subprocess", _mock_subprocess(0, "")),
+            patch("genesis.guardian.recovery._run_subprocess", _revert_mock()),
             patch("genesis.guardian.recovery.collect_all_signals", return_value=_healthy_snapshot()),
             patch.object(engine._snapshots, "take", return_value="pre-recovery"),
             patch("asyncio.sleep", new_callable=AsyncMock),
@@ -244,6 +276,203 @@ class TestRecoveryRevertCode:
             result = await engine.execute(_diagnosis(RecoveryAction.REVERT_CODE))
         assert result.success is True
         assert "reverted" in result.detail.lower()
+
+
+class TestRevertCodeGuards:
+    """REVERT_CODE runs `git stash` then `git revert` against the container's
+    LIVE dev checkout. Two ways that destroyed work it should not touch:
+
+    1. The stash's exit code was DISCARDED (`rc, _, _ = ...`), so a failed stash
+       still went on to revert — on top of uncommitted work never saved.
+    2. HEAD was resolved implicitly by the revert itself. With a stash round-trip
+       in between, a deploy landing in that window meant reverting a commit the
+       action never looked at.
+    """
+
+    @pytest.mark.asyncio
+    async def test_failed_stash_aborts_before_reverting(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(stash=(1, "fatal: unable to write new index file"), calls=calls),
+        ):
+            ok, detail = await engine._revert_code("genesis")
+        assert ok is False
+        assert "stash" in detail.lower()
+        assert not any("git revert" in c for c in calls), (
+            "a failed stash must abort — reverting on top of unsaved work destroys it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_stash_timeout_aborts_before_reverting(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        # _run_subprocess returns (-1, "", "timeout") on timeout — rc != 0.
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(stash=(-1, "timeout"), calls=calls),
+        ):
+            ok, detail = await engine._revert_code("genesis")
+        assert ok is False
+        assert not any("git revert" in c for c in calls)
+
+    @pytest.mark.asyncio
+    async def test_reverts_the_pinned_sha_not_symbolic_head(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(head=(0, _SHA_B), calls=calls),
+        ):
+            ok, _ = await engine._revert_code("genesis")
+        assert ok is True
+        revert_cmds = [c for c in calls if "git revert" in c]
+        assert len(revert_cmds) == 1
+        assert _SHA_B in revert_cmds[0], "the resolved sha must be what gets reverted"
+        assert "HEAD" not in revert_cmds[0], (
+            "reverting symbolic HEAD re-resolves it — a deploy landing after the "
+            "probe would then revert a commit that was never vetted"
+        )
+
+    @pytest.mark.asyncio
+    async def test_refuses_when_head_cannot_be_resolved(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(head=(128, ""), calls=calls),
+        ):
+            ok, detail = await engine._revert_code("genesis")
+        assert ok is False
+        assert "resolve" in detail.lower()
+        assert not any("git stash" in c for c in calls), (
+            "refuse BEFORE stashing — a refusal that stashes still displaces the work"
+        )
+        assert not any("git revert" in c for c in calls)
+
+    @pytest.mark.parametrize(
+        "contaminated",
+        [
+            "nvm: loaded\n" + _SHA_A,          # login-shell banner ahead of the value
+            "$(rm -rf /)",                      # not sha-shaped at all
+            _SHA_A + "; rm -rf /",              # sha-shaped prefix, shell suffix
+            "HEAD",
+            "",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_refuses_any_head_value_that_is_not_a_bare_sha(
+        self, engine: RecoveryEngine, contaminated: str,
+    ) -> None:
+        # The sha is interpolated into a shell command inside the container, so
+        # the shape check is a boundary, not a formality. `| tail -n1` strips a
+        # banner; this refuses whatever still is not a bare 40-hex sha.
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(head=(0, contaminated), calls=calls),
+        ):
+            ok, _ = await engine._revert_code("genesis")
+        assert ok is False
+        assert not any("git revert" in c for c in calls)
+
+    @pytest.mark.asyncio
+    async def test_failed_revert_aborts_so_the_tree_is_not_left_mid_revert(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        # Without the abort the two guards deadlock: a conflicted revert leaves
+        # an unmerged index, `git stash` refuses an unmerged index, and the stash
+        # guard then refuses this rung on EVERY later attempt.
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(revert=(1, "error: could not revert... conflict"), calls=calls),
+        ):
+            ok, detail = await engine._revert_code("genesis")
+        assert ok is False
+        assert "revert failed" in detail.lower()
+        assert any("revert --abort" in c for c in calls), (
+            "a failed revert must be aborted, or the conflicted tree disables the rung"
+        )
+
+    @pytest.mark.asyncio
+    async def test_abort_failure_is_reported_but_does_not_mask_the_revert_failure(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(revert=(1, "conflict"), abort=(1, "no revert in progress")),
+        ):
+            ok, detail = await engine._revert_code("genesis")
+        assert ok is False
+        # The caller still learns why the RECOVERY failed, not why cleanup did.
+        assert "revert failed" in detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_nonzero_probe_rc_refuses_even_when_stdout_looks_valid(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        # Isolates the `rc != 0` half of the probe guard. Without pipefail the
+        # pipe reports tail's status, so a failing `git rev-parse` reads as rc=0;
+        # a test that also supplies empty stdout would pass on the regex alone
+        # and leave this clause unverified.
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(head=(128, _SHA_A), calls=calls),
+        ):
+            ok, _ = await engine._revert_code("genesis")
+        assert ok is False
+        assert not any("git stash" in c for c in calls)
+
+    @pytest.mark.asyncio
+    async def test_probe_command_restores_pipeline_exit_status(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        # The mock cannot execute a shell, so assert on the command TEXT: the
+        # pipe must not be allowed to mask a failing `git rev-parse`.
+        calls: list[str] = []
+        with patch("genesis.guardian.recovery._run_subprocess", _revert_mock(calls=calls)):
+            await engine._revert_code("genesis")
+        probe = next(c for c in calls if "rev-parse" in c)
+        assert "pipefail" in probe, (
+            "`git rev-parse HEAD | tail -n1` reports tail's status; rev-parse "
+            "exits 128 AND prints 'HEAD' on a broken repo, so the rc check is "
+            "dead without pipefail"
+        )
+
+    @pytest.mark.parametrize("short_sha", ["a" * 7, "a" * 39, "a" * 41])
+    @pytest.mark.asyncio
+    async def test_refuses_a_sha_of_the_wrong_length(
+        self, engine: RecoveryEngine, short_sha: str,
+    ) -> None:
+        # Isolates the regex's exact-40 requirement: an abbreviated sha is hex
+        # and would satisfy a length-relaxed pattern, but is not what the probe
+        # is contracted to return.
+        calls: list[str] = []
+        with patch(
+            "genesis.guardian.recovery._run_subprocess",
+            _revert_mock(head=(0, short_sha), calls=calls),
+        ):
+            ok, _ = await engine._revert_code("genesis")
+        assert ok is False
+        assert not any("git revert" in c for c in calls)
+
+    @pytest.mark.asyncio
+    async def test_success_detail_says_where_uncommitted_work_went(
+        self, engine: RecoveryEngine,
+    ) -> None:
+        # The stash is never popped, so the outcome string is the only place the
+        # recovery alert can tell the owner their work is recoverable.
+        with patch("genesis.guardian.recovery._run_subprocess", _revert_mock()):
+            ok, detail = await engine._revert_code("genesis")
+        assert ok is True
+        assert "stash" in detail.lower()
 
 
 class TestRestartContainerStopped:


### PR DESCRIPTION
## What

`REVERT_CODE` runs `git stash` then `git revert` over `incus exec`, against the
container's **live development checkout** — the tree sessions hold uncommitted work in.
The stash's exit code was discarded (`rc, _, _ = ...`), so a **failed stash still went on
to revert**, on top of tracked changes that were never saved.

The guard is `rc != 0`. `_run_subprocess` never raises — it returns `-1` for a timeout and
`-1` for an exec failure — so that test covers infrastructure failures as well as genuine
nonzero git exits. A clean tree exits 0 with "No local changes to save", which is success,
and that case is asserted so the guard cannot quietly become an always-refuse.

Three supporting details:

- **The stash gets the same 30s budget as the revert it gates.** It had 15s while every
  sibling call in the file had 30s — the cheapest precondition on the tightest deadline,
  and now the one whose failure retires the rung *and* burns one of three escalation
  attempts. `su -` starts a login shell before git runs, inside a container unhealthy
  enough to have triggered this ladder at all.
- **A timeout is reported as unknown, not as failure.** `rc=-1` means the command did not
  report, not that the stash failed. Refusing is still right — this gates a destructive
  action — but an alert asserting a failure it cannot establish sends the reader after the
  wrong thing.
- **The outcome string names where the displaced work went.** The stash is never popped,
  and the ladder's next rung restores a whole-container snapshot that would destroy it, so
  this string is the owner's only notice. It says **tracked** deliberately: plain
  `git stash` does not take untracked files, so `rc == 0` is not "the working tree is
  safe" — the same residual `scripts/hooks/git_discard_guard.py:23` documents. `-u` would
  *remove* untracked files from a running checkout, a behaviour change this guard should
  not make on its own.

## What was withdrawn, and why

Earlier commits on this branch also pinned the reverted commit by sha, shape-validated it,
probed for an in-flight revert, and cleaned up after a failed one. **Two external review
rounds produced six findings — none against the stash guard, all against that machinery**,
each round's fix generating the next round's finding in the same family:

- the banner filter worked for a probe that prints a line, and returned the banner itself
  for one that prints nothing;
- `|| true` made a probe error indistinguishable from a real empty answer;
- ownership by commit id cannot tell two invocations that pinned the same commit apart.

The shared cause is inferring state from unstructured shell output and hand-modelling
git's sequencer ownership across four round-trips — an open-set claim, where a startup
line nobody enumerated changes the verdict. So it is **redesigned rather than patched a
third time**. Those axes return to the prior behaviour, making this **strictly better on
the stash axis and a regression on nothing**.

The TOCTOU between resolving HEAD and reverting it symbolically, the cleanup deadlock, and
the deferred landing-time implication guard are filed as an issue with their measurements.
**This PR stops one specific way the rung destroyed uncommitted work. It does not make the
rung correct.**

## ⚠️ Merging — squash with an explicit subject and body

The two earlier commits describe the withdrawn machinery, and force-push to this remote is
blocked, so they cannot be rewritten. This repo squash-merges and the **default** squash
body concatenates every branch commit message — which would publish claims about code that
never shipped. Pass `--subject` and `--body-file` explicitly.

## Verification

- `pytest tests/test_guardian/test_recovery.py` → **23 passed**; `ruff check src/ tests/` clean.
- **Verify-RED, per mechanism**, in place with an M0 control and hash-verified restore:

  | mutation | result |
  |---|---|
  | M0 control (none) | 8 passed |
  | stash timeout tightened to 10s | RED |
  | stash gains `-u` | RED |
  | timeout called a failure | RED |
  | success detail loses the note | RED |
  | guard deleted | RED (4 tests, incl. the `execute()` blast-radius test) |

  Separately, guard-set-to-always-refuse fails the clean-tree control and the acceptance
  test — the suite bites in both directions.

## Caveats

- This rung has **never executed on this install** (`recovery_attempts=0`,
  `last_recovery_at=None`, read live from the host guardian), so there is no production
  path to exercise end-to-end. See the post-merge checklist comment.
- Guardian code does not reach the host until `scripts/update.sh` runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Recovery now preserves tracked changes in a stash while attempting to revert the latest commit.
  - Reversion is prevented when stashing fails or its outcome is uncertain, including timeout conditions.
  - Recovery status messages now clarify clean-tree results and when preserved changes remain in an unpopped stash.
  - Failed stash operations now produce clearer recovery guidance and critical status reporting.
  - Successful recovery alerts now include details about the action performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wingedguardian/genesis-agi/pull/1717" target="_blank"><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=4"><img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=4" alt="Devin Review"></picture></a>
<!-- devin-review-badge-end -->