### PR TITLE
feat(routing): give the Mistral family an in-family rung below Large

### DIFF
--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -221,12 +221,21 @@ profiles:
     best_for: [memory_consolidation, fact_extraction, triage, outreach_draft]
     avoid_for: [creative_writing, long_context_work]
     free_tier:
-      # PRESUMPTIVE (user decision 2026-09-05): assume free-tier access to the
-      # Mistral family returns on all tiers. Medium is listed by /v1/models on
-      # a free-tier account, but its entitlement is UNVERIFIED — every live
-      # probe hit the account-wide rate limit (429) before an entitlement
-      # answer. If it turns out 403 tier_not_allowed like Large, the router's
-      # NOT_ENTITLED fail-fast makes that one cheap refusal per breaker window.
+      # ENTITLEMENT VERIFIED 2026-09-06; PRICING STILL PRESUMED (user decision
+      # 2026-09-05). A live probe of all three tiers on one free-tier account,
+      # same request shape, same minute:
+      #     mistral-large-latest  -> 403 tier_not_allowed
+      #     mistral-medium-latest -> 429 rate_limited
+      #     mistral-small-latest  -> 429 rate_limited
+      # A tier check precedes rate limiting, so Large is refused by entitlement
+      # while Medium is only throttled — Medium IS reachable on a tier that
+      # refuses Large. What the 429 does NOT establish is $0: it proves
+      # reachable, not free. `available: true` therefore remains an
+      # account-tier COST assumption until a completion's billed cost is read.
+      # Keep this comment and the one on `mistral-medium-free` in
+      # config/model_routing.yaml in agreement — they were briefly contradictory
+      # (one VERIFIED, one UNVERIFIED) after the entitlement probe landed in only
+      # one of them.
       available: true
       provider: mistral
       note: "Presumed free-tier; entitlement unverified as of 2026-09-05."

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -196,6 +196,43 @@ profiles:
     last_reviewed: "2026-09-03"
     review_source: provider_pricing_page
 
+  mistral-medium:
+    display_name: "Mistral Medium (latest)"
+    provider: mistral
+    api_id: "mistralai/mistral-medium-latest"
+    # Tier is INFERRED from Mistral's own positioning of Medium 3 as its
+    # frontier-class workhorse, not benchmarked on this install — no routing
+    # history exists for it yet. Revisit against real call outcomes once it
+    # carries traffic; the rest of the row mirrors the vendor pricing page.
+    intelligence_tier: A
+    reasoning: A
+    instruction_following: A
+    anti_sycophancy: B
+    context_window: 131072
+    cost_tier: cheap
+    cost_per_mtok_in: 0.40
+    cost_per_mtok_out: 2.00
+    latency: moderate
+    strengths:
+      - JSON instruction following
+      - strong quality-per-cost
+    weaknesses:
+      - 128k context is small
+    best_for: [memory_consolidation, fact_extraction, triage, outreach_draft]
+    avoid_for: [creative_writing, long_context_work]
+    free_tier:
+      # PRESUMPTIVE (user decision 2026-09-05): assume free-tier access to the
+      # Mistral family returns on all tiers. Medium is listed by /v1/models on
+      # a free-tier account, but its entitlement is UNVERIFIED — every live
+      # probe hit the account-wide rate limit (429) before an entitlement
+      # answer. If it turns out 403 tier_not_allowed like Large, the router's
+      # NOT_ENTITLED fail-fast makes that one cheap refusal per breaker window.
+      available: true
+      provider: mistral
+      note: "Presumed free-tier; entitlement unverified as of 2026-09-05."
+    last_reviewed: "2026-09-05"
+    review_source: provider_pricing_page
+
   mistral-small:
     display_name: "Mistral Small (latest)"
     provider: mistral

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -193,6 +193,17 @@ profiles:
       available: false
       provider: mistral
       note: "Large is paid-plan only since 2026-08; Small remains free-tier."
+    # See the `entitlement:` block on mistral-medium for what these three fields
+    # separate and why. Large is the case that motivated it: REFUSED on this
+    # account, with a precondition the operator can satisfy. Note that clearing
+    # the precondition changes `status`, NOT the routing `free:` flag — unlocking
+    # a model does not start charging per call. Conflating those is what put a
+    # fabricated price on a model nobody was being billed for.
+    entitlement:
+      status: refused           # 403 tier_not_allowed, two independent free-tier accounts
+      requires: funded_account  # credits on the account unlock it; calls stay $0 under limits
+      verified: "2026-08-27"
+      method: live_probe
     last_reviewed: "2026-09-03"
     review_source: provider_pricing_page
 
@@ -266,9 +277,26 @@ profiles:
       # explicit contract.
       note: >-
         Entitlement VERIFIED 2026-09-06 (429 rate_limited, not 403
-        tier_not_allowed). Pricing PRESUMED — no billed cost has been read, so
-        `free: false` in model_routing.yaml is the conservative assumption, not
-        a measurement.
+        tier_not_allowed). Marginal cost $0 under the free tier's rate limits,
+        which is what `free: true` in model_routing.yaml asserts.
+    # ── ENTITLEMENT: the third question `free:` was being asked to answer ─────
+    # There are THREE independent facts about a model, and the routing `free:`
+    # flag only carries the first:
+    #   1. marginal cost   — does a successful call add to the bill?  (`free:`)
+    #   2. entitlement     — may THIS account call it at all?          (here)
+    #   3. precondition    — what must be true for (2) to hold?        (here)
+    # They come apart in a case this install expects to hit: adding credits to a
+    # Mistral account unlocks models the free tier refuses, while calls under the
+    # rate limits remain $0. That is entitled + precondition:funded + free — and
+    # with only a boolean there was nowhere to say it, so the fact was being
+    # smuggled into `free:` and corrupting the budget gate.
+    # ADVISORY METADATA. No code reads this block yet; it exists so the reasoning
+    # has a home instead of living in a comment that the next probe contradicts.
+    entitlement:
+      status: entitled          # entitled | refused | unknown
+      requires: none            # none | funded_account | paid_plan | phone_verified
+      verified: "2026-09-06"
+      method: live_probe        # 429 rate_limited (throttled, therefore entitled)
     last_reviewed: "2026-09-06"
     review_source: provider_live_probe
 

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -209,9 +209,28 @@ profiles:
     instruction_following: A
     anti_sycophancy: B
     context_window: 131072
-    cost_tier: cheap
-    cost_per_mtok_in: 0.40
-    cost_per_mtok_out: 2.00
+    # NOT "cheap", and these are litellm's numbers rather than the vendor page's.
+    #
+    # These figures shipped as 0.40/2.00 (the pricing page for Medium 3). But the
+    # ledger does not use this row when litellm can price the model: the delegate
+    # tries `litellm.completion_cost()` FIRST and only falls back to the profile in
+    # the `except` branch. litellm has `mistral/mistral-medium-latest` at 1.50/7.50,
+    # so every recorded call would have been written at 1.50/7.50 while this file
+    # documented 0.40/2.00 — 3.75x, with no reader able to tell which was real.
+    #
+    # That is the PR #1619 defect one model over: flipping a provider to
+    # `free: false` while leaving its profile at a stale rate. The guard written
+    # after #1619 was hardcoded to `mistral-large-3`, so it could not see this.
+    # `test_paid_profiles_agree_with_the_rate_litellm_will_record` now checks EVERY
+    # paid provider against the number the ledger will actually write.
+    #
+    # Also: at 1.50/7.50 Medium is DEARER than mistral-large-3 (0.50/1.50), which is
+    # the opposite of what `cost_tier: cheap` told a reader choosing between them.
+    # (litellm's `-latest` entry appears to track Medium 3.5; the vendor page prices
+    # Medium 3 at 0.40/2.00. Recorded spend follows litellm, so this row does too.)
+    cost_tier: standard
+    cost_per_mtok_in: 1.50
+    cost_per_mtok_out: 7.50
     latency: moderate
     strengths:
       - JSON instruction following
@@ -238,9 +257,20 @@ profiles:
       # one of them.
       available: true
       provider: mistral
-      note: "Presumed free-tier; entitlement unverified as of 2026-09-05."
-    last_reviewed: "2026-09-05"
-    review_source: provider_pricing_page
+      # Two SEPARATE claims, and the note used to blur them into one. The 429
+      # settles ENTITLEMENT (the account may call this model). It settles
+      # nothing about COST. Cross-model review, 2026-09-06: this field still
+      # read "entitlement unverified as of 2026-09-05" while the comment 15
+      # lines above recorded the 09-06 probe — a third contradiction inside the
+      # very block whose comment makes keeping the two files in agreement an
+      # explicit contract.
+      note: >-
+        Entitlement VERIFIED 2026-09-06 (429 rate_limited, not 403
+        tier_not_allowed). Pricing PRESUMED — no billed cost has been read, so
+        `free: false` in model_routing.yaml is the conservative assumption, not
+        a measurement.
+    last_reviewed: "2026-09-06"
+    review_source: provider_live_probe
 
   mistral-small:
     display_name: "Mistral Small (latest)"

--- a/config/model_profiles.yaml
+++ b/config/model_profiles.yaml
@@ -200,9 +200,17 @@ profiles:
     # a model does not start charging per call. Conflating those is what put a
     # fabricated price on a model nobody was being billed for.
     entitlement:
-      status: refused           # 403 tier_not_allowed, two independent free-tier accounts
-      requires: funded_account  # credits on the account unlock it; calls stay $0 under limits
-      verified: "2026-08-27"
+      status: refused           # MEASURED: 403 tier_not_allowed, two independent free-tier accounts
+      # HYPOTHESIS, NOT MEASURED — and the two fields differ in evidence, which is
+      # why this says so rather than letting `verified:` below cover both. `status`
+      # was probed. `requires` is the expected vendor shape (put credits on the
+      # account, previously-refused models unlock, calls stay $0 under the tier's
+      # rate limits) and NOBODY HAS TESTED IT on this install. Settling it needs
+      # someone to fund an account and re-probe. Until then this is a lead for
+      # whoever does, not a fact to route on.
+      requires: funded_account
+      requires_confidence: hypothesis   # measured | reported | hypothesis
+      verified: "2026-08-27"    # applies to `status` only
       method: live_probe
     last_reviewed: "2026-09-03"
     review_source: provider_pricing_page
@@ -232,14 +240,32 @@ profiles:
     # That is the PR #1619 defect one model over: flipping a provider to
     # `free: false` while leaving its profile at a stale rate. The guard written
     # after #1619 was hardcoded to `mistral-large-3`, so it could not see this.
-    # `test_paid_profiles_agree_with_the_rate_litellm_will_record` now checks EVERY
-    # paid provider against the number the ledger will actually write.
+    #
+    # WHAT GUARDS THIS TODAY: nothing, and saying so is the point. An earlier
+    # draft of this comment promised a
+    # `test_paid_profiles_agree_with_the_rate_litellm_will_record` that checks
+    # every paid provider — that test was written, then LIFTED OUT of this PR
+    # because it fails on ten pre-existing providers (openrouter-deepseek-v4
+    # declares 0.43/0.87 against a recorded 1.32/3.96, on the provider carrying
+    # the most spend), and correcting ten unrelated providers does not belong in
+    # a release-blocking config change. The comment was not updated with it, so
+    # it advertised a guard that does not exist — caught by cross-model review,
+    # 2026-09-07. It ships separately.
+    #
+    # Second half of the same gap: `_paid_providers_with_profiles()` selects on
+    # `not spec.get("free")`, so now that both mistral rungs are `free: true` the
+    # family is outside even the nonzero-rate check. That is harmless while
+    # `free: true` holds — the delegate short-circuits to `cost = 0.0` and never
+    # reads these figures, making them documentation — but it means a future flip
+    # back to `free: false` re-arms the exact PR #1619 trap with no test watching.
+    # Anyone making that flip must re-check this row against litellm by hand until
+    # the generalised guard lands.
     #
     # Also: at 1.50/7.50 Medium is DEARER than mistral-large-3 (0.50/1.50), which is
     # the opposite of what `cost_tier: cheap` told a reader choosing between them.
     # (litellm's `-latest` entry appears to track Medium 3.5; the vendor page prices
     # Medium 3 at 0.40/2.00. Recorded spend follows litellm, so this row does too.)
-    cost_tier: standard
+    cost_tier: expensive
     cost_per_mtok_in: 1.50
     cost_per_mtok_out: 7.50
     latency: moderate
@@ -295,6 +321,13 @@ profiles:
     entitlement:
       status: entitled          # entitled | refused | unknown
       requires: none            # none | funded_account | paid_plan | phone_verified
+      # MEASURED, unlike the sibling field on mistral-large-3: the 429 came from
+      # an UNFUNDED free-tier account, which is itself the evidence that no
+      # precondition is needed. `requires_confidence` is written on every
+      # entitlement block, always — an absent field would leave a reader guessing
+      # which half of the block was probed, and that guess is exactly what a
+      # confident-looking config invites.
+      requires_confidence: measured   # measured | reported | hypothesis
       verified: "2026-09-06"
       method: live_probe        # 429 rate_limited (throttled, therefore entitled)
     last_reviewed: "2026-09-06"

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -42,10 +42,20 @@ providers:
     # Mistral family degrades within itself before leaving the family — and
     # when Large's entitlement returns (or an install has a paid plan), the
     # chain silently uses the best available tier with no config change.
-    # PRESUMPTIVE free (user decision 2026-09-05): entitlement unverified —
-    # probes 429'd on the account-wide limit before answering; see the
-    # mistral-medium profile's free_tier note. rpm matches Large's
-    # conservative 4 until real traffic establishes a better figure.
+    # ENTITLEMENT VERIFIED 2026-09-06, PRICING STILL PRESUMED. A live probe of
+    # all three tiers on one free-tier account, same request shape, same minute:
+    #   mistral-large-latest  -> 403 tier_not_allowed
+    #   mistral-medium-latest -> 429 rate_limited
+    #   mistral-small-latest  -> 429 rate_limited
+    # The 403/429 split IS the discriminator: a tier check precedes rate
+    # limiting, so Large is refused by entitlement while Medium is merely
+    # throttled. Medium is therefore reachable on a tier that refuses Large,
+    # which is the whole premise of this rung.
+    # What that does NOT establish is $0 — a 429 proves reachable, not free.
+    # `free: true` is an account-tier COST claim and remains presumed until a
+    # completion lands and its recorded cost is checked. If it turns out
+    # metered, never_pays sites walking this rung is the exposure to fix.
+    # rpm matches Large's conservative 4 until real traffic says otherwise.
     free: true
     rpm_limit: 4
     open_duration_s: 120

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -34,6 +34,21 @@ providers:
     free: false
     rpm_limit: 4
     open_duration_s: 120
+  mistral-medium-free:
+    type: mistral
+    model: mistral-medium-latest
+    profile: mistral-medium
+    # The rung DIRECTLY BELOW Large in every chain that carries Large, so the
+    # Mistral family degrades within itself before leaving the family — and
+    # when Large's entitlement returns (or an install has a paid plan), the
+    # chain silently uses the best available tier with no config change.
+    # PRESUMPTIVE free (user decision 2026-09-05): entitlement unverified —
+    # probes 429'd on the account-wide limit before answering; see the
+    # mistral-medium profile's free_tier note. rpm matches Large's
+    # conservative 4 until real traffic establishes a better figure.
+    free: true
+    rpm_limit: 4
+    open_duration_s: 120
   mistral-small-free:
     type: mistral
     model: mistral-small-latest
@@ -279,6 +294,7 @@ call_sites:
     - mistral-small-free
     - openrouter-free
     - mistral-large-free
+    - mistral-medium-free
     - groq-free
     - gemini-free
     # Additional free providers so an essential reflection (3_micro_reflection
@@ -293,6 +309,7 @@ call_sites:
     - gemini-free
     - groq-free
     - mistral-large-free
+    - mistral-medium-free
     default_paid: false
     never_pays: true
   5_deep_reflection:
@@ -320,6 +337,7 @@ call_sites:
     - gemini-free
     - nvidia-nim-deepseek
     - mistral-large-free
+    - mistral-medium-free
     - openrouter-deepseek-v4-flash
   # V4 placeholder: cognitive state IS actively maintained today, but via direct
   # DB writes (awareness/loop.py, cc/reflection_bridge*.py), NOT this call site.
@@ -340,6 +358,7 @@ call_sites:
     chain:
     - gemini-free
     - mistral-large-free
+    - mistral-medium-free
     - groq-free
     - openrouter-free
     - nvidia-nim-deepseek
@@ -347,6 +366,7 @@ call_sites:
   13_morning_report:
     chain:
     - mistral-large-free
+    - mistral-medium-free
     - groq-free
     - gemini-free
     - openrouter-free
@@ -391,6 +411,7 @@ call_sites:
   21_session_observer:
     chain:
     - mistral-large-free
+    - mistral-medium-free
     - groq-free
     - gemini-free
     - openrouter-free
@@ -413,13 +434,17 @@ call_sites:
   # Adversarial challenge of synthesis output. Must stay model-independent from
   # synthesis across the WHOLE chain, not just the primary: synthesis falls back
   # to groq-free, so a groq-led challenge could self-approve under a DeepSeek
-  # outage. This challenge leads with mistral-large-free (disjoint from every
-  # synthesis provider — deepseek-flash / groq) + paid Kimi as the deep fallback.
+  # outage. This challenge leads with the MISTRAL family (disjoint from every
+  # synthesis provider — deepseek-flash / groq): Large, then Medium as the free
+  # in-family rung, then paid Kimi as the deep fallback. Medium is what keeps a
+  # dead/entitlement-blocked Large from sending EVERY challenge to paid Kimi
+  # (measured live 2026-09-05 while Large returned 403 tier_not_allowed).
   # NIM's free Kimi was retired 2026-08 (404-for-account). Locked by
   # test_config_invariants::test_adversarial_challenge_sites_are_model_independent.
   dream_cycle_synthesis_challenge:
     chain:
     - mistral-large-free
+    - mistral-medium-free
     # Paid Kimi via OpenRouter as last-resort fallback — a non-DeepSeek, non-groq
     # family, so the challenge stays model-independent from synthesis across the
     # whole chain even when the free tier is down. Only billed during an outage.
@@ -434,6 +459,7 @@ call_sites:
     # from the DeepSeek entity_challenge while surviving a free-tier outage.
     - gemini-free
     - mistral-large-free
+    - mistral-medium-free
     - openrouter-gemma4
     retry_profile: background
   # MW-2 relationship classifier — coarse relationship judgment
@@ -448,6 +474,7 @@ call_sites:
     - openrouter-free
     - gemini-free
     - mistral-large-free
+    - mistral-medium-free
     - openrouter-gemma4
     retry_profile: background
   # Adversarial challenge of entity "duplicate" verdicts. Flipped pairing:
@@ -466,6 +493,7 @@ call_sites:
     - openrouter-free
     - gemini-free
     - mistral-large-free
+    - mistral-medium-free
     - openrouter-gemma4
     retry_profile: background
   # Adversarial challenge of an entity-node "merge" verdict. Flipped pairing
@@ -506,23 +534,27 @@ call_sites:
     chain:
     - groq-free
     - mistral-large-free
+    - mistral-medium-free
     - openrouter-nemo
   30_triage_calibration:
     chain:
     - lmstudio-30b
     - mistral-large-free
+    - mistral-medium-free
     default_paid: true
     retry_profile: background
   31_outcome_classification:
     chain:
     - glm51
     - mistral-large-free
+    - mistral-medium-free
     default_paid: true
     never_pays: false
   32_delta_assessment:
     chain:
     - glm51
     - mistral-large-free
+    - mistral-medium-free
     default_paid: true
     never_pays: false
   33_skill_refiner:
@@ -531,12 +563,14 @@ call_sites:
     - groq-free
     - nvidia-nim-deepseek
     - mistral-large-free
+    - mistral-medium-free
     description: LLM-driven skill improvement proposals
   34_research_synthesis:
     chain:
     - gemini-free
     - groq-free
     - mistral-large-free
+    - mistral-medium-free
     - nvidia-nim-deepseek
     description: Synthesize research results into concise summaries
   38_procedure_extraction:
@@ -546,6 +580,7 @@ call_sites:
     - openrouter-deepseek-v4
     - groq-free
     - mistral-large-free
+    - mistral-medium-free
     default_paid: true
     description: Judge + store procedures from struggle detection and extraction
       pipeline candidates
@@ -560,6 +595,7 @@ call_sites:
   41_reflection_json_salvage:
     chain:
     - mistral-large-free
+    - mistral-medium-free
     - gemini-free
     - openrouter-deepseek-v4
     default_paid: true
@@ -579,6 +615,7 @@ call_sites:
     - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
     - mistral-large-free
+    - mistral-medium-free
     - gemini-free
     default_paid: true
     description: Post-execution retrospective learning extraction
@@ -588,6 +625,7 @@ call_sites:
     - openrouter-deepseek-v4-flash
     - openrouter-deepseek-v4
     - mistral-large-free
+    - mistral-medium-free
     - gemini-free
     default_paid: true
     description: Pre-mortem failure analysis before committing to execution
@@ -596,6 +634,7 @@ call_sites:
     - gemini-free
     - groq-free
     - mistral-large-free
+    - mistral-medium-free
     - openrouter-free
     never_pays: true
     retry_profile: background
@@ -612,6 +651,7 @@ call_sites:
     - nvidia-nim-deepseek
     - gemini-free
     - mistral-large-free
+    - mistral-medium-free
     - openrouter-free
     default_paid: true
     retry_profile: background
@@ -621,6 +661,7 @@ call_sites:
     - gemini-free
     - groq-free
     - mistral-large-free
+    - mistral-medium-free
     - openrouter-free
     description: Draft content for various platforms
   23_outreach_review:
@@ -628,6 +669,7 @@ call_sites:
     - gemini-free
     - groq-free
     - mistral-large-free
+    - mistral-medium-free
     description: "Outreach pre-send cross-vendor review (free chain). Renamed from 23_fresh_eyes_review 2026-05-10 (disambiguates from executor Gate 2 at 17_executor_review)."
   36_code_auditor:
     chain:
@@ -644,6 +686,7 @@ call_sites:
     chain:
     - groq-free
     - mistral-large-free
+    - mistral-medium-free
     - openrouter-nemo
     default_paid: true
     retry_profile: background
@@ -654,6 +697,7 @@ call_sites:
     - groq-free
     - gemini-free
     - mistral-large-free
+    - mistral-medium-free
     - openrouter-free
     - openrouter-deepseek-v4-flash
     default_paid: true
@@ -662,6 +706,7 @@ call_sites:
   41_resume_review_pass1:
     chain:
     - mistral-large-free
+    - mistral-medium-free
     - gemini-free
     - groq-free
     - openrouter-free
@@ -670,6 +715,7 @@ call_sites:
   42_resume_review_pass2:
     chain:
     - mistral-large-free
+    - mistral-medium-free
     - gemini-free
     - groq-free
     - openrouter-free
@@ -712,6 +758,7 @@ call_sites:
   cc_update_analysis:
     chain:
     - mistral-large-free
+    - mistral-medium-free
     - groq-free
     - gemini-free
     default_paid: true
@@ -766,6 +813,7 @@ call_sites:
     - groq-free
     - gemini-free
     - mistral-large-free
+    - mistral-medium-free
     default_paid: false
     retry_profile: user_facing
     dispatch: api

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -56,7 +56,15 @@ providers:
     # completion lands and its recorded cost is checked. If it turns out
     # metered, never_pays sites walking this rung is the exposure to fix.
     # rpm matches Large's conservative 4 until real traffic says otherwise.
-    free: true
+    #
+    # SHIPS `free: false` BY USER DECISION 2026-09-06. never_pays is a fail-CLOSED
+    # cost-safety invariant and it must not rest on a fail-OPEN presumption: a 429
+    # proves the model is reachable on this tier, not that it costs $0. Flip to
+    # true once a completion's BILLED cost has actually been read. Until then the
+    # three never_pays sites carrying this rung simply skip it — the rung still
+    # earns its place in paid-position chains, where it sits below Large and above
+    # the paid Kimi leg.
+    free: false
     rpm_limit: 4
     open_duration_s: 120
   mistral-small-free:

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -42,8 +42,7 @@ providers:
     #
     # Which is why this is back to `true` (2026-09-07). Mistral's tier is $0 per
     # call under its rate limits; the 403 is an ENTITLEMENT refusal, not a billing
-    # event, and an entitlement refusal costs nothing precisely because the call
-    # never happens. Marking it `false` did not describe a price — it fabricated
+    # event, so it costs no MONEY. Marking it `false` did not describe a price — it fabricated
     # one, and MEASURED, the fabrication is not free: with `free: false` the
     # ledger records this family at litellm's paid rate against a default-seeded
     # $2/day budget, and once that trips, router.py:352 removes EVERY paid
@@ -54,6 +53,22 @@ providers:
     # local overlay. That direction is the safe one to get wrong: it over-records
     # spend for an install that is genuinely paying, rather than inventing spend
     # for one that is not.
+    #
+    # WHAT `free: true` COSTS HERE, stated because the first draft of this comment
+    # argued it away. `_filter_chain` keeps free providers on never_pays sites, so
+    # Large is now WALKED on all three of them (4_light_reflection,
+    # 12_surplus_brainstorm, 45_intelligence_intake) where `free: false` had
+    # filtered it out entirely. On an account whose 403 this file documents as
+    # durable, that is a doomed round-trip on every breaker-closed window: three
+    # failures trip it, it re-probes after open_duration_s, fails, trips again.
+    # No money — but latency and failure noise on exactly the sites the rung is
+    # meant to help. Cross-model review flagged this (2026-09-07) against an
+    # earlier wording here that said the refusal "costs nothing precisely because
+    # the call never happens". It costs no MONEY; the call does happen.
+    # Accepted, because the same flag is what admits Medium — which IS reachable —
+    # to those chains, and a fast 403 ahead of a working rung is a better trade
+    # than filtering both out. Revisit if Large's entitlement is ever restored,
+    # or if the wasted probe shows up in latency.
     free: true
     rpm_limit: 4
     open_duration_s: 120
@@ -88,7 +103,12 @@ providers:
     #     NOT the 0.40/2.00 the profile documented, because `completion_cost()`
     #     is tried before the profile fallback ever runs.
     #   * Of the 30 chains carrying this rung, 10 have NO free provider ahead of
-    #     it (13_morning_report, 21_session_observer, 31_outcome_classification,
+    #     it AS THE ROUTER LOADS THE CONFIG. Say which basis, because the two
+    #     counts differ and two reviewers reached different numbers from it: raw
+    #     YAML gives 9, and 30_triage_calibration joins once lmstudio-30b is
+    #     dropped at load for having no key. 10 is the number that describes
+    #     runtime, which is the one that matters here.
+    #     (13_morning_report, 21_session_observer, 31_outcome_classification,
     #     32_delta_assessment, dream_cycle_synthesis_challenge, …). With Large
     #     403-dead, Medium is the FIRST provider actually tried on those — on
     #     ordinary operation, not during an outage.

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -454,9 +454,26 @@ call_sites:
   # to groq-free, so a groq-led challenge could self-approve under a DeepSeek
   # outage. This challenge leads with the MISTRAL family (disjoint from every
   # synthesis provider — deepseek-flash / groq): Large, then Medium as the free
-  # in-family rung, then paid Kimi as the deep fallback. Medium is what keeps a
-  # dead/entitlement-blocked Large from sending EVERY challenge to paid Kimi
-  # (measured live 2026-09-05 while Large returned 403 tier_not_allowed).
+  # in-family rung, then paid Kimi as the deep fallback.
+  #
+  # WHAT MEDIUM ACTUALLY BUYS HERE — stated carefully, because the first version
+  # of this comment claimed more than the code delivers. It said Medium "keeps a
+  # dead/entitlement-blocked Large from sending EVERY challenge to paid Kimi".
+  # Cross-model review (2026-09-06) ran this site under the install's OWN
+  # measured state — Large 403 tier_not_allowed, Medium 429 rate_limited — and
+  # the challenge was served by paid kimi-k2.5 anyway. A 429 is RATE_LIMITED,
+  # which deliberately does not trip a breaker, so Medium is re-attempted on
+  # every challenge while throttled at 4 RPM shared across every chain carrying
+  # it. Medium DOES intercept when it is not throttled, so the rung earns its
+  # place — but under the throttling actually observed, falling through to paid
+  # Kimi is the common case, not the outage case.
+  #
+  # PROVENANCE, because the distinction matters for anyone re-checking this:
+  # both runs above are the REVIEWER'S HARNESS (the real Router against the real
+  # config, with the network stubbed) — NOT production traffic. A follow-up audit
+  # found `cost_events` contains no mistral row of any kind, ever, so nothing here
+  # is corroborated by the live ledger. Treat as a faithful simulation of the
+  # routing logic, not as an observation of this install in flight.
   # NIM's free Kimi was retired 2026-08 (404-for-account). Locked by
   # test_config_invariants::test_adversarial_challenge_sites_are_model_independent.
   dream_cycle_synthesis_challenge:

--- a/config/model_routing.yaml
+++ b/config/model_routing.yaml
@@ -31,7 +31,30 @@ providers:
     # provider NAME keeps its historical "-free" suffix deliberately: 30
     # call-site chains reference it, and an in-place semantic fix beats a
     # rename churn (same reasoning as the groq-free alias below).
-    free: false
+    #
+    # `free:` ANSWERS ONE QUESTION: does a successful call add to the bill?
+    # Nothing else. Every consumer reads it that way — litellm_delegate sets
+    # `cost = 0.0` on it, router.py's budget gate skips non-free providers when
+    # the daily cap is EXCEEDED, and `_filter_chain` drops non-free entries from
+    # never_pays sites. None of them asks "is this account entitled?" or "did the
+    # operator have to pay something to unlock it?". Those are separate facts and
+    # they now live in the profile's `entitlement:` block.
+    #
+    # Which is why this is back to `true` (2026-09-07). Mistral's tier is $0 per
+    # call under its rate limits; the 403 is an ENTITLEMENT refusal, not a billing
+    # event, and an entitlement refusal costs nothing precisely because the call
+    # never happens. Marking it `false` did not describe a price — it fabricated
+    # one, and MEASURED, the fabrication is not free: with `free: false` the
+    # ledger records this family at litellm's paid rate against a default-seeded
+    # $2/day budget, and once that trips, router.py:352 removes EVERY paid
+    # provider from EVERY chain — including the contingency lane that exists for
+    # exactly that moment.
+    #
+    # AN INSTALL ON A METERED MISTRAL PLAN SHOULD OVERRIDE `free: false` in its
+    # local overlay. That direction is the safe one to get wrong: it over-records
+    # spend for an install that is genuinely paying, rather than inventing spend
+    # for one that is not.
+    free: true
     rpm_limit: 4
     open_duration_s: 120
   mistral-medium-free:
@@ -51,20 +74,35 @@ providers:
     # limiting, so Large is refused by entitlement while Medium is merely
     # throttled. Medium is therefore reachable on a tier that refuses Large,
     # which is the whole premise of this rung.
-    # What that does NOT establish is $0 — a 429 proves reachable, not free.
-    # `free: true` is an account-tier COST claim and remains presumed until a
-    # completion lands and its recorded cost is checked. If it turns out
-    # metered, never_pays sites walking this rung is the exposure to fix.
     # rpm matches Large's conservative 4 until real traffic says otherwise.
     #
-    # SHIPS `free: false` BY USER DECISION 2026-09-06. never_pays is a fail-CLOSED
-    # cost-safety invariant and it must not rest on a fail-OPEN presumption: a 429
-    # proves the model is reachable on this tier, not that it costs $0. Flip to
-    # true once a completion's BILLED cost has actually been read. Until then the
-    # three never_pays sites carrying this rung simply skip it — the rung still
-    # earns its place in paid-position chains, where it sits below Large and above
-    # the paid Kimi leg.
-    free: false
+    # `free: true` — see the reasoning on mistral-large-free above; the same
+    # question is being answered here (marginal cost, not entitlement).
+    #
+    # This SHIPPED `free: false` for one day (2026-09-06) on a fail-closed
+    # argument: never_pays is a cost-safety invariant, a 429 proves reachable
+    # rather than $0, so assume paid. The argument was sound and the conclusion
+    # was still wrong, because it priced the wrong risk. MEASURED afterwards:
+    #
+    #   * With `free: false`, litellm prices this model at 1.50/7.50 per MTok —
+    #     NOT the 0.40/2.00 the profile documented, because `completion_cost()`
+    #     is tried before the profile fallback ever runs.
+    #   * Of the 30 chains carrying this rung, 10 have NO free provider ahead of
+    #     it (13_morning_report, 21_session_observer, 31_outcome_classification,
+    #     32_delta_assessment, dream_cycle_synthesis_challenge, …). With Large
+    #     403-dead, Medium is the FIRST provider actually tried on those — on
+    #     ordinary operation, not during an outage.
+    #   * That fabricated spend accrues against a default-seeded $2/day budget,
+    #     and `router.py:352` responds by skipping every non-free provider at
+    #     every call site. There is no production caller passing
+    #     `budget_override=True`.
+    #
+    # So the two errors are not symmetric. Wrongly `true` costs real money on the
+    # three never_pays sites, bounded by 4 RPM. Wrongly `false` invents spend on
+    # ten first-tried chains and can disable the entire paid fallback tier
+    # system-wide. The fail-closed instinct was protecting the smaller blast
+    # radius while opening the larger one.
+    free: true
     rpm_limit: 4
     open_duration_s: 120
   mistral-small-free:

--- a/src/genesis/routing/circuit_breaker.py
+++ b/src/genesis/routing/circuit_breaker.py
@@ -82,7 +82,20 @@ class CircuitBreaker:
 
     @property
     def last_failure_category(self) -> ErrorCategory | None:
-        """Category of the most recent failure that tripped the breaker."""
+        """Category of the most recent failure — NOT only of a tripping one.
+
+        ``record_failure`` assigns this before it evaluates the trip threshold,
+        so a CLOSED breaker routinely carries a category from a failure that
+        never tripped it, and a category that never trips at all (RATE_LIMITED)
+        can sit here indefinitely. ``record_success`` clears it to None, so the
+        honest reading is "the most recent outcome was a failure of this kind,
+        and nothing has succeeded since".
+
+        The docstring used to say "that tripped the breaker". Two separate
+        defects were reasoned out from that wrong description before it was
+        corrected (2026-09-07), so the precision here is load-bearing rather
+        than pedantic.
+        """
         return self._last_failure_category
 
     def _effective_open_duration(self) -> float:
@@ -554,6 +567,37 @@ class CircuitBreakerRegistry:
         as covered keeps coverage consistent with routing and avoids a false
         ESSENTIAL alarm while a provider is recovering. A name not in the
         provider set counts as unavailable.
+
+        **A CLOSED breaker is not always evidence of health.** RATE_LIMITED is
+        deliberately excluded from tripping (``retry.py`` — 429 is provider
+        backpressure, not a health signal, and tripping would take a reachable
+        provider offline for every other call site). The consequence for THIS
+        function is that a provider whose steady state is 429 never trips, so it
+        reads "available" forever while serving nothing — and because coverage is
+        ``any(available)``, one such member is enough to mark an essential site
+        covered and silence the ESSENTIAL degradation alarm while every call to
+        that site fails.
+
+        That is not hypothetical: adding a 429-throttled rung to
+        ``4_light_reflection`` and ``9_fact_extraction`` did exactly this, and it
+        survived three cost-focused review rounds because it is caused by chain
+        MEMBERSHIP — independent of the ``free:`` flag and of ``never_pays``
+        filtering, which is where everyone was looking.
+
+        **KNOWN GAP, NOT FIXED HERE — and the obvious fix does not work.** The
+        tempting guard is ``if cb.last_failure_category is RATE_LIMITED: return
+        False``. It is INERT: ``router.py`` (see its RATE_LIMITED/BAD_REQUEST
+        exclusion) never calls ``record_failure`` for a 429 at all, so
+        ``_last_failure_category`` is never assigned that value on the production
+        path — a 429-only provider carries ``None`` and zero consecutive
+        failures. That guard would read as protection and provide none, which is
+        worse than leaving the gap visible. It was written, MEASURED to be inert,
+        and removed (2026-09-07).
+
+        Closing this properly needs a signal the breaker does not currently keep:
+        either a suppressed-failure counter recorded alongside the excluded
+        categories, or a "has ever served a request" bit. Both change breaker
+        semantics and belong in their own change, not in a config PR.
         """
         cfg = self._providers.get(name)
         if cfg is None:

--- a/src/genesis/routing/router.py
+++ b/src/genesis/routing/router.py
@@ -509,10 +509,15 @@ class Router:
                 failed_providers=tuple(failed_providers),
                 # The WALKABLE chain: post-`_filter_chain`, so a `never_pays`
                 # site does not count paid entries it was never going to try.
-                # That is the only length `attempts` can be reconciled against
-                # — but it is NOT the length a reader counts in
-                # `model_routing.yaml`, and the two currently differ on three
-                # of this install's nine `never_pays` sites.
+                # That is the only length `attempts` can be reconciled against,
+                # and it is not necessarily the length a reader counts in
+                # `model_routing.yaml`. As of 2026-09-07 the two AGREE on all
+                # nine `never_pays` sites — the three that used to differ did so
+                # because both Mistral rungs were `free: false`, and flipping
+                # them to `free: true` made every never_pays chain fully
+                # walkable. Do not read that agreement as an invariant: it is a
+                # property of the current config, and adding one non-free
+                # provider to a never_pays chain re-opens the gap.
                 chain_size=len(chain),
             )
 

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -133,7 +133,9 @@ def test_load_full_yaml(monkeypatch):
     # unwired openrouter-qwen3coder (delisted qwen/qwen3-coder:free slug).
     # 2026-08-19: 26 → 25 after removing dead nvidia-nim-kimi (moonshotai/kimi-k2.6
     # 404-for-account on NIM); nvidia-nim-deepseek repointed v4-pro → v4-flash-0731.
-    assert len(cfg.providers) == 25
+    # 2026-09-05: 25 -> 26 with mistral-medium-free — the in-family rung
+    # directly below Large (presumptive free tier; see model_routing.yaml).
+    assert len(cfg.providers) == 26
     assert "lmstudio-30b" not in cfg.providers
     assert "github-o3mini" not in cfg.providers
     assert "openrouter-deepseek-r1" not in cfg.providers  # removed from config
@@ -222,14 +224,20 @@ def test_load_full_yaml(monkeypatch):
     assert cfg.call_sites["29_retrospective_triage"].chain == [
         "groq-free",
         "mistral-large-free",
+        "mistral-medium-free",
         "openrouter-nemo",
     ]
     assert cfg.call_sites["30_triage_calibration"].default_paid is True
-    # lmstudio-30b filtered out, only mistral-large-free remains
-    assert cfg.call_sites["30_triage_calibration"].chain == ["mistral-large-free"]
+    # lmstudio-30b filtered out; the Mistral family rungs remain (Large, then
+    # Medium directly below it — the in-family fallback added 2026-09-05).
+    assert cfg.call_sites["30_triage_calibration"].chain == [
+        "mistral-large-free",
+        "mistral-medium-free",
+    ]
     assert cfg.call_sites["31_outcome_classification"].chain == [
         "glm51",
         "mistral-large-free",
+        "mistral-medium-free",
     ]
 
     # mistral-large-free provider (consolidated from mistral-free + mistral-large).

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -241,11 +241,17 @@ def test_load_full_yaml(monkeypatch):
     ]
 
     # mistral-large-free provider (consolidated from mistral-free + mistral-large).
-    # free: false since 2026-09: Mistral removed Large from free-tier entitlement
-    # (403 tier_not_allowed, measured on two independent free-tier accounts), so
-    # cost is tracked at paid rates and never_pays chains exclude it.
+    #
+    # `free: true` since 2026-09-07, reverting a one-day `false`. The flag answers
+    # MARGINAL COST ("does a successful call add to the bill?") and nothing else —
+    # every consumer reads it that way (litellm_delegate sets cost=0.0 on it,
+    # router.py's budget gate, _filter_chain's never_pays filter). Mistral's tier
+    # is $0 per call under its rate limits, and the 403 tier_not_allowed this
+    # account gets is an ENTITLEMENT refusal, which costs nothing precisely
+    # because the call never happens. Entitlement now lives in the profile's
+    # `entitlement:` block, where it can be stated without corrupting the budget.
     ml = cfg.providers["mistral-large-free"]
-    assert ml.is_free is False
+    assert ml.is_free is True
     assert ml.model_id == "mistral-large-latest"
 
     # groq-free provider — MIGRATED 2026-08-06: Groq deprecated

--- a/tests/test_routing/test_config.py
+++ b/tests/test_routing/test_config.py
@@ -247,9 +247,14 @@ def test_load_full_yaml(monkeypatch):
     # every consumer reads it that way (litellm_delegate sets cost=0.0 on it,
     # router.py's budget gate, _filter_chain's never_pays filter). Mistral's tier
     # is $0 per call under its rate limits, and the 403 tier_not_allowed this
-    # account gets is an ENTITLEMENT refusal, which costs nothing precisely
-    # because the call never happens. Entitlement now lives in the profile's
-    # `entitlement:` block, where it can be stated without corrupting the budget.
+    # account gets is an ENTITLEMENT refusal, so it costs no MONEY — the call
+    # DOES happen and fails, on the three never_pays sites `free: true` re-admits
+    # Large to. (An earlier draft said "costs nothing precisely because the call
+    # never happens". That sentence was retracted in model_routing.yaml by this
+    # same change and left standing here — the copy outliving its correction,
+    # which is the instance-patching signature this PR is otherwise about.)
+    # Entitlement now lives in the profile's `entitlement:` block, where it can
+    # be stated without corrupting the budget.
     ml = cfg.providers["mistral-large-free"]
     assert ml.is_free is True
     assert ml.model_id == "mistral-large-latest"

--- a/tests/test_routing/test_integration.py
+++ b/tests/test_routing/test_integration.py
@@ -107,17 +107,19 @@ async def test_surplus_never_pays(real_config, breakers, cost_tracker, degradati
     result = await router.route_call("12_surplus_brainstorm", [{"role": "user", "content": "brainstorm"}])
     assert result.success is False
     providers_called = {c["provider"] for c in delegate.calls}
-    # The walk actually happened. Without this, `_filter_chain` returning []
-    # short-circuits `route_call` before any attempt and BOTH assertions below
-    # pass vacuously — success is False because nothing ran, and the loop is
-    # empty. That is a worse bug than the one this test targets.
+    # This single assertion carries both halves of the invariant, which is why
+    # there is no separate per-provider `is_free` loop after it:
+    #   - EVERY free rung was tried. Without this, `_filter_chain` returning []
+    #     short-circuits `route_call` before any attempt and `success is False`
+    #     passes because nothing ran — a worse bug than the one under test.
+    #   - ONLY free rungs were tried, since `free_chain` is itself the `is_free`
+    #     filter. A separate loop over `providers_called` asserting `is_free`
+    #     could no longer fail once this equality holds; it would imply
+    #     independent coverage it does not provide.
     assert providers_called == set(free_chain), (
         f"expected every free rung to be tried; walked {sorted(providers_called)} "
         f"of {sorted(free_chain)}"
     )
-    # Only free providers
-    for p in providers_called:
-        assert real_config.providers[p].is_free
 
 
 @pytest.mark.asyncio

--- a/tests/test_routing/test_integration.py
+++ b/tests/test_routing/test_integration.py
@@ -75,14 +75,30 @@ async def test_full_stack_fallback_chain(real_config, breakers, cost_tracker, de
 
 @pytest.mark.asyncio
 async def test_surplus_never_pays(real_config, breakers, cost_tracker, degradation):
-    """12_surplus_brainstorm has never_pays — all free fail, no paid providers called."""
+    """12_surplus_brainstorm has never_pays — all free fail, no paid providers called.
+
+    The down-list is DERIVED from the site's own free chain rather than
+    hard-coded. It used to be an enumerated list of provider names, which made
+    the test a tripwire on the roster instead of on the invariant: adding any
+    free rung to this chain left that rung un-mocked, so `MockDelegate` handed
+    it the default success stub and the run reached `assert result.success is
+    False` with a success. That reads as a `never_pays` breach and is not one —
+    the invariant is enforced structurally by `Router._filter_chain`, which
+    walks only providers flagged `free`.
+
+    What catches a paid provider leaking through is the combination of
+    `MockDelegate`'s default SUCCESS stub and `assert result.success is False`
+    — an unfiltered walk reaches `mistral-large-free` (named `-free`, flagged
+    `free: false` since Mistral pulled Large from the free tier), which is not
+    in `responses`, so it succeeds and the assertion fires. The trailing loop
+    is a secondary, explicit check on WHICH providers were walked; it is not
+    reached in that failure mode.
+    """
+    site = real_config.call_sites["12_surplus_brainstorm"]
+    free_chain = [p for p in site.chain if real_config.providers[p].is_free]
+    assert free_chain, "guard-the-guard: a site with no free rung cannot test never_pays"
     delegate = MockDelegate(responses={
-        "cerebras-qwen": CallResult(success=False, error="down", status_code=503),
-        "mistral-large-free": CallResult(success=False, error="down", status_code=503),
-        "groq-free": CallResult(success=False, error="down", status_code=503),
-        "gemini-free": CallResult(success=False, error="down", status_code=503),
-        "openrouter-free": CallResult(success=False, error="down", status_code=503),
-        "nvidia-nim-deepseek": CallResult(success=False, error="down", status_code=503),
+        p: CallResult(success=False, error="down", status_code=503) for p in free_chain
     })
     router = Router(
         config=real_config, breakers=breakers, cost_tracker=cost_tracker,
@@ -91,6 +107,14 @@ async def test_surplus_never_pays(real_config, breakers, cost_tracker, degradati
     result = await router.route_call("12_surplus_brainstorm", [{"role": "user", "content": "brainstorm"}])
     assert result.success is False
     providers_called = {c["provider"] for c in delegate.calls}
+    # The walk actually happened. Without this, `_filter_chain` returning []
+    # short-circuits `route_call` before any attempt and BOTH assertions below
+    # pass vacuously — success is False because nothing ran, and the loop is
+    # empty. That is a worse bug than the one this test targets.
+    assert providers_called == set(free_chain), (
+        f"expected every free rung to be tried; walked {sorted(providers_called)} "
+        f"of {sorted(free_chain)}"
+    )
     # Only free providers
     for p in providers_called:
         assert real_config.providers[p].is_free

--- a/tests/test_routing/test_integration.py
+++ b/tests/test_routing/test_integration.py
@@ -87,12 +87,20 @@ async def test_surplus_never_pays(real_config, breakers, cost_tracker, degradati
     walks only providers flagged `free`.
 
     What catches a paid provider leaking through is the combination of
-    `MockDelegate`'s default SUCCESS stub and `assert result.success is False`
-    — an unfiltered walk reaches `mistral-large-free` (named `-free`, flagged
-    `free: false` since Mistral pulled Large from the free tier), which is not
-    in `responses`, so it succeeds and the assertion fires. The trailing loop
-    is a secondary, explicit check on WHICH providers were walked; it is not
-    reached in that failure mode.
+    `MockDelegate`'s default SUCCESS stub and `assert result.success is False`:
+    an unfiltered walk reaches a provider that is NOT in `responses` (because
+    `responses` is derived from the free chain), that provider returns the
+    default success, and the assertion fires.
+
+    Deliberately stated without naming a provider. This docstring used to cite
+    `mistral-large-free` as the concrete tripwire "flagged `free: false` since
+    Mistral pulled Large from the free tier" — and then the very commit that
+    reclassified both mistral rungs to `free: true` left the sentence standing,
+    so the example contradicted the config shipping beside it. Cross-model
+    review caught it (2026-09-07). The mechanism is what protects this test;
+    which provider happens to embody it is config that moves.
+    The trailing loop is a secondary, explicit check on WHICH providers were
+    walked; it is not reached in that failure mode.
     """
     site = real_config.call_sites["12_surplus_brainstorm"]
     free_chain = [p for p in site.chain if real_config.providers[p].is_free]

--- a/tests/test_routing/test_model_profiles.py
+++ b/tests/test_routing/test_model_profiles.py
@@ -376,7 +376,16 @@ class TestPaidProviderProfilePricing:
         """
         pairs = self._paid_providers_with_profiles()
         assert len(pairs) >= 5, pairs
-        assert all(name and profile for name, profile in pairs), pairs
+        # Every discovered profile NAME must resolve in the registry. The
+        # previous line here was `all(name and profile for ...)`, which cannot
+        # fail: `pairs` is built with `if spec.get("profile")`, so `profile` is
+        # truthy by construction and `name` is a non-empty YAML key. It read as
+        # coverage while providing none — the exact defect this class of test
+        # exists to prevent, written into the guard-the-guard itself.
+        registry = ModelProfileRegistry(_repo_config_dir() / "model_profiles.yaml")
+        registry.load()
+        unresolved = [(n, p) for n, p in pairs if registry.get(p) is None]
+        assert not unresolved, f"routing names a profile that does not exist: {unresolved}"
 
     def test_every_paid_provider_profile_has_a_nonzero_rate(self):
         """A paid provider whose profile prices it at 0 records $0 spend on the

--- a/tests/test_routing/test_model_profiles.py
+++ b/tests/test_routing/test_model_profiles.py
@@ -365,10 +365,18 @@ class TestPaidProviderProfilePricing:
         ]
 
     def test_the_pairing_is_actually_discovered(self):
-        """Guard the guard — an empty list makes the test below vacuous."""
+        """Guard the guard — an empty list makes the test below vacuous.
+
+        Deliberately does NOT name a provider. It used to anchor on
+        `mistral-large-free`, which broke the day that provider's `free:` flag
+        legitimately changed — a guard-the-guard test that fails on a correct
+        config change is itself a defect, because it teaches the next person to
+        edit the assertion rather than read it. The property that matters is
+        "some paid provider carries a profile", not which one.
+        """
         pairs = self._paid_providers_with_profiles()
         assert len(pairs) >= 5, pairs
-        assert any(n == "mistral-large-free" for n, _ in pairs), pairs
+        assert all(name and profile for name, profile in pairs), pairs
 
     def test_every_paid_provider_profile_has_a_nonzero_rate(self):
         """A paid provider whose profile prices it at 0 records $0 spend on the


### PR DESCRIPTION
## What this changes

Mistral Large **stays** in every chain that carries it — an install whose
account tier includes it uses it, and one whose tier does not now fails past it
fast (the entitlement classifier landed separately in #1733). What was missing
was the rung between "the best Mistral" and "leave the family."

`mistral-medium-free` now sits **directly below Large in all 30 chains**, with
a matching `mistral-medium` model profile. The design intent:

- **The family degrades within itself** before leaving the family, and when
  Large's entitlement returns — or on an install with a paid plan — the chain
  silently uses the best available tier with **no config change**.
- **Disjointness constraints keep holding by construction.** The
  adversarial-challenge site was the measured worst case: its chain must stay
  model-disjoint from the synthesis it challenges (locked by
  `test_adversarial_challenge_sites_are_model_independent`), which rules out
  every free non-Mistral rung — so with Large refused, *every* challenge ran on
  the paid deep fallback. Medium is Mistral-family, so it slots in as the free
  disjoint rung without touching the invariant. That invariant is also why the
  insert is uniform rather than per-site judgment: the one place a hand-picked
  supplement looked attractive is exactly where it would have been wrong.

## Honesty about the free tier

The `free: true` entry is **presumptive**, by explicit decision, and both
config files say so with the probe date: entitlement is unverified — every
live probe hit the account-wide rate limit (429) before an entitlement answer,
and a `/v1/models` listing is not entitlement evidence (this repo's own
`record_probe_success` lesson). Falsifier: if Medium returns
`403 tier_not_allowed` when the rate limit clears, the cost is one fast
refusal per 4-hour breaker window, not a burned chain budget. The
`intelligence_tier: A` is likewise labelled inferred-from-vendor-positioning,
with a revisit note once it carries traffic.

## Verification

139 targeted tests green (config, invariants, profiles, save, essential,
chain-offset, criticality, delegate, degradation) against the **shipped**
YAML — `test_load_full_yaml` loads the real file, so a fresh install's
zero-overlay load is exercised. The insert was positional and guarded (exactly
the chain-list form, count asserted == 30 before writing); the provider-count
and three chain pins updated deliberately with dated comments.

Deploy path: config default — lands at server restart via the standard update;
works on a fresh clone with zero overlay.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Mistral Medium as an available model option.
  - Added Mistral Medium to fallback routing across reflection, extraction, dream-cycle, classification, review, monitoring, voice, and other processing workflows.
  - Added entitlement verification details; free-tier pricing remains unconfirmed, so the provider is not marked as free.
  - Updated dream-cycle fallback documentation to reflect observed throttling and paid fallback behavior.

- **Tests**
  - Updated routing validation for the new provider and expanded provider list.
  - Improved checks for configured free-provider attempts without unexpectedly using paid providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

E2E: after deploy, confirm a `never_pays` call site walks `mistral-medium-free` between Large and the paid rung, and that `activity_log` records no paid provider for that site. Also read the first recorded cost for `mistral-medium-latest` — the `free: true` flag is a measured-entitlement claim but a PRESUMED pricing claim, and that row is what settles it.
