### PR TITLE
feat(awareness): alert when the code index is dead instead of logging it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,19 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ### Added
 
+- **A dead code index now says so.** The code indexer could give up on a
+  repository permanently and report it only into a log file: on one install the
+  main repo's index request was abandoned after five failed attempts, its
+  database sat corrupt for two weeks, and code-intelligence tools kept answering
+  from nothing — with no alert anywhere, because nothing read the indexer's
+  failure records. An hourly check now reads those records directly (abandoned
+  index requests, and whether an index actually exists for the path being
+  indexed) and raises one self-resolving alert that clears when the index comes
+  back. It reads the indexer's own files rather than asking the tool how it is
+  doing, since a crashed indexer cannot answer. Configurable via
+  `code_intel_health` (`enabled`, `indexed_path`, `alert_priority`); set
+  `indexed_path` to whatever the indexer is actually pointed at.
+
 - **A `tmux kill-server` with no socket binding now draws an advisory.** tmux
   resolves its target server from the inherited `$TMUX` variable before
   `TMUX_TMPDIR`, so a cleanup aimed at a scratch or probe server can address

--- a/config/code_intel_health.yaml
+++ b/config/code_intel_health.yaml
@@ -1,0 +1,38 @@
+# Code-intel index health (awareness hourly band).
+#
+# The code indexer can fail permanently and say nothing. MEASURED on a live
+# install 2026-09-05: the main repo's index request was euthanized to a
+# <hash>.failed.json marker after 5 genuine failures (a state index_marker.py
+# describes as "never retried"), its database sat as a 164 MB .db.corrupt for
+# two weeks, and the runner logged "index failed" 35 times — while no awareness
+# check covered code-intel and nothing in src/ read either signal. It did not
+# fail silently; it failed loudly into a log file, which is the same thing.
+#
+# This check reads the indexer's OWN artifacts on disk (euthanized request
+# markers + the index database for the configured target). It never asks the
+# code-intel tool how it is doing: a tool that has crashed cannot report its own
+# health, and its daemon may not be running at all.
+#
+# Values here merge over built-in defaults; a .local.yaml overlay merges over
+# this file. Env kill switch: GENESIS_CODE_INTEL_HEALTH_DISABLED=1.
+
+enabled: true
+
+# Which path code-intel is expected to have an index for. Empty = repo root.
+#
+# LEAVE THIS EMPTY unless you have also re-pointed the indexer. Every writer of
+# an index request hardcodes the repo root today (the post-commit hook,
+# disk_reclaim, the gitnexus surplus job), and the runner indexes whatever the
+# request names — nothing in that path reads this file.
+#
+# The knob exists because the index's on-disk name derives from the FULL path,
+# so an install that genuinely indexes a subdirectory needs this check to
+# follow. But it steers ONLY this check: set it on its own and the check will
+# look for an index nothing ever builds, reporting ABSENT forever. Narrowing the
+# indexer means changing the writers AND setting this to match.
+indexed_path: ""
+
+# high = the morning report. A dead code index degrades tool quality; it does
+# not lose the user's data or session context. `critical` (the ~5-minute
+# Telegram path) is reserved for the context-loss class.
+alert_priority: high

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1210,6 +1210,27 @@ verified: 29a382e7 2026-09-03
   `next_fire_at` proxies that stay green through a deadlock) raises one
   self-superseding `high` `ego_alert` per ego, auto-resolving when a cycle lands;
   `gated`/`paused`/fresh-install are never stalls.
+  Also (hourly) **code-intel index health** (`_check_code_intel_health`,
+  `observability/snapshots/code_intel_health.py`): the code indexer can give up
+  permanently and say nothing — MEASURED 2026-09-05, the main repo's index
+  request was euthanized to a `<hash>.failed.json` marker (a state
+  `scripts/lib/index_marker.py` calls "never retried") and its database sat as a
+  164 MB `.db.corrupt` for two weeks while the runner logged `index failed` 35
+  times and no check covered it. Reads the INDEXER'S OWN artifacts (euthanized
+  markers + the index db for the configured target), never the tool's
+  self-report: a crashed indexer cannot report its own health. **Do-not-touch
+  edge:** `config/code_intel_health.yaml:indexed_path` steers ONLY the check —
+  every index-request writer (post-commit hook, `disk_reclaim`, the gitnexus
+  surplus job) hardcodes the repo root, and nothing in the indexing path reads
+  that config. Narrowing what is indexed therefore means re-pointing those
+  writers AND setting `indexed_path` to match; setting it alone makes the check
+  watch an index nothing builds and report ABSENT forever. Equally: a
+  `<slug>.db.corrupt` file is the indexer's RETAINED BACKUP (it rebuilds the db
+  in place and never unlinks the backup), so it means "currently broken" only
+  when NEWER than the live db. Scoped to that one target
+  (worktree indexes churn constantly; alerting on them is how an alarm gets
+  muted). `high`, not `critical` — a dead index degrades tool quality, it does
+  not lose user data or session context.
   Also per-tick (WS-2 M10) the SINGLE designated `alert_events` writer:
   `_persist_health_alerts` recomputes the firing set via the pure
   `mcp/health/errors.py::_compute_alerts()` and reconciles a durable open-set

--- a/src/genesis/awareness/code_intel_health_config.py
+++ b/src/genesis/awareness/code_intel_health_config.py
@@ -1,0 +1,127 @@
+"""Config lever for the code-intel health check (awareness hourly band).
+
+Cloned from ``context_injection_watch_config``: read-and-alert only, so there is
+no authority to grade — an ``enabled`` master switch + knobs + an env kill
+switch.
+
+Failure posture: a missing/corrupt config degrades to DEFAULTS; the env kill
+switch ``GENESIS_CODE_INTEL_HEALTH_DISABLED=1`` forces the check off regardless
+of the file.
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports the public ``DEFAULTS`` from here (never
+the reverse).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_NAME = "code_intel_health.yaml"
+_ENV_KILL_SWITCH = "GENESIS_CODE_INTEL_HEALTH_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    # WHICH path code-intel is expected to have an index for. Empty = repo root,
+    # which is what EVERY marker writer currently hardcodes (the post-commit
+    # hook, disk_reclaim, the gitnexus surplus job) — so the default is the
+    # correct value on a stock install and this knob should usually stay empty.
+    #
+    # It exists because the index's on-disk name is derived from the FULL path,
+    # so an install that re-points its indexer at a subdirectory needs the check
+    # to follow. It steers ONLY THIS CHECK: nothing in the indexing path reads
+    # this file. Setting it without also re-pointing the writers makes the check
+    # look for an index nothing will ever build — reporting ABSENT forever,
+    # which is the permanently-wrong alarm this knob was meant to avoid.
+    "indexed_path": "",
+    # A dead code index degrades tool QUALITY; it does not lose the user's data
+    # or their session context. `high` reaches the morning report; `critical` is
+    # the ~5-minute Telegram path and is reserved for the context-loss class.
+    "alert_priority": "high",
+}
+
+_VALID_ALERT_PRIORITY = ("low", "medium", "high", "critical")
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults ← base yaml ← .local.yaml overlay). Missing or corrupt
+    files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("code_intel_health base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("code_intel_health overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def is_enabled() -> bool:
+    """True unless the env kill switch is set or the config EXPLICITLY disables it.
+
+    Only a real boolean turns the check off. Plain truthiness would let
+    ``enabled: null`` / ``0`` / ``[]`` — a damaged base file or a half-written
+    overlay — silence the only alarm covering code-intel, which is the same
+    fail-open shape as the two-week silence this check exists to end. Config
+    damage therefore degrades toward WATCHING.
+    """
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return False
+    value = load_config().get("enabled", True)
+    return value if isinstance(value, bool) else True
+
+
+def indexed_path(cfg: dict[str, Any]) -> Path:
+    """The path code-intel is expected to have indexed; repo root by default.
+
+    Resolved, not merely expanded: the indexer realpath's the repo path it
+    records (``index_marker.canonical_repo``), so a config value crossing a
+    symlink or containing ``..`` would slug differently and silently match no
+    marker at all — dropping every euthanized request for the target AND
+    leaving ``requested`` False, so an absent index would read as a fresh
+    install. Both halves of the check would go quiet together.
+    """
+    value = cfg.get("indexed_path")
+    if isinstance(value, str) and value.strip():
+        raw = Path(value.strip()).expanduser()
+    else:
+        raw = repo_root()
+    try:
+        return raw.resolve()
+    except OSError:
+        return raw
+
+
+def alert_priority(cfg: dict[str, Any]) -> str:
+    """The configured alert priority, falling back to the default on damage."""
+    value = cfg.get("alert_priority")
+    if value in _VALID_ALERT_PRIORITY:
+        return str(value)
+    return str(DEFAULTS["alert_priority"])

--- a/src/genesis/awareness/loop.py
+++ b/src/genesis/awareness/loop.py
@@ -1468,6 +1468,106 @@ async def _check_context_injection_health(db) -> None:
         logger.warning("Failed context-injection health check", exc_info=True)
 
 
+_CODE_INTEL_SUPERSEDED_NOTE = "superseded by current code-intel index state"
+
+
+async def _check_code_intel_health(db) -> None:
+    """Alert when the code index is dead, corrupt, or permanently abandoned.
+
+    Same generator as the context-injection watcher one subsystem over: the
+    indexer DOES detect its own failures — it logged ``index failed`` 35 times
+    and euthanized the main repo's request after 5 attempts — but it records
+    them in a log file and a marker nothing reads. MEASURED 2026-09-05: the main
+    repo's index sat as a 164 MB ``.db.corrupt`` for two weeks while
+    ``list_projects`` reported only a worktree whose root no longer exists.
+
+    Reads the indexer's own on-disk artifacts, never the tool's self-report: a
+    crashed indexer cannot report its own health, and its daemon may be gone.
+
+    Priority defaults to ``high`` (morning report), not ``critical``: a dead
+    index degrades tool quality, it does not lose the user's data or context.
+
+    Best-effort — the whole body is guarded and never raises into the tick.
+    """
+    if db is None:
+        return
+    try:
+        from genesis.awareness import code_intel_health_config as _cfg_mod
+        from genesis.observability.snapshots.code_intel_health import (
+            alert_identity,
+            collect,
+            derive_findings,
+        )
+
+        if not _cfg_mod.is_enabled():
+            # Resolve on the way out: disabling a check must not leave its last
+            # alert standing forever on the health and outreach surfaces.
+            await observations.resolve_by_source_and_type(
+                db,
+                source="code_intel_health_monitor",
+                type="infrastructure_alert",
+                resolved_at=datetime.now(UTC).isoformat(),
+                resolution_notes="code-intel health check disabled",
+            )
+            return
+
+        cfg = _cfg_mod.load_config()
+        health = await asyncio.to_thread(
+            collect, indexed_path=_cfg_mod.indexed_path(cfg)
+        )
+        findings = derive_findings(health)
+        if not findings:
+            await observations.resolve_by_source_and_type(
+                db,
+                source="code_intel_health_monitor",
+                type="infrastructure_alert",
+                resolved_at=datetime.now(UTC).isoformat(),
+                resolution_notes="code index present and no abandoned index requests",
+            )
+            return
+
+        alert_key = alert_identity(health)
+        content_hash = hashlib.sha256(f"code_intel:{alert_key}".encode()).hexdigest()
+        await observations.supersede_except_hash(
+            db,
+            source="code_intel_health_monitor",
+            type="infrastructure_alert",
+            keep_content_hash=content_hash,
+            resolved_at=datetime.now(UTC).isoformat(),
+            resolution_notes=_CODE_INTEL_SUPERSEDED_NOTE,
+        )
+        await observations.create(
+            db,
+            id=str(uuid.uuid4()),
+            source="code_intel_health_monitor",
+            type="infrastructure_alert",
+            content=(
+                "CODE INTELLIGENCE IS ANSWERING FROM NOTHING — "
+                + " | ".join(findings)
+                + " Recovery: clear the euthanized marker in "
+                "~/.genesis/index-requests so the runner retries (it is a "
+                "terminal state — nothing retries it on its own), then watch "
+                "~/.genesis/code-intelligence-runner.log. If it dies again with "
+                "rc=143 it is being killed under the memory cap: the indexed "
+                "path is decided by whoever WRITES the marker (post-commit hook, "
+                "disk_reclaim, the gitnexus surplus job — all repo-root), so "
+                "narrowing it means re-pointing those writers AND setting "
+                "config/code_intel_health.yaml:indexed_path to match. Setting "
+                "indexed_path alone only moves what this check looks for, and "
+                "would report ABSENT forever."
+            ),
+            priority=_cfg_mod.alert_priority(cfg),
+            created_at=datetime.now(UTC).isoformat(),
+            content_hash=content_hash,
+            skip_if_duplicate=True,
+        )
+    except Exception:
+        # WARNING, not debug: a crash here is indistinguishable from "nothing to
+        # report" on every operator-visible surface — the exact failure mode
+        # this check exists to catch, applied to itself.
+        logger.warning("Failed code-intel health check", exc_info=True)
+
+
 def _created_before(row: dict, cutoff: datetime) -> bool:
     """True if the row's created_at is older than cutoff (grace boundary).
 
@@ -3274,6 +3374,11 @@ class AwarenessLoop:
                     # rows gain a trigger or close.
                     await _check_follow_up_watchdog(self._db)
                     await _check_context_injection_health(self._db)
+                    # Code-intel index health: a permanently-abandoned index
+                    # request or a corrupt/absent index for the configured
+                    # target. Same silent-failure class one subsystem over —
+                    # the indexer logs its failures where nothing reads them.
+                    await _check_code_intel_health(self._db)
                     # Ego liveness: an ego completing NO real cycle well past its
                     # cadence (job_health.last_success gap), NOT the is_running /
                     # heartbeat proxies that stay green while deadlocked.

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -344,6 +344,32 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # re-read every hourly tick
     ),
+    "code_intel_health": SettingsDomain(
+        name="code_intel_health",
+        description=(
+            "Code-intel index health (awareness hourly band) — master `enabled` + "
+            "`indexed_path` / `alert_priority`. Reads the INDEXER'S OWN artifacts: a "
+            "`<hash>.failed.json` marker means the runner permanently gave up on a "
+            "repo (never retried), and the index database for `indexed_path` may be "
+            "absent or carry a `.corrupt` suffix. Never asks the code-intel tool how "
+            "it is doing — a crashed indexer cannot report its own health. "
+            "`indexed_path` (empty = repo root) steers ONLY this check — every "
+            "index-request writer hardcodes the repo root and nothing in the indexing "
+            "path reads this config, so leave it empty unless you have also re-pointed "
+            "those writers; setting it alone makes the check watch an index nothing "
+            "builds and report 'no index' forever. "
+            "Scoped to that one target — worktree indexes churn constantly and "
+            "alerting on them is how an alarm gets muted. One deduped, "
+            "self-resolving infrastructure_alert; default priority high (morning "
+            "report, not the Telegram path — a dead index degrades tool quality, it "
+            "does not lose user data). Read-and-alert only. off (or env "
+            "GENESIS_CODE_INTEL_HEALTH_DISABLED=1) silences it AND resolves any open "
+            "alert. Read live each hourly tick — no restart."
+        ),
+        config_filename="code_intel_health.yaml",
+        readonly=False,
+        needs_restart=False,  # re-read every hourly tick
+    ),
     "provider_outage_notify": SettingsDomain(
         name="provider_outage_notify",
         description=(
@@ -1732,6 +1758,34 @@ def _validate_follow_up_watchdog(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_code_intel_health(changes: dict) -> list[str]:
+    """Validate code-intel health lever changes (see
+    genesis.awareness.code_intel_health_config)."""
+    from genesis.awareness.code_intel_health_config import _VALID_ALERT_PRIORITY
+
+    errors: list[str] = []
+    valid_keys = ("enabled", "alert_priority", "indexed_path")
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif key == "alert_priority":
+            if value not in _VALID_ALERT_PRIORITY:
+                errors.append(
+                    f"'alert_priority' must be one of {', '.join(_VALID_ALERT_PRIORITY)}; "
+                    f"got {value!r}"
+                )
+        # Empty string is meaningful (= repo root), so only the TYPE is
+        # constrained. Whether the path EXISTS is deliberately not validated: it
+        # may legitimately not exist yet at config time, and the check itself
+        # reports an absent index as a finding rather than a config error.
+        elif key == "indexed_path" and not isinstance(value, str):
+            errors.append("'indexed_path' must be a string ('' = repo root)")
+    return errors
+
+
 def _validate_context_injection_watch(changes: dict) -> list[str]:
     """Validate context-injection watcher lever changes (see
     genesis.awareness.context_injection_watch_config)."""
@@ -1781,6 +1835,7 @@ _DOMAIN_VALIDATORS: dict[str, Any] = {
     "ego_reconcile": _validate_ego_reconcile,
     "follow_up_watchdog": _validate_follow_up_watchdog,
     "context_injection_watch": _validate_context_injection_watch,
+    "code_intel_health": _validate_code_intel_health,
     "provider_outage_notify": _validate_provider_outage_notify,
     "surplus_ideation_promotion": _validate_surplus_ideation_promotion,
     "memory_integrity": _validate_memory_integrity,

--- a/src/genesis/memory/provenance.py
+++ b/src/genesis/memory/provenance.py
@@ -494,6 +494,18 @@ _FIRST_PARTY_OBS_SOURCES: frozenset[str] = frozenset(
         # reflection and perception. If a future change puts hook content back
         # in this observation, this source must LOSE its place in this list.
         "context_injection_monitor",
+        # Code-intel index health (awareness/loop.py _check_code_intel_health) —
+        # Genesis observing its OWN indexer. The evidence is file existence and
+        # the contents of markers GENESIS ITSELF writes (scripts/lib/
+        # index_marker.py): a repo path, an attempt count, and whether an index
+        # database exists or carries a .corrupt suffix. No byte of any indexed
+        # SOURCE FILE, and no output from the third-party indexer binary, enters
+        # the observation — the finding text is authored here from a closed set
+        # of states (ok / absent / corrupt). Paths are escaped at ingestion in
+        # code_intel_health.collect. If a future change quotes indexer output or
+        # file content into this observation, this source must LOSE its place in
+        # this list.
+        "code_intel_health_monitor",
     }
 )
 

--- a/src/genesis/observability/snapshots/code_intel_health.py
+++ b/src/genesis/observability/snapshots/code_intel_health.py
@@ -60,8 +60,8 @@ def _safe_path(value: object) -> str:
 def index_slug(path: Path) -> str:
     """CBM's on-disk name for a project: the FULL path with ``/`` -> ``-``.
 
-    Verified against a live cache entry rather than assumed:
-    ``/home/ubuntu/tmp/kimi_review`` -> ``home-ubuntu-tmp-kimi_review``.
+    Verified against a real cache entry rather than assumed:
+    ``/home/<user>/tmp/scratch`` -> ``home-<user>-tmp-scratch``.
 
     That the slug carries the WHOLE path is load-bearing here, not a detail: it
     means indexing ``<repo>/src`` produces a DIFFERENT slug from indexing

--- a/src/genesis/observability/snapshots/code_intel_health.py
+++ b/src/genesis/observability/snapshots/code_intel_health.py
@@ -1,0 +1,280 @@
+"""Code-intel index health: is the code index actually there, or quietly dead?
+
+MEASURED on this install (2026-09-05), which is why this module exists:
+
+  * the main repo's index request was euthanized to ``<hash>.failed.json`` after
+    ``index_marker.MAX_ATTEMPTS`` genuine failures — a state that module's own
+    docstring describes as "never retried";
+  * its database sat as a 164 MB ``home-ubuntu-genesis.db.corrupt`` for two weeks;
+  * ``~/.genesis/code-intelligence-runner.log`` carried 35 ``index failed`` lines,
+    the last three ``rc=143`` (SIGTERM — killed under memory pressure);
+  * and the live server reported exactly two indexed projects: a worktree whose
+    root no longer exists, and a 26-node scratch dir.
+
+Nothing surfaced any of it. No awareness check covered code-intel, and the only
+``src/`` consumer of the marker system is a WRITER
+(``surplus/jobs/gitnexus.py``). So it did not fail silently — it failed LOUDLY
+INTO A LOG FILE, which is operationally identical. This is the same generator the
+SessionStart-injection watcher was built for, one subsystem over: a failure
+recorded where only the machine can see it.
+
+Shape mirrors ``context_injection.py`` deliberately (facts -> pure
+``derive_findings`` -> condition-keyed ``alert_identity``), because that module
+is the proven template for this exact class.
+
+**Ground truth only.** Every signal here is a file on disk written by the
+indexer itself. Nothing asks CBM how it is doing: a tool that has crashed cannot
+be trusted to report its own health, and the daemon may not even be running.
+
+**Scope is the CONFIGURED target, deliberately narrow.** Worktrees are created
+and destroyed constantly on this install — a live example right now is a
+31,431-node index whose worktree root is gone. Alerting on those is how this
+alarm would get muted, taking the real signal with it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Everything outside the shape a path takes. Marker JSON is written by our own
+# runner, so this is defence in depth rather than a known attack path — but the
+# value lands in an observation that `memory/provenance.py` stamps first_party
+# and `crud/observations.py` stores verbatim, so it is escaped at ingestion like
+# every other filesystem-derived value in this package.
+_PATH_UNSAFE = re.compile(r"[^\w./~+-]")
+
+#: Where CBM keeps its per-project index databases. `CBM_CACHE_DIR` is honoured
+#: because the binary honours it — MEASURED 2026-09-05: setting it relocates the
+#: whole cache, which is what makes an isolated probe possible.
+_DEFAULT_CACHE = Path.home() / ".cache" / "codebase-memory-mcp"
+
+
+def _safe_path(value: object) -> str:
+    return _PATH_UNSAFE.sub("?", str(value))
+
+
+def index_slug(path: Path) -> str:
+    """CBM's on-disk name for a project: the FULL path with ``/`` -> ``-``.
+
+    Verified against a live cache entry rather than assumed:
+    ``/home/ubuntu/tmp/kimi_review`` -> ``home-ubuntu-tmp-kimi_review``.
+
+    That the slug carries the WHOLE path is load-bearing here, not a detail: it
+    means indexing ``<repo>/src`` produces a DIFFERENT slug from indexing
+    ``<repo>``. A check hardcoded to the repo root would therefore report
+    "unusable" forever the moment code-intel is scoped to a subdirectory — a
+    permanently-wrong alarm shipped by the very work meant to stop silent
+    failures. Hence :func:`collect` takes the target as a parameter.
+    """
+    return str(path).strip("/").replace("/", "-")
+
+
+def default_cache_dir() -> Path:
+    env = os.environ.get("CBM_CACHE_DIR")
+    return Path(env) if env else _DEFAULT_CACHE
+
+
+def default_marker_dir() -> Path:
+    """The indexer's request queue. Resolved through the marker helper that
+    WRITES it, so this cannot drift from the producer."""
+    base = os.environ.get("GENESIS_HOME") or str(Path.home() / ".genesis")
+    return Path(base) / "index-requests"
+
+
+@dataclass
+class CodeIntelHealth:
+    """Facts from disk; findings derived separately."""
+
+    #: Index requests the runner permanently gave up on (``*.failed.json``).
+    euthanized: list[dict] = field(default_factory=list)
+    #: ``ok`` | ``absent`` | ``corrupt`` — state of the CONFIGURED target's index.
+    index_state: str = "ok"
+    #: The target this reading is about, escaped.
+    target: str = ""
+    #: Whether anything ever ASKED for this target to be indexed. Absence of an
+    #: index only means something when an index was requested — a fresh clone
+    #: has neither, and that is correct, not a fault.
+    requested: bool = False
+    #: Reads that FAILED. A check that cannot look must never read as all-clear.
+    errors: list[str] = field(default_factory=list)
+
+
+def collect(
+    *,
+    indexed_path: Path,
+    marker_dir: Path | None = None,
+    cache_dir: Path | None = None,
+) -> CodeIntelHealth:
+    """Read the indexer's own artifacts. Never raises; failures are recorded."""
+    health = CodeIntelHealth(target=_safe_path(indexed_path))
+    markers = marker_dir if marker_dir is not None else default_marker_dir()
+    cache = cache_dir if cache_dir is not None else default_cache_dir()
+    target_slug = index_slug(indexed_path)
+
+    # ── euthanized requests ───────────────────────────────────────────────
+    entries: list[Path] = []
+    try:
+        if markers.exists():
+            entries = sorted(markers.glob("*.failed.json"))
+            # `glob` SWALLOWS a traversal OSError and yields nothing, so an
+            # unreadable dir is indistinguishable from an empty one. Probe it —
+            # inside the SAME try, so a permission change between the exists()
+            # and the probe cannot raise out of collect(). `with`, because a
+            # bare scandir leaks its iterator's fd on every hourly tick.
+            with os.scandir(markers) as it:
+                next(iter(it), None)
+    except OSError as exc:
+        health.errors.append(f"{_safe_path(markers)} is not readable: {exc.strerror}")
+        entries = []
+
+    def _marker_data(entry: Path) -> dict | None:
+        """This marker's payload IF it names our target, else None.
+
+        Returns None silently for another repo's marker; records an error for
+        anything unreadable or structurally wrong, because a marker we cannot
+        classify must not quietly pass as "not ours".
+        """
+        try:
+            data = json.loads(entry.read_text())
+        except OSError as exc:
+            # `exc` is NOT interpolated: OSError.__str__ embeds the raw
+            # filename, which would carry an UNESCAPED path into a first_party
+            # observation right beside its escaped twin.
+            health.errors.append(
+                f"{_safe_path(entry)} could not be read: {_safe_path(exc.strerror)}"
+            )
+            return None
+        except ValueError:
+            health.errors.append(f"{_safe_path(entry)} is not valid JSON")
+            return None
+        if not isinstance(data, dict):
+            # `json.loads` happily returns a list/str/int, and `.get` on those
+            # raises AttributeError straight OUT of collect() — past both except
+            # clauses into the caller's bare `except Exception: logger.warning`.
+            # That is this module's own failure mode applied to itself: no
+            # alert, no error entry, one log line nobody reads.
+            health.errors.append(f"{_safe_path(entry)} is not a JSON object")
+            return None
+        raw = str(data.get("repo_path", ""))
+        return data if index_slug(Path(raw)) == target_slug else None
+
+    for entry in entries:
+        data = _marker_data(entry)
+        if data is None:
+            continue
+        health.requested = True
+        health.euthanized.append(
+            {
+                "repo_path": _safe_path(data.get("repo_path", "")),
+                # `attempts` is escaped too: it is interpolated into the finding
+                # text, so an unescaped newline forges a finding line exactly as
+                # a path would.
+                "attempts": _safe_path(data.get("attempts", "?")),
+            }
+        )
+
+    # A PENDING (not yet euthanized) request also proves the target was ASKED
+    # for — which is what makes an absent index meaningful rather than fresh.
+    # Scoped by READING each marker: filenames are opaque hashes carrying no
+    # repo identity, so an `any(*.json)` test would accept ANOTHER repo's
+    # pending request — or a `.tmp-` file from index_marker's atomic write — as
+    # proof that OUR target was requested.
+    try:
+        pending = [
+            p
+            for p in markers.iterdir()
+            if p.name.endswith(".json")
+            and not p.name.endswith(".failed.json")
+            and not p.name.startswith(".tmp-")
+        ]
+    except OSError:
+        pending = []  # an unreadable dir is already recorded above
+    if any(_marker_data(p) is not None for p in pending):
+        health.requested = True
+
+    # ── the configured target's index ─────────────────────────────────────
+    try:
+        db = cache / f"{target_slug}.db"
+        corrupt = cache / f"{target_slug}.db.corrupt"
+        if db.exists():
+            # `.corrupt` is the indexer's RETAINED BACKUP of a previously-bad
+            # database, NOT a flag meaning "the current index is broken". Its
+            # own binary says `backing up corrupt db to .corrupt` and then
+            # rebuilds `<slug>.db` in place; nothing ever unlinks the backup
+            # (MEASURED: a 164 MB one on this box, retained for two weeks).
+            # Treating its mere existence as failure fired the alarm FOREVER
+            # after a successful rebuild — a permanently-wrong alarm, which is
+            # the exact failure this module exists to prevent, committed by the
+            # module itself. Only a backup NEWER than the live db means the
+            # CURRENT index is the broken one.
+            health.index_state = (
+                "corrupt"
+                if corrupt.exists() and corrupt.stat().st_mtime > db.stat().st_mtime
+                else "ok"
+            )
+        else:
+            # No live db: a backup alone means the rebuild never completed.
+            health.index_state = "corrupt" if corrupt.exists() else "absent"
+    except OSError as exc:
+        health.errors.append(f"{_safe_path(cache)} is not readable: {exc.strerror}")
+
+    return health
+
+
+def derive_findings(health: CodeIntelHealth) -> list[str]:
+    """Facts -> human-readable findings. Pure; empty list = healthy."""
+    findings: list[str] = []
+
+    if health.errors:
+        findings.append(
+            "code-intel health check DEGRADED — "
+            + "; ".join(health.errors)
+            + ". It could not read everything it watches, so THIS READING CANNOT "
+            "BE TREATED AS ALL-CLEAR."
+        )
+
+    if health.euthanized:
+        named = ", ".join(
+            f"{e['repo_path']} (after {e['attempts']} attempts)" for e in health.euthanized
+        )
+        findings.append(
+            f"the code indexer GAVE UP on {named} — the request was euthanized to "
+            "a .failed.json marker and is NEVER retried, so the index will stay "
+            "stale until someone clears it. Check "
+            "~/.genesis/code-intelligence-runner.log for the failure reason "
+            "(rc=143 means it was killed, usually under the memory cap)."
+        )
+
+    # An absent index is only a fault if something ASKED for one; a fresh clone
+    # legitimately has neither, and alerting there would fire on every install.
+    if health.index_state == "corrupt" or (health.index_state == "absent" and health.requested):
+        findings.append(
+            f"the code index for {health.target} is {health.index_state.upper()} — "
+            "code-intelligence tools that read it are answering from nothing. "
+            "Rebuild it, or narrow the indexed path if it no longer fits the "
+            "memory cap."
+        )
+
+    return findings
+
+
+def alert_identity(health: CodeIntelHealth) -> str:
+    """A stable key over every state :func:`derive_findings` can report.
+
+    Keyed on the CONDITION, never on a tally. Attempt counts and the number of
+    dead repos drift while one standing incident sits unfixed, and an alarm that
+    re-pages for a condition the operator has already seen is how the channel
+    gets muted — which is precisely how this failure survived two weeks.
+    """
+    repos = ",".join(sorted(e["repo_path"] for e in health.euthanized))
+    return (
+        f"target:{health.target}"
+        f":index:{health.index_state}"
+        f":requested:{'yes' if health.requested else 'no'}"
+        f":euthanized:{repos}"
+        f":errors:{'|'.join(sorted(health.errors))}"
+    )

--- a/tests/test_awareness/test_code_intel_health.py
+++ b/tests/test_awareness/test_code_intel_health.py
@@ -54,8 +54,8 @@ def _euthanized(markers: Path, repo: str, attempts: int = 5) -> Path:
 def _index(cache: Path, target: Path, *, suffix: str = ".db") -> Path:
     """Write a fake index db for `target`, using CBM's real slug shape.
 
-    Slug is the FULL path with '/' -> '-', verified against a live cache entry
-    (/home/ubuntu/tmp/kimi_review -> home-ubuntu-tmp-kimi_review).
+    Slug is the FULL path with '/' -> '-', verified against a real cache entry
+    (/home/<user>/tmp/scratch -> home-<user>-tmp-scratch).
     """
     p = cache / (ci.index_slug(target) + suffix)
     p.write_bytes(b"x" * 64)

--- a/tests/test_awareness/test_code_intel_health.py
+++ b/tests/test_awareness/test_code_intel_health.py
@@ -1,0 +1,443 @@
+"""Code-intel index health: does a dead code index actually SAY so?
+
+MEASURED failure this exists for (2026-09-05): the main repo's index request was
+euthanized after ``MAX_ATTEMPTS`` genuine failures and its database sat as a
+164 MB ``.db.corrupt`` for two weeks, while the runner logged ``index failed``
+35 times. Nothing read either signal — no awareness check covered code-intel, and
+the only ``src/`` consumer of the marker system is a WRITER. So it did not fail
+silently; it failed LOUDLY INTO A LOG, which is operationally identical.
+
+Fixtures are synthetic and every ambient input is pinned: these tests must never
+read this box's real cache or marker dir (the same isolation the injection
+watcher's suite needs, and for the same reason — a real euthanized marker on the
+developer's machine would make unrelated "clean" assertions fail).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from genesis.observability.snapshots import code_intel_health as ci
+
+
+@pytest.fixture(autouse=True)
+def _isolate_from_the_real_install(tmp_path, monkeypatch):
+    """Pin HOME so nothing resolves to this box's real ~/.cache or ~/.genesis."""
+    home = tmp_path / "home"
+    (home / ".genesis").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("CBM_CACHE_DIR", raising=False)
+
+
+def _markers(tmp_path) -> Path:
+    d = tmp_path / "index-requests"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _cache(tmp_path) -> Path:
+    d = tmp_path / "cbm-cache"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _euthanized(markers: Path, repo: str, attempts: int = 5) -> Path:
+    p = markers / "deadbeef0000.failed.json"
+    p.write_text(json.dumps({"repo_path": repo, "attempts": attempts, "mode": "fast"}))
+    return p
+
+
+def _index(cache: Path, target: Path, *, suffix: str = ".db") -> Path:
+    """Write a fake index db for `target`, using CBM's real slug shape.
+
+    Slug is the FULL path with '/' -> '-', verified against a live cache entry
+    (/home/ubuntu/tmp/kimi_review -> home-ubuntu-tmp-kimi_review).
+    """
+    p = cache / (ci.index_slug(target) + suffix)
+    p.write_bytes(b"x" * 64)
+    return p
+
+
+def _collect(tmp_path, target: Path):
+    return ci.collect(
+        indexed_path=target,
+        marker_dir=_markers(tmp_path),
+        cache_dir=_cache(tmp_path),
+    )
+
+
+# ── the acceptance bar: replay the real 2026-09-05 defect ─────────────────
+
+
+def test_a_euthanized_index_request_alerts(tmp_path):
+    """THE ACCEPTANCE BAR — replays the measured defect.
+
+    ``<hash>.failed.json`` is a TERMINAL state: index_marker's docstring says
+    such a marker is "never retried", and it takes MAX_ATTEMPTS=5 genuine
+    failures to reach. A repo abandoned by the indexer with nobody told is
+    exactly the silence this check exists to break.
+    """
+    target = tmp_path / "repo"
+    target.mkdir()
+    _index(_cache(tmp_path), target)  # index itself is fine — the REQUEST died
+    _euthanized(_markers(tmp_path), str(target))
+
+    h = _collect(tmp_path, target)
+    findings = ci.derive_findings(h)
+    assert h.euthanized, "a euthanized index request was not detected"
+    assert findings, "euthanized request produced no finding"
+    assert any("gave up" in f or "euthanized" in f for f in findings), findings
+
+
+def test_a_corrupt_target_index_alerts(tmp_path):
+    """The 164 MB `.db.corrupt` shape, measured on the live box."""
+    target = tmp_path / "repo"
+    target.mkdir()
+    _index(_cache(tmp_path), target, suffix=".db.corrupt")
+
+    h = _collect(tmp_path, target)
+    assert h.index_state == "corrupt", h.index_state
+    assert ci.derive_findings(h)
+
+
+def test_an_absent_target_index_alerts(tmp_path):
+    """Requested-and-never-built is as blind as corrupt."""
+    target = tmp_path / "repo"
+    target.mkdir()
+    _euthanized(_markers(tmp_path), str(target))  # it WAS asked for
+
+    h = _collect(tmp_path, target)
+    assert h.index_state == "absent", h.index_state
+    assert ci.derive_findings(h)
+
+
+# ── CONTROLS: a noisy alarm gets muted, which recreates the failure ───────
+
+
+def test_a_healthy_install_is_silent(tmp_path):
+    """Index present, nothing euthanized -> no finding. If this fires, the
+    check is unusable regardless of how well it detects the real thing."""
+    target = tmp_path / "repo"
+    target.mkdir()
+    _index(_cache(tmp_path), target)
+
+    h = _collect(tmp_path, target)
+    assert h.index_state == "ok", h.index_state
+    assert not ci.derive_findings(h), ci.derive_findings(h)
+
+
+def test_a_fresh_install_is_silent(tmp_path):
+    """No marker dir, no cache, nothing ever requested.
+
+    A fresh clone has no index and that is CORRECT, not a fault — the check
+    must distinguish "never asked" from "asked and failed". Absence of an index
+    only speaks when something asked for one.
+    """
+    target = tmp_path / "repo"
+    target.mkdir()
+    h = ci.collect(
+        indexed_path=target,
+        marker_dir=tmp_path / "no-such-markers",
+        cache_dir=tmp_path / "no-such-cache",
+    )
+    assert not ci.derive_findings(h), ci.derive_findings(h)
+
+
+def test_a_worktree_index_with_a_missing_root_is_out_of_scope(tmp_path):
+    """DELIBERATELY out of scope (owner decision 2026-09-05).
+
+    A live example exists on this box right now: a 31,431-node index whose
+    worktree root was deleted. Worktrees are created and destroyed constantly
+    here, so alerting on them is how this alarm would get muted — taking the
+    real signal with it. Only the CONFIGURED target is in scope.
+    """
+    target = tmp_path / "repo"
+    target.mkdir()
+    _index(_cache(tmp_path), target)  # the target itself is healthy
+    # ...and a stale worktree index whose root is long gone:
+    gone = tmp_path / "repo" / ".claude" / "worktrees" / "deleted-one"
+    _index(_cache(tmp_path), gone)
+
+    h = _collect(tmp_path, target)
+    assert not ci.derive_findings(h), "a deleted worktree's index must not alert"
+
+
+def test_a_euthanized_request_for_another_repo_is_out_of_scope(tmp_path):
+    """Scope is the configured target, not every repo that ever failed."""
+    target = tmp_path / "repo"
+    target.mkdir()
+    _index(_cache(tmp_path), target)
+    _euthanized(_markers(tmp_path), "/somewhere/else/entirely")
+
+    h = _collect(tmp_path, target)
+    assert not ci.derive_findings(h), ci.derive_findings(h)
+
+
+# ── fail-loud discipline: the check must not go quiet on its own faults ───
+
+
+def test_an_unreadable_marker_dir_is_reported_not_silent(tmp_path):
+    """A check that cannot look must not report all-clear — the generator this
+    whole class of work exists to kill."""
+    from tests.conftest import require_access_denied
+
+    target = tmp_path / "repo"
+    target.mkdir()
+    _index(_cache(tmp_path), target)
+    markers = _markers(tmp_path)
+    markers.chmod(0o000)
+    require_access_denied(markers)
+    try:
+        h = ci.collect(indexed_path=target, marker_dir=markers, cache_dir=_cache(tmp_path))
+        assert h.errors, "an unreadable marker dir read as clean"
+        assert any("DEGRADED" in f for f in ci.derive_findings(h))
+    finally:
+        markers.chmod(0o755)
+
+
+# ── alert identity: keyed on the CONDITION, never on a tally ──────────────
+
+
+def test_alert_identity_ignores_counts_but_tracks_condition(tmp_path):
+    """A rolling count re-pages hourly for one standing incident; the CONDITION
+    changing is a genuinely different alert. Same discipline as the injection
+    watcher's _IDENTITY_EXEMPT_FIELDS."""
+    target = tmp_path / "repo"
+    target.mkdir()
+    _euthanized(_markers(tmp_path), str(target), attempts=5)
+    first = ci.alert_identity(_collect(tmp_path, target))
+
+    # Same condition, different attempt count -> identity MUST NOT change.
+    _euthanized(_markers(tmp_path), str(target), attempts=9)
+    assert ci.alert_identity(_collect(tmp_path, target)) == first
+
+    # Condition changes (index also corrupt now) -> identity MUST change.
+    _index(_cache(tmp_path), target, suffix=".db.corrupt")
+    assert ci.alert_identity(_collect(tmp_path, target)) != first
+
+
+def test_findings_escape_every_marker_field(tmp_path):
+    """Both fields that reach the finding text are escaped at ingestion.
+
+    The previous version of this test injected into `repo_path` — which the
+    SCOPE FILTER then dropped, because a mangled path no longer slugs to the
+    target. It asserted over an empty list and was vacuous. Inject through
+    `attempts` instead, which the filter does not key on and which really was
+    unescaped, and assert the euthanized list is NON-EMPTY first so the test
+    cannot silently pass on nothing again.
+    """
+    target = tmp_path / "repo"
+    target.mkdir()
+    _index(_cache(tmp_path), target)
+    p = _markers(tmp_path) / "deadbeef0000.failed.json"
+    p.write_text(
+        json.dumps(
+            {
+                "repo_path": str(target),  # must MATCH, or scope drops it
+                "attempts": "5\nINJECTED FINDING LINE",
+                "mode": "fast",
+            }
+        )
+    )
+
+    h = _collect(tmp_path, target)
+    assert h.euthanized, "scope filter dropped the marker — the test would be vacuous"
+    assert all("\n" not in str(e["attempts"]) for e in h.euthanized), h.euthanized
+    assert all("\n" not in f for f in ci.derive_findings(h)), ci.derive_findings(h)
+
+
+def test_a_retained_corrupt_backup_beside_a_healthy_index_is_quiet(tmp_path):
+    """BLOCKER regression: `.corrupt` is a RETAINED BACKUP, not a live flag.
+
+    The indexer's own binary says `backing up corrupt db to .corrupt` and then
+    rebuilds `<slug>.db` in place; nothing ever unlinks the backup (a 164 MB one
+    on this box is two weeks old). Treating its existence as failure fired the
+    alarm FOREVER after a successful rebuild — a permanently-wrong alarm, which
+    is precisely what this module exists to prevent.
+    """
+    target = tmp_path / "repo"
+    target.mkdir()
+    db = _index(_cache(tmp_path), target)  # rebuilt, healthy
+    old = _index(_cache(tmp_path), target, suffix=".db.corrupt")  # retained backup
+    os.utime(old, (db.stat().st_mtime - 3600, db.stat().st_mtime - 3600))
+
+    h = _collect(tmp_path, target)
+    assert h.index_state == "ok", h.index_state
+    assert not ci.derive_findings(h), ci.derive_findings(h)
+
+
+def test_a_corrupt_backup_newer_than_the_index_still_alerts(tmp_path):
+    """The other direction — a backup NEWER than the live db means the current
+    index is the broken one. Without this cell the fix above could be a blanket
+    'ignore .corrupt', which would blind the check entirely."""
+    target = tmp_path / "repo"
+    target.mkdir()
+    db = _index(_cache(tmp_path), target)
+    new = _index(_cache(tmp_path), target, suffix=".db.corrupt")
+    os.utime(new, (db.stat().st_mtime + 3600, db.stat().st_mtime + 3600))
+
+    h = _collect(tmp_path, target)
+    assert h.index_state == "corrupt", h.index_state
+    assert ci.derive_findings(h)
+
+
+def test_a_non_object_marker_is_recorded_not_raised(tmp_path):
+    """BLOCKER-adjacent regression: `json.loads` returns lists/ints happily, and
+    `.get` on those raised AttributeError straight out of collect() — past every
+    except clause into the caller's bare `except Exception: logger.warning`. No
+    alert, no error entry, one log line nobody reads: this module's own failure
+    mode applied to itself."""
+    target = tmp_path / "repo"
+    target.mkdir()
+    _index(_cache(tmp_path), target)
+    (_markers(tmp_path) / "deadbeef0000.failed.json").write_text("[]")
+
+    h = _collect(tmp_path, target)  # must not raise
+    assert h.errors, "a structurally-invalid marker was swallowed"
+    assert any("DEGRADED" in f for f in ci.derive_findings(h))
+
+
+def test_a_pending_marker_for_another_repo_does_not_prove_ours_was_requested(tmp_path):
+    """`requested` gates whether an ABSENT index is a fault or a fresh install.
+
+    Marker filenames are opaque hashes carrying no repo identity, so the old
+    `any(*.json)` test treated ANY pending request as proof that OUR target was
+    requested — turning a fresh install into a permanent 'index ABSENT' alert
+    the moment a second repo was indexed.
+    """
+    target = tmp_path / "repo"
+    target.mkdir()  # no index, never requested
+    (_markers(tmp_path) / "cafe00001111.json").write_text(
+        json.dumps({"repo_path": "/some/other/repo", "mode": "fast"})
+    )
+
+    h = _collect(tmp_path, target)
+    assert not h.requested, "another repo's pending request marked ours as requested"
+    assert not ci.derive_findings(h), ci.derive_findings(h)
+
+
+def test_the_marker_dir_matches_the_helper_that_writes_it(tmp_path, monkeypatch):
+    """PARITY LOCK for a hand-copied path.
+
+    `default_marker_dir` re-derives what `scripts/lib/index_marker.py::marker_dir`
+    computes, because `src/` cannot import from `scripts/lib`. Tests CAN (other
+    call sites already import it by path), so the drift is locked here rather
+    than asserted away in a docstring.
+    """
+    import importlib.util
+
+    monkeypatch.setenv("GENESIS_HOME", str(tmp_path / "gh"))
+    spec = importlib.util.spec_from_file_location(
+        "_im", Path("scripts/lib/index_marker.py").resolve()
+    )
+    im = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(im)
+    assert ci.default_marker_dir() == im.marker_dir()
+
+
+# ── awareness check wiring — "wired", not merely "substantive" ────────────
+
+
+async def _alerts(db):
+    cur = await db.execute(
+        "SELECT content, priority, resolved_at FROM observations"
+        " WHERE source = 'code_intel_health_monitor' AND type = 'infrastructure_alert'"
+    )
+    return [dict(r) for r in await cur.fetchall()]
+
+
+async def _live(db):
+    return [a for a in await _alerts(db) if not a["resolved_at"]]
+
+
+@pytest.fixture
+async def db():
+    import aiosqlite
+
+    from genesis.db.schema import create_all_tables
+
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture
+def wired(monkeypatch, tmp_path):
+    """Point the check's config at a synthetic target + dirs."""
+    target = tmp_path / "repo"
+    target.mkdir(exist_ok=True)
+    from genesis.awareness import code_intel_health_config as cfg_mod
+
+    monkeypatch.setattr(cfg_mod, "load_config", lambda: {**cfg_mod.DEFAULTS})
+    monkeypatch.setattr(cfg_mod, "indexed_path", lambda cfg: target)
+    monkeypatch.setattr(ci, "default_marker_dir", lambda: _markers(tmp_path))
+    monkeypatch.setattr(ci, "default_cache_dir", lambda: _cache(tmp_path))
+    return target
+
+
+@pytest.mark.asyncio
+async def test_check_creates_one_high_alert(db, wired, tmp_path):
+    from genesis.awareness.loop import _check_code_intel_health
+
+    _euthanized(_markers(tmp_path), str(wired))
+    await _check_code_intel_health(db)
+    live = await _live(db)
+    assert len(live) == 1, live
+    # high, NOT critical: a dead index degrades tool quality; it does not lose
+    # the user's data or session context.
+    assert live[0]["priority"] == "high"
+    assert "ANSWERING FROM NOTHING" in live[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_check_is_idempotent_for_same_state(db, wired, tmp_path):
+    from genesis.awareness.loop import _check_code_intel_health
+
+    _euthanized(_markers(tmp_path), str(wired))
+    await _check_code_intel_health(db)
+    await _check_code_intel_health(db)
+    assert len(await _live(db)) == 1, "a standing incident re-paged"
+
+
+@pytest.mark.asyncio
+async def test_recovery_resolves_the_alert(db, wired, tmp_path):
+    """The index coming back must CLEAR the alert, not orphan it."""
+    from genesis.awareness.loop import _check_code_intel_health
+
+    marker = _euthanized(_markers(tmp_path), str(wired))
+    await _check_code_intel_health(db)
+    assert len(await _live(db)) == 1
+
+    marker.unlink()  # someone cleared the dead request...
+    _index(_cache(tmp_path), wired)  # ...and the index rebuilt
+    await _check_code_intel_health(db)
+    assert not await _live(db), "recovery left the alert standing"
+
+
+@pytest.mark.asyncio
+async def test_disabling_the_check_resolves_a_standing_alert(db, wired, tmp_path, monkeypatch):
+    """Disabling must not strand the last alert on the health surfaces."""
+    from genesis.awareness.loop import _check_code_intel_health
+
+    _euthanized(_markers(tmp_path), str(wired))
+    await _check_code_intel_health(db)
+    assert len(await _live(db)) == 1
+
+    monkeypatch.setenv("GENESIS_CODE_INTEL_HEALTH_DISABLED", "1")
+    await _check_code_intel_health(db)
+    assert not await _live(db), "disabling orphaned the alert"
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_install_writes_no_alert(db, wired, tmp_path):
+    from genesis.awareness.loop import _check_code_intel_health
+
+    _index(_cache(tmp_path), wired)
+    await _check_code_intel_health(db)
+    assert not await _alerts(db), "healthy state produced an alert"


### PR DESCRIPTION
## The problem

The code indexer can give up on a repository **permanently** and report it only into a
log file. Measured on a live install:

- the main repo's index request was euthanized after 5 failed attempts, to a marker
  `scripts/lib/index_marker.py` itself describes as **"never retried"**;
- its database sat as a 164 MB `.db.corrupt` for **two weeks**;
- `code-intelligence-runner.log` carried **35** `index failed` lines (the last three
  `rc=143` — killed under the memory cap);
- the live server reported two indexed projects: a worktree whose root no longer exists,
  and a 26-node scratch dir. The main repo was **not indexed at all**.

Nothing surfaced any of it: no awareness check covered code-intel, and the only `src/`
consumer of the marker system is a *writer*. It did not fail silently — it failed loudly
into a log, which is operationally identical. Same generator as the SessionStart-injection
silence (#1556), one subsystem over.

## The fix

An hourly awareness check reading the indexer's **own on-disk artifacts** — euthanized
request markers, and whether an index exists for the configured target. It never asks the
code-intel tool how it is doing: a crashed indexer cannot report its own health, and its
daemon may not be running.

Scope is deliberately narrow (the configured target only). Worktree indexes churn
constantly here — a live example is a 31,431-node index whose root is gone — and alerting
on those is how an alarm gets muted, taking the real signal with it.

Priority `high` (morning report), **not** `critical`: a dead index degrades tool quality;
it does not lose the user's data or session context.

## Two traps found in adversarial review

Both the same shape — the *watcher's* contract verified, the *producer's* asserted:

1. **`.db.corrupt` is a retained BACKUP, not a live-state flag.** The indexer's own binary
   says `backing up corrupt db to .corrupt`, rebuilds the db in place, and never unlinks
   the backup. Keying on its existence fired the alarm **forever after a successful
   rebuild** — a permanently-wrong alarm, which is precisely what this check exists to
   prevent. Now: corrupt only when the backup is *newer* than the live db. Regression
   cells in both directions, because a blanket "ignore `.corrupt`" would blind the check.
2. **`indexed_path` steers only this check.** Every index-request writer (post-commit
   hook, `disk_reclaim`, the gitnexus surplus job) hardcodes the repo root, and nothing in
   the indexing path reads this config — so the alert's original remedy ("narrow
   `indexed_path`") would have made the check watch an index nothing builds. The remedy
   and all doc sites now say narrowing means re-pointing the *writers* and matching the
   knob; setting it alone reports ABSENT forever.

Also fixed: an `any(*.json)` fresh-install guard that accepted *another* repo's pending
request (marker filenames are opaque hashes); a non-object marker raising `AttributeError`
straight out of the collector into a bare `except Exception: logger.warning` — this
module's own failure mode applied to itself; two unescaped values reaching a first-party
observation; and a vacuous escaping test whose injected value was dropped by an upstream
scope filter before any escaping happened.

One consciously accepted limit, stated rather than inherited silently: a raise *outside*
the collector is still log-only. The sibling `_check_context_injection_health` has the same
hole, and fixing one while leaving the other is worse than fixing the class deliberately —
that belongs in its own change. The concrete trigger is fixed here.

## Verification

198 targeted tests green (20 in the new suite); ruff clean; 4 local CI guards OK.
**Acceptance bar: run against real live state, it fires on the actual two-week-old
defect.** Live E2E through the real awareness path: exactly one `high` alert after two
ticks (no re-paging), resolving on recovery and on disable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added hourly monitoring for code-intelligence index health.
  - Added configurable monitoring controls for enablement, indexed path, and alert priority.
  - Added detection of missing, stale, corrupted, unreadable, or incomplete index data.
  - Added clear health findings based on available index artifacts.
  - Added high-priority alerts with duplicate prevention and automatic resolution when issues recover or monitoring is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->