### PR TITLE
feat(memory): capture the domain a preference is scoped to

### DIFF
--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -260,6 +260,19 @@ at gate time (`security/immunity.py`). Migration 0053 backfilled history
 (no owner heuristics); `scripts/backfill_origin_class_qdrant.py` mirrors the
 payloads idempotently.
 
+**Judgment axes (DARK — written, no reader):** `memory_metadata` carries six
+write-only classification columns stamped at extraction time and consumed by
+nothing yet — `speech_act` + `speech_act_confidence`
+(# GROUNDWORK(mw-5-speech-act-protection)), `assertion_provenance`
+(# GROUNDWORK(mw-4-provenance-weight)), `durability` + `expires_at`
+(# GROUNDWORK(mw-4-durability-ttl)), and `preference_domain`
+(# GROUNDWORK(mw-4-preference-domain) — the domain a preference is scoped to,
+so a later conflicting preference coexists as a different-context truth
+instead of overwriting). Contract + normalizers in `memory/judgment.py`;
+distinct from `origin_class` above, which is a pipeline-trust label. Expiry is
+opt-in (`durability='temporary'` + an elapsed `expires_at` only), so an
+unclassified row never expires.
+
 ## 2. Execution — CC sessions (DirectSession)
 
 Spawning, tracking, and recovering Claude Code sessions — Genesis's hands for

--- a/src/genesis/db/crud/memory.py
+++ b/src/genesis/db/crud/memory.py
@@ -353,6 +353,7 @@ async def create_metadata(
     assertion_provenance: str | None = None,
     durability: str | None = None,
     expires_at: str | None = None,
+    preference_domain: str | None = None,
 ) -> str:
     """Insert a row into memory_metadata. Returns memory_id.
 
@@ -367,11 +368,13 @@ async def create_metadata(
     ``MemoryStore.store()``; NULL = legacy/unclassified (gates treat it
     fail-closed at gate time).
     ``speech_act`` / ``speech_act_confidence`` / ``assertion_provenance`` /
-    ``durability`` / ``expires_at`` are the MW-1 Tier-0 extraction judgment
+    ``durability`` / ``expires_at`` / ``preference_domain`` are the MW-1 Tier-0
+    (+ the MW-4 ``preference_domain`` satellite) extraction judgment
     axes — WRITE-ONLY (no reader yet). NULL = unclassified; expiry is opt-in
     (``durability='temporary'`` + an elapsed canonicalized ``expires_at``
     only). Contract in ``memory/judgment.py``.
-    # GROUNDWORK(mw-4-provenance-weight / mw-4-durability-ttl / mw-5-speech-act-protection)
+    # GROUNDWORK(mw-4-provenance-weight / mw-4-durability-ttl / mw-4-preference-domain
+    # / mw-5-speech-act-protection)
     """
     # Bitemporal columns are raw TEXT-compared everywhere — canonicalize
     # at the write gate. Unparseable valid_at (LLM temporal strings like
@@ -384,8 +387,8 @@ async def create_metadata(
         "(memory_id, created_at, collection, confidence, embedding_status, "
         "memory_class, wing, room, valid_at, invalid_at, source_subsystem, "
         "origin_class, speech_act, speech_act_confidence, assertion_provenance, "
-        "durability, expires_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "durability, expires_at, preference_domain) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             memory_id,
             created_at,
@@ -404,6 +407,7 @@ async def create_metadata(
             assertion_provenance,
             durability,
             canonical_iso(expires_at),
+            preference_domain,
         ),
     )
     await db.commit()

--- a/src/genesis/db/migrations/20260906042425_preference_domain.py
+++ b/src/genesis/db/migrations/20260906042425_preference_domain.py
@@ -1,0 +1,48 @@
+"""Add ``preference_domain`` to ``memory_metadata`` (MW-4 satellite).
+
+A preference is not a scalar fact: "favorite color" legitimately differs by
+domain (work vs vehicles vs this-month). MW-1 already classifies
+``speech_act='preference'`` at extraction; this column captures the DOMAIN
+qualifier the extractor now emits alongside it, so a detected conflict can
+dissolve into two coexisting domain-scoped statements instead of newest-wins.
+Open vocabulary by design (domains are an open set — "work", "vehicles",
+"food"); normalized lowercase at the write path (memory/judgment.py).
+
+WRITE-ONLY like the other judgment axes: nothing reads it yet; the consumer is
+MW-4 recall ranking (follow-up b51542de). # GROUNDWORK(mw-4-preference-domain)
+
+NULLable, no default, no backfill — NULL means "captured before this column
+existed or not a preference", never a judgment.
+
+Self-contained + idempotent: the ADD is PRAGMA-guarded (applies via the base
+path OR the numbered runner; whichever ran first, the guard skips). No commit —
+the runner owns the transaction. Mirrored in ``_migrate_add_columns``
+(schema_both_build_paths).
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+
+
+async def _add_column(db: aiosqlite.Connection, table: str, col: str, decl: str) -> None:
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    )
+    if await cursor.fetchone() is None:
+        return  # fresh install: create_all_tables builds the full canonical shape
+    cursor = await db.execute(f"PRAGMA table_info({table})")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if col not in cols:
+        await db.execute(f"ALTER TABLE {table} ADD COLUMN {col} {decl}")
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    await _add_column(db, "memory_metadata", "preference_domain", "TEXT")
+
+
+async def down(db: aiosqlite.Connection) -> None:
+    """No-op: a NULLable write-only column is harmless to leave in place.
+
+    (0081 does DROP its columns; the difference is a choice, not a fleet
+    constraint — dropping buys nothing for a column nothing reads.)"""

--- a/src/genesis/db/schema/_migrations.py
+++ b/src/genesis/db/schema/_migrations.py
@@ -1512,6 +1512,9 @@ async def _migrate_add_columns(db: aiosqlite.Connection) -> None:
     await _try_alter(db,
         "ALTER TABLE memory_metadata ADD COLUMN expires_at TEXT",
         "memory_metadata.expires_at")
+    await _try_alter(db,
+        "ALTER TABLE memory_metadata ADD COLUMN preference_domain TEXT",
+        "memory_metadata.preference_domain")
 
     # Bi-temporal columns for temporal fact tracking (0010_bitemporal_memory)
     await _try_alter(db,

--- a/src/genesis/db/schema/_tables.py
+++ b/src/genesis/db/schema/_tables.py
@@ -1255,12 +1255,15 @@ TABLES = {
             -- All NULLable with NO default: expiry is strictly opt-in
             -- (durability='temporary' + an elapsed expires_at only), so an
             -- unclassified row NEVER expires. Contract in memory/judgment.py;
-            -- added to existing DBs by migration 0079.
+            -- added to existing DBs by migration 0081 (renumbered from 0079);
+            -- preference_domain by 20260906042425 (# GROUNDWORK(mw-4-preference-domain):
+            -- domain a preference is scoped to, open vocab, write-only).
             speech_act            TEXT,
             speech_act_confidence REAL,
             assertion_provenance  TEXT,
             durability            TEXT,
-            expires_at            TEXT
+            expires_at            TEXT,
+            preference_domain     TEXT
         )
     """,
     "graduation_events": """

--- a/src/genesis/memory/extraction.py
+++ b/src/genesis/memory/extraction.py
@@ -61,6 +61,11 @@ For each extraction, provide:
   being relevant — a wrong "temporary" causes the memory to be forgotten.
 - expires_at: for "temporary" only — ISO date/time it stops being relevant, if
   known (otherwise omit)
+- preference_domain: for speech_act="preference" only — the DOMAIN the
+  preference is scoped to, 1-3 lowercase words ("work", "vehicles", "food",
+  "code style"). A preference is rarely universal: capturing its domain lets a
+  later conflicting preference coexist as a different-context truth instead of
+  overwriting this one. Omit if the preference is genuinely general.
 
 For each extraction that has a temporal reference AND describes a concrete
 action (something that happened, was decided, or will happen), additionally
@@ -153,6 +158,18 @@ Respond with a JSON object inside backticks containing:
       "relationships": [],
       "temporal": "2026-05-12",
       "event": {"subject": "user", "verb": "applied", "object": "Solutions Engineer at Salesforce"}
+    },
+    {
+      "content": "User prefers muted colors for work materials, not for personal projects",
+      "type": "preference",
+      "confidence": 0.85,
+      "entities": [],
+      "relationships": [],
+      "speech_act": "preference",
+      "speech_act_confidence": 0.9,
+      "provenance": "user",
+      "durability": "permanent",
+      "preference_domain": "work"
     }
   ],
   "session_keywords": ["agentmail", "email", "outreach", "evaluation"],
@@ -202,6 +219,9 @@ class Extraction:
     assertion_provenance: str | None = None
     durability: str = "permanent"
     expires_at: str | None = None
+    # Domain a preference is scoped to (speech_act="preference" only; open
+    # vocab, normalized lowercase). # GROUNDWORK(mw-4-preference-domain)
+    preference_domain: str | None = None
 
 
 @dataclass
@@ -364,6 +384,9 @@ def parse_extraction_response_full(text: str) -> ParsedResponse:
         expires_at = item.get("expires_at")
         if expires_at is not None:
             expires_at = str(expires_at).strip() or None
+        preference_domain = judgment.normalize_preference_domain(
+            item.get("preference_domain"), speech_act=speech_act
+        )
 
         extractions.append(Extraction(
             content=content,
@@ -381,6 +404,7 @@ def parse_extraction_response_full(text: str) -> ParsedResponse:
             assertion_provenance=assertion_provenance,
             durability=durability,
             expires_at=expires_at,
+            preference_domain=preference_domain,
         ))
 
     return ParsedResponse(
@@ -427,4 +451,5 @@ def extractions_to_store_kwargs(
         "assertion_provenance": extraction.assertion_provenance,
         "durability": extraction.durability,
         "expires_at": extraction.expires_at,
+        "preference_domain": extraction.preference_domain,
     }

--- a/src/genesis/memory/judgment.py
+++ b/src/genesis/memory/judgment.py
@@ -76,6 +76,31 @@ def normalize_provenance(value: object) -> str | None:
     return None
 
 
+def normalize_preference_domain(value: object, *, speech_act: str) -> str | None:
+    """Coerce an LLM ``preference_domain`` qualifier; None unless it qualifies a preference.
+
+    Open vocabulary BY DESIGN — domains are an open set ("work", "vehicles",
+    "food"), so this normalizes shape (strip, lowercase, collapse inner
+    whitespace) rather than validating membership. Dropped entirely when the
+    ``speech_act`` is not ``preference``: the domain qualifies a preference,
+    and a stray domain on a claim is noise that would dilute the column.
+    Consumer: MW-4 ranking — a conflict between two preferences that carry
+    different domains dissolves into two coexisting scoped statements instead
+    of newest-wins. # GROUNDWORK(mw-4-preference-domain)
+
+    ACCEPTED: ``speech_act`` here is the NORMALIZED value, and
+    ``normalize_speech_act`` is exact-match — so an LLM emitting "Preference"
+    lands as "observation" and loses the domain with it. Case-folding there
+    would also promote "Rule"/"Decision" into PROTECTED_SPEECH_ACTS, changing
+    protection eligibility; that is an MW-1/MW-5 decision, not this
+    satellite's. Locked by test_capitalized_speech_act_normalizes_away.
+    """
+    if speech_act != "preference" or not isinstance(value, str):
+        return None
+    domain = " ".join(value.split()).lower()
+    return domain or None
+
+
 def clamp_unit(value: object, default: float = 0.5) -> float:
     """Coerce a confidence to [0.0, 1.0]; non-numeric → ``default``."""
     if isinstance(value, bool) or not isinstance(value, (int, float)):

--- a/src/genesis/memory/store.py
+++ b/src/genesis/memory/store.py
@@ -133,6 +133,7 @@ class MemoryStore:
         assertion_provenance: str | None = None,
         durability: str | None = None,
         expires_at: str | None = None,
+        preference_domain: str | None = None,
     ) -> str:
         """Full store pipeline: embed -> Qdrant -> FTS5 -> auto-link. Returns memory_id.
 
@@ -418,12 +419,14 @@ class MemoryStore:
             # join (as origin_class's FTS fallback is), and a consumer that
             # needs vector-path parity owns adding it to the payload + the
             # re-embed recovery path together.
-            # GROUNDWORK(mw-4-provenance-weight / mw-4-durability-ttl / mw-5-speech-act-protection)
+            # GROUNDWORK(mw-4-provenance-weight / mw-4-durability-ttl
+            # / mw-4-preference-domain / mw-5-speech-act-protection)
             speech_act=speech_act,
             speech_act_confidence=speech_act_confidence,
             assertion_provenance=assertion_provenance,
             durability=durability,
             expires_at=expires_at,
+            preference_domain=preference_domain,
         )
 
         # Mechanical code anchors (entity layer) — regex-only, every write

--- a/tests/test_db/test_memory_metadata_base_path_upgrade.py
+++ b/tests/test_db/test_memory_metadata_base_path_upgrade.py
@@ -38,6 +38,10 @@ _JUDGMENT_COLS = {
     "assertion_provenance",
     "durability",
     "expires_at",
+    # MW-4 satellite: same class, same trap — create_all_tables runs
+    # _migrate_add_columns and NOT the numbered runner, so the base-path
+    # mirror is the ONLY thing adding this column on an existing DB.
+    "preference_domain",
 }
 
 

--- a/tests/test_db/test_migration_preference_domain.py
+++ b/tests/test_db/test_migration_preference_domain.py
@@ -1,0 +1,131 @@
+"""preference_domain — migration + persistence (MW-4 satellite).
+
+Mirrors the 0081 judgment-column tests: the column exists on BOTH schema build
+paths (numbered migration for legacy DBs, canonical CREATE for fresh ones), the
+migration is idempotent, and ``create_metadata`` persists the value.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import aiosqlite
+
+from genesis.db.crud import memory
+from genesis.db.schema import TABLES
+
+_mig = importlib.import_module("genesis.db.migrations.20260906042425_preference_domain")
+
+_COL = "preference_domain"
+
+# memory_metadata as it stands BEFORE this column (i.e. post-0081).
+_PRE_DDL = """
+    CREATE TABLE memory_metadata (
+        memory_id             TEXT PRIMARY KEY,
+        created_at            TEXT NOT NULL,
+        collection            TEXT NOT NULL DEFAULT 'episodic_memory',
+        confidence            REAL,
+        embedding_status      TEXT NOT NULL DEFAULT 'embedded',
+        memory_class          TEXT DEFAULT 'fact',
+        valid_at              TEXT,
+        invalid_at            TEXT,
+        origin_class          TEXT,
+        speech_act            TEXT,
+        speech_act_confidence REAL,
+        assertion_provenance  TEXT,
+        durability            TEXT,
+        expires_at            TEXT
+    )
+"""
+
+
+async def _columns(conn: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await conn.execute(f"PRAGMA table_info({table})")
+    return {row[1] for row in await cur.fetchall()}
+
+
+async def test_migration_adds_the_column_to_an_existing_db():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(_PRE_DDL)
+        await conn.commit()
+        assert _COL not in await _columns(conn, "memory_metadata")
+
+        await _mig.up(conn)
+        await conn.commit()
+
+        assert _COL in await _columns(conn, "memory_metadata")
+    finally:
+        await conn.close()
+
+
+async def test_migration_is_idempotent():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(_PRE_DDL)
+        await conn.commit()
+        await _mig.up(conn)
+        await _mig.up(conn)  # second run must not raise
+        await conn.commit()
+        assert _COL in await _columns(conn, "memory_metadata")
+    finally:
+        await conn.close()
+
+
+async def test_migration_skips_a_db_without_the_table():
+    """Fresh install: create_all_tables builds the canonical shape; the
+    migration must no-op rather than raise on the missing table."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await _mig.up(conn)  # no memory_metadata at all
+        await conn.commit()
+    finally:
+        await conn.close()
+
+
+async def test_fresh_db_create_carries_the_column():
+    """schema_both_build_paths: the canonical CREATE must carry it too, or a
+    fresh install's first create_metadata INSERT hits 'no such column'."""
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["memory_metadata"])
+        await conn.commit()
+        assert _COL in await _columns(conn, "memory_metadata")
+    finally:
+        await conn.close()
+
+
+async def test_create_metadata_persists_the_domain():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["memory_metadata"])
+        await conn.commit()
+        await memory.create_metadata(
+            conn,
+            memory_id="m-pref",
+            created_at="2026-09-06T00:00:00+00:00",
+            speech_act="preference",
+            preference_domain="work",
+        )
+        cur = await conn.execute(
+            "SELECT preference_domain FROM memory_metadata WHERE memory_id = ?", ("m-pref",)
+        )
+        assert (await cur.fetchone())[0] == "work"
+    finally:
+        await conn.close()
+
+
+async def test_create_metadata_defaults_null():
+    conn = await aiosqlite.connect(":memory:")
+    try:
+        await conn.execute(TABLES["memory_metadata"])
+        await conn.commit()
+        await memory.create_metadata(
+            conn, memory_id="m-plain", created_at="2026-09-06T00:00:00+00:00"
+        )
+        cur = await conn.execute(
+            "SELECT preference_domain FROM memory_metadata WHERE memory_id = ?", ("m-plain",)
+        )
+        assert (await cur.fetchone())[0] is None
+    finally:
+        await conn.close()

--- a/tests/test_memory/test_extraction_judgment.py
+++ b/tests/test_memory/test_extraction_judgment.py
@@ -155,3 +155,97 @@ class TestKwargsThreading:
         assert kwargs["assertion_provenance"] == "user"
         assert kwargs["durability"] == "permanent"
         assert kwargs["expires_at"] is None
+
+
+class TestPreferenceDomain:
+    """MW-4 satellite (2026-09-06, from the Clarity exchange): a preference is
+    not a scalar fact — 'favorite color' differs by domain (work vs this-month
+    vs vehicles). Capturing the domain at extraction time lets a detected
+    conflict dissolve into two coexisting domain-scoped statements instead of
+    newest-wins. Write-only until MW-4 ranking consumes it."""
+
+    def test_normalize_lowercases_and_strips(self):
+        assert (
+            judgment.normalize_preference_domain("  Work  ", speech_act="preference")
+            == "work"
+        )
+
+    def test_normalize_collapses_inner_whitespace(self):
+        assert (
+            judgment.normalize_preference_domain("home  audio", speech_act="preference")
+            == "home audio"
+        )
+
+    @pytest.mark.parametrize("value", ["", "   ", None, 7, ["work"]])
+    def test_normalize_garbage_is_none(self, value):
+        assert judgment.normalize_preference_domain(value, speech_act="preference") is None
+
+    def test_normalize_dropped_for_non_preference_acts(self):
+        # The domain qualifies a PREFERENCE; a stray domain on a claim is noise,
+        # not signal — dropped at the write path so the column stays meaningful.
+        assert judgment.normalize_preference_domain("work", speech_act="claim") is None
+
+    def test_parse_carries_domain_on_preference(self):
+        item = {
+            "content": "I prefer red for work materials",
+            "type": "preference",
+            "confidence": 0.85,
+            "speech_act": "preference",
+            "preference_domain": "Work",
+        }
+        ext = parse_extraction_response(_wrap(item))[0]
+        assert ext.preference_domain == "work"
+
+    def test_parse_absent_is_none(self):
+        item = {
+            "content": "I prefer tea",
+            "type": "preference",
+            "confidence": 0.8,
+            "speech_act": "preference",
+        }
+        assert parse_extraction_response(_wrap(item))[0].preference_domain is None
+
+    def test_parse_drops_domain_on_non_preference(self):
+        item = {
+            "content": "The deploy failed twice",
+            "type": "entity",
+            "confidence": 0.8,
+            "speech_act": "observation",
+            "preference_domain": "work",
+        }
+        assert parse_extraction_response(_wrap(item))[0].preference_domain is None
+
+    def test_kwargs_include_preference_domain(self):
+        ext = Extraction(
+            content="I prefer red for work materials",
+            extraction_type="preference",
+            confidence=0.85,
+            speech_act="preference",
+            preference_domain="work",
+        )
+        assert extractions_to_store_kwargs(ext)["preference_domain"] == "work"
+
+    def test_prompt_carries_the_instruction_not_just_the_example(self):
+        """Asserting the bare token passes on the JSON example alone — deleting
+        the whole instruction bullet would leave it green. Anchor on the bullet."""
+        from genesis.memory.extraction import EXTRACTION_PROMPT
+
+        assert 'for speech_act="preference" only' in EXTRACTION_PROMPT
+        assert '"preference_domain": "work"' in EXTRACTION_PROMPT  # positive example
+
+    def test_capitalized_speech_act_normalizes_away_and_drops_the_domain(self):
+        """ACCEPTED BEHAVIOR, locked deliberately: normalize_speech_act is an
+        EXACT-match membership test (MW-1), so "Preference" becomes
+        "observation" and the domain is dropped with it. Not widened here on
+        purpose — case-folding would also promote "Rule"/"Decision" into
+        PROTECTED_SPEECH_ACTS, a protection-eligibility change that belongs to
+        MW-1/MW-5, not to this satellite."""
+        assert judgment.normalize_speech_act("Preference") == "observation"
+        item = {
+            "content": "I prefer red for work",
+            "type": "preference",
+            "confidence": 0.8,
+            "speech_act": "Preference",
+            "preference_domain": "work",
+        }
+        assert parse_extraction_response(_wrap(item))[0].preference_domain is None

--- a/tests/test_memory/test_store.py
+++ b/tests/test_memory/test_store.py
@@ -317,3 +317,27 @@ async def test_store_falls_back_on_unexpected_error(store):
     assert isinstance(result, str)
     mock_mem.upsert.assert_awaited_once()
     mock_pending.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio()
+async def test_store_threads_preference_domain_to_metadata(store):
+    """The MW-4 domain qualifier reaches memory_metadata.
+
+    This single line in store() is the whole runtime path for the column: with
+    it deleted, preference_domain is NULL for every row ever written and the
+    consumer finds an empty corpus — while every other test stays green
+    (mutation-verified: 0/89 caught it before this test existed).
+    """
+    with patch("genesis.memory.store.upsert_point"), \
+         patch("genesis.memory.store.memory_crud") as mock_mem:
+        mock_mem.upsert = AsyncMock(return_value="id")
+        mock_mem.create_metadata = AsyncMock(return_value=None)
+        mock_mem.find_exact_duplicate = AsyncMock(return_value=None)
+        await store.store(
+            "prefers muted colors for work materials",
+            "src",
+            speech_act="preference",
+            preference_domain="work",
+        )
+
+    assert mock_mem.create_metadata.call_args.kwargs["preference_domain"] == "work"


### PR DESCRIPTION
## What

Extraction now captures **which domain a preference is scoped to**.

A preference is not a scalar fact. "Favorite color" can be red for work materials
and blue this month because of a new car — both true, about different contexts.
Extraction already classified `speech_act="preference"`, but captured nothing about
*what the preference is about*, so two conflicting preferences could only resolve as
newest-wins, silently discarding the older context.

## The chain

`normalize_preference_domain` (open vocabulary — shapes rather than validates, since
domains are an open set; returns `None` unless the **normalized** speech act really is
`preference`) → prompt bullet + a positive JSON example → `Extraction` field →
tolerant parse → `extractions_to_store_kwargs` → `MemoryStore.store()` →
`create_metadata` → `memory_metadata.preference_domain`, present on **both** schema
build paths (timestamp migration `20260906042425` + the `_migrate_add_columns` mirror
+ the canonical CREATE).

**Write-only**, exactly like its five MW-1 siblings — nothing reads it yet. The
consumer is MW-4 recall ranking, where a conflict between two domain-scoped
preferences resolves into coexisting truths instead of an overwrite.
`# GROUNDWORK(mw-4-preference-domain)`.

## Verification

- 13 tests written RED first; final ring **93 green** (judgment, migration, store,
  base-path upgrade, extraction).
- **Mutation-verified where it counts.** The adversarial review measured that the two
  most load-bearing lines — the `create_all_tables` mirror and the `store()` threading
  line — could each be deleted with **0/89** test failures (the second would leave the
  column always-NULL in production with no signal). Both now have guards, and both
  mutations were re-run after the fix: they fail 2 and 1 tests respectively.
- Also caught by review and fixed: the only few-shot example of the new field was a
  *negative* one (`null` on a non-preference item), contradicting the instruction and
  never showing the intended shape.
- ruff, migration-id (`--base origin/main`), subsystem-map, frozen-clock and
  external-io guards all clean; privacy grep clean.

## Deliberately not done

- **`normalize_speech_act` not widened to case-insensitive.** An LLM emitting
  `"Preference"` normalizes to `"observation"` and the domain drops with it. Case-folding
  would also promote `"Rule"`/`"Decision"` into `PROTECTED_SPEECH_ACTS` — a
  protection-eligibility change owned by MW-1/MW-5, not by this satellite. The behavior
  is documented at the decision point and locked by a test so the next reader sees a
  decision rather than an oversight.
- **No CHANGELOG entry**, consistent with the five sibling columns: write-only, no
  user-visible effect. The dark-column class is now documented in the architecture map
  instead, which had six such columns and no entry despite its own dark-code convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for capturing and storing an optional preference domain with memory metadata.
  * Preference domains are normalized for consistent formatting and retained only for valid preference judgments.
  * Existing databases are upgraded automatically to support the new metadata.

* **Tests**
  * Added coverage for persistence, migrations, normalization, extraction, and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->