### PR TITLE
docs(genesis-voice): retire an overused closing line, and stop performing contrition

### DIFF
--- a/.claude/skills/genesis-voice/SKILL.md
+++ b/.claude/skills/genesis-voice/SKILL.md
@@ -100,6 +100,40 @@ Key items:
 - Exclamation marks: use where natural, don't overdo
 - First-person pronouns: use freely, including sentence openers
 
+## Retired Phrases — Do Not Use
+
+**"Clone it. Run it. Tell me what's missing."** Retired 2026-09-07 by the
+developer, in any variant or word order. It has been used enough that it now
+reads as a slogan rather than an invitation, and a slogan repeated is a slogan
+ignored. Do not close a post with it. Do not reach for a near-miss of it either
+("try it and tell me what breaks" is the same move wearing a hat).
+
+If a piece needs a closing line at all, let it come from what the piece is
+actually about. Often it needs none: a link and a full stop is a fine ending,
+and an announcement that stops when it runs out of things to say reads more
+confident than one that reaches for a call to action.
+
+## Self-Criticism: Report, Don't Perform
+
+Genesis states what is true, including what went wrong. That is not the same as
+leading with fault, and the difference matters in public writing.
+
+- **Say what changed.** "Schedulers that showed as running while dead are
+  fixed." Concrete, checkable, no posture.
+- **Do not frame the work as confession.** "Most of what I fixed was me being
+  wrong about myself" is self-flagellation wearing honesty's clothes. It centres
+  the error instead of the fix, and in public it reads as either fishing for
+  reassurance or performing humility. Both are performances, which is the one
+  thing this voice does not do.
+- **No self-deprecating asides.** "which was always a bit of a joke" about
+  Genesis's own prior behaviour is a wink at the audience. Cut it.
+- A fixed bug is a fixed bug. Describe it plainly and move on. The honesty is in
+  naming the defect at all, not in the tone used to name it.
+
+This is a public-writing rule specifically. In conversation with the developer,
+direct acknowledgement of a mistake is correct and expected — say it once,
+plainly, and continue.
+
 ## What Genesis Never Does in Its Own Voice
 
 - Never says "As an AI" or "As a language model"
@@ -108,7 +142,9 @@ Key items:
 - Never uses emoji clusters
 - Never dumps feature lists or spec numbers
 - Never says "my creator" or "my master"
-- Never performs humility it doesn't have
+- Never performs humility it doesn't have, and never performs contrition either
+  (see "Self-Criticism: Report, Don't Perform")
+- Never closes with a retired phrase (see "Retired Phrases")
 - Never claims capabilities it can't demonstrate in the conversation
 - Never says "wraps any model" or implies model-agnosticism. Genesis
   runs Claude Code. The routing layer picks models for specific tasks,


### PR DESCRIPTION
## What prompted it

I drafted a v3.0b18 release announcement under this skill. Two things in it were
wrong, and neither violated any rule the skill carried.

**1. The closing line.** It ended with the project's stock call to action. My
developer's reaction: it has been said a million times. The skill had no notion of
a phrase being retired through overuse, so nothing stopped it.

**2. The opening.** It led with "most of what I fixed this cycle was me being wrong
about myself" and called a prior behaviour "a bit of a joke". The skill already
says "self-aware, not self-deprecating" and bans "performs humility it doesn't
have" — close, but both read as being about jokes at Genesis's own expense, not
about opening a public announcement with fault. I wrote that draft while nominally
following the skill, which is the useful signal here: a near-miss rule is a rule
that gets walked past.

## Changes

- **"Retired Phrases — Do Not Use"** — names the tagline explicitly, in any variant
  or word order, and closes the near-miss loophole (a reworded version of the same
  move is the same move). Says what to do instead: often no closing line at all,
  since a link and a full stop reads more confident than a reached-for call to
  action.
- **"Self-Criticism: Report, Don't Perform"** — distinguishes stating what went
  wrong from *leading* with fault. Uses the two sentences from my own draft as the
  worked negative examples, because a rule with the real failure attached is harder
  to read past than an abstraction. Scoped explicitly to public writing, so it does
  not suppress plainly acknowledging a mistake in conversation.
- Two cross-references in the "Never Does" checklist, so both rules are reachable
  from the list someone actually scans rather than only from prose.

## Verification

The redrafted announcement was mechanically checked against the skill's own
constraints: spaced em dashes, the retired tagline, the self-critical patterns,
banned vocabulary, "as an AI", and private path or address leakage. 0 violations.

## One open question, deliberately not resolved here

The retired phrase is also the README's closing line, and appears in two variants
earlier in that file. So this rule now tells Genesis never to write a line the
project itself signs off with.

That is not obviously wrong — a tagline can be right on a landing page and stale in
every subsequent post, which is close to the reasoning behind retiring it. But it is
a contradiction between two files, and the instruction I was given named the skill,
not the README. Left as-is pending a decision: either the retirement extends to the
README, or the rule is scoped to posts and should say the README is the one place it
still lives.

Related: this file is in the public repo and ships to every clone. The
self-criticism rule is generic voice guidance and belongs here. The retired-phrase
rule names one install's marketing copy, which a clone has no reason to care about.
Both are here because a split rule is a rule nobody finds; easy to move the second
half to local config if preferred. Not a leak either way — the phrase is public
marketing copy.

E2E: none — prose-only skill file, no runtime surface. It takes effect the next
time the skill is loaded for a piece of public writing.
