### PR TITLE
docs(skills): say which click path actually has the guarantee

### DIFF
--- a/src/genesis/skills/browser-automation/SKILL.md
+++ b/src/genesis/skills/browser-automation/SKILL.md
@@ -69,10 +69,24 @@ that can accomplish the task. **Token cost increases with each layer.**
 - Use when you need network inspection, Lighthouse, or performance tracing
   beyond what the built-in Genesis browser tools provide
 
-### Layer 4: Computer Use (visual fallback — V4)
-- Claude Computer Use API (screenshot-based interaction)
-- ~1000 tokens per screenshot, expensive but universal
-- Not yet implemented
+### Layer 4: Computer Use — the operator's whole desktop, not just a browser
+- Reaches what no browser layer can: native applications, OS dialogs, and any
+  window that is not a web page. Also drives a browser when the point is to
+  drive it *as the operator sees it*.
+- **Perceive leg is live.** `scripts/capture_desktop.sh` triggers a capture on
+  the operator's machine and returns the image. Window-scoped by default;
+  full-screen exists but is never the default and is never inherited from a
+  window grant (it discloses every open window at once).
+- **Act leg — mouse, keyboard, drag — is NOT live**, and is gated behind an
+  approval design. Do not attempt to construct it ad hoc.
+- Mechanism, and it is not obvious: an SSH login on Windows lands in
+  SessionId 0 while the desktop is SessionId 1, so **nothing run over SSH can
+  see or touch the desktop**. Work reaches the desktop only via a scheduled
+  task registered with an Interactive logon type.
+  Full detail: `docs/reference/windows-remote-execution.md`.
+- Cost is a screenshot per observation, so prefer a lower layer whenever the
+  target is reachable by one. A browser task is almost always cheaper at
+  Layer 2 or 3.
 
 ### Layer Selection Guide
 | Need | Layer | Why |
@@ -86,6 +100,8 @@ that can accomplish the task. **Token cost increases with each layer.**
 | Submit on user's logged-in site | Remote CDP | User's sessions |
 | Network inspection / Lighthouse | On-Demand MCP | Chrome DevTools |
 | Take action in user's banking app | Remote CDP | MUST confirm |
+| Native app / OS dialog / non-web window | Computer Use | No browser layer can reach it |
+| See what is actually on the operator's screen | Computer Use | Capture, not a page |
 
 ## When to Use
 
@@ -152,6 +168,51 @@ button:has-text("Add to Cart")
 6. **Screenshot before submit** — Visual verification before irreversible action
 7. **Submit** — Click submit button
 8. **Verify result** — Read resulting page to confirm success
+
+## Coordinate Safety
+
+Applies to every layer that computes a position rather than naming an element,
+and to the desktop layer especially. Two of these were live bugs in this
+codebase, found 2026-09-06.
+
+**Prefer a selector to a coordinate.** `browser_click` resolves the element
+through Playwright, so there is no coordinate to get wrong. A computed
+coordinate can be wrong for reasons the computation cannot see. Reach for
+coordinates only when nothing else can hit the target.
+
+**Never mix coordinate spaces.** The recurring defect is arithmetic that adds
+two numbers from different spaces:
+
+| space | comes from |
+|---|---|
+| CSS pixels | `getBoundingClientRect()`, `outerHeight - innerHeight` |
+| physical screen pixels | `xdotool` window geometry, `SendInput` absolute mode |
+| DPI-virtualised pixels | any Windows API read by a process that has not called `SetProcessDPIAware()` |
+
+They coincide **only at `devicePixelRatio == 1` and 100% display scaling**,
+which is why this class of bug sits dormant on an unscaled dev machine and
+breaks on a real laptop. On Windows at 125% scaling a DPI-unaware process is
+told the screen is 1536x864 when it is 1920x1080 — every measurement it then
+takes is wrong by 1.25, silently.
+
+**Set DPI awareness before the first measurement, not before the first use.**
+Anything measured beforehand is already in the wrong space.
+
+**Confirm the target, then act.** After positioning and before clicking, read
+back what is actually under the pointer and refuse if it is not the element
+intended. This converts every coordinate error — scaling, stale bounds, a
+window that moved between measuring and acting — from a wrong click into a
+refusal.
+
+**Log where it actually landed, not where you aimed.** Intent is a
+computation; a computation cannot notice that it is wrong. Record actual
+against intended with the drift and the scale factor, at the moment of the
+action, so a mis-click leaves a forensic trail instead of a log that looks
+correct. If the readback fails, say so — "unknown" must never render as fine.
+
+**A zero return is a refusal.** `SendInput` returns the number of events
+injected and returns `0` rather than raising when the OS declines. Any API of
+this shape must have its return value checked; ignoring it reads as success.
 
 ## Safety Gates
 

--- a/src/genesis/skills/stealth-browser/SKILL.md
+++ b/src/genesis/skills/stealth-browser/SKILL.md
@@ -159,6 +159,15 @@ This section documents the mechanism for debugging only. The VNC
 protocol injects real input events, bypassing detection of synthetic
 events (XTest, CDP, Playwright mouse).
 
+**Coordinate correctness is NOT this skill's subject, and the rules live in
+one place.** This path is the only one in the codebase that mixes coordinate
+spaces — DOM coordinates in CSS pixels against a window origin in physical
+screen pixels — and it got that wrong until 2026-09-06 by measuring
+`devicePixelRatio` and never applying it. Anti-detection and hitting the right
+pixel are orthogonal concerns; see **Coordinate Safety** in the
+`browser-automation` skill rather than re-deriving it here, so the two cannot
+drift apart.
+
 ### Why It Works
 
 x11vnc injects input through the VNC protocol, adding network-realistic


### PR DESCRIPTION
Seven review findings, all one class: the skill files asserted capabilities, paths and fixed defects the code does not support. Fixing them surfaced three more, and an adversarial audit **of the fix** surfaced three blockers in the fix itself — which is the part of this worth reading, since it is the same failure the PR exists to correct.

## Root cause

The branch sat **130 commits behind main**. Claims that were true when written had quietly stopped being true, in both directions — one reviewer finding was itself stale, because the defect it described had been fixed in #1828 two days before the review. The branch is merged up now, and every statement below was re-derived against the current tree.

## What changed

**Layer 4 no longer claims Genesis builds no desktop layer "by design."** The present-tense half is true and was verified by enumeration — no input injection, no capture code, anywhere in the tree. The design half was contradicted by the module the same bullet cited: the takeover gate ships first and alone *precisely so* an actuator, loop and MCP tool can follow behind it. Saying no Genesis subsystem may actuate would leave that gate governing nothing. It now describes two routes at their actual stages — ask a resident agent (available today, no new code), or the gated actuator (in flight, inert) — and keeps the prohibition that matters: **do not build a third route outside the gate.**

**The coordinate-safety warning claimed no path reads back what is under the pointer before clicking.** That is false, and it is falsified by this repo's own vendored dependency: Playwright hit-tests the point and refuses with `intercepts pointer events` on every non-stealth click. The truth is messier, so it is now a table — five click paths against two questions, *does it hit-test* and *does it read back*:

- **Stealth mode is the DEFAULT and does not hit-test.** Which is why the advice preferring a selector was wrong forty lines before the text explaining why.
- **A third and fourth coordinate path existed** that the first rewrite missed entirely — the Turnstile widget click and the shadow-DOM fallback.
- **The VNC row is the subtle one.** It verifies DELIVERY, not IDENTITY: it reads the pointer position back and warns on drift past 3px, then clicks anyway, deliberately.

A table rather than prose on purpose — a path added later is visibly missing from it, where a sentence beginning "either path" just silently stops being true.

**`SendInput` absolute mode was listed as physical pixels.** It is normalised 0–65,535, and *which rectangle* it normalises across is the part that bites: the primary monitor alone, or — with `MOUSEEVENTF_VIRTUALDESK` — the whole virtual desktop, whose origin can be **negative**. Get it wrong and the pointer lands correctly on the primary display and silently wrong on every other one.

**Two helpers were documented as implemented** under a heading instructing you to apply them in every session. `_idle_jitter()` and `_human_scroll()` exist and **nothing calls them**, so the behaviour simply does not happen. Now stated plainly, with `_human_type()` marked as genuinely wired and scoped to the path it is wired on.

**Also:** the perceive leg pointed at a script that exists on no branch; the desktop is session 1 **or higher**, not 1; the dpr fix landed 2026-09-09 in #1828, not the 09-06 the doc claimed (that was when it was *found*); material from an unlanded Windows spike now carries its provenance instead of reading as described behaviour; and the layer had three different names across the file, one of them in the `description` the skill-injection hook matches on.

## Verification

Every claim was checked against the code it describes, including reading the vendored Playwright driver rather than reasoning about Playwright's semantics. The adversarial audit's own findings were then re-derived independently before being acted on — three blockers, six should-fix, four notes, all addressed.

Two claims the audit confirmed exactly right on the first pass: the dead-helper call sites, and the #1828 attribution.

## Ordering

Depends on **#1823** for `docs/reference/windows-remote-execution.md`, which is not on main yet. That PR is clear of its gates and merges first.

E2E: none — documentation. Nothing in this diff runs.
