### PR TITLE
feat(ci): fresh-machine install test on a clean GitHub runner

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,96 @@
+name: Install Test
+
+# Fresh-machine install verification. Replaces the retired EC2 install-test
+# harness (removed in #623): a clean GitHub-hosted runner clones the repo and
+# runs the public installer end-to-end, so the PR that breaks a fresh install
+# fails here instead of on a user's machine weeks later.
+#
+# Coverage notes: GitHub-hosted runners are full Ubuntu VMs (systemd present),
+# so this exercises the real install path. Not covered: arbitrary cloud images
+# and the LXC/Incus container-install variant — run a manual VM install before
+# a release when those matter.
+#
+# Do NOT add this workflow to required status checks: it is path-filtered, so
+# PRs touching none of the filtered paths report no status and would wait on
+# "Expected" forever.
+
+on:
+  pull_request:
+    branches: [main]
+    # The filter mirrors what install.sh actually CONSUMES (sourced libs,
+    # rendered templates, seed files, the dependency set) — not what merely
+    # sounds install-related. Derived by enumerating install.sh's inputs.
+    paths:
+      - "scripts/install.sh"
+      - "scripts/lib/**"
+      - "scripts/systemd/**"
+      - "scripts/hooks/pre-commit"
+      - "scripts/hooks/pre-push"
+      - "config/mcp.json.template"
+      - "config/genesis-tmp-watchgod.service"
+      - "pyproject.toml"
+      - "secrets.env.example"
+      - "src/genesis/identity/*.example"
+      - ".claude/mcp/run-codebase-memory"
+      - ".github/workflows/install-test.yml"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * 1"  # weekly Mon 07:00 UTC — catch drift even without install-path commits
+
+concurrency:
+  group: install-test-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  fresh-install:
+    runs-on: ubuntu-latest
+    # A healthy full install measures in the tens of minutes (apt + Node +
+    # Qdrant + venv + Claude Code). The failure mode bounded here is a hung
+    # network fetch or apt lock burning the 6h default job budget on a weekly
+    # schedule; 60 min is ~2-3x a healthy run.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Provision a user systemd session
+        # Hosted runners execute steps via a system unit with no logind session
+        # and no XDG_RUNTIME_DIR, so `systemctl --user` cannot reach a user bus
+        # — and Qdrant's only start path in install.sh is a user unit. Linger
+        # gives the runner user a manager; the final line makes "still no user
+        # bus" a legible failure of THIS step instead of an unexplained Qdrant
+        # timeout deep in the install log. No-op where a manager already runs.
+        run: |
+          set -euo pipefail
+          sudo loginctl enable-linger "$USER"
+          echo "XDG_RUNTIME_DIR=/run/user/$(id -u)" >> "$GITHUB_ENV"
+          echo "DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$(id -u)/bus" >> "$GITHUB_ENV"
+          export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+          for _ in $(seq 1 20); do
+            systemctl --user is-system-running >/dev/null 2>&1 && break
+            sleep 1
+          done
+          systemctl --user show-environment >/dev/null
+
+      - name: Run installer (non-interactive, strict)
+        env:
+          GENESIS_INSTALL_STRICT: "1"
+        run: ./scripts/install.sh --non-interactive
+
+      - name: Verify install outcome
+        run: |
+          set -euo pipefail
+          # Deliberately NOT a re-run of the installer's own smoke test (that
+          # already gates via strict mode): assert artifacts the installer only
+          # WARNs about, plus rendered-template integrity it never checks.
+          test -f ~/.config/systemd/user/genesis-server.service
+          grep -q "$PWD" ~/.config/systemd/user/genesis-server.service
+          ! grep -q '__[A-Z_]*__' ~/.config/systemd/user/genesis-server.service
+          test -f .mcp.json
+          ! grep -q '{{' .mcp.json
+          command -v claude
+          . scripts/lib/cc_version.sh
+          claude --version | grep -q "$CC_VERSION"
+          .venv/bin/python -c "import genesis, sys; print(genesis.__file__)"

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -33,12 +33,23 @@ on:
       - "src/genesis/identity/*.example"
       - ".claude/mcp/run-codebase-memory"
       - ".github/workflows/install-test.yml"
+      # The installer installs the source tree and imports GenesisRuntime
+      # (scripts/lib/venv_setup.sh), and treats .claude/settings.json as a
+      # smoke-test requirement — so both are genuine inputs. The first filter
+      # omitted them, which meant a PR could break a clean install without ever
+      # running this check. Including src/genesis/** makes this run on most PRs;
+      # that is the honest cost of the claim, and the job is a few minutes.
+      - "src/genesis/**"
+      - ".claude/settings.json"
   workflow_dispatch:
   schedule:
     - cron: "0 7 * * 1"  # weekly Mon 07:00 UTC — catch drift even without install-path commits
 
 concurrency:
-  group: install-test-${{ github.head_ref || github.ref }}
+  # Key on the PR NUMBER, not the branch name. Two forked PRs whose source
+  # branches share a name — `main` is the common case — collide on head_ref, so
+  # one contributor's push would cancel another contributor's unrelated run.
+  group: install-test-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
@@ -87,9 +98,43 @@ jobs:
           # WARNs about, plus rendered-template integrity it never checks.
           test -f ~/.config/systemd/user/genesis-server.service
           grep -q "$PWD" ~/.config/systemd/user/genesis-server.service
-          ! grep -q '__[A-Z_]*__' ~/.config/systemd/user/genesis-server.service
+
+          # The primary service must be RUNNING, not merely rendered. A unit with a
+          # bad ExecStart or a missing runtime dep renders fine and fails to start;
+          # asserting the file exists cannot tell those apart, which is a green
+          # install test over a dead server.
+          systemctl --user is-active --quiet genesis-server
+
+          # EVERY rendered unit, not just genesis-server. The installer renders all
+          # templates through one loop, so a placeholder introduced in any other
+          # template shipped a broken unit that a genesis-server-only check
+          # accepted — which is exactly how agent-zero.service went out with a
+          # literal __AZ_ROOT__ (fixed in this PR).
+          for _unit in ~/.config/systemd/user/genesis-*.service \
+                       ~/.config/systemd/user/genesis-*.timer \
+                       ~/.config/systemd/user/agent-zero.service \
+                       ~/.config/systemd/user/qdrant.service; do
+            [ -f "$_unit" ] || continue
+            if grep -q '__[A-Z_]*__' "$_unit"; then
+              echo "::error::unsubstituted placeholder in $_unit:"
+              grep -n '__[A-Z_]*__' "$_unit"
+              exit 1
+            fi
+          done
+
+          # The user-facing artifacts that hardcoded ~/genesis until this PR: both
+          # must point at where the repo ACTUALLY is, or they are installed dead on
+          # any clone that is not at ~/genesis.
+          grep -qF "$PWD" /usr/local/bin/genesis
+          grep -qF "$PWD" ~/.bashrc
+
           test -f .mcp.json
           ! grep -q '{{' .mcp.json
+          # PARSE it. Placeholder-free is not the same as valid: a trailing comma
+          # in the template renders clean and Claude Code then rejects the file,
+          # leaving every MCP server unavailable behind a green install.
+          python3 -c "import json,sys; json.load(open('.mcp.json'))"
+
           command -v claude
           . scripts/lib/cc_version.sh
           claude --version | grep -q "$CC_VERSION"

--- a/changelog.d/20260909233000-fixed-fresh-install-defects.md
+++ b/changelog.d/20260909233000-fixed-fresh-install-defects.md
@@ -1,0 +1,16 @@
+- **Four things that only broke on a genuinely fresh machine are fixed, found by
+  the new fresh-install check on its very first run.** A clean install of Qdrant
+  reported a setup warning anyway and printed "Genesis REQUIRES Qdrant" directly
+  under the line saying it had just installed it. The `genesis` command and the
+  auto-cd on login both assumed the repo lives at one specific path, so on any
+  other clone location the command was installed already broken. One service unit
+  shipped with a placeholder where a directory should be, which systemd rejects.
+  And a server that failed to start printed a warning and carried on as though
+  the install had succeeded. None of these are visible on a machine that already
+  has Genesis running, which is why twelve weeks of installer changes went by
+  without anyone noticing them.
+- **A failed setup now says what went wrong.** The installer tracked warnings as
+  a single yes/no flag set from eight different places, several of which print no
+  warning text at all — so "setup completed with warnings" meant scrolling back
+  through hundreds of lines to guess which one fired. Each warning now records its
+  own reason, and both the summary and the strict-mode failure list them.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -799,7 +799,12 @@ if ! grep -q '# Auto-cd to Genesis project on login' "$HOME/.bashrc" 2>/dev/null
     # $REPO_DIR, not a hardcoded ~/genesis: the installer already knows where it
     # was cloned, and a clone anywhere else got a login hook pointing at a
     # directory that does not exist.
-    echo "[ -d '$REPO_DIR' ] && cd '$REPO_DIR'" >> "$HOME/.bashrc"
+    #
+    # printf %q, not fixed single quotes: a path containing an apostrophe would
+    # END the quoted string early, and the line would silently target a DIFFERENT
+    # directory (or fail to parse) with nothing to indicate it. %q produces a
+    # form the shell re-reads as exactly this path, whatever is in it.
+    echo "[ -d $(printf '%q' "$REPO_DIR") ] && cd $(printf '%q' "$REPO_DIR")" >> "$HOME/.bashrc"
     echo "    + Auto-cd to $REPO_DIR on login"
 fi
 
@@ -935,11 +940,25 @@ if [ -d "$SYSTEMD_TEMPLATE_DIR" ]; then
             # placeholder where an absolute path belongs — systemd rejects it, and
             # nothing noticed because install.sh never enables agent-zero. Default
             # matches scripts/vendor_assets.sh's own AZ_ROOT default.
+            #
+            # AZ_ROOT is operator-CONFIGURABLE, so it is escaped for use as a sed
+            # REPLACEMENT before substitution. An unescaped `&` means "the whole
+            # matched text" to sed, so AZ_ROOT=/tmp/R&D would render
+            # `WorkingDirectory=/tmp/R__AZ_ROOT__D`; a `|` is the delimiter here
+            # and makes sed reject the expression outright, aborting the install
+            # under `set -e`. The other four values are installer-derived paths,
+            # not user input, but escaping only the configurable one is the point:
+            # it is the only one an operator can put a metacharacter into.
+            # Replacement is `\\&` in the sed script: `\\` is a literal backslash
+            # and `&` the matched char, so each metacharacter gets exactly ONE
+            # backslash. `\\\\&` would emit TWO, leaving `&` still meaning "the
+            # whole match" — verified by hand, since it looks correct and is not.
+            _az_root_esc=$(printf '%s' "${AZ_ROOT:-$HOME/agent-zero}" | sed -e 's/[\\&|]/\\&/g')
             sed -e "s|__HOME__|$HOME|g" \
                 -e "s|__VENV__|$VENV_PATH|g" \
                 -e "s|__REPO_DIR__|$REPO_DIR|g" \
                 -e "s|__CC_BIN_DIR__|$CC_BIN_DIR|g" \
-                -e "s|__AZ_ROOT__|${AZ_ROOT:-$HOME/agent-zero}|g" \
+                -e "s|__AZ_ROOT__|$_az_root_esc|g" \
                 "$template" > "$target"
             echo "    + $svc_name generated"
             SERVICES_GENERATED=1
@@ -1363,9 +1382,15 @@ if [ ! -f /usr/local/bin/genesis ]; then
     # quoted form hardcoded ~/genesis, so on any clone elsewhere the `genesis`
     # command was installed dead and every assertion about it still passed.
     # "$@" is escaped so it survives to the generated script.
+    # printf %q, not fixed single quotes: an apostrophe in the path would end the
+    # quoted string early, so the GENERATED script would not even parse
+    # (`bash -n` fails on it) — and the failure would only show up the first time
+    # someone typed `genesis`. %q emits a form the shell re-reads as exactly this
+    # path. The message keeps the raw path, since it is prose, not code.
+    _repo_q="$(printf '%q' "$REPO_DIR")"
     sudo tee /usr/local/bin/genesis >/dev/null <<WRAPPER
 #!/bin/bash
-cd '$REPO_DIR' 2>/dev/null || { echo "Genesis repo not found at $REPO_DIR"; exit 1; }
+cd $_repo_q 2>/dev/null || { echo "Genesis repo not found at $REPO_DIR"; exit 1; }
 exec claude "\$@"
 WRAPPER
     sudo chmod +x /usr/local/bin/genesis

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,6 +25,7 @@
 #   GH_VERSION             — gh CLI version if pkg-mgr fails (default: 2.65.0)
 #   RIPGREP_VERSION        — ripgrep version if pkg-mgr fails (default: 14.1.1)
 #   NODE_MAJOR             — Node.js major version (default: 20)
+#   GENESIS_INSTALL_STRICT — exit nonzero on any smoke failure/setup warning (default: 0; used by CI)
 
 set -euo pipefail
 
@@ -1701,3 +1702,15 @@ if ! echo "$_os_name" | grep -qi 'ubuntu 24'; then
     echo "  Report issues: https://github.com/WingedGuardian/GENesis-AGI/issues"
 fi
 echo ""
+
+# Strict mode for CI (the install-test workflow): any smoke-test failure OR
+# setup warning must fail the run — SETUP_WARNINGS is where real breakage in
+# the Claude Code / venv / port-conflict paths lands (they only WARN for
+# humans, and a fresh-install test that greens through a broken CC install is
+# a false green). Kept off for humans — a partial install with a readable
+# summary beats a nonzero exit mid-setup.
+if [ "${GENESIS_INSTALL_STRICT:-0}" = "1" ] \
+   && { [ "${SMOKE_FAIL:-0}" -gt 0 ] || [ "${SETUP_WARNINGS:-0}" = "1" ]; }; then
+    echo "  STRICT: smoke failures=${SMOKE_FAIL:-0}, SETUP_WARNINGS=${SETUP_WARNINGS:-0} — exiting nonzero." >&2
+    exit 1
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -127,6 +127,19 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 VENV_PATH="${VENV_PATH:-$REPO_DIR/.venv}"
 SECRETS_FILE="${SECRETS_PATH:-$REPO_DIR/secrets.env}"
 SETUP_WARNINGS=0
+# Every setter of SETUP_WARNINGS goes through setup_warn, so the flag can name
+# its own causes. The flag alone made a strict-mode failure undiagnosable: the
+# exit line said only "SETUP_WARNINGS=1" while eight separate sites can set it,
+# several of which print no "WARNING:" text at all — so identifying the cause
+# meant grepping the script for setters and cross-reading a 900-line CI log.
+# A newline-joined string rather than an array: nothing else in this script uses
+# arrays, and an empty-array expansion under `set -u` is a bash-version trap.
+SETUP_WARNING_LOG=""
+setup_warn() {
+    SETUP_WARNINGS=1
+    SETUP_WARNING_LOG="${SETUP_WARNING_LOG}${SETUP_WARNING_LOG:+
+}    • $1"
+}
 TOTAL_STEPS=14
 
 echo ""
@@ -689,7 +702,7 @@ if [ ! -d "$VENV_PATH" ] || [ ! -x "$VENV_PATH/bin/python" ] || [ ! -x "$VENV_PA
     if ! "$VENV_PATH/bin/python" -c "import sys; sys.exit(0 if sys.version_info >= (3, 12) else 1)" 2>/dev/null; then
         echo "    WARNING: venv Python is $_venv_pyver but Genesis requires 3.12+"
         echo "    Install Python 3.12 and re-run this script."
-        SETUP_WARNINGS=1
+        setup_warn "venv Python is $_venv_pyver but Genesis requires 3.12+"
     fi
 fi
 
@@ -776,11 +789,18 @@ echo "    + CC temp: ${CC_TMP_DIR} (budget: 500MB, sacred: 150MB)"
 
 # Auto-cd to genesis on login so Claude Code finds the project (slash
 # commands, hooks, .claude/settings.json all depend on cwd = project root)
-if ! grep -q 'cd ~/genesis' "$HOME/.bashrc" 2>/dev/null; then
+# Guard on the comment, not on the path: the written line now carries the ACTUAL
+# repo directory, so a path-based guard would append a duplicate on every re-run
+# of an install that lives anywhere but ~/genesis. The comment is also what
+# existing installs already have, so this stays idempotent for them.
+if ! grep -q '# Auto-cd to Genesis project on login' "$HOME/.bashrc" 2>/dev/null; then
     echo '' >> "$HOME/.bashrc"
     echo '# Auto-cd to Genesis project on login' >> "$HOME/.bashrc"
-    echo '[ -d ~/genesis ] && cd ~/genesis' >> "$HOME/.bashrc"
-    echo "    + Auto-cd to ~/genesis on login"
+    # $REPO_DIR, not a hardcoded ~/genesis: the installer already knows where it
+    # was cloned, and a clone anywhere else got a login hook pointing at a
+    # directory that does not exist.
+    echo "[ -d '$REPO_DIR' ] && cd '$REPO_DIR'" >> "$HOME/.bashrc"
+    echo "    + Auto-cd to $REPO_DIR on login"
 fi
 
 # Enable Genesis CC hooks on first launch. Without this flag,
@@ -836,7 +856,7 @@ if [ -d "$VENV_PATH" ]; then
         *)
             echo "    FAIL  pip install completed but Genesis is not importable."
             echo "    Re-run with verbose output: $VENV_PATH/bin/pip install -e $REPO_DIR --verbose"
-            SETUP_WARNINGS=1
+            setup_warn "Genesis is not importable after the editable install step"
             ;;
     esac
 else
@@ -859,7 +879,7 @@ if [ -f "$_cc_env" ]; then
     unset CC_SUPPRESSION_STATE
     if ! cc_ensure_local; then
         echo "    (will finalize at step 12; manual: npm install -g @anthropic-ai/claude-code@${CC_VERSION})"
-        SETUP_WARNINGS=1
+        setup_warn "Claude Code could not be installed/aligned before service generation"
     fi
     # cc_ensure_local's return code carries only the VERSION outcome; suppression
     # travels on CC_SUPPRESSION_STATE and used to be dropped here entirely. A
@@ -910,10 +930,16 @@ if [ -d "$SYSTEMD_TEMPLATE_DIR" ]; then
         if [ -f "$target" ]; then
             echo "    . $svc_name already exists (not overwriting)"
         else
+            # __AZ_ROOT__ (agent-zero.service.template's WorkingDirectory) was
+            # absent from this list, so that unit shipped with a literal
+            # placeholder where an absolute path belongs — systemd rejects it, and
+            # nothing noticed because install.sh never enables agent-zero. Default
+            # matches scripts/vendor_assets.sh's own AZ_ROOT default.
             sed -e "s|__HOME__|$HOME|g" \
                 -e "s|__VENV__|$VENV_PATH|g" \
                 -e "s|__REPO_DIR__|$REPO_DIR|g" \
                 -e "s|__CC_BIN_DIR__|$CC_BIN_DIR|g" \
+                -e "s|__AZ_ROOT__|${AZ_ROOT:-$HOME/agent-zero}|g" \
                 "$template" > "$target"
             echo "    + $svc_name generated"
             SERVICES_GENERATED=1
@@ -1002,15 +1028,16 @@ if curl -sf "$QDRANT_URL/collections" >/dev/null 2>&1; then
     if [ "$qdrant_ver" = "unknown" ]; then
         echo "    WARNING: Port 6333 responds but doesn't look like Qdrant"
         echo "    Another service may be using this port."
-        SETUP_WARNINGS=1
+        setup_warn "port 6333 responds but does not look like Qdrant (another service?)"
     else
         echo "    . Qdrant reachable at $QDRANT_URL (v${qdrant_ver})"
     fi
 elif command -v qdrant &>/dev/null; then
     echo "    . Qdrant binary found but not running"
-    SETUP_WARNINGS=1
+    setup_warn "Qdrant binary is present but not running"
 else
     echo "    Qdrant not found — attempting install (v${QDRANT_VERSION})..."
+    _qdrant_installed=0
     _qdrant_arch="x86_64"
     [ "$(uname -m)" = "aarch64" ] && _qdrant_arch="aarch64"
     _qdrant_url="https://github.com/qdrant/qdrant/releases/download/v${QDRANT_VERSION}/qdrant-${_qdrant_arch}-unknown-linux-musl.tar.gz"
@@ -1025,6 +1052,7 @@ else
                 export PATH="$HOME/.local/bin:$PATH"
                 echo "    + Qdrant ${QDRANT_VERSION} installed to ~/.local/bin/"
             fi
+            _qdrant_installed=1
             rm -f /tmp/qdrant.tar.gz
             # Create data dir and config
             mkdir -p "$HOME/.qdrant/storage"
@@ -1049,8 +1077,18 @@ QDCONF
     else
         echo "    WARNING: Could not download Qdrant from $_qdrant_url"
     fi
-    echo "    Genesis REQUIRES Qdrant for vector storage."
-    SETUP_WARNINGS=1
+    # Only a FAILED install warns. This used to warn unconditionally at the end
+    # of the branch, so a perfectly successful install printed "+ Qdrant
+    # installed" and then "Genesis REQUIRES Qdrant" — advice contradicting the
+    # line above it — and left SETUP_WARNINGS set. Invisible on every developer
+    # box, because a box that already has Qdrant takes the first branch and never
+    # reaches here; only a genuinely fresh machine does, which is why 12 weeks of
+    # installer changes went by without anyone seeing it. Found by the first run
+    # of the fresh-install CI check this PR adds.
+    if [ "$_qdrant_installed" != "1" ]; then
+        echo "    Genesis REQUIRES Qdrant for vector storage."
+        setup_warn "Qdrant install failed — Genesis requires it for vector storage"
+    fi
 fi
 
 # Ollama (optional)
@@ -1224,9 +1262,17 @@ if [ -f "$SYSTEMD_USER_DIR/genesis-server.service" ]; then
     systemctl --user enable genesis-server 2>/dev/null && \
         echo "    + genesis-server.service enabled" || true
     if ! systemctl --user is-active --quiet genesis-server 2>/dev/null; then
-        systemctl --user start genesis-server 2>/dev/null && \
-            echo "    + genesis-server started" || \
+        if systemctl --user start genesis-server 2>/dev/null; then
+            echo "    + genesis-server started"
+        else
+            # A dead primary service is the definition of a broken install, and
+            # this used to print and move on without touching either strict-mode
+            # counter — so a fresh-install check could pass with the server
+            # stopped, which is a false green of exactly the kind the check
+            # exists to prevent.
             echo "    WARNING: could not start genesis-server"
+            setup_warn "genesis-server did not start (journalctl --user -u genesis-server)"
+        fi
     fi
 fi
 
@@ -1306,17 +1352,21 @@ echo "  [12/$TOTAL_STEPS] Setting up Claude Code (v${CC_VERSION})..."
 unset CC_SUPPRESSION_STATE
 if ! cc_ensure_local; then
     echo "    Install manually: npm install -g @anthropic-ai/claude-code@${CC_VERSION}"
-    SETUP_WARNINGS=1
+    setup_warn "Claude Code could not be installed/aligned to the pin"
 fi
 cc_shadow_scan || true
 
 # Genesis wrapper — lets users type 'genesis' from anywhere inside the container
 # to launch Claude Code in the right directory with all hooks/MCP active.
 if [ ! -f /usr/local/bin/genesis ]; then
-    sudo tee /usr/local/bin/genesis >/dev/null <<'WRAPPER'
+    # Unquoted heredoc so $REPO_DIR is baked in at install time — the previous
+    # quoted form hardcoded ~/genesis, so on any clone elsewhere the `genesis`
+    # command was installed dead and every assertion about it still passed.
+    # "$@" is escaped so it survives to the generated script.
+    sudo tee /usr/local/bin/genesis >/dev/null <<WRAPPER
 #!/bin/bash
-cd ~/genesis 2>/dev/null || { echo "Genesis repo not found at ~/genesis"; exit 1; }
-exec claude "$@"
+cd '$REPO_DIR' 2>/dev/null || { echo "Genesis repo not found at $REPO_DIR"; exit 1; }
+exec claude "\$@"
 WRAPPER
     sudo chmod +x /usr/local/bin/genesis
     echo "    + genesis command installed (/usr/local/bin/genesis)"
@@ -1366,7 +1416,7 @@ else
     echo "    WARNING: Could not write CC settings in $_settings_file"
     echo "    Add manually:  {\"env\": {\"DISABLE_AUTOUPDATER\": \"1\", \"DISABLE_UPDATES\": \"1\","
     echo "                            \"CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH\": \"2\"}}"
-    SETUP_WARNINGS=1
+    setup_warn "could not write Claude Code settings in $_settings_file"
 fi
 
 # Login guidance (interactive only)
@@ -1657,7 +1707,11 @@ echo "  ────────────────────────
 if [ "$SMOKE_FAIL" -gt 0 ]; then
     echo "  Setup complete (with failures — see above)."
 elif [ "${SETUP_WARNINGS:-0}" = "1" ]; then
-    echo "  Setup complete (with warnings — see above)."
+    echo "  Setup complete (with warnings):"
+    # "see above" was the whole problem: the warning can be several hundred lines
+    # up a scrolling install, and two of the setters print no "WARNING:" text to
+    # scroll back and find. Restate them here, where the reader already is.
+    echo "$SETUP_WARNING_LOG"
 else
     echo "  Setup complete!"
 fi
@@ -1712,5 +1766,13 @@ echo ""
 if [ "${GENESIS_INSTALL_STRICT:-0}" = "1" ] \
    && { [ "${SMOKE_FAIL:-0}" -gt 0 ] || [ "${SETUP_WARNINGS:-0}" = "1" ]; }; then
     echo "  STRICT: smoke failures=${SMOKE_FAIL:-0}, SETUP_WARNINGS=${SETUP_WARNINGS:-0} — exiting nonzero." >&2
+    if [ -n "$SETUP_WARNING_LOG" ]; then
+        # Name the causes. Without this the CI failure is a bare flag, and
+        # finding out which of eight setters fired means grepping the script and
+        # cross-reading the full job log — which is exactly what the first run of
+        # this workflow cost.
+        echo "  Setup warnings behind this exit:" >&2
+        echo "$SETUP_WARNING_LOG" >&2
+    fi
     exit 1
 fi

--- a/tests/test_scripts/test_install_qdrant_warning.py
+++ b/tests/test_scripts/test_install_qdrant_warning.py
@@ -1,0 +1,248 @@
+"""install.sh: a SUCCESSFUL Qdrant install must not report a setup warning.
+
+The defect this pins, found by the first run of the fresh-install CI check in
+this same PR: the "Qdrant not found → install it" branch set ``SETUP_WARNINGS=1``
+unconditionally at the end of the branch, outside the inner success/failure
+if-chain. So a clean install printed
+
+    + Qdrant 1.14.0 installed to /usr/local/bin/
+    Genesis REQUIRES Qdrant for vector storage.
+
+— the second line contradicting the first — and left the warning flag set. Under
+``GENESIS_INSTALL_STRICT=1`` that is a guaranteed nonzero exit on every genuinely
+fresh machine, i.e. the check could never be green.
+
+Why it survived: a box that already has Qdrant takes the FIRST branch and never
+reaches this code. Every developer box already has Qdrant. Only a fresh machine
+reaches it, and nothing had installed Genesis on a fresh machine in ~12 weeks.
+
+The branch is extracted from the shipped script and executed, so these tests
+exercise the real control flow rather than a restatement of it. The only textual
+substitution is the hardcoded ``/tmp`` path, redirected into the sandbox so a
+test run cannot collide with a real download or with a concurrent test; the
+if/else structure and the warn decision — what is actually under test — are
+untouched.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_qdrant_block() -> str:
+    """Pull the shipped Qdrant infrastructure block verbatim.
+
+    Anchored on the two comments that bracket it, so a rename inside the block
+    cannot silently shrink what is under test — the extraction fails loudly.
+    """
+    text = INSTALL.read_text()
+    m = re.search(
+        r"^# Qdrant \(required\)\n(.*?)^# Ollama \(optional\)",
+        text,
+        re.DOTALL | re.MULTILINE,
+    )
+    assert m, "Qdrant block anchors not found in install.sh — extraction is stale"
+    block = m.group(1)
+    assert "_qdrant_installed" in block, "extracted block is missing the success flag"
+    return block
+
+
+def _run(tmp_path: Path, *, download_ok: bool, binary_in_archive: bool, sudo_ok: bool):
+    """Execute the shipped block with stubbed curl/tar/sudo. Returns CompletedProcess."""
+    sandbox_tmp = tmp_path / "tmp"
+    sandbox_tmp.mkdir()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+
+    # curl: the reachability probe must FAIL (so the block takes the install
+    # branch); the download then succeeds or fails per scenario.
+    (fake_bin / "curl").write_text(
+        "#!/bin/bash\n"
+        'for a in "$@"; do case "$a" in *collections) exit 7;; esac; done\n'
+        f"exit {0 if download_ok else 22}\n"
+    )
+    # tar: materialise the extracted binary, or not.
+    (fake_bin / "tar").write_text(
+        "#!/bin/bash\n"
+        + (f'echo stub > "{sandbox_tmp}/qdrant"\n' if binary_in_archive else "")
+        + "exit 0\n"
+    )
+    (fake_bin / "sudo").write_text("#!/bin/bash\n" + ('exec "$@"\n' if sudo_ok else "exit 1\n"))
+    for f in fake_bin.iterdir():
+        f.chmod(0o755)
+
+    block = _extract_qdrant_block().replace("/tmp/", f"{sandbox_tmp}/")
+    # /usr/local/bin is not writable in the sandbox; send the sudo-success path
+    # somewhere it can actually land, without touching the branch logic.
+    usr_local = tmp_path / "usrlocal"
+    usr_local.mkdir()
+    block = block.replace("/usr/local/bin/qdrant", f"{usr_local}/qdrant")
+
+    script = f"""set -euo pipefail
+SETUP_WARNINGS=0
+SETUP_WARNING_LOG=""
+setup_warn() {{ SETUP_WARNINGS=1; SETUP_WARNING_LOG="$SETUP_WARNING_LOG $1"; }}
+{block}
+echo "RESULT_WARNINGS=$SETUP_WARNINGS"
+echo "RESULT_REASONS=$SETUP_WARNING_LOG"
+"""
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{fake_bin}:/usr/bin:/bin",
+            "HOME": str(home),
+            "QDRANT_URL": "http://localhost:6333",
+            "QDRANT_VERSION": "1.14.0",
+        },
+        timeout=60,
+    )
+
+
+def test_successful_install_records_no_setup_warning(tmp_path):
+    """THE regression. A clean install must leave the flag at 0."""
+    r = _run(tmp_path, download_ok=True, binary_in_archive=True, sudo_ok=True)
+    assert r.returncode == 0, r.stderr
+    assert "RESULT_WARNINGS=0" in r.stdout, r.stdout
+    assert "installed to" in r.stdout, "the success path did not actually run"
+    assert "REQUIRES Qdrant" not in r.stdout, (
+        "a successful install still printed the 'you need Qdrant' advice — "
+        "the line that contradicts the '+ installed' line above it"
+    )
+
+
+def test_successful_install_without_sudo_also_records_no_warning(tmp_path):
+    """The ~/.local/bin fallback is equally a success and must not warn either —
+    the flag has to be set on the shared success path, not in one sub-branch."""
+    r = _run(tmp_path, download_ok=True, binary_in_archive=True, sudo_ok=False)
+    assert r.returncode == 0, r.stderr
+    assert "RESULT_WARNINGS=0" in r.stdout, r.stdout
+    assert ".local/bin" in r.stdout, "the no-sudo path did not run"
+
+
+@pytest.mark.parametrize(
+    ("download_ok", "binary_in_archive", "label"),
+    [(False, False, "download failed"), (True, False, "binary missing from archive")],
+)
+def test_failed_install_still_warns(tmp_path, download_ok, binary_in_archive, label):
+    """The other direction — a precision fix that blinded the real warning would
+    be worse than the bug. A genuinely failed install must still warn, and the
+    reason must name Qdrant so the strict-mode exit is diagnosable."""
+    r = _run(tmp_path, download_ok=download_ok, binary_in_archive=binary_in_archive, sudo_ok=True)
+    assert r.returncode == 0, r.stderr
+    assert "RESULT_WARNINGS=1" in r.stdout, f"{label}: should still warn\n{r.stdout}"
+    assert "REQUIRES Qdrant" in r.stdout, f"{label}: lost the operator-facing advice"
+    assert "Qdrant" in r.stdout.split("RESULT_REASONS=")[1], (
+        f"{label}: the recorded reason does not name Qdrant, so a strict-mode "
+        "failure would again be a bare flag with no cause"
+    )
+
+
+def test_every_warning_setter_goes_through_setup_warn():
+    """Structural guardrail: no bare ``SETUP_WARNINGS=1`` assignment may remain.
+
+    The reason log only works if every setter registers a cause. A future edit
+    that adds a bare assignment would set the flag with no reason, and the strict
+    exit would print a header over an empty list — silently back to the
+    undiagnosable state this replaced. Asserted on the shipped text because there
+    is no runtime moment at which all eight paths are exercised.
+    """
+    text = INSTALL.read_text()
+
+    # Exactly one bare assignment is legitimate: the one INSIDE setup_warn. Cut
+    # the helper's body out first rather than relaxing the pattern, so the check
+    # still fires on a bare assignment anywhere else — including one added right
+    # next to the helper.
+    helper = re.search(r"^setup_warn\(\) \{\n(?:.*?\n)*?^\}\n", text, re.MULTILINE)
+    assert helper, "setup_warn helper not found — has the mechanism been removed?"
+    assert "SETUP_WARNINGS=1" in helper.group(0), "setup_warn no longer sets the flag"
+    outside = text[: helper.start()] + text[helper.end() :]
+
+    # Allowed in `outside`: the declaration (=0), the reads, and comment prose.
+    offenders = [
+        line for line in outside.splitlines() if re.match(r"^\s*SETUP_WARNINGS=1\s*$", line)
+    ]
+    assert not offenders, (
+        'bare SETUP_WARNINGS=1 assignment(s) found — use setup_warn "reason" so '
+        f"the strict-mode exit can name the cause: {offenders}"
+    )
+    assert text.count("setup_warn ") >= 8, (
+        "expected every warning site to route through setup_warn; found "
+        f"{text.count('setup_warn ')} call(s)"
+    )
+
+
+# ── rendered-template placeholder parity ──────────────────────────────────────
+
+
+def test_every_template_placeholder_is_substituted_by_the_render_loop():
+    """Every ``__TOKEN__`` in any shipped unit template must be in install.sh's sed
+    list, or the installer writes a unit with a literal placeholder in it.
+
+    This is stated as parity between two sets rather than as a check for one known
+    token, because the specific defect it was written for —
+    ``agent-zero.service.template``'s ``WorkingDirectory=__AZ_ROOT__``, absent from
+    the sed list, so systemd would reject the rendered unit — is only interesting as
+    an instance. Testing for ``__AZ_ROOT__`` by name would pass forever and catch
+    nothing new; the next template to add a placeholder is the actual risk.
+
+    It went unnoticed because install.sh never enables agent-zero, so the broken
+    unit just sat on disk unusable.
+    """
+    templates = sorted((REPO_ROOT / "scripts" / "systemd").glob("*.template"))
+    assert templates, "no unit templates found — this test is looking in the wrong place"
+
+    install_text = INSTALL.read_text()
+    # The sed expressions in the render loop, e.g. -e "s|__HOME__|$HOME|g"
+    substituted = set(re.findall(r'-e "s\|(__[A-Z0-9_]+__)\|', install_text))
+    assert substituted, "could not find the render loop's sed list — extraction is stale"
+
+    missing: dict[str, set[str]] = {}
+    for template in templates:
+        tokens = set(re.findall(r"__[A-Z0-9_]+__", template.read_text()))
+        unhandled = tokens - substituted
+        if unhandled:
+            missing[template.name] = unhandled
+
+    assert not missing, (
+        "unit template placeholder(s) with no substitution in install.sh's render "
+        f"loop — the rendered unit ships the literal token: {missing}. Add each to "
+        "the sed list (with a default if the value is optional)."
+    )
+
+
+def test_user_facing_artifacts_use_the_actual_repo_dir_not_a_hardcoded_home_path():
+    """The ``genesis`` command and the login auto-cd must reference $REPO_DIR.
+
+    Both hardcoded ``~/genesis``. On any clone elsewhere the wrapper was installed
+    dead ("Genesis repo not found") and the login hook pointed at a non-existent
+    directory — while every install-test assertion still passed, because nothing
+    checked where they pointed. The installer already knows its own location.
+    """
+    text = INSTALL.read_text()
+
+    wrapper = re.search(r"sudo tee /usr/local/bin/genesis .*?\nWRAPPER", text, re.DOTALL)
+    assert wrapper, "genesis wrapper heredoc not found — extraction is stale"
+    body = wrapper.group(0)
+    assert "$REPO_DIR" in body, "the genesis wrapper must cd to $REPO_DIR"
+    assert "~/genesis" not in body, (
+        "the genesis wrapper still hardcodes ~/genesis — dead on any other clone"
+    )
+    assert '"\\$@"' in body or "\\$@" in body, (
+        "the wrapper heredoc is unquoted (so $REPO_DIR expands); $@ must be escaped "
+        "or the generated script loses its arguments"
+    )
+
+    autocd = re.search(r"# Auto-cd to Genesis project on login.*?\nfi", text, re.DOTALL)
+    assert autocd, "auto-cd block not found — extraction is stale"
+    assert "$REPO_DIR" in autocd.group(0)

--- a/tests/test_scripts/test_install_qdrant_warning.py
+++ b/tests/test_scripts/test_install_qdrant_warning.py
@@ -182,6 +182,113 @@ def test_every_warning_setter_goes_through_setup_warn():
     )
 
 
+# ── generated-code escaping ───────────────────────────────────────────────────
+# install.sh GENERATES shell (the `genesis` wrapper, a .bashrc line) and a sed
+# replacement. Both embed values that can contain metacharacters, and both used
+# fixed quoting that silently mis-renders rather than failing loudly.
+
+
+@pytest.mark.parametrize(
+    "repo_dir",
+    [
+        "/home/u/it's genesis",   # apostrophe ENDS a single-quoted string early
+        "/home/u/plain",
+        '/home/u/say "hi"',
+        "/home/u/with space",
+    ],
+)
+def test_generated_genesis_wrapper_parses_for_any_repo_path(repo_dir):
+    """The generated wrapper must be valid shell whatever the checkout path is.
+
+    With fixed single quotes an apostrophe in the path closed the string early, so
+    /usr/local/bin/genesis did not even parse — and nothing would surface that
+    until the first time someone typed `genesis`.
+
+    Runs the SHIPPED quoting and the SHIPPED heredoc, extracted from install.sh.
+    An earlier version of this test re-implemented `printf %q` inline and was
+    consequently GREEN when the production quoting was mutated back to fixed
+    single quotes — it was testing its own copy. Mutation testing is what caught
+    that, and it is the reason this extracts instead of restating.
+    """
+    text = INSTALL.read_text()
+
+    m = re.search(r"^(\s*_repo_q=.*)$", text, re.MULTILINE)
+    assert m, "could not extract the _repo_q assignment from install.sh — stale"
+    quote_line = m.group(1).strip()
+
+    h = re.search(
+        r"sudo tee /usr/local/bin/genesis >/dev/null <<WRAPPER\n(.*?)\nWRAPPER",
+        text, re.DOTALL,
+    )
+    assert h, "could not extract the wrapper heredoc from install.sh — stale"
+    heredoc_body = h.group(1)
+
+    # Reproduce install.sh's generation step verbatim: set REPO_DIR, run the
+    # shipped quoting line, expand the shipped heredoc.
+    gen = subprocess.run(
+        ["bash", "-c",
+         f'REPO_DIR="$1"\n{quote_line}\ncat <<WRAPPER\n{heredoc_body}\nWRAPPER\n',
+         "_", repo_dir],
+        capture_output=True, text=True,
+    )
+    assert gen.returncode == 0, f"generation failed: {gen.stderr}"
+    script = gen.stdout
+
+    syn = subprocess.run(["bash", "-n", "/dev/stdin"], input=script,
+                         capture_output=True, text=True)
+    assert syn.returncode == 0, (
+        f"the generated wrapper does not parse for {repo_dir!r}: {syn.stderr}\n{script}"
+    )
+
+    # And its `cd` must target the SAME directory, not a truncated one.
+    cd_line = next(line for line in script.splitlines() if line.startswith("cd "))
+    probe = subprocess.run(
+        ["bash", "-c", f'{cd_line.split(" 2>/dev/null")[0]} 2>/dev/null && pwd || echo MISSING'],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    assert probe in (repo_dir, "MISSING"), (
+        f"the generated cd resolved to {probe!r}, a DIFFERENT directory than {repo_dir!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "az_root",
+    [
+        "/tmp/R&D",          # bare & in a sed replacement = the whole matched text
+        "/tmp/a|b",          # the delimiter — sed rejects the expression outright
+        "/tmp/back\\slash",
+        "/home/u/agent-zero",
+    ],
+)
+def test_az_root_survives_sed_substitution_verbatim(az_root):
+    """A configurable path used as a sed REPLACEMENT must render verbatim.
+
+    AZ_ROOT is operator-set, so it is the one substitution value that can carry a
+    metacharacter. Unescaped, `/tmp/R&D` rendered
+    `WorkingDirectory=/tmp/R__AZ_ROOT__D` (& means "the whole match") and `|` made
+    sed reject the expression, aborting the install under `set -e`.
+
+    The escape is extracted from the shipped script so this tests the real
+    expression, not a restatement of it — and the first version I wrote emitted
+    TWO backslashes and still mis-rendered, which is exactly why this asserts the
+    rendered OUTPUT rather than the shape of the escape.
+    """
+    text = INSTALL.read_text()
+    m = re.search(r"_az_root_esc=\$\(printf '%s' \S+ \| (sed -e '[^']+')\)", text)
+    assert m, "could not extract the AZ_ROOT escape from install.sh — stale"
+    escape_cmd = m.group(1)
+
+    rendered = subprocess.run(
+        ["bash", "-c",
+         f'esc=$(printf "%s" "$1" | {escape_cmd}); '
+         f'printf "WorkingDirectory=__AZ_ROOT__\n" | sed -e "s|__AZ_ROOT__|$esc|g"',
+         "_", az_root],
+        capture_output=True, text=True,
+    )
+    assert rendered.returncode == 0, f"sed rejected the expression: {rendered.stderr}"
+    assert rendered.stdout.strip() == f"WorkingDirectory={az_root}", rendered.stdout
+
+
 # ── rendered-template placeholder parity ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

The weekly install test's EC2 harness was deliberately removed in #623 (dead code, zero callers — correct at the time), but the weekly dispatch kept firing against the deleted modules and silently no-op'd. Result: `scripts/install.sh` took **24 commits over ~12 weeks with zero fresh-machine verification**, including changes to exactly the paths that only break on a clean install (`/etc/environment` writes, `$HOME` under `set -u`, fresh-container provisioning). Diagnosed 2026-09-07; the owner chose replacement with CI over restoring the EC2 harness.

## What this adds

**`.github/workflows/install-test.yml`** — a clean `ubuntu-latest` runner clones the repo and runs `./scripts/install.sh --non-interactive` end-to-end:
- **Triggers**: PRs path-filtered to what install.sh actually *consumes* (sourced `scripts/lib/**`, `scripts/systemd/**` templates, `config/mcp.json.template`, `pyproject.toml`, seed files…) — derived by enumerating the script's inputs, not name-similarity — plus a weekly cron and manual dispatch. Header warns against making it a required check (path-filtered workflows report no status on unrelated PRs).
- **User-systemd prep step**: hosted runners have no logind session/user bus, and Qdrant's only start path is a user unit — the prep step lingers the runner user, exports `XDG_RUNTIME_DIR`/DBus address, and fails *legibly* if no user manager appears, so an environment gap can never masquerade as an install failure.
- **Verify step** asserts what the installer does NOT self-report: rendered units contain the repo path with no residual `__TOKEN__` placeholders, `.mcp.json` fully substituted, `claude` present at the pinned `CC_VERSION`, venv imports `genesis`.

**`scripts/install.sh`** — `GENESIS_INSTALL_STRICT=1` (documented in the `--help` env block): exit nonzero on any smoke failure **or** `SETUP_WARNINGS` — the warning channel is where a broken Claude Code install, a stale venv Python, or a port squatter land, and greening through those is the false green this check exists to catch. Default off: humans keep the readable summary.

## Coverage honesty

Runners are full Ubuntu VMs, so most of the install path is exercised for real. Not covered: arbitrary cloud images and the LXC/Incus container variant — a rare manual VM run before releases covers those. **The first run of this workflow is expected to need triage** — 12 weeks of unverified installer churn is exactly what it's here to surface; treat findings on that run as install.sh bugs to fix, not workflow defects.

Operational note: the dead weekly dispatcher (user_jobs row) has been paused on the origin install; other installs carrying it should do the same — it imports modules deleted in #623.

E2E: read this PR's own Install Test run end-to-end (it triggers itself via the path filter); after merge, confirm the Monday 07:00 UTC scheduled run fires.

Ledger: ba35c15d8d684100800027fdcc7958dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added strict installation mode, which fails when setup warnings or smoke-test failures occur.
  - Installation summaries now provide clearer details about setup issues.

- **Bug Fixes**
  - Generated commands and automatic directory changes support custom repository paths, including special characters.
  - System service configuration preserves customized installation roots.
  - Qdrant warnings appear only when installation fails.

- **Tests**
  - Expanded automated checks cover installation behavior, generated configuration, shell safety, service status, timers, configuration validity, and Genesis availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wingedguardian/genesis-agi/pull/1859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->