### PR TITLE
fix(hooks): score inline review findings only when their path is in the PR's diff

### DIFF
--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -1584,10 +1584,21 @@ def _check_inline_review_findings(
     Returns (should_block, message). Each unresolved finding contributes to a review
     score — P1 = 1.0, P2 = 0.5 — and the gate blocks when the score >= 1.0 (any P1, OR
     >= 2 P2s). A finding is EXCLUDED from the score when its thread has a MAINTAINER
-    reply (engagement = consciously accepted) or its path is documentation
-    (``_is_doc_path``). The two exclusions differ in VISIBILITY by design: a doc-path
-    finding was auto-excluded by PATH (not engaged), so it is still SURFACED as a NOTE —
-    scored P2s print as a WARNING, doc-path P1s/P2s as a NOTE — nothing unaddressed is
+    reply (engagement = consciously accepted), its path is documentation
+    (``_is_doc_path``), or its path is OUTSIDE the PR's diff (issue #1728: a
+    merge of main stamps base-branch findings onto the PR; scoring them makes
+    the gate demand base-branch fixes as this PR's price — reconciliation must
+    stay gate-neutral). Off-diff findings are surfaced with their paths so real
+    ones can be routed to the base branch's tracker; a MISSING/null path always
+    scores (never silently discount a finding this check cannot place), and an
+    unreadable changed-file set scores everything (status quo) with a loud
+    NOTE. Scoping leans on the Codex FRESHNESS gate as its backstop: code moved
+    away from a reverted file re-enters the diff at the new head, where a current
+    review is separately required — weakening that gate widens this one.
+    The exclusions differ in VISIBILITY by design: doc-path and off-diff findings
+    were auto-excluded by PATH (not engaged), so both are still SURFACED as NOTEs —
+    scored P2s print as a WARNING, doc-path P1s/P2s and off-diff findings as NOTEs —
+    nothing unaddressed is
     dropped. A maintainer-replied finding was CONSCIOUSLY ENGAGED (the reply IS the
     acknowledgement), so it is excluded from the report too: the pre-merge report shows
     what still needs attention, not what a maintainer already handled (re-listing every
@@ -1633,6 +1644,40 @@ def _check_inline_review_findings(
     cr_unknown: list[str] = []  # a severity header naming a level we don't know
     cr_doc_skipped: list[str] = []  # CodeRabbit Critical/Major on a doc path
     unmatched_bot: list[tuple[str, str]] = []  # (login, title) — read, unrecognised
+    # Off-diff findings (issue #1728): (title, path) — surfaced, never scored.
+    cr_off_diff: list[tuple[str, str]] = []
+    off_diff_p1: list[tuple[str, str]] = []
+    off_diff_p2: list[tuple[str, str]] = []
+    # The PR's changed-file set, resolved LAZILY and at most once: only a PR
+    # that actually carries a candidate blocking finding pays for the read
+    # (one paginated `gh api pulls/N/files` under _gh_timeout(8), which clamps
+    # to the remaining merge deadline). [] = unresolved; [set] = resolved;
+    # [None] = resolution failed → every check answers "in diff" (scored),
+    # which re-creates the pre-scoping behavior, announced by a NOTE below.
+    _scope_cache: list[set[str] | None] = []
+
+    def _off_diff(path: str | None) -> bool:
+        """True only when the finding names a path PROVABLY outside the diff.
+
+        An EMPTY changed-file set is treated like an UNREADABLE one (score
+        everything + the loud NOTE), not like a resolved answer: over the API,
+        200-with-zero-rows cannot be told apart from a transiently-degraded
+        response, and "discount every finding on the whole PR" is the one
+        outcome this gate must never reach through an ambiguity (security
+        review HIGH, 2026-09-06). The cost is only that a genuinely empty PR
+        (head == base) scores its findings — the stricter direction, and such
+        a PR has no content to merge anyway. NOTE: `_hook_surface_override_check`
+        deliberately keeps the opposite reading of `[]` ("no hook files") —
+        that consumer fails CLOSED on `None` and an empty PR truly has no hook
+        files, so its contract is untouched.
+        """
+        if not path:
+            return False  # pathless/outdated comment — never silently discounted
+        if not _scope_cache:
+            files = _pr_changed_files(pr_num, repo=repo)
+            _scope_cache.append(set(files) if files else None)
+        changed = _scope_cache[0]
+        return changed is not None and path not in changed
     for c in raw:
         login, utype = c.get("login") or "", c.get("type") or ""
         body = c.get("body") or ""
@@ -1679,6 +1724,14 @@ def _check_inline_review_findings(
                     else:
                         cr_advisory.append(title)
                     continue
+                if _off_diff(c.get("path")):
+                    # Checked BEFORE the doc-path lever: off-diff is the broader
+                    # exclusion (a base-branch finding is not this PR's to
+                    # answer whatever the file type), and unlike doc-skipping it
+                    # is not mode-gated — it enforces ratified policy (#1728),
+                    # not a per-install preference.
+                    cr_off_diff.append((_coderabbit_title(seg), c.get("path") or ""))
+                    continue
                 if _is_doc_path(c.get("path") or "") and _doc_findings_mode() == "skip":
                     # Its OWN list, not the Codex `doc_skipped` one — landing a
                     # CodeRabbit finding there printed it as "[doc P1]" under a
@@ -1695,6 +1748,13 @@ def _check_inline_review_findings(
         if _INLINE_P1_RE.search(body):
             if c.get("id") in replied_to:
                 continue  # thread engaged — treated as acknowledged
+            if _off_diff(c.get("path")):
+                # Same scoping the CodeRabbit branch gets above — the stale-
+                # anchor mechanism (#1728) is reviewer-agnostic, and enforcing
+                # it for one reviewer only would be an asymmetry with no
+                # stated reason (the #1677 class).
+                off_diff_p1.append((_inline_title(body), c.get("path") or ""))
+                continue
             if _is_doc_path(c.get("path") or "") and _doc_findings_mode() == "skip":
                 # A P1 on a documentation file (ledger 54eb3752) is surfaced but
                 # does NOT block; a code file (incl. code under docs/) still does.
@@ -1706,6 +1766,9 @@ def _check_inline_review_findings(
         elif _INLINE_P2_RE.search(body):
             if c.get("id") in replied_to:
                 continue  # thread engaged — maintainer consciously accepted the P2
+            if _off_diff(c.get("path")):
+                off_diff_p2.append((_inline_title(body), c.get("path") or ""))
+                continue
             if _is_doc_path(c.get("path") or "") and _doc_findings_mode() in ("skip", "p1_only"):
                 # A P2 on a doc path is not a code defect — excluded from the SCORE, but
                 # still SURFACED as a NOTE (mirroring doc-path P1s). A documentation-
@@ -1738,6 +1801,38 @@ def _check_inline_review_findings(
         )
         for bot_login, title in unmatched_bot[:5]:
             print(f"  [unrecognised: {bot_login}] {title}", file=sys.stderr)
+    if _scope_cache and _scope_cache[0] is None:
+        # Resolution was ATTEMPTED (a candidate finding consulted it) and
+        # failed — say so loudly, because from here the scan behaves exactly
+        # as it did before scoping existed: everything scores.
+        print(
+            f"NOTE: PR #{pr_num} — diff scoping unavailable (changed-file set "
+            f"unreadable or empty: gh error, a >3000-file PR, or a no-content "
+            f"PR). ALL findings scored, including any on base-branch content.",
+            file=sys.stderr,
+        )
+    if cr_off_diff:
+        print(
+            f"NOTE: PR #{pr_num} — {len(cr_off_diff)} CodeRabbit Critical/Major "
+            f"finding(s) on files outside this PR's diff (base-branch content, "
+            f"typically stamped by a merge of main) — NOT scored. A real one "
+            f"belongs to the base branch's tracker, not this PR's gate:",
+            file=sys.stderr,
+        )
+        for title, fpath in cr_off_diff[:8]:
+            print(f"  [off-diff CodeRabbit Critical/Major] {title} ({fpath})", file=sys.stderr)
+    if off_diff_p1 or off_diff_p2:
+        print(
+            f"NOTE: PR #{pr_num} — {len(off_diff_p1)} [P1] + {len(off_diff_p2)} "
+            f"[P2] inline finding(s) on files outside this PR's diff — NOT "
+            f"scored (base-branch content; route real ones to the base "
+            f"branch's tracker):",
+            file=sys.stderr,
+        )
+        for title, fpath in off_diff_p1[:5]:
+            print(f"  [off-diff P1] {title} ({fpath})", file=sys.stderr)
+        for title, fpath in off_diff_p2[:5]:
+            print(f"  [off-diff P2] {title} ({fpath})", file=sys.stderr)
     if cr_unknown:
         print(
             f"NOTE: PR #{pr_num} — {len(cr_unknown)} CodeRabbit finding(s) whose "
@@ -2615,9 +2710,14 @@ def _pr_changed_files(pr_num: str, repo: str | None = None) -> list[str] | None:
                 ],
                 capture_output=True,
                 text=True,
-                # Merge-path timeout budget (see main()): this runs ONLY on the
-                # rare `# stale-review-override` path, so one paginated read
-                # stays inside the hook's wall-clock.
+                # Merge-path timeout budget (see main()): THREE consumers —
+                # the hook-surface override check (rare override path),
+                # _pin_blob_unchanged (rare pin path), and the inline-findings
+                # diff scoping (#1728), which is on the hot merge path but
+                # LAZY: it reads only when a candidate blocking finding exists,
+                # at most once per scan. _gh_timeout clamps this call to the
+                # remaining merge deadline, and a timeout degrades to None →
+                # the scoping caller scores everything (status quo) + a NOTE.
                 timeout=_gh_timeout(8),
             )
             if result.returncode != 0:

--- a/tests/test_hooks/test_merge_review_gate.py
+++ b/tests/test_hooks/test_merge_review_gate.py
@@ -1207,6 +1207,65 @@ class TestCheckInlineReviewFindings:
     boilerplate — 173 findings passed the gate unseen before this
     (2026-07-10 audit)."""
 
+    # Every path this class anchors a finding on. Pinned as IN the PR's diff
+    # by the autouse fixture below.
+    _FINDING_PATHS = [
+        "src/benign.py",
+        "src/genesis/foo.py",
+        "src/genesis/a.py",
+        "src/genesis/router.py",
+        "CHANGELOG.md",
+        "README.md",
+        "NOTES.md",
+        "AGENTS.md",
+        "LICENSE",
+        "LICENSE.txt",
+        "README.txt",
+        "guide.rst",
+        "docs/CURRENT.md",
+        "docs/architecture/x.md",
+        "docs/conf.py",
+        "docs/conf.py\n",
+        "docs/build.rs",
+        "docs/config.yaml",
+        "docs/notebook.ipynb",
+        "docs/init.sql",
+        "docs/Script.java",
+        "docs/deploy.ps1",
+        "docs/Makefile",
+        "docs/requirements.txt",
+        "docs/constraints.txt",
+        "docs/CMakeLists.txt",
+        "docs/meson_options.txt",
+        "docs/guide.txt",
+        "docs/README.txt",
+        "docs/guide\x7f.md",
+        "docs/guide\x85.md",
+        "docs/guide\x9f.md",
+    ]
+
+    @pytest.fixture(autouse=True)
+    def _findings_are_in_diff(self, monkeypatch):
+        """Pin this class's finding paths as IN the PR's changed-file set.
+
+        This class tests severity parsing, engagement, and the doc-path lever —
+        all semantics of findings on files the PR touches. Diff SCOPING is
+        ``TestDiffScopedInlineFindings``' subject (issue #1728); without this
+        fixture its arrival would divert these cases to the off-diff lane and
+        they would test nothing they name. A new test anchoring a finding on a
+        new path adds it to ``_FINDING_PATHS``. A miss fails loudly ONLY in a
+        test that asserts a block or a lane marker — the off-diff lane also
+        yields ``not block``, so a bare not-block assertion passes vacuously on
+        an unlisted path. That is why every not-block doc-path test below ALSO
+        asserts its doc-lane marker in stderr."""
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            "\n".join(
+                json.dumps({"filename": p, "previous_filename": None})
+                for p in self._FINDING_PATHS
+            ),
+        )
+
     def _mock(self, guard_module, comments, rc=0):
         # gh api --paginate with a per-element jq filter emits one
         # compact JSON object per line across ALL result pages.
@@ -1853,7 +1912,7 @@ class TestCheckInlineReviewFindings:
         assert "[doc P1]" in capsys.readouterr().err, "surfaced, never silently dropped"
 
     def test_p1_only_mode_a_doc_p1_blocks_but_a_doc_p2_does_not(
-        self, guard_module, monkeypatch
+        self, guard_module, monkeypatch, capsys
     ):
         """The middle setting, so it can be dialled back without another PR."""
         monkeypatch.setenv("_TEST_DOC_FINDINGS_MODE", "p1_only")
@@ -1861,9 +1920,10 @@ class TestCheckInlineReviewFindings:
             assert guard_module._check_inline_review_findings("100")[0] is True
         with self._mock(guard_module, [self._codex(2, _P2_BODY, path="AGENTS.md")]):
             assert guard_module._check_inline_review_findings("100")[0] is False
+        assert "[doc P2]" in capsys.readouterr().err  # the doc lane, not off-diff
 
     def test_stricter_modes_apply_to_coderabbit_doc_findings_too(
-        self, guard_module, monkeypatch
+        self, guard_module, monkeypatch, capsys
     ):
         """The mode lever must govern BOTH reviewers (Codex P2, PR #1677 round 4).
 
@@ -1881,6 +1941,7 @@ class TestCheckInlineReviewFindings:
         with self._mock(guard_module, [self._coderabbit(1, _CR_MAJOR_BODY, path="AGENTS.md")]):
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block, "the default must keep doc findings non-blocking"
+        assert "[doc CodeRabbit Critical/Major]" in capsys.readouterr().err
 
     def test_score_mode_restores_the_old_behaviour(self, guard_module, monkeypatch):
         """Two doc P2s = 1.0 → blocks, exactly as two code P2s would."""
@@ -2015,22 +2076,30 @@ class TestCheckInlineReviewFindings:
         assert not block
         assert "documentation" in capsys.readouterr().err.lower()
 
-    def test_inline_p1_on_readme_does_not_block(self, guard_module):
+    # Every not-block doc-path test asserts its DOC-LANE marker too: the
+    # off-diff lane (issue #1728) also returns not-block, so the verdict alone
+    # cannot tell "exempt as documentation" from "diverted by an unlisted
+    # path in _FINDING_PATHS" (architect SF, 2026-09-06).
+
+    def test_inline_p1_on_readme_does_not_block(self, guard_module, capsys):
         with self._mock(guard_module, [self._codex(1, _P1_BODY, path="README.md")]):
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
+        assert "[doc P1]" in capsys.readouterr().err
 
-    def test_inline_p1_under_docs_dir_does_not_block(self, guard_module):
+    def test_inline_p1_under_docs_dir_does_not_block(self, guard_module, capsys):
         with self._mock(
             guard_module, [self._codex(1, _P1_BODY, path="docs/architecture/x.md")]
         ):
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
+        assert "[doc P1]" in capsys.readouterr().err
 
-    def test_inline_p1_on_rst_does_not_block(self, guard_module):
+    def test_inline_p1_on_rst_does_not_block(self, guard_module, capsys):
         with self._mock(guard_module, [self._codex(1, _P1_BODY, path="guide.rst")]):
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
+        assert "[doc P1]" in capsys.readouterr().err
 
     def test_inline_p1_on_code_path_still_blocks(self, guard_module):
         with self._mock(
@@ -2040,7 +2109,7 @@ class TestCheckInlineReviewFindings:
         assert block
         assert "Make queue claim atomic" in msg
 
-    def test_inline_p1_on_a_markdown_file_no_longer_blocks(self, guard_module):
+    def test_inline_p1_on_a_markdown_file_no_longer_blocks(self, guard_module, capsys):
         """DELIBERATE REVERSAL (owner decision, 2026-09-04) of the old default.
 
         This test previously locked the opposite: a `*.md` outside `docs/` was NOT a
@@ -2061,6 +2130,7 @@ class TestCheckInlineReviewFindings:
         with self._mock(guard_module, [self._codex(1, _P1_BODY, path="NOTES.md")]):
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
+        assert "[doc P1]" in capsys.readouterr().err
 
     def test_inline_p1_on_code_under_docs_still_blocks(self, guard_module):
         # docs/conf.py is executable Python — a finding there must still block.
@@ -2124,10 +2194,11 @@ class TestCheckInlineReviewFindings:
             block, _ = guard_module._check_inline_review_findings("100")
         assert block
 
-    def test_inline_p1_on_license_no_ext_does_not_block(self, guard_module):
+    def test_inline_p1_on_license_no_ext_does_not_block(self, guard_module, capsys):
         with self._mock(guard_module, [self._codex(1, _P1_BODY, path="LICENSE")]):
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
+        assert "[doc P1]" in capsys.readouterr().err
 
     @pytest.mark.parametrize(
         "path",
@@ -2149,11 +2220,12 @@ class TestCheckInlineReviewFindings:
         assert block, f"{path!r} is an ambiguous .txt — must block"
 
     @pytest.mark.parametrize("path", ["LICENSE.txt", "README.txt", "docs/README.txt"])
-    def test_inline_p1_known_stem_txt_does_not_block(self, guard_module, path):
+    def test_inline_p1_known_stem_txt_does_not_block(self, guard_module, path, capsys):
         # A doc-named STEM pins the file as prose, so .txt is safe there.
         with self._mock(guard_module, [self._codex(1, _P1_BODY, path=path)]):
             block, _ = guard_module._check_inline_review_findings("100")
         assert not block
+        assert "[doc P1]" in capsys.readouterr().err
 
     @pytest.mark.parametrize(
         "path",
@@ -2168,6 +2240,261 @@ class TestCheckInlineReviewFindings:
         with self._mock(guard_module, [self._codex(1, _P1_BODY, path=path)]):
             block, _ = guard_module._check_inline_review_findings("100")
         assert block
+
+
+# ── Diff-scoped inline findings (issue #1728) ─────────────────────────────
+#
+# Module-level comment factories for the class below. Same shapes as
+# TestCheckInlineReviewFindings' bound helpers (which carry no state);
+# duplicated as module functions rather than inherited, because subclassing
+# that class would re-run its entire suite under a second name.
+
+
+def _cr_c(cid, body, reply_to=None, path=None):
+    d = {
+        "id": cid,
+        "reply_to": reply_to,
+        "login": "coderabbitai[bot]",
+        "type": "Bot",
+        "body": body,
+    }
+    if path is not None:
+        d["path"] = path
+    return d
+
+
+def _codex_c(cid, body, reply_to=None, path=None):
+    d = {
+        "id": cid,
+        "reply_to": reply_to,
+        "login": "chatgpt-codex-connector[bot]",
+        "type": "Bot",
+        "body": body,
+    }
+    if path is not None:
+        d["path"] = path
+    return d
+
+
+def _mock_inline(guard_module, comments, rc=0):
+    return patch.object(
+        guard_module.subprocess,
+        "run",
+        return_value=subprocess.CompletedProcess(
+            args=[],
+            returncode=rc,
+            stdout="\n".join(json.dumps(c) for c in comments),
+            stderr="",
+        ),
+    )
+
+
+def _cr_major(title: str) -> str:
+    """A CodeRabbit Major body in the verbatim live header format, custom title."""
+    return f"_🔒 Security & Privacy_ | _🟠 Major_ | _⚡ Quick win_\n\n**{title}**\n\nDetails."
+
+
+class TestDiffScopedInlineFindings:
+    """A finding is SCORED only when its path is inside the PR's diff (issue #1728).
+
+    MEASURED on live PR #1541 (gate run 2026-09-05): the inline score reached 7.0
+    with 4 of 7 CodeRabbit Critical/Major findings anchored on files ABSENT from
+    the PR's diff — base-branch content stamped onto the PR by a merge of main.
+    The gate scored them at full weight because nothing compared a finding's
+    ``path`` to the PR's changed-file set.
+
+    The contract under test: off-diff findings are surfaced (labeled base-branch)
+    and excluded from the score; a missing/null path is always scored (a pathless
+    finding must never be silently discounted); an unreadable changed-file set
+    scores everything (status quo) and says so. The autouse ``_hermetic_pr_files``
+    fixture pins the changed-file set to ``src/benign.py``, the in-diff control.
+    """
+
+    def test_off_diff_coderabbit_major_not_scored(self, guard_module, capsys):
+        """RED before the fix: an off-diff Major blocked at full weight."""
+        with _mock_inline(guard_module, [_cr_c(1, _CR_MAJOR_BODY, path="src/other.py")]):
+            block, msg = guard_module._check_inline_review_findings("100")
+        assert not block, f"off-diff CodeRabbit Major was scored: {msg}"
+        err = capsys.readouterr().err
+        assert "outside this PR's diff" in err
+        assert "src/other.py" in err
+
+    def test_in_diff_coderabbit_major_still_blocks(self, guard_module):
+        """The control: scoping must not blind the gate to in-diff findings."""
+        with _mock_inline(guard_module, [_cr_c(1, _CR_MAJOR_BODY, path="src/benign.py")]):
+            block, msg = guard_module._check_inline_review_findings("100")
+        assert block
+        assert "Track unresolved reparsing prefixes" in msg
+
+    def test_pathless_coderabbit_major_still_blocks(self, guard_module):
+        """No ``path`` key at all (file-level/outdated comment) → scored.
+
+        A pathless finding must never be silently discounted by a check that
+        needs a path to run.
+        """
+        with _mock_inline(guard_module, [_cr_c(1, _CR_MAJOR_BODY)]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block
+
+    def test_null_path_coderabbit_major_still_blocks(self, guard_module):
+        """Explicit ``path: null`` (GitHub emits it on outdated comments) → scored."""
+        c = _cr_c(1, _CR_MAJOR_BODY)
+        c["path"] = None
+        with _mock_inline(guard_module, [c]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block
+
+    def test_unreadable_file_set_scores_everything_with_note(
+        self, guard_module, capsys, monkeypatch
+    ):
+        """Changed-file set unreadable → status quo (score all) + a loud NOTE.
+
+        Fail direction chosen deliberately: scoring everything is the STRICTER
+        direction, so an API failure can never let a real finding through —
+        it can only re-create the pre-fix behavior, announced.
+        """
+        monkeypatch.setenv("_TEST_GH_PR_FILES", "__error__")
+        with _mock_inline(guard_module, [_cr_c(1, _CR_MAJOR_BODY, path="src/other.py")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block, "unreadable file set must keep the old scoring, not skip it"
+        assert "diff scoping unavailable" in capsys.readouterr().err
+
+    def test_off_diff_codex_p1_not_scored(self, guard_module, capsys):
+        """Codex findings get the same scoping — the mechanism is reviewer-agnostic."""
+        with _mock_inline(guard_module, [_codex_c(1, _P1_BODY, path="src/other.py")]):
+            block, msg = guard_module._check_inline_review_findings("100")
+        assert not block, f"off-diff Codex P1 was scored: {msg}"
+        assert "outside this PR's diff" in capsys.readouterr().err
+
+    def test_off_diff_codex_p2_pair_not_scored(self, guard_module):
+        """Two off-diff P2s would sum to the 1.0 threshold — neither may score."""
+        comments = [
+            _codex_c(1, _P2_BODY, path="src/other.py"),
+            _codex_c(2, _P2_BODY, path="src/third.py"),
+        ]
+        with _mock_inline(guard_module, comments):
+            block, msg = guard_module._check_inline_review_findings("100")
+        assert not block, f"off-diff P2 pair reached the threshold: {msg}"
+
+    def test_maintainer_replied_off_diff_excluded_silently(self, guard_module, capsys):
+        """Engagement is checked FIRST: a replied off-diff finding is already
+        handled, so it must not be re-listed in the off-diff NOTE either."""
+        comments = [
+            _cr_c(1, _CR_MAJOR_BODY, path="src/other.py"),
+            {
+                "id": 2,
+                "reply_to": 1,
+                "login": "owner",
+                "type": "User",
+                "assoc": "OWNER",
+                "body": "acknowledged — tracked in the base-branch issue",
+            },
+        ]
+        with _mock_inline(guard_module, comments):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert not block
+        assert "outside this PR's diff" not in capsys.readouterr().err
+
+    def test_empty_changed_file_set_scores_everything_with_note(
+        self, guard_module, monkeypatch, capsys
+    ):
+        """An EMPTY file set is treated as UNRESOLVABLE, not as an answer
+        (security review HIGH, 2026-09-06): a 200-with-zero-rows response is
+        indistinguishable from a transiently-degraded one, and the ambiguous
+        reading must never discount every finding on the PR. Scoped to this
+        check only — the hook-surface consumer keeps ``[]`` = "no hook files"
+        (an empty PR truly has none, and it fails closed on ``None``)."""
+        monkeypatch.setenv("_TEST_GH_PR_FILES", "")
+        with _mock_inline(guard_module, [_cr_c(1, _CR_MAJOR_BODY, path="src/other.py")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block, "empty file set must fail toward scoring, never discounting"
+        assert "diff scoping unavailable" in capsys.readouterr().err
+
+    def test_rename_source_counts_as_in_diff(self, guard_module, monkeypatch):
+        """A comment left on the pre-rename path still scores — the changed-file
+        set includes rename SOURCES via ``previous_filename``."""
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            '{"filename": "src/new_name.py", "previous_filename": "src/old_name.py"}',
+        )
+        with _mock_inline(guard_module, [_cr_c(1, _CR_MAJOR_BODY, path="src/old_name.py")]):
+            block, _ = guard_module._check_inline_review_findings("100")
+        assert block
+
+    # ── Acceptance replay: PR #1541, the measured motivating case ──────────
+
+    # The PR's REAL changed-file list (gh api pulls/1541/files, 2026-09-06;
+    # 24 files, no renames) and the REAL paths of its 8 top-level CodeRabbit
+    # Major findings: 3 on files in the diff, 5 on base-branch files stamped
+    # by merges of main. Bodies use the verbatim live header format with
+    # synthetic titles — the load-bearing data here is the path set.
+    _PR1541_FILES = [
+        "CHANGELOG.md",
+        "config/model_routing.yaml",
+        "config/session_ledger_shadow.yaml",
+        "docs/architecture/CURRENT.md",
+        "scripts/genesis_precompact.py",
+        "scripts/ledger_shadow_report.py",
+        "src/genesis/db/crud/session_charters.py",
+        "src/genesis/db/crud/session_ledger_shadow.py",
+        "src/genesis/db/migrations/20260904231054_session_ledger_ambient_extractor.py",
+        "src/genesis/db/schema/_tables.py",
+        "src/genesis/mcp/health/session_charter_tools.py",
+        "src/genesis/mcp/health/settings.py",
+        "src/genesis/session_awareness/ledger_extractor.py",
+        "src/genesis/session_awareness/ledger_shadow_config.py",
+        "src/genesis/session_awareness/ledger_worker.py",
+        "src/genesis/session_awareness/repo_pulse_worker.py",
+        "src/genesis/session_charter.py",
+        "tests/test_db/test_migration_0059_session_ledger_shadow.py",
+        "tests/test_db/test_migration_ambient_extractor.py",
+        "tests/test_db/test_session_charters_crud.py",
+        "tests/test_scripts/test_ledger_shadow_report.py",
+        "tests/test_session_awareness/test_ledger_extractor.py",
+        "tests/test_session_awareness/test_ledger_shadow_config.py",
+        "tests/test_session_awareness/test_ledger_worker.py",
+    ]
+    _PR1541_IN_DIFF_MAJORS = [
+        "src/genesis/session_awareness/ledger_shadow_config.py",
+        "src/genesis/session_awareness/ledger_worker.py",
+        "src/genesis/session_awareness/ledger_worker.py",
+    ]
+    _PR1541_OFF_DIFF_MAJORS = [
+        ".github/workflows/ci.yml",
+        "scripts/genesis_session_context.py",
+        "src/genesis/db/crud/ego_intentions.py",
+        "src/genesis/db/migrations/0088_ego_intentions_origin.py",
+        "src/genesis/session_awareness/repo_pulse_gh.py",
+    ]
+
+    def test_acceptance_replay_pr1541(self, guard_module, capsys, monkeypatch):
+        """Replay #1728's measured defect: base-branch Majors drop from the
+        score, in-diff Majors still block.
+
+        With the full current comment set (8 Majors: 3 in-diff, 5 off-diff,
+        none replied) the pre-fix score is 8.0; scoped, it is 3.0 — still a
+        block, on exactly the findings that are this PR's to answer.
+        """
+        monkeypatch.setenv(
+            "_TEST_GH_PR_FILES",
+            "\n".join(
+                json.dumps({"filename": f, "previous_filename": None})
+                for f in self._PR1541_FILES
+            ),
+        )
+        comments = []
+        for i, path in enumerate(self._PR1541_IN_DIFF_MAJORS):
+            comments.append(_cr_c(100 + i, _cr_major(f"in-diff finding {i}"), path=path))
+        for i, path in enumerate(self._PR1541_OFF_DIFF_MAJORS):
+            comments.append(_cr_c(200 + i, _cr_major(f"base-branch finding {i}"), path=path))
+        with _mock_inline(guard_module, comments):
+            block, msg = guard_module._check_inline_review_findings("1541")
+        assert block, "the 3 in-diff Majors must still block"
+        assert "review score 3.0" in msg
+        assert "3 CodeRabbit" in msg
+        err = capsys.readouterr().err
+        assert "5 CodeRabbit" in err and "outside this PR's diff" in err
+        assert "0088_ego_intentions_origin" in err
 
 
 class TestResolvePrNumber:


### PR DESCRIPTION
## What

The inline-findings merge gate scored every CodeRabbit Critical/Major (and Codex P1/P2) at full weight without checking that the finding's file is part of the PR's diff. A merge of main stamps the base branch's findings onto the PR, so base-branch content blocked unrelated PRs — measured on the motivating PR: review score 7.0 with 4 of 7 Critical/Major findings on files absent from the diff (#1728).

The gate now scores a finding only when its `path` is inside the PR's changed-file set (`pulls/N/files`, one lazy paginated read per scan, clamped to the merge deadline). Off-diff findings are surfaced in a NOTE with their paths, labeled base-branch content — filing real ones on the base branch's tracker stays a deliberate human step (#1732 is the live example). Reconciliation is gate-neutral.

## Fail directions (the load-bearing part)

- **Missing/null `path`** → scored. A pathless finding is never silently discounted.
- **Unreadable changed-file set** (gh error, timeout, malformed row, >3000-file cap) → everything scores + a loud `diff scoping unavailable` NOTE — the stricter direction; an API failure can only re-create pre-fix behavior, announced.
- **Empty changed-file set** → treated exactly like unreadable (security review HIGH): a 200-with-zero-rows response is indistinguishable from a transiently degraded one, and the ambiguous reading must never discount a whole PR's findings. A genuinely empty PR scores its findings — it has no content to merge anyway.
- Rename sources count as in-diff (`previous_filename`).

## Verification

- Verify-RED on every new test (5 seen failing against the unpatched gate; 2 mutations — fixture-miss and scoping-deleted — each caught by the tests that pin them, with hash-verified restores).
- **Acceptance replay, in-suite**: the motivating PR's real changed-file list + its 8 real Major finding paths → score 8.0 → 3.0, still blocking on the 3 in-diff findings, 5 off-diff surfaced.
- **Measured over all 65 open PRs** (patched vs unpatched, live): 3/65 scores change (26.5→25.5, 4.5→4.0, 16.5→6.5), **0/65 BLOCK→pass flips**, off-diff NOTE fires on exactly those 3.
- 381/381 gate tests + 318/318 sibling gate-test files green; ruff clean.
- Internal adversarial pass: genesis-architect (1 SHOULD-FIX — vacuous-test trap in the pinning fixture, fixed with lane-marker assertions) then genesis-security-reviewer (1 HIGH — the empty-set fail-open above, fixed; TOCTOU verified closed by `--match-head-commit`).

## Known limitation

A multi-hop rename inside one PR (A→B→C with a finding anchored at B) could classify a current finding off-diff — the files API records only `filename` + `previous_filename`. Inferred, not measured; the finding stays surfaced with its path, and the Codex freshness gate independently requires a current review at head. Single-hop renames are test-locked.

## Deploy path

Hook change — lands at next CC session start on any install via `git pull`; no migration, no config.

E2E: run `--check-pr` against a live open PR carrying base-branch findings (e.g. #1675) and confirm the score counts only in-diff findings with the off-diff NOTE listing the rest.

Ledger: c77cde96635545c198669f56daade48a

Closes #1728


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Review findings are now scored only when they apply to files changed in the pull request.
  - Findings on unchanged files remain visible as notes without affecting the review score.
  - Findings without a file path continue to be scored.
  - If changed-file information is unavailable, scoring preserves previous behavior and displays an explicit warning.
  - Documentation-related diagnostics are now labeled more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->