### PR TITLE
fix(cc-tmp): watchgod RED sweep spares unix sockets, the control plane it severed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,15 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Fixed
 
+- **The temp-space watchdog no longer severs cross-session messaging when it
+  goes nuclear.** At its most aggressive cleanup tier the watchdog deleted every
+  top-level directory of Claude Code's working temp — including the directory
+  holding each live session's messaging socket. The sockets are zero bytes, so
+  deleting them reclaimed nothing, while every running session silently became
+  unreachable to its peers until restarted. The nuclear sweep now spares unix
+  sockets (and only them — all reclaimable bytes are still deleted) and logs
+  how many it preserved.
+
 - **The pre-merge check now reads the second review bot it was already fetching.**
   Two automated reviewers comment on every pull request, and the gate that decides
   whether a change is ready to merge only understood the format of one of them. The

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -114,6 +114,19 @@ fs_total_mb() {
     echo "${result:-0}"
 }
 
+reap_dir_sparing_sockets() {
+    # Object-level deletion that NEVER removes unix sockets. CC binds one
+    # socket per live session under cc-tmp (cross-session messaging); they are
+    # 0 bytes, so deleting them reclaims nothing and silently severs the local
+    # coordination plane — sessions keep listening on bound-but-unlinked
+    # sockets and inbound connects fail ENOENT (measured, 2026-09-05 RED
+    # incident). Deletes everything else depth-first; a socket's ancestor dirs
+    # stay non-empty so they survive; a dir holding no sockets is removed
+    # entirely, exactly like rm -rf. -delete failures on non-empty dirs are
+    # expected and suppressed; GNU find continues past them.
+    find "$1" -depth -not -type s -delete 2>/dev/null || true
+}
+
 write_state() {
     local cc_tier="$1" cc_used="$2" sys_tier="$3" sys_pct="$4"
     local is_tmpfs="false"
@@ -238,14 +251,18 @@ clean_cc_red() {
     newest_session=$(find "$CC_TMP_DIR" -mindepth 2 -maxdepth 2 -type d -path "*/claude-*" \
         -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | awk '{print $2}') || true
 
-    # Delete ALL session dirs EXCEPT the newest one and files modified in last 60s
+    # Reap every depth-1 dir except the newest session's ancestor —
+    # object-level and socket-sparing (see reap_dir_sparing_sockets); loose
+    # depth-1 files are the separate sweep below. `|| true` matches the
+    # file's find idiom: a transient find error must not abort the daemon
+    # mid-RED under set -euo pipefail.
     find "$CC_TMP_DIR" -mindepth 1 -maxdepth 1 -type d | while IFS= read -r dir; do
         # Skip if this contains the active session
         if [[ -n "$newest_session" && "$newest_session" == "$dir/"* ]]; then
             continue
         fi
-        rm -rf "$dir" 2>/dev/null || true
-    done
+        reap_dir_sparing_sockets "$dir"
+    done || true
 
     # Delete all reclaimable files except those modified in last 60s
     find "$CC_TMP_DIR" -type f -not -newermt '60 seconds ago' \
@@ -254,6 +271,17 @@ clean_cc_red() {
     # Delete caches unconditionally
     find "$CC_TMP_DIR" -type d \( -name "claude-skills" -o -name "tsx-*" \) \
         -exec rm -rf {} + 2>/dev/null || true
+
+    # Report the surviving control plane — counted AFTER every sweep above,
+    # so the line is true by construction whatever any sweep did. Sockets
+    # are 0 bytes: deleting them reclaims nothing and silently severs
+    # cross-session messaging (measured, 2026-09-05 incident — this line's
+    # absence is what made that invisible).
+    local sock_count
+    sock_count=$(find "$CC_TMP_DIR" -type s 2>/dev/null | wc -l) || sock_count=0
+    if (( sock_count > 0 )); then
+        log INFO "RED preserved ${sock_count} unix socket(s) under cc-tmp — control plane, 0 bytes reclaimable"
+    fi
 
     # Kill ALL idle CC sessions (log each — so it's clear which terminals were reaped)
     while IFS= read -r sname; do

--- a/tests/test_scripts/test_watchgod_socket_sparing.py
+++ b/tests/test_scripts/test_watchgod_socket_sparing.py
@@ -1,0 +1,169 @@
+"""tmp_watchgod socket-sparing — the RED reaper must never delete unix sockets.
+
+Origin (measured on a live install, 2026-09-05): Zone A RED's depth-1 sweep
+(`clean_cc_red`) `rm -rf`s every top-level directory of CC_TMP_DIR except the
+one holding the newest `*/claude-*` session dir. `cc-socks/` — where the
+Claude Code binary binds one unix socket per session for cross-session
+messaging — is such a directory and was deleted wholesale, leaving live
+sessions listening on bound-but-unlinked sockets: inbound connects fail
+ENOENT and the local coordination plane fails silently. The sockets are
+0 bytes, so deleting them reclaims nothing.
+
+These tests pin the fix (object-level socket-sparing deletion at the RED
+depth-1 sweep) and that the yellow/orange sweeps cannot touch a socket in
+the cc-socks layout CC actually creates.
+
+Harness idiom mirrors test_watchgod_loopbreak.py (deliberately duplicated —
+repo precedent: the existing watchgod test files do not share a conftest):
+HOME-redirected sandbox so the script's HOME-derived paths land in tmp_path,
+overrides injected as a bash snippet after sourcing (the script assigns
+CC_TMP_BUDGET_MB unconditionally, so env vars cannot set it), and a tmux
+stub on a PATH-prepended bin dir so the RED tier's session-kill loop sees no
+sessions.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+_WATCHGOD = Path(__file__).resolve().parents[2] / "scripts" / "tmp_watchgod.sh"
+
+# No-op-ish tmux stub: list-sessions prints nothing (no killable sessions),
+# every other verb exits 0 — the RED kill loop is out of scope here.
+_TMUX_STUB = """#!/usr/bin/env bash
+exit 0
+"""
+
+# Tier functions are called directly, so the budget only feeds orange's
+# post-cleanup re-measure; keep it tiny. Stub queue_alert so the
+# RED path's emergency alert becomes a log line instead of a real queue write.
+_PRELUDE = (
+    'CC_TMP_BUDGET_MB=4; '
+    'queue_alert() { echo "ALERT $*" >> "$HOME/.genesis/alerts/calls.log"; }; '
+)
+
+
+def _make_exec(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _sandbox(tmp_path: Path) -> tuple[Path, Path, Path]:
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    (home / ".genesis" / "alerts").mkdir(parents=True)
+    cctmp = home / ".genesis" / "cc-tmp"  # the script's default CC_TMP_DIR
+    cctmp.mkdir(parents=True)
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    _make_exec(bind / "tmux", _TMUX_STUB)
+    return home, cctmp, bind
+
+
+def _run(home: Path, bind: Path, snippet: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(HOME=str(home), PATH=f"{bind}:{os.environ['PATH']}")
+    return subprocess.run(
+        ["bash", "-c", f"source '{_WATCHGOD}'\n{snippet}"],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _mksock(path: Path) -> None:
+    """A real socket-type inode via mknod — no AF_UNIX sun_path length limit,
+    unprivileged on Linux, and exactly what `find -type s` matches."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.mknod(path, stat.S_IFSOCK | 0o600)
+
+
+def _log(home: Path) -> str:
+    return (home / ".genesis" / "logs" / "tmp_watchgod.log").read_text()
+
+
+def test_red_preserves_socket_deletes_sibling_junk(tmp_path):
+    """The incident replay: RED must delete reclaimable depth-1 dirs but never
+    the control-plane socket. Pre-fix, rm -rf takes cc-socks with the rest."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    sock = cctmp / "cc-socks" / "2501887.sock"
+    _mksock(sock)
+    (cctmp / "pyright-x").mkdir()
+    (cctmp / "pyright-x" / "blob").write_bytes(b"x" * 4096)
+    (cctmp / "gh-cli-cache").mkdir()
+    (cctmp / "gh-cli-cache" / "f").write_bytes(b"y" * 4096)
+    # a session dir, so newest_session resolves like production
+    (cctmp / "claude-1000" / "some-session-uuid").mkdir(parents=True)
+
+    proc = _run(home, bind, _PRELUDE + "clean_cc_red")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    assert sock.exists() and stat.S_ISSOCK(sock.stat().st_mode), (
+        "RED deleted the control-plane socket"
+    )
+    assert not (cctmp / "pyright-x").exists(), "junk dir should be reclaimed"
+    assert not (cctmp / "gh-cli-cache").exists(), "junk dir should be reclaimed"
+    assert "preserved 1 unix socket" in _log(home)
+
+
+def test_red_preserves_socket_with_no_session_dir(tmp_path):
+    """The measured worst case: with NO claude-* session dir anywhere,
+    newest_session is empty and the pre-fix guard spares NOTHING — every
+    depth-1 dir including cc-socks is rm -rf'd. The socket must survive."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    sock = cctmp / "cc-socks" / "999.sock"
+    _mksock(sock)
+    (cctmp / "junkdir").mkdir()
+    (cctmp / "junkdir" / "f").write_bytes(b"z" * 4096)
+
+    proc = _run(home, bind, _PRELUDE + "clean_cc_red")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    assert sock.exists() and stat.S_ISSOCK(sock.stat().st_mode), (
+        "RED deleted the socket in the empty-newest_session case"
+    )
+    assert (cctmp / "cc-socks").is_dir()
+
+
+def test_red_reclaims_files_inside_socket_dir(tmp_path):
+    """Object-level, not skip-wholesale: regular files sharing a directory
+    with a socket ARE reclaimed; the socket and its parent dir survive."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    sock = cctmp / "cc-socks" / "1234.sock"
+    _mksock(sock)
+    junk = cctmp / "cc-socks" / "junk.log"
+    junk.write_bytes(b"j" * 4096)
+    (cctmp / "claude-1000" / "some-session-uuid").mkdir(parents=True)
+
+    proc = _run(home, bind, _PRELUDE + "clean_cc_red")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    assert not junk.exists(), "regular file beside the socket should be reclaimed"
+    assert sock.exists() and stat.S_ISSOCK(sock.stat().st_mode)
+    assert (cctmp / "cc-socks").is_dir()
+
+
+def test_orange_never_touches_old_socket_pin(tmp_path):
+    """Pin: the yellow/orange sweeps are dir-name- and -type f-scoped and must
+    never delete a socket, however old. Guards future sweep edits."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    sock = cctmp / "cc-socks" / "999.sock"
+    _mksock(sock)
+    eight_days_ago = time.time() - 8 * 86400
+    os.utime(sock, (eight_days_ago, eight_days_ago))
+    # give orange a cache to evict so the tier does real work
+    (cctmp / "claude-skills").mkdir()
+    (cctmp / "claude-skills" / "blob").write_bytes(b"c" * 4096)
+
+    proc = _run(home, bind, _PRELUDE + "clean_cc_orange")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    assert sock.exists() and stat.S_ISSOCK(sock.stat().st_mode), (
+        "yellow/orange sweep deleted a socket"
+    )
+    assert not (cctmp / "claude-skills").exists(), "orange should evict the cache"


### PR DESCRIPTION
## What

The temp-space watchdog's RED (nuclear) tier deleted every depth-1 directory of Claude Code's working temp except the newest session's ancestor. That included the directory where the CC binary binds one unix socket per live session for cross-session messaging. The sockets are 0 bytes — deleting them reclaimed nothing — while every running session silently became unreachable: still listening on a bound-but-unlinked socket, inbound connects failing ENOENT, nothing logged on either side. Measured on a live install after a real RED event: 3 of 4 running sessions severed until restart.

## Fix

- New `reap_dir_sparing_sockets()` helper: `find "$dir" -depth -not -type s -delete` — object-level deletion that spares socket inodes only. All reclaimable bytes are still deleted; a socket's ancestor dirs survive as empty shells; a socket-free dir is removed exactly as `rm -rf` did.
- The RED depth-1 loop uses the helper; the newest-session guard is untouched.
- After all sweeps, RED logs `preserved N unix socket(s)` — counted post-sweep, so the line is true by construction whatever any sweep did.
- The sweep pipeline gains the file's standard `|| true` idiom so a transient `find` error can't abort the daemon mid-RED under `set -euo pipefail`.
- Yellow/orange tiers, file sweeps, and cache sweeps deliberately unchanged; a pin test locks them out of socket deletion for the layout CC creates.

## Verification

- Verify-RED: 3 of the 4 new tests fail against the pre-fix script on the socket-survival assertions; the pin test was seen failing against a behaviorally-real mutant before trusting its green.
- 18/18 green post-fix (4 new + all 14 existing watchgod tests).
- Acceptance replay of the live incident's depth-1 shape through both scripts: pre-fix 0/4 sockets survive and the socket dir is deleted (incident reproduced); post-fix 4/4 preserved, newest-session dir spared, identical 7/7 junk-dir reclaim, INFO line present.
- Helper semantics measured against GNU findutils 4.9.0 (the binary the systemd unit resolves). shellcheck at baseline parity (no findings on new code).
- Adversarial review: architect + security passes, sequential; all findings fixed or dispositioned in-diff. Fail direction of every change is under-deleting only.

## Accepted limitation

Sockets orphaned by crashed sessions are now spared indefinitely — zero-byte inodes, no disk cost. Liveness-aware reaping belongs to session-roster tooling, not a byte-reclaiming daemon, and is tracked separately.

## Deploy

Container-local systemd user unit (`genesis-tmp-watchgod.service` runs the checkout directly). Post-merge: `systemctl --user restart genesis-tmp-watchgod`; verify via `is-active` + a fresh "Watchgod starting" line in the watchgod log. No host-side deploy path involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cleanup now preserves Unix sockets and their required parent directories.
  - Unrelated temporary files and directories continue to be removed during cleanup.
  - Cleanup works correctly even when no active session is present.
  - Improved cleanup reporting includes the number of sockets preserved.

- **Tests**
  - Added coverage for socket preservation across cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->