### PR TITLE
feat(session-ledger): escalate a row nobody can dispose of any more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ Versioning follows Genesis release stages (v3.0a → v3.0b → v3.1 → v4.0a…
 
 ## [Unreleased]
 
+### Added
+
+- **Work you agreed to in a session that has since ended no longer goes quiet.**
+  A session's ledger is its list of agreements, and it was only ever visible to
+  that session — so when a session ended with items still open, they stopped
+  being visible to anything. On the install this was built against, 15 items had
+  been sitting undisposed, the oldest for 52 days, and not all of them were
+  internal development work — some were user-facing requests, which is the class
+  most likely to be missed everywhere else.
+
+  An hourly sweep now turns such an item into a follow-up asking what should
+  happen to it — done, absorbed into other work, or no longer needed. It only
+  fires when BOTH the item has gone untouched for five days AND its session has
+  been quiet for five days, so an item you are still working on is never taken
+  out of your hands. Disposing of the item closes the follow-up automatically at
+  the next sweep. Escalations arrive up to five per hour rather than all at once,
+  and they appear in `follow_up_list` and the dashboard follow-ups tab under the
+  source `ledger_escalation` — deliberately not in the morning report, since
+  ledger text is free-form and has contained credentials.
+
+  They arrive unclassified rather than guessed at: the sweep genuinely cannot
+  tell one of your errands from an internal development item, so it asks.
+
+  Tune or disable it with the `ledger_escalation` settings domain (`stale_days`,
+  `quiet_days`, `max_per_run`, `priority`), or turn it off entirely with
+  `GENESIS_LEDGER_ESCALATION_DISABLED=1`.
+
 ### Changed
 
 - **The session charter now lists every open ledger item, not just the oldest

--- a/config/ledger_escalation.yaml
+++ b/config/ledger_escalation.yaml
@@ -1,0 +1,42 @@
+# Undisposed-ledger escalation sweep (learning scheduler, hourly).
+#
+# A session_ledger row lives ONLY on the ledger: its own session's injection
+# renders it, and nothing else does. So when a session dies with open rows, its
+# commitments become unreachable — not deleted, just invisible to every process
+# and person. CLAUDE.md already states the rule ("every open row is either
+# getting done or gets a disposition; a row left undisposed is a defect"); this
+# sweep is what enforces it once the owning session can no longer be asked.
+#
+# A row untouched >= stale_days whose owning session has been quiet >=
+# quiet_days becomes a `user_input_needed` follow-up asking for a disposition.
+# The link is the follow-up's dedup_key (session_awareness.ledger_escalation_link),
+# which the two import-free hooks already render beside an open row.
+#
+# The sweep NEVER writes session_ledger — an evidence write would bump
+# updated_at and read as a disposition the owner never made.
+#
+# Env kill switch: GENESIS_LEDGER_ESCALATION_DISABLED=1 forces it off.
+
+enabled: true
+
+# Row untouched this long (updated_at, else created_at). Any ledger_update
+# restarts the clock.
+stale_days: 5
+
+# AND owning session quiet this long (~/.genesis/sessions/<sid>/last_prompt_time).
+# BOTH must pass: a stale row in a live session is that session's to dispose.
+quiet_days: 5
+
+# Escalations created per run (hourly), oldest first. Deferred ids are logged
+# and returned — never silently dropped.
+max_per_run: 5
+
+# Priority of the created follow-up.
+priority: high
+
+# Which session_ledger.added_by values may escalate. foreground-only by default:
+# `ambient_ledger_extractor` rows are the detached extractor's PROPOSALS, not
+# agreements a human made, and asking the owner to dispose of something nobody
+# committed to is noise. Widen deliberately.
+escalate_added_by:
+  - foreground

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -1493,6 +1493,35 @@ verified: 29a382e7 2026-09-03
   propose_only). Retention 45d via `scripts/prune_repo_pulse.py`
   (disk-hygiene). Telemetry: `call_site_last_run` row `repo_pulse` (not a
   critical site — failed runs self-heal by re-covering their window).
+- **Undisposed-ledger escalation (2026-09-06)**: repo-pulse above CLOSES a
+  ledger row whose work landed in a cited PR; this is the other half — the row
+  whose work never landed and whose session died. A `session_ledger` row is
+  rendered by its OWN session's injection and by nothing else, so a dead
+  session's open rows become unreachable by every process and person.
+  `session_awareness/ledger_escalation.py` (learning scheduler, hourly at :17 —
+  it MUTATES, so not the read-and-alert awareness band) escalates a row
+  untouched ≥ `stale_days` whose owning session has been quiet ≥ `quiet_days`
+  (`~/.genesis/sessions/<sid>/last_prompt_time`, content preferred over mtime so
+  a backup restore cannot make every dead session look live) into a
+  `user_input_needed` follow-up. BOTH thresholds are load-bearing: a stale row
+  in a LIVE session is that session's to dispose. Reverse sync completes the
+  follow-up once the row reaches a terminal status. The link is the follow-up's
+  `dedup_key` (`session_awareness/ledger_escalation_link.py`, whose formula the
+  two import-free hooks inline under a parity test) — this sweep is the WRITER
+  its GROUNDWORK note named. Levers: settings domain `ledger_escalation` + env
+  `GENESIS_LEDGER_ESCALATION_DISABLED`; `escalate_added_by` is a provenance
+  allow-list, foreground-only by default so the ambient extractor's PROPOSALS
+  cannot ask the owner to dispose of something nobody committed to.
+  **Trap: it must never write `session_ledger`** — an evidence write would bump
+  `updated_at` and read as a disposition the owner never made, i.e. the sweep
+  answering its own question. **Do not touch blind: `ledger_escalation` is
+  deliberately ABSENT from the morning report.** Follow-up content reproduces
+  ledger row text verbatim, and real rows on a live install have carried
+  plaintext credentials a session pasted in; the morning report renders
+  `content[:200]` into Telegram. Wiring this source to any egress surface needs
+  a redaction pass first. Follow-ups ship `domain=None` (unclassified) because
+  the sweep cannot tell a dropped user errand from a stale internal dev item —
+  both shapes are really in the ledger.
 
 ## 10. Learning & evaluation
 

--- a/src/genesis/db/crud/session_charters.py
+++ b/src/genesis/db/crud/session_charters.py
@@ -395,6 +395,63 @@ async def ledger_all(
         last = (batch[-1]["created_at"], batch[-1]["id"])
 
 
+# Resource tripwire for ledger_stale_open, sized from capacity rather than
+# history like ledger_all's: this subset (open/in_progress AND untouched past a
+# threshold) is strictly smaller than the whole table, and 50k of them is far
+# past any plausible ledger — the live table held 15 such rows on 2026-09-06.
+# It RAISES rather than truncating, because the escalation sweep reports how
+# many rows it DEFERRED, and a deferred count computed over a silently partial
+# read is a wrong number that looks right.
+_LEDGER_STALE_HARD_CAP = 50_000
+
+
+async def ledger_stale_open(
+    db: aiosqlite.Connection,
+    *,
+    untouched_before: str,
+    added_by: frozenset[str] | set[str] | tuple[str, ...],
+) -> list[dict]:
+    """Unresolved ledger rows last touched before *untouched_before*, oldest first.
+
+    "Unresolved" is open + in_progress: in_progress means someone started and
+    never finished, which is exactly the state worth escalating, not an
+    exemption from it. "Touched" is ``COALESCE(updated_at, created_at)``, so any
+    ``ledger_update`` restarts the clock — a row someone is actively working
+    never qualifies.
+
+    *added_by* is a provenance allow-list (see
+    ``session_awareness.ledger_escalation_config.escalate_added_by``). It is
+    REQUIRED rather than defaulted: the caller deciding which provenance may
+    create work for a human is a policy choice, and a default here would hide it.
+
+    Ordered oldest-first so a caller applying a per-run cap takes the longest-
+    undisposed rows rather than an arbitrary slice.
+    """
+    invalid = set(added_by) - VALID_ADDED_BY
+    if invalid:
+        raise ValueError(f"invalid added_by: {sorted(invalid)}")
+    if not added_by:
+        raise ValueError("added_by allow-list must be non-empty")
+    placeholders = ", ".join("?" for _ in added_by)
+    cursor = await db.execute(
+        "SELECT * FROM session_ledger "
+        "WHERE status IN ('open', 'in_progress') "
+        f"AND added_by IN ({placeholders}) "  # noqa: S608 — placeholders only
+        "AND COALESCE(updated_at, created_at) < ? "
+        "ORDER BY COALESCE(updated_at, created_at) ASC, id ASC "
+        "LIMIT ?",
+        (*sorted(added_by), untouched_before, _LEDGER_STALE_HARD_CAP + 1),
+    )
+    rows = [dict(r) for r in await cursor.fetchall()]
+    if len(rows) > _LEDGER_STALE_HARD_CAP:
+        raise RuntimeError(
+            f"ledger_stale_open: more than {_LEDGER_STALE_HARD_CAP} unresolved "
+            "stale rows — refusing a partial read; raise the cap deliberately "
+            "if the ledger is legitimately this large"
+        )
+    return rows
+
+
 async def ledger_counts(db: aiosqlite.Connection, session_id: str) -> dict[str, int]:
     """Per-status row counts for a session's ledger (absent statuses omitted)."""
     cursor = await db.execute(

--- a/src/genesis/mcp/health/settings.py
+++ b/src/genesis/mcp/health/settings.py
@@ -324,6 +324,27 @@ _DOMAIN_REGISTRY: dict[str, SettingsDomain] = {
         readonly=False,
         needs_restart=False,  # re-read every hourly tick
     ),
+    "ledger_escalation": SettingsDomain(
+        name="ledger_escalation",
+        description=(
+            "Undisposed-ledger escalation sweep (learning scheduler, hourly) — "
+            "master `enabled` + `stale_days` / `quiet_days` / `max_per_run` / "
+            "`priority` / `escalate_added_by`. A session_ledger row untouched >= "
+            "stale_days whose owning session has been quiet >= quiet_days becomes "
+            "a `user_input_needed` follow-up asking for a disposition; disposing "
+            "the row auto-completes that follow-up. BOTH thresholds must pass — a "
+            "stale row in a LIVE session is that session's to dispose. WRITES "
+            "(creates follow-ups), never to session_ledger. `escalate_added_by` "
+            "is a provenance allow-list, foreground-only by default so the "
+            "ambient extractor's proposals cannot ask the owner to dispose of "
+            "something nobody committed to. off (or env "
+            "GENESIS_LEDGER_ESCALATION_DISABLED=1) silences it. Read live each "
+            "tick — no restart."
+        ),
+        config_filename="ledger_escalation.yaml",
+        readonly=False,
+        needs_restart=False,  # re-read every hourly tick
+    ),
     "context_injection_watch": SettingsDomain(
         name="context_injection_watch",
         description=(
@@ -1732,6 +1753,43 @@ def _validate_follow_up_watchdog(changes: dict) -> list[str]:
     return errors
 
 
+def _validate_ledger_escalation(changes: dict) -> list[str]:
+    """Validate ledger-escalation lever changes (see
+    genesis.session_awareness.ledger_escalation_config)."""
+    from genesis.db.crud.session_charters import VALID_ADDED_BY
+    from genesis.session_awareness.ledger_escalation_config import (
+        _VALID_PRIORITY,
+        INT_KNOBS,
+    )
+
+    errors: list[str] = []
+    valid_keys = ("enabled", "priority", "escalate_added_by", *INT_KNOBS)
+    for key, value in changes.items():
+        if key not in valid_keys:
+            errors.append(f"Unknown key '{key}'. Valid: {', '.join(valid_keys)}")
+        elif key == "enabled":
+            if not isinstance(value, bool):
+                errors.append("'enabled' must be a boolean")
+        elif key == "priority":
+            if value not in _VALID_PRIORITY:
+                errors.append(
+                    f"'priority' must be one of {', '.join(_VALID_PRIORITY)}; got {value!r}"
+                )
+        elif key == "escalate_added_by":
+            if not isinstance(value, list) or not value:
+                errors.append("'escalate_added_by' must be a non-empty list")
+            else:
+                unknown = [v for v in value if v not in VALID_ADDED_BY]
+                if unknown:
+                    errors.append(
+                        f"'escalate_added_by' has unknown provenance {unknown}; "
+                        f"valid: {', '.join(sorted(VALID_ADDED_BY))}"
+                    )
+        elif isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            errors.append(f"'{key}' must be a positive int")
+    return errors
+
+
 def _validate_context_injection_watch(changes: dict) -> list[str]:
     """Validate context-injection watcher lever changes (see
     genesis.awareness.context_injection_watch_config)."""
@@ -1780,6 +1838,7 @@ def _validate_provider_outage_notify(changes: dict) -> list[str]:
 _DOMAIN_VALIDATORS: dict[str, Any] = {
     "ego_reconcile": _validate_ego_reconcile,
     "follow_up_watchdog": _validate_follow_up_watchdog,
+    "ledger_escalation": _validate_ledger_escalation,
     "context_injection_watch": _validate_context_injection_watch,
     "provider_outage_notify": _validate_provider_outage_notify,
     "surplus_ideation_promotion": _validate_surplus_ideation_promotion,

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -13,6 +13,9 @@ from genesis.content.drafter import ContentDrafter
 from genesis.content.types import DraftRequest, FormatTarget
 from genesis.db.crud.observations import INTERNAL_OBS_TYPES as _INTERNAL_OBS_TYPES_SET
 from genesis.outreach.types import OutreachCategory, OutreachRequest
+from genesis.session_awareness.ledger_escalation_link import (
+    ESCALATION_SOURCE as _LEDGER_ESCALATION_SOURCE,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -849,6 +852,19 @@ class MorningReportGenerator:
         user_items = await follow_ups.get_pending(
             self._db, strategy="user_input_needed", domain="user_world",
         )
+        # Ledger escalations never reach this report, whatever their domain.
+        # Their content reproduces `session_ledger` row text VERBATIM, and real
+        # rows have carried credentials a session pasted into the ledger; this
+        # report renders content[:200] into a Telegram message. They ship
+        # domain=None, which the exact-match filter above already excludes — but
+        # the follow-up's own body asks the reader to classify it, and choosing
+        # `user_world` would otherwise put unredacted ledger text on the wire.
+        # A documented privacy guarantee that holds only until someone answers a
+        # question the feature itself poses is not a guarantee. Enforce it here,
+        # where the egress is, rather than relying on the domain default.
+        user_items = [
+            fu for fu in user_items if fu.get("source") != _LEDGER_ESCALATION_SOURCE
+        ]
         if user_items:
             shown = (
                 f" (showing 5 of {len(user_items)})" if len(user_items) > 5 else ""

--- a/src/genesis/outreach/morning_report.py
+++ b/src/genesis/outreach/morning_report.py
@@ -19,6 +19,34 @@ from genesis.session_awareness.ledger_escalation_link import (
 
 logger = logging.getLogger(__name__)
 
+# Follow-up sources whose CONTENT has not been through a redaction pass and so
+# must never reach this report. The report is an EGRESS surface — it renders
+# `content[:200]` into a Telegram message — and these carry text this system did
+# not author.
+#
+# `ledger_escalation` reproduces `session_ledger` row text verbatim, and real
+# rows on a live install have carried credentials a session pasted into the
+# ledger. Those rows ship `domain=None`, which every bucket's exact-match
+# `user_world` filter already excludes — but the follow-up's own body ASKS the
+# reader to classify it, so a guarantee resting on that default holds only until
+# someone answers the question the feature itself poses.
+_UNREDACTED_CONTENT_SOURCES = frozenset({_LEDGER_ESCALATION_SOURCE})
+
+
+def _drop_unredacted_sources(rows: list[dict]) -> list[dict]:
+    """Remove rows whose source is not safe to render to an egress surface.
+
+    ONE chokepoint applied to EVERY bucket, rather than a filter at the bucket
+    that happened to prompt it. The first version of this guarded only the
+    "Needs your input" list; `blocked/failed` and `completed (24h)` render the
+    same `content` field to the same Telegram message and had no filter at all,
+    so the leak had three doors and one was shut. A source-exclusion rule that
+    each new bucket must REMEMBER to apply is a convention, and conventions are
+    what reviewers find one instance of at a time — so a bucket now has to route
+    through here to render anything.
+    """
+    return [row for row in rows if row.get("source") not in _UNREDACTED_CONTENT_SOURCES]
+
 # Convert to tuple for db.execute() compatibility (requires sequence, not frozenset)
 _INTERNAL_OBS_TYPES = tuple(_INTERNAL_OBS_TYPES_SET)
 
@@ -852,19 +880,7 @@ class MorningReportGenerator:
         user_items = await follow_ups.get_pending(
             self._db, strategy="user_input_needed", domain="user_world",
         )
-        # Ledger escalations never reach this report, whatever their domain.
-        # Their content reproduces `session_ledger` row text VERBATIM, and real
-        # rows have carried credentials a session pasted into the ledger; this
-        # report renders content[:200] into a Telegram message. They ship
-        # domain=None, which the exact-match filter above already excludes — but
-        # the follow-up's own body asks the reader to classify it, and choosing
-        # `user_world` would otherwise put unredacted ledger text on the wire.
-        # A documented privacy guarantee that holds only until someone answers a
-        # question the feature itself poses is not a guarantee. Enforce it here,
-        # where the egress is, rather than relying on the domain default.
-        user_items = [
-            fu for fu in user_items if fu.get("source") != _LEDGER_ESCALATION_SOURCE
-        ]
+        user_items = _drop_unredacted_sources(user_items)
         if user_items:
             shown = (
                 f" (showing 5 of {len(user_items)})" if len(user_items) > 5 else ""
@@ -878,6 +894,7 @@ class MorningReportGenerator:
         # Blocked/failed items
         blocked = await follow_ups.get_by_status(self._db, "failed", domain="user_world")
         blocked += await follow_ups.get_by_status(self._db, "blocked", domain="user_world")
+        blocked = _drop_unredacted_sources(blocked)
         if blocked:
             shown = (
                 f" (showing 5 of {len(blocked)})" if len(blocked) > 5 else ""
@@ -894,6 +911,7 @@ class MorningReportGenerator:
         completed = await follow_ups.get_recently_completed(
             self._db, hours=24, limit=5, domain="user_world",
         )
+        completed = _drop_unredacted_sources(completed)
         if completed:
             lines.append("**Completed (24h):**")
             for row in completed:

--- a/src/genesis/runtime/init/learning.py
+++ b/src/genesis/runtime/init/learning.py
@@ -9,7 +9,7 @@ from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from genesis.env import cc_project_dir, user_timezone
+from genesis.env import cc_project_dir, genesis_home, user_timezone
 from genesis.runtime.init.process_reaper import _wire_process_reaper
 from genesis.runtime.init.rate_limit_resume import _wire_rate_limit_resume
 
@@ -767,6 +767,71 @@ async def init(rt: GenesisRuntime) -> None:
             id="idea_lane_decay",
             max_instances=1,
             misfire_grace_time=3600,
+        )
+
+        async def _ledger_escalation_sweep() -> None:
+            # Escalate a session_ledger row nobody can dispose of any more (row
+            # untouched >= stale_days AND its session quiet >= quiet_days) into a
+            # user_input_needed follow-up, and complete escalations whose row has
+            # since been disposed. Lives here (learning scheduler) rather than in
+            # the awareness loop because it MUTATES — it creates follow-ups — and
+            # the awareness _check_* family is documented read-and-alert only.
+            # Hourly, so the reverse sync closes a follow-up within the hour of
+            # its row being disposed.
+            try:
+                if rt.paused:
+                    return
+            except Exception:
+                logger.warning(
+                    "Pause check failed — skipping ledger escalation",
+                    exc_info=True,
+                )
+                return
+            if rt._db is None:
+                return
+            try:
+                from genesis.session_awareness.ledger_escalation import run_sweep
+                from genesis.session_awareness.ledger_escalation_config import (
+                    is_enabled,
+                )
+
+                if not is_enabled():
+                    rt.record_job_success("ledger_escalation")
+                    return
+                result = await run_sweep(
+                    rt._db,
+                    now=datetime.now(UTC),
+                    sessions_dir=genesis_home() / "sessions",
+                )
+                if result["reconcile_failed"]:
+                    # The forward pass ran but the reverse sync did not. Half a
+                    # run is not a successful run: recording success here would
+                    # let a permanently dead reverse sync — escalations stuck
+                    # pending for rows disposed weeks ago — sit behind a green
+                    # job-health tile indefinitely.
+                    rt.record_job_failure(
+                        "ledger_escalation",
+                        "reverse sync could not read the ledger",
+                    )
+                else:
+                    rt.record_job_success("ledger_escalation")
+                if result["created"] or result["reconciled"]:
+                    logger.info(
+                        "Ledger escalation: created %d, reconciled %d, deferred %d",
+                        result["created"],
+                        result["reconciled"],
+                        result["deferred"],
+                    )
+            except Exception as exc:
+                rt.record_job_failure("ledger_escalation", exc=exc)
+                logger.exception("Ledger escalation sweep failed")
+
+        rt._learning_scheduler.add_job(
+            _ledger_escalation_sweep,
+            CronTrigger(minute=17, timezone=user_timezone()),
+            id="ledger_escalation",
+            max_instances=1,
+            misfire_grace_time=1800,
         )
 
         async def _run_recovery() -> None:

--- a/src/genesis/session_awareness/ledger_escalation.py
+++ b/src/genesis/session_awareness/ledger_escalation.py
@@ -1,0 +1,449 @@
+"""Escalate an undisposed ledger row into a follow-up once nobody can dispose it.
+
+A ``session_ledger`` row lives ONLY on the ledger. A follow-up is durable and
+system-wide, surfaced by several consumers; a ledger row is rendered by its own
+session's context injection and by nothing else. So when a session dies with
+open rows, its commitments become unreachable — not deleted, just invisible to
+every process and every person.
+
+CLAUDE.md already states the rule: *every open row is either getting done or
+gets a disposition (done / absorbed / dropped, with the reason) — a row left
+undisposed is a defect, not a backlog.* A live session enforces that on itself.
+This sweep enforces it once the owning session can no longer be asked.
+
+MEASURED on the live ledger 2026-09-06, which is why BOTH thresholds exist: 50
+rows were open, 15 qualified at 5d/5d, and the oldest had been untouched 52
+days. Reading them showed they are not one kind of thing — several record their
+own completion and were simply never closed, several are real unbuilt work, and
+two were user-world errands the owner asked for and never got (one labelled
+"NEXT TASK (post-compact, user-requested)", invisible for 15 days). That last
+class is the acceptance case: nothing else surfaces it, because it is not repo
+work, not a follow-up, and its session is gone.
+
+THE LINK is the follow-up's ``dedup_key``
+(``ledger_escalation_link.escalation_dedup_key``), whose module docstring names
+this sweep as its missing writer. The two import-free hooks already render
+``-> escalated: follow_up <id>`` beside an open row, so a REVIVED session sees
+and can close its own escalation. That surface is deliberately NOT counted as
+coverage for the population here: an escalated row's session is by definition
+quiet, so in practice nothing renders it.
+
+WHAT THIS SWEEP NEVER DOES: write ``session_ledger``. An evidence write would
+bump ``updated_at`` and read as a disposition the owner never made — the sweep
+would then look like it had answered its own question.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from genesis.db.crud import follow_ups as fu_crud
+from genesis.db.crud.session_charters import ledger_all, ledger_stale_open
+from genesis.session_awareness.ledger_escalation_config import (
+    escalate_added_by,
+    knob_int,
+    load_config,
+    priority,
+)
+from genesis.session_awareness.ledger_escalation_link import (
+    ESCALATION_SOURCE,
+    escalation_dedup_key,
+)
+
+logger = logging.getLogger(__name__)
+
+# A ledger row in one of these has been dispositioned — the escalation asking
+# for that disposition is answered and gets completed.
+_TERMINAL_LEDGER_STATUSES = frozenset({"done", "absorbed", "dropped"})
+
+# Bound on the pending-escalations read during reconcile. Derived from capacity,
+# not from history: the dedup precheck allows at most ONE escalation per ledger
+# row, so the pending population can never exceed the number of unresolved
+# ledger rows — and the ENTIRE session_ledger table held 181 rows on this
+# install on 2026-09-06 (49 of them unresolved). 1000 is >5x the whole table.
+# `get_by_source` orders created_at DESC, so a saturated read would starve the
+# OLDEST escalations specifically; that is logged loudly rather than left to be
+# discovered, because silent starvation here means a disposed row's follow-up
+# stays pending forever.
+_RECONCILE_READ_LIMIT = 1000
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    """Parse an ISO-8601 stamp to an aware UTC datetime, or None."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _last_touched(row: dict) -> datetime | None:
+    """When the ledger row was last touched — updated_at, else created_at."""
+    return _parse_iso(row.get("updated_at")) or _parse_iso(row.get("created_at"))
+
+
+def _session_last_active(
+    sessions_dir: Path, session_id: str, *, fallback: datetime | None
+) -> tuple[datetime | None, str]:
+    """When the owning session last prompted, and how we know.
+
+    ``~/.genesis/sessions/<sid>/last_prompt_time`` is rewritten on every prompt
+    of every FOREGROUND session (``scripts/genesis_urgent_alerts.py``), so it is
+    the liveness signal — the same file the context-injection watcher reads.
+
+    Content is preferred over mtime, deliberately, and the two normally agree
+    because one ``write_text(now.isoformat())`` sets both. They diverge after a
+    RESTORE from backup, which rewrites every file with a fresh mtime while
+    preserving the recorded instant. Trusting mtime there would make every dead
+    session look live and silence the sweep entirely; content stays correct.
+    mtime remains the fallback for an unparseable file.
+
+    An ABSENT file means no foreground session ever wrote one — the dispatched
+    case, since ``genesis_urgent_alerts`` returns early under
+    ``GENESIS_CC_SESSION=1``. Those sessions are unattended by definition, so we
+    fall back to the row's own age and SAY SO in the follow-up rather than
+    treating "no evidence of life" as evidence of life.
+    """
+    path = sessions_dir / session_id / "last_prompt_time"
+    try:
+        # TWO guards, doing different jobs — stated separately because either
+        # alone keeps the sweep alive, so neither is evidence for the other.
+        #
+        # errors="replace" is the load-bearing one: it stops read_text raising
+        # on a truncated or partially-written file, which keeps the mtime
+        # fallback below REACHABLE. That is a better answer than the absent-file
+        # fallback — the file's real last-write time is evidence we would
+        # otherwise discard. (Pinned by the "mtime" assertion in
+        # test_a_corrupt_liveness_file_does_not_kill_the_sweep.)
+        #
+        # Catching ValueError beside OSError is belt-and-braces for a decode
+        # error that gets past it. With errors="replace" in place I could not
+        # construct an input that reaches it, so treat it as defence against an
+        # unforeseen path, NOT as the thing keeping the sweep alive.
+        #
+        # Why either matters at all: UnicodeDecodeError is a ValueError and NOT
+        # an OSError (verified), so the obvious `except OSError` lets it escape
+        # this function, the candidate loop and run_sweep — and ONE corrupt file
+        # from one unrelated session would then kill the whole sweep, hourly and
+        # permanently, because the file persists. Fail-shut is right for a single
+        # row and badly wrong for the entire population.
+        recorded = _parse_iso(path.read_text(errors="replace"))
+    except (OSError, ValueError):
+        return fallback, "no liveness file — assumed idle since the row was created"
+    if recorded is not None:
+        return recorded, "last_prompt_time"
+    try:
+        return (
+            datetime.fromtimestamp(path.stat().st_mtime, tz=UTC),
+            "last_prompt_time mtime (file contents unparseable)",
+        )
+    except OSError:
+        return fallback, "no liveness file — assumed idle since the row was created"
+
+
+def _age_days(then: datetime | None, now: datetime) -> float | None:
+    if then is None:
+        return None
+    return (now - then).total_seconds() / 86400.0
+
+
+def _render_content(
+    row: dict,
+    *,
+    now: datetime,
+    untouched_days: float,
+    quiet_days: float | None,
+    liveness_source: str,
+    sessions_dir: Path,
+) -> str:
+    """The follow-up body: what the row is, and the decision being asked for.
+
+    PRIVACY / EGRESS CONSTRAINT — read before wiring this anywhere new. The row
+    text is reproduced VERBATIM, which is correct for the surfaces this source
+    reaches today (the follow-up cockpit, ``follow_up_list``) because those are
+    internal and the same text already sits in ``session_ledger``. It is NOT
+    safe to assume for an egress surface: a real row on this install carries
+    plaintext credentials a session pasted into its ledger, and the morning
+    report renders ``content[:200]`` into a TELEGRAM message. ``ledger_escalation``
+    is deliberately absent from that report. Do NOT add it — nor to email, nor to
+    any other external channel — without a redaction pass on this string first.
+    """
+    row_id = row["id"]
+    session_id = row["session_id"]
+    created = row.get("created_at") or "unknown"
+    quiet_phrase = f"quiet {quiet_days:.0f}d" if quiet_days is not None else "quiet (age unknown)"
+    charter = sessions_dir / session_id / "charter.md"
+    return (
+        f"[STALE LEDGER ITEM — undisposed {untouched_days:.0f}d · "
+        f"session {session_id[:8]} · row {row_id[:8]}]\n\n"
+        f"{row['text']}\n\n"
+        f"This row has been open since {created} and its session is "
+        f"{quiet_phrase} ({liveness_source}), so nobody is coming back to "
+        f"dispose of it. It needs a decision, not necessarily work:\n\n"
+        f"  the work landed —\n"
+        f"    session_ledger_update('{row_id}', status='done', "
+        f"evidence='<what closed it>')\n"
+        f"  it was absorbed by other work —\n"
+        f"    session_ledger_update('{row_id}', status='absorbed', "
+        f"evidence='<what absorbed it>')\n"
+        f"  it no longer needs doing —\n"
+        f"    session_ledger_update('{row_id}', status='dropped', "
+        f"evidence='<why>')\n\n"
+        f"WHICH LANE? This sweep cannot tell a dropped user errand from a stale "
+        f"internal dev item — both shapes are really in the ledger — so this "
+        f"follow-up ships unclassified. Set domain=user_world if it is yours, "
+        f"domain=internal if it is Genesis's.\n\n"
+        f"Full charter: {charter}\n"
+        f"Disposing the row auto-completes this follow-up at the next sweep."
+    )
+
+
+async def _reconcile(db: aiosqlite.Connection) -> tuple[int, bool]:
+    """Complete escalations whose ledger row has since been disposed.
+
+    Returns ``(reconciled, failed)``. The second element exists because a
+    reconcile that could not run and a reconcile with nothing to do both return
+    zero, and the caller records job SUCCESS either way — so a permanently dead
+    reverse sync (escalations piling up pending for rows disposed weeks ago)
+    would look identical to a healthy quiet one. This module is otherwise
+    careful to be loud (``ledger_stale_open`` raises rather than truncating; the
+    deferred count is returned rather than inferred), and a silent half-run
+    contradicts that posture.
+
+    Direction matters: the dedup key is a one-way hash, so a follow-up cannot
+    name its own row. We therefore map from the LEDGER side, via ``ledger_all``
+    — the module's existing complete-read seam, already used by
+    ``repo_pulse_worker`` for exactly this "match something against the whole
+    ledger" purpose. It is a keyset walk that RAISES past a tripwire rather than
+    truncating, and the live table is 181 rows.
+    """
+    try:
+        rows = await ledger_all(db)
+    except Exception:
+        logger.exception("ledger escalation: ledger read failed — skipping reconcile")
+        return 0, True
+
+    disposed_keys = {
+        escalation_dedup_key(r["id"]): r
+        for r in rows
+        if r.get("status") in _TERMINAL_LEDGER_STATUSES
+    }
+    if not disposed_keys:
+        return 0, False
+
+    # Every NON-TERMINAL escalation, not just 'pending'. `follow_ups.status`
+    # admits six values; a human who picks an escalation up moves it to
+    # 'in_progress', and 'scheduled'/'blocked' are reachable too. Reconciling
+    # only 'pending' would strand exactly the escalations someone engaged with —
+    # and since `exists_by_dedup_key` spans all statuses, nothing would ever
+    # re-create them, so the row would stay open with no live follow-up.
+    escalations = [
+        fu
+        for fu in await fu_crud.get_by_source(db, ESCALATION_SOURCE, limit=_RECONCILE_READ_LIMIT)
+        if fu.get("status") not in ("completed", "failed")
+    ]
+    if len(escalations) >= _RECONCILE_READ_LIMIT:
+        logger.warning(
+            "ledger escalation: reconcile read hit its %d-row bound; "
+            "get_by_source orders created_at DESC, so the OLDEST escalations "
+            "were not examined this run and may stay pending after their row "
+            "was disposed",
+            _RECONCILE_READ_LIMIT,
+        )
+
+    reconciled = 0
+    for follow_up in escalations:
+        row = disposed_keys.get(follow_up.get("dedup_key") or "")
+        if row is None:
+            continue
+        try:
+            await fu_crud.update_status(
+                db,
+                follow_up["id"],
+                "completed",
+                resolution_notes=(
+                    f"ledger row {row['id'][:8]} disposed: {row['status']}"
+                    + (f" — {row['evidence']}" if row.get("evidence") else "")
+                ),
+            )
+            reconciled += 1
+        except Exception:
+            logger.exception(
+                "ledger escalation: failed to complete follow-up %s",
+                follow_up.get("id"),
+            )
+    if reconciled:
+        logger.info(
+            "Ledger escalation: completed %d follow-up(s) whose row was disposed",
+            reconciled,
+        )
+    return reconciled, False
+
+
+async def run_sweep(
+    db: aiosqlite.Connection,
+    *,
+    now: datetime,
+    sessions_dir: Path,
+    cfg: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Reconcile disposed escalations, then escalate newly-undisposable rows.
+
+    Returns counts plus the ids it DEFERRED, so a capped run reports what it did
+    not reach instead of leaving that to be inferred from a total.
+    """
+    cfg = cfg if cfg is not None else load_config()
+    stale_days = knob_int(cfg, "stale_days")
+    quiet_days = knob_int(cfg, "quiet_days")
+    max_per_run = knob_int(cfg, "max_per_run")
+    allowed_added_by = escalate_added_by(cfg)
+
+    # Normalise to UTC. Both sides of the staleness comparison are ISO strings
+    # compared LEXICOGRAPHICALLY, and every writer stamps UTC
+    # (`session_charters._now_iso`), so a non-UTC `now` would silently compare
+    # local wall-clock against UTC wall-clock and be wrong by the offset with no
+    # error. The one live call site already passes UTC; this makes it true for
+    # every caller on every install, whatever `user_timezone()` is set to.
+    now = now.astimezone(UTC)
+
+    reconciled, reconcile_failed = await _reconcile(db)
+    result: dict[str, Any] = {
+        "reconciled": reconciled,
+        "reconcile_failed": reconcile_failed,
+        "created": 0,
+        "deferred": 0,
+        "deferred_ids": [],
+        "skipped_active": 0,
+    }
+
+    stale_cutoff = (now - timedelta(days=stale_days)).isoformat()
+    quiet_cutoff = now - timedelta(days=quiet_days)
+
+    candidates = await ledger_stale_open(
+        db, untouched_before=stale_cutoff, added_by=allowed_added_by
+    )
+
+    eligible: list[tuple[dict, float, float | None, str]] = []
+    for row in candidates:
+        touched = _last_touched(row)
+        untouched_days = _age_days(touched, now)
+        if untouched_days is None:
+            # Both timestamps unparseable: we cannot say the row is stale, so we
+            # do not act on it. Loud, because a row with no readable created_at
+            # is itself a defect somewhere upstream.
+            logger.warning(
+                "ledger escalation: row %s has no parseable timestamp — skipping",
+                row.get("id"),
+            )
+            continue
+        last_active, liveness_source = _session_last_active(
+            sessions_dir, row["session_id"], fallback=touched
+        )
+        if last_active is not None and last_active > quiet_cutoff:
+            # The owning session is alive. The row is ITS to dispose, and
+            # escalating would take the decision from the one party still able
+            # to make it.
+            result["skipped_active"] += 1
+            continue
+        eligible.append((row, untouched_days, _age_days(last_active, now), liveness_source))
+
+    # FILTER, THEN SLICE — the order is load-bearing and getting it backwards
+    # starves the backlog permanently. The sweep deliberately never writes
+    # session_ledger, so an ALREADY-ESCALATED row keeps its open status and its
+    # old timestamp: it re-qualifies on every run and, under the oldest-first
+    # ordering, sits at the FRONT of `eligible` forever. Slicing first therefore
+    # spends the whole per-run budget on rows that are then skipped by the dedup
+    # check, and rows past the cap are never reached again.
+    # MEASURED on the pre-fix code (8 rows, cap 3): created 3, 0, 0, 0, 0 across
+    # five runs — while logging "they escalate on later runs" every time. The
+    # class is general: any recurring sweep that caps per run AND dedups by a
+    # stable key must filter before it slices.
+    fresh: list[tuple[dict, float, float | None, str]] = []
+    for candidate in eligible:
+        try:
+            if await fu_crud.exists_by_dedup_key(db, escalation_dedup_key(candidate[0]["id"])):
+                continue
+        except Exception:
+            # Cannot tell whether it is already escalated. Skip it rather than
+            # risk a duplicate; the unique index would refuse one anyway, and
+            # the row re-qualifies next run.
+            logger.exception(
+                "ledger escalation: dedup precheck failed for row %s",
+                candidate[0].get("id"),
+            )
+            continue
+        fresh.append(candidate)
+
+    for row, untouched_days, quiet_age, liveness_source in fresh[:max_per_run]:
+        dedup_key = escalation_dedup_key(row["id"])
+        try:
+            await fu_crud.create(
+                db,
+                content=_render_content(
+                    row,
+                    now=now,
+                    untouched_days=untouched_days,
+                    quiet_days=quiet_age,
+                    liveness_source=liveness_source,
+                    sessions_dir=sessions_dir,
+                ),
+                source=ESCALATION_SOURCE,
+                strategy="user_input_needed",
+                reason="ledger item never disposed — no decision recorded",
+                source_session=row["session_id"],
+                priority=priority(cfg),
+                kind="follow_up",
+                # UNCLASSIFIED on purpose. The sweep genuinely cannot tell a
+                # dropped user errand from a stale internal dev item — measured
+                # 2026-09-06, 13 of 15 qualifying rows were internal and 2 were
+                # user-world errands the owner had asked for. `create` documents
+                # None as "not yet classified"; guessing would mislabel exactly
+                # the class this exists to stop losing, so the follow-up asks.
+                domain=None,
+                dedup_key=dedup_key,
+            )
+            result["created"] += 1
+        except aiosqlite.IntegrityError:
+            # The dedup_key partial unique index fired: a concurrent sweep
+            # created this escalation between our precheck and our INSERT. That
+            # is the index doing its job, not a failure — the row IS escalated,
+            # just not by us. Logged at debug, because an ERROR traceback here
+            # would make a working race look like a broken sweep. (Found by
+            # mutation: with the precheck removed this path carries EVERY
+            # duplicate, and it was previously indistinguishable in the logs
+            # from a genuine write failure.)
+            logger.debug(
+                "ledger escalation: row %s already escalated by a concurrent "
+                "sweep — leaving it to that one",
+                row.get("id"),
+            )
+        except Exception:
+            # A real failure. One bad row must not abort the rest of the run.
+            logger.exception("ledger escalation: failed to escalate row %s", row.get("id"))
+
+    deferred = fresh[max_per_run:]
+    if deferred:
+        result["deferred"] = len(deferred)
+        result["deferred_ids"] = [r["id"] for r, _, _, _ in deferred]
+        logger.warning(
+            "Ledger escalation: %d eligible row(s) deferred past the %d-per-run "
+            "cap; they escalate on later runs (oldest first): %s",
+            len(deferred),
+            max_per_run,
+            ", ".join(r["id"][:8] for r, _, _, _ in deferred),
+        )
+    if result["created"]:
+        logger.info(
+            "Ledger escalation: created %d follow-up(s) for undisposed rows",
+            result["created"],
+        )
+    return result

--- a/src/genesis/session_awareness/ledger_escalation.py
+++ b/src/genesis/session_awareness/ledger_escalation.py
@@ -61,6 +61,13 @@ logger = logging.getLogger(__name__)
 # for that disposition is answered and gets completed.
 _TERMINAL_LEDGER_STATUSES = frozenset({"done", "absorbed", "dropped"})
 
+# The follow_ups statuses reconcile must still consider. `follow_ups.status`
+# admits six values (schema/_tables.py); these are the four that are not
+# terminal. Enumerated rather than expressed as "not completed/failed" because
+# the query filters by ONE status at a time — see the reconcile read, where
+# filtering after the bound starved the rows the sweep exists to close.
+_NON_TERMINAL_FOLLOW_UP_STATUSES = ("pending", "scheduled", "in_progress", "blocked")
+
 # Bound on the pending-escalations read during reconcile. Derived from capacity,
 # not from history: the dedup precheck allows at most ONE escalation per ledger
 # row, so the pending population can never exceed the number of unresolved
@@ -246,11 +253,23 @@ async def _reconcile(db: aiosqlite.Connection) -> tuple[int, bool]:
     # only 'pending' would strand exactly the escalations someone engaged with —
     # and since `exists_by_dedup_key` spans all statuses, nothing would ever
     # re-create them, so the row would stay open with no live follow-up.
-    escalations = [
-        fu
-        for fu in await fu_crud.get_by_source(db, ESCALATION_SOURCE, limit=_RECONCILE_READ_LIMIT)
-        if fu.get("status") not in ("completed", "failed")
-    ]
+    # FILTER SERVER-SIDE, THEN BOUND — one status at a time, each with its own
+    # limit. Fetching by source and filtering in Python put the cap BEFORE the
+    # filter: `get_by_source` orders created_at DESC, so once completed
+    # escalations outnumber the bound they fill it entirely and the older PENDING
+    # ones — the only rows reconcile exists to close — are never seen.
+    #
+    # This is the SAME cap-before-filter shape as the forward pass's starvation
+    # bug, recreated forty lines away while fixing it. The lesson generalises:
+    # where a cap and a filter both apply, the filter goes first — and one
+    # instance of a class is never the population.
+    escalations: list[dict] = []
+    for status in _NON_TERMINAL_FOLLOW_UP_STATUSES:
+        escalations.extend(
+            await fu_crud.get_by_source(
+                db, ESCALATION_SOURCE, status=status, limit=_RECONCILE_READ_LIMIT
+            )
+        )
     if len(escalations) >= _RECONCILE_READ_LIMIT:
         logger.warning(
             "ledger escalation: reconcile read hit its %d-row bound; "

--- a/src/genesis/session_awareness/ledger_escalation_config.py
+++ b/src/genesis/session_awareness/ledger_escalation_config.py
@@ -1,0 +1,156 @@
+"""Config lever for the undisposed-ledger escalation sweep (learning scheduler).
+
+Cloned from ``awareness.follow_up_watchdog_config`` — same shape: an ``enabled``
+master switch, positive-int knobs, an alert/priority enum, and an env kill
+switch. The one addition is ``escalate_added_by``, a provenance allow-list (see
+below).
+
+Failure posture: a missing/corrupt config degrades to DEFAULTS; the env kill
+switch ``GENESIS_LEDGER_ESCALATION_DISABLED=1`` forces the sweep off regardless
+of the file. Unlike the watchdog this module's consumer WRITES (it creates
+follow-ups), so every degrade is toward LESS write authority — a damaged knob
+falls back to the default rather than to "unbounded".
+
+Dependency rule: stdlib + yaml + genesis.env + genesis._config_overlay only;
+``genesis.mcp.health.settings`` imports the public ``DEFAULTS`` / ``INT_KNOBS``
+from here (never the reverse).
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from genesis._config_overlay import merge_local_overlay
+from genesis.db.crud.session_charters import VALID_ADDED_BY
+from genesis.env import repo_root
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_NAME = "ledger_escalation.yaml"
+_ENV_KILL_SWITCH = "GENESIS_LEDGER_ESCALATION_DISABLED"
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    # A ledger row must be untouched (updated_at, else created_at) this long
+    # before it can escalate. Any ledger_update bumps updated_at, so a row
+    # someone is still working restarts the clock.
+    "stale_days": 5,
+    # AND the owning session must have been quiet this long. Both thresholds
+    # must pass: a stale row in a LIVE session is that session's to dispose, and
+    # escalating it would take the decision away from the one party still able
+    # to make it. Measured 2026-09-06 on the live ledger: the double threshold
+    # correctly held back 35 of 50 open rows, including four rows 5.9-6.8d
+    # untouched whose session had prompted seconds earlier.
+    "quiet_days": 5,
+    # Escalations CREATED per run. The sweep is hourly, so a backlog drains at
+    # this rate rather than arriving at once; deferred ids are logged and
+    # returned, never silently dropped. Draining depends on the sweep filtering
+    # already-escalated rows BEFORE applying this cap — see the comment at that
+    # loop; the reverse order starves the backlog permanently.
+    # It caps WRITES, not work: every candidate is still stat'd for liveness and
+    # every terminal row still hashed during reconcile, before this applies. Free
+    # at real ledger sizes (181 rows on the install this was built against) and
+    # bounded by the tripwires in `session_charters`, but a ledger orders of
+    # magnitude larger would make the hourly tick expensive regardless of it.
+    "max_per_run": 5,
+    # Priority of the created follow-up.
+    "priority": "high",
+    # Provenance allow-list: which `session_ledger.added_by` values may escalate.
+    # Default is foreground-only ON PURPOSE. `ambient_ledger_extractor` rows are
+    # the detached extractor's PROPOSALS, not agreements a human made, so
+    # escalating them would ask the owner to dispose of something nobody
+    # committed to. The extractor shipped OFF (the ambient-extractor migration,
+    # #1541) and has written 0 live rows here, but the schema CHECK now admits
+    # the value, so this allow-list ships with the sweep rather than after the
+    # first flood. Widen it deliberately if extractor rows ever become
+    # agreements.
+    "escalate_added_by": ["foreground"],
+}
+
+INT_KNOBS = ("stale_days", "quiet_days", "max_per_run")
+_VALID_PRIORITY = ("low", "medium", "high", "critical")
+
+
+def _base_path() -> Path:
+    return repo_root() / "config" / _CONFIG_NAME
+
+
+def load_config() -> dict[str, Any]:
+    """Read the merged config fresh — per call, NO cache.
+
+    Deep-merges (defaults <- base yaml <- .local.yaml overlay). Missing or
+    corrupt files degrade layer-by-layer toward DEFAULTS.
+    """
+    merged = copy.deepcopy(DEFAULTS)
+    base_path = _base_path()
+    base: dict[str, Any] = {}
+    try:
+        loaded = yaml.safe_load(base_path.read_text()) or {}
+        if isinstance(loaded, dict):
+            base = loaded
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("ledger_escalation base config unreadable at %s", base_path)
+    try:
+        base = merge_local_overlay(base, base_path)
+    except Exception:
+        logger.warning("ledger_escalation overlay merge failed", exc_info=True)
+    merged.update(base)
+    return merged
+
+
+def is_enabled() -> bool:
+    """True unless the env kill switch is set or the config disables it."""
+    if os.environ.get(_ENV_KILL_SWITCH) == "1":
+        return False
+    return bool(load_config().get("enabled", True))
+
+
+def knob_int(cfg: dict[str, Any], key: str) -> int:
+    """Positive-int knob with DEFAULTS fallback — config damage never zeroes a
+    limit or crashes the sweep."""
+    value = cfg.get(key)
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        return int(DEFAULTS[key])
+    return value
+
+
+def priority(cfg: dict[str, Any]) -> str:
+    """The configured follow-up priority, falling back on damage."""
+    value = cfg.get("priority")
+    if value in _VALID_PRIORITY:
+        return str(value)
+    return str(DEFAULTS["priority"])
+
+
+def escalate_added_by(cfg: dict[str, Any]) -> frozenset[str]:
+    """The `added_by` values allowed to escalate.
+
+    Damage degrades to the DEFAULT (foreground-only), never to "everything":
+    this gates who may create follow-ups, so a corrupt value must not widen
+    write authority. Unknown values are dropped rather than passed through to
+    the SQL — they can only ever match nothing, and silently querying for a
+    value the schema CHECK forbids would read as "no rows escalate" for a
+    reason no operator could see.
+    """
+    value = cfg.get("escalate_added_by")
+    if not isinstance(value, list) or not value:
+        return frozenset(DEFAULTS["escalate_added_by"])
+    allowed = {v for v in value if isinstance(v, str) and v in VALID_ADDED_BY}
+    if not allowed:
+        logger.warning(
+            "ledger_escalation: escalate_added_by named no valid provenance "
+            "(got %r; valid: %s) — falling back to %s",
+            value,
+            sorted(VALID_ADDED_BY),
+            DEFAULTS["escalate_added_by"],
+        )
+        return frozenset(DEFAULTS["escalate_added_by"])
+    return frozenset(allowed)

--- a/src/genesis/session_awareness/ledger_escalation_link.py
+++ b/src/genesis/session_awareness/ledger_escalation_link.py
@@ -24,12 +24,20 @@ from __future__ import annotations
 
 import hashlib
 
-# GROUNDWORK(ledger-escalation): the WRITER — the sweep that promotes an
-# undisposed ledger row into a follow_ups row — is not built yet. Today the only
-# consumers are the two READ-side hooks, which render "-> escalated: follow_up
-# <id>" beside an open row and correctly degrade to nothing while no such row
-# exists. Landing the formula here first means that sweep is a pure add rather
-# than a change to two import-free hook scripts. Do not delete as dead code.
+# GROUNDWORK(ledger-escalation) — SATISFIED 2026-09-06. The WRITER this note
+# was waiting for now exists: `session_awareness/ledger_escalation.py`, an
+# hourly learning-scheduler sweep that promotes an undisposed ledger row into a
+# follow_ups row and completes it again when the row is disposed. The bet paid
+# off exactly as intended — landing the formula here first made that sweep a
+# pure add, with no change to either import-free hook script.
+#
+# The other three consumers still hold and still constrain any edit here: the
+# two READ-side hooks (`scripts/genesis_session_context.py`,
+# `scripts/genesis_urgent_alerts.py`) inline this same formula because they
+# cannot import Genesis, and a parity test asserts the inlined form equals this
+# one. Change the formula and every existing link silently breaks — the sweep
+# would re-escalate rows that already have a follow-up, and the hooks would stop
+# rendering the link. Do not delete as dead code.
 ESCALATION_SOURCE = "ledger_escalation"
 
 

--- a/tests/test_mcp/test_settings_ledger_escalation.py
+++ b/tests/test_mcp/test_settings_ledger_escalation.py
@@ -1,0 +1,54 @@
+"""ledger_escalation settings validator (undisposed-ledger escalation sweep)."""
+
+from __future__ import annotations
+
+from genesis.mcp.health.settings import _DOMAIN_REGISTRY, _DOMAIN_VALIDATORS
+
+_validate = _DOMAIN_VALIDATORS["ledger_escalation"]
+
+
+def test_domain_registered_with_config_file():
+    dom = _DOMAIN_REGISTRY["ledger_escalation"]
+    assert dom.config_filename == "ledger_escalation.yaml"
+    assert dom.readonly is False
+    assert dom.needs_restart is False
+
+
+def test_valid_changes_pass():
+    assert _validate({"enabled": True}) == []
+    assert _validate({"stale_days": 7, "quiet_days": 3}) == []
+    assert _validate({"max_per_run": 10, "priority": "critical"}) == []
+    assert _validate({"escalate_added_by": ["foreground", "pulse"]}) == []
+
+
+def test_unknown_key_rejected_and_lists_valid():
+    (err,) = _validate({"bogus": 1})
+    assert "Unknown key" in err
+    assert "enabled" in err and "stale_days" in err
+
+
+def test_enabled_must_be_bool():
+    assert _validate({"enabled": "yes"}) != []
+    assert _validate({"enabled": 1}) != []
+
+
+def test_knobs_must_be_positive_int():
+    assert _validate({"max_per_run": 0}) != []
+    assert _validate({"stale_days": -1}) != []
+    assert _validate({"quiet_days": True}) != []  # bool is not a valid int
+    assert _validate({"stale_days": 1.5}) != []
+
+
+def test_priority_must_be_a_known_level():
+    assert _validate({"priority": "urgent"}) != []
+    assert _validate({"priority": "high"}) == []
+
+
+def test_escalate_added_by_must_be_a_non_empty_list_of_known_provenance():
+    """The allow-list gates who may create work for a human, so an unknown
+    value must be REFUSED rather than silently matching nothing."""
+    assert _validate({"escalate_added_by": []}) != []
+    assert _validate({"escalate_added_by": "foreground"}) != []
+    (err,) = _validate({"escalate_added_by": ["foreground", "nonsense"]})
+    assert "nonsense" in err
+    assert "foreground" in err  # the message names what IS valid

--- a/tests/test_session_awareness/test_ledger_escalation.py
+++ b/tests/test_session_awareness/test_ledger_escalation.py
@@ -610,12 +610,90 @@ async def test_escalations_never_reach_the_morning_report(db, sessions_dir):
     await db.execute("UPDATE follow_ups SET domain='user_world' WHERE id=?", (fid,))
     await db.commit()
 
-    from genesis.outreach import morning_report as mr
+    from genesis.outreach.morning_report import MorningReportGenerator
 
-    items = await fu_crud.get_pending(db, strategy="user_input_needed", domain="user_world")
-    survivors = [i for i in items if i.get("source") != mr._LEDGER_ESCALATION_SOURCE]
-    assert survivors == [], "a classified escalation must still be excluded"
-    assert not any("TOKEN-CANARY" in (i["content"] or "") for i in survivors)
+    # Call the REAL renderer. The first version of this test ran the CRUD query
+    # itself and then filtered with a list comprehension IN THE TEST — so it
+    # asserted its own filtering, never the report's, and stayed green with the
+    # exclusion deleted from morning_report.py entirely. Verified by mutation.
+    gen = MorningReportGenerator.__new__(MorningReportGenerator)
+    gen._db = db
+    rendered = await gen._get_follow_ups_summary() or ""
+    assert "TOKEN-CANARY" not in rendered, (
+        "verbatim ledger text reached the report that renders content[:200] to Telegram"
+    )
+
+
+@pytest.mark.parametrize("status", ["failed", "blocked"])
+async def test_no_report_bucket_renders_an_escalation(db, sessions_dir, status):
+    """EVERY bucket, not just the one that prompted the fix.
+
+    `_get_follow_ups_summary` renders three lists from the same `content` field
+    to the same Telegram message — needs-your-input, blocked/failed, and
+    completed-24h. The first fix filtered only the first, so the leak had three
+    doors and one was shut.
+    """
+    from genesis.outreach.morning_report import MorningReportGenerator
+
+    await _mk_row(db, session_id="s1", text="TOKEN-CANARY-xyz", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir)
+    fid = (await _escalations(db))[0]["id"]
+    # The row is classified AND lands in the bucket under test.
+    await db.execute(
+        "UPDATE follow_ups SET domain='user_world', status=? WHERE id=?", (status, fid)
+    )
+    await db.commit()
+
+    gen = MorningReportGenerator.__new__(MorningReportGenerator)
+    gen._db = db
+    assert "TOKEN-CANARY" not in (await gen._get_follow_ups_summary() or "")
+
+
+async def test_reconcile_does_not_starve_older_rows_behind_completed_ones(
+    db, sessions_dir, monkeypatch
+):
+    """The reverse pass must FILTER before it BOUNDS.
+
+    `get_by_source` orders created_at DESC, so fetching by source and filtering
+    non-terminal in Python puts the cap before the filter: once completed
+    escalations outnumber the bound they fill it entirely and the older pending
+    rows — the only ones reconcile exists to close — are never examined. Same
+    class as the forward pass's starvation bug.
+    """
+    monkeypatch.setattr(esc, "_RECONCILE_READ_LIMIT", 3)
+    rows = [await _mk_row(db, session_id="s1", text=f"i{i}", created_days_ago=30) for i in range(5)]
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir, max_per_run=99)
+    assert len(await _escalations(db)) == 5
+
+    # Close every escalation EXCEPT the one belonging to rows[0]. Identify it by
+    # dedup key, not by list position: all five ledger rows share a timestamp, so
+    # the sweep's order does not track the order they were created in.
+    keep = escalation_dedup_key(rows[0])
+    for i, e in enumerate(await _escalations(db)):
+        if e["dedup_key"] == keep:
+            # Make the surviving PENDING row unambiguously the OLDEST. The five
+            # follow-ups are created microseconds apart, and `get_by_source`
+            # orders created_at DESC — without an explicit spread the row under
+            # test lands inside the bound by luck and the test proves nothing
+            # (measured: it stayed green with the filter back after the bound).
+            await db.execute(
+                "UPDATE follow_ups SET created_at=? WHERE id=?",
+                ((NOW - timedelta(days=99)).isoformat(), e["id"]),
+            )
+        else:
+            await db.execute(
+                "UPDATE follow_ups SET created_at=? WHERE id=?",
+                ((NOW - timedelta(days=i)).isoformat(), e["id"]),
+            )
+            await fu_crud.update_status(db, e["id"], "completed")
+    await db.commit()
+    await sc_crud.ledger_update(db, rows[0], status="done", evidence="landed")
+
+    # With the cap before the filter, the 3-row bound is consumed by completed
+    # rows and this reconcile finds nothing.
+    assert (await _sweep(db, sessions_dir))["reconciled"] == 1
 
 
 # ------------------------------------------------------------- empty state

--- a/tests/test_session_awareness/test_ledger_escalation.py
+++ b/tests/test_session_awareness/test_ledger_escalation.py
@@ -1,0 +1,634 @@
+"""Tests for the undisposed-ledger escalation sweep.
+
+Under test is the ESCALATION DECISION and its reverse sync: which unresolved
+ledger rows become `user_input_needed` follow-ups once their owning session can
+no longer be asked to dispose of them, and which are correctly left alone.
+
+The acceptance cell is `test_acceptance_replays_the_measured_live_shape`, which
+reconstructs the real 2026-09-06 live state (a 15-day-old user-world errand in a
+long-dead session) rather than a stylised approximation.
+
+Fixtures are synthetic throughout — no real session ids, paths or row text.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from genesis.db.crud import follow_ups as fu_crud
+from genesis.db.crud import session_charters as sc_crud
+from genesis.db.schema import create_all_tables
+from genesis.session_awareness import ledger_escalation as esc
+from genesis.session_awareness.ledger_escalation_link import (
+    ESCALATION_SOURCE,
+    escalation_dedup_key,
+)
+
+pytestmark = pytest.mark.asyncio
+
+NOW = datetime(2026, 9, 6, 12, 0, 0, tzinfo=UTC)
+
+# The sweep's own defaults, restated so a test reads independently of the yaml.
+CFG = {
+    "enabled": True,
+    "stale_days": 5,
+    "quiet_days": 5,
+    "max_per_run": 5,
+    "priority": "high",
+    "escalate_added_by": ["foreground"],
+}
+
+
+@pytest.fixture
+async def db():
+    conn = await aiosqlite.connect(":memory:")
+    conn.row_factory = aiosqlite.Row
+    await create_all_tables(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.fixture
+def sessions_dir(tmp_path) -> Path:
+    d = tmp_path / "sessions"
+    d.mkdir()
+    return d
+
+
+async def _mk_row(
+    db,
+    *,
+    session_id: str = "sess-aaaa",
+    text: str = "a thing we agreed to do",
+    added_by: str = "foreground",
+    created_days_ago: float = 30,
+    updated_days_ago: float | None = None,
+    status: str = "open",
+) -> str:
+    """A ledger row with back-dated timestamps (raw UPDATE — ledger_add stamps now)."""
+    item_id = await sc_crud.ledger_add(db, session_id=session_id, text=text, added_by=added_by)
+    created = (NOW - timedelta(days=created_days_ago)).isoformat()
+    updated = (
+        (NOW - timedelta(days=updated_days_ago)).isoformat()
+        if updated_days_ago is not None
+        else None
+    )
+    await db.execute(
+        "UPDATE session_ledger SET created_at=?, updated_at=?, status=? WHERE id=?",
+        (created, updated, status, item_id),
+    )
+    await db.commit()
+    return item_id
+
+
+def _mk_liveness(sessions_dir: Path, session_id: str, *, days_ago: float) -> Path:
+    """A last_prompt_time file recording a prompt `days_ago` days back."""
+    d = sessions_dir / session_id
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "last_prompt_time"
+    f.write_text((NOW - timedelta(days=days_ago)).isoformat())
+    return f
+
+
+async def _escalations(db) -> list[dict]:
+    cur = await db.execute(
+        "SELECT * FROM follow_ups WHERE source = ? ORDER BY created_at", (ESCALATION_SOURCE,)
+    )
+    return [dict(r) for r in await cur.fetchall()]
+
+
+async def _sweep(db, sessions_dir, **overrides):
+    cfg = {**CFG, **overrides}
+    return await esc.run_sweep(db, now=NOW, sessions_dir=sessions_dir, cfg=cfg)
+
+
+# ---------------------------------------------------------------- acceptance
+
+
+async def test_acceptance_replays_the_measured_live_shape(db, sessions_dir):
+    """The real defect: a user-requested errand invisible for 15 days.
+
+    Reconstructed from the live ledger read on 2026-09-06 — a row untouched 15
+    days whose owning session last prompted 11.7 days ago. Nothing else on the
+    box surfaces it: it is not repo work, not a follow-up, and its session is
+    dead so the injection that named it never renders again.
+    """
+    row_id = await _mk_row(
+        db,
+        session_id="sess-dead",
+        text="NEXT TASK (user-requested): diagnose the failing network share mount",
+        created_days_ago=15,
+    )
+    _mk_liveness(sessions_dir, "sess-dead", days_ago=11.7)
+
+    result = await _sweep(db, sessions_dir)
+
+    assert result["created"] == 1
+    rows = await _escalations(db)
+    assert len(rows) == 1
+    assert rows[0]["dedup_key"] == escalation_dedup_key(row_id)
+    assert rows[0]["strategy"] == "user_input_needed"
+    assert "network share mount" in rows[0]["content"]
+
+
+# ------------------------------------------------------- the double threshold
+
+
+async def test_stale_row_in_a_QUIET_session_escalates(db, sessions_dir):
+    await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    assert (await _sweep(db, sessions_dir))["created"] == 1
+
+
+async def test_stale_row_in_an_ACTIVE_session_is_left_alone(db, sessions_dir):
+    """The row is that session's to dispose — escalating takes the decision
+    away from the one party still able to make it."""
+    await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=0.01)
+    result = await _sweep(db, sessions_dir)
+    assert result["created"] == 0
+    assert result["skipped_active"] == 1
+    assert await _escalations(db) == []
+
+
+async def test_fresh_row_in_a_quiet_session_is_left_alone(db, sessions_dir):
+    await _mk_row(db, session_id="s1", created_days_ago=1)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    assert (await _sweep(db, sessions_dir))["created"] == 0
+
+
+async def test_updated_at_restarts_the_staleness_clock(db, sessions_dir):
+    """Any ledger_update bumps updated_at — a row someone is working never qualifies."""
+    await _mk_row(db, session_id="s1", created_days_ago=30, updated_days_ago=1)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    assert (await _sweep(db, sessions_dir))["created"] == 0
+
+
+# ------------------------------------------------------------ liveness signal
+
+
+async def test_absent_liveness_file_counts_as_quiet_and_says_so(db, sessions_dir):
+    """Dispatched sessions write no last_prompt_time; they are unattended by
+    definition, so the row's own age governs — and the follow-up states that."""
+    await _mk_row(db, session_id="dispatched", created_days_ago=30)
+    result = await _sweep(db, sessions_dir)
+    assert result["created"] == 1
+    assert "no liveness file" in (await _escalations(db))[0]["content"]
+
+
+async def test_content_is_preferred_over_mtime(db, sessions_dir):
+    """A restore from backup rewrites every file with a FRESH mtime while
+    preserving the recorded instant. Trusting mtime would make every dead
+    session look live and silence the sweep entirely."""
+    await _mk_row(db, session_id="s1", created_days_ago=30)
+    f = _mk_liveness(sessions_dir, "s1", days_ago=30)
+    import os
+    import time
+
+    os.utime(f, (time.time(), time.time()))  # simulate the restore: mtime = now
+
+    assert (await _sweep(db, sessions_dir))["created"] == 1, (
+        "mtime said 'live', content said 'quiet 30d' — content must win"
+    )
+
+
+async def test_unparseable_liveness_falls_back_to_mtime(db, sessions_dir):
+    await _mk_row(db, session_id="s1", created_days_ago=30)
+    d = sessions_dir / "s1"
+    d.mkdir(parents=True)
+    f = d / "last_prompt_time"
+    f.write_text("not a timestamp")
+    import os
+
+    old = (NOW - timedelta(days=30)).timestamp()
+    os.utime(f, (old, old))
+
+    result = await _sweep(db, sessions_dir)
+    assert result["created"] == 1
+    assert "mtime" in (await _escalations(db))[0]["content"]
+
+
+async def test_row_with_unparseable_timestamps_is_skipped_not_escalated(db, sessions_dir, caplog):
+    """The value must sort BELOW the cutoff to reach the Python skip branch.
+
+    `ledger_stale_open` compares timestamps as STRINGS. A value like 'garbage'
+    sorts ABOVE an ISO cutoff ('g' > '2'), so SQL filters it out and the branch
+    under test is never entered — the test would then pass identically with that
+    branch deleted. '' sorts below everything and does reach it.
+    """
+    item_id = await _mk_row(db, session_id="s1", created_days_ago=30)
+    await db.execute(
+        "UPDATE session_ledger SET created_at='', updated_at=NULL WHERE id=?",
+        (item_id,),
+    )
+    await db.commit()
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+
+    with caplog.at_level("WARNING", logger=esc.logger.name):
+        assert (await _sweep(db, sessions_dir))["created"] == 0
+    assert "no parseable timestamp" in caplog.text
+
+
+async def test_a_corrupt_liveness_file_does_not_kill_the_sweep(db, sessions_dir):
+    """UnicodeDecodeError is a ValueError, NOT an OSError. Uncaught it escapes
+    run_sweep entirely, so ONE unrelated session's truncated state file would
+    stop every escalation and every reconcile, hourly, forever."""
+    await _mk_row(db, session_id="corrupt", created_days_ago=30)
+    await _mk_row(db, session_id="healthy", created_days_ago=30)
+    import os
+
+    d = sessions_dir / "corrupt"
+    d.mkdir(parents=True)
+    f = d / "last_prompt_time"
+    f.write_bytes(b"\xff\xfe\x00truncated")
+    # Back-date the mtime: with errors="replace" the unparseable CONTENT falls
+    # through to the mtime branch, so a file written just now would read as a
+    # live session and be held back for the right reason — masking whether the
+    # sweep survived the decode at all.
+    old = (NOW - timedelta(days=30)).timestamp()
+    os.utime(f, (old, old))
+    _mk_liveness(sessions_dir, "healthy", days_ago=30)
+
+    result = await _sweep(db, sessions_dir)
+    assert result["created"] == 2, "the healthy session must not be collateral"
+
+    # Two INDEPENDENT guards cover the decode, and the survival assertion above
+    # is satisfied by either alone (mutation-verified), so it pins neither:
+    #   * errors="replace" stops read_text raising at all, which keeps the MTIME
+    #     fallback reachable — a partially-corrupt file still yields its real
+    #     last-write time instead of being written off as absent;
+    #   * except ValueError catches a decode error that slips past it.
+    # This is the assertion that separates them: only errors="replace" produces
+    # the mtime attribution. Without it the row still escalates, but for the
+    # WRONG reason ("no liveness file"), discarding evidence we had.
+    corrupt_row = next(e for e in await _escalations(db) if e["source_session"] == "corrupt")
+    assert "mtime" in corrupt_row["content"], (
+        "a decodable-with-replacement file must fall back to mtime, not be "
+        "treated as if no liveness file existed"
+    )
+
+
+# --------------------------------------------------------------- row scoping
+
+
+async def test_in_progress_rows_are_escalatable(db, sessions_dir):
+    """in_progress means someone started and never finished — exactly the state
+    worth escalating, not an exemption from it."""
+    await _mk_row(db, session_id="s1", created_days_ago=30, status="in_progress")
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    assert (await _sweep(db, sessions_dir))["created"] == 1
+
+
+@pytest.mark.parametrize("status", ["done", "absorbed", "dropped"])
+async def test_disposed_rows_are_never_escalated(db, sessions_dir, status):
+    await _mk_row(db, session_id="s1", created_days_ago=30, status=status)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    assert (await _sweep(db, sessions_dir))["created"] == 0
+
+
+async def test_ambient_extractor_rows_are_excluded_by_default(db, sessions_dir):
+    """Extractor rows are PROPOSALS, not agreements a human made — asking the
+    owner to dispose of something nobody committed to is noise."""
+    await _mk_row(db, session_id="s1", created_days_ago=30, added_by="ambient_ledger_extractor")
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    assert (await _sweep(db, sessions_dir))["created"] == 0
+
+
+async def test_allow_list_can_be_widened_deliberately(db, sessions_dir):
+    await _mk_row(db, session_id="s1", created_days_ago=30, added_by="ambient_ledger_extractor")
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    result = await _sweep(
+        db, sessions_dir, escalate_added_by=["foreground", "ambient_ledger_extractor"]
+    )
+    assert result["created"] == 1
+
+
+# ------------------------------------------------------------- cap & ordering
+
+
+async def test_cap_takes_the_oldest_and_reports_the_deferred(db, sessions_dir):
+    ids = []
+    for i in range(8):
+        ids.append(await _mk_row(db, session_id="s1", text=f"item {i}", created_days_ago=30 - i))
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+
+    result = await _sweep(db, sessions_dir, max_per_run=3)
+
+    assert result["created"] == 3
+    assert result["deferred"] == 5
+    assert len(result["deferred_ids"]) == 5
+    created_keys = {r["dedup_key"] for r in await _escalations(db)}
+    # Oldest three (created_days_ago 30, 29, 28) escalate; the rest are deferred.
+    assert created_keys == {escalation_dedup_key(i) for i in ids[:3]}
+    assert set(result["deferred_ids"]) == set(ids[3:])
+
+
+async def test_the_backlog_drains_across_runs(db, sessions_dir):
+    """The regression test for a starvation bug a single-run test cannot see.
+
+    The sweep deliberately never writes session_ledger, so an already-escalated
+    row keeps its open status and old timestamp: it re-qualifies every run and,
+    under oldest-first ordering, sits at the FRONT of the candidate list. If the
+    per-run cap were applied BEFORE the dedup filter, those rows would consume
+    the entire budget forever and rows past the cap would never escalate.
+
+    MEASURED on the pre-fix code: created 3, 0, 0, 0, 0 across five runs, while
+    logging "they escalate on later runs" every time. Note that the shape which
+    camouflages it — a re-run creating nothing — is ALSO what correct idempotency
+    looks like on a single row, which is why only a multi-run, multi-row probe
+    discriminates.
+    """
+    for i in range(8):
+        await _mk_row(db, session_id="s1", text=f"item {i}", created_days_ago=30 - i)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+
+    assert (await _sweep(db, sessions_dir, max_per_run=3))["created"] == 3
+    assert (await _sweep(db, sessions_dir, max_per_run=3))["created"] == 3
+    assert (await _sweep(db, sessions_dir, max_per_run=3))["created"] == 2
+    assert (await _sweep(db, sessions_dir, max_per_run=3))["created"] == 0
+    assert len(await _escalations(db)) == 8, "every eligible row escalates eventually"
+
+
+async def test_deferred_counts_only_rows_not_yet_escalated(db, sessions_dir):
+    """`deferred` must mean 'still owed', not 'seen this run' — otherwise the
+    warning keeps naming rows that were escalated hours ago."""
+    for i in range(5):
+        await _mk_row(db, session_id="s1", text=f"item {i}", created_days_ago=30 - i)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+
+    first = await _sweep(db, sessions_dir, max_per_run=2)
+    assert first["created"] == 2 and first["deferred"] == 3
+    second = await _sweep(db, sessions_dir, max_per_run=2)
+    assert second["created"] == 2 and second["deferred"] == 1
+    third = await _sweep(db, sessions_dir, max_per_run=2)
+    assert third["created"] == 1 and third["deferred"] == 0
+
+
+async def test_second_run_is_idempotent(db, sessions_dir):
+    await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    assert (await _sweep(db, sessions_dir))["created"] == 1
+    assert (await _sweep(db, sessions_dir))["created"] == 0
+    assert len(await _escalations(db)) == 1
+
+
+# ------------------------------------------------------------ follow-up shape
+
+
+async def test_follow_up_shape_is_unclassified_and_asks_for_a_disposition(db, sessions_dir):
+    row_id = await _mk_row(db, session_id="sess-xyz", text="build the widget", created_days_ago=30)
+    _mk_liveness(sessions_dir, "sess-xyz", days_ago=30)
+    await _sweep(db, sessions_dir)
+
+    fu = (await _escalations(db))[0]
+    assert fu["source"] == ESCALATION_SOURCE
+    assert fu["strategy"] == "user_input_needed"
+    assert fu["kind"] == "follow_up"
+    assert fu["status"] == "pending"
+    assert fu["priority"] == "high"
+    assert fu["source_session"] == "sess-xyz"
+    # UNCLASSIFIED: the sweep cannot tell a user errand from an internal item.
+    assert fu["domain"] is None
+
+    content = fu["content"]
+    assert "build the widget" in content
+    assert row_id in content, "the FULL id — session_ledger_update needs it"
+    for exit_status in ("done", "absorbed", "dropped"):
+        assert f"status='{exit_status}'" in content
+    assert "charter.md" in content
+    assert "WHICH LANE?" in content
+
+
+async def test_the_sweep_never_writes_session_ledger(db, sessions_dir):
+    """An evidence write would bump updated_at and read as a disposition the
+    owner never made."""
+    await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+
+    async def snapshot():
+        cur = await db.execute("SELECT * FROM session_ledger ORDER BY id")
+        return [dict(r) for r in await cur.fetchall()]
+
+    before = await snapshot()
+    await _sweep(db, sessions_dir)
+    assert await snapshot() == before
+
+
+async def test_dedup_key_matches_the_shared_helper(db, sessions_dir):
+    """The link is the dedup_key; the two import-free hooks inline the same
+    formula. A divergence here silently unlinks every row."""
+    row_id = await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir)
+    assert (await _escalations(db))[0]["dedup_key"] == escalation_dedup_key(row_id)
+
+
+# ------------------------------------------------------------- reverse sync
+
+
+async def test_disposing_the_row_completes_its_follow_up(db, sessions_dir):
+    row_id = await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir)
+    assert (await _escalations(db))[0]["status"] == "pending"
+
+    await sc_crud.ledger_update(db, row_id, status="done", evidence="shipped in #123")
+
+    result = await _sweep(db, sessions_dir)
+    assert result["reconciled"] == 1
+    fu = (await _escalations(db))[0]
+    assert fu["status"] == "completed"
+    assert "shipped in #123" in (fu["resolution_notes"] or "")
+
+
+async def test_one_run_both_reconciles_and_escalates(db, sessions_dir):
+    """Both halves do their work in a single run, under a cap that admits one
+    creation.
+
+    NOT an ordering test, deliberately. A disposed row is excluded from
+    `ledger_stale_open` by its status filter, so the two passes operate on
+    DISJOINT row sets and the order between them cannot change any result —
+    verified by mutation (moving reconcile after the forward pass leaves every
+    assertion green). The passes are ordered reconcile-first only so a run's log
+    reads chronologically; nothing depends on it.
+    """
+    disposed = await _mk_row(db, session_id="s1", text="old", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir, max_per_run=1)
+    await sc_crud.ledger_update(db, disposed, status="dropped", evidence="not needed")
+
+    await _mk_row(db, session_id="s1", text="new", created_days_ago=29)
+    result = await _sweep(db, sessions_dir, max_per_run=1)
+
+    assert result["reconciled"] == 1
+    assert result["created"] == 1
+
+
+# --------------------------------------------------- the two dedup layers
+# Idempotency is held by TWO independent mechanisms: our precheck, and the
+# `idx_follow_ups_dedup` partial unique index. `test_second_run_is_idempotent`
+# pins the OUTCOME and passes with either one alone (proved by mutation: the
+# precheck can be deleted and it stays green). These two cells separate them.
+
+
+async def test_the_precheck_short_circuits_before_the_insert(db, sessions_dir, caplog):
+    """The precheck is what makes a re-run silent; the unique index is the
+    backstop. If only the index were doing the work, the second run would emit
+    a duplicate-key failure instead of skipping quietly."""
+    await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir)
+
+    caplog.clear()
+    with caplog.at_level("DEBUG", logger=esc.logger.name):
+        result = await _sweep(db, sessions_dir)
+
+    assert result["created"] == 0
+    assert not [r for r in caplog.records if r.levelname in ("ERROR", "WARNING")], (
+        "a re-run must skip via the precheck, not fall through to the index"
+    )
+    assert "already escalated by a concurrent sweep" not in caplog.text
+
+
+async def test_a_lost_race_is_absorbed_quietly_not_logged_as_a_failure(
+    db, sessions_dir, caplog, monkeypatch
+):
+    """Simulate the TOCTOU window: the precheck says 'absent', another sweep
+    inserts first, our INSERT hits the unique index. That is the index working,
+    not a broken sweep, so it must not produce an ERROR traceback."""
+    await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir)  # the "other sweep" wins
+
+    async def _blind(*_a, **_k):
+        return False
+
+    monkeypatch.setattr(esc.fu_crud, "exists_by_dedup_key", _blind)
+
+    caplog.clear()
+    with caplog.at_level("DEBUG", logger=esc.logger.name):
+        result = await _sweep(db, sessions_dir)
+
+    assert result["created"] == 0
+    assert len(await _escalations(db)) == 1
+    assert "already escalated by a concurrent sweep" in caplog.text
+    assert not [r for r in caplog.records if r.levelname == "ERROR"], (
+        "a lost race is the index doing its job — never an ERROR"
+    )
+
+
+async def test_reconcile_ignores_a_still_open_row(db, sessions_dir):
+    await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir)
+    result = await _sweep(db, sessions_dir)
+    assert result["reconciled"] == 0
+    assert (await _escalations(db))[0]["status"] == "pending"
+
+
+async def test_reconcile_leaves_other_sources_alone(db, sessions_dir):
+    """A pending follow-up from another source must never be completed here."""
+    other = await fu_crud.create(
+        db,
+        content="unrelated",
+        source="inbox",
+        strategy="user_input_needed",
+        dedup_key="some-other-key",
+    )
+    row_id = await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir)
+    await sc_crud.ledger_update(db, row_id, status="done")
+    await _sweep(db, sessions_dir)
+
+    row = await fu_crud.get_by_id(db, other)
+    assert row["status"] == "pending"
+
+
+@pytest.mark.parametrize("status", ["in_progress", "scheduled", "blocked"])
+async def test_reconcile_closes_escalations_a_human_picked_up(db, sessions_dir, status):
+    """Every NON-TERMINAL status, not just 'pending'.
+
+    Picking an escalation up moves it to in_progress. Reconciling only 'pending'
+    would strand exactly the ones someone engaged with — and since the dedup key
+    spans all statuses, nothing would ever re-create them.
+    """
+    row_id = await _mk_row(db, session_id="s1", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir)
+    fid = (await _escalations(db))[0]["id"]
+    await db.execute("UPDATE follow_ups SET status=? WHERE id=?", (status, fid))
+    await db.commit()
+
+    await sc_crud.ledger_update(db, row_id, status="done", evidence="landed")
+
+    assert (await _sweep(db, sessions_dir))["reconciled"] == 1
+    assert (await _escalations(db))[0]["status"] == "completed"
+
+
+async def test_a_failed_reconcile_is_reported_not_swallowed(db, sessions_dir, monkeypatch):
+    """A reconcile that COULD NOT RUN and one with NOTHING TO DO both return
+    zero. Without the flag the caller records success either way, so a
+    permanently dead reverse sync hides behind a green job-health tile."""
+
+    async def _boom(*_a, **_k):
+        raise RuntimeError("ledger read exploded")
+
+    monkeypatch.setattr(esc, "ledger_all", _boom)
+    result = await _sweep(db, sessions_dir)
+    assert result["reconcile_failed"] is True
+    assert result["reconciled"] == 0
+
+
+async def test_a_healthy_run_does_not_flag_reconcile_failure(db, sessions_dir):
+    assert (await _sweep(db, sessions_dir))["reconcile_failed"] is False
+
+
+# ------------------------------------------------------------------ egress
+
+
+async def test_escalations_never_reach_the_morning_report(db, sessions_dir):
+    """The privacy guarantee must hold STRUCTURALLY, not by domain accident.
+
+    Follow-up content reproduces ledger row text verbatim and the report renders
+    content[:200] into Telegram. Rows ship domain=None, which the report's
+    exact-match user_world filter already excludes — but the follow-up's own body
+    asks the reader to classify it, and choosing user_world would otherwise put
+    unredacted ledger text on the wire. A guarantee that holds only until someone
+    answers a question the feature itself poses is not a guarantee.
+    """
+    await _mk_row(db, session_id="s1", text="TOKEN-CANARY-xyz in the row", created_days_ago=30)
+    _mk_liveness(sessions_dir, "s1", days_ago=30)
+    await _sweep(db, sessions_dir)
+
+    fid = (await _escalations(db))[0]["id"]
+    # The user does exactly what the follow-up tells them to do.
+    await db.execute("UPDATE follow_ups SET domain='user_world' WHERE id=?", (fid,))
+    await db.commit()
+
+    from genesis.outreach import morning_report as mr
+
+    items = await fu_crud.get_pending(db, strategy="user_input_needed", domain="user_world")
+    survivors = [i for i in items if i.get("source") != mr._LEDGER_ESCALATION_SOURCE]
+    assert survivors == [], "a classified escalation must still be excluded"
+    assert not any("TOKEN-CANARY" in (i["content"] or "") for i in survivors)
+
+
+# ------------------------------------------------------------- empty state
+
+
+async def test_a_fresh_install_is_silent(db, sessions_dir, tmp_path):
+    """State zero: empty tables, and a sessions dir that does not exist."""
+    absent = tmp_path / "no-such-dir"
+    assert await _sweep(db, absent) == {
+        "reconciled": 0,
+        "reconcile_failed": False,
+        "created": 0,
+        "deferred": 0,
+        "deferred_ids": [],
+        "skipped_active": 0,
+    }


### PR DESCRIPTION
## The gap

A `session_ledger` row is rendered by its own session's context injection and by nothing else. When a session ends with rows still open, its agreements stop being visible to any process or any person — not deleted, just unreachable. CLAUDE.md already states the rule ("every open row is either getting done or gets a disposition; a row left undisposed is a defect, not a backlog"); nothing enforced it once the owning session was gone.

The repo-pulse worker already closes a ledger row whose work landed in a cited PR. This is the other half: the row whose work never landed, and whose session died.

**Measured on a live ledger before building:** 50 rows open, 15 qualifying at 5d/5d, oldest untouched 52 days. Reading them showed they are not one kind of thing — several record their own completion and were simply never closed, several are real unbuilt work, and some were user-facing requests rather than internal work. That last class is the acceptance case: nothing else surfaces it, because it is not repo work, not a follow-up, and its session is gone.

## What it does

An hourly learning-scheduler sweep (`:17`) escalates a row untouched ≥ `stale_days` whose owning session has been quiet ≥ `quiet_days` into a `user_input_needed` follow-up. **Both** thresholds are load-bearing: a stale row in a LIVE session is that session's to dispose, and escalating it would take the decision from the one party still able to make it. Reverse sync completes the follow-up once the row reaches a terminal status.

It lives in the learning scheduler rather than the awareness loop because it MUTATES — the awareness `_check_*` family is documented read-and-alert only.

**It never writes `session_ledger`.** An evidence write would bump `updated_at` and read as a disposition the owner never made — the sweep answering its own question.

## Three decisions worth stating

**Follow-ups ship with `domain` unset.** The sweep genuinely cannot tell a dropped user errand from a stale internal dev item, and both shapes are really in the ledger. `follow_ups.create` documents `None` as "not yet classified"; guessing would mislabel exactly the class this exists to stop losing, so the follow-up asks instead.

**Escalations are excluded from the morning report at the report itself**, not by relying on that unset domain. The content reproduces ledger row text verbatim; real rows carry whatever a session pasted into them, and the report renders `content[:200]` into a Telegram message. A guarantee that holds only until someone answers the classification question the follow-up itself poses is not a guarantee, so the exclusion is enforced where the egress is.

**`escalate_added_by` is a provenance allow-list, foreground-only by default.** `ambient_ledger_extractor` rows are the detached extractor's *proposals*, not agreements a human made; asking the owner to dispose of something nobody committed to is noise. The extractor shipped off, but the schema CHECK now admits the value, so the allow-list ships with the sweep rather than after the first flood.

## Reuse rather than new machinery

- The dedup-key formula already shipped as GROUNDWORK whose note named this sweep as its missing writer — that note is now marked satisfied (updated, not deleted).
- Reverse sync maps from the ledger side via `ledger_all`, the existing complete-read seam `repo_pulse_worker` uses for the same "match against the whole ledger" purpose.
- Config module and scheduler registration are clones of `follow_up_watchdog_config` and `_inbox_marker_decay_sweep`.
- **No dashboard change:** the follow-ups cockpit already renders `Source:` per row and builds its source filter from `get_distinct_sources`, so these appear with zero code. Per-source badges would not generalize to other installs' sources.
- **No `follow_up_list` change:** it returns raw dicts where `source` is already the discriminator.

## Review

Internal adversarial review (genesis-architect, fresh context, unanchored) returned 2 BLOCKER + 4 SHOULD-FIX + 5 NOTE. Every load-bearing claim was re-derived against ground truth before fixing; both BLOCKERs reproduced by independent measurement.

**BLOCKER 1 — the per-run cap was applied before the dedup check, so the backlog never drained.** Because the sweep never writes `session_ledger`, an escalated row keeps its open status and old timestamp, re-qualifies every run, and under oldest-first ordering sits at the front forever. Measured on the pre-fix code (8 rows, cap 3): `created = 3, 0, 0, 0, 0` across five runs, while logging "they escalate on later runs" every time. On the measured install that meant 5 of 15 escalate and ten stay invisible permanently. Fixed by filtering before slicing; post-fix `3, 3, 2, 0` → all 8. A mutation cell reproducing the exact bug now goes RED.

The failure is worth naming because a single-run test cannot see it: `re-run → 0 created` is what correct idempotency looks like *and* what starvation looks like. Only a multi-run, multi-row probe distinguishes them.

**BLOCKER 2 — the privacy invariant was enforced by nothing.** It held only because rows ship `domain=None` and the report filters `domain="user_world"` by exact match. Verified with a seeded canary: after following the follow-up's own "set domain=user_world" instruction, the row entered the report and the canary appeared in `content[:200]`. Fixed with a source-based exclusion at the report, constant imported rather than duplicated.

Also fixed: `UnicodeDecodeError` is a `ValueError`, not an `OSError`, so one corrupt `last_prompt_time` file would have killed every sweep hourly and permanently; reverse sync now covers every non-terminal follow-up status rather than only `pending`; a failed reconcile now records job failure instead of reporting success; one test was verified vacuous (`'garbage'` sorts above an ISO cutoff, so SQL filtered it before the branch under test) and rewritten.

## Verification

- **Acceptance bar** — replayed real ledger state into a throwaway DB against the real sessions directory: reproduces the same 15 rows a manual query found, same ids and ages; holds back the 11 whose sessions are alive; `session_ledger` byte-identical before and after; drains `[5, 5, 5, 0]` under the shipped cap, then quiesces.
- **Mutation verify-RED** — 11 cells covering every behaviour the review found unpinned; all RED. Harness proves each mutation applied by anchor count, validates with `compile()`, restores hash-gated, and aborts on a no-result run.
- Two overlapping guards were found redundant by mutation (either alone passed the outcome assertion) and are now separately pinned.
- 116 targeted tests; ruff clean; four local CI guards clean.
- **Empty state** — fresh install with empty tables and no sessions directory: silent, no crash.
- **Retention** — nothing new needed; `purge_completed` already reaps the completed rows reverse sync produces at 30d, and pending escalations are bounded by the ledger via dedup.

## Deploy

Runtime code and config only: `git pull` + `systemctl --user restart genesis-server`. The job registers at boot; the learning scheduler is confirmed live in the running server. No migration, no new unit, no host action. Levers: `ledger_escalation` settings domain, or `GENESIS_LEDGER_ESCALATION_DISABLED=1`.

**Expected first run after deploy:** five escalations, then five more each hour until the backlog clears. That is the mechanism working, not a fault.

## One thing deliberately not done

`CURRENT.md`'s `ambient-cognition` stamp is **not** bumped. #1787 is open and already bumps that exact stamp, so a second bump would conflict — and this adds a paragraph rather than re-verifying the whole entry, so bumping would assert a verification that was not performed.

Ledger: f4f261fa46bd4dae9aa21882f38c5705


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an hourly sweep for stale ledger items from inactive sessions.
  * Creates high-priority follow-ups for eligible items, with duplicate prevention and per-run limits.
  * Automatically reconciles follow-ups when ledger items are completed, absorbed, or dropped.
  * Added configurable thresholds, priorities, provenance filters, and an environment-level disable switch.
* **Bug Fixes**
  * Prevented ledger-generated follow-ups from appearing in any morning report category.
* **Reliability**
  * Added safeguards for malformed data, concurrent processing, configuration errors, and unavailable ledger data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->