### PR TITLE
feat(hooks): require an explicit post-merge E2E decision in every PR body

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,5 +21,19 @@ Closes #
 
 - [ ] `ruff check .` passes
 - [ ] `pytest -v` passes
-- [ ] Tested end-to-end (describe how)
 - [ ] `docs/architecture/CURRENT.md` updated (entry prose + `verified:` stamp) if subsystem capabilities changed
+
+<!-- REQUIRED, and the merge gate enforces it: declare the POST-MERGE end-to-end
+     verification this change needs. Replace the line below with one of:
+
+       E2E: <one-line plan for the post-merge verification>
+       E2E: none — <reason there is no runtime surface to verify>
+
+     `none` is a legitimate answer for a docs/prose PR — what is not legitimate is
+     leaving the decision unmade. Note it passes the gate but does NOT release the
+     validator, which assumes every merged PR has an E2E and hunts for one anyway;
+     the line is its first lead, not a boundary. (This guidance lives inside a
+     comment on purpose: the gate strips comments before reading, so the template
+     itself can never satisfy the gate.) -->
+
+E2E:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,6 +356,18 @@ reads as noise. You are the first line of defense; ambient
 extraction (session-manager PR-3) is only the safety net. Plan files stay
 the working documents — ledger rows are the durable index, not a duplicate.
 
+**PR-body convention — `E2E:` (required, merge-gated):** every PR body declares
+the POST-MERGE end-to-end verification its change needs, on its own line:
+`E2E: <one-line plan>` or `E2E: none — <reason there is no runtime surface>`.
+The merge gate blocks a PR that declares neither — and a `none` carrying no real
+reason (a bare `none`, a placeholder, or a refusal word like TBD). Merge time
+only, never on push. PRs created before the convention are exempt; if the PR's
+creation date cannot be READ, the gate blocks rather than assuming the
+exemption. `none` is a fine answer for a docs PR; what is refused is leaving the
+decision unmade. It does NOT release
+the validator, which assumes every merged PR has an E2E and hunts for one anyway
+— the line is its first lead, not a boundary.
+
 **PR-body convention:** a PR that completes a ledger item cites
 `Ledger: <item-id>` (the 32-hex row id) on its own line in the PR body —
 the repo-pulse worker auto-absorbs the row with PR evidence at the next

--- a/scripts/e2e_declaration.py
+++ b/scripts/e2e_declaration.py
@@ -1,0 +1,356 @@
+"""The `E2E:` PR-body declaration — one parser, two readers (issue #1699 sibling).
+
+WHY THIS EXISTS. Running the end-to-end verification a merged change needs is an
+obligation that lives AFTER the merge, and it was carried by memory alone. Measured
+2026-09-04: of two owner-directed merges, one had its E2E forgotten until the owner
+asked — 50% on n=2, and BOTH E2Es, once run, found something real. Two failure modes
+sit behind that: (A) nobody decided whether the PR needed an E2E at all, and (B) the
+decision was made and then evaporated at merge time. This module is the shared
+reading of the declaration that closes (A); the repo-pulse worker turns a declaration
+into a durable row to close (B).
+
+THE CONVENTION, in the PR body:
+
+    E2E: <one-line plan for the post-merge verification>
+    E2E: none — <reason there is no runtime surface to verify>
+
+The point is NOT to force an E2E onto a docs PR. It is to make the DECISION explicit
+— the obligation-side twin of "a check that could not run must say so" (#1683).
+
+`none` PASSES THE GATE BUT DOES NOT RELEASE THE VALIDATOR (spec §8.13). A validation
+session assumes every merged PR has an end-to-end test and hunts for it; this line is
+its first LEAD, never a boundary. So `none` is a declaration, not an authority — a
+builder who forgets, or who declares `none` wrongly, is still caught from the merge
+side.
+
+WHY THE PARSING IS THIS PARANOID. Every hardening below was bought by a measured
+defect in `check_cc_pin_receipts.py`, the sibling body-reader, and is inherited
+deliberately rather than re-learned:
+
+  * HTML comments and fenced blocks are stripped BEFORE any marker is sought. This
+    repo's own PULL_REQUEST_TEMPLATE.md is built from `<!-- -->` blocks, so a
+    declaration that is invisible in the rendered PR is the likely accident, not an
+    exotic one — and a fence is how the format gets DOCUMENTED, so text inside one
+    describes a declaration rather than making one.
+  * The stripping is a LINE SCANNER, never a regex pair. A non-greedy `<!--.*?-->`
+    costs ~14s of CPU on a 65_536-byte body (GitHub's cap) — tolerable in an advisory
+    CI job, fatal on the merge gate, which runs under a wall clock and skips its
+    remaining checks when killed. And both regexes need a CLOSER, so an unterminated
+    opener inverts the rule.
+  * Horizontal whitespace only (`[^\\S\\n]`) around the colon. Plain `\\s*` crosses
+    newlines, which let an EMPTY marker borrow the NEXT line's text as its value.
+  * Markdown wrappers are tolerated (`-`, `*`, `>`, `- [x]`, `**E2E**`, `` `E2E` ``).
+    Blocking a compliant PR at merge time is how an operator learns to route around
+    a gate.
+  * EVERY occurrence is considered, not the first: a leftover template line above a
+    filled one must not veto the filled one.
+  * Placeholders are derived from the shipped examples, never hand-listed.
+
+THE SHARPEST POINT, stated so the next reader does not "simplify" it away: the
+`none — <reason>` form is a TRAILING QUALIFICATION, the exact shape
+`repo_pulse.FOLLOWUP_MARKER_RE` is deliberately anchored at BOTH ends to reject.
+That rejection is right for a 32-hex id, where any trailing text means the line was
+prose about an id rather than a claim on it. Here the trailing text IS the payload,
+so both-end anchoring cannot be copied. What replaces it is line-START anchoring plus
+a substance check on the reason: prose like "the E2E: I ran it by hand" does not
+begin a line at the marker, and `E2E: none` with no reason is INVALID (blocks) rather
+than a silent pass.
+
+Pure functions, stdlib only, no I/O — so the merge gate and the repo-pulse worker can
+both load it without dragging in the other's dependencies.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+#: PRs created BEFORE this instant are exempt. The convention cannot bind a body
+#: written before it existed, and retro-blocking the open queue would make an
+#: unrelated backlog the price of landing this. Compared against the PR's
+#: ``createdAt`` (GitHub ISO-8601, UTC). Set to the day after this lands so nothing
+#: in flight is caught mid-review.
+E2E_CUTOFF_ISO = "2026-09-08T00:00:00Z"
+
+#: The marker, and the two shipped example values. The placeholder set is DERIVED
+#: from these, so a pasted-but-unfilled template can never read as a declaration.
+MARKER = "E2E"
+_EXAMPLES = (
+    "<one-line plan for the post-merge verification>",
+    "none — <reason there is no runtime surface to verify>",
+)
+_PLACEHOLDERS = frozenset(tok.lower() for ex in _EXAMPLES for tok in re.findall(r"<[^<>]+>", ex))
+
+#: GitHub's PR-body cap. Bounds the scan regardless of its O(n).
+_MAX_BODY = 65_536
+_COMMENT_OPEN, _COMMENT_CLOSE = "<!--", "-->"
+_FENCE_MARKS = ("```", "~~~")
+
+#: Words that state an omission rather than a decision. `none` is deliberately NOT
+#: here — it is a VALID declaration when it carries a reason, and is classified
+#: before this set is consulted.
+_REFUSAL_WORDS = frozenset({"todo", "tbd", "pending", "n/a", "na", "yes", "no", "?"})
+
+#: A reason/plan must carry real content — but the floor is deliberately LOW, and
+#: the placeholder/refusal checks above it do the real work. MEASURED (architect,
+#: 2026-09-06): at 12 this rejected `none — docs only` (8 alnum) — the exact string
+#: this module's own GUIDANCE prints as the remedy. On a gate with NO override
+#: sigil that is a closed loop: the author is blocked, types the suggested line
+#: verbatim, and is blocked identically, with nothing in the message naming an
+#: undocumented length rule. A false BLOCK here is worse than a false pass, and
+#: `test_every_example_in_the_guidance_passes_the_parser` now makes the class
+#: unrepeatable: any example this module tells an author to write must survive it.
+#: 7 admits "docs only" and "prose-only"; "x", "ok" and "n/a" still fail.
+_MIN_SUBSTANCE = 7
+
+#: Markdown-tolerant, line-START anchored. See the module docstring for why every
+#: piece is here. `re.IGNORECASE` so `e2e:` works; the marker is short, and the
+#: line-start anchor is what keeps it from matching prose.
+#: The marker's PREFIX — everything up to and including the colon. Shared by the
+#: value-bearing pattern and the presence-only probe so the two can never drift
+#: about what counts as a marker (one definition, two questions).
+_MARKER_PREFIX = (
+    rf"^[^\S\n]*(?:[-*+>][^\S\n]*)*(?:\[[ xX]\][^\S\n]*)?"
+    rf"[*_`]{{0,2}}{re.escape(MARKER)}[*_`]{{0,2}}"
+    rf"[^\S\n]*:"
+)
+_MARKER_RE = re.compile(
+    _MARKER_PREFIX + r"[^\S\n]*(\S[^\n]*)$",
+    re.MULTILINE | re.IGNORECASE,
+)
+#: Presence only — matches a marker whether or not it carries a value, so an EMPTY
+#: declaration can be reported as empty rather than as absent.
+_MARKER_PRESENT_RE = re.compile(_MARKER_PREFIX, re.MULTILINE | re.IGNORECASE)
+
+#: A `none` declaration: the word, then ANY separator an author might type, then
+#: the reason. The shipped example uses an em dash, but requiring one misclassified
+#: every other natural phrasing as a PLAN — MEASURED before this shape existed:
+#: `none because docs only`, `none, docs only` and `none: docs only` all read as
+#: plans. At the gate that is invisible (both kinds pass), which is exactly why it
+#: had to be found by mutation rather than by use: the damage lands downstream,
+#: where the repo-pulse worker turns a PLAN into a hot follow-up row and a docs PR
+#: acquires a junk obligation reading "Run the declared E2E: none, docs only".
+#: The reason itself is still REQUIRED — a bare `E2E: none` is the decision left
+#: unmade wearing the grammar of a decision — but that is enforced by the substance
+#: check on the remainder, not by the punctuation.
+#: A separator (or an empty remainder, or an explicit "needed/required") is
+#: REQUIRED. MEASURED (architect, 2026-09-06) with the separator optional: `none of
+#: the existing tests cover the new path; run it by hand after merge` classified as
+#: `none` — a real PLAN swallowed. That is failure mode (B) from the spec arriving
+#: through the parser: at the gate both kinds pass, so nothing shows, and in PR-2b
+#: a `none` creates NO follow-up row — so a PR that declared a real plan silently
+#: acquires no obligation, which is the exact loss this feature exists to prevent.
+_NONE_RE = re.compile(
+    r"^none(?:[^\S\n]+(?:needed|required|necessary|applicable))?"
+    r"[^\S\n]*(?:(?:[—–\-:,;.]|\bbecause\b)[^\S\n]*(.*))?$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+_FORMATTING = "*_`~ \t"
+
+
+def _strip_formatting(value: str) -> str:
+    return value.strip(_FORMATTING)
+
+
+def _load_sibling_readable_body():
+    """``readable_body`` from ``check_cc_pin_receipts.py`` — the SAME scanner the pin
+    gate uses, so the two body-readers can never disagree about what is visible.
+
+    Falls back to the local scanner below if that module cannot be loaded (it carries
+    imports this one deliberately does not need). Degrading the STRIPPING is safe in
+    the direction that matters: the local copy implements the same rules."""
+    try:
+        path = Path(__file__).resolve().parent / "check_cc_pin_receipts.py"
+        spec = importlib.util.spec_from_file_location("_cc_pin_receipts_for_e2e", path)
+        if spec and spec.loader:
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            fn = getattr(mod, "readable_body", None)
+            if callable(fn):
+                return fn
+    except Exception:
+        pass
+    return None
+
+
+def _local_readable_body(body: str) -> str:
+    """Line scanner: drop fenced blocks and HTML comments. Mirrors the sibling's
+    rules (a fenced line is opaque and never interpreted; an unterminated opener
+    hides to the end, as CommonMark does)."""
+    visible: list[str] = []
+    in_comment = False
+    fence: str | None = None
+    for line in body[:_MAX_BODY].splitlines():
+        if fence is not None:
+            if line.strip().startswith(fence):
+                fence = None
+            continue
+        out: list[str] = []
+        rest = line
+        while rest:
+            if in_comment:
+                close = rest.find(_COMMENT_CLOSE)
+                if close == -1:
+                    rest = ""
+                    break
+                in_comment = False
+                rest = rest[close + len(_COMMENT_CLOSE) :]
+                continue
+            open_at = rest.find(_COMMENT_OPEN)
+            if open_at == -1:
+                out.append(rest)
+                break
+            out.append(rest[:open_at])
+            in_comment = True
+            rest = rest[open_at + len(_COMMENT_OPEN) :]
+        kept = "".join(out)
+        stripped = kept.strip()
+        for mark in _FENCE_MARKS:
+            if stripped.startswith(mark):
+                fence = mark
+                break
+        else:
+            visible.append(kept)
+            continue
+    return "\n".join(visible)
+
+
+def readable_body(body: str) -> str:
+    """The part of a PR body a human actually reads."""
+    fn = _load_sibling_readable_body()
+    return fn(body[:_MAX_BODY]) if fn else _local_readable_body(body)
+
+
+def _reason_is_real(value: str) -> bool:
+    cleaned = _strip_formatting(value)
+    normalised = re.sub(r"<\s*([^<>]+?)\s*>", r"<\1>", cleaned.lower())
+    if any(p in normalised for p in _PLACEHOLDERS):
+        return False
+    # A value that is ENTIRELY one angle-bracketed span is a template placeholder
+    # whatever words it contains — an author who reworded or reflowed the shipped
+    # example (`< one-line plan >`) still has not made a decision. Derived
+    # placeholders alone caught only the verbatim string; before the substance
+    # floor was lowered, the reworded form was rejected by LENGTH, which is an
+    # accident rather than a rule. Safe by shape: a real plan or reason is never
+    # wholly wrapped in angle brackets.
+    if re.fullmatch(r"<[^<>]+>", normalised.strip()):
+        return False
+    if normalised.strip(" .-—–") in _REFUSAL_WORDS:
+        return False
+    return sum(ch.isalnum() for ch in cleaned) >= _MIN_SUBSTANCE
+
+
+def parse_e2e(body: str | None) -> dict:
+    """Classify a PR body's E2E declaration.
+
+    Returns ``{"kind", "text", "detail"}`` where kind is:
+      * ``plan``    — a real post-merge verification plan (the text).
+      * ``none``    — an explicit, reasoned "no runtime surface" (the reason).
+      * ``absent``  — no ``E2E:`` line at all.
+      * ``invalid`` — a line exists but says nothing (empty, placeholder, a bare
+        ``none`` with no reason, a refusal word). Treated as absent by the gate,
+        but reported differently so the author is told WHICH mistake they made.
+
+    CRLF is normalised first: GitHub's textarea stores bodies with `\\r\\n`, and a
+    line-anchored `$` would otherwise never match a real line (the defect
+    `repo_pulse._pr_text` was written to fix).
+
+    LAST valid occurrence wins for content, and ANY valid occurrence satisfies
+    presence — so a filled line below a leftover template line is what counts.
+    """
+    if not body:
+        return {"kind": "absent", "text": "", "detail": "empty PR body"}
+
+    text = body[:_MAX_BODY].replace("\r\n", "\n").replace("\r", "\n")
+    visible = readable_body(text)
+
+    values = _MARKER_RE.findall(visible)
+    if not values:
+        # A VALUELESS marker (`E2E:` with nothing after it) does not match the
+        # value-bearing pattern at all, so without this probe the single most
+        # common mistake — the template pasted and the line left unfilled, which
+        # is the state EVERY template-created PR starts in — reported "no E2E:
+        # line in the PR body" to an author looking at a body that visibly
+        # contains one (architect SHOULD-FIX, 2026-09-06). The `invalid` bucket
+        # exists to name WHICH mistake was made; this is the one it most owes.
+        if _MARKER_PRESENT_RE.search(visible):
+            return {
+                "kind": "invalid",
+                "text": "",
+                "detail": "the E2E: line is present but EMPTY — fill it in",
+            }
+        return {"kind": "absent", "text": "", "detail": "no E2E: line in the PR body"}
+
+    best: dict | None = None
+    saw_invalid_detail = ""
+    for raw in values:
+        value = _strip_formatting(raw)
+        none_match = _NONE_RE.match(value)
+        if none_match:
+            # group(1) is None for a bare `none` (the whole separator+reason group
+            # is optional), which is the "decision left unmade" case — coalesce to
+            # "" so the substance check below is the single place that decides.
+            reason = (none_match.group(1) or "").strip()
+            if _reason_is_real(reason):
+                best = {"kind": "none", "text": reason, "detail": ""}
+            else:
+                saw_invalid_detail = (
+                    "`E2E: none` needs a REASON — what makes this PR have no "
+                    "runtime surface to verify (e.g. `none — docs only`)"
+                )
+            continue
+        # No separate bare-`none` branch: _NONE_RE matches `none` with an empty
+        # remainder, so the substance check above is the single place that decides
+        # whether a `none` carries its reason. One decision point, not two that
+        # must agree.
+        if _reason_is_real(value):
+            best = {"kind": "plan", "text": value, "detail": ""}
+        elif not saw_invalid_detail:
+            saw_invalid_detail = (
+                "the E2E: line has no real content (empty, a placeholder, or a "
+                "template value left unfilled)"
+            )
+
+    if best is not None:
+        return best
+    return {"kind": "invalid", "text": "", "detail": saw_invalid_detail}
+
+
+def is_pre_cutoff(created_at: str | None) -> bool:
+    """True when a PR predates the convention and is therefore exempt.
+
+    Fails CLOSED (not exempt) on an unreadable/absent timestamp: the pre-cutoff
+    population is finite and shrinking, so treating a parse failure as "old" would
+    build a permanent hole out of a temporary transition.
+    """
+    if not created_at:
+        return False
+    try:
+        stamp = created_at.strip().replace("Z", "+00:00")
+        cutoff = E2E_CUTOFF_ISO.replace("Z", "+00:00")
+        from datetime import datetime
+
+        return datetime.fromisoformat(stamp) < datetime.fromisoformat(cutoff)
+    except (ValueError, TypeError):
+        return False
+
+
+#: What the gate prints when a body has no usable declaration. Names BOTH valid
+#: forms and the §8.13 seam, so an author reading the block knows that `none` is a
+#: real option AND that it does not end the obligation.
+GUIDANCE = (
+    "Add an E2E: line to the PR body — one of:\n"
+    f"  {MARKER}: <one-line plan for the post-merge verification>\n"
+    f"  {MARKER}: none — <reason there is no runtime surface to verify>\n"
+    # A CONCRETE example, not only the bracketed template: an author blocked by
+    # this gate needs a line they can copy, and `test_every_example_in_the_
+    # guidance_passes_the_parser` runs every concrete example here through the
+    # parser so the gate can never again prescribe a remedy it would refuse.
+    f"For example:  {MARKER}: none — docs only, no runtime surface\n"
+    "`none` is a legitimate answer for a docs/prose PR; what is not legitimate is "
+    "leaving the decision unmade. Note it passes this gate but does NOT release the "
+    "validator, which assumes every merged PR has an E2E and hunts for one anyway "
+    "(spec §8.13) — the line is its first lead, not a boundary."
+)

--- a/scripts/e2e_declaration.py
+++ b/scripts/e2e_declaration.py
@@ -161,12 +161,30 @@ def _load_sibling_readable_body():
     Falls back to the local scanner below if that module cannot be loaded (it carries
     imports this one deliberately does not need). Degrading the STRIPPING is safe in
     the direction that matters: the local copy implements the same rules."""
+    import sys
+
+    name = "_cc_pin_receipts_for_e2e"
     try:
         path = Path(__file__).resolve().parent / "check_cc_pin_receipts.py"
-        spec = importlib.util.spec_from_file_location("_cc_pin_receipts_for_e2e", path)
+        spec = importlib.util.spec_from_file_location(name, path)
         if spec and spec.loader:
             mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(mod)
+            # REGISTERED BEFORE exec: that module's dataclasses resolve their own
+            # module out of sys.modules, so exec-ing an unregistered module raises
+            # `AttributeError: 'NoneType' object has no attribute '__dict__'`.
+            # Without this line the load ALWAYS failed and the local fallback
+            # silently ran instead — so the docstring's "the SAME scanner the pin
+            # gate uses, so the two can never disagree" was false in every run
+            # (Kimi P2, 2026-09-06). The guard's own _load_pin_receipt_checker
+            # carries this line and says why; I read that comment and did not copy
+            # it. On failure the half-initialised entry is removed so a later
+            # import of the real module is not poisoned.
+            sys.modules[name] = mod
+            try:
+                spec.loader.exec_module(mod)
+            except Exception:
+                sys.modules.pop(name, None)
+                raise
             fn = getattr(mod, "readable_body", None)
             if callable(fn):
                 return fn
@@ -308,10 +326,23 @@ def parse_e2e(body: str | None) -> dict:
         if _reason_is_real(value):
             best = {"kind": "plan", "text": value, "detail": ""}
         elif not saw_invalid_detail:
-            saw_invalid_detail = (
-                "the E2E: line has no real content (empty, a placeholder, or a "
-                "template value left unfilled)"
-            )
+            # Name the ACTUAL rule. A terse-but-real plan ("manual", "smoke",
+            # "run CI") fails only the length floor, and telling that author the
+            # line "has no real content" is a false diagnosis on a gate with no
+            # override — it sends them guessing (Kimi P3, 2026-09-06). Say which
+            # rule bit, and quote what they wrote back to them.
+            shown = _strip_formatting(value)[:60]
+            if sum(ch.isalnum() for ch in _strip_formatting(value)) < _MIN_SUBSTANCE:
+                saw_invalid_detail = (
+                    f"the E2E: line is too short to be a plan ({shown!r}) — give at "
+                    f"least a few words saying what will be run, or use "
+                    f"`E2E: none — <reason>`"
+                )
+            else:
+                saw_invalid_detail = (
+                    "the E2E: line has no real content (a placeholder, or a "
+                    "template value left unfilled)"
+                )
 
     if best is not None:
         return best
@@ -348,7 +379,11 @@ GUIDANCE = (
     # this gate needs a line they can copy, and `test_every_example_in_the_
     # guidance_passes_the_parser` runs every concrete example here through the
     # parser so the gate can never again prescribe a remedy it would refuse.
-    f"For example:  {MARKER}: none — docs only, no runtime surface\n"
+    # BOTH forms get a concrete, copyable example. Offering one only for `none`
+    # meant the single line a blocked author could copy was the one that creates NO
+    # obligation — on a gate whose purpose is creating them (Kimi P3, 2026-09-06).
+    f"For example:  {MARKER}: restart genesis-server and confirm /api/genesis/health answers 200\n"
+    f"         or:  {MARKER}: none — docs only, no runtime surface\n"
     "`none` is a legitimate answer for a docs/prose PR; what is not legitimate is "
     "leaving the decision unmade. Note it passes this gate but does NOT release the "
     "validator, which assumes every merged PR has an E2E and hunts for one anyway "

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -4797,6 +4797,158 @@ def _pr_body_text(pr_num: str, repo: str | None) -> str | None:
     return result.stdout if result.returncode == 0 else None
 
 
+#: Last-resort matcher for the E2E declaration, used ONLY when
+#: scripts/e2e_declaration.py cannot be imported. Same shape as that module's
+#: _MARKER_RE (markdown wrappers, horizontal whitespace, case-insensitive) with one
+#: addition: `(?!<)` refuses a value that opens with a placeholder bracket, so the
+#: shipped PR template — whose guidance lives in an HTML comment this degraded path
+#: cannot strip — cannot satisfy the gate. Kept adjacent to the loader so the two
+#: are read together; the real pattern remains the parser's.
+_E2E_FALLBACK_RE = re.compile(
+    r"^[^\S\n]*(?:[-*+>][^\S\n]*)*(?:\[[ xX]\][^\S\n]*)?"
+    r"[*_`]{0,2}E2E[*_`]{0,2}[^\S\n]*:[^\S\n]*(?!<)(\S[^\n]*)$",
+    re.MULTILINE | re.IGNORECASE,
+)
+
+
+def _load_e2e_declaration():
+    """Import scripts/e2e_declaration.py, or None if unavailable.
+
+    Same lazy, failure-tolerant shape as ``_load_pin_receipt_checker``: a sibling
+    script rather than a package, and a hook that cannot import it must not stop
+    being a merge gate for everything else."""
+    import importlib.util
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+    path = os.path.join(repo_root, "scripts", "e2e_declaration.py")
+    try:
+        spec = importlib.util.spec_from_file_location("_e2e_declaration", path)
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["_e2e_declaration"] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:
+        return None
+
+
+def _pr_created_at(pr_num: str, repo: str | None = None) -> str | None:
+    """The PR's creation timestamp (ISO-8601), or None if unreadable.
+
+    Mirrors ``_pr_body_text``: ``None`` is UNREADABLE, which the caller treats as
+    "not exempt" — the pre-cutoff population is finite and shrinking, so a parse
+    failure must not become a permanent exemption."""
+    raw = os.environ.get("_TEST_GH_PR_CREATED_AT")
+    if raw is not None:
+        return raw
+    try:
+        result = subprocess.run(
+            [
+                "gh", "pr", "view", pr_num, *_repo_args(repo),
+                "--json", "createdAt", "--jq", ".createdAt",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_gh_timeout(6),
+        )
+    except Exception:
+        return None
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def _check_e2e_plan(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
+    """Block a merge whose PR body never DECIDED about a post-merge E2E (§8.12).
+
+    Returns (should_block, message). The obligation is one line in the PR body —
+    either a plan or an explicit reasoned ``none`` (see scripts/e2e_declaration.py
+    for the full convention and why its parsing is what it is).
+
+    GUARD AXIOMS, stated because every gate change owes them:
+      * VERDICT: block, at MERGE time only. The push arm never calls this — a
+        body is written and revised while a PR is open, so demanding it at push
+        would gate the wrong moment.
+      * AUDIENCE: the agent. The message names both valid forms verbatim.
+      * BACKGROUND: none. Background sessions cannot merge PRs by design, so this
+        cannot impede one.
+
+    Fail directions, each chosen rather than inherited:
+      * body UNREADABLE → BLOCK. This gate guards EVERY merge, so an unreadable
+        body is an unanswered question, not a pass. (The pin gate fails open on
+        the same read because it guards only the rare pin-bump path — the
+        divergence is deliberate, not an oversight.)
+      * createdAt UNREADABLE → BLOCK, naming the cause. Treating it as "old"
+        would turn the transition window into a permanent hole.
+      * parser module MISSING → the body is still scanned for a bare ``E2E:``
+        line and a NOTE says the comment/fence stripping was unavailable. Losing
+        the invisibility defence must not lose the whole gate.
+
+    NO OVERRIDE SIGIL, deliberately: ``E2E: none — <reason>`` IS the auditable
+    escape hatch, and it costs one honest sentence. Mirrors the pin gate's stance.
+    """
+    # Module FIRST, then the timestamp: the cutoff exemption is only consulted when
+    # the parser is present, so loading in the other order spent a gh round-trip
+    # whose answer was then discarded — and, worse, blocked a PRE-CUTOFF PR in
+    # degraded mode, where the exemption never ran (architect NOTE, 2026-09-06).
+    mod = _load_e2e_declaration()
+    if mod is not None:
+        created_at = _pr_created_at(pr_num, repo=repo)
+        if created_at is None:
+            return True, (
+                f"E2E obligation: could not read PR #{pr_num}'s createdAt, so the "
+                f"pre-convention exemption cannot be established. Re-run; if it "
+                f"persists, the gh read is failing."
+            )
+        if mod.is_pre_cutoff(created_at):
+            return False, f"n/a (PR created {created_at}, before the convention)"
+
+    body = _pr_body_text(pr_num, repo)
+    if body is None:
+        return True, (
+            f"E2E obligation: PR #{pr_num}'s body is unreadable, so the declaration "
+            f"cannot be confirmed. This gate guards every merge — an unread body is "
+            f"an unanswered question, not a pass."
+        )
+
+    if mod is None:
+        # Degraded: no comment/fence stripping. A hand-written second matcher here
+        # DIVERGED from the parser in BOTH directions (architect SHOULD-FIX,
+        # 2026-09-06, measured): it accepted the shipped PR template's guidance line
+        # — which lives inside an HTML comment, so every straight-from-template PR
+        # would have passed — while REJECTING `- E2E: …`, `* E2E: …`, `> E2E: …` and
+        # checkbox forms, the exact markdown tolerance the real pattern exists for.
+        # Two matchers for one rule, selected by an exception handler, is the defect;
+        # this one is derived from the same shape and refuses a placeholder value
+        # (`(?!<)`), so the template cannot satisfy it.
+        found = _E2E_FALLBACK_RE.search(body)
+        if found:
+            print(
+                f"NOTE: PR #{pr_num} — e2e_declaration.py could not be loaded; the "
+                f"E2E: line was matched WITHOUT comment/fence stripping, so a "
+                f"declaration hidden in an HTML comment would not be caught.",
+                file=sys.stderr,
+            )
+            return False, "ok (degraded: parser unavailable)"
+        return True, (
+            f"E2E obligation: no E2E: line found in PR #{pr_num}'s body (parser "
+            f"unavailable, presence-only scan)."
+        )
+
+    result = mod.parse_e2e(body)
+    kind = result.get("kind")
+    if kind in ("plan", "none"):
+        label = "plan" if kind == "plan" else "none"
+        print(
+            f"NOTE: PR #{pr_num} — E2E obligation declared ({label}): "
+            f"{result.get('text', '')[:200]}",
+            file=sys.stderr,
+        )
+        return False, f"ok ({label})"
+
+    detail = result.get("detail") or "no E2E: line in the PR body"
+    return True, f"E2E obligation not declared for PR #{pr_num}: {detail}\n{mod.GUIDANCE}"
+
+
 def _check_pin_receipts(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
     """Block a PR that moves the Claude Code pin FORWARD without its gate receipts.
 
@@ -6477,14 +6629,36 @@ def main() -> int:
                     )
                     print(receipts_msg, file=sys.stderr)
                     return 2
-                elif receipts_msg.startswith("NOTE:"):
+                if receipts_msg.startswith("NOTE:"):
                     # A NOTE means the gate did NOT verify the receipts and is allowing the
                     # merge anyway. That is the fail-open direction, so it has to be VISIBLE
                     # at the moment of merging — every other fail-open gate on this path
                     # prints its note, and this one silently discarded seven of them, which
                     # made "the residue is narrow and named" false at the only surface a
                     # human reads.
+                    #
+                    # A plain `if`, NOT an `elif`: this NOTE belongs to the PIN gate
+                    # above. When the E2E block below was first inserted between the
+                    # two, this clause re-bound to IT, so a merge blocked for a missing
+                    # E2E line silently swallowed the pin gate's fail-open note —
+                    # reintroducing, in miniature, the exact suppression the paragraph
+                    # above records as measured (architect SHOULD-FIX, 2026-09-06).
                     print(receipts_msg, file=sys.stderr)
+
+                # E2E obligation (§8.12). Sits beside the pin gate because it is
+                # the same KIND of check — a merge-time read of the PR body, which
+                # stays mutable after any CI run — and because both are cheap
+                # reads that should fail before the expensive finding scans.
+                # Like the pin gate it carries NO override sigil: `E2E: none —
+                # <reason>` is the escape hatch, and it costs one honest sentence.
+                should_block, e2e_msg = _check_e2e_plan(pr_num, repo=merge_repo)
+                if should_block:
+                    print(
+                        f"BLOCKED: PR #{pr_num} — no post-merge E2E decision in the PR body.",
+                        file=sys.stderr,
+                    )
+                    print(e2e_msg, file=sys.stderr)
+                    return 2
 
                 # Codex must have reviewed the CURRENT head (existence + freshness)
                 # — not merely have no open findings. This runs BEFORE the finding
@@ -6766,6 +6940,14 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
     print(
         f"pin-receipts   : {'BLOCK — ' + msg.splitlines()[0] if blocked else msg.splitlines()[0]}"
     )
+    if blocked:
+        for line in msg.splitlines()[1:]:
+            print(f"  {line}")
+    failures += 1 if blocked else 0
+    # E2E obligation (§8.12), same tier and same reason as pin-receipts: a
+    # merge-time read of a mutable body, so CI could never be its authority.
+    blocked, msg = _check_e2e_plan(pr_num, repo=repo)
+    print(f"e2e-plan       : {'BLOCK — ' + msg.splitlines()[0] if blocked else msg.splitlines()[0]}")
     if blocked:
         for line in msg.splitlines()[1:]:
             print(f"  {line}")

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -4797,16 +4797,31 @@ def _pr_body_text(pr_num: str, repo: str | None) -> str | None:
     return result.stdout if result.returncode == 0 else None
 
 
+#: MIRROR of e2e_declaration.E2E_CUTOFF_ISO, for the degraded path only. Without it
+#: the cutoff exemption was gated on the parser importing, so a PRE-CUTOFF PR was
+#: BLOCKED whenever the module could not load — a false block on a gate with no
+#: override, against the one population the cutoff exists to protect (CodeRabbit
+#: Minor, 2026-09-06; an earlier comment here claimed a reorder had fixed this, when
+#: the reorder only removed a wasted round-trip). Duplicating a constant invites
+#: drift, so `test_the_degraded_cutoff_mirror_matches_the_parser` locks the two
+#: together and fails the moment either moves.
+_E2E_CUTOFF_FALLBACK = "2026-09-08T00:00:00Z"
+
 #: Last-resort matcher for the E2E declaration, used ONLY when
 #: scripts/e2e_declaration.py cannot be imported. Same shape as that module's
 #: _MARKER_RE (markdown wrappers, horizontal whitespace, case-insensitive) with one
-#: addition: `(?!<)` refuses a value that opens with a placeholder bracket, so the
-#: shipped PR template — whose guidance lives in an HTML comment this degraded path
-#: cannot strip — cannot satisfy the gate. Kept adjacent to the loader so the two
-#: are read together; the real pattern remains the parser's.
+#: addition: the value must contain NO `<…>` placeholder span, because this path
+#: cannot strip HTML comments and the shipped template's guidance lives in one.
+#: An earlier version used `(?!<)`, which only guards the FIRST character — so the
+#: template's own `E2E: none — <reason there is no runtime surface to verify>` line
+#: matched, and every straight-from-template PR would have satisfied the degraded
+#: gate while the comment right here claimed it could not (Kimi P2, 2026-09-06,
+#: reproduced). A real one-line declaration does not carry an angle-bracketed span;
+#: a template line always does. Kept adjacent to the loader so the two are read
+#: together; the real pattern remains the parser's.
 _E2E_FALLBACK_RE = re.compile(
     r"^[^\S\n]*(?:[-*+>][^\S\n]*)*(?:\[[ xX]\][^\S\n]*)?"
-    r"[*_`]{0,2}E2E[*_`]{0,2}[^\S\n]*:[^\S\n]*(?!<)(\S[^\n]*)$",
+    r"[*_`]{0,2}E2E[*_`]{0,2}[^\S\n]*:[^\S\n]*(?![^\n]*<[^<>\n]*>)(\S[^\n]*)$",
     re.MULTILINE | re.IGNORECASE,
 )
 
@@ -4826,8 +4841,16 @@ def _load_e2e_declaration():
         if spec is None or spec.loader is None:
             return None
         mod = importlib.util.module_from_spec(spec)
+        # Registered before exec (dataclasses resolve their module from sys.modules),
+        # and popped on failure so a half-initialised entry cannot poison a later
+        # import — the same hygiene the sibling loader in e2e_declaration.py argues
+        # for. The two loaders disagreeing about it is how one of them ends up wrong.
         sys.modules["_e2e_declaration"] = mod
-        spec.loader.exec_module(mod)
+        try:
+            spec.loader.exec_module(mod)
+        except Exception:
+            sys.modules.pop("_e2e_declaration", None)
+            raise
         return mod
     except Exception:
         return None
@@ -4886,20 +4909,35 @@ def _check_e2e_plan(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
     NO OVERRIDE SIGIL, deliberately: ``E2E: none — <reason>`` IS the auditable
     escape hatch, and it costs one honest sentence. Mirrors the pin gate's stance.
     """
-    # Module FIRST, then the timestamp: the cutoff exemption is only consulted when
-    # the parser is present, so loading in the other order spent a gh round-trip
-    # whose answer was then discarded — and, worse, blocked a PRE-CUTOFF PR in
-    # degraded mode, where the exemption never ran (architect NOTE, 2026-09-06).
+    # The cutoff is checked FIRST and in BOTH modes. An earlier revision consulted
+    # it only when the parser had loaded, which blocked a PRE-CUTOFF PR whenever the
+    # module was missing — a false block, on a gate with no override, against the one
+    # population the exemption exists to protect. Degraded mode compares the mirror
+    # constant lexicographically: both values are ISO-8601 UTC of the same shape, so
+    # that ordering is exact without a parser.
     mod = _load_e2e_declaration()
-    if mod is not None:
-        created_at = _pr_created_at(pr_num, repo=repo)
-        if created_at is None:
+    created_at = _pr_created_at(pr_num, repo=repo)
+    if created_at is None:
+        if mod is None:
+            # Neither the parser NOR the timestamp: nothing can be established, and
+            # the presence scan below still runs. Fail toward asking for a line.
+            print(
+                f"NOTE: PR #{pr_num} — createdAt unreadable AND the E2E parser could "
+                f"not load; the pre-convention exemption could not be checked.",
+                file=sys.stderr,
+            )
+        else:
             return True, (
                 f"E2E obligation: could not read PR #{pr_num}'s createdAt, so the "
                 f"pre-convention exemption cannot be established. Re-run; if it "
                 f"persists, the gh read is failing."
             )
-        if mod.is_pre_cutoff(created_at):
+    else:
+        if mod is not None:
+            exempt = mod.is_pre_cutoff(created_at)
+        else:
+            exempt = created_at.strip() < _E2E_CUTOFF_FALLBACK
+        if exempt:
             return False, f"n/a (PR created {created_at}, before the convention)"
 
     body = _pr_body_text(pr_num, repo)
@@ -4918,8 +4956,10 @@ def _check_e2e_plan(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
         # would have passed — while REJECTING `- E2E: …`, `* E2E: …`, `> E2E: …` and
         # checkbox forms, the exact markdown tolerance the real pattern exists for.
         # Two matchers for one rule, selected by an exception handler, is the defect;
-        # this one is derived from the same shape and refuses a placeholder value
-        # (`(?!<)`), so the template cannot satisfy it.
+        # this one is derived from the same shape and refuses any value carrying a
+        # `<…>` span, so no template line can satisfy it. (The narrower `(?!<)` this
+        # comment used to name was itself the bug — it guarded only the first
+        # character; see the pattern's own docstring.)
         found = _E2E_FALLBACK_RE.search(body)
         if found:
             print(

--- a/tests/test_hooks/conftest.py
+++ b/tests/test_hooks/conftest.py
@@ -25,6 +25,25 @@ def _pin_required_ci_workflows(monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_e2e_declaration(monkeypatch):
+    """Give EVERY hook test a PR body that satisfies the E2E-obligation gate (§8.12).
+
+    That gate fails CLOSED on an unreadable body and on an unreadable ``createdAt``
+    — deliberately, since it guards every merge — so without this pin each test
+    that drives the merge gate or its report would make a LIVE ``gh pr view`` call:
+    green on a dev box with gh authenticated and PR "1" answering, red in CI, and
+    in both cases testing the network rather than the thing under test.
+
+    This is the hermetic DEFAULT, not a waiver. The gate's own behaviour — every
+    verdict, both fail directions, the cutoff, and the degraded path — is exercised
+    in tests/test_hooks/test_e2e_plan_gate.py, which overrides these per case; a
+    later ``monkeypatch.setenv`` in any test wins over this one."""
+    monkeypatch.setenv("_TEST_GH_PR_BODY", "E2E: none — hermetic default for hook tests\n")
+    monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2099-01-01T00:00:00Z")
+    yield
+
+
 def _load_settings() -> dict:
     """Load .claude/settings.json from the repo root."""
     here = Path(__file__).resolve()

--- a/tests/test_hooks/test_e2e_plan_gate.py
+++ b/tests/test_hooks/test_e2e_plan_gate.py
@@ -69,10 +69,28 @@ class TestVerdicts:
         assert "E2E: <one-line plan" in msg and "E2E: none —" in msg
 
     def test_bare_none_blocks_and_says_why(self, guard, monkeypatch):
+        """The message must name THIS mistake, not just block.
+
+        `"reason" in msg` was vacuous: GUIDANCE is appended to every block message
+        and itself contains "<reason there is no runtime surface to verify>", so the
+        assertion passed for the generic detail too (CodeRabbit Minor, 2026-09-06).
+        Assert the specific detail, and assert the generic one is ABSENT."""
         monkeypatch.setenv("_TEST_GH_PR_BODY", "E2E: none\n")
         blocked, msg = guard._check_e2e_plan("100")
         assert blocked
-        assert "reason" in msg.lower()
+        assert "needs a REASON" in msg, "must name the bare-`none` mistake specifically"
+        assert "no real content" not in msg, "must not fall back to the generic detail"
+
+    def test_placeholder_block_uses_the_generic_detail(self, guard, monkeypatch):
+        """The control that makes the assertion above discriminating: a DIFFERENT
+        invalid shape must produce a DIFFERENT detail."""
+        monkeypatch.setenv(
+            "_TEST_GH_PR_BODY", "E2E: <one-line plan for the post-merge verification>\n"
+        )
+        blocked, msg = guard._check_e2e_plan("100")
+        assert blocked
+        assert "no real content" in msg
+        assert "needs a REASON" not in msg
 
     def test_block_message_names_the_validator_seam(self, guard, monkeypatch):
         """§8.13: `none` passes this gate but does NOT release the validator. An
@@ -126,6 +144,51 @@ class TestFailDirections:
         monkeypatch.setattr(guard, "_load_e2e_declaration", lambda: None)
         blocked, _ = guard._check_e2e_plan("100")
         assert blocked
+
+    def test_degraded_fallback_refuses_the_untouched_pr_template(self, guard):
+        """The degraded path cannot strip HTML comments, and the shipped template's
+        guidance lives in one — so without this the template's own
+        `E2E: none — <reason …>` line satisfied the gate and EVERY
+        straight-from-template PR passed, while the comment beside the regex claimed
+        it could not (Kimi P2, 2026-09-06, reproduced)."""
+        template = (
+            Path(__file__).resolve().parents[2] / ".github" / "PULL_REQUEST_TEMPLATE.md"
+        ).read_text()
+        assert guard._E2E_FALLBACK_RE.search(template) is None
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "E2E: restart the server and curl the health endpoint",
+            "- E2E: run the migration on a fresh DB",
+            "- [x] E2E: smoke the installer",
+            "**E2E**: replay the failing case",
+        ],
+    )
+    def test_degraded_fallback_still_accepts_real_declarations(self, guard, line):
+        """The control: tightening against the template must not blind the fallback
+        to the shapes it exists to read."""
+        assert guard._E2E_FALLBACK_RE.search(line) is not None
+
+    def test_degraded_mode_still_honours_the_cutoff(self, guard, monkeypatch):
+        """A PRE-CUTOFF PR must stay exempt even when the parser cannot load.
+
+        It did not: the exemption was gated on the module importing, so a broken
+        install turned into a false BLOCK on a gate with no override, against
+        exactly the population the cutoff protects (CodeRabbit Minor, 2026-09-06)."""
+        monkeypatch.setenv("_TEST_GH_PR_BODY", "an old body, no declaration\n")
+        monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2020-01-01T00:00:00Z")
+        monkeypatch.setattr(guard, "_load_e2e_declaration", lambda: None)
+        blocked, msg = guard._check_e2e_plan("100")
+        assert not blocked, msg
+        assert "n/a" in msg
+
+    def test_the_degraded_cutoff_mirror_matches_the_parser(self, guard):
+        """The lock on the duplicated constant: two copies of a policy date drift,
+        and a drifted mirror silently changes who is exempt in degraded mode."""
+        mod = guard._load_e2e_declaration()
+        assert mod is not None, "the parser must be loadable in the repo under test"
+        assert guard._E2E_CUTOFF_FALLBACK == mod.E2E_CUTOFF_ISO
 
 
 class TestCutoff:

--- a/tests/test_hooks/test_e2e_plan_gate.py
+++ b/tests/test_hooks/test_e2e_plan_gate.py
@@ -1,0 +1,192 @@
+"""The E2E-obligation merge gate (`_check_e2e_plan` in git_push_guard.py, §8.12).
+
+The parser's own semantics are covered in tests/test_scripts/test_e2e_declaration.py.
+What is tested HERE is the gate's contract, which is a different thing and fails in
+different directions:
+
+  * it blocks at MERGE time and nowhere else (a body is written and revised while a
+    PR is open — gating a push would gate the wrong moment);
+  * pre-cutoff PRs are exempt, so landing this does not retro-block the open queue;
+  * every unreadable input BLOCKS rather than passing, and says which one;
+  * a missing parser module degrades to a presence-only scan with a NOTE, rather
+    than taking the whole gate down with it;
+  * the report row mirrors the enforcement arm (they call the same function, so a
+    bug in one is a bug in both — the property the whole report rests on).
+
+Network-free throughout via the `_TEST_GH_*` env seams.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts" / "hooks"
+_GUARD = _SCRIPTS / "git_push_guard.py"
+
+_PLAN = "E2E: restart the server and confirm /api/genesis/health answers 200\n"
+_NONE = "E2E: none — docs only, no runtime surface to verify\n"
+
+
+@pytest.fixture(scope="module")
+def guard():
+    spec = importlib.util.spec_from_file_location("git_push_guard", _GUARD)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _post_cutoff(monkeypatch):
+    """Default every case to a PR created AFTER the convention — the population the
+    gate actually governs. Pre-cutoff exemption gets its own explicit tests."""
+    monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2099-01-01T00:00:00Z")
+
+
+class TestVerdicts:
+    def test_plan_passes(self, guard, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_BODY", _PLAN)
+        blocked, msg = guard._check_e2e_plan("100")
+        assert not blocked, msg
+        assert "plan" in msg
+
+    def test_none_with_reason_passes(self, guard, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_BODY", _NONE)
+        blocked, msg = guard._check_e2e_plan("100")
+        assert not blocked, msg
+        assert "none" in msg
+
+    def test_absent_declaration_blocks(self, guard, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_BODY", "A body that never decided.\n")
+        blocked, msg = guard._check_e2e_plan("100")
+        assert blocked
+        assert "E2E: <one-line plan" in msg and "E2E: none —" in msg
+
+    def test_bare_none_blocks_and_says_why(self, guard, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_BODY", "E2E: none\n")
+        blocked, msg = guard._check_e2e_plan("100")
+        assert blocked
+        assert "reason" in msg.lower()
+
+    def test_block_message_names_the_validator_seam(self, guard, monkeypatch):
+        """§8.13: `none` passes this gate but does NOT release the validator. An
+        author reading the block must learn the whole contract, or `none` becomes
+        folklore for "no E2E needed"."""
+        monkeypatch.setenv("_TEST_GH_PR_BODY", "nothing\n")
+        _, msg = guard._check_e2e_plan("100")
+        assert "validator" in msg.lower()
+
+    def test_declaration_is_echoed_on_pass(self, guard, monkeypatch, capsys):
+        """Belt-and-braces from the spec: the obligation is printed at merge time,
+        so it is in front of the person merging, not only in the body."""
+        monkeypatch.setenv("_TEST_GH_PR_BODY", _PLAN)
+        guard._check_e2e_plan("100")
+        assert "E2E obligation declared" in capsys.readouterr().err
+
+
+class TestFailDirections:
+    def test_unreadable_body_blocks(self, guard, monkeypatch):
+        """Diverges from the pin gate on purpose: that one fails OPEN on an
+        unreadable body because it guards the rare pin-bump path; this one guards
+        EVERY merge, so an unread body is an unanswered question."""
+        monkeypatch.delenv("_TEST_GH_PR_BODY", raising=False)
+        monkeypatch.setattr(guard, "_pr_body_text", lambda *a, **k: None)
+        blocked, msg = guard._check_e2e_plan("100")
+        assert blocked
+        assert "unreadable" in msg.lower()
+
+    def test_unreadable_created_at_blocks_naming_the_cause(self, guard, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_BODY", _PLAN)
+        monkeypatch.delenv("_TEST_GH_PR_CREATED_AT", raising=False)
+        monkeypatch.setattr(guard, "_pr_created_at", lambda *a, **k: None)
+        blocked, msg = guard._check_e2e_plan("100")
+        assert blocked
+        assert "createdAt" in msg
+
+    def test_parser_unavailable_degrades_to_presence_scan(self, guard, monkeypatch, capsys):
+        """Losing the comment/fence stripping must not lose the gate. A bare E2E:
+        line still passes, and the NOTE says what protection was unavailable."""
+        monkeypatch.setenv("_TEST_GH_PR_BODY", _PLAN)
+        monkeypatch.setattr(guard, "_load_e2e_declaration", lambda: None)
+        blocked, msg = guard._check_e2e_plan("100")
+        assert not blocked
+        assert "degraded" in msg
+        err = capsys.readouterr().err
+        assert "WITHOUT comment/fence stripping" in err
+        assert "hidden in an HTML comment" in err, "the NOTE must name what is now unprotected"
+
+    def test_parser_unavailable_still_blocks_a_body_with_no_line(self, guard, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_BODY", "no declaration here\n")
+        monkeypatch.setattr(guard, "_load_e2e_declaration", lambda: None)
+        blocked, _ = guard._check_e2e_plan("100")
+        assert blocked
+
+
+class TestCutoff:
+    def test_pre_cutoff_pr_is_exempt_even_with_no_declaration(self, guard, monkeypatch):
+        """The transition rule: landing this must not retro-block the open queue."""
+        monkeypatch.setenv("_TEST_GH_PR_BODY", "an old body, no declaration\n")
+        monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2020-01-01T00:00:00Z")
+        blocked, msg = guard._check_e2e_plan("100")
+        assert not blocked
+        assert "n/a" in msg
+
+    def test_post_cutoff_pr_is_bound(self, guard, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_PR_BODY", "a new body, no declaration\n")
+        monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2099-01-01T00:00:00Z")
+        assert guard._check_e2e_plan("100")[0] is True
+
+
+class TestWiring:
+    """Built != wired.
+
+    A source-string grep is NOT a wiring test: MEASURED (architect, 2026-09-06)
+    that replacing the enforcement branch with `if False:` — leaving the call
+    itself in place — kept every test in this file green while the gate did
+    nothing at all. The exit-code proof lives in
+    tests/test_hooks/test_merge_gate_characterization.py (the `e2e_*` cases drive
+    a real `gh pr merge` and assert the exit code); what remains here is only the
+    property no exit code can show — that the REPORT and the ENFORCEMENT call the
+    same function, so the two can never disagree."""
+
+    def test_report_and_enforcement_share_one_function(self):
+        text = _GUARD.read_text()
+        assert "e2e-plan       :" in text, "the report must carry the row"
+        assert text.count("_check_e2e_plan(") >= 3, "def + merge arm + report row"
+
+
+class TestEndToEndThroughTheHook:
+    """Drive the real hook binary, so the gate is proven to fire through the actual
+    PreToolUse contract rather than only as a Python function."""
+
+    def _run(self, command: str, body: str, created: str = "2099-01-01T00:00:00Z"):
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDE_TOOL_INPUT"}
+        env["_TEST_GH_PR_BODY"] = body
+        env["_TEST_GH_PR_CREATED_AT"] = created
+        payload = json.dumps(
+            {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+            }
+        )
+        return subprocess.run(
+            [sys.executable, str(_GUARD)],
+            input=payload,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_a_push_is_not_blocked_by_a_missing_declaration(self):
+        """The audience/verdict axiom in executable form: no declaration, but a
+        push must sail through — this gate has nothing to say at push time."""
+        r = self._run("git push", "no declaration at all\n")
+        assert "no post-merge E2E decision" not in r.stderr

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -262,6 +262,11 @@ _PIN_RECEIPTS_BODY = (
     "CC-Gate-Changelog: read (2.1.218, 2.1.246] in full from CHANGELOG.md, 2026-08-28\n"
     "CC-Gate-Soak: 2.1.246 on container 2026-08-25..2026-08-27, "
     "check_cc_running_versions.sh clean, sign-off recorded\n"
+    # These cases assert an ALLOW, so the body must satisfy every body-reading gate,
+    # not just the pin one — the E2E obligation (§8.12) reads the same body and
+    # fails closed without a declaration. A case whose subject is the pin gate must
+    # not start failing for an unrelated missing line.
+    "E2E: none — pin bump only, no runtime surface to verify\n"
 )
 
 
@@ -279,6 +284,9 @@ def _run(
     head_pin: str | None = None,
     base_pin: str | None = None,
     pr_body: str | None = None,
+    # E2E obligation (§8.12): the conftest pins a POST-cutoff default, so a case
+    # only passes this to exercise the pre-convention exemption.
+    created_at: str | None = None,
     router=None,
 ) -> int:
     """Drive ``main()`` in-process: granular seams via env, un-seamed gh via the
@@ -308,6 +316,7 @@ def _run(
         ("_TEST_GH_HEAD_PIN_FILE", head_pin),
         ("_TEST_GH_BASE_PIN_FILE", base_pin),
         ("_TEST_GH_PR_BODY", pr_body),
+        ("_TEST_GH_PR_CREATED_AT", created_at),
     ):
         if value is not None:
             monkeypatch.setenv(seam, value)
@@ -1039,10 +1048,59 @@ _CASES: list[tuple[str, object, int, str]] = [
         0,
         "",
     ),
+    # ── E2E obligation (§8.12) ──────────────────────────────────────────────
+    # These drive the REAL merge command through the hook. The gate's first
+    # "wiring" tests were source-string greps, and MEASURED: replacing the
+    # enforcement branch with `if False:` left the call in place, so all 147
+    # tests stayed green while the gate did nothing. A grep proves a call exists;
+    # only an exit code proves it BLOCKS.
+    (
+        "e2e_declaration_absent_blocks_merge",
+        lambda mp: _run(mp, _merge_cmd(), pr_body="A body that never decided.\n"),
+        2,
+        "no post-merge E2E decision",
+    ),
+    (
+        "e2e_none_with_reason_allows_merge",
+        lambda mp: _run(
+            mp, _merge_cmd(), pr_body="E2E: none — docs only, no runtime surface\n"
+        ),
+        0,
+        "",
+    ),
+    (
+        "e2e_plan_allows_merge",
+        lambda mp: _run(
+            mp, _merge_cmd(), pr_body="E2E: restart the server and curl the health endpoint\n"
+        ),
+        0,
+        "",
+    ),
+    (
+        "e2e_bare_none_blocks_merge",
+        lambda mp: _run(mp, _merge_cmd(), pr_body="E2E: none\n"),
+        2,
+        "no post-merge E2E decision",
+    ),
+    (
+        "e2e_pre_cutoff_pr_is_exempt_at_merge",
+        lambda mp: _run(
+            mp, _merge_cmd(), pr_body="an old body, no declaration\n", created_at="2020-01-01T00:00:00Z"
+        ),
+        0,
+        "",
+    ),
     (
         "pin_unchanged_allows_through_main",
         lambda mp: _run(
-            mp, _merge_cmd(), head_pin=_PIN_BASE, base_pin=_PIN_BASE, pr_body="no receipts"
+            mp,
+            _merge_cmd(),
+            head_pin=_PIN_BASE,
+            base_pin=_PIN_BASE,
+            # "no receipts" is the point of THIS case (an unchanged pin needs none);
+            # the E2E line is present only so the allow is not stolen by a different
+            # body-reading gate (§8.12).
+            pr_body="no receipts\nE2E: none — unchanged pin, no runtime surface\n",
         ),
         0,
         "",

--- a/tests/test_scripts/test_e2e_declaration.py
+++ b/tests/test_scripts/test_e2e_declaration.py
@@ -45,6 +45,32 @@ def e2e():
 # ── the two valid forms ──────────────────────────────────────────────────────
 
 
+def test_the_sibling_scanner_actually_loads(e2e):
+    """The module claims it uses the SAME body scanner as the pin gate "so the two
+    can never disagree". That was FALSE in every run: the sibling resolves its
+    dataclasses out of sys.modules, so exec-ing it unregistered raised
+    AttributeError and the load silently fell back to the local copy (Kimi P2,
+    2026-09-06). A claim of shared behaviour has to be executable, or it is just a
+    comment."""
+    assert e2e._load_sibling_readable_body() is not None
+
+
+def test_the_two_scanners_agree_on_marker_visibility(e2e):
+    """Guard-the-guard: with the sibling now genuinely loading, assert the local
+    fallback and the shared scanner reach the same verdict on the cases that matter,
+    so a future divergence is caught rather than assumed away."""
+    bodies = [
+        "E2E: a plain declaration\n",
+        "<!--\nE2E: hidden in a comment\n-->\nreal text\n",
+        "```\nE2E: inside a fence\n```\n",
+        "intro\n<!-- unterminated\nE2E: after an open comment\n",
+    ]
+    for body in bodies:
+        shared = e2e.readable_body(body)
+        local = e2e._local_readable_body(body)
+        assert bool(e2e._MARKER_RE.search(shared)) == bool(e2e._MARKER_RE.search(local)), body
+
+
 def test_plan_form_is_read(e2e):
     r = e2e.parse_e2e("Some body\n\nE2E: run the migration on a fresh DB and check 92 applied\n")
     assert r["kind"] == "plan"
@@ -281,17 +307,23 @@ def test_every_example_in_the_guidance_passes_the_parser(e2e):
     # GUIDANCE only — it is the text the GATE prints. The module docstring also
     # says `E2E: none` while explaining that a bare one is INVALID, and scraping
     # that would assert the parser accepts the very shape the docs call refused.
-    examples = _re.findall(r"E2E: (none[^\n]*)", e2e.GUIDANCE)
+    examples = _re.findall(r"E2E: ([^\n]+)", e2e.GUIDANCE)
     concrete = [
         ex.strip()
         for ex in examples
         if "<" not in ex  # placeholder templates are meant to be rejected
     ]
-    assert concrete, "the guidance must show at least one concrete `none` example"
+    # BOTH forms, not just `none`: scraping only the none-examples would let a
+    # broken PLAN example ship (Kimi P3, 2026-09-06).
+    kinds = {e2e.parse_e2e(f"E2E: {ex}\n")["kind"] for ex in concrete}
+    assert concrete, "the guidance must show at least one concrete example"
     for ex in concrete:
-        assert e2e.parse_e2e(f"E2E: {ex}\n")["kind"] == "none", (
+        assert e2e.parse_e2e(f"E2E: {ex}\n")["kind"] in {"none", "plan"}, (
             f"guidance offers {ex!r} but the parser rejects it"
         )
+    assert kinds == {"none", "plan"}, (
+        f"the guidance must show a concrete example of BOTH forms; got {kinds}"
+    )
 
 
 @pytest.mark.parametrize("reason", ["docs only", "prose-only", "no runtime surface"])

--- a/tests/test_scripts/test_e2e_declaration.py
+++ b/tests/test_scripts/test_e2e_declaration.py
@@ -1,0 +1,335 @@
+"""The `E2E:` PR-body declaration parser (scripts/e2e_declaration.py).
+
+Two directions matter and both are tested here, because a parser measured on only
+one of them is half measured:
+
+  * A real declaration in any shape a PR body is ACTUALLY written in must be READ
+    (markdown bullets, checkboxes, bold/backtick wrappers, CRLF, a filled line under
+    a leftover template line). A gate that blocks a compliant PR at merge time is how
+    an operator learns to route around it.
+  * Text that only MENTIONS an E2E, or that leaves the decision unmade, must NOT read
+    as a declaration — prose, a fenced example, an HTML-comment template, a bare
+    `none`, a placeholder.
+
+The `none — <reason>` form is the sharp case: it is a trailing qualification, the
+exact shape `repo_pulse.FOLLOWUP_MARKER_RE` anchors at both ends to REJECT. Line-start
+anchoring plus a substance check is what replaces that anchoring here, so both are
+exercised directly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location(
+        "e2e_declaration", _SCRIPTS / "e2e_declaration.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def e2e():
+    return _load()
+
+
+# ── the two valid forms ──────────────────────────────────────────────────────
+
+
+def test_plan_form_is_read(e2e):
+    r = e2e.parse_e2e("Some body\n\nE2E: run the migration on a fresh DB and check 92 applied\n")
+    assert r["kind"] == "plan"
+    assert "fresh DB" in r["text"]
+
+
+def test_none_form_with_reason_is_read(e2e):
+    r = e2e.parse_e2e("E2E: none — docs only, no runtime surface to verify\n")
+    assert r["kind"] == "none"
+    assert "docs only" in r["text"]
+
+
+@pytest.mark.parametrize("dash", ["—", "–", "-"])
+def test_none_accepts_em_en_and_plain_dashes(e2e, dash):
+    """Authors type whichever dash their editor produces; all three are the same
+    declaration."""
+    r = e2e.parse_e2e(f"E2E: none {dash} prose-only change, nothing executes\n")
+    assert r["kind"] == "none"
+
+
+@pytest.mark.parametrize(
+    "phrasing",
+    [
+        "none because this is documentation only",
+        "none, docs only with no runtime surface",
+        "none: prose change with no runtime surface",
+        "none — docs only with no runtime surface",
+        # NOTE: whitespace-ONLY separation is deliberately NOT here. An earlier
+        # revision accepted it, which is exactly what let `none of the existing
+        # tests cover …` — a real PLAN — classify as `none`. A separator (or an
+        # explicit "needed/required", or nothing at all) is the signal; a space
+        # is not.
+    ],
+)
+def test_none_is_recognised_however_the_author_punctuates_it(e2e, phrasing):
+    """FOUND BY MUTATION, not by use: requiring an em dash classified every other
+    natural phrasing as a PLAN. Invisible at the gate (both kinds pass), which is
+    why it needed a mutation to surface — the damage lands downstream, where the
+    repo-pulse worker turns a `plan` into a hot follow-up row and a docs PR
+    acquires a junk obligation reading "Run the declared E2E: none, docs only"."""
+    r = e2e.parse_e2e(f"E2E: {phrasing}\n")
+    assert r["kind"] == "none", f"{phrasing!r} is a `none` declaration, not a plan"
+
+
+@pytest.mark.parametrize(
+    "plan",
+    [
+        # "nonetheless" is stopped by \b alone — it passed for the wrong reason and
+        # left the REAL swallow untested (architect SHOULD-FIX, 2026-09-06).
+        "nonetheless run the migration and check the row count",
+        # THE case that was actually broken: `none` + ordinary prose. With the
+        # separator optional, this classified as `none` — a real plan swallowed,
+        # which in PR-2b means the PR silently acquires NO obligation row. That is
+        # the spec's failure mode (B) arriving through the parser.
+        "none of the existing tests cover the new path; run it by hand after merge",
+        "none needed beyond restarting genesis-server and watching the log",
+    ],
+)
+def test_a_plan_that_merely_starts_with_a_none_ish_word_is_still_a_plan(e2e, plan):
+    assert e2e.parse_e2e(f"E2E: {plan}\n")["kind"] == "plan", plan
+
+
+# ── shapes a PR body is actually written in ──────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "E2E: deploy and curl the health endpoint",
+        "- E2E: deploy and curl the health endpoint",
+        "* E2E: deploy and curl the health endpoint",
+        "> E2E: deploy and curl the health endpoint",
+        "- [ ] E2E: deploy and curl the health endpoint",
+        "- [x] E2E: deploy and curl the health endpoint",
+        "**E2E**: deploy and curl the health endpoint",
+        "`E2E`: deploy and curl the health endpoint",
+        "  E2E:   deploy and curl the health endpoint",
+        "e2e: deploy and curl the health endpoint",
+    ],
+)
+def test_markdown_wrappers_are_tolerated(e2e, line):
+    assert e2e.parse_e2e(f"intro\n{line}\noutro\n")["kind"] == "plan"
+
+
+def test_crlf_body_still_matches(e2e):
+    """GitHub's textarea stores CRLF; a line-anchored `$` would otherwise never
+    match a real line (the defect repo_pulse._pr_text exists to fix)."""
+    assert (
+        e2e.parse_e2e("intro\r\nE2E: restart and verify the unit is active\r\n")["kind"] == "plan"
+    )
+
+
+def test_last_valid_occurrence_wins_over_a_template_line_above(e2e):
+    """A leftover template line ABOVE a filled one must not veto it."""
+    body = (
+        "E2E: <one-line plan for the post-merge verification>\n"
+        "E2E: run the assembler on a fixture repo and diff the output\n"
+    )
+    r = e2e.parse_e2e(body)
+    assert r["kind"] == "plan"
+    assert "assembler" in r["text"]
+
+
+# ── text that must NOT read as a declaration ─────────────────────────────────
+
+
+def test_prose_mentioning_e2e_mid_line_is_not_a_declaration(e2e):
+    """The marker is short, so line-START anchoring is what keeps ordinary prose
+    from becoming a declaration."""
+    body = "I skipped the E2E: it needs hardware we do not have in CI.\n"
+    assert e2e.parse_e2e(body)["kind"] == "absent"
+
+
+def test_declaration_inside_an_html_comment_is_invisible(e2e):
+    """This repo's PULL_REQUEST_TEMPLATE.md is built from comment blocks, so a
+    declaration that never renders is the likely accident, not an exotic one."""
+    body = "<!--\nE2E: <one-line plan>\n-->\nreal body text\n"
+    assert e2e.parse_e2e(body)["kind"] == "absent"
+
+
+def test_declaration_inside_a_fence_is_documentation_not_a_claim(e2e):
+    body = "How to declare one:\n\n```\nE2E: run the thing and check the output\n```\n"
+    assert e2e.parse_e2e(body)["kind"] == "absent"
+
+
+def test_an_unterminated_comment_hides_to_the_end(e2e):
+    """Both-ends regexes leave an unterminated opener intact, inverting the rule;
+    the line scanner hides to the end, as CommonMark does."""
+    body = "intro\n<!-- template start\nE2E: this never renders\n"
+    assert e2e.parse_e2e(body)["kind"] == "absent"
+
+
+def test_a_fenced_html_example_does_not_swallow_a_later_declaration(e2e):
+    """MEASURED on the sibling checker: an unmatched `<!--` inside a fence turned
+    comment-mode on, which hid the closing fence, which swallowed every marker after
+    it — a compliant PR blocked by a gate with no override."""
+    body = (
+        "Example:\n\n```html\n<!-- an unclosed comment in an example\n```\n\n"
+        "E2E: restart the server and confirm the endpoint answers 200\n"
+    )
+    assert e2e.parse_e2e(body)["kind"] == "plan"
+
+
+def test_empty_value_does_not_borrow_the_next_line(e2e):
+    """Horizontal-whitespace-only around the colon. Plain `\\s*` crosses newlines,
+    which let an EMPTY marker take the following line as its value."""
+    body = "E2E:\nSome unrelated following line with plenty of words in it\n"
+    assert e2e.parse_e2e(body)["kind"] in {"absent", "invalid"}
+
+
+@pytest.mark.parametrize(
+    "value", ["<one-line plan for the post-merge verification>", "< one-line plan >"]
+)
+def test_unfilled_placeholder_is_invalid_not_a_plan(e2e, value):
+    r = e2e.parse_e2e(f"E2E: {value}\n")
+    assert r["kind"] == "invalid"
+
+
+@pytest.mark.parametrize("value", ["TODO", "tbd", "pending", "n/a", "yes", "?"])
+def test_refusal_words_are_invalid(e2e, value):
+    assert e2e.parse_e2e(f"E2E: {value}\n")["kind"] == "invalid"
+
+
+def test_bare_none_without_a_reason_is_invalid(e2e):
+    """The reason is the whole point of the `none` form — a bare `none` is the
+    decision left unmade wearing the grammar of a decision."""
+    r = e2e.parse_e2e("E2E: none\n")
+    assert r["kind"] == "invalid"
+    assert "reason" in r["detail"].lower()
+
+
+def test_none_with_a_placeholder_reason_is_invalid(e2e):
+    r = e2e.parse_e2e("E2E: none — <reason there is no runtime surface to verify>\n")
+    assert r["kind"] == "invalid"
+
+
+def test_absent_and_empty_bodies(e2e):
+    assert e2e.parse_e2e("nothing here\n")["kind"] == "absent"
+    assert e2e.parse_e2e("")["kind"] == "absent"
+    assert e2e.parse_e2e(None)["kind"] == "absent"
+
+
+# ── performance: the merge gate runs under a wall clock ──────────────────────
+
+
+def test_pathological_body_parses_fast(e2e):
+    """A 64KB body of unterminated comment openers is what a non-greedy regex pair
+    costs ~14s on. The line scanner is O(n) — bound it here so a future
+    'simplification' back to regexes fails loudly instead of quietly eating the
+    merge gate's budget."""
+    body = ("<!-- " * 8192) + "\nE2E: run it\n"
+    start = time.monotonic()
+    e2e.parse_e2e(body)
+    assert time.monotonic() - start < 2.0, "parse must stay well inside the gate budget"
+
+
+def test_body_is_bounded(e2e):
+    """Beyond GitHub's cap the scan must not grow without bound."""
+    body = ("filler line\n" * 20000) + "E2E: a plan far past the cap\n"
+    start = time.monotonic()
+    e2e.parse_e2e(body)
+    assert time.monotonic() - start < 2.0
+
+
+# ── the cutoff ───────────────────────────────────────────────────────────────
+
+
+def test_pre_cutoff_pr_is_exempt(e2e):
+    assert e2e.is_pre_cutoff("2026-01-01T00:00:00Z") is True
+
+
+def test_post_cutoff_pr_is_bound(e2e):
+    assert e2e.is_pre_cutoff("2099-01-01T00:00:00Z") is False
+
+
+@pytest.mark.parametrize("bad", [None, "", "not-a-date", "2026-13-45T99:99:99Z"])
+def test_unreadable_created_at_is_not_exempt(e2e, bad):
+    """Fails CLOSED: treating an unparseable timestamp as 'old' would turn a
+    finite transition window into a permanent hole."""
+    assert e2e.is_pre_cutoff(bad) is False
+
+
+def test_every_example_in_the_guidance_passes_the_parser(e2e):
+    """A remedy the gate PRINTS must survive the gate.
+
+    MEASURED (architect, 2026-09-06): with the substance floor at 12 alnum chars,
+    `E2E: none — docs only` — the exact string GUIDANCE offers as the example —
+    was rejected. On a gate with no override sigil that is a closed loop: blocked,
+    type the suggested line verbatim, blocked identically, with nothing naming an
+    undocumented length rule. This test makes the class unrepeatable rather than
+    fixing the one number."""
+    import re as _re
+
+    # GUIDANCE only — it is the text the GATE prints. The module docstring also
+    # says `E2E: none` while explaining that a bare one is INVALID, and scraping
+    # that would assert the parser accepts the very shape the docs call refused.
+    examples = _re.findall(r"E2E: (none[^\n]*)", e2e.GUIDANCE)
+    concrete = [
+        ex.strip()
+        for ex in examples
+        if "<" not in ex  # placeholder templates are meant to be rejected
+    ]
+    assert concrete, "the guidance must show at least one concrete `none` example"
+    for ex in concrete:
+        assert e2e.parse_e2e(f"E2E: {ex}\n")["kind"] == "none", (
+            f"guidance offers {ex!r} but the parser rejects it"
+        )
+
+
+@pytest.mark.parametrize("reason", ["docs only", "prose-only", "no runtime surface"])
+def test_short_but_real_reasons_are_accepted(reason, e2e):
+    """The floor admits the short, honest reasons a docs PR actually gives."""
+    assert e2e.parse_e2e(f"E2E: none — {reason}\n")["kind"] == "none"
+
+
+@pytest.mark.parametrize("junk", ["x", "ok", "n/a", "?"])
+def test_contentless_reasons_are_still_refused(junk, e2e):
+    """The control that keeps the lowered floor honest."""
+    assert e2e.parse_e2e(f"E2E: none — {junk}\n")["kind"] == "invalid"
+
+
+def test_empty_marker_is_reported_as_empty_not_absent(e2e):
+    """The shipped PR template ends with a bare `E2E:` line, so this is the state
+    EVERY template-created PR starts in. Reporting "no E2E: line in the PR body"
+    to an author looking at a body that visibly contains one is the `invalid`
+    bucket failing at the one case it most owes (architect SHOULD-FIX)."""
+    r = e2e.parse_e2e("## Testing\n\nE2E:\n")
+    assert r["kind"] == "invalid"
+    assert "EMPTY" in r["detail"]
+
+
+def test_the_shipped_pr_template_does_not_satisfy_the_gate(e2e):
+    """Guard-the-guard on the whole convention: the template's guidance lives in an
+    HTML comment and its declaration line is bare, so an untouched template must
+    read as a decision NOT made. If this ever passes, every template-created PR
+    silently satisfies the gate."""
+    template = (
+        Path(__file__).resolve().parents[2] / ".github" / "PULL_REQUEST_TEMPLATE.md"
+    ).read_text()
+    assert e2e.parse_e2e(template)["kind"] in {"absent", "invalid"}
+
+
+def test_guidance_names_both_forms_and_the_seam(e2e):
+    """The block message must teach the whole contract: `none` is legitimate, and it
+    does not release the validator (spec §8.13)."""
+    g = e2e.GUIDANCE
+    assert "E2E: <one-line plan" in g and "E2E: none —" in g
+    assert "validator" in g.lower()


### PR DESCRIPTION
## What

Half A of #1718: every PR body declares its **post-merge** end-to-end verification on one line, and the merge gate blocks when it declares neither.

```
E2E: <one-line plan for the post-merge verification>
E2E: none — <reason there is no runtime surface to verify>
```

The point is not forcing an E2E onto a docs PR — it is making the **decision** explicit. Motivating measurement (2026-09-04): of two owner-directed merges, one had its E2E forgotten until someone asked, and both, once run, found something real.

**Guard axioms**, since this changes a gate: verdict is **BLOCK at merge time only** (never on push — a body is written and revised while a PR is open); audience is the agent (the message names both valid forms and a copyable example); background effect is **none** (background sessions cannot merge PRs by design). PRs created before `E2E_CUTOFF_ISO` are exempt, so this does not retro-block the queue. **No override sigil**, deliberately — `none — <reason>` *is* the escape hatch and costs one honest sentence.

`none` passes the gate but does **not** release the validator, which assumes every merged PR has an E2E and hunts for one anyway (§8.13). The line is its first lead, not a boundary — the block message says so, so the convention can't decay into folklore.

## Why a shared parser module

`scripts/e2e_declaration.py` rather than a regex at the call site: half B (repo-pulse worker) reads the same declaration, and every piece of hardening here was bought by a measured defect in the sibling body-reader — comment/fence stripping by **line scanner** (a non-greedy regex pair costs ~14s on a 64KB body and leaves an unterminated opener intact), horizontal-whitespace-only around the colon (plain `\s*` lets an empty marker borrow the next line's text), markdown tolerance, placeholders derived from the shipped examples, CRLF normalisation, 64KB bound.

## Review found two blockers; both are fixed and re-verified

- **The enforcement had no executable coverage.** Replacing the merge branch with `if False:` left all 147 tests green — my "wiring" tests were source-string greps, which survive deleting the enforcement. The exit-code proof now lives in the characterization table (five cases driving a real `gh pr merge`), and **replaying that same disarm mutation now fails 2 tests**.
- **The gate rejected the remedy its own message prints.** `E2E: none — docs only` is 8 alnum characters against a 12 floor, on a gate with no override — blocked, copy the suggestion, blocked identically. Floor lowered to 7, and a test now runs **every concrete example the gate prints** through the parser, so the class can't recur. That also exposed a placeholder only being rejected by length; now rejected by shape.

Also fixed: a degraded-mode matcher that diverged from the parser both ways (accepted the untouched template, rejected `- E2E:` list items), `none` swallowing real plans beginning with that word (invisible at the gate, but half B would have dropped the obligation), an inserted block that re-bound the pin gate's fail-open NOTE onto itself, and an empty declaration reported as *absent* to an author looking at one on screen.

## Verification

- **573 passed** across the parser, gate, characterization, review-gate and context-budget suites; ruff clean.
- **Mutation sweep** on the parser: 6 mutations, 5 RED — and the one survivor is what found the `none`-classification bug, now fixed and pinned. Plus the reviewer's disarm mutation replayed.
- **Live**: `--check-pr 1804` prints `e2e-plan : n/a (PR created 2026-09-06…, before the convention)`.
- **Measured baseline**, 50 most-recent merged PRs: 49/50 absent (the pre-convention state), 1/50 a real plan — #1803, where the line was written by hand. A true positive on real data, not a tuned fixture.

## Merge-time obligation

`E2E_CUTOFF_ISO = 2026-09-08T00:00:00Z` must still be in the future when this lands. **If it slips past the 8th, bump it before merging** — otherwise every PR created in the interim is retro-blocked, the outcome the constant exists to prevent.

## Deploy path

Hook + sibling script; lands at next CC session start via `git pull`. No migration, no config, no service unit.

E2E: on a post-cutoff PR with no declaration, confirm `--check-pr` shows `e2e-plan: BLOCK` and `gh pr merge` exits 2; then add `E2E: none — <reason>` and confirm both pass.

Refs #1718 (half A of two — the repo-pulse worker half follows, so the issue stays open)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for E2E declarations in pull-request descriptions.
  - Merge checks accept valid test plans or justified `none` declarations.
  - Added copyable examples and clearer guidance, including specific feedback for short declarations.
  - Pre-cutoff pull requests remain exempt, including when full parsing is unavailable.
  - E2E validation results appear in pre-merge reports.

- **Bug Fixes**
  - Merge checks now reliably block missing, invalid, unreadable, or placeholder-based declarations.
  - Added fallback validation when the primary parser is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->