### PR TITLE
fix(cc-tmp): reap sessions not projects, and report a severed control plane

### DIFF
--- a/changelog.d/20260907220000-fixed-watchgod-control-plane-safety.md
+++ b/changelog.d/20260907220000-fixed-watchgod-control-plane-safety.md
@@ -1,0 +1,21 @@
+- **The temp watchgod no longer damages the things it exists to protect, and it
+  now reports a broken Claude Code control plane instead of leaving it silent.**
+  Its weekly cleanup was aimed one directory level too shallow and judged
+  staleness by directory timestamp, so a project folder whose sessions were all
+  still active could be deleted whole — on one install that folder held 54 live
+  session workspaces. It now reaps individual session folders, and only when
+  nothing inside has been touched for seven days; if it cannot work out what
+  "seven days ago" means, it deletes nothing at all. The ORANGE tier no longer
+  kills idle Claude Code sessions: sessions are not what fills the temp
+  directory, so the kill freed almost nothing while destroying a session's entire
+  context. The /tmp housekeeping now leaves Claude Code's socket directories
+  alone — an empty folder inside a live socket tree is a rendezvous point the
+  daemon fills in later, not leftover junk.
+
+  And a new check reports Claude Code sessions whose messaging socket has been
+  deleted underneath them. They keep listening, so they look healthy while no
+  other session can reach them, and nothing re-binds after startup — the only
+  cure is restarting them. The count appears in the watchgod state file and pages
+  once when it rises, staying quiet across restarts until it rises again. The
+  check never deletes a socket, and says "unknown" rather than "fine" when it
+  cannot see.

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -2149,6 +2149,56 @@ verified: f24c15e9 2026-09-05
 - **_config_overlay.py**: `.local.yaml` deep-merge (user config dir first;
   dicts merge, lists REPLACE wholesale); dependency-free by design to stay
   import-cycle-safe.
+- **`scripts/tmp_watchgod.sh`** (a standalone systemd user service, not a
+  `src/genesis` package — it must keep running when Genesis does not): dual-zone
+  temp protection, polling every 30s. Zone A is `~/.genesis/cc-tmp` against a
+  budget (GREEN <50% / YELLOW >50% / ORANGE >75% / RED >90% or free space under
+  the sacred-ground floor); Zone B is `/tmp` on time-based housekeeping. **Its
+  one job is stopping runaway temp usage from killing Claude Code — so the bar
+  for any sweep is that it must not damage correct functioning, even when it has
+  to fire.** Three edges follow from that and are easy to reintroduce:
+  * **Sockets are never deleted.** CC binds one unix socket per session for
+    cross-session messaging, at `$XDG_RUNTIME_DIR/cc-socks/<pid>.sock` — falling
+    back to the temp dir when that variable is unset, which on a Genesis install
+    is cc-tmp itself. Deleting the PATH does not stop the listener: the process
+    keeps the inode, so `ss` still shows LISTEN and the session looks healthy
+    from the inside while every peer resolves by path and gets ENOENT. Nothing
+    re-binds after startup, so the session is unreachable for life and cannot
+    notice. Measured 2026-09-05, when a RED sweep deleted them: 3 of 4 sessions
+    severed here, 6 of 6 on a sibling install. Every Zone A sweep that removes a
+    directory now goes through `reap_dir_sparing_sockets` (object-level, never
+    `-type s`); Zone B's file sweeps spare `*.sock` by name, and its empty-dir
+    sweep spares the socket TREES — an empty directory inside a live socket tree
+    is a rendezvous point CC populates later, not garbage, and the exclusion by
+    name is what covers it (MEASURED 2026-09-07: that predicate matched
+    `/tmp/cc-socks` and a live daemon's `pty` directory). `check_control_plane`
+    reports severed listeners and stale socket files into the state file, paging
+    once on a confirmed rise. It is strictly READ-ONLY — reaping a stale socket
+    would put socket deletion back in the daemon that caused the outage — and it
+    watches the per-session `cc-socks/` plane ONLY. CC's separate daemon tree
+    (`/tmp/cc-daemon-<uid>/`: control, pty and rendezvous sockets for the
+    background-spare machinery) is protected from deletion but deliberately not
+    counted: what severance means there is unestablished, and a number derived
+    from unverified failure semantics is a guess wearing a measurement's clothes.
+  * **YELLOW reaps SESSIONS, never PROJECTS.** The layout is
+    `claude-<uid>/<project>/<session-uuid>/`, and a project directory's mtime
+    tracks only its direct children — so it goes stale as soon as no NEW session
+    starts under it, however busy the sessions inside are. Measured 2026-09-07:
+    the one actively-used project directory carried an mtime 2.1 days old while
+    its contents were seconds old, and held 54 live session workspaces. Staleness
+    is therefore judged on CONTENTS, recursively, per session directory, and the
+    probe fails CLOSED — an undeterminable directory is kept.
+  * **ORANGE does not kill sessions.** It used to reap unattached tmux sessions
+    idle over 2h; sessions are not what fills cc-tmp, so that freed ~nothing
+    while destroying a session's whole context. Removed 2026-09-07 (measured: 1
+    reach and 0 kills across the entire log history). RED remains the pressure
+    valve and still reaps.
+
+  Deliberately NOT done: relocating the sockets out of cc-tmp. That is the real
+  fix — the control plane should not live in a directory whose purpose is to be
+  reclaimed — but a mixed-era fleet cannot see itself during the cutover (one
+  resolver in the CC binary serves both bind and discovery), so it waits on the
+  deploy path that restarts resident daemons.
 
 ## 13. Modules, skills & self-extension
 

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -35,6 +35,18 @@ ALERT_DIR="$HOME/.genesis/alerts"
 OOM_EVENTS_FILE="${OOM_EVENTS_FILE:-/sys/fs/cgroup/memory.events}"
 OOM_LOG="$(dirname "$LOG_FILE")/oom_events.log"
 
+# The socket-listing tool for the control-plane check. Overridable for the same
+# reason OOM_EVENTS_FILE is: it is the only way to exercise the "tool absent"
+# branch without rebuilding PATH from scratch, and an operator on a box where
+# iproute2 lives elsewhere can point at it.
+SS_BIN="${SS_BIN:-ss}"
+
+# Zone B's target. A literal /tmp made this whole zone untestable — a test would
+# have had to sweep the real one — which is why its sweeps had no coverage at all
+# until the 2026-09-07 socket-tree finding. Overridable purely as a seam; nothing
+# in production sets it.
+SYS_TMP_DIR="${SYS_TMP_DIR:-/tmp}"
+
 # Durable alert queue (F.3) — emergency-tier events page Telegram via the
 # container drainer. Guarded: if the lib is ever not co-located, degrade to a
 # no-op so `set -e` can never take the service down over an alert.
@@ -76,10 +88,10 @@ dir_usage_mb() {
 }
 
 tmp_usage_pct() {
-    if df -T /tmp 2>/dev/null | grep -q tmpfs; then
+    if df -T "$SYS_TMP_DIR" 2>/dev/null | grep -q tmpfs; then
         # tmpfs: filesystem percentage is meaningful
         local result
-        result=$(df --output=pcent /tmp 2>/dev/null | tail -1 | tr -d ' %') || true
+        result=$(df --output=pcent "$SYS_TMP_DIR" 2>/dev/null | tail -1 | tr -d ' %') || true
         echo "${result:-0}"
     else
         # Not tmpfs (/tmp on root disk): use absolute free space thresholds.
@@ -87,7 +99,7 @@ tmp_usage_pct() {
         # each, sacred ground is 150MB.  Percentage-based thresholds are
         # meaningless when measuring the whole root filesystem.
         local free_mb
-        free_mb=$(df -BM --output=avail /tmp 2>/dev/null | tail -1 | tr -d ' M') || true
+        free_mb=$(df -BM --output=avail "$SYS_TMP_DIR" 2>/dev/null | tail -1 | tr -d ' M') || true
         free_mb="${free_mb:-9999}"
         if (( free_mb > 2048 )); then echo 0       # >2GB free  → green
         elif (( free_mb > 1024 )); then echo 60     # 1-2GB free → yellow
@@ -127,10 +139,138 @@ reap_dir_sparing_sockets() {
     find "$1" -depth -not -type s -delete 2>/dev/null || true
 }
 
+# ── Control plane: severed CC messaging sockets ───────────────
+#
+# Claude Code binds ONE unix socket per session for cross-session messaging,
+# at `$XDG_RUNTIME_DIR/cc-socks/<pid>.sock` — falling back to the process temp
+# dir when XDG_RUNTIME_DIR is unset, which on a Genesis install is cc-tmp: the
+# very directory this daemon reclaims.
+#
+# Deleting the socket PATH does not stop the listener. The process keeps the
+# inode, so `ss` still reports LISTEN and the session looks healthy from the
+# inside, while every peer resolves BY PATH and gets ENOENT. Nothing re-binds
+# after startup, so the session stays unreachable for the rest of its life and
+# cannot notice. Measured 2026-09-05: one sweep severed 3 of 4 sessions here and
+# 6 of 6 on a sibling install; the only survivor had started after the sweep.
+#
+# The sweeps learned to spare sockets, which prevents recurrence but cannot heal
+# a session that is already severed. This check makes the state VISIBLE: it
+# compares live listeners against what is on disk, so a severance is reported
+# instead of silent. Strictly READ-ONLY — a stale socket file is counted and
+# never deleted, because deleting sockets from this daemon is what caused the
+# outage in the first place.
+#
+# Path-agnostic on purpose: directories come from the live listeners, so this
+# keeps working unchanged if the sockets move out of cc-tmp later.
+#
+# SCOPE. This watches the per-session MESSAGING sockets under `cc-socks/` only.
+# CC also runs a separate daemon tree (`/tmp/cc-daemon-<uid>/…` — control, pty and
+# rendezvous sockets for the background-spare machinery), which is deliberately
+# NOT counted here: what severance MEANS there has not been established, and
+# reporting on a subsystem whose failure semantics you have not verified is a
+# guess wearing a number. Those sockets are protected from deletion all the same
+# (see the Zone B sweeps) — protect what you do not understand, report only what
+# you do.
+#
+# Echoes "<status>:<severed>:<stale>:<listeners>". status is one of:
+#   ok      — the probe ran and saw at least one socket, live or left behind.
+#   empty   — the probe ran and saw NOTHING. Usually true (no CC sessions), but
+#             it is also what a detector that has gone blind looks like (an `ss`
+#             output change, a netns move, sockets relocating out of cc-socks),
+#             so it is NOT reported as health.
+#   unknown — the probe could not run at all. Never a clean plane: "could not
+#             measure" and "measured, and it is fine" must not share a value.
+check_control_plane() {
+    command -v "$SS_BIN" >/dev/null 2>&1 || { echo "unknown:0:0:0"; return 0; }
+
+    local raw rc=0
+    raw=$("$SS_BIN" -xlpH state listening 2>/dev/null) || rc=$?
+    if (( rc != 0 )); then
+        echo "unknown:0:0:0"
+        return 0
+    fi
+
+    local listeners=0 severed=0 stale=0
+    local -A live=()
+    local -A dirs=()
+    # Always scan cc-tmp's own socket dir, even when no listener points there:
+    # on a fully-severed install every listener path is already gone from disk,
+    # and that is exactly when the leftovers still need counting. `%/` because
+    # watchgod.conf is re-sourced every poll and a trailing slash there would
+    # otherwise build keys that never match the ones `find` produces.
+    dirs["${CC_TMP_DIR%/}/cc-socks"]=1
+
+    local path
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        listeners=$(( listeners + 1 ))
+        live["$path"]=1
+        dirs["$(dirname "$path")"]=1
+        # -S is "exists AND is a socket": a path replaced by an ordinary file is
+        # no more reachable than a missing one, so it counts as severed too.
+        [[ -S "$path" ]] || severed=$(( severed + 1 ))
+        # NOTE: `ss -xlp` lists every user's sockets. On a shared box another
+        # user's cc-socks path would be counted here, and an unstattable one
+        # would read as severed. Genesis is single-user by design, so this is
+        # left as a known limitation rather than engineered around.
+    done < <(awk '$4 ~ /\/cc-socks\/.*\.sock$/ {print $4}' <<<"$raw" | sort -u)
+
+    local d f
+    for d in "${!dirs[@]}"; do
+        [[ -d "$d" ]] || continue
+        while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            [[ -n "${live[$f]:-}" ]] || stale=$(( stale + 1 ))
+        done < <(find "$d" -maxdepth 1 -type s -name '*.sock' 2>/dev/null)
+    done
+
+    if (( listeners == 0 && stale == 0 )); then
+        echo "empty:0:0:0"
+        return 0
+    fi
+    echo "ok:${severed}:${stale}:${listeners}"
+}
+
+# Should this control-plane reading page, and at what level is the plane now
+# "reported"? Pure arithmetic, kept out of the poll loop so the two rules below
+# can be tested without running the daemon.
+#
+#   CONFIRMATION — the SAME elevated count must appear on two consecutive polls,
+#   which is stricter than "elevated twice": a count still climbing (1 -> 2 -> 3)
+#   stays silent until it settles, and one that oscillates never pages at all.
+#   Severance is permanent — nothing re-binds — so a real one always settles,
+#   usually within a poll or two. What this buys is the false positive: a session
+#   exiting between ss's snapshot and its own unlink reads as one severed listener
+#   for a single poll, and a monitor that cries wolf gets ignored.
+#
+#   HIGH WATER THAT FOLLOWS DOWN — `paged` is the level already reported, and it
+#   drops with the count. Without that, sessions being restarted (4 -> 0) would
+#   leave the bar at 4 and a later, smaller severance would never page.
+#
+# Args: <prev-count> <already-paged-level> <current-count>.
+# Echoes "<0|1 page>:<new already-paged level>".
+control_plane_page_decision() {
+    local prev="$1" paged="$2" severed="$3"
+    if (( severed < paged )); then
+        paged=$severed
+    fi
+    if (( severed > paged )) && (( severed == prev )); then
+        echo "1:${severed}"
+    else
+        echo "0:${paged}"
+    fi
+}
+
 write_state() {
     local cc_tier="$1" cc_used="$2" sys_tier="$3" sys_pct="$4"
+    # Control-plane tuple from check_control_plane, "status:severed:stale:listeners".
+    # Defaulted so a caller that predates this field (the existing tier tests)
+    # still writes a valid state file.
+    local cp="${5:-unknown:0:0:0}"
+    local cp_status cp_severed cp_stale cp_listeners
+    IFS=: read -r cp_status cp_severed cp_stale cp_listeners <<<"$cp"
     local is_tmpfs="false"
-    if df -T /tmp 2>/dev/null | grep -q tmpfs; then
+    if df -T "$SYS_TMP_DIR" 2>/dev/null | grep -q tmpfs; then
         is_tmpfs="true"
     fi
     # Filesystem headroom for cc-tmp's mount. Post-split these describe the
@@ -144,6 +284,7 @@ write_state() {
 {
   "cc_tmp": {"tier": "$cc_tier", "used_mb": $cc_used, "budget_mb": $CC_TMP_BUDGET_MB, "sacred_mb": $SACRED_GROUND_MB, "fs_free_mb": $cc_fs_free, "fs_total_mb": $cc_fs_total},
   "system_tmp": {"tier": "$sys_tier", "used_pct": $sys_pct, "is_tmpfs": $is_tmpfs},
+  "control_plane": {"status": "${cp_status:-unknown}", "severed_sockets": ${cp_severed:-0}, "stale_sockets": ${cp_stale:-0}, "listeners": ${cp_listeners:-0}},
   "poll_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 EOF
@@ -155,15 +296,68 @@ EOF
 # Tiers (% of budget):
 #   Green  : < 50%  — no action
 #   Yellow : > 50%  — clean stale session dirs + old temp files
-#   Orange : > 75%  — yellow + delete caches + kill idle sessions + alert
+#   Orange : > 75%  — yellow + delete caches + warn (never kills a session)
 #   Red    : > 90% OR fs free < sacred — nuclear cleanup + emergency alert
+
+# The 7-day session reap. Two things here are load-bearing, and both were wrong
+# before (measured on a live install, 2026-09-07):
+#
+#   DEPTH. The layout under cc-tmp is claude-<uid>/<project>/<session-uuid>/…,
+#   so depth 2 is the PROJECT directory, not a session. On this install one
+#   depth-2 directory held 54 session workspaces — every live session's
+#   scratchpad and its running background-task output. The intended target has
+#   always been the depth-3 per-SESSION directory.
+#
+#   STALENESS. A directory's mtime tracks only its DIRECT children, so a project
+#   directory goes stale the moment no NEW session starts under it, however busy
+#   the sessions inside are. Measured: the one actively-used project directory
+#   carried an mtime 2.1 days old while its contents had been written seconds
+#   earlier, and every dormant directory showed no divergence at all — the gap
+#   appears precisely on the directory that must not be deleted. Seven quiet days
+#   and a routine 50%-usage YELLOW would have reaped live workspaces at a tier
+#   that pages nobody. So staleness is tested against the CONTENTS, recursively.
+#
+# The freshness probe fails CLOSED: a directory whose freshness cannot be
+# determined counts as fresh and is kept. Deleting on an unreadable probe is how
+# one broken predicate turns a housekeeping sweep into total data loss.
+reap_stale_session_dirs() {
+    local cutoff
+    cutoff=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || cutoff=""
+    if [[ -z "$cutoff" ]]; then
+        log WARN "session reap skipped — could not compute the 7-day cutoff"
+        return 0
+    fi
+
+    local sdir probe rc
+    while IFS= read -r sdir; do
+        [[ -z "$sdir" ]] && continue
+        rc=0
+        probe=$(find "$sdir" -newermt "$cutoff" -print -quit 2>/dev/null) || rc=$?
+        if (( rc == 0 )) && [[ -z "$probe" ]]; then
+            # Socket-sparing, like every other sweep in this file. A socket's
+            # mtime is its BIND time, so a session that bound one here and then
+            # wrote nothing for seven days reads as stale — and a plain `rm -rf`
+            # would have this daemon sever a live session in the very sweep added
+            # to stop it doing that. The rmdir then succeeds only if nothing
+            # survived, which is exactly the intent.
+            reap_dir_sparing_sockets "$sdir"
+            rmdir "$sdir" 2>/dev/null || true
+        fi
+    done < <(find "$CC_TMP_DIR" -mindepth 3 -maxdepth 3 -type d -path "*/claude-*/*/*" 2>/dev/null)
+
+    # A project directory the reap emptied holds nothing, and without this they
+    # accumulate. `-mtime +7` is not about staleness here — an empty directory has
+    # nothing to be stale — it closes a race: CC creates <project>/ and then
+    # <session-uuid>/ as two steps, and an rmdir landing between them gives the
+    # starting session ENOENT. A directory created moments ago cannot match.
+    find "$CC_TMP_DIR" -mindepth 2 -maxdepth 2 -type d -path "*/claude-*/*" -empty \
+        -mtime +7 -delete 2>/dev/null || true
+}
 
 clean_cc_yellow() {
     log INFO "Zone A YELLOW — cleaning stale session dirs and temp files"
 
-    # Clean session dirs with mtime > 7 days
-    find "$CC_TMP_DIR" -mindepth 2 -maxdepth 2 -type d -path "*/claude-*/???*" \
-        -mtime +7 -exec rm -rf {} + 2>/dev/null || true
+    reap_stale_session_dirs
 
     # Clean old temp files (*.tmp, *.env, *.yaml) > 1 hour old
     find "$CC_TMP_DIR" -type f \( -name "*.tmp" -o -name "*.env" -o -name "*.yaml" \) \
@@ -172,7 +366,7 @@ clean_cc_yellow() {
 
 clean_cc_orange() {
     clean_cc_yellow
-    log WARN "Zone A ORANGE — deleting caches, then re-measuring before any session kill"
+    log WARN "Zone A ORANGE — deleting caches, then re-measuring (ORANGE never kills a session)"
 
     # Delete claude-skills cache (~35MB, CC re-clones on demand)
     find "$CC_TMP_DIR" -type d -name "claude-skills" -exec rm -rf {} + 2>/dev/null || true
@@ -183,62 +377,36 @@ clean_cc_orange() {
     mkdir -p "$ALERT_DIR"
     touch "$ALERT_DIR/tmp_warning"
 
-    # LOOP-BREAK: re-measure AFTER the cleanup above and kill idle sessions ONLY
-    # if we're still over the ORANGE line. This closes the runaway that killed no
-    # session but churned for ~4.5h on 2026-08-19: the tier that dispatched us
-    # here was measured BEFORE cleanup, so without a re-measure the daemon would
-    # re-enter ORANGE every poll and re-run the kill loop forever while the real
-    # filler (a pytest tree the cache-evict never touches) sat untouched. Killing
-    # an idle session cannot reduce cc-tmp anyway (sessions aren't the filler), so
-    # a kill here is at best useless and at worst reaps an innocent bystander.
-    # Use dir_usage_mb (du) — it drops immediately after rm; df can lag on
-    # held-open deleted fds.
+    # Re-measure AFTER the cleanup above. Use dir_usage_mb (du) — it drops
+    # immediately after rm, where df can lag on held-open deleted fds.
+    #
+    # ORANGE DOES NOT KILL SESSIONS. It used to reap unattached tmux sessions
+    # idle over 2h, and the loop-break comment that guarded it already made the
+    # case against itself: sessions are not what fills cc-tmp, so a kill here
+    # reclaims essentially nothing while destroying a session's entire context.
+    # That is the exact inversion this daemon must not make — it exists to stop
+    # runaway usage from killing CC, not to kill CC to tidy up. The measurement
+    # settles the cost of removing it: across the whole log history
+    # (2026-08-19 → 2026-09-07, 7,563 lines, 1,029 ORANGE polls) the kill loop
+    # was reached ONCE and killed ZERO sessions, so removal is behaviour-neutral
+    # on the record we have. RED remains the pressure valve and still reaps.
     local used_after threshold_orange
     used_after=$(dir_usage_mb "$CC_TMP_DIR")
     threshold_orange=$(( CC_TMP_BUDGET_MB * 75 / 100 ))
     if (( used_after <= threshold_orange )); then
-        log INFO "ORANGE resolved by cache cleanup (used=${used_after}MB <= ${threshold_orange}MB) — no session kills"
+        log INFO "ORANGE resolved by cache cleanup (used=${used_after}MB <= ${threshold_orange}MB)"
         rm -f "$ALERT_DIR/tmp_orange_stuck" 2>/dev/null || true
         return 0
     fi
 
-    log WARN "ORANGE persists after cleanup (used=${used_after}MB > ${threshold_orange}MB) — evaluating idle sessions"
-    # Kill idle CC tmux sessions (unattached, idle > 2h)
-    local killed_any=0
-    while IFS= read -r session; do
-        [[ -z "$session" ]] && continue
-        local sname
-        sname=$(echo "$session" | cut -d: -f1)
-        if [[ "$sname" =~ ^cc- ]]; then
-            local last_activity
-            last_activity=$(tmux display-message -t "$sname" -p '#{session_activity}' 2>/dev/null || echo 0)
-            local now
-            now=$(date +%s)
-            local idle_s=$(( now - last_activity ))
-            if (( idle_s > 7200 )); then
-                log WARN "Killing idle CC session: $sname (idle ${idle_s}s)"
-                # Count a reap only when tmux actually killed it — if the session
-                # vanished between listing and killing (or the kill fails), we
-                # reclaimed nothing, so killed_any must stay 0 and the stuck
-                # marker must still be recorded rather than silently skipped.
-                if tmux kill-session -t "$sname" 2>/dev/null; then
-                    killed_any=1
-                fi
-            fi
-        fi
-    done < <(tmux list-sessions -F '#{session_name}:#{session_attached}' 2>/dev/null | grep ':0$' || true)
-
-    # Stuck-ORANGE: cleanup didn't resolve it AND nothing was killable → the
-    # daemon has nothing safe left to do. Per design D2 (ORANGE is dashboard/log
-    # only — only RED pages) this does NOT page; it records the stuck state ONCE
-    # (dedupe flag) in the log instead of silently re-polling forever, so the
-    # condition is discoverable. If cc-tmp keeps filling it escalates to RED,
-    # which DOES page. The flag is cleared (main loop) whenever cc-tmp LEAVES
-    # ORANGE (green/yellow/red) — never on a kill: reaping an idle session does
-    # not reduce cc-tmp, so a kill that leaves us ORANGE keeps cc_tier==orange and
-    # must not re-arm and re-log the same episode.
-    if (( killed_any == 0 )) && [[ ! -f "$ALERT_DIR/tmp_orange_stuck" ]]; then
-        log WARN "cc-tmp STUCK ORANGE (used=${used_after}MB, budget=${CC_TMP_BUDGET_MB}MB): reclaim freed nothing and no idle (>2h) session is killable — non-reclaimable data is filling cc-tmp (see cc_tmp_top snapshots). Dashboard/log-only per D2; RED will page if it escalates."
+    # Stuck-ORANGE: the cleanup did not resolve it and there is nothing else safe
+    # to do. Per design D2 (ORANGE is dashboard/log only — only RED pages) this
+    # does NOT page; it records the stuck state ONCE (dedupe flag) so the
+    # condition is discoverable instead of silently re-polling forever. If cc-tmp
+    # keeps filling it escalates to RED, which DOES page. The flag is cleared in
+    # the main loop whenever cc-tmp LEAVES ORANGE.
+    if [[ ! -f "$ALERT_DIR/tmp_orange_stuck" ]]; then
+        log WARN "cc-tmp STUCK ORANGE (used=${used_after}MB, budget=${CC_TMP_BUDGET_MB}MB): reclaim freed nothing — non-reclaimable data is filling cc-tmp (see cc_tmp_top snapshots). Dashboard/log-only per D2; RED will page if it escalates."
         touch "$ALERT_DIR/tmp_orange_stuck"
     fi
 }
@@ -371,16 +539,27 @@ check_cc_tmp() {
 
 clean_sys_yellow() {
     log INFO "Zone B YELLOW — cleaning /tmp files not accessed in 7+ days"
-    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
+    find "$SYS_TMP_DIR" -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
         -atime +7 -delete 2>/dev/null || true
-    find /tmp -mindepth 1 -type d -empty -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" \
+    # The file sweeps above spare `*.sock`; this one must spare their DIRECTORIES,
+    # which the socket exclusion cannot cover. MEASURED 2026-09-07: this predicate
+    # matched `/tmp/cc-socks` and `/tmp/cc-daemon-1000/<id>/pty` — the latter an
+    # empty rendezvous directory inside a LIVE CC daemon's tree, created up front
+    # and populated later. An empty directory under a socket tree is a rendezvous
+    # point, not garbage, and deleting one is the same failure class as deleting
+    # the socket itself. (An earlier audit of this sweep called it safe "because
+    # socket-holding dirs are non-empty" — true of the directory holding the
+    # socket, false of its siblings.)
+    find "$SYS_TMP_DIR" -mindepth 1 -type d -empty \
+        -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" \
+        -not -path "*/cc-socks*" -not -path "*/cc-daemon-*" \
         -delete 2>/dev/null || true
 }
 
 clean_sys_orange() {
     clean_sys_yellow
     log WARN "Zone B ORANGE — cleaning /tmp files not accessed in 3+ days"
-    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
+    find "$SYS_TMP_DIR" -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
         -atime +3 -delete 2>/dev/null || true
     mkdir -p "$ALERT_DIR"
     touch "$ALERT_DIR/tmp_warning"
@@ -389,14 +568,14 @@ clean_sys_orange() {
 clean_sys_red() {
     log WARN "Zone B RED — aggressive /tmp cleanup"
     # Files not accessed in 1+ day
-    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
+    find "$SYS_TMP_DIR" -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
         -atime +1 -delete 2>/dev/null || true
 
     # If still critical, remove all regular files except last 1h, sockets, tmux, pytest, claude
     local pct_after
     pct_after=$(tmp_usage_pct)
     if (( pct_after > 85 )); then
-        find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
+        find "$SYS_TMP_DIR" -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
             -mmin +60 -delete 2>/dev/null || true
     fi
 
@@ -498,19 +677,84 @@ main() {
         log INFO "OOM event capture armed (baseline oom_kill=${oom_baseline})"
     fi
 
+    # Control-plane paging state. `prev` is the previous poll's count and starts
+    # at -1 so no page can fire on the daemon's very first reading — an elevated
+    # count must be CONFIRMED by a second consecutive poll. Without that, a
+    # session exiting between ss's snapshot and its own unlink reads as one
+    # severed listener for a single poll and would page spuriously.
+    #
+    # `paged` is the level already reported. It survives a restart in a file, the
+    # way the RED tier's transition marker does: the unit is Restart=always, a
+    # severance is UNHEALABLE without restarting the sessions, and an in-memory
+    # level would therefore re-page the same unfixed condition after every deploy
+    # or crash-restart. It still follows the count DOWN, so once the sessions ARE
+    # restarted a later, smaller severance pages again.
+    local cp_prev_severed=-1 cp_last=""
+    local cp_paged_file="$ALERT_DIR/control_plane_paged"
+    local cp_paged_severed
+    cp_paged_severed=$(cat "$cp_paged_file" 2>/dev/null) || cp_paged_severed=""
+    [[ "$cp_paged_severed" =~ ^[0-9]+$ ]] || cp_paged_severed=0
+
     while true; do
         load_config
 
-        local cc_result sys_result
+        local cc_result sys_result cp_result
         cc_result=$(check_cc_tmp)
         sys_result=$(check_sys_tmp)
+        cp_result=$(check_control_plane)
 
         local cc_tier="${cc_result%%:*}"
         local cc_used="${cc_result##*:}"
         local sys_tier="${sys_result%%:*}"
         local sys_pct="${sys_result##*:}"
 
-        write_state "$cc_tier" "$cc_used" "$sys_tier" "$sys_pct"
+        write_state "$cc_tier" "$cc_used" "$sys_tier" "$sys_pct" "$cp_result"
+
+        local cp_status cp_severed cp_stale cp_listeners
+        IFS=: read -r cp_status cp_severed cp_stale cp_listeners <<<"$cp_result"
+
+        # Log only on CHANGE — this runs every poll and an unchanged plane has
+        # nothing to say.
+        if [[ "$cp_result" != "$cp_last" ]]; then
+            case "$cp_status" in
+                ok)
+                    log INFO "control plane: ${cp_listeners} listener(s), ${cp_severed} severed (socket path deleted under a live listener), ${cp_stale} stale socket file(s)" ;;
+                empty)
+                    log INFO "control plane: no CC sockets visible — either no session is running, or this check can no longer see them" ;;
+                *)
+                    log INFO "control plane: unknown (${SS_BIN} unavailable or failed) — severance cannot be detected on this box" ;;
+            esac
+            cp_last="$cp_result"
+        fi
+
+        if [[ "$cp_status" == "ok" ]]; then
+            local cp_decision cp_should_page
+            cp_decision=$(control_plane_page_decision \
+                "$cp_prev_severed" "$cp_paged_severed" "$cp_severed")
+            cp_should_page="${cp_decision%%:*}"
+            cp_paged_severed="${cp_decision##*:}"
+            printf '%s' "$cp_paged_severed" > "$cp_paged_file" 2>/dev/null || true
+            if [[ "$cp_should_page" == "1" ]]; then
+                log WARN "control plane SEVERED: ${cp_severed} of ${cp_listeners} session(s) unreachable"
+                # `warning` is the honest severity for the event, but note it does
+                # NOT buy a quieter delivery: the container drain submits every
+                # queued entry at one category and salience regardless of this
+                # argument, so this pages exactly like the RED emergency does.
+                # That is intended here (the owner asked to be paged on a NEW
+                # severance) — recorded so nobody infers a tier that does not exist.
+                queue_alert warning "watchgod:control-plane" \
+                    "CC control plane severed (${cp_severed} session(s) unreachable)" \
+                    "${cp_severed} of ${cp_listeners} live Claude Code session(s) are listening on a socket whose PATH no longer exists, so peers get ENOENT and cannot reach them. Nothing re-binds after startup — the only remedy is restarting those sessions. Check what deleted the paths under cc-socks." \
+                    "watchgod:control_plane:${cp_severed}"
+            fi
+            cp_prev_severed=$cp_severed
+        else
+            # Neither `unknown` nor `empty` is a recovery: forget the previous
+            # count so the next readable one needs its own confirmation, and leave
+            # the already-paged level alone so a blind spell cannot silently
+            # re-arm a page for a severance that was already reported.
+            cp_prev_severed=-1
+        fi
 
         # Durable OOM capture — snapshot + page on any NEW cgroup OOM kill.
         oom_baseline=$(check_oom_events "$oom_baseline")

--- a/src/genesis/observability/service_status.py
+++ b/src/genesis/observability/service_status.py
@@ -300,6 +300,18 @@ def collect_cc_tmp_usage() -> dict:
         data = json.loads(_TMP_WATCHGOD_STATE.read_text())
         cc = data.get("cc_tmp", {})
         sys_tmp = data.get("system_tmp", {})
+        # Control plane: how many live CC sessions are listening on a socket path
+        # that no longer exists (severed → unreachable by peers, and unable to
+        # notice), plus socket files no process holds. Defaults to `unknown`
+        # rather than a zero, so a state file written before this field existed —
+        # or by a daemon that could not run the probe — never reads as healthy.
+        cp = data.get("control_plane")
+        if not isinstance(cp, dict):
+            # Absent, null, or a hand-edited/truncated state file. `.get` on a
+            # non-dict raises AttributeError, which the handler below does not
+            # catch and the infrastructure-snapshot caller does not either — so an
+            # unreadable field would take the whole snapshot down.
+            cp = {}
         return {
             "cc_tier": cc.get("tier", "unknown"),
             "cc_used_mb": cc.get("used_mb", 0),
@@ -309,6 +321,12 @@ def collect_cc_tmp_usage() -> dict:
             "cc_fs_total_mb": cc.get("fs_total_mb", None),
             "sys_tier": sys_tmp.get("tier", "unknown"),
             "sys_used_pct": sys_tmp.get("used_pct", 0),
+            "control_plane": {
+                "status": cp.get("status", "unknown"),
+                "severed_sockets": cp.get("severed_sockets", 0),
+                "stale_sockets": cp.get("stale_sockets", 0),
+                "listeners": cp.get("listeners", 0),
+            },
             "poll_at": data.get("poll_at", ""),
         }
     except (json.JSONDecodeError, OSError):

--- a/tests/test_observability/test_service_status.py
+++ b/tests/test_observability/test_service_status.py
@@ -234,3 +234,76 @@ class TestDetectGenesisService:
             side_effect=self._side_effect(server_installed=False, relay_active=False),
         ):
             assert _detect_genesis_service() == ("genesis-server.service", "Server")
+
+
+class TestCollectCcTmpUsageControlPlane:
+    """The control-plane counts must survive the read from the watchgod state file.
+
+    The state JSON is the only channel between the daemon that can SEE a severed
+    CC messaging socket and anything that can show it to a human, so a field that
+    the reader drops is a detector that reports to nobody.
+
+    The `unknown` cases matter as much as the populated one: a state file written
+    before this field existed, or written by a daemon whose probe could not run,
+    must never read as a healthy plane. "Could not measure" and "measured, and it
+    is fine" cannot share a value.
+    """
+
+    @staticmethod
+    def _read(tmp_path, payload: dict) -> dict:
+        state = tmp_path / "watchgod_state.json"
+        state.write_text(json.dumps(payload))
+        with patch(
+            "genesis.observability.service_status._TMP_WATCHGOD_STATE", state
+        ):
+            from genesis.observability.service_status import collect_cc_tmp_usage
+
+            return collect_cc_tmp_usage()
+
+    _BASE = {
+        "cc_tmp": {"tier": "green", "used_mb": 128, "budget_mb": 500},
+        "system_tmp": {"tier": "green", "used_pct": 0},
+        "poll_at": "2026-09-07T21:36:04Z",
+    }
+
+    def test_counts_are_passed_through(self, tmp_path):
+        result = self._read(
+            tmp_path,
+            {
+                **self._BASE,
+                "control_plane": {
+                    "status": "ok",
+                    "severed_sockets": 4,
+                    "stale_sockets": 1,
+                    "listeners": 5,
+                },
+            },
+        )
+        assert result["control_plane"] == {
+            "status": "ok",
+            "severed_sockets": 4,
+            "stale_sockets": 1,
+            "listeners": 5,
+        }
+        assert result["cc_tier"] == "green", "the existing fields must be untouched"
+
+    def test_missing_field_reads_as_unknown_not_healthy(self, tmp_path):
+        """A state file from a daemon that predates the detector."""
+        result = self._read(tmp_path, self._BASE)
+        assert result["control_plane"]["status"] == "unknown"
+
+    def test_daemon_reported_unknown_is_preserved(self, tmp_path):
+        """The daemon could not run its probe; that is not zero severed sockets."""
+        result = self._read(
+            tmp_path,
+            {
+                **self._BASE,
+                "control_plane": {
+                    "status": "unknown",
+                    "severed_sockets": 0,
+                    "stale_sockets": 0,
+                    "listeners": 0,
+                },
+            },
+        )
+        assert result["control_plane"]["status"] == "unknown"

--- a/tests/test_scripts/test_watchgod_control_plane.py
+++ b/tests/test_scripts/test_watchgod_control_plane.py
@@ -1,0 +1,325 @@
+"""tmp_watchgod's severed-control-plane detector.
+
+WHAT IT DETECTS. Claude Code binds one unix socket per session for cross-session
+messaging. Deleting the socket's PATH does not stop the listener: the process
+keeps the inode, so `ss` still reports LISTEN and the session looks healthy from
+the inside, while every peer resolves BY PATH and gets ENOENT. Nothing re-binds
+after startup, so the session is unreachable for the rest of its life and cannot
+notice. Measured 2026-09-05, when a cleanup sweep deleted those paths: 3 of 4
+sessions severed on one install and 6 of 6 on a sibling — and the only signal
+anyone had was peers mysteriously failing to answer.
+
+The sweeps now spare sockets, which stops recurrence but cannot heal a session
+already severed. This detector makes the state visible so a new severance is
+never silent again.
+
+WHAT THESE TESTS PIN, in order of how they fail:
+
+  * severed  — a listener whose path is gone, or has been replaced by something
+    that is not a socket. This is the incident.
+  * stale    — a socket file with no listener. Reported and NEVER deleted:
+    deleting sockets from this daemon is what caused the outage.
+  * unknown  — ss missing or failing. A monitor whose probe did not run must not
+    report a clean plane; "could not measure" and "measured, and it is fine"
+    never share a value.
+  * empty    — the probe ran and saw nothing. Usually true, and also what a
+    detector that has gone blind looks like, so it is not reported as health.
+  * the paging rules — confirmation before paging, and a high-water mark that
+    follows the count back down.
+
+WHAT THESE ARE NOT: regression cover. `check_control_plane` and
+`control_plane_page_decision` are new, so running these against `origin/main` only
+proves a function name is absent. They are CONTRACT tests for a new detector, and
+the two `write_state` cases are the only ones that exercise a pre-existing
+function. The one lock worth naming is
+`test_stale_socket_file_is_counted_and_kept`, which fails the moment anyone adds
+a delete to a function whose whole contract is that it never deletes.
+
+`ss` is a PATH-prepended STUB emitting whatever rows a test wants, so no test
+depends on the machine's real sockets. Socket inodes come from ``os.mknod``,
+which has no AF_UNIX ``sun_path`` length limit — a real ``bind()`` under pytest's
+tmp_path would exceed 108 bytes and fail (the same trap the sibling
+socket-sparing suite documents).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_WATCHGOD = Path(__file__).resolve().parents[2] / "scripts" / "tmp_watchgod.sh"
+
+# Reproduces `ss -xlpH state listening` output shape: netid, queues, path, inode,
+# peer, peer-port, then the users:(...) column. STUB_SS_ROWS holds one
+# "<path> <pid>" pair per line; STUB_SS_RC forces a failure exit.
+_SS_STUB = r"""#!/usr/bin/env bash
+rc="${STUB_SS_RC:-0}"
+if (( rc != 0 )); then exit "$rc"; fi
+while IFS=' ' read -r p pid; do
+  [[ -z "$p" ]] && continue
+  printf 'u_str 0      512        %s 12345 * 0 users:(("claude",pid=%s,fd=11))\n' "$p" "$pid"
+done <<< "${STUB_SS_ROWS:-}"
+exit 0
+"""
+
+_TMUX_STUB = "#!/usr/bin/env bash\nexit 0\n"
+
+
+def _make_exec(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _sandbox(tmp_path: Path) -> tuple[Path, Path, Path]:
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    (home / ".genesis" / "alerts").mkdir(parents=True)
+    cctmp = home / ".genesis" / "cc-tmp"
+    cctmp.mkdir(parents=True)
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    _make_exec(bind / "ss", _SS_STUB)
+    _make_exec(bind / "tmux", _TMUX_STUB)
+    return home, cctmp, bind
+
+
+def _run(
+    home: Path, bind: Path, snippet: str, rows: str = "", ss_rc: int = 0, ss_bin: str = ""
+) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(
+        HOME=str(home),
+        PATH=f"{bind}:{os.environ['PATH']}",
+        STUB_SS_ROWS=rows,
+        STUB_SS_RC=str(ss_rc),
+    )
+    if ss_bin:
+        env["SS_BIN"] = ss_bin
+    return subprocess.run(
+        ["bash", "-c", f"source '{_WATCHGOD}'\n{snippet}"],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _mksock(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.mknod(path, stat.S_IFSOCK | 0o600)
+
+
+def _probe(home: Path, bind: Path, rows: str = "", **kw) -> str:
+    proc = _run(home, bind, "check_control_plane", rows=rows, **kw)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    return proc.stdout.strip()
+
+
+# ── severed ──────────────────────────────────────────────────────────────
+
+
+def test_severed_listener_is_counted(tmp_path):
+    """The incident: a live listener whose socket path has been deleted."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    gone = cctmp / "cc-socks" / "111.sock"
+    gone.parent.mkdir(parents=True)  # dir survives, file does not
+    assert _probe(home, bind, f"{gone} 111") == "ok:1:0:1"
+
+
+def test_healthy_listener_is_not_severed(tmp_path):
+    """A listener whose path is on disk is exactly what health looks like."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    live = cctmp / "cc-socks" / "222.sock"
+    _mksock(live)
+    assert _probe(home, bind, f"{live} 222") == "ok:0:0:1"
+
+
+def test_non_socket_at_the_path_counts_as_severed(tmp_path):
+    """A path occupied by an ordinary file is no more reachable than a missing
+    one — `-e` would call this healthy, which is why the check is `-S`."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    impostor = cctmp / "cc-socks" / "333.sock"
+    impostor.parent.mkdir(parents=True)
+    impostor.write_text("not a socket")
+    assert _probe(home, bind, f"{impostor} 333") == "ok:1:0:1"
+
+
+def test_incident_replay_mixed_population(tmp_path):
+    """The measured live shape at build time: several severed listeners, one
+    healthy survivor, and one socket file left by a dead process — reported as
+    `ok:4:1:5`, which is what this install's real `ss` produced."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    socks = cctmp / "cc-socks"
+    socks.mkdir(parents=True)
+    survivor = socks / "2501887.sock"
+    _mksock(survivor)
+    _mksock(socks / "3794276.sock")  # dead pid's leftover — stale, not severed
+    rows = "\n".join(
+        [
+            f"{socks}/3689517.sock 3689517",
+            f"{socks}/2864896.sock 2864896",
+            f"{socks}/3265893.sock 3265893",
+            f"{socks}/1859653.sock 1859653",
+            f"{survivor} 2501887",
+        ]
+    )
+    assert _probe(home, bind, rows) == "ok:4:1:5"
+
+
+# ── stale ────────────────────────────────────────────────────────────────
+
+
+def test_stale_socket_file_is_counted_and_kept(tmp_path):
+    """A socket with no listener is counted — and must still exist afterwards.
+    This detector is read-only by contract."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    orphan = cctmp / "cc-socks" / "444.sock"
+    _mksock(orphan)
+    assert _probe(home, bind, "") == "ok:0:1:0"
+    assert orphan.exists(), "the detector deleted a socket; it must never delete"
+
+
+def test_stale_is_found_with_no_listeners_at_all(tmp_path):
+    """A fully-severed install has no listener path on disk to derive a directory
+    from, which is exactly when the leftovers still need counting — so cc-tmp's
+    own socket dir is always scanned."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    _mksock(cctmp / "cc-socks" / "555.sock")
+    gone = cctmp / "cc-socks" / "666.sock"
+    assert _probe(home, bind, f"{gone} 666") == "ok:1:1:1"
+
+
+# ── path-agnostic ────────────────────────────────────────────────────────
+
+
+def test_listener_outside_cc_tmp_is_covered(tmp_path):
+    """Directories come from the live listeners, not from a hardcoded location,
+    so this keeps working unchanged when the sockets move to the runtime dir."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    runtime = tmp_path / "run" / "user" / "1000" / "cc-socks"
+    runtime.mkdir(parents=True)
+    healthy = runtime / "777.sock"
+    _mksock(healthy)
+    _mksock(runtime / "888.sock")  # stale, in the non-cc-tmp directory
+    assert _probe(home, bind, f"{healthy} 777") == "ok:0:1:1"
+
+
+# ── unknown ──────────────────────────────────────────────────────────────
+
+
+def test_ss_failure_reports_unknown_not_healthy(tmp_path):
+    """A probe that could not run must never look like a clean plane."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _probe(home, bind, "", ss_rc=1) == "unknown:0:0:0"
+
+
+def test_ss_absent_reports_unknown(tmp_path):
+    """Same when the tool is not installed at all — the box simply cannot answer.
+    Pointed at a name that does not exist rather than emptying PATH, which would
+    take `bash` and the rest of the script's own tools with it."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    _mksock(_cctmp / "cc-socks" / "999.sock")  # present, and still not counted
+    assert _probe(home, bind, "", ss_bin="watchgod-no-such-tool") == "unknown:0:0:0"
+
+
+# ── empty ────────────────────────────────────────────────────────────────
+
+
+def test_nothing_visible_is_empty_not_ok(tmp_path):
+    """The residual hole in a two-value design, closed with a third value.
+
+    A probe that ran and saw nothing is usually the truth (no CC session is up),
+    but it is ALSO exactly what a detector that has gone blind looks like — an
+    `ss` output change, a netns move, sockets relocating out of `cc-socks`. Both
+    of those would otherwise report as `ok`, which is the one thing they are not.
+    """
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _probe(home, bind, "") == "empty:0:0:0"
+
+
+def test_a_lone_stale_socket_is_still_ok_not_empty(tmp_path):
+    """`empty` means the probe saw NOTHING. A leftover socket file is something,
+    so the plane is visible and the status is `ok` with a stale count."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    _mksock(cctmp / "cc-socks" / "111.sock")
+    assert _probe(home, bind, "") == "ok:0:1:0"
+
+
+# ── state file ───────────────────────────────────────────────────────────
+
+
+def test_state_file_carries_the_control_plane(tmp_path):
+    """The state JSON is the only channel a reader has — the counts must land in
+    it, and it must stay parseable."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    proc = _run(home, bind, 'write_state green 10 green 5 "ok:2:1:6"')
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    state = json.loads((home / ".genesis" / "watchgod_state.json").read_text())
+    assert state["control_plane"] == {
+        "status": "ok",
+        "severed_sockets": 2,
+        "stale_sockets": 1,
+        "listeners": 6,
+    }
+
+
+def test_state_file_without_a_control_plane_argument_stays_valid(tmp_path):
+    """The argument is defaulted, so a caller that predates the field still
+    writes valid JSON — and it says `unknown`, never a fabricated zero."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    proc = _run(home, bind, "write_state green 10 green 5")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    state = json.loads((home / ".genesis" / "watchgod_state.json").read_text())
+    assert state["control_plane"]["status"] == "unknown"
+    assert state["cc_tmp"]["tier"] == "green"
+
+
+# ── paging rules ─────────────────────────────────────────────────────────
+
+
+def _decide(home: Path, bind: Path, prev: int, paged: int, severed: int) -> str:
+    proc = _run(home, bind, f"control_plane_page_decision {prev} {paged} {severed}")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    return proc.stdout.strip()
+
+
+def test_first_elevated_reading_does_not_page(tmp_path):
+    """Confirmation rule: the daemon's very first reading (prev = -1) cannot page.
+    A session exiting between ss's snapshot and its own unlink shows up as one
+    severed listener for a single poll, and a monitor that cries wolf gets
+    ignored."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _decide(home, bind, -1, 0, 4) == "0:0"
+
+
+def test_confirmed_rise_pages_once(tmp_path):
+    """The same count on two consecutive polls is a real severance — page, and
+    record the level so the next identical poll stays quiet."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _decide(home, bind, 4, 0, 4) == "1:4"
+    assert _decide(home, bind, 4, 4, 4) == "0:4", "a steady severance must not re-page"
+
+
+def test_further_rise_pages_again(tmp_path):
+    """A severance getting worse is news."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _decide(home, bind, 5, 4, 5) == "1:5"
+
+
+def test_recovery_lowers_the_bar_so_a_later_severance_still_pages(tmp_path):
+    """High-water that follows DOWN. After sessions are restarted the count drops;
+    if the reported level stayed at its peak, the next — smaller — severance would
+    be silent forever. That miss is the reason this rule exists."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _decide(home, bind, 4, 4, 0) == "0:0", "recovery itself is not a page"
+    assert _decide(home, bind, 2, 0, 2) == "1:2", "a later, smaller severance must page"
+
+
+def test_zero_severed_never_pages(tmp_path):
+    """A healthy plane says nothing, at any prior level."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _decide(home, bind, 0, 0, 0) == "0:0"
+    assert _decide(home, bind, -1, 0, 0) == "0:0"

--- a/tests/test_scripts/test_watchgod_loopbreak.py
+++ b/tests/test_scripts/test_watchgod_loopbreak.py
@@ -4,17 +4,22 @@ Regression cover for the 2026-08-19 runaway: cc-tmp went ORANGE (a ~382MB pytest
 tree the cache-evict never touches), and because the tier that dispatched the
 handler was measured BEFORE cleanup, the daemon re-entered ORANGE every poll and
 re-ran the idle-session kill loop for ~4.5h. The loop-break re-measures AFTER
-cleanup and kills ONLY if still over the line; when nothing is reclaimable and
-nothing is killable it pages once instead of looping silently.
+cleanup; when nothing is reclaimable it records the stuck state once instead of
+looping silently.
+
+The kill itself is GONE as of 2026-09-07 — ORANGE never reaps a session. The
+tests that pinned the kill are now their inverse (both an unattached idle
+session and an attached one must SURVIVE an ORANGE that cleanup cannot clear),
+which is what keeps the removal from being quietly reintroduced.
 
 Plus the OOM sampler: on a NEW cgroup oom_kill it writes a durable snapshot and
 pages once (the death that started all this left no diagnosable trace).
 
 tmux is a configurable STUB (never a real session): it reports whatever sessions
 the test injects and records every kill-session call to a file, so we can assert
-the loop-break did or did NOT kill. queue_alert is overridden to a call-log so we
-can assert page-once. The script's sourcing guard loads its functions without
-starting the daemon.
+that nothing was killed. queue_alert is overridden to a call-log so we can assert
+page-once. The script's sourcing guard loads its functions without starting the
+daemon.
 """
 
 import os
@@ -100,10 +105,10 @@ def test_orange_resolved_by_cleanup_does_not_kill(tmp_path):
     assert "resolved by cache cleanup" in log, log
 
 
-def test_orange_persists_no_killable_logs_once_no_page(tmp_path):
-    """Non-reclaimable data keeps cc-tmp ORANGE and no idle session is killable →
-    per design D2 this does NOT page (only RED pages); it records the stuck state
-    once (dedupe flag + a single STUCK log line), not silently every poll."""
+def test_orange_persists_logs_once_no_page(tmp_path):
+    """Non-reclaimable data keeps cc-tmp ORANGE and there is nothing else safe to
+    do → per design D2 this does NOT page (only RED pages); it records the stuck
+    state once (dedupe flag + a single STUCK log line), not silently every poll."""
     home, cctmp, bind = _sandbox(tmp_path)
     _mb(cctmp / "bigdata" / "blob", 6)  # NOT a cache/session dir → cleanup can't evict
     killlog = home / "killed.log"
@@ -124,66 +129,46 @@ def test_orange_persists_no_killable_logs_once_no_page(tmp_path):
     )
 
 
-def test_orange_persists_with_killable_reaps_and_no_stuck_flag(tmp_path):
-    """When ORANGE persists AND an idle>2h unattached session exists, it IS
-    reaped (unchanged behavior) and the stuck flag is not raised."""
+def test_orange_never_kills_a_session(tmp_path):
+    """ORANGE does not kill sessions — the removal, pinned.
+
+    The old handler reaped every unattached tmux session idle over 2h once
+    cleanup failed to clear the line. The loop-break comment guarding it already
+    made the case against it: sessions are not what fills cc-tmp, so the kill
+    freed essentially nothing while destroying a session's whole context. Across
+    the full log history at removal time (2026-08-19 → 2026-09-07, 1,029 ORANGE
+    polls) it was reached ONCE and killed ZERO sessions.
+
+    The setup is the exact shape that used to reap: non-reclaimable data holding
+    cc-tmp over the line, plus an unattached session idle far past 2h. Both must
+    survive, and because nothing was reclaimed the stuck marker IS raised — the
+    pre-removal code took the kill branch and left the marker unset.
+
+    Verify-RED: against the pre-removal script this fails on both assertions.
+    """
     home, cctmp, bind = _sandbox(tmp_path)
-    _mb(cctmp / "bigdata" / "blob", 6)
-    killlog = home / "killed.log"
-    env = {"STUB_SESSIONS": "cc-77:0", "STUB_ACTIVITY": "100", "STUB_KILLLOG": str(killlog)}
-    proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
-    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
-    assert killlog.exists() and "cc-77" in killlog.read_text(), "idle session should be reaped"
-    stuck = home / ".genesis" / "alerts" / "tmp_orange_stuck"
-    assert not stuck.exists(), "stuck flag must not be set when a session was killed"
-
-
-def test_kill_does_not_clear_stuck_flag_no_double_page(tmp_path):
-    """Regression for the double-page edge: once stuck-ORANGE has paged, a later
-    poll that happens to reap a newly-idle session must NOT clear the flag (a kill
-    doesn't reduce cc-tmp), else the next still-ORANGE poll re-arms and re-pages
-    the same episode. The flag clears only on the green transition."""
-    home, cctmp, bind = _sandbox(tmp_path)
-    _mb(cctmp / "bigdata" / "blob", 6)  # persists ORANGE
-    stuck = home / ".genesis" / "alerts" / "tmp_orange_stuck"
-    stuck.touch()  # a prior poll already paged
-    killlog = home / "killed.log"
-    env = {"STUB_SESSIONS": "cc-88:0", "STUB_ACTIVITY": "100", "STUB_KILLLOG": str(killlog)}
-    proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
-    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
-    assert killlog.exists(), "idle session should still be reaped"
-    assert stuck.exists(), "a kill must NOT clear the stuck flag (would re-page next poll)"
-
-
-def test_failed_kill_does_not_count_as_reaped(tmp_path):
-    """If tmux kill-session FAILS (session vanished between listing and killing,
-    or any error), killed_any must stay 0 — nothing was reclaimed — so the stuck
-    marker is still recorded rather than silently skipped on a phantom reap."""
-    home, cctmp, bind = _sandbox(tmp_path)
-    _mb(cctmp / "bigdata" / "blob", 6)  # persists ORANGE
+    _mb(cctmp / "bigdata" / "blob", 6)  # not a cache dir → ORANGE persists
     killlog = home / "killed.log"
     env = {
-        "STUB_SESSIONS": "cc-66:0",
-        "STUB_ACTIVITY": "100",
+        "STUB_SESSIONS": "cc-77:0",  # unattached
+        "STUB_ACTIVITY": "100",  # epoch 100 → idle for decades
         "STUB_KILLLOG": str(killlog),
-        "STUB_KILL_RC": "1",  # kill-session fails
     }
     proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
-    assert killlog.exists(), "kill was attempted"
+    assert not killlog.exists(), "ORANGE killed a session; the kill was removed"
     stuck = home / ".genesis" / "alerts" / "tmp_orange_stuck"
-    assert stuck.exists(), "a FAILED kill must not suppress the stuck marker"
+    assert stuck.exists(), "nothing was reclaimed, so the stuck marker must be raised"
 
 
-def test_attached_session_never_killed(tmp_path):
-    """An ATTACHED session (activity recent, or simply not matched by the ':0$'
-    unattached filter) is never a kill candidate — asserts the filter shape."""
+def test_orange_never_kills_an_attached_session(tmp_path):
+    """The same for an ATTACHED session — a live terminal someone is looking at.
+    It was already excluded by the ':0$' unattached filter; asserted here so the
+    guarantee survives the filter being gone."""
     home, cctmp, bind = _sandbox(tmp_path)
     _mb(cctmp / "bigdata" / "blob", 6)
     killlog = home / "killed.log"
-    # attached=1 → the ':0$' grep drops it, so the stub still lists it but the
-    # loop never sees it. (list-sessions output is pre-filtered by the script.)
-    env = {"STUB_SESSIONS": "cc-5:1", "STUB_KILLLOG": str(killlog)}
+    env = {"STUB_SESSIONS": "cc-5:1", "STUB_ACTIVITY": "100", "STUB_KILLLOG": str(killlog)}
     proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert not killlog.exists(), "attached session must never be killed"

--- a/tests/test_scripts/test_watchgod_session_reap.py
+++ b/tests/test_scripts/test_watchgod_session_reap.py
@@ -106,9 +106,9 @@ def test_live_session_under_a_stale_project_survives(tmp_path):
     directory and ``rm -rf``s the live session with it.
     """
     home, cctmp, bind = _sandbox(tmp_path)
-    live = _session(cctmp, "-home-ubuntu-genesis", "live-uuid")
+    live = _session(cctmp, "-home-dev-workrepo", "live-uuid")
     (live / "scratchpad" / "notes.json").write_text("fresh work")
-    project = cctmp / "claude-1000" / "-home-ubuntu-genesis"
+    project = cctmp / "claude-1000" / "-home-dev-workrepo"
     _age(project, 10)  # no NEW session started here in 10 days
 
     proc = _run(home, bind, "clean_cc_yellow")
@@ -122,7 +122,7 @@ def test_live_session_under_a_stale_project_survives(tmp_path):
 def test_stale_session_is_reaped(tmp_path):
     """The feature still works: a session with nothing touched in 7 days goes."""
     home, cctmp, bind = _sandbox(tmp_path)
-    old = _session(cctmp, "-home-ubuntu-genesis", "old-uuid")
+    old = _session(cctmp, "-home-dev-workrepo", "old-uuid")
     (old / "scratchpad" / "junk.bin").write_bytes(b"x" * 1024)
     for p in (old / "scratchpad" / "junk.bin", old / "scratchpad", old):
         _age(p, 30)
@@ -137,13 +137,13 @@ def test_reap_is_per_session_not_per_project(tmp_path):
     goes, and the project survives. The pre-fix sweep had no way to express this —
     its unit of deletion was the whole project."""
     home, cctmp, bind = _sandbox(tmp_path)
-    fresh = _session(cctmp, "-home-ubuntu-genesis", "fresh-uuid")
+    fresh = _session(cctmp, "-home-dev-workrepo", "fresh-uuid")
     (fresh / "scratchpad" / "now.txt").write_text("active")
-    stale = _session(cctmp, "-home-ubuntu-genesis", "stale-uuid")
+    stale = _session(cctmp, "-home-dev-workrepo", "stale-uuid")
     (stale / "scratchpad" / "then.txt").write_text("done")
     for p in (stale / "scratchpad" / "then.txt", stale / "scratchpad", stale):
         _age(p, 20)
-    project = cctmp / "claude-1000" / "-home-ubuntu-genesis"
+    project = cctmp / "claude-1000" / "-home-dev-workrepo"
     _age(project, 20)
 
     proc = _run(home, bind, "clean_cc_yellow")
@@ -159,7 +159,7 @@ def test_deep_fresh_file_keeps_the_session(tmp_path):
     old. Directory mtimes alone cannot see this, which is the whole reason the
     old sweep was wrong."""
     home, cctmp, bind = _sandbox(tmp_path)
-    sdir = _session(cctmp, "-home-ubuntu-genesis", "deep-uuid")
+    sdir = _session(cctmp, "-home-dev-workrepo", "deep-uuid")
     deep = sdir / "scratchpad" / "a" / "b" / "c"
     deep.mkdir(parents=True)
     (deep / "just-written.log").write_text("recent")
@@ -171,7 +171,7 @@ def test_deep_fresh_file_keeps_the_session(tmp_path):
         deep.parent.parent,
         sdir / "scratchpad",
         sdir,
-        cctmp / "claude-1000" / "-home-ubuntu-genesis",
+        cctmp / "claude-1000" / "-home-dev-workrepo",
     ):
         _age(p, 40)
 
@@ -196,10 +196,10 @@ def test_emptied_project_dir_is_reclaimed_on_a_later_pass(tmp_path):
     the end state held there too, by deleting live data to get it.
     """
     home, cctmp, bind = _sandbox(tmp_path)
-    old = _session(cctmp, "-home-ubuntu-dead-project", "gone-uuid")
+    old = _session(cctmp, "-home-dev-retired", "gone-uuid")
     for p in (old / "scratchpad", old):
         _age(p, 30)
-    project = cctmp / "claude-1000" / "-home-ubuntu-dead-project"
+    project = cctmp / "claude-1000" / "-home-dev-retired"
     _age(project, 30)
 
     proc = _run(home, bind, "clean_cc_yellow")
@@ -226,14 +226,14 @@ def test_the_reap_spares_a_socket_like_every_other_sweep(tmp_path):
     stop that happening. Everything else in the directory is still reclaimed.
     """
     home, cctmp, bind = _sandbox(tmp_path)
-    sdir = _session(cctmp, "-home-ubuntu-genesis", "socket-uuid")
+    sdir = _session(cctmp, "-home-dev-workrepo", "socket-uuid")
     sock = sdir / "scratchpad" / "agent.sock"
     os.mknod(sock, stat.S_IFSOCK | 0o600)
     junk = sdir / "scratchpad" / "big.bin"
     junk.write_bytes(b"x" * 4096)
     for p in (sock, junk, sdir / "scratchpad", sdir):
         _age(p, 30)
-    _age(cctmp / "claude-1000" / "-home-ubuntu-genesis", 30)
+    _age(cctmp / "claude-1000" / "-home-dev-workrepo", 30)
 
     proc = _run(home, bind, "clean_cc_yellow")
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
@@ -245,7 +245,7 @@ def test_a_freshly_created_project_dir_is_never_reclaimed(tmp_path):
     """The race itself: a project directory CC created moments ago and is about
     to add a session to must survive a sweep landing in that window."""
     home, cctmp, bind = _sandbox(tmp_path)
-    project = cctmp / "claude-1000" / "-home-ubuntu-brand-new"
+    project = cctmp / "claude-1000" / "-home-dev-newrepo"
     project.mkdir(parents=True)  # mkdir <project>, session dir not yet created
 
     proc = _run(home, bind, "clean_cc_yellow")
@@ -270,7 +270,7 @@ def test_reap_fails_closed_when_the_cutoff_cannot_be_computed(tmp_path):
     """
     home, cctmp, bind = _sandbox(tmp_path)
     _make_exec(bind / "date", "#!/usr/bin/env bash\nexit 1\n")
-    ancient = _session(cctmp, "-home-ubuntu-genesis", "ancient-uuid")
+    ancient = _session(cctmp, "-home-dev-workrepo", "ancient-uuid")
     for p in (ancient / "scratchpad", ancient):
         _age(p, 400)
 

--- a/tests/test_scripts/test_watchgod_session_reap.py
+++ b/tests/test_scripts/test_watchgod_session_reap.py
@@ -1,0 +1,279 @@
+"""tmp_watchgod's 7-day session reap — depth and staleness, both of which were wrong.
+
+The YELLOW tier reclaims session workspaces nobody has touched in a week. Until
+2026-09-07 it did that with
+
+    find "$CC_TMP_DIR" -mindepth 2 -maxdepth 2 -type d -path "*/claude-*/???*" \\
+        -mtime +7 -exec rm -rf {} +
+
+and both halves of that line are aimed at the wrong thing.
+
+DEPTH. The layout is ``cc-tmp/claude-<uid>/<project>/<session-uuid>/…``, so
+depth 2 is the PROJECT directory. Measured on a live install: one depth-2
+directory held 54 session workspaces, including every live session's scratchpad
+and the output files of running background tasks. A single ``rm -rf`` took all
+of it.
+
+STALENESS. A directory's mtime tracks only its DIRECT children, so a project
+directory stops being touched the moment no NEW session starts under it — no
+matter how busy the sessions inside are. Measured the same day: the one
+actively-used project directory had an mtime 2.1 days old while its contents had
+been written seconds earlier, and every dormant project directory showed a
+divergence of 0.0 days. The gap appears precisely on the directory that must not
+be deleted.
+
+Those two together are the hazard: seven quiet days and a routine 50%-usage
+YELLOW — a tier that pages nobody — reaps live workspaces.
+
+Every test here drives ``clean_cc_yellow`` — the tier handler the daemon actually
+calls — rather than the reap helper, so they are meaningful against the pre-fix
+script instead of merely reporting that a new function name is absent. Measured
+verify-RED against ``origin/main``:
+``test_live_session_under_a_stale_project_survives`` fails with "the live session
+was deleted", which is the hazard demonstrated rather than asserted.
+
+Harness idiom mirrors the sibling watchgod test files (deliberately duplicated —
+those files share no conftest): a HOME-redirected sandbox so the script's
+HOME-derived paths land in tmp_path, and a tmux stub on a PATH-prepended bin dir.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+_WATCHGOD = Path(__file__).resolve().parents[2] / "scripts" / "tmp_watchgod.sh"
+
+_TMUX_STUB = """#!/usr/bin/env bash
+exit 0
+"""
+
+_DAY = 86400
+
+
+def _make_exec(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _sandbox(tmp_path: Path) -> tuple[Path, Path, Path]:
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    (home / ".genesis" / "alerts").mkdir(parents=True)
+    cctmp = home / ".genesis" / "cc-tmp"
+    cctmp.mkdir(parents=True)
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    _make_exec(bind / "tmux", _TMUX_STUB)
+    return home, cctmp, bind
+
+
+def _run(home: Path, bind: Path, snippet: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(HOME=str(home), PATH=f"{bind}:{os.environ['PATH']}")
+    return subprocess.run(
+        ["bash", "-c", f"source '{_WATCHGOD}'\n{snippet}"],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _age(path: Path, days: float) -> None:
+    """Backdate a path's mtime/atime by ``days``."""
+    when = time.time() - days * _DAY
+    os.utime(path, (when, when))
+
+
+def _session(cctmp: Path, project: str, uuid: str) -> Path:
+    """Create ``claude-1000/<project>/<uuid>/scratchpad`` and return the session dir."""
+    sdir = cctmp / "claude-1000" / project / uuid
+    (sdir / "scratchpad").mkdir(parents=True)
+    return sdir
+
+
+def test_live_session_under_a_stale_project_survives(tmp_path):
+    """THE hazard, replayed: a project directory whose own mtime is 10 days old
+    while a session inside it was written moments ago.
+
+    This is not a constructed curiosity — it is the measured live shape (2.1 days
+    of divergence on the only actively-used project directory, and 0.0 on every
+    dormant one). The pre-fix depth-2 ``-mtime +7`` sweep matches the project
+    directory and ``rm -rf``s the live session with it.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    live = _session(cctmp, "-home-ubuntu-genesis", "live-uuid")
+    (live / "scratchpad" / "notes.json").write_text("fresh work")
+    project = cctmp / "claude-1000" / "-home-ubuntu-genesis"
+    _age(project, 10)  # no NEW session started here in 10 days
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    assert live.exists(), "a live session was reaped because its PROJECT dir went stale"
+    assert (live / "scratchpad" / "notes.json").read_text() == "fresh work"
+    assert project.exists(), "the project dir must survive while it holds a live session"
+
+
+def test_stale_session_is_reaped(tmp_path):
+    """The feature still works: a session with nothing touched in 7 days goes."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    old = _session(cctmp, "-home-ubuntu-genesis", "old-uuid")
+    (old / "scratchpad" / "junk.bin").write_bytes(b"x" * 1024)
+    for p in (old / "scratchpad" / "junk.bin", old / "scratchpad", old):
+        _age(p, 30)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not old.exists(), "a 30-day-old session workspace should be reclaimed"
+
+
+def test_reap_is_per_session_not_per_project(tmp_path):
+    """Two sessions under ONE project, one stale and one fresh: only the stale one
+    goes, and the project survives. The pre-fix sweep had no way to express this —
+    its unit of deletion was the whole project."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    fresh = _session(cctmp, "-home-ubuntu-genesis", "fresh-uuid")
+    (fresh / "scratchpad" / "now.txt").write_text("active")
+    stale = _session(cctmp, "-home-ubuntu-genesis", "stale-uuid")
+    (stale / "scratchpad" / "then.txt").write_text("done")
+    for p in (stale / "scratchpad" / "then.txt", stale / "scratchpad", stale):
+        _age(p, 20)
+    project = cctmp / "claude-1000" / "-home-ubuntu-genesis"
+    _age(project, 20)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert fresh.exists(), "the fresh session must survive"
+    assert not stale.exists(), "the stale sibling should be reclaimed"
+    assert project.exists(), "a project dir with a surviving session must remain"
+
+
+def test_deep_fresh_file_keeps_the_session(tmp_path):
+    """Freshness is judged on CONTENTS, recursively — a file several levels down
+    counts, even when every directory above it, project directory included, is
+    old. Directory mtimes alone cannot see this, which is the whole reason the
+    old sweep was wrong."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    sdir = _session(cctmp, "-home-ubuntu-genesis", "deep-uuid")
+    deep = sdir / "scratchpad" / "a" / "b" / "c"
+    deep.mkdir(parents=True)
+    (deep / "just-written.log").write_text("recent")
+    # Age every ancestor, project dir included — without that the old depth-2
+    # sweep never matched and this test passed against the unfixed code too.
+    for p in (
+        deep,
+        deep.parent,
+        deep.parent.parent,
+        sdir / "scratchpad",
+        sdir,
+        cctmp / "claude-1000" / "-home-ubuntu-genesis",
+    ):
+        _age(p, 40)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert sdir.exists(), "a fresh file deep inside must keep the session alive"
+
+
+def test_emptied_project_dir_is_reclaimed_on_a_later_pass(tmp_path):
+    """Reaping every session under a project leaves an empty directory behind;
+    without cleanup those accumulate forever. Removal is deliberately TWO-PHASE,
+    and this pins both halves.
+
+    Removing the last session updates the project directory's own mtime, so
+    `-empty -mtime +7` does not match it in the same pass — it goes on a later
+    one, once seven quiet days have passed. That delay is the point: CC creates
+    `<project>/` and then `<session-uuid>/` as two steps, and an rmdir landing
+    between them gives the starting session ENOENT. An empty directory is one
+    inode, which is not worth racing a session start for.
+
+    Not regression cover — the old sweep removed the whole project directory, so
+    the end state held there too, by deleting live data to get it.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    old = _session(cctmp, "-home-ubuntu-dead-project", "gone-uuid")
+    for p in (old / "scratchpad", old):
+        _age(p, 30)
+    project = cctmp / "claude-1000" / "-home-ubuntu-dead-project"
+    _age(project, 30)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not old.exists(), "the stale session should be reclaimed"
+    assert project.exists(), (
+        "the project dir was just touched by that removal — reclaiming it in the "
+        "same pass is the race the mtime guard exists to avoid"
+    )
+
+    _age(project, 30)  # seven quiet days later
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not project.exists(), "an empty, long-untouched project dir is reclaimed"
+
+
+def test_the_reap_spares_a_socket_like_every_other_sweep(tmp_path):
+    """The invariant this daemon is built on is "no sweep deletes a socket", and
+    a new sweep is a new member of that population.
+
+    A socket's mtime is its BIND time, so a session that bound one inside its
+    workspace and then wrote nothing for seven days looks stale — and a plain
+    `rm -rf` would have the reap sever a live session in the very sweep added to
+    stop that happening. Everything else in the directory is still reclaimed.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    sdir = _session(cctmp, "-home-ubuntu-genesis", "socket-uuid")
+    sock = sdir / "scratchpad" / "agent.sock"
+    os.mknod(sock, stat.S_IFSOCK | 0o600)
+    junk = sdir / "scratchpad" / "big.bin"
+    junk.write_bytes(b"x" * 4096)
+    for p in (sock, junk, sdir / "scratchpad", sdir):
+        _age(p, 30)
+    _age(cctmp / "claude-1000" / "-home-ubuntu-genesis", 30)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert sock.exists() and stat.S_ISSOCK(sock.stat().st_mode), "the session reap deleted a socket"
+    assert not junk.exists(), "everything that is not a socket is still reclaimed"
+
+
+def test_a_freshly_created_project_dir_is_never_reclaimed(tmp_path):
+    """The race itself: a project directory CC created moments ago and is about
+    to add a session to must survive a sweep landing in that window."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    project = cctmp / "claude-1000" / "-home-ubuntu-brand-new"
+    project.mkdir(parents=True)  # mkdir <project>, session dir not yet created
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert project.exists(), "a starting session's project dir was deleted under it"
+
+
+def test_reap_fails_closed_when_the_cutoff_cannot_be_computed(tmp_path):
+    """The fail direction, which is the part that turns a housekeeping sweep into
+    data loss when it is wrong. If the 7-day cutoff cannot be computed, NOTHING is
+    deleted — not even a genuinely ancient session — and the skip is logged.
+
+    Not regression cover (the old sweep called no `date` at all): this is RED
+    against the new code with its guard removed, because `find -newermt ""` exits
+    0 and treats an empty cutoff as roughly NOW, so every session would read as
+    stale and be deleted. The guard is what stands between an unusable timestamp
+    and total loss.
+
+    Shadowing `date` with a failing stub is the smallest way to reach that branch;
+    the branch itself guards against any environment where the timestamp cannot be
+    produced.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    _make_exec(bind / "date", "#!/usr/bin/env bash\nexit 1\n")
+    ancient = _session(cctmp, "-home-ubuntu-genesis", "ancient-uuid")
+    for p in (ancient / "scratchpad", ancient):
+        _age(p, 400)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert ancient.exists(), "an unusable cutoff must delete nothing at all"

--- a/tests/test_scripts/test_watchgod_zone_b.py
+++ b/tests/test_scripts/test_watchgod_zone_b.py
@@ -1,0 +1,179 @@
+"""tmp_watchgod Zone B (/tmp housekeeping) — it must not delete a control plane either.
+
+Zone B had NO test coverage before 2026-09-07, because its sweeps named `/tmp`
+literally and a test would have had to sweep the real one. That gap is how the
+finding below survived an audit: an earlier pass over this daemon marked the
+empty-directory sweep SAFE on the reasoning that "socket-holding dirs are
+non-empty" — true of the directory holding the socket, and false of its siblings.
+
+MEASURED on a live install, running the pre-fix predicate with `-print` instead of
+`-delete`: it matched `/tmp/cc-socks` and `/tmp/cc-daemon-1000/<id>/pty`. The
+second is an empty rendezvous directory inside a LIVE Claude Code daemon's socket
+tree — created up front and populated later — held by a process with 11 days of
+uptime. Deleting it is the same failure class as the 2026-09-05 incident: the
+socket itself is spared by name, and the directory it needs is not.
+
+Zone B is currently unreachable on that install (`/tmp` is not tmpfs there, so the
+tier comes from absolute free space, which was ~13 GB) — latent, not firing.
+Latent is worth fixing and worth pinning: free space falls.
+
+The sweeps now run against `$SYS_TMP_DIR`, which exists solely so these tests can
+point the zone at a sandbox. Nothing in production sets it.
+
+TWO THINGS KEEP THESE TESTS FROM BEING VACUOUS, and the first was learned the hard
+way — an earlier draft of this file passed for the wrong reason.
+
+  1. The swept sandbox is NOT `tmp_path`. Zone B carries a pre-existing
+     `-not -path "*/pytest-*"` exclusion, and pytest's basetemp is
+     `…/pytest-of-<user>/pytest-<n>/…` under some configurations — so every
+     survival assertion under `tmp_path` would pass because the sweep skipped the
+     whole tree, on a path that varies between runners. MEASURED: the same four
+     tests deleted correctly under one basetemp and swept nothing under another.
+  2. Every survival test plants a CANARY — an ordinary empty directory the sweep
+     MUST reclaim. If the canary survives, the sweep did not run and the survival
+     assertion proved nothing, so the test fails instead of passing quietly.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+_WATCHGOD = Path(__file__).resolve().parents[2] / "scripts" / "tmp_watchgod.sh"
+
+_TMUX_STUB = "#!/usr/bin/env bash\nexit 0\n"
+
+_DAY = 86400
+
+
+def _make_exec(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _age(path: Path, days: float) -> None:
+    when = time.time() - days * _DAY
+    os.utime(path, (when, when))
+
+
+@pytest.fixture
+def zone_b(tmp_path):
+    """HOME under tmp_path (never swept), but the SWEPT tree somewhere neutral —
+    see the module docstring on why `tmp_path` cannot be the swept directory."""
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    (home / ".genesis" / "alerts").mkdir(parents=True)
+    (home / ".genesis" / "cc-tmp").mkdir(parents=True)
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    _make_exec(bind / "tmux", _TMUX_STUB)
+    systmp = Path(tempfile.mkdtemp(prefix="wgzoneb"))
+    try:
+        yield home, systmp, bind
+    finally:
+        shutil.rmtree(systmp, ignore_errors=True)
+
+
+def _run(home: Path, systmp: Path, bind: Path, snippet: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(HOME=str(home), PATH=f"{bind}:{os.environ['PATH']}", SYS_TMP_DIR=str(systmp))
+    return subprocess.run(
+        ["bash", "-c", f"source '{_WATCHGOD}'\n{snippet}"],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _canary(systmp: Path) -> Path:
+    """An ordinary empty dir the sweep MUST reclaim. If it survives, the sweep did
+    not run and every survival assertion beside it is meaningless."""
+    c = systmp / "canary-ordinary-empty-dir"
+    c.mkdir()
+    _age(c, 30)
+    return c
+
+
+def _assert_swept(canary: Path) -> None:
+    assert not canary.exists(), (
+        "the canary survived, so the sweep never ran over this tree — any survival "
+        "assertion in this test would have passed for the wrong reason"
+    )
+
+
+def test_empty_dir_inside_a_live_socket_tree_survives(zone_b):
+    """The measured shape: CC's daemon tree, with an empty rendezvous directory
+    beside the sockets. The sockets are spared by name; the directory they need
+    has to be spared too, or the tree is broken just as thoroughly."""
+    home, systmp, bind = zone_b
+    canary = _canary(systmp)
+    tree = systmp / "cc-daemon-1000" / "5c860797"
+    (tree / "spare").mkdir(parents=True)
+    os.mknod(tree / "control.sock", stat.S_IFSOCK | 0o600)
+    os.mknod(tree / "spare" / "c3436363.claim.sock", stat.S_IFSOCK | 0o600)
+    pty = tree / "pty"  # empty, created up front, populated later
+    pty.mkdir()
+    _age(pty, 30)
+
+    proc = _run(home, systmp, bind, "clean_sys_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    _assert_swept(canary)
+    assert pty.is_dir(), "an empty rendezvous dir inside a live CC daemon tree was deleted"
+    assert (tree / "control.sock").exists(), "a daemon socket was deleted"
+
+
+def test_empty_cc_socks_dir_survives(zone_b):
+    """`cc-socks` is where the per-session messaging sockets land on an install
+    whose temp dir is /tmp. Empty right now is not a reason to remove it: it is
+    the directory the next session binds into."""
+    home, systmp, bind = zone_b
+    canary = _canary(systmp)
+    socks = systmp / "cc-socks"
+    socks.mkdir()
+    _age(socks, 30)
+
+    proc = _run(home, systmp, bind, "clean_sys_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    _assert_swept(canary)
+    assert socks.is_dir(), "the socket directory was deleted while empty"
+
+
+def test_ordinary_empty_dirs_are_still_reclaimed(zone_b):
+    """The sweep still does its job — the exclusions are narrow, not a disable."""
+    home, systmp, bind = zone_b
+    junk = systmp / "leftover-build-dir"
+    junk.mkdir()
+    _age(junk, 30)
+
+    proc = _run(home, systmp, bind, "clean_sys_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not junk.exists(), "an ordinary empty dir should still be reclaimed"
+
+
+def test_socket_files_survive_every_zone_b_tier(zone_b):
+    """The pre-existing `-not -name '*.sock'` exclusion, pinned across all three
+    tiers — RED is the aggressive one and the easiest to regress."""
+    home, systmp, bind = zone_b
+    sock = systmp / "cc-socks" / "42.sock"
+    sock.parent.mkdir()
+    os.mknod(sock, stat.S_IFSOCK | 0o600)
+    junk = systmp / "old.log"
+    junk.write_text("x")
+    for p in (sock, junk, sock.parent):
+        _age(p, 30)
+
+    for tier in ("clean_sys_yellow", "clean_sys_orange", "clean_sys_red"):
+        proc = _run(home, systmp, bind, tier)
+        assert proc.returncode == 0, f"{tier}: {proc.stdout}\n{proc.stderr}"
+        assert sock.exists() and stat.S_ISSOCK(sock.stat().st_mode), (
+            f"{tier} deleted a unix socket under the swept tree"
+        )
+    assert not junk.exists(), "the sweeps must still reclaim ordinary old files"


### PR DESCRIPTION
The temp watchgod exists so runaway temp usage cannot kill Claude Code. This
fixes three places where it did the opposite, and adds the detector for the one
failure it cannot undo.

## What was wrong

**YELLOW reaped projects, not sessions.** The layout under cc-tmp is
`claude-<uid>/<project>/<session-uuid>/`, so the sweep's depth-2 target was the
PROJECT directory — and staleness was judged by that directory's own mtime,
which tracks only its direct children. A project directory therefore goes stale
as soon as no NEW session starts under it, however busy the sessions inside are.

MEASURED on a live install: the one actively-used project directory carried an
mtime **2.1 days old while its contents had been written seconds earlier**, and
held **54 session workspaces** including every live session's scratchpad and the
output of running background tasks. Every dormant project showed a divergence of
0.0 days — the gap appears precisely on the directory that must not be deleted.
Seven quiet days and a routine 50%-usage YELLOW, a tier that pages nobody, takes
the lot.

The reap is now per SESSION, judged on contents recursively, and it **fails
closed**: a directory whose freshness cannot be determined is kept. That
direction is the real finding here — a first draft of this fix used a
relative-date predicate that a different `find` implementation rejects, and the
swallowed error made every session read as stale. A housekeeping sweep is one
broken predicate away from total data loss, so the branch that cannot evaluate
must delete nothing.

**ORANGE killed idle sessions for nothing.** It reaped unattached tmux sessions
idle over 2h. The loop-break comment guarding it already made the case against
itself — sessions are not what fills cc-tmp — so the kill freed approximately
nothing while destroying a session's entire context. Across the whole log
history (2026-08-19 → 2026-09-07, 7,563 lines, **1,029 ORANGE polls**) the kill
loop was reached **once** and killed **zero** sessions, so removing it is
behaviour-neutral on the record available. RED is unchanged and remains the
pressure valve.

**Zone B could delete a live socket tree.** Its file sweeps already spared
`*.sock` by name; the empty-directory sweep did not spare their DIRECTORIES.
Measured by running the predicate with `-print` instead of `-delete`: it matched
`/tmp/cc-socks` and a live CC daemon's empty `pty` rendezvous directory —
created up front, populated later. Latent rather than firing (that `/tmp` is not
tmpfs, so the tier reads absolute free space, which was ample), but the same
failure class as the incident below. This zone had **no test coverage at all**,
which is how an earlier audit of mine called it safe on the reasoning
"socket-holding dirs are non-empty" — true of the directory holding the socket,
false of its siblings.

## The detector

Claude Code binds one unix socket per session for cross-session messaging, at a
path that falls back into cc-tmp when `XDG_RUNTIME_DIR` is unset — the very
directory this daemon reclaims. Deleting the PATH does not stop the listener:
the process keeps the inode, so `ss` still reports LISTEN and the session looks
healthy from the inside, while every peer resolves by path and gets ENOENT.
Nothing re-binds after startup, so the session is unreachable for the rest of
its life and cannot notice. On 2026-09-05 a sweep severed 3 of 4 sessions on one
install and 6 of 6 on another.

The sweeps were taught to spare sockets, which prevents recurrence and cannot
heal what is already severed. So the state is now reported: counts in the
watchgod state file, one page on a confirmed rise, quiet across daemon restarts
until it rises again.

Deliberate edges, since each is easy to "simplify" away later:
- **Read-only.** A stale socket file is counted, never reaped. Putting socket
  deletion back into this daemon is what caused the outage.
- **Three statuses, not two.** `unknown` when the probe could not run, `empty`
  when it ran and saw nothing. Neither is health — a detector that has gone
  blind must not be indistinguishable from a clean plane.
- **Confirmation before paging.** The same elevated count must appear on two
  consecutive polls, so a session exiting between `ss`'s snapshot and its own
  unlink cannot page spuriously.
- **Scope.** It watches the per-session `cc-socks` plane only. CC's separate
  daemon tree is protected from deletion but not counted, because what severance
  means there is unestablished — protect what you do not understand, report only
  what you do.

**Expect a page on the first deploy** to any install that is already severed.
That is the feature working, not a regression.

## Verification

Not only unit tests. The real daemon loop, run against a live 4-session
severance with a sandboxed HOME: silent on the first reading, paged exactly once
on the confirming second, silent thereafter, correct counts in the state file,
and still exactly one alert after a full daemon restart.

Verify-RED is measured, not asserted. Against the pre-fix script,
`test_live_session_under_a_stale_project_survives` fails with *"a live session
was reaped because its PROJECT dir went stale"* — the hazard demonstrated
through the real tier entry point rather than described. Zone B could not use
the base as a baseline (its test seam is new), so its control is a mutant of
this branch with the two exclusions removed, and exactly the two socket-tree
tests fail against it.

Four tests are honestly labelled as NOT regression cover, and one earlier draft
of the Zone B tests was **vacuous** — pytest's basetemp can contain a `pytest-`
path component, which Zone B's own exclusion then skips wholesale, so every
survival assertion passed on a sweep that never ran. Fixed by sweeping outside
`tmp_path` and planting a canary the sweep must reclaim in every survival test.

Cost measured: `ss` at 45.6 ms on a 30 s poll (0.15% duty); the session sweep at
420 ms across 83 session directories, falling once the stale ones are reaped.

## Not in this PR

Relocating the sockets out of cc-tmp. That is the actual fix — the control plane
should not live in a directory whose purpose is to be reclaimed — but one
resolver inside the CC binary serves both bind and discovery, so a mixed-era
fleet cannot see itself during the cutover. It waits on the deploy path that
restarts resident daemons (#1703), so one deploy can move the fleet.

Region: `scripts/tmp_watchgod.sh` (all Zone A/B sweep functions, the main poll
loop) and `collect_cc_tmp_usage`. Noted here rather than messaged, because the
peer sessions that would want to know are themselves severed and unreachable —
which is the bug this PR reports.

Ledger row `1eaf5081f0fe41bebfef1df848754457` covers this work and a follow-on;
not cited as complete, because the relocation half is still outstanding.

E2E: after merge and deploy, restart genesis-tmp-watchgod and confirm the state
file's `control_plane.severed_sockets` equals the count of live sessions whose
cc-socks path is missing (cross-check against `ss -xlp`), that exactly one page
fires on the first confirmed rise, and that a YELLOW pass leaves live session
workspaces under cc-tmp intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added control-plane monitoring for messaging sockets, including health status, stale or severed socket detection, persisted metrics, and confirmed-issue paging.
  * Added configurable temporary and socket-tool paths.
  * Improved state reporting with control-plane health metrics.

* **Bug Fixes**
  * Preserved socket-related directories during temporary-file cleanup.
  * Session cleanup now safely handles nested sessions and protects active or recently updated data.
  * Orange cleanup no longer terminates idle or attached terminal sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->