### PR TITLE
fix(guardian): do not resume an escalation episode across a host reboot

### DIFF
--- a/src/genesis/guardian/check.py
+++ b/src/genesis/guardian/check.py
@@ -50,6 +50,11 @@ from genesis.guardian.state_machine import (
     GuardianState,
 )
 
+# genesis.util is import-safe on the host (stdlib-only chain); genesis.observability
+# is NOT — its package __init__ pulls aiohttp/aiosqlite, which the Guardian venv
+# does not carry. See genesis/util/host_boot.py.
+from genesis.util.host_boot import read_boot_id
+
 logger = logging.getLogger(__name__)
 
 _STARTED_AT = datetime.now(UTC)
@@ -439,6 +444,23 @@ async def run_check(config: GuardianConfig | None = None) -> None:
     sm = ConfirmationStateMachine(config)
     sm.load_state(state_path)
 
+    # Each timer tick is a fresh oneshot process, so the state on disk is the
+    # only continuity — including across a host reboot, where an escalation
+    # episode would otherwise resume mid-climb against a container that is
+    # legitimately still bootstrapping. Recovery budgets are preserved; see
+    # ConfirmationStateMachine.reset_if_rebooted.
+    #
+    # Contained like every other host-side helper in this tick: this runs BEFORE
+    # the heartbeat write and the `finally: save_state`, so an exception here
+    # would leave the Guardian silent and get it restart-looped by the container
+    # watchdog — a worse outcome than carrying stale state for one tick.
+    try:
+        sm.reset_if_rebooted(read_boot_id())
+    except Exception:
+        logger.warning(
+            "boot-aware state reset failed — carrying state forward", exc_info=True,
+        )
+
     dispatcher = _build_dispatcher(config)
     snapshots = SnapshotManager(config)
     diagnosis_engine = DiagnosisEngine(config)
@@ -545,17 +567,29 @@ async def _check_cycle(
         # so auto-reset (routes CONFIRMED_DEAD→HEALTHY while STILL down,
         # all_alive=False) neither pings nor clears — the storm stays suppressed.
         if sm.state.down_alert_sent and snapshot.all_alive:
-            if transition.old_state == GuardianState.CONFIRMED_DEAD:
-                # Autonomous recovery (container returned on its own — process()
-                # detected all_alive). The recovery-engine / CC-resolved /
-                # approval / self-heal paths clear the flag at their own
-                # recovery point + emit their own success alert, so
-                # down_alert_sent is already False here for them — no double-ping.
-                await dispatcher.send(Alert(
-                    severity=AlertSeverity.INFO,
-                    title="Genesis recovered",
-                    body="Genesis is back online — all health signals passing.",
-                ))
+            # The flag alone is the right predicate — do NOT also require
+            # old_state == CONFIRMED_DEAD.
+            #
+            # The recovery engine (recovery.py) and the approval gates below
+            # clear the flag at their own recovery point AND emit their own
+            # success alert, so they cannot double-ping here. But the CC-resolved
+            # firewall does NOT clear it, and the AWAITING_SELF_HEAL -> HEALTHY
+            # transition does not either — the "Genesis self-healed" alert is
+            # behind a branch whose only caller dispatches on
+            # state == AWAITING_SELF_HEAL, so it is unreachable. Keying on
+            # old_state therefore left the latch stuck True after those
+            # episodes, permanently muting every LATER down-alert.
+            #
+            # A post-reboot episode reset makes that guaranteed rather than
+            # occasional: the host reboots while the user is paged "Genesis
+            # down", the reset forces current_state to HEALTHY, the container
+            # comes back healthy, and the CRITICAL is never closed out. This
+            # branch is now the single close-out point for every predecessor.
+            await dispatcher.send(Alert(
+                severity=AlertSeverity.INFO,
+                title="Genesis recovered",
+                body="Genesis is back online — all health signals passing.",
+            ))
             sm.clear_down_alert_sent()
         await _handle_healthy(config, snapshots)
 

--- a/src/genesis/guardian/state_machine.py
+++ b/src/genesis/guardian/state_machine.py
@@ -74,6 +74,7 @@ class StateData:
     last_recovery_at: str | None = None  # ISO8601 timestamp of last recovery attempt
     io_triage_attempts: int = 0  # Separate counter for IO_TRIAGE (low-risk, repeatable)
     snapshot_size_history: list[int] = field(default_factory=list)  # Last N snapshot sizes in bytes
+    boot_id: str = ""  # kernel boot UUID when this state was last written; "" = unknown
 
     def to_dict(self) -> dict:
         return {
@@ -99,6 +100,7 @@ class StateData:
             "last_recovery_at": self.last_recovery_at,
             "io_triage_attempts": self.io_triage_attempts,
             "snapshot_size_history": self.snapshot_size_history[-5:],
+            "boot_id": self.boot_id,
         }
 
     @classmethod
@@ -130,6 +132,7 @@ class StateData:
             last_recovery_at=data.get("last_recovery_at"),
             io_triage_attempts=data.get("io_triage_attempts", 0),
             snapshot_size_history=data.get("snapshot_size_history", []),
+            boot_id=str(data.get("boot_id") or ""),
         )
 
 
@@ -612,6 +615,77 @@ class ConfirmationStateMachine:
             return elapsed < self._config.confirmation.bootstrap_grace_s
         except (ValueError, TypeError):
             return False
+
+    def reset_if_rebooted(self, current_boot_id: str | None) -> bool:
+        """Drop a stale episode when the host has rebooted since it was written.
+
+        Returns True if a reset happened.
+
+        The escalation ladder must never resume mid-climb across a reboot. The
+        state file survives (`load_state` restores it verbatim, fresh only on
+        corruption) and the 300s bootstrap grace is consulted from exactly one
+        transition — CONFIRMING->SURVEYING — so past CONFIRMING the grace is
+        never reached, and inside CONFIRMING it is computed from the persisted
+        PRE-reboot ``first_failure_at`` and has already expired on arrival.
+        Resetting to HEALTHY re-arms the grace that already works, through the
+        normal HEALTHY->SIGNAL_DROPPED->CONFIRMING path.
+
+        This deliberately does NOT call ``_reset_to_healthy``: that zeroes
+        ``recovery_attempts``, ``io_triage_attempts`` and ``last_recovery_at``,
+        which are three of the values that must survive.
+
+        The budgets are preserved because a reboot is not evidence the incident
+        is over, and the Guardian cannot tell a reboot it provoked from an
+        unrelated one. Refunding the escalation budget on every reboot would turn
+        a bounded 3-rung ladder into an unbounded loop on a box that is
+        reboot-cycling — which is exactly the box where reboots get observed.
+        (The gateway's manual ``reset-state`` verb DOES zero them, correctly: a
+        human has looked at the machine and decided the incident is over.)
+
+        Fails OPEN on an unknown boot id: a false positive silently discards a
+        live episode, which is worse than carrying a stale one for another tick.
+        """
+        if not current_boot_id:
+            return False
+        stored = self._state.boot_id
+        # Adopt, don't reset, when the state predates this field — otherwise the
+        # first tick after deploying this would wipe a live episode everywhere.
+        if not stored:
+            self._state.boot_id = current_boot_id
+            return False
+        if stored == current_boot_id:
+            return False
+
+        was_paused = self._state.current_state is GuardianState.PAUSED
+        logger.warning(
+            "Host rebooted since this state was written (boot %s -> %s) — %s; "
+            "recovery budgets are preserved",
+            stored, current_boot_id,
+            "staying PAUSED (user sovereignty), clearing episode tracking only"
+            if was_paused else
+            f"dropping the '{self._state.current_state.value}' episode and "
+            "re-arming the bootstrap grace",
+        )
+        # PAUSED is not a rung on the ladder: process() re-derives it from the
+        # snapshot every tick, and forcing it to HEALTHY here would make
+        # _handle_paused rewrite paused_since, restarting the long-pause reminder
+        # clock on every reboot.
+        if self._state.current_state is not GuardianState.PAUSED:
+            self._state.current_state = GuardianState.HEALTHY
+        self._state.consecutive_failures = 0
+        self._state.recheck_count = 0
+        self._state.first_failure_at = None
+        # Stale pre-reboot signals would otherwise be quoted into post-reboot
+        # alert bodies (check.py reads signal_history[-5:] at three alert sites)
+        # as if the episode were contiguous. Nothing holds a live reference to
+        # this list — process() rebinds it every tick — so clear() is for
+        # symmetry with snapshot_size_history, which IS aliased, not because it
+        # has to be in place here.
+        self._state.signal_history.clear()
+        self._clear_dialogue_state()
+        self.clear_cc_unavailable()
+        self._state.boot_id = current_boot_id
+        return True
 
     def _reset_to_healthy(self, now: str) -> None:
         """Reset all failure tracking state."""

--- a/src/genesis/util/host_boot.py
+++ b/src/genesis/util/host_boot.py
@@ -1,0 +1,38 @@
+"""Boot identity — which boot of this machine is currently running.
+
+STDLIB-ONLY, deliberately. This is imported by the host-side Guardian, whose
+venv carries ``pyyaml`` and nothing else (``scripts/install_guardian.sh``
+installs exactly that). Anything under ``genesis.observability`` is off-limits
+here: importing any of its submodules executes that package's ``__init__``,
+which pulls ``aiohttp`` and ``aiosqlite`` — absent on the host, so the import
+would raise and take the Guardian's whole tick down with it. The same constraint
+is recorded at ``genesis/guardian/repo_bundle.py``.
+
+``boot_id`` rather than ``/proc/stat``'s ``btime``: boot_id is a per-boot random
+UUID, regenerated only on an actual boot and independent of the clock. ``btime``
+is derived as wall-clock minus uptime, so it moves by the full amount of any NTP
+step — and a step during a live incident would read as a reboot and discard the
+episode, the exact false positive this mechanism must avoid. Comparing boot ids
+needs no tolerance, no drift anchor, and no direction reasoning.
+"""
+
+from __future__ import annotations
+
+# Module-level so tests can repoint it at a fake tree, mirroring the `_PROC`
+# seam in genesis/observability/cc_slots.py.
+_PROC = "/proc"
+
+
+def read_boot_id() -> str | None:
+    """This boot's UUID from ``/proc/sys/kernel/random/boot_id``, or None.
+
+    None means "cannot tell" — never "rebooted". Callers must fail OPEN on it:
+    treating an unreadable boot id as a reboot would silently discard live state.
+    """
+    try:
+        with open(f"{_PROC}/sys/kernel/random/boot_id") as f:
+            return f.read().strip() or None
+    except (OSError, ValueError):
+        # ValueError covers UnicodeDecodeError from a repointed _PROC in tests;
+        # the real file is ASCII. Either way the contract is "cannot tell".
+        return None

--- a/tests/test_guardian/test_check.py
+++ b/tests/test_guardian/test_check.py
@@ -521,6 +521,152 @@ def _alert_titles(mock_dispatcher: MagicMock) -> list[str]:
     return [call.args[0].title for call in mock_dispatcher.send.call_args_list]
 
 
+class TestBootAwareEpisodeReset:
+    """`run_check` must actually CALL the reboot reset, and the "Genesis
+    recovered" ping must key on the latch rather than on which rung we came from.
+
+    Both were built-but-unverified-as-wired: deleting the call site left 304
+    tests green, and re-adding the `old_state == CONFIRMED_DEAD` gate left 120
+    green, because every existing test seeds `current_state="confirmed_dead"`.
+    """
+
+    @pytest.mark.asyncio
+    async def test_run_check_resets_the_episode_after_a_host_reboot(
+        self, config: GuardianConfig,
+    ) -> None:
+        state_path = _seed_state(
+            config,
+            current_state="confirmed_dead",
+            first_failure_at="2020-01-01T00:00:00+00:00",   # long expired
+            recovery_attempts=2,
+            boot_id="1a2b3c4d-0000-4111-8000-000000000001",
+        )
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.send = AsyncMock()
+
+        with (
+            patch(
+                "genesis.guardian.check.collect_all_signals",
+                AsyncMock(return_value=_dead_snapshot()),
+            ),
+            patch("genesis.guardian.check._build_dispatcher", return_value=mock_dispatcher),
+            patch("genesis.guardian.check._write_guardian_heartbeat", AsyncMock()),
+            patch("genesis.guardian.check.load_secrets", return_value={}),
+            patch(
+                "genesis.guardian.check.read_boot_id",
+                return_value="9f9f9f9f-0000-4222-8000-000000000002",
+            ),
+        ):
+            await run_check(config)
+
+        import json
+
+        saved = json.loads(state_path.read_text())
+        assert saved["boot_id"] == "9f9f9f9f-0000-4222-8000-000000000002"
+        assert saved["current_state"] != "confirmed_dead", (
+            "the ladder must restart from HEALTHY, not resume mid-climb"
+        )
+        assert saved["recovery_attempts"] == 2, (
+            "the escalation budget must survive — refunding it on every reboot "
+            "turns a bounded ladder into an unbounded loop"
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_check_leaves_state_alone_within_one_boot(
+        self, config: GuardianConfig,
+    ) -> None:
+        state_path = _seed_state(
+            config,
+            current_state="confirmed_dead",
+            down_alert_sent=True,
+            first_failure_at=_now_iso(),
+            boot_id="1a2b3c4d-0000-4111-8000-000000000001",
+        )
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.send = AsyncMock()
+
+        with (
+            patch(
+                "genesis.guardian.check.collect_all_signals",
+                AsyncMock(return_value=_dead_snapshot()),
+            ),
+            patch("genesis.guardian.check._build_dispatcher", return_value=mock_dispatcher),
+            patch("genesis.guardian.check._write_guardian_heartbeat", AsyncMock()),
+            patch("genesis.guardian.check.load_secrets", return_value={}),
+            patch(
+                "genesis.guardian.check.read_boot_id",
+                return_value="1a2b3c4d-0000-4111-8000-000000000001",
+            ),
+        ):
+            await run_check(config)
+
+        import json
+
+        saved = json.loads(state_path.read_text())
+        assert saved["current_state"] == "confirmed_dead", (
+            "same boot — an in-flight episode must not be discarded"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "predecessor", ["awaiting_self_heal", "contacting_genesis", "recovered"],
+    )
+    async def test_restored_ping_fires_from_any_predecessor(
+        self, config: GuardianConfig, predecessor: str,
+    ) -> None:
+        """The latch is the predicate, not the rung. Before this, an episode that
+        ended from any state other than CONFIRMED_DEAD left `down_alert_sent`
+        stuck True — muting every LATER down-alert, permanently."""
+        _seed_state(
+            config,
+            current_state=predecessor,
+            down_alert_sent=True,
+            first_failure_at=_now_iso(),
+        )
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.send = AsyncMock()
+
+        with (
+            patch(
+                "genesis.guardian.check.collect_all_signals",
+                AsyncMock(return_value=_healthy_snapshot()),
+            ),
+            patch("genesis.guardian.check._build_dispatcher", return_value=mock_dispatcher),
+            patch("genesis.guardian.check._handle_healthy", AsyncMock()),
+            patch("genesis.guardian.check._write_guardian_heartbeat", AsyncMock()),
+            patch("genesis.guardian.check.load_secrets", return_value={}),
+        ):
+            await run_check(config)
+
+        titles = _alert_titles(mock_dispatcher)
+        restored = [t for t in titles if "recovered" in t.lower() or "restored" in t.lower()]
+        assert len(restored) == 1, f"expected one close-out ping, got {titles}"
+
+    @pytest.mark.asyncio
+    async def test_no_ping_when_no_down_alert_was_sent(
+        self, config: GuardianConfig,
+    ) -> None:
+        """The negative twin — the flag, not the state, is what gates it."""
+        _seed_state(config, current_state="recovered", down_alert_sent=False)
+        mock_dispatcher = MagicMock()
+        mock_dispatcher.send = AsyncMock()
+
+        with (
+            patch(
+                "genesis.guardian.check.collect_all_signals",
+                AsyncMock(return_value=_healthy_snapshot()),
+            ),
+            patch("genesis.guardian.check._build_dispatcher", return_value=mock_dispatcher),
+            patch("genesis.guardian.check._handle_healthy", AsyncMock()),
+            patch("genesis.guardian.check._write_guardian_heartbeat", AsyncMock()),
+            patch("genesis.guardian.check.load_secrets", return_value={}),
+        ):
+            await run_check(config)
+
+        titles = _alert_titles(mock_dispatcher)
+        assert not [t for t in titles if "recovered" in t.lower()], titles
+
+
 class TestGuardianAlertOnce:
     """GUARD-R2-01 — alert once per down-episode + a single 'restored' ping.
 

--- a/tests/test_guardian/test_host_import_contract.py
+++ b/tests/test_guardian/test_host_import_contract.py
@@ -1,0 +1,133 @@
+"""The host Guardian's venv is pyyaml and nothing else — guard that contract.
+
+`scripts/install_guardian.sh` creates the Guardian venv and installs exactly
+`pyyaml`. So every module the host-side Guardian imports must resolve using the
+standard library plus yaml. Nothing else is available, and there is no other
+`pip install` anywhere in the install or gateway path.
+
+This is easy to break invisibly: `genesis.observability` looks like a natural
+home for a `/proc` helper, but importing ANY of its submodules executes that
+package's `__init__`, which pulls `aiohttp` and `aiosqlite`. The failure does not
+appear in CI (the container venv has both), in review (the import line looks
+ordinary), or in a file-presence check of the deploy path (the file IS shipped).
+It appears on the host, as a ModuleNotFoundError before the tick's `try:`, which
+means no heartbeat and no `save_state` — so the container watchdog sees a stale
+heartbeat and restart-loops a Guardian that fails identically every time. The
+recovery brain stops watching, which is worse than the bug being fixed.
+
+Each import runs in a SUBPROCESS with the absent packages blocked at the meta
+path, so one module's success cannot mask another's failure through a warm
+`sys.modules`, and nothing leaks into the rest of the suite.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# The host venv is the standard library plus pyyaml. Expressed as an ALLOWLIST,
+# not a list of known-absent packages: a denylist can only ever catch the
+# dependencies somebody already thought of, and the whole point of this guard is
+# the one nobody thought of. MEASURED in the container venv, importable and
+# invisible to a denylist of the obvious names: requests, psutil, pydantic,
+# dotenv, jinja2, bs4, tiktoken, websockets, rich, tenacity — any of which would
+# reproduce the original failure on the host.
+_HOST_ALLOWED = "sys.stdlib_module_names | {'yaml', '_yaml', 'genesis'}"
+
+# Modules the host actually executes. `check` is the tick, but `__main__` is the
+# entry point and dispatches the gateway verbs, several of which import modules
+# that are NOT in check's transitive closure — measured, not assumed.
+_HOST_MODULES = (
+    "genesis.guardian.__main__",
+    "genesis.guardian.check",
+    "genesis.guardian.state_machine",
+    "genesis.guardian.recovery",
+    "genesis.guardian.diagnosis",
+    "genesis.guardian.collector",
+    "genesis.guardian.host_profile",       # --host-profile
+    "genesis.guardian.bundle_watch",       # --bundle-status
+    "genesis.guardian.memory_watch",       # --ram-status
+    "genesis.guardian.grow_capacity",      # provisioning verbs
+    "genesis.guardian.provisioning.flow",
+    "genesis.guardian.provisioning.ledger",
+    "genesis.guardian.provisioning.expand",
+    "genesis.guardian.repo_bundle",
+    "genesis.guardian.credential_bridge",
+    "genesis.env",
+    "genesis.util.host_boot",
+)
+
+_PROBE = """
+import importlib.abc, sys
+# Pin THIS worktree's src ahead of any installed genesis, so the probe tests the
+# code under review rather than whatever is on site-packages.
+sys.path.insert(0, {src!r})
+ALLOWED = {allowed}
+
+class Blocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] not in ALLOWED:
+            raise ModuleNotFoundError(
+                "No module named %r (host venv = stdlib + pyyaml only)" % name
+            )
+        return None
+
+sys.meta_path.insert(0, Blocker())
+mod = __import__({module!r})
+# Prove the worktree copy was the one imported. A future switch to a
+# finder-based editable install would beat sys.path and silently make every
+# assertion here vacuous.
+resolved = sys.modules[{module!r}].__file__ or ""
+assert resolved.startswith({src!r}), "imported %s, not the worktree copy" % resolved
+print("OK")
+"""
+
+
+def _import_under_minimal_venv(module: str, repo_root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable, "-c",
+            _PROBE.format(
+                src=str(repo_root / "src"),
+                allowed=_HOST_ALLOWED,
+                module=module,
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=repo_root,
+    )
+
+
+@pytest.fixture(scope="module")
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize("module", _HOST_MODULES)
+def test_host_module_imports_without_container_only_dependencies(
+    module: str,
+    repo_root: Path,
+) -> None:
+    result = _import_under_minimal_venv(module, repo_root)
+    assert result.returncode == 0, (
+        f"{module} does not import on the host Guardian's venv:\n{result.stderr}\n"
+        "Something in its import chain needs a package install_guardian.sh does "
+        "not install. Move the dependency-free part into genesis/util/ (stdlib-only, "
+        "already imported host-side) rather than importing genesis.observability."
+    )
+
+
+def test_the_probe_actually_blocks(repo_root: Path) -> None:
+    """Control — without this, a probe that silently imports nothing would report
+    every module clean and the guard above would be inert."""
+    result = _import_under_minimal_venv("genesis.observability.cc_slots", repo_root)
+    assert result.returncode != 0, (
+        "the blocker did not fire: genesis.observability pulls aiohttp via its "
+        "package __init__, so this import MUST fail under a minimal venv"
+    )
+    assert "aiohttp" in result.stderr

--- a/tests/test_guardian/test_state_machine.py
+++ b/tests/test_guardian/test_state_machine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -434,3 +435,219 @@ class TestDownAlertFlag:
         sm.mark_down_alert_sent()
         sm._reset_to_healthy("2026-06-16T00:00:00+00:00")
         assert sm.state.down_alert_sent is True
+
+
+class TestRebootResetsTheEpisode:
+    """The Guardian's escalation ladder must not resume mid-climb after a host
+    reboot.
+
+    `load_state` restores StateData verbatim (fresh only on corruption), and the
+    300s bootstrap grace is consulted from exactly ONE transition —
+    CONFIRMING->SURVEYING. So after a reboot: past CONFIRMING the grace is never
+    reached, and inside CONFIRMING `elapsed` is computed from the persisted
+    PRE-reboot `first_failure_at` and is already expired on arrival. Meanwhile
+    the container legitimately IS bootstrapping and needs the full window.
+
+    Resetting to HEALTHY re-arms the grace that already works, via the normal
+    HEALTHY->SIGNAL_DROPPED->CONFIRMING path — rather than adding a second
+    mechanism beside it.
+    """
+
+    BOOT_A = "1a2b3c4d-0000-4111-8000-000000000001"
+    BOOT_B = "9f1c2d3e-0000-4444-8888-aaaabbbbcccc"
+
+    def _rebooted(self, sm: ConfirmationStateMachine, *, was: GuardianState) -> bool:
+        sm._state.current_state = was
+        sm._state.boot_id = self.BOOT_A
+        return sm.reset_if_rebooted(self.BOOT_B)
+
+    def test_reboot_resets_the_episode(self, sm: ConfirmationStateMachine) -> None:
+        sm._state.first_failure_at = "2026-03-25T11:50:00+00:00"
+        sm._state.consecutive_failures = 4
+        sm._state.recheck_count = 3
+        assert self._rebooted(sm, was=GuardianState.CONFIRMED_DEAD) is True
+        assert sm.state.current_state is GuardianState.HEALTHY
+        assert sm.state.first_failure_at is None
+        assert sm.state.consecutive_failures == 0
+        assert sm.state.recheck_count == 0
+
+    def test_same_boot_leaves_an_in_flight_episode_alone(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        sm._state.current_state = GuardianState.SURVEYING
+        sm._state.boot_id = self.BOOT_A
+        assert sm.reset_if_rebooted(self.BOOT_A) is False
+        assert sm.state.current_state is GuardianState.SURVEYING
+
+    def test_legacy_state_adopts_the_boot_id_without_resetting(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        # A state.json written before this field existed has boot_id == "".
+        # Treating that as a reboot would wipe a live episode on the very tick
+        # the new code first runs, on every install.
+        sm._state.current_state = GuardianState.SURVEYING
+        assert sm.state.boot_id == ""
+        assert sm.reset_if_rebooted(self.BOOT_B) is False
+        assert sm.state.current_state is GuardianState.SURVEYING
+        assert sm.state.boot_id == self.BOOT_B
+
+    def test_unreadable_boot_time_does_not_reset(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        # Fail OPEN. A false positive silently discards an in-flight episode,
+        # which is worse than carrying a stale one for another tick.
+        sm._state.current_state = GuardianState.SURVEYING
+        sm._state.boot_id = self.BOOT_A
+        assert sm.reset_if_rebooted(None) is False
+        assert sm.state.current_state is GuardianState.SURVEYING
+
+    def test_reboot_clears_dialogue_state(self, sm: ConfirmationStateMachine) -> None:
+        # The dialogue counterparty lives in the container and is gone across a
+        # reboot; a stale sentinel_state would later be read as "proceed".
+        sm._state.dialogue_sent_at = "2026-03-25T11:50:00+00:00"
+        sm._state.dialogue_eta_s = 120
+        sm._state.dialogue_action = "self_heal"
+        sm._state.sentinel_state = "investigating"
+        self._rebooted(sm, was=GuardianState.AWAITING_SELF_HEAL)
+        assert sm.state.dialogue_sent_at is None
+        assert sm.state.dialogue_eta_s == 0
+        assert sm.state.dialogue_action is None
+        assert sm.state.sentinel_state == ""
+
+    # ── the bounded behaviours a reset must NOT re-enable ──────────────
+
+    def test_reboot_preserves_recovery_attempts(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        """RESTART_CONTAINER and SNAPSHOT_ROLLBACK *cause* reboots. Zeroing the
+        escalation budget on a reboot the Guardian itself triggered turns a
+        bounded 3-rung ladder into an unbounded loop."""
+        sm._state.recovery_attempts = 2
+        sm._state.last_recovery_at = "2026-03-25T11:50:00+00:00"
+        self._rebooted(sm, was=GuardianState.RECOVERING)
+        assert sm.state.recovery_attempts == 2
+        assert sm.state.last_recovery_at == "2026-03-25T11:50:00+00:00"
+
+    def test_reboot_preserves_io_triage_budget(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        """IO_TRIAGE kills processes. Its budget resetting on every reboot would
+        grant unlimited kills to a box in a reboot loop."""
+        sm._state.io_triage_attempts = 4
+        self._rebooted(sm, was=GuardianState.RECOVERING)
+        assert sm.state.io_triage_attempts == 4
+
+    def test_reboot_preserves_auto_reset_count(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        """The confirmed-dead oscillation guard, capped at max_auto_resets."""
+        sm._state.auto_reset_count = 2
+        self._rebooted(sm, was=GuardianState.CONFIRMED_DEAD)
+        assert sm.state.auto_reset_count == 2
+
+    def test_reboot_preserves_down_alert_latch(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        """GUARD-R2-01's one-alert-per-episode latch. Clearing it on a reboot
+        sends a fresh CRITICAL every 30s to a box in a reboot loop — which is
+        exactly the situation where reboots are observed."""
+        sm.mark_down_alert_sent()
+        self._rebooted(sm, was=GuardianState.CONFIRMED_DEAD)
+        assert sm.state.down_alert_sent is True
+
+    def test_reboot_preserves_the_snapshot_size_baseline(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        """Not a counter — the disk-space baseline gating safe_to_snapshot().
+        It is also aliased by reference from check.py and recovery.py, so the
+        SAME list object must survive, not just equal contents."""
+        history = sm._state.snapshot_size_history
+        history.extend([4096, 8192, 49430528])
+        self._rebooted(sm, was=GuardianState.RECOVERING)
+        assert sm.state.snapshot_size_history == [4096, 8192, 49430528]
+        assert sm.state.snapshot_size_history is history, (
+            "re-binding a fresh list detaches the aliases held by check.py/recovery.py"
+        )
+
+    def test_reboot_preserves_pause_state_through_the_next_tick(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        """User sovereignty: resetting these re-arms an already-sent reminder.
+
+        Asserted through a following `process()`, not just on the field. Forcing
+        current_state to HEALTHY would make `_handle_paused` treat the next tick
+        as a NEW pause and rewrite paused_since — so a field-only assertion would
+        pass while the value survived exactly zero ticks.
+        """
+        # A RECENT pause, so the 24h long-pause reminder does not legitimately
+        # fire and overwrite last_pause_reminder_at — that would be correct
+        # behaviour masquerading as a failure of the thing under test.
+        paused_at = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        sm._state.paused_since = paused_at
+        sm._state.last_pause_reminder_at = None
+        self._rebooted(sm, was=GuardianState.PAUSED)
+        sm.process(_paused_snapshot())
+        assert sm.state.paused_since == paused_at, (
+            "forcing PAUSED to HEALTHY makes the next tick read as a NEW pause, "
+            "restarting the long-pause reminder clock on every host reboot"
+        )
+
+    def test_reboot_clears_stale_signal_history(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        # check.py quotes signal_history[-5:] into three alert bodies. Carrying
+        # pre-reboot signals across makes a post-reboot alert read as if the
+        # episode were contiguous.
+        sm._state.signal_history.append(
+            {"at": "2026-03-25T11:50:00+00:00", "all_alive": False, "failed": ["health_api"]},
+        )
+        self._rebooted(sm, was=GuardianState.CONFIRMED_DEAD)
+        assert sm.state.signal_history == []
+
+    def test_reboot_clears_cc_unavailable_tracking(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        # Tracks a CC outage episode on the HOST; the host just rebooted, so its
+        # CC state is new.
+        sm.set_cc_unavailable()
+        sm.record_cc_unavailable_alert()
+        self._rebooted(sm, was=GuardianState.CONFIRMED_DEAD)
+        assert sm.state.cc_unavailable_since is None
+        assert sm.state.last_cc_unavailable_alert_at is None
+
+    def test_boot_id_survives_a_save_load_round_trip(
+        self, config: GuardianConfig, tmp_path: Path,
+    ) -> None:
+        sm = ConfirmationStateMachine(config)
+        sm._state.boot_id = self.BOOT_A
+        state_file = tmp_path / "state.json"
+        sm.save_state(state_file)
+
+        sm2 = ConfirmationStateMachine(config)
+        sm2.load_state(state_file)
+        assert sm2.state.boot_id == self.BOOT_A
+
+    def test_a_non_string_boot_id_on_disk_does_not_raise(
+        self, config: GuardianConfig, tmp_path: Path,
+    ) -> None:
+        # The gateway's reset-state verb read-modify-writes this same JSON, and a
+        # hand-edited file is plausible. An uncoerced value would raise inside the
+        # comparison — before the heartbeat write and the finally: save_state.
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({"current_state": "healthy", "boot_id": 12345}))
+        sm = ConfirmationStateMachine(config)
+        sm.load_state(state_file)
+        assert sm.state.boot_id == "12345"
+        assert sm.reset_if_rebooted(self.BOOT_A) is True
+
+    def test_post_reboot_failure_gets_the_full_bootstrap_grace(
+        self, sm: ConfirmationStateMachine,
+    ) -> None:
+        """The point of the reset: a fresh first_failure_at means CONFIRMING
+        holds for the whole grace window instead of arriving already expired."""
+        sm._state.first_failure_at = "2020-01-01T00:00:00+00:00"  # long expired
+        self._rebooted(sm, was=GuardianState.CONFIRMING)
+        sm.process(_dead_snapshot(["health_api"]))   # HEALTHY -> SIGNAL_DROPPED
+        sm.process(_dead_snapshot(["health_api"]))   # -> CONFIRMING, fresh onset
+        assert sm.state.current_state is GuardianState.CONFIRMING
+        assert sm._is_within_bootstrap_grace() is True

--- a/tests/test_util/test_host_boot.py
+++ b/tests/test_util/test_host_boot.py
@@ -1,0 +1,69 @@
+"""Tests for genesis.util.host_boot.
+
+This primitive decides whether the Guardian drops a live escalation episode, so
+its failure mode matters more than its happy path: `None` must mean "cannot
+tell", never "rebooted". A `read_boot_id` that always returned falsy would make
+`reset_if_rebooted` a permanent no-op and the whole feature silently dead —
+measured as a GREEN mutation before these tests existed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from genesis.util import host_boot
+
+_UUID = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+
+@pytest.fixture()
+def fake_proc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Repoint the module's `_PROC` seam at a fake tree and return the boot_id path."""
+    boot_id = tmp_path / "sys" / "kernel" / "random" / "boot_id"
+    boot_id.parent.mkdir(parents=True)
+    monkeypatch.setattr(host_boot, "_PROC", str(tmp_path))
+    return boot_id
+
+
+def test_reads_the_value_and_strips_the_trailing_newline(fake_proc: Path) -> None:
+    fake_proc.write_text("1a2b3c4d-0000-4111-8000-000000000001\n")
+    assert host_boot.read_boot_id() == "1a2b3c4d-0000-4111-8000-000000000001"
+
+
+def test_blank_content_reads_as_cannot_tell(fake_proc: Path) -> None:
+    # An empty string would compare unequal to a stored id and be read as a
+    # reboot, discarding a live episode. It must be None instead.
+    fake_proc.write_text("   \n")
+    assert host_boot.read_boot_id() is None
+
+
+def test_missing_file_reads_as_cannot_tell(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(host_boot, "_PROC", str(tmp_path / "nonexistent"))
+    assert host_boot.read_boot_id() is None
+
+
+def test_undecodable_content_reads_as_cannot_tell(fake_proc: Path) -> None:
+    # UnicodeDecodeError is a ValueError, not an OSError — the real /proc file is
+    # ASCII, but the contract must hold for anything the seam can be pointed at.
+    fake_proc.write_bytes(b"\xff\xfe not utf-8")
+    assert host_boot.read_boot_id() is None
+
+
+def test_the_real_kernel_path_yields_a_uuid() -> None:
+    """Guards the PATH itself. Every test above would pass with a typo'd
+    filename, since a missing file is a legitimate 'cannot tell'."""
+    value = host_boot.read_boot_id()
+    assert value is not None, "/proc/sys/kernel/random/boot_id was not readable"
+    assert _UUID.match(value), f"not a boot UUID: {value!r}"
+
+
+def test_the_value_is_stable_within_one_boot() -> None:
+    # The whole design rests on this: two of the Guardian's oneshot processes in
+    # the same boot must agree, or every tick would look like a reboot.
+    assert host_boot.read_boot_id() == host_boot.read_boot_id()


### PR DESCRIPTION
## What

The Guardian's state file is its only continuity — each timer tick is a fresh `Type=oneshot`
process — and `load_state` restored it verbatim, starting fresh only on corruption. The
300s bootstrap grace is consulted from **exactly one transition of nine**
(`CONFIRMING → SURVEYING`).

So after a host reboot the escalation ladder resumed wherever it left off:

- **past CONFIRMING** — the grace was never reached at all;
- **inside CONFIRMING** — it was measured from the persisted *pre-reboot*
  `first_failure_at` and had already expired on arrival.

Against a container that was legitimately still bootstrapping, and a ladder whose upper
rungs kill processes, drop page cache, revert commits and restore snapshots.

## How

Reset to HEALTHY so the normal `HEALTHY → SIGNAL_DROPPED → CONFIRMING` path stamps a fresh
onset — re-arming the grace that already works rather than adding a second mechanism.
It deliberately does **not** call `_reset_to_healthy`, which zeroes three values that must
survive.

**Preserved, all bounded behaviours:** `recovery_attempts`, `io_triage_attempts`,
`auto_reset_count` — a reboot is not evidence the incident is over, and refunding these
turns a bounded ladder into an unbounded loop on a box that is reboot-cycling, which is the
box where reboots get observed. `down_alert_sent` (clearing it sends a fresh CRITICAL every
30s). `snapshot_size_history` — the disk-space baseline, aliased **by reference** from the
snapshot manager, so the same list object survives. `PAUSED` is excluded from the reset
entirely: forcing it to HEALTHY made the next tick read as a *new* pause and restarted the
long-pause reminder clock.

**Boot identity is `/proc/sys/kernel/random/boot_id`**, a per-boot UUID — not `/proc/stat`
btime. btime is wall-clock minus uptime, so it moves by the full amount of any NTP step or
a suspend/resume, which would read as a reboot and discard a live episode: the one false
positive this must avoid. A UUID needs no tolerance, no direction reasoning, no drift anchor.

## The import contract — and the bug an earlier revision had

The primitive lives in `genesis/util/host_boot.py` and is **stdlib-only on purpose**. The
host Guardian venv installs `pyyaml` and nothing else (`install_guardian.sh:447-448`), and
importing anything under `genesis.observability` executes that package's `__init__`, which
pulls `aiohttp`/`aiosqlite`.

An earlier revision of this change did exactly that. The import sat *before* the tick's
`try:`, so on the host it would have raised, skipped the heartbeat and the
`finally: save_state`, and been restart-looped by the container watchdog — **the recovery
brain silently ceasing to watch, which is worse than the bug being fixed.** Verifying that
the file ships (`GUARDIAN_PATHS`) was not enough; the constraint is the import chain.

So the **class** is guarded, not the instance: `test_host_import_contract.py` imports every
host-side Guardian module in a subprocess with everything outside the stdlib and `pyyaml`
blocked — expressed as an **allowlist**, because a denylist only catches the dependency
somebody already thought of. (Measured: `requests`, `psutil`, `pydantic`, `jinja2` and six
others were importable and invisible to the denylist first written.) It carries a control
asserting the blocker fires, and asserts the worktree copy is the one imported.

**Acceptance-replayed:** restoring the original bad import turns that guard RED.

## Also fixed

The "Genesis recovered" ping was gated on the previous state being `CONFIRMED_DEAD`.
Anything that reset the state first swallowed it, leaving `down_alert_sent` stuck true and
**permanently muting every later down-alert**. Pre-existing (`AWAITING_SELF_HEAL → HEALTHY`
and the auto-reset both hit it), but this change makes it guaranteed rather than occasional,
so it is fixed here. The flag alone is the right predicate.

## Verification

- 134 passed across `test_check` / `test_state_machine` / `test_host_import_contract` /
  `test_util/test_host_boot`; `ruff` clean.
- **Verify-RED, per mechanism**, M0 control green, hash-verified restore. Three mutations
  that were *green before this round* are now RED: re-adding the `old_state` gate,
  `read_boot_id` always falsy, and deleting the `run_check` call site entirely. Plus:
  adopt-legacy removed, fail-open removed, same-boot check removed,
  uses-`_reset_to_healthy`, PAUSED exclusion removed, `signal_history` clear removed,
  `cc_unavailable` clear removed, `boot_id` coercion removed.
- Live: the import contract measured against a simulated minimal venv **with controls both
  ways**, and `read_boot_id` against the real kernel path.

## Caveats

- The reset only fires on an actual **host** reboot — `boot_id` does not change on a bare
  `incus restart`. Correct (the Guardian and the state it protects are both host-side), and
  stated in the docstring so nobody assumes wider coverage.
- The ladder has never executed on this install, so the reboot path cannot be exercised
  before deploy. Guardian code reaches the host only via `scripts/update.sh`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guardian episodes now reset correctly after a host reboot while preserving recovery attempts and paused state.
  * Recovery notifications are sent consistently after successful recovery, including post-reboot and self-healing scenarios.
  * Reboot detection safely handles unavailable or malformed boot information.

* **Tests**
  * Added coverage for reboot recovery, state persistence, notification behavior, and host-environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->