### PR TITLE
docs(dev-skill): correct what the rm guards do when the parse degrades

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -883,7 +883,6 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   knowing the rule, it is believing you already applied it.
 
   A corpus run only ever yields `did not, here`, and by the rule above it is
-  corpus run only ever yields `did not, here`, and by the rule above it is
   structurally blind to the shape nobody typed. Run the corpus as
   corroboration, never as the proof, and pair it with a control that DOES flip
   — an unflipped corpus and an inert measurement look identical.
@@ -919,14 +918,33 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   This does NOT loosen the fail-closed mandate above, and the two are easy to
   read as contradicting each other. Rule (b) is scoped to the git-operation
   blind-spot net — a guard whose trigger is deliberately broad and whose false
-  positive is one confirmation. It is NOT a template for every guard: the
-  protected-paths and destructive-command guards hard-block an unreliable parse
-  even when a person is present, by design, because their false negative is an
-  irreplaceable path or a broad recursive removal and their false positive is a
-  rewrite. Within the net, the two rules are scoped by who is present: `ask` is
-  the interactive form of the refusal, and where a session is unattended
-  fail-closed governs and (c) applies. The operation proceeds unverified in
-  neither case.
+  positive is one confirmation. It is NOT a template for every guard: where the
+  false negative is an irreplaceable path or a broad recursive removal and the
+  false positive is a rewrite, that asymmetry justifies refusing outright rather
+  than asking. Neither the protected-paths nor the destructive-command guard has
+  an `ask` branch at all — both return only 0 or 2 — so a person's presence
+  genuinely cannot change their verdict.
+
+  One clause of that used to read "hard-block an unreliable parse", and it is
+  FALSE. MEASURED 2026-09-06 through both live hook entries, controls flipping:
+  each guard refuses on the PARSED path and then falls back to a DIFFERENT
+  matcher, neither a subset nor a superset of it — it misses spellings the
+  parser catches, AND it drops the target tests the parser applies, so it also
+  refuses commands the parser allows. **A guard's fail direction is a property
+  of its DEGRADED path, and that path has to be read in BOTH directions.** The
+  two differ in what their fallback is for: `destructive_command_guard`'s is
+  fail-open by design and says so in its own docstring, so argue with the design
+  rather than patching it; `protected_paths_guard`'s calls itself "conservative:
+  over-blocks, never under", which is true relative to the old guard it
+  reinstates (`protected_paths_guard.py:33-35`) and false of the parsed resolver
+  it stands in for — one sentence, two readings, and that ambiguity is the
+  defect. Verify a docstring's stated direction IN CONTEXT; never quote it as a
+  fact. The shapes are deliberately not enumerated here, per the rule above.
+
+  Within the git-operation blind-spot net, the two rules are scoped by who is
+  present: `ask` is the interactive form of the refusal, and where a session is
+  unattended fail-closed governs and (c) applies. The operation proceeds
+  unverified in neither case.
 
   This is the shipped shape now, not an aspiration, and one distinction inside
   it must stay visible. The shared parser still degrades to a naive split with


### PR DESCRIPTION
## The false claim

The genesis-development skill told every session this:

> the protected-paths and destructive-command guards **hard-block an unreliable parse
> even when a person is present, by design**

Measured through both live hook entries, with parseable controls refused in every case:
the **"hard-block" half is false for both guards**. Each refuses on the parsed path and
then falls back to a *different* matcher — and that matcher is neither a subset nor a
superset of the parser it stands in for.

Both directions were measured, because the first two attempts at this correction each
asserted one direction as a universal and were wrong:

* the fallback **misses** shapes the parser catches, so it allows where the parsed path
  refuses;
* the fallback also **drops the target tests** the parser applies, so it refuses
  commands the parsed path allows — a specific non-glob file inside a protected dir,
  and a path deeper than the depth floor both block on the degraded path and pass on
  the parsed one.

The **"even when a person is present" half was CORRECT** and is now stated rather than
deleted: neither guard has an `ask` branch at all (both return only `0` or `2`, and
`run_guard` exits `2` or the returned code), so presence cannot change their verdict.
The previous text was right about that for a reason worth keeping.

## What else the correction restores

The paragraph's cost-asymmetry rationale — false negative is an irreplaceable path or a
broad recursive removal, false positive is a rewrite — is **restored**. An earlier draft
deleted it along with the false clause, leaving "NOT a template for every guard" asserted
with no support at all.

The two guards differ in what their fallback *is*, which is the part worth carrying:

* `destructive_command_guard`'s is **fail-open by design** and says so in its own
  docstring. A decision to argue with, never an oversight to patch.
* `protected_paths_guard`'s calls itself *"conservative: over-blocks, never under"* —
  true relative to the old guard it reinstates (module docstring), false of the parsed
  resolver it stands in for. One sentence, two readings, and **that ambiguity is the
  defect**; a future caller may lean on the absolute one.

No shapes are enumerated. The file states 17 lines above that a guard's defeat
conditions are not a teaching aid and that it ships publicly — an earlier draft of this
change violated that rule and was rewritten.

## Supporting measurement (deliberately NOT in the skill file)

These figures are install-local, perishable and corpus-limited, so they belong here
rather than in a file loaded into every session.

Over one install's transcripts, **113,278 unique commands**:

| | |
|---|---|
| untokenizable (parser raised) | 1,648 (1.455%) |
| caught by the legacy fallback | 17 |
| reached the fail-open path | 1,631 |
| **carried a command-position recursive-force removal** | **0** |

Separately for the protected-paths fallback: 53 candidates were both removal-mentioning
and untokenizable, 4 blocked by the current aliases, **0** newly blocked by a widened
alias set.

**Both zeros are corpus-limited and are NOT evidence of safety** — a corpus only ever
contains shapes someone has already typed. They are the absence of a measured reason to
change either fail direction, which is why this PR changes documentation and no code.

The matcher behind the first zero passed a 12-case acceptance bar before the run. An
earlier unvalidated matcher reported **29** hits on the same corpus that were all regex
artifacts — it read `--repo` as a recursive flag and `--body-file` as a force flag. The
acceptance bar is the only reason that number is a 0 and not a 29.

## Review

Two adversarial passes, **both internal** (same-model) — no cross-model round consumed.

* **Round 1** blocked it for publishing working defeat conditions in a public file, 17
  lines under the rule forbidding exactly that. Also caught a false PR citation, an
  enumeration presented as closed when it was a sample, and a docstring declared FALSE
  by reading a parenthetical absolutely while ignoring the module docstring that fixes
  its referent.
* **Round 2** blocked the round-1 *fix* for asserting the mirror-image falsehood
  ("strictly narrower"), refuted by measurement with controls flipping in the same run.

On the third attempt the passage was **cut from +41 to +25** rather than patched again,
per the skill's own "three fix attempts means question the architecture" rule. The
corpus figures, the per-guard bullet list, and the self-referential meta-commentary all
came out; the transferable sentence stayed.

One reviewer escalation was **checked and rejected**: it called a particular spelling "a
security defect named in neither the diff nor any open PR". The merged PR that shipped
the current behaviour names it explicitly in its own body. Not a new defect, and not
escalated as one.

## Also in this diff

* Removes a pre-existing duplicated line in the corpus-discipline paragraph this passage
  depends on.
* Names "the git-operation blind-spot net" inline, where the inserted text had stranded
  the pronoun 41 lines from its antecedent.

## Verification

* `ruff` / `subsystem-map` / `external-io` / `frozen-clock` checkers: **PASS**
* `test_export_agents_md.py`, `test_skill_injection.py`,
  `test_git_push_guard_hook_surface.py`: **98 passed**
* Privacy scan of the branch diff: clean
* Mechanical re-check that no defeat condition survives in the added lines: clean

## Known and deliberately not fixed here

`protected_paths_guard`'s docstring is still ambiguous *in the code*. Fixing it there is
a hook-surface change on a function three open PRs are already modifying, for zero
measured behaviour change — better folded into whichever of those lands last than opened
as a fourth PR against the same function.

Ledger: 89dba4272bd346bead2543d6fd5d0533
