### PR TITLE
fix: report full deterministic stream size

### DIFF
--- a/src/genesis/autonomy/executor/deterministic.py
+++ b/src/genesis/autonomy/executor/deterministic.py
@@ -108,24 +108,26 @@ def validate_command(command: str) -> str | None:
 async def _read_limited(
     stream: asyncio.StreamReader,
     limit: int = _MAX_STREAM_BYTES,
-) -> bytes:
-    """Read up to *limit* bytes from *stream*, discarding the rest."""
+) -> tuple[bytes, int]:
+    """Retain up to *limit* bytes while counting and draining the full stream."""
     chunks: list[bytes] = []
-    total = 0
+    retained_size = 0
+    total_size = 0
     while True:
         chunk = await stream.read(8192)
         if not chunk:
             break
-        remaining = limit - total
+        total_size += len(chunk)
+        remaining = limit - retained_size
         if remaining <= 0:
             continue
         if len(chunk) > remaining:
             chunks.append(chunk[:remaining])
-            total = limit
+            retained_size = limit
         else:
             chunks.append(chunk)
-            total += len(chunk)
-    return b"".join(chunks)
+            retained_size += len(chunk)
+    return b"".join(chunks), total_size
 
 
 # ---------------------------------------------------------------------------
@@ -221,12 +223,14 @@ async def execute_deterministic_step(
         # Hard timeout prevents a hung subprocess from blocking the
         # executor semaphore indefinitely.
         try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                asyncio.gather(
-                    _read_limited(proc.stdout),
-                    _read_limited(proc.stderr),
-                ),
-                timeout=_HARD_TIMEOUT_S,
+            (stdout_bytes, stdout_total), (stderr_bytes, stderr_total) = (
+                await asyncio.wait_for(
+                    asyncio.gather(
+                        _read_limited(proc.stdout),
+                        _read_limited(proc.stderr),
+                    ),
+                    timeout=_HARD_TIMEOUT_S,
+                )
             )
             await proc.wait()
         except asyncio.CancelledError:
@@ -275,9 +279,9 @@ async def execute_deterministic_step(
     # Cap stored output for result_json
     max_output = 50_000
     if len(stdout) > max_output:
-        stdout = stdout[:max_output] + f"\n... (truncated, {len(stdout_bytes)} bytes total)"
+        stdout = stdout[:max_output] + f"\n... (truncated, {stdout_total} bytes total)"
     if len(stderr) > max_output:
-        stderr = stderr[:max_output] + f"\n... (truncated, {len(stderr_bytes)} bytes total)"
+        stderr = stderr[:max_output] + f"\n... (truncated, {stderr_total} bytes total)"
 
     result_text = ""
     if stdout:

--- a/tests/test_autonomy/test_executor/test_deterministic.py
+++ b/tests/test_autonomy/test_executor/test_deterministic.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from genesis.autonomy.executor.deterministic import (
+    _read_limited,
     execute_deterministic_step,
     validate_command,
 )
@@ -115,6 +116,21 @@ class TestValidateCommand:
 
 
 @pytest.mark.asyncio
+async def test_read_limited_reports_discarded_bytes() -> None:
+    """The reader retains a prefix while counting the full drained stream."""
+    import asyncio
+
+    stream = asyncio.StreamReader()
+    stream.feed_data(b"0123456789")
+    stream.feed_eof()
+
+    retained, total = await _read_limited(stream, limit=4)
+
+    assert retained == b"0123"
+    assert total == 10
+
+
+@pytest.mark.asyncio
 class TestExecuteDeterministicStep:
     """Test deterministic step execution."""
 
@@ -167,6 +183,15 @@ class TestExecuteDeterministicStep:
         result = await execute_deterministic_step(step)
         assert result.status == "failed"
         assert "STDERR" in result.result
+
+    async def test_truncation_reports_full_stream_size(self) -> None:
+        step = {"idx": 0, "type": "bash", "command": "seq 1 400000"}
+
+        result = await execute_deterministic_step(step)
+
+        expected_size = sum(len(str(number)) + 1 for number in range(1, 400001))
+        assert result.status == "completed"
+        assert f"(truncated, {expected_size} bytes total)" in result.result
 
     async def test_worktree_path_used(self, tmp_path: Path) -> None:
         step = {"idx": 0, "type": "bash", "command": "pwd"}


### PR DESCRIPTION
Closes #1707

## Summary
- count every drained stdout/stderr byte while retaining the existing 2 MiB cap
- report the exact total in truncation messages

## Tests
- `pytest tests/test_autonomy/test_executor/test_deterministic.py -q`
- `ruff check src/genesis/autonomy/executor/deterministic.py tests/test_autonomy/test_executor/test_deterministic.py`

Existing installs receive the runtime fix after pulling and restarting Genesis; fresh clones include it directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output truncation messages to report the complete amount of data produced, rather than only the portion retained.
  * Standardized accurate size reporting for both standard output and standard error during execution.

* **Tests**
  * Added coverage for truncated output and full stream-size reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->