### PR TITLE
fix(cc-tmp): reap sessions not projects, and report a severed control plane

### DIFF
--- a/changelog.d/20260907220000-fixed-watchgod-control-plane-safety.md
+++ b/changelog.d/20260907220000-fixed-watchgod-control-plane-safety.md
@@ -8,8 +8,12 @@
   "seven days ago" means, it deletes nothing at all. The ORANGE tier no longer
   kills idle Claude Code sessions: sessions are not what fills the temp
   directory, so the kill freed almost nothing while destroying a session's entire
-  context. The /tmp housekeeping now leaves Claude Code's socket directories
-  alone — an empty folder inside a live socket tree is a rendezvous point the
+  context. Its emergency tier now works out which workspace is actually in use
+  from the newest file inside it, rather than from a directory timestamp that
+  stops moving while you work — on one install that timestamp was three days
+  stale and only ten minutes ahead of a long-dormant folder, so the emergency
+  cleanup was a coin flip away from preserving the wrong one. The /tmp
+  housekeeping now leaves Claude Code's socket directories alone — an empty folder inside a live socket tree is a rendezvous point the
   daemon fills in later, not leftover junk.
 
   And a new check reports Claude Code sessions whose messaging socket has been

--- a/changelog.d/20260907220000-fixed-watchgod-control-plane-safety.md
+++ b/changelog.d/20260907220000-fixed-watchgod-control-plane-safety.md
@@ -1,0 +1,21 @@
+- **The temp watchgod no longer damages the things it exists to protect, and it
+  now reports a broken Claude Code control plane instead of leaving it silent.**
+  Its weekly cleanup was aimed one directory level too shallow and judged
+  staleness by directory timestamp, so a project folder whose sessions were all
+  still active could be deleted whole — on one install that folder held 54 live
+  session workspaces. It now reaps individual session folders, and only when
+  nothing inside has been touched for seven days; if it cannot work out what
+  "seven days ago" means, it deletes nothing at all. The ORANGE tier no longer
+  kills idle Claude Code sessions: sessions are not what fills the temp
+  directory, so the kill freed almost nothing while destroying a session's entire
+  context. The /tmp housekeeping now leaves Claude Code's socket directories
+  alone — an empty folder inside a live socket tree is a rendezvous point the
+  daemon fills in later, not leftover junk.
+
+  And a new check reports Claude Code sessions whose messaging socket has been
+  deleted underneath them. They keep listening, so they look healthy while no
+  other session can reach them, and nothing re-binds after startup — the only
+  cure is restarting them. The count appears in the watchgod state file and pages
+  once when it rises, staying quiet across restarts until it rises again. The
+  check never deletes a socket, and says "unknown" rather than "fine" when it
+  cannot see.

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -2172,8 +2172,16 @@ verified: f24c15e9 2026-09-05
     is a rendezvous point CC populates later, not garbage, and the exclusion by
     name is what covers it (MEASURED 2026-09-07: that predicate matched
     `/tmp/cc-socks` and a live daemon's `pty` directory). `check_control_plane`
-    reports severed listeners and stale socket files into the state file, paging
-    once on a confirmed rise. It is strictly READ-ONLY — reaping a stale socket
+    reports severed listeners and stale socket files into the state file, and
+    pages once per severed socket IDENTITY (confirmed across two consecutive
+    polls, forgotten when it recovers). Identities rather than a count, because a
+    count cannot tell "the same sessions are still severed" from "those exited and
+    a different one broke" — both read as the number falling, and the new
+    severance would then never page. The reported set advances only after the
+    alert is observed on the queue: `queue_alert` is best-effort and degrades
+    silently to a no-op, so marking first would let an unwritable queue
+    permanently suppress the alert on exactly the degraded box this exists to
+    expose. It is strictly READ-ONLY — reaping a stale socket
     would put socket deletion back in the daemon that caused the outage — and it
     watches the per-session `cc-socks/` plane ONLY. CC's separate daemon tree
     (`/tmp/cc-daemon-<uid>/`: control, pty and rendezvous sockets for the
@@ -2201,10 +2209,15 @@ verified: f24c15e9 2026-09-05
     directory mtime, and that directory led a DORMANT project's by 10 minutes; one
     more session started in the dormant project and RED would have preserved that
     one and reaped 54 live workspaces while logging "preserving active session".
-    Selection is now by newest file anywhere inside. The preserved UNIT stays the
-    project, deliberately: narrowing it to the single session would reap the
-    active project's other sessions, which is more destruction, not better
-    aim — a separate decision from fixing the aim.
+    Selection is now by the newest ENTRY of any type at depth 3 or below — files
+    AND directories. Files alone left a session that had created its workspace
+    but not yet written anything with no candidate at all, so nothing was
+    preserved and the sweep reaped that live session's directories out from under
+    it; a brand-new session is a fresh directory and nothing else. The depth floor
+    is what keeps the original fix intact: the stale project directory at depth 2
+    is still excluded. The preserved UNIT stays the project, deliberately —
+    narrowing it to the single session would reap the active project's other
+    sessions, which is more destruction, not better aim.
 
   Deliberately NOT done: relocating the sockets out of cc-tmp. That is the real
   fix — the control plane should not live in a directory whose purpose is to be

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -2201,23 +2201,24 @@ verified: f24c15e9 2026-09-05
     while destroying a session's whole context. Removed 2026-09-07 (measured: 1
     reach and 0 kills across the entire log history). RED remains the pressure
     valve and still reaps.
-  * **RED decides what to preserve the same way.** "Preserving active session"
-    used to mean the depth-2 project directory with the newest mtime — the same
+  * **RED's preserve rule is UNCHANGED, and is the known remaining gap.** It
+    still means "the depth-2 project directory with the newest mtime" — the same
     proxy YELLOW got wrong, in the tier where being wrong costs the most, since
     that mtime moves only when a session dir is created or removed. MEASURED
     2026-09-07: the active project's newest FILE was 3 days newer than its own
     directory mtime, and that directory led a DORMANT project's by 10 minutes; one
-    more session started in the dormant project and RED would have preserved that
-    one and reaped 54 live workspaces while logging "preserving active session".
-    Selection is now by the newest ENTRY of any type at depth 3 or below — files
-    AND directories. Files alone left a session that had created its workspace
-    but not yet written anything with no candidate at all, so nothing was
-    preserved and the sweep reaped that live session's directories out from under
-    it; a brand-new session is a fresh directory and nothing else. The depth floor
-    is what keeps the original fix intact: the stale project directory at depth 2
-    is still excluded. The preserved UNIT stays the project, deliberately —
-    narrowing it to the single session would reap the active project's other
-    sessions, which is more destruction, not better aim.
+    more session started in the dormant project and RED would preserve that one
+    and reap 54 live workspaces while logging "preserving active session".
+    This change deliberately does NOT fix it. Two attempts to fix it here each
+    shipped a worse regression — widening the selector's depth silently
+    re-anchored its `-path` glob (find's `-path` matches the whole path and its
+    `*` crosses `/`), so an unrelated directory won and RED deleted the live
+    workspace it claimed to preserve; MEASURED against a one-decoy fixture, where
+    the unchanged selector preserves and the widened one destroys. The answer is
+    not a narrower glob: RED should not INFER the live set from mtimes when it is
+    directly observable, and this file already enumerates listening CC sockets.
+    That is a redesign of the nuclear tier's preserve rule, tracked separately so
+    it cannot ride along in a change about reaping sessions instead of projects.
 
   Deliberately NOT done: relocating the sockets out of cc-tmp. That is the real
   fix — the control plane should not live in a directory whose purpose is to be

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -2193,6 +2193,18 @@ verified: f24c15e9 2026-09-05
     while destroying a session's whole context. Removed 2026-09-07 (measured: 1
     reach and 0 kills across the entire log history). RED remains the pressure
     valve and still reaps.
+  * **RED decides what to preserve the same way.** "Preserving active session"
+    used to mean the depth-2 project directory with the newest mtime — the same
+    proxy YELLOW got wrong, in the tier where being wrong costs the most, since
+    that mtime moves only when a session dir is created or removed. MEASURED
+    2026-09-07: the active project's newest FILE was 3 days newer than its own
+    directory mtime, and that directory led a DORMANT project's by 10 minutes; one
+    more session started in the dormant project and RED would have preserved that
+    one and reaped 54 live workspaces while logging "preserving active session".
+    Selection is now by newest file anywhere inside. The preserved UNIT stays the
+    project, deliberately: narrowing it to the single session would reap the
+    active project's other sessions, which is more destruction, not better
+    aim — a separate decision from fixing the aim.
 
   Deliberately NOT done: relocating the sockets out of cc-tmp. That is the real
   fix — the control plane should not live in a directory whose purpose is to be

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -2217,7 +2217,7 @@ verified: f24c15e9 2026-09-05
     the unchanged selector preserves and the widened one destroys. The answer is
     not a narrower glob: RED should not INFER the live set from mtimes when it is
     directly observable, and this file already enumerates listening CC sockets.
-    That is a redesign of the nuclear tier's preserve rule, tracked separately so
+    That is a redesign of the nuclear tier's preserve rule, tracked in issue #1878 so
     it cannot ride along in a change about reaping sessions instead of projects.
 
   Deliberately NOT done: relocating the sockets out of cc-tmp. That is the real

--- a/docs/architecture/CURRENT.md
+++ b/docs/architecture/CURRENT.md
@@ -2149,6 +2149,56 @@ verified: f24c15e9 2026-09-05
 - **_config_overlay.py**: `.local.yaml` deep-merge (user config dir first;
   dicts merge, lists REPLACE wholesale); dependency-free by design to stay
   import-cycle-safe.
+- **`scripts/tmp_watchgod.sh`** (a standalone systemd user service, not a
+  `src/genesis` package — it must keep running when Genesis does not): dual-zone
+  temp protection, polling every 30s. Zone A is `~/.genesis/cc-tmp` against a
+  budget (GREEN <50% / YELLOW >50% / ORANGE >75% / RED >90% or free space under
+  the sacred-ground floor); Zone B is `/tmp` on time-based housekeeping. **Its
+  one job is stopping runaway temp usage from killing Claude Code — so the bar
+  for any sweep is that it must not damage correct functioning, even when it has
+  to fire.** Three edges follow from that and are easy to reintroduce:
+  * **Sockets are never deleted.** CC binds one unix socket per session for
+    cross-session messaging, at `$XDG_RUNTIME_DIR/cc-socks/<pid>.sock` — falling
+    back to the temp dir when that variable is unset, which on a Genesis install
+    is cc-tmp itself. Deleting the PATH does not stop the listener: the process
+    keeps the inode, so `ss` still shows LISTEN and the session looks healthy
+    from the inside while every peer resolves by path and gets ENOENT. Nothing
+    re-binds after startup, so the session is unreachable for life and cannot
+    notice. Measured 2026-09-05, when a RED sweep deleted them: 3 of 4 sessions
+    severed here, 6 of 6 on a sibling install. Every Zone A sweep that removes a
+    directory now goes through `reap_dir_sparing_sockets` (object-level, never
+    `-type s`); Zone B's file sweeps spare `*.sock` by name, and its empty-dir
+    sweep spares the socket TREES — an empty directory inside a live socket tree
+    is a rendezvous point CC populates later, not garbage, and the exclusion by
+    name is what covers it (MEASURED 2026-09-07: that predicate matched
+    `/tmp/cc-socks` and a live daemon's `pty` directory). `check_control_plane`
+    reports severed listeners and stale socket files into the state file, paging
+    once on a confirmed rise. It is strictly READ-ONLY — reaping a stale socket
+    would put socket deletion back in the daemon that caused the outage — and it
+    watches the per-session `cc-socks/` plane ONLY. CC's separate daemon tree
+    (`/tmp/cc-daemon-<uid>/`: control, pty and rendezvous sockets for the
+    background-spare machinery) is protected from deletion but deliberately not
+    counted: what severance means there is unestablished, and a number derived
+    from unverified failure semantics is a guess wearing a measurement's clothes.
+  * **YELLOW reaps SESSIONS, never PROJECTS.** The layout is
+    `claude-<uid>/<project>/<session-uuid>/`, and a project directory's mtime
+    tracks only its direct children — so it goes stale as soon as no NEW session
+    starts under it, however busy the sessions inside are. Measured 2026-09-07:
+    the one actively-used project directory carried an mtime 2.1 days old while
+    its contents were seconds old, and held 54 live session workspaces. Staleness
+    is therefore judged on CONTENTS, recursively, per session directory, and the
+    probe fails CLOSED — an undeterminable directory is kept.
+  * **ORANGE does not kill sessions.** It used to reap unattached tmux sessions
+    idle over 2h; sessions are not what fills cc-tmp, so that freed ~nothing
+    while destroying a session's whole context. Removed 2026-09-07 (measured: 1
+    reach and 0 kills across the entire log history). RED remains the pressure
+    valve and still reaps.
+
+  Deliberately NOT done: relocating the sockets out of cc-tmp. That is the real
+  fix — the control plane should not live in a directory whose purpose is to be
+  reclaimed — but a mixed-era fleet cannot see itself during the cutover (one
+  resolver in the CC binary serves both bind and discovery), so it waits on the
+  deploy path that restarts resident daemons.
 
 ## 13. Modules, skills & self-extension
 

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -414,10 +414,40 @@ clean_cc_orange() {
 clean_cc_red() {
     log WARN "Zone A RED — NUCLEAR cleanup, preserving active session"
 
-    # Find the most recently modified session UUID dir (the active workspace)
+    # Which workspace is ACTIVE — by the newest file anywhere inside it, not by a
+    # directory's own mtime.
+    #
+    # This is the same defect the YELLOW reap had, in the tier where getting it
+    # wrong costs the most, and fixing it in only one of the two places would have
+    # left the class alive in the nuclear one. Depth 2 is the PROJECT directory,
+    # and its mtime moves only when a session dir is created or removed directly
+    # under it — never when a live session writes. So the sort was ranking
+    # projects by "when did a session last start here", and preserving the winner.
+    #
+    # MEASURED on a live install (2026-09-07): the truly-active project's newest
+    # FILE was 3 days newer than its own directory mtime, and that directory led a
+    # DORMANT project's by 10 minutes. One more session started in the dormant
+    # project and RED would have preserved that one and reaped the active
+    # project's 54 session workspaces — while logging "preserving active session".
+    #
+    # `%T@ %p` over files, taking the max per project: a project with no files at
+    # all cannot win, which is correct — there is nothing there to preserve.
     local newest_session=""
-    newest_session=$(find "$CC_TMP_DIR" -mindepth 2 -maxdepth 2 -type d -path "*/claude-*" \
+    newest_session=$(find "$CC_TMP_DIR" -mindepth 3 -type f -path "*/claude-*" \
         -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | awk '{print $2}') || true
+    if [[ -n "$newest_session" ]]; then
+        # Reduce the winning FILE to its project dir (…/claude-<uid>/<project>),
+        # which is the unit the sweeps below exclude. Deliberately NOT narrowed to
+        # the single session dir, which is what the review that found this
+        # suggested: that would make RED delete the other sessions of the active
+        # project, i.e. MORE destruction in the nuclear tier, and this change is
+        # about preserving the right thing rather than preserving less of it.
+        local _rel="${newest_session#"$CC_TMP_DIR"/}"
+        local _uid="${_rel%%/*}"
+        local _proj="${_rel#*/}"
+        _proj="${_proj%%/*}"
+        newest_session="$CC_TMP_DIR/$_uid/$_proj"
+    fi
 
     # Reap every depth-1 dir except the newest session's ancestor —
     # object-level and socket-sparing (see reap_dir_sparing_sockets); loose

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -35,6 +35,18 @@ ALERT_DIR="$HOME/.genesis/alerts"
 OOM_EVENTS_FILE="${OOM_EVENTS_FILE:-/sys/fs/cgroup/memory.events}"
 OOM_LOG="$(dirname "$LOG_FILE")/oom_events.log"
 
+# The socket-listing tool for the control-plane check. Overridable for the same
+# reason OOM_EVENTS_FILE is: it is the only way to exercise the "tool absent"
+# branch without rebuilding PATH from scratch, and an operator on a box where
+# iproute2 lives elsewhere can point at it.
+SS_BIN="${SS_BIN:-ss}"
+
+# Zone B's target. A literal /tmp made this whole zone untestable — a test would
+# have had to sweep the real one — which is why its sweeps had no coverage at all
+# until the 2026-09-07 socket-tree finding. Overridable purely as a seam; nothing
+# in production sets it.
+SYS_TMP_DIR="${SYS_TMP_DIR:-/tmp}"
+
 # Durable alert queue (F.3) — emergency-tier events page Telegram via the
 # container drainer. Guarded: if the lib is ever not co-located, degrade to a
 # no-op so `set -e` can never take the service down over an alert.
@@ -76,10 +88,10 @@ dir_usage_mb() {
 }
 
 tmp_usage_pct() {
-    if df -T /tmp 2>/dev/null | grep -q tmpfs; then
+    if df -T "$SYS_TMP_DIR" 2>/dev/null | grep -q tmpfs; then
         # tmpfs: filesystem percentage is meaningful
         local result
-        result=$(df --output=pcent /tmp 2>/dev/null | tail -1 | tr -d ' %') || true
+        result=$(df --output=pcent "$SYS_TMP_DIR" 2>/dev/null | tail -1 | tr -d ' %') || true
         echo "${result:-0}"
     else
         # Not tmpfs (/tmp on root disk): use absolute free space thresholds.
@@ -87,7 +99,7 @@ tmp_usage_pct() {
         # each, sacred ground is 150MB.  Percentage-based thresholds are
         # meaningless when measuring the whole root filesystem.
         local free_mb
-        free_mb=$(df -BM --output=avail /tmp 2>/dev/null | tail -1 | tr -d ' M') || true
+        free_mb=$(df -BM --output=avail "$SYS_TMP_DIR" 2>/dev/null | tail -1 | tr -d ' M') || true
         free_mb="${free_mb:-9999}"
         if (( free_mb > 2048 )); then echo 0       # >2GB free  → green
         elif (( free_mb > 1024 )); then echo 60     # 1-2GB free → yellow
@@ -127,10 +139,138 @@ reap_dir_sparing_sockets() {
     find "$1" -depth -not -type s -delete 2>/dev/null || true
 }
 
+# ── Control plane: severed CC messaging sockets ───────────────
+#
+# Claude Code binds ONE unix socket per session for cross-session messaging,
+# at `$XDG_RUNTIME_DIR/cc-socks/<pid>.sock` — falling back to the process temp
+# dir when XDG_RUNTIME_DIR is unset, which on a Genesis install is cc-tmp: the
+# very directory this daemon reclaims.
+#
+# Deleting the socket PATH does not stop the listener. The process keeps the
+# inode, so `ss` still reports LISTEN and the session looks healthy from the
+# inside, while every peer resolves BY PATH and gets ENOENT. Nothing re-binds
+# after startup, so the session stays unreachable for the rest of its life and
+# cannot notice. Measured 2026-09-05: one sweep severed 3 of 4 sessions here and
+# 6 of 6 on a sibling install; the only survivor had started after the sweep.
+#
+# The sweeps learned to spare sockets, which prevents recurrence but cannot heal
+# a session that is already severed. This check makes the state VISIBLE: it
+# compares live listeners against what is on disk, so a severance is reported
+# instead of silent. Strictly READ-ONLY — a stale socket file is counted and
+# never deleted, because deleting sockets from this daemon is what caused the
+# outage in the first place.
+#
+# Path-agnostic on purpose: directories come from the live listeners, so this
+# keeps working unchanged if the sockets move out of cc-tmp later.
+#
+# SCOPE. This watches the per-session MESSAGING sockets under `cc-socks/` only.
+# CC also runs a separate daemon tree (`/tmp/cc-daemon-<uid>/…` — control, pty and
+# rendezvous sockets for the background-spare machinery), which is deliberately
+# NOT counted here: what severance MEANS there has not been established, and
+# reporting on a subsystem whose failure semantics you have not verified is a
+# guess wearing a number. Those sockets are protected from deletion all the same
+# (see the Zone B sweeps) — protect what you do not understand, report only what
+# you do.
+#
+# Echoes "<status>:<severed>:<stale>:<listeners>". status is one of:
+#   ok      — the probe ran and saw at least one socket, live or left behind.
+#   empty   — the probe ran and saw NOTHING. Usually true (no CC sessions), but
+#             it is also what a detector that has gone blind looks like (an `ss`
+#             output change, a netns move, sockets relocating out of cc-socks),
+#             so it is NOT reported as health.
+#   unknown — the probe could not run at all. Never a clean plane: "could not
+#             measure" and "measured, and it is fine" must not share a value.
+check_control_plane() {
+    command -v "$SS_BIN" >/dev/null 2>&1 || { echo "unknown:0:0:0"; return 0; }
+
+    local raw rc=0
+    raw=$("$SS_BIN" -xlpH state listening 2>/dev/null) || rc=$?
+    if (( rc != 0 )); then
+        echo "unknown:0:0:0"
+        return 0
+    fi
+
+    local listeners=0 severed=0 stale=0
+    local -A live=()
+    local -A dirs=()
+    # Always scan cc-tmp's own socket dir, even when no listener points there:
+    # on a fully-severed install every listener path is already gone from disk,
+    # and that is exactly when the leftovers still need counting. `%/` because
+    # watchgod.conf is re-sourced every poll and a trailing slash there would
+    # otherwise build keys that never match the ones `find` produces.
+    dirs["${CC_TMP_DIR%/}/cc-socks"]=1
+
+    local path
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        listeners=$(( listeners + 1 ))
+        live["$path"]=1
+        dirs["$(dirname "$path")"]=1
+        # -S is "exists AND is a socket": a path replaced by an ordinary file is
+        # no more reachable than a missing one, so it counts as severed too.
+        [[ -S "$path" ]] || severed=$(( severed + 1 ))
+        # NOTE: `ss -xlp` lists every user's sockets. On a shared box another
+        # user's cc-socks path would be counted here, and an unstattable one
+        # would read as severed. Genesis is single-user by design, so this is
+        # left as a known limitation rather than engineered around.
+    done < <(awk '$4 ~ /\/cc-socks\/.*\.sock$/ {print $4}' <<<"$raw" | sort -u)
+
+    local d f
+    for d in "${!dirs[@]}"; do
+        [[ -d "$d" ]] || continue
+        while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            [[ -n "${live[$f]:-}" ]] || stale=$(( stale + 1 ))
+        done < <(find "$d" -maxdepth 1 -type s -name '*.sock' 2>/dev/null)
+    done
+
+    if (( listeners == 0 && stale == 0 )); then
+        echo "empty:0:0:0"
+        return 0
+    fi
+    echo "ok:${severed}:${stale}:${listeners}"
+}
+
+# Should this control-plane reading page, and at what level is the plane now
+# "reported"? Pure arithmetic, kept out of the poll loop so the two rules below
+# can be tested without running the daemon.
+#
+#   CONFIRMATION — the SAME elevated count must appear on two consecutive polls,
+#   which is stricter than "elevated twice": a count still climbing (1 -> 2 -> 3)
+#   stays silent until it settles, and one that oscillates never pages at all.
+#   Severance is permanent — nothing re-binds — so a real one always settles,
+#   usually within a poll or two. What this buys is the false positive: a session
+#   exiting between ss's snapshot and its own unlink reads as one severed listener
+#   for a single poll, and a monitor that cries wolf gets ignored.
+#
+#   HIGH WATER THAT FOLLOWS DOWN — `paged` is the level already reported, and it
+#   drops with the count. Without that, sessions being restarted (4 -> 0) would
+#   leave the bar at 4 and a later, smaller severance would never page.
+#
+# Args: <prev-count> <already-paged-level> <current-count>.
+# Echoes "<0|1 page>:<new already-paged level>".
+control_plane_page_decision() {
+    local prev="$1" paged="$2" severed="$3"
+    if (( severed < paged )); then
+        paged=$severed
+    fi
+    if (( severed > paged )) && (( severed == prev )); then
+        echo "1:${severed}"
+    else
+        echo "0:${paged}"
+    fi
+}
+
 write_state() {
     local cc_tier="$1" cc_used="$2" sys_tier="$3" sys_pct="$4"
+    # Control-plane tuple from check_control_plane, "status:severed:stale:listeners".
+    # Defaulted so a caller that predates this field (the existing tier tests)
+    # still writes a valid state file.
+    local cp="${5:-unknown:0:0:0}"
+    local cp_status cp_severed cp_stale cp_listeners
+    IFS=: read -r cp_status cp_severed cp_stale cp_listeners <<<"$cp"
     local is_tmpfs="false"
-    if df -T /tmp 2>/dev/null | grep -q tmpfs; then
+    if df -T "$SYS_TMP_DIR" 2>/dev/null | grep -q tmpfs; then
         is_tmpfs="true"
     fi
     # Filesystem headroom for cc-tmp's mount. Post-split these describe the
@@ -144,6 +284,7 @@ write_state() {
 {
   "cc_tmp": {"tier": "$cc_tier", "used_mb": $cc_used, "budget_mb": $CC_TMP_BUDGET_MB, "sacred_mb": $SACRED_GROUND_MB, "fs_free_mb": $cc_fs_free, "fs_total_mb": $cc_fs_total},
   "system_tmp": {"tier": "$sys_tier", "used_pct": $sys_pct, "is_tmpfs": $is_tmpfs},
+  "control_plane": {"status": "${cp_status:-unknown}", "severed_sockets": ${cp_severed:-0}, "stale_sockets": ${cp_stale:-0}, "listeners": ${cp_listeners:-0}},
   "poll_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 }
 EOF
@@ -155,15 +296,68 @@ EOF
 # Tiers (% of budget):
 #   Green  : < 50%  — no action
 #   Yellow : > 50%  — clean stale session dirs + old temp files
-#   Orange : > 75%  — yellow + delete caches + kill idle sessions + alert
+#   Orange : > 75%  — yellow + delete caches + warn (never kills a session)
 #   Red    : > 90% OR fs free < sacred — nuclear cleanup + emergency alert
+
+# The 7-day session reap. Two things here are load-bearing, and both were wrong
+# before (measured on a live install, 2026-09-07):
+#
+#   DEPTH. The layout under cc-tmp is claude-<uid>/<project>/<session-uuid>/…,
+#   so depth 2 is the PROJECT directory, not a session. On this install one
+#   depth-2 directory held 54 session workspaces — every live session's
+#   scratchpad and its running background-task output. The intended target has
+#   always been the depth-3 per-SESSION directory.
+#
+#   STALENESS. A directory's mtime tracks only its DIRECT children, so a project
+#   directory goes stale the moment no NEW session starts under it, however busy
+#   the sessions inside are. Measured: the one actively-used project directory
+#   carried an mtime 2.1 days old while its contents had been written seconds
+#   earlier, and every dormant directory showed no divergence at all — the gap
+#   appears precisely on the directory that must not be deleted. Seven quiet days
+#   and a routine 50%-usage YELLOW would have reaped live workspaces at a tier
+#   that pages nobody. So staleness is tested against the CONTENTS, recursively.
+#
+# The freshness probe fails CLOSED: a directory whose freshness cannot be
+# determined counts as fresh and is kept. Deleting on an unreadable probe is how
+# one broken predicate turns a housekeeping sweep into total data loss.
+reap_stale_session_dirs() {
+    local cutoff
+    cutoff=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null) || cutoff=""
+    if [[ -z "$cutoff" ]]; then
+        log WARN "session reap skipped — could not compute the 7-day cutoff"
+        return 0
+    fi
+
+    local sdir probe rc
+    while IFS= read -r sdir; do
+        [[ -z "$sdir" ]] && continue
+        rc=0
+        probe=$(find "$sdir" -newermt "$cutoff" -print -quit 2>/dev/null) || rc=$?
+        if (( rc == 0 )) && [[ -z "$probe" ]]; then
+            # Socket-sparing, like every other sweep in this file. A socket's
+            # mtime is its BIND time, so a session that bound one here and then
+            # wrote nothing for seven days reads as stale — and a plain `rm -rf`
+            # would have this daemon sever a live session in the very sweep added
+            # to stop it doing that. The rmdir then succeeds only if nothing
+            # survived, which is exactly the intent.
+            reap_dir_sparing_sockets "$sdir"
+            rmdir "$sdir" 2>/dev/null || true
+        fi
+    done < <(find "$CC_TMP_DIR" -mindepth 3 -maxdepth 3 -type d -path "*/claude-*/*/*" 2>/dev/null)
+
+    # A project directory the reap emptied holds nothing, and without this they
+    # accumulate. `-mtime +7` is not about staleness here — an empty directory has
+    # nothing to be stale — it closes a race: CC creates <project>/ and then
+    # <session-uuid>/ as two steps, and an rmdir landing between them gives the
+    # starting session ENOENT. A directory created moments ago cannot match.
+    find "$CC_TMP_DIR" -mindepth 2 -maxdepth 2 -type d -path "*/claude-*/*" -empty \
+        -mtime +7 -delete 2>/dev/null || true
+}
 
 clean_cc_yellow() {
     log INFO "Zone A YELLOW — cleaning stale session dirs and temp files"
 
-    # Clean session dirs with mtime > 7 days
-    find "$CC_TMP_DIR" -mindepth 2 -maxdepth 2 -type d -path "*/claude-*/???*" \
-        -mtime +7 -exec rm -rf {} + 2>/dev/null || true
+    reap_stale_session_dirs
 
     # Clean old temp files (*.tmp, *.env, *.yaml) > 1 hour old
     find "$CC_TMP_DIR" -type f \( -name "*.tmp" -o -name "*.env" -o -name "*.yaml" \) \
@@ -172,7 +366,7 @@ clean_cc_yellow() {
 
 clean_cc_orange() {
     clean_cc_yellow
-    log WARN "Zone A ORANGE — deleting caches, then re-measuring before any session kill"
+    log WARN "Zone A ORANGE — deleting caches, then re-measuring (ORANGE never kills a session)"
 
     # Delete claude-skills cache (~35MB, CC re-clones on demand)
     find "$CC_TMP_DIR" -type d -name "claude-skills" -exec rm -rf {} + 2>/dev/null || true
@@ -183,62 +377,36 @@ clean_cc_orange() {
     mkdir -p "$ALERT_DIR"
     touch "$ALERT_DIR/tmp_warning"
 
-    # LOOP-BREAK: re-measure AFTER the cleanup above and kill idle sessions ONLY
-    # if we're still over the ORANGE line. This closes the runaway that killed no
-    # session but churned for ~4.5h on 2026-08-19: the tier that dispatched us
-    # here was measured BEFORE cleanup, so without a re-measure the daemon would
-    # re-enter ORANGE every poll and re-run the kill loop forever while the real
-    # filler (a pytest tree the cache-evict never touches) sat untouched. Killing
-    # an idle session cannot reduce cc-tmp anyway (sessions aren't the filler), so
-    # a kill here is at best useless and at worst reaps an innocent bystander.
-    # Use dir_usage_mb (du) — it drops immediately after rm; df can lag on
-    # held-open deleted fds.
+    # Re-measure AFTER the cleanup above. Use dir_usage_mb (du) — it drops
+    # immediately after rm, where df can lag on held-open deleted fds.
+    #
+    # ORANGE DOES NOT KILL SESSIONS. It used to reap unattached tmux sessions
+    # idle over 2h, and the loop-break comment that guarded it already made the
+    # case against itself: sessions are not what fills cc-tmp, so a kill here
+    # reclaims essentially nothing while destroying a session's entire context.
+    # That is the exact inversion this daemon must not make — it exists to stop
+    # runaway usage from killing CC, not to kill CC to tidy up. The measurement
+    # settles the cost of removing it: across the whole log history
+    # (2026-08-19 → 2026-09-07, 7,563 lines, 1,029 ORANGE polls) the kill loop
+    # was reached ONCE and killed ZERO sessions, so removal is behaviour-neutral
+    # on the record we have. RED remains the pressure valve and still reaps.
     local used_after threshold_orange
     used_after=$(dir_usage_mb "$CC_TMP_DIR")
     threshold_orange=$(( CC_TMP_BUDGET_MB * 75 / 100 ))
     if (( used_after <= threshold_orange )); then
-        log INFO "ORANGE resolved by cache cleanup (used=${used_after}MB <= ${threshold_orange}MB) — no session kills"
+        log INFO "ORANGE resolved by cache cleanup (used=${used_after}MB <= ${threshold_orange}MB)"
         rm -f "$ALERT_DIR/tmp_orange_stuck" 2>/dev/null || true
         return 0
     fi
 
-    log WARN "ORANGE persists after cleanup (used=${used_after}MB > ${threshold_orange}MB) — evaluating idle sessions"
-    # Kill idle CC tmux sessions (unattached, idle > 2h)
-    local killed_any=0
-    while IFS= read -r session; do
-        [[ -z "$session" ]] && continue
-        local sname
-        sname=$(echo "$session" | cut -d: -f1)
-        if [[ "$sname" =~ ^cc- ]]; then
-            local last_activity
-            last_activity=$(tmux display-message -t "$sname" -p '#{session_activity}' 2>/dev/null || echo 0)
-            local now
-            now=$(date +%s)
-            local idle_s=$(( now - last_activity ))
-            if (( idle_s > 7200 )); then
-                log WARN "Killing idle CC session: $sname (idle ${idle_s}s)"
-                # Count a reap only when tmux actually killed it — if the session
-                # vanished between listing and killing (or the kill fails), we
-                # reclaimed nothing, so killed_any must stay 0 and the stuck
-                # marker must still be recorded rather than silently skipped.
-                if tmux kill-session -t "$sname" 2>/dev/null; then
-                    killed_any=1
-                fi
-            fi
-        fi
-    done < <(tmux list-sessions -F '#{session_name}:#{session_attached}' 2>/dev/null | grep ':0$' || true)
-
-    # Stuck-ORANGE: cleanup didn't resolve it AND nothing was killable → the
-    # daemon has nothing safe left to do. Per design D2 (ORANGE is dashboard/log
-    # only — only RED pages) this does NOT page; it records the stuck state ONCE
-    # (dedupe flag) in the log instead of silently re-polling forever, so the
-    # condition is discoverable. If cc-tmp keeps filling it escalates to RED,
-    # which DOES page. The flag is cleared (main loop) whenever cc-tmp LEAVES
-    # ORANGE (green/yellow/red) — never on a kill: reaping an idle session does
-    # not reduce cc-tmp, so a kill that leaves us ORANGE keeps cc_tier==orange and
-    # must not re-arm and re-log the same episode.
-    if (( killed_any == 0 )) && [[ ! -f "$ALERT_DIR/tmp_orange_stuck" ]]; then
-        log WARN "cc-tmp STUCK ORANGE (used=${used_after}MB, budget=${CC_TMP_BUDGET_MB}MB): reclaim freed nothing and no idle (>2h) session is killable — non-reclaimable data is filling cc-tmp (see cc_tmp_top snapshots). Dashboard/log-only per D2; RED will page if it escalates."
+    # Stuck-ORANGE: the cleanup did not resolve it and there is nothing else safe
+    # to do. Per design D2 (ORANGE is dashboard/log only — only RED pages) this
+    # does NOT page; it records the stuck state ONCE (dedupe flag) so the
+    # condition is discoverable instead of silently re-polling forever. If cc-tmp
+    # keeps filling it escalates to RED, which DOES page. The flag is cleared in
+    # the main loop whenever cc-tmp LEAVES ORANGE.
+    if [[ ! -f "$ALERT_DIR/tmp_orange_stuck" ]]; then
+        log WARN "cc-tmp STUCK ORANGE (used=${used_after}MB, budget=${CC_TMP_BUDGET_MB}MB): reclaim freed nothing — non-reclaimable data is filling cc-tmp (see cc_tmp_top snapshots). Dashboard/log-only per D2; RED will page if it escalates."
         touch "$ALERT_DIR/tmp_orange_stuck"
     fi
 }
@@ -371,16 +539,27 @@ check_cc_tmp() {
 
 clean_sys_yellow() {
     log INFO "Zone B YELLOW — cleaning /tmp files not accessed in 7+ days"
-    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
+    find "$SYS_TMP_DIR" -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
         -atime +7 -delete 2>/dev/null || true
-    find /tmp -mindepth 1 -type d -empty -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" \
+    # The file sweeps above spare `*.sock`; this one must spare their DIRECTORIES,
+    # which the socket exclusion cannot cover. MEASURED 2026-09-07: this predicate
+    # matched `/tmp/cc-socks` and `/tmp/cc-daemon-1000/<id>/pty` — the latter an
+    # empty rendezvous directory inside a LIVE CC daemon's tree, created up front
+    # and populated later. An empty directory under a socket tree is a rendezvous
+    # point, not garbage, and deleting one is the same failure class as deleting
+    # the socket itself. (An earlier audit of this sweep called it safe "because
+    # socket-holding dirs are non-empty" — true of the directory holding the
+    # socket, false of its siblings.)
+    find "$SYS_TMP_DIR" -mindepth 1 -type d -empty \
+        -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" \
+        -not -path "*/cc-socks*" -not -path "*/cc-daemon-*" \
         -delete 2>/dev/null || true
 }
 
 clean_sys_orange() {
     clean_sys_yellow
     log WARN "Zone B ORANGE — cleaning /tmp files not accessed in 3+ days"
-    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
+    find "$SYS_TMP_DIR" -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
         -atime +3 -delete 2>/dev/null || true
     mkdir -p "$ALERT_DIR"
     touch "$ALERT_DIR/tmp_warning"
@@ -389,14 +568,14 @@ clean_sys_orange() {
 clean_sys_red() {
     log WARN "Zone B RED — aggressive /tmp cleanup"
     # Files not accessed in 1+ day
-    find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
+    find "$SYS_TMP_DIR" -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
         -atime +1 -delete 2>/dev/null || true
 
     # If still critical, remove all regular files except last 1h, sockets, tmux, pytest, claude
     local pct_after
     pct_after=$(tmp_usage_pct)
     if (( pct_after > 85 )); then
-        find /tmp -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
+        find "$SYS_TMP_DIR" -type f -not -path "*/tmux-*" -not -path "*/pytest-*" -not -path "*/claude-*" -not -name "*.sock" \
             -mmin +60 -delete 2>/dev/null || true
     fi
 
@@ -498,19 +677,84 @@ main() {
         log INFO "OOM event capture armed (baseline oom_kill=${oom_baseline})"
     fi
 
+    # Control-plane paging state. `prev` is the previous poll's count and starts
+    # at -1 so no page can fire on the daemon's very first reading — an elevated
+    # count must be CONFIRMED by a second consecutive poll. Without that, a
+    # session exiting between ss's snapshot and its own unlink reads as one
+    # severed listener for a single poll and would page spuriously.
+    #
+    # `paged` is the level already reported. It survives a restart in a file, the
+    # way the RED tier's transition marker does: the unit is Restart=always, a
+    # severance is UNHEALABLE without restarting the sessions, and an in-memory
+    # level would therefore re-page the same unfixed condition after every deploy
+    # or crash-restart. It still follows the count DOWN, so once the sessions ARE
+    # restarted a later, smaller severance pages again.
+    local cp_prev_severed=-1 cp_last=""
+    local cp_paged_file="$ALERT_DIR/control_plane_paged"
+    local cp_paged_severed
+    cp_paged_severed=$(cat "$cp_paged_file" 2>/dev/null) || cp_paged_severed=""
+    [[ "$cp_paged_severed" =~ ^[0-9]+$ ]] || cp_paged_severed=0
+
     while true; do
         load_config
 
-        local cc_result sys_result
+        local cc_result sys_result cp_result
         cc_result=$(check_cc_tmp)
         sys_result=$(check_sys_tmp)
+        cp_result=$(check_control_plane)
 
         local cc_tier="${cc_result%%:*}"
         local cc_used="${cc_result##*:}"
         local sys_tier="${sys_result%%:*}"
         local sys_pct="${sys_result##*:}"
 
-        write_state "$cc_tier" "$cc_used" "$sys_tier" "$sys_pct"
+        write_state "$cc_tier" "$cc_used" "$sys_tier" "$sys_pct" "$cp_result"
+
+        local cp_status cp_severed cp_stale cp_listeners
+        IFS=: read -r cp_status cp_severed cp_stale cp_listeners <<<"$cp_result"
+
+        # Log only on CHANGE — this runs every poll and an unchanged plane has
+        # nothing to say.
+        if [[ "$cp_result" != "$cp_last" ]]; then
+            case "$cp_status" in
+                ok)
+                    log INFO "control plane: ${cp_listeners} listener(s), ${cp_severed} severed (socket path deleted under a live listener), ${cp_stale} stale socket file(s)" ;;
+                empty)
+                    log INFO "control plane: no CC sockets visible — either no session is running, or this check can no longer see them" ;;
+                *)
+                    log INFO "control plane: unknown (${SS_BIN} unavailable or failed) — severance cannot be detected on this box" ;;
+            esac
+            cp_last="$cp_result"
+        fi
+
+        if [[ "$cp_status" == "ok" ]]; then
+            local cp_decision cp_should_page
+            cp_decision=$(control_plane_page_decision \
+                "$cp_prev_severed" "$cp_paged_severed" "$cp_severed")
+            cp_should_page="${cp_decision%%:*}"
+            cp_paged_severed="${cp_decision##*:}"
+            printf '%s' "$cp_paged_severed" > "$cp_paged_file" 2>/dev/null || true
+            if [[ "$cp_should_page" == "1" ]]; then
+                log WARN "control plane SEVERED: ${cp_severed} of ${cp_listeners} session(s) unreachable"
+                # `warning` is the honest severity for the event, but note it does
+                # NOT buy a quieter delivery: the container drain submits every
+                # queued entry at one category and salience regardless of this
+                # argument, so this pages exactly like the RED emergency does.
+                # That is intended here (the owner asked to be paged on a NEW
+                # severance) — recorded so nobody infers a tier that does not exist.
+                queue_alert warning "watchgod:control-plane" \
+                    "CC control plane severed (${cp_severed} session(s) unreachable)" \
+                    "${cp_severed} of ${cp_listeners} live Claude Code session(s) are listening on a socket whose PATH no longer exists, so peers get ENOENT and cannot reach them. Nothing re-binds after startup — the only remedy is restarting those sessions. Check what deleted the paths under cc-socks." \
+                    "watchgod:control_plane:${cp_severed}"
+            fi
+            cp_prev_severed=$cp_severed
+        else
+            # Neither `unknown` nor `empty` is a recovery: forget the previous
+            # count so the next readable one needs its own confirmation, and leave
+            # the already-paged level alone so a blind spell cannot silently
+            # re-arm a page for a severance that was already reported.
+            cp_prev_severed=-1
+        fi
 
         # Durable OOM capture — snapshot + page on any NEW cgroup OOM kill.
         oom_baseline=$(check_oom_events "$oom_baseline")

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -191,6 +191,7 @@ check_control_plane() {
     fi
 
     local listeners=0 severed=0 stale=0
+    local severed_ids=""
     local -A live=()
     local -A dirs=()
     # Always scan cc-tmp's own socket dir, even when no listener points there:
@@ -208,7 +209,15 @@ check_control_plane() {
         dirs["$(dirname "$path")"]=1
         # -S is "exists AND is a socket": a path replaced by an ordinary file is
         # no more reachable than a missing one, so it counts as severed too.
-        [[ -S "$path" ]] || severed=$(( severed + 1 ))
+        if [[ ! -S "$path" ]]; then
+            severed=$(( severed + 1 ))
+            # Carry the IDENTITY, not just the tally. A count cannot tell "the
+            # same four sessions are still severed" from "those four exited and a
+            # different one broke": both read as a number going down, and the new
+            # severance would never page. Basenames are `<pid>.sock`, so the field
+            # is bounded by the number of live CC sessions.
+            severed_ids+="${severed_ids:+ }$(basename "$path")"
+        fi
         # NOTE: `ss -xlp` lists every user's sockets. On a shared box another
         # user's cc-socks path would be counted here, and an unstattable one
         # would read as severed. Genesis is single-user by design, so this is
@@ -225,40 +234,48 @@ check_control_plane() {
     done
 
     if (( listeners == 0 && stale == 0 )); then
-        echo "empty:0:0:0"
+        echo "empty:0:0:0:"
         return 0
     fi
-    echo "ok:${severed}:${stale}:${listeners}"
+    # Fifth field: the severed socket basenames, space separated. write_state
+    # reads only the first four, so the protocol is unchanged for it.
+    echo "ok:${severed}:${stale}:${listeners}:${severed_ids}"
 }
 
-# Should this control-plane reading page, and at what level is the plane now
-# "reported"? Pure arithmetic, kept out of the poll loop so the two rules below
-# can be tested without running the daemon.
+# Should this control-plane reading page, and which severances are now reported?
+# Pure set logic, kept out of the poll loop so it can be tested without running
+# the daemon.
 #
-#   CONFIRMATION — the SAME elevated count must appear on two consecutive polls,
-#   which is stricter than "elevated twice": a count still climbing (1 -> 2 -> 3)
-#   stays silent until it settles, and one that oscillates never pages at all.
-#   Severance is permanent — nothing re-binds — so a real one always settles,
-#   usually within a poll or two. What this buys is the false positive: a session
-#   exiting between ss's snapshot and its own unlink reads as one severed listener
+# IDENTITIES, NOT A COUNT. An earlier version tracked a high-water COUNT that
+# followed the number down, and a count cannot distinguish "the same four
+# sessions are still severed" from "those four exited and a different one broke".
+# Both read as 4 -> 1, the bar dropped to 1, and the NEW severance then never
+# paged — silently losing the one alert the detector exists to send. Sets do not
+# have that failure: a severance is news iff its own id has not been reported.
+#
+#   CONFIRMATION — an id must appear on two consecutive polls before it can page.
+#   A session exiting between ss's snapshot and its own unlink reads as severed
 #   for a single poll, and a monitor that cries wolf gets ignored.
 #
-#   HIGH WATER THAT FOLLOWS DOWN — `paged` is the level already reported, and it
-#   drops with the count. Without that, sessions being restarted (4 -> 0) would
-#   leave the bar at 4 and a later, smaller severance would never page.
+#   FORGET WHAT RECOVERED — an id that is no longer severed drops out of the
+#   reported set, so if that pid is ever severed again it is news again.
 #
-# Args: <prev-count> <already-paged-level> <current-count>.
-# Echoes "<0|1 page>:<new already-paged level>".
+# Args: <prev-ids> <already-paged-ids> <current-ids>  (space separated).
+# Echoes "<0|1 page>:<new already-paged ids>".
 control_plane_page_decision() {
-    local prev="$1" paged="$2" severed="$3"
-    if (( severed < paged )); then
-        paged=$severed
-    fi
-    if (( severed > paged )) && (( severed == prev )); then
-        echo "1:${severed}"
-    else
-        echo "0:${paged}"
-    fi
+    local prev=" $1 " paged=" $2 " cur="$3"
+    local id page=0 new_paged=""
+    for id in $cur; do
+        # Confirmed = seen on the previous poll too.
+        if [[ "$prev" == *" $id "* ]]; then
+            new_paged+="${new_paged:+ }$id"
+            [[ "$paged" == *" $id "* ]] || page=1
+        elif [[ "$paged" == *" $id "* ]]; then
+            # Already reported and still severed: keep it, do not re-page.
+            new_paged+="${new_paged:+ }$id"
+        fi
+    done
+    echo "${page}:${new_paged}"
 }
 
 write_state() {
@@ -430,10 +447,19 @@ clean_cc_red() {
     # project and RED would have preserved that one and reaped the active
     # project's 54 session workspaces — while logging "preserving active session".
     #
-    # `%T@ %p` over files, taking the max per project: a project with no files at
-    # all cannot win, which is correct — there is nothing there to preserve.
+    # Every entry at depth 3 or deeper, of ANY type — not just files.
+    #
+    # `-type f` was wrong in the other direction and is the regression this line
+    # exists to avoid: a session that has created its workspace but not yet
+    # written a regular file has no candidate at all, `newest_session` comes back
+    # empty, and the depth-1 sweep below then reaps the live session's own
+    # directories out from under it (its next write gets ENOENT). Directories
+    # count as evidence of life precisely because a brand-new session IS a fresh
+    # directory and nothing else. The depth floor is what keeps this correct: the
+    # stale PROJECT directory at depth 2 is still excluded, so the divergence
+    # this whole change is about cannot come back.
     local newest_session=""
-    newest_session=$(find "$CC_TMP_DIR" -mindepth 3 -type f -path "*/claude-*" \
+    newest_session=$(find "$CC_TMP_DIR" -mindepth 3 -path "*/claude-*" \
         -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | awk '{print $2}') || true
     if [[ -n "$newest_session" ]]; then
         # Reduce the winning FILE to its project dir (…/claude-<uid>/<project>),
@@ -719,11 +745,14 @@ main() {
     # level would therefore re-page the same unfixed condition after every deploy
     # or crash-restart. It still follows the count DOWN, so once the sessions ARE
     # restarted a later, smaller severance pages again.
-    local cp_prev_severed=-1 cp_last=""
+    local cp_prev_ids="" cp_last=""
     local cp_paged_file="$ALERT_DIR/control_plane_paged"
-    local cp_paged_severed
-    cp_paged_severed=$(cat "$cp_paged_file" 2>/dev/null) || cp_paged_severed=""
-    [[ "$cp_paged_severed" =~ ^[0-9]+$ ]] || cp_paged_severed=0
+    local cp_paged_ids
+    cp_paged_ids=$(cat "$cp_paged_file" 2>/dev/null) || cp_paged_ids=""
+    # Ids are `<pid>.sock` basenames; anything else is a file from an older
+    # version (which stored a count) or corruption — start clean rather than
+    # treat a stray token as a reported severance.
+    [[ "$cp_paged_ids" =~ ^([0-9]+\.sock( [0-9]+\.sock)*)?$ ]] || cp_paged_ids=""
 
     while true; do
         load_config
@@ -740,8 +769,8 @@ main() {
 
         write_state "$cc_tier" "$cc_used" "$sys_tier" "$sys_pct" "$cp_result"
 
-        local cp_status cp_severed cp_stale cp_listeners
-        IFS=: read -r cp_status cp_severed cp_stale cp_listeners <<<"$cp_result"
+        local cp_status cp_severed cp_stale cp_listeners cp_ids
+        IFS=: read -r cp_status cp_severed cp_stale cp_listeners cp_ids <<<"$cp_result"
 
         # Log only on CHANGE — this runs every poll and an unchanged plane has
         # nothing to say.
@@ -760,10 +789,9 @@ main() {
         if [[ "$cp_status" == "ok" ]]; then
             local cp_decision cp_should_page
             cp_decision=$(control_plane_page_decision \
-                "$cp_prev_severed" "$cp_paged_severed" "$cp_severed")
+                "$cp_prev_ids" "$cp_paged_ids" "$cp_ids")
             cp_should_page="${cp_decision%%:*}"
-            cp_paged_severed="${cp_decision##*:}"
-            printf '%s' "$cp_paged_severed" > "$cp_paged_file" 2>/dev/null || true
+            local cp_next_paged="${cp_decision#*:}"
             if [[ "$cp_should_page" == "1" ]]; then
                 log WARN "control plane SEVERED: ${cp_severed} of ${cp_listeners} session(s) unreachable"
                 # `warning` is the honest severity for the event, but note it does
@@ -772,18 +800,37 @@ main() {
                 # argument, so this pages exactly like the RED emergency does.
                 # That is intended here (the owner asked to be paged on a NEW
                 # severance) — recorded so nobody infers a tier that does not exist.
+                # Record the severance as reported ONLY once the entry is on
+                # disk. `queue_alert` is best-effort by contract — it swallows
+                # every failure and degrades to a no-op when its library is
+                # absent — so marking first would let an unwritable queue silence
+                # the alert permanently, on exactly the degraded box this
+                # detector exists to expose. Count the queue instead of trusting
+                # the return value.
+                local _q="${_ALERT_QUEUE_ROOT:-$HOME/.genesis/alerts/queue}"
+                local _before _after
+                _before=$(find "$_q" -maxdepth 1 -name '*.json' 2>/dev/null | wc -l)
                 queue_alert warning "watchgod:control-plane" \
                     "CC control plane severed (${cp_severed} session(s) unreachable)" \
                     "${cp_severed} of ${cp_listeners} live Claude Code session(s) are listening on a socket whose PATH no longer exists, so peers get ENOENT and cannot reach them. Nothing re-binds after startup — the only remedy is restarting those sessions. Check what deleted the paths under cc-socks." \
                     "watchgod:control_plane:${cp_severed}"
+                _after=$(find "$_q" -maxdepth 1 -name '*.json' 2>/dev/null | wc -l)
+                if (( _after > _before )); then
+                    cp_paged_ids="$cp_next_paged"
+                else
+                    log WARN "control-plane alert could not be queued (${_q}) — leaving the severance UNREPORTED so a later poll retries"
+                fi
+            else
+                cp_paged_ids="$cp_next_paged"
             fi
-            cp_prev_severed=$cp_severed
+            printf '%s' "$cp_paged_ids" > "$cp_paged_file" 2>/dev/null || true
+            cp_prev_ids="$cp_ids"
         else
             # Neither `unknown` nor `empty` is a recovery: forget the previous
-            # count so the next readable one needs its own confirmation, and leave
-            # the already-paged level alone so a blind spell cannot silently
+            # reading so the next readable one needs its own confirmation, and
+            # leave the reported set alone so a blind spell cannot silently
             # re-arm a page for a severance that was already reported.
-            cp_prev_severed=-1
+            cp_prev_ids=""
         fi
 
         # Durable OOM capture — snapshot + page on any NEW cgroup OOM kill.

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -496,7 +496,7 @@ clean_cc_red() {
     # live from filesystem mtimes at all, when the live set is directly
     # observable (this file already enumerates listening CC sockets in
     # `check_control_plane`). That is a redesign of the nuclear tier's preserve
-    # rule and is tracked separately — it must not ride along in a change about
+    # rule, tracked in issue #1878 — it must not ride along in a change about
     # reaping sessions instead of projects.
     #
     # KNOWN LIMITATION, carried from main unchanged: depth 2 is the PROJECT

--- a/scripts/tmp_watchgod.sh
+++ b/scripts/tmp_watchgod.sh
@@ -27,6 +27,7 @@ CONF_FILE="$HOME/.genesis/config/watchgod.conf"
 STATE_FILE="$HOME/.genesis/watchgod_state.json"
 LOG_FILE="$HOME/.genesis/logs/tmp_watchgod.log"
 ALERT_DIR="$HOME/.genesis/alerts"
+CP_IDS_FILE="$HOME/.genesis/alerts/control_plane_severed_ids"
 
 # OOM event capture: the container cgroup-v2 cumulative oom_kill counter, and a
 # durable log for the snapshots. OOM_EVENTS_FILE is overridable so tests can
@@ -69,6 +70,12 @@ load_config() {
         # shellcheck source=/dev/null
         source "$CONF_FILE"
     fi
+    # Normalise ONCE, here, so no later site has to remember. watchgod.conf is
+    # re-sourced every poll and `CC_TMP_DIR=/path/to/cc-tmp/` is a perfectly valid
+    # thing to write there; a trailing slash then broke string surgery downstream
+    # in one place while another had its own `%/` guard — normalised here, and
+    # nowhere else, that whole class cannot recur (Codex P2, PR #1856).
+    CC_TMP_DIR="${CC_TMP_DIR%/}"
 }
 
 # ── Logging ──────────────────────────────────────────────────
@@ -136,7 +143,23 @@ reap_dir_sparing_sockets() {
     # stay non-empty so they survive; a dir holding no sockets is removed
     # entirely, exactly like rm -rf. -delete failures on non-empty dirs are
     # expected and suppressed; GNU find continues past them.
-    find "$1" -depth -not -type s -delete 2>/dev/null || true
+    #
+    # The socket DIRECTORY is spared as well, because sparing the inodes is not
+    # enough: an EMPTY cc-socks has no socket inside it to keep it non-empty, so
+    # the depth-first pass removes it — and it is the directory the next session
+    # binds into. Zone B's empty-dir sweep already spares it; this is the same
+    # rule in Zone A, applied at the one function every Zone A caller goes
+    # through rather than at each call site.
+    #
+    # `-type d -name` and NOT `-path '*/cc-socks*'`: `-path` matches the whole
+    # path and its `*` crosses `/`, so the path form would also spare every
+    # reclaimable FILE sitting inside the directory — which RED must still
+    # reclaim, and which `test_red_reclaims_files_inside_socket_dir` pins.
+    # `-name` matches the basename only and cannot widen.
+    find "$1" -depth -not -type s \
+        -not \( -type d -name 'cc-socks' \) \
+        -not \( -type d -name 'cc-daemon-*' \) \
+        -delete 2>/dev/null || true
 }
 
 # ── Control plane: severed CC messaging sockets ───────────────
@@ -196,10 +219,11 @@ check_control_plane() {
     local -A dirs=()
     # Always scan cc-tmp's own socket dir, even when no listener points there:
     # on a fully-severed install every listener path is already gone from disk,
-    # and that is exactly when the leftovers still need counting. `%/` because
-    # watchgod.conf is re-sourced every poll and a trailing slash there would
-    # otherwise build keys that never match the ones `find` produces.
-    dirs["${CC_TMP_DIR%/}/cc-socks"]=1
+    # and that is exactly when the leftovers still need counting. The trailing
+    # slash a re-sourced watchgod.conf could carry is stripped once in
+    # `load_config` (a local `%/` here would be a second place to remember), so
+    # this key always matches the ones `find` produces.
+    dirs["$CC_TMP_DIR/cc-socks"]=1
 
     local path
     while IFS= read -r path; do
@@ -222,7 +246,16 @@ check_control_plane() {
         # user's cc-socks path would be counted here, and an unstattable one
         # would read as severed. Genesis is single-user by design, so this is
         # left as a known limitation rather than engineered around.
-    done < <(awk '$4 ~ /\/cc-socks\/.*\.sock$/ {print $4}' <<<"$raw" | sort -u)
+        # Whichever FIELD looks like a socket path — never a fixed index. Two
+        # reviewers pushed this in opposite directions (one to $4, one to $5)
+        # because the column count is not stable: `ss` prints a State column for
+        # unix sockets, and MEASURED here on iproute2-6.1.0 with `state listening`
+        # it does not, putting the path at $4 while the man page's row shape says
+        # $5. A guard whose verdict depends on which release of a tool is
+        # installed is the wrong shape; matching the field by what it IS cannot
+        # be wrong either way. Scoped to a field, so the `users:((...))` column
+        # can never supply one.
+    done < <(awk '{for (i = 1; i <= NF; i++) if ($i ~ /\/cc-socks\/[^\/]*\.sock$/) { print $i; break }}' <<<"$raw" | sort -u)
 
     local d f
     for d in "${!dirs[@]}"; do
@@ -233,13 +266,19 @@ check_control_plane() {
         done < <(find "$d" -maxdepth 1 -type s -name '*.sock' 2>/dev/null)
     done
 
+    # Identities travel on their OWN channel, never as a fifth field. Packing them
+    # into the colon-delimited string meant two readers with different arities:
+    # `write_state` reads four, so bash handed it "1:123.sock" as the listener
+    # count and the state file became invalid JSON exactly when a severance made
+    # it worth reading (Codex P1, PR #1856). A positional protocol with a
+    # variable-length tail cannot be extended safely; this one is fixed-width
+    # again, and the tail has a file of its own.
+    printf '%s' "$severed_ids" > "$CP_IDS_FILE" 2>/dev/null || true
     if (( listeners == 0 && stale == 0 )); then
-        echo "empty:0:0:0:"
+        echo "empty:0:0:0"
         return 0
     fi
-    # Fifth field: the severed socket basenames, space separated. write_state
-    # reads only the first four, so the protocol is unchanged for it.
-    echo "ok:${severed}:${stale}:${listeners}:${severed_ids}"
+    echo "ok:${severed}:${stale}:${listeners}"
 }
 
 # Should this control-plane reading page, and which severances are now reported?
@@ -431,49 +470,46 @@ clean_cc_orange() {
 clean_cc_red() {
     log WARN "Zone A RED — NUCLEAR cleanup, preserving active session"
 
-    # Which workspace is ACTIVE — by the newest file anywhere inside it, not by a
-    # directory's own mtime.
+    # Which workspace is ACTIVE. UNCHANGED FROM main, DELIBERATELY — see below.
     #
-    # This is the same defect the YELLOW reap had, in the tier where getting it
-    # wrong costs the most, and fixing it in only one of the two places would have
-    # left the class alive in the nuclear one. Depth 2 is the PROJECT directory,
-    # and its mtime moves only when a session dir is created or removed directly
-    # under it — never when a live session writes. So the sort was ranking
-    # projects by "when did a session last start here", and preserving the winner.
+    # This selector is NOT part of this change, and two attempts to improve it
+    # here both shipped a regression that deleted the live session workspace
+    # while logging "preserving active session". Recorded so the next reader does
+    # not make it three:
     #
-    # MEASURED on a live install (2026-09-07): the truly-active project's newest
-    # FILE was 3 days newer than its own directory mtime, and that directory led a
-    # DORMANT project's by 10 minutes. One more session started in the dormant
-    # project and RED would have preserved that one and reaped the active
-    # project's 54 session workspaces — while logging "preserving active session".
+    #   1. Widening to `-mindepth 3 -type f` (to let a file's mtime outrank a
+    #      stale directory mtime) silently RE-ANCHORED the `-path` glob. `find`'s
+    #      `-path` matches the WHOLE path and its `*` crosses `/`, so with the
+    #      `-maxdepth` bound gone, `*/claude-*` matches a component OR BASENAME
+    #      beginning `claude-` ANYWHERE in the tree. A file under an unrelated
+    #      depth-1 directory then wins the sort, the reduction below names that
+    #      directory as the active project, and the depth-1 loop reaps the real
+    #      one. MEASURED with one decoy: main preserves the live tree, the
+    #      widened selector destroys it. The shape is not hypothetical — pytest
+    #      basetemps live inside cc-tmp, so the test suite plants it.
+    #   2. Reducing the winning entry to `<uid>/<project>` by string surgery
+    #      (`${p#$ROOT/}` then `%%/*`) turns a mis-selection into a plausible
+    #      wrong answer rather than an obvious one, and inherits every
+    #      normalisation bug in the configured path.
     #
-    # Every entry at depth 3 or deeper, of ANY type — not just files.
+    # The real fix is not a narrower glob: RED should not INFER which session is
+    # live from filesystem mtimes at all, when the live set is directly
+    # observable (this file already enumerates listening CC sockets in
+    # `check_control_plane`). That is a redesign of the nuclear tier's preserve
+    # rule and is tracked separately — it must not ride along in a change about
+    # reaping sessions instead of projects.
     #
-    # `-type f` was wrong in the other direction and is the regression this line
-    # exists to avoid: a session that has created its workspace but not yet
-    # written a regular file has no candidate at all, `newest_session` comes back
-    # empty, and the depth-1 sweep below then reaps the live session's own
-    # directories out from under it (its next write gets ENOENT). Directories
-    # count as evidence of life precisely because a brand-new session IS a fresh
-    # directory and nothing else. The depth floor is what keeps this correct: the
-    # stale PROJECT directory at depth 2 is still excluded, so the divergence
-    # this whole change is about cannot come back.
+    # KNOWN LIMITATION, carried from main unchanged: depth 2 is the PROJECT
+    # directory, whose mtime moves only when a session dir is created or removed
+    # directly under it — never when a live session writes. So this ranks
+    # projects by "when did a session last start here". MEASURED on a live
+    # install (2026-09-07): the active project's newest FILE was 3 days newer
+    # than its own directory mtime, and that directory led a dormant project's by
+    # 10 minutes. The YELLOW reap below no longer has this defect; RED still does,
+    # and closing it is the tracked redesign above.
     local newest_session=""
-    newest_session=$(find "$CC_TMP_DIR" -mindepth 3 -path "*/claude-*" \
+    newest_session=$(find "$CC_TMP_DIR" -mindepth 2 -maxdepth 2 -type d -path "*/claude-*" \
         -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | awk '{print $2}') || true
-    if [[ -n "$newest_session" ]]; then
-        # Reduce the winning FILE to its project dir (…/claude-<uid>/<project>),
-        # which is the unit the sweeps below exclude. Deliberately NOT narrowed to
-        # the single session dir, which is what the review that found this
-        # suggested: that would make RED delete the other sessions of the active
-        # project, i.e. MORE destruction in the nuclear tier, and this change is
-        # about preserving the right thing rather than preserving less of it.
-        local _rel="${newest_session#"$CC_TMP_DIR"/}"
-        local _uid="${_rel%%/*}"
-        local _proj="${_rel#*/}"
-        _proj="${_proj%%/*}"
-        newest_session="$CC_TMP_DIR/$_uid/$_proj"
-    fi
 
     # Reap every depth-1 dir except the newest session's ancestor —
     # object-level and socket-sparing (see reap_dir_sparing_sockets); loose
@@ -749,10 +785,17 @@ main() {
     local cp_paged_file="$ALERT_DIR/control_plane_paged"
     local cp_paged_ids
     cp_paged_ids=$(cat "$cp_paged_file" 2>/dev/null) || cp_paged_ids=""
-    # Ids are `<pid>.sock` basenames; anything else is a file from an older
-    # version (which stored a count) or corruption — start clean rather than
-    # treat a stray token as a reported severance.
-    [[ "$cp_paged_ids" =~ ^([0-9]+\.sock( [0-9]+\.sock)*)?$ ]] || cp_paged_ids=""
+    # Ids are socket basenames; anything else is a file from an older version
+    # (which stored a count) or corruption — start clean rather than treat a
+    # stray token as a reported severance.
+    #
+    # This pattern must stay as WIDE as the producer, which takes any basename
+    # ending `.sock` (see check_control_plane). Today CC names them `<pid>.sock`,
+    # but a validator narrower than its producer fails in the worst direction:
+    # ONE non-conforming id would fail the whole-string match, discard every
+    # reported severance, and re-page the same unhealed condition after every
+    # restart — exactly what this file exists to prevent.
+    [[ "$cp_paged_ids" =~ ^([^[:space:]]+\.sock( [^[:space:]]+\.sock)*)?$ ]] || cp_paged_ids=""
 
     while true; do
         load_config
@@ -769,8 +812,12 @@ main() {
 
         write_state "$cc_tier" "$cc_used" "$sys_tier" "$sys_pct" "$cp_result"
 
+        # FOUR fields, matching the fixed-width contract check_control_plane
+        # publishes. The identities come from their own channel — see the note
+        # there on why a variable-length tail cannot ride a positional string.
         local cp_status cp_severed cp_stale cp_listeners cp_ids
-        IFS=: read -r cp_status cp_severed cp_stale cp_listeners cp_ids <<<"$cp_result"
+        IFS=: read -r cp_status cp_severed cp_stale cp_listeners <<<"$cp_result"
+        cp_ids=$(cat "$CP_IDS_FILE" 2>/dev/null) || cp_ids=""
 
         # Log only on CHANGE — this runs every poll and an unchanged plane has
         # nothing to say.
@@ -794,6 +841,13 @@ main() {
             local cp_next_paged="${cp_decision#*:}"
             if [[ "$cp_should_page" == "1" ]]; then
                 log WARN "control plane SEVERED: ${cp_severed} of ${cp_listeners} session(s) unreachable"
+                # The dedupe key carries the IDENTITIES, for the same reason the
+                # paging decision does. Keyed on the COUNT, a severance of one
+                # session replaced by a severance of a different session inside
+                # the drainer's 24h dedupe window is a second "count 1" alert —
+                # rejected and unlinked, while this daemon has already recorded
+                # the new id as paged and will never raise it again (Codex P2,
+                # PR #1856).
                 # `warning` is the honest severity for the event, but note it does
                 # NOT buy a quieter delivery: the container drain submits every
                 # queued entry at one category and salience regardless of this
@@ -809,12 +863,21 @@ main() {
                 # the return value.
                 local _q="${_ALERT_QUEUE_ROOT:-$HOME/.genesis/alerts/queue}"
                 local _before _after
-                _before=$(find "$_q" -maxdepth 1 -name '*.json' 2>/dev/null | wc -l)
+                # `set -euo pipefail` is on, and `find` on a MISSING directory
+                # exits nonzero — which under pipefail fails the whole
+                # substitution and kills the daemon outright. On a clean install
+                # the queue does not exist until queue_alert makes it, so the
+                # probe added to verify delivery would have taken the service
+                # down on the first severance and again after every restart
+                # (Codex P1, PR #1856). Create it first, and give every count a
+                # floor so no arithmetic can inherit an empty string.
+                mkdir -p "$_q" 2>/dev/null || true
+                _before=$( { find "$_q" -maxdepth 1 -name '*.json' 2>/dev/null || true; } | wc -l)
                 queue_alert warning "watchgod:control-plane" \
                     "CC control plane severed (${cp_severed} session(s) unreachable)" \
                     "${cp_severed} of ${cp_listeners} live Claude Code session(s) are listening on a socket whose PATH no longer exists, so peers get ENOENT and cannot reach them. Nothing re-binds after startup — the only remedy is restarting those sessions. Check what deleted the paths under cc-socks." \
-                    "watchgod:control_plane:${cp_severed}"
-                _after=$(find "$_q" -maxdepth 1 -name '*.json' 2>/dev/null | wc -l)
+                    "watchgod:control_plane:${cp_ids// /,}"
+                _after=$( { find "$_q" -maxdepth 1 -name '*.json' 2>/dev/null || true; } | wc -l)
                 if (( _after > _before )); then
                     cp_paged_ids="$cp_next_paged"
                 else

--- a/src/genesis/observability/service_status.py
+++ b/src/genesis/observability/service_status.py
@@ -300,6 +300,18 @@ def collect_cc_tmp_usage() -> dict:
         data = json.loads(_TMP_WATCHGOD_STATE.read_text())
         cc = data.get("cc_tmp", {})
         sys_tmp = data.get("system_tmp", {})
+        # Control plane: how many live CC sessions are listening on a socket path
+        # that no longer exists (severed → unreachable by peers, and unable to
+        # notice), plus socket files no process holds. Defaults to `unknown`
+        # rather than a zero, so a state file written before this field existed —
+        # or by a daemon that could not run the probe — never reads as healthy.
+        cp = data.get("control_plane")
+        if not isinstance(cp, dict):
+            # Absent, null, or a hand-edited/truncated state file. `.get` on a
+            # non-dict raises AttributeError, which the handler below does not
+            # catch and the infrastructure-snapshot caller does not either — so an
+            # unreadable field would take the whole snapshot down.
+            cp = {}
         return {
             "cc_tier": cc.get("tier", "unknown"),
             "cc_used_mb": cc.get("used_mb", 0),
@@ -309,6 +321,12 @@ def collect_cc_tmp_usage() -> dict:
             "cc_fs_total_mb": cc.get("fs_total_mb", None),
             "sys_tier": sys_tmp.get("tier", "unknown"),
             "sys_used_pct": sys_tmp.get("used_pct", 0),
+            "control_plane": {
+                "status": cp.get("status", "unknown"),
+                "severed_sockets": cp.get("severed_sockets", 0),
+                "stale_sockets": cp.get("stale_sockets", 0),
+                "listeners": cp.get("listeners", 0),
+            },
             "poll_at": data.get("poll_at", ""),
         }
     except (json.JSONDecodeError, OSError):

--- a/tests/test_observability/test_service_status.py
+++ b/tests/test_observability/test_service_status.py
@@ -234,3 +234,76 @@ class TestDetectGenesisService:
             side_effect=self._side_effect(server_installed=False, relay_active=False),
         ):
             assert _detect_genesis_service() == ("genesis-server.service", "Server")
+
+
+class TestCollectCcTmpUsageControlPlane:
+    """The control-plane counts must survive the read from the watchgod state file.
+
+    The state JSON is the only channel between the daemon that can SEE a severed
+    CC messaging socket and anything that can show it to a human, so a field that
+    the reader drops is a detector that reports to nobody.
+
+    The `unknown` cases matter as much as the populated one: a state file written
+    before this field existed, or written by a daemon whose probe could not run,
+    must never read as a healthy plane. "Could not measure" and "measured, and it
+    is fine" cannot share a value.
+    """
+
+    @staticmethod
+    def _read(tmp_path, payload: dict) -> dict:
+        state = tmp_path / "watchgod_state.json"
+        state.write_text(json.dumps(payload))
+        with patch(
+            "genesis.observability.service_status._TMP_WATCHGOD_STATE", state
+        ):
+            from genesis.observability.service_status import collect_cc_tmp_usage
+
+            return collect_cc_tmp_usage()
+
+    _BASE = {
+        "cc_tmp": {"tier": "green", "used_mb": 128, "budget_mb": 500},
+        "system_tmp": {"tier": "green", "used_pct": 0},
+        "poll_at": "2026-09-07T21:36:04Z",
+    }
+
+    def test_counts_are_passed_through(self, tmp_path):
+        result = self._read(
+            tmp_path,
+            {
+                **self._BASE,
+                "control_plane": {
+                    "status": "ok",
+                    "severed_sockets": 4,
+                    "stale_sockets": 1,
+                    "listeners": 5,
+                },
+            },
+        )
+        assert result["control_plane"] == {
+            "status": "ok",
+            "severed_sockets": 4,
+            "stale_sockets": 1,
+            "listeners": 5,
+        }
+        assert result["cc_tier"] == "green", "the existing fields must be untouched"
+
+    def test_missing_field_reads_as_unknown_not_healthy(self, tmp_path):
+        """A state file from a daemon that predates the detector."""
+        result = self._read(tmp_path, self._BASE)
+        assert result["control_plane"]["status"] == "unknown"
+
+    def test_daemon_reported_unknown_is_preserved(self, tmp_path):
+        """The daemon could not run its probe; that is not zero severed sockets."""
+        result = self._read(
+            tmp_path,
+            {
+                **self._BASE,
+                "control_plane": {
+                    "status": "unknown",
+                    "severed_sockets": 0,
+                    "stale_sockets": 0,
+                    "listeners": 0,
+                },
+            },
+        )
+        assert result["control_plane"]["status"] == "unknown"

--- a/tests/test_scripts/test_watchgod_control_plane.py
+++ b/tests/test_scripts/test_watchgod_control_plane.py
@@ -113,26 +113,26 @@ def _mksock(path: Path) -> None:
 
 
 def _probe(home: Path, bind: Path, rows: str = "", **kw) -> str:
-    """The COUNTS tuple — `status:severed:stale:listeners`.
+    """The COUNTS tuple — `status:severed:stale:listeners`, and nothing else.
 
-    The check also emits a fifth field carrying the severed socket identities;
-    `_probe_ids` is for that. Splitting them keeps the counts assertions readable
-    and stops every one of them having to restate an id list it does not care
-    about.
+    FIXED WIDTH on purpose. The identities used to ride along as a fifth field,
+    and `write_state` parses four — so bash handed it "1:123.sock" as the
+    listener count and the state file became invalid JSON exactly when a
+    severance made it worth reading. They travel on their own channel now, which
+    `_probe_ids` reads.
     """
-    return ":".join(_probe_full(home, bind, rows, **kw).split(":")[:4])
-
-
-def _probe_full(home: Path, bind: Path, rows: str = "", **kw) -> str:
     proc = _run(home, bind, "check_control_plane", rows=rows, **kw)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
-    return proc.stdout.strip()
+    out = proc.stdout.strip()
+    assert out.count(":") == 3, f"the counts tuple must stay four fields, got {out!r}"
+    return out
 
 
 def _probe_ids(home: Path, bind: Path, rows: str = "", **kw) -> list[str]:
-    """The severed socket identities, as a list."""
-    parts = _probe_full(home, bind, rows, **kw).split(":")
-    return parts[4].split() if len(parts) > 4 else []
+    """The severed socket identities, from the channel of their own."""
+    _probe(home, bind, rows, **kw)
+    ids = home / ".genesis" / "alerts" / "control_plane_severed_ids"
+    return ids.read_text().split() if ids.is_file() else []
 
 
 # ── severed ──────────────────────────────────────────────────────────────
@@ -313,6 +313,8 @@ def test_severed_identities_are_reported_not_just_counted(tmp_path):
     rows = f"{socks}/11.sock 11\n{socks}/77.sock 77"
     assert _probe_ids(home, bind, rows) == ["11.sock"]
     assert _probe(home, bind, rows) == "ok:1:0:2"
+    # ...and the counts tuple carries no trace of them (see _probe's docstring).
+    assert "sock" not in _probe(home, bind, rows)
 
 
 def test_first_sighting_does_not_page(tmp_path):
@@ -359,3 +361,220 @@ def test_a_healthy_plane_says_nothing(tmp_path):
     home, _cctmp, bind = _sandbox(tmp_path)
     assert _decide(home, bind, "", "", "") == "0:"
     assert _decide(home, bind, "a.sock", "a.sock", "") == "0:"
+
+
+# ── round 2: the mechanisms behind the fixes, not the fixes ──────────────
+#
+# Three of Codex's round-2 findings were defects the round-1 fixes introduced.
+# Each test below pins the MECHANISM that made its class possible, so the class
+# cannot come back through a different door.
+
+
+def test_the_state_file_stays_valid_json_when_sockets_are_severed(tmp_path):
+    """The defect the fixed-width protocol exists to prevent.
+
+    Identities were packed into the counts tuple as a fifth field while
+    `write_state` read four, so bash assigned the surplus to the LAST
+    destination: `"listeners": 5:1859653.sock` — invalid JSON, emitted precisely
+    when a severance made the file worth reading, so `collect_cc_tmp_usage()`
+    returned a parse error exactly then (Codex P1, PR #1856).
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    gone = cctmp / "cc-socks" / "1859653.sock"
+    gone.parent.mkdir(parents=True)
+    _mksock(cctmp / "cc-socks" / "2501887.sock")
+    # Drive the PRODUCER's real output into the CONSUMER — passing a hand-written
+    # four-field string would exercise a shape the old code never emitted, and
+    # would pass against the very bug this pins.
+    proc = _run(
+        home,
+        bind,
+        'cp=$(check_control_plane); write_state green 10 green 5 "$cp"',
+        rows=f"{gone} 1859653",
+    )
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    raw = (home / ".genesis" / "watchgod_state.json").read_text()
+    state = json.loads(raw)  # the assertion: this parses at all
+    assert state["control_plane"]["severed_sockets"] == 1
+    assert state["control_plane"]["listeners"] == 1
+    # `.sock` — the identity shape. Plain "sock" matches the field NAMES
+    # (`severed_sockets`), which is what an earlier draft of this line caught.
+    assert ".sock" not in raw, "a socket identity leaked into the state file"
+
+
+def test_the_socket_path_is_found_whatever_column_it_lands_in(tmp_path):
+    """`ss` column counts are not stable, so the parse must not depend on one.
+
+    Two reviewers pushed this to opposite indexes — one to `$4`, one to `$5` —
+    because `ss` prints a State column for unix sockets and MEASURED here on
+    iproute2-6.1.0 with `state listening` it does not. A guard whose verdict
+    depends on which release is installed is the wrong shape.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    gone = cctmp / "cc-socks" / "42.sock"
+    gone.parent.mkdir(parents=True)
+    # A stub that DOES emit the State column, i.e. the shape this box does not
+    # produce and the man page says to expect — the path is now at $5.
+    _make_exec(
+        bind / "ss",
+        "#!/usr/bin/env bash\n"
+        'printf \'u_str LISTEN 0 512 %s 12345 * 0 users:(("claude",pid=42,fd=11))\\n\' '
+        '"${STUB_SS_ROWS%% *}"\n',
+    )
+    assert _probe(home, bind, f"{gone} 42") == "ok:1:0:1", (
+        "the path was not found when ss included its State column"
+    )
+
+
+def test_a_missing_alert_queue_does_not_kill_the_daemon(tmp_path):
+    """`set -euo pipefail` plus `find` on an absent directory is fatal.
+
+    The probe added in round 1 to confirm an alert actually landed ran `find` on
+    the queue directory BEFORE `queue_alert` could create it. On a clean install
+    that exits nonzero, the substitution fails, and the daemon dies — so every
+    confirmed severance became another service restart with no alert ever sent
+    (Codex P1, PR #1856).
+
+    Exercises the REAL daemon, not a copy of its snippet: one poll of `main`
+    against a sandbox whose alert queue does not exist. An earlier draft of this
+    test ran the fixed guard inline and therefore passed against the bug.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    (cctmp / "cc-socks").mkdir(parents=True)
+    queue = home / ".genesis" / "alerts" / "queue"
+    assert not queue.exists(), "fixture precondition: the queue must be absent"
+    conf = home / ".genesis" / "config"
+    conf.mkdir(parents=True)
+    (conf / "watchgod.conf").write_text("POLL_INTERVAL=1\n")
+    proc = subprocess.run(
+        ["timeout", "-s", "TERM", "4", "bash", str(_WATCHGOD)],
+        env={
+            **os.environ,
+            "HOME": str(home),
+            "PATH": f"{bind}:{os.environ['PATH']}",
+            "STUB_SS_ROWS": f"{cctmp}/cc-socks/77.sock 77",
+            "STUB_SS_RC": "0",
+            "SYS_TMP_DIR": str(tmp_path / "systmp"),
+        },
+        capture_output=True,
+        text=True,
+    )
+    # SIGTERM from `timeout` is 124; anything else means the loop died on its own.
+    assert proc.returncode in (0, 124), (
+        f"the daemon exited on its own (rc={proc.returncode}): {proc.stderr[-400:]}"
+    )
+    log = (home / ".genesis" / "logs" / "tmp_watchgod.log").read_text()
+    assert "control plane" in log, f"the poll loop never completed a pass: {log}"
+
+
+def test_a_trailing_slash_in_the_configured_path_is_normalised_once(tmp_path):
+    """`CC_TMP_DIR=/path/to/cc-tmp/` is a valid thing to write in watchgod.conf.
+
+    Left un-normalised it broke string surgery downstream — one site carried its
+    own `%/` guard and another did not, so RED reconstructed the wrong exclusion
+    path and deleted the project it meant to preserve (Codex P2, PR #1856).
+    Normalising in `load_config`, once, is what stops a future site having to
+    remember.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    conf = home / ".genesis" / "config"
+    conf.mkdir(parents=True)
+    (conf / "watchgod.conf").write_text(f'CC_TMP_DIR="{cctmp}/"\n')
+    proc = _run(home, bind, 'load_config; printf "%s" "$CC_TMP_DIR"')
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert proc.stdout == str(cctmp), (
+        f"trailing slash survived load_config: {proc.stdout!r}"
+    )
+
+
+def _run_daemon(home, bind, cctmp, tmp_path, rows, seconds="4"):
+    """One or two polls of the REAL daemon against a sandbox."""
+    return subprocess.run(
+        ["timeout", "-s", "TERM", seconds, "bash", str(_WATCHGOD)],
+        env={
+            **os.environ,
+            "HOME": str(home),
+            "PATH": f"{bind}:{os.environ['PATH']}",
+            "STUB_SS_ROWS": rows,
+            "STUB_SS_RC": "0",
+            "SYS_TMP_DIR": str(tmp_path / "systmp"),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_a_severance_already_paged_does_not_page_again_after_a_restart(tmp_path):
+    """The paged level survives a restart, so a deploy cannot re-page an
+    unhealed severance.
+
+    A severance is UNHEALABLE without restarting the sessions themselves, and
+    the unit is Restart=always. If the reported level lived only in memory, the
+    same unfixed condition would page again after every deploy or crash. This
+    exercises the REAL daemon reading the on-disk marker at startup — the path
+    the PR body claimed by manual verification and no test covered.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    (cctmp / "cc-socks").mkdir(parents=True)
+    conf = home / ".genesis" / "config"
+    conf.mkdir(parents=True)
+    (conf / "watchgod.conf").write_text("POLL_INTERVAL=1\n")
+    queue = home / ".genesis" / "alerts" / "queue"
+    queue.mkdir(parents=True, exist_ok=True)
+
+    # A listener whose socket path is absent from disk = one severed session,
+    # and it is ALREADY the reported level from before the restart.
+    rows = f"{cctmp}/cc-socks/77.sock 77"
+    (home / ".genesis" / "alerts" / "control_plane_paged").write_text("77.sock")
+
+    proc = _run_daemon(home, bind, cctmp, tmp_path, rows)
+    assert proc.returncode in (0, 124), (
+        f"the daemon exited on its own (rc={proc.returncode}): {proc.stderr[-400:]}"
+    )
+    log = (home / ".genesis" / "logs" / "tmp_watchgod.log").read_text()
+    assert "control plane" in log, f"the poll loop never completed a pass: {log}"
+    # Guard the guard: the severance must actually be DETECTED this run, or the
+    # absence of an alert below proves nothing.
+    state = json.loads((home / ".genesis" / "watchgod_state.json").read_text())
+    assert state["control_plane"]["severed_sockets"] == 1, (
+        "fixture precondition: the daemon did not detect the severed listener, "
+        f"so a quiet queue says nothing — {state['control_plane']}"
+    )
+    assert not list(queue.glob("*.json")), (
+        "the daemon re-paged a severance already recorded as reported — the "
+        "restart marker was not honoured"
+    )
+
+
+def test_an_unrecognised_id_in_the_marker_does_not_discard_the_whole_level(tmp_path):
+    """The marker validator must be as wide as the id producer.
+
+    The producer takes any basename ending `.sock`; a validator that accepts
+    only `<pid>.sock` would fail the whole-string match on ONE unusual name,
+    discard every reported severance, and re-page the same unhealed condition
+    after every restart — the failure the marker exists to prevent.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    (cctmp / "cc-socks").mkdir(parents=True)
+    conf = home / ".genesis" / "config"
+    conf.mkdir(parents=True)
+    (conf / "watchgod.conf").write_text("POLL_INTERVAL=1\n")
+    queue = home / ".genesis" / "alerts" / "queue"
+    queue.mkdir(parents=True, exist_ok=True)
+
+    rows = f"{cctmp}/cc-socks/agent-a.sock 77"
+    (home / ".genesis" / "alerts" / "control_plane_paged").write_text("agent-a.sock")
+
+    proc = _run_daemon(home, bind, cctmp, tmp_path, rows)
+    assert proc.returncode in (0, 124), (
+        f"the daemon exited on its own (rc={proc.returncode}): {proc.stderr[-400:]}"
+    )
+    state = json.loads((home / ".genesis" / "watchgod_state.json").read_text())
+    assert state["control_plane"]["severed_sockets"] == 1, (
+        "fixture precondition: the severance was not detected — "
+        f"{state['control_plane']}"
+    )
+    assert not list(queue.glob("*.json")), (
+        "a non-<pid> socket name poisoned the marker, so the whole reported "
+        "level was discarded and the severance paged again"
+    )

--- a/tests/test_scripts/test_watchgod_control_plane.py
+++ b/tests/test_scripts/test_watchgod_control_plane.py
@@ -1,0 +1,325 @@
+"""tmp_watchgod's severed-control-plane detector.
+
+WHAT IT DETECTS. Claude Code binds one unix socket per session for cross-session
+messaging. Deleting the socket's PATH does not stop the listener: the process
+keeps the inode, so `ss` still reports LISTEN and the session looks healthy from
+the inside, while every peer resolves BY PATH and gets ENOENT. Nothing re-binds
+after startup, so the session is unreachable for the rest of its life and cannot
+notice. Measured 2026-09-05, when a cleanup sweep deleted those paths: 3 of 4
+sessions severed on one install and 6 of 6 on a sibling — and the only signal
+anyone had was peers mysteriously failing to answer.
+
+The sweeps now spare sockets, which stops recurrence but cannot heal a session
+already severed. This detector makes the state visible so a new severance is
+never silent again.
+
+WHAT THESE TESTS PIN, in order of how they fail:
+
+  * severed  — a listener whose path is gone, or has been replaced by something
+    that is not a socket. This is the incident.
+  * stale    — a socket file with no listener. Reported and NEVER deleted:
+    deleting sockets from this daemon is what caused the outage.
+  * unknown  — ss missing or failing. A monitor whose probe did not run must not
+    report a clean plane; "could not measure" and "measured, and it is fine"
+    never share a value.
+  * empty    — the probe ran and saw nothing. Usually true, and also what a
+    detector that has gone blind looks like, so it is not reported as health.
+  * the paging rules — confirmation before paging, and a high-water mark that
+    follows the count back down.
+
+WHAT THESE ARE NOT: regression cover. `check_control_plane` and
+`control_plane_page_decision` are new, so running these against `origin/main` only
+proves a function name is absent. They are CONTRACT tests for a new detector, and
+the two `write_state` cases are the only ones that exercise a pre-existing
+function. The one lock worth naming is
+`test_stale_socket_file_is_counted_and_kept`, which fails the moment anyone adds
+a delete to a function whose whole contract is that it never deletes.
+
+`ss` is a PATH-prepended STUB emitting whatever rows a test wants, so no test
+depends on the machine's real sockets. Socket inodes come from ``os.mknod``,
+which has no AF_UNIX ``sun_path`` length limit — a real ``bind()`` under pytest's
+tmp_path would exceed 108 bytes and fail (the same trap the sibling
+socket-sparing suite documents).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_WATCHGOD = Path(__file__).resolve().parents[2] / "scripts" / "tmp_watchgod.sh"
+
+# Reproduces `ss -xlpH state listening` output shape: netid, queues, path, inode,
+# peer, peer-port, then the users:(...) column. STUB_SS_ROWS holds one
+# "<path> <pid>" pair per line; STUB_SS_RC forces a failure exit.
+_SS_STUB = r"""#!/usr/bin/env bash
+rc="${STUB_SS_RC:-0}"
+if (( rc != 0 )); then exit "$rc"; fi
+while IFS=' ' read -r p pid; do
+  [[ -z "$p" ]] && continue
+  printf 'u_str 0      512        %s 12345 * 0 users:(("claude",pid=%s,fd=11))\n' "$p" "$pid"
+done <<< "${STUB_SS_ROWS:-}"
+exit 0
+"""
+
+_TMUX_STUB = "#!/usr/bin/env bash\nexit 0\n"
+
+
+def _make_exec(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _sandbox(tmp_path: Path) -> tuple[Path, Path, Path]:
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    (home / ".genesis" / "alerts").mkdir(parents=True)
+    cctmp = home / ".genesis" / "cc-tmp"
+    cctmp.mkdir(parents=True)
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    _make_exec(bind / "ss", _SS_STUB)
+    _make_exec(bind / "tmux", _TMUX_STUB)
+    return home, cctmp, bind
+
+
+def _run(
+    home: Path, bind: Path, snippet: str, rows: str = "", ss_rc: int = 0, ss_bin: str = ""
+) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(
+        HOME=str(home),
+        PATH=f"{bind}:{os.environ['PATH']}",
+        STUB_SS_ROWS=rows,
+        STUB_SS_RC=str(ss_rc),
+    )
+    if ss_bin:
+        env["SS_BIN"] = ss_bin
+    return subprocess.run(
+        ["bash", "-c", f"source '{_WATCHGOD}'\n{snippet}"],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _mksock(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.mknod(path, stat.S_IFSOCK | 0o600)
+
+
+def _probe(home: Path, bind: Path, rows: str = "", **kw) -> str:
+    proc = _run(home, bind, "check_control_plane", rows=rows, **kw)
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    return proc.stdout.strip()
+
+
+# ── severed ──────────────────────────────────────────────────────────────
+
+
+def test_severed_listener_is_counted(tmp_path):
+    """The incident: a live listener whose socket path has been deleted."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    gone = cctmp / "cc-socks" / "111.sock"
+    gone.parent.mkdir(parents=True)  # dir survives, file does not
+    assert _probe(home, bind, f"{gone} 111") == "ok:1:0:1"
+
+
+def test_healthy_listener_is_not_severed(tmp_path):
+    """A listener whose path is on disk is exactly what health looks like."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    live = cctmp / "cc-socks" / "222.sock"
+    _mksock(live)
+    assert _probe(home, bind, f"{live} 222") == "ok:0:0:1"
+
+
+def test_non_socket_at_the_path_counts_as_severed(tmp_path):
+    """A path occupied by an ordinary file is no more reachable than a missing
+    one — `-e` would call this healthy, which is why the check is `-S`."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    impostor = cctmp / "cc-socks" / "333.sock"
+    impostor.parent.mkdir(parents=True)
+    impostor.write_text("not a socket")
+    assert _probe(home, bind, f"{impostor} 333") == "ok:1:0:1"
+
+
+def test_incident_replay_mixed_population(tmp_path):
+    """The measured live shape at build time: several severed listeners, one
+    healthy survivor, and one socket file left by a dead process — reported as
+    `ok:4:1:5`, which is what this install's real `ss` produced."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    socks = cctmp / "cc-socks"
+    socks.mkdir(parents=True)
+    survivor = socks / "2501887.sock"
+    _mksock(survivor)
+    _mksock(socks / "3794276.sock")  # dead pid's leftover — stale, not severed
+    rows = "\n".join(
+        [
+            f"{socks}/3689517.sock 3689517",
+            f"{socks}/2864896.sock 2864896",
+            f"{socks}/3265893.sock 3265893",
+            f"{socks}/1859653.sock 1859653",
+            f"{survivor} 2501887",
+        ]
+    )
+    assert _probe(home, bind, rows) == "ok:4:1:5"
+
+
+# ── stale ────────────────────────────────────────────────────────────────
+
+
+def test_stale_socket_file_is_counted_and_kept(tmp_path):
+    """A socket with no listener is counted — and must still exist afterwards.
+    This detector is read-only by contract."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    orphan = cctmp / "cc-socks" / "444.sock"
+    _mksock(orphan)
+    assert _probe(home, bind, "") == "ok:0:1:0"
+    assert orphan.exists(), "the detector deleted a socket; it must never delete"
+
+
+def test_stale_is_found_with_no_listeners_at_all(tmp_path):
+    """A fully-severed install has no listener path on disk to derive a directory
+    from, which is exactly when the leftovers still need counting — so cc-tmp's
+    own socket dir is always scanned."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    _mksock(cctmp / "cc-socks" / "555.sock")
+    gone = cctmp / "cc-socks" / "666.sock"
+    assert _probe(home, bind, f"{gone} 666") == "ok:1:1:1"
+
+
+# ── path-agnostic ────────────────────────────────────────────────────────
+
+
+def test_listener_outside_cc_tmp_is_covered(tmp_path):
+    """Directories come from the live listeners, not from a hardcoded location,
+    so this keeps working unchanged when the sockets move to the runtime dir."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    runtime = tmp_path / "run" / "user" / "1000" / "cc-socks"
+    runtime.mkdir(parents=True)
+    healthy = runtime / "777.sock"
+    _mksock(healthy)
+    _mksock(runtime / "888.sock")  # stale, in the non-cc-tmp directory
+    assert _probe(home, bind, f"{healthy} 777") == "ok:0:1:1"
+
+
+# ── unknown ──────────────────────────────────────────────────────────────
+
+
+def test_ss_failure_reports_unknown_not_healthy(tmp_path):
+    """A probe that could not run must never look like a clean plane."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _probe(home, bind, "", ss_rc=1) == "unknown:0:0:0"
+
+
+def test_ss_absent_reports_unknown(tmp_path):
+    """Same when the tool is not installed at all — the box simply cannot answer.
+    Pointed at a name that does not exist rather than emptying PATH, which would
+    take `bash` and the rest of the script's own tools with it."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    _mksock(_cctmp / "cc-socks" / "999.sock")  # present, and still not counted
+    assert _probe(home, bind, "", ss_bin="watchgod-no-such-tool") == "unknown:0:0:0"
+
+
+# ── empty ────────────────────────────────────────────────────────────────
+
+
+def test_nothing_visible_is_empty_not_ok(tmp_path):
+    """The residual hole in a two-value design, closed with a third value.
+
+    A probe that ran and saw nothing is usually the truth (no CC session is up),
+    but it is ALSO exactly what a detector that has gone blind looks like — an
+    `ss` output change, a netns move, sockets relocating out of `cc-socks`. Both
+    of those would otherwise report as `ok`, which is the one thing they are not.
+    """
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _probe(home, bind, "") == "empty:0:0:0"
+
+
+def test_a_lone_stale_socket_is_still_ok_not_empty(tmp_path):
+    """`empty` means the probe saw NOTHING. A leftover socket file is something,
+    so the plane is visible and the status is `ok` with a stale count."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    _mksock(cctmp / "cc-socks" / "111.sock")
+    assert _probe(home, bind, "") == "ok:0:1:0"
+
+
+# ── state file ───────────────────────────────────────────────────────────
+
+
+def test_state_file_carries_the_control_plane(tmp_path):
+    """The state JSON is the only channel a reader has — the counts must land in
+    it, and it must stay parseable."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    proc = _run(home, bind, 'write_state green 10 green 5 "ok:2:1:6"')
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    state = json.loads((home / ".genesis" / "watchgod_state.json").read_text())
+    assert state["control_plane"] == {
+        "status": "ok",
+        "severed_sockets": 2,
+        "stale_sockets": 1,
+        "listeners": 6,
+    }
+
+
+def test_state_file_without_a_control_plane_argument_stays_valid(tmp_path):
+    """The argument is defaulted, so a caller that predates the field still
+    writes valid JSON — and it says `unknown`, never a fabricated zero."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    proc = _run(home, bind, "write_state green 10 green 5")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    state = json.loads((home / ".genesis" / "watchgod_state.json").read_text())
+    assert state["control_plane"]["status"] == "unknown"
+    assert state["cc_tmp"]["tier"] == "green"
+
+
+# ── paging rules ─────────────────────────────────────────────────────────
+
+
+def _decide(home: Path, bind: Path, prev: int, paged: int, severed: int) -> str:
+    proc = _run(home, bind, f"control_plane_page_decision {prev} {paged} {severed}")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    return proc.stdout.strip()
+
+
+def test_first_elevated_reading_does_not_page(tmp_path):
+    """Confirmation rule: the daemon's very first reading (prev = -1) cannot page.
+    A session exiting between ss's snapshot and its own unlink shows up as one
+    severed listener for a single poll, and a monitor that cries wolf gets
+    ignored."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _decide(home, bind, -1, 0, 4) == "0:0"
+
+
+def test_confirmed_rise_pages_once(tmp_path):
+    """The same count on two consecutive polls is a real severance — page, and
+    record the level so the next identical poll stays quiet."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _decide(home, bind, 4, 0, 4) == "1:4"
+    assert _decide(home, bind, 4, 4, 4) == "0:4", "a steady severance must not re-page"
+
+
+def test_further_rise_pages_again(tmp_path):
+    """A severance getting worse is news."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _decide(home, bind, 5, 4, 5) == "1:5"
+
+
+def test_recovery_lowers_the_bar_so_a_later_severance_still_pages(tmp_path):
+    """High-water that follows DOWN. After sessions are restarted the count drops;
+    if the reported level stayed at its peak, the next — smaller — severance would
+    be silent forever. That miss is the reason this rule exists."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _decide(home, bind, 4, 4, 0) == "0:0", "recovery itself is not a page"
+    assert _decide(home, bind, 2, 0, 2) == "1:2", "a later, smaller severance must page"
+
+
+def test_zero_severed_never_pages(tmp_path):
+    """A healthy plane says nothing, at any prior level."""
+    home, _cctmp, bind = _sandbox(tmp_path)
+    assert _decide(home, bind, 0, 0, 0) == "0:0"
+    assert _decide(home, bind, -1, 0, 0) == "0:0"

--- a/tests/test_scripts/test_watchgod_control_plane.py
+++ b/tests/test_scripts/test_watchgod_control_plane.py
@@ -113,9 +113,26 @@ def _mksock(path: Path) -> None:
 
 
 def _probe(home: Path, bind: Path, rows: str = "", **kw) -> str:
+    """The COUNTS tuple — `status:severed:stale:listeners`.
+
+    The check also emits a fifth field carrying the severed socket identities;
+    `_probe_ids` is for that. Splitting them keeps the counts assertions readable
+    and stops every one of them having to restate an id list it does not care
+    about.
+    """
+    return ":".join(_probe_full(home, bind, rows, **kw).split(":")[:4])
+
+
+def _probe_full(home: Path, bind: Path, rows: str = "", **kw) -> str:
     proc = _run(home, bind, "check_control_plane", rows=rows, **kw)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     return proc.stdout.strip()
+
+
+def _probe_ids(home: Path, bind: Path, rows: str = "", **kw) -> list[str]:
+    """The severed socket identities, as a list."""
+    parts = _probe_full(home, bind, rows, **kw).split(":")
+    return parts[4].split() if len(parts) > 4 else []
 
 
 # ── severed ──────────────────────────────────────────────────────────────
@@ -280,46 +297,65 @@ def test_state_file_without_a_control_plane_argument_stays_valid(tmp_path):
 # ── paging rules ─────────────────────────────────────────────────────────
 
 
-def _decide(home: Path, bind: Path, prev: int, paged: int, severed: int) -> str:
-    proc = _run(home, bind, f"control_plane_page_decision {prev} {paged} {severed}")
+def _decide(home: Path, bind: Path, prev: str, paged: str, cur: str) -> str:
+    proc = _run(home, bind, f"control_plane_page_decision '{prev}' '{paged}' '{cur}'")
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     return proc.stdout.strip()
 
 
-def test_first_elevated_reading_does_not_page(tmp_path):
-    """Confirmation rule: the daemon's very first reading (prev = -1) cannot page.
-    A session exiting between ss's snapshot and its own unlink shows up as one
-    severed listener for a single poll, and a monitor that cries wolf gets
-    ignored."""
+def test_severed_identities_are_reported_not_just_counted(tmp_path):
+    """The decision is made on WHICH sockets are severed, so the check has to say
+    which — a bare tally cannot support the rules below."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    socks = cctmp / "cc-socks"
+    socks.mkdir(parents=True)
+    _mksock(socks / "77.sock")
+    rows = f"{socks}/11.sock 11\n{socks}/77.sock 77"
+    assert _probe_ids(home, bind, rows) == ["11.sock"]
+    assert _probe(home, bind, rows) == "ok:1:0:2"
+
+
+def test_first_sighting_does_not_page(tmp_path):
+    """Confirmation: an id must be seen on two consecutive polls. A session
+    exiting between ss's snapshot and its own unlink shows up as severed for a
+    single poll, and a monitor that cries wolf gets ignored."""
     home, _cctmp, bind = _sandbox(tmp_path)
-    assert _decide(home, bind, -1, 0, 4) == "0:0"
+    assert _decide(home, bind, "", "", "a.sock b.sock") == "0:"
 
 
-def test_confirmed_rise_pages_once(tmp_path):
-    """The same count on two consecutive polls is a real severance — page, and
-    record the level so the next identical poll stays quiet."""
+def test_confirmed_severance_pages_once(tmp_path):
+    """Seen twice running — page, then record it so the next poll stays quiet."""
     home, _cctmp, bind = _sandbox(tmp_path)
-    assert _decide(home, bind, 4, 0, 4) == "1:4"
-    assert _decide(home, bind, 4, 4, 4) == "0:4", "a steady severance must not re-page"
+    assert _decide(home, bind, "a.sock b.sock", "", "a.sock b.sock") == "1:a.sock b.sock"
+    assert (
+        _decide(home, bind, "a.sock b.sock", "a.sock b.sock", "a.sock b.sock") == "0:a.sock b.sock"
+    ), "a steady severance must not re-page"
 
 
-def test_further_rise_pages_again(tmp_path):
-    """A severance getting worse is news."""
+def test_a_new_severance_pages_even_when_the_COUNT_falls(tmp_path):
+    """The defect identities exist to fix (Codex P2 on #1856).
+
+    A previously-paged population is replaced between polls: four severed
+    sessions exit and one newly severed session appears. The count goes 4 -> 1,
+    so a high-water COUNT that follows the number down lands at 1, and the next
+    poll's `severed > paged` is false — the new unreachable session NEVER pages,
+    silently losing the one alert this detector exists to send. An id that has
+    not been reported is news whatever the tally did.
+    """
     home, _cctmp, bind = _sandbox(tmp_path)
-    assert _decide(home, bind, 5, 4, 5) == "1:5"
+    paged_four = "a.sock b.sock c.sock d.sock"
+    assert _decide(home, bind, "z.sock", paged_four, "z.sock") == "1:z.sock"
 
 
-def test_recovery_lowers_the_bar_so_a_later_severance_still_pages(tmp_path):
-    """High-water that follows DOWN. After sessions are restarted the count drops;
-    if the reported level stayed at its peak, the next — smaller — severance would
-    be silent forever. That miss is the reason this rule exists."""
+def test_a_severance_that_recovers_is_forgotten(tmp_path):
+    """An id that is no longer severed drops out of the reported set, so if that
+    pid is ever severed again it is news again rather than permanently silenced."""
     home, _cctmp, bind = _sandbox(tmp_path)
-    assert _decide(home, bind, 4, 4, 0) == "0:0", "recovery itself is not a page"
-    assert _decide(home, bind, 2, 0, 2) == "1:2", "a later, smaller severance must page"
+    assert _decide(home, bind, "", "a.sock", "") == "0:", "recovery itself is not a page"
+    assert _decide(home, bind, "a.sock", "", "a.sock") == "1:a.sock"
 
 
-def test_zero_severed_never_pages(tmp_path):
-    """A healthy plane says nothing, at any prior level."""
+def test_a_healthy_plane_says_nothing(tmp_path):
     home, _cctmp, bind = _sandbox(tmp_path)
-    assert _decide(home, bind, 0, 0, 0) == "0:0"
-    assert _decide(home, bind, -1, 0, 0) == "0:0"
+    assert _decide(home, bind, "", "", "") == "0:"
+    assert _decide(home, bind, "a.sock", "a.sock", "") == "0:"

--- a/tests/test_scripts/test_watchgod_loopbreak.py
+++ b/tests/test_scripts/test_watchgod_loopbreak.py
@@ -4,17 +4,22 @@ Regression cover for the 2026-08-19 runaway: cc-tmp went ORANGE (a ~382MB pytest
 tree the cache-evict never touches), and because the tier that dispatched the
 handler was measured BEFORE cleanup, the daemon re-entered ORANGE every poll and
 re-ran the idle-session kill loop for ~4.5h. The loop-break re-measures AFTER
-cleanup and kills ONLY if still over the line; when nothing is reclaimable and
-nothing is killable it pages once instead of looping silently.
+cleanup; when nothing is reclaimable it records the stuck state once instead of
+looping silently.
+
+The kill itself is GONE as of 2026-09-07 — ORANGE never reaps a session. The
+tests that pinned the kill are now their inverse (both an unattached idle
+session and an attached one must SURVIVE an ORANGE that cleanup cannot clear),
+which is what keeps the removal from being quietly reintroduced.
 
 Plus the OOM sampler: on a NEW cgroup oom_kill it writes a durable snapshot and
 pages once (the death that started all this left no diagnosable trace).
 
 tmux is a configurable STUB (never a real session): it reports whatever sessions
 the test injects and records every kill-session call to a file, so we can assert
-the loop-break did or did NOT kill. queue_alert is overridden to a call-log so we
-can assert page-once. The script's sourcing guard loads its functions without
-starting the daemon.
+that nothing was killed. queue_alert is overridden to a call-log so we can assert
+page-once. The script's sourcing guard loads its functions without starting the
+daemon.
 """
 
 import os
@@ -100,10 +105,10 @@ def test_orange_resolved_by_cleanup_does_not_kill(tmp_path):
     assert "resolved by cache cleanup" in log, log
 
 
-def test_orange_persists_no_killable_logs_once_no_page(tmp_path):
-    """Non-reclaimable data keeps cc-tmp ORANGE and no idle session is killable →
-    per design D2 this does NOT page (only RED pages); it records the stuck state
-    once (dedupe flag + a single STUCK log line), not silently every poll."""
+def test_orange_persists_logs_once_no_page(tmp_path):
+    """Non-reclaimable data keeps cc-tmp ORANGE and there is nothing else safe to
+    do → per design D2 this does NOT page (only RED pages); it records the stuck
+    state once (dedupe flag + a single STUCK log line), not silently every poll."""
     home, cctmp, bind = _sandbox(tmp_path)
     _mb(cctmp / "bigdata" / "blob", 6)  # NOT a cache/session dir → cleanup can't evict
     killlog = home / "killed.log"
@@ -124,66 +129,46 @@ def test_orange_persists_no_killable_logs_once_no_page(tmp_path):
     )
 
 
-def test_orange_persists_with_killable_reaps_and_no_stuck_flag(tmp_path):
-    """When ORANGE persists AND an idle>2h unattached session exists, it IS
-    reaped (unchanged behavior) and the stuck flag is not raised."""
+def test_orange_never_kills_a_session(tmp_path):
+    """ORANGE does not kill sessions — the removal, pinned.
+
+    The old handler reaped every unattached tmux session idle over 2h once
+    cleanup failed to clear the line. The loop-break comment guarding it already
+    made the case against it: sessions are not what fills cc-tmp, so the kill
+    freed essentially nothing while destroying a session's whole context. Across
+    the full log history at removal time (2026-08-19 → 2026-09-07, 1,029 ORANGE
+    polls) it was reached ONCE and killed ZERO sessions.
+
+    The setup is the exact shape that used to reap: non-reclaimable data holding
+    cc-tmp over the line, plus an unattached session idle far past 2h. Both must
+    survive, and because nothing was reclaimed the stuck marker IS raised — the
+    pre-removal code took the kill branch and left the marker unset.
+
+    Verify-RED: against the pre-removal script this fails on both assertions.
+    """
     home, cctmp, bind = _sandbox(tmp_path)
-    _mb(cctmp / "bigdata" / "blob", 6)
-    killlog = home / "killed.log"
-    env = {"STUB_SESSIONS": "cc-77:0", "STUB_ACTIVITY": "100", "STUB_KILLLOG": str(killlog)}
-    proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
-    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
-    assert killlog.exists() and "cc-77" in killlog.read_text(), "idle session should be reaped"
-    stuck = home / ".genesis" / "alerts" / "tmp_orange_stuck"
-    assert not stuck.exists(), "stuck flag must not be set when a session was killed"
-
-
-def test_kill_does_not_clear_stuck_flag_no_double_page(tmp_path):
-    """Regression for the double-page edge: once stuck-ORANGE has paged, a later
-    poll that happens to reap a newly-idle session must NOT clear the flag (a kill
-    doesn't reduce cc-tmp), else the next still-ORANGE poll re-arms and re-pages
-    the same episode. The flag clears only on the green transition."""
-    home, cctmp, bind = _sandbox(tmp_path)
-    _mb(cctmp / "bigdata" / "blob", 6)  # persists ORANGE
-    stuck = home / ".genesis" / "alerts" / "tmp_orange_stuck"
-    stuck.touch()  # a prior poll already paged
-    killlog = home / "killed.log"
-    env = {"STUB_SESSIONS": "cc-88:0", "STUB_ACTIVITY": "100", "STUB_KILLLOG": str(killlog)}
-    proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
-    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
-    assert killlog.exists(), "idle session should still be reaped"
-    assert stuck.exists(), "a kill must NOT clear the stuck flag (would re-page next poll)"
-
-
-def test_failed_kill_does_not_count_as_reaped(tmp_path):
-    """If tmux kill-session FAILS (session vanished between listing and killing,
-    or any error), killed_any must stay 0 — nothing was reclaimed — so the stuck
-    marker is still recorded rather than silently skipped on a phantom reap."""
-    home, cctmp, bind = _sandbox(tmp_path)
-    _mb(cctmp / "bigdata" / "blob", 6)  # persists ORANGE
+    _mb(cctmp / "bigdata" / "blob", 6)  # not a cache dir → ORANGE persists
     killlog = home / "killed.log"
     env = {
-        "STUB_SESSIONS": "cc-66:0",
-        "STUB_ACTIVITY": "100",
+        "STUB_SESSIONS": "cc-77:0",  # unattached
+        "STUB_ACTIVITY": "100",  # epoch 100 → idle for decades
         "STUB_KILLLOG": str(killlog),
-        "STUB_KILL_RC": "1",  # kill-session fails
     }
     proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
-    assert killlog.exists(), "kill was attempted"
+    assert not killlog.exists(), "ORANGE killed a session; the kill was removed"
     stuck = home / ".genesis" / "alerts" / "tmp_orange_stuck"
-    assert stuck.exists(), "a FAILED kill must not suppress the stuck marker"
+    assert stuck.exists(), "nothing was reclaimed, so the stuck marker must be raised"
 
 
-def test_attached_session_never_killed(tmp_path):
-    """An ATTACHED session (activity recent, or simply not matched by the ':0$'
-    unattached filter) is never a kill candidate — asserts the filter shape."""
+def test_orange_never_kills_an_attached_session(tmp_path):
+    """The same for an ATTACHED session — a live terminal someone is looking at.
+    It was already excluded by the ':0$' unattached filter; asserted here so the
+    guarantee survives the filter being gone."""
     home, cctmp, bind = _sandbox(tmp_path)
     _mb(cctmp / "bigdata" / "blob", 6)
     killlog = home / "killed.log"
-    # attached=1 → the ':0$' grep drops it, so the stub still lists it but the
-    # loop never sees it. (list-sessions output is pre-filtered by the script.)
-    env = {"STUB_SESSIONS": "cc-5:1", "STUB_KILLLOG": str(killlog)}
+    env = {"STUB_SESSIONS": "cc-5:1", "STUB_ACTIVITY": "100", "STUB_KILLLOG": str(killlog)}
     proc = _run(home, bind, _PRELUDE + "clean_cc_orange", env)
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
     assert not killlog.exists(), "attached session must never be killed"

--- a/tests/test_scripts/test_watchgod_session_reap.py
+++ b/tests/test_scripts/test_watchgod_session_reap.py
@@ -1,0 +1,279 @@
+"""tmp_watchgod's 7-day session reap — depth and staleness, both of which were wrong.
+
+The YELLOW tier reclaims session workspaces nobody has touched in a week. Until
+2026-09-07 it did that with
+
+    find "$CC_TMP_DIR" -mindepth 2 -maxdepth 2 -type d -path "*/claude-*/???*" \\
+        -mtime +7 -exec rm -rf {} +
+
+and both halves of that line are aimed at the wrong thing.
+
+DEPTH. The layout is ``cc-tmp/claude-<uid>/<project>/<session-uuid>/…``, so
+depth 2 is the PROJECT directory. Measured on a live install: one depth-2
+directory held 54 session workspaces, including every live session's scratchpad
+and the output files of running background tasks. A single ``rm -rf`` took all
+of it.
+
+STALENESS. A directory's mtime tracks only its DIRECT children, so a project
+directory stops being touched the moment no NEW session starts under it — no
+matter how busy the sessions inside are. Measured the same day: the one
+actively-used project directory had an mtime 2.1 days old while its contents had
+been written seconds earlier, and every dormant project directory showed a
+divergence of 0.0 days. The gap appears precisely on the directory that must not
+be deleted.
+
+Those two together are the hazard: seven quiet days and a routine 50%-usage
+YELLOW — a tier that pages nobody — reaps live workspaces.
+
+Every test here drives ``clean_cc_yellow`` — the tier handler the daemon actually
+calls — rather than the reap helper, so they are meaningful against the pre-fix
+script instead of merely reporting that a new function name is absent. Measured
+verify-RED against ``origin/main``:
+``test_live_session_under_a_stale_project_survives`` fails with "the live session
+was deleted", which is the hazard demonstrated rather than asserted.
+
+Harness idiom mirrors the sibling watchgod test files (deliberately duplicated —
+those files share no conftest): a HOME-redirected sandbox so the script's
+HOME-derived paths land in tmp_path, and a tmux stub on a PATH-prepended bin dir.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+_WATCHGOD = Path(__file__).resolve().parents[2] / "scripts" / "tmp_watchgod.sh"
+
+_TMUX_STUB = """#!/usr/bin/env bash
+exit 0
+"""
+
+_DAY = 86400
+
+
+def _make_exec(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _sandbox(tmp_path: Path) -> tuple[Path, Path, Path]:
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    (home / ".genesis" / "alerts").mkdir(parents=True)
+    cctmp = home / ".genesis" / "cc-tmp"
+    cctmp.mkdir(parents=True)
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    _make_exec(bind / "tmux", _TMUX_STUB)
+    return home, cctmp, bind
+
+
+def _run(home: Path, bind: Path, snippet: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(HOME=str(home), PATH=f"{bind}:{os.environ['PATH']}")
+    return subprocess.run(
+        ["bash", "-c", f"source '{_WATCHGOD}'\n{snippet}"],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _age(path: Path, days: float) -> None:
+    """Backdate a path's mtime/atime by ``days``."""
+    when = time.time() - days * _DAY
+    os.utime(path, (when, when))
+
+
+def _session(cctmp: Path, project: str, uuid: str) -> Path:
+    """Create ``claude-1000/<project>/<uuid>/scratchpad`` and return the session dir."""
+    sdir = cctmp / "claude-1000" / project / uuid
+    (sdir / "scratchpad").mkdir(parents=True)
+    return sdir
+
+
+def test_live_session_under_a_stale_project_survives(tmp_path):
+    """THE hazard, replayed: a project directory whose own mtime is 10 days old
+    while a session inside it was written moments ago.
+
+    This is not a constructed curiosity — it is the measured live shape (2.1 days
+    of divergence on the only actively-used project directory, and 0.0 on every
+    dormant one). The pre-fix depth-2 ``-mtime +7`` sweep matches the project
+    directory and ``rm -rf``s the live session with it.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    live = _session(cctmp, "-home-dev-workrepo", "live-uuid")
+    (live / "scratchpad" / "notes.json").write_text("fresh work")
+    project = cctmp / "claude-1000" / "-home-dev-workrepo"
+    _age(project, 10)  # no NEW session started here in 10 days
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    assert live.exists(), "a live session was reaped because its PROJECT dir went stale"
+    assert (live / "scratchpad" / "notes.json").read_text() == "fresh work"
+    assert project.exists(), "the project dir must survive while it holds a live session"
+
+
+def test_stale_session_is_reaped(tmp_path):
+    """The feature still works: a session with nothing touched in 7 days goes."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    old = _session(cctmp, "-home-dev-workrepo", "old-uuid")
+    (old / "scratchpad" / "junk.bin").write_bytes(b"x" * 1024)
+    for p in (old / "scratchpad" / "junk.bin", old / "scratchpad", old):
+        _age(p, 30)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not old.exists(), "a 30-day-old session workspace should be reclaimed"
+
+
+def test_reap_is_per_session_not_per_project(tmp_path):
+    """Two sessions under ONE project, one stale and one fresh: only the stale one
+    goes, and the project survives. The pre-fix sweep had no way to express this —
+    its unit of deletion was the whole project."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    fresh = _session(cctmp, "-home-dev-workrepo", "fresh-uuid")
+    (fresh / "scratchpad" / "now.txt").write_text("active")
+    stale = _session(cctmp, "-home-dev-workrepo", "stale-uuid")
+    (stale / "scratchpad" / "then.txt").write_text("done")
+    for p in (stale / "scratchpad" / "then.txt", stale / "scratchpad", stale):
+        _age(p, 20)
+    project = cctmp / "claude-1000" / "-home-dev-workrepo"
+    _age(project, 20)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert fresh.exists(), "the fresh session must survive"
+    assert not stale.exists(), "the stale sibling should be reclaimed"
+    assert project.exists(), "a project dir with a surviving session must remain"
+
+
+def test_deep_fresh_file_keeps_the_session(tmp_path):
+    """Freshness is judged on CONTENTS, recursively — a file several levels down
+    counts, even when every directory above it, project directory included, is
+    old. Directory mtimes alone cannot see this, which is the whole reason the
+    old sweep was wrong."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    sdir = _session(cctmp, "-home-dev-workrepo", "deep-uuid")
+    deep = sdir / "scratchpad" / "a" / "b" / "c"
+    deep.mkdir(parents=True)
+    (deep / "just-written.log").write_text("recent")
+    # Age every ancestor, project dir included — without that the old depth-2
+    # sweep never matched and this test passed against the unfixed code too.
+    for p in (
+        deep,
+        deep.parent,
+        deep.parent.parent,
+        sdir / "scratchpad",
+        sdir,
+        cctmp / "claude-1000" / "-home-dev-workrepo",
+    ):
+        _age(p, 40)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert sdir.exists(), "a fresh file deep inside must keep the session alive"
+
+
+def test_emptied_project_dir_is_reclaimed_on_a_later_pass(tmp_path):
+    """Reaping every session under a project leaves an empty directory behind;
+    without cleanup those accumulate forever. Removal is deliberately TWO-PHASE,
+    and this pins both halves.
+
+    Removing the last session updates the project directory's own mtime, so
+    `-empty -mtime +7` does not match it in the same pass — it goes on a later
+    one, once seven quiet days have passed. That delay is the point: CC creates
+    `<project>/` and then `<session-uuid>/` as two steps, and an rmdir landing
+    between them gives the starting session ENOENT. An empty directory is one
+    inode, which is not worth racing a session start for.
+
+    Not regression cover — the old sweep removed the whole project directory, so
+    the end state held there too, by deleting live data to get it.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    old = _session(cctmp, "-home-dev-retired", "gone-uuid")
+    for p in (old / "scratchpad", old):
+        _age(p, 30)
+    project = cctmp / "claude-1000" / "-home-dev-retired"
+    _age(project, 30)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not old.exists(), "the stale session should be reclaimed"
+    assert project.exists(), (
+        "the project dir was just touched by that removal — reclaiming it in the "
+        "same pass is the race the mtime guard exists to avoid"
+    )
+
+    _age(project, 30)  # seven quiet days later
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not project.exists(), "an empty, long-untouched project dir is reclaimed"
+
+
+def test_the_reap_spares_a_socket_like_every_other_sweep(tmp_path):
+    """The invariant this daemon is built on is "no sweep deletes a socket", and
+    a new sweep is a new member of that population.
+
+    A socket's mtime is its BIND time, so a session that bound one inside its
+    workspace and then wrote nothing for seven days looks stale — and a plain
+    `rm -rf` would have the reap sever a live session in the very sweep added to
+    stop that happening. Everything else in the directory is still reclaimed.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    sdir = _session(cctmp, "-home-dev-workrepo", "socket-uuid")
+    sock = sdir / "scratchpad" / "agent.sock"
+    os.mknod(sock, stat.S_IFSOCK | 0o600)
+    junk = sdir / "scratchpad" / "big.bin"
+    junk.write_bytes(b"x" * 4096)
+    for p in (sock, junk, sdir / "scratchpad", sdir):
+        _age(p, 30)
+    _age(cctmp / "claude-1000" / "-home-dev-workrepo", 30)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert sock.exists() and stat.S_ISSOCK(sock.stat().st_mode), "the session reap deleted a socket"
+    assert not junk.exists(), "everything that is not a socket is still reclaimed"
+
+
+def test_a_freshly_created_project_dir_is_never_reclaimed(tmp_path):
+    """The race itself: a project directory CC created moments ago and is about
+    to add a session to must survive a sweep landing in that window."""
+    home, cctmp, bind = _sandbox(tmp_path)
+    project = cctmp / "claude-1000" / "-home-dev-newrepo"
+    project.mkdir(parents=True)  # mkdir <project>, session dir not yet created
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert project.exists(), "a starting session's project dir was deleted under it"
+
+
+def test_reap_fails_closed_when_the_cutoff_cannot_be_computed(tmp_path):
+    """The fail direction, which is the part that turns a housekeeping sweep into
+    data loss when it is wrong. If the 7-day cutoff cannot be computed, NOTHING is
+    deleted — not even a genuinely ancient session — and the skip is logged.
+
+    Not regression cover (the old sweep called no `date` at all): this is RED
+    against the new code with its guard removed, because `find -newermt ""` exits
+    0 and treats an empty cutoff as roughly NOW, so every session would read as
+    stale and be deleted. The guard is what stands between an unusable timestamp
+    and total loss.
+
+    Shadowing `date` with a failing stub is the smallest way to reach that branch;
+    the branch itself guards against any environment where the timestamp cannot be
+    produced.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    _make_exec(bind / "date", "#!/usr/bin/env bash\nexit 1\n")
+    ancient = _session(cctmp, "-home-dev-workrepo", "ancient-uuid")
+    for p in (ancient / "scratchpad", ancient):
+        _age(p, 400)
+
+    proc = _run(home, bind, "clean_cc_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert ancient.exists(), "an unusable cutoff must delete nothing at all"

--- a/tests/test_scripts/test_watchgod_socket_sparing.py
+++ b/tests/test_scripts/test_watchgod_socket_sparing.py
@@ -169,6 +169,42 @@ def test_orange_never_touches_old_socket_pin(tmp_path):
     assert not (cctmp / "claude-skills").exists(), "orange should evict the cache"
 
 
+def test_red_preserves_a_session_that_has_not_written_a_file_yet(tmp_path):
+    """A session between creating its workspace and writing its first file.
+
+    Selecting on `-type f` alone found no candidate there, so nothing was
+    preserved and the depth-1 sweep reaped the live session's own directories out
+    from under it — its next write gets ENOENT. A brand-new session IS a fresh
+    directory and nothing else, so directories have to count as evidence of life.
+    (Codex P2 on #1856; the regression was introduced by the newest-FILE fix in
+    the commit before it, which is why both shapes are pinned here.)
+
+    The fixture is deliberately the ONLY session, with no file anywhere under a
+    `claude-*` tree: that is what leaves a `-type f` search with no candidate at
+    all, and an empty selection means the depth-1 skip protects NOTHING. With any
+    other file present the skip covers the whole `claude-<uid>` tree and the
+    hazard is masked — an earlier draft of this test made exactly that mistake
+    and passed against the unfixed code.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    starting = cctmp / "claude-1000" / "-home-dev-starting" / "session-new"
+    starting.mkdir(parents=True)  # dirs exist, no file written yet
+    canary = cctmp / "reclaimable-junk"  # outside claude-*, so it cannot be selected
+    canary.mkdir()
+    (canary / "blob").write_bytes(b"x" * 4096)
+
+    proc = _run(home, bind, _PRELUDE + "clean_cc_red")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert starting.is_dir(), (
+        "RED reaped a session that had created its workspace but not yet written "
+        "a file — the live process's next write would fail with ENOENT"
+    )
+    assert not (canary / "blob").exists(), (
+        "the canary survived, so RED reclaimed nothing and the assertion above "
+        "proved nothing"
+    )
+
+
 def test_red_preserves_the_project_with_the_newest_FILE_not_the_newest_DIR(tmp_path):
     """RED's "preserving active session" must mean the workspace someone is
     actually using — judged by the newest file inside it, not by a directory's

--- a/tests/test_scripts/test_watchgod_socket_sparing.py
+++ b/tests/test_scripts/test_watchgod_socket_sparing.py
@@ -167,3 +167,59 @@ def test_orange_never_touches_old_socket_pin(tmp_path):
         "yellow/orange sweep deleted a socket"
     )
     assert not (cctmp / "claude-skills").exists(), "orange should evict the cache"
+
+
+def test_red_preserves_the_project_with_the_newest_FILE_not_the_newest_DIR(tmp_path):
+    """RED's "preserving active session" must mean the workspace someone is
+    actually using — judged by the newest file inside it, not by a directory's
+    own mtime.
+
+    Same defect as the YELLOW reap had, in the tier where being wrong costs
+    most: a project directory's mtime moves only when a session dir is created
+    or removed under it, never when a live session writes. So the old sort
+    ranked projects by "when did a session last START here".
+
+    MEASURED on a live install: the active project's newest FILE was 3 days newer
+    than its own directory mtime, and that directory led a DORMANT project's by
+    10 minutes. This fixture makes the dormant project win that comparison
+    outright, which is the shape one more dormant session would have produced —
+    RED would preserve the dormant project and reap the active one's workspaces
+    while logging "preserving active session".
+
+    Verify-RED: against the pre-fix selection this fails on the first assertion.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    old = time.time() - 30 * 86400
+
+    # ACTIVE project: stale directory mtime, recently-written file inside.
+    # Aged an HOUR, deliberately: RED's file sweep spares anything touched in the
+    # last 60 seconds, so a just-written file would survive whatever the selection
+    # did and the assertion below would pass for the wrong reason. An hour is
+    # outside that window and still far newer than the dormant project.
+    active = cctmp / "claude-1000" / "-home-dev-active" / "session-a"
+    active.mkdir(parents=True)
+    (active / "live.json").write_bytes(b"a" * 4096)
+    recent = time.time() - 3600
+    os.utime(active / "live.json", (recent, recent))
+    os.utime(active, (recent, recent))
+    os.utime(active.parent, (old, old))  # no NEW session started here in a month
+
+    # DORMANT project: newer directory mtime, nothing written inside for a month.
+    dormant = cctmp / "claude-1000" / "-home-dev-dormant" / "session-b"
+    dormant.mkdir(parents=True)
+    (dormant / "cold.bin").write_bytes(b"b" * 4096)
+    os.utime(dormant / "cold.bin", (old, old))
+    os.utime(dormant, (old, old))
+    # its project dir is left with a NOW mtime — it wins the old comparison
+
+    proc = _run(home, bind, _PRELUDE + "clean_cc_red")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    assert (active / "live.json").exists(), (
+        "RED reaped the ACTIVE project's files and preserved a dormant one — it "
+        "selected by directory mtime, which does not track writes inside sessions"
+    )
+    assert not (dormant / "cold.bin").exists(), (
+        "the dormant project's files should be reclaimed; if they survive, RED "
+        "preserved everything and this test proves nothing"
+    )

--- a/tests/test_scripts/test_watchgod_socket_sparing.py
+++ b/tests/test_scripts/test_watchgod_socket_sparing.py
@@ -205,57 +205,83 @@ def test_red_preserves_a_session_that_has_not_written_a_file_yet(tmp_path):
     )
 
 
-def test_red_preserves_the_project_with_the_newest_FILE_not_the_newest_DIR(tmp_path):
-    """RED's "preserving active session" must mean the workspace someone is
-    actually using — judged by the newest file inside it, not by a directory's
-    own mtime.
 
-    Same defect as the YELLOW reap had, in the tier where being wrong costs
-    most: a project directory's mtime moves only when a session dir is created
-    or removed under it, never when a live session writes. So the old sort
-    ranked projects by "when did a session last START here".
 
-    MEASURED on a live install: the active project's newest FILE was 3 days newer
-    than its own directory mtime, and that directory led a DORMANT project's by
-    10 minutes. This fixture makes the dormant project win that comparison
-    outright, which is the shape one more dormant session would have produced —
-    RED would preserve the dormant project and reap the active one's workspaces
-    while logging "preserving active session".
+def test_red_does_not_let_a_claude_named_decoy_outside_the_tree_win(tmp_path):
+    """RED's preserve-selector must never resolve to a directory outside the
+    ``claude-<uid>/`` tree, however new an entry inside it happens to be.
 
-    Verify-RED: against the pre-fix selection this fails on the first assertion.
+    This is the anti-regression for the defect two attempts at "improve the
+    selector" shipped (PR #1856): ``find``'s ``-path`` matches the WHOLE path
+    and its ``*`` crosses ``/``, so widening the selector's depth turns
+    ``-path "*/claude-*"`` into "a component OR BASENAME beginning ``claude-``
+    anywhere". A file under an unrelated depth-1 directory then wins the mtime
+    sort, the winner is reduced to the wrong project root, and the depth-1 loop
+    reaps the real live workspace — while the log still says "preserving active
+    session".
+
+    The shape is not hypothetical: pytest basetemps live inside cc-tmp on this
+    install, so the watchgod suite itself plants ``claude-*`` fixtures in the
+    directory the daemon sweeps.
     """
     home, cctmp, bind = _sandbox(tmp_path)
-    old = time.time() - 30 * 86400
 
-    # ACTIVE project: stale directory mtime, recently-written file inside.
-    # Aged an HOUR, deliberately: RED's file sweep spares anything touched in the
-    # last 60 seconds, so a just-written file would survive whatever the selection
-    # did and the assertion below would pass for the wrong reason. An hour is
-    # outside that window and still far newer than the dormant project.
-    active = cctmp / "claude-1000" / "-home-dev-active" / "session-a"
-    active.mkdir(parents=True)
-    (active / "live.json").write_bytes(b"a" * 4096)
-    recent = time.time() - 3600
-    os.utime(active / "live.json", (recent, recent))
-    os.utime(active, (recent, recent))
-    os.utime(active.parent, (old, old))  # no NEW session started here in a month
+    live = cctmp / "claude-1000" / "-home-dev-active" / "session-a"
+    live.mkdir(parents=True)
+    (live / "live.json").write_bytes(b"L" * 4096)
 
-    # DORMANT project: newer directory mtime, nothing written inside for a month.
-    dormant = cctmp / "claude-1000" / "-home-dev-dormant" / "session-b"
-    dormant.mkdir(parents=True)
-    (dormant / "cold.bin").write_bytes(b"b" * 4096)
-    os.utime(dormant / "cold.bin", (old, old))
-    os.utime(dormant, (old, old))
-    # its project dir is left with a NOW mtime — it wins the old comparison
+    # The decoy: basename begins "claude-", depth 3, under a NON-claude depth-1
+    # dir, and strictly the newest thing in the tree.
+    decoy = cctmp / "tmpXYZ" / "sub"
+    decoy.mkdir(parents=True)
+    (decoy / "claude-notes.txt").write_bytes(b"D" * 4096)
+    old = time.time() - 600
+    os.utime(live / "live.json", (old, old))
+    os.utime(live, (old, old))
 
     proc = _run(home, bind, _PRELUDE + "clean_cc_red")
     assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
 
-    assert (active / "live.json").exists(), (
-        "RED reaped the ACTIVE project's files and preserved a dormant one — it "
-        "selected by directory mtime, which does not track writes inside sessions"
+    assert (live / "live.json").exists(), (
+        "RED deleted the live session workspace: a claude-named decoy OUTSIDE "
+        "the claude-<uid> tree won the preserve-selector"
     )
-    assert not (dormant / "cold.bin").exists(), (
-        "the dormant project's files should be reclaimed; if they survive, RED "
-        "preserved everything and this test proves nothing"
+    # Guard the guard: if the decoy survived too, RED preserved everything and
+    # the assertion above is vacuous.
+    assert not (decoy / "claude-notes.txt").exists(), (
+        "the decoy survived as well, so RED reclaimed nothing and this test "
+        "proves nothing"
+    )
+
+
+def test_red_spares_an_empty_socket_dir_but_still_reclaims_files_in_it(tmp_path):
+    """cc-socks must survive RED even with no socket inside it — it is the
+    directory the next session binds into — while non-socket files sitting in
+    it are still reclaimable.
+
+    Sparing socket INODES is not enough: an empty cc-socks has nothing to keep
+    it non-empty, so the depth-first pass removes the directory itself. Zone B's
+    empty-dir sweep already spares it; this pins the same rule in Zone A.
+    """
+    home, cctmp, bind = _sandbox(tmp_path)
+    socks = cctmp / "cc-socks"
+    socks.mkdir()
+    junk = socks / "stale.log"
+    junk.write_bytes(b"j" * 8192)
+    old = time.time() - 600
+    os.utime(junk, (old, old))
+
+    session = cctmp / "claude-1000" / "-home-dev-active" / "session-a"
+    session.mkdir(parents=True)
+    (session / "live.json").write_bytes(b"L" * 1024)
+
+    proc = _run(home, bind, _PRELUDE + "clean_cc_red")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+
+    assert socks.is_dir(), (
+        "RED removed an EMPTY cc-socks — the next session has nowhere to bind"
+    )
+    assert not junk.exists(), (
+        "the reclaimable file inside cc-socks survived, so the directory "
+        "exclusion widened to its contents"
     )

--- a/tests/test_scripts/test_watchgod_zone_b.py
+++ b/tests/test_scripts/test_watchgod_zone_b.py
@@ -159,8 +159,16 @@ def test_ordinary_empty_dirs_are_still_reclaimed(zone_b):
 
 
 def test_socket_files_survive_every_zone_b_tier(zone_b):
-    """The pre-existing `-not -name '*.sock'` exclusion, pinned across all three
-    tiers — RED is the aggressive one and the easiest to regress."""
+    """A unix socket survives all three Zone B tiers — RED is the aggressive one
+    and the easiest to regress.
+
+    What this pins is that every Zone B file sweep is `-type f`, which a socket
+    can never satisfy. It does NOT pin the `-not -name '*.sock'` exclusion those
+    sweeps also carry: that exclusion is redundant for a real socket, and
+    MEASURED 2026-09-08 this test still passes with all four occurrences
+    stripped. `test_a_regular_file_named_sock_is_still_reclaimable` below is
+    what gives that exclusion a mutation-sensitive case.
+    """
     home, systmp, bind = zone_b
     sock = systmp / "cc-socks" / "42.sock"
     sock.parent.mkdir()
@@ -177,3 +185,28 @@ def test_socket_files_survive_every_zone_b_tier(zone_b):
             f"{tier} deleted a unix socket under the swept tree"
         )
     assert not junk.exists(), "the sweeps must still reclaim ordinary old files"
+
+
+def test_a_regular_file_named_sock_is_still_reclaimable(zone_b):
+    """The `-not -name '*.sock'` exclusion, given the one input that can see it.
+
+    A real socket is spared by `-type f` alone, so the name exclusion is
+    invisible to every socket-based test. A REGULAR FILE named `*.sock` is the
+    only input that distinguishes them: it is reclaimable disk that the name
+    exclusion currently protects. This test documents which way that falls, so
+    a future change to the exclusion has to decide deliberately rather than
+    discover it.
+    """
+    home, systmp, bind = zone_b
+    impostor = systmp / "cc-socks" / "notreally.sock"
+    impostor.parent.mkdir()
+    impostor.write_bytes(b"x" * 8192)
+    _age(impostor, 30)
+    _age(impostor.parent, 30)
+
+    proc = _run(home, systmp, bind, "clean_sys_red")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert impostor.exists(), (
+        "a regular file named *.sock was reclaimed — the name exclusion no "
+        "longer covers it, which changes what Zone B RED protects"
+    )

--- a/tests/test_scripts/test_watchgod_zone_b.py
+++ b/tests/test_scripts/test_watchgod_zone_b.py
@@ -1,0 +1,179 @@
+"""tmp_watchgod Zone B (/tmp housekeeping) — it must not delete a control plane either.
+
+Zone B had NO test coverage before 2026-09-07, because its sweeps named `/tmp`
+literally and a test would have had to sweep the real one. That gap is how the
+finding below survived an audit: an earlier pass over this daemon marked the
+empty-directory sweep SAFE on the reasoning that "socket-holding dirs are
+non-empty" — true of the directory holding the socket, and false of its siblings.
+
+MEASURED on a live install, running the pre-fix predicate with `-print` instead of
+`-delete`: it matched `/tmp/cc-socks` and `/tmp/cc-daemon-1000/<id>/pty`. The
+second is an empty rendezvous directory inside a LIVE Claude Code daemon's socket
+tree — created up front and populated later — held by a process with 11 days of
+uptime. Deleting it is the same failure class as the 2026-09-05 incident: the
+socket itself is spared by name, and the directory it needs is not.
+
+Zone B is currently unreachable on that install (`/tmp` is not tmpfs there, so the
+tier comes from absolute free space, which was ~13 GB) — latent, not firing.
+Latent is worth fixing and worth pinning: free space falls.
+
+The sweeps now run against `$SYS_TMP_DIR`, which exists solely so these tests can
+point the zone at a sandbox. Nothing in production sets it.
+
+TWO THINGS KEEP THESE TESTS FROM BEING VACUOUS, and the first was learned the hard
+way — an earlier draft of this file passed for the wrong reason.
+
+  1. The swept sandbox is NOT `tmp_path`. Zone B carries a pre-existing
+     `-not -path "*/pytest-*"` exclusion, and pytest's basetemp is
+     `…/pytest-of-<user>/pytest-<n>/…` under some configurations — so every
+     survival assertion under `tmp_path` would pass because the sweep skipped the
+     whole tree, on a path that varies between runners. MEASURED: the same four
+     tests deleted correctly under one basetemp and swept nothing under another.
+  2. Every survival test plants a CANARY — an ordinary empty directory the sweep
+     MUST reclaim. If the canary survives, the sweep did not run and the survival
+     assertion proved nothing, so the test fails instead of passing quietly.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+_WATCHGOD = Path(__file__).resolve().parents[2] / "scripts" / "tmp_watchgod.sh"
+
+_TMUX_STUB = "#!/usr/bin/env bash\nexit 0\n"
+
+_DAY = 86400
+
+
+def _make_exec(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _age(path: Path, days: float) -> None:
+    when = time.time() - days * _DAY
+    os.utime(path, (when, when))
+
+
+@pytest.fixture
+def zone_b(tmp_path):
+    """HOME under tmp_path (never swept), but the SWEPT tree somewhere neutral —
+    see the module docstring on why `tmp_path` cannot be the swept directory."""
+    home = tmp_path / "home"
+    (home / ".genesis" / "logs").mkdir(parents=True)
+    (home / ".genesis" / "alerts").mkdir(parents=True)
+    (home / ".genesis" / "cc-tmp").mkdir(parents=True)
+    bind = tmp_path / "bin"
+    bind.mkdir()
+    _make_exec(bind / "tmux", _TMUX_STUB)
+    systmp = Path(tempfile.mkdtemp(prefix="wgzoneb"))
+    try:
+        yield home, systmp, bind
+    finally:
+        shutil.rmtree(systmp, ignore_errors=True)
+
+
+def _run(home: Path, systmp: Path, bind: Path, snippet: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(HOME=str(home), PATH=f"{bind}:{os.environ['PATH']}", SYS_TMP_DIR=str(systmp))
+    return subprocess.run(
+        ["bash", "-c", f"source '{_WATCHGOD}'\n{snippet}"],
+        env=env,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def _canary(systmp: Path) -> Path:
+    """An ordinary empty dir the sweep MUST reclaim. If it survives, the sweep did
+    not run and every survival assertion beside it is meaningless."""
+    c = systmp / "canary-ordinary-empty-dir"
+    c.mkdir()
+    _age(c, 30)
+    return c
+
+
+def _assert_swept(canary: Path) -> None:
+    assert not canary.exists(), (
+        "the canary survived, so the sweep never ran over this tree — any survival "
+        "assertion in this test would have passed for the wrong reason"
+    )
+
+
+def test_empty_dir_inside_a_live_socket_tree_survives(zone_b):
+    """The measured shape: CC's daemon tree, with an empty rendezvous directory
+    beside the sockets. The sockets are spared by name; the directory they need
+    has to be spared too, or the tree is broken just as thoroughly."""
+    home, systmp, bind = zone_b
+    canary = _canary(systmp)
+    tree = systmp / "cc-daemon-1000" / "5c860797"
+    (tree / "spare").mkdir(parents=True)
+    os.mknod(tree / "control.sock", stat.S_IFSOCK | 0o600)
+    os.mknod(tree / "spare" / "c3436363.claim.sock", stat.S_IFSOCK | 0o600)
+    pty = tree / "pty"  # empty, created up front, populated later
+    pty.mkdir()
+    _age(pty, 30)
+
+    proc = _run(home, systmp, bind, "clean_sys_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    _assert_swept(canary)
+    assert pty.is_dir(), "an empty rendezvous dir inside a live CC daemon tree was deleted"
+    assert (tree / "control.sock").exists(), "a daemon socket was deleted"
+
+
+def test_empty_cc_socks_dir_survives(zone_b):
+    """`cc-socks` is where the per-session messaging sockets land on an install
+    whose temp dir is /tmp. Empty right now is not a reason to remove it: it is
+    the directory the next session binds into."""
+    home, systmp, bind = zone_b
+    canary = _canary(systmp)
+    socks = systmp / "cc-socks"
+    socks.mkdir()
+    _age(socks, 30)
+
+    proc = _run(home, systmp, bind, "clean_sys_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    _assert_swept(canary)
+    assert socks.is_dir(), "the socket directory was deleted while empty"
+
+
+def test_ordinary_empty_dirs_are_still_reclaimed(zone_b):
+    """The sweep still does its job — the exclusions are narrow, not a disable."""
+    home, systmp, bind = zone_b
+    junk = systmp / "leftover-build-dir"
+    junk.mkdir()
+    _age(junk, 30)
+
+    proc = _run(home, systmp, bind, "clean_sys_yellow")
+    assert proc.returncode == 0, f"{proc.stdout}\n{proc.stderr}"
+    assert not junk.exists(), "an ordinary empty dir should still be reclaimed"
+
+
+def test_socket_files_survive_every_zone_b_tier(zone_b):
+    """The pre-existing `-not -name '*.sock'` exclusion, pinned across all three
+    tiers — RED is the aggressive one and the easiest to regress."""
+    home, systmp, bind = zone_b
+    sock = systmp / "cc-socks" / "42.sock"
+    sock.parent.mkdir()
+    os.mknod(sock, stat.S_IFSOCK | 0o600)
+    junk = systmp / "old.log"
+    junk.write_text("x")
+    for p in (sock, junk, sock.parent):
+        _age(p, 30)
+
+    for tier in ("clean_sys_yellow", "clean_sys_orange", "clean_sys_red"):
+        proc = _run(home, systmp, bind, tier)
+        assert proc.returncode == 0, f"{tier}: {proc.stdout}\n{proc.stderr}"
+        assert sock.exists() and stat.S_ISSOCK(sock.stat().st_mode), (
+            f"{tier} deleted a unix socket under the swept tree"
+        )
+    assert not junk.exists(), "the sweeps must still reclaim ordinary old files"


### PR DESCRIPTION
The temp watchgod exists so runaway temp usage cannot kill Claude Code. This
fixes three places where it did the opposite, and adds the detector for the one
failure it cannot undo.

## What was wrong

**YELLOW reaped projects, not sessions.** The layout under cc-tmp is
`claude-<uid>/<project>/<session-uuid>/`, so the sweep's depth-2 target was the
PROJECT directory — and staleness was judged by that directory's own mtime,
which tracks only its direct children. A project directory therefore goes stale
as soon as no NEW session starts under it, however busy the sessions inside are.

MEASURED on a live install: the one actively-used project directory carried an
mtime **2.1 days old while its contents had been written seconds earlier**, and
held **54 session workspaces** including every live session's scratchpad and the
output of running background tasks. Every dormant project showed a divergence of
0.0 days — the gap appears precisely on the directory that must not be deleted.
Seven quiet days and a routine 50%-usage YELLOW, a tier that pages nobody, takes
the lot.

The reap is now per SESSION, judged on contents recursively, and it **fails
closed**: a directory whose freshness cannot be determined is kept. That
direction is the real finding here — a first draft of this fix used a
relative-date predicate that a different `find` implementation rejects, and the
swallowed error made every session read as stale. A housekeeping sweep is one
broken predicate away from total data loss, so the branch that cannot evaluate
must delete nothing.

**ORANGE killed idle sessions for nothing.** It reaped unattached tmux sessions
idle over 2h. The loop-break comment guarding it already made the case against
itself — sessions are not what fills cc-tmp — so the kill freed approximately
nothing while destroying a session's entire context. Across the whole log
history (2026-08-19 → 2026-09-07, 7,563 lines, **1,029 ORANGE polls**) the kill
loop was reached **once** and killed **zero** sessions, so removing it is
behaviour-neutral on the record available. RED is unchanged and remains the
pressure valve.

**Zone B could delete a live socket tree.** Its file sweeps already spared
`*.sock` by name; the empty-directory sweep did not spare their DIRECTORIES.
Measured by running the predicate with `-print` instead of `-delete`: it matched
`/tmp/cc-socks` and a live CC daemon's empty `pty` rendezvous directory —
created up front, populated later. Latent rather than firing (that `/tmp` is not
tmpfs, so the tier reads absolute free space, which was ample), but the same
failure class as the incident below. This zone had **no test coverage at all**,
which is how an earlier audit of mine called it safe on the reasoning
"socket-holding dirs are non-empty" — true of the directory holding the socket,
false of its siblings.

## The detector

Claude Code binds one unix socket per session for cross-session messaging, at a
path that falls back into cc-tmp when `XDG_RUNTIME_DIR` is unset — the very
directory this daemon reclaims. Deleting the PATH does not stop the listener:
the process keeps the inode, so `ss` still reports LISTEN and the session looks
healthy from the inside, while every peer resolves by path and gets ENOENT.
Nothing re-binds after startup, so the session is unreachable for the rest of
its life and cannot notice. On 2026-09-05 a sweep severed 3 of 4 sessions on one
install and 6 of 6 on another.

The sweeps were taught to spare sockets, which prevents recurrence and cannot
heal what is already severed. So the state is now reported: counts in the
watchgod state file, one page on a confirmed rise, quiet across daemon restarts
until it rises again.

Deliberate edges, since each is easy to "simplify" away later:
- **Read-only.** A stale socket file is counted, never reaped. Putting socket
  deletion back into this daemon is what caused the outage.
- **Three statuses, not two.** `unknown` when the probe could not run, `empty`
  when it ran and saw nothing. Neither is health — a detector that has gone
  blind must not be indistinguishable from a clean plane.
- **Confirmation before paging.** The same elevated count must appear on two
  consecutive polls, so a session exiting between `ss`'s snapshot and its own
  unlink cannot page spuriously.
- **Scope.** It watches the per-session `cc-socks` plane only. CC's separate
  daemon tree is protected from deletion but not counted, because what severance
  means there is unestablished — protect what you do not understand, report only
  what you do.

**Expect a page on the first deploy** to any install that is already severed.
That is the feature working, not a regression.

## Verification

Not only unit tests. The real daemon loop, run against a live 4-session
severance with a sandboxed HOME: silent on the first reading, paged exactly once
on the confirming second, silent thereafter, correct counts in the state file,
and still exactly one alert after a full daemon restart.

Verify-RED is measured, not asserted. Against the pre-fix script,
`test_live_session_under_a_stale_project_survives` fails with *"a live session
was reaped because its PROJECT dir went stale"* — the hazard demonstrated
through the real tier entry point rather than described. Zone B could not use
the base as a baseline (its test seam is new), so its control is a mutant of
this branch with the two exclusions removed, and exactly the two socket-tree
tests fail against it.

Four tests are honestly labelled as NOT regression cover, and one earlier draft
of the Zone B tests was **vacuous** — pytest's basetemp can contain a `pytest-`
path component, which Zone B's own exclusion then skips wholesale, so every
survival assertion passed on a sweep that never ran. Fixed by sweeping outside
`tmp_path` and planting a canary the sweep must reclaim in every survival test.

Cost measured: `ss` at 45.6 ms on a 30 s poll (0.15% duty); the session sweep at
420 ms across 83 session directories, falling once the stale ones are reaped.

## Not in this PR

Relocating the sockets out of cc-tmp. That is the actual fix — the control plane
should not live in a directory whose purpose is to be reclaimed — but one
resolver inside the CC binary serves both bind and discovery, so a mixed-era
fleet cannot see itself during the cutover. It waits on the deploy path that
restarts resident daemons (#1703), so one deploy can move the fleet.

Region: `scripts/tmp_watchgod.sh` (all Zone A/B sweep functions, the main poll
loop) and `collect_cc_tmp_usage`. Noted here rather than messaged, because the
peer sessions that would want to know are themselves severed and unreachable —
which is the bug this PR reports.

Ledger row `1eaf5081f0fe41bebfef1df848754457` covers this work and a follow-on;
not cited as complete, because the relocation half is still outstanding.

E2E: after merge and deploy, restart genesis-tmp-watchgod and confirm the state
file's `control_plane.severed_sockets` equals the count of live sessions whose
cc-socks path is missing (cross-check against `ss -xlp`), that exactly one page
fires on the first confirmed rise, and that a YELLOW pass leaves live session
workspaces under cc-tmp intact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added monitoring for severed or stale messaging sockets.
  - Status reporting now includes control-plane health, socket counts, and listener counts.
  - Confirmed socket severances can trigger deduplicated alerts with escalation and recovery tracking.

- **Bug Fixes**
  - Session cleanup now evaluates nested activity safely and preserves active sessions, sockets, and newly created project directories.
  - Temporary-file cleanup protects live socket trees and socket files.
  - Orange-tier pressure is recorded without terminating tmux sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->