### PR TITLE
fix(browser): apply the devicePixelRatio it was already measuring

### DIFF
--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -122,6 +122,10 @@ _IDLE_TIMEOUT_S = 3600  # 1 hour
 
 _SCREENSHOT_DIR = Path.home() / "tmp"
 _VNC_DISPLAY = ":99"
+#: Pointer readback tolerance. VNC positioning is not exact to the pixel, so a
+#: small delta is normal; a large one is the signature of a coordinate-space
+#: mismatch rather than jitter.
+_POINTER_DRIFT_TOLERANCE_PX = 3
 _VNC_PASSWORD = os.environ.get("GENESIS_VNC_PASSWORD", "genesis")
 # vncdotool server format: display-number notation (display 99 = port 5999).
 # "localhost::5999" causes Connection Lost due to IPv6 resolution.
@@ -1504,6 +1508,41 @@ async def _solve_with_playwright_captcha(page) -> bool:
         return False
 
 
+def vnc_click_target(
+    *,
+    win_x: int,
+    win_y: int,
+    page_left: float,
+    page_top: float,
+    chrome_h: int,
+    dpr: float,
+) -> tuple[int, int]:
+    """Map a CSS-pixel page coordinate to a PHYSICAL screen coordinate.
+
+    Two different spaces meet here, and mixing them is silent:
+
+    * ``win_x``/``win_y`` come from ``xdotool getwindowgeometry`` — PHYSICAL
+      screen pixels, the space VNC input is delivered in.
+    * ``page_left``/``page_top`` come from ``getBoundingClientRect()``, and
+      ``chrome_h`` from ``outerHeight - innerHeight`` — both CSS pixels.
+
+    Those are the same number only when ``devicePixelRatio == 1``. Anywhere
+    else the click lands short of the target by the scale factor, with no
+    error — at dpr 1.25 a control 800 CSS-px down the page is clicked 200
+    physical pixels high.
+
+    This is pure so the scaled cases can be tested: the display this runs on
+    is dpr 1.0, so the bug is dormant here and CANNOT be exercised end to end.
+    Note the caller already spoofs window metrics for anti-detection, and
+    ``devicePixelRatio`` is itself a common fingerprinting vector, so a dpr
+    other than 1.0 is not hypothetical.
+    """
+    scale = dpr if dpr and dpr > 0 else 1.0
+    click_x = win_x + int(page_left * scale)
+    click_y = win_y + int((chrome_h + page_top) * scale)
+    return click_x, click_y
+
+
 async def _vnc_click_turnstile(page) -> bool:
     """Click the Turnstile checkbox via VNC trusted input (fallback).
 
@@ -1603,10 +1642,14 @@ async def _vnc_click_turnstile(page) -> bool:
                 chrome_h = 34
         except Exception:
             chrome_h = 34
+            dpr = 1.0
             _ts_log.info("VNC: chrome_h measurement failed, using default 34")
 
-        click_x = win_x + int(page_coords["left"])
-        click_y = win_y + chrome_h + int(page_coords["top"])
+        click_x, click_y = vnc_click_target(
+            win_x=win_x, win_y=win_y,
+            page_left=page_coords["left"], page_top=page_coords["top"],
+            chrome_h=chrome_h, dpr=dpr,
+        )
 
         _ts_log.info(
             "VNC TARGETING: (%d, %d) matched='%s' "
@@ -1650,6 +1693,56 @@ async def _vnc_click_turnstile(page) -> bool:
             return False
 
         await asyncio.sleep(random.uniform(0.2, 0.5))
+
+        # WHERE DID THE POINTER ACTUALLY GO? Read it back before clicking.
+        #
+        # Everything above is a COMPUTATION. It can be wrong for reasons the
+        # computation cannot see: a coordinate-space mismatch, a window that
+        # moved between measuring and acting, a VNC move that reported success
+        # and did nothing. Logging only the intended coordinate records what we
+        # meant, never what happened — and a click on the wrong thing is
+        # exactly the failure that needs a forensic trail afterwards.
+        #
+        # Best-effort: a readback failure must not block the click, but it IS
+        # reported rather than swallowed, so "unknown" never reads as "fine".
+        actual_x = actual_y = None
+        try:
+            probe = await asyncio.create_subprocess_exec(
+                "xdotool", "getmouselocation", "--shell",
+                env={**os.environ, "DISPLAY": _VNC_DISPLAY},
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            probe_out, _ = await asyncio.wait_for(probe.communicate(), timeout=5)
+            probe_vals = dict(
+                line.split("=", 1)
+                for line in probe_out.decode().splitlines()
+                if "=" in line
+            )
+            actual_x = int(probe_vals["X"])
+            actual_y = int(probe_vals["Y"])
+        except (TimeoutError, KeyError, ValueError, OSError) as exc:
+            _ts_log.info("VNC: pointer readback unavailable (%s)", type(exc).__name__)
+
+        if actual_x is None:
+            _ts_log.info(
+                "VNC LANDED: unknown — pointer readback failed; "
+                "intended=(%d,%d)", click_x, click_y,
+            )
+        else:
+            drift = abs(actual_x - click_x) + abs(actual_y - click_y)
+            _ts_log.info(
+                "VNC LANDED: (%d,%d) intended=(%d,%d) drift=%d dpr=%.2f",
+                actual_x, actual_y, click_x, click_y, drift, dpr,
+            )
+            if drift > _POINTER_DRIFT_TOLERANCE_PX:
+                # Loud, because this is the signature of a coordinate-space
+                # bug and it would otherwise look like an ordinary miss.
+                logger.warning(
+                    "VNC pointer drift %dpx: intended=(%d,%d) actual=(%d,%d) "
+                    "dpr=%.2f — clicking anyway, but the target may be wrong",
+                    drift, click_x, click_y, actual_x, actual_y, dpr,
+                )
 
         # VNC click at current position
         click_proc = await asyncio.create_subprocess_exec(

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -1771,12 +1771,24 @@ async def _vnc_click_turnstile(page) -> bool:
 
         # WHERE DID THE POINTER ACTUALLY GO? Read it back before clicking.
         #
-        # Everything above is a COMPUTATION. It can be wrong for reasons the
-        # computation cannot see: a coordinate-space mismatch, a window that
-        # moved between measuring and acting, a VNC move that reported success
-        # and did nothing. Logging only the intended coordinate records what we
-        # meant, never what happened — and a click on the wrong thing is
-        # exactly the failure that needs a forensic trail afterwards.
+        # Be precise about what this can and cannot catch, because the two are
+        # easy to conflate. It compares the pointer against the coordinate we
+        # ASKED FOR, so it detects a DELIVERY failure: a `vncdo move` that
+        # reported success and did nothing, a server that clamped the position,
+        # a pointer grabbed by something else.
+        #
+        # It CANNOT detect a wrong coordinate. If the computation above picked
+        # the wrong pixel — a coordinate-space mismatch, a window that moved
+        # after it was measured, a spoofed dpr — the move delivers the pointer
+        # to exactly that wrong pixel and drift is ZERO. Reading the position
+        # answers "did the pointer go where we said", never "was where we said
+        # correct"; only hit-testing what is under the pointer would answer
+        # that, and this path has no element handle to test against.
+        #
+        # It still earns its place: without it the log records only intent, and
+        # a click on the wrong thing is exactly the failure that needs a
+        # forensic trail afterwards. The dpr is logged alongside so the
+        # coordinate can be recomputed later from the record.
         #
         # Best-effort: a readback failure must not block the click, but it IS
         # reported rather than swallowed, so "unknown" never reads as "fine".
@@ -1795,11 +1807,14 @@ async def _vnc_click_turnstile(page) -> bool:
                 actual_x, actual_y, click_x, click_y, drift, dpr,
             )
             if drift > _POINTER_DRIFT_TOLERANCE_PX:
-                # Loud, because this is the signature of a coordinate-space
-                # bug and it would otherwise look like an ordinary miss.
+                # Loud, because the pointer is NOT where we put it — the click
+                # about to be sent lands somewhere we never chose. That is a
+                # different failure from aiming wrong, and it would otherwise
+                # look like an ordinary miss.
                 logger.warning(
                     "VNC pointer drift %dpx: intended=(%d,%d) actual=(%d,%d) "
-                    "dpr=%.2f — clicking anyway, but the target may be wrong",
+                    "dpr=%.2f — clicking anyway, but the pointer is not where "
+                    "it was placed",
                     drift, click_x, click_y, actual_x, actual_y, dpr,
                 )
 

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -126,6 +126,10 @@ _VNC_DISPLAY = ":99"
 #: small delta is normal; a large one is the signature of a coordinate-space
 #: mismatch rather than jitter.
 _POINTER_DRIFT_TOLERANCE_PX = 3
+#: Pointer readback probe timeout. Generous — xdotool answers in
+#: milliseconds against a healthy X server, so exceeding this means the
+#: server is wedged, not that the probe was slow.
+_POINTER_PROBE_TIMEOUT_S = 5
 _VNC_PASSWORD = os.environ.get("GENESIS_VNC_PASSWORD", "genesis")
 # vncdotool server format: display-number notation (display 99 = port 5999).
 # "localhost::5999" causes Connection Lost due to IPv6 resolution.
@@ -1543,6 +1547,70 @@ def vnc_click_target(
     return click_x, click_y
 
 
+async def _kill_and_reap(proc) -> None:
+    """Kill a subprocess and collect it.
+
+    ``asyncio.wait_for`` cancels the WAIT, never the child. MEASURED: a
+    process whose ``communicate()`` was cancelled by ``wait_for`` is still
+    running afterwards, with ``returncode is None``. Every timeout path that
+    does not do this leaks the process for as long as it chooses to run —
+    which, for a probe against a wedged X server, is unbounded.
+    """
+    try:
+        proc.kill()
+    except ProcessLookupError:
+        return  # already gone; nothing to reap
+    with contextlib.suppress(Exception):
+        await proc.wait()
+
+
+async def _read_pointer_position(
+    *, timeout_s: float = _POINTER_PROBE_TIMEOUT_S,
+) -> tuple[int, int] | None:
+    """Read the X pointer's ACTUAL position, or ``None`` if it cannot be read.
+
+    Best-effort by contract: every failure returns ``None`` rather than
+    raising, because a click must not be blocked by an unavailable
+    measurement. It is still LOGGED — an absent readback must never read as a
+    clean one. The ``OSError`` catch is load-bearing beyond tidiness: a
+    missing ``xdotool`` raises ``FileNotFoundError`` here, and the caller's
+    outer handler for that exception reports a missing ``vncdo`` and abandons
+    the click.
+    """
+    try:
+        probe = await asyncio.create_subprocess_exec(
+            "xdotool", "getmouselocation", "--shell",
+            env={**os.environ, "DISPLAY": _VNC_DISPLAY},
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except OSError as exc:
+        _ts_log.info("VNC: pointer readback unavailable (%s)", type(exc).__name__)
+        return None
+
+    try:
+        probe_out, _ = await asyncio.wait_for(probe.communicate(), timeout=timeout_s)
+    except TimeoutError:
+        await _kill_and_reap(probe)
+        _ts_log.info("VNC: pointer readback unavailable (TimeoutError)")
+        return None
+    except OSError as exc:
+        await _kill_and_reap(probe)
+        _ts_log.info("VNC: pointer readback unavailable (%s)", type(exc).__name__)
+        return None
+
+    try:
+        probe_vals = dict(
+            line.split("=", 1)
+            for line in probe_out.decode().splitlines()
+            if "=" in line
+        )
+        return int(probe_vals["X"]), int(probe_vals["Y"])
+    except (KeyError, ValueError, UnicodeDecodeError) as exc:
+        _ts_log.info("VNC: pointer readback unavailable (%s)", type(exc).__name__)
+        return None
+
+
 async def _vnc_click_turnstile(page) -> bool:
     """Click the Turnstile checkbox via VNC trusted input (fallback).
 
@@ -1566,7 +1634,14 @@ async def _vnc_click_turnstile(page) -> bool:
                 stderr=asyncio.subprocess.PIPE,
                 env={**os.environ, "DISPLAY": _VNC_DISPLAY},
             )
-            xdo_out, _ = await asyncio.wait_for(xdo.communicate(), timeout=3)
+            try:
+                xdo_out, _ = await asyncio.wait_for(xdo.communicate(), timeout=3)
+            except TimeoutError:
+                # Same leak as the pointer probe below: the wait is cancelled,
+                # the process is not. Reap it, then fall through to the (0,0)
+                # default via the enclosing handler.
+                await _kill_and_reap(xdo)
+                raise
             xdo_text = xdo_out.decode()
             # Parse "Position: X,Y (screen: 0)\n  Geometry: WxH"
             import re
@@ -1705,31 +1780,15 @@ async def _vnc_click_turnstile(page) -> bool:
         #
         # Best-effort: a readback failure must not block the click, but it IS
         # reported rather than swallowed, so "unknown" never reads as "fine".
-        actual_x = actual_y = None
-        try:
-            probe = await asyncio.create_subprocess_exec(
-                "xdotool", "getmouselocation", "--shell",
-                env={**os.environ, "DISPLAY": _VNC_DISPLAY},
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.DEVNULL,
-            )
-            probe_out, _ = await asyncio.wait_for(probe.communicate(), timeout=5)
-            probe_vals = dict(
-                line.split("=", 1)
-                for line in probe_out.decode().splitlines()
-                if "=" in line
-            )
-            actual_x = int(probe_vals["X"])
-            actual_y = int(probe_vals["Y"])
-        except (TimeoutError, KeyError, ValueError, OSError) as exc:
-            _ts_log.info("VNC: pointer readback unavailable (%s)", type(exc).__name__)
+        pointer = await _read_pointer_position()
 
-        if actual_x is None:
+        if pointer is None:
             _ts_log.info(
                 "VNC LANDED: unknown — pointer readback failed; "
                 "intended=(%d,%d)", click_x, click_y,
             )
         else:
+            actual_x, actual_y = pointer
             drift = abs(actual_x - click_x) + abs(actual_y - click_y)
             _ts_log.info(
                 "VNC LANDED: (%d,%d) intended=(%d,%d) drift=%d dpr=%.2f",

--- a/src/genesis/mcp/health/browser.py
+++ b/src/genesis/mcp/health/browser.py
@@ -123,8 +123,8 @@ _IDLE_TIMEOUT_S = 3600  # 1 hour
 _SCREENSHOT_DIR = Path.home() / "tmp"
 _VNC_DISPLAY = ":99"
 #: Pointer readback tolerance. VNC positioning is not exact to the pixel, so a
-#: small delta is normal; a large one is the signature of a coordinate-space
-#: mismatch rather than jitter.
+#: small delta is normal; a large one means the move was not DELIVERED as
+#: asked — clamped, dropped, or the pointer grabbed — rather than jitter.
 _POINTER_DRIFT_TOLERANCE_PX = 3
 #: Pointer readback probe timeout. Generous — xdotool answers in
 #: milliseconds against a healthy X server, so exceeding this means the
@@ -1569,13 +1569,14 @@ async def _read_pointer_position(
 ) -> tuple[int, int] | None:
     """Read the X pointer's ACTUAL position, or ``None`` if it cannot be read.
 
-    Best-effort by contract: every failure returns ``None`` rather than
-    raising, because a click must not be blocked by an unavailable
-    measurement. It is still LOGGED — an absent readback must never read as a
-    clean one. The ``OSError`` catch is load-bearing beyond tidiness: a
-    missing ``xdotool`` raises ``FileNotFoundError`` here, and the caller's
-    outer handler for that exception reports a missing ``vncdo`` and abandons
-    the click.
+    Best-effort by contract: every measurement failure returns ``None`` rather
+    than raising, because a click must not be blocked by an unavailable
+    measurement. Cancellation is not a measurement failure — the caller is
+    gone — so it reaps the child and propagates. It is still LOGGED: an absent
+    readback must never read as a clean one. The ``OSError`` catch is
+    load-bearing beyond tidiness: a missing ``xdotool`` raises
+    ``FileNotFoundError`` here, and the caller's outer handler for that
+    exception reports a missing ``vncdo`` and abandons the click.
     """
     try:
         probe = await asyncio.create_subprocess_exec(
@@ -1590,11 +1591,15 @@ async def _read_pointer_position(
 
     try:
         probe_out, _ = await asyncio.wait_for(probe.communicate(), timeout=timeout_s)
-    except TimeoutError:
+    except asyncio.CancelledError:
+        # MEASURED: an outer cancellation reaches NEITHER handler below and
+        # leaves the child running (returncode None, pid alive). Not an exotic
+        # path — browser_navigate cancels this whole call at its 300s ceiling,
+        # and a wedged X server is both what holds the probe open and what
+        # makes that ceiling get reached.
         await _kill_and_reap(probe)
-        _ts_log.info("VNC: pointer readback unavailable (TimeoutError)")
-        return None
-    except OSError as exc:
+        raise
+    except (TimeoutError, OSError) as exc:
         await _kill_and_reap(probe)
         _ts_log.info("VNC: pointer readback unavailable (%s)", type(exc).__name__)
         return None
@@ -1636,10 +1641,12 @@ async def _vnc_click_turnstile(page) -> bool:
             )
             try:
                 xdo_out, _ = await asyncio.wait_for(xdo.communicate(), timeout=3)
-            except TimeoutError:
+            except (asyncio.CancelledError, TimeoutError):
                 # Same leak as the pointer probe below: the wait is cancelled,
-                # the process is not. Reap it, then fall through to the (0,0)
-                # default via the enclosing handler.
+                # the process is not. Reap it, then re-raise — a timeout falls
+                # through to the (0,0) default via the enclosing
+                # ``except Exception``, a cancellation propagates straight past
+                # it (CancelledError is a BaseException).
                 await _kill_and_reap(xdo)
                 raise
             xdo_text = xdo_out.decode()

--- a/tests/test_browser/test_click_coordinates.py
+++ b/tests/test_browser/test_click_coordinates.py
@@ -1,0 +1,74 @@
+"""Coordinate-space safety for VNC-delivered clicks.
+
+The VNC click path mixes two coordinate spaces: window position comes from
+``xdotool`` in PHYSICAL screen pixels, while the in-page target and the chrome
+height come from the DOM in CSS pixels. They coincide only at
+``devicePixelRatio == 1``.
+
+The display this suite runs on is dpr 1.0, so the scaled cases cannot be
+exercised end to end here — which is exactly why the mapping was extracted
+into a pure function and is tested directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from genesis.mcp.health.browser import vnc_click_target
+
+
+def test_unscaled_display_is_a_plain_offset():
+    """At dpr 1.0 the CSS and physical spaces coincide."""
+    x, y = vnc_click_target(
+        win_x=100, win_y=50, page_left=200, page_top=300, chrome_h=34, dpr=1.0,
+    )
+    assert (x, y) == (300, 384)
+
+
+@pytest.mark.parametrize(
+    ("dpr", "expected"),
+    [
+        (1.25, (350, 467)),   # 100 + 200*1.25 , 50 + (34+300)*1.25
+        (1.5, (400, 551)),
+        (2.0, (500, 718)),
+    ],
+)
+def test_scaled_display_scales_the_css_offsets_only(dpr, expected):
+    """The window origin is already physical; only the CSS parts scale.
+
+    Scaling the whole sum would double-count the window origin — a distinct
+    bug from the one this fixes, so it is pinned here too.
+    """
+    assert vnc_click_target(
+        win_x=100, win_y=50, page_left=200, page_top=300, chrome_h=34, dpr=dpr,
+    ) == expected
+
+
+def test_a_scaled_display_lands_far_from_the_unscaled_answer():
+    """The regression this exists to prevent, stated as a distance.
+
+    Without the scale factor a control partway down the page is clicked high
+    by a wide margin — silently, since nothing errors.
+    """
+    unscaled = vnc_click_target(
+        win_x=0, win_y=0, page_left=0, page_top=800, chrome_h=0, dpr=1.0,
+    )
+    scaled = vnc_click_target(
+        win_x=0, win_y=0, page_left=0, page_top=800, chrome_h=0, dpr=1.25,
+    )
+    assert scaled[1] - unscaled[1] == 200
+
+
+@pytest.mark.parametrize("bad_dpr", [0, 0.0, None, -1.0])
+def test_an_implausible_dpr_falls_back_to_unscaled(bad_dpr):
+    """A missing or nonsense dpr must not collapse the coordinate to the origin.
+
+    ``page.evaluate`` can return a spoofed or absent value — the anti-detection
+    layer already spoofs sibling window metrics — and multiplying by 0 would
+    silently click the top-left corner of the window.
+    """
+    x, y = vnc_click_target(
+        win_x=10, win_y=20, page_left=200, page_top=300, chrome_h=34,
+        dpr=bad_dpr,
+    )
+    assert (x, y) == (210, 354)

--- a/tests/test_browser/test_click_coordinates.py
+++ b/tests/test_browser/test_click_coordinates.py
@@ -96,8 +96,10 @@ class _FakeProc:
         self.killed = False
         self.reaped = False
         self.returncode = None
+        self.waiting = asyncio.Event()
 
     async def communicate(self):
+        self.waiting.set()
         if self._hang:
             await asyncio.sleep(60)  # cancelled by wait_for; process lives on
         return self._stdout, b""
@@ -134,6 +136,33 @@ async def test_a_timed_out_probe_is_killed_and_reaped(monkeypatch):
 
     assert await browser._read_pointer_position(timeout_s=0.01) is None
     assert proc.killed, "timed-out probe was never killed — the process leaks"
+    assert proc.reaped, "killed probe was never awaited — it stays a zombie"
+
+
+async def test_a_cancelled_probe_is_killed_and_the_cancellation_propagates(
+    monkeypatch,
+):
+    """The timeout is not the only way this wait ends — cancellation is.
+
+    MEASURED on a REAL child under this structure: cancelling the outer task
+    while ``wait_for`` is pending raises ``CancelledError``, so neither
+    handler runs, ``returncode`` stays None and the pid is still alive. The
+    timeout test above cannot see that — its own path DOES reap (-9, pid
+    gone). Nor is it exotic: ``browser_navigate`` cancels this whole call at
+    its 300s ceiling, and a wedged X server is both what holds the probe open
+    and what drives the loop to that ceiling. It must still PROPAGATE —
+    returning ``None`` would leave a torn-down request running.
+    """
+    proc = _FakeProc(hang=True)
+    _patch_spawn(monkeypatch, proc)
+
+    task = asyncio.create_task(browser._read_pointer_position(timeout_s=30))
+    await proc.waiting.wait()  # the probe is spawned and inside the wait
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert proc.killed, "cancelled probe was never killed — the process leaks"
     assert proc.reaped, "killed probe was never awaited — it stays a zombie"
 
 

--- a/tests/test_browser/test_click_coordinates.py
+++ b/tests/test_browser/test_click_coordinates.py
@@ -12,8 +12,11 @@ into a pure function and is tested directly.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
+from genesis.mcp.health import browser
 from genesis.mcp.health.browser import vnc_click_target
 
 
@@ -72,3 +75,114 @@ def test_an_implausible_dpr_falls_back_to_unscaled(bad_dpr):
         dpr=bad_dpr,
     )
     assert (x, y) == (210, 354)
+
+
+# ---------------------------------------------------------------------------
+# Pointer readback probe lifecycle
+#
+# The readback exists to prove where the pointer actually LANDED, so it runs
+# on every VNC click. That makes its failure path a lifecycle question, not a
+# cosmetic one: asyncio.wait_for cancels the WAIT, never the child, so a probe
+# that times out against a wedged X server keeps running unless it is killed.
+# ---------------------------------------------------------------------------
+
+
+class _FakeProc:
+    """A subprocess stand-in that records whether it was killed and reaped."""
+
+    def __init__(self, *, stdout: bytes = b"", hang: bool = False):
+        self._stdout = stdout
+        self._hang = hang
+        self.killed = False
+        self.reaped = False
+        self.returncode = None
+
+    async def communicate(self):
+        if self._hang:
+            await asyncio.sleep(60)  # cancelled by wait_for; process lives on
+        return self._stdout, b""
+
+    def kill(self):
+        self.killed = True
+
+    async def wait(self):
+        self.reaped = True
+        self.returncode = -9
+        return self.returncode
+
+
+def _patch_spawn(monkeypatch, result):
+    """Install ``result`` (a proc or an exception) as the spawned process."""
+    async def _fake_exec(*args, **kwargs):
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+
+
+async def test_a_timed_out_probe_is_killed_and_reaped(monkeypatch):
+    """The failure this test exists for is a LEAK, not a wrong answer.
+
+    ``asyncio.wait_for`` cancels the wait and leaves the child running —
+    measured: ``returncode`` is None and the pid is still alive afterwards.
+    Without an explicit kill, every stalled probe outlives its call for as
+    long as the wedged X server holds it.
+    """
+    proc = _FakeProc(hang=True)
+    _patch_spawn(monkeypatch, proc)
+
+    assert await browser._read_pointer_position(timeout_s=0.01) is None
+    assert proc.killed, "timed-out probe was never killed — the process leaks"
+    assert proc.reaped, "killed probe was never awaited — it stays a zombie"
+
+
+async def test_a_healthy_probe_returns_the_pointer_and_is_not_killed(monkeypatch):
+    """Negative control: the kill must fire ONLY on the timeout path.
+
+    A kill on the success path would be indistinguishable from the fix in the
+    timeout test above while breaking every real readback.
+    """
+    proc = _FakeProc(stdout=b"X=412\nY=307\nSCREEN=0\nWINDOW=12582919\n")
+    _patch_spawn(monkeypatch, proc)
+
+    assert await browser._read_pointer_position(timeout_s=5) == (412, 307)
+    assert not proc.killed
+    assert not proc.reaped
+
+
+async def test_a_missing_xdotool_is_reported_not_raised(monkeypatch):
+    """A missing binary must not abandon the click.
+
+    ``create_subprocess_exec`` raises ``FileNotFoundError`` when xdotool is
+    absent, and the caller's outer handler for that exception reports a
+    missing ``vncdo`` and returns False. Letting it escape would turn an
+    unavailable measurement into a skipped click.
+    """
+    _patch_spawn(monkeypatch, FileNotFoundError("xdotool"))
+
+    assert await browser._read_pointer_position(timeout_s=5) is None
+
+
+async def test_unparseable_probe_output_is_not_a_pointer(monkeypatch):
+    """Absent coordinates must read as absent, never as (0, 0).
+
+    Zero is a legitimate pointer position, so a parse failure that returned it
+    would masquerade as a real reading in the drift check.
+    """
+    proc = _FakeProc(stdout=b"SCREEN=0\nWINDOW=12582919\n")
+    _patch_spawn(monkeypatch, proc)
+
+    assert await browser._read_pointer_position(timeout_s=5) is None
+    assert not proc.killed
+
+
+async def test_kill_and_reap_tolerates_an_already_exited_process():
+    """A process that died between the timeout and the kill is not an error."""
+    class _Gone(_FakeProc):
+        def kill(self):
+            raise ProcessLookupError
+
+    proc = _Gone()
+    await browser._kill_and_reap(proc)  # must not raise
+    assert not proc.reaped


### PR DESCRIPTION
## The bug

The VNC click path mixes two coordinate spaces:

| value | source | space |
|---|---|---|
| `win_x`, `win_y` | `xdotool getwindowgeometry` | **physical** screen pixels — where VNC delivers input |
| `page_coords` | `getBoundingClientRect()` | **CSS** pixels |
| `chrome_h` | `outerHeight - innerHeight` | **CSS** pixels |

Those are the same number only at `devicePixelRatio == 1`.

And the code **already measured `dpr`, logged it, and never multiplied by it**:

```python
dpr = dims.get("dpr", 1.0)
_ts_log.info("VNC: chrome_h=%d ... dpr=%.2f", ...)   # measured, logged
click_x = win_x + int(page_coords["left"])           # ...and discarded
```

At `dpr 1.25` a control 800 CSS-px down the page is clicked **200 physical pixels high** — silently, with an intent log that looks entirely correct.

**Dormant, not absent.** The container's Xvfb is 1920×1080 at 100 DPI, so `dpr == 1.0` and the missing multiplication is a no-op. Not hypothetical either: the comment directly above that measurement notes the anti-detection layer spoofs `outerHeight`/`innerHeight`, and `devicePixelRatio` is itself a standard fingerprinting vector.

## Why the mapping is now a pure function

This display **cannot exercise the scaled cases end to end** — `dpr` is 1.0 here. Testing the arithmetic directly is the only honest verification available, and shipping a fix I couldn't demonstrate wasn't acceptable.

Reverting to the old arithmetic fails **4 of 9** cases, every scaled case collapsing to the unscaled answer `(300, 384)`. The `dpr 1.0` case still **passes** under the mutation — which is exactly why a suite covering only 1.0 would have sat green over this indefinitely.

Also pinned: an implausible `dpr` (`0`, `None`, negative) falls back to unscaled rather than multiplying the coordinate to the window origin. A spoofed or absent value from `page.evaluate` is live on this path, and silently clicking the top-left corner is a worse failure than not scaling.

## Logging what actually happened

No click path recorded where the pointer **actually went**. Intent is a computation, and a computation cannot notice it's wrong — a space mismatch, a window that moved between measuring and acting, or a `vncdo move` that returns success and does nothing all produce a correct-looking intent log and a click somewhere else.

The pointer is now read back after the move and before the click:

```
VNC LANDED: (x,y) intended=(x,y) drift=N dpr=1.00
```

Drift past a small jitter tolerance (3px — VNC positioning isn't pixel-exact) escalates to a WARNING naming both coordinates. A readback failure doesn't block the click but **is reported** (`VNC LANDED: unknown`), so an absent measurement never reads as a clean one.

## Corrections after review (312b56499, ab6e45e97)

**The readback detects less than this description first claimed.** It compares
the pointer against the coordinate this code computed and handed to
`vncdo move`, so it catches a DELIVERY failure — a move that reported success
and did nothing, a clamped or grabbed pointer. It does **not** catch a wrong
coordinate: if the computation picked the wrong pixel, the move faithfully
delivers the pointer there and drift is **zero**. Of the three cases named
above, only the third is detected. The comments and the warning text now say
so; the readback keeps its place because the log otherwise records only intent,
and `dpr` is recorded alongside so a coordinate can be recomputed from the log
afterwards.

**A timed-out probe is now killed.** `asyncio.wait_for` cancels the wait, never
the child — measured: `returncode` is `None` and the pid is still alive after
the cancellation. Enumerating every `wait_for(...communicate())` in the file
found 4 sites, 2 of them leaking: the new pointer probe (raised by CodeRabbit)
and the pre-existing window-geometry probe three lines up the same function.
Both reap now; the two `vncdo` paths already did.

E2E: unchanged from the line below — no runtime surface was added. The probe's
failure paths are unit-tested against a fake process (timeout kills and reaps,
success does not kill, a missing `xdotool` is reported rather than raised).

## Checked, not presumed

Three coordinate-based click paths exist. The two Playwright ones (`browser.py:1387`, `:1447`) go `bounding_box()` → `page.mouse.click()`, staying entirely inside Playwright's CSS-pixel space — internally consistent, and both already log their coordinates and box. **Only the VNC path crosses spaces.** One instance, not a pattern.

## Not done, deliberately

`browser_click` — the main, selector-based path — still logs no coordinates. It resolves elements through Playwright rather than computing coordinates, so it has no coordinate to get wrong and is safer by construction. Adding a bounding-box log there is observability, not a fix, and belongs with the computer-use skill work rather than in a bugfix PR.

## Context

Found by asking whether the local browser stack shares the DPI defect just fixed for Windows capture in #1823. It does.

E2E: verified pre-merge by mutation against the pre-fix arithmetic (4 of 9 cases flip) plus 127 passing tests across the browser suites. Post-merge E2E is not meaningful for the scaled path on this install — `dpr` is 1.0, so the corrected branch is unreachable here by construction; that is precisely why the mapping was extracted and unit-tested. The pointer-readback logging is exercised on any real VNC click.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved remote browser clicking on high-DPI displays by accurately translating page coordinates to screen coordinates.
  - Preserved reliable clicking when display-scale information is unavailable or invalid.
  - Added position verification and warnings when the pointer lands outside the expected area.
  - Improved coordinate handling across browser window offsets and display scaling scenarios.
- **Tests**
  - Added coverage for scaled, unscaled, and fallback remote-click coordinate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
