### PR TITLE
docs(security): the autonomous-CLI approval gate is a setting, not a constant

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,8 +68,15 @@ currently ships.
 Every autonomous background Claude Code session must be rooted in an explicit
 operator approval: `manual_approval_required` (`autonomy/cli_policy.py`)
 defaults to `True`, and `AutonomousCliApprovalGate` refuses to dispatch without
-one. No autonomy level unlocks past it, and it is not a tunable — a fork that
-defaults it off has removed the guarantee the rest of this section describes.
+one. No autonomy level unlocks past it.
+
+It is a SETTING, not a constant, and you should treat it as one worth checking.
+It is read from `config/autonomous_cli_policy.yaml` and can be overridden by the
+`GENESIS_AUTONOMOUS_CLI_APPROVAL_ENABLED` environment variable — so it can be
+turned off in an install without anyone forking anything. The project treats
+keeping it `True` as non-negotiable and ships it that way; what this document
+cannot tell you is whether it is still `True` in YOUR install. Verify it, and
+treat a `False` as the whole earned-autonomy model being switched off.
 
 ### Container Isolation
 
@@ -104,10 +111,15 @@ isolation is still load-bearing for you — it is:
 - It is **inert when no dashboard password is set**, which is the default.
 - It exempts everything under the `/api/genesis/auth/` prefix — a prefix match,
   not a fixed list, so any route added there in future is exempt by default.
-  Today that prefix holds only login, logout and an auth-status probe, none of
-  which mutate a credential.
+  Today that prefix holds login, logout and an auth-status probe. None of them
+  changes a credential — but login and logout do establish and tear down an
+  authenticated session, and they run ungated by design, because a login that
+  required prior authentication could never succeed.
 - It can be disabled outright with `GENESIS_DASHBOARD_API_AUTH=off`.
-- The built-in web terminal and the noVNC console are **not** covered by it.
+- It covers state-changing HTTP requests under the API prefixes, and nothing
+  else. The interactive terminal runs over a WebSocket and the noVNC console
+  over its own port; neither is behind this gate, so for those the control is
+  still network isolation and the dashboard password on the UI.
 
 This is safe **only under the assumed deployment model: the host is not
 publicly exposed.** The dashboard is meant to be reachable through one of:


### PR DESCRIPTION
## What

One paragraph in `SECURITY.md`. It currently tells operators the autonomous-CLI
approval gate **"is not a tunable — a fork that defaults it off has removed the
guarantee"**, one line below saying `manual_approval_required` *defaults to* `True`.

A defaulted setting is tunable by definition, and this one is settable from two
places with no fork involved:

- `autonomy/cli_policy.py:102-104` — `_env_bool("GENESIS_AUTONOMOUS_CLI_APPROVAL_ENABLED", True)`
- `autonomy/cli_policy.py:172-173` — `raw.get("manual_approval_required", …)` read from
  `config/autonomous_cli_policy.yaml` (shipped, line 2)

## Why it matters more than a wording nit

It is an overstatement in the **fail-open** direction, in the document whose entire
defect was describing protection wrongly. An operator reading "not a tunable" may
conclude the approval gate cannot be silently disabled in their install. It can.

The replacement says it is a setting, names both override paths, states that the
project ships it `True` and treats keeping it so as non-negotiable, and then says
the one thing the document cannot know: **whether it is still `True` in your
install** — so verify it, and read a `False` as the earned-autonomy model being
switched off.

## Provenance

This sentence was written by the previous commit on the branch that became #1810,
while fixing a *different* review finding — and #1810 merged before the correction
landed, so the overstatement is live on `main` now. Found by a re-review at the
current head.

E2E: none — prose only, no runtime surface. Verified by reading `cli_policy.py`
and `config/autonomous_cli_policy.yaml` directly rather than by execution, which is
the appropriate check for a document whose defect was describing the code wrongly.
