### PR TITLE
fix(hooks): a bound that stops the parse must not silence the worktree guard

### DIFF
--- a/changelog.d/20260908212219-fixed-worktree-guard-blind-parse.md
+++ b/changelog.d/20260908212219-fixed-worktree-guard-blind-parse.md
@@ -1,0 +1,19 @@
+- **The worktree-removal guard no longer goes silent when a bound stops the
+  parse.** It decided by searching `analyze`'s segment list, and a parse halted
+  by the substitution-depth or command-length bound yields no segments at all —
+  by design, so a searching consumer cannot read "stopped looking" as "nothing
+  found". The guard read it as the latter: a removal wrapped past the depth
+  bound produced no targets and was allowed, on a guard whose only job is
+  blocking.
+
+  It now asks `analyze_checked` once per invocation and treats a blind spot the
+  same way it already treats a command shlex cannot tokenize — falling back to
+  the coarser regex extractor, which reads the raw text and so cannot be hidden
+  from by nesting. Measured by mutation: with the new branch removed, a real
+  `git worktree remove` nested eight substitutions deep exits 0 (allowed); with
+  it, 2 (blocked). A deep command carrying no removal is still allowed, so the
+  fallback discriminates rather than blocking everything unreadable.
+
+  This also restores the chokepoint invariant that every consumer of the shared
+  parser either uses the checked entry point or is listed with a stated reason
+  why blindness is safe for it. That reason could not be written here.

--- a/scripts/hooks/worktree_cwd_guard.py
+++ b/scripts/hooks/worktree_cwd_guard.py
@@ -40,7 +40,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from hook_input import read_payload, run_guard, tool_input  # noqa: E402
 from shell_parse import (  # noqa: E402
-    analyze,
+    analyze_checked,
     git_subcommand_index,
     untokenizable,
 )
@@ -146,7 +146,7 @@ def _legacy_targets(cmd: str) -> list[str]:
     return targets
 
 
-def _extract_worktree_targets(cmd: str) -> list[str]:
+def _extract_worktree_targets(segs: list) -> list[str]:
     """Target paths of every EXECUTED worktree-removal segment.
 
     Keyed on parsed structure, not on the phrase appearing in the text: the
@@ -163,7 +163,7 @@ def _extract_worktree_targets(cmd: str) -> list[str]:
     what covers that class.
     """
     targets: list[str] = []
-    for seg in analyze(cmd):
+    for seg in segs:
         if seg.exe != "git":
             continue
         # The INDEX from the parser's own scan, never `argv.index(_SUBCOMMAND)`:
@@ -185,7 +185,7 @@ def _extract_worktree_targets(cmd: str) -> list[str]:
     return targets
 
 
-def _carries_a_command(cmd: str) -> bool:
+def _carries_a_command(cmd: str, segs: list) -> bool:
     """Whether ``cmd`` hands a command STRING to something ``analyze`` skips.
 
     Asks the PARSER first, and the raw text only as a fallback. The regex above
@@ -200,7 +200,7 @@ def _carries_a_command(cmd: str) -> bool:
     once, for every spelling of a path, with no new name to guess. The regex is
     still consulted because a shell function definition has no executable at all.
     """
-    if any(seg.exe in _CARRIER_NAMES for seg in analyze(cmd)):
+    if any(seg.exe in _CARRIER_NAMES for seg in segs):
         return True
     return bool(_COMMAND_CARRIER.search(cmd))
 
@@ -309,10 +309,27 @@ def _handle_bash(data: dict) -> int:
     # the command was allowed — a branch whose comment claimed fail-closed while
     # the code fell open. `echo 'it's fine' ; git worktree remove /wt/X` is the
     # shape (an unbalanced quote collapses everything into one echo segment).
-    if untokenizable(cmd):
+    # ONE parse for this hook, per `analyze_checked`'s own contract: the blind
+    # spot is asked once here rather than remembered at each probe, which is the
+    # shape that has repeatedly shipped guards importing a check they never call.
+    segs, blind = analyze_checked(cmd)
+
+    # `blind is not None` joins `untokenizable` as a fail-CLOSED trigger, and the
+    # two are different failures. `untokenizable` means shlex could not read the
+    # command at all. A blind spot means a BOUND stopped the parse — and
+    # `analyze_checked` then returns NO segments rather than the ones it reached,
+    # precisely because this guard decides by SEARCHING that list and would read
+    # "stopped looking" as "no removal present". Without this branch a removal
+    # wrapped past the depth bound parses to [], `_extract_worktree_targets`
+    # finds nothing, and a guard whose whole job is blocking allows it — the
+    # BLOCK -> ALLOW shape `analyze_checked`'s docstring measured for the guards
+    # that already fail closed here. The legacy regex extractor is the same
+    # coarser reading the untokenizable case falls back to: weaker than the
+    # parser, but it reads the raw text, so a bound cannot hide anything from it.
+    if untokenizable(cmd) or blind is not None:
         targets = _legacy_targets(cmd)
     else:
-        targets = _extract_worktree_targets(cmd)
+        targets = _extract_worktree_targets(segs)
         # The text says a removal and the parser found none, in a command that
         # hands a command STRING to something. That is the carrier class: it
         # tokenizes cleanly, so the probe above cannot see it, and the parser
@@ -343,7 +360,7 @@ def _handle_bash(data: dict) -> int:
             not targets
             and _WORKTREE_REMOVE.search(cmd)
             and _GIT_TOKEN.search(cmd)
-            and _carries_a_command(cmd)
+            and _carries_a_command(cmd, segs)
         ):
             targets = _legacy_targets(cmd)
     if not targets:

--- a/tests/test_hooks/test_worktree_guard.py
+++ b/tests/test_hooks/test_worktree_guard.py
@@ -115,6 +115,38 @@ class TestBashBlockAll:
         assert result.returncode == 2
         assert "BLOCKED" in result.stderr
 
+    def test_removal_past_the_depth_bound_still_blocks(self, guard_cmd: str) -> None:
+        """A removal nested past shell_parse's depth bound must NOT slip through.
+
+        This is the fail-open the bare-`analyze` chokepoint exists to catch. A
+        bounded parse returns NO segments — deliberately, so a searching guard
+        cannot read "stopped looking" as "nothing found" — and this guard decides
+        by searching. Before the blind-spot branch that meant zero targets and a
+        silent allow, on a guard whose entire job is blocking.
+        """
+        deep = "git worktree remove /tmp/nonexistent-worktree-xyz"
+        for _ in range(8):  # comfortably past MAX_SUBSTITUTION_DEPTH (5)
+            deep = f"echo $({deep})"
+        result = _run_guard(guard_cmd, {"command": deep})
+        assert result.returncode == 2, result.stdout + result.stderr
+        assert "BLOCKED" in result.stderr
+
+    def test_deep_nesting_without_a_removal_is_still_allowed(
+        self, guard_cmd: str
+    ) -> None:
+        """Negative control for the test above.
+
+        Without it, a fallback that simply blocked every unreadable command
+        naming the subcommand would pass the acceptance test while being
+        useless — the "a matcher that finds nothing is indistinguishable from a
+        matcher that looks at nothing" failure, in its blocking direction.
+        """
+        deep = "git worktree list"
+        for _ in range(8):
+            deep = f"echo $({deep})"
+        result = _run_guard(guard_cmd, {"command": deep})
+        assert result.returncode == 0, result.stdout + result.stderr
+
     def test_block_message_mentions_lifecycle(self, guard_cmd: str) -> None:
         result = _run_guard(
             guard_cmd,


### PR DESCRIPTION
## What

`worktree_cwd_guard` asks `analyze_checked` once per invocation and treats a blind
spot as a fail-CLOSED trigger, alongside the `untokenizable` case it already
handled.

## Why

The guard decides by **searching** `analyze`'s segment list. A parse stopped by
the substitution-depth or command-length bound returns *no* segments — by
design, so a searching consumer cannot read "stopped looking" as "nothing
found". This guard read it as exactly that: a removal nested past the depth
bound produced no targets and was allowed, on a guard whose only job is
blocking.

The fallback is the guard's own existing answer for an unreadable command, not a
new mechanism: the legacy regex extractor reads raw text, so nesting cannot hide
a removal from it.

### Why not the allowlist

The chokepoint test offers two ways out, and the other one could not be
justified here. Every existing `_BARE_ANALYZE_ALLOWED` entry states why
blindness is *safe* for that module — `git_push_guard` filters to `depth == 0`,
so a depth bound cannot change its result; `tmux_kill_server_guard` is
advisory-only, so its worst case is advice nobody needed. Neither shape fits a
blocking guard that searches. Writing the entry would have meant recording a
known fail-open.

## This also repairs a red main

#1607 added the bare-`analyze` chokepoint test; #1675 carries this guard's bare
import. Each was green against a main that lacked the other, and neither diff
touches the other's files — so the collision merged textually clean and CI only
found it afterwards, on main. Because PR CI builds the merge commit, it was
failing every open PR, not just one branch.

## Evidence

- **Verify-RED**: reverting the new branch makes a real `git worktree remove`
  nested 8 substitutions deep exit `0` (allowed) instead of `2`. Mutant hash
  confirmed changed and compiling, restore hash-verified.
- **Negative control** stays green under the same mutation: a deep command
  carrying no removal is still allowed, so the fallback discriminates rather
  than blocking everything unreadable.
- 281 passed across both hook test directories; the chokepoint test passes.

## Not claimed

This does not make the parser see `eval`, process substitution or `env -S`.
`analyze_checked`'s docstring is explicit that it cannot report those; that gap
is pre-existing and unchanged.

E2E: confirm main's push CI goes green after merge, then confirm an open PR's
next CI run no longer fails on `test_bare_analyze_requires_being_on_the_allowlist`.
