### PR TITLE
fix(hooks): refuse a push that would publish an install's own private value

### DIFF
--- a/changelog.d/20260908005218-changed-pre-push-privacy-block.md
+++ b/changelog.d/20260908005218-changed-pre-push-privacy-block.md
@@ -1,0 +1,17 @@
+- **A push that would publish one of your install's own private values is now
+  refused, not just flagged.** The pre-push privacy check already spotted these
+  and printed a warning — but the warning arrived alongside the push it was
+  describing, and a push cannot be taken back. CI scans every commit a branch
+  adds rather than its net result, so a later commit that removes the value does
+  not clear it; the only remedy left is abandoning the branch and opening a
+  replacement pull request. The check now refuses that push up front, naming the
+  file and line and never repeating the value itself.
+
+  Only a match against your own `release-fingerprints.txt` — the list naming this
+  install's private values — blocks. Pattern-shaped findings — private-range addresses, home-directory paths, email
+  addresses — stay advisory, because those patterns have real false positives and
+  legitimate test fixtures carry them. If you genuinely mean to push a matching
+  line (updating the fingerprint file itself is the usual reason), append
+  `# privacy-override` to the push command; it says so out loud rather than
+  passing quietly. An install with no fingerprint file, and any failure of the
+  check itself, leaves pushes untouched.

--- a/scripts/hooks/pre_push_privacy_review.py
+++ b/scripts/hooks/pre_push_privacy_review.py
@@ -1,14 +1,49 @@
 #!/usr/bin/env python3
-"""PreToolUse ADVISORY: surface private-data leaks in an outgoing PUBLIC push.
+"""PreToolUse gate: private-data leaks in an outgoing PUBLIC push.
 
-NON-BLOCKING. When a ``git push`` targets the public repo (origin), this hook
-scans the diff being pushed for this install's private data — install IPs,
-personal emails, and local release-fingerprints — and, if it finds any, injects
-a review prompt into the model's context (PreToolUse ``additionalContext``). It
-NEVER blocks the push: the CI ``leak-detector`` job and the branch/force gates
-in ``git_push_guard.py`` own hard enforcement. Its job is to make the author
-LOOK at suspicious lines before code goes public — the exact step that, when
-skipped manually, put real install IPs into public test fixtures.
+TWO VERDICTS, split by how confident the match is.
+
+ADVISORY (the default, and what this hook was originally): CLASS findings —
+RFC1918-shaped addresses, ``/home/<user>`` shapes, personal emails. These are
+regexes over generic patterns and they have real false positives; this repo's
+own test fixtures carry a dozen legitimate ones. They inject a review prompt
+into the model's context and never block.
+
+BLOCKING: a FINGERPRINT match — an entry from ``~/.genesis/release-fingerprints.txt``,
+the install's own curated list of its private values. The sanitizer already
+classifies such a hit as ``Severity.BLOCK``; this change makes the push hook act
+on the severity that was already assigned, rather than inventing a new judgement.
+
+Be precise about what "fingerprint" means, because an earlier draft of this
+docstring said "exact literals" and that is FALSE: ``sanitize._check_fingerprints``
+compiles each line as a REGEX, falling back to ``re.escape`` only for a line that
+is not valid regex — and on this install 4 of 7 entries carry metacharacters. So
+an entry is as precise as whoever wrote it: an escaped one is exact, an unescaped
+dot is a wildcard. The reason this tier blocks and the class tier does not is
+therefore NOT "zero false positives"; it is that these patterns are curated
+per-install to name that install's own values, while the class patterns are
+generic shapes this repo's own fixtures legitimately contain by the dozen.
+
+WHY THIS ONE BLOCKS, measured 2026-09-07. The advisory fired correctly on a real
+push and the push proceeded in the same tool call, because that is what an
+advisory does — so the warning arrived AFTER the irreversible act it described.
+A published fingerprint cannot be fixed forward: ``private_pattern_scan`` in CI
+deliberately scans every commit's ADDED lines rather than the net diff (a value
+added then removed still lives in published history), and force-push is banned
+here, so the only remediation was abandoning the branch, opening a replacement
+PR, and deleting the old ref. CI is the right place to enforce a merge; it is the
+wrong place to prevent a publication, because by the time it speaks the value is
+already public.
+
+This does not cost a background session anything: ``git_push_guard`` already
+hard-denies ``git push`` in a Genesis-dispatched session (no human to approve),
+so the only sessions that reach this gate are foreground ones where someone can
+act on it.
+
+Fail direction is OPEN, deliberately: any error, timeout, or unreadable
+fingerprint file leaves the push alone. A fresh clone has no fingerprint file at
+all, and a hook bug that blocked every push would be far worse than the leak it
+prevents — CI still refuses the merge either way.
 
 Reuses the contribution sanitizer's cheap REGEX scanners (``parse_diff`` +
 ``_check_portability`` / ``_check_emails`` / ``_check_fingerprints``) — NOT the
@@ -17,11 +52,21 @@ binary" finding on every push, since the venv bin isn't on the hook's PATH) and
 whose secret scanners spawn one subprocess per added line (latency / timeout
 kill on large diffs).
 
-Contract: emits ONLY ``hookSpecificOutput.additionalContext`` on stdout and
-ALWAYS exits 0. It carries no ``permissionDecision``, so it composes cleanly
-with git_push_guard's ask/allow/deny on the same Bash matcher (each hook runs as
-a separate process; additionalContext is concatenated, order-independent). Any
-error → silent exit 0. An advisory must NEVER block a push.
+Contract: on the advisory path it emits ONLY
+``hookSpecificOutput.additionalContext`` on stdout and exits 0, carrying no
+``permissionDecision`` — so it composes with git_push_guard's ask/allow/deny on
+the same Bash matcher (each hook is a separate process; additionalContext is
+concatenated, order-independent). On the blocking path it exits 2 with the reason
+on stderr, the same mechanism every other blocking gate in this repo uses; the
+wrapper ``exec``s the interpreter, so the code propagates. Any error → silent
+exit 0.
+
+The escape is ``# privacy-override`` as a trailing comment on the push command,
+matched by the shared ``shell_parse.has_trailing_override`` (never a local
+regex), and registered in ``_KNOWN_SIGILS`` so it does not silently end the
+leading sigil run for anything written after it. It is for the deliberate case —
+updating the fingerprint file itself, or a fingerprint entry so broad it matches
+generic text — and it announces itself in context rather than passing silently.
 
 Stdlib + the contribution sanitizer only.
 """
@@ -41,6 +86,7 @@ from pathlib import Path
 # script and when it is imported for tests (mirrors git_push_guard.py:27).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import field, read_payload  # noqa: E402
+from shell_parse import analyze, has_trailing_override  # noqa: E402
 
 # Make `genesis.contribution.sanitize` importable. The genesis-hook wrapper runs
 # the venv python where genesis is editable-installed, so the import normally
@@ -204,12 +250,44 @@ def _effective_cwd(cmd: str, payload_cwd: str | None) -> str | None:
     return cwd
 
 
+def _resolve_target(remote: str, cwd: str | None) -> str:
+    """``"public"`` | ``"other"`` | ``"unknown"`` for the push destination.
+
+    The two-value version of this returned True on "unresolvable" — correct while
+    the verdict was advisory, because over-informing is free. It is wrong for a
+    gate: an unreadable remote would be reported to the operator as a PUBLIC push
+    and their only way forward would be a sigil whose message says "you are
+    deliberately publishing this value", which is false for someone not
+    publishing at all. So uncertainty still ADVISES (a warning nobody needs costs
+    nothing) and only a confident match BLOCKS.
+    """
+    if _targets_public_repo(remote, cwd):
+        return "public" if _target_resolved(remote, cwd) else "unknown"
+    return "other"
+
+
+def _target_resolved(remote: str, cwd: str | None) -> bool:
+    """True when both the target and origin URLs were actually readable."""
+    origin_url = _git(["remote", "get-url", "--push", "origin"], cwd)
+    if not origin_url:
+        return False
+    if remote == "":
+        tracked = _git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{push}"], cwd)
+        name = tracked.split("/", 1)[0] if tracked else "origin"
+        return bool(_git(["remote", "get-url", "--push", name], cwd))
+    if "://" in remote or re.match(r"^[^/\s]+@[^/\s]+:", remote):
+        return True  # a literal URL is self-resolving
+    return bool(_git(["remote", "get-url", "--push", remote], cwd))
+
+
 def _targets_public_repo(remote: str, cwd: str | None) -> bool:
     """True if the push destination is origin (public), or is unresolvable.
 
-    Advisory bias: scan on origin AND on anything we cannot confidently resolve
-    to a NON-origin remote; skip only when the target clearly resolves to a
-    different remote (e.g. a private fork), where real install IPs are allowed.
+    Advisory bias, deliberately retained HERE: scan on origin AND on anything we
+    cannot confidently resolve to a NON-origin remote; skip only when the target
+    clearly resolves to a different remote (e.g. a private fork), where real
+    install IPs are allowed. `_resolve_target` is what separates the confident
+    case from the uncertain one for the BLOCKING decision.
     """
     origin_url = _git(["remote", "get-url", "--push", "origin"], cwd)
     if remote == "":
@@ -226,34 +304,88 @@ def _targets_public_repo(remote: str, cwd: str | None) -> bool:
 
 
 def _outgoing_diff(cwd: str | None) -> str:
-    """The unified diff being pushed (local commits not yet on origin)."""
-    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], cwd)
-    base = None
-    if (
-        branch
-        and branch != "HEAD"
-        and _git(["rev-parse", "--verify", "--quiet", f"origin/{branch}"], cwd)
-    ):
-        base = f"origin/{branch}"
-    else:
-        base = _git(["merge-base", "origin/main", "HEAD"], cwd)
+    """The added lines this branch publishes — PER COMMIT, not the net difference.
+
+    This is the same model `scripts/ci/leak_scan_added_lines.py` uses, and the
+    reason is this hook's whole justification: a value added in one commit and
+    removed in the next leaves a CLEAN net diff while shipping in published
+    history forever. Scanning `git diff base..HEAD` would therefore wave through
+    precisely the scenario the block message tells the operator is unfixable.
+    MEASURED against the real hook: an add-then-scrub branch scored 0 findings on
+    the net diff and 1 on the per-commit walk.
+
+    The base is the merge-base with origin/main, again matching CI — anchoring on
+    `origin/<branch>` instead would mean that after the first push the scan only
+    ever sees the newest commits, so a leak already pushed to the branch stops
+    being reported the moment it is on the remote.
+    """
+    base = _git(["merge-base", "origin/main", "HEAD"], cwd)
     if not base:
         return ""
-    return _git(["diff", f"{base}..HEAD"], cwd) or ""
+    return _git(["log", "-p", "--no-merges", "--format=", f"{base}..HEAD"], cwd) or ""
 
 
-def _scan(diff_text: str) -> list:
-    """Run only the cheap regex scanners from the contribution sanitizer."""
+def _scan(diff_text: str) -> tuple[list, list]:
+    """Run only the cheap regex scanners from the contribution sanitizer.
+
+    Returns ``(class_findings, fingerprint_findings)`` as two lists, kept apart
+    STRUCTURALLY — by which scanner produced them — rather than by matching on a
+    finding's message text, which would silently reclassify the moment the
+    sanitizer rewords itself. The split is what decides advisory vs block, so it
+    has to be the sturdier of the two.
+    """
     from genesis.contribution import sanitize
 
     parsed = sanitize.parse_diff(diff_text)
-    findings = list(sanitize._check_portability(parsed))
-    findings += sanitize._check_emails(parsed)
+    class_findings = list(sanitize._check_portability(parsed))
+    class_findings += sanitize._check_emails(parsed)
+    fingerprint_findings: list = []
     fp_env = os.environ.get("GENESIS_RELEASE_FINGERPRINTS")
     fp = Path(fp_env) if fp_env else Path.home() / ".genesis" / "release-fingerprints.txt"
     if fp.is_file():
-        findings += sanitize._check_fingerprints(parsed, fp)
-    return findings
+        fingerprint_findings = list(sanitize._check_fingerprints(parsed, fp))
+    return class_findings, fingerprint_findings
+
+
+def _render(findings: list) -> list[str]:
+    """One deduplicated ``file:line  message`` line per finding.
+
+    On the BLOCK path this never carries content: ``_check_fingerprints`` sets a
+    constant message, and the raw line lives in ``Finding.detail``, which is not
+    read here. Scope the claim to that path and no further — the email scanner
+    embeds the address in its own message, so the ADVISORY path does print it.
+    That is pre-existing behaviour and useful there (the author needs to see which
+    address), but a blanket "never the matched CONTENT" would have been a false
+    sentence sitting one line above the call that disproves it.
+    """
+    seen: set = set()
+    lines: list[str] = []
+    for finding in findings:
+        key = (finding.file, finding.line, finding.message)
+        if key in seen:
+            continue
+        seen.add(key)
+        lines.append(f"  {finding.file or '?'}:{finding.line or '?'}  {finding.message}")
+    return lines
+
+
+def _push_segments(cmd: str) -> list:
+    """Every ``git push`` SEGMENT, via the shared parser the sibling guards use.
+
+    NOT the local ``_push_remote`` splitter, which is kept only for the remote
+    NAME. That splitter never splits on a NEWLINE, so this repo's own house
+    idiom — `git add -A && git commit -m x` on one line, `git push` on the next —
+    parsed as a single non-push segment and skipped the scan entirely. MEASURED:
+    4 of 5 ordinary spellings (a preceding `git status`, a preceding `cd`, a
+    multi-line commit-then-push, an absolute `/usr/bin/git`) returned "not a
+    push" while the shared parser found the push in all 5.
+
+    Under an advisory that miss cost a missing warning. Under a gate it is a
+    fail-OPEN on a publication guard — and `git_push_guard` runs on the same tool
+    call and DOES parse those spellings, so the operator gets its approval prompt,
+    which reads as "this push was reviewed", with no privacy verdict behind it.
+    """
+    return [s for s in analyze(cmd) if s.exe == "git" and "push" in s.argv]
 
 
 def main() -> None:
@@ -262,9 +394,15 @@ def main() -> None:
         cmd = field(payload, "command")
         if not cmd:
             return
+        push_segs = _push_segments(cmd)
+        if not push_segs:
+            return  # not a git push
+        # The remote NAME still comes from the local parser; when it cannot read
+        # one, "" means "the branch's default push remote", which resolves the
+        # same way a bare `git push` does.
         remote = _push_remote(cmd)
         if remote is None:
-            return  # not a git push
+            remote = ""
         # All git calls below share ONE wall-clock budget (see _GIT_BUDGET_S) so
         # the chain can never approach the hook's CC timeout (a timeout = block).
         global _deadline
@@ -274,27 +412,72 @@ def main() -> None:
         # and a preceding `cd <dir>` — so we scan the branch being pushed, not
         # the payload cwd (Codex P2 on #1267).
         cwd = _effective_cwd(cmd, payload_cwd)
-        if not _targets_public_repo(remote, cwd):
+        target = _resolve_target(remote, cwd)
+        if target == "other":
             return  # private-fork / non-origin push — real IPs allowed there
         diff_text = _outgoing_diff(cwd)
         if not diff_text:
             return
-        findings = _scan(diff_text)
-        if not findings:
+        # The scan runs inside the SAME wall-clock budget as the git calls. It is
+        # regex work over a user-editable pattern file, and a PreToolUse hook that
+        # times out is treated as a BLOCK — an external kill no `try` can catch.
+        # MEASURED on a catastrophic-backtracking pattern: 0.20s at 20 input
+        # characters, 7.11s at 26, 28.61s at 28, doubling per character, against
+        # this hook's 30s settings.json timeout. One unlucky fingerprint entry
+        # would otherwise make the repo unpushable — inverting the fail-OPEN this
+        # hook promises, in the one direction it must never fail.
+        if _deadline is not None and time.monotonic() >= _deadline:
             return
-        seen: set = set()
-        lines: list[str] = []
-        for finding in findings:
-            key = (finding.file, finding.line, finding.message)
-            if key in seen:
-                continue
-            seen.add(key)
-            lines.append(f"  {finding.file or '?'}:{finding.line or '?'}  {finding.message}")
+        class_findings, fingerprint_findings = _scan(diff_text)
+        if _deadline is not None and time.monotonic() >= _deadline:
+            return  # the scan itself overran — fail OPEN, as every git overrun does
+        if not class_findings and not fingerprint_findings:
+            return
+
+        # Scoped to the PUSH segment, like 14 of the 15 sibling call sites.
+        # `_has_trailing_override` breaks at the first unquoted `#` in whatever it
+        # is given and its token scan crosses newlines, so passing the whole
+        # command made "trailing comment" mean "any comment anywhere". MEASURED:
+        # a comment written for a following `rm`, and one on a later `echo` line,
+        # both waived the block on a push the author never meant to override.
+        # (Quoted mentions were already safe — the parser's quote tracking is
+        # sound, verified against `bash -c '… # privacy-override'` and
+        # `echo '# privacy-override'`, both correctly refused.)
+        overridden = any(has_trailing_override(s.raw, "privacy-override") for s in push_segs)
+        # Only a CONFIDENTLY public target blocks; `unknown` falls through to the
+        # advisory below (see _resolve_target).
+        if fingerprint_findings and not overridden and target == "public":
+            sys.stderr.write(
+                "BLOCKED: this push to the PUBLIC repo adds "
+                f"{len(fingerprint_findings)} line(s) matching an entry in this "
+                "install's release-fingerprints file. Locations (content withheld):\n"
+                + "\n".join(_render(fingerprint_findings)[:_MAX_LINES])
+                + "\n\nThis is blocked rather than flagged because a push cannot be "
+                "taken back. CI scans every commit's added lines, not the net diff, so "
+                "a later scrub commit does NOT clear it — remediation once published is "
+                "abandoning the branch and opening a replacement PR.\n"
+                "Fix it here: replace the value with a synthetic stand-in (a test "
+                "fixture almost never depends on the real one), then re-stage and "
+                "amend. If the value is genuinely generic and the fingerprint entry is "
+                "too broad, correct the fingerprint file. If you are deliberately "
+                "pushing this value — updating the fingerprints themselves is the real "
+                "case — append '# privacy-override' to the push command; it is a "
+                "conscious, announced act, not a way around the check.\n"
+            )
+            sys.exit(2)
+
+        header = "[Pre-push privacy review] "
+        if overridden and fingerprint_findings:
+            header += (
+                "⚠️ OVERRIDDEN: '# privacy-override' waived a block on "
+                f"{len(fingerprint_findings)} exact fingerprint match(es). "
+                "This push publishes them. "
+            )
         context = (
-            "[Pre-push privacy review] ⚠️ This push to the PUBLIC repo "
-            "adds lines matching private-data patterns. Before it lands, confirm "
-            "each is a generic placeholder (safe) or scrub the real value:\n"
-            + "\n".join(lines[:_MAX_LINES])
+            header + "This push to the PUBLIC repo adds lines matching private-data "
+            "patterns. Before it lands, confirm each is a generic placeholder "
+            "(safe) or scrub the real value:\n"
+            + "\n".join(_render(fingerprint_findings + class_findings)[:_MAX_LINES])
         )
         json.dump(
             {
@@ -305,8 +488,16 @@ def main() -> None:
             },
             sys.stdout,
         )
+    except SystemExit:
+        # SystemExit derives from BaseException, so `except Exception` below would
+        # not catch it anyway. This clause is documentation, not a repair: it makes
+        # the deliberate block visibly exempt from the swallow-everything guard, so
+        # nobody later "tidies up" by widening that guard to BaseException.
+        raise
     except Exception:
-        # An advisory must NEVER block a push — swallow everything, exit 0.
+        # Any OTHER failure leaves the push alone. A hook bug that blocked every
+        # push would cost more than the leak it prevents, and CI still refuses
+        # the merge.
         return
 
 

--- a/scripts/hooks/pre_push_privacy_review.py
+++ b/scripts/hooks/pre_push_privacy_review.py
@@ -86,7 +86,7 @@ from pathlib import Path
 # script and when it is imported for tests (mirrors git_push_guard.py:27).
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import field, read_payload  # noqa: E402
-from shell_parse import analyze, has_trailing_override  # noqa: E402
+from shell_parse import analyze, git_subcommand, has_trailing_override  # noqa: E402
 
 # Make `genesis.contribution.sanitize` importable. The genesis-hook wrapper runs
 # the venv python where genesis is editable-installed, so the import normally
@@ -157,46 +157,41 @@ def _norm_url(url: str) -> str:
     return re.sub(r"\.git$", "", url.strip().lower()).rstrip("/")
 
 
+def _remote_from_argv(argv: list[str]) -> str:
+    """The remote/URL a parsed ``git push`` argv targets; "" for a bare push
+    (the branch's default push remote)."""
+    i = 0
+    while i < len(argv) and argv[i] != "push":
+        i += 1
+    j = i + 1
+    while j < len(argv):
+        tok = argv[j]
+        if tok.startswith("-"):
+            if tok in _PUSH_VALUE_FLAGS and j + 1 < len(argv):
+                j += 2
+                continue
+            j += 1
+            continue
+        return tok
+    return ""  # bare push
+
+
 def _push_remote(cmd: str) -> str | None:
     """The remote/URL a ``git push`` targets, or None if cmd is not a git push.
 
-    Returns "" for a bare ``git push`` (the branch's default push remote).
-    Best-effort argv parse over shell segments; ambiguity resolves toward "" so
-    the caller still scans (an advisory over-informs rather than misses).
+    Reads BOTH facts — is this a push, and where to — from the SAME shared parse.
+    It used to re-split the raw command with a local `re.split`, which put two
+    parsers in one hook that disagreed: the shared one found a push in a
+    multi-line command and this one did not, so `git push private feat` written
+    over two lines came back None, was folded to "" (= the default remote),
+    resolved as origin, and a push to a PRIVATE fork could be blocked as public.
+    Each parser was wrong in a different direction and both ended in a false
+    block. There is now one parser and nothing left to disagree with.
     """
-    for seg in re.split(r"\|\||&&|[;|&]", cmd):
-        try:
-            toks = shlex.split(seg)
-        except ValueError:
+    for seg in analyze(cmd):
+        if seg.exe != "git" or git_subcommand(seg.argv) != "push":
             continue
-        # Skip leading `VAR=val` env assignments, then require `git` as the
-        # command word (so `echo git push` is not mistaken for a push).
-        k = 0
-        while k < len(toks) and re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", toks[k]):
-            k += 1
-        if k >= len(toks) or toks[k] != "git":
-            continue
-        i = k + 1
-        # Advance past git global options (and their values) to the subcommand.
-        while i < len(toks) and toks[i].startswith("-"):
-            if toks[i] in _GIT_GLOBAL_VALUE_OPTS and i + 1 < len(toks):
-                i += 2
-            else:
-                i += 1
-        if i >= len(toks) or toks[i] != "push":
-            continue
-        # First non-flag positional after `push` is the remote (or a URL).
-        j = i + 1
-        while j < len(toks):
-            tok = toks[j]
-            if tok.startswith("-"):
-                if tok in _PUSH_VALUE_FLAGS and j + 1 < len(toks):
-                    j += 2
-                    continue
-                j += 1
-                continue
-            return tok
-        return ""  # bare push
+        return _remote_from_argv(seg.argv)
     return None
 
 
@@ -385,7 +380,11 @@ def _push_segments(cmd: str) -> list:
     call and DOES parse those spellings, so the operator gets its approval prompt,
     which reads as "this push was reviewed", with no privacy verdict behind it.
     """
-    return [s for s in analyze(cmd) if s.exe == "git" and "push" in s.argv]
+    # `git_subcommand`, not `"push" in argv`: a membership test treats a REF
+    # named push as a push, so `git checkout push` / `git branch push` would be
+    # scanned and could be refused — a false block on a command that publishes
+    # nothing.
+    return [s for s in analyze(cmd) if s.exe == "git" and git_subcommand(s.argv) == "push"]
 
 
 def main() -> None:
@@ -397,12 +396,9 @@ def main() -> None:
         push_segs = _push_segments(cmd)
         if not push_segs:
             return  # not a git push
-        # The remote NAME still comes from the local parser; when it cannot read
-        # one, "" means "the branch's default push remote", which resolves the
-        # same way a bare `git push` does.
-        remote = _push_remote(cmd)
-        if remote is None:
-            remote = ""
+        # The remote comes from the SAME segment that established this is a push,
+        # so the two facts can never come from different readings of the command.
+        remote = _remote_from_argv(push_segs[0].argv)
         # All git calls below share ONE wall-clock budget (see _GIT_BUDGET_S) so
         # the chain can never approach the hook's CC timeout (a timeout = block).
         global _deadline
@@ -470,11 +466,20 @@ def main() -> None:
         if overridden and fingerprint_findings:
             header += (
                 "⚠️ OVERRIDDEN: '# privacy-override' waived a block on "
-                f"{len(fingerprint_findings)} exact fingerprint match(es). "
+                f"{len(fingerprint_findings)} fingerprint match(es). "
                 "This push publishes them. "
             )
+        # Say what is known. On the `unknown` path the remote did not resolve, so
+        # asserting "the PUBLIC repo" states as fact the very thing that could not
+        # be determined — and an advisory that overstates its own certainty is how
+        # a reader learns to discount it.
+        where = (
+            "This push to the PUBLIC repo adds"
+            if target == "public"
+            else "This push adds (its remote did not resolve, so whether it is public is unknown)"
+        )
         context = (
-            header + "This push to the PUBLIC repo adds lines matching private-data "
+            header + where + " lines matching private-data "
             "patterns. Before it lands, confirm each is a generic placeholder "
             "(safe) or scrub the real value:\n"
             + "\n".join(_render(fingerprint_findings + class_findings)[:_MAX_LINES])

--- a/scripts/hooks/shell_parse.py
+++ b/scripts/hooks/shell_parse.py
@@ -535,6 +535,7 @@ _KNOWN_SIGILS = (
     "stale-review-override",
     "scheduled-review-override",
     "discard-override",
+    "privacy-override",
     # Both were passed to has_trailing_override from the day they shipped but never
     # listed here, so the "kept in sync" claim above was false. The consequence is
     # silent and asymmetric: the sigil queried FOR ITSELF still matches, so nothing

--- a/tests/test_hooks/test_pre_push_privacy_review.py
+++ b/tests/test_hooks/test_pre_push_privacy_review.py
@@ -546,3 +546,61 @@ def test_an_unresolvable_remote_advises_rather_than_blocks(monkeypatch, capsys, 
     assert code == 0, "an unresolvable remote must not hard-block"
     assert cap.err == ""
     assert "Pre-push privacy review" in cap.out, "but it must still warn"
+
+
+# ── one parser, both facts (CodeRabbit Major on #1857) ─────────────────
+#
+# Reusing the shared parser for DETECTION while the remote still came from a
+# local re.split left two parsers in one hook that disagreed, and each was wrong
+# in a different direction — both ending in a false exit-2 block on a command
+# that publishes nothing to the public repo.
+
+
+def test_a_ref_named_push_is_not_a_push():
+    """`"push" in argv` is a membership test, so a REF named push made
+    `git checkout push` look like a push — scanned, and refusable. The subcommand
+    is what decides."""
+    for cmd in ("git checkout push", "git branch push", "git switch push"):
+        assert not hook._push_segments(cmd), f"{cmd!r} is not a push"
+    assert hook._push_segments("git push origin x"), "a real push must still be seen"
+
+
+def test_the_remote_survives_a_multi_line_command():
+    """The other direction: the shared parser found the push in a multi-line
+    command and the local splitter did not, so the remote came back None, was
+    folded to "" (= the default remote), and resolved as origin — a push to a
+    PRIVATE fork could then be blocked as public."""
+    assert hook._push_remote("git status\ngit push private feat") == "private"
+    assert hook._push_remote("git add -A && git commit -m x\ngit push private feat") == "private"
+
+
+def test_remote_is_read_from_the_same_segment_that_found_the_push():
+    """The class fix, asserted directly: whatever segment establishes 'this is a
+    push' is the segment the remote is read from, so the two facts cannot come
+    from different readings of the command. The flag here takes a value, which is
+    the shape a naive 'first non-flag token' scan gets wrong."""
+    cmd = "git status\ngit push --receive-pack=/x private feat"
+    segs = hook._push_segments(cmd)
+    assert segs
+    assert hook._remote_from_argv(segs[0].argv) == "private"
+
+
+def test_advisory_does_not_claim_PUBLIC_when_the_remote_did_not_resolve(
+    monkeypatch, capsys, fingerprints
+):
+    """An advisory that overstates its own certainty teaches the reader to
+    discount it. On the unresolved path, 'the PUBLIC repo' asserts as fact the
+    one thing that could not be determined."""
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "git push notaremote feat"},
+        "cwd": "/tmp",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(hook, "_targets_public_repo", lambda remote, cwd: True)
+    monkeypatch.setattr(hook, "_target_resolved", lambda remote, cwd: False)
+    monkeypatch.setattr(hook, "_outgoing_diff", lambda cwd: _FINGERPRINT_DIFF)
+    hook.main()
+    ctx = json.loads(capsys.readouterr().out)["hookSpecificOutput"]["additionalContext"]
+    assert "PUBLIC repo" not in ctx
+    assert "did not resolve" in ctx

--- a/tests/test_hooks/test_pre_push_privacy_review.py
+++ b/tests/test_hooks/test_pre_push_privacy_review.py
@@ -1,7 +1,11 @@
-"""Tests for the pre-push privacy ADVISORY hook.
+"""Tests for the pre-push privacy hook.
 
-The hook is non-blocking: it emits `hookSpecificOutput.additionalContext` on
-findings and ALWAYS exits 0. Fixtures use a generic CGNAT literal (100.64.0.1)
+TWO VERDICTS. A CLASS finding (RFC1918 shapes, /home/<user>, emails) is advisory:
+it emits `hookSpecificOutput.additionalContext` and exits 0, because those
+regexes have real false positives. A FINGERPRINT match exits 2 and blocks: those
+patterns are curated per-install to name that install's own values, and a push
+cannot be taken back. (Not "exact literals" — the sanitizer compiles each entry
+as a regex; an entry is as precise as whoever wrote it.) Fixtures use a generic CGNAT literal (100.64.0.1)
 that the contribution sanitizer's portability scanner flags but that is NOT
 this install's real address (so this test file leaks nothing and is not caught
 by the CI install-IP scan).
@@ -13,6 +17,8 @@ import io
 import json
 import sys
 from pathlib import Path
+
+import pytest
 
 _ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_ROOT / "scripts" / "hooks"))
@@ -88,14 +94,22 @@ def test_effective_cwd_skips_super_prefix_to_find_dash_C():
 # ── _scan (reuses the sanitizer's cheap regex scanners) ────────────────
 
 
-def test_scan_flags_install_pattern():
-    findings = hook._scan(_LEAK_DIFF)
-    assert findings, "portability scanner should flag the CGNAT literal"
-    assert any(getattr(f, "file", None) == "x.py" for f in findings)
+def test_scan_flags_install_pattern(fingerprints):
+    # The `fingerprints` fixture is REQUIRED, not decoration: without it `_scan`
+    # falls through to the developer's real ~/.genesis file, which does not exist
+    # on CI — so the fingerprint assertion below would be vacuous there and merely
+    # environment-dependent locally.
+    class_findings, fingerprint_findings = hook._scan(_LEAK_DIFF)
+    assert class_findings, "portability scanner should flag the CGNAT literal"
+    assert any(getattr(f, "file", None) == "x.py" for f in class_findings)
+    assert fingerprint_findings == [], (
+        "a class-pattern hit must not land in the fingerprint bucket — that bucket "
+        "is what blocks, and the two verdicts must not blur"
+    )
 
 
-def test_scan_clean_diff_no_findings():
-    assert hook._scan(_CLEAN_DIFF) == []
+def test_scan_clean_diff_no_findings(fingerprints):
+    assert hook._scan(_CLEAN_DIFF) == ([], [])
 
 
 # ── main() end-to-end (git helpers monkeypatched) ──────────────────────
@@ -210,3 +224,325 @@ def test_targets_public_repo_normalizes_url(monkeypatch):
     assert hook._targets_public_repo("https://github.com/Org/Repo", None) is True
     assert hook._targets_public_repo("https://github.com/Org/Repo/", None) is True
     assert hook._targets_public_repo("https://github.com/Org/Other", None) is False
+
+
+# ── the BLOCKING path: exact fingerprint matches ───────────────────────
+#
+# Class findings stay advisory because their regexes have real false positives
+# (this repo's own fixtures carry a dozen). A fingerprint is an exact literal
+# from the install's own file, so a hit IS the private value — and a push cannot
+# be taken back, which is why this one blocks rather than warns.
+
+_SECRET = "sw-fixture-secret-slug-42"
+_FINGERPRINT_DIFF = (
+    f"diff --git a/t.py b/t.py\n--- a/t.py\n+++ b/t.py\n@@ -1 +1 @@\n+PROJECT = '{_SECRET}'\n"
+)
+
+
+@pytest.fixture
+def fingerprints(tmp_path, monkeypatch):
+    """Point the hook at a synthetic fingerprint file — never the real one."""
+    fp = tmp_path / "release-fingerprints.txt"
+    fp.write_text(f"# a comment line, ignored\n\n{_SECRET}\n")
+    monkeypatch.setenv("GENESIS_RELEASE_FINGERPRINTS", str(fp))
+    return fp
+
+
+def _run_main_full(monkeypatch, capsys, *, command, public, diff):
+    """Like _run_main but returns (exit_code, stdout, stderr)."""
+    payload = {"tool_name": "Bash", "tool_input": {"command": command}, "cwd": "/tmp"}
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(hook, "_targets_public_repo", lambda remote, cwd: public)
+    # A CONFIDENT resolution — the uncertain case has its own test. Without this
+    # the real resolver runs git in a temp cwd, resolves nothing, and every block
+    # test silently degrades to the advisory path.
+    monkeypatch.setattr(hook, "_target_resolved", lambda remote, cwd: True)
+    monkeypatch.setattr(hook, "_outgoing_diff", lambda cwd: diff)
+    code = 0
+    try:
+        hook.main()
+    except SystemExit as exc:
+        code = exc.code
+    cap = capsys.readouterr()
+    return code, cap.out, cap.err
+
+
+def test_fingerprint_match_blocks_the_push(monkeypatch, capsys, fingerprints):
+    """The whole point: exit 2, which is what PreToolUse treats as a block."""
+    code, out, err = _run_main_full(
+        monkeypatch, capsys, command="git push origin feat", public=True, diff=_FINGERPRINT_DIFF
+    )
+    assert code == 2, "an exact fingerprint match must BLOCK, not advise"
+    assert out == "", "a block speaks on stderr; stdout stays free of JSON"
+    assert "t.py" in err, "the author needs the location"
+
+
+def test_block_message_never_echoes_the_matched_value(monkeypatch, capsys, fingerprints):
+    """Same contract as the CI scanner: name the location, never the content.
+    A transcript is one of the places the value should not end up."""
+    _code, _out, err = _run_main_full(
+        monkeypatch, capsys, command="git push origin feat", public=True, diff=_FINGERPRINT_DIFF
+    )
+    assert _SECRET not in err
+
+
+def test_class_findings_alone_never_block(monkeypatch, capsys, fingerprints):
+    """A fingerprint file is present and simply does not match. Class hits keep
+    their advisory verdict — the false-positive rate is why they have it."""
+    code, out, err = _run_main_full(
+        monkeypatch, capsys, command="git push origin feat", public=True, diff=_LEAK_DIFF
+    )
+    assert code == 0
+    assert err == ""
+    assert "Pre-push privacy review" in json.loads(out)["hookSpecificOutput"]["additionalContext"]
+
+
+def test_missing_fingerprint_file_never_blocks(monkeypatch, capsys, tmp_path):
+    """Fail OPEN on an absent file. A fresh clone has no fingerprints, and a hook
+    that blocked every push there would cost more than the leak it prevents."""
+    monkeypatch.setenv("GENESIS_RELEASE_FINGERPRINTS", str(tmp_path / "nope.txt"))
+    code, _out, err = _run_main_full(
+        monkeypatch, capsys, command="git push origin feat", public=True, diff=_FINGERPRINT_DIFF
+    )
+    assert code == 0
+    assert err == ""
+
+
+def test_override_sigil_downgrades_to_an_announced_advisory(monkeypatch, capsys, fingerprints):
+    """The deliberate case — pushing the fingerprint file itself, say. It goes
+    through, and it says out loud that it did; a silent override would be worse
+    than no override."""
+    code, out, err = _run_main_full(
+        monkeypatch,
+        capsys,
+        command="git push origin feat  # privacy-override",
+        public=True,
+        diff=_FINGERPRINT_DIFF,
+    )
+    assert code == 0, "the sigil must clear the block"
+    assert err == ""
+    ctx = json.loads(out)["hookSpecificOutput"]["additionalContext"]
+    assert "OVERRIDDEN" in ctx and "privacy-override" in ctx
+    assert _SECRET not in ctx, "even when overridden, do not echo the value"
+
+
+def test_a_quoted_sigil_is_not_an_override(monkeypatch, capsys, fingerprints):
+    """The sigil must be a real trailing comment, not the word appearing inside a
+    quoted string somewhere in the command — that is the shared parser's job and
+    this pins that we use it rather than a local regex."""
+    code, _out, _err = _run_main_full(
+        monkeypatch,
+        capsys,
+        command="git push origin feat && echo 'not a # privacy-override marker'",
+        public=True,
+        diff=_FINGERPRINT_DIFF,
+    )
+    assert code == 2, "a quoted mention must not waive the block"
+
+
+def test_a_non_public_push_is_never_blocked(monkeypatch, capsys, fingerprints):
+    """Real install values are allowed on a private fork; the gate is about
+    publication, not about the value existing."""
+    code, out, err = _run_main_full(
+        monkeypatch, capsys, command="git push private feat", public=False, diff=_FINGERPRINT_DIFF
+    )
+    assert (code, out, err) == (0, "", "")
+
+
+def test_scanner_failure_still_fails_open(monkeypatch, capsys, fingerprints):
+    """The fail direction, restated for the blocking path: a hook bug must not
+    become an unpushable repo."""
+
+    def _boom(_diff):
+        raise RuntimeError("scanner exploded")
+
+    monkeypatch.setattr(hook, "_scan", _boom)
+    code, out, err = _run_main_full(
+        monkeypatch, capsys, command="git push origin feat", public=True, diff=_FINGERPRINT_DIFF
+    )
+    assert (code, out, err) == (0, "", "")
+
+
+def test_the_sigil_is_registered_with_the_shared_parser():
+    """An unregistered sigil still matches when queried for itself, but reads as
+    prose and ENDS the leading run for anything written after it — silently
+    disabling a second sigil on the same command."""
+    import shell_parse
+
+    assert "privacy-override" in shell_parse._KNOWN_SIGILS
+    assert shell_parse.has_trailing_override(
+        "git push origin x  # privacy-override ci-override", "ci-override"
+    ), "a sigil written after privacy-override must still be seen"
+
+
+# ── the input side, converted from advisory to blocking tolerances ─────
+#
+# The verdict changed from "print a warning" to "refuse the push", but the
+# helpers that decide WHETHER and WHAT to scan were written when a miss cost a
+# missing warning. Under a gate the same miss is a fail-OPEN on a publication
+# guard. Each test below pins one of those conversions; each fails against the
+# first draft of this change, which is what makes them worth having.
+
+
+def test_every_ordinary_push_spelling_is_seen(fingerprints):
+    """The parser conversion. A local `re.split` on `&&|;|&|||` never splits on a
+    NEWLINE, so this repo's own idiom — commit on one line, push on the next —
+    read as a single non-push segment and skipped the gate entirely, while
+    `git_push_guard` on the same tool call parsed it fine and asked for approval.
+    An operator would see 'this push was reviewed' with no privacy verdict behind
+    it, which is worse than either hook alone.
+    """
+    for cmd in (
+        "git push origin feat",
+        "git status\ngit push origin feat",
+        "git add -A && git commit -m x\ngit push origin feat",
+        "cd /work\ngit push origin feat",
+        "/usr/bin/git push origin feat",
+        "time git push origin feat",
+    ):
+        assert hook._push_segments(cmd), f"push not seen in {cmd!r}"
+
+
+def test_non_pushes_are_still_ignored():
+    """The conversion must not widen into 'scan everything' — a guard that fires
+    on unrelated commands gets routed around."""
+    for cmd in ("git commit -m x", "echo git push", "git log --oneline", "grep -r push src/"):
+        assert not hook._push_segments(cmd), f"false positive on {cmd!r}"
+
+
+def test_the_sigil_is_scoped_to_the_push_segment(fingerprints):
+    """The sigil conversion. `_has_trailing_override` breaks at the first unquoted
+    `#` in whatever it is handed and its token scan crosses newlines, so passing
+    the WHOLE command made 'trailing comment' mean 'any comment anywhere' — a note
+    written for a following `rm`, or on a later line, waived a security gate on a
+    push the author never meant to override."""
+    for cmd in (
+        "git push origin feat && rm -f /tmp/x  # privacy-override cleanup",
+        "git push origin feat\necho done  # privacy-override",
+    ):
+        segs = hook._push_segments(cmd)
+        assert segs, cmd
+        assert not any(
+            hook.has_trailing_override(s.raw, "privacy-override") for s in segs
+        ), f"a comment on ANOTHER command waived the block: {cmd!r}"
+
+
+def test_the_sigil_still_works_on_the_push_itself(fingerprints):
+    """Guard-the-guard for the test above: narrowing the scope must not break the
+    override, or the block would have no escape at all."""
+    segs = hook._push_segments("git add -A\ngit push origin feat  # privacy-override")
+    assert any(hook.has_trailing_override(s.raw, "privacy-override") for s in segs)
+
+
+# ── _outgoing_diff: the range model, on a real repo ────────────────────
+#
+# This helper had NO test, which is exactly why it shipped scanning the net diff
+# — the one model its own docstring argues is wrong for a publication gate.
+
+
+def _repo(tmp_path):
+    """A real git repo with an `origin` and one commit already pushed."""
+    import subprocess as sp
+
+    origin, work = tmp_path / "origin.git", tmp_path / "work"
+    sp.run(["git", "init", "-q", "--bare", str(origin)], check=True)
+    sp.run(["git", "init", "-q", "-b", "main", str(work)], check=True)
+    g = ["git", "-C", str(work)]
+    sp.run([*g, "remote", "add", "origin", str(origin)], check=True)
+    sp.run([*g, "config", "user.email", "t@t"], check=True)
+    sp.run([*g, "config", "user.name", "t"], check=True)
+    (work / "a.txt").write_text("base\n")
+    sp.run([*g, "add", "a.txt"], check=True)
+    sp.run([*g, "commit", "-qm", "base"], check=True)
+    sp.run([*g, "push", "-q", "origin", "main"], check=True)
+    return work, g
+
+
+def test_a_value_added_then_scrubbed_is_still_seen(tmp_path):
+    """THE range defect, replayed. Commit A adds the value, commit B removes it.
+    The net `diff base..HEAD` is clean — and the value still ships in A's patch,
+    published forever. That is precisely the scenario the block message calls
+    unfixable, so the gate that exists to prevent it must not be blind to it.
+    """
+    import subprocess as sp
+
+    work, g = _repo(tmp_path)
+    (work / "leak.py").write_text("TOKEN = 'sw-fixture-secret-slug-42'\n")
+    sp.run([*g, "add", "leak.py"], check=True)
+    sp.run([*g, "commit", "-qm", "adds it"], check=True)
+    (work / "leak.py").write_text("TOKEN = 'placeholder'\n")
+    sp.run([*g, "add", "leak.py"], check=True)
+    sp.run([*g, "commit", "-qm", "scrubs it"], check=True)
+
+    hook._deadline = None
+    diff = hook._outgoing_diff(str(work))
+    assert _SECRET in diff, (
+        "the scrubbed value is absent from what gets scanned — a net-diff model, "
+        "which is the exact blind spot this gate exists to close"
+    )
+
+
+def test_a_leak_already_on_the_remote_is_still_seen(tmp_path):
+    """The second narrowing: anchoring on `origin/<branch>` means that after the
+    first push the scan only ever sees the newest commits, so a leak already
+    pushed to the branch silently stops being reported."""
+    import subprocess as sp
+
+    work, g = _repo(tmp_path)
+    sp.run([*g, "checkout", "-q", "-b", "feat"], check=True)
+    (work / "leak.py").write_text(f"TOKEN = '{_SECRET}'\n")
+    sp.run([*g, "add", "leak.py"], check=True)
+    sp.run([*g, "commit", "-qm", "adds it"], check=True)
+    sp.run([*g, "push", "-q", "origin", "feat"], check=True)
+    (work / "other.txt").write_text("unrelated\n")
+    sp.run([*g, "add", "other.txt"], check=True)
+    sp.run([*g, "commit", "-qm", "unrelated follow-up"], check=True)
+
+    hook._deadline = None
+    assert _SECRET in hook._outgoing_diff(str(work)), (
+        "a value already pushed to this branch dropped out of the scan"
+    )
+
+
+def test_clean_branch_scans_clean(tmp_path):
+    """Guard-the-guard: the two tests above would also pass if `_outgoing_diff`
+    simply returned the whole of history. It must not."""
+    import subprocess as sp
+
+    work, g = _repo(tmp_path)
+    (work / "b.txt").write_text("nothing private\n")
+    sp.run([*g, "add", "b.txt"], check=True)
+    sp.run([*g, "commit", "-qm", "ordinary work"], check=True)
+
+    hook._deadline = None
+    diff = hook._outgoing_diff(str(work))
+    assert "nothing private" in diff, "the new commit should be in range"
+    assert "base" not in diff.replace("rebase", ""), "history before the merge-base is out of range"
+
+
+# ── target resolution: uncertainty advises, it never blocks ────────────
+
+
+def test_an_unresolvable_remote_advises_rather_than_blocks(monkeypatch, capsys, fingerprints):
+    """The resolution conversion. 'Uncertain → treat as public' was right for an
+    advisory (over-informing is free) and wrong for a gate: it strands an operator
+    whose remote merely failed to resolve, and offers them only a sigil whose
+    message says they are deliberately publishing — which they are not."""
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "git push notaremote feat"},
+        "cwd": "/tmp",
+    }
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(payload)))
+    monkeypatch.setattr(hook, "_targets_public_repo", lambda remote, cwd: True)
+    monkeypatch.setattr(hook, "_target_resolved", lambda remote, cwd: False)
+    monkeypatch.setattr(hook, "_outgoing_diff", lambda cwd: _FINGERPRINT_DIFF)
+    code = 0
+    try:
+        hook.main()
+    except SystemExit as exc:
+        code = exc.code
+    cap = capsys.readouterr()
+    assert code == 0, "an unresolvable remote must not hard-block"
+    assert cap.err == ""
+    assert "Pre-push privacy review" in cap.out, "but it must still warn"


### PR DESCRIPTION
The pre-push privacy check already found install-private values in an outgoing
push and printed a warning. The warning arrived in the same tool call as the push
it described — which is too late to be useful, because a push cannot be taken
back.

## Why an advisory is the wrong shape here

MEASURED 2026-09-07. The advisory fired correctly on a real push, the push
proceeded, and the value was published. It could not then be fixed forward:
`private_pattern_scan` in CI deliberately scans **every commit's added lines**
rather than the net diff, so a later scrub commit does not clear it, and
force-push is banned. The remediation was abandoning the branch, opening a
replacement PR, and deleting the old ref.

CI is the right place to refuse a *merge*. It is the wrong place to prevent a
*publication*, because by the time it speaks the value is already public.

## What blocks, and what deliberately does not

Only a match against the install's own `release-fingerprints.txt`. Class-pattern
findings — private-range addresses, `/home/<user>` shapes, email addresses — stay
advisory, because those regexes have real false positives and this repo's own
fixtures carry a dozen legitimate ones. Blocking on those would train everyone to
route around the gate.

Two things worth stating precisely, because the first draft of this change got
both wrong:

- It is **not** an "exact literal" match. `sanitize._check_fingerprints` compiles
  each entry as a **regex**, with `re.escape` only as the fallback for a line
  that is not valid regex; on one install 4 of 7 entries carry metacharacters. So
  an entry is as precise as whoever wrote it. The reason this tier blocks is not
  "zero false positives" — it is that the patterns are curated per-install to name
  that install's own values.
- The sanitizer **already** assigns a fingerprint hit `Severity.BLOCK`
  (`sanitize.py:455`). This change makes the push hook act on a severity that was
  already decided, rather than inventing a new judgement.

Background sessions lose nothing: `git_push_guard` already hard-denies a push in
a Genesis-dispatched session, so the only sessions that reach this gate are
foreground ones where somebody can act on it.

## The substantive half: converting the input side

An adversarial review found the verdict had changed from advisory to blocking
while the helpers that decide **whether** and **what** to scan were still at
advisory tolerances — a gate failing OPEN on the common path and CLOSED on an
uncommon one. Each was fixed as one class, and each is measured:

| what | was | now |
|---|---|---|
| command parser | local `re.split` with no `\n` — **4 of 5** ordinary spellings read as "not a push" and skipped the scan | the shared `shell_parse.analyze()`, like the four sibling hooks — 5 of 5 |
| scan range | net `diff base..HEAD` — blind to add-then-scrub, the one shape this gate exists to catch | per-commit over the merge-base, matching CI's own range selector |
| sigil scope | command-wide — a comment written for a following `rm`, or on a later line, waived the block | scoped to the push segment, like 14 of the 15 sibling call sites |
| unresolvable remote | reported as PUBLIC and blocked | advises; only a confident public target blocks |
| scan budget | outside the wall-clock budget — a hook timeout is treated as a block, so an unbounded regex over a user-editable file could make the repo unpushable | inside it, failing open on overrun |

The parser one is the sharpest: `git_push_guard` runs on the same tool call and
**does** parse those spellings, so the operator would get its approval prompt —
which reads as "this push was reviewed" — with no privacy verdict behind it. That
is worse than either hook alone.

## Verification

End-to-end against the real hook script, on a real repo whose **net diff is
clean** (add-then-scrub, 0 occurrences confirmed by `git diff`):

| case | result |
|---|---|
| plain push | **exit 2**, blocked |
| multi-line commit-then-push | **exit 2** — used to bypass the gate entirely |
| sigil written for a *different* command | **exit 2** — used to waive |
| sigil on the push itself | exit 0, and the advisory announces the waiver |

Plus the acceptance replay: the value that actually leaked on 2026-09-07, against
the real fingerprint file, blocked with the value not echoed. 248 tests pass
across this hook, `shell_parse`, the value-flag consistency lock and the
hook-surface guardrail.

Quoted spoofing was probed and is **not** possible — `bash -c '… # sigil'` and
`echo '# privacy-override'` are both correctly refused. The parser's quote
tracking is sound; the defect was only the argument scope.

## What registering the sigil changes elsewhere

`shell_parse.py` asks the PR that adds a sigil to enumerate what flips, so: with
`# privacy-override` written FIRST in a comment, all **11** other sigils flip
`False → True` for a following token — `review-override`, `ci-override`,
`full-suite-ok`, `escalation-ack`, `merge-to-main-override`, `discard-override`,
`final-round-accept`, `audit-ack`, `depth-ack`, `stale-review-override`,
`scheduled-review-override`. That is the registry's intended property (an
unregistered token reads as prose and ends the leading run, silently disabling
every sigil after it), and the practical risk is low, since the second sigil must
actually be typed.

## Known limitations, stated rather than hidden

Two hooks emit verdicts on the same tool call; a deny is terminal in Claude
Code's aggregation, so exit 2 should win over `git_push_guard`'s `ask`. That
precedence is **not** independently verified against the binary. Likewise the
"a PreToolUse timeout is treated as a block" premise is this file's own
long-standing claim, inherited rather than re-measured here — it only informs the
budget fix, which is safe either way.

E2E: after merge and deploy, run a push carrying a line that matches this
install's fingerprint file and confirm it exits 2 with the location named and the
value absent from stderr; then confirm a class-only finding (a private-range
address in a fixture) still exits 0 with the advisory, and that
`# privacy-override` on the push itself passes with the waiver announced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Privacy checks now distinguish advisory pattern findings from high-confidence fingerprint matches.
  - Confirmed fingerprint matches can block public pushes, while uncertain or non-public cases remain advisory.
  - Added a trailing-comment override for intentionally approved fingerprint findings.
  - Push checks now review all newly added content across the outgoing commit range.

- **Bug Fixes**
  - Privacy check failures, timeouts, missing data, and unreadable configuration continue to fail safely without blocking pushes.
  - Block messages no longer expose matched sensitive values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->