### PR TITLE
fix(eval): a factor with no denominator must not score as zero

### DIFF
--- a/src/genesis/dashboard/routes/eval.py
+++ b/src/genesis/dashboard/routes/eval.py
@@ -22,6 +22,30 @@ _HEADLINE_DEFN_KEY = {
     "ego": "approval_rate_defn",
 }
 
+
+def detect_series_break(
+    snapshots: list[dict], defn_key: str | None,
+) -> str | None:
+    """period_end where a headline metric's DEFINITION changes, else None.
+
+    A redefined metric cannot be read as one trend line: the ego's
+    approval_rate denominator changed on 2026-09-06, which shrinks the
+    denominator and raises the rate, so an unmarked series would show a rise
+    caused by nothing but the redefinition. Points are kept and the break is
+    named, rather than dropping points and blanking the chart.
+
+    Snapshots must be in chronological order.
+    """
+    if not defn_key:
+        return None
+    prev_defn = None
+    for i, snap in enumerate(snapshots):
+        defn = (snap.get("metrics") or {}).get(defn_key)
+        if i > 0 and defn != prev_defn:
+            return snap.get("period_end")
+        prev_defn = defn
+    return None
+
 _HEADLINE_METRIC = {
     "memory": "precision_at_5",
     "system": "composite_score",
@@ -95,20 +119,14 @@ async def metrics_compounding():
         # per point and name where it breaks, rather than dropping points and
         # blanking the chart.
         defn_key = _HEADLINE_DEFN_KEY.get(dim)
-        series_break_at = None
-        prev_defn = None
+        series_break_at = detect_series_break(snapshots, defn_key)
         for snap in snapshots:
             metrics = snap.get("metrics", {})
-            defn = metrics.get(defn_key) if defn_key else None
-            if (defn_key and series_break_at is None and series
-                    and defn != prev_defn):
-                series_break_at = snap.get("period_end")
-            prev_defn = defn
             series.append({
                 "period_end": snap.get("period_end"),
                 "value": metrics.get(headline_key),
                 "sample_count": snap.get("sample_count", 0),
-                "definition": defn,
+                "definition": metrics.get(defn_key) if defn_key else None,
                 "metrics": metrics,
             })
 

--- a/src/genesis/dashboard/routes/eval.py
+++ b/src/genesis/dashboard/routes/eval.py
@@ -16,6 +16,12 @@ _DIMENSIONS = (
 )
 
 # Which metric to extract as the "headline" value per dimension
+#: Dimensions whose headline metric carries a definition-version marker in its
+#: snapshot metrics. A change in the marker is a series break, not a trend.
+_HEADLINE_DEFN_KEY = {
+    "ego": "approval_rate_defn",
+}
+
 _HEADLINE_METRIC = {
     "memory": "precision_at_5",
     "system": "composite_score",
@@ -81,12 +87,28 @@ async def metrics_compounding():
 
         headline_key = _HEADLINE_METRIC.get(dim, "")
         series = []
+        # A headline metric whose DEFINITION changed cannot be plotted as one
+        # line. The ego's approval_rate denominator changed on 2026-09-06
+        # (tabled/withdrawn stopped counting as rejections), which shrinks the
+        # denominator and raises the rate — so an unmarked sparkline would show
+        # a rise caused by nothing but the redefinition. Carry the definition
+        # per point and name where it breaks, rather than dropping points and
+        # blanking the chart.
+        defn_key = _HEADLINE_DEFN_KEY.get(dim)
+        series_break_at = None
+        prev_defn = None
         for snap in snapshots:
             metrics = snap.get("metrics", {})
+            defn = metrics.get(defn_key) if defn_key else None
+            if (defn_key and series_break_at is None and series
+                    and defn != prev_defn):
+                series_break_at = snap.get("period_end")
+            prev_defn = defn
             series.append({
                 "period_end": snap.get("period_end"),
                 "value": metrics.get(headline_key),
                 "sample_count": snap.get("sample_count", 0),
+                "definition": defn,
                 "metrics": metrics,
             })
 
@@ -97,6 +119,10 @@ async def metrics_compounding():
                 latest.get("metrics", {}).get(headline_key) if latest else None
             ),
             "series": series,
+            # Non-null when this dimension's headline metric was redefined
+            # inside the plotted window: the period_end where the new
+            # definition starts. Consumers must not read across it as a trend.
+            "series_break_at": series_break_at,
             "weeks_of_data": len(series),
         }
 

--- a/src/genesis/dashboard/routes/eval.py
+++ b/src/genesis/dashboard/routes/eval.py
@@ -46,6 +46,33 @@ def detect_series_break(
         prev_defn = defn
     return None
 
+
+def latest_definition_segment(series: list[dict]) -> list[dict]:
+    """The trailing run of series points that share one metric definition.
+
+    Naming the break is not enough: the trend below averages a first half
+    against a second half, so a window straddling a redefinition reports the
+    redefinition as movement. The ego's approval_rate v2 raises the rate by
+    construction (a smaller denominator, `failed` in the numerator), which
+    would render as `trend: up`, `trend_good: true` on a week nobody judged
+    anything differently.
+
+    Points carry `definition` (None for dimensions with no registered marker),
+    so a dimension that has never been redefined yields the whole series and
+    the trend is bit-identical to the unsegmented one.
+
+    Series must be in chronological order.
+    """
+    if not series:
+        return []
+    latest = series[-1].get("definition")
+    cut = len(series)
+    for i in range(len(series) - 1, -1, -1):
+        if series[i].get("definition") != latest:
+            break
+        cut = i
+    return series[cut:]
+
 _HEADLINE_METRIC = {
     "memory": "precision_at_5",
     "system": "composite_score",
@@ -144,10 +171,15 @@ async def metrics_compounding():
             "weeks_of_data": len(series),
         }
 
-    # Compute trend direction for each dimension
+    # Compute trend direction for each dimension — WITHIN one definition only.
+    # A trend read across a redefinition measures the redefinition; when the
+    # newest definition has too few points to compare, that is honestly
+    # insufficient data rather than a direction borrowed from the old one.
     for _dim, data in dimensions.items():
+        segment = latest_definition_segment(data["series"])
+        data["trend_basis_weeks"] = len(segment)
         values = [
-            p["value"] for p in data["series"]
+            p["value"] for p in segment
             if p["value"] is not None
         ]
         if len(values) >= 2:

--- a/src/genesis/dashboard/templates/partials/tabs/internals.html
+++ b/src/genesis/dashboard/templates/partials/tabs/internals.html
@@ -486,15 +486,22 @@
                   <template x-for="(pt, i) in data.series" :key="i">
                     <div :style="(() => {
                       const color = data.trend_good === true ? 'rgba(76,175,80,0.5)' : data.trend_good === false ? 'rgba(217,83,79,0.5)' : 'rgba(136,136,136,0.4)';
-                      if (pt.value === null) return `flex:1; background:${color}; border-radius:1px; height:2px;`;
+                      // First point on a REDEFINED metric: the bars either side
+                      // of this edge are not the same measurement.
+                      const brk = pt.period_end && pt.period_end === data.series_break_at ? ' border-left:2px dashed #d9a441;' : '';
+                      if (pt.value === null) return `flex:1; background:${color}; border-radius:1px; height:2px;${brk}`;
                       const vals = data.series.filter(p => p.value !== null).map(p => p.value);
                       const mn = Math.min(...vals), mx = Math.max(...vals);
                       const pct = mx > mn ? ((pt.value - mn) / (mx - mn)) * 90 + 10 : 50;
-                      return `flex:1; background:${color}; border-radius:1px; height:${pct}%;`;
+                      return `flex:1; background:${color}; border-radius:1px; height:${pct}%;${brk}`;
                     })()"></div>
                   </template>
                 </div>
-                <div style="font-size: 0.62rem; opacity: 0.5; margin-top: 0.2rem;" x-text="data.weeks_of_data + ' weeks'"></div>
+                <!-- Name the break in words too: the arrow above is computed
+                     inside the newest definition only (trend_basis_weeks), so
+                     the footer must say what it covers. -->
+                <div style="font-size: 0.62rem; opacity: 0.5; margin-top: 0.2rem;"
+                     x-text="data.series_break_at ? (data.weeks_of_data + ' weeks \u00b7 redefined ' + data.series_break_at + ' \u00b7 trend over ' + data.trend_basis_weeks) : (data.weeks_of_data + ' weeks')"></div>
               </div>
             </template>
           </div>

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -494,7 +494,14 @@ async def _compute_ego_quality(
     # bookkeeping (2026-09-06: one self-tabled row was the entire denominator).
     _NOT_A_JUDGMENT = ("pending", "expired", "tabled", "withdrawn")
     resolved = [p for p in proposals if p["status"] not in _NOT_A_JUDGMENT]
-    approved = [p for p in resolved if p["status"] in ("approved", "executed")]
+    # 'failed' belongs in the NUMERATOR: it is reachable only from 'approved'
+    # (execute_proposal) or from 'executed' (mark_proposal_verification_failed),
+    # so a failed proposal is by definition one the user approved. Counting it
+    # as an approval failure conflates execution with approval — the same
+    # conflation this whole change exists to remove. Its failure is already
+    # measured, separately and correctly, by execution_success_rate below.
+    _WAS_APPROVED = ("approved", "executed", "failed")
+    approved = [p for p in resolved if p["status"] in _WAS_APPROVED]
     approval_rate = round(len(approved) / len(resolved), 4) if resolved else None
 
     # Execution success rate
@@ -515,7 +522,7 @@ async def _compute_ego_quality(
                           else p["confidence"] < bucket_high)]
         if in_bucket:
             bucket_approved = [p for p in in_bucket
-                               if p["status"] in ("approved", "executed")]
+                               if p["status"] in _WAS_APPROVED]
             calibration[label] = {
                 "count": len(in_bucket),
                 "success_rate": round(len(bucket_approved) / len(in_bucket), 4),
@@ -532,11 +539,12 @@ async def _compute_ego_quality(
         "total_unjudged": total - len(resolved),
         # SERIES BREAK MARKER. approval_rate is the ego dimension's headline
         # metric — it drives the dashboard sparkline and _extract_trend_values
-        # -> ego_slope -> go_ready. v1 counted tabled/withdrawn as rejections;
-        # v2 (2026-09-06) excludes them, which shrinks the denominator and
-        # mechanically RAISES the rate. Without this marker the trend would
-        # read as improvement caused by nothing but the redefinition. Same
-        # discipline as judge_prompt_versions above.
+        # -> ego_slope -> go_ready. v2 (2026-09-06) changes it three ways
+        # against v1: tabled/withdrawn leave the denominator, `failed` joins
+        # the numerator, and the calibration buckets stop dropping a
+        # confidence of exactly 1.0. All three RAISE the rate. Without this
+        # marker the trend would read as improvement caused by nothing but the
+        # redefinition. Same discipline as judge_prompt_versions above.
         "approval_rate_defn": _EGO_APPROVAL_RATE_DEFN,
     }
     return metrics, total

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -156,6 +156,14 @@ async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
     ]:
         try:
             grade_info = await grade_fn(db, period_start, period_end, results)
+            # Graders return `reason` at the top level, but the row has no
+            # `reason` column and the dashboard reads factors["reason"]
+            # (dashboard/routes/eval.py) — so every withheld grade rendered a
+            # blank explanation. Fold it in HERE, at the one persist call, so
+            # no future grader has to remember to.
+            grade_factors = dict(grade_info["factors"])
+            if grade_info.get("reason") and "reason" not in grade_factors:
+                grade_factors["reason"] = grade_info["reason"]
             await j9_eval.insert_subsystem_grade(
                 db,
                 period_start=period_start,
@@ -164,7 +172,7 @@ async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
                 subsystem=sub_name,
                 grade=grade_info["grade"],
                 score=grade_info["score"],
-                factors=grade_info["factors"],
+                factors=grade_factors,
                 sample_count=grade_info["sample_count"],
             )
             subsystem_results[sub_name] = grade_info
@@ -417,7 +425,7 @@ async def _compute_system_composite(
         "WHERE deprecated = 0 AND draft = 0",
     )
     row = await cursor.fetchone()
-    proc_mean_conf = round(row["avg_conf"], 4) if row and row["avg_conf"] else None
+    proc_mean_conf = round(row["avg_conf"], 4) if row and row["avg_conf"] is not None else None
 
     # Get memory precision from this week's snapshot (if computed already)
     mem_snapshot = await j9_eval.get_latest_snapshot(db, dimension="memory")
@@ -447,6 +455,19 @@ async def _compute_system_composite(
 
 # ── Dimension 3: Ego Proposal Quality ────────────────────────────────────────
 
+#: Confidence-calibration buckets, written as explicit pairs. Accumulating them
+#: as ``low + 0.2`` gives 0.4 + 0.2 == 0.6000000000000001, which put a
+#: confidence of exactly 0.6 in two buckets and one of exactly 1.0 in none.
+#: The last bucket is closed on the right so 1.0 is counted.
+_CALIBRATION_BUCKETS: list[tuple[float, float]] = [
+    (0.0, 0.2), (0.2, 0.4), (0.4, 0.6), (0.6, 0.8), (0.8, 1.0),
+]
+
+#: Bumped whenever the approval_rate denominator changes. Trend consumers
+#: must not mix versions — see _extract_trend_values.
+_EGO_APPROVAL_RATE_DEFN = "v2_judged_only"
+
+
 
 async def _compute_ego_quality(
     db: aiosqlite.Connection, since: str, until: str,
@@ -461,8 +482,18 @@ async def _compute_ego_quality(
         return {"approval_rate": None, "execution_success_rate": None,
                 "confidence_calibration": {}, "total_proposals": 0}, 0
 
-    # Approval rate (resolved proposals only)
-    resolved = [p for p in proposals if p["status"] not in ("pending", "expired")]
+    # Approval rate — JUDGED proposals only.
+    #
+    # A proposal counts here only if someone actually ruled on it. Four of the
+    # eight statuses are not rulings: 'pending'/'expired' never got an answer,
+    # and 'tabled'/'withdrawn' are reachable with NO human involved at all —
+    # `auto_table_stale_proposals` tables anything past its TTL, the
+    # develop-scope roadmap gate tables a proposal in the same cycle it was
+    # created, and the ego's own reconcile stage withdraws on premise
+    # invalidation. Scoring those as rejections graded the ego down for its own
+    # bookkeeping (2026-09-06: one self-tabled row was the entire denominator).
+    _NOT_A_JUDGMENT = ("pending", "expired", "tabled", "withdrawn")
+    resolved = [p for p in proposals if p["status"] not in _NOT_A_JUDGMENT]
     approved = [p for p in resolved if p["status"] in ("approved", "executed")]
     approval_rate = round(len(approved) / len(resolved), 4) if resolved else None
 
@@ -474,12 +505,14 @@ async def _compute_ego_quality(
 
     # Confidence calibration: bin by confidence decile
     calibration: dict[str, dict] = {}
-    for bucket_low in [0.0, 0.2, 0.4, 0.6, 0.8]:
-        bucket_high = bucket_low + 0.2
+    for i, (bucket_low, bucket_high) in enumerate(_CALIBRATION_BUCKETS):
         label = f"{bucket_low:.1f}-{bucket_high:.1f}"
+        is_last = i == len(_CALIBRATION_BUCKETS) - 1
         in_bucket = [p for p in resolved
                      if p.get("confidence") is not None
-                     and bucket_low <= p["confidence"] < bucket_high]
+                     and bucket_low <= p["confidence"]
+                     and (p["confidence"] <= bucket_high if is_last
+                          else p["confidence"] < bucket_high)]
         if in_bucket:
             bucket_approved = [p for p in in_bucket
                                if p["status"] in ("approved", "executed")]
@@ -494,6 +527,17 @@ async def _compute_ego_quality(
         "confidence_calibration": calibration,
         "total_proposals": total,
         "total_resolved": len(resolved),
+        # Observability: non-judgments are excluded from scoring, but a week
+        # made entirely of them should be legible rather than invisible.
+        "total_unjudged": total - len(resolved),
+        # SERIES BREAK MARKER. approval_rate is the ego dimension's headline
+        # metric — it drives the dashboard sparkline and _extract_trend_values
+        # -> ego_slope -> go_ready. v1 counted tabled/withdrawn as rejections;
+        # v2 (2026-09-06) excludes them, which shrinks the denominator and
+        # mechanically RAISES the rate. Without this marker the trend would
+        # read as improvement caused by nothing but the redefinition. Same
+        # discipline as judge_prompt_versions above.
+        "approval_rate_defn": _EGO_APPROVAL_RATE_DEFN,
     }
     return metrics, total
 
@@ -586,7 +630,7 @@ async def _compute_procedural_effectiveness(
     )
     row = await cursor.fetchone()
     total_procedures = row["total"] if row else 0
-    mean_confidence = round(row["avg_conf"], 4) if row and row["avg_conf"] else None
+    mean_confidence = round(row["avg_conf"], 4) if row and row["avg_conf"] is not None else None
 
     # Tier distribution
     cursor = await db.execute(
@@ -1099,6 +1143,14 @@ def _extract_trend_values(dimension: str, snapshots: list[dict]) -> list[float]:
     values = []
     for s in snapshots:
         m = s.get("metrics", {})
+        # The ego's approval_rate denominator was redefined on 2026-09-06
+        # (tabled/withdrawn are no longer counted as rejections). Mixing the
+        # two definitions in one slope would report improvement caused purely
+        # by the smaller denominator, and ego_slope feeds go_ready. Skip
+        # snapshots that predate the marker rather than comparing across it.
+        if (dimension == "ego"
+                and m.get("approval_rate_defn") != _EGO_APPROVAL_RATE_DEFN):
+            continue
         v = m.get(key_metric)
         if v is not None:
             values.append(float(v))
@@ -1124,20 +1176,34 @@ _MIN_SAMPLES = {"memory": 10, "ego": 5, "procedural": 5,
                 "awareness": 20, "reflection": 10}
 
 
-def _score_with_zero_fill(
+def _score_available_factors(
     available: list[tuple[float | None, float]],
     *,
-    max_nulls: int = 1,
+    max_absent: int = 1,
 ) -> float | None:
-    """Compute weighted score, treating null factors as 0.0.
+    """Weighted score over the factors that HAVE a denominator.
 
-    Returns None if more than *max_nulls* factors are null — the grade
-    should be withheld rather than computed from mostly-absent data.
+    ``None`` means "no data", never "measured zero" — the callers below build
+    it that way (a rate over an empty population is None, a real zero is 0.0).
+    An absent factor is therefore EXCLUDED and the remaining weights are
+    renormalised, so a grade rests on what was actually measured.
+
+    It used to be zero-filled instead, which made "nothing was dispatched"
+    score identically to "everything failed" and produced two recorded ego F
+    grades — including one where the approval rate was 100%. See
+    ``test_absent_factor_never_drags_a_grade_downward``.
+
+    Returns None if more than *max_absent* factors are absent — too little was
+    measured to judge on, so the grade is withheld rather than invented.
     """
-    null_count = sum(1 for v, _ in available if v is None)
-    if null_count > max_nulls:
+    absent = sum(1 for v, _ in available if v is None)
+    if absent > max_absent:
         return None
-    return sum((v if v is not None else 0.0) * w for v, w in available) * 100
+    present = [(v, w) for v, w in available if v is not None]
+    total_weight = sum(w for _, w in present)
+    if total_weight <= 0:
+        return None
+    return sum(v * w for v, w in present) / total_weight * 100
 
 
 def _score_to_grade(score: float | None) -> str | None:
@@ -1182,7 +1248,7 @@ async def _grade_memory(
                 "sample_count": total,
                 "reason": f"insufficient data ({total} recalls, need {_MIN_SAMPLES['memory']})"}
 
-    score = _score_with_zero_fill(available, max_nulls=1)
+    score = _score_available_factors(available, max_absent=1)
     if score is None:
         return {"grade": None, "score": None, "factors": factors,
                 "sample_count": total,
@@ -1209,6 +1275,11 @@ async def _grade_ego(
     approval = metrics.get("approval_rate")
     exec_success = metrics.get("execution_success_rate")
     total = metrics.get("total_proposals", 0)
+    # Gate on the population the FACTORS came from, not on every proposal in
+    # the window. Every factor below is computed over judged proposals only, so
+    # counting pending ones toward _MIN_SAMPLES let a grade issue off n=1 while
+    # reporting a sample of 12 (2026-09-06).
+    judged = metrics.get("total_resolved", 0)
 
     # Confidence calibration accuracy: how well does stated confidence
     # predict actual approval? Perfect calibration = 1.0.
@@ -1228,23 +1299,25 @@ async def _grade_ego(
 
     factors = {"approval_rate": approval, "execution_success_rate": exec_success,
                "calibration_accuracy": cal_accuracy,
-               "total_proposals": total}
+               "total_proposals": total,
+               "total_judged": judged}
 
     available = [(cal_accuracy, 0.4), (exec_success, 0.4), (approval, 0.2)]
 
-    if all(v is None for v, _ in available) or total < _MIN_SAMPLES["ego"]:
+    if all(v is None for v, _ in available) or judged < _MIN_SAMPLES["ego"]:
         return {"grade": None, "score": None, "factors": factors,
-                "sample_count": total,
-                "reason": f"insufficient data ({total} proposals, need {_MIN_SAMPLES['ego']})"}
+                "sample_count": judged,
+                "reason": (f"insufficient data ({judged} judged of {total} "
+                           f"proposals, need {_MIN_SAMPLES['ego']})")}
 
-    score = _score_with_zero_fill(available, max_nulls=1)
+    score = _score_available_factors(available, max_absent=1)
     if score is None:
         return {"grade": None, "score": None, "factors": factors,
-                "sample_count": total,
+                "sample_count": judged,
                 "reason": "too many factors unavailable"}
 
     return {"grade": _score_to_grade(score), "score": round(score, 1),
-            "factors": factors, "sample_count": total}
+            "factors": factors, "sample_count": judged}
 
 
 async def _grade_procedural(
@@ -1263,6 +1336,12 @@ async def _grade_procedural(
     confidence = metrics.get("mean_confidence")
     invocations = metrics.get("invocation_count", 0)
     total_procs = metrics.get("total_procedures", 1)
+    # success_rate is computed over procedure_OUTCOME events, a different and
+    # independently-sized population from the invocation_count the gate below
+    # reads. Without this, a week with 20 invocations and 1 outcome cleared the
+    # sufficiency bar and graded on that single outcome — the same
+    # gate-vs-factor population mismatch that produced the 2026-09-06 ego F.
+    outcomes = metrics.get("outcome_count", 0)
 
     # Invocation activity: ratio of invocations to total procedures.
     # >1.0 per procedure per week = healthy, cap at 1.0 for scoring.
@@ -1270,6 +1349,7 @@ async def _grade_procedural(
 
     factors = {"success_rate": success, "mean_confidence": confidence,
                "invocation_count": invocations, "activity_ratio": round(activity, 4),
+               "outcome_count": outcomes,
                "total_procedures": total_procs}
 
     available = [(success, 0.5), (confidence, 0.25), (activity, 0.25)]
@@ -1279,14 +1359,21 @@ async def _grade_procedural(
                 "sample_count": invocations,
                 "reason": f"insufficient data ({invocations} invocations, need {_MIN_SAMPLES['procedural']})"}
 
-    # Primary factor gate: success_rate is the most important signal.
-    # Without it, grading on confidence + activity alone is misleading.
+    # Primary factor gate: success_rate is the most important signal (50%).
+    # Without it — or without enough of it — grading on confidence + activity
+    # alone is misleading, so withhold rather than invent a letter.
     if success is None:
         return {"grade": None, "score": None, "factors": factors,
                 "sample_count": invocations,
                 "reason": "primary metric (success_rate) not yet measurable"}
+    if outcomes < _MIN_SAMPLES["procedural"]:
+        return {"grade": None, "score": None, "factors": factors,
+                "sample_count": outcomes,
+                "reason": (f"insufficient data ({outcomes} outcomes, need "
+                           f"{_MIN_SAMPLES['procedural']}) — success_rate is "
+                           "50% of the score")}
 
-    score = _score_with_zero_fill(available, max_nulls=1)
+    score = _score_available_factors(available, max_absent=1)
     if score is None:
         return {"grade": None, "score": None, "factors": factors,
                 "sample_count": invocations,
@@ -1383,7 +1470,7 @@ async def _grade_awareness(
                 "reason": f"insufficient data ({total_ticks} ticks, need {_MIN_SAMPLES['awareness']})"}
 
     available = [(tick_regularity, 0.6), (signal_completeness, 0.4)]
-    score = _score_with_zero_fill(available, max_nulls=0)
+    score = _score_available_factors(available, max_absent=0)
     if score is None:
         return {"grade": None, "score": None, "factors": factors,
                 "sample_count": total_ticks,
@@ -1445,7 +1532,7 @@ async def _grade_reflection(
                 "reason": f"insufficient data ({total_obs} observations, need {_MIN_SAMPLES['reflection']})"}
 
     available = [(volume_score, 0.25), (influence_rate, 0.5), (type_diversity, 0.25)]
-    score = _score_with_zero_fill(available, max_nulls=1)
+    score = _score_available_factors(available, max_absent=1)
     if score is None:
         return {"grade": None, "score": None, "factors": factors,
                 "sample_count": total_obs,

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -493,7 +493,10 @@ async def _compute_ego_quality(
 
     if not total:
         return {"approval_rate": None, "execution_success_rate": None,
-                "confidence_calibration": {}, "total_proposals": 0}, 0
+                "confidence_calibration": {}, "total_proposals": 0,
+                # A quiet week is still computed under the CURRENT definition;
+                # without the marker it reads to detect_series_break as a break.
+                "approval_rate_defn": _EGO_APPROVAL_RATE_DEFN}, 0
 
     # Approval rate — JUDGED proposals only.
     #

--- a/src/genesis/eval/j9_aggregator.py
+++ b/src/genesis/eval/j9_aggregator.py
@@ -90,6 +90,24 @@ async def _compute_cognitive_drift(
     return metrics, total
 
 
+def factors_with_reason(grade_info: dict) -> dict:
+    """Return a grader's factors with its top-level `reason` folded in.
+
+    Graders return `reason` alongside `factors`, but `eval_subsystem_grades`
+    has no `reason` column and the dashboard reads `factors["reason"]`
+    (dashboard/routes/eval.py), so every withheld grade rendered a blank
+    explanation. This is the single chokepoint where the fold happens — named
+    so the persist call below and its test exercise the same code, rather than
+    a test re-implementing the fold and passing whatever production does.
+
+    A grader that already put `reason` in its own factors keeps it.
+    """
+    factors = dict(grade_info.get("factors") or {})
+    if grade_info.get("reason") and "reason" not in factors:
+        factors["reason"] = grade_info["reason"]
+    return factors
+
+
 async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
     """Compute and store weekly snapshots for all eval dimensions.
 
@@ -156,14 +174,9 @@ async def run_weekly_aggregation(db: aiosqlite.Connection) -> dict[str, dict]:
     ]:
         try:
             grade_info = await grade_fn(db, period_start, period_end, results)
-            # Graders return `reason` at the top level, but the row has no
-            # `reason` column and the dashboard reads factors["reason"]
-            # (dashboard/routes/eval.py) — so every withheld grade rendered a
-            # blank explanation. Fold it in HERE, at the one persist call, so
-            # no future grader has to remember to.
-            grade_factors = dict(grade_info["factors"])
-            if grade_info.get("reason") and "reason" not in grade_factors:
-                grade_factors["reason"] = grade_info["reason"]
+            # Fold `reason` into factors HERE, at the one persist call, so no
+            # future grader has to remember to. See factors_with_reason.
+            grade_factors = factors_with_reason(grade_info)
             await j9_eval.insert_subsystem_grade(
                 db,
                 period_start=period_start,
@@ -1338,6 +1351,13 @@ async def _grade_procedural(
 
     Factors: success_rate (50%), mean_confidence (25%),
     invocation_activity (25% — normalized by total procedures).
+
+    `sample_count` is the OUTCOME count on every return path, withheld or
+    graded. It is the population the dominant factor (success_rate, 50%) is
+    measured over and the one the gate below withholds on, so it is the number
+    that says how much the grade rests on. Reporting invocations here was how
+    a grade computed from ONE outcome came back labelled `sample_count 435`.
+    Both counts stay in `factors`.
     """
     metrics = dimension_results.get("procedure", {})
     success = metrics.get("success_rate")
@@ -1364,7 +1384,7 @@ async def _grade_procedural(
 
     if invocations < _MIN_SAMPLES["procedural"]:
         return {"grade": None, "score": None, "factors": factors,
-                "sample_count": invocations,
+                "sample_count": outcomes,
                 "reason": f"insufficient data ({invocations} invocations, need {_MIN_SAMPLES['procedural']})"}
 
     # Primary factor gate: success_rate is the most important signal (50%).
@@ -1372,7 +1392,7 @@ async def _grade_procedural(
     # alone is misleading, so withhold rather than invent a letter.
     if success is None:
         return {"grade": None, "score": None, "factors": factors,
-                "sample_count": invocations,
+                "sample_count": outcomes,
                 "reason": "primary metric (success_rate) not yet measurable"}
     if outcomes < _MIN_SAMPLES["procedural"]:
         return {"grade": None, "score": None, "factors": factors,
@@ -1384,11 +1404,11 @@ async def _grade_procedural(
     score = _score_available_factors(available, max_absent=1)
     if score is None:
         return {"grade": None, "score": None, "factors": factors,
-                "sample_count": invocations,
+                "sample_count": outcomes,
                 "reason": "too many factors unavailable"}
 
     return {"grade": _score_to_grade(score), "score": round(score, 1),
-            "factors": factors, "sample_count": invocations}
+            "factors": factors, "sample_count": outcomes}
 
 
 async def _grade_awareness(

--- a/tests/test_dashboard/test_eval_routes.py
+++ b/tests/test_dashboard/test_eval_routes.py
@@ -58,33 +58,48 @@ def test_trend_good_valence(dim, trend, expected):
     assert _trend_good(dim, trend) is expected
 
 
-async def test_headline_series_marks_a_definition_break(monkeypatch):
+def test_headline_series_marks_a_definition_break():
     """A redefined headline metric must not be plotted as one continuous line.
 
     The ego's approval_rate denominator changed on 2026-09-06 (tabled and
-    withdrawn stopped counting as rejections), which shrinks the denominator
-    and raises the rate. An unmarked sparkline would render that as
-    improvement caused by nothing but the redefinition.
+    withdrawn stopped counting as rejections, and failed moved into the
+    numerator), which raises the rate. An unmarked sparkline would render that
+    as improvement caused by nothing but the redefinition.
+
+    This exercises the route's own detect_series_break rather than a copy of
+    its loop, so a change to the route cannot leave the test passing.
     """
-    from genesis.dashboard.routes.eval import _HEADLINE_DEFN_KEY, _HEADLINE_METRIC
+    from genesis.dashboard.routes.eval import (
+        _HEADLINE_DEFN_KEY,
+        _HEADLINE_METRIC,
+        detect_series_break,
+    )
 
     assert _HEADLINE_DEFN_KEY["ego"] == "approval_rate_defn"
     assert _HEADLINE_METRIC["ego"] == "approval_rate"
 
-    # Simulate the loop's break detection over a mixed window.
-    snapshots = [
+    v2 = {"approval_rate": 0.9, "approval_rate_defn": "v2_judged_only"}
+    mixed = [
         {"period_end": "2026-08-23", "metrics": {"approval_rate": 0.2}},
         {"period_end": "2026-08-30", "metrics": {"approval_rate": 0.3}},
-        {"period_end": "2026-09-06",
-         "metrics": {"approval_rate": 0.9, "approval_rate_defn": "v2_judged_only"}},
+        {"period_end": "2026-09-06", "metrics": v2},
     ]
-    defn_key, series_break_at, prev_defn, series = "approval_rate_defn", None, None, []
-    for snap in snapshots:
-        defn = snap["metrics"].get(defn_key)
-        if series_break_at is None and series and defn != prev_defn:
-            series_break_at = snap["period_end"]
-        prev_defn = defn
-        series.append(snap["period_end"])
+    assert detect_series_break(mixed, "approval_rate_defn") == "2026-09-06"
 
-    assert series_break_at == "2026-09-06", series_break_at
-    assert len(series) == 3, "points must be kept, not dropped"
+    # A window entirely on one definition has no break — either side of it.
+    assert detect_series_break(mixed[:2], "approval_rate_defn") is None
+    assert detect_series_break([mixed[2], {"period_end": "x", "metrics": v2}],
+                               "approval_rate_defn") is None
+    # Dimensions with no registered marker never report a break.
+    assert detect_series_break(mixed, None) is None
+    assert detect_series_break([], "approval_rate_defn") is None
+
+
+def test_series_break_is_detected_for_every_registered_defn_key():
+    """The registry and the detector must not drift apart."""
+    from genesis.dashboard.routes.eval import _HEADLINE_DEFN_KEY, detect_series_break
+
+    for dim, key in _HEADLINE_DEFN_KEY.items():
+        snaps = [{"period_end": "a", "metrics": {key: "v1"}},
+                 {"period_end": "b", "metrics": {key: "v2"}}]
+        assert detect_series_break(snaps, key) == "b", dim

--- a/tests/test_dashboard/test_eval_routes.py
+++ b/tests/test_dashboard/test_eval_routes.py
@@ -56,3 +56,35 @@ def test_dimensions_match_aggregator_registration():
 )
 def test_trend_good_valence(dim, trend, expected):
     assert _trend_good(dim, trend) is expected
+
+
+async def test_headline_series_marks_a_definition_break(monkeypatch):
+    """A redefined headline metric must not be plotted as one continuous line.
+
+    The ego's approval_rate denominator changed on 2026-09-06 (tabled and
+    withdrawn stopped counting as rejections), which shrinks the denominator
+    and raises the rate. An unmarked sparkline would render that as
+    improvement caused by nothing but the redefinition.
+    """
+    from genesis.dashboard.routes.eval import _HEADLINE_DEFN_KEY, _HEADLINE_METRIC
+
+    assert _HEADLINE_DEFN_KEY["ego"] == "approval_rate_defn"
+    assert _HEADLINE_METRIC["ego"] == "approval_rate"
+
+    # Simulate the loop's break detection over a mixed window.
+    snapshots = [
+        {"period_end": "2026-08-23", "metrics": {"approval_rate": 0.2}},
+        {"period_end": "2026-08-30", "metrics": {"approval_rate": 0.3}},
+        {"period_end": "2026-09-06",
+         "metrics": {"approval_rate": 0.9, "approval_rate_defn": "v2_judged_only"}},
+    ]
+    defn_key, series_break_at, prev_defn, series = "approval_rate_defn", None, None, []
+    for snap in snapshots:
+        defn = snap["metrics"].get(defn_key)
+        if series_break_at is None and series and defn != prev_defn:
+            series_break_at = snap["period_end"]
+        prev_defn = defn
+        series.append(snap["period_end"])
+
+    assert series_break_at == "2026-09-06", series_break_at
+    assert len(series) == 3, "points must be kept, not dropped"

--- a/tests/test_dashboard/test_eval_routes.py
+++ b/tests/test_dashboard/test_eval_routes.py
@@ -10,7 +10,13 @@ as improvement).
 from __future__ import annotations
 
 import pytest
+from flask import Flask
 
+# Imported at MODULE level on purpose: genesis.dashboard.api decorates the
+# shared blueprint at import time, and Flask forbids that once the blueprint
+# has been registered on any app. A lazy import inside the fixture blows up
+# when another test module in the same session registers it first.
+from genesis.dashboard.api import blueprint
 from genesis.dashboard.routes.eval import (
     _DIMENSIONS,
     _HEADLINE_METRIC,
@@ -103,3 +109,118 @@ def test_series_break_is_detected_for_every_registered_defn_key():
         snaps = [{"period_end": "a", "metrics": {key: "v1"}},
                  {"period_end": "b", "metrics": {key: "v2"}}]
         assert detect_series_break(snaps, key) == "b", dim
+
+
+# ── route-level: the trend must not read across a definition break ───────────
+
+
+@pytest.fixture()
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(blueprint)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def _snap(period_end: str, rate: float, defn: str | None = None) -> dict:
+    metrics: dict = {"approval_rate": rate}
+    if defn is not None:
+        metrics["approval_rate_defn"] = defn
+    return {"period_end": period_end, "metrics": metrics, "sample_count": 4}
+
+
+def _compounding(client, by_dim: dict[str, list[dict]]) -> dict:
+    """Invoke the real route with get_snapshots mocked; return its JSON.
+
+    Exercises ``metrics_compounding`` end to end rather than re-implementing
+    its loop, so a route that stops segmenting the trend — or stops emitting
+    series_break_at — fails here.
+    """
+    from unittest.mock import MagicMock, patch
+
+    async def fake_get_snapshots(_db, *, dimension, period_type, limit):
+        assert period_type == "weekly" and limit == 12
+        # The route reverses into chronological order, so hand back newest-first.
+        return list(reversed(by_dim.get(dimension, [])))
+
+    rt = MagicMock()
+    rt.is_bootstrapped = True
+    rt._db = MagicMock()
+    with patch("genesis.runtime.GenesisRuntime") as MockRT, patch(
+        "genesis.db.crud.j9_eval.get_snapshots", new=fake_get_snapshots,
+    ):
+        MockRT.instance.return_value = rt
+        resp = client.get("/api/genesis/metrics/compounding")
+    assert resp.status_code == 200, resp.data
+    return resp.get_json()["dimensions"]
+
+
+def test_route_trend_is_computed_inside_one_definition(client):
+    """A rise caused only by the redefinition must not render as improvement.
+
+    Chronological ego series: three v1 weeks around 0.1-0.2, then two v2 weeks
+    at 0.95 and 0.90. Averaging the whole window compares 0.10 against 0.68 and
+    reports `up`/`trend_good: true` — improvement manufactured entirely by the
+    denominator change. Inside v2 the rate is FALLING.
+    """
+    ego = [
+        _snap("2026-08-16", 0.10),
+        _snap("2026-08-23", 0.10),
+        _snap("2026-08-30", 0.20),
+        _snap("2026-09-06", 0.95, "v2_judged_only"),
+        _snap("2026-09-13", 0.90, "v2_judged_only"),
+    ]
+    dims = _compounding(client, {"ego": ego})
+
+    assert dims["ego"]["series_break_at"] == "2026-09-06"
+    assert dims["ego"]["weeks_of_data"] == 5          # no point is dropped
+    assert dims["ego"]["trend_basis_weeks"] == 2      # only v2 is compared
+    assert dims["ego"]["trend"] == "down"
+    assert dims["ego"]["trend_good"] is False
+
+
+def test_route_trend_is_insufficient_when_the_new_definition_is_one_week(client):
+    """One point on the new definition is not a trend — it is no data yet.
+
+    Under the unsegmented average this window reported `up`/true off a single
+    redefined week.
+    """
+    ego = [
+        _snap("2026-08-23", 0.10),
+        _snap("2026-08-30", 0.20),
+        _snap("2026-09-06", 0.95, "v2_judged_only"),
+    ]
+    dims = _compounding(client, {"ego": ego})
+
+    assert dims["ego"]["series_break_at"] == "2026-09-06"
+    assert dims["ego"]["trend_basis_weeks"] == 1
+    assert dims["ego"]["trend"] == "insufficient_data"
+    assert dims["ego"]["trend_good"] is None
+
+
+def test_route_trend_unchanged_for_a_series_with_no_break(client):
+    """Blast radius: a dimension that was never redefined keeps its old trend.
+
+    Every point carries `definition: None`, so the segment is the whole series
+    and the computation is the pre-existing one.
+    """
+    ego = [_snap("2026-08-30", 0.20), _snap("2026-09-06", 0.40)]
+    dims = _compounding(client, {"ego": ego})
+
+    assert dims["ego"]["series_break_at"] is None
+    assert dims["ego"]["trend_basis_weeks"] == 2
+    assert dims["ego"]["trend"] == "up"
+    assert dims["ego"]["trend_good"] is True
+    # A dimension with no snapshots at all still answers.
+    assert dims["memory"]["trend"] == "insufficient_data"
+    assert dims["memory"]["weeks_of_data"] == 0
+
+
+def test_latest_definition_segment_keeps_only_the_newest_run():
+    """Direct unit coverage of the segmenting helper's edges."""
+    from genesis.dashboard.routes.eval import latest_definition_segment
+
+    series = [{"definition": None}, {"definition": None}, {"definition": "v2"}]
+    assert latest_definition_segment(series) == [{"definition": "v2"}]
+    assert len(latest_definition_segment(series[:2])) == 2
+    assert latest_definition_segment([]) == []

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -654,12 +654,16 @@ async def test_grade_ego_with_data(db):
                 "0.8-1.0": {"count": 16, "success_rate": 0.13},
             },
             "total_proposals": 29,
+            # 25 of the 29 were actually judged (9 + 16 in the calibration
+            # buckets); the rest never got an answer. The grade is gated on
+            # THIS number, not on total_proposals — see _grade_ego.
+            "total_resolved": 25,
         },
     }
     result = await _grade_ego(db, "2026-05-01", "2026-05-08", dimension_results)
     assert result["grade"] is not None
     assert result["score"] is not None
-    assert result["sample_count"] == 29
+    assert result["sample_count"] == 25
     # Calibration + execution dominate; approval demoted to 20%
     assert result["score"] < 70  # C or below
 
@@ -692,27 +696,6 @@ async def test_grade_procedural_null_success_rate(db):
     result = await _grade_procedural(db, "2026-05-01", "2026-05-08", dimension_results)
     assert result["grade"] is None
     assert "success_rate" in result.get("reason", "")
-
-
-async def test_zero_fill_single_null_penalizes(db):
-    """A single null factor is treated as 0.0, not skipped."""
-    from genesis.eval.j9_aggregator import _score_with_zero_fill
-
-    # All present: (0.8 * 0.4 + 0.6 * 0.3 + 0.7 * 0.3) * 100 ≈ 71.0
-    all_present = [(0.8, 0.4), (0.6, 0.3), (0.7, 0.3)]
-    assert abs(_score_with_zero_fill(all_present, max_nulls=1) - 71.0) < 0.01
-
-    # One null: (0.8 * 0.4 + 0.0 * 0.3 + 0.7 * 0.3) * 100 ≈ 53.0
-    one_null = [(0.8, 0.4), (None, 0.3), (0.7, 0.3)]
-    assert abs(_score_with_zero_fill(one_null, max_nulls=1) - 53.0) < 0.01
-
-
-async def test_zero_fill_multiple_nulls_returns_none(db):
-    """More than max_nulls null factors → no grade."""
-    from genesis.eval.j9_aggregator import _score_with_zero_fill
-
-    two_nulls = [(0.8, 0.4), (None, 0.3), (None, 0.3)]
-    assert _score_with_zero_fill(two_nulls, max_nulls=1) is None
 
 
 async def test_grade_awareness_from_ticks(db):
@@ -1533,3 +1516,264 @@ async def test_compute_goal_completion_excludes_ego_goals(db):
         "abandoned": 0,
     }
     assert metrics["achieved_count"] == 1
+
+
+# ── No-data scoring: a factor without a denominator must not score as 0 ──────
+#
+# Acceptance bar for the 2026-09-06 ego "F" (score 4.0). That week had 12
+# proposals: 11 still pending, and ONE tabled 60ms after creation by the
+# develop-scope roadmap gate (a recoverable bookkeeping record of a proposal
+# self-development being disabled declined to pursue). The tabled row became
+# the entire resolved population, so approval_rate was 0/1, its 0.85 confidence
+# scored against a 0.0 outcome gave calibration 0.1, and a null
+# execution_success_rate was zero-filled at 40% weight. No human judged
+# anything, yet the ego was graded F on it.
+
+
+async def _seed_window_proposals(db, rows):
+    """Seed ego_proposals. rows = [(status, confidence, resolved)]."""
+    for i, (status, conf, resolved) in enumerate(rows):
+        await db.execute(
+            "INSERT INTO ego_proposals "
+            "(id, action_type, content, status, confidence, created_at, resolved_at) "
+            "VALUES (?,'maintenance','c',?,?,?,?)",
+            (f"np{i}", status, conf, "2026-09-02T00:00:00+00:00",
+             "2026-09-02T00:00:00+00:00" if resolved else None),
+        )
+    await db.commit()
+
+
+async def test_ego_grade_withheld_when_only_resolution_is_a_self_tabling(db):
+    """The real 2026-09-06 defect: 11 pending + 1 auto-tabled must NOT grade F.
+
+    Nobody judged any of these proposals, so there is nothing to grade. The
+    correct outcome is a WITHHELD grade, not the worst possible one.
+    """
+    from genesis.eval.j9_aggregator import _compute_ego_quality, _grade_ego
+
+    await _seed_window_proposals(
+        db,
+        [("pending", 0.75, False)] * 11 + [("tabled", 0.85, True)],
+    )
+    since, until = "2026-09-01T00:00:00+00:00", "2026-09-08T00:00:00+00:00"
+    metrics, _ = await _compute_ego_quality(db, since, until)
+    result = await _grade_ego(db, since, until, {"ego": metrics})
+
+    assert result["grade"] != "F", (
+        "an ego whose proposals nobody answered was graded F on one "
+        f"self-tabled bookkeeping row: {result}"
+    )
+    assert result["grade"] is None, result
+
+
+async def test_tabled_and_withdrawn_are_not_rejections(db):
+    """Non-judgments must stay out of the approval denominator.
+
+    Both statuses are reachable with no human involved — `auto_table_stale_
+    proposals` and the ego's own reconcile withdrawal — so scoring them as
+    rejections penalises the ego for its own cleanup.
+    """
+    from genesis.eval.j9_aggregator import _compute_ego_quality
+
+    await _seed_window_proposals(
+        db,
+        [("approved", 0.8, True), ("rejected", 0.8, True),
+         ("tabled", 0.8, True), ("withdrawn", 0.8, True)],
+    )
+    metrics, _ = await _compute_ego_quality(
+        db, "2026-09-01T00:00:00+00:00", "2026-09-08T00:00:00+00:00",
+    )
+    # 1 approved of (1 approved + 1 rejected) — tabled/withdrawn excluded.
+    assert metrics["approval_rate"] == 0.5, metrics
+    assert metrics["total_resolved"] == 2, metrics
+
+
+async def test_ego_min_samples_counts_the_scored_population(db):
+    """The sufficiency gate must read the population the factors came from.
+
+    Pending proposals contribute to no factor, so they must not be what
+    satisfies _MIN_SAMPLES — otherwise a grade issues off n=1 while
+    reporting a sample of 12.
+    """
+    from genesis.eval.j9_aggregator import _compute_ego_quality, _grade_ego
+
+    await _seed_window_proposals(
+        db, [("pending", 0.75, False)] * 20 + [("approved", 0.9, True)],
+    )
+    since, until = "2026-09-01T00:00:00+00:00", "2026-09-08T00:00:00+00:00"
+    metrics, _ = await _compute_ego_quality(db, since, until)
+    result = await _grade_ego(db, since, until, {"ego": metrics})
+
+    assert result["grade"] is None, (
+        f"graded on 1 resolved proposal padded by 20 pending ones: {result}"
+    )
+    assert result["sample_count"] == 1, result
+
+
+async def test_absent_factor_is_excluded_not_scored_as_zero(db):
+    """A factor with no denominator is dropped and the rest renormalised."""
+    from genesis.eval.j9_aggregator import _score_available_factors
+
+    all_present = [(0.8, 0.4), (0.6, 0.3), (0.7, 0.3)]
+    assert abs(_score_available_factors(all_present, max_absent=1) - 71.0) < 0.01
+
+    # Absent middle factor: (0.8*0.4 + 0.7*0.3) / (0.4+0.3) * 100 ≈ 75.71
+    one_absent = [(0.8, 0.4), (None, 0.3), (0.7, 0.3)]
+    assert abs(_score_available_factors(one_absent, max_absent=1) - 75.71) < 0.01
+
+    # Too little left to judge on.
+    two_absent = [(0.8, 0.4), (None, 0.3), (None, 0.3)]
+    assert _score_available_factors(two_absent, max_absent=1) is None
+
+
+async def test_absent_factor_never_drags_a_grade_downward(db):
+    """Regression guard: absence must never be cheaper than presence.
+
+    Zero-filling made 'no data' indistinguishable from 'scored 0.0', which is
+    the mechanism behind both recorded ego F grades.
+    """
+    from genesis.eval.j9_aggregator import _score_available_factors
+
+    absent = _score_available_factors([(0.8, 0.4), (None, 0.6)], max_absent=1)
+    scored_zero = _score_available_factors([(0.8, 0.4), (0.0, 0.6)], max_absent=1)
+    assert absent > scored_zero, (absent, scored_zero)
+
+
+async def test_procedural_grade_gated_on_the_outcome_population(db):
+    """The gate must read outcomes, not invocations.
+
+    success_rate is 50% of the procedural score and is computed over
+    procedure_outcome events, while the sufficiency gate read
+    invocation_count — a different, independently-sized population. A week
+    with plenty of invocations and one outcome graded on that one outcome.
+    """
+    dimension_results = {
+        "procedure": {
+            "success_rate": 0.0,
+            "mean_confidence": 0.7,
+            "invocation_count": 435,   # clears the old gate easily
+            "outcome_count": 1,        # ...on a single measured outcome
+            "total_procedures": 2334,
+        },
+    }
+    result = await _grade_procedural(db, "2026-05-01", "2026-05-08", dimension_results)
+    assert result["grade"] is None, result
+    assert "outcomes" in result.get("reason", ""), result
+
+
+async def test_awareness_and_reflection_scoring_is_unchanged(db):
+    """These two graders never produce an absent factor, so the helper change
+    must be a no-op for them.
+
+    Their factors are ratios that default to 0.0 rather than None once the
+    gate passes, so renormalising over 'present' factors is the identity. This
+    pins that the blast radius of the scoring change stops here.
+    """
+    from genesis.eval.j9_aggregator import _score_available_factors
+
+    # Real weight vectors: awareness (.6/.4) and reflection (.25/.5/.25).
+    # An earlier revision of this test used memory's (.4/.3/.3) by mistake and
+    # claimed to cover reflection.
+    for weights in ([(0.9, 0.6), (0.8, 0.4)],
+                    [(1.0, 0.25), (0.55, 0.5), (0.6, 0.25)]):
+        renormalised = _score_available_factors(weights, max_absent=0)
+        legacy = sum(v * w for v, w in weights) * 100
+        assert abs(renormalised - legacy) < 1e-9, (weights, renormalised, legacy)
+
+
+async def test_calibration_buckets_cover_every_confidence_exactly_once(db):
+    """Bucket edges must not be accumulated in floating point.
+
+    `bucket_low + 0.2` gives 0.4 + 0.2 == 0.6000000000000001, which put a
+    confidence of exactly 0.6 in TWO buckets and one of exactly 1.0 in NONE.
+    Calibration is 40% of the ego grade, and `j9_regression` proposals are
+    created at confidence 1.0 — so every auto-filed regression proposal was
+    invisible to the heaviest factor in its own subsystem's grade.
+    """
+    from genesis.eval.j9_aggregator import _CALIBRATION_BUCKETS, _compute_ego_quality
+
+    for lo, hi in _CALIBRATION_BUCKETS:
+        assert round(hi - lo, 10) == 0.2, (lo, hi)
+
+    # NOTE: a total-slot count is NOT a valid assertion here — under the bug
+    # the double-counted 0.6 and the dropped 1.0 cancel out exactly, so the
+    # total is conserved. Assert each edge case's PLACEMENT instead.
+    await _seed_window_proposals(db, [("approved", 0.6, True)])
+    metrics, _ = await _compute_ego_quality(
+        db, "2026-09-01T00:00:00+00:00", "2026-09-08T00:00:00+00:00",
+    )
+    cal = metrics["confidence_calibration"]
+    assert sum(b["count"] for b in cal.values()) == 1, (
+        f"one proposal at confidence 0.6 occupies {len(cal)} buckets: {cal}"
+    )
+    assert list(cal) == ["0.6-0.8"], cal
+
+
+async def test_calibration_counts_a_confidence_of_exactly_one(db):
+    """confidence == 1.0 fell outside every half-open bucket.
+
+    j9_regression proposals are created at confidence 1.0
+    (regression_alert.py), so the ego's own auto-filed regressions never
+    reached the factor worth 40% of its grade.
+    """
+    from genesis.eval.j9_aggregator import _compute_ego_quality
+
+    await _seed_window_proposals(db, [("approved", 1.0, True)])
+    metrics, _ = await _compute_ego_quality(
+        db, "2026-09-01T00:00:00+00:00", "2026-09-08T00:00:00+00:00",
+    )
+    cal = metrics["confidence_calibration"]
+    assert cal.get("0.8-1.0", {}).get("count") == 1, (
+        f"a confidence of exactly 1.0 was counted nowhere: {cal}"
+    )
+
+
+async def test_ego_metrics_carry_the_approval_rate_definition_marker(db):
+    """approval_rate is the ego headline series — its definition must travel.
+
+    It drives the dashboard sparkline and _extract_trend_values -> ego_slope
+    -> go_ready. Excluding tabled/withdrawn shrinks the denominator and raises
+    the rate, so an unmarked change would read as improvement.
+    """
+    from genesis.eval.j9_aggregator import (
+        _EGO_APPROVAL_RATE_DEFN,
+        _compute_ego_quality,
+        _extract_trend_values,
+    )
+
+    await _seed_window_proposals(db, [("approved", 0.8, True)])
+    metrics, _ = await _compute_ego_quality(
+        db, "2026-09-01T00:00:00+00:00", "2026-09-08T00:00:00+00:00",
+    )
+    assert metrics["approval_rate_defn"] == _EGO_APPROVAL_RATE_DEFN
+
+    # A pre-marker snapshot must not be averaged into the slope.
+    mixed = [{"metrics": {"approval_rate": 0.1}},                       # v1
+             {"metrics": {"approval_rate": 0.9,
+                          "approval_rate_defn": _EGO_APPROVAL_RATE_DEFN}}]
+    assert _extract_trend_values("ego", mixed) == [0.9]
+    # Other dimensions are unaffected by the guard.
+    assert _extract_trend_values(
+        "memory", [{"metrics": {"precision_at_5": 0.5}}]) == [0.5]
+
+
+async def test_withheld_grade_reason_reaches_the_dashboard_key(db):
+    """`reason` must land in factors, which is where the dashboard reads it.
+
+    insert_subsystem_grade has no `reason` column and
+    dashboard/routes/eval.py reads factors["reason"], so every grader's
+    explanation was silently dropped. This fix makes the withheld path — now
+    the common path for ego — legible instead of blank.
+    """
+    from genesis.eval.j9_aggregator import _compute_ego_quality, _grade_ego
+
+    await _seed_window_proposals(db, [("pending", 0.7, False)] * 6)
+    since, until = "2026-09-01T00:00:00+00:00", "2026-09-08T00:00:00+00:00"
+    metrics, _ = await _compute_ego_quality(db, since, until)
+    info = await _grade_ego(db, since, until, {"ego": metrics})
+
+    assert info["grade"] is None
+    grade_factors = dict(info["factors"])
+    if info.get("reason") and "reason" not in grade_factors:
+        grade_factors["reason"] = info["reason"]          # the persist chokepoint
+    assert "judged" in grade_factors["reason"], grade_factors["reason"]

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -1777,3 +1777,29 @@ async def test_withheld_grade_reason_reaches_the_dashboard_key(db):
     if info.get("reason") and "reason" not in grade_factors:
         grade_factors["reason"] = info["reason"]          # the persist chokepoint
     assert "judged" in grade_factors["reason"], grade_factors["reason"]
+
+
+async def test_a_failed_execution_still_counts_as_an_approval(db):
+    """`failed` is post-approval, so it belongs in the approval numerator.
+
+    ego_crud.execute_proposal only transitions rows that are already
+    'approved', and mark_proposal_verification_failed only transitions rows
+    that are already 'executed'. So a failed proposal is by definition one the
+    user approved; scoring it as an approval failure conflates execution with
+    approval — the same conflation the rest of this change removes. Its
+    failure is measured separately by execution_success_rate.
+    """
+    from genesis.eval.j9_aggregator import _compute_ego_quality
+
+    await _seed_window_proposals(
+        db,
+        [("approved", 0.8, True), ("executed", 0.8, True),
+         ("failed", 0.8, True), ("rejected", 0.8, True)],
+    )
+    metrics, _ = await _compute_ego_quality(
+        db, "2026-09-01T00:00:00+00:00", "2026-09-08T00:00:00+00:00",
+    )
+    # 3 of 4 judged proposals were approved; only the rejection was not.
+    assert metrics["approval_rate"] == 0.75, metrics
+    # The failure is still counted, in the metric that measures execution.
+    assert metrics["execution_success_rate"] == 0.5, metrics

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -1659,6 +1659,38 @@ async def test_procedural_grade_gated_on_the_outcome_population(db):
     result = await _grade_procedural(db, "2026-05-01", "2026-05-08", dimension_results)
     assert result["grade"] is None, result
     assert "outcomes" in result.get("reason", ""), result
+    # sample_count must describe the population the grade rests on. Reporting
+    # invocations here is how "graded on 1 outcome" came back as n=435.
+    assert result["sample_count"] == 1, result
+    assert result["factors"]["invocation_count"] == 435   # still legible
+
+
+async def test_procedural_sample_count_is_one_population_on_every_path(db):
+    """Withheld and graded rows must not report different populations.
+
+    sample_count lands in one column and one sparkline; if the withheld path
+    counts outcomes and the graded path counts invocations, the series changes
+    meaning between adjacent weeks. _grade_ego reports its judged population on
+    every path — procedural now matches.
+    """
+    base = {"success_rate": 0.8, "mean_confidence": 0.7,
+            "invocation_count": 435, "outcome_count": 40,
+            "total_procedures": 2334}
+    graded = await _grade_procedural(
+        db, "2026-05-01", "2026-05-08", {"procedure": base})
+    assert graded["grade"] is not None, graded
+    assert graded["sample_count"] == 40, graded
+
+    # Withheld on the invocation gate, and withheld on the missing primary
+    # factor — both report the same population as the graded path.
+    few = await _grade_procedural(
+        db, "2026-05-01", "2026-05-08",
+        {"procedure": {**base, "invocation_count": 2, "outcome_count": 1}})
+    assert few["grade"] is None and few["sample_count"] == 1, few
+    no_primary = await _grade_procedural(
+        db, "2026-05-01", "2026-05-08",
+        {"procedure": {**base, "success_rate": None}})
+    assert no_primary["grade"] is None and no_primary["sample_count"] == 40, no_primary
 
 
 async def test_awareness_and_reflection_scoring_is_unchanged(db):
@@ -1764,8 +1796,16 @@ async def test_withheld_grade_reason_reaches_the_dashboard_key(db):
     dashboard/routes/eval.py reads factors["reason"], so every grader's
     explanation was silently dropped. This fix makes the withheld path — now
     the common path for ego — legible instead of blank.
+
+    It calls the production fold (`factors_with_reason`, the named chokepoint
+    run_weekly_aggregation uses) rather than a copy of it, so deleting the fold
+    fails this test instead of leaving it green.
     """
-    from genesis.eval.j9_aggregator import _compute_ego_quality, _grade_ego
+    from genesis.eval.j9_aggregator import (
+        _compute_ego_quality,
+        _grade_ego,
+        factors_with_reason,
+    )
 
     await _seed_window_proposals(db, [("pending", 0.7, False)] * 6)
     since, until = "2026-09-01T00:00:00+00:00", "2026-09-08T00:00:00+00:00"
@@ -1773,10 +1813,36 @@ async def test_withheld_grade_reason_reaches_the_dashboard_key(db):
     info = await _grade_ego(db, since, until, {"ego": metrics})
 
     assert info["grade"] is None
-    grade_factors = dict(info["factors"])
-    if info.get("reason") and "reason" not in grade_factors:
-        grade_factors["reason"] = info["reason"]          # the persist chokepoint
+    grade_factors = factors_with_reason(info)             # the persist chokepoint
     assert "judged" in grade_factors["reason"], grade_factors["reason"]
+    # A grader that already carries its own `reason` in factors keeps it.
+    assert factors_with_reason(
+        {"factors": {"reason": "mine"}, "reason": "outer"})["reason"] == "mine"
+    # No reason at all leaves factors untouched (graded path).
+    assert factors_with_reason({"factors": {"a": 1}}) == {"a": 1}
+
+
+async def test_withheld_reason_survives_the_persist_call(db):
+    """The fold must be WIRED, not merely available.
+
+    Asserting the helper alone would stay green if run_weekly_aggregation
+    stopped calling it, so this reads the row the dashboard reads: every
+    withheld grade persisted by a full aggregation must carry its reason in
+    factors_json.
+    """
+    from genesis.db.crud import j9_eval as j9_crud
+    from genesis.eval.j9_aggregator import run_weekly_aggregation
+
+    await run_weekly_aggregation(db)          # empty window -> all withheld
+
+    rows = await j9_crud.get_latest_subsystem_grades(db)
+    assert rows, "aggregation persisted no subsystem grades"
+    withheld = [r for r in rows if r["grade"] is None]
+    assert withheld, [r["subsystem"] for r in rows]
+    for row in withheld:
+        assert row["factors"].get("reason"), row["subsystem"]
+    ego = [r for r in rows if r["subsystem"] == "ego"]
+    assert ego and "judged" in ego[0]["factors"]["reason"], ego
 
 
 async def test_a_failed_execution_still_counts_as_an_approval(db):

--- a/tests/test_eval/test_j9_eval.py
+++ b/tests/test_eval/test_j9_eval.py
@@ -1869,3 +1869,35 @@ async def test_a_failed_execution_still_counts_as_an_approval(db):
     assert metrics["approval_rate"] == 0.75, metrics
     # The failure is still counted, in the metric that measures execution.
     assert metrics["execution_success_rate"] == 0.5, metrics
+
+
+async def test_a_quiet_week_is_not_a_definition_break(db):
+    """A week with no proposals must still carry the definition marker.
+
+    The marker is what detect_series_break / latest_definition_segment read.
+    An empty week that omits it looks like a REDEFINITION sitting between two
+    v2 weeks: the trend segment is cut to the single newest point and the
+    dashboard reports `insufficient_data` on a series whose definition never
+    changed. The week WAS computed under v2 rules, so it must say so.
+    """
+    from genesis.dashboard.routes.eval import latest_definition_segment
+    from genesis.eval.j9_aggregator import (
+        _EGO_APPROVAL_RATE_DEFN,
+        _compute_ego_quality,
+    )
+
+    metrics, sample = await _compute_ego_quality(
+        db,
+        "2026-09-01T00:00:00+00:00",
+        "2026-09-08T00:00:00+00:00",
+    )
+    assert sample == 0 and metrics["total_proposals"] == 0, metrics
+    assert metrics.get("approval_rate_defn") == _EGO_APPROVAL_RATE_DEFN, metrics
+
+    # v2 -> quiet week -> v2 is ONE segment: the trend keeps both real points.
+    series = [
+        {"definition": _EGO_APPROVAL_RATE_DEFN, "value": 0.5},
+        {"definition": metrics.get("approval_rate_defn"), "value": None},
+        {"definition": _EGO_APPROVAL_RATE_DEFN, "value": 0.9},
+    ]
+    assert len(latest_definition_segment(series)) == 3, series


### PR DESCRIPTION
## What broke

The weekly grader gave the ego an **F (score 4.0)** for the week ending 2026-09-06, which fired an operator BLOCKER alert and filed a `j9_regression` proposal. Nobody had judged anything that week: 11 of 12 proposals were still `pending`, and the 12th was `tabled` 60 milliseconds after creation by the develop-scope roadmap gate — a recoverable bookkeeping record of a proposal that self-development being disabled declined to pursue. That single row became the entire denominator.

Three defects had to line up:

| | Defect | Effect |
|---|---|---|
| a | `tabled`/`withdrawn` scored as rejections | the ego marked down for its own cleanup |
| b | sufficiency gate counted `pending` while factors came from `resolved` | grade issued off n=1 while reporting a sample of 12 |
| c | null `execution_success_rate` zero-filled at 40% weight | "nothing was dispatched" scored as "everything failed" |

`0.1 x 0.4 + 0 x 0.4 + 0.0 x 0.2 = 0.04` — the stored 4.0, reproduced exactly by the new tests against the unfixed code.

Defect (c) alone is enough to produce an F on a **100%-approval week**: a second recorded case grades 56.0 with `approval_rate` 1.0 and calibration 0.9, purely from the zero-filled factor.

## What changed

`_score_with_zero_fill` becomes `_score_available_factors`: an absent factor is excluded and the remaining weights renormalised, so a grade rests on what was measured. `tabled`/`withdrawn` leave the approval denominator. `_grade_ego` gates on the judged population; `_grade_procedural` gets the same fix, gating on `outcome_count` rather than `invocation_count` since `success_rate` is 50% of that score and comes from a different population.

This aligns j9 with definitions the codebase already had: `feedback/harvest.py` classifies both statuses as neutral lifecycle states ("a timeout is NOT disapproval"), and `intervention_journal` / `capability_aggregator` already select the exact complement of the new judged set.

## Found while fixing it

- **Calibration bucket edges were accumulated in floating point** — `0.4 + 0.2 == 0.6000000000000001`. A confidence of exactly `0.6` was counted in two buckets and one of exactly `1.0` in none. `j9_regression` proposals are created at confidence 1.0, so the ego's own auto-filed regressions never reached the factor worth **40% of its grade**.
- **Every grader's `reason` was dropped at the DB boundary.** The row has no `reason` column and the dashboard reads `factors["reason"]`, which no grader ever set. An AST walk found 11 of 16 return paths affected across all five graders, so it is folded in at the single persist call rather than patched at 11 sites.
- **A measured mean confidence of `0.0` was read as absent** via a truthiness test. Harmless under zero-fill; score-inflating under renormalisation.

`approval_rate` is the ego's headline series — it drives the dashboard sparkline and `ego_slope` → `go_ready` — so the redefinition ships a version marker and the slope now refuses to mix definitions, rather than reporting improvement caused by a smaller denominator.

## Measured blast radius

Pre-fix vs post-fix on **identical data**, across all 17 stored weekly windows: **2 letter grades change** (2026-07-12 D→C, 2026-09-06 F→withheld). Both genuine F weeks (2026-06-07, 2026-07-19) remain F — the fix corrects the pathological case without whitewashing bad weeks.

Awareness and reflection are provably unaffected: all four weight vectors sum to exactly 1.0 in IEEE754, so with every factor present the renormalisation is a bit-exact identity, and both graders' factors are `X if Y else 0.0` rather than `None`.

## Verification

- 80 tests in `tests/test_eval/test_j9_eval.py`; 38 in adjacent consumers (`test_regression_alert`, `test_j9_batch`, `test_j9_dev_quality`, `test_dashboard/test_eval_routes`).
- Verify-RED by mutation with restore-by-hash: removing the procedural gate reproduces `F/22.2` on `sample_count 435` from one outcome; reverting the bucket loop reproduces "0.6 occupies 2 buckets" and "1.0 counted nowhere".
- One earlier mutation run emitted no result line (venv not inherited) and was treated as inconclusive and re-run, not read as a pass.
- A first version of the bucket test was **vacuous** and was caught before commit: the double-counted `0.6` and the dropped `1.0` cancel exactly, so a slot-count assertion passes on broken code. It now asserts placement.

## Not fixed here

Stored `eval_subsystem_grades` rows are not reproducible from the data they were computed on — `ego_proposals` statuses keep mutating after a grade is stored. Control measurement: week 2026-08-16 stored 82.0 but recomputes to 70.0 under **both** old and new semantics, 12 points of drift unrelated to this change. That is why history is not rewritten here; it is being filed separately.

Two superseded tests were removed: `test_zero_fill_single_null_penalizes` pinned the retired semantics, and `test_zero_fill_multiple_nulls_returns_none` is covered by its replacement. `test_grade_ego_with_data` gained the `total_resolved` key its real producer always emits.

Ledger: b07a73b5aeda42d698149e28980fab6e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved evaluation accuracy when grading factors are unavailable by recalculating scores from measured factors.
  - Preserved valid zero values in confidence averages.
  - Refined approval-rate and calibration calculations, including boundary cases and excluded non-judgment outcomes.
  - Counted failed executions as approved rulings while tracking execution failures separately.
  - Prevented grades when judged proposals or outcome data is insufficient.
  - Improved trend reporting across metric-definition changes.
  - Added clearer grading context, withheld-grade reasons, definition metadata, and trend-period details in the dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->