### PR TITLE
fix: correct the bypass-mode finding, and the guard that rejected it

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -456,18 +456,23 @@ bodies, so legitimate commands get blocked too.
 ### Editing source in bypass/auto mode: reads via Bash, WRITES via Edit/Write
 
 In bypass or auto permission mode the CC binary injects a meta message telling
-the session to prefer Bash (`sed`, heredocs, scripts) over Read/Edit/Write. It
-is gated on permission mode, so it is an EFFICIENCY heuristic and makes no
-correctness claim (provenance + full measurement:
+the session to prefer Bash (`sed`, heredocs, scripts) over Read/Edit/Write —
+and NOT only there: a third selector branch is a cohort assignment, so a
+default-mode session can receive it too. It is an EFFICIENCY heuristic making no
+correctness claim, which follows from how the message is phrased (a preference,
+with its own escape hatch back to the dedicated tools) rather than from where it
+is gated (provenance + full measurement:
 `docs/reference/cc-compatibility.md` "Bypass/auto mode tells the agent to edit
 via Bash"). For reads and search it is simply right — use `cat`/`sed -n`/`grep`/
 `find` freely. For WRITES TO SOURCE it is not: a bare `sed -i` returns exit 0 on
 an absent anchor (silent no-op), rewrites ALL matches of a non-unique one, and
 silently hits the wrong line on a regex-metacharacter anchor where a literal was
-meant — where Edit fails LOUDLY on each. A Bash write also bypasses the five
+meant — where Edit fails LOUDLY on each. A Bash write also fires none of the five
 `Edit|Write` PostToolUse hooks (the repo's own post-edit verification plane) and
-a heredoc sits in the blocked-compound blast radius above. MEASURED: 75% of real
-edit anchors in this repo carry a `sed` metacharacter, so the unsafe case is the
+a heredoc sits in the blocked-compound blast radius above. MEASURED: 54.9% of
+real edit anchors in this repo carry a character `sed` treats as special in BRE,
+its default dialect (2,750 / 5,013; an ERE set scores 74.0% over the same
+corpus, so quote the dialect or the number misleads) — the unsafe case is the
 common one. Use Edit/Write for source; a script that does a literal replace AND
 asserts its occurrence count is acceptable (it re-implements Edit's checks). This
 is universal — the machinery is tracked, so every clone inherits it.

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -453,6 +453,25 @@ to be reverted as cross-branch contamination. Guard false-positives make this
 worse: `shell_parse` mis-parses backslash line-continuations and quoted heredoc
 bodies, so legitimate commands get blocked too.
 
+### Editing source in bypass/auto mode: reads via Bash, WRITES via Edit/Write
+
+In bypass or auto permission mode the CC binary injects a meta message telling
+the session to prefer Bash (`sed`, heredocs, scripts) over Read/Edit/Write. It
+is gated on permission mode, so it is an EFFICIENCY heuristic and makes no
+correctness claim (provenance + full measurement:
+`docs/reference/cc-compatibility.md` "Bypass/auto mode tells the agent to edit
+via Bash"). For reads and search it is simply right — use `cat`/`sed -n`/`grep`/
+`find` freely. For WRITES TO SOURCE it is not: a bare `sed -i` returns exit 0 on
+an absent anchor (silent no-op), rewrites ALL matches of a non-unique one, and
+silently hits the wrong line on a regex-metacharacter anchor where a literal was
+meant — where Edit fails LOUDLY on each. A Bash write also bypasses the five
+`Edit|Write` PostToolUse hooks (the repo's own post-edit verification plane) and
+a heredoc sits in the blocked-compound blast radius above. MEASURED: 75% of real
+edit anchors in this repo carry a `sed` metacharacter, so the unsafe case is the
+common one. Use Edit/Write for source; a script that does a literal replace AND
+asserts its occurrence count is acceptable (it re-implements Edit's checks). This
+is universal — the machinery is tracked, so every clone inherits it.
+
 ### Instance-Fix vs Class-Fix Gate
 
 When a mechanism failed to write or propagate something (a memory, a

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1139,7 +1139,7 @@ The loops that make Genesis think between conversations.
 entry: ambient-cognition
 modules: [awareness, perception, reflection, attention, session_awareness,
           session_charter.py]
-verified: 29a382e7 2026-09-03
+verified: 9730efe9 2026-09-05
 ```
 
 - **PR-watch inline surface (2026-07-21)**: a SessionStart hook
@@ -1340,7 +1340,16 @@ verified: 29a382e7 2026-09-03
   Genesis checkouts (foreign filings counted, never alerted); alerts at
   `critical` — the fast Telegram path, deliberately, because this class went
   unnoticed for a month. Settings lever + env kill switch as usual; disabling
-  RESOLVES the open alert rather than orphaning it.
+  RESOLVES the open alert rather than orphaning it. **Cross-store coupling (do
+  not touch blind):** the watcher's blind-scan guard uses a NON-EMPTY
+  `~/.genesis/sessions/` as its proof that CC has ever run here — without it, a
+  moved CC data root reads as a clean all-clear instead of blindness. That
+  directory is pruned at 60 days by `scripts/disk_hygiene.sh` (step 8b), so the
+  60-day floor is load-bearing for THIS check too: lower it toward a live
+  session's age and the guard silently disarms. The two do not collide today (60d
+  is far past any live session), but the coupling lives only in the script's own
+  comment — recorded here because it is exactly the do-not-touch edge the map is
+  for.
 - **Open-PR resurfacing** (LIVE): a SessionStart surface lists open PRs left
   idle past a threshold, so a ready-but-forgotten PR is re-raised instead of
   rotting. Sibling of the PR-watch surface above (external PR *changes*); this
@@ -1756,7 +1765,7 @@ config resolution, and hygiene utilities.
 entry: platform-data
 modules: [db, runtime, resilience, observability, security, codebase,
           restore, util, infra_profile, onboarding, env.py, _config_overlay.py]
-verified: 50b79ffb 2026-09-01
+verified: 9730efe9 2026-09-05
 ```
 
 - **onboarding/**: the live *functional floor* (`floor.py`) — the honest "is this
@@ -1791,8 +1800,9 @@ verified: 50b79ffb 2026-09-01
   framed, refreshed on return to Overview) is **PR-B2b** — shipped.
 - **db/**: aiosqlite WAL behind `SerializedConnection` (an asyncio.Lock —
   without it interleaved commits pin `in_transaction` until restart). Two
-  schema paths coexist: base DDL (`schema/_tables.py`, 118 CREATE TABLE; docs
-  still say "60+") plus versioned `migrations/` run ONCE at startup before any
+  schema paths coexist: base DDL (`schema/_tables.py`, 117 CREATE TABLE, a count
+  that drifts every table-adding PR — re-measure, do not trust) plus versioned
+  `migrations/` run ONCE at startup before any
   other init step touches data; a failed migration ABORTS bootstrap. Ids are
   92 FROZEN legacy 4-digit ones (`0001`..`0093`, with a GAP at `0092` from a
   rename) plus new `YYYYMMDDHHMMSS_*.py` UTC timestamps — nobody allocates an

--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -1161,13 +1161,23 @@ In bypass or auto permission mode the CC binary injects a meta message:
 > Do your work through the Bash tool wherever it can accomplish the job: read
 > files with cat, head, or sed -n, search with grep and find, and **make file
 > changes with sed, heredocs, or short scripts**, rather than using the
-> dedicated Read, Edit, or Write tools.
+> dedicated Read, Edit, or Write tools. Fall back to a dedicated tool only when
+> Bash genuinely cannot do the job.
 
 **Provenance (established, not inferred):** the text is compiled into the CC
-binary and emitted purely on permission mode (`e.bypass ? … : e.steerOnly ? …`);
-it is in no `settings.json`, `CLAUDE.md`, output-style, or agent file. Because it
-is gated on MODE (where nothing prompts, so the dedicated tools' permission value
-is gone), it is an **efficiency heuristic** — it makes no correctness claim. The
+binary; it is in no `settings.json`, `CLAUDE.md`, output-style, or agent file.
+
+**It reaches a session by three routes, not one.** The selector falls through
+the bypass flag, then the steer-only flag, then — and this is the one that
+matters — a `bashFirst` flag, which is a COHORT assignment
+(`bashFirstSessionAssignment`, resolving to forced/cohort/none) rather than a
+permission mode. **A default-mode session can therefore receive this message.**
+An earlier draft of this section said it was emitted purely on permission mode;
+that was read off a truncated transcription and is wrong.
+
+It is still an **efficiency heuristic** making no correctness claim — but that
+follows from what the message SAYS, not from where it is gated: it is phrased as
+a preference and carries its own escape hatch back to the dedicated tools. The
 same is true of the sibling `AgentTool`/workflows restriction lines: also in the
 binary (`grep -c -a -F` → 2 occurrences each), also not install config. Neither
 is install-specific; both apply to every CC user of this version.
@@ -1190,15 +1200,22 @@ Three reasons the split is correct HERE specifically (all universal to any
 Genesis clone, since the machinery is tracked):
 1. **`sed`'s silent-failure contract** above is `sed`, not this box — a
    mis-anchored edit that changes nothing, or the wrong thing, returns exit 0.
-2. **`Edit`/`Write` fire five PostToolUse hooks** wired in the tracked
+2. **`Edit`/`Write` fire five EDIT-SPECIFIC PostToolUse hooks** wired in the tracked
    `.claude/settings.json` (`edit_verify_advisory`, `file_modification_audit`,
    `edit_failure_sensor`, `subsystem_traps`, `file_context`); a `Bash` write
-   fires none of them — it bypasses the repo's own post-edit verification plane.
+   fires none of them, so the repo's own post-edit verification plane never
+   sees the change.
 3. **Heredoc writes sit in blocked-compound blast radius** — a PreToolUse block
    discards the whole call including the heredoc, silently.
-MEASURED cost of ignoring this in practice: **75.2% of realistic edit anchors in
-this repo carry a `sed` regex metacharacter** (3,678 / 4,892 removed lines ≥8
-chars over 200 commits on `src/` + `scripts/`) — the unsafe case is the common
+MEASURED cost of ignoring this in practice, **and state the dialect or the
+number means nothing**: `sed` uses BRE by default, where `+ ? | ( ) { }` are
+literal. Counting only the characters BRE actually treats as special
+(`. * [ ] ^ $ \`), **54.9% of realistic edit anchors in this repo carry one**
+(2,750 / 5,013 removed lines ≥8 chars over the last 200 non-merge commits on
+`src/` + `scripts/`; re-derivable, 2026-09-06). The same corpus scores 74.0%
+against an ERE set, which is what an earlier revision of this line reported as
+"75.2%" — a real number for the wrong dialect. Either way the unsafe case is the
+common
 one, not a tail. A "short script" that does a literal `str.replace` AND asserts
 its occurrence count is acceptable — it re-implements Edit's two checks by hand.
 

--- a/docs/reference/cc-compatibility.md
+++ b/docs/reference/cc-compatibility.md
@@ -1155,6 +1155,53 @@ typed turn writes no transcript, and "newest transcript" mis-attributes a
 concurrent session's — identify your own transcript by before/after set
 difference and send a real turn.
 
+### Bypass/auto mode tells the agent to edit via Bash — safe for reads, NOT for writes (measured 2.1.246, 2026-09-05)
+
+In bypass or auto permission mode the CC binary injects a meta message:
+> Do your work through the Bash tool wherever it can accomplish the job: read
+> files with cat, head, or sed -n, search with grep and find, and **make file
+> changes with sed, heredocs, or short scripts**, rather than using the
+> dedicated Read, Edit, or Write tools.
+
+**Provenance (established, not inferred):** the text is compiled into the CC
+binary and emitted purely on permission mode (`e.bypass ? … : e.steerOnly ? …`);
+it is in no `settings.json`, `CLAUDE.md`, output-style, or agent file. Because it
+is gated on MODE (where nothing prompts, so the dedicated tools' permission value
+is gone), it is an **efficiency heuristic** — it makes no correctness claim. The
+same is true of the sibling `AgentTool`/workflows restriction lines: also in the
+binary (`grep -c -a -F` → 2 occurrences each), also not install config. Neither
+is install-specific; both apply to every CC user of this version.
+
+**Reads: follow it.** `cat`/`sed -n`/`grep`/`find` are cheaper round-trips and
+carry no correctness cost.
+
+**Writes to source: do NOT use bare `sed -i`. Prefer Edit/Write.** Measured
+contrast (fixtures + results kept locally under `~/tmp/edit-probe/`, pre-registered
+decision rule):
+
+| case | `sed -i` | Edit |
+|---|---|---|
+| anchor absent | exit 0, file unchanged, **no error** (silent no-op) | refuses: "String to replace not found" |
+| anchor non-unique (×3) | exit 0, **replaces all 3**, incl. unrelated lines | refuses, names the count, demands `replace_all` |
+| anchor with regex metachar, literal intent | exit 0, **wrong-target rewrite or silent no-op** | applied correctly (literal match) |
+| control: valid unique anchor | applied | applied |
+
+Three reasons the split is correct HERE specifically (all universal to any
+Genesis clone, since the machinery is tracked):
+1. **`sed`'s silent-failure contract** above is `sed`, not this box — a
+   mis-anchored edit that changes nothing, or the wrong thing, returns exit 0.
+2. **`Edit`/`Write` fire five PostToolUse hooks** wired in the tracked
+   `.claude/settings.json` (`edit_verify_advisory`, `file_modification_audit`,
+   `edit_failure_sensor`, `subsystem_traps`, `file_context`); a `Bash` write
+   fires none of them — it bypasses the repo's own post-edit verification plane.
+3. **Heredoc writes sit in blocked-compound blast radius** — a PreToolUse block
+   discards the whole call including the heredoc, silently.
+MEASURED cost of ignoring this in practice: **75.2% of realistic edit anchors in
+this repo carry a `sed` regex metacharacter** (3,678 / 4,892 removed lines ≥8
+chars over 200 commits on `src/` + `scripts/`) — the unsafe case is the common
+one, not a tail. A "short script" that does a literal `str.replace` AND asserts
+its occurrence count is acceptable — it re-implements Edit's two checks by hand.
+
 ## Known Risks
 
 ### Rebase-Like Risk for CC

--- a/tests/test_hooks/test_no_published_bypass_recipes.py
+++ b/tests/test_hooks/test_no_published_bypass_recipes.py
@@ -127,7 +127,7 @@ _CONCESSIVE = (
 # An exemption broadened from anchored to unanchored loosens a gate while
 # reading as a tightening — the failure this file exists to prevent, committed
 # inside this file.
-_MODE_NAME_RE = re.compile(r"bypass(?:/|\s+or\s+)auto\b\s*(?:permission\s+)?mode\b")
+_MODE_NAME_RE = re.compile(r"\bbypass(?:/|\s+or\s+)auto\b\s*(?:permission\s+)?mode\b")
 
 # How close the two halves must be to read as one claim. A construct in one
 # paragraph and the word "bypass" three paragraphs later is not a recipe.
@@ -321,6 +321,10 @@ def test_markdown_carries_no_bypass_recipe():
         ("a heredoc will bypass or automatically allow the push", True),
         ("a heredoc flips the gate to bypass/auto and nothing runs", True),
         ("an ANSI-C span makes the hook bypass/auto-return zero", True),
+        # The outcome scan finds "bypass" INSIDE a longer word too, and the
+        # exemption is matched at that offset — so without a leading boundary
+        # the naming could be claimed by a word that merely ends in it.
+        ("a heredoc turns on nobypass/auto mode handling", True),
         # A DOTTED IDENTIFIER IS NOT EXEMPT. An earlier revision skipped any
         # outcome preceded by ".", to let a quoted gating expression stand. It
         # applied to all ten outcomes and to markdown paths, so `state.disarm`,

--- a/tests/test_hooks/test_no_published_bypass_recipes.py
+++ b/tests/test_hooks/test_no_published_bypass_recipes.py
@@ -107,6 +107,28 @@ _CONCESSIVE = (
     "not simply",
 )
 
+# "bypass" is also the NAME of a Claude Code permission mode, and this repo
+# documents that mode. A name is not a claim: "in bypass/auto mode the binary
+# injects a meta message" says nothing about a gate failing, and no rewording
+# fixes it, because the mode is called what it is called.
+#
+# Matched at the outcome's own offset, because the qualifier FOLLOWS the word
+# here where a negator precedes it. The trailing "mode" is REQUIRED, and that
+# requirement is the whole safety of this carve-out.
+#
+# The first version of this exemption matched those two namings as PREFIXES,
+# with a comment claiming it was narrow. It was not: a prefix admits every
+# continuation, so an ordinary claim that merely begins with the same words was
+# exempted too. MEASURED against the pre-change detector: 9 constructed cases
+# went from caught to missed. The cases themselves are in the parametrized data
+# below, where this file's own rule permits them; describing them here would
+# make this comment the thing it is warning about.
+#
+# An exemption broadened from anchored to unanchored loosens a gate while
+# reading as a tightening — the failure this file exists to prevent, committed
+# inside this file.
+_MODE_NAME_RE = re.compile(r"bypass(?:/|\s+or\s+)auto\b\s*(?:permission\s+)?mode\b")
+
 # How close the two halves must be to read as one claim. A construct in one
 # paragraph and the word "bypass" three paragraphs later is not a recipe.
 _WINDOW = 240
@@ -210,15 +232,24 @@ def _recipe_hits(text: str) -> list[tuple[str, str]]:
         for m in re.finditer(re.escape(construct.lower()), low):
             window = low[max(0, m.start() - _WINDOW) : m.end() + _WINDOW]
             for outcome in _OUTCOMES:
-                at = window.find(outcome)
-                if at < 0:
-                    continue
-                lead = window[max(0, at - _NEGATION_LOOKBACK) : at]
-                for phrase in _CONCESSIVE:
-                    lead = lead.replace(phrase, " ")
-                if any(neg in lead for neg in _NEGATORS):
-                    continue  # denied, not asserted — see _NEGATORS
-                hits.append((construct, outcome))
+                # EVERY occurrence, not just the first. `find` returned one
+                # offset, so a window opening with a denied or mode-named
+                # mention ("never a bypass …", "in bypass/auto mode …") took
+                # the `continue` below and the outcome was abandoned for that
+                # construct — a real claim later in the SAME window was never
+                # examined. Fail-open, and exactly the shape a carve-out makes
+                # more likely, so the two changes belong together.
+                for om in re.finditer(re.escape(outcome), window):
+                    at = om.start()
+                    if _MODE_NAME_RE.match(window, at):
+                        continue  # a mode's NAME, not a claim — see _MODE_NAME_RE
+                    lead = window[max(0, at - _NEGATION_LOOKBACK) : at]
+                    for phrase in _CONCESSIVE:
+                        lead = lead.replace(phrase, " ")
+                    if any(neg in lead for neg in _NEGATORS):
+                        continue  # denied, not asserted — see _NEGATORS
+                    hits.append((construct, outcome))
+                    break  # one hit per (construct, outcome) window
     return hits
 
 
@@ -276,6 +307,45 @@ def test_markdown_carries_no_bypass_recipe():
         # denial and swallowed a real recipe.
         ("an ANSI-C span is not only able to bypass the gate", True),
         ("a here" + "-doc does not just bypass it, it hides the command", True),
+        # MODE NAME — "bypass" naming a CC permission mode is not a claim that
+        # anything was defeated, and this repo has to be able to document that
+        # mode. No rewording removes the collision; the mode is called this.
+        ("in bypass/auto mode the binary suggests heredocs", False),
+        ("in bypass or auto permission mode, prefer heredocs", False),
+        # …and the carve-out is NARROW, which a prefix match was NOT. Each of
+        # these was silently allowed by the first version of the exemption and
+        # caught by the detector it replaced. The trailing "mode" is what makes
+        # the naming a naming; without it the words are an ordinary claim.
+        ("a heredoc leaves the gate in bypass mode", True),
+        ("a heredoc will bypass or auto-approve the command", True),
+        ("a heredoc will bypass or automatically allow the push", True),
+        ("a heredoc flips the gate to bypass/auto and nothing runs", True),
+        ("an ANSI-C span makes the hook bypass/auto-return zero", True),
+        # A DOTTED IDENTIFIER IS NOT EXEMPT. An earlier revision skipped any
+        # outcome preceded by ".", to let a quoted gating expression stand. It
+        # applied to all ten outcomes and to markdown paths, so `state.disarm`,
+        # `cfg.defeat` and `docs/guard.bypass.md` all went quiet. The prose was
+        # reworded to describe the mechanism instead, which is what the failure
+        # message tells authors to do.
+        ("a heredoc leaves it at state.disarm forever", True),
+        ("see docs/guard.bypass.md — a heredoc is enough", True),
+        # FAIL-OPEN REGRESSION — a denied or mode-named FIRST mention used to
+        # abandon the whole outcome for that construct, so a real claim later
+        # in the same window went unexamined. Both must still flag.
+        # The denied mention is kept well clear of the real one: _NEGATION_LOOKBACK
+        # is 40 chars, so a nearer "never" would legitimately suppress the second
+        # claim too and the case would prove nothing about the first-only bug.
+        (
+            "never a bypass in the ordinary case; the detector is careful here, "
+            "yet a heredoc will bypass the gate",
+            True,
+        ),
+        # …and the MIRROR of it, which is what distinguishes "walks every
+        # occurrence" from "walks the last one". A last-occurrence-only scan
+        # passes every other case in this list, so without this pair the class
+        # would pin nothing about the traversal at all.
+        ("a heredoc will bypass the gate; in benign cases this is never a bypass", True),
+        ("in bypass/auto mode a heredoc will bypass the gate outright", True),
     ],
 )
 def test_the_detector_discriminates(prose, should_flag):


### PR DESCRIPTION
Started as docs-only; it is not any more. The repo's own guard rejected the
documentation, and fixing that meant changing the guard.

## The bypass-mode "edit via Bash" finding

In bypass/auto permission mode the CC binary injects a meta message telling the
session to prefer Bash (`sed`, heredocs, scripts) over Read/Edit/Write. Measured
(2.1.246): it is **compiled into the binary** and is **not** install-specific
(the sibling `AgentTool`/workflows lines are in the binary too; neither is config).

**It is not gated only on permission mode.** The selector has a third branch on
a cohort assignment, so a **default-mode session can receive it**. An earlier
revision of this PR claimed it was emitted purely on permission mode; that was
read off a truncated transcription and is corrected here. It is still an
efficiency heuristic making no correctness claim, but that now follows from what
the message SAYS — it carries its own fall-back-to-a-dedicated-tool escape hatch
— rather than from where it is gated. That escape hatch was also the last
sentence of the quoted message, which the blockquote had cut; it is restored.

For reads/search the advice is right. For **writes to source** it is not: bare
`sed -i` returns exit 0 on an absent anchor (silent no-op), rewrites all matches
of a non-unique one, and hits the wrong line on a regex-metacharacter anchor —
where Edit fails loudly. A Bash write also fires none of the five edit-specific
`Edit|Write` PostToolUse hooks (the repo's own post-edit verification plane) and
heredocs sit in blocked-compound blast radius.

**Measured, with the dialect stated, because without it the number misleads:**
`sed` uses BRE by default, where `+ ? | ( ) { }` are literal. Over the last 200
non-merge commits on `src/` + `scripts/`, removed lines ≥8 chars: **2,750 /
5,013 = 54.9%** carry a BRE special, against 3,708 / 5,013 = 74.0% for an ERE
set. An earlier revision published the ERE figure as "75.2%" — a real number for
the wrong dialect. The claim's direction survives; its precision did not.

## Why this is no longer docs-only

`tests/test_hooks/test_no_published_bypass_recipes.py` forbids prose that names
a shell construct AND, nearby, claims a gate was defeated by it. It flagged this
branch six times. Two were real and are reworded. **Four were the word "bypass"
naming the permission mode these docs exist to describe** — not a claim, and
unfixable by rewording.

So the detector learns the naming, with the trailing "mode" REQUIRED. That
requirement is the whole safety of it: the first version of this carve-out
matched the namings as prefixes while its comment claimed it was narrow, which
exempted every continuation. Measured against the pre-change detector, **9
constructed cases went from caught to missed** — an exemption broadened from
anchored to unanchored, which loosens a gate while reading as a tightening. That
is the failure this file exists to prevent, committed inside this file, and it
was caught by an adversarial audit rather than by the green suite.

A second carve-out for a quoted attribute access was removed entirely — it
applied to all ten outcomes and to markdown paths. The prose it protected now
describes the selector instead of pasting the identifier, which is what the
guard's own failure message tells authors to do.

**Separately, a fail-open hole older than this branch:** `_recipe_hits` located
each outcome with `find` — the first occurrence only — so a window opening with
a denied mention took the negation `continue` and abandoned that outcome
entirely; a genuine claim later in the same window was never examined. It now
walks every occurrence, and the control class pins the traversal in both
directions, since a last-occurrence-only implementation was passing every
earlier case.

## Injection-map refresh (CURRENT.md)

- Document the **prune↔watcher cross-store coupling**: the injection watcher's
  blind-scan guard relies on a non-empty `~/.genesis/sessions/`, which
  `disk_hygiene.sh` prunes at 60 days — so that floor is load-bearing for the
  guard too. This lived only in the script's comment.
- **Re-verify + re-stamp** `ambient-cognition` (delta trivial) and `platform-data`
  (14-commit delta checked). The re-verification found a stale count — the entry
  claimed 118 `CREATE TABLE`, HEAD has 117 — corrected and reframed as
  drift-prone per the map's own rate-of-change rule.
- The `routing-providers` orphan stamp is left untouched (owned by another
  in-flight branch; the subsystem-map guard already warns on it there).

## Verification

- **26 passed** on the guard suite, up from 14 on main; ruff clean.
- **verify-RED 7/7**, each mutation proved applied against a hash-checked
  baseline: restoring the first-occurrence scan, walking only the last
  occurrence, reverting the naming match to a prefix, dropping the required
  trailing "mode", restoring the blanket dotted carve-out, and restoring each of
  the two reworded sentences.
- **237 tracked `.md` and 2,815 `.py` rescanned** under the stricter walk: zero
  offenders.
- subsystem-map guard coverage CLEAN; `test_subsystem_traps_hook` (consumes
  CURRENT.md) passes.
- Every documentation correction above was re-derived against the source — the
  binary for the selector, `.claude/settings.json` for the hook count, git
  history for the metacharacter rate — not reasoned about.

E2E: none — documentation plus a test-only guard. The guard's own effect is
exercised by CI on this PR: it must reject the pre-rewording prose and accept
the corrected prose, which is what the 7/7 mutation set asserts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recipe validation to inspect all relevant claims, including later occurrences.
  - Improved detection of embedded or dotted identifiers containing bypass/auto references.
  - Prevented valid permission-mode names and negated claims from being incorrectly flagged.
  - Tightened matching to distinguish complete permission modes from similarly named values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->