### PR TITLE
fix(gate): E2E declaration is advisory, not a merge block

### DIFF
--- a/.claude/skills/genesis-development/SKILL.md
+++ b/.claude/skills/genesis-development/SKILL.md
@@ -2054,9 +2054,10 @@ merge, the Pre-Merge Gate below governs unchanged.
 
 **Canonical pre-merge check:** run
 `python3 scripts/hooks/git_push_guard.py --check-pr <N> [--repo OWNER/REPO]`
-BEFORE proposing a merge. It runs the SAME functions the enforcement gate uses
-(mergeable → CI → base-invariant → Codex-freshness → scheduled-Claude-review →
-review-body → inline findings), so the report and the gate can never disagree —
+BEFORE proposing a merge. It runs the SAME functions the enforcement gate uses, in the gate's own order
+(mergeable → CI → base-invariant → pin-receipts → e2e-plan *(advisory)* →
+Codex-freshness → head-binding → review-body → inline findings →
+scheduled-Claude-review), so the two read the same state —
 this `--check-pr` read IS the mandatory pre-merge step: **always run it and read
 the PR's automated-review comments (Codex, leak/CI, the scheduled Claude review)
 before any merge** — never hand-roll a

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,10 @@ Closes #
      declaring here pre-fills that row with what YOU know instead of leaving a
      validator to reverse-engineer it from the diff days later. (This guidance
      lives inside a comment on purpose: comments are stripped before the line is
-     read, so the template can never fill itself in.) -->
+     read, so the template can never fill itself in.)
 
-E2E:
+     The marker is NOT pre-printed below. A bare `E2E:` parses as *present but
+     empty*, which is reported as undeclared — so shipping one in the template
+     would fire the advisory, with its full remedy block, on every PR whose
+     author simply left the template alone. An advisory that fires on everything
+     is one nobody reads. Type the whole line, or type nothing. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,17 +23,19 @@ Closes #
 - [ ] `pytest -v` passes
 - [ ] `docs/architecture/CURRENT.md` updated (entry prose + `verified:` stamp) if subsystem capabilities changed
 
-<!-- REQUIRED, and the merge gate enforces it: declare the POST-MERGE end-to-end
+<!-- OPTIONAL but worth 10 seconds: declare the POST-MERGE end-to-end
      verification this change needs. Replace the line below with one of:
 
        E2E: <one-line plan for the post-merge verification>
        E2E: none — <reason there is no runtime surface to verify>
 
-     `none` is a legitimate answer for a docs/prose PR — what is not legitimate is
-     leaving the decision unmade. Note it passes the gate but does NOT release the
-     validator, which assumes every merged PR has an E2E and hunts for one anyway;
-     the line is its first lead, not a boundary. (This guidance lives inside a
-     comment on purpose: the gate strips comments before reading, so the template
-     itself can never satisfy the gate.) -->
+     `none` is a legitimate answer for a docs/prose PR. Leaving the line empty
+     does not block the merge — but nothing else records the decision yet either:
+     the per-merge verification row that will carry this automatically is not
+     built (issue #1718), so today this line is the only record. Once it exists,
+     declaring here pre-fills that row with what YOU know instead of leaving a
+     validator to reverse-engineer it from the diff days later. (This guidance
+     lives inside a comment on purpose: comments are stripped before the line is
+     read, so the template can never fill itself in.) -->
 
 E2E:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -386,17 +386,25 @@ reads as noise. You are the first line of defense; ambient
 extraction (session-manager PR-3) is only the safety net. Plan files stay
 the working documents — ledger rows are the durable index, not a duplicate.
 
-**PR-body convention — `E2E:` (required, merge-gated):** every PR body declares
+**PR-body convention — `E2E:` (encouraged, advisory):** a PR body may declare
 the POST-MERGE end-to-end verification its change needs, on its own line:
 `E2E: <one-line plan>` or `E2E: none — <reason there is no runtime surface>`.
-The merge gate blocks a PR that declares neither — and a `none` carrying no real
-reason (a bare `none`, a placeholder, or a refusal word like TBD). Merge time
-only, never on push. PRs created before the convention are exempt; if the PR's
-creation date cannot be READ, the gate blocks rather than assuming the
-exemption. `none` is a fine answer for a docs PR; what is refused is leaving the
-decision unmade. It does NOT release
-the validator, which assumes every merged PR has an E2E and hunts for one anyway
-— the line is its first lead, not a boundary.
+This does NOT gate the merge — the merge gate prints an advisory NOTE when a
+body declares neither, and proceeds.
+
+**The obligation WILL be carried after the merge, not before it — and that half
+is NOT BUILT YET (issue #1718).** The design: every merged PR gets a post-merge
+verification row; a documentation-only diff has its row auto-closed with the
+reason recorded (a DETERMINISTIC exemption by path, so no LLM ever decides that
+a prompt or docs change "needs an E2E"); the validator session runs the rest, or
+records why nothing was needed. **Until that ships, this line is the only record
+there is** — so writing it is worth the ten seconds even though nothing forces
+you. When the row exists, declaring here will PRE-FILL it with your own lead:
+the author knows in one sentence what a validator would otherwise
+reverse-engineer from the diff days later. Note the row's exemption is by PATH,
+so it cannot recover a judgment the author skipped on a code PR — a bare
+`E2E: none` there just costs a validator round-trip instead of one sentence
+from the person who knew.
 
 **PR-body convention:** a PR that completes a ledger item cites
 `Ledger: <item-id>` (the 32-hex row id) on its own line in the PR body —

--- a/scripts/e2e_declaration.py
+++ b/scripts/e2e_declaration.py
@@ -17,7 +17,7 @@ THE CONVENTION, in the PR body:
 The point is NOT to force an E2E onto a docs PR. It is to make the DECISION explicit
 — the obligation-side twin of "a check that could not run must say so" (#1683).
 
-`none` PASSES THE GATE BUT DOES NOT RELEASE THE VALIDATOR (spec §8.13). A validation
+`none` SATISFIES THIS READER BUT DOES NOT RELEASE THE VALIDATOR (spec §8.13). A validation
 session assumes every merged PR has an end-to-end test and hunts for it; this line is
 its first LEAD, never a boundary. So `none` is a declaration, not an authority — a
 builder who forgets, or who declares `none` wrongly, is still caught from the merge
@@ -40,8 +40,10 @@ deliberately rather than re-learned:
   * Horizontal whitespace only (`[^\\S\\n]`) around the colon. Plain `\\s*` crosses
     newlines, which let an EMPTY marker borrow the NEXT line's text as its value.
   * Markdown wrappers are tolerated (`-`, `*`, `>`, `- [x]`, `**E2E**`, `` `E2E` ``).
-    Blocking a compliant PR at merge time is how an operator learns to route around
-    a gate.
+    Refusing to read a compliant PR's declaration is how an operator learns to
+    ignore the advisory. (Written when this reader gated the merge; it is
+    advisory since 2026-09-06, and the tolerance is worth keeping either way —
+    an advisory nobody's declaration matches is an advisory nobody reads.)
   * EVERY occurrence is considered, not the first: a leftover template line above a
     filled one must not veto the filled one.
   * Placeholders are derived from the shipped examples, never hand-listed.
@@ -53,8 +55,8 @@ That rejection is right for a 32-hex id, where any trailing text means the line 
 prose about an id rather than a claim on it. Here the trailing text IS the payload,
 so both-end anchoring cannot be copied. What replaces it is line-START anchoring plus
 a substance check on the reason: prose like "the E2E: I ran it by hand" does not
-begin a line at the marker, and `E2E: none` with no reason is INVALID (blocks) rather
-than a silent pass.
+begin a line at the marker, and `E2E: none` with no reason is INVALID (reported
+undeclared) rather than a silent pass.
 
 Pure functions, stdlib only, no I/O — so the merge gate and the repo-pulse worker can
 both load it without dragging in the other's dependencies.
@@ -97,7 +99,7 @@ _REFUSAL_WORDS = frozenset({"todo", "tbd", "pending", "n/a", "na", "yes", "no", 
 #: 2026-09-06): at 12 this rejected `none — docs only` (8 alnum) — the exact string
 #: this module's own GUIDANCE prints as the remedy. On a gate with NO override
 #: sigil that is a closed loop: the author is blocked, types the suggested line
-#: verbatim, and is blocked identically, with nothing in the message naming an
+#: verbatim, and is refused identically, with nothing in the message naming an
 #: undocumented length rule. A false BLOCK here is worse than a false pass, and
 #: `test_every_example_in_the_guidance_passes_the_parser` now makes the class
 #: unrepeatable: any example this module tells an author to write must survive it.
@@ -384,8 +386,10 @@ GUIDANCE = (
     # obligation — on a gate whose purpose is creating them (Kimi P3, 2026-09-06).
     f"For example:  {MARKER}: restart genesis-server and confirm /api/genesis/health answers 200\n"
     f"         or:  {MARKER}: none — docs only, no runtime surface\n"
-    "`none` is a legitimate answer for a docs/prose PR; what is not legitimate is "
-    "leaving the decision unmade. Note it passes this gate but does NOT release the "
-    "validator, which assumes every merged PR has an E2E and hunts for one anyway "
-    "(spec §8.13) — the line is its first lead, not a boundary."
+    "`none` is a legitimate answer for a docs/prose PR. Leaving the line out does "
+    "NOT block the merge — but nothing else records the decision yet either "
+    "(the per-merge obligation row is unbuilt, issue #1718), so right now this "
+    "line is the only record. Note `none` does NOT release the validator, which "
+    "assumes every merged PR has an E2E and hunts for one anyway (spec §8.13) — "
+    "the line is its first lead, not a boundary."
 )

--- a/scripts/e2e_declaration.py
+++ b/scripts/e2e_declaration.py
@@ -97,10 +97,12 @@ _REFUSAL_WORDS = frozenset({"todo", "tbd", "pending", "n/a", "na", "yes", "no", 
 #: A reason/plan must carry real content — but the floor is deliberately LOW, and
 #: the placeholder/refusal checks above it do the real work. MEASURED (architect,
 #: 2026-09-06): at 12 this rejected `none — docs only` (8 alnum) — the exact string
-#: this module's own GUIDANCE prints as the remedy. On a gate with NO override
-#: sigil that is a closed loop: the author is blocked, types the suggested line
-#: verbatim, and is refused identically, with nothing in the message naming an
-#: undocumented length rule. A false BLOCK here is worse than a false pass, and
+#: this module's own GUIDANCE prints as the remedy. When this reader still GATED
+#: the merge, with no override sigil, that was a closed loop: the author was
+#: blocked, typed the suggested line verbatim, and was refused identically, with
+#: nothing in the message naming an undocumented length rule. A false refusal here
+#: is worse than a false pass — it was worse as a block, and it is still worse as
+#: an advisory, because a reader who is wrongly corrected stops reading. And
 #: `test_every_example_in_the_guidance_passes_the_parser` now makes the class
 #: unrepeatable: any example this module tells an author to write must survive it.
 #: 7 admits "docs only" and "prose-only"; "x", "ok" and "n/a" still fail.
@@ -270,8 +272,9 @@ def parse_e2e(body: str | None) -> dict:
       * ``none``    — an explicit, reasoned "no runtime surface" (the reason).
       * ``absent``  — no ``E2E:`` line at all.
       * ``invalid`` — a line exists but says nothing (empty, placeholder, a bare
-        ``none`` with no reason, a refusal word). Treated as absent by the gate,
-        but reported differently so the author is told WHICH mistake they made.
+        ``none`` with no reason, a refusal word). Classified as undeclared, the
+        same as absent, but reported differently so the author is told WHICH
+        mistake they made.
 
     CRLF is normalised first: GitHub's textarea stores bodies with `\\r\\n`, and a
     line-anchored `$` would otherwise never match a real line (the defect
@@ -330,8 +333,10 @@ def parse_e2e(body: str | None) -> dict:
         elif not saw_invalid_detail:
             # Name the ACTUAL rule. A terse-but-real plan ("manual", "smoke",
             # "run CI") fails only the length floor, and telling that author the
-            # line "has no real content" is a false diagnosis on a gate with no
-            # override — it sends them guessing (Kimi P3, 2026-09-06). Say which
+            # line "has no real content" is a false diagnosis that sends them
+            # guessing (Kimi P3, 2026-09-06). It mattered more when this reader
+            # gated the merge with no override; it still matters, because an
+            # advisory that misdiagnoses is one nobody reads twice. Say which
             # rule bit, and quote what they wrote back to them.
             shown = _strip_formatting(value)[:60]
             if sum(ch.isalnum() for ch in _strip_formatting(value)) < _MIN_SUBSTANCE:

--- a/scripts/e2e_declaration.py
+++ b/scripts/e2e_declaration.py
@@ -370,20 +370,25 @@ def is_pre_cutoff(created_at: str | None) -> bool:
         return False
 
 
-#: What the gate prints when a body has no usable declaration. Names BOTH valid
-#: forms and the §8.13 seam, so an author reading the block knows that `none` is a
-#: real option AND that it does not end the obligation.
+#: What the advisory prints when a body has no usable declaration. Names BOTH
+#: valid forms and the §8.13 seam, so an author reading the NOTE knows that `none`
+#: is a real option AND that it does not end the obligation. Nothing here is
+#: enforced — which raises the bar on this text rather than lowering it: an
+#: advisory earns its reading or gets skipped.
 GUIDANCE = (
     "Add an E2E: line to the PR body — one of:\n"
     f"  {MARKER}: <one-line plan for the post-merge verification>\n"
     f"  {MARKER}: none — <reason there is no runtime surface to verify>\n"
-    # A CONCRETE example, not only the bracketed template: an author blocked by
-    # this gate needs a line they can copy, and `test_every_example_in_the_
-    # guidance_passes_the_parser` runs every concrete example here through the
-    # parser so the gate can never again prescribe a remedy it would refuse.
+    # A CONCRETE example, not only the bracketed template: an author reading this
+    # needs a line they can copy, and `test_every_example_in_the_guidance_passes_
+    # the_parser` runs every concrete example here through the parser so this text
+    # can never prescribe a remedy the parser would refuse. That test predates the
+    # advisory downgrade and outlives it: the examples were WORSE than useless when
+    # the reader rejected its own printed remedy, and are still the whole value now
+    # that nothing forces anyone to read them.
     # BOTH forms get a concrete, copyable example. Offering one only for `none`
-    # meant the single line a blocked author could copy was the one that creates NO
-    # obligation — on a gate whose purpose is creating them (Kimi P3, 2026-09-06).
+    # meant the single copyable line was the one that creates NO obligation — in
+    # text whose purpose is prompting them (Kimi P3, 2026-09-06).
     f"For example:  {MARKER}: restart genesis-server and confirm /api/genesis/health answers 200\n"
     f"         or:  {MARKER}: none — docs only, no runtime surface\n"
     "`none` is a legitimate answer for a docs/prose PR. Leaving the line out does "

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -4807,6 +4807,33 @@ def _pr_body_text(pr_num: str, repo: str | None) -> str | None:
 #: together and fails the moment either moves.
 _E2E_CUTOFF_FALLBACK = "2026-09-08T00:00:00Z"
 
+# The remedy, for the degraded path where scripts/e2e_declaration.py could not be
+# loaded and its GUIDANCE is therefore unreachable. Deliberately short: the full
+# version lives in the module, and a second long copy here would be a replica to
+# drift. Both forms, because an author who can only copy the `none` line gets the
+# one answer that creates no obligation.
+_E2E_GUIDANCE_FALLBACK = (
+    "Add an E2E: line to the PR body — one of:\n"
+    "  E2E: <one-line plan for the post-merge verification>\n"
+    "  E2E: none — <reason there is no runtime surface to verify>"
+)
+
+
+def _e2e_undeclared(pr_num: str, detail: str, mod) -> tuple[bool, str]:
+    """Build an `undeclared` verdict that ALWAYS carries the remedy.
+
+    Structural, not a convention: the callers open with "Declaring one takes 10
+    seconds:" and then print this whole string, so a return that omits the forms
+    answers a colon-promise with a restatement of the problem. Three of the four
+    undeclared returns used to do exactly that while a docstring two functions up
+    claimed the tail was always GUIDANCE — the claim was true only of the path
+    someone happened to check (fresh-context audit, 2026-09-06). Routing every
+    return through here makes the property hold by construction; the docstring
+    now describes the code instead of hoping for it.
+    """
+    tail = mod.GUIDANCE if mod is not None else _E2E_GUIDANCE_FALLBACK
+    return True, f"E2E obligation not declared for PR #{pr_num}: {detail}\n{tail}"
+
 #: Last-resort matcher for the E2E declaration, used ONLY when
 #: scripts/e2e_declaration.py cannot be imported. Same shape as that module's
 #: _MARKER_RE (markdown wrappers, horizontal whitespace, case-insensitive) with one
@@ -4898,9 +4925,12 @@ def _check_e2e_plan(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
         row is UNBUILT (issue #1718, half B), so in the interim this advisory is
         the only record. See the merge-arm comment.
       * AUDIENCE: the agent — and both callers print the WHOLE message, whose
-        tail is ``GUIDANCE`` (both valid forms plus copyable examples). Printing
-        only its first line silently drops the remedy; that is the failure this
-        line exists to prevent, not a claim about the string's contents.
+        tail is the remedy (both valid forms plus, when the parser loaded,
+        copyable examples). Printing only its first line silently drops that.
+        Every ``undeclared`` return is built by ``_e2e_undeclared``, which
+        appends the remedy, so this is a property of the code rather than a
+        claim about it — the earlier wording asserted the tail was always
+        GUIDANCE while three of the four returns omitted it.
       * BACKGROUND: none — background sessions cannot merge PRs by design.
 
     "Fail direction" now means which way an UNREADABLE input is REPORTED, since
@@ -4937,10 +4967,12 @@ def _check_e2e_plan(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
                 file=sys.stderr,
             )
         else:
-            return True, (
-                f"E2E obligation: could not read PR #{pr_num}'s createdAt, so the "
-                f"pre-convention exemption cannot be established. Re-run; if it "
-                f"persists, the gh read is failing."
+            return _e2e_undeclared(
+                pr_num,
+                "could not read the PR's createdAt, so the pre-convention "
+                "exemption cannot be established. Re-run; if it persists, the "
+                "gh read is failing",
+                mod,
             )
     else:
         if mod is not None:
@@ -4952,10 +4984,12 @@ def _check_e2e_plan(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
 
     body = _pr_body_text(pr_num, repo)
     if body is None:
-        return True, (
-            f"E2E obligation: PR #{pr_num}'s body is unreadable, so the declaration "
-            f"cannot be confirmed. This gate guards every merge — an unread body is "
-            f"an unanswered question, not a pass."
+        return _e2e_undeclared(
+            pr_num,
+            "the PR body is unreadable, so the declaration cannot be confirmed. "
+            "Reported undeclared rather than assumed declared — an unread body is "
+            "an unanswered question, not a pass",
+            mod,
         )
 
     if mod is None:
@@ -4979,9 +5013,10 @@ def _check_e2e_plan(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
                 file=sys.stderr,
             )
             return False, "ok (degraded: parser unavailable)"
-        return True, (
-            f"E2E obligation: no E2E: line found in PR #{pr_num}'s body (parser "
-            f"unavailable, presence-only scan)."
+        return _e2e_undeclared(
+            pr_num,
+            "no E2E: line found in the body (parser unavailable, presence-only scan)",
+            mod,
         )
 
     result = mod.parse_e2e(body)
@@ -4996,7 +5031,7 @@ def _check_e2e_plan(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
         return False, f"ok ({label})"
 
     detail = result.get("detail") or "no E2E: line in the PR body"
-    return True, f"E2E obligation not declared for PR #{pr_num}: {detail}\n{mod.GUIDANCE}"
+    return _e2e_undeclared(pr_num, detail, mod)
 
 
 def _check_pin_receipts(pr_num: str, repo: str | None = None) -> tuple[bool, str]:

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -4907,8 +4907,13 @@ def _check_e2e_plan(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
     nothing blocks:
       * body UNREADABLE → reported undeclared. An unread body is an unanswered
         question, not a pass — the row will still be opened post-merge.
-      * createdAt UNREADABLE → reported undeclared, naming the cause, rather than
-        assuming the pre-convention exemption.
+      * createdAt UNREADABLE, parser LOADED → reported undeclared, naming the
+        cause, rather than assuming the pre-convention exemption.
+      * createdAt UNREADABLE *and* parser MISSING → neither the exemption nor the
+        stripping can be established, so this returns whatever the bare presence
+        scan below finds: a body carrying an ``E2E:`` line is reported declared
+        (degraded), one without it undeclared. Stating that exception here because
+        the line above read as unconditional and is not (Kimi P3, 2026-09-06).
       * parser module MISSING → the body is still scanned for a bare ``E2E:``
         line and a NOTE says the comment/fence stripping was unavailable.
 
@@ -6709,8 +6714,15 @@ def main() -> int:
                 # What WILL close the obligation is a durable row: a follow-on PR
                 # (issue #1718, half B) teaches the repo-pulse worker to open one
                 # per merged PR, auto-closed with the reason recorded when the diff
-                # is documentation-only. **UNBUILT as of this commit** — 0 of the 5
-                # repo_pulse modules contain it. Until it lands, this NOTE is the
+                # is documentation-only. **UNBUILT as of this commit** — MEASURED as
+                # zero occurrences of `parse_e2e`, `e2e_declaration` or the row's
+                # dedup key anywhere under src/, and repo_pulse_gh.PR_FIELDS still
+                # lacks the `createdAt` the lane needs. (Stated that way on purpose:
+                # the earlier phrasing counted "repo_pulse modules", a denominator
+                # three reviewers agreed on and none of us had measured — it is 4 or
+                # 6 depending on whether you count the crud and scripts modules. A
+                # grep for the thing itself does not depend on how you count.)
+                # Until it lands, this NOTE is the
                 # only thing that remembers, which is a deliberate and tracked gap,
                 # not a covered one. Say so rather than implying coverage: the
                 # measured miss rate the block was justified by is unmitigated in

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -4881,33 +4881,38 @@ def _pr_created_at(pr_num: str, repo: str | None = None) -> str | None:
 
 
 def _check_e2e_plan(pr_num: str, repo: str | None = None) -> tuple[bool, str]:
-    """Block a merge whose PR body never DECIDED about a post-merge E2E (§8.12).
+    """Report whether a PR body DECIDED about its post-merge E2E (§8.12).
 
-    Returns (should_block, message). The obligation is one line in the PR body —
-    either a plan or an explicit reasoned ``none`` (see scripts/e2e_declaration.py
-    for the full convention and why its parsing is what it is).
+    Returns ``(undeclared, message)``. ``undeclared`` is a FINDING, not a
+    verdict: no caller blocks on it. The merge arm prints an advisory NOTE and
+    proceeds; ``--check-pr`` prints an ``advisory`` row that never counts toward
+    `failures`. Keeping the severity in the CALLERS is what let this become
+    advisory without touching a line of the classification below.
 
     GUARD AXIOMS, stated because every gate change owes them:
-      * VERDICT: block, at MERGE time only. The push arm never calls this — a
-        body is written and revised while a PR is open, so demanding it at push
-        would gate the wrong moment.
-      * AUDIENCE: the agent. The message names both valid forms verbatim.
-      * BACKGROUND: none. Background sessions cannot merge PRs by design, so this
-        cannot impede one.
+      * VERDICT: **advisory** (owner decision 2026-09-06, reversing the
+        2026-09-05 hard-fail). A block only guaranteed that a SENTENCE EXISTS,
+        never that it was true, so it added no determinism to the judgment —
+        while taxing every merge on an n=2 justification. The obligation is
+        MEANT to be carried by a per-merge row from the repo-pulse worker; that
+        row is UNBUILT (issue #1718, half B), so in the interim this advisory is
+        the only record. See the merge-arm comment.
+      * AUDIENCE: the agent — and both callers print the WHOLE message, whose
+        tail is ``GUIDANCE`` (both valid forms plus copyable examples). Printing
+        only its first line silently drops the remedy; that is the failure this
+        line exists to prevent, not a claim about the string's contents.
+      * BACKGROUND: none — background sessions cannot merge PRs by design.
 
-    Fail directions, each chosen rather than inherited:
-      * body UNREADABLE → BLOCK. This gate guards EVERY merge, so an unreadable
-        body is an unanswered question, not a pass. (The pin gate fails open on
-        the same read because it guards only the rare pin-bump path — the
-        divergence is deliberate, not an oversight.)
-      * createdAt UNREADABLE → BLOCK, naming the cause. Treating it as "old"
-        would turn the transition window into a permanent hole.
+    "Fail direction" now means which way an UNREADABLE input is REPORTED, since
+    nothing blocks:
+      * body UNREADABLE → reported undeclared. An unread body is an unanswered
+        question, not a pass — the row will still be opened post-merge.
+      * createdAt UNREADABLE → reported undeclared, naming the cause, rather than
+        assuming the pre-convention exemption.
       * parser module MISSING → the body is still scanned for a bare ``E2E:``
-        line and a NOTE says the comment/fence stripping was unavailable. Losing
-        the invisibility defence must not lose the whole gate.
+        line and a NOTE says the comment/fence stripping was unavailable.
 
-    NO OVERRIDE SIGIL, deliberately: ``E2E: none — <reason>`` IS the auditable
-    escape hatch, and it costs one honest sentence. Mirrors the pin gate's stance.
+    No override sigil exists because there is nothing to override.
     """
     # The cutoff is checked FIRST and in BOTH modes. An earlier revision consulted
     # it only when the parser had loaded, which blocked a PRE-CUTOFF PR whenever the
@@ -6685,20 +6690,53 @@ def main() -> int:
                     # above records as measured (architect SHOULD-FIX, 2026-09-06).
                     print(receipts_msg, file=sys.stderr)
 
-                # E2E obligation (§8.12). Sits beside the pin gate because it is
-                # the same KIND of check — a merge-time read of the PR body, which
-                # stays mutable after any CI run — and because both are cheap
-                # reads that should fail before the expensive finding scans.
-                # Like the pin gate it carries NO override sigil: `E2E: none —
-                # <reason>` is the escape hatch, and it costs one honest sentence.
-                should_block, e2e_msg = _check_e2e_plan(pr_num, repo=merge_repo)
-                if should_block:
+                # E2E obligation (§8.12) — ADVISORY, never blocking (owner
+                # decision 2026-09-06, reversing the 2026-09-05 hard-fail call).
+                #
+                # The gate never made the JUDGMENT deterministic: whether a change
+                # needs an E2E is an LLM call either way, and a block only
+                # guarantees that a SENTENCE EXISTS, not that it is true —
+                # `E2E: none — docs only` on a code PR passes and the gate cannot
+                # tell. Worse, a mandatory field produces compliance text: a line
+                # typed to get past a gate is the cheapest thing that passes, which
+                # is lower-quality signal than a line written because the author
+                # had something to say. Against that, the block's measured
+                # justification was 1-of-2 merges (n=2) — far under this repo's own
+                # bar for escalating past advisory — while binding EVERY merge
+                # forever, including external contributors who have never heard of
+                # the convention.
+                #
+                # What WILL close the obligation is a durable row: a follow-on PR
+                # (issue #1718, half B) teaches the repo-pulse worker to open one
+                # per merged PR, auto-closed with the reason recorded when the diff
+                # is documentation-only. **UNBUILT as of this commit** — 0 of the 5
+                # repo_pulse modules contain it. Until it lands, this NOTE is the
+                # only thing that remembers, which is a deliberate and tracked gap,
+                # not a covered one. Say so rather than implying coverage: the
+                # measured miss rate the block was justified by is unmitigated in
+                # the interim, and a message claiming otherwise is worse than
+                # silence.
+                #
+                # Branch on the RETURNED FLAG, never on the message text. Both arms
+                # must apply the same predicate to the same value or "report and
+                # enforcement share a function so they cannot disagree" stops being
+                # true — sharing the call while re-deriving severity from a string
+                # prefix is the divergence wearing the invariant's clothes.
+                undeclared, e2e_msg = _check_e2e_plan(pr_num, repo=merge_repo)
+                if undeclared:
                     print(
-                        f"BLOCKED: PR #{pr_num} — no post-merge E2E decision in the PR body.",
+                        f"NOTE: PR #{pr_num} — no post-merge E2E decision in the PR "
+                        f"body. Not blocking. The obligation row that will carry this "
+                        f"automatically is NOT built yet (issue #1718), so right now "
+                        f"this NOTE is the only record. Declaring one takes 10 seconds:",
                         file=sys.stderr,
                     )
+                    # The WHOLE message: its tail is GUIDANCE, which carries both
+                    # valid forms and two copyable examples. Printing only line 0
+                    # ended a colon-promise with a restatement of the problem and
+                    # dropped the remedy — an advisory minus its remedy is noise,
+                    # which is the strongest argument for ignoring it.
                     print(e2e_msg, file=sys.stderr)
-                    return 2
 
                 # Codex must have reviewed the CURRENT head (existence + freshness)
                 # — not merely have no open findings. This runs BEFORE the finding
@@ -6984,14 +7022,20 @@ def check_pr_report(pr_num: str, repo: str | None = None) -> int:
         for line in msg.splitlines()[1:]:
             print(f"  {line}")
     failures += 1 if blocked else 0
-    # E2E obligation (§8.12), same tier and same reason as pin-receipts: a
-    # merge-time read of a mutable body, so CI could never be its authority.
-    blocked, msg = _check_e2e_plan(pr_num, repo=repo)
-    print(f"e2e-plan       : {'BLOCK — ' + msg.splitlines()[0] if blocked else msg.splitlines()[0]}")
-    if blocked:
+    # E2E obligation (§8.12) — ADVISORY. Reported so the declaration is visible
+    # at merge time, but it NEVER contributes to `failures`: the enforcement arm
+    # does not block on it either, and a report row that counted a gate the gate
+    # does not enforce would be the report and the enforcement disagreeing —
+    # the one property this whole report rests on not doing.
+    undeclared, msg = _check_e2e_plan(pr_num, repo=repo)
+    if undeclared:
+        print(f"e2e-plan       : advisory — {msg.splitlines()[0]}")
+        # Indented tail, the same idiom pin-receipts and scheduled-review use —
+        # the remedy is the point of an advisory.
         for line in msg.splitlines()[1:]:
             print(f"  {line}")
-    failures += 1 if blocked else 0
+    else:
+        print(f"e2e-plan       : {msg.splitlines()[0]}")
     blocked, msg, verified_head = _check_codex_reviewed_head(pr_num, repo=repo)
     if blocked:
         label = "BLOCK — " + msg.splitlines()[0]

--- a/tests/test_hooks/conftest.py
+++ b/tests/test_hooks/conftest.py
@@ -34,10 +34,20 @@ def _hermetic_e2e_declaration(monkeypatch):
     LIVE call: green on a dev box with gh authenticated and PR "1" answering, red in
     CI, and in both cases testing the network rather than the thing under test.
 
-    Since 2026-09-06 the reader is advisory, so what this prevents is NOTE noise on
-    unrelated tests, not a false block — nothing here can fail a merge. It is still
-    the hermetic default rather than a waiver: the reader's own behaviour (every
-    classification, both report directions, the cutoff, the degraded path) is
+    Since 2026-09-06 the E2E reader is advisory, so ITS verdict cannot fail a merge
+    and what this prevents for that gate is NOTE noise, not a false block.
+
+    But do not read that as "nothing here can fail a merge" — an earlier version of
+    this docstring said exactly that and it is FALSE. ``_TEST_GH_PR_BODY`` is a
+    SHARED seam: ``_check_pin_receipts`` reads the same body via ``_pr_body_text``
+    and DOES block. MEASURED 2026-09-06 — feeding it this fixture's body with a
+    forward pin returns blocked=True ("CC pin moves FORWARD … but the PR body is
+    missing 2 required gate receipt(s)"). So changing or deleting the default here
+    silently changes what every pin-gate test in this directory is fed; edit it only
+    with those tests in view.
+
+    Still the hermetic default rather than a waiver: the E2E reader's own behaviour
+    (every classification, both report directions, the cutoff, the degraded path) is
     exercised in tests/test_hooks/test_e2e_plan_gate.py, which overrides these per
     case; a later ``monkeypatch.setenv`` in any test wins over this one."""
     monkeypatch.setenv("_TEST_GH_PR_BODY", "E2E: none — hermetic default for hook tests\n")

--- a/tests/test_hooks/conftest.py
+++ b/tests/test_hooks/conftest.py
@@ -27,18 +27,19 @@ def _pin_required_ci_workflows(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _hermetic_e2e_declaration(monkeypatch):
-    """Give EVERY hook test a PR body that satisfies the E2E-obligation gate (§8.12).
+    """Keep the ADVISORY E2E read hermetic for EVERY hook test (§8.12).
 
-    That gate fails CLOSED on an unreadable body and on an unreadable ``createdAt``
-    — deliberately, since it guards every merge — so without this pin each test
-    that drives the merge gate or its report would make a LIVE ``gh pr view`` call:
-    green on a dev box with gh authenticated and PR "1" answering, red in CI, and
-    in both cases testing the network rather than the thing under test.
+    The reader shells out to ``gh pr view`` for the body and for ``createdAt``, so
+    without this pin each test that drives the merge arm or its report would make a
+    LIVE call: green on a dev box with gh authenticated and PR "1" answering, red in
+    CI, and in both cases testing the network rather than the thing under test.
 
-    This is the hermetic DEFAULT, not a waiver. The gate's own behaviour — every
-    verdict, both fail directions, the cutoff, and the degraded path — is exercised
-    in tests/test_hooks/test_e2e_plan_gate.py, which overrides these per case; a
-    later ``monkeypatch.setenv`` in any test wins over this one."""
+    Since 2026-09-06 the reader is advisory, so what this prevents is NOTE noise on
+    unrelated tests, not a false block — nothing here can fail a merge. It is still
+    the hermetic default rather than a waiver: the reader's own behaviour (every
+    classification, both report directions, the cutoff, the degraded path) is
+    exercised in tests/test_hooks/test_e2e_plan_gate.py, which overrides these per
+    case; a later ``monkeypatch.setenv`` in any test wins over this one."""
     monkeypatch.setenv("_TEST_GH_PR_BODY", "E2E: none — hermetic default for hook tests\n")
     monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2099-01-01T00:00:00Z")
     yield

--- a/tests/test_hooks/test_e2e_plan_gate.py
+++ b/tests/test_hooks/test_e2e_plan_gate.py
@@ -1,17 +1,25 @@
-"""The E2E-obligation merge gate (`_check_e2e_plan` in git_push_guard.py, §8.12).
+"""The E2E-obligation READER (`_check_e2e_plan` in git_push_guard.py, §8.12).
+
+ADVISORY since 2026-09-06 (owner reversal of the 2026-09-05 hard-fail). The
+function's first return value is `undeclared` — a FINDING, not a verdict. NO
+caller blocks on it: the merge arm prints a NOTE and proceeds, and the
+`--check-pr` row never counts toward `failures`. Every name and assertion below
+is about the CLASSIFICATION, never a merge verdict; the exit-code proof that
+nothing blocks lives in tests/test_hooks/test_merge_gate_characterization.py,
+whose `e2e_*` cases drive the real merge command.
 
 The parser's own semantics are covered in tests/test_scripts/test_e2e_declaration.py.
-What is tested HERE is the gate's contract, which is a different thing and fails in
-different directions:
+What is tested HERE:
 
-  * it blocks at MERGE time and nowhere else (a body is written and revised while a
-    PR is open — gating a push would gate the wrong moment);
-  * pre-cutoff PRs are exempt, so landing this does not retro-block the open queue;
-  * every unreadable input BLOCKS rather than passing, and says which one;
+  * it is read at MERGE time and nowhere else (a body is written and revised while
+    a PR is open — reading it at push would read the wrong moment);
+  * pre-cutoff PRs are exempt, so the convention never reached back over the queue;
+  * every unreadable input is REPORTED UNDECLARED rather than passing silently,
+    and says which one;
   * a missing parser module degrades to a presence-only scan with a NOTE, rather
-    than taking the whole gate down with it;
-  * the report row mirrors the enforcement arm (they call the same function, so a
-    bug in one is a bug in both — the property the whole report rests on).
+    than taking the whole reader down with it;
+  * the report row and the merge arm consume the SAME returned flag, so they
+    cannot disagree — the property the whole report rests on.
 
 Network-free throughout via the `_TEST_GH_*` env seams.
 """
@@ -49,53 +57,53 @@ def _post_cutoff(monkeypatch):
     monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2099-01-01T00:00:00Z")
 
 
-class TestVerdicts:
+class TestClassification:
     def test_plan_passes(self, guard, monkeypatch):
         monkeypatch.setenv("_TEST_GH_PR_BODY", _PLAN)
-        blocked, msg = guard._check_e2e_plan("100")
-        assert not blocked, msg
+        undeclared, msg = guard._check_e2e_plan("100")
+        assert not undeclared, msg
         assert "plan" in msg
 
     def test_none_with_reason_passes(self, guard, monkeypatch):
         monkeypatch.setenv("_TEST_GH_PR_BODY", _NONE)
-        blocked, msg = guard._check_e2e_plan("100")
-        assert not blocked, msg
+        undeclared, msg = guard._check_e2e_plan("100")
+        assert not undeclared, msg
         assert "none" in msg
 
-    def test_absent_declaration_blocks(self, guard, monkeypatch):
+    def test_absent_declaration_is_reported_undeclared(self, guard, monkeypatch):
         monkeypatch.setenv("_TEST_GH_PR_BODY", "A body that never decided.\n")
-        blocked, msg = guard._check_e2e_plan("100")
-        assert blocked
+        undeclared, msg = guard._check_e2e_plan("100")
+        assert undeclared
         assert "E2E: <one-line plan" in msg and "E2E: none —" in msg
 
-    def test_bare_none_blocks_and_says_why(self, guard, monkeypatch):
-        """The message must name THIS mistake, not just block.
+    def test_bare_none_is_undeclared_and_says_why(self, guard, monkeypatch):
+        """The message must name THIS mistake, not merely report one.
 
-        `"reason" in msg` was vacuous: GUIDANCE is appended to every block message
+        `"reason" in msg` was vacuous: GUIDANCE is appended to every message
         and itself contains "<reason there is no runtime surface to verify>", so the
         assertion passed for the generic detail too (CodeRabbit Minor, 2026-09-06).
         Assert the specific detail, and assert the generic one is ABSENT."""
         monkeypatch.setenv("_TEST_GH_PR_BODY", "E2E: none\n")
-        blocked, msg = guard._check_e2e_plan("100")
-        assert blocked
+        undeclared, msg = guard._check_e2e_plan("100")
+        assert undeclared
         assert "needs a REASON" in msg, "must name the bare-`none` mistake specifically"
         assert "no real content" not in msg, "must not fall back to the generic detail"
 
-    def test_placeholder_block_uses_the_generic_detail(self, guard, monkeypatch):
+    def test_placeholder_uses_the_generic_detail(self, guard, monkeypatch):
         """The control that makes the assertion above discriminating: a DIFFERENT
         invalid shape must produce a DIFFERENT detail."""
         monkeypatch.setenv(
             "_TEST_GH_PR_BODY", "E2E: <one-line plan for the post-merge verification>\n"
         )
-        blocked, msg = guard._check_e2e_plan("100")
-        assert blocked
+        undeclared, msg = guard._check_e2e_plan("100")
+        assert undeclared
         assert "no real content" in msg
         assert "needs a REASON" not in msg
 
-    def test_block_message_names_the_validator_seam(self, guard, monkeypatch):
-        """§8.13: `none` passes this gate but does NOT release the validator. An
-        author reading the block must learn the whole contract, or `none` becomes
-        folklore for "no E2E needed"."""
+    def test_advisory_message_names_the_validator_seam(self, guard, monkeypatch):
+        """§8.13: `none` satisfies this reader but does NOT release the validator.
+        An author reading the advisory must learn the whole contract, or `none`
+        becomes folklore for "no E2E needed"."""
         monkeypatch.setenv("_TEST_GH_PR_BODY", "nothing\n")
         _, msg = guard._check_e2e_plan("100")
         assert "validator" in msg.lower()
@@ -108,23 +116,23 @@ class TestVerdicts:
         assert "E2E obligation declared" in capsys.readouterr().err
 
 
-class TestFailDirections:
-    def test_unreadable_body_blocks(self, guard, monkeypatch):
+class TestReportDirections:
+    def test_unreadable_body_is_reported_undeclared(self, guard, monkeypatch):
         """Diverges from the pin gate on purpose: that one fails OPEN on an
         unreadable body because it guards the rare pin-bump path; this one guards
         EVERY merge, so an unread body is an unanswered question."""
         monkeypatch.delenv("_TEST_GH_PR_BODY", raising=False)
         monkeypatch.setattr(guard, "_pr_body_text", lambda *a, **k: None)
-        blocked, msg = guard._check_e2e_plan("100")
-        assert blocked
+        undeclared, msg = guard._check_e2e_plan("100")
+        assert undeclared
         assert "unreadable" in msg.lower()
 
-    def test_unreadable_created_at_blocks_naming_the_cause(self, guard, monkeypatch):
+    def test_unreadable_created_at_is_undeclared_naming_the_cause(self, guard, monkeypatch):
         monkeypatch.setenv("_TEST_GH_PR_BODY", _PLAN)
         monkeypatch.delenv("_TEST_GH_PR_CREATED_AT", raising=False)
         monkeypatch.setattr(guard, "_pr_created_at", lambda *a, **k: None)
-        blocked, msg = guard._check_e2e_plan("100")
-        assert blocked
+        undeclared, msg = guard._check_e2e_plan("100")
+        assert undeclared
         assert "createdAt" in msg
 
     def test_parser_unavailable_degrades_to_presence_scan(self, guard, monkeypatch, capsys):
@@ -132,18 +140,18 @@ class TestFailDirections:
         line still passes, and the NOTE says what protection was unavailable."""
         monkeypatch.setenv("_TEST_GH_PR_BODY", _PLAN)
         monkeypatch.setattr(guard, "_load_e2e_declaration", lambda: None)
-        blocked, msg = guard._check_e2e_plan("100")
-        assert not blocked
+        undeclared, msg = guard._check_e2e_plan("100")
+        assert not undeclared
         assert "degraded" in msg
         err = capsys.readouterr().err
         assert "WITHOUT comment/fence stripping" in err
         assert "hidden in an HTML comment" in err, "the NOTE must name what is now unprotected"
 
-    def test_parser_unavailable_still_blocks_a_body_with_no_line(self, guard, monkeypatch):
+    def test_parser_unavailable_still_reports_a_body_with_no_line(self, guard, monkeypatch):
         monkeypatch.setenv("_TEST_GH_PR_BODY", "no declaration here\n")
         monkeypatch.setattr(guard, "_load_e2e_declaration", lambda: None)
-        blocked, _ = guard._check_e2e_plan("100")
-        assert blocked
+        undeclared, _ = guard._check_e2e_plan("100")
+        assert undeclared
 
     def test_degraded_fallback_refuses_the_untouched_pr_template(self, guard):
         """The degraded path cannot strip HTML comments, and the shipped template's
@@ -179,8 +187,8 @@ class TestFailDirections:
         monkeypatch.setenv("_TEST_GH_PR_BODY", "an old body, no declaration\n")
         monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2020-01-01T00:00:00Z")
         monkeypatch.setattr(guard, "_load_e2e_declaration", lambda: None)
-        blocked, msg = guard._check_e2e_plan("100")
-        assert not blocked, msg
+        undeclared, msg = guard._check_e2e_plan("100")
+        assert not undeclared, msg
         assert "n/a" in msg
 
     def test_the_degraded_cutoff_mirror_matches_the_parser(self, guard):
@@ -196,11 +204,11 @@ class TestCutoff:
         """The transition rule: landing this must not retro-block the open queue."""
         monkeypatch.setenv("_TEST_GH_PR_BODY", "an old body, no declaration\n")
         monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2020-01-01T00:00:00Z")
-        blocked, msg = guard._check_e2e_plan("100")
-        assert not blocked
+        undeclared, msg = guard._check_e2e_plan("100")
+        assert not undeclared
         assert "n/a" in msg
 
-    def test_post_cutoff_pr_is_bound(self, guard, monkeypatch):
+    def test_post_cutoff_pr_is_in_scope(self, guard, monkeypatch):
         monkeypatch.setenv("_TEST_GH_PR_BODY", "a new body, no declaration\n")
         monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2099-01-01T00:00:00Z")
         assert guard._check_e2e_plan("100")[0] is True
@@ -222,6 +230,23 @@ class TestWiring:
         text = _GUARD.read_text()
         assert "e2e-plan       :" in text, "the report must carry the row"
         assert text.count("_check_e2e_plan(") >= 3, "def + merge arm + report row"
+
+    def test_both_arms_branch_on_the_returned_flag_not_the_message_text(self):
+        """Sharing the FUNCTION was never the invariant — sharing the PREDICATE is.
+
+        The advisory rewrite briefly had the merge arm discard the returned bool and
+        re-derive severity from `e2e_msg.startswith(("ok", "n/a"))` while the report
+        row used the bool. Both agreed that day, so every test passed; the coupling
+        was invisible and unlocked, and renaming a label to "declared (plan)" — or a
+        case change, since startswith is case-sensitive — would have made the merge
+        arm emit a NOTE on a PR the report calls ok. That is the report/enforcement
+        divergence wearing the shared-function invariant's clothes (architect
+        SHOULD-FIX, 2026-09-06)."""
+        text = _GUARD.read_text()
+        assert "e2e_msg.startswith" not in text, (
+            "the merge arm must branch on the returned flag; re-deriving severity "
+            "from the message text recreates the divergence this file forbids"
+        )
 
 
 class TestEndToEndThroughTheHook:

--- a/tests/test_hooks/test_e2e_plan_gate.py
+++ b/tests/test_hooks/test_e2e_plan_gate.py
@@ -224,24 +224,41 @@ class TestWiring:
     tests/test_hooks/test_merge_gate_characterization.py (the `e2e_*` cases drive
     a real `gh pr merge` and assert the exit code); what remains here is only the
     property no exit code can show — that the REPORT and the ENFORCEMENT call the
-    same function, so the two can never disagree."""
+    same function.
+
+    Sharing the function does NOT make them unable to disagree, and an earlier
+    version of this docstring said it did. Severity lives in each CALLER (that is
+    what the advisory downgrade moved), so the two mappings can diverge while the
+    classifier stays shared. What keeps them agreeing is behavioural and lives in
+    the characterization file: `test_merge_arm_advisory_follows_the_flag_not_the_
+    message_text` and `test_check_pr_report_e2e_row_is_advisory_and_never_flips_
+    the_verdict`. MEASURED 2026-09-06 that without those two, re-adding the
+    report's failure increment, or re-deriving the merge arm's severity from the
+    message text under a different variable name, both left the suite green."""
 
     def test_report_and_enforcement_share_one_function(self):
         text = _GUARD.read_text()
         assert "e2e-plan       :" in text, "the report must carry the row"
         assert text.count("_check_e2e_plan(") >= 3, "def + merge arm + report row"
 
-    def test_both_arms_branch_on_the_returned_flag_not_the_message_text(self):
-        """Sharing the FUNCTION was never the invariant — sharing the PREDICATE is.
+    def test_no_arm_re_derives_severity_from_the_message_text(self):
+        """A belt to the behavioural brace, kept ONLY because it is free.
 
-        The advisory rewrite briefly had the merge arm discard the returned bool and
-        re-derive severity from `e2e_msg.startswith(("ok", "n/a"))` while the report
-        row used the bool. Both agreed that day, so every test passed; the coupling
-        was invisible and unlocked, and renaming a label to "declared (plan)" — or a
-        case change, since startswith is case-sensitive — would have made the merge
-        arm emit a NOTE on a PR the report calls ok. That is the report/enforcement
-        divergence wearing the shared-function invariant's clothes (architect
-        SHOULD-FIX, 2026-09-06)."""
+        The real lock is `test_merge_arm_advisory_follows_the_flag_not_the_message_
+        text` in the characterization file, which fails however the re-derivation is
+        spelled. This grep pins one historical spelling and nothing more: MEASURED
+        2026-09-06 that renaming the local to `e2e_text` and reinstating
+        `startswith(("ok", "n/a"))` left THIS assertion green while the forbidden
+        behaviour was fully back. A negative grep on an identifier locks a name, and
+        a name is the cheapest thing in a refactor to change — so do not let this
+        test's presence read as coverage.
+
+        Why the original divergence matters: the advisory rewrite briefly had the
+        merge arm discard the returned bool and re-derive severity from the message,
+        while the report row used the bool. Both agreed that day, so everything
+        passed — and any label change ("declared (plan)", or a case flip, since
+        startswith is case-sensitive) would have made the merge arm emit a NOTE on a
+        PR the report calls ok."""
         text = _GUARD.read_text()
         assert "e2e_msg.startswith" not in text, (
             "the merge arm must branch on the returned flag; re-deriving severity "

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -262,10 +262,11 @@ _PIN_RECEIPTS_BODY = (
     "CC-Gate-Changelog: read (2.1.218, 2.1.246] in full from CHANGELOG.md, 2026-08-28\n"
     "CC-Gate-Soak: 2.1.246 on container 2026-08-25..2026-08-27, "
     "check_cc_running_versions.sh clean, sign-off recorded\n"
-    # These cases assert an ALLOW, so the body must satisfy every body-reading gate,
-    # not just the pin one — the E2E obligation (§8.12) reads the same body and
-    # fails closed without a declaration. A case whose subject is the pin gate must
-    # not start failing for an unrelated missing line.
+    # Kept, but no longer load-bearing: it dated from when the E2E reader (§8.12)
+    # blocked on a body with no declaration, so a pin case would have failed for an
+    # unrelated missing line. That reader is advisory since 2026-09-06 and can no
+    # longer steal this allow. The line stays because these cases assert an ALLOW
+    # and a body that answers every body-reading gate keeps the subject unambiguous.
     "E2E: none — pin bump only, no runtime surface to verify\n"
 )
 
@@ -1093,6 +1094,28 @@ _CASES: list[tuple[str, object, int, str]] = [
         ),
         0,
         "",
+    ),
+    # "Advisory" has to mean the merge arm CONTINUES INTO the blocking gates, not
+    # merely that it exits 0 when everything downstream is already green — which is
+    # all the five cases above can prove, since they run with every other gate
+    # passing. The blocking version `return 2`'d here, so every later check was
+    # skipped for exactly this population; if a future edit "tidies" the advisory
+    # branch with an early `return 0`, Codex-at-head freshness, the TOCTOU head
+    # binding and both finding scans go silently unenforced on every PR that lacks
+    # an E2E line, and the cases above stay green. This is the same shape as the
+    # `if False:` mutation measured on the blocking version (see the comment above),
+    # one gate further on. So: undeclared body AND a stale Codex review — the
+    # DOWNSTREAM gate must still be the thing that decides. (Kimi P2, 2026-09-06.)
+    (
+        "e2e_advisory_does_not_short_circuit_downstream_gates",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            pr_body="A body that never decided.\n",
+            reviews=_reviews_jsonl(STALE),
+        ),
+        2,
+        "has not reviewed the current head",
     ),
     (
         "pin_unchanged_allows_through_main",

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -1048,17 +1048,21 @@ _CASES: list[tuple[str, object, int, str]] = [
         0,
         "",
     ),
-    # ── E2E obligation (§8.12) ──────────────────────────────────────────────
-    # These drive the REAL merge command through the hook. The gate's first
-    # "wiring" tests were source-string greps, and MEASURED: replacing the
-    # enforcement branch with `if False:` left the call in place, so all 147
-    # tests stayed green while the gate did nothing. A grep proves a call exists;
-    # only an exit code proves it BLOCKS.
+    # ── E2E obligation (§8.12) — ADVISORY, never blocking ───────────────────
+    # These drive the REAL merge command through the hook, which is the only
+    # thing that proves a verdict: MEASURED on the blocking version, replacing
+    # the enforcement branch with `if False:` left the call in place and all 147
+    # tests stayed green. A grep proves a call exists; only an exit code proves
+    # what it DOES. The exit code these now assert is 0 — the owner reversed the
+    # hard-fail on 2026-09-06 because the block never made the JUDGMENT
+    # deterministic (an LLM decides either way; a block only guarantees a
+    # sentence exists, not that it is true) while taxing every merge on an n=2
+    # justification. The obligation lives in the per-merge row instead.
     (
-        "e2e_declaration_absent_blocks_merge",
+        "e2e_declaration_absent_is_advisory_not_blocking",
         lambda mp: _run(mp, _merge_cmd(), pr_body="A body that never decided.\n"),
-        2,
-        "no post-merge E2E decision",
+        0,
+        "no post-merge E2E decision",  # the NOTE still fires, on a passing merge
     ),
     (
         "e2e_none_with_reason_allows_merge",
@@ -1077,9 +1081,9 @@ _CASES: list[tuple[str, object, int, str]] = [
         "",
     ),
     (
-        "e2e_bare_none_blocks_merge",
+        "e2e_bare_none_is_advisory_not_blocking",
         lambda mp: _run(mp, _merge_cmd(), pr_body="E2E: none\n"),
-        2,
+        0,
         "no post-merge E2E decision",
     ),
     (

--- a/tests/test_hooks/test_merge_gate_characterization.py
+++ b/tests/test_hooks/test_merge_gate_characterization.py
@@ -1117,6 +1117,112 @@ _CASES: list[tuple[str, object, int, str]] = [
         2,
         "has not reviewed the current head",
     ),
+    # The case above pins only the FIRST downstream gate. An early return placed
+    # after freshness would still bypass everything later while it stayed green.
+    #
+    # COUNT THE GATES FROM THE CODE, NOT FROM THIS COMMENT. As of 2026-09-06 the
+    # merge arm runs FIVE gates after the E2E advisory: Codex freshness
+    # (git_push_guard.py:6761), the TOCTOU head binding (:6785), the review-body
+    # scan (:6797), the inline scan (:6814), and the scheduled-Claude review
+    # (:6855). There is one case below for each.
+    #
+    # An earlier revision of this comment said "one case per remaining gate" while
+    # covering four of the five — the scheduled-review gate was unpinned, and a
+    # `return 0` before :6845 left the entire suite green with every required
+    # scheduled review unenforced for exactly this population. Three consecutive
+    # review rounds each added the gates the previous reviewer named and each
+    # stopped one short; what broke the run was enumerating the arm from the
+    # source instead of from the last finding. If you add a gate to that arm, add
+    # a case here and update the list above — the list is load-bearing.
+    #
+    # Each case leaves everything upstream of the gate under test clean, so that
+    # gate is the only thing that can produce the block.
+    (
+        "e2e_advisory_still_reaches_head_binding",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(match=None),
+            pr_body="A body that never decided.\n",
+        ),
+        2,
+        "bound to the Codex-verified head",
+    ),
+    (
+        "e2e_advisory_still_reaches_review_body_scan",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            pr_body="A body that never decided.\n",
+            router=_router(review_lines=_REVIEW_BODY_P1),
+        ),
+        2,
+        "review-body gate did not pass",
+    ),
+    (
+        "e2e_advisory_still_reaches_inline_scan",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            pr_body="A body that never decided.\n",
+            router=_router(inline_lines=_INLINE_P1_LINE),
+        ),
+        2,
+        "inline review gate did not pass",
+    ),
+    (
+        "e2e_advisory_still_reaches_scheduled_review",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(),
+            pr_body="A body that never decided.\n",
+            scheduled="",
+        ),
+        2,
+        "scheduled Claude review(s) missing",
+    ),
+    # ── SAME CLASS, PRE-EXISTING MEMBERS: the `# ci-override` paths ────────────
+    # The E2E advisory is not the only "print a NOTE and continue" path in the
+    # merge arm — the CI gate has two, and their ids say `_continues` while
+    # nothing checked that anything continues: both asserted exit 0 with every
+    # downstream gate green, which is the shape this file's own comment above
+    # calls insufficient ("only an exit code proves what it DOES"). MEASURED
+    # 2026-09-06: a `return 0` after the CI-absent NOTE left 699 tests green.
+    # Covered here rather than filed, because "fix the class" means the
+    # population and not just the member this PR happened to touch — the whole
+    # point of the round that found it. One downstream gate each is enough to
+    # catch an early return; the per-gate enumeration above belongs to the path
+    # this PR actually changes.
+    (
+        "ci_absent_override_still_reaches_inline_scan",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(trailer="# ci-override"),
+            ci="[]",
+            router=_router(inline_lines=_INLINE_P1_LINE),
+        ),
+        2,
+        "inline review gate did not pass",
+    ),
+    (
+        "ci_incomplete_override_still_reaches_inline_scan",
+        lambda mp: _run(
+            mp,
+            _merge_cmd(trailer="# ci-override"),
+            ci=json.dumps(
+                [
+                    {
+                        "name": "Analyze (python)",
+                        "workflowName": "CodeQL",
+                        "conclusion": "SUCCESS",
+                        "status": "COMPLETED",
+                    }
+                ]
+            ),
+            router=_router(inline_lines=_INLINE_P1_LINE),
+        ),
+        2,
+        "inline review gate did not pass",
+    ),
     (
         "pin_unchanged_allows_through_main",
         lambda mp: _run(
@@ -1164,6 +1270,30 @@ def test_merge_gate_aggregation(case_id, thunk, expected_rc, expected_msg, monke
     assert rc == expected_rc, f"{case_id}: expected exit {expected_rc}, got {rc}. stderr:\n{err}"
     if expected_msg:
         assert expected_msg in err, f"{case_id}: {expected_msg!r} not in stderr:\n{err}"
+
+
+def test_merge_arm_advisory_follows_the_flag_not_the_message_text(monkeypatch, capsys):
+    """The merge arm decides from the RETURNED FLAG, never from the message prose.
+
+    Behavioural lock. The equivalent assertion in test_e2e_plan_gate.py was a
+    negative grep for the literal `e2e_msg.startswith`, which pins a variable
+    SPELLING: MEASURED 2026-09-06 that renaming the local and reinstating the
+    re-derivation left that lock green while the forbidden behaviour was back.
+    A name is the cheapest thing in a refactor to change.
+
+    Here the classifier is made to return `declared` under a label that does NOT
+    start with "ok"/"n/a". Any arm that re-derives severity from the text emits
+    the undeclared NOTE on a PR the report calls declared — the exact
+    report/enforcement divergence — and this test fails however it is spelled."""
+    monkeypatch.setattr(_mod, "_check_e2e_plan", lambda *a, **k: (False, "declared (plan)"))
+    rc = _run(monkeypatch, _merge_cmd())
+    err = capsys.readouterr().err
+    assert rc == 0, f"a declared PR must not be blocked. stderr:\n{err}"
+    assert "no post-merge E2E decision" not in err, (
+        "the merge arm emitted the UNDECLARED advisory for a declaration the "
+        "classifier reported as present — it is reading the message text, not "
+        f"the returned flag. stderr:\n{err}"
+    )
 
 
 def test_findings_not_fetched_when_freshness_blocks(monkeypatch):
@@ -1292,6 +1422,36 @@ def test_check_pr_report_scheduled_absent_fails_verdict(monkeypatch, capsys):
     sched_line = next(ln for ln in out.splitlines() if ln.startswith("scheduled-claude"))
     assert "BLOCK" in sched_line
     assert rc == 1
+
+
+def test_check_pr_report_e2e_row_is_advisory_and_never_flips_the_verdict(monkeypatch, capsys):
+    """The `e2e-plan` row reports, and NEVER counts toward the report's verdict.
+
+    Until this existed, the ONLY reference to `e2e-plan` anywhere in tests/ was a
+    source-string grep asserting the label appears in the file. MEASURED
+    2026-09-06: re-adding `failures += 1 if undeclared else 0` to the report arm —
+    the report blocking a PR the merge arm allows, which is precisely the
+    divergence the arm's own comment forbids — left the whole suite green.
+
+    Locks three things no grep can: the row is labelled `advisory`, the remedy
+    tail is rendered under it, and the verdict stays 0."""
+    _report_env(monkeypatch, scheduled=_scheduled_marker(HEAD))
+    monkeypatch.setenv("_TEST_GH_PR_BODY", "A body that never decided.\n")
+    monkeypatch.setenv("_TEST_GH_PR_CREATED_AT", "2099-01-01T00:00:00Z")
+    rc = _mod.check_pr_report("100", repo=REPO)
+    out = capsys.readouterr().out
+    e2e_line = next(ln for ln in out.splitlines() if ln.startswith("e2e-plan"))
+    assert "advisory" in e2e_line, e2e_line
+    assert "BLOCK" not in e2e_line, "an advisory row must not wear the blocking label"
+    assert "E2E: none —" in out, (
+        "the remedy tail must reach the operator — an advisory minus its remedy "
+        "is the strongest argument for ignoring it"
+    )
+    assert rc == 0, (
+        "an undeclared E2E flipped the report's verdict while the merge arm allows "
+        "it — report and enforcement disagreeing is the one thing this report rests "
+        "on not doing"
+    )
 
 
 def test_check_pr_report_ci_absent_fails_verdict_on_canonical(monkeypatch, capsys):


### PR DESCRIPTION
## Summary

Reverses the enforcement half of #1808. The `E2E:` PR-body declaration stops blocking the merge command and becomes an advisory NOTE. The parser, the cutoff, the `--check-pr` row and every classification test are unchanged — only the verdict moves.

## Why

A block guarantees that a **sentence exists**, never that it is **true**. The judgment behind that sentence gets made the same way with or without the gate, so the gate bought no determinism — it bought compliance text. A mandatory field produces the shortest string that satisfies the parser; an optional one produces signal. The original justification was two observed cases.

The obligation belongs **after** the merge instead: a per-merge verification row, with a documentation-only diff auto-closed by **path** so no model ever decides that a prompt change "needs an end-to-end". **That half is not built** — #1718 stays open for it — and every message in this diff now says so instead of promising a safety net that does not exist. Until it ships, the declaration line is the only record there is, which the advisory states plainly.

## Changes

- **Merge arm** prints a NOTE and proceeds. It prints the **whole** message, so the remedy — both valid forms plus two copyable examples — actually reaches the operator. Printing only the first line answered a colon-promise with a restatement of the problem; an advisory minus its remedy is just noise to route around.
- **`--check-pr`** prints `advisory — …` with the guidance indented beneath, and never increments the failure count.
- Both arms branch on the **returned flag**, never on the message prose. Sharing a function while re-deriving severity from a string prefix is divergence wearing the invariant's clothes.
- `CLAUDE.md` and the PR template rewritten as encouragement — including what skipping the line on a **code** PR actually costs, since the future row's exemption is by path and cannot recover a judgment nobody made.
- Test file renamed off "blocked"/"gate" vocabulary: a test named `..._blocks` that asserts exit 0 is a trap for whoever greps next.

## Testing

- [x] `ruff check .` passes
- [x] `pytest` — 1278 passed across 15 merge-gate-adjacent hook suites plus the parser unit file
- [ ] `docs/architecture/CURRENT.md` — not applicable, no subsystem capability change

**Mutation proof, not a source grep.** Re-inserting `sys.exit(2)` after the merge-arm NOTE goes RED on exactly the two cases that encode the reversal (`e2e_declaration_absent_is_advisory_not_blocking`, `e2e_bare_none_is_advisory_not_blocking`) while 108 others stay green; restored from backup with `sha256sum -c` verified. #1808's "wiring" tests were source-string greps that stayed green while the gate was disarmed — this diff does not repeat that.

**Live:** `--check-pr 1804` against a body that declares nothing prints `e2e-plan : advisory — …` with the full guidance tail, and the report's only remaining BLOCK is `codex-at-head`.

## Residual risk, stated

Until #1718's half B lands, this strictly **removes** a record: a PR declaring nothing now merges with only stderr text nobody retains. That is the accepted tradeoff, and no message in the diff pretends otherwise.

E2E: none — the change removes a merge-time block; its behavior is fully exercised by the characterization suite driving the real command and asserting exit codes, and the live `--check-pr` run above. No runtime service surface is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * E2E-plan checks remain advisory and do not block merges.
  * Missing or invalid declarations now receive consistent remediation guidance while processing continues.
  * Compliant declarations are not rejected, and advisory messages are not treated as enforcement decisions.
  * Clarified that `none` requires a reason; omitted declarations leave the decision unrecorded.

* **Tests**
  * Expanded coverage for advisory reporting, parser fallbacks, unreadable inputs, downstream gates, and merge verdict behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->