### PR TITLE
fix(autonomy): name the unit the watchdog actually monitors

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1048,7 +1048,8 @@ verified: 84c7259d 2026-08-31
 - **autonomy zombie-scheduler watchdog** (`autonomy/watchdog.py`, run out-of-process
   by `genesis-watchdog.timer` every 300s via `watchdog_runner.py`; distinct from the
   container `watchdog.py` above): reads `~/.genesis/status.json` (written by the runtime's
-  `status_writer_loop`) and RESTARTS the bridge/runtime on status-file staleness, or a
+  `status_writer_loop`) and RESTARTS its auto-detected target — genesis-server on any
+  install where that unit file exists, NOT the deprecated relay — on status-file staleness, or a
   specific scheduler on a stale `scheduler_heartbeats` entry (`awareness`/`surplus`,
   `job_health.last_run` age > 900s) — the "zombie scheduler, alive but not dispatching"
   case. Restart is deferred while `heavy_workload` is set (dream cycle), during a boot

--- a/docs/architecture/genesis-v3-self-healing-design.md
+++ b/docs/architecture/genesis-v3-self-healing-design.md
@@ -36,9 +36,10 @@ to the repository root.
 - Max 5 consecutive restart attempts before `WatchdogAction.NOTIFY`
 - Pre-restart config validation: checks `secrets.env` exists with `TELEGRAM_BOT_TOKEN`, compiles bridge module for syntax errors
 - Restarts the **auto-detected** target service — `_detect_target_service()` reuses
-  `observability.service_status._detect_genesis_service()` (is-enabled → is-active →
-  default), which resolves to `genesis-server.service` on a normal install and never
-  targets the deprecated relay when genesis-server is present. Via `systemctl --user
+  `observability.service_status._detect_genesis_service()` (genesis-server unit FILE
+  installed, via `list-unit-files` → else the legacy relay), which resolves to
+  `genesis-server.service` on a normal install and never targets the deprecated relay
+  when genesis-server is present — enabled or not, running or not. Via `systemctl --user
   restart <target>` — never `os.kill()`
 - State persisted in `~/.genesis/watchdog_state.json` (survives process restarts)
 - Also checks `systemctl --user is-active <target>` as a fast-path before staleness check

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -43,6 +43,25 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent.parent.parent / "config" / "autonomy.yaml"
 
+# Restart reasons persisted under an older name, normalised once on load.
+# ~/.genesis/watchdog_state.json survives upgrades, so a rename that stopped
+# matching the old entries would silently reset the flap counter for a full
+# flap_window (6h) — granting flap_threshold extra unrestrained restarts on a
+# service that is ALREADY flapping.
+#
+# Normalising on load rather than matching aliases at compare time keeps the
+# flap filter a plain equality, self-heals the persisted `last_reason` the
+# dashboard renders, and leaves no alias set that could be written without its
+# own current name (which would stop a reason matching its own go-forward
+# history). `restart_history` is pruned to flap_window_s on every write, so this
+# shim goes inert on its own within one window of the rename.
+_LEGACY_REASONS: dict[str, str] = {
+    # Renamed once the watchdog's target became genesis-server: `_detect_genesis_service`
+    # prefers genesis-server whenever that unit FILE is installed, so the old label
+    # named a unit this never monitors.
+    "bridge_inactive": "target_inactive",
+}
+
 
 class WatchdogChecker:
     """Stateless health checker — called by systemd timer or standalone script.
@@ -105,8 +124,10 @@ class WatchdogChecker:
         """Auto-detect which Genesis service to monitor.
 
         Reuses the canonical detector (``observability.service_status``): it
-        probes ``is-enabled`` then ``is-active`` for genesis-server, then the
-        legacy relay, and defaults to genesis-server. It never targets the
+        probes whether the genesis-server unit FILE is installed
+        (``list-unit-files``) and prefers it whenever it is — enabled or not,
+        running or not — falling back to the legacy relay only when that unit is
+        genuinely absent. It never targets the
         deprecated relay when genesis-server is present (the 2026-07-02 §7
         recovery bug: restarting an inactive unit "succeeds" but hides
         genesis-server crash loops) while still recovering a relay-only legacy
@@ -160,12 +181,18 @@ class WatchdogChecker:
         bridge_active = self._is_bridge_active()
         if bridge_active is False:
             if self._bridge_exited_unconfigured():
-                logger.info("Bridge exited unconfigured (exit 2) — skipping restart")
+                logger.info(
+                    "%s exited unconfigured (exit 2) — skipping restart",
+                    self._target_service,
+                )
                 return WatchdogAction.SKIP
-            logger.warning("Bridge service is not active — skipping staleness check, going to restart logic")
+            logger.warning(
+                "%s is not active — skipping staleness check, going to restart logic",
+                self._target_service,
+            )
             # Fall through to backoff/validation/restart below
             state = self._load_state()
-            return self._restart_if_allowed(state, reason="bridge_inactive")
+            return self._restart_if_allowed(state, reason="target_inactive")
 
         # 1. Read status.json
         status = self._read_status()
@@ -227,8 +254,8 @@ class WatchdogChecker:
             return WatchdogAction.SKIP  # Healthy — no action needed
 
         logger.warning(
-            "Status file stale: %.0fs old (threshold %ds) — bridge may be down",
-            staleness_s, self._staleness_threshold,
+            "Status file stale: %.0fs old (threshold %ds) — %s may be down",
+            staleness_s, self._staleness_threshold, self._target_service,
         )
 
         # 3. Stale — attempt restart via shared logic
@@ -580,10 +607,28 @@ class WatchdogChecker:
     def _load_state(self) -> dict:
         if self._state_path.exists():
             try:
-                return json.loads(self._state_path.read_text())
+                return self._normalise_legacy_reasons(
+                    json.loads(self._state_path.read_text()),
+                )
             except (json.JSONDecodeError, OSError):
                 pass
         return {"consecutive_failures": 0, "next_attempt_after": None, "last_reason": None, "last_restart_at": None, "last_check_at": None, "restart_history": []}
+
+    @staticmethod
+    def _normalise_legacy_reasons(state: dict) -> dict:
+        """Rewrite reason strings persisted under a previous name, in place.
+
+        Covers both surfaces that carry one: every `restart_history` entry (which
+        the flap window matches by equality) and `last_reason` (which the
+        dashboard's degraded card renders). Without the second, an operator keeps
+        seeing the retired label until the next restart decision writes over it.
+        """
+        for entry in state.get("restart_history") or []:
+            if isinstance(entry, dict) and entry.get("reason") in _LEGACY_REASONS:
+                entry["reason"] = _LEGACY_REASONS[entry["reason"]]
+        if state.get("last_reason") in _LEGACY_REASONS:
+            state["last_reason"] = _LEGACY_REASONS[state["last_reason"]]
+        return state
 
     def _save_state(self, state: dict) -> None:
         self._state_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -622,10 +622,42 @@ class WatchdogChecker:
         the flap window matches by equality) and `last_reason` (which the
         dashboard's degraded card renders). Without the second, an operator keeps
         seeing the retired label until the next restart decision writes over it.
+
+        It also DROPS entries the rest of the class cannot read. Three separate
+        sites filter `restart_history` with ``h.get("reason")`` and
+        ``now - h.get("ts", 0)``, so a persisted entry that is not a dict, or
+        whose timestamp is not a number, takes the watchdog down with an
+        AttributeError or a TypeError — MEASURED on both shapes. Skipping such an
+        entry here (the previous behaviour) left it in the list for those three
+        readers to trip over.
+
+        Filtering at this ONE load path is deliberate: it is the only way state
+        enters the checker, so the three readers cannot each forget the guard.
+        The alternative — teaching every filter to skip malformed entries — is a
+        convention three call sites have to remember, and a fourth reader would
+        reintroduce the crash.
+
+        Valid unrelated entries are kept: a malformed neighbour must not discard
+        real flap history, or a corrupt write would silently reset the damping
+        that stops a restart loop.
         """
-        for entry in state.get("restart_history") or []:
-            if isinstance(entry, dict) and entry.get("reason") in _LEGACY_REASONS:
-                entry["reason"] = _LEGACY_REASONS[entry["reason"]]
+        history = state.get("restart_history") or []
+        if isinstance(history, list):
+            kept = []
+            for entry in history:
+                if not isinstance(entry, dict):
+                    continue
+                ts = entry.get("ts", 0)
+                # bool is a subclass of int; a True timestamp is not a time.
+                if isinstance(ts, bool) or not isinstance(ts, (int, float)):
+                    continue
+                if entry.get("reason") in _LEGACY_REASONS:
+                    entry["reason"] = _LEGACY_REASONS[entry["reason"]]
+                kept.append(entry)
+            state["restart_history"] = kept
+        else:
+            # Not even a list — the shape below it cannot be trusted either.
+            state["restart_history"] = []
         if state.get("last_reason") in _LEGACY_REASONS:
             state["last_reason"] = _LEGACY_REASONS[state["last_reason"]]
         return state

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -566,10 +566,77 @@ class TestLegacyReasonNormalisation:
 
     def test_a_malformed_history_entry_does_not_raise(self, tmp_path: Path):
         # The file is hand-editable and shared with the dashboard; a non-dict
-        # entry must not take the whole tick down on load.
-        self._write(tmp_path, {"restart_history": ["not-a-dict", None]})
+        # entry must not take the whole tick down.
+        #
+        # This assertion used to be `== ["not-a-dict", None]` — it proved LOAD
+        # survives, which was never where the crash was. Three sites filter the
+        # history with `h.get("reason")` and `now - h.get("ts", 0)`, so the
+        # entry took the watchdog down on the next DECISION instead. Assert
+        # through the decision path, not the load.
+        self._write(tmp_path, {
+            "consecutive_failures": 0,
+            "next_attempt_after": None,
+            "restart_history": ["not-a-dict", None],
+        })
         checker = _make_checker(tmp_path, tmp_path / "status.json")
-        assert checker._load_state()["restart_history"] == ["not-a-dict", None]
+        state = checker._load_state()
+        assert state["restart_history"] == [], "unreadable entries must be dropped"
+        # The real crash site: this raised AttributeError before the fix.
+        assert (
+            checker._restart_if_allowed(state, reason="target_inactive")
+            is WatchdogAction.RESTART
+        )
+
+    @pytest.mark.parametrize(
+        "bad_ts", ["yesterday", None, True, [1], {"t": 1}],
+        ids=["str", "none", "bool", "list", "dict"],
+    )
+    def test_a_non_numeric_timestamp_is_dropped(self, tmp_path: Path, bad_ts: object):
+        """`now - h.get("ts", 0)` raises TypeError on anything unsubtractable.
+
+        `True` is in the set deliberately: bool is a subclass of int, so a naive
+        `isinstance(ts, int)` check admits it, and a timestamp of True is not a
+        time even though the arithmetic happens to work.
+        """
+        self._write(tmp_path, {
+            "consecutive_failures": 0,
+            "next_attempt_after": None,
+            "restart_history": [{"ts": bad_ts, "reason": "x"}],
+        })
+        checker = _make_checker(tmp_path, tmp_path / "status.json")
+        state = checker._load_state()
+        assert state["restart_history"] == []
+        assert (
+            checker._restart_if_allowed(state, reason="target_inactive")
+            is WatchdogAction.RESTART
+        )
+
+    def test_a_malformed_neighbour_does_not_discard_real_history(
+        self, tmp_path: Path, stale_status: Path,
+    ):
+        """Dropping the whole list would silently reset flap damping.
+
+        A corrupt write next to three genuine entries must not hand a flapping
+        service `flap_threshold` more unrestrained restarts — which is the exact
+        failure this class's docstring says the normalisation exists to prevent.
+        """
+        now = time.time()
+        self._write(tmp_path, {
+            "consecutive_failures": 0,
+            "next_attempt_after": None,
+            "restart_history": (
+                ["not-a-dict"]
+                + [{"ts": now - 5, "reason": "target_inactive"} for _ in range(3)]
+                + [{"ts": "bad", "reason": "target_inactive"}]
+            ),
+        })
+        checker = _make_checker(tmp_path, stale_status, flap_threshold=3, backoff_max_s=10)
+        state = checker._load_state()
+        assert len(state["restart_history"]) == 3, "the valid entries must survive"
+        assert (
+            checker._restart_if_allowed(state, reason="target_inactive")
+            is WatchdogAction.BACKOFF
+        ), "damping must still fire — the malformed neighbours must not reset it"
 
 
 class TestTargetActiveCheck:

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -193,6 +193,30 @@ class TestFlapDamping:
             is WatchdogAction.RESTART
         )
 
+    def test_reason_damps_against_its_own_history(
+        self, tmp_path: Path, stale_status: Path,
+    ):
+        """The go-forward case, and the one a rename can silently break: a reason
+        must match the history it is itself writing."""
+        checker = _make_checker(tmp_path, stale_status, flap_threshold=3, backoff_max_s=10)
+        assert (
+            checker._restart_if_allowed(
+                self._seed(3, reason="target_inactive"), reason="target_inactive",
+            )
+            is WatchdogAction.BACKOFF
+        )
+
+    def test_unrelated_reasons_still_do_not_cross_count(
+        self, tmp_path: Path, stale_status: Path,
+    ):
+        checker = _make_checker(tmp_path, stale_status, flap_threshold=3, backoff_max_s=10)
+        assert (
+            checker._restart_if_allowed(
+                self._seed(3, reason="zombie_scheduler"), reason="target_inactive",
+            )
+            is WatchdogAction.RESTART
+        )
+
     def test_different_reasons_dont_cross_count(self, tmp_path: Path, stale_status: Path):
         checker = _make_checker(tmp_path, stale_status, flap_threshold=3, backoff_max_s=10)
         now = time.time()
@@ -395,21 +419,174 @@ class TestConfigValidation:
         assert not any("Secrets" in i for i in issues)
 
 
-class TestBridgeActiveCheck:
+class TestInactiveTargetReasonLabel:
+    """The reason string reaches an operator: it is written to `last_reason` in
+    the watchdog state file, rendered on the dashboard's degraded card, and
+    interpolated into the deploy-defer log line.
+
+    It read `bridge_inactive` while the unit it actually monitors is
+    genesis-server (`_detect_genesis_service` prefers genesis-server whenever
+    that unit FILE is installed — `is-active` is not consulted). A reader who
+    saw the log concluded the watchdog was chasing genesis-bridge, a unit that
+    has been dead for two months, and the misdiagnosis cost a whole
+    investigation before the code said otherwise.
+    """
+
+    def test_reason_names_the_target_not_the_legacy_relay(
+        self, tmp_path: Path, fresh_status: Path,
+    ):
+        checker = _make_checker(tmp_path, fresh_status)
+        with (
+            patch.object(checker, "_is_bridge_active", return_value=False),
+            patch.object(checker, "_bridge_exited_unconfigured", return_value=False),
+            patch.object(checker, "_restart_if_allowed") as restart,
+        ):
+            checker.check()
+        assert restart.call_args.kwargs["reason"] == "target_inactive", (
+            "the reason is operator-facing; naming a unit this watchdog does not "
+            "monitor sends the reader after the wrong service"
+        )
+
+    def test_deploy_defer_covers_the_inactive_target_path(
+        self, tmp_path: Path, fresh_status: Path,
+    ):
+        # watchdog.py guards this path with update_in_progress() too, but only
+        # the STALE path had a test for it.
+        checker = _make_checker(tmp_path, fresh_status)
+        with (
+            patch.object(checker, "_is_bridge_active", return_value=False),
+            patch.object(checker, "_bridge_exited_unconfigured", return_value=False),
+            patch("genesis.autonomy.watchdog.update_in_progress", return_value=True),
+        ):
+            assert checker.check() is WatchdogAction.SKIP
+
+
+class TestOperatorFacingTextNamesTheTarget:
+    """Every journal line this tick emits about the target must name the unit it
+    actually monitors.
+
+    The reason string was not the only surface saying "bridge": the stale-status
+    warning is the COMMON path (it fires on ordinary degradation, not just an
+    inactive unit), so it is the line most likely to be read — and it said
+    "bridge may be down" while the watchdog was monitoring genesis-server.
+    """
+
+    def test_stale_status_warning_names_the_target(
+        self, tmp_path: Path, stale_status: Path, caplog,
+    ):
+        checker = _make_checker(tmp_path, stale_status)
+        checker._target_service = "genesis-server.service"
+        with caplog.at_level("WARNING", logger="genesis.autonomy.watchdog"):
+            checker.check()
+        stale = [r for r in caplog.records if "Status file stale" in r.getMessage()]
+        assert stale, "expected the stale-status warning"
+        assert "genesis-server.service" in stale[0].getMessage()
+        assert "bridge" not in stale[0].getMessage().lower()
+
+    def test_inactive_target_warning_names_the_target(
+        self, tmp_path: Path, fresh_status: Path, caplog,
+    ):
+        checker = _make_checker(tmp_path, fresh_status)
+        checker._target_service = "genesis-server.service"
+        with (
+            patch.object(checker, "_is_bridge_active", return_value=False),
+            patch.object(checker, "_bridge_exited_unconfigured", return_value=False),
+            caplog.at_level("WARNING", logger="genesis.autonomy.watchdog"),
+        ):
+            checker.check()
+        msgs = [r.getMessage() for r in caplog.records if "not active" in r.getMessage()]
+        assert msgs, "expected the inactive-target warning"
+        assert "genesis-server.service" in msgs[0]
+
+    def test_unconfigured_exit_notice_names_the_target(
+        self, tmp_path: Path, fresh_status: Path, caplog,
+    ):
+        checker = _make_checker(tmp_path, fresh_status)
+        checker._target_service = "genesis-server.service"
+        with (
+            patch.object(checker, "_is_bridge_active", return_value=False),
+            patch.object(checker, "_bridge_exited_unconfigured", return_value=True),
+            caplog.at_level("INFO", logger="genesis.autonomy.watchdog"),
+        ):
+            checker.check()
+        msgs = [r.getMessage() for r in caplog.records if "unconfigured" in r.getMessage()]
+        assert msgs, "expected the unconfigured-exit notice"
+        assert "genesis-server.service" in msgs[0]
+
+
+class TestLegacyReasonNormalisation:
+    """`~/.genesis/watchdog_state.json` survives upgrades, so it still carries the
+    reason under its retired name after a rename. Both surfaces that hold one are
+    normalised on load: `restart_history` (matched by equality in the flap
+    window) and `last_reason` (rendered on the dashboard's degraded card).
+
+    Losing the history match would silently reset the flap counter for a full
+    flap_window — granting flap_threshold extra unrestrained restarts to a
+    service that is already flapping.
+    """
+
+    def _write(self, tmp_path: Path, state: dict) -> Path:
+        f = tmp_path / "watchdog_state.json"
+        f.write_text(json.dumps(state))
+        return f
+
+    def test_history_written_under_the_old_name_still_damps(
+        self, tmp_path: Path, stale_status: Path,
+    ):
+        now = time.time()
+        self._write(tmp_path, {
+            "consecutive_failures": 0,
+            "next_attempt_after": None,
+            "restart_history": [
+                {"ts": now - 5, "reason": "bridge_inactive"} for _ in range(3)
+            ],
+        })
+        # _make_checker points the checker at tmp_path/"watchdog_state.json",
+        # which is exactly what _write created.
+        checker = _make_checker(tmp_path, stale_status, flap_threshold=3, backoff_max_s=10)
+        assert (
+            checker._restart_if_allowed(checker._load_state(), reason="target_inactive")
+            is WatchdogAction.BACKOFF
+        )
+
+    def test_last_reason_is_healed_for_the_dashboard(self, tmp_path: Path):
+        self._write(tmp_path, {"last_reason": "bridge_inactive"})
+        checker = _make_checker(tmp_path, tmp_path / "status.json")
+        assert checker._load_state()["last_reason"] == "target_inactive"
+
+    def test_unrelated_reasons_pass_through_untouched(self, tmp_path: Path):
+        self._write(tmp_path, {
+            "last_reason": "zombie_scheduler",
+            "restart_history": [{"ts": 1.0, "reason": "stale_status_restart"}],
+        })
+        checker = _make_checker(tmp_path, tmp_path / "status.json")
+        state = checker._load_state()
+        assert state["last_reason"] == "zombie_scheduler"
+        assert state["restart_history"][0]["reason"] == "stale_status_restart"
+
+    def test_a_malformed_history_entry_does_not_raise(self, tmp_path: Path):
+        # The file is hand-editable and shared with the dashboard; a non-dict
+        # entry must not take the whole tick down on load.
+        self._write(tmp_path, {"restart_history": ["not-a-dict", None]})
+        checker = _make_checker(tmp_path, tmp_path / "status.json")
+        assert checker._load_state()["restart_history"] == ["not-a-dict", None]
+
+
+class TestTargetActiveCheck:
     def test_inactive_bridge_triggers_restart(self, tmp_path: Path, fresh_status: Path):
-        """If bridge is inactive, skip staleness check and go to restart."""
+        """If the target is inactive, skip staleness check and go to restart."""
         checker = _make_checker(tmp_path, fresh_status)
         with patch.object(checker, "_is_bridge_active", return_value=False):
             assert checker.check() is WatchdogAction.RESTART
 
     def test_active_bridge_uses_normal_flow(self, tmp_path: Path, fresh_status: Path):
-        """If bridge is active and status fresh, return SKIP."""
+        """If the target is active and status fresh, return SKIP."""
         checker = _make_checker(tmp_path, fresh_status)
         with patch.object(checker, "_is_bridge_active", return_value=True):
             assert checker.check() is WatchdogAction.SKIP
 
     def test_unknown_bridge_uses_normal_flow(self, tmp_path: Path, fresh_status: Path):
-        """If bridge status unknown (None), fall through to staleness check."""
+        """If target status is unknown (None), fall through to staleness check."""
         checker = _make_checker(tmp_path, fresh_status)
         with patch.object(checker, "_is_bridge_active", return_value=None):
             assert checker.check() is WatchdogAction.SKIP
@@ -1022,7 +1199,7 @@ class TestLivenessRestartGate:
         ):
             assert c.check() is WatchdogAction.SKIP
 
-    def test_bridge_inactive_never_probes(self, tmp_path: Path):
+    def test_inactive_target_never_probes(self, tmp_path: Path):
         # service down = definitionally dead; the probe is not consulted.
         c = _liveness_checker(tmp_path, _stale_file(tmp_path))
         with (


### PR DESCRIPTION
## What

The watchdog reported the reason `bridge_inactive` while the unit it monitors is
**genesis-server**. `_detect_genesis_service` prefers genesis-server whenever that unit
*file* is installed — `is-active` is never consulted — so on any normal install the label
named a service the watchdog never touches.

That string is operator-facing: persisted as `last_reason`, rendered on the dashboard's
degraded card, and interpolated into the deploy-defer log line. A reader took it at face
value, concluded the watchdog was chasing `genesis-bridge` (dead for two months), and lost
a full investigation before the code said otherwise.

## The class was three strings, not one

The first attempt renamed the reason and its log line. Two siblings in the same function
were untouched — and one of them is the **common** path:

| line | text | when it fires |
|---|---|---|
| `watchdog.py:190` | "…is not active…" | inactive target |
| `watchdog.py:185` | "Bridge exited unconfigured (exit 2)" | unconfigured exit |
| `watchdog.py:257` | "…**bridge may be down**" | **ordinary staleness — the usual case** |

Shipping the first alone, an operator greps the journal after this lands, still finds
"bridge may be down", and re-runs the exact investigation this exists to prevent. All three
now name `self._target_service`, held by three `caplog` tests — reverting any of them was
previously a **green** mutation.

## Persisted state

`~/.genesis/watchdog_state.json` survives upgrades, so it still carries the old reason.
Entries are **normalised once on load** rather than matched through an alias at compare time.
That keeps the flap filter a plain equality, heals the persisted `last_reason` the dashboard
renders (an alias would not have), and leaves no alias set that can be written without its
own current name — a mutation that silently stops a reason matching its *own* go-forward
history, which was measured green against the alias version. The shim goes inert on its own:
`restart_history` is pruned to `flap_window_s` on every write.

## Documentation

Two documents and the docstring of the calling function stated the detector's mechanism
incorrectly — "is-enabled → is-active → default", and "RESTARTS the bridge/runtime". It does
neither; it calls `list-unit-files`. Corrected, because authoritative text naming a probe
that is never run is the same defect as the label.

## Deliberately not here

- `_is_bridge_active`, `_bridge_exited_unconfigured`, `restart_bridge` keep their names — 23
  references across four files including a dashboard route, and they are internal
  identifiers an operator never sees.
- An earlier revision also relaxed `_detect_genesis_service`'s relay-only branch to accept
  transient systemd states. **Withdrawn as scope drift**: it changes which unit gets
  *targeted* rather than what gets *printed*, it left its own stated failure case (a
  relay-only install whose relay is `inactive`) unfixed, and on the only path that reaches
  it, it widened the misdetection window that branch's docstring exists to close.

## Verification

- 97 passed in `test_watchdog.py`; 117 across the touched files; `ruff` clean.
- **Verify-RED per mechanism**, M0 control green, hash-verified restore: reason reverted to
  the old name · history normalise removed · `last_reason` normalise removed · normalise not
  wired into load · malformed-entry guard removed · stale-status log un-targeted · inactive
  log un-targeted. All RED.

## Known, accepted

`_alert_flap`'s dedupe key changes with the reason, so an **undrained** alert under the old
key stops suppressing — bounded at exactly one extra queued alert, after which the new key
dedupes normally.

## Noted, not touched

`dashboard/routes/services.py` implements a **second, divergent** detector using
`is-enabled` that defaults to `genesis-bridge.service` on any failure — the inverse of the
canonical fail-toward-server rule. It backs the restart button an operator clicks after
reading the very card this PR fixes. Pre-existing and out of scope; worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved watchdog detection for installed target services, including services that are not enabled or active.
  - Preserved restart safeguards for previously saved watchdog state, including legacy inactivity reasons.
  - Improved handling of malformed restart history while retaining valid entries.
  - Deferred deployment when the target service is inactive.
  - Updated operator-facing status and restart messages to identify `genesis-server.service`.

- **Tests**
  - Expanded coverage for legacy state compatibility, restart dampening, inactive targets, malformed history, and updated watchdog messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->