### PR TITLE
docs(dev-skill): the verification method, as a reference not a habit

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -883,7 +883,6 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   knowing the rule, it is believing you already applied it.
 
   A corpus run only ever yields `did not, here`, and by the rule above it is
-  corpus run only ever yields `did not, here`, and by the rule above it is
   structurally blind to the shape nobody typed. Run the corpus as
   corroboration, never as the proof, and pair it with a control that DOES flip
   — an unflipped corpus and an inert measurement look identical.
@@ -919,14 +918,33 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   This does NOT loosen the fail-closed mandate above, and the two are easy to
   read as contradicting each other. Rule (b) is scoped to the git-operation
   blind-spot net — a guard whose trigger is deliberately broad and whose false
-  positive is one confirmation. It is NOT a template for every guard: the
-  protected-paths and destructive-command guards hard-block an unreliable parse
-  even when a person is present, by design, because their false negative is an
-  irreplaceable path or a broad recursive removal and their false positive is a
-  rewrite. Within the net, the two rules are scoped by who is present: `ask` is
-  the interactive form of the refusal, and where a session is unattended
-  fail-closed governs and (c) applies. The operation proceeds unverified in
-  neither case.
+  positive is one confirmation. It is NOT a template for every guard: where the
+  false negative is an irreplaceable path or a broad recursive removal and the
+  false positive is a rewrite, that asymmetry justifies refusing outright rather
+  than asking. Neither the protected-paths nor the destructive-command guard has
+  an `ask` branch at all — both return only 0 or 2 — so a person's presence
+  genuinely cannot change their verdict.
+
+  One clause of that used to read "hard-block an unreliable parse", and it is
+  FALSE. MEASURED 2026-09-06 through both live hook entries, controls flipping:
+  each guard refuses on the PARSED path and then falls back to a DIFFERENT
+  matcher, neither a subset nor a superset of it — it misses spellings the
+  parser catches, AND it drops the target tests the parser applies, so it also
+  refuses commands the parser allows. **A guard's fail direction is a property
+  of its DEGRADED path, and that path has to be read in BOTH directions.** The
+  two differ in what their fallback is for: `destructive_command_guard`'s is
+  fail-open by design and says so in its own docstring, so argue with the design
+  rather than patching it; `protected_paths_guard`'s calls itself "conservative:
+  over-blocks, never under", which is true relative to the old guard it
+  reinstates (`protected_paths_guard.py:33-35`) and false of the parsed resolver
+  it stands in for — one sentence, two readings, and that ambiguity is the
+  defect. Verify a docstring's stated direction IN CONTEXT; never quote it as a
+  fact. The shapes are deliberately not enumerated here, per the rule above.
+
+  Within the git-operation blind-spot net, the two rules are scoped by who is
+  present: `ask` is the interactive form of the refusal, and where a session is
+  unattended fail-closed governs and (c) applies. The operation proceeds
+  unverified in neither case.
 
   This is the shipped shape now, not an aspiration, and one distinction inside
   it must stay visible. The shared parser still degrades to a naive split with

--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -811,6 +811,17 @@ tool-selection decision matrix: `.claude/docs/code-intelligence.md`
   the open-set version and plan to harden it later; the review loop IS the
   hardening loop, one bug per round, and it does not converge.
 
+  **An instrument's stated invariant is its blind spot — and so is the one it
+  does not state.** Before trusting a harness's clean result, read what it
+  promises to hold fixed, then ask what ELSE it holds fixed without saying so.
+  READ, and EXTERNAL to this repo — a sibling toolkit's own release notes,
+  2026-09, not a Genesis measurement: a fuzzer whose mutators were all fixed
+  one-character strings had a whole mutant shape unreachable by construction,
+  and that writeup attributes its own long-lived bypass to exactly that. The
+  remedy generalises even if the number does not: vary what the instrument
+  never varies, rather than running it more times.
+  Method for the whole class: `references/high-stakes-verification.md`.
+
   **Three corollaries, each bought with a non-converging review loop.**
 
   **(a) NEVER normalize the command text before a blind-spot probe.** A probe
@@ -1319,6 +1330,23 @@ above (full definitions in `.claude/agents/genesis-architect.md`):
   file:line or be confidence-capped).
 
 ### Review-loop discipline
+
+- **A RELEASE review is scoped to what the release CHANGES; a whole-codebase
+  audit gates nothing.** Point a reviewer at "the repository" and it returns
+  findings that PRE-DATE the release — real, worth fixing, and not release
+  blockers. Treating them as blockers is how a release never ships. Scope the
+  gating pass to the diff between the previous RELEASE tag and HEAD (this repo
+  also carries non-release tags, so `git describe --tags` alone can land on the
+  wrong one); run the broader
+  audit separately, on its own clock, where its findings become ordinary work
+  rather than a stop. The distinction is not "which findings are real" but
+  "which findings this release is answerable for" — a defect that already
+  shipped in the last release is answerable by the next fix, not by this gate.
+  Release scope decides what BLOCKS, never whether an external round COUNTS: a
+  pre-dating finding is still a defect-bearing round on the escalation counter,
+  filed as ordinary work rather than held as a release blocker. "It pre-dates
+  the release" is otherwise just a new spelling of the rationalization that
+  counter exists to kill.
 
 - **A review's findings are a SAMPLE, not a to-do list.** This is the single
   highest-value habit in this section, and the one most often skipped. CLAUDE.md
@@ -2216,6 +2244,7 @@ references on every trigger.
 | Phase 6 contribution pipeline, sanitizer | `references/contribution.md` |
 | Pending work, active incidents, subsystem status | `references/build-state.md` |
 | Auditing/deep-reviewing AI-generated code (failure taxonomy, audit passes) | `references/ai-code-audit.md` |
+| Pre-release review, bug hunt, guard/gate change — verification method | `references/high-stakes-verification.md` |
 | Which code tool to use (CBM vs Serena vs GitNexus vs Grep) | `.claude/docs/code-intelligence.md` |
 
 **Freshness rule:** On first read of `codebase-map.md` in a session,

--- a/.claude/skills/genesis-development/references/high-stakes-verification.md
+++ b/.claude/skills/genesis-development/references/high-stakes-verification.md
@@ -1,0 +1,143 @@
+# High-Stakes Verification
+
+Read this when the work is a pre-release review, a bug hunt, a guard or gate
+change, or a fix that must not regress. Not for ordinary work — applied
+everywhere it burns cycles for nothing, which is the failure mode of a method
+document.
+
+Most rules here exist because their absence shipped a defect; those carry the
+instance. What is already covered elsewhere is a pointer, not a restatement —
+a second copy of an instruction is a second thing to keep right, and the copy
+is the one that goes stale.
+
+## Already covered — read there, do not re-derive here
+
+| Rule | Read |
+|---|---|
+| Evidence tiers (MEASURED / READ / INFERRED / ASSUMED) | CLAUDE.md, "Evidence Must Match the Scope of the Claim" |
+| A number without a denominator is not a measurement | same |
+| A truncated listing is not absence | same |
+| An "absent" claim needs enumeration, not a failed spot-check | same |
+| **Vacuous tests** — the named shapes, and "would this still pass if the mechanism it names were deleted?" | SKILL.md, Test-First Discipline |
+| **A RED that comes back GREEN has six causes**, the first being that the run never executed — abort when the command emits no result line | same |
+| **Mutation housekeeping** — proving a mutation applied, restore placement, hashing, and PRESERVING a file that no longer matches what the mutation wrote | same |
+| A corpus replay is structurally blind to a shape nobody has typed | same, and the guard-corollary block |
+| Every harness needs a control expected to FAIL, wired as an abort | SKILL.md, guard corollaries ("pair it with a control that DOES flip") |
+| Re-measure another agent's finding before acting on it | CLAUDE.md, "Verify agent output" |
+| Acceptance bar + measured rate as the default method | SKILL.md, On-Load Mindset |
+
+The rest of this file is what those do not cover.
+
+## 1. One twin per clause
+
+A compound condition is not one branch. Each guard shadows the ones behind it,
+so a single test only ever exercises the first clause it trips. Write one test
+per clause, and confirm each fails for its own reason.
+
+## 2. Validate the matcher before trusting the rate
+
+A rate produced by an unvalidated matcher is not a measurement, and it is worse
+than no number because it looks like one.
+
+Measured: a first-pass audit matcher reported **29** hits over a real corpus.
+Every one was an artifact — it read one long flag as a recursive flag and
+another as a force flag, so it matched ordinary commands that merely mentioned
+the verb. The same corpus, with a matcher that had passed a 12-case acceptance
+bar first, returned **0**. The difference between "29 findings" and "no
+findings" was entirely the instrument.
+
+Run the acceptance bar BEFORE the corpus, every time: a set of must-catch cases
+and a set of must-not-fire cases. If the bar fails, the rate is not reportable.
+
+## 3. Fix at the choke point, not the call site
+
+If the defect can recur at a caller that does not exist yet, the fix is in the
+wrong place. Put the guard where the ACTION happens so a future caller inherits
+it.
+
+Watch ORDERING especially. A backup, a prune or a validation placed AFTER the
+operation it exists to make safe is inert, and reads as completely correct.
+
+## 4. Generate, don't just read
+
+Reading alone finds little. What finds things:
+
+- plant mutants over the code you just changed and see whether anything notices
+- fuzz the GRAMMAR of the input space, not your own bug history — a bug history
+  contains only what has already bitten you
+- run the thing on real input and diff PER ITEM, never on totals
+- use an external oracle (a real parser, the actual runtime) rather than your own
+  model of the syntax
+
+A corpus replay and a generated matrix answer different questions and neither
+substitutes for the other (SKILL.md carries the full form of this). When you
+find one defect, search for its SHAPE across the codebase, not for the symptom.
+
+## 5. Check what is already in flight before claiming novelty
+
+Four findings in one session were measured correctly and were not new: two were
+already fixed in an open PR with a larger denominator than the one I had, one
+was documented-intentional behaviour named in a merged PR's own body, and one
+had no measurable exposure. The measurements were right every time; the leap
+from "I measured X" to "X is an undiscovered defect" was wrong every time.
+
+Before writing a finding down as new, in this order:
+
+1. open PRs touching the file (`gh pr list --state open --json number,files`)
+2. the file's own git log, and the merged PR bodies it references
+3. the code's own docstrings and comments — a documented deliberate behaviour is
+   a design to argue with, never an oversight to patch
+
+The cost of skipping this is not just wasted work; it is a confident wrong claim
+in a durable record.
+
+## 6. An agent's finding is a lead, and it errs in BOTH directions
+
+Sub-agent output gets an independent pass before it drives anything. The
+verify-agent-output rule in CLAUDE.md covers under-reporting. The direction it
+does not emphasise is the other one, and both were measured in one session:
+
+- One audit had two specific claims that were simply wrong when re-run, while
+  its top-ranked severity item was never reproduced at all.
+- Another **over-escalated**: it flagged a "security defect named in neither the
+  diff nor any open PR" — the merged PR that shipped the behaviour named it
+  explicitly in its own body, which that same agent had already read for a
+  different finding.
+
+Treat an over-escalation as seriously as a miss. Acting on one burns a session
+and can put a false claim into a public record.
+
+## 7. Suspect the checker — but only with cause
+
+**Reach for this only when you have a specific reason to doubt a particular
+tool.** The four that qualify:
+
+- it disagrees with a second, independent measurement
+- it reports a suspiciously round or absolute result
+- it is brand new, or you have just changed it, AND its result is the one you
+  wanted
+- its output is identical across inputs that should differ
+
+Applied as a general habit this is a cycle burner and a way to talk yourself out
+of true results; this repo's tooling is usually right. That scoping is the rule,
+not a caveat on it.
+
+When one of those fires, ask: does the check cover the same population as the
+claim? Is it answering an ADJACENT question? Did it narrow the data and report
+success anyway?
+
+The generalisable instance is narrower and worth internalising on its own: **a
+query against the wrong FIELD returns a clean empty result indistinguishable
+from a true negative.** Measured — a migration was declared unapplied by
+querying the wrong column; the runner reads a different one, and the migration
+was simply pending a restart. A failed grep is the same shape: a pattern that
+does not account for line wrapping returns nothing and reads as absence.
+
+## 8. Report honestly
+
+Say what you measured, what you assumed, and what you did not check. Record your
+own checker bugs — a mistake in the checking step is the most repeated defect
+there is, and it is invisible unless written down.
+
+A finding that shrinks under investigation is a SUCCESS of this method, not a
+failure of it. The alternative was shipping it.


### PR DESCRIPTION
> **Stacked on #1805** (`docs/guard-fail-direction-truth`), because both touch
> `SKILL.md`. Base is that branch, not `main` — GitHub will retarget automatically
> when #1805 merges. The `base-branch` merge gate will correctly block until then;
> that is expected for a stack, not a defect to override.

## What this adds

`references/high-stakes-verification.md` (143 lines) plus three small `SKILL.md`
insertions (+29): a Reference Router row, an unlettered guard corollary, and a
release-review-scoping rule.

## Invocable, not ambient

It fires on a pre-release review, a bug hunt, or a guard/gate change. Applied to
ordinary work a method document burns cycles for nothing, which is its own
characteristic failure mode. `SKILL.md` is already ~4.6× over its documented size
budget, so the bulk lives in `references/` behind one router row, and only the two
rules that must fire **without** a reference load went inline.

## It carries only what Genesis lacks

The file opens with a pointer table for what is already covered — evidence tiers,
denominators, vacuous-test shapes, the six causes of a RED that comes back GREEN,
mutation housekeeping, corpus blindness, control-must-flip, verify-agent-output,
the acceptance bar — and restates none of them. A second copy of an instruction is
a second thing to keep right, and the copy is the one that goes stale.

**Genuinely new:** one twin per clause · validate the matcher before trusting the
rate · fix at the choke point rather than the call site, including the ordering
trap where a backup placed *after* the operation it protects is inert · generate
rather than read · check what is already in flight before calling a finding new ·
and that an agent's finding errs in **both** directions, over-escalation being as
costly as a miss.

`"Suspect the checker"` is deliberately **scoped**, per an explicit owner decision,
to a tool there is specific cause to doubt. Applied generally it is a way to talk
yourself out of true results, and this repo's tooling is usually right. The section
leads with its four triggers so a reader who stops early gets the scoping rather
than the licence.

## The examples are this session's own failures

Labelled as single instances, not laws: three vacuous tests sharing one shape (an
assertion also true when the mechanism is absent) · a mutation sweep that reported
everything caught **while running zero tests** · a matcher whose 29 findings were
all artifacts and became **0** once it passed an acceptance bar · four findings
measured correctly that were not new · a migration declared unapplied by querying
the wrong column.

## Review

One adversarial pass, internal — no cross-model round consumed.

**The blocker was mine.** A mutant/test count taken from an **external** toolkit's
release notes sat unattributed among first-party located numbers, inside a
corollary that also asserted its cause. A number dropped into that neighbourhood
inherits its neighbours' provenance, so every future session would have read it as
a Genesis measurement over a Genesis bypass. The figure is now **removed** rather
than merely attributed — the shape is kept qualitatively, the source labelled
external, and the project deliberately unnamed.

**Four sections were cut as duplicates** of `SKILL.md`'s Test-First Discipline, and
one of them mattered: the mutation-housekeeping copy told the reader to compare
hashes but dropped the instruction to **PRESERVE** a file that no longer matches
what the mutation wrote — a degraded instruction governing an operation that
destroys another session's uncommitted work. The file went 195 → 143 lines.

Also fixed: a table row pointing at an install-local memory slug that resolves to
**nothing in a clone** (measured: zero hits repo-wide) · a mis-attributed pointer ·
a false universal in the opening line · and an ambiguous "previous tag" in a repo
carrying 124 tags across four prefixes.

The release-scoping rule now **fences the escalation counter** explicitly: scope
decides what BLOCKS, never whether an external round COUNTS. Otherwise "it
pre-dates the release" becomes a new spelling of the rationalization that counter
exists to kill.

## Two process notes

**I broke the file mid-edit.** A two-step replace deleted `SKILL.md`'s "Three
corollaries" header — the second replace then had nothing to match, so my own text
vanished with it. Repaired; `git diff | grep "^-"` returns only the diff header,
zero content deletions, confirmed independently by the reviewer. The `(a)/(b)/(c)`
sequence is unmoved and its three downstream cross-references still resolve, which
is why the new corollary sits outside that sequence.

**My first verification of the duplicate-content finding was wrong.** Single-line
greps returned nothing because the text wraps across lines, and I nearly rejected a
correct finding on it. A failed grep is a lead, not absence — which the reference
itself now says.

Ledger: 39f6465d4e0a4976845aee9e6f5f2c21
