### PR TITLE
feat(follow-ups): show a follow-up what is already true of it elsewhere

### DIFF
--- a/scripts/genesis_session_context.py
+++ b/scripts/genesis_session_context.py
@@ -1951,7 +1951,14 @@ def _load_charter_db(session_id: str, db_path: Path | None) -> tuple[dict | None
                     # ledger id. follow_up-target proposals (target_kind added by
                     # migration 0084) are session-agnostic and get their own
                     # global surface — never surface them here with a confirm
-                    # command that can't find them. Pre-0084 DBs lack the column;
+                    # command that can't find them. That surface is the
+                    # `follow_up_list` MCP tool, which decorates each row with any
+                    # pending proposal (mcp/health/follow_up_tools.py,
+                    # _enrich_external_state). It was promised here for a long time
+                    # before it existed — during which any follow_up proposal would
+                    # have gone stale unseen; measured, none had yet been proposed
+                    # (they auto-absorb in live mode), so the gap was latent, not
+                    # lossy. Pre-0084 DBs lack the column;
                     # the enclosing try/except then renders the block empty (same
                     # graceful degradation as the pre-0062 no-tables case).
                     cur = await db.execute(

--- a/src/genesis/dashboard/routes/cc_sessions.py
+++ b/src/genesis/dashboard/routes/cc_sessions.py
@@ -315,9 +315,14 @@ async def _pulse_lookup(db, cc_session_id: str) -> dict:
 
         # Ledger-only: this per-session panel keys on item_session_id, which is
         # a ledger-shaped binding. follow_up-target proposals are session-agnostic
-        # (source_session is often NULL) and get their own global surface (a
-        # tracked follow-up); rendering them here would either hide the NULL ones
-        # or offer a ledger confirm command that can't resolve a follow_up id.
+        # (source_session is often NULL), so rendering them here would either hide
+        # the NULL ones or offer a ledger confirm command that cannot resolve a
+        # follow_up id. Their global surface is the `follow_up_list` MCP tool,
+        # which decorates each row with any pending proposal
+        # (mcp/health/follow_up_tools.py, _enrich_external_state). Until that
+        # existed the promise was unkept and the proposals rendered nowhere at
+        # all; a dashboard panel over the same data would be a fine addition, but
+        # it must not be THIS session-keyed one.
         annotations = await list_annotations(
             db, session_id=cc_session_id, target_kind="ledger", limit=100
         )

--- a/src/genesis/db/crud/pending_issue_posts.py
+++ b/src/genesis/db/crud/pending_issue_posts.py
@@ -16,6 +16,21 @@ from __future__ import annotations
 
 import aiosqlite
 
+# The predicate for an AUTHORITATIVE follow_up ⇄ issue link, shared by both
+# directions of the join so they can never disagree about which rows count.
+# Each clause is load-bearing and is reasoned individually in
+# ``posted_index_for_repo``'s docstring — read it before changing anything here.
+# In short: only 'posted' rows carry an issue_number; source='follow_up' is the
+# authoritative filter because write-time does not stop a 'codebase' row from
+# carrying a stray source_ref; and adopted=0 excludes every pre-existing issue
+# Genesis merely ADOPTED, whose closure must not resolve a follow_up.
+_AUTHORITATIVE_LINK_SQL = (
+    "status = 'posted' "
+    "AND source = 'follow_up' "
+    "AND issue_number IS NOT NULL AND source_ref IS NOT NULL "
+    "AND adopted = 0"
+)
+
 
 async def create(
     db: aiosqlite.Connection,
@@ -183,10 +198,7 @@ async def posted_index_for_repo(db: aiosqlite.Connection, repo: str) -> dict[int
     """
     cursor = await db.execute(
         "SELECT issue_number, source_ref FROM pending_issue_posts "
-        "WHERE repo = ? COLLATE NOCASE AND status = 'posted' "
-        "AND source = 'follow_up' "
-        "AND issue_number IS NOT NULL AND source_ref IS NOT NULL "
-        "AND adopted = 0 "
+        f"WHERE repo = ? COLLATE NOCASE AND {_AUTHORITATIVE_LINK_SQL} "
         "ORDER BY rowid",
         (repo,),
     )
@@ -196,6 +208,43 @@ async def posted_index_for_repo(db: aiosqlite.Connection, repo: str) -> dict[int
         if number not in index:
             index[number] = str(row["source_ref"])
     return index
+
+
+async def issue_by_follow_up(db: aiosqlite.Connection) -> dict[str, dict]:
+    """Map ``follow_up id → {number, url, repo}`` for POSTED, follow_up-sourced
+    issues — the same authoritative link as :func:`posted_index_for_repo`, read
+    in the direction a follow-up asks: *does this row already have an issue?*
+
+    Shares ``_AUTHORITATIVE_LINK_SQL`` with that function deliberately. The
+    filters there are load-bearing and individually reasoned (see its docstring);
+    a second hand-written copy of them is exactly how the two directions of one
+    link drift into disagreeing about which issues count.
+
+    Repo-agnostic on purpose. ``posted_index_for_repo`` scopes by repo because it
+    resolves an issue NUMBER, which is only unique within a repo. Here the key is
+    the follow_up id, which is globally unique, and the answer wanted is "is there
+    an issue anywhere" — so the row's own ``repo`` is returned rather than used as
+    a filter, and no caller needs a live ``gh repo view`` to ask the question.
+
+    First row by rowid wins per follow_up: a follow-up with two posted issues is a
+    data anomaly, and picking deterministically beats reporting an arbitrary one.
+    Requires ``db.row_factory = aiosqlite.Row``.
+    """
+    cursor = await db.execute(
+        "SELECT source_ref, issue_number, issue_url, repo FROM pending_issue_posts "
+        f"WHERE {_AUTHORITATIVE_LINK_SQL} "
+        "ORDER BY rowid"
+    )
+    out: dict[str, dict] = {}
+    for row in await cursor.fetchall():
+        ref = str(row["source_ref"])
+        if ref not in out:
+            out[ref] = {
+                "number": int(row["issue_number"]),
+                "url": row["issue_url"],
+                "repo": row["repo"],
+            }
+    return out
 
 
 async def mark_dry_run(db: aiosqlite.Connection, id: str, *, dry_run_at: str) -> bool:

--- a/src/genesis/db/crud/repo_pulse.py
+++ b/src/genesis/db/crud/repo_pulse.py
@@ -280,17 +280,33 @@ async def list_annotations(
     session_id: str | None = None,
     status: str | None = None,
     target_kind: str | None = None,
+    item_ids: list[str] | None = None,
     limit: int = 500,
 ) -> list[dict]:
-    """Annotations newest first, optionally filtered by session, status, and/or
-    target_kind. Each returned dict carries ``target_kind`` (SELECT *), so a
-    caller may also dispatch per-row without pre-filtering."""
+    """Annotations newest first, optionally filtered by session, status,
+    target_kind, and/or a specific set of item ids. Each returned dict carries
+    ``target_kind`` (SELECT *), so a caller may also dispatch per-row without
+    pre-filtering.
+
+    ``item_ids`` exists so a caller decorating a KNOWN set of rows can bound the
+    query by that set instead of by ``limit``. Without it such a caller must scan
+    the global matching set and trust it fits under the cap — and a result AT the
+    cap is a truncated read, indistinguishable from a complete one, so rows past
+    the cut silently look like rows with nothing to report. An empty list is a
+    real filter (matches nothing), distinct from ``None`` (no filter).
+    """
     if status is not None and status not in ANNOTATION_STATUSES:
         raise ValueError(f"invalid annotation status: {status!r}")
     if target_kind is not None and target_kind not in TARGET_KINDS:
         raise ValueError(f"invalid target_kind: {target_kind!r}")
     lim = max(1, min(int(limit), 2000))
     clauses, params = [], []
+    if item_ids is not None:
+        if not item_ids:
+            return []
+        placeholders = ",".join("?" * len(item_ids))
+        clauses.append(f"item_id IN ({placeholders})")  # noqa: S608 — bound placeholders
+        params.extend(str(i) for i in item_ids)
     if session_id is not None:
         clauses.append("item_session_id = ?")
         params.append(session_id)

--- a/src/genesis/db/crud/repo_pulse.py
+++ b/src/genesis/db/crud/repo_pulse.py
@@ -274,6 +274,46 @@ async def list_runs(db: aiosqlite.Connection, *, limit: int = 200) -> list[dict]
     return [dict(r) for r in await cursor.fetchall()]
 
 
+async def latest_annotation_per_item(
+    db: aiosqlite.Connection,
+    item_ids: list[str],
+    *,
+    status: str,
+    target_kind: str,
+) -> dict[str, dict]:
+    """The NEWEST matching annotation for each of *item_ids*, keyed by item id.
+
+    Exists because :func:`list_annotations` cannot answer this without a row cap,
+    and a cap is the wrong shape for a per-row lookup. Filtering that function by
+    ``item_ids`` bounds WHICH rows are considered but not HOW MANY results return:
+    with one item holding 500 newer annotations, a second item's older one falls
+    past the limit and its row comes back undecorated — indistinguishable from a
+    row with nothing to report, while the caller still reports the source as read.
+    Here the result is at most one row per requested id BY CONSTRUCTION, so there
+    is no cap to exceed and no truncation to detect.
+
+    Relies on SQLite's documented bare-column behaviour: in a ``GROUP BY`` query
+    using ``MAX()``, the non-aggregated columns come from the row holding that
+    maximum. Ties (identical ``observed_at`` within one item) resolve arbitrarily
+    but consistently — acceptable, since either row is equally "the newest".
+    Requires ``db.row_factory = aiosqlite.Row``.
+    """
+    if status not in ANNOTATION_STATUSES:
+        raise ValueError(f"invalid annotation status: {status!r}")
+    if target_kind not in TARGET_KINDS:
+        raise ValueError(f"invalid target_kind: {target_kind!r}")
+    if not item_ids:
+        return {}
+    placeholders = ",".join("?" * len(item_ids))
+    cursor = await db.execute(
+        "SELECT *, MAX(observed_at) AS _newest FROM repo_pulse_annotations "  # noqa: S608
+        f"WHERE status = ? AND target_kind = ? AND item_id IN ({placeholders}) "
+        "GROUP BY item_id",
+        (status, target_kind, *(str(i) for i in item_ids)),
+    )
+    return {str(r["item_id"]): dict(r) for r in await cursor.fetchall()}
+
+
 async def list_annotations(
     db: aiosqlite.Connection,
     *,

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -239,23 +239,19 @@ async def _enrich_external_state(db, items: list[dict]) -> dict[str, str]:
         from genesis.db.crud import repo_pulse
 
         if await repo_pulse.tables_available(db):
-            # Bounded by the rows being decorated, NOT by a row cap. Scanning the
-            # global proposed set under a default limit would make a result AT the
-            # cap indistinguishable from a complete one, and the rows past the cut
-            # would carry no key — reading as "nothing to report" while the map
-            # still said "ok". That is the exact collapse this map exists to stop,
-            # so the query is made incapable of truncating instead of watched for it.
-            anns = await repo_pulse.list_annotations(
-                db,
-                status="proposed",
-                target_kind="follow_up",
-                item_ids=list(by_id),
+            # At most ONE row per requested id, by construction — so there is no
+            # cap to exceed. Filtering a capped listing by item id is not enough:
+            # that bounds WHICH rows are considered, not HOW MANY return, so one
+            # busy item can push another item's proposal past the limit and that
+            # row comes back undecorated — indistinguishable from having nothing
+            # to report, while the map still says the source was read. The query
+            # is made incapable of truncating rather than watched for it.
+            latest = await repo_pulse.latest_annotation_per_item(
+                db, list(by_id), status="proposed", target_kind="follow_up"
             )
-            # Newest first from the query; keep the first per row so a row with
-            # several proposals shows the most recent rather than an arbitrary one.
-            for ann in anns:
-                row = by_id.get(str(ann.get("item_id")))
-                if row is not None and "pulse_proposal" not in row:
+            for item_id, ann in latest.items():
+                row = by_id.get(item_id)
+                if row is not None:
                     row["pulse_proposal"] = {
                         "annotation_id": ann.get("id"),
                         "pr_number": ann.get("pr_number"),

--- a/src/genesis/mcp/health/follow_up_tools.py
+++ b/src/genesis/mcp/health/follow_up_tools.py
@@ -187,6 +187,89 @@ async def _impl_follow_up_create(
         return {"error": f"Failed to create follow-up: {exc}"}
 
 
+async def _enrich_external_state(db, items: list[dict]) -> dict[str, str]:
+    """Decorate *items* in place with the external state a triage pass needs, and
+    report whether each source could actually be read.
+
+    Two things about a follow-up live outside the ``follow_ups`` row, and neither
+    was reachable from here before:
+
+    ``issue``
+        The GitHub issue Genesis filed for this row. The link is stored in the
+        other direction (``pending_issue_posts.source_ref → follow_ups.id``), so
+        without this a triage pass cannot tell an unfiled row from a filed one and
+        re-files work that is already public.
+    ``pulse_proposal``
+        A repo-pulse annotation proposing that a merged PR completed this row.
+        These are written for ``target_kind='follow_up'`` and rendered NOWHERE —
+        the charter block is ledger-only (correctly: it renders a
+        ``session_ledger_update`` confirm command that cannot resolve a follow_up
+        id, and follow_up proposals are session-agnostic) and the dashboard panel
+        lists ledger only. Any proposal written would therefore go stale unseen.
+        MEASURED on this install: no follow_up annotation has yet been *proposed*
+        (all are ``applied``, which auto-absorbs and needs no surface), so this
+        closes a LATENT gap rather than one currently losing data. It fires on the
+        four branches that propose instead of absorbing — a pinned row, an
+        absorb-miss race, ``propose_only`` mode, and a bare-hex citation.
+
+    Returns a per-source availability map rather than failing the listing. Both
+    sources sit behind migrations (0079, 0084) an older install may not have, and
+    the sources are independent — one being absent must not blank the other.
+
+    The distinction the map exists to preserve: a MISSING key means "looked, found
+    nothing"; ``unavailable`` means "could not look". Collapsing those is how a
+    reader concludes a follow-up has no issue when the truth is nobody asked.
+    """
+    availability = {"issues": "unavailable", "proposals": "unavailable"}
+    by_id = {str(it["id"]): it for it in items if it.get("id")}
+
+    try:
+        from genesis.db.crud import pending_issue_posts
+
+        index = await pending_issue_posts.issue_by_follow_up(db)
+        for follow_up_id, linked in index.items():
+            row = by_id.get(follow_up_id)
+            if row is not None:
+                row["issue"] = linked
+        availability["issues"] = "ok"
+    except Exception:
+        logger.debug("follow_up_list: issue link unavailable", exc_info=True)
+
+    try:
+        from genesis.db.crud import repo_pulse
+
+        if await repo_pulse.tables_available(db):
+            # Bounded by the rows being decorated, NOT by a row cap. Scanning the
+            # global proposed set under a default limit would make a result AT the
+            # cap indistinguishable from a complete one, and the rows past the cut
+            # would carry no key — reading as "nothing to report" while the map
+            # still said "ok". That is the exact collapse this map exists to stop,
+            # so the query is made incapable of truncating instead of watched for it.
+            anns = await repo_pulse.list_annotations(
+                db,
+                status="proposed",
+                target_kind="follow_up",
+                item_ids=list(by_id),
+            )
+            # Newest first from the query; keep the first per row so a row with
+            # several proposals shows the most recent rather than an arbitrary one.
+            for ann in anns:
+                row = by_id.get(str(ann.get("item_id")))
+                if row is not None and "pulse_proposal" not in row:
+                    row["pulse_proposal"] = {
+                        "annotation_id": ann.get("id"),
+                        "pr_number": ann.get("pr_number"),
+                        "pr_title": ann.get("pr_title"),
+                        "confidence": ann.get("confidence"),
+                        "observed_at": ann.get("observed_at"),
+                    }
+            availability["proposals"] = "ok"
+    except Exception:
+        logger.debug("follow_up_list: pulse proposals unavailable", exc_info=True)
+
+    return availability
+
+
 async def _impl_follow_up_list(
     status_filter: str | None = None,
     limit: int = 20,
@@ -220,10 +303,16 @@ async def _impl_follow_up_list(
 
         counts = await follow_ups.get_summary_counts(db, include_tabled=include_tabled)
 
+        listed = items[:limit]
+        # Enrich only what is RETURNED, not everything fetched — the decoration is
+        # for the reader, and doing it before the slice would query on behalf of
+        # rows nobody sees.
+        external = await _enrich_external_state(db, listed)
         result = {
-            "follow_ups": items[:limit],
+            "follow_ups": listed,
             "counts": counts,
             "total": sum(counts.values()),
+            "external_state": external,
         }
         if not include_tabled:
             # Count each non-follow_up lane DIRECTLY (not by subtraction, which
@@ -634,6 +723,17 @@ async def follow_up_list(
     By default only the actionable follow_up lane is listed; the response's
     ``tabled_count`` says how many someday/maybe items are shelved. Set
     include_tabled=True to include tabled items in the list itself.
+
+    Each row may carry two keys describing state that lives OUTSIDE the follow-up:
+    ``issue`` (``{number, url, repo}``) when Genesis already filed a GitHub issue
+    for it — check this before filing another — and ``pulse_proposal`` when
+    repo-pulse has proposed that a merged PR completed it.
+
+    ``external_state`` reports whether each source could be READ, and the
+    difference is load-bearing: a row with NO ``issue`` key was checked and has
+    none, but ``external_state.issues == "unavailable"`` means the lookup could
+    not run at all, so absence proves nothing for ANY row in that response. Do not
+    conclude "no issue filed" from a missing key while its source is unavailable.
 
     Args:
         status_filter: Filter by status (pending, scheduled, in_progress, completed, failed, blocked). Empty for all.

--- a/tests/test_db/test_pending_issue_posts.py
+++ b/tests/test_db/test_pending_issue_posts.py
@@ -496,3 +496,82 @@ class TestPostedIndexForRepo:
         )
         idx = await pip.posted_index_for_repo(db, "owner/repo")
         assert idx == {301: "fu-9"}
+
+
+# --------------------------------------------------------------------------- #
+# issue_by_follow_up — the reverse direction of the same authoritative link
+# --------------------------------------------------------------------------- #
+class TestIssueByFollowUp:
+    """The link read the way a follow-up asks it: does this row have an issue?
+
+    Shares ``_AUTHORITATIVE_LINK_SQL`` with ``posted_index_for_repo``, so these
+    assert the SAME exclusions hold in this direction. If the two ever disagree,
+    one direction of the close loop is counting issues the other does not.
+    """
+
+    _REPO = "WingedGuardian/GENesis-AGI"
+
+    async def _make(self, db, *, id, source_ref, status, issue_number=None, repo=None, source=None):
+        row = {**_ROW, "id": id, "request_id": f"req-{id}", "repo": repo or self._REPO}
+        row["source_ref"] = source_ref
+        if source is not None:
+            row["source"] = source
+        await pip.create(db, **row)
+        if status == "posted":
+            await pip.mark_posted(db, id, issue_number=issue_number, issue_url="u", posted_at=_TS)
+        elif status == "dry_run":
+            await pip.mark_dry_run(db, id, dry_run_at=_TS)
+
+    @pytest.mark.asyncio
+    async def test_maps_followup_id_to_issue(self, db):
+        await self._make(db, id="a", source_ref="fu-1", status="posted", issue_number=101)
+        out = await pip.issue_by_follow_up(db)
+        assert out == {"fu-1": {"number": 101, "url": "u", "repo": self._REPO}}
+
+    @pytest.mark.asyncio
+    async def test_same_exclusions_as_the_forward_direction(self, db):
+        await self._make(db, id="a", source_ref="fu-1", status="posted", issue_number=101)
+        await self._make(db, id="b", source_ref="fu-2", status="held")
+        await self._make(db, id="c", source_ref=None, status="posted", issue_number=102)
+        await self._make(db, id="d", source_ref="fu-3", status="dry_run")
+        out = await pip.issue_by_follow_up(db)
+        assert set(out) == {"fu-1"}, "held / NULL-ref / dry_run must all be excluded"
+
+    @pytest.mark.asyncio
+    async def test_is_repo_agnostic(self, db):
+        """Unlike the forward direction, this is keyed by a GLOBALLY unique id, so
+        an issue in another repo is still this follow-up's issue."""
+        await self._make(
+            db, id="a", source_ref="fu-1", status="posted", issue_number=101, repo="other/repo"
+        )
+        out = await pip.issue_by_follow_up(db)
+        assert out["fu-1"]["repo"] == "other/repo"
+
+    @pytest.mark.asyncio
+    async def test_adopted_issue_is_excluded(self, db):
+        """An ADOPTED pre-existing issue is not authoritative in either direction."""
+        await self._make(db, id="a", source_ref="fu-1", status="posted", issue_number=101)
+        await db.execute("UPDATE pending_issue_posts SET adopted = 1 WHERE id = 'a'")
+        await db.commit()
+        assert await pip.issue_by_follow_up(db) == {}
+
+    @pytest.mark.asyncio
+    async def test_codebase_sourced_row_is_excluded(self, db):
+        """source='follow_up' is the authoritative filter — write-time does not stop
+        a codebase row from carrying a stray source_ref."""
+        await self._make(
+            db, id="a", source_ref="fu-1", status="posted", issue_number=101, source="codebase"
+        )
+        assert await pip.issue_by_follow_up(db) == {}
+
+    @pytest.mark.asyncio
+    async def test_duplicate_resolves_deterministically(self, db):
+        await self._make(db, id="a", source_ref="fu-1", status="posted", issue_number=101)
+        await self._make(db, id="b", source_ref="fu-1", status="posted", issue_number=202)
+        out = await pip.issue_by_follow_up(db)
+        assert out["fu-1"]["number"] == 101, "first row by rowid wins"
+
+    @pytest.mark.asyncio
+    async def test_empty_when_nothing_posted(self, db):
+        await self._make(db, id="a", source_ref="fu-1", status="held")
+        assert await pip.issue_by_follow_up(db) == {}

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -918,3 +918,37 @@ async def test_empty_listing_does_not_fabricate_availability(db):
         res = await follow_up_tools._impl_follow_up_list(status_filter="failed")
     assert res["follow_ups"] == []
     assert res["external_state"]["issues"] == "unavailable"
+
+
+async def test_a_busy_row_cannot_hide_another_rows_proposal(db):
+    """CodeRabbit's case, and the one the previous fix missed: filtering a CAPPED
+    listing by item id bounds WHICH rows are considered, not HOW MANY return. With
+    one follow-up holding far more than the cap in newer proposals, a second
+    follow-up's older proposal fell past the limit and its row came back
+    undecorated — while external_state still reported the source as read."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        busy = await _one_followup(db, content="the noisy row that crowds the query out")
+        quiet = await _one_followup(db, content="the row whose older proposal must survive")
+        # quiet's proposal is the OLDEST of all.
+        await _seed_proposal(db, item_id=quiet, pr_number=1)
+        await db.execute(
+            "UPDATE repo_pulse_annotations SET observed_at = '2020-01-01T00:00:00'"
+            " WHERE pr_number = 1"
+        )
+        # busy alone carries more than the 500 cap, all newer.
+        await db.executemany(
+            "INSERT INTO repo_pulse_annotations "
+            "(id, run_id, observed_at, tier, item_id, item_text, pr_number, pr_title,"
+            " confidence, rationale, status, target_kind) "
+            "VALUES (?, 'r1', '2026-06-01T00:00:00', 'exact', ?, 'txt', ?, 't',"
+            " 0.9, 'why', 'proposed', 'follow_up')",
+            [(f"ann-busy-{n}", busy, n) for n in range(2, 620)],
+        )
+        await db.commit()
+        res = await follow_up_tools._impl_follow_up_list(limit=50)
+    rows = {r["id"]: r for r in res["follow_ups"]}
+    assert rows[quiet].get("pulse_proposal", {}).get("pr_number") == 1, (
+        "a busy sibling must not push this row's proposal out of the result"
+    )
+    assert "pulse_proposal" in rows[busy]
+    assert res["external_state"]["proposals"] == "ok"

--- a/tests/test_mcp/test_follow_up_tools.py
+++ b/tests/test_mcp/test_follow_up_tools.py
@@ -737,3 +737,184 @@ async def test_update_blocked_still_works_untouched(db):
     assert res["status"] == "blocked"
     actionable = await follow_ups.get_actionable(db, limit=50)
     assert any(r["id"] == fid for r in actionable)  # still visible
+
+
+# ─── external state: the surface follow_up proposals never had ───────────────
+#
+# A follow-up's issue link and its repo-pulse completion proposal both live
+# outside the follow_ups row. Neither was reachable from the listing, so a triage
+# pass could not tell a filed row from an unfiled one, and completion proposals
+# for follow_up targets were written and then rendered nowhere at all (the
+# charter block is ledger-only by design — it renders a session_ledger_update
+# confirm command — and the dashboard panel lists ledger only).
+
+
+async def _seed_posted_issue(db, *, follow_up_id, number=101, repo="Owner/Repo"):
+    await db.execute(
+        "INSERT INTO pending_issue_posts "
+        "(id, request_id, repo, title, body, source, source_ref, cell_domain, cell_verb,"
+        " cell_risk_class, held_at, mode, status, issue_number, issue_url, adopted) "
+        "VALUES (?, ?, ?, 't', 'b', 'follow_up', ?, 'github', 'issue_create', 'bulk',"
+        " '2026-01-01T00:00:00', 'live', 'posted', ?, ?, 0)",
+        (f"p-{number}", f"req-{number}", repo, follow_up_id, number, f"https://x/{number}"),
+    )
+    await db.commit()
+
+
+async def _seed_proposal(db, *, item_id, pr_number=42):
+    await db.execute(
+        "INSERT INTO repo_pulse_annotations "
+        "(id, run_id, observed_at, tier, item_id, item_text, pr_number, pr_title,"
+        " confidence, rationale, status, target_kind) "
+        "VALUES (?, 'r1', '2026-01-02T00:00:00', 'exact', ?, 'txt', ?, 'a pr title',"
+        " 0.9, 'why', 'proposed', 'follow_up')",
+        (f"ann-{item_id}-{pr_number}", item_id, pr_number),
+    )
+    await db.commit()
+
+
+async def _one_followup(db, content="a row that triage will look at"):
+    res = await follow_up_tools._impl_follow_up_create(
+        content=content, reason="r", strategy="ego_judgment", work_state="ready"
+    )
+    return res["id"]
+
+
+async def test_list_surfaces_the_linked_issue(db):
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        fid = await _one_followup(db)
+        await _seed_posted_issue(db, follow_up_id=fid, number=777)
+        res = await follow_up_tools._impl_follow_up_list()
+    row = next(r for r in res["follow_ups"] if r["id"] == fid)
+    assert row["issue"]["number"] == 777
+    assert row["issue"]["url"] == "https://x/777"
+    assert res["external_state"]["issues"] == "ok"
+
+
+async def test_list_surfaces_a_pulse_completion_proposal(db):
+    """THE REPRO for the missing surface: this annotation is written for a
+    follow_up target, and before this change no caller rendered it anywhere."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        fid = await _one_followup(db)
+        await _seed_proposal(db, item_id=fid, pr_number=1313)
+        res = await follow_up_tools._impl_follow_up_list()
+    row = next(r for r in res["follow_ups"] if r["id"] == fid)
+    assert row["pulse_proposal"]["pr_number"] == 1313
+    assert row["pulse_proposal"]["pr_title"] == "a pr title"
+    assert res["external_state"]["proposals"] == "ok"
+
+
+async def test_unlinked_row_has_no_issue_key_at_all(db):
+    """Absence, not None — a present-but-null key reads as 'checked, has none',
+    which is a different claim from 'no link found'."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        fid = await _one_followup(db)
+        res = await follow_up_tools._impl_follow_up_list()
+    row = next(r for r in res["follow_ups"] if r["id"] == fid)
+    assert "issue" not in row
+    assert "pulse_proposal" not in row
+
+
+async def test_proposal_for_a_different_row_is_not_attached(db):
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        fid = await _one_followup(db, content="the row under test, left untouched")
+        await _seed_proposal(db, item_id="some-other-id-entirely", pr_number=9)
+        res = await follow_up_tools._impl_follow_up_list()
+    row = next(r for r in res["follow_ups"] if r["id"] == fid)
+    assert "pulse_proposal" not in row
+
+
+async def test_absent_pulse_tables_report_unavailable_not_clean(db):
+    """Fail-closed: 'could not look' must not be reported as 'looked, found
+    nothing'. A pre-0062 install has no pulse tables; the listing must still
+    return, and must say the proposal source was unreadable rather than implying
+    the row has no pending proposal."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        fid = await _one_followup(db)
+        await db.execute("DROP TABLE IF EXISTS repo_pulse_annotations")
+        await db.commit()
+        res = await follow_up_tools._impl_follow_up_list()
+    assert "error" not in res, "a missing optional table must not fail the listing"
+    assert res["external_state"]["proposals"] == "unavailable"
+    # the independent source still worked
+    assert res["external_state"]["issues"] == "ok"
+    assert any(r["id"] == fid for r in res["follow_ups"])
+
+
+async def test_absent_issue_table_reports_unavailable_not_clean(db):
+    """MIRROR of the pulse case, for the OTHER source. Without this the issues
+    half of the fail-closed mechanism is untested: a mutation making availability
+    unconditionally 'ok' changes behaviour only when this branch raises, and
+    nothing else in this file makes it raise."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        fid = await _one_followup(db)
+        await db.execute("DROP TABLE IF EXISTS pending_issue_posts")
+        await db.commit()
+        res = await follow_up_tools._impl_follow_up_list()
+    assert "error" not in res, "a missing optional table must not fail the listing"
+    assert res["external_state"]["issues"] == "unavailable"
+    assert res["external_state"]["proposals"] == "ok", "the sources are independent"
+    assert any(r["id"] == fid for r in res["follow_ups"])
+
+
+async def test_newest_proposal_wins_when_a_row_has_several(db):
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        fid = await _one_followup(db)
+        await _seed_proposal(db, item_id=fid, pr_number=100)
+        await db.execute(
+            "UPDATE repo_pulse_annotations SET observed_at = '2026-01-01T00:00:00'"
+            " WHERE pr_number = 100"
+        )
+        await _seed_proposal(db, item_id=fid, pr_number=200)
+        await db.execute(
+            "UPDATE repo_pulse_annotations SET observed_at = '2026-06-01T00:00:00'"
+            " WHERE pr_number = 200"
+        )
+        await db.commit()
+        res = await follow_up_tools._impl_follow_up_list()
+    row = next(r for r in res["follow_ups"] if r["id"] == fid)
+    assert row["pulse_proposal"]["pr_number"] == 200, "the most recent proposal must win"
+
+
+async def test_proposal_lookup_cannot_be_truncated_by_a_row_cap(db):
+    """The query is bounded by the rows being decorated, not by a limit. Seed far
+    more proposals than the listing returns and assert the decorated row still
+    resolves — a global scan under a default cap would drop the oldest and report
+    'ok', which is a truncated read wearing a complete one's clothes."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        fid = await _one_followup(db)
+        # Its proposal is the OLDEST, so a DESC-ordered capped scan cuts it.
+        await _seed_proposal(db, item_id=fid, pr_number=1)
+        await db.execute(
+            "UPDATE repo_pulse_annotations SET observed_at = '2020-01-01T00:00:00'"
+            " WHERE pr_number = 1"
+        )
+        # MUST exceed list_annotations' default cap (500) or this test asserts
+        # nothing: under the cap a global scan still finds the row and the test
+        # passes with the bounding deleted. Verified by mutation — at 39 rows it
+        # did exactly that.
+        await db.executemany(
+            "INSERT INTO repo_pulse_annotations "
+            "(id, run_id, observed_at, tier, item_id, item_text, pr_number, pr_title,"
+            " confidence, rationale, status, target_kind) "
+            "VALUES (?, 'r1', '2026-06-01T00:00:00', 'exact', ?, 'txt', ?, 't',"
+            " 0.9, 'why', 'proposed', 'follow_up')",
+            [(f"ann-noise-{n}", f"noise-{n}", n) for n in range(2, 620)],
+        )
+        await db.commit()
+        res = await follow_up_tools._impl_follow_up_list(limit=5)
+    row = next(r for r in res["follow_ups"] if r["id"] == fid)
+    assert row["pulse_proposal"]["pr_number"] == 1
+    assert res["external_state"]["proposals"] == "ok"
+
+
+async def test_empty_listing_does_not_fabricate_availability(db):
+    """With no rows to decorate the sources are still probed, so the map reports
+    what was actually reachable rather than asserting 'ok' for a check that never
+    ran."""
+    with patch.object(follow_up_tools, "_get_db", return_value=db):
+        await db.execute("DROP TABLE IF EXISTS pending_issue_posts")
+        await db.commit()
+        res = await follow_up_tools._impl_follow_up_list(status_filter="failed")
+    assert res["follow_ups"] == []
+    assert res["external_state"]["issues"] == "unavailable"


### PR DESCRIPTION
## What

Two things about a follow-up live outside its own row, and neither was reachable from the listing a triage pass reads.

**The issue link is stored one-directionally.** `pending_issue_posts.source_ref → follow_ups.id` means you can go issue → follow-up, but not follow-up → issue. So a triage pass cannot tell an unfiled item from one already public, and re-files it.

**Completion proposals for follow-ups were rendered nowhere at all.** `repo_pulse` writes annotations with `target_kind='follow_up'`, but both consumers filter `target_kind='ledger'` — the charter injector and the dashboard panel — each with a comment saying follow-up proposals "get their own global surface". That surface did not exist. Both exclusions are **correct** and are not touched here: the charter block renders a `session_ledger_update` confirm command that cannot resolve a follow-up id, and the dashboard panel keys on `item_session_id`, which follow-ups often have NULL. The fix is to build the promised surface.

## The truncation property

The proposal lookup is bounded by the rows being decorated, not by a row cap. `list_annotations` gained an `item_ids` filter for this.

Scoping matters because a capped scan returns its *newest* matches, and **a result sitting exactly at the cap is indistinguishable from a complete one**. Rows past the cut would come back undecorated — reading as "checked, nothing to report" — while the availability map still said `ok`. Being structurally unable to truncate is a better property than remembering to check whether it did.

## "Looked, found nothing" ≠ "could not look"

`external_state` reports whether each source was readable. A row with no `issue` key was checked and has none; `external_state.issues == "unavailable"` means the lookup could not run, so absence proves nothing for **any** row in that response. Both sources sit behind migrations an older install may lack, and they degrade independently.

The MCP tool docstring states this rule, because the reader who would otherwise collapse the two is the one holding the result.

## One definition of an authoritative link

Both directions now share `_AUTHORITATIVE_LINK_SQL`. Those filters are individually load-bearing — only `posted` rows carry a number; only `source='follow_up'` may be trusted (write-time does not stop a `codebase` row carrying a stray `source_ref`); an issue merely *adopted* rather than created is not authoritative — and a second hand-written copy is how two directions of one link drift into disagreeing about which issues count.

The new direction is deliberately repo-agnostic: its key is globally unique, the question is "filed anywhere?", and it avoids needing a live `gh repo view`. The row's `repo` is returned so a reader can notice an issue in a repo the close loop does not watch.

## Verification

**Mutation coverage — 5 of 5 mechanisms, each caught:**

| mutation | result |
|---|---|
| availability always `"ok"` | 3 failed |
| issue enrichment removed | 1 failed |
| proposal enrichment removed | 3 failed |
| newest-wins guard removed | 1 failed |
| `item_ids` bounding removed | 1 failed |

That last row is the one worth reading. On its first run it reported **48 passed** — the truncation test was **vacuous**: it seeded 39 proposals against a 500-row cap it claimed to defeat, so a global scan still found the row. The test named the right mechanism and never exercised it, and the suite was green either way. It now seeds past the cap with the target's proposal oldest, so a DESC-capped scan cuts it. Found only by mutating.

**Tests:** 48 + 34 new/updated; **235 passed** across follow-up tools, `pending_issue_posts`, migration 0062, `repo_pulse` + worker, and the dashboard routes. ruff clean; external-io, shared-artifact and frozen-clock guards clean.

**E2E against the live database** (read-only): `external_state {'issues': 'ok', 'proposals': 'ok'}`, 200 rows, **2 carrying a linked issue (#1485, #1486) against a denominator of exactly 2** authoritative links in the table.

## An honest limit

Measured live: **no follow-up proposal has ever been written** on this install — all 18 follow-up annotations are `applied`, which auto-absorbs and needs no surface. So this closes a gap that *would* lose signal, not one that *was*. The proposal half is verified by tests and mutation, not by live data.

An earlier draft of this change asserted in code comments that proposals "were written and rendered nowhere" and "superseded as stale having never been seen". The live store contradicts both — 0 proposed, 0 superseded for follow-up targets; all 34 superseded rows are ledger. Those comments now state the conditional and the measurement instead of a history that did not happen.

It fires on the four branches that propose rather than absorb: a pinned row, an absorb-miss race, `propose_only` mode, and a bare-hex citation — the last plausibly the most frequent, since any PR body carrying a bare follow-up id produces one.

## Review

Internal adversarial pass returned 4 SHOULD-FIX, all fixed: the truncation fail-open above; an untested issues-side fail-closed path (an earlier mutation run covered only the proposals half); comments asserting unhappened history; and the availability contract being invisible to the tool's only consumer. Two notes accepted as-is with reasons, one fixed alongside.

Ledger: e59311dad4af43f18abb646eac06fc3c
Ledger: 01367b02998447f184aaac875989490b


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Follow-up listings now show linked GitHub issues and proposed repo-pulse completions when available.
  * Listings indicate whether external follow-up data sources are available or unavailable.
  * Follow-ups without linked external records are handled more clearly.

* **Bug Fixes**
  * Session charters now exclude session-independent follow-up annotations, which remain available through global follow-up listings.
  * Improved matching and filtering of follow-ups to related issues and completion proposals.
  * Follow-up listings now consistently show the latest proposal for every displayed follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->