### PR TITLE
feat(ci): catch a test that stops running, on both axes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,4 +584,10 @@ jobs:
         # would kill pytest mid-suite, leave no report, and the step would
         # refuse with a cause that is not the cause.
         if: ${{ !cancelled() }}
-        run: python scripts/check_skip_ceiling.py junit.xml
+        # Baseline MEASURED on this PR's own green run (job 101515129147, head
+        # bbd11ad1): "95 skipped of 23164 collected". Exact-fit on both axes, not
+        # a padded guess — headroom would be a number nobody measured, and the
+        # whole point of shipping report-only first was to avoid inventing one.
+        # Raising either bound is a deliberate act that belongs in the same commit
+        # as the change that moves it; both failure messages say so.
+        run: python scripts/check_skip_ceiling.py junit.xml --ceiling 95 --min-collected 23164

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,10 +559,29 @@ jobs:
           pip install -e ".[test]"
       - name: Run tests
         run: |
+          # Never measure a stale report: if pytest dies before writing
+          # one, the checker must find nothing rather than yesterday's.
+          rm -f junit.xml
           # Ignore preserved AZ-era test files that import removed modules
           pytest -v \
             --ignore-glob='**/test_*az*.py' \
             --ignore-glob='**/test_*shim*.py' \
-            --ignore=tests/test_ui/
+            --ignore=tests/test_ui/ \
+            --junit-xml=junit.xml
         env:
           GENESIS_TESTING: "1"
+      # A test that stops running is invisible: it makes the suite SMALLER,
+      # not red. Two axes, because dormancy moves both ways — a broken
+      # skipif RAISES the skip count, while a lost marker or a dropped
+      # directory LOWERS it and is only visible in the collected count.
+      # REPORT ONLY until both bounds, measured on these runners, are
+      # recorded here — a threshold invented rather than measured is one
+      # nobody trusts. The step still has teeth meanwhile: a missing or
+      # unreadable report exits 2.
+      - name: Suite dormancy guard
+        # NOT always(): that also fires on cancellation, and this workflow
+        # sets cancel-in-progress for every non-main ref — so a re-push
+        # would kill pytest mid-suite, leave no report, and the step would
+        # refuse with a cause that is not the cause.
+        if: ${{ !cancelled() }}
+        run: python scripts/check_skip_ceiling.py junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,8 @@ scripts/cops_interop.sh
 
 # Personal skills (user-level data, lives at ~/.claude/skills/)
 .claude/skills/code-voice/
+
+# pytest junit report, written by CI's test job. Carries hostname and
+# absolute local paths, and a committed copy would let the skip-ceiling
+# checker read a stale report as a live measurement.
+junit.xml

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -654,6 +654,7 @@ if $_ENCRYPT_READY; then
         "$HOME/.config/gh/hosts.yml:gh_hosts.yml" \
         "$HOME/.claude/.credentials.json:claude_credentials.json" \
         "$HOME/.claude.json:claude.json" \
+        "$HOME/.claude/settings.json:claude_settings.json" \
         "$HOME/.genesis/guardian_remote.yaml:guardian_remote.yaml" \
         "$HOME/.genesis/config/genesis.yaml:genesis.yaml" \
         "$HOME/.genesis/release-fingerprints.txt:release-fingerprints.txt"; do

--- a/scripts/check_skip_ceiling.py
+++ b/scripts/check_skip_ceiling.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Watch the suite's SKIP count for an unexplained rise.
+
+WHY. A test that stops running is invisible. It does not turn the suite red;
+it turns it *smaller*, and a smaller green suite reads exactly like a healthy
+one. CI has no assertion on collection or skip counts today.
+
+TWO AXES, because dormancy moves in both directions and one number cannot see
+both. A broken ``skipif`` RAISES the skip count — the ceiling catches that. A
+marker lost in a refactor, or a directory that falls out of collection, LOWERS
+or leaves it unchanged, so the ceiling is structurally blind to them; the
+COLLECTED count is the only instrument for those. MEASURED on a 4-test sandbox
+at ``--ceiling 1``: dropping half the suite printed "1 skipped of 2 collected.
+OK." Each failure message names only the causes ITS axis can produce — a
+ceiling trip is never a lost directory, and a floor trip is never an xfail.
+
+WHAT IT DOES NOT DO. It is a ceiling, never a floor. Removing a skip means a
+dormant test came back; a checker that punished that would be arguing for
+dormancy. Only an increase past the recorded ceiling fails.
+
+WHY IT SHIPS WITHOUT A CEILING. The honest baseline is a number measured on the
+CI runners, and inventing one is how a guard gets a threshold nobody trusts and
+everybody works around. With no ``--ceiling`` this REPORTS the count and exits
+0, so the first real CI run produces the baseline. Setting the ceiling is then a
+one-line follow-up against a measured number.
+
+REFUSAL. "Could not measure" and "measured, and it is fine" must never share an
+exit code. A missing report, an unparseable one, a run that collected zero
+tests, or a nonsense ceiling all exit 2 — never 0. Every refusal names itself in
+the output, because the interpreter ALSO exits 2 when it cannot open this file,
+and a caller keying on the code alone could not tell the two apart.
+
+NOTE. pytest's junit writer folds xfail into ``skipped``, so this is a
+skip+xfail ceiling: marking a known-broken test xfail raises the number.
+That is not wrong to count — an xfail is also a test not really running —
+but it is the kind of silent conflation that earns a threshold nobody
+trusts, so it is stated here and in the failure text.
+
+Exit: 0 ok / 1 ceiling exceeded / 2 refused to measure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from xml.etree import ElementTree
+
+# Named in every line so a refusal is distinguishable from the interpreter's own
+# exit 2 on a missing script. The test suite asserts on this string.
+TAG = "SKIP-CEILING"
+
+OK, EXCEEDED, REFUSED = 0, 1, 2
+
+
+def _say(msg: str) -> None:
+    print(f"{TAG}: {msg}")
+
+
+def _refuse(msg: str) -> int:
+    print(f"{TAG}: REFUSING — {msg}", file=sys.stderr)
+    return REFUSED
+
+
+def _parse_bound(raw: str | None, flag: str, noun: str) -> int | None | str:
+    """Return the bound, None for report mode, or a str describing why not.
+
+    Parametrised rather than string-patched: an earlier version derived the
+    floor's message by ``.replace("ceiling", "min-collected")`` over the
+    ceiling's, which rewrote the operator's OWN echoed input (``--min-collected
+    my-ceiling-value`` came back as ``'my-min-collected-value'``) and blamed the
+    skip axis for a collected-count error.
+    """
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return f"{flag} {raw!r} is not an integer"
+    if value < 0:
+        return f"{flag} {value} is negative; a {noun} cannot go below zero"
+    return value
+
+
+def _read_counts(path: Path) -> tuple[int, int] | str:
+    """Return (collected, skipped, dirty) summed over every testsuite, or a reason.
+
+    ``dirty`` is errors+failures. The step runs under ``!cancelled()``, so it
+    also runs on FAILED runs — where the counts describe a corpus that did not
+    finish, and a baseline read off it would be wrong in the one place the
+    docstring promises honesty.
+    """
+    try:
+        # S314 justification: the document is pytest's OWN --junit-xml
+        # output, written by the same CI job seconds earlier. There is no
+        # untrusted-author path — anyone who can write this file already has
+        # write access inside the runner, at which point the XML parser is not
+        # the weak link. defusedxml is deliberately NOT used: it is not a
+        # declared dependency (checked pyproject.toml), so importing it here
+        # would work locally and ImportError in CI.
+        tree = ElementTree.parse(path)  # noqa: S314
+    except FileNotFoundError:
+        return f"no report at {path} — the test step did not produce one"
+    except (ElementTree.ParseError, OSError) as exc:
+        return f"report at {path} is unreadable: {type(exc).__name__}: {exc}"
+
+    root = tree.getroot()
+    suites = list(root.iter("testsuite"))
+    if not suites:
+        return f"report at {path} contains no <testsuite> element"
+
+    if any(suite.find("testsuite") is not None for suite in suites):
+        return f"report at {path} nests <testsuite>; counts would double"
+
+    collected = skipped = dirty = 0
+    for suite in suites:
+        raw_tests = suite.get("tests")
+        raw_skipped = suite.get("skipped")
+        # A suite that does not state both counts cannot be summed. Guessing
+        # zero here is exactly the silent under-read this script exists to stop.
+        if raw_tests is None or raw_skipped is None:
+            name = suite.get("name", "<unnamed>")
+            return f"testsuite {name!r} omits {'tests' if raw_tests is None else 'skipped'}"
+        try:
+            n_tests, n_skipped = int(raw_tests), int(raw_skipped)
+        except ValueError:
+            return f"testsuite {suite.get('name', '<unnamed>')!r} has non-numeric counts"
+        # The same invariant refused for --ceiling, applied to the report too:
+        # an operator's negative count is refused, so the file's must be as well.
+        if n_tests < 0 or n_skipped < 0:
+            return f"testsuite {suite.get('name', '<unnamed>')!r} reports negative counts"
+        collected += n_tests
+        skipped += n_skipped
+        # Absent errors/failures attributes are treated as zero, not refused:
+        # they are optional in the junit schema and their absence says nothing
+        # about whether the run was clean.
+        for attr in ("errors", "failures"):
+            try:
+                dirty += int(suite.get(attr) or 0)
+            except ValueError:
+                return (
+                    f"testsuite {suite.get('name', '<unnamed>')!r} has a "
+                    f"non-numeric {attr} count"
+                )
+    return collected, skipped, dirty
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", help="pytest --junit-xml report path")
+    parser.add_argument(
+        "--ceiling",
+        default=None,
+        help="max skips allowed; omit to REPORT the count without enforcing",
+    )
+    parser.add_argument(
+        "--min-collected",
+        default=None,
+        help="min tests that must be collected; omit to REPORT without enforcing",
+    )
+    args = parser.parse_args(argv)
+
+    ceiling = _parse_bound(args.ceiling, "ceiling", "skip count")
+    if isinstance(ceiling, str):
+        return _refuse(ceiling)
+
+    floor = _parse_bound(args.min_collected, "min-collected", "collected count")
+    if isinstance(floor, str):
+        return _refuse(floor)
+
+    counts = _read_counts(Path(args.report))
+    if isinstance(counts, str):
+        return _refuse(counts)
+    collected, skipped, dirty = counts
+
+    # The empty-corpus trap: zero collected tests yields zero skips, which is
+    # indistinguishable from a healthy suite unless it is refused outright.
+    if collected == 0:
+        return _refuse("the report collected 0 tests, so its 0 skips measure nothing")
+
+    # The floor is checked FIRST: if tests vanished from collection, the skip
+    # count is measured over a corpus that is already wrong, so its verdict is
+    # not the useful one to report.
+    if floor is not None and collected < floor:
+        print(
+            f"{TAG}: FAIL — {collected} tests collected, floor is {floor}. "
+            f"{floor - collected} test(s) stopped being collected at all: a "
+            f"marker lost in a refactor, a directory out of collection, or a "
+            f"collection error. If the removal was deliberate, lower the floor "
+            f"in the same commit.",
+            file=sys.stderr,
+        )
+        return EXCEEDED
+
+    if ceiling is None and floor is None:
+        if dirty:
+            _say(
+                f"{skipped} skipped of {collected} collected. REPORT ONLY — not "
+                f"enforcing. NO baseline offered: this run had {dirty} error(s)/"
+                f"failure(s), so its corpus is not the healthy one to lock in. "
+                f"Read this line again on a green run."
+            )
+            return OK
+        _say(
+            f"{skipped} skipped of {collected} collected. "
+            f"REPORT ONLY — not enforcing (no --ceiling / --min-collected given). "
+            f"Set --ceiling {skipped} --min-collected {collected} to lock this in."
+        )
+        return OK
+
+    if ceiling is None:
+        _say(
+            f"{skipped} skipped of {collected} collected, floor {floor}. "
+            f"OK (skip ceiling not enforced; set --ceiling {skipped})."
+        )
+        return OK
+
+    if skipped > ceiling:
+        print(
+            f"{TAG}: FAIL — {skipped} skipped, ceiling is {ceiling}. "
+            f"{skipped - ceiling} more test(s) are being skipped than expected. "
+            f"Either a skipif condition broke and is now always true, or a skip "
+            f"or xfail was added deliberately (junit counts xfail as skipped) "
+            f"and the ceiling needs raising in the same commit. NOT a lost "
+            f"marker or a dropped directory — those LOWER this number; "
+            f"--min-collected is the check for them.",
+            file=sys.stderr,
+        )
+        return EXCEEDED
+
+    if floor is None:
+        # The likely misconfiguration: this script and its CI step are both
+        # named for the ceiling, so an operator pasting one flag pastes this
+        # one — silently restoring the gap the floor was added to close.
+        _say(
+            f"{skipped} skipped of {collected} collected, ceiling {ceiling}. "
+            f"OK (collection floor NOT enforced — the ceiling is blind to a lost "
+            f"marker or a dropped directory; set --min-collected {collected})."
+        )
+        return OK
+
+    _say(
+        f"{skipped} skipped of {collected} collected, ceiling {ceiling}, "
+        f"floor {floor}. OK."
+    )
+    return OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/genesis/guardian/cred_integrity.py
+++ b/src/genesis/guardian/cred_integrity.py
@@ -85,6 +85,17 @@ DEFAULT_TARGETS: tuple[CredTarget, ...] = (
                "creds/claude_credentials.json.gpg", "json",
                required_keys=("claudeAiOauth",)),
     CredTarget("claude_json", ".claude.json", "creds/claude.json.gpg", "json"),
+    # User-level CC settings. The PROJECT .claude/settings.json is tracked in
+    # git; this one is not, and it carries its own live hooks block — so a
+    # process-internal write that empties it disarms those hooks with nothing
+    # to notice. Deliberately NO required_keys, for the same reason secrets.env
+    # has none: a user-level hooks block is install-local and a fresh install
+    # may legitimately have none, and missing_keys is RESTORABLE, so requiring
+    # it would trigger a destructive restore over a perfectly healthy file. The
+    # real outage signatures here (empty, NUL-zeroed, unparseable) are caught
+    # without any key assumption — the same shape as claude_json above.
+    CredTarget("claude_settings", ".claude/settings.json",
+               "creds/claude_settings.json.gpg", "json"),
     CredTarget("gh_hosts", ".config/gh/hosts.yml", "creds/gh_hosts.yml.gpg", "yaml"),
     CredTarget("guardian_remote", ".genesis/guardian_remote.yaml",
                "creds/guardian_remote.yaml.gpg", "yaml"),

--- a/tests/test_guardian/test_cred_integrity.py
+++ b/tests/test_guardian/test_cred_integrity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import pathlib
 import shutil
 import subprocess
 import sys
@@ -342,9 +343,45 @@ def test_restore_placement_failure_leaves_no_plaintext_temp(tmp_path, monkeypatc
 
 
 def test_default_targets_match_backup_paths():
-    """Guard: every target's backup_rel matches scripts/backup.sh §8 naming."""
-    by_name = {t.name: t for t in DEFAULT_TARGETS}
-    assert by_name["secrets_env"].backup_rel == "secrets/secrets.env.gpg"
-    assert by_name["claude_credentials"].backup_rel == "creds/claude_credentials.json.gpg"
-    assert by_name["gh_hosts"].backup_rel == "creds/gh_hosts.yml.gpg"
-    assert by_name["ssh_guardian_key"].backup_rel == "creds/ssh/genesis_guardian_ed25519.gpg"
+    """Guard: EVERY target's backup_rel matches scripts/backup.sh §8 naming.
+
+    Derived from backup.sh rather than a hand-listed sample. The previous
+    version's docstring said "every target" while its body asserted four of
+    them, so a new target — and a typo in its backup_rel — joined the unchecked
+    set silently. That matters more here than in most tests: cred_integrity's
+    own module docstring makes the name/path match a MUST, because a mismatch
+    means a corrupt file has no decryptable last-known-good copy and the
+    restore no-ops. The repo's enumerate-don't-spot-check rule, applied to the
+    test that exists to enforce an enumeration.
+    """
+    spec = (
+        pathlib.Path(__file__).resolve().parents[2] / "scripts" / "backup.sh"
+    ).read_text(encoding="utf-8")
+
+    checked = 0
+    for t in DEFAULT_TARGETS:
+        if t.backup_rel.startswith("creds/ssh/"):
+            continue  # §8 sweeps all of ~/.ssh by find(1), not the named list
+        if not t.backup_rel.startswith("creds/"):
+            continue  # secrets.env is §7 (its own GPG step), not the §8 loop
+        flat = t.backup_rel.removeprefix("creds/").removesuffix(".gpg")
+        assert f'"$HOME/{t.path}:{flat}"' in spec, (
+            f"{t.name}: backup.sh §8 has no entry producing creds/{flat}.gpg "
+            f"from $HOME/{t.path}"
+        )
+        checked += 1
+
+    # A derived assertion that matched nothing would pass silently; pin the
+    # population so an empty sweep is a failure rather than a clean run.
+    assert checked >= 5, f"only {checked} §8 targets checked — the filter is wrong"
+
+
+def test_secrets_env_is_backed_up_by_its_own_section():
+    """secrets_env is excluded from the §8 loop above; prove it is not simply
+    unbacked-up. Without this the exclusion could hide a real gap."""
+    spec = (
+        pathlib.Path(__file__).resolve().parents[2] / "scripts" / "backup.sh"
+    ).read_text(encoding="utf-8")
+    target = next(t for t in DEFAULT_TARGETS if t.name == "secrets_env")
+    assert target.backup_rel == "secrets/secrets.env.gpg"
+    assert "secrets/secrets.env.gpg" in spec

--- a/tests/test_scripts/test_check_skip_ceiling.py
+++ b/tests/test_scripts/test_check_skip_ceiling.py
@@ -1,0 +1,362 @@
+"""The skip-ceiling checker must REFUSE rather than report clean.
+
+A dormant test — one that stopped running because a skipif broke, a marker was
+lost, or a directory fell out of collection — is invisible: the suite still
+prints green. This checker exists to make that visible by watching the SKIP
+count for an unexplained rise.
+
+Every test here is written against the failure that makes such a checker
+worthless: a run that measured NOTHING and said so in the grammar of a pass.
+"0 skips" from an empty report and "0 skips" from a healthy suite must never
+be the same exit code.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "scripts" / "check_skip_ceiling.py"
+
+# Exit contract — asserted here so a change to it breaks a test, not a caller.
+OK, EXCEEDED, REFUSED = 0, 1, 2
+
+
+def run(xml: Path | str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(xml), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+# The checker's own refusal marker. Python ALSO exits 2 when it cannot open a
+# script file, so asserting the code alone passes when the script is DELETED —
+# measured: the five refuse-tests below all passed before the script existed.
+# Every refusal assertion therefore requires output only the checker emits.
+REFUSAL_MARKER = "SKIP-CEILING"
+
+
+def assert_refused(r: subprocess.CompletedProcess) -> None:
+    out = r.stdout + r.stderr
+    assert r.returncode == REFUSED, out
+    assert REFUSAL_MARKER in out, (
+        f"exit 2 but no {REFUSAL_MARKER!r} in output — this is python failing to "
+        f"open the script, not the checker refusing. Output: {out!r}"
+    )
+
+
+def write(tmp_path: Path, body: str, name: str = "junit.xml") -> Path:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def suite(tests: int, skipped: int) -> str:
+    return (
+        f'<?xml version="1.0" encoding="utf-8"?>\n'
+        f'<testsuites><testsuite name="pytest" tests="{tests}" '
+        f'errors="0" failures="0" skipped="{skipped}"></testsuite></testsuites>\n'
+    )
+
+
+class TestRefusesRatherThanGuesses:
+    """A checker that cannot measure must not print a clean result."""
+
+    def test_missing_report_refuses(self, tmp_path: Path) -> None:
+        r = run(tmp_path / "nope.xml")
+        assert_refused(r)
+        assert "REFUS" in (r.stdout + r.stderr).upper()
+
+    def test_unparseable_report_refuses(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, "<testsuites><broken"))
+        assert_refused(r)
+
+    def test_report_with_no_testsuite_refuses(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, '<?xml version="1.0"?>\n<other/>\n'))
+        assert_refused(r)
+
+    def test_zero_collected_tests_refuses(self, tmp_path: Path) -> None:
+        """The empty-corpus trap: a suite that ran nothing reports 0 skips,
+        which reads identically to a healthy suite unless we refuse it."""
+        r = run(write(tmp_path, suite(tests=0, skipped=0)))
+        assert_refused(r)
+        assert "0" in r.stdout + r.stderr
+
+    def test_missing_skipped_attribute_refuses(self, tmp_path: Path) -> None:
+        body = (
+            '<?xml version="1.0"?>\n<testsuites><testsuite name="pytest" '
+            'tests="10"></testsuite></testsuites>\n'
+        )
+        r = run(write(tmp_path, body))
+        assert_refused(r)
+
+
+class TestReportMode:
+    """With no ceiling configured the checker MEASURES and passes, so the
+    first run on real CI produces the baseline instead of us inventing one."""
+
+    def test_reports_count_and_passes(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=100, skipped=7)))
+        assert r.returncode == OK, r.stdout + r.stderr
+        assert "7" in r.stdout
+
+    def test_report_mode_says_it_is_not_enforcing(self, tmp_path: Path) -> None:
+        """MEASURED vacuous once: the old assertion allowed `or "report"` over
+        stdout+stderr, and every REFUSAL message contains the word "report"
+        ("REFUSING — no report at ..."). It therefore survived a mutation that
+        replaced report-mode with a refusal — the very thing it names."""
+        r = run(write(tmp_path, suite(tests=100, skipped=7)))
+        assert r.returncode == OK, r.stdout + r.stderr
+        assert "not enforcing" in r.stdout.lower()
+
+
+class TestEnforcement:
+    def test_under_ceiling_passes(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=100, skipped=5)), "--ceiling", "10")
+        assert r.returncode == OK, r.stdout + r.stderr
+
+    def test_at_ceiling_passes(self, tmp_path: Path) -> None:
+        """The ceiling is a maximum, not a forbidden value."""
+        r = run(write(tmp_path, suite(tests=100, skipped=10)), "--ceiling", "10")
+        assert r.returncode == OK, r.stdout + r.stderr
+
+    def test_over_ceiling_fails(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=100, skipped=11)), "--ceiling", "10")
+        assert r.returncode == EXCEEDED, r.stdout + r.stderr
+        assert "11" in r.stdout + r.stderr and "10" in r.stdout + r.stderr
+
+    def test_far_under_ceiling_still_passes(self, tmp_path: Path) -> None:
+        """Deliberately NOT a floor. Removing a skip is fixing a dormant test;
+        a checker that punished that would be arguing for dormancy."""
+        r = run(write(tmp_path, suite(tests=100, skipped=0)), "--ceiling", "10")
+        assert r.returncode == OK, r.stdout + r.stderr
+
+    def test_negative_ceiling_refuses(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=100, skipped=5)), "--ceiling", "-1")
+        assert_refused(r)
+
+    def test_non_numeric_ceiling_refuses(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=100, skipped=5)), "--ceiling", "lots")
+        assert_refused(r)
+
+
+class TestMultipleSuites:
+    def test_skips_are_summed_across_testsuite_elements(self, tmp_path: Path) -> None:
+        body = (
+            '<?xml version="1.0"?>\n<testsuites>'
+            '<testsuite name="a" tests="10" skipped="2"></testsuite>'
+            '<testsuite name="b" tests="10" skipped="3"></testsuite>'
+            "</testsuites>\n"
+        )
+        r = run(write(tmp_path, body), "--ceiling", "4")
+        assert r.returncode == EXCEEDED, r.stdout + r.stderr
+        assert "5" in r.stdout + r.stderr
+
+
+class TestReportCountsAreSane:
+    """The script refuses a negative --ceiling; it must hold the report to the
+    same invariant, and must not silently double-count a nested producer."""
+
+    def test_negative_counts_in_report_refuse(self, tmp_path: Path) -> None:
+        body = (
+            '<?xml version="1.0"?>\n<testsuites><testsuite name="pytest" '
+            'tests="10" skipped="-3"></testsuite></testsuites>\n'
+        )
+        assert_refused(run(write(tmp_path, body)))
+
+    def test_nested_testsuite_refuses_rather_than_double_counting(
+        self, tmp_path: Path
+    ) -> None:
+        """pytest never nests, but other junit producers do, and
+        ElementTree.iter() walks all descendants — so a nested report would
+        sum each suite twice and pass a ceiling it should trip."""
+        body = (
+            '<?xml version="1.0"?>\n<testsuites>'
+            '<testsuite name="outer" tests="10" skipped="9">'
+            '<testsuite name="inner" tests="10" skipped="9"></testsuite>'
+            "</testsuite></testsuites>\n"
+        )
+        assert_refused(run(write(tmp_path, body)))
+
+
+class TestCollectedFloor:
+    """The skip ceiling is blind to two of the three dormancy modes, because
+    both LOWER the skip count. MEASURED on a 4-test sandbox at --ceiling 1:
+    dropping half the suite from collection printed "1 skipped of 2 collected.
+    OK." and deleting the skip marker printed "0 skipped of 4 collected. OK."
+    The collected count is the instrument for those two; these tests are the
+    acceptance bar for the exact scenarios the ceiling let through."""
+
+    def test_dropped_collection_is_caught_by_the_floor(self, tmp_path: Path) -> None:
+        """The scenario the ceiling missed: half the suite stops being collected."""
+        r = run(write(tmp_path, suite(tests=2, skipped=1)), "--ceiling", "1",
+                "--min-collected", "4")
+        assert r.returncode == EXCEEDED, r.stdout + r.stderr
+        assert "2" in r.stdout + r.stderr and "4" in r.stdout + r.stderr
+
+    def test_deleted_marker_leaves_collection_intact_and_passes(
+        self, tmp_path: Path
+    ) -> None:
+        """A deleted skip marker LOWERS skips but does not change collection,
+        so the floor correctly does not fire. Recorded so the floor's scope is
+        not overclaimed: it catches tests that vanish, not skips that vanish."""
+        r = run(write(tmp_path, suite(tests=4, skipped=0)), "--ceiling", "1",
+                "--min-collected", "4")
+        assert r.returncode == OK, r.stdout + r.stderr
+
+    def test_at_floor_passes(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=4, skipped=0)), "--min-collected", "4")
+        assert r.returncode == OK, r.stdout + r.stderr
+
+    def test_above_floor_passes(self, tmp_path: Path) -> None:
+        """Adding tests must never fail: the floor is a floor, not a target."""
+        r = run(write(tmp_path, suite(tests=99, skipped=0)), "--min-collected", "4")
+        assert r.returncode == OK, r.stdout + r.stderr
+
+    def test_negative_floor_refuses(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=4, skipped=0)), "--min-collected", "-1")
+        assert_refused(r)
+
+    def test_non_numeric_floor_refuses(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=4, skipped=0)), "--min-collected", "some")
+        assert_refused(r)
+
+    def test_floor_message_does_not_blame_skip_causes(self, tmp_path: Path) -> None:
+        """The FAIL text must name only causes ITS axis can produce. A ceiling
+        trip is never a lost directory; a floor trip is never an added xfail."""
+        r = run(write(tmp_path, suite(tests=2, skipped=0)), "--min-collected", "4")
+        # MEASURED vacuous once: asserting `"collect" in out` alone passed on
+        # argparse's own error ("unrecognized arguments: --min-collected"),
+        # which is exactly the absent-mechanism path. Pin the exit code and a
+        # phrase only the real floor message emits.
+        assert r.returncode == EXCEEDED, r.stdout + r.stderr
+        out = (r.stdout + r.stderr).lower()
+        assert "stopped being collected" in out
+        assert "xfail" not in out
+
+    def test_ceiling_message_excludes_collection_causes_by_name(
+        self, tmp_path: Path
+    ) -> None:
+        r = run(write(tmp_path, suite(tests=100, skipped=11)), "--ceiling", "10")
+        assert r.returncode == EXCEEDED, r.stdout + r.stderr
+        out = (r.stdout + r.stderr).lower()
+        # The message may NAME the collection causes, but only to EXCLUDE them
+        # and redirect to the other axis. Asserting mere absence was the weaker
+        # property: silence leaves the reader to guess, whereas an explicit
+        # "not this, use --min-collected" is what stops the misdirection.
+        assert "not a lost marker" in out
+        assert "--min-collected" in out
+
+    def test_report_mode_reports_both_axes(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=100, skipped=7)))
+        assert r.returncode == OK, r.stdout + r.stderr
+        assert "--ceiling 7" in r.stdout and "--min-collected 100" in r.stdout
+
+
+class TestDirtyRunBaseline:
+    """`if: !cancelled()` guarantees the step runs on FAILED runs too — exactly
+    when the counts describe a corpus that did not finish. Report mode must not
+    hand the operator a paste-ready baseline measured on a red run: the whole
+    justification for report-only is that the number is honest."""
+
+    @staticmethod
+    def _dirty(tests: int, skipped: int, errors: int, failures: int) -> str:
+        return (
+            f'<?xml version="1.0"?>\n<testsuites><testsuite name="pytest" '
+            f'tests="{tests}" errors="{errors}" failures="{failures}" '
+            f'skipped="{skipped}"></testsuite></testsuites>\n'
+        )
+
+    def test_errors_suppress_the_baseline_suggestion(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, self._dirty(100, 7, errors=37, failures=0)))
+        assert r.returncode == OK, r.stdout + r.stderr
+        assert "--ceiling 7" not in r.stdout, "offered a baseline from a red run"
+        assert "37" in r.stdout
+
+    def test_failures_suppress_the_baseline_suggestion(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, self._dirty(100, 7, errors=0, failures=4)))
+        assert r.returncode == OK, r.stdout + r.stderr
+        assert "--ceiling 7" not in r.stdout
+
+    def test_clean_run_still_offers_the_baseline(self, tmp_path: Path) -> None:
+        """The control: suppression must be caused by the dirt, not by the
+        suggestion having been removed altogether."""
+        r = run(write(tmp_path, self._dirty(100, 7, errors=0, failures=0)))
+        assert r.returncode == OK, r.stdout + r.stderr
+        assert "--ceiling 7" in r.stdout and "--min-collected 100" in r.stdout
+
+    def test_a_dirty_run_still_ENFORCES_when_configured(self, tmp_path: Path) -> None:
+        """Only the SUGGESTION is gated. A configured ceiling must still bite on
+        a red run — dormancy does not become acceptable because tests failed."""
+        r = run(write(tmp_path, self._dirty(100, 11, errors=3, failures=0)),
+                "--ceiling", "10")
+        assert r.returncode == EXCEEDED, r.stdout + r.stderr
+
+
+class TestHalfConfigured:
+    """Ceiling-only silently reinstates the gap the floor was added to close,
+    and it is the LIKELY misconfiguration: the script and the CI step are both
+    named for the ceiling, so a hurried operator pastes the first flag."""
+
+    def test_ceiling_only_warns_the_floor_is_not_enforced(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=100, skipped=5)), "--ceiling", "10")
+        assert r.returncode == OK, r.stdout + r.stderr
+        assert "--min-collected" in r.stdout, "ceiling-only did not name the gap"
+
+    def test_floor_only_warns_the_ceiling_is_not_enforced(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=100, skipped=5)), "--min-collected", "4")
+        assert r.returncode == OK, r.stdout + r.stderr
+        assert "--ceiling" in r.stdout
+
+    def test_both_configured_warns_about_neither(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=100, skipped=5)),
+                "--ceiling", "10", "--min-collected", "4")
+        assert r.returncode == OK, r.stdout + r.stderr
+        assert "not enforced" not in r.stdout.lower()
+
+
+class TestRefusalTextIntegrity:
+    """A blanket str.replace over a message embedding the operator's own input
+    rewrites what they typed, and blamed the wrong axis for a floor error."""
+
+    def test_floor_refusal_does_not_rewrite_the_echoed_input(
+        self, tmp_path: Path
+    ) -> None:
+        r = run(write(tmp_path, suite(tests=4, skipped=0)),
+                "--min-collected", "my-ceiling-value")
+        assert_refused(r)
+        out = r.stdout + r.stderr
+        assert "my-ceiling-value" in out, "the echoed input was rewritten"
+
+    def test_negative_floor_names_the_collected_axis(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=4, skipped=0)), "--min-collected", "-1")
+        assert_refused(r)
+        out = (r.stdout + r.stderr).lower()
+        assert "collected count" in out
+        assert "skip count" not in out, "floor error blamed the skip axis"
+
+    def test_negative_ceiling_names_the_skip_axis(self, tmp_path: Path) -> None:
+        r = run(write(tmp_path, suite(tests=4, skipped=0)), "--ceiling", "-1")
+        assert_refused(r)
+        assert "skip count" in (r.stdout + r.stderr).lower()
+
+
+class TestRunsTheWayCIRunsIt:
+    """ci.yml invokes a bare `python` with a RELATIVE path and only the test
+    extra installed. Precedent: tests/test_scripts/test_check_migration_prefixes.py
+    carries an equivalent guard because a checker once exited 2 on every PR —
+    enforcing nothing — while every in-venv test passed."""
+
+    def test_bare_interpreter_relative_path_stdlib_only(self, tmp_path: Path) -> None:
+        import os
+        report = write(tmp_path, suite(tests=100, skipped=7))
+        r = subprocess.run(
+            ["python3", "-E", "-S", "scripts/check_skip_ceiling.py", str(report)],
+            capture_output=True, text=True, cwd=str(REPO),
+            env={"PATH": os.environ.get("PATH", "/usr/bin:/bin")},
+        )
+        assert r.returncode == OK, f"CI-shaped invocation failed: {r.stdout}{r.stderr}"
+        assert "7 skipped of 100 collected" in r.stdout


### PR DESCRIPTION
## The gap

A test that stops running is invisible. It does not turn the suite red — it turns it
**smaller**, and a smaller green suite reads exactly like a healthy one. CI had no
assertion on collection or skip counts at all.

## Two axes, because dormancy moves both ways

One number cannot see both directions, and the first version of this shipped with only
one of them:

| failure | effect on counts | caught by |
|---|---|---|
| a `skipif` breaks and becomes always-true | skip count **rises** | `--ceiling` |
| a marker lost in a refactor | skip count **falls** | `--min-collected` |
| a directory falls out of collection | both fall | `--min-collected` |

**Measured on a 4-test sandbox at `--ceiling 1`, before the floor existed:**

```
half the suite dropped from collection → "1 skipped of 2 collected. OK."   exit 0
skip marker deleted                     → "0 skipped of 4 collected. OK."   exit 0
```

So the ceiling detected one of the three modes its own docstring named, and its failure
message listed the two it categorically cannot detect — an inverted diagnosis headed for
permanent record. Each message now names only the causes its own axis can produce, and
the ceiling message explicitly redirects to `--min-collected` for the rest.

**Acceptance bar, replayed after the fix:**

```
healthy    → "1 skipped of 4 collected, ceiling 1, floor 4. OK."              exit 0
dropped    → FAIL "2 tests collected, floor is 4 … stopped being collected"   exit 1
skipif     → FAIL "3 skipped, ceiling is 1 … NOT a lost marker or a dropped
              directory — those LOWER this number; --min-collected is the
              check for them."                                               exit 1
```

## Refusal over guessing

"Could not measure" and "measured, and it is fine" must never share an exit code. Exit 2
on: a missing report, an unparseable one, a run that collected **zero** tests, a suite
omitting its counts, negative counts, a nested `<testsuite>` that would double-count, and
a nonsense bound. Every refusal names itself, because the interpreter *also* exits 2 when
it cannot open the script — a caller keying on the code alone could not tell them apart.

## Why it ships report-only

The honest thresholds are numbers measured on the CI runners. I could not obtain them
beforehand (the run log truncates at 45%, the raw API log had expired), and a threshold
invented rather than measured is one nobody trusts. **This PR's own `test` job prints
both numbers; they go in as a second commit on this branch before merge.**

The step is not inert meanwhile — a missing or unreadable report still exits 2. And
report mode refuses to offer a paste-ready baseline from a run that had errors or
failures: the step runs under `!cancelled()`, so it runs on red runs too, which is
exactly when the counts describe a corpus that did not finish.

## Also here

`~/.claude/settings.json` becomes a ninth credential-integrity target with its matching
backup entry. The **project** settings file is tracked in git; the **user-level** one is
in neither git nor the backup set, and carries its own live hooks block — so a
process-internal write that empties it disarms those hooks with nothing to notice.

It deliberately declares **no** `required_keys`: `missing_keys` is a *restorable* status,
so requiring `"hooks"` would arm a destructive restore over a healthy fresh install that
legitimately has none — the failure the `secrets.env` comment already documents.

The parity test that holds `cred_integrity.py` and `backup.sh` in sync claimed in its
docstring to check *every* target and checked **four of nine**. It now derives the
expectation from `backup.sh` for every entry, with a population floor so an empty sweep
fails instead of passing. Mutation-verified: a typo in the new target's `backup_rel` is
caught, and so are typos in two targets the old spot-check never looked at.

## Review

Two adversarial passes, both internal — no cross-model round consumed.

Round 1: one blocker (the single-axis gap) plus six findings — a blanket `# noqa`, an
ungitignored `junit.xml` carrying hostname and absolute paths, `if: always()` firing on
cancellation under `cancel-in-progress`, a vacuous test, undocumented xfail conflation,
and unchecked report counts.

Round 2: a 15-mutation battery confirmed all of those resolved (15/15 caught), and found
two more — a baseline offered from red runs, and a silent half-configured state where
setting only the ceiling reinstated the original gap while printing OK.

**Three vacuous tests were found and fixed on the way, all the same shape** — an
assertion that is also true when the mechanism is absent:

1. asserting only `returncode == 2` — the interpreter returns 2 for a missing script
2. `or "report"` — every refusal message contains the word
3. `assert "collect" in out` — argparse's own `unrecognized arguments: --min-collected`

Every refusal assertion now requires a marker only the checker emits. Separately, the
first mutation sweep reported every mutation caught **while running zero tests** — it
invoked an interpreter with no pytest and a non-zero exit was read as a kill. Sweeps now
abort unless pytest emits a result line, and carry a green baseline control.

## Verification

- `ruff` clean on all four touched Python files, including `--select S314,RUF100` (an
  earlier `# noqa justification (S314):` was a **blanket** suppression — ruff reads
  `# noqa` followed by anything but a colon as suppressing every rule on the line, and
  this repo does not select RUF100, so it was silent)
- 116 targeted tests pass · `bash -n` clean · external-io, frozen-clock, subsystem-map pass
- Workflow YAML parses; the step is last in the job and adds no new check run

## Deploy note

`src/genesis/guardian/` is a host-deploy path, so the guardian side picks this up only
after `scripts/update.sh` runs. Merged is not deployed.

Ledger: c3dedfc7ba3741b5b5d6489cea38e17f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CI now detects missing, malformed, or unexpectedly dormant test reports and flags excessive skipped or insufficiently collected tests.
  * Credential integrity checks now include Claude settings, rejecting empty, corrupted, or invalid configuration data.

* **Chores**
  * CI-generated test reports are excluded from version control.
  * Encrypted backups now include Claude settings.

* **Tests**
  * Added comprehensive coverage for test-report validation, enforcement thresholds, and credential backup consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->