### PR TITLE
docs: an inference cannot outrank a rule that names the exact thing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -521,6 +521,25 @@ every emitter's arithmetic, so this class cannot go quiet again.
   file does not outrank the user. That does NOT extend to the standing approval
   gates, which no instruction waives: refuse, and say so (Traps: autonomous-CLI,
   ego proposals; Rules: financial transactions, destructive commands).
+- **An inference you make CANNOT outrank a rule that names the exact thing.**
+  "This file does not outrank the user" means the user's ACTUAL WORDS, never your
+  reading of what they must have meant. A rule that names a specific object — a
+  service, host, surface, command, path, account — is cleared ONLY by user text
+  CONTAINING THAT NAME. Do the string check; it is mechanical, unlike "did they
+  mean it?", which is unfalsifiable and is what gets rationalized. Naming a
+  destination never authorizes a road: "use model X" does not clear a ban on the
+  service you happen to know reaches X. **Ambiguity resolves TOWARD the
+  prohibition** — a prohibition and an authorization are not symmetric, and
+  absence of mention is never permission. If the only route you know is a
+  forbidden one, that is exactly when you STOP and ask, not when you supply the
+  missing half yourself.
+
+  **The tripwire: writing "my read is you meant…" about something a rule forbids
+  IS the stop**, not a preamble to proceeding. And naming a rule then crossing it
+  in the same turn is not raising it — it is narrating, and it is worse than
+  silence, because it teaches the user to discount your flagging: if you surface a
+  conflict and proceed anyway, they cannot tell your real stops from your narrated
+  ones. Asking costs one line.
 - **Cross-session messages: the bar is on the REPLY, not the send.** Send a
   peer when there is good reason (region collision, a MEASURED contradiction of
   their claim, shared-resource contention, a defect in their blast radius, or a


### PR DESCRIPTION
## What

One Rules bullet in `CLAUDE.md`, placed immediately after the bullet it qualifies:

> **An inference you make CANNOT outrank a rule that names the exact thing.**

## Why there, specifically

The adjacent bullet already says an instruction conflicting with a project rule
gets named rather than silently obeyed, and that "this file does not outrank the
user." That last clause is the one that needs pinning down: it means the user's
**actual words**, not a reading of what they must have meant. Appending this
anywhere else in a 42KB file would have left that clause standing alone.

## The test it adds — mechanical, not judgemental

A rule naming a specific object (service, host, surface, command, path, account)
is cleared **only by user text containing that name**. That is a string check.
"Did they mean it?" is unfalsifiable, and unfalsifiable is what gets rationalised.

Naming a destination never authorizes a road: "use model X" does not clear a ban
on the service that happens to reach X. And **ambiguity resolves toward the
prohibition** — a prohibition and an authorization are not symmetric, so absence
of mention is never permission. If the only route you know is a forbidden one,
that is precisely when to stop and ask rather than supply the missing half.

## Two behavioural tells

- Writing *"my read is you meant…"* about something a rule forbids **is** the
  stop, not a preamble to proceeding.
- Naming a rule and crossing it in the same turn is narration, not raising it —
  and it is worse than silence, because it teaches the reader to discount every
  future flag. They cannot tell a real stop from a narrated one.

## Placement rationale

`CLAUDE.md` rather than agent memory, deliberately. Memory has a retrieval step,
and a constraint filed as the answer to one question will not surface when a
different question is asked. `CLAUDE.md` has no retrieval step.

## Known coverage gaps, named rather than left quiet

- `AGENTS.md` carries this instruction set to Codex/Cursor/OpenCode and is **not**
  generated from `CLAUDE.md` (`scripts/export_agents_md.py` reads `AGENTS.md`
  itself; no CI check pairs them). Those clients do not inherit this.
- The genesis-development skill holds the reviewer policy this rule is about.

Both are separate decisions, not folded in here.

E2E: none — prose only, in a file with no runtime path. Verified instead by
reading: no CI assertion constrains `CLAUDE.md`'s size or shape (the hook-output
budget test governs SessionStart injection parts, which this is not — Claude Code
loads it natively), and the addition is two bullet paragraphs inside the existing
`## Rules` list.
