### PR TITLE
fix(routing): stop retrying provider refusals that cannot change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Fixed
+
+- **A model your account tier cannot use no longer stalls the fallback chain.**
+  When a provider refuses a call because the plan does not include that model,
+  the refusal arrives as an HTTP 403 whose message names the plan or subscription
+  you would need. Those are the same words a genuine "you have used up your
+  allowance" message uses, so the router read the refusal as an exhausted quota
+  and did what that calls for: waited, and tried the same provider again. Since
+  the answer can never change, that wait was spent against the chain's overall
+  time budget for nothing — measured at several seconds on each attempt.
+
+  Entitlement refusals are now recognised on their own terms. The router gives up
+  on that provider immediately and moves to the next one in the chain, and the
+  provider is held out of rotation on the long window rather than being re-tried
+  every half hour.
+
+  The same correction is applied to an exhausted allowance, which had the same
+  problem for the same reason: a spent quota is a billing state, so waiting a
+  few seconds cannot change it either, and the limit usually applies to the
+  whole account rather than one model — so a single walk could pay that wait
+  once per provider it tried. Both now behave the way a rate-limit already did,
+  which is to stop asking and move on.
+
 ### Changed
 
 - **A review comment on documentation no longer blocks a merge.** The pre-merge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,12 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
   time budget for nothing — measured at several seconds on each attempt.
 
   Entitlement refusals are now recognised on their own terms. The router gives up
-  on that provider immediately and moves to the next one in the chain, and the
-  provider is held out of rotation on the long window rather than being re-tried
-  every half hour.
+  on that provider immediately and moves to the next one in the chain, and a
+  provider that keeps refusing escalates onto the longer hold-out window instead
+  of levelling off at half an hour. To be exact about what that is worth: the
+  hold-out is identical to the existing one for the first four trips and only
+  pulls ahead during a sustained outage, so the gain is in not re-probing a
+  provider that has been dead for hours — not in the first few minutes.
 
   The same correction is applied to an exhausted allowance, which had the same
   problem for the same reason: a spent quota is a billing state, so waiting a

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1707,7 +1707,7 @@ verified: ee9ebf85c 2026-09-05
   like from outside. The 403-on-use half of that is now classified in its own
   right: `NOT_ENTITLED` (`retry.py` `_ENTITLEMENT_MARKERS`, checked BEFORE
   `_QUOTA_KEYWORDS` because an entitlement message names the plan/tier/
-  subscription it lacks and three of those words are quota keywords). It takes
+  subscription it lacks, and two of those words are themselves quota keywords). It takes
   one behaviour from each neighbour — fail-fast like PERMANENT, so a dead
   provider cannot spend the chain's aggregate `max_total_s` before the walk
   reaches a working one; the 4h cap like QUOTA_EXHAUSTED, since an entitlement

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1649,21 +1649,37 @@ How every LLM call picks a provider, and the registry for non-LLM tools.
 ```yaml subsystem-map
 entry: routing-providers
 modules: [routing, providers]
-verified: b8232425 2026-09-02
+verified: df6605eda 2026-09-05
 ```
 
 - **routing/**: `config/model_routing.yaml` defines ~54 numbered call sites,
   each a free-first → paid-last chain; `never_pays` sites are filtered to
   free-only. Per-provider circuit breaker (3 failures, exponential backoff
-  capped 30 min — 4h for QUOTA_EXHAUSTED; 429 = backpressure, NOT a breaker
-  failure; state persisted cross-process to
+  capped 30 min — 4h for QUOTA_EXHAUSTED and NOT_ENTITLED; 429 = backpressure,
+  NOT a breaker failure; state persisted cross-process to
   `~/.genesis/circuit_breaker_state.json`). **Probe/call evidence symmetry** —
   a probe may only undo what a probe did: `probe_suspect()` downgrades CLOSED to
   HALF_OPEN on a failed probe and a clean probe may clear THAT, but a breaker
   opened by a real call failure (`_opened_by_call`) is closed only by a real
   `record_success`. A models-listing 200 evidences *reachable*, never *working* —
   it is what a 403-on-use, an exhausted quota or a truncated completion looks
-  like from outside. The probe heal deliberately does NOT fire `on_recovery`
+  like from outside. The 403-on-use half of that is now classified in its own
+  right: `NOT_ENTITLED` (`retry.py` `_ENTITLEMENT_MARKERS`, checked BEFORE
+  `_QUOTA_KEYWORDS` because an entitlement message names the plan/tier/
+  subscription it lacks and three of those words are quota keywords). It takes
+  one behaviour from each neighbour — fail-fast like PERMANENT, so a dead
+  provider cannot spend the chain's aggregate `max_total_s` before the walk
+  reaches a working one; the 4h cap like QUOTA_EXHAUSTED, since an entitlement
+  does not change in 30 minutes. Either neighbour alone gives up the other half.
+  The same review pass closed the CLASS: QUOTA_EXHAUSTED now fails fast too. The
+  old split was inverted — RATE_LIMITED, the one 4xx that genuinely might clear
+  inside a backoff, already failed fast, while a spent allowance (a billing
+  state, and usually account-global: one OpenRouter key limit covers all 13
+  openrouter chain entries) was retried. MEASURED 2026-09-05 before the fix:
+  ~11.9s avg per entitlement exposure (n=15), 4.1-6.8s per quota exposure
+  (n=22), against a 180-600s aggregate `max_total_s`. The two categories stay
+  DISTINCT on every reporting surface; only the retry behaviour is shared.
+  The probe heal deliberately does NOT fire `on_recovery`
   (which resolves the `provider_failure` observation and clears `first_trip_at`),
   so a listing can no longer erase an outage clock. This does not hold a provider
   out of rotation: OPEN auto-transitions to HALF_OPEN on backoff, HALF_OPEN is

--- a/src/genesis/dashboard/templates/partials/tabs/overview.html
+++ b/src/genesis/dashboard/templates/partials/tabs/overview.html
@@ -1032,10 +1032,15 @@
                            :style="`color: ${$store.genesisDashboard.keyHealthColor(info.key_health)}`"
                            :title="info.error || info.cb_reason || ''">
                         <span class="status-dot" :style="`background: ${$store.genesisDashboard.keyHealthColor(info.key_health)}`"></span>
+                        <!-- cb_label comes from the backend (api_keys.py
+                             _CB_SHORT_LABEL), which is exhaustive over
+                             ErrorCategory and test-locked. This template used to
+                             re-derive it with its own quota_exhausted ternary —
+                             a second copy of the mapping that silently rendered
+                             every newly-added category as "API down". -->
                         <span x-text="name + ' (' + (
                           info.status === 'missing' ? 'key missing'
-                          : info.cb_reason === 'quota_exhausted' ? 'out of credits'
-                          : info.cb_state === 'open' ? 'API down'
+                          : info.cb_label ? info.cb_label
                           : info.error ? info.error.substring(0, 40)
                           : info.status
                         ) + ')'"></span>

--- a/src/genesis/observability/snapshots/api_keys.py
+++ b/src/genesis/observability/snapshots/api_keys.py
@@ -178,6 +178,16 @@ def api_key_health(
         cb_state, cb_reason = cb_by_type.get(ptype, ("closed", None))
         entry["cb_state"] = cb_state
         entry["cb_reason"] = cb_reason
+        # Short operator label, rendered by the dashboard instead of re-deriving
+        # the mapping in Alpine. The template previously carried its own
+        # `cb_reason === 'quota_exhausted' ? … : 'API down'` ternary — a second
+        # copy of this decision, which drifted the moment a category was added
+        # and which no Python test could ever catch.
+        entry["cb_label"] = (
+            _CB_SHORT_LABEL.get(cb_reason or "", _CB_SHORT_GENERIC)
+            if cb_state == "open"
+            else None
+        )
 
         entry["alert_severity"] = _compute_alert_severity(
             status=entry["status"],
@@ -297,6 +307,56 @@ def _key_health_color(status: str, cb_state: str) -> str:
     return "green"
 
 
+#: Operator wording per breaker category — the SINGLE source of truth, and
+#: EXHAUSTIVE over ``ErrorCategory`` by contract (locked by
+#: ``test_every_error_category_has_an_operator_label``).
+#:
+#: Why a table rather than the ``if cb_reason == "quota_exhausted"`` chain that
+#: was here: that chain named ONE category and sent every other one to the
+#: generic "down (circuit breaker open)". So the day ``NOT_ENTITLED`` was added,
+#: an account-tier fact the operator can fix in a minute began rendering as a
+#: provider outage they cannot — worse than the "credits depleted" the same 403
+#: produced BEFORE the category existed. Nothing failed; a new enum member just
+#: fell into the default arm, silently.
+#:
+#: A category that genuinely reads as an outage belongs in ``_CB_GENERIC``, not
+#: omitted. Absent from BOTH is a test failure, on purpose: adding a category is
+#: then a decision, not an accident.
+_CB_ALERT_BY_CATEGORY: dict[str, tuple[str, str]] = {
+    "quota_exhausted": ("credit_exhaustion", "{p} credits depleted"),
+    # Points at the ACCOUNT, which is the only place this is fixable. The plan
+    # or tier does not include the model; the provider itself is perfectly up.
+    "not_entitled": ("not_entitled", "{p} not included on this plan/tier"),
+}
+
+#: Categories that correctly read as "the provider is unwell". Listed rather
+#: than defaulted, so the set is auditable.
+_CB_GENERIC: frozenset[str] = frozenset(
+    {"transient", "degraded", "permanent", "timeout", "rate_limited", "bad_request"}
+)
+
+_CB_GENERIC_ALERT = ("provider_down", "{p} down (circuit breaker open)")
+
+#: The same decision in the compact form the provider list renders. Keyed by the
+#: same categories so the two cannot disagree; the enumeration test covers both.
+_CB_SHORT_LABEL: dict[str, str] = {
+    "quota_exhausted": "out of credits",
+    "not_entitled": "not on this plan",
+}
+_CB_SHORT_GENERIC = "API down"
+
+
+def cb_alert_for(cb_reason: str | None) -> tuple[str, str]:
+    """``(reason, message_prefix)`` for a breaker category. Never raises.
+
+    An UNKNOWN category (a rollback reading a value a newer build wrote, or one
+    added without updating the table) degrades to the generic outage wording —
+    the test is what stops that being the silent path for a category we ship.
+    """
+    mapped = _CB_ALERT_BY_CATEGORY.get(cb_reason or "")
+    return mapped if mapped else _CB_GENERIC_ALERT
+
+
 def _build_alerts(providers: dict) -> list[dict]:
     """Build attention-strip alerts from enriched provider entries."""
     alerts: list[dict] = []
@@ -314,12 +374,12 @@ def _build_alerts(providers: dict) -> list[dict]:
         cb_reason = info.get("cb_reason")
         chain_count = info.get("chain_count", 0)
 
-        if cb_reason == "quota_exhausted":
-            reason = "credit_exhaustion"
-            message = f"{ptype.title()} credits depleted — {chain_count} call site(s) affected"
+        if cb_reason in _CB_ALERT_BY_CATEGORY:
+            reason, prefix = cb_alert_for(cb_reason)
+            message = f"{prefix.format(p=ptype.title())} — {chain_count} call site(s) affected"
         elif info.get("cb_state") == "open":
-            reason = "provider_down"
-            message = f"{ptype.title()} down (circuit breaker open) — {chain_count} call site(s) affected"
+            reason, prefix = _CB_GENERIC_ALERT
+            message = f"{prefix.format(p=ptype.title())} — {chain_count} call site(s) affected"
         elif info.get("status") == "missing":
             sole = info.get("sole_sites", [])
             reason = "missing_key"

--- a/src/genesis/observability/snapshots/api_keys.py
+++ b/src/genesis/observability/snapshots/api_keys.py
@@ -372,12 +372,26 @@ def _build_alerts(providers: dict) -> list[dict]:
         seen_types.add(ptype)
 
         cb_reason = info.get("cb_reason")
+        cb_state = info.get("cb_state")
         chain_count = info.get("chain_count", 0)
 
-        if cb_reason in _CB_ALERT_BY_CATEGORY:
+        # `cb_state == "open"` is required, not incidental. `record_failure` sets
+        # `_last_failure_category` on EVERY failure, before the trip threshold is
+        # even checked (circuit_breaker.py:242), so a CLOSED breaker routinely
+        # carries a stale category from a failure that never tripped it. Keying on
+        # the category alone therefore announced "X is not included on this
+        # plan/tier" for a provider whose actual problem was a MISSING API KEY —
+        # the branch below that would have said so never got the chance.
+        #
+        # The old `cb_reason == "quota_exhausted"` arm had the same shape, so this
+        # is not a regression; it is the same latent bug, and this diff rewrote
+        # these exact lines, so leaving it would have been choosing not to fix it.
+        # Cross-model review flagged it at P3 for precisely that reason.
+        # `cb_label` above already gates on open — these two now agree.
+        if cb_state == "open" and cb_reason in _CB_ALERT_BY_CATEGORY:
             reason, prefix = cb_alert_for(cb_reason)
             message = f"{prefix.format(p=ptype.title())} — {chain_count} call site(s) affected"
-        elif info.get("cb_state") == "open":
+        elif cb_state == "open":
             reason, prefix = _CB_GENERIC_ALERT
             message = f"{prefix.format(p=ptype.title())} — {chain_count} call site(s) affected"
         elif info.get("status") == "missing":

--- a/src/genesis/routing/circuit_breaker.py
+++ b/src/genesis/routing/circuit_breaker.py
@@ -22,6 +22,12 @@ _STATE_FILE = Path.home() / ".genesis" / "circuit_breaker_state.json"
 
 _MAX_OPEN_S = 1800  # 30-minute cap on escalating backoff
 _MAX_QUOTA_OPEN_S = 14400  # 4-hour cap for quota/billing exhaustion
+# Categories that hold the breaker open on the LONG cap: neither an exhausted
+# allowance nor a missing entitlement resolves itself within the 30m default.
+_LONG_OPEN_CATEGORIES = frozenset({
+    ErrorCategory.QUOTA_EXHAUSTED,
+    ErrorCategory.NOT_ENTITLED,
+})
 
 
 
@@ -89,10 +95,17 @@ class CircuitBreaker:
         """Open duration with escalating backoff.
 
         First trip uses base duration; each subsequent trip doubles it.
-        Capped at _MAX_QUOTA_OPEN_S (4h) for quota exhaustion, _MAX_OPEN_S (30m) otherwise.
+        Capped at _MAX_QUOTA_OPEN_S (4h) for quota exhaustion and entitlement
+        denial, _MAX_OPEN_S (30m) otherwise. Both of those clear on a timescale
+        set by an account change, not by a passing outage, so re-probing them on
+        the short cap only buys a doomed attempt 8x more often.
         """
         exponent = max(0, self._trip_count - 1)
-        cap = _MAX_QUOTA_OPEN_S if self._last_failure_category == ErrorCategory.QUOTA_EXHAUSTED else _MAX_OPEN_S
+        cap = (
+            _MAX_QUOTA_OPEN_S
+            if self._last_failure_category in _LONG_OPEN_CATEGORIES
+            else _MAX_OPEN_S
+        )
         return min(self._open_duration_s * (2 ** exponent), cap)
 
     @property

--- a/src/genesis/routing/retry.py
+++ b/src/genesis/routing/retry.py
@@ -17,6 +17,40 @@ _QUOTA_KEYWORDS = frozenset({
     "quota", "exceeded", "billing", "limit", "exhausted",
     "usage", "credits", "subscription", "plan",
 })
+# A 403 that means "your tier may not use this model" — checked BEFORE
+# _QUOTA_KEYWORDS, because the two vocabularies overlap and quota would
+# otherwise win: an entitlement message naturally names the thing you do not
+# have ("subscription", "plan", "tier"), and three of those words are quota
+# keywords. Order is the whole fix; see ErrorCategory.NOT_ENTITLED for why the
+# distinction has to exist at all.
+#
+# Provenance, because these are matched against live vendor prose. The first
+# two are MEASURED verbatim from Mistral (2026-09-05, and the same shape in the
+# outage from 2026-08-27); zero false positives over 1,093 real error messages
+# in `activity_log` that day, with OpenRouter's genuine "Key limit exceeded"
+# quota 403 correctly NOT captured. The remaining four are INFERRED, and are of
+# two different kinds rather than one:
+#   - negation beside an access noun ("does not have access", "not authorized")
+#     — consumption language ("exceeded your usage") cannot reach these.
+#   - a vendor status TOKEN ("permission_denied"). Broader than entitlement
+#     proper: Google returns it at 403 for project-level states too (API not
+#     enabled, suspended consumer). Those want the same fail-fast and tolerate
+#     the same long cap, so the over-capture is acceptable — but it is
+#     over-capture, not a precise match, and is recorded as such.
+# KNOWN GAP, measured not assumed: the OpenAI-family phrasing that carries the
+# "access" wording ("The model X does not exist or you do not have access to
+# it") arrives as 404, which `litellm_delegate` maps to `status_code=404` and
+# `_PERMANENT_CODES` sends straight to PERMANENT — so those two markers are
+# UNCONFIRMED at 403 and may never fire here. Widening this branch to 404 on
+# inference alone was rejected; add a marker when a real one is measured.
+_ENTITLEMENT_MARKERS = (
+    "tier_not_allowed",
+    "not available in your",
+    "does not have access",
+    "do not have access",
+    "not authorized",
+    "permission_denied",
+)
 
 
 def classify_error(status_code: int | None, error_msg: str) -> ErrorCategory:
@@ -25,7 +59,10 @@ def classify_error(status_code: int | None, error_msg: str) -> ErrorCategory:
         if status_code in _QUOTA_CODES:
             return ErrorCategory.QUOTA_EXHAUSTED
         if status_code in _MAYBE_QUOTA_CODES:
-            if any(kw in error_msg.lower() for kw in _QUOTA_KEYWORDS):
+            msg_lower = error_msg.lower()
+            if any(m in msg_lower for m in _ENTITLEMENT_MARKERS):
+                return ErrorCategory.NOT_ENTITLED
+            if any(kw in msg_lower for kw in _QUOTA_KEYWORDS):
                 return ErrorCategory.QUOTA_EXHAUSTED
             return ErrorCategory.PERMANENT
         if status_code in _PERMANENT_CODES:

--- a/src/genesis/routing/retry.py
+++ b/src/genesis/routing/retry.py
@@ -20,8 +20,8 @@ _QUOTA_KEYWORDS = frozenset({
 # A 403 that means "your tier may not use this model" — checked BEFORE
 # _QUOTA_KEYWORDS, because the two vocabularies overlap and quota would
 # otherwise win: an entitlement message naturally names the thing you do not
-# have ("subscription", "plan", "tier"), and three of those words are quota
-# keywords. Order is the whole fix; see ErrorCategory.NOT_ENTITLED for why the
+# have ("subscription", "plan", "tier"), and two of those three — "subscription"
+# and "plan" — are themselves quota keywords. Order is the whole fix; see ErrorCategory.NOT_ENTITLED for why the
 # distinction has to exist at all.
 #
 # Provenance, because these are matched against live vendor prose. The first

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -500,9 +500,23 @@ class Router:
             #    burning more of this provider's rate quota.
             #  - BAD_REQUEST: a 400/422 is deterministic (our payload) — the
             #    same provider with the same payload fails identically.
+            #  - NOT_ENTITLED: a 403 on account tier is deterministic — the
+            #    same credential and model fail identically on every retry.
+            #  - QUOTA_EXHAUSTED: an exhausted allowance is a BILLING state, not
+            #    a timing one. Unlike a 429 it cannot clear inside a backoff
+            #    window, and the limit is usually account-global rather than
+            #    per-model — one OpenRouter key limit covers every openrouter
+            #    entry in the chain — so retrying pays the same toll repeatedly
+            #    within a single walk. MEASURED 2026-09-05 on this install:
+            #    4.1-6.8s average per exposure (n=22) spent sleeping on a
+            #    provider whose answer could not change.
+            # Both were previously retried, which is the inversion this fixes:
+            # RATE_LIMITED — the one 4xx that genuinely might clear — already
+            # fails fast, while the two that certainly will not did not.
             if category in (
                 ErrorCategory.PERMANENT, ErrorCategory.TIMEOUT,
                 ErrorCategory.RATE_LIMITED, ErrorCategory.BAD_REQUEST,
+                ErrorCategory.NOT_ENTITLED, ErrorCategory.QUOTA_EXHAUSTED,
             ):
                 return result
 

--- a/src/genesis/routing/types.py
+++ b/src/genesis/routing/types.py
@@ -33,6 +33,22 @@ class ErrorCategory(StrEnum):
     # and the breaker does NOT trip — it's our payload's fault, not the
     # provider's health, so tripping would wrongly take a healthy provider down.
     BAD_REQUEST = "bad_request"
+    # An entitlement 403: the credential authenticates fine, but THIS account
+    # tier may not use this model. Distinct from both neighbours on purpose,
+    # because it needs one behaviour from each and neither alone is right:
+    #   - like PERMANENT, it must fail FAST (no same-provider retry). MEASURED
+    #     2026-09-05: the retry stack cost ~11.9s avg / 19.2s max per exposure
+    #     (n=15) sleeping on a provider whose answer could not change, against
+    #     a 180-600s aggregate `max_total_s` — i.e. a few percent of the walk's
+    #     budget each time it is reached, not the whole of it.
+    #   - like QUOTA_EXHAUSTED, it must hold the breaker open on the LONG cap —
+    #     an entitlement does not change in 30 minutes, and re-probing on the
+    #     short cap costs a doomed attempt 8x more often.
+    # Classifying it as either one alone gives up the other half. MEASURED:
+    # `mistral-large-latest` returned this continuously from 2026-08-27 while
+    # its "not available in your subscription tier" message matched
+    # `_QUOTA_KEYWORDS` and bought it the retry-with-backoff path.
+    NOT_ENTITLED = "not_entitled"
 
 
 class DegradationLevel(StrEnum):

--- a/src/genesis/routing/types.py
+++ b/src/genesis/routing/types.py
@@ -41,9 +41,23 @@ class ErrorCategory(StrEnum):
     #     (n=15) sleeping on a provider whose answer could not change, against
     #     a 180-600s aggregate `max_total_s` — i.e. a few percent of the walk's
     #     budget each time it is reached, not the whole of it.
-    #   - like QUOTA_EXHAUSTED, it must hold the breaker open on the LONG cap —
-    #     an entitlement does not change in 30 minutes, and re-probing on the
-    #     short cap costs a doomed attempt 8x more often.
+    #   - like QUOTA_EXHAUSTED, it takes the LONG breaker cap — an entitlement
+    #     does not change in 30 minutes.
+    #     BE PRECISE ABOUT WHAT THAT BUYS, because the obvious reading is wrong.
+    #     `_effective_open_duration()` is `min(open_duration_s * 2**(trip-1),
+    #     cap)`, and every provider in config/model_routing.yaml sets
+    #     `open_duration_s: 120`, so the two curves are:
+    #        long cap  [120, 240, 480, 960, 1920, 3840, 7680, 14400]
+    #        short cap [120, 240, 480, 960, 1800, 1800, 1800, 1800]
+    #     IDENTICAL for trips 1-4. They diverge at trip 5 and only reach the
+    #     nominal 8x at trip 8 — roughly 4.2h into a CONTINUOUS outage. And
+    #     `load_state` caps `trip_count` at 3 on restart (circuit_breaker.py),
+    #     so any deploy or crash resets the escalation to the shared part of the
+    #     curve. A freshly-tripping entitlement-dead provider is therefore held
+    #     out for exactly as long as a PERMANENT one; the long cap is a
+    #     saturation property, not a first-failure one.
+    #     (Cross-model review, 2026-09-06 — the earlier wording here claimed the
+    #     8x as though it applied from the first trip.)
     # Classifying it as either one alone gives up the other half. MEASURED:
     # `mistral-large-latest` returned this continuously from 2026-08-27 while
     # its "not available in your subscription tier" message matched

--- a/tests/test_observability/test_api_keys.py
+++ b/tests/test_observability/test_api_keys.py
@@ -360,3 +360,50 @@ def test_unknown_category_degrades_to_the_generic_outage():
 
     assert cb_alert_for("a_category_from_the_future") == _CB_GENERIC_ALERT
     assert cb_alert_for(None) == _CB_GENERIC_ALERT
+
+
+def test_a_stale_category_on_a_closed_breaker_does_not_hijack_the_alert():
+    """A missing KEY must say so, even when a stale category is sitting around.
+
+    `record_failure` sets `_last_failure_category` on every failure, BEFORE the
+    trip threshold is checked, so a CLOSED breaker routinely carries a category
+    from a failure that never tripped it. Keying the alert on the category alone
+    therefore announced "not included on this plan/tier" for a provider whose
+    real problem was an absent API key — the branch that would have said so was
+    unreachable. Found at P3 by cross-model review of PR #1733.
+    """
+    from genesis.observability.snapshots.api_keys import _build_alerts
+
+    alerts = _build_alerts({
+        "mistral-large-free": {
+            "alert_severity": "critical",
+            "provider_type": "mistral",
+            "status": "missing",       # the ACTUAL problem
+            "cb_state": "closed",      # never tripped
+            "cb_reason": "not_entitled",  # stale, from a non-tripping failure
+            "chain_count": 3,
+            "sole_sites": ["30_triage_calibration"],
+        }
+    })
+    assert len(alerts) == 1
+    assert alerts[0]["reason"] == "missing_key", alerts
+    assert "API key missing" in alerts[0]["message"]
+
+
+def test_an_open_breaker_still_gets_its_category_label():
+    """The control: gating on cb_state must not blind the category labels."""
+    from genesis.observability.snapshots.api_keys import _build_alerts
+
+    alerts = _build_alerts({
+        "mistral-large-free": {
+            "alert_severity": "critical",
+            "provider_type": "mistral",
+            "status": "ok",
+            "cb_state": "open",
+            "cb_reason": "not_entitled",
+            "chain_count": 3,
+        }
+    })
+    assert len(alerts) == 1
+    assert alerts[0]["reason"] == "not_entitled"
+    assert "down" not in alerts[0]["message"].lower()

--- a/tests/test_observability/test_api_keys.py
+++ b/tests/test_observability/test_api_keys.py
@@ -289,3 +289,74 @@ def test_recent_fallbacks_does_not_change_severity_or_color(monkeypatch):
         assert w["key_health"] == f["key_health"]
         assert w.get("alert_severity") == f.get("alert_severity")
     assert without["alerts"] == with_fb["alerts"]
+
+
+# ── Operator labels are EXHAUSTIVE over ErrorCategory ────────────────────────
+#
+# Origin (2026-09-06, cross-model review of PR #1733): the alert builder named
+# ONE category (`quota_exhausted`) and sent everything else to "down (circuit
+# breaker open)". Adding NOT_ENTITLED therefore made the operator experience
+# WORSE than before the category existed — the identical Mistral 403 used to
+# render "credits depleted", which at least pointed at the account, and started
+# rendering "Mistral down", which sends the operator to check a provider that is
+# perfectly healthy. Nothing raised. A new enum member just fell into the
+# default arm.
+#
+# So the test is not "not_entitled has a label". It is "every member has an
+# explicit decision" — the only shape that catches the NEXT category.
+
+
+def test_every_error_category_has_an_operator_label():
+    """A category must be labelled or explicitly generic — never merely absent.
+
+    This is the whole point: it fails when someone ADDS an ErrorCategory without
+    deciding how an operator should read it, which is exactly what happened.
+    """
+    from genesis.observability.snapshots.api_keys import (
+        _CB_ALERT_BY_CATEGORY,
+        _CB_GENERIC,
+        _CB_SHORT_LABEL,
+    )
+    from genesis.routing.types import ErrorCategory
+
+    members = {c.value for c in ErrorCategory}
+    decided = set(_CB_ALERT_BY_CATEGORY) | set(_CB_GENERIC)
+
+    undecided = members - decided
+    assert not undecided, (
+        f"ErrorCategory member(s) {sorted(undecided)} have no operator label decision. "
+        f"Add to _CB_ALERT_BY_CATEGORY (distinct wording) or _CB_GENERIC (reads as an "
+        f"outage) — absent from both means it silently renders as 'provider down'."
+    )
+    stale = decided - members
+    assert not stale, f"label table names non-existent categories: {sorted(stale)}"
+
+    # The two tables are the same decision at two lengths; they must not diverge.
+    assert set(_CB_SHORT_LABEL) == set(_CB_ALERT_BY_CATEGORY), (
+        "the long and short label tables disagree about which categories are special"
+    )
+    # A category cannot be both special-cased and generic.
+    assert not (set(_CB_ALERT_BY_CATEGORY) & set(_CB_GENERIC))
+
+
+def test_not_entitled_points_at_the_account_not_the_provider():
+    """The regression this came from, pinned as behaviour rather than wording.
+
+    An entitlement failure must not be described as the provider being down: the
+    provider is up, and only the account holder can fix it.
+    """
+    from genesis.observability.snapshots.api_keys import cb_alert_for
+
+    reason, prefix = cb_alert_for("not_entitled")
+    assert reason != "provider_down"
+    rendered = prefix.format(p="Mistral").lower()
+    assert "down" not in rendered
+    assert "plan" in rendered or "tier" in rendered
+
+
+def test_unknown_category_degrades_to_the_generic_outage():
+    """A rollback reading a value a newer build wrote must not crash the strip."""
+    from genesis.observability.snapshots.api_keys import _CB_GENERIC_ALERT, cb_alert_for
+
+    assert cb_alert_for("a_category_from_the_future") == _CB_GENERIC_ALERT
+    assert cb_alert_for(None) == _CB_GENERIC_ALERT

--- a/tests/test_routing/test_circuit_breaker.py
+++ b/tests/test_routing/test_circuit_breaker.py
@@ -6,7 +6,9 @@ import json
 import logging
 
 from genesis.routing.circuit_breaker import (
+    _LONG_OPEN_CATEGORIES,
     _MAX_OPEN_S,
+    _MAX_QUOTA_OPEN_S,
     CircuitBreaker,
     CircuitBreakerRegistry,
 )
@@ -1155,3 +1157,51 @@ def test_a_restart_keeps_the_failure_reason_for_a_half_open_row(tmp_path):
         "the failure reason was blanked on restart; the dashboard and the API-key "
         "snapshot lose why this provider is not closed"
     )
+
+
+# --- open-duration cap by failure category ---
+
+class TestOpenDurationCapByCategory:
+    """Which categories hold the breaker open on the LONG (4h) cap.
+
+    Previously untested. Partitioning the enum is NOT enough on its own —
+    see `test_every_member_has_an_explicit_cap_decision` for why, and for
+    the guard that actually catches an undecided new member.
+    """
+
+    def _tripped_cap(self, category: ErrorCategory) -> float:
+        # Trip well past the threshold so escalating backoff saturates and the
+        # cap — not the doubling — is what the duration reports.
+        cb = CircuitBreaker(_provider(), failure_threshold=1, open_duration_s=120)
+        for _ in range(12):
+            cb.record_failure(category)
+        return cb._effective_open_duration()
+
+    def test_every_member_has_an_explicit_cap_decision(self):
+        # The guard the other two tests CANNOT provide: they partition the enum
+        # into the long-cap set and "everything else", so a new member added to
+        # neither set lands in the short-cap branch and SATISFIES the assertion
+        # — the skip branch is the default branch. Only pinning the whole enum
+        # turns "nobody decided" into a failure.
+        assert {c.value for c in ErrorCategory} == {
+            "transient", "degraded", "permanent", "quota_exhausted",
+            "timeout", "rate_limited", "bad_request", "not_entitled",
+        }, "new ErrorCategory member — decide whether it belongs in _LONG_OPEN_CATEGORIES"
+
+    def test_long_cap_categories(self):
+        # Read from the production set, not a hardcoded pair, so the literal
+        # and the frozenset cannot drift apart.
+        for category in _LONG_OPEN_CATEGORIES:
+            assert self._tripped_cap(category) == _MAX_QUOTA_OPEN_S, category
+
+    def test_every_other_category_gets_the_short_cap(self):
+        for category in set(ErrorCategory) - _LONG_OPEN_CATEGORIES:
+            assert self._tripped_cap(category) == _MAX_OPEN_S, category
+
+    def test_entitlement_is_not_merely_permanent(self):
+        # The distinction that motivates the category: PERMANENT would have
+        # given an entitlement denial the 30-minute cap, re-probing a dead
+        # provider 8x more often than the fix does.
+        assert self._tripped_cap(ErrorCategory.NOT_ENTITLED) > self._tripped_cap(
+            ErrorCategory.PERMANENT
+        )

--- a/tests/test_routing/test_circuit_breaker.py
+++ b/tests/test_routing/test_circuit_breaker.py
@@ -1195,10 +1195,10 @@ class TestOpenDurationCapByCategory:
         # partition passes: moving TIMEOUT into the long set would leave this
         # test and test_every_other_category_gets_the_short_cap both green
         # while a transient error held the 4h cap.
-        assert _LONG_OPEN_CATEGORIES == {
+        assert {
             ErrorCategory.QUOTA_EXHAUSTED,
             ErrorCategory.NOT_ENTITLED,
-        }, "membership changed — a category gained or lost the 4h cap"
+        } == _LONG_OPEN_CATEGORIES, "membership changed — a category gained or lost the 4h cap"
         for category in _LONG_OPEN_CATEGORIES:
             assert self._tripped_cap(category) == _MAX_QUOTA_OPEN_S, category
 

--- a/tests/test_routing/test_circuit_breaker.py
+++ b/tests/test_routing/test_circuit_breaker.py
@@ -1189,8 +1189,16 @@ class TestOpenDurationCapByCategory:
         }, "new ErrorCategory member — decide whether it belongs in _LONG_OPEN_CATEGORIES"
 
     def test_long_cap_categories(self):
-        # Read from the production set, not a hardcoded pair, so the literal
-        # and the frozenset cannot drift apart.
+        # Pin MEMBERSHIP first. The loop below reads the production set so the
+        # literal and the frozenset cannot drift apart — but that alone makes
+        # the pair of cap tests a PARTITION of set(ErrorCategory), and every
+        # partition passes: moving TIMEOUT into the long set would leave this
+        # test and test_every_other_category_gets_the_short_cap both green
+        # while a transient error held the 4h cap.
+        assert _LONG_OPEN_CATEGORIES == {
+            ErrorCategory.QUOTA_EXHAUSTED,
+            ErrorCategory.NOT_ENTITLED,
+        }, "membership changed — a category gained or lost the 4h cap"
         for category in _LONG_OPEN_CATEGORIES:
             assert self._tripped_cap(category) == _MAX_QUOTA_OPEN_S, category
 

--- a/tests/test_routing/test_retry.py
+++ b/tests/test_routing/test_retry.py
@@ -135,12 +135,25 @@ def test_entitlement_403_is_not_quota():
 
 
 def test_entitlement_markers_outrank_quota_keywords():
-    # Order matters: these all carry a quota keyword too ("subscription",
-    # "plan", "limit"). Entitlement is checked FIRST, so it wins.
+    # PRECEDENCE. Only these two actually contest the ordering: each contains a
+    # member of _QUOTA_KEYWORDS ("subscription", "plan"), so with the checks in
+    # the other order the quota arm would win and return QUOTA_EXHAUSTED. This
+    # is the property the fix exists for, and it is what makes the test bite.
     for msg in (
-        "tier_not_allowed",
         "This model is not available in your subscription tier",
         "Your plan does not have access to this model",
+    ):
+        assert classify_error(403, msg) == ErrorCategory.NOT_ENTITLED, msg
+
+
+def test_entitlement_markers_match_without_any_quota_keyword():
+    # MARKER PRESENCE, a weaker and separate property. Neither string contains a
+    # quota keyword, so ordering is irrelevant to them — without the entitlement
+    # markers they would fall through to PERMANENT, never QUOTA_EXHAUSTED.
+    # Kept apart from the precedence test above because grouping them together
+    # let a comment claim all four contested the ordering when only two did.
+    for msg in (
+        "tier_not_allowed",
         "You are not authorized to use this model",
     ):
         assert classify_error(403, msg) == ErrorCategory.NOT_ENTITLED, msg

--- a/tests/test_routing/test_retry.py
+++ b/tests/test_routing/test_retry.py
@@ -112,3 +112,53 @@ def test_never_negative():
     policy = RetryPolicy(base_delay_ms=1, max_delay_ms=1, jitter_pct=0.5)
     for _ in range(100):
         assert compute_delay(policy, 0) >= 0.0
+
+
+# --- entitlement 403s (NOT_ENTITLED) ---
+
+def test_entitlement_403_is_not_quota():
+    """A 403 that says 'your plan may not use this model' is NOT quota.
+
+    ACCEPTANCE BAR — the verbatim live body measured from the Mistral API on
+    2026-09-05 (and the same shape recorded in `record_probe_success`'s
+    docstring for the outage that began 2026-08-27). Its message contains
+    "subscription", a `_QUOTA_KEYWORDS` member, so before this change it
+    classified QUOTA_EXHAUSTED: the router then RETRIED it with backoff
+    instead of failing fast, burning the chain's aggregate `max_total_s`
+    budget on a provider that can never succeed.
+    """
+    live_body = (
+        '{"object":"error","message":"This model is not available in your '
+        'subscription tier","type":"tier_not_allowed","code":"1910"}'
+    )
+    assert classify_error(403, live_body) == ErrorCategory.NOT_ENTITLED
+
+
+def test_entitlement_markers_outrank_quota_keywords():
+    # Order matters: these all carry a quota keyword too ("subscription",
+    # "plan", "limit"). Entitlement is checked FIRST, so it wins.
+    for msg in (
+        "tier_not_allowed",
+        "This model is not available in your subscription tier",
+        "Your plan does not have access to this model",
+        "You are not authorized to use this model",
+    ):
+        assert classify_error(403, msg) == ErrorCategory.NOT_ENTITLED, msg
+
+
+def test_real_quota_403_still_classifies_quota():
+    # The counter-direction control: consumption language must NOT be captured
+    # by the entitlement arm, or a genuine quota 403 loses its 4h breaker cap.
+    for msg in (
+        "Key limit exceeded",
+        "quota exhausted",
+        "You have exceeded your monthly usage",
+        "Billing credits depleted",
+    ):
+        assert classify_error(403, msg) == ErrorCategory.QUOTA_EXHAUSTED, msg
+
+
+def test_bare_403_still_permanent():
+    # Unchanged: no entitlement marker, no quota keyword → PERMANENT.
+    assert classify_error(403, "") == ErrorCategory.PERMANENT
+    assert classify_error(403, "access denied") == ErrorCategory.PERMANENT

--- a/tests/test_routing/test_router.py
+++ b/tests/test_routing/test_router.py
@@ -675,8 +675,12 @@ async def test_entitlement_403_fails_fast_and_chain_reaches_a_working_provider(
     assert result.success is True
     assert result.provider_used == "free-2"
     assert result.fallback_used is True
-    # The breaker recorded it (unlike RATE_LIMITED/BAD_REQUEST) and holds the
-    # long cap, so the next call skips the dead provider outright.
+    # The breaker RECORDED it — unlike RATE_LIMITED/BAD_REQUEST, which are
+    # deliberately not provider-health signals and record nothing. That is what
+    # the assertion below proves, and it is all it proves: one walk records one
+    # failure against a threshold of 3, so the provider is NOT yet held out.
+    # What the recorded category buys is the cap it will carry when the third
+    # failure does open the breaker (4h, not 30m).
     cb = breakers.get("free-1")
     assert cb.last_failure_category == ErrorCategory.NOT_ENTITLED
 

--- a/tests/test_routing/test_router.py
+++ b/tests/test_routing/test_router.py
@@ -632,3 +632,90 @@ async def test_aggregate_deadline_stops_inner_retries(cost_tracker, degradation)
     # attempt0(0.0→0.1) attempt1(0.1→0.2) attempt2(0.2→0.3); attempt3 sees
     # 0.3 >= 0.25 and stops — 3 calls, NOT the full 6 (max_retries+1).
     assert len(delegate.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_entitlement_403_fails_fast_and_chain_reaches_a_working_provider(
+    sample_config, breakers, cost_tracker, degradation
+):
+    """ACCEPTANCE BAR — replay of the live outage this change exists for.
+
+    `free-1` returns the verbatim 403 body measured from Mistral on
+    2026-09-05. Before this change that message matched `_QUOTA_KEYWORDS`
+    ("subscription") and classified QUOTA_EXHAUSTED, which is NOT in the
+    router's fail-fast set — so the dead provider was retried with backoff,
+    spending the chain's aggregate `max_total_s` budget before the walk could
+    reach a provider that works.
+
+    The load-bearing assertion is the ATTEMPT COUNT against the dead provider:
+    exactly one. A chain that merely succeeds proves nothing, because the walk
+    reaches `free-2` either way when the budget happens to be generous.
+    """
+    live_403 = CallResult(
+        success=False,
+        status_code=403,
+        error=(
+            '{"object":"error","message":"This model is not available in your '
+            'subscription tier","type":"tier_not_allowed","code":"1910"}'
+        ),
+    )
+    delegate = MockDelegate(responses={"free-1": live_403})
+    router = Router(
+        config=sample_config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+
+    result = await router.route_call("test_mixed", [{"role": "user", "content": "hi"}])
+
+    dead_attempts = [c for c in delegate.calls if c["provider"] == "free-1"]
+    assert len(dead_attempts) == 1, (
+        f"entitlement 403 must not be retried against the same provider; "
+        f"got {len(dead_attempts)} attempts"
+    )
+    assert result.success is True
+    assert result.provider_used == "free-2"
+    assert result.fallback_used is True
+    # The breaker recorded it (unlike RATE_LIMITED/BAD_REQUEST) and holds the
+    # long cap, so the next call skips the dead provider outright.
+    cb = breakers.get("free-1")
+    assert cb.last_failure_category == ErrorCategory.NOT_ENTITLED
+
+
+@pytest.mark.asyncio
+async def test_exhausted_quota_403_also_fails_fast(
+    sample_config, breakers, cost_tracker, degradation
+):
+    """The other member of the same class, found by review rather than by the alert.
+
+    A spent allowance is a BILLING state: it cannot clear inside a backoff
+    window, so retrying it is the same defect as retrying an entitlement
+    denial. It matters more than the single-provider case suggests, because
+    the limit is usually account-global — OpenRouter's "Key limit exceeded
+    (total limit)" applies to every openrouter entry in a chain at once, so a
+    single walk could pay the wait repeatedly.
+
+    MEASURED on this install 2026-09-05, before the fix: 4.1-6.8s average per
+    exposure across 22 rows (openrouter-deepseek-v4 / -flash / -nemo).
+    """
+    live_quota_403 = CallResult(
+        success=False,
+        status_code=403,
+        error=(
+            "litellm.APIError: APIError: OpenrouterException - "
+            '{"error":{"message":"Key limit exceeded (total limit)."}}'
+        ),
+    )
+    delegate = MockDelegate(responses={"free-1": live_quota_403})
+    router = Router(
+        config=sample_config, breakers=breakers, cost_tracker=cost_tracker,
+        degradation=degradation, delegate=delegate,
+    )
+
+    result = await router.route_call("test_mixed", [{"role": "user", "content": "hi"}])
+
+    assert len([c for c in delegate.calls if c["provider"] == "free-1"]) == 1
+    assert result.success is True
+    # Still classified QUOTA, not swept into the new category — the two keep
+    # distinct meanings on every surface that reports them; only the retry
+    # behaviour is now shared.
+    assert breakers.get("free-1").last_failure_category == ErrorCategory.QUOTA_EXHAUSTED


### PR DESCRIPTION
## What was wrong

A 403 meaning *"your account tier may not use this model"* was classified as an
exhausted quota. The vendor message names the plan or subscription you would
need — and `subscription`, `plan` and `limit` are all members of
`_QUOTA_KEYWORDS`, so the quota arm won.

That matters because `QUOTA_EXHAUSTED` was not in the router's fail-fast set.
The router waited and re-asked, with backoff, on a refusal whose answer could
not change — spending the chain's aggregate `max_total_s` on a provider that
could never answer, so a walk could run out of budget before reaching a
provider that works.

`circuit_breaker.record_probe_success`'s docstring has named this exact
provider and error since 2026-08-27. #1563 fixed the probe-healing half; this
is the classification half.

## What changed

`ErrorCategory.NOT_ENTITLED`, matched ahead of the quota keywords. It takes one
behaviour from each neighbour, because neither alone is right:

| axis | `QUOTA_EXHAUSTED` | `PERMANENT` | `NOT_ENTITLED` |
|---|---|---|---|
| router fail-fast | no — retries | yes | **yes** |
| breaker open cap | 4h | 30m | **4h** |

**The class, not the instance.** Review found the first draft fixed one member
of a defect class and left the other live: `QUOTA_EXHAUSTED` had the identical
problem for the identical reason, so it now fails fast too. The old split was
inverted — `RATE_LIMITED`, the one 4xx that genuinely *might* clear inside a
backoff, already failed fast, while a spent allowance, which cannot, was
retried. It matters more than one provider, because such a limit is usually
account-global: a single walk could pay the wait once per chain member.

The two categories stay distinct on every reporting surface. Only the retry
behaviour is shared.

## Measured

Before the change, from `activity_log.latency_ms` (which times the whole
`_call_with_retry`, so it *is* the retry burn):

| refusal | n | avg | max |
|---|---|---|---|
| entitlement 403 | 15 | 11.9s | 19.2s |
| quota 403 | 22 | 4.1–6.8s | 16.9s |

…against a 180–600s aggregate budget.

Classification measured **both directions** over 1,093 real error messages:
15 fire, all genuine entitlement denials (zero false positives), and the one
403 that does *not* fire is a real quota refusal that correctly keeps its own
category. That corpus has a retention window, so the denominator is not
reproducible later.

## Verification

- 235 targeted tests green; ruff and all four CI-reproducible guards clean.
- **Four mutation controls**, one per guard, each restored by hash. One of them
  replays a mutation the reviewer used to prove a test was claiming a guard it
  did not provide — it passed silently then, and fails now.
- **Live E2E** against the real API.
- **Runtime-context check** — the assumption that could have made this inert:
  verified that the client library surfaces this as an `APIError` carrying
  `status_code == 403`, which the delegate's generic handler passes through, so
  the 403-gated branch is genuinely reachable in production rather than only on
  a raw HTTP body.

## Regression marker

Checkable one day after deploy: `activity_log.latency_ms` for the affected
providers should fall from seconds to sub-second, and their breaker
`trip_count` should stop climbing. If those latencies persist, the fail-fast
wiring is not being reached and the diagnosis is wrong.

## Not in scope

Terminal-state semantics (chain removal, a category-aware operator alert)
are not here, so that follow-up stays open. Operator-facing surfaces still
branch on the literal `quota_exhausted` and will render the generic
"provider down" text for a `NOT_ENTITLED` breaker — nothing breaks, both are
fall-through chains, but the distinction does not yet reach the dashboard.

Ledger: 998c59178aa843528c81e32f748aa829


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider failover for entitlement-related and exhausted-quota errors by avoiding unnecessary retries.
  - Distinguished entitlement-related access denials from quota exhaustion and other permanent failures.
  - Extended circuit-breaker protection for entitlement and quota failures.
  - Improved exhaustion reporting with clearer provider status, attempt counts, and routing-chain details.
- **Tests**
  - Added coverage for failover, error classification, circuit-breaker behavior, and exhaustion reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

E2E: after deploy, exercise a call site whose chain carries `mistral-large-free` and confirm in `activity_log` that the 403 is recorded as `not_entitled` after a single attempt, rather than as a retried `quota_exhausted` — the whole point of the reclassification is the attempt count, not the label.
