### PR TITLE
fix(watchdog): bound a bootstrap grace on the stale-status restart path

### DIFF
--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -234,6 +234,42 @@ class WatchdogChecker:
                     )
                     return WatchdogAction.SKIP
 
+                # ...but `uptime_s` belongs to whichever process WROTE the
+                # file. When a restart lands while the previous status.json is
+                # still inside the freshness window, that file is retained: its
+                # `uptime_s` is the PRIOR runtime's (stamped from that
+                # process's own bootstrap — see resilience/status_writer.py's
+                # `_bootstrap_completed_at` arithmetic) and its scheduler
+                # heartbeats describe a runtime that no longer exists. A large
+                # `uptime_s` therefore cannot establish that THIS process is
+                # old, and the first tick after boot would restart a healthy,
+                # still-bootstrapping server — the same defect the stale branch
+                # below closes, reached through the fresh/zombie path instead.
+                # systemd's clock is the only reading tied to the CURRENT
+                # activation: a status file older than the unit's own uptime
+                # was written before the service started. (The comparison mixes
+                # a wall-clock age with a monotonic one; a wall-clock step can
+                # only inflate `staleness_s`, i.e. err toward suppressing, and
+                # the shared counter bounds that.)
+                service_uptime = self._service_uptime_s()
+                if (
+                    service_uptime is not None
+                    and staleness_s > service_uptime
+                    and self._grant_bootstrap_grace(
+                        service_uptime,
+                        context=(
+                            f"Zombie heartbeats ({', '.join(zombie)}) but the "
+                            f"status file ({staleness_s:.0f}s old) predates this "
+                            f"activation of {self._target_service} "
+                            f"({service_uptime:.0f}s ago), so they belong to the "
+                            f"previous process"
+                        ),
+                    )
+                ):
+                    return WatchdogAction.SKIP
+                # An exhausted / unpersisted grace falls through to the normal
+                # zombie-restart path below.
+
                 # Connectivity forgiveness (PR-2): a zombie scheduler during a
                 # network outage is surplus dispatch stalled on dead-network
                 # provider calls — a restart cannot fix an ISP outage (it just
@@ -275,39 +311,21 @@ class WatchdogChecker:
         # on a FRESH file, whose uptime_s field it already checks against
         # stabilization_s.
         service_uptime = self._service_uptime_s()
-        if service_uptime is not None and service_uptime < self._staleness_threshold:
-            state = self._load_state()
-            skips = int(state.get("bootstrap_grace_skips", 0)) + 1
-            if skips > self._max_bootstrap_grace_skips:
-                logger.error(
-                    "Bootstrap grace exhausted (%d skips): %s keeps presenting "
-                    "a young uptime without ever writing a fresh status file — "
-                    "likely a restart loop; no longer suppressing.",
-                    skips - 1, self._target_service,
-                )
-                self._alert_grace_exhausted(service_uptime, skips - 1)
-                # fall through to the normal stale-restart path below
-            else:
-                state["bootstrap_grace_skips"] = skips
-                # A skip is granted only when its counter PERSISTED — an
-                # unwritable state file would otherwise reload the old count
-                # every invocation and re-grant the same slot forever
-                # (unbounded grace, the exact hole the counter closes).
-                if self._save_state(state):
-                    logger.info(
-                        "Status file stale (%.0fs) but %s started only %.0fs "
-                        "ago (< %ds threshold) — bootstrap grace %d/%d, "
-                        "skipping",
-                        staleness_s, self._target_service, service_uptime,
-                        self._staleness_threshold, skips,
-                        self._max_bootstrap_grace_skips,
-                    )
-                    return WatchdogAction.SKIP
-                logger.error(
-                    "Bootstrap grace NOT granted: skip counter could not be "
-                    "persisted — falling through to normal stale handling.",
-                )
-                # fall through to the normal stale-restart path below
+        if (
+            service_uptime is not None
+            and service_uptime < self._staleness_threshold
+            and self._grant_bootstrap_grace(
+                service_uptime,
+                context=(
+                    f"Status file stale ({staleness_s:.0f}s) but "
+                    f"{self._target_service} started only {service_uptime:.0f}s "
+                    f"ago (< {self._staleness_threshold}s threshold)"
+                ),
+            )
+        ):
+            return WatchdogAction.SKIP
+        # An exhausted / unpersisted grace falls through to the normal
+        # stale-restart path below.
 
         logger.warning(
             "Status file stale: %.0fs old (threshold %ds) — %s may be down",
@@ -317,6 +335,51 @@ class WatchdogChecker:
         # 4. Stale — attempt restart via shared logic
         state = self._load_state()
         return self._restart_if_allowed(state, reason="stale_status_restart")
+
+    def _grant_bootstrap_grace(self, service_uptime: float, *, context: str) -> bool:
+        """Consume one bounded bootstrap-grace slot. True ⇒ suppress this cycle.
+
+        Shared by the two branches that can be handed a status.json written
+        BEFORE the current activation: the stale branch (file older than the
+        staleness threshold) and the zombie branch (file still inside the
+        freshness window, but carrying the previous process's heartbeats and
+        `uptime_s`). They share ONE counter deliberately — a crash loop must
+        not get a fresh budget per branch, and the counter clears for both when
+        a genuinely fresh status file appears (``_reset_state``).
+
+        Returns False — do not suppress — in exactly two cases: the bound is
+        spent (logged + alerted once), or the incremented counter did not
+        persist. The second matters because an unwritable state file would
+        otherwise reload the old count on every oneshot invocation and re-grant
+        the same slot forever, which is precisely the unbounded grace the
+        counter exists to close.
+        """
+        state = self._load_state()
+        skips = self._coerce_counter(state.get("bootstrap_grace_skips")) + 1
+        if skips > self._max_bootstrap_grace_skips:
+            logger.error(
+                "Bootstrap grace exhausted (%d skips): %s keeps presenting a "
+                "young uptime without ever writing a fresh status file — "
+                "likely a restart loop; no longer suppressing. (%s)",
+                skips - 1, self._target_service, context,
+            )
+            self._alert_grace_exhausted(service_uptime, skips - 1)
+            return False
+
+        state["bootstrap_grace_skips"] = skips
+        if not self._save_state(state):
+            logger.error(
+                "Bootstrap grace NOT granted: skip counter could not be "
+                "persisted — falling through to normal handling. (%s)",
+                context,
+            )
+            return False
+
+        logger.info(
+            "%s — bootstrap grace %d/%d, skipping",
+            context, skips, self._max_bootstrap_grace_skips,
+        )
+        return True
 
     def _service_uptime_s(self) -> float | None:
         """Seconds since the target unit entered active, or None if unknowable.
@@ -412,7 +475,7 @@ class WatchdogChecker:
             verdict, detail = self._probe_liveness()
             d = detail or {}
             if verdict == "starved":
-                skips = int(state.get("starved_skips", 0)) + 1
+                skips = self._coerce_counter(state.get("starved_skips")) + 1
                 if skips <= self._liveness_max_starved_skips:
                     state["starved_skips"] = skips
                     if not self._save_state(state):
@@ -698,12 +761,82 @@ class WatchdogChecker:
     def _load_state(self) -> dict:
         if self._state_path.exists():
             try:
-                return self._normalise_legacy_reasons(
-                    json.loads(self._state_path.read_text()),
-                )
+                loaded = json.loads(self._state_path.read_text())
             except (json.JSONDecodeError, OSError):
-                pass
+                loaded = None
+            # Valid JSON that is not an object (a list, a bare string, a
+            # number) has no `.get`, so every normaliser and reader below
+            # would raise AttributeError. Treat it like unreadable state.
+            if isinstance(loaded, dict):
+                return self._normalise_numeric_fields(
+                    self._normalise_legacy_reasons(loaded),
+                )
         return {"consecutive_failures": 0, "next_attempt_after": None, "last_reason": None, "last_restart_at": None, "last_check_at": None, "restart_history": []}
+
+    @staticmethod
+    def _coerce_counter(value: Any) -> int:
+        """A persisted counter as a usable non-negative int; 0 for anything else.
+
+        The suppression paths do arithmetic on these (``int(x) + 1``,
+        ``x += 1``), so a state file carrying null, a string, a dict or a
+        negative — corruption, a partial write, a hand-edit — otherwise takes
+        the oneshot down with TypeError/ValueError/KeyError on every check
+        instead of returning an action. Booleans are rejected explicitly: bool
+        is a subclass of int, but True is not a count. Resetting corruption to
+        0 re-grants a budget, which is the conservative direction (suppress,
+        bounded) rather than restart-storm, and it is self-limiting — the next
+        successful save rewrites the field as a real int.
+        """
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return 0
+        if value != value or value in (float("inf"), float("-inf")):  # NaN / inf
+            return 0
+        return max(0, int(value))
+
+    @staticmethod
+    def _coerce_epoch(value: Any) -> float | None:
+        """A persisted epoch/deadline as a float, or None for anything unusable.
+
+        ``next_attempt_after`` and ``last_restart_at`` are fed straight into
+        ``time.time() < x`` / ``time.time() - x``, which raise TypeError on a
+        string, a container or None-with-arithmetic. None is the field's own
+        "unset" value, so degrading to it is the correct failure mode: the
+        backoff/cooldown simply does not apply this cycle, and the next
+        decision writes a real timestamp.
+        """
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        if value != value or value in (float("inf"), float("-inf")):  # NaN / inf
+            return None
+        return float(value)
+
+    @classmethod
+    def _normalise_numeric_fields(cls, state: dict) -> dict:
+        """Coerce every numeric field at the ONE load boundary, in place.
+
+        Same rationale as ``_normalise_legacy_reasons`` above: state enters the
+        checker through a single path, so hardening here is what keeps each
+        individual reader from having to remember the guard (and keeps a future
+        reader from reintroducing the crash). ``_record_check`` then writes the
+        cleaned values back, so corruption does not survive a tick.
+
+        The set is derived from the readers, not guessed: every field that
+        ``check()``/``_restart_if_allowed`` index with ``state[...]`` or do
+        arithmetic on. ``consecutive_failures`` and ``next_attempt_after`` are
+        materialised UNCONDITIONALLY because three readers subscript them
+        directly (watchdog.py:561, :568-569, :883) and would raise KeyError on a
+        state file that merely omits them — MEASURED, not hypothesised.
+        """
+        for key in ("starved_skips", "bootstrap_grace_skips"):
+            if key in state:
+                state[key] = cls._coerce_counter(state[key])
+        state["consecutive_failures"] = cls._coerce_counter(
+            state.get("consecutive_failures"),
+        )
+        state["next_attempt_after"] = cls._coerce_epoch(state.get("next_attempt_after"))
+        if "last_restart_at" in state:
+            state["last_restart_at"] = cls._coerce_epoch(state["last_restart_at"])
+        return state
 
     @staticmethod
     def _normalise_legacy_reasons(state: dict) -> dict:
@@ -959,10 +1092,9 @@ class WatchdogChecker:
         # was attempted recently.  This prevents the counter from bouncing
         # back to 0 when a service briefly appears healthy right after
         # restart but crashes again within the cooldown window.
-        try:
-            state = json.loads(self._state_path.read_text())
-        except (json.JSONDecodeError, OSError):
-            state = {}
+        # Via the hardened loader (not a raw json.loads) so the arithmetic
+        # below cannot trip over a corrupt/foreign-typed last_restart_at.
+        state = self._load_state()
 
         last_restart_at = state.get("last_restart_at")
         if last_restart_at is not None:

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -278,25 +278,36 @@ class WatchdogChecker:
         if service_uptime is not None and service_uptime < self._staleness_threshold:
             state = self._load_state()
             skips = int(state.get("bootstrap_grace_skips", 0)) + 1
-            if skips <= self._max_bootstrap_grace_skips:
-                state["bootstrap_grace_skips"] = skips
-                self._save_state(state)
-                logger.info(
-                    "Status file stale (%.0fs) but %s started only %.0fs ago "
-                    "(< %ds threshold) — bootstrap grace %d/%d, skipping",
-                    staleness_s, self._target_service, service_uptime,
-                    self._staleness_threshold, skips,
-                    self._max_bootstrap_grace_skips,
+            if skips > self._max_bootstrap_grace_skips:
+                logger.error(
+                    "Bootstrap grace exhausted (%d skips): %s keeps presenting "
+                    "a young uptime without ever writing a fresh status file — "
+                    "likely a restart loop; no longer suppressing.",
+                    skips - 1, self._target_service,
                 )
-                return WatchdogAction.SKIP
-            logger.error(
-                "Bootstrap grace exhausted (%d skips): %s keeps presenting a "
-                "young uptime without ever writing a fresh status file — "
-                "likely a restart loop; no longer suppressing.",
-                skips - 1, self._target_service,
-            )
-            self._alert_grace_exhausted(service_uptime, skips - 1)
-            # fall through to the normal stale-restart path below
+                self._alert_grace_exhausted(service_uptime, skips - 1)
+                # fall through to the normal stale-restart path below
+            else:
+                state["bootstrap_grace_skips"] = skips
+                # A skip is granted only when its counter PERSISTED — an
+                # unwritable state file would otherwise reload the old count
+                # every invocation and re-grant the same slot forever
+                # (unbounded grace, the exact hole the counter closes).
+                if self._save_state(state):
+                    logger.info(
+                        "Status file stale (%.0fs) but %s started only %.0fs "
+                        "ago (< %ds threshold) — bootstrap grace %d/%d, "
+                        "skipping",
+                        staleness_s, self._target_service, service_uptime,
+                        self._staleness_threshold, skips,
+                        self._max_bootstrap_grace_skips,
+                    )
+                    return WatchdogAction.SKIP
+                logger.error(
+                    "Bootstrap grace NOT granted: skip counter could not be "
+                    "persisted — falling through to normal stale handling.",
+                )
+                # fall through to the normal stale-restart path below
 
         logger.warning(
             "Status file stale: %.0fs old (threshold %ds) — %s may be down",
@@ -404,18 +415,28 @@ class WatchdogChecker:
                 skips = int(state.get("starved_skips", 0)) + 1
                 if skips <= self._liveness_max_starved_skips:
                     state["starved_skips"] = skips
-                    self._save_state(state)
-                    self._alert_starved(reason, d, skips)
-                    logger.warning(
-                        "Liveness probe: server UP but event loop STARVED "
-                        "(lag %sms, sample %ss old, executor=%s) — suppressing "
-                        "'%s' restart (%d/%d); a restart would re-trigger the "
-                        "starvation. Alerting instead.",
-                        d.get("lag_ms", "?"), d.get("sample_age_s", "?"),
-                        d.get("executor"), reason, skips,
-                        self._liveness_max_starved_skips,
-                    )
-                    return WatchdogAction.SKIP
+                    if not self._save_state(state):
+                        # Same class as the bootstrap-grace persistence gate:
+                        # a suppression whose counter did not land is unbounded
+                        # on a box with a failing state write. Fall through to
+                        # the normal restart path instead of suppressing.
+                        logger.error(
+                            "Starved suppression NOT granted: skip counter "
+                            "could not be persisted — proceeding to normal "
+                            "restart logic.",
+                        )
+                    else:
+                        self._alert_starved(reason, d, skips)
+                        logger.warning(
+                            "Liveness probe: server UP but event loop STARVED "
+                            "(lag %sms, sample %ss old, executor=%s) — "
+                            "suppressing '%s' restart (%d/%d); a restart would "
+                            "re-trigger the starvation. Alerting instead.",
+                            d.get("lag_ms", "?"), d.get("sample_age_s", "?"),
+                            d.get("executor"), reason, skips,
+                            self._liveness_max_starved_skips,
+                        )
+                        return WatchdogAction.SKIP
                 # Past the suppression bound: stop suppressing and proceed to the
                 # restart path. Deliberately do NOT reset starved_skips here (that
                 # would re-enable suppression next cycle) — it stays pinned so we
@@ -732,12 +753,22 @@ class WatchdogChecker:
             state["last_reason"] = _LEGACY_REASONS[state["last_reason"]]
         return state
 
-    def _save_state(self, state: dict) -> None:
-        self._state_path.parent.mkdir(parents=True, exist_ok=True)
+    def _save_state(self, state: dict) -> bool:
+        """Persist state; True only when the write actually landed.
+
+        The return value is load-bearing for the bounded suppressions (bootstrap
+        grace, starved skips): a suppression whose counter did not persist is
+        unbounded on a box with a failing state write (disk-full, permissions —
+        each oneshot invocation would reload the old count and re-grant the same
+        slot forever), so callers grant a skip only on True.
+        """
         try:
+            self._state_path.parent.mkdir(parents=True, exist_ok=True)
             self._state_path.write_text(json.dumps(state))
+            return True
         except OSError:
             logger.error("Failed to save watchdog state to %s", self._state_path, exc_info=True)
+            return False
 
     def _record_failure(self, state: dict, *, reason: str) -> None:
         now = time.time()

--- a/src/genesis/autonomy/watchdog.py
+++ b/src/genesis/autonomy/watchdog.py
@@ -90,6 +90,7 @@ class WatchdogChecker:
         liveness_lag_suppress_ms: float = 1000.0,
         liveness_sample_stale_s: float = 120.0,
         liveness_max_starved_skips: int = 6,
+        max_bootstrap_grace_skips: int = 4,
         remediation_registry: RemediationRegistry | None = None,
         outreach_fn: OutreachFn | None = None,
     ) -> None:
@@ -111,6 +112,7 @@ class WatchdogChecker:
         self._liveness_lag_suppress_ms = liveness_lag_suppress_ms
         self._liveness_sample_stale_s = liveness_sample_stale_s
         self._liveness_max_starved_skips = liveness_max_starved_skips
+        self._max_bootstrap_grace_skips = max_bootstrap_grace_skips
         self._remediation_registry = remediation_registry
         self._outreach_fn = outreach_fn
         self._target_service = self._detect_target_service()
@@ -161,6 +163,7 @@ class WatchdogChecker:
                 liveness_lag_suppress_ms=wd.get("liveness_lag_suppress_ms", 1000.0),
                 liveness_sample_stale_s=wd.get("liveness_sample_stale_s", 120.0),
                 liveness_max_starved_skips=wd.get("liveness_max_starved_skips", 6),
+                max_bootstrap_grace_skips=wd.get("max_bootstrap_grace_skips", 4),
             )
         except (yaml.YAMLError, OSError, AttributeError):
             logger.warning("Failed to load watchdog config — using defaults", exc_info=True)
@@ -253,14 +256,81 @@ class WatchdogChecker:
             self._reset_state()
             return WatchdogAction.SKIP  # Healthy — no action needed
 
+        # 3. Bootstrap grace: a file stale from BEFORE the service started says
+        # nothing about THIS process — after an outage the status.json predates
+        # the boot, so raw staleness is guaranteed huge while the server is
+        # still mid-bootstrap (2026-09-08: 22,583s-stale file, server 49s into
+        # a ~2min bootstrap, SIGKILLed on both boots that day). Service start
+        # is the freshness epoch: until the unit's own uptime exceeds the
+        # staleness threshold, the file cannot yet be expected fresh. A wedged
+        # (still-active) server restarts once its uptime crosses the threshold.
+        # A RESTARTING server is the hole: ActiveEnter resets on every
+        # activation, so a crash-loop that stays `active` at tick time would
+        # renew the grace forever — which is why the grace is bounded by an
+        # explicit skip counter (like every other suppression in this file),
+        # not by uptime alone. The counter clears with the rest of the state
+        # when a genuinely fresh status file appears (_reset_state), so a
+        # healthy bootstrap spends at most one skip. A failed probe suppresses
+        # nothing. The zombie branch above needs no equivalent — it only runs
+        # on a FRESH file, whose uptime_s field it already checks against
+        # stabilization_s.
+        service_uptime = self._service_uptime_s()
+        if service_uptime is not None and service_uptime < self._staleness_threshold:
+            state = self._load_state()
+            skips = int(state.get("bootstrap_grace_skips", 0)) + 1
+            if skips <= self._max_bootstrap_grace_skips:
+                state["bootstrap_grace_skips"] = skips
+                self._save_state(state)
+                logger.info(
+                    "Status file stale (%.0fs) but %s started only %.0fs ago "
+                    "(< %ds threshold) — bootstrap grace %d/%d, skipping",
+                    staleness_s, self._target_service, service_uptime,
+                    self._staleness_threshold, skips,
+                    self._max_bootstrap_grace_skips,
+                )
+                return WatchdogAction.SKIP
+            logger.error(
+                "Bootstrap grace exhausted (%d skips): %s keeps presenting a "
+                "young uptime without ever writing a fresh status file — "
+                "likely a restart loop; no longer suppressing.",
+                skips - 1, self._target_service,
+            )
+            self._alert_grace_exhausted(service_uptime, skips - 1)
+            # fall through to the normal stale-restart path below
+
         logger.warning(
             "Status file stale: %.0fs old (threshold %ds) — %s may be down",
             staleness_s, self._staleness_threshold, self._target_service,
         )
 
-        # 3. Stale — attempt restart via shared logic
+        # 4. Stale — attempt restart via shared logic
         state = self._load_state()
         return self._restart_if_allowed(state, reason="stale_status_restart")
+
+    def _service_uptime_s(self) -> float | None:
+        """Seconds since the target unit entered active, or None if unknowable.
+
+        Reads systemd's MONOTONIC ActiveEnter timestamp so a wall-clock step
+        during boot (a containerized install's clock is stepped by the host
+        rather than disciplined by a local NTP daemon) cannot fake a large
+        uptime. Never raises: unit absent, systemd
+        unreachable, or unparsable output all return None, and the caller
+        falls through to the pre-existing restart path — the grace suppresses
+        only on a positive young reading.
+        """
+        try:
+            result = subprocess.run(
+                ["systemctl", "--user", "show", self._target_service,
+                 "--property=ActiveEnterTimestampMonotonic", "--value"],
+                capture_output=True, text=True, timeout=5, env=systemctl_env(),
+            )
+            raw = (result.stdout or "").strip()
+            if result.returncode != 0 or not raw.isdigit() or int(raw) == 0:
+                return None
+            uptime = time.clock_gettime(time.CLOCK_MONOTONIC) - int(raw) / 1e6
+            return uptime if uptime >= 0 else None
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError, ValueError):
+            return None
 
     def _network_suppresses_restart(self, status: dict) -> bool:
         """True ONLY when a FRESH sentinel probe reports degraded/offline.
@@ -792,6 +862,34 @@ class WatchdogChecker:
         if lag >= self._liveness_lag_suppress_ms:
             return "starved", loop_block
         return "responsive", loop_block
+
+    def _alert_grace_exhausted(self, service_uptime: float, skips: int) -> None:
+        """Surface ONE durable alert that the bootstrap grace ran out — the
+        target keeps presenting a young uptime without ever writing a fresh
+        status file, the signature of a restart loop. Same queue + dedupe
+        mechanism as ``_alert_starved``. Best-effort — never raises."""
+        try:
+            from genesis.env import alert_queue_root
+            from genesis.guardian.alert.queue import enqueue_alert
+
+            enqueue_alert(
+                alert_queue_root(),
+                severity="warning",
+                source="watchdog",
+                title="Watchdog bootstrap grace exhausted — possible restart loop",
+                body=(
+                    f"{self._target_service} has consumed all "
+                    f"{skips}/{self._max_bootstrap_grace_skips} bootstrap-grace "
+                    f"skips: its unit uptime keeps reading young "
+                    f"({service_uptime:.0f}s) while the status file stays stale, "
+                    "which means it keeps (re)starting without ever finishing "
+                    "bootstrap. The watchdog has resumed normal stale-restart "
+                    "handling. Check the service journal for the crash cause."
+                ),
+                dedupe_key="watchdog:bootstrap-grace-exhausted",
+            )
+        except Exception:
+            logger.debug("Failed to enqueue grace-exhausted alert", exc_info=True)
 
     def _alert_starved(self, reason: str, detail: dict, count: int) -> None:
         """Surface ONE durable alert that a restart was suppressed because the

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -276,6 +276,176 @@ class TestStaleBootstrapGrace:
         assert state.get("bootstrap_grace_skips", 0) == 0
 
 
+class TestZombieFileFromPreviousActivation:
+    """The zombie branch runs on a status file that is FRESH by timestamp, but a
+    restart landing inside the freshness window leaves the PREVIOUS process's
+    file in place: its `uptime_s` is that process's (status_writer stamps it from
+    the writing runtime's own `_bootstrap_completed_at`) and its scheduler
+    heartbeats describe a runtime that no longer exists. So the pre-existing
+    `uptime_s < stabilization_s` guard cannot fire, and the first tick after boot
+    would restart a healthy, still-bootstrapping server — the same defect the
+    stale branch's grace closes, reached through the fresh/zombie path instead
+    (Codex P2, PR #1858). The discriminator is systemd's own clock: a status file
+    OLDER than the unit's uptime was written before this activation.
+    """
+
+    def _retained_zombie(self, tmp_path: Path, *, age_s: float) -> Path:
+        """A status.json `age_s` old (inside the freshness window) whose
+        heartbeats are 30 min stale and whose uptime_s is far past
+        stabilization — i.e. reaches the zombie-restart decision on every
+        pre-existing guard."""
+        written = datetime.now(UTC) - timedelta(seconds=age_s)
+        stale_hb = datetime.now(UTC) - timedelta(minutes=30)
+        status_file = tmp_path / "status.json"
+        status_file.write_text(json.dumps({
+            "timestamp": written.isoformat(),
+            "uptime_s": 99999,  # the PREVIOUS process's uptime
+            "scheduler_heartbeats": {"surplus": stale_hb.isoformat()},
+        }))
+        return status_file
+
+    def test_path_assertions_hold(self, tmp_path: Path):
+        """Guard against a vacuous fixture: prove this status really does reach
+        the zombie decision (fresh by timestamp, zombie heartbeats, past
+        stabilization) before the tests below claim the grace is what stopped
+        the restart."""
+        status = self._retained_zombie(tmp_path, age_s=100)
+        checker = _make_checker(tmp_path, status)
+        data = json.loads(status.read_text())
+        staleness = WatchdogChecker._compute_staleness(data)
+        assert staleness is not None and staleness <= checker._staleness_threshold
+        assert WatchdogChecker._check_scheduler_heartbeats(data)  # zombie
+        assert data["uptime_s"] >= checker._stabilization_s  # stabilization guard cannot fire
+        # ...and with no systemd reading at all it restarts (the defect).
+        assert checker.check() is WatchdogAction.RESTART
+
+    def test_retained_file_predating_activation_grants_grace(self, tmp_path: Path):
+        status = self._retained_zombie(tmp_path, age_s=100)
+        checker = _make_checker(tmp_path, status)
+        # Unit came up 40s ago; the file is 100s old ⇒ written before this boot.
+        with patch.object(WatchdogChecker, "_service_uptime_s", return_value=40.0):
+            assert checker.check() is WatchdogAction.SKIP
+        # Prove the BOOTSTRAP GRACE is what suppressed it (not some other skip):
+        # the shared counter was consumed.
+        state = json.loads((tmp_path / "watchdog_state.json").read_text())
+        assert state["bootstrap_grace_skips"] == 1
+
+    def test_file_written_by_current_activation_still_restarts(self, tmp_path: Path):
+        # Control: unit up 500s, file only 100s old ⇒ THIS process wrote it, so
+        # its dead heartbeats are real. Grace must not suppress that.
+        status = self._retained_zombie(tmp_path, age_s=100)
+        checker = _make_checker(tmp_path, status)
+        with patch.object(WatchdogChecker, "_service_uptime_s", return_value=500.0):
+            assert checker.check() is WatchdogAction.RESTART
+        state = json.loads((tmp_path / "watchdog_state.json").read_text())
+        assert state.get("bootstrap_grace_skips", 0) == 0
+
+    def test_zombie_grace_shares_the_bootstrap_bound(self, tmp_path: Path):
+        # One counter for both branches: a crash loop must not get a fresh
+        # budget per branch. Four skips, then normal zombie-restart handling.
+        status = self._retained_zombie(tmp_path, age_s=100)
+        checker = _make_checker(tmp_path, status)
+        with patch.object(WatchdogChecker, "_service_uptime_s", return_value=40.0):
+            for _ in range(4):  # default max_bootstrap_grace_skips
+                assert checker.check() is WatchdogAction.SKIP
+            assert checker.check() is WatchdogAction.RESTART
+
+    def test_zombie_grace_requires_persisted_counter(self, tmp_path: Path):
+        status = self._retained_zombie(tmp_path, age_s=100)
+        checker = _make_checker(tmp_path, status)
+        with (
+            patch.object(WatchdogChecker, "_service_uptime_s", return_value=40.0),
+            patch.object(WatchdogChecker, "_save_state", return_value=False),
+        ):
+            assert checker.check() is WatchdogAction.RESTART
+
+
+class TestStateCounterSanitization:
+    """A persisted counter is arithmetic input (`_coerce_counter(x) + 1`,
+    `x += 1`), so a malformed value in watchdog_state.json — null, a string, a
+    container, a bool, a negative — must not take the oneshot down with
+    TypeError/ValueError/KeyError on every check (Codex P2, PR #1858).
+    Normalised at the ONE load boundary so no individual reader has to remember.
+    """
+
+    @pytest.mark.parametrize(
+        "bad", [None, "3", {}, [], True, False, -5, 2.7, float("nan")],
+    )
+    def test_malformed_grace_counter_does_not_crash_the_check(
+        self, tmp_path: Path, stale_status: Path, bad
+    ):
+        checker = _make_checker(tmp_path, stale_status)
+        state_file = tmp_path / "watchdog_state.json"
+        state_file.write_text(json.dumps(
+            {"consecutive_failures": 0, "bootstrap_grace_skips": bad},
+            allow_nan=True,
+        ))
+        with patch.object(WatchdogChecker, "_service_uptime_s", return_value=49.0):
+            assert checker.check() is WatchdogAction.SKIP
+        # 2.7 truncates to 2 → 3; everything else normalises to 0 → 1.
+        expected = 3 if bad == 2.7 else 1
+        assert json.loads(state_file.read_text())["bootstrap_grace_skips"] == expected
+
+    @pytest.mark.parametrize("bad", [None, "9", {}, True, -1])
+    def test_malformed_starved_counter_does_not_crash_the_check(
+        self, tmp_path: Path, stale_status: Path, bad
+    ):
+        # Same hazard on the other bounded suppression, reached via the
+        # liveness gate inside _restart_if_allowed.
+        checker = _liveness_checker(tmp_path, stale_status)
+        state_file = tmp_path / "watchdog_state.json"
+        state_file.write_text(json.dumps({"consecutive_failures": 0, "starved_skips": bad}))
+        with patch.object(
+            WatchdogChecker, "_probe_liveness",
+            return_value=("starved", {"lag_ms": 5000, "sample_age_s": 1}),
+        ):
+            assert checker.check() is WatchdogAction.SKIP
+        assert json.loads(state_file.read_text())["starved_skips"] == 1
+
+    @pytest.mark.parametrize("blob", ["[1, 2]", '"nope"', "5", "null"])
+    def test_non_object_state_falls_back_to_defaults(
+        self, tmp_path: Path, stale_status: Path, blob: str
+    ):
+        # Valid JSON that is not an object has no `.get`; every normaliser and
+        # reader below would raise AttributeError.
+        checker = _make_checker(tmp_path, stale_status)
+        (tmp_path / "watchdog_state.json").write_text(blob)
+        state = checker._load_state()
+        assert state["consecutive_failures"] == 0
+        assert state["restart_history"] == []
+        assert checker.check() is WatchdogAction.RESTART
+
+    def test_directly_subscripted_keys_are_materialised(
+        self, tmp_path: Path, stale_status: Path
+    ):
+        # Three readers subscript state directly rather than .get() —
+        # watchdog.py:561 and :568-569 in _restart_if_allowed, :883 in
+        # _record_failure — so a state file that merely OMITS these keys raises
+        # KeyError instead of returning an action. (Found by this test: the
+        # first draft normalised only consecutive_failures and the check died
+        # on `state["next_attempt_after"]`.)
+        checker = _make_checker(tmp_path, stale_status)
+        (tmp_path / "watchdog_state.json").write_text(json.dumps({"last_reason": "x"}))
+        state = checker._load_state()
+        assert state["consecutive_failures"] == 0
+        assert state["next_attempt_after"] is None
+        assert checker.check() is WatchdogAction.RESTART
+
+    @pytest.mark.parametrize("bad", ["soon", {}, [], True, float("inf")])
+    def test_malformed_backoff_deadline_does_not_crash_the_check(
+        self, tmp_path: Path, stale_status: Path, bad
+    ):
+        # `time.time() < state["next_attempt_after"]` raises TypeError on a
+        # string or a container. None is the field's own "unset" value, so the
+        # backoff simply does not apply and the next decision rewrites it.
+        checker = _make_checker(tmp_path, stale_status)
+        state_file = tmp_path / "watchdog_state.json"
+        state_file.write_text(json.dumps(
+            {"consecutive_failures": 0, "next_attempt_after": bad}, allow_nan=True,
+        ))
+        assert checker.check() is WatchdogAction.RESTART
+
+
 class TestServiceUptimeProbe:
     """Drive the REAL _service_uptime_s body (the autouse fixture stubs it for
     every other test, so nothing else executes the subprocess triage). Note the

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -230,6 +230,20 @@ class TestStaleBootstrapGrace:
         with patch.object(WatchdogChecker, "_service_uptime_s", return_value=None):
             assert checker.check() is WatchdogAction.RESTART
 
+    def test_unpersisted_counter_grants_no_grace(
+        self, tmp_path: Path, stale_status: Path
+    ):
+        # A grace whose counter did not persist is unbounded on a box with a
+        # failing state write — each oneshot invocation would reload the old
+        # count and re-grant the same slot forever (Codex P2, PR #1858). Deny
+        # the skip and fall through to the pre-existing restart path.
+        checker = _make_checker(tmp_path, stale_status)
+        with (
+            patch.object(WatchdogChecker, "_service_uptime_s", return_value=49.0),
+            patch.object(WatchdogChecker, "_save_state", return_value=False),
+        ):
+            assert checker.check() is WatchdogAction.RESTART
+
     def test_grace_is_bounded_by_skip_counter(
         self, tmp_path: Path, stale_status: Path
     ):
@@ -1336,6 +1350,22 @@ class TestLivenessRestartGate:
         assert state["starved_skips"] == 1
         # A suppressed cycle must NOT burn the restart/backoff counter.
         assert state.get("consecutive_failures", 0) == 0
+
+    def test_starved_suppression_requires_persisted_counter(self, tmp_path: Path):
+        # Same class as the bootstrap-grace persistence gate (Codex P2,
+        # PR #1858): a suppression whose counter did not land is unbounded on a
+        # box with a failing state write — fall through to restart instead.
+        c = self._stale(tmp_path)
+        payload = {"loop": {"lag_ms": 4200.0, "sample_age_s": 1.0, "lagging": True,
+                            "executor": {"pending": 30}}}
+        with (
+            patch("urllib.request.OpenerDirector.open", _opener_returning(200, payload)),
+            patch.object(c, "_alert_starved") as alert,
+            patch.object(WatchdogChecker, "_save_state", return_value=False),
+        ):
+            action = c.check()
+        assert action is WatchdogAction.RESTART
+        alert.assert_not_called()
 
     def test_starved_suppression_is_bounded(self, tmp_path: Path):
         c = self._stale(tmp_path)

--- a/tests/test_autonomy/test_watchdog.py
+++ b/tests/test_autonomy/test_watchdog.py
@@ -19,6 +19,10 @@ from genesis.autonomy.watchdog import (
     reclaim_page_cache,
 )
 
+# Captured at import time, BEFORE the autouse fixture stubs the class attribute,
+# so TestServiceUptimeProbe can drive the real body.
+_REAL_SERVICE_UPTIME_S = WatchdogChecker._service_uptime_s
+
 
 @pytest.fixture(autouse=True)
 def _mock_bridge_active():
@@ -39,6 +43,16 @@ def _no_deploy_in_progress():
     """
     with patch("genesis.autonomy.watchdog.update_in_progress", return_value=False):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _no_live_service_uptime(monkeypatch):
+    """Default the bootstrap-grace probe to 'unknown' so tests are insulated
+    from the REAL target unit's uptime on a dev box running genesis-server
+    (same pattern as _is_bridge_active above). None falls through to the
+    pre-grace restart path; the grace tests patch their own readings.
+    """
+    monkeypatch.setattr(WatchdogChecker, "_service_uptime_s", lambda self: None)
 
 
 @pytest.fixture(autouse=True)
@@ -164,6 +178,127 @@ class TestDeployInProgress:
         # guard adds zero behavior change outside a deploy window.
         checker = _make_checker(tmp_path, stale_status)
         assert checker.check() is WatchdogAction.RESTART
+
+
+class TestStaleBootstrapGrace:
+    """A status file stale from BEFORE the service started is not evidence about
+    THIS process (2026-09-08 incident: post-outage boot left a 22,583s-stale
+    status.json; the watchdog fired 49s into a ~2min bootstrap and SIGKILLed a
+    healthy server — once per boot, twice that day). Service start is treated as
+    the freshness epoch: while the unit's own uptime is below the staleness
+    threshold, the file cannot yet be expected fresh → SKIP. A genuinely wedged
+    server still restarts once its uptime exceeds the threshold, so the grace
+    cannot livelock; a failed probe suppresses nothing (pre-existing behavior).
+    """
+
+    def test_young_service_grace_skips_restart(
+        self, tmp_path: Path, stale_status: Path
+    ):
+        # The incident shape: stale file, service 49s old (< 300s threshold).
+        checker = _make_checker(tmp_path, stale_status)
+        with patch.object(WatchdogChecker, "_service_uptime_s", return_value=49.0):
+            assert checker.check() is WatchdogAction.SKIP
+
+    def test_grace_does_not_trip_failure_counter(
+        self, tmp_path: Path, stale_status: Path
+    ):
+        # SKIP returns BEFORE _restart_if_allowed, so backoff/flap counters
+        # never burn during bootstrap (same contract as the deploy guard).
+        checker = _make_checker(tmp_path, stale_status)
+        state_file = tmp_path / "watchdog_state.json"
+        state_file.write_text(json.dumps({
+            "consecutive_failures": 2, "next_attempt_after": None, "last_reason": "x",
+        }))
+        with patch.object(WatchdogChecker, "_service_uptime_s", return_value=49.0):
+            checker.check()
+        state = json.loads(state_file.read_text())
+        assert state["consecutive_failures"] == 2
+
+    def test_old_service_still_restarts(self, tmp_path: Path, stale_status: Path):
+        # Control (anti-livelock): a service up longer than the threshold with a
+        # still-stale file is genuinely wedged — grace must not suppress that.
+        checker = _make_checker(tmp_path, stale_status)
+        with patch.object(WatchdogChecker, "_service_uptime_s", return_value=301.0):
+            assert checker.check() is WatchdogAction.RESTART
+
+    def test_unknown_uptime_falls_through_to_restart(
+        self, tmp_path: Path, stale_status: Path
+    ):
+        # Probe failure (unit absent, no systemd) preserves pre-grace behavior:
+        # suppression requires a POSITIVE young reading.
+        checker = _make_checker(tmp_path, stale_status)
+        with patch.object(WatchdogChecker, "_service_uptime_s", return_value=None):
+            assert checker.check() is WatchdogAction.RESTART
+
+    def test_grace_is_bounded_by_skip_counter(
+        self, tmp_path: Path, stale_status: Path
+    ):
+        # ActiveEnter resets on every activation, so a crash-loop that stays
+        # `active` at tick time presents a young uptime FOREVER. The explicit
+        # counter is what keeps that from renewing the grace indefinitely:
+        # max skips, then normal stale-restart handling resumes.
+        checker = _make_checker(tmp_path, stale_status)
+        with patch.object(WatchdogChecker, "_service_uptime_s", return_value=49.0):
+            for _ in range(4):  # default max_bootstrap_grace_skips
+                assert checker.check() is WatchdogAction.SKIP
+            assert checker.check() is WatchdogAction.RESTART
+
+    def test_grace_counter_clears_on_fresh_status(
+        self, tmp_path: Path, stale_status: Path
+    ):
+        # A genuinely fresh status file (bootstrap finished) resets the whole
+        # state including the grace counter, so the NEXT outage gets a full
+        # grace budget rather than inheriting spent skips.
+        checker = _make_checker(tmp_path, stale_status)
+        state_file = tmp_path / "watchdog_state.json"
+        state_file.write_text(json.dumps({"bootstrap_grace_skips": 3}))
+        stale_status.write_text(json.dumps({
+            "timestamp": datetime.now(UTC).isoformat(),
+            "resilience_state": {"cloud": "NORMAL"},
+            "human_summary": "All systems normal.",
+        }))
+        assert checker.check() is WatchdogAction.SKIP  # healthy
+        state = json.loads(state_file.read_text())
+        assert state.get("bootstrap_grace_skips", 0) == 0
+
+
+class TestServiceUptimeProbe:
+    """Drive the REAL _service_uptime_s body (the autouse fixture stubs it for
+    every other test, so nothing else executes the subprocess triage). Note the
+    subtlety pinned here: `systemctl show <nonexistent> --value` exits 0 with
+    output "0" (measured), so the `int(raw) == 0` clause — not the returncode
+    check — is the guard that actually rejects a never-activated unit.
+    """
+
+    def _real_uptime(self, checker: WatchdogChecker) -> float | None:
+        return _REAL_SERVICE_UPTIME_S(checker)
+
+    def test_parses_monotonic_active_enter(self, tmp_path: Path, stale_status: Path):
+        checker = _make_checker(tmp_path, stale_status)
+        started = time.clock_gettime(time.CLOCK_MONOTONIC) - 42.0
+        fake = MagicMock(returncode=0, stdout=f"{int(started * 1e6)}\n")
+        with patch("genesis.autonomy.watchdog.subprocess.run", return_value=fake):
+            uptime = self._real_uptime(checker)
+        assert uptime is not None and 41.0 < uptime < 43.0
+
+    @pytest.mark.parametrize(
+        "stdout", ["0\n", "", "  \n", "not-a-number", "[not set]", "-5", "²"],
+    )
+    def test_unparsable_or_never_activated_is_none(
+        self, tmp_path: Path, stale_status: Path, stdout: str
+    ):
+        checker = _make_checker(tmp_path, stale_status)
+        fake = MagicMock(returncode=0, stdout=stdout)
+        with patch("genesis.autonomy.watchdog.subprocess.run", return_value=fake):
+            assert self._real_uptime(checker) is None
+
+    def test_subprocess_failure_is_none(self, tmp_path: Path, stale_status: Path):
+        checker = _make_checker(tmp_path, stale_status)
+        with patch(
+            "genesis.autonomy.watchdog.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("systemctl", 5),
+        ):
+            assert self._real_uptime(checker) is None
 
 
 class TestFlapDamping:


### PR DESCRIPTION
## Problem

After any outage longer than the staleness threshold, `status.json` predates the boot, so the stale-status branch reads a huge staleness while genesis-server is still mid-bootstrap. Measured on a live install (2026-09-08, post-power-outage): a 22,583s-stale file, watchdog fired 60s after boot (`OnBootSec=60`), concluded the server was down 49s into a ~2min bootstrap, and SIGTERM→SIGKILL-restarted it — once per boot, twice that day. An independent host-side diagnosis flagged the same defect as a latent livelock (bootstrap slower than the 300s tick ⇒ restart forever). The zombie branch, the guardian (`bootstrap_grace_s: 300`) and the sentinel (240) all carry an equivalent guard; the stale branch alone had none.

## Fix

Treat service start as the freshness epoch: the stale branch probes the target unit's own uptime via systemd's **monotonic** ActiveEnter timestamp (`CLOCK_MONOTONIC` comparison — wall-clock steps during boot can't fake it, and `/proc/uptime` is lxcfs-adrift in containers) and skips while the unit is younger than the staleness threshold.

The grace is **bounded by an explicit skip counter** (`max_bootstrap_grace_skips`, default 4): ActiveEnter resets on every activation, so an uptime-only grace would renew forever under a crash loop that stays `active` at tick time (measured: the timestamp advances across a restart). Exhaustion logs an ERROR, enqueues a durable alert (same queue/dedupe as the starved-liveness alert), and resumes normal stale-restart handling. The counter clears with the rest of the state when a genuinely fresh status file appears, so a healthy bootstrap spends at most one skip. A failed probe suppresses nothing — grace requires a positive young reading.

Reviewed tradeoff, accepted: during a grace window the starved_skips reset isn't reached, and time-to-NOTIFY after repeated failed restarts grows ~3x at prod cadence (900s threshold × 300s tick).

## Tests

11 new: grace-skip on the incident shape (49s uptime), failure-counter untouched, anti-livelock control (uptime > threshold still restarts), probe-failure fall-through, counter bound (mutation-verified RED on cap removal), counter reset on fresh status, and the real `_service_uptime_s` body (monotonic parse; `systemctl show` on a nonexistent unit exits 0 with "0", so the parametrized triage pins `int(raw)==0` as the operative guard; timeout → None). Autouse fixture insulates the other 107 tests from live-unit state.

E2E: after merge + deploy, reboot-shaped verification — restart genesis-server, confirm the first post-restart watchdog tick logs "bootstrap grace 1/4" instead of restarting, and a fresh status file clears the counter.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Watchdog no longer restarts a service prematurely when its status appears stale immediately after startup.
  * A bounded startup grace period allows the service time to publish fresh status information.
  * Grace attempts persist across checks and reset once fresh status is detected.
  * If the grace period is exhausted, the watchdog raises a durable alert and resumes normal stale-status recovery.

* **Configuration**
  * Added an option to control the maximum number of startup grace checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->