### PR TITLE
fix(memory): an unreachable graph backend no longer erases the shield's thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,18 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **A graph backend that cannot answer no longer erases the shield's memory.**
+  "The graph store is unreachable" and "no bridge memories exist" used to look
+  identical — an empty answer — so a missing library or unreachable backend
+  made the nightly centrality pass wipe its cache, and the importance shield
+  then protected nothing until the backend came back AND the pass re-ran.
+  Unavailability is now its own loud signal: the pass keeps the previous
+  bridge-node population standing and says why, while a genuinely empty graph
+  still supersedes stale rows. Two writers also stopped leaving the cached
+  graph stale: superseding a memory now tells the graph about the new
+  succession edge, and the integrity sweep that purges a dead memory's edges
+  now invalidates the cache it just made wrong.
+
 - **The pre-merge check now reads the second review bot it was already fetching.**
   Two automated reviewers comment on every pull request, and the gate that decides
   whether a change is ready to merge only understood the format of one of them. The

--- a/src/genesis/memory/dream_centrality.py
+++ b/src/genesis/memory/dream_centrality.py
@@ -48,7 +48,7 @@ async def run_centrality_recompute(
         "computation_ms": 0.0,
     }
 
-    from genesis.memory.graph import centrality_scores
+    from genesis.memory.graph import GraphUnavailableError, centrality_scores
 
     t0 = time.monotonic()
     try:
@@ -57,6 +57,16 @@ async def run_centrality_recompute(
         # how many rows land in the cache, which the importance shield reads
         # as its bridge-node population.
         scores = await centrality_scores(db, top_n=None)
+    except GraphUnavailableError as exc:
+        # The store could not answer — which is NOT "no bridges". Returning
+        # here (before any DELETE below) keeps the previous cache standing, so
+        # the importance shield keeps its last real threshold instead of
+        # silently shielding nothing. The stale-cache cost is bounded: the
+        # next successful run atomically replaces it.
+        logger.warning("Centrality skipped — graph unavailable: %s", exc)
+        report["graph_unavailable"] = True
+        report["error"] = str(exc)
+        return report
     except Exception as exc:
         logger.warning("Centrality computation failed: %s", exc, exc_info=True)
         report["error"] = str(exc)

--- a/src/genesis/memory/graph.py
+++ b/src/genesis/memory/graph.py
@@ -54,6 +54,13 @@ _nx_graph: object | None = None  # nx.MultiDiGraph when _NX_AVAILABLE
 _nx_dirty: bool = True
 
 
+class GraphUnavailableError(RuntimeError):
+    """The graph backend cannot answer AT ALL (missing library, unreachable
+    store) — as distinct from answering "empty". Decision-tier readers
+    (dream-centrality → the importance shield) treat these opposite ways:
+    empty supersedes their cache, unavailable must LEAVE it alone."""
+
+
 def invalidate_graph_cache() -> None:
     """Mark the in-memory graph as stale.
 
@@ -268,7 +275,8 @@ async def centrality_scores(
     """Return memories ranked by betweenness centrality.
 
     Identifies memories that are "bridges" between clusters of knowledge.
-    Requires NetworkX; returns empty list if unavailable.
+    Requires NetworkX; raises GraphUnavailableError if the backend cannot
+    answer (an EMPTY graph still returns [] — zero nodes means zero bridges).
 
     ``top_n`` caps the returned slice; ``top_n=None`` returns EVERY scored
     node (the full ranking). Betweenness is computed over all nodes regardless
@@ -276,7 +284,16 @@ async def centrality_scores(
     just a longer list.
     """
     if not _NX_AVAILABLE:
-        return []
+        # "The store is unreachable" and "no bridges exist" are DIFFERENT
+        # answers, and returning [] for both let the first masquerade as the
+        # second: the dream-centrality consumer reads an empty result as "no
+        # bridges", wipes centrality_cache, and the importance shield then
+        # computes no threshold — bridge-node protection silently disappears
+        # because a library failed to import. A decision-tier consumer must
+        # never degrade silently (issue #1641 / the graph-store seam contract),
+        # so unavailability RAISES; an empty graph still returns [] below,
+        # because zero nodes genuinely means zero bridges.
+        raise GraphUnavailableError("NetworkX is not importable — centrality cannot be computed")
 
     G = await _ensure_graph(db)
     if G.number_of_nodes() == 0:

--- a/src/genesis/memory/integrity_repair.py
+++ b/src/genesis/memory/integrity_repair.py
@@ -362,42 +362,47 @@ async def run_reconcile(
         # and our sweep — which would strand a vector-only ghost. A ghost has no
         # metadata row by definition, so the sweep is a completeness no-op in the
         # normal case. Shared serialized connection, periodic commit, never rollback.
-        for i, (pid, coll) in enumerate(deletable, 1):
-            async with memory_id_lock(pid):
+        try:
+            for i, (pid, coll) in enumerate(deletable, 1):
+                async with memory_id_lock(pid):
+                    try:
+                        await asyncio.to_thread(
+                            qdrant_ops.delete_point, qdrant_client, collection=coll, point_id=pid
+                        )
+                    except Exception:
+                        logger.warning(
+                            "reconcile: ghost point delete failed for %s — left for next run",
+                            pid,
+                            exc_info=True,
+                        )
+                        ghost_delete_failed += 1
+                        continue
+                    await db.execute("DELETE FROM memory_fts WHERE memory_id = ?", (pid,))
+                    await db.execute(
+                        "DELETE FROM memory_links WHERE source_id = ? OR target_id = ?", (pid, pid)
+                    )
+                    await db.execute("DELETE FROM pending_embeddings WHERE memory_id = ?", (pid,))
+                    await db.execute("DELETE FROM entity_mentions WHERE memory_id = ?", (pid,))
+                    deleted.append(pid)
+                if i % _SWEEP_COMMIT_EVERY == 0:
+                    await db.commit()
+            await db.commit()
+        finally:
+            if deleted:
+                # This sweep deletes memory_links rows directly (no CRUD), and this
+                # module previously contained zero invalidations — the cached graph
+                # kept ghost edges until an unrelated write refreshed it. The other
+                # of the two known invalidation gaps (issue #1641). Once per sweep,
+                # not per row: invalidation is a flag flip, rebuild happens lazily.
+                # finally-scoped: a raise mid-loop after a periodic commit leaves
+                # earlier deletions DURABLE — the cache must go dirty even on a
+                # partial sweep (CodeRabbit Major, PR #1725).
                 try:
-                    await asyncio.to_thread(
-                        qdrant_ops.delete_point, qdrant_client, collection=coll, point_id=pid
-                    )
-                except Exception:
-                    logger.warning(
-                        "reconcile: ghost point delete failed for %s — left for next run",
-                        pid,
-                        exc_info=True,
-                    )
-                    ghost_delete_failed += 1
-                    continue
-                await db.execute("DELETE FROM memory_fts WHERE memory_id = ?", (pid,))
-                await db.execute(
-                    "DELETE FROM memory_links WHERE source_id = ? OR target_id = ?", (pid, pid)
-                )
-                await db.execute("DELETE FROM pending_embeddings WHERE memory_id = ?", (pid,))
-                await db.execute("DELETE FROM entity_mentions WHERE memory_id = ?", (pid,))
-                deleted.append(pid)
-            if i % _SWEEP_COMMIT_EVERY == 0:
-                await db.commit()
-        await db.commit()
-        if deleted:
-            # This sweep deletes memory_links rows directly (no CRUD), and this
-            # module previously contained zero invalidations — the cached graph
-            # kept ghost edges until an unrelated write refreshed it. The other
-            # of the two known invalidation gaps (issue #1641). Once per sweep,
-            # not per row: invalidation is a flag flip, rebuild happens lazily.
-            try:
-                from genesis.memory.graph import invalidate_graph_cache
+                    from genesis.memory.graph import invalidate_graph_cache
 
-                invalidate_graph_cache()
-            except ImportError:
-                pass
+                    invalidate_graph_cache()
+                except ImportError:
+                    pass
 
     # ── Repair: mirrors (re-read → requeue for re-embed) ──
     mirrors_requeued = 0

--- a/src/genesis/memory/integrity_repair.py
+++ b/src/genesis/memory/integrity_repair.py
@@ -386,6 +386,18 @@ async def run_reconcile(
             if i % _SWEEP_COMMIT_EVERY == 0:
                 await db.commit()
         await db.commit()
+        if deleted:
+            # This sweep deletes memory_links rows directly (no CRUD), and this
+            # module previously contained zero invalidations — the cached graph
+            # kept ghost edges until an unrelated write refreshed it. The other
+            # of the two known invalidation gaps (issue #1641). Once per sweep,
+            # not per row: invalidation is a flag flip, rebuild happens lazily.
+            try:
+                from genesis.memory.graph import invalidate_graph_cache
+
+                invalidate_graph_cache()
+            except ImportError:
+                pass
 
     # ── Repair: mirrors (re-read → requeue for re-embed) ──
     mirrors_requeued = 0

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -542,6 +542,22 @@ class MemoryStore:
                     "Failed to create succeeded_by link %s → %s: %s",
                     old_id, new_id, link_exc,
                 )
+        else:
+            # The CRUD create does not invalidate (its callers do, by
+            # convention) — and this caller previously didn't either, so every
+            # supersede left the cached graph missing the succeeded_by edge
+            # until some unrelated write invalidated it. One of the two known
+            # invalidation gaps from the graph-store consumer map (issue #1641).
+            # Scope: this flips THIS process's projection (the MCP child, which
+            # hosts the traverse readers most affected); cross-process readers
+            # rebuild on their own invalidations — the DB-generation token that
+            # closes that fully is future seam work (#1641).
+            try:
+                from genesis.memory.graph import invalidate_graph_cache
+
+                invalidate_graph_cache()
+            except ImportError:
+                pass
 
     async def delete(self, memory_id: str) -> dict:
         """Delete a memory from all layers. Returns per-layer status.

--- a/tests/test_memory/test_dream_centrality.py
+++ b/tests/test_memory/test_dream_centrality.py
@@ -135,3 +135,70 @@ async def test_centrality_skips_zero_scores(phase_kwargs):
     cursor = await db.execute("SELECT memory_id FROM centrality_cache")
     rows = [r[0] for r in await cursor.fetchall()]
     assert rows == ["bridge"]
+
+
+async def test_unavailable_graph_keeps_the_existing_cache(phase_kwargs):
+    """"Store unreachable" must NOT masquerade as "no bridges exist".
+
+    The fail-open chain this pins shut: centrality_scores returning [] on an
+    unavailable backend read as an empty result, the recompute wiped
+    centrality_cache, the importance shield computed no threshold, and
+    bridge-node protection silently disappeared. Unavailability now raises,
+    and the recompute must leave the previous cache STANDING.
+    """
+    from genesis.memory.graph import GraphUnavailableError
+
+    db = phase_kwargs["db"]
+    await db.execute(
+        "INSERT INTO centrality_cache (memory_id, centrality_score, computed_at) "
+        "VALUES ('mem-prior', 0.7, '2026-01-01T00:00:00+00:00')"
+    )
+    await db.commit()
+
+    with patch(
+        "genesis.memory.graph.centrality_scores",
+        new_callable=AsyncMock,
+        side_effect=GraphUnavailableError("backend down"),
+    ):
+        report = await run_centrality_recompute(**phase_kwargs)
+
+    assert report.get("graph_unavailable") is True
+    cursor = await db.execute("SELECT COUNT(*) FROM centrality_cache")
+    assert (await cursor.fetchone())[0] == 1, (
+        "an unavailable graph wiped the shield's threshold population"
+    )
+
+
+async def test_empty_graph_still_supersedes_the_cache(phase_kwargs):
+    """CONTROL for the fix above: a REAL empty result (zero bridges) must keep
+    clearing stale rows — the unavailability fix must not turn every empty
+    run into a keep."""
+    db = phase_kwargs["db"]
+    await db.execute(
+        "INSERT INTO centrality_cache (memory_id, centrality_score, computed_at) "
+        "VALUES ('mem-stale', 0.7, '2026-01-01T00:00:00+00:00')"
+    )
+    await db.commit()
+
+    with patch(
+        "genesis.memory.graph.centrality_scores",
+        new_callable=AsyncMock,
+        return_value=[],
+    ):
+        report = await run_centrality_recompute(**phase_kwargs)
+
+    assert not report.get("graph_unavailable")
+    cursor = await db.execute("SELECT COUNT(*) FROM centrality_cache")
+    assert (await cursor.fetchone())[0] == 0
+
+
+async def test_centrality_scores_raises_when_networkx_absent(db):
+    """The producer half of the contract: unavailability is a typed raise,
+    never an empty list wearing "no bridges" clothing."""
+    from genesis.memory import graph as graph_mod
+
+    with (
+        patch.object(graph_mod, "_NX_AVAILABLE", False),
+        pytest.raises(graph_mod.GraphUnavailableError),
+    ):
+        await graph_mod.centrality_scores(db, top_n=None)

--- a/tests/test_memory/test_supersession.py
+++ b/tests/test_memory/test_supersession.py
@@ -357,3 +357,66 @@ async def test_supersede_skips_qdrant_for_non_embedded(store, status):
         await store._mark_superseded("old", "new", "2026-03-11T12:00:00")
 
     mock_update.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_supersede_link_invalidates_the_graph_cache(store, db):
+    """The cached graph must learn about the new succeeded_by edge.
+
+    The CRUD create deliberately does not invalidate (its callers do, by
+    convention) — and this caller didn't either, so every supersede left the
+    cached projection missing the edge until some unrelated write refreshed
+    it. One of the two known invalidation gaps (issue #1641).
+    """
+    old_id = "old-memory-id"
+    calls = []
+
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.update_payload"), \
+         patch("genesis.memory.store.memory_crud") as mock_mem, \
+         patch("genesis.memory.store.memory_links_crud") as mock_links, \
+         patch("genesis.memory.graph.invalidate_graph_cache",
+               side_effect=lambda: calls.append(1)):
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        mock_mem.mark_superseded = AsyncMock(return_value=True)
+        mock_mem.get_metadata = AsyncMock(return_value={
+            "memory_id": old_id, "collection": "episodic_memory",
+            "embedding_status": "embedded", "deprecated": 0,
+            "superseded_by": None, "superseded_at": None,
+        })
+        mock_links.create = AsyncMock(return_value=(old_id, "new"))
+
+        await store.store("new fact", "conversation", supersedes=old_id)
+
+    assert calls, "supersede created a graph edge without invalidating the cached projection"
+
+
+@pytest.mark.asyncio()
+async def test_failed_supersede_link_does_not_invalidate(store, db):
+    """CONTROL: a link create that RAISES must not invalidate — there is no
+    new edge for the cache to learn."""
+    old_id = "old-memory-id"
+    calls = []
+
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.update_payload"), \
+         patch("genesis.memory.store.memory_crud") as mock_mem, \
+         patch("genesis.memory.store.memory_links_crud") as mock_links, \
+         patch("genesis.memory.graph.invalidate_graph_cache",
+               side_effect=lambda: calls.append(1)):
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        mock_mem.mark_superseded = AsyncMock(return_value=True)
+        mock_mem.get_metadata = AsyncMock(return_value={
+            "memory_id": old_id, "collection": "episodic_memory",
+            "embedding_status": "embedded", "deprecated": 0,
+            "superseded_by": None, "superseded_at": None,
+        })
+        mock_links.create = AsyncMock(side_effect=RuntimeError("db down"))
+
+        await store.store("new fact", "conversation", supersedes=old_id)
+
+    assert not calls, "a failed link create must not dirty the cache"

--- a/tests/test_memory_integrity/test_integrity_repair.py
+++ b/tests/test_memory_integrity/test_integrity_repair.py
@@ -734,3 +734,51 @@ async def test_drain_with_real_store_delete_end_to_end(tmp_path, monkeypatch):
         "SELECT status FROM deferred_work_queue WHERE work_type='memory_deferred_delete'",
     )
     assert [r[0] for r in rows] == ["completed"]
+
+
+# ── graph-cache invalidation on edge-purging repairs (issue #1641 gap) ────
+
+
+async def test_ghost_purge_invalidates_the_graph_cache(tmp_path, monkeypatch):
+    """The sweep deletes memory_links rows directly (no CRUD), and this module
+    carried zero invalidations — the cached graph kept ghost edges until an
+    unrelated write refreshed it."""
+    path = await _db(tmp_path)
+    await _seed(path, "ok", created_at=_OLD)
+    client = _points(
+        {
+            "episodic_memory": {
+                "ok": {"created_at": _OLD},
+                "ghost_old": {"created_at": _OLD},
+                "ghost_old2": {"created_at": _OLD},
+            }
+        }
+    )
+    calls = []
+    monkeypatch.setattr(
+        "genesis.memory.graph.invalidate_graph_cache", lambda: calls.append(1)
+    )
+
+    result = await _run(path, client, monkeypatch, tmp_path)
+
+    assert result.ghosts_deleted == 2
+    assert calls, "an edge-purging repair left the cached graph stale"
+    # TWO ghosts, ONE call: with a single ghost this assertion is vacuous
+    # (per-row and per-sweep both produce 1) — the second ghost makes it bite.
+    assert len(calls) == 1, "invalidation is a flag flip — once per sweep, not per row"
+
+
+async def test_clean_reconcile_does_not_invalidate(tmp_path, monkeypatch):
+    """CONTROL: a sweep that deletes nothing must not dirty the cache."""
+    path = await _db(tmp_path)
+    await _seed(path, "ok", created_at=_OLD)
+    client = _points({"episodic_memory": {"ok": {"created_at": _OLD}}})
+    calls = []
+    monkeypatch.setattr(
+        "genesis.memory.graph.invalidate_graph_cache", lambda: calls.append(1)
+    )
+
+    result = await _run(path, client, monkeypatch, tmp_path)
+
+    assert result.ghosts_deleted == 0
+    assert not calls

--- a/tests/test_memory_integrity/test_integrity_repair.py
+++ b/tests/test_memory_integrity/test_integrity_repair.py
@@ -782,3 +782,44 @@ async def test_clean_reconcile_does_not_invalidate(tmp_path, monkeypatch):
 
     assert result.ghosts_deleted == 0
     assert not calls
+
+
+@pytest.mark.asyncio
+async def test_partial_ghost_sweep_still_invalidates(tmp_path, monkeypatch):
+    """A raise mid-loop AFTER a periodic commit leaves the earlier ghosts'
+    memory_links deletions durable — the invalidation must still fire on that
+    partial sweep (finally-scoped), or the cached graph keeps the purged edges
+    until an unrelated write refreshes it (CodeRabbit Major, PR #1725)."""
+    path = await _db(tmp_path)
+    await _seed(path, "ok", created_at=_OLD)
+    client = _points(
+        {
+            "episodic_memory": {
+                "ok": {"created_at": _OLD},
+                "ghost_old": {"created_at": _OLD},
+                "ghost_old2": {"created_at": _OLD},
+            }
+        }
+    )
+    calls = []
+    monkeypatch.setattr(
+        "genesis.memory.graph.invalidate_graph_cache", lambda: calls.append(1)
+    )
+    # Commit after every row so the first ghost's deletions are DURABLE before
+    # the injected failure on the second — the exact window the finding names.
+    monkeypatch.setattr(integrity_repair, "_SWEEP_COMMIT_EVERY", 1)
+    real_lock = integrity_repair.memory_id_lock
+    seen = {"n": 0}
+
+    def _failing_lock(pid):
+        seen["n"] += 1
+        if seen["n"] >= 2:
+            raise RuntimeError("injected mid-sweep failure")
+        return real_lock(pid)
+
+    monkeypatch.setattr(integrity_repair, "memory_id_lock", _failing_lock)
+
+    with pytest.raises(RuntimeError):
+        await _run(path, client, monkeypatch, tmp_path)
+
+    assert calls, "a partial sweep left committed deletions with a clean cache"


### PR DESCRIPTION
## What

The first independently-shippable slice of the graph-store migration (#1641): make "the graph backend cannot answer" distinguishable from "the graph is empty", and close the two known cache-invalidation gaps.

## The data-loss chain this closes

`centrality_scores` returned `[]` both when NetworkX was unavailable and when the graph was empty. The dream-centrality pass reads an empty result as "no bridges exist" and **atomically replaces its cache — with nothing**. The importance shield then computes its percentile threshold over zero rows and shields nothing. Net effect: a library import failure silently disabled bridge-node protection until the backend recovered *and* the nightly pass happened to re-run.

Unavailability now raises `GraphUnavailableError`; the pass catches it before any `DELETE`, keeps the previous threshold population standing, and reports `graph_unavailable` in its phase report. A genuinely empty graph still supersedes stale rows — locked by a control test. This is the seam contract from #1641 ("a read that cannot reach its store raises or returns typed-unknown, never an empty result") applied to the one consumer whose empty-read was actively destructive.

## The two invalidation gaps

- Superseding a memory creates a `succeeded_by` edge via the CRUD `create`, which deliberately does not invalidate (its callers do, by convention) — but this caller didn't either, so every supersede left the cached projection missing the edge.
- The integrity sweep purges a dead memory's `memory_links` rows with raw SQL, and the module carried zero invalidations — ghost edges persisted in the cache until an unrelated write refreshed it. Now invalidates once per sweep (two-ghost test pins once-per-sweep, not per-row).

## Verification

Four RED-witnessed fix tests (each failed against the unfixed sources; three controls passed both sides), 49 green across the three affected test files plus the two graph suites (64 total in the wide run), ruff clean. Adversarial audit: 0 BLOCKER, 1 SHOULD-FIX (applied — the docstring on the fixed function still taught the old conflation), caller set enumerated (one production caller, wrapped in the dream-cycle phase guard, so no scheduler job can crash on propagation).

Known limitation, documented in-code and at #1641: `invalidate_graph_cache` is a per-process flag; cross-process propagation is the seam's future DB-generation token, not this slice.

## Deploy

Runtime code — `git pull` + server restart; no migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved centrality recomputation when the graph backend is unavailable: existing cached results are preserved and the report clearly indicates the unavailable graph.
  - Empty graphs continue to be handled separately, allowing stale cache entries to be cleared appropriately.
  - Graph caches now refresh after memory supersession updates and ghost-record cleanup, including partial cleanup operations, while remaining unchanged when no relevant updates occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->