### PR TITLE
fix: read ego queue depths from snapshot keys

### DIFF
--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -134,16 +134,12 @@ class EgoContextBuilder:
         queues = snap.get("queues", {})
         if queues:
             lines.append("\n### Queues")
-            deferred = queues.get("deferred_work_queue", {})
-            dead_letter = queues.get("dead_letter_queue", {})
-            if isinstance(deferred, dict):
-                lines.append(
-                    f"- Deferred work: {deferred.get('pending', 0)} pending"
-                )
-            if isinstance(dead_letter, dict):
-                lines.append(
-                    f"- Dead letter: {dead_letter.get('count', 0)} items"
-                )
+            lines.append(
+                f"- Deferred work: {queues.get('deferred_work', 0)} pending"
+            )
+            lines.append(
+                f"- Dead letter: {queues.get('dead_letters', 0)} items"
+            )
 
         # Surplus
         surplus = snap.get("surplus", {})

--- a/src/genesis/ego/context.py
+++ b/src/genesis/ego/context.py
@@ -134,11 +134,18 @@ class EgoContextBuilder:
         queues = snap.get("queues", {})
         if queues:
             lines.append("\n### Queues")
+            # A FAILED queue query leaves the producer's value None while the
+            # KEY stays present, so `.get(name, 0)` never defaults — rendering
+            # it raw puts the token "None" in this context, and defaulting it
+            # to 0 states "nothing pending" for a depth nobody measured. Say
+            # unknown; the snapshot's `errors` list carries the reason.
+            deferred = queues.get("deferred_work")
+            dead = queues.get("dead_letters")
             lines.append(
-                f"- Deferred work: {queues.get('deferred_work', 0)} pending"
+                f"- Deferred work: {'unknown' if deferred is None else deferred} pending"
             )
             lines.append(
-                f"- Dead letter: {queues.get('dead_letters', 0)} items"
+                f"- Dead letter: {'unknown' if dead is None else dead} items"
             )
 
         # Surplus

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -204,16 +204,12 @@ class GenesisEgoContextBuilder:
         queues = snap.get("queues", {})
         if queues:
             lines.append("\n### Queues")
-            deferred = queues.get("deferred_work_queue", {})
-            dead_letter = queues.get("dead_letter_queue", {})
-            if isinstance(deferred, dict):
-                lines.append(
-                    f"- Deferred work: {deferred.get('pending', 0)} pending"
-                )
-            if isinstance(dead_letter, dict):
-                lines.append(
-                    f"- Dead letter: {dead_letter.get('count', 0)} items"
-                )
+            lines.append(
+                f"- Deferred work: {queues.get('deferred_work', 0)} pending"
+            )
+            lines.append(
+                f"- Dead letter: {queues.get('dead_letters', 0)} items"
+            )
 
         # Surplus
         surplus = snap.get("surplus", {})

--- a/src/genesis/ego/genesis_context.py
+++ b/src/genesis/ego/genesis_context.py
@@ -204,11 +204,18 @@ class GenesisEgoContextBuilder:
         queues = snap.get("queues", {})
         if queues:
             lines.append("\n### Queues")
+            # A FAILED queue query leaves the producer's value None while the
+            # KEY stays present, so `.get(name, 0)` never defaults — rendering
+            # it raw puts the token "None" in this context, and defaulting it
+            # to 0 states "nothing pending" for a depth nobody measured. Say
+            # unknown; the snapshot's `errors` list carries the reason.
+            deferred = queues.get("deferred_work")
+            dead = queues.get("dead_letters")
             lines.append(
-                f"- Deferred work: {queues.get('deferred_work', 0)} pending"
+                f"- Deferred work: {'unknown' if deferred is None else deferred} pending"
             )
             lines.append(
-                f"- Dead letter: {queues.get('dead_letters', 0)} items"
+                f"- Dead letter: {'unknown' if dead is None else dead} items"
             )
 
         # Surplus

--- a/tests/ego/test_context.py
+++ b/tests/ego/test_context.py
@@ -76,8 +76,8 @@ def mock_health_data():
         },
         "resilience": "healthy",
         "queues": {
-            "deferred_work_queue": {"pending": 3},
-            "dead_letter_queue": {"count": 0},
+            "deferred_work": 3,
+            "dead_letters": 0,
         },
         "surplus": {"queue_depth": 2, "last_dispatch": "2026-03-28T16:00:00"},
         "conversation": {

--- a/tests/ego/test_genesis_context.py
+++ b/tests/ego/test_genesis_context.py
@@ -157,8 +157,8 @@ def mock_health_data():
         },
         "resilience": "healthy",
         "queues": {
-            "deferred_work_queue": {"pending": 3},
-            "dead_letter_queue": {"count": 0},
+            "deferred_work": 3,
+            "dead_letters": 0,
         },
         "surplus": {"queue_depth": 2, "last_dispatch": "2026-04-24T08:00:00"},
     }

--- a/tests/ego/test_queue_snapshot_contract.py
+++ b/tests/ego/test_queue_snapshot_contract.py
@@ -36,3 +36,44 @@ async def test_both_ego_contexts_render_real_queue_snapshot_depths():
     for context in (user_context, genesis_context):
         assert "- Deferred work: 7 pending" in context
         assert "- Dead letter: 11 items" in context
+@pytest.mark.asyncio
+async def test_a_failed_queue_query_reads_unknown_never_zero():
+    """A failed query is not an empty queue.
+
+    The producer leaves the value None on a query failure while the KEY stays
+    present, so `.get(name, 0)` does NOT default: rendering it raw put the
+    literal token "None" in the ego's context, and defaulting to 0 would state
+    "nothing pending" for a depth nobody measured — the same confident-wrong
+    reading this file's other test exists to prevent, one layer down.
+    """
+    deferred_queue = AsyncMock()
+    deferred_queue.count_pending.side_effect = RuntimeError("db unavailable")
+    deferred_queue.count_recovery_pending.side_effect = RuntimeError("db unavailable")
+    deferred_queue.count_worklist_pending.side_effect = RuntimeError("db unavailable")
+    dead_letter = AsyncMock()
+    dead_letter.get_pending_count.side_effect = RuntimeError("db unavailable")
+    health_data = HealthDataService(
+        deferred_queue=deferred_queue,
+        dead_letter=dead_letter,
+    )
+
+    snapshot = await health_data.snapshot()
+    # The producer's own contract: key present, value None, reason recorded.
+    assert snapshot["queues"]["deferred_work"] is None
+    assert snapshot["queues"]["dead_letters"] is None
+    assert snapshot["queues"]["errors"]
+
+    user_context = await EgoContextBuilder(
+        db=None,
+        health_data=health_data,
+    )._system_health_section()
+    genesis_context = await GenesisEgoContextBuilder(
+        db=None,
+        health_data=health_data,
+    )._system_health_section()
+
+    for context in (user_context, genesis_context):
+        assert "- Deferred work: unknown pending" in context
+        assert "- Dead letter: unknown items" in context
+        assert "None" not in context
+        assert "- Deferred work: 0 pending" not in context

--- a/tests/ego/test_queue_snapshot_contract.py
+++ b/tests/ego/test_queue_snapshot_contract.py
@@ -1,0 +1,38 @@
+"""Regression tests for ego queue metrics from the real health snapshot."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from genesis.ego.context import EgoContextBuilder
+from genesis.ego.genesis_context import GenesisEgoContextBuilder
+from genesis.observability.health_data import HealthDataService
+
+
+@pytest.mark.asyncio
+async def test_both_ego_contexts_render_real_queue_snapshot_depths():
+    deferred_queue = AsyncMock()
+    deferred_queue.count_pending.return_value = 7
+    dead_letter = AsyncMock()
+    dead_letter.get_pending_count.return_value = 11
+    health_data = HealthDataService(
+        deferred_queue=deferred_queue,
+        dead_letter=dead_letter,
+    )
+
+    snapshot = await health_data.snapshot()
+    assert snapshot["queues"]["deferred_work"] == 7
+    assert snapshot["queues"]["dead_letters"] == 11
+
+    user_context = await EgoContextBuilder(
+        db=None,
+        health_data=health_data,
+    )._system_health_section()
+    genesis_context = await GenesisEgoContextBuilder(
+        db=None,
+        health_data=health_data,
+    )._system_health_section()
+
+    for context in (user_context, genesis_context):
+        assert "- Deferred work: 7 pending" in context
+        assert "- Dead letter: 11 items" in context


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it brief. -->

## Related issue

<!-- If this PR resolves a tracked issue, link it with a CLOSING KEYWORD so the
     issue closes automatically when this merges to the default branch. A bare
     "#123" only cross-links — "Closes #123" (or Fixes/Resolves #123) closes it.
     Delete this section if there's no linked issue. -->

Closes #

## Changes

<!-- Bullet the key changes. -->

## Testing

<!-- How did you verify this works? -->

- [x] `ruff check .` passes
- [x] `pytest -v` passes
- [x] Tested end-to-end (describe how)
- [x] `docs/architecture/CURRENT.md` updated (entry prose + `verified:` stamp) if subsystem capabilities changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated system health displays to use the current deferred-work and dead-letter queue counts.
  - Missing queue counts now display as “unknown” instead of defaulting to zero.
  - Snapshot errors remain available for troubleshooting.
  - Applied the corrected behavior consistently across user and Genesis system-health views.

- **Tests**
  - Added regression coverage for failed queue-count queries, preserved error details, and “unknown” rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->