### PR TITLE
docs(architecture): refresh routing verification stamp

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1649,7 +1649,7 @@ How every LLM call picks a provider, and the registry for non-LLM tools.
 ```yaml subsystem-map
 entry: routing-providers
 modules: [routing, providers]
-verified: b8232425 2026-09-02
+verified: 9730efe9 2026-09-05
 ```
 
 - **routing/**: `config/model_routing.yaml` defines ~54 numbered call sites,


### PR DESCRIPTION
Closes #1673

Re-verified the routing/providers architecture section against the current default-branch tip and updated its verified stamp to 9730efe9 (2026-09-05). The stamped commit is on the default branch and includes the later routing configuration change.

Validation: python -m compileall -q scripts; full repository checks are delegated to CI.