### PR TITLE
fix(observability): context-injection findings actionable and fail-loud

### DIFF
--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -139,17 +139,37 @@ def _audit_line(
     )
 
 
+def _audit_line_minimal(part: str, where: str) -> str:
+    """The counters-dropped fallback for :func:`_audit_line`'s cut form.
+
+    Emitted by ``emit_final`` only when the full cut line will not fit its
+    reserve. It keeps the two load-bearing parts — the part id and the mirror
+    pointer (``where``) — and drops the unbounded counters, which is the
+    'select, don't amputate' answer to a line that must shrink: omit the
+    volatile field explicitly rather than let a right-clip eat the pointer.
+    The widened reserve below makes this path unreachable for any real part;
+    it is the STRUCTURAL guarantee behind that arithmetic, not a substitute.
+    """
+    return f"\n_[ctx {part}: audit counts omitted for size{where}]_"
+
+
 # Room reserved for the trailing `_[ctx <part>: …]_` self-audit line — DERIVED
 # from the renderer above at its realistic worst case, not a round number.
 # Pinned by test_the_audit_reserve_fits_the_line_it_reserves_for, which rebuilds
 # this same worst case, so the two cannot drift.
+# 12-digit worst-case counters (999_999_999_999 ≈ 1 TB): `intended`/`dropped`
+# are unbounded, and the earlier 5-digit 99_999 under-reserved for any part that
+# renders a 6+-digit count — a right-clip would then eat the trailing mirror
+# pointer. 12 digits covers any real payload with room to spare; the fallback in
+# `_finish_part` is the structural backstop past even that.
+_AUDIT_WORST_COUNTER = 999_999_999_999
 _AUDIT_LINE_RESERVE = (
     len(
         _audit_line(
             "identity-user",
-            99_999,
-            99_999,
-            cut=("x" * _AUDIT_BLOCK_LABEL_MAX, 99_999),
+            _AUDIT_WORST_COUNTER,
+            _AUDIT_WORST_COUNTER,
+            cut=("x" * _AUDIT_BLOCK_LABEL_MAX, _AUDIT_WORST_COUNTER),
             where=(
                 f" — full text: {Path.home()}/.genesis/sessions/{'0' * 36}/context-identity-user.md"
             ),
@@ -179,7 +199,11 @@ def _audit_reserve(part: str, mirror: Path | None) -> int:
     """
     where = f" — full text: {mirror}" if mirror is not None else " — MIRROR UNAVAILABLE"
     worst = _audit_line(
-        part, 99_999, 99_999, cut=("x" * _AUDIT_BLOCK_LABEL_MAX, 99_999), where=where
+        part,
+        _AUDIT_WORST_COUNTER,
+        _AUDIT_WORST_COUNTER,
+        cut=("x" * _AUDIT_BLOCK_LABEL_MAX, _AUDIT_WORST_COUNTER),
+        where=where,
     )
     return max(_AUDIT_LINE_RESERVE, emit_cost(worst))
 
@@ -1406,7 +1430,8 @@ def _finish_part(part: str, session_id: str, miswired: str = "") -> None:
         block, dropped = cut
         where = f" — full text: {mirror}" if wrote_mirror else " — MIRROR UNAVAILABLE"
         out.emit_final(
-            _audit_line(part, out.intended_chars, out.emitted_chars, cut=cut, where=where)
+            _audit_line(part, out.intended_chars, out.emitted_chars, cut=cut, where=where),
+            fallback=_audit_line_minimal(part, where),
         )
     else:
         out.emit_final(_audit_line(part, out.emitted_chars, out.emitted_chars))

--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -155,8 +155,11 @@ def _audit_line_minimal(part: str, where: str) -> str:
 
 # Room reserved for the trailing `_[ctx <part>: …]_` self-audit line — DERIVED
 # from the renderer above at its realistic worst case, not a round number.
-# Pinned by test_the_audit_reserve_fits_the_line_it_reserves_for, which rebuilds
-# this same worst case, so the two cannot drift.
+# The load-bearing invariant is that `_AUDIT_WORST_COUNTER` exceeds any counter a
+# real part can render (checked by test_the_audit_worst_counter_exceeds_any_real_part,
+# which asserts that margin directly — not by rebuilding the line, which would be
+# tautological against a reserve derived from the same figure); the pointer-safe
+# fallback in `_finish_part` is the structural backstop past even that.
 # 12-digit worst-case counters (999_999_999_999 ≈ 1 TB): `intended`/`dropped`
 # are unbounded, and the earlier 5-digit 99_999 under-reserved for any part that
 # renders a 6+-digit count — a right-clip would then eat the trailing mirror

--- a/scripts/hooks/hook_output.py
+++ b/scripts/hooks/hook_output.py
@@ -358,18 +358,32 @@ class BoundedStdout:
             return
         self._cut_here(text, block=block, room=room)
 
-    def emit_final(self, text: str) -> None:
+    def emit_final(self, text: str, fallback: str | None = None) -> None:
         """Write a closing line using the reserved headroom.
 
         Bypasses ``reserve`` (that is what it was reserved for) but never the
         budget, and is emitted even after a cut — the audit line reporting the
         cut is the one thing that must always land.
+
+        ``fallback`` is a SHORTER form of the same line to emit WHOLE when the
+        full text will not fit the remaining room. The writer chooses (the
+        caller supplies candidates, never arithmetic): full if it fits, else a
+        fitting fallback, else a raw clip as the genuine last resort. The clip
+        cuts from the RIGHT, so a line whose tail is load-bearing — the audit
+        line's ``— full text: <mirror>]_`` pointer — loses exactly the part the
+        reader needs; the fallback exists so that outcome requires BOTH the full
+        line AND its own shorter form to overflow, not merely the full line.
         """
         self._intended.append(text)
         room = self._budget - self._emitted
         if room <= 0:
             return
-        self._write(text if emit_cost(text) <= room else clip_to_cost(text, max(0, room - 1)))
+        if emit_cost(text) <= room:
+            self._write(text)
+        elif fallback is not None and emit_cost(fallback) <= room:
+            self._write(fallback)
+        else:
+            self._write(clip_to_cost(text, max(0, room - 1)))
 
     # ── internals ──────────────────────────────────────────────────────
     def _write(self, text: str) -> None:

--- a/src/genesis/memory/provenance.py
+++ b/src/genesis/memory/provenance.py
@@ -481,8 +481,10 @@ _FIRST_PARTY_OBS_SOURCES: frozenset[str] = frozenset(
         # Context-injection watcher (awareness/loop.py _check_context_injection_health)
         # — Genesis observing its OWN runtime: whether the harness filed a
         # SessionStart hook's output instead of delivering it. The evidence is
-        # file sizes, mtimes and PATHS of the harness's own persisted files
-        # under ~/.claude/projects — filesystem metadata Genesis observed. No
+        # file sizes, mtimes, PATHS, and the SESSION-DIR names of the harness's
+        # own persisted files under ~/.claude/projects — all filesystem metadata
+        # Genesis observed (the session id is the grandparent dir name, escaped
+        # at ingestion like the path; see context_injection.note_filing). No
         # byte of a filed hook's CONTENT reaches the observation: the collector
         # attributes each filing from a closed set of labels it authors itself
         # (context_injection._attribute). That is what makes first_party true

--- a/src/genesis/observability/snapshots/context_injection.py
+++ b/src/genesis/observability/snapshots/context_injection.py
@@ -225,6 +225,22 @@ _MAX_FRESH = 2_000
 #: How many distinct read failures to name in the findings before summarising.
 _MAX_LISTED_ERRORS = 3
 
+#: How many affected session ids the restart remedy names before summarising.
+#: SEPARATE from the filings' ``max_listed`` (5) on purpose: the session list is
+#: an INVENTORY the operator acts on ("restart THESE"), not a sample, so it must
+#: name every session in the ordinary case — 8 sessions filing at once was the
+#: live 2026-09-05 shape, and inheriting the filings' 5 would leave 3 unnamed
+#: under a "restart the affected sessions" remedy. 20 sits well above that while
+#: bounding a pathological fan-out. Past it, the EXACT total is stated alongside
+#: the first 20 names — a selection with a denominator, not a silent cut. It does
+#: NOT claim the "filing paths above" cover the rest: that list caps at
+#: ``max_listed`` (5), so beyond 20 sessions the overflow is genuinely
+#: un-enumerated, and the honest thing is to say the count, not point at a list
+#: that does not hold them. 20 named + an exact total is enough for the operator
+#: to grasp the scale; a >20-session fan-out is itself the "cap MOVED" escalation
+#: the remedy already names.
+_MAX_SESSIONS_NAMED = 20
+
 #: Hard bound on the recorded errors themselves (the display bound above is a
 #: separate, smaller one). One entry per unreadable path, and the whole list is
 #: hashed into the alert identity, so an unbounded list is unbounded work on a
@@ -319,6 +335,17 @@ class InjectionHealth:
         """``{path, size, age_h, producer}`` per filing, paths already escaped."""
         return self._filings
 
+    @property
+    def filing_session_ids(self) -> list[str]:
+        """Distinct sessions that filed, first-seen order, ids already escaped.
+
+        Over ALL producers — this is the "across N session(s)" population.
+        Derived from the per-filing ``session`` fact rather than stored, so it
+        cannot drift from ``_filings``. The restart remedy scopes a NARROWER
+        list (session-context producers only); see :func:`_session_context_sessions`.
+        """
+        return list(dict.fromkeys(d["session"] for d in self._filings))
+
     def add_error(self, subject: object, what: str, exc: BaseException | None = None) -> None:
         """Record a read that failed. Escapes at the boundary, every time.
 
@@ -330,13 +357,24 @@ class InjectionHealth:
         self._errors.append(f"{_safe_path(subject)} {what}{detail}")
 
     def note_filing(self, path: Path, *, size: int, age_h: float, producer: str) -> None:
-        """Record a filing. The path is escaped here so no renderer has to."""
+        """Record a filing. The path is escaped here so no renderer has to.
+
+        The session id (``<projects>/<slug>/<SESSION>/tool-results/<file>`` — the
+        grandparent's name) rides in the row too, escaped at this same boundary:
+        it is CC-authored filesystem metadata, POSIX permits a newline in it, and
+        it now reaches a first_party observation via the restart remedy. Kept as
+        a FACT on each filing rather than a pre-derived list, so each consumer
+        scopes it correctly — the distinct-session COUNT is over all producers,
+        but the restart remedy names only the session-context subset (a session
+        that filed only an other-hook output has a different remedy, not restart).
+        """
         self._filings.append(
             {
                 "path": _safe_path(path),
                 "size": size,
                 "age_h": age_h,
                 "producer": producer,
+                "session": _safe_path(path.parent.parent.name),
             }
         )
 
@@ -562,12 +600,22 @@ def _genesis_saw_recent_session(reads: _Reads, cutoff: float) -> bool:
     session, so a fresh mtime here is Genesis's own evidence that CC ran —
     independent of CC's directory layout, which is the whole point: it is the
     half of the freshness comparison that a CC update cannot move.
+
+    Reads are REPORTED, deliberately NOT wrapped in ``unreported()``. Absent
+    files — dispatched sessions with no ``last_prompt_time`` — are already
+    silent: ``_Reads.stat`` maps FileNotFoundError to None. What is left to
+    report is a genuine I/O failure on THIS install's own store (a permission
+    fault, an unreadable subtree), which must not read as "no fresh prompt":
+    that answer is indistinguishable from an idle install and would let a
+    fossil CC tree resolve a live alert (the fourth-granularity blind resolve
+    this probe exists to catch). Suppressing here traded that failure for
+    silence; the primitives already give absence for free, so the wrapper only
+    hid the case worth reporting.
     """
-    with reads.unreported():  # absent files are the norm (dispatched sessions)
-        for d in reads.listdir(_genesis_sessions_dir()):
-            st = reads.stat(d / "last_prompt_time")
-            if st is not None and st.st_mtime >= cutoff:
-                return True
+    for d in reads.listdir(_genesis_sessions_dir()):
+        st = reads.stat(d / "last_prompt_time")
+        if st is not None and st.st_mtime >= cutoff:
+            return True
     return False
 
 
@@ -814,15 +862,15 @@ def _collect_sync(
         health.scan_truncated = True
         fresh = fresh[:_MAX_FRESH]
 
-    sessions: set[str] = set()
     for mtime, f, size in fresh:
         producer, is_probe = _attribute(f, reads)
         if is_probe:
             health.probe_filings += 1
             continue
         health.note_filing(f, size=size, age_h=round((now - mtime) / 3600, 1), producer=producer)
-        sessions.add(f.parent.parent.name)
-    health.filing_sessions = len(sessions)
+    # note_filing tracks the distinct affected sessions (escaped, deduped); the
+    # count is just its length — no second, unescaped set to drift from it.
+    health.filing_sessions = len(health.filing_session_ids)
 
     # Applied LAST, after attribution has had its chance to record failures.
     health.bound_errors(_MAX_ERRORS)
@@ -843,6 +891,18 @@ _IDENTITY_EXEMPT_FIELDS: dict[str, str] = {
     # and the producer set carry the condition; the count is reported in the
     # finding text, where it informs without re-paging.
     "filing_sessions": "a rolling-window count — reported, never keyed",
+    # The session ids the restart remedy names now ride inside `_filings` (a
+    # per-filing `session` fact), covered by `_filings`'s exemption above — so
+    # they need no separate entry here. Their re-page behaviour is a DELIBERATE
+    # tradeoff, documented at the remedy: keying the session SET into the alert
+    # identity would re-page on every session change (the churn this exemption
+    # avoids), while exempting it means a sustained-churn window can show a
+    # stale "restart THESE" list until the alert resolves. Post-deploy the
+    # session-context population only SHRINKS (a restarted session stops filing;
+    # new sessions carry the fixed wiring and never file), so the list ages to
+    # empty and the alert resolves — the frozen-list case needs NEW sessions to
+    # start filing, which only happens if the cap MOVED, and the remedy already
+    # escalates to that. Accepted with that reasoning rather than re-paging.
     # Not rendered by derive_findings, and both move for reasons unrelated to
     # any loss: probes appear while measuring the cap, foreign filings whenever
     # the operator opens another repo.
@@ -942,12 +1002,30 @@ def derive_findings(health: InjectionHealth, *, max_listed: int = 5) -> list[str
         f"session(s) — those windows ran WITHOUT the filed content: {listed}{more}."
     )
     if any(p.startswith("session-context") for p in by_producer):
+        # SCOPED to session-context filings: a session that filed only an
+        # other-hook output has a different remedy (bound that hook), so naming
+        # it here under "restart" would be wrong and would inflate the count.
+        ids = list(
+            dict.fromkeys(
+                d["session"]
+                for d in health.fresh_filings
+                if d["producer"].startswith("session-context")
+            )
+        )
+        named = ", ".join(ids[:_MAX_SESSIONS_NAMED])
+        overflow = (
+            f" …and {len(ids) - _MAX_SESSIONS_NAMED} more of {len(ids)} (the count is "
+            "exact; only the first names are listed)"
+            if len(ids) > _MAX_SESSIONS_NAMED
+            else ""
+        )
         findings.append(
             "session-context filings mean the injection crossed the harness cap: "
-            "RESTART the affected sessions (a session started before a fix keeps the "
-            "old wiring until it does), and if filings continue after a restart the "
-            "cap itself has MOVED — re-measure it with the probe seam in "
-            "scripts/genesis_session_context.py and re-fit the part budgets."
+            f"RESTART the affected sessions ({len(ids)} total) [{named}{overflow}] "
+            "(a session started before a fix keeps the old wiring until it does), "
+            "and if filings continue after a restart the cap itself has MOVED — "
+            "re-measure it with the probe seam in scripts/genesis_session_context.py "
+            "and re-fit the part budgets."
         )
     if any(not p.startswith(("session-context", "cap-measurement")) for p in by_producer):
         findings.append(

--- a/src/genesis/observability/snapshots/context_injection.py
+++ b/src/genesis/observability/snapshots/context_injection.py
@@ -146,6 +146,31 @@ def _safe_path(path: object) -> str:
     return _PATH_UNSAFE.sub("?", str(path))
 
 
+def _safe_session_id(value: object) -> str:
+    """Escape a session directory name that will be used as a KEY.
+
+    Deliberately separate from :func:`_safe_path`, which is a DISPLAY escape and
+    is lossy on purpose — it maps every disallowed character to a single ``?``.
+    That is right for prose and wrong for an identifier: ``sess\\nx`` and
+    ``sess\\tx`` both render ``sess?x``, and this value is deduplicated with
+    ``dict.fromkeys`` to produce ``filing_sessions``. MEASURED before this
+    existed: the two names collide, so two affected sessions counted as one and
+    one of them was omitted from the restart list the operator acts on.
+
+    A cap or an escape that merges two identities into one is the same defect
+    whichever end it happens at, and it is worse than a visibly mangled name
+    because the undercount still LOOKS like an exact total.
+
+    Injective by construction: everything outside the allowed set becomes
+    ``\\UXXXXXXXX``, and the backslash introducer is itself outside that set, so
+    no escaped form can be produced by any other input. Session directories are
+    UUIDs in practice, so this escapes nothing on the normal path.
+    """
+    return "".join(
+        c if c.isalnum() or c in "._~+-" else f"\\U{ord(c):08X}" for c in str(value)
+    )
+
+
 def _safe_text(text: object) -> str:
     """Escape PROSE read off disk on its way into an observation.
 
@@ -374,7 +399,9 @@ class InjectionHealth:
                 "size": size,
                 "age_h": age_h,
                 "producer": producer,
-                "session": _safe_path(path.parent.parent.name),
+                # KEY, not display — this is deduplicated into `filing_sessions`
+                # and drives the restart list, so it needs an injective escape.
+                "session": _safe_session_id(path.parent.parent.name),
             }
         )
 

--- a/src/genesis/observability/snapshots/context_injection.py
+++ b/src/genesis/observability/snapshots/context_injection.py
@@ -1013,15 +1013,24 @@ def derive_findings(health: InjectionHealth, *, max_listed: int = 5) -> list[str
             )
         )
         named = ", ".join(ids[:_MAX_SESSIONS_NAMED])
+        # When the scan itself truncated (>_MAX_FRESH fresh filings), the loop
+        # that built these ids saw only the newest _MAX_FRESH — so this count is
+        # a LOWER BOUND, not exact, and saying "exact" would be the false
+        # completeness claim the whole watcher exists to avoid.
+        total_desc = (
+            f"at least {len(ids)}; the scan hit its {_MAX_FRESH}-filing cap, so more "
+            "may be affected"
+            if health.scan_truncated
+            else f"{len(ids)} total"
+        )
         overflow = (
-            f" …and {len(ids) - _MAX_SESSIONS_NAMED} more of {len(ids)} (the count is "
-            "exact; only the first names are listed)"
+            f" …and {len(ids) - _MAX_SESSIONS_NAMED} more not listed"
             if len(ids) > _MAX_SESSIONS_NAMED
             else ""
         )
         findings.append(
             "session-context filings mean the injection crossed the harness cap: "
-            f"RESTART the affected sessions ({len(ids)} total) [{named}{overflow}] "
+            f"RESTART the affected sessions ({total_desc}) [{named}{overflow}] "
             "(a session started before a fix keeps the old wiring until it does), "
             "and if filings continue after a restart the cap itself has MOVED — "
             "re-measure it with the probe seam in scripts/genesis_session_context.py "

--- a/tests/test_awareness/test_context_injection_watch.py
+++ b/tests/test_awareness/test_context_injection_watch.py
@@ -1671,3 +1671,46 @@ def test_absent_last_prompt_time_files_stay_silent_in_the_freshness_probe(tmp_pa
     h = _collect(projects)
     assert not h.errors, h.errors
     assert not ci.derive_findings(h)
+
+
+def test_two_session_names_that_differ_only_in_escaped_bytes_stay_distinct(tmp_path):
+    """The stored session id is a KEY, so its escape must be injective.
+
+    `_safe_path` is a DISPLAY escape and lossy on purpose — every disallowed
+    character becomes a single `?`. Applied to the identifier, `sess\\nx` and
+    `sess\\tx` both rendered `sess?x`, and `filing_session_ids` deduplicates with
+    `dict.fromkeys`, so two affected sessions counted as ONE and one of them was
+    dropped from the restart list the operator acts on.
+
+    Worse than a mangled name, because the undercount still reads as an exact
+    total. Same defect as a truncated key merging two identities, one mechanism
+    over.
+    """
+    _file(tmp_path, slug=_GENESIS_SLUG, session="sess\nx", name="hook-1-stdout.txt",
+          body=b"## Session Configuration\n\npayload")
+    _file(tmp_path, slug=_GENESIS_SLUG, session="sess\tx", name="hook-2-stdout.txt",
+          body=b"## Session Configuration\n\npayload")
+    h = _collect(tmp_path)
+
+    ids = h.filing_session_ids
+    assert len(ids) == 2, f"two distinct sessions collapsed to one: {ids}"
+    assert h.filing_sessions == 2, "the reported total under-counts"
+    # Still safe: the escape must not reintroduce what the display escape removed.
+    for sid in ids:
+        assert not any(c in sid for c in "\n\r\t"), sid
+
+
+def test_the_injective_escape_cannot_be_forged_by_a_literal_escape_sequence(tmp_path):
+    """A name that already LOOKS escaped must not collide with the real thing.
+
+    Injectivity only holds if the escape introducer is itself escaped —
+    otherwise a session literally named `sess\\U0000000Ax` maps onto the encoding
+    of `sess<newline>x`, which is the collision this fix removes, reachable by
+    anyone who can name a directory.
+    """
+    _file(tmp_path, slug=_GENESIS_SLUG, session="sess\nx", name="hook-1-stdout.txt",
+          body=b"## Session Configuration\n\npayload")
+    _file(tmp_path, slug=_GENESIS_SLUG, session="sess\\U0000000Ax",
+          name="hook-2-stdout.txt", body=b"## Session Configuration\n\npayload")
+    h = _collect(tmp_path)
+    assert len(h.filing_session_ids) == 2, h.filing_session_ids

--- a/tests/test_awareness/test_context_injection_watch.py
+++ b/tests/test_awareness/test_context_injection_watch.py
@@ -362,6 +362,94 @@ def test_findings_list_caps_visibly(tmp_path):
     assert "and 4 more" in joined, joined
 
 
+def test_session_context_remedy_names_the_sessions_to_restart(tmp_path):
+    """The remedy says "RESTART the affected sessions" — so it must NAME them.
+
+    Replays the live shape (2026-09-05): 8 sessions filing, the remedy naming
+    none, and listing 5 FILINGS covers only 4 of the 8 sessions. An operator
+    cannot act on "restart the affected sessions" without the ids.
+    """
+    ids = [f"1c93a6da-sess{i}" for i in range(8)]
+    for i, sid in enumerate(ids):
+        _file(
+            tmp_path,
+            session=sid,
+            name=f"hook-{i}-stdout.txt",
+            body=b"## Session Configuration\n\npayload",
+        )
+    h = _collect(tmp_path)
+    remedy = next(f for f in ci.derive_findings(h) if "RESTART the affected sessions" in f)
+    for sid in ids:
+        assert sid in remedy, f"session {sid} not named in the restart remedy: {remedy}"
+
+
+def test_session_list_bounds_and_says_so(tmp_path, monkeypatch):
+    """A pathological fan-out is bounded LOUDLY, not silently cut.
+
+    The bound is its own ceiling (not the filings' ``max_listed``): the session
+    list is an INVENTORY the remedy acts on, so it must name more than the 5
+    filings shown. When it does bound, the true total is stated.
+    """
+    monkeypatch.setattr(ci, "_MAX_SESSIONS_NAMED", 3)
+    for i in range(6):
+        _file(
+            tmp_path,
+            session=f"sess-{i}",
+            name=f"hook-{i}-stdout.txt",
+            body=b"## Session Configuration\n\npayload",
+        )
+    h = _collect(tmp_path)
+    remedy = next(f for f in ci.derive_findings(h) if "RESTART the affected sessions" in f)
+    assert "6" in remedy, f"true session total not stated: {remedy}"
+    assert "more" in remedy, f"bounded list did not announce the overflow: {remedy}"
+
+
+def test_filing_session_ids_are_escaped(tmp_path):
+    """A session directory name is CC-authored filesystem metadata — POSIX
+    permits a newline in it — and it now reaches a first_party observation, so
+    it is escaped like the filing path (see ``memory/provenance.py``)."""
+    _file(
+        tmp_path,
+        slug=_GENESIS_SLUG,
+        session="evil\nINJECTED",
+        name="hook-1-stdout.txt",
+        body=b"## Session Configuration\n\npayload",
+    )
+    h = _collect(tmp_path)
+    assert all("\n" not in d["session"] for d in h.fresh_filings), h.fresh_filings
+    assert all("\n" not in sid for sid in h.filing_session_ids), h.filing_session_ids
+
+
+def test_restart_remedy_excludes_a_session_that_only_filed_another_hook(tmp_path):
+    """The restart inventory is SCOPED to session-context producers.
+
+    A session whose only filing is an OTHER_HOOK output has a different remedy
+    (bound that hook), so naming it under "RESTART the affected sessions" is
+    wrong and inflates the count. This is the mixed-producer case the pure
+    8-session test cannot catch.
+    """
+    # A real session-context filing (stamped head → attributed to a part).
+    _file(
+        tmp_path,
+        session="ctx-session",
+        name="hook-1-stdout.txt",
+        body=b"[genesis-ctx:charter] payload\n" + b"x" * 200,
+    )
+    # An unrecognised-producer filing in a DIFFERENT session.
+    _file(
+        tmp_path,
+        session="other-hook-session",
+        name="hook-2-stdout.txt",
+        body=b"[Memory | recall payload not from session-context]\n" + b"y" * 200,
+    )
+    h = _collect(tmp_path)
+    remedy = next(f for f in ci.derive_findings(h) if "RESTART the affected sessions" in f)
+    assert "ctx-session" in remedy, remedy
+    assert "other-hook-session" not in remedy, (
+        "a non-session-context session was named under RESTART: " + remedy
+    )
+
+
 # ── cannot-look is never all-clear ─────────────────────────────────────
 
 
@@ -1496,6 +1584,59 @@ def test_an_idle_install_with_a_fossil_tree_stays_quiet(tmp_path, monkeypatch):
     lpt = sess / "last_prompt_time"
     lpt.write_text("2026-08-01T00:00:00+00:00")
     _aged(lpt, 200.0)  # Genesis saw nothing recent either
+    monkeypatch.setenv("HOME", str(home))
+
+    projects = tmp_path / "projects"
+    old = _file(projects, name="hook-old-stdout.txt", age_h=200.0)
+    for p in (old.parent, old.parent.parent, old.parent.parent.parent):
+        _aged(p, 200.0)
+
+    h = _collect(projects)
+    assert not h.errors, h.errors
+    assert not ci.derive_findings(h)
+
+
+def test_an_unreadable_session_store_degrades_the_freshness_probe(tmp_path, monkeypatch):
+    """A permission failure on the sessions store must be RECORDED, not read as
+    "no fresh prompt".
+
+    The freshness probe is the fourth granularity's Genesis-side half. With its
+    reads suppressed, an unreadable ``~/.genesis/sessions`` returns False — the
+    same answer as a genuinely idle install — so a fossil CC tree resolves a
+    live alert and the failure is silent. The probe's reads must report like
+    every other read this collector makes; only ABSENT files stay silent
+    (``_Reads.stat`` already separates those two).
+    """
+    home = tmp_path / "inuse"
+    sessions = home / ".genesis" / "sessions"
+    (sessions / "sess-live").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+
+    projects = tmp_path / "projects"
+    old = _file(projects, name="hook-old-stdout.txt", age_h=200.0)
+    for p in (old.parent, old.parent.parent, old.parent.parent.parent):
+        _aged(p, 200.0)
+
+    sessions.chmod(0o000)
+    require_access_denied(sessions)
+    try:
+        h = _collect(projects)
+        assert h.errors, (
+            "an unreadable session store read as 'no fresh prompt' — the "
+            "freshness probe swallowed a real I/O failure"
+        )
+        assert any("CANNOT BE TREATED AS ALL-CLEAR" in f for f in ci.derive_findings(h))
+    finally:
+        sessions.chmod(0o755)
+
+
+def test_absent_last_prompt_time_files_stay_silent_in_the_freshness_probe(tmp_path, monkeypatch):
+    """Control: dispatched sessions have dirs but no ``last_prompt_time`` — the
+    NORM, not a failure. ``_Reads.stat`` maps FileNotFoundError to a silent
+    None, so reporting the probe's reads must not page an ordinary install."""
+    home = tmp_path / "inuse"
+    for name in ("dispatched-a", "dispatched-b"):
+        (home / ".genesis" / "sessions" / name).mkdir(parents=True)
     monkeypatch.setenv("HOME", str(home))
 
     projects = tmp_path / "projects"

--- a/tests/test_awareness/test_context_injection_watch.py
+++ b/tests/test_awareness/test_context_injection_watch.py
@@ -367,9 +367,10 @@ def test_session_context_remedy_names_the_sessions_to_restart(tmp_path):
 
     Replays the live shape (2026-09-05): 8 sessions filing, the remedy naming
     none, and listing 5 FILINGS covers only 4 of the 8 sessions. An operator
-    cannot act on "restart the affected sessions" without the ids.
+    cannot act on "restart the affected sessions" without the ids. (Synthetic
+    ids — never a real session's, per the privacy gate.)
     """
-    ids = [f"1c93a6da-sess{i}" for i in range(8)]
+    ids = [f"sess-{i:02d}" for i in range(8)]
     for i, sid in enumerate(ids):
         _file(
             tmp_path,
@@ -402,6 +403,29 @@ def test_session_list_bounds_and_says_so(tmp_path, monkeypatch):
     remedy = next(f for f in ci.derive_findings(h) if "RESTART the affected sessions" in f)
     assert "6" in remedy, f"true session total not stated: {remedy}"
     assert "more" in remedy, f"bounded list did not announce the overflow: {remedy}"
+
+
+def test_a_truncated_scan_does_not_claim_an_exact_session_count(tmp_path, monkeypatch):
+    """When the scan hit `_MAX_FRESH` the session inventory is a LOWER BOUND.
+
+    `_collect_sync` truncates the filing list to `_MAX_FRESH` BEFORE the session
+    ids are derived, so the count covers only the sampled filings. Labelling it
+    "exact" (or a bare "N total") would be the false completeness claim the
+    watcher exists to avoid — the remedy must say the count is a floor.
+    """
+    monkeypatch.setattr(ci, "_MAX_FRESH", 3)
+    for i in range(6):
+        _file(
+            tmp_path,
+            session=f"sess-{i:02d}",
+            name=f"hook-{i}-stdout.txt",
+            body=b"## Session Configuration\n\npayload",
+        )
+    h = _collect(tmp_path)
+    assert h.scan_truncated, "fixture did not trip the scan cap"
+    remedy = next(f for f in ci.derive_findings(h) if "RESTART the affected sessions" in f)
+    assert "at least" in remedy, f"truncated scan claimed a complete count: {remedy}"
+    assert "-filing cap" in remedy, remedy
 
 
 def test_filing_session_ids_are_escaped(tmp_path):

--- a/tests/test_hooks/test_hook_output.py
+++ b/tests/test_hooks/test_hook_output.py
@@ -110,6 +110,36 @@ def test_emit_final_lands_WHOLE_not_merely_present(sink):
     assert sink.getvalue().endswith(line + "\n"), sink.getvalue()[-90:]
 
 
+def test_emit_final_prefers_a_pointer_fallback_over_clipping_the_tail(sink):
+    """When the full closing line will not fit, a caller-supplied fallback that
+    fits is emitted WHOLE — the raw clip (which drops the line's tail, and the
+    tail is the mirror pointer) is the last resort, not the first.
+
+    Reproduces F1: `emit_final` used to `clip_to_cost` from the right, so an
+    audit line whose counters or session id pushed it past the room lost its
+    trailing `— full text: <mirror>]_` — the one part the reader needs. The
+    fallback drops the volatile counters and keeps part + pointer.
+    """
+    full = (
+        "_[ctx knowledge: 123456789012 intended / 9800 emitted — CUT 123456779212 chars at 'ek' — full text: /home/u/.genesis/sessions/"
+        + "s" * 60
+        + "/context-knowledge.md]_"
+    )
+    fallback = (
+        "_[ctx knowledge: audit counts omitted for size — full text: /home/u/.genesis/sessions/"
+        + "s" * 60
+        + "/context-knowledge.md]_"
+    )
+    # Room fits the fallback but not the full line.
+    reserve = _ho.emit_cost(fallback)
+    out = _writer(sink, budget=500, reserve=reserve)
+    out.emit("x" * (500 - reserve), block="knowledge")
+    out.emit_final(full, fallback=fallback)
+    got = sink.getvalue()
+    assert got.rstrip("\n").endswith("context-knowledge.md]_"), got[-90:]
+    assert "audit counts omitted" in got, "fell back to a raw clip instead of the pointer form"
+
+
 def test_reserve_is_held_back_from_emit(sink):
     """A block may not spend the headroom kept for the closing line."""
     out = _writer(sink, budget=200, reserve=100)

--- a/tests/test_scripts/test_context_injection_budget.py
+++ b/tests/test_scripts/test_context_injection_budget.py
@@ -628,28 +628,33 @@ def test_the_budget_lock_can_itself_fail():
         assert not _budget_offenders(sample), f"false positive on: {label}"
 
 
-def test_the_audit_reserve_fits_the_line_it_reserves_for(tmp_path):
-    """The reserve is DERIVED from the renderer, and must stay ahead of it.
+def test_the_audit_worst_counter_exceeds_any_real_part(tmp_path):
+    """The reserve's counter width must dominate any counter a real part emits.
 
-    Rebuilds the same worst case `_AUDIT_LINE_RESERVE` is computed from, so the
-    constant and the line cannot drift. This is the pin the old round number
-    lacked: 120 was chosen once and the line grew past it, and because
-    `_cut_here` fills the ceiling by construction, `room` at `emit_final` time
-    is ALWAYS exactly the reserve — so being short by any amount truncates
-    deterministically rather than occasionally.
+    The reserve is DERIVED from ``_audit_line(... _AUDIT_WORST_COUNTER ...)``, so
+    "the reserve fits a line built from _AUDIT_WORST_COUNTER" is a tautology and
+    cannot catch the original defect (a 5-digit reserve while a 6+-digit
+    `intended` clipped the mirror pointer). The NON-tautological invariant is the
+    one that actually protects the pointer: ``_AUDIT_WORST_COUNTER`` is larger
+    than any counter a real part can render.
+
+    ``intended``/``emitted``/``dropped`` are CHARACTER counts of a single hook
+    part. Even a pathological multi-MB identity file is well under 10**8 chars;
+    10**9 is a 10x margin past that. Assert the constant clears that ceiling — a
+    constant shrunk back toward 5 digits fails HERE, independently of how the
+    reserve is derived from it. The impossible beyond-constant case is the
+    structural backstop's job (the pointer-preserving fallback, proven in
+    test_emit_final_prefers_a_pointer_fallback_over_clipping_the_tail).
     """
-    worst = _ctx._audit_line(
-        "identity-user",
-        99_999,
-        99_999,
-        cut=("x" * _ctx._AUDIT_BLOCK_LABEL_MAX, 99_999),
-        where=(
-            f" — full text: {Path.home()}/.genesis/sessions/{'0' * 36}/context-identity-user.md"
-        ),
+    realistic_max_part_chars = 10**9  # 1 GB in one hook part — absurd, deliberately
+    assert realistic_max_part_chars <= _ctx._AUDIT_WORST_COUNTER, (
+        f"_AUDIT_WORST_COUNTER ({_ctx._AUDIT_WORST_COUNTER}) is not comfortably "
+        "above the largest counter a real part can render — a large part would "
+        "clip the audit line's mirror pointer"
     )
-    assert len(worst) + 1 <= _ctx._AUDIT_LINE_RESERVE, (
-        f"reserve {_ctx._AUDIT_LINE_RESERVE} < worst-case audit line {len(worst)} + newline"
-    )
+    # And the reserve derived from it is a positive, sane size (guards against a
+    # derivation that silently collapsed to the +16 slack alone).
+    assert _ctx._AUDIT_LINE_RESERVE > 100, _ctx._AUDIT_LINE_RESERVE
 
 
 def test_the_block_label_in_an_audit_line_is_bounded(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Follow-up to #1556. Addresses four of its review threads on the context-injection
watcher + SessionStart hook output path. Each was cleared in-thread on #1556 by
PROMISING this PR, so each gets a real disposition here.

## What

**F2 — fail-open in the freshness probe** (thread https://github.com/WingedGuardian/GENesis-AGI/pull/1556#discussion_r3939738712).
`_genesis_saw_recent_session` wrapped its reads in `unreported()`, so a permission
fault on this install's OWN `~/.genesis/sessions` store read as "no fresh prompt" —
identical to an idle install, which let a fossil CC projects tree resolve a live
alert (the fourth-granularity blind resolve). The wrapper is deleted; `_Reads.stat`
already maps absent files (dispatched sessions) to a silent `None`, so only a genuine
own-store I/O fault now degrades. FP side measured 0/645 on a healthy install.

**F3 — name the sessions the remedy tells you to restart** (thread https://github.com/WingedGuardian/GENesis-AGI/pull/1556#discussion_r3939738724).
"RESTART the affected sessions" named none, and the 5-filing list under it covered
only some. Each filing now carries its session id as an escaped fact; the remedy
names the sessions, **scoped to session-context producers** (a session that filed only
another hook has a different remedy, not restart), bounded with an exact-total overflow.

**F1 — keep the completion proof's pointer** (thread https://github.com/WingedGuardian/GENesis-AGI/pull/1556#discussion_r3939738698).
`emit_final` clipped from the right when the audit line overran its reserve, dropping
the trailing `— full text: <mirror>]_` pointer. It now prefers a counters-dropped
fallback that keeps part + pointer; the reserve's worst-case counters are widened past
any real part, so the fallback is a structural backstop, not a routine path.

**F4 — DEFERRED** (thread https://github.com/WingedGuardian/GENesis-AGI/pull/1556#discussion_r3939738718).
Liveness-keyed expiry for stale filings is deferred: its "a restart mints a new session
id" premise is contradicted by CC's `--fork-session` docs (plain `--resume` reuses the
id), which would invert the fix into a permanent critical alert; and #1706 /
peer work is already building the authoritative session-liveness substrate. Tracked as
a local follow-up gated on that substrate merging. The one correct insight is kept as
prose: MISWIRE records self-refresh (mtime expiry is correct there); only FILINGS have
the one-shot problem.

## Review

Fresh-context genesis-architect adversarial pass (internal), every load-bearing claim
re-derived from ground truth before fixing. It returned 4 SHOULD-FIX + 1 NOTE, all
addressed: the restart inventory scoped to session-context producers (was unscoped),
the overflow pointer made honest (it claimed the 5-path list covered the overflow — it
does not), the audit-reserve pin test made non-tautological (it compared the constant
to itself), the alert-identity churn tradeoff documented as a conscious accept. Branch
fast-forwarded onto current main so #1730 is preserved.

## Verification

152 targeted tests green; ruff + 4 local CI guards clean; verify-RED on every new test.
Live E2E: the real collector names all 7 session-context sessions in the remedy (shipped
code names 0); four-part hook subprocess emits under cap with intact audit lines.

Follow-up: 4f1e707e1bec43708b3740a1b7146546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Audit output now preserves part identifiers and mirror paths when full audit details exceed available space.
  - Session-context restart guidance identifies affected sessions, safely escapes session IDs, and distinguishes exact totals from lower bounds when results are truncated.
  - Failures reading session state are now reported as degraded findings instead of being silently ignored.
  - Sessions unrelated to the relevant filing source are excluded from restart guidance.
  - Restart instructions now appear before potentially lengthy session inventories.

- **Documentation**
  - Monitoring documentation now clarifies that session-directory names are observed and escaped during ingestion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->