### PR TITLE
fix(hooks): catching up with the base is not an unreviewed change

### DIFF
--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2950,7 +2950,25 @@ def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | No
         # a STALE review to bind the merge on a delta that was never verified
         # (Codex P2, #1373). Only the documented linear statuses are classifiable.
         return None
-    files = data.get("files")
+    return _classify_delta_files(data.get("files"))
+
+
+def _classify_delta_files(files: object) -> str | None:
+    """Classify a list of compare FILE RECORDS as ``inline`` / ``substantial`` / None.
+
+    The shared tail of every unreviewed-delta judgement, extracted so the
+    base-advance refinement below cannot quietly acquire weaker RECORD rules than
+    the raw compare path: the hook-surface teeth, the malformed-record refusal
+    and the shared substantiality classifier all reach both callers here.
+
+    The 300-file truncation guard below does NOT protect both, and an earlier
+    version of this docstring claimed it did. It tests the list it is HANDED,
+    and the refinement hands it a changed SUBSET — always under the cap, so the
+    check would be vacuous there. The refinement therefore applies its own cap
+    to the lists it FETCHES, which is where truncation can actually hide a file.
+    Stated rather than fixed by moving the check, because the two callers
+    legitimately have different lists to guard.
+    """
     if not isinstance(files, list):
         return None
     if len(files) >= 300:
@@ -2991,6 +3009,236 @@ def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | No
         return classify_compare_substantiality(files)
     except Exception:
         return None
+
+
+def _pr_contribution(
+    base_sha: str, tip_sha: str, repo: str | None
+) -> tuple[str, str, list] | None:
+    """``(merge_base_sha, status, files)`` for what ``tip`` contributes over ``base``.
+
+    ``compare/base...tip`` is three-dot, so GitHub computes it from the MERGE
+    BASE of the two — which is what makes this the PR's own work rather than a
+    commit range. **That merge base is returned, not discarded, because it is
+    load-bearing**: it is the LEFT-hand side of the diff, it MOVES when the
+    branch catches up, and a file's blob sha is only the RIGHT-hand side. Two
+    diffs with the same right side and different left sides are different
+    diffs. The caller needs the left side to know whether it may compare them
+    at all.
+
+    Returns None on any error — including a returncode, unparseable JSON, or an
+    exit-0 with an EMPTY payload. An empty stdout is not an empty diff: reading
+    it as ``[]`` would manufacture positive evidence of "unchanged" out of a
+    degraded response.
+
+    Tests inject via ``_TEST_GH_CONTRIBUTION`` — a JSON object keyed
+    ``"<base12>..<tip12>"`` whose value is ``{"mb": <sha>, "files": [...]}``.
+    """
+    raw = os.environ.get("_TEST_GH_CONTRIBUTION")
+    if raw is not None:
+        try:
+            got = json.loads(raw).get(f"{base_sha[:12]}..{tip_sha[:12]}")
+        except Exception:
+            return None
+        if not isinstance(got, dict) or not isinstance(got.get("files"), list):
+            return None
+        mb, st = got.get("mb"), got.get("status")
+        if not (isinstance(mb, str) and mb) or not isinstance(st, str) or not st:
+            return None
+        return (mb, st, got["files"])
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo or ':owner/:repo'}/compare/{base_sha}...{tip_sha}",
+                "--jq",
+                '{mb: .merge_base_commit.sha, status: .status, '
+                'files: [.files[]? | {filename, sha, additions, deletions, status, '
+                'previous_filename, has_patch: has("patch")}]}',
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_gh_timeout(8),
+        )
+        if result.returncode != 0:
+            return None
+        # No `or "[]"` fallback: an exit-0 with an EMPTY payload must not become an
+        # empty diff. json.loads("") raises, which the except below turns into
+        # None — a degraded response reads as unreadable, never as "unchanged".
+        parsed = json.loads(result.stdout)
+    except Exception:
+        return None
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("files"), list):
+        return None
+    mb, st = parsed.get("mb"), parsed.get("status")
+    if not (isinstance(mb, str) and mb) or not isinstance(st, str) or not st:
+        return None
+    return (mb, st, parsed["files"])
+
+
+def _classify_base_advance_delta(
+    reviewed_sha: str, head_sha: str, base_sha: str, repo: str | None
+) -> str | None:
+    """Re-judge a "substantial" delta as what the BRANCH actually changed.
+
+    A branch that merges its base to catch up acquires every commit the base
+    contributed. The raw ``reviewed...head`` compare cannot tell that from a
+    force-push and reports all of it as unreviewed, so the gate demands a fresh
+    review of code that was already reviewed on its own PR — MEASURED on this
+    repo: PR #1847 showed 28 files / 7 commits after merging main, of which the
+    branch's own change was 2 files. #1690 made catching up MANDATORY for every
+    branch carrying a changelog entry, so this stopped being incidental.
+
+    The question this asks instead: did the PR's OWN contribution change? Both
+    sides are the PR's diff over its base — at review time and now — compared by
+    blob sha. Files whose content is identical in both were reviewed and have
+    not moved; only the remainder is unreviewed.
+
+    NARROWING, so every uncertainty fails CLOSED: either fetch failing returns
+    None (the caller blocks), and the surviving subset goes through the SAME
+    ``_classify_delta_files`` as the raw path, keeping the hook-surface teeth and
+    the truncation guard. A file the base touched that the branch ALSO touches
+    shows a different blob and stays in the delta — the PR's diff over its base
+    genuinely changed there, which is the case most worth re-reading.
+    """
+    got_before = _pr_contribution(base_sha, reviewed_sha, repo)
+    got_after = _pr_contribution(base_sha, head_sha, repo)
+    if got_before is None or got_after is None:
+        return None
+    before_mb, _before_status, before = got_before
+    after_mb, _after_status, after = got_after
+    if not before and not after:
+        # Two empty lists are not evidence of "unchanged" — they are evidence of
+        # nothing. The sibling path already fails closed on an empty `files`
+        # (Codex P2, #1373: "an empty files would read as inline and permit a
+        # STALE review to bind the merge on a delta that was never verified");
+        # a narrowing built on the same shape must not read it the other way.
+        return None
+    if len(before) >= 300 or len(after) >= 300:
+        # GitHub caps compare `files` at 300. The cap must be checked on the
+        # FETCHED lists, not on the changed subset derived from them — a subset
+        # is always under the cap, so checking it there tests nothing. MEASURED
+        # on this repo: a wide compare reports 300 files against 1293 real ones,
+        # so the invisible remainder could hold the very change being claimed
+        # unchanged.
+        return None
+    def _identities(records: list) -> dict[str, tuple[str, object]] | None:
+        """filename -> (blob sha, status), or None if any identity is unreadable.
+
+        Blob sha alone is CONTENT identity, not file identity: it encodes bytes
+        and not mode, so a script that becomes executable keeps its blob and
+        would drop out of the changed set. `status` is folded in because it is
+        what the compare record actually offers. This does NOT fully close the
+        mode question — GitHub's compare record carries no mode field at all —
+        and saying so here is the point: the earlier docstring claimed "exact
+        content identity" and was read as exact FILE identity, which it is not.
+
+        A record MISSING its ``sha`` must not compare EQUAL to another missing
+        one. MEASURED on this code before the check: two absent shas matched, the
+        file dropped out of the changed set, and a genuinely modified file read as
+        a base-advance — a stale review allowed on changed code, which is the one
+        outcome this refinement must never produce. Triviality is an exception
+        granted on POSITIVE evidence; an identity that cannot be read is not it,
+        so the whole claim is withdrawn rather than made on partial data.
+        """
+        out: dict[str, tuple[str, object]] = {}
+        for f in records:
+            if not isinstance(f, dict):
+                return None
+            name, blob = f.get("filename"), f.get("sha")
+            if not isinstance(name, str) or not name:
+                return None
+            if not isinstance(blob, str) or not blob:
+                return None
+            if name in out:
+                return None  # duplicate filename — cannot compare honestly
+            out[name] = (blob, f.get("status"))
+        return out
+
+    a, b = _identities(before), _identities(after)
+    if a is None or b is None:
+        return None
+    changed = {name for name in set(a) | set(b) if a.get(name) != b.get(name)}
+    moved_names: set[str] = set()  # what the BASE changed, when it moved
+    if before_mb != after_mb:
+        # THE MERGE BASE MOVED, which is the normal case here — catching up is
+        # what advances it. A file's blob sha is only the RIGHT-hand side of the
+        # diff; the merge base is the LEFT. So identical blobs across a moved
+        # base do NOT mean an identical diff, and treating them as such is a
+        # fail-open with a specific, routine trigger: resolve a catch-up conflict
+        # with `--ours` and the merge silently REVERTS what the base contributed
+        # while every tip blob stays put. Codex reviewed `F1 -> X`; what ships is
+        # `F2 -> X`, which it never saw.
+        #
+        # So ask what the base itself changed across the move, and refuse the
+        # claim if it overlaps the files this PR touches. A genuine base-advance
+        # — the base moving in files the branch does not touch — has an empty
+        # intersection and is still allowed.
+        moved = _pr_contribution(before_mb, after_mb, repo)
+        if moved is None:
+            return None
+        _mb, moved_status, moved_files = moved
+        if moved_status != "ahead":
+            # The base must have moved FORWARD for "the base advanced" to mean
+            # anything. MEASURED: a three-dot compare of a base that moved
+            # BACKWARDS reports status "behind" with ZERO files, so the overlap
+            # test below would find nothing and wave the claim through. Only a
+            # genuine advance qualifies; behind / diverged / identical fail closed.
+            return None
+        if len(moved_files) >= 300:
+            return None  # truncated: cannot rule out an overlap
+        # Rename SOURCES count, matching `_classify_delta_files` and
+        # `_pr_changed_files`: a file the base renamed out from under the branch
+        # is a change to that path. This was the one place in the feature that
+        # folded only `filename`, and the asymmetry is the shape this whole
+        # refinement exists to close.
+        for f in moved_files:
+            name = f.get("filename") if isinstance(f, dict) else None
+            if not isinstance(name, str) or not name:
+                return None  # malformed record — cannot establish the overlap
+            moved_names.add(name)
+            prev = f.get("previous_filename")
+            if prev is not None:
+                if not isinstance(prev, str) or not prev:
+                    return None
+                moved_names.add(prev)
+        if moved_names & (set(a) | set(b)):
+            return None
+    # THE HOOK SURFACE IS NEVER RESCUED, whatever the blobs say.
+    #
+    # This refinement RECONSTRUCTS "what changed" from two base-relative
+    # snapshots plus a synthetic identity, where the raw path diffs the two
+    # commits directly. That reconstruction loses whatever the identity does not
+    # carry — and GitHub's compare record carries no file MODE at all. So a
+    # content-preserving `chmod +x` on a guard keeps its blob AND its status,
+    # never enters `changed`, never reaches `_classify_delta_files`, and the
+    # teeth that exist to catch "any touch to the enforcement surface, however
+    # small" never run. The raw path would have caught it, so this is a
+    # REGRESSION the refinement introduces rather than a limitation it inherits.
+    #
+    # Rather than chase an identity rich enough to be safe, decline the rescue
+    # outright when the enforcement surface is anywhere in view. A hook-surface
+    # PR forgoing a stale-review allowance is exactly the trade the surrounding
+    # gate already makes everywhere else.
+    for name in set(a) | set(b) | moved_names:
+        if _is_hook_surface_path(name):
+            return None
+    if not changed:
+        # The branch contributes byte-identical content over its base, and the
+        # base did not touch any file the branch touches. Everything new since
+        # the review came from the base, and was reviewed there.
+        return "inline"
+    records = [f for f in after if isinstance(f, dict) and f.get("filename") in changed]
+    # A file the PR USED to touch and no longer does still counts as a change to
+    # its contribution; it has no record on the `after` side, so take the `before`
+    # one rather than dropping it silently.
+    seen = {f.get("filename") for f in records}
+    records += [
+        f
+        for f in before
+        if isinstance(f, dict) and f.get("filename") in changed and f.get("filename") not in seen
+    ]
+    return _classify_delta_files(records)
 
 
 def _check_codex_reviewed_head(
@@ -3092,7 +3340,34 @@ def _check_codex_reviewed_head(
         )
     if reviewed != head:
         level = _classify_post_review_delta(reviewed, head, repo)
+        base_advance = False
+        if level == "substantial":
+            # The raw range says substantial. Ask the narrower question before
+            # blocking: did the BRANCH change, or did its base just advance
+            # underneath it? Only a definite "substantial" is re-judged — a None
+            # (API/parse failure) is the fail-closed state and must not be
+            # rescued by a second read that could itself be degraded.
+            base_sha = _pr_base_sha(pr_num, repo=repo)
+            # COST guard, not a correctness one — say so, because a mutation that
+            # deletes it is behaviourally NULL and will survive any sweep: without
+            # a base the refinement already declines (its fetches cannot resolve a
+            # revision, so it returns None and the block stands). What this saves
+            # is two doomed `gh` round-trips against the 45s merge budget.
+            if base_sha:
+                refined = _classify_base_advance_delta(reviewed, head, base_sha, repo)
+                if refined == "inline":
+                    level, base_advance = "inline", True
         if level == "inline":
+            if base_advance:
+                print(
+                    f"NOTE: Codex's review on PR #{pr_num} is on {reviewed[:12]} (head "
+                    f"{head[:12]}), but the branch's own contribution over its base is "
+                    f"UNCHANGED since — the delta is a base-advance (commits the base "
+                    f"contributed, each reviewed on its own PR) — allowing. Inspect: "
+                    f"git log {reviewed[:12]}..{head[:12]} --oneline",
+                    file=sys.stderr,
+                )
+                return False, "", head
             # The unreviewed delta is provably review-trivial — allow, but still
             # bind the merge to THIS head (TOCTOU): the triviality claim is about
             # exactly this reviewed...head range, not any later push.

--- a/scripts/hooks/git_push_guard.py
+++ b/scripts/hooks/git_push_guard.py
@@ -2950,25 +2950,7 @@ def _classify_post_review_delta(reviewed_sha: str, head_sha: str, repo: str | No
         # a STALE review to bind the merge on a delta that was never verified
         # (Codex P2, #1373). Only the documented linear statuses are classifiable.
         return None
-    return _classify_delta_files(data.get("files"))
-
-
-def _classify_delta_files(files: object) -> str | None:
-    """Classify a list of compare FILE RECORDS as ``inline`` / ``substantial`` / None.
-
-    The shared tail of every unreviewed-delta judgement, extracted so the
-    base-advance refinement below cannot quietly acquire weaker RECORD rules than
-    the raw compare path: the hook-surface teeth, the malformed-record refusal
-    and the shared substantiality classifier all reach both callers here.
-
-    The 300-file truncation guard below does NOT protect both, and an earlier
-    version of this docstring claimed it did. It tests the list it is HANDED,
-    and the refinement hands it a changed SUBSET — always under the cap, so the
-    check would be vacuous there. The refinement therefore applies its own cap
-    to the lists it FETCHES, which is where truncation can actually hide a file.
-    Stated rather than fixed by moving the check, because the two callers
-    legitimately have different lists to guard.
-    """
+    files = data.get("files")
     if not isinstance(files, list):
         return None
     if len(files) >= 300:
@@ -3091,15 +3073,27 @@ def _classify_base_advance_delta(
 
     The question this asks instead: did the PR's OWN contribution change? Both
     sides are the PR's diff over its base — at review time and now — compared by
-    blob sha. Files whose content is identical in both were reviewed and have
-    not moved; only the remainder is unreviewed.
+    file identity. It returns ``"inline"`` for exactly ONE finding: the two
+    contributions are IDENTICAL. It never sizes a residual change, so its only
+    two answers are "provably a pure base-advance" and None.
 
-    NARROWING, so every uncertainty fails CLOSED: either fetch failing returns
-    None (the caller blocks), and the surviving subset goes through the SAME
-    ``_classify_delta_files`` as the raw path, keeping the hook-surface teeth and
-    the truncation guard. A file the base touched that the branch ALSO touches
-    shows a different blob and stays in the delta — the PR's diff over its base
-    genuinely changed there, which is the case most worth re-reading.
+    That is a deliberate narrowing over a version that DID size the residual
+    (Codex P1, #1849): the records available here are base-relative, so a
+    contribution that SHRANK between the review and head presents small counts
+    while the reviewed...head delta is large, and the sizing read as trivial. See
+    the ``if changed:`` block below.
+
+    NARROWING, so uncertainty fails CLOSED at every point it can be SEEN: a
+    failing fetch returns None (the caller blocks), an unreadable identity
+    withdraws the claim, an unreadable base move withdraws it, and a file the base
+    touched that the branch ALSO touches is a collision rather than an advance.
+
+    The one uncertainty it CANNOT see is file MODE, which the compare record does
+    not carry at all. That is why the enforcement surface is declined outright
+    rather than trusted to the identity — see the block above the hook-surface
+    loop. On a NON-hook path a mode-only change still rides through as unchanged,
+    and this docstring says so rather than claiming a closure the code does not
+    have.
     """
     got_before = _pr_contribution(base_sha, reviewed_sha, repo)
     got_after = _pr_contribution(base_sha, head_sha, repo)
@@ -3122,8 +3116,8 @@ def _classify_base_advance_delta(
         # so the invisible remainder could hold the very change being claimed
         # unchanged.
         return None
-    def _identities(records: list) -> dict[str, tuple[str, object]] | None:
-        """filename -> (blob sha, status), or None if any identity is unreadable.
+    def _identities(records: list) -> dict[str, tuple[str, object, str | None]] | None:
+        """filename -> (blob sha, status, rename source), or None if unreadable.
 
         Blob sha alone is CONTENT identity, not file identity: it encodes bytes
         and not mode, so a script that becomes executable keeps its blob and
@@ -3133,6 +3127,16 @@ def _classify_base_advance_delta(
         and saying so here is the point: the earlier docstring claimed "exact
         content identity" and was read as exact FILE identity, which it is not.
 
+        ``previous_filename`` is folded in for the same reason, and it is the
+        half an earlier version omitted (Codex P1, #1849). A rename is a diff
+        with two endpoints, and the compare record reports only the DESTINATION
+        as ``filename``; the blob is the destination's bytes. So a contribution
+        that renames ``A -> B`` and one that renames ``D -> B`` present the same
+        filename, the same blob and the same ``renamed`` status while deleting
+        DIFFERENT files. MEASURED on this code before the fix: those two compared
+        equal, the file dropped out of the changed set, and the branch's changed
+        rename read as a base-advance.
+
         A record MISSING its ``sha`` must not compare EQUAL to another missing
         one. MEASURED on this code before the check: two absent shas matched, the
         file dropped out of the changed set, and a genuinely modified file read as
@@ -3141,7 +3145,7 @@ def _classify_base_advance_delta(
         granted on POSITIVE evidence; an identity that cannot be read is not it,
         so the whole claim is withdrawn rather than made on partial data.
         """
-        out: dict[str, tuple[str, object]] = {}
+        out: dict[str, tuple[str, object, str | None]] = {}
         for f in records:
             if not isinstance(f, dict):
                 return None
@@ -3150,15 +3154,25 @@ def _classify_base_advance_delta(
                 return None
             if not isinstance(blob, str) or not blob:
                 return None
+            prev = f.get("previous_filename")
+            if prev is not None and (not isinstance(prev, str) or not prev):
+                return None  # present but unreadable — cannot compare honestly
             if name in out:
                 return None  # duplicate filename — cannot compare honestly
-            out[name] = (blob, f.get("status"))
+            out[name] = (blob, f.get("status"), prev)
         return out
 
     a, b = _identities(before), _identities(after)
     if a is None or b is None:
         return None
     changed = {name for name in set(a) | set(b) if a.get(name) != b.get(name)}
+    # Every path the PR's contribution touches, on EITHER side — destinations AND
+    # rename SOURCES. The source is a path this branch changes (it deletes it), so
+    # a base that touches it is a base change to a file the branch touches. Folding
+    # only destinations here is the same omission as in the identity above, one
+    # scope out: the overlap test below would compare the base's moved set against
+    # destinations alone and miss the collision entirely (Codex P1, #1849).
+    touched = set(a) | set(b) | {p for (_blob, _st, p) in (*a.values(), *b.values()) if p}
     moved_names: set[str] = set()  # what the BASE changed, when it moved
     if before_mb != after_mb:
         # THE MERGE BASE MOVED, which is the normal case here — catching up is
@@ -3185,13 +3199,28 @@ def _classify_base_advance_delta(
             # test below would find nothing and wave the claim through. Only a
             # genuine advance qualifies; behind / diverged / identical fail closed.
             return None
+        if not moved_files:
+            # The base MOVED, so it changed something — a compare that reports
+            # ZERO files is a degraded read, not an empty advance. The jq at
+            # `_pr_contribution` is `.files[]?`, and `?` swallows a MISSING or
+            # null `files` key, so an upstream response without it arrives here
+            # as `[]`, indistinguishable from a real empty diff.
+            #
+            # It is also self-contradictory: this refinement runs only when the
+            # RAW range classified `substantial`, and an empty compare `files`
+            # classifies `inline` (review_scope.classify_compare_substantiality:
+            # "An empty / None list means no reviewable delta"). So a base that
+            # advanced while changing nothing could not have produced the
+            # substantial raw verdict that got us here. No evidence, no claim —
+            # the same rule the two contribution lists already get above.
+            return None
         if len(moved_files) >= 300:
             return None  # truncated: cannot rule out an overlap
-        # Rename SOURCES count, matching `_classify_delta_files` and
-        # `_pr_changed_files`: a file the base renamed out from under the branch
-        # is a change to that path. This was the one place in the feature that
-        # folded only `filename`, and the asymmetry is the shape this whole
-        # refinement exists to close.
+        # Rename SOURCES count on BOTH sides of this intersection — here for the
+        # base's moved set, and in `touched` above for the branch's, matching
+        # `classify_compare_substantiality` and `_pr_changed_files`. A file the
+        # base renamed out from under the branch is a change to that path, and so
+        # is a file the branch renamed away.
         for f in moved_files:
             name = f.get("filename") if isinstance(f, dict) else None
             if not isinstance(name, str) or not name:
@@ -3202,7 +3231,7 @@ def _classify_base_advance_delta(
                 if not isinstance(prev, str) or not prev:
                     return None
                 moved_names.add(prev)
-        if moved_names & (set(a) | set(b)):
+        if moved_names & touched:
             return None
     # THE HOOK SURFACE IS NEVER RESCUED, whatever the blobs say.
     #
@@ -3211,34 +3240,46 @@ def _classify_base_advance_delta(
     # commits directly. That reconstruction loses whatever the identity does not
     # carry — and GitHub's compare record carries no file MODE at all. So a
     # content-preserving `chmod +x` on a guard keeps its blob AND its status,
-    # never enters `changed`, never reaches `_classify_delta_files`, and the
-    # teeth that exist to catch "any touch to the enforcement surface, however
-    # small" never run. The raw path would have caught it, so this is a
-    # REGRESSION the refinement introduces rather than a limitation it inherits.
+    # never enters `changed`, and the teeth that exist to catch "any touch to the
+    # enforcement surface, however small" never run. The raw path would have
+    # caught it, so this is a REGRESSION the refinement introduces rather than a
+    # limitation it inherits.
     #
     # Rather than chase an identity rich enough to be safe, decline the rescue
     # outright when the enforcement surface is anywhere in view. A hook-surface
     # PR forgoing a stale-review allowance is exactly the trade the surrounding
     # gate already makes everywhere else.
-    for name in set(a) | set(b) | moved_names:
+    for name in touched | moved_names:
         if _is_hook_surface_path(name):
             return None
-    if not changed:
-        # The branch contributes byte-identical content over its base, and the
-        # base did not touch any file the branch touches. Everything new since
-        # the review came from the base, and was reviewed there.
-        return "inline"
-    records = [f for f in after if isinstance(f, dict) and f.get("filename") in changed]
-    # A file the PR USED to touch and no longer does still counts as a change to
-    # its contribution; it has no record on the `after` side, so take the `before`
-    # one rather than dropping it silently.
-    seen = {f.get("filename") for f in records}
-    records += [
-        f
-        for f in before
-        if isinstance(f, dict) and f.get("filename") in changed and f.get("filename") not in seen
-    ]
-    return _classify_delta_files(records)
+    if changed:
+        # ANY change to the branch's own contribution withdraws the claim. The
+        # ONLY thing this refinement establishes is "byte-identical contribution";
+        # it does not, and must not, try to SIZE a residual change.
+        #
+        # An earlier version sized it, by handing the changed subset's `after`
+        # records to the shared substantiality classifier — and that was a
+        # fail-open with a mundane trigger (Codex P1, #1849). Those records are
+        # BASE-relative, not reviewed-relative: a file the review saw as a 100-line
+        # addition that head trims back to 3 lines presents an `after` record of 3
+        # lines, classifies `inline`, and lets a ~97-line unreviewed rewrite bind a
+        # stale review. MEASURED on this code before the fix: before=100 additions,
+        # after=3 additions returned "inline" (the growing direction, 3 -> 100,
+        # correctly returned "substantial" — so the leak was one-directional and
+        # invisible from the side anyone would test).
+        #
+        # Reconstructing the true reviewed...head size from two base-relative
+        # snapshots is exactly the argv->effect reconstruction the guard doctrine
+        # says not to build: any bound would rest on the diff algorithm's
+        # minimality, which is not a guarantee GitHub makes. So the residual is not
+        # sized at all — it blocks, and the fresh review the gate would have
+        # demanded anyway is the answer. Nothing is lost against the status quo:
+        # without this refinement the raw range read `substantial` and blocked too.
+        return None
+    # The branch contributes byte-identical content over its base, and the base
+    # did not touch any path the branch touches. Everything new since the review
+    # came from the base, and was reviewed there.
+    return "inline"
 
 
 def _check_codex_reviewed_head(

--- a/tests/test_hooks/conftest.py
+++ b/tests/test_hooks/conftest.py
@@ -44,6 +44,27 @@ def _hermetic_e2e_declaration(monkeypatch):
     yield
 
 
+@pytest.fixture(autouse=True)
+def _hermetic_base_advance(monkeypatch):
+    """Hermetic defaults for the base-advance refinement of the freshness gate.
+
+    When the raw ``reviewed...head`` compare reads SUBSTANTIAL, the gate now asks
+    a second question — did the BRANCH change, or did its base advance under it?
+    — which reads the base tip and the PR's own contribution. Without a seam both
+    are LIVE ``gh`` calls: green on a dev box with gh authenticated, red in CI,
+    and slow either way, so every existing freshness test would be testing the
+    network.
+
+    The contribution seam defaults to ``{}``, which resolves to None for any
+    revision pair → the refinement declines to rescue → existing tests keep the
+    exact verdicts they were written for. That is the fail-CLOSED direction, so
+    the default cannot mask a regression by accidentally allowing something.
+    Cases that exercise the refinement set both seams themselves and win."""
+    monkeypatch.setenv("_TEST_GH_BASE_OID", "ba5e" * 10)
+    monkeypatch.setenv("_TEST_GH_CONTRIBUTION", "{}")
+    yield
+
+
 def _load_settings() -> dict:
     """Load .claude/settings.json from the repo root."""
     here = Path(__file__).resolve()

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -579,6 +579,372 @@ class TestSmartDeltaFreshness:
         assert "stale-review-override" in msg
 
 
+class TestContributionFetchLivePath:
+    """The PRODUCTION query, with the env seam DELETED.
+
+    Every other test in this file reaches `_pr_contribution` through
+    `_TEST_GH_CONTRIBUTION`, which short-circuits before `subprocess.run` — so
+    the jq filter, the returncode check, the empty-stdout refusal and the shape
+    guards had no coverage at all. That is the seam-hides-the-query shape: the
+    merge-base field these tests depend on is REQUESTED here and nowhere else,
+    and a wrong field name would leave every seamed test green while the feature
+    silently never fired.
+    """
+
+    def _run(self, monkeypatch, *, rc=0, stdout=""):
+        monkeypatch.delenv("_TEST_GH_CONTRIBUTION", raising=False)
+        calls = []
+
+        def fake(cmd, **kwargs):
+            calls.append(cmd)
+            return __import__("subprocess").CompletedProcess(cmd, rc, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake)
+        got = _mod._pr_contribution("b" * 40, "t" * 40, "o/r")
+        return got, calls
+
+    def test_the_query_requests_the_merge_base_and_blob_sha(self, monkeypatch):
+        payload = json.dumps(
+            {"mb": "m" * 40, "status": "ahead", "files": [{"filename": "a.py", "sha": "s"}]}
+        )
+        got, calls = self._run(monkeypatch, stdout=payload)
+        assert got == ("m" * 40, "ahead", [{"filename": "a.py", "sha": "s"}])
+        argv = " ".join(calls[0])
+        assert "compare/" + "b" * 40 + "..." + "t" * 40 in argv
+        for field in ("merge_base_commit.sha", ".status", "filename", "sha"):
+            assert field in argv, f"the production jq no longer requests {field!r}"
+
+    @pytest.mark.parametrize(
+        ("label", "rc", "stdout"),
+        [
+            ("non-zero returncode", 1, '{"mb": "m", "status": "ahead", "files": []}'),
+            ("empty stdout on exit 0", 0, ""),
+            ("whitespace-only stdout", 0, "   \n"),
+            ("valid JSON, wrong shape", 0, "[]"),
+            ("files not a list", 0, '{"mb": "m", "status": "ahead", "files": "oops"}'),
+            ("merge base missing", 0, '{"status": "ahead", "files": []}'),
+            ("merge base empty", 0, '{"mb": "", "status": "ahead", "files": []}'),
+            ("status missing", 0, '{"mb": "m", "files": []}'),
+            ("unparseable JSON", 0, "{not json"),
+        ],
+    )
+    def test_every_degraded_response_is_unreadable(self, monkeypatch, label, rc, stdout):
+        # An exit-0 with no payload is NOT an empty diff. Reading it as one would
+        # manufacture positive evidence of "unchanged" from a degraded response.
+        got, _calls = self._run(monkeypatch, rc=rc, stdout=stdout)
+        assert got is None, f"{label} must be unreadable, not an empty contribution"
+
+
+def _contrib(name, sha, *, additions=5, deletions=0, status="modified"):
+    return {
+        "filename": name,
+        "sha": sha,
+        "additions": additions,
+        "deletions": deletions,
+        "status": status,
+        "previous_filename": None,
+        "has_patch": True,
+    }
+
+
+class TestBaseAdvanceRefinement:
+    """A branch that merges its BASE to catch up acquires every commit the base
+    contributed. The raw ``reviewed...head`` compare cannot tell that from a
+    force-push and reports all of it as unreviewed — so the gate demanded a fresh
+    review of code already reviewed on its own PR.
+
+    MEASURED on live PR #1847: the raw range showed 28 files / 7 commits, of
+    which the branch's own contribution changed in 3. #1690 made catching up
+    MANDATORY for every branch carrying a changelog entry, so this went from
+    incidental to systematic — 15 PRs, 4 of them previously Codex-clean.
+
+    The refinement asks whether the PR's OWN contribution over its base changed,
+    comparing by blob sha. It NARROWS a gate, so every cell below that is not a
+    proven base-advance must still block."""
+
+    BASE = "ba5e" * 10
+
+    MB = "17b0" * 10  # merge base, IDENTICAL on both sides unless a case moves it
+
+    def _setup(self, monkeypatch, before, after, *, raw=None, mb_before=None, mb_after=None,
+               moved=None, moved_status="ahead"):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(STALE))
+        # Raw range reads SUBSTANTIAL unless a case says otherwise — that is the
+        # verdict the refinement exists to re-judge.
+        monkeypatch.setenv(
+            "_TEST_GH_COMPARE", raw if raw is not None else _compare_json("ahead", [_code_file()])
+        )
+        monkeypatch.setenv("_TEST_GH_BASE_OID", self.BASE)
+        mb_b = mb_before or self.MB
+        mb_a = mb_after or self.MB
+        seam = {
+            f"{self.BASE[:12]}..{STALE[:12]}": {"mb": mb_b, "status": "ahead", "files": before},
+            f"{self.BASE[:12]}..{HEAD[:12]}": {"mb": mb_a, "status": "ahead", "files": after},
+        }
+        if mb_b != mb_a:
+            # What the BASE itself changed across the move. Absent unless a case
+            # supplies it, so a moved base with no answer fails closed.
+            seam[f"{mb_b[:12]}..{mb_a[:12]}"] = {
+                "mb": mb_b,
+                "status": moved_status,
+                "files": moved or [],
+            }
+        monkeypatch.setenv("_TEST_GH_CONTRIBUTION", json.dumps(seam))
+
+    def test_pure_base_advance_allows_and_binds_head(self, monkeypatch, capsys):
+        same = [_contrib("src/genesis/a.py", "blob1"), _contrib("README.md", "blob2")]
+        self._setup(monkeypatch, same, list(same))
+        block, _msg, verified = _mod._check_codex_reviewed_head("5")
+        assert block is False
+        # TOCTOU: the claim is about exactly this head, so the merge still binds to it.
+        assert verified == HEAD
+        err = capsys.readouterr().err
+        assert "base-advance" in err, "the operator must be told WHY a stale review was allowed"
+
+    def test_a_real_branch_change_still_blocks(self, monkeypatch):
+        before = [_contrib("src/genesis/a.py", "blob1")]
+        after = [_contrib("src/genesis/a.py", "blob2", additions=200)]
+        self._setup(monkeypatch, before, after)
+        block, msg, verified = _mod._check_codex_reviewed_head("5")
+        assert block is True and verified is None
+        assert "SUBSTANTIAL" in msg
+
+    def test_hook_surface_in_the_changed_contribution_still_blocks(self, monkeypatch):
+        # Teeth rule 1: a delta touching the enforcement-hook surface is NEVER
+        # review-trivial, however small. The refinement routes through the SAME
+        # _classify_delta_files, so it cannot acquire a weaker rule than the raw path.
+        # Anchored on a NON-hook path on purpose. A hook path now declines the
+        # rescue outright, one layer earlier — so anchoring here would block for
+        # that reason and prove nothing about the classifier. Two substantial
+        # code files is what only `_classify_delta_files` can judge.
+        before = [
+            _contrib("src/genesis/a.py", "b1", additions=200),
+            _contrib("src/genesis/b.py", "b2", additions=200),
+        ]
+        after = [
+            _contrib("src/genesis/a.py", "b3", additions=200),
+            _contrib("src/genesis/b.py", "b4", additions=200),
+        ]
+        self._setup(monkeypatch, before, after)
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+
+    def test_a_file_dropped_from_the_contribution_counts_as_changed(self, monkeypatch):
+        # The PR used to touch this file and no longer does. It has no record on
+        # the `after` side; dropping it silently would let a removal read as
+        # "nothing changed".
+        before = [_contrib("src/genesis/a.py", "blob1", additions=200)]
+        self._setup(monkeypatch, before, [])
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+
+    def test_an_unreadable_contribution_blocks(self, monkeypatch):
+        monkeypatch.setenv("_TEST_GH_HEAD_SHA", HEAD)
+        monkeypatch.setenv("_TEST_GH_CODEX_REVIEWS", _reviews_jsonl(STALE))
+        monkeypatch.setenv("_TEST_GH_COMPARE", _compare_json("ahead", [_code_file()]))
+        monkeypatch.setenv("_TEST_GH_BASE_OID", self.BASE)
+        monkeypatch.setenv("_TEST_GH_CONTRIBUTION", "{}")  # neither side resolves
+        block, msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+        assert "SUBSTANTIAL" in msg
+
+    def test_an_unclassifiable_raw_delta_is_NOT_rescued(self, monkeypatch):
+        # Only a DEFINITE "substantial" is re-judged. A None raw verdict is the
+        # fail-closed state — rescuing it with a second read that could itself be
+        # degraded would turn two unknowns into an allow.
+        same = [_contrib("README.md", "blob1")]
+        self._setup(monkeypatch, same, list(same), raw="null")
+        block, msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+        assert "could not be classified" in msg
+
+    def test_an_absent_base_sha_blocks(self, monkeypatch):
+        # Isolates the `if base_sha:` guard. The contribution seam is deliberately
+        # keyed for the EMPTY base too, and with identical content on both sides —
+        # so a build that proceeds without a base would find "nothing changed" and
+        # ALLOW. Without this seeding the downstream None catches it anyway and the
+        # guard's removal survives, which is how a sibling layer hides a missing test.
+        same = [_contrib("README.md", "blob1")]
+        self._setup(monkeypatch, same, list(same))
+        monkeypatch.setenv("_TEST_GH_BASE_OID", "")  # base tip unreadable
+        monkeypatch.setenv(
+            "_TEST_GH_CONTRIBUTION",
+            json.dumps({f"..{STALE[:12]}": same, f"..{HEAD[:12]}": list(same)}),
+        )
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True, "no base tip means no base-advance claim can be made"
+
+    @pytest.mark.parametrize(
+        ("label", "before", "after"),
+        [
+            ("sha absent on both sides", [{"filename": "src/a.py"}], [{"filename": "src/a.py"}]),
+            (
+                "sha null on both sides",
+                [{"filename": "src/a.py", "sha": None}],
+                [{"filename": "src/a.py", "sha": None}],
+            ),
+            (
+                "duplicate filename in one contribution",
+                [{"filename": "src/a.py", "sha": "x"}, {"filename": "src/a.py", "sha": "y"}],
+                [{"filename": "src/a.py", "sha": "x"}],
+            ),
+        ],
+    )
+    def test_an_unreadable_file_identity_withdraws_the_claim(
+        self, monkeypatch, label, before, after
+    ):
+        # MEASURED on this code before the identity check: two ABSENT shas compared
+        # EQUAL, so a genuinely modified file dropped out of the changed set and read
+        # as a base-advance — a stale review allowed on changed code, the one outcome
+        # this refinement must never produce. Triviality is an exception granted on
+        # POSITIVE evidence; an identity that cannot be read is not it.
+        self._setup(monkeypatch, before, after)
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True, f"{label}: must not claim a base-advance on unreadable identity"
+
+    # ── The merge base MOVES when a branch catches up, and a blob sha is only
+    #    the RIGHT-hand side of the diff. These pin the left-hand side.
+
+    def test_a_base_change_to_a_file_the_branch_touches_blocks(self, monkeypatch):
+        """The `--ours` revert: identical tip blobs, genuinely different diff.
+
+        Branch edits F; base edits F; the catch-up merge resolves `--ours`,
+        discarding what the base contributed. Every tip blob is unchanged, so a
+        comparison of blobs alone reads it as a pure base-advance and ALLOWS a
+        stale review over a silent revert Codex never saw. Resolving a catch-up
+        conflict this way is routine, and #1690 made catch-up merges mandatory.
+        """
+        same = [_contrib("src/genesis/F.py", "blobX")]
+        self._setup(
+            monkeypatch, same, list(same),
+            mb_before="1111" * 10, mb_after="2222" * 10,
+            moved=[_contrib("src/genesis/F.py", "base-side")],  # the base touched F too
+        )
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True, "a base change to a file the branch touches is not a base-advance"
+
+    def test_a_base_change_elsewhere_is_still_a_base_advance(self, monkeypatch):
+        # The control that keeps the feature meaningful: the base moving in files
+        # the branch does not touch is exactly what this refinement exists to allow.
+        same = [_contrib("src/genesis/F.py", "blobX")]
+        self._setup(
+            monkeypatch, same, list(same),
+            mb_before="1111" * 10, mb_after="2222" * 10,
+            moved=[_contrib("docs/unrelated.md", "other")],
+        )
+        block, _msg, verified = _mod._check_codex_reviewed_head("5")
+        assert block is False and verified == HEAD
+
+    def test_a_moved_base_with_an_unreadable_move_blocks(self, monkeypatch):
+        same = [_contrib("src/genesis/F.py", "blobX")]
+        # No seam entry for the mb..mb range -> unreadable -> the claim is withdrawn.
+        self._setup(monkeypatch, same, list(same),
+                    mb_before="1111" * 10, mb_after="2222" * 10)
+        monkeypatch.setenv(
+            "_TEST_GH_CONTRIBUTION",
+            json.dumps({
+                f"{self.BASE[:12]}..{STALE[:12]}": {
+                    "mb": "1111" * 10, "status": "ahead", "files": same,
+                },
+                f"{self.BASE[:12]}..{HEAD[:12]}": {
+                    "mb": "2222" * 10, "status": "ahead", "files": list(same),
+                },
+            }),
+        )
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+
+    def test_a_hook_surface_path_is_never_rescued_even_when_unchanged(self, monkeypatch):
+        """Identical blob AND status on a guard file — still no rescue.
+
+        This refinement RECONSTRUCTS "what changed" from two base-relative
+        snapshots plus a synthetic identity, where the raw path diffs the two
+        commits directly. GitHub's compare record carries no MODE, so a
+        content-preserving `chmod +x` on a guard keeps its blob and status,
+        never enters `changed`, and never reaches the hook-surface teeth — which
+        the raw path WOULD have caught. That is a regression the refinement
+        introduces, so the enforcement surface is declined outright.
+        """
+        same = [_contrib("scripts/hooks/git_push_guard.py", "sameblob")]
+        self._setup(monkeypatch, same, list(same))
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+
+    def test_a_base_rename_of_a_file_the_branch_touches_blocks(self, monkeypatch):
+        # Rename SOURCES count. The base renamed F -> F2; the branch still
+        # contributes to F. Folding only `filename` would put F2 in moved_names
+        # and miss F entirely — the one place in this feature that did not fold
+        # `previous_filename`, where every sibling helper does.
+        same = [_contrib("src/genesis/F.py", "blobX")]
+        moved = [_contrib("src/genesis/F2.py", "renamed", status="renamed")]
+        moved[0]["previous_filename"] = "src/genesis/F.py"
+        self._setup(
+            monkeypatch, same, list(same),
+            mb_before="1111" * 10, mb_after="2222" * 10, moved=moved,
+        )
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+
+    def test_a_base_that_moved_BACKWARDS_is_not_an_advance(self, monkeypatch):
+        # MEASURED against live GitHub: a three-dot compare of a base that moved
+        # backwards reports status "behind" with ZERO files — so the overlap test
+        # finds nothing and would wave the claim through. "The base advanced" only
+        # means something if it actually advanced.
+        same = [_contrib("src/genesis/F.py", "blobX")]
+        self._setup(
+            monkeypatch, same, list(same),
+            mb_before="1111" * 10, mb_after="2222" * 10,
+            moved=[], moved_status="behind",
+        )
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+
+    def test_two_empty_contributions_are_not_evidence_of_unchanged(self, monkeypatch):
+        # The sibling path already fails closed on an empty `files` (Codex P2,
+        # #1373). A narrowing built on the same shape must not read it the other way.
+        self._setup(monkeypatch, [], [])
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+
+    def test_a_truncated_contribution_blocks(self, monkeypatch):
+        # GitHub caps compare `files` at 300. The cap must be tested on the
+        # FETCHED list — a changed SUBSET is always under it, so checking there
+        # tests nothing while the invisible remainder could hold the real change.
+        wide = [_contrib(f"src/genesis/f{i}.py", "same") for i in range(300)]
+        self._setup(monkeypatch, wide, list(wide))
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+
+    def test_a_status_change_with_an_identical_blob_still_counts_as_changed(
+        self, monkeypatch
+    ):
+        """Blob sha encodes bytes, not mode — so identity folds in `status`.
+
+        Anchored on a SUBSTANTIAL non-hook change. A same-blob record whose
+        status differs must land in the CHANGED set, and a 200-line file is what
+        makes that observable as a block. A hook path would block one layer
+        earlier (the surface is never rescued), so it would pass with the
+        identity broken and prove nothing.
+        """
+        before = [_contrib("src/genesis/big.py", "sameblob", additions=200,
+                           status="modified")]
+        after = [_contrib("src/genesis/big.py", "sameblob", additions=200,
+                          status="changed")]
+        self._setup(monkeypatch, before, after)
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+
+    def test_identical_filenames_with_differing_blobs_are_changed(self, monkeypatch):
+        # The reason this compares blob SHAs and not additions/deletions: an edit
+        # preserving both counts would otherwise read as unchanged.
+        before = [_contrib("src/genesis/a.py", "blob1", additions=200, deletions=200)]
+        after = [_contrib("src/genesis/a.py", "blob2", additions=200, deletions=200)]
+        self._setup(monkeypatch, before, after)
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True
+
+
 class TestMainLevelIntegration:
     """main()-level wiring: TOCTOU binding enforcement + sigil decoupling.
 

--- a/tests/test_hooks/test_git_push_guard_codex_freshness.py
+++ b/tests/test_hooks/test_git_push_guard_codex_freshness.py
@@ -710,25 +710,40 @@ class TestBaseAdvanceRefinement:
         assert block is True and verified is None
         assert "SUBSTANTIAL" in msg
 
-    def test_hook_surface_in_the_changed_contribution_still_blocks(self, monkeypatch):
-        # Teeth rule 1: a delta touching the enforcement-hook surface is NEVER
-        # review-trivial, however small. The refinement routes through the SAME
-        # _classify_delta_files, so it cannot acquire a weaker rule than the raw path.
-        # Anchored on a NON-hook path on purpose. A hook path now declines the
-        # rescue outright, one layer earlier — so anchoring here would block for
-        # that reason and prove nothing about the classifier. Two substantial
-        # code files is what only `_classify_delta_files` can judge.
-        before = [
-            _contrib("src/genesis/a.py", "b1", additions=200),
-            _contrib("src/genesis/b.py", "b2", additions=200),
-        ]
-        after = [
-            _contrib("src/genesis/a.py", "b3", additions=200),
-            _contrib("src/genesis/b.py", "b4", additions=200),
-        ]
+    def test_ANY_changed_contribution_blocks_however_small(self, monkeypatch):
+        """The refinement's only finding is "the two contributions are IDENTICAL".
+
+        A one-line difference on one non-hook file is the smallest possible
+        residual, and it still blocks. This pins the rule that replaced an
+        earlier version which SIZED the residual through the shared
+        substantiality classifier — see the shrinking-contribution test below for
+        the fail-open that sizing produced.
+        """
+        before = [_contrib("src/genesis/a.py", "b1", additions=1)]
+        after = [_contrib("src/genesis/a.py", "b2", additions=1)]
         self._setup(monkeypatch, before, after)
         block, _msg, _v = _mod._check_codex_reviewed_head("5")
         assert block is True
+
+    def test_a_SHRUNKEN_contribution_is_not_review_trivial(self, monkeypatch):
+        """Codex P1 (#1849): base-relative records cannot SIZE a reviewed...head delta.
+
+        Codex reviewed a 100-line addition to this file; head trims it back to 3
+        lines. The real ``reviewed...head`` delta is a ~97-line removal of code
+        Codex approved — the same failure the ``behind`` note in
+        `_classify_post_review_delta` describes (a head can carry the reviewed
+        commit's removals unreviewed), arriving by a different route.
+
+        MEASURED on this code before the fix: before=100 additions / after=3
+        additions returned "inline" and allowed the stale review. The GROWING
+        direction (3 -> 100) correctly returned "substantial", so the leak was
+        one-directional — the side anyone would think to test was the sound one.
+        """
+        before = [_contrib("src/genesis/a.py", "blob1", additions=100)]
+        after = [_contrib("src/genesis/a.py", "blob2", additions=3)]
+        self._setup(monkeypatch, before, after)
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True, "a contribution that SHRANK since the review is not trivial"
 
     def test_a_file_dropped_from_the_contribution_counts_as_changed(self, monkeypatch):
         # The PR used to touch this file and no longer does. It has no record on
@@ -785,9 +800,30 @@ class TestBaseAdvanceRefinement:
                 [{"filename": "src/a.py", "sha": None}],
             ),
             (
+                # The two duplicates carry the SAME sha deliberately. With
+                # differing shas, last-write-wins would leave the two sides
+                # unequal and the block would happen via `changed` instead —
+                # the duplicate guard would never be observed (MEASURED: with
+                # differing shas, deleting the guard leaves this file green).
                 "duplicate filename in one contribution",
-                [{"filename": "src/a.py", "sha": "x"}, {"filename": "src/a.py", "sha": "y"}],
+                [{"filename": "src/a.py", "sha": "x"}, {"filename": "src/a.py", "sha": "x"}],
                 [{"filename": "src/a.py", "sha": "x"}],
+            ),
+            (
+                # previous_filename is OPTIONAL, but a present-and-unreadable one
+                # is an identity that cannot be compared honestly — the rename
+                # source is half of what a renamed record means. Unreadable on
+                # BOTH sides on purpose: differing values would land in `changed`
+                # and block for that reason instead, leaving the validation
+                # untested (the shape that makes a guard test vacuous).
+                "previous_filename present but empty on both sides",
+                [{"filename": "src/a.py", "sha": "x", "previous_filename": ""}],
+                [{"filename": "src/a.py", "sha": "x", "previous_filename": ""}],
+            ),
+            (
+                "previous_filename present but not a string on both sides",
+                [{"filename": "src/a.py", "sha": "x", "previous_filename": 7}],
+                [{"filename": "src/a.py", "sha": "x", "previous_filename": 7}],
             ),
         ],
     )
@@ -886,6 +922,107 @@ class TestBaseAdvanceRefinement:
         block, _msg, _v = _mod._check_codex_reviewed_head("5")
         assert block is True
 
+    def test_a_REROUTED_rename_source_counts_as_changed(self, monkeypatch):
+        """Codex P1 (#1849): a rename has two endpoints; the record names one.
+
+        The compare record reports only the rename DESTINATION as ``filename``,
+        and the blob is the destination's bytes. So a contribution that renames
+        ``A -> B`` and one that renames ``D -> B`` present the same filename, the
+        same blob and the same ``renamed`` status — while deleting DIFFERENT
+        files. The base never moves here, so nothing downstream can catch it:
+        this pins the IDENTITY itself.
+
+        MEASURED on this code before ``previous_filename`` joined the identity:
+        the two compared equal, the file left the changed set, and the branch's
+        rerouted rename read as a pure base-advance.
+        """
+        before = [_contrib("src/genesis/B.py", "sameblob", status="renamed")]
+        before[0]["previous_filename"] = "src/genesis/A.py"
+        after = [_contrib("src/genesis/B.py", "sameblob", status="renamed")]
+        after[0]["previous_filename"] = "src/genesis/D.py"
+        self._setup(monkeypatch, before, after)
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True, "the branch renamed a DIFFERENT file to the same destination"
+
+    def test_a_base_change_to_the_branchs_rename_SOURCE_blocks(self, monkeypatch):
+        """Codex P1 (#1849): the overlap test needs the branch's rename sources too.
+
+        The branch renames ``A -> B``, so it DELETES ``A`` — ``A`` is a path this
+        branch changes. The base then modifies ``A``. Merging discards the base's
+        edit, which is the same ``--ours`` shape the moved-base check exists for,
+        arriving through the rename door.
+
+        The branch's touched set held only the DESTINATION ``B``, so
+        ``{A} & {B}`` was empty and the collision was invisible; the identity
+        cannot catch it either, because the rename is byte-identical on both
+        sides. With sources folded in, ``{A} & {A, B}`` collides.
+        """
+        same = [_contrib("src/genesis/B.py", "sameblob", status="renamed")]
+        same[0]["previous_filename"] = "src/genesis/A.py"
+        self._setup(
+            monkeypatch, same, [dict(same[0])],
+            mb_before="1111" * 10, mb_after="2222" * 10,
+            moved=[_contrib("src/genesis/A.py", "abase", additions=80)],
+        )
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True, "the base edited the very file the branch renames away"
+
+    def test_an_IDENTICAL_rename_with_the_base_elsewhere_is_still_rescued(self, monkeypatch):
+        # The control for the two tests above: folding rename sources into the
+        # identity and the touched set must not make every rename unrescuable.
+        # Same source, same destination, same blob, base moved in an unrelated
+        # file -> still a pure base-advance.
+        same = [_contrib("src/genesis/B.py", "sameblob", status="renamed")]
+        same[0]["previous_filename"] = "src/genesis/A.py"
+        self._setup(
+            monkeypatch, same, [dict(same[0])],
+            mb_before="1111" * 10, mb_after="2222" * 10,
+            moved=[_contrib("docs/unrelated.md", "other")],
+        )
+        block, _msg, verified = _mod._check_codex_reviewed_head("5")
+        assert block is False and verified == HEAD
+
+    def test_a_BASE_change_to_the_hook_surface_is_never_rescued(self, monkeypatch):
+        # The base advanced by touching a guard; the branch touches nothing
+        # hook-related. `moved_names & touched` is therefore EMPTY, so the
+        # overlap test passes it through and the `| moved_names` half of the
+        # hook-surface scan is the only thing that blocks it. Without that half
+        # this returns "inline".
+        same = [_contrib("src/genesis/a.py", "blobX")]
+        self._setup(
+            monkeypatch, same, list(same),
+            mb_before="1111" * 10, mb_after="2222" * 10,
+            moved=[_contrib("scripts/hooks/git_push_guard.py", "hookblob")],
+        )
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True, "the base moved the enforcement surface — never rescued"
+
+    def test_a_base_advance_reporting_ZERO_files_is_a_degraded_read(self, monkeypatch):
+        """A base that MOVED must have changed something.
+
+        `_pr_contribution`'s jq is ``.files[]?``, and ``?`` swallows a MISSING or
+        null ``files`` key — so a degraded response arrives as ``[]``, which is
+        indistinguishable from a real empty diff and used to leave `moved_names`
+        empty, pass the overlap test, and rescue the review.
+
+        It is also self-contradictory: this refinement runs only when the RAW
+        range read `substantial`, and an empty compare `files` classifies
+        `inline`, so a base that advanced while changing nothing could not have
+        produced the verdict that got us here.
+
+        Distinct from `test_a_base_that_moved_BACKWARDS_is_not_an_advance`, which
+        also passes ``moved=[]`` but blocks on ``status != "ahead"`` and so
+        cannot observe this guard.
+        """
+        same = [_contrib("src/genesis/a.py", "blobX")]
+        self._setup(
+            monkeypatch, same, list(same),
+            mb_before="1111" * 10, mb_after="2222" * 10,
+            moved=[], moved_status="ahead",
+        )
+        block, _msg, _v = _mod._check_codex_reviewed_head("5")
+        assert block is True, "an advance that changed no files is a degraded read"
+
     def test_a_base_that_moved_BACKWARDS_is_not_an_advance(self, monkeypatch):
         # MEASURED against live GitHub: a three-dot compare of a base that moved
         # backwards reports status "behind" with ZERO files — so the overlap test
@@ -921,15 +1058,14 @@ class TestBaseAdvanceRefinement:
     ):
         """Blob sha encodes bytes, not mode — so identity folds in `status`.
 
-        Anchored on a SUBSTANTIAL non-hook change. A same-blob record whose
-        status differs must land in the CHANGED set, and a 200-line file is what
-        makes that observable as a block. A hook path would block one layer
-        earlier (the surface is never rescued), so it would pass with the
-        identity broken and prove nothing.
+        Anchored on a NON-hook path on purpose: a hook path would block one layer
+        earlier (the surface is never rescued), so it would pass with the identity
+        broken and prove nothing. The line counts are deliberately irrelevant now
+        — any changed contribution blocks — so this observes the identity alone.
         """
-        before = [_contrib("src/genesis/big.py", "sameblob", additions=200,
+        before = [_contrib("src/genesis/big.py", "sameblob", additions=5,
                            status="modified")]
-        after = [_contrib("src/genesis/big.py", "sameblob", additions=200,
+        after = [_contrib("src/genesis/big.py", "sameblob", additions=5,
                           status="changed")]
         self._setup(monkeypatch, before, after)
         block, _msg, _v = _mod._check_codex_reviewed_head("5")


### PR DESCRIPTION
## Summary

The Codex freshness gate classifies `compare/reviewed...head`. After a branch merges its base to catch up, that range contains **every commit the base contributed** — each already reviewed on its own PR — so the gate demands a fresh review of code Codex has seen. It cannot tell a **base-advance** from a **force-push** and treats them identically.

**Measured on PR #1847:** 28 files across 7 commits after merging main, of which the branch's own change was a handful. #1690 made catching up mandatory for every branch carrying a changelog entry — 15 open PRs conflict on `CHANGELOG.md`, four of them Codex-clean today and about to acquire a block they don't owe — so this stopped being incidental.

The gate now asks the narrower question when the raw range reads substantial: **did the PR's own contribution over its base change?** Only a definite `substantial` is re-judged; a `None` stays the fail-closed state.

## The care this needed, because it narrows a gate

Every item below was a **fail-open**, found by review or by probe, and fixed:

- **A blob sha is only the right-hand side of a diff.** `compare/base...tip` is three-dot, so its left side is the merge base — and that **moves** when a branch catches up. Resolve a catch-up conflict with `--ours` and the merge silently reverts what the base contributed while every tip blob stays put. Codex reviewed `F1 → X`; what ships is `F2 → X`. So when the merge base moved, the gate asks what the *base* changed across the move and refuses if that touches files this PR touches.
- **A base that moved backwards is not an advance.** Measured against live GitHub: a three-dot compare of a backwards move reports `behind` with **zero** files, so the overlap test found nothing. The moved range must report `ahead`.
- **The 300-file truncation guard tested the changed subset**, which is always under the cap. It now caps the *fetched* lists, where truncation can actually hide a file — measured: a wide compare reports 300 against 1293 real files.
- **Two empty contributions are not evidence of "unchanged."** That's the hole a prior review closed on the sibling path (#1373); the new path must not read the same shape the other way. An exit-0 with no payload is likewise unreadable, not an empty diff.
- **Two missing blob shas compared equal**, so a modified file dropped out of the delta. An identity that cannot be read now withdraws the whole claim.
- **The enforcement surface is never rescued**, whatever the blobs say. GitHub's compare record carries no file **mode**, so a `chmod` on a guard keeps its blob and status and would never reach the hook-surface teeth. That is a regression this reconstruction introduces where the raw path diffs the two commits directly — so the surface is declined outright rather than trusted to an identity rich enough to be safe.
- **Rename sources count** in the base's moved set, matching every sibling helper.

## Testing

- [x] `ruff check .` passes
- [x] 1264 tests green across both hook test directories (see the review-round section below for the numbers at the current head)
- [x] `docs/architecture/CURRENT.md` — no change needed; subsystem-map guard clean

**Mutation sweep (original build): 15/15 RED, 0 survivors** — single baseline, exact anchor counts, `compile()`-checked, hash-verified restores, and an ABORT on a zero-execution run (which fired twice on stale anchors and correctly stopped the sweep).

**Live acceptance, re-run after every tightening.** On #1847 the refinement now correctly **declines** — main changed two files this PR also changes — so the benefit is narrower than the raw 28-vs-3 figure suggests, and the allow path is covered by its own test rather than by that PR.

**Cost:** `_pr_base_sha` plus up to 3 `_pr_contribution` calls, each clamped by `_gh_timeout` to the remaining deadline, worst case ~+3s into ~15s of headroom under the 45s budget. Every timeout returns `None` → blocks.

Two mutations were diagnosed as **behaviourally null** rather than chased with contorted tests: one guard is kept and relabelled as the cost optimisation it actually is, the other removed for having no purpose at all. Two of my own tests were found **masked** by my own hook-surface fix — both anchored on hook paths, so they blocked one layer earlier and stopped testing what they named; the sweep caught it and both were re-anchored.

## Review round 2 — Codex's four [P1]s

Three distinct findings. Two fixed, one rebutted with a measurement; the internal adversarial pass over the fix found two more fail-opens of the same class and two vacuous guards, all fixed in the same commit.

- **Sizing a residual was a fail-open.** When the branch's contribution CHANGED, the leftover was sized with BASE-relative records — so a contribution that SHRANK between the review and head (100 additions down to 3) classified review-trivial and let a stale review bind a ~97-line unreviewed removal. Reproduced before fixing; the growing direction classified substantial, so the leak was one-directional. The refinement now supports exactly one finding — the two contributions are IDENTICAL — and never sizes. A nonempty changed set blocks, which is what the raw range already did, so nothing regresses.
- **Rename SOURCES were missing from the identity and the touched set.** `A -> B` and `D -> B` compared equal; and a base edit to a source the branch deletes did not register as an overlap. Both fold `previous_filename` now, matching `_pr_changed_files` and `classify_compare_substantiality`.
- **A base compare reporting "ahead" with ZERO files** was read as evidence the base changed nothing. The jq is `.files[]?`, and `?` swallows a missing key, so a degraded response arrives as an empty list. Self-contradictory when honest — an empty compare classifies inline, so such a move cannot have produced the substantial raw verdict that reaches the code. It now declines.
- **Rebutted:** requiring `after_mb == base_sha`. Both contributions are three-dot, so each is computed from its OWN merge base, and those two are exactly the endpoints the overlap test inspects; movement past `after_mb` is in neither snapshot and not in the range this gate judges. The interaction is real but is not head freshness — a fresh at-head review carries it identically. Measured cost: 0 of 40 open PRs satisfy that constraint today, so it would make the refinement unreachable rather than stricter.

Sizing was the only reason `_classify_delta_files` had two callers, so that extraction is reverted; `_classify_post_review_delta` is byte-identical to its form on `main` again (verified by string comparison of the extracted function body).

**Verification at this head:** mutation sweep **7/7 RED, 0 survivors** (hash-gated restores, exact anchor counts, `compile()`-checked, aborts on a zero-execution run — which fired once on the test lock and correctly stopped the sweep). 1264 tests green across both hook test directories. The acceptance replays were re-run after every tightening, together with the allow-path controls, so the feature is not merely inert.

**Corpus measurement, both directions** (this repo's merged PRs, 57 fetched, 2026-09-08). Substantive branch delta still NOT rescued: **41/41** after, 38/41 before. Pure base catch-up correctly rescued: **0/22 before and after** — unchanged by this round, and worth stating plainly: on this corpus every catch-up merge collides on `CHANGELOG.md` or `docs/architecture/CURRENT.md`, which both the base and the branch touch, so the feature's benefit is not demonstrated here. That is the "Known and deliberate" scope below, quantified.

## Known and deliberate

The refinement only fires when the base moved in files the branch does **not** touch. Where both sides touch a file, the PR's diff over its base genuinely changed and a fresh review is the right answer.

Reviewed by three sequential internal passes (architect, security, then a security re-review on a frozen and checksummed tree). One process note in the open: the first security pass was given a false premise — that no mutation sweep was running — which was wrong and degraded it; the re-review was run on a frozen tree and verified the checksum unchanged at both ends.

E2E: after merge, run `python3 scripts/hooks/git_push_guard.py --check-pr <N>` on a PR whose branch has merged main without other changes — `codex-at-head` must report the delta as review-trivial rather than SUBSTANTIAL, and a PR whose branch changed since its review must still block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stale review handling by distinguishing changes caused by the base branch advancing from changes made in the pull request.
  - Stale reviews are now allowed only when the pull request’s contribution is verified to remain unchanged; otherwise, the freshness check continues to block the push.
  - Added safeguards for file changes, renames, incomplete results, merge-base movement, and hook-related updates to ensure freshness decisions fail safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
