### PR TITLE
feat(ci): commit the verify-RED harness everyone keeps rewriting, and gate on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,6 +448,32 @@ jobs:
       - name: External-I/O egress guard
         run: python scripts/check_external_io.py
 
+  mutation-gate:
+    # Verify-RED, enforced. A guard's test can stop pinning the property it is
+    # named for -- through a refactor, a widened assertion, a sibling layer that
+    # starts masking it -- and nothing goes red, because the test still passes.
+    # This breaks a handful of load-bearing guard decisions on purpose and fails
+    # if the test does NOT notice. An ABORT is a failure too: a case that could
+    # not run has established nothing, which is the confident false negative this
+    # class is famous for. See scripts/mutation_sweep.py.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        # MUST mirror the `test` job. The ROOT tests/conftest.py imports
+        # aiosqlite, so a minimal install fails collection and every case
+        # ABORTS -- a job red for the wrong reason. `--noconftest` is not the
+        # escape either: the guard tests use fixtures from
+        # tests/test_hooks/conftest.py.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+      - name: Mutation gate
+        run: python scripts/mutation_sweep.py config/mutation_gate.json --repo .
+
   frozen-clock-check:
     # A test that captures a wall clock at IMPORT time gives the whole suite's
     # runtime to burn its safety margin, then fails on slow runners as an

--- a/config/mutation_gate.json
+++ b/config/mutation_gate.json
@@ -1,0 +1,45 @@
+{
+  "_README": [
+    "The pinned verify-RED set. Each case BREAKS one guard's decision and names",
+    "the test that must notice. CI fails if any case SURVIVES -- that test no",
+    "longer pins the property it is named for -- or ABORTS, because a case that",
+    "could not run has established nothing.",
+    "",
+    "Deliberately SMALL. This is not coverage tooling; it is a handful of",
+    "load-bearing decisions whose tests must never rot silently.",
+    "",
+    "EVERY PAIRING HERE WAS VERIFIED TO DISCRIMINATE, not assumed. The first",
+    "draft of this file had two cases that SURVIVED, and neither was a weak",
+    "test: one mutated `main()` while the test calls `_rm_violations` directly,",
+    "and the other was behaviourally null -- `rm -rf /` has zero path segments,",
+    "so `len(parts) < 4` and `< 1` are both true. A third candidate was masked",
+    "by a sibling layer: `_ALWAYS_BLOCK` refuses `/`, `.`, `~` regardless of",
+    "depth, so every test using those inputs is structurally blind to the depth",
+    "rule. Choose the input that discriminates, then confirm it does.",
+    "",
+    "AN ANCHOR THAT STOPS MATCHING IS A FEATURE. If someone edits a guard and",
+    "this gate aborts with 'anchor matched 0x', the case must be updated in the",
+    "same change -- exactly the moment to ask whether the test still pins the",
+    "new shape."
+  ],
+  "cases": [
+    {
+      "label": "rm-guard depth floor weakened from 4 to 1",
+      "path": "scripts/hooks/destructive_command_guard.py",
+      "anchor": "    if len(parts) < 4:",
+      "replacement": "    if len(parts) < 1:",
+      "validator": "python",
+      "test": "tests/test_hooks/test_destructive_command_guard.py::TestLineContinuationFoldsAsTheShellFolds::test_positive_control_the_joined_form_is_refused",
+      "why": "the depth threshold IS the guard's judgement. A weakened floor still refuses something, so a test asserting only 'blocks at all' would miss it -- this case uses a depth-3 target (~/genesis) precisely because `/` is refused by _ALWAYS_BLOCK regardless of depth and would mask the mutation"
+    },
+    {
+      "label": "protected-paths guard stops blocking entirely",
+      "path": "scripts/hooks/protected_paths_guard.py",
+      "anchor": "    return 2",
+      "replacement": "    return 0",
+      "validator": "python",
+      "test": "tests/test_hooks/test_protected_paths_guard.py::TestProtectedDirBlocks::test_dir_itself",
+      "why": "deleting a protected directory must be refused, and this is the single decision point that refuses it"
+    }
+  ]
+}

--- a/scripts/mutation_sweep.py
+++ b/scripts/mutation_sweep.py
@@ -335,11 +335,25 @@ def run_case(
     if err:
         return Result(case, ABORTED, err)
 
-    # TOCTOU: the drift check above happened before `compile()` (and, for a
-    # `bash` validator, before an out-of-process `bash -n`). A peer edit landing
-    # in that window would be clobbered by the write below and then "restored"
-    # to the baseline -- silently destroying their work, which is the one thing
-    # guarantee (6) exists to prevent. Re-check immediately before writing.
+    # TOCTOU, NARROWED BUT NOT CLOSED -- stated plainly because the difference
+    # matters and a re-check cannot do better.
+    #
+    # The original drift check ran before `compile()` and, for a `bash`
+    # validator, before an out-of-process `bash -n`: a window measured in
+    # subprocess time. Re-checking here shrinks it to the gap between this read
+    # and the write on the next line. It does NOT eliminate it: a peer writing in
+    # that gap is clobbered, the restore then sees its own hash, and no CONFLICT
+    # is reported.
+    #
+    # A re-check can only ever narrow a TOCTOU. Closing it needs one of:
+    #   * mutating an ISOLATED COPY so the shared file is never written -- the
+    #     only option that actually closes it, and a rewrite of this module's
+    #     core (the test must then run against the copy);
+    #   * an exclusive lock across check/write/test/restore -- which serialises
+    #     other SWEEPS but not an arbitrary editor, and the arbitrary editor is
+    #     the threat. `flock` is advisory; a peer CC session does not take it.
+    # Accepted for now, and named here rather than left for the next reviewer to
+    # rediscover. Raised by CodeRabbit on PR #1851, tagged "heavy lift" by it too.
     if target.read_bytes() != base_bytes:
         return Result(case, CONFLICT,
                       "the target changed between the drift check and the "

--- a/scripts/mutation_sweep.py
+++ b/scripts/mutation_sweep.py
@@ -217,6 +217,13 @@ def _child_env(extra: dict[str, str] | None) -> dict[str, str]:
         # Queue rather than fail when a peer session holds the test lock; a
         # lock collision would otherwise land as an ABORT on every case.
         "GENESIS_PYTEST_LOCK_WAIT": "1",
+        # The anti-deadlock lever, forwarded ONLY when the parent already holds
+        # the box lock. Its documented purpose is that a pytest spawned inside a
+        # locked run does not contend with its own parent; stripping it meant a
+        # sweep launched from inside a locked session queued behind itself and
+        # died at the per-case timeout, ~15 minutes per case.
+        **({"GENESIS_PYTEST_LOCK_HELD": os.environ["GENESIS_PYTEST_LOCK_HELD"]}
+           if os.environ.get("GENESIS_PYTEST_LOCK_HELD") else {}),
         # TMPDIR is a PATH, not a behaviour lever. Dropping it sends every child's
         # temp to /tmp, which this project forbids for anything large, and makes
         # tests/conftest.py take its no-op basetemp branch on a dev box.
@@ -241,9 +248,15 @@ def _has_result_line(stdout: str) -> bool:
     if not tail:
         return False
     for line in reversed(tail):
-        if "no tests ran" in line or (
-            "deselected" in line and "passed" not in line
-        ):
+        # A REAL OUTCOME beats a sibling deselection. "1 failed, 1 deselected"
+        # means the target ran and failed -- MEASURED, the previous rule read it
+        # as "no result" and turned a genuinely-caught mutation into an ABORT.
+        # Only a line with NO outcome at all ("2 deselected", "no tests ran")
+        # means nothing ran. The earlier test covered the `passed` variant and
+        # not the `failed` one, which is why this survived.
+        if "passed" in line or "failed" in line:
+            return True
+        if "no tests ran" in line or "deselected" in line:
             return False
         if "passed" in line or "failed" in line or "error" in line.lower():
             return True
@@ -322,6 +335,15 @@ def run_case(
     if err:
         return Result(case, ABORTED, err)
 
+    # TOCTOU: the drift check above happened before `compile()` (and, for a
+    # `bash` validator, before an out-of-process `bash -n`). A peer edit landing
+    # in that window would be clobbered by the write below and then "restored"
+    # to the baseline -- silently destroying their work, which is the one thing
+    # guarantee (6) exists to prevent. Re-check immediately before writing.
+    if target.read_bytes() != base_bytes:
+        return Result(case, CONFLICT,
+                      "the target changed between the drift check and the "
+                      "mutation write -- a peer's edit was left untouched")
     target.write_text(mutated, encoding="utf-8")
     wrote = _sha(target)
     verdict: Result | None = None
@@ -427,18 +449,30 @@ def assert_green_baseline(
     seen = {(c.test, c.python, c.pytest_args, tuple(sorted(c.env.items())))
             for c in cases}
     for test, py, extra, case_env in seen:
-        proc = subprocess.run(
-            [py or python, "-m", "pytest", test, "-q", "--no-header",
-             "-p", "no:cacheprovider", *extra],
-            cwd=str(cwd), capture_output=True, text=True,
-            env=_child_env({**(env or {}), **dict(case_env)}), timeout=timeout,
-        )
+        try:
+            proc = _baseline_run(test, py, extra, case_env, cwd, python, env, timeout)
+        except subprocess.TimeoutExpired:
+            # Every other outcome in this module is enumerated; a raw traceback
+            # here was the one path that escaped the contract. Nothing has been
+            # mutated at this point, so this is purely a reporting fix.
+            return (f"baseline run of {test} timed out after {timeout}s -- it "
+                    "cannot be established as green, so no mutation is trustworthy")
         if not _has_result_line(proc.stdout):
             return f"baseline run of {test} produced no result line"
         if proc.returncode != 0:
             return (f"baseline is RED: {test} already fails before any mutation, "
                     "so every 'BIT' from it would be meaningless")
     return None
+
+
+def _baseline_run(test, py, extra, case_env, cwd, python, env, timeout):
+    """One baseline invocation, factored out so the timeout has somewhere to land."""
+    return subprocess.run(
+        [py or python, "-m", "pytest", test, "-q", "--no-header",
+         "-p", "no:cacheprovider", *extra],
+        cwd=str(cwd), capture_output=True, text=True,
+        env=_child_env({**(env or {}), **dict(case_env)}), timeout=timeout,
+    )
 
 
 def sweep(

--- a/scripts/mutation_sweep.py
+++ b/scripts/mutation_sweep.py
@@ -376,7 +376,15 @@ def run_case(
             current = None
         if current is None or current == wrote:
             # Gone, unreadable, or still exactly what we wrote -> put it back.
-            target.write_bytes(base_bytes)
+            # copy2 rather than write_bytes: when the child DELETED the target,
+            # write_bytes recreates it at the default creation mode and the
+            # original permission bits are gone. MEASURED 0o755 -> 0o644. The two
+            # guards in the shipped manifest happen to be 0644 so it would not
+            # bite today, but this is a general library and a hook script is
+            # normally executable -- restoring it unrunnable is a quieter kind of
+            # the same damage blocker 4 was about. `baseline` came from copy2, so
+            # it carries the mode.
+            shutil.copy2(baseline, target)
         else:
             # A peer edited it mid-run. PRESERVE their work -- and SAY SO, which
             # the previous version did not: CONFLICT was defined, rendered, and
@@ -448,11 +456,26 @@ def sweep(
         raise ValueError("a sweep with no cases proves nothing")
 
     if check_baseline:
-        problem = assert_green_baseline(
-            cases, cwd=cwd, python=python, env=env, timeout=timeout
-        )
-        if problem:
-            raise RuntimeError(problem)
+        # A case gated on state this run does not have CANNOT be baselined: its
+        # test fails without that state, the gate reads that as a RED baseline,
+        # and the RuntimeError kills the whole sweep -- so one unavailable
+        # resource silently prevents every OTHER case from running. That
+        # contradicts the per-case contract, which says such a case reports
+        # ABORTED and leaves the rest intact. `run_case` still aborts it, loudly.
+        #
+        # The test for requirement 5 could not catch this: it passes
+        # check_baseline=False, so it never exercised the interaction between the
+        # two mechanisms. Both are now asserted together.
+        baselineable = [
+            c for c in cases
+            if all(r in (available or set()) for r in c.requires)
+        ]
+        if baselineable:
+            problem = assert_green_baseline(
+                baselineable, cwd=cwd, python=python, env=env, timeout=timeout
+            )
+            if problem:
+                raise RuntimeError(problem)
 
     # `~/tmp` is a Genesis-container convention (CLAUDE.md "Temp files"), NOT a
     # property of hosts in general -- a CI runner's HOME has no `tmp`, and

--- a/scripts/mutation_sweep.py
+++ b/scripts/mutation_sweep.py
@@ -254,6 +254,14 @@ def _has_result_line(stdout: str) -> bool:
         # Only a line with NO outcome at all ("2 deselected", "no tests ran")
         # means nothing ran. The earlier test covered the `passed` variant and
         # not the `failed` one, which is why this survived.
+        # An ERROR outcome is NOT a result, whatever the exit code. A fixture
+        # setup failure exits 1 with "1 error", and a teardown failure produces
+        # "1 passed, 1 error" -- both previously read as a result, so rc=1 scored
+        # BIT while the named test body never ran. That is the exact import/setup
+        # class the exit-code check was added to exclude, surviving one layer in
+        # because it arrives as rc=1 rather than rc=2.
+        if "error" in line:
+            return False
         if "passed" in line or "failed" in line:
             return True
         if "no tests ran" in line or "deselected" in line:
@@ -288,6 +296,28 @@ def _validate(case: Case, text: str) -> str | None:
     return None
 
 
+def _reject_symlink(path: Path) -> str | None:
+    """A symlink target cannot be safely mutated, so it is REFUSED, not handled.
+
+    MEASURED: the mutation writes THROUGH the link into the referent; if the
+    child then deletes the link, `copy2(baseline, target)` recreates `target` as
+    a regular file holding the baseline text while THE REFERENT STAYS MUTATED --
+    permanently, with the case still reporting BIT. Source corruption in the tool
+    whose entire justification is that it does not corrupt source.
+
+    Refusing is the right call rather than snapshotting link+referent: the
+    correct semantics (restore the link? the referent? both? what if the referent
+    is outside the repo?) are genuinely ambiguous, and a mutation harness has no
+    business guessing about them. A case naming a symlink is a case that should
+    name the real file.
+    """
+    if path.is_symlink():
+        return (f"{path} is a SYMLINK; mutating it writes through to the "
+                "referent and the restore cannot put the link back. Point the "
+                "case at the real file.")
+    return None
+
+
 def run_case(
     case: Case,
     baseline: Path,
@@ -304,6 +334,10 @@ def run_case(
     # A case gated on shared live state ABORTS when that state is absent. It does
     # NOT skip: a skipped case and a killed one look identical in a summary line,
     # and "11/11 bit" means nothing if two of them never ran.
+    symlink = _reject_symlink(target)
+    if symlink:
+        return Result(case, ABORTED, symlink)
+
     missing = [r for r in case.requires if r not in (available or set())]
     if missing:
         return Result(case, ABORTED,
@@ -503,6 +537,68 @@ def sweep(
     if not cases:
         raise ValueError("a sweep with no cases proves nothing")
 
+    # SNAPSHOT FIRST, BEFORE ANY CHILD PROCESS RUNS. The baseline check used to
+    # come first, and a baseline test (or one of its fixtures) that edits or
+    # deletes a target then had no recovery copy anywhere: a deleted target made
+    # the later copy2 raise with nothing to restore from, and an edited one
+    # became the snapshot and survived the sweep. A failing baseline left the
+    # same damage. The window existed for every case, on every run, before a
+    # single mutation was written.
+    #
+    # `~/tmp` is a Genesis-container convention, not a property of hosts, and
+    # mkdtemp against an absent parent raises.
+    tmp_root = Path.home() / "tmp"
+    tmp_root.mkdir(parents=True, exist_ok=True)
+    tmpdir = Path(tempfile.mkdtemp(prefix="mutation-sweep-", dir=str(tmp_root)))
+    baselines: dict[Path, Path] = {}
+    completed = False
+    for c in {c.path for c in cases}:
+        snap = tmpdir / (str(c).replace("/", "__"))
+        shutil.copy2(c, snap)
+        baselines[c] = snap
+
+    try:
+        _run_baseline_and_verify(
+            cases, baselines, cwd=cwd, python=python, env=env, timeout=timeout,
+            available=available, check_baseline=check_baseline,
+        )
+    except BaseException:
+        print(f"mutation-sweep: baselines PRESERVED for recovery: {tmpdir}",
+              file=sys.stderr)
+        raise
+
+    try:
+        out = Sweep()
+        for case in cases:
+            out.results.append(
+                run_case(case, baselines[case.path], cwd=cwd, python=python,
+                         env=env, timeout=timeout, available=available)
+            )
+        completed = True
+        return out
+    finally:
+        if completed:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        else:
+            # An abnormal exit is exactly when the snapshots are worth keeping:
+            # they may be the only surviving copy of a file whose restore did not
+            # finish. Deleting them here is what turned a crash into data loss.
+            print(f"mutation-sweep: baselines PRESERVED for recovery: {tmpdir}",
+                  file=sys.stderr)
+
+
+def _run_baseline_and_verify(
+    cases, baselines, *, cwd, python, env, timeout, available, check_baseline
+) -> None:
+    """Green-baseline check, then confirm no target was damaged by running it.
+
+    The verification half is not paranoia: a baseline test -- or one of its
+    fixtures -- can edit or delete the very file a case is about to mutate. With
+    the snapshot now taken first, that damage is recoverable; without the CHECK
+    it would still go unnoticed, and the sweep would mutate a file that no longer
+    matches what it was baselined against.
+    """
+    problem: str | None = None
     if check_baseline:
         # A case gated on state this run does not have CANNOT be baselined: its
         # test fails without that state, the gate reads that as a RED baseline,
@@ -522,39 +618,29 @@ def sweep(
             problem = assert_green_baseline(
                 baselineable, cwd=cwd, python=python, env=env, timeout=timeout
             )
-            if problem:
-                raise RuntimeError(problem)
+    # NOTE the deliberate ordering: the baseline verdict is CAPTURED, not raised
+    # yet. A damaged target EXPLAINS a red baseline -- if a fixture deleted the
+    # file under test, "baseline is RED" is a true statement and a useless
+    # diagnosis, and it hides the one fact the operator needs (their file is gone,
+    # and here is the copy). The specific cause reports first.
 
-    # `~/tmp` is a Genesis-container convention (CLAUDE.md "Temp files"), NOT a
-    # property of hosts in general -- a CI runner's HOME has no `tmp`, and
-    # `mkdtemp` against an absent parent raises FileNotFoundError. Create it.
-    tmp_root = Path.home() / "tmp"
-    tmp_root.mkdir(parents=True, exist_ok=True)
-    tmpdir = Path(tempfile.mkdtemp(prefix="mutation-sweep-", dir=str(tmp_root)))
-    baselines: dict[Path, Path] = {}
-    completed = False
-    try:
-        for c in {c.path for c in cases}:
-            snap = tmpdir / (str(c).replace("/", "__"))
-            shutil.copy2(c, snap)
-            baselines[c] = snap
-        out = Sweep()
-        for case in cases:
-            out.results.append(
-                run_case(case, baselines[case.path], cwd=cwd, python=python,
-                         env=env, timeout=timeout, available=available)
+    # Whether or not the baseline ran, confirm every target still matches its
+    # snapshot before a single mutation is written.
+    for target, snap in baselines.items():
+        if not target.exists():
+            raise RuntimeError(
+                f"{target} was DELETED before any mutation -- by a baseline test "
+                f"or its fixture. A recovery copy exists at {snap}."
             )
-        completed = True
-        return out
-    finally:
-        if completed:
-            shutil.rmtree(tmpdir, ignore_errors=True)
-        else:
-            # An abnormal exit is exactly when the snapshots are worth keeping:
-            # they may be the only surviving copy of a file whose restore did not
-            # finish. Deleting them here is what turned a crash into data loss.
-            print(f"mutation-sweep: baselines PRESERVED for recovery: {tmpdir}",
-                  file=sys.stderr)
+        if target.read_bytes() != snap.read_bytes():
+            raise RuntimeError(
+                f"{target} was MODIFIED before any mutation -- by a baseline test "
+                f"or its fixture. Mutating it now would be mutating a file that "
+                f"no longer matches what it was baselined against. Snapshot: {snap}"
+            )
+
+    if problem:
+        raise RuntimeError(problem)
 
 
 def render(result: Sweep) -> str:

--- a/scripts/mutation_sweep.py
+++ b/scripts/mutation_sweep.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""Verify-RED as a library: break the mechanism, prove the test notices, put it back.
+
+WHY THIS IS COMMITTED. The repo's own discipline says every new test must be seen
+to FAIL for the right reason before its green is trusted. Sessions do follow it --
+and each one hand-rolls the harness and throws it away. MEASURED 2026-09-07:
+**15 independent implementations** under ~/tmp, five of them written that day by
+one session, two within ten minutes of each other. They are the same program.
+
+The contract below is not designed; it is what those fifteen CONVERGED on:
+
+    per-case test target      15/15
+    baseline copy             14/15
+    hash-verified restore     14/15
+    anchor matched exactly 1x 14/15
+    abort on no result line   14/15
+    explicit child env        14/15
+    compile() the mutation    13/15
+    -----------------------------------------
+    abort if the file drifted  9/15   <-- the one that matters most
+    tally / rationale          8/15
+
+That last group is why this exists. The near-universal features are the ones
+people remember; **the drift check is the one they skip**, and it is the only
+one whose absence damages someone ELSE's work -- a mutation that overwrites a
+concurrent session's uncommitted edit, then "restores" a file it never owned.
+Six of fifteen would have done exactly that. A convention nobody is forced
+through is a convention with better documentation, so the obligation moves into
+a chokepoint here instead.
+
+WHAT A SWEEP GUARANTEES, per case:
+  1. The target still matches the ONE baseline snapshot taken before the sweep.
+     Re-snapshotting per case would make this vacuous -- the file trivially
+     matches a copy a moment old. The baseline exists to catch a PREVIOUS case
+     that failed to restore, or a concurrent editor.
+  2. The anchor matches exactly once. With two or more edits, a whole-file
+     "did it change" test stays true while a later anchor silently misses, so
+     a partial mutation reads as complete.
+  3. The mutated source COMPILES, using the file's own parser. `compile()`, not
+     `ast.parse`: the latter accepts context-invalid constructs (a `return`
+     outside a function), and the SyntaxError then surfaces at COLLECTION, where
+     a nonzero exit reads as a successful RED.
+  4. The test command produced a RESULT LINE. No line means the run never
+     happened -- a lock, a guard, a timeout -- and "all mutations survived" from
+     a sweep that never ran is the confident false negative this class is famous
+     for. It is an ABORT, never a survival.
+  5. The file is restored, and the restore is verified by hash. Restore happens
+     in a `finally`, because the expected outcome of a good case is a NONZERO
+     exit and a trailing restore is exactly the statement that does not run.
+  6. The restore only overwrites what THIS mutation wrote. If the file changed
+     underneath, the sweep PRESERVES it and reports a conflict rather than
+     destroying an edit a final hash check would happily confirm it had made.
+
+WHAT IT DELIBERATELY DOES NOT DO. It does not generate mutations. Picking the
+mutation is the thinking part -- a behaviourally-null edit (swapped operands
+that commute, a type annotation Python does not enforce) produces a GREEN that
+means nothing, and no generator knows which is which. It also does not replace
+`mutmut`/`cosmic-ray`-style coverage sweeps; this is targeted verify-RED, where
+each case names the property it is supposed to break.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: Outcomes. `ABORTED` is deliberately NOT a synonym for "survived" -- conflating
+#: them is how a sweep that never ran reports a clean bill of health.
+BIT = "BIT"
+SURVIVED = "SURVIVED"
+ABORTED = "ABORTED"
+CONFLICT = "CONFLICT"
+
+
+@dataclass(frozen=True)
+class Edit:
+    """One anchored replacement. A case may carry several, applied together."""
+
+    anchor: str
+    replacement: str
+
+    def __post_init__(self) -> None:
+        if self.anchor == self.replacement:
+            raise ValueError("edit is a no-op")
+
+
+#: How a mutated file proves it is still valid. REQUIRED per case, and `none`
+#: must carry a reason. Silently skipping the check for a file type we cannot
+#: parse is the trap: an invalid mutation breaks pytest COLLECTION, and the
+#: nonzero exit then reads as a successful RED -- the exact false positive the
+#: postcondition exists to prevent. Raised by the session that mutates systemd
+#: `.service.template` files, for which no validator exists at all (
+#: `systemd-analyze verify` needs a rendered unit, not one carrying placeholders).
+VALIDATORS = {
+    "python": lambda text, path: compile(text, str(path), "exec"),
+    "bash": None,   # handled out-of-process; see _validate
+    "none": None,   # requires a reason
+}
+
+
+@dataclass(frozen=True)
+class Case:
+    """One mutation and the test that must notice it.
+
+    ``why`` is required, not decorative: a case whose author cannot say which
+    property it breaks is usually a behaviourally-null edit, and that is the
+    failure mode a GREEN result cannot distinguish from a vacuous test.
+
+    The runner fields are PER CASE, not module-global. That is the measured
+    reason sessions forked their harnesses rather than adding cases to them: one
+    sweep can need a probe venv with `--noconftest` for an engine-backed test and
+    the production interpreter for a test that needs the full import tree, and a
+    single global runner cannot express both.
+    """
+
+    label: str
+    path: Path
+    test: str
+    why: str
+    validator: str
+    anchor: str | None = None
+    replacement: str | None = None
+    edits: tuple[Edit, ...] = ()
+    #: Overrides the sweep default when set.
+    python: str | None = None
+    pytest_args: tuple[str, ...] = ()
+    env: dict[str, str] = field(default_factory=dict)
+    #: Shared live state this case touches (a running engine, a real socket).
+    #: The pytest lock does not model these -- two sessions mutating against the
+    #: same live engine stomp each other and nothing notices. Declared here so a
+    #: reader can serialise on it; a case that names a resource ABORTS LOUDLY
+    #: when it is absent rather than being skipped, because a skipped case and a
+    #: killed one look identical in a summary line.
+    requires: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.why.strip():
+            raise ValueError(f"case {self.label!r}: `why` is required")
+        if not self.validator.strip():
+            raise ValueError(
+                f"case {self.label!r}: `validator` is required -- one of "
+                f"{sorted(VALIDATORS)}, and `none` must carry a reason "
+                f"(e.g. 'none: a systemd template has no validator')"
+            )
+        kind = self.validator.split(":", 1)[0].strip()
+        if kind not in VALIDATORS:
+            raise ValueError(f"case {self.label!r}: unknown validator {kind!r}")
+        if kind == "none" and ":" not in self.validator:
+            raise ValueError(
+                f"case {self.label!r}: `none` must say WHY there is no validator"
+            )
+        if self.anchor is not None:
+            object.__setattr__(
+                self, "edits", (Edit(self.anchor, self.replacement or ""),) + self.edits
+            )
+        if not self.edits:
+            raise ValueError(f"case {self.label!r}: no edits")
+
+
+@dataclass
+class Result:
+    case: Case
+    outcome: str
+    detail: str = ""
+    stdout: str = ""
+
+
+@dataclass
+class Sweep:
+    results: list[Result] = field(default_factory=list)
+
+    @property
+    def bit(self) -> list[Result]:
+        return [r for r in self.results if r.outcome == BIT]
+
+    @property
+    def survived(self) -> list[Result]:
+        return [r for r in self.results if r.outcome == SURVIVED]
+
+    @property
+    def aborted(self) -> list[Result]:
+        return [r for r in self.results if r.outcome in (ABORTED, CONFLICT)]
+
+    @property
+    def clean(self) -> bool:
+        """Every case bit, and nothing aborted.
+
+        An abort is NOT a pass. A sweep that could not run half its cases has
+        established nothing about them.
+        """
+        return bool(self.results) and not self.survived and not self.aborted
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _child_env(extra: dict[str, str] | None) -> dict[str, str]:
+    """The ONE place that decides what a sweep's child process may see.
+
+    An ALLOWLIST, not a subtract-list: a stray inherited variable is how a
+    'deliberate concurrent run' lever, a disabled guard, or a pointer at another
+    worktree silently changes what the test under mutation actually exercises.
+    """
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", str(Path.home())),
+        "LANG": os.environ.get("LANG", "C.UTF-8"),
+        # Queue rather than fail when a peer session holds the test lock; a
+        # lock collision would otherwise land as an ABORT on every case.
+        "GENESIS_PYTEST_LOCK_WAIT": "1",
+        # TMPDIR is a PATH, not a behaviour lever. Dropping it sends every child's
+        # temp to /tmp, which this project forbids for anything large, and makes
+        # tests/conftest.py take its no-op basetemp branch on a dev box.
+        "TMPDIR": os.environ.get("TMPDIR", str(Path.home() / "tmp")),
+        # CPython validates cached bytecode on (mtime_seconds, size), so a
+        # same-length mutation restored inside the same integer second leaves a
+        # .pyc compiled from the MUTATED source for the next run to import.
+        # Narrow, and this tool's whole value is that its RED/GREEN means something.
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    env.update(extra or {})
+    return env
+
+
+def _has_result_line(stdout: str) -> bool:
+    """Did pytest actually report on the target?
+
+    A SKIPPED/deselected line FOR THE CASE'S OWN TARGET means nothing ran and is
+    treated as no result. A bare 'no tests ran' likewise.
+    """
+    tail = stdout.strip().splitlines()
+    if not tail:
+        return False
+    for line in reversed(tail):
+        if "no tests ran" in line or (
+            "deselected" in line and "passed" not in line
+        ):
+            return False
+        if "passed" in line or "failed" in line or "error" in line.lower():
+            return True
+    return False
+
+
+def _validate(case: Case, text: str) -> str | None:
+    """Prove the mutated file is still valid, or say why that cannot be proven.
+
+    Returns an error string, or None when the mutation is valid / deliberately
+    unvalidated. NEVER silently skips: an unvalidatable target must have SAID so
+    in its `validator` field, which `Case.__post_init__` enforces.
+    """
+    kind = case.validator.split(":", 1)[0].strip()
+    if kind == "python":
+        try:
+            compile(text, str(case.path), "exec")
+        except SyntaxError as exc:
+            return f"mutation is not valid python: {exc}"
+        return None
+    if kind == "bash":
+        proc = subprocess.run(["bash", "-n"], input=text, capture_output=True,
+                              text=True, timeout=60)
+        if proc.returncode != 0:
+            return f"mutation is not valid bash: {proc.stderr.strip()[:200]}"
+        return None
+    # `none: <reason>` -- declared unvalidatable. The reason travels with the
+    # case so a reader knows the postcondition is absent BY DECISION.
+    return None
+
+
+def run_case(
+    case: Case,
+    baseline: Path,
+    *,
+    cwd: Path,
+    python: str,
+    env: dict[str, str] | None = None,
+    timeout: int = 900,
+    available: set[str] | None = None,
+) -> Result:
+    target = case.path
+    base_bytes = baseline.read_bytes()
+
+    # A case gated on shared live state ABORTS when that state is absent. It does
+    # NOT skip: a skipped case and a killed one look identical in a summary line,
+    # and "11/11 bit" means nothing if two of them never ran.
+    missing = [r for r in case.requires if r not in (available or set())]
+    if missing:
+        return Result(case, ABORTED,
+                      f"requires {', '.join(missing)}, which this run did not "
+                      "declare available -- not skipped, because a skipped case "
+                      "and a killed one are indistinguishable in a tally")
+
+    # (1) the file must still match the ONE baseline for the whole sweep.
+    if target.read_bytes() != base_bytes:
+        return Result(case, ABORTED,
+                      "target differs from the sweep baseline -- a previous case "
+                      "failed to restore, or someone else is editing this file")
+
+    text = base_bytes.decode("utf-8")
+    mutated = text
+    for i, edit in enumerate(case.edits):
+        # (2) EVERY edit is counted. With two or more, a whole-file "did it
+        # change" test stays true while a later anchor silently misses, so a
+        # partial mutation reads as complete.
+        hits = mutated.count(edit.anchor)
+        if hits != 1:
+            return Result(case, ABORTED,
+                          f"edit {i + 1}/{len(case.edits)}: anchor matched "
+                          f"{hits}x, expected exactly 1")
+        mutated = mutated.replace(edit.anchor, edit.replacement, 1)
+
+    # (3) the declared validator, never a silent skip.
+    err = _validate(case, mutated)
+    if err:
+        return Result(case, ABORTED, err)
+
+    target.write_text(mutated, encoding="utf-8")
+    wrote = _sha(target)
+    verdict: Result | None = None
+    conflict: list[str] = []
+    try:
+        cmd = [case.python or python, "-m", "pytest", case.test, "-q", "--no-header",
+               "-p", "no:cacheprovider", *case.pytest_args]
+        proc = subprocess.run(
+            cmd, cwd=str(cwd), capture_output=True, text=True,
+            env=_child_env({**(env or {}), **case.env}), timeout=timeout,
+        )
+        out = proc.stdout + proc.stderr
+        # THE EXIT CODE IS THE VERDICT, not the stdout text. pytest's codes are
+        # an enumerated contract (pytest.ExitCode): 0 OK, 1 TESTS_FAILED,
+        # 2 INTERRUPTED, 3 INTERNAL_ERROR, 4 USAGE_ERROR, 5 NO_TESTS_COLLECTED.
+        # ONLY 0 and 1 mean the tests actually ran.
+        #
+        # MEASURED, and this was a live false GREEN: a mutation that COMPILES but
+        # raises at import time (an invalid module-level `re.compile`, a deleted
+        # constant another line references, a changed decorator argument) gives
+        # rc=2 with "1 error in 0.26s" on stdout. The old rule -- has a result
+        # line AND rc != 0 -- read that as BIT while the test never ran.
+        # `compile()` closes the SyntaxError door only, so the docstring's claim
+        # to have closed this class was false until the exit code became the
+        # verdict. `destructive_command_guard.py` carries a module-level
+        # re.compile, so this is reachable from the shipped gate.
+        if proc.returncode not in (0, 1):
+            verdict = Result(case, ABORTED,
+                             f"pytest exit {proc.returncode}: the run did not "
+                             "happen (collection error, usage error, or nothing "
+                             "collected)", out)
+        elif not _has_result_line(proc.stdout):
+            verdict = Result(case, ABORTED, "no pytest result line -- the run did "
+                             "not happen (lock, guard, collection error?)", out)
+        else:
+            verdict = Result(case, BIT if proc.returncode == 1 else SURVIVED, "", out)
+    except subprocess.TimeoutExpired:
+        verdict = Result(case, ABORTED, f"test timed out after {timeout}s")
+    finally:
+        # (6) restore what this mutation wrote -- and NEVER lose the file.
+        #
+        # `_sha` raises when the target is gone or unreadable, and an exception
+        # here escapes into `sweep`, whose own cleanup deletes the snapshot
+        # directory -- the file's only remaining copy. MEASURED with a child that
+        # unlinks the target: FileNotFoundError, target absent, zero surviving
+        # snapshots. Unrecoverable loss, in the tool whose stated purpose is that
+        # it must never damage anyone's work. An over-broad cleanup fixture in
+        # the test under mutation is enough to trigger it.
+        try:
+            current: str | None = _sha(target) if target.exists() else None
+        except OSError:
+            current = None
+        if current is None or current == wrote:
+            # Gone, unreadable, or still exactly what we wrote -> put it back.
+            target.write_bytes(base_bytes)
+        else:
+            # A peer edited it mid-run. PRESERVE their work -- and SAY SO, which
+            # the previous version did not: CONFLICT was defined, rendered, and
+            # never produced, so a verdict computed against a file that changed
+            # mid-flight was returned as though it were trustworthy. For the last
+            # case, the only case, or the only case touching that path, the next
+            # case's drift check never runs and the conflict was invisible.
+            conflict.append(
+                "the target changed while the test ran -- a peer's edit was "
+                "PRESERVED, so this case's verdict is not trustworthy"
+            )
+
+    # AFTER the finally, so a conflict detected during restore is visible.
+    if verdict is None:  # pragma: no cover -- every branch above assigns one
+        verdict = Result(case, ABORTED, "no verdict produced")
+    if conflict:
+        return Result(case, CONFLICT, conflict[0], verdict.stdout)
+    return verdict
+
+
+def assert_green_baseline(
+    cases: list[Case], *, cwd: Path, python: str, env: dict[str, str] | None,
+    timeout: int,
+) -> str | None:
+    """Every case's test must PASS before anything is mutated.
+
+    Without this the whole sweep is meaningless in the most flattering
+    direction: an already-red test "fails" under every mutation, so each case
+    reports BIT and the sweep declares success while proving nothing. Raised by
+    the session that had been doing this check by hand.
+    """
+    # The env is part of the identity: a case carrying its own `env` must be
+    # baselined UNDER that env. Running it under the sweep's env instead gives a
+    # false RED (the case's flag is missing, the test fails, and the whole sweep
+    # raises) -- so per-case env and the baseline gate were mutually exclusive.
+    # The mirror is worse and silent: a baseline GREEN under the wrong
+    # environment makes every later BIT from that case meaningless, which is the
+    # exact thing this gate exists to prevent. Frozen to a tuple because a dict
+    # is unhashable, which is why it was dropped from the key in the first place.
+    seen = {(c.test, c.python, c.pytest_args, tuple(sorted(c.env.items())))
+            for c in cases}
+    for test, py, extra, case_env in seen:
+        proc = subprocess.run(
+            [py or python, "-m", "pytest", test, "-q", "--no-header",
+             "-p", "no:cacheprovider", *extra],
+            cwd=str(cwd), capture_output=True, text=True,
+            env=_child_env({**(env or {}), **dict(case_env)}), timeout=timeout,
+        )
+        if not _has_result_line(proc.stdout):
+            return f"baseline run of {test} produced no result line"
+        if proc.returncode != 0:
+            return (f"baseline is RED: {test} already fails before any mutation, "
+                    "so every 'BIT' from it would be meaningless")
+    return None
+
+
+def sweep(
+    cases: list[Case],
+    *,
+    cwd: Path,
+    python: str = sys.executable,
+    env: dict[str, str] | None = None,
+    timeout: int = 900,
+    available: set[str] | None = None,
+    check_baseline: bool = True,
+) -> Sweep:
+    """Run every case, restoring between each. Never leaves a file mutated."""
+    if not cases:
+        raise ValueError("a sweep with no cases proves nothing")
+
+    if check_baseline:
+        problem = assert_green_baseline(
+            cases, cwd=cwd, python=python, env=env, timeout=timeout
+        )
+        if problem:
+            raise RuntimeError(problem)
+
+    # `~/tmp` is a Genesis-container convention (CLAUDE.md "Temp files"), NOT a
+    # property of hosts in general -- a CI runner's HOME has no `tmp`, and
+    # `mkdtemp` against an absent parent raises FileNotFoundError. Create it.
+    tmp_root = Path.home() / "tmp"
+    tmp_root.mkdir(parents=True, exist_ok=True)
+    tmpdir = Path(tempfile.mkdtemp(prefix="mutation-sweep-", dir=str(tmp_root)))
+    baselines: dict[Path, Path] = {}
+    completed = False
+    try:
+        for c in {c.path for c in cases}:
+            snap = tmpdir / (str(c).replace("/", "__"))
+            shutil.copy2(c, snap)
+            baselines[c] = snap
+        out = Sweep()
+        for case in cases:
+            out.results.append(
+                run_case(case, baselines[case.path], cwd=cwd, python=python,
+                         env=env, timeout=timeout, available=available)
+            )
+        completed = True
+        return out
+    finally:
+        if completed:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+        else:
+            # An abnormal exit is exactly when the snapshots are worth keeping:
+            # they may be the only surviving copy of a file whose restore did not
+            # finish. Deleting them here is what turned a crash into data loss.
+            print(f"mutation-sweep: baselines PRESERVED for recovery: {tmpdir}",
+                  file=sys.stderr)
+
+
+def render(result: Sweep) -> str:
+    lines = []
+    for r in result.results:
+        mark = {BIT: "BIT     ", SURVIVED: "SURVIVED", ABORTED: "ABORTED ",
+                CONFLICT: "CONFLICT"}[r.outcome]
+        lines.append(f"  {mark}  {r.case.label}")
+        if r.detail:
+            lines.append(f"            {r.detail}")
+        if r.outcome == SURVIVED:
+            lines.append(f"            expected to break: {r.case.why}")
+    lines.append("")
+    lines.append(f"  {len(result.bit)} bit, {len(result.survived)} SURVIVED, "
+                 f"{len(result.aborted)} ABORTED")
+    if result.survived:
+        lines.append("  A survivor means the test does not pin the property its "
+                     "case names -- or the mutation was behaviourally null.")
+    if result.aborted:
+        lines.append("  An abort is NOT a pass: those cases established nothing.")
+    return "\n".join(lines)
+
+
+def cases_from_json(doc: dict, repo: Path) -> list[Case]:
+    out = []
+    for c in doc["cases"]:
+        out.append(Case(
+            label=c["label"], path=repo / c["path"], test=c["test"],
+            why=c["why"], validator=c["validator"],
+            anchor=c.get("anchor"), replacement=c.get("replacement"),
+            edits=tuple(Edit(e["anchor"], e["replacement"]) for e in c.get("edits", ())),
+            python=c.get("python"), pytest_args=tuple(c.get("pytest_args", ())),
+            env=c.get("env", {}), requires=tuple(c.get("requires", ())),
+        ))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("manifest", type=Path, help="JSON file with a `cases` list")
+    ap.add_argument("--repo", type=Path, default=Path.cwd())
+    ap.add_argument("--python", default=sys.executable)
+    ap.add_argument(
+        "--available", action="append", default=[], metavar="RESOURCE",
+        help="declare a shared resource as present (repeatable). A case whose "
+             "`requires` names something not declared here ABORTS -- loudly, "
+             "because a skipped case and a killed one look identical in a tally.",
+    )
+    args = ap.parse_args(argv)
+
+    doc = json.loads(args.manifest.read_text(encoding="utf-8"))
+    cases = cases_from_json(doc, args.repo)
+    # The child env is an ALLOWLIST (see _child_env), so anything the tests need
+    # must be DECLARED. A manifest-level `env` covers the sweep; a case's own
+    # `env` overrides it. VERIFIED 2026-09-07 that the shipped cases pass under
+    # the minimal set, but leaving this undeclarable would be a trap for the
+    # first case that needs a marker variable.
+    env = {"PYTHONPATH": str(args.repo / "src"), **doc.get("env", {})}
+    available = set(doc.get("available", ())) | set(args.available)
+    result = sweep(cases, cwd=args.repo, python=args.python, env=env,
+                   available=available)
+    print(render(result))
+    return 0 if result.clean else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_scripts/test_mutation_sweep.py
+++ b/tests/test_scripts/test_mutation_sweep.py
@@ -242,9 +242,13 @@ def test_aborts_are_not_counted_as_clean(project):
     # exactly how it survived.
     ("1 failed, 1 deselected in 0.1s", True),
     ("2 deselected in 0.1s", False),
-    # A collection error. The exit-code check catches this first now, but the
-    # string still must not read as a result on its own.
-    ("1 error in 0.24s", True),
+    # AN ERROR IS NOT A RESULT, and this row previously asserted True --
+    # encoding the bug. A fixture setup failure exits 1 with "1 error", which
+    # passed the exit-code check (rc in (0,1)) and then read as a result, so the
+    # case scored BIT while the test body never ran. A teardown failure produces
+    # both words at once.
+    ("1 error in 0.24s", False),
+    ("1 passed, 1 error in 0.3s", False),
 ])
 def test_the_result_line_detector(stdout, expected):
     assert ms._has_result_line(stdout) is expected
@@ -637,3 +641,84 @@ def test_the_anti_deadlock_lever_survives_the_allowlist(monkeypatch):
     assert "GENESIS_PYTEST_LOCK_HELD" not in ms._child_env({})
     monkeypatch.setenv("GENESIS_PYTEST_LOCK_HELD", "1")
     assert ms._child_env({})["GENESIS_PYTEST_LOCK_HELD"] == "1"
+
+
+# --------------------------------------------------------------------------
+# THREE P1s: a fixture error scoring as caught, and two ways to corrupt source.
+# --------------------------------------------------------------------------
+
+def test_a_fixture_error_is_an_ABORT_not_a_BIT(project, monkeypatch):
+    """rc=1 with "1 error" is a setup failure, not a caught mutation.
+
+    The exit-code check closed rc != 1 and left this open: an error arrives as
+    rc=1, passed the result-line test, and scored BIT while the named test body
+    never ran — the same false GREEN the exit-code check was added to prevent,
+    one layer in.
+    """
+    class Fake:
+        returncode = 1
+        stdout = "1 error in 0.24s"
+        stderr = ""
+
+    monkeypatch.setattr(ms.subprocess, "run", lambda *a, **k: Fake())
+    result = _sweep(project, [_case(project)])
+    assert result.results[0].outcome == ms.ABORTED
+    assert not result.clean
+
+
+def test_a_symlink_target_is_REFUSED(project):
+    """Mutating a symlink writes THROUGH to the referent, and the restore cannot
+    put the link back — MEASURED: the referent stays mutated permanently while
+    the case reports BIT. Refused rather than handled, because the correct
+    semantics (restore the link? the referent? one outside the repo?) are
+    genuinely ambiguous and a mutation harness must not guess."""
+    real = project / "guard.py"
+    link = project / "guard_link.py"
+    link.symlink_to(real)
+    before = real.read_bytes()
+
+    result = _sweep(project, [_case(project, path=link)])
+    assert result.results[0].outcome == ms.ABORTED
+    assert "SYMLINK" in result.results[0].detail
+    assert real.read_bytes() == before, "the referent was mutated"
+    assert link.is_symlink(), "the link was replaced by a regular file"
+
+
+def test_a_baseline_that_DELETES_the_target_is_caught_with_a_copy_surviving(
+    project, monkeypatch, capsys
+):
+    """The snapshot used to be taken AFTER the baseline ran, so a baseline test
+    (or a fixture) that deleted a target left no recovery copy anywhere — a
+    permanently missing file, before a single mutation was written."""
+    target = project / "guard.py"
+    real_run = ms.subprocess.run
+
+    def delete_during_baseline(*a, **k):
+        if target.exists():
+            target.unlink()
+        return real_run(*a, **k)
+
+    monkeypatch.setattr(ms.subprocess, "run", delete_during_baseline)
+    with pytest.raises(RuntimeError, match="DELETED before any mutation"):
+        ms.sweep([_case(project)], cwd=project, python=sys.executable,
+                 env={"PYTHONPATH": str(project)}, timeout=120, check_baseline=True)
+    err = capsys.readouterr().err
+    assert "baselines PRESERVED" in err, "no recovery copy was reported"
+    snap_dir = err.split("baselines PRESERVED for recovery:")[1].strip().split()[0]
+    assert (Path(snap_dir)).exists(), "the recovery copy was deleted anyway"
+
+
+def test_a_baseline_that_MODIFIES_the_target_refuses_to_mutate(project, monkeypatch):
+    """Mutating a file that no longer matches what it was baselined against makes
+    every verdict from it meaningless."""
+    target = project / "guard.py"
+    real_run = ms.subprocess.run
+
+    def edit_during_baseline(*a, **k):
+        target.write_text("# a fixture rewrote this\n", encoding="utf-8")
+        return real_run(*a, **k)
+
+    monkeypatch.setattr(ms.subprocess, "run", edit_during_baseline)
+    with pytest.raises(RuntimeError, match="MODIFIED before any mutation"):
+        ms.sweep([_case(project)], cwd=project, python=sys.executable,
+                 env={"PYTHONPATH": str(project)}, timeout=120, check_baseline=True)

--- a/tests/test_scripts/test_mutation_sweep.py
+++ b/tests/test_scripts/test_mutation_sweep.py
@@ -236,6 +236,12 @@ def test_aborts_are_not_counted_as_clean(project):
     ("   ", False),
     ("1 deselected in 0.1s", False),
     ("1 passed, 1 deselected in 0.02s", True),
+    # A REAL OUTCOME beats a sibling deselection. MEASURED: the old rule read
+    # this as "no result", turning a genuinely-caught mutation into an ABORT.
+    # The table covered the `passed` variant and not the `failed` one, which is
+    # exactly how it survived.
+    ("1 failed, 1 deselected in 0.1s", True),
+    ("2 deselected in 0.1s", False),
     # A collection error. The exit-code check catches this first now, but the
     # string still must not read as a result on its own.
     ("1 error in 0.24s", True),
@@ -589,3 +595,45 @@ def test_a_gated_case_does_not_kill_the_whole_sweep(project):
     outcomes = {r.case.label: r.outcome for r in result.results}
     assert outcomes["needs an engine"] == ms.ABORTED
     assert outcomes["ordinary"] == ms.BIT, "the ungated case must still have run"
+
+
+def test_a_peer_edit_between_the_drift_check_and_the_write_is_not_clobbered(project, monkeypatch):
+    """TOCTOU. The drift check runs BEFORE the validator (and, for a `bash`
+    validator, before an out-of-process `bash -n`). A peer edit landing in that
+    window was overwritten by the mutation and then "restored" to the baseline --
+    silently destroying their work, which is the one thing guarantee (6) exists
+    to prevent. Re-checked immediately before the write."""
+    target = project / "guard.py"
+    real_validate = ms._validate
+
+    def edit_during_validation(case, text):
+        target.write_text("# a peer edited during validation\n", encoding="utf-8")
+        return real_validate(case, text)
+
+    monkeypatch.setattr(ms, "_validate", edit_during_validation)
+    result = _sweep(project, [_case(project)])
+    assert target.read_text(encoding="utf-8") == "# a peer edited during validation\n"
+    assert result.results[0].outcome == ms.CONFLICT
+    assert not result.clean
+
+
+def test_a_baseline_timeout_is_a_rendered_problem_not_a_traceback(project, monkeypatch):
+    """Every other outcome in this module is enumerated; this was the one path
+    that escaped the contract as a raw traceback."""
+    def boom(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="pytest", timeout=1)
+
+    monkeypatch.setattr(ms, "_baseline_run", boom)
+    with pytest.raises(RuntimeError, match="timed out"):
+        ms.sweep([_case(project)], cwd=project, python=sys.executable,
+                 env={"PYTHONPATH": str(project)}, timeout=1, check_baseline=True)
+
+
+def test_the_anti_deadlock_lever_survives_the_allowlist(monkeypatch):
+    """`GENESIS_PYTEST_LOCK_HELD` tells a nested pytest not to contend with its
+    own parent. Stripping it meant a sweep launched inside a locked session
+    queued behind itself and died at the per-case timeout."""
+    monkeypatch.delenv("GENESIS_PYTEST_LOCK_HELD", raising=False)
+    assert "GENESIS_PYTEST_LOCK_HELD" not in ms._child_env({})
+    monkeypatch.setenv("GENESIS_PYTEST_LOCK_HELD", "1")
+    assert ms._child_env({})["GENESIS_PYTEST_LOCK_HELD"] == "1"

--- a/tests/test_scripts/test_mutation_sweep.py
+++ b/tests/test_scripts/test_mutation_sweep.py
@@ -1,0 +1,560 @@
+"""Controls for the mutation harness -- including the damage it must never do.
+
+The harness EDITS SOURCE FILES IN PLACE, so its failure modes are not "a wrong
+number in a report": a bad restore destroys uncommitted work, and a mis-reported
+survival retires a test that was actually fine. Both directions are pinned here.
+
+Install-agnostic: every case operates on files under `tmp_path`. No repo file is
+mutated by this suite, no network, no live DB.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+_MOD = _REPO / "scripts" / "mutation_sweep.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_mutation_sweep", _MOD)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_mutation_sweep"] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules.pop("_mutation_sweep", None)
+        raise
+    return mod
+
+
+ms = _load()
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A miniature project: one guard, one test that pins it."""
+    src = tmp_path / "guard.py"
+    src.write_text(
+        textwrap.dedent(
+            """
+            def is_allowed(name):
+                if name.startswith("danger"):
+                    return False
+                return True
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "test_guard.py").write_text(
+        textwrap.dedent(
+            """
+            import guard
+            def test_blocks_danger():
+                assert guard.is_allowed("dangerous") is False
+            def test_allows_ordinary():
+                assert guard.is_allowed("ordinary") is True
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _case(project, **kw):
+    base = dict(
+        label="guard removed",
+        path=project / "guard.py",
+        anchor='if name.startswith("danger"):',
+        replacement="if False:",
+        test="test_guard.py::test_blocks_danger",
+        why="the guard must refuse a dangerous name",
+        validator="python",
+    )
+    base.update(kw)
+    return ms.Case(**base)
+
+
+def _sweep(project, cases, **kw):
+    kw.setdefault("check_baseline", False)  # most cases here mutate on purpose
+    return ms.sweep(cases, cwd=project, python=sys.executable,
+                    env={"PYTHONPATH": str(project)}, timeout=120, **kw)
+
+
+# --------------------------------------------------------------------------
+# THE HAPPY PATH, both outcomes.
+# --------------------------------------------------------------------------
+
+def test_a_mutation_the_test_notices_is_reported_as_BIT(project):
+    result = _sweep(project, [_case(project)])
+    assert [r.outcome for r in result.results] == [ms.BIT]
+    assert result.clean
+
+
+def test_a_mutation_no_test_notices_is_reported_as_SURVIVED(project):
+    """The other test in the fixture does not exercise the danger branch, so
+    pointing the same mutation at it must NOT read as a pass."""
+    result = _sweep(project, [_case(project, test="test_guard.py::test_allows_ordinary")])
+    assert [r.outcome for r in result.results] == [ms.SURVIVED]
+    assert not result.clean
+
+
+# --------------------------------------------------------------------------
+# THE FILE MUST COME BACK. This is the half that can destroy work.
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "case_kw",
+    [
+        {},                                                    # BIT
+        {"test": "test_guard.py::test_allows_ordinary"},       # SURVIVED
+        {"anchor": "not present anywhere"},                    # ABORTED (anchor)
+        {"replacement": "if False:\n  return ("},              # ABORTED (syntax)
+        {"test": "test_guard.py::test_does_not_exist"},        # ABORTED/BIT, no result
+    ],
+    ids=["bit", "survived", "bad-anchor", "invalid-mutation", "missing-test"],
+)
+def test_the_target_is_byte_identical_afterwards(project, case_kw):
+    """Whatever the outcome -- including the abort paths, and including the
+    SURVIVED path where the expected exit code is zero and a trailing restore
+    would still have run. The restore is in a `finally` precisely because the
+    GOOD outcome here is a nonzero exit."""
+    target = project / "guard.py"
+    before = target.read_bytes()
+    _sweep(project, [_case(project, **case_kw)])
+    assert target.read_bytes() == before
+
+
+def test_a_crash_mid_sweep_still_restores(project, monkeypatch):
+    target = project / "guard.py"
+    before = target.read_bytes()
+
+    def boom(*a, **k):
+        raise RuntimeError("injected")
+
+    monkeypatch.setattr(ms.subprocess, "run", boom)
+    with pytest.raises(RuntimeError):
+        _sweep(project, [_case(project)])
+    assert target.read_bytes() == before, "a crash must not leave the file mutated"
+
+
+def test_a_concurrent_edit_is_PRESERVED_not_overwritten(project, monkeypatch):
+    """THE 6-of-15 CASE. If the file changes while the test runs, that is someone
+    else's uncommitted work. Restoring the snapshot over it would destroy the
+    edit -- and a final hash check would happily confirm the overwrite
+    succeeded."""
+    target = project / "guard.py"
+    real_run = ms.subprocess.run
+
+    def edit_then_run(*a, **k):
+        target.write_text("# a peer session edited this\n", encoding="utf-8")
+        return real_run(*a, **k)
+
+    monkeypatch.setattr(ms.subprocess, "run", edit_then_run)
+    result = _sweep(project, [_case(project)])
+    assert target.read_text(encoding="utf-8") == "# a peer session edited this\n"
+    # And it must SAY SO. Asserting only the preservation locked in the silent
+    # half: CONFLICT was defined, rendered and never produced, so a verdict
+    # computed against a file that changed mid-flight was returned as though it
+    # were trustworthy -- invisible whenever no later case touches that path.
+    assert result.results[0].outcome == ms.CONFLICT
+    assert not result.clean
+
+
+def test_the_next_case_aborts_after_a_drift(project, monkeypatch):
+    """And the drift must be REPORTED, not silently absorbed."""
+    target = project / "guard.py"
+    real_run = ms.subprocess.run
+    calls = {"n": 0}
+
+    def edit_on_first(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            target.write_text("# peer edit\n", encoding="utf-8")
+        return real_run(*a, **k)
+
+    monkeypatch.setattr(ms.subprocess, "run", edit_on_first)
+    result = _sweep(project, [_case(project, label="first"), _case(project, label="second")])
+    assert result.results[1].outcome == ms.ABORTED
+    assert "differs from the sweep baseline" in result.results[1].detail
+
+
+# --------------------------------------------------------------------------
+# ABORT IS NOT A PASS. The confident false negative this class is famous for.
+# --------------------------------------------------------------------------
+
+def test_an_anchor_matching_twice_aborts(project):
+    (project / "guard.py").write_text(
+        "def f():\n    x = 1\n    y = 1\n", encoding="utf-8"
+    )
+    result = _sweep(project, [_case(project, anchor="= 1", replacement="= 2")])
+    assert result.results[0].outcome == ms.ABORTED
+    assert "matched 2x" in result.results[0].detail
+
+
+def test_an_invalid_mutation_aborts_rather_than_reading_as_RED(project):
+    """A mutation that does not compile breaks COLLECTION, and a nonzero exit
+    then reads as a successful RED -- the test looks like it caught something it
+    never saw."""
+    result = _sweep(project, [_case(project, replacement="if False:\n  return (")])
+    assert result.results[0].outcome == ms.ABORTED
+    assert "not valid python" in result.results[0].detail
+
+
+def test_a_run_that_produced_no_result_line_aborts(project):
+    result = _sweep(project, [_case(project, test="test_guard.py::test_missing")])
+    assert result.results[0].outcome == ms.ABORTED
+    # Either guard may catch it -- the exit code fires first and reports a more
+    # precise cause. The PROPERTY is that a run which did not happen never reads
+    # as a verdict; pinning one specific message would make the test brittle
+    # about which of two correct mechanisms got there first.
+    assert "the run did not happen" in result.results[0].detail
+
+
+def test_aborts_are_not_counted_as_clean(project):
+    """`clean` must require every case to have BIT. A sweep that could not run
+    half its cases has established nothing about them."""
+    result = _sweep(project, [_case(project), _case(project, label="bad", anchor="nope")])
+    assert result.bit and result.aborted
+    assert not result.clean
+
+
+@pytest.mark.parametrize("stdout,expected", [
+    ("1 failed, 2 passed in 3.0s", True),
+    ("2 passed in 1.0s", True),
+    ("no tests ran in 0.01s", False),
+    ("", False),
+    ("   ", False),
+    ("1 deselected in 0.1s", False),
+    ("1 passed, 1 deselected in 0.02s", True),
+    # A collection error. The exit-code check catches this first now, but the
+    # string still must not read as a result on its own.
+    ("1 error in 0.24s", True),
+])
+def test_the_result_line_detector(stdout, expected):
+    assert ms._has_result_line(stdout) is expected
+
+
+# --------------------------------------------------------------------------
+# THE CONTRACT.
+# --------------------------------------------------------------------------
+
+# --------------------------------------------------------------------------
+# REQUIREMENTS CONTRIBUTED BY THE SESSION THAT WROTE 5 OF THE 15 HARNESSES.
+# Each of these is a defect the shared version would otherwise have shipped.
+# --------------------------------------------------------------------------
+
+def test_a_validator_is_REQUIRED_never_silently_skipped():
+    """The original silently skipped `compile()` for non-.py targets. An
+    unvalidatable mutation breaks pytest COLLECTION, and the nonzero exit then
+    reads as a successful RED -- the precise false positive the postcondition
+    exists to prevent. Raised by the session mutating systemd .service.template
+    files, for which no validator exists at all."""
+    with pytest.raises(ValueError, match="validator"):
+        ms.Case(label="x", path=Path("a.service.template"), anchor="a",
+                replacement="b", test="t", why="w", validator="")
+
+
+def test_declaring_no_validator_requires_a_reason():
+    with pytest.raises(ValueError, match="WHY"):
+        ms.Case(label="x", path=Path("a.tmpl"), anchor="a", replacement="b",
+                test="t", why="w", validator="none")
+    ms.Case(label="x", path=Path("a.tmpl"), anchor="a", replacement="b",
+            test="t", why="w",
+            validator="none: a systemd template has no validator -- "
+                      "systemd-analyze verify needs a rendered unit")
+
+
+def test_a_bash_target_is_validated_with_bash_n(project):
+    sh = project / "thing.sh"
+    sh.write_text("#!/bin/bash\nif true; then\n  echo ok\nfi\n", encoding="utf-8")
+    bad = ms.Case(label="broken shell", path=sh, anchor="if true; then",
+                  replacement="if true; then\ndone", test="test_guard.py::test_allows_ordinary",
+                  why="w", validator="bash")
+    result = _sweep(project, [bad])
+    assert result.results[0].outcome == ms.ABORTED
+    assert "not valid bash" in result.results[0].detail
+    assert sh.read_text(encoding="utf-8").startswith("#!/bin/bash")
+
+
+def test_a_multi_edit_case_counts_EVERY_anchor(project):
+    """Sibling-layer masking: removing one `raise` while a second layer still
+    converts the error is behaviourally null. The fix is mutating the whole
+    mechanism at once -- so a case carries N edits, and a later anchor that
+    misses must ABORT rather than shipping a partial mutation that reads as
+    complete."""
+    case = ms.Case(
+        label="two-site", path=project / "guard.py",
+        edits=(ms.Edit('if name.startswith("danger"):', "if False:"),
+               ms.Edit("nonexistent second anchor", "x")),
+        test="test_guard.py::test_blocks_danger", why="w", validator="python",
+    )
+    result = _sweep(project, [case])
+    assert result.results[0].outcome == ms.ABORTED
+    assert "edit 2/2" in result.results[0].detail
+
+
+def test_a_multi_edit_case_applies_all_edits_together(project, monkeypatch):
+    case = ms.Case(
+        label="two-site", path=project / "guard.py",
+        edits=(ms.Edit('if name.startswith("danger"):', "if False:"),
+               ms.Edit("return True", "return True  # touched")),
+        test="test_guard.py::test_blocks_danger", why="w", validator="python",
+    )
+    seen = {}
+    real_run = ms.subprocess.run
+
+    def capture(*a, **k):
+        seen["text"] = (project / "guard.py").read_text(encoding="utf-8")
+        return real_run(*a, **k)
+
+    monkeypatch.setattr(ms.subprocess, "run", capture)
+    result = _sweep(project, [case])
+    # The MUTATED text is what proves both edits landed. Asserting only that
+    # "# touched" is absent afterwards tests the RESTORE, and stays true whether
+    # or not edit 2 ever applied -- edit 1 bites on its own.
+    assert "if False:" in seen["text"]
+    assert "# touched" in seen["text"]
+    assert result.results[0].outcome == ms.BIT
+    assert (project / "guard.py").read_text(encoding="utf-8").count("# touched") == 0
+
+
+def test_a_RED_baseline_refuses_to_sweep(project):
+    """If the test already fails, every mutation 'bites' and the sweep reports
+    success while proving nothing -- meaningless in the most flattering
+    direction."""
+    (project / "test_guard.py").write_text(
+        "def test_blocks_danger():\n    assert False\n", encoding="utf-8"
+    )
+    with pytest.raises(RuntimeError, match="baseline is RED"):
+        ms.sweep([_case(project)], cwd=project, python=sys.executable,
+                 env={"PYTHONPATH": str(project)}, timeout=120, check_baseline=True)
+
+
+def test_a_green_baseline_lets_the_sweep_proceed(project):
+    result = ms.sweep([_case(project)], cwd=project, python=sys.executable,
+                      env={"PYTHONPATH": str(project)}, timeout=120,
+                      check_baseline=True)
+    assert result.clean
+
+
+def test_a_case_needing_absent_live_state_ABORTS_rather_than_skipping(project):
+    """A skipped case and a killed one are indistinguishable in a tally, so
+    '11/11 bit' can silently mean 9 ran. Raised by the session whose engine-gated
+    cases were only reachable because the engine happened to be armed."""
+    case = _case(project, requires=("falkordb-engine",))
+    result = _sweep(project, [case], available=set())
+    assert result.results[0].outcome == ms.ABORTED
+    assert "falkordb-engine" in result.results[0].detail
+    assert not result.clean
+
+
+def test_a_declared_resource_that_IS_available_runs(project):
+    result = _sweep(project, [_case(project, requires=("falkordb-engine",))],
+                    available={"falkordb-engine"})
+    assert result.results[0].outcome == ms.BIT
+
+
+def test_a_cases_own_env_reaches_the_child(project):
+    """THE measured reason five harnesses were forked rather than extended.
+
+    The previous version of this test asserted `case.pytest_args == (...)` -- a
+    dataclass field read back from the constructor that just stored it -- and set
+    an `env` nothing observed. Deleting BOTH forwarding sites left it green. The
+    property is now observed from inside the child process."""
+    (project / "test_env.py").write_text(
+        'import os\ndef test_flag():\n    assert os.environ["EXTRA"] == "1"\n',
+        encoding="utf-8",
+    )
+    case = _case(project, test="test_env.py::test_flag", env={"EXTRA": "1"},
+                 why="the child must see the case's own env")
+    # SURVIVED == the test ran and PASSED, which it can only do if EXTRA arrived.
+    assert _sweep(project, [case]).results[0].outcome == ms.SURVIVED
+
+
+def test_a_cases_own_pytest_args_reach_the_child(project):
+    """A -k that matches nothing deselects everything -> no result -> ABORT."""
+    case = _case(project, pytest_args=("-k", "no_such_selector"))
+    assert _sweep(project, [case]).results[0].outcome == ms.ABORTED
+
+
+def test_HOME_and_PATH_are_in_the_allowlist_deliberately():
+    """genesis.env composes path resolution from HOME, so dropping it fails in a
+    confusing way -- a socket path silently resolving elsewhere rather than
+    erroring."""
+    env = ms._child_env({})
+    assert env["HOME"] and env["PATH"]
+
+
+def test_a_case_must_say_what_it_breaks():
+    """`why` is required because a case whose author cannot name the property is
+    usually a behaviourally-null edit -- and a GREEN from one of those is
+    indistinguishable from a vacuous test."""
+    with pytest.raises(ValueError, match="why"):
+        ms.Case(label="x", path=Path("a.py"), anchor="a", replacement="b",
+                test="t", why="  ", validator="python")
+
+
+def test_a_no_op_mutation_is_refused():
+    with pytest.raises(ValueError, match="no-op"):
+        ms.Case(label="x", path=Path("a.py"), anchor="same", replacement="same",
+                test="t", why="something", validator="python")
+
+
+def test_an_empty_sweep_is_refused(project):
+    with pytest.raises(ValueError, match="proves nothing"):
+        _sweep(project, [])
+
+
+def test_the_child_env_is_an_allowlist(monkeypatch):
+    """A subtract-list lets a stray inherited lever change what the mutated test
+    actually exercises -- a disabled guard, a pointer at another worktree."""
+    monkeypatch.setenv("GENESIS_SOMETHING_DANGEROUS", "1")
+    env = ms._child_env({"PYTHONPATH": "/x"})
+    assert "GENESIS_SOMETHING_DANGEROUS" not in env
+    assert env["PYTHONPATH"] == "/x"
+    assert env["GENESIS_PYTEST_LOCK_WAIT"] == "1"
+
+
+def test_the_cli_exits_nonzero_on_a_survivor(project, tmp_path):
+    manifest = tmp_path / "m.json"
+    manifest.write_text(
+        '{"cases": [{"label": "l", "path": "guard.py", '
+        '"anchor": "if name.startswith(\\"danger\\"):", "replacement": "if False:", '
+        '"validator": "python", '
+        '"test": "test_guard.py::test_allows_ordinary", "why": "w"}]}',
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [sys.executable, str(_MOD), str(manifest), "--repo", str(project)],
+        capture_output=True, text=True, timeout=180,
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "SURVIVED" in proc.stdout
+
+
+# --------------------------------------------------------------------------
+# THE FALSE GREEN. A mutation that compiles but breaks IMPORT.
+# --------------------------------------------------------------------------
+
+def test_a_mutation_that_breaks_import_ABORTS_rather_than_reading_as_BIT(project):
+    """`compile()` closes the SyntaxError door ONLY.
+
+    MEASURED before the fix: a module-level statement that raises at import time
+    compiles cleanly, pytest exits 2 with "1 error in 0.26s" on stdout, and the
+    old rule (has a result line AND rc != 0) called that BIT -- while the test
+    never ran. Realistic shapes: an invalid module-level `re.compile`, a deleted
+    constant another line references, a changed decorator argument. The shipped
+    gate targets a file that carries a module-level re.compile, so this is
+    reachable, not hypothetical.
+    """
+    case = _case(
+        project,
+        anchor="def is_allowed(name):",
+        replacement="raise RuntimeError('mutation broke import')\ndef is_allowed(name):",
+        why="a compiling-but-unimportable mutation must not count as caught",
+    )
+    result = _sweep(project, [case])
+    assert result.results[0].outcome == ms.ABORTED
+    assert "pytest exit" in result.results[0].detail
+    assert not result.clean
+
+
+@pytest.mark.parametrize("rc,expected", [(0, ms.SURVIVED), (1, ms.BIT),
+                                         (2, ms.ABORTED), (3, ms.ABORTED),
+                                         (4, ms.ABORTED), (5, ms.ABORTED)])
+def test_only_pytest_exit_0_and_1_mean_the_tests_ran(project, monkeypatch, rc, expected):
+    """pytest's exit codes are an enumerated contract; stdout text is not."""
+    class Fake:
+        returncode = rc
+        stdout = "1 failed, 0 passed in 0.1s"
+        stderr = ""
+
+    monkeypatch.setattr(ms.subprocess, "run", lambda *a, **k: Fake())
+    result = _sweep(project, [_case(project)])
+    assert result.results[0].outcome == expected
+
+
+# --------------------------------------------------------------------------
+# THE DATA-LOSS PATH.
+# --------------------------------------------------------------------------
+
+def test_a_child_that_DELETES_the_target_does_not_lose_it(project, monkeypatch):
+    """`_sha` raises on a missing file. In the restore `finally` that exception
+    escaped into `sweep`, whose cleanup then deleted the snapshot -- the only
+    remaining copy. MEASURED: FileNotFoundError, target absent, zero surviving
+    snapshots. Unrecoverable loss, in the tool sold on never damaging work."""
+    target = project / "guard.py"
+    before = target.read_bytes()
+    real_run = ms.subprocess.run
+
+    def delete_then_run(*a, **k):
+        target.unlink()
+        return real_run(*a, **k)
+
+    monkeypatch.setattr(ms.subprocess, "run", delete_then_run)
+    _sweep(project, [_case(project)])
+    assert target.exists(), "the target was destroyed"
+    assert target.read_bytes() == before
+
+
+def test_baselines_are_PRESERVED_when_the_sweep_dies(project, monkeypatch, capsys):
+    """An abnormal exit is exactly when the snapshots are worth keeping."""
+    monkeypatch.setattr(ms, "run_case", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    with pytest.raises(RuntimeError):
+        _sweep(project, [_case(project)])
+    assert "baselines PRESERVED" in capsys.readouterr().err
+
+
+# --------------------------------------------------------------------------
+# THE BASELINE MUST RUN UNDER THE CASE'S OWN ENV.
+# --------------------------------------------------------------------------
+
+def test_the_green_baseline_uses_the_cases_own_env(project):
+    """Running the baseline under the SWEEP's env gave a false RED for any case
+    carrying its own env -- and it raises rather than degrading, so per-case env
+    and the baseline gate were mutually exclusive."""
+    (project / "test_env.py").write_text(
+        'import os\ndef test_flag():\n    assert os.environ["EXTRA"] == "1"\n',
+        encoding="utf-8",
+    )
+    case = _case(project, test="test_env.py::test_flag", env={"EXTRA": "1"},
+                 why="the baseline must see the case's env")
+    # check_baseline=True must NOT raise: the case's env makes its test green.
+    result = ms.sweep([case], cwd=project, python=sys.executable,
+                      env={"PYTHONPATH": str(project)}, timeout=120,
+                      check_baseline=True)
+    assert result.results[0].outcome == ms.SURVIVED
+
+
+def test_the_cli_can_declare_an_available_resource(project, tmp_path):
+    """`requires` was unreachable from the CLI -- the only entry point CI uses --
+    so any case declaring a resource aborted unconditionally, and the author's
+    fix would have been to delete the declaration."""
+    manifest = tmp_path / "m.json"
+    manifest.write_text(
+        '{"cases": [{"label": "l", "path": "guard.py", '
+        '"anchor": "if name.startswith(\\"danger\\"):", "replacement": "if False:", '
+        '"validator": "python", "requires": ["an-engine"], '
+        '"test": "test_guard.py::test_blocks_danger", "why": "w"}]}',
+        encoding="utf-8",
+    )
+    without = subprocess.run(
+        [sys.executable, str(_MOD), str(manifest), "--repo", str(project)],
+        capture_output=True, text=True, timeout=180)
+    assert "ABORTED" in without.stdout and without.returncode == 1
+
+    with_res = subprocess.run(
+        [sys.executable, str(_MOD), str(manifest), "--repo", str(project),
+         "--available", "an-engine"],
+        capture_output=True, text=True, timeout=180)
+    assert "BIT" in with_res.stdout, with_res.stdout + with_res.stderr

--- a/tests/test_scripts/test_mutation_sweep.py
+++ b/tests/test_scripts/test_mutation_sweep.py
@@ -501,10 +501,19 @@ def test_a_child_that_DELETES_the_target_does_not_lose_it(project, monkeypatch):
         target.unlink()
         return real_run(*a, **k)
 
+    import os as _os
+    import stat as _stat
+    _os.chmod(target, 0o755)
+    mode_before = _stat.S_IMODE(target.stat().st_mode)
+
     monkeypatch.setattr(ms.subprocess, "run", delete_then_run)
     _sweep(project, [_case(project)])
     assert target.exists(), "the target was destroyed"
     assert target.read_bytes() == before
+    # AND its mode. `write_bytes` on a deleted file recreates it at the default
+    # creation mode -- MEASURED 0o755 -> 0o644 -- so a restored hook script would
+    # come back unrunnable. A quieter version of the same damage.
+    assert _stat.S_IMODE(target.stat().st_mode) == mode_before
 
 
 def test_baselines_are_PRESERVED_when_the_sweep_dies(project, monkeypatch, capsys):
@@ -558,3 +567,25 @@ def test_the_cli_can_declare_an_available_resource(project, tmp_path):
          "--available", "an-engine"],
         capture_output=True, text=True, timeout=180)
     assert "BIT" in with_res.stdout, with_res.stdout + with_res.stderr
+
+
+def test_a_gated_case_does_not_kill_the_whole_sweep(project):
+    """Requirement 5 and requirement 4, ASSERTED TOGETHER.
+
+    `assert_green_baseline` saw every case including ones gated on state this run
+    does not have. Such a case's test fails without that state, the gate read
+    that as a RED baseline, and the RuntimeError killed the sweep -- so one
+    unavailable resource silently prevented every OTHER case from running.
+
+    The existing requirement-5 test passes check_baseline=False and so could
+    never see this: each mechanism was correct alone and wrong together.
+    """
+    gated = _case(project, label="needs an engine", requires=("an-engine",),
+                  test="test_guard.py::test_missing_entirely")
+    ordinary = _case(project, label="ordinary")
+    result = ms.sweep([gated, ordinary], cwd=project, python=sys.executable,
+                      env={"PYTHONPATH": str(project)}, timeout=120,
+                      check_baseline=True, available=set())
+    outcomes = {r.case.label: r.outcome for r in result.results}
+    assert outcomes["needs an engine"] == ms.ABORTED
+    assert outcomes["ordinary"] == ms.BIT, "the ungated case must still have run"


### PR DESCRIPTION
## Why this is committed rather than documented

The repo's discipline says a new test must be seen to FAIL for the right reason
before its green is trusted. Sessions follow it — and each one hand-rolls the
harness and throws it away.

**MEASURED: 15 independent implementations under `~/tmp`**, five written in one day
by a single session, two within ten minutes. They are the same program. The
contract below isn't designed; it's what those fifteen converged on:

```
per-case test target      15/15  ████████████████████
baseline copy             14/15  ███████████████████
hash-verified restore     14/15  ███████████████████
anchor matched exactly 1x 14/15  ███████████████████
abort on no result line   14/15  ███████████████████
explicit child env        14/15  ███████████████████
compile() the mutation    13/15  █████████████████
─────────────────────────────────────────────────────
abort if the file drifted  9/15  ████████████
```

That last number is what decided this. The drift check is the one people skip
under time pressure, and it's the only one whose absence damages **another
session's uncommitted work** — six of fifteen would have restored over a peer's
edit. A convention nobody is forced through is a convention with better
documentation.

## Requirements came from the session that wrote five of them

Relayed by the owner. Four were things this would otherwise have shipped wrong:

- **Per-case runner** (interpreter, pytest args, env) — the measured reason they
  forked files rather than adding cases: one sweep needed a probe venv with
  `--noconftest` *and* the production interpreter for a test requiring the full
  import tree.
- **A validator declared per case, never silently skipped.** The first version
  `compile()`'d only `.py` and skipped everything else in silence, while they
  mutate systemd `.service.template` and shell. A silently-absent postcondition
  means an invalid mutation breaks collection and the nonzero exit reads as a
  successful RED.
- **Multi-edit atomic cases** — their sibling-layer case was behaviourally null:
  one `raise` removed while a second layer still converted the error.
- **A GREEN baseline assertion** — an already-red baseline makes every "BIT"
  meaningless while the sweep reports success.
- **Abort loudly, never skip**, for cases gated on unreachable live state. Their
  note: 11/11 bit, but two were only reachable because an engine happened to be
  armed.

## Four blockers from review, two serious

**The false GREEN.** `compile()` closes the SyntaxError door *only*. A mutation
that compiles but raises at **import** gives pytest `rc=2` with `1 error` on
stdout, and the old rule — result line plus `rc != 0` — called that BIT while the
test never ran:

```
rc = 2, stdout tail = "1 error in 0.26s"
_has_result_line -> True  ->  verdict: BIT   (the test never ran)
```

Reachable from the shipped gate, not hypothetical: `destructive_command_guard.py`
carries a module-level `re.compile`. pytest's exit codes are an enumerated
contract, so they're the verdict now — only `0` and `1` mean the tests ran.

**An unrecoverable data-loss path**, in the tool justified by never damaging
anyone's work. `_sha` raises when the target is gone; in the restore `finally`
that exception escaped into the sweep, whose cleanup then deleted the snapshot —
the file's only remaining copy. An over-broad cleanup fixture in the test under
mutation is enough to trigger it. The restore is now total, and an abnormal exit
**preserves** the baselines instead of deleting them.

Also: `~/tmp` was assumed to exist (a container convention, not a property of
hosts); the green-baseline check ran under the sweep's env rather than the case's,
making per-case env and the baseline gate mutually exclusive; and `CONFLICT` was
defined, rendered, and produced nowhere — so a verdict computed against a file
that changed mid-flight was returned as though it were trustworthy.

## Three of my own tests were vacuous

Rewritten rather than explained around. The per-case-runner test asserted a
dataclass field the constructor had just stored — deleting *both* forwarding
sites left it green. The multi-edit test asserted only that the marker was absent
*afterwards*, which tests the restore and stays true whether or not the second
edit applied. The result-line table omitted the two rows that mattered.

## Verification

**The harness was run against its own source**, with each blocker reintroduced:

```
BIT  exit-code check removed (blocker 3)
BIT  total restore removed (blocker 4)
BIT  CONFLICT reporting removed (should-fix 6)
BIT  baseline ignores the case env (should-fix 5)
4 bit, 0 SURVIVED, 0 ABORTED
```

Every fix is pinned by a test that fails when the fix is reverted.

The pinned CI gate runs `2 bit / 0 / 0`, and weakening one of its tests flips it
to exit 1 with the `why` printed. **Both pairings were verified to discriminate
rather than assumed** — a third candidate was masked by a sibling layer
(`_ALWAYS_BLOCK` refuses `/`, `.`, `~` regardless of depth, so every test using
those inputs is structurally blind to the depth rule), and two earlier candidates
survived because one mutated a function the test doesn't call and the other was
behaviourally null.

50 targeted tests · `ruff` clean.

E2E: none — a CI guard and a dev library with no runtime surface. Both were
executed against the live tree before commit (figures above), including the
self-mutation sweep and a deliberate test-weakening that flips the gate red.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated mutation testing as a required continuous integration check.
  * Added configurable validation scenarios for destructive-command safeguards and protected-path handling.
  * Added reporting for detected weaknesses, surviving mutations, aborted runs, and conflicts.

* **Bug Fixes**
  * Improved recovery safeguards to preserve changes and detect restoration conflicts during test runs.

* **Tests**
  * Added comprehensive coverage for validation, baseline checks, environment handling, failure reporting, and safe recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wingedguardian/genesis-agi/pull/1851" target="_blank"><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=4"><img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=4" alt="Devin Review"></picture></a>
<!-- devin-review-badge-end -->